### PR TITLE
fix: Pulling image error on Extension install should stop the flow

### DIFF
--- a/packages/main/src/plugin/docker-extension/docker-desktop-installation.ts
+++ b/packages/main/src/plugin/docker-extension/docker-desktop-installation.ts
@@ -185,7 +185,7 @@ export class DockerDesktopInstallation {
             }
           });
         } catch (error) {
-          reportLog('Error while pulling image: ' + error);
+          event.reply('docker-desktop-plugin:install-error', logCallbackId, 'Error while pulling image: ' + error);
           return;
         }
 


### PR DESCRIPTION
### What does this PR do?
Make sure error is reported but also stop the install flow.

### Screenshot/screencast of this PR

![image](https://user-images.githubusercontent.com/436777/200114584-2847eaa9-4250-49ca-b2ce-d86fe087770e.png)

### What issues does this PR fix or reference?
fixes https://github.com/containers/podman-desktop/issues/781


### How to test this PR?

try to follow https://github.com/containers/podman-desktop/issues/781 test case

Change-Id: Ibc14006129221c7b1fced367b0579abb8e6ef997
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
