### PR TITLE
fix: Remove nav page subtitles

### DIFF
--- a/packages/renderer/src/lib/ContainerList.svelte
+++ b/packages/renderer/src/lib/ContainerList.svelte
@@ -315,10 +315,7 @@ function errorCallback(container: ContainerInfoUI, errorMessage: string): void {
 }
 </script>
 
-<NavPage
-  bind:searchTerm="{searchTerm}"
-  title="containers"
-  subtitle="Hover over a container to view action buttons; click to open up full details.">
+<NavPage bind:searchTerm="{searchTerm}" title="containers">
   <div slot="additional-actions" class="space-x-2 flex flex-nowrap">
     <!-- Only show if there are containers-->
     {#if $containersInfos.length > 0}

--- a/packages/renderer/src/lib/ImagesList.svelte
+++ b/packages/renderer/src/lib/ImagesList.svelte
@@ -209,10 +209,7 @@ function computeInterval(): number {
 }
 </script>
 
-<NavPage
-  bind:searchTerm="{searchTerm}"
-  title="images"
-  subtitle="Hover over an image to view action buttons; click to open up full details.">
+<NavPage bind:searchTerm="{searchTerm}" title="images">
   <div slot="additional-actions" class="space-x-2 flex flex-nowrap">
     {#if $imagesInfos.length > 0}
       <Prune type="images" engines="{enginesList}" />

--- a/packages/renderer/src/lib/dashboard/DashboardPage.svelte
+++ b/packages/renderer/src/lib/dashboard/DashboardPage.svelte
@@ -18,7 +18,7 @@ $: providersStarting = $providerInfos.filter(provider => provider.status === 'st
 $: providersStopped = $providerInfos.filter(provider => provider.status === 'stopped');
 </script>
 
-<NavPage searchEnabled="{false}" title="Dashboard" subtitle="&nbsp;">
+<NavPage searchEnabled="{false}" title="Dashboard">
   <div slot="empty" class="flex flex-col min-h-full bg-zinc-700">
     <div class="min-w-full flex-1">
       <div class="pt-5 px-5 space-y-5">

--- a/packages/renderer/src/lib/image/RunImage.svelte
+++ b/packages/renderer/src/lib/image/RunImage.svelte
@@ -386,10 +386,7 @@ function checkContainerName(event: any) {
 
 <Route path="/*" let:meta>
   {#if dataReady}
-    <NavPage
-      title="Create a container from image {imageDisplayName}"
-      searchEnabled="{false}"
-      subtitle="{image.tag}@{image.shortId} ">
+    <NavPage title="Create a container from image {imageDisplayName}" searchEnabled="{false}">
       <div slot="empty" class="bg-zinc-700 p-5 h-full">
         <div class="bg-zinc-800 px-6 py-4 space-y-2 lg:px-8 sm:pb-6 xl:pb-8">
           <section class="pf-c-page__main-tabs pf-m-limit-width">

--- a/packages/renderer/src/lib/image/RunImage.svelte
+++ b/packages/renderer/src/lib/image/RunImage.svelte
@@ -386,7 +386,7 @@ function checkContainerName(event: any) {
 
 <Route path="/*" let:meta>
   {#if dataReady}
-    <NavPage title="Create a container from image {imageDisplayName}" searchEnabled="{false}">
+    <NavPage title="Create a container from image {imageDisplayName}:{image.tag}" searchEnabled="{false}">
       <div slot="empty" class="bg-zinc-700 p-5 h-full">
         <div class="bg-zinc-800 px-6 py-4 space-y-2 lg:px-8 sm:pb-6 xl:pb-8">
           <section class="pf-c-page__main-tabs pf-m-limit-width">

--- a/packages/renderer/src/lib/pod/PodCreateFromContainers.svelte
+++ b/packages/renderer/src/lib/pod/PodCreateFromContainers.svelte
@@ -121,7 +121,7 @@ onDestroy(() => {
 });
 </script>
 
-<NavPage title="Copy containers to a pod" searchEnabled="{false}" subtitle="Create a pod from containers">
+<NavPage title="Copy containers to a pod" searchEnabled="{false}">
   <div class="w-full h-full" slot="empty">
     <div class="m-5 p-5 h-full bg-zinc-900 rounded-sm text-gray-400">
       {#if podCreation}

--- a/packages/renderer/src/lib/pod/PodsList.svelte
+++ b/packages/renderer/src/lib/pod/PodsList.svelte
@@ -209,10 +209,7 @@ function errorCallback(pod: PodInfoUI, errorMessage: string): void {
 }
 </script>
 
-<NavPage
-  bind:searchTerm="{searchTerm}"
-  title="pods"
-  subtitle="Hover over a pod to view action buttons; click to open up full details.">
+<NavPage bind:searchTerm="{searchTerm}" title="pods">
   <div slot="additional-actions" class="space-x-2 flex flex-nowrap">
     {#if $podsInfos.length > 0}
       <Prune type="pods" engines="{enginesList}" />

--- a/packages/renderer/src/lib/preferences/PreferencesPage.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesPage.svelte
@@ -34,7 +34,7 @@ onMount(async () => {
 });
 </script>
 
-<NavPage searchEnabled="{false}" title="Settings" subtitle="&nbsp;">
+<NavPage searchEnabled="{false}" title="Settings">
   <div slot="empty" class="flex h-full px-3 py-3 bg-zinc-700">
     <Route path="/">
       {#if defaultPrefPageId !== undefined}

--- a/packages/renderer/src/lib/ui/NavPage.svelte
+++ b/packages/renderer/src/lib/ui/NavPage.svelte
@@ -1,28 +1,24 @@
 <script lang="ts">
 export let title: string;
-export let subtitle: string = '';
 export let searchTerm = '';
 export let searchEnabled: boolean = true;
 </script>
 
 <div class="flex flex-col min-h-full min-w-full">
-  <div class="min-w-full">
+  <div class="min-w-full pt-4" class:pb-4="{!searchEnabled}">
     <div class="flex">
-      <div class="pt-5 px-5">
+      <div class="px-5">
         <p class="text-xl first-letter:uppercase">{title}</p>
-        <p class="text-sm text-gray-400">
-          {subtitle}
-        </p>
       </div>
       <div class="flex flex-1 justify-end">
-        <div class="py-5 px-5">
+        <div class="px-5">
           <slot name="additional-actions">&nbsp;</slot>
         </div>
       </div>
     </div>
     {#if searchEnabled}
-      <div class="flex flex-row pb-4">
-        <div class="pt-2 pl-5 lg:w-[35rem] w-[22rem]">
+      <div class="flex flex-row pt-2 pb-4">
+        <div class="pl-5 lg:w-[35rem] w-[22rem]">
           <div class="flex items-center bg-zinc-900 text-gray-400 rounded-sm">
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -44,7 +40,7 @@ export let searchEnabled: boolean = true;
               class="w-full py-2 outline-none text-sm bg-zinc-900 rounded-sm text-gray-400 placeholder-gray-400" />
           </div>
         </div>
-        <div class="flex flex-1 pt-4 px-5">
+        <div class="flex flex-1 px-5">
           <slot name="bottom-additional-actions">&nbsp;</slot>
         </div>
       </div>

--- a/packages/renderer/src/lib/volume/VolumesList.svelte
+++ b/packages/renderer/src/lib/volume/VolumesList.svelte
@@ -176,10 +176,7 @@ function computeInterval(): number {
 }
 </script>
 
-<NavPage
-  bind:searchTerm="{searchTerm}"
-  title="volumes"
-  subtitle="Hover over a volume to view action buttons; click to open up full details.">
+<NavPage bind:searchTerm="{searchTerm}" title="volumes">
   <div slot="additional-actions" class="space-x-2 flex flex-nowrap">
     {#if $volumeListInfos.map(volumeInfo => volumeInfo.Volumes).flat().length > 0}
       <Prune type="volumes" engines="{enginesList}" />


### PR DESCRIPTION
### What does this PR do?

The subtitles for the list views said "Hover over X to view action buttons; ...", which is out of date with the current UI. We started to have a discussion about what to change it to on Thursday afternoon, but then decided that our UI is obvious enough and we prefer the clean look.

I reviewed the other places that had subtitles, and all of these either used &nbsp to keep the layout consistent, or had subtitles that didn't add anything significant beyond the title, so I am removing the ability to add subtitles entirely (git history remains if we ever need it again).

Tweaked nav page layout so that the lower padding remains the same size with or without the search bar.

### Screenshot/screencast of this PR

<img width="574" alt="Screenshot 2023-03-13 at 8 00 06 AM" src="https://user-images.githubusercontent.com/19958075/224695922-b8736fd1-7947-4c5e-9186-97e587373225.png">

### What issues does this PR fix or reference?

N/A, related to PR #1642.