### PR TITLE
feat: Show kubernetes yaml for containers

### DIFF
--- a/packages/main/src/plugin/api/container-info.ts
+++ b/packages/main/src/plugin/api/container-info.ts
@@ -21,6 +21,7 @@ import type Dockerode from 'dockerode';
 export interface ContainerInfo extends Dockerode.ContainerInfo {
   engineId: string;
   engineName: string;
+  engineType: 'podman' | 'docker';
   StartedAt: string;
   pod?: {
     id: string;

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -244,6 +244,7 @@ export class ContainerProviderRegistry {
                 pod,
                 engineName: provider.name,
                 engineId: provider.id,
+                engineType: provider.connection.type,
                 StartedAt,
               };
               return containerInfo;
@@ -478,6 +479,11 @@ export class ContainerProviderRegistry {
   async startContainer(engineId: string, id: string): Promise<void> {
     this.telemetryService.track('startContainer');
     return this.getMatchingContainer(engineId, id).start();
+  }
+
+  async generatePodmanKube(engineId: string, names: string[]): Promise<string> {
+    this.telemetryService.track('generatePodmanKube');
+    return this.getMatchingPodmanEngine(engineId).generateKube(names);
   }
 
   async startPod(engineId: string, podId: string): Promise<void> {

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -218,6 +218,12 @@ export class PluginSystem {
       },
     );
     this.ipcHandle(
+      'container-provider-registry:generatePodmanKube',
+      async (_listener, engine: string, names: string[]): Promise<string> => {
+        return containerProviderRegistry.generatePodmanKube(engine, names);
+      },
+    );
+    this.ipcHandle(
       'container-provider-registry:startContainer',
       async (_listener, engine: string, containerId: string): Promise<void> => {
         return containerProviderRegistry.startContainer(engine, containerId);

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -120,6 +120,9 @@ function initExposure(): void {
   contextBridge.exposeInMainWorld('restartPod', async (engine: string, podId: string): Promise<void> => {
     return ipcInvoke('container-provider-registry:restartPod', engine, podId);
   });
+  contextBridge.exposeInMainWorld('generatePodmanKube', async (engine: string, names: string[]): Promise<string> => {
+    return ipcInvoke('container-provider-registry:generatePodmanKube', engine, names);
+  });
   contextBridge.exposeInMainWorld('stopPod', async (engine: string, podId: string): Promise<void> => {
     return ipcInvoke('container-provider-registry:stopPod', engine, podId);
   });

--- a/packages/renderer/src/lib/ContainerDetails.svelte
+++ b/packages/renderer/src/lib/ContainerDetails.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import type { ContainerInfoUI } from './container/ContainerInfoUI';
+import { ContainerGroupInfoTypeUI, ContainerInfoUI } from './container/ContainerInfoUI';
 import { Route } from 'tinro';
 import ContainerIcon from './ContainerIcon.svelte';
 import 'xterm/css/xterm.css';
@@ -11,6 +11,7 @@ import { containersInfos } from '../stores/containers';
 import { ContainerUtils } from './container/container-utils';
 import ContainerDetailsInspect from './ContainerDetailsInspect.svelte';
 import { getPanelDetailColor } from './color/color';
+import ContainerDetailsKube from './ContainerDetailsKube.svelte';
 
 export let containerID: string;
 
@@ -71,7 +72,19 @@ onMount(() => {
                         <span class="pf-c-tabs__item-text">Inspect</span>
                       </a>
                     </li>
-
+                    {#if container.engineType === 'podman' && container.groupInfo.type === ContainerGroupInfoTypeUI.STANDALONE}
+                      <li
+                        class="pf-c-tabs__item"
+                        class:pf-m-current="{meta.url === `/containers/${container.id}/kube`}">
+                        <a
+                          href="/containers/{container.id}/kube"
+                          class="pf-c-tabs__link"
+                          aria-controls="open-tabs-example-tabs-list-yaml-panel"
+                          id="open-tabs-example-tabs-list-yaml-link">
+                          <span class="pf-c-tabs__item-text">Kube</span>
+                        </a>
+                      </li>
+                    {/if}
                     <li
                       class="pf-c-tabs__item"
                       class:pf-m-current="{meta.url === `/containers/${container.id}/terminal`}">
@@ -112,6 +125,9 @@ onMount(() => {
         </Route>
         <Route path="/inspect">
           <ContainerDetailsInspect container="{container}" />
+        </Route>
+        <Route path="/kube">
+          <ContainerDetailsKube container="{container}" />
         </Route>
         <Route path="/details">
           <div class="flex py-4 h-full" style="background-color: {getPanelDetailColor()}">

--- a/packages/renderer/src/lib/ContainerDetailsKube.svelte
+++ b/packages/renderer/src/lib/ContainerDetailsKube.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+import type { ContainerInfoUI } from './container/ContainerInfoUI';
+import { onMount } from 'svelte';
+import MonacoEditor from './editor/MonacoEditor.svelte';
+
+export let container: ContainerInfoUI;
+
+let kubeDetails: string;
+
+onMount(async () => {
+  // grab kube result from the container
+  const kubeResult = await window.generatePodmanKube(container.engineId, [container.id]);
+  kubeDetails = kubeResult;
+});
+</script>
+
+{#if kubeDetails}
+  <MonacoEditor content="{kubeDetails}" language="yaml" />
+{/if}

--- a/packages/renderer/src/lib/container/ContainerActions.svelte
+++ b/packages/renderer/src/lib/container/ContainerActions.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
 import Fa from 'svelte-fa/src/fa.svelte';
-import { faPlayCircle, faTerminal } from '@fortawesome/free-solid-svg-icons';
+import { faFileCode, faPlayCircle, faTerminal } from '@fortawesome/free-solid-svg-icons';
 import { faStopCircle } from '@fortawesome/free-solid-svg-icons';
 import { faArrowsRotate } from '@fortawesome/free-solid-svg-icons';
 import { faTrash } from '@fortawesome/free-solid-svg-icons';
 import { faExternalLinkSquareAlt } from '@fortawesome/free-solid-svg-icons';
-import type { ContainerInfoUI } from './ContainerInfoUI';
+import { ContainerGroupInfoTypeUI, ContainerInfoUI } from './ContainerInfoUI';
 import { router } from 'tinro';
 import ListItemButtonIcon from '../ui/ListItemButtonIcon.svelte';
 
@@ -34,6 +34,10 @@ async function deleteContainer(containerInfo: ContainerInfoUI): Promise<void> {
 function openTerminalContainer(containerInfo: ContainerInfoUI): void {
   router.goto(`/containers/${container.id}/terminal`);
 }
+
+function openGenerateKube(): void {
+  router.goto(`/containers/${container.id}/kube`);
+}
 </script>
 
 <ListItemButtonIcon
@@ -48,6 +52,12 @@ function openTerminalContainer(containerInfo: ContainerInfoUI): void {
   hidden="{!(container.state === 'RUNNING')}"
   backgroundColor="{backgroundColor}"
   icon="{faTerminal}" />
+<ListItemButtonIcon
+  title="Generate Kube"
+  onClick="{() => openGenerateKube()}"
+  hidden="{!(container.engineType === 'podman' && container.groupInfo.type === ContainerGroupInfoTypeUI.STANDALONE)}"
+  backgroundColor="{backgroundColor}"
+  icon="{faFileCode}" />
 <ListItemButtonIcon
   title="Start Container"
   onClick="{() => startContainer(container)}"

--- a/packages/renderer/src/lib/container/ContainerInfoUI.ts
+++ b/packages/renderer/src/lib/container/ContainerInfoUI.ts
@@ -37,6 +37,7 @@ export interface ContainerInfoUI {
   image: string;
   engineId: string;
   engineName: string;
+  engineType: 'podman' | 'docker';
   state: string;
   uptime: string;
   startedAt: string;

--- a/packages/renderer/src/lib/container/container-utils.ts
+++ b/packages/renderer/src/lib/container/container-utils.ts
@@ -112,6 +112,7 @@ export class ContainerUtils {
       uptime: this.getUptime(containerInfo),
       engineId: this.getEngineId(containerInfo),
       engineName: this.getEngineName(containerInfo),
+      engineType: containerInfo.engineType,
       command: containerInfo.Command,
       port: this.getPort(containerInfo),
       hasPublicPort: this.hasPublicPort(containerInfo),


### PR DESCRIPTION
### What does this PR do?

Generate kube yaml for containers

### Screenshot/screencast of this PR

![image](https://user-images.githubusercontent.com/436777/187384135-d1355d3a-bbf6-44fe-b123-1aab780cd35b.png)
![image](https://user-images.githubusercontent.com/436777/187384178-b4f73385-ed27-4bde-b3e8-c61241a64392.png)


### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/202


### How to test this PR?

Use podman as engine, start a container and click on Generate kube icon or in the details, select Kube in the tab.

Change-Id: Id25e3f923fc5afeabdcc053a5e8c97df3e442198
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
