### PR TITLE
fix: update detection checks, status and version periodically

### DIFF
--- a/extensions/podman/src/detection-checks.ts
+++ b/extensions/podman/src/detection-checks.ts
@@ -1,0 +1,39 @@
+/**********************************************************************
+ * Copyright (C) 2022 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type * as extensionApi from '@tmpwip/extension-api';
+import type { InstalledPodman } from './podman-cli';
+import { getInstallationPath } from './podman-cli';
+
+export function getDetectionChecks(installedPodman?: InstalledPodman): extensionApi.ProviderDetectionCheck[] {
+  const detectionChecks: extensionApi.ProviderDetectionCheck[] = [];
+  if (installedPodman?.version) {
+    detectionChecks.push({
+      name: `Podman ${installedPodman.version} found`,
+      status: true,
+    });
+  } else {
+    detectionChecks.push({
+      name: 'podman cli was not found in the PATH',
+      details: `Current path is ${getInstallationPath()}`,
+      status: false,
+    });
+  }
+
+  return detectionChecks;
+}

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -256,7 +256,16 @@ declare module '@tmpwip/extension-api' {
     readonly images: ProviderImages;
 
     readonly links: ProviderLinks[];
+
+    // detection checks for the provider
     readonly detectionChecks: ProviderDetectionCheck[];
+
+    // update the detection checks for the provider
+    // it may happen after an update or an installation
+    updateDetectionChecks(detectionChecks: ProviderDetectionCheck[]): void;
+
+    // notify that detection checks have changed
+    onDidUpdateDetectionChecks: Event<ProviderDetectionCheck[]>;
   }
 
   export namespace commands {

--- a/packages/main/src/plugin/provider-impl.ts
+++ b/packages/main/src/plugin/provider-impl.ts
@@ -61,8 +61,11 @@ export class ProviderImpl implements Provider, IDisposable {
   readonly onDidUpdateVersion: Event<string> = this._onDidUpdateVersion.event;
 
   private _links: ProviderLinks[];
-  private _detectionChecks: ProviderDetectionCheck[];
   private _images: ProviderImages;
+
+  private _detectionChecks: ProviderDetectionCheck[];
+  private readonly _onDidUpdateDetectionChecks = new Emitter<ProviderDetectionCheck[]>();
+  readonly onDidUpdateDetectionChecks: Event<ProviderDetectionCheck[]> = this._onDidUpdateDetectionChecks.event;
 
   constructor(
     private _internalId: string,
@@ -135,11 +138,22 @@ export class ProviderImpl implements Provider, IDisposable {
   }
 
   updateStatus(status: ProviderStatus): void {
+    if (status !== this._status) {
+      this._onDidUpdateStatus.fire(status);
+    }
     this._status = status;
   }
 
   updateVersion(version: string): void {
+    if (version !== this._version) {
+      this._onDidUpdateVersion.fire(version);
+    }
     this._version = version;
+  }
+
+  updateDetectionChecks(detectionChecks: ProviderDetectionCheck[]): void {
+    this._detectionChecks = detectionChecks;
+    this._onDidUpdateDetectionChecks.fire(detectionChecks);
   }
 
   get status(): ProviderStatus {


### PR DESCRIPTION
If people install/update externally we're trying to track these
changes as well by checking version/podman periodically

Fixes https://github.com/containers/podman-desktop/issues/270
Fixes https://github.com/containers/podman-desktop/issues/343


https://user-images.githubusercontent.com/436777/180779916-89066a96-824c-464b-9e87-2b95b7e67dcc.mp4




Change-Id: Ic8e810e4eeaa4cc8633a7a1a7521fc27a376eb27
Signed-off-by: Florent Benoit <fbenoit@redhat.com>