### PR TITLE
fix: Hide the menu bar to make it look more like a native app

### DIFF
--- a/packages/main/src/mainWindow.ts
+++ b/packages/main/src/mainWindow.ts
@@ -32,6 +32,7 @@ async function createWindow() {
 
   const browserWindowConstructorOptions: BrowserWindowConstructorOptions = {
     show: false, // Use 'ready-to-show' event to show window
+    autoHideMenuBar: true, // This makes Podman Desktop look more like a native app
     width: INITIAL_APP_WIDTH,
     minWidth: INITIAL_APP_MIN_WIDTH,
     minHeight: INITIAL_APP_MIN_HEIGHT,
@@ -43,8 +44,7 @@ async function createWindow() {
       preload: join(__dirname, '../../preload/dist/index.cjs'),
     },
   };
-  // On Linux keep title bar as we may not have any tray icon
-  // being displayed
+
   if (isMac) {
     // This property is not available on Linux.
     browserWindowConstructorOptions.titleBarStyle = 'hiddenInset';


### PR DESCRIPTION
Signed-off-by: Dylan M. Taylor <dylan@dylanmtaylor.com>

### What does this PR do?
Sets the menu bar to auto-hide. It can still be used with alt keys.

### Screenshot/screencast of this PR

![image](https://user-images.githubusercontent.com/277927/197262947-129324ef-2a84-4b44-afde-452ea85889f4.png)

This is on GNOME 43, showing the patch applied. See #663 for a screenshot of how this looks without the patch.

![image](https://user-images.githubusercontent.com/277927/197210491-9ced4701-cad9-40b6-b674-c5bde06a178c.png)
I tested this on a different machine, running KDE. The only thing I was testing for was that the app still ran and the menu bar was gone. 
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?
This PR closes #663.

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

### How to test this PR?
Simply open the application.
<!-- Please explain steps to reproduce -->
