### PR TITLE
Issue835 - update to allow up to 9 characters

### DIFF
--- a/packages/renderer/src/lib/validation/FieldValidation.ts
+++ b/packages/renderer/src/lib/validation/FieldValidation.ts
@@ -73,7 +73,7 @@ export function urlValidator() {
     return (
       (value &&
         !!value.match(
-          /(http(s)?:\/\/.)?(www\.)?[-a-zA-Z0-9@:%._+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_+.~#?&//=]*)/g,
+          /(http(s)?:\/\/.)?(www\.)?[-a-zA-Z0-9@:%._+~#=]{2,256}\.[a-z]{2,9}\b([-a-zA-Z0-9@:%_+.~#?&//=]*)/g,
         )) ||
       'Please enter a valid URL'
     );


### PR DESCRIPTION
### What does this PR do?
Allow TLDs for Registries up to 9 Characters

### Screenshot/screencast of this PR

I ran tests locally.  My local dev env seems to choke on flatpaks.
Though the fix is very small (changing from 6 character limit to 9 to allow for things like .website, .foundation and .science to name a few)

example of issue:
http://freshbrewed-test.s3-website-us-east-1.amazonaws.com/content/images/2022/11/podmandt-18.png

### What issues does this PR fix or reference?

https://github.com/containers/podman-desktop/issues/835

### How to test this PR?

Try to add a Registry with a longer domain name (e.g. harbor.freshbrewed.science)
