### PR TITLE
fix: Singular containers

### DIFF
--- a/packages/renderer/src/lib/pod/PodsList.svelte
+++ b/packages/renderer/src/lib/pod/PodsList.svelte
@@ -272,7 +272,7 @@ function errorCallback(pod: PodInfoUI, errorMessage: string): void {
                       class="ml-1 text-xs font-extra-light text-gray-500"
                       class:cursor-pointer="{pod.containers.length > 0}"
                       on:click="{() => openContainersFromPod(pod)}">
-                      {pod.containers.length} containers
+                      {pod.containers.length} container{pod.containers.length > 1 ? 's' : ''}
                     </div>
                   </div>
                   <div class="flex flex-row text-xs font-extra-light text-gray-500">


### PR DESCRIPTION
### What does this PR do?

Nit: the pods list always shows the word containers plural, so when you only have 1 container it shows "1 containers". I don't love this fix if we ever decide to translate, but it matches what we do in ContainerList.svelte.