### PR TITLE
feat: adds option to minimize on start

### DIFF
--- a/packages/main/src/index.ts
+++ b/packages/main/src/index.ts
@@ -18,7 +18,7 @@
 
 import { app, ipcMain, Tray } from 'electron';
 import './security-restrictions';
-import { restoreOrCreateWindow } from '/@/mainWindow';
+import { createNewWindow, restoreOrCreateWindow, restoreWindow } from '/@/mainWindow';
 import { TrayMenu } from './tray-menu';
 import { isMac, isWindows } from './util';
 import { AnimatedTray } from './tray-animate-icon';
@@ -33,7 +33,11 @@ if (!isSingleInstance) {
   app.quit();
   process.exit(0);
 }
-app.on('second-instance', restoreOrCreateWindow);
+
+// Only executes when a second instance has started and tries
+// to call on requestSingleInstanceLock. If this happens, we'll find
+// the first window and restore it / unminimize it.
+app.on('second-instance', restoreWindow);
 
 /**
  * Disable Hardware Acceleration for more power-save
@@ -50,40 +54,11 @@ app.on('window-all-closed', () => {
 });
 
 /**
- * @see https://www.electronjs.org/docs/v14-x-y/api/app#event-activate-macos Event: 'activate'
- */
-app.on('activate', restoreOrCreateWindow);
-
-/**
  *  @see https://www.electronjs.org/docs/latest/api/app#appsetappusermodelidid-windows
  */
 if (isWindows) {
   app.setAppUserModelId(app.name);
 }
-
-/**
- * Create app window when background process will be ready
- */
-app
-  .whenReady()
-  .then(restoreOrCreateWindow)
-  .catch(e => console.error('Failed create window:', e));
-
-/**
- * Install some other devtools in development mode only
- */
-/*
-if (import.meta.env.DEV) {
-  app.whenReady()
-    .then(() => import('electron-devtools-installer'))
-    .then(({default: installExtension, VUEJS3_DEVTOOLS}) => installExtension(VUEJS3_DEVTOOLS, {
-      loadExtensionOptions: {
-        allowFileAccess: true,
-      },
-    }))
-    .catch(e => console.error('Failed install extension:', e));
-}
-*/
 
 /**
  * Check new app version in production mode only
@@ -98,33 +73,54 @@ if (import.meta.env.PROD) {
 
 let tray: Tray | null = null;
 
-app.whenReady().then(async () => {
-  // Setup the default tray icon + menu items
-  const animatedTray = new AnimatedTray();
-  tray = new Tray(animatedTray.getDefaultImage());
-  animatedTray.setTray(tray);
-  const trayMenu = new TrayMenu(tray, animatedTray);
+app.whenReady().then(
+  async () => {
+    // We must create the window first before initialization so that we can load the
+    // configuration as well as plugins
+    // The window is hiddenly created and shown when ready
 
-  // Start extensions
-  const pluginSystem = new PluginSystem(trayMenu);
-  const extensionLoader = await pluginSystem.initExtensions();
+    // Platforms: Linux, macOS, Windows
+    // Create the main window
+    createNewWindow();
 
-  // Get the configuration registry (saves all our settings)
-  const configurationRegistry = extensionLoader.getConfigurationRegistry();
+    // Platforms: macOS
+    // Required for macOS to start the app correctly (this is will be shown in the dock)
+    // https://www.electronjs.org/docs/latest/api/app#event-activate-macos
+    app.on('activate', createNewWindow);
 
-  // If we've manually set the tray icon color, update the tray icon. This can only be done
-  // after configurationRegistry is loaded. Windows or Linux support only for icon color change.
-  if (!isMac) {
-    const color = configurationRegistry.getConfiguration('preferences').get('TrayIconColor');
-    if (typeof color === 'string') {
-      animatedTray.setColor(color);
+    // Setup the default tray icon + menu items
+    const animatedTray = new AnimatedTray();
+    tray = new Tray(animatedTray.getDefaultImage());
+    animatedTray.setTray(tray);
+    const trayMenu = new TrayMenu(tray, animatedTray);
+
+    // Start extensions
+    const pluginSystem = new PluginSystem(trayMenu);
+    const extensionLoader = await pluginSystem.initExtensions();
+
+    // Get the configuration registry (saves all our settings)
+    const configurationRegistry = extensionLoader.getConfigurationRegistry();
+
+    // If we've manually set the tray icon color, update the tray icon. This can only be done
+    // after configurationRegistry is loaded. Windows or Linux support only for icon color change.
+    if (!isMac) {
+      const color = configurationRegistry.getConfiguration('preferences').get('TrayIconColor');
+      if (typeof color === 'string') {
+        animatedTray.setColor(color);
+      }
     }
-  }
 
-  // Share configuration registry with renderer process
-  ipcMain.emit('configuration-registry', '', configurationRegistry);
+    // Share configuration registry with renderer process
+    ipcMain.emit('configuration-registry', '', configurationRegistry);
 
-  // Configure automatic startup
-  const automaticStartup = new StartupInstall(configurationRegistry);
-  await automaticStartup.configure();
-});
+    // Configure automatic startup
+    const automaticStartup = new StartupInstall(configurationRegistry);
+    await automaticStartup.configure();
+
+    // Restore or create the main window now that we've loaded the configuration
+    // we pass in the configuration registry so that we can use it to restore the window
+    // based upon the user's preferences (start on minimized, tray only, etc.)
+    restoreOrCreateWindow(configurationRegistry);
+  },
+  e => console.error('Failed to start app:', e),
+);

--- a/packages/main/src/index.ts
+++ b/packages/main/src/index.ts
@@ -85,7 +85,8 @@ app.whenReady().then(
 
     // Platforms: macOS
     // Required for macOS to start the app correctly (this is will be shown in the dock)
-    // https://www.electronjs.org/docs/latest/api/app#event-activate-macos
+    // We use 'activate' within whenReady in order to gracefully start on macOS, see this link:
+    // https://www.electronjs.org/docs/latest/tutorial/quick-start#open-a-window-if-none-are-open-macos
     app.on('activate', createNewWindow);
 
     // Setup the default tray icon + menu items

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -74,6 +74,7 @@ import type {
 import { AutostartEngine } from './autostart-engine';
 import { CloseBehavior } from './close-behavior';
 import { TrayIconColor } from './tray-icon-color';
+import { StartMinimized } from './start-minimized';
 import { KubernetesClient } from './kubernetes-client';
 import type { V1Pod, V1ConfigMap, V1NamespaceList, V1PodList, V1Service } from '@kubernetes/client-node';
 import type { V1Route } from './api/openshift-types';
@@ -281,6 +282,9 @@ export class PluginSystem {
 
     const autoStartConfiguration = new AutostartEngine(configurationRegistry, providerRegistry);
     await autoStartConfiguration.init();
+
+    const startMinimized = new StartMinimized(configurationRegistry);
+    await startMinimized.init();
 
     providerRegistry.addProviderListener((name: string, providerInfo: ProviderInfo) => {
       if (name === 'provider:update-status') {

--- a/packages/main/src/plugin/start-minimized.ts
+++ b/packages/main/src/plugin/start-minimized.ts
@@ -1,0 +1,40 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { ConfigurationRegistry, IConfigurationNode } from './configuration-registry';
+
+export class StartMinimized {
+  constructor(private configurationRegistry: ConfigurationRegistry) {}
+
+  async init(): Promise<void> {
+    const startMinimizedConfigurationNode: IConfigurationNode = {
+      id: 'preferences.startminimized',
+      title: 'Start Minimized',
+      type: 'object',
+      properties: {
+        ['preferences.StartMinimized']: {
+          description: 'On startup, start the application minimized to the tray. (Requires restart)',
+          type: 'boolean',
+          default: 'false',
+        },
+      },
+    };
+
+    this.configurationRegistry.registerConfigurations([startMinimizedConfigurationNode]);
+  }
+}


### PR DESCRIPTION
feat: adds option to minimize on start

### What does this PR do?

* Refactors the index.ts and mainWindow.ts functionality when first
  intilizating Podman Desktop. We must be able to retrieve configuration
  settings before creating windows, and a refactor was required to
  implement that change
* Podman Desktop will now start minimized on Windows, macOS and Linux

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

Closes https://github.com/containers/podman-desktop/issues/868

### How to test this PR?

Set the setting within Preferences, and restart Podman Desktop

<!-- Please explain steps to reproduce -->
