### PR TITLE
fix: adding/deleting a machine should be reflected in the navbar tree

### DIFF
--- a/packages/renderer/src/PreferencesNavigation.svelte
+++ b/packages/renderer/src/PreferencesNavigation.svelte
@@ -5,15 +5,15 @@ import { extensionInfos } from './stores/extensions';
 import { configurationProperties } from './stores/configurationProperties';
 import { ConfigurationRegistry } from '../../main/src/plugin/configuration-registry';
 import type { ProviderInfo } from '../../main/src/plugin/api/provider-info';
+import { providerInfos } from './stores/providers';
 
 export let exitSettingsCallback: () => void;
 export let meta;
 
-let extensions, configProperties, providers;
+let extensions, configProperties;
 
 $: extensions = [];
 $: configProperties = new Map();
-$: providers = [];
 $: sectionExpanded = {};
 
 function toggleSection(provider: string) {
@@ -21,7 +21,6 @@ function toggleSection(provider: string) {
 }
 
 onMount(async () => {
-  await fetchProviderInfos();
   extensionInfos.subscribe(value => {
     extensions = value;
   });
@@ -43,10 +42,6 @@ onMount(async () => {
       }, new Map());
   });
 });
-
-async function fetchProviderInfos() {
-  providers = await window.getProviderInfos();
-}
 
 $: isCurrentPage = (pathParam: string): boolean => meta.url === pathParam;
 $: addExpandedClass = (section: string): string => (sectionExpanded[section] ? 'pf-m-expanded' : '');
@@ -82,7 +77,7 @@ $: addHiddenClass = (provider: ProviderInfo): string => (provider.containerConne
       </button>
       <section class="pf-c-nav__subnav {addSectionHiddenClass('resources')}">
         <ul class="pf-c-nav__list">
-          {#each providers as provider}
+          {#each $providerInfos as provider}
             <li
               class="pf-c-nav__item {addExpandableClass(provider)} {addExpandedClass(provider.name)} {addCurrentClass(
                 `/preferences/provider/${provider.internalId}`,


### PR DESCRIPTION
### What does this PR do?
Listen to the changes so the tree is refreshed.

### Screenshot/screencast of this PR

https://user-images.githubusercontent.com/436777/201889735-2e75d303-5ae4-44da-a477-8198f4aadbe5.mp4


### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/761


### How to test this PR?

Create a machine and see that it appears in the navbar

Change-Id: I829def95ce1042d5735ec5495d5aafd759ff0e33
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
