### PR TITLE
chore: update iconUrl to a CDN for chocolatey

### DIFF
--- a/.chocolatey/podman-desktop/podman-desktop.nuspec
+++ b/.chocolatey/podman-desktop/podman-desktop.nuspec
@@ -9,7 +9,7 @@
     <owners>https://github.com/containers</owners>
     <licenseUrl>https://github.com/containers/podman-desktop/blob/main/LICENSE</licenseUrl>
     <projectUrl>http://www.podman-desktop.io/</projectUrl>
-    <iconUrl>https://raw.githubusercontent.com/containers/podman-desktop/main/buildResources/icon.png</iconUrl>
+    <iconUrl>https://cdn.jsdelivr.net/gh/containers/podman-desktop@v0.9.1/buildResources/icon.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>
 ## Containers and Kubernetes for application developers


### PR DESCRIPTION

### What does this PR do?
fixes comment reported by moderator
https://community.chocolatey.org/packages/podman-desktop For the next package version can you please switch the iconUrl from github raw to a CDN: https://docs.chocolatey.org/en-us/create/create-packages#package-icon-guidelines


### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

https://community.chocolatey.org/packages/podman-desktop

### How to test this PR?

Try iconUrl link


Change-Id: Ic193925770063f483c69b826a4eb0fe8f0bc1496
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
