### PR TITLE
tests: fix issue with yarn test not working on mac / not running binary correctly

### DIFF
--- a/extensions/podman/src/compatibility-mode.spec.ts
+++ b/extensions/podman/src/compatibility-mode.spec.ts
@@ -40,12 +40,13 @@ test('darwin: compatibility mode binary not found failure', async () => {
     value: 'darwin',
   });
 
-  const compatibility = getSocketCompatibility();
-  expect(compatibility).toBeInstanceOf(DarwinSocketCompatibility);
+  // Mock that the binary is not found
+  const socketCompatClass = new DarwinSocketCompatibility();
+  const spyFindPodmanHelper = vi.spyOn(socketCompatClass, 'findPodmanHelper');
+  spyFindPodmanHelper.mockReturnValue('');
 
-  await compatibility.enable();
-
-  // Expect the binary to have not been found
+  // Expect the error to show when it's not found / enable isn't ran.
+  await socketCompatClass.enable();
   expect(extensionApi.window.showErrorMessage).toHaveBeenCalledWith('podman-mac-helper binary not found.', 'OK');
 });
 
@@ -59,9 +60,7 @@ test('darwin: DarwinSocketCompatibility class, test runSudoMacHelperCommand ran 
 
   // Mock that the binary is found
   const spyFindPodmanHelper = vi.spyOn(socketCompatClass, 'findPodmanHelper');
-  spyFindPodmanHelper.mockImplementation(() => {
-    return Promise.resolve('/opt/podman/bin/podman-mac-helper');
-  });
+  spyFindPodmanHelper.mockReturnValue('/opt/podman/bin/podman-mac-helper');
 
   // Mock that sudo ran successfully (since we cannot test sudo-prompt in vitest / has to be integration tests)
   const spyMacHelperCommand = vi.spyOn(socketCompatClass, 'runSudoMacHelperCommand');


### PR DESCRIPTION
tests: fix issue with yarn test not working on mac / not running binary correctly

### What does this PR do?

Try to run `yarn test` on mac for the podman extension and it does not
work. The test was written incorrectly (wasn't actually properly
working).

The "sudo-prompt" will come up when running the test locally, which indicates that the "fake binary not found" test wasn't written correctly.

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

![Screenshot 2023-03-22 at 11 52 03 AM](https://user-images.githubusercontent.com/6422176/226969304-3dde6230-a847-4c24-bca7-dda589c2b0e6.png)


### What issues does this PR fix or reference?

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

N/A

### How to test this PR?

<!-- Please explain steps to reproduce -->

cd extensions/podman
yarn build && yarn test

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
