### PR TITLE
nit: change text of proxy page

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesProxiesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesProxiesRendering.svelte
@@ -26,33 +26,32 @@ function updateProvider(provider: ProviderInfo) {
           </div>
 
           <div>
-            <label for="httpProxy" class="block mt-2 mb-1 text-sm font-medium text-gray-300">Http Proxy:</label>
+            <label for="httpProxy" class="block mt-2 mb-1 text-sm font-medium text-gray-300">Web Proxy (HTTP):</label>
             <input
               name="{provider.id}-httpProxy"
               id="{provider.id}-httpProxy"
               bind:value="{provider.proxySettings.httpProxy}"
-              placeholder="Defines Http proxy to use..."
               class=" text-sm rounded-lg focus:ring-violet-500 focus:border-violet-500 block w-full p-2.5 bg-gray-600 border-gray-500 placeholder-gray-400 text-white"
               required />
           </div>
           <div>
-            <label for="httpsProxy" class="block mt-2 mb-1  text-sm font-medium text-gray-300">Https Proxy:</label>
+            <label for="httpsProxy" class="block mt-2 mb-1  text-sm font-medium text-gray-300"
+              >Secure Web Proxy (HTTPS):</label>
             <input
               name="{provider.id}-httpsProxy"
               id="{provider.id}-httpsProxy"
               bind:value="{provider.proxySettings.httpsProxy}"
-              placeholder="Defines Https proxy to use..."
               class=" text-sm rounded-lg focus:ring-violet-500 focus:border-violet-500 block w-full p-2.5 bg-gray-600 border-gray-500 placeholder-gray-400 text-white"
               required />
           </div>
           <div>
             <label for="httpProxy" class="block mt-2 mb-1 text-sm font-medium text-gray-300"
-              >No Proxy for the following hosts:</label>
+              >Bypass proxy settings for these hosts and domains:</label>
             <input
               name="{provider.id}-noProxy"
               id="{provider.id}-noProxy"
               bind:value="{provider.proxySettings.noProxy}"
-              placeholder="Defines No proxy (ignore pattern) to use..."
+              placeholder="Example: *.domain.com, 192.168.*"
               class=" text-sm rounded-lg focus:ring-violet-500 focus:border-violet-500 block w-full p-2.5 bg-gray-600 border-gray-500 placeholder-gray-400 text-white"
               required />
           </div>

--- a/packages/renderer/src/lib/preferences/PreferencesProxiesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesProxiesRendering.svelte
@@ -51,7 +51,7 @@ function updateProvider(provider: ProviderInfo) {
               name="{provider.id}-noProxy"
               id="{provider.id}-noProxy"
               bind:value="{provider.proxySettings.noProxy}"
-              placeholder="Example: *.domain.com, 192.168.*"
+              placeholder="Example: *.domain.com, 192.168.*.*"
               class=" text-sm rounded-lg focus:ring-violet-500 focus:border-violet-500 block w-full p-2.5 bg-gray-600 border-gray-500 placeholder-gray-400 text-white"
               required />
           </div>


### PR DESCRIPTION
nit: change text of proxy page

### What does this PR do?

* Remove placeholders. Placeholders repeat what's in the title, we
  should only use placeholders if we need to explain meaning of the
  entry (ex, comma deliminated list, etc.)
* Https should be capitalized as HTTPS
* Makes it similar to Mac proxy configuration (most of our users are on
  Mac)

### Screenshot/screencast of this PR

![Screenshot 2022-11-30 at 11 05 23 AM](https://user-images.githubusercontent.com/6422176/204848318-135164ad-6158-4688-af8e-a35b6f9bd7b1.png)


<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

N/A

### How to test this PR?

View it :)

<!-- Please explain steps to reproduce -->

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
