### PR TITLE
docs(fix): typo that caused page title to appear twice

### DIFF
--- a/website/docs/Installation/windows-install/installing-podman-desktop-with-winget.md
+++ b/website/docs/Installation/windows-install/installing-podman-desktop-with-winget.md
@@ -6,7 +6,7 @@ tags: [podman-desktop, installing, windows, winget]
 keywords: [podman desktop, containers, podman, installing, installation, windows, winget]
 ---
 
-## Installing Podman Desktop with Winget
+# Installing Podman Desktop with Winget
 
 #### Prerequisites
 


### PR DESCRIPTION
* Fixed "Installing Podman Desktop with Winget" title appearing twice in https://podman-desktop.io/docs/Installation/windows-install/installing-podman-desktop-with-winget

Signed-off-by: Fabrice Flore-Thébault <ffloreth@redhat.com>

### What does this PR do?

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

### How to test this PR?

<!-- Please explain steps to reproduce -->
