### PR TITLE
website: fix windows installation link

### DIFF
--- a/website/src/pages/downloads/windows.tsx
+++ b/website/src/pages/downloads/windows.tsx
@@ -69,7 +69,7 @@ export function WindowsDownloads(): JSX.Element {
             <div>Package managers for Windows:</div>
             <Link
               className="underline inline-flex dark:text-white text-purple-600 hover:text-purple-300 py-2 px-6 font-semibold text-md"
-              to="docs/Installation/windows-install">
+              to="/docs/Installation/windows-install">
               <FontAwesomeIcon size="1x" icon={faWindows} className="mr-2" />
               Windows install guide
             </Link>


### PR DESCRIPTION
### What does this PR do?

[Windows install guide](https://podman-desktop.io/downloads/docs/Installation/windows-install) link works fine from downloads page, but broken if you go to https://podman-desktop.io/downloads/windows (you can get there from the home page like on screenshot).

### Screenshot/screencast of this PR
![изображение](https://user-images.githubusercontent.com/1058537/200187917-68e727bb-0f14-4f2b-a779-263d1ff72405.png)


<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

### How to test this PR?

<!-- Please explain steps to reproduce -->
