### PR TITLE
chore(website): allow to use $ or # in output and copy button ignoring the symbol in codeblock

### DIFF
--- a/website/src/theme/CodeBlock/CopyButton/index.js
+++ b/website/src/theme/CodeBlock/CopyButton/index.js
@@ -1,0 +1,33 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import React from 'react';
+import CopyButton from '@theme-original/CodeBlock/CopyButton';
+
+// Update the CopyButton to remove the '$ ' or '# ' from the code
+export default function CopyButtonWrapper(props) {
+  const updatedProps = {...props};
+  if (updatedProps?.code?.length > 2 && (updatedProps.code.substring(0, 2) === '$ ' ||  updatedProps.code.substring(0, 2) === '# ')) {
+    updatedProps.code = updatedProps.code.substring(2);
+  }
+  return (
+    <>
+      <CopyButton {...updatedProps} />
+    </>
+  );
+}


### PR DESCRIPTION
### What does this PR do?
Allow to specify $ or # in block commands but copy button is ignoring it
swizzle the docusaurus component

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

related to https://github.com/containers/podman-desktop/pull/1118

### How to test this PR?

Try to use the copy button with 
```shell
$ hello
```

block

Change-Id: I006bf9cf6fb501ea2a7d8f1309623ca404cb4ccb
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
