### PR TITLE
fix: listing containers is failing on production builds

### DIFF
--- a/packages/renderer/src/lib/container/container-utils.ts
+++ b/packages/renderer/src/lib/container/container-utils.ts
@@ -19,7 +19,7 @@
 import type { ContainerInfo } from '../../../../main/src/plugin/api/container-info';
 import type { ContainerInfoUI } from './ContainerInfoUI';
 import moment from 'moment';
-import * as humanize from 'humanize-duration';
+import humanizeDuration from 'humanize-duration';
 export class ContainerUtils {
   getName(containerInfo: ContainerInfo) {
     return containerInfo.Names[0].replace(/^\//, '');
@@ -42,7 +42,7 @@ export class ContainerUtils {
     // get start time in ms
     const uptimeInMs = moment().diff(started);
     // make it human friendly
-    return humanize(uptimeInMs, { round: true, largest: 1 });
+    return humanizeDuration(uptimeInMs, { round: true, largest: 1 });
   }
 
   refreshUptime(containerInfoUI: ContainerInfoUI): string {


### PR DESCRIPTION
### What does this PR do?
There is an error like 'Symbol undefined'

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?

N/A (was not in latest release 0.0.6)

### How to test this PR?

before: launch production build: containers do not display uptime
after: containers are displayed
