### PR TITLE
fix: Status bar wrapping

### DIFF
--- a/packages/renderer/src/lib/statusbar/StatusBar.svelte
+++ b/packages/renderer/src/lib/statusbar/StatusBar.svelte
@@ -47,8 +47,8 @@ onMount(async () => {
 </script>
 
 <div class="flex items-center justify-between px-1 bg-[#302251] text-sm py-0.5 space-x-2">
-  <div class="-mx-1">
-    <ul class="flex flex-wrap list-none">
+  <div>
+    <ul class="flex flex-wrap gap-x-2 list-none">
       {#each leftEntries as entry}
         <li>
           <StatusBarItem entry="{entry}" />
@@ -57,7 +57,7 @@ onMount(async () => {
     </ul>
   </div>
   <div class="place-self-end">
-    <ul class="flex flex-wrap flex-row-reverse list-none">
+    <ul class="flex flex-wrap flex-row-reverse gap-x-2 list-none">
       {#each rightEntries as entry}
         <li>
           <StatusBarItem entry="{entry}" />

--- a/packages/renderer/src/lib/statusbar/StatusBar.svelte
+++ b/packages/renderer/src/lib/statusbar/StatusBar.svelte
@@ -46,9 +46,9 @@ onMount(async () => {
 });
 </script>
 
-<div class="flex flex-wrap items-center justify-between px-2 h-6 bg-[#302251] text-sm">
-  <div class="w-1/2">
-    <ul class="flex flex-wrap list-none space-x-4">
+<div class="flex items-center justify-between px-1 bg-[#302251] text-sm py-0.5 space-x-2">
+  <div class="-mx-1">
+    <ul class="flex flex-wrap list-none">
       {#each leftEntries as entry}
         <li>
           <StatusBarItem entry="{entry}" />
@@ -56,8 +56,8 @@ onMount(async () => {
       {/each}
     </ul>
   </div>
-  <div class="w-1/2">
-    <ul class="flex flex-wrap flex-row-reverse list-none space-x-2 space-x-reverse">
+  <div class="place-self-end">
+    <ul class="flex flex-wrap flex-row-reverse list-none">
       {#each rightEntries as entry}
         <li>
           <StatusBarItem entry="{entry}" />

--- a/packages/renderer/src/lib/statusbar/StatusBarItem.svelte
+++ b/packages/renderer/src/lib/statusbar/StatusBarItem.svelte
@@ -44,7 +44,7 @@ async function executeCommand(entry: StatusBarEntry) {
   on:click="{() => {
     executeCommand(entry);
   }}"
-  class="{opacity(entry)} px-1 {hoverBackground(entry)} {hoverCursor(entry)}"
+  class="{opacity(entry)} px-1 mx-1 {hoverBackground(entry)} {hoverCursor(entry)}"
   title="{tooltipText(entry)}">
   {#if iconClass(entry)}
     <i class="{iconClass(entry)}" aria-hidden="true"></i>

--- a/packages/renderer/src/lib/statusbar/StatusBarItem.svelte
+++ b/packages/renderer/src/lib/statusbar/StatusBarItem.svelte
@@ -44,7 +44,7 @@ async function executeCommand(entry: StatusBarEntry) {
   on:click="{() => {
     executeCommand(entry);
   }}"
-  class="{opacity(entry)} px-1 mx-1 {hoverBackground(entry)} {hoverCursor(entry)}"
+  class="{opacity(entry)} px-1 {hoverBackground(entry)} {hoverCursor(entry)}"
   title="{tooltipText(entry)}">
   {#if iconClass(entry)}
     <i class="{iconClass(entry)}" aria-hidden="true"></i>


### PR DESCRIPTION
### What does this PR do?

Fixes issue #1723 by allowing the status bar to wrap correctly.

- Replaced h-6 with equivalent padding.
- Remove strict 1/2 + 1/2 width - won't wrap until the line is completely full now.
- Replaced 'space-x' on individual items because it doesn't handle wrapping correctly.

### Screenshot/screencast of this PR

See issue #1723 for current behaviour. After this PR the line won't wrap until the line is completely full, and will look better once it does.

<img width="1009" alt="Screenshot 2023-03-21 at 11 56 36 AM" src="https://user-images.githubusercontent.com/19958075/226668120-ea868d56-b443-4bee-b496-0cab66a6efde.png">
<img width="644" alt="Screenshot 2023-03-21 at 11 56 52 AM" src="https://user-images.githubusercontent.com/19958075/226668126-6f580d79-7e4a-4083-9a0b-e429e92a6d37.png">

### What issues does this PR fix or reference?

Issue #1723.

### How to test this PR?

You'll have a hard time filling the status bar with current contributions, so use `yarn watch` and then edit an extension like Kind (as in screenshot above) so make the contribution really wide.