### PR TITLE
fix: log too verbose in installation of DD extensions

### DIFF
--- a/packages/main/src/plugin/docker-extension/docker-desktop-installation.ts
+++ b/packages/main/src/plugin/docker-extension/docker-desktop-installation.ts
@@ -177,8 +177,10 @@ export class DockerDesktopInstallation {
         reportLog(`Pulling image ${imageName}...`);
 
         await this.containerRegistry.pullImage(providerConnectionInfo, imageName, (pullEvent: PullEvent) => {
-          if (pullEvent.progress) {
-            reportLog(pullEvent.progress);
+          if (pullEvent.progress || pullEvent.progressDetail) {
+            console.log(pullEvent.progress);
+          } else if (pullEvent.status) {
+            reportLog(pullEvent.status);
           }
         });
 

--- a/packages/renderer/src/lib/docker-extension/PreferencesPageDockerExtensions.svelte
+++ b/packages/renderer/src/lib/docker-extension/PreferencesPageDockerExtensions.svelte
@@ -1,10 +1,14 @@
 <script lang="ts">
+import { afterUpdate } from 'svelte';
+
 import { contributions } from '../../stores/contribs';
 let ociImage: string;
 
 let installInProgress: boolean = false;
 let errorInstall: string = '';
 let logs: string[] = [];
+
+let logElement;
 
 async function installDDExtensionFromImage() {
   logs.length = 0;
@@ -24,6 +28,10 @@ async function installDDExtensionFromImage() {
   installInProgress = false;
   ociImage = '';
 }
+
+afterUpdate(() => {
+  logElement.scroll({ top: logElement.scrollHeight, behavior: 'smooth' });
+});
 
 function deleteContribution(extensionName: string) {
   window.ddExtensionDelete(extensionName);
@@ -80,13 +88,14 @@ function deleteContribution(extensionName: string) {
         </div>
       {/if}
 
-      {#if logs.length > 0}
-        <div class="bg-zinc-700 text-gray-200 m-4 ">
-          {#each logs as log}
-            <p class="font-light text-sm">{log}</p>
-          {/each}
-        </div>
-      {/if}
+      <div
+        class:opacity-0="{logs.length === 0}"
+        bind:this="{logElement}"
+        class="bg-zinc-700 text-gray-200 mt-4 h-16 overflow-y-auto">
+        {#each logs as log}
+          <p class="font-light text-sm">{log}</p>
+        {/each}
+      </div>
     </div>
   </div>
 


### PR DESCRIPTION
### What does this PR do?
Reduce verbosity
also add an automatic scrolling
fixes https://github.com/containers/podman-desktop/issues/428

### Screenshot/screencast of this PR

https://user-images.githubusercontent.com/436777/187622629-41529643-d889-4438-810b-8ce4a76e422c.mp4


### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop/issues/428

### How to test this PR?

Navigate to preferences / DD extension and try to pull `docker/logs-explorer-extension:0.2.1`


Change-Id: I9a9dd7cb779d0616d2ba8f858de45ce8ce20de1b
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
