### PR TITLE
chore: rename page from Preferences to Settings

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesPage.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesPage.svelte
@@ -31,7 +31,7 @@ onMount(async () => {
 });
 </script>
 
-<NavPage searchEnabled="{false}" title="Preferences" subtitle="&nbsp;">
+<NavPage searchEnabled="{false}" title="Settings" subtitle="&nbsp;">
   <div slot="empty" class="flex h-full px-3 py-3 bg-zinc-700">
     <Route path="/">
       {#if defaultPrefPageId !== undefined}


### PR DESCRIPTION

### What does this PR do?
To be consistent with new Settings page, it should use the `Settings` title, not `Preferences`

### Screenshot/screencast of this PR

![image](https://user-images.githubusercontent.com/436777/195616097-4709b75e-1b34-4ca0-9e8f-d5927b9aa5f4.png)

### What issues does this PR fix or reference?



### How to test this PR?

N/A

Change-Id: I32240e34e6ae2a6f0b819094e17cd01623a0ec05
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
