### PR TITLE
chore: DD extensions should see only minimal information on containers

### DIFF
--- a/packages/preload-docker-extension/src/index.ts
+++ b/packages/preload-docker-extension/src/index.ts
@@ -25,6 +25,7 @@ import { contextBridge, ipcRenderer } from 'electron';
 import type { v1 as dockerDesktopAPI } from '@docker/extension-api-client-types';
 
 import type { ImageInfo } from '../../main/src/plugin/api/image-info';
+import type { SimpleContainerInfo } from '../../main/src/plugin/api/container-info';
 import type { Dialog, OpenDialogResult } from '@docker/extension-api-client-types/dist/v1/dialog';
 import type { ExecStreamOptions, NavigationIntents, RequestConfig } from '@docker/extension-api-client-types/dist/v1';
 import { lines, parseJsonLines, parseJsonObject } from './exec-result-helper';
@@ -58,8 +59,8 @@ export class DockerExtensionPreload {
     return ipcInvoke('container-provider-registry:listImages', options);
   }
 
-  listContainers(options?: any): Promise<ImageInfo[]> {
-    return ipcInvoke('container-provider-registry:listContainers', options);
+  listContainers(options?: any): Promise<SimpleContainerInfo[]> {
+    return ipcInvoke('container-provider-registry:listSimpleContainers', options);
   }
 
   async exec(


### PR DESCRIPTION
### What does this PR do?
Switch to a simpler way of listing containers

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

Avoid to compute some data

### How to test this PR?



Change-Id: I6744c6f8e5436a5025f8cab0938063fb712427bf
Signed-off-by: Florent Benoit <fbenoit@redhat.com>