### PR TITLE
feat: Hide the header bar on non-Mac platforms

### DIFF
--- a/packages/main/src/mainWindow.ts
+++ b/packages/main/src/mainWindow.ts
@@ -37,6 +37,7 @@ async function createWindow() {
     minWidth: INITIAL_APP_MIN_WIDTH,
     minHeight: INITIAL_APP_MIN_HEIGHT,
     height: INITIAL_APP_HEIGHT,
+    titleBarStyle: 'hiddenInset', // This property only exists on Mac and is ignored on other platforms.
     webPreferences: {
       webSecurity: false,
       //nativeWindowOpen: true,
@@ -44,11 +45,6 @@ async function createWindow() {
       preload: join(__dirname, '../../preload/dist/index.cjs'),
     },
   };
-
-  if (isMac) {
-    // This property is not available on Linux.
-    browserWindowConstructorOptions.titleBarStyle = 'hiddenInset';
-  }
 
   const browserWindow = new BrowserWindow(browserWindowConstructorOptions);
   const { getCursorScreenPoint, getDisplayNearestPoint } = screen;

--- a/packages/main/src/mainWindow.ts
+++ b/packages/main/src/mainWindow.ts
@@ -74,6 +74,8 @@ async function createWindow() {
     browserWindow?.show();
     if (isMac) {
       app.dock.show();
+    } else {
+      browserWindow.webContents.executeJavaScript("document.getElementById('navbar').style.display = 'none';");
     }
 
     if (import.meta.env.DEV) {


### PR DESCRIPTION
Signed-off-by: Dylan M. Taylor <dylan@dylanmtaylor.com>

This is an implementation for #708. On non-Mac platforms, because they use native OS decorations, unlike on the Mac, this results in a header with 'Podman Desktop' on it, as well as the Window bar which also says 'Podman Desktop'. Until custom controls on other platforms are implemented using frameless windows, I feel like it would make sense to hide this to de-clutter the window.

GNOME with this patch:

![image](https://user-images.githubusercontent.com/277927/198165337-dfb533a8-5a3d-44fb-a51c-f920221a124b.png)


KDE with this patch:

![image](https://user-images.githubusercontent.com/277927/198165163-2a05663b-e563-4bed-86ef-f4666a1d24d0.png)

