### PR TITLE
feat: menu implementation

### DIFF
--- a/packages/renderer/src/lib/menu/Menu.svelte
+++ b/packages/renderer/src/lib/menu/Menu.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+import { setContext, createEventDispatcher } from 'svelte';
+import { key } from './menu.ts';
+
+export let x;
+export let y;
+
+// whenever x and y is changed, restrict box to be within bounds
+$: (() => {
+  if (!menuEl) return;
+
+  const rect = menuEl.getBoundingClientRect();
+  x = Math.min(window.innerWidth - rect.width, x);
+  if (y > window.innerHeight - rect.height) y -= rect.height;
+})(x, y);
+
+const dispatch = createEventDispatcher();
+
+setContext(key, {
+  dispatchClick: () => dispatch('click'),
+});
+
+let menuEl;
+function onPageClick(event: PointerEvent) {
+  if (event.target === menuEl || menuEl.contains(event.target)) return;
+  dispatch('clickoutside');
+}
+</script>
+
+<svelte:body on:click="{onPageClick}" />
+
+<div
+  bind:this="{menuEl}"
+  style="top: {y}px; left: {x}px;"
+  class="absolute z-10 w-40 origin-top-right border border-gray-600 bg-zinc-800 shadow-md focus:outline-none right-5 top-2">
+  <slot />
+</div>

--- a/packages/renderer/src/lib/menu/MenuOption.svelte
+++ b/packages/renderer/src/lib/menu/MenuOption.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+import { getContext } from 'svelte';
+import { key } from './menu.ts';
+
+export let isDisabled = false;
+export let text = '';
+
+import { createEventDispatcher } from 'svelte';
+const dispatch = createEventDispatcher();
+
+const { dispatchClick } = getContext(key);
+
+const handleClick = event => {
+  if (isDisabled) return;
+
+  dispatch('click');
+  dispatchClick();
+};
+</script>
+
+<div
+  class:disabled="{isDisabled}"
+  on:click="{event => handleClick(event)}"
+  class="text-white block px-4 py-1 text-sm w-full text-left hover:bg-zinc-700 hover:no-underline">
+  {#if text}
+    {text}
+  {:else}
+    <slot />
+  {/if}
+</div>

--- a/packages/renderer/src/lib/menu/menu.ts
+++ b/packages/renderer/src/lib/menu/menu.ts
@@ -1,0 +1,3 @@
+const key = {};
+
+export { key };


### PR DESCRIPTION
### What does this PR do?
The following changes proposal brings menu implementation:

```typescript
<script lang="ts">
	import Menu from './Menu.svelte';
	import MenuOption from './MenuOption.svelte';
	
	let pos = { x: 0, y: 0 };
	let showMenu = false;
	
	function showMenu(event: PointerEvent) {
		pos = { x: e.clientX, y: e.clientY };
		showMenu = true;
	}
	
	function closeMenu() {
		showMenu = false;
	}
</script>

<button
  on:click={event => showMenu(event)}
  type="button">
  Show Menu
</button>

{#if showMenu}
	<Menu {...pos} on:click={closeMenu} on:clickoutside={closeMenu}>
		<MenuOption 
			on:click={console.log} 
			text="Do nothing" />
		<MenuOption 
			on:click={console.log} 
			text="Do nothing, but twice" />
	</Menu>
{/if}
```

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>

### Screenshot/screencast of this PR

![Снимок экрана 2022-11-09 в 16 03 56](https://user-images.githubusercontent.com/1968177/200850765-7d95d79f-ba83-4649-b084-0f9c3675c72b.png)

### What issues does this PR fix or reference?

Part of #446 

### How to test this PR?

Use the sample of code provided in PR description.
