### PR TITLE
feat: Adds extension name as prefix when extension is using logger

### DIFF
--- a/packages/main/src/plugin/api/extension-info.ts
+++ b/packages/main/src/plugin/api/extension-info.ts
@@ -23,4 +23,5 @@ export interface ExtensionInfo {
   publisher: string;
   version: string;
   state: string;
+  path: string;
 }

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -92,6 +92,7 @@ export class ExtensionLoader {
       publisher: extension.manifest.publisher,
       state: this.activatedExtensions.get(extension.id) ? 'active' : 'inactive',
       id: extension.id,
+      path: extension.path,
     }));
   }
 

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -20,6 +20,7 @@
  * @module preload
  */
 import * as os from 'node:os';
+import * as path from 'path';
 import type * as containerDesktopAPI from '@tmpwip/extension-api';
 import { CommandRegistry } from './command-registry';
 import { ContainerProviderRegistry } from './container-registry';
@@ -85,6 +86,10 @@ export class PluginSystem {
   // notified when UI is dom-ready
   private uiReady = false;
 
+  // The yet to be init ExtensionLoader
+  private extensionLoader!: ExtensionLoader;
+  private validExtList!: ExtensionInfo[];
+
   constructor(private trayMenu: TrayMenu) {}
 
   getWebContentsSender(): WebContents {
@@ -120,12 +125,53 @@ export class PluginSystem {
     });
   }
 
+  // Create an Error to access stack trace
+  // Match a regex for the file name and return it
+  // return nothing if file name not found
+  async getExtName() {
+    //Create an error for its stack property
+    const stack = new Error().stack;
+    //Create a map for extension path => extension name
+    const extensions: Map<string, string> = new Map();
+
+    //Check if index.ts private member extensionLoader initialized
+    //If it is grab listExtensions()
+    if (!this.extensionLoader) return;
+
+    const currentExtList = await this.extensionLoader.listExtensions();
+
+    //Only loop through if list of extensions is different than last time
+    if (this.validExtList != currentExtList) {
+      this.validExtList = currentExtList;
+      //start setting path => name
+      this.validExtList.forEach((extInfo: ExtensionInfo) => {
+        extensions.set(extInfo.path, extInfo.name);
+      });
+    }
+
+    if (extensions.size > 0 && stack) {
+      let toAppend = '';
+      extensions.forEach((name, extPath) => {
+        extPath = path.normalize(extPath);
+
+        if (stack.includes(extPath)) toAppend = name;
+      });
+
+      if (toAppend != '') return `[${toAppend}]`;
+    }
+    return;
+  }
+
   // log locally and also send it to the renderer process
   // so client can see logs in the developer console
   redirectConsole(logType: LogType): void {
     // keep original method
     const originalConsoleMethod = console[logType];
-    console[logType] = (...args) => {
+    console[logType] = async (...args) => {
+      const extName = await this.getExtName();
+
+      if (extName) args.unshift(extName);
+
       // still display as before by invoking original method
       originalConsoleMethod(...args);
 
@@ -233,7 +279,7 @@ export class PluginSystem {
     const terminalInit = new TerminalInit(configurationRegistry);
     terminalInit.init();
 
-    const extensionLoader = new ExtensionLoader(
+    this.extensionLoader = new ExtensionLoader(
       commandRegistry,
       providerRegistry,
       configurationRegistry,
@@ -733,19 +779,19 @@ export class PluginSystem {
     });
 
     this.ipcHandle('extension-loader:listExtensions', async (): Promise<ExtensionInfo[]> => {
-      return extensionLoader.listExtensions();
+      return this.extensionLoader.listExtensions();
     });
 
     this.ipcHandle(
       'extension-loader:deactivateExtension',
       async (_listener: Electron.IpcMainInvokeEvent, extensionId: string): Promise<void> => {
-        return extensionLoader.deactivateExtension(extensionId);
+        return this.extensionLoader.deactivateExtension(extensionId);
       },
     );
     this.ipcHandle(
       'extension-loader:startExtension',
       async (_listener: Electron.IpcMainInvokeEvent, extensionId: string): Promise<void> => {
-        return extensionLoader.startExtension(extensionId);
+        return this.extensionLoader.startExtension(extensionId);
       },
     );
 
@@ -898,13 +944,11 @@ export class PluginSystem {
 
     await contributionManager.init();
 
-    await extensionLoader.start();
+    await this.extensionLoader.start();
     this.isReady = true;
     console.log('PluginSystem: initialization done.');
     apiSender.send('extension-system', `${this.isReady}`);
-
     autoStartConfiguration.start();
-
-    return extensionLoader;
+    return this.extensionLoader;
   }
 }


### PR DESCRIPTION
### What does this PR do?

I am aiming to create a wrapper for some of the logging so that we can have a prefix for each separate extension.

### Screenshot/screencast of this PR

![image](https://user-images.githubusercontent.com/77400826/202931350-a28b2180-4de1-41c6-bfdf-4dc544409d9b.png)

Something similar to this

### What issues does this PR fix or reference?

#822 

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

### How to test this PR?

Check logs originating from extensions folder for the appropriate names

Signed-off-by: Stefan Frunza <stefanfrunza@gmail.com>
