### PR TITLE
fix: Consistent summary pages

### DIFF
--- a/packages/renderer/src/lib/ContainerDetails.svelte
+++ b/packages/renderer/src/lib/ContainerDetails.svelte
@@ -11,6 +11,7 @@ import ContainerActions from './container/ContainerActions.svelte';
 import { onMount } from 'svelte';
 import { containersInfos } from '../stores/containers';
 import { ContainerUtils } from './container/container-utils';
+import ContainerDetailsSummary from './ContainerDetailsSummary.svelte';
 import ContainerDetailsInspect from './ContainerDetailsInspect.svelte';
 import { getPanelDetailColor } from './color/color';
 import ContainerDetailsKube from './ContainerDetailsKube.svelte';
@@ -73,6 +74,17 @@ function errorCallback(errorMessage: string): void {
               <div class="pf-c-page__main-body">
                 <div class="pf-c-tabs pf-m-page-insets" id="open-tabs-example-tabs-list">
                   <ul class="pf-c-tabs__list">
+                    <li
+                      class="pf-c-tabs__item"
+                      class:pf-m-current="{meta.url === `/containers/${container.id}/summary`}">
+                      <a
+                        href="/containers/{container.id}/summary"
+                        class="pf-c-tabs__link"
+                        aria-controls="open-tabs-example-tabs-list-details-panel"
+                        id="open-tabs-example-tabs-list-details-link">
+                        <span class="pf-c-tabs__item-text">Summary</span>
+                      </a>
+                    </li>
                     <li class="pf-c-tabs__item" class:pf-m-current="{meta.url === `/containers/${container.id}/logs`}">
                       <a
                         href="/containers/{container.id}/logs"
@@ -118,17 +130,6 @@ function errorCallback(errorMessage: string): void {
                         <span class="pf-c-tabs__item-text">Terminal</span>
                       </a>
                     </li>
-                    <li
-                      class="pf-c-tabs__item"
-                      class:pf-m-current="{meta.url === `/containers/${container.id}/details`}">
-                      <a
-                        href="/containers/{container.id}/details"
-                        class="pf-c-tabs__link"
-                        aria-controls="open-tabs-example-tabs-list-details-panel"
-                        id="open-tabs-example-tabs-list-details-link">
-                        <span class="pf-c-tabs__item-text">Details</span>
-                      </a>
-                    </li>
                   </ul>
                 </div>
               </div>
@@ -171,6 +172,9 @@ function errorCallback(errorMessage: string): void {
           <a href="/containers" title="Close Details" class="mt-2 mr-2 text-gray-500"
             ><i class="fas fa-times" aria-hidden="true"></i></a>
         </div>
+        <Route path="/summary">
+          <ContainerDetailsSummary container="{container}" />
+        </Route>
         <Route path="/logs">
           <ContainerDetailsLogs container="{container}" />
         </Route>
@@ -179,29 +183,6 @@ function errorCallback(errorMessage: string): void {
         </Route>
         <Route path="/kube">
           <ContainerDetailsKube container="{container}" />
-        </Route>
-        <Route path="/details">
-          <div class="flex py-4 h-full" style="background-color: {getPanelDetailColor()}">
-            <table class="h-2 font-thin text-xs">
-              <tr>
-                <td class="px-2">Id</td>
-                <td class="px-2 font-thin text-xs">{container.shortId}</td>
-              </tr>
-              <tr>
-                <td class="px-2">Command</td>
-                <td class="px-2 font-thin text-xs">{container.command}</td>
-              </tr>
-              <tr>
-                <td class="px-2">State</td>
-                <td class="px-2 font-thin text-xs">{container.state}</td>
-              </tr>
-              <tr>
-                <td class="px-2">Ports</td>
-                <td class="px-2 font-thin text-xs" class:hidden="{container.hasPublicPort}">N/A</td>
-                <td class="px-2 font-thin text-xs" class:hidden="{!container.hasPublicPort}">{container.port}</td>
-              </tr>
-            </table>
-          </div>
         </Route>
         <Route path="/terminal">
           <ContainerDetailsTerminal container="{container}" />

--- a/packages/renderer/src/lib/ContainerDetailsSummary.svelte
+++ b/packages/renderer/src/lib/ContainerDetailsSummary.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+import type { ContainerInfoUI } from './container/ContainerInfoUI';
+import { getPanelDetailColor } from './color/color';
+
+export let container: ContainerInfoUI;
+</script>
+
+<div class="h-full" style="background-color: {getPanelDetailColor()}">
+  <div class="flex px-5 py-4 flex-col">
+    <div class="w-full">
+      <table class="h-2">
+        <tr>
+          <td class="pt-2 pr-2">Id</td>
+          <td class="pt-2 pr-2">{container.shortId}</td>
+        </tr>
+        <tr>
+          <td class="pt-2 pr-2">Command</td>
+          <td class="pt-2 pr-2">{container.command}</td>
+        </tr>
+        <tr>
+          <td class="pt-2 pr-2">State</td>
+          <td class="pt-2 pr-2">{container.state}</td>
+        </tr>
+        <tr>
+          <td class="pt-2 pr-2">Ports</td>
+          <td class="pt-2 pr-2" class:hidden="{container.hasPublicPort}">N/A</td>
+          <td class="pt-2 pr-2" class:hidden="{!container.hasPublicPort}">{container.port}</td>
+        </tr>
+      </table>
+    </div>
+  </div>
+</div>

--- a/packages/renderer/src/lib/pod/PodDetails.svelte
+++ b/packages/renderer/src/lib/pod/PodDetails.svelte
@@ -86,18 +86,6 @@ function errorCallback(errorMessage: string): void {
                     <li
                       class="pf-c-tabs__item"
                       class:pf-m-current="{meta.url ===
-                        `/pods/${encodeURI(pod.kind)}/${encodeURI(pod.name)}/${encodeURI(pod.engineId)}/logs`}">
-                      <a
-                        href="/pods/${encodeURI(pod.kind)}/${encodeURI(pod.name)}/${encodeURI(pod.engineId)}/logs"
-                        class="pf-c-tabs__link"
-                        aria-controls="open-tabs-example-tabs-list-details-panel"
-                        id="open-tabs-example-tabs-list-details-link">
-                        <span class="pf-c-tabs__item-text">Logs</span>
-                      </a>
-                    </li>
-                    <li
-                      class="pf-c-tabs__item"
-                      class:pf-m-current="{meta.url ===
                         `/pods/${encodeURI(pod.kind)}/${encodeURI(pod.name)}/${encodeURI(pod.engineId)}/summary`}">
                       <a
                         href="/pods/${encodeURI(pod.kind)}/{encodeURI(pod.name)}/{encodeURI(pod.engineId)}/summary"
@@ -105,6 +93,18 @@ function errorCallback(errorMessage: string): void {
                         aria-controls="open-tabs-example-tabs-list-details-panel"
                         id="open-tabs-example-tabs-list-details-link">
                         <span class="pf-c-tabs__item-text">Summary</span>
+                      </a>
+                    </li>
+                    <li
+                      class="pf-c-tabs__item"
+                      class:pf-m-current="{meta.url ===
+                        `/pods/${encodeURI(pod.kind)}/${encodeURI(pod.name)}/${encodeURI(pod.engineId)}/logs`}">
+                      <a
+                        href="/pods/${encodeURI(pod.kind)}/${encodeURI(pod.name)}/${encodeURI(pod.engineId)}/logs"
+                        class="pf-c-tabs__link"
+                        aria-controls="open-tabs-example-tabs-list-details-panel"
+                        id="open-tabs-example-tabs-list-details-link">
+                        <span class="pf-c-tabs__item-text">Logs</span>
                       </a>
                     </li>
                     <li
@@ -170,11 +170,11 @@ function errorCallback(errorMessage: string): void {
           <a href="/containers" title="Close Details" class="mt-2 mr-2 text-gray-500"
             ><i class="fas fa-times" aria-hidden="true"></i></a>
         </div>
-        <Route path="/logs">
-          <PodDetailsLogs pod="{pod}" />
-        </Route>
         <Route path="/summary">
           <PodDetailsSummary pod="{pod}" />
+        </Route>
+        <Route path="/logs">
+          <PodDetailsLogs pod="{pod}" />
         </Route>
         <Route path="/inspect">
           <PodDetailsInspect pod="{pod}" />


### PR DESCRIPTION
### What does this PR do?

Fix for issue #1540, inconsistent summary pages:
- Pod details Summary tab moved first.
- Container details details page (no, that's not a typo :) ) is moved first, renamed to Summary.
- Moved container details summary into it's own svelte file to match other pages.
- Formatting (font and spacing) changed to match other summary pages.

Selecting a container or pod from the list pages still links directly into the /logs page instead of /summary, but leaving that since it is a separate issue.

### Screenshot/screencast of this PR

<img width="449" alt="Screenshot 2023-02-24 at 3 17 08 PM" src="https://user-images.githubusercontent.com/19958075/221319462-3023637b-4ada-4983-9b51-611c5737e6c6.png">
<img width="724" alt="Screenshot 2023-02-24 at 3 17 23 PM" src="https://user-images.githubusercontent.com/19958075/221319463-4303ced2-3360-4765-8a91-5ab4c5de2bd0.png">

### What issues does this PR fix or reference?

Issue #1540.

### How to test this PR?

Start a container engine that has both containers and pods. Click on one of each to get to the Details page and see Summary tabs first.