### PR TITLE
fix: increase contrast for image tag in images list

### DIFF
--- a/packages/renderer/src/lib/ImagesList.svelte
+++ b/packages/renderer/src/lib/ImagesList.svelte
@@ -234,7 +234,7 @@ async function deleteSelectedImages() {
                   </div>
                   <div class="flex flex-row items-center">
                     <div class="text-xs text-violet-400">{image.shortId}</div>
-                    <div class="ml-1 text-xs font-extra-light text-gray-500">{image.tag}</div>
+                    <div class="ml-1 text-xs font-extra-light text-gray-300">{image.tag}</div>
                   </div>
                   <div class="flex flex-row text-xs font-extra-light text-gray-500">
                     <!-- Hide in case of single engine-->


### PR DESCRIPTION
### What does this PR do?

Increase contrast for the tag name

### Screenshot/screencast of this PR

before: (from the issue)
![image](https://user-images.githubusercontent.com/436777/200875265-99e9d0a1-deda-4d21-99f7-c114ca1d55f7.png)

After:
![image](https://user-images.githubusercontent.com/436777/200873752-1f0b6397-351f-4ec4-8f2f-1843b9dc7ff4.png)

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/801


### How to test this PR?

Look at tags in image list



Change-Id: Ia1a07311c484f121f335a1ff4654026cca38b71f
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
