### PR TITLE
Website: Changes colours of site for more contrast / readability

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "typecheck:preload": "tsc --noEmit -p packages/preload/tsconfig.json",
     "typecheck:renderer": "npm run build:preload:types",
     "typecheck": "npm run typecheck:main && npm run typecheck:preload && npm run typecheck:renderer",
-    "website:build": "cd website && yarn run docusaurus build"
+    "website:build": "cd website && yarn run docusaurus build",
+    "website:dev": "cd website && yarn run start"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^21.0.1",

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -41,24 +41,24 @@ Apply style on documentation
 /* You can override the default Infima variables here. */
 :root {
   --ifm-color-primary: #6d28d9;
-  --ifm-color-primary-dark: #7c3aed;
+  --ifm-color-primary-dark: #6223c5;
   --ifm-color-primary-darker: #5c21ba;
   --ifm-color-primary-darkest: #4c1b99;
   --ifm-color-primary-light: #7c3edd;
   --ifm-color-primary-lighter: #8349df;
-  --ifm-color-primary-lightest: #996ae5;
+  --ifm-color-primary-lightest: #8b54e1;
   --ifm-code-font-size: 95%;
 }
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */
 [data-theme='dark'] {
-  --ifm-color-primary: #a778fa;
-  --ifm-color-primary-dark: #7c3aed;
-  --ifm-color-primary-darker: #5c21ba;
-  --ifm-color-primary-darkest: #4c1b99;
-  --ifm-color-primary-light: #7c3edd;
-  --ifm-color-primary-lighter: #8349df;
-  --ifm-color-primary-lightest: #996ae5;
+  --ifm-color-primary: #e5dbf5;
+  --ifm-color-primary-dark: #cbb7eb;
+  --ifm-color-primary-darker: #bea5e6;
+  --ifm-color-primary-darkest: #966ed7;
+  --ifm-color-primary-light: #ffffff;
+  --ifm-color-primary-lighter: #ffffff;
+  --ifm-color-primary-lightest: #ffffff;
 }
 
 .docusaurus-highlight-code-line {


### PR DESCRIPTION
Changes colours of site for more contrast / readability

### What does this PR do?

* Changes the website to use more contrasting colour for readibility with
the purple.

* If you use the current colour codes against Infinima on the docusaurus
site, it is failing the "contrast check".

* Adds `yarn run website:dev` testing the site / looking for active
  changes instead of building

### Screenshot/screencast of this PR

See below for updated colour codes that pass the docusaurus Infinima
contrast check.

![Screen Shot 2022-10-11 at 12 30 08 PM](https://user-images.githubusercontent.com/6422176/195150631-bb7ebe9b-726b-4096-b827-a768725a45c1.png)

![Screen Shot 2022-10-11 at 12 32 50 PM](https://user-images.githubusercontent.com/6422176/195150652-0f920193-4f64-462d-acc4-6d73ed697575.png)


### What issues does this PR fix or reference?

See: https://docusaurus.io/docs/styling-layout#styling-your-site-with-infima

The readibility of the purple against the gray background / black is too
light (and sometimes too dark) for me to be able to read it clearly.

N/A (let me know if I should open up issues for anything minor like
this!)

### How to test this PR?

<!-- Please explain steps to reproduce -->

Run `yarn run website:dev`

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
