### PR TITLE
feat: Allow to install extension from OCI images and re-enable extension list in settings page

### DIFF
--- a/packages/main/src/plugin/api/extension-info.ts
+++ b/packages/main/src/plugin/api/extension-info.ts
@@ -22,6 +22,7 @@ export interface ExtensionInfo {
   description: string;
   displayName: string;
   publisher: string;
+  removable: boolean;
   version: string;
   state: string;
   path: string;

--- a/packages/main/src/plugin/install/extension-installer.ts
+++ b/packages/main/src/plugin/install/extension-installer.ts
@@ -1,0 +1,281 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { IpcMainEvent } from 'electron';
+import { ipcMain } from 'electron';
+import type { ContainerProviderRegistry } from '../container-registry';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { cp } from 'node:fs/promises';
+import * as tarFs from 'tar-fs';
+import type Dockerode from 'dockerode';
+import type { PullEvent } from '../api/pull-event';
+import type { ExtensionLoader } from '../extension-loader';
+export class ExtensionInstaller {
+  constructor(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    private apiSender: any,
+    private containerRegistry: ContainerProviderRegistry,
+    private extensionLoader: ExtensionLoader,
+  ) {}
+
+  async extractExtensionFiles(tmpFolderPath: string, finalFolderPath: string, reportLog: (message: string) => void) {
+    // files or folder to grab
+    const filesExtension: string[] = [];
+    const hostFiles: string[] = [];
+    // do we have binaries in ${tmpFolderPath}/extension folder ?
+    if (fs.existsSync(`${tmpFolderPath}/extension`)) {
+      // list all files in the binaries/${platform} folder
+      const extensionFolder = `${tmpFolderPath}/extension/`;
+
+      // grab files from that directory using fs promises
+      const extensionFiles = await fs.promises.readdir(extensionFolder, { withFileTypes: true });
+
+      // add all files
+      for (const file of extensionFiles) {
+        // if it's a file, add it to the files list
+        //if (file.isFile()) {
+        filesExtension.push(file.name);
+        //}
+      }
+    }
+
+    // copy all files
+    await Promise.all(
+      filesExtension.map(async (file: string) => {
+        return cp(path.join(tmpFolderPath, 'extension', file), path.join(finalFolderPath, file), { recursive: true });
+      }),
+    );
+    // copy all host files
+    await Promise.all(
+      hostFiles.map(async (file: string) => {
+        const sourceFile = path.join(tmpFolderPath, file);
+        // get only the filename from the path
+        const destFile = path.basename(sourceFile);
+        reportLog(`Copying host file ${destFile}.`);
+        return cp(sourceFile, path.join(finalFolderPath, 'host', destFile), { recursive: true });
+      }),
+    );
+
+    // delete the tmp folder
+    fs.rmSync(tmpFolderPath, { recursive: true });
+  }
+
+  async unpackTarFile(tarFilePath: string, destFolder: string): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      const readStream = fs.createReadStream(tarFilePath);
+      const extract = tarFs.extract(destFolder);
+      readStream.pipe(extract);
+
+      extract.on('finish', async () => {
+        resolve();
+      });
+
+      extract.on('error', error => {
+        reject(error);
+      });
+    });
+  }
+
+  async exportContentOfContainer(providerConnection: Dockerode, imageId: string, tmpTarPath: string): Promise<void> {
+    // export the content of the image
+    const containerFromImage = await providerConnection.createContainer({ Image: imageId, Entrypoint: ['/bin/sh'] });
+    const exportResult = await containerFromImage.export();
+
+    const fileWriteStream = fs.createWriteStream(tmpTarPath, {
+      flags: 'w',
+    });
+
+    return new Promise<void>((resolve, reject) => {
+      exportResult.on('close', () => {
+        fileWriteStream.close();
+
+        // ok we can remove the container
+        containerFromImage.remove().then(() => resolve(undefined));
+      });
+
+      exportResult.on('data', chunk => {
+        fileWriteStream.write(chunk);
+      });
+
+      exportResult.on('error', error => {
+        reject(error);
+      });
+    });
+  }
+
+  async init(): Promise<void> {
+    ipcMain.on(
+      'extension-installer:install-from-image',
+      async (event: IpcMainEvent, imageName: string, logCallbackId: number): Promise<void> => {
+        const reportLog = (message: string): void => {
+          event.reply('extension-installer:install-from-image-log', logCallbackId, message);
+        };
+
+        // use first working connection
+        let providerConnectionDetails;
+        try {
+          providerConnectionDetails = this.containerRegistry.getFirstRunningConnection();
+        } catch (error) {
+          event.reply(
+            'extension-installer:install-from-image-error',
+            logCallbackId,
+            'No provider is running. Please start a provider.',
+          );
+          return;
+        }
+
+        const providerConnectionInfo = providerConnectionDetails[0];
+        const providerConnection = providerConnectionDetails[1];
+        reportLog(`Pulling image ${imageName}...`);
+
+        try {
+          await this.containerRegistry.pullImage(providerConnectionInfo, imageName, (pullEvent: PullEvent) => {
+            if (pullEvent.progress || pullEvent.progressDetail) {
+              console.log(pullEvent.progress);
+            } else if (pullEvent.status) {
+              reportLog(pullEvent.status);
+            }
+          });
+        } catch (error) {
+          event.reply(
+            'extension-installer:install-from-image-error',
+            logCallbackId,
+            'Error while pulling image: ' + error,
+          );
+          return;
+        }
+
+        // ok search the image
+        const images = await providerConnection.listImages();
+        const foundMatchingImage = images.find(image =>
+          image.RepoTags?.find(tag => tag.includes(imageName) || imageName.includes(tag)),
+        );
+
+        if (!foundMatchingImage) {
+          event.reply(
+            'extension-installer:install-from-image-error',
+            logCallbackId,
+            `Not able to pull image ${imageName}`,
+          );
+          return;
+        }
+
+        // get the image information
+        const image = await providerConnection.getImage(foundMatchingImage.Id);
+        reportLog('Check if image is a Podman Desktop Extension...');
+
+        // analyze the image
+        const imageAnalysis = await image.inspect();
+
+        // check if it's a Podman Desktop Extension
+        const labels = imageAnalysis.Config.Labels;
+        if (!labels) {
+          event.reply(
+            'extension-installer:install-from-image-error',
+            logCallbackId,
+            `Image ${imageName} is not a Podman Desktop Extension`,
+          );
+          return;
+        }
+        const titleLabel = labels['org.opencontainers.image.title'];
+        const descriptionLabel = labels['org.opencontainers.image.description'];
+        const vendorLabel = labels['org.opencontainers.image.vendor'];
+        const apiVersion = labels['io.podman-desktop.api.version'];
+
+        if (!titleLabel || !descriptionLabel || !vendorLabel || !apiVersion) {
+          event.reply(
+            'extension-installer:install-from-image-error',
+            logCallbackId,
+            `Image ${imageName} is not a Podman Desktop Extension`,
+          );
+          return;
+        }
+
+        // strip the tag (ending with :something) from the image name if any
+        let imageNameWithoutTag: string;
+        if (imageName.includes(':')) {
+          imageNameWithoutTag = imageName.split(':')[0];
+        } else {
+          imageNameWithoutTag = imageName;
+        }
+
+        // remove all special characters from the image name
+        const imageNameWithoutSpecialChars = imageNameWithoutTag.replace(/[^a-zA-Z0-9]/g, '');
+
+        // tmp folder
+        const tmpFolderPath = path.join(os.tmpdir(), `/tmp/${imageNameWithoutSpecialChars}-tmp`);
+
+        // tmp tar file
+        const tmpTarPath = path.join(os.tmpdir(), `${imageNameWithoutSpecialChars}-tmp.tar`);
+
+        // final folder
+        const finalFolderPath = path.join(this.extensionLoader.getPluginsDirectory(), imageNameWithoutSpecialChars);
+
+        // grab all extensions
+        const extensions = await this.extensionLoader.listExtensions();
+
+        // check if the extension is already installed for that path
+        const alreadyInstalledExtension = extensions.find(extension => extension.path === finalFolderPath);
+
+        if (alreadyInstalledExtension) {
+          event.reply(
+            'extension-installer:install-from-image-error',
+            logCallbackId,
+            `Extension ${alreadyInstalledExtension.name} is already installed`,
+          );
+          return;
+        }
+
+        reportLog('Grabbing image content...');
+        await this.exportContentOfContainer(providerConnection, foundMatchingImage.Id, tmpTarPath);
+
+        // delete image
+        await image.remove();
+
+        reportLog('Extracting image content...');
+        try {
+          await this.unpackTarFile(tmpTarPath, tmpFolderPath);
+        } finally {
+          // delete the tmp tar file
+          fs.unlinkSync(tmpTarPath);
+        }
+
+        event.reply('extension-installer:install-from-image-log', logCallbackId, 'Filtering image content...');
+
+        await this.extractExtensionFiles(tmpFolderPath, finalFolderPath, reportLog);
+
+        // refresh contributions
+        try {
+          await this.extensionLoader.loadExtension(finalFolderPath, true);
+        } catch (error) {
+          event.reply(
+            'extension-installer:install-from-image-error',
+            logCallbackId,
+            'Error while loading the extension ' + error,
+          );
+          return;
+        }
+
+        event.reply('extension-installer:install-from-image-end', logCallbackId, 'Extension Successfully installed.');
+        this.apiSender.send('extension-started', {});
+      },
+    );
+  }
+}

--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -9,7 +9,6 @@ import { Route, router } from 'tinro';
 
 import ContainerList from './lib/ContainerList.svelte';
 import { onMount } from 'svelte';
-import ExtensionList from './lib/ExtensionList.svelte';
 import ImagesList from './lib/ImagesList.svelte';
 import ProviderList from './lib/ProviderList.svelte';
 import Logo from './lib/logo/Logo.svelte';
@@ -143,10 +142,6 @@ window.events?.receive('display-help', () => {
         </Route>
         <Route path="/volumes/:name/:engineId/*" let:meta>
           <VolumeDetails volumeName="{decodeURI(meta.params.name)}" engineId="{decodeURI(meta.params.engineId)}" />
-        </Route>
-
-        <Route path="/extensions">
-          <ExtensionList />
         </Route>
         <Route path="/providers">
           <ProviderList />

--- a/packages/renderer/src/PreferencesNavigation.svelte
+++ b/packages/renderer/src/PreferencesNavigation.svelte
@@ -178,7 +178,8 @@ $: addHiddenClass = (provider: ProviderInfo): string =>
       class="pf-c-nav__item pf-m-expandable {addExpandedClass('extensionsCatalog')} {addCurrentClass(
         '/preferences/extensions',
       )} hover:text-gray-300 cursor-pointer items-center">
-      <button
+      <a
+        href="/preferences/extensions"
         class="pf-c-nav__link text-left"
         id="configuration-section-extensions-catalog"
         aria-expanded="{isAriaExpanded('extensionsCatalog')}"
@@ -189,7 +190,7 @@ $: addHiddenClass = (provider: ProviderInfo): string =>
             <i class="fas fa-angle-right" aria-hidden="true"></i>
           </span>
         </span>
-      </button>
+      </a>
       <section class="pf-c-nav__subnav {addSectionHiddenClass('extensionsCatalog')}">
         <ul class="pf-c-nav__list">
           {#each extensions as extension}

--- a/packages/renderer/src/lib/ExtensionList.svelte
+++ b/packages/renderer/src/lib/ExtensionList.svelte
@@ -1,57 +1,148 @@
 <script lang="ts">
 import Fa from 'svelte-fa/src/fa.svelte';
-import { faPuzzlePiece } from '@fortawesome/free-solid-svg-icons';
+import { faPuzzlePiece, faTrash } from '@fortawesome/free-solid-svg-icons';
 import { faPlay } from '@fortawesome/free-solid-svg-icons';
 import { faStop } from '@fortawesome/free-solid-svg-icons';
-import { onMount } from 'svelte';
+import { afterUpdate, onMount } from 'svelte';
 import { extensionInfos } from '../stores/extensions';
 import type { ExtensionInfo } from '../../../main/src/plugin/api/extension-info';
 
-let extensions = [];
-onMount(async () => {
-  extensionInfos.subscribe(value => {
-    extensions = value;
-  });
+let ociImage: string;
+
+let installInProgress: boolean = false;
+let errorInstall: string = '';
+let logs: string[] = [];
+
+let logElement;
+
+$: sortedExtensions = $extensionInfos.sort((a, b) => a.name.localeCompare(b.name));
+
+const buttonClass: string =
+  'm-0.5 text-gray-300 hover:bg-zinc-800 hover:text-violet-600 font-medium rounded-full inline-flex items-center px-2 py-2 text-center';
+
+async function installExtensionFromImage() {
+  errorInstall = '';
+  logs.length = 0;
+  installInProgress = true;
+
+  // do a trim on the image name
+  ociImage = ociImage.trim();
+
+  // download image
+  await window.extensionInstallFromImage(
+    ociImage,
+    (data: string) => {
+      logs = [...logs, data];
+    },
+    (error: string) => {
+      console.log('got an error', error);
+      installInProgress = false;
+      errorInstall = error;
+    },
+  );
+  logs = [...logs, '☑️ installation finished !'];
+  installInProgress = false;
+  ociImage = '';
+}
+
+afterUpdate(() => {
+  logElement.scroll({ top: logElement.scrollHeight, behavior: 'smooth' });
 });
 
 async function stopExtension(extension: ExtensionInfo) {
-  console.log('stopping extension...');
   await window.stopExtension(extension.id);
   window.dispatchEvent(new CustomEvent('extension-stopped', { detail: extension }));
 }
 async function startExtension(extension: ExtensionInfo) {
-  console.log('starting extension...');
   await window.startExtension(extension.id);
   window.dispatchEvent(new CustomEvent('extension-started', { detail: extension }));
-  console.log('extension started');
 }
 
-function getColorForState(extensionInfo: ExtensionInfo): string {
-  if (extensionInfo.state === 'active') {
-    return 'text-emerald-500';
-  }
-  return 'text-gray-700';
+async function removeExtension(extension: ExtensionInfo) {
+  await window.removeExtension(extension.id);
+  window.dispatchEvent(new CustomEvent('extension-removed', { detail: extension }));
 }
 </script>
 
-<div class="flex flex-col">
-  <div class="shadow overflow-hidden border-b border-gray-600 sm">
+<div class="flex flex-1 flex-col p-2 bg-zinc-800">
+  <h1 class="capitalize text-xl">Extensions List</h1>
+
+  <div class="bg-zinc-800 border border-zinc-700 p-4 mt-2">
+    <h1 class="text-lg mb-2">Install a new extension from OCI Image</h1>
+
+    <div class="flex flex-col w-full">
+      <div class="flex flex-row mb-2 w-full space-x-8 items-center">
+        <input
+          name="ociImage"
+          id="ociImage"
+          bind:value="{ociImage}"
+          placeholder="Name of the Image"
+          class="w-1/2 p-2 outline-none text-sm bg-zinc-900 rounded-sm text-gray-400 placeholder-gray-400"
+          required />
+
+        <button
+          on:click="{() => installExtensionFromImage()}"
+          disabled="{ociImage === undefined || ociImage === '' || installInProgress}"
+          class="w-full pf-c-button pf-m-primary"
+          type="button">
+          {#if installInProgress}
+            <i class="pf-c-button__progress">
+              <span class="pf-c-spinner pf-m-md" role="progressbar">
+                <span class="pf-c-spinner__clipper"></span>
+                <span class="pf-c-spinner__lead-ball"></span>
+                <span class="pf-c-spinner__tail-ball"></span>
+              </span>
+            </i>
+          {/if}
+          <span class="pf-c-button__icon pf-m-start ">
+            <i class="fas fa-arrow-circle-down" aria-hidden="true"></i>
+          </span>
+          Install extension from the OCI image
+        </button>
+      </div>
+
+      <div class="container mx-auto w-full flex-col">
+        {#if errorInstall !== ''}
+          <div class="bg-red-300 text-gray-900 m-4">
+            {errorInstall}
+          </div>
+        {/if}
+
+        <div
+          class:opacity-0="{logs.length === 0}"
+          bind:this="{logElement}"
+          class="bg-zinc-700 text-gray-200 mt-4 h-16 overflow-y-auto">
+          {#each logs as log}
+            <p class="font-light text-sm">{log}</p>
+          {/each}
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="shadow overflow-hidden border border-zinc-700 sm mt-2">
     <table class="min-w-full divide-y divide-gray-800">
-      <tbody class="bg-gray-800 divide-y divide-gray-200">
-        {#each extensions as extension}
+      <tbody class="bg-zinc-900 divide-y divide-zinc-700">
+        {#each sortedExtensions as extension}
           <tr>
             <td class="px-6 py-2 whitespace-nowrap">
               <div class="flex items-center">
-                <div class="flex-shrink-0 h-10 w-10 py-3">
-                  <Fa class="h-10 w-10 rounded-full {getColorForState(extension)}" icon="{faPuzzlePiece}" />
+                <div class="flex-shrink-0 h-10 w-10 py-3" title="Extension {extension.name} is {extension.state}">
+                  <Fa
+                    class="h-10 w-10 rounded-full {extension.state === 'active' ? 'text-violet-600' : 'text-gray-700'}"
+                    icon="{faPuzzlePiece}" />
                 </div>
                 <div class="ml-4">
                   <div class="flex flex-row">
-                    <div class="text-sm text-gray-200">{extension.name}</div>
-                    <div class="pl-2 text-sm text-violet-400">{extension.publisher}</div>
+                    <div class="text-sm text-gray-200">
+                      {extension.name}
+                      {extension.removable ? '(user)' : '(default extension)'}
+                    </div>
                   </div>
-                  <div class="flex flex-row text-xs font-extra-light text-gray-500">
-                    <div>{extension.version}</div>
+                  <div class="flex flex-row">
+                    <div class="text-sm text-gray-400 italic">{extension.description}</div>
+                  </div>
+                  <div class="flex flex-row text-xs font-extra-light text-violet-500">
+                    <div>v{extension.version}</div>
                   </div>
                 </div>
               </div>
@@ -61,16 +152,33 @@ function getColorForState(extensionInfo: ExtensionInfo): string {
                 <button
                   title="Start extension"
                   on:click="{() => startExtension(extension)}"
-                  hidden
-                  class:block="{extension?.state !== 'active'}"
-                  ><Fa class="cursor-pointer h-10 w-10 rounded-full text-3xl text-sky-800" icon="{faPlay}" /></button>
+                  class="{buttonClass}"
+                  class:hidden="{extension.state === 'active'}"><Fa class="h-4 w-4" icon="{faPlay}" /></button>
                 <button
                   title="Stop extension"
+                  class="{buttonClass}"
                   on:click="{() => stopExtension(extension)}"
                   hidden
-                  class:block="{extension?.state === 'active'}"
-                  ><Fa class="cursor-pointer h-10 w-10 rounded-full text-3xl text-sky-800" icon="{faStop}" /></button>
-                <!--<span><Fa class="h-10 w-10 rounded-full text-3xl text-sky-800" icon={faTrash} /></span>-->
+                  class:hidden="{extension.state !== 'active'}"><Fa class="h-4 w-4" icon="{faStop}" /></button>
+
+                {#if extension.removable}
+                  {#if extension.state === 'inactive'}
+                    <button title="Remove extension" class="{buttonClass}" on:click="{() => removeExtension(extension)}"
+                      ><Fa class="h-4 w-4" icon="{faTrash}" /></button>
+                  {:else}
+                    <div
+                      class="m-0.5 text-gray-700 rounded-full inline-flex items-center px-2 py-2 text-center"
+                      title="Active extension cannot be removed.">
+                      <Fa class="h-4 w-4" icon="{faTrash}" />
+                    </div>
+                  {/if}
+                {:else}
+                  <div
+                    class="m-0.5 text-gray-700 rounded-full inline-flex items-center px-2 py-2 text-center"
+                    title="Default extension. Cannot be removed.">
+                    <Fa class="h-4 w-4" icon="{faTrash}" />
+                  </div>
+                {/if}
               </div>
             </td>
           </tr>

--- a/packages/renderer/src/lib/preferences/PreferencesPage.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesPage.svelte
@@ -16,6 +16,7 @@ import PreferencesRegistriesEditing from './PreferencesRegistriesEditing.svelte'
 import PreferencesPageDockerExtensions from '../docker-extension/PreferencesPageDockerExtensions.svelte';
 import PreferencesProxiesRendering from './PreferencesProxiesRendering.svelte';
 import NavPage from '../ui/NavPage.svelte';
+import ExtensionList from '../ExtensionList.svelte';
 
 let properties: IConfigurationPropertyRecordedSchema[];
 let defaultPrefPageId: string;
@@ -64,6 +65,10 @@ onMount(async () => {
     <Route path="/proxies">
       <PreferencesProxiesRendering />
     </Route>
+    <Route path="/extensions">
+      <ExtensionList />
+    </Route>
+
     <Route path="/container-connection/" let:meta />
     <Route path="/container-connection/:provider/:connection" let:meta>
       <PreferencesContainerConnectionRendering

--- a/packages/renderer/src/stores/extensions.ts
+++ b/packages/renderer/src/stores/extensions.ts
@@ -16,20 +16,25 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { Writable } from 'svelte/store';
 import { writable } from 'svelte/store';
+import type { ExtensionInfo } from '../../../main/src/plugin/api/extension-info';
 
 export async function fetchExtensions() {
   const result = await window.listExtensions();
   extensionInfos.set(result);
 }
 
-export const extensionInfos = writable([]);
+export const extensionInfos: Writable<ExtensionInfo[]> = writable([]);
 
 // need to refresh when extension is started or stopped
 window.addEventListener('extension-started', () => {
   fetchExtensions();
 });
 window.addEventListener('extension-stopped', () => {
+  fetchExtensions();
+});
+window.addEventListener('extension-removed', () => {
   fetchExtensions();
 });
 


### PR DESCRIPTION
### What does this PR do?
Allow to install on-the fly Podman Desktop extensions using an OCI image

### Screenshot/screencast of this PR


https://user-images.githubusercontent.com/436777/212858033-4c0d7ed1-3599-4044-88bb-2880f254bd80.mp4




### What issues does this PR fix or reference?

Fixes #812 

### How to test this PR?

Go to the extension list in settings page

Select `quay.io/fbenoit/podman-desktop-hello-world` as example and click on deploy

Check that status bar has a new element called "hello world" and click on it: You should see a dialog box