### PR TITLE
feat: adds prune functionality for containers

### DIFF
--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -727,6 +727,11 @@ export class ContainerProviderRegistry {
     return this.getMatchingPodmanEngine(engineId).removePod(podId);
   }
 
+  async pruneContainers(engineId: string): Promise<Dockerode.PruneContainersInfo> {
+    this.telemetryService.track('pruneContainers');
+    return this.getMatchingEngine(engineId).pruneContainers();
+  }
+
   async restartContainer(engineId: string, id: string): Promise<void> {
     this.telemetryService.track('restartContainer');
     return this.getMatchingContainer(engineId, id).restart();

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -70,7 +70,7 @@ import type {
   PodCreateOptions,
   ContainerCreateOptions as PodmanContainerCreateOptions,
 } from './dockerode/libpod-dockerode';
-
+import type Dockerode from 'dockerode';
 import { AutostartEngine } from './autostart-engine';
 import { CloseBehavior } from './close-behavior';
 import { TrayIconColor } from './tray-icon-color';
@@ -490,6 +490,13 @@ export class PluginSystem {
       'container-provider-registry:stopContainerStats',
       async (_listener, containerStatsId: number): Promise<void> => {
         return containerProviderRegistry.stopContainerStats(containerStatsId);
+      },
+    );
+
+    this.ipcHandle(
+      'container-provider-registry:pruneContainers',
+      async (_listener, engine: string): Promise<Dockerode.PruneContainersInfo> => {
+        return containerProviderRegistry.pruneContainers(engine);
       },
     );
 

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -1000,6 +1000,10 @@ function initExposure(): void {
     },
   );
 
+  contextBridge.exposeInMainWorld('pruneContainers', async (engine: string): Promise<string> => {
+    return ipcInvoke('container-provider-registry:pruneContainers', engine);
+  });
+
   contextBridge.exposeInMainWorld('getOsPlatform', async (): Promise<string> => {
     return ipcInvoke('os:getPlatform');
   });

--- a/packages/renderer/src/lib/ContainerList.svelte
+++ b/packages/renderer/src/lib/ContainerList.svelte
@@ -22,10 +22,13 @@ import { faChevronDown, faChevronRight, faExclamationCircle } from '@fortawesome
 import Fa from 'svelte-fa/src/fa.svelte';
 import { podCreationHolder } from '../stores/creation-from-containers-store';
 import KubePlayButton from './kube/KubePlayButton.svelte';
+import Prune from './engine/Prune.svelte';
 import Tooltip from './ui/Tooltip.svelte';
+import type { EngineInfoUI } from './engine/EngineInfoUI';
 
 const containerUtils = new ContainerUtils();
 let openChoiceModal = false;
+let enginesList: EngineInfoUI[];
 
 // groups of containers that will be displayed
 let containerGroups: ContainerGroupInfoUI[] = [];
@@ -184,15 +187,28 @@ onMount(async () => {
       return containerUtils.getContainerInfoUI(containerInfo);
     });
 
-    // multiple engines ?
-    const engineNamesArray = currentContainers.map(container => container.engineName);
-    // remove duplicates
-    const engineNames = [...new Set(engineNamesArray)];
-    if (engineNames.length > 1) {
+    // Map engineName, engineId and engineType from currentContainers to EngineInfoUI[]
+    const engines = currentContainers.map(container => {
+      return {
+        name: container.engineName,
+        id: container.engineId,
+        type: container.engineType,
+      };
+    });
+
+    // Remove duplicates from engines by name
+    const uniqueEngines = engines.filter(
+      (engine, index, self) => index === self.findIndex(t => t.name === engine.name),
+    );
+
+    if (uniqueEngines.length > 1) {
       multipleEngines = true;
     } else {
       multipleEngines = false;
     }
+
+    // Set the engines to the global variable for the Prune functionality button
+    enginesList = uniqueEngines;
 
     // create groups
     const computedContainerGroups = containerUtils.getContainerGroups(currentContainers);
@@ -305,6 +321,7 @@ function errorCallback(container: ContainerInfoUI, errorMessage: string): void {
   title="containers"
   subtitle="Hover over a container to view action buttons; click to open up full details.">
   <div slot="additional-actions" class="space-x-2 flex flex-nowrap">
+    <Prune type="containers" engines="{enginesList}" />
     <button on:click="{() => toggleCreateContainer()}" class="pf-c-button pf-m-primary" type="button">
       <span class="pf-c-button__icon pf-m-start">
         <i class="fas fa-plus-circle" aria-hidden="true"></i>

--- a/packages/renderer/src/lib/engine/EngineInfoUI.ts
+++ b/packages/renderer/src/lib/engine/EngineInfoUI.ts
@@ -1,0 +1,24 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+// Simple interface containing the basic information about a container engine
+export interface EngineInfoUI {
+  id: string;
+  name: string;
+  type: 'podman' | 'docker';
+}

--- a/packages/renderer/src/lib/engine/Prune.svelte
+++ b/packages/renderer/src/lib/engine/Prune.svelte
@@ -1,0 +1,102 @@
+<script lang="ts">
+import Modal from '../dialogs/Modal.svelte';
+import type { EngineInfoUI } from './EngineInfoUI';
+
+// Imported type for prune (containers, images, pods, volumes)
+export let type: string;
+
+// List of engines that the prune will work on
+export let engines: EngineInfoUI[];
+
+// Functionality for modal
+let openChoiceModal = false;
+function toggleChoiceModal(): void {
+  openChoiceModal = !openChoiceModal;
+}
+function keydownChoice(e: KeyboardEvent) {
+  e.stopPropagation();
+  if (e.key === 'Escape') {
+    toggleChoiceModal();
+  }
+}
+
+// Function to prune the selected type: containers
+// TODO: Add prune for pods, images and volumes in a later PR
+async function prune(type: string) {
+  switch (type) {
+    case 'containers':
+      engines.forEach(async engine => {
+        try {
+          await window.pruneContainers(engine.id);
+        } catch (error) {
+          console.error(error);
+        }
+      });
+
+      break;
+    default:
+      console.error('Prune type not found');
+      break;
+    /*
+          case 'pods':
+              // Prune pods from podman and docker engines
+              await window.prunePods();
+              break;
+          case 'images':
+              // Prune images from podman and docker engines
+              await window.pruneImages();
+              break;
+          case 'volumes':
+              // Prune volumes from podman and docker engines
+              await window.pruneVolumes();
+              break;
+              */
+  }
+
+  // Close the modal once the prune is completed
+  toggleChoiceModal();
+}
+</script>
+
+<button
+  on:click="{() => toggleChoiceModal()}"
+  class="pf-c-button pf-m-primary"
+  type="button"
+  title="Play pod/containers from kubernetes YAML file ">
+  <span class="pf-c-button__icon pf-m-start">
+    <i class="fas fa-trash" aria-hidden="true"></i>
+  </span>
+  Prune {type}
+</button>
+
+<!-- Create modal that confirms the user wants to prune the selected type -->
+{#if openChoiceModal}
+  <Modal
+    on:close="{() => {
+      openChoiceModal = false;
+    }}">
+    <div
+      class="inline-block w-full overflow-hidden text-left transition-all transform bg-zinc-800 z-50 h-[200px] rounded-xl shadow-xl shadow-neutral-900"
+      on:keydown="{keydownChoice}">
+      <div class="flex items-center justify-between bg-black px-5 py-4 border-b-2 border-violet-700">
+        <h1 class="text-xl font-bold">Prune unused {type}</h1>
+
+        <button class="hover:text-gray-200 px-2 py-1" on:click="{() => toggleChoiceModal()}">
+          <i class="fas fa-times" aria-hidden="true"></i>
+        </button>
+      </div>
+      <div class="bg-zinc-800 p-5 h-full flex flex-col justify-items-center">
+        {#if engines.length > 1}
+          <span class="pb-3">This action will prune all unused {type} from all container engines.</span>
+        {:else}
+          <span class="pb-3">This action will prune all unused {type} from the {engines[0].name} engine.</span>
+        {/if}
+        <span class="pb-3">Are you sure you want to continue?</span>
+        <div class="pt-5 grid grid-cols-2 gap-10 place-content-center w-full">
+          <button class="pf-c-button pf-m-primary" type="button" on:click="{() => prune(type)}">Yes</button>
+          <button class="pf-c-button pf-m-secondary" type="button" on:click="{() => toggleChoiceModal()}">No</button>
+        </div>
+      </div>
+    </div>
+  </Modal>
+{/if}

--- a/packages/renderer/src/lib/engine/Prune.svelte
+++ b/packages/renderer/src/lib/engine/Prune.svelte
@@ -58,11 +58,7 @@ async function prune(type: string) {
 }
 </script>
 
-<button
-  on:click="{() => toggleChoiceModal()}"
-  class="pf-c-button pf-m-primary"
-  type="button"
-  title="Play pod/containers from kubernetes YAML file ">
+<button on:click="{() => toggleChoiceModal()}" class="pf-c-button pf-m-primary" type="button" title="Prune {type}">
   <span class="pf-c-button__icon pf-m-start">
     <i class="fas fa-trash" aria-hidden="true"></i>
   </span>


### PR DESCRIPTION
feat: adds prune functionality for containers

### What does this PR do?

* Adds prune functionality to containers list
* Works on multiple container engines (podman and docker)
* Does pruning on both container engines if running

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
![Screenshot 2023-02-13 at 2 33 11 PM](https://user-images.githubusercontent.com/6422176/218556550-1a4f0a75-d377-45fe-9652-c720cd63b9bd.png)
![Screenshot 2023-02-13 at 2 33 02 PM](https://user-images.githubusercontent.com/6422176/218556558-eb5702f8-dd56-43c1-b997-392e76499cf5.png)

https://user-images.githubusercontent.com/6422176/218556569-4d7841b0-c405-49d5-bbdc-24e124361d76.mov




### What issues does this PR fix or reference?

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

Implements part of https://github.com/containers/podman-desktop/issues/924

### How to test this PR?

<!-- Please explain steps to reproduce -->

Stop a container. Press the prune button. Prune button will remove any
stopped containers.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
