### PR TITLE
fix: pass the copy of object to avoid modifying an original one

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesRegistriesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRegistriesRendering.svelte
@@ -107,6 +107,6 @@ function toggleRegistryModal(): void {
     <PreferencesRegistriesEditCreateRegistryModal
       toggleCallback="{toggleRegistryModal}"
       mode="{preferencesMode}"
-      registry="{selectedRegistry}" />
+      registry="{{ ...selectedRegistry }}" />
   </Modal>
 {/if}


### PR DESCRIPTION
### What does this PR do?
Do not modify the original registry object instance, when the dialog opens. This prevents the original object instance from the modification, when user closes the dialog without create or update action.

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

part of #290 

### How to test this PR?

Open dialog to modify the existed registry, type any values and close the dialog, then open the dialog again. Values should not be modified.
