### PR TITLE
nit: fix wording for compatibility mode on macOS

### DIFF
--- a/extensions/podman/src/warnings.ts
+++ b/extensions/podman/src/warnings.ts
@@ -44,7 +44,7 @@ export function getDisguisedPodmanInformation(): extensionApi.ProviderInformatio
       details = detailsExplanation.concat(
         defaultSocketPath,
         detailsNotWorking,
-        ' See troubleshooting page on podman-desktop.io for more information.',
+        " Press 'Docker Compatibility' button to enable.",
       );
       break;
     default:


### PR DESCRIPTION
nit: fix wording for compatibility mode on macOS

### What does this PR do?

Fixes the wording to indicate that you can press the button to enable
compatibility mode support

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

### How to test this PR?

<!-- Please explain steps to reproduce -->

`yarn watch`

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
