### PR TITLE
fix: disable drag feature for help icon

### DIFF
--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -71,7 +71,7 @@ onMount(() => {
           <span class="ml-3 text-xl block text-gray-300">Podman Desktop</span>
         </div>
         <div class="lg:w-2/5 flex-1 lg:justify-end ml-5 lg:ml-0"></div>
-        <div class="flex">
+        <div class="flex" style="-webkit-app-region: none;">
           <a
             href="/help"
             class="p-1 rounded-full {meta.url === '/help'


### PR DESCRIPTION
On Linux it was not possible to click on the `?` icon

before

https://user-images.githubusercontent.com/436777/176878817-0fe10788-30e0-4a79-8cfe-3062ad89b96d.mp4


after

https://user-images.githubusercontent.com/436777/176878887-9efacf4f-b8e0-4d97-8dc4-53dfdf695d26.mp4




Else we can't click on help icon on Linux for example

Change-Id: I9454d5c1a1068a26f03b1efd793cb268958bac0f
Signed-off-by: Florent Benoit <fbenoit@redhat.com>