### PR TITLE
chore: allow to use /@/ alias for importing source code from the same module

### DIFF
--- a/packages/renderer/tsconfig.json
+++ b/packages/renderer/tsconfig.json
@@ -6,6 +6,11 @@
     "resolveJsonModule": true,
     "preserveValueImports": false,
     "baseUrl": ".",
+    "paths": {
+      "/@/*": [
+        "./src/*"
+      ]
+    },
     /**
      * Typecheck JS in `.svelte` and `.js` files by default.
      * Disable checkJs if you'd like to use dynamic types in JS.


### PR DESCRIPTION

### What does this PR do?
it would avoid to use the ../../../../path format and be more robust for code refactoring 

example: instead of

```ts
import {foo} from '../../../foo/bar.ts'
```
```ts
import {foo} from '/@/foo/bar.ts'
```


### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

N/A

### How to test this PR?

we can do that in packages/main but not in the renderer part

Change-Id: I24ca195e27cb7c61edaf4f17627a2cf36633387f
