### PR TITLE
fix: allows to continue the loading of extensions on missing package

### DIFF
--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -251,6 +251,12 @@ export class ExtensionLoader {
   }
 
   async loadExtension(extensionPath: string, removable: boolean): Promise<void> {
+    // do nothing if there is no package.json file
+    if (!fs.existsSync(path.resolve(extensionPath, 'package.json'))) {
+      console.warn(`Ignoring extension ${extensionPath} without package.json file`);
+      return;
+    }
+
     // load manifest
     const manifest = await this.loadManifest(extensionPath);
     this.overrideRequire();


### PR DESCRIPTION
### What does this PR do?
if the package.json is not there and we try to load directory it was not caught

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/1232

### How to test this PR?

Creates empty folder in `extensions/` folder and launch dev mode (`yarn watch`)

Change-Id: Ie0de17f8e3586a321f88877ba7af9c503563c81a
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
