### PR TITLE
fix: check brew command only if brew is installed

### DIFF
--- a/extensions/podman/src/macos-checks.ts
+++ b/extensions/podman/src/macos-checks.ts
@@ -66,6 +66,14 @@ export class MacVersionCheck extends BaseCheck {
 export class MacPodmanInstallCheck extends BaseCheck {
   title = 'Podman Installation';
   async execute(): Promise<extensionApi.CheckResult> {
+    // we need to check if brew is installed to avoid unexpected error
+    const brewResult = await runCliCommand('which', ['brew']);
+    if (brewResult.exitCode !== 0) {
+      // brew is not installed so do not check if podman has been installed with brew
+      return this.createSuccessfulResult();
+    }
+
+    // brew is installed, check if podman has been installed with brew
     const runResult = await runCliCommand('brew', ['list', '--verbose', 'podman'], {
       env: { HOMEBREW_NO_AUTO_UPDATE: '1', HOMEBREW_NO_ANALYTICS: '1' },
     });


### PR DESCRIPTION
### What does this PR do?
Do not run `brew` commands if `brew` is not installed

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/1463


### How to test this PR?

Check that you don't have brew (you can just rename brew to another temporary name) and cherry-pick https://github.com/containers/podman-desktop/pull/1456 so there is an update

Also install podman and brew and check that you can't update with podman desktop as it's there with brew
and check that if you only have brew but not podman installed by brew, you can update to 4.4 as well


Change-Id: I49a429aa5014737a2b7150304ce1b1ffdd66ad34
Signed-off-by: Florent Benoit <fbenoit@redhat.com>