### PR TITLE
feat: Add Help/about menu for macOS/Windows/Linux

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "chokidar": "^3.5.3",
     "dockerode": "^3.3.4",
     "electron-updater": "5.3.0",
+    "electron-util": "^0.17.2",
     "getos": "^3.2.1",
     "got": "^12.5.3",
     "hpagent": "^1.2.0",

--- a/packages/main/src/mainWindow.ts
+++ b/packages/main/src/mainWindow.ts
@@ -17,8 +17,10 @@
  ***********************************************************************/
 
 import type { BrowserWindowConstructorOptions, FileFilter } from 'electron';
+import { Menu } from 'electron';
 import { BrowserWindow, ipcMain, app, dialog, screen } from 'electron';
 import contextMenu from 'electron-context-menu';
+const { aboutMenuItem } = require('electron-util');
 import { join } from 'path';
 import { URL } from 'url';
 import type { ConfigurationRegistry } from './plugin/configuration-registry';
@@ -164,6 +166,29 @@ async function createWindow() {
       }
     },
   });
+
+  // Add help/about menu entry
+  const menu = Menu.getApplicationMenu(); // get default menu
+  if (menu) {
+    // build a new menu based on default one but adding about entry in the help menu
+    const newmenu = Menu.buildFromTemplate(
+      menu.items.map(i => {
+        // add the About entry only in the help menu
+        if (i.role === 'help' && i.submenu) {
+          const aboutMenuSubItem = aboutMenuItem({});
+          aboutMenuSubItem.label = 'About';
+
+          // create new submenu
+          // also add a separator before the About entry
+          const newSubMenu = Menu.buildFromTemplate([...i.submenu.items, { type: 'separator' }, aboutMenuSubItem]);
+          return Object.assign({}, i, { submenu: newSubMenu });
+        }
+        return i;
+      }),
+    );
+
+    Menu.setApplicationMenu(newmenu);
+  }
 
   /**
    * URL for main window.

--- a/yarn.lock
+++ b/yarn.lock
@@ -6272,6 +6272,11 @@ electron-dl@^3.2.1:
     pupa "^2.0.1"
     unused-filename "^2.1.0"
 
+electron-is-dev@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/electron-is-dev/-/electron-is-dev-1.2.0.tgz#2e5cea0a1b3ccf1c86f577cee77363ef55deb05e"
+  integrity sha512-R1oD5gMBPS7PVU8gJwH6CtT0e6VSoD0+SzSnYpNm+dBkcijgA+K7VAMHDfnRq/lkKPZArpzplTW6jfiMYosdzw==
+
 electron-is-dev@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/electron-is-dev/-/electron-is-dev-2.0.0.tgz#833487a069b8dad21425c67a19847d9064ab19bd"
@@ -6329,6 +6334,14 @@ electron-updater@5.3.0:
     lodash.isequal "^4.5.0"
     semver "^7.3.5"
     typed-emitter "^2.1.0"
+
+electron-util@^0.17.2:
+  version "0.17.2"
+  resolved "https://registry.yarnpkg.com/electron-util/-/electron-util-0.17.2.tgz#6b0fe798ae0154585e7e0e96a707bfeae592be05"
+  integrity sha512-4Kg/aZxJ2BZklgyfH86px/D2GyROPyIcnAZar+7KiNmKI2I5l09pwQTP7V95zM3FVhgDQwV9iuJta5dyEvuWAw==
+  dependencies:
+    electron-is-dev "^1.1.0"
+    new-github-issue-url "^0.2.1"
 
 electron@^22.0.2:
   version "22.0.2"
@@ -8950,6 +8963,11 @@ neo-async@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
+
+new-github-issue-url@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/new-github-issue-url/-/new-github-issue-url-0.2.1.tgz#e17be1f665a92de465926603e44b9f8685630c1d"
+  integrity sha512-md4cGoxuT4T4d/HDOXbrUHkTKrp/vp+m3aOA7XXVYwNsUNMK49g3SQicTSeV5GIz/5QVGAeYRAOlyp9OvlgsYA==
 
 ninja-keys@^1.2.2:
   version "1.2.2"


### PR DESCRIPTION
### What does this PR do?
Add Help/About entry to display the version of Podman Desktop

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/770


### How to test this PR?

On mac, Windows and Linux, check the availability of `Help/About` menu