### PR TITLE
Handle when there are no image tags

### DIFF
--- a/packages/preload/src/container-registry.ts
+++ b/packages/preload/src/container-registry.ts
@@ -1,12 +1,12 @@
 /**********************************************************************
  * Copyright (C) 2022 Red Hat, Inc.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,7 +18,7 @@
 
 import type * as containerDesktopAPI from '@tmpwip/extension-api';
 import { Disposable } from './types/disposable';
-import Dockerode from 'dockerode';  
+import Dockerode from 'dockerode';
 import type { ContainerCreateOptions, ContainerInfo } from './api/container-info';
 import type { ImageInfo } from './api/image-info';
 import type { ImageInspectInfo } from './api/image-inspect-info';
@@ -45,13 +45,12 @@ export class ContainerProviderRegistry {
     constructor(private apiSender: any) {
 
     }
-    
+
     private providers: Map<string, containerDesktopAPI.ContainerProvider> = new Map();
     private providerLifecycles: Map<string, InternalContainerProviderLifecycle> = new Map();
     private internalProviders: Map<string, InternalContainerProvider> = new Map();
 
     async registerContainerProviderLifecycle(providerLifecycle: containerDesktopAPI.ContainerProviderLifecycle): Promise<Disposable> {
-
         const providerName = providerLifecycle.provideName();
         const internalProviderLifecycle = {
             internal: providerLifecycle,
@@ -130,7 +129,7 @@ export class ContainerProviderRegistry {
         async listImages(): Promise<ImageInfo[]> {
             const images = await Promise.all(Array.from(this.internalProviders.values()).map(async (provider) => {
                 try {
-                const images = await provider.api.listImages({all:true});
+                const images = await provider.api.listImages({all:false});
                 return images.map((image) => {
                     const imageInfo: ImageInfo = {...image,
                         engine: provider.name,
@@ -153,7 +152,7 @@ export class ContainerProviderRegistry {
             }
             await providerLifecycle.internal.start();
             this.apiSender.send('provider-lifecycle-change', {});
-        }    
+        }
 
         async stopProviderLifecycle(providerName: string): Promise<void> {
             // need to find the container engine of the container
@@ -163,7 +162,7 @@ export class ContainerProviderRegistry {
             }
             await providerLifecycle.internal.stop();
             this.apiSender.send('provider-lifecycle-change', {});
-        }    
+        }
 
     async stopContainer(engineName: string, id: string): Promise<void> {
         // need to find the container engine of the container
@@ -172,8 +171,8 @@ export class ContainerProviderRegistry {
             throw new Error('no engine matching this container');
         }
         return engine.api.getContainer(id).stop();
-    }    
-    
+    }
+
     async startContainer(engineName: string, id: string): Promise<void> {
         // need to find the container engine of the container
         const engine = this.internalProviders.get(engineName);
@@ -276,5 +275,5 @@ export class ContainerProviderRegistry {
         });
     }
 
-    
+
 }

--- a/packages/renderer/src/lib/ImagesList.svelte
+++ b/packages/renderer/src/lib/ImagesList.svelte
@@ -21,7 +21,10 @@ let modalImageInfo: ImageInfo;
 
 function getName(imageInfo: ImageInfo) {
   // get name
-  return imageInfo.RepoTags.map((tag => {
+ if(!imageInfo.RepoTags){
+   return '<none>';
+ }
+ return imageInfo.RepoTags.map((tag => {
     return tag.split(':')[0];
   })).join(',');
 
@@ -72,7 +75,7 @@ async function startContainer() {
     name: modalContainerName,
     HostConfig,
     ExposedPorts,
-  
+
   }
   console.log('calling create and start with options', options);
   const response = await window.createAndStartContainer(modalImageInspectInfo.engine, options);
@@ -99,11 +102,12 @@ function getId(imageInfo: ImageInfo) {
 }
 
 function getTag(imageInfo: ImageInfo) {
-  // get name
+  if(!imageInfo.RepoTags){
+    return '<node>'
+  }
   return imageInfo.RepoTags.map((tag => {
     return tag.split(':')[1];
   })).join(',');
-
 }
 
 function getSize(imageInfo: ImageInfo) {
@@ -127,7 +131,7 @@ function getEngine(containerInfo: ImageInfo): string {
 
 
 <div class="flex flex-col" >
-    
+
   <div class="min-w-full">
     <div class="flex flex-row">
     <div class="py-5 px-5 lg:w-[35rem] w-[22rem]">
@@ -139,7 +143,7 @@ function getEngine(containerInfo: ImageInfo): string {
       </svg>
       <input bind:value={searchTerm} type="text" name="containerSearchName" placeholder="Search...."
           class="w-full py-2 outline-none bg-gray-700">
-    </div>  
+    </div>
   </div>
   <!--
   <div class="flex flex-1 justify-end">
@@ -148,7 +152,7 @@ function getEngine(containerInfo: ImageInfo): string {
       <Fa class="h-10 w-8 cursor-pointer rounded-full text-xl text-white" icon={faPlusCircle} />
       Create container
     </button>
-  </div>              
+  </div>
 </div>
 -->
   </div>
@@ -207,15 +211,15 @@ function getEngine(containerInfo: ImageInfo): string {
         <div class="pf-c-empty-state h-full">
           <div class="pf-c-empty-state__content">
             <i class="fas fa-cubes pf-c-empty-state__icon" aria-hidden="true"></i>
-        
+
             <h1 class="pf-c-title pf-m-lg">No images</h1>
             <div
               class="pf-c-empty-state__body"
             >No images</div>
-            
+
           </div>
         </div>
-    
+
       </div>
 
 
@@ -223,23 +227,23 @@ function getEngine(containerInfo: ImageInfo): string {
       {#if runContainerFromImageModal}
       <div class="modal z-50 fixed w-full h-full top-0 left-0 flex items-center justify-center p-8 lg:p-0" tabindex={0} autofocus on:keydown={keydownDockerfileChoice}>
         <div class="modal-overlay fixed w-full h-full bg-gray-900 opacity-50"></div>
-      
-      
-      
+
+
+
         <div class="relative px-4 w-full max-w-4xl h-full md:h-auto">
           <div class="relative bg-white rounded-lg shadow dark:bg-gray-700">
-      
-      
+
+
             <div class="relative bg-white rounded-lg shadow dark:bg-gray-700">
               <div class="flex justify-end p-2">
                   <button on:click='{() => {runContainerFromImageModal = false}}' type="button" class="text-gray-400 bg-transparent hover:bg-gray-200 hover:text-gray-900 rounded-lg text-sm p-1.5 ml-auto inline-flex items-center dark:hover:bg-gray-800 dark:hover:text-white" data-modal-toggle="authentication-modal">
-                      <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd"></path></svg>  
+                      <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd"></path></svg>
                   </button>
               </div>
               <!--<form class="px-6 pb-4 space-y-6 lg:px-8 sm:pb-6 xl:pb-8">-->
                 <div class="px-6 pb-4 space-y-6 lg:px-8 sm:pb-6 xl:pb-8">
                   <h3 class="text-xl font-medium text-gray-900 dark:text-white">Create Container {getName(modalImageInfo)}</h3>
-         
+
                   <div>
                       <label for="modalContainerName" class="block mb-2 text-sm font-medium text-gray-900 dark:text-gray-300">Container Name</label>
                       <input type="text" bind:value={modalContainerName} name="modalContainerName" id="modalContainerName" placeholder="Enter container name" class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-600 dark:border-gray-500 dark:placeholder-gray-400 dark:text-white" required>
@@ -249,16 +253,16 @@ function getEngine(containerInfo: ImageInfo): string {
                       <input type="text" bind:value={modalContainerPortMapping[index]} placeholder="Enter value for port {port}" class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-600 dark:border-gray-500 dark:placeholder-gray-400 dark:text-white" required>
                       {/each}
                   </div>
-      
-                  
+
+
                   <button  on:click="{() => startContainer()}" class="w-full text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800">Start Container</button>
-                  
+
              <!-- </form>-->
              </div>
           </div>
           </div>
       </div>
-      
-      
+
+
       </div>
-      {/if}      
+      {/if}


### PR DESCRIPTION
Handles the case when an image does not have any image tags. Displays a default value if it can not find tags. Also, changes the list images so that intermediate layers are filtered. This aligns the behaviour better with `podman images.`