### PR TITLE
fix: handle errors when receiving broken events

### DIFF
--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -96,6 +96,9 @@ export class ContainerProviderRegistry {
         console.log('error is', err);
       }
       const pipeline = stream?.pipe(StreamValues.withParser());
+      pipeline?.on('error', error => {
+        console.error('Error while parsing events', error);
+      });
       pipeline?.on('data', data => {
         if (data?.value !== undefined) {
           eventEmitter.emit('event', data.value);


### PR DESCRIPTION
### What does this PR do?
After https://github.com/containers/podman-desktop/pull/344 we're
not handling anymore errors so it's thrown directly to the main
loop and then we've errors being displayed directly by electron
with popups
Adds the error event so error is displayed in the log

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/354

### How to test this PR?

For example Docker Desktop running and Podman Desktop
then you close Docker Desktop

before the fix: popup error
after the fix: error displayed in the log


Change-Id: I520c2dbc6ec0434666a08815a709b43e25db2229
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
