### PR TITLE
feat(extension-api): Allows to select a file for string properties

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
@@ -93,6 +93,13 @@ function update(record: IConfigurationPropertyRecordedSchema) {
     invalidText = error;
   }
 }
+
+async function selectFilePath() {
+  const result = await window.openFileDialog(`Select ${record.description}`);
+  if (!result.canceled && result.filePaths.length === 1) {
+    recordValue = result.filePaths[0];
+  }
+}
 </script>
 
 <div class="flex flex-row mb-2 pt-2">
@@ -108,6 +115,18 @@ function update(record: IConfigurationPropertyRecordedSchema) {
         id="input-standard-{record.id}"
         aria-invalid="{invalidEntry}"
         aria-label="{record.description}" />
+    {:else if record.type === 'string' && record.format === 'file'}
+      <input
+        name="{record.id}"
+        on:click="{() => selectFilePath()}"
+        id="rendering.FilePath.{record.id}"
+        bind:value="{recordValue}"
+        readonly
+        aria-invalid="{invalidEntry}"
+        aria-label="{record.description}"
+        placeholder="Select {record.description}..."
+        class="w-full p-2 outline-none text-sm bg-zinc-900 rounded-sm text-gray-400 placeholder-gray-400 cursor-pointer"
+        required />
     {:else if record.type === 'string' && record.enum && record.enum.length > 0}
       <select
         class="border  text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 bg-gray-600 border-gray-500 placeholder-gray-400 text-white"


### PR DESCRIPTION
### What does this PR do?
provides a file selector if formatter is set to file on string properties in properties

### Screenshot/screencast of this PR


https://user-images.githubusercontent.com/436777/210508524-45005536-ac74-4074-92c1-2b3ca51d0073.mp4



### What issues does this PR fix or reference?
https://github.com/containers/podman-desktop/issues/185

### How to test this PR?

Add in package.json of for example podman extension a new property like

```json
        "podman.factory.machine.image-path": {
          "type": "string",
          "format": "file",
          "scope": "ContainerProviderConnectionFactory",
          "description": "Image Path (Optional)"
        }
```

then in settings/resources/podman, when creating a podman machine you should see a new field where you can select a file

Change-Id: Ibb5a069be31e47ccf68c9c5654478a7861e8ec89
Signed-off-by: Florent Benoit <fbenoit@redhat.com>