### PR TITLE
fix: path may not be accurate on macOS for Docker Extensions

### DIFF
--- a/packages/main/src/plugin/docker-extension/docker-plugin-adapter.ts
+++ b/packages/main/src/plugin/docker-extension/docker-plugin-adapter.ts
@@ -15,6 +15,8 @@ export interface RawExecResult {
 }
 
 export class DockerPluginAdapter {
+  static MACOS_EXTRA_PATH = '/usr/local/bin:/opt/homebrew/bin:/opt/local/bin:/opt/podman/bin';
+
   constructor(private contributionManager: ContributionManager) {}
 
   filterDockerArgs(cmd: string, args: string[]): string[] {
@@ -43,7 +45,7 @@ export class DockerPluginAdapter {
           env.Path = `${contributionPath}`;
         }
       } else {
-        env.PATH = `${contributionPath}:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin`;
+        env.PATH = `${contributionPath}:${env.PATH}`;
       }
     }
   }
@@ -65,6 +67,10 @@ export class DockerPluginAdapter {
         };
 
         const env = process.env;
+        if (os.platform() === 'darwin' && env.PATH) {
+          env.PATH = env.PATH.concat(':').concat(DockerPluginAdapter.MACOS_EXTRA_PATH);
+        }
+
         // In production mode, applications don't have access to the 'user' path like brew
         return new Promise(resolve => {
           // need to add launcher as command and we move command as the first arg
@@ -126,6 +132,9 @@ export class DockerPluginAdapter {
         let updatedCommand;
         let updatedArgs;
         const env = process.env;
+        if (os.platform() === 'darwin' && env.PATH) {
+          env.PATH = env.PATH.concat(':').concat(DockerPluginAdapter.MACOS_EXTRA_PATH);
+        }
         if (launcher) {
           updatedCommand = launcher;
           updatedArgs = this.filterDockerArgs(cmd, args);


### PR DESCRIPTION
### What does this PR do?
on macOS, electron is not using user PATH
fixes https://github.com/containers/podman-desktop/issues/508

### Screenshot/screencast of this PR

![image](https://user-images.githubusercontent.com/436777/193591278-c942c106-8fc4-4e99-975d-a32d0958a876.png)

![image](https://user-images.githubusercontent.com/436777/193591386-89edad10-04dc-4aad-8fde-912771aa2ec9.png)


### What issues does this PR fix or reference?

#508 

### How to test this PR?

Use production mode, not development mode else for sure it contains the right env/PATH.


Change-Id: I47d65a45eb126bdf36f34eb69fe5a0340566ddf7
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
