### PR TITLE
chore: Use error message component

### DIFF
--- a/packages/renderer/src/lib/dashboard/ProviderConfigured.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderConfigured.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import type { CheckStatus, ProviderInfo } from '../../../../main/src/plugin/api/provider-info';
+import ErrorMessage from '../ui/ErrorMessage.svelte';
 import PreflightChecks from './PreflightChecks.svelte';
 import ProviderLinks from './ProviderLinks.svelte';
 import ProviderLogo from './ProviderLogo.svelte';
@@ -81,12 +82,7 @@ async function runProvider() {
       </div>
     {/if}
     {#if runError}
-      <div class="flex mt-2 flex-col">
-        <div>Error:</div>
-        <div class="my-2">
-          <p class="text-sm text-red-500">{runError}</p>
-        </div>
-      </div>
+      <ErrorMessage class="flex flex-col mt-2 my-2 text-sm" error="{runError}" />
     {/if}
   </div>
   {#if provider.updateInfo}

--- a/packages/renderer/src/lib/docker-extension/PreferencesPageDockerExtensions.svelte
+++ b/packages/renderer/src/lib/docker-extension/PreferencesPageDockerExtensions.svelte
@@ -2,6 +2,7 @@
 import { afterUpdate } from 'svelte';
 
 import { contributions } from '../../stores/contribs';
+import ErrorMessage from '../ui/ErrorMessage.svelte';
 let ociImage: string;
 
 let installInProgress: boolean = false;
@@ -85,20 +86,16 @@ function deleteContribution(extensionName: string) {
       Install extension from the OCI image
     </button>
 
-    {#if errorInstall !== ''}
-      <div class="bg-red-500 text-gray-900 m-4">
-        {errorInstall}
-      </div>
-    {/if}
-
     <div
       class:opacity-0="{logs.length === 0}"
       bind:this="{logElement}"
-      class="bg-zinc-700 text-gray-200 mt-4 h-16 overflow-y-auto">
+      class="bg-zinc-700 text-gray-200 mt-2 h-16 p-1 overflow-y-auto">
       {#each logs as log}
         <p class="font-light text-sm">{log}</p>
       {/each}
     </div>
+
+    <ErrorMessage class="p-1 text-sm" error="{errorInstall}" />
   </div>
 
   {#if $contributions.length > 0}

--- a/packages/renderer/src/lib/feedback/SendFeedback.svelte
+++ b/packages/renderer/src/lib/feedback/SendFeedback.svelte
@@ -3,6 +3,7 @@ import { faFrown, faGrinStars, faMeh, faSmile } from '@fortawesome/free-solid-sv
 import Fa from 'svelte-fa/src/fa.svelte';
 import Modal from '../dialogs/Modal.svelte';
 import type { FeedbackProperties } from '../../../../preload/src/index';
+import ErrorMessage from '../ui/ErrorMessage.svelte';
 let displayModal = false;
 
 // feedback of the user
@@ -114,7 +115,7 @@ async function sendFeedback(): Promise<void> {
 
         <div class="pt-5 flex flex-row w-full">
           {#if smileyRating === 0}
-            <div class="text-red-500 text-xs flex flex-row w-[300px]">Please select an experience smiley</div>
+            <ErrorMessage class="flex flex-row w-[350px] text-xs" error="Please select an experience smiley" />
           {/if}
 
           <div class="flex flex-row justify-end w-full">

--- a/packages/renderer/src/lib/image/RunImage.svelte
+++ b/packages/renderer/src/lib/image/RunImage.svelte
@@ -451,7 +451,7 @@ function checkContainerName(event: any) {
                   class="w-full p-2 outline-none text-sm bg-zinc-900 rounded-sm text-gray-400 placeholder-gray-400 border  {containerNameError
                     ? 'border-red-500'
                     : 'border-zinc-900'}" />
-                <div class="h-1 text-sm text-red-500 text-xs">{containerNameError}</div>
+                <ErrorMessage class="h-1 text-sm" error="{containerNameError}" />
                 <label for="volumes" class="pt-4 block mb-2 text-sm font-medium text-gray-300 dark:text-gray-300"
                   >Volumes:</label>
                 <!-- Display the list of volumes -->
@@ -894,7 +894,7 @@ function checkContainerName(event: any) {
               <i class="fas fa-play" aria-hidden="true"></i>
             </span>
             Start Container</button>
-          <div class="py-2 text-sm"><ErrorMessage error="{createError}" /></div>
+          <ErrorMessage class="py-2 text-sm" error="{createError}" />
         </div>
       </div>
     </NavPage>

--- a/packages/renderer/src/lib/kube/KubePlayYAML.svelte
+++ b/packages/renderer/src/lib/kube/KubePlayYAML.svelte
@@ -9,6 +9,7 @@ import MonacoEditor from '../editor/MonacoEditor.svelte';
 import NoContainerEngineEmptyScreen from '../image/NoContainerEngineEmptyScreen.svelte';
 import NavPage from '../ui/NavPage.svelte';
 import KubePlayIcon from '../kube/KubePlayIcon.svelte';
+import ErrorMessage from '../ui/ErrorMessage.svelte';
 
 let runStarted = false;
 let runFinished = false;
@@ -155,9 +156,7 @@ async function getKubernetesfileLocation() {
             complete...
           </div>
         {/if}
-        {#if runError}
-          <div class="text-red-500 text-sm">{runError}</div>
-        {/if}
+        <div class="text-sm"><ErrorMessage error="{runError}" /></div>
         {#if runFinished}
           <!-- On click, go BACK to the previous page (if clicked on Pods page, go back to pods, same for Containers)-->
           <button on:click="{() => history.back()}" class="w-full pf-c-button pf-m-primary">Done</button>

--- a/packages/renderer/src/lib/pod/DeployPodToKube.svelte
+++ b/packages/renderer/src/lib/pod/DeployPodToKube.svelte
@@ -5,6 +5,7 @@ import NavPage from '../ui/NavPage.svelte';
 import * as jsYaml from 'js-yaml';
 import type { V1Route } from '../../../../main/src/plugin/api/openshift-types';
 import type { V1NamespaceList } from '@kubernetes/client-node/dist/api';
+import ErrorMessage from '../ui/ErrorMessage.svelte';
 
 export let resourceId: string;
 export let engineId: string;
@@ -300,9 +301,7 @@ function updateKubeResult() {
           </button>
         </div>
       {/if}
-      {#if deployError}
-        <div class="text-red-500 text-sm">{deployError}</div>
-      {/if}
+      <ErrorMessage class="text-sm" error="{deployError}" />
 
       {#if createdPod}
         <div class="h-1/3 bg-zinc-900 p-5 my-4">

--- a/packages/renderer/src/lib/pod/PodCreateFromContainers.svelte
+++ b/packages/renderer/src/lib/pod/PodCreateFromContainers.svelte
@@ -6,6 +6,7 @@ import { PodCreation, podCreationHolder } from '../../stores/creation-from-conta
 import NavPage from '../ui/NavPage.svelte';
 import { router } from 'tinro';
 import type { Unsubscriber } from 'svelte/store';
+import ErrorMessage from '../ui/ErrorMessage.svelte';
 
 let podCreation: PodCreation;
 let createInProgress = false;
@@ -205,7 +206,7 @@ onDestroy(() => {
       </button>
 
       {#if createError}
-        <div class="pt-4 text-red-500 text-sm">{createError}</div>
+        <ErrorMessage class="pt-2 text-sm" error="{createError}" />
       {/if}
     </div>
   </div>

--- a/packages/renderer/src/lib/pod/PodDetails.svelte
+++ b/packages/renderer/src/lib/pod/PodDetails.svelte
@@ -16,6 +16,7 @@ import { faExclamationCircle } from '@fortawesome/free-solid-svg-icons';
 import Tooltip from '../ui/Tooltip.svelte';
 import Fa from 'svelte-fa/src/fa.svelte';
 import DetailsTab from '../ui/DetailsTab.svelte';
+import ErrorMessage from '../ui/ErrorMessage.svelte';
 
 export let podName: string;
 export let engineId: string;
@@ -110,9 +111,7 @@ function errorCallback(errorMessage: string): void {
                     ></path>
                   </svg>
                 {:else if pod.actionError}
-                  <Tooltip tip="{pod.actionError}" top>
-                    <Fa size="18" class="cursor-pointer text-red-500" icon="{faExclamationCircle}" />
-                  </Tooltip>
+                  <ErrorMessage error="{pod.actionError}" icon />
                 {:else}
                   <div>&nbsp;</div>
                 {/if}

--- a/packages/renderer/src/lib/pod/PodsList.svelte
+++ b/packages/renderer/src/lib/pod/PodsList.svelte
@@ -21,6 +21,7 @@ import Fa from 'svelte-fa/src/fa.svelte';
 import { faExclamationCircle } from '@fortawesome/free-solid-svg-icons';
 import Prune from '../engine/Prune.svelte';
 import type { EngineInfoUI } from '../engine/EngineInfoUI';
+import ErrorMessage from '../ui/ErrorMessage.svelte';
 
 let searchTerm = '';
 $: searchPattern.set(searchTerm);
@@ -331,9 +332,7 @@ function errorCallback(pod: PodInfoUI, errorMessage: string): void {
                       ></path>
                     </svg>
                   {:else if pod.actionError}
-                    <Tooltip tip="{pod.actionError}" top>
-                      <Fa size="18" class="cursor-pointer text-red-500" icon="{faExclamationCircle}" />
-                    </Tooltip>
+                    <ErrorMessage error="{pod.actionError}" icon />
                   {:else}
                     <div>&nbsp;</div>
                   {/if}

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationRendering.svelte
@@ -5,6 +5,7 @@ import PreferencesRenderingItemFormat from './PreferencesRenderingItemFormat.sve
 import type { Logger as LoggerType } from '@tmpwip/extension-api';
 import Logger from './Logger.svelte';
 import { writeToTerminal } from './Util';
+import ErrorMessage from '../ui/ErrorMessage.svelte';
 export let properties: IConfigurationPropertyRecordedSchema[] = [];
 export let providerInfo: ProviderInfo;
 export let propertyScope: string;
@@ -120,9 +121,7 @@ async function handleOnSubmit(e) {
       </div>
     {/if}
     {#if errorMessage}
-      <div class="text-red-500">
-        {errorMessage}
-      </div>
+      <ErrorMessage error="{errorMessage}" />
     {/if}
   {/if}
 </div>

--- a/packages/renderer/src/lib/preferences/PreferencesContainerConnectionRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesContainerConnectionRendering.svelte
@@ -10,6 +10,7 @@ import { router } from 'tinro';
 import Modal from '../dialogs/Modal.svelte';
 import Logger from './Logger.svelte';
 import { writeToTerminal } from './Util';
+import ErrorMessage from '../ui/ErrorMessage.svelte';
 
 export let properties: IConfigurationPropertyRecordedSchema[] = [];
 export let providerInternalId: string = undefined;
@@ -208,9 +209,7 @@ async function stopReceivingLogs(provider: ProviderInfo): Promise<void> {
     </div>
 
     {#if lifecycleError}
-      <div class="text-red-500">
-        {lifecycleError}
-      </div>
+      <ErrorMessage error="{lifecycleError}" />
     {/if}
   {/if}
 

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesConnectionRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesConnectionRendering.svelte
@@ -9,6 +9,7 @@ import type { ProviderInfo, ProviderKubernetesConnectionInfo } from '../../../..
 import { router } from 'tinro';
 import Modal from '../dialogs/Modal.svelte';
 import Logger from './Logger.svelte';
+import ErrorMessage from '../ui/ErrorMessage.svelte';
 
 export let properties: IConfigurationPropertyRecordedSchema[] = [];
 export let providerInternalId: string = undefined;
@@ -193,9 +194,7 @@ async function stopReceivingLogs(provider: ProviderInfo): Promise<void> {
     </div>
 
     {#if lifecycleError}
-      <div class="text-red-500">
-        {lifecycleError}
-      </div>
+      <ErrorMessage error="{lifecycleError}" />
     {/if}
   {/if}
 

--- a/packages/renderer/src/lib/preferences/PreferencesProviderRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesProviderRendering.svelte
@@ -10,6 +10,7 @@ import Modal from '../dialogs/Modal.svelte';
 import Logger from './Logger.svelte';
 import { writeToTerminal } from './Util';
 import PreferencesConnectionCreationRendering from './PreferencesConnectionCreationRendering.svelte';
+import ErrorMessage from '../ui/ErrorMessage.svelte';
 
 export let properties: IConfigurationPropertyRecordedSchema[] = [];
 export let providerInternalId: string = undefined;
@@ -120,9 +121,7 @@ async function stopReceivingLogs(provider: ProviderInfo): Promise<void> {
     </div>
 
     {#if providerLifecycleError}
-      <div class="text-red-500">
-        {providerLifecycleError}
-      </div>
+      <ErrorMessage error="{providerLifecycleError}" />
     {/if}
   {/if}
 

--- a/packages/renderer/src/lib/preferences/PreferencesRegistriesEditCreateRegistryModal.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRegistriesEditCreateRegistryModal.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import type { Registry } from '@tmpwip/extension-api';
 import { onMount } from 'svelte';
+import ErrorMessage from '../ui/ErrorMessage.svelte';
 import { createFieldValidator, requiredValidator, urlValidator } from '../validation/FieldValidation';
 
 export let toggleCallback: () => void;
@@ -101,10 +102,7 @@ const setType = (node: any) => {
           class="block disabled:opacity-75 disabled:text-gray-500 w-full px-3 py-2 mt-2 transition ease-in-out delay-50 text-sm text-gray-400 placeholder-gray-400 bg-[#111311] rounded-sm focus:outline-none focus:ring-1 focus:ring-gray-200 focus:ring-opacity-20" />
         <div class="h-3 mt-2 text-xs">
           {#if $serverUrlValidity.dirty && !$serverUrlValidity.valid}
-            <p class="text-red-500">
-              <i class="fas fa-exclamation-circle pr-1" aria-hidden="true"></i>
-              {$serverUrlValidity.message}
-            </p>
+            <ErrorMessage error="{$serverUrlValidity.message}" icon />
           {/if}
         </div>
       </div>
@@ -122,8 +120,7 @@ const setType = (node: any) => {
           class="block w-full w-full px-3 py-2 mt-2 transition ease-in-out delay-50 text-sm text-gray-400 placeholder-gray-400 bg-[#111311] rounded-sm focus:outline-none focus:ring-1 focus:ring-gray-200 focus:ring-opacity-20" />
         <p class="mt-2 text-xs text-red-500 h-3">
           {#if $userNameValidity.dirty && !$userNameValidity.valid}
-            <i class="fas fa-exclamation-circle pr-1" aria-hidden="true"></i>
-            {$userNameValidity.message}
+            <ErrorMessage error="{$userNameValidity.message}" icon />
           {/if}
         </p>
       </div>
@@ -157,19 +154,13 @@ const setType = (node: any) => {
           class="block w-full w-full px-3 py-2 mt-2 transition ease-in-out delay-50 text-sm text-gray-400 placeholder-gray-400 bg-[#111311] rounded-sm focus:outline-none focus:ring-1 focus:ring-gray-200 focus:ring-opacity-20" />
         <p class="mt-2 text-xs text-red-500 h-3">
           {#if $passwordValidity.dirty && !$passwordValidity.valid}
-            <i class="fas fa-exclamation-circle pr-1" aria-hidden="true"></i>
-            {$passwordValidity.message}
+            <ErrorMessage error="{$passwordValidity.message}" icon />
           {/if}
         </p>
       </div>
 
       {#if errorMessage}
-        <div class="">
-          <p class="mt-2 text-xs text-red-500 h-3">
-            <i class="fas fa-exclamation-circle pr-1" aria-hidden="true"></i>
-            {errorMessage}
-          </p>
-        </div>
+        <ErrorMessage class="mt-2 text-xs h-3" error="{errorMessage}" icon />
       {/if}
 
       <div class="text-center mt-6 mb-2">

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
@@ -3,6 +3,7 @@ import {
   CONFIGURATION_DEFAULT_SCOPE,
   IConfigurationPropertyRecordedSchema,
 } from '../../../../main/src/plugin/configuration-registry';
+import ErrorMessage from '../ui/ErrorMessage.svelte';
 
 let invalidEntry = false;
 let invalidText = undefined;
@@ -154,9 +155,7 @@ async function selectFilePath() {
     {/if}
 
     {#if invalidEntry}
-      <p class="pf-c-form__helper-text pf-m-error text:red-500" id="form-help-text-address-helper" aria-live="polite">
-        {invalidText}.
-      </p>
+      <ErrorMessage error="{invalidText}." />
     {/if}
   </div>
   {#if showUpdate}

--- a/packages/renderer/src/lib/ui/ErrorMessage.svelte
+++ b/packages/renderer/src/lib/ui/ErrorMessage.svelte
@@ -14,7 +14,9 @@ export let icon: boolean = false;
     </Tooltip>
   {/if}
 {:else}
-  <div class="text-red-500 p-1 flex flex-row items-center" class:opacity-0="{error == undefined || error === ''}">
+  <div
+    class="text-red-500 p-1 flex flex-row items-center {$$props.class}"
+    class:opacity-0="{error == undefined || error === ''}">
     <Fa size="18" class="cursor-pointer text-red-500" icon="{faExclamationCircle}" />
     <div class="ml-2">{error}</div>
   </div>


### PR DESCRIPTION
### What does this PR do?

This commit updates all remaining error messages to use the error message component.

I've added {$$props.class} to the component so that styling can be applied directly to the component. I've left if statements around the use in cases where we were not clearing the space unless an error existed.

The only remaining use of 'red-' is DeployPodToKube:342, but this is a status component not an error message.

### Screenshot/screencast of this PR

A couple examples:
<img width="623" alt="Screenshot 2023-03-02 at 8 29 01 AM" src="https://user-images.githubusercontent.com/19958075/222442275-60c3cb73-58e8-4bda-b41c-a970259a9379.png">
<img width="332" alt="Screenshot 2023-03-02 at 8 29 42 AM" src="https://user-images.githubusercontent.com/19958075/222442278-854296ee-70e0-4187-affb-c43b768fa5de.png">

### What issues does this PR fix or reference?

Final PR for issue #1365.

### How to test this PR?

Use the file names to find where each of these errors appear.