### PR TITLE
fix: set UI culture to 'en-US' for hyper-v check

### DIFF
--- a/extensions/podman/src/podman-install.ts
+++ b/extensions/podman/src/podman-install.ts
@@ -429,7 +429,11 @@ class HyperVCheck extends BaseCheck {
 
   async execute(): Promise<extensionApi.CheckResult> {
     try {
-      const res = await execPromise('powershell.exe', ['(Get-Service vmcompute).DisplayName']);
+      // set CurrentUICulture to force output in english
+      const res = await execPromise('powershell.exe', [
+        "[Threading.Thread]::CurrentThread.CurrentUICulture = 'en-US';",
+        '(Get-Service vmcompute).DisplayName',
+      ]);
       if (res === 'Hyper-V Host Compute Service') {
         return this.createSuccessfulResult();
       }


### PR DESCRIPTION
### What does this PR do?
Set UI culture to force `(Get-Service vmcompute).DisplayName` output in english.

### Screenshot/screencast of this PR
n/a
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?
Fix https://github.com/containers/podman-desktop/issues/402
<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

### How to test this PR?

<!-- Please explain steps to reproduce -->
