### PR TITLE
doc: added command to fix lint and format in Contribution.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -156,7 +156,7 @@ commit automatically with `git commit -s`.
 ### Format and lint
 
 All code changes must pass ``yarn format:check`` and ``yarn lint:check``.
-To fix format and lint``yarn format:fix && yarn lint:fix``
+To fix format and lint ``yarn format:fix && yarn lint:fix``
 
 ## Continuous Integration
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -156,6 +156,7 @@ commit automatically with `git commit -s`.
 ### Format and lint
 
 All code changes must pass ``yarn format:check`` and ``yarn lint:check``.
+To fix format and lint``yarn format:fix && yarn lint:fix``
 
 ## Continuous Integration
 


### PR DESCRIPTION
Signed-off-by: ankanroy-code <8ankanroy@gmail.com>

``yarn format:fix && yarn lint:fix`` should be present in the CONTRIBUTING.md