### PR TITLE
copr: Enable automatic RPM build on every PR merge

### DIFF
--- a/.copr-rpm.podman-desktop.desktop
+++ b/.copr-rpm.podman-desktop.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Name=Podman Desktop
+Exec="/opt/Podman-Desktop/podman-desktop" %U
+Terminal=false
+Type=Application
+Icon=podman-desktop
+StartupWMClass=Podman Desktop
+Categories=Utility;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "podman-desktop",
   "productName": "Podman Desktop",
+  "repository": "https://github.com/containers/podman-desktop",
   "version": "0.10.0-next",
   "license": "apache-2.0",
   "private": true,

--- a/podman-desktop.spec.rpkg
+++ b/podman-desktop.spec.rpkg
@@ -1,0 +1,91 @@
+# For automatic rebuilds in COPR
+
+# The following tag is to get correct syntax highlighting for this file in vim text editor
+# vim: syntax=spec
+
+%global pkg_name Podman-Desktop
+%global _optpkgdir /opt/%{pkg_name}
+%global _icondir %{_datadir}/icons/hicolor/512x512/apps
+
+%if 0%{?rhel} || 0%{?fedora} <= 37
+%global debug_package %{nil}
+%endif
+
+Name: {{{ git_dir_name }}}
+Epoch: 101
+Version: {{{ git_dir_version }}}
+Release: 1%{?dist}
+Summary: Manage Pods, Containers and Container Images
+License: ASL 2.0
+URL: https://github.com/containers/podman-desktop
+VCS: {{{ git_dir_vcs }}}
+Source: {{{ git_dir_pack }}}
+BuildRequires: python3-devel
+BuildRequires: gcc-c++
+BuildRequires: git-core
+BuildRequires: make
+BuildRequires: npm
+BuildRequires: yarnpkg
+BuildRequires: libglvnd-devel
+Requires: vulkan-loader
+Requires: python3
+ExclusiveArch: x86_64
+
+# More detailed description of the package
+%description
+Podman Desktop is a graphical interface that enables application developers
+to seamlessly work with containers and Kubernetes.
+
+Podman Desktop installs, configures and keeps Podman up to date on your
+local environment. It provides a system tray, to check status and interact
+with your container engine without losing focus from other tasks.
+The desktop application provides a dashboard to interact with containers,
+images, pods and volumes but also configures your environment with your OCI
+registries and network settings. Podman Desktop also provides capabilities
+to connect and deploy pods to Kubernetes environments.
+
+Podman Desktop also supports multiple container engines, pick your favourite
+one and use the tool!
+
+%prep
+{{{ git_dir_setup_macro }}}
+
+%build
+sed -i "/target: \['flatpak'/d" .electron-builder.config.js
+
+yarn install
+yarn compile:current
+
+rm -f dist/linux-unpacked/resources/app.asar.unpacked/node_modules/ssh2/lib/protocol/crypto/build/node_gyp_bins/python3
+rm -f dist/linux-unpacked/resources/app.asar.unpacked/node_modules/cpu-features/build/node_gyp_bins/python3
+
+%install
+# install everything to /opt/%%{pkg_name}
+install -dp %{buildroot}%{_optpkgdir}
+cp -Rp dist/linux-unpacked/* %{buildroot}%{_optpkgdir}
+
+# install icon
+install -dp %{buildroot}%{_icondir}
+install -Dp -m0755 buildResources/icon-512x512.png %{buildroot}%{_icondir}/%{name}.png
+
+# install desktop file
+install -dp %{buildroot}%{_datadir}/applications
+install -Dp -m0755 .copr-rpm.%{name}.desktop %{buildroot}%{_datadir}/applications/%{name}.desktop
+
+# symlink main binary to /usr/bin
+install -dp %{buildroot}%{_bindir}
+ln -s %{_optpkgdir}/%{name} %{buildroot}%{_bindir}/%{name}
+
+%files
+%license LICENSE
+%doc CODE-OF-CONDUCT.md CONTRIBUTING.md README.md SECURITY.md
+%{_bindir}/%{name}
+%dir %{_optpkgdir}
+%{_optpkgdir}/*
+%dir %{_icondir}
+%{_icondir}/%{name}.png
+%dir %{_datadir}/applications
+%{_datadir}/applications/%{name}.desktop
+
+%changelog
+{{{ git_dir_changelog }}}


### PR DESCRIPTION
This commit along with a github webhook will automatically trigger rpm builds on the `rhcontainerbot/podman-next` copr after every PR merge.

Useful for those who can't wait for releases and are ok with danger.

Ref: https://copr.fedorainfracloud.org/coprs/rhcontainerbot/podman-next/

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>

### What does this PR do?

will automatically trigger rpm builds on `rhcontainerbot/podman-next` copr.

### Screenshot/screencast of this PR

Not relevant. But here's the link to the builds triggered on the copr: https://copr.fedorainfracloud.org/coprs/rhcontainerbot/podman-next/package/podman-desktop/

### What issues does this PR fix or reference?

None. Though loosely related to https://github.com/containers/podman-desktop/issues/112 

### How to test this PR?

As long as every PR successfully triggers an RPM build on the copr, we're good.


/cc @rhatdan