### PR TITLE
fix: handle properly certificates on Windows

### DIFF
--- a/.electron-builder.config.js
+++ b/.electron-builder.config.js
@@ -58,6 +58,8 @@ const config = {
     }
 
     if(context.arch === Arch.x64 && context.electronPlatformName === 'win32'){
+      // add also the win-ca package
+      context.packager.config.extraResources.push({from: 'node_modules/win-ca/lib/roots.exe', to: 'win-ca/roots.exe'});
       context.packager.config.extraResources.push('extensions/podman/assets/**');
     }
   },


### PR DESCRIPTION
### What does this PR do?
- Use alternative path for win-ca root.exe (as it may not be possible to read root.exe from .asar archive)
- Use a try/catch block for Windows certificates (in case of unknown error)

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Launch on Windows and see if no error is reported when starting the application

Change-Id: I8fa6540afcd0aea1e1d548c7052a4372a685bd36
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
