### PR TITLE
docs: Using the `podman-mac-helper` tool to migrate from Docker

### DIFF
--- a/website/docs/getting-started/using-podman-mac-helper-to-migrate-from-docker-to-podman-on-macos.md
+++ b/website/docs/getting-started/using-podman-mac-helper-to-migrate-from-docker-to-podman-on-macos.md
@@ -6,52 +6,55 @@ tags: [podman-desktop, getting-started, podman-mac-helper, macOS]
 keywords: [podman desktop, podman, containers]
 ---
 
-## Using the `podman-mac-helper` tool to migrate from Docker to Podman on macOS
+# Using the `podman-mac-helper` tool to migrate from Docker to Podman on macOS
+
+Consider using `podman-mac-help` to migrate transparently to Podman on macOS.
+
+* Continue using familiar Docker commands.
+* Take advantage of the benefits of Podman on macOS.
+
+* Your tools, such as Maven or test containers, communicate with Podman without reconfiguration.
 
 The `podman-mac-helper` tool provides a compatibility layer that allows you to use most Docker commands with Podman on macOS.
 The service redirects `/var/run/docker` to the fixed user-assigned UNIX socket location.
-
-Using the `podman-mac-helper` tool can make it easier to migrate from Docker to Podman on macOS.
-It allows you to continue using familiar Docker commands while taking advantage of the benefits of Podman.
 
 #### Prerequisites
 
 * macOS
 * [Podman](../Installation/macos-install)
 * [Homebrew](https://brew.sh/)
-
-#### Procedure
-
-1. Save your existing Docker containers by running the command:
+* Optionnally, you saved your existing Docker containers by running the command:
 
     ```
     $ docker save <your_container> > <your_container_archive>.tar
     ```
 
-2. Disable or uninstall the Docker service.
+* Docker service is [paused](https://docs.docker.com/desktop/use-desktop/pause/) and [*Start Docker Desktop when you log in* is disabled](https://docs.docker.com/desktop/settings/mac/), or Docker is [uninstalled](https://docs.docker.com/desktop/uninstall/).
 
-3. Install the `podman-mac-helper` tool.
+#### Procedure
+
+1. Install the `podman-mac-helper` tool.
    Run the command:
 
     ```
     $ brew install podman-mac-helper
     ```
 
-4. Set up the `podman-mac-helper` service for each user.
+2. Set up the `podman-mac-helper` service for each user.
    Run the command:
 
     ```
     $ podman-mac-helper setup
     ```
 
-5. Import your existing containers into Podman.
+3. Optionally, import your existing containers into Podman.
    Run the command for each container archive:
 
      ```
      $ podman import <your_container_archive>.tar
      ```
 
-6. Use the `podman-mac-helper` tool to run commands.
+4. Use the `podman-mac-helper` tool to run commands.
    To run a command with Podman by using the `podman-mac-helper` tool, prefix the command with `podman-mac-helper`.
 
    Example:

--- a/website/docs/getting-started/using-podman-mac-helper-to-migrate-from-docker-to-podman-on-macos.md
+++ b/website/docs/getting-started/using-podman-mac-helper-to-migrate-from-docker-to-podman-on-macos.md
@@ -12,7 +12,6 @@ Consider using `podman-mac-help` to migrate transparently to Podman on macOS.
 
 * Continue using familiar Docker commands.
 * Take advantage of the benefits of Podman on macOS.
-
 * Your tools, such as Maven or test containers, communicate with Podman without reconfiguration.
 
 The `podman-mac-helper` tool provides a compatibility layer that allows you to use most Docker commands with Podman on macOS.
@@ -23,7 +22,7 @@ The service redirects `/var/run/docker` to the fixed user-assigned UNIX socket l
 * macOS
 * [Podman](../Installation/macos-install)
 * [Homebrew](https://brew.sh/)
-* Optionnally, you saved your existing Docker containers by running the command:
+* (Optional) You saved your existing Docker containers by running the command:
 
     ```
     $ docker save <your_container> > <your_container_archive>.tar
@@ -47,7 +46,7 @@ The service redirects `/var/run/docker` to the fixed user-assigned UNIX socket l
     $ podman-mac-helper setup
     ```
 
-3. Optionally, import your existing containers into Podman.
+3. (Optional) Import your existing containers into Podman.
    Run the command for each container archive:
 
      ```

--- a/website/docs/getting-started/using-podman-mac-helper-to-migrate-from-docker-to-podman-on-macos.md
+++ b/website/docs/getting-started/using-podman-mac-helper-to-migrate-from-docker-to-podman-on-macos.md
@@ -1,0 +1,68 @@
+---
+id: using-podman-mac-helper-to-migrate-from-docker-to-podman-on-macos.md
+title: Using the `podman-mac-helper` tool on macOS
+description: Using the `podman-mac-helper` tool can make it easier to migrate from Docker to Podman on macOS, as it allows you to continue using familiar Docker commands while taking advantage of the benefits of Podman.
+tags: [podman-desktop, getting-started, podman-mac-helper, macOS]
+keywords: [podman desktop, podman, containers]
+---
+
+## Using the `podman-mac-helper` tool to migrate from Docker to Podman on macOS
+
+The `podman-mac-helper` tool provides a compatibility layer that allows you to use most Docker commands with Podman on macOS.
+The service redirects `/var/run/docker` to the fixed user-assigned UNIX socket location.
+
+Using the `podman-mac-helper` tool can make it easier to migrate from Docker to Podman on macOS.
+It allows you to continue using familiar Docker commands while taking advantage of the benefits of Podman.
+
+#### Prerequisites
+
+* macOS
+* [Podman](../Installation/macos-install)
+* [Homebrew](https://brew.sh/)
+
+#### Procedure
+
+1. Save your existing Docker containers by running the command:
+
+    ```
+    $ docker save <your_container> > <your_container_archive>.tar
+    ```
+
+2. Disable or uninstall the Docker service.
+
+3. Install the `podman-mac-helper` tool.
+   Run the command:
+
+    ```
+    $ brew install podman-mac-helper
+    ```
+
+4. Set up the `podman-mac-helper` service for each user.
+   Run the command:
+
+    ```
+    $ podman-mac-helper setup
+    ```
+
+5. Import your existing containers into Podman.
+   Run the command for each container archive:
+
+     ```
+     $ podman import <your_container_archive>.tar
+     ```
+
+6. Use the `podman-mac-helper` tool to run commands.
+   To run a command with Podman by using the `podman-mac-helper` tool, prefix the command with `podman-mac-helper`.
+
+   Example:
+
+    ```
+    $ podman-mac-helper run -it <your_container> bash
+    ```
+
+#### Additional resources
+
+* [`podman-mac-helper` source](https://github.com/containers/podman/tree/main/cmd/podman-mac-helper)
+* [`docker save` reference documentation](https://docs.docker.com/engine/reference/commandline/save/)
+* [`podman import` reference documentation](https://docs.podman.io/en/latest/markdown/podman-import.1.html)
+


### PR DESCRIPTION
### What does this PR do?

docs: Using the `podman-mac-helper` tool to migrate from Docker to Podman on macOS

### Screenshot/screencast of this PR

![Screenshot from 2022-12-23 15-50-17](https://user-images.githubusercontent.com/243761/209355098-253519f7-336e-4ec3-ba18-1a981ff3a7f6.png)


Not properly tested on macOS.

### What issues does this PR fix or reference?

refs: #1036 (partial)

### How to test this PR?

Run the steps on a macOS workstation.
