### PR TITLE
feat: add age and image column to container list

### DIFF
--- a/packages/renderer/src/lib/ContainerList.svelte
+++ b/packages/renderer/src/lib/ContainerList.svelte
@@ -4,7 +4,6 @@ import { filtered, searchPattern } from '../stores/containers';
 
 import type { ContainerInfo } from '../../../../main/src/plugin/api/container-info';
 import ContainerIcon from './ContainerIcon.svelte';
-import type { PodInfoUI } from '../pod/PodInfoUI';
 import { router } from 'tinro';
 import { ContainerGroupInfoTypeUI, ContainerGroupInfoUI, ContainerInfoUI } from './container/ContainerInfoUI';
 import ContainerActions from './container/ContainerActions.svelte';
@@ -333,7 +332,8 @@ function toggleAllContainerGroups(value: boolean) {
               class="cursor-pointer invert hue-rotate-[218deg] brightness-75" /></th>
           <th class="text-center font-extrabold w-10 px-2">Status</th>
           <th>Name</th>
-          <th class="text-center">started</th>
+          <th>Image</th>
+          <th class="pl-4">Age</th>
           <th class="text-right pr-2">actions</th>
         </tr>
       </thead>
@@ -379,6 +379,11 @@ function toggleAllContainerGroups(value: boolean) {
                   <div class="ml-2 text-sm text-gray-400"></div>
                 </div>
               </td>
+              <td class="whitespace-nowrap pl-4">
+                <div class="flex items-center">
+                  <div class="text-sm text-gray-400"></div>
+                </div>
+              </td>
               <td
                 class="pl-6 text-right whitespace-nowrap rounded-tr-lg"
                 class:rounded-br-lg="{!containerGroup.expanded}">
@@ -417,11 +422,6 @@ function toggleAllContainerGroups(value: boolean) {
                         <div class="text-sm text-gray-200 overflow-hidden text-ellipsis" title="{container.name}">
                           {container.name}
                         </div>
-                        <div
-                          class="pl-2 text-sm text-violet-400 overflow-hidden text-ellipsis"
-                          title="{container.image}">
-                          {container.image}
-                        </div>
                       </div>
                       <div class="flex flex-row text-xs font-extra-light text-gray-500">
                         <div>{container.state}</div>
@@ -437,9 +437,16 @@ function toggleAllContainerGroups(value: boolean) {
                     </div>
                   </div>
                 </td>
-                <td class="px-6 py-2 whitespace-nowrap w-10">
+                <!-- Open the container details, TODO: open image details instead? -->
+                <td class="whitespace-nowrap hover:cursor-pointer" on:click="{() => openDetailsContainer(container)}">
                   <div class="flex items-center">
-                    <div class="ml-2 text-sm text-gray-400">{container.uptime}</div>
+                    <div class="text-sm text-violet-400 overflow-hidden text-ellipsis" title="{container.image}">
+                      {container.image}
+                    </div>
+                  </div></td>
+                <td class="whitespace-nowrap pl-4">
+                  <div class="flex items-center">
+                    <div class="text-sm text-gray-400">{container.uptime}</div>
                   </div>
                 </td>
                 <td

--- a/packages/renderer/src/lib/container/container-utils.ts
+++ b/packages/renderer/src/lib/container/container-utils.ts
@@ -44,7 +44,7 @@ export class ContainerUtils {
     }
 
     // make it human friendly
-    return `${this.humanizeUptime(containerInfo.StartedAt)} ago`;
+    return this.humanizeUptime(containerInfo.StartedAt);
   }
 
   humanizeUptime(started: string): string {
@@ -59,7 +59,7 @@ export class ContainerUtils {
       return '';
     }
     // make it human friendly
-    return `${this.humanizeUptime(containerInfoUI.startedAt)} ago`;
+    return this.humanizeUptime(containerInfoUI.startedAt);
   }
 
   getImage(containerInfo: ContainerInfo): string {


### PR DESCRIPTION
feat: add age and image column to container list

### What does this PR do?

Added image column:

* Now that we have more space on the row thanks to the kebab menu, we can
now add more items to the row such as image, instead of having it beside
the name.
* Allows to eventually "sort" by image in the list in the future.

Added age column:

* We repeatedly say "... ago" in every row which is redundant.
* Changed to to "AGE" and created shorter output (`X seconds ago` is now
`Xs`).
* Allows for more space on the row.

### Screenshot/screencast of this PR

![Screenshot 2022-11-21 at 4 03 35 PM](https://user-images.githubusercontent.com/6422176/203157894-fe94bfca-bed4-43c4-afad-ec92e2d1021c.png)


<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

Closes https://github.com/containers/podman-desktop/issues/446

### How to test this PR?

<!-- Please explain steps to reproduce -->

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
