### PR TITLE
feat: Clicking on the Pod name should redirect to the Pod details page

### DIFF
--- a/packages/renderer/src/lib/ContainerList.svelte
+++ b/packages/renderer/src/lib/ContainerList.svelte
@@ -245,6 +245,12 @@ function keydownChoice(e: KeyboardEvent) {
   }
 }
 
+function openGroupDetails(containerGroup: ContainerGroupInfoUI): void {
+  if (containerGroup.type === ContainerGroupInfoTypeUI.POD) {
+    router.goto(`/pods/${encodeURI(containerGroup.name)}/${encodeURI(containerGroup.engineId)}/logs`);
+  }
+}
+
 function toggleCreateContainer(): void {
   openChoiceModal = !openChoiceModal;
 }
@@ -386,7 +392,10 @@ function errorCallback(container: ContainerInfoUI, errorMessage: string): void {
               <td class="whitespace-nowrap hover:cursor-pointer">
                 <div class="flex items-center text-sm text-gray-200 overflow-hidden text-ellipsis">
                   <div class="flex flex-col flex-nowrap">
-                    <div class="text-sm text-gray-200 overflow-hidden text-ellipsis" title="{containerGroup.type}">
+                    <div
+                      class="text-sm text-gray-200 overflow-hidden text-ellipsis"
+                      title="{containerGroup.type}"
+                      on:click="{() => openGroupDetails(containerGroup)}">
                       {containerGroup.name} ({containerGroup.type})
                     </div>
                     <div class="text-xs font-extra-light text-gray-500">


### PR DESCRIPTION
### What does this PR do?
Clicking on the Pod name in container list page should redirect to the Pod details page

### Screenshot/screencast of this PR


https://user-images.githubusercontent.com/436777/211770946-2255f39f-7e2e-48ad-9ead-bcbfe6a115a7.mp4



### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/1119


### How to test this PR?

Follow issue steps

Change-Id: I15c7be152393e3eaf7023b0461caaebda9fab9f0
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
