### PR TITLE
fix: start a pod instead of trying to start each individual container

### DIFF
--- a/packages/renderer/src/lib/pod/PodCreateFromContainers.svelte
+++ b/packages/renderer/src/lib/pod/PodCreateFromContainers.svelte
@@ -67,6 +67,7 @@ async function doCreatePodFromContainers() {
 
   const containersToStart: { engineId: string; id: string }[] = [];
 
+  // then, stop all containers
   for (const container of podCreation.containers) {
     // make sure it is stopped
     try {
@@ -74,21 +75,22 @@ async function doCreatePodFromContainers() {
     } catch (error) {
       // already stopped
     }
+  }
 
+  // then replicate containers
+  for (const container of podCreation.containers) {
     // recreate the container but adding the pod and using a different name
+
     const replicatedContainer = await window.replicatePodmanContainer(
       { ...container },
       { engineId },
       { pod: Id, name: container.name + '-podified' },
     );
-
     containersToStart.push({ engineId, id: replicatedContainer.Id });
   }
 
-  for (const containerToStart of containersToStart) {
-    // start the new container
-    await window.startContainer(containerToStart.engineId, containerToStart.id);
-  }
+  // finally, start the pod
+  await window.startPod(engineId, Id);
 
   // ok now, redirect to the pods
   router.goto('/pods/');


### PR DESCRIPTION

### What does this PR do?
at the end of creating the pod, just start the pod.
starting all individual containers make the logic failed
also, we stop all containers first.

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?

#516 

### How to test this PR?

Stevan's demo


Change-Id: I41ece2faff39b736a5c85f4e675a624df96b3336
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
