### PR TITLE
fix: always bring the window on top when opening dashboard

### DIFF
--- a/packages/main/src/tray-menu.ts
+++ b/packages/main/src/tray-menu.ts
@@ -345,12 +345,9 @@ export class TrayMenu {
     if (window?.isMinimized()) {
       window.restore();
     }
-
-    if (!window?.isVisible()) {
-      window?.show();
-      if (isMac) {
-        app.dock.show();
-      }
+    window?.show();
+    if (isMac) {
+      app.dock.show();
     }
     window?.focus();
     window?.moveTop();


### PR DESCRIPTION
Fixes https://github.com/containers/podman-desktop/issues/119

Change-Id: I93005fa6e1f1c193f6b98b914fabdbedfc51f4b6
Signed-off-by: Florent Benoit <fbenoit@redhat.com>