### PR TITLE
fix: move extension properties to preferences

### DIFF
--- a/extensions/podman/package.json
+++ b/extensions/podman/package.json
@@ -18,7 +18,7 @@
       }
     ],
     "configuration": {
-      "title": "Podman Machine",
+      "title": "Podman",
       "properties": {
         "podman.machine.cpus": {
           "type": "number",

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -239,7 +239,9 @@ export class ExtensionLoader {
     if (extensionConfiguration) {
       // add information about the current extension
       extensionConfiguration.extension = extension;
-      extensionConfiguration.id = 'extensions.' + extension.id;
+      extensionConfiguration.title = `Extension: ${extensionConfiguration.title}`;
+      extensionConfiguration.id = 'preferences.' + extension.id;
+
       this.configurationRegistry.registerConfigurations([extensionConfiguration]);
     }
 

--- a/packages/renderer/src/lib/preferences/PreferencesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRendering.svelte
@@ -8,7 +8,7 @@ export let key: string;
 let title;
 
 $: title = key.replaceAll('.', ' ');
-$: matchingRecords = properties.filter(property => property.parentId.startsWith(key));
+$: matchingRecords = properties.filter(property => property.parentId.startsWith(key) && property.scope === 'DEFAULT');
 </script>
 
 <div class="flex flex-1 flex-col">


### PR DESCRIPTION

### What does this PR do?
Make preferences visible (and only the one with the default scope) when adding simple properties to an extension.

### Screenshot/screencast of this PR

![image](https://user-images.githubusercontent.com/436777/205066787-09e74e1b-598a-4002-803d-7a5326189c09.png)

### What issues does this PR fix or reference?

#947 

### How to test this PR?

Add some properties (like in podman package.json file)
```json
      "properties": {
        "podman.my.test.property": {
          "type": "string",
          "default": "test",
          "description": "My test property"
        },
```        
and look if you see them appear in the preferences screen.

Change-Id: If8889eae5c1ef13232d22fe2539b941b728e2fef
Signed-off-by: Florent Benoit <fbenoit@redhat.com>