### PR TITLE
check for flatpak when calling command from exec

### DIFF
--- a/packages/preload-docker-extension/src/index.ts
+++ b/packages/preload-docker-extension/src/index.ts
@@ -70,12 +70,18 @@ export class DockerExtensionPreload {
     args: string[],
     execOptions?: dockerDesktopAPI.ExecOptions,
   ): Promise<dockerDesktopAPI.ExecResult> {
+    let command = cmd;
+    let _args = args;
+    if (process.env.FLATPAK_ID) {
+      _args = ['--host', cmd, ...args];
+      command = 'flatpak-spawn';
+    }
     const rawResult = await ipcRenderer.invoke(
       'docker-plugin-adapter:exec',
       extensionName,
       launcher,
-      cmd,
-      args,
+      command,
+      _args,
       execOptions,
     );
     if (rawResult.error) {


### PR DESCRIPTION
### What does this PR do?
Fixes issue where commands cannot be executed on system when running within a Flatpak.

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?

When running commands within an extension, they all are spawned on the system the same way.
However, running the same commands when Podman desktop is running as a Flatpak will cause the extension to break with the following error message:
```
Command failed: undefined
```

#### Flatpak
![Running as Flatpak](https://user-images.githubusercontent.com/97077423/221684282-9999e96d-f379-42fc-96f1-cd10fde40860.png "Running as flatpak")

#### Non-Flatpak
![Running as non-Flatpak](https://user-images.githubusercontent.com/97077423/221684384-c36eb249-9d3d-423b-8c15-17d56a5b8917.png "Running as non-flatpak")


### How to test this PR?

Try running the FetchIt Desktop extension from within a Flatpak environment and then outside of Flatpak.
