### PR TITLE
feat: Use operating system certificates + proxy when using the login to registry

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,10 +91,12 @@
     "electron-updater": "4.6.5",
     "getos": "^3.2.1",
     "got": "^12.5.3",
+    "hpagent": "^1.2.0",
     "moment": "^2.29.4",
     "os-locale": "^6.0.2",
     "stream-json": "^1.7.5",
-    "tar-fs": "^2.1.1"
+    "tar-fs": "^2.1.1",
+    "win-ca": "^3.5.0"
   },
   "resolutions": {
     "trim": "0.0.3"

--- a/packages/main/src/plugin/certificate.spec.ts
+++ b/packages/main/src/plugin/certificate.spec.ts
@@ -1,0 +1,53 @@
+/**********************************************************************
+ * Copyright (C) 2022 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { beforeEach, expect, test, vi } from 'vitest';
+import { Certificates } from './certificates';
+
+let certificate;
+
+const BEGIN_CERTIFICATE = '-----BEGIN CERTIFICATE-----';
+const END_CERTIFICATE = '-----END CERTIFICATE-----';
+const CR = '\n';
+
+// mock spawn
+vi.mock('node:child_process', () => {
+  return {
+    spawn: vi.fn(),
+  };
+});
+
+beforeEach(() => {
+  certificate = new Certificates();
+  vi.clearAllMocks();
+});
+
+test('expect parse correctly certificates', async () => {
+  const certificateContent = `${BEGIN_CERTIFICATE}${CR}Foo${CR}${END_CERTIFICATE}${CR}${BEGIN_CERTIFICATE}${CR}Bar${CR}${END_CERTIFICATE}${CR}${BEGIN_CERTIFICATE}${CR}Baz${CR}${END_CERTIFICATE}${CR}${BEGIN_CERTIFICATE}${CR}Qux${CR}${END_CERTIFICATE}${CR}`;
+  const list = await certificate.extractCertificates(certificateContent);
+  expect(list.length).toBe(4);
+
+  // strip prefix and suffix, CR
+  const stripped = list.map(cert =>
+    cert
+      .replace(new RegExp(BEGIN_CERTIFICATE, 'g'), '')
+      .replace(new RegExp(END_CERTIFICATE, 'g'), '')
+      .replace(new RegExp(CR, 'g'), ''),
+  );
+  expect(stripped).toStrictEqual(['Foo', 'Bar', 'Baz', 'Qux']);
+});

--- a/packages/main/src/plugin/certificates.ts
+++ b/packages/main/src/plugin/certificates.ts
@@ -1,0 +1,144 @@
+/**********************************************************************
+ * Copyright (C) 2022 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { isLinux, isMac, isWindows } from '../util';
+import { spawnWithPromise } from './util/spawn-promise';
+import * as https from 'node:https';
+import * as tls from 'node:tls';
+import * as fs from 'node:fs';
+import wincaAPI from 'win-ca/api';
+
+/**
+ * Provides access to the certificates of the underlying platform.
+ * It supports Linux, Windows and MacOS.
+ */
+export class Certificates {
+  private allCertificates: string[] = [];
+
+  /**
+   * Setup all certificates globally depending on the platform.
+   */
+  async init(): Promise<void> {
+    this.allCertificates = await this.retrieveCertificates();
+
+    // initialize the certificates globally
+    https.globalAgent.options.ca = this.allCertificates;
+  }
+
+  getAllCertificates(): string[] {
+    return this.allCertificates;
+  }
+
+  async retrieveCertificates(): Promise<string[]> {
+    if (isMac) {
+      return this.retrieveMacOSCertificates();
+    } else if (isWindows) {
+      return this.retrieveWindowsCertificates();
+    } else if (isLinux) {
+      return this.retrieveLinuxCertificates();
+    }
+
+    // else return default root certificates
+    return [...tls.rootCertificates];
+  }
+
+  public extractCertificates(content: string): string[] {
+    // need to create an array of text from the content starting by '-----BEGIN CERTIFICATE-----'
+    // use a regexp
+    return content.split(/(?=-----BEGIN CERTIFICATE-----)/g).filter(c => c.trim().length > 0);
+  }
+
+  async retrieveMacOSCertificates(): Promise<string[]> {
+    const rootCertificates = await this.getMacOSCertificates(
+      '/System/Library/Keychains/SystemRootCertificates.keychain',
+    );
+    const userCertificates = await this.getMacOSCertificates();
+    return rootCertificates.concat(userCertificates);
+  }
+
+  // get the certificates from the Windows certificate store
+  async retrieveWindowsCertificates(): Promise<string[]> {
+    // delegate to the win-ca module
+    const winCaRetrieval = new Promise<string[]>(resolve => {
+      const CAs: string[] = [];
+
+      wincaAPI({
+        format: wincaAPI.der2.pem,
+        inject: false,
+        ondata: (ca: string) => {
+          CAs.push(ca);
+        },
+        onend: () => {
+          resolve(CAs);
+        },
+      });
+    });
+
+    const result = await winCaRetrieval;
+    // also do the patch on tls.createSecureContext()
+    wincaAPI.inject('+');
+    return result;
+  }
+
+  // grab the certificates from the Linux certificate store
+  async retrieveLinuxCertificates(): Promise<string[]> {
+    // certificates on Linux are stored in /etc/ssl/certs/ folder
+    // for example
+    // /etc/ssl/certs/ca-certificates.crt or /etc/ssl/certs/ca-bundle.crt
+    const LINUX_FILES = ['/etc/ssl/certs/ca-certificates.crt', '/etc/ssl/certs/ca-bundle.crt'];
+
+    // read the files and parse the content
+    const certificates: string[] = [];
+    for (const file of LINUX_FILES) {
+      // if the file exists, read it
+      if (fs.existsSync(file)) {
+        const content = await fs.promises.readFile(file, { encoding: 'utf8' });
+        try {
+          this.extractCertificates(content).forEach(certificate => certificates.push(certificate));
+        } catch (error) {
+          console.log(`error while extracting certificates from ${file}`, error);
+        }
+      }
+    }
+    // remove any duplicates
+    return certificates.filter((value, index, self) => self.indexOf(value) === index);
+  }
+
+  async getMacOSCertificates(key?: string): Promise<string[]> {
+    const command = '/usr/bin/security';
+    const spawnArgs = ['find-certificate', '-a', '-p'];
+    // do we have an extra parameter
+    if (key) {
+      spawnArgs.push(key);
+    }
+
+    // call the spawn command (as we've lot ot output)
+    const spawnResult = await spawnWithPromise(command, spawnArgs);
+    if (spawnResult.error) {
+      console.log('error while executing command', command, spawnArgs, spawnResult.error);
+      return [];
+    } else {
+      try {
+        return this.extractCertificates(spawnResult.stdout);
+      } catch (error) {
+        console.log('error while extracting certificates', error);
+        return [];
+      }
+    }
+  }
+}

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -76,6 +76,7 @@ import type { V1Pod, V1ConfigMap, V1NamespaceList, V1PodList, V1Service } from '
 import type { V1Route } from './api/openshift-types';
 import type { NetworkInspectInfo } from './api/network-info';
 import { FilesystemMonitoring } from './filesystem-monitoring';
+import { Certificates } from './certificates';
 
 type LogType = 'log' | 'warn' | 'trace' | 'debug' | 'error';
 export class PluginSystem {
@@ -204,9 +205,12 @@ export class PluginSystem {
     await telemetry.init();
 
     const commandRegistry = new CommandRegistry();
-    const imageRegistry = new ImageRegistry(apiSender, telemetry);
+    const certificates = new Certificates();
+    await certificates.init();
+    const imageRegistry = new ImageRegistry(apiSender, telemetry, certificates);
     const containerProviderRegistry = new ContainerProviderRegistry(apiSender, imageRegistry, telemetry);
     const providerRegistry = new ProviderRegistry(apiSender, containerProviderRegistry, telemetry);
+    providerRegistry.addProviderListener(imageRegistry.getProviderListener());
     const trayMenuRegistry = new TrayMenuRegistry(this.trayMenu, commandRegistry, providerRegistry, telemetry);
     const statusBarRegistry = new StatusBarRegistry(apiSender);
     const fileSystemMonitoring = new FilesystemMonitoring();

--- a/types/additional.d.ts
+++ b/types/additional.d.ts
@@ -1,0 +1,1 @@
+declare module 'win-ca/api';

--- a/yarn.lock
+++ b/yarn.lock
@@ -7486,6 +7486,11 @@ hpack.js@^2.1.6:
     readable-stream "^2.0.1"
     wbuf "^1.1.0"
 
+hpagent@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/hpagent/-/hpagent-1.2.0.tgz#0ae417895430eb3770c03443456b8d90ca464903"
+  integrity sha512-A91dYTeIB6NoXG+PxTQpCCDDnfHsW9kc06Lvpu1TEe9gnd6ZFeiBoRO9JvzEv6xK7EX97/dUE8g/vBMTqTS3CA==
+
 html-entities@^2.3.2:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/html-entities/-/html-entities-2.3.3.tgz#117d7626bece327fc8baace8868fa6f5ef856e46"
@@ -7869,6 +7874,11 @@ is-docker@^2.0.0, is-docker@^2.1.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.2.1.tgz#33eeabe23cfe86f14bde4408a02c0cfb853acdaa"
   integrity sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==
+
+is-electron@^2.2.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/is-electron/-/is-electron-2.2.1.tgz#751b1dd8a74907422faa5c35aaa0cf66d98086e9"
+  integrity sha512-r8EEQQsqT+Gn0aXFx7lTFygYQhILLCB+wn0WCDL5LZRINeLH/Rvw1j2oKodELLXYNImQ3CRlVsY8wW4cGOsyuw==
 
 is-extendable@^0.1.0:
   version "0.1.1"
@@ -8578,6 +8588,13 @@ magic-string@^0.26.4, magic-string@^0.26.7:
   dependencies:
     sourcemap-codec "^1.4.8"
 
+make-dir@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-1.3.0.tgz#79c1033b80515bd6d24ec9933e860ca75ee27f0c"
+  integrity sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==
+  dependencies:
+    pify "^3.0.0"
+
 make-dir@^3.0.0, make-dir@^3.0.2, make-dir@^3.1.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz"
@@ -8957,7 +8974,7 @@ node-fetch@2.6.7, node-fetch@^2.6.7:
   dependencies:
     whatwg-url "^5.0.0"
 
-node-forge@^1:
+node-forge@^1, node-forge@^1.2.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.3.1.tgz#be8da2af243b2417d5f646a770663a92b7e9ded3"
   integrity sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==
@@ -11098,6 +11115,13 @@ split-ca@^1.0.1:
   resolved "https://registry.npmjs.org/split-ca/-/split-ca-1.0.1.tgz"
   integrity sha1-bIOv82kvphJW4M0ZfgXp3hV2kaY=
 
+split@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/split/-/split-1.0.1.tgz#605bd9be303aa59fb35f9229fbea0ddec9ea07d9"
+  integrity sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==
+  dependencies:
+    through "2"
+
 sprintf-js@^1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz"
@@ -11510,6 +11534,11 @@ text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
+
+through@2:
+  version "2.3.8"
+  resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
+  integrity sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==
 
 thunky@^1.0.2:
   version "1.1.0"
@@ -12346,6 +12375,16 @@ wildcard@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/wildcard/-/wildcard-2.0.0.tgz#a77d20e5200c6faaac979e4b3aadc7b3dd7f8fec"
   integrity sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==
+
+win-ca@^3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/win-ca/-/win-ca-3.5.0.tgz#87fa778d629077651d323169aadf122ff16954e7"
+  integrity sha512-0TgO/+2iz2pS3OxBy2ikovPHOYyZRdLRxRTT9ze7DpZwEpaahLFOBuac93GM3lYEVzDyf8fXskJjIX/EILvkhQ==
+  dependencies:
+    is-electron "^2.2.0"
+    make-dir "^1.3.0"
+    node-forge "^1.2.1"
+    split "^1.0.1"
 
 word-wrap@^1.2.3:
   version "1.2.3"


### PR DESCRIPTION
### What does this PR do?
Grab underlying operating system certificates when doing network operations
Also, report correct error message to the user when there is a connection issue.

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?
fixes https://github.com/containers/podman-desktop/issues/818


### How to test this PR?

1. check that you can still use existing registries (without proxy)
it's just changing certificates taking them from the operating system rather than the default nodejs/mozilla certificates.

2. Setup a custom proxy (for example on macOS, use proxyman)
after setting proxy configuration to proxyman server, try to connect to a server
check with previous version of podman-desktop: it should fail
try with PR version: it should work

Change-Id: I190d432290e2732944ca1da3a038144434f979de
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
