### PR TITLE
fix: search only in leaves of objects (ignoring key names)

### DIFF
--- a/packages/renderer/src/stores/containers.ts
+++ b/packages/renderer/src/stores/containers.ts
@@ -19,6 +19,7 @@
 import type { Writable } from 'svelte/store';
 import { writable, derived } from 'svelte/store';
 import type { ContainerInfo } from '../../../main/src/plugin/api/container-info';
+import { findMatchInLeaves } from './search-util';
 
 export async function fetchContainers() {
   const result = await window.listContainers();
@@ -29,12 +30,8 @@ export const containersInfos: Writable<ContainerInfo[]> = writable([]);
 
 export const searchPattern = writable('');
 
-function getName(containerInfo: ContainerInfo) {
-  return JSON.stringify(containerInfo).toLowerCase();
-}
-
 export const filtered = derived([searchPattern, containersInfos], ([$searchPattern, $containersInfos]) =>
-  $containersInfos.filter(containerInfo => getName(containerInfo).includes($searchPattern.toLowerCase())),
+  $containersInfos.filter(containerInfo => findMatchInLeaves(containerInfo, $searchPattern.toLowerCase())),
 );
 
 // need to refresh when extension is started or stopped

--- a/packages/renderer/src/stores/images.ts
+++ b/packages/renderer/src/stores/images.ts
@@ -19,6 +19,7 @@
 import type { Writable } from 'svelte/store';
 import { writable, derived } from 'svelte/store';
 import type { ImageInfo } from '../../../main/src/plugin/api/image-info';
+import { findMatchInLeaves } from './search-util';
 export async function fetchImages() {
   const result = await window.listImages();
   imagesInfos.set(result);
@@ -28,12 +29,8 @@ export const imagesInfos: Writable<ImageInfo[]> = writable([]);
 
 export const searchPattern = writable('');
 
-function getName(imageInfo: ImageInfo) {
-  return JSON.stringify(imageInfo).toLowerCase();
-}
-
 export const filtered = derived([searchPattern, imagesInfos], ([$searchPattern, $imagesInfos]) =>
-  $imagesInfos.filter(imageInfo => getName(imageInfo).includes($searchPattern.toLowerCase())),
+  $imagesInfos.filter(imageInfo => findMatchInLeaves(imageInfo, $searchPattern.toLowerCase())),
 );
 
 // need to refresh when extension is started or stopped

--- a/packages/renderer/src/stores/pods.ts
+++ b/packages/renderer/src/stores/pods.ts
@@ -19,6 +19,7 @@
 import type { Writable } from 'svelte/store';
 import { writable, derived } from 'svelte/store';
 import type { PodInfo } from '../../../main/src/plugin/api/pod-info';
+import { findMatchInLeaves } from './search-util';
 export async function fetchPods() {
   const result = await window.listPods();
   podsInfos.set(result);
@@ -28,12 +29,8 @@ export const podsInfos: Writable<PodInfo[]> = writable([]);
 
 export const searchPattern = writable('');
 
-function getJson(podInfo: PodInfo) {
-  return JSON.stringify(podInfo).toLowerCase();
-}
-
 export const filtered = derived([searchPattern, podsInfos], ([$searchPattern, $imagesInfos]) =>
-  $imagesInfos.filter(imageInfo => getJson(imageInfo).includes($searchPattern.toLowerCase())),
+  $imagesInfos.filter(podInfo => findMatchInLeaves(podInfo, $searchPattern.toLowerCase())),
 );
 
 // need to refresh when extension is started or stopped

--- a/packages/renderer/src/stores/search-util.spec.ts
+++ b/packages/renderer/src/stores/search-util.spec.ts
@@ -1,0 +1,105 @@
+/**********************************************************************
+ * Copyright (C) 2022 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { beforeEach, expect, test, vi } from 'vitest';
+import { findMatchInLeaves } from './search-util';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+test('should expect valid match with string', async () => {
+  const object = 'nginx';
+  expect(findMatchInLeaves(object, 'nginx')).toBe(true);
+  expect(findMatchInLeaves(object, 'foo')).toBe(false);
+});
+
+test('should expect valid match with array of string', async () => {
+  const object = ['a', 'b', 'my super name'];
+  expect(findMatchInLeaves(object, 'name')).toBe(true);
+  expect(findMatchInLeaves(object, 'b')).toBe(true);
+  expect(findMatchInLeaves(object, 'foo')).toBe(false);
+});
+
+test('should expect valid match with string and case', async () => {
+  const object = 'NgInX';
+  expect(findMatchInLeaves(object, 'nginx')).toBe(true);
+  expect(findMatchInLeaves(object, 'foo')).toBe(false);
+
+  const object2 = 'nginx';
+  expect(findMatchInLeaves(object2, 'NgInX')).toBe(true);
+  expect(findMatchInLeaves(object2, 'foo')).toBe(false);
+});
+
+test('should expect valid match with array of string', async () => {
+  const object = ['a', 'b', 'my super name'];
+  expect(findMatchInLeaves(object, 'name')).toBe(true);
+  expect(findMatchInLeaves(object, 'b')).toBe(true);
+  expect(findMatchInLeaves(object, 'foo')).toBe(false);
+});
+
+test('should expect valid match with array of string and different case', async () => {
+  const object = ['a', 'B', 'My Super Name'];
+  expect(findMatchInLeaves(object, 'name')).toBe(true);
+  expect(findMatchInLeaves(object, 'b')).toBe(true);
+  expect(findMatchInLeaves(object, 'foo')).toBe(false);
+
+  const object2 = ['a', 'b', 'my super name'];
+  expect(findMatchInLeaves(object2, 'NaMe')).toBe(true);
+  expect(findMatchInLeaves(object2, 'B')).toBe(true);
+  expect(findMatchInLeaves(object2, 'foo')).toBe(false);
+});
+
+test('should expect valid match with simple object', async () => {
+  const object = {
+    hello: 'foo',
+    baz: null,
+  };
+  expect(findMatchInLeaves(object, 'foo')).toBe(true);
+
+  // should not match on key name
+  expect(findMatchInLeaves(object, 'hello')).toBe(false);
+});
+
+test('should expect valid match with complex object', async () => {
+  const object = {
+    hello: {
+      hello: {
+        hello: 'foo',
+      },
+    },
+  };
+  expect(findMatchInLeaves(object, 'foo')).toBe(true);
+
+  // should not match on key name
+  expect(findMatchInLeaves(object, 'hello')).toBe(false);
+});
+
+test('should expect valid match with complex object and case', async () => {
+  const object = {
+    hello: {
+      hello: {
+        hello: 'FoO',
+      },
+    },
+  };
+  expect(findMatchInLeaves(object, 'foo')).toBe(true);
+
+  // should not match on key name
+  expect(findMatchInLeaves(object, 'hello')).toBe(false);
+});

--- a/packages/renderer/src/stores/search-util.ts
+++ b/packages/renderer/src/stores/search-util.ts
@@ -1,0 +1,46 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+// Search if a given query is present in the leaves of a given object
+export function findMatchInLeaves(object: unknown, query: string): boolean {
+  if (typeof object === 'string') {
+    return object.toLowerCase().includes(query.toLowerCase());
+  } else if (Array.isArray(object)) {
+    return object.some(element => findMatchInLeaves(element, query));
+  } else if (typeof object === 'object') {
+    // we will search only in the leaf of the object
+    return aggregateLeaves(object).some(leaf => findMatchInLeaves(leaf, query));
+  } else {
+    return false;
+  }
+}
+
+// Aggregate all leaves of a given object
+function aggregateLeaves(object: unknown): string[] {
+  if (object === undefined || object === null) {
+    return [];
+  } else if (typeof object === 'string') {
+    return [object];
+  } else if (Array.isArray(object)) {
+    return object.flatMap(element => aggregateLeaves(element));
+  } else if (typeof object === 'object') {
+    return Object.values(object).flatMap(value => aggregateLeaves(value));
+  } else {
+    return [];
+  }
+}

--- a/packages/renderer/src/stores/volumes.ts
+++ b/packages/renderer/src/stores/volumes.ts
@@ -18,7 +18,8 @@
 
 import type { Writable } from 'svelte/store';
 import { writable, derived } from 'svelte/store';
-import type { VolumeInfo, VolumeListInfo } from '../../../main/src/plugin/api/volume-info';
+import type { VolumeListInfo } from '../../../main/src/plugin/api/volume-info';
+import { findMatchInLeaves } from './search-util';
 export async function fetchVolumes() {
   const result = await window.listVolumes();
   volumeListInfos.set(result);
@@ -28,15 +29,13 @@ export const volumeListInfos: Writable<VolumeListInfo[]> = writable([]);
 
 export const searchPattern = writable('');
 
-function getName(volumeInfo: VolumeInfo) {
-  return JSON.stringify(volumeInfo).toLowerCase();
-}
-
 export const filtered = derived([searchPattern, volumeListInfos], ([$searchPattern, $volumeListInfos]) => {
   // returned object
   return $volumeListInfos.map(volumeInfo => {
     // list of volumes is filtered
-    const filteredVolumes = volumeInfo.Volumes.filter(volume => getName(volume).includes($searchPattern.toLowerCase()));
+    const filteredVolumes = volumeInfo.Volumes.filter(volume =>
+      findMatchInLeaves(volume, $searchPattern.toLowerCase()),
+    );
 
     const updatedVolumeInfo = {
       ...volumeInfo,


### PR DESCRIPTION
### What does this PR do?
Search only matching field but in values/leaves of object
before it was searching in the whole tree so for example:

```json
{
"engineName": "Podman"
}
```
was matching for `ngin` keyword

now it would match only if you use `podman`

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/1183

### How to test this PR?

Try the search fields of containers, pods, volumes, images, etc.


Change-Id: I699a28bf04a18f79c520d689a7a2baa84cd500c7
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
