### PR TITLE
fix: invalid name/tag for images with registries using a different port

### DIFF
--- a/packages/renderer/src/lib/image/image-utils.spec.ts
+++ b/packages/renderer/src/lib/image/image-utils.spec.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { beforeEach, expect, test, vi } from 'vitest';
+import { describe, beforeEach, expect, test, vi } from 'vitest';
 import { ImageUtils } from './image-utils';
 
 let imageUtils: ImageUtils;
@@ -29,4 +29,24 @@ beforeEach(() => {
 test('should expect valid size', async () => {
   const size = imageUtils.getHumanSize(1000);
   expect(size).toBe('1 kB');
+});
+
+describe.each([
+  { repoTag: 'nginx:latest', expectedName: 'nginx', expectedTag: 'latest' },
+  { repoTag: 'quay.io/podman/hello:latest', expectedName: 'quay.io/podman/hello', expectedTag: 'latest' },
+  {
+    repoTag: 'my.registry:1234/podman/hello:latest',
+    expectedName: 'my.registry:1234/podman/hello',
+    expectedTag: 'latest',
+  },
+  {
+    repoTag: 'my.registry:1234/podman/hello:my-custom-tag',
+    expectedName: 'my.registry:1234/podman/hello',
+    expectedTag: 'my-custom-tag',
+  },
+])('describe object add($a, $b)', ({ repoTag, expectedName, expectedTag }) => {
+  test(`should parse correctly image ${repoTag}`, () => {
+    expect(imageUtils.getName(repoTag)).toBe(expectedName);
+    expect(imageUtils.getTag(repoTag)).toBe(expectedTag);
+  });
 });

--- a/packages/renderer/src/lib/image/image-utils.ts
+++ b/packages/renderer/src/lib/image/image-utils.ts
@@ -41,11 +41,21 @@ export class ImageUtils {
   }
 
   getName(repoTag: string) {
-    return repoTag.split(':')[0];
+    const indexTag = repoTag.lastIndexOf(':');
+    if (indexTag > 0) {
+      return repoTag.slice(0, indexTag);
+    } else {
+      return '';
+    }
   }
 
   getTag(repoTag: string) {
-    return repoTag.split(':')[1];
+    const indexTag = repoTag.lastIndexOf(':');
+    if (indexTag > 0) {
+      return repoTag.slice(indexTag + 1);
+    } else {
+      return '';
+    }
   }
 
   getEngineId(containerInfo: ImageInfo): string {


### PR DESCRIPTION
### What does this PR do?
Extract correct values for name and tag of images.

### Screenshot/screencast of this PR
![image](https://user-images.githubusercontent.com/436777/210976167-459455c0-7a0f-4786-9855-2e5524a0073f.png)


### What issues does this PR fix or reference?
fixes https://github.com/containers/podman-desktop/issues/1082

### How to test this PR?

```
podman run quay.io/podman/hello
podman tag quay.io/podman/hello my.registry:1234/podman/hello
podman tag quay.io/podman/hello my.registry:1234/podman/hello:my-custom-tag
```


Change-Id: I732938ebb365d72b8771e1b85ca23d7224c3e9f7
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
