### PR TITLE
fix: 404 page not found on kubernetes deploy (#1318)

### DIFF
--- a/packages/renderer/src/lib/pod/DeployPodToKube.svelte
+++ b/packages/renderer/src/lib/pod/DeployPodToKube.svelte
@@ -146,7 +146,7 @@ async function deployToKube() {
           };
           servicesToCreate.push(service);
 
-          if (openOpenshiftConsole && deployUsingRoutes) {
+          if (openshiftConsoleURL && deployUsingRoutes) {
             // Create OpenShift route object
             const route = {
               apiVersion: 'route.openshift.io/v1',


### PR DESCRIPTION
### What does this PR do?

it prevents from showing `404 page not found` error when deploying on a kubernetes cluster.

The problem was that it tried to create a route even if it was not an OCP cluster.

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

it resolves #1318 

### How to test this PR?

1. use a kubernetes cluster (i used minikube, charlie k0s)
2. try to deploy a pod
