### PR TITLE
fix: Windows pipe name calculation

### DIFF
--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -100,7 +100,7 @@ async function updateMachines(provider: extensionApi.Provider): Promise<void> {
       if (isMac) {
         socketPath = path.resolve(podmanMachineSocketsDirectoryMac, machineName, 'podman.sock');
       } else if (isWindows) {
-        socketPath = `//./pipe/podman-${machineName}`;
+        socketPath = calcWinPipeName(machineName);
       }
       registerProviderFor(provider, podmanMachinesInfo.get(machineName), socketPath);
     }),
@@ -114,6 +114,11 @@ async function updateMachines(provider: extensionApi.Provider): Promise<void> {
       currentConnections.delete(machine);
     }
   });
+}
+
+function calcWinPipeName(machineName: string): string {
+  name = machineName.startsWith('podman') ? machineName : 'podman-' + machineName;
+  return `//./pipe/${name}`;
 }
 
 // on linux, socket is started by the system service on a path like /run/user/1000/podman/podman.sock


### PR DESCRIPTION
Small fix. The WSL podman backend only prefixes a name with `podman-` if it does not already start with podman (to maintain uniqueness but prevent redundancy)

I wonder if maybe this should be exposed in the machine API so you don't have to mirror logic (although no plans to change the path logic). 

Signed-off-by: Jason T. Greene <jason.greene@redhat.com>