### PR TITLE
feat(extension-api): Allows to provide logger for kube/container factory creation

### DIFF
--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -389,7 +389,7 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
   // allows to create machines
   if (isMac || isWindows) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const createFunction = async (params: { [key: string]: any }): Promise<void> => {
+    const createFunction = async (params: { [key: string]: any }, logger: extensionApi.Logger): Promise<void> => {
       const parameters = [];
       parameters.push('machine');
       parameters.push('init');
@@ -442,11 +442,11 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
           }
         }
       }
-      await execPromise(getPodmanCli(), parameters, { env });
+      await execPromise(getPodmanCli(), parameters, { logger, env });
     };
 
     provider.setContainerProviderConnectionFactory({
-      initialize: () => createFunction({}),
+      initialize: () => createFunction({}, undefined),
       create: createFunction,
     });
   }

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -195,13 +195,13 @@ declare module '@tmpwip/extension-api' {
   export interface ContainerProviderConnectionFactory {
     initialize(): Promise<void>;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    create(params: { [key: string]: any }): Promise<void>;
+    create(params: { [key: string]: any }, logger?: Logger): Promise<void>;
   }
 
   // create a kubernetes provider
   export interface KubernetesProviderConnectionFactory {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    create(params: { [key: string]: any }): Promise<void>;
+    create(params: { [key: string]: any }, logger?: Logger): Promise<void>;
   }
 
   export interface Link {

--- a/packages/main/src/plugin/provider-registry.ts
+++ b/packages/main/src/plugin/provider-registry.ts
@@ -31,6 +31,7 @@ import type {
   KubernetesProviderConnection,
   UnregisterKubernetesConnectionEvent,
   RegisterKubernetesConnectionEvent,
+  Logger,
 } from '@tmpwip/extension-api';
 import type {
   ProviderContainerConnectionInfo,
@@ -544,26 +545,37 @@ export class ProviderRegistry {
     return context;
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  async createContainerProviderConnection(internalProviderId: string, params: { [key: string]: any }): Promise<void> {
+  async createContainerProviderConnection(
+    internalProviderId: string,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    params: { [key: string]: any },
+    logHandler: Logger,
+  ): Promise<void> {
     // grab the correct provider
     const provider = this.getMatchingProvider(internalProviderId);
 
     if (!provider.containerProviderConnectionFactory) {
       throw new Error('The provider does not support container connection creation');
     }
-    return provider.containerProviderConnectionFactory.create(params);
+
+    // create a logger
+
+    return provider.containerProviderConnectionFactory.create(params, logHandler);
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  async createKubernetesProviderConnection(internalProviderId: string, params: { [key: string]: any }): Promise<void> {
+  async createKubernetesProviderConnection(
+    internalProviderId: string,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    params: { [key: string]: any },
+    logHandler: Logger,
+  ): Promise<void> {
     // grab the correct provider
     const provider = this.getMatchingProvider(internalProviderId);
 
     if (!provider.kubernetesProviderConnectionFactory) {
       throw new Error('The provider does not support kubernetes connection creation');
     }
-    return provider.kubernetesProviderConnectionFactory.create(params);
+    return provider.kubernetesProviderConnectionFactory.create(params, logHandler);
   }
 
   // helper method

--- a/packages/renderer/src/lib/preferences/Logger.svelte
+++ b/packages/renderer/src/lib/preferences/Logger.svelte
@@ -32,7 +32,7 @@ async function refreshTerminal() {
   // disable cursor
   logsTerminal.write('\x1b[?25l');
 
-  logsTerminal.write(`Log output will appear here...\n\r`);
+  logsTerminal.write('\n\r');
 
   resizeHandler = () => {
     fitAddon.fit();


### PR DESCRIPTION
### What does this PR do?
It allows to display the creation details in a terminal

### Screenshot/screencast of this PR


https://user-images.githubusercontent.com/436777/208446606-8c072fdf-8967-4ddb-8de2-6ed4bef6f16a.mp4



### What issues does this PR fix or reference?

related to #413 

### How to test this PR?

if you go to settings/resource/podman and create a podman machine, you should see creation log.

Change-Id: Iceb11b6ee91365bd5a0921e09627429bbce51fa9
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
