### PR TITLE
fix: Tray menu: we should not have a start/stop menu item if not supported

### DIFF
--- a/packages/main/src/tray-menu.ts
+++ b/packages/main/src/tray-menu.ts
@@ -68,6 +68,11 @@ export class TrayMenu {
           containerConnections: [],
           kubernetesConnections: [],
           lifecycleMethods: [],
+          detectionChecks: [],
+          version: '',
+          links: [],
+          images: {},
+          installationSupport: false,
           containerProviderConnectionCreation: false,
         });
       }
@@ -245,7 +250,14 @@ export class TrayMenu {
 
   private createProviderConnectionMenuItem(
     providerContainerConnectionInfoMenuItem: ProviderContainerConnectionInfoMenuItem,
-  ): MenuItemConstructorOptions {
+  ): MenuItemConstructorOptions | undefined {
+    if (!providerContainerConnectionInfoMenuItem.lifecycleMethods) {
+      return {
+        label: providerContainerConnectionInfoMenuItem.name,
+        icon: this.getStatusIcon(providerContainerConnectionInfoMenuItem.status),
+      };
+    }
+
     const result: MenuItemConstructorOptions = {
       label: providerContainerConnectionInfoMenuItem.name,
       icon: this.getStatusIcon(providerContainerConnectionInfoMenuItem.status),


### PR DESCRIPTION
If extension is not providing lifecycle methods like start/stop/etc then we shouldn't have any menu actions to start or stop the engine

before:
![image](https://user-images.githubusercontent.com/436777/176695892-8c0afa5b-b8a3-4f10-8f38-b7055129ee83.png)

after:
![image](https://user-images.githubusercontent.com/436777/176696053-64ef0d6d-4ad3-46d8-98be-c00a2af3c88e.png)


Change-Id: Ia56390b978894bb2002709e6c88d93fdb28c82a9
Signed-off-by: Florent Benoit <fbenoit@redhat.com>