### PR TITLE
fix: Consistent empty icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "podman-desktop",
   "productName": "Podman Desktop",
   "repository": "https://github.com/containers/podman-desktop",
-  "version": "0.11.0-next",
+  "version": "0.0.202301242017-0b66aeb",
   "license": "apache-2.0",
   "type": "module",
   "private": true,

--- a/packages/renderer/src/lib/ContainerList.svelte
+++ b/packages/renderer/src/lib/ContainerList.svelte
@@ -548,10 +548,10 @@ function errorCallback(container: ContainerInfoUI, errorMessage: string): void {
   </div>
 
   <div slot="empty" class="min-h-full">
-    {#if providerConnections.length > 0}
-      <ContainerEmptyScreen slot="empty" containers="{$filtered}" />
-    {:else}
-      <NoContainerEngineEmptyScreen slot="empty" />
+    {#if providerConnections.length === 0}
+      <NoContainerEngineEmptyScreen />
+    {:else if $filtered.length === 0}
+      <ContainerEmptyScreen />
     {/if}
   </div>
 </NavPage>

--- a/packages/renderer/src/lib/ImagesList.svelte
+++ b/packages/renderer/src/lib/ImagesList.svelte
@@ -320,10 +320,10 @@ function computeInterval(): number {
     </table>
   </div>
   <div slot="empty" class="min-h-full">
-    {#if providerConnections.length > 0}
-      <ImageEmptyScreen images="{$filtered}" />
-    {:else}
+    {#if providerConnections.length === 0}
       <NoContainerEngineEmptyScreen />
+    {:else if $filtered.length === 0}
+      <ImageEmptyScreen />
     {/if}
 
     {#if pushImageModal}

--- a/packages/renderer/src/lib/container/ContainerEmptyScreen.svelte
+++ b/packages/renderer/src/lib/container/ContainerEmptyScreen.svelte
@@ -1,33 +1,10 @@
 <script lang="ts">
-import Fa from 'svelte-fa/src/fa.svelte';
-import { faPaste } from '@fortawesome/free-solid-svg-icons';
-import { onMount } from 'svelte';
-
-export let containers: Array<unknown>;
-
-function copyRunInstructionToClipboard() {
-  const text = copyText?.innerText;
-  navigator.clipboard.writeText(text);
-}
-
-let copyText;
-
-onMount(async () => {
-  copyText = document.getElementById('noContainerCommandLine') as HTMLElement;
-});
+import EmptyScreen from '../ui/EmptyScreen.svelte';
+import ContainerIcon from '../images/ContainerIcon.svelte';
 </script>
 
-<div class="h-full min-w-full flex flex-col" class:hidden="{containers.length > 0}">
-  <div class="pf-c-empty-state h-full">
-    <div class="pf-c-empty-state__content">
-      <i class="fas fa-cubes pf-c-empty-state__icon" aria-hidden="true"></i>
-      <h1 class="pf-c-title pf-m-lg">No containers</h1>
-      <div class="pf-c-empty-state__body">Run a first container using the following command line:</div>
-      <div class="flex flex-row bg-gray-800 w-full items-center p-2 mt-2">
-        <div id="noContainerCommandLine">podman run quay.io/podman/hello</div>
-        <button title="Copy To Clipboard" class="mr-5" on:click="{() => copyRunInstructionToClipboard()}"
-          ><Fa class="ml-3 h-5 w-5 cursor-pointer rounded-full text-3xl text-sky-800" icon="{faPaste}" /></button>
-      </div>
-    </div>
-  </div>
-</div>
+<EmptyScreen
+  icon={ContainerIcon}
+  title="No containers"
+  message="Run a first container using the following command line:"
+  commandline="podman run quay.io/podman/hello"/>

--- a/packages/renderer/src/lib/image/ImageEmptyScreen.svelte
+++ b/packages/renderer/src/lib/image/ImageEmptyScreen.svelte
@@ -1,34 +1,10 @@
 <script lang="ts">
-import Fa from 'svelte-fa/src/fa.svelte';
-import { faPaste } from '@fortawesome/free-solid-svg-icons';
-import { onMount } from 'svelte';
-
-export let images: Array<unknown>;
-
-function copyPullInstructionToClipboard() {
-  const text = copyText?.innerText;
-  navigator.clipboard.writeText(text);
-}
-
-let copyText;
-
-onMount(async () => {
-  copyText = document.getElementById('noImageCommandLine') as HTMLElement;
-});
+import EmptyScreen from '../ui/EmptyScreen.svelte';
+import ImageIcon from '../images/ImageIcon.svelte';
 </script>
 
-<div class="h-full min-w-full flex flex-col" class:hidden="{images.length > 0}">
-  <div class="pf-c-empty-state h-full">
-    <div class="pf-c-empty-state__content">
-      <i class="fas fa-layer-group pf-c-empty-state__icon" aria-hidden="true"></i>
-
-      <h1 class="pf-c-title pf-m-lg">No images</h1>
-      <div class="pf-c-empty-state__body">Pull a first image using the following command line:</div>
-      <div class="flex flex-row bg-gray-800 w-full items-center justify-center p-2 mt-2">
-        <div id="noImageCommandLine">podman pull redhat/ubi8-micro</div>
-        <button title="Copy To Clipboard" class="mr-5" on:click="{() => copyPullInstructionToClipboard()}"
-          ><Fa class="ml-3 h-5 w-5 cursor-pointer rounded-full text-3xl text-sky-800" icon="{faPaste}" /></button>
-      </div>
-    </div>
-  </div>
-</div>
+<EmptyScreen
+  icon="{ImageIcon}"
+  title="No images"
+  message="Pull a first image using the following command line:"
+  commandline="podman pull redhat/ubi8-micro" />

--- a/packages/renderer/src/lib/pod/PodEmptyScreen.svelte
+++ b/packages/renderer/src/lib/pod/PodEmptyScreen.svelte
@@ -1,33 +1,10 @@
 <script lang="ts">
-import Fa from 'svelte-fa/src/fa.svelte';
-import { faPaste } from '@fortawesome/free-solid-svg-icons';
-import { onMount } from 'svelte';
-
-export let pods: Array<unknown>;
-
-function copyRunInstructionToClipboard() {
-  const text = copyText?.innerText;
-  navigator.clipboard.writeText(text);
-}
-
-let copyText;
-
-onMount(async () => {
-  copyText = document.getElementById('noPodCommandLine') as HTMLElement;
-});
+import EmptyScreen from '../ui/EmptyScreen.svelte';
+import PodIcon from '../images/PodIcon.svelte';
 </script>
 
-<div class="h-full min-w-full flex flex-col" class:hidden="{pods.length > 0}">
-  <div class="pf-c-empty-state h-full">
-    <div class="pf-c-empty-state__content">
-      <i class="fas fa-cubes pf-c-empty-state__icon" aria-hidden="true"></i>
-      <h1 class="pf-c-title pf-m-lg">No pods</h1>
-      <div class="pf-c-empty-state__body">Run a first pod using the following command line:</div>
-      <div class="flex flex-row bg-gray-800 w-full items-center p-2 mt-2">
-        <div id="noPodCommandLine">podman pod create --label myFirstPod</div>
-        <button title="Copy To Clipboard" class="mr-5" on:click="{() => copyRunInstructionToClipboard()}"
-          ><Fa class="ml-3 h-5 w-5 cursor-pointer rounded-full text-3xl text-sky-800" icon="{faPaste}" /></button>
-      </div>
-    </div>
-  </div>
-</div>
+<EmptyScreen
+  icon="{PodIcon}"
+  title="No pods"
+  message="Run a first pod using the following command line:"
+  commandline="podman volume create myFirstVolume" />

--- a/packages/renderer/src/lib/pod/PodsList.svelte
+++ b/packages/renderer/src/lib/pod/PodsList.svelte
@@ -287,10 +287,10 @@ function computeInterval(): number {
     </table>
   </div>
   <div slot="empty" class="min-h-full">
-    {#if providerConnections.length > 0}
-      <PodEmptyScreen pods="{$filtered}" />
-    {:else}
+    {#if providerConnections.length === 0}
       <NoContainerEngineEmptyScreen />
+    {:else if $filtered.length === 0}
+      <PodEmptyScreen />
     {/if}
   </div>
 </NavPage>

--- a/packages/renderer/src/lib/volume/VolumeEmptyScreen.svelte
+++ b/packages/renderer/src/lib/volume/VolumeEmptyScreen.svelte
@@ -1,33 +1,10 @@
 <script lang="ts">
-import Fa from 'svelte-fa/src/fa.svelte';
-import { faPaste } from '@fortawesome/free-solid-svg-icons';
-import { onMount } from 'svelte';
-
-export let volumes: Array<unknown>;
-
-function copyRunInstructionToClipboard() {
-  const text = copyText?.innerText;
-  navigator.clipboard.writeText(text);
-}
-
-let copyText;
-
-onMount(async () => {
-  copyText = document.getElementById('noVolumeCommandLine') as HTMLElement;
-});
+import EmptyScreen from '../ui/EmptyScreen.svelte';
+import VolumeIcon from '../images/VolumeIcon.svelte';
 </script>
 
-<div class="h-full min-w-full flex flex-col" class:hidden="{volumes.length > 0}">
-  <div class="pf-c-empty-state h-full">
-    <div class="pf-c-empty-state__content">
-      <i class="fas fa-cubes pf-c-empty-state__icon" aria-hidden="true"></i>
-      <h1 class="pf-c-title pf-m-lg">No volumes</h1>
-      <div class="pf-c-empty-state__body">Create a volume using the following command line:</div>
-      <div class="flex flex-row bg-gray-800 w-full items-center p-2 mt-2">
-        <div id="noVolumeCommandLine">podman volume create myFirstVolume</div>
-        <button title="Copy To Clipboard" class="mr-5" on:click="{() => copyRunInstructionToClipboard()}"
-          ><Fa class="ml-3 h-5 w-5 cursor-pointer rounded-full text-3xl text-sky-800" icon="{faPaste}" /></button>
-      </div>
-    </div>
-  </div>
-</div>
+<EmptyScreen
+  icon="{VolumeIcon}"
+  title="No volumes"
+  message="Create a volume using the following command line:"
+  commandline="podman volume create myFirstVolume" />

--- a/packages/renderer/src/lib/volume/VolumesList.svelte
+++ b/packages/renderer/src/lib/volume/VolumesList.svelte
@@ -271,10 +271,10 @@ function computeInterval(): number {
     </table>
   </div>
   <div slot="empty" class="min-h-full">
-    {#if providerConnections.length > 0}
-      <VolumeEmptyScreen volumes="{$filtered}" />
-    {:else}
+    {#if providerConnections.length === 0}
       <NoContainerEngineEmptyScreen />
+    {:else if $filtered.length === 0}
+      <VolumeEmptyScreen />
     {/if}
   </div>
 </NavPage>


### PR DESCRIPTION
### What does this PR do?

Fix each of the four empty screens to use the correct SVG icon and reduce code duplication via EmptyScreen.

Switched the order of the if statement in each of the lists because I thought this is more natural, and avoids passing array into each screen to confirm if it is empty.

The volumes empty screen does not appear before or after this change because filtered.length == 1 when there are no visible volumes, will continue investigating via separate PR.

### Screenshot/screencast of this PR

<img width="337" alt="no-pods" src="https://user-images.githubusercontent.com/19958075/214433881-0cb66745-0709-40c8-970b-db5007654042.png">