### PR TITLE
fix: createContainer using Podman API should be a different method on API endpoint

### DIFF
--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -649,7 +649,7 @@ export class ContainerProviderRegistry {
       ...originalConfiguration,
       ...overrideParameters,
     };
-    return libPod.createContainer(configuration);
+    return libPod.createPodmanContainer(configuration);
   }
 
   async stopPod(engineId: string, podId: string): Promise<void> {

--- a/packages/main/src/plugin/dockerode/libpod-dockerode.ts
+++ b/packages/main/src/plugin/dockerode/libpod-dockerode.ts
@@ -98,7 +98,7 @@ export interface ContainerCreateOptions {
 // API of libpod that we want to expose on our side
 export interface LibPod {
   createPod(podOptions: PodCreateOptions): Promise<{ Id: string }>;
-  createContainer(containerCreateOptions: ContainerCreateOptions): Promise<{ Id: string; Warnings: string[] }>;
+  createPodmanContainer(containerCreateOptions: ContainerCreateOptions): Promise<{ Id: string; Warnings: string[] }>;
   listPods(): Promise<PodInfo[]>;
   getPodInspect(podId: string): Promise<PodInspectInfo>;
   startPod(podId: string): Promise<void>;
@@ -110,14 +110,15 @@ export interface LibPod {
 }
 
 // tweak Dockerode by adding the support of libpod API
+// WARNING: make sure to not override existing functions
 export class LibpodDockerode {
   // setup the libpod API
   enhancePrototypeWithLibPod() {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const prototypeOfDockerode = Dockerode.prototype as any;
 
-    // add createContainer
-    prototypeOfDockerode.createContainer = function (containerCreateOptions: ContainerCreateOptions) {
+    // add createPodmanContainer
+    prototypeOfDockerode.createPodmanContainer = function (containerCreateOptions: ContainerCreateOptions) {
       const optsf = {
         path: '/v4.2.0/libpod/containers/create',
         method: 'POST',


### PR DESCRIPTION
### What does this PR do?
createContainer API was overrided with libPod API leading to a different return value.


### Screenshot/screencast of this PR

![image](https://user-images.githubusercontent.com/436777/197816026-456b16fd-6bd5-4dd0-b309-07ad94c11c38.png)


### What issues does this PR fix or reference?

#691 

### How to test this PR?

Try to install a desktop extension

Change-Id: I7210567ae88826bc969f1f12007f6c740b65995d
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
