### PR TITLE
feat: add function to disable docker socket check

### DIFF
--- a/extensions/podman/package.json
+++ b/extensions/podman/package.json
@@ -20,6 +20,11 @@
     "configuration": {
       "title": "Podman",
       "properties": {
+        "podman.socket.check": {
+          "type": "boolean",
+          "default": true,
+          "description": "Check if Podman is successfully emulating the Docker socket (Requires restart)"
+        },
         "podman.binary.path": {
           "type": "string",
           "default": "",

--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -26,7 +26,7 @@ import { RegistrySetup } from './registry-setup';
 import { getAssetsFolder, isLinux, isMac, isWindows } from './util';
 import { PodmanInstall } from './podman-install';
 import type { InstalledPodman } from './podman-cli';
-import { execPromise, getPodmanCli, getPodmanInstallation } from './podman-cli';
+import { execPromise, getPodmanCli, getPodmanInstallation, getSocketCheck } from './podman-cli';
 import { PodmanConfiguration } from './podman-configuration';
 import { getDetectionChecks } from './detection-checks';
 import { getDisguisedPodmanInformation, getSocketPath, isDisguisedPodman } from './warnings';
@@ -384,11 +384,17 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
 
   const provider = extensionApi.provider.createProvider(providerOptions);
 
-  // Check on initial setup
-  checkDisguisedPodmanSocket(provider);
-  // update the status of the provider if the socket is changed, created or deleted
-  disguisedPodmanSocketWatcher = setupDisguisedPodmanSocketWatcher(provider, getSocketPath());
-  extensionContext.subscriptions.push(disguisedPodmanSocketWatcher);
+  // We will check to see that that user has selected 'true'
+  // for the configuration of podman.socket.check
+  // If they have, we will check to see if the socket exists
+  if (getSocketCheck()) {
+    // Check on initial setup
+    checkDisguisedPodmanSocket(provider);
+
+    // Update the status of the provider if the socket is changed, created or deleted
+    disguisedPodmanSocketWatcher = setupDisguisedPodmanSocketWatcher(provider, getSocketPath());
+    extensionContext.subscriptions.push(disguisedPodmanSocketWatcher);
+  }
 
   // provide an installation path ?
   if (podmanInstall.isAbleToInstall()) {

--- a/extensions/podman/src/podman-cli.ts
+++ b/extensions/podman/src/podman-cli.ts
@@ -56,6 +56,12 @@ export function getCustomBinaryPath(): string | undefined {
   return configuration.getConfiguration('podman').get('binary.path');
 }
 
+// Get the boolean value from configuration podman.socket.check
+// return boolean or undefined
+export function getSocketCheck(): boolean | undefined {
+  return configuration.getConfiguration('podman').get('socket.check');
+}
+
 export interface ExecOptions {
   logger?: Logger;
   env?: NodeJS.ProcessEnv | undefined;


### PR DESCRIPTION
feat: add function to disable docker socket check

### What does this PR do?

Adds a configuration setting to enable / disable the docker socket check
via the podman provider.

Requires restart as it will remove the "socket" watcher / prevent
watching anymore / update the UI.

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
![Screenshot 2023-02-22 at 3 12 22 PM](https://user-images.githubusercontent.com/6422176/220748388-8a9a4451-fa21-4fae-8933-1ea96679da81.png)



### What issues does this PR fix or reference?

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

Closes https://github.com/containers/podman-desktop/issues/1447

### How to test this PR?

<!-- Please explain steps to reproduce -->

1. Purposely run Podman and then Docker (docker will override the socket
   alias).
1. Go into settings the disable the socket check
1. Restart Podman Desktop. You should no longer see the warning

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
