### PR TITLE
feat(extension-api): Allows to register a factory for kubernetes connection objects (like for container connections)

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -198,6 +198,12 @@ declare module '@tmpwip/extension-api' {
     create(params: { [key: string]: any }): Promise<void>;
   }
 
+  // create a kubernetes provider
+  export interface KubernetesProviderConnectionFactory {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    create(params: { [key: string]: any }): Promise<void>;
+  }
+
   export interface Link {
     title: string;
     url: string;
@@ -249,6 +255,10 @@ declare module '@tmpwip/extension-api' {
     setContainerProviderConnectionFactory(
       containerProviderConnectionFactory: ContainerProviderConnectionFactory,
     ): Disposable;
+    setKubernetesProviderConnectionFactory(
+      containerProviderConnectionFactory: KubernetesProviderConnectionFactory,
+    ): Disposable;
+
     registerContainerProviderConnection(connection: ContainerProviderConnection): Disposable;
     registerKubernetesProviderConnection(connection: KubernetesProviderConnection): Disposable;
     registerLifecycle(lifecycle: ProviderLifecycle): Disposable;

--- a/packages/main/src/plugin/api/provider-info.ts
+++ b/packages/main/src/plugin/api/provider-info.ts
@@ -57,6 +57,9 @@ export interface ProviderInfo {
   // can create provider connection from ContainerProviderConnectionFactory params
   containerProviderConnectionCreation: boolean;
 
+  // can create provider connection from KubernetesProviderConnectionFactory params
+  kubernetesProviderConnectionCreation: boolean;
+
   version?: string;
 
   links: ProviderLinks[];

--- a/packages/main/src/plugin/configuration-registry.ts
+++ b/packages/main/src/plugin/configuration-registry.ts
@@ -62,7 +62,12 @@ export interface IConfigurationPropertySchema {
   hidden?: boolean;
 }
 
-export type ConfigurationScope = 'DEFAULT' | 'ContainerConnection' | 'ContainerProviderConnectionFactory';
+export type ConfigurationScope =
+  | 'DEFAULT'
+  | 'ContainerConnection'
+  | 'KubernetesConnection'
+  | 'ContainerProviderConnectionFactory'
+  | 'KubernetesProviderConnectionFactory';
 
 export interface IConfigurationExtensionInfo {
   id: string;

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -300,6 +300,7 @@ export class PluginSystem {
       kubernetesClient,
       fileSystemMonitoring,
       proxy,
+      containerProviderRegistry,
     );
 
     const contributionManager = new ContributionManager(apiSender);
@@ -890,13 +891,24 @@ export class PluginSystem {
     );
 
     this.ipcHandle(
-      'provider-registry:createProviderConnection',
+      'provider-registry:createContainerProviderConnection',
       async (
         _listener: Electron.IpcMainInvokeEvent,
         internalProviderId: string,
         params: { [key: string]: unknown },
       ): Promise<void> => {
-        return providerRegistry.createProviderConnection(internalProviderId, params);
+        return providerRegistry.createContainerProviderConnection(internalProviderId, params);
+      },
+    );
+
+    this.ipcHandle(
+      'provider-registry:createKubernetesProviderConnection',
+      async (
+        _listener: Electron.IpcMainInvokeEvent,
+        internalProviderId: string,
+        params: { [key: string]: unknown },
+      ): Promise<void> => {
+        return providerRegistry.createKubernetesProviderConnection(internalProviderId, params);
       },
     );
 

--- a/packages/main/src/tray-menu.ts
+++ b/packages/main/src/tray-menu.ts
@@ -80,6 +80,7 @@ export class TrayMenu {
             images: {},
             installationSupport: false,
             containerProviderConnectionCreation: false,
+            kubernetesProviderConnectionCreation: false,
           });
         }
         this.updateMenu();

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -496,10 +496,18 @@ function initExposure(): void {
   );
 
   contextBridge.exposeInMainWorld(
-    'createProviderConnection',
+    'createContainerProviderConnection',
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     async (internalProviderId: string, params: { [key: string]: any }): Promise<void> => {
-      return ipcInvoke('provider-registry:createProviderConnection', internalProviderId, params);
+      return ipcInvoke('provider-registry:createContainerProviderConnection', internalProviderId, params);
+    },
+  );
+
+  contextBridge.exposeInMainWorld(
+    'createKubernetesProviderConnection',
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    async (internalProviderId: string, params: { [key: string]: any }): Promise<void> => {
+      return ipcInvoke('provider-registry:createKubernetesProviderConnection', internalProviderId, params);
     },
   );
 

--- a/packages/renderer/src/PreferencesNavigation.svelte
+++ b/packages/renderer/src/PreferencesNavigation.svelte
@@ -51,8 +51,9 @@ $: addCurrentClass = (pathParam: string): string =>
 $: isAriaExpanded = (section: string): boolean => (sectionExpanded[section] ? true : false);
 $: addSectionHiddenClass = (section: string): string => (sectionExpanded[section] ? '' : 'hidden');
 $: addExpandableClass = (provider: ProviderInfo): string =>
-  provider.containerConnections.length > 0 ? 'pf-m-expandable' : '';
-$: addHiddenClass = (provider: ProviderInfo): string => (provider.containerConnections.length > 0 ? '' : 'hidden');
+  provider.containerConnections.length > 0 || provider.kubernetesConnections.length > 0 ? 'pf-m-expandable' : '';
+$: addHiddenClass = (provider: ProviderInfo): string =>
+  provider.containerConnections.length > 0 || provider.kubernetesConnections.length > 0 ? '' : 'hidden';
 </script>
 
 <nav
@@ -95,6 +96,7 @@ $: addHiddenClass = (provider: ProviderInfo): string => (provider.containerConne
                   </span>
                 </span>
               </a>
+              <!-- container connections -->
               <section class="pf-c-nav__subnav {addSectionHiddenClass(provider.name)}">
                 <ul class="pf-c-nav__list">
                   {#each provider.containerConnections as connection}
@@ -112,6 +114,28 @@ $: addHiddenClass = (provider: ProviderInfo): string => (provider.containerConne
                           .toLowerCase()
                           .replaceAll(' ', '_')}"
                         class="pf-c-nav__link">{connection.name}</a>
+                    </li>
+                  {/each}
+                </ul>
+              </section>
+              <!-- kubernetes connections -->
+              <section class="pf-c-nav__subnav {addSectionHiddenClass(provider.name)}">
+                <ul class="pf-c-nav__list">
+                  {#each provider.kubernetesConnections as kubernetesConnection}
+                    <li
+                      class="pf-c-nav__item {addCurrentClass(
+                        `/preferences/kubernetes-connection/${provider.internalId}/${Buffer.from(
+                          kubernetesConnection.endpoint.apiURL,
+                        ).toString('base64')}`,
+                      )}">
+                      <a
+                        href="/preferences/kubernetes-connection/{provider.internalId}/{Buffer.from(
+                          kubernetesConnection.endpoint.apiURL,
+                        ).toString('base64')}"
+                        id="configuration-section-provider-{provider.name.toLowerCase()}-{kubernetesConnection.name
+                          .toLowerCase()
+                          .replaceAll(' ', '_')}"
+                        class="pf-c-nav__link">{kubernetesConnection.name}</a>
                     </li>
                   {/each}
                 </ul>

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationRendering.svelte
@@ -4,6 +4,8 @@ import type { ProviderInfo } from '../../../../main/src/plugin/api/provider-info
 import PreferencesRenderingItemFormat from './PreferencesRenderingItemFormat.svelte';
 export let properties: IConfigurationPropertyRecordedSchema[] = [];
 export let providerInfo: ProviderInfo;
+export let propertyScope: string;
+export let callback: (string, data) => Promise<void>;
 
 let creationInProgress = false;
 let creationSuccessful = false;
@@ -11,7 +13,7 @@ let creationSuccessful = false;
 // get only ContainerProviderConnectionFactory scope fields that are starting by the provider id
 let configurationKeys: IConfigurationPropertyRecordedSchema[];
 $: configurationKeys = properties
-  .filter(property => property.scope === 'ContainerProviderConnectionFactory')
+  .filter(property => property.scope === propertyScope)
   .filter(property => property.id.startsWith(providerInfo.id));
 
 let isValid = true;
@@ -39,7 +41,7 @@ async function handleOnSubmit(e) {
   creationInProgress = true;
   errorMessage = undefined;
   try {
-    await window.createProviderConnection(providerInfo.internalId, data);
+    await callback(providerInfo.internalId, data);
     window.dispatchEvent(new CustomEvent('provider-lifecycle-change'));
     creationSuccessful = true;
   } catch (error) {

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesConnectionRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesConnectionRendering.svelte
@@ -9,7 +9,6 @@ import type { ProviderInfo, ProviderKubernetesConnectionInfo } from '../../../..
 import { router } from 'tinro';
 import Modal from '../dialogs/Modal.svelte';
 import Logger from './Logger.svelte';
-import { writeToTerminal } from './Util';
 
 export let properties: IConfigurationPropertyRecordedSchema[] = [];
 export let providerInternalId: string = undefined;
@@ -102,19 +101,6 @@ async function deleteConnection() {
 let showModal: ProviderInfo = undefined;
 
 let logsTerminal;
-
-async function startReceivinLogs(provider: ProviderInfo): Promise<void> {
-  const logHandler = (newContent: any[], colorPrefix: string) => {
-    writeToTerminal(logsTerminal, newContent, colorPrefix);
-  };
-  /*window.startReceiveLogs(
-    provider.internalId,
-    data => logHandler(data, '\x1b[37m'),
-    data => logHandler(data, '\x1b[33m'),
-    data => logHandler(data, '\x1b[1;31m'),
-    kubernetesConnectionInfo,
-  );*/
-}
 
 async function stopReceivingLogs(provider: ProviderInfo): Promise<void> {
   // await window.stopReceiveLogs(provider.internalId, kubernetesConnectionInfo);
@@ -240,7 +226,7 @@ async function stopReceivingLogs(provider: ProviderInfo): Promise<void> {
     <h2 slot="header">Logs</h2>
     <div id="log" style="height: 400px; width: 650px;">
       <div style="width:100%; height:100%;">
-        <Logger bind:logsTerminal="{logsTerminal}" onInit="{() => startReceivinLogs(showModal)}" />
+        <Logger bind:logsTerminal="{logsTerminal}" onInit="{() => {}}" />
       </div>
     </div>
   </Modal>

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesConnectionRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesConnectionRendering.svelte
@@ -1,0 +1,247 @@
+<script lang="ts">
+import type { IConfigurationPropertyRecordedSchema } from '../../../../main/src/plugin/configuration-registry';
+
+import { Buffer } from 'buffer';
+import type { KubernetesProviderConnection } from '@tmpwip/extension-api';
+import { providerInfos } from '../../stores/providers';
+import { onMount } from 'svelte';
+import type { ProviderInfo, ProviderKubernetesConnectionInfo } from '../../../../main/src/plugin/api/provider-info';
+import { router } from 'tinro';
+import Modal from '../dialogs/Modal.svelte';
+import Logger from './Logger.svelte';
+import { writeToTerminal } from './Util';
+
+export let properties: IConfigurationPropertyRecordedSchema[] = [];
+export let providerInternalId: string = undefined;
+export let apiUrlBase64: string = '';
+
+let scope: KubernetesProviderConnection;
+let providers: ProviderInfo[] = [];
+onMount(() => {
+  lifecycleError = '';
+  providerInfos.subscribe(value => {
+    providers = value;
+  });
+});
+
+$: apiURL = Buffer.from(apiUrlBase64, 'base64').toString();
+
+let providerInfo: ProviderInfo;
+$: providerInfo = providers.find(provider => provider.internalId === providerInternalId);
+
+$: connectionName = providers
+  .filter(provider => provider.internalId === providerInternalId)
+  .map(provider => {
+    const matchingConnection = provider.kubernetesConnections?.filter(
+      connection => connection.endpoint.apiURL === apiURL,
+    );
+
+    if (matchingConnection) {
+      return matchingConnection.length === 1 ? matchingConnection[0].name : 'N/A';
+    } else {
+      return '';
+    }
+  })
+  .flat();
+
+// get only ContainerConnection scope fields
+let configurationKeys: IConfigurationPropertyRecordedSchema[];
+$: configurationKeys = properties
+  .filter(property => property.scope === 'KubernetesConnection')
+  .sort((a, b) => a.id.localeCompare(b.id));
+
+// key + value for the properties declared for the ContainerConnection scope and has a value
+let connectionSettings = [];
+$: Promise.all(
+  configurationKeys.map(async configurationKey => {
+    return {
+      ...configurationKey,
+      value: await window.getConfigurationValue(configurationKey.id, scope),
+    };
+  }),
+).then(values => (connectionSettings = values.filter(configurationKey => configurationKey.value !== undefined)));
+$: scope = {
+  endpoint: {
+    apiURL,
+  },
+} as KubernetesProviderConnection;
+
+let kubernetesConnectionInfo: ProviderKubernetesConnectionInfo = undefined;
+$: kubernetesConnectionInfo = providerInfo?.kubernetesConnections?.find(
+  connection => connection.endpoint.apiURL === apiURL,
+);
+
+function createNewConnection(providerId: string) {
+  router.goto(`/preferences/provider/${providerId}`);
+}
+
+let lifecycleError = '';
+router.subscribe(async route => {
+  lifecycleError = '';
+});
+async function startConnection() {
+  lifecycleError = undefined;
+  try {
+    // await window.startProviderConnectionLifecycle(providerInfo.internalId, kubernetesConnectionInfo);
+  } catch (err) {
+    lifecycleError = err;
+  }
+}
+
+async function stopConnection() {
+  lifecycleError = undefined;
+  //  await window.stopProviderConnectionLifecycle(providerInfo.internalId, kubernetesConnectionInfo);
+}
+
+async function deleteConnection() {
+  lifecycleError = undefined;
+  // await window.deleteProviderConnectionLifecycle(providerInfo.internalId, kubernetesConnectionInfo);
+  router.goto('/preferences/providers');
+}
+
+let showModal: ProviderInfo = undefined;
+
+let logsTerminal;
+
+async function startReceivinLogs(provider: ProviderInfo): Promise<void> {
+  const logHandler = (newContent: any[], colorPrefix: string) => {
+    writeToTerminal(logsTerminal, newContent, colorPrefix);
+  };
+  /*window.startReceiveLogs(
+    provider.internalId,
+    data => logHandler(data, '\x1b[37m'),
+    data => logHandler(data, '\x1b[33m'),
+    data => logHandler(data, '\x1b[1;31m'),
+    kubernetesConnectionInfo,
+  );*/
+}
+
+async function stopReceivingLogs(provider: ProviderInfo): Promise<void> {
+  // await window.stopReceiveLogs(provider.internalId, kubernetesConnectionInfo);
+}
+</script>
+
+<div class="flex flex-1 flex-col bg-zinc-800 px-2">
+  <div class="flex flex-row align-middle my-4">
+    <div class="capitalize text-xl">{connectionName}</div>
+    {#if providerInfo?.containerProviderConnectionCreation}
+      <div class="flex-1 ml-10">
+        <button
+          on:click="{() => createNewConnection(providerInfo.internalId)}"
+          class="pf-c-button pf-m-secondary"
+          type="button">
+          <span class="pf-c-button__icon pf-m-start">
+            <i class="fas fa-plus-circle" aria-hidden="true"></i>
+          </span>
+          Create New
+        </button>
+      </div>
+    {/if}
+  </div>
+  <p class="capitalize text-sm">provider: {providerInfo?.name}</p>
+
+  <!-- Display lifecycle -->
+  {#if kubernetesConnectionInfo?.lifecycleMethods && kubernetesConnectionInfo.lifecycleMethods.length > 0}
+    <div class="py-2 flex flex:row ">
+      <!-- start is enabled only in stopped mode-->
+      {#if kubernetesConnectionInfo.lifecycleMethods.includes('start')}
+        <div class="px-2 text-sm italic  text-gray-400">
+          <button
+            disabled="{kubernetesConnectionInfo.status !== 'stopped'}"
+            on:click="{() => startConnection()}"
+            class="pf-c-button pf-m-primary"
+            type="button">
+            <span class="pf-c-button__icon pf-m-start">
+              <i class="fas fa-play" aria-hidden="true"></i>
+            </span>
+            Start
+          </button>
+        </div>
+      {/if}
+
+      <!-- stop is enabled only in started mode-->
+      {#if kubernetesConnectionInfo.lifecycleMethods.includes('stop')}
+        <div class="px-2 text-sm italic  text-gray-400">
+          <button
+            disabled="{kubernetesConnectionInfo.status !== 'started'}"
+            on:click="{() => stopConnection()}"
+            class="pf-c-button pf-m-primary"
+            type="button">
+            <span class="pf-c-button__icon pf-m-start">
+              <i class="fas fa-stop" aria-hidden="true"></i>
+            </span>
+            Stop
+          </button>
+        </div>
+      {/if}
+
+      <!-- delete is disabled if it is running-->
+      {#if kubernetesConnectionInfo.lifecycleMethods.includes('delete')}
+        <div class="px-2 text-sm italic  text-gray-400">
+          <button
+            disabled="{kubernetesConnectionInfo.status !== 'stopped'}"
+            on:click="{() => deleteConnection()}"
+            class="pf-c-button pf-m-secondary"
+            type="button">
+            <span class="pf-c-button__icon pf-m-start">
+              <i class="fas fa-trash" aria-hidden="true"></i>
+            </span>
+            Delete
+          </button>
+        </div>
+      {/if}
+      <div class="px-2 text-sm italic  text-gray-400">
+        <button
+          type="button"
+          disabled="{kubernetesConnectionInfo.status !== 'started'}"
+          on:click="{() => {
+            showModal = providerInfo;
+          }}"
+          class="pf-c-button pf-m-secondary">
+          <span class="pf-c-button__icon pf-m-start">
+            <i class="fas fa-history" aria-hidden="true"></i>
+          </span>
+          Show Logs
+        </button>
+      </div>
+    </div>
+
+    {#if lifecycleError}
+      <div class="text-red-600">
+        {lifecycleError}
+      </div>
+    {/if}
+  {/if}
+
+  {#each connectionSettings as connectionSetting}
+    <div class="pl-1 py-2">
+      <div class="text-sm italic  text-gray-400">{connectionSetting.description}</div>
+      <div class="pl-3">{connectionSetting.value}</div>
+    </div>
+  {/each}
+
+  {#if kubernetesConnectionInfo}
+    <div class="pl-1 py-2">
+      <div class="text-sm italic  text-gray-400">Status</div>
+      <div class="pl-3">{kubernetesConnectionInfo.status}</div>
+    </div>
+    <div class="pl-1 py-2">
+      <div class="text-sm italic  text-gray-400">Kubernetes endpoint API URL</div>
+      <div class="pl-3">{kubernetesConnectionInfo.endpoint.apiURL}</div>
+    </div>
+  {/if}
+</div>
+{#if showModal}
+  <Modal
+    on:close="{() => {
+      stopReceivingLogs(showModal);
+      showModal = undefined;
+    }}">
+    <h2 slot="header">Logs</h2>
+    <div id="log" style="height: 400px; width: 650px;">
+      <div style="width:100%; height:100%;">
+        <Logger bind:logsTerminal="{logsTerminal}" onInit="{() => startReceivinLogs(showModal)}" />
+      </div>
+    </div>
+  </Modal>
+{/if}

--- a/packages/renderer/src/lib/preferences/PreferencesPage.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesPage.svelte
@@ -9,6 +9,7 @@ import {
 
 import PreferencesRendering from './PreferencesRendering.svelte';
 import PreferencesContainerConnectionRendering from './PreferencesContainerConnectionRendering.svelte';
+import PreferencesKubernetesConnectionRendering from './PreferencesKubernetesConnectionRendering.svelte';
 import PreferencesProviderRendering from './PreferencesProviderRendering.svelte';
 import PreferencesExtensionRendering from './PreferencesExtensionRendering.svelte';
 import PreferencesRegistriesEditing from './PreferencesRegistriesEditing.svelte';
@@ -22,11 +23,15 @@ let defaultPrefPageId: string;
 onMount(async () => {
   configurationProperties.subscribe(value => {
     properties = value;
-    [defaultPrefPageId] = value
+
+    const iterator = value
       .filter(property => property.scope === CONFIGURATION_DEFAULT_SCOPE)
       .values()
-      .next()
-      .value.parentId.split('.');
+      .next().value;
+
+    if (iterator) {
+      [defaultPrefPageId] = iterator.parentId.split('.')[0];
+    }
   });
 });
 </script>
@@ -64,6 +69,12 @@ onMount(async () => {
       <PreferencesContainerConnectionRendering
         providerInternalId="{meta.params.provider}"
         connection="{meta.params.connection}"
+        properties="{properties}" />
+    </Route>
+    <Route path="/kubernetes-connection/:provider/:apiUrlBase64" let:meta>
+      <PreferencesKubernetesConnectionRendering
+        providerInternalId="{meta.params.provider}"
+        apiUrlBase64="{meta.params.apiUrlBase64}"
         properties="{properties}" />
     </Route>
   </div>

--- a/packages/renderer/src/lib/preferences/PreferencesProviderRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesProviderRendering.svelte
@@ -4,11 +4,12 @@ import type { IConfigurationPropertyRecordedSchema } from '../../../../main/src/
 import { providerInfos } from '../../stores/providers';
 import { onMount } from 'svelte';
 import type { ProviderInfo } from '../../../../main/src/plugin/api/provider-info';
-import PreferencesContainerConnectionCreationRendering from './PreferencesContainerConnectionCreationRendering.svelte';
+import PreferencesContainerConnectionCreationRendering from './PreferencesConnectionCreationRendering.svelte';
 import { router } from 'tinro';
 import Modal from '../dialogs/Modal.svelte';
 import Logger from './Logger.svelte';
 import { writeToTerminal } from './Util';
+import PreferencesConnectionCreationRendering from './PreferencesConnectionCreationRendering.svelte';
 
 export let properties: IConfigurationPropertyRecordedSchema[] = [];
 export let providerInternalId: string = undefined;
@@ -127,7 +128,20 @@ async function stopReceivingLogs(provider: ProviderInfo): Promise<void> {
 
   <!-- Create connection panel-->
   {#if providerInfo?.containerProviderConnectionCreation === true}
-    <PreferencesContainerConnectionCreationRendering providerInfo="{providerInfo}" properties="{properties}" />
+    <PreferencesConnectionCreationRendering
+      providerInfo="{providerInfo}"
+      properties="{properties}"
+      propertyScope="ContainerProviderConnectionFactory"
+      callback="{window.createContainerProviderConnection}" />
+  {/if}
+
+  <!-- Create connection panel-->
+  {#if providerInfo?.kubernetesProviderConnectionCreation === true}
+    <PreferencesConnectionCreationRendering
+      providerInfo="{providerInfo}"
+      properties="{properties}"
+      propertyScope="KubernetesProviderConnectionFactory"
+      callback="{window.createKubernetesProviderConnection}" />
   {/if}
 </div>
 {#if showModal}

--- a/packages/renderer/src/stores/providers.ts
+++ b/packages/renderer/src/stores/providers.ts
@@ -67,3 +67,9 @@ window?.events.receive('provider:update-status', () => {
 window.addEventListener('system-ready', () => {
   fetchProviders();
 });
+window?.events.receive('provider-register-kubernetes-connection', () => {
+  fetchProviders();
+});
+window?.events.receive('provider-unregister-kubernetes-connection', () => {
+  fetchProviders();
+});


### PR DESCRIPTION
### What does this PR do?
Add missing items for .kubernetesConnections object of providers

part of https://github.com/containers/podman-desktop/issues/413



### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?
related to https://github.com/containers/podman-desktop/issues/413

### How to test this PR?
it should just work as before for current providers.
Check that the resource page for container providers is not broken as now one page is shared between container and kubernetes connections


Change-Id: Ic85b01c20253062899b67cc72616fc4d4ecbccd7
Signed-off-by: Florent Benoit <fbenoit@redhat.com>