### PR TITLE
website: the linux binary is not a source, it should be promoted as a binary

### DIFF
--- a/website/src/pages/downloads/linux.tsx
+++ b/website/src/pages/downloads/linux.tsx
@@ -73,7 +73,7 @@ export function LinuxDownloads(): JSX.Element {
               className="underline inline-flex dark:text-white text-purple-600 hover:text-purple-300 py-2 px-6 font-semibold text-md"
               to={downloadData.binary}>
               <FontAwesomeIcon size="1x" icon={faDownload} className="mr-2" />
-              Source *.tar.gz
+              AMD64 binary (tar.gz)
             </Link>
           </div>
           <div className="flex flex-col align-middle items-center">

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -448,7 +448,7 @@ function RunAnywhere() {
               </Link>
 
               <div className="flex-grow">
-                <p className="text-base text-center">flatpak or zip</p>
+                <p className="text-base text-center">Flatpak or AMD64 binary (tar.gz)</p>
               </div>
             </div>
           </div>


### PR DESCRIPTION
### What does this PR do?
alternate file for linux is not called 'binary' so people might think there is only a flatpak version

### Screenshot/screencast of this PR

![image](https://user-images.githubusercontent.com/436777/211263448-40334dc1-9baf-414a-baa4-54dc2c4d314d.png)

![image](https://user-images.githubusercontent.com/436777/211263417-d0a051bb-674c-4abc-93e2-b914bf210e3d.png)

N/A 

### What issues does this PR fix or reference? https://github.com/containers/podman-desktop/issues/1132

### How to test this PR?

Look at netlify rendering

Change-Id: I4c3414c5dace72a90095239015f20157dbea12c4
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
