### PR TITLE
fix: WSL2 detection check

### DIFF
--- a/extensions/podman/src/podman-install.ts
+++ b/extensions/podman/src/podman-install.ts
@@ -431,7 +431,7 @@ class HyperVCheck extends BaseCheck {
     try {
       // set CurrentUICulture to force output in english
       const res = await execPromise('powershell.exe', ['(Get-Service vmcompute).DisplayName']);
-      if (res.indexOf('Hyper-V') > 0) {
+      if (res.indexOf('Hyper-V') >= 0) {
         return this.createSuccessfulResult();
       }
     } catch (err) {

--- a/extensions/podman/src/podman-install.ts
+++ b/extensions/podman/src/podman-install.ts
@@ -430,11 +430,8 @@ class HyperVCheck extends BaseCheck {
   async execute(): Promise<extensionApi.CheckResult> {
     try {
       // set CurrentUICulture to force output in english
-      const res = await execPromise('powershell.exe', [
-        "[Threading.Thread]::CurrentThread.CurrentUICulture = 'en-US';",
-        '(Get-Service vmcompute).DisplayName',
-      ]);
-      if (res === 'Hyper-V Host Compute Service') {
+      const res = await execPromise('powershell.exe', ['(Get-Service vmcompute).DisplayName']);
+      if (res.indexOf('Hyper-V') > 0) {
         return this.createSuccessfulResult();
       }
     } catch (err) {

--- a/extensions/podman/src/podman-install.ts
+++ b/extensions/podman/src/podman-install.ts
@@ -452,12 +452,8 @@ class WSL2Check extends BaseCheck {
     try {
       const res = await execPromise('wsl', ['--status'], { env: { WSL_UTF8: '1' } });
       const output = this.normalizeOutput(res);
-      if (output.indexOf('wsl.exe--update') > 0) {
-        return this.createFailureResult(
-          'WSL2 Linux kernel is not installed. Call "wsl --update" in terminal.',
-          'Install WLS2 Linux kernel',
-          'https://aka.ms/wsl2kernel',
-        );
+      if (!output) {
+        throw new Error();
       }
     } catch (err) {
       return this.createFailureResult(

--- a/extensions/podman/src/podman-install.ts
+++ b/extensions/podman/src/podman-install.ts
@@ -244,7 +244,7 @@ abstract class BaseInstaller implements Installer {
       return path.resolve(__dirname, '..', 'assets');
     } else {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      return path.resolve((process as any).resourcesPath, 'extensions', 'podman', 'builtin', 'podman.cdix', 'assets');
+      return path.resolve((process as any).resourcesPath, 'extensions', 'podman', 'assets');
     }
   }
 


### PR DESCRIPTION
### What does this PR do?
It changes the command and output processing of wsl detection.
Previous implementation doesn’t work on non English Windows.

Current implementation doesn't rely on direct text output, it just call `wsl --status` and assume that wsl installed when it return non zero exit code.

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?
n/a
<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

### How to test this PR?
Just run it on non English windows(windows should have localised version of `wsl`, I know that French and German windows has such), and try to install podman from podman-sesktop.
<!-- Please explain steps to reproduce -->
