### PR TITLE
feat: add listNetworks operation

### DIFF
--- a/packages/main/src/plugin/api/network-info.ts
+++ b/packages/main/src/plugin/api/network-info.ts
@@ -1,0 +1,24 @@
+/**********************************************************************
+ * Copyright (C) 2022 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type Dockerode from 'dockerode';
+
+export interface NetworkInspectInfo extends Dockerode.NetworkInspectInfo {
+  engineId: string;
+  engineName: string;
+}

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -74,6 +74,7 @@ import { CloseBehavior } from './close-behavior';
 import { KubernetesClient } from './kubernetes-client';
 import type { V1Pod, V1ConfigMap, V1NamespaceList, V1PodList, V1Service } from '@kubernetes/client-node';
 import type { V1Route } from './api/openshift-types';
+import type { NetworkInspectInfo } from './api/network-info';
 
 type LogType = 'log' | 'warn' | 'trace' | 'debug' | 'error';
 export class PluginSystem {
@@ -250,6 +251,9 @@ export class PluginSystem {
     });
     this.ipcHandle('container-provider-registry:listPods', async (): Promise<PodInfo[]> => {
       return containerProviderRegistry.listPods();
+    });
+    this.ipcHandle('container-provider-registry:listNetworks', async (): Promise<NetworkInspectInfo[]> => {
+      return containerProviderRegistry.listNetworks();
     });
     this.ipcHandle('container-provider-registry:listVolumes', async (): Promise<VolumeListInfo[]> => {
       return containerProviderRegistry.listVolumes();

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -28,6 +28,7 @@ import type { ContributionInfo } from '../../main/src/plugin/api/contribution-in
 import type { ImageInfo } from '../../main/src/plugin/api/image-info';
 import type { VolumeInspectInfo, VolumeListInfo } from '../../main/src/plugin/api/volume-info';
 import type { PodInfo, PodInspectInfo } from '../../main/src/plugin/api/pod-info';
+import type { NetworkInspectInfo } from '../../main/src/plugin/api/network-info';
 import type { ImageInspectInfo } from '../../main/src/plugin/api/image-inspect-info';
 import type { HistoryInfo } from '../../main/src/plugin/api/history-info';
 import type { ContainerInspectInfo } from '../../main/src/plugin/api/container-inspect-info';
@@ -139,6 +140,10 @@ function initExposure(): void {
 
   contextBridge.exposeInMainWorld('listPods', async (): Promise<PodInfo[]> => {
     return ipcInvoke('container-provider-registry:listPods');
+  });
+
+  contextBridge.exposeInMainWorld('listNetworks', async (): Promise<NetworkInspectInfo[]> => {
+    return ipcInvoke('container-provider-registry:listNetworks');
   });
 
   contextBridge.exposeInMainWorld(


### PR DESCRIPTION
### What does this PR do?
Add a remote method to list the networks
It will allow to reuse a network when creating containers as part of https://github.com/containers/podman-desktop/issues/375

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

#375 

### How to test this PR?

