### PR TITLE
fix: statistics area in container details

### DIFF
--- a/packages/renderer/src/lib/container/container-utils.spec.ts
+++ b/packages/renderer/src/lib/container/container-utils.spec.ts
@@ -27,6 +27,6 @@ beforeEach(() => {
 });
 
 test('should expect valid memory usage', async () => {
-  const size = containerUtils.getMemoryUsageTitle(4, 1000000);
+  const size = containerUtils.getMemoryPercentageUsageTitle(4, 1000000);
   expect(size).toBe('4.00% (1 MB)');
 });

--- a/packages/renderer/src/lib/container/container-utils.ts
+++ b/packages/renderer/src/lib/container/container-utils.ts
@@ -178,7 +178,11 @@ export class ContainerUtils {
     return Array.from(groups.values());
   }
 
-  getMemoryUsageTitle(memoryUsagePercentage: number, usedMemory: number): string {
+  getMemoryPercentageUsageTitle(memoryUsagePercentage: number, usedMemory: number): string {
     return `${memoryUsagePercentage.toFixed(2)}% (${filesize(usedMemory)})`;
+  }
+
+  getMemoryUsageTitle(usedMemory: number): string {
+    return `${filesize(usedMemory)}`;
   }
 }


### PR DESCRIPTION
### What does this PR do?
- fix random appear/disappear (was the case if cpuUsage or memoryUsage was 0)

fix other bugs around it
- always view the bars
- add initializing text field when we're collecting data
- display current memory as well on the right

### Screenshot/screencast of this PR

https://user-images.githubusercontent.com/436777/211025973-54b989c6-e756-458e-b7ac-1f5b914bc29f.mp4


### What issues does this PR fix or reference?
Fixes https://github.com/containers/podman-desktop/issues/495
Fixes https://github.com/containers/podman-desktop/issues/505


### How to test this PR?

Start a container and goes to container's details view.
