### PR TITLE
fix: random CRC status change

### DIFF
--- a/extensions/crc/src/extension.ts
+++ b/extensions/crc/src/extension.ts
@@ -34,15 +34,14 @@ let crcStatus: Status;
 
 const crcLogProvider = new LogProvider(commander);
 
+const defaultStatus = { CrcStatus: 'Unknown', Preset: 'Unknown' };
+
 export async function activate(extensionContext: extensionApi.ExtensionContext): Promise<void> {
   // crc is installed or not ?
   if (!fs.existsSync(crcBinary())) {
     console.warn('Can not find CRC binary!');
     return;
   }
-
-  // detect preset of CRC
-  const preset = await readPreset();
 
   // create CRC provider
   const provider = extensionApi.provider.createProvider({
@@ -66,7 +65,11 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
     crcStatus = await commander.status();
   } catch (err) {
     console.error('error in CRC extension', err);
+    crcStatus = defaultStatus;
   }
+
+  // detect preset of CRC
+  const preset = readPreset(crcStatus);
 
   const providerLifecycle: extensionApi.ProviderLifecycle = {
     status: () => convertToProviderStatus(crcStatus?.CrcStatus),
@@ -232,39 +235,24 @@ function convertToProviderStatus(crcStatus: string): extensionApi.ProviderStatus
 
 async function startStatusUpdateTimer(): Promise<void> {
   statusFetchTimer = setInterval(async () => {
-    crcStatus = await commander.status();
-  }, 2000);
+    try {
+      crcStatus = await commander.status();
+    } catch (e) {
+      console.error('CRC Status tick: ' + e);
+      crcStatus = defaultStatus;
+    }
+  }, 1000);
 }
 
-// async function crcBinary(): Promise<string> {
-//   return which('crc');
-// }
-
-function execPromise(command, args?: string[]): Promise<string> {
-  const env = process.env;
-  // In production mode, applications don't have access to the 'user' path like brew
-  return new Promise((resolve, reject) => {
-    let output = '';
-    const process = childProcess.spawn(command, args, { env });
-    process.stdout.setEncoding('utf8');
-    process.stdout.on('data', data => {
-      output += data;
-    });
-
-    process.on('close', () => resolve(output.trim()));
-    process.on('error', err => reject(err));
-  });
-}
-
-async function readPreset(): Promise<'Podman' | 'OpenShift' | 'unknown'> {
+function readPreset(crcStatus: Status): 'Podman' | 'OpenShift' | 'unknown' {
   try {
-    const stdout = await execPromise('crc', ['config', 'get', 'preset']);
-    if (stdout.includes('podman')) {
-      return 'Podman';
-    } else if (stdout.includes('openshift')) {
-      return 'OpenShift';
-    } else {
-      return 'unknown';
+    switch (crcStatus.Preset) {
+      case 'podman':
+        return 'Podman';
+      case 'openshift':
+        return 'OpenShift';
+      default:
+        return 'unknown';
     }
   } catch (err) {
     console.log('error while getting preset', err);


### PR DESCRIPTION
### What does this PR do?
It change a bit of how fetching CRC status, add better error handling.
Also it use status object to get preset, instead of calling `crc` CLI.

Basically status is getting close to existing tray-app in CRC https://github.com/crc-org/tray-electron

### Screenshot/screencast of this PR
n/a
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?
Fix: https://github.com/containers/podman-desktop/issues/1387
<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

### How to test this PR?
It very hard to test, as issue appears of some specific windows environment( with VPN setup etc.), at least, this PR shouldn’t break any thing.
<!-- Please explain steps to reproduce -->
