### PR TITLE
fix: escape command with quotes only for Windows

### DIFF
--- a/extensions/podman/src/util.ts
+++ b/extensions/podman/src/util.ts
@@ -63,8 +63,10 @@ export function runCliCommand(command: string, args: string[], options?: RunOpti
     // In production mode, applications don't have access to the 'user' path like brew
     if (isMac || isWindows) {
       env.PATH = getInstallationPath();
-      // Escape any whitespaces in command
-      command = `"${command}"`;
+      if (isWindows) {
+        // Escape any whitespaces in command
+        command = `"${command}"`;
+      }
     } else if (env.FLATPAK_ID) {
       // need to execute the command on the host
       args = ['--host', command, ...args];


### PR DESCRIPTION
### What does this PR do?
On macOS, testing the upgrade flow, it failed for brew command

### Screenshot/screencast of this PR

![image](https://user-images.githubusercontent.com/436777/218986868-1f4068f0-df2d-4ab6-8797-dc3e5de81aee.png)


### What issues does this PR fix or reference?

#1208 
#1270 

### How to test this PR?

Check podman extension
