### PR TITLE
chore: update to svelte preprocess 5.0.3

### DIFF
--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -30,7 +30,7 @@
     "svelte": "3.57.0",
     "svelte-check": "^2.10.3",
     "svelte-fa": "^3.0.3",
-    "svelte-preprocess": "^5.0.2",
+    "svelte-preprocess": "^5.0.3",
     "tailwindcss": "^3.2.7",
     "tslib": "^2.5.0",
     "typescript": "^4.9.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11597,10 +11597,10 @@ svelte-preprocess@^4.0.0:
     sorcery "^0.10.0"
     strip-indent "^3.0.0"
 
-svelte-preprocess@^5.0.2:
-  version "5.0.2"
-  resolved "https://registry.yarnpkg.com/svelte-preprocess/-/svelte-preprocess-5.0.2.tgz#72e31adb559732aa6811b5449058d231c0974f95"
-  integrity sha512-iXpIoa43VdF7fPkBdoodztZd4H+3EP/GYA66tbuLVtQnM3sWCpsOtc7HjfA7BDR+6VTpqlEnpDmPoXk0dgUa0g==
+svelte-preprocess@^5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/svelte-preprocess/-/svelte-preprocess-5.0.3.tgz#431d538d457d3a5ba470a5ae5754a5aeb76579c8"
+  integrity sha512-GrHF1rusdJVbOZOwgPWtpqmaexkydznKzy5qIC2FabgpFyKN57bjMUUUqPRfbBXK5igiEWn1uO/DXsa2vJ5VHA==
   dependencies:
     "@types/pug" "^2.0.6"
     detect-indent "^6.1.0"


### PR DESCRIPTION

### What does this PR do?
fixing some issues with TypeScript 5.0
https://github.com/sveltejs/svelte-preprocess/blob/main/CHANGELOG.md#503-2023-03-17

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

unable to update to TypeScript 5.0
https://github.com/containers/podman-desktop/pull/1730

### How to test this PR?

Should work as usual


Change-Id: Iabfce8a8aa6c61e7f72a2bb319d13ad8ff67e9d5

