### PR TITLE
fix: Hide dock icon on macOS if starting minimized

### DIFF
--- a/packages/main/src/mainWindow.ts
+++ b/packages/main/src/mainWindow.ts
@@ -79,13 +79,13 @@ async function createWindow() {
    * @see https://github.com/electron/electron/issues/25012
    */
   browserWindow.on('ready-to-show', () => {
-    // If started with --minimize flag, don't show the window
-    if (!isStartedMinimize()) {
+    // If started with --minimize flag, don't show the window and hide the dock icon on macOS
+    if (isStartedMinimize()) {
+      if (isMac()) {
+        app.dock.hide();
+      }
+    } else {
       browserWindow.show();
-    }
-
-    if (isMac() && !isStartedMinimize()) {
-      app.dock.show();
     }
 
     if (import.meta.env.DEV) {


### PR DESCRIPTION
### What does this PR do?
When starting Podman Desktop on macOS with the minimize on startup setting enabled (introduced in #1374), the dock icon remains until the dashboard is shown, and then closed. Clicking the icon in the dock doesn't bring up the application.

With this small fix, the dock icon is hidden on startup, similar to when the application window is closed normally. I've also verified that the current `app.dock.show();` is currently a noop as when `browserWindow.show();` is invoked, the dock icon is automatically shown so this covers both the use case when `isStartedMinimize()` is true, and false.

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

### How to test this PR?

On MacOS:

1. `yarn compile`
2. Move the binary to your Applications folder
3. Launch Podman Desktop + toggle Preferences > Login: Minimize setting
4. Logout and login your computer.
