### PR TITLE
chore: use 8GB as memory requirement

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -35,5 +35,8 @@
     "3000": {
       "label": "website"
     }
+  },
+  "hostRequirements": {
+    "memory": "8gb"
   }
 }


### PR DESCRIPTION
### What does this PR do?
Now that there is the GA of Codespaces we can choose machines but default one is too small (not enough memory)
It increases the requirement to match what we need

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

N/A

### How to test this PR?


Change-Id: I95cd74d3990c18e5cb736d916f1912a343edca68
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
