### PR TITLE
fix: use GH token for podman packages download

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -25,7 +25,7 @@ jobs:
     runs-on: windows-2022
     timeout-minutes: 60
     env:
-      GITHUB_TOKEN: ${{ github.token }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v2
 
@@ -70,7 +70,7 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 40
     env:
-      GITHUB_TOKEN: ${{ github.token }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v2
 
@@ -124,7 +124,7 @@ jobs:
     runs-on: macos-11
     timeout-minutes: 40
     env:
-      GITHUB_TOKEN: ${{ github.token }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -1,12 +1,12 @@
 #
 # Copyright (C) 2022 Red Hat, Inc.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 # SPDX-License-Identifier: Apache-2.0
- 
+
 name: pr-check
 
 on: [pull_request]
@@ -24,6 +24,8 @@ jobs:
     name: Windows
     runs-on: windows-2022
     timeout-minutes: 60
+    env:
+      GITHUB_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@v2
 
@@ -67,6 +69,8 @@ jobs:
     name: Linux
     runs-on: ubuntu-20.04
     timeout-minutes: 40
+    env:
+      GITHUB_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@v2
 
@@ -119,6 +123,8 @@ jobs:
     name: macOS
     runs-on: macos-11
     timeout-minutes: 40
+    env:
+      GITHUB_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,12 +1,12 @@
 #
 # Copyright (C) 2022 Red Hat, Inc.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 # SPDX-License-Identifier: Apache-2.0
- 
+
 name: release
 
 on:
@@ -75,6 +75,8 @@ jobs:
       matrix:
         os: [windows-2022, ubuntu-20.04, macos-11]
     timeout-minutes: 60
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v3
         with:

--- a/extensions/podman/scripts/download.ts
+++ b/extensions/podman/scripts/download.ts
@@ -20,6 +20,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { Octokit } from 'octokit';
+import type { OctokitOptions } from '@octokit/core/dist-types/types';
 import * as hasha from 'hasha';
 
 const tools = require('../src/podman.json');
@@ -29,7 +30,11 @@ const platform = process.platform;
 const MAX_DOWNLOAD_ATTEMPT = 3;
 let downloadAttempt = 0;
 
-const octokit = new Octokit();
+const octokitOptions: OctokitOptions  = {};
+if(process.env.GITHUB_TOKEN) {
+  octokitOptions.auth = process.env.GITHUB_TOKEN;
+}
+const octokit = new Octokit(octokitOptions);
 
 // to make this file a module
 export {};

--- a/extensions/podman/scripts/download.ts
+++ b/extensions/podman/scripts/download.ts
@@ -30,8 +30,8 @@ const platform = process.platform;
 const MAX_DOWNLOAD_ATTEMPT = 3;
 let downloadAttempt = 0;
 
-const octokitOptions: OctokitOptions  = {};
-if(process.env.GITHUB_TOKEN) {
+const octokitOptions: OctokitOptions = {};
+if (process.env.GITHUB_TOKEN) {
   octokitOptions.auth = process.env.GITHUB_TOKEN;
 }
 const octokit = new Octokit(octokitOptions);


### PR DESCRIPTION
### What does this PR do?
Use GitHub token in octokit while downloading podman packages.

### Screenshot/screencast of this PR
n/a
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?
Fix https://github.com/containers/podman-desktop/issues/416
<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

### How to test this PR?

<!-- Please explain steps to reproduce -->
