### PR TITLE
fix: collapsed pod is always expanded on refresh

### DIFF
--- a/packages/renderer/src/lib/ContainerList.svelte
+++ b/packages/renderer/src/lib/ContainerList.svelte
@@ -196,6 +196,7 @@ onMount(async () => {
       const matchingGroup = containerGroups.find(currentGroup => currentGroup.name === group.name);
       if (matchingGroup) {
         group.selected = matchingGroup.selected;
+        group.expanded = matchingGroup.expanded;
         group.containers.forEach(container => {
           const matchingContainer = matchingGroup.containers.find(
             currentContainer => currentContainer.id === container.id,


### PR DESCRIPTION
### What does this PR do?
keep expanded state of pods when refreshing containers

### Screenshot/screencast of this PR


https://user-images.githubusercontent.com/436777/207864147-b68ea9bd-0ca9-42dc-882e-b8a705233749.mp4



### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/1011


### How to test this PR?

Follow use-case of https://github.com/containers/podman-desktop/issues/1011

Change-Id: I5c468e260113328652825ae53d63df30e591ff92
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
