### PR TITLE
feat: display Kubernetes pods

### DIFF
--- a/packages/main/src/plugin/api/pod-info.ts
+++ b/packages/main/src/plugin/api/pod-info.ts
@@ -22,6 +22,7 @@ import type { PodInspectInfo as LibPodPodInspectInfo } from '../dockerode/libpod
 export interface PodInfo extends LibPodPodInfo {
   engineId: string;
   engineName: string;
+  kind: 'kubernetes' | 'podman';
 }
 
 export interface PodInspectInfo extends LibPodPodInspectInfo {

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -356,7 +356,7 @@ export class ContainerProviderRegistry {
           }
           const pods = await provider.libpodApi.listPods();
           return pods.map(pod => {
-            const podInfo: PodInfo = { ...pod, engineName: provider.name, engineId: provider.id };
+            const podInfo: PodInfo = { ...pod, engineName: provider.name, engineId: provider.id, kind: 'podman' };
             return podInfo;
           });
         } catch (error) {

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1016,12 +1016,9 @@ export class PluginSystem {
       },
     );
 
-    this.ipcHandle(
-      'kubernetes-client:listPods',
-      async (): Promise<PodInfo[]> => {
-        return kubernetesClient.listPods();
-      },
-    );
+    this.ipcHandle('kubernetes-client:listPods', async (): Promise<PodInfo[]> => {
+      return kubernetesClient.listPods();
+    });
 
     this.ipcHandle(
       'kubernetes-client:readPodLog',
@@ -1032,12 +1029,9 @@ export class PluginSystem {
       },
     );
 
-    this.ipcHandle(
-      'kubernetes-client:deletePod',
-      async (_listener, name: string): Promise<void> => {
-        return kubernetesClient.deletePod(name);
-      },
-    );
+    this.ipcHandle('kubernetes-client:deletePod', async (_listener, name: string): Promise<void> => {
+      return kubernetesClient.deletePod(name);
+    });
 
     this.ipcHandle(
       'openshift-client:createRoute',

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1024,6 +1024,15 @@ export class PluginSystem {
     );
 
     this.ipcHandle(
+      'kubernetes-client:readPodLog',
+      async (_listener, name: string, container: string, onDataId: number): Promise<void> => {
+        return kubernetesClient.readPodLog(name, container, (name: string, data: string) => {
+          this.getWebContentsSender().send('kubernetes-client:readPodLog-onData', onDataId, name, data);
+        });
+      },
+    );
+
+    this.ipcHandle(
       'openshift-client:createRoute',
       async (_listener, namespace: string, route: V1Route): Promise<V1Route> => {
         return kubernetesClient.createOpenShiftRoute(namespace, route);

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -270,7 +270,7 @@ export class PluginSystem {
     const inputQuickPickRegistry = new InputQuickPickRegistry(apiSender);
     const fileSystemMonitoring = new FilesystemMonitoring();
 
-    const kubernetesClient = new KubernetesClient(configurationRegistry, fileSystemMonitoring);
+    const kubernetesClient = new KubernetesClient(apiSender, configurationRegistry, fileSystemMonitoring);
     await kubernetesClient.init();
     const closeBehaviorConfiguration = new CloseBehavior(configurationRegistry);
     await closeBehaviorConfiguration.init();
@@ -1029,6 +1029,13 @@ export class PluginSystem {
         return kubernetesClient.readPodLog(name, container, (name: string, data: string) => {
           this.getWebContentsSender().send('kubernetes-client:readPodLog-onData', onDataId, name, data);
         });
+      },
+    );
+
+    this.ipcHandle(
+      'kubernetes-client:deletePod',
+      async (_listener, name: string): Promise<void> => {
+        return kubernetesClient.deletePod(name);
       },
     );
 

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1017,6 +1017,13 @@ export class PluginSystem {
     );
 
     this.ipcHandle(
+      'kubernetes-client:listPods',
+      async (): Promise<PodInfo[]> => {
+        return kubernetesClient.listPods();
+      },
+    );
+
+    this.ipcHandle(
       'openshift-client:createRoute',
       async (_listener, namespace: string, route: V1Route): Promise<V1Route> => {
         return kubernetesClient.createOpenShiftRoute(namespace, route);

--- a/packages/main/src/plugin/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes-client.ts
@@ -192,7 +192,7 @@ export class KubernetesClient {
             this.apiSender.send('pod-event');
           },
           (err: any) => {
-            console.log('Kube event error ' + err);
+            console.error('Kube event error', err);
           },
         )
         .then(req => (this.kubeWatcher = req));

--- a/packages/main/src/plugin/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes-client.ts
@@ -295,7 +295,7 @@ export class KubernetesClient {
 
   async listPods(): Promise<PodInfo[]> {
     const ns = this.getCurrentNamespace();
-    if (ns !== undefined) {
+    if (ns) {
       const pods = await this.listNamespacedPod(ns);
       return pods.items.map(pod => toPodInfo(pod));
     }

--- a/packages/main/src/plugin/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes-client.ts
@@ -307,7 +307,6 @@ export class KubernetesClient {
   }
 
   async readPodLog(name: string, container: string, callback: (name: string, data: string) => void): Promise<void> {
-    console.log('Reading podlog name=' + name + ' container=' + container + ' callback=' + callback);
     const ns = this.currrentNamespace;
     if (ns) {
       const log = new Log(this.kubeConfig);
@@ -316,14 +315,10 @@ export class KubernetesClient {
 
       logStream.on('data', chunk => {
         // use write rather than console.log to prevent double line feed
-        console.log('Received chunk=' + chunk);
         callback('data', chunk.toString('utf-8'));
       });
 
       log.log(ns, name, container, logStream, { follow: true });
-      //.then(req => {
-      //  req.abort();
-      //});
     }
   }
 

--- a/packages/main/src/plugin/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes-client.ts
@@ -183,17 +183,13 @@ export class KubernetesClient {
     this.kubeWatcher?.abort();
     const ns = this.currrentNamespace;
     if (ns) {
-      new Watch(this.kubeConfig)
+      const watch = new Watch(this.kubeConfig);
+      watch
         .watch(
           '/api/v1/namespaces/' + ns + '/pods',
           {},
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          (phase: string, apiObj: any, watchObj?: any) => {
-            this.apiSender.send('pod-event');
-          },
-          (err: any) => {
-            console.error('Kube event error', err);
-          },
+          () => this.apiSender.send('pod-event'),
+          (err: any) => console.error('Kube event error', err),
         )
         .then(req => (this.kubeWatcher = req));
     }

--- a/packages/main/src/plugin/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes-client.ts
@@ -39,7 +39,7 @@ import type { FilesystemMonitoring } from './filesystem-monitoring';
 import type { PodInfo } from './api/pod-info';
 import { PassThrough } from 'node:stream';
 
-function getContainerStatus(state: V1ContainerState | undefined) {
+function toContainerStatus(state: V1ContainerState | undefined): string {
   if (state) {
     if (state.running) {
       return 'Running';
@@ -58,7 +58,7 @@ function toPodInfo(pod: V1Pod): PodInfo {
       return {
         Id: status.containerID || '',
         Names: status.name,
-        Status: getContainerStatus(status.state),
+        Status: toContainerStatus(status.state),
       };
     }) || [];
   return {
@@ -300,7 +300,7 @@ export class KubernetesClient {
   async listPods(): Promise<PodInfo[]> {
     const ns = this.getCurrentNamespace();
     if (ns !== undefined) {
-      const pods = await this.listNamespacedPod(this.getCurrentNamespace() as string);
+      const pods = await this.listNamespacedPod(ns);
       return pods.items.map(pod => toPodInfo(pod));
     }
     return [];

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -1053,6 +1053,13 @@ function initExposure(): void {
     },
   );
 
+  contextBridge.exposeInMainWorld(
+    'kubernetesDeletePod',
+    async (name: string): Promise<void> => {
+      return ipcInvoke('kubernetes-client:deletePod', name);
+    },
+  );
+
 
   contextBridge.exposeInMainWorld(
     'openshiftCreateRoute',

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -1024,12 +1024,9 @@ function initExposure(): void {
     },
   );
 
-  contextBridge.exposeInMainWorld(
-    'kubernetesListPods',
-    async (): Promise<PodInfo[]> => {
-      return ipcInvoke('kubernetes-client:listPods');
-    },
-  );
+  contextBridge.exposeInMainWorld('kubernetesListPods', async (): Promise<PodInfo[]> => {
+    return ipcInvoke('kubernetes-client:listPods');
+  });
 
   let onDataCallbacksKubernetesPodLogId = 0;
   const onDataCallbacksKubernetesPodLog = new Map<number, (name: string, data: string) => void>();
@@ -1045,21 +1042,25 @@ function initExposure(): void {
     (_, onDataCallbacksKubernetesReadPodLogId: number, name: string, data: string) => {
       // grab callback from the map
       const callback = onDataCallbacksKubernetesPodLog.get(onDataCallbacksKubernetesReadPodLogId);
-      console.log('kubernetes-client:readPodLog-onData id=' + onDataCallbacksKubernetesReadPodLogId + ' name=' + name
-        + ' data=' + data + ' callback=' + callback);
+      console.log(
+        'kubernetes-client:readPodLog-onData id=' +
+          onDataCallbacksKubernetesReadPodLogId +
+          ' name=' +
+          name +
+          ' data=' +
+          data +
+          ' callback=' +
+          callback,
+      );
       if (callback) {
         callback(name, data);
       }
     },
   );
 
-  contextBridge.exposeInMainWorld(
-    'kubernetesDeletePod',
-    async (name: string): Promise<void> => {
-      return ipcInvoke('kubernetes-client:deletePod', name);
-    },
-  );
-
+  contextBridge.exposeInMainWorld('kubernetesDeletePod', async (name: string): Promise<void> => {
+    return ipcInvoke('kubernetes-client:deletePod', name);
+  });
 
   contextBridge.exposeInMainWorld(
     'openshiftCreateRoute',

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -1042,16 +1042,6 @@ function initExposure(): void {
     (_, onDataCallbacksKubernetesReadPodLogId: number, name: string, data: string) => {
       // grab callback from the map
       const callback = onDataCallbacksKubernetesPodLog.get(onDataCallbacksKubernetesReadPodLogId);
-      console.log(
-        'kubernetes-client:readPodLog-onData id=' +
-          onDataCallbacksKubernetesReadPodLogId +
-          ' name=' +
-          name +
-          ' data=' +
-          data +
-          ' callback=' +
-          callback,
-      );
       if (callback) {
         callback(name, data);
       }

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -1025,6 +1025,13 @@ function initExposure(): void {
   );
 
   contextBridge.exposeInMainWorld(
+    'kubernetesListPods',
+    async (): Promise<PodInfo[]> => {
+      return ipcInvoke('kubernetes-client:listPods');
+    },
+  );
+
+  contextBridge.exposeInMainWorld(
     'openshiftCreateRoute',
     async (namespace: string, route: V1Route): Promise<V1Route> => {
       return ipcInvoke('openshift-client:createRoute', namespace, route);

--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -131,8 +131,10 @@ window.events?.receive('display-help', () => {
             engineId="{decodeURI(meta.params.engineId)}" />
         </Route>
         <Route path="/pods/:kind/:name/:engineId/*" let:meta>
-          <PodDetails podName="{decodeURI(meta.params.name)}" engineId="{decodeURI(meta.params.engineId)}"
-                      kind="{decodeURI(meta.params.kind)}"/>
+          <PodDetails
+            podName="{decodeURI(meta.params.name)}"
+            engineId="{decodeURI(meta.params.engineId)}"
+            kind="{decodeURI(meta.params.kind)}" />
         </Route>
         <Route path="/pod-create-from-containers">
           <PodCreateFromContainers />

--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -130,8 +130,9 @@ window.events?.receive('display-help', () => {
             resourceId="{decodeURI(meta.params.resourceId)}"
             engineId="{decodeURI(meta.params.engineId)}" />
         </Route>
-        <Route path="/pods/:name/:engineId/*" let:meta>
-          <PodDetails podName="{decodeURI(meta.params.name)}" engineId="{decodeURI(meta.params.engineId)}" />
+        <Route path="/pods/:kind/:name/:engineId/*" let:meta>
+          <PodDetails podName="{decodeURI(meta.params.name)}" engineId="{decodeURI(meta.params.engineId)}"
+                      kind="{decodeURI(meta.params.kind)}"/>
         </Route>
         <Route path="/pod-create-from-containers">
           <PodCreateFromContainers />

--- a/packages/renderer/src/lib/ContainerList.svelte
+++ b/packages/renderer/src/lib/ContainerList.svelte
@@ -456,6 +456,7 @@ function errorCallback(container: ContainerInfoUI, errorMessage: string): void {
                       created: containerGroup.created,
                       selected: false,
                       containers: [],
+                      kind: 'podman',
                     }}"
                     dropdownMenu="{true}" />
                 {/if}

--- a/packages/renderer/src/lib/ContainerList.svelte
+++ b/packages/renderer/src/lib/ContainerList.svelte
@@ -264,7 +264,7 @@ function keydownChoice(e: KeyboardEvent) {
 
 function openGroupDetails(containerGroup: ContainerGroupInfoUI): void {
   if (containerGroup.type === ContainerGroupInfoTypeUI.POD) {
-    router.goto(`/pods/${encodeURI(containerGroup.name)}/${encodeURI(containerGroup.engineId)}/logs`);
+    router.goto(`/pods/podman/${encodeURI(containerGroup.name)}/${encodeURI(containerGroup.engineId)}/logs`);
   }
 }
 

--- a/packages/renderer/src/lib/pod/PodActions.svelte
+++ b/packages/renderer/src/lib/pod/PodActions.svelte
@@ -52,7 +52,11 @@ async function stopPod(podInfoUI: PodInfoUI) {
 async function removePod(podInfoUI: PodInfoUI): Promise<void> {
   inProgressCallback(true, 'REMOVING');
   try {
-    await window.removePod(podInfoUI.engineId, podInfoUI.id);
+    if (pod.kind === 'podman') {
+      await window.removePod(podInfoUI.engineId, podInfoUI.id);
+    } else {
+      await window.kubernetesDeletePod(podInfoUI.name);
+    }
     router.goto('/pods/');
   } catch (error) {
     errorCallback(error);
@@ -78,6 +82,7 @@ if (dropdownMenu) {
 }
 </script>
 
+{#if pod.kind === 'podman'}
 <ListItemButtonIcon
   title="Start Pod"
   onClick="{() => startPod(pod)}"
@@ -90,6 +95,7 @@ if (dropdownMenu) {
   hidden="{!(pod.status === 'RUNNING')}"
   detailed="{detailed}"
   icon="{faStop}" />
+{/if}
 <ListItemButtonIcon title="Delete Pod" onClick="{() => removePod(pod)}" icon="{faTrash}" detailed="{detailed}" />
 
 <!-- If dropdownMenu is true, use it, otherwise just show the regular buttons -->

--- a/packages/renderer/src/lib/pod/PodActions.svelte
+++ b/packages/renderer/src/lib/pod/PodActions.svelte
@@ -83,38 +83,38 @@ if (dropdownMenu) {
 </script>
 
 {#if pod.kind === 'podman'}
-<ListItemButtonIcon
-  title="Start Pod"
-  onClick="{() => startPod(pod)}"
-  hidden="{pod.status === 'RUNNING'}"
-  detailed="{detailed}"
-  icon="{faPlay}" />
-<ListItemButtonIcon
-  title="Stop Pod"
-  onClick="{() => stopPod(pod)}"
-  hidden="{!(pod.status === 'RUNNING')}"
-  detailed="{detailed}"
-  icon="{faStop}" />
+  <ListItemButtonIcon
+    title="Start Pod"
+    onClick="{() => startPod(pod)}"
+    hidden="{pod.status === 'RUNNING'}"
+    detailed="{detailed}"
+    icon="{faPlay}" />
+  <ListItemButtonIcon
+    title="Stop Pod"
+    onClick="{() => stopPod(pod)}"
+    hidden="{!(pod.status === 'RUNNING')}"
+    detailed="{detailed}"
+    icon="{faStop}" />
 {/if}
 <ListItemButtonIcon title="Delete Pod" onClick="{() => removePod(pod)}" icon="{faTrash}" detailed="{detailed}" />
 
 <!-- If dropdownMenu is true, use it, otherwise just show the regular buttons -->
 <svelte:component this="{actionsStyle}">
   {#if pod.kind === 'podman'}
-  {#if !detailed}
+    {#if !detailed}
+      <ListItemButtonIcon
+        title="Generate Kube"
+        onClick="{() => openGenerateKube()}"
+        menu="{dropdownMenu}"
+        detailed="{detailed}"
+        icon="{faFileCode}" />
+    {/if}
     <ListItemButtonIcon
-      title="Generate Kube"
-      onClick="{() => openGenerateKube()}"
+      title="Deploy to Kubernetes"
+      onClick="{() => deployToKubernetes()}"
       menu="{dropdownMenu}"
       detailed="{detailed}"
-      icon="{faFileCode}" />
-  {/if}
-  <ListItemButtonIcon
-    title="Deploy to Kubernetes"
-    onClick="{() => deployToKubernetes()}"
-    menu="{dropdownMenu}"
-    detailed="{detailed}"
-    icon="{faRocket}" />
+      icon="{faRocket}" />
   {/if}
   <ListItemButtonIcon
     title="Restart Pod"

--- a/packages/renderer/src/lib/pod/PodActions.svelte
+++ b/packages/renderer/src/lib/pod/PodActions.svelte
@@ -62,7 +62,7 @@ async function removePod(podInfoUI: PodInfoUI): Promise<void> {
 }
 
 function openGenerateKube(): void {
-  router.goto(`/pods/${encodeURI(pod.name)}/${encodeURI(pod.engineId)}/kube`);
+  router.goto(`/pods/${encodeURI(pod.kind)}/${encodeURI(pod.name)}/${encodeURI(pod.engineId)}/kube`);
 }
 
 function deployToKubernetes(): void {
@@ -94,6 +94,7 @@ if (dropdownMenu) {
 
 <!-- If dropdownMenu is true, use it, otherwise just show the regular buttons -->
 <svelte:component this="{actionsStyle}">
+  {#if pod.kind === 'podman'}
   {#if !detailed}
     <ListItemButtonIcon
       title="Generate Kube"
@@ -108,6 +109,7 @@ if (dropdownMenu) {
     menu="{dropdownMenu}"
     detailed="{detailed}"
     icon="{faRocket}" />
+  {/if}
   <ListItemButtonIcon
     title="Restart Pod"
     onClick="{() => restartPod(pod)}"

--- a/packages/renderer/src/lib/pod/PodDetails.svelte
+++ b/packages/renderer/src/lib/pod/PodDetails.svelte
@@ -27,8 +27,9 @@ onMount(() => {
   const podUtils = new PodUtils();
   // loading volume info
   podUnsubscribe = podsInfos.subscribe(pods => {
-    const matchingPod = pods.find(podInPods => podInPods.Name === podName && podInPods.engineId === engineId &&
-      kind === podInPods.kind);
+    const matchingPod = pods.find(
+      podInPods => podInPods.Name === podName && podInPods.engineId === engineId && kind === podInPods.kind,
+    );
     if (matchingPod) {
       try {
         pod = podUtils.getPodInfoUI(matchingPod);

--- a/packages/renderer/src/lib/pod/PodDetails.svelte
+++ b/packages/renderer/src/lib/pod/PodDetails.svelte
@@ -18,6 +18,7 @@ import Fa from 'svelte-fa/src/fa.svelte';
 
 export let podName: string;
 export let engineId: string;
+export let kind: string;
 
 let pod: PodInfoUI;
 let podUnsubscribe: Unsubscriber;
@@ -26,7 +27,8 @@ onMount(() => {
   const podUtils = new PodUtils();
   // loading volume info
   podUnsubscribe = podsInfos.subscribe(pods => {
-    const matchingPod = pods.find(podInPods => podInPods.Name === podName && podInPods.engineId === engineId);
+    const matchingPod = pods.find(podInPods => podInPods.Name === podName && podInPods.engineId === engineId &&
+      kind === podInPods.kind);
     if (matchingPod) {
       try {
         pod = podUtils.getPodInfoUI(matchingPod);
@@ -83,9 +85,9 @@ function errorCallback(errorMessage: string): void {
                     <li
                       class="pf-c-tabs__item"
                       class:pf-m-current="{meta.url ===
-                        `/pods/${encodeURI(pod.name)}/${encodeURI(pod.engineId)}/logs`}">
+                        `/pods/${encodeURI(pod.kind)}/${encodeURI(pod.name)}/${encodeURI(pod.engineId)}/logs`}">
                       <a
-                        href="/pods/${encodeURI(pod.name)}/${encodeURI(pod.engineId)}/logs"
+                        href="/pods/${encodeURI(pod.kind)}/${encodeURI(pod.name)}/${encodeURI(pod.engineId)}/logs"
                         class="pf-c-tabs__link"
                         aria-controls="open-tabs-example-tabs-list-details-panel"
                         id="open-tabs-example-tabs-list-details-link">
@@ -95,9 +97,9 @@ function errorCallback(errorMessage: string): void {
                     <li
                       class="pf-c-tabs__item"
                       class:pf-m-current="{meta.url ===
-                        `/pods/${encodeURI(pod.name)}/${encodeURI(pod.engineId)}/summary`}">
+                        `/pods/${encodeURI(pod.kind)}/${encodeURI(pod.name)}/${encodeURI(pod.engineId)}/summary`}">
                       <a
-                        href="/pods/{encodeURI(pod.name)}/{encodeURI(pod.engineId)}/summary"
+                        href="/pods/${encodeURI(pod.kind)}/{encodeURI(pod.name)}/{encodeURI(pod.engineId)}/summary"
                         class="pf-c-tabs__link"
                         aria-controls="open-tabs-example-tabs-list-details-panel"
                         id="open-tabs-example-tabs-list-details-link">
@@ -107,9 +109,9 @@ function errorCallback(errorMessage: string): void {
                     <li
                       class="pf-c-tabs__item"
                       class:pf-m-current="{meta.url ===
-                        `/pods/${encodeURI(pod.name)}/${encodeURI(pod.engineId)}/inspect`}">
+                        `/pods/${encodeURI(pod.kind)}/${encodeURI(pod.name)}/${encodeURI(pod.engineId)}/inspect`}">
                       <a
-                        href="/pods/{encodeURI(pod.name)}/{encodeURI(pod.engineId)}/inspect"
+                        href="/pods/${encodeURI(pod.kind)}/{encodeURI(pod.name)}/{encodeURI(pod.engineId)}/inspect"
                         class="pf-c-tabs__link"
                         aria-controls="open-tabs-example-tabs-list-yaml-panel"
                         id="open-tabs-example-tabs-list-yaml-link">
@@ -119,9 +121,9 @@ function errorCallback(errorMessage: string): void {
                     <li
                       class="pf-c-tabs__item"
                       class:pf-m-current="{meta.url ===
-                        `/pods/${encodeURI(pod.name)}/${encodeURI(pod.engineId)}/kube`}">
+                        `/pods/${encodeURI(pod.kind)}/${encodeURI(pod.name)}/${encodeURI(pod.engineId)}/kube`}">
                       <a
-                        href="/pods/{encodeURI(pod.name)}/{encodeURI(pod.engineId)}/kube"
+                        href="/pods/${encodeURI(pod.kind)}/{encodeURI(pod.name)}/{encodeURI(pod.engineId)}/kube"
                         class="pf-c-tabs__link"
                         aria-controls="open-tabs-example-tabs-list-yaml-panel"
                         id="open-tabs-example-tabs-list-yaml-link">

--- a/packages/renderer/src/lib/pod/PodDetailsInspect.svelte
+++ b/packages/renderer/src/lib/pod/PodDetailsInspect.svelte
@@ -20,7 +20,7 @@ onMount(async () => {
     if (ns) {
       const kubepod = await window.kubernetesReadNamespacedPod(pod.name, ns);
       if (kubepod) {
-        inspectResult = kubepod
+        inspectResult = kubepod;
       } else {
         inspectResult = "Can't inspect pod " + pod.name;
       }

--- a/packages/renderer/src/lib/pod/PodDetailsInspect.svelte
+++ b/packages/renderer/src/lib/pod/PodDetailsInspect.svelte
@@ -9,10 +9,23 @@ let inspectDetails: string;
 
 onMount(async () => {
   // grab inspect result from the container
-  const inspectResult = await window.getPodInspect(pod.engineId, pod.id);
-  // remove engine* properties from the inspect result as it's more internal
-  delete inspectResult.engineId;
-  delete inspectResult.engineName;
+  let inspectResult;
+  if (pod.kind === 'podman') {
+    inspectResult = await window.getPodInspect(pod.engineId, pod.id);
+    // remove engine* properties from the inspect result as it's more internal
+    delete inspectResult.engineId;
+    delete inspectResult.engineName;
+  } else {
+    const ns = await window.kubernetesGetCurrentNamespace();
+    if (ns) {
+      const kubepod = await window.kubernetesReadNamespacedPod(pod.name, ns);
+      if (kubepod) {
+        inspectResult = kubepod
+      } else {
+        inspectResult = "Can't inspect pod " + pod.name;
+      }
+    }
+  }
 
   inspectDetails = JSON.stringify(inspectResult, null, 2);
 });

--- a/packages/renderer/src/lib/pod/PodDetailsKube.svelte
+++ b/packages/renderer/src/lib/pod/PodDetailsKube.svelte
@@ -2,7 +2,7 @@
 import { onMount } from 'svelte';
 import MonacoEditor from '../editor/MonacoEditor.svelte';
 import type { PodInfoUI } from './PodInfoUI';
-import { stringify } from 'YAML'
+import { stringify } from 'yaml'
 export let pod: PodInfoUI;
 
 let kubeDetails: string;

--- a/packages/renderer/src/lib/pod/PodDetailsKube.svelte
+++ b/packages/renderer/src/lib/pod/PodDetailsKube.svelte
@@ -1,16 +1,27 @@
 <script lang="ts">
 import { onMount } from 'svelte';
 import MonacoEditor from '../editor/MonacoEditor.svelte';
-
 import type { PodInfoUI } from './PodInfoUI';
+import { stringify } from 'YAML'
 export let pod: PodInfoUI;
 
 let kubeDetails: string;
 
 onMount(async () => {
   // grab kube result from the pod
-  const kubeResult = await window.generatePodmanKube(pod.engineId, [pod.id]);
-  kubeDetails = kubeResult;
+  if (pod.kind === 'podman') {
+    const kubeResult = await window.generatePodmanKube(pod.engineId, [pod.id]);
+    kubeDetails = kubeResult;
+  } else {
+    const ns = await window.kubernetesGetCurrentNamespace();
+    if (ns) {
+      const kubepod = await window.kubernetesReadNamespacedPod(pod.name, ns);
+      if (kubepod) {
+        kubeDetails = stringify(kubepod);
+
+      }
+    }
+  }
 });
 </script>
 

--- a/packages/renderer/src/lib/pod/PodDetailsKube.svelte
+++ b/packages/renderer/src/lib/pod/PodDetailsKube.svelte
@@ -2,7 +2,7 @@
 import { onMount } from 'svelte';
 import MonacoEditor from '../editor/MonacoEditor.svelte';
 import type { PodInfoUI } from './PodInfoUI';
-import { stringify } from 'yaml'
+import { stringify } from 'yaml';
 export let pod: PodInfoUI;
 
 let kubeDetails: string;
@@ -18,7 +18,6 @@ onMount(async () => {
       const kubepod = await window.kubernetesReadNamespacedPod(pod.name, ns);
       if (kubepod) {
         kubeDetails = stringify(kubepod);
-
       }
     }
   }

--- a/packages/renderer/src/lib/pod/PodDetailsLogs.svelte
+++ b/packages/renderer/src/lib/pod/PodDetailsLogs.svelte
@@ -24,7 +24,7 @@ let logsTerminal: Terminal;
 let resizeObserver: ResizeObserver;
 let termFit: FitAddon;
 let currentRouterPath: string;
-let logsRouterPath: string = `/pods/${encodeURI(pod.name)}/${encodeURI(pod.engineId)}/logs`;
+let logsRouterPath: string = `/pods/${encodeURI(pod.kind)}/${encodeURI(pod.name)}/${encodeURI(pod.engineId)}/logs`;
 
 // An array of readable ANSI escape sequence colours against a black terminal background
 // these are the most "readable" colours against a black background
@@ -102,7 +102,11 @@ async function fetchPodLogs() {
     };
 
     // Get the logs for the container
-    await window.logsContainer(pod.engineId, container.Id, logsCallback);
+    if (pod.kind === 'podman') {
+      await window.logsContainer(pod.engineId, container.Id, logsCallback);
+    } else {
+      await window.kubernetesReadPodLog(pod.name, container.Names, logsCallback);
+    }
   });
 }
 

--- a/packages/renderer/src/lib/pod/PodInfoUI.ts
+++ b/packages/renderer/src/lib/pod/PodInfoUI.ts
@@ -35,4 +35,5 @@ export interface PodInfoUI {
   containers: PodInfoContainerUI[];
   actionInProgress?: boolean;
   actionError?: string;
+  kind: 'kubernetes' | 'podman';
 }

--- a/packages/renderer/src/lib/pod/PodsList.svelte
+++ b/packages/renderer/src/lib/pod/PodsList.svelte
@@ -106,7 +106,11 @@ async function deleteSelectedPods() {
     await Promise.all(
       selectedPods.map(async pod => {
         try {
-          await window.removePod(pod.engineId, pod.id);
+          if (pod.kind === 'podman') {
+            await window.removePod(pod.engineId, pod.id);
+          } else {
+            await window.kubernetesDeletePod(pod.name);
+          }
         } catch (e) {
           console.log('error while removing pod', e);
         }

--- a/packages/renderer/src/lib/pod/PodsList.svelte
+++ b/packages/renderer/src/lib/pod/PodsList.svelte
@@ -117,7 +117,7 @@ async function deleteSelectedPods() {
 }
 
 function openDetailsPod(pod: PodInfoUI) {
-  router.goto(`/pods/${encodeURI(pod.name)}/${encodeURI(pod.engineId)}/logs`);
+  router.goto(`/pods/${encodeURI(pod.kind)}/${encodeURI(pod.name)}/${encodeURI(pod.engineId)}/logs`);
 }
 
 function openContainersFromPod(pod: PodInfoUI) {

--- a/packages/renderer/src/lib/pod/pod-utils.ts
+++ b/packages/renderer/src/lib/pod/pod-utils.ts
@@ -60,6 +60,7 @@ export class PodUtils {
       engineName: this.getEngineName(podinfo),
       containers: podinfo.Containers,
       selected: false,
+      kind: podinfo.kind
     };
   }
 }

--- a/packages/renderer/src/lib/pod/pod-utils.ts
+++ b/packages/renderer/src/lib/pod/pod-utils.ts
@@ -60,7 +60,7 @@ export class PodUtils {
       engineName: this.getEngineName(podinfo),
       containers: podinfo.Containers,
       selected: false,
-      kind: podinfo.kind
+      kind: podinfo.kind,
     };
   }
 }

--- a/packages/renderer/src/stores/pods.ts
+++ b/packages/renderer/src/stores/pods.ts
@@ -22,22 +22,17 @@ import type { PodInfo } from '../../../main/src/plugin/api/pod-info';
 import { findMatchInLeaves } from './search-util';
 export async function fetchPods() {
   const result = await window.listPods();
-  podsInfos.set(result);
   const pods = await window.kubernetesListPods();
-  kubePods.set(pods);
+  podsInfos.set(result.concat(pods));
 }
 
 export const podsInfos: Writable<PodInfo[]> = writable([]);
 
-export const kubePods: Writable<PodInfo[]> = writable([]);
-
 export const searchPattern = writable('');
 
-export const filtered = derived([searchPattern, podsInfos, kubePods],
-  ([$searchPattern, $imagesInfos, $kubePods]) => {
-    const filteredContainerPods = $imagesInfos.filter(podInfo => findMatchInLeaves(podInfo, $searchPattern.toLowerCase()));
-    const filteredKubePods = $kubePods.filter(pod => findMatchInLeaves(pod, $searchPattern.toLowerCase()));
-    return [filteredContainerPods, filteredKubePods].flat();
+export const filtered = derived([searchPattern, podsInfos],
+  ([$searchPattern, $imagesInfos]) => {
+    return $imagesInfos.filter(podInfo => findMatchInLeaves(podInfo, $searchPattern.toLowerCase()));
   }
 );
 

--- a/packages/renderer/src/stores/pods.ts
+++ b/packages/renderer/src/stores/pods.ts
@@ -34,11 +34,9 @@ export const podsInfos: Writable<PodInfo[]> = writable([]);
 
 export const searchPattern = writable('');
 
-export const filtered = derived([searchPattern, podsInfos],
-  ([$searchPattern, $imagesInfos]) => {
-    return $imagesInfos.filter(podInfo => findMatchInLeaves(podInfo, $searchPattern.toLowerCase()));
-  }
-);
+export const filtered = derived([searchPattern, podsInfos], ([$searchPattern, $imagesInfos]) => {
+  return $imagesInfos.filter(podInfo => findMatchInLeaves(podInfo, $searchPattern.toLowerCase()));
+});
 
 // need to refresh when extension is started or stopped
 window.addEventListener('extension-started', () => {

--- a/packages/renderer/src/stores/pods.ts
+++ b/packages/renderer/src/stores/pods.ts
@@ -23,14 +23,22 @@ import { findMatchInLeaves } from './search-util';
 export async function fetchPods() {
   const result = await window.listPods();
   podsInfos.set(result);
+  const pods = await window.kubernetesListPods();
+  kubePods.set(pods);
 }
 
 export const podsInfos: Writable<PodInfo[]> = writable([]);
 
+export const kubePods: Writable<PodInfo[]> = writable([]);
+
 export const searchPattern = writable('');
 
-export const filtered = derived([searchPattern, podsInfos], ([$searchPattern, $imagesInfos]) =>
-  $imagesInfos.filter(podInfo => findMatchInLeaves(podInfo, $searchPattern.toLowerCase())),
+export const filtered = derived([searchPattern, podsInfos, kubePods],
+  ([$searchPattern, $imagesInfos, $kubePods]) => {
+    const filteredContainerPods = $imagesInfos.filter(podInfo => findMatchInLeaves(podInfo, $searchPattern.toLowerCase()));
+    const filteredKubePods = $kubePods.filter(pod => findMatchInLeaves(pod, $searchPattern.toLowerCase()));
+    return [filteredContainerPods, filteredKubePods].flat();
+  }
 );
 
 // need to refresh when extension is started or stopped

--- a/packages/renderer/src/stores/pods.ts
+++ b/packages/renderer/src/stores/pods.ts
@@ -21,9 +21,13 @@ import { writable, derived } from 'svelte/store';
 import type { PodInfo } from '../../../main/src/plugin/api/pod-info';
 import { findMatchInLeaves } from './search-util';
 export async function fetchPods() {
-  const result = await window.listPods();
-  const pods = await window.kubernetesListPods();
-  podsInfos.set(result.concat(pods));
+  let result = await window.listPods();
+  try {
+    const pods = await window.kubernetesListPods();
+    result = result.concat(pods);
+  } finally {
+    podsInfos.set(result);
+  }
 }
 
 export const podsInfos: Writable<PodInfo[]> = writable([]);


### PR DESCRIPTION
Signed-off-by: Jeff MAURY <jmaury@redhat.com>

### What does this PR do?

### Screenshot/screencast of this PR

#### Kubernetes pods are now reported in the Pods list window:

![image](https://user-images.githubusercontent.com/695993/216968384-35830aa4-9206-4fc1-821d-7737f23d4c06.png)

#### Clicking on the pod goes to the pod log:

![image](https://user-images.githubusercontent.com/695993/216969495-c77e71bb-27f2-49a4-88a2-ca4394e9fd5d.png)

#### Summary for the pod is similar to the Podman pod:

![image](https://user-images.githubusercontent.com/695993/216969723-2de2a135-54e3-46e7-8645-b80264a2e66c.png)

#### Inspect for the pod gives the Kubernetes YAML pod resource:

![image](https://user-images.githubusercontent.com/695993/216970070-b8e43b6e-c177-4aca-8afa-4703a51dc2be.png)

#### The Kube tab is similar to the Inspect tab and should probaby be hidden for Kubernetes pods in the future:

![image](https://user-images.githubusercontent.com/695993/216970259-85495eb6-948f-4a3e-bcbe-65aa8c0888a4.png)


<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?

Fixes #1263 

### How to test this PR?

1. Start a Kubernetes cluster (Kind, minikube,..)
2. Start one or several pods on this cluster
3. Go to Podman Desktop Pods UI
4. Ensure the pods from Kubernetes are listed there
