### PR TITLE
feat: calculate primary display to show application on bootstrap

### DIFF
--- a/packages/main/src/mainWindow.ts
+++ b/packages/main/src/mainWindow.ts
@@ -17,19 +17,24 @@
  ***********************************************************************/
 
 import type { BrowserWindowConstructorOptions } from 'electron';
-import { BrowserWindow, ipcMain, app, dialog } from 'electron';
+import { BrowserWindow, ipcMain, app, dialog, screen } from 'electron';
 import contextMenu from 'electron-context-menu';
 import { join } from 'path';
 import { URL } from 'url';
 import { isLinux, isMac } from './util';
 
 async function createWindow() {
+  const INITIAL_APP_WIDTH = 1050;
+  const INITIAL_APP_MIN_WIDTH = 640;
+  const INITIAL_APP_HEIGHT = 600;
+  const INITIAL_APP_MIN_HEIGHT = 600;
+
   const browserWindowConstructorOptions: BrowserWindowConstructorOptions = {
     show: false, // Use 'ready-to-show' event to show window
-    width: 1050,
-    minWidth: 640,
-    minHeight: 600,
-    height: 600,
+    width: INITIAL_APP_WIDTH,
+    minWidth: INITIAL_APP_MIN_WIDTH,
+    minHeight: INITIAL_APP_MIN_HEIGHT,
+    height: INITIAL_APP_HEIGHT,
     webPreferences: {
       webSecurity: false,
       //nativeWindowOpen: true,
@@ -43,6 +48,18 @@ async function createWindow() {
     browserWindowConstructorOptions.frame = false;
   }
   const browserWindow = new BrowserWindow(browserWindowConstructorOptions);
+  const { getCursorScreenPoint, getDisplayNearestPoint } = screen;
+  const workArea = getDisplayNearestPoint(getCursorScreenPoint()).workArea;
+
+  const x = Math.round(workArea.width / 2 - INITIAL_APP_WIDTH / 2 + workArea.x);
+  const y = Math.round(workArea.height / 2 - INITIAL_APP_HEIGHT / 2);
+
+  browserWindow.setBounds({
+    x: x,
+    y: y,
+    width: browserWindowConstructorOptions.width,
+    height: browserWindowConstructorOptions.height,
+  });
 
   setTimeout(() => {
     browserWindow.webContents.send('container-stopped-event', 'containerID');


### PR DESCRIPTION
This changes proposal provides an ability to calculate the primary display where application will be shown at bootstrap.

The problem discovered:

I'm as developer have three monitors with the following dimensions:
<img width="413" alt="Снимок экрана 2022-07-22 в 15 32 14" src="https://user-images.githubusercontent.com/1968177/180439850-cd021bc3-dcba-490a-a901-6b9cc939e320.png">

(from left to right)
- Dell 23" `{ x: -4480, y: 25, width: 1920, height: 1055 }`
- Dell 27" `{ x: -2560, y: 25, width: 2560, height: 1415 }`
- MB Retina Display (Primary) `{ x: 0, y: 25, width: 1792, height: 1095 }`

The problem is that application on each fresh built starts only on primary display. Current enhancement provides an ability to calculate the primary display based on the cursor placement. So the initial position will be calculated based on the current active display:

- `{ x: -2560, y: 25, width: 2560, height: 1415 }`
  - `x: -1805, y: 408`
- `{ x: -4480, y: 25, width: 1920, height: 1055 }`
  - `x: -4045, y: 228`
- `{ x: 0, y: 25, width: 1792, height: 1095 }`
  - `x: -371, y: 248`

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>