### PR TITLE
feat: allow to toggle on/off the proxy

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -132,12 +132,6 @@ declare module '@tmpwip/extension-api' {
     status(): ProviderStatus;
   }
 
-  export interface ProviderProxySettings {
-    httpProxy: string;
-    httpsProxy: string;
-    noProxy: string;
-  }
-
   export interface ProviderDetectionCheck {
     name: string;
     details?: string;
@@ -258,10 +252,6 @@ declare module '@tmpwip/extension-api' {
     registerContainerProviderConnection(connection: ContainerProviderConnection): Disposable;
     registerKubernetesProviderConnection(connection: KubernetesProviderConnection): Disposable;
     registerLifecycle(lifecycle: ProviderLifecycle): Disposable;
-    // Sets the proxy that has been defined in the provider
-    registerProxy(proxySettings: ProxySettings): Disposable;
-    // Podman Desktop has updated the settings, propagates the changes to the provider.
-    onDidUpdateProxy: Event<ProxySettings>;
 
     // register installation flow
     registerInstallation(installation: ProviderInstallation): Disposable;
@@ -308,6 +298,23 @@ declare module '@tmpwip/extension-api' {
 
   export namespace provider {
     export function createProvider(provider: ProviderOptions): Provider;
+  }
+
+  export interface ProxySettings {
+    httpProxy: string | undefined;
+    httpsProxy: string | undefined;
+    noProxy: string | undefined;
+  }
+
+  export namespace proxy {
+    export function getProxySettings(): ProxySettings | undefined;
+    export function setProxy(proxySettings: ProxySettings): void;
+    // Podman Desktop has updated the settings, propagates the changes to the provider.
+    export const onDidUpdateProxy: Event<ProxySettings>;
+
+    // The state of the proxy
+    export function isEnabled(): boolean;
+    export const onDidStateChange: Event<boolean>;
   }
 
   export interface Registry extends RegistryCreateOptions {

--- a/packages/main/src/plugin/api/provider-info.ts
+++ b/packages/main/src/plugin/api/provider-info.ts
@@ -21,7 +21,6 @@ import type {
   ProviderDetectionCheck,
   ProviderImages,
   ProviderLinks,
-  ProviderProxySettings,
   ProviderStatus,
   Link,
 } from '@tmpwip/extension-api';
@@ -57,8 +56,6 @@ export interface ProviderInfo {
   lifecycleMethods?: LifecycleMethod[];
   // can create provider connection from ContainerProviderConnectionFactory params
   containerProviderConnectionCreation: boolean;
-
-  proxySettings?: ProviderProxySettings;
 
   version?: string;
 

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -38,6 +38,7 @@ import { StatusBarAlignLeft, StatusBarAlignRight, StatusBarItemDefaultPriority }
 import type { FilesystemMonitoring } from './filesystem-monitoring';
 import { Uri } from './types/uri';
 import type { KubernetesClient } from './kubernetes-client';
+import type { Proxy } from './proxy';
 
 /**
  * Handle the loading of an extension
@@ -82,6 +83,7 @@ export class ExtensionLoader {
     private statusBarRegistry: StatusBarRegistry,
     private kubernetesClient: KubernetesClient,
     private fileSystemMonitoring: FilesystemMonitoring,
+    private proxy: Proxy,
   ) {}
 
   async listExtensions(): Promise<ExtensionInfo[]> {
@@ -290,6 +292,25 @@ export class ExtensionLoader {
       },
     };
 
+    const proxyInstance = this.proxy;
+    const proxy: typeof containerDesktopAPI.proxy = {
+      getProxySettings(): containerDesktopAPI.ProxySettings | undefined {
+        return proxyInstance.proxy;
+      },
+      setProxy(proxySettings: containerDesktopAPI.ProxySettings): void {
+        proxyInstance.setProxy(proxySettings);
+      },
+      onDidUpdateProxy: (listener, thisArg, disposables) => {
+        return proxyInstance.onDidUpdateProxy(listener, thisArg, disposables);
+      },
+      isEnabled(): boolean {
+        return proxyInstance.isEnabled();
+      },
+      onDidStateChange: (listener, thisArg, disposables) => {
+        return proxyInstance.onDidStateChange(listener, thisArg, disposables);
+      },
+    };
+
     const trayMenuRegistry = this.trayMenuRegistry;
     const tray: typeof containerDesktopAPI.tray = {
       registerMenuItem(item: containerDesktopAPI.MenuItem): containerDesktopAPI.Disposable {
@@ -415,6 +436,7 @@ export class ExtensionLoader {
       fs,
       configuration,
       tray,
+      proxy,
       kubernetes,
       ProgressLocation,
       window: windowObj,

--- a/packages/main/src/plugin/image-registry.spec.ts
+++ b/packages/main/src/plugin/image-registry.spec.ts
@@ -17,15 +17,24 @@
  ***********************************************************************/
 
 import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
+import type { Certificates } from './certificates';
 
 import { ImageRegistry } from './image-registry';
+import type { Proxy } from './proxy';
 import type { Telemetry } from './telemetry/telemetry';
 
 let imageRegistry;
 
 beforeAll(() => {
   const telemetry: Telemetry = {} as Telemetry;
-  imageRegistry = new ImageRegistry({}, telemetry);
+  const certificates: Certificates = {} as Certificates;
+  const proxy: Proxy = {
+    onDidStateChange: vi.fn(),
+    onDidUpdateProxy: vi.fn(),
+    isEnabled: vi.fn(),
+  } as unknown as Proxy;
+
+  imageRegistry = new ImageRegistry({}, telemetry, certificates, proxy);
 });
 
 beforeEach(() => {

--- a/packages/main/src/plugin/provider-impl.ts
+++ b/packages/main/src/plugin/provider-impl.ts
@@ -29,7 +29,6 @@ import type {
   ProviderOptions,
   ProviderStatus,
   ProviderConnectionStatus,
-  ProviderProxySettings,
   Event,
   ProviderInstallation,
   ProviderLinks,
@@ -48,11 +47,6 @@ export class ProviderImpl implements Provider, IDisposable {
   // optional factory
   private _containerProviderConnectionFactory: ContainerProviderConnectionFactory | undefined = undefined;
   private _status: ProviderStatus;
-
-  private proxySettings: ProviderProxySettings | undefined;
-
-  private readonly _onDidUpdateProxy = new Emitter<ProviderProxySettings>();
-  readonly onDidUpdateProxy: Event<ProviderProxySettings> = this._onDidUpdateProxy.event;
 
   private readonly _onDidUpdateStatus = new Emitter<ProviderStatus>();
   readonly onDidUpdateStatus: Event<ProviderStatus> = this._onDidUpdateStatus.event;
@@ -95,27 +89,6 @@ export class ProviderImpl implements Provider, IDisposable {
         }
       });
     }, 2000);
-  }
-
-  registerProxy(proxySettings: ProviderProxySettings): Disposable {
-    this.proxySettings = proxySettings;
-    this._onDidUpdateProxy.fire(proxySettings);
-
-    return Disposable.create(() => {
-      this.proxySettings = undefined;
-    });
-  }
-
-  updateProxy(proxy: ProviderProxySettings): void {
-    // notify
-    this._onDidUpdateProxy.fire(proxy);
-
-    // update
-    this.proxySettings = proxy;
-  }
-
-  get proxy(): ProviderProxySettings | undefined {
-    return this.proxySettings;
   }
 
   get containerProviderConnectionFactory(): ContainerProviderConnectionFactory | undefined {

--- a/packages/main/src/plugin/provider-registry.ts
+++ b/packages/main/src/plugin/provider-registry.ts
@@ -24,7 +24,6 @@ import type {
   ProviderInstallation,
   ProviderLifecycle,
   ProviderOptions,
-  ProviderProxySettings,
   ProviderStatus,
   ProviderUpdate,
 } from '@tmpwip/extension-api';
@@ -113,10 +112,6 @@ export class ProviderRegistry {
     if (providerOptions.version) {
       trackOpts.version = providerOptions.version;
     }
-    providerImpl.onDidUpdateProxy(() => {
-      this.listeners.forEach(listener => listener('provider:update-proxy', this.getProviderInfo(providerImpl)));
-    });
-
     this.telemetryService.track('createProvider', trackOpts);
     this.apiSender.send('provider-create', id);
     return providerImpl;
@@ -253,13 +248,6 @@ export class ProviderRegistry {
     this.lifecycleListeners.forEach(listener =>
       listener('provider:after-stop-lifecycle', this.getProviderInfo(provider), providerLifecycle),
     );
-  }
-
-  // Update the proxy for the given provider
-  async updateProxySettings(providerId: string, proxy: ProviderProxySettings): Promise<void> {
-    const provider = this.getMatchingProvider(providerId);
-    provider.updateProxy(proxy);
-    this.listeners.forEach(listener => listener('provider:update-proxy', this.getProviderInfo(provider)));
   }
 
   async getProviderDetectionChecks(providerInternalId: string): Promise<ProviderDetectionCheck[]> {

--- a/packages/main/src/plugin/proxy.ts
+++ b/packages/main/src/plugin/proxy.ts
@@ -1,0 +1,132 @@
+/**********************************************************************
+ * Copyright (C) 2022 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { ProxySettings, Event } from '@tmpwip/extension-api';
+import type { ConfigurationRegistry, IConfigurationNode } from './configuration-registry';
+import { Emitter } from './events/emitter';
+
+/**
+ * Handle proxy settings for Podman Desktop
+ */
+export class Proxy {
+  private proxySettings: ProxySettings | undefined;
+  private proxyState = false;
+
+  private readonly _onDidUpdateProxy = new Emitter<ProxySettings>();
+  public readonly onDidUpdateProxy: Event<ProxySettings> = this._onDidUpdateProxy.event;
+
+  private readonly _onDidStateChange = new Emitter<boolean>();
+  public readonly onDidStateChange: Event<boolean> = this._onDidStateChange.event;
+
+  constructor(private configurationRegistry: ConfigurationRegistry) {}
+
+  async init(): Promise<void> {
+    const proxyConfigurationNode: IConfigurationNode = {
+      id: 'proxy',
+      title: 'Proxy',
+      type: 'object',
+      properties: {
+        ['proxy.http']: {
+          description: 'Http Proxy value',
+          type: 'string',
+          default: '',
+          hidden: true,
+        },
+        ['proxy.https']: {
+          description: 'Https Proxy value',
+          type: 'string',
+          default: '',
+          hidden: true,
+        },
+        ['proxy.no']: {
+          description: 'Pattern for not using a proxy',
+          type: 'string',
+          default: '',
+          hidden: true,
+        },
+        ['proxy.enabled']: {
+          description: 'Toggle to enable',
+          type: 'string',
+          default: false,
+          hidden: true,
+        },
+      },
+    };
+
+    this.configurationRegistry.registerConfigurations([proxyConfigurationNode]);
+
+    // be notified when configuration is updated
+    this.configurationRegistry.onDidChangeConfiguration(e => {
+      if (e.key.startsWith('proxy')) {
+        this.updateFromConfiguration();
+      }
+    });
+
+    // read initial value
+    this.updateFromConfiguration();
+  }
+
+  updateFromConfiguration(): void {
+    // read value from the configuration
+    const proxyConfiguration = this.configurationRegistry.getConfiguration('proxy');
+    const httpProxy = proxyConfiguration.get<string>('http');
+    const httpsProxy = proxyConfiguration.get<string>('https');
+    const noProxy = proxyConfiguration.get<string>('no');
+    const isEnabled = proxyConfiguration.get<boolean>('enabled') || false;
+
+    this.proxySettings = {
+      httpProxy,
+      httpsProxy,
+      noProxy,
+    };
+    this.proxyState = isEnabled;
+  }
+
+  setProxy(proxy: ProxySettings): void {
+    // notify
+    this._onDidUpdateProxy.fire(proxy);
+
+    // update
+    this.proxySettings = proxy;
+
+    // update configuration
+    const proxyConfiguration = this.configurationRegistry.getConfiguration('proxy');
+    proxyConfiguration.update('http', proxy.httpProxy);
+    proxyConfiguration.update('https', proxy.httpsProxy);
+    proxyConfiguration.update('no', proxy.noProxy);
+  }
+
+  get proxy(): ProxySettings | undefined {
+    return this.proxySettings;
+  }
+
+  isEnabled(): boolean {
+    return this.proxyState;
+  }
+
+  setState(state: boolean): void {
+    this.proxyState = state;
+
+    // update configuration
+    const proxyConfiguration = this.configurationRegistry.getConfiguration('proxy');
+    proxyConfiguration.update('enabled', state);
+
+    // notify
+    this._onDidStateChange.fire(this.proxyState);
+  }
+}

--- a/packages/main/src/plugin/proxy.ts
+++ b/packages/main/src/plugin/proxy.ts
@@ -42,13 +42,13 @@ export class Proxy {
       type: 'object',
       properties: {
         ['proxy.http']: {
-          description: 'Http Proxy value',
+          description: 'Proxy (HTTP)',
           type: 'string',
           default: '',
           hidden: true,
         },
         ['proxy.https']: {
-          description: 'Https Proxy value',
+          description: 'Proxy (HTTPS)',
           type: 'string',
           default: '',
           hidden: true,

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -395,11 +395,22 @@ function initExposure(): void {
   });
 
   contextBridge.exposeInMainWorld(
-    'updateProviderProxySettings',
-    async (providerId: string, proxySettings: containerDesktopAPI.ProviderProxySettings): Promise<void> => {
-      return ipcInvoke('provider-registry:updateProxySettings', providerId, proxySettings);
+    'updateProxySettings',
+    async (proxySettings: containerDesktopAPI.ProxySettings): Promise<void> => {
+      return ipcInvoke('proxy:updateSettings', proxySettings);
     },
   );
+
+  contextBridge.exposeInMainWorld('getProxySettings', async (): Promise<containerDesktopAPI.ProxySettings> => {
+    return ipcInvoke('proxy:getSettings');
+  });
+
+  contextBridge.exposeInMainWorld('isProxyEnabled', async (): Promise<boolean> => {
+    return ipcInvoke('proxy:isEnabled');
+  });
+  contextBridge.exposeInMainWorld('setProxyState', async (state: boolean): Promise<void> => {
+    return ipcInvoke('proxy:setState', state);
+  });
 
   contextBridge.exposeInMainWorld(
     'getProviderDetectionChecks',


### PR DESCRIPTION
### What does this PR do?

Podman Desktop is now storing in its preferences the proxy settings and if it is enabled or not.
Extensions can read this information and then update the proxy configuration

Settings page allows to toggle the proxy configuration

### Screenshot/screencast of this PR
https://user-images.githubusercontent.com/436777/205955418-670bc37c-a74f-40ef-bc60-8d9d013aa0dc.mp4


### What issues does this PR fix or reference?
Fixes #319 


### How to test this PR?

Launch Podman Desktop and goes into Proxy settings
enable the Proxy settings and then check that in `$HOME/.config/containers/containers.conf` you have the proxy settings
toggle the proxy settings and then check that in `$HOME/.config/containers/containers.conf` you don't have the proxy settings 

If you restart it should also keep the settings
