### PR TITLE
feat: prune button for images

### DIFF
--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -355,6 +355,7 @@ export class ContainerProviderRegistry {
 
     // PODMAN:
     // Have to use podman API directly for pruning images
+    // TODO: Remove this once the Podman API respects the 'dangling' filter: https://github.com/containers/podman/issues/17614
     const provider = this.internalProviders.get(engineId);
     if (provider?.libpodApi) {
       return this.getMatchingPodmanEngine(engineId).pruneAllImages(true);
@@ -362,10 +363,7 @@ export class ContainerProviderRegistry {
 
     // DOCKER:
     // Return Promise<void> for this call, because Dockerode does not return anything
-    this.getMatchingEngine(engineId).pruneImages({ filters: { dangling: { false: true } } });
-
-    // Return an empty promise since we do not check the above docker result / don't use the image information (yet).
-    return Promise.resolve();
+    await this.getMatchingEngine(engineId).pruneImages({ filters: { dangling: { false: true } } });
   }
 
   async listPods(): Promise<PodInfo[]> {

--- a/packages/main/src/plugin/dockerode/libpod-dockerode.ts
+++ b/packages/main/src/plugin/dockerode/libpod-dockerode.ts
@@ -108,6 +108,7 @@ export interface LibPod {
   restartPod(podId: string): Promise<void>;
   generateKube(names: string[]): Promise<string>;
   playKube(yamlContentFilePath: string): Promise<PlayKubeInfo>;
+  pruneAllImages(dangling: boolean): Promise<void>;
 }
 
 // tweak Dockerode by adding the support of libpod API
@@ -150,6 +151,29 @@ export class LibpodDockerode {
         path: '/v4.2.0/libpod/pods/json',
         method: 'GET',
         options: {},
+        statusCodes: {
+          200: true,
+          400: 'bad parameter',
+          500: 'server error',
+        },
+      };
+      return new Promise((resolve, reject) => {
+        this.modem.dial(optsf, (err: unknown, data: unknown) => {
+          if (err) {
+            return reject(err);
+          }
+          resolve(data);
+        });
+      });
+    };
+
+    // add pruneAllImages
+    prototypeOfDockerode.pruneAllImages = function () {
+      const optsf = {
+        path: '/v4.2.0/libpod/images/prune?all=true&', // this works
+        // For some reason the below doesn't work? TODO / help / fixme
+        // options: {all: 'true'}, // this doesn't work
+        method: 'POST',
         statusCodes: {
           200: true,
           400: 'bad parameter',

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -518,6 +518,10 @@ export class PluginSystem {
       return containerProviderRegistry.prunePods(engine);
     });
 
+    this.ipcHandle('container-provider-registry:pruneImages', async (_listener, engine: string): Promise<void> => {
+      return containerProviderRegistry.pruneImages(engine);
+    });
+
     this.ipcHandle(
       'container-provider-registry:restartContainer',
       async (_listener, engine: string, containerId: string): Promise<void> => {

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -1076,6 +1076,10 @@ function initExposure(): void {
     return ipcInvoke('container-provider-registry:pruneVolumes', engine);
   });
 
+  contextBridge.exposeInMainWorld('pruneImages', async (engine: string): Promise<string> => {
+    return ipcInvoke('container-provider-registry:pruneImages', engine);
+  });
+
   contextBridge.exposeInMainWorld('getOsPlatform', async (): Promise<string> => {
     return ipcInvoke('os:getPlatform');
   });

--- a/packages/renderer/src/lib/engine/Prune.svelte
+++ b/packages/renderer/src/lib/engine/Prune.svelte
@@ -51,23 +51,18 @@ async function prune(type: string) {
         }
       });
       break;
+    case 'images':
+      engines.forEach(async engine => {
+        try {
+          await window.pruneImages(engine.id);
+        } catch (error) {
+          console.error(error);
+        }
+      });
+      break;
     default:
       console.error('Prune type not found');
       break;
-    /*
-          case 'pods':
-              // Prune pods from podman and docker engines
-              await window.prunePods();
-              break;
-          case 'images':
-              // Prune images from podman and docker engines
-              await window.pruneImages();
-              break;
-          case 'volumes':
-              // Prune volumes from podman and docker engines
-              await window.pruneVolumes();
-              break;
-              */
   }
 
   // Close the modal once the prune is completed

--- a/packages/renderer/src/lib/engine/Prune.svelte
+++ b/packages/renderer/src/lib/engine/Prune.svelte
@@ -55,9 +55,17 @@ async function prune(type: string) {
       console.error('Prune type not found');
       break;
     /*
+          case 'pods':
+              // Prune pods from podman and docker engines
+              await window.prunePods();
+              break;
           case 'images':
               // Prune images from podman and docker engines
               await window.pruneImages();
+              break;
+          case 'volumes':
+              // Prune volumes from podman and docker engines
+              await window.pruneVolumes();
               break;
               */
   }


### PR DESCRIPTION
feat: add prune for images

### What does this PR do?

Adds prune button for deleting images from container engines

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

Part of https://github.com/containers/podman-desktop/issues/924

### How to test this PR?

<!-- Please explain steps to reproduce -->

Press the prune images button, your unused images will be deleted /
removed

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
