### PR TITLE
feat: allow to create a pod from containers

### DIFF
--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -63,7 +63,12 @@ import type { HistoryInfo } from './api/history-info';
 import type { PodInfo, PodInspectInfo } from './api/pod-info';
 import type { VolumeInspectInfo, VolumeListInfo } from './api/volume-info';
 import type { ContainerStatsInfo } from './api/container-stats-info';
-import type { PlayKubeInfo } from './dockerode/libpod-dockerode';
+import type {
+  PlayKubeInfo,
+  PodCreateOptions,
+  ContainerCreateOptions as PodmanContainerCreateOptions,
+} from './dockerode/libpod-dockerode';
+
 import { AutostartEngine } from './autostart-engine';
 import { KubernetesClient } from './kubernetes-client';
 import type { V1Pod, V1ConfigMap, V1NamespaceList, V1PodList } from '@kubernetes/client-node';
@@ -259,6 +264,28 @@ export class PluginSystem {
       },
     );
 
+    this.ipcHandle(
+      'container-provider-registry:replicatePodmanContainer',
+      async (
+        _listener,
+        source: { engineId: string; id: string },
+        target: { engineId: string },
+        overrideParameters: PodmanContainerCreateOptions,
+      ): Promise<{ Id: string; Warnings: string[] }> => {
+        return containerProviderRegistry.replicatePodmanContainer(source, target, overrideParameters);
+      },
+    );
+
+    this.ipcHandle(
+      'container-provider-registry:createPod',
+      async (
+        _listener,
+        selectedProvider: ProviderContainerConnectionInfo,
+        createOptions: PodCreateOptions,
+      ): Promise<{ engineId: string; Id: string }> => {
+        return containerProviderRegistry.createPod(selectedProvider, createOptions);
+      },
+    );
     this.ipcHandle(
       'container-provider-registry:startPod',
       async (_listener, engine: string, podId: string): Promise<void> => {

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -43,8 +43,12 @@ import type { IConfigurationPropertyRecordedSchema } from '../../main/src/plugin
 import type { PullEvent } from '../../main/src/plugin/api/pull-event';
 import { Deferred } from './util/deferred';
 import type { StatusBarEntryDescriptor } from '../../main/src/plugin/statusbar/statusbar-registry';
-import type { PlayKubeInfo } from '../../main/src/plugin/dockerode/libpod-dockerode';
-import type { V1Pod, V1ConfigMap, V1PodList, V1NamespaceList } from '@kubernetes/client-node';
+import type {
+  PlayKubeInfo,
+  PodCreateOptions,
+  ContainerCreateOptions as PodmanContainerCreateOptions,
+} from '../../main/src/plugin/dockerode/libpod-dockerode';
+import type { V1ConfigMap, V1NamespaceList, V1Pod, V1PodList } from '@kubernetes/client-node';
 
 export type DialogResultCallback = (openDialogReturnValue: Electron.OpenDialogReturnValue) => void;
 
@@ -135,6 +139,26 @@ function initExposure(): void {
   contextBridge.exposeInMainWorld('listPods', async (): Promise<PodInfo[]> => {
     return ipcInvoke('container-provider-registry:listPods');
   });
+
+  contextBridge.exposeInMainWorld(
+    'replicatePodmanContainer',
+    async (
+      source: { engineId: string; id: string },
+      target: { engineId: string },
+      overrideParameters: PodmanContainerCreateOptions,
+    ): Promise<{ Id: string; Warnings: string[] }> => {
+      return ipcInvoke('container-provider-registry:replicatePodmanContainer', source, target, overrideParameters);
+    },
+  );
+  contextBridge.exposeInMainWorld(
+    'createPod',
+    async (
+      selectedProvider: ProviderContainerConnectionInfo,
+      podCreateOptions: PodCreateOptions,
+    ): Promise<{ engineId: string; Id: string }> => {
+      return ipcInvoke('container-provider-registry:createPod', selectedProvider, podCreateOptions);
+    },
+  );
   contextBridge.exposeInMainWorld('startPod', async (engine: string, podId: string): Promise<void> => {
     return ipcInvoke('container-provider-registry:startPod', engine, podId);
   });

--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -31,6 +31,7 @@ import VolumesList from './lib/volume/VolumesList.svelte';
 import VolumeDetails from './lib/volume/VolumeDetails.svelte';
 import ContainerPlayKubefile from './lib/container/ContainerPlayKubefile.svelte';
 import PodDetails from './lib/pod/PodDetails.svelte';
+import PodCreateFromContainers from './lib/pod/PodCreateFromContainers.svelte';
 import DeployPodToKube from './lib/pod/DeployPodToKube.svelte';
 
 router.mode.hash();
@@ -124,6 +125,9 @@ window.events?.receive('display-help', () => {
         </Route>
         <Route path="/pods/:name/:engineId/*" let:meta>
           <PodDetails podName="{decodeURI(meta.params.name)}" engineId="{decodeURI(meta.params.engineId)}" />
+        </Route>
+        <Route path="/pod-create-from-containers">
+          <PodCreateFromContainers />
         </Route>
         <Route path="/volumes">
           <VolumesList />

--- a/packages/renderer/src/lib/ContainerList.svelte
+++ b/packages/renderer/src/lib/ContainerList.svelte
@@ -19,6 +19,7 @@ import { faChevronDown, faChevronRight } from '@fortawesome/free-solid-svg-icons
 import Fa from 'svelte-fa/src/fa.svelte';
 import ContainerGroupIcon from './container/ContainerGroupIcon.svelte';
 import KubePlayIcon from './container/KubePlayIcon.svelte';
+import { podCreationHolder } from '../stores/creation-from-containers-store';
 
 const containerUtils = new ContainerUtils();
 let openChoiceModal = false;
@@ -147,6 +148,26 @@ async function deleteSelectedContainers() {
     );
     bulkDeleteInProgress = false;
   }
+}
+
+function createPodFromContainers() {
+  const selectedContainers = containerGroups
+    .map(group => group.containers)
+    .flat()
+    .filter(container => container.selected);
+
+  const podCreation = {
+    name: 'my-pod',
+    containers: selectedContainers.map(container => {
+      return { id: container.id, name: container.name, engineId: container.engineId, ports: container.ports };
+    }),
+  };
+
+  // update the store
+  podCreationHolder.set(podCreation);
+
+  // redirect to pod creation page
+  router.goto('/pod-create-from-containers');
 }
 
 let containersUnsubscribe: Unsubscriber;
@@ -291,6 +312,14 @@ function toggleAllContainerGroups(value: boolean) {
             <i class="fas fa-trash" aria-hidden="true"></i>
           {/if}
         </span>
+      </button>
+      <div class="px-1"></div>
+      <button
+        class="pf-c-button pf-m-primary"
+        on:click="{() => createPodFromContainers()}"
+        title="Create Pod with {selectedItemsNumber} selected items"
+        type="button">
+        <i class="fas fa-cubes" aria-hidden="true"></i>
       </button>
       <span class="pl-2">On {selectedItemsNumber} selected items.</span>
     {/if}

--- a/packages/renderer/src/lib/pod/PodCreateFromContainers.svelte
+++ b/packages/renderer/src/lib/pod/PodCreateFromContainers.svelte
@@ -1,0 +1,204 @@
+<script lang="ts">
+import { providerInfos } from '../../stores/providers';
+import { onDestroy, onMount } from 'svelte';
+import type { ProviderContainerConnectionInfo, ProviderInfo } from '../../../../main/src/plugin/api/provider-info';
+import { PodCreation, podCreationHolder } from '../../stores/creation-from-containers-store';
+import NavPage from '../ui/NavPage.svelte';
+import { router } from 'tinro';
+import type { Unsubscriber } from 'svelte/store';
+
+let podCreation: PodCreation;
+let createInProgress = false;
+let createError = undefined;
+
+let providers: ProviderInfo[] = [];
+$: providerConnections = providers
+  .map(provider => provider.containerConnections)
+  .flat()
+  .filter(providerContainerConnection => providerContainerConnection.type === 'podman')
+  .filter(providerContainerConnection => providerContainerConnection.status === 'started');
+$: selectedProviderConnection = providerConnections.length > 0 ? providerConnections[0] : undefined;
+let selectedProvider: ProviderContainerConnectionInfo = undefined;
+$: selectedProvider = !selectedProvider && selectedProviderConnection ? selectedProviderConnection : selectedProvider;
+
+async function createPodFromContainers() {
+  createInProgress = true;
+  try {
+    await doCreatePodFromContainers();
+  } catch (error) {
+    createError = error;
+  }
+  createInProgress = false;
+}
+async function doCreatePodFromContainers() {
+  // fetch port info from all containers
+  const portmappingsArray = await Promise.all(
+    podCreation.containers.map(async container => {
+      const containerInspect = await window.getContainerInspect(container.engineId, container.id);
+
+      // convert port bindings to an port mapping object
+      return Object.entries(containerInspect.HostConfig.PortBindings).map(([key, value]) => {
+        const container_port = parseInt(key.split('/')[0]);
+        // we may not have any value
+        if (!value || value === null) {
+          return undefined;
+        }
+        const host_port = parseInt(value[0].HostPort);
+
+        const host_ip = value[0].HostIp as string;
+        return {
+          host_ip,
+          host_port,
+          container_port,
+          range: 1,
+          protocol: '',
+        };
+      });
+    }),
+  );
+
+  // make it flat and remove undefined values
+  const portmappings = portmappingsArray.flat().filter(portmapping => portmapping !== undefined);
+
+  // first create pod
+  const { Id, engineId } = await window.createPod(selectedProvider, { name: podCreation.name, portmappings });
+  // now, for each container, recreate it with the pod
+  // but before, stop the container
+
+  for (const container of podCreation.containers) {
+    // make sure it is stopped
+    try {
+      await window.stopContainer(container.engineId, container.id);
+    } catch (error) {
+      // already stopped
+    }
+
+    // recreate the container but adding the pod and using a different name
+    const replicatedContainer = await window.replicatePodmanContainer(
+      { ...container },
+      { engineId },
+      { pod: Id, name: container.name + '-podified' },
+    );
+
+    // start the new container
+    await window.startContainer(engineId, replicatedContainer.Id);
+  }
+
+  // ok now, redirect to the pods
+  router.goto('/pods/');
+}
+
+let providersUnsubscribe: Unsubscriber;
+let podCreationUnsubscribe: Unsubscriber;
+onMount(() => {
+  providersUnsubscribe = providerInfos.subscribe(value => {
+    providers = value;
+  });
+
+  podCreationUnsubscribe = podCreationHolder.subscribe(value => {
+    podCreation = value;
+  });
+});
+
+onDestroy(() => {
+  if (providersUnsubscribe) {
+    providersUnsubscribe();
+  }
+  if (podCreationUnsubscribe) {
+    podCreationUnsubscribe();
+  }
+  // reset
+  podCreationHolder.set(undefined);
+});
+</script>
+
+<NavPage title="Copy containers to a pod" searchEnabled="{false}" subtitle="Create a pod from containers">
+  <div class="w-full h-full" slot="empty">
+    <div class="m-5 p-5 h-full bg-zinc-900 rounded-sm text-gray-400">
+      {#if podCreation}
+        <div class="">
+          <label
+            for="podName"
+            class="p-2 block mb-2 text-sm font-medium rounded bg-zinc-700 text-gray-900 dark:text-gray-300"
+            >Name of the pod:
+            <input
+              name="podName"
+              id="podName"
+              bind:value="{podCreation.name}"
+              placeholder="Select name of the pod..."
+              class="w-full p-2 outline-none text-sm bg-zinc-900 rounded-sm text-gray-400 placeholder-gray-400"
+              required />
+          </label>
+        </div>
+
+        <div class="">
+          <label
+            for="podName"
+            class="p-2 block mb-2 text-sm font-medium rounded bg-zinc-700 text-gray-900 dark:text-gray-300"
+            >Containers to replicate to the pod:
+
+            <table>
+              {#each podCreation.containers as container, index}
+                <tr class="w-full p-2 outline-none text-sm bg-zinc-900 rounded-sm text-gray-400 placeholder-gray-400">
+                  <td class="px-2">{index + 1}.</td>
+                  <td class="px-2">{container.name}</td>
+                  <td class="px-2">({container.id.substring(0, 7)})</td>
+                </tr>
+              {/each}
+            </table>
+          </label>
+        </div>
+      {/if}
+
+      <div>
+        {#if providerConnections.length > 1}
+          <label
+            for="providerConnectionName"
+            class="p-2 block mb-2 text-sm font-medium rounded bg-zinc-700 text-gray-900 dark:text-gray-300"
+            >Container Engine
+            <select
+              class="w-full p-2 outline-none text-sm bg-zinc-900 rounded-sm text-gray-400 placeholder-gray-400"
+              name="providerChoice"
+              bind:value="{selectedProvider}">
+              {#each providerConnections as providerConnection}
+                <option value="{providerConnection}">{providerConnection.name}</option>
+              {/each}
+            </select>
+          </label>
+        {/if}
+        {#if providerConnections.length == 1}
+          <input type="hidden" name="providerChoice" readonly bind:value="{selectedProviderConnection.name}" />
+        {/if}
+      </div>
+
+      <button
+        disabled="{createInProgress}"
+        on:click="{() => {
+          createPodFromContainers();
+        }}"
+        class="w-full pf-c-button pf-m-primary"
+        type="button">
+        <span class="pf-c-button__icon pf-m-start">
+          {#if createInProgress}
+            <div class="mr-4">
+              <i class="pf-c-button__progress">
+                <span class="pf-c-spinner pf-m-md" role="progressbar">
+                  <span class="pf-c-spinner__clipper"></span>
+                  <span class="pf-c-spinner__lead-ball"></span>
+                  <span class="pf-c-spinner__tail-ball"></span>
+                </span>
+              </i>
+            </div>
+          {:else}
+            <i class="fas fa-cube" aria-hidden="true"></i>
+          {/if}
+        </span>
+        Create Pod using these containers
+      </button>
+
+      {#if createError}
+        <div class="pt-4 text-red-500 text-sm">{createError}</div>
+      {/if}
+    </div>
+  </div>
+</NavPage>

--- a/packages/renderer/src/stores/creation-from-containers-store.ts
+++ b/packages/renderer/src/stores/creation-from-containers-store.ts
@@ -1,0 +1,33 @@
+/**********************************************************************
+ * Copyright (C) 2022 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { Writable } from 'svelte/store';
+import { writable } from 'svelte/store';
+
+export interface PodCreationContainer {
+  id: string;
+  name: string;
+  engineId: string;
+}
+
+export interface PodCreation {
+  name: string;
+  containers: PodCreationContainer[];
+}
+
+export const podCreationHolder: Writable<PodCreation> = writable();


### PR DESCRIPTION
### What does this PR do?
Adds ability to create a pod from containers
exposed port of container is also moved to the newly created pod

### Screenshot/screencast of this PR


https://user-images.githubusercontent.com/436777/197004091-fa291670-758b-4467-aae9-f879298b2831.mp4



### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/516

### How to test this PR?

Start a container.
Then select it and create a pod from there
Old one is stopped, new one is added using `-podified`


Change-Id: I1eceeafc357a6a0d78a3ae1e276dca18346cc107
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
