### PR TITLE
fix(ui): update the style of secondary button

### DIFF
--- a/packages/renderer/src/override.css
+++ b/packages/renderer/src/override.css
@@ -54,7 +54,7 @@
 
 .pf-c-button.pf-m-secondary {
   --pf-c-button--m-secondary--Color: #ddd;
-  --pf-c-button--m-secondary--BackgroundColor: rgb(156,163,175);
+  --pf-c-button--m-secondary--BackgroundColor: transparent;
   --pf-c-button--after--BorderColor: rgb(229,231,235);
 }
 


### PR DESCRIPTION

### What does this PR do?
While implementing task manager I noticed background color of 'secondary' buttons should be transparent and not greyed based on mockups

### Screenshot/screencast of this PR

before:

https://user-images.githubusercontent.com/436777/222455465-dcfaf149-f4e1-43f9-bac7-d85df2b72119.mp4

after:

https://user-images.githubusercontent.com/436777/222455871-fba420c1-0c7d-47e9-a1d0-25a2255fae82.mp4



### What issues does this PR fix or reference?

#1411 

### How to test this PR?

Try buttons like 'Create a new container dialog box"



Change-Id: Icdedb700993fd52147c9f50ba7e57a300ed5212c
