### PR TITLE
fix: start all containers after all the replication

### DIFF
--- a/packages/renderer/src/lib/pod/PodCreateFromContainers.svelte
+++ b/packages/renderer/src/lib/pod/PodCreateFromContainers.svelte
@@ -65,6 +65,8 @@ async function doCreatePodFromContainers() {
   // now, for each container, recreate it with the pod
   // but before, stop the container
 
+  const containersToStart: { engineId: string; id: string }[] = [];
+
   for (const container of podCreation.containers) {
     // make sure it is stopped
     try {
@@ -80,8 +82,12 @@ async function doCreatePodFromContainers() {
       { pod: Id, name: container.name + '-podified' },
     );
 
+    containersToStart.push({ engineId, id: replicatedContainer.Id });
+  }
+
+  for (const containerToStart of containersToStart) {
     // start the new container
-    await window.startContainer(engineId, replicatedContainer.Id);
+    await window.startContainer(containerToStart.engineId, containerToStart.id);
   }
 
   // ok now, redirect to the pods


### PR DESCRIPTION
### What does this PR do?
Fix an issue within Podman
it says: "internal libpod error"

so, instead of adding containers to the pod while one container is already running, add all of them

### Screenshot/screencast of this PR

![image](https://user-images.githubusercontent.com/436777/197363052-47a9ef08-904b-446b-aa91-2117774c7519.png)

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Try Stevan's demo

Change-Id: Iaf10beb50efef4fadca6d13964a6c93a282c09c1
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
