### PR TITLE
feat(extension-api): Provides list of container connections

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -338,11 +338,17 @@ declare module '@tmpwip/extension-api' {
   export interface RegisterContainerConnectionEvent {
     providerId: string;
   }
+  export interface ProviderContainerConnection {
+    providerId: string;
+    connection: ContainerProviderConnection;
+  }
+
   export namespace provider {
     export function createProvider(provider: ProviderOptions): Provider;
     export const onDidUpdateProvider: Event<ProviderEvent>;
     export const onDidUnregisterContainerConnection: Event<UnregisterContainerConnectionEvent>;
     export const onDidRegisterContainerConnection: Event<UnregisterContainerConnectionEvent>;
+    export function getContainerConnections(): ProviderContainerConnection[];
   }
 
   export interface ProxySettings {

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -387,6 +387,9 @@ export class ExtensionLoader {
       onDidRegisterContainerConnection: (listener, thisArg, disposables) => {
         return providerRegistry.onDidRegisterContainerConnection(listener, thisArg, disposables);
       },
+      getContainerConnections: () => {
+        return providerRegistry.getContainerConnections();
+      },
     };
 
     const proxyInstance = this.proxy;

--- a/packages/main/src/plugin/provider-registry.ts
+++ b/packages/main/src/plugin/provider-registry.ts
@@ -34,6 +34,7 @@ import type {
   RegisterKubernetesConnectionEvent,
   Logger,
   ProviderInformation,
+  ProviderContainerConnection,
 } from '@tmpwip/extension-api';
 import type {
   ProviderContainerConnectionInfo,
@@ -768,5 +769,18 @@ export class ProviderRegistry {
       name: provider.name,
       status: provider.status,
     });
+  }
+
+  getContainerConnections(): ProviderContainerConnection[] {
+    const connections: ProviderContainerConnection[] = [];
+    this.providers.forEach(provider => {
+      provider.containerConnections.forEach(connection => {
+        connections.push({
+          providerId: provider.id,
+          connection,
+        });
+      });
+    });
+    return connections;
   }
 }


### PR DESCRIPTION
### What does this PR do?
Add a way to retrieve connections from extensions

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

Compose extension will need the socket (and then retrieve the connections)

### How to test this PR?

<!-- Please explain steps to reproduce -->

Change-Id: Id8de6c024bcba2f8c9e0d531d49b1776313117c9
