### PR TITLE
fix: allow to pick-up .yml (in addition to .yaml) file extension on play kube

### DIFF
--- a/packages/renderer/src/lib/container/ContainerPlayKubefile.svelte
+++ b/packages/renderer/src/lib/container/ContainerPlayKubefile.svelte
@@ -71,7 +71,10 @@ onDestroy(() => {
 });
 
 async function getKubernetesfileLocation() {
-  const result = await window.openFileDialog('Select .YAML file to play', { name: 'YAML files', extensions: ['yaml'] });
+  const result = await window.openFileDialog('Select .YAML file to play', {
+    name: 'YAML files',
+    extensions: ['yaml', 'yml'],
+  });
   if (!result.canceled && result.filePaths.length === 1) {
     kubernetesYamlFilePath = result.filePaths[0];
     hasInvalidFields = false;


### PR DESCRIPTION
### What does this PR do?
Allows .yml in addition to .yaml

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/538


### How to test this PR?

Try to select a .yml file

Change-Id: I36bc3093ca374dbb0cf0db75c90f961808442fb6
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
