### PR TITLE
fix: provider tray menu items disappearance

### DIFF
--- a/packages/main/src/tray-menu.spec.ts
+++ b/packages/main/src/tray-menu.spec.ts
@@ -79,3 +79,33 @@ test('Tray delete provider item', () => {
     ),
   ).to.be.empty;
 });
+
+test('Tray update provider not delete provider items', () => {
+  const onSpy = vi.spyOn(ipcMain, 'on');
+  const menuBuild = vi.spyOn(Menu, 'buildFromTemplate');
+
+  trayMenu = new TrayMenu(tray, animatedTray);
+
+  trayMenu.addProviderItems({
+    id: 'testId',
+    name: 'TestProv',
+    internalId: 'internalId',
+  } as ProviderInfo);
+
+  onSpy.mock.calls[0][1](undefined as unknown as Electron.IpcMainEvent, {
+    providerId: 'testId',
+    menuItem: { id: 'itemId', label: 'SomeLabel' },
+  });
+
+  trayMenu.addProviderItems({
+    id: 'testId',
+    name: 'TestProv',
+    internalId: 'internalId',
+  } as ProviderInfo);
+
+  expect(
+    (menuBuild.mock.lastCall?.[0][0].submenu as Array<MenuItemConstructorOptions>)?.filter(
+      it => it.label === 'SomeLabel',
+    ),
+  ).to.be.not.empty;
+});

--- a/packages/main/src/tray-menu.ts
+++ b/packages/main/src/tray-menu.ts
@@ -190,8 +190,7 @@ export class TrayMenu {
     };
 
     const oldProvider = this.menuProviderItems.get(providerMenuItem.internalId);
-    if (oldProvider && oldProvider.name === 'temp') {
-      this.menuProviderItems.delete(provider.internalId);
+    if (oldProvider) {
       providerMenuItem.childItems.push(...oldProvider.childItems);
     }
     this.menuProviderItems.set(provider.internalId, providerMenuItem);


### PR DESCRIPTION
### What does this PR do?
It fixes provider tray menu items disappearance after provider status change.
We don't copy existing additional menu items during provider update.

### Screenshot/screencast of this PR

Before this PR:

Extension contributes menu item `Delete`:
<img width="314" alt="Screenshot 2023-03-23 at 16 55 41" src="https://user-images.githubusercontent.com/929743/227246333-32b3dd94-acca-4411-bb30-e11bec4df34d.png">

But it disappeared after provider status change:

<img width="314" alt="Screenshot 2023-03-23 at 16 55 52" src="https://user-images.githubusercontent.com/929743/227246571-1e7f7cf5-87c2-47cc-a552-2ac609d07684.png">

With this PR:

Extension contributes menu item `Delete`:


<img width="314" alt="Screenshot 2023-03-23 at 16 57 50" src="https://user-images.githubusercontent.com/929743/227246717-37e89acc-422a-4522-9057-dc76f173f775.png">

And after status change it still present:

<img width="314" alt="Screenshot 2023-03-23 at 16 59 55" src="https://user-images.githubusercontent.com/929743/227246843-f402d689-af4d-4602-b578-5e3424600ff8.png">

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?
n/a
<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

### How to test this PR?
Just register any menu item with `tray.registerProviderMenuItem`
Ensure that it appears in tray menu
Then trigger provider status change
Ensure that you menu item is still present in tray

<!-- Please explain steps to reproduce -->
