### PR TITLE
fix: Make sure we correctly detect registry from an image name

### DIFF
--- a/packages/main/src/plugin/image-registry.spec.ts
+++ b/packages/main/src/plugin/image-registry.spec.ts
@@ -84,3 +84,35 @@ test('Should extract auth registry with Amazon ECR registry', async () => {
   expect(authInfo?.service).toBe('ecr.amazonaws.com');
   expect(authInfo?.scope).toBeUndefined();
 });
+
+test('should map short name to hub server', () => {
+  const registryServer = imageRegistry.extractRegistryServerFromImage('mysql');
+  expect(registryServer).toBe('docker.io');
+});
+
+test('should map short name with tag to hub server', () => {
+  const registryServer = imageRegistry.extractRegistryServerFromImage('mysql:latest');
+  expect(registryServer).toBe('docker.io');
+});
+
+test('should map localhost with port registry', () => {
+  const registryServer = imageRegistry.extractRegistryServerFromImage('localhost:5000/myimage');
+  expect(registryServer).toBe('localhost:5000');
+});
+
+test('should map localhost registry', () => {
+  const registryServer = imageRegistry.extractRegistryServerFromImage('localhost/myimage');
+  expect(registryServer).toBe('localhost');
+});
+
+test('should map quay registry', () => {
+  const registryServer = imageRegistry.extractRegistryServerFromImage('quay.io/podman/hello');
+  expect(registryServer).toBe('quay.io');
+});
+
+test('should map ecr', () => {
+  const registryServer = imageRegistry.extractRegistryServerFromImage(
+    '12345.dkr.ecr.us-east-1.amazonaws.com/podman-desktop',
+  );
+  expect(registryServer).toBe('12345.dkr.ecr.us-east-1.amazonaws.com');
+});

--- a/packages/main/src/plugin/image-registry.ts
+++ b/packages/main/src/plugin/image-registry.ts
@@ -50,18 +50,25 @@ export class ImageRegistry {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   constructor(private apiSender: any, private telemetryService: Telemetry) {}
 
-  getAuthconfigForImage(imageName: string): Dockerode.AuthConfig | undefined {
-    // do we have some auth for this image
-    // try to extract registry part from the image
-
-    // no / in the imageName
-    let registryServer: string | undefined;
-    if (imageName.indexOf('/') === -1 || imageName.split('/').length == 2) {
-      registryServer = 'docker.io';
-    } else if (imageName.split('/').length == 3) {
+  extractRegistryServerFromImage(imageName: string): string | undefined {
+    // check if image is a valid identifier for dockerhub
+    const splitParts = imageName.split('/');
+    if (
+      splitParts.length === 1 ||
+      (!splitParts[0].includes('.') && !splitParts[0].includes(':') && splitParts[0] != 'localhost')
+    ) {
+      return 'docker.io';
+    } else {
       // if image name contains two /, we assume there is a registry at the beginning
-      registryServer = imageName.split('/')[0];
+      return splitParts[0];
     }
+  }
+
+  /**
+   * Provides authentication information for the given image if any.
+   */
+  getAuthconfigForImage(imageName: string): Dockerode.AuthConfig | undefined {
+    const registryServer = this.extractRegistryServerFromImage(imageName);
     let authconfig;
     if (registryServer) {
       const matchingUrl = registryServer;


### PR DESCRIPTION
### What does this PR do?
For now we may not detect that images are from an external server, assuming it's coming from default hub

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?
fixes https://github.com/containers/podman-desktop/issues/648

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

### How to test this PR?

Unit tests + check that providing different format of image name in "pull image" screen is working on private images
