### PR TITLE
feat: pod Actions to list of containers

### DIFF
--- a/packages/main/src/plugin/api/container-info.ts
+++ b/packages/main/src/plugin/api/container-info.ts
@@ -27,7 +27,7 @@ export interface ContainerInfo extends Dockerode.ContainerInfo {
     id: string;
     name: string;
     status: string;
-    engineID: string;
+    engineId: string;
   };
 }
 

--- a/packages/main/src/plugin/api/container-info.ts
+++ b/packages/main/src/plugin/api/container-info.ts
@@ -27,6 +27,7 @@ export interface ContainerInfo extends Dockerode.ContainerInfo {
     id: string;
     name: string;
     status: string;
+    engineID: string;
   };
 }
 

--- a/packages/renderer/src/lib/ContainerList.svelte
+++ b/packages/renderer/src/lib/ContainerList.svelte
@@ -361,7 +361,6 @@ function toggleAllContainerGroups(value: boolean) {
               </td>
               <td class="px-6 whitespace-nowrap">
                 <div class="flex flex-row justify-end opacity-0 group-hover:opacity-100">
-                  <!-- TODO: Figure out how to correctly pass in the id / engineid in a proper Typescript way. -->
                   <!-- Only show POD actions if the container group is POD, otherwise keep blank / empty (for future compose implementation) -->
                   {#if containerGroup.type === ContainerGroupInfoTypeUI.POD}
                     <PodActions

--- a/packages/renderer/src/lib/ContainerList.svelte
+++ b/packages/renderer/src/lib/ContainerList.svelte
@@ -362,8 +362,11 @@ function toggleAllContainerGroups(value: boolean) {
               <td class="px-6 whitespace-nowrap">
                 <div class="flex flex-row justify-end opacity-0 group-hover:opacity-100">
                   <!-- TODO: Figure out how to correctly pass in the id / engineid in a proper Typescript way. -->
-                  <PodActions
-                    pod="{{ id: containerGroup.id, name: containerGroup.name, engineId: containerGroup.engineId }}" />
+                  <!-- Only show POD actions if the container group is POD, otherwise keep blank / empty (for future compose implementation) -->
+                  {#if containerGroup.type === ContainerGroupInfoTypeUI.POD}
+                    <PodActions
+                      pod="{{ id: containerGroup.id, name: containerGroup.name, engineId: containerGroup.engineId }}" />
+                  {/if}
                 </div>
               </td>
             </tr>

--- a/packages/renderer/src/lib/ContainerList.svelte
+++ b/packages/renderer/src/lib/ContainerList.svelte
@@ -4,9 +4,11 @@ import { filtered, searchPattern } from '../stores/containers';
 
 import type { ContainerInfo } from '../../../../main/src/plugin/api/container-info';
 import ContainerIcon from './ContainerIcon.svelte';
+import type { PodInfoUI } from '../pod/PodInfoUI';
 import { router } from 'tinro';
 import { ContainerGroupInfoTypeUI, ContainerGroupInfoUI, ContainerInfoUI } from './container/ContainerInfoUI';
 import ContainerActions from './container/ContainerActions.svelte';
+import PodActions from './pod/PodActions.svelte';
 import ContainerEmptyScreen from './container/ContainerEmptyScreen.svelte';
 import Modal from './dialogs/Modal.svelte';
 import { ContainerUtils } from './container/container-utils';
@@ -320,7 +322,7 @@ function toggleAllContainerGroups(value: boolean) {
       {#each containerGroups as containerGroup}
         <tbody>
           {#if containerGroup.type === ContainerGroupInfoTypeUI.COMPOSE || containerGroup.type === ContainerGroupInfoTypeUI.POD}
-            <tr class="h-10 group">
+            <tr class="group h-12 bg-zinc-900 hover:bg-zinc-700">
               <td
                 class="bg-zinc-900 group-hover:bg-zinc-700 pl-2 w-3 rounded-tl-lg"
                 class:rounded-bl-lg="{!containerGroup.expanded}"
@@ -330,23 +332,17 @@ function toggleAllContainerGroups(value: boolean) {
                   class="text-gray-400 cursor-pointer"
                   icon="{containerGroup.expanded ? faChevronDown : faChevronRight}" />
               </td>
-              <td class="px-2 w-5 bg-zinc-900 group-hover:bg-zinc-700">
+              <td class="px-2">
                 <input
                   type="checkbox"
                   on:click="{event => toggleCheckboxContainerGroup(event.currentTarget.checked, containerGroup)}"
                   bind:checked="{containerGroup.selected}"
                   class=" cursor-pointer invert hue-rotate-[218deg] brightness-75" />
               </td>
-              <td
-                class="bg-zinc-900 group-hover:bg-zinc-700 flex flex-row justify-center h-12"
-                title="{containerGroup.type}">
+              <td class="flex flex-row justify-center h-12" title="{containerGroup.type}">
                 <ContainerGroupIcon type="{containerGroup.type}" containers="{containerGroup.containers}" />
               </td>
-              <td
-                colspan="4"
-                class="bg-zinc-900 group-hover:bg-zinc-700 rounded-tr-lg {!containerGroup.expanded
-                  ? 'rounded-br-lg'
-                  : ''}">
+              <td class="whitespace-nowrap hover:cursor-pointer {!containerGroup.expanded ? 'rounded-br-lg' : ''}">
                 <div class="flex items-center text-sm text-gray-200 overflow-hidden text-ellipsis">
                   <div class="flex flex-col flex-nowrap">
                     <div class="text-sm text-gray-200 overflow-hidden text-ellipsis" title="{containerGroup.type}">
@@ -356,6 +352,18 @@ function toggleAllContainerGroups(value: boolean) {
                       {containerGroup.containers.length} container{containerGroup.containers.length > 1 ? 's' : ''}
                     </div>
                   </div>
+                </div>
+              </td>
+              <td class="px-6 py-2 whitespace-nowrap w-10">
+                <div class="flex items-center">
+                  <div class="ml-2 text-sm text-gray-400"></div>
+                </div>
+              </td>
+              <td class="px-6 whitespace-nowrap">
+                <div class="flex flex-row justify-end opacity-0 group-hover:opacity-100">
+                  <!-- TODO: Figure out how to correctly pass in the id / engineid in a proper Typescript way. -->
+                  <PodActions
+                    pod="{{ id: containerGroup.id, name: containerGroup.name, engineId: containerGroup.engineId }}" />
                 </div>
               </td>
             </tr>

--- a/packages/renderer/src/lib/container/ContainerInfoUI.ts
+++ b/packages/renderer/src/lib/container/ContainerInfoUI.ts
@@ -24,10 +24,14 @@ export enum ContainerGroupInfoTypeUI {
 }
 
 export interface ContainerGroupPartInfoUI {
-  // name of this group
+  // The name and type of each group
   name: string;
-
   type: ContainerGroupInfoTypeUI;
+
+  // Information regarding the entire group (ex. name of the pod)
+  // as well as the "engine" running the group (ex. podman or docker)
+  id?: string;
+  engineId?: string;
 }
 
 export interface ContainerInfoUI {

--- a/packages/renderer/src/lib/container/container-utils.ts
+++ b/packages/renderer/src/lib/container/container-utils.ts
@@ -138,6 +138,8 @@ export class ContainerUtils {
       return {
         name: podInfo.name,
         type: ContainerGroupInfoTypeUI.POD,
+        id: podInfo.id,
+        engineId: containerInfo.engineId,
       };
     }
 
@@ -163,6 +165,8 @@ export class ContainerUtils {
             expanded: true,
             name: group.name,
             type: group.type,
+            id: group.id,
+            engineId: group.engineId,
             containers: [],
           });
         }


### PR DESCRIPTION
Add Pod Actions to list of containers

### What does this PR do?

* Adds Pod actions to the container list, when hovering over the grouped list, you're now able to execute actions (start, stop, delete, convert to k8s yaml)
* Modifies the CSS slightly so the first grouped option has the same format (the css was different vs child elements)

This implementation also modifies multiple interface's for the future implementation of compose functionality, specifically adding `engineid` and `id` to the "group" interface so that we can correctly retrieve information with regards to Pods or Compose.

### Screenshot/screencast of this PR

![Screen Shot 2022-10-19 at 3 36 23 PM](https://user-images.githubusercontent.com/6422176/196787223-7c60b576-719e-4036-8131-6841d0d6db9a.png)


<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

Fixes https://github.com/containers/podman-desktop/issues/513

### How to test this PR?

1. `yarn watch`
2. Create a pod with multiple containers
3. Use the actions in the container list

<!-- Please explain steps to reproduce -->
