### PR TITLE
docs: add notes on extension and frameworks/tooling of Podman Desktop

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -213,6 +213,19 @@ Discussions are possible using Github Discussions https://github.com/containers/
 
 ## Code Architecture
 
+### Frameworks and tooling
+
+Within Podman Desktop, we use the following frameworks and tools to build the desktop application:
+* [Electron](https://www.electronjs.org/): In order to deploy cross-platform to multiple operating systems.
+* [Svelte](https://svelte.dev/): The reactive UI/UX framework for building the interface.
+* [Tailwind CSS](https://tailwindcss.com/): A utility-first CSS framework for the UI/UX framework.
+* [Vite](https://vitejs.dev/): Dev tooling for rapid development, debugging and deployment.
+
+> **_NOTE:_**  We also use TypeScript instead of JavaScript for strongly typed programming language development.
+
+
+### Folders
+
 Below are brief descriptions on the architecture on each folder of Podman Desktop and how it's organized.
 
 If you're unsure where to add code (renderer, UI, extensions, plugins) see the below TLDR:
@@ -224,9 +237,11 @@ If you're unsure where to add code (renderer, UI, extensions, plugins) see the b
 * `packages/main`: Electron process code that is responsible for creating the app's main windows, setting up system events and communicating with other processes
 * `packages/preload`: Electron code that runs before the page gets rendered. Typically has access to APIs and used to setup communication processes between the main and renderer code.
 * `packages/preload-docker-extension`: Electron preload code specific to the Docker Desktop extension.
-* `packages/renderer`: Electron code that runs in the renderer process. The renderer runs separate to the main process and is responsible for typically rendering the main pages of Podman Desktop. Typically, this is where you find the `.svelte` code that renders the main Podman Desktop UI.
-* `scripts`: Scripts Podman Desktop requires such as `yarn watch` functionality and updating Electron vendorered modules.
+* `packages/renderer`: Electron code that runs in the renderer process. The renderer runs separate to the main process and is responsible for typically rendering the main pages of Podman Desktop. Typically, this is where you find the `.svelte` code that renders the main Podman Desktop UI.  * `scripts`: Scripts Podman Desktop requires such as `yarn watch` functionality and updating Electron vendorered modules.
 * `tests`: Contains e2e tests for Podman Desktop.
 * `types`: Additional types required for TypeScript.
 * `website`: The documentation as well as [Podman Desktop website](https://podman-desktop.io) developed in [Docusaurus](https://docusaurus.io).
 * `node_modules`: Location for Node.JS packages / dependencies.
+
+
+> **_NOTE:_** Each `extension` folder is a separately packaged module. If there are any issues with loading, make sure your module is packaged correctly.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -237,7 +237,8 @@ If you're unsure where to add code (renderer, UI, extensions, plugins) see the b
 * `packages/main`: Electron process code that is responsible for creating the app's main windows, setting up system events and communicating with other processes
 * `packages/preload`: Electron code that runs before the page gets rendered. Typically has access to APIs and used to setup communication processes between the main and renderer code.
 * `packages/preload-docker-extension`: Electron preload code specific to the Docker Desktop extension.
-* `packages/renderer`: Electron code that runs in the renderer process. The renderer runs separate to the main process and is responsible for typically rendering the main pages of Podman Desktop. Typically, this is where you find the `.svelte` code that renders the main Podman Desktop UI.  * `scripts`: Scripts Podman Desktop requires such as `yarn watch` functionality and updating Electron vendorered modules.
+* `packages/renderer`: Electron code that runs in the renderer process. The renderer runs separate to the main process and is responsible for typically rendering the main pages of Podman Desktop. Typically, this is where you find the `.svelte` code that renders the main Podman Desktop UI.
+* `scripts`: Scripts Podman Desktop requires such as `yarn watch` functionality and updating Electron vendorered modules.
 * `tests`: Contains e2e tests for Podman Desktop.
 * `types`: Additional types required for TypeScript.
 * `website`: The documentation as well as [Podman Desktop website](https://podman-desktop.io) developed in [Docusaurus](https://docusaurus.io).


### PR DESCRIPTION
docs: add notes on extension and frameworks/tooling of Podman Desktop

### What does this PR do?

Issues regarding developing extensions has been brought up in the past.
This PR adds a note regarding the extension folder as well as explains
the frameworks and tooling behind Podman Desktop.

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

N/A

### What issues does this PR fix or reference?

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

N/A

### How to test this PR?

N/A
<!-- Please explain steps to reproduce -->

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
