### PR TITLE
feat: implement status bar

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -457,6 +457,76 @@ declare module '@tmpwip/extension-api' {
     silent?: boolean;
   }
 
+  /**
+   * Aligned to the left side.
+   */
+  export const StatusBarAlignLeft = 'LEFT';
+  /**
+   * Aligned to the right side.
+   */
+  export const StatusBarAlignRight = 'RIGHT';
+  /**
+   * Represents the alignment of status bar items.
+   */
+  export type StatusBarAlignment = typeof StatusBarAlignLeft | typeof StatusBarAlignRight;
+
+  /**
+   * Default priority for the status bar items.
+   */
+  export const StatusBarItemDefaultPriority = 0;
+
+  /**
+   * A status bar item is a status bar contribution that can
+   * show text and icons and run a command on click.
+   */
+  export interface StatusBarItem {
+    /**
+     * The alignment of this item.
+     */
+    readonly alignment: StatusBarAlignment;
+    /**
+     * The priority of this item. Higher value means the item should be shown more to the left
+     * or more to the right.
+     */
+    readonly priority: number;
+    /**
+     * The text to show for the entry.
+     */
+    text?: string;
+    /**
+     * The tooltip text when you hover over this entry.
+     */
+    tooltip?: string;
+    /**
+     * Icon class that is used to display the particular icon from the Font Awesome icon set.
+     * Icon class should be in format e.g. 'fa fa-toggle-on'. It is possible to provide an icons
+     * for state which can be enabled or disabled.
+     */
+    iconClass?: string | { active: string; inactive: string };
+    /**
+     * Marks an item as disabled. When property is set to true, then icon will be changed to inactive
+     * and there won't be possible to execute a command if it is provided in the following configuration.
+     */
+    enabled: boolean;
+    /**
+     * The identifier of a command to run on click.
+     */
+    command?: string;
+    /**
+     * Arguments that the command handler should be invoked with.
+     */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    commandArgs?: any[];
+    /**
+     * Shows the entry in the status bar.
+     */
+    show(): void;
+    /**
+     * Hides the entry in the status bar.
+     */
+    hide(): void;
+  }
+
   export namespace window {
     /**
      * Show an information message. Optionally provide an array of items which will be presented as
@@ -498,5 +568,14 @@ declare module '@tmpwip/extension-api' {
      * @param options
      */
     export function showNotification(options: NotificationOptions): Disposable;
+
+    /**
+     * Creates a status bar {@link StatusBarItem} item.
+     *
+     * @param alignment The alignment of the item.
+     * @param priority The priority of the item. Higher values mean more to the left or more to the right.
+     * @return A new status bar item.
+     */
+    export function createStatusBarItem(alignment?: StatusBarAlignment, priority?: number): StatusBarItem;
   }
 }

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -32,6 +32,9 @@ import type { Dialogs } from './dialog-impl';
 import type { ProgressImpl } from './progress-impl';
 import { ProgressLocation } from './progress-impl';
 import type { NotificationImpl } from './notification-impl';
+import { StatusBarItemImpl } from './statusbar/statusbar-item';
+import type { StatusBarRegistry } from './statusbar/statusbar-registry';
+import { StatusBarAlignLeft, StatusBarAlignRight, StatusBarItemDefaultPriority } from './statusbar/statusbar-item';
 
 /**
  * Handle the loading of an extension
@@ -73,6 +76,7 @@ export class ExtensionLoader {
     private dialogs: Dialogs,
     private progress: ProgressImpl,
     private notifications: NotificationImpl,
+    private statusBarRegistry: StatusBarRegistry,
   ) {}
 
   async listExtensions(): Promise<ExtensionInfo[]> {
@@ -341,6 +345,27 @@ export class ExtensionLoader {
       showNotification: (options: containerDesktopAPI.NotificationOptions): containerDesktopAPI.Disposable => {
         return notifications.showNotification(options);
       },
+
+      createStatusBarItem: (
+        param1?: containerDesktopAPI.StatusBarAlignment | number,
+        param2?: number,
+      ): containerDesktopAPI.StatusBarItem => {
+        let alignment: containerDesktopAPI.StatusBarAlignment = StatusBarAlignLeft;
+        let priority = StatusBarItemDefaultPriority;
+
+        if (typeof param2 !== 'undefined') {
+          alignment = param1 as containerDesktopAPI.StatusBarAlignment;
+          priority = param2;
+        } else if (typeof param1 !== 'undefined') {
+          if (typeof param1 === 'string') {
+            alignment = param1 as containerDesktopAPI.StatusBarAlignment;
+          } else {
+            priority = param1;
+          }
+        }
+
+        return new StatusBarItemImpl(this.statusBarRegistry, alignment, priority);
+      },
     };
 
     return <typeof containerDesktopAPI>{
@@ -353,6 +378,9 @@ export class ExtensionLoader {
       tray,
       ProgressLocation,
       window: windowObj,
+      StatusBarItemDefaultPriority,
+      StatusBarAlignLeft,
+      StatusBarAlignRight,
     };
   }
 

--- a/packages/main/src/plugin/statusbar/statusbar-item.ts
+++ b/packages/main/src/plugin/statusbar/statusbar-item.ts
@@ -1,0 +1,148 @@
+/**********************************************************************
+ * Copyright (C) 2022 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { StatusBarAlignment, StatusBarItem } from '@tmpwip/extension-api';
+import crypto from 'node:crypto';
+import type { StatusBarRegistry } from './statusbar-registry';
+
+export const StatusBarAlignLeft = 'LEFT';
+export const StatusBarAlignRight = 'RIGHT';
+export const StatusBarItemDefaultPriority = 0;
+
+export class StatusBarItemImpl implements StatusBarItem {
+  private readonly _id: string;
+  private readonly _alignment: StatusBarAlignment;
+  private readonly _priority: number;
+
+  private _text: string | undefined;
+  private _tooltip: string | undefined;
+  private isVisible = false;
+  private _iconClass: string | { active: string; inactive: string } | undefined;
+  private _enabled = true;
+
+  private _command: string | undefined;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private _commandArgs: any[] | undefined;
+
+  private registry: StatusBarRegistry;
+
+  constructor(registry: StatusBarRegistry, alignment: StatusBarAlignment, priority = 0) {
+    this.registry = registry;
+    this._alignment = alignment;
+    this._priority = priority;
+    this._id = StatusBarItemImpl.nextId();
+  }
+
+  public get alignment(): StatusBarAlignment {
+    return this._alignment;
+  }
+
+  public get priority(): number {
+    return this._priority;
+  }
+
+  public get text(): string | undefined {
+    return this._text;
+  }
+
+  public set text(text: string | undefined) {
+    this._text = text;
+    this.update();
+  }
+
+  public get tooltip(): string | undefined {
+    return this._tooltip;
+  }
+
+  public set tooltip(tooltip: string | undefined) {
+    this._tooltip = tooltip;
+    this.update();
+  }
+
+  public get iconClass(): string | { active: string; inactive: string } | undefined {
+    return this._iconClass;
+  }
+
+  public set iconClass(iconClass: string | { active: string; inactive: string } | undefined) {
+    this._iconClass = iconClass;
+    this.update();
+  }
+
+  public get enabled(): boolean {
+    return this._enabled;
+  }
+
+  public set enabled(enabled: boolean) {
+    this._enabled = enabled;
+    this.update();
+  }
+
+  public get command(): string | undefined {
+    return this._command;
+  }
+
+  public set command(command: string | undefined) {
+    this._command = command;
+    this.update();
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  public get commandArgs(): any[] | undefined {
+    return this._commandArgs;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  public set commandArgs(commandArgs: any[] | undefined) {
+    this._commandArgs = commandArgs;
+    this.update();
+  }
+
+  hide(): void {
+    this.registry.removeEntry(this._id);
+  }
+
+  show(): void {
+    this.isVisible = true;
+    this.update();
+  }
+
+  private update(): void {
+    if (!this.isVisible) {
+      return;
+    }
+
+    this.registry.setEntry(
+      this._id,
+      this._alignment === 'LEFT',
+      this._priority,
+      this._text,
+      this._tooltip,
+      this._iconClass,
+      this._enabled,
+      this._command,
+      this._commandArgs,
+    );
+  }
+
+  static nextId(): string {
+    const generatedId = crypto.randomUUID();
+    return StatusBarItemImpl.ID_PREFIX + ':' + generatedId;
+  }
+
+  static ID_PREFIX = 'status-bar-item';
+}

--- a/packages/main/src/plugin/statusbar/statusbar-registry.ts
+++ b/packages/main/src/plugin/statusbar/statusbar-registry.ts
@@ -1,0 +1,116 @@
+/**********************************************************************
+ * Copyright (C) 2022 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { IDisposable } from '../types/disposable';
+
+export const STATUS_BAR_UPDATED_EVENT_NAME = 'status-bar-updated';
+
+export interface StatusBarEntry {
+  text?: string;
+  tooltip?: string;
+  activeIconClass?: string;
+  inactiveIconClass?: string;
+  enabled: boolean;
+  command?: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  commandArgs?: any[];
+}
+
+export interface StatusBarEntryDescriptor {
+  priority: number;
+  alignLeft: boolean;
+  entry: StatusBarEntry;
+}
+
+export class StatusBarRegistry implements IDisposable {
+  private readonly entries: Map<string, StatusBarEntryDescriptor> = new Map();
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  constructor(private apiSender: any) {}
+
+  removeEntry(id: string) {
+    const entry = this.entries.get(id);
+    if (entry) {
+      this.entries.delete(id);
+      this.apiSender.send(STATUS_BAR_UPDATED_EVENT_NAME, undefined);
+    }
+  }
+
+  setEntry(
+    entryId: string,
+    alignLeft: boolean,
+    priority: number,
+    text: string | undefined,
+    tooltip: string | undefined,
+    iconClass: string | { active: string; inactive: string } | undefined,
+    enabled: boolean,
+    command: string | undefined,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    commandArgs: any[] | undefined,
+  ) {
+    const existingEntry = this.entries.get(entryId);
+    if (existingEntry && (existingEntry.alignLeft !== alignLeft || existingEntry.priority !== priority)) {
+      this.entries.delete(entryId);
+    }
+
+    const activeIconClass = typeof iconClass === 'string' ? iconClass : iconClass?.active;
+    const inactiveIconClass = typeof iconClass !== 'string' ? iconClass?.inactive : undefined;
+
+    if (!existingEntry) {
+      const newEntry: StatusBarEntry = {
+        text: text,
+        tooltip: tooltip,
+        activeIconClass: activeIconClass,
+        inactiveIconClass: inactiveIconClass,
+        enabled: enabled,
+        command: command,
+        commandArgs: commandArgs,
+      };
+
+      const entryDescriptor: StatusBarEntryDescriptor = {
+        alignLeft: alignLeft,
+        priority: priority,
+        entry: newEntry,
+      };
+      this.entries.set(entryId, entryDescriptor);
+    } else {
+      const entryToUpdate = existingEntry.entry;
+      entryToUpdate.text = text;
+      entryToUpdate.tooltip = tooltip;
+      entryToUpdate.activeIconClass = activeIconClass;
+      entryToUpdate.inactiveIconClass = inactiveIconClass;
+      entryToUpdate.enabled = enabled;
+      entryToUpdate.command = command;
+      entryToUpdate.commandArgs = commandArgs;
+    }
+
+    this.apiSender.send(STATUS_BAR_UPDATED_EVENT_NAME, undefined);
+  }
+
+  dispose(): void {
+    this.entries.clear();
+  }
+
+  getStatusBarEntries(): StatusBarEntryDescriptor[] {
+    const entries: StatusBarEntryDescriptor[] = [];
+    for (const entry of this.entries.values()) {
+      entries.push(entry);
+    }
+    return entries;
+  }
+}

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -32,6 +32,7 @@ import type { ProviderContainerConnectionInfo, ProviderInfo } from '../../main/s
 import type { IConfigurationPropertyRecordedSchema } from '../../main/src/plugin/configuration-registry';
 import type { PullEvent } from '../../main/src/plugin/api/pull-event';
 import { Deferred } from './util/deferred';
+import type { StatusBarEntryDescriptor } from '../../main/src/plugin/statusbar/statusbar-registry';
 
 export type DialogResultCallback = (openDialogReturnValue: Electron.OpenDialogReturnValue) => void;
 
@@ -330,6 +331,18 @@ function initExposure(): void {
       if (callback) {
         callback(eventName, data);
       }
+    },
+  );
+
+  contextBridge.exposeInMainWorld('getStatusBarEntries', async (): Promise<StatusBarEntryDescriptor[]> => {
+    return ipcRenderer.invoke('status-bar:getStatusBarEntries');
+  });
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  contextBridge.exposeInMainWorld(
+    'executeStatusBarEntryCommand',
+    async (command: string, args: any[]): Promise<void> => {
+      return ipcRenderer.invoke('status-bar:executeStatusBarEntryCommand', command, args);
     },
   );
 

--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -26,6 +26,7 @@ import { providerInfos } from './stores/providers';
 import type { ProviderInfo } from '../../main/src/plugin/api/provider-info';
 import WelcomePage from './lib/welcome/WelcomePage.svelte';
 import HelpPage from './lib/help/HelpPage.svelte';
+import StatusBar from './lib/statusbar/StatusBar.svelte';
 let containersCountValue;
 
 router.mode.hash();
@@ -55,6 +56,12 @@ onMount(() => {
     providers = value;
   });
 });
+
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+window.events?.receive('display-help', () => {
+  router.goto('/help');
+});
 </script>
 
 <svelte:window bind:innerWidth />
@@ -71,24 +78,6 @@ onMount(() => {
           <span class="ml-3 text-xl block text-gray-300">Podman Desktop</span>
         </div>
         <div class="lg:w-2/5 flex-1 lg:justify-end ml-5 lg:ml-0"></div>
-        <div class="flex" style="-webkit-app-region: none;">
-          <a
-            href="/help"
-            class="p-1 rounded-full {meta.url === '/help'
-              ? 'bg-gray-600 fill-gray-300'
-              : 'fill-gray-400'} hover:bg-gray-600 hover:fill-gray-300 cursor-pointer">
-            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 1000 1000">
-              <g>
-                <path
-                  d="M990,500c0,270.6-219.4,490-490,490C229.4,990,10,770.6,10,500C10,229.4,229.4,10,500,10C770.6,10,990,229.4,990,500z M500,99.1C278.6,99.1,99.1,278.6,99.1,500c0,221.4,179.5,400.9,400.9,400.9c221.4,0,400.9-179.5,400.9-400.9C900.9,278.6,721.4,99.1,500,99.1z"
-                ></path>
-                <path
-                  d="M543.7,622.3H455c-0.3-12.7-0.4-20.5-0.4-23.3c0-28.8,4.7-52.4,14.3-71c9.5-18.5,28.6-39.4,57.1-62.6c28.6-23.2,45.6-38.4,51.1-45.6c8.5-11.4,12.9-23.9,12.9-37.6c0-19-7.7-35.3-22.8-48.9c-15.2-13.5-35.6-20.4-61.3-20.4c-24.9,0-45.6,7.1-62.3,21.2c-16.7,14.2-28.2,35.7-34.5,64.7l-89.8-11.1c2.5-41.5,20.2-76.8,53.1-105.8c32.8-29,75.9-43.5,129.3-43.5c56.1,0,100.7,14.7,133.9,44c33.1,29.4,49.8,63.5,49.8,102.5c0,21.6-6.1,42-18.3,61.3c-12.2,19.3-38.3,45.5-78.1,78.6c-20.7,17.2-33.5,31-38.4,41.4C545.4,576.7,543.2,595.4,543.7,622.3z M455,753.8V656h97.8v97.8H455z"
-                ></path>
-              </g>
-            </svg>
-          </a>
-        </div>
       </div>
     </header>
 
@@ -332,5 +321,6 @@ onMount(() => {
         </Route>
       </div>
     </div>
+    <StatusBar />
   </main>
 </Route>

--- a/packages/renderer/src/lib/statusbar/StatusBar.svelte
+++ b/packages/renderer/src/lib/statusbar/StatusBar.svelte
@@ -1,0 +1,68 @@
+<script lang="ts">
+import type { StatusBarEntry } from '../../../../main/src/plugin/statusbar/statusbar-registry';
+import { onMount } from 'svelte';
+import { statusBarEntries } from '../../stores/statusbar';
+import StatusBarItem from './StatusBarItem.svelte';
+
+let leftEntries: StatusBarEntry[] = [];
+let rightEntries: StatusBarEntry[] = [];
+
+onMount(async () => {
+  statusBarEntries.subscribe(value => {
+    leftEntries = value
+      .filter(descriptor => {
+        return descriptor.alignLeft === true;
+      })
+      .sort((d1, d2) => {
+        if (d1.priority > d2.priority) {
+          return 1;
+        } else if (d1.priority < d2.priority) {
+          return -1;
+        } else {
+          return 0;
+        }
+      })
+      .map(descriptor => {
+        return descriptor.entry;
+      });
+
+    rightEntries = value
+      .filter(descriptor => {
+        return descriptor.alignLeft === false;
+      })
+      .sort((d1, d2) => {
+        if (d1.priority > d2.priority) {
+          return 1;
+        } else if (d1.priority < d2.priority) {
+          return -1;
+        } else {
+          return 0;
+        }
+      })
+      .map(descriptor => {
+        return descriptor.entry;
+      });
+  });
+});
+</script>
+
+<div class="flex flex-wrap items-center justify-between px-2 h-6 bg-[#302251] text-sm">
+  <div class="w-1/2">
+    <ul class="flex flex-wrap list-none space-x-4">
+      {#each leftEntries as entry}
+        <li>
+          <StatusBarItem entry="{entry}" />
+        </li>
+      {/each}
+    </ul>
+  </div>
+  <div class="w-1/2">
+    <ul class="flex flex-wrap flex-row-reverse list-none space-x-2 space-x-reverse">
+      {#each rightEntries as entry}
+        <li>
+          <StatusBarItem entry="{entry}" />
+        </li>
+      {/each}
+    </ul>
+  </div>
+</div>

--- a/packages/renderer/src/lib/statusbar/StatusBarItem.svelte
+++ b/packages/renderer/src/lib/statusbar/StatusBarItem.svelte
@@ -1,0 +1,55 @@
+<script lang="ts">
+import { StatusBarEntry } from '../../../../main/src/plugin/statusbar/statusbar-registry';
+
+export let entry;
+
+function iconClass(entry: StatusBarEntry): string | undefined {
+  let iconClass = undefined;
+  if (entry.enabled && entry.activeIconClass !== undefined && entry.activeIconClass.trim().length !== 0) {
+    iconClass = entry.activeIconClass;
+  } else if (!entry.enabled && entry.inactiveIconClass !== undefined && entry.inactiveIconClass.trim().length !== 0) {
+    iconClass = entry.inactiveIconClass;
+  }
+  return iconClass;
+}
+
+function tooltipText(entry: StatusBarEntry): string {
+  return entry.tooltip !== undefined ? entry.tooltip : '';
+}
+
+function opacity(entry: StatusBarEntry): string {
+  return entry.enabled ? 'opacity-100' : 'opacity-25';
+}
+
+function hoverBackground(entry: StatusBarEntry): string {
+  return entry.enabled && typeof entry.command === 'string' ? 'hover:bg-[#4d3782]' : '';
+}
+
+function hoverCursor(entry: StatusBarEntry): string {
+  return entry.enabled && typeof entry.command === 'string' ? 'hover:cursor-pointer' : '';
+}
+
+async function executeCommand(entry: StatusBarEntry) {
+  if (typeof entry.command === 'undefined') {
+    return;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  await window.executeStatusBarEntryCommand(entry.command, entry.commandArgs);
+}
+</script>
+
+<div
+  on:click="{() => {
+    executeCommand(entry);
+  }}"
+  class="{opacity(entry)} px-1 {hoverBackground(entry)} {hoverCursor(entry)}"
+  title="{tooltipText(entry)}">
+  {#if iconClass(entry)}
+    <i class="{iconClass(entry)}" aria-hidden="true"></i>
+  {/if}
+  {#if entry.text}
+    <span class="ml-1">{entry.text}</span>
+  {/if}
+</div>

--- a/packages/renderer/src/stores/statusbar.ts
+++ b/packages/renderer/src/stores/statusbar.ts
@@ -1,0 +1,34 @@
+/**********************************************************************
+ * Copyright (C) 2022 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { Writable } from 'svelte/store';
+import { writable } from 'svelte/store';
+import type { StatusBarEntryDescriptor } from '../../../main/src/plugin/statusbar/statusbar-registry';
+import { STATUS_BAR_UPDATED_EVENT_NAME } from '../../../main/src/plugin/statusbar/statusbar-registry';
+
+export async function fetchRenderModel() {
+  const result = await window.getStatusBarEntries();
+  statusBarEntries.set(result);
+}
+
+fetchRenderModel();
+export const statusBarEntries: Writable<readonly StatusBarEntryDescriptor[]> = writable([]);
+
+window.events?.receive(STATUS_BAR_UPDATED_EVENT_NAME, async () => {
+  await fetchRenderModel();
+});


### PR DESCRIPTION
Current changes proposal provides an implementation of status bar.

As it shown on the example below:
<img width="1118" alt="Снимок экрана 2022-07-22 в 11 52 23" src="https://user-images.githubusercontent.com/1968177/180402537-c0f7651a-183a-4023-a216-a567c8266fff.png">

_Docker and Podman status bar items displayed as an example._

To use the following API there is an code example provided below:
```ts
import * as extensionApi from '@tmpwip/extension-api';
...
const sbItem = extensionApi.window.createStatusBarItem(
  extensionApi.StatusBarAlignLeft,
  extensionApi.StatusBarItemDefaultPriority,
);
//const sbItem = extensionApi.window.createStatusBarItem();
//const sbItem = extensionApi.window.createStatusBarItem(
//  extensionApi.StatusBarAlignLeft,
//);
sbItem.text = 'Podman';
sbItem.iconClass = { active: 'fa fa-toggle-on', inactive: 'fa fa-toggle-off' };
//sbItem.iconClass = 'fa fa-toggle-on';
sbItem.tooltip = 'Podman Engine';
sbItem.command = 'commandId';
sbItem.commandArgs = ['arg1', 'arg2'];
sbItem.enabled = true;
sbItem.show();
```

By default, help icon moved from the title bar to the status bar and displayed to the right.

fixes https://github.com/containers/podman-desktop/issues/263

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>