### PR TITLE
feat: Display a no-engine empty screen when there is no engine running

### DIFF
--- a/packages/renderer/src/lib/ContainerList.svelte
+++ b/packages/renderer/src/lib/ContainerList.svelte
@@ -10,6 +10,8 @@ import ContainerActions from './container/ContainerActions.svelte';
 import ContainerEmptyScreen from './container/ContainerEmptyScreen.svelte';
 import Modal from './dialogs/Modal.svelte';
 import { ContainerUtils } from './container/container-utils';
+import { providerInfos } from '../stores/providers';
+import NoContainerEngineEmptyScreen from './image/NoContainerEngineEmptyScreen.svelte';
 
 let openChoiceModal = false;
 
@@ -23,6 +25,11 @@ function fromExistingImage(): void {
 }
 
 let multipleEngines = false;
+
+$: providerConnections = $providerInfos
+  .map(provider => provider.containerConnections)
+  .flat()
+  .filter(providerContainerConnection => providerContainerConnection.status === 'started');
 
 onMount(async () => {
   const containerUtils = new ContainerUtils();
@@ -151,9 +158,12 @@ function fromDockerfile(): void {
       </tbody>
     </table>
   </div>
-  <ContainerEmptyScreen containers="{$filtered}" />
+  {#if providerConnections.length > 0}
+    <ContainerEmptyScreen containers="{$filtered}" />
+  {:else}
+    <NoContainerEngineEmptyScreen />
+  {/if}
 </div>
-
 {#if openChoiceModal}
   <Modal
     on:close="{() => {

--- a/packages/renderer/src/lib/ImagesList.svelte
+++ b/packages/renderer/src/lib/ImagesList.svelte
@@ -10,12 +10,19 @@ import ImageActions from './image/ImageActions.svelte';
 import type { ImageInfo } from '../../../main/src/plugin/api/image-info';
 import Fa from 'svelte-fa/src/fa.svelte';
 import { faLayerGroup } from '@fortawesome/free-solid-svg-icons';
+import NoContainerEngineEmptyScreen from './image/NoContainerEngineEmptyScreen.svelte';
+import { providerInfos } from '../stores/providers';
 
 let searchTerm = '';
 $: searchPattern.set(searchTerm);
 
 let images: ImageInfoUI[] = [];
 let multipleEngines = false;
+
+$: providerConnections = $providerInfos
+  .map(provider => provider.containerConnections)
+  .flat()
+  .filter(providerContainerConnection => providerContainerConnection.status === 'started');
 
 onMount(async () => {
   filtered.subscribe(value => {
@@ -202,5 +209,9 @@ function getEngineName(containerInfo: ImageInfo): string {
       </tbody>
     </table>
   </div>
-  <ImageEmptyScreen images="{$filtered}" />
+  {#if providerConnections.length > 0}
+    <ImageEmptyScreen images="{$filtered}" />
+  {:else}
+    <NoContainerEngineEmptyScreen />
+  {/if}
 </div>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/436777/176218003-aebf78e1-9e72-4b8e-a337-a392dcdc23e0.png)

related to https://github.com/containers/podman-desktop/issues/164

Change-Id: If203051afde703788483e9807760545e0afdfa8e
Signed-off-by: Florent Benoit <fbenoit@redhat.com>