### PR TITLE
feat: Allow to use a custom kubeconfig file

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -649,4 +649,18 @@ declare module '@tmpwip/extension-api' {
      */
     export function createStatusBarItem(alignment?: StatusBarAlignment, priority?: number): StatusBarItem;
   }
+
+  export namespace kubernetes {
+    // Path to the configuration file
+    export function getKubeconfig(): Uri;
+    export const onDidChangeKubeconfig: Event<KubeConfigChangeEvent>;
+    export function setKubeconfig(kubeconfig: Uri): Promise<void>;
+  }
+  /**
+   * An event describing the change in kubeconfig location
+   */
+  export interface KubeConfigChangeEvent {
+    readonly oldLocation: Uri;
+    readonly newLocation: Uri;
+  }
 }

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -37,6 +37,7 @@ import type { StatusBarRegistry } from './statusbar/statusbar-registry';
 import { StatusBarAlignLeft, StatusBarAlignRight, StatusBarItemDefaultPriority } from './statusbar/statusbar-item';
 import { FilesystemMonitoring } from './filesystem-monitoring';
 import { Uri } from './types/uri';
+import type { KubernetesClient } from './kubernetes-client';
 
 /**
  * Handle the loading of an extension
@@ -80,6 +81,7 @@ export class ExtensionLoader {
     private progress: ProgressImpl,
     private notifications: NotificationImpl,
     private statusBarRegistry: StatusBarRegistry,
+    private kubernetesClient: KubernetesClient,
   ) {
     this.fileSystemMonitoring = new FilesystemMonitoring();
   }
@@ -383,6 +385,19 @@ export class ExtensionLoader {
       },
     };
 
+    const kubernetesClient = this.kubernetesClient;
+    const kubernetes: typeof containerDesktopAPI.kubernetes = {
+      getKubeconfig(): containerDesktopAPI.Uri {
+        return kubernetesClient.getKubeconfig();
+      },
+      async setKubeconfig(kubeconfig: containerDesktopAPI.Uri): Promise<void> {
+        return kubernetesClient.setKubeconfig(kubeconfig);
+      },
+      onDidChangeKubeconfig: (listener, thisArg, disposables) => {
+        return kubernetesClient.onDidChangeKubeconfig(listener, thisArg, disposables);
+      },
+    };
+
     return <typeof containerDesktopAPI>{
       // Types
       Disposable: Disposable,
@@ -393,6 +408,7 @@ export class ExtensionLoader {
       fs,
       configuration,
       tray,
+      kubernetes,
       ProgressLocation,
       window: windowObj,
       StatusBarItemDefaultPriority,

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -208,7 +208,8 @@ export class PluginSystem {
     const providerRegistry = new ProviderRegistry(apiSender, containerProviderRegistry, telemetry);
     const trayMenuRegistry = new TrayMenuRegistry(this.trayMenu, commandRegistry, providerRegistry, telemetry);
     const statusBarRegistry = new StatusBarRegistry(apiSender);
-    const kubernetesClient = new KubernetesClient();
+    const kubernetesClient = new KubernetesClient(configurationRegistry);
+    await kubernetesClient.init();
     const closeBehaviorConfiguration = new CloseBehavior(configurationRegistry, providerRegistry);
     await closeBehaviorConfiguration.init();
     const autoStartConfiguration = new AutostartEngine(configurationRegistry, providerRegistry);
@@ -240,6 +241,7 @@ export class PluginSystem {
       new ProgressImpl(),
       new NotificationImpl(),
       statusBarRegistry,
+      kubernetesClient,
     );
 
     const contributionManager = new ContributionManager(apiSender);


### PR DESCRIPTION
### What does this PR do?
Allow users to provide their kubeconfig path location instead of letting Podman Desktop to use the default path `$HOME/.kube/config`

### Screenshot/screencast of this PR

![image](https://user-images.githubusercontent.com/436777/200032661-d5bc426a-7ef5-4705-aef7-351ecb2e4e4b.png)


### What issues does this PR fix or reference?

Fixes #657 

### How to test this PR?

Specify an alternate kubeconfig path location in settings and check that kube context displayed in tray icon is accurate

note: https://github.com/containers/podman-desktop/issues/766 will be handled in another PR
