### PR TITLE
chore: update to electron 21.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@typescript-eslint/parser": "^5.30.7",
     "cross-env": "7.0.3",
     "dts-for-context-bridge": "0.7.1",
-    "electron": "^20.0.0",
+    "electron": "^21.1.1",
     "electron-builder": "23.0.9",
     "electron-builder-notarize": "^1.5.0",
     "electron-devtools-installer": "^3.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6341,10 +6341,10 @@ electron-updater@4.6.5:
     lodash.isequal "^4.5.0"
     semver "^7.3.5"
 
-electron@^20.0.0:
-  version "20.0.0"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-20.0.0.tgz#c15a441341380effda071515d8b9c88a11e2a9c4"
-  integrity sha512-rPHTdjBKGSoLgGuJVsqDgmK9woDQxzlU18H+3cO4i+fNh29BMbFRwKKyit13lniO1hzRsEJDG5UKvFXs4vEpnA==
+electron@^21.1.1:
+  version "21.1.1"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-21.1.1.tgz#3ee427e31cccafbce45bebd32f2a8eba9e3399ca"
+  integrity sha512-EM2hvRJtiS3n54yx25Z0Qv54t3LGG+WjUHf1AOl+PKjQj+fmXnjIgVeIF9pM21kP1BTcyjrgvN6Sff0A45OB6A==
   dependencies:
     "@electron/get" "^1.14.1"
     "@types/node" "^16.11.26"


### PR DESCRIPTION
### What does this PR do?
stay up-to-date with electron 21

it will allow to use immersive dark mode on Windows

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

N/A

### How to test this PR?

check app is running

Change-Id: I6643b9125306f713ae2b045ba599d7d5d5b94466
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
