### PR TITLE
chore: add missing apt-get update instruction

### DIFF
--- a/.github/workflows/next-build.yaml
+++ b/.github/workflows/next-build.yaml
@@ -112,6 +112,7 @@ jobs:
       - name: Install flatpak on Linux
         if: ${{ matrix.os=='ubuntu-20.04' }}
         run: |
+          sudo apt-get update
           sudo apt-get install flatpak -y
           sudo apt-get install flatpak-builder -y
           sudo apt-get install elfutils -y

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -96,6 +96,7 @@ jobs:
 
       - name: Install flatpak
         run: |
+          sudo apt-get update
           sudo apt-get install flatpak -y
           sudo apt-get install flatpak-builder -y
           sudo apt-get install elfutils -y

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -162,6 +162,7 @@ jobs:
       - name: Install flatpak on Linux
         if: ${{ matrix.os=='ubuntu-20.04' }}
         run: |
+          sudo apt-get update
           sudo apt-get install flatpak -y
           sudo apt-get install flatpak-builder -y
           sudo apt-get install elfutils -y


### PR DESCRIPTION
### What does this PR do?
sometimes, Linux VMs are not up-to-date with the remote deb repositories
Need to update the cache to be sure to install right files from the mirror

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?

https://github.com/containers/podman-desktop/actions/runs/3602126107/jobs/6069637567

### How to test this PR?

Change-Id: Ie279dc360c54b13702842c985fb7b6cfaaef3220
Signed-off-by: Florent Benoit <fbenoit@redhat.com>

