### PR TITLE
fix: in some corner case, tailwind dark theme is not applied

### DIFF
--- a/website/src/components/TailWindThemeSelector/index.tsx
+++ b/website/src/components/TailWindThemeSelector/index.tsx
@@ -38,10 +38,12 @@ useEffect(() => {
     return;
   }
   const mutationObserver = new MutationObserver((mutations) => {
-      mutations.forEach((mutation) => {
-          if (mutation.attributeName === 'data-theme' && mutation.type == 'attributes') {
-                updadeTailwindDarkTheme();
-          }
+      mutations.forEach(mutation => {
+        if (mutation.attributeName === 'data-rh' && mutation.type == 'attributes') {
+          updadeTailwindDarkTheme();
+        } else if (mutation.attributeName === 'data-theme' && mutation.type == 'attributes') {
+          updadeTailwindDarkTheme();
+        }
       });
   });
   mutationObserver.observe(document.documentElement, {


### PR DESCRIPTION
Fixes https://github.com/containers/podman-desktop/issues/266

Change-Id: I189d4a22e7a6b7a30389d82d24635abe22620275
Signed-off-by: Florent Benoit <fbenoit@redhat.com>