### PR TITLE
chore: add repository key to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "podman-desktop",
   "productName": "Podman Desktop",
+  "repository": "https://github.com/containers/podman-desktop",
   "version": "0.11.0-next",
   "license": "apache-2.0",
   "private": true,


### PR DESCRIPTION
Follow up from #906

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>

### What does this PR do?

Adds a `repository` key with upstream URL value.

### Screenshot/screencast of this PR

NA

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?

None

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

### How to test this PR?

NA. I need this mainly for copr rpm builds and IIUC, upstream is ok with it.
<!-- Please explain steps to reproduce -->
