### PR TITLE
chore: revert svelte update

### DIFF
--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -27,7 +27,7 @@
     "monaco-editor": "^0.36.1",
     "postcss": "^8.4.21",
     "postcss-load-config": "^4.0.1",
-    "svelte": "^3.56.0",
+    "svelte": "3.55.1",
     "svelte-check": "^2.10.3",
     "svelte-fa": "^3.0.3",
     "svelte-preprocess": "^5.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11601,14 +11601,15 @@ svelte-preprocess@^5.0.1:
     sorcery "^0.11.0"
     strip-indent "^3.0.0"
 
-svelte@^3.56.0:
-  version "3.56.0"
-  resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.56.0.tgz#0fe159e2e342cc3d430c7ff219315d1ea681c7b4"
-  integrity sha512-LvXiJbjdvJKwB/0CQyYpDX0q+hFqCyWmybzC2G6eK1tJJA/RSRCytTfNmjHv+RHlLuA70vWG7nXp6gbeErYvRA==
 svelte-steps@2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/svelte-steps/-/svelte-steps-2.4.1.tgz#64e055735818e81454e1ca5be8b7b9fe23a8b239"
   integrity sha512-2Xq2lLcGJf3PaEY46f1w5s+/O+tLl4U2V+Z+sCeoUm/kEPFXeZP/aFr2JVKwdzSlXCT+raz75xqXtnZrPWJ0zA==
+
+svelte@3.55.1:
+  version "3.55.1"
+  resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.55.1.tgz#6f93b153e5248039906ce5fe196efdb9e05dfce8"
+  integrity sha512-S+87/P0Ve67HxKkEV23iCdAh/SX1xiSfjF1HOglno/YTbSTW7RniICMCofWGdJJbdjw3S+0PfFb1JtGfTXE0oQ==
 
 svg-parser@^2.0.2:
   version "2.0.4"


### PR DESCRIPTION
### What does this PR do?
settings page tree is broken after svelte update from 3.55 to 3.56

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

Fixes #1678 
and more

### How to test this PR?

Go in settings page, you should see a non-broken tree and see preferences as well

Change-Id: I9b73a4355d548a3dc634afbea7d2b21a1c7b80e5
