### PR TITLE
chore: allow to hide properties (they're persisted but not visible as a preference)

### DIFF
--- a/packages/main/src/plugin/configuration-registry.ts
+++ b/packages/main/src/plugin/configuration-registry.ts
@@ -56,6 +56,7 @@ export interface IConfigurationPropertySchema {
   format?: string;
   scope?: ConfigurationScope;
   readonly?: boolean;
+  hidden?: boolean;
 }
 
 export type ConfigurationScope = 'DEFAULT' | 'ContainerConnection' | 'ContainerProviderConnectionFactory';

--- a/packages/main/src/plugin/telemetry/telemetry.ts
+++ b/packages/main/src/plugin/telemetry/telemetry.ts
@@ -67,6 +67,7 @@ export class Telemetry {
           description: 'Dialog prompt for telemetry',
           type: 'boolean',
           default: false,
+          hidden: true,
         },
       },
     };

--- a/packages/renderer/src/PreferencesNavigation.svelte
+++ b/packages/renderer/src/PreferencesNavigation.svelte
@@ -27,6 +27,7 @@ onMount(async () => {
   configurationProperties.subscribe(value => {
     configProperties = value
       .filter(property => property.scope === ConfigurationRegistry.DEFAULT_SCOPE)
+      .filter(property => !property.hidden)
       .reduce(function (map, property) {
         let [parentLeftId] = property.parentId.split('.');
 

--- a/packages/renderer/src/lib/preferences/PreferencesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRendering.svelte
@@ -8,7 +8,9 @@ export let key: string;
 let title;
 
 $: title = key.replaceAll('.', ' ');
-$: matchingRecords = properties.filter(property => property.parentId.startsWith(key) && property.scope === 'DEFAULT');
+$: matchingRecords = properties.filter(
+  property => property.parentId.startsWith(key) && property.scope === 'DEFAULT' && !property.hidden,
+);
 </script>
 
 <div class="flex flex-1 flex-col">


### PR DESCRIPTION
### What does this PR do?
Allow to store/read properties but not exposed them in the UI

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

https://github.com/containers/podman-desktop/issues/319

### How to test this PR?

Check that `telemetry.check` property is no longer visible.

Change-Id: I4e4f3cc12c56afba7558e1fe66e86b90ccf480d1
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
