### PR TITLE
fix: Detect podman.exe installed with scoop

### DIFF
--- a/extensions/podman/src/podman-cli.ts
+++ b/extensions/podman/src/podman-cli.ts
@@ -25,7 +25,7 @@ const macosExtraPath = '/usr/local/bin:/opt/homebrew/bin:/opt/local/bin:/opt/pod
 export function getInstallationPath(): string {
   const env = process.env;
   if (isWindows) {
-    return 'c:\\Program Files\\RedHat\\Podman\\podman.exe';
+    return `c:\\Program Files\\RedHat\\Podman;${env.PATH}`;
   } else if (isMac) {
     if (!env.PATH) {
       return macosExtraPath;
@@ -39,7 +39,7 @@ export function getInstallationPath(): string {
 
 export function getPodmanCli(): string {
   if (isWindows) {
-    return getInstallationPath();
+    return 'podman.exe';
   }
   return 'podman';
 }
@@ -53,7 +53,7 @@ export function execPromise(command: string, args?: string[], options?: ExecOpti
   let env = Object.assign({}, process.env); // clone original env object
 
   // In production mode, applications don't have access to the 'user' path like brew
-  if (isMac) {
+  if (isMac || isWindows) {
     env.PATH = getInstallationPath();
   } else if (env.FLATPAK_ID) {
     // need to execute the command on the host


### PR DESCRIPTION
### What does this PR do?
Change hardcoded path to podman.exe on windows, to use `PATH` env variable.

### Screenshot/screencast of this PR
![Capture](https://user-images.githubusercontent.com/929743/187434769-d3b708cd-aa25-47c0-bc39-acc03322c5be.PNG)

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?
Fix https://github.com/containers/podman-desktop/issues/404
<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

### How to test this PR?
Run on Windows with podman installed with scoop, podman-desktop should detect such installation
<!-- Please explain steps to reproduce -->
