### PR TITLE
fix: search image with FQN (registry there or without registry prefix)

### DIFF
--- a/packages/main/src/plugin/docker-extension/docker-desktop-installation.ts
+++ b/packages/main/src/plugin/docker-extension/docker-desktop-installation.ts
@@ -185,7 +185,9 @@ export class DockerDesktopInstallation {
         // ok search the image
         const images = await providerConnection.listImages();
         // const foundMatchingImage = images.find(image => image.RepoTags?.find(tag => tag.includes('aquasec/trivy-docker-extension:0.4.3')));
-        const foundMatchingImage = images.find(image => image.RepoTags?.find(tag => tag.includes(imageName)));
+        const foundMatchingImage = images.find(image =>
+          image.RepoTags?.find(tag => tag.includes(imageName) || imageName.includes(tag)),
+        );
 
         if (!foundMatchingImage) {
           reportLog('not able to get pulled image');


### PR DESCRIPTION
### What does this PR do?
Check for FQN of the image as well when pulling docker desktop extension image

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/425


### How to test this PR?

Try to use `docker.io/docker/logs-explorer-extension:0.2.1` instead of `docker/logs-explorer-extension:0.2.1`
before the fix, fails, after the fix = succeed

Change-Id: Id81171f11ec5c6d47b3d9bde1fb8d47c8927e49c
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
