### PR TITLE
Fix partial reads in event processing

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,11 +80,13 @@
   },
   "dependencies": {
     "@docker/extension-api-client-types": "0.2.3",
+    "@types/stream-json": "^1.7.2",
     "analytics-node": "^6.0.0",
     "dockerode": "^3.3.1",
     "electron-updater": "4.6.5",
     "getos": "^3.2.1",
     "os-locale": "^6.0.2",
+    "stream-json": "^1.7.4",
     "tar-fs": "^2.1.1"
   },
   "resolutionsComments": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2810,6 +2810,21 @@
     "@types/node" "*"
     "@types/ssh2-streams" "*"
 
+"@types/stream-chain@*":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@types/stream-chain/-/stream-chain-2.0.1.tgz#4d3cc47a32609878bc188de0bae420bcfd3bf1f5"
+  integrity sha512-D+Id9XpcBpampptkegH7WMsEk6fUdf9LlCIX7UhLydILsqDin4L0QT7ryJR0oycwC7OqohIzdfcMHVZ34ezNGg==
+  dependencies:
+    "@types/node" "*"
+
+"@types/stream-json@^1.7.2":
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/@types/stream-json/-/stream-json-1.7.2.tgz#8d7f1cc3a37a9a402a4af284348499cdf5e28248"
+  integrity sha512-i4LE2aWVb1R3p/Z6S6Sw9kmmOs4Drhg0SybZUyfM499I1c8p7MUKZHs4Sg9jL5eu4mDmcgfQ6eGIG3+rmfUWYw==
+  dependencies:
+    "@types/node" "*"
+    "@types/stream-chain" "*"
+
 "@types/tar-fs@^2.0.1":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@types/tar-fs/-/tar-fs-2.0.1.tgz#6391dcad1b03dea2d79fac07371585ab54472bb1"
@@ -10415,6 +10430,18 @@ std-env@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/std-env/-/std-env-3.0.1.tgz#bc4cbc0e438610197e34c2d79c3df30b491f5182"
   integrity sha512-mC1Ps9l77/97qeOZc+HrOL7TIaOboHqMZ24dGVQrlxFcpPpfCHpH+qfUT7Dz+6mlG8+JPA1KfBQo19iC/+Ngcw==
+
+stream-chain@^2.2.5:
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/stream-chain/-/stream-chain-2.2.5.tgz#b30967e8f14ee033c5b9a19bbe8a2cba90ba0d09"
+  integrity sha512-1TJmBx6aSWqZ4tx7aTpBDXK0/e2hhcNSTV8+CbFJtDjbb+I1mZ8lHit0Grw9GRT+6JbIrrDd8esncgBi8aBXGA==
+
+stream-json@^1.7.4:
+  version "1.7.4"
+  resolved "https://registry.yarnpkg.com/stream-json/-/stream-json-1.7.4.tgz#e41637f93c5aca7267009ca8a3f6751e62331e69"
+  integrity sha512-ja2dde1v7dOlx5/vmavn8kLrxvNfs7r2oNc5DYmNJzayDDdudyCSuTB1gFjH4XBVTIwxiMxL4i059HX+ZiouXg==
+  dependencies:
+    stream-chain "^2.2.5"
 
 streamsearch@~0.1.2:
   version "0.1.2"


### PR DESCRIPTION
The current implementation expects that the json payload will not be split across reads. However,  read() can return arbitrary size chunks per call based on a number of factors (OS stack, transport, network, etc) irrespective of http values. Additionally, since socket streams are not framed, and the payload size is variable: a read may return multiple records, including partial segments at the end and beginning. 

The approach in this PR uses a streaming JSON parser library, which can tolerate semantic separation (e.g. it understands concatenated JSON payloads with no need for record delimiters or whitespace separation). 

An alternative approach would be to pipe the stream into a line scanner pipeline such as split2, and then use standard JSON parsing on each record from this pipeline. Such an approach would be limited to LF separated JSON streaming only.

TESTING NOTES: Forced partial reads can be simulated with socat, like so (in this case 10 bytes)

```
mv .local/share/containers/podman/machine/podman-machine-default/podman.sock  \  
   .local/share/containers/podman/machine/podman-machine-default/podman-orig.sock

socat -v -b10  UNIX-LISTEN:.local/share/containers/podman/machine/podman-machine-default/podman.sock,sndbuf=10,rcvbuf=10,fork \ 
               UNIX-CONNECT:.local/share/coniners/podman/machine/podman-machine-default/podman-orig.sock
```