### PR TITLE
fix(tests): ensure onMount method is called on components

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationRendering.spec.ts
@@ -21,7 +21,7 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 
 import '@testing-library/jest-dom';
-import { beforeAll, test, expect, vi } from 'vitest';
+import { test, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/svelte';
 import PreferencesConnectionCreationRendering from './PreferencesConnectionCreationRendering.svelte';
 import type { IConfigurationPropertyRecordedSchema } from '../../../../main/src/plugin/configuration-registry';
@@ -35,9 +35,24 @@ const providerInfo: ProviderInfo = {
 } as unknown as ProviderInfo;
 const propertyScope = 'FOO';
 
+beforeAll(() => {
+  (window as any).getConfigurationValue = vi.fn();
+  (window as any).updateConfigurationValue = vi.fn();
+
+  Object.defineProperty(window, 'matchMedia', {
+    value: () => {
+      return {
+        matches: false,
+        addListener: () => {},
+        removeListener: () => {},
+      };
+    },
+  });
+});
+
 test('Expect that the create button is available', async () => {
   const callback = vi.fn();
-  render(PreferencesConnectionCreationRendering, { properties, providerInfo, propertyScope, callback });
+  await render(PreferencesConnectionCreationRendering, { properties, providerInfo, propertyScope, callback });
   const createButton = screen.getByRole('button', { name: 'Create' });
   expect(createButton).toBeInTheDocument();
   expect(createButton).toBeEnabled();
@@ -57,7 +72,7 @@ test('Expect create connection successfully', async () => {
     providedKeyLogger = keyLogger;
   });
 
-  render(PreferencesConnectionCreationRendering, { properties, providerInfo, propertyScope, callback });
+  await render(PreferencesConnectionCreationRendering, { properties, providerInfo, propertyScope, callback });
   const createButton = screen.getByRole('button', { name: 'Create' });
   expect(createButton).toBeInTheDocument();
   // click on the button

--- a/packages/renderer/src/lib/welcome/WelcomePage.spec.ts
+++ b/packages/renderer/src/lib/welcome/WelcomePage.spec.ts
@@ -16,8 +16,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
 import '@testing-library/jest-dom';
-import { beforeAll, test, expect } from 'vitest';
+import { beforeAll, test, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/svelte';
 import WelcomePage from './WelcomePage.svelte';
 import type { Unsubscriber } from 'svelte/store';
@@ -28,8 +30,10 @@ let path: string;
 
 // fake the window.events object
 beforeAll(() => {
+  (window as any).getConfigurationValue = vi.fn();
+  (window as any).updateConfigurationValue = vi.fn();
+
   (window.events as unknown) = {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     receive: (_channel: string, func: any) => {
       func();
     },
@@ -45,21 +49,21 @@ afterAll(() => {
 });
 
 test('Expect the close button is on the page', async () => {
-  render(WelcomePage, { showWelcome: true });
+  await render(WelcomePage, { showWelcome: true });
   const button = screen.getByRole('button', { name: 'Go to Podman Desktop' });
   expect(button).toBeInTheDocument();
   expect(button).toBeEnabled();
 });
 
 test('Expect the settings button is on the page', async () => {
-  render(WelcomePage, { showWelcome: true });
+  await render(WelcomePage, { showWelcome: true });
   const button = screen.getByRole('button', { name: 'Settings' });
   expect(button).toBeInTheDocument();
   expect(button).toBeEnabled();
 });
 
 test('Expect that the close button closes the window', async () => {
-  render(WelcomePage, { showWelcome: true });
+  await render(WelcomePage, { showWelcome: true });
   const button = screen.getByRole('button', { name: 'Go to Podman Desktop' });
   await fireEvent.click(button);
 
@@ -68,7 +72,8 @@ test('Expect that the close button closes the window', async () => {
 });
 
 test('Expect that the settings button closes the window and opens the settings', async () => {
-  render(WelcomePage, { showWelcome: true });
+  await render(WelcomePage, { showWelcome: true });
+
   const button = screen.getByRole('button', { name: 'Settings' });
   await fireEvent.click(button);
 

--- a/packages/renderer/vite.config.js
+++ b/packages/renderer/vite.config.js
@@ -45,6 +45,10 @@ export default defineConfig({
     include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
     globals: true,
     environment: 'jsdom',
+    alias: [
+      // https://github.com/vitest-dev/vitest/issues/2834
+      { find: /^svelte$/, replacement: 'svelte/internal' },
+    ],
     deps: {
       inline: [
         'moment',


### PR DESCRIPTION
### What does this PR do?


### Screenshot/screencast of this PR

- [x] First commit ensure that `onMount` method is called on components https://github.com/containers/podman-desktop/pull/1796/commits/ed4f20c34b5259248f568b011a978f9a0832a041
- [x] Second commit fix the tests because now the onMount method is called https://github.com/containers/podman-desktop/pull/1796/commits/840fce5733b1ccef4909ecc7b7da0c166cb4b617
Also we need to use await on renderer method if there are asynchronous `onMount` methods.

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop/issues/1795

### How to test this PR?

Tests should be ✅ 