### PR TITLE
website: finish sentence about Windows codesigning

### DIFF
--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -365,7 +365,7 @@ function EnterpriseReady() {
                 <h2 className="text-gray-900 dark:text-gray-100 text-lg title-font font-medium mb-2">Code signing</h2>
 
                 <p className="leading-relaxed text-base">
-                  macOS binaries are digitally signed (Windows certification is in)
+                  macOS binaries are digitally signed (Windows certification is in progress).
                 </p>
               </div>
             </div>


### PR DESCRIPTION
Signed-off-by: Fionn Kelleher <self@osslate.net>

### What does this PR do?

Changes the phrasing in the "Enterprise Ready" section of the website to say `macOS binaries are digitally signed (Windows certification is in progress).`, rather than `macOS binaries are digitally signed (Windows certification is in)`.

### Screenshot/screencast of this PR

Left: current
Right: this PR

![image](https://user-images.githubusercontent.com/773673/198269608-35bf119b-c9b8-425f-ae08-811a66e7253b.png)

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Build the website and view the index page.
