### PR TITLE
fix: enable/disable open browser action based on container state (#1348)

### DIFF
--- a/packages/renderer/src/lib/ui/ListItemButtonIcon.svelte
+++ b/packages/renderer/src/lib/ui/ListItemButtonIcon.svelte
@@ -20,7 +20,8 @@ const buttonClass: string =
 const buttonDisabledClass: string =
   'm-0.5 text-gray-700 font-medium rounded-full inline-flex items-center px-2 py-2 text-center';
 
-let styleClass: string = detailed
+$: handleClick = enabled ? onClick : () => {};
+$: styleClass = detailed
   ? enabled
     ? buttonDetailedClass
     : buttonDetailedDisabledClass
@@ -30,20 +31,12 @@ let styleClass: string = detailed
 </script>
 
 <!-- If menu = true, use the menu, otherwise implement the button -->
-{#if menu && enabled}
+{#if menu}
   <!-- enabled menu -->
-  <DropdownMenuItem title="{title}" icon="{icon}" hidden="{hidden}" onClick="{onClick}" />
-{:else if menu}
-  <!-- disabled menu -->
-  <DropdownMenuItem title="{title}" icon="{icon}" hidden="{hidden}" />
-{:else if enabled}
-  <!-- enabled button -->
-  <button title="{title}" on:click="{onClick}" class="{styleClass}" class:hidden="{hidden}">
-    <Fa class="h-4 w-4" icon="{icon}" />
-  </button>
+  <DropdownMenuItem title="{title}" icon="{icon}" hidden="{hidden}" onClick="{handleClick}" />
 {:else}
-  <!-- disabled button -->
-  <button title="{title}" class="{styleClass}" class:hidden="{hidden}">
+  <!-- enabled button -->
+  <button title="{title}" on:click="{handleClick}" class="{styleClass}" class:hidden="{hidden}">
     <Fa class="h-4 w-4" icon="{icon}" />
   </button>
 {/if}


### PR DESCRIPTION
### What does this PR do?

enable/disable open browser action based on container state

### Screenshot/screencast of this PR

![open-browser-button](https://user-images.githubusercontent.com/49404737/217284414-1bdc820b-30a8-485e-b0f9-485229026696.gif)

### What issues does this PR fix or reference?

it fixes #1348 

### How to test this PR?

1. open a container
2. check that the open in browser is not enabled
3. start the container
4. the open browser should be enabled
5. stop it, check again ...
