### PR TITLE
Use bold instead of headline formatting for GitHub pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,14 +1,20 @@
-### What does this PR do?
+**What does this PR do?**
+<!-- Please provide a list of changes implemented by this PR -->
 
-### Screenshot/screencast of this PR
 
+
+**Screenshot/screencast of this PR:**
 <!-- Please include a screenshot or a screencast explaining what is doing this PR -->
 
-### What issues does this PR fix or reference?
 
-<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
--->
 
-### How to test this PR?
+**What issues does this PR fix or reference:**
+<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker) -->
 
+
+
+**How to test this PR:**
 <!-- Please explain steps to reproduce -->
+
+
+


### PR DESCRIPTION
Use bold instead of headline formatting for GitHub pull request template

**What does this PR do?**
<!-- Please provide a list of changes implemented by this PR -->

Small nitpick, but when you use the cli `gh` and the current template,
the headlines go missing as git ignores all lines starting with `#`.

For example, if you push via the command line, the title:
`# What does this PR do` will dissapear as commit messages with `#` are
ignored.

I've gone ahead and changed it to using **bold** titles instead so
titles don't dissapear on commit push. This aligns with other GitHub
projects who use bolded titles instead of headlines.

**Screenshot/screencast of this PR:**
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

N/A

**What issues does this PR fix or reference:**
<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker) -->

N/A

**How to test this PR:**
<!-- Please explain steps to reproduce -->

N/A

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
