### PR TITLE
fix: new xterm instance spawn when clicking the logs route (#640)

### DIFF
--- a/packages/renderer/src/lib/ContainerDetailsLogs.svelte
+++ b/packages/renderer/src/lib/ContainerDetailsLogs.svelte
@@ -33,7 +33,7 @@ $: {
 
 let currentRouterPath: string;
 
-let logsTerminal;
+let logsTerminal: Terminal;
 
 function callback(name: string, data: string) {
   if (name === 'first-message') {
@@ -56,14 +56,6 @@ async function fetchContainerLogs() {
   await window.logsContainer(container.engineId, container.id, callback);
   logsReady = true;
 }
-
-router.subscribe(async route => {
-  currentRouterPath = route.path;
-  if (route.path.endsWith('/logs')) {
-    await refreshTerminal();
-    fetchContainerLogs();
-  }
-});
 
 async function refreshTerminal() {
   // missing element, return
@@ -106,8 +98,8 @@ async function refreshTerminal() {
 
 onMount(async () => {
   // Refresh the terminal on initial load
-  refreshTerminal();
-
+  await refreshTerminal();
+  fetchContainerLogs();
   // Resize the terminal each time we change the div size
   resizeObserver = new ResizeObserver(entries => {
     termFit?.fit();


### PR DESCRIPTION
Signed-off-by: luca <lstocchi@redhat.com>

### What does this PR do?

This PR prevents creating multiple xterm instances.
I don't know if there was a specific reason to start a terminal when switching tab but the `onMount` event is called everytime as well. This removes a double call to refreshTerminal and also it fixes the issue the user had.

### Screenshot/screencast of this PR

No screecast for this PR as it doesn't do anything. The terminal is shown as before without spawning new xterm instance if you click on the logs route.
The problem that there was before can be seen here
![multiple_term_spawn](https://user-images.githubusercontent.com/49404737/216112655-feb626cd-db72-4b78-a0eb-6f91b153c863.gif)


### What issues does this PR fix or reference?

it fixes #640 

### How to test this PR?

1. Open a container with logs
2. Switch tabs, click on the logs tab multiple times. 
3. Verify no new xterm instances have been created.
