### PR TITLE
feat: remove background, add hover, delete background parameter to icon

### DIFF
--- a/packages/renderer/src/lib/ContainerDetails.svelte
+++ b/packages/renderer/src/lib/ContainerDetails.svelte
@@ -113,11 +113,11 @@ onMount(() => {
               </div>
             </section>
           </div>
-          <div class="flex flex-col px-5 pt-5">
-            <div class="flex justify-end bg-zinc-700 rounded-md"> 
-              <ContainerActions container="{container}" />
+          <div class="flex flex-col w-full px-5 pt-5">
+            <div class="flex justify-end">
+              <ContainerActions container="{container}" detailed="{true}" />
             </div>
-            <div class="flex my-2 w-full justify-end">
+            <div class="flex my-2 w-full justify-end ">
               <ContainerStatistics container="{container}" />
             </div>
           </div>

--- a/packages/renderer/src/lib/ContainerDetails.svelte
+++ b/packages/renderer/src/lib/ContainerDetails.svelte
@@ -114,8 +114,8 @@ onMount(() => {
             </section>
           </div>
           <div class="flex flex-col w-full px-5 pt-5">
-            <div class="flex h-10 justify-end">
-              <ContainerActions container="{container}" backgroundColor="bg-neutral-900" />
+            <div class="flex justify-end">
+              <ContainerActions container="{container}" />
             </div>
             <div class="flex my-2 w-full justify-end ">
               <ContainerStatistics container="{container}" />

--- a/packages/renderer/src/lib/ContainerDetails.svelte
+++ b/packages/renderer/src/lib/ContainerDetails.svelte
@@ -113,11 +113,11 @@ onMount(() => {
               </div>
             </section>
           </div>
-          <div class="flex flex-col w-full px-5 pt-5">
-            <div class="flex justify-end">
+          <div class="flex flex-col px-5 pt-5">
+            <div class="flex justify-end bg-zinc-700 rounded-md"> 
               <ContainerActions container="{container}" />
             </div>
-            <div class="flex my-2 w-full justify-end ">
+            <div class="flex my-2 w-full justify-end">
               <ContainerStatistics container="{container}" />
             </div>
           </div>

--- a/packages/renderer/src/lib/ExtensionList.svelte
+++ b/packages/renderer/src/lib/ExtensionList.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
 import Fa from 'svelte-fa/src/fa.svelte';
 import { faPuzzlePiece } from '@fortawesome/free-solid-svg-icons';
-import { faPlayCircle } from '@fortawesome/free-solid-svg-icons';
-import { faStopCircle } from '@fortawesome/free-solid-svg-icons';
+import { faPlay } from '@fortawesome/free-solid-svg-icons';
+import { faStop } from '@fortawesome/free-solid-svg-icons';
 import { onMount } from 'svelte';
 import { extensionInfos } from '../stores/extensions';
 import type { ExtensionInfo } from '../../../main/src/plugin/api/extension-info';
@@ -63,17 +63,13 @@ function getColorForState(extensionInfo: ExtensionInfo): string {
                   on:click="{() => startExtension(extension)}"
                   hidden
                   class:block="{extension?.state !== 'active'}"
-                  ><Fa
-                    class="cursor-pointer h-10 w-10 rounded-full text-3xl text-sky-800"
-                    icon="{faPlayCircle}" /></button>
+                  ><Fa class="cursor-pointer h-10 w-10 rounded-full text-3xl text-sky-800" icon="{faPlay}" /></button>
                 <button
                   title="Stop extension"
                   on:click="{() => stopExtension(extension)}"
                   hidden
                   class:block="{extension?.state === 'active'}"
-                  ><Fa
-                    class="cursor-pointer h-10 w-10 rounded-full text-3xl text-sky-800"
-                    icon="{faStopCircle}" /></button>
+                  ><Fa class="cursor-pointer h-10 w-10 rounded-full text-3xl text-sky-800" icon="{faStop}" /></button>
                 <!--<span><Fa class="h-10 w-10 rounded-full text-3xl text-sky-800" icon={faTrash} /></span>-->
               </div>
             </td>

--- a/packages/renderer/src/lib/ImagesList.svelte
+++ b/packages/renderer/src/lib/ImagesList.svelte
@@ -205,7 +205,7 @@ async function deleteSelectedImages() {
           <th class="text-center font-extrabold w-10">Name</th>
           <th class="text-center">Creation date</th>
           <th class="px-6 whitespace-nowrap text-end">size</th>
-          <th class="text-center">actions</th>
+          <th class="text-right pr-2">Actions</th>
         </tr>
       </thead>
       <tbody class="">
@@ -257,10 +257,8 @@ async function deleteSelectedImages() {
                 <div class="w-full text-right text-sm text-gray-200">{image.humanSize}</div>
               </div>
             </td>
-            <td class="px-6 whitespace-nowrap rounded-tr-lg rounded-br-lg ">
-              <div class="flex opacity-0 flex-row justify-end group-hover:opacity-100">
-                <ImageActions image="{image}" onPushImage="{handlePushImageModal}" />
-              </div>
+            <td class="pl-6 text-right whitespace-nowrap rounded-tr-lg rounded-br-lg pr-1">
+              <ImageActions image="{image}" onPushImage="{handlePushImageModal}" />
             </td>
           </tr>
           <tr><td class="leading-[8px]">&nbsp;</td></tr>

--- a/packages/renderer/src/lib/ProviderList.svelte
+++ b/packages/renderer/src/lib/ProviderList.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
 import { providerInfos } from '../stores/providers';
 import Fa from 'svelte-fa/src/fa.svelte';
-import { faPlayCircle } from '@fortawesome/free-solid-svg-icons';
-import { faStopCircle } from '@fortawesome/free-solid-svg-icons';
+import { faPlay } from '@fortawesome/free-solid-svg-icons';
+import { faStop } from '@fortawesome/free-solid-svg-icons';
 import type { ProviderInfo } from '../../../main/src/plugin/api/provider-info';
 
 let waiting = false;
@@ -54,7 +54,7 @@ async function stopProviderLifecycle(provider: ProviderInfo): Promise<void> {
                   ></path>
                 </svg>
               {:else}
-                <Fa class="h-10 w-8 cursor-pointer rounded-full text-xl text-white" icon="{faPlayCircle}" />
+                <Fa class="h-10 w-8 cursor-pointer rounded-full text-xl text-white" icon="{faPlay}" />
               {/if}
               Start
             </button>
@@ -78,7 +78,7 @@ async function stopProviderLifecycle(provider: ProviderInfo): Promise<void> {
                   ></path>
                 </svg>
               {:else}
-                <Fa class="h-10 w-8 cursor-pointer rounded-full text-xl text-white" icon="{faStopCircle}" />
+                <Fa class="h-10 w-8 cursor-pointer rounded-full text-xl text-white" icon="{faStop}" />
               {/if}
               Stop
             </button>

--- a/packages/renderer/src/lib/container/ContainerActions.svelte
+++ b/packages/renderer/src/lib/container/ContainerActions.svelte
@@ -12,6 +12,7 @@ import DropdownMenu from '../ui/DropdownMenu.svelte';
 import FlatMenu from '../ui/FlatMenu.svelte';
 export let container: ContainerInfoUI;
 export let dropdownMenu: boolean = false;
+export let detailed: boolean = false;
 
 async function startContainer(containerInfo: ContainerInfoUI) {
   await window.startContainer(containerInfo.engineId, containerInfo.id);
@@ -58,15 +59,21 @@ if (dropdownMenu) {
   title="Start Container"
   onClick="{() => startContainer(container)}"
   hidden="{container.state === 'RUNNING'}"
+  detailed="{detailed}"
   icon="{faPlay}" />
 
 <ListItemButtonIcon
   title="Stop Container"
   onClick="{() => stopContainer(container)}"
   hidden="{!(container.state === 'RUNNING')}"
+  detailed="{detailed}"
   icon="{faStop}" />
 
-<ListItemButtonIcon title="Delete Container" onClick="{() => deleteContainer(container)}" icon="{faTrash}" />
+<ListItemButtonIcon
+  title="Delete Container"
+  onClick="{() => deleteContainer(container)}"
+  icon="{faTrash}"
+  detailed="{detailed}" />
 
 <!-- If dropdownMenu is true, use it, otherwise just show the regular buttons -->
 <svelte:component this="{actionsStyle}">
@@ -75,28 +82,33 @@ if (dropdownMenu) {
     onClick="{() => openGenerateKube()}"
     menu="{dropdownMenu}"
     hidden="{!(container.engineType === 'podman' && container.groupInfo.type === ContainerGroupInfoTypeUI.STANDALONE)}"
+    detailed="{detailed}"
     icon="{faFileCode}" />
   <ListItemButtonIcon
     title="Deploy to Kubernetes"
     onClick="{() => deployToKubernetes()}"
     menu="{dropdownMenu}"
     hidden="{!(container.engineType === 'podman' && container.groupInfo.type === ContainerGroupInfoTypeUI.STANDALONE)}"
+    detailed="{detailed}"
     icon="{faRocket}" />
   <ListItemButtonIcon
     title="Open Browser"
     onClick="{() => openBrowser(container)}"
     menu="{dropdownMenu}"
     hidden="{!(container.state === 'RUNNING' && container.hasPublicPort)}"
+    detailed="{detailed}"
     icon="{faExternalLinkSquareAlt}" />
   <ListItemButtonIcon
     title="Open Terminal"
     onClick="{() => openTerminalContainer(container)}"
     menu="{dropdownMenu}"
     hidden="{!(container.state === 'RUNNING')}"
+    detailed="{detailed}"
     icon="{faTerminal}" />
   <ListItemButtonIcon
     title="Restart Container"
     onClick="{() => restartContainer(container)}"
     menu="{dropdownMenu}"
+    detailed="{detailed}"
     icon="{faArrowsRotate}" />
 </svelte:component>

--- a/packages/renderer/src/lib/container/ContainerActions.svelte
+++ b/packages/renderer/src/lib/container/ContainerActions.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-import { faEllipsisVertical, faFileCode, faPlayCircle, faRocket, faTerminal } from '@fortawesome/free-solid-svg-icons';
-import { faStopCircle } from '@fortawesome/free-solid-svg-icons';
+import { faEllipsisVertical, faFileCode, faPlay, faRocket, faTerminal } from '@fortawesome/free-solid-svg-icons';
+import { faStop } from '@fortawesome/free-solid-svg-icons';
 import { faArrowsRotate } from '@fortawesome/free-solid-svg-icons';
 import { faTrash } from '@fortawesome/free-solid-svg-icons';
 import { faExternalLinkSquareAlt } from '@fortawesome/free-solid-svg-icons';
@@ -11,7 +11,6 @@ import ListItemButtonIcon from '../ui/ListItemButtonIcon.svelte';
 import DropdownMenu from '../ui/DropdownMenu.svelte';
 import FlatMenu from '../ui/FlatMenu.svelte';
 export let container: ContainerInfoUI;
-export let backgroundColor = 'bg-zinc-800';
 export let dropdownMenu: boolean = false;
 
 async function startContainer(containerInfo: ContainerInfoUI) {
@@ -59,56 +58,45 @@ if (dropdownMenu) {
   title="Start Container"
   onClick="{() => startContainer(container)}"
   hidden="{container.state === 'RUNNING'}"
-  backgroundColor="{backgroundColor}"
-  icon="{faPlayCircle}" />
+  icon="{faPlay}" />
 
 <ListItemButtonIcon
   title="Stop Container"
   onClick="{() => stopContainer(container)}"
   hidden="{!(container.state === 'RUNNING')}"
-  backgroundColor="{backgroundColor}"
-  icon="{faStopCircle}" />
+  icon="{faStop}" />
 
-<ListItemButtonIcon
-  title="Delete Container"
-  onClick="{() => deleteContainer(container)}"
-  backgroundColor="{backgroundColor}"
-  icon="{faTrash}" />
+<ListItemButtonIcon title="Delete Container" onClick="{() => deleteContainer(container)}" icon="{faTrash}" />
 
 <!-- If dropdownMenu is true, use it, otherwise just show the regular buttons -->
-<svelte:component this="{actionsStyle}" backgroundColor="{backgroundColor}">
+<svelte:component this="{actionsStyle}">
   <ListItemButtonIcon
     title="Generate Kube"
     onClick="{() => openGenerateKube()}"
     menu="{dropdownMenu}"
     hidden="{!(container.engineType === 'podman' && container.groupInfo.type === ContainerGroupInfoTypeUI.STANDALONE)}"
-    backgroundColor="{backgroundColor}"
     icon="{faFileCode}" />
   <ListItemButtonIcon
     title="Deploy to Kubernetes"
     onClick="{() => deployToKubernetes()}"
     menu="{dropdownMenu}"
     hidden="{!(container.engineType === 'podman' && container.groupInfo.type === ContainerGroupInfoTypeUI.STANDALONE)}"
-    backgroundColor="{backgroundColor}"
     icon="{faRocket}" />
   <ListItemButtonIcon
     title="Open Browser"
     onClick="{() => openBrowser(container)}"
     menu="{dropdownMenu}"
     hidden="{!(container.state === 'RUNNING' && container.hasPublicPort)}"
-    backgroundColor="{backgroundColor}"
     icon="{faExternalLinkSquareAlt}" />
   <ListItemButtonIcon
     title="Open Terminal"
     onClick="{() => openTerminalContainer(container)}"
     menu="{dropdownMenu}"
     hidden="{!(container.state === 'RUNNING')}"
-    backgroundColor="{backgroundColor}"
     icon="{faTerminal}" />
   <ListItemButtonIcon
     title="Restart Container"
     onClick="{() => restartContainer(container)}"
     menu="{dropdownMenu}"
-    backgroundColor="{backgroundColor}"
     icon="{faArrowsRotate}" />
 </svelte:component>

--- a/packages/renderer/src/lib/image/ImageActions.svelte
+++ b/packages/renderer/src/lib/image/ImageActions.svelte
@@ -6,9 +6,8 @@ import ListItemButtonIcon from '../ui/ListItemButtonIcon.svelte';
 import { runImageInfo } from '../../stores/run-image-store';
 
 export let onPushImage: (imageInfo: ImageInfoUI) => void;
-
 export let image: ImageInfoUI;
-export let backgroundColor = 'bg-zinc-800';
+export let detailed: boolean = false;
 
 let errorMessage: string = undefined;
 let isAuthenticatedForThisImage: boolean = false;
@@ -39,28 +38,16 @@ async function showLayersImage(): Promise<void> {
 </script>
 
 {#if isAuthenticatedForThisImage}
-  <ListItemButtonIcon
-    title="Push Image"
-    onClick="{() => pushImage(image)}"
-    backgroundColor="{backgroundColor}"
-    icon="{faArrowUp}" />
+  <ListItemButtonIcon title="Push Image" onClick="{() => pushImage(image)}" detailed="{detailed}" icon="{faArrowUp}" />
 {/if}
-<ListItemButtonIcon
-  title="Run Image"
-  onClick="{() => runImage(image)}"
-  backgroundColor="{backgroundColor}"
-  icon="{faPlay}" />
+<ListItemButtonIcon title="Run Image" onClick="{() => runImage(image)}" detailed="{detailed}" icon="{faPlay}" />
 {#if !image.inUse}
-  <ListItemButtonIcon
-    title="Delete Image"
-    onClick="{() => deleteImage()}"
-    backgroundColor="{backgroundColor}"
-    icon="{faTrash}" />
+  <ListItemButtonIcon title="Delete Image" onClick="{() => deleteImage()}" detailed="{detailed}" icon="{faTrash}" />
 {/if}
 <ListItemButtonIcon
   title="Show History"
   onClick="{() => showLayersImage()}"
-  backgroundColor="{backgroundColor}"
+  detailed="{detailed}"
   icon="{faLayerGroup}" />
 
 {#if errorMessage}

--- a/packages/renderer/src/lib/image/ImageActions.svelte
+++ b/packages/renderer/src/lib/image/ImageActions.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { faCircleUp, faLayerGroup, faPlayCircle, faTrash } from '@fortawesome/free-solid-svg-icons';
+import { faArrowUp, faLayerGroup, faPlay, faTrash } from '@fortawesome/free-solid-svg-icons';
 import type { ImageInfoUI } from './ImageInfoUI';
 import { router } from 'tinro';
 import ListItemButtonIcon from '../ui/ListItemButtonIcon.svelte';
@@ -43,13 +43,13 @@ async function showLayersImage(): Promise<void> {
     title="Push Image"
     onClick="{() => pushImage(image)}"
     backgroundColor="{backgroundColor}"
-    icon="{faCircleUp}" />
+    icon="{faArrowUp}" />
 {/if}
 <ListItemButtonIcon
   title="Run Image"
   onClick="{() => runImage(image)}"
   backgroundColor="{backgroundColor}"
-  icon="{faPlayCircle}" />
+  icon="{faPlay}" />
 {#if !image.inUse}
   <ListItemButtonIcon
     title="Delete Image"

--- a/packages/renderer/src/lib/image/ImageDetails.svelte
+++ b/packages/renderer/src/lib/image/ImageDetails.svelte
@@ -104,9 +104,9 @@ onMount(() => {
               </div>
             </section>
           </div>
-          <div class="flex flex-row-reverse w-full  px-5 pt-5">
-            <div class="flex h-10">
-              <ImageActions image="{image}" onPushImage="{handlePushImageModal}" />
+          <div class="flex flex-col w-full px-5 pt-5">
+            <div class="flex justify-end">
+              <ImageActions image="{image}" onPushImage="{handlePushImageModal}" detailed="{true}" />
             </div>
           </div>
           <a href="/containers" title="Close Details" class="mt-2 mr-2 text-gray-500"

--- a/packages/renderer/src/lib/image/ImageDetails.svelte
+++ b/packages/renderer/src/lib/image/ImageDetails.svelte
@@ -106,7 +106,7 @@ onMount(() => {
           </div>
           <div class="flex flex-row-reverse w-full  px-5 pt-5">
             <div class="flex h-10">
-              <ImageActions image="{image}" backgroundColor="bg-neutral-900" onPushImage="{handlePushImageModal}" />
+              <ImageActions image="{image}" onPushImage="{handlePushImageModal}" />
             </div>
           </div>
           <a href="/containers" title="Close Details" class="mt-2 mr-2 text-gray-500"

--- a/packages/renderer/src/lib/pod/PodActions.svelte
+++ b/packages/renderer/src/lib/pod/PodActions.svelte
@@ -11,6 +11,7 @@ import FlatMenu from '../ui/FlatMenu.svelte';
 
 export let pod: PodInfoUI;
 export let dropdownMenu: boolean = false;
+export let detailed: boolean = false;
 
 async function startPod(podInfoUI: PodInfoUI) {
   await window.startPod(podInfoUI.engineId, podInfoUI.id);
@@ -50,13 +51,15 @@ if (dropdownMenu) {
   title="Start Pod"
   onClick="{() => startPod(pod)}"
   hidden="{pod.status === 'RUNNING'}"
+  detailed="{detailed}"
   icon="{faPlay}" />
 <ListItemButtonIcon
   title="Stop Pod"
   onClick="{() => stopPod(pod)}"
   hidden="{!(pod.status === 'RUNNING')}"
+  detailed="{detailed}"
   icon="{faStop}" />
-<ListItemButtonIcon title="Delete Pod" onClick="{() => removePod(pod)}" icon="{faTrash}" />
+<ListItemButtonIcon title="Delete Pod" onClick="{() => removePod(pod)}" icon="{faTrash}" detailed="{detailed}" />
 
 <!-- If dropdownMenu is true, use it, otherwise just show the regular buttons -->
 <svelte:component this="{actionsStyle}">
@@ -64,15 +67,18 @@ if (dropdownMenu) {
     title="Generate Kube"
     onClick="{() => openGenerateKube()}"
     menu="{dropdownMenu}"
+    detailed="{detailed}"
     icon="{faFileCode}" />
   <ListItemButtonIcon
     title="Deploy to Kubernetes"
     onClick="{() => deployToKubernetes()}"
     menu="{dropdownMenu}"
+    detailed="{detailed}"
     icon="{faRocket}" />
   <ListItemButtonIcon
     title="Restart Pod"
     onClick="{() => restartPod(pod)}"
     menu="{dropdownMenu}"
+    detailed="{detailed}"
     icon="{faArrowsRotate}" />
 </svelte:component>

--- a/packages/renderer/src/lib/pod/PodActions.svelte
+++ b/packages/renderer/src/lib/pod/PodActions.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-import { faFileCode, faPlayCircle, faRocket } from '@fortawesome/free-solid-svg-icons';
-import { faStopCircle } from '@fortawesome/free-solid-svg-icons';
+import { faFileCode, faPlay, faRocket } from '@fortawesome/free-solid-svg-icons';
+import { faStop } from '@fortawesome/free-solid-svg-icons';
 import { faArrowsRotate } from '@fortawesome/free-solid-svg-icons';
 import { faTrash } from '@fortawesome/free-solid-svg-icons';
 import type { PodInfoUI } from './PodInfoUI';
@@ -10,7 +10,6 @@ import DropdownMenu from '../ui/DropdownMenu.svelte';
 import FlatMenu from '../ui/FlatMenu.svelte';
 
 export let pod: PodInfoUI;
-export let backgroundColor = 'bg-zinc-800';
 export let dropdownMenu: boolean = false;
 
 async function startPod(podInfoUI: PodInfoUI) {
@@ -51,38 +50,29 @@ if (dropdownMenu) {
   title="Start Pod"
   onClick="{() => startPod(pod)}"
   hidden="{pod.status === 'RUNNING'}"
-  backgroundColor="{backgroundColor}"
-  icon="{faPlayCircle}" />
+  icon="{faPlay}" />
 <ListItemButtonIcon
   title="Stop Pod"
   onClick="{() => stopPod(pod)}"
   hidden="{!(pod.status === 'RUNNING')}"
-  backgroundColor="{backgroundColor}"
-  icon="{faStopCircle}" />
-<ListItemButtonIcon
-  title="Delete Pod"
-  onClick="{() => removePod(pod)}"
-  backgroundColor="{backgroundColor}"
-  icon="{faTrash}" />
+  icon="{faStop}" />
+<ListItemButtonIcon title="Delete Pod" onClick="{() => removePod(pod)}" icon="{faTrash}" />
 
 <!-- If dropdownMenu is true, use it, otherwise just show the regular buttons -->
-<svelte:component this="{actionsStyle}" backgroundColor="{backgroundColor}">
+<svelte:component this="{actionsStyle}">
   <ListItemButtonIcon
     title="Generate Kube"
     onClick="{() => openGenerateKube()}"
     menu="{dropdownMenu}"
-    backgroundColor="{backgroundColor}"
     icon="{faFileCode}" />
   <ListItemButtonIcon
     title="Deploy to Kubernetes"
     onClick="{() => deployToKubernetes()}"
     menu="{dropdownMenu}"
-    backgroundColor="{backgroundColor}"
     icon="{faRocket}" />
   <ListItemButtonIcon
     title="Restart Pod"
     onClick="{() => restartPod(pod)}"
     menu="{dropdownMenu}"
-    backgroundColor="{backgroundColor}"
     icon="{faArrowsRotate}" />
 </svelte:component>

--- a/packages/renderer/src/lib/pod/PodDetails.svelte
+++ b/packages/renderer/src/lib/pod/PodDetails.svelte
@@ -99,9 +99,9 @@ onDestroy(() => {
               </div>
             </section>
           </div>
-          <div class="flex flex-row-reverse w-full  px-5 pt-5">
-            <div class="flex h-10">
-              <PodActions pod="{pod}" />
+          <div class="flex flex-col w-full px-5 pt-5">
+            <div class="flex justify-end">
+              <PodActions pod="{pod}" detailed="{true}" />
             </div>
           </div>
           <a href="/containers" title="Close Details" class="mt-2 mr-2 text-gray-500"

--- a/packages/renderer/src/lib/pod/PodDetails.svelte
+++ b/packages/renderer/src/lib/pod/PodDetails.svelte
@@ -101,7 +101,7 @@ onDestroy(() => {
           </div>
           <div class="flex flex-row-reverse w-full  px-5 pt-5">
             <div class="flex h-10">
-              <PodActions pod="{pod}" backgroundColor="bg-neutral-900" />
+              <PodActions pod="{pod}" />
             </div>
           </div>
           <a href="/containers" title="Close Details" class="mt-2 mr-2 text-gray-500"

--- a/packages/renderer/src/lib/ui/DropDownMenuItem.svelte
+++ b/packages/renderer/src/lib/ui/DropDownMenuItem.svelte
@@ -6,7 +6,6 @@ export let title: string;
 export let icon: IconDefinition;
 export let hidden: boolean = false;
 export let onClick: () => void = () => {};
-export let backgroundColor: string = 'bg-zinc-800';
 </script>
 
 {#if !hidden}

--- a/packages/renderer/src/lib/ui/DropdownMenu.svelte
+++ b/packages/renderer/src/lib/ui/DropdownMenu.svelte
@@ -2,7 +2,6 @@
 import { faEllipsisVertical } from '@fortawesome/free-solid-svg-icons';
 import Fa from 'svelte-fa/src/fa.svelte';
 import DropDownMenuItems from './DropDownMenuItems.svelte';
-export let backgroundColor = 'bg-zinc-800';
 
 // Show and hide the menu using clickOutside
 let showMenu = false;
@@ -42,8 +41,8 @@ function onWindowClick(e) {
       toggleMenu();
     }}"
     bind:this="{outsideWindow}"
-    class="mx-1 px-3 py-2 hover:text-violet-600 font-medium rounded-lg text-sm inline-flex items-center text-center {backgroundColor}">
-    <Fa class="h-4 w-4 text-xl" icon="{faEllipsisVertical}" />
+    class="mr-2 text-gray-300 hover:bg-zinc-900 hover:text-violet-600 font-medium rounded-full inline-flex items-center px-2 py-2 text-center">
+    <Fa class="h-4 w-4" icon="{faEllipsisVertical}" />
   </button>
 
   <!-- Dropdown menu for all other actions -->

--- a/packages/renderer/src/lib/ui/ListItemButtonIcon.svelte
+++ b/packages/renderer/src/lib/ui/ListItemButtonIcon.svelte
@@ -8,17 +8,21 @@ export let icon: IconDefinition;
 export let hidden: boolean = false;
 export let onClick: () => void = () => {};
 export let menu: boolean = false;
+export let detailed: boolean = false;
+
+const buttonDetailedClass: string =
+  'mx-1 text-gray-300 bg-zinc-900 hover:text-violet-600 font-medium rounded-lg text-sm inline-flex items-center px-3 py-2 text-center';
+const buttonClass: string =
+  'm-0.5 text-gray-300 hover:bg-zinc-800 hover:text-violet-600 font-medium rounded-full inline-flex items-center px-2 py-2 text-center';
+
+let styleClass: string = detailed ? buttonDetailedClass : buttonClass;
 </script>
 
 <!-- If menu = true, use the menu, otherwise implement the button -->
 {#if menu}
   <DropdownMenuItem title="{title}" icon="{icon}" hidden="{hidden}" onClick="{onClick}" />
 {:else}
-  <button
-    title="{title}"
-    on:click="{onClick}"
-    class="m-0.5 text-gray-300 hover:bg-zinc-900 hover:text-violet-600 font-medium rounded-full inline-flex items-center px-2 py-2 text-center"
-    class:hidden>
+  <button title="{title}" on:click="{onClick}" class="{styleClass}" class:hidden>
     <Fa class="h-4 w-4" icon="{icon}" />
   </button>
 {/if}

--- a/packages/renderer/src/lib/ui/ListItemButtonIcon.svelte
+++ b/packages/renderer/src/lib/ui/ListItemButtonIcon.svelte
@@ -7,24 +7,18 @@ export let title: string;
 export let icon: IconDefinition;
 export let hidden: boolean = false;
 export let onClick: () => void = () => {};
-export let backgroundColor: string = 'bg-zinc-800';
 export let menu: boolean = false;
 </script>
 
 <!-- If menu = true, use the menu, otherwise implement the button -->
 {#if menu}
-  <DropdownMenuItem
-    title="{title}"
-    icon="{icon}"
-    hidden="{hidden}"
-    onClick="{onClick}"
-    backgroundColor="{backgroundColor}" />
+  <DropdownMenuItem title="{title}" icon="{icon}" hidden="{hidden}" onClick="{onClick}" />
 {:else}
   <button
     title="{title}"
     on:click="{onClick}"
-    class="mx-1 text-gray-300 {backgroundColor} hover:text-violet-600 font-medium rounded-lg text-sm inline-flex items-center px-3 py-2 text-center"
-    class:hidden
-    ><Fa class="h-4 w-4 text-xl" icon="{icon}" />
+    class="m-0.5 text-gray-300 hover:bg-zinc-900 hover:text-violet-600 font-medium rounded-full inline-flex items-center px-2 py-2 text-center"
+    class:hidden>
+    <Fa class="h-4 w-4" icon="{icon}" />
   </button>
 {/if}

--- a/packages/renderer/src/lib/volume/VolumeActions.svelte
+++ b/packages/renderer/src/lib/volume/VolumeActions.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-import { faPlayCircle } from '@fortawesome/free-solid-svg-icons';
-import { faStopCircle } from '@fortawesome/free-solid-svg-icons';
+import { faPlay } from '@fortawesome/free-solid-svg-icons';
+import { faStop } from '@fortawesome/free-solid-svg-icons';
 import { faArrowsRotate } from '@fortawesome/free-solid-svg-icons';
 import { faTrash } from '@fortawesome/free-solid-svg-icons';
 import type { VolumeInfoUI } from './VolumeInfoUI';

--- a/packages/renderer/src/lib/volume/VolumeActions.svelte
+++ b/packages/renderer/src/lib/volume/VolumeActions.svelte
@@ -8,7 +8,7 @@ import { router } from 'tinro';
 import ListItemButtonIcon from '../ui/ListItemButtonIcon.svelte';
 
 export let volume: VolumeInfoUI;
-export let backgroundColor = 'bg-zinc-800';
+export let detailed: boolean = false;
 
 async function removeVolume(): Promise<void> {
   await window.removeVolume(volume.engineId, volume.name);
@@ -17,9 +17,5 @@ async function removeVolume(): Promise<void> {
 </script>
 
 {#if !volume.inUse}
-  <ListItemButtonIcon
-    title="Delete Volume"
-    onClick="{() => removeVolume()}"
-    backgroundColor="{backgroundColor}"
-    icon="{faTrash}" />
+  <ListItemButtonIcon title="Delete Volume" onClick="{() => removeVolume()}" detailed="{detailed}" icon="{faTrash}" />
 {/if}

--- a/packages/renderer/src/lib/volume/VolumeDetails.svelte
+++ b/packages/renderer/src/lib/volume/VolumeDetails.svelte
@@ -81,7 +81,7 @@ onMount(() => {
           </div>
           <div class="flex flex-row-reverse w-full  px-5 pt-5">
             <div class="flex h-10">
-              <VolumeActions volume="{volume}" backgroundColor="bg-neutral-900" />
+              <VolumeActions volume="{volume}" />
             </div>
           </div>
           <a href="/containers" title="Close Details" class="mt-2 mr-2 text-gray-500"

--- a/packages/renderer/src/lib/volume/VolumeDetails.svelte
+++ b/packages/renderer/src/lib/volume/VolumeDetails.svelte
@@ -79,9 +79,9 @@ onMount(() => {
               </div>
             </section>
           </div>
-          <div class="flex flex-row-reverse w-full  px-5 pt-5">
-            <div class="flex h-10">
-              <VolumeActions volume="{volume}" />
+          <div class="flex flex-col w-full px-5 pt-5">
+            <div class="flex justify-end">
+              <VolumeActions volume="{volume}" detailed="{true}" />
             </div>
           </div>
           <a href="/containers" title="Close Details" class="mt-2 mr-2 text-gray-500"

--- a/packages/renderer/src/lib/volume/VolumesList.svelte
+++ b/packages/renderer/src/lib/volume/VolumesList.svelte
@@ -159,7 +159,7 @@ function openDetailsVolume(volume: VolumeInfoUI) {
           <th class="text-center font-extrabold w-10">Name</th>
           <th class="text-center">Creation date</th>
           <th class="px-6 whitespace-nowrap text-end">size</th>
-          <th class="text-center">actions</th>
+          <th class="text-right pr-2">Actions</th>
         </tr>
       </thead>
       <tbody class="">
@@ -207,10 +207,8 @@ function openDetailsVolume(volume: VolumeInfoUI) {
                 <div class="w-full text-right text-sm text-gray-200">{volume.humanSize}</div>
               </div>
             </td>
-            <td class="px-6 whitespace-nowrap rounded-tr-lg rounded-br-lg ">
-              <div class="flex opacity-0 flex-row justify-end group-hover:opacity-100">
-                <VolumeActions volume="{volume}" />
-              </div>
+            <td class="pl-6 text-right whitespace-nowrap rounded-tr-lg rounded-br-lg pr-1">
+              <VolumeActions volume="{volume}" />
             </td>
           </tr>
           <tr><td class="leading-[8px]">&nbsp;</td></tr>


### PR DESCRIPTION
feat: remove background, add hover, delete background parameter to icon

### What does this PR do?

* Removes the background on list and details for a "hover" circle
* Delete the background parameter for icons

Note: Reasoning for deleting background parameter: No longer needed as
no longer adding a background. Tailwind also does not show the hover
correctly as a parameter (ex. class="{backgroundColor} m-2") with hover.

### Screenshot/screencast of this PR

![Screenshot 2022-12-06 at 12 18 59 PM](https://user-images.githubusercontent.com/6422176/205979121-b49a0ddf-03bb-4a4d-8d12-bc8d0bd52387.png)
![Screenshot 2022-12-06 at 12 19 07 PM](https://user-images.githubusercontent.com/6422176/205979123-ea420b17-e834-4029-82eb-22949889eee9.png)


### What issues does this PR fix or reference?

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

N/A

### How to test this PR?

<!-- Please explain steps to reproduce -->

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
