### PR TITLE
fix: Works with extensions without name

### DIFF
--- a/packages/main/src/plugin/contribution-manager.ts
+++ b/packages/main/src/plugin/contribution-manager.ts
@@ -95,6 +95,27 @@ export class ContributionManager {
     });
   }
 
+  async saveMetadata(rootDirectory: string, metadata: unknown): Promise<void> {
+    const manifestPath = path.join(rootDirectory, 'metadata.json');
+    if (!fs.existsSync(manifestPath)) {
+      throw new Error('Invalid path : ' + manifestPath);
+    }
+    return new Promise((resolve, reject) => {
+      fs.writeFile(
+        manifestPath,
+        JSON.stringify(metadata, undefined, 2),
+        { encoding: 'utf-8' },
+        (err: NodeJS.ErrnoException | null) => {
+          if (err) {
+            reject(err);
+          } else {
+            resolve();
+          }
+        },
+      );
+    });
+  }
+
   public getContributionStorageDir(): string {
     return path.resolve(os.homedir(), '.local/share/containers/podman-desktop/contributions');
   }

--- a/packages/main/src/plugin/docker-extension/docker-desktop-installation.ts
+++ b/packages/main/src/plugin/docker-extension/docker-desktop-installation.ts
@@ -263,6 +263,15 @@ export class DockerDesktopInstallation {
         event.reply('docker-desktop-plugin:install-log', logCallbackId, 'Filtering image content...');
 
         await this.extractDockerDesktopFiles(tmpFolderPath, finalFolderPath, reportLog);
+
+        // check metadata. If name is missing, add the one from the image
+        const metadata = await this.contributionManager.loadMetadata(finalFolderPath);
+        if (!metadata.name) {
+          // need to add the title from the image
+          metadata.name = titleLabel;
+          await this.contributionManager.saveMetadata(finalFolderPath, metadata);
+        }
+
         event.reply('docker-desktop-plugin:install-end', logCallbackId, 'Extension Successfully installed.');
         // refresh contributions
         await this.contributionManager.init();

--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -370,7 +370,7 @@ window.events?.receive('display-help', () => {
           <PreferencesPage />
         </Route>
         <Route path="/contribs/:name" let:meta>
-          <DockerExtension name="{meta.params.name}" />
+          <DockerExtension name="{decodeURI(meta.params.name)}" />
         </Route>
         <Route path="/help">
           <HelpPage />


### PR DESCRIPTION
### What does this PR do?
Left navbar was not working with extensions without names

### Screenshot/screencast of this PR

![image](https://user-images.githubusercontent.com/436777/187521849-bd6ebb02-40ef-4a10-b755-6be963dc83da.png)


### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/427


### How to test this PR?

Use `docker/logs-explorer-extension:0.2.1` as docker extension in preferences


Change-Id: I0c43fa5a69d40ec4d11ddb3eefebef08d4254994
Signed-off-by: Florent Benoit <fbenoit@redhat.com>

