### PR TITLE
fix: If we already have the embedded version, it shouldn't suggest an update

### DIFF
--- a/extensions/podman/src/podman-install.ts
+++ b/extensions/podman/src/podman-install.ts
@@ -215,7 +215,7 @@ abstract class BaseInstaller implements Installer {
   abstract update(): Promise<boolean>;
 
   requireUpdate(installedVersion: string): boolean {
-    return compareVersions.compare(installedVersion, getBundledPodmanVersion(), '<=');
+    return compareVersions.compare(installedVersion, getBundledPodmanVersion(), '<');
   }
 
   protected getAssetsFolder(): string {


### PR DESCRIPTION
before:
![image](https://user-images.githubusercontent.com/436777/176894373-98554e15-a4dd-49f4-9828-733520ad0a47.png)


after:
![image](https://user-images.githubusercontent.com/436777/176894571-507aacce-2dc4-4aa1-b0a8-ecfa9db9002f.png)


and if there is really a new version:
![image](https://user-images.githubusercontent.com/436777/176894639-98bec867-9efe-4082-88df-84e934d803ba.png)



Change-Id: I7e0bdec98b119a77dfbfa5949a965ff298b8451c
Signed-off-by: Florent Benoit <fbenoit@redhat.com>