### PR TITLE
fix: use label of QuickPickItems elements

### DIFF
--- a/packages/renderer/src/lib/dialogs/QuickPickInput.svelte
+++ b/packages/renderer/src/lib/dialogs/QuickPickInput.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { QuickPickItem } from '@tmpwip/extension-api';
 import { onDestroy, onMount, tick } from 'svelte';
 
 interface InputBoxOptions {
@@ -13,7 +14,7 @@ interface InputBoxOptions {
 
 interface QuickPickOptions {
   placeHolder?: string;
-  items: any[];
+  items: QuickPickItem[] | string[];
   prompt: string;
   id: number;
   canPickMany: boolean;
@@ -74,7 +75,14 @@ const showQuickPickCallback = async (options?: QuickPickOptions) => {
     prompt = options.prompt;
   }
   mode = 'QuickPick';
-  quickPickItems = options.items.map(item => ({ value: item, checkbox: false }));
+  quickPickItems = options.items.map(item => {
+    if (typeof item === 'string') {
+      return { value: item, checkbox: false };
+    } else {
+      // if type is QuickPickItem use label field for the display
+      return { value: item.label, checkbox: false };
+    }
+  });
   quickPickFilteredItems = quickPickItems;
 
   if (options.canPickMany) {


### PR DESCRIPTION
### What does this PR do?
QuickPick can be used by array of strings or using QuickPickItems In that case, we need to display the label field of QuickPickItems

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

N/A

### How to test this PR?

You may try to use extension API using `QuickPickItems`


Change-Id: I780e14aeae59bf2e36781d154698ff901c95952e
