### PR TITLE
chore: update to 0.3.4 API of DD extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "xvfb-maybe": "^0.2.1"
   },
   "dependencies": {
-    "@docker/extension-api-client-types": "0.3.2",
+    "@docker/extension-api-client-types": "0.3.4",
     "@kubernetes/client-node": "^0.18.1",
     "@types/stream-json": "^1.7.3",
     "analytics-node": "^6.2.0",

--- a/packages/preload-docker-extension/src/index.ts
+++ b/packages/preload-docker-extension/src/index.ts
@@ -258,6 +258,9 @@ export class DockerExtensionPreload {
       viewDevEnvironments: async (): Promise<void> => {
         console.error('navigationIntents.viewDevEnvironments not implemented');
       },
+      viewContainerTerminal: async (id: string): Promise<void> => {
+        console.error('navigationIntents.viewContainerTerminal not implemented', id);
+      },
     };
 
     const desktopUI: dockerDesktopAPI.DesktopUI = { toast, dialog, navigate };
@@ -329,6 +332,7 @@ export class DockerExtensionPreload {
     const extension: dockerDesktopAPI.Extension = {
       vm: extensionVM,
       host: extensionHost,
+      image: '',
     };
 
     const docker: dockerDesktopAPI.Docker = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2183,10 +2183,10 @@
     ajv "^6.12.0"
     ajv-keywords "^3.4.1"
 
-"@docker/extension-api-client-types@0.3.2":
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/@docker/extension-api-client-types/-/extension-api-client-types-0.3.2.tgz#5ff25345bd0c83d52ff64fb62e4e9def90232c2e"
-  integrity sha512-VTig2LAUAj2y37kEBqGvsGdlAVEHnusRwDNQGCom8gzggHZWrPRv3y0MRpgDjkVdc2YGPyPgUDVvd1UjsaIXng==
+"@docker/extension-api-client-types@0.3.4":
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/@docker/extension-api-client-types/-/extension-api-client-types-0.3.4.tgz#0393c98ecad937f95ea805615a917060358aa384"
+  integrity sha512-cDdD+dNSE0XCvQiw0R4j9aHpK+p6E7vi+z7RbKXfxwuQpfEMoeNCKFlp4W7K3XT78iWmoPz3DxQtZEAe4VJ1oQ==
 
 "@docsearch/css@3.2.0":
   version "3.2.0"


### PR DESCRIPTION
### What does this PR do?

Adds mocks for the new API

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

https://github.com/containers/podman-desktop/pull/1308

### How to test this PR?

You may try a Docker Desktop Extension but typescript tscheck is enough

Change-Id: Ia9ec974a70b6eb3ab21f9445aabf0a8d077f12f1
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
