### PR TITLE
Minor aesthetic tweaks to website in light mode

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -61,6 +61,7 @@ Apply style on documentation
   --ifm-code-font-size: 95%;
   --ifm-navbar-background-color: #fff;
   --ifm-navbar-height: 85px;
+  --ifm-navbar-shadow: none;
 }
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */

--- a/website/src/pages/downloads/index.tsx
+++ b/website/src/pages/downloads/index.tsx
@@ -11,16 +11,18 @@ export default function Home(): JSX.Element {
   return (
     <Layout title={siteConfig.title} description="Downloads">
       <section className="container mx-auto flex justify-left flex-col bg-hero-pattern bg-no-repeat bg-center bg-cover">
-        <div className="lg:w-2/3 w-full">
-          <h1 className="flex flex-col title-font sm:text-3xl text-2xl lg:text-5xl mb-10 font-medium text-gray-900 dark:text-white">
-            Downloads
-          </h1>
-        </div>
-        <div className="flex lg:flex-row flex-col mb-12 gap-8">
-          <TailWindThemeSelector />
-          <WindowsDownloads />
-          <MacOSDownloads />
-          <LinuxDownloads />
+        <div className="bg-white/30 dark:bg-transparent">
+          <div className="lg:w-2/3 w-full">
+            <h1 className="flex flex-col title-font sm:text-3xl text-2xl lg:text-5xl mb-10 font-medium text-gray-900 dark:text-white">
+              Downloads
+            </h1>
+          </div>
+          <div className="flex lg:flex-row flex-col mb-12 gap-8">
+            <TailWindThemeSelector />
+            <WindowsDownloads />
+            <MacOSDownloads />
+            <LinuxDownloads />
+          </div>
         </div>
       </section>
     </Layout>

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -139,7 +139,7 @@ function Hero() {
                 {() => {
                   return <DownloadClientLinks />;
                 }}
-             </BrowserOnly>
+              </BrowserOnly>
             </div>
           </div>
         </div>

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -120,25 +120,27 @@ function Hero() {
   return (
     <section className="text-gray-600 dark:text-gray-300 body-font">
       <div className="container mx-auto flex px-5 pb-24 pt-4 items-center justify-center flex-col">
-        <div className="text-center lg:w-2/3 w-full bg-hero-pattern bg-no-repeat bg-center bg-cover">
-          <h1 className="title-font sm:text-4xl text-3xl lg:text-6xl mb-8 font-medium text-gray-900 dark:text-white">
-            Containers and Kubernetes for application developers
-          </h1>
-          <p className="text-base md:text-lg">
-            Podman Desktop enables you to easily work with containers from your local environment. Podman Desktop
-            leverages{' '}
-            <a href="https://podman.io/" className="text-purple-700 dark:text-purple-400" target="_blank">
-              Podman Engine
-            </a>{' '}
-            to provide a lightweight and daemon-less container tool.
-          </p>
-          <div className="flex-none">
-            {/* With client mode, provides the link to the client browser */}
-            <BrowserOnly fallback={<DownloadGenericLinks></DownloadGenericLinks>}>
-              {() => {
-                return <DownloadClientLinks />;
-              }}
-            </BrowserOnly>
+        <div className="text-center lg:w-2/3 w-full bg-hero-pattern bg-no-repeat bg-center">
+          <div className="bg-white/30 dark:bg-transparent">
+            <h1 className="title-font sm:text-4xl text-3xl lg:text-6xl mb-8 font-medium text-gray-900 dark:text-white">
+              Containers and Kubernetes for application developers
+            </h1>
+            <p className="text-base md:text-lg">
+              Podman Desktop enables you to easily work with containers from your local environment. Podman Desktop
+              leverages{' '}
+              <a href="https://podman.io/" className="text-purple-700 dark:text-purple-400" target="_blank">
+                Podman Engine
+              </a>{' '}
+              to provide a lightweight and daemon-less container tool.
+            </p>
+            <div className="flex-none">
+              {/* With client mode, provides the link to the client browser */}
+              <BrowserOnly fallback={<DownloadGenericLinks></DownloadGenericLinks>}>
+                {() => {
+                  return <DownloadClientLinks />;
+                }}
+             </BrowserOnly>
+            </div>
           </div>
         </div>
         <div className="text-center w-full text-center">

--- a/website/tailwind.config.js
+++ b/website/tailwind.config.js
@@ -6,7 +6,7 @@ module.exports = {
   theme: {
     extend: {
       backgroundImage: {
-        'hero-pattern': "url('/img/gradients.png')",
+        'hero-pattern': 'url(\'/img/gradients.png\')',
       },
       fontFamily: {
         sans: ['Montserrat', ...defaultTheme.fontFamily.sans],

--- a/website/tailwind.config.js
+++ b/website/tailwind.config.js
@@ -6,7 +6,7 @@ module.exports = {
   theme: {
     extend: {
       backgroundImage: {
-        'hero-pattern': 'url(\'/img/gradients.png\')',
+        'hero-pattern': "url('/img/gradients.png')",
       },
       fontFamily: {
         sans: ['Montserrat', ...defaultTheme.fontFamily.sans],


### PR DESCRIPTION
### What does this PR do?

Removes the line below the nav bar in light mode && lightened the hero background gradient in light mode to look at little more polished.

### Screenshot/screencast of this PR

Here is a crude (and optimized, so don't worry about the banding) animated gif showing the difference. It's slight but makes a difference in terms of the text a little easier to read and the overall appearance coming across a bit neater. This change makes it the lighter version.

![diff](https://user-images.githubusercontent.com/799683/197591650-a7b32285-9dd9-4bd7-948e-88d05b946e90.gif)


### What issues does this PR fix or reference?

https://gitlab.com/groups/fedora/design/-/epics/17

### How to test this PR?

yarn start