### PR TITLE
refactor: refactors window initializing

### DIFF
--- a/packages/main/src/index.ts
+++ b/packages/main/src/index.ts
@@ -18,7 +18,7 @@
 
 import { app, ipcMain, Tray } from 'electron';
 import './security-restrictions';
-import { restoreOrCreateWindow } from '/@/mainWindow';
+import { createNewWindow, restoreWindow } from '/@/mainWindow';
 import { TrayMenu } from './tray-menu';
 import { isMac, isWindows } from './util';
 import { AnimatedTray } from './tray-animate-icon';
@@ -33,7 +33,7 @@ if (!isSingleInstance) {
   app.quit();
   process.exit(0);
 }
-app.on('second-instance', restoreOrCreateWindow);
+app.on('second-instance', restoreWindow);
 
 /**
  * Disable Hardware Acceleration for more power-save
@@ -50,40 +50,11 @@ app.on('window-all-closed', () => {
 });
 
 /**
- * @see https://www.electronjs.org/docs/v14-x-y/api/app#event-activate-macos Event: 'activate'
- */
-app.on('activate', restoreOrCreateWindow);
-
-/**
  *  @see https://www.electronjs.org/docs/latest/api/app#appsetappusermodelidid-windows
  */
 if (isWindows) {
   app.setAppUserModelId(app.name);
 }
-
-/**
- * Create app window when background process will be ready
- */
-app
-  .whenReady()
-  .then(restoreOrCreateWindow)
-  .catch(e => console.error('Failed create window:', e));
-
-/**
- * Install some other devtools in development mode only
- */
-/*
-if (import.meta.env.DEV) {
-  app.whenReady()
-    .then(() => import('electron-devtools-installer'))
-    .then(({default: installExtension, VUEJS3_DEVTOOLS}) => installExtension(VUEJS3_DEVTOOLS, {
-      loadExtensionOptions: {
-        allowFileAccess: true,
-      },
-    }))
-    .catch(e => console.error('Failed install extension:', e));
-}
-*/
 
 /**
  * Check new app version in production mode only
@@ -98,33 +69,50 @@ if (import.meta.env.PROD) {
 
 let tray: Tray | null = null;
 
-app.whenReady().then(async () => {
-  // Setup the default tray icon + menu items
-  const animatedTray = new AnimatedTray();
-  tray = new Tray(animatedTray.getDefaultImage());
-  animatedTray.setTray(tray);
-  const trayMenu = new TrayMenu(tray, animatedTray);
+app.whenReady().then(
+  async () => {
+    // We must create the window first before initialization so that we can load the
+    // configuration as well as plugins
+    // The window is hiddenly created and shown when ready
 
-  // Start extensions
-  const pluginSystem = new PluginSystem(trayMenu);
-  const extensionLoader = await pluginSystem.initExtensions();
+    // Platforms: Linux, macOS, Windows
+    // Create the main window
+    createNewWindow();
 
-  // Get the configuration registry (saves all our settings)
-  const configurationRegistry = extensionLoader.getConfigurationRegistry();
+    // Platforms: macOS
+    // Required for macOS to start the app correctly (this is will be shown in the dock)
+    // We use 'activate' within whenReady in order to gracefully start on macOS, see this link:
+    // https://www.electronjs.org/docs/latest/tutorial/quick-start#open-a-window-if-none-are-open-macos
+    app.on('activate', createNewWindow);
 
-  // If we've manually set the tray icon color, update the tray icon. This can only be done
-  // after configurationRegistry is loaded. Windows or Linux support only for icon color change.
-  if (!isMac) {
-    const color = configurationRegistry.getConfiguration('preferences').get('TrayIconColor');
-    if (typeof color === 'string') {
-      animatedTray.setColor(color);
+    // Setup the default tray icon + menu items
+    const animatedTray = new AnimatedTray();
+    tray = new Tray(animatedTray.getDefaultImage());
+    animatedTray.setTray(tray);
+    const trayMenu = new TrayMenu(tray, animatedTray);
+
+    // Start extensions
+    const pluginSystem = new PluginSystem(trayMenu);
+    const extensionLoader = await pluginSystem.initExtensions();
+
+    // Get the configuration registry (saves all our settings)
+    const configurationRegistry = extensionLoader.getConfigurationRegistry();
+
+    // If we've manually set the tray icon color, update the tray icon. This can only be done
+    // after configurationRegistry is loaded. Windows or Linux support only for icon color change.
+    if (!isMac) {
+      const color = configurationRegistry.getConfiguration('preferences').get('TrayIconColor');
+      if (typeof color === 'string') {
+        animatedTray.setColor(color);
+      }
     }
-  }
 
-  // Share configuration registry with renderer process
-  ipcMain.emit('configuration-registry', '', configurationRegistry);
+    // Share configuration registry with renderer process
+    ipcMain.emit('configuration-registry', '', configurationRegistry);
 
-  // Configure automatic startup
-  const automaticStartup = new StartupInstall(configurationRegistry);
-  await automaticStartup.configure();
-});
+    // Configure automatic startup
+    const automaticStartup = new StartupInstall(configurationRegistry);
+    await automaticStartup.configure();
+  },
+  e => console.error('Failed to start app:', e),
+);

--- a/packages/main/src/mainWindow.ts
+++ b/packages/main/src/mainWindow.ts
@@ -205,23 +205,26 @@ async function createWindow() {
   return browserWindow;
 }
 
-/**
- * Restore existing BrowserWindow or Create new BrowserWindow
- */
-export async function restoreOrCreateWindow() {
+// Create a new window if there is no existing window
+export async function createNewWindow() {
   let window = BrowserWindow.getAllWindows().find(w => !w.isDestroyed());
 
   if (window === undefined) {
     window = await createWindow();
   }
+}
 
-  if (window.isMinimized()) {
-    window.restore();
-  }
+// Restore the window if it is minimized / not shown / there is already another instance running
+export async function restoreWindow() {
+  const window = BrowserWindow.getAllWindows().find(w => !w.isDestroyed());
 
-  if (!window.isVisible()) {
+  // Only restore the window if we were able to find it
+  if (window) {
+    if (window.isMinimized()) {
+      window.restore();
+    }
+
     window.show();
+    window.focus();
   }
-
-  window.focus();
 }


### PR DESCRIPTION
refactor: refactors window initializing

### What does this PR do?

* Refactors how we restore / open windows by making two separate
  functions for restoring as well as opening
* Moves app.on('active', createNewWindow()); to within app.whenReady()
  in order to fix issues with macOS now opening correctly
 * Adds error checking to the main startup process `e => console.error('Failed to start app:', e),`

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

N/A

### What issues does this PR fix or reference?

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

1/2 of of https://github.com/containers/podman-desktop/issues/868

### How to test this PR?

<!-- Please explain steps to reproduce -->

`yarn watch` and it should open / start as normal

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
