### PR TITLE
chore: introduce devcontainer to try it out everything from inside a container

### DIFF
--- a/.devcontainer/.parent/Containerfile
+++ b/.devcontainer/.parent/Containerfile
@@ -1,0 +1,60 @@
+FROM quay.io/fedora/fedora:37
+
+# install Node.js + yarn
+ENV NODE_VERSION 16.18.1
+RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz" && \
+    tar -xzf "node-v$NODE_VERSION-linux-x64.tar.gz" -C /usr/local --strip-components=1 && \
+    rm "node-v$NODE_VERSION-linux-x64.tar.gz" && \
+    npm install -g yarn
+
+RUN dnf -y update && \
+    yum -y reinstall shadow-utils && \
+    yum install -y git \
+                   # dependencies for Podman Desktop
+                   nss \
+                   atk \
+                   at-spi2-atk \
+                   cups-libs \
+                   gtk3 \
+                   # for remote Display
+                   fluxbox \
+                   tigervnc-server \
+                   xorg-x11-fonts-Type1 \
+                   novnc \
+                   supervisor \
+                   xdpyinfo \
+                   # for podman
+                   podman \
+                   fuse-overlayfs --exclude container-selinux \
+                   xterm && \
+    rm -rf /var/cache /var/log/dnf* /var/log/yum.*
+COPY entrypoint.sh /entrypoint.sh
+COPY supervisord.conf /etc/supervisord.conf
+COPY fluxbox /usr/share/fluxbox/init
+RUN useradd -u 1000 podman-desktop && echo podman-desktop:10000:5000 > /etc/subuid && echo podman-desktop:10000:5000 > /etc/subgid
+
+# Disable telemetry
+RUN mkdir -p /home/podman-desktop/.local/share/containers/podman-desktop/configuration && \
+    echo '{"telemetry.enabled": false, "telemetry.check": true}' > /home/podman-desktop/.local/share/containers/podman-desktop/configuration/settings.json
+
+# expose port for VNC
+EXPOSE 8080
+
+# initialize conf files
+ADD https://raw.githubusercontent.com/containers/libpod/master/contrib/podmanimage/stable/containers.conf /etc/containers/containers.conf
+ADD https://raw.githubusercontent.com/containers/libpod/master/contrib/podmanimage/stable/podman-containers.conf /home/podman-desktop/.config/containers/containers.conf
+
+# set permissions
+RUN chown podman-desktop:podman-desktop -R /home/podman-desktop && chmod 644 /etc/containers/containers.conf && \
+    mkdir -p /var/lib/shared/overlay-images /var/lib/shared/overlay-layers /var/lib/shared/vfs-images /var/lib/shared/vfs-layers; touch /var/lib/shared/overlay-images/images.lock; touch /var/lib/shared/overlay-layers/layers.lock; touch /var/lib/shared/vfs-images/images.lock; touch /var/lib/shared/vfs-layers/layers.lock && \
+    mkdir -p /run/user/1000 && chown podman-desktop:podman-desktop /run/user/1000
+
+
+ENV _CONTAINERS_USERNS_CONFIGURED=""
+
+# socket path for podman
+ENV XDG_RUNTIME_DIR=/run/user/1000
+
+ENTRYPOINT [ "/entrypoint.sh" ]
+USER podman-desktop
+CMD ["tail", "-f", "/dev/null"]

--- a/.devcontainer/.parent/entrypoint.sh
+++ b/.devcontainer/.parent/entrypoint.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+#
+# Copyright (C) 2022 Red Hat, Inc.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+ 
+# Ensure $HOME exists when starting
+if [ ! -d "${HOME}" ]; then
+  mkdir -p "${HOME}"
+fi
+
+# Setup $PS1 for a consistent and reasonable prompt
+if [ -w "${HOME}" ] && [ ! -f "${HOME}"/.bashrc ]; then
+  echo "PS1='\s-\v \w \$ '" > "${HOME}"/.bashrc
+fi
+
+# Add current (arbitrary) user to /etc/passwd and /etc/group
+if ! whoami > /dev/null 2>&1; then
+  if [ -w /etc/passwd ]; then
+    echo "update passwd file"
+    echo "${USER_NAME:-user}:x:$(id -u):0:${USER_NAME:-user} user:${HOME}:/bin/bash" >> /etc/passwd
+    echo "${USER_NAME:-user}:x:$(id -u):" >> /etc/group
+  fi
+fi
+/usr/bin/supervisord -c /etc/supervisord.conf

--- a/.devcontainer/.parent/fluxbox
+++ b/.devcontainer/.parent/fluxbox
@@ -1,0 +1,13 @@
+! If you're looking for settings to configure, they won't be saved here until
+! you change something in the fluxbox configuration menu.
+
+session.menuFile:	~/.fluxbox/menu
+session.keyFile: ~/.fluxbox/keys
+! Change the default theme
+session.styleFile: /usr/share/fluxbox/styles/bora_blue
+session.configVersion:	13
+session.screen0.toolbar.widthPercent: 100
+session.screen0.strftimeFormat: %d %b, %a %02k:%M:%S
+session.screen0.toolbar.tools: prevworkspace, workspacename, nextworkspace, clock, prevwindow, nextwindow, iconbar, systemtray
+! disable toolbar
+session.screen0.toolbar.visible:	false

--- a/.devcontainer/.parent/supervisord.conf
+++ b/.devcontainer/.parent/supervisord.conf
@@ -1,0 +1,18 @@
+[supervisord]
+nodaemon=true
+logfile = /home/podman-desktop/supervisord.log
+pidfile = /home/podman-desktop/supervisord.pid
+
+[program:tigervnc]
+environment=DISPLAY=":0"
+command=vncserver :0 -geometry 1920x1080 -depth 24 -SecurityTypes None
+user=podman-desktop
+autorestart=false
+priority=300
+
+[program:windowmanager]
+environment=DISPLAY=":0"
+command=fluxbox
+user=podman-desktop
+autorestart=true
+priority=350

--- a/.devcontainer/Containerfile
+++ b/.devcontainer/Containerfile
@@ -1,0 +1,2 @@
+FROM quay.io/podman-desktop/devcontainer-parent:next
+

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,39 @@
+{
+  "name": "Podman Desktop",
+  "build": {
+    "dockerfile": "Containerfile"
+  },
+  // do not use root
+  "containerUser": "podman-desktop",
+  // Add the IDs of extensions you want installed when the container is created.
+  "extensions": ["svelte.svelte-vscode", "bradlc.vscode-tailwindcss"],
+  "features": {},
+  "runArgs": [
+    "--cap-add=sys_admin",
+    "--security-opt",
+    "seccomp=unconfined",
+    "--device",
+    "/dev/fuse",
+    "--security-opt",
+    "label=disable",
+    "--security-opt",
+    "apparmor=unconfined"
+  ],
+  "postStartCommand": "${containerWorkspaceFolder}/.devcontainer/postStartCommand.sh",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
+  "workspaceFolder": "/workspace",
+  "onCreateCommand": "${containerWorkspaceFolder}/.devcontainer/onCreateCommand.sh",
+  "updateContentCommand": "${containerWorkspaceFolder}/.devcontainer/updateContentCommand.sh",
+  "remoteEnv": {
+    "DISPLAY": ":0"
+  },
+  "portsAttributes": {
+    "9000": {
+      "label": "vnc",
+      "onAutoForward": "openPreview"
+    },
+    "3000": {
+      "label": "website"
+    }
+  }
+}

--- a/.devcontainer/onCreateCommand.sh
+++ b/.devcontainer/onCreateCommand.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+#
+# Copyright (C) 2022 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# This script is run inside the container after the repo has been cloned.
+# Launch yarn to install dependencies and build the project.
+yarn
+
+# build podman-desktop
+MODE=production yarn run build && yarn run electron-builder build --linux --dir --config .electron-builder.config.js

--- a/.devcontainer/postStartCommand.sh
+++ b/.devcontainer/postStartCommand.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+#
+# Copyright (C) 2022 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Need to start all services
+/usr/bin/supervisord -c /etc/supervisord.conf &
+
+# wait X server to be ready or after 2mn exit
+echo "Waiting for X server to be ready"
+timeout 120 bash -c 'until xdpyinfo -display :0 &> /dev/null; do printf "."; sleep 1; done'
+
+# launch podman desktop
+echo "Launching Podman Desktop"
+cd dist/linux-unpacked/&& ./podman-desktop &
+
+
+# Launch the 9000 redirect after 20 seconds
+sleep 20
+websockify --web=/usr/share/novnc localhost:9000 localhost:5900 &
+
+# launch the website rendering
+echo "Launching Website"
+cd website && yarn start

--- a/.devcontainer/updateContentCommand.sh
+++ b/.devcontainer/updateContentCommand.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+#
+# Copyright (C) 2022 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Do nothing for now (maybe need to use postStartCommand.sh)


### PR DESCRIPTION
### What does this PR do?
Introduce devcontainer.json file 
it allows to try podman desktop running containers within a custom container including podman, rendering being displayed on VNC side.

Also you can explore the website. Watch mode is not possible due to a lack of memory but it's possible to compile binaries and run them.

### Screenshot/screencast of this PR

https://user-images.githubusercontent.com/436777/201101343-76a72fdc-9132-43f7-aa4a-a7760592066b.mp4




### What issues does this PR fix or reference?

N/A

### How to test this PR?




Change-Id: Ia14558c92ef45fa58b81d8e32064df6d859cd80f
Signed-off-by: Florent Benoit <fbenoit@redhat.com>