### PR TITLE
website: exclude some preflights (not all) from tailwind css

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -8,17 +8,25 @@
 @tailwind components;
 @tailwind utilities;
 
-/* Apply default style for markdown
-*/
-h1 {
-  @apply text-4xl font-bold;
+/* Apply default style for markdown*/
+@layer base {
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    font-size: revert;
+    font-weight: revert;
+  }
+  ol,
+  ul {
+    list-style: revert;
+    margin: revert;
+    padding: revert;
+  }
 }
-h2 {
-  @apply text-2xl font-bold;
-}
-h3 {
-  @apply text-xl font-bold;
-}
+
 /*
 Apply style on documentation
 */


### PR DESCRIPTION
### What does this PR do?
By default, tailwind applies default preflight removals https://tailwindcss.com/docs/preflight
But for markdown rendering we need to exclude some of these rules so we have lists having bullets or decimals on the rendering

### Screenshot/screencast of this PR

![image](https://user-images.githubusercontent.com/436777/194822254-8a43c09f-5cc7-49c5-9139-5a162640d0c1.png)


### What issues does this PR fix or reference?

N/A

### How to test this PR?

Look at website rendering


Change-Id: I6e4a32194b25400a9fd1662b9824cb91c833ea39
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
