### PR TITLE
feat: do not show prune button on no containers

### DIFF
--- a/packages/renderer/src/lib/ContainerList.svelte
+++ b/packages/renderer/src/lib/ContainerList.svelte
@@ -321,7 +321,10 @@ function errorCallback(container: ContainerInfoUI, errorMessage: string): void {
   title="containers"
   subtitle="Hover over a container to view action buttons; click to open up full details.">
   <div slot="additional-actions" class="space-x-2 flex flex-nowrap">
-    <Prune type="containers" engines="{enginesList}" />
+    <!-- Only show if there are containers-->
+    {#if $filtered.length > 0}
+      <Prune type="containers" engines="{enginesList}" />
+    {/if}
     <button on:click="{() => toggleCreateContainer()}" class="pf-c-button pf-m-primary" type="button">
       <span class="pf-c-button__icon pf-m-start">
         <i class="fas fa-plus-circle" aria-hidden="true"></i>

--- a/packages/renderer/src/lib/ContainerList.svelte
+++ b/packages/renderer/src/lib/ContainerList.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { onDestroy, onMount } from 'svelte';
-import { filtered, searchPattern } from '../stores/containers';
+import { filtered, searchPattern, containersInfos } from '../stores/containers';
 
 import type { ContainerInfo } from '../../../main/src/plugin/api/container-info';
 import ContainerIcon from './images/ContainerIcon.svelte';
@@ -322,7 +322,7 @@ function errorCallback(container: ContainerInfoUI, errorMessage: string): void {
   subtitle="Hover over a container to view action buttons; click to open up full details.">
   <div slot="additional-actions" class="space-x-2 flex flex-nowrap">
     <!-- Only show if there are containers-->
-    {#if $filtered.length > 0}
+    {#if $containersInfos.length > 0}
       <Prune type="containers" engines="{enginesList}" />
     {/if}
     <button on:click="{() => toggleCreateContainer()}" class="pf-c-button pf-m-primary" type="button">

--- a/packages/renderer/src/lib/engine/Prune.svelte
+++ b/packages/renderer/src/lib/engine/Prune.svelte
@@ -27,7 +27,7 @@ async function prune(type: string) {
     case 'containers':
       engines.forEach(async engine => {
         try {
-          await window.pruneContainers(engine.id);
+          window.pruneContainers(engine.id);
         } catch (error) {
           console.error(error);
         }

--- a/packages/renderer/src/lib/engine/Prune.svelte
+++ b/packages/renderer/src/lib/engine/Prune.svelte
@@ -27,7 +27,7 @@ async function prune(type: string) {
     case 'containers':
       engines.forEach(async engine => {
         try {
-          window.pruneContainers(engine.id);
+          await window.pruneContainers(engine.id);
         } catch (error) {
           console.error(error);
         }


### PR DESCRIPTION
feat: do not show prune button on no containers

### What does this PR do?

* Don't show the prune button if there are no containers
* Don't wait for the pruning as we do not do error feedback / show
  removed yet.

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

https://user-images.githubusercontent.com/6422176/219381349-5835da5d-d08b-4619-8619-2198d519fa94.mov




### What issues does this PR fix or reference?

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

### How to test this PR?

<!-- Please explain steps to reproduce -->

See video

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
