### PR TITLE
fix: use same default name than using the CLI

### DIFF
--- a/extensions/podman/package.json
+++ b/extensions/podman/package.json
@@ -45,7 +45,7 @@
         },
         "podman.factory.machine.name": {
           "type": "string",
-          "default": "my-machine",
+          "default": "podman-machine-default",
           "scope": "ContainerProviderConnectionFactory",
           "description": "Name of the machine"
         },


### PR DESCRIPTION
### What does this PR do?
Change default machine name for podman provider

### Screenshot/screencast of this PR

![image](https://user-images.githubusercontent.com/436777/199939975-20032a3c-6528-4a1b-a94b-b51952f17320.png)

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/762


### How to test this PR?

Try to create a machine in resources view


Change-Id: I552db1b689a81e58471808578cfd20434fa128b4
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
