### PR TITLE
fix: delete enablement for engines that support Container count

### DIFF
--- a/packages/renderer/src/lib/image/image-utils.ts
+++ b/packages/renderer/src/lib/image/image-utils.ts
@@ -68,12 +68,12 @@ export class ImageUtils {
     }
   }
 
-  getEngineId(containerInfo: ImageInfo): string {
-    return containerInfo.engineId;
+  getEngineId(imageInfo: ImageInfo): string {
+    return imageInfo.engineId;
   }
 
-  getEngineName(containerInfo: ImageInfo): string {
-    return containerInfo.engineName;
+  getEngineName(imageInfo: ImageInfo): string {
+    return imageInfo.engineName;
   }
 
   getBase64EncodedName(name: string) {
@@ -104,7 +104,7 @@ export class ImageUtils {
           tag: '',
           base64RepoTag: this.getBase64EncodedName('<none>'),
           selected: false,
-          inUse: this.getInUse(imageInfo, containersInfo),
+          inUse: imageInfo.Containers > 0 || this.getInUse(imageInfo, containersInfo),
         },
       ];
     } else {
@@ -121,7 +121,7 @@ export class ImageUtils {
           tag: this.getTag(repoTag),
           base64RepoTag: this.getBase64EncodedName(repoTag),
           selected: false,
-          inUse: this.getInUse(imageInfo, containersInfo),
+          inUse: imageInfo.Containers > 0 || this.getInUse(imageInfo, containersInfo),
         };
       });
     }


### PR DESCRIPTION
### What does this PR do?

Partial fix for issue #1504. See previous attempt in PR #1437.

The problem with delete action enablement and incorrect icon will still exist in the ImageDetails page for container engines that don't support a container count, but this will fix the problem for those that do, and avoid the extra processing in that path. I don't know how others feel about partial fixes, but IMHO this solves the problem immediately and safely for one class of engines.

Couldn't help myself, I also fixed the odd variable names.