### PR TITLE
chore: allow running and debugging external extensions

### DIFF
--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -68,6 +68,8 @@ export interface ActivatedExtension {
   extensionContext: containerDesktopAPI.ExtensionContext;
 }
 
+const EXTENSION_OPTION = '--extension-folder';
+
 export class ExtensionLoader {
   private overrideRequireDone = false;
 
@@ -194,8 +196,10 @@ export class ExtensionLoader {
       // in development mode, use the extensions locally
       folders = await this.readDevelopmentFolders(path.join(__dirname, '../../../extensions'));
     }
+    const externalExtensions = await this.readExternalFolders();
     // ok now load all extensions from these folders
     await Promise.all(folders.map(folder => this.loadExtension(folder, false)));
+    await Promise.all(externalExtensions.map(folder => this.loadExtension(folder, false)));
 
     // also load extensions from the plugins directory
     if (fs.existsSync(this.pluginsDirectory)) {
@@ -213,12 +217,16 @@ export class ExtensionLoader {
   async readDevelopmentFolders(path: string): Promise<string[]> {
     const entries = await fs.promises.readdir(path, { withFileTypes: true });
     // filter only directories ignoring node_modules directory
-    const pathes = entries
+    return entries
       .filter(entry => entry.isDirectory())
       .filter(directory => directory.name !== 'node_modules')
       .map(directory => path + '/' + directory.name);
+  }
+
+  async readExternalFolders(): Promise<string[]> {
+    const pathes = [];
     for (let index = 0; index < process.argv.length; index++) {
-      if (process.argv[index] === '--extension' && index < process.argv.length - 1) {
+      if (process.argv[index] === EXTENSION_OPTION && index < process.argv.length - 1) {
         pathes.push(process.argv[++index]);
       }
     }

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -213,10 +213,16 @@ export class ExtensionLoader {
   async readDevelopmentFolders(path: string): Promise<string[]> {
     const entries = await fs.promises.readdir(path, { withFileTypes: true });
     // filter only directories ignoring node_modules directory
-    return entries
+    const pathes = entries
       .filter(entry => entry.isDirectory())
       .filter(directory => directory.name !== 'node_modules')
       .map(directory => path + '/' + directory.name);
+    for (let index = 0; index < process.argv.length; index++) {
+      if (process.argv[index] === '--extension' && index < process.argv.length - 1) {
+        pathes.push(process.argv[++index]);
+      }
+    }
+    return pathes;
   }
 
   async readProductionFolders(path: string): Promise<string[]> {

--- a/scripts/watch.cjs
+++ b/scripts/watch.cjs
@@ -40,11 +40,13 @@ const getWatcher = ({ name, configFile, writeBundle }) => {
   });
 };
 
+const EXTENSION_OPTION = '--extension';
+
 /**
  * Start or restart App when source files are changed
  * @param {{config: {server: import('vite').ResolvedServerOptions}}} ResolvedServerOptions
  */
-const setupMainPackageWatcher = ({ config: { server } }) => {
+const setupMainPackageWatcher = ({ config: { server, extensions } }) => {
   // Create VITE_DEV_SERVER_URL environment variable to pass it to the main process.
   {
     const protocol = server.https ? 'https:' : 'http:';
@@ -71,7 +73,12 @@ const setupMainPackageWatcher = ({ config: { server } }) => {
         spawnProcess = null;
       }
 
-      spawnProcess = spawn(String(electronPath), [ '--remote-debugging-port=9223', '.'], { env: { ...process.env, ELECTRON_IS_DEV: 1 } });
+      const extensionArgs = [];
+      extensions.forEach(extension => {
+        extensionArgs.push(EXTENSION_OPTION);
+        extensionArgs.push(extension);
+      })
+      spawnProcess = spawn(String(electronPath), [ '--remote-debugging-port=9223', '.', ...extensionArgs], { env: { ...process.env, ELECTRON_IS_DEV: 1 } });
 
       spawnProcess.stdout.on('data', d => d.toString().trim() && logger.warn(d.toString(), { timestamp: true }));
       spawnProcess.stderr.on('data', d => {
@@ -135,7 +142,7 @@ const setupPreloadDockerExtensionPackageWatcher = ({ ws }) =>
  */
 const setupExtensionApiWatcher = name => {
   let spawnProcess;
-  const folderName = path.resolve(__dirname, '../extensions/' + name);
+  const folderName = path.resolve(name);
 
   console.log('dirname is', folderName);
   spawnProcess = spawn('yarn', ['--cwd', folderName, 'watch'], { shell: process.platform === 'win32' });
@@ -153,19 +160,29 @@ const setupExtensionApiWatcher = name => {
 
 (async () => {
   try {
+    const extensions = []
+    for(let index=0; index < process.argv.length;index++) {
+      if (process.argv[index] === EXTENSION_OPTION && index < process.argv.length - 1) {
+        extensions.push(path.resolve(process.argv[++index]));
+      }
+    }
     const viteDevServer = await createServer({
       ...sharedConfig,
       configFile: 'packages/renderer/vite.config.js',
+      extensions: extensions
     });
 
     await viteDevServer.listen();
-    await setupExtensionApiWatcher('compose');
-    await setupExtensionApiWatcher('docker');
-    await setupExtensionApiWatcher('kube-context');
-    await setupExtensionApiWatcher('lima');
-    await setupExtensionApiWatcher('podman');
-    await setupExtensionApiWatcher('kind');
-    await setupExtensionApiWatcher('registries');
+    await setupExtensionApiWatcher(path.resolve(__dirname, '../extensions/compose'));
+    await setupExtensionApiWatcher(path.resolve(__dirname, '../extensions/docker'));
+    await setupExtensionApiWatcher(path.resolve(__dirname, '../extensions/kube-context'));
+    await setupExtensionApiWatcher(path.resolve(__dirname, '../extensions/lima'));
+    await setupExtensionApiWatcher(path.resolve(__dirname, '../extensions/podman'));
+    await setupExtensionApiWatcher(path.resolve(__dirname, '../extensions/kind'));
+    await setupExtensionApiWatcher(path.resolve(__dirname, '../extensions/registries'));
+    for (const extension of extensions) {
+      await setupExtensionApiWatcher(extension);
+    }
     await setupPreloadPackageWatcher(viteDevServer);
     await setupPreloadDockerExtensionPackageWatcher(viteDevServer);
     await setupMainPackageWatcher(viteDevServer);

--- a/scripts/watch.cjs
+++ b/scripts/watch.cjs
@@ -40,7 +40,7 @@ const getWatcher = ({ name, configFile, writeBundle }) => {
   });
 };
 
-const EXTENSION_OPTION = '--extension';
+const EXTENSION_OPTION = '--extension-folder';
 
 /**
  * Start or restart App when source files are changed
@@ -158,6 +158,10 @@ const setupExtensionApiWatcher = name => {
   spawnProcess.on('exit', process.exit);
 };
 
+const setupBuiltinExtensionApiWatcher = name => {
+  setupExtensionApiWatcher(path.resolve(__dirname, '../extensions/' + name));
+}
+
 (async () => {
   try {
     const extensions = []
@@ -173,13 +177,13 @@ const setupExtensionApiWatcher = name => {
     });
 
     await viteDevServer.listen();
-    await setupExtensionApiWatcher(path.resolve(__dirname, '../extensions/compose'));
-    await setupExtensionApiWatcher(path.resolve(__dirname, '../extensions/docker'));
-    await setupExtensionApiWatcher(path.resolve(__dirname, '../extensions/kube-context'));
-    await setupExtensionApiWatcher(path.resolve(__dirname, '../extensions/lima'));
-    await setupExtensionApiWatcher(path.resolve(__dirname, '../extensions/podman'));
-    await setupExtensionApiWatcher(path.resolve(__dirname, '../extensions/kind'));
-    await setupExtensionApiWatcher(path.resolve(__dirname, '../extensions/registries'));
+    await setupBuiltinExtensionApiWatcher('compose');
+    await setupBuiltinExtensionApiWatcher('docker');
+    await setupBuiltinExtensionApiWatcher('kube-context');
+    await setupBuiltinExtensionApiWatcher('lima');
+    await setupBuiltinExtensionApiWatcher('podman');
+    await setupBuiltinExtensionApiWatcher('kind');
+    await setupBuiltinExtensionApiWatcher('registries');
     for (const extension of extensions) {
       await setupExtensionApiWatcher(extension);
     }


### PR DESCRIPTION
Fixes #1663

### What does this PR do?

Allow adding external extensions to be loaded when running `yarn:watch`. Simply add `--extension-folder extension_path` when runnning yarn watch. If you want to add more than one extension, add another `--extension-folder` tuple
I tested with `yarn watch --extension-folder ../../crc-org/crc-extension`

I was able to reach a breakpoint in the external extension through WebStorm but not through VSCode so I let VSCode fans test it.

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?

Fixes #1663

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

### How to test this PR?

`yarn watch --extension-folder extension_path`
