### PR TITLE
fix: Cannot create Kind cluster on Windows

### DIFF
--- a/extensions/kind/src/extension.ts
+++ b/extensions/kind/src/extension.ts
@@ -19,6 +19,7 @@
 import * as extensionApi from '@tmpwip/extension-api';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import * as os from 'node:os';
 import { runCliCommand, detectKind } from './util';
 
 const API_KIND_INTERNAL_API_PORT = 6443;
@@ -89,7 +90,7 @@ nodes:
 `;
 
     // create a temporary file
-    const tmpDirectory = await fs.promises.mkdtemp('/tmp/kind-cluster-config-');
+    const tmpDirectory = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'kind-cluster-config-'));
 
     // path to the file inside this directory
     const tmpFilePath = path.join(tmpDirectory, 'kind-cluster-config.yaml');


### PR DESCRIPTION
Fixes #1193

Signed-off-by: Jeff MAURY <jmaury@redhat.com>

### What does this PR do?

Update generated path for the Kind cluster config file

### Screenshot/screencast of this PR

N/A

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?

Fixes #1193
<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

### How to test this PR?

Create a Kind cluster on Windows platform

<!-- Please explain steps to reproduce -->
