### PR TITLE
fix: display correctly non-multiplexed stream in logs

### DIFF
--- a/packages/renderer/src/lib/ContainerDetailsLogs.svelte
+++ b/packages/renderer/src/lib/ContainerDetailsLogs.svelte
@@ -8,6 +8,8 @@ import 'xterm/css/xterm.css';
 import { TerminalSettings } from '../../../main/src/plugin/terminal-settings';
 import { getPanelDetailColor } from './color/color';
 
+import { isMultiplexedLog } from './stream/stream-utils';
+
 export let container: ContainerInfoUI;
 
 // Log
@@ -40,10 +42,12 @@ function callback(name: string, data: string) {
     logsTerminal?.clear();
   } else if (name === 'data') {
     noLogs = false;
-    const printHelp = data.charCodeAt(0);
-    // 1: STDOUT
-    // 2: STDERR
-    logsTerminal?.write(data.substring(8) + '\r');
+
+    if (isMultiplexedLog(data)) {
+      logsTerminal?.write(data.substring(8) + '\r');
+    } else {
+      logsTerminal?.write(data + '\r');
+    }
   }
 }
 

--- a/packages/renderer/src/lib/pod/PodDetailsLogs.svelte
+++ b/packages/renderer/src/lib/pod/PodDetailsLogs.svelte
@@ -7,6 +7,7 @@ import 'xterm/css/xterm.css';
 import { TerminalSettings } from '../../../../main/src/plugin/terminal-settings';
 import { getPanelDetailColor } from '../color/color';
 import type { PodInfoUI } from './PodInfoUI';
+import { isMultiplexedLog } from '../stream/stream-utils';
 
 export let pod: PodInfoUI;
 
@@ -88,7 +89,15 @@ async function fetchPodLogs() {
     const logsCallback = (name: string, data: string) => {
       const padding = ' '.repeat(maxNameLength - container.Names.length);
       const colouredName = colourizedContainerName.get(container.Names);
-      callback(name, `${colouredName} ${padding} | ${data.substring(8)}`);
+
+      let content;
+      if (isMultiplexedLog(data)) {
+        content = data.substring(8);
+      } else {
+        content = data;
+      }
+
+      callback(name, `${colouredName} ${padding} | ${content}`);
     };
 
     // Get the logs for the container and set logsReady as true

--- a/packages/renderer/src/lib/stream/stream-utils.ts
+++ b/packages/renderer/src/lib/stream/stream-utils.ts
@@ -1,0 +1,50 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { Buffer } from 'buffer';
+
+// if multiplexed, we have:
+// header := [8]byte{STREAM_TYPE, 0, 0, 0, SIZE1, SIZE2, SIZE3, SIZE4}
+
+export function isMultiplexedLog(log: string): boolean {
+  console.log('display the content', log.substring(8));
+  const zero1 = log.charCodeAt(1);
+  const zero2 = log.charCodeAt(2);
+  const zero3 = log.charCodeAt(3);
+
+  // not multiplexed if 0 0 0 bytes are not set to zero (means it's not multiplexed)
+  if (zero1 !== 0 && zero2 !== 0 && zero3 !== 0) {
+    return false;
+  }
+
+  // else try to figure out the length
+  const size1 = log.charCodeAt(4);
+  const size2 = log.charCodeAt(5);
+  const size3 = log.charCodeAt(6);
+  const size4 = log.charCodeAt(7);
+
+  // SIZE1, SIZE2, SIZE3, SIZE4 are the four bytes of the uint32 size encoded as big endian.
+  const length = Buffer.from([size1, size2, size3, size4]).readInt32BE();
+  const potentialLength = log.substring(8).length;
+  if (length !== potentialLength) {
+    return false;
+  } else {
+    // it is multiplexed
+    return true;
+  }
+}


### PR DESCRIPTION
### What does this PR do?
Logs are multiplexed when using non-interactive mode and are raw when using a tty

https://docs.docker.com/engine/api/v1.41/#tag/Container/operation/ContainerAttach
see streamFormat

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/1174

### How to test this PR?

Check logs of multiplexed or non-multiplexed for containers and pods.

Current failure to reproduce:
```
podman run -it quay.io/podman/hello
```
and

```
podman run -it --pod new:testlog quay.io/podman/hello
```

and try without -it (to get multiplexed stream)


Change-Id: I2f01dd1451cfb78bbc41401411d007642fd9dd81
Signed-off-by: Florent Benoit <fbenoit@redhat.com>

