### PR TITLE
fix: Link to simple WSL2 installation instructions

### DIFF
--- a/extensions/podman/src/podman-install.ts
+++ b/extensions/podman/src/podman-install.ts
@@ -432,15 +432,15 @@ class WSL2Check extends BaseCheck {
       if (!isWSL) {
         if (isAdmin) {
           return this.createFailureResult(
-            'WSL2 is not installed. Call "wsl --install" in terminal.',
+            'WSL2 is not installed. Call "wsl --install" in a terminal.',
             'Install WSL',
-            'https://docs.microsoft.com/en-us/windows/wsl/install-manual',
+            'https://learn.microsoft.com/en-us/windows/wsl/install',
           );
         } else {
           return this.createFailureResult(
             'WSL2 is not installed or you do not have permissions to run WSL2. Contact your Administrator to setup WSL2.',
             'More info',
-            'https://docs.microsoft.com/en-us/windows/wsl/install-manual',
+            'https://learn.microsoft.com/en-us/windows/wsl/install',
           );
         }
       }
@@ -448,7 +448,7 @@ class WSL2Check extends BaseCheck {
       return this.createFailureResult(
         'Could not detect WSL2',
         'Install WSL',
-        'https://docs.microsoft.com/en-us/windows/wsl/install-manual',
+        'https://learn.microsoft.com/en-us/windows/wsl/install',
       );
     }
 

--- a/website/docs/Installation/windows-install.md
+++ b/website/docs/Installation/windows-install.md
@@ -9,7 +9,7 @@ This page contains information regarding installation of Podman Desktop on Windo
 :::infoPrerequisites:
 **NOTE: Administrator access is required for both these prerequisites.**
 1. [Hyper-V should be enabled](https://learn.microsoft.com/en-us/virtualization/hyper-v-on-windows/quick-start/enable-hyper-v)
-2. [Windows Subsystem for Linux v2 (WSL2)](https://learn.microsoft.com/en-us/windows/wsl/install-manual) should be installed.
+2. [Windows Subsystem for Linux v2 (WSL2)](https://learn.microsoft.com/en-us/windows/wsl/install) should be installed.
 :::
 
 ## Installing Podman Desktop on Windows


### PR DESCRIPTION
Microsoft provides two pages with installation instructions for WSL2:
* https://learn.microsoft.com/en-us/windows/wsl/install for a "typical" installation on recent versions. This page also describes the quick way of doing an installation using `wsl --install`.
* https://learn.microsoft.com/en-us/windows/wsl/install-manual with manual installation instructions for older Windows versions (or special cases).

Currently users are always directed to the manual installation instructions, even in cases where the instruction above it reads `Call "wsl --install" in terminal.`. That's confusing users, who might be tricked into doing the more elaborate manual setup when there's a much easier way.

Update the links to point to the simple installation mechanism by default. This page also links to the manual setup if users need it.

Signed-off-by: Philipp Wagner <phw@ibm.com>
