### PR TITLE
chore: allow to deploy website on netlify on each PR

### DIFF
--- a/.github/workflows/pr-check-website.yaml
+++ b/.github/workflows/pr-check-website.yaml
@@ -1,12 +1,12 @@
 #
 # Copyright (C) 2022 Red Hat, Inc.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -14,10 +14,10 @@
 # limitations under the License.
 #
 # SPDX-License-Identifier: Apache-2.0
- 
-name: pr-check-website
 
-on: 
+name: Build website on pull request
+
+on:
   pull_request:
     paths:
       - 'package.json'
@@ -51,3 +51,17 @@ jobs:
 
       - name: Run website
         run: yarn website:build
+
+      - name: Store pull request details for publish-netlify
+        run: |
+          echo "${{ github.event.number }}" > PR_NUMBER
+          echo "${{ github.event.pull_request.head.sha }}" > PR_SHA
+
+      - name: Upload artifact website-content
+        uses: actions/upload-artifact@v3.1.1
+        with:
+          name: website-content
+          path: |
+            website/build
+            PR_NUMBER
+            PR_SHA

--- a/.github/workflows/publish-website-pr-netlify.yaml
+++ b/.github/workflows/publish-website-pr-netlify.yaml
@@ -1,0 +1,63 @@
+#
+# Copyright (C) 2022 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# NOTE: Because this worklow is using secrets, it cannot run directly on a pull-request workflow, which is running in the context of the forked repository.
+
+name: Publish pull request content on netlify
+
+on:
+  workflow_run:
+    workflows:
+      - 'Build website on pull request'
+    types:
+      - completed
+
+jobs:
+  publish:
+    name: Publish content of the website pull request on netlify
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Download website content artifact
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: ${{ github.event.workflow_run.workflow_id }}
+          name: website-content
+          path: content
+
+      - name: Set PR_NUMBER and PR_SHA variables
+        id: vars
+        run: |
+          echo "PR_NUMBER=$(<content/PR_NUMBER)" >> $GITHUB_OUTPUT
+          echo "PR_SHA=$(<content/PR_SHA)" >> $GITHUB_OUTPUT
+
+      - name: Publish preview netlify
+        uses: netlify/actions/cli@master
+        id: netlify-publish
+        with:
+          args: deploy --dir=content/website/build --functions=functions
+        env:
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+
+      - name: 'Update status of Pull Request'
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const { repo: { owner, repo } } = context;
+            const netlifyUrl = '${{ steps.netlify-publish.outputs.NETLIFY_URL }}';
+            const sha = '${{ steps.vars.outputs.PR_SHA }}';
+            await github.rest.repos.createCommitStatus({ owner, repo, sha, state: "success", target_url: netlifyUrl, description: "See pull request website online", context: "netlify"})


### PR DESCRIPTION
### What does this PR do?
Depoy the website being built on the PR check to netlify

### Screenshot/screencast of this PR

PR status:
![image](https://user-images.githubusercontent.com/436777/206152540-b4aeeeef-546f-4121-bbce-a022f8626ece.png)

on netlify:
![image](https://user-images.githubusercontent.com/436777/206152737-0ac59c05-0be4-407c-ac72-fe2a3cd0f7be.png)


### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/622


### How to test this PR?

Once it is merged, on every PR there will be an updated PR status with a link to netlify


Change-Id: If50153720133184e0fb733946fd0620bb6adc6db
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
