### PR TITLE
feat: add cancellationToken to stop/cancel the execution of a command

### DIFF
--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -577,8 +577,12 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
 
   // allows to create machines
   if (isMac() || isWindows()) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const createFunction = async (params: { [key: string]: any }, logger: extensionApi.Logger, token?: extensionApi.CancellationToken): Promise<void> => {
+    const createFunction = async (
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      params: { [key: string]: any },
+      logger: extensionApi.Logger,
+      token?: extensionApi.CancellationToken,
+    ): Promise<void> => {
       const parameters = [];
       parameters.push('machine');
       parameters.push('init');

--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -578,7 +578,7 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
   // allows to create machines
   if (isMac() || isWindows()) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const createFunction = async (params: { [key: string]: any }, logger: extensionApi.Logger): Promise<void> => {
+    const createFunction = async (params: { [key: string]: any }, logger: extensionApi.Logger, token?: extensionApi.CancellationToken): Promise<void> => {
       const parameters = [];
       parameters.push('machine');
       parameters.push('init');
@@ -651,7 +651,7 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
           }
         }
       }
-      await execPromise(getPodmanCli(), parameters, { logger, env });
+      await execPromise(getPodmanCli(), parameters, { logger, env }, token);
     };
 
     provider.setContainerProviderConnectionFactory({

--- a/extensions/podman/src/podman-cli.ts
+++ b/extensions/podman/src/podman-cli.ts
@@ -61,7 +61,12 @@ export interface ExecOptions {
   env?: NodeJS.ProcessEnv | undefined;
 }
 
-export function execPromise(command: string, args?: string[], options?: ExecOptions, token?: CancellationToken): Promise<string> {
+export function execPromise(
+  command: string,
+  args?: string[],
+  options?: ExecOptions,
+  token?: CancellationToken,
+): Promise<string> {
   let env = Object.assign({}, process.env); // clone original env object
 
   // In production mode, applications don't have access to the 'user' path like brew

--- a/extensions/podman/src/podman-cli.ts
+++ b/extensions/podman/src/podman-cli.ts
@@ -17,7 +17,7 @@
  ***********************************************************************/
 import { spawn } from 'node:child_process';
 import { isMac, isWindows } from './util';
-import type { Logger } from '@podman-desktop/api';
+import type { CancellationToken, Logger } from '@podman-desktop/api';
 import { configuration } from '@podman-desktop/api';
 
 const macosExtraPath = '/usr/local/bin:/opt/homebrew/bin:/opt/local/bin:/opt/podman/bin';
@@ -61,7 +61,7 @@ export interface ExecOptions {
   env?: NodeJS.ProcessEnv | undefined;
 }
 
-export function execPromise(command: string, args?: string[], options?: ExecOptions): Promise<string> {
+export function execPromise(command: string, args?: string[], options?: ExecOptions, token?: CancellationToken): Promise<string> {
   let env = Object.assign({}, process.env); // clone original env object
 
   // In production mode, applications don't have access to the 'user' path like brew
@@ -80,6 +80,12 @@ export function execPromise(command: string, args?: string[], options?: ExecOpti
     let stdOut = '';
     let stdErr = '';
     const process = spawn(command, args, { env });
+    // if the token is cancelled, kill the process and reject the promise
+    token?.onCancellationRequested(() => {
+      process.kill();
+      // reject the promise
+      reject('Execution cancelled');
+    });
     process.on('error', error => {
       let content = '';
       if (stdOut && stdOut !== '') {

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -228,7 +228,7 @@ declare module '@podman-desktop/api' {
   export interface ContainerProviderConnectionFactory {
     initialize(): Promise<void>;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    create(params: { [key: string]: any }, logger?: Logger): Promise<void>;
+    create(params: { [key: string]: any }, logger?: Logger, token?: CancellationToken): Promise<void>;
   }
 
   // create a kubernetes provider
@@ -587,6 +587,23 @@ declare module '@podman-desktop/api' {
      */
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     onCancellationRequested: Event<any>;
+  }
+
+  export interface CancellationTokenSource {
+      /**
+       * The cancellation token of this source.
+       */
+      token: CancellationToken;
+
+      /**
+       * Signal cancellation on the token.
+       */
+      cancel(): void;
+
+      /**
+       * Dispose object and free resources.
+       */
+      dispose(): void;
   }
 
   /**

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -590,20 +590,20 @@ declare module '@podman-desktop/api' {
   }
 
   export interface CancellationTokenSource {
-      /**
-       * The cancellation token of this source.
-       */
-      token: CancellationToken;
+    /**
+     * The cancellation token of this source.
+     */
+    token: CancellationToken;
 
-      /**
-       * Signal cancellation on the token.
-       */
-      cancel(): void;
+    /**
+     * Signal cancellation on the token.
+     */
+    cancel(): void;
 
-      /**
-       * Dispose object and free resources.
-       */
-      dispose(): void;
+    /**
+     * Dispose object and free resources.
+     */
+    dispose(): void;
   }
 
   /**

--- a/packages/main/src/plugin/cancellation-token-registry.spec.ts
+++ b/packages/main/src/plugin/cancellation-token-registry.spec.ts
@@ -1,0 +1,55 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { beforeAll, expect, expectTypeOf, test } from 'vitest';
+import { CancellationTokenSource } from './cancellation-token';
+import { CancellationTokenRegistry } from './cancellation-token-registry';
+
+let cancellationTokenRegistry;
+
+/* eslint-disable @typescript-eslint/no-empty-function */
+beforeAll(() => {
+  cancellationTokenRegistry = new CancellationTokenRegistry();
+});
+
+test('Should return CancellationTokenSources with progressive id', async () => {
+  const tokenSourceId1 = cancellationTokenRegistry.createCancellationTokenSource();
+  const tokenSourceid2 = cancellationTokenRegistry.createCancellationTokenSource();
+  expectTypeOf(tokenSourceId1).toBeNumber();
+  expectTypeOf(tokenSourceid2).toBeNumber();
+  expect(tokenSourceid2).toBeGreaterThan(tokenSourceId1);
+});
+
+test('Check if CancellationToken is saved in registry', async () => {
+  const tokenSourceId = cancellationTokenRegistry.createCancellationTokenSource();
+  const hasToken = cancellationTokenRegistry.hasCancellationTokenSource(tokenSourceId);
+  expect(hasToken).toBe(true);
+});
+
+test('Return undefined if id not valid', async () => {
+  const token = cancellationTokenRegistry.getCancellationTokenSource(-1);
+  expect(token).toBeUndefined();
+});
+
+test('Return CancellationToken if id valid', async () => {
+  const tokenSourceId = cancellationTokenRegistry.createCancellationTokenSource();
+  expectTypeOf(tokenSourceId).toBeNumber();
+  const token = cancellationTokenRegistry.getCancellationTokenSource(tokenSourceId);
+  expectTypeOf(token).toBeObject();
+  expect(token instanceof CancellationTokenSource);
+});

--- a/packages/main/src/plugin/cancellation-token-registry.ts
+++ b/packages/main/src/plugin/cancellation-token-registry.ts
@@ -1,0 +1,53 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { CancellationTokenSource } from './cancellation-token';
+  
+  export class CancellationTokenRegistry {
+    private callbackId = 0;
+  
+    private callbacksCancellableToken = new Map<
+      number,
+      CancellationTokenSource
+    >();
+    
+    createCancellationTokenSource(): number {
+        // keep track of this request
+        this.callbackId++;
+
+        const token = new CancellationTokenSource();
+  
+        // store the callback that will resolve the promise
+        this.callbacksCancellableToken.set(this.callbackId, token);
+  
+        return this.callbackId;
+    }
+
+    getCancellationTokenSource(id: number): CancellationTokenSource | undefined {
+        if (this.hasCancellationTokenSource(id)) {
+            return this.callbacksCancellableToken.get(id);
+        }
+        return undefined;
+    }
+
+    hasCancellationTokenSource(id: number): boolean {
+        return this.callbacksCancellableToken.has(id);
+    }
+  
+ }
+  

--- a/packages/main/src/plugin/cancellation-token-registry.ts
+++ b/packages/main/src/plugin/cancellation-token-registry.ts
@@ -17,37 +17,32 @@
  ***********************************************************************/
 
 import { CancellationTokenSource } from './cancellation-token';
-  
-  export class CancellationTokenRegistry {
-    private callbackId = 0;
-  
-    private callbacksCancellableToken = new Map<
-      number,
-      CancellationTokenSource
-    >();
-    
-    createCancellationTokenSource(): number {
-        // keep track of this request
-        this.callbackId++;
 
-        const token = new CancellationTokenSource();
-  
-        // store the callback that will resolve the promise
-        this.callbacksCancellableToken.set(this.callbackId, token);
-  
-        return this.callbackId;
-    }
+export class CancellationTokenRegistry {
+  private callbackId = 0;
 
-    getCancellationTokenSource(id: number): CancellationTokenSource | undefined {
-        if (this.hasCancellationTokenSource(id)) {
-            return this.callbacksCancellableToken.get(id);
-        }
-        return undefined;
-    }
+  private callbacksCancellableToken = new Map<number, CancellationTokenSource>();
 
-    hasCancellationTokenSource(id: number): boolean {
-        return this.callbacksCancellableToken.has(id);
+  createCancellationTokenSource(): number {
+    // keep track of this request
+    this.callbackId++;
+
+    const token = new CancellationTokenSource();
+
+    // store the callback that will resolve the promise
+    this.callbacksCancellableToken.set(this.callbackId, token);
+
+    return this.callbackId;
+  }
+
+  getCancellationTokenSource(id: number): CancellationTokenSource | undefined {
+    if (this.hasCancellationTokenSource(id)) {
+      return this.callbacksCancellableToken.get(id);
     }
-  
- }
-  
+    return undefined;
+  }
+
+  hasCancellationTokenSource(id: number): boolean {
+    return this.callbacksCancellableToken.has(id);
+  }
+}

--- a/packages/main/src/plugin/cancellation-token.spec.ts
+++ b/packages/main/src/plugin/cancellation-token.spec.ts
@@ -1,0 +1,76 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { beforeAll, beforeEach, expect, expectTypeOf, test, vi, vitest } from 'vitest';
+import { CancellationTokenImpl } from './cancellation-token';
+import { CancellationTokenRegistry } from './cancellation-token-registry';
+
+let cancellationTokenRegistry;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+/* eslint-disable @typescript-eslint/no-empty-function */
+beforeAll(() => {
+  cancellationTokenRegistry = new CancellationTokenRegistry();
+});
+
+test('Should return CancellationToken', async () => {
+  const tokenSourceId = cancellationTokenRegistry.createCancellationTokenSource();
+  const tokenSource = cancellationTokenRegistry.getCancellationTokenSource(tokenSourceId);
+  const token = tokenSource.token;
+  expectTypeOf(token).toBeObject();
+  expect(token instanceof CancellationTokenImpl).toBe(true);
+});
+
+test('Check if token cancel is triggered when tokenSource cancel', async () => {
+  const tokenSourceId = cancellationTokenRegistry.createCancellationTokenSource();
+  const tokenSource = cancellationTokenRegistry.getCancellationTokenSource(tokenSourceId);
+  const token = tokenSource.token;
+  const tokenCancelMock = vitest.spyOn(token, 'cancel');
+  tokenCancelMock.mockImplementation(() => {});
+  tokenSource.cancel();
+  expect(tokenCancelMock).toBeCalled();
+});
+
+test('Check if tokenSource cancel is triggered if tokenSource is disposed', async () => {
+  const tokenSourceId = cancellationTokenRegistry.createCancellationTokenSource();
+  const tokenSource = cancellationTokenRegistry.getCancellationTokenSource(tokenSourceId);
+  const token = tokenSource.token;
+  const tokenSourceCancelMock = vitest.spyOn(tokenSource, 'cancel');
+  tokenSourceCancelMock.mockImplementation(() => {});
+  const tokenDisposeMock = vitest.spyOn(token, 'dispose');
+  tokenDisposeMock.mockImplementation(() => {});
+  tokenSource.dispose(true);
+  expect(tokenSourceCancelMock).toBeCalled();
+  expect(tokenDisposeMock).toBeCalled();
+});
+
+test('Check if tokenSource cancel is not triggered if tokenSource is disposed without cancel set', async () => {
+  const tokenSourceId = cancellationTokenRegistry.createCancellationTokenSource();
+  const tokenSource = cancellationTokenRegistry.getCancellationTokenSource(tokenSourceId);
+  const token = tokenSource.token;
+  const tokenSourceCancelMock = vitest.spyOn(tokenSource, 'cancel');
+  tokenSourceCancelMock.mockImplementation(() => {});
+  const tokenDisposeMock = vitest.spyOn(token, 'dispose');
+  tokenDisposeMock.mockImplementation(() => {});
+  tokenSource.dispose();
+  expect(tokenSourceCancelMock).toBeCalledTimes(0);
+  expect(tokenDisposeMock).toBeCalled();
+});

--- a/packages/main/src/plugin/cancellation-token.ts
+++ b/packages/main/src/plugin/cancellation-token.ts
@@ -21,73 +21,77 @@ import { Emitter } from './events/emitter';
 import { IDisposable } from './types/disposable';
 
 const shortcutEvent: extensionApi.Event<any> = Object.freeze(function (callback, context?): IDisposable {
-	const handle = setTimeout(callback.bind(context), 0);
-	return { dispose() { clearTimeout(handle); } };
+  const handle = setTimeout(callback.bind(context), 0);
+  return {
+    dispose() {
+      clearTimeout(handle);
+    },
+  };
 });
 
 export class CancellationTokenImpl implements extensionApi.CancellationToken {
-  	private _isCancellationRequested: boolean;
-	private emitter: Emitter<any> | null = null;
+  private _isCancellationRequested: boolean;
+  private emitter: Emitter<any> | null = null;
 
-	constructor() {
-		this._isCancellationRequested = false;
-	}
+  constructor() {
+    this._isCancellationRequested = false;
+  }
 
-	public cancel() {
-		if (!this._isCancellationRequested) {
-			this._isCancellationRequested = true;
-			if (this.emitter) {
-				this.emitter.fire(undefined);
-				this.dispose();
-			}
-		}
-	}
+  public cancel() {
+    if (!this._isCancellationRequested) {
+      this._isCancellationRequested = true;
+      if (this.emitter) {
+        this.emitter.fire(undefined);
+        this.dispose();
+      }
+    }
+  }
 
-	get isCancellationRequested(): boolean {
-		return this._isCancellationRequested;
-	}
+  get isCancellationRequested(): boolean {
+    return this._isCancellationRequested;
+  }
 
-	get onCancellationRequested(): extensionApi.Event<any> {
-		if (this._isCancellationRequested) {
-			return shortcutEvent;
-		}
-		if (!this.emitter) {
-			this.emitter = new Emitter<any>();
-		}
-		return this.emitter.event;
-	}
+  get onCancellationRequested(): extensionApi.Event<any> {
+    if (this._isCancellationRequested) {
+      return shortcutEvent;
+    }
+    if (!this.emitter) {
+      this.emitter = new Emitter<any>();
+    }
+    return this.emitter.event;
+  }
 
-	public dispose(): void {
-		if (this.emitter) {
-			this.emitter.dispose();
-			this.emitter = null;
-		}
-	}
+  public dispose(): void {
+    if (this.emitter) {
+      this.emitter.dispose();
+      this.emitter = null;
+    }
+  }
 }
 
 export class CancellationTokenSource {
-  	private _token?: extensionApi.CancellationToken = undefined;
+  private _token?: CancellationTokenImpl = undefined;
 
-	get token(): extensionApi.CancellationToken {
-		if (!this._token) {
-			// be lazy and create the token only when actually needed
-			this._token = new CancellationTokenImpl();
-		}
-		return this._token;
-	}
+  get token(): extensionApi.CancellationToken {
+    if (!this._token) {
+      // be lazy and create the token only when actually needed
+      this._token = new CancellationTokenImpl();
+    }
+    return this._token;
+  }
 
-	cancel(): void {
-		if (this._token instanceof CancellationTokenImpl) {
-			this._token.cancel();
-		}
-	}
+  cancel(): void {
+    if (this._token) {
+      this._token?.cancel();
+    }
+  }
 
-	dispose(cancel: boolean = false): void {
-		if (cancel) {
-			this.cancel();
-		}
-		if (this._token instanceof CancellationTokenImpl) {
-			this._token.dispose();
-		}
-	}
+  dispose(cancel: boolean = false): void {
+    if (cancel) {
+      this.cancel();
+    }
+    if (this._token) {
+      this._token.dispose();
+    }
+  }
 }

--- a/packages/main/src/plugin/cancellation-token.ts
+++ b/packages/main/src/plugin/cancellation-token.ts
@@ -18,8 +18,9 @@
 
 import type * as extensionApi from '@podman-desktop/api';
 import { Emitter } from './events/emitter';
-import { IDisposable } from './types/disposable';
+import type { IDisposable } from './types/disposable';
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const shortcutEvent: extensionApi.Event<any> = Object.freeze(function (callback, context?): IDisposable {
   const handle = setTimeout(callback.bind(context), 0);
   return {
@@ -31,6 +32,7 @@ const shortcutEvent: extensionApi.Event<any> = Object.freeze(function (callback,
 
 export class CancellationTokenImpl implements extensionApi.CancellationToken {
   private _isCancellationRequested: boolean;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private emitter: Emitter<any> | null = null;
 
   constructor() {
@@ -51,11 +53,13 @@ export class CancellationTokenImpl implements extensionApi.CancellationToken {
     return this._isCancellationRequested;
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   get onCancellationRequested(): extensionApi.Event<any> {
     if (this._isCancellationRequested) {
       return shortcutEvent;
     }
     if (!this.emitter) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       this.emitter = new Emitter<any>();
     }
     return this.emitter.event;
@@ -86,7 +90,7 @@ export class CancellationTokenSource {
     }
   }
 
-  dispose(cancel: boolean = false): void {
+  dispose(cancel = false): void {
     if (cancel) {
       this.cancel();
     }

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -45,6 +45,7 @@ import { QuickPickItemKind, InputBoxValidationSeverity } from './input-quickpick
 import type { MenuRegistry } from '/@/plugin/menu-registry';
 import { desktopAppHomeDir } from '../util';
 import { Emitter } from './events/emitter';
+import { CancellationTokenSource } from './cancellation-token';
 
 /**
  * Handle the loading of an extension
@@ -571,6 +572,7 @@ export class ExtensionLoader {
       Disposable: Disposable,
       Uri: Uri,
       EventEmitter: Emitter,
+      CancellationTokenSource: CancellationTokenSource,
       commands,
       registry,
       provider,

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -89,7 +89,6 @@ import { ExtensionInstaller } from './install/extension-installer';
 import { InputQuickPickRegistry } from './input-quickpick/input-quickpick-registry';
 import type { Menu } from '/@/plugin/menu-registry';
 import { MenuRegistry } from '/@/plugin/menu-registry';
-import { CancellationTokenImpl, CancellationTokenSource } from './cancellation-token';
 import { CancellationTokenRegistry } from './cancellation-token-registry';
 
 type LogType = 'log' | 'warn' | 'trace' | 'debug' | 'error';

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -89,6 +89,8 @@ import { ExtensionInstaller } from './install/extension-installer';
 import { InputQuickPickRegistry } from './input-quickpick/input-quickpick-registry';
 import type { Menu } from '/@/plugin/menu-registry';
 import { MenuRegistry } from '/@/plugin/menu-registry';
+import { CancellationTokenImpl, CancellationTokenSource } from './cancellation-token';
+import { CancellationTokenRegistry } from './cancellation-token-registry';
 
 type LogType = 'log' | 'warn' | 'trace' | 'debug' | 'error';
 
@@ -276,6 +278,7 @@ export class PluginSystem {
     await certificates.init();
     const imageRegistry = new ImageRegistry(apiSender, telemetry, certificates, proxy);
     const containerProviderRegistry = new ContainerProviderRegistry(apiSender, imageRegistry, telemetry);
+    const cancellationTokenRegistry = new CancellationTokenRegistry();
     const providerRegistry = new ProviderRegistry(apiSender, containerProviderRegistry, telemetry);
     const trayMenuRegistry = new TrayMenuRegistry(this.trayMenu, commandRegistry, providerRegistry, telemetry);
     const statusBarRegistry = new StatusBarRegistry(apiSender);
@@ -1121,9 +1124,15 @@ export class PluginSystem {
         internalProviderId: string,
         params: { [key: string]: unknown },
         loggerId: string,
+        tokenId?: number
       ): Promise<void> => {
         const logger = this.getLogHandlerCreateConnection(loggerId);
-        await providerRegistry.createContainerProviderConnection(internalProviderId, params, logger);
+        let token;
+        if (tokenId) {
+          const tokenSource = cancellationTokenRegistry.getCancellationTokenSource(tokenId);
+          token = tokenSource?.token;
+        }        
+        await providerRegistry.createContainerProviderConnection(internalProviderId, params, logger, token);
         logger.onEnd();
       },
     );
@@ -1213,6 +1222,17 @@ export class PluginSystem {
 
     this.ipcHandle('feedback:send', async (_listener, feedbackProperties: unknown): Promise<void> => {
       return telemetry.sendFeedback(feedbackProperties);
+    });
+
+    this.ipcHandle('cancellableTokenSource:create', async (): Promise<number> => {
+      return cancellationTokenRegistry.createCancellationTokenSource();
+    });
+
+    this.ipcHandle('cancellableToken:cancel', async (_listener, id: number): Promise<void> => {
+      const tokenSource = cancellationTokenRegistry.getCancellationTokenSource(id);
+      if (!tokenSource?.token.isCancellationRequested) {
+        tokenSource?.dispose(true);
+      }      
     });
 
     const dockerDesktopInstallation = new DockerDesktopInstallation(

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1124,14 +1124,14 @@ export class PluginSystem {
         internalProviderId: string,
         params: { [key: string]: unknown },
         loggerId: string,
-        tokenId?: number
+        tokenId?: number,
       ): Promise<void> => {
         const logger = this.getLogHandlerCreateConnection(loggerId);
         let token;
         if (tokenId) {
           const tokenSource = cancellationTokenRegistry.getCancellationTokenSource(tokenId);
           token = tokenSource?.token;
-        }        
+        }
         await providerRegistry.createContainerProviderConnection(internalProviderId, params, logger, token);
         logger.onEnd();
       },
@@ -1232,7 +1232,7 @@ export class PluginSystem {
       const tokenSource = cancellationTokenRegistry.getCancellationTokenSource(id);
       if (!tokenSource?.token.isCancellationRequested) {
         tokenSource?.dispose(true);
-      }      
+      }
     });
 
     const dockerDesktopInstallation = new DockerDesktopInstallation(

--- a/packages/main/src/plugin/provider-registry.ts
+++ b/packages/main/src/plugin/provider-registry.ts
@@ -36,7 +36,6 @@ import type {
   ProviderInformation,
   ProviderContainerConnection,
   CancellationToken,
-  CancellationTokenSource,
 } from '@podman-desktop/api';
 import type {
   ProviderContainerConnectionInfo,

--- a/packages/main/src/plugin/provider-registry.ts
+++ b/packages/main/src/plugin/provider-registry.ts
@@ -35,6 +35,8 @@ import type {
   Logger,
   ProviderInformation,
   ProviderContainerConnection,
+  CancellationToken,
+  CancellationTokenSource,
 } from '@podman-desktop/api';
 import type {
   ProviderContainerConnectionInfo,
@@ -588,6 +590,7 @@ export class ProviderRegistry {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     params: { [key: string]: any },
     logHandler: Logger,
+    token?: CancellationToken
   ): Promise<void> {
     // grab the correct provider
     const provider = this.getMatchingProvider(internalProviderId);
@@ -597,8 +600,7 @@ export class ProviderRegistry {
     }
 
     // create a logger
-
-    return provider.containerProviderConnectionFactory.create(params, logHandler);
+    return provider.containerProviderConnectionFactory.create(params, logHandler, token);
   }
 
   async createKubernetesProviderConnection(

--- a/packages/main/src/plugin/provider-registry.ts
+++ b/packages/main/src/plugin/provider-registry.ts
@@ -590,7 +590,7 @@ export class ProviderRegistry {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     params: { [key: string]: any },
     logHandler: Logger,
-    token?: CancellationToken
+    token?: CancellationToken,
   ): Promise<void> {
     // grab the correct provider
     const provider = this.getMatchingProvider(internalProviderId);

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -527,7 +527,7 @@ function initExposure(): void {
       params: { [key: string]: any },
       key: symbol,
       keyLogger: (key: symbol, eventName: 'log' | 'warn' | 'error' | 'finish', args: unknown[]) => void,
-      tokenId?: number
+      tokenId?: number,
     ): Promise<void> => {
       onDataCallbacksCreateConnectionId++;
       onDataCallbacksCreateConnectionKeys.set(onDataCallbacksCreateConnectionId, key);
@@ -537,7 +537,7 @@ function initExposure(): void {
         internalProviderId,
         params,
         onDataCallbacksCreateConnectionId,
-        tokenId
+        tokenId,
       );
     },
   );

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -527,6 +527,7 @@ function initExposure(): void {
       params: { [key: string]: any },
       key: symbol,
       keyLogger: (key: symbol, eventName: 'log' | 'warn' | 'error' | 'finish', args: unknown[]) => void,
+      tokenId?: number
     ): Promise<void> => {
       onDataCallbacksCreateConnectionId++;
       onDataCallbacksCreateConnectionKeys.set(onDataCallbacksCreateConnectionId, key);
@@ -536,6 +537,7 @@ function initExposure(): void {
         internalProviderId,
         params,
         onDataCallbacksCreateConnectionId,
+        tokenId
       );
     },
   );
@@ -1118,6 +1120,14 @@ function initExposure(): void {
 
   contextBridge.exposeInMainWorld('getOsHostname', async (): Promise<string> => {
     return ipcInvoke('os:getHostname');
+  });
+
+  contextBridge.exposeInMainWorld('getCancellableTokenSource', async (): Promise<number> => {
+    return ipcInvoke('cancellableTokenSource:create');
+  });
+
+  contextBridge.exposeInMainWorld('cancelToken', async (id: number): Promise<void> => {
+    return ipcInvoke('cancellableToken:cancel', id);
   });
 
   contextBridge.exposeInMainWorld('sendFeedback', async (feedback: FeedbackProperties): Promise<void> => {


### PR DESCRIPTION
### What does this PR do?

This PR adds the logic to send a cancellationToken to stop the execution of a command and focus on creating a new podman machine. 

Eventually (in another PR) the user will be able to click the `cancel` button and stop the creation of a new podman machine
(based on the mockup here https://github.com/containers/podman-desktop/pull/1762#issuecomment-1478766503)

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

N/A

### How to test this PR?

1. This PR does nothing. Just try to create a new machine to see if everything works as before.
