### PR TITLE
feat: add help page

### DIFF
--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -25,6 +25,7 @@ import ContainerDetails from './lib/ContainerDetails.svelte';
 import { providerInfos } from './stores/providers';
 import type { ProviderInfo } from '../../main/src/plugin/api/provider-info';
 import WelcomePage from './lib/welcome/WelcomePage.svelte';
+import HelpPage from './lib/help/HelpPage.svelte';
 let containersCountValue;
 
 router.mode.hash();
@@ -62,14 +63,32 @@ onMount(() => {
     <ninja-keys id="command-palette" placeholder="" openHotkey="F1" hideBreadcrumbs class="dark"></ninja-keys>
 
     <header id="navbar" class="text-gray-400 bg-zinc-900 body-font" style="-webkit-app-region: drag;">
-      <div class="container flex mx-auto flex-col p-2 items-center">
-        <div class="flex lg:w-1/5 flex-wrap items-center text-base ml-auto"></div>
+      <div class="flex mx-auto flex-row p-2 items-center">
+        <div class="flex lg:w-2/5 flex-1 items-center text-base ml-auto"></div>
         <div
           class="flex order-none title-font font-medium items-center text-white align-middle justify-center mb-4 md:mb-0">
           <Logo />
           <span class="ml-3 text-xl block text-gray-300">Podman Desktop</span>
         </div>
-        <div class="lg:w-2/5 inline-flex lg:justify-end ml-5 lg:ml-0"></div>
+        <div class="lg:w-2/5 flex-1 lg:justify-end ml-5 lg:ml-0"></div>
+        <div class="flex">
+          <a
+            href="/help"
+            class="p-1 rounded-full {meta.url === '/help'
+              ? 'bg-gray-600 fill-gray-300'
+              : 'fill-gray-400'} hover:bg-gray-600 hover:fill-gray-300 cursor-pointer">
+            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 1000 1000">
+              <g>
+                <path
+                  d="M990,500c0,270.6-219.4,490-490,490C229.4,990,10,770.6,10,500C10,229.4,229.4,10,500,10C770.6,10,990,229.4,990,500z M500,99.1C278.6,99.1,99.1,278.6,99.1,500c0,221.4,179.5,400.9,400.9,400.9c221.4,0,400.9-179.5,400.9-400.9C900.9,278.6,721.4,99.1,500,99.1z"
+                ></path>
+                <path
+                  d="M543.7,622.3H455c-0.3-12.7-0.4-20.5-0.4-23.3c0-28.8,4.7-52.4,14.3-71c9.5-18.5,28.6-39.4,57.1-62.6c28.6-23.2,45.6-38.4,51.1-45.6c8.5-11.4,12.9-23.9,12.9-37.6c0-19-7.7-35.3-22.8-48.9c-15.2-13.5-35.6-20.4-61.3-20.4c-24.9,0-45.6,7.1-62.3,21.2c-16.7,14.2-28.2,35.7-34.5,64.7l-89.8-11.1c2.5-41.5,20.2-76.8,53.1-105.8c32.8-29,75.9-43.5,129.3-43.5c56.1,0,100.7,14.7,133.9,44c33.1,29.4,49.8,63.5,49.8,102.5c0,21.6-6.1,42-18.3,61.3c-12.2,19.3-38.3,45.5-78.1,78.6c-20.7,17.2-33.5,31-38.4,41.4C545.4,576.7,543.2,595.4,543.7,622.3z M455,753.8V656h97.8v97.8H455z"
+                ></path>
+              </g>
+            </svg>
+          </a>
+        </div>
       </div>
     </header>
 
@@ -192,7 +211,6 @@ onMount(() => {
               </div>
             </a>
           </li>
-
           <li
             class="pf-c-nav__item flex w-full justify-between {meta.url.startsWith('/preferences')
               ? 'dark:text-white pf-m-current'
@@ -308,6 +326,9 @@ onMount(() => {
         </Route>
         <Route path="/contribs/:name" let:meta>
           <DockerExtension name="{meta.params.name}" />
+        </Route>
+        <Route path="/help">
+          <HelpPage />
         </Route>
       </div>
     </div>

--- a/packages/renderer/src/lib/help/HelpPage.svelte
+++ b/packages/renderer/src/lib/help/HelpPage.svelte
@@ -1,0 +1,52 @@
+<div class="flex flex-col min-h-full">
+  <div class="min-w-full flex">
+    <div class="pt-5 px-5">
+      <p class="text-xl">Help</p>
+      <p class="text-sm text-gray-400">Looking for assistance? We've got you covered.</p>
+    </div>
+  </div>
+  <div class="min-w-full flex-1">
+    <ul role="list" class="px-5 py-3">
+      <li class="pb-2">
+        <i class="fas fa-solid fa-book-open" aria-hidden="true"></i>
+        <p
+          on:click="{() => window.openExternal('https://podman-desktop.io/docs/intro')}"
+          title="https://podman-desktop.io/docs/intro"
+          class="text-sm inline-flex ml-1 cursor-pointer text-violet-400 hover:text-violet-600 hover:no-underline">
+          Access to Documentation
+        </p>
+      </li>
+
+      <li class="pb-2">
+        <i class="fas fa-solid fa-bug" aria-hidden="true"></i>
+        <p
+          on:click="{() => window.openExternal('https://github.com/containers/podman-desktop/issues/new/choose')}"
+          title="https://github.com/containers/podman-desktop/issues/new/choose"
+          class="text-sm inline-flex ml-1 cursor-pointer text-violet-400 hover:text-violet-600 hover:no-underline">
+          Report a bug
+        </p>
+      </li>
+
+      <li class="pb-2">
+        <i class="fas fa-solid fa-comment" aria-hidden="true"></i>
+        <p
+          on:click="{() =>
+            window.openExternal('https://github.com/containers/podman-desktop/discussions/categories/general')}"
+          title="https://github.com/containers/podman-desktop/discussions/categories/general"
+          class="text-sm inline-flex ml-1 cursor-pointer text-violet-400 hover:text-violet-600 hover:no-underline">
+          Share a Feedback
+        </p>
+      </li>
+
+      <li class="pb-2">
+        <i class="fas fa-comments" aria-hidden="true"></i>
+        <p
+          on:click="{() => window.openExternal('https://discordapp.com/invite/TCTB38RWpf')}"
+          title="https://discordapp.com/invite/TCTB38RWpf"
+          class="text-sm inline-flex ml-1 cursor-pointer text-violet-400 hover:text-violet-600 hover:no-underline">
+          Discuss with us
+        </p>
+      </li>
+    </ul>
+  </div>
+</div>


### PR DESCRIPTION
Current changes proposal adds a Help page with the list of useful resources related to Podman Desktop.

<img width="1118" alt="Снимок экрана 2022-06-30 в 11 21 19" src="https://user-images.githubusercontent.com/1968177/176628992-abe62780-50d6-47b6-ba51-1af8efee24ef.png">

fixes https://github.com/containers/podman-desktop/issues/163

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>