### PR TITLE
feat: add cpu/memory usage in container details

### DIFF
--- a/packages/main/src/plugin/api/container-stats-info.ts
+++ b/packages/main/src/plugin/api/container-stats-info.ts
@@ -1,0 +1,24 @@
+/**********************************************************************
+ * Copyright (C) 2022 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type Dockerode from 'dockerode';
+
+export interface ContainerStatsInfo extends Dockerode.ContainerStats {
+  engineId: string;
+  engineName: string;
+}

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -62,6 +62,7 @@ import type { ContainerInspectInfo } from './api/container-inspect-info';
 import type { HistoryInfo } from './api/history-info';
 import type { PodInfo } from './api/pod-info';
 import type { VolumeInspectInfo, VolumeListInfo } from './api/volume-info';
+import type { ContainerStatsInfo } from './api/container-stats-info';
 
 type LogType = 'log' | 'warn' | 'trace' | 'debug' | 'error';
 export class PluginSystem {
@@ -322,6 +323,22 @@ export class PluginSystem {
         return containerProviderRegistry.getContainerInspect(engine, containerId);
       },
     );
+    this.ipcHandle(
+      'container-provider-registry:getContainerStats',
+      async (_listener, engine: string, containerId: string, onDataId: number): Promise<number> => {
+        return containerProviderRegistry.getContainerStats(engine, containerId, (stats: ContainerStatsInfo) => {
+          this.getWebContentsSender().send('container-provider-registry:getContainerStats-onData', onDataId, stats);
+        });
+      },
+    );
+
+    this.ipcHandle(
+      'container-provider-registry:stopContainerStats',
+      async (_listener, containerStatsId: number): Promise<void> => {
+        return containerProviderRegistry.stopContainerStats(containerStatsId);
+      },
+    );
+
     this.ipcHandle(
       'container-provider-registry:restartContainer',
       async (_listener, engine: string, containerId: string): Promise<void> => {

--- a/packages/renderer/src/lib/ContainerDetails.svelte
+++ b/packages/renderer/src/lib/ContainerDetails.svelte
@@ -12,6 +12,7 @@ import { ContainerUtils } from './container/container-utils';
 import ContainerDetailsInspect from './ContainerDetailsInspect.svelte';
 import { getPanelDetailColor } from './color/color';
 import ContainerDetailsKube from './ContainerDetailsKube.svelte';
+import ContainerStatistics from './container/ContainerStatistics.svelte';
 
 export let containerID: string;
 
@@ -112,9 +113,12 @@ onMount(() => {
               </div>
             </section>
           </div>
-          <div class="flex flex-row-reverse w-full  px-5 pt-5">
-            <div class="flex h-10">
+          <div class="flex flex-col w-full px-5 pt-5">
+            <div class="flex h-10 justify-end">
               <ContainerActions container="{container}" backgroundColor="bg-neutral-900" />
+            </div>
+            <div class="flex my-2 w-full justify-end ">
+              <ContainerStatistics container="{container}" />
             </div>
           </div>
           <a href="/containers" title="Close Details" class="mt-2 mr-2 text-gray-500"

--- a/packages/renderer/src/lib/container/ContainerStatistics.svelte
+++ b/packages/renderer/src/lib/container/ContainerStatistics.svelte
@@ -1,0 +1,102 @@
+<script lang="ts">
+import { onMount, onDestroy } from 'svelte';
+import type { ContainerStatsInfo } from '../../../../main/src/plugin/api/container-stats-info';
+import type { ContainerInfoUI } from './ContainerInfoUI';
+import filesize from 'filesize';
+
+export let container: ContainerInfoUI;
+
+const WARNING_PERCENTAGE = 70;
+const DANGER_PERCENTAGE = 90;
+
+const GREEN_COLOR = '#16a34a';
+const ORANGE_COLOR = '#F97316';
+const RED_COLOR = '#cb4d3e';
+
+$: cpuColor =
+  cpuUsagePercentage < WARNING_PERCENTAGE
+    ? GREEN_COLOR
+    : cpuUsagePercentage < DANGER_PERCENTAGE
+    ? ORANGE_COLOR
+    : RED_COLOR;
+$: memoryColor =
+  memoryUsagePercentage < WARNING_PERCENTAGE
+    ? GREEN_COLOR
+    : memoryUsagePercentage < DANGER_PERCENTAGE
+    ? ORANGE_COLOR
+    : RED_COLOR;
+
+// percentage
+let cpuUsagePercentage: number;
+let memoryUsagePercentage: number;
+let usedMemory;
+
+// id to cancel the streaming
+let fetchStatsId: number;
+
+// need two samples to compute stats
+let firstIteration = true;
+
+// title to use on
+let cpuUsagePercentageTitle;
+let memoryUsagePercentageTitle;
+
+async function updateStatistics(containerStats: ContainerStatsInfo) {
+  // we need enough data to compute the CPU usage
+  if (firstIteration) {
+    firstIteration = false;
+    return;
+  }
+
+  //
+  usedMemory = containerStats.memory_stats.usage - (containerStats.memory_stats.stats?.cache || 0);
+  const availableMemory = containerStats.memory_stats.limit;
+  memoryUsagePercentage = (usedMemory / availableMemory) * 100.0;
+  memoryUsagePercentageTitle = `${memoryUsagePercentage.toFixed(2)}% (${filesize(usedMemory)})`;
+
+  const cpuDelta = containerStats.cpu_stats.cpu_usage.total_usage - containerStats.precpu_stats.cpu_usage.total_usage;
+  const systemCpuDelta =
+    containerStats.cpu_stats.system_cpu_usage - (containerStats.precpu_stats?.system_cpu_usage || 0);
+  const numberCpus =
+    containerStats.cpu_stats.online_cpus || containerStats.cpu_stats.cpu_usage?.percpu_usage?.length || 1.0;
+  cpuUsagePercentage = (cpuDelta / systemCpuDelta) * numberCpus * 100.0;
+  cpuUsagePercentageTitle = `${cpuUsagePercentage.toFixed(2)}%`;
+}
+
+onMount(async () => {
+  if (container.state !== 'RUNNING') {
+    return;
+  }
+  // grab stats result from the container
+  fetchStatsId = await window.getContainerStats(container.engineId, container.id, updateStatistics);
+});
+
+onDestroy(async () => {
+  // unsubscribe from the store
+  if (fetchStatsId) {
+    await window.stopContainerStats(fetchStatsId);
+  }
+});
+</script>
+
+{#if container.state === 'RUNNING' && memoryUsagePercentage && cpuUsagePercentage}
+  <div class="mt-2 px-1 mx-2 border border-zinc-700 w-[220px] flex flex-row">
+    <svg class="mr-1 text-zinc-400" width="70px" height="40px">
+      <g class="bars">
+        <text text-anchor="end" x="63" y="16" font-size="12px" fill="currentColor">MEMORY </text>
+        <text text-anchor="end" x="63" y="34" font-size="12px" fill="currentColor">CPU</text>
+      </g>
+    </svg>
+    <svg width="150px" height="40px">
+      <g class="bars">
+        <rect fill="currentColor" width="100%" x="0" y="5" height="12"><title>{memoryUsagePercentageTitle}</title></rect
+        >;
+        <rect fill="{memoryColor}" width="{memoryUsagePercentage}%" x="0" y="5" height="12"
+          ><title>{memoryUsagePercentageTitle}</title></rect>
+        <rect fill="currentColor" width="100%" x="0" y="23" height="12"><title>{cpuUsagePercentageTitle}</title></rect>;
+        <rect fill="{cpuColor}" width="{cpuUsagePercentage}%" x="0" y="23" height="12"
+          ><title>{cpuUsagePercentageTitle}</title></rect>
+      </g>
+    </svg>
+  </div>
+{/if}


### PR DESCRIPTION
### What does this PR do?
Add cpu and memory usage statistics

### Screenshot/screencast of this PR

https://user-images.githubusercontent.com/436777/189916277-a403ee32-e07e-49da-9fce-27a0c8d6bdd3.mp4




### What issues does this PR fix or reference?

https://github.com/containers/podman-desktop/issues/331

### How to test this PR?

you can use these commands
`</dev/zero head -c 500m | tail` for memory
install `stress-ng` or `stress` package as well 


Change-Id: I25475ac8c4425e726ec2ce56e07098dab9485022
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
