### PR TITLE
chore: Make status icon consistent in detail pages

### DIFF
--- a/packages/renderer/src/lib/image/ImageDetails.svelte
+++ b/packages/renderer/src/lib/image/ImageDetails.svelte
@@ -3,6 +3,8 @@ import type { ImageInfoUI } from './ImageInfoUI';
 import { Route } from 'tinro';
 import { onMount } from 'svelte';
 import { imagesInfos } from '../../stores/images';
+import ImageIcon from '../images/ImageIcon.svelte';
+import StatusIcon from '../images/StatusIcon.svelte';
 import ImageActions from './ImageActions.svelte';
 import { ImageUtils } from './image-utils';
 import ImageDetailsInspect from './ImageDetailsInspect.svelte';
@@ -52,11 +54,18 @@ onMount(() => {
               <div class="text-xl mx-2 text-gray-400">></div>
               <div class="text-sm font-extralight text-gray-400">Image Details</div>
             </div>
-            <div class="text-lg flex flex-row items-center">
-              <p class="mr-2">{image.name}</p>
-              <div class="text-base text-violet-400">{image.shortId}</div>
+            <div class="flex flex-row items-start pt-1">
+              <div class="pr-3 pt-1">
+                <StatusIcon icon="{ImageIcon}" status="{image.inUse ? 'USED' : 'UNUSED'}" />
+              </div>
+              <div class="text-lg flex flex-col">
+                <div class="flex flex-row">
+                  <div class="mr-2">{image.name}</div>
+                  <div class="text-base text-violet-400">{image.shortId}</div>
+                </div>
+                <div class="mr-2 pb-4 text-small text-gray-500">{image.tag}</div>
+              </div>
             </div>
-            <div class="mr-2 pb-4 text-small text-gray-500">{image.tag}</div>
 
             <section class="pf-c-page__main-tabs pf-m-limit-width">
               <div class="pf-c-page__main-body">

--- a/packages/renderer/src/lib/pod/PodDetails.svelte
+++ b/packages/renderer/src/lib/pod/PodDetails.svelte
@@ -5,6 +5,8 @@ import type { PodInfoUI } from './PodInfoUI';
 import { PodUtils } from './pod-utils';
 import type { Unsubscriber } from 'svelte/store';
 import { podsInfos } from '../../stores/pods';
+import PodIcon from '../images/PodIcon.svelte';
+import StatusIcon from '../images/StatusIcon.svelte';
 import PodActions from './PodActions.svelte';
 import PodDetailsSummary from './PodDetailsSummary.svelte';
 import PodDetailsInspect from './PodDetailsInspect.svelte';
@@ -65,11 +67,15 @@ function errorCallback(errorMessage: string): void {
               <div class="text-xl mx-2 text-gray-400">></div>
               <div class="text-sm font-extralight text-gray-400">Pod Details</div>
             </div>
-            <div class="text-lg flex flex-row items-center">
-              <p class="mr-2">{pod.name}</p>
+            <div class="text-lg flex flex-row items-start pt-1">
+              <div class="pr-3 pt-1">
+                <StatusIcon icon="{PodIcon}" status="{pod.status}" />
+              </div>
+              <div class="text-lg flex flex-col">
+                <div class="mr-2">{pod.name}</div>
+                <div class="mr-2 pb-4 text-small text-gray-500">{pod.id}</div>
+              </div>
             </div>
-            <div class="mr-2 pb-4 text-small text-gray-500">{pod.id}</div>
-
             <section class="pf-c-page__main-tabs pf-m-limit-width">
               <div class="pf-c-page__main-body">
                 <div class="pf-c-tabs pf-m-page-insets" id="open-tabs-example-tabs-list">

--- a/packages/renderer/src/lib/volume/VolumeDetails.svelte
+++ b/packages/renderer/src/lib/volume/VolumeDetails.svelte
@@ -3,6 +3,8 @@ import type { VolumeInfoUI } from './VolumeInfoUI';
 import { Route } from 'tinro';
 import { onMount } from 'svelte';
 import { volumeListInfos } from '../../stores/volumes';
+import VolumeIcon from '../images/VolumeIcon.svelte';
+import StatusIcon from '../images/StatusIcon.svelte';
 import VolumeActions from './VolumeActions.svelte';
 import { VolumeUtils } from './volume-utils';
 import VolumeDetailsSummary from '././VolumeDetailsSummary.svelte';
@@ -41,10 +43,15 @@ onMount(() => {
               <div class="text-xl mx-2 text-gray-400">></div>
               <div class="text-sm font-extralight text-gray-400">Volume Details</div>
             </div>
-            <div class="text-lg flex flex-row items-center">
-              <p class="mr-2">{volume.name}</p>
+            <div class="text-lg flex flex-row items-start pt-1">
+              <div class="pr-3 pt-1">
+                <StatusIcon icon="{VolumeIcon}" status="{volume.inUse ? 'USED' : 'UNUSED'}" />
+              </div>
+              <div class="text-lg flex flex-col">
+                <div class="mr-2">{volume.name}</div>
+                <div class="mr-2 pb-4 text-small text-gray-500">{volume.humanSize}</div>
+              </div>
             </div>
-            <div class="mr-2 pb-4 text-small text-gray-500">{volume.humanSize}</div>
 
             <section class="pf-c-page__main-tabs pf-m-limit-width">
               <div class="pf-c-page__main-body">


### PR DESCRIPTION
### What does this PR do?

The ContainerDetails page has the container status icon at the top left, this just matches it in the other details pages.

Note that until #1437 or an equivalent fix is merged the image status icon will always be the 'unused' (outline icon) even if the image is used (solid green icon). IMHO we don't need to block this PR as the code is independent and most people won't notice the minor visual inconsistency.

### Screenshot/screencast of this PR

<img width="115" alt="Screenshot 2023-02-14 at 2 00 22 PM" src="https://user-images.githubusercontent.com/19958075/218856042-65058606-deae-4211-98ae-8bdfa27a5ed9.png">
<img width="115" alt="Screenshot 2023-02-14 at 2 00 11 PM" src="https://user-images.githubusercontent.com/19958075/218856050-efb8193a-3090-415c-8af2-000066d1562c.png">
<img width="115" alt="Screenshot 2023-02-14 at 1 59 57 PM" src="https://user-images.githubusercontent.com/19958075/218856052-201b4e29-7818-487d-b1f5-31cf9d09b6e9.png">