### PR TITLE
feat: allow to create services and routes when deploying to k8s

### DIFF
--- a/packages/main/src/plugin/api/openshift-types.ts
+++ b/packages/main/src/plugin/api/openshift-types.ts
@@ -1,0 +1,43 @@
+/**********************************************************************
+ * Copyright (C) 2022 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+export type V1Route = {
+  apiVersion?: string;
+  kind?: string;
+  metadata: {
+    name: string;
+    namespace: string;
+    annotations?: { [key: string]: string };
+  };
+  spec: {
+    host: string;
+    port: {
+      targetPort: string;
+    };
+    tls: {
+      insecureEdgeTerminationPolicy: string;
+      termination: string;
+    };
+    to: {
+      kind: string;
+      name: string;
+      weight: number;
+    };
+    wildcardPolicy: string;
+  };
+};

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -71,7 +71,8 @@ import type {
 
 import { AutostartEngine } from './autostart-engine';
 import { KubernetesClient } from './kubernetes-client';
-import type { V1Pod, V1ConfigMap, V1NamespaceList, V1PodList } from '@kubernetes/client-node';
+import type { V1Pod, V1ConfigMap, V1NamespaceList, V1PodList, V1Service } from '@kubernetes/client-node';
+import type { V1Route } from './api/openshift-types';
 
 type LogType = 'log' | 'warn' | 'trace' | 'debug' | 'error';
 export class PluginSystem {
@@ -825,6 +826,20 @@ export class PluginSystem {
     this.ipcHandle('kubernetes-client:createPod', async (_listener, namespace: string, pod: V1Pod): Promise<V1Pod> => {
       return kubernetesClient.createPod(namespace, pod);
     });
+
+    this.ipcHandle(
+      'kubernetes-client:createService',
+      async (_listener, namespace: string, service: V1Service): Promise<V1Service> => {
+        return kubernetesClient.createService(namespace, service);
+      },
+    );
+
+    this.ipcHandle(
+      'openshift-client:createRoute',
+      async (_listener, namespace: string, route: V1Route): Promise<V1Route> => {
+        return kubernetesClient.createOpenShiftRoute(namespace, route);
+      },
+    );
 
     this.ipcHandle(
       'kubernetes-client:listNamespacedPod',

--- a/packages/main/src/plugin/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes-client.ts
@@ -16,8 +16,11 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { Context, V1Pod, V1ConfigMap, V1PodList, V1NamespaceList } from '@kubernetes/client-node';
+import type { Context, V1Pod, V1ConfigMap, V1PodList, V1NamespaceList, V1Service } from '@kubernetes/client-node';
+import { CustomObjectsApi } from '@kubernetes/client-node';
 import { CoreV1Api, KubeConfig } from '@kubernetes/client-node';
+import type { V1Route } from './api/openshift-types';
+
 /**
  * Handle calls to kubernetes API
  */
@@ -71,6 +74,34 @@ export class KubernetesClient {
     try {
       const createdPodData = await k8sCoreApi.createNamespacedPod(namespace, body);
       return createdPodData.body;
+    } catch (error) {
+      throw this.wrapK8sClientError(error);
+    }
+  }
+
+  async createService(namespace: string, body: V1Service): Promise<V1Service> {
+    const k8sCoreApi = this.kubeConfig.makeApiClient(CoreV1Api);
+
+    try {
+      const createdPodData = await k8sCoreApi.createNamespacedService(namespace, body);
+      return createdPodData.body;
+    } catch (error) {
+      throw this.wrapK8sClientError(error);
+    }
+  }
+
+  async createOpenShiftRoute(namespace: string, body: V1Route): Promise<V1Route> {
+    const k8sCustomObjectsApi = this.kubeConfig.makeApiClient(CustomObjectsApi);
+
+    try {
+      const createdPodData = await k8sCustomObjectsApi.createNamespacedCustomObject(
+        'route.openshift.io',
+        'v1',
+        namespace,
+        'routes',
+        body,
+      );
+      return createdPodData.body as V1Route;
     } catch (error) {
       throw this.wrapK8sClientError(error);
     }

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -33,6 +33,7 @@ import type { HistoryInfo } from '../../main/src/plugin/api/history-info';
 import type { ContainerInspectInfo } from '../../main/src/plugin/api/container-inspect-info';
 import type { ContainerStatsInfo } from '../../main/src/plugin/api/container-stats-info';
 import type { ExtensionInfo } from '../../main/src/plugin/api/extension-info';
+import type { V1Route } from '../../main/src/plugin/api/openshift-types';
 import type {
   PreflightCheckEvent,
   PreflightChecksCallback,
@@ -48,7 +49,7 @@ import type {
   PodCreateOptions,
   ContainerCreateOptions as PodmanContainerCreateOptions,
 } from '../../main/src/plugin/dockerode/libpod-dockerode';
-import type { V1ConfigMap, V1NamespaceList, V1Pod, V1PodList } from '@kubernetes/client-node';
+import type { V1ConfigMap, V1NamespaceList, V1Pod, V1PodList, V1Service } from '@kubernetes/client-node';
 
 export type DialogResultCallback = (openDialogReturnValue: Electron.OpenDialogReturnValue) => void;
 
@@ -895,6 +896,20 @@ function initExposure(): void {
   contextBridge.exposeInMainWorld('kubernetesCreatePod', async (namespace: string, pod: V1Pod): Promise<V1Pod> => {
     return ipcInvoke('kubernetes-client:createPod', namespace, pod);
   });
+
+  contextBridge.exposeInMainWorld(
+    'kubernetesCreateService',
+    async (namespace: string, service: V1Service): Promise<V1Service> => {
+      return ipcInvoke('kubernetes-client:createService', namespace, service);
+    },
+  );
+
+  contextBridge.exposeInMainWorld(
+    'openshiftCreateRoute',
+    async (namespace: string, route: V1Route): Promise<V1Route> => {
+      return ipcInvoke('openshift-client:createRoute', namespace, route);
+    },
+  );
 }
 
 // expose methods

--- a/packages/renderer/src/lib/pod/DeployPodToKube.svelte
+++ b/packages/renderer/src/lib/pod/DeployPodToKube.svelte
@@ -4,6 +4,7 @@ import MonacoEditor from '../editor/MonacoEditor.svelte';
 import NavPage from '../ui/NavPage.svelte';
 import * as jsYaml from 'js-yaml';
 import { each } from 'svelte/internal';
+import type { V1Route } from '../../../../main/src/plugin/api/openshift-types';
 
 export let resourceId: string;
 export let engineId: string;
@@ -18,12 +19,20 @@ let deployError = '';
 let updatePodInterval: NodeJS.Timeout;
 let openshiftConsoleURL: string;
 
+let deployUsingServices = true;
+let deployUsingRoutes = true;
 let createdPod = undefined;
+let bodyPod;
+
+let createdRoutes: V1Route[] = [];
 
 onMount(async () => {
   // grab kube result from the pod
   const kubeResult = await window.generatePodmanKube(engineId, [resourceId]);
   kubeDetails = kubeResult;
+
+  // parse yaml
+  bodyPod = jsYaml.load(kubeDetails) as any;
 
   // grab default context
   defaultContextName = await window.kubernetesGetCurrentContextName();
@@ -76,6 +85,10 @@ function goBackToHistory(): void {
   window.history.go(-1);
 }
 
+function openRoute(route: V1Route) {
+  window.openExternal(`http://${route.spec.host}`);
+}
+
 async function deployToKube() {
   deployStarted = true;
   deployFinished = false;
@@ -83,15 +96,91 @@ async function deployToKube() {
   createdPod = undefined;
   // reset any timeout
   clearInterval(updatePodInterval);
-  const bodyPod = jsYaml.load(kubeDetails) as any;
+
+  createdRoutes = [];
+  let servicesToCreate: any[] = [];
+  let routesToCreate: any[] = [];
+
+  // if we deploy using services, we need to get rid of .hostPort and generate kubernetes services object
+  if (deployUsingServices) {
+    // collect all ports
+    bodyPod.spec?.containers?.forEach((container: any) => {
+      container?.ports.forEach((port: any) => {
+        console.log('checking port', port);
+        if (port.hostPort) {
+          // create service
+          const service = {
+            apiVersion: 'v1',
+            kind: 'Service',
+            metadata: {
+              name: `${bodyPod.metadata.name}-${port.hostPort}`,
+              namespace: currentNamespace,
+            },
+            spec: {
+              ports: [
+                {
+                  name: port.name,
+                  port: port.hostPort,
+                  protocol: port.protocol || 'TCP',
+                  targetPort: port.containerPort,
+                },
+              ],
+              selector: {
+                app: bodyPod.metadata.name,
+              },
+            },
+          };
+          servicesToCreate.push(service);
+
+          if (openOpenshiftConsole && deployUsingRoutes) {
+            // Create OpenShift route object
+            const route = {
+              apiVersion: 'route.openshift.io/v1',
+              kind: 'Route',
+              metadata: {
+                name: `${bodyPod.metadata.name}-${port.hostPort}`,
+                namespace: currentNamespace,
+              },
+              spec: {
+                port: {
+                  targetPort: port.containerPort,
+                },
+                to: {
+                  kind: 'Service',
+                  name: `${bodyPod.metadata.name}-${port.hostPort}`,
+                },
+              },
+            };
+            routesToCreate.push(route);
+          }
+          // delete
+          console.log('deelte port.hostPort', port.hostPort);
+          delete port.hostPort;
+          console.log('after port.hostPort', port);
+        }
+      });
+    });
+  }
 
   // https://github.com/kubernetes-client/javascript/issues/487
   if (bodyPod?.metadata?.creationTimestamp) {
     bodyPod.metadata.creationTimestamp = new Date(bodyPod.metadata.creationTimestamp);
   }
 
+  console.log('bodyPod', bodyPod);
   try {
     createdPod = await window.kubernetesCreatePod(currentNamespace, bodyPod);
+
+    // create services
+    for (const service of servicesToCreate) {
+      await window.kubernetesCreateService(currentNamespace, service);
+    }
+
+    // Create routes
+    for (const route of routesToCreate) {
+      const createdRoute = await window.openshiftCreateRoute(currentNamespace, route);
+      createdRoutes = [...createdRoutes, createdRoute];
+    }
 
     // update status
     updatePodInterval = setInterval(updatePod, 2000);
@@ -110,6 +199,43 @@ async function deployToKube() {
         <p>Generated pod to deploy to Kubernetes:</p>
         <div class="h-1/3 pt-2">
           <MonacoEditor content="{kubeDetails}" language="yaml" />
+        </div>
+      {/if}
+
+      {#if bodyPod}
+        <div class="pt-2 pb-4">
+          <label for="contextToUse" class="block mb-1 text-sm font-medium text-gray-300">Pod Name:</label>
+          <input
+            type="text"
+            bind:value="{bodyPod.metadata.name}"
+            name="podName"
+            id="podName"
+            class=" cursor-default w-full p-2 outline-none text-sm bg-zinc-900 rounded-sm text-gray-400 placeholder-gray-400"
+            required />
+        </div>
+      {/if}
+
+      <div class="pt-2 m-2">
+        <label for="services" class="block mb-1 text-sm font-medium text-gray-300">Use Kubernetes Services:</label>
+        <input
+          type="checkbox"
+          bind:checked="{deployUsingServices}"
+          name="useServices"
+          id="useServices"
+          class=""
+          required />
+        <span class="text-gray-300 text-sm ml-1"
+          >Replace .hostPort exposure on containers by Services. It is the recommended way to expose ports, as a cluster
+          policy may prevent to use hostPort.</span>
+      </div>
+
+      <!-- Allow to create routes for OpenShift clusters -->
+      {#if openshiftConsoleURL}
+        <div class="pt-2 m-2">
+          <label for="routes" class="block mb-1 text-sm font-medium text-gray-300">Create OpenShift routes:</label>
+          <input type="checkbox" bind:checked="{deployUsingRoutes}" name="useRoutes" id="useRoutes" class="" required />
+          <span class="text-gray-300 text-sm ml-1"
+            >Create OpenShift routes to get access to the exposed ports of this pod.</span>
         </div>
       {/if}
 
@@ -144,7 +270,7 @@ async function deployToKube() {
       {#if !deployStarted}
         <button on:click="{() => deployToKube()}" class="w-full pf-c-button pf-m-primary" type="button">
           <span class="pf-c-button__icon pf-m-start">
-            <i class="fas fa-cubes" aria-hidden="true"></i>
+            <i class="fas fa-rocket" aria-hidden="true"></i>
           </span>
           Deploy
         </button>
@@ -201,7 +327,23 @@ async function deployToKube() {
                 {/each}
               </ul>
             {/if}
+            {#if createdRoutes && createdRoutes.length > 0}
+              <p class="pt-2">Endpoints:</p>
+              <ul class="list-disc list-inside">
+                {#each createdRoutes as createdRoute}
+                  <li class="pt-2">
+                    Port {createdRoute.spec.port.targetPort} is reachable with route
+                    <span
+                      class="cursor-pointer text-violet-400 hover:text-violet-600 hover:no-underline"
+                      on:click="{() => {
+                        openRoute(createdRoute);
+                      }}">{createdRoute.metadata.name}</span>
+                  </li>
+                {/each}
+              </ul>
+            {/if}
           </div>
+
           <!-- add editor for the result-->
           <div class="h-[100px] pt-2">
             <MonacoEditor content="{jsYaml.dump(createdPod)}" language="yaml" />


### PR DESCRIPTION
### What does this PR do?

Some clusters are not allowing to use hostPorts
So here we allow to create services and if it's OpenShift, create routes as well.
In addition we can also rename the pod name before it is deployed



### Screenshot/screencast of this PR


https://user-images.githubusercontent.com/436777/197246669-f6dce42b-5d94-4bea-8fac-36f30f259faf.mov




### What issues does this PR fix or reference?


### How to test this PR?

Deploy on DevSandbox for example


Change-Id: Ie4fb2b0eaa2a228b6cfb13779fe853e53581a993
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
