### PR TITLE
feat: add show messages and 'withProgress' API

### DIFF
--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -118,7 +118,7 @@ async function updateMachines(provider: extensionApi.Provider): Promise<void> {
 }
 
 function calcWinPipeName(machineName: string): string {
-  name = machineName.startsWith('podman') ? machineName : 'podman-' + machineName;
+  const name = machineName.startsWith('podman') ? machineName : 'podman-' + machineName;
   return `//./pipe/${name}`;
 }
 

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -102,6 +102,13 @@ declare module '@tmpwip/extension-api' {
   export interface ExtensionContext {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     readonly subscriptions: { dispose(): any }[];
+
+    /**
+     * An absolute file path in which the extension can store state.
+     * The directory might not exist on disk and creation is
+     * up to the extension.
+     */
+    readonly storagePath: string;
   }
 
   export type ProviderStatus =
@@ -305,5 +312,109 @@ declare module '@tmpwip/extension-api' {
      * @return `true` if the given section has changed.
      */
     affectsConfiguration(section: string, scope?: ConfigurationScope): boolean;
+  }
+
+  /**
+   * Defines a generalized way of reporting progress updates.
+   */
+  export interface Progress<T> {
+    /**
+     * Report a progress update.
+     * @param value A progress item, like a message and/or an
+     * report on how much work finished
+     */
+    report(value: T): void;
+  }
+
+  /**
+ * A location in the editor at which progress information can be shown. It depends on the
+ * location how progress is visually represented.
+ */
+  export enum ProgressLocation {
+    /**
+     * Show progress bar under app icon in launcher bar.
+     */
+    APP_ICON = 1,
+  }
+
+  /**
+   * Value-object describing where and how progress should show.
+   */
+  export interface ProgressOptions {
+
+    /**
+     * The location at which progress should show.
+     */
+    location: ProgressLocation;
+
+    /**
+     * A human-readable string which will be used to describe the
+     * operation.
+     */
+    title?: string;
+
+    /**
+     * Controls if a cancel button should show to allow the user to
+     * cancel the long running operation.  Note that currently only
+     * `ProgressLocation.Notification` is supporting to show a cancel
+     * button.
+     */
+    cancellable?: boolean;
+  }
+
+  /**
+   * A cancellation token is passed to an asynchronous or long running
+   * operation to request cancellation.
+   */
+  export interface CancellationToken {
+
+    /**
+     * Is `true` when the token has been cancelled, `false` otherwise.
+     */
+    isCancellationRequested: boolean;
+
+    /**
+     * An {@link Event} which fires upon cancellation.
+     */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    onCancellationRequested: Event<any>;
+  }
+
+  export namespace window {
+    /**
+     * Show an information message. Optionally provide an array of items which will be presented as
+     * clickable buttons.
+     *
+     * @param message The message to show.
+     * @param items A set of items that will be rendered as actions in the message.
+     * @return A thenable that resolves to the selected item or `undefined` when being dismissed.
+     */
+    export function showInformationMessage(
+      title: string,
+      message: string,
+      ...items: string[]
+    ): Promise<string | undefined>;
+
+    /**
+     * Show a warning message. Optionally provide an array of items which will be presented as
+     * clickable buttons.
+     *
+     * @param message The message to show.
+     * @param items A set of items that will be rendered as actions in the message.
+     * @return A thenable that resolves to the selected item or `undefined` when being dismissed.
+     */
+    export function showWarningMessage(title: string, message: string, ...items: string[]): Promise<string | undefined>;
+
+    /**
+     * Show a error message. Optionally provide an array of items which will be presented as
+     * clickable buttons.
+     *
+     * @param message The message to show.
+     * @param items A set of items that will be rendered as actions in the message.
+     * @return A thenable that resolves to the selected item or `undefined` when being dismissed.
+     */
+    export function showErrorMessage(title: string, message: string, ...items: string[]): Promise<string | undefined>;
+
+    export function withProgress<R>(options: ProgressOptions, task: (progress: Progress<{ message?: string; increment?: number }>, token: CancellationToken) => Promise<R>): Promise<R>;
   }
 }

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -327,9 +327,9 @@ declare module '@tmpwip/extension-api' {
   }
 
   /**
- * A location in the editor at which progress information can be shown. It depends on the
- * location how progress is visually represented.
- */
+   * A location in the editor at which progress information can be shown. It depends on the
+   * location how progress is visually represented.
+   */
   export enum ProgressLocation {
     /**
      * Show progress bar under app icon in launcher bar.
@@ -341,7 +341,6 @@ declare module '@tmpwip/extension-api' {
    * Value-object describing where and how progress should show.
    */
   export interface ProgressOptions {
-
     /**
      * The location at which progress should show.
      */
@@ -367,7 +366,6 @@ declare module '@tmpwip/extension-api' {
    * operation to request cancellation.
    */
   export interface CancellationToken {
-
     /**
      * Is `true` when the token has been cancelled, `false` otherwise.
      */
@@ -415,6 +413,9 @@ declare module '@tmpwip/extension-api' {
      */
     export function showErrorMessage(title: string, message: string, ...items: string[]): Promise<string | undefined>;
 
-    export function withProgress<R>(options: ProgressOptions, task: (progress: Progress<{ message?: string; increment?: number }>, token: CancellationToken) => Promise<R>): Promise<R>;
+    export function withProgress<R>(
+      options: ProgressOptions,
+      task: (progress: Progress<{ message?: string; increment?: number }>, token: CancellationToken) => Promise<R>,
+    ): Promise<R>;
   }
 }

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -387,11 +387,7 @@ declare module '@tmpwip/extension-api' {
      * @param items A set of items that will be rendered as actions in the message.
      * @return A thenable that resolves to the selected item or `undefined` when being dismissed.
      */
-    export function showInformationMessage(
-      title: string,
-      message: string,
-      ...items: string[]
-    ): Promise<string | undefined>;
+    export function showInformationMessage(message: string, ...items: string[]): Promise<string | undefined>;
 
     /**
      * Show a warning message. Optionally provide an array of items which will be presented as
@@ -401,7 +397,7 @@ declare module '@tmpwip/extension-api' {
      * @param items A set of items that will be rendered as actions in the message.
      * @return A thenable that resolves to the selected item or `undefined` when being dismissed.
      */
-    export function showWarningMessage(title: string, message: string, ...items: string[]): Promise<string | undefined>;
+    export function showWarningMessage(message: string, ...items: string[]): Promise<string | undefined>;
 
     /**
      * Show a error message. Optionally provide an array of items which will be presented as
@@ -411,7 +407,7 @@ declare module '@tmpwip/extension-api' {
      * @param items A set of items that will be rendered as actions in the message.
      * @return A thenable that resolves to the selected item or `undefined` when being dismissed.
      */
-    export function showErrorMessage(title: string, message: string, ...items: string[]): Promise<string | undefined>;
+    export function showErrorMessage(message: string, ...items: string[]): Promise<string | undefined>;
 
     export function withProgress<R>(
       options: ProgressOptions,

--- a/packages/main/src/plugin/cancellation-token.ts
+++ b/packages/main/src/plugin/cancellation-token.ts
@@ -27,6 +27,5 @@ export class CancellationTokenImpl implements extensionApi.CancellationToken {
 
   constructor() {
     this.isCancellationRequested = false;
-
   }
 }

--- a/packages/main/src/plugin/cancellation-token.ts
+++ b/packages/main/src/plugin/cancellation-token.ts
@@ -23,6 +23,7 @@ export class CancellationTokenImpl implements extensionApi.CancellationToken {
   isCancellationRequested: boolean;
 
   private readonly cancellationEmitter = new Emitter();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   onCancellationRequested: extensionApi.Event<any> = this.cancellationEmitter.event;
 
   constructor() {

--- a/packages/main/src/plugin/cancellation-token.ts
+++ b/packages/main/src/plugin/cancellation-token.ts
@@ -16,13 +16,17 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { BrowserWindow } from 'electron';
-import * as os from 'os';
+import type * as extensionApi from '@tmpwip/extension-api';
+import { Emitter } from './events/emitter';
 
-export const isWindows = os.platform() === 'win32';
-export const isMac = os.platform() === 'darwin';
-export const isLinux = os.platform() === 'linux';
+export class CancellationTokenImpl implements extensionApi.CancellationToken {
+  isCancellationRequested: boolean;
 
-export function findWindow(): Electron.BrowserWindow | undefined {
-  return BrowserWindow.getAllWindows().find(w => !w.isDestroyed());
+  private readonly cancellationEmitter = new Emitter();
+  onCancellationRequested: extensionApi.Event<any> = this.cancellationEmitter.event;
+
+  constructor() {
+    this.isCancellationRequested = false;
+
+  }
 }

--- a/packages/main/src/plugin/dialog-impl.ts
+++ b/packages/main/src/plugin/dialog-impl.ts
@@ -16,13 +16,24 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { BrowserWindow } from 'electron';
-import * as os from 'os';
+import { dialog } from 'electron';
+import { findWindow } from '../util';
 
-export const isWindows = os.platform() === 'win32';
-export const isMac = os.platform() === 'darwin';
-export const isLinux = os.platform() === 'linux';
+type DialogType = 'none' | 'info' | 'error' | 'question' | 'warning';
+export class Dialogs {
+  async showDialog(type: DialogType, title: string, message: string, items: string[]): Promise<string | undefined> {
+    const window = findWindow();
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const result = await dialog.showMessageBox(window!, {
+      title: title,
+      message: message,
+      buttons: items,
+      type: type,
+    });
+    if (result) {
+      return items[result.response];
+    }
 
-export function findWindow(): Electron.BrowserWindow | undefined {
-  return BrowserWindow.getAllWindows().find(w => !w.isDestroyed());
+    return undefined;
+  }
 }

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -176,7 +176,7 @@ export class ExtensionLoader {
     this.overrideRequire();
 
     // create api object
-    const api = this.createApi();
+    const api = this.createApi(manifest);
 
     const extension: AnalyzedExtension = {
       id: manifest.name,
@@ -200,7 +200,8 @@ export class ExtensionLoader {
     return this.activateExtension(extension, runtime);
   }
 
-  createApi(): typeof containerDesktopAPI {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  createApi(extManifest: any): typeof containerDesktopAPI {
     const commandRegistry = this.commandRegistry;
     const commands: typeof containerDesktopAPI.commands = {
       registerCommand(
@@ -268,14 +269,14 @@ export class ExtensionLoader {
     const dialogs = this.dialogs;
     const progress = this.progress;
     const windowObj: typeof containerDesktopAPI.window = {
-      showInformationMessage: (title: string, message: string, ...items: string[]) => {
-        return dialogs.showDialog('info', title, message, items);
+      showInformationMessage: (message: string, ...items: string[]) => {
+        return dialogs.showDialog('info', extManifest.name, message, items);
       },
-      showWarningMessage: (title: string, message: string, ...items: string[]) => {
-        return dialogs.showDialog('warning', title, message, items);
+      showWarningMessage: (message: string, ...items: string[]) => {
+        return dialogs.showDialog('warning', extManifest.name, message, items);
       },
-      showErrorMessage: (title: string, message: string, ...items: string[]) => {
-        return dialogs.showDialog('error', title, message, items);
+      showErrorMessage: (message: string, ...items: string[]) => {
+        return dialogs.showDialog('error', extManifest.name, message, items);
       },
 
       withProgress: <R>(

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -29,7 +29,7 @@ import type { ProviderRegistry } from './provider-registry';
 import type { ConfigurationRegistry } from './configuration-registry';
 import type { ImageRegistry } from './image-registry';
 import type { Dialogs } from './dialog-impl';
-import type { ProgressImpl} from './progress-impl';
+import type { ProgressImpl } from './progress-impl';
 import { ProgressLocation } from './progress-impl';
 
 /**
@@ -278,8 +278,12 @@ export class ExtensionLoader {
         return dialogs.showDialog('error', title, message, items);
       },
 
-      withProgress: <R>(options: containerDesktopAPI.ProgressOptions,
-        task: (progress: containerDesktopAPI.Progress<{ message?: string; increment?: number }>, token: containerDesktopAPI.CancellationToken) => Promise<R>,
+      withProgress: <R>(
+        options: containerDesktopAPI.ProgressOptions,
+        task: (
+          progress: containerDesktopAPI.Progress<{ message?: string; increment?: number }>,
+          token: containerDesktopAPI.CancellationToken,
+        ) => Promise<R>,
       ): Promise<R> => {
         return progress.withProgress(options, task);
       },

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -42,6 +42,8 @@ import { shell } from 'electron';
 import type { ImageInspectInfo } from './api/image-inspect-info';
 import type { TrayMenu } from '../tray-menu';
 import { getFreePort } from './util/port';
+import { Dialogs } from './dialog-impl';
+import { ProgressImpl } from './progress-impl';
 
 export class PluginSystem {
   constructor(private trayMenu: TrayMenu) {}
@@ -94,6 +96,8 @@ export class PluginSystem {
       imageRegistry,
       apiSender,
       trayMenuRegistry,
+      new Dialogs(),
+      new ProgressImpl(),
     );
 
     ipcMain.handle('container-provider-registry:listContainers', async (): Promise<ContainerInfo[]> => {

--- a/packages/main/src/plugin/progress-impl.ts
+++ b/packages/main/src/plugin/progress-impl.ts
@@ -27,16 +27,23 @@ export enum ProgressLocation {
 }
 
 export class ProgressImpl {
-  withProgress<R>(options: extensionApi.ProgressOptions,
-    task: (progress: extensionApi.Progress<{ message?: string; increment?: number }>, token: extensionApi.CancellationToken) => Promise<R>,
+  withProgress<R>(
+    options: extensionApi.ProgressOptions,
+    task: (
+      progress: extensionApi.Progress<{ message?: string; increment?: number }>,
+      token: extensionApi.CancellationToken,
+    ) => Promise<R>,
   ): Promise<R> {
-    return task({
-      report: value => {
-        const window = findWindow();
-        if (window) {
-          window.setProgressBar(value.increment ?? 1 / 100, { mode: 'normal' });
-        }
+    return task(
+      {
+        report: value => {
+          const window = findWindow();
+          if (window) {
+            window.setProgressBar(value.increment ?? 1 / 100, { mode: 'normal' });
+          }
+        },
       },
-    }, new CancellationTokenImpl());
+      new CancellationTokenImpl(),
+    );
   }
 }

--- a/packages/main/src/tray-menu.ts
+++ b/packages/main/src/tray-menu.ts
@@ -17,12 +17,12 @@
  ***********************************************************************/
 
 import type { ProviderStatus } from '@tmpwip/extension-api';
-import { app, ipcMain, BrowserWindow, Menu, nativeImage } from 'electron';
+import { app, ipcMain, Menu, nativeImage } from 'electron';
 import type { MenuItemConstructorOptions, Tray, NativeImage } from 'electron';
 import statusStarted from './assets/status-started.png';
 import statusStopped from './assets/status-stopped.png';
 import statusUnknown from './assets/status-unknown.png';
-import { isMac } from './util';
+import { findWindow, isMac } from './util';
 import statusBusy from './assets/status-busy.png';
 import type { AnimatedTray, TrayIconStatus } from './tray-animate-icon';
 import type { ProviderContainerConnectionInfo, ProviderInfo } from './plugin/api/provider-info';
@@ -318,7 +318,7 @@ export class TrayMenu {
   }
 
   private showMainWindow(): void {
-    const window = BrowserWindow.getAllWindows().find(w => !w.isDestroyed());
+    const window = findWindow();
 
     if (window?.isMinimized()) {
       window.restore();


### PR DESCRIPTION
This PR add new API in `window` namespace:
- `showInformationMessage`
- `showWarningMessage`
- `showErrorMessage`
- `withProgress`

As part from https://github.com/containers/podman-desktop/pull/160