### PR TITLE
nit: remove type from EngineInfoUI

### DIFF
--- a/packages/renderer/src/lib/ContainerList.svelte
+++ b/packages/renderer/src/lib/ContainerList.svelte
@@ -192,7 +192,6 @@ onMount(async () => {
       return {
         name: container.engineName,
         id: container.engineId,
-        type: container.engineType,
       };
     });
 

--- a/packages/renderer/src/lib/engine/EngineInfoUI.ts
+++ b/packages/renderer/src/lib/engine/EngineInfoUI.ts
@@ -20,5 +20,4 @@
 export interface EngineInfoUI {
   id: string;
   name: string;
-  type: 'podman' | 'docker';
 }


### PR DESCRIPTION
nit: remove type from EngineInfoUI

### What does this PR do?

We don't really need type for the UI component for specifying the engine
id + name

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

N/A

### What issues does this PR fix or reference?

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

See: https://github.com/containers/podman-desktop/pull/1484#discussion_r1113474597

### How to test this PR?

<!-- Please explain steps to reproduce -->

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
