### PR TITLE
feat: Add Notification API

### DIFF
--- a/extensions/podman/src/podman-install.ts
+++ b/extensions/podman/src/podman-install.ts
@@ -182,7 +182,7 @@ class WinInstaller extends BaseInstaller {
         if (fs.existsSync(msiPath)) {
           await this.executeInstaller('msiexec', ['/i', msiPath, '/qb', '/norestart']);
           progress.report({ increment: 80 });
-          await extensionApi.window.showInformationMessage('Podman is successfully installed.', 'OK');
+          extensionApi.window.showNotification({ body: 'Podman is successfully installed.' });
           return true;
         } else {
           throw new Error(`Can't find Podman msi package! Path: ${msiPath} doesn't exists.`);

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -379,6 +379,21 @@ declare module '@tmpwip/extension-api' {
     onCancellationRequested: Event<any>;
   }
 
+  export interface NotificationOptions {
+    /**
+     * A title for the notification, which will be shown at the top of the notification window when it is shown.
+     */
+    title?: string;
+    /**
+     * The body text of the notification, which will be displayed below the title.
+     */
+    body?: string;
+    /**
+     * Whether or not to emit an OS notification noise when showing the notification.
+     */
+    silent?: boolean;
+  }
+
   export namespace window {
     /**
      * Show an information message. Optionally provide an array of items which will be presented as
@@ -414,5 +429,11 @@ declare module '@tmpwip/extension-api' {
       options: ProgressOptions,
       task: (progress: Progress<{ message?: string; increment?: number }>, token: CancellationToken) => Promise<R>,
     ): Promise<R>;
+
+    /**
+     * Show OS desktop notification
+     * @param options
+     */
+    export function showNotification(options: NotificationOptions): Disposable;
   }
 }

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -31,6 +31,7 @@ import type { ImageRegistry } from './image-registry';
 import type { Dialogs } from './dialog-impl';
 import type { ProgressImpl } from './progress-impl';
 import { ProgressLocation } from './progress-impl';
+import type { NotificationImpl } from './notification-impl';
 
 /**
  * Handle the loading of an extension
@@ -71,6 +72,7 @@ export class ExtensionLoader {
     private trayMenuRegistry: TrayMenuRegistry,
     private dialogs: Dialogs,
     private progress: ProgressImpl,
+    private notifications: NotificationImpl,
   ) {}
 
   async listExtensions(): Promise<ExtensionInfo[]> {
@@ -272,6 +274,7 @@ export class ExtensionLoader {
 
     const dialogs = this.dialogs;
     const progress = this.progress;
+    const notifications = this.notifications;
     const windowObj: typeof containerDesktopAPI.window = {
       showInformationMessage: (message: string, ...items: string[]) => {
         return dialogs.showDialog('info', extManifest.name, message, items);
@@ -291,6 +294,10 @@ export class ExtensionLoader {
         ) => Promise<R>,
       ): Promise<R> => {
         return progress.withProgress(options, task);
+      },
+
+      showNotification: (options: containerDesktopAPI.NotificationOptions): containerDesktopAPI.Disposable => {
+        return notifications.showNotification(options);
       },
     };
 

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -49,6 +49,7 @@ import { ContributionManager } from './contribution-manager';
 import { DockerDesktopInstallation } from './docker-extension/docker-desktop-installation';
 import { DockerPluginAdapter } from './docker-extension/docker-plugin-adapter';
 import { Telemetry } from './telemetry/telemetry';
+import { NotificationImpl } from './notification-impl';
 
 export class PluginSystem {
   constructor(private trayMenu: TrayMenu) {}
@@ -107,6 +108,7 @@ export class PluginSystem {
       trayMenuRegistry,
       new Dialogs(),
       new ProgressImpl(),
+      new NotificationImpl(),
     );
 
     const contributionManager = new ContributionManager(apiSender);

--- a/packages/main/src/plugin/notification-impl.ts
+++ b/packages/main/src/plugin/notification-impl.ts
@@ -16,17 +16,16 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import * as os from 'node:os';
+import type * as containerDesktopAPI from '@tmpwip/extension-api';
+import { Notification } from 'electron';
+import { Disposable } from './types/disposable';
 
-export const isWindows = os.platform() === 'win32';
-export const isMac = os.platform() === 'darwin';
-export const isLinux = os.platform() === 'linux';
-
-/**
- * @returns true if app running in dev mode
- */
-export function isDev(): boolean {
-  const isEnvSet = 'ELECTRON_IS_DEV' in process.env;
-  const envSet = Number.parseInt(process.env.ELECTRON_IS_DEV, 10) === 1;
-  return isEnvSet ? envSet : false;
+export class NotificationImpl {
+  showNotification(options: containerDesktopAPI.NotificationOptions): Disposable {
+    const notification = new Notification(options);
+    notification.show();
+    return Disposable.create(() => {
+      notification.close();
+    });
+  }
 }

--- a/scripts/watch.js
+++ b/scripts/watch.js
@@ -74,7 +74,7 @@ const setupMainPackageWatcher = ({config: {server}}) => {
         spawnProcess = null;
       }
 
-      spawnProcess = spawn(String(electronPath), ['.']);
+      spawnProcess = spawn(String(electronPath), ['.'], { env: {ELECTRON_IS_DEV: 1} });
 
       spawnProcess.stdout.on('data', d => d.toString().trim() && logger.warn(d.toString(), {timestamp: true}));
       spawnProcess.stderr.on('data', d => {


### PR DESCRIPTION
This PR introduce `showNotification` function in `window` object.

Example notification on Windows:
![Screenshot 2022-06-16 121923](https://user-images.githubusercontent.com/929743/174065255-b3f685cc-4510-4a3a-8f56-9291976f918c.png)

Also it use notification to inform user that podman was installed.

>Note: also it fix `isDev` function implementation
