### PR TITLE
fix: Remove redundant actions from details pages

### DIFF
--- a/packages/renderer/src/lib/container/ContainerActions.svelte
+++ b/packages/renderer/src/lib/container/ContainerActions.svelte
@@ -109,6 +109,7 @@ if (dropdownMenu) {
 
 <!-- If dropdownMenu is true, use it, otherwise just show the regular buttons -->
 <svelte:component this="{actionsStyle}">
+  {#if (!detailed)}
   <ListItemButtonIcon
     title="Generate Kube"
     onClick="{() => openGenerateKube()}"
@@ -116,6 +117,7 @@ if (dropdownMenu) {
     hidden="{!(container.engineType === 'podman' && container.groupInfo.type === ContainerGroupInfoTypeUI.STANDALONE)}"
     detailed="{detailed}"
     icon="{faFileCode}" />
+  {/if}
   <ListItemButtonIcon
     title="Deploy to Kubernetes"
     onClick="{() => deployToKubernetes()}"

--- a/packages/renderer/src/lib/container/ContainerActions.svelte
+++ b/packages/renderer/src/lib/container/ContainerActions.svelte
@@ -132,6 +132,7 @@ if (dropdownMenu) {
     hidden="{!(container.state === 'RUNNING' && container.hasPublicPort)}"
     detailed="{detailed}"
     icon="{faExternalLinkSquareAlt}" />
+  {#if (!detailed)}
   <ListItemButtonIcon
     title="Open Terminal"
     onClick="{() => openTerminalContainer(container)}"
@@ -139,6 +140,7 @@ if (dropdownMenu) {
     hidden="{!(container.state === 'RUNNING')}"
     detailed="{detailed}"
     icon="{faTerminal}" />
+  {/if}
   <ListItemButtonIcon
     title="Restart Container"
     onClick="{() => restartContainer(container)}"

--- a/packages/renderer/src/lib/container/ContainerActions.svelte
+++ b/packages/renderer/src/lib/container/ContainerActions.svelte
@@ -109,14 +109,16 @@ if (dropdownMenu) {
 
 <!-- If dropdownMenu is true, use it, otherwise just show the regular buttons -->
 <svelte:component this="{actionsStyle}">
-  {#if (!detailed)}
-  <ListItemButtonIcon
-    title="Generate Kube"
-    onClick="{() => openGenerateKube()}"
-    menu="{dropdownMenu}"
-    hidden="{!(container.engineType === 'podman' && container.groupInfo.type === ContainerGroupInfoTypeUI.STANDALONE)}"
-    detailed="{detailed}"
-    icon="{faFileCode}" />
+  {#if !detailed}
+    <ListItemButtonIcon
+      title="Generate Kube"
+      onClick="{() => openGenerateKube()}"
+      menu="{dropdownMenu}"
+      hidden="{!(
+        container.engineType === 'podman' && container.groupInfo.type === ContainerGroupInfoTypeUI.STANDALONE
+      )}"
+      detailed="{detailed}"
+      icon="{faFileCode}" />
   {/if}
   <ListItemButtonIcon
     title="Deploy to Kubernetes"
@@ -132,14 +134,14 @@ if (dropdownMenu) {
     hidden="{!(container.state === 'RUNNING' && container.hasPublicPort)}"
     detailed="{detailed}"
     icon="{faExternalLinkSquareAlt}" />
-  {#if (!detailed)}
-  <ListItemButtonIcon
-    title="Open Terminal"
-    onClick="{() => openTerminalContainer(container)}"
-    menu="{dropdownMenu}"
-    hidden="{!(container.state === 'RUNNING')}"
-    detailed="{detailed}"
-    icon="{faTerminal}" />
+  {#if !detailed}
+    <ListItemButtonIcon
+      title="Open Terminal"
+      onClick="{() => openTerminalContainer(container)}"
+      menu="{dropdownMenu}"
+      hidden="{!(container.state === 'RUNNING')}"
+      detailed="{detailed}"
+      icon="{faTerminal}" />
   {/if}
   <ListItemButtonIcon
     title="Restart Container"

--- a/packages/renderer/src/lib/image/ImageActions.svelte
+++ b/packages/renderer/src/lib/image/ImageActions.svelte
@@ -44,11 +44,13 @@ async function showLayersImage(): Promise<void> {
 {#if !image.inUse}
   <ListItemButtonIcon title="Delete Image" onClick="{() => deleteImage()}" detailed="{detailed}" icon="{faTrash}" />
 {/if}
+{#if (!detailed)}
 <ListItemButtonIcon
   title="Show History"
   onClick="{() => showLayersImage()}"
   detailed="{detailed}"
   icon="{faLayerGroup}" />
+{/if}
 
 {#if errorMessage}
   <div class="modal fixed w-full h-full top-0 left-0 flex items-center justify-center p-8 lg:p-0 z-50" tabindex="{0}">

--- a/packages/renderer/src/lib/image/ImageActions.svelte
+++ b/packages/renderer/src/lib/image/ImageActions.svelte
@@ -44,12 +44,12 @@ async function showLayersImage(): Promise<void> {
 {#if !image.inUse}
   <ListItemButtonIcon title="Delete Image" onClick="{() => deleteImage()}" detailed="{detailed}" icon="{faTrash}" />
 {/if}
-{#if (!detailed)}
-<ListItemButtonIcon
-  title="Show History"
-  onClick="{() => showLayersImage()}"
-  detailed="{detailed}"
-  icon="{faLayerGroup}" />
+{#if !detailed}
+  <ListItemButtonIcon
+    title="Show History"
+    onClick="{() => showLayersImage()}"
+    detailed="{detailed}"
+    icon="{faLayerGroup}" />
 {/if}
 
 {#if errorMessage}

--- a/packages/renderer/src/lib/pod/PodActions.svelte
+++ b/packages/renderer/src/lib/pod/PodActions.svelte
@@ -63,12 +63,14 @@ if (dropdownMenu) {
 
 <!-- If dropdownMenu is true, use it, otherwise just show the regular buttons -->
 <svelte:component this="{actionsStyle}">
+  {#if (!detailed)}
   <ListItemButtonIcon
     title="Generate Kube"
     onClick="{() => openGenerateKube()}"
     menu="{dropdownMenu}"
     detailed="{detailed}"
     icon="{faFileCode}" />
+  {/if}
   <ListItemButtonIcon
     title="Deploy to Kubernetes"
     onClick="{() => deployToKubernetes()}"

--- a/packages/renderer/src/lib/pod/PodActions.svelte
+++ b/packages/renderer/src/lib/pod/PodActions.svelte
@@ -63,13 +63,13 @@ if (dropdownMenu) {
 
 <!-- If dropdownMenu is true, use it, otherwise just show the regular buttons -->
 <svelte:component this="{actionsStyle}">
-  {#if (!detailed)}
-  <ListItemButtonIcon
-    title="Generate Kube"
-    onClick="{() => openGenerateKube()}"
-    menu="{dropdownMenu}"
-    detailed="{detailed}"
-    icon="{faFileCode}" />
+  {#if !detailed}
+    <ListItemButtonIcon
+      title="Generate Kube"
+      onClick="{() => openGenerateKube()}"
+      menu="{dropdownMenu}"
+      detailed="{detailed}"
+      icon="{faFileCode}" />
   {/if}
   <ListItemButtonIcon
     title="Deploy to Kubernetes"


### PR DESCRIPTION
### What does this PR do?

Removes 3 'redundant' actions from details pages:
- Container: Generate Kube
- Pod: Generate Kube
- Image: Show History

Although it's handy to have these as quick links from the main pages, these actions are already available via the tabs on the respective details page.

### What issues does this PR fix or reference?

Fixes #497.