### PR TITLE
feat: adds menu for actions on pods and containers

### DIFF
--- a/packages/renderer/src/lib/ContainerList.svelte
+++ b/packages/renderer/src/lib/ContainerList.svelte
@@ -334,7 +334,7 @@ function toggleAllContainerGroups(value: boolean) {
           <th class="text-center font-extrabold w-10 pr-2">Status</th>
           <th>Name</th>
           <th class="text-center">started</th>
-          <th class="text-center">actions</th>
+          <th class="text-right pr-2">actions</th>
         </tr>
       </thead>
 
@@ -379,14 +379,12 @@ function toggleAllContainerGroups(value: boolean) {
                   <div class="ml-2 text-sm text-gray-400"></div>
                 </div>
               </td>
-              <td class="px-6 whitespace-nowrap">
-                <div class="flex flex-row justify-end opacity-0 group-hover:opacity-100">
-                  <!-- Only show POD actions if the container group is POD, otherwise keep blank / empty (for future compose implementation) -->
-                  {#if containerGroup.type === ContainerGroupInfoTypeUI.POD}
-                    <PodActions
-                      pod="{{ id: containerGroup.id, name: containerGroup.name, engineId: containerGroup.engineId }}" />
-                  {/if}
-                </div>
+              <td class="pl-6 text-right whitespace-nowrap">
+                <!-- Only show POD actions if the container group is POD, otherwise keep blank / empty (for future compose implementation) -->
+                {#if containerGroup.type === ContainerGroupInfoTypeUI.POD}
+                  <PodActions
+                    pod="{{ id: containerGroup.id, name: containerGroup.name, engineId: containerGroup.engineId }}" />
+                {/if}
               </td>
             </tr>
           {/if}
@@ -442,12 +440,10 @@ function toggleAllContainerGroups(value: boolean) {
                   </div>
                 </td>
                 <td
-                  class="px-6 whitespace-nowrap {containerGroup.type === ContainerGroupInfoTypeUI.STANDALONE
+                  class="pl-6 text-right whitespace-nowrap {containerGroup.type === ContainerGroupInfoTypeUI.STANDALONE
                     ? 'rounded-tr-lg'
                     : ''} {index === containerGroup.containers.length - 1 ? 'rounded-br-lg' : ''}">
-                  <div class="flex flex-row justify-end opacity-0 group-hover:opacity-100 ">
-                    <ContainerActions container="{container}" />
-                  </div>
+                  <ContainerActions container="{container}" />
                 </td>
               </tr>
             {/each}

--- a/packages/renderer/src/lib/container/ContainerActions.svelte
+++ b/packages/renderer/src/lib/container/ContainerActions.svelte
@@ -1,21 +1,23 @@
 <script lang="ts">
-import { faFileCode, faPlayCircle, faRocket, faTerminal } from '@fortawesome/free-solid-svg-icons';
+import { faEllipsisVertical, faFileCode, faPlayCircle, faRocket, faTerminal } from '@fortawesome/free-solid-svg-icons';
 import { faStopCircle } from '@fortawesome/free-solid-svg-icons';
 import { faArrowsRotate } from '@fortawesome/free-solid-svg-icons';
 import { faTrash } from '@fortawesome/free-solid-svg-icons';
 import { faExternalLinkSquareAlt } from '@fortawesome/free-solid-svg-icons';
 import { ContainerGroupInfoTypeUI, ContainerInfoUI } from './ContainerInfoUI';
+import Fa from 'svelte-fa/src/fa.svelte';
 import { router } from 'tinro';
 import ListItemButtonIcon from '../ui/ListItemButtonIcon.svelte';
+import ListItemButtonIconMenu from '../ui/ListItemButtonIconMenu.svelte';
 
 export let container: ContainerInfoUI;
-export let backgroundColor = 'bg-zinc-800';
 
 async function startContainer(containerInfo: ContainerInfoUI) {
   await window.startContainer(containerInfo.engineId, containerInfo.id);
 }
 
 async function restartContainer(containerInfo: ContainerInfoUI) {
+  toggleMenu();
   await window.restartContainer(containerInfo.engineId, containerInfo.id);
 }
 
@@ -23,69 +25,93 @@ async function stopContainer(containerInfo: ContainerInfoUI) {
   await window.stopContainer(containerInfo.engineId, containerInfo.id);
 }
 function openBrowser(containerInfo: ContainerInfoUI): void {
+  toggleMenu();
   window.openExternal(containerInfo.openingUrl);
 }
 
 async function deleteContainer(containerInfo: ContainerInfoUI): Promise<void> {
+  toggleMenu();
   await window.deleteContainer(containerInfo.engineId, containerInfo.id);
   router.goto('/containers/');
 }
 function openTerminalContainer(containerInfo: ContainerInfoUI): void {
+  toggleMenu();
   router.goto(`/containers/${container.id}/terminal`);
 }
 
 function openGenerateKube(): void {
+  toggleMenu();
   router.goto(`/containers/${container.id}/kube`);
 }
 
 function deployToKubernetes(): void {
+  toggleMenu();
   router.goto(`/deploy-to-kube/${container.id}/${container.engineId}`);
+}
+
+// Toggle the container actions menu by "clicking" the menu button again
+async function toggleMenu() {
+  document.getElementById(container.id).click();
 }
 </script>
 
 <ListItemButtonIcon
-  title="Open Browser"
-  onClick="{() => openBrowser(container)}"
-  hidden="{!(container.state === 'RUNNING' && container.hasPublicPort)}"
-  backgroundColor="{backgroundColor}"
-  icon="{faExternalLinkSquareAlt}" />
-<ListItemButtonIcon
-  title="Open Terminal"
-  onClick="{() => openTerminalContainer(container)}"
-  hidden="{!(container.state === 'RUNNING')}"
-  backgroundColor="{backgroundColor}"
-  icon="{faTerminal}" />
-<ListItemButtonIcon
-  title="Generate Kube"
-  onClick="{() => openGenerateKube()}"
-  hidden="{!(container.engineType === 'podman' && container.groupInfo.type === ContainerGroupInfoTypeUI.STANDALONE)}"
-  backgroundColor="{backgroundColor}"
-  icon="{faFileCode}" />
-<ListItemButtonIcon
-  title="Deploy to Kubernetes"
-  onClick="{() => deployToKubernetes()}"
-  hidden="{!(container.engineType === 'podman' && container.groupInfo.type === ContainerGroupInfoTypeUI.STANDALONE)}"
-  backgroundColor="{backgroundColor}"
-  icon="{faRocket}" />
-<ListItemButtonIcon
   title="Start Container"
   onClick="{() => startContainer(container)}"
   hidden="{container.state === 'RUNNING'}"
-  backgroundColor="{backgroundColor}"
   icon="{faPlayCircle}" />
+
 <ListItemButtonIcon
   title="Stop Container"
   onClick="{() => stopContainer(container)}"
   hidden="{!(container.state === 'RUNNING')}"
-  backgroundColor="{backgroundColor}"
   icon="{faStopCircle}" />
-<ListItemButtonIcon
-  title="Restart Container"
-  onClick="{() => restartContainer(container)}"
-  backgroundColor="{backgroundColor}"
-  icon="{faArrowsRotate}" />
-<ListItemButtonIcon
-  title="Delete Container"
-  onClick="{() => deleteContainer(container)}"
-  backgroundColor="{backgroundColor}"
-  icon="{faTrash}" />
+
+<!-- Create a "kebab" menu for additional actions. -->
+<div class="relative inline-block text-left">
+  <!-- We use a "checkbox" input in order to use the peer:checked functionality of tailwindcss 
+    this avoids us having to implement a manual custom.css for menus -->
+  <input class="sr-only peer text-red-600" type="checkbox" value="yes" name="answer" id="{container.id}" />
+
+  <!-- Label it similar to all the other container action icons -->
+  <label
+    class="mx-1 text-gray-300 hover:text-violet-600 font-medium rounded-lg text-sm inline-flex items-center p-2 text-center "
+    for="{container.id}">
+    <Fa class="h-4 w-4 text-xl" icon="{faEllipsisVertical}" />
+  </label>
+
+  <!-- Dropdown menu for all other actions -->
+  <div
+    id="dropdown"
+    class="peer-checked:block hidden origin-top-right absolute right-0 z-10 mt-2 w-56 rounded-md shadow-lg bg-zinc-800 ring-1 ring-black ring-opacity-5 divide-y divide-gray-300 focus:outline-none">
+    <ListItemButtonIconMenu
+      title="Generate Kube"
+      onClick="{() => openGenerateKube()}"
+      hidden="{!(
+        container.engineType === 'podman' && container.groupInfo.type === ContainerGroupInfoTypeUI.STANDALONE
+      )}"
+      icon="{faFileCode}" />
+    <ListItemButtonIconMenu
+      title="Deploy to Kubernetes"
+      onClick="{() => deployToKubernetes()}"
+      hidden="{!(
+        container.engineType === 'podman' && container.groupInfo.type === ContainerGroupInfoTypeUI.STANDALONE
+      )}"
+      icon="{faRocket}" />
+    <ListItemButtonIconMenu
+      title="Open Browser"
+      onClick="{() => openBrowser(container)}"
+      hidden="{!(container.state === 'RUNNING' && container.hasPublicPort)}"
+      icon="{faExternalLinkSquareAlt}" />
+    <ListItemButtonIconMenu
+      title="Open Terminal"
+      onClick="{() => openTerminalContainer(container)}"
+      hidden="{!(container.state === 'RUNNING')}"
+      icon="{faTerminal}" />
+    <ListItemButtonIconMenu
+      title="Restart Container"
+      onClick="{() => restartContainer(container)}"
+      icon="{faArrowsRotate}" />
+    <ListItemButtonIconMenu title="Delete Container" onClick="{() => deleteContainer(container)}" icon="{faTrash}" />
+  </div>
+</div>

--- a/packages/renderer/src/lib/pod/PodActions.svelte
+++ b/packages/renderer/src/lib/pod/PodActions.svelte
@@ -1,20 +1,22 @@
 <script lang="ts">
-import { faFileCode, faPlayCircle, faRocket } from '@fortawesome/free-solid-svg-icons';
+import { faFileCode, faPlayCircle, faRocket, faEllipsisVertical } from '@fortawesome/free-solid-svg-icons';
 import { faStopCircle } from '@fortawesome/free-solid-svg-icons';
 import { faArrowsRotate } from '@fortawesome/free-solid-svg-icons';
 import { faTrash } from '@fortawesome/free-solid-svg-icons';
 import type { PodInfoUI } from './PodInfoUI';
 import { router } from 'tinro';
+import Fa from 'svelte-fa/src/fa.svelte';
 import ListItemButtonIcon from '../ui/ListItemButtonIcon.svelte';
+import ListItemButtonIconMenu from '../ui/ListItemButtonIconMenu.svelte';
 
 export let pod: PodInfoUI;
-export let backgroundColor = 'bg-zinc-800';
 
 async function startPod(podInfoUI: PodInfoUI) {
   await window.startPod(podInfoUI.engineId, podInfoUI.id);
 }
 
 async function restartPod(podInfoUI: PodInfoUI) {
+  toggleMenu();
   await window.restartPod(podInfoUI.engineId, podInfoUI.id);
 }
 
@@ -23,6 +25,7 @@ async function stopPod(podInfoUI: PodInfoUI) {
 }
 
 async function removePod(podInfoUI: PodInfoUI): Promise<void> {
+  toggleMenu();
   await window.removePod(podInfoUI.engineId, podInfoUI.id);
   router.goto('/pods/');
 }
@@ -34,37 +37,44 @@ function openGenerateKube(): void {
 function deployToKubernetes(): void {
   router.goto(`/deploy-to-kube/${pod.id}/${pod.engineId}`);
 }
+
+// Toggle the container actions menu by "clicking" the menu button again
+async function toggleMenu() {
+  document.getElementById(pod.id).click();
+}
 </script>
 
-<ListItemButtonIcon
-  title="Generate Kube"
-  onClick="{() => openGenerateKube()}"
-  backgroundColor="{backgroundColor}"
-  icon="{faFileCode}" />
-<ListItemButtonIcon
-  title="Deploy to Kubernetes"
-  onClick="{() => deployToKubernetes()}"
-  backgroundColor="{backgroundColor}"
-  icon="{faRocket}" />
 <ListItemButtonIcon
   title="Start Pod"
   onClick="{() => startPod(pod)}"
   hidden="{pod.status === 'RUNNING'}"
-  backgroundColor="{backgroundColor}"
   icon="{faPlayCircle}" />
 <ListItemButtonIcon
   title="Stop Pod"
   onClick="{() => stopPod(pod)}"
   hidden="{!(pod.status === 'RUNNING')}"
-  backgroundColor="{backgroundColor}"
   icon="{faStopCircle}" />
-<ListItemButtonIcon
-  title="Restart Pod"
-  onClick="{() => restartPod(pod)}"
-  backgroundColor="{backgroundColor}"
-  icon="{faArrowsRotate}" />
-<ListItemButtonIcon
-  title="Delete Pod"
-  onClick="{() => removePod(pod)}"
-  backgroundColor="{backgroundColor}"
-  icon="{faTrash}" />
+
+<!-- Create a "kebab" menu for additional actions. -->
+<div class="relative inline-block text-left">
+  <!-- We use a "checkbox" input in order to use the peer:checked functionality of tailwindcss 
+    this avoids us having to implement a manual custom.css for menus -->
+  <input class="sr-only peer text-red-600" type="checkbox" value="yes" name="answer" id="{pod.id}" />
+
+  <!-- Label it similar to all the other container action icons -->
+  <label
+    class="mx-1 text-gray-300 hover:text-violet-600 font-medium rounded-lg text-sm inline-flex items-center p-2 text-center "
+    for="{pod.id}">
+    <Fa class="h-4 w-4 text-xl" icon="{faEllipsisVertical}" />
+  </label>
+
+  <!-- Dropdown menu for all other actions -->
+  <div
+    id="dropdown"
+    class="peer-checked:block hidden origin-top-right absolute right-0 z-10 mt-2 w-56 rounded-md shadow-lg bg-zinc-800 ring-1 ring-black ring-opacity-5 divide-y divide-gray-300 focus:outline-none">
+    <ListItemButtonIconMenu title="Generate Kube" onClick="{() => openGenerateKube()}" icon="{faFileCode}" />
+    <ListItemButtonIconMenu title="Deploy to Kubernetes" onClick="{() => deployToKubernetes()}" icon="{faRocket}" />
+    <ListItemButtonIconMenu title="Restart Pod" onClick="{() => restartPod(pod)}" icon="{faArrowsRotate}" />
+    <ListItemButtonIconMenu title="Delete Pod" onClick="{() => removePod(pod)}" icon="{faTrash}" />
+  </div>
+</div>

--- a/packages/renderer/src/lib/pod/PodsList.svelte
+++ b/packages/renderer/src/lib/pod/PodsList.svelte
@@ -165,7 +165,7 @@ function openContainersFromPod(pod: PodInfoUI) {
           <th class="text-center font-extrabold w-10">status</th>
           <th class="text-center font-extrabold w-10">Name</th>
           <th class="text-center">Creation date</th>
-          <th class="text-center">actions</th>
+          <th class="text-right pr-2">actions</th>
         </tr>
       </thead>
       <tbody class="">
@@ -223,10 +223,8 @@ function openContainersFromPod(pod: PodInfoUI) {
               </div>
             </td>
 
-            <td class="px-6 whitespace-nowrap rounded-tr-lg rounded-br-lg ">
-              <div class="flex opacity-0 flex-row justify-end group-hover:opacity-100">
-                <PodActions pod="{pod}" />
-              </div>
+            <td class="pl-6 text-right whitespace-nowrap">
+              <PodActions pod="{pod}" />
             </td>
           </tr>
           <tr><td class="leading-[8px]">&nbsp;</td></tr>

--- a/packages/renderer/src/lib/ui/ListItemButtonIcon.svelte
+++ b/packages/renderer/src/lib/ui/ListItemButtonIcon.svelte
@@ -6,13 +6,12 @@ export let title: string;
 export let icon: IconDefinition;
 export let hidden: boolean = false;
 export let onClick: () => void = () => {};
-export let backgroundColor: string = 'bg-zinc-800';
 </script>
 
 <button
   title="{title}"
   on:click="{onClick}"
-  class="mx-1 text-gray-300 {backgroundColor}  hover:text-violet-600 font-medium rounded-lg text-sm inline-flex items-center px-3 py-2 text-center"
+  class="p-2 text-gray-300 hover:text-violet-600 font-medium rounded-lg text-sm inline-flex items-center text-center"
   class:hidden
   ><Fa class="h-4 w-4 text-xl" icon="{icon}" />
 </button>

--- a/packages/renderer/src/lib/ui/ListItemButtonIconMenu.svelte
+++ b/packages/renderer/src/lib/ui/ListItemButtonIconMenu.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+import type { IconDefinition } from '@fortawesome/free-solid-svg-icons';
+import Fa from 'svelte-fa/src/fa.svelte';
+
+export let title: string;
+export let icon: IconDefinition;
+export let hidden: boolean = false;
+export let onClick: () => void = () => {};
+</script>
+
+<div class="py-1" role="none">
+  <a
+    title="{title}"
+    on:click="{onClick}"
+    class="text-gray-300 group flex items-center px-4 py-2 text-sm hover:text-violet-600"
+    role="menuitem"
+    tabindex="-1"
+    id="menu-item-1">
+    <Fa class="h-4 w-4 text-xl mr-2" icon="{icon}" />
+    {title}
+  </a>
+</div>


### PR DESCRIPTION
feat: adds menu for actions on pods and containers

### What does this PR do?

* This PR adds a "kebab" menu for the actions on containers
  as well as pods.

* Added due to more actions now filling the action bar, adding a menu
  helps reduce visual noise

* No more infering through the icon, actions now have descriptive words
  describing the action

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
![Screen Shot 2022-11-08 at 1 45 39 PM](https://user-images.githubusercontent.com/6422176/200652769-458af287-cb46-4751-a79f-848dae01aea1.png)
![Screen Shot 2022-11-08 at 1 45 32 PM](https://user-images.githubusercontent.com/6422176/200652775-9cb7b117-9b35-41e1-9616-9db964484a9c.png)



### What issues does this PR fix or reference?

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

This  menu was implemented while testing out https://github.com/containers/podman-desktop/issues/506

### How to test this PR?

`yarn watch` and press the action button

<!-- Please explain steps to reproduce -->
