### PR TITLE
fix: Use podman/hello as the example podman container

### DIFF
--- a/packages/renderer/src/lib/container/ContainerEmptyScreen.svelte
+++ b/packages/renderer/src/lib/container/ContainerEmptyScreen.svelte
@@ -24,7 +24,7 @@ onMount(async () => {
       <h1 class="pf-c-title pf-m-lg">No containers</h1>
       <div class="pf-c-empty-state__body">Run a first container using the following command line:</div>
       <div class="flex flex-row bg-gray-800 w-full items-center p-2 mt-2">
-        <div id="noContainerCommandLine">podman run redhat/ubi8-micro echo hello world</div>
+        <div id="noContainerCommandLine">podman run quay.io/podman/hello</div>
         <button title="Copy To Clipboard" class="mr-5" on:click="{() => copyRunInstructionToClipboard()}"
           ><Fa class="ml-3 h-5 w-5 cursor-pointer rounded-full text-3xl text-sky-800" icon="{faPaste}" /></button>
       </div>

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -20,5 +20,21 @@ Get started by **[Downloading](/downloads) the product** for your Operating Syst
 Run the development server:
 
 ```sh
-$ podman run redhat/ubi8-micro echo hello world
+$ podman run quay.io/podman/hello
+!... Hello Podman World ...!
+
+	 .--"--.
+       / -     - \
+      / (O)   (O) \
+   ~~~| -=(,Y,)=- |
+    .---. /`  \   |~~
+ ~/  o  o \~~~~.----. ~~
+  | =(X)= |~  / (O (O) \
+   ~~~~~~~  ~| =(Y_)=-  |
+  ~~~~    ~~~|   U      |~~
+
+Project:   https://github.com/containers/podman
+Website:   https://podman.io
+Documents: https://docs.podman.io
+Twitter:   @Podman_io
 ```

--- a/website/docs/troubleshooting.md
+++ b/website/docs/troubleshooting.md
@@ -26,7 +26,23 @@ podman machine list
 And check a connection can be made with the CLI
 
 ```sh
-$ podman run redhat/ubi8-micro echo hello world
+$ podman run quay.io/podman/hello
+!... Hello Podman World ...!
+
+	 .--"--.
+       / -     - \
+      / (O)   (O) \
+   ~~~| -=(,Y,)=- |
+    .---. /`  \   |~~
+ ~/  o  o \~~~~.----. ~~
+  | =(X)= |~  / (O (O) \
+   ~~~~~~~  ~| =(Y_)=-  |
+  ~~~~    ~~~|   U      |~~
+
+Project:   https://github.com/containers/podman
+Website:   https://podman.io
+Documents: https://docs.podman.io
+Twitter:   @Podman_io
 ```
 
 ## Code Ready Containers


### PR DESCRIPTION
the image redhat/ubi8-micro does not exists.

It should be just ubi8-micro, but I think this image is better.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>