### PR TITLE
fix: pass correct extension storage path to extension via context

### DIFF
--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -74,7 +74,6 @@ export class ExtensionLoader {
   private analyzedExtensions = new Map<string, AnalyzedExtension>();
   private watcherExtensions = new Map<string, containerDesktopAPI.FileSystemWatcher>();
   private reloadInProgressExtensions = new Map<string, boolean>();
-  private extensionsStoragePath = '';
 
   // Plugins directory location
   private pluginsDirectory = path.resolve(os.homedir(), '.local/share/podman-desktop/plugins');
@@ -637,7 +636,7 @@ export class ExtensionLoader {
 
     const extensionContext: containerDesktopAPI.ExtensionContext = {
       subscriptions,
-      storagePath: path.resolve(this.extensionsStoragePath, extension.id),
+      storagePath: path.resolve(this.extensionsStorageDirectory, extension.id),
     };
     let deactivateFunction = undefined;
     if (typeof extensionMain['deactivate'] === 'function') {


### PR DESCRIPTION
Fixes #1429

### What does this PR do?

It fixes wrong extension storage path given to extension via context. This is a follow up of #1551 

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

Fixes #1429

### How to test this PR?

1. Install kind
2. Ensure the binary is installed under the `$HOME/.local/share/podman-desktop/extensions-storage/kind` folder
