### PR TITLE
fix: make sure UI and server(main) extension system being ready

### DIFF
--- a/packages/main/src/mainWindow.ts
+++ b/packages/main/src/mainWindow.ts
@@ -62,15 +62,6 @@ async function createWindow() {
     height: browserWindowConstructorOptions.height,
   });
 
-  setTimeout(() => {
-    browserWindow.webContents.send('container-stopped-event', 'containerID');
-  }, 5000);
-
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  ipcMain.on('container-stopped-event', (event: any) => {
-    browserWindow.webContents.send('container-stopped-event', event);
-  });
-
   /**
    * If you install `show: true` then it can cause issues when trying to close the window.
    * Use `show: false` and listener events `ready-to-show` to fix these issues.

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -103,6 +103,10 @@ function initExposure(): void {
     }
   });
 
+  contextBridge.exposeInMainWorld('extensionSystemIsReady', async (): Promise<boolean> => {
+    return ipcInvoke('extension-system:isReady');
+  });
+
   contextBridge.exposeInMainWorld('listContainers', async (): Promise<ContainerInfo[]> => {
     return ipcInvoke('container-provider-registry:listContainers');
   });

--- a/packages/renderer/src/Loader.svelte
+++ b/packages/renderer/src/Loader.svelte
@@ -1,0 +1,59 @@
+<script lang="ts">
+import { onDestroy, onMount } from 'svelte';
+
+import App from './App.svelte';
+
+let systemReady: boolean = false;
+
+let toggle: boolean = false;
+
+let loadingSequence;
+
+onMount(async () => {
+  loadingSequence = setInterval(() => {
+    toggle = !toggle;
+  }, 2000);
+  // check if the server side is ready
+  try {
+    const isReady = await window.extensionSystemIsReady();
+    systemReady = isReady;
+    if (systemReady) {
+      window.dispatchEvent(new CustomEvent('system-ready', {}));
+    }
+  } catch (error) {}
+});
+
+onDestroy(() => {
+  if (loadingSequence) {
+    clearInterval(loadingSequence);
+  }
+});
+
+// Wait that the server-side is ready
+window.events.receive('extension-system', (value: string) => {
+  systemReady = value === 'true';
+  if (systemReady) {
+    window.dispatchEvent(new CustomEvent('system-ready', {}));
+  }
+  clearInterval(loadingSequence);
+});
+</script>
+
+{#if !systemReady}
+  <main class="min-h-screen flex flex-col h-screen">
+    <div class="min-h-full min-w-full flex flex-col">
+      <div class="pf-c-empty-state h-full">
+        <div class="pf-c-empty-state__content">
+          <i
+            class:text-zinc-700="{toggle}"
+            class:text-zinc-600="{!toggle}"
+            class="fas fa-layer-group m-4 text-8xl"
+            aria-hidden="true"></i>
+          <h1 class="pf-c-title pf-m-lg">Initializing...</h1>
+        </div>
+      </div>
+    </div>
+  </main>
+{:else}
+  <App />
+{/if}

--- a/packages/renderer/src/main.ts
+++ b/packages/renderer/src/main.ts
@@ -1,6 +1,6 @@
-import App from './App.svelte';
+import Loader from './Loader.svelte';
 
-const app = new App({
+const app = new Loader({
   target: document.getElementById('app'),
 });
 

--- a/packages/renderer/src/stores/configurationProperties.ts
+++ b/packages/renderer/src/stores/configurationProperties.ts
@@ -27,12 +27,14 @@ export async function fetchConfigurationProperties() {
   configurationProperties.set(properties);
 }
 
-fetchConfigurationProperties();
 export const configurationProperties = writable([]);
 
 window.addEventListener('extension-started', () => {
   fetchConfigurationProperties();
 });
 window.addEventListener('extension-stopped', () => {
+  fetchConfigurationProperties();
+});
+window.addEventListener('system-ready', () => {
   fetchConfigurationProperties();
 });

--- a/packages/renderer/src/stores/containers.ts
+++ b/packages/renderer/src/stores/containers.ts
@@ -25,7 +25,6 @@ export async function fetchContainers() {
   containersInfos.set(result);
 }
 
-fetchContainers();
 export const containersInfos: Writable<ContainerInfo[]> = writable([]);
 
 export const searchPattern = writable('');
@@ -44,6 +43,9 @@ window.addEventListener('extension-started', () => {
 });
 
 window.addEventListener('tray:update-provider', () => {
+  fetchContainers();
+});
+window.addEventListener('system-ready', () => {
   fetchContainers();
 });
 

--- a/packages/renderer/src/stores/contribs.ts
+++ b/packages/renderer/src/stores/contribs.ts
@@ -25,7 +25,6 @@ export async function fetchContributions() {
   contributions.set(result);
 }
 
-fetchContributions();
 export const contributions: Writable<readonly ContributionInfo[]> = writable([]);
 
 // need to refresh when new registry are updated/deleted
@@ -34,5 +33,8 @@ window.events?.receive('contribution-register', () => {
 });
 
 window.events?.receive('contribution-unregister', () => {
+  fetchContributions();
+});
+window.addEventListener('system-ready', () => {
   fetchContributions();
 });

--- a/packages/renderer/src/stores/extensions.ts
+++ b/packages/renderer/src/stores/extensions.ts
@@ -23,7 +23,6 @@ export async function fetchExtensions() {
   extensionInfos.set(result);
 }
 
-fetchExtensions();
 export const extensionInfos = writable([]);
 
 // need to refresh when extension is started or stopped
@@ -35,5 +34,8 @@ window.addEventListener('extension-stopped', () => {
 });
 
 window?.events.receive('extension-started', () => {
+  fetchExtensions();
+});
+window.addEventListener('system-ready', () => {
   fetchExtensions();
 });

--- a/packages/renderer/src/stores/images.ts
+++ b/packages/renderer/src/stores/images.ts
@@ -24,7 +24,6 @@ export async function fetchImages() {
   imagesInfos.set(result);
 }
 
-fetchImages();
 export const imagesInfos: Writable<ImageInfo[]> = writable([]);
 
 export const searchPattern = writable('');
@@ -46,6 +45,9 @@ window.addEventListener('extension-stopped', () => {
 });
 
 window.addEventListener('image-build', () => {
+  fetchImages();
+});
+window.addEventListener('system-ready', () => {
   fetchImages();
 });
 

--- a/packages/renderer/src/stores/pods.ts
+++ b/packages/renderer/src/stores/pods.ts
@@ -24,7 +24,6 @@ export async function fetchPods() {
   podsInfos.set(result);
 }
 
-fetchPods();
 export const podsInfos: Writable<PodInfo[]> = writable([]);
 
 export const searchPattern = writable('');
@@ -66,5 +65,8 @@ window.events?.receive('provider-change', () => {
 });
 
 window.events?.receive('pod-event', () => {
+  fetchPods();
+});
+window.addEventListener('system-ready', () => {
   fetchPods();
 });

--- a/packages/renderer/src/stores/providers.ts
+++ b/packages/renderer/src/stores/providers.ts
@@ -34,7 +34,6 @@ export async function fetchProviders() {
   });
 }
 
-fetchProviders();
 export const providerInfos: Writable<ProviderInfo[]> = writable([]);
 
 // need to refresh when extension is started or stopped
@@ -63,5 +62,8 @@ window?.events.receive('provider-delete', () => {
   fetchProviders();
 });
 window?.events.receive('provider:update-status', () => {
+  fetchProviders();
+});
+window.addEventListener('system-ready', () => {
   fetchProviders();
 });

--- a/packages/renderer/src/stores/registries.ts
+++ b/packages/renderer/src/stores/registries.ts
@@ -25,7 +25,6 @@ export async function fetchRegistries() {
   registriesInfos.set(result);
 }
 
-fetchRegistries();
 export const registriesInfos: Writable<readonly Registry[]> = writable([]);
 
 export const searchPattern = writable('');
@@ -40,5 +39,8 @@ window.events?.receive('registry-unregister', () => {
 });
 
 window.events?.receive('registry-update', () => {
+  fetchRegistries();
+});
+window.addEventListener('system-ready', () => {
   fetchRegistries();
 });

--- a/packages/renderer/src/stores/statusbar.ts
+++ b/packages/renderer/src/stores/statusbar.ts
@@ -26,9 +26,11 @@ export async function fetchRenderModel() {
   statusBarEntries.set(result);
 }
 
-fetchRenderModel();
 export const statusBarEntries: Writable<readonly StatusBarEntryDescriptor[]> = writable([]);
 
 window.events?.receive(STATUS_BAR_UPDATED_EVENT_NAME, async () => {
   await fetchRenderModel();
+});
+window.addEventListener('system-ready', () => {
+  fetchRenderModel();
 });


### PR DESCRIPTION
### What does this PR do?
Ensure both main and renderer processes are ready/available before communicating
On some slow computers, it may cause some race conditions

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/417
fixes https://github.com/containers/podman-desktop/issues/294

### How to test this PR?

you may add a (await timeout) in https://github.com/containers/podman-desktop/blob/main/packages/main/src/plugin/index.ts#L144
to make a slow 'server/main' startup

Change-Id: Ib0f05e18b6157cb513669be87020ba2ee5bece68
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
