### PR TITLE
chore: move constant to a dedicated file so we can share it with renderer part properly

### DIFF
--- a/packages/main/src/plugin/configuration-impl.ts
+++ b/packages/main/src/plugin/configuration-impl.ts
@@ -17,7 +17,8 @@
  ***********************************************************************/
 
 import type * as containerDesktopAPI from '@podman-desktop/api';
-import { CONFIGURATION_DEFAULT_SCOPE } from './configuration-registry';
+import { CONFIGURATION_DEFAULT_SCOPE } from './configuration-registry-constants';
+
 /**
  * Local view of the configuration values for a given scope
  */

--- a/packages/main/src/plugin/configuration-registry-constants.ts
+++ b/packages/main/src/plugin/configuration-registry-constants.ts
@@ -1,0 +1,19 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+export const CONFIGURATION_DEFAULT_SCOPE = 'DEFAULT';

--- a/packages/main/src/plugin/configuration-registry.ts
+++ b/packages/main/src/plugin/configuration-registry.ts
@@ -23,8 +23,7 @@ import type * as containerDesktopAPI from '@podman-desktop/api';
 import { ConfigurationImpl } from './configuration-impl';
 import type { Event } from './events/emitter';
 import { Emitter } from './events/emitter';
-
-export const CONFIGURATION_DEFAULT_SCOPE = 'DEFAULT';
+import { CONFIGURATION_DEFAULT_SCOPE } from './configuration-registry-constants';
 
 export type IConfigurationPropertySchemaType =
   | 'string'

--- a/packages/main/src/plugin/telemetry/telemetry.ts
+++ b/packages/main/src/plugin/telemetry/telemetry.ts
@@ -25,7 +25,7 @@ import getos from 'getos';
 import * as osLocale from 'os-locale';
 import { promisify } from 'node:util';
 import type { ConfigurationRegistry, IConfigurationNode } from '../configuration-registry';
-import { CONFIGURATION_DEFAULT_SCOPE } from '../configuration-registry';
+import { CONFIGURATION_DEFAULT_SCOPE } from '../configuration-registry-constants';
 import { findWindow } from '../../util';
 
 /**

--- a/packages/renderer/src/PreferencesNavigation.svelte
+++ b/packages/renderer/src/PreferencesNavigation.svelte
@@ -3,7 +3,7 @@ import { onMount } from 'svelte';
 import { Buffer } from 'buffer';
 import { extensionInfos } from './stores/extensions';
 import { configurationProperties } from './stores/configurationProperties';
-import { CONFIGURATION_DEFAULT_SCOPE } from '../../main/src/plugin/configuration-registry';
+import { CONFIGURATION_DEFAULT_SCOPE } from '../../main/src/plugin/configuration-registry-constants';
 import type { ProviderInfo } from '../../main/src/plugin/api/provider-info';
 import { providerInfos } from './stores/providers';
 

--- a/packages/renderer/src/lib/preferences/PreferencesPage.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesPage.svelte
@@ -2,11 +2,8 @@
 import { configurationProperties } from '../../stores/configurationProperties';
 import { onMount } from 'svelte';
 import { Route } from 'tinro';
-import {
-  CONFIGURATION_DEFAULT_SCOPE,
-  IConfigurationPropertyRecordedSchema,
-} from '../../../../main/src/plugin/configuration-registry';
-
+import type { IConfigurationPropertyRecordedSchema } from '../../../../main/src/plugin/configuration-registry';
+import { CONFIGURATION_DEFAULT_SCOPE } from '../../../../main/src/plugin/configuration-registry-constants';
 import PreferencesRendering from './PreferencesRendering.svelte';
 import PreferencesContainerConnectionRendering from './PreferencesContainerConnectionRendering.svelte';
 import PreferencesKubernetesConnectionRendering from './PreferencesKubernetesConnectionRendering.svelte';

--- a/packages/renderer/src/lib/preferences/PreferencesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRendering.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
-import {
-  CONFIGURATION_DEFAULT_SCOPE,
-  IConfigurationPropertyRecordedSchema,
-} from '../../../../main/src/plugin/configuration-registry';
+import type { IConfigurationPropertyRecordedSchema } from '../../../../main/src/plugin/configuration-registry';
+import { CONFIGURATION_DEFAULT_SCOPE } from '../../../../main/src/plugin/configuration-registry-constants';
+
 import PreferencesRenderingItem from './PreferencesRenderingItem.svelte';
 
 export let properties: IConfigurationPropertyRecordedSchema[] = [];

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
@@ -1,8 +1,6 @@
 <script lang="ts">
-import {
-  CONFIGURATION_DEFAULT_SCOPE,
-  IConfigurationPropertyRecordedSchema,
-} from '../../../../main/src/plugin/configuration-registry';
+import type { IConfigurationPropertyRecordedSchema } from '../../../../main/src/plugin/configuration-registry';
+import { CONFIGURATION_DEFAULT_SCOPE } from '../../../../main/src/plugin/configuration-registry-constants';
 import ErrorMessage from '../ui/ErrorMessage.svelte';
 
 let invalidEntry = false;


### PR DESCRIPTION
### What does this PR do?
extract constant to a separate file so we avoid to pull stuff in renderer part.
Avoid to have renderer part depending on internals from configuration-registry related to https://github.com/containers/podman-desktop/pull/1605


### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

https://github.com/containers/podman-desktop/pull/1605

### How to test this PR?

<!-- Please explain steps to reproduce -->


Change-Id: I8389e3bab16f013e2e0e0feb1abb0253f2f938dc
