### PR TITLE
fix: docker desktop extension support

### DIFF
--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -19,7 +19,7 @@
 /**
  * @module preload
  */
-
+import * as os from 'node:os';
 import type * as containerDesktopAPI from '@tmpwip/extension-api';
 import { CommandRegistry } from './command-registry';
 import { ContainerProviderRegistry } from './container-registry';
@@ -562,6 +562,16 @@ export class PluginSystem {
         shell.openExternal(link);
       },
     );
+
+    this.ipcHandle('os:getPlatform', async (): Promise<string> => {
+      return os.platform();
+    });
+    this.ipcHandle('os:getArch', async (): Promise<string> => {
+      return os.arch();
+    });
+    this.ipcHandle('os:getHostname', async (): Promise<string> => {
+      return os.hostname();
+    });
 
     this.ipcHandle(
       'provider-registry:startProviderLifecycle',


### PR DESCRIPTION
### What does this PR do?
node:os is not available on client side, need to fetch remotely

### Screenshot/screencast of this PR

![image](https://user-images.githubusercontent.com/436777/185605382-03b8fdb8-626d-49ff-a0ff-fa33e3e76eda.png)

### What issues does this PR fix or reference?

https://github.com/containers/podman-desktop/issues/415

### How to test this PR?

Try latest OpenShift Docker Desktop Extension

Change-Id: Ibbe54945519c84b3f1d82365c587197c95b74088
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
