### PR TITLE
chore: add cursor-default to logo to not display text selection

### DIFF
--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -75,7 +75,7 @@ window.events?.receive('display-help', () => {
         <div
           class="flex order-none title-font font-medium items-center text-white align-middle justify-center mb-4 md:mb-0">
           <Logo />
-          <span class="ml-3 text-xl block text-gray-300">Podman Desktop</span>
+          <span class="select-none ml-3 text-xl block text-gray-300">Podman Desktop</span>
         </div>
         <div class="lg:w-2/5 flex-1 lg:justify-end ml-5 lg:ml-0"></div>
       </div>


### PR DESCRIPTION
chore: add cursor-default to logo to not display text selection

### What does this PR do?

Super small nitpick. Does not display the "text selection" cursor icon when moving the Podman
Desktop application while hovering over the logo (most likely doesn't
affect the production build of Podman Desktop, but it does show it in
dev mode).

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

https://user-images.githubusercontent.com/6422176/214679662-6c93ff78-412c-4fe8-a52b-e712cd1f800f.mov




### What issues does this PR fix or reference?

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

N/A

### How to test this PR?

<!-- Please explain steps to reproduce -->

Run `yarn watch` and move Podman Desktop around by the logo, it should
no longer show the "text selection" cursor on your mouse.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
