### PR TITLE
chore: update mkdirp to v2.0.0

### DIFF
--- a/extensions/crc/package.json
+++ b/extensions/crc/package.json
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "7zip-min": "^1.4.3",
-    "mkdirp": "^1.0.4",
+    "mkdirp": "^2.0.0",
     "zip-local": "^0.3.5"
   }
 }

--- a/extensions/crc/scripts/build.js
+++ b/extensions/crc/scripts/build.js
@@ -20,7 +20,7 @@
 const zipper = require('zip-local');
 const path = require('path');
 const package = require('../package.json');
-const mkdirp = require('mkdirp');
+const { mkdirp } = require('mkdirp');
 const fs = require('fs');
 
 const destFile = path.resolve(__dirname, `../${package.name}.cdix`);

--- a/extensions/docker/package.json
+++ b/extensions/docker/package.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "7zip-min": "^1.4.3",
-    "mkdirp": "^1.0.4",
+    "mkdirp": "^2.0.0",
     "zip-local": "^0.3.5"
   }
 }

--- a/extensions/docker/scripts/build.js
+++ b/extensions/docker/scripts/build.js
@@ -20,7 +20,7 @@
 const zipper = require('zip-local');
 const path = require('path');
 const package = require('../package.json');
-const mkdirp = require('mkdirp');
+const { mkdirp } = require('mkdirp');
 const fs = require('fs');
 
 const destFile = path.resolve(__dirname, `../${package.name}.cdix`);

--- a/extensions/kind/package.json
+++ b/extensions/kind/package.json
@@ -55,7 +55,7 @@
   },
   "devDependencies": {
     "7zip-min": "^1.4.3",
-    "mkdirp": "^1.0.4",
+    "mkdirp": "^2.0.0",
     "zip-local": "^0.3.5"
   }
 }

--- a/extensions/kube-context/package.json
+++ b/extensions/kube-context/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "7zip-min": "^1.4.3",
     "@types/js-yaml": "^4.0.5",
-    "mkdirp": "^1.0.4",
+    "mkdirp": "^2.0.0",
     "zip-local": "^0.3.5"
   }
 }

--- a/extensions/kube-context/scripts/build.js
+++ b/extensions/kube-context/scripts/build.js
@@ -20,7 +20,7 @@
 const zipper = require('zip-local');
 const path = require('path');
 const package = require('../package.json');
-const mkdirp = require('mkdirp');
+const { mkdirp } = require('mkdirp');
 const fs = require('fs');
 
 const destFile = path.resolve(__dirname, `../${package.name}.cdix`);

--- a/extensions/lima/package.json
+++ b/extensions/lima/package.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "7zip-min": "^1.4.3",
-    "mkdirp": "^1.0.4",
+    "mkdirp": "^2.0.0",
     "zip-local": "^0.3.5"
   }
 }

--- a/extensions/lima/scripts/build.js
+++ b/extensions/lima/scripts/build.js
@@ -20,7 +20,7 @@
 const zipper = require('zip-local');
 const path = require('path');
 const package = require('../package.json');
-const mkdirp = require('mkdirp');
+const { mkdirp } = require('mkdirp');
 const fs = require('fs');
 
 const destFile = path.resolve(__dirname, `../${package.name}.cdix`);

--- a/extensions/podman/package.json
+++ b/extensions/podman/package.json
@@ -98,7 +98,7 @@
   "devDependencies": {
     "7zip-min": "^1.4.3",
     "hasha": "^5.2.2",
-    "mkdirp": "^1.0.4",
+    "mkdirp": "^2.0.0",
     "octokit": "^2.0.11",
     "ts-node": "^10.9.1",
     "zip-local": "^0.3.5"

--- a/extensions/podman/scripts/build.js
+++ b/extensions/podman/scripts/build.js
@@ -20,7 +20,7 @@
 const zipper = require('zip-local');
 const path = require('path');
 const package = require('../package.json');
-const mkdirp = require('mkdirp');
+const { mkdirp } = require('mkdirp');
 const fs = require('fs');
 
 const destFile = path.resolve(__dirname, `../${package.name}.cdix`);

--- a/yarn.lock
+++ b/yarn.lock
@@ -8848,6 +8848,11 @@ mkdirp@^1.0.3, mkdirp@^1.0.4:
   resolved "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
+mkdirp@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-2.0.0.tgz#1460f186644abf3b751e74f5ee82f47d191b586d"
+  integrity sha512-M9ecBPkCu6jZ+H19zruhjw/JB97qqVhyi1H2Lxxo2XAoIMdpHKQ8MfQiMzXk9SH/oJXIbM3oSAfLB8qSWJdCLA==
+
 mlly@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/mlly/-/mlly-1.0.0.tgz#d38ca6e33ab89b60654f71ef08931d51e83d3569"


### PR DESCRIPTION
### What does this PR do?
Update mkdirp to v2.0.0
It is now using hybrid module

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

Automatic PR failed https://github.com/containers/podman-desktop/pull/1179
as it was not using right import formula

### How to test this PR?

PR check should be green


Change-Id: I625e9bb39b2ba63976d4ef2ad0e6f13901032870
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
