### PR TITLE
feat: add pod details when clicking on a pod

### DIFF
--- a/packages/main/src/plugin/api/pod-info.ts
+++ b/packages/main/src/plugin/api/pod-info.ts
@@ -17,8 +17,14 @@
  ***********************************************************************/
 
 import type { PodInfo as LibPodPodInfo } from '../dockerode/libpod-dockerode';
+import type { PodInspectInfo as LibPodPodInspectInfo } from '../dockerode/libpod-dockerode';
 
 export interface PodInfo extends LibPodPodInfo {
+  engineId: string;
+  engineName: string;
+}
+
+export interface PodInspectInfo extends LibPodPodInspectInfo {
   engineId: string;
   engineName: string;
 }

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -60,7 +60,7 @@ import type { StatusBarEntryDescriptor } from './statusbar/statusbar-registry';
 import type { IpcMainInvokeEvent } from 'electron/main';
 import type { ContainerInspectInfo } from './api/container-inspect-info';
 import type { HistoryInfo } from './api/history-info';
-import type { PodInfo } from './api/pod-info';
+import type { PodInfo, PodInspectInfo } from './api/pod-info';
 import type { VolumeInspectInfo, VolumeListInfo } from './api/volume-info';
 import type { ContainerStatsInfo } from './api/container-stats-info';
 import type { PlayKubeInfo } from './dockerode/libpod-dockerode';
@@ -337,6 +337,12 @@ export class PluginSystem {
       'container-provider-registry:getContainerInspect',
       async (_listener, engine: string, containerId: string): Promise<ContainerInspectInfo> => {
         return containerProviderRegistry.getContainerInspect(engine, containerId);
+      },
+    );
+    this.ipcHandle(
+      'container-provider-registry:getPodInspect',
+      async (_listener, engine: string, podId: string): Promise<PodInspectInfo> => {
+        return containerProviderRegistry.getPodInspect(engine, podId);
       },
     );
     this.ipcHandle(

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -27,7 +27,7 @@ import type { ContainerCreateOptions, ContainerInfo } from '../../main/src/plugi
 import type { ContributionInfo } from '../../main/src/plugin/api/contribution-info';
 import type { ImageInfo } from '../../main/src/plugin/api/image-info';
 import type { VolumeInspectInfo, VolumeListInfo } from '../../main/src/plugin/api/volume-info';
-import type { PodInfo } from '../../main/src/plugin/api/pod-info';
+import type { PodInfo, PodInspectInfo } from '../../main/src/plugin/api/pod-info';
 import type { ImageInspectInfo } from '../../main/src/plugin/api/image-inspect-info';
 import type { HistoryInfo } from '../../main/src/plugin/api/history-info';
 import type { ContainerInspectInfo } from '../../main/src/plugin/api/container-inspect-info';
@@ -299,6 +299,10 @@ function initExposure(): void {
       return ipcInvoke('container-provider-registry:getContainerInspect', engine, containerId);
     },
   );
+
+  contextBridge.exposeInMainWorld('getPodInspect', async (engine: string, podId: string): Promise<PodInspectInfo> => {
+    return ipcInvoke('container-provider-registry:getPodInspect', engine, podId);
+  });
 
   let onDataCallbacksGetContainerStatsId = 0;
   const onDataCallbacksGetContainerStats = new Map<number, (containerStats: ContainerStatsInfo) => void>();

--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -30,6 +30,7 @@ import AppNavigation from './AppNavigation.svelte';
 import VolumesList from './lib/volume/VolumesList.svelte';
 import VolumeDetails from './lib/volume/VolumeDetails.svelte';
 import ContainerPlayKubefile from './lib/container/ContainerPlayKubefile.svelte';
+import PodDetails from './lib/pod/PodDetails.svelte';
 
 router.mode.hash();
 
@@ -114,6 +115,9 @@ window.events?.receive('display-help', () => {
         </Route>
         <Route path="/pods">
           <PodsList />
+        </Route>
+        <Route path="/pods/:name/:engineId/*" let:meta>
+          <PodDetails podName="{decodeURI(meta.params.name)}" engineId="{decodeURI(meta.params.engineId)}" />
         </Route>
         <Route path="/volumes">
           <VolumesList />

--- a/packages/renderer/src/lib/pod/PodActions.svelte
+++ b/packages/renderer/src/lib/pod/PodActions.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { faPlayCircle } from '@fortawesome/free-solid-svg-icons';
+import { faFileCode, faPlayCircle } from '@fortawesome/free-solid-svg-icons';
 import { faStopCircle } from '@fortawesome/free-solid-svg-icons';
 import { faArrowsRotate } from '@fortawesome/free-solid-svg-icons';
 import { faTrash } from '@fortawesome/free-solid-svg-icons';
@@ -26,8 +26,17 @@ async function removePod(podInfoUI: PodInfoUI): Promise<void> {
   await window.removePod(podInfoUI.engineId, podInfoUI.id);
   router.goto('/pods/');
 }
+
+function openGenerateKube(): void {
+  router.goto(`/pods/${encodeURI(pod.name)}/${encodeURI(pod.engineId)}/kube`);
+}
 </script>
 
+<ListItemButtonIcon
+  title="Generate Kube"
+  onClick="{() => openGenerateKube()}"
+  backgroundColor="{backgroundColor}"
+  icon="{faFileCode}" />
 <ListItemButtonIcon
   title="Start Pod"
   onClick="{() => startPod(pod)}"

--- a/packages/renderer/src/lib/pod/PodDetails.svelte
+++ b/packages/renderer/src/lib/pod/PodDetails.svelte
@@ -1,0 +1,122 @@
+<script lang="ts">
+import { Route } from 'tinro';
+import { onDestroy, onMount } from 'svelte';
+import type { PodInfoUI } from './PodInfoUI';
+import { PodUtils } from './pod-utils';
+import type { Unsubscriber } from 'svelte/store';
+import { podsInfos } from '../../stores/pods';
+import PodActions from './PodActions.svelte';
+import PodDetailsSummary from './PodDetailsSummary.svelte';
+import PodDetailsInspect from './PodDetailsInspect.svelte';
+import PodDetailsKube from './PodDetailsKube.svelte';
+
+export let podName: string;
+export let engineId: string;
+
+let pod: PodInfoUI;
+let podUnsubscribe: Unsubscriber;
+
+onMount(() => {
+  const podUtils = new PodUtils();
+  // loading volume info
+  podUnsubscribe = podsInfos.subscribe(pods => {
+    const matchingPod = pods.find(podInPods => podInPods.Name === podName && podInPods.engineId === engineId);
+    if (matchingPod) {
+      try {
+        pod = podUtils.getPodInfoUI(matchingPod);
+      } catch (err) {
+        console.error(err);
+      }
+    }
+  });
+});
+
+onDestroy(() => {
+  if (podUnsubscribe) {
+    podUnsubscribe();
+  }
+});
+</script>
+
+{#if pod}
+  <Route path="/*" let:meta>
+    <div class="w-full h-full">
+      <div class="flex h-full flex-col">
+        <div class="flex w-full flex-row">
+          <div class="w-full  px-5 pt-5">
+            <div class="flex flew-row items-center">
+              <a class="text-violet-400 text-base hover:no-underline" href="/pods" title="Go back to pods list">Pods</a>
+              <div class="text-xl mx-2 text-gray-400">></div>
+              <div class="text-sm font-extralight text-gray-400">Pod Details</div>
+            </div>
+            <div class="text-lg flex flex-row items-center">
+              <p class="mx-2">{pod.name}</p>
+            </div>
+            <div class="mx-2 pb-4 text-small text-gray-500">{pod.id}</div>
+
+            <section class="pf-c-page__main-tabs pf-m-limit-width">
+              <div class="pf-c-page__main-body">
+                <div class="pf-c-tabs pf-m-page-insets" id="open-tabs-example-tabs-list">
+                  <ul class="pf-c-tabs__list">
+                    <li
+                      class="pf-c-tabs__item"
+                      class:pf-m-current="{meta.url ===
+                        `/pods/${encodeURI(pod.name)}/${encodeURI(pod.engineId)}/summary`}">
+                      <a
+                        href="/pods/${encodeURI(pod.name)}/${encodeURI(pod.engineId)}/summary"
+                        class="pf-c-tabs__link"
+                        aria-controls="open-tabs-example-tabs-list-details-panel"
+                        id="open-tabs-example-tabs-list-details-link">
+                        <span class="pf-c-tabs__item-text">Summary</span>
+                      </a>
+                    </li>
+                    <li
+                      class="pf-c-tabs__item"
+                      class:pf-m-current="{meta.url ===
+                        `/pods/${encodeURI(pod.name)}/${encodeURI(pod.engineId)}/inspect`}">
+                      <a
+                        href="/pods/${encodeURI(pod.name)}/${encodeURI(pod.engineId)}/inspect"
+                        class="pf-c-tabs__link"
+                        aria-controls="open-tabs-example-tabs-list-yaml-panel"
+                        id="open-tabs-example-tabs-list-yaml-link">
+                        <span class="pf-c-tabs__item-text">Inspect</span>
+                      </a>
+                    </li>
+                    <li
+                      class="pf-c-tabs__item"
+                      class:pf-m-current="{meta.url ===
+                        `/pods/${encodeURI(pod.name)}/${encodeURI(pod.engineId)}/kube`}">
+                      <a
+                        href="/pods/${encodeURI(pod.name)}/${encodeURI(pod.engineId)}/kube"
+                        class="pf-c-tabs__link"
+                        aria-controls="open-tabs-example-tabs-list-yaml-panel"
+                        id="open-tabs-example-tabs-list-yaml-link">
+                        <span class="pf-c-tabs__item-text">Kube</span>
+                      </a>
+                    </li>
+                  </ul>
+                </div>
+              </div>
+            </section>
+          </div>
+          <div class="flex flex-row-reverse w-full  px-5 pt-5">
+            <div class="flex h-10">
+              <PodActions pod="{pod}" backgroundColor="bg-neutral-900" />
+            </div>
+          </div>
+          <a href="/containers" title="Close Details" class="mt-2 mr-2 text-gray-500"
+            ><i class="fas fa-times" aria-hidden="true"></i></a>
+        </div>
+        <Route path="/summary">
+          <PodDetailsSummary pod="{pod}" />
+        </Route>
+        <Route path="/inspect">
+          <PodDetailsInspect pod="{pod}" />
+        </Route>
+        <Route path="/kube">
+          <PodDetailsKube pod="{pod}" />
+        </Route>
+      </div>
+    </div>
+  </Route>
+{/if}

--- a/packages/renderer/src/lib/pod/PodDetailsInspect.svelte
+++ b/packages/renderer/src/lib/pod/PodDetailsInspect.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+import { onMount } from 'svelte';
+import MonacoEditor from '../editor/MonacoEditor.svelte';
+import type { PodInfoUI } from './PodInfoUI';
+
+export let pod: PodInfoUI;
+
+let inspectDetails: string;
+
+onMount(async () => {
+  // grab inspect result from the container
+  const inspectResult = await window.getPodInspect(pod.engineId, pod.id);
+  // remove engine* properties from the inspect result as it's more internal
+  delete inspectResult.engineId;
+  delete inspectResult.engineName;
+
+  inspectDetails = JSON.stringify(inspectResult, null, 2);
+});
+</script>
+
+{#if inspectDetails}
+  <MonacoEditor content="{inspectDetails}" language="json" />
+{/if}

--- a/packages/renderer/src/lib/pod/PodDetailsKube.svelte
+++ b/packages/renderer/src/lib/pod/PodDetailsKube.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+import { onMount } from 'svelte';
+import MonacoEditor from '../editor/MonacoEditor.svelte';
+
+import type { PodInfoUI } from './PodInfoUI';
+export let pod: PodInfoUI;
+
+let kubeDetails: string;
+
+onMount(async () => {
+  // grab kube result from the pod
+  const kubeResult = await window.generatePodmanKube(pod.engineId, [pod.id]);
+  kubeDetails = kubeResult;
+});
+</script>
+
+{#if kubeDetails}
+  <MonacoEditor content="{kubeDetails}" language="yaml" />
+{/if}

--- a/packages/renderer/src/lib/pod/PodDetailsSummary.svelte
+++ b/packages/renderer/src/lib/pod/PodDetailsSummary.svelte
@@ -1,0 +1,46 @@
+<script lang="ts">
+import { router } from 'tinro';
+
+import { getPanelDetailColor } from '../color/color';
+import type { PodInfoUI } from './PodInfoUI';
+
+export let pod: PodInfoUI;
+
+function openContainer(containerID: string) {
+  router.goto(`/containers/${containerID}/logs`);
+}
+</script>
+
+<div class="h-full" style="background-color: {getPanelDetailColor()}">
+  <div class="flex py-4 flex-col">
+    <div class="w-full">
+      <table class="h-2 font-thin text-xs">
+        <tr>
+          <td class="px-2">Name</td>
+          <td class="px-2 font-thin text-xs">{pod.name}</td>
+        </tr>
+        <tr>
+          <td class="px-2">Size</td>
+          <td class="px-2 font-thin text-xs">{pod.id}</td>
+        </tr>
+        <tr>
+          <td class="px-2">Created</td>
+          <td class="px-2 font-thin text-xs">{pod.humanCreationDate}</td>
+        </tr>
+      </table>
+    </div>
+    {#if pod.containers.length > 0}
+      <div class="w-full my-4 p-2">
+        <span class="font-bold text-xs">Containers using this pod:</span>
+        <table class="h-2 font-thin text-xs">
+          {#each pod.containers as container}
+            <tr class="cursor-pointer" on:click="{() => openContainer(container.Id)}">
+              <td class="px-2 font-thin text-xs">{container.Names}</td>
+              <td class="px-2 font-thin text-xs">{container.Id}</td>
+            </tr>
+          {/each}
+        </table>
+      </div>
+    {/if}
+  </div>
+</div>

--- a/packages/renderer/src/lib/pod/PodsList.svelte
+++ b/packages/renderer/src/lib/pod/PodsList.svelte
@@ -4,7 +4,7 @@ import { onDestroy, onMount } from 'svelte';
 import { router } from 'tinro';
 import type { Unsubscriber } from 'svelte/store';
 import type { PodInfoUI } from './PodInfoUI';
-import { filtered, searchPattern, podsInfos } from '../../stores/pods';
+import { filtered, searchPattern } from '../../stores/pods';
 import { providerInfos } from '../../stores/providers';
 import NavPage from '../ui/NavPage.svelte';
 import { PodUtils } from './pod-utils';
@@ -96,6 +96,10 @@ async function deleteSelectedPods() {
 }
 
 function openDetailsPod(pod: PodInfoUI) {
+  router.goto(`/pods/${encodeURI(pod.name)}/${encodeURI(pod.engineId)}/summary`);
+}
+
+function openContainersFromPod(pod: PodInfoUI) {
   router.goto(`/containers/?filter=${pod.shortId}`);
 }
 </script>
@@ -175,7 +179,7 @@ function openDetailsPod(pod: PodInfoUI) {
                 <PodIcon colorClasses="" />
               </div>
             </td>
-            <td class="whitespace-nowrap  w-10">
+            <td class="whitespace-nowrap w-10 hover:cursor-pointer" on:click="{() => openDetailsPod(pod)}">
               <div class="flex items-center">
                 <div class="">
                   <div class="flex flex-row items-center">
@@ -186,7 +190,7 @@ function openDetailsPod(pod: PodInfoUI) {
                     <div
                       class="ml-1 text-xs font-extra-light text-gray-500"
                       class:cursor-pointer="{pod.containers.length > 0}"
-                      on:click="{() => openDetailsPod(pod)}">
+                      on:click="{() => openContainersFromPod(pod)}">
                       {pod.containers.length} containers
                     </div>
                   </div>


### PR DESCRIPTION

### What does this PR do?
Provides summary, inspect and 'generate kube' tabs

### Screenshot/screencast of this PR


https://user-images.githubusercontent.com/436777/195282864-ebc338c5-f6a6-41e0-b20b-34fcba58cc7f.mp4



### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/518


### How to test this PR?

Start a pod, then click on the pod in pod list, it should open the details of the pod.


Change-Id: Ia026277b72dbdfd5ec6eae0ff1641ada593bd686
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
