### PR TITLE
feat: add ability to manually set color of tray icon for Windows and Linux

### DIFF
--- a/packages/main/src/index.ts
+++ b/packages/main/src/index.ts
@@ -112,13 +112,13 @@ app.whenReady().then(async () => {
   // Get the configuration registry (saves all our settings)
   const configurationRegistry = extensionLoader.getConfigurationRegistry();
 
-  // If we've manually set the tray icon colour, update the tray icon. This can only be done
-  // after configurationRegistry is loaded.
-  const colour = configurationRegistry.getConfiguration('preferences').get('TrayIconColour');
-
-  // If colour is a string, set it
-  if (typeof colour === 'string') {
-    animatedTray.setColour(colour);
+  // If we've manually set the tray icon color, update the tray icon. This can only be done
+  // after configurationRegistry is loaded. Windows or Linux support only for icon color change.
+  if (!isMac) {
+    const color = configurationRegistry.getConfiguration('preferences').get('TrayIconColor');
+    if (typeof color === 'string') {
+      animatedTray.setColor(color);
+    }
   }
 
   // Share configuration registry with renderer process

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -72,6 +72,7 @@ import type {
 
 import { AutostartEngine } from './autostart-engine';
 import { CloseBehavior } from './close-behavior';
+import { TrayIconColour } from './tray-icon-colour';
 import { KubernetesClient } from './kubernetes-client';
 import type { V1Pod, V1ConfigMap, V1NamespaceList, V1PodList, V1Service } from '@kubernetes/client-node';
 import type { V1Route } from './api/openshift-types';
@@ -270,6 +271,8 @@ export class PluginSystem {
     await kubernetesClient.init();
     const closeBehaviorConfiguration = new CloseBehavior(configurationRegistry, providerRegistry);
     await closeBehaviorConfiguration.init();
+    const trayIconColour = new TrayIconColour(configurationRegistry, providerRegistry);
+    await trayIconColour.init();
     const autoStartConfiguration = new AutostartEngine(configurationRegistry, providerRegistry);
     await autoStartConfiguration.init();
 

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -48,6 +48,7 @@ import { shell } from 'electron';
 import type { ImageInspectInfo } from './api/image-inspect-info';
 import type { TrayMenu } from '../tray-menu';
 import { getFreePort } from './util/port';
+import { isMac } from '../util';
 import { Dialogs } from './dialog-impl';
 import { ProgressImpl } from './progress-impl';
 import type { ContributionInfo } from './api/contribution-info';
@@ -72,7 +73,7 @@ import type {
 
 import { AutostartEngine } from './autostart-engine';
 import { CloseBehavior } from './close-behavior';
-import { TrayIconColour } from './tray-icon-colour';
+import { TrayIconColor } from './tray-icon-color';
 import { KubernetesClient } from './kubernetes-client';
 import type { V1Pod, V1ConfigMap, V1NamespaceList, V1PodList, V1Service } from '@kubernetes/client-node';
 import type { V1Route } from './api/openshift-types';
@@ -271,8 +272,13 @@ export class PluginSystem {
     await kubernetesClient.init();
     const closeBehaviorConfiguration = new CloseBehavior(configurationRegistry, providerRegistry);
     await closeBehaviorConfiguration.init();
-    const trayIconColour = new TrayIconColour(configurationRegistry, providerRegistry);
-    await trayIconColour.init();
+
+    // Don't show the tray icon options on Mac
+    if (!isMac) {
+      const trayIconColor = new TrayIconColor(configurationRegistry, providerRegistry);
+      await trayIconColor.init();
+    }
+
     const autoStartConfiguration = new AutostartEngine(configurationRegistry, providerRegistry);
     await autoStartConfiguration.init();
 

--- a/packages/main/src/plugin/tray-icon-color.ts
+++ b/packages/main/src/plugin/tray-icon-color.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2022 Red Hat, Inc.
+ * Copyright (C) 2023 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/main/src/plugin/tray-icon-color.ts
+++ b/packages/main/src/plugin/tray-icon-color.ts
@@ -19,18 +19,18 @@
 import type { ConfigurationRegistry, IConfigurationNode } from './configuration-registry';
 import type { ProviderRegistry } from './provider-registry';
 
-export class TrayIconColour {
+export class TrayIconColor {
   constructor(private configurationRegistry: ConfigurationRegistry, private providerRegistry: ProviderRegistry) {}
 
   async init(): Promise<void> {
     // add configuration
-    const trayIconColourConfigurationNode: IConfigurationNode = {
-      id: 'preferences.trayiconcolour',
-      title: 'Tray Icon Colour',
+    const trayIconColorConfigurationNode: IConfigurationNode = {
+      id: 'preferences.trayiconcolor',
+      title: 'Tray Icon Color',
       type: 'object',
       properties: {
-        ['preferences.TrayIconColour']: {
-          description: 'Force the tray icon colour to be light or dark. (Requires restart)',
+        ['preferences.TrayIconColor']: {
+          description: 'Force the tray icon color to be light or dark. (Requires restart)',
           type: 'string',
           enum: ['default', 'light', 'dark'],
           default: 'default',
@@ -38,6 +38,6 @@ export class TrayIconColour {
       },
     };
 
-    this.configurationRegistry.registerConfigurations([trayIconColourConfigurationNode]);
+    this.configurationRegistry.registerConfigurations([trayIconColorConfigurationNode]);
   }
 }

--- a/packages/main/src/plugin/tray-icon-colour.ts
+++ b/packages/main/src/plugin/tray-icon-colour.ts
@@ -1,0 +1,43 @@
+/**********************************************************************
+ * Copyright (C) 2022 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { ConfigurationRegistry, IConfigurationNode } from './configuration-registry';
+import type { ProviderRegistry } from './provider-registry';
+
+export class TrayIconColour {
+  constructor(private configurationRegistry: ConfigurationRegistry, private providerRegistry: ProviderRegistry) {}
+
+  async init(): Promise<void> {
+    // add configuration
+    const trayIconColourConfigurationNode: IConfigurationNode = {
+      id: 'preferences.trayiconcolour',
+      title: 'Tray Icon Colour',
+      type: 'object',
+      properties: {
+        ['preferences.TrayIconColour']: {
+          description: 'Force the tray icon colour to be light or dark. (Requires restart)',
+          type: 'string',
+          enum: ['default', 'light', 'dark'],
+          default: 'default',
+        },
+      },
+    };
+
+    this.configurationRegistry.registerConfigurations([trayIconColourConfigurationNode]);
+  }
+}

--- a/packages/main/src/tray-animate-icon.ts
+++ b/packages/main/src/tray-animate-icon.ts
@@ -27,7 +27,7 @@ export class AnimatedTray {
   private trayIconLoopId = 0;
   private animatedInterval: NodeJS.Timeout | undefined = undefined;
   private tray: Tray | undefined = undefined;
-  private colour = 'default'; // default, light, dark
+  private color = 'default'; // default, light, dark
 
   constructor() {
     this.status = 'initialized';
@@ -66,10 +66,10 @@ export class AnimatedTray {
     this.updateIcon();
   }
 
-  // set the colour of the icon if we're manually overriding the theme
+  // set the color of the icon if we're manually overriding the theme
   // and then update the current icon
-  public setColour(colour: string): void {
-    this.colour = colour;
+  public setColor(color: string): void {
+    this.color = color;
     this.updateIcon();
   }
 
@@ -97,10 +97,10 @@ export class AnimatedTray {
       }
     }
 
-    // Regardless what is the theme, if the user has set the colour to light, we use the light icon, same as dark, etc.
-    if (this.colour === 'light') {
+    // Regardless what is the theme, if the user has set the color to light, we use the light icon, same as dark, etc.
+    if (this.color === 'light') {
       suffix = 'Template';
-    } else if (this.colour === 'dark') {
+    } else if (this.color === 'dark') {
       suffix = 'Dark';
     }
 

--- a/packages/main/src/tray-animate-icon.ts
+++ b/packages/main/src/tray-animate-icon.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2022 Red Hat, Inc.
+ * Copyright (C) 2023 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@ import type { Tray } from 'electron';
 import * as path from 'path';
 import { isLinux, isMac } from './util';
 import { nativeTheme } from 'electron';
-
 export type TrayIconStatus = 'initialized' | 'updating' | 'error' | 'ready';
 
 export class AnimatedTray {
@@ -28,6 +27,7 @@ export class AnimatedTray {
   private trayIconLoopId = 0;
   private animatedInterval: NodeJS.Timeout | undefined = undefined;
   private tray: Tray | undefined = undefined;
+  private colour = 'default'; // default, light, dark
 
   constructor() {
     this.status = 'initialized';
@@ -66,6 +66,13 @@ export class AnimatedTray {
     this.updateIcon();
   }
 
+  // set the colour of the icon if we're manually overriding the theme
+  // and then update the current icon
+  public setColour(colour: string): void {
+    this.colour = colour;
+    this.updateIcon();
+  }
+
   // provide the path to the icon depending on theme and platform
   protected getIconPath(iconName: string): string {
     let name;
@@ -89,6 +96,14 @@ export class AnimatedTray {
         suffix = 'Template';
       }
     }
+
+    // Regardless what is the theme, if the user has set the colour to light, we use the light icon, same as dark, etc.
+    if (this.colour === 'light') {
+      suffix = 'Template';
+    } else if (this.colour === 'dark') {
+      suffix = 'Dark';
+    }
+
     return path.resolve(this.getAssetsFolder(), `tray-icon${name}${suffix}.png`);
   }
 

--- a/packages/main/src/tray-animate-icon.ts
+++ b/packages/main/src/tray-animate-icon.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2022-2023 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
@@ -129,7 +129,7 @@ async function selectFilePath() {
         required />
     {:else if record.type === 'string' && record.enum && record.enum.length > 0}
       <select
-        class="border  text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 bg-gray-600 border-gray-500 placeholder-gray-400 text-white"
+        class="border-b text-md focus:ring-blue-500 focus:border-blue-500 block w-full p-1 bg-zinc-700 border-gray-500 placeholder-gray-400 text-white"
         name="{record.id}"
         id="input-standard-{record.id}"
         on:input="{event => checkValue(record, event)}"


### PR DESCRIPTION
feat: add ability to manually set colour of icon

### What does this PR do?

* Allows the ability to set the default 'theme' of the icon to either
light (black icon) or dark (white icon).

__NOTE:__ This does not work on Mac, because if you set the theme to
'light' to display a black icon, macOS will automatically detect it is
an all-black icon, and invert the colours to white.

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

![Screenshot 2023-01-24 at 3 47 48 PM](https://user-images.githubusercontent.com/6422176/214415442-ae67011d-e0b9-4214-adbb-c542db85492f.png)
![Screenshot 2023-01-24 at 3 48 18 PM](https://user-images.githubusercontent.com/6422176/214415475-df66731b-30f8-4d29-a3dd-9e9c14352bd4.png)



### What issues does this PR fix or reference?

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

Closes https://github.com/containers/podman-desktop/issues/980

### How to test this PR?

1. Compile / yarn watch on Windows
2. Change the setting
3. Restart podman desktop and view the icon on the taskbar.

<!-- Please explain steps to reproduce -->

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
