### PR TITLE
feat: allows to change the font size for the editor

### DIFF
--- a/packages/main/src/plugin/editor-init.ts
+++ b/packages/main/src/plugin/editor-init.ts
@@ -1,0 +1,43 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { IConfigurationNode, IConfigurationRegistry } from './configuration-registry';
+import { EditorSettings } from './editor-settings';
+
+export class EditorInit {
+  constructor(private configurationRegistry: IConfigurationRegistry) {}
+
+  init() {
+    const editorPlatformConfiguration: IConfigurationNode = {
+      id: 'preferences.editor',
+      title: 'Editor',
+      type: 'object',
+      properties: {
+        [EditorSettings.SectionName + '.' + EditorSettings.FontSize]: {
+          description: 'Editor font size, in pixels.',
+          type: 'number',
+          default: 10,
+          minimum: 6,
+          maximum: 100,
+        },
+      },
+    };
+
+    this.configurationRegistry.registerConfigurations([editorPlatformConfiguration]);
+  }
+}

--- a/packages/main/src/plugin/editor-settings.ts
+++ b/packages/main/src/plugin/editor-settings.ts
@@ -1,0 +1,22 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+export enum EditorSettings {
+  SectionName = 'editor',
+  FontSize = 'integrated.fontSize',
+}

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -79,6 +79,7 @@ import type { NetworkInspectInfo } from './api/network-info';
 import { FilesystemMonitoring } from './filesystem-monitoring';
 import { Certificates } from './certificates';
 import { Proxy } from './proxy';
+import { EditorInit } from './editor-init';
 
 type LogType = 'log' | 'warn' | 'trace' | 'debug' | 'error';
 export class PluginSystem {
@@ -300,6 +301,10 @@ export class PluginSystem {
 
     const terminalInit = new TerminalInit(configurationRegistry);
     terminalInit.init();
+
+    // init editor configuration
+    const editorInit = new EditorInit(configurationRegistry);
+    editorInit.init();
 
     this.extensionLoader = new ExtensionLoader(
       commandRegistry,

--- a/packages/renderer/src/lib/editor/MonacoEditor.svelte
+++ b/packages/renderer/src/lib/editor/MonacoEditor.svelte
@@ -2,6 +2,7 @@
 import { onMount } from 'svelte';
 import editorWorker from 'monaco-editor/esm/vs/editor/editor.worker?worker';
 import jsonWorker from 'monaco-editor/esm/vs/language/json/json.worker?worker';
+import { EditorSettings } from '../../../../main/src/plugin/editor-settings';
 
 import type monaco from 'monaco-editor';
 import { getPanelDetailColor } from '../color/color';
@@ -26,6 +27,11 @@ onMount(async () => {
 
   Monaco = await import('monaco-editor');
 
+  // grab font size
+  const fontSize = await window.getConfigurationValue<number>(
+    EditorSettings.SectionName + '.' + EditorSettings.FontSize,
+  );
+
   Monaco.editor.defineTheme('podmanDesktopTheme', {
     base: 'vs-dark',
     inherit: true,
@@ -37,7 +43,7 @@ onMount(async () => {
 
   editor = Monaco.editor.create(divEl, {
     value: content,
-    fontSize: '10px',
+    fontSize,
     language,
     readOnly: true,
     theme: 'podmanDesktopTheme',


### PR DESCRIPTION
### What does this PR do?
Allows to change the default font size for the editor

### Screenshot/screencast of this PR

https://user-images.githubusercontent.com/436777/211778161-130ff733-b2ca-4306-bea3-d031196c3b29.mp4



### What issues does this PR fix or reference?
fixes https://github.com/containers/podman-desktop/issues/1094


### How to test this PR?

Go to settings page and change the font size of the editor
now, goes back to inspect view for example and check that the font size has changed

Change-Id: Id75530c647d981b313f199d0b9ac91de7d261a51
Signed-off-by: Florent Benoit <fbenoit@redhat.com>

