### PR TITLE
docs: document where code is located within Podman Desktop

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -217,7 +217,7 @@ Below are brief descriptions on the architecture on each folder of Podman Deskto
 
 If you're unsure where to add code (renderer, UI, extensions, plugins) see the below TLDR:
 
-* `__mocks__/@tmpwip`: Mock API tests for Vitest `@tmpwip` package.
+* `__mocks__/`: Mock packages for Vitest.
 * `buildResources`: Podman Desktop logo location / build resources for electron
 * `extensions`: We separate functionality into separate "extensions" to keep Podman Desktop modular. Here you'll find extensions such as Kubernetes, CRC, Podman and Docker functionality that Podman Desktop interacts with and integrates into the API (see `packages/extension-api`). Examples include `extensions/crc`, `extensions/podman`, `extensions/docker`.
 * `packages/extension-api`: The extension API for extensions such as `extensions/podman` to interact with the Podman Desktop GUI. This API acts as a "middleware" to the main Electron functionality such as displaying notifications, progress messages, configuration changes, etc.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,7 @@ that we follow.
 * [Continuous Integration](#continuous-integration)
 * [Submitting Pull Requests](#submitting-pull-requests)
 * [Communication](#communication)
+* [Code Architecture](#code-architecture)
 
 ## Reporting Issues
 
@@ -209,3 +210,23 @@ You can follow these jobs in Github Actions https://github.com/containers/podman
 For bugs/feature requests please [file issues](https://github.com/containers/podman-desktop/issues/new/choose)
 
 Discussions are possible using Github Discussions https://github.com/containers/podman-desktop/discussions/
+
+## Code Architecture
+
+Below are brief descriptions on the architecture on each folder of Podman Desktop and how it's organized.
+
+If you're unsure where to add code (renderer, UI, extensions, plugins) see the below TLDR:
+
+* `__mocks__/@tmpwip`: Mock API tests for Vitest `@tmpwip` package.
+* `buildResources`: Podman Desktop logo location / build resources for electron
+* `extensions`: We separate functionality into separate "extensions" to keep Podman Desktop modular. Here you'll find extensions such as Kubernetes, CRC, Podman and Docker functionality that Podman Desktop interacts with and integrates into the API (see `packages/extension-api`). Examples include `extensions/crc`, `extensions/podman`, `extensions/docker`.
+* `packages/extension-api`: The extension API for extensions such as `extensions/podman` to interact with the Podman Desktop GUI. This API acts as a "middleware" to the main Electron functionality such as displaying notifications, progress messages, configuration changes, etc.
+* `packages/main`: Electron process code that is responsible for creating the app's main windows, setting up system events and communicating with other processes
+* `packages/preload`: Electron code that runs before the page gets rendered. Typically has access to APIs and used to setup communication processes between the main and renderer code.
+* `packages/preload-docker-extension`: Electron preload code specific to the Docker extension.
+* `packages/renderer`: Electron code that runs in the renderer process. The renderer runs separate to the main process and is responsible for typically rendering the main pages of Podman Desktop. Typically, this is where you find the `.svelte` code that renders the main Podman Desktop UI.
+* `scripts`: Scripts Podman Desktop requires such as `yarn watch` functionality and updating Electron vendorered modules.
+* `tests`: Contains e2e tests for Podman Desktop.
+* `types`: Additional types required for Vitest.
+* `website`: The documentation as well as [Podman Desktop website](https://podman-desktop.io) developed in [Docusaurus](https://docusaurus.io).
+* `node_modules`: Location for Node.JS packages / dependencies.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -227,6 +227,6 @@ If you're unsure where to add code (renderer, UI, extensions, plugins) see the b
 * `packages/renderer`: Electron code that runs in the renderer process. The renderer runs separate to the main process and is responsible for typically rendering the main pages of Podman Desktop. Typically, this is where you find the `.svelte` code that renders the main Podman Desktop UI.
 * `scripts`: Scripts Podman Desktop requires such as `yarn watch` functionality and updating Electron vendorered modules.
 * `tests`: Contains e2e tests for Podman Desktop.
-* `types`: Additional types required for Vitest.
+* `types`: Additional types required for TypeScript.
 * `website`: The documentation as well as [Podman Desktop website](https://podman-desktop.io) developed in [Docusaurus](https://docusaurus.io).
 * `node_modules`: Location for Node.JS packages / dependencies.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -223,7 +223,7 @@ If you're unsure where to add code (renderer, UI, extensions, plugins) see the b
 * `packages/extension-api`: The extension API for extensions such as `extensions/podman` to interact with the Podman Desktop GUI. This API acts as a "middleware" to the main Electron functionality such as displaying notifications, progress messages, configuration changes, etc.
 * `packages/main`: Electron process code that is responsible for creating the app's main windows, setting up system events and communicating with other processes
 * `packages/preload`: Electron code that runs before the page gets rendered. Typically has access to APIs and used to setup communication processes between the main and renderer code.
-* `packages/preload-docker-extension`: Electron preload code specific to the Docker extension.
+* `packages/preload-docker-extension`: Electron preload code specific to the Docker Desktop extension.
 * `packages/renderer`: Electron code that runs in the renderer process. The renderer runs separate to the main process and is responsible for typically rendering the main pages of Podman Desktop. Typically, this is where you find the `.svelte` code that renders the main Podman Desktop UI.
 * `scripts`: Scripts Podman Desktop requires such as `yarn watch` functionality and updating Electron vendorered modules.
 * `tests`: Contains e2e tests for Podman Desktop.


### PR DESCRIPTION
docs: document where code is located within Podman Desktop

### What does this PR do?

Documents what goes go where within Podman Desktop. For example, we use
`extensions` extensively and the `tmpwip` module, but it's not
documented.

This helps for future contributors (and onboarding developers) what code
is located where.

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

N/A

### What issues does this PR fix or reference?

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

N/A

### How to test this PR?

N/A

<!-- Please explain steps to reproduce -->

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
