### PR TITLE
feat: change codeready to CRC(#109)

### DIFF
--- a/extensions/crc/package.json
+++ b/extensions/crc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "crc",
-  "displayName": "Manages CodeReady Containers",
-  "description": "Allow to start and stop CodeReady Containers and use Podman",
+  "displayName": "Manages CRC",
+  "description": "Allow to start and stop CRC and use Podman",
   "version": "0.0.1",
   "icon": "icon.png",
   "publisher": "benoitf",

--- a/extensions/crc/src/extension.ts
+++ b/extensions/crc/src/extension.ts
@@ -39,7 +39,7 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
   const preset = await readPreset();
 
   // create CRC provider
-  const provider = extensionApi.provider.createProvider({ name: 'CodeReady Containers', id: 'crc', status: 'unknown' });
+  const provider = extensionApi.provider.createProvider({ name: 'CRC', id: 'crc', status: 'unknown' });
   extensionContext.subscriptions.push(provider);
 
   const daemonStarted = await daemonStart();


### PR DESCRIPTION
Closes #109

Let me know if there's anything that I missed.

Screenshot after the change:

<img width="1440" alt="Screen Shot 2022-06-10 at 6 53 58 PM" src="https://user-images.githubusercontent.com/70570804/173041164-3f58cc18-a902-4b88-aff3-bdda1ec4879e.png">

Signed-off-by: Doehyun Baek <doehyunbaek@gmail.com>