### PR TITLE
feat: show no logs view when opening logs tab and waiting for logs to being fetched (#1117)

### DIFF
--- a/packages/renderer/src/lib/ContainerDetailsLogs.svelte
+++ b/packages/renderer/src/lib/ContainerDetailsLogs.svelte
@@ -49,7 +49,6 @@ function callback(name: string, data: string) {
       logsTerminal?.write(data + '\r');
     }
   }
-  termFit?.fit();
 }
 
 async function fetchContainerLogs() {

--- a/packages/renderer/src/lib/ContainerDetailsLogs.svelte
+++ b/packages/renderer/src/lib/ContainerDetailsLogs.svelte
@@ -137,12 +137,15 @@ onDestroy(() => {
   style="background-color: {getPanelDetailColor()}"
   class:h-full="{noLogs === false}"
   class:min-w-full="{noLogs === false}"
-  bind:this="{logsXtermDiv}">
-  <i class="pf-c-button__progress z-10" class:hidden="{noLogs === false}">
-    <span class="pf-c-spinner pf-m-md" role="progressbar">
-      <span class="pf-c-spinner__clipper"></span>
-      <span class="pf-c-spinner__lead-ball"></span>
-      <span class="pf-c-spinner__tail-ball"></span>
-    </span>
-  </i>
+  bind:this="{logsXtermDiv}">    
+    <div class="pf-c-button__progress z-10" class:hidden="{logsReady || !noLogs}">
+      <div class="align-top inline-block">
+        <span>Fetching logs</span>
+      </div>
+      <span class="pf-c-spinner pf-m-md" role="progressbar">
+        <span class="pf-c-spinner__clipper"></span>
+        <span class="pf-c-spinner__lead-ball"></span>
+        <span class="pf-c-spinner__tail-ball"></span>
+      </span>
+    </div>
 </div>

--- a/packages/renderer/src/lib/ContainerDetailsLogs.svelte
+++ b/packages/renderer/src/lib/ContainerDetailsLogs.svelte
@@ -16,7 +16,6 @@ export let container: ContainerInfoUI;
 let logsXtermDiv: HTMLDivElement;
 let logsContainer;
 // logs has been initialized
-let logsReady = false;
 let noLogs = true;
 
 // Terminal resize
@@ -42,19 +41,18 @@ function callback(name: string, data: string) {
     logsTerminal?.clear();
   } else if (name === 'data') {
     noLogs = false;
-
     if (isMultiplexedLog(data)) {
       logsTerminal?.write(data.substring(8) + '\r');
     } else {
       logsTerminal?.write(data + '\r');
     }
   }
+  termFit?.fit();
 }
 
 async function fetchContainerLogs() {
   // grab logs of the container
   await window.logsContainer(container.engineId, container.id, callback);
-  logsReady = true;
 }
 
 async function refreshTerminal() {
@@ -84,6 +82,7 @@ async function refreshTerminal() {
   logsTerminal.loadAddon(termFit);
 
   logsTerminal.open(logsXtermDiv);
+
   // disable cursor
   logsTerminal.write('\x1b[?25l');
 
@@ -115,37 +114,26 @@ onDestroy(() => {
 });
 </script>
 
-{#if logsReady}
-  <div
-    class="h-full min-w-full flex flex-col"
-    class:hidden="{noLogs === false}"
-    style="background-color: {getPanelDetailColor()}">
-    <div class="pf-c-empty-state h-full">
-      <div class="pf-c-empty-state__content">
-        <i class="fas fa-terminal pf-c-empty-state__icon" aria-hidden="true"></i>
+<div
+  class="h-full min-w-full flex flex-col"
+  class:hidden="{noLogs === false}"
+  style="background-color: {getPanelDetailColor()}">
+  <div class="pf-c-empty-state h-full">
+    <div class="pf-c-empty-state__content">
+      <i class="fas fa-terminal pf-c-empty-state__icon" aria-hidden="true"></i>
 
-        <h1 class="pf-c-title pf-m-lg">No Log</h1>
+      <h1 class="pf-c-title pf-m-lg">No Log</h1>
 
-        <div class="pf-c-empty-state__body">Log output of {container.name}</div>
-      </div>
+      <div class="pf-c-empty-state__body">Log output of {container.name}</div>
     </div>
   </div>
-{/if}
+</div>
 
 <div
-  class="flex flex-col items-center justify-center"
-  style="background-color: {getPanelDetailColor()}"
+  class="min-w-full flex flex-col"
+  class:invisible="{noLogs === true}"
+  class:h-0="{noLogs === true}"
   class:h-full="{noLogs === false}"
-  class:min-w-full="{noLogs === false}"
+  style="background-color: {getPanelDetailColor()}"
   bind:this="{logsXtermDiv}">
-  <div class="pf-c-button__progress z-10" class:hidden="{logsReady || !noLogs}">
-    <div class="align-top inline-block">
-      <span>Fetching logs</span>
-    </div>
-    <span class="pf-c-spinner pf-m-md" role="progressbar">
-      <span class="pf-c-spinner__clipper"></span>
-      <span class="pf-c-spinner__lead-ball"></span>
-      <span class="pf-c-spinner__tail-ball"></span>
-    </span>
-  </div>
 </div>

--- a/packages/renderer/src/lib/ContainerDetailsLogs.svelte
+++ b/packages/renderer/src/lib/ContainerDetailsLogs.svelte
@@ -133,9 +133,16 @@ onDestroy(() => {
 {/if}
 
 <div
-  class="flex flex-col"
+  class="flex flex-col items-center justify-center"
   style="background-color: {getPanelDetailColor()}"
   class:h-full="{noLogs === false}"
   class:min-w-full="{noLogs === false}"
   bind:this="{logsXtermDiv}">
+  <i class="pf-c-button__progress z-10" class:hidden="{noLogs === false}">
+    <span class="pf-c-spinner pf-m-md" role="progressbar">
+      <span class="pf-c-spinner__clipper"></span>
+      <span class="pf-c-spinner__lead-ball"></span>
+      <span class="pf-c-spinner__tail-ball"></span>
+    </span>
+  </i>
 </div>

--- a/packages/renderer/src/lib/ContainerDetailsLogs.svelte
+++ b/packages/renderer/src/lib/ContainerDetailsLogs.svelte
@@ -137,15 +137,15 @@ onDestroy(() => {
   style="background-color: {getPanelDetailColor()}"
   class:h-full="{noLogs === false}"
   class:min-w-full="{noLogs === false}"
-  bind:this="{logsXtermDiv}">    
-    <div class="pf-c-button__progress z-10" class:hidden="{logsReady || !noLogs}">
-      <div class="align-top inline-block">
-        <span>Fetching logs</span>
-      </div>
-      <span class="pf-c-spinner pf-m-md" role="progressbar">
-        <span class="pf-c-spinner__clipper"></span>
-        <span class="pf-c-spinner__lead-ball"></span>
-        <span class="pf-c-spinner__tail-ball"></span>
-      </span>
+  bind:this="{logsXtermDiv}">
+  <div class="pf-c-button__progress z-10" class:hidden="{logsReady || !noLogs}">
+    <div class="align-top inline-block">
+      <span>Fetching logs</span>
     </div>
+    <span class="pf-c-spinner pf-m-md" role="progressbar">
+      <span class="pf-c-spinner__clipper"></span>
+      <span class="pf-c-spinner__lead-ball"></span>
+      <span class="pf-c-spinner__tail-ball"></span>
+    </span>
+  </div>
 </div>

--- a/packages/renderer/src/lib/ContainerDetailsLogs.svelte
+++ b/packages/renderer/src/lib/ContainerDetailsLogs.svelte
@@ -9,6 +9,8 @@ import { TerminalSettings } from '../../../main/src/plugin/terminal-settings';
 import { getPanelDetailColor } from './color/color';
 
 import { isMultiplexedLog } from './stream/stream-utils';
+import EmptyScreen from './ui/EmptyScreen.svelte';
+import NoLogIcon from './ui/NoLogIcon.svelte';
 
 export let container: ContainerInfoUI;
 
@@ -114,20 +116,12 @@ onDestroy(() => {
 });
 </script>
 
-<div
-  class="h-full min-w-full flex flex-col"
-  class:hidden="{noLogs === false}"
-  style="background-color: {getPanelDetailColor()}">
-  <div class="pf-c-empty-state h-full">
-    <div class="pf-c-empty-state__content">
-      <i class="fas fa-terminal pf-c-empty-state__icon" aria-hidden="true"></i>
-
-      <h1 class="pf-c-title pf-m-lg">No Log</h1>
-
-      <div class="pf-c-empty-state__body">Log output of {container.name}</div>
-    </div>
-  </div>
-</div>
+<EmptyScreen
+  icon="{NoLogIcon}"
+  title="No Log"
+  message="Log output of {container.name}"
+  hidden="{noLogs === false}"
+  style="background-color: {getPanelDetailColor()}" />
 
 <div
   class="min-w-full flex flex-col"

--- a/packages/renderer/src/lib/pod/PodDetailsLogs.svelte
+++ b/packages/renderer/src/lib/pod/PodDetailsLogs.svelte
@@ -17,7 +17,6 @@ export let pod: PodInfoUI;
 let logsXtermDiv: HTMLDivElement;
 
 // Logs has been initialized
-let logsReady = false;
 let noLogs = true;
 let logsTerminal;
 
@@ -102,9 +101,8 @@ async function fetchPodLogs() {
       callback(name, `${colouredName} ${padding} | ${content}`);
     };
 
-    // Get the logs for the container and set logsReady as true
+    // Get the logs for the container
     await window.logsContainer(pod.engineId, container.Id, logsCallback);
-    logsReady = true;
   });
 }
 

--- a/packages/renderer/src/lib/pod/PodDetailsLogs.svelte
+++ b/packages/renderer/src/lib/pod/PodDetailsLogs.svelte
@@ -8,6 +8,8 @@ import { TerminalSettings } from '../../../../main/src/plugin/terminal-settings'
 import { getPanelDetailColor } from '../color/color';
 import type { PodInfoUI } from './PodInfoUI';
 import { isMultiplexedLog } from '../stream/stream-utils';
+import EmptyScreen from '../ui/EmptyScreen.svelte';
+import NoLogIcon from '../ui/NoLogIcon.svelte';
 
 export let pod: PodInfoUI;
 
@@ -173,27 +175,18 @@ onDestroy(() => {
 });
 </script>
 
-{#if logsReady}
-  <div
-    class="h-full min-w-full flex flex-col"
-    class:hidden="{noLogs === false}"
-    style="background-color: {getPanelDetailColor()}">
-    <div class="pf-c-empty-state h-full">
-      <div class="pf-c-empty-state__content">
-        <i class="fas fa-terminal pf-c-empty-state__icon" aria-hidden="true"></i>
-
-        <h1 class="pf-c-title pf-m-lg">No Log</h1>
-
-        <div class="pf-c-empty-state__body">Log output of Pod {pod.name}</div>
-      </div>
-    </div>
-  </div>
-{/if}
+<EmptyScreen
+  icon="{NoLogIcon}"
+  title="No Log"
+  message="Log output of Pod {pod.name}"
+  hidden="{noLogs === false}"
+  style="background-color: {getPanelDetailColor()}" />
 
 <div
-  class="flex flex-col"
-  style="background-color: {getPanelDetailColor()}"
+  class="min-w-full flex flex-col"
+  class:invisible="{noLogs === true}"
+  class:h-0="{noLogs === true}"
   class:h-full="{noLogs === false}"
-  class:min-w-full="{noLogs === false}"
+  style="background-color: {getPanelDetailColor()}"
   bind:this="{logsXtermDiv}">
 </div>

--- a/packages/renderer/src/lib/ui/EmptyScreen.svelte
+++ b/packages/renderer/src/lib/ui/EmptyScreen.svelte
@@ -8,6 +8,7 @@ export let title: string = 'No title';
 export let message: string = 'Message';
 export let commandline: string = '';
 export let hidden: boolean = false;
+export let style: string = '';
 
 let fontAwesomeIcon = false;
 let processed = false;
@@ -27,7 +28,7 @@ function copyRunInstructionToClipboard() {
 let copyTextDivElement: HTMLDivElement;
 </script>
 
-<div class="h-full min-w-full flex flex-col" class:hidden="{hidden}">
+<div class="h-full min-w-full flex flex-col" class:hidden="{hidden}" style="{style}">
   <div class="pf-c-empty-state h-full">
     <div class="pf-c-empty-state__content">
       <p class="pf-c-empty-state__body">

--- a/packages/renderer/src/lib/ui/NoLogIcon.svelte
+++ b/packages/renderer/src/lib/ui/NoLogIcon.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+export let size: string = '40';
+</script>
+
+<svg
+  width="{size}"
+  height="{size}"
+  class="{$$props.class}"
+  style="{$$props.style}"
+  aria-hidden="true"
+  data-prefix="far"
+  data-icon="terminal"
+  role="img"
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 640 512">
+  <path
+    fill="currentColor"
+    d="M41.678 38.101l209.414 209.414c4.686 4.686 4.686 12.284 0 16.971L41.678 473.899c-4.686 4.686-12.284 4.686-16.971 0L4.908 454.101c-4.686-4.686-4.686-12.284 0-16.971L185.607 256 4.908 74.87c-4.686-4.686-4.686-12.284 0-16.971L24.707 38.1c4.686-4.686 12.284-4.686 16.971.001zM640 468v-28c0-6.627-5.373-12-12-12H300c-6.627 0-12 5.373-12 12v28c0 6.627 5.373 12 12 12h328c6.627 0 12-5.373 12-12z"
+    class="">
+  </path>
+</svg>


### PR DESCRIPTION
### What does this PR do?

This shows the no logs view when opening the logs tab and waiting for logs to being fetched.

### Screenshot/screencast of this PR

![spinner_terminal](https://user-images.githubusercontent.com/49404737/216952505-899308ae-183e-487a-b6e5-28832a0b6452.gif)

### What issues does this PR fix or reference?

it fixes https://github.com/containers/podman-desktop/issues/1117

### How to test this PR?

1. have a container that start printing logs after a while
2. open the logs view, see the no logs view 

I have used this to simulate a similar behavior
```
apiVersion: v1
kind: Pod
metadata:
  name: sleep-print
spec:
  containers:
    - name: sleepy
      image: alpine      
      command: 
        - /bin/sh
        - -c 
        - | 
          sleep 10 && echo "hello"
```
