### PR TITLE
docs: add chore to contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -161,12 +161,12 @@ Some examples for correct titles would be:
 
 For Podman Desktop we use the following types:
 
-
+* `fix:` A bug fix
+* `chore:` Very small change / insignificant impact
+* `docs:` Documentation only changes (ex. website)
 * `build:` Changes that affect the build system
 * `ci:` Changes to the CI (ex. GitHub actions)
-* `docs:` Documentation only changes (ex. website)
 * `feat:` A new feature
-* `fix:` A bug fix
 * `perf:` A code change that improves performance
 * `refactor:` A code change that neither fixes a bug nor adds a feature
 * `style:` Changes that affect the formatting, but not the ability of the code


### PR DESCRIPTION
docs: add chore to contributing.md

### What does this PR do?

Adds missing part for chore description / reorders the section so that
it's similar to the "example" part

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

N/A

### What issues does this PR fix or reference?

N/A

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

### How to test this PR?

N/A

<!-- Please explain steps to reproduce -->

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
