### PR TITLE
feat: Better feedback for containers that exit immediately

### DIFF
--- a/packages/renderer/src/lib/ContainerDetails.svelte
+++ b/packages/renderer/src/lib/ContainerDetails.svelte
@@ -13,6 +13,9 @@ import ContainerDetailsInspect from './ContainerDetailsInspect.svelte';
 import { getPanelDetailColor } from './color/color';
 import ContainerDetailsKube from './ContainerDetailsKube.svelte';
 import ContainerStatistics from './container/ContainerStatistics.svelte';
+import Tooltip from './ui/Tooltip.svelte';
+import Fa from 'svelte-fa/src/fa.svelte';
+import { faExclamationCircle } from '@fortawesome/free-solid-svg-icons';
 
 export let containerID: string;
 
@@ -27,6 +30,18 @@ onMount(() => {
     }
   });
 });
+
+function inProgressCallback(inProgress: boolean, state: string): void {
+  container.actionInProgress = inProgress;
+  if (state && inProgress) {
+    container.state = 'STARTING';
+  }
+}
+
+function errorCallback(errorMessage: string): void {
+  container.actionError = errorMessage;
+  container.state = 'ERROR';
+}
 </script>
 
 {#if container}
@@ -115,7 +130,33 @@ onMount(() => {
           </div>
           <div class="flex flex-col w-full px-5 pt-5">
             <div class="flex justify-end">
-              <ContainerActions container="{container}" detailed="{true}" />
+              <div class="flex items-center w-5">
+                {#if container.actionInProgress}
+                  <svg
+                    class="animate-spin -ml-1 mr-3 h-5 w-5 text-white"
+                    xmlns="http://www.w3.org/2000/svg"
+                    fill="none"
+                    viewBox="0 0 24 24">
+                    <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                    <path
+                      class="opacity-75"
+                      fill="currentColor"
+                      d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                    ></path>
+                  </svg>
+                {:else if container.actionError}
+                  <Tooltip tip="{container.actionError}" top>
+                    <Fa size="18" class="cursor-pointer text-red-500" icon="{faExclamationCircle}" />
+                  </Tooltip>
+                {:else}
+                  <div>&nbsp;</div>
+                {/if}
+              </div>
+              <ContainerActions
+                inProgressCallback="{(flag, state) => inProgressCallback(flag, state)}"
+                errorCallback="{error => errorCallback(error)}"
+                container="{container}"
+                detailed="{true}" />
             </div>
             <div class="flex my-2 w-full justify-end ">
               <ContainerStatistics container="{container}" />

--- a/packages/renderer/src/lib/ContainerIcon.svelte
+++ b/packages/renderer/src/lib/ContainerIcon.svelte
@@ -2,7 +2,50 @@
 export let state = '';
 </script>
 
-{#if state === 'RUNNING'}
+{#if state === 'STARTING'}
+  <div class="flex flex-col justify-center align-middle">
+    <svg
+      width="24"
+      height="24"
+      version="1.1"
+      viewBox="0 0 6.35 6.35"
+      xml:space="preserve"
+      xmlns="http://www.w3.org/2000/svg"
+      xmlns:xlink="http://www.w3.org/1999/xlink"
+      ><g transform="translate(28.585 -26.647)"
+        ><g transform="matrix(.26458 0 0 .26458 -29.906 26.92)" fill="none"
+          ><g transform="matrix(.90909 0 0 .90909 1.5451 .99685)" stroke-width="1.1"
+            ><path
+              d="m8.0765-0.034671h17.838c1.1528 0 2.0809 1.0604 2.0809 2.3776v17.245c0 1.3172-0.92807 2.3776-2.0809 2.3776h-17.838c-1.1528 0-2.0809-1.0604-2.0809-2.3776v-17.245c0-1.3172 0.92807-2.3776 2.0809-2.3776z"
+              fill="#42544d"
+              stroke-linecap="round"
+              stroke-linejoin="round"></path
+            ><g transform="translate(.64282 -1.0347)" rx="0" ry="0" stroke-width="1.1"
+              ><g transform="translate(1.3528)" stroke-width="1.1"
+                ><g stroke-width="1.1"
+                  ><path
+                    rx="0"
+                    ry="0"
+                    d="m13 6.5c0-0.828 0.672-1.5 1.5-1.5h1c0.828 0 1.5 0.672 1.5 1.5v11c0 0.828-0.672 1.5-1.5 1.5h-1c-0.828 0-1.5-0.672-1.5-1.5zm-5 6c0-0.828 0.672-1.5 1.5-1.5h1c0.828 0 1.5 0.672 1.5 1.5v5c0 0.828-0.672 1.5-1.5 1.5h-1c-0.828 0-1.5-0.672-1.5-1.5zm12.5-5.5c0.828 0 1.5 0.672 1.5 1.5v9c0 0.828-0.672 1.5-1.5 1.5h-1c-0.828 0-1.5-0.672-1.5-1.5v-9c0-0.828 0.672-1.5 1.5-1.5z"
+                    fill="#fff"
+                    stroke-width="1.1"></path
+                  ></g
+                ></g
+              ></g
+            ></g
+          ><g
+            transform="matrix(.75157 0 0 .75157 63.838 -3.9997)"
+            fill="#b6b6b6"
+            stroke-width="1.3305"
+            style="-webkit-print-color-adjust:exact"
+            ><g transform="translate(-3.2856 8.5688)" rx="0" ry="0" fill="#b6b6b6" stroke-width="1.3305"
+              ><g rx="0" ry="0" fill="#b6b6b6" stroke-width="1.3305"><g fill="#b6b6b6" stroke-width="1.3305"></g></g></g
+            ></g
+          ></g
+        ></g
+      ></svg>
+  </div>
+{:else if state === 'RUNNING'}
   <div class="flex flex-col justify-center align-middle">
     <svg
       id="running"

--- a/packages/renderer/src/lib/ContainerList.svelte
+++ b/packages/renderer/src/lib/ContainerList.svelte
@@ -273,17 +273,22 @@ function toggleAllContainerGroups(value: boolean) {
   containerGroups = toggleContainers;
 }
 
-function inProgressCallback(container: ContainerInfoUI, inProgress: boolean): void {
+function inProgressCallback(container: ContainerInfoUI, inProgress: boolean, state?: string): void {
   container.actionInProgress = inProgress;
   // reset error when starting task
   if (inProgress) {
     container.actionError = '';
   }
+  if (state) {
+    container.state = state;
+  }
+
   containerGroups = [...containerGroups];
 }
 
 function errorCallback(container: ContainerInfoUI, errorMessage: string): void {
   container.actionError = errorMessage;
+  container.state = 'ERROR';
   containerGroups = [...containerGroups];
 }
 </script>
@@ -518,7 +523,7 @@ function errorCallback(container: ContainerInfoUI, errorMessage: string): void {
                     <div class="text-right w-full">
                       <ContainerActions
                         errorCallback="{error => errorCallback(container, error)}"
-                        inProgressCallback="{flag => inProgressCallback(container, flag)}"
+                        inProgressCallback="{(flag, state) => inProgressCallback(container, flag, state)}"
                         container="{container}"
                         dropdownMenu="{true}" />
                     </div>

--- a/packages/renderer/src/lib/container/ContainerActions.svelte
+++ b/packages/renderer/src/lib/container/ContainerActions.svelte
@@ -14,17 +14,22 @@ export let container: ContainerInfoUI;
 export let dropdownMenu: boolean = false;
 export let detailed: boolean = false;
 
-export let inProgressCallback: (inProgress: boolean) => void = () => {};
+export let inProgressCallback: (inProgress: boolean, state?: string) => void = () => {};
 export let errorCallback: (erroMessage: string) => void = () => {};
 
 async function startContainer(containerInfo: ContainerInfoUI) {
-  inProgressCallback(true);
-  await window.startContainer(containerInfo.engineId, containerInfo.id);
-  inProgressCallback(false);
+  inProgressCallback(true, 'STARTING');
+  try {
+    await window.startContainer(containerInfo.engineId, containerInfo.id);
+  } catch (error) {
+    errorCallback(error);
+  } finally {
+    inProgressCallback(false);
+  }
 }
 
 async function restartContainer(containerInfo: ContainerInfoUI) {
-  inProgressCallback(true);
+  inProgressCallback(true, 'RESTARTING');
   try {
     await window.restartContainer(containerInfo.engineId, containerInfo.id);
   } catch (error) {


### PR DESCRIPTION
### What does this PR do?
Following the fix for https://github.com/containers/podman-desktop/issues/1013, add feedback for the details of containers as well.
Include report of error and for short-lived containers


### Screenshot/screencast of this PR

https://user-images.githubusercontent.com/436777/211831905-ebf596d5-efc8-4f55-8cb8-3f31655388b9.mp4



### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/504


### How to test this PR?

In Container list, start for example quay.io/podman/hello multiple times. Icons and status is changed to STARTING
Go to details of a page, you can see spinner and status changing as well when starting again the container


Change-Id: Iadc90864dab9bd77d7efd4b11ca0867e823ec883
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
