### PR TITLE
chore: replace deprecated set-output instructions in github actions

### DIFF
--- a/.github/workflows/next-build.yaml
+++ b/.github/workflows/next-build.yaml
@@ -45,8 +45,8 @@ jobs:
             CURRENT_DAY=$(date +'%Y%m%d')
             SHORT_SHA1=$(git rev-parse --short HEAD)
             TAG_PATTERN=0.0.$(date +'%Y%m%d%H%M')-${SHORT_SHA1}
-            echo "::set-output name=githubTag::v$TAG_PATTERN"
-            echo "::set-output name=desktopVersion::$TAG_PATTERN"
+            echo "githubTag=v$TAG_PATTERN" >> ${GITHUB_OUTPUT}
+            echo "desktopVersion=$TAG_PATTERN" >> ${GITHUB_OUTPUT}
       - name: tag
         run: |
           git config --local user.name ${{ github.actor }}
@@ -89,9 +89,16 @@ jobs:
         with:
           python-version: "3.x"
 
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - name: Get yarn cache directory path (Windows)
+        if: ${{ matrix.os=='windows-2022' }}
+        id: yarn-cache-dir-path-windows
+        run: echo "dir=$(yarn cache dir)" >> ${env:GITHUB_OUTPUT}
+
+      - name: Get yarn cache directory path (mac/Linux)
+        if: ${{ matrix.os=='ubuntu-20.04' || matrix.os=='macos-11' }}
+        id: yarn-cache-dir-path-unix
+        run: echo "dir=$(yarn cache dir)" >> ${GITHUB_OUTPUT}
+
 
       - uses: actions/cache@v3
         id: yarn-cache

--- a/.github/workflows/pr-check-website.yaml
+++ b/.github/workflows/pr-check-website.yaml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> ${GITHUB_OUTPUT}
 
       - uses: actions/cache@v3
         id: yarn-cache

--- a/.github/workflows/publish-to-brew.yaml
+++ b/.github/workflows/publish-to-brew.yaml
@@ -46,7 +46,7 @@ jobs:
           if [[ $version == v* ]]; then
             version="${version:1}"
           fi
-          echo "::set-output name=desktopVersion::$version"
+          echo "desktopVersion=$version" >> ${GITHUB_OUTPUT}
       - name: Create Pull Request to update Brew
         run: |
           # update formulae

--- a/.github/workflows/publish-to-chocolatey.yaml
+++ b/.github/workflows/publish-to-chocolatey.yaml
@@ -53,7 +53,7 @@ jobs:
           if [[ $version == v* ]]; then
             version="${version:1}"
           fi
-          echo "::set-output name=desktopVersion::$version"
+          echo "desktopVersion=$version" >> ${GITHUB_OUTPUT}
 
   winget-bump:
     name: Update Chocolatey

--- a/.github/workflows/publish-to-winget.yaml
+++ b/.github/workflows/publish-to-winget.yaml
@@ -49,7 +49,7 @@ jobs:
           if [[ $version == v* ]]; then
             version="${version:1}"
           fi
-          echo "::set-output name=desktopVersion::$version"
+          echo "desktopVersion=$version" >> ${GITHUB_OUTPUT}
 
   winget-bump:
     name: Update Winget

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,8 +49,9 @@ jobs:
         id: TAG_UTIL
         run: |
             TAG_PATTERN=${{ github.event.inputs.version }}
-            echo "::set-output name=githubTag::v$TAG_PATTERN"
-            echo "::set-output name=desktopVersion::$TAG_PATTERN"
+            echo "githubTag=v$TAG_PATTERN" >> ${GITHUB_OUTPUT}
+            echo "desktopVersion=$TAG_PATTERN" >> ${GITHUB_OUTPUT}
+
       - name: tag
         run: |
           git config --local user.name ${{ github.actor }}
@@ -139,9 +140,15 @@ jobs:
         with:
           python-version: "3.x"
 
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - name: Get yarn cache directory path (Windows)
+        if: ${{ matrix.os=='windows-2022' }}
+        id: yarn-cache-dir-path-windows
+        run: echo "dir=$(yarn cache dir)" >> ${env:GITHUB_OUTPUT}
+
+      - name: Get yarn cache directory path (mac/Linux)
+        if: ${{ matrix.os=='ubuntu-20.04' || matrix.os=='macos-11' }}
+        id: yarn-cache-dir-path-unix
+        run: echo "dir=$(yarn cache dir)" >> ${GITHUB_OUTPUT}
 
       - uses: actions/cache@v3
         id: yarn-cache

--- a/.github/workflows/website-next.yaml
+++ b/.github/workflows/website-next.yaml
@@ -44,7 +44,7 @@ jobs:
           node-version: 16
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> ${GITHUB_OUTPUT}
       - uses: actions/cache@v3
         id: yarn-cache
         with:


### PR DESCRIPTION
### What does this PR do?
use newer way of adding environment variables

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

part of https://github.com/containers/podman-desktop/issues/694
last remaining deprecated stuff will be around nodejs 12/nodejs 16 in another Pull Request

### How to test this PR?

PR checks should be green

Change-Id: Id2457d16e81aa776b20d2962ecd09b7017ef2f53
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
