### PR TITLE
docs: add k8s slack channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ For all bug and feature requests please [file a GitHub issue](https://github.com
 
 Discussions are done using [Github Discussions](https://github.com/containers/podman-desktop/discussions/).
 
-Join #podman-desktop on the [Kubernetes Slack](https://communityinviter.com/apps/kubernetes/community).
+Join [#podman-desktop](https://app.slack.com/client/T09NY5SBT/C04A0L7LUFM) on the [Kubernetes Slack](https://slack.k8s.io/).
 
 Hangout with us on [Discord](https://discordapp.com/invite/TCTB38RWpf)
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ For all bug and feature requests please [file a GitHub issue](https://github.com
 
 Discussions are done using [Github Discussions](https://github.com/containers/podman-desktop/discussions/).
 
+Join #podman-desktop on the [Kubernetes Slack](https://communityinviter.com/apps/kubernetes/community).
+
+Hangout with us on [Discord](https://discordapp.com/invite/TCTB38RWpf)
+
 ## Code of Conduct
 
 This project uses the [Containers Community Code of Conduct](https://github.com/containers/common/blob/main/CODE-OF-CONDUCT.md).

--- a/packages/renderer/src/lib/help/HelpPage.svelte
+++ b/packages/renderer/src/lib/help/HelpPage.svelte
@@ -41,8 +41,8 @@
       <li class="pb-2">
         <i class="fas fa-comments" aria-hidden="true"></i>
         <p
-          on:click="{() => window.openExternal('https://communityinviter.com/apps/kubernetes/community')}"
-          title="https://communityinviter.com/apps/kubernetes/community"
+          on:click="{() => window.openExternal('https://slack.k8s.io/')}"
+          title="https://slack.k8s.io/"
           class="text-sm inline-flex ml-1 cursor-pointer text-violet-400 hover:text-violet-600 hover:no-underline">
           Join #podman-desktop on Kubernetes Slack
         </p>

--- a/packages/renderer/src/lib/help/HelpPage.svelte
+++ b/packages/renderer/src/lib/help/HelpPage.svelte
@@ -41,10 +41,20 @@
       <li class="pb-2">
         <i class="fas fa-comments" aria-hidden="true"></i>
         <p
+          on:click="{() => window.openExternal('https://communityinviter.com/apps/kubernetes/community')}"
+          title="https://communityinviter.com/apps/kubernetes/community"
+          class="text-sm inline-flex ml-1 cursor-pointer text-violet-400 hover:text-violet-600 hover:no-underline">
+          Join #podman-desktop on Kubernetes Slack
+        </p>
+      </li>
+
+      <li class="pb-2">
+        <i class="fas fa-comments" aria-hidden="true"></i>
+        <p
           on:click="{() => window.openExternal('https://discordapp.com/invite/TCTB38RWpf')}"
           title="https://discordapp.com/invite/TCTB38RWpf"
           class="text-sm inline-flex ml-1 cursor-pointer text-violet-400 hover:text-violet-600 hover:no-underline">
-          Discuss with us
+          Hang out with us on Discord
         </p>
       </li>
     </ul>

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -109,7 +109,11 @@ const config = {
                 href: 'https://github.com/containers/podman-desktop',
               },
               {
-                label: 'Chat with us',
+                label: 'Join #podman-desktop on the Kubernetes Slack',
+                href: 'https://communityinviter.com/apps/kubernetes/community',
+              },
+              {
+                label: 'Hang out with us on Discord',
                 href: 'https://discordapp.com/invite/TCTB38RWpf',
               },
               {

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -110,7 +110,7 @@ const config = {
               },
               {
                 label: 'Join #podman-desktop on the Kubernetes Slack',
-                href: 'https://communityinviter.com/apps/kubernetes/community',
+                href: 'https://slack.k8s.io/',
               },
               {
                 label: 'Hang out with us on Discord',


### PR DESCRIPTION
docs: add k8s slack channel

### What does this PR do?

Adds the Kubernetes slack channel to the site / README as well as Podman
Desktop help page

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

N/A

### What issues does this PR fix or reference?

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

N/A

### How to test this PR?

N/A

<!-- Please explain steps to reproduce -->

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
