### PR TITLE
fix: stop spinner if image cannot be retrieved (#1354)

### DIFF
--- a/packages/main/src/plugin/docker-extension/docker-desktop-installation.ts
+++ b/packages/main/src/plugin/docker-extension/docker-desktop-installation.ts
@@ -197,7 +197,7 @@ export class DockerDesktopInstallation {
         );
 
         if (!foundMatchingImage) {
-          reportLog('not able to get pulled image');
+          event.reply('docker-desktop-plugin:install-error', logCallbackId, `Not able to find image ${imageName}`);
           return;
         }
 


### PR DESCRIPTION
### What does this PR do?

it stops the spinner from the install button if the image cannot be retrieved

### Screenshot/screencast of this PR

![stop-spinner-install-ext](https://user-images.githubusercontent.com/49404737/217267457-7d146f15-088b-4cfc-b3f5-1b3807977960.gif)


### What issues does this PR fix or reference?

it fixes #1354 

### How to test this PR?

1. Go to settings -> Desktop extensions
2. Add the name of a not existing image
3. Try installing it. When failing you should be able to click the button again
