### PR TITLE
feat: Change icon of deploy to kubernetes

### DIFF
--- a/packages/renderer/src/lib/container/ContainerActions.svelte
+++ b/packages/renderer/src/lib/container/ContainerActions.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { faCubes, faFileCode, faPlayCircle, faTerminal } from '@fortawesome/free-solid-svg-icons';
+import { faFileCode, faPlayCircle, faRocket, faTerminal } from '@fortawesome/free-solid-svg-icons';
 import { faStopCircle } from '@fortawesome/free-solid-svg-icons';
 import { faArrowsRotate } from '@fortawesome/free-solid-svg-icons';
 import { faTrash } from '@fortawesome/free-solid-svg-icons';
@@ -66,7 +66,7 @@ function deployToKubernetes(): void {
   onClick="{() => deployToKubernetes()}"
   hidden="{!(container.engineType === 'podman' && container.groupInfo.type === ContainerGroupInfoTypeUI.STANDALONE)}"
   backgroundColor="{backgroundColor}"
-  icon="{faCubes}" />
+  icon="{faRocket}" />
 <ListItemButtonIcon
   title="Start Container"
   onClick="{() => startContainer(container)}"

--- a/packages/renderer/src/lib/pod/PodActions.svelte
+++ b/packages/renderer/src/lib/pod/PodActions.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { faCubes, faFileCode, faPlayCircle } from '@fortawesome/free-solid-svg-icons';
+import { faFileCode, faPlayCircle, faRocket } from '@fortawesome/free-solid-svg-icons';
 import { faStopCircle } from '@fortawesome/free-solid-svg-icons';
 import { faArrowsRotate } from '@fortawesome/free-solid-svg-icons';
 import { faTrash } from '@fortawesome/free-solid-svg-icons';
@@ -45,7 +45,7 @@ function deployToKubernetes(): void {
   title="Deploy to Kubernetes"
   onClick="{() => deployToKubernetes()}"
   backgroundColor="{backgroundColor}"
-  icon="{faCubes}" />
+  icon="{faRocket}" />
 <ListItemButtonIcon
   title="Start Pod"
   onClick="{() => startPod(pod)}"


### PR DESCRIPTION
### What does this PR do?
Replace cubes icon for deploy to kubernetes
Use a rocket. (For now it needs to be a font-awesome icon)

### Screenshot/screencast of this PR

![image](https://user-images.githubusercontent.com/436777/197221811-a8034135-2582-463c-a3a1-26e67132c730.png)


### What issues does this PR fix or reference?

https://github.com/containers/podman-desktop/pull/661#issuecomment-1287007326

### How to test this PR?

Look at the icon

Change-Id: I9deb0755de231577e82cf5d3efbe7fa13ec34e38
Signed-off-by: Florent Benoit <fbenoit@redhat.com>

