### PR TITLE
fix: avoid setting multiple listeners to onDidUpdateProviderStatus (#1511)

### DIFF
--- a/packages/renderer/src/stores/providers.ts
+++ b/packages/renderer/src/stores/providers.ts
@@ -25,7 +25,7 @@ export async function fetchProviders() {
   providerInfos.set(result);
   result.forEach(providerInfo => {
     // register only if none for this provider id
-    if (!updateProviderCallbacks.includes[providerInfo.internalId]) {
+    if (!updateProviderCallbacks.includes(providerInfo.internalId)) {
       window.onDidUpdateProviderStatus(providerInfo.internalId, () => {
         fetchProviders();
       });


### PR DESCRIPTION
### What does this PR do?

Fix a check to see if a callback has already been added for the provider

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

it fixes #1511 

### How to test this PR?

1. remove your podman machine
2. recreate it
3. there are no errors in the console
