### PR TITLE
feat: add check on podman socket on linux to update container engine status (#1446)

### DIFF
--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -256,14 +256,14 @@ async function monitorPodmanSocket(socketPath: string) {
         podmanProviderStatus = 'stopped';
       } else {
         podmanProviderStatus = 'started';
-      }      
+      }
     } catch (error) {
       // ignore the update of machines
     }
     await timeout(5000);
     monitorPodmanSocket(socketPath);
   }
-} 
+}
 
 async function timeout(time: number): Promise<void> {
   return new Promise<void>(resolve => {

--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -19,6 +19,7 @@
 import * as extensionApi from '@tmpwip/extension-api';
 import * as path from 'node:path';
 import * as os from 'node:os';
+import * as http from 'node:http';
 import * as fs from 'node:fs';
 import { spawn } from 'node:child_process';
 import { RegistrySetup } from './registry-setup';
@@ -42,6 +43,7 @@ let stopLoop = false;
 
 // current status of machines
 const podmanMachinesStatuses = new Map<string, extensionApi.ProviderConnectionStatus>();
+let podmanProviderStatus: extensionApi.ProviderConnectionStatus = 'started';
 const podmanMachinesInfo = new Map<string, MachineInfo>();
 const currentConnections = new Map<string, extensionApi.Disposable>();
 
@@ -208,16 +210,60 @@ async function initDefaultLinux(provider: extensionApi.Provider) {
   const containerProviderConnection: extensionApi.ContainerProviderConnection = {
     name: 'Podman',
     type: 'podman',
-    status: () => 'started',
+    status: () => podmanProviderStatus,
     endpoint: {
       socketPath,
     },
   };
 
+  monitorPodmanSocket(socketPath);
+
   const disposable = provider.registerContainerProviderConnection(containerProviderConnection);
   currentConnections.set('podman', disposable);
   storedExtensionContext.subscriptions.push(disposable);
 }
+
+async function isPodmanSocketAlive(socketPath: string): Promise<boolean> {
+  const pingUrl = {
+    path: '/_ping',
+    socketPath,
+  };
+  return new Promise<boolean>(resolve => {
+    const req = http.get(pingUrl, res => {
+      res.on('data', () => {
+        // do nothing
+      });
+      res.on('end', () => {
+        if (res.statusCode === 200) {
+          resolve(true);
+        } else {
+          resolve(false);
+        }
+      });
+    });
+    req.once('error', () => {
+      resolve(false);
+    });
+  });
+}
+
+async function monitorPodmanSocket(socketPath: string) {
+  // call us again
+  if (!stopLoop) {
+    try {
+      const alive = await isPodmanSocketAlive(socketPath);
+      if (!alive) {
+        podmanProviderStatus = 'stopped';
+      } else {
+        podmanProviderStatus = 'started';
+      }      
+    } catch (error) {
+      // ignore the update of machines
+    }
+    await timeout(5000);
+    monitorPodmanSocket(socketPath);
+  }
+} 
 
 async function timeout(time: number): Promise<void> {
   return new Promise<void>(resolve => {


### PR DESCRIPTION
### What does this PR do?

This PR is only related to Linux
This adds a periodic check on the podman socket so that the dashboard is updated accordingly

### Screenshot/screencast of this PR

https://user-images.githubusercontent.com/49404737/222119184-b08afd9d-d1a6-438b-bdeb-2be3843b483c.mp4

### What issues does this PR fix or reference?

#1446 

### How to test this PR?

1. update the socket to look at in https://github.com/containers/podman-desktop/compare/main...lstocchi:i1446-2?expand=1#diff-c885162dd627b7cd812c83544b19b9b166179fec79ddbc13273fede7c2566791R200 
2. i used `/run/user/${uid}/podman/podman2.sock`;
3. use sockat to create a chain of socket
4. 
```
socat -v -b10  UNIX-LISTEN:/run/user/1000/podman/podman3.sock,sndbuf=10,rcvbuf=10,fork UNIX-CONNECT:/run/user/1000/podman/podman.sock
socat -v -b10  UNIX-LISTEN:/run/user/1000/podman/podman2.sock,sndbuf=10,rcvbuf=10,fork UNIX-CONNECT:/run/user/1000/podman/podman3.sock
```
5 you should have something like podman desktop -> podman2.sock -> podman3.sock -> podman.sock
6 launch podman desktop, kill an intermediate socket to see if the dashboard refreshes 