### PR TITLE
fix: handle path with spaces on Windows when installing Podman (#1208)

### DIFF
--- a/extensions/kind/src/util.ts
+++ b/extensions/kind/src/util.ts
@@ -69,6 +69,8 @@ export function runCliCommand(command: string, args: string[], options?: RunOpti
     // In production mode, applications don't have access to the 'user' path like brew
     if (isMac || isWindows) {
       env.PATH = getKindPath();
+      // Escape any whitespaces in command
+      command = `"${command}"`;
     } else if (env.FLATPAK_ID) {
       // need to execute the command on the host
       args = ['--host', command, ...args];
@@ -78,9 +80,6 @@ export function runCliCommand(command: string, args: string[], options?: RunOpti
     if (options?.env) {
       env = Object.assign(env, options.env);
     }
-
-    // Escape any whitespaces in command
-    command = command.replace(/(\s+)/g, '\\$1');
 
     const spawnProcess = spawn(command, args, { shell: isWindows, env });
     // do not reject as we want to store exit code in the result

--- a/extensions/podman/src/util.ts
+++ b/extensions/podman/src/util.ts
@@ -63,6 +63,8 @@ export function runCliCommand(command: string, args: string[], options?: RunOpti
     // In production mode, applications don't have access to the 'user' path like brew
     if (isMac || isWindows) {
       env.PATH = getInstallationPath();
+      // Escape any whitespaces in command
+      command = `"${command}"`;
     } else if (env.FLATPAK_ID) {
       // need to execute the command on the host
       args = ['--host', command, ...args];
@@ -72,9 +74,6 @@ export function runCliCommand(command: string, args: string[], options?: RunOpti
     if (options?.env) {
       env = Object.assign(env, options.env);
     }
-
-    // Escape any whitespaces in command
-    command = command.replace(/(\s+)/g, '\\$1');
 
     const spawnProcess = spawn(command, args, { shell: isWindows, env });
     spawnProcess.on('error', err => {


### PR DESCRIPTION
### What does this PR do?

It makes sure to install Podman even on paths having spaces
Found a discussion on node repo about it https://github.com/nodejs/node/issues/38490#issuecomment-830544134
By wrapping the path with double quotes everything should work fine.

This also impacts MacOs users so please give it a try. It should work though.

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

Fixes #1208 

### How to test this PR?

1. make sure you don't have podman installed and you have a username with a space in it
2. start podman-desktop and install podman from it
