### PR TITLE
feat(extension-api): allow to specify enum type for configuration items

### DIFF
--- a/packages/main/src/plugin/configuration-registry.ts
+++ b/packages/main/src/plugin/configuration-registry.ts
@@ -60,6 +60,7 @@ export interface IConfigurationPropertySchema {
   scope?: ConfigurationScope;
   readonly?: boolean;
   hidden?: boolean;
+  enum?: string[];
 }
 
 export type ConfigurationScope =

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
@@ -108,6 +108,19 @@ function update(record: IConfigurationPropertyRecordedSchema) {
         id="input-standard-{record.id}"
         aria-invalid="{invalidEntry}"
         aria-label="{record.description}" />
+    {:else if record.type === 'string' && record.enum && record.enum.length > 0}
+      <select
+        class="border  text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 bg-gray-600 border-gray-500 placeholder-gray-400 text-white"
+        name="{record.id}"
+        id="input-standard-{record.id}"
+        on:input="{event => checkValue(record, event)}"
+        bind:value="{recordValue}"
+        aria-invalid="{invalidEntry}"
+        aria-label="{record.description}">
+        {#each record.enum as recordEnum}
+          <option value="{recordEnum}">{recordEnum}</option>
+        {/each}
+      </select>
     {:else}
       <input
         on:input="{event => checkValue(record, event)}"


### PR DESCRIPTION
### What does this PR do?
extension/internal components can provide enum type for properties

### Screenshot/screencast of this PR


https://user-images.githubusercontent.com/436777/208445151-8382e055-8d59-44e5-a120-8d60dbdabf5c.mp4



### What issues does this PR fix or reference?

Related to #413 

### How to test this PR?

Add into an extension enum type

example for podman extension in package.json/contributes

```json
        "podman.factory.example": {
          "type": "string",
          "default": "foo",
          "scope": "ContainerProviderConnectionFactory",
          "description": "Name",
          "enum": ["foo", "bar", "baz"]
        },
```
Change-Id: I69b2c00642cc9b1162add7090e7f95974ba143f2
Signed-off-by: Florent Benoit <fbenoit@redhat.com>