### PR TITLE
docs: fix invalid ascii

### DIFF
--- a/website/docs/troubleshooting.md
+++ b/website/docs/troubleshooting.md
@@ -29,7 +29,7 @@ And check a connection can be made with the CLI
 $ podman run quay.io/podman/hello
 !... Hello Podman World ...!
 
-	 .--"--.
+         .--"--.
        / -     - \
       / (O)   (O) \
    ~~~| -=(,Y,)=- |


### PR DESCRIPTION
Logo was not displayed properly

before:
![Screenshot 2022-04-15 at 10 53 54](https://user-images.githubusercontent.com/436777/163549739-a02892a2-a057-4a6b-b31c-d8b4cf2163ce.png)

after:
![Screenshot 2022-04-15 at 10 53 39](https://user-images.githubusercontent.com/436777/163549727-cfbb02bc-751c-4def-a715-3a675e47b7e7.png)


Change-Id: I64ce2909e2e89960166ceb82d7f51559ca46c138
Signed-off-by: Florent Benoit <fbenoit@redhat.com>