### PR TITLE
Add GitHub Action for reporting downloads-count on daily basis

### DIFF
--- a/.github/workflows/downloads-count.yaml
+++ b/.github/workflows/downloads-count.yaml
@@ -1,4 +1,22 @@
-# Launch bot
+#
+# Copyright (C) 2023 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Grab downloads
+
 name: Downloads Count
 
 on:

--- a/.github/workflows/downloads-count.yaml
+++ b/.github/workflows/downloads-count.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
 
   get-all-releases-count:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/github-script@v6

--- a/.github/workflows/downloads-count.yaml
+++ b/.github/workflows/downloads-count.yaml
@@ -41,9 +41,6 @@ jobs:
 
             const releases = resp;
 
-            // Create a new json array which keeps tag_name and assets from result
-            //const releases = resp.data.map(({ tag_name, assets }) => ({ tag_name, assets }))
-
             // Keep only tag_name and asset.name and asset.download_count from releases
             releases.forEach((release) => { release.assets = release.assets.map(({ name, download_count }) => ({ name, download_count })) })
 

--- a/.github/workflows/downloads-count.yaml
+++ b/.github/workflows/downloads-count.yaml
@@ -1,0 +1,72 @@
+# Launch bot
+name: Downloads Count
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+
+  get-all-releases-count:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/github-script@v6
+        id: process-downloads
+        with:
+          script: |
+            const resp = await github.paginate('GET /repos/{owner}/{repo}/releases{?per_page,page}', {
+                owner: 'containers',
+                repo: 'podman-desktop',
+                per_page: 100
+            }, (response) => response.data.map(({ tag_name, assets }) => ({ tag_name, assets })));
+
+            const releases = resp;
+
+            // Create a new json array which keeps tag_name and assets from result
+            //const releases = resp.data.map(({ tag_name, assets }) => ({ tag_name, assets }))
+
+            // Keep only tag_name and asset.name and asset.download_count from releases
+            releases.forEach((release) => { release.assets = release.assets.map(({ name, download_count }) => ({ name, download_count })) })
+
+            let totalMac = 0;
+            let totalWin = 0;
+            let totalLinux = 0;
+
+            // count the total number of downloads for each release for mac,windows,linux assests
+            releases.forEach((release) => { 
+                release.assets = release.assets.filter((asset) => { 
+                    if (asset.name.endsWith(".dmg") || (asset.name.endsWith("arm64.zip") || asset.name.endsWith("x64.zip") || asset.name.endsWith("universal.zip")) ){
+                        totalMac += asset.download_count;
+                    } else if (asset.name.endsWith(".exe")){
+                        totalWin += asset.download_count;
+                    } else if (asset.name.endsWith(".tar.gz") || asset.name.endsWith(".flatpak")){
+                        totalLinux+=asset.download_count;
+                    }
+                })
+            })
+
+            let totalDownloads = totalMac + totalWin + totalLinux;
+
+            // Export results as environment variables
+            core.exportVariable('totalDownloads', totalDownloads);
+            core.exportVariable('totalMac', totalMac);
+            core.exportVariable('totalWin', totalWin);
+            core.exportVariable('totalLinux', totalLinux);
+        
+      - name: send-event-4
+        run: |
+            curl https://api.segment.io/v1/track \
+            -X POST \
+            -H 'Content-Type: application/json' \
+            -d '{
+              "userId": "gh-action",
+              "event": "download-count",
+               "properties": {
+                "mac": "${{ env.totalMac }}",
+                "windows": "${{ env.totalWin }}",
+                "linux": "${{ env.totalLinux }}",
+                "total": "${{ env.totalDownloads }}"
+              }
+            }' \
+            -u ${{ secrets.SEGMENT_WRITE_KEY }}


### PR DESCRIPTION
### What does this PR do?

This PR adds a github action to the repository which is triggered every day at 12:00 UTC. It pulls the number of downloads from the github releases and publish that under the telemetry tool. This allows us to get history in the number of downloads.

### Screenshot/screencast of this PR

not applicable

### How to test this PR?

It is possible to test the action if you add it to your own fork. Then you'll need to:
- Make sure there is a secret defined on your fork for `SEGMENT_WRITE_KEY` using the "Dev" key.
- Wait a day to see if the action is triggered and the event published on segment
