### PR TITLE
chore: fix wrong isWindows calls in Kind extension

### DIFF
--- a/extensions/kind/src/kind-installer.ts
+++ b/extensions/kind/src/kind-installer.ts
@@ -120,12 +120,12 @@ export class KindInstaller {
             });
             progress.report({ increment: 80 });
             if (asset) {
-              const destFile = path.resolve(this.storagePath, isWindows ? assetInfo.name + '.exe' : assetInfo.name);
+              const destFile = path.resolve(this.storagePath, isWindows() ? assetInfo.name + '.exe' : assetInfo.name);
               if (!fs.existsSync(this.storagePath)) {
                 fs.mkdirSync(this.storagePath);
               }
               fs.appendFileSync(destFile, Buffer.from(asset.data as unknown as ArrayBuffer));
-              if (!isWindows) {
+              if (!isWindows()) {
                 const stat = fs.statSync(destFile);
                 fs.chmodSync(destFile, stat.mode | fs.constants.S_IXUSR);
               }

--- a/extensions/kind/src/util.ts
+++ b/extensions/kind/src/util.ts
@@ -73,7 +73,7 @@ export async function detectKind(pathAddition: string, installer: KindInstaller)
       env: { PATH: getKindPath().concat(path.delimiter).concat(pathAddition) },
     });
     if (result.exitCode === 0) {
-      return pathAddition.concat(path.sep).concat(isWindows ? assetInfo.name + '.exe' : assetInfo.name);
+      return pathAddition.concat(path.sep).concat(isWindows() ? assetInfo.name + '.exe' : assetInfo.name);
     }
   }
   return undefined;


### PR DESCRIPTION
### What does this PR do?

Fix wrong `isWindows` calls in Kind extension following refactoring

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Install Kind using the Kind extension
