### PR TITLE
fix: logs inconsistency behavior (#1356)

### DIFF
--- a/packages/renderer/src/lib/ContainerDetailsLogs.svelte
+++ b/packages/renderer/src/lib/ContainerDetailsLogs.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 import type { ContainerInfoUI } from './container/ContainerInfoUI';
-import { router } from 'tinro';
 import { onDestroy, onMount } from 'svelte';
 import { Terminal } from 'xterm';
 import { FitAddon } from 'xterm-addon-fit';
@@ -16,7 +15,7 @@ export let container: ContainerInfoUI;
 
 // Log
 let logsXtermDiv: HTMLDivElement;
-let logsContainer;
+let refContainer;
 // logs has been initialized
 let noLogs = true;
 
@@ -24,12 +23,16 @@ let noLogs = true;
 let resizeObserver: ResizeObserver;
 let termFit: FitAddon;
 
-// need to refresh logs when container is switched
+// need to refresh logs when container is switched or state changes
 $: {
-  if (logsContainer?.id !== container.id || logsContainer?.state != container.state) {
+  if (
+    refContainer &&
+    (refContainer.id !== container.id || (refContainer.state != container.state && container.state !== 'EXITED'))
+  ) {
     logsTerminal?.clear();
+    fetchContainerLogs();
   }
-  logsContainer = container;
+  refContainer = container;
 }
 
 let currentRouterPath: string;

--- a/packages/renderer/src/lib/pod/PodDetailsLogs.svelte
+++ b/packages/renderer/src/lib/pod/PodDetailsLogs.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-import { router } from 'tinro';
 import { onDestroy, onMount } from 'svelte';
 import { Terminal } from 'xterm';
 import { FitAddon } from 'xterm-addon-fit';
@@ -15,10 +14,19 @@ export let pod: PodInfoUI;
 
 // Log
 let logsXtermDiv: HTMLDivElement;
-
+let refPod;
 // Logs has been initialized
 let noLogs = true;
 let logsTerminal: Terminal;
+
+// need to refresh logs when pod is switched or state changes
+$: {
+  if (refPod && (refPod.id !== pod.id || (refPod.status != pod.status && pod.status !== 'EXITED'))) {
+    logsTerminal?.clear();
+    fetchPodLogs();
+  }
+  refPod = pod;
+}
 
 // Terminal resize
 let resizeObserver: ResizeObserver;


### PR DESCRIPTION
### What does this PR do?

This PR fixes the behavior of the logs view with containers/pods.

In the current main branch if you are in the container logs view and you stop the container, the logs console gets emptied. If you start it again nothing is printed.

In the pod logs view if you stop it you still see the logs, if you start it again the logs are not updated.

This PR fixes this behavior.
If you are in the logs view (pod/container) and you stop the resource, the logs stay there. If you start it, the logs view is refreshed.

### Screenshot/screencast of this PR

![container-pod-logs](https://user-images.githubusercontent.com/49404737/225328374-58797d52-80cd-4c25-8e28-dd21c1e027c8.gif)

### What issues does this PR fix or reference?

this fixes #1356 

### How to test this PR?

1. open a container, go to its logs tab
2. if it's running, stop it. The logs should still show the logs
3. start it again, the logs view should be refreshed
4. repeat with a pod
