### PR TITLE
fix: avoid blinking for modal pages of image lists

### DIFF
--- a/packages/renderer/src/lib/ImagesList.svelte
+++ b/packages/renderer/src/lib/ImagesList.svelte
@@ -12,12 +12,28 @@ import Fa from 'svelte-fa/src/fa.svelte';
 import { faLayerGroup } from '@fortawesome/free-solid-svg-icons';
 import NoContainerEngineEmptyScreen from './image/NoContainerEngineEmptyScreen.svelte';
 import { providerInfos } from '../stores/providers';
+import RunContainerModal from './image/RunContainerModal.svelte';
+import PushImageModal from './image/PushImageModal.svelte';
 
 let searchTerm = '';
 $: searchPattern.set(searchTerm);
 
 let images: ImageInfoUI[] = [];
 let multipleEngines = false;
+
+let runContainerFromImageModal = false;
+let runContainerFromImageInfo = undefined;
+function handleRunContainerFromImageModal(imageInfo: ImageInfoUI) {
+  runContainerFromImageInfo = imageInfo;
+  runContainerFromImageModal = true;
+}
+
+let pushImageModal = false;
+let pushImageModalImageInfo = undefined;
+function handlePushImageModal(imageInfo: ImageInfoUI) {
+  pushImageModalImageInfo = imageInfo;
+  pushImageModal = true;
+}
 
 $: providerConnections = $providerInfos
   .map(provider => provider.containerConnections)
@@ -68,9 +84,9 @@ onMount(async () => {
   });
 });
 
-let hasModal = false;
-function handleModal(param: boolean) {
-  hasModal = param;
+function closeModals() {
+  runContainerFromImageModal = false;
+  pushImageModal = false;
 }
 
 // extract SHA256 from image id and take the first 12 digits
@@ -201,7 +217,10 @@ function getEngineName(containerInfo: ImageInfo): string {
             </td>
             <td class="px-6 whitespace-nowrap">
               <div class="flex opacity-0 flex-row justify-end group-hover:opacity-100">
-                <ImageActions image="{image}" hasModalCallback="{handleModal}" />
+                <ImageActions
+                  image="{image}"
+                  onPushImage="{handlePushImageModal}"
+                  onRunContainerImage="{handleRunContainerFromImageModal}" />
               </div>
             </td>
           </tr>
@@ -213,5 +232,21 @@ function getEngineName(containerInfo: ImageInfo): string {
     <ImageEmptyScreen images="{$filtered}" />
   {:else}
     <NoContainerEngineEmptyScreen />
+  {/if}
+
+  {#if runContainerFromImageModal}
+    <RunContainerModal
+      image="{runContainerFromImageInfo}"
+      closeCallback="{() => {
+        closeModals();
+      }}" />
+  {/if}
+
+  {#if pushImageModal}
+    <PushImageModal
+      imageInfoToPush="{pushImageModalImageInfo}"
+      closeCallback="{() => {
+        closeModals();
+      }}" />
   {/if}
 </div>

--- a/packages/renderer/src/lib/image/ImageActions.svelte
+++ b/packages/renderer/src/lib/image/ImageActions.svelte
@@ -3,29 +3,21 @@ import Fa from 'svelte-fa/src/fa.svelte';
 import { faCircleUp, faPlayCircle, faTrash } from '@fortawesome/free-solid-svg-icons';
 import type { ImageInfoUI } from './ImageInfoUI';
 import { router } from 'tinro';
-import RunContainerModal from './RunContainerModal.svelte';
-import { onMount } from 'svelte';
-import PushImage from './PushImageModal.svelte';
-import PushImageModal from './PushImageModal.svelte';
-import Modal from '../dialogs/Modal.svelte';
 import ListItemButtonIcon from '../ui/ListItemButtonIcon.svelte';
 
-export let hasModalCallback: (flag: boolean) => void;
+export let onRunContainerImage: (imageInfo: ImageInfoUI) => void;
+export let onPushImage: (imageInfo: ImageInfoUI) => void;
+
 export let image: ImageInfoUI;
 
-let runContainerFromImageModal = false;
-let pushImageModal = false;
-let modalImageInfo: ImageInfoUI;
 let errorMessage: string = undefined;
 let isAuthenticatedForThisImage: boolean = false;
 
 async function runImage(imageInfo: ImageInfoUI) {
-  modalImageInfo = imageInfo;
-  runContainerFromImageModal = true;
+  onRunContainerImage(imageInfo);
 }
 
 $: window.hasAuthconfigForImage(image.name).then(result => (isAuthenticatedForThisImage = result));
-let imageInfoToPush = undefined;
 
 async function deleteImage(imageInfo: ImageInfoUI): Promise<void> {
   try {
@@ -37,9 +29,7 @@ async function deleteImage(imageInfo: ImageInfoUI): Promise<void> {
 }
 
 async function pushImage(imageInfo: ImageInfoUI): Promise<void> {
-  imageInfoToPush = imageInfo;
-  hasModalCallback(true);
-  pushImageModal = true;
+  onPushImage(imageInfo);
 }
 </script>
 
@@ -48,31 +38,6 @@ async function pushImage(imageInfo: ImageInfoUI): Promise<void> {
 {/if}
 <ListItemButtonIcon title="Run Image" onClick="{() => runImage(image)}" icon="{faPlayCircle}" />
 <ListItemButtonIcon title="Delete Image" onClick="{() => deleteImage(image)}" icon="{faTrash}" />
-
-{#if pushImageModal}
-  <Modal
-    on:close="{() => {
-      pushImageModal = false;
-    }}">
-    <PushImageModal
-      imageInfoToPush="{imageInfoToPush}"
-      closeCallback="{() => {
-        (pushImageModal = false), hasModalCallback(false);
-      }}" />
-  </Modal>
-{/if}
-{#if runContainerFromImageModal}
-  <Modal
-    on:close="{() => {
-      runContainerFromImageModal = false;
-    }}">
-    <RunContainerModal
-      image="{modalImageInfo}"
-      closeCallback="{() => {
-        runContainerFromImageModal = false;
-      }}" />
-  </Modal>
-{/if}
 
 {#if errorMessage}
   <div class="modal fixed w-full h-full top-0 left-0 flex items-center justify-center p-8 lg:p-0" tabindex="{0}">

--- a/packages/renderer/src/lib/image/PushImageModal.svelte
+++ b/packages/renderer/src/lib/image/PushImageModal.svelte
@@ -3,8 +3,8 @@ import { onMount, tick } from 'svelte';
 import { router } from 'tinro';
 import { Terminal } from 'xterm';
 import { FitAddon } from 'xterm-addon-fit';
-import type { ImageInfo } from '../../../../main/src/plugin/api/image-info';
 import { TerminalSettings } from '../../../../main/src/plugin/terminal-settings';
+import Modal from '../dialogs/Modal.svelte';
 import type { ImageInfoUI } from './ImageInfoUI';
 
 export let closeCallback: () => void;
@@ -16,7 +16,6 @@ function keydownDockerfileChoice(e: KeyboardEvent) {
     closeCallback();
   }
 }
-let pushError = '';
 let pushInProgress = false;
 let pushFinished = false;
 let logsPush;
@@ -109,75 +108,80 @@ function callback(name: string, data: string) {
 let pushLogsXtermDiv: HTMLDivElement;
 </script>
 
-<div
-  class="modal z-50 w-full h-full top-0 left-0 flex items-center justify-center p-8 lg:p-0"
-  tabindex="{0}"
-  autofocus
-  on:keydown="{keydownDockerfileChoice}">
-  <div class="modal-overlay fixed w-full h-full bg-gray-900 opacity-50"></div>
+<Modal
+  on:close="{() => {
+    closeCallback();
+  }}">
+  <!-- svelte-ignore a11y-autofocus -->
+  <div
+    class="modal z-50 w-full h-full top-0 left-0 flex items-center justify-center p-8 lg:p-0"
+    tabindex="{0}"
+    autofocus
+    on:keydown="{keydownDockerfileChoice}">
+    <div class="modal-overlay fixed w-full h-full bg-gray-900 opacity-50"></div>
 
-  <div class="relative px-4 w-full max-w-4xl h-full md:h-auto">
-    <div class="relative bg-white rounded-lg shadow dark:bg-gray-700">
+    <div class="relative px-4 w-full max-w-4xl h-full md:h-auto">
       <div class="relative bg-white rounded-lg shadow dark:bg-gray-700">
-        <div class="flex justify-end p-2">
-          <button
-            on:click="{() => closeCallback()}"
-            type="button"
-            class="text-gray-400 bg-transparent hover:bg-gray-200 hover:text-gray-900 rounded-lg text-sm p-1.5 ml-auto inline-flex items-center dark:hover:bg-gray-800 dark:hover:text-white"
-            data-modal-toggle="authentication-modal">
-            <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"
-              ><path
-                fill-rule="evenodd"
-                d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
-                clip-rule="evenodd"></path
-              ></svg>
-          </button>
-        </div>
-        <!--<form class="px-6 pb-4 space-y-6 lg:px-8 sm:pb-6 xl:pb-8">-->
-        <div class="px-6 pb-4 space-y-6 lg:px-8 sm:pb-6 xl:pb-8">
-          <h3 class="text-xl font-medium text-gray-900 dark:text-white">Pushing image</h3>
-
-          <div>
-            <label for="modalImageTag" class="block mb-2 text-sm font-medium text-gray-900 dark:text-gray-300"
-              >Image Tag</label>
-            <select
-              class="border text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 bg-gray-600 border-gray-500 placeholder-gray-400 text-white"
-              name="imageChoice"
-              bind:value="{selectedImageTag}">
-              {#each imageTags as imageTag}
-                <option value="{imageTag}">{imageTag}</option>
-              {/each}
-            </select>
-          </div>
-
-          {#if !pushFinished}
+        <div class="relative bg-white rounded-lg shadow dark:bg-gray-700">
+          <div class="flex justify-end p-2">
             <button
-              class="pf-c-button pf-m-primary"
-              disabled="{pushInProgress}"
+              on:click="{() => closeCallback()}"
               type="button"
-              on:click="{() => {
-                pushImage(selectedImageTag);
-              }}">
-              {#if pushInProgress === true}
-                <i class="pf-c-button__progress">
-                  <span class="pf-c-spinner pf-m-md" role="progressbar">
-                    <span class="pf-c-spinner__clipper"></span>
-                    <span class="pf-c-spinner__lead-ball"></span>
-                    <span class="pf-c-spinner__tail-ball"></span>
-                  </span>
-                </i>
-              {:else}
-                <i class="fas fa-arrow-circle-up" aria-hidden="true"></i>
-              {/if}
-              Push image</button>
-          {:else}
-            <button class="pf-c-button pf-m-primary" type="button" on:click="{() => pushImageFinished()}"> Done</button>
-          {/if}
+              class="text-gray-400 bg-transparent hover:bg-gray-200 hover:text-gray-900 rounded-lg text-sm p-1.5 ml-auto inline-flex items-center dark:hover:bg-gray-800 dark:hover:text-white"
+              data-modal-toggle="authentication-modal">
+              <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"
+                ><path
+                  fill-rule="evenodd"
+                  d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
+                  clip-rule="evenodd"></path
+                ></svg>
+            </button>
+          </div>
+          <div class="px-6 pb-4 space-y-6 lg:px-8 sm:pb-6 xl:pb-8">
+            <h3 class="text-xl font-medium text-gray-900 dark:text-white">Pushing image</h3>
 
-          <div bind:this="{pushLogsXtermDiv}"></div>
-          <!-- </form>-->
+            <div>
+              <label for="modalImageTag" class="block mb-2 text-sm font-medium text-gray-900 dark:text-gray-300"
+                >Image Tag</label>
+              <select
+                class="border text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 bg-gray-600 border-gray-500 placeholder-gray-400 text-white"
+                name="imageChoice"
+                bind:value="{selectedImageTag}">
+                {#each imageTags as imageTag}
+                  <option value="{imageTag}">{imageTag}</option>
+                {/each}
+              </select>
+            </div>
+
+            {#if !pushFinished}
+              <button
+                class="pf-c-button pf-m-primary"
+                disabled="{pushInProgress}"
+                type="button"
+                on:click="{() => {
+                  pushImage(selectedImageTag);
+                }}">
+                {#if pushInProgress === true}
+                  <i class="pf-c-button__progress">
+                    <span class="pf-c-spinner pf-m-md" role="progressbar">
+                      <span class="pf-c-spinner__clipper"></span>
+                      <span class="pf-c-spinner__lead-ball"></span>
+                      <span class="pf-c-spinner__tail-ball"></span>
+                    </span>
+                  </i>
+                {:else}
+                  <i class="fas fa-arrow-circle-up" aria-hidden="true"></i>
+                {/if}
+                Push image</button>
+            {:else}
+              <button class="pf-c-button pf-m-primary" type="button" on:click="{() => pushImageFinished()}">
+                Done</button>
+            {/if}
+
+            <div bind:this="{pushLogsXtermDiv}"></div>
+          </div>
         </div>
       </div>
     </div>
   </div>
-</div>
+</Modal>

--- a/packages/renderer/src/lib/image/RunContainerModal.svelte
+++ b/packages/renderer/src/lib/image/RunContainerModal.svelte
@@ -3,6 +3,7 @@ import type { ImageInfoUI } from './ImageInfoUI';
 import type { ImageInspectInfo } from '../../../../main/src/plugin/api/image-inspect-info';
 import type { ContainerCreateOptions } from '../../../../main/src/plugin/api/container-info';
 import { onMount } from 'svelte';
+import Modal from '../dialogs/Modal.svelte';
 
 export let image: ImageInfoUI;
 export let closeCallback: () => void;
@@ -93,78 +94,81 @@ async function startContainer() {
 </script>
 
 {#if dataReady}
-  <div
-    class="modal z-50 w-full h-full top-0 left-0 flex items-center justify-center p-8 lg:p-0"
-    tabindex="{0}"
-    autofocus
-    on:keydown="{keydownDockerfileChoice}">
-    <div class="modal-overlay fixed w-full h-full bg-gray-900 opacity-50"></div>
+  <Modal
+    on:close="{() => {
+      closeCallback();
+    }}">
+    <!-- svelte-ignore a11y-autofocus -->
+    <div
+      class="modal z-50 w-full h-full top-0 left-0 flex items-center justify-center p-8 lg:p-0"
+      tabindex="{0}"
+      autofocus
+      on:keydown="{keydownDockerfileChoice}">
+      <div class="modal-overlay fixed w-full h-full bg-gray-900 opacity-50"></div>
 
-    <div class="relative px-4 w-full max-w-4xl h-full md:h-auto">
-      <div class="relative bg-white rounded-lg shadow dark:bg-gray-700">
+      <div class="relative px-4 w-full max-w-4xl h-full md:h-auto">
         <div class="relative bg-white rounded-lg shadow dark:bg-gray-700">
-          <div class="flex justify-end p-2">
-            <button
-              on:click="{() => {
-                closeCallback();
-              }}"
-              type="button"
-              class="text-gray-400 bg-transparent hover:bg-gray-200 hover:text-gray-900 rounded-lg text-sm p-1.5 ml-auto inline-flex items-center dark:hover:bg-gray-800 dark:hover:text-white"
-              data-modal-toggle="authentication-modal">
-              <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"
-                ><path
-                  fill-rule="evenodd"
-                  d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
-                  clip-rule="evenodd"></path
-                ></svg>
-            </button>
-          </div>
-          <!--<form class="px-6 pb-4 space-y-6 lg:px-8 sm:pb-6 xl:pb-8">-->
-          <div class="px-6 pb-4 space-y-6 lg:px-8 sm:pb-6 xl:pb-8">
-            <h3 class="text-lg font-medium text-gray-900 dark:text-white truncate">
-              Create container from image {imageDisplayName}
-            </h3>
-
-            <div>
-              <label for="modalContainerName" class="block mb-2 text-sm font-medium text-gray-900 dark:text-gray-300"
-                >Container Name</label>
-              <input
-                type="text"
-                bind:value="{containerName}"
-                name="modalContainerName"
-                id="modalContainerName"
-                placeholder="Enter container name (leave blank to have one generated)"
-                class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-600 dark:border-gray-500 dark:placeholder-gray-400 dark:text-white"
-                required />
-              <!-- add a label for each port-->
-              <label
-                for="modalContainerName"
-                class:hidden="{exposedPorts.length === 0}"
-                class="pt-6 block mb-2 text-sm font-medium text-gray-900 dark:text-gray-300">Port Mapping</label>
-              {#each exposedPorts as port, index}
-                <div class="flex flex-row justify-center items-center w-full">
-                  <span class="flex-1 inline-block align-middle whitespace-nowrap">Local port for {port}:</span>
-
-                  <input
-                    type="text"
-                    bind:value="{containerPortMapping[index]}"
-                    placeholder="Enter value for port {port}"
-                    class="bg-gray-50 border ml-2 border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-600 dark:border-gray-500 dark:placeholder-gray-400 dark:text-white"
-                    required />
-                </div>
-              {/each}
+          <div class="relative bg-white rounded-lg shadow dark:bg-gray-700">
+            <div class="flex justify-end p-2">
+              <button
+                on:click="{() => {
+                  closeCallback();
+                }}"
+                type="button"
+                class="text-gray-400 bg-transparent hover:bg-gray-200 hover:text-gray-900 rounded-lg text-sm p-1.5 ml-auto inline-flex items-center dark:hover:bg-gray-800 dark:hover:text-white"
+                data-modal-toggle="authentication-modal">
+                <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"
+                  ><path
+                    fill-rule="evenodd"
+                    d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
+                    clip-rule="evenodd"></path
+                  ></svg>
+              </button>
             </div>
+            <div class="px-6 pb-4 space-y-6 lg:px-8 sm:pb-6 xl:pb-8">
+              <h3 class="text-lg font-medium text-gray-900 dark:text-white truncate">
+                Create container from image {imageDisplayName}
+              </h3>
 
-            <button on:click="{() => startContainer()}" class="w-full pf-c-button pf-m-primary">
-              <span class="pf-c-button__icon pf-m-start">
-                <i class="fas fa-play" aria-hidden="true"></i>
-              </span>
-              Start Container</button>
+              <div>
+                <label for="modalContainerName" class="block mb-2 text-sm font-medium text-gray-900 dark:text-gray-300"
+                  >Container Name</label>
+                <input
+                  type="text"
+                  bind:value="{containerName}"
+                  name="modalContainerName"
+                  id="modalContainerName"
+                  placeholder="Enter container name (leave blank to have one generated)"
+                  class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-600 dark:border-gray-500 dark:placeholder-gray-400 dark:text-white"
+                  required />
+                <!-- add a label for each port-->
+                <label
+                  for="modalContainerName"
+                  class:hidden="{exposedPorts.length === 0}"
+                  class="pt-6 block mb-2 text-sm font-medium text-gray-900 dark:text-gray-300">Port Mapping</label>
+                {#each exposedPorts as port, index}
+                  <div class="flex flex-row justify-center items-center w-full">
+                    <span class="flex-1 inline-block align-middle whitespace-nowrap">Local port for {port}:</span>
 
-            <!-- </form>-->
+                    <input
+                      type="text"
+                      bind:value="{containerPortMapping[index]}"
+                      placeholder="Enter value for port {port}"
+                      class="bg-gray-50 border ml-2 border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-600 dark:border-gray-500 dark:placeholder-gray-400 dark:text-white"
+                      required />
+                  </div>
+                {/each}
+              </div>
+
+              <button on:click="{() => startContainer()}" class="w-full pf-c-button pf-m-primary">
+                <span class="pf-c-button__icon pf-m-start">
+                  <i class="fas fa-play" aria-hidden="true"></i>
+                </span>
+                Start Container</button>
+            </div>
           </div>
         </div>
       </div>
     </div>
-  </div>
+  </Modal>
 {/if}


### PR DESCRIPTION
Fixes https://github.com/containers/podman-desktop/issues/314
move modal element from the hover element as when moving
the mouse to another line, it's hiding/showing modal

also move Modal element inside the Modal svelte component rather
than using Modal on the callee/consumer

Change-Id: I38c0a770e665014b4446cd5d104d0a9115246300
Signed-off-by: Florent Benoit <fbenoit@redhat.com>