### PR TITLE
chore: Increase build timeout for the CI

### DIFF
--- a/.github/workflows/next-build.yaml
+++ b/.github/workflows/next-build.yaml
@@ -138,7 +138,7 @@ jobs:
           echo "AZURE_KEY_VAULT_URL=${{secrets.AZURE_KEY_VAULT_URL}}" | Out-File -FilePath $env:GITHUB_ENV -Append
 
       - name: Run Build
-        timeout-minutes: 20
+        timeout-minutes: 40
         run: yarn compile:next
 
   release:

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -149,7 +149,7 @@ jobs:
         run: yarn --frozen-lockfile --network-timeout 180000
 
       - name: Run Build
-        timeout-minutes: 20
+        timeout-minutes: 40
         run: yarn compile:pull-request
 
       - name: List Build

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -181,7 +181,7 @@ jobs:
           echo "AZURE_KEY_VAULT_URL=${{secrets.AZURE_KEY_VAULT_URL}}" | Out-File -FilePath $env:GITHUB_ENV -Append
 
       - name: Run Build
-        timeout-minutes: 20
+        timeout-minutes: 40
         run: yarn compile:next
 
   release:


### PR DESCRIPTION
### What does this PR do?
Sometimes the github actions are taking more time than usual
It's still a valid flow, just taking extra time so we shouldn't kill the process.

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?
fixes https://github.com/containers/podman-desktop/issues/695

### How to test this PR?

Looking at the history of actions, you can see some of them are automatically killed after 20mn