### PR TITLE
chore: enable unit tests in extensions using vitest

### DIFF
--- a/extensions/podman/package.json
+++ b/extensions/podman/package.json
@@ -76,7 +76,8 @@
   },
   "scripts": {
     "build": "rollup --config rollup.config.js --compact --environment BUILD:production && npx ts-node ./scripts/download.ts  && node ./scripts/build.js",
-    "watch": "rollup --config rollup.config.js -w"
+    "watch": "rollup --config rollup.config.js -w",
+    "test": "vitest run -r src --passWithNoTests"
   },
   "dependencies": {
     "@ltd/j-toml": "^1.30.0",

--- a/extensions/podman/src/macos-check.spec.ts
+++ b/extensions/podman/src/macos-check.spec.ts
@@ -1,0 +1,60 @@
+/**********************************************************************
+ * Copyright (C) 2022 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { Mock } from 'vitest';
+import { beforeEach, expect, test, vi } from 'vitest';
+import { MacVersionCheck } from './macos-checks';
+import * as os from 'node:os';
+let macVersionCheck;
+
+vi.mock('node:os', () => {
+  return {
+    release: vi.fn(),
+    platform: vi.fn(),
+  };
+});
+
+beforeEach(() => {
+  macVersionCheck = new MacVersionCheck();
+  vi.clearAllMocks();
+});
+
+test('expect error on versions of macOS too old', async () => {
+  // Let say we have a very old macOS version
+  (os.release as Mock).mockReturnValue('5.0.0');
+  const result = await macVersionCheck.execute();
+  expect(result).toBeDefined();
+  expect(result.successful).toBeFalsy();
+  expect(result.description).toMatch('you need to update to macOS Catalina');
+});
+
+test('expect success on versions of macOS matching the minimum version', async () => {
+  // pickup minimum version
+  (os.release as Mock).mockReturnValue(macVersionCheck.MINIMUM_VERSION);
+  const result = await macVersionCheck.execute();
+  expect(result).toBeDefined();
+  // minimum version should match
+  expect(result.successful).toBeTruthy();
+});
+
+test('expect success on a recent macOS version', async () => {
+  (os.release as Mock).mockReturnValue('22.1.0');
+  const result = await macVersionCheck.execute();
+  expect(result).toBeDefined();
+  expect(result.successful).toBeTruthy();
+});

--- a/extensions/podman/src/macos-checks.ts
+++ b/extensions/podman/src/macos-checks.ts
@@ -19,7 +19,7 @@
 import { BaseCheck } from './base-check';
 import type * as extensionApi from '@tmpwip/extension-api';
 import * as os from 'node:os';
-import * as compareVersions from 'compare-versions';
+import { compare } from 'compare-versions';
 import { runCliCommand } from './util';
 
 export class MacCPUCheck extends BaseCheck {
@@ -55,7 +55,7 @@ export class MacVersionCheck extends BaseCheck {
 
   async execute(): Promise<extensionApi.CheckResult> {
     const darwinVersion = os.release();
-    if (compareVersions.compare(darwinVersion, this.MINIMUM_VERSION, '>=')) {
+    if (compare(darwinVersion, this.MINIMUM_VERSION, '>=')) {
       return this.createSuccessfulResult();
     }
 

--- a/extensions/podman/src/podman-install.ts
+++ b/extensions/podman/src/podman-install.ts
@@ -20,7 +20,7 @@ import { promisify } from 'node:util';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
-import * as compareVersions from 'compare-versions';
+import { compare } from 'compare-versions';
 
 import * as podmanTool from './podman.json';
 import type { InstalledPodman } from './podman-cli';
@@ -248,7 +248,7 @@ abstract class BaseInstaller implements Installer {
   abstract getPreflightChecks(): extensionApi.InstallCheck[];
 
   requireUpdate(installedVersion: string): boolean {
-    return compareVersions.compare(installedVersion, getBundledPodmanVersion(), '<');
+    return compare(installedVersion, getBundledPodmanVersion(), '<');
   }
 
   protected getAssetsFolder(): string {

--- a/extensions/vitest.config.js
+++ b/extensions/vitest.config.js
@@ -1,0 +1,41 @@
+/**********************************************************************
+ * Copyright (C) 2022 Red Hat, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/**
+ * Config for global end-to-end tests
+ * placed in project root tests folder
+ * @type {import('vite').UserConfig}
+ * @see https://vitest.dev/config/
+ */
+const config = {
+  test: {
+    /**
+     * By default, vitest search test files in all packages.
+     * For e2e tests have sense search only is project root tests folder
+     */
+    include: ['**/*.{test,spec}.ts'],
+    exclude: ['**/builtin/**', '**/dist/**', '**/cypress/**', '**/.{idea,git,cache,output,temp}/**', '**/{karma,rollup,webpack,vite,vitest,jest,ava,babel,nyc,cypress}.config.*'],
+    /**
+     * A default timeout of 5000ms is sometimes not enough for playwright.
+     */
+    testTimeout: 30_000,
+    hookTimeout: 30_000,
+  },
+};
+
+export default config;

--- a/package.json
+++ b/package.json
@@ -34,10 +34,11 @@
     "compile:next": "cross-env MODE=production npm run build && electron-builder build --publish always --config .electron-builder.config.js",
     "compile:pull-request": "cross-env MODE=production npm run build && electron-builder build --publish never --config .electron-builder.config.js",
     "compile:current": "cross-env MODE=production npm run build && electron-builder build --config .electron-builder.config.js",
-    "test": "npm run test:main && npm run test:preload && npm run test:renderer && npm run test:e2e",
+    "test": "npm run test:main && npm run test:preload && npm run test:renderer && npm run test:e2e && npm run test:extensions",
     "test:e2e": "npm run build && vitest run",
     "test:main": "vitest run -r packages/main --passWithNoTests",
     "test:preload": "vitest run -r packages/preload --passWithNoTests",
+    "test:extensions": "vitest run -r extensions --passWithNoTests",
     "test:renderer": "vitest run -r packages/renderer --passWithNoTests",
     "watch": "node scripts/watch.js",
     "format:check": "prettier --check '{extensions,packages,tests,types}/**/*.{ts,svelte}' 'extensions/*/scripts/build.js' 'website/*.js' 'website/src/**/*.{css,tsx}'",
@@ -76,7 +77,7 @@
     "prettier-plugin-svelte": "^2.8.0",
     "typescript": "4.8.4",
     "vite": "3.2.3",
-    "vitest": "0.24.5"
+    "vitest": "^0.25.1"
   },
   "dependencies": {
     "@docker/extension-api-client-types": "0.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4221,7 +4221,7 @@ acorn-walk@^7.0.0:
   resolved "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz"
   integrity sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==
 
-acorn-walk@^8.0.0, acorn-walk@^8.1.1:
+acorn-walk@^8.0.0, acorn-walk@^8.1.1, acorn-walk@^8.2.0:
   version "8.2.0"
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
   integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
@@ -12414,17 +12414,20 @@ vite@3.2.3, vite@^3.0.0, vite@^3.2.3:
   optionalDependencies:
     fsevents "~2.3.2"
 
-vitest@0.24.5:
-  version "0.24.5"
-  resolved "https://registry.yarnpkg.com/vitest/-/vitest-0.24.5.tgz#ba23acdf4362e3299ca2a8a55afe3d2e7402b763"
-  integrity sha512-zw6JhPUHtLILQDe5Q39b/SzoITkG+R7hcFjuthp4xsi6zpmfQPOZcHodZ+3bqoWl4EdGK/p1fuMiEwdxgbGLOA==
+vitest@^0.25.1:
+  version "0.25.1"
+  resolved "https://registry.yarnpkg.com/vitest/-/vitest-0.25.1.tgz#4eafca68fabab22b6099451ab3fcaac33290a4ed"
+  integrity sha512-eH74h6MkuEgsqR4mAQZeMK9O0PROiKY+i+1GMz/fBi5A3L2ml5U7JQs7LfPU7+uWUziZyLHagl+rkyfR8SLhlA==
   dependencies:
     "@types/chai" "^4.3.3"
     "@types/chai-subset" "^1.3.3"
     "@types/node" "*"
+    acorn "^8.8.0"
+    acorn-walk "^8.2.0"
     chai "^4.3.6"
     debug "^4.3.4"
     local-pkg "^0.4.2"
+    source-map "^0.6.1"
     strip-literal "^0.4.2"
     tinybench "^2.3.1"
     tinypool "^0.3.0"


### PR DESCRIPTION
### What does this PR do?
I wanted to check dependabot automatic updates by writing a test but there was none
So adding test + enabling them.
So I'll be able to test dependency update in the dependabot PR


### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

https://github.com/containers/podman-desktop/pull/557

### How to test this PR?

Launch `yarn test` or `yarn test:extensions` (after yarn) (or `yarn test` when you're inside the podman extension)
it should run all tests from extensions

Change-Id: If6c7a8ab547cde5c55f5831ac759243fce25d129
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
