### PR TITLE
chore: fails when unable to find podman assets

### DIFF
--- a/extensions/podman/scripts/download.ts
+++ b/extensions/podman/scripts/download.ts
@@ -92,7 +92,7 @@ async function downloadAndCheckSha(tagVersion: string, fileName: string, artifac
   }
   if (!msiSha) {
     console.error(`Can't find SHA256 sum for ${artifactName} in:\n${shaFileContent}`);
-    return;
+    process.exit(1);
   }
 
   const destDir = path.resolve(__dirname, '..', 'assets');

--- a/extensions/podman/scripts/download.ts
+++ b/extensions/podman/scripts/download.ts
@@ -85,8 +85,8 @@ async function downloadAndCheckSha(tagVersion: string, fileName: string, artifac
   let msiSha = '';
 
   for (const shaLine of shaArr) {
-    if (shaLine.endsWith(artifactName)) {
-      msiSha = shaLine.split('  ')[0];
+    if (shaLine.trim().endsWith(artifactName)) {
+      msiSha = shaLine.split(' ')[0];
       break;
     }
   }


### PR DESCRIPTION
### What does this PR do?
- fails when unable to find podman assets
- apply trim to make it more robust

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

Fixes #928 

### How to test this PR?

yarn build in `extensions/podman` folder.
(remove `assets` folder of `extensions/podman` first)