### PR TITLE
feat(extension-api): Implements showInputBox & showQuickPick

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -559,6 +559,229 @@ declare module '@tmpwip/extension-api' {
     onCancellationRequested: Event<any>;
   }
 
+  /**
+   * Impacts the behavior and appearance of the validation message.
+   */
+  export enum InputBoxValidationSeverity {
+    Info = 1,
+    Warning = 2,
+    Error = 3,
+  }
+
+  /**
+   * Object to configure the behavior of the validation message.
+   */
+  export interface InputBoxValidationMessage {
+    /**
+     * The validation message to display.
+     */
+    readonly message: string;
+
+    /**
+     * The severity of the validation message.
+     * NOTE: When using `InputBoxValidationSeverity.Error`, the user will not be allowed to accept (hit ENTER) the input.
+     * `Info` and `Warning` will still allow the InputBox to accept the input.
+     */
+    readonly severity: InputBoxValidationSeverity;
+  }
+
+  /**
+   * Options to configure the behavior of the input box UI.
+   */
+  export interface InputBoxOptions {
+    /**
+     * An optional string that represents the title of the input box.
+     */
+    title?: string;
+
+    /**
+     * The value to pre-fill in the input box.
+     */
+    value?: string;
+
+    /**
+     * Selection of the pre-filled {@linkcode InputBoxOptions.value value}. Defined as tuple of two number where the
+     * first is the inclusive start index and the second the exclusive end index. When `undefined` the whole
+     * pre-filled value will be selected, when empty (start equals end) only the cursor will be set,
+     * otherwise the defined range will be selected.
+     */
+    valueSelection?: [number, number];
+
+    /**
+     * The text to display underneath the input box.
+     */
+    prompt?: string;
+
+    /**
+     * An optional string to show as placeholder in the input box to guide the user what to type.
+     */
+    placeHolder?: string;
+
+    /**
+     * Controls if a password input is shown. Password input hides the typed text.
+     */
+    password?: boolean;
+
+    /**
+     * Set to `true` to keep the input box open when focus moves to another part of the editor or to another window.
+     * This setting is ignored on iPad and is always false.
+     */
+    ignoreFocusOut?: boolean;
+
+    /**
+     * An optional function that will be called to validate input and to give a hint
+     * to the user.
+     *
+     * @param value The current value of the input box.
+     * @return Either a human-readable string which is presented as an error message or an {@link InputBoxValidationMessage}
+     *  which can provide a specific message severity. Return `undefined`, `null`, or the empty string when 'value' is valid.
+     */
+    validateInput?(
+      value: string,
+    ):
+      | string
+      | InputBoxValidationMessage
+      | undefined
+      | null
+      | Promise<string | InputBoxValidationMessage | undefined | null>;
+  }
+
+  /**
+   * The kind of {@link QuickPickItem quick pick item}.
+   */
+  export enum QuickPickItemKind {
+    /**
+     * When a {@link QuickPickItem} has a kind of {@link Separator}, the item is just a visual separator and does not represent a real item.
+     * The only property that applies is {@link QuickPickItem.label label }. All other properties on {@link QuickPickItem} will be ignored and have no effect.
+     */
+    Separator = -1,
+    /**
+     * The default {@link QuickPickItem.kind} is an item that can be selected in the quick pick.
+     */
+    Default = 0,
+  }
+
+  /**
+   * Button for an action in a {@link QuickPick} or {@link InputBox}.
+   */
+  export interface QuickInputButton {
+    /**
+     * Icon for the button.
+     */
+    readonly iconPath: Uri | { light: Uri; dark: Uri };
+
+    /**
+     * An optional tooltip.
+     */
+    readonly tooltip?: string | undefined;
+  }
+
+  /**
+   * Options to configure the behavior of the quick pick UI.
+   */
+  export interface QuickPickOptions {
+    /**
+     * An optional string that represents the title of the quick pick.
+     */
+    title?: string;
+
+    /**
+     * An optional flag to include the description when filtering the picks.
+     */
+    matchOnDescription?: boolean;
+
+    /**
+     * An optional flag to include the detail when filtering the picks.
+     */
+    matchOnDetail?: boolean;
+
+    /**
+     * An optional string to show as placeholder in the input box to guide the user what to pick on.
+     */
+    placeHolder?: string;
+
+    /**
+     * Set to `true` to keep the picker open when focus moves to another part of the editor or to another window.
+     * This setting is ignored on iPad and is always false.
+     */
+    ignoreFocusOut?: boolean;
+
+    /**
+     * An optional flag to make the picker accept multiple selections, if true the result is an array of picks.
+     */
+    canPickMany?: boolean;
+
+    /**
+     * An optional function that is invoked whenever an item is selected.
+     */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    onDidSelectItem?(item: QuickPickItem | string): any;
+  }
+
+  /**
+   * Represents an item that can be selected from
+   * a list of items.
+   */
+  export interface QuickPickItem {
+    /**
+     * A human-readable string which is rendered prominent. Supports rendering of {@link ThemeIcon theme icons} via
+     * the `$(<name>)`-syntax.
+     */
+    label: string;
+
+    /**
+     * The kind of QuickPickItem that will determine how this item is rendered in the quick pick. When not specified,
+     * the default is {@link QuickPickItemKind.Default}.
+     */
+    kind?: QuickPickItemKind;
+
+    /**
+     * A human-readable string which is rendered less prominent in the same line. Supports rendering of
+     * {@link ThemeIcon theme icons} via the `$(<name>)`-syntax.
+     *
+     * Note: this property is ignored when {@link QuickPickItem.kind kind} is set to {@link QuickPickItemKind.Separator}
+     */
+    description?: string;
+
+    /**
+     * A human-readable string which is rendered less prominent in a separate line. Supports rendering of
+     * {@link ThemeIcon theme icons} via the `$(<name>)`-syntax.
+     *
+     * Note: this property is ignored when {@link QuickPickItem.kind kind} is set to {@link QuickPickItemKind.Separator}
+     */
+    detail?: string;
+
+    /**
+     * Optional flag indicating if this item is picked initially. This is only honored when using
+     * the {@link window.showQuickPick showQuickPick()} API. To do the same thing with
+     * the {@link window.createQuickPick createQuickPick()} API, simply set the {@link QuickPick.selectedItems}
+     * to the items you want picked initially.
+     * (*Note:* This is only honored when the picker allows multiple selections.)
+     *
+     * @see {@link QuickPickOptions.canPickMany}
+     *
+     * Note: this property is ignored when {@link QuickPickItem.kind kind} is set to {@link QuickPickItemKind.Separator}
+     */
+    picked?: boolean;
+
+    /**
+     * Always show this item.
+     *
+     * Note: this property is ignored when {@link QuickPickItem.kind kind} is set to {@link QuickPickItemKind.Separator}
+     */
+    alwaysShow?: boolean;
+
+    /**
+     * Optional buttons that will be rendered on this particular item. These buttons will trigger
+     * an {@link QuickPickItemButtonEvent} when clicked. Buttons are only rendered when using a quickpick
+     * created by the {@link window.createQuickPick createQuickPick()} API. Buttons are not rendered when using
+     * the {@link window.showQuickPick showQuickPick()} API.
+     *
+     * Note: this property is ignored when {@link QuickPickItem.kind kind} is set to {@link QuickPickItemKind.Separator}
+     */
+    buttons?: readonly QuickInputButton[];
+  }
+
   export interface NotificationOptions {
     /**
      * A title for the notification, which will be shown at the top of the notification window when it is shown.
@@ -725,6 +948,75 @@ declare module '@tmpwip/extension-api' {
      * @return A new status bar item.
      */
     export function createStatusBarItem(alignment?: StatusBarAlignment, priority?: number): StatusBarItem;
+
+    /**
+     * Opens an input box to ask the user for input.
+     *
+     * The returned value will be `undefined` if the input box was canceled (e.g. pressing ESC). Otherwise the
+     * returned value will be the string typed by the user or an empty string if the user did not type
+     * anything but dismissed the input box with OK.
+     *
+     * @param options Configures the behavior of the input box.
+     * @param token A token that can be used to signal cancellation.
+     * @return A promise that resolves to a string the user provided or to `undefined` in case of dismissal.
+     */
+    export function showInputBox(options?: InputBoxOptions, token?: CancellationToken): Promise<string | undefined>;
+
+    /**
+     * Shows a selection list allowing multiple selections.
+     *
+     * @param items An array of strings, or a promise that resolves to an array of strings.
+     * @param options Configures the behavior of the selection list.
+     * @param token A token that can be used to signal cancellation.
+     * @return A promise that resolves to the selected items or `undefined`.
+     */
+    export function showQuickPick(
+      items: readonly string[] | Promise<readonly string[]>,
+      options: QuickPickOptions & { canPickMany: true },
+      token?: CancellationToken,
+    ): Promise<string[] | undefined>;
+
+    /**
+     * Shows a selection list.
+     *
+     * @param items An array of strings, or a promise that resolves to an array of strings.
+     * @param options Configures the behavior of the selection list.
+     * @param token A token that can be used to signal cancellation.
+     * @return A promise that resolves to the selection or `undefined`.
+     */
+    export function showQuickPick(
+      items: readonly string[] | Promise<readonly string[]>,
+      options?: QuickPickOptions,
+      token?: CancellationToken,
+    ): Promise<string | undefined>;
+
+    /**
+     * Shows a selection list allowing multiple selections.
+     *
+     * @param items An array of items, or a promise that resolves to an array of items.
+     * @param options Configures the behavior of the selection list.
+     * @param token A token that can be used to signal cancellation.
+     * @return A promise that resolves to the selected items or `undefined`.
+     */
+    export function showQuickPick<T extends QuickPickItem>(
+      items: readonly T[] | Promise<readonly T[]>,
+      options: QuickPickOptions & { canPickMany: true },
+      token?: CancellationToken,
+    ): Promise<T[] | undefined>;
+
+    /**
+     * Shows a selection list.
+     *
+     * @param items An array of items, or a promise that resolves to an array of items.
+     * @param options Configures the behavior of the selection list.
+     * @param token A token that can be used to signal cancellation.
+     * @return A promise that resolves to the selected item or `undefined`.
+     */
+    export function showQuickPick<T extends QuickPickItem>(
+      items: readonly T[] | Promise<readonly T[]>,
+      options?: QuickPickOptions,
+      token?: CancellationToken,
+    ): Promise<T | undefined>;
   }
 
   export namespace kubernetes {

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2022 Red Hat, Inc.
+ * Copyright (C) 2022-2023 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,6 +40,8 @@ import { Uri } from './types/uri';
 import type { KubernetesClient } from './kubernetes-client';
 import type { Proxy } from './proxy';
 import type { ContainerProviderRegistry } from './container-registry';
+import type { InputQuickPickRegistry } from './input-quickpick/input-quickpick-registry';
+import { QuickPickItemKind, InputBoxValidationSeverity } from './input-quickpick/input-quickpick-registry';
 
 /**
  * Handle the loading of an extension
@@ -88,6 +90,7 @@ export class ExtensionLoader {
     private fileSystemMonitoring: FilesystemMonitoring,
     private proxy: Proxy,
     private containerProviderRegistry: ContainerProviderRegistry,
+    private inputQuickPickRegistry: InputQuickPickRegistry,
   ) {}
 
   async listExtensions(): Promise<ExtensionInfo[]> {
@@ -407,6 +410,7 @@ export class ExtensionLoader {
     const dialogs = this.dialogs;
     const progress = this.progress;
     const notifications = this.notifications;
+    const inputQuickPickRegistry = this.inputQuickPickRegistry;
     const windowObj: typeof containerDesktopAPI.window = {
       showInformationMessage: (message: string, ...items: string[]) => {
         return dialogs.showDialog('info', extManifest.name, message, items);
@@ -416,6 +420,20 @@ export class ExtensionLoader {
       },
       showErrorMessage: (message: string, ...items: string[]) => {
         return dialogs.showDialog('error', extManifest.name, message, items);
+      },
+
+      showInputBox: (options?: containerDesktopAPI.InputBoxOptions, token?: containerDesktopAPI.CancellationToken) => {
+        return inputQuickPickRegistry.showInputBox(options, token);
+      },
+
+      showQuickPick(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        items: readonly any[] | Promise<readonly any[]>,
+        options?: containerDesktopAPI.QuickPickOptions,
+        token?: containerDesktopAPI.CancellationToken,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ): Promise<any> {
+        return inputQuickPickRegistry.showQuickPick(items, options, token);
       },
 
       withProgress: <R>(
@@ -505,6 +523,8 @@ export class ExtensionLoader {
       StatusBarItemDefaultPriority,
       StatusBarAlignLeft,
       StatusBarAlignRight,
+      InputBoxValidationSeverity,
+      QuickPickItemKind,
     };
   }
 

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2022 Red Hat, Inc.
+ * Copyright (C) 2022-2023 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -83,6 +83,7 @@ import { Certificates } from './certificates';
 import { Proxy } from './proxy';
 import { EditorInit } from './editor-init';
 import { ExtensionInstaller } from './install/extension-installer';
+import { InputQuickPickRegistry } from './input-quickpick/input-quickpick-registry';
 
 type LogType = 'log' | 'warn' | 'trace' | 'debug' | 'error';
 export class PluginSystem {
@@ -266,6 +267,7 @@ export class PluginSystem {
     const providerRegistry = new ProviderRegistry(apiSender, containerProviderRegistry, telemetry);
     const trayMenuRegistry = new TrayMenuRegistry(this.trayMenu, commandRegistry, providerRegistry, telemetry);
     const statusBarRegistry = new StatusBarRegistry(apiSender);
+    const inputQuickPickRegistry = new InputQuickPickRegistry(apiSender);
     const fileSystemMonitoring = new FilesystemMonitoring();
 
     const kubernetesClient = new KubernetesClient(configurationRegistry, fileSystemMonitoring);
@@ -331,6 +333,7 @@ export class PluginSystem {
       fileSystemMonitoring,
       proxy,
       containerProviderRegistry,
+      inputQuickPickRegistry,
     );
     await this.extensionLoader.init();
 
@@ -737,6 +740,32 @@ export class PluginSystem {
         context.log.removeLogHandler();
       },
     );
+
+    this.ipcHandle(
+      'showInputBox:value',
+      async (_listener, id: number, value: string | undefined, error?: string): Promise<void> => {
+        return inputQuickPickRegistry.onInputBoxValueEntered(id, value, error);
+      },
+    );
+
+    this.ipcHandle('showQuickPick:values', async (_listener, id: number, indexes: number[]): Promise<void> => {
+      return inputQuickPickRegistry.onQuickPickValuesSelected(id, indexes);
+    });
+
+    this.ipcHandle(
+      'showInputBox:validate',
+      async (
+        _listener,
+        id: number,
+        value: string,
+      ): Promise<string | containerDesktopAPI.InputBoxValidationMessage | undefined | null> => {
+        return inputQuickPickRegistry.validate(id, value);
+      },
+    );
+
+    this.ipcHandle('showQuickPick:onSelect', async (_listener, id: number, selectedId: number): Promise<void> => {
+      return inputQuickPickRegistry.onDidSelectQuickPickItem(id, selectedId);
+    });
 
     this.ipcHandle('image-registry:getRegistries', async (): Promise<readonly containerDesktopAPI.Registry[]> => {
       return imageRegistry.getRegistries();

--- a/packages/main/src/plugin/input-quickpick/input-quickpick-registry.ts
+++ b/packages/main/src/plugin/input-quickpick/input-quickpick-registry.ts
@@ -1,0 +1,235 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type {
+  CancellationToken,
+  InputBoxOptions,
+  InputBoxValidationMessage,
+  QuickPickOptions,
+} from '@tmpwip/extension-api';
+import { Deferred } from '../util/deferred';
+
+export class InputQuickPickRegistry {
+  private callbackId = 0;
+
+  private callbacksInputBox = new Map<
+    number,
+    { deferred: Deferred<string | undefined>; options?: InputBoxOptions; token?: CancellationToken }
+  >();
+
+  private callbacksQuickPicks = new Map<
+    number,
+    {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      items: readonly any[];
+      deferred: Deferred<string[] | string | undefined>;
+      options?: QuickPickOptions;
+      token?: CancellationToken;
+    }
+  >();
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  constructor(private apiSender: any) {}
+
+  async showInputBox(options?: InputBoxOptions, token?: CancellationToken): Promise<string | undefined> {
+    // keep track of this request
+    this.callbackId++;
+
+    // create a promise that will be resolved when the frontend sends the result
+    const deferred = new Deferred<string | undefined>();
+
+    // store the callback that will resolve the promise
+    this.callbacksInputBox.set(this.callbackId, { deferred, options, token });
+
+    let validate = false;
+    if (options?.validateInput) {
+      validate = true;
+    }
+    const data = {
+      id: this.callbackId,
+      value: options?.value,
+      placeHolder: options?.placeHolder,
+      valueSelection: options?.valueSelection,
+      prompt: options?.prompt,
+      validate,
+    };
+
+    // need to send the options to the frontend
+    this.apiSender.send('showInputBox:add', data);
+
+    // if the token is cancelled, reject the promise
+    token?.onCancellationRequested(() => {
+      // ask to hide the input box
+      this.apiSender.send('showInputBox:cancel', this.callbackId);
+
+      // reject the promise
+      deferred.reject('Input has been cancelled');
+    });
+    // return the promise
+    return deferred.promise;
+  }
+
+  // this method is called by the frontend when the user has entered a value
+  onInputBoxValueEntered(id: number, value: string | undefined, error?: string) {
+    // get the callback
+    const callback = this.callbacksInputBox.get(id);
+
+    // if there is a callback
+    if (callback) {
+      // if there is an error, reject the promise
+      if (error) {
+        callback.deferred.reject(error);
+      } else {
+        // resolve the promise
+        callback.deferred.resolve(value);
+      }
+
+      // remove the callback
+      this.callbacksInputBox.delete(id);
+    }
+  }
+
+  // this method is called by the frontend when the user has selected a value in QuickPick
+  onQuickPickValuesSelected(id: number, indexes: number[]): void {
+    // get the callback
+    const callback = this.callbacksQuickPicks.get(id);
+
+    // if there is a callback
+    if (callback) {
+      if (callback.options?.canPickMany) {
+        const allItems = indexes.map(index => callback.items[index]);
+        // resolve the promise
+        callback.deferred.resolve(allItems);
+      } else {
+        // grab item
+        const item = callback.items[indexes[0]];
+
+        // resolve the promise
+        callback.deferred.resolve(item);
+      }
+
+      // remove the callback
+      this.callbacksInputBox.delete(id);
+    }
+  }
+
+  // this method is called by the frontend when the user has entered a value
+  async validate(id: number, value: string): Promise<string | InputBoxValidationMessage | undefined | null> {
+    // get the callback
+    const callback = this.callbacksInputBox.get(id);
+
+    // if there is a callback
+    if (callback && callback.options?.validateInput) {
+      return callback.options.validateInput(value);
+    }
+    return undefined;
+  }
+
+  // this method is called by the frontend when the user is selecting a quickPick item (focus)
+  async onDidSelectQuickPickItem(id: number, index: number): Promise<void> {
+    // get the callback
+    const callback = this.callbacksQuickPicks.get(id);
+
+    // if there is a callback
+    if (callback && callback.options?.onDidSelectItem) {
+      // grab item
+      const item = callback.items[index];
+
+      return callback.options.onDidSelectItem(item);
+    }
+    return undefined;
+  }
+
+  /**
+   * Return a promise that resolves to the selected item (or undefined if cancelled)
+   */
+  async showQuickPick(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    items: readonly any[] | Promise<readonly any[]>,
+    options?: QuickPickOptions,
+    token?: CancellationToken,
+  ): Promise<string[] | string | undefined> {
+    // keep track of this request
+    this.callbackId++;
+
+    // create a promise that will be resolved when the frontend sends the result
+    const deferred = new Deferred<string | string[] | undefined>();
+
+    // check if the items are a promise
+    if (items instanceof Promise) {
+      // if so, wait for the promise to resolve
+      items = await items;
+    }
+
+    // store the callback that will resolve the promise
+    this.callbacksQuickPicks.set(this.callbackId, { items, deferred, options, token });
+
+    let onSelectCallback = false;
+    if (options?.onDidSelectItem) {
+      onSelectCallback = true;
+    }
+
+    const data = {
+      id: this.callbackId,
+      placeHolder: options?.placeHolder,
+      canPickMany: options?.canPickMany,
+      items: items,
+      // need to callback to the frontend when selecting an item
+      onSelectCallback,
+    };
+
+    // need to send the options to the frontend
+    this.apiSender.send('showQuickPick:add', data);
+
+    // if the token is cancelled, reject the promise
+    token?.onCancellationRequested(() => {
+      // ask to hide the input box
+      this.apiSender.send('showQuickPick:cancel', this.callbackId);
+
+      // reject the promise
+      deferred.reject('QuickPick has been cancelled');
+    });
+
+    // return the promise
+    return deferred.promise;
+  }
+}
+
+/**
+ * Impacts the behavior and appearance of the validation message.
+ */
+export enum InputBoxValidationSeverity {
+  Info = 1,
+  Warning = 2,
+  Error = 3,
+}
+
+/**
+ * The kind of {@link QuickPickItem quick pick item}.
+ */
+export enum QuickPickItemKind {
+  /**
+   * When a {@link QuickPickItem} has a kind of {@link Separator}, the item is just a visual separator and does not represent a real item.
+   * The only property that applies is {@link QuickPickItem.label label }. All other properties on {@link QuickPickItem} will be ignored and have no effect.
+   */
+  Separator = -1,
+  /**
+   * The default {@link QuickPickItem.kind} is an item that can be selected in the quick pick.
+   */
+  Default = 0,
+}

--- a/packages/main/src/plugin/util/deferred.ts
+++ b/packages/main/src/plugin/util/deferred.ts
@@ -1,0 +1,34 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+export class Deferred<T> {
+  resolve: (value: T | PromiseLike<T>) => void = () => {
+    return;
+  };
+  reject: (err?: unknown) => void = () => {
+    return;
+  };
+  promise: Promise<T>;
+
+  constructor() {
+    this.promise = new Promise<T>((resolve, reject) => {
+      this.resolve = resolve;
+      this.reject = reject;
+    });
+  }
+}

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2022 Red Hat, Inc.
+ * Copyright (C) 2022-2023 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -885,6 +885,37 @@ function initExposure(): void {
     'stopReceiveLogs',
     async (providerId: string, containerConnectionInfo?: ProviderContainerConnectionInfo): Promise<void> => {
       return ipcInvoke('provider-registry:stopReceiveLogs', providerId, containerConnectionInfo);
+    },
+  );
+
+  contextBridge.exposeInMainWorld(
+    'sendShowInputBoxValue',
+    async (inputBoxId: number, value: string | undefined, error: string | undefined): Promise<void> => {
+      return ipcInvoke('showInputBox:value', inputBoxId, value, error);
+    },
+  );
+
+  contextBridge.exposeInMainWorld(
+    'sendShowQuickPickValues',
+    async (quickPickId: number, selectedIndexes: number[]): Promise<void> => {
+      return ipcInvoke('showQuickPick:values', quickPickId, selectedIndexes);
+    },
+  );
+
+  contextBridge.exposeInMainWorld(
+    'sendShowInputBoxValidate',
+    async (
+      inputBoxId: number,
+      value: string,
+    ): Promise<string | containerDesktopAPI.InputBoxValidationMessage | undefined | null> => {
+      return ipcInvoke('showInputBox:validate', inputBoxId, value);
+    },
+  );
+
+  contextBridge.exposeInMainWorld(
+    'sendShowQuickPickOnSelect',
+    async (inputBoxId: number, selectedIndex: number): Promise<void> => {
+      return ipcInvoke('showQuickPick:onSelect', inputBoxId, selectedIndex);
     },
   );
 

--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -34,6 +34,7 @@ import DeployPodToKube from './lib/pod/DeployPodToKube.svelte';
 import RunImage from './lib/image/RunImage.svelte';
 import SendFeedback from './lib/feedback/SendFeedback.svelte';
 import ToastHandler from './lib/toast/ToastHandler.svelte';
+import QuickPickInput from './lib/dialogs/QuickPickInput.svelte';
 
 router.mode.hash();
 
@@ -88,6 +89,7 @@ window.events?.receive('display-help', () => {
       <div class="z-0 w-full h-full bg-zinc-800 flex flex-col overflow-y-scroll">
         <SendFeedback />
         <ToastHandler />
+        <QuickPickInput />
         <Route path="/">
           <WelcomePage />
         </Route>

--- a/packages/renderer/src/lib/dialogs/QuickPickInput.svelte
+++ b/packages/renderer/src/lib/dialogs/QuickPickInput.svelte
@@ -1,0 +1,291 @@
+<script lang="ts">
+import { onDestroy, onMount, tick } from 'svelte';
+
+interface InputBoxOptions {
+  placeHolder?: string;
+  value?: string;
+  valueSelection?: [number, number];
+  // if true, the input box will be validated on each keystroke
+  validate: boolean;
+  prompt: string;
+  id: number;
+}
+
+interface QuickPickOptions {
+  placeHolder?: string;
+  items: any[];
+  prompt: string;
+  id: number;
+  canPickMany: boolean;
+  // if true, needs to send the current element when item is selected
+  onSelectCallback: boolean;
+}
+
+const DEFAULT_PROMPT = "Press 'Enter' to confirm your input or 'Escape' to cancel";
+let inputValue = '';
+let placeHolder = '';
+let prompt = '';
+let currentId = 0;
+
+let validationEnabled = false;
+let validationError = '';
+
+let onSelectCallbackEnabled = false;
+
+let display = false;
+let mode: 'InputBox' | 'QuickPick';
+
+let quickPickItems: { value: any; checkbox: boolean }[] = [];
+let quickPickFilteredItems: { value: any; checkbox: boolean }[] = quickPickItems;
+let quickPickSelectedIndex = 0;
+let quickPickSelectedFilteredIndex = 0;
+let quickPickCanPickMany = false;
+
+let inputElement: HTMLInputElement = undefined;
+
+const showInputCallback = async (options?: InputBoxOptions) => {
+  mode = 'InputBox';
+  inputValue = options.value;
+  placeHolder = options.placeHolder;
+  currentId = options.id;
+  if (options.prompt) {
+    prompt = `${options.prompt} (${DEFAULT_PROMPT})`;
+  } else {
+    prompt = DEFAULT_PROMPT;
+  }
+
+  validationEnabled = options.validate;
+  display = true;
+  await tick();
+
+  if (display && inputElement) {
+    inputElement.focus();
+    if (options.valueSelection) {
+      inputElement.setSelectionRange(options.valueSelection[0], options.valueSelection[1]);
+    }
+  }
+};
+
+const showQuickPickCallback = async (options?: QuickPickOptions) => {
+  mode = 'InputBox';
+  placeHolder = options.placeHolder;
+  currentId = options.id;
+  if (options.prompt) {
+    prompt = options.prompt;
+  }
+  mode = 'QuickPick';
+  quickPickItems = options.items.map(item => ({ value: item, checkbox: false }));
+  quickPickFilteredItems = quickPickItems;
+
+  if (options.canPickMany) {
+    quickPickCanPickMany = true;
+  }
+
+  if (options.onSelectCallback) {
+    onSelectCallbackEnabled = true;
+    // if there is one item, notify that focus will be on it
+    if (quickPickItems.length > 0) {
+      window.sendShowQuickPickOnSelect(currentId, 0);
+    }
+  }
+
+  display = true;
+
+  await tick();
+
+  if (display && inputElement) {
+    inputElement.focus();
+  }
+};
+
+onMount(() => {
+  // handle the showInputBox events
+  window.events?.receive('showInputBox:add', showInputCallback);
+
+  // handle the showInputBox events
+  window.events?.receive('showQuickPick:add', showQuickPickCallback);
+});
+
+async function onInputChange(event: any) {
+  // in case of quick pick, filter the items
+  if (mode === 'QuickPick') {
+    quickPickFilteredItems = quickPickItems.filter(item => item.value.includes(event.target.value));
+    quickPickSelectedFilteredIndex = 0;
+    if (quickPickFilteredItems.length > 0) {
+      quickPickSelectedIndex = quickPickItems.indexOf(quickPickFilteredItems[quickPickSelectedFilteredIndex]);
+    }
+    return;
+  }
+
+  // skip validation if it is not enabled
+  if (!validationEnabled) {
+    return;
+  }
+  validationError = undefined;
+  const value = event.target.value;
+  const result = await window.sendShowInputBoxValidate(currentId, value);
+  if (result !== undefined && result !== null && result) {
+    validationError = result.toString();
+  }
+}
+
+onDestroy(() => {
+  cleanup();
+});
+
+function cleanup() {
+  display = false;
+  inputValue = '';
+  placeHolder = '';
+  prompt = '';
+  validationEnabled = false;
+  onSelectCallbackEnabled = false;
+  quickPickCanPickMany = false;
+  quickPickSelectedFilteredIndex = 0;
+  quickPickSelectedIndex = 0;
+}
+
+function validateQuickPick() {
+  if (mode === 'InputBox') {
+    // needs to convert the index from the filtered index to the original index
+    const originalIndex = quickPickItems.indexOf(quickPickFilteredItems[quickPickSelectedIndex]);
+
+    window.sendShowQuickPickValues(currentId, [originalIndex]);
+  } else {
+    // grab all selected items
+    if (quickPickCanPickMany) {
+      const selectedItems = quickPickItems.filter(item => item.checkbox);
+      window.sendShowQuickPickValues(
+        currentId,
+        selectedItems.map(item => quickPickItems.indexOf(item)),
+      );
+    } else {
+      window.sendShowQuickPickValues(currentId, [quickPickSelectedIndex]);
+    }
+  }
+  cleanup();
+}
+
+function clickQuickPickItem(item: any) {
+  if (quickPickCanPickMany) {
+    item.checkbox = !item.checkbox;
+    quickPickItems = [...quickPickItems];
+    quickPickFilteredItems = [...quickPickFilteredItems];
+  } else {
+    validateQuickPick();
+  }
+}
+
+function handleKeydown(e: KeyboardEvent) {
+  if (e.key === 'Escape') {
+    window.sendShowInputBoxValue(currentId, undefined, undefined);
+    cleanup();
+    e.preventDefault();
+    return;
+  } else if (e.key === 'Enter') {
+    if (mode === 'InputBox') {
+      window.sendShowInputBoxValue(currentId, inputValue, undefined);
+      cleanup();
+      e.preventDefault();
+      return;
+    } else if (mode === 'QuickPick') {
+      validateQuickPick();
+      e.preventDefault();
+      return;
+    }
+  } else if (e.key === ' ') {
+    if (mode === 'QuickPick') {
+      if (quickPickCanPickMany) {
+        // if space is pressed, toggle the item
+        const originalIndex = quickPickItems.indexOf(quickPickFilteredItems[quickPickSelectedFilteredIndex]);
+        quickPickItems[originalIndex].checkbox = !quickPickItems[originalIndex].checkbox;
+        quickPickFilteredItems = quickPickItems;
+        e.preventDefault();
+        return;
+      }
+    }
+  }
+
+  if (mode === 'QuickPick') {
+    if (e.key === 'ArrowDown') {
+      // if down key is pressed, move the index
+      quickPickSelectedFilteredIndex++;
+      if (quickPickSelectedFilteredIndex >= quickPickFilteredItems.length) {
+        quickPickSelectedFilteredIndex = 0;
+      }
+      quickPickSelectedIndex = quickPickItems.indexOf(quickPickFilteredItems[quickPickSelectedFilteredIndex]);
+      e.preventDefault();
+      if (onSelectCallbackEnabled) {
+        window.sendShowQuickPickOnSelect(currentId, quickPickSelectedIndex);
+      }
+      return;
+    } else if (e.key === 'ArrowUp') {
+      // if down key is pressed, move the index
+      quickPickSelectedFilteredIndex--;
+      if (quickPickSelectedFilteredIndex < 0) {
+        quickPickSelectedFilteredIndex = quickPickItems.length - 1;
+      }
+      quickPickSelectedIndex = quickPickItems.indexOf(quickPickFilteredItems[quickPickSelectedFilteredIndex]);
+      if (onSelectCallbackEnabled) {
+        window.sendShowQuickPickOnSelect(currentId, quickPickSelectedIndex);
+      }
+      e.preventDefault();
+      return;
+    }
+  }
+}
+</script>
+
+<svelte:window on:keydown="{handleKeydown}" />
+
+{#if display}
+  <!-- Create overlay-->
+  <div class="fixed top-0 left-0 right-0 bottom-0 bg-black bg-opacity-60 h-full z-40"></div>
+
+  <div class="absolute m-auto left-0 right-0 z-50">
+    <div class=" flex justify-center items-center mt-1">
+      <div
+        class="bg-zinc-900  w-[700px] {mode === 'InputBox'
+          ? 'h-16'
+          : ''} shadow-sm p-2 rounded shadow-zinc-700  text-sm">
+        <div class="w-full flex flex-row">
+          <input
+            bind:this="{inputElement}"
+            on:input="{event => onInputChange(event)}"
+            type="text"
+            bind:value="{inputValue}"
+            class="px-1 w-full text-gray-300 bg-zinc-700 border {validationError
+              ? 'border-red-700'
+              : 'border-zinc-800'} focus:outline-none"
+            placeholder="{placeHolder}" />
+          {#if quickPickCanPickMany}
+            <button
+              on:click="{() => validateQuickPick()}"
+              class="text-gray-300 bg-violet-600 border border-zinc-800 focus:outline-none px-1">OK</button>
+          {/if}
+        </div>
+
+        {#if mode === 'InputBox'}
+          {#if validationError}
+            <div class="text-gray-300 border border-red-700 relative  w-full bg-red-700 px-1">{validationError}</div>
+          {:else}
+            <div class="relative text-gray-300 pt-2 px-1 h-6 overflow-y-auto">{prompt}</div>
+          {/if}
+        {:else if mode === 'QuickPick'}
+          {#each quickPickFilteredItems as item, i}
+            <div class="flex w-full flex-row  {i === quickPickSelectedFilteredIndex ? 'bg-violet-500' : ''} ">
+              {#if quickPickCanPickMany}
+                <input type="checkbox" class="mx-1 outline-none" bind:checked="{item.checkbox}" />
+              {/if}
+              <button
+                on:click="{() => clickQuickPickItem(item)}"
+                class="text-gray-300 text-left relative my-1 w-full {i === quickPickSelectedFilteredIndex
+                  ? 'bg-violet-500'
+                  : ''} px-1">{item.value}</button>
+            </div>
+          {/each}
+        {/if}
+      </div>
+    </div>
+  </div>
+{/if}

--- a/packages/renderer/src/lib/dialogs/QuickPickInput.svelte
+++ b/packages/renderer/src/lib/dialogs/QuickPickInput.svelte
@@ -166,24 +166,38 @@ function validateQuickPick() {
   cleanup();
 }
 
-function clickQuickPickItem(item: any) {
+function clickQuickPickItem(item: any, index: number) {
   if (quickPickCanPickMany) {
+    // reset index as we clicked
+    quickPickSelectedFilteredIndex = -1;
     item.checkbox = !item.checkbox;
     quickPickItems = [...quickPickItems];
     quickPickFilteredItems = [...quickPickFilteredItems];
   } else {
+    // select the index from the cursor
+    quickPickSelectedIndex = quickPickItems.indexOf(quickPickFilteredItems[index]);
     validateQuickPick();
   }
 }
 
 function handleKeydown(e: KeyboardEvent) {
   if (e.key === 'Escape') {
+    // In case of validating error, do not proceed
+    if (validationError) {
+      e.preventDefault();
+      return;
+    }
     window.sendShowInputBoxValue(currentId, undefined, undefined);
     cleanup();
     e.preventDefault();
     return;
   } else if (e.key === 'Enter') {
     if (mode === 'InputBox') {
+      // In case of validating error, do not proceed
+      if (validationError) {
+        e.preventDefault();
+        return;
+      }
       window.sendShowInputBoxValue(currentId, inputValue, undefined);
       cleanup();
       e.preventDefault();
@@ -273,13 +287,16 @@ function handleKeydown(e: KeyboardEvent) {
           {/if}
         {:else if mode === 'QuickPick'}
           {#each quickPickFilteredItems as item, i}
-            <div class="flex w-full flex-row  {i === quickPickSelectedFilteredIndex ? 'bg-violet-500' : ''} ">
+            <div
+              class="flex w-full flex-row {i === quickPickSelectedFilteredIndex
+                ? 'bg-violet-500'
+                : 'hover:bg-zinc-800'} ">
               {#if quickPickCanPickMany}
                 <input type="checkbox" class="mx-1 outline-none" bind:checked="{item.checkbox}" />
               {/if}
               <button
-                on:click="{() => clickQuickPickItem(item)}"
-                class="text-gray-300 text-left relative my-1 w-full {i === quickPickSelectedFilteredIndex
+                on:click="{() => clickQuickPickItem(item, i)}"
+                class="text-gray-300 text-left relative my-1 w-full  {i === quickPickSelectedFilteredIndex
                   ? 'bg-violet-500'
                   : ''} px-1">{item.value}</button>
             </div>


### PR DESCRIPTION


### What does this PR do?
Adds new methods `showInputBox` and `showQuickPick`

it allows to interact with the user through extensions 

### Screenshot/screencast of this PR


https://user-images.githubusercontent.com/436777/216383150-9920577b-038d-4b0c-81c5-a9f2b4e8298b.mp4



### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/1300
fixes https://github.com/containers/podman-desktop/issues/1301


### How to test this PR?

Go to the extensions panel in settings and use as OCI image `quay.io/fbenoit/podman-desktop-quickpick`

you should see items in the status bar, click on it



Change-Id: I769c2491bcd00acc468300a549957b2fd96457c4
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
