### PR TITLE
feat: move extensions into Preferences tab

### DIFF
--- a/extensions/crc/package.json
+++ b/extensions/crc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "crc",
-  "displayName": "crc extension",
-  "description": "crc extension",
+  "displayName": "Manages CodeReady Containers",
+  "description": "Allow to start and stop CodeReady Containers and use Podman",
   "version": "0.0.1",
   "icon": "icon.png",
   "publisher": "benoitf",
@@ -14,7 +14,7 @@
   "contributes": {
     "commands": [
       {
-        "command": "docker.info",
+        "command": "crc.info",
         "title": "crc: Specific info about crc"
       }
     ]

--- a/extensions/podman/package.json
+++ b/extensions/podman/package.json
@@ -1,7 +1,7 @@
 {
   "name": "podman",
-  "displayName": "podman extension",
-  "description": "podman extension",
+  "displayName": "Manage podman containers and podman machines",
+  "description": "Manage podman containers and podman machines",
   "version": "0.0.1",
   "icon": "icon.png",
   "publisher": "benoitf",

--- a/packages/preload/src/api/extension-info.ts
+++ b/packages/preload/src/api/extension-info.ts
@@ -19,6 +19,7 @@
 export interface ExtensionInfo {
   id: string;
   name: string;
+  displayName: string;
   publisher: string;
   version: string;
   state: string;

--- a/packages/preload/src/extension-loader.ts
+++ b/packages/preload/src/extension-loader.ts
@@ -68,6 +68,7 @@ export class ExtensionLoader {
   async listExtensions(): Promise<ExtensionInfo[]> {
     return Array.from(this.analyzedExtensions.values()).map(extension => ({
       name: extension.manifest.name,
+      displayName: extension.manifest.displayName,
       version: extension.manifest.version,
       publisher: extension.manifest.publisher,
       state: this.activatedExtensions.get(extension.id) ? 'active' : 'inactive',

--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -143,6 +143,7 @@ function jumpToImages() {
             </a>
           </li>
           -->
+          <!--
           <li
             class="pf-c-nav__item flex w-full justify-between {meta.url === '/extensions'
               ? 'dark:text-white pf-m-current'
@@ -167,6 +168,7 @@ function jumpToImages() {
               <span class="hidden md:block group-hover:block mr-5">Extensions</span>
             </a>
           </li>
+          -->
           <li
             class="pf-c-nav__item flex w-full justify-between {meta.url === '/preferences'
               ? 'dark:text-white pf-m-current'

--- a/packages/renderer/src/lib/preferences/PreferencesExtensionRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesExtensionRendering.svelte
@@ -1,0 +1,70 @@
+<script lang="ts">
+import { onMount } from 'svelte';
+import { extensionInfos } from '../../stores/extensions';
+import type { ExtensionInfo } from '../../../../preload/src/api/extension-info';
+export let extensionId: string = undefined;
+
+let extensions: ExtensionInfo[] = [];
+onMount(() => {
+  extensionInfos.subscribe(value => {
+    extensions = value;
+  });
+});
+
+let extensionInfo: ExtensionInfo;
+$: extensionInfo = extensions.find(extension => extension.id === extensionId);
+
+async function stopExtension() {
+  await window.stopExtension(extensionInfo.id);
+  window.dispatchEvent(new CustomEvent('extension-stopped', { detail: extensionInfo }));
+}
+async function startExtension() {
+  await window.startExtension(extensionInfo.id);
+  window.dispatchEvent(new CustomEvent('extension-started', { detail: extensionInfo }));
+}
+</script>
+
+<div class="flex flex-1 flex-col">
+  {#if extensionInfo}
+    <div class="pl-1 py-2">
+      <h1 class="capitalize text-xl">{extensionInfo.name} Extension</h1>
+      <div class="text-sm italic  text-gray-400">{extensionInfo.displayName}</div>
+    </div>
+
+    <!-- Manage lifecycle-->
+    <div class="pl-1 py-2">
+      <div class="text-sm italic  text-gray-400">Status</div>
+      <div class="pl-3">{extensionInfo.state}</div>
+    </div>
+
+    <div class="py-2 flex flex:row ">
+      <!-- start is enabled only in stopped mode-->
+      <div class="px-2 text-sm italic  text-gray-400">
+        <button
+          disabled="{extensionInfo.state !== 'inactive'}"
+          on:click="{() => startExtension()}"
+          class="pf-c-button pf-m-primary"
+          type="button">
+          <span class="pf-c-button__icon pf-m-start">
+            <i class="fas fa-play" aria-hidden="true"></i>
+          </span>
+          Enable
+        </button>
+      </div>
+
+      <!-- stop is enabled only in started mode-->
+      <div class="px-2 text-sm italic  text-gray-400">
+        <button
+          disabled="{extensionInfo.state !== 'active'}"
+          on:click="{() => stopExtension()}"
+          class="pf-c-button pf-m-primary"
+          type="button">
+          <span class="pf-c-button__icon pf-m-start">
+            <i class="fas fa-stop" aria-hidden="true"></i>
+          </span>
+          Disable
+        </button>
+      </div>
+    </div>
+  {/if}
+</div>


### PR DESCRIPTION
Also rename start/stop to enable/disable
and display a description of the extension
![Screenshot 2022-04-12 at 12 08 50](https://user-images.githubusercontent.com/436777/162936690-d323f13c-8bd8-482a-a135-5fe989683829.png)

Fixes https://github.com/containers/desktop/issues/83

Change-Id: Ida47fe0f4bb17d107c4a74338d285fc3ccee26ba
Signed-off-by: Florent Benoit <fbenoit@redhat.com>