### PR TITLE
chore: Simplify image inUse

### DIFF
--- a/packages/renderer/src/AppNavigation.svelte
+++ b/packages/renderer/src/AppNavigation.svelte
@@ -28,7 +28,7 @@ onMount(async () => {
     containersCountValue = value.length;
   });
   imageInfoSubscribe = imagesInfos.subscribe(value => {
-    images = value.map((imageInfo: ImageInfo) => imageUtils.getImagesInfoUI(imageInfo, [])).flat();
+    images = value.map((imageInfo: ImageInfo) => imageUtils.getImagesInfoUI(imageInfo)).flat();
   });
 });
 

--- a/packages/renderer/src/lib/ImagesList.svelte
+++ b/packages/renderer/src/lib/ImagesList.svelte
@@ -47,9 +47,7 @@ let allChecked = false;
 const imageUtils = new ImageUtils();
 
 function updateImages() {
-  const computedImages = storeImages
-    .map((imageInfo: ImageInfo) => imageUtils.getImagesInfoUI(imageInfo))
-    .flat();
+  const computedImages = storeImages.map((imageInfo: ImageInfo) => imageUtils.getImagesInfoUI(imageInfo)).flat();
 
   // update selected items based on current selected items
   computedImages.forEach(image => {

--- a/packages/renderer/src/lib/ImagesList.svelte
+++ b/packages/renderer/src/lib/ImagesList.svelte
@@ -48,7 +48,7 @@ const imageUtils = new ImageUtils();
 
 function updateImages() {
   const computedImages = storeImages
-    .map((imageInfo: ImageInfo) => imageUtils.getImagesInfoUI(imageInfo, storeContainers))
+    .map((imageInfo: ImageInfo) => imageUtils.getImagesInfoUI(imageInfo))
     .flat();
 
   // update selected items based on current selected items

--- a/packages/renderer/src/lib/image/image-utils.ts
+++ b/packages/renderer/src/lib/image/image-utils.ts
@@ -80,16 +80,7 @@ export class ImageUtils {
     return Buffer.from(name, 'binary').toString('base64');
   }
 
-  // is that this image is used by a container or not
-  // search if there is a container matching this image
-  getInUse(imageInfo: ImageInfo, containersInfo?: ContainerInfo[]): boolean {
-    if (!containersInfo) {
-      return false;
-    }
-    return containersInfo.some(container => container.ImageID === imageInfo.Id);
-  }
-
-  getImagesInfoUI(imageInfo: ImageInfo, containersInfo: ContainerInfo[]): ImageInfoUI[] {
+  getImagesInfoUI(imageInfo: ImageInfo): ImageInfoUI[] {
     if (!imageInfo.RepoTags) {
       return [
         {
@@ -104,7 +95,7 @@ export class ImageUtils {
           tag: '',
           base64RepoTag: this.getBase64EncodedName('<none>'),
           selected: false,
-          inUse: this.getInUse(imageInfo, containersInfo),
+          inUse: imageInfo.Containers > 0,
         },
       ];
     } else {
@@ -121,14 +112,14 @@ export class ImageUtils {
           tag: this.getTag(repoTag),
           base64RepoTag: this.getBase64EncodedName(repoTag),
           selected: false,
-          inUse: this.getInUse(imageInfo, containersInfo),
+          inUse: imageInfo.Containers > 0,
         };
       });
     }
   }
 
   getImageInfoUI(imageInfo: ImageInfo, base64RepoTag: string): ImageInfoUI {
-    const images = this.getImagesInfoUI(imageInfo, []);
+    const images = this.getImagesInfoUI(imageInfo);
     const matchingImages = images.filter(image => image.base64RepoTag === base64RepoTag);
     if (matchingImages.length === 1) {
       return matchingImages[0];

--- a/packages/renderer/src/lib/image/image-utils.ts
+++ b/packages/renderer/src/lib/image/image-utils.ts
@@ -22,7 +22,6 @@ import moment from 'moment';
 import humanizeDuration from 'humanize-duration';
 import { filesize } from 'filesize';
 import { Buffer } from 'buffer';
-import type { ContainerInfo } from '../../../../main/src/plugin/api/container-info';
 
 export class ImageUtils {
   // extract SHA256 from image id and take the first 12 digits
@@ -68,12 +67,12 @@ export class ImageUtils {
     }
   }
 
-  getEngineId(containerInfo: ImageInfo): string {
-    return containerInfo.engineId;
+  getEngineId(imageInfo: ImageInfo): string {
+    return imageInfo.engineId;
   }
 
-  getEngineName(containerInfo: ImageInfo): string {
-    return containerInfo.engineName;
+  getEngineName(imageInfo: ImageInfo): string {
+    return imageInfo.engineName;
   }
 
   getBase64EncodedName(name: string) {


### PR DESCRIPTION
### What does this PR do?

I noticed (while working on a related UI PR) that inUse is always false within the image details page. This is because the page is not passing through any container information.

Instead of making the details page subscribe to containers and pass the info through to image-utils.ts, it seems a simpler change to use the Containers count similar to how volume-utils.ts uses UsageData?.RefCount. Is this change safe (i.e. this counter was just missed during implementation)? The identical images are marked inUse for me.