### PR TITLE
website: fix Flathub CLI instruction

### DIFF
--- a/website/src/pages/downloads/linux.tsx
+++ b/website/src/pages/downloads/linux.tsx
@@ -94,7 +94,7 @@ export function LinuxDownloads(): JSX.Element {
                 <div className="dark:bg-zinc-900/50 bg-zinc-300/50 p-1 text-xl dark:text-purple-300 text-purple-700 flex flex-row">
                   <div className="w-72 truncate">
                     <FontAwesomeIcon size="xs" icon={faTerminal} className="mx-2 mt-3" />
-                    flatpak install --user flathub io.podman_desktop.PodmanDesktop
+                    flatpak install flathub io.podman_desktop.PodmanDesktop
                   </div>
                   <div>
                     <button title="Copy To Clipboard" className="mr-2 p-1">


### PR DESCRIPTION
The current format is not correct for installing Podman Desktop, and --user is not recommended

Signed-off-by: Kevin @ Sesam Solutions <56027840+KevinAtSesam@users.noreply.github.com>

### What does this PR do?
Fix the CLI instruction for installing Podman Desktop

### What issues does this PR fix or reference?
Latest docs: https://docs.flatpak.org/en/latest/flatpak-command-reference.html#flatpak-install

### How to test this PR?

Type it in yourself; `flatpak install flathub io.podman_desktop.PodmanDesktop`
