### PR TITLE
fix: infinite loop when watching /var/run (#1435)

### DIFF
--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -592,8 +592,13 @@ function setupDisguisedPodmanSocketWatcher(
     checkDisguisedPodmanSocket(provider);
   });
 
-  // watch parent directory
-  const socketWatcher = extensionApi.fs.createFileSystemWatcher(path.dirname(socketFile));
+  let socketWatcher: extensionApi.FileSystemWatcher;
+  if (isLinux) {
+    socketWatcher = extensionApi.fs.createFileSystemWatcher(socketFile);
+  } else {
+    // watch parent directory
+    socketWatcher = extensionApi.fs.createFileSystemWatcher(path.dirname(socketFile));
+  }
 
   // only trigger if the watched file is the socket file
   const updateSocket = (uri: extensionApi.Uri) => {


### PR DESCRIPTION
### What does this PR do?

It makes podman desktop watch the docker socket when on linux, preventing it from erroring infinitely.

I kept the default behavior for mac/windows as it works fine there. 

By watching the specific file on linux, the listeners get triggered correctly when the socket is deleted/created/changed.
The error comes when watching the full directory as it contains files that are only allowed to be read by the root user so if you start podman as non-root, it starts failing.

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

it fixes #1435 

### How to test this PR?

1. start podman on linux (fedora 37 in my case)
2. check that there are no errors coming on in loop
