### PR TITLE
feat: add welcome page

### DIFF
--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -22,6 +22,9 @@ import BuildImageFromContainerfile from './lib/image/BuildImageFromContainerfile
 import PullImage from './lib/image/PullImage.svelte';
 import DockerExtension from './lib/docker-extension/DockerExtension.svelte';
 import ContainerDetails from './lib/ContainerDetails.svelte';
+import { providerInfos } from './stores/providers';
+import type { ProviderInfo } from '../../main/src/plugin/api/provider-info';
+import WelcomePage from './lib/welcome/WelcomePage.svelte';
 let containersCountValue;
 
 router.mode.hash();
@@ -39,11 +42,22 @@ let contributionsExpanded: boolean = true;
 function toggleContributions() {
   contributionsExpanded = !contributionsExpanded;
 }
+
+let providers: ProviderInfo[] = [];
+$: providerConnections = providers
+  .map(provider => provider.containerConnections)
+  .flat()
+  .filter(providerContainerConnection => providerContainerConnection.status === 'started');
+
+onMount(() => {
+  providerInfos.subscribe(value => {
+    providers = value;
+  });
+});
 </script>
 
 <svelte:window bind:innerWidth />
 <Route path="/*" breadcrumb="Home" let:meta>
-  <Route path="/" redirect="/containers" />
   <main class="min-h-screen flex flex-col h-screen bg-zinc-900">
     <ninja-keys id="command-palette" placeholder="" openHotkey="F1" hideBreadcrumbs class="dark"></ninja-keys>
 
@@ -65,8 +79,24 @@ function toggleContributions() {
         aria-label="Global">
         <ul class="pf-c-nav__list">
           <li
-            class="pf-c-nav__item flex w-full items-center justify-between {meta.url.startsWith('/containers') ||
-            meta.url === '/'
+            class="pf-c-nav__item flex w-full items-center justify-between {meta.url === '/'
+              ? 'pf-m-current'
+              : ''} hover:text-gray-300 cursor-pointer items-center mb-6">
+            <a href="/" class="pf-c-nav__link flex items-center align-middle">
+              <div class="flex items-center">
+                <svg class="" width="20" viewBox="0 0 576 512"
+                  ><path
+                    style="fill: currentColor;"
+                    d="M575.8 255.5C575.8 273.5 560.8 287.6 543.8 287.6H511.8L512.5 447.7C512.5 450.5 512.3 453.1 512 455.8V472C512 494.1 494.1 512 472 512H456C454.9 512 453.8 511.1 452.7 511.9C451.3 511.1 449.9 512 448.5 512H392C369.9 512 352 494.1 352 472V384C352 366.3 337.7 352 320 352H256C238.3 352 224 366.3 224 384V472C224 494.1 206.1 512 184 512H128.1C126.6 512 125.1 511.9 123.6 511.8C122.4 511.9 121.2 512 120 512H104C81.91 512 64 494.1 64 472V360C64 359.1 64.03 358.1 64.09 357.2V287.6H32.05C14.02 287.6 0 273.5 0 255.5C0 246.5 3.004 238.5 10.01 231.5L266.4 8.016C273.4 1.002 281.4 0 288.4 0C295.4 0 303.4 2.004 309.5 7.014L564.8 231.5C572.8 238.5 576.9 246.5 575.8 255.5L575.8 255.5z"
+                  ></path
+                  ></svg>
+                <span class="hidden md:block group-hover:block mx-2">Home</span>
+              </div>
+            </a>
+          </li>
+
+          <li
+            class="pf-c-nav__item flex w-full items-center justify-between {meta.url.startsWith('/containers')
               ? 'pf-m-current'
               : ''} hover:text-gray-300 cursor-pointer items-center mb-6">
             <a href="/containers" class="pf-c-nav__link flex items-center align-middle">
@@ -162,6 +192,7 @@ function toggleContributions() {
               </div>
             </a>
           </li>
+
           <li
             class="pf-c-nav__item flex w-full justify-between {meta.url.startsWith('/preferences')
               ? 'dark:text-white pf-m-current'
@@ -248,6 +279,9 @@ function toggleContributions() {
       </nav>
 
       <div class="w-full h-full bg-zinc-800 flex flex-col overflow-y-scroll">
+        <Route path="/">
+          <WelcomePage />
+        </Route>
         <Route path="/containers">
           <ContainerList />
         </Route>

--- a/packages/renderer/src/lib/welcome/ProviderConfigured.svelte
+++ b/packages/renderer/src/lib/welcome/ProviderConfigured.svelte
@@ -1,0 +1,95 @@
+<script lang="ts">
+import type { ProviderInfo } from '../../../../main/src/plugin/api/provider-info';
+import ProviderLinks from './ProviderLinks.svelte';
+import ProviderLogo from './ProviderLogo.svelte';
+import ProviderUpdateButton from './ProviderUpdateButton.svelte';
+
+export let provider: ProviderInfo;
+let providerToggleValue = false;
+
+let runInProgress = false;
+
+let runError: string | undefined = undefined;
+
+async function runProvider() {
+  runError = undefined;
+  if (providerToggleValue) {
+    runInProgress = true;
+    try {
+      await window.startProvider(provider.internalId);
+      // wait that status is updated
+      await new Promise<void>(resolve => {
+        window.events.receive('provider-change', () => {
+          resolve();
+        });
+      });
+    } catch (error) {
+      runError = error;
+      console.error('Error while starting the provider', error);
+    }
+    runInProgress = false;
+  }
+}
+</script>
+
+<div class="p-2 flex flex-col bg-zinc-700 rounded-lg">
+  <ProviderLogo provider="{provider}" />
+  <div class="flex flex-col items-center text-center">
+    <p class="text-xl text-gray-300">
+      {provider.name}
+      {#if provider.version}
+        v{provider.version}
+      {/if}
+      is stopped
+    </p>
+    <p class="text-base text-gray-400">
+      To start working with containers, {provider.name}
+      {#if provider.version}
+        v{provider.version}
+      {/if} needs to be started.
+    </p>
+
+    <label for="toggle-{provider.internalId}" class="inline-flex relative items-center my-5 cursor-pointer">
+      <input
+        type="checkbox"
+        disabled="{runInProgress}"
+        bind:checked="{providerToggleValue}"
+        on:change="{() => runProvider()}"
+        id="toggle-{provider.internalId}"
+        class="sr-only peer" />
+      <div
+        class="w-9 h-5 peer-focus:ring-violet-800 rounded-full peer bg-zinc-400 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-4 after:w-4 after:transition-all dark:border-gray-600 peer-checked:bg-violet-600">
+      </div>
+      <span class="ml-3 text-sm font-medium text-gray-300">Run {provider.name}</span>
+    </label>
+    {#if runInProgress}
+      <div class="flex mt-2 flex-col">
+        <div>Starting...Please Wait...</div>
+        <div class="my-2">
+          <i class="pf-c-button__progress">
+            <span class="pf-c-spinner pf-m-md" role="progressbar">
+              <span class="pf-c-spinner__clipper"></span>
+              <span class="pf-c-spinner__lead-ball"></span>
+              <span class="pf-c-spinner__tail-ball"></span>
+            </span>
+          </i>
+        </div>
+      </div>
+    {/if}
+    {#if runError}
+      <div class="flex mt-2 flex-col">
+        <div>Error:</div>
+        <div class="my-2">
+          <p class="text-sm text-red-500">{runError}</p>
+        </div>
+      </div>
+    {/if}
+  </div>
+  {#if provider.updateInfo}
+    <div class="mt-10 mb-1  w-full flex  justify-around">
+      <ProviderUpdateButton provider="{provider}" />
+    </div>
+  {/if}
+  <div class="mt-10 mb-1  w-full flex  justify-around"></div>
+  <ProviderLinks provider="{provider}" />
+</div>

--- a/packages/renderer/src/lib/welcome/ProviderDetectionChecksButton.svelte
+++ b/packages/renderer/src/lib/welcome/ProviderDetectionChecksButton.svelte
@@ -1,0 +1,56 @@
+<script lang="ts">
+import type { ProviderDetectionCheck } from '@tmpwip/extension-api';
+
+import type { ProviderInfo } from '../../../../main/src/plugin/api/provider-info';
+
+export let provider: ProviderInfo;
+export let onDetectionChecks = (_detectionChecks: ProviderDetectionCheck[]) => {};
+let viewInProgress = false;
+
+let mode: 'view' | 'hide' = 'view';
+
+async function toggleDetectionChecks(provider: ProviderInfo) {
+  let detectionChecks: ProviderDetectionCheck[] = [];
+  if (mode === 'view') {
+    viewInProgress = true;
+    // needs to ask the provider why it didn't find provider being installed
+    detectionChecks = await window.getProviderDetectionChecks(provider.internalId);
+  } else {
+    detectionChecks = [];
+  }
+  onDetectionChecks(detectionChecks);
+  viewInProgress = false;
+
+  if (mode === 'view') {
+    mode = 'hide';
+  } else {
+    mode = 'view';
+  }
+}
+</script>
+
+{#if provider.detectionChecks.length > 0}
+  <button
+    on:click="{() => toggleDetectionChecks(provider)}"
+    class="pf-c-button pf-m-primary"
+    disabled="{viewInProgress}"
+    type="button"
+    title="Why {provider.name} is not found.">
+    <span class="pf-c-button__icon pf-m-start ">
+      {#if viewInProgress}
+        <div class="mr-44">
+          <i class="pf-c-button__progress">
+            <span class="pf-c-spinner pf-m-md" role="progressbar">
+              <span class="pf-c-spinner__clipper"></span>
+              <span class="pf-c-spinner__lead-ball"></span>
+              <span class="pf-c-spinner__tail-ball"></span>
+            </span>
+          </i>
+        </div>
+      {:else}
+        <i class="fas fa-list" aria-hidden="true"></i>
+      {/if}
+    </span>
+    {mode === 'view' ? 'View' : 'Hide'} detection checks
+  </button>
+{/if}

--- a/packages/renderer/src/lib/welcome/ProviderInstallationButton.svelte
+++ b/packages/renderer/src/lib/welcome/ProviderInstallationButton.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+import type { ProviderInfo } from '../../../../main/src/plugin/api/provider-info';
+
+export let provider: ProviderInfo;
+let installInProgress = false;
+
+async function performInstallation(provider: ProviderInfo) {
+  installInProgress = true;
+
+  await window.installProvider(provider.internalId);
+
+  installInProgress = false;
+}
+</script>
+
+{#if provider.installationSupport}
+  <button
+    disabled="{installInProgress}"
+    on:click="{() => performInstallation(provider)}"
+    class="pf-c-button pf-m-primary"
+    type="button">
+    <span class="pf-c-button__icon pf-m-start ">
+      {#if installInProgress}
+        <div class="mr-20">
+          <i class="pf-c-button__progress">
+            <span class="pf-c-spinner pf-m-md" role="progressbar">
+              <span class="pf-c-spinner__clipper"></span>
+              <span class="pf-c-spinner__lead-ball"></span>
+              <span class="pf-c-spinner__tail-ball"></span>
+            </span>
+          </i>
+        </div>
+      {:else}
+        <i class="fas fa-rocket" aria-hidden="true"></i>
+      {/if}
+    </span>
+    Install
+  </button>
+{/if}

--- a/packages/renderer/src/lib/welcome/ProviderInstalled.svelte
+++ b/packages/renderer/src/lib/welcome/ProviderInstalled.svelte
@@ -1,0 +1,92 @@
+<script lang="ts">
+import type { ProviderInfo } from '../../../../main/src/plugin/api/provider-info';
+import ProviderLinks from './ProviderLinks.svelte';
+import ProviderLogo from './ProviderLogo.svelte';
+import ProviderUpdateButton from './ProviderUpdateButton.svelte';
+
+export let provider: ProviderInfo;
+let providerToggleValue = false;
+
+let initializeInProgress = false;
+
+let initalizeError: string | undefined = undefined;
+
+async function initializeProvider() {
+  initalizeError = undefined;
+  if (providerToggleValue) {
+    initializeInProgress = true;
+    try {
+      await window.initializeProvider(provider.internalId);
+      // wait that status is updated
+      await new Promise<void>(resolve => {
+        window.events.receive('provider-change', () => {
+          resolve();
+        });
+      });
+    } catch (error) {
+      initalizeError = error;
+      console.error('Error while initializing the provider', error);
+    }
+    initializeInProgress = false;
+  }
+}
+</script>
+
+<div class="p-2 flex flex-col bg-zinc-700 rounded-lg">
+  <ProviderLogo provider="{provider}" />
+  <div class="flex flex-col items-center text-center">
+    <p class="text-xl text-gray-300">
+      {provider.name}
+      {#if provider.version}
+        v{provider.version}
+      {/if}
+      is installed but not ready
+    </p>
+    <p class="text-base text-gray-400">
+      To start working with containers, {provider.name} needs to be initialized.
+    </p>
+    <label for="toggle-{provider.internalId}" class="inline-flex relative items-center my-5 cursor-pointer">
+      <input
+        type="checkbox"
+        disabled="{initializeInProgress}"
+        bind:checked="{providerToggleValue}"
+        on:change="{() => initializeProvider()}"
+        id="toggle-{provider.internalId}"
+        class="sr-only peer" />
+      <div
+        class="w-9 h-5 peer-focus:ring-violet-800 rounded-full peer bg-zinc-400 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-4 after:w-4 after:transition-all dark:border-gray-600 peer-checked:bg-violet-600">
+      </div>
+      <span class="ml-3 text-sm font-medium text-gray-300">Initialize {provider.name}</span>
+    </label>
+    {#if initializeInProgress}
+      <div class="flex mt-2 flex-col">
+        <div>Initializing...Please Wait...</div>
+        <div class="my-2">
+          <i class="pf-c-button__progress">
+            <span class="pf-c-spinner pf-m-md" role="progressbar">
+              <span class="pf-c-spinner__clipper"></span>
+              <span class="pf-c-spinner__lead-ball"></span>
+              <span class="pf-c-spinner__tail-ball"></span>
+            </span>
+          </i>
+        </div>
+      </div>
+    {/if}
+    {#if initalizeError}
+      <div class="flex mt-2 flex-col">
+        <div>Error:</div>
+        <div class="my-2">
+          <p class="text-sm text-red-500">{initalizeError}</p>
+        </div>
+      </div>
+    {/if}
+  </div>
+  {#if provider.updateInfo}
+    <div class="mt-10 mb-1  w-full flex  justify-around">
+      <ProviderUpdateButton provider="{provider}" />
+    </div>
+  {/if}
+
+  <div class="mt-10 mb-1  w-full flex  justify-around"></div>
+  <ProviderLinks provider="{provider}" />
+</div>

--- a/packages/renderer/src/lib/welcome/ProviderLinks.svelte
+++ b/packages/renderer/src/lib/welcome/ProviderLinks.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+import type { ProviderInfo } from '../../../../main/src/plugin/api/provider-info';
+
+export let provider: ProviderInfo;
+</script>
+
+{#if provider.links.length > 0}
+  <div class="mt-10 flex flex-row justify-around">
+    {#each provider.links as link}
+      <p
+        on:click="{() => window.openExternal(link.url)}"
+        class="text-sm  text-center cursor-pointer text-violet-400 hover:text-violet-600 hover:no-underline">
+        {link.title}
+      </p>
+    {/each}
+  </div>
+{/if}

--- a/packages/renderer/src/lib/welcome/ProviderLogo.svelte
+++ b/packages/renderer/src/lib/welcome/ProviderLogo.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+import { onMount } from 'svelte';
+
+import type { ProviderInfo } from '../../../../main/src/plugin/api/provider-info';
+
+export let provider: ProviderInfo;
+
+let logo;
+
+onMount(() => {
+  if (typeof provider.images.logo === 'string') {
+    logo = provider.images.logo;
+  } else {
+    // for now use dark theme
+    logo = provider.images.logo.dark;
+  }
+});
+</script>
+
+{#if logo}
+  <div class="flex">
+    <!--w-3/4 lg:w-2/3 xl:w-1/2 -->
+    <img src="{logo}" alt="{provider.name}" class="mx-auto max-h-24 xl:max-h-36" />
+  </div>
+{/if}

--- a/packages/renderer/src/lib/welcome/ProviderNotInstalled.svelte
+++ b/packages/renderer/src/lib/welcome/ProviderNotInstalled.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+import type { ProviderDetectionCheck } from '@tmpwip/extension-api';
+
+import type { ProviderInfo } from '../../../../main/src/plugin/api/provider-info';
+import ProviderDetectionChecksButton from './ProviderDetectionChecksButton.svelte';
+import ProviderInstallationButton from './ProviderInstallationButton.svelte';
+import ProviderLinks from './ProviderLinks.svelte';
+import ProviderLogo from './ProviderLogo.svelte';
+
+export let provider: ProviderInfo;
+
+let detectionChecks: ProviderDetectionCheck[] = [];
+</script>
+
+<div class="p-2 flex flex-col bg-zinc-700 rounded-lg">
+  <ProviderLogo provider="{provider}" />
+  <div class="flex flex-col items-center text-center">
+    <p class="text-xl text-gray-300">
+      Podman Desktop was not able to find an installation of {provider.name}.
+    </p>
+    <p class="text-base text-gray-400">
+      To start working with containers, {provider.name} needs to be detected/installed.
+    </p>
+  </div>
+  <div class="mt-10 mb-1  w-full flex  justify-around">
+    <ProviderDetectionChecksButton onDetectionChecks="{checks => (detectionChecks = checks)}" provider="{provider}" />
+    <ProviderInstallationButton provider="{provider}" />
+  </div>
+  {#if detectionChecks.length > 0}
+    <div class="flex flex-col w-full mt-5 px-5 pt-5 pb-0 rounded-lg bg-zinc-600">
+      {#each detectionChecks as detectionCheck}
+        <div class="flex flex-col">
+          <p class="mb-4 items-center list-inside">{detectionCheck.status ? '✅' : '❌'} {detectionCheck.name}</p>
+          {#if detectionCheck.details}
+            Details: <p class="text-gray-300 w-full break-all">{detectionCheck.details}</p>
+          {/if}
+        </div>
+      {/each}
+    </div>
+  {/if}
+  <ProviderLinks provider="{provider}" />
+</div>

--- a/packages/renderer/src/lib/welcome/ProviderReady.svelte
+++ b/packages/renderer/src/lib/welcome/ProviderReady.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+import type { ProviderInfo } from '../../../../main/src/plugin/api/provider-info';
+import ProviderLinks from './ProviderLinks.svelte';
+import ProviderLogo from './ProviderLogo.svelte';
+import ProviderUpdateButton from './ProviderUpdateButton.svelte';
+
+export let provider: ProviderInfo;
+</script>
+
+<div class="p-2 flex flex-col bg-zinc-700 rounded-lg">
+  <ProviderLogo provider="{provider}" />
+  <div class="flex flex-col items-center text-center">
+    <p class="text-xl text-gray-300">
+      {provider.name} is running
+    </p>
+    {#if provider.version}
+      <p class="text-base font-semibold text-gray-400">
+        version {provider.version}
+      </p>
+    {/if}
+    {#if provider.containerConnections.length > 0}
+      <div class="flex flex-row  text-xs text-gray-500 mt-4">
+        <p>
+          {provider.containerConnections.map(c => c.name).join(', ')}
+        </p>
+      </div>
+    {/if}
+  </div>
+  {#if provider.updateInfo}
+    <div class="mt-10 mb-1  w-full flex  justify-around">
+      <ProviderUpdateButton provider="{provider}" />
+    </div>
+  {/if}
+  <ProviderLinks provider="{provider}" />
+</div>

--- a/packages/renderer/src/lib/welcome/ProviderUpdateButton.svelte
+++ b/packages/renderer/src/lib/welcome/ProviderUpdateButton.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+import type { ProviderInfo } from '../../../../main/src/plugin/api/provider-info';
+
+export let provider: ProviderInfo;
+let updateInProgress = false;
+
+async function performUpdate(provider: ProviderInfo) {
+  updateInProgress = true;
+
+  await window.updateProvider(provider.internalId);
+
+  updateInProgress = false;
+}
+</script>
+
+{#if provider.updateInfo && provider.updateInfo.version}
+  <button
+    disabled="{updateInProgress}"
+    on:click="{() => performUpdate(provider)}"
+    class="pf-c-button pf-m-primary"
+    type="button">
+    <span class="pf-c-button__icon pf-m-start ">
+      {#if updateInProgress}
+        <div class="mr-20">
+          <i class="pf-c-button__progress">
+            <span class="pf-c-spinner pf-m-md" role="progressbar">
+              <span class="pf-c-spinner__clipper"></span>
+              <span class="pf-c-spinner__lead-ball"></span>
+              <span class="pf-c-spinner__tail-ball"></span>
+            </span>
+          </i>
+        </div>
+      {:else}
+        <i class="fas fa-box-open" aria-hidden="true"></i>
+      {/if}
+    </span>
+    Update to {provider.updateInfo.version}
+  </button>
+{/if}

--- a/packages/renderer/src/lib/welcome/WelcomePage.svelte
+++ b/packages/renderer/src/lib/welcome/WelcomePage.svelte
@@ -1,0 +1,65 @@
+<script lang="ts">
+import { providerInfos } from '../../stores/providers';
+import { onMount } from 'svelte';
+import type { ProviderInfo } from '../../../../main/src/plugin/api/provider-info';
+import { each } from 'svelte/internal';
+import ProviderNotInstalled from './ProviderNotInstalled.svelte';
+import ProviderReady from './ProviderReady.svelte';
+import ProviderInstalled from './ProviderInstalled.svelte';
+import ProviderConfigured from './ProviderConfigured.svelte';
+
+let providers: ProviderInfo[] = [];
+$: providerConnections = providers
+  .map(provider => provider.containerConnections)
+  .flat()
+  .filter(providerContainerConnection => providerContainerConnection.status === 'started');
+
+$: providersNotInstalled = providers.filter(provider => provider.status === 'not-installed');
+$: providersInstalled = providers.filter(provider => provider.status === 'installed');
+$: providersConfigured = providers.filter(provider => provider.status === 'configured');
+$: providersReady = providers.filter(
+  provider => provider.status === 'ready' || provider.status === 'started' || provider.status === 'stopped',
+);
+
+onMount(() => {
+  providerInfos.subscribe(value => {
+    providers = value;
+  });
+});
+</script>
+
+<div class="flex flex-col min-h-full">
+  <div class="min-w-full flex-1">
+    <div class="pt-5 px-5 space-y-5">
+      <!-- Provider is ready display a box to indicate some information -->
+      {#if providersReady.length > 0}
+        {#each providersReady as providerReady}
+          <ProviderReady provider="{providerReady}" />
+        {/each}
+      {/if}
+
+      <!-- Provider is installed but not ready, it requires a user action
+        display a box to indicate how to make the provider ready -->
+      {#if providersInstalled.length > 0}
+        {#each providersInstalled as providerInstalled}
+          <ProviderInstalled provider="{providerInstalled}" />
+        {/each}
+      {/if}
+
+      <!-- Provider is configured but not ready, it requires a user action
+        display a box to indicate how to make the provider ready -->
+      {#if providersConfigured.length > 0}
+        {#each providersConfigured as providerConfigured}
+          <ProviderConfigured provider="{providerConfigured}" />
+        {/each}
+      {/if}
+
+      <!-- Provider is not installed, display a box to indicate how to install from the tool if possible -->
+      {#if providersNotInstalled.length > 0}
+        {#each providersNotInstalled as providerNotInstalled}
+          <ProviderNotInstalled provider="{providerNotInstalled}" />
+        {/each}
+      {/if}
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
Welcome page displays user onboarding
like installation link, update links, documentation links, images
also initialization/update is possible depending on the support of extensions

fixes https://github.com/containers/podman-desktop/issues/164
fixes https://github.com/containers/podman-desktop/issues/49

https://user-images.githubusercontent.com/436777/176435969-dde70fcc-856a-4d3c-b513-d6605a2e51ca.mp4




Change-Id: I302a527d944c06119a6f7778b3931e58874c7de3
Signed-off-by: Florent Benoit <fbenoit@redhat.com>