### PR TITLE
feat: add open dev console on dd webview in development mode

### DIFF
--- a/packages/main/src/mainWindow.ts
+++ b/packages/main/src/mainWindow.ts
@@ -141,6 +141,28 @@ async function createWindow() {
     showSaveLinkAs: false,
     showInspectElement: import.meta.env.DEV,
     showServices: false,
+    prepend: (_defaultActions, parameters) => {
+      // In development mode, show the "Open DevTools of Extension" menu item
+      if (import.meta.env.DEV) {
+        let extensionId = '';
+        if (parameters.linkURL && parameters.linkURL.includes('/contribs')) {
+          extensionId = parameters.linkURL.split('/contribs/')[1];
+        }
+        return [
+          {
+            label: `Open DevTools of ${decodeURI(extensionId)} Extension`,
+            // make it visible when link contains contribs and we're inside the extension
+            visible:
+              parameters.linkURL.includes('/contribs/') && parameters.pageURL.includes(`/contribs/${extensionId}`),
+            click: () => {
+              browserWindow.webContents.send('dev-tools:open-extension', extensionId.replaceAll('%20', '-'));
+            },
+          },
+        ];
+      } else {
+        return [];
+      }
+    },
   });
 
   /**

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -738,6 +738,12 @@ function initExposure(): void {
     return ipcInvoke('contributions:listContributions');
   });
 
+  // Handle callback to open devtools for extensions
+  // by delegating to the renderer process
+  ipcRenderer.on('dev-tools:open-extension', (_, extensionId: string) => {
+    apiSender.send('dev-tools:open-extension', extensionId);
+  });
+
   // Handle callback on dialog file/folder by calling the callback once we get the answer
   ipcRenderer.on(
     'dialog:open-file-or-folder-response',

--- a/packages/renderer/src/lib/docker-extension/DockerExtension.svelte
+++ b/packages/renderer/src/lib/docker-extension/DockerExtension.svelte
@@ -17,6 +17,14 @@ onMount(async () => {
   preloadPath = await window.getDDPreloadPath();
   source = currentContrib?.uiUri;
 });
+
+window.events?.receive('dev-tools:open-extension', extensionId => {
+  const extensionElement = document.getElementById(`dd-webview-${extensionId}`);
+
+  if (extensionElement) {
+    (extensionElement as any).openDevTools();
+  }
+});
 </script>
 
 {#if source && preloadPath}


### PR DESCRIPTION


### What does this PR do?
Allows with right click on a dd extension entry to open the debug menu

- [ ] depends on https://github.com/containers/podman-desktop/pull/1070

### Screenshot/screencast of this PR

https://user-images.githubusercontent.com/436777/208715738-2773cf1c-1311-44cb-8685-e82db53e1819.mp4




### What issues does this PR fix or reference?

N/A

### How to test this PR?

In development mode, right click on an extension in menu item

Change-Id: Ief18aa26a0563b1213613764090d5e3981159e77
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
