### PR TITLE
feat: add way to provide additional path for podman binary

### DIFF
--- a/extensions/podman/package.json
+++ b/extensions/podman/package.json
@@ -23,7 +23,7 @@
         "podman.binary.path": {
           "type": "string",
           "default": "",
-          "description": "Custom path to Podman binary (Default is blank)"
+          "description": "Custom path to Podman binary. If gvproxy and podman-mac-helper are required, update helper_binaries_dir in containers.conf. (Default is blank)"
         },
         "podman.machine.cpus": {
           "type": "number",

--- a/extensions/podman/package.json
+++ b/extensions/podman/package.json
@@ -20,6 +20,11 @@
     "configuration": {
       "title": "Podman",
       "properties": {
+        "podman.binary.path": {
+          "type": "string",
+          "default": "",
+          "description": "Custom path to Podman binary (Default is blank)"
+        },
         "podman.machine.cpus": {
           "type": "number",
           "format": "cpu",

--- a/extensions/podman/src/detection-checks.ts
+++ b/extensions/podman/src/detection-checks.ts
@@ -18,7 +18,7 @@
 
 import type * as extensionApi from '@tmpwip/extension-api';
 import type { InstalledPodman } from './podman-cli';
-import { getInstallationPath } from './podman-cli';
+import { getInstallationPath, getCustomBinaryPath } from './podman-cli';
 
 export function getDetectionChecks(installedPodman?: InstalledPodman): extensionApi.ProviderDetectionCheck[] {
   const detectionChecks: extensionApi.ProviderDetectionCheck[] = [];
@@ -26,6 +26,12 @@ export function getDetectionChecks(installedPodman?: InstalledPodman): extension
     detectionChecks.push({
       name: `Podman ${installedPodman.version} found`,
       status: true,
+    });
+  } else if (getCustomBinaryPath()) {
+    detectionChecks.push({
+      name: 'podman cli binary was not found in custom path',
+      details: `Binary path set to ${getCustomBinaryPath()}`,
+      status: false,
     });
   } else {
     detectionChecks.push({

--- a/extensions/podman/src/podman-cli.ts
+++ b/extensions/podman/src/podman-cli.ts
@@ -16,8 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 import { spawn } from 'node:child_process';
-
-import type * as extensionApi from '@tmpwip/extension-api';
+import * as extensionApi from '@tmpwip/extension-api';
 import { isMac, isWindows } from './util';
 
 const macosExtraPath = '/usr/local/bin:/opt/homebrew/bin:/opt/local/bin:/opt/podman/bin';
@@ -38,10 +37,22 @@ export function getInstallationPath(): string {
 }
 
 export function getPodmanCli(): string {
+  // If we have a custom binary path regardless if we are running Windows or not
+  const customBinaryPath = getCustomBinaryPath();
+  if (customBinaryPath) {
+    return customBinaryPath;
+  }
+
   if (isWindows) {
     return 'podman.exe';
   }
   return 'podman';
+}
+
+// Get the Podman binary path from configuration podman.binary.path
+// return string or undefined
+export function getCustomBinaryPath(): string | undefined {
+  return extensionApi.configuration.getConfiguration('podman').get('binary.path');
 }
 
 export interface ExecOptions {

--- a/extensions/podman/src/podman-cli.ts
+++ b/extensions/podman/src/podman-cli.ts
@@ -16,8 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 import { spawn } from 'node:child_process';
-import * as extensionApi from '@tmpwip/extension-api';
 import { isMac, isWindows } from './util';
+import type { Logger } from '@tmpwip/extension-api';
+import { configuration } from '@tmpwip/extension-api';
 
 const macosExtraPath = '/usr/local/bin:/opt/homebrew/bin:/opt/local/bin:/opt/podman/bin';
 
@@ -52,11 +53,11 @@ export function getPodmanCli(): string {
 // Get the Podman binary path from configuration podman.binary.path
 // return string or undefined
 export function getCustomBinaryPath(): string | undefined {
-  return extensionApi.configuration.getConfiguration('podman').get('binary.path');
+  return configuration.getConfiguration('podman').get('binary.path');
 }
 
 export interface ExecOptions {
-  logger?: extensionApi.Logger;
+  logger?: Logger;
   env?: NodeJS.ProcessEnv | undefined;
 }
 


### PR DESCRIPTION
feat: add way to provide additional path for podman binary

### What does this PR do?

* Adds an option within settings (Extensions -> Podman Desktop) to be
  able to provide an additional path to binary

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

![Screenshot 2022-11-30 at 9 58 55 AM](https://user-images.githubusercontent.com/6422176/204832063-5858065a-2fc3-49de-8d23-3b99b7d10dbf.png)


### What issues does this PR fix or reference?

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

Closes https://github.com/containers/podman-desktop/issues/810

### How to test this PR?

<!-- Please explain steps to reproduce -->

1. Add option (ex. `/Users/username/podman` for additional binary in settings
2. Detection tests will pass

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
