### PR TITLE
fix: provide better error message on createPod error

### DIFF
--- a/packages/main/src/plugin/dockerode/libpod-dockerode.ts
+++ b/packages/main/src/plugin/dockerode/libpod-dockerode.ts
@@ -224,14 +224,23 @@ export class LibpodDockerode {
           204: true,
           304: 'pod already stopped',
           404: 'no such pod',
+          409: 'unexpected error',
           500: 'server error',
         },
         options: {},
       };
 
       return new Promise((resolve, reject) => {
-        this.modem.dial(optsf, (err: unknown, data: unknown) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        this.modem.dial(optsf, (err: any, data: unknown) => {
           if (err) {
+            if (err?.statusCode === 409 && err?.json) {
+              // check that err.json is a JSON
+              if (err.json.Errs) {
+                return reject(err.json.Errs.join(' '));
+              }
+            }
+
             return reject(err);
           }
           resolve(data);


### PR DESCRIPTION
### What does this PR do?
Unmarshall JSON and get the original error instead of [Object Object] 

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?

related to https://github.com/containers/podman-desktop/issues/1219

### How to test this PR?

<!-- Please explain steps to reproduce -->

Change-Id: I9f458d3f1ae8c8a6e3420f91e86eed832a3de16e
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
