### PR TITLE
fix: provide registry config when building images

### DIFF
--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -904,10 +904,15 @@ export class ContainerProviderRegistry {
     if (!matchingContainerProvider || !matchingContainerProvider.api) {
       throw new Error('No provider with a running engine');
     }
+
+    // grab auth for all registries
+    const registryconfig = this.imageRegistry.getRegistryConfig();
+
     const tarStream = tar.pack(containerBuildContextDirectory);
     let streamingPromise;
     try {
       streamingPromise = await matchingContainerProvider.api.buildImage(tarStream, {
+        registryconfig,
         dockerfile: relativeContainerfilePath,
         t: imageName,
       });

--- a/packages/main/src/plugin/image-registry.ts
+++ b/packages/main/src/plugin/image-registry.ts
@@ -91,6 +91,21 @@ export class ImageRegistry {
     return authconfig;
   }
 
+  /**
+   * Provides authentication information from all registries.
+   */
+  getRegistryConfig(): Dockerode.RegistryConfig {
+    const registryConfig: Dockerode.RegistryConfig = {};
+    for (const registry of this.getRegistries()) {
+      const serveraddress = registry.serverUrl.toLowerCase();
+      registryConfig[serveraddress] = {
+        username: registry.username,
+        password: registry.secret,
+      };
+    }
+    return registryConfig;
+  }
+
   getRegistryHash(registry: { serverUrl: string }): string {
     return crypto.createHash('sha512').update(registry.serverUrl).digest('hex');
   }


### PR DESCRIPTION
### What does this PR do?
Add missing auth details for registries when building images.

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/722


### How to test this PR?

Build a containerfile that uses a private image from a registry (and you are authenticated on this registry)

Change-Id: I96bc075409b0639d94c47fed1731d658f2208202
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
