### PR TITLE
fix: do not stop activating the extensions if one fails

### DIFF
--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -284,9 +284,12 @@ export class ExtensionLoader {
     }
 
     this.analyzedExtensions.set(extension.id, extension);
-    const runtime = this.loadRuntime(extension.mainPath);
-
-    await this.activateExtension(extension, runtime);
+    try {
+      const runtime = this.loadRuntime(extension.mainPath);
+      await this.activateExtension(extension, runtime);
+    } catch (ex) {
+      console.log(`'${extension.id}' extension activation error: ${ex}`);
+    }
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
### What does this PR do?

PR adds try/catch block to `ExtensionLoader.loadExtension()` method to let the extension loader to continue loading extensions in case of loading failure.

Signed-off-by: Denis Golovin [dgolovin@redhat.com](mailto:dgolovin@redhat.com)

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

N/A

### How to test this PR?

N/A