### PR TITLE
fix: update editor content when pod name changes and disable deploy button when empty (#1319)

### DIFF
--- a/packages/renderer/src/lib/editor/MonacoEditor.svelte
+++ b/packages/renderer/src/lib/editor/MonacoEditor.svelte
@@ -55,9 +55,7 @@ onMount(async () => {
   };
 });
 
-export function setContent(content: string) {
-  editor.getModel().setValue(content);
-}
+$: content, editor && editor.getModel().setValue(content);
 </script>
 
 <div bind:this="{divEl}" class="h-full"></div>

--- a/packages/renderer/src/lib/editor/MonacoEditor.svelte
+++ b/packages/renderer/src/lib/editor/MonacoEditor.svelte
@@ -54,6 +54,10 @@ onMount(async () => {
     editor.dispose();
   };
 });
+
+export function setContent(content: string) {
+  editor.getModel().setValue(content);
+}
 </script>
 
 <div bind:this="{divEl}" class="h-full"></div>


### PR DESCRIPTION
### What does this PR do?

it updates the editor content when the pod name is hangedby the user

### Screenshot/screencast of this PR

![editor-pod-name-update](https://user-images.githubusercontent.com/49404737/217561292-4ad2e355-e356-4890-b596-046afc65b9ed.gif)

### What issues does this PR fix or reference?

it fixes #1319 

### How to test this PR?

1. go to the deploy page of a pod
2. update the pod name
3. the editor content should reflect the change made
4. delete everything so that the input box is empty
5. the deploy button should be disabled
