### PR TITLE
feat: install podman on macos

### DIFF
--- a/extensions/podman/src/podman-cli.ts
+++ b/extensions/podman/src/podman-cli.ts
@@ -20,7 +20,7 @@ import { spawn } from 'node:child_process';
 import type * as extensionApi from '@tmpwip/extension-api';
 import { isMac, isWindows } from './util';
 
-const macosExtraPath = '/usr/local/bin:/opt/homebrew/bin:/opt/local/bin';
+const macosExtraPath = '/usr/local/bin:/opt/homebrew/bin:/opt/local/bin:/opt/podman/bin';
 
 export function getInstallationPath(): string {
   const env = process.env;


### PR DESCRIPTION
### What does this PR do?
Add installation of podman on macos.

### Screenshot/screencast of this PR

https://user-images.githubusercontent.com/929743/185893129-ba5272a7-9a1d-476b-90c4-1e512f49dccd.mov


<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?
Resolve https://github.com/containers/podman-desktop/issues/370
<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

### How to test this PR?
Run app on macos without podman, click on `install` button on podman welcome page, follow podman installation wizard, ensure that podman-desktop works with installed podman. 
<!-- Please explain steps to reproduce -->
