### PR TITLE
fix: check if auth.json file exists before reading

### DIFF
--- a/extensions/podman/src/registry-setup.ts
+++ b/extensions/podman/src/registry-setup.ts
@@ -166,7 +166,13 @@ export class RegistrySetup {
     this.updateRegistries(extensionContext);
   }
 
-  protected readAuthFile(): Promise<ContainersAuthConfigFile> {
+  protected async readAuthFile(): Promise<ContainersAuthConfigFile> {
+    // when we have a fresh installation of podman, auth file might not have been created
+    if (!fs.existsSync(this.getAuthFileLocation())) {
+      const emptyAuthFile = { auths: {} } as ContainersAuthConfigFile;
+      await this.writeAuthFile(JSON.stringify(emptyAuthFile, undefined, 8));
+    }
+
     return new Promise((resolve, reject) => {
       fs.readFile(this.getAuthFileLocation(), 'utf8', (err, data) => {
         if (err) {


### PR DESCRIPTION
### What does this PR do?
The following changes proposal adds an additional check for `auth.json` file before reading.

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>

### How to test this PR?

Having a fresh installation of podman and ensure, that `auth.json` is not existing try to add a new registry. Podman Desktop should not throw an exception, that it is not possible to read non-existent file.
