### PR TITLE
fix: rename variable to fix register tray item

### DIFF
--- a/packages/main/src/plugin/tray-menu-registry.spec.ts
+++ b/packages/main/src/plugin/tray-menu-registry.spec.ts
@@ -1,0 +1,89 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { ipcMain } from 'electron';
+import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
+import type { TrayMenu } from '../tray-menu';
+import type { ProviderInfo } from './api/provider-info';
+import type { CommandRegistry } from './command-registry';
+import type { ProviderRegistry } from './provider-registry';
+import type { Telemetry } from './telemetry/telemetry';
+import { TrayMenuRegistry } from './tray-menu-registry';
+
+let menuRegistry: TrayMenuRegistry;
+let trayMenu: TrayMenu;
+
+vi.mock('electron', () => {
+  return {
+    ipcMain: {
+      emit: vi.fn(),
+      on: vi.fn(),
+    },
+  };
+});
+
+beforeAll(() => {
+  trayMenu = {
+    addProviderItems: vi.fn(),
+    deleteProviderItem: vi.fn(),
+  } as unknown as TrayMenu;
+  const commandRegistry = {} as CommandRegistry;
+  const providerRegistry = {
+    addProviderListener: vi.fn(),
+    addProviderLifecycleListener: vi.fn(),
+    addProviderContainerConnectionLifecycleListener: vi.fn(),
+  } as unknown as ProviderRegistry;
+  const telemetryService = {} as Telemetry;
+  menuRegistry = new TrayMenuRegistry(trayMenu, commandRegistry, providerRegistry, telemetryService);
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+test('Should pass proper providerId field', () => {
+  const ipcEmit = vi.spyOn(ipcMain, 'emit');
+  menuRegistry.registerProvider({
+    internalId: 'internalId',
+    id: 'testId',
+  } as ProviderInfo);
+
+  const menuItem = { id: 'itemId' };
+  menuRegistry.registerProviderMenuItem('testId', menuItem);
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  const lastIpcArguments = ipcEmit.mock.lastCall!;
+  expect(lastIpcArguments).is.not.undefined;
+  expect(lastIpcArguments[0]).eqls('tray:add-provider-menu-item');
+  expect(lastIpcArguments[1]).eqls('');
+  expect(lastIpcArguments[2]).eqls({ providerId: 'testId', menuItem: menuItem });
+});
+
+test('Should remove menu item on dispose', () => {
+  const deleteItem = vi.spyOn(trayMenu, 'deleteProviderItem');
+  menuRegistry.registerProvider({
+    internalId: 'internalId',
+    id: 'testId',
+  } as ProviderInfo);
+
+  const menuItem = { id: 'itemId' };
+  const disposable = menuRegistry.registerProviderMenuItem('testId', menuItem);
+  disposable.dispose();
+
+  expect(deleteItem.mock.calls).length(1);
+  expect(deleteItem.mock.lastCall).eqls(['testId', 'itemId']);
+});

--- a/packages/main/src/plugin/tray-menu-registry.ts
+++ b/packages/main/src/plugin/tray-menu-registry.ts
@@ -150,6 +150,7 @@ export class TrayMenuRegistry {
     this.menuItems.set(menuItem.id, menuItem);
     ipcMain.emit('tray:add-provider-menu-item', '', { providerId, menuItem });
     return Disposable.create(() => {
+      this.trayMenu.deleteProviderItem(providerId, menuItem.id);
       this.menuItems.delete(menuItem.id);
     });
   }

--- a/packages/main/src/plugin/tray-menu-registry.ts
+++ b/packages/main/src/plugin/tray-menu-registry.ts
@@ -146,9 +146,9 @@ export class TrayMenuRegistry {
     });
   }
 
-  registerProviderMenuItem(providerName: string, menuItem: MenuItem): Disposable {
+  registerProviderMenuItem(providerId: string, menuItem: MenuItem): Disposable {
     this.menuItems.set(menuItem.id, menuItem);
-    ipcMain.emit('tray:add-provider-menu-item', '', { providerName, menuItem });
+    ipcMain.emit('tray:add-provider-menu-item', '', { providerId, menuItem });
     return Disposable.create(() => {
       this.menuItems.delete(menuItem.id);
     });

--- a/packages/main/src/tray-menu.spec.ts
+++ b/packages/main/src/tray-menu.spec.ts
@@ -1,0 +1,81 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { MenuItemConstructorOptions, Tray } from 'electron';
+import { Menu } from 'electron';
+import { ipcMain } from 'electron';
+import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
+import type { ProviderInfo } from './plugin/api/provider-info';
+import type { AnimatedTray } from './tray-animate-icon';
+import { TrayMenu } from './tray-menu';
+
+let trayMenu: TrayMenu;
+let tray;
+let animatedTray;
+vi.mock('electron', async () => {
+  const Menu = vi.fn();
+  Menu['buildFromTemplate'] = vi.fn();
+  return {
+    Menu,
+    ipcMain: {
+      emit: vi.fn(),
+      on: vi.fn(),
+    },
+    nativeImage: {
+      createFromDataURL: vi.fn(),
+    },
+  };
+});
+
+beforeAll(() => {
+  tray = {
+    setContextMenu: vi.fn(),
+  } as unknown as Tray;
+  animatedTray = {
+    setStatus: vi.fn(),
+  } as unknown as AnimatedTray;
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+test('Tray delete provider item', () => {
+  const onSpy = vi.spyOn(ipcMain, 'on');
+  const menuBuild = vi.spyOn(Menu, 'buildFromTemplate');
+
+  trayMenu = new TrayMenu(tray, animatedTray);
+
+  trayMenu.addProviderItems({
+    id: 'testId',
+    name: 'TestProv',
+    internalId: 'internalId',
+  } as ProviderInfo);
+
+  onSpy.mock.calls[0][1](undefined as unknown as Electron.IpcMainEvent, {
+    providerId: 'testId',
+    menuItem: { id: 'itemId', label: 'SomeLabel' },
+  });
+
+  trayMenu.deleteProviderItem('testId', 'itemId');
+  expect(
+    (menuBuild.mock.lastCall?.[0][0].submenu as Array<MenuItemConstructorOptions>)?.filter(
+      it => it.label === 'SomeLabel',
+    ),
+  ).to.be.empty;
+});

--- a/packages/main/src/tray-menu.ts
+++ b/packages/main/src/tray-menu.ts
@@ -116,6 +116,16 @@ export class TrayMenu {
     this.updateMenu();
   }
 
+  public deleteProviderItem(providerId: string, itemId: string): void {
+    const provider = Array.from(this.menuProviderItems.values()).find(item => item.id === providerId);
+    if (provider) {
+      provider.childItems = provider.childItems.filter(it => it.id !== itemId);
+      this.updateMenu();
+    } else {
+      console.error(`Cannot find provider ${providerId}`);
+    }
+  }
+
   // Handle provider container connection
   handleConnection(
     action: string,


### PR DESCRIPTION
### What does this PR do?
It fix registration of provider tray menu, by properly sending `providerId`.
And, also, fix deleting/removing provider menu item, as `Disposable` which created upon registration is not remove command from tray itself.

As `TrayMenu` expects to receive object with field `providerId` , but we send `providerName`.

### Screenshot/screencast of this PR
Without this fix, any tray provider menu item added in to `temp` sub menu:
<img width="262" alt="Screenshot 2023-03-22 at 15 01 12" src="https://user-images.githubusercontent.com/929743/226912633-e42fbad0-290c-4045-9d6a-395d5f54c3d7.png">

With this fix tray menu item adde to proper provider sub menu:

<img width="262" alt="Screenshot 2023-03-22 at 14 59 52" src="https://user-images.githubusercontent.com/929743/226912778-8c3cbae5-2b09-4189-b6e2-085e755812bb.png">


<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?
n/a
<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

### How to test this PR?

In your extension use `extensionApi.tray.registerProviderMenuItem` function to register command for your provider,
ensure that your command is on proper sub menu of tray menu. (i.e. no under `temp` menu item)

<!-- Please explain steps to reproduce -->
