### PR TITLE
chore: publish to npmjs the API module for releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -231,3 +231,21 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           id: ${{ needs.tag.outputs.releaseId}}
+
+  publish:
+    needs: [tag, release]
+    name: Publish
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - name: Set-up npmjs auth token
+        run: printf "//registry.npmjs.org/:_authToken=${{ secrets.NPM_AUTH_TOKEN }}\n" >> ~/.npmrc
+
+      - name: Publish API to npmjs
+        run: |
+          echo "Using version ${{ needs.tag.outputs.desktopVersion }}"
+          sed -i  "s#version\":\ \"\(.*\)\",#version\":\ \"${{ needs.tag.outputs.desktopVersion }}\",#g" packages/extension-api/package.json
+          cd packages/extension-api && yarn publish --tag latest --no-git-tag-version --new-version "${{ needs.tag.outputs.desktopVersion }}" --access public


### PR DESCRIPTION
### What does this PR do?
For now API is published only on each commit with the next alias
here we should publish for releases under the `latest` tag

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/1468

### How to test this PR?

N/A

Change-Id: I4287d2c311e989e756fafee47ab2091eb40d9916
