### PR TITLE
feat: Namespace selection for deploy to kubernetes

### DIFF
--- a/packages/renderer/src/lib/pod/DeployPodToKube.svelte
+++ b/packages/renderer/src/lib/pod/DeployPodToKube.svelte
@@ -3,8 +3,8 @@ import { onDestroy, onMount } from 'svelte';
 import MonacoEditor from '../editor/MonacoEditor.svelte';
 import NavPage from '../ui/NavPage.svelte';
 import * as jsYaml from 'js-yaml';
-import { each } from 'svelte/internal';
 import type { V1Route } from '../../../../main/src/plugin/api/openshift-types';
+import type { V1NamespaceList } from '@kubernetes/client-node/dist/api';
 
 export let resourceId: string;
 export let engineId: string;
@@ -13,7 +13,7 @@ let kubeDetails: string;
 
 let defaultContextName: string;
 let currentNamespace: string;
-let allNamespaces: string[];
+let allNamespaces: V1NamespaceList;
 let deployStarted = false;
 let deployFinished = false;
 let deployError = '';

--- a/packages/renderer/src/lib/pod/DeployPodToKube.svelte
+++ b/packages/renderer/src/lib/pod/DeployPodToKube.svelte
@@ -13,6 +13,7 @@ let kubeDetails: string;
 
 let defaultContextName: string;
 let currentNamespace: string;
+let allNamespaces: string[];
 let deployStarted = false;
 let deployFinished = false;
 let deployError = '';
@@ -40,9 +41,14 @@ onMount(async () => {
   // grab current namespace
   currentNamespace = await window.kubernetesGetCurrentNamespace();
 
+  // check that the variable is set to a value, otherwise set to default namespace
+  if (!currentNamespace) {
+    currentNamespace = 'default';
+  }
+
   // grab all the namespaces (will be useful to provide a drop-down to select the namespace)
   try {
-    await window.kubernetesListNamespaces();
+    allNamespaces = await window.kubernetesListNamespaces();
   } catch (error) {
     console.debug('Not able to list all namespaces, probably a permission error', error);
   }
@@ -257,27 +263,32 @@ async function deployToKube() {
         </div>
       {/if}
 
-      {#if currentNamespace}
-        <div class="pt-2 pb-4">
-          <label for="contextToUse" class="block mb-1 text-sm font-medium text-gray-300">Kubernetes Namespace:</label>
-          <input
-            type="text"
-            bind:value="{currentNamespace}"
-            name="currentNamespace"
-            id="currentNamespace"
-            readonly
-            class=" cursor-default w-full p-2 outline-none text-sm bg-zinc-900 rounded-sm text-gray-400 placeholder-gray-400"
-            required />
+      {#if allNamespaces}
+        <div class="pt-2">
+          <label for="namespaceToUse" class="block mb-1 text-sm font-medium  text-gray-300"
+            >Kubernetes namespace:</label>
+          <select
+            class="w-full p-2 outline-none text-sm bg-zinc-900 rounded-sm text-gray-400 placeholder-gray-400"
+            name="namespaceChoice"
+            bind:value="{currentNamespace}">
+            {#each allNamespaces.items as namespace}
+              <option value="{namespace.metadata.name}">
+                {namespace.metadata.name}
+              </option>
+            {/each}
+          </select>
         </div>
       {/if}
 
       {#if !deployStarted}
-        <button on:click="{() => deployToKube()}" class="w-full pf-c-button pf-m-primary" type="button">
-          <span class="pf-c-button__icon pf-m-start">
-            <i class="fas fa-rocket" aria-hidden="true"></i>
-          </span>
-          Deploy
-        </button>
+        <div class="pt-2 m-2">
+          <button on:click="{() => deployToKube()}" class="w-full pf-c-button pf-m-primary" type="button">
+            <span class="pf-c-button__icon pf-m-start">
+              <i class="fas fa-rocket" aria-hidden="true"></i>
+            </span>
+            Deploy
+          </button>
+        </div>
       {/if}
       {#if deployError}
         <div class="text-red-500 text-sm">{deployError}</div>


### PR DESCRIPTION
Signed-off-by: Endre Lervik <endrel@met.no>

### What does this PR do?
Adds a dropdown menu, populated with namespaces. Defaults to defaultnamespace, if unable to get any from kube_client module.

If the user have set `kubectl config set-context --current --namespace=NAMESPACE` it should honor that as the chosen value.

Also adds a `<div>` around the "deploy" button to get some spacing between the menus.
### Screenshot/screencast of this PR

![deploy2](https://user-images.githubusercontent.com/7339809/206688886-095e4f15-42ae-4a0a-b1c6-ae4b547fcdfb.gif)

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?
Couldnt find any on this, but it delivers on the comment at
https://github.com/containers/podman-desktop/blob/main/packages/renderer/src/lib/pod/DeployPodToKube.svelte#L43

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

### How to test this PR?
create a pod > select a valid kubeconfig > deploy 
<!-- Please explain steps to reproduce -->
