### PR TITLE
fix: remove PORT label from port value (#712)

### DIFF
--- a/packages/renderer/src/lib/ContainerList.svelte
+++ b/packages/renderer/src/lib/ContainerList.svelte
@@ -504,7 +504,7 @@ function errorCallback(container: ContainerInfoUI, errorMessage: string): void {
                             {container.engineName}
                           </div>
                         {/if}
-                        <div class="pl-2 pr-2">{container.port}</div>
+                        <div class="pl-2 pr-2">PORT{container.port.indexOf(',') > 0 ? 'S ' : ' ' + container.port}</div>
                       </div>
                     </div>
                   </div>

--- a/packages/renderer/src/lib/ContainerList.svelte
+++ b/packages/renderer/src/lib/ContainerList.svelte
@@ -504,7 +504,7 @@ function errorCallback(container: ContainerInfoUI, errorMessage: string): void {
                             {container.engineName}
                           </div>
                         {/if}
-                        <div class="pl-2 pr-2">PORT{container.port.indexOf(',') > 0 ? 'S ' : ' ' + container.port}</div>
+                        <div class="pl-2 pr-2">{container.displayPort}</div>
                       </div>
                     </div>
                   </div>

--- a/packages/renderer/src/lib/container/ContainerInfoUI.ts
+++ b/packages/renderer/src/lib/container/ContainerInfoUI.ts
@@ -51,6 +51,7 @@ export interface ContainerInfoUI {
   uptime: string;
   startedAt: string;
   port: string;
+  displayPort: string;
   command: string;
   hasPublicPort: boolean;
   openingUrl?: string;

--- a/packages/renderer/src/lib/container/container-utils.ts
+++ b/packages/renderer/src/lib/container/container-utils.ts
@@ -71,9 +71,9 @@ export class ContainerUtils {
     const ports = containerInfo.Ports?.filter(port => port.PublicPort).map(port => port.PublicPort);
 
     if (ports && ports.length > 1) {
-      return `PORTS: ${ports.join(', ')}`;
+      return ports.join(', ');
     } else if (ports && ports.length === 1) {
-      return `PORT: ${ports[0]}`;
+      return `${ports[0]}`;
     } else {
       return '';
     }

--- a/packages/renderer/src/lib/container/container-utils.ts
+++ b/packages/renderer/src/lib/container/container-utils.ts
@@ -79,6 +79,14 @@ export class ContainerUtils {
     }
   }
 
+  getDisplayPort(containerInfo: ContainerInfo): string {
+    const ports = this.getPort(containerInfo);
+    if (ports === '') {
+      return '';
+    }
+    return `PORT${ports.indexOf(',') > 0 ? 'S' : ''} ${ports}`;
+  }
+
   hasPublicPort(containerInfo: ContainerInfo): boolean {
     const publicPorts = containerInfo.Ports?.filter(port => port.PublicPort).map(port => port.PublicPort);
 
@@ -116,6 +124,7 @@ export class ContainerUtils {
       engineType: containerInfo.engineType,
       command: containerInfo.Command,
       port: this.getPort(containerInfo),
+      displayPort: this.getDisplayPort(containerInfo),
       hasPublicPort: this.hasPublicPort(containerInfo),
       openingUrl: this.getOpeningUrl(containerInfo),
       groupInfo: this.getContainerGroup(containerInfo),


### PR DESCRIPTION
### What does this PR do?

It removes the label PORT from the container port value

### Screenshot/screencast of this PR

Before:
![immagine](https://user-images.githubusercontent.com/49404737/219433254-5d0f250b-6323-494d-8104-8e96042e0b3c.png)

After:
![immagine](https://user-images.githubusercontent.com/49404737/219432803-31f0ff2b-2d25-4482-be6e-a0087c88d3b4.png)

### What issues does this PR fix or reference?
it closes #712 

### How to test this PR?

Open the container details page of a container that has atleast a port. Check there is no extra PORT label
