### PR TITLE
fix: remove duplicate background class to add custom port button

### DIFF
--- a/packages/renderer/src/lib/image/RunImage.svelte
+++ b/packages/renderer/src/lib/image/RunImage.svelte
@@ -506,7 +506,7 @@ function checkContainerName(event: any) {
                 {/each}
 
                 <button
-                  class="pt-3 pb-2 outline-none text-sm bg-zinc-900 rounded-sm bg-transparent placeholder-gray-400"
+                  class="pt-3 pb-2 outline-none text-sm rounded-sm bg-transparent placeholder-gray-400"
                   on:click="{addHostContainerPorts}">
                   <span class="pf-c-button__icon pf-m-start">
                     <i class="fas fa-plus-circle"></i>


### PR DESCRIPTION
### What does this PR do?

It removes a duplicate background class.

Not sure for what reason I never saw it before... i also recorded the demo yesterday and it was fine ... but this morning i had a black background behind the `add custom port mapping` button.
It looks like i forgot to remove a duplicate background class.

### Screenshot/screencast of this PR

how i see it today

![immagine](https://user-images.githubusercontent.com/49404737/219001722-b9a98b05-e709-4e82-832d-6585b3646171.png)

how it should be 

![immagine](https://user-images.githubusercontent.com/49404737/219001608-61608419-3c37-42ce-8fa7-30a832b9e745.png)


### What issues does this PR fix or reference?

N/A

### How to test this PR?

1. Create a container from an image
