### PR TITLE
website: justify center the downloads on smaller screens

### DIFF
--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -412,7 +412,7 @@ function RunAnywhere() {
             Use the same UI across different operating systems
           </p>
         </div>
-        <div className="flex flex-wrap w-full">
+        <div className="flex flex-wrap w-full justify-center">
           <div className="p-4 w-11/12 md:w-1/2 lg:w-1/3">
             <div className="flex rounded-lg h-full bg-zinc-300 dark:bg-zinc-700 bg-opacity-60 p-8 flex-col">
               <Link


### PR DESCRIPTION
website: justify center the downloads on smaller screens

### What does this PR do?

Centers the downloads section when viewing on smaller screens.

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

Before:


![Screen Shot 2022-10-26 at 11 04 01 AM](https://user-images.githubusercontent.com/6422176/198063656-d3b52849-3cf6-42ec-8d06-039ca6663090.png)

After:

![Screen Shot 2022-10-26 at 11 03 52 AM](https://user-images.githubusercontent.com/6422176/198063631-565e033f-0613-445f-b93d-b9900870392b.png)


### What issues does this PR fix or reference?

The downloads aren't centered on smaller screens

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

### How to test this PR?

View the site :)

<!-- Please explain steps to reproduce -->

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
