### PR TITLE
fix: hide open browser action in kebab menu for stopped container (#1347)

### DIFF
--- a/packages/renderer/src/lib/container/ContainerActions.svelte
+++ b/packages/renderer/src/lib/container/ContainerActions.svelte
@@ -132,6 +132,7 @@ if (dropdownMenu) {
     onClick="{() => openBrowser(container)}"
     menu="{dropdownMenu}"
     enabled="{container.state === 'RUNNING' && container.hasPublicPort}"
+    hidden="{dropdownMenu && container.state !== 'RUNNING'}"
     detailed="{detailed}"
     icon="{faExternalLinkSquareAlt}" />
   {#if !detailed}


### PR DESCRIPTION
### What does this PR do?

it hides the open browser action for stopped container within the kebab menu 

### Screenshot/screencast of this PR

![open-browser-kebab-menu](https://user-images.githubusercontent.com/49404737/217487769-e577090e-c75d-4fb6-90fe-59639aa5a3ed.gif)

### What issues does this PR fix or reference?

it fixes #1347 

### How to test this PR?

1. start a container, check that the open browser action is visible in the kebab menu
2. stop it, the action is not visible anymore
