### PR TITLE
feat: send console traces to the renderer process

### DIFF
--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -54,6 +54,7 @@ import { StatusBarRegistry } from './statusbar/statusbar-registry';
 import type { StatusBarEntryDescriptor } from './statusbar/statusbar-registry';
 import type { IpcMainInvokeEvent } from 'electron/main';
 
+type LogType = 'log' | 'warn' | 'trace' | 'debug' | 'error';
 export class PluginSystem {
   constructor(private trayMenu: TrayMenu) {}
 
@@ -90,8 +91,35 @@ export class PluginSystem {
     });
   }
 
+  // log locally and also send it to the renderer process
+  // so client can see logs in the developer console
+  redirectConsole(logType: LogType): void {
+    // keep original method
+    const originalConsoleMethod = console[logType];
+    console[logType] = (...args) => {
+      // still display as before by invoking original method
+      originalConsoleMethod(...args);
+
+      // but also send the content remotely
+      try {
+        this.getWebContentsSender().send('console:output', logType, ...args);
+      } catch (err) {
+        originalConsoleMethod(err);
+      }
+    };
+  }
+
+  // setup pipe/redirect for console.log, console.warn, console.trace, console.debug, console.error
+  redirectLogging() {
+    const logTypes: LogType[] = ['log', 'warn', 'trace', 'debug', 'error'];
+    logTypes.forEach(logType => this.redirectConsole(logType));
+  }
+
   // initialize extension loader mechanism
   async initExtensions(): Promise<void> {
+    // redirect main process logs to the extension loader
+    this.redirectLogging();
+
     const eventEmitter = new EventEmitter();
     const apiSender = {
       send: (channel: string, data: string) => {

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -80,6 +80,21 @@ function initExposure(): void {
     apiSender.send(channel, data);
   });
 
+  ipcRenderer.on('console:output', (_, target: string, ...args) => {
+    const prefix = 'main ↪️';
+    if (target === 'log') {
+      console.log(prefix, ...args);
+    } else if (target === 'warn') {
+      console.warn(prefix, ...args);
+    } else if (target === 'trace') {
+      console.trace(prefix, ...args);
+    } else if (target === 'debug') {
+      console.debug(prefix, ...args);
+    } else if (target === 'error') {
+      console.error(prefix, ...args);
+    }
+  });
+
   contextBridge.exposeInMainWorld('listContainers', async (): Promise<ContainerInfo[]> => {
     return ipcInvoke('container-provider-registry:listContainers');
   });


### PR DESCRIPTION
### What does this PR do?

allow to get 'main process' traces by clients when error
is thrown.
As the main process logs may be hidden as basically users
click on Podman Desktop to launch it and probably don't launch
it with a terminal prompt

### What issues does this PR fix or reference?
Fixes https://github.com/containers/podman-desktop/issues/345

### Screenshot/screencast of this PR
![image](https://user-images.githubusercontent.com/436777/182181267-e3c0e2c4-ccb6-4b94-8bbc-b9ce9454727f.png)


### How to test ?

Launch podman desktop and open developer console
you should see traces about the main process being redirected/displayed there


Change-Id: Ie62d3cde859ec646affa47313c3a8bab1fd7a1be
Signed-off-by: Florent Benoit <fbenoit@redhat.com>