### PR TITLE
fix: Add error on form if you didn't select a smiley/experience feedback

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "compile:pull-request": "cross-env MODE=production npm run build && electron-builder build --publish never --config .electron-builder.config.cjs",
     "compile:current": "cross-env MODE=production npm run build && electron-builder build --config .electron-builder.config.cjs",
     "test": "npm run test:main && npm run test:preload && npm run test:preload-docker-extension && npm run test:renderer && npm run test:e2e && npm run test:extensions",
-    "test:e2e": "npm run build && xvfb-maybe vitest run",
+    "test:e2e": "npm run build && xvfb-maybe vitest run tests",
     "test:main": "vitest run -r packages/main --passWithNoTests",
     "test:preload": "vitest run -r packages/preload --passWithNoTests",
     "test:preload-docker-extension": "vitest run -r packages/preload-docker-extension --passWithNoTests",

--- a/packages/renderer/src/lib/feedback/SendFeedback.spec.ts
+++ b/packages/renderer/src/lib/feedback/SendFeedback.spec.ts
@@ -1,0 +1,57 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom';
+import { beforeAll, test, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/svelte';
+import SendFeedback from './SendFeedback.svelte';
+
+// fake the window.events object
+beforeAll(() => {
+  (window.events as unknown) = {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    receive: (_channel: string, func: any) => {
+      func();
+    },
+  };
+});
+
+test('Expect that the button is disabled when loading the page', async () => {
+  render(SendFeedback, {});
+  const button = screen.getByRole('button', { name: 'Send feedback' });
+  expect(button).toBeInTheDocument();
+  expect(button).toBeDisabled();
+});
+
+test('Expect that the button is enabled after clicking on a smiley', async () => {
+  render(SendFeedback, {});
+  const button = screen.getByRole('button', { name: 'Send feedback' });
+
+  // expect to have indication why the button is disabled
+  expect(screen.getByText('Please select an experience smiley')).toBeInTheDocument();
+
+  // click on a smiley
+  const smiley = screen.getByRole('button', { name: 'very-happy-smiley' });
+  await fireEvent.click(smiley);
+
+  // now expect to have the button enabled
+  expect(button).toBeEnabled();
+
+  // and the indication is gone
+  expect(screen.queryByText('Please select an experience smiley')).not.toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/feedback/SendFeedback.svelte
+++ b/packages/renderer/src/lib/feedback/SendFeedback.svelte
@@ -63,30 +63,30 @@ async function sendFeedback(): Promise<void> {
         <label for="smiley" class="block mb-2 text-sm font-medium text-gray-300 dark:text-gray-300"
           >How was your experience with Podman Desktop ?</label>
         <div class="flex space-x-4">
-          <div on:click="{() => selectSmiley(1)}">
+          <button aria-label="very-sad-smiley" on:click="{() => selectSmiley(1)}">
             <Fa
               size="24"
               class="cursor-pointer {smileyRating === 1 ? 'text-violet-400' : 'text-gray-500'}"
               icon="{faFrown}" />
-          </div>
-          <div on:click="{() => selectSmiley(2)}">
+          </button>
+          <button aria-label="sad-smiley" on:click="{() => selectSmiley(2)}">
             <Fa
               size="24"
               class="cursor-pointer {smileyRating === 2 ? 'text-violet-400' : 'text-gray-500'}"
               icon="{faMeh}" />
-          </div>
-          <div on:click="{() => selectSmiley(3)}">
+          </button>
+          <button aria-label="happy-smiley" on:click="{() => selectSmiley(3)}">
             <Fa
               size="24"
               class="cursor-pointer {smileyRating === 3 ? 'text-violet-400' : 'text-gray-500'}"
               icon="{faSmile}" />
-          </div>
-          <div on:click="{() => selectSmiley(4)}">
+          </button>
+          <button aria-label="very-happy-smiley" on:click="{() => selectSmiley(4)}">
             <Fa
               size="24"
               class="cursor-pointer {smileyRating === 4 ? 'text-violet-400' : 'text-gray-500'}"
               icon="{faGrinStars}" />
-          </div>
+          </button>
         </div>
 
         <label for="tellUsWhyFeedback" class="block mt-4 mb-2 text-sm font-medium text-gray-300 dark:text-gray-300"
@@ -112,12 +112,18 @@ async function sendFeedback(): Promise<void> {
           placeholder="Enter email address, phone number or leave blank for anonymous feedback"
           class="w-full p-2 outline-none text-sm bg-zinc-900 rounded-sm text-gray-400 placeholder-gray-400" />
 
-        <div class="pt-5 flex flex-row justify-end">
-          <button
-            disabled="{smileyRating === 0}"
-            class="pf-c-button pf-m-primary"
-            type="button"
-            on:click="{() => sendFeedback()}">Send feedback</button>
+        <div class="pt-5 flex flex-row w-full">
+          {#if smileyRating === 0}
+            <div class="text-red-600 text-xs flex flex-row w-[300px]">Please select an experience smiley</div>
+          {/if}
+
+          <div class="flex flex-row justify-end w-full">
+            <button
+              disabled="{smileyRating === 0}"
+              class="pf-c-button pf-m-primary"
+              type="button"
+              on:click="{() => sendFeedback()}">Send feedback</button>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
### What does this PR do?

Display an error until a feedback is selected and then enable the button

- [x] depends on https://github.com/containers/podman-desktop/pull/1285

### Screenshot/screencast of this PR
![image](https://user-images.githubusercontent.com/436777/215745073-27d066a6-bc61-4a74-92ed-824febfa076c.png)



### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/1275


### How to test this PR?

Integration test should pass


Change-Id: Iba6dbfa0ee01781a453442685f6a5acc763e4a1c
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
