### PR TITLE
chore: updated link to the Matrix room

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ General questions & development:
 
 * [#general on Discord](https://discordapp.com/invite/TCTB38RWpf)
 * [#podman-desktop@libera.chat on IRC](https://libera.chat/)
-* [#podman-desktop@fedora.im on Matrix](https://fedora.im)
+* [#podman-desktop@fedora.im on Matrix](https://chat.fedoraproject.org/#/room/#podman-desktop:fedora.im)
 
 Note: All channels are bridged. Chat on either: Discord, IRC or Matrix!
 


### PR DESCRIPTION

### What does this PR do?

Use https://chat.fedoraproject.org/#/room/#podman-desktop:fedora.im rather than https://fedora.im.

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?

https://fedora.im is redirecting to https://chat.fedoraproject.org/

Finding the room there is not obvious for a first time user.

A direct link is more straightforward.

### How to test this PR?

<!-- Please explain steps to reproduce -->
