### PR TITLE
chore: Allow development on linux

### DIFF
--- a/extensions/crc/src/extension.ts
+++ b/extensions/crc/src/extension.ts
@@ -222,7 +222,7 @@ function execPromise(command, args?: string[]): Promise<string> {
 
 async function readPreset(): Promise<'Podman' | 'OpenShift' | 'unknown'> {
   try {
-    const stdout = await execPromise('/usr/local/bin/crc', ['config', 'get', 'preset']);
+    const stdout = await execPromise('crc', ['config', 'get', 'preset']);
     if (stdout.includes('podman')) {
       return 'Podman';
     } else if (stdout.includes('openshift')) {

--- a/extensions/podman/src/registry-setup.ts
+++ b/extensions/podman/src/registry-setup.ts
@@ -134,15 +134,16 @@ export class RegistrySetup {
       }
     });
 
+    // check if the file exists
+    if (!fs.existsSync(this.getAuthFileLocation())) {
+      return;
+    }
+
     // need to monitor this file
     fs.watchFile(this.getAuthFileLocation(), () => {
       this.updateRegistries(extensionContext);
     });
 
-    // check if the file exists
-    if (!fs.existsSync(this.getAuthFileLocation())) {
-      return;
-    }
     // else init with the content of this file
     this.updateRegistries(extensionContext);
   }


### PR DESCRIPTION
## Fixes

* Don't rely on hard coded path - rely on `$PATH` or `%PATH%`
* Test before watch - in `Linux` it crashes if watch is launched and file does not exists