### PR TITLE
chore: adds `website:dev` command to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "typecheck:preload": "tsc --noEmit -p packages/preload/tsconfig.json",
     "typecheck:renderer": "npm run build:preload:types",
     "typecheck": "npm run typecheck:main && npm run typecheck:preload && npm run typecheck:renderer",
-    "website:build": "cd website && yarn run docusaurus build"
+    "website:build": "cd website && yarn run docusaurus build",
+    "website:dev": "cd website && yarn run docusaurus start"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^21.0.1",


### PR DESCRIPTION
Adds `website:dev` command to package.json

### What does this PR do?

Very small nitpick!

I'd like to run `yarn run website:dev` to use docusaurus in dev mode /
watch mode.

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

N/A

### What issues does this PR fix or reference?

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

N/A

### How to test this PR?

<!-- Please explain steps to reproduce -->

Run `yarn run website:dev`

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
