### PR TITLE
chore: remove deprecated set-output

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> ${env:GITHUB_OUTPUT}
 
       - uses: actions/cache@v3
         id: yarn-cache
@@ -80,7 +80,7 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> ${GITHUB_OUTPUT}
 
       - uses: actions/cache@v3
         id: yarn-cache
@@ -134,7 +134,7 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> ${GITHUB_OUTPUT}
 
       - uses: actions/cache@v3
         id: yarn-cache
@@ -180,7 +180,7 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> ${GITHUB_OUTPUT}
 
       - uses: actions/cache@v3
         id: yarn-cache


### PR DESCRIPTION
### What does this PR do?
remove deprecated on pr-check workflow
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

I'll make follow-up PRs if this one works fine :-)

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?

https://github.com/containers/podman-desktop/issues/694

### How to test this PR?

<!-- Please explain steps to reproduce -->


Change-Id: I09f8fc0a3f8fa91827365890167f2654c7fd9502
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
