### PR TITLE
feat: Drop redundant provider names from dashboard

### DIFF
--- a/packages/renderer/src/lib/welcome/ProviderReady.svelte
+++ b/packages/renderer/src/lib/welcome/ProviderReady.svelte
@@ -21,13 +21,13 @@ let preflightChecks: CheckStatus[] = [];
         version {provider.version}
       </p>
     {/if}
-    {#if provider.containerConnections.length > 0}
+    <!--{#if provider.containerConnections.length > 0}
       <div class="flex flex-row  text-xs text-gray-500 mt-4">
         <p>
           {provider.containerConnections.map(c => c.name).join(', ')}
         </p>
       </div>
-    {/if}
+    {/if}-->
   </div>
   {#if provider.updateInfo}
     <div class="mt-10 mb-1  w-full flex  justify-around">

--- a/packages/renderer/src/lib/welcome/ProviderStarting.svelte
+++ b/packages/renderer/src/lib/welcome/ProviderStarting.svelte
@@ -17,13 +17,13 @@ export let provider: ProviderInfo;
         version {provider.version}
       </p>
     {/if}
-    {#if provider.containerConnections.length > 0}
+    <!-- {#if provider.containerConnections.length > 0}
       <div class="flex flex-row  text-xs text-gray-500 mt-4">
         <p>
           {provider.containerConnections.map(c => c.name).join(', ')}
         </p>
       </div>
-    {/if}
+    {/if} -->
   </div>
   <ProviderLinks provider="{provider}" />
 </div>


### PR DESCRIPTION
Signed-off-by: Dylan M. Taylor <dylan@dylanmtaylor.com>

This PR drops the redundant line stating "Docker" or "Podman" at the bottom of each section.

Before:

![image](https://user-images.githubusercontent.com/277927/198163851-04917bad-8b37-43dd-80f9-453f3c3ca2ef.png)

After:

![image](https://user-images.githubusercontent.com/277927/198163920-0344f6f6-a623-4e67-abd5-6213f7ea604b.png)

