### PR TITLE
feat: hide App on macOS dock only if dashboard is hidden

### DIFF
--- a/packages/main/src/index.ts
+++ b/packages/main/src/index.ts
@@ -21,6 +21,7 @@ import { app, nativeImage, Tray } from 'electron';
 import './security-restrictions';
 import { restoreOrCreateWindow } from '/@/mainWindow';
 import { TrayMenu } from './tray-menu';
+import { isMac } from './util';
 
 /**
  * Prevent multiple instances
@@ -41,7 +42,7 @@ app.disableHardwareAcceleration();
  * Shout down background process if all windows was closed
  */
 app.on('window-all-closed', () => {
-  if (process.platform !== 'darwin') {
+  if (!isMac) {
     app.quit();
   }
 });
@@ -93,8 +94,4 @@ let tray: Tray | null = null;
 app.whenReady().then(() => {
   tray = new Tray(nativeTrayIcon);
   new TrayMenu(tray);
-
-  if (process.platform === 'darwin') {
-    app.dock.hide();
-  }
 });

--- a/packages/main/src/mainWindow.ts
+++ b/packages/main/src/mainWindow.ts
@@ -20,7 +20,7 @@ import type { BrowserWindowConstructorOptions } from 'electron';
 import { BrowserWindow, ipcMain, app } from 'electron';
 import { join } from 'path';
 import { URL } from 'url';
-import * as os from 'os';
+import { isLinux, isMac } from './util';
 
 async function createWindow() {
   const browserWindowConstructorOptions: BrowserWindowConstructorOptions = {
@@ -36,8 +36,7 @@ async function createWindow() {
       preload: join(__dirname, '../../preload/dist/index.cjs'),
     },
   };
-  const osType = os.type();
-  if (osType === 'Darwin') {
+  if (isMac) {
     browserWindowConstructorOptions.titleBarStyle = 'hiddenInset';
   }
   const browserWindow = new BrowserWindow(browserWindowConstructorOptions);
@@ -61,6 +60,9 @@ async function createWindow() {
    */
   browserWindow.on('ready-to-show', () => {
     browserWindow?.show();
+    if (isMac) {
+      app.dock.show();
+    }
 
     if (import.meta.env.DEV) {
       browserWindow?.webContents.openDevTools();
@@ -69,10 +71,13 @@ async function createWindow() {
 
   browserWindow.on('close', e => {
     e.preventDefault();
-    if (os.platform() === 'linux') {
+    if (isLinux) {
       browserWindow.minimize();
     } else {
       browserWindow.hide();
+      if (isMac) {
+        app.dock.hide();
+      }
     }
   });
 

--- a/packages/main/src/tray-menu.ts
+++ b/packages/main/src/tray-menu.ts
@@ -16,11 +16,12 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { ipcMain, BrowserWindow, Menu, nativeImage } from 'electron';
+import { app, ipcMain, BrowserWindow, Menu, nativeImage } from 'electron';
 import type { MenuItemConstructorOptions, Tray, NativeImage } from 'electron';
 import statusStarted from './assets/status-started.png';
 import statusStopped from './assets/status-stopped.png';
 import statusUnknown from './assets/status-unknown.png';
+import { isMac } from './util';
 
 interface ContainerProvider {
   providerName: string;
@@ -182,8 +183,11 @@ export class TrayMenu {
 
     if (!window?.isVisible()) {
       window?.show();
+      if (isMac) {
+        app.dock.show();
+      }
     }
-
+    window?.focus();
     window?.moveTop();
   }
 }

--- a/packages/main/src/util.ts
+++ b/packages/main/src/util.ts
@@ -1,0 +1,23 @@
+/**********************************************************************
+ * Copyright (C) 2022 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import * as os from 'os';
+
+export const isWindows = os.platform() === 'win32';
+export const isMac = os.platform() === 'darwin';
+export const isLinux = os.platform() === 'linux';


### PR DESCRIPTION
Also make the window being focused when we bring it back
Else it can be behind other windows

Introduce is* utilities (following https://github.com/containers/desktop/commit/4af4a6166aba3eb84680e081cee84ef219b7cf6d#r68888586)

Change-Id: I88a4395b028b3cf0cf7d475a70abb292d46d82fc
Signed-off-by: Florent Benoit <fbenoit@redhat.com>