### PR TITLE
feat: move run container from modal to a standalone page

### DIFF
--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -33,6 +33,7 @@ import ContainerPlayKubefile from './lib/container/ContainerPlayKubefile.svelte'
 import PodDetails from './lib/pod/PodDetails.svelte';
 import PodCreateFromContainers from './lib/pod/PodCreateFromContainers.svelte';
 import DeployPodToKube from './lib/pod/DeployPodToKube.svelte';
+import RunImage from './lib/image/RunImage.svelte';
 
 router.mode.hash();
 
@@ -111,6 +112,9 @@ window.events?.receive('display-help', () => {
         </Route>
         <Route path="/images/build">
           <BuildImageFromContainerfile />
+        </Route>
+        <Route path="/images/run">
+          <RunImage />
         </Route>
         <Route path="/images/pull">
           <PullImage />

--- a/packages/renderer/src/lib/ImagesList.svelte
+++ b/packages/renderer/src/lib/ImagesList.svelte
@@ -9,7 +9,6 @@ import ImageActions from './image/ImageActions.svelte';
 import type { ImageInfo } from '../../../main/src/plugin/api/image-info';
 import NoContainerEngineEmptyScreen from './image/NoContainerEngineEmptyScreen.svelte';
 import { providerInfos } from '../stores/providers';
-import RunContainerModal from './image/RunContainerModal.svelte';
 import PushImageModal from './image/PushImageModal.svelte';
 import { ImageUtils } from './image/image-utils';
 import NavPage from './ui/NavPage.svelte';
@@ -23,13 +22,6 @@ $: searchPattern.set(searchTerm);
 
 let images: ImageInfoUI[] = [];
 let multipleEngines = false;
-
-let runContainerFromImageModal = false;
-let runContainerFromImageInfo = undefined;
-function handleRunContainerFromImageModal(imageInfo: ImageInfoUI) {
-  runContainerFromImageInfo = imageInfo;
-  runContainerFromImageModal = true;
-}
 
 let pushImageModal = false;
 let pushImageModalImageInfo = undefined;
@@ -107,7 +99,6 @@ onDestroy(() => {
 });
 
 function closeModals() {
-  runContainerFromImageModal = false;
   pushImageModal = false;
 }
 
@@ -268,10 +259,7 @@ async function deleteSelectedImages() {
             </td>
             <td class="px-6 whitespace-nowrap rounded-tr-lg rounded-br-lg ">
               <div class="flex opacity-0 flex-row justify-end group-hover:opacity-100">
-                <ImageActions
-                  image="{image}"
-                  onPushImage="{handlePushImageModal}"
-                  onRunContainerImage="{handleRunContainerFromImageModal}" />
+                <ImageActions image="{image}" onPushImage="{handlePushImageModal}" />
               </div>
             </td>
           </tr>
@@ -285,14 +273,6 @@ async function deleteSelectedImages() {
       <ImageEmptyScreen images="{$filtered}" />
     {:else}
       <NoContainerEngineEmptyScreen />
-    {/if}
-
-    {#if runContainerFromImageModal}
-      <RunContainerModal
-        image="{runContainerFromImageInfo}"
-        closeCallback="{() => {
-          closeModals();
-        }}" />
     {/if}
 
     {#if pushImageModal}

--- a/packages/renderer/src/lib/image/ImageActions.svelte
+++ b/packages/renderer/src/lib/image/ImageActions.svelte
@@ -1,18 +1,10 @@
 <script lang="ts">
-import Fa from 'svelte-fa/src/fa.svelte';
-import {
-  faCircleUp,
-  faHistory,
-  faLayerGroup,
-  faPlayCircle,
-  faRectangleAd,
-  faTrash,
-} from '@fortawesome/free-solid-svg-icons';
+import { faCircleUp, faLayerGroup, faPlayCircle, faTrash } from '@fortawesome/free-solid-svg-icons';
 import type { ImageInfoUI } from './ImageInfoUI';
 import { router } from 'tinro';
 import ListItemButtonIcon from '../ui/ListItemButtonIcon.svelte';
+import { runImageInfo } from '../../stores/run-image-store';
 
-export let onRunContainerImage: (imageInfo: ImageInfoUI) => void;
 export let onPushImage: (imageInfo: ImageInfoUI) => void;
 
 export let image: ImageInfoUI;
@@ -22,7 +14,8 @@ let errorMessage: string = undefined;
 let isAuthenticatedForThisImage: boolean = false;
 
 async function runImage(imageInfo: ImageInfoUI) {
-  onRunContainerImage(imageInfo);
+  runImageInfo.set(imageInfo);
+  router.goto('/images/run');
 }
 
 $: window.hasAuthconfigForImage(image.name).then(result => (isAuthenticatedForThisImage = result));

--- a/packages/renderer/src/lib/image/ImageDetails.svelte
+++ b/packages/renderer/src/lib/image/ImageDetails.svelte
@@ -8,17 +8,11 @@ import { ImageUtils } from './image-utils';
 import ImageDetailsInspect from './ImageDetailsInspect.svelte';
 import ImageDetailsHistory from './ImageDetailsHistory.svelte';
 import ImageDetailsSummary from './ImageDetailsSummary.svelte';
-import RunContainerModal from './RunContainerModal.svelte';
 import PushImageModal from './PushImageModal.svelte';
 
 export let imageID: string;
 export let engineId: string;
 export let base64RepoTag: string;
-
-let runContainerFromImageModal = false;
-function handleRunContainerFromImageModal() {
-  runContainerFromImageModal = true;
-}
 
 let pushImageModal = false;
 function handlePushImageModal() {
@@ -26,7 +20,6 @@ function handlePushImageModal() {
 }
 
 function closeModals() {
-  runContainerFromImageModal = false;
   pushImageModal = false;
 }
 
@@ -113,11 +106,7 @@ onMount(() => {
           </div>
           <div class="flex flex-row-reverse w-full  px-5 pt-5">
             <div class="flex h-10">
-              <ImageActions
-                image="{image}"
-                backgroundColor="bg-neutral-900"
-                onPushImage="{handlePushImageModal}"
-                onRunContainerImage="{handleRunContainerFromImageModal}" />
+              <ImageActions image="{image}" backgroundColor="bg-neutral-900" onPushImage="{handlePushImageModal}" />
             </div>
           </div>
           <a href="/containers" title="Close Details" class="mt-2 mr-2 text-gray-500"
@@ -135,14 +124,6 @@ onMount(() => {
       </div>
     </div>
   </Route>
-{/if}
-
-{#if runContainerFromImageModal}
-  <RunContainerModal
-    image="{image}"
-    closeCallback="{() => {
-      closeModals();
-    }}" />
 {/if}
 
 {#if pushImageModal}

--- a/packages/renderer/src/lib/image/RunImage.svelte
+++ b/packages/renderer/src/lib/image/RunImage.svelte
@@ -1,0 +1,136 @@
+<script lang="ts">
+import { runImageInfo } from '../../stores/run-image-store';
+import { onMount } from 'svelte';
+import type { ContainerCreateOptions } from '../../../../main/src/plugin/api/container-info';
+import type { ImageInspectInfo } from '../../../../main/src/plugin/api/image-inspect-info';
+import NavPage from '../ui/NavPage.svelte';
+import type { ImageInfoUI } from './ImageInfoUI';
+
+let image: ImageInfoUI;
+
+let imageInspectInfo: ImageInspectInfo;
+
+let containerName = '';
+let containerPortMapping: string[];
+let exposedPorts = [];
+let dataReady = false;
+
+let imageDisplayName = '';
+
+onMount(async () => {
+  runImageInfo.subscribe(async value => {
+    exposedPorts = [];
+    containerPortMapping = [];
+    image = value;
+
+    imageInspectInfo = await window.getImageInspect(image.engineId, image.id);
+    exposedPorts = Array.from(Object.keys(imageInspectInfo?.Config?.ExposedPorts || {}));
+
+    // auto-assign ports from available free port
+    containerPortMapping = new Array<string>(exposedPorts.length);
+    await Promise.all(
+      exposedPorts.map(async (port, index) => {
+        const localPort = await getPort(port);
+        containerPortMapping[index] = `${localPort}`;
+      }),
+    );
+    dataReady = true;
+    if (image.name && image.name.length > 60) {
+      imageDisplayName = '...' + image.name.substring(image.name.length - 60);
+    } else {
+      imageDisplayName = image.name;
+    }
+  });
+});
+
+function getPort(portDescriptor: string): Promise<number | undefined> {
+  let port: number;
+  if (portDescriptor.endsWith('/tcp')) {
+    port = parseInt(portDescriptor.substring(0, portDescriptor.length - 4));
+  } else {
+    port = parseInt(portDescriptor);
+  }
+  // invalid port
+  if (port === NaN) {
+    return Promise.resolve(undefined);
+  }
+  return window.getFreePort(port);
+}
+
+async function startContainer() {
+  // create ExposedPorts objects
+  const ExposedPorts = {};
+
+  const PortBindings = {};
+  exposedPorts.forEach((port, index) => {
+    if (containerPortMapping[index]) {
+      PortBindings[port] = [{ HostPort: containerPortMapping[index] }];
+    }
+    ExposedPorts[port] = {};
+  });
+
+  const Image = image.id;
+
+  const HostConfig = {
+    PortBindings,
+  };
+
+  const options: ContainerCreateOptions = {
+    Image,
+    name: containerName,
+    HostConfig,
+    ExposedPorts,
+  };
+  await window.createAndStartContainer(imageInspectInfo.engineId, options);
+
+  // redirect to containers
+  window.location.href = '#/containers';
+}
+</script>
+
+{#if dataReady}
+  <NavPage
+    title="Create container from Image {imageDisplayName}"
+    searchEnabled="{false}"
+    subtitle="{image.tag}@{image.shortId} ">
+    <div slot="empty" class="bg-zinc-700 p-5 h-full">
+      <div class="bg-zinc-800 px-6 py-4 space-y-6 lg:px-8 sm:pb-6 xl:pb-8">
+        <div>
+          <label for="modalContainerName" class="block mb-2 text-sm font-medium text-gray-900 dark:text-gray-300"
+            >Container Name:</label>
+          <input
+            type="text"
+            bind:value="{containerName}"
+            name="modalContainerName"
+            id="modalContainerName"
+            placeholder="Enter container name (leave blank to have one generated)"
+            class="w-full p-2 outline-none text-sm bg-zinc-900 rounded-sm text-gray-400 placeholder-gray-400"
+            required />
+          <!-- add a label for each port-->
+          <label
+            for="modalContainerName"
+            class:hidden="{exposedPorts.length === 0}"
+            class="pt-6 block mb-2 text-sm font-medium text-gray-900 dark:text-gray-300">Port Mapping:</label>
+          {#each exposedPorts as port, index}
+            <div class="flex flex-row justify-center items-center w-full">
+              <span class="text-sm flex-1 inline-block align-middle whitespace-nowrap text-gray-400"
+                >Local port for {port}:</span>
+              <input
+                type="text"
+                bind:value="{containerPortMapping[index]}"
+                placeholder="Enter value for port {port}"
+                class="ml-2 w-full p-2 outline-none text-sm bg-zinc-900 rounded-sm text-gray-400 placeholder-gray-400"
+                required />
+            </div>
+          {/each}
+        </div>
+
+        <button on:click="{() => startContainer()}" class="w-full pf-c-button pf-m-primary">
+          <span class="pf-c-button__icon pf-m-start">
+            <i class="fas fa-play" aria-hidden="true"></i>
+          </span>
+          Start Container</button>
+      </div>
+    </div>
+  </NavPage>
+{/if}

--- a/packages/renderer/src/stores/run-image-store.ts
+++ b/packages/renderer/src/stores/run-image-store.ts
@@ -1,0 +1,26 @@
+/**********************************************************************
+ * Copyright (C) 2022 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { ImageInfoUI } from 'src/lib/image/ImageInfoUI';
+import type { Writable } from 'svelte/store';
+import { writable } from 'svelte/store';
+
+/**
+ * Defines the store used to define the image to run when starting a container.
+ */
+export const runImageInfo: Writable<ImageInfoUI> = writable();


### PR DESCRIPTION
### What does this PR do?
Use standard layout when running a container
Update UI /  layout

It's a pre-req step to be able to display more options for https://github.com/containers/podman-desktop/issues/375


### Screenshot/screencast of this PR

before:
![image](https://user-images.githubusercontent.com/436777/198677648-1866932d-c3dd-4843-aa66-bef521f1e219.png)


after:
![image](https://user-images.githubusercontent.com/436777/198677690-9b09d4fd-a612-45c1-b857-155cc971fb1b.png)


video:

https://user-images.githubusercontent.com/436777/198677768-2eba0bca-cd2a-4bdc-8cf8-cf0eb74a13f5.mp4





### What issues does this PR fix or reference?

Related to #375 

### How to test this PR?

Try to create a container from an image


Change-Id: Ibc38bfa87ee91fcf9b2d398fae9190d5e14e6d70
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
