### PR TITLE
fix: Tabs not selected in Container and Image Details pages

### DIFF
--- a/packages/renderer/src/lib/ContainerDetails.svelte
+++ b/packages/renderer/src/lib/ContainerDetails.svelte
@@ -13,12 +13,12 @@ import { containersInfos } from '../stores/containers';
 import { ContainerUtils } from './container/container-utils';
 import ContainerDetailsSummary from './ContainerDetailsSummary.svelte';
 import ContainerDetailsInspect from './ContainerDetailsInspect.svelte';
-import { getPanelDetailColor } from './color/color';
 import ContainerDetailsKube from './ContainerDetailsKube.svelte';
 import ContainerStatistics from './container/ContainerStatistics.svelte';
 import Tooltip from './ui/Tooltip.svelte';
 import Fa from 'svelte-fa/src/fa.svelte';
 import { faExclamationCircle } from '@fortawesome/free-solid-svg-icons';
+import DetailsTab from './ui/DetailsTab.svelte';
 
 export let containerID: string;
 
@@ -48,7 +48,7 @@ function errorCallback(errorMessage: string): void {
 </script>
 
 {#if container}
-  <Route path="/*" let:meta>
+  <Route path="/*">
     <div class="w-full h-full">
       <div class="flex h-full flex-col">
         <div class="flex w-full flex-row">
@@ -74,62 +74,14 @@ function errorCallback(errorMessage: string): void {
               <div class="pf-c-page__main-body">
                 <div class="pf-c-tabs pf-m-page-insets" id="open-tabs-example-tabs-list">
                   <ul class="pf-c-tabs__list">
-                    <li
-                      class="pf-c-tabs__item"
-                      class:pf-m-current="{meta.url === `/containers/${container.id}/summary`}">
-                      <a
-                        href="/containers/{container.id}/summary"
-                        class="pf-c-tabs__link"
-                        aria-controls="open-tabs-example-tabs-list-details-panel"
-                        id="open-tabs-example-tabs-list-details-link">
-                        <span class="pf-c-tabs__item-text">Summary</span>
-                      </a>
-                    </li>
-                    <li class="pf-c-tabs__item" class:pf-m-current="{meta.url === `/containers/${container.id}/logs`}">
-                      <a
-                        href="/containers/{container.id}/logs"
-                        class="pf-c-tabs__link"
-                        aria-controls="open-tabs-example-tabs-list-details-panel"
-                        id="open-tabs-example-tabs-list-details-link">
-                        <span class="pf-c-tabs__item-text">Logs</span>
-                      </a>
-                    </li>
+                    <DetailsTab title="Summary" url="summary" />
+                    <DetailsTab title="Logs" url="logs" />
+                    <DetailsTab title="Inspect" url="inspect" />
 
-                    <li
-                      class="pf-c-tabs__item"
-                      class:pf-m-current="{meta.url === `/containers/${container.id}/inspect`}">
-                      <a
-                        href="/containers/{container.id}/inspect"
-                        class="pf-c-tabs__link"
-                        aria-controls="open-tabs-example-tabs-list-yaml-panel"
-                        id="open-tabs-example-tabs-list-yaml-link">
-                        <span class="pf-c-tabs__item-text">Inspect</span>
-                      </a>
-                    </li>
                     {#if container.engineType === 'podman' && container.groupInfo.type === ContainerGroupInfoTypeUI.STANDALONE}
-                      <li
-                        class="pf-c-tabs__item"
-                        class:pf-m-current="{meta.url === `/containers/${container.id}/kube`}">
-                        <a
-                          href="/containers/{container.id}/kube"
-                          class="pf-c-tabs__link"
-                          aria-controls="open-tabs-example-tabs-list-yaml-panel"
-                          id="open-tabs-example-tabs-list-yaml-link">
-                          <span class="pf-c-tabs__item-text">Kube</span>
-                        </a>
-                      </li>
+                      <DetailsTab title="Kube" url="kube" />
                     {/if}
-                    <li
-                      class="pf-c-tabs__item"
-                      class:pf-m-current="{meta.url === `/containers/${container.id}/terminal`}">
-                      <a
-                        href="/containers/{container.id}/terminal"
-                        class="pf-c-tabs__link"
-                        aria-controls="open-tabs-example-tabs-list-environment-panel"
-                        id="open-tabs-example-tabs-list-environment-link">
-                        <span class="pf-c-tabs__item-text">Terminal</span>
-                      </a>
-                    </li>
+                    <DetailsTab title="Terminal" url="terminal" />
                   </ul>
                 </div>
               </div>

--- a/packages/renderer/src/lib/image/ImageDetails.svelte
+++ b/packages/renderer/src/lib/image/ImageDetails.svelte
@@ -11,6 +11,7 @@ import ImageDetailsInspect from './ImageDetailsInspect.svelte';
 import ImageDetailsHistory from './ImageDetailsHistory.svelte';
 import ImageDetailsSummary from './ImageDetailsSummary.svelte';
 import PushImageModal from './PushImageModal.svelte';
+import DetailsTab from '../ui/DetailsTab.svelte';
 
 export let imageID: string;
 export let engineId: string;
@@ -43,7 +44,7 @@ onMount(() => {
 </script>
 
 {#if image}
-  <Route path="/*" let:meta>
+  <Route path="/*">
     <div class="w-full h-full">
       <div class="flex h-full flex-col">
         <div class="flex w-full flex-row">
@@ -71,43 +72,9 @@ onMount(() => {
               <div class="pf-c-page__main-body">
                 <div class="pf-c-tabs pf-m-page-insets" id="open-tabs-example-tabs-list">
                   <ul class="pf-c-tabs__list">
-                    <li
-                      class="pf-c-tabs__item"
-                      class:pf-m-current="{meta.url ===
-                        `/images/${image.id}/${encodeURI(image.engineId)}/${image.base64RepoTag}/summary`}">
-                      <a
-                        href="/images/{image.id}/{image.engineId}/{image.base64RepoTag}/summary"
-                        class="pf-c-tabs__link"
-                        aria-controls="open-tabs-example-tabs-list-details-panel"
-                        id="open-tabs-example-tabs-list-details-link">
-                        <span class="pf-c-tabs__item-text">Summary</span>
-                      </a>
-                    </li>
-                    <li
-                      class="pf-c-tabs__item"
-                      class:pf-m-current="{meta.url ===
-                        `/images/${image.id}/${encodeURI(image.engineId)}/${image.base64RepoTag}/history`}">
-                      <a
-                        href="/images/{image.id}/{image.engineId}/{image.base64RepoTag}/history"
-                        class="pf-c-tabs__link"
-                        aria-controls="open-tabs-example-tabs-list-details-panel"
-                        id="open-tabs-example-tabs-list-details-link">
-                        <span class="pf-c-tabs__item-text">History</span>
-                      </a>
-                    </li>
-
-                    <li
-                      class="pf-c-tabs__item"
-                      class:pf-m-current="{meta.url ===
-                        `/images/${image.id}/${encodeURI(image.engineId)}/${image.base64RepoTag}/inspect`}">
-                      <a
-                        href="/images/{image.id}/{image.engineId}/{image.base64RepoTag}/inspect"
-                        class="pf-c-tabs__link"
-                        aria-controls="open-tabs-example-tabs-list-yaml-panel"
-                        id="open-tabs-example-tabs-list-yaml-link">
-                        <span class="pf-c-tabs__item-text">Inspect</span>
-                      </a>
-                    </li>
+                    <DetailsTab title="Summary" url="summary" />
+                    <DetailsTab title="History" url="history" />
+                    <DetailsTab title="Inspect" url="inspect" />
                   </ul>
                 </div>
               </div>

--- a/packages/renderer/src/lib/pod/PodDetails.svelte
+++ b/packages/renderer/src/lib/pod/PodDetails.svelte
@@ -15,6 +15,7 @@ import PodDetailsLogs from './PodDetailsLogs.svelte';
 import { faExclamationCircle } from '@fortawesome/free-solid-svg-icons';
 import Tooltip from '../ui/Tooltip.svelte';
 import Fa from 'svelte-fa/src/fa.svelte';
+import DetailsTab from '../ui/DetailsTab.svelte';
 
 export let podName: string;
 export let engineId: string;
@@ -60,7 +61,7 @@ function errorCallback(errorMessage: string): void {
 </script>
 
 {#if pod}
-  <Route path="/*" let:meta>
+  <Route path="/*">
     <div class="w-full h-full">
       <div class="flex h-full flex-col">
         <div class="flex w-full flex-row">
@@ -83,54 +84,10 @@ function errorCallback(errorMessage: string): void {
               <div class="pf-c-page__main-body">
                 <div class="pf-c-tabs pf-m-page-insets" id="open-tabs-example-tabs-list">
                   <ul class="pf-c-tabs__list">
-                    <li
-                      class="pf-c-tabs__item"
-                      class:pf-m-current="{meta.url ===
-                        `/pods/${encodeURI(pod.kind)}/${encodeURI(pod.name)}/${encodeURI(pod.engineId)}/summary`}">
-                      <a
-                        href="/pods/${encodeURI(pod.kind)}/{encodeURI(pod.name)}/{encodeURI(pod.engineId)}/summary"
-                        class="pf-c-tabs__link"
-                        aria-controls="open-tabs-example-tabs-list-details-panel"
-                        id="open-tabs-example-tabs-list-details-link">
-                        <span class="pf-c-tabs__item-text">Summary</span>
-                      </a>
-                    </li>
-                    <li
-                      class="pf-c-tabs__item"
-                      class:pf-m-current="{meta.url ===
-                        `/pods/${encodeURI(pod.kind)}/${encodeURI(pod.name)}/${encodeURI(pod.engineId)}/logs`}">
-                      <a
-                        href="/pods/${encodeURI(pod.kind)}/${encodeURI(pod.name)}/${encodeURI(pod.engineId)}/logs"
-                        class="pf-c-tabs__link"
-                        aria-controls="open-tabs-example-tabs-list-details-panel"
-                        id="open-tabs-example-tabs-list-details-link">
-                        <span class="pf-c-tabs__item-text">Logs</span>
-                      </a>
-                    </li>
-                    <li
-                      class="pf-c-tabs__item"
-                      class:pf-m-current="{meta.url ===
-                        `/pods/${encodeURI(pod.kind)}/${encodeURI(pod.name)}/${encodeURI(pod.engineId)}/inspect`}">
-                      <a
-                        href="/pods/${encodeURI(pod.kind)}/{encodeURI(pod.name)}/{encodeURI(pod.engineId)}/inspect"
-                        class="pf-c-tabs__link"
-                        aria-controls="open-tabs-example-tabs-list-yaml-panel"
-                        id="open-tabs-example-tabs-list-yaml-link">
-                        <span class="pf-c-tabs__item-text">Inspect</span>
-                      </a>
-                    </li>
-                    <li
-                      class="pf-c-tabs__item"
-                      class:pf-m-current="{meta.url ===
-                        `/pods/${encodeURI(pod.kind)}/${encodeURI(pod.name)}/${encodeURI(pod.engineId)}/kube`}">
-                      <a
-                        href="/pods/${encodeURI(pod.kind)}/{encodeURI(pod.name)}/{encodeURI(pod.engineId)}/kube"
-                        class="pf-c-tabs__link"
-                        aria-controls="open-tabs-example-tabs-list-yaml-panel"
-                        id="open-tabs-example-tabs-list-yaml-link">
-                        <span class="pf-c-tabs__item-text">Kube</span>
-                      </a>
-                    </li>
+                    <DetailsTab title="Summary" url="summary" />
+                    <DetailsTab title="Logs" url="logs" />
+                    <DetailsTab title="Inspect" url="inspect" />
+                    <DetailsTab title="Kube" url="kube" />
                   </ul>
                 </div>
               </div>

--- a/packages/renderer/src/lib/ui/DetailsTab.svelte
+++ b/packages/renderer/src/lib/ui/DetailsTab.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+import { router } from 'tinro';
+
+export let url;
+export let title;
+
+let baseURL = $router.path.substring(0, $router.path.lastIndexOf('/'));
+</script>
+
+<li class="pf-c-tabs__item" class:pf-m-current="{$router.path === baseURL + '/' + url}">
+  <a
+    href="{baseURL}/{url}"
+    class="pf-c-tabs__link"
+    aria-controls="open-tabs-example-tabs-list-{url}-panel"
+    id="open-tabs-example-tabs-list-{url}-link">
+    <span class="pf-c-tabs__item-text">{title}</span>
+  </a>
+</li>

--- a/packages/renderer/src/lib/volume/VolumeDetails.svelte
+++ b/packages/renderer/src/lib/volume/VolumeDetails.svelte
@@ -9,6 +9,7 @@ import VolumeActions from './VolumeActions.svelte';
 import { VolumeUtils } from './volume-utils';
 import VolumeDetailsSummary from '././VolumeDetailsSummary.svelte';
 import VolumeDetailsInspect from './VolumeDetailsInspect.svelte';
+import DetailsTab from '../ui/DetailsTab.svelte';
 
 export let volumeName: string;
 export let engineId: string;
@@ -32,7 +33,7 @@ onMount(() => {
 </script>
 
 {#if volume}
-  <Route path="/*" let:meta>
+  <Route path="/*">
     <div class="w-full h-full">
       <div class="flex h-full flex-col">
         <div class="flex w-full flex-row">
@@ -57,30 +58,8 @@ onMount(() => {
               <div class="pf-c-page__main-body">
                 <div class="pf-c-tabs pf-m-page-insets" id="open-tabs-example-tabs-list">
                   <ul class="pf-c-tabs__list">
-                    <li
-                      class="pf-c-tabs__item"
-                      class:pf-m-current="{meta.url ===
-                        `/volumes/${encodeURI(volume.name)}/${encodeURI(volume.engineId)}/summary`}">
-                      <a
-                        href="/volumes/{encodeURI(volume.name)}/{encodeURI(volume.engineId)}/summary"
-                        class="pf-c-tabs__link"
-                        aria-controls="open-tabs-example-tabs-list-details-panel"
-                        id="open-tabs-example-tabs-list-details-link">
-                        <span class="pf-c-tabs__item-text">Summary</span>
-                      </a>
-                    </li>
-                    <li
-                      class="pf-c-tabs__item"
-                      class:pf-m-current="{meta.url ===
-                        `/volumes/${encodeURI(volume.name)}/${encodeURI(volume.engineId)}/inspect`}">
-                      <a
-                        href="/volumes/{encodeURI(volume.name)}/{encodeURI(volume.engineId)}/inspect"
-                        class="pf-c-tabs__link"
-                        aria-controls="open-tabs-example-tabs-list-yaml-panel"
-                        id="open-tabs-example-tabs-list-yaml-link">
-                        <span class="pf-c-tabs__item-text">Inspect</span>
-                      </a>
-                    </li>
+                    <DetailsTab title="Summary" url="summary" />
+                    <DetailsTab title="Inspect" url="inspect" />
                   </ul>
                 </div>
               </div>


### PR DESCRIPTION
### What does this PR do?

I noticed that some of the tabs on the container and image details pages weren't correctly showing as selected when they should be (yes, it's subtle but I notice this kind of thing). I tracked this down to some missing encodeURI() calls that the other pages were doing, which caused the pf-m-current style to be missing.

I started to fix this, but it seemed like a lot of copy/paste code so I pulled a baseURL out into a variable... then I thought it's even better to use the router and avoid all calls to encodeURI()... then went full Svelte component. In the end this is a lot more cleanup than necessary to fix a simple bug, but the result is far less code, ensured consistency, and easier to update/maintain.

### Screenshot/screencast of this PR

Before:
<img width="724" alt="Screenshot 2023-02-24 at 3 17 23 PM" src="https://user-images.githubusercontent.com/19958075/221608838-76ab2754-a5a3-43dc-8ef3-958a2b988e66.png">

After:
<img width="362" alt="Screenshot 2023-02-27 at 10 37 39 AM" src="https://user-images.githubusercontent.com/19958075/221608762-335e31cc-e940-4bd6-8c5d-76c40a8d7332.png">

### How to test this PR?

For regression testing start with at least one volume, image, container, and pod and confirm that the tabs on all the details pages still work. To confirm the actual fix, you'll need a container or image whose name contains a character that needs URL encoding.