### PR TITLE
feat: allow to resume/see task for creating a podman provider

### DIFF
--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -61,6 +61,15 @@ export interface FeedbackProperties {
   contact?: string;
 }
 
+export interface KeyLogger {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  log(key: symbol, ...data: any[]): void;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  error(key: symbol, ...data: any[]): void;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  warn(key: symbol, ...data: any[]): void;
+}
+
 // initialize extension loader mechanism
 function initExposure(): void {
   const eventEmitter = new EventEmitter();
@@ -504,7 +513,11 @@ function initExposure(): void {
 
   let onDataCallbacksCreateConnectionId = 0;
 
-  const onDataCallbacksCreateConnectionLogs = new Map<number, containerDesktopAPI.Logger>();
+  const onDataCallbacksCreateConnectionLogs = new Map<
+    number,
+    (key: symbol, eventName: 'log' | 'warn' | 'error' | 'finish', args: unknown[]) => void
+  >();
+  const onDataCallbacksCreateConnectionKeys = new Map<number, symbol>();
 
   contextBridge.exposeInMainWorld(
     'createContainerProviderConnection',
@@ -512,10 +525,12 @@ function initExposure(): void {
       internalProviderId: string,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       params: { [key: string]: any },
-      logger: containerDesktopAPI.Logger,
+      key: symbol,
+      keyLogger: (key: symbol, eventName: 'log' | 'warn' | 'error' | 'finish', args: unknown[]) => void,
     ): Promise<void> => {
       onDataCallbacksCreateConnectionId++;
-      onDataCallbacksCreateConnectionLogs.set(onDataCallbacksCreateConnectionId, logger);
+      onDataCallbacksCreateConnectionKeys.set(onDataCallbacksCreateConnectionId, key);
+      onDataCallbacksCreateConnectionLogs.set(onDataCallbacksCreateConnectionId, keyLogger);
       return ipcInvoke(
         'provider-registry:createContainerProviderConnection',
         internalProviderId,
@@ -531,10 +546,12 @@ function initExposure(): void {
       internalProviderId: string,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       params: { [key: string]: any },
-      logger: containerDesktopAPI.Logger,
+      key: symbol,
+      keyLogger: (key: symbol, eventName: 'log' | 'warn' | 'error' | 'finish', args: unknown[]) => void,
     ): Promise<void> => {
       onDataCallbacksCreateConnectionId++;
-      onDataCallbacksCreateConnectionLogs.set(onDataCallbacksCreateConnectionId, logger);
+      onDataCallbacksCreateConnectionKeys.set(onDataCallbacksCreateConnectionId, key);
+      onDataCallbacksCreateConnectionLogs.set(onDataCallbacksCreateConnectionId, keyLogger);
       return ipcInvoke(
         'provider-registry:createKubernetesProviderConnection',
         internalProviderId,
@@ -549,13 +566,16 @@ function initExposure(): void {
     (_, onDataCallbacksCreateConnectionId: number, channel: string, data: unknown[]) => {
       // grab callback from the map
       const callback = onDataCallbacksCreateConnectionLogs.get(onDataCallbacksCreateConnectionId);
-      if (callback) {
+      const key = onDataCallbacksCreateConnectionKeys.get(onDataCallbacksCreateConnectionId);
+      if (callback && key) {
         if (channel === 'log') {
-          callback.log(data);
+          callback(key, 'log', data);
         } else if (channel === 'warn') {
-          callback.warn(data);
+          callback(key, 'warn', data);
         } else if (channel === 'error') {
-          callback.error(data);
+          callback(key, 'error', data);
+        } else if (channel === 'finish') {
+          callback(key, 'finish', data);
         }
       }
     },

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationRendering.spec.ts
@@ -1,0 +1,88 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-unused-vars */
+/* eslint-disable @typescript-eslint/no-empty-function */
+
+import '@testing-library/jest-dom';
+import { beforeAll, test, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/svelte';
+import PreferencesConnectionCreationRendering from './PreferencesConnectionCreationRendering.svelte';
+import type { IConfigurationPropertyRecordedSchema } from '../../../../main/src/plugin/configuration-registry';
+import type { ProviderInfo } from '../../../../main/src/plugin/api/provider-info';
+import { get } from 'svelte/store';
+import { createConnectionsInfo } from '/@/stores/create-connections';
+
+const properties: IConfigurationPropertyRecordedSchema[] = [];
+const providerInfo: ProviderInfo = {
+  id: 'test',
+} as unknown as ProviderInfo;
+const propertyScope = 'FOO';
+
+test('Expect that the create button is available', async () => {
+  const callback = vi.fn();
+  render(PreferencesConnectionCreationRendering, { properties, providerInfo, propertyScope, callback });
+  const createButton = screen.getByRole('button', { name: 'Create' });
+  expect(createButton).toBeInTheDocument();
+  expect(createButton).toBeEnabled();
+});
+
+test('Expect create connection successfully', async () => {
+  let providedKeyLogger;
+
+  const callback = vi.fn();
+  callback.mockImplementation(async function (
+    _id: string,
+    _params: unknown,
+    _key: unknown,
+    keyLogger: (key: symbol, eventName: 'log' | 'warn' | 'error' | 'finish', args: unknown[]) => void,
+  ): Promise<void> {
+    // keep reference
+    providedKeyLogger = keyLogger;
+  });
+
+  render(PreferencesConnectionCreationRendering, { properties, providerInfo, propertyScope, callback });
+  const createButton = screen.getByRole('button', { name: 'Create' });
+  expect(createButton).toBeInTheDocument();
+  // click on the button
+  await fireEvent.click(createButton);
+
+  // do we have a task
+  const currentConnectionInfo = get(createConnectionsInfo);
+
+  expect(currentConnectionInfo).toBeDefined();
+  expect(currentConnectionInfo.creationInProgress).toBeTruthy();
+  expect(currentConnectionInfo.creationStarted).toBeTruthy();
+  expect(currentConnectionInfo.creationSuccessful).toBeFalsy();
+
+  expect(currentConnectionInfo.propertyScope).toBe(propertyScope);
+  expect(currentConnectionInfo.providerInfo).toBe(providerInfo);
+
+  expect(callback).toHaveBeenCalled();
+  expect(providedKeyLogger).toBeDefined();
+
+  // simulate end of the create operation
+  providedKeyLogger(currentConnectionInfo.createKey, 'finish', []);
+
+  // expect it is sucessful
+  const currentConnectionInfoAfter = get(createConnectionsInfo);
+  expect(currentConnectionInfoAfter.creationInProgress).toBeFalsy();
+  expect(currentConnectionInfoAfter.creationStarted).toBeTruthy();
+  expect(currentConnectionInfoAfter.creationSuccessful).toBeTruthy();
+});

--- a/packages/renderer/src/lib/preferences/preferences-connection-rendering-task.spec.ts
+++ b/packages/renderer/src/lib/preferences/preferences-connection-rendering-task.spec.ts
@@ -1,0 +1,90 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { get } from 'svelte/store';
+import { beforeEach, expect, test, vi } from 'vitest';
+import type { CreateConnectionCallback } from './preferences-connection-rendering-task';
+import { disconnectUI, eventCollect, reconnectUI } from './preferences-connection-rendering-task';
+import { startCreate, clearCreateTask } from './preferences-connection-rendering-task';
+import { tasksInfo } from '/@/stores/tasks';
+
+const dummyCallback: CreateConnectionCallback = {
+  log: vi.fn(),
+  error: vi.fn(),
+  warn: vi.fn(),
+  onEnd: vi.fn(),
+};
+
+const newCallback: CreateConnectionCallback = {
+  log: vi.fn(),
+  error: vi.fn(),
+  warn: vi.fn(),
+  onEnd: vi.fn(),
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+test('check start build', async () => {
+  const id = '1';
+  const key = startCreate('foo', id, dummyCallback);
+  expect(key).toBeDefined();
+  const allTasks = get(tasksInfo);
+  const matchingTask = allTasks.find(task => task.id === id);
+  expect(matchingTask).toBeDefined();
+  clearCreateTask(key);
+  const allTasksAfter = get(tasksInfo);
+  const matchingTaskAfter = allTasksAfter.find(task => task.id === id);
+  expect(matchingTaskAfter).toBeUndefined();
+});
+
+test('check reconnect', async () => {
+  const firstKey = startCreate('bar', '2', dummyCallback);
+
+  // stream some stuff
+  eventCollect(firstKey, 'log', ['hello']);
+  eventCollect(firstKey, 'log', ['world']);
+
+  disconnectUI(firstKey);
+
+  // send event while there is no UI connected
+  eventCollect(firstKey, 'log', ['during disconnect']);
+  eventCollect(firstKey, 'finish', []);
+
+  reconnectUI(firstKey, newCallback);
+
+  // check that we've replayed everything (including events that happened while there was no UI connected)
+  expect(newCallback.log).toHaveBeenCalledWith([['hello'], ['world'], ['during disconnect']]);
+  expect(newCallback.onEnd).toHaveBeenCalledTimes(1);
+});
+
+test('check events', async () => {
+  const firstKey = startCreate('baz', '3', dummyCallback);
+
+  // stream some stuff
+  eventCollect(firstKey, 'log', ['hello']);
+  eventCollect(firstKey, 'warn', ['world']);
+  eventCollect(firstKey, 'error', ['foo']);
+  eventCollect(firstKey, 'finish', []);
+
+  expect(dummyCallback.log).toHaveBeenCalledWith(['hello']);
+  expect(dummyCallback.warn).toHaveBeenCalledWith(['world']);
+  expect(dummyCallback.error).toHaveBeenCalledWith(['foo']);
+  expect(dummyCallback.onEnd).toHaveBeenCalled();
+});

--- a/packages/renderer/src/lib/preferences/preferences-connection-rendering-task.ts
+++ b/packages/renderer/src/lib/preferences/preferences-connection-rendering-task.ts
@@ -1,0 +1,224 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { createConnectionsInfo } from '/@/stores/create-connections';
+import { router } from 'tinro';
+
+import type { Logger as LoggerType } from '@podman-desktop/api';
+import type { Task } from '/@/stores/tasks';
+import { createTask, removeTask } from '/@/stores/tasks';
+
+export interface CreateConnectionCallback extends LoggerType {
+  // when build is finished, this function is called
+  onEnd: () => void;
+}
+
+export interface CreateReplay {
+  // log replay
+  log: string[][];
+
+  // error replay
+  error: string[][];
+
+  // warn replay
+  warn: string[][];
+
+  // end replay
+  end: boolean;
+}
+
+export interface CreateHold {
+  // log replay
+  log: string[][];
+
+  // error replay
+  error: string[][];
+
+  // warn replay
+  warn: string[][];
+
+  // end hold
+  end: boolean;
+}
+
+// map by build id
+const createLogCallbacks = new Map<symbol, CreateConnectionCallback>();
+const createLogOnHolds = new Map<symbol, CreateHold>();
+const createLogReplays = new Map<symbol, CreateReplay>();
+const allTasks = new Map<symbol, Task>();
+
+// new create is occuring, needs to compute a new key and prepare replay data
+export function startCreate(
+  name: string,
+  providerInternalId: string,
+  createCallback: CreateConnectionCallback,
+): symbol {
+  const key = getKey();
+  createLogCallbacks.set(key, createCallback);
+
+  // start a task
+  const task = createTask(name);
+
+  // go to the images build
+  task.gotoTask = () => {
+    router.goto(`/preferences/provider/${providerInternalId}`);
+  };
+
+  // store the task
+  allTasks.set(key, task);
+
+  // create a new replay value
+  createLogReplays.set(key, { log: [], warn: [], error: [], end: false });
+  return key;
+}
+
+// clear all data related to the given build
+export function clearCreateTask(key: symbol): void {
+  createLogCallbacks.delete(key);
+  createLogOnHolds.delete(key);
+  createLogReplays.delete(key);
+  // remove current create
+  createConnectionsInfo.set(undefined);
+
+  // remove the task
+  const task = allTasks.get(key);
+  if (task) {
+    removeTask(task.id);
+  }
+  allTasks.delete(key);
+}
+
+// client is leaving the page, disconnect the UI
+// need to store the events
+export function disconnectUI(key: symbol): void {
+  // provide on hold events
+  const holdingEvents: CreateHold = { log: [], warn: [], error: [], end: false };
+  createLogOnHolds.set(key, holdingEvents);
+
+  // remove the current callback
+  createLogCallbacks.delete(key);
+}
+
+// reconnecting the UI, needs to replay events / hold events as well
+export function reconnectUI(key: symbol, createCallback: CreateConnectionCallback): void {
+  // add the new callback
+  createLogCallbacks.set(key, createCallback);
+
+  // replay previous lines
+  const replay = createLogReplays.get(key);
+  if (replay) {
+    if (replay.log.length > 0) {
+      createCallback.log(replay.log);
+    }
+    if (replay.warn.length > 0) {
+      createCallback.warn(replay.warn);
+    }
+    if (replay.error.length > 0) {
+      createCallback.error(replay.error);
+    }
+  }
+
+  // on hold events should be replayed
+  // replay the holding results
+  let ended = false;
+  const hold = createLogOnHolds.get(key);
+  if (hold) {
+    if (hold.log.length > 0) {
+      createCallback.log(hold.log);
+    }
+    if (hold.error.length > 0) {
+      createCallback.error(hold.error);
+    }
+    if (hold.warn.length > 0) {
+      createCallback.warn(hold.warn);
+    }
+    if (hold.end) {
+      ended = true;
+      createCallback.onEnd();
+    }
+  }
+  // ok remove the intermediate events
+  createLogOnHolds.delete(key);
+
+  // check if it was ended in the replay
+  if (!ended) {
+    if (replay && replay.end) {
+      createCallback.onEnd();
+    }
+  }
+}
+
+// build a new key
+function getKey(): symbol {
+  return Symbol();
+}
+
+export function eventCollect(key: symbol, eventName: 'log' | 'warn' | 'error' | 'finish', args: string[]): void {
+  const task = allTasks.get(key);
+  if (task) {
+    if (eventName === 'error') {
+      task.status = 'failure';
+    } else if (eventName === 'finish') {
+      if (task.status !== 'failure') {
+        task.status = 'success';
+      }
+      task.state = 'completed';
+    }
+  }
+
+  // keep values for replay
+  const replay = createLogReplays.get(key);
+  if (replay) {
+    if (eventName === 'log') {
+      replay.log.push(args);
+    } else if (eventName === 'error') {
+      replay.error.push(args);
+    } else if (eventName === 'warn') {
+      replay.warn.push(args);
+    } else if (eventName === 'finish') {
+      replay.end = true;
+    }
+  }
+  const callback = createLogCallbacks.get(key);
+
+  if (!callback) {
+    // need to store the result for later as no UI is connected
+    const hold = createLogOnHolds.get(key);
+    if (hold) {
+      if (eventName === 'log') {
+        hold.log.push(args);
+      } else if (eventName === 'warn') {
+        hold.warn.push(args);
+      } else if (eventName === 'error') {
+        hold.error.push(args);
+      } else if (eventName === 'finish') {
+        hold.end = true;
+      }
+      return;
+    }
+  }
+  if (eventName === 'log') {
+    callback.log(args);
+  } else if (eventName === 'warn') {
+    callback.warn(args);
+  } else if (eventName === 'error') {
+    callback.error(args);
+  } else if (eventName === 'finish') {
+    callback.onEnd();
+  }
+}

--- a/packages/renderer/src/stores/create-connections.ts
+++ b/packages/renderer/src/stores/create-connections.ts
@@ -1,0 +1,34 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { Writable } from 'svelte/store';
+import { writable } from 'svelte/store';
+import type { IConfigurationPropertyRecordedSchema } from '../../../main/src/plugin/configuration-registry';
+import type { ProviderInfo } from '../../../main/src/plugin/api/provider-info';
+
+// current create key
+export const createConnectionsInfo: Writable<{
+  createKey: symbol;
+  providerInfo: ProviderInfo;
+  properties: IConfigurationPropertyRecordedSchema[];
+  propertyScope: string;
+  creationInProgress: boolean;
+  creationSuccessful: boolean;
+  creationStarted: boolean;
+  errorMessage: string;
+}> = writable();


### PR DESCRIPTION
### What does this PR do?
If user was leaving the create machine screen, there was no way to get it back.
Now, we can go back and see the current task in the task manager as well

### Screenshot/screencast of this PR

https://user-images.githubusercontent.com/436777/226310240-266560b7-e753-4b56-9740-399c61791f37.mp4


### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/1342



### How to test this PR?

Create a Podman Machine, go elsewhere and try to go back using the settings/podman link or through the task manager widget/view task


Change-Id: I8feeec780ffb1ae2e000bc0704dd01d3911b3811
