### PR TITLE
feat: add preflight checks for windows

### DIFF
--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -224,7 +224,7 @@ async function registerProviderFor(provider: extensionApi.Provider, machineInfo:
     start: async (context): Promise<void> => {
       try {
         // start the machine
-        await execPromise(getPodmanCli(), ['machine', 'start', machineInfo.name], context.log);
+        await execPromise(getPodmanCli(), ['machine', 'start', machineInfo.name], { logger: context.log });
         provider.updateStatus('started');
       } catch (err) {
         console.error(err);
@@ -233,7 +233,7 @@ async function registerProviderFor(provider: extensionApi.Provider, machineInfo:
       }
     },
     stop: async (context): Promise<void> => {
-      await execPromise(getPodmanCli(), ['machine', 'stop', machineInfo.name], context.log);
+      await execPromise(getPodmanCli(), ['machine', 'stop', machineInfo.name], { logger: context.log });
       provider.updateStatus('ready');
     },
     delete: async (): Promise<void> => {

--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -328,7 +328,10 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
   const provider = extensionApi.provider.createProvider(providerOptions);
   // provide an installation path ?
   if (podmanInstall.isAbleToInstall()) {
-    provider.registerInstallation({ install: () => podmanInstall.doInstallPodman(provider) });
+    provider.registerInstallation({
+      install: () => podmanInstall.doInstallPodman(provider),
+      preflightChecks: () => podmanInstall.getInstallChecks(),
+    });
   }
 
   // provide an installation path ?

--- a/extensions/podman/src/podman-cli.ts
+++ b/extensions/podman/src/podman-cli.ts
@@ -44,8 +44,14 @@ export function getPodmanCli(): string {
   return 'podman';
 }
 
-export function execPromise(command: string, args?: string[], logger?: extensionApi.Logger): Promise<string> {
-  const env = process.env;
+export interface ExecOptions {
+  logger?: extensionApi.Logger;
+  env?: NodeJS.ProcessEnv | undefined;
+}
+
+export function execPromise(command: string, args?: string[], options?: ExecOptions): Promise<string> {
+  let env = Object.assign({}, process.env); // clone original env object
+
   // In production mode, applications don't have access to the 'user' path like brew
   if (isMac) {
     env.PATH = getInstallationPath();
@@ -53,6 +59,10 @@ export function execPromise(command: string, args?: string[], logger?: extension
     // need to execute the command on the host
     args = ['--host', command, ...args];
     command = 'flatpak-spawn';
+  }
+
+  if (options?.env) {
+    env = Object.assign(env, options.env);
   }
   return new Promise((resolve, reject) => {
     let stdOut = '';
@@ -71,12 +81,12 @@ export function execPromise(command: string, args?: string[], logger?: extension
     process.stdout.setEncoding('utf8');
     process.stdout.on('data', data => {
       stdOut += data;
-      logger?.log(data);
+      options?.logger?.log(data);
     });
     process.stderr.setEncoding('utf8');
     process.stderr.on('data', data => {
       stdErr += data;
-      logger?.error(data);
+      options?.logger?.error(data);
     });
 
     process.on('close', exitCode => {

--- a/extensions/podman/src/podman-cli.ts
+++ b/extensions/podman/src/podman-cli.ts
@@ -59,7 +59,7 @@ export function execPromise(command: string, args?: string[], logger?: extension
     let stdErr = '';
     const process = spawn(command, args, { env });
     process.on('error', error => {
-      let content;
+      let content = '';
       if (stdOut && stdOut !== '') {
         content += stdOut + '\n';
       }
@@ -80,7 +80,7 @@ export function execPromise(command: string, args?: string[], logger?: extension
     });
 
     process.on('close', exitCode => {
-      let content;
+      let content = '';
       if (stdOut && stdOut !== '') {
         content += stdOut + '\n';
       }

--- a/extensions/podman/src/podman-install.ts
+++ b/extensions/podman/src/podman-install.ts
@@ -315,8 +315,8 @@ abstract class BaseCheck implements extensionApi.InstallCheck {
   abstract title: string;
   abstract execute(): Promise<extensionApi.CheckResult>;
 
-  protected createFailureResult(description?: string, name?: string, url?: string): extensionApi.CheckResult {
-    return { successful: false, description, docLinks: [{ url, name }] };
+  protected createFailureResult(description?: string, title?: string, url?: string): extensionApi.CheckResult {
+    return { successful: false, description, docLinks: [{ url, title }] };
   }
 
   protected createSuccessfulResult(): extensionApi.CheckResult {

--- a/extensions/podman/src/podman-install.ts
+++ b/extensions/podman/src/podman-install.ts
@@ -415,7 +415,7 @@ class WSL2Check extends BaseCheck {
       }
     } catch (err) {
       if (typeof err === 'string') {
-        // this is workaround, wsl2 some time send output in utf16le, but we thereat that as utf8,
+        // this is workaround, wsl2 some time send output in utf16le, but we treat that as utf8,
         // this code just eliminate every 'empty' character
         let str = '';
         for (let i = 0; i < err.length; i++) {

--- a/extensions/podman/src/podman-install.ts
+++ b/extensions/podman/src/podman-install.ts
@@ -315,8 +315,8 @@ abstract class BaseCheck implements extensionApi.InstallCheck {
   abstract title: string;
   abstract execute(): Promise<extensionApi.CheckResult>;
 
-  protected createFailureResult(description?: string): extensionApi.CheckResult {
-    return { successful: false, description };
+  protected createFailureResult(description?: string, name?: string, url?: string): extensionApi.CheckResult {
+    return { successful: false, description, docLinks: [{ url, name }] };
   }
 
   protected createSuccessfulResult(): extensionApi.CheckResult {
@@ -335,7 +335,10 @@ class WinBitCheck extends BaseCheck {
     if (this.ARCH_X64 === currentArch || this.ARCH_ARM === currentArch) {
       return this.createSuccessfulResult();
     } else {
-      return this.createFailureResult('WSL2 works only on 64bit OS.');
+      return this.createFailureResult(
+        'WSL2 works only on 64bit OS.',
+        'https://docs.microsoft.com/en-us/windows/wsl/install-manual#step-2---check-requirements-for-running-wsl-2',
+      );
     }
   }
 }
@@ -353,11 +356,15 @@ class WinVersionCheck extends BaseCheck {
         return { successful: true };
       } else {
         return this.createFailureResult(
-          'To be able to run WSL2 you need Windows 10 Build 18362 or later. See https://docs.microsoft.com/en-us/windows/wsl/install-manual#step-2---check-requirements-for-running-wsl-2',
+          'To be able to run WSL2 you need Windows 10 Build 18362 or later.',
+          'https://docs.microsoft.com/en-us/windows/wsl/install-manual#step-2---check-requirements-for-running-wsl-2',
         );
       }
     } else {
-      return this.createFailureResult('WSL2 works only on Windows 10 and newest OS');
+      return this.createFailureResult(
+        'WSL2 works only on Windows 10 and newest OS',
+        'https://docs.microsoft.com/en-us/windows/wsl/install-manual#step-2---check-requirements-for-running-wsl-2',
+      );
     }
   }
 }
@@ -389,7 +396,9 @@ class HyperVCheck extends BaseCheck {
       // ignore error, this means that hyper-v not enabled
     }
     return this.createFailureResult(
-      'Hyper-V should be enabled to be able to run Podman. See https://docs.microsoft.com/en-us/virtualization/hyper-v-on-windows/quick-start/enable-hyper-v',
+      'Hyper-V should be enabled to be able to run Podman.',
+      'Install Hyper-V',
+      'https://docs.microsoft.com/en-us/virtualization/hyper-v-on-windows/quick-start/enable-hyper-v',
     );
   }
 }
@@ -421,6 +430,10 @@ class WSL2Check extends BaseCheck {
         }
       }
     }
-    return this.createFailureResult('WSL2 is not installed. Call "wsl --install" in terminal.');
+    return this.createFailureResult(
+      'WSL2 is not installed. Call "wsl --install" in terminal.',
+      'Install WSL',
+      'https://docs.microsoft.com/en-us/windows/wsl/install-manual',
+    );
   }
 }

--- a/extensions/podman/src/podman-install.ts
+++ b/extensions/podman/src/podman-install.ts
@@ -332,7 +332,7 @@ class WinBitCheck extends BaseCheck {
     if (this.ARCH === currentArch) {
       return this.createSuccessfulResult();
     } else {
-      return this.createFailureResult('WSL2 works only on x64 OS.');
+      return this.createFailureResult('WSL2 works only on 64bit OS.');
     }
   }
 }
@@ -350,7 +350,7 @@ class WinVersionCheck extends BaseCheck {
         return { successful: true };
       } else {
         return this.createFailureResult(
-          'To be able to run WSL2 you need Windows 10 Build 18362 or later. Please update your OS.',
+          'To be able to run WSL2 you need Windows 10 Build 18362 or later. See https://docs.microsoft.com/en-us/windows/wsl/install-manual#step-2---check-requirements-for-running-wsl-2',
         );
       }
     } else {
@@ -368,7 +368,7 @@ class WinMemoryCheck extends BaseCheck {
     if (this.REQUIRED_MEM <= totalMem) {
       return this.createSuccessfulResult();
     } else {
-      return this.createFailureResult('You need at least 6Gb to run Podman.');
+      return this.createFailureResult('You need at least 6GB to run Podman.');
     }
   }
 }
@@ -385,7 +385,7 @@ class HyperVCheck extends BaseCheck {
     } catch (err) {
       // ignore error, this means that hyper-v not enabled
     }
-    return this.createFailureResult('Hyper-V should be enabled to be able to run Podman');
+    return this.createFailureResult('Hyper-V should be enabled to be able to run Podman. See https://docs.microsoft.com/en-us/virtualization/hyper-v-on-windows/quick-start/enable-hyper-v');
   }
 }
 
@@ -399,7 +399,10 @@ class WSL2Check extends BaseCheck {
         return this.createSuccessfulResult();
       }
     } catch (err) {
-      // ignore error, that means that wsl2 is not installed
+      if(typeof err === 'string' && err.indexOf('Windows Subsystem for Linux has no installed distributions.') !== -1) {
+        // WSL2 installed, it just doesn't have any distro installed.
+        return this.createSuccessfulResult();
+      }
     }
     return this.createFailureResult('WSL2 is not installed. Call "wsl --install" in terminal.');
   }

--- a/extensions/podman/src/podman-install.ts
+++ b/extensions/podman/src/podman-install.ts
@@ -325,11 +325,14 @@ abstract class BaseCheck implements extensionApi.InstallCheck {
 }
 
 class WinBitCheck extends BaseCheck {
-  title = 'Windows x64';
-  private ARCH = 'x64';
+  title = 'Windows 64bit';
+
+  private ARCH_X64 = 'x64';
+  private ARCH_ARM = 'arm64';
+
   async execute(): Promise<extensionApi.CheckResult> {
     const currentArch = process.arch;
-    if (this.ARCH === currentArch) {
+    if (this.ARCH_X64 === currentArch || this.ARCH_ARM === currentArch) {
       return this.createSuccessfulResult();
     } else {
       return this.createFailureResult('WSL2 works only on 64bit OS.');
@@ -397,31 +400,26 @@ class WSL2Check extends BaseCheck {
   async execute(): Promise<extensionApi.CheckResult> {
     try {
       // set WSL_UTF8 to force WSL2 output in UTF8, otherwise it will use utf16le
-      const res = await execPromise('wsl', ['-l', '-v'], { env: { 'WSL_UTF8': '1'}});
+      const res = await execPromise('wsl', ['-l', '-v'], { env: { WSL_UTF8: '1' } });
       if (!res.startsWith('Usage: wsl.exe [Argument]')) {
         return this.createSuccessfulResult();
       }
     } catch (err) {
-
-      if(typeof err === 'string') {
+      if (typeof err === 'string') {
         // this is workaround, wsl2 some time send output in utf16le, but we thereat that as utf8,
         // this code just eliminate every 'empty' character
         let str = '';
-        for(let i=0; i< err.length; i++) {
-          if(err.charCodeAt(i) !== 0){
+        for (let i = 0; i < err.length; i++) {
+          if (err.charCodeAt(i) !== 0) {
             str += err.charAt(i);
           }
         }
 
-        if (
-          str.indexOf('Windows Subsystem for Linux has no installed distributions.') !== -1
-        ) {
+        if (str.indexOf('Windows Subsystem for Linux has no installed distributions.') !== -1) {
           // WSL2 installed, it just doesn't have any distro installed.
           return this.createSuccessfulResult();
         }
       }
-
-
     }
     return this.createFailureResult('WSL2 is not installed. Call "wsl --install" in terminal.');
   }

--- a/extensions/podman/src/podman-install.ts
+++ b/extensions/podman/src/podman-install.ts
@@ -25,6 +25,7 @@ import * as compareVersions from 'compare-versions';
 
 import * as podmanTool from './podman.json';
 import type { InstalledPodman } from './podman-cli';
+import { execPromise } from './podman-cli';
 import { getPodmanInstallation } from './podman-cli';
 import { isDev, isWindows } from './util';
 import { getDetectionChecks } from './detection-checks';
@@ -93,6 +94,7 @@ export class PodmanInfoImpl implements PodmanInfo {
 }
 
 interface Installer {
+  getPreflightChecks(): extensionApi.InstallCheck[] | undefined;
   install(): Promise<boolean>;
   requireUpdate(installedVersion: string): boolean;
   update(): Promise<boolean>;
@@ -180,6 +182,14 @@ export class PodmanInstall {
     }
   }
 
+  getInstallChecks(): extensionApi.InstallCheck[] | undefined {
+    const installer = this.getInstaller();
+    if (installer) {
+      return installer.getPreflightChecks();
+    }
+    return undefined;
+  }
+
   isAbleToInstall(): boolean {
     return this.installers.has(os.platform());
   }
@@ -222,6 +232,8 @@ abstract class BaseInstaller implements Installer {
 
   abstract update(): Promise<boolean>;
 
+  abstract getPreflightChecks(): extensionApi.InstallCheck[];
+
   requireUpdate(installedVersion: string): boolean {
     return compareVersions.compare(installedVersion, getBundledPodmanVersion(), '<');
   }
@@ -238,6 +250,10 @@ abstract class BaseInstaller implements Installer {
 }
 
 class WinInstaller extends BaseInstaller {
+  getPreflightChecks(): extensionApi.InstallCheck[] {
+    return [new WinBitCheck(), new WinVersionCheck(), new WinMemoryCheck(), new HyperVCheck(), new WSL2Check()];
+  }
+
   update(): Promise<boolean> {
     return this.install();
   }
@@ -292,5 +308,99 @@ class WinInstaller extends BaseInstaller {
         resolve(output.trim());
       });
     });
+  }
+}
+
+abstract class BaseCheck implements extensionApi.InstallCheck {
+  abstract title: string;
+  abstract execute(): Promise<extensionApi.CheckResult>;
+
+  protected createFailureResult(description?: string): extensionApi.CheckResult {
+    return { successful: false, description };
+  }
+
+  protected createSuccessfulResult(): extensionApi.CheckResult {
+    return { successful: true };
+  }
+}
+
+class WinBitCheck extends BaseCheck {
+  title = 'Windows x64';
+  private ARCH = 'x64';
+  async execute(): Promise<extensionApi.CheckResult> {
+    const currentArch = process.arch;
+    if (this.ARCH === currentArch) {
+      return this.createSuccessfulResult();
+    } else {
+      return this.createFailureResult('WSL2 works only on x64 OS.');
+    }
+  }
+}
+
+class WinVersionCheck extends BaseCheck {
+  title = 'Windows Version';
+
+  private MIN_BUILD = 18362;
+  async execute(): Promise<extensionApi.CheckResult> {
+    const winRelease = os.release();
+    if (winRelease.startsWith('10.0.')) {
+      const splitRelease = winRelease.split('.');
+      const winBuild = splitRelease[2];
+      if (Number.parseInt(winBuild) >= this.MIN_BUILD) {
+        return { successful: true };
+      } else {
+        return this.createFailureResult(
+          'To be able to run WSL2 you need Windows 10 Build 18362 or later. Please update your OS.',
+        );
+      }
+    } else {
+      return this.createFailureResult('WSL2 works only on Windows 10 and newest OS');
+    }
+  }
+}
+
+class WinMemoryCheck extends BaseCheck {
+  title = 'RAM';
+  private REQUIRED_MEM = 6 * 1024 * 1024 * 1024; // 6Gb
+
+  async execute(): Promise<extensionApi.CheckResult> {
+    const totalMem = os.totalmem();
+    if (this.REQUIRED_MEM <= totalMem) {
+      return this.createSuccessfulResult();
+    } else {
+      return this.createFailureResult('You need at least 6Gb to run Podman.');
+    }
+  }
+}
+
+class HyperVCheck extends BaseCheck {
+  title = 'Hyper-V Enabled';
+
+  async execute(): Promise<extensionApi.CheckResult> {
+    try {
+      const res = await execPromise('powershell.exe', ['(Get-Service vmcompute).DisplayName']);
+      if (res === 'Hyper-V Host Compute Service') {
+        return this.createSuccessfulResult();
+      }
+    } catch (err) {
+      // ignore error, this means that hyper-v not enabled
+    }
+    return this.createFailureResult('Hyper-V should be enabled to be able to run Podman');
+  }
+}
+
+class WSL2Check extends BaseCheck {
+  title = 'WSL2 Installed';
+
+  async execute(): Promise<extensionApi.CheckResult> {
+    try {
+      const res = await execPromise('wsl', ['-l', '-v']);
+      if (!res.startsWith('Usage: wsl.exe [Argument]')) {
+        return this.createSuccessfulResult();
+      }
+    } catch (err) {
+      // ignore error, that means that wsl2 is not installed
+    }
+    return this.createFailureResult('WSL2 is not installed. Call "wsl --install" in terminal.');
   }
 }

--- a/extensions/podman/src/podman-install.ts
+++ b/extensions/podman/src/podman-install.ts
@@ -385,7 +385,9 @@ class HyperVCheck extends BaseCheck {
     } catch (err) {
       // ignore error, this means that hyper-v not enabled
     }
-    return this.createFailureResult('Hyper-V should be enabled to be able to run Podman. See https://docs.microsoft.com/en-us/virtualization/hyper-v-on-windows/quick-start/enable-hyper-v');
+    return this.createFailureResult(
+      'Hyper-V should be enabled to be able to run Podman. See https://docs.microsoft.com/en-us/virtualization/hyper-v-on-windows/quick-start/enable-hyper-v',
+    );
   }
 }
 
@@ -394,12 +396,16 @@ class WSL2Check extends BaseCheck {
 
   async execute(): Promise<extensionApi.CheckResult> {
     try {
-      const res = await execPromise('wsl', ['-l', '-v']);
+      // set WSL_UTF8 to force WSL2 output in UTF8, otherwise it will use utf16le
+      const res = await execPromise('wsl', ['-l', '-v'], { env: { 'WSL_UTF8': '1'}});
       if (!res.startsWith('Usage: wsl.exe [Argument]')) {
         return this.createSuccessfulResult();
       }
     } catch (err) {
-      if(typeof err === 'string' && err.indexOf('Windows Subsystem for Linux has no installed distributions.') !== -1) {
+      if (
+        typeof err === 'string' &&
+        err.indexOf('Windows Subsystem for Linux has no installed distributions.') !== -1
+      ) {
         // WSL2 installed, it just doesn't have any distro installed.
         return this.createSuccessfulResult();
       }

--- a/extensions/podman/src/podman-install.ts
+++ b/extensions/podman/src/podman-install.ts
@@ -402,13 +402,26 @@ class WSL2Check extends BaseCheck {
         return this.createSuccessfulResult();
       }
     } catch (err) {
-      if (
-        typeof err === 'string' &&
-        err.indexOf('Windows Subsystem for Linux has no installed distributions.') !== -1
-      ) {
-        // WSL2 installed, it just doesn't have any distro installed.
-        return this.createSuccessfulResult();
+
+      if(typeof err === 'string') {
+        // this is workaround, wsl2 some time send output in utf16le, but we thereat that as utf8,
+        // this code just eliminate every 'empty' character
+        let str = '';
+        for(let i=0; i< err.length; i++) {
+          if(err.charCodeAt(i) !== 0){
+            str += err.charAt(i);
+          }
+        }
+
+        if (
+          str.indexOf('Windows Subsystem for Linux has no installed distributions.') !== -1
+        ) {
+          // WSL2 installed, it just doesn't have any distro installed.
+          return this.createSuccessfulResult();
+        }
       }
+
+
     }
     return this.createFailureResult('WSL2 is not installed. Call "wsl --install" in terminal.');
   }

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -203,14 +203,15 @@ declare module '@tmpwip/extension-api' {
   }
 
   export interface Link {
-    name: string;
+    title: string;
     url: string;
   }
+  export type CheckResultLink = Link;
 
   export interface CheckResult {
     successful: boolean;
     description?: string;
-    docLinks?: Link[];
+    docLinks?: CheckResultLink[];
   }
 
   export interface InstallCheck {
@@ -230,10 +231,7 @@ declare module '@tmpwip/extension-api' {
     update(logger: Logger): Promise<void>;
   }
 
-  export interface ProviderLinks {
-    title: string;
-    url: string;
-  }
+  export type ProviderLinks = Link;
 
   export interface ProviderImages {
     icon?: string | { light: string; dark: string };

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -202,9 +202,15 @@ declare module '@tmpwip/extension-api' {
     create(params: { [key: string]: any }): Promise<void>;
   }
 
+  export interface Link {
+    name: string;
+    url: string;
+  }
+
   export interface CheckResult {
     successful: boolean;
     description?: string;
+    docLinks?: Link[];
   }
 
   export interface InstallCheck {

--- a/packages/main/src/plugin/api/provider-info.ts
+++ b/packages/main/src/plugin/api/provider-info.ts
@@ -23,6 +23,7 @@ import type {
   ProviderLinks,
   ProviderProxySettings,
   ProviderStatus,
+  Link,
 } from '@tmpwip/extension-api';
 
 export type LifecycleMethod = 'start' | 'stop' | 'delete';
@@ -83,6 +84,7 @@ export interface CheckStatus {
   name: string;
   successful?: boolean;
   description?: string;
+  docLinks?: Link[];
 }
 
 export interface PreflightCheckEvent {

--- a/packages/main/src/plugin/provider-registry.ts
+++ b/packages/main/src/plugin/provider-registry.ts
@@ -273,6 +273,7 @@ export class ProviderRegistry {
           name: check.title,
           successful: checkResult.successful,
           description: checkResult.description,
+          docLinks: checkResult.docLinks,
         });
 
         if (!checkResult.successful) {

--- a/packages/main/src/plugin/provider-registry.ts
+++ b/packages/main/src/plugin/provider-registry.ts
@@ -285,6 +285,7 @@ export class ProviderRegistry {
           successful: false,
           description: err instanceof Error ? err.message : typeof err === 'object' ? err?.toString() : 'unknown error',
         });
+        return false;
       }
     }
     return true;

--- a/packages/renderer/src/lib/welcome/ProviderInstallationButton.svelte
+++ b/packages/renderer/src/lib/welcome/ProviderInstallationButton.svelte
@@ -37,6 +37,8 @@ async function performInstallation(provider: ProviderInfo) {
   }
   if (checkSuccess) {
     await window.installProvider(provider.internalId);
+    // reset checks
+    onPreflightChecks([]);
   } else {
     preflightChecksFailed = true;
   }

--- a/packages/renderer/src/lib/welcome/ProviderNotInstalled.svelte
+++ b/packages/renderer/src/lib/welcome/ProviderNotInstalled.svelte
@@ -11,6 +11,12 @@ export let provider: ProviderInfo;
 
 let detectionChecks: ProviderDetectionCheck[] = [];
 let preflightChecks: CheckStatus[] = [];
+
+function openLink(e: MouseEvent, url: string): void {
+  e.preventDefault();
+  e.stopPropagation();
+  window.openExternal(url);
+}
 </script>
 
 <div class="p-2 flex flex-col bg-zinc-700 rounded-lg">
@@ -55,6 +61,11 @@ let preflightChecks: CheckStatus[] = [];
           </p>
           {#if preCheck.description}
             Details: <p class="text-gray-300 w-full break-all">{preCheck.description}</p>
+            {#if preCheck.docLinks}
+              {#each preCheck.docLinks as link}
+                <a href="{link.url}" target="_blank" on:click="{e => openLink(e, link.url)}">{link.name}</a>
+              {/each}
+            {/if}
           {/if}
         </div>
       {/each}

--- a/packages/renderer/src/lib/welcome/ProviderNotInstalled.svelte
+++ b/packages/renderer/src/lib/welcome/ProviderNotInstalled.svelte
@@ -62,8 +62,9 @@ function openLink(e: MouseEvent, url: string): void {
           {#if preCheck.description}
             Details: <p class="text-gray-300 w-full break-all">{preCheck.description}</p>
             {#if preCheck.docLinks}
+              See:
               {#each preCheck.docLinks as link}
-                <a href="{link.url}" target="_blank" on:click="{e => openLink(e, link.url)}">{link.name}</a>
+                <a href="{link.url}" target="_blank" on:click="{e => openLink(e, link.url)}">{link.title}</a>
               {/each}
             {/if}
           {/if}


### PR DESCRIPTION
### What does this PR do?
Add preflight check which executes before podman installation.

### Screenshot/screencast of this PR

WSL2 not installed:

https://user-images.githubusercontent.com/929743/182620513-d26de262-5761-407a-b29f-40d67d4d4430.mp4

All checks passed:

https://user-images.githubusercontent.com/929743/182620537-e4ad4676-c798-4e0b-91b1-85c5b927c55e.mp4


<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?
Resolve https://github.com/containers/podman-desktop/issues/326
<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

### How to test this PR?
You need windows machine without podman, hyper-v, wsl2 installed. Run podman-desktop, on podman welcome page click on `Install` button.
<!-- Please explain steps to reproduce -->
