### PR TITLE
chore: ignore the TypeScript 5.0 deprecation

### DIFF
--- a/packages/renderer/tsconfig.json
+++ b/packages/renderer/tsconfig.json
@@ -5,6 +5,7 @@
     "module": "esnext",
     "resolveJsonModule": true,
     "preserveValueImports": false,
+    "ignoreDeprecations": "5.0",
     "baseUrl": ".",
     "paths": {
       "/@/*": [


### PR DESCRIPTION


### What does this PR do?
https://github.com/tsconfig/bases/blob/main/bases/svelte.json is referencing importsNotUsedAsValues and preserveValueImports

but it's replaced by https://devblogs.microsoft.com/typescript/announcing-typescript-5-0/#verbatimmodulesyntax

Until 5.5 it is still supported, so we need to ignore the flag and upgrade tsconfig when fix will land there In the meantime, it means we could upgrade to TypeScript 5.0


### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?

https://github.com/containers/podman-desktop/pull/1730


### How to test this PR?

Compilation should work as usual

Change-Id: Ia89ab5deeb3dce38d252f9adc33b9e62616d92e5
