### PR TITLE
Remove CloseBehavior's constructor unused argument

### DIFF
--- a/packages/main/src/plugin/close-behavior.spec.ts
+++ b/packages/main/src/plugin/close-behavior.spec.ts
@@ -18,16 +18,14 @@
 import { beforeEach, test, expect } from 'vitest';
 import { CloseBehavior } from './close-behavior';
 import { ConfigurationRegistry } from './configuration-registry';
-import type { ProviderRegistry } from './provider-registry';
 import * as util from '../util';
 
-const providerRegistry = {} as ProviderRegistry;
 let closeBehavior;
 let configurationRegistry;
 
 beforeEach(() => {
   configurationRegistry = new ConfigurationRegistry();
-  closeBehavior = new CloseBehavior(configurationRegistry, providerRegistry);
+  closeBehavior = new CloseBehavior(configurationRegistry);
 });
 
 test('should register a configuration', async () => {

--- a/packages/main/src/plugin/close-behavior.ts
+++ b/packages/main/src/plugin/close-behavior.ts
@@ -18,10 +18,9 @@
 
 import { isLinux } from '../util';
 import type { ConfigurationRegistry, IConfigurationNode } from './configuration-registry';
-import type { ProviderRegistry } from './provider-registry';
 
 export class CloseBehavior {
-  constructor(private configurationRegistry: ConfigurationRegistry, private providerRegistry: ProviderRegistry) {}
+  constructor(private configurationRegistry: ConfigurationRegistry) {}
 
   async init(): Promise<void> {
     // add configuration

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -272,7 +272,7 @@ export class PluginSystem {
 
     const kubernetesClient = new KubernetesClient(configurationRegistry, fileSystemMonitoring);
     await kubernetesClient.init();
-    const closeBehaviorConfiguration = new CloseBehavior(configurationRegistry, providerRegistry);
+    const closeBehaviorConfiguration = new CloseBehavior(configurationRegistry);
     await closeBehaviorConfiguration.init();
 
     // Don't show the tray icon options on Mac


### PR DESCRIPTION
### What does this PR do?
Addressing technical debt. Unused constructor argument removal.

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?

Closes #1461.

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

### How to test this PR?

<!-- Please explain steps to reproduce -->
