### PR TITLE
nit: change directory of extensions storage

### DIFF
--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -75,8 +75,14 @@ export class ExtensionLoader {
   private watcherExtensions = new Map<string, containerDesktopAPI.FileSystemWatcher>();
   private reloadInProgressExtensions = new Map<string, boolean>();
   private extensionsStoragePath = '';
+
+  // Plugins directory location
   private pluginsDirectory = path.resolve(os.homedir(), '.local/share/podman-desktop/plugins');
   private pluginsScanDirectory = path.resolve(os.homedir(), '.local/share/podman-desktop/plugins-scanning');
+
+  // Extensions directory location
+  private extensionsStorageDirectory = path.resolve(os.homedir(), '.local/share/podman-desktop/extensions-storage');
+
   constructor(
     private commandRegistry: CommandRegistry,
     private menuRegistry: MenuRegistry,
@@ -174,9 +180,9 @@ export class ExtensionLoader {
       });
     }
 
-    this.extensionsStoragePath = path.resolve(os.homedir(), '.podman-desktop');
-    if (!fs.existsSync(this.extensionsStoragePath)) {
-      fs.mkdirSync(this.extensionsStoragePath);
+    // Create the extensions storage directory if it does not exist
+    if (!fs.existsSync(this.extensionsStorageDirectory)) {
+      fs.mkdirSync(this.extensionsStorageDirectory);
     }
 
     let folders;


### PR DESCRIPTION
nit: change directory of extensions storage

### What does this PR do?

Changes the directory of the extensions storage (used to be
`.podman-desktop` to the proper `.local` directory that the other
directories use.

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

N/A

### What issues does this PR fix or reference?

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

Fixes https://github.com/containers/podman-desktop/issues/1429

### How to test this PR?

<!-- Please explain steps to reproduce -->

1. Run `yarn watch`
2. Check that the directory `extensions-storage` was made in
   `.local/share/podman-desktop`

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
