### PR TITLE
feat: add feedback when clicking on container list action icons

### DIFF
--- a/packages/renderer/src/lib/container/ContainerActions.svelte
+++ b/packages/renderer/src/lib/container/ContainerActions.svelte
@@ -5,7 +5,7 @@ import { faArrowsRotate } from '@fortawesome/free-solid-svg-icons';
 import { faTrash } from '@fortawesome/free-solid-svg-icons';
 import { faExternalLinkSquareAlt } from '@fortawesome/free-solid-svg-icons';
 import { ContainerGroupInfoTypeUI, ContainerInfoUI } from './ContainerInfoUI';
-import Fa from 'svelte-fa/src/fa.svelte';
+
 import { router } from 'tinro';
 import ListItemButtonIcon from '../ui/ListItemButtonIcon.svelte';
 import DropdownMenu from '../ui/DropdownMenu.svelte';
@@ -14,24 +14,51 @@ export let container: ContainerInfoUI;
 export let dropdownMenu: boolean = false;
 export let detailed: boolean = false;
 
+export let inProgressCallback: (inProgress: boolean) => void = () => {};
+export let errorCallback: (erroMessage: string) => void = () => {};
+
 async function startContainer(containerInfo: ContainerInfoUI) {
+  inProgressCallback(true);
   await window.startContainer(containerInfo.engineId, containerInfo.id);
+  inProgressCallback(false);
 }
 
 async function restartContainer(containerInfo: ContainerInfoUI) {
-  await window.restartContainer(containerInfo.engineId, containerInfo.id);
+  inProgressCallback(true);
+  try {
+    await window.restartContainer(containerInfo.engineId, containerInfo.id);
+  } catch (error) {
+    errorCallback(error);
+  } finally {
+    inProgressCallback(false);
+  }
 }
 
 async function stopContainer(containerInfo: ContainerInfoUI) {
-  await window.stopContainer(containerInfo.engineId, containerInfo.id);
+  inProgressCallback(true);
+  try {
+    await window.stopContainer(containerInfo.engineId, containerInfo.id);
+  } catch (error) {
+    errorCallback(error);
+  } finally {
+    inProgressCallback(false);
+  }
 }
+
 function openBrowser(containerInfo: ContainerInfoUI): void {
   window.openExternal(containerInfo.openingUrl);
 }
 
 async function deleteContainer(containerInfo: ContainerInfoUI): Promise<void> {
-  await window.deleteContainer(containerInfo.engineId, containerInfo.id);
-  router.goto('/containers/');
+  inProgressCallback(true);
+  try {
+    await window.deleteContainer(containerInfo.engineId, containerInfo.id);
+    router.goto('/containers/');
+  } catch (error) {
+    errorCallback(error);
+  } finally {
+    inProgressCallback(false);
+  }
 }
 function openTerminalContainer(containerInfo: ContainerInfoUI): void {
   router.goto(`/containers/${container.id}/terminal`);

--- a/packages/renderer/src/lib/container/ContainerInfoUI.ts
+++ b/packages/renderer/src/lib/container/ContainerInfoUI.ts
@@ -57,6 +57,8 @@ export interface ContainerInfoUI {
   groupInfo: ContainerGroupPartInfoUI;
   selected: boolean;
   created: number;
+  actionInProgress?: boolean;
+  actionError?: string;
 }
 
 export interface ContainerGroupInfoUI extends ContainerGroupPartInfoUI {

--- a/packages/renderer/src/lib/ui/Tooltip.svelte
+++ b/packages/renderer/src/lib/ui/Tooltip.svelte
@@ -1,0 +1,51 @@
+<style>
+.tooltip.top {
+  left: 50%;
+  transform: translate(-50%, -100%);
+  margin-top: -8px;
+}
+.tooltip.bottom {
+  left: 50%;
+  bottom: 0;
+  transform: translate(-50%, 100%);
+  margin-bottom: -8px;
+}
+.tooltip.left {
+  left: 0;
+  transform: translateX(-100%);
+  margin-left: -8px;
+}
+.tooltip.right {
+  right: 0;
+  transform: translateX(100%);
+  margin-right: -8px;
+}
+.tooltip-slot:hover + .tooltip {
+  opacity: 1;
+  visibility: initial;
+}
+</style>
+
+<script>
+export let tip = '';
+export let top = false;
+export let right = false;
+export let bottom = false;
+export let left = false;
+</script>
+
+<div class="relative inline-block">
+  <span class="group tooltip-slot">
+    <slot />
+  </span>
+  <div
+    class="whitespace-nowrap absolute tooltip opacity-0 inline-block transition-opacity duration-150 ease-in-out"
+    class:left="{left}"
+    class:right="{right}"
+    class:bottom="{bottom}"
+    class:top="{top}">
+    {#if tip}
+      <div class="inline-block py-2 px-4 rounded-md bg-zinc-900 text-xs">{tip}</div>
+    {/if}
+  </div>
+</div>


### PR DESCRIPTION
### What does this PR do?
Add inProgress state and error feedback when clicking on container list actions


### Screenshot/screencast of this PR

https://user-images.githubusercontent.com/436777/211531610-2347d302-4918-46ae-a5a2-c80fac0314f5.mp4

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/1013

### How to test this PR?

Click on container list actions and look at the spinner/progress or error tooltip


Change-Id: I0c6e55169723a09d6cbb00f971adcb7e66bf5ef4
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
