### PR TITLE
fix: add registry ui glitches

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesRegistriesEditCreateRegistryModal.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRegistriesEditCreateRegistryModal.svelte
@@ -116,7 +116,7 @@ async function createOrUpdateRegistry() {
               {/if}
             </label>
           </div>
-          <div class="pf-c-form__group-control">
+          <div class="pf-c-form__group-control pf-u-min-height">
             <input
               class="pf-c-form-control"
               type="text"
@@ -136,11 +136,11 @@ async function createOrUpdateRegistry() {
         <div class="pf-c-form__group">
           <div class="pf-c-form__group-label">
             <label class="pf-c-form__label" for="form-horizontal-custom-breakpoint-name">
-              <span class="pf-c-form__label-text">username:</span>
+              <span class="pf-c-form__label-text">Username:</span>
               <span class="pf-c-form__label-required" aria-hidden="true">&#42;</span>
             </label>
           </div>
-          <div class="pf-c-form__group-control">
+          <div class="pf-c-form__group-control pf-u-min-height">
             <input
               class="pf-c-form-control"
               type="text"
@@ -159,11 +159,11 @@ async function createOrUpdateRegistry() {
         <div class="pf-c-form__group">
           <div class="pf-c-form__group-label">
             <label class="pf-c-form__label" for="form-horizontal-custom-breakpoint-name">
-              <span class="pf-c-form__label-text">password:</span>
+              <span class="pf-c-form__label-text">Password:</span>
               <span class="pf-c-form__label-required" aria-hidden="true">&#42;</span>
             </label>
           </div>
-          <div class="pf-c-form__group-control">
+          <div class="pf-c-form__group-control pf-u-min-height">
             <input
               class="pf-c-form-control"
               type="password"

--- a/packages/renderer/src/override.css
+++ b/packages/renderer/src/override.css
@@ -69,3 +69,17 @@ nav .pf-c-badge.pf-m-read {
   --pf-c-tree-view__node--PaddingBottom: 0.2rem;
   --pf-c-tree-view__node--indent--base: calc(0.6rem * 2 + var(--pf-c-tree-view__node-toggle-icon--MinWidth));
 }
+
+.pf-c-form {
+  --pf-c-form--GridGap: 1rem;
+  overflow-y: hidden;
+}
+
+.pf-c-form .pf-u-min-height {
+  --pf-u-min-height--MinHeight: 3.3rem;
+}
+
+.pf-c-modal-box {
+  --pf-c-modal-box__body--PaddingTop: 3.5rem;
+  --pf-c-modal-box__header--body--PaddingTop: 1.5rem;
+}


### PR DESCRIPTION
This changes proposal fixes UI glitches that appears when user is trying to add a new registry.
Set up the fixed height for the field group to avoid jumping the UI when validation passes or not.

Fixes https://github.com/containers/podman-desktop/issues/149

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>