### PR TITLE
Fix: directories inconsistency in ~/.local/share/

### DIFF
--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -24,7 +24,7 @@ import * as fs from 'node:fs';
 import { spawn } from 'node:child_process';
 import { RegistrySetup } from './registry-setup';
 
-import { getAssetsFolder, isLinux, isMac, isWindows } from './util';
+import { getAssetsFolder, isLinux, isMac, isWindows, appHomeDir } from './util';
 import { PodmanInstall } from './podman-install';
 import type { InstalledPodman } from './podman-cli';
 import { execPromise, getPodmanCli, getPodmanInstallation } from './podman-cli';
@@ -35,7 +35,7 @@ import { getDisguisedPodmanInformation, getSocketPath, isDisguisedPodman } from 
 type StatusHandler = (name: string, event: extensionApi.ProviderConnectionStatus) => void;
 
 const listeners = new Set<StatusHandler>();
-const podmanMachineSocketsDirectoryMac = path.resolve(os.homedir(), '.local/share/containers/podman/machine');
+const podmanMachineSocketsDirectoryMac = path.resolve(os.homedir(), appHomeDir(), 'machine');
 const podmanMachineSocketsSymlinkDirectoryMac = path.resolve(os.homedir(), '.podman');
 const MACOS_MAX_SOCKET_PATH_LENGTH = 104;
 let storedExtensionContext;

--- a/extensions/podman/src/util.ts
+++ b/extensions/podman/src/util.ts
@@ -33,6 +33,10 @@ const linux = os.platform() === 'linux';
 export function isLinux(): boolean {
   return linux;
 }
+const xdgDataDirectory = '.local/share/containers';
+export function appHomeDir(): string {
+  return xdgDataDirectory + '/podman';
+}
 
 /**
  * @returns true if app running in dev mode

--- a/packages/main/src/plugin/configuration-registry.ts
+++ b/packages/main/src/plugin/configuration-registry.ts
@@ -24,6 +24,7 @@ import { ConfigurationImpl } from './configuration-impl';
 import type { Event } from './events/emitter';
 import { Emitter } from './events/emitter';
 import { CONFIGURATION_DEFAULT_SCOPE } from './configuration-registry-constants';
+import { desktopAppHomeDir } from '../util';
 
 export type IConfigurationPropertySchemaType =
   | 'string'
@@ -114,7 +115,7 @@ export class ConfigurationRegistry implements IConfigurationRegistry {
   }
 
   protected getSettingsFile(): string {
-    const configurationDirectory = path.resolve(os.homedir(), '.local/share/containers/podman-desktop/configuration');
+    const configurationDirectory = path.resolve(os.homedir(), desktopAppHomeDir(), 'configuration');
     // create directory if it does not exist
     return path.resolve(configurationDirectory, 'settings.json');
   }

--- a/packages/main/src/plugin/contribution-manager.ts
+++ b/packages/main/src/plugin/contribution-manager.ts
@@ -20,6 +20,7 @@ import * as path from 'node:path';
 import * as os from 'node:os';
 import * as fs from 'node:fs';
 import type { ContributionInfo } from './api/contribution-info';
+import { desktopAppHomeDir } from '../util';
 
 /**
  * Contribution manager to provide the list of external OCI contributions
@@ -138,7 +139,7 @@ export class ContributionManager {
   }
 
   public getContributionStorageDir(): string {
-    return path.resolve(os.homedir(), '.local/share/containers/podman-desktop/contributions');
+    return path.resolve(os.homedir(), desktopAppHomeDir(), 'contributions');
   }
 
   getExtensionPath(extensionId: string): string | undefined {

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -43,6 +43,7 @@ import type { ContainerProviderRegistry } from './container-registry';
 import type { InputQuickPickRegistry } from './input-quickpick/input-quickpick-registry';
 import { QuickPickItemKind, InputBoxValidationSeverity } from './input-quickpick/input-quickpick-registry';
 import type { MenuRegistry } from '/@/plugin/menu-registry';
+import { desktopAppHomeDir } from '../util';
 
 /**
  * Handle the loading of an extension
@@ -76,11 +77,11 @@ export class ExtensionLoader {
   private reloadInProgressExtensions = new Map<string, boolean>();
 
   // Plugins directory location
-  private pluginsDirectory = path.resolve(os.homedir(), '.local/share/podman-desktop/plugins');
-  private pluginsScanDirectory = path.resolve(os.homedir(), '.local/share/podman-desktop/plugins-scanning');
+  private pluginsDirectory = path.resolve(os.homedir(), desktopAppHomeDir(), 'plugins');
+  private pluginsScanDirectory = path.resolve(os.homedir(), desktopAppHomeDir(), 'plugins-scanning');
 
   // Extensions directory location
-  private extensionsStorageDirectory = path.resolve(os.homedir(), '.local/share/podman-desktop/extensions-storage');
+  private extensionsStorageDirectory = path.resolve(os.homedir(), desktopAppHomeDir(), 'extensions-storage');
 
   constructor(
     private commandRegistry: CommandRegistry,

--- a/packages/main/src/util.ts
+++ b/packages/main/src/util.ts
@@ -31,6 +31,10 @@ const linux = os.platform() === 'linux';
 export function isLinux(): boolean {
   return linux;
 }
+const xdgDataDirectory = '.local/share/containers';
+export function desktopAppHomeDir(): string {
+  return xdgDataDirectory + '/podman-desktop';
+}
 
 export function findWindow(): Electron.BrowserWindow | undefined {
   return BrowserWindow.getAllWindows().find(w => !w.isDestroyed());


### PR DESCRIPTION
### What does this PR do?
Fixes directories inconsistency 
### Screenshot/screencast of this PR
N/A
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?
Related to issue https://github.com/containers/podman-desktop/issues/1429 and https://github.com/containers/podman-desktop/pull/1551, https://github.com/containers/podman-desktop/pull/1564 pulls
<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

### How to test this PR?
Install kind
Move directories under .local/share/podman-desktop/ into .local/share/containers/podman-desktop/
Ensure that plugins and extensions works same as before
<!-- Please explain steps to reproduce -->
