### PR TITLE
chore: update filesize to v10

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "test:main": "vitest run -r packages/main --passWithNoTests",
     "test:preload": "vitest run -r packages/preload --passWithNoTests",
     "test:extensions": "vitest run -r extensions --passWithNoTests",
-    "test:renderer": "vitest run -r packages/renderer --passWithNoTests",
+    "test:renderer": "vitest run packages/renderer --passWithNoTests",
     "test:watch": "vitest watch",
     "watch": "node scripts/watch.js",
     "generate-types": "node scripts/watch.js --types-only",

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -17,7 +17,7 @@
     "@tsconfig/svelte": "^3.0.0",
     "@typescript-eslint/eslint-plugin": "5.46.1",
     "autoprefixer": "^10.4.13",
-    "filesize": "^8.0.7",
+    "filesize": "^10.0.6",
     "humanize-duration": "^3.27.3",
     "moment": "^2.29.4",
     "monaco-editor": "^0.34.1",

--- a/packages/renderer/src/lib/container/ContainerStatistics.svelte
+++ b/packages/renderer/src/lib/container/ContainerStatistics.svelte
@@ -2,7 +2,7 @@
 import { onMount, onDestroy } from 'svelte';
 import type { ContainerStatsInfo } from '../../../../main/src/plugin/api/container-stats-info';
 import type { ContainerInfoUI } from './ContainerInfoUI';
-import filesize from 'filesize';
+import { ContainerUtils } from './container-utils';
 
 export let container: ContainerInfoUI;
 
@@ -12,6 +12,8 @@ const DANGER_PERCENTAGE = 90;
 const GREEN_COLOR = '#16a34a';
 const ORANGE_COLOR = '#F97316';
 const RED_COLOR = '#cb4d3e';
+
+const containerUtils = new ContainerUtils();
 
 $: cpuColor =
   cpuUsagePercentage < WARNING_PERCENTAGE
@@ -52,7 +54,7 @@ async function updateStatistics(containerStats: ContainerStatsInfo) {
   usedMemory = containerStats.memory_stats.usage - (containerStats.memory_stats.stats?.cache || 0);
   const availableMemory = containerStats.memory_stats.limit;
   memoryUsagePercentage = (usedMemory / availableMemory) * 100.0;
-  memoryUsagePercentageTitle = `${memoryUsagePercentage.toFixed(2)}% (${filesize(usedMemory)})`;
+  memoryUsagePercentageTitle = containerUtils.getMemoryUsageTitle(memoryUsagePercentage, usedMemory);
 
   const cpuDelta = containerStats.cpu_stats.cpu_usage.total_usage - containerStats.precpu_stats.cpu_usage.total_usage;
   const systemCpuDelta =

--- a/packages/renderer/src/lib/container/container-utils.spec.ts
+++ b/packages/renderer/src/lib/container/container-utils.spec.ts
@@ -1,0 +1,32 @@
+/**********************************************************************
+ * Copyright (C) 2022 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { beforeEach, expect, test, vi } from 'vitest';
+import { ContainerUtils } from './container-utils';
+
+let containerUtils: ContainerUtils;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  containerUtils = new ContainerUtils();
+});
+
+test('should expect valid memory usage', async () => {
+  const size = containerUtils.getMemoryUsageTitle(4, 1000000);
+  expect(size).toBe('4.00% (1 MB)');
+});

--- a/packages/renderer/src/lib/container/container-utils.ts
+++ b/packages/renderer/src/lib/container/container-utils.ts
@@ -21,6 +21,7 @@ import type { ContainerGroupInfoUI, ContainerGroupPartInfoUI, ContainerInfoUI } 
 import { ContainerGroupInfoTypeUI } from './ContainerInfoUI';
 import moment from 'moment';
 import humanizeDuration from 'humanize-duration';
+import { filesize } from 'filesize';
 export class ContainerUtils {
   getName(containerInfo: ContainerInfo) {
     // part of a compose ?
@@ -175,5 +176,9 @@ export class ContainerUtils {
       }
     });
     return Array.from(groups.values());
+  }
+
+  getMemoryUsageTitle(memoryUsagePercentage: number, usedMemory: number): string {
+    return `${memoryUsagePercentage.toFixed(2)}% (${filesize(usedMemory)})`;
   }
 }

--- a/packages/renderer/src/lib/image/image-utils.spec.ts
+++ b/packages/renderer/src/lib/image/image-utils.spec.ts
@@ -1,0 +1,32 @@
+/**********************************************************************
+ * Copyright (C) 2022 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { beforeEach, expect, test, vi } from 'vitest';
+import { ImageUtils } from './image-utils';
+
+let imageUtils: ImageUtils;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  imageUtils = new ImageUtils();
+});
+
+test('should expect valid size', async () => {
+  const size = imageUtils.getHumanSize(1000);
+  expect(size).toBe('1 kB');
+});

--- a/packages/renderer/src/lib/image/image-utils.ts
+++ b/packages/renderer/src/lib/image/image-utils.ts
@@ -19,7 +19,7 @@
 import type { ImageInfo } from '../../../../main/src/plugin/api/image-info';
 import type { ImageInfoUI } from './ImageInfoUI';
 import moment from 'moment';
-import filesize from 'filesize';
+import { filesize } from 'filesize';
 import { Buffer } from 'buffer';
 import type { ContainerInfo } from '../../../../main/src/plugin/api/container-info';
 

--- a/packages/renderer/src/lib/volume/volume-utils.spec.ts
+++ b/packages/renderer/src/lib/volume/volume-utils.spec.ts
@@ -1,0 +1,40 @@
+/**********************************************************************
+ * Copyright (C) 2022 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { beforeEach, expect, test, vi } from 'vitest';
+import type { VolumeInfo } from '../../../../main/src/plugin/api/volume-info';
+import { VolumeUtils } from './volume-utils';
+
+let volumeUtils: VolumeUtils;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  volumeUtils = new VolumeUtils();
+});
+
+test('should expect valid size', async () => {
+  const volumeInfo = { UsageData: { Size: 1000, RefCount: 1 } } as VolumeInfo;
+  const size = volumeUtils.getSize(volumeInfo);
+  expect(size).toBe('1 kB');
+});
+
+test('should expect valid size if missing', async () => {
+  const volumeInfo = {} as VolumeInfo;
+  const size = volumeUtils.getSize(volumeInfo);
+  expect(size).toBe('0 B');
+});

--- a/packages/renderer/src/lib/volume/volume-utils.ts
+++ b/packages/renderer/src/lib/volume/volume-utils.ts
@@ -20,7 +20,7 @@ import moment from 'moment';
 import humanizeDuration from 'humanize-duration';
 import type { VolumeInfo } from '../../../../main/src/plugin/api/volume-info';
 import type { VolumeInfoUI } from './VolumeInfoUI';
-import filesize from 'filesize';
+import { filesize } from 'filesize';
 
 export class VolumeUtils {
   getUptime(volumeInfo: VolumeInfo): string {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6961,7 +6961,12 @@ filelist@^1.0.1:
   dependencies:
     minimatch "^3.0.4"
 
-filesize@^8.0.6, filesize@^8.0.7:
+filesize@^10.0.6:
+  version "10.0.6"
+  resolved "https://registry.yarnpkg.com/filesize/-/filesize-10.0.6.tgz#5f4cd2721664cd925db3a7a5a87bbfd6ab5ebb1a"
+  integrity sha512-rzpOZ4C9vMFDqOa6dNpog92CoLYjD79dnjLk2TYDDtImRIyLTOzqojCb05Opd1WuiWjs+fshhCgTd8cl7y5t+g==
+
+filesize@^8.0.6:
   version "8.0.7"
   resolved "https://registry.yarnpkg.com/filesize/-/filesize-8.0.7.tgz#695e70d80f4e47012c132d57a059e80c6b580bd8"
   integrity sha512-pjmC+bkIF8XI7fWaH8KxHcZL3DPybs1roSKP4rKDvy20tAWwIObE4+JIseG2byfGKhud5ZnM4YSGKBz7Sh0ndQ==


### PR DESCRIPTION
### What does this PR do?
update filesize from v8 to v10
we need to change how we're importing/using the library

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

related to a dependabot issue that doesn't work out of the box
https://github.com/containers/podman-desktop/pull/1024

### How to test this PR?

I've added unit tests
but you may check were we display some size units.

Change-Id: I68fe64c411e566d56a17f606e8ffa2286c742bd2
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
