### PR TITLE
fix: we should be able to delete images if they are not used

### DIFF
--- a/packages/renderer/src/lib/image/ImageActions.svelte
+++ b/packages/renderer/src/lib/image/ImageActions.svelte
@@ -56,7 +56,7 @@ if (dropdownMenu) {
   onClick="{() => deleteImage()}"
   detailed="{detailed}"
   icon="{faTrash}"
-  enabled="{image.inUse}" />
+  enabled="{!image.inUse}" />
 
 <!-- If dropdownMenu is true, use it, otherwise just show the regular buttons -->
 <svelte:component this="{actionsStyle}">


### PR DESCRIPTION
### What does this PR do?
Fix a typo following https://github.com/containers/podman-desktop/pull/1225

### Screenshot/screencast of this PR

![image](https://user-images.githubusercontent.com/436777/219320875-0c94964a-74a3-47b8-a346-fb1e37968460.png)


### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/1483

### How to test this PR?

Go to the images list page
before: unable to delete images that are not used (but can delete images used by containers)
after: able to delete images that are not used


Change-Id: I110c131b52556f31ffa09a037abd20332bc310b3
