### PR TITLE
feat: adds ability to view pod logs

### DIFF
--- a/packages/renderer/src/lib/pod/PodDetails.svelte
+++ b/packages/renderer/src/lib/pod/PodDetails.svelte
@@ -9,6 +9,7 @@ import PodActions from './PodActions.svelte';
 import PodDetailsSummary from './PodDetailsSummary.svelte';
 import PodDetailsInspect from './PodDetailsInspect.svelte';
 import PodDetailsKube from './PodDetailsKube.svelte';
+import PodDetailsLogs from './PodDetailsLogs.svelte';
 
 export let podName: string;
 export let engineId: string;
@@ -61,6 +62,18 @@ onDestroy(() => {
                     <li
                       class="pf-c-tabs__item"
                       class:pf-m-current="{meta.url ===
+                        `/pods/${encodeURI(pod.name)}/${encodeURI(pod.engineId)}/logs`}">
+                      <a
+                        href="/pods/${encodeURI(pod.name)}/${encodeURI(pod.engineId)}/logs"
+                        class="pf-c-tabs__link"
+                        aria-controls="open-tabs-example-tabs-list-details-panel"
+                        id="open-tabs-example-tabs-list-details-link">
+                        <span class="pf-c-tabs__item-text">Logs</span>
+                      </a>
+                    </li>
+                    <li
+                      class="pf-c-tabs__item"
+                      class:pf-m-current="{meta.url ===
                         `/pods/${encodeURI(pod.name)}/${encodeURI(pod.engineId)}/summary`}">
                       <a
                         href="/pods/{encodeURI(pod.name)}/{encodeURI(pod.engineId)}/summary"
@@ -107,6 +120,9 @@ onDestroy(() => {
           <a href="/containers" title="Close Details" class="mt-2 mr-2 text-gray-500"
             ><i class="fas fa-times" aria-hidden="true"></i></a>
         </div>
+        <Route path="/logs">
+          <PodDetailsLogs pod="{pod}" />
+        </Route>
         <Route path="/summary">
           <PodDetailsSummary pod="{pod}" />
         </Route>

--- a/packages/renderer/src/lib/pod/PodDetailsLogs.svelte
+++ b/packages/renderer/src/lib/pod/PodDetailsLogs.svelte
@@ -1,0 +1,177 @@
+<script lang="ts">
+import { router } from 'tinro';
+import { onDestroy, onMount } from 'svelte';
+import { Terminal } from 'xterm';
+import { FitAddon } from 'xterm-addon-fit';
+import 'xterm/css/xterm.css';
+import { TerminalSettings } from '../../../../main/src/plugin/terminal-settings';
+import { getPanelDetailColor } from '../color/color';
+import type { PodInfoUI } from './PodInfoUI';
+
+export let pod: PodInfoUI;
+
+// Log
+let logsXtermDiv: HTMLDivElement;
+
+// Logs has been initialized
+let logsReady = false;
+let noLogs = true;
+let logsTerminal;
+
+// Terminal resize
+let resizeObserver: ResizeObserver;
+let termFit: FitAddon;
+let currentRouterPath: string;
+let logsRouterPath: string = `/pods/${encodeURI(pod.name)}/${encodeURI(pod.engineId)}/logs`;
+
+// Create a map that will store the ANSI 256 colour for each container name
+// Go through each container.name and create a map of the ANSI 256 colour based on the name
+const colourizedContainerName = new Map<string, string>();
+pod.containers.forEach(container => {
+  colourizedContainerName.set(container.Names, colourizeString(container.Names));
+});
+
+// Function that inputs a string and returns an ANSI 256 coloured string based on the string name
+// must use a colour that looks good against a black terminal background
+function colourizeString(str: string): string {
+  const hash = str.split('').reduce((acc, char) => {
+    return acc + char.charCodeAt(0);
+  }, 0);
+  const color = hash % 256;
+  return `\u001b[38;5;${color}m${str}\u001b[0m`;
+}
+
+// Callback for logs which will output the logs to the terminal
+function callback(name: string, data: string) {
+  if (name === 'first-message') {
+    noLogs = false;
+  } else if (name === 'data') {
+    noLogs = false;
+    // 1: STDOUT
+    // 2: STDERR
+    logsTerminal?.write(data + '\r');
+  }
+}
+
+// Fetches the logs for each container in the pod and outputs to the terminal
+async function fetchPodLogs() {
+  // Go through each name of pod.containers array and determine
+  // how much spacing is required for each name to be printed.
+  let maxNameLength = 0;
+  pod.containers.forEach(container => {
+    if (container.Names.length > maxNameLength) {
+      maxNameLength = container.Names.length;
+    }
+  });
+
+  // Go through the array of containers from pod.containers and
+  // call window.logsContainer for each container with a logs callback.
+  // We use a custom logsCallback since we are adding the container name and padding
+  // before each log output.
+  //
+  // NOTE: Podman API returns 'Names' despite being a singular name for the container.
+  pod.containers.forEach(async container => {
+    // Set a customer callback that will add the container name and padding
+    const logsCallback = (name: string, data: string) => {
+      const padding = ' '.repeat(maxNameLength - container.Names.length);
+      const colouredName = colourizedContainerName.get(container.Names);
+      callback(name, `${colouredName} ${padding} | ${data.substring(8)}`);
+    };
+
+    // Get the logs for the container and set logsReady as true
+    await window.logsContainer(pod.engineId, container.Id, logsCallback);
+    logsReady = true;
+  });
+}
+
+router.subscribe(async route => {
+  currentRouterPath = route.path;
+  if (route.path.endsWith('/logs')) {
+    await refreshTerminal();
+    fetchPodLogs();
+  }
+});
+
+async function refreshTerminal() {
+  // missing element, return
+  if (!logsXtermDiv) {
+    console.log('missing xterm div, exiting...');
+    return;
+  }
+  // grab font size
+  const fontSize = await window.getConfigurationValue<number>(
+    TerminalSettings.SectionName + '.' + TerminalSettings.FontSize,
+  );
+  const lineHeight = await window.getConfigurationValue<number>(
+    TerminalSettings.SectionName + '.' + TerminalSettings.LineHeight,
+  );
+
+  logsTerminal = new Terminal({
+    fontSize,
+    lineHeight,
+    disableStdin: true,
+    theme: {
+      background: getPanelDetailColor(),
+    },
+    convertEol: true,
+  });
+  termFit = new FitAddon();
+  logsTerminal.loadAddon(termFit);
+
+  logsTerminal.open(logsXtermDiv);
+
+  // disable cursor
+  logsTerminal.write('\x1b[?25l');
+
+  // call fit addon each time we resize the window
+  window.addEventListener('resize', () => {
+    if (currentRouterPath === logsRouterPath) {
+      termFit.fit();
+    }
+  });
+  termFit.fit();
+}
+
+onMount(async () => {
+  // Refresh the terminal on initial load
+  refreshTerminal();
+
+  // Resize the terminal each time we change the div size
+  resizeObserver = new ResizeObserver(entries => {
+    termFit?.fit();
+  });
+
+  // Observe the terminal div
+  resizeObserver.observe(logsXtermDiv);
+});
+
+onDestroy(() => {
+  // Cleanup the observer on destroy
+  resizeObserver?.unobserve(logsXtermDiv);
+});
+</script>
+
+{#if logsReady}
+  <div
+    class="h-full min-w-full flex flex-col"
+    class:hidden="{noLogs === false}"
+    style="background-color: {getPanelDetailColor()}">
+    <div class="pf-c-empty-state h-full">
+      <div class="pf-c-empty-state__content">
+        <i class="fas fa-terminal pf-c-empty-state__icon" aria-hidden="true"></i>
+
+        <h1 class="pf-c-title pf-m-lg">No Log</h1>
+
+        <div class="pf-c-empty-state__body">Log output of Pod {pod.name}</div>
+      </div>
+    </div>
+  </div>
+{/if}
+
+<div
+  class="flex flex-col"
+  style="background-color: {getPanelDetailColor()}"
+  class:h-full="{noLogs === false}"
+  class:min-w-full="{noLogs === false}"
+  bind:this="{logsXtermDiv}">
+</div>

--- a/packages/renderer/src/lib/pod/PodsList.svelte
+++ b/packages/renderer/src/lib/pod/PodsList.svelte
@@ -104,7 +104,7 @@ async function deleteSelectedPods() {
 }
 
 function openDetailsPod(pod: PodInfoUI) {
-  router.goto(`/pods/${encodeURI(pod.name)}/${encodeURI(pod.engineId)}/summary`);
+  router.goto(`/pods/${encodeURI(pod.name)}/${encodeURI(pod.engineId)}/logs`);
 }
 
 function openContainersFromPod(pod: PodInfoUI) {


### PR DESCRIPTION
feat: adds ability to view pod logs

### What does this PR do?
- When viewing a pod, logs will show all containers log outputs with the
  container name appended to the beginning
- By default, when clicking on Pod details, it will now show the pod
  logs

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

https://user-images.githubusercontent.com/6422176/210870034-d2707403-66a6-48c6-9ff8-b6f0bea8418b.mov




### What issues does this PR fix or reference?

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

Fixes 1/2 of https://github.com/containers/podman-desktop/issues/391

The other part (filter based on container name) will have to mock up
UX/UI before implementation

### How to test this PR?

<!-- Please explain steps to reproduce -->

1. Run two containers that echo the date: `podman run -d alpine sh -c
"while true; do date +%s; sleep 2; done"`
2. Podify it within Podman Desktop
3. View the Pod details
