### PR TITLE
chore: added Vale configuration to validate style guide consistency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist
 *.cdix
 .parcel-cache
 .idea
+.vale/styles/RedHat

--- a/.vale.ini
+++ b/.vale.ini
@@ -1,0 +1,24 @@
+; .vale.ini
+; Vale configuration file. See https://vale.sh
+;
+; Copyright (C) 2023 Red Hat, Inc.
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+; http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+;
+; SPDX-License-Identifier: Apache-2.0
+;
+MinAlertLevel = suggestion
+Packages = RedHat
+StylesPath = .vale/styles
+
+[*.md]
+BasedOnStyles = RedHat,PodmanDesktop

--- a/.vale/fixtures/PodmanDesktop/ProductNames/.vale.ini
+++ b/.vale/fixtures/PodmanDesktop/ProductNames/.vale.ini
@@ -1,0 +1,23 @@
+; .vale.ini
+; Vale configuration file. See https://vale.sh
+;
+; Copyright (C) 2023 Red Hat, Inc.
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+; http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+;
+; SPDX-License-Identifier: Apache-2.0
+;
+MinAlertLevel = suggestion
+StylesPath = ../../../styles
+
+[*.md]
+PodmanDesktop.ProductNames = YES

--- a/.vale/fixtures/PodmanDesktop/ProductNames/testinvalid.md
+++ b/.vale/fixtures/PodmanDesktop/ProductNames/testinvalid.md
@@ -1,0 +1,2 @@
+Podman desktop
+podman

--- a/.vale/fixtures/PodmanDesktop/ProductNames/testvalid.md
+++ b/.vale/fixtures/PodmanDesktop/ProductNames/testvalid.md
@@ -1,0 +1,3 @@
+Podman Desktop
+`podman`
+Podman

--- a/.vale/styles/PodmanDesktop/ProductNames.yml
+++ b/.vale/styles/PodmanDesktop/ProductNames.yml
@@ -1,0 +1,9 @@
+---
+extends: substitution
+message: "Consider using: %s, rather than: %s"
+level: warning
+ignorecase: false
+# swap map tokens in the form of bad: good
+swap:
+  Podman desktop: Podman Desktop
+  podman: '`podman` or Podman'


### PR DESCRIPTION
### What does this PR do?

This pull request is adding Vale configuration to validate style guide consistency and product names using Vale CLI.

The purpose is to ensure compliance and consistency with the Red Hat Style Guide as implemented for Vale. See: https://redhat-documentation.github.io/vale-at-red-hat/docs/main/user-guide/redhat-style-for-vale/

The pull request also introduces a project specific rule to ensure consistent product naming (and associated tests).

This pull request doesn't include GitHub automation. I believe it is too soon to introduce it.

Signed-off-by: Fabrice Flore-Thébault <ffloreth@redhat.com>

### Screenshot/screencast of this PR

![Screenshot from 2023-01-04 10-48-04](https://user-images.githubusercontent.com/243761/210528035-5e2aa96b-9e6b-487f-9708-5c1d66f710b8.png)

![Screenshot from 2023-01-04 11-01-23](https://user-images.githubusercontent.com/243761/210530623-bdfccc08-05b6-4bc2-a641-b9473dad9e7d.png)


### What issues does this PR fix or reference?

### How to test this PR?

1. Install the Vale CLI. See https://vale.sh/docs/vale-cli/installation/.
2. Synchronize the Red Hat style package
   ```
   $ vale sync
   ```
4. Run Vale
   ```
   $ vale .
   ```

Optionally, consider integrating Vale into your IDE:
* For IntelliJ IDEs: https://plugins.jetbrains.com/plugin/19613-vale-cli or https://plugins.jetbrains.com/plugin/16136-grazie-professional/docs/project-style-guides.html#vanilla-vale
* For Visual Studio Code: https://github.com/errata-ai/vale-vscode

