### PR TITLE
fix: uses proxy settings (if any) on podman machine init command

### DIFF
--- a/extensions/podman/src/podman-configuration.ts
+++ b/extensions/podman/src/podman-configuration.ts
@@ -28,6 +28,8 @@ import type { Provider, ProviderProxySettings } from '@tmpwip/extension-api';
  * Manages access to the containers.conf configuration file used to configure Podman
  */
 export class PodmanConfiguration {
+  private proxySettings: ProviderProxySettings | undefined;
+
   async init(provider: Provider) {
     let httpProxy = undefined;
     let httpsProxy = undefined;
@@ -139,6 +141,9 @@ export class PodmanConfiguration {
         // write the file
         const content = toml.stringify(tomlConfigFile, { newline: '\n' });
         await fs.promises.writeFile(this.getContainersFileLocation(), content);
+
+        // update the values
+        this.proxySettings = proxySettings;
       }
     });
     // check if the file exists
@@ -177,6 +182,7 @@ export class PodmanConfiguration {
       httpProxy,
       noProxy,
     };
+    this.proxySettings = proxySettings;
 
     // register the proxy even if there are no values set so Podman Desktop knows that we support proxy handling.
     provider.registerProxy(proxySettings);
@@ -208,5 +214,9 @@ export class PodmanConfiguration {
         }
       });
     });
+  }
+
+  getProxySettings(): ProviderProxySettings | undefined {
+    return this.proxySettings;
   }
 }


### PR DESCRIPTION
### What does this PR do?
Sets environment variables to use http(s) proxy when initializing a machine

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?

Fixes #939 

### How to test this PR?

Sets http/https proxy in settings

then try to run the 'init' command to initialize a machine.

expect: use the proxy to fetch the data


Change-Id: I177af61e5665710e1bd462a59f06c850c848e2bd
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
