### PR TITLE
fix: handle invalid kubeconfig files instead of crashing

### DIFF
--- a/packages/main/src/plugin/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes-client.ts
@@ -140,7 +140,13 @@ export class KubernetesClient {
   }
 
   refresh() {
-    this.kubeConfig.loadFromFile(this.kubeconfigPath);
+    // perform it under a try/catch block as the file may not be valid for the kubernetes-javascript client library
+    try {
+      this.kubeConfig.loadFromFile(this.kubeconfigPath);
+    } catch (error) {
+      console.error(`An error happened when loading kubeconfig file at ${this.kubeconfigPath}`, error);
+      return;
+    }
 
     // get the current context
     this.currentContextName = this.kubeConfig.getCurrentContext();


### PR DESCRIPTION
### What does this PR do?
kubernetes-client library expect to have non-empty context.cluster values. Loading such files is throwing an error in the library.

Now, we're handling such behavior by ignoring these invalid files


### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/951


### How to test this PR?

use an empty `context.cluster` value in kubeconfig file.
before = crash
now = log an error

Change-Id: Ifde9c4b6e9b8e02cd5cb89b1da12026d89e7e695
Signed-off-by: Florent Benoit <fbenoit@redhat.com>

