### PR TITLE
chore: Open Logs container action

### DIFF
--- a/packages/renderer/src/lib/container/ContainerActions.svelte
+++ b/packages/renderer/src/lib/container/ContainerActions.svelte
@@ -1,5 +1,12 @@
 <script lang="ts">
-import { faEllipsisVertical, faFileCode, faPlay, faRocket, faTerminal } from '@fortawesome/free-solid-svg-icons';
+import {
+  faAlignLeft,
+  faEllipsisVertical,
+  faFileCode,
+  faPlay,
+  faRocket,
+  faTerminal,
+} from '@fortawesome/free-solid-svg-icons';
 import { faStop } from '@fortawesome/free-solid-svg-icons';
 import { faArrowsRotate } from '@fortawesome/free-solid-svg-icons';
 import { faTrash } from '@fortawesome/free-solid-svg-icons';
@@ -54,6 +61,10 @@ function openBrowser(containerInfo: ContainerInfoUI): void {
   window.openExternal(containerInfo.openingUrl);
 }
 
+function openLogs(containerInfo: ContainerInfoUI): void {
+  router.goto(`/containers/${container.id}/logs`);
+}
+
 async function deleteContainer(containerInfo: ContainerInfoUI): Promise<void> {
   inProgressCallback(true);
   try {
@@ -65,6 +76,7 @@ async function deleteContainer(containerInfo: ContainerInfoUI): Promise<void> {
     inProgressCallback(false);
   }
 }
+
 function openTerminalContainer(containerInfo: ContainerInfoUI): void {
   router.goto(`/containers/${container.id}/terminal`);
 }
@@ -111,6 +123,12 @@ if (dropdownMenu) {
 <svelte:component this="{actionsStyle}">
   {#if !detailed}
     <ListItemButtonIcon
+      title="Open Logs"
+      onClick="{() => openLogs(container)}"
+      menu="{dropdownMenu}"
+      detailed="{false}"
+      icon="{faAlignLeft}" />
+    <ListItemButtonIcon
       title="Generate Kube"
       onClick="{() => openGenerateKube()}"
       menu="{dropdownMenu}"
@@ -141,7 +159,7 @@ if (dropdownMenu) {
       onClick="{() => openTerminalContainer(container)}"
       menu="{dropdownMenu}"
       hidden="{!(container.state === 'RUNNING')}"
-      detailed="{detailed}"
+      detailed="{false}"
       icon="{faTerminal}" />
   {/if}
   <ListItemButtonIcon


### PR DESCRIPTION
### What does this PR do?

Adds an 'Open Logs' action to the container popup menu. I couldn't find an existing 'log icon' anywhere, the best fit I came up with is faAlignLeft.

### Screenshot/screencast of this PR

<img width="186" alt="Screenshot 2023-03-20 at 2 24 23 PM" src="https://user-images.githubusercontent.com/19958075/226432372-5ba4e6fe-192d-4185-acd3-b78ea3b18224.png">

### What issues does this PR fix or reference?

Fixes issue #1346.

### How to test this PR?

Select the popup menu on a container to see the new action. Also confirm it doesn't appear in the container's details page (since you can just click on the tab there).