### PR TITLE
fix: trim 0.0.1 has a CVE

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,5 +92,8 @@
     "os-locale": "^6.0.2",
     "stream-json": "^1.7.4",
     "tar-fs": "^2.1.1"
+  },
+  "resolutions": {
+    "trim": "0.0.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11954,10 +11954,10 @@ trim-trailing-lines@^1.0.0:
   resolved "https://registry.yarnpkg.com/trim-trailing-lines/-/trim-trailing-lines-1.1.4.tgz#bd4abbec7cc880462f10b2c8b5ce1d8d1ec7c2c0"
   integrity sha512-rjUWSqnfTNrjbB9NQWfPMH/xRK1deHeGsHoVfpxJ++XeYXE0d6B1En37AHfw3jtfTU7dzMzZL2jjpe8Qb5gLIQ==
 
-trim@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.1.tgz#5858547f6b290757ee95cccc666fb50084c460dd"
-  integrity sha1-WFhUf2spB1fulczMZm+1AITEYN0=
+trim@0.0.1, trim@0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.3.tgz#05243a47a3a4113e6b49367880a9cca59697a20b"
+  integrity sha512-h82ywcYhHK7veeelXrCScdH7HkWfbIT1D/CgYO+nmDarz3SGNssVBMws6jU16Ga60AJCRAvPV6w6RLuNerQqjg==
 
 trough@^1.0.0:
   version "1.0.5"


### PR DESCRIPTION
### What does this PR do?

Update 3rd party library to a fixed version
https://github.com/advisories/GHSA-w5p7-h5w8-2hfq

note that it's only used at build time so there is no way that it's impacting Podman Desktop at runtime
But it'll remove security alerts from scanners


### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?

https://github.com/advisories/GHSA-w5p7-h5w8-2hfq

### How to test this PR?

It's used in docusaurus for markdown rendering

Change-Id: I74e3b64741eee14bc8d6d5105cc0f7d996b7d989
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
