### PR TITLE
fix: invalid badge count for images

### DIFF
--- a/packages/renderer/src/AppNavigation.svelte
+++ b/packages/renderer/src/AppNavigation.svelte
@@ -2,12 +2,19 @@
 import { imagesInfos } from './stores/images';
 import { contributions } from './stores/contribs';
 import { podsInfos } from './stores/pods';
-import { onMount } from 'svelte';
+import { onDestroy, onMount } from 'svelte';
 import { CommandRegistry } from './lib/CommandRegistry';
 import { containersInfos } from './stores/containers';
 import { volumeListInfos } from './stores/volumes';
+import { ImageUtils } from './lib/image/image-utils';
+import type { ImageInfo } from '../../main/src/plugin/api/image-info';
+import type { ImageInfoUI } from './lib/image/ImageInfoUI';
 
 let containersCountValue;
+let imageInfoSubscribe;
+let images: ImageInfoUI[] = [];
+
+const imageUtils = new ImageUtils();
 
 onMount(async () => {
   const commandRegistry = new CommandRegistry();
@@ -15,6 +22,15 @@ onMount(async () => {
   containersInfos.subscribe(value => {
     containersCountValue = value.length;
   });
+  imageInfoSubscribe = imagesInfos.subscribe(value => {
+    images = value.map((imageInfo: ImageInfo) => imageUtils.getImagesInfoUI(imageInfo, [])).flat();
+  });
+});
+
+onDestroy(() => {
+  if (imageInfoSubscribe) {
+    imageInfoSubscribe();
+  }
 });
 
 let contributionsExpanded: boolean = true;
@@ -201,7 +217,7 @@ export let meta;
             <div>
               {#if innerWidth >= 768}
                 {#if $imagesInfos.length > 0}
-                  <span class="pf-c-badge pf-m-read hidden items-center justify-center">{$imagesInfos.length}</span>
+                  <span class="pf-c-badge pf-m-read hidden items-center justify-center">{images.length}</span>
                 {/if}
               {/if}
             </div>


### PR DESCRIPTION
### What does this PR do?
if 2 images have the same tag we display two lines in images list badge count should take that into account

### Screenshot/screencast of this PR

![image](https://user-images.githubusercontent.com/436777/210958746-2ceeb499-8229-4fef-8664-d28d1720ec21.png)

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/1101

### How to test this PR?

perform:
```shell
podman pull quay.io/podman/hello
podman tag quay.io/podman/hello quay.io/podman/hello2
```

check you have a badge count of 2 and not 1

Change-Id: I9de232f51c2fa0a0811543225590fd13026ba8ec
Signed-off-by: Florent Benoit <fbenoit@redhat.com>