### PR TITLE
fix: view logs not showing full screen height on load

### DIFF
--- a/packages/renderer/src/lib/ContainerDetailsLogs.svelte
+++ b/packages/renderer/src/lib/ContainerDetailsLogs.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 import type { ContainerInfoUI } from './container/ContainerInfoUI';
 import { router } from 'tinro';
-import { onMount } from 'svelte';
+import { onDestroy, onMount } from 'svelte';
 import { Terminal } from 'xterm';
 import { FitAddon } from 'xterm-addon-fit';
 import 'xterm/css/xterm.css';
@@ -10,15 +10,16 @@ import { getPanelDetailColor } from './color/color';
 
 export let container: ContainerInfoUI;
 
+// Log
 let logsXtermDiv: HTMLDivElement;
-
 let logsContainer;
-
 // logs has been initialized
 let logsReady = false;
 let noLogs = true;
 
-let termFit;
+// Terminal resize
+let resizeObserver: ResizeObserver;
+let termFit: FitAddon;
 
 // need to refresh logs when container is switched
 $: {
@@ -106,19 +107,21 @@ function resizeTerminal() {
 }
 
 onMount(async () => {
+  // Refresh the terminal on initial load
   refreshTerminal();
-});
 
-onMount(() => {
   // Resize the terminal each time we change the div size
-  const resizeObserver = new ResizeObserver(entries => {
+  resizeObserver = new ResizeObserver(entries => {
     resizeTerminal();
   });
 
+  // Observe the terminal div
   resizeObserver.observe(logsXtermDiv);
+});
 
-  // Cleanup the observer
-  return () => resizeObserver.unobserve(logsXtermDiv);
+onDestroy(() => {
+  // Cleanup the observer on destroy
+  resizeObserver.unobserve(logsXtermDiv);
 });
 </script>
 

--- a/packages/renderer/src/lib/ContainerDetailsLogs.svelte
+++ b/packages/renderer/src/lib/ContainerDetailsLogs.svelte
@@ -100,19 +100,13 @@ async function refreshTerminal() {
   termFit.fit();
 }
 
-function resizeTerminal() {
-  if (logsTerminal) {
-    termFit.fit();
-  }
-}
-
 onMount(async () => {
   // Refresh the terminal on initial load
   refreshTerminal();
 
   // Resize the terminal each time we change the div size
   resizeObserver = new ResizeObserver(entries => {
-    resizeTerminal();
+    termFit?.fit();
   });
 
   // Observe the terminal div
@@ -121,7 +115,7 @@ onMount(async () => {
 
 onDestroy(() => {
   // Cleanup the observer on destroy
-  resizeObserver.unobserve(logsXtermDiv);
+  resizeObserver?.unobserve(logsXtermDiv);
 });
 </script>
 


### PR DESCRIPTION
fix: view logs not showing full screen height on load

### What does this PR do?

Fixes the issue of the logs only showing half the screen rather than
full.

This is caused by the xterm package incorrectly loading and setting the
height to half.

Related bug: https://github.com/xtermjs/xterm.js/issues/3887

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

Before:
![Screenshot 2022-11-24 at 10 13 44 AM](https://user-images.githubusercontent.com/6422176/203818539-30a9e9a3-bde6-42d8-87b3-8a5eaa4869da.png)

After:
![Screenshot 2022-11-24 at 10 13 55 AM](https://user-images.githubusercontent.com/6422176/203818561-3b71707b-f399-461a-8e31-784622bf87df.png)



### What issues does this PR fix or reference?

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

Closes https://github.com/containers/podman-desktop/issues/501

### How to test this PR?

Use `yarn watch` and load up the logs on a container. It should now be
full height.

<!-- Please explain steps to reproduce -->

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
