### PR TITLE
fix: we may not be able to get details on short TTL containers

### DIFF
--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -226,11 +226,18 @@ export class ContainerProviderRegistry {
               let StartedAt;
               if (container.State.toUpperCase() === 'RUNNING') {
                 // grab additional field like StartedAt
-                const containerData = providerApi.getContainer(container.Id);
-                const containerInspect = await containerData.inspect();
-                // needs to adjust
-                const correctedDate = moment(containerInspect.State.StartedAt).add(delta, 'milliseconds').toISOString();
-                StartedAt = correctedDate;
+                try {
+                  const containerData = providerApi.getContainer(container.Id);
+                  const containerInspect = await containerData.inspect();
+                  // needs to adjust
+                  const correctedDate = moment(containerInspect.State.StartedAt)
+                    .add(delta, 'milliseconds')
+                    .toISOString();
+                  StartedAt = correctedDate;
+                } catch (error) {
+                  console.debug('Unable to get container, probably container is gone due to a short TTL', error);
+                  StartedAt = '';
+                }
               } else {
                 StartedAt = '';
               }


### PR DESCRIPTION
### What does this PR do?
On short TTL containers, we may not be able to fetch details after fetching the list of containers


### Screenshot/screencast of this PR

![image](https://user-images.githubusercontent.com/436777/191329822-1ae6dd7f-1261-4c74-ace3-1a1a5979ff1f.png)


### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/484

### How to test this PR?

Try to execute trivy extension

Change-Id: Iabf2b969511edae9997ea2935818e24ed2246803
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
