### PR TITLE
chore: fix deprecated

### DIFF
--- a/packages/main/src/plugin/contribution-manager.ts
+++ b/packages/main/src/plugin/contribution-manager.ts
@@ -96,7 +96,7 @@ export class ContributionManager {
     }
     return fs.promises
       .readFile(iconPath, 'utf-8')
-      .then(data => 'data:image/svg+xml;base64,' + new Buffer(data).toString('base64'));
+      .then(data => 'data:image/svg+xml;base64,' + Buffer.from(data).toString('base64'));
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION

### What does this PR do?
avoid to see 
```
index.ts:120 main ↪️ (node:48057) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead. (Use `Electron --trace-deprecation ...` to show where the warning was created)
```


### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Check you don't see anymore the warning (and that you see svg icons of extensions)

Change-Id: I41dbe40becc1024a6ce83f21f7e22f1562415421

