### PR TITLE
feat: extension API: allows to register menu in tray not tied to a provider

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -53,6 +53,8 @@ declare module '@tmpwip/extension-api' {
      * Should only be specified for `checkbox` or `radio` type menu items.
      */
     checked?: boolean;
+
+    submenu?: MenuItem[];
   }
 
   export class Disposable {
@@ -341,11 +343,17 @@ declare module '@tmpwip/extension-api' {
 
   export namespace tray {
     /**
-     *
+     * Creates a menu not related to a Provider
+     * @param item the item to add in the tray menu
+     */
+    export function registerMenuItem(item: MenuItem): Disposable;
+
+    /**
+     * Creates a menu in the tray for a given Provider
      * @param providerId the same as the id on Provider provided by createProvider() method, need to place menu item properly
      * @param item
      */
-    export function registerMenuItem(providerId: string, item: MenuItem): Disposable;
+    export function registerProviderMenuItem(providerId: string, item: MenuItem): Disposable;
   }
 
   export namespace configuration {

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -278,8 +278,11 @@ export class ExtensionLoader {
 
     const trayMenuRegistry = this.trayMenuRegistry;
     const tray: typeof containerDesktopAPI.tray = {
-      registerMenuItem(providerId: string, item: containerDesktopAPI.MenuItem): containerDesktopAPI.Disposable {
-        return trayMenuRegistry.registerMenuItem(providerId, item);
+      registerMenuItem(item: containerDesktopAPI.MenuItem): containerDesktopAPI.Disposable {
+        return trayMenuRegistry.registerMenuItem(item);
+      },
+      registerProviderMenuItem(providerId: string, item: containerDesktopAPI.MenuItem): containerDesktopAPI.Disposable {
+        return trayMenuRegistry.registerProviderMenuItem(providerId, item);
       },
     };
     const configurationRegistry = this.configurationRegistry;

--- a/packages/main/src/plugin/tray-menu-registry.ts
+++ b/packages/main/src/plugin/tray-menu-registry.ts
@@ -76,9 +76,9 @@ export class TrayMenuRegistry {
       },
     );
 
-    ipcMain.on('tray:menu-item-click', (_, menuItemId: string) => {
+    ipcMain.on('tray:menu-item-click', (_, menuItemId: string, label: string) => {
       try {
-        this.commandRegistry.executeCommand(menuItemId);
+        this.commandRegistry.executeCommand(menuItemId, label);
       } catch (err) {
         console.error(err);
       }
@@ -137,12 +137,19 @@ export class TrayMenuRegistry {
     );
   }
 
-  registerMenuItem(providerName: string, menuItem: MenuItem): Disposable {
+  registerMenuItem(menuItem: MenuItem): Disposable {
     this.menuItems.set(menuItem.id, menuItem);
-    ipcMain.emit('tray:add-menu-item', '', { providerName, menuItem });
+    ipcMain.emit('tray:add-menu-item', '', { menuItem });
     return Disposable.create(() => {
       this.menuItems.delete(menuItem.id);
-      // TODO: notify main
+    });
+  }
+
+  registerProviderMenuItem(providerName: string, menuItem: MenuItem): Disposable {
+    this.menuItems.set(menuItem.id, menuItem);
+    ipcMain.emit('tray:add-provider-menu-item', '', { providerName, menuItem });
+    return Disposable.create(() => {
+      this.menuItems.delete(menuItem.id);
     });
   }
 

--- a/packages/main/src/tray-menu.ts
+++ b/packages/main/src/tray-menu.ts
@@ -39,43 +39,70 @@ interface ProviderContainerConnectionInfoMenuItem extends ProviderContainerConne
 export class TrayMenu {
   private globalStatus: TrayIconStatus = 'initialized';
 
-  private readonly menuTemplate: MenuItemConstructorOptions[] = [
+  private readonly startMenuTemplate: MenuItemConstructorOptions[] = [
     { type: 'separator' },
     { label: 'Dashboard', click: this.showMainWindow.bind(this) },
+  ];
+  private readonly endMenuTemplate: MenuItemConstructorOptions[] = [
     { type: 'separator' },
     { label: 'Quit', type: 'normal', role: 'quit' },
   ];
+
   private menuProviderItems = new Map<string, ProviderMenuItem>();
+  private menuCustomItems = new Map<string, MenuItemConstructorOptions>();
   private menuContainerProviderConnectionItems = new Map<string, ProviderContainerConnectionInfoMenuItem>();
 
   constructor(private readonly tray: Tray, private readonly animatedTray: AnimatedTray) {
-    ipcMain.on('tray:add-menu-item', (_, param: { providerId: string; menuItem: MenuItemConstructorOptions }) => {
-      param.menuItem.click = () => {
-        ipcMain.emit('tray:menu-item-click', '', param.menuItem.id);
-      };
-      // grab matching provider
-      const provider = Array.from(this.menuProviderItems.values()).find(item => item.id === param.providerId);
-      if (provider) {
-        provider.childItems.push(param.menuItem);
+    ipcMain.on(
+      'tray:add-provider-menu-item',
+      (_, param: { providerId: string; menuItem: MenuItemConstructorOptions }) => {
+        param.menuItem.click = () => {
+          ipcMain.emit('tray:menu-item-click', '', param.menuItem.id);
+        };
+        // grab matching provider
+        const provider = Array.from(this.menuProviderItems.values()).find(item => item.id === param.providerId);
+        if (provider) {
+          provider.childItems.push(param.menuItem);
+          this.updateMenu();
+        } else {
+          this.menuProviderItems.set(param.providerId, {
+            id: param.providerId,
+            internalId: '',
+            childItems: [param.menuItem],
+            name: 'temp',
+            status: 'unknown',
+            containerConnections: [],
+            kubernetesConnections: [],
+            lifecycleMethods: [],
+            detectionChecks: [],
+            version: '',
+            links: [],
+            images: {},
+            installationSupport: false,
+            containerProviderConnectionCreation: false,
+          });
+        }
         this.updateMenu();
-      } else {
-        this.menuProviderItems.set(param.providerId, {
-          id: param.providerId,
-          internalId: '',
-          childItems: [param.menuItem],
-          name: 'temp',
-          status: 'unknown',
-          containerConnections: [],
-          kubernetesConnections: [],
-          lifecycleMethods: [],
-          detectionChecks: [],
-          version: '',
-          links: [],
-          images: {},
-          installationSupport: false,
-          containerProviderConnectionCreation: false,
+      },
+    );
+
+    ipcMain.on('tray:add-menu-item', (_, param: { menuItem: MenuItemConstructorOptions }) => {
+      param.menuItem.click = () => {
+        ipcMain.emit('tray:menu-item-click', '', param.menuItem.id, param.menuItem.label);
+      };
+
+      // add also the click on all submenu items
+      if (Array.isArray(param.menuItem.submenu)) {
+        param.menuItem.submenu.forEach(item => {
+          item.click = () => {
+            ipcMain.emit('tray:menu-item-click', '', item.id, item.label);
+          };
         });
       }
+      this.menuCustomItems.set(param.menuItem.id || 'default', param.menuItem);
+
+      // create menu first time
+      this.updateMenu();
     });
 
     // create menu first time
@@ -175,10 +202,32 @@ export class TrayMenu {
       generatedMenuTemplate.push(this.createProviderMenuItem(item));
     }
     for (const [, item] of this.menuContainerProviderConnectionItems) {
-      generatedMenuTemplate.push(this.createProviderConnectionMenuItem(item));
+      const createdItem = this.createProviderConnectionMenuItem(item);
+      if (createdItem) {
+        generatedMenuTemplate.push(createdItem);
+      }
     }
 
-    generatedMenuTemplate.push(...this.menuTemplate);
+    // add top menu
+    generatedMenuTemplate.push(...this.startMenuTemplate);
+
+    // needs to add an extra separator in case we had custom menu items
+    if (this.menuCustomItems.size > 0) {
+      generatedMenuTemplate.push({ type: 'separator' });
+    }
+
+    // add custom items
+    for (const [, item] of this.menuCustomItems) {
+      generatedMenuTemplate.push(item);
+    }
+
+    // needs to add an extra separator in case we had custom menu items
+    if (this.menuCustomItems.size > 0) {
+      generatedMenuTemplate.push({ type: 'separator' });
+    }
+
+    // add end of the menu (quit)
+    generatedMenuTemplate.push(...this.endMenuTemplate);
 
     const contextMenu = Menu.buildFromTemplate(generatedMenuTemplate);
     this.tray.setContextMenu(contextMenu);


### PR DESCRIPTION
### What does this PR do?
We need to be able to add custom menu items but without provider logic.

Current API was not permitting to add submenu as well on items

### Screenshot/screencast of this PR
example of use-case: 
![image](https://user-images.githubusercontent.com/436777/194523305-872913ac-faa8-4bbb-86dd-3edd3bb421f5.png)

### What issues does this PR fix or reference?

pre-reqs for https://github.com/containers/podman-desktop/issues/521


### How to test this PR?

use the extension API

Change-Id: I6069f9da894b6a3388295c58671f3cdfc91fb399
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
