### PR TITLE
website: clarify the installation steps on linux

### DIFF
--- a/website/docs/Installation/linux-install.md
+++ b/website/docs/Installation/linux-install.md
@@ -24,13 +24,20 @@ Open the Terminal and go to Downloads directory.
 cd Downloads
 ```
 
+> In order to install & start the application, you need to know the Flatpak identifier for the application. In our case, that is `io.podman_desktop.PodmanDesktop` starting 0.0.6 and `com.github.containers.desktop` for previous versions
+
 Run the following command to install the flatpak application,
 
 ```sh
 flatpak install <name_of_the_flatpak_file> 
 ```
 
-In order to start the application, you need to know the Flatpak identifier for the application. In our case, that is `io.podman_desktop.PodmanDesktop` starting 0.0.6 and `com.github.containers.desktop` for previous versions
+For example:
+
+```sh
+flatpak install io.podman_desktop.PodmanDesktop
+```
+
 
 Run the following command to start the application,
 


### PR DESCRIPTION
### What does this PR do?
Linux install process docs improvement.

Clarifies the installation steps on Linux so that they may be followed chronologically.

Previously the docs didn't state how to get the name of the flatpak file, and was ambiguous. 
Now the flatpak file name is explained early, and an example given.

Care has been taken not to remove the note that versions prior to 0.0.6 use the old name `com.github.containers.desktop`.

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?
na

### How to test this PR?

See docs diff