### PR TITLE
fix: add docker socket access

### DIFF
--- a/.electron-builder.config.js
+++ b/.electron-builder.config.js
@@ -86,6 +86,8 @@ const config = {
       '--filesystem=home',
       // Read podman socket
       '--filesystem=xdg-run/podman:create',
+      // Read docker socket
+      '--filesystem=/run/docker.sock',
       // Allow communication with network
       '--share=network',
       // System notifications with libnotify


### PR DESCRIPTION
### What does this PR do?
Provides access to the docker socket file in var run directory
(and yes to read /var/run/docker.sock we give /run/docker.sock to flatpak...)

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/870

### How to test this PR?

Launch flatpak built on a Linux system with docker
it should display docker containers


Change-Id: I5962eebd18097880e2eb34c9bb95faed16e7ccb0
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
