### PR TITLE
docs: Introducing tabs for operatings systems and container engines

### DIFF
--- a/website/docs/migrating-from-docker/importing-saved-containers.md
+++ b/website/docs/migrating-from-docker/importing-saved-containers.md
@@ -6,6 +6,9 @@ keywords: [podman desktop, podman, containers, importing]
 tags: [migrating-from-docker]
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 # Importing saved containers to Podman
 
 Consider importing saved containers to continue using familiar containers.
@@ -13,16 +16,25 @@ Consider importing saved containers to continue using familiar containers.
 #### Prerequisites
 
 * Podman
-* You saved your existing Docker containers by running the command:
+
+* You saved your existing containers by running the command:
+
+  <Tabs groupId="container-engines">
+    <TabItem value="podman" label="Podman">
+
+    ```shell-session
+    $ podman save <your_container> > <your_container_archive>.tar 
+    ```
+
+    </TabItem>
+    <TabItem value="docker" label="Docker">
 
     ```shell-session
     $ docker save <your_container> > <your_container_archive>.tar
     ```
-* You saved your existing Podman containers by running the command:
 
-    ```shell-session
-    $ podman save <your_container> > <your_container_archive>.tar
-    ```
+    </TabItem>
+  </Tabs>
 
 #### Procedure
 

--- a/website/docs/migrating-from-docker/using-the-docker_host-environment-variable.md
+++ b/website/docs/migrating-from-docker/using-the-docker_host-environment-variable.md
@@ -6,6 +6,9 @@ keywords: [podman desktop, podman, containers, docker_host, environment, variabl
 tags: [migrating-from-docker]
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 # Using the `DOCKER_HOST` environment variable
 
 Consider using the `DOCKER_HOST` environment variable to migrate transparently from Docker to Podman Desktop on all platforms.
@@ -20,20 +23,31 @@ Consider using the `DOCKER_HOST` environment variable to migrate transparently f
 
 #### Procedure
 
-1. Identify the location of your Podman socket:
+1. Identify the location of your Podman socket
 
-  
-    * On Linux:
-   
-      ```shell-session
-      $ podman info --format '{{.Host.RemoteSocket.Path}}'
-      ```
-
-    * On macOS and Windows:
+    <Tabs groupId="operating-systems">
+      <TabItem value="win" label="Windows">
 
       ```shell-session
       $ podman machine inspect --format '{{.ConnectionInfo.PodmanSocket.Path}}'
       ```
+
+      </TabItem>
+      <TabItem value="mac" label="macOS">
+
+      ```shell-session
+      $ podman machine inspect --format '{{.ConnectionInfo.PodmanSocket.Path}}'
+      ```
+
+      </TabItem>
+      <TabItem value="linux" label="Linux">
+
+      ```shell-session
+      $ podman info --format '{{.Host.RemoteSocket.Path}}'
+      ```
+
+      </TabItem>
+    </Tabs>
 
 2. Set the `DOCKER_HOST` environment variable to your Podman socker location:
 

--- a/website/docs/migrating-from-docker/verifying-your-tools-are-using-podman.md
+++ b/website/docs/migrating-from-docker/verifying-your-tools-are-using-podman.md
@@ -6,6 +6,9 @@ keywords: [podman desktop, podman, containers, migrating, docker]
 tags: [migrating-from-docker]
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 # Verifying that your tools are using Podman
 
 When you have configured your host to use Podman rather then Docker, consider verifying your setup works as intended.
@@ -22,31 +25,53 @@ When you have configured your host to use Podman rather then Docker, consider ve
 
 1. The Docker socket replies successfully for listing all containers:
 
+    <Tabs groupId="operating-systems">
+      <TabItem value="win" label="Windows">
 
-    * On Linux and macOS
-    
-      ```shell-session
-      $ curl --unix-socket /var/run/docker.sock "http:/v1.41/containers/json?all=true"
-      ```
-
-    * On Windows
-    
       ```shell-session
       $ curl --unix-socket npipe:////./pipe/docker_engine "http:/v1.41/containers/json?all=true"
       ```
 
+      </TabItem>
+      <TabItem value="mac" label="macOS">
+
+      ```shell-session
+      $ curl --unix-socket /var/run/docker.sock "http:/v1.41/containers/json?all=true"
+      ```
+
+      </TabItem>
+      <TabItem value="linux" label="Linux">
+
+      ```shell-session
+      $ curl --unix-socket /var/run/docker.sock "http:/v1.41/containers/json?all=true"
+      ```
+
+      </TabItem>
+    </Tabs>
+
 
 2. Podman commands run successfully when redirected to the Docker socket:
 
-    * On Linux and macOS
-    
-      ```shell-session
-      $ CONTAINER_HOST=/var/run/docker.sock podman ps
-      ```
+    <Tabs groupId="operating-systems">
+      <TabItem value="win" label="Windows">
 
-    * On Windows
-    
       ```shell-session
       $ CONTAINER_HOST=npipe:////./pipe/docker_engine podman ps
       ```
 
+      </TabItem>
+      <TabItem value="mac" label="macOS">
+
+      ```shell-session
+      $ CONTAINER_HOST=/var/run/docker.sock podman ps
+      ```
+
+      </TabItem>
+      <TabItem value="linux" label="Linux">
+
+      ```shell-session
+      $ CONTAINER_HOST=/var/run/docker.sock podman ps
+      ```
+
+      </TabItem>
+    </Tabs>


### PR DESCRIPTION
docs: Introducing tabs for operatings systems and container engines

fixes: https://github.com/containers/podman-desktop/issues/1036

references: https://github.com/containers/podman-desktop/issues/1036

Signed-off-by: Fabrice Flore-Thébault <ffloreth@redhat.com>


![Screenshot from 2023-01-11 16-25-17](https://user-images.githubusercontent.com/243761/211845796-3d18b48d-5529-4f55-9935-9d3d6df4e5cf.png)
![Screenshot from 2023-01-11 16-25-12](https://user-images.githubusercontent.com/243761/211845799-0cbf62ad-109b-4e5f-955b-5e9508e80c80.png)
![Screenshot from 2023-01-11 16-25-08](https://user-images.githubusercontent.com/243761/211845801-6ab265cd-f202-43fb-bd25-7e860ea5c74d.png)
![Screenshot from 2023-01-11 16-24-57](https://user-images.githubusercontent.com/243761/211845805-80709e6d-2a0e-46ee-b7fc-819b0f3cddf5.png)
![Screenshot from 2023-01-11 16-24-52](https://user-images.githubusercontent.com/243761/211845809-1e6d50c6-93e9-417b-afc0-456f3724978f.png)
![Screenshot from 2023-01-11 16-24-26](https://user-images.githubusercontent.com/243761/211845810-f89886db-6841-41e1-97f4-7c2e1e31da0e.png)


