### PR TITLE
fix: unregister of tray menu provider

### DIFF
--- a/packages/main/src/plugin/provider-registry.ts
+++ b/packages/main/src/plugin/provider-registry.ts
@@ -558,7 +558,7 @@ export class ProviderRegistry {
     // notify listeners
     this.containerConnectionLifecycleListeners.forEach(listener => {
       listener(
-        'provider-container-connection::unregister',
+        'provider-container-connection:unregister',
         this.getProviderInfo(provider),
         this.getProviderContainerConnectionInfo(containerConnection),
       );


### PR DESCRIPTION
Fixes https://github.com/containers/podman-desktop/issues/211

typo...

If we remove a podman machine, item is correctly removed from the tray menu

Change-Id: I2bbf42a66fdafdc925f162a15d856dbdff58658d
Signed-off-by: Florent Benoit <fbenoit@redhat.com>