### PR TITLE
fix: handle status change for libPod API

### DIFF
--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -167,10 +167,14 @@ export class ContainerProviderRegistry {
       if (newStatus !== previousStatus) {
         if (newStatus === 'stopped') {
           internalProvider.api = undefined;
+          internalProvider.libpodApi = undefined;
           this.apiSender.send('provider-change', {});
         }
         if (newStatus === 'started') {
           internalProvider.api = new Dockerode({ socketPath: containerProviderConnection.endpoint.socketPath });
+          if (containerProviderConnection.type === 'podman') {
+            internalProvider.libpodApi = internalProvider.api as unknown as LibPod;
+          }
           this.handleEvents(internalProvider.api);
           this.internalProviders.set(id, internalProvider);
           this.apiSender.send('provider-change', {});


### PR DESCRIPTION
### What does this PR do?
If a machine is started/stopped externally we need to propagate the new state to the libPod API

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

N/A

### How to test this PR?

stop podman machine
launch podman desktop
start podman machine externally (from CLI)
try to run a pod on the CLI. It should appear on the UI


Change-Id: I995be3c6568c25dba3cac74b02222800efde24ba
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
