### PR TITLE
fix: remove InlineSVG component (#1584)

### DIFF
--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -29,7 +29,6 @@
     "svelte": "^3.55.1",
     "svelte-check": "^2.10.3",
     "svelte-fa": "^3.0.3",
-    "svelte-inline-svg": "^1.2.0",
     "svelte-preprocess": "^5.0.1",
     "tailwindcss": "^3.2.7",
     "tslib": "^2.5.0",

--- a/packages/renderer/src/AppNavigation.svelte
+++ b/packages/renderer/src/AppNavigation.svelte
@@ -217,7 +217,7 @@ export let meta;
               <li class="pf-c-nav__item">
                 <a href="/contribs/{contribution.name}" class="pf-c-nav__link">
                   <div class="flex items-center w-full sm:-ml-1.5 md:-ml-1.5 mr-2">
-                    <img src="{contribution.icon}" width="24" height="24" class="mr-4" alt="{contribution.name} icon"/>
+                    <img src="{contribution.icon}" width="24" height="24" class="mr-4" alt="{contribution.name} icon" />
                     <span
                       class="w-full text-ellipsis whitespace-nowrap overflow-hidden opacity-0 -z-40 md:z-0 md:opacity-100 group-hover:z-0 group-hover:opacity-100 group-hover:delay-150 group-hover:duration-75 group-hover:ease-in-out md:transition-opacity md:delay-150 md:duration-150 md:ease-in-out"
                       title="{contribution.name}">{contribution.name}</span>

--- a/packages/renderer/src/AppNavigation.svelte
+++ b/packages/renderer/src/AppNavigation.svelte
@@ -13,7 +13,6 @@ import ContainerIcon from './lib/images/ContainerIcon.svelte';
 import PodIcon from './lib/images/PodIcon.svelte';
 import ImageIcon from './lib/images/ImageIcon.svelte';
 import VolumeIcon from './lib/images/VolumeIcon.svelte';
-import InlineSVG from 'svelte-inline-svg';
 
 let containersCountValue;
 let imageInfoSubscribe;
@@ -218,7 +217,7 @@ export let meta;
               <li class="pf-c-nav__item">
                 <a href="/contribs/{contribution.name}" class="pf-c-nav__link">
                   <div class="flex items-center w-full sm:-ml-1.5 md:-ml-1.5 mr-2">
-                    <InlineSVG src="{contribution.icon}" width="24" height="24" class="mr-4" />
+                    <img src="{contribution.icon}" width="24" height="24" class="mr-4" alt="{contribution.name} icon"/>
                     <span
                       class="w-full text-ellipsis whitespace-nowrap overflow-hidden opacity-0 -z-40 md:z-0 md:opacity-100 group-hover:z-0 group-hover:opacity-100 group-hover:delay-150 group-hover:duration-75 group-hover:ease-in-out md:transition-opacity md:delay-150 md:duration-150 md:ease-in-out"
                       title="{contribution.name}">{contribution.name}</span>


### PR DESCRIPTION
### What does this PR do?

it removes the `svelte-inline-svg` package that causes a problem on linux

### Screenshot/screencast of this PR

![image](https://user-images.githubusercontent.com/49404737/222105673-eaf2844e-66c4-4546-b90c-c4710e660c62.png)

### What issues does this PR fix or reference?

fixes #1584 

### How to test this PR?

1. on linux fedora 37, launch the current main branch, you should see a white window.
