### PR TITLE
fix: check and refresh Podman container engine connection on Windows/Mac (#1446)

### DIFF
--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -100,7 +100,7 @@ async function updateMachines(provider: extensionApi.Provider): Promise<void> {
 
     if (!podmanMachinesStatuses.has(machine.Name)) {
       podmanMachinesStatuses.set(machine.Name, status);
-    }    
+    }
   });
 
   // remove machine no longer there
@@ -271,7 +271,7 @@ function stopMonitoringPodmanSocket(machineName?: string) {
   if (machineName) {
     return stopLoop || !podmanMachinesStatuses.has(machineName);
   }
-  return stopLoop; 
+  return stopLoop;
 }
 
 function updateProviderStatus(status: extensionApi.ProviderConnectionStatus, machineName?: string) {


### PR DESCRIPTION
### What does this PR do?

This is the part related to Windows/Mac of #1446. The Linux PR was https://github.com/containers/podman-desktop/pull/1590
This adds a periodic check on the podman socket so that the dashboard is updated accordingly

### Screenshot/screencast of this PR

![windows-socket](https://user-images.githubusercontent.com/49404737/224645774-c2097904-787d-49e6-8796-d652e57b44bc.gif)

### What issues does this PR fix or reference?

it resolves #1446

### How to test this PR?

1. login into your podman machine.  `wsl -d podman-machine-default` in my case
2. remove temporarily the socket file in `/run/user/$UID/podman/`
3. the dashboard should refresh
4. add it again
5. the dashboard should display resources as before
