### PR TITLE
website: fix macos arm64 link

### DIFF
--- a/website/src/pages/downloads/macOS.tsx
+++ b/website/src/pages/downloads/macOS.tsx
@@ -102,7 +102,7 @@ export function MacOSDownloads(): JSX.Element {
                 </Link>
                 <Link
                   className="no-underline hover:no-underline inline-flex text-white hover:text-white bg-purple-500 border-0 py-2 px-6 focus:outline-none hover:bg-purple-600 rounded text-sm"
-                  to={downloadData.x64}>
+                  to={downloadData.arm64}>
                   <FontAwesomeIcon size="1x" icon={faDownload} className="mr-2" />
                   Arm
                 </Link>


### PR DESCRIPTION
### What does this PR do?
Fix arm64 link (was providing the amd64 link)

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Look at the arm64 link

Change-Id: I65e4ef44a80e3c67a2bd352e6ccb5ef3b32248d3
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
