### PR TITLE
feat: adds a filesystem watcher for extension API

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,14 +82,15 @@
     "@docker/extension-api-client-types": "0.2.3",
     "@types/stream-json": "^1.7.2",
     "analytics-node": "^6.0.0",
+    "chokidar": "^3.5.3",
     "dockerode": "^3.3.1",
     "electron-updater": "4.6.5",
     "getos": "^3.2.1",
+    "got": "^12.3.1",
     "moment": "^2.29.2",
     "os-locale": "^6.0.2",
     "stream-json": "^1.7.4",
-    "tar-fs": "^2.1.1",
-    "got": "^12.3.1"
+    "tar-fs": "^2.1.1"
   },
   "resolutionsComments": {
     "ssh2": "Need to use an old version of ssh2 to avoid vite/rollup issue on loading some internal lib"

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -565,6 +565,31 @@ declare module '@tmpwip/extension-api' {
     hide(): void;
   }
 
+  /**
+   * Resource identifier for a resource
+   */
+  export class Uri {
+    private constructor(scheme: string, authority: string, path: string);
+    static file(path: string): Uri;
+    readonly fsPath: string;
+    readonly authority: string;
+    readonly scheme: string;
+    toString(): string;
+  }
+
+  /**
+   * Notifies changes on files or folders.
+   */
+  export interface FileSystemWatcher extends Disposable {
+    readonly onDidCreate: Event<Uri>;
+    readonly onDidChange: Event<Uri>;
+    readonly onDidDelete: Event<Uri>;
+  }
+
+  export namespace fs {
+    export function createFileSystemWatcher(path: string): FileSystemWatcher;
+  }
+
   export namespace window {
     /**
      * Show an information message. Optionally provide an array of items which will be presented as

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -35,6 +35,8 @@ import type { NotificationImpl } from './notification-impl';
 import { StatusBarItemImpl } from './statusbar/statusbar-item';
 import type { StatusBarRegistry } from './statusbar/statusbar-registry';
 import { StatusBarAlignLeft, StatusBarAlignRight, StatusBarItemDefaultPriority } from './statusbar/statusbar-item';
+import { FilesystemMonitoring } from './filesystem-monitoring';
+import { Uri } from './types/uri';
 
 /**
  * Handle the loading of an extension
@@ -64,6 +66,7 @@ export class ExtensionLoader {
   private activatedExtensions = new Map<string, ActivatedExtension>();
   private analyzedExtensions = new Map<string, AnalyzedExtension>();
   private extensionsStoragePath = '';
+  private fileSystemMonitoring: FilesystemMonitoring;
 
   constructor(
     private commandRegistry: CommandRegistry,
@@ -77,7 +80,9 @@ export class ExtensionLoader {
     private progress: ProgressImpl,
     private notifications: NotificationImpl,
     private statusBarRegistry: StatusBarRegistry,
-  ) {}
+  ) {
+    this.fileSystemMonitoring = new FilesystemMonitoring();
+  }
 
   async listExtensions(): Promise<ExtensionInfo[]> {
     return Array.from(this.analyzedExtensions.values()).map(extension => ({
@@ -235,7 +240,7 @@ export class ExtensionLoader {
     this.analyzedExtensions.set(extension.id, extension);
     const runtime = this.loadRuntime(extension.mainPath);
 
-    return this.activateExtension(extension, runtime);
+    await this.activateExtension(extension, runtime);
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -368,12 +373,21 @@ export class ExtensionLoader {
       },
     };
 
+    const fileSystemMonitoring = this.fileSystemMonitoring;
+    const fs: typeof containerDesktopAPI.fs = {
+      createFileSystemWatcher(path: string): containerDesktopAPI.FileSystemWatcher {
+        return fileSystemMonitoring.createFileSystemWatcher(path);
+      },
+    };
+
     return <typeof containerDesktopAPI>{
       // Types
       Disposable: Disposable,
+      Uri: Uri,
       commands,
       registry,
       provider,
+      fs,
       configuration,
       tray,
       ProgressLocation,

--- a/packages/main/src/plugin/filesystem-monitoring.ts
+++ b/packages/main/src/plugin/filesystem-monitoring.ts
@@ -1,0 +1,68 @@
+/**********************************************************************
+ * Copyright (C) 2022 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type * as containerDesktopAPI from '@tmpwip/extension-api';
+import { Emitter } from './events/emitter';
+import { Disposable } from './types/disposable';
+import * as chokidar from 'chokidar';
+import { Uri } from './types/uri';
+
+export class FileSystemWatcherImpl implements containerDesktopAPI.FileSystemWatcher {
+  constructor(path: string) {
+    // needs to call chokidar
+    const watcher = chokidar.watch(path, {
+      persistent: true,
+    });
+
+    watcher.on('add', (addedPath: string) => {
+      const uri: containerDesktopAPI.Uri = Uri.file(addedPath);
+      this._onDidCreate.fire(uri);
+    });
+
+    watcher.on('change', (addedPath: string) => {
+      const uri: containerDesktopAPI.Uri = Uri.file(addedPath);
+      this._onDidChange.fire(uri);
+    });
+
+    watcher.on('unlink', (addedPath: string) => {
+      const uri: containerDesktopAPI.Uri = Uri.file(addedPath);
+      this._onDidDelete.fire(uri);
+    });
+
+    this._disposable = Disposable.from(this._onDidCreate, this._onDidChange, this._onDidDelete);
+  }
+
+  private _disposable: containerDesktopAPI.Disposable;
+  private readonly _onDidChange = new Emitter<containerDesktopAPI.Uri>();
+  private readonly _onDidCreate = new Emitter<containerDesktopAPI.Uri>();
+  private readonly _onDidDelete = new Emitter<containerDesktopAPI.Uri>();
+
+  readonly onDidChange: containerDesktopAPI.Event<containerDesktopAPI.Uri> = this._onDidChange.event;
+  readonly onDidCreate: containerDesktopAPI.Event<containerDesktopAPI.Uri> = this._onDidCreate.event;
+  readonly onDidDelete: containerDesktopAPI.Event<containerDesktopAPI.Uri> = this._onDidDelete.event;
+
+  dispose(): void {
+    this._disposable.dispose();
+  }
+}
+
+export class FilesystemMonitoring {
+  createFileSystemWatcher(path: string): containerDesktopAPI.FileSystemWatcher {
+    return new FileSystemWatcherImpl(path);
+  }
+}

--- a/packages/main/src/plugin/types/uri.ts
+++ b/packages/main/src/plugin/types/uri.ts
@@ -1,0 +1,42 @@
+/**********************************************************************
+ * Copyright (C) 2022 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/**
+ * Represents a resource that can be manipulated. The resource is identified by a Uri.
+ */
+export class Uri {
+  constructor(private _scheme: string, private _authority: string, private _fsPath: string) {}
+
+  static file(path: string): Uri {
+    return new Uri('file', '', path);
+  }
+  get fsPath(): string {
+    return this._fsPath;
+  }
+  get scheme(): string {
+    return this._scheme;
+  }
+
+  get authority(): string {
+    return this._scheme;
+  }
+
+  toString(): string {
+    return `${this._scheme}://${this._authority}${this._fsPath}`;
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5203,7 +5203,7 @@ cheerio@^1.0.0-rc.12:
 
 chokidar@^3.4.1, chokidar@^3.4.2, chokidar@^3.5.3:
   version "3.5.3"
-  resolved "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.3.tgz#1cf37c8707b932bd1af1ae22c0432e2acd1903bd"
   integrity sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==
   dependencies:
     anymatch "~3.1.2"


### PR DESCRIPTION
### What does this PR do?
Sometimes we need to monitor files and get events when it's created/updated or deleted. By using chokidar it allows to get notified for those.


### Screenshot/screencast of this PR

No UI

### What issues does this PR fix or reference?

pre-req for https://github.com/containers/podman-desktop/issues/521


### How to test this PR?

consume API and check that we can be notified for add/update/delete on files

Change-Id: I6356973a4e853d6aaf76ea8046211b646b044380
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
