### PR TITLE
feat: Plug building of an image into the task manager

### DIFF
--- a/packages/renderer/src/lib/image/BuildImageFromContainerfile.svelte
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfile.svelte
@@ -58,7 +58,7 @@ async function buildContainerImage(): Promise<void> {
     // extract the relative path from the containerFilePath and containerBuildContextDirectory
     const relativeContainerfilePath = containerFilePath.substring(containerBuildContextDirectory.length + 1);
 
-    buildImageKey = startBuild(getTerminalCallback());
+    buildImageKey = startBuild(containerImageName, getTerminalCallback());
     // store the key
     buildImagesInfo.set({ buildImageKey: buildImageKey });
     try {

--- a/packages/renderer/src/lib/image/build-image-task.spec.ts
+++ b/packages/renderer/src/lib/image/build-image-task.spec.ts
@@ -32,7 +32,7 @@ test('check start build', async () => {
     onEnd: vi.fn(),
   };
 
-  const key = startBuild(dummyCallback);
+  const key = startBuild('foo', dummyCallback);
   expect(key).toBeDefined();
 });
 
@@ -49,7 +49,7 @@ test('check reconnect', async () => {
     onEnd: vi.fn(),
   };
 
-  const firstKey = startBuild(dummyCallback);
+  const firstKey = startBuild('foo', dummyCallback);
 
   // stream some stuff
   eventCollect(firstKey, 'stream', 'hello');


### PR DESCRIPTION

### What does this PR do?
Allow to go back to a build of OCI image through the task manager

depends on
 - [ ] https://github.com/containers/podman-desktop/pull/1724

### Screenshot/screencast of this PR

https://user-images.githubusercontent.com/436777/225675346-c277d671-780a-49c3-baa3-5acb69e28ff9.mp4


### What issues does this PR fix or reference?

first step of https://github.com/containers/podman-desktop/issues/1343

### How to test this PR?

Needs to apply first https://github.com/containers/podman-desktop/pull/1724

then, check that if you start to build an image, you see the task in the task manager and you can go back to it.

Change-Id: If60f491744b200f65e267c22559739ec313a7edf
