### PR TITLE
feat: Implement preference for exit on close behavior, defaulting to true on Linux

### DIFF
--- a/packages/main/src/index.ts
+++ b/packages/main/src/index.ts
@@ -24,6 +24,7 @@ import { isMac, isWindows } from './util';
 import { AnimatedTray } from './tray-animate-icon';
 import { PluginSystem } from './plugin';
 import { StartupInstall } from './system/startup-install';
+import type { ConfigurationRegistry } from './plugin/configuration-registry';
 
 /**
  * Prevent multiple instances
@@ -97,6 +98,9 @@ if (import.meta.env.PROD) {
 }
 
 let tray: Tray | null = null;
+declare global {
+  let configurationRegistry: ConfigurationRegistry;
+}
 
 app.whenReady().then(async () => {
   const animatedTray = new AnimatedTray();
@@ -107,9 +111,9 @@ app.whenReady().then(async () => {
   const pluginSystem = new PluginSystem(trayMenu);
   const extensionLoader = await pluginSystem.initExtensions();
 
-  const configurationRegistry = extensionLoader.getConfigurationRegistry();
+  global.configurationRegistry = extensionLoader.getConfigurationRegistry();
 
   // configure automatic startup
-  const automaticStartup = new StartupInstall(configurationRegistry);
+  const automaticStartup = new StartupInstall(global.configurationRegistry);
   await automaticStartup.configure();
 });

--- a/packages/main/src/mainWindow.ts
+++ b/packages/main/src/mainWindow.ts
@@ -101,10 +101,8 @@ async function createWindow() {
   });
 
   browserWindow.on('close', e => {
-    e.preventDefault();
-    if (isLinux) {
-      browserWindow.minimize();
-    } else {
+    if (!isLinux) {
+      e.preventDefault();
       browserWindow.hide();
       if (isMac) {
         app.dock.hide();

--- a/packages/main/src/mainWindow.ts
+++ b/packages/main/src/mainWindow.ts
@@ -42,9 +42,9 @@ async function createWindow() {
       preload: join(__dirname, '../../preload/dist/index.cjs'),
     },
   };
-  // On Linux keep title bar as we may not have any tray icon
-  // being displayed
+
   if (isMac) {
+    // This property is not available on Linux.
     browserWindowConstructorOptions.titleBarStyle = 'hiddenInset';
   }
 
@@ -102,15 +102,15 @@ async function createWindow() {
 
   browserWindow.on('close', e => {
     const closeBehaviorConfiguration = global.configurationRegistry?.getConfiguration('preferences');
-    let minimizeonclose = !isLinux; // default value, which we will use unless the user preference is available.
-    if (typeof closeBehaviorConfiguration !== 'undefined') {
-      minimizeonclose = closeBehaviorConfiguration.get<boolean>('MinimizeToTrayOnClose') == true;
+    let exitonclose = isLinux; // default value, which we will use unless the user preference is available.
+    if (closeBehaviorConfiguration) {
+      exitonclose = closeBehaviorConfiguration.get<boolean>('ExitOnClose') == true;
     } else {
       console.log('Configuration registry was undefined when window was closed. Using default behavior.');
     }
-    console.log('Minimize on close: ' + minimizeonclose);
+    console.log('Exit on close: ' + exitonclose);
 
-    if (minimizeonclose) {
+    if (!exitonclose) {
       e.preventDefault();
       browserWindow.hide();
       if (isMac) {

--- a/packages/main/src/mainWindow.ts
+++ b/packages/main/src/mainWindow.ts
@@ -21,6 +21,7 @@ import { BrowserWindow, ipcMain, app, dialog, screen } from 'electron';
 import contextMenu from 'electron-context-menu';
 import { join } from 'path';
 import { URL } from 'url';
+import type { ConfigurationRegistry } from './plugin/configuration-registry';
 import { isLinux, isMac } from './util';
 
 async function createWindow() {
@@ -42,7 +43,8 @@ async function createWindow() {
       preload: join(__dirname, '../../preload/dist/index.cjs'),
     },
   };
-
+  // On Linux keep title bar as we may not have any tray icon
+  // being displayed
   if (isMac) {
     // This property is not available on Linux.
     browserWindowConstructorOptions.titleBarStyle = 'hiddenInset';
@@ -100,8 +102,13 @@ async function createWindow() {
     browserWindow.webContents.send('dialog:open-file-or-folder-response', param.dialogId, response);
   });
 
+  let configurationRegistry: ConfigurationRegistry;
+  ipcMain.on('configuration-registry', (_, data) => {
+    configurationRegistry = data;
+  });
+
   browserWindow.on('close', e => {
-    const closeBehaviorConfiguration = global.configurationRegistry?.getConfiguration('preferences');
+    const closeBehaviorConfiguration = configurationRegistry?.getConfiguration('preferences');
     let exitonclose = isLinux; // default value, which we will use unless the user preference is available.
     if (closeBehaviorConfiguration) {
       exitonclose = closeBehaviorConfiguration.get<boolean>('ExitOnClose') == true;

--- a/packages/main/src/mainWindow.ts
+++ b/packages/main/src/mainWindow.ts
@@ -101,12 +101,24 @@ async function createWindow() {
   });
 
   browserWindow.on('close', e => {
-    if (!isLinux) {
+    const closeBehaviorConfiguration = global.configurationRegistry?.getConfiguration('preferences');
+    let minimizeonclose = !isLinux; // default value, which we will use unless the user preference is available.
+    if (typeof closeBehaviorConfiguration !== 'undefined') {
+      minimizeonclose = closeBehaviorConfiguration.get<boolean>('MinimizeToTrayOnClose') == true;
+    } else {
+      console.log('Configuration registry was undefined when window was closed. Using default behavior.');
+    }
+    console.log('Minimize on close: ' + minimizeonclose);
+
+    if (minimizeonclose) {
       e.preventDefault();
       browserWindow.hide();
       if (isMac) {
         app.dock.hide();
       }
+    } else {
+      browserWindow.destroy();
+      app.quit();
     }
   });
 

--- a/packages/main/src/mainWindow.ts
+++ b/packages/main/src/mainWindow.ts
@@ -105,10 +105,7 @@ async function createWindow() {
     let exitonclose = isLinux; // default value, which we will use unless the user preference is available.
     if (closeBehaviorConfiguration) {
       exitonclose = closeBehaviorConfiguration.get<boolean>('ExitOnClose') == true;
-    } else {
-      console.log('Configuration registry was undefined when window was closed. Using default behavior.');
     }
-    console.log('Exit on close: ' + exitonclose);
 
     if (!exitonclose) {
       e.preventDefault();

--- a/packages/main/src/plugin/close-behavior.ts
+++ b/packages/main/src/plugin/close-behavior.ts
@@ -1,0 +1,43 @@
+/**********************************************************************
+ * Copyright (C) 2022 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { isLinux } from '../util';
+import type { ConfigurationRegistry, IConfigurationNode } from './configuration-registry';
+import type { ProviderRegistry } from './provider-registry';
+
+export class CloseBehavior {
+  constructor(private configurationRegistry: ConfigurationRegistry, private providerRegistry: ProviderRegistry) {}
+
+  async init(): Promise<void> {
+    // add configuration
+    const closeBehaviorConfigurationNode: IConfigurationNode = {
+      id: 'preferences.MinimizeToTrayOnClose',
+      title: 'Minimize To Tray On Close',
+      type: 'object',
+      properties: {
+        ['preferences.MinimizeToTrayOnClose']: {
+          description: 'Overrides close button behavior to hide or minimize to tray.',
+          type: 'boolean',
+          default: !isLinux,
+        },
+      },
+    };
+
+    this.configurationRegistry.registerConfigurations([closeBehaviorConfigurationNode]);
+  }
+}

--- a/packages/main/src/plugin/close-behavior.ts
+++ b/packages/main/src/plugin/close-behavior.ts
@@ -26,14 +26,14 @@ export class CloseBehavior {
   async init(): Promise<void> {
     // add configuration
     const closeBehaviorConfigurationNode: IConfigurationNode = {
-      id: 'preferences.MinimizeToTrayOnClose',
-      title: 'Minimize To Tray On Close',
+      id: 'preferences.ExitOnClose',
+      title: 'Exit On Close',
       type: 'object',
       properties: {
-        ['preferences.MinimizeToTrayOnClose']: {
-          description: 'Overrides close button behavior to hide or minimize to tray.',
+        ['preferences.ExitOnClose']: {
+          description: 'Quit the app when the close button is clicked instead of minimizing to the tray.',
           type: 'boolean',
-          default: !isLinux,
+          default: isLinux,
         },
       },
     };

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -70,6 +70,7 @@ import type {
 } from './dockerode/libpod-dockerode';
 
 import { AutostartEngine } from './autostart-engine';
+import { CloseBehavior } from './close-behavior';
 import { KubernetesClient } from './kubernetes-client';
 import type { V1Pod, V1ConfigMap, V1NamespaceList, V1PodList, V1Service } from '@kubernetes/client-node';
 import type { V1Route } from './api/openshift-types';
@@ -207,7 +208,8 @@ export class PluginSystem {
     const trayMenuRegistry = new TrayMenuRegistry(this.trayMenu, commandRegistry, providerRegistry, telemetry);
     const statusBarRegistry = new StatusBarRegistry(apiSender);
     const kubernetesClient = new KubernetesClient();
-
+    const closeBehaviorConfiguration = new CloseBehavior(configurationRegistry, providerRegistry);
+    await closeBehaviorConfiguration.init();
     const autoStartConfiguration = new AutostartEngine(configurationRegistry, providerRegistry);
     await autoStartConfiguration.init();
 


### PR DESCRIPTION
Signed-off-by: Dylan M. Taylor <dylan@dylanmtaylor.com>

### What does this PR do?

This pull request alters the behavior of the application when running on Linux. When the close button is clicked, the application will close like a normal application would, instead of attempting to run  in the background still or minimize to tray.

The rationale for this change is as follows:

* On GNOME systems, such as Fedora Workstation or RHEL, by default there is no system tray. 
  * The workaround for this is ugly - both from a UX perspective as well as cosmetically -- having a menu bar and expecting the user to do File > Quit to close out of the application
  * I made another PR, #668 to hide the menu bar, and the client looks MUCH better IMO, but now a user still has to use the menu bar to close the app normally, and they have to hold Alt to get it to appear.
* Linux is a very different beast with podman than Mac or Windows. While it's super inconvenient to have the podman machine VM unexpectedly close on Mac/Windows, this is simply not a problem on Linux. The GUI for podman desktop simply attaches to a socket, so closing the app doesn't necessarily terminate podman containers. Users will _expect_ that the close button will close the application, and not having it do so will be a bad user experience.

### What issues does this PR fix or reference?

Issue #663, and this goes with PR #668.

Closes #471

### How to test this PR?

Open the application on Linux and then click the X to close it. Validate that it did, in fact, close.

This has been tested by me to work, but it isn't exactly a complicated change.