### PR TITLE
docs: fix old documentation for 'podman-mac-helper setup'

### DIFF
--- a/website/docs/migrating-from-docker/using-podman-mac-helper.md
+++ b/website/docs/migrating-from-docker/using-podman-mac-helper.md
@@ -29,16 +29,23 @@ The service redirects `/var/run/docker` to the fixed user-assigned UNIX socket l
 1. Install the `podman-mac-helper` tool.
    Run the command:
 
-    ```
-    $ brew install podman-mac-helper
+    ```sh
+    brew install podman-mac-helper
     ```
 
 2. Set up the `podman-mac-helper` service for each user.
    Run the command:
 
+    ```sh
+    sudo podman-mac-helper install
     ```
-    $ podman-mac-helper setup
+
+    For additional install options please run the command:
+
+    ```sh
+    sudo podman-mac-helper install --help
     ```
+
 
 #### Verification
 

--- a/website/docs/troubleshooting.md
+++ b/website/docs/troubleshooting.md
@@ -171,9 +171,16 @@ This may appear when either:
 
 1. Stop Docker Desktop (if install)
 2. Run the `podman-mac-helper` binary:
-```sh
-sudo podman-mac-helper install
-```
+
+    ```sh
+    sudo podman-mac-helper install
+    ```
+    for additional options please run the command:
+
+    ```sh
+    sudo podman-mac-helper install --help
+    ```
+
 3. Restart the Podman machine (the default Docker socket path will be recreated and Podman will emulate it)
 
 


### PR DESCRIPTION
…elper install' and direct users to 'podman-mac-helper install --help' for more options

Signed-off-by: Mitch West <mitch9378dev@gmail.com>

### What does this PR do?

Updates an old piece of documentation on podman-mac-helper to reflect the current CLI. Also it points users to review the --help flag for more options to facilitate discover of new command line flag --user (https://github.com/containers/podman/pull/17478) and future command line changes. The intent was to not be overly verbose as the CLI should contain the necessary usage docs.

### Screenshot/screencast of this PR
Old (left) vs new (right):

<img width="1855" alt="Screenshot 2023-02-11 at 3 23 27 PM" src="https://user-images.githubusercontent.com/4658072/218279981-4c67eff4-eb76-4b93-a35d-56eb89bfc976.png">

<img width="1873" alt="Screenshot 2023-02-11 at 3 25 07 PM" src="https://user-images.githubusercontent.com/4658072/218279984-cc5af512-4ded-4251-9bfe-2c98cbe634d2.png">

### What issues does this PR fix or reference?

Documentation referenced a command:

```sh
podman-mac-helper setup
```

which no longer exists and has been changed to 'install'

This will also facilitate the discovery of https://github.com/containers/podman/pull/17478 should it be merged.

### How to test this PR?

Build website and review:

/docs/troubleshooting
/docs/migrating-from-docker/using-podman-mac-helper
