### PR TITLE
feat: Display container's started time

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "dockerode": "^3.3.1",
     "electron-updater": "4.6.5",
     "getos": "^3.2.1",
+    "moment": "^2.29.2",
     "os-locale": "^6.0.2",
     "stream-json": "^1.7.4",
     "tar-fs": "^2.1.1"

--- a/packages/main/src/plugin/api/container-info.ts
+++ b/packages/main/src/plugin/api/container-info.ts
@@ -21,6 +21,7 @@ import type Dockerode from 'dockerode';
 export interface ContainerInfo extends Dockerode.ContainerInfo {
   engineId: string;
   engineName: string;
+  StartedAt: string;
 }
 
 export interface HostConfig {

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -19,6 +19,7 @@
     "@typescript-eslint/eslint-plugin": "5.11.0",
     "autoprefixer": "^10.4.2",
     "filesize": "^8.0.7",
+    "humanize-duration": "^3.27.2",
     "moment": "^2.29.2",
     "monaco-editor": "^0.33.0",
     "ninja-keys": "^1.1.12",

--- a/packages/renderer/src/lib/ContainerList.svelte
+++ b/packages/renderer/src/lib/ContainerList.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { onMount } from 'svelte';
-import { filtered, searchPattern } from '../stores/containers';
+import { fetchContainers, filtered, searchPattern } from '../stores/containers';
 
 import type { ContainerInfo } from '../../../../main/src/plugin/api/container-info';
 import ContainerIcon from './ContainerIcon.svelte';
@@ -12,6 +12,8 @@ import Modal from './dialogs/Modal.svelte';
 import { ContainerUtils } from './container/container-utils';
 import { providerInfos } from '../stores/providers';
 import NoContainerEngineEmptyScreen from './image/NoContainerEngineEmptyScreen.svelte';
+
+setInterval(() => fetchContainers(), 5000);
 
 let openChoiceModal = false;
 
@@ -146,6 +148,11 @@ function fromDockerfile(): void {
                     <div class="pl-2 pr-2">{container.port}</div>
                   </div>
                 </div>
+              </div>
+            </td>
+            <td class="px-6 py-2 whitespace-nowrap w-10">
+              <div class="flex items-center">
+                <div class="ml-2 text-sm text-gray-200">{container.status}</div>
               </div>
             </td>
             <td class="px-6 whitespace-nowrap">

--- a/packages/renderer/src/lib/container/ContainerInfoUI.ts
+++ b/packages/renderer/src/lib/container/ContainerInfoUI.ts
@@ -24,7 +24,8 @@ export interface ContainerInfoUI {
   engineId: string;
   engineName: string;
   state: string;
-  status: string;
+  uptime: string;
+  startedAt: string;
   port: string;
   command: string;
   hasPublicPort: boolean;

--- a/packages/renderer/src/lib/container/ContainerInfoUI.ts
+++ b/packages/renderer/src/lib/container/ContainerInfoUI.ts
@@ -24,6 +24,7 @@ export interface ContainerInfoUI {
   engineId: string;
   engineName: string;
   state: string;
+  status: string;
   port: string;
   command: string;
   hasPublicPort: boolean;

--- a/packages/renderer/src/lib/container/container-utils.ts
+++ b/packages/renderer/src/lib/container/container-utils.ts
@@ -28,6 +28,10 @@ export class ContainerUtils {
     return (containerInfo.State || '').toUpperCase();
   }
 
+  getStatus(containerInfo: ContainerInfo): string {
+    return containerInfo.State === 'running' ? containerInfo.Status : '-';
+  }
+
   getImage(containerInfo: ContainerInfo): string {
     return containerInfo.Image;
   }
@@ -74,6 +78,7 @@ export class ContainerUtils {
       name: this.getName(containerInfo),
       image: this.getImage(containerInfo),
       state: this.getState(containerInfo),
+      status: this.getStatus(containerInfo),
       engineId: this.getEngineId(containerInfo),
       engineName: this.getEngineName(containerInfo),
       command: containerInfo.Command,

--- a/yarn.lock
+++ b/yarn.lock
@@ -7881,6 +7881,11 @@ human-signals@^2.1.0:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
   integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
 
+humanize-duration@^3.27.2:
+  version "3.27.2"
+  resolved "https://registry.yarnpkg.com/humanize-duration/-/humanize-duration-3.27.2.tgz#4b4e565bec098d22c9a54344e16156d1c649f160"
+  integrity sha512-A15OmA3FLFRnehvF4ZMocsxTZYvHq4ze7L+AgR1DeHw0xC9vMd4euInY83uqGU9/XXKNnVIEeKc1R8G8nKqtzg==
+
 iconv-corefoundation@^1.1.7:
   version "1.1.7"
   resolved "https://registry.npmjs.org/iconv-corefoundation/-/iconv-corefoundation-1.1.7.tgz"


### PR DESCRIPTION
### What does this PR do?
Add container's started time column.
To update the started time column, the Containers page refreshes every 5 seconds.

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
https://user-images.githubusercontent.com/436777/183963384-f0d8b1b6-7bd8-4dd2-90b6-ef32f0f5885c.mp4


### What issues does this PR fix or reference?

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->
Fixes https://github.com/containers/podman-desktop/issues/386

### How to test this PR?

<!-- Please explain steps to reproduce -->
Check the `started time` column.
The container which state is running will display  `<time> ago`.
Any other state will display empty string.