### PR TITLE
fix: do not display volume badge if it's zero

### DIFF
--- a/packages/renderer/src/AppNavigation.svelte
+++ b/packages/renderer/src/AppNavigation.svelte
@@ -249,9 +249,9 @@ export let meta;
           <div class="flex w-full justify-end">
             <div>
               {#if innerWidth >= 768}
-                {#if $volumeListInfos.length > 0}
-                  <span class="pf-c-badge pf-m-read hidden items-center justify-center"
-                    >{$volumeListInfos.map(volumeInfo => volumeInfo.Volumes).flat().length}</span>
+                {@const flattenedVolumes = $volumeListInfos.map(volumeInfo => volumeInfo.Volumes).flat()}
+                {#if flattenedVolumes.length > 0}
+                  <span class="pf-c-badge pf-m-read hidden items-center justify-center">{flattenedVolumes.length}</span>
                 {/if}
               {/if}
             </div>


### PR DESCRIPTION
### What does this PR do?
Ensure we don't display the badge for volumes if there are no volumes

### Screenshot/screencast of this PR

https://user-images.githubusercontent.com/436777/198636691-28a353c5-c02b-4ad5-b536-2f3bfd022086.mp4

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/726


### How to test this PR?

Check badge is gone after deleting all volumes


Change-Id: I05627f95e075543b07b1d7cedbcb19321217d14c
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
