### PR TITLE
fix: Align text of image size should be right-justified

### DIFF
--- a/packages/renderer/src/lib/ImagesList.svelte
+++ b/packages/renderer/src/lib/ImagesList.svelte
@@ -255,8 +255,8 @@ function getEngineName(containerInfo: ImageInfo): string {
               </div>
             </td>
             <td class="px-6 py-2 whitespace-nowrap w-10">
-              <div class="flex items-center">
-                <div class="ml-2 text-sm text-gray-200">{image.humanSize}</div>
+              <div class="flex">
+                <div class="w-full text-right text-sm text-gray-200">{image.humanSize}</div>
               </div>
             </td>
             <td class="px-6 py-2 whitespace-nowrap">


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/436777/167083422-a01ff0ff-e615-401e-a580-9e39425d9209.png)

Fixes https://github.com/containers/podman-desktop/issues/130
Change-Id: Ifb83d0993466a57a06fa40b5d8319a8f52db692e
Signed-off-by: Florent Benoit <fbenoit@redhat.com>