### PR TITLE
fix: escape whitespace in command

### DIFF
--- a/extensions/podman/src/util.ts
+++ b/extensions/podman/src/util.ts
@@ -62,6 +62,9 @@ export function runCliCommand(command: string, args: string[], options?: RunOpti
       env = Object.assign(env, options.env);
     }
 
+    // Escape any whitespaces in command
+    command = command.replace(/(\s+)/g, '\\$1');
+
     const spawnProcess = spawn(command, args, { shell: isWindows, env });
     spawnProcess.on('error', err => {
       reject(err);


### PR DESCRIPTION
fixes #806

Signed-off-by: Anjan Nath <kaludios@gmail.com>

### What does this PR do?

this escapes any whitespaces that might be present in a command due to including the absolute path to the executable file

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

### How to test this PR?

<!-- Please explain steps to reproduce -->
