### PR TITLE
fix(extension-api): Handle esc key for QuickPickInput

### DIFF
--- a/packages/renderer/src/lib/dialogs/QuickPickInput.spec.ts
+++ b/packages/renderer/src/lib/dialogs/QuickPickInput.spec.ts
@@ -1,0 +1,70 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import '@testing-library/jest-dom';
+import { beforeAll, test, expect, vi } from 'vitest';
+import { render } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import QuickPickInput from './QuickPickInput.svelte';
+import type { QuickPickOptions } from './quickpick-input';
+
+const sendShowQuickPickValuesMock = vi.fn();
+const sendShowInputBoxValueMock = vi.fn();
+const receiveFunctionMock = vi.fn();
+
+// mock some methods of the window object
+beforeAll(() => {
+  (window.events as unknown) = {
+    receive: receiveFunctionMock,
+  };
+  (window as any).sendShowQuickPickValues = sendShowQuickPickValuesMock;
+  (window as any).sendShowInputBoxValue = sendShowInputBoxValueMock;
+});
+
+describe('QuickPickInput', () => {
+  test('Expect that esc key is sending an answer', async () => {
+    const idRequest = 123;
+
+    const quickPickOptions: QuickPickOptions = {
+      items: ['item1', 'item2'],
+      canPickMany: false,
+      placeHolder: 'placeHolder',
+      prompt: '',
+      id: idRequest,
+      onSelectCallback: false,
+    };
+
+    receiveFunctionMock.mockImplementation((message: string, callback: (options: QuickPickOptions) => void) => {
+      if (message === 'showQuickPick:add') {
+        callback(quickPickOptions);
+      }
+    });
+
+    render(QuickPickInput, {});
+    // now, press the ESC key
+    await userEvent.keyboard('{Escape}');
+
+    // check we received the answer for showQuickPick
+    expect(sendShowQuickPickValuesMock).toBeCalledWith(idRequest, []);
+
+    // and not for showInputBox
+    expect(sendShowInputBoxValueMock).not.toBeCalled();
+  });
+});

--- a/packages/renderer/src/lib/dialogs/QuickPickInput.svelte
+++ b/packages/renderer/src/lib/dialogs/QuickPickInput.svelte
@@ -175,7 +175,11 @@ function handleKeydown(e: KeyboardEvent) {
       e.preventDefault();
       return;
     }
-    window.sendShowInputBoxValue(currentId, undefined, undefined);
+    if (mode === 'QuickPick') {
+      window.sendShowQuickPickValues(currentId, []);
+    } else if (mode === 'InputBox') {
+      window.sendShowInputBoxValue(currentId, undefined, undefined);
+    }
     cleanup();
     e.preventDefault();
     return;


### PR DESCRIPTION
### What does this PR do?
Handle if user click esc key for QuickPickInput

depends on:
- [x] : https://github.com/containers/podman-desktop/pull/1796

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/1695

### How to test this PR?

<!-- Please explain steps to reproduce -->


Change-Id: I460ef74f1dd561a3e2ed77d0b4638f1ef4e4dfc0
