### PR TITLE
feat: Reload kubernetes context if it is changed over time

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -653,14 +653,14 @@ declare module '@tmpwip/extension-api' {
   export namespace kubernetes {
     // Path to the configuration file
     export function getKubeconfig(): Uri;
-    export const onDidChangeKubeconfig: Event<KubeConfigChangeEvent>;
+    export const onDidUpdateKubeconfig: Event<KubeconfigUpdateEvent>;
     export function setKubeconfig(kubeconfig: Uri): Promise<void>;
   }
   /**
-   * An event describing the change in kubeconfig location
+   * An event describing the update in kubeconfig location
    */
-  export interface KubeConfigChangeEvent {
-    readonly oldLocation: Uri;
-    readonly newLocation: Uri;
+  export interface KubeconfigUpdateEvent {
+    readonly type: 'CREATE' | 'UPDATE' | 'DELETE';
+    readonly location: Uri;
   }
 }

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -35,7 +35,7 @@ import type { NotificationImpl } from './notification-impl';
 import { StatusBarItemImpl } from './statusbar/statusbar-item';
 import type { StatusBarRegistry } from './statusbar/statusbar-registry';
 import { StatusBarAlignLeft, StatusBarAlignRight, StatusBarItemDefaultPriority } from './statusbar/statusbar-item';
-import { FilesystemMonitoring } from './filesystem-monitoring';
+import type { FilesystemMonitoring } from './filesystem-monitoring';
 import { Uri } from './types/uri';
 import type { KubernetesClient } from './kubernetes-client';
 
@@ -67,7 +67,6 @@ export class ExtensionLoader {
   private activatedExtensions = new Map<string, ActivatedExtension>();
   private analyzedExtensions = new Map<string, AnalyzedExtension>();
   private extensionsStoragePath = '';
-  private fileSystemMonitoring: FilesystemMonitoring;
 
   constructor(
     private commandRegistry: CommandRegistry,
@@ -82,9 +81,8 @@ export class ExtensionLoader {
     private notifications: NotificationImpl,
     private statusBarRegistry: StatusBarRegistry,
     private kubernetesClient: KubernetesClient,
-  ) {
-    this.fileSystemMonitoring = new FilesystemMonitoring();
-  }
+    private fileSystemMonitoring: FilesystemMonitoring,
+  ) {}
 
   async listExtensions(): Promise<ExtensionInfo[]> {
     return Array.from(this.analyzedExtensions.values()).map(extension => ({
@@ -393,8 +391,8 @@ export class ExtensionLoader {
       async setKubeconfig(kubeconfig: containerDesktopAPI.Uri): Promise<void> {
         return kubernetesClient.setKubeconfig(kubeconfig);
       },
-      onDidChangeKubeconfig: (listener, thisArg, disposables) => {
-        return kubernetesClient.onDidChangeKubeconfig(listener, thisArg, disposables);
+      onDidUpdateKubeconfig: (listener, thisArg, disposables) => {
+        return kubernetesClient.onDidUpdateKubeconfig(listener, thisArg, disposables);
       },
     };
 

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -75,6 +75,7 @@ import { KubernetesClient } from './kubernetes-client';
 import type { V1Pod, V1ConfigMap, V1NamespaceList, V1PodList, V1Service } from '@kubernetes/client-node';
 import type { V1Route } from './api/openshift-types';
 import type { NetworkInspectInfo } from './api/network-info';
+import { FilesystemMonitoring } from './filesystem-monitoring';
 
 type LogType = 'log' | 'warn' | 'trace' | 'debug' | 'error';
 export class PluginSystem {
@@ -208,7 +209,9 @@ export class PluginSystem {
     const providerRegistry = new ProviderRegistry(apiSender, containerProviderRegistry, telemetry);
     const trayMenuRegistry = new TrayMenuRegistry(this.trayMenu, commandRegistry, providerRegistry, telemetry);
     const statusBarRegistry = new StatusBarRegistry(apiSender);
-    const kubernetesClient = new KubernetesClient(configurationRegistry);
+    const fileSystemMonitoring = new FilesystemMonitoring();
+
+    const kubernetesClient = new KubernetesClient(configurationRegistry, fileSystemMonitoring);
     await kubernetesClient.init();
     const closeBehaviorConfiguration = new CloseBehavior(configurationRegistry, providerRegistry);
     await closeBehaviorConfiguration.init();
@@ -242,6 +245,7 @@ export class PluginSystem {
       new NotificationImpl(),
       statusBarRegistry,
       kubernetesClient,
+      fileSystemMonitoring,
     );
 
     const contributionManager = new ContributionManager(apiSender);


### PR DESCRIPTION
### What does this PR do?
Reload context when file is changed or if content is changing

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/766

### How to test this PR?

Launch Podman Desktop and then try to change the current k8s context either using the tray icon or with `kubectl` tool and then try to use `Deploy to kubernetes` feature, the selected context should be displayed.


Change-Id: I574d9dbfcacdfcdcaea8e89230fe24cb01920fb0
Signed-off-by: Florent Benoit <fbenoit@redhat.com>