### PR TITLE
fix: Use Login to instead of Add

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesRegistriesEditCreateRegistryModal.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRegistriesEditCreateRegistryModal.svelte
@@ -75,7 +75,7 @@ const setType = (node: any) => {
   class="inline-block w-full overflow-hidden text-left transition-all transform bg-[#4b5563] z-50 rounded-xl shadow-xl shadow-neutral-900"
   on:keydown="{keydownChoice}">
   <div class="flex items-center justify-between bg-black px-6 py-4 border-b-2 border-[#7c3aed]">
-    <h1 class="text-xl font-bold">{mode === 'create' ? 'Add Registry' : 'Edit Registry'}</h1>
+    <h1 class="text-xl font-bold">{mode === 'create' ? 'Login to a Registry' : 'Edit Registry'}</h1>
 
     <button class="hover:text-gray-200 px-2 py-1" on:click="{toggleCallback}">
       <i class="fas fa-times" aria-hidden="true"></i>
@@ -178,7 +178,7 @@ const setType = (node: any) => {
           type="button"
           disabled="{!$serverUrlValidity.valid || !$userNameValidity.valid || !$passwordValidity.valid}"
           on:click="{createOrUpdateRegistry}">
-          {mode === 'create' ? 'Add registry' : 'Update registry'}
+          {mode === 'create' ? 'Login to a registry' : 'Update registry'}
         </button>
       </div>
     </form>

--- a/packages/renderer/src/lib/preferences/PreferencesRegistriesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRegistriesRendering.svelte
@@ -79,8 +79,8 @@ function toggleRegistryModal(): void {
           createRegistry();
         }}"
         class="flex flex-col mr-4 mb-4 rounded-md shadow-md bg-zinc-700 hover:bg-gray-600 dark:hover:bg-gray-600 hover:cursor-pointer w-52 h-28 sm:w-60 justify-center text-center">
-        <i class="text-3xl text-gray-100 fas fa-plus-circle" aria-hidden="true"></i>
-        <h2 class="text-xl font-bold font-bol text-gray-100">Add registry</h2>
+        <i class="text-3xl text-gray-100 fas fa-user-plus" aria-hidden="true"></i>
+        <h2 class="text-xl font-bold font-bol text-gray-100">Login to a registry</h2>
       </div>
     </div>
   </div>


### PR DESCRIPTION
### What does this PR do?

Replace 'Add Registry' by 'Login to a registry'

### Screenshot/screencast of this PR

![image](https://user-images.githubusercontent.com/436777/188898842-22c39c3e-25b0-4656-ab5c-ce8ad4059d9a.png)
![image](https://user-images.githubusercontent.com/436777/188898884-dc0bfcb7-2c44-4c2b-a2c0-9008b5769bba.png)


### What issues does this PR fix or reference?
fixes https://github.com/containers/podman-desktop/issues/453

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

### How to test this PR?

Try to login to a registry in preferences

Change-Id: I79a1399f29871c95bf4dfe3ac47ef6437366ce1f
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
