### PR TITLE
chore: update prettier-plugin-svelte from 2.8.0 to 2.8.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "playwright": "1.18.1",
     "postcss-import": "^15.1.0",
     "prettier": "^2.8.1",
-    "prettier-plugin-svelte": "^2.8.0",
+    "prettier-plugin-svelte": "^2.8.1",
     "typescript": "4.9.4",
     "validator": "^13.7.0",
     "vite": "3.2.5",

--- a/packages/renderer/src/AppNavigation.svelte
+++ b/packages/renderer/src/AppNavigation.svelte
@@ -27,7 +27,7 @@ let innerWidth = 0;
 export let meta;
 </script>
 
-<svelte:window bind:innerWidth />
+<svelte:window bind:innerWidth="{innerWidth}" />
 <nav
   class="pf-c-nav z-0 group w-12 hover:w-[180px] md:w-[180px] md:min-w-[180px] shadow flex-col justify-between sm:flex transition-all duration-500 ease-in-out"
   aria-label="Global">

--- a/packages/renderer/src/lib/ContainerList.svelte
+++ b/packages/renderer/src/lib/ContainerList.svelte
@@ -268,7 +268,7 @@ function toggleAllContainerGroups(value: boolean) {
 </script>
 
 <NavPage
-  bind:searchTerm
+  bind:searchTerm="{searchTerm}"
   title="containers"
   subtitle="Hover over a container to view action buttons; click to open up full details.">
   <div slot="additional-actions" class="space-x-2 flex flex-nowrap">

--- a/packages/renderer/src/lib/ImagesList.svelte
+++ b/packages/renderer/src/lib/ImagesList.svelte
@@ -143,7 +143,7 @@ async function deleteSelectedImages() {
 </script>
 
 <NavPage
-  bind:searchTerm
+  bind:searchTerm="{searchTerm}"
   title="images"
   subtitle="Hover over an image to view action buttons; click to open up full details.">
   <div slot="additional-actions" class="space-x-2 flex flex-nowrap">

--- a/packages/renderer/src/lib/pod/PodsList.svelte
+++ b/packages/renderer/src/lib/pod/PodsList.svelte
@@ -113,7 +113,7 @@ function openContainersFromPod(pod: PodInfoUI) {
 </script>
 
 <NavPage
-  bind:searchTerm
+  bind:searchTerm="{searchTerm}"
   title="pods"
   subtitle="Hover over an pod to view action buttons; click to open up full details.">
   <div slot="additional-actions" class="space-x-2 flex flex-nowrap">

--- a/packages/renderer/src/lib/preferences/PreferencesContainerConnectionRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesContainerConnectionRendering.svelte
@@ -256,7 +256,7 @@ async function stopReceivingLogs(provider: ProviderInfo): Promise<void> {
     <h2 slot="header">Logs</h2>
     <div id="log" style="height: 400px; width: 650px;">
       <div style="width:100%; height:100%;">
-        <Logger bind:logsTerminal onInit="{() => startReceivinLogs(showModal)}" />
+        <Logger bind:logsTerminal="{logsTerminal}" onInit="{() => startReceivinLogs(showModal)}" />
       </div>
     </div>
   </Modal>

--- a/packages/renderer/src/lib/preferences/PreferencesProviderRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesProviderRendering.svelte
@@ -139,7 +139,7 @@ async function stopReceivingLogs(provider: ProviderInfo): Promise<void> {
     <h2 slot="header">Logs</h2>
     <div id="log" style="height: 400px; width: 647px;">
       <div style="width:100%; height:100%; flexDirection: column;">
-        <Logger bind:logsTerminal onInit="{() => startReceivinLogs(showModal)}" />
+        <Logger bind:logsTerminal="{logsTerminal}" onInit="{() => startReceivinLogs(showModal)}" />
       </div>
     </div>
   </Modal>

--- a/packages/renderer/src/lib/volume/VolumesList.svelte
+++ b/packages/renderer/src/lib/volume/VolumesList.svelte
@@ -110,7 +110,7 @@ function openDetailsVolume(volume: VolumeInfoUI) {
 </script>
 
 <NavPage
-  bind:searchTerm
+  bind:searchTerm="{searchTerm}"
   title="volumes"
   subtitle="Hover over a volume to view action buttons; click to open up full details.">
   <div slot="additional-actions" class="space-x-2 flex flex-nowrap"></div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -9821,10 +9821,10 @@ prepend-http@^2.0.0:
   resolved "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz"
   integrity sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=
 
-prettier-plugin-svelte@^2.8.0:
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/prettier-plugin-svelte/-/prettier-plugin-svelte-2.8.0.tgz#e5681d9867c4ab584c0ccbe43c3684d132b389f2"
-  integrity sha512-QlXv/U3bUszks3XYDPsk1fsaQC+fo2lshwKbcbO+lrSVdJ+40mB1BfL8OCAk1W9y4pJxpqO/4gqm6NtF3zNGCw==
+prettier-plugin-svelte@^2.8.1:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/prettier-plugin-svelte/-/prettier-plugin-svelte-2.8.1.tgz#5b7df5bd0d953b133281607295a3e5131052bb8b"
+  integrity sha512-KA3K1J3/wKDnCxW7ZDRA/QL2Q67N7Xs3gOERqJ5X1qFjq1DdnN3K1R29scSKwh+kA8FF67pXbYytUpvN/i3iQw==
 
 prettier@^2.8.1:
   version "2.8.1"


### PR DESCRIPTION
### What does this PR do?
Update the prettier formatter

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?
https://github.com/containers/podman-desktop/pull/873

but formatting output has changed, so we had to update files

### How to test this PR?

should work as before

Change-Id: I1212e575c95e283948cdffb9b17d0d0f1f35d5d0
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
