### PR TITLE
feat: change colour of image name / change colour on hover

### DIFF
--- a/packages/renderer/src/lib/ContainerList.svelte
+++ b/packages/renderer/src/lib/ContainerList.svelte
@@ -415,11 +415,15 @@ function toggleAllContainerGroups(value: boolean) {
                 <td class="flex flex-row justify-center h-12">
                   <ContainerIcon state="{container.state}" />
                 </td>
-                <td class="whitespace-nowrap hover:cursor-pointer" on:click="{() => openDetailsContainer(container)}">
+                <td
+                  class="whitespace-nowrap hover:cursor-pointer group"
+                  on:click="{() => openDetailsContainer(container)}">
                   <div class="flex items-center">
                     <div class="">
                       <div class="flex flex-nowrap">
-                        <div class="text-sm text-gray-200 overflow-hidden text-ellipsis" title="{container.name}">
+                        <div
+                          class="text-sm text-gray-200 overflow-hidden text-ellipsis group-hover:text-violet-400"
+                          title="{container.name}">
                           {container.name}
                         </div>
                       </div>
@@ -438,9 +442,11 @@ function toggleAllContainerGroups(value: boolean) {
                   </div>
                 </td>
                 <!-- Open the container details, TODO: open image details instead? -->
-                <td class="whitespace-nowrap hover:cursor-pointer" on:click="{() => openDetailsContainer(container)}">
+                <td
+                  class="whitespace-nowrap hover:cursor-pointer group"
+                  on:click="{() => openDetailsContainer(container)}">
                   <div class="flex items-center">
-                    <div class="text-sm text-violet-400 overflow-hidden text-ellipsis" title="{container.image}">
+                    <div class="text-sm text-gray-400 overflow-hidden text-ellipsis" title="{container.image}">
                       {container.image}
                     </div>
                   </div></td>


### PR DESCRIPTION
feat: change colour of image name / change colour on hover

### What does this PR do?

* Changes the image name colour from violet to white
* On hover for both the image and the name column, change the colour of
  the image name to violet to indicate that you have selected it.

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

N/A

### How to test this PR?

`yarn watch`

<!-- Please explain steps to reproduce -->

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
