### PR TITLE
fix: do not use long calls for external clients

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -720,13 +720,6 @@ declare module '@tmpwip/extension-api' {
     engineId: string;
     engineName: string;
     engineType: 'podman' | 'docker';
-    StartedAt: string;
-    pod?: {
-      id: string;
-      name: string;
-      status: string;
-      engineId: string;
-    };
     Id: string;
     Names: string[];
     Image: string;

--- a/packages/main/src/plugin/api/container-info.ts
+++ b/packages/main/src/plugin/api/container-info.ts
@@ -31,6 +31,12 @@ export interface ContainerInfo extends Dockerode.ContainerInfo {
   };
 }
 
+export interface SimpleContainerInfo extends Dockerode.ContainerInfo {
+  engineId: string;
+  engineName: string;
+  engineType: 'podman' | 'docker';
+}
+
 export interface HostConfig {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   PortBindings?: any;

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -440,7 +440,7 @@ export class ExtensionLoader {
     const containerProviderRegistry = this.containerProviderRegistry;
     const containerEngine: typeof containerDesktopAPI.containerEngine = {
       listContainers(): Promise<containerDesktopAPI.ContainerInfo[]> {
-        return containerProviderRegistry.listContainers();
+        return containerProviderRegistry.listSimpleContainers();
       },
       inspectContainer(engineId: string, id: string): Promise<containerDesktopAPI.ContainerInspectInfo> {
         return containerProviderRegistry.getContainerInspect(engineId, id);

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -40,7 +40,7 @@ import type {
 } from './api/provider-info';
 import type { WebContents } from 'electron';
 import { ipcMain, BrowserWindow } from 'electron';
-import type { ContainerCreateOptions, ContainerInfo } from './api/container-info';
+import type { ContainerCreateOptions, ContainerInfo, SimpleContainerInfo } from './api/container-info';
 import type { ImageInfo } from './api/image-info';
 import type { PullEvent } from './api/pull-event';
 import type { ExtensionInfo } from './api/extension-info';
@@ -321,6 +321,9 @@ export class PluginSystem {
     const contributionManager = new ContributionManager(apiSender);
     this.ipcHandle('container-provider-registry:listContainers', async (): Promise<ContainerInfo[]> => {
       return containerProviderRegistry.listContainers();
+    });
+    this.ipcHandle('container-provider-registry:listSimpleContainers', async (): Promise<SimpleContainerInfo[]> => {
+      return containerProviderRegistry.listSimpleContainers();
     });
     this.ipcHandle('container-provider-registry:listImages', async (): Promise<ImageInfo[]> => {
       return containerProviderRegistry.listImages();


### PR DESCRIPTION
### What does this PR do?
Clients may call the method every seconds so we should not make the call doing long tasks like aggregating results or fetching inspect data

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop/issues/1123

### How to test this PR?

Should behave as before for Podman Desktop

Change-Id: I02ef5dd70b2b0b6af5f010d4135555537b7e4376
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
