### PR TITLE
fix: new xterm instance spawn when clicking the logs route in pod details (#1355)

### DIFF
--- a/packages/renderer/src/lib/pod/PodDetailsLogs.svelte
+++ b/packages/renderer/src/lib/pod/PodDetailsLogs.svelte
@@ -17,7 +17,7 @@ let logsXtermDiv: HTMLDivElement;
 // Logs has been initialized
 let logsReady = false;
 let noLogs = true;
-let logsTerminal;
+let logsTerminal: Terminal;
 
 // Terminal resize
 let resizeObserver: ResizeObserver;
@@ -106,14 +106,6 @@ async function fetchPodLogs() {
   });
 }
 
-router.subscribe(async route => {
-  currentRouterPath = route.path;
-  if (route.path.endsWith('/logs')) {
-    await refreshTerminal();
-    fetchPodLogs();
-  }
-});
-
 async function refreshTerminal() {
   // missing element, return
   if (!logsXtermDiv) {
@@ -156,7 +148,8 @@ async function refreshTerminal() {
 
 onMount(async () => {
   // Refresh the terminal on initial load
-  refreshTerminal();
+  await refreshTerminal();
+  fetchPodLogs();
 
   // Resize the terminal each time we change the div size
   resizeObserver = new ResizeObserver(entries => {


### PR DESCRIPTION
### What does this PR do?

This PR prevents creating multiple xterm instances. The same fix as https://github.com/containers/podman-desktop/pull/1344 for Pod logs

### Screenshot/screencast of this PR

N/A
To view the issue it is the same as it was for containers https://user-images.githubusercontent.com/49404737/216112655-feb626cd-db72-4b78-a0eb-6f91b153c863.gif

### What issues does this PR fix or reference?

it fixes #1355 

### How to test this PR?

1. Open a pod with logs
2. Switch tabs, click on the logs tab multiple times.
3. Verify no new xterm instances have been created.

