### PR TITLE
feat: upgrade to flatpak 22.08

### DIFF
--- a/.electron-builder.config.js
+++ b/.electron-builder.config.js
@@ -93,7 +93,7 @@ const config = {
     ],
     useWaylandFlags: 'false',
     artifactName: 'podman-desktop-${version}.${ext}',
-    runtimeVersion: '21.08',
+    runtimeVersion: '22.08',
     branch: 'main',
     files: [
       ['.flatpak-appdata.xml', '/share/metainfo/io.podman_desktop.PodmanDesktop.metainfo.xml'],

--- a/.github/workflows/next-build.yaml
+++ b/.github/workflows/next-build.yaml
@@ -1,12 +1,12 @@
 #
 # Copyright (C) 2022 Red Hat, Inc.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 # SPDX-License-Identifier: Apache-2.0
- 
+
 name: next build
 
 on:
@@ -116,7 +116,7 @@ jobs:
           sudo apt-get install flatpak-builder -y
           sudo apt-get install elfutils -y
           flatpak remote-add --if-not-exists flathub --user https://flathub.org/repo/flathub.flatpakrepo
-          flatpak install flathub --user -y org.freedesktop.Platform/x86_64/21.08
+          flatpak install flathub --user -y org.freedesktop.Platform//22.08 org.freedesktop.Sdk//22.08
 
       - name: Set macOS environment variables
         if: startsWith(matrix.os, 'macos')

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -100,7 +100,7 @@ jobs:
           sudo apt-get install flatpak-builder -y
           sudo apt-get install elfutils -y
           flatpak remote-add --if-not-exists flathub --user https://flathub.org/repo/flathub.flatpakrepo
-          flatpak install flathub --user -y org.freedesktop.Platform/x86_64/21.08
+          flatpak install flathub --user -y org.freedesktop.Platform//22.08 org.freedesktop.Sdk//22.08
 
       - name: Run Build
         timeout-minutes: 20

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -107,7 +107,7 @@ jobs:
           git add package.json
           git commit -s --amend -m "chore: bump version to ${bumpedVersion}"
           git push origin "${bumpedBranchName}"
-          echo -e "📢 Bump version to ${bumpedVersion}\n\n${{ steps.TAG_UTIL.outputs.desktopVersion }} has been released.\n\n Time to switch to the new ${bumpedVersion} version 🥳" > /tmp/pr-title 
+          echo -e "📢 Bump version to ${bumpedVersion}\n\n${{ steps.TAG_UTIL.outputs.desktopVersion }} has been released.\n\n Time to switch to the new ${bumpedVersion} version 🥳" > /tmp/pr-title
           pullRequestUrl=$(gh pr create --title "chore: 📢 Bump version to ${bumpedVersion}" --body-file /tmp/pr-title --head "${bumpedBranchName}" --base "main")
           echo "📢 Pull request created: ${pullRequestUrl}"
           echo "➡️ Flag the PR as being ready for review"
@@ -166,8 +166,7 @@ jobs:
           sudo apt-get install flatpak-builder -y
           sudo apt-get install elfutils -y
           flatpak remote-add --if-not-exists flathub --user https://flathub.org/repo/flathub.flatpakrepo
-          flatpak install flathub --user -y org.freedesktop.Platform/x86_64/21.08
-
+          flatpak install flathub --user -y org.freedesktop.Platform//22.08 org.freedesktop.Sdk//22.08
       - name: Set macOS environment variables
         if: startsWith(matrix.os, 'macos')
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,19 +50,17 @@ This section describes how to start a contribution to Podman Desktop.
 
 ### Prerequisites: Prepare your environment
 
+You can develop on either: `Windows`, `macOS` or `Linux`.
+
 Requirements: 
 * [Node.js 16+](https://nodejs.org/en/)
 * [yarn](https://yarnpkg.com/)
 
-Optional Linux Requirements:
-* [flatpak-builder](https://docs.flatpak.org/en/latest/first-build.html) 
-* Flatpak 21.08 SDK
+Optional Linux requirements:
+* [Flatpak builder, runtime, and SDK, version 22.08](https://docs.flatpak.org/en/latest/first-build.html) 
   ```sh
-  flatpak install runtime/org.freedesktop.Sdk/x86_64/21.08
+  flatpak install flathub org.flatpak.Builder org.freedesktop.Platform//22.08 org.freedesktop.Sdk//22.08
   ```
-
-
-You can develop on either: `Windows`, `macOS` or `Linux`.
 
 ### Step 1. Fork and clone Podman Desktop
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,8 @@ Requirements:
 Optional Linux requirements:
 * [Flatpak builder, runtime, and SDK, version 22.08](https://docs.flatpak.org/en/latest/first-build.html) 
   ```sh
-  flatpak install flathub org.flatpak.Builder org.freedesktop.Platform//22.08 org.freedesktop.Sdk//22.08
+  flatpak remote-add --if-not-exists flathub --user https://flathub.org/repo/flathub.flatpakrepo
+  flatpak install --user flathub org.flatpak.Builder org.freedesktop.Platform//22.08 org.freedesktop.Sdk//22.08
   ```
 
 ### Step 1. Fork and clone Podman Desktop


### PR DESCRIPTION
### What does this PR do?

* Bump to flatpak 22.08
* Use multi-arch notation for flatpak packages
* Clarify Linux requirements in Contributing

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?

Flatpak SDK version 22.08 is the stable version. Installing the Builder from Flathub installs the stable version.

### How to test this PR?

Install and run the flatpak that you can find in the `pr-check` build artifacts.

<!-- Please explain steps to reproduce -->

Signed-off-by: Fabrice Flore-Thébault <ffloreth@redhat.com>