### PR TITLE
fix: Remove setFeedURL for updating

### DIFF
--- a/packages/main/src/index.ts
+++ b/packages/main/src/index.ts
@@ -25,19 +25,11 @@ import { AnimatedTray } from './tray-animate-icon';
 import { PluginSystem } from './plugin';
 import { StartupInstall } from './system/startup-install';
 
-export const UPDATER_PROVIDER = 'github';
-export const UPDATER_OWNER = 'containers';
-export const UPDATER_REPO = 'podman-desktop';
 export const UPDATER_UPDATE_AVAILABLE_ICON = 'fa fa-exclamation-triangle';
 
 // Check for updates when initially ready as well as set a 6 hour interval for any checks
 if (import.meta.env.PROD) {
   import('electron-updater').then(({ autoUpdater }) => {
-    autoUpdater.setFeedURL({
-      provider: UPDATER_PROVIDER,
-      owner: UPDATER_OWNER,
-      repo: UPDATER_REPO,
-    });
     app
       .whenReady()
       .then(() => {

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -22,7 +22,7 @@
 import * as os from 'node:os';
 import * as path from 'path';
 import type * as containerDesktopAPI from '@podman-desktop/api';
-import { UPDATER_PROVIDER, UPDATER_OWNER, UPDATER_REPO, UPDATER_UPDATE_AVAILABLE_ICON } from '..';
+import { UPDATER_UPDATE_AVAILABLE_ICON } from '..';
 import { CommandRegistry } from './command-registry';
 import { ContainerProviderRegistry } from './container-registry';
 import { ExtensionLoader } from './extension-loader';
@@ -367,15 +367,6 @@ export class PluginSystem {
     if (import.meta.env.PROD) {
       // Only import on production builds
       import('electron-updater').then(({ autoUpdater }) => {
-        // Setting the feed URL is now required as we are now using
-        // autoUpdater.on('update-available', () => {
-        // in other parts of the code
-        autoUpdater.setFeedURL({
-          provider: UPDATER_PROVIDER,
-          owner: UPDATER_OWNER,
-          repo: UPDATER_REPO,
-        });
-
         // autoUpdater.checkForUpdatesAndNotify() is called from main/src/index.ts
         autoUpdater.on('update-available', () => {
           // Update the 'version' entry in the status bar to show that an update is available


### PR DESCRIPTION
fix: Remove setFeedURL for updating

### What does this PR do?

* setFeedURL shouldn't be required (electron-builder autodetects)
* fixes the "update" not working on production binaries

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

N/A

### What issues does this PR fix or reference?

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

### How to test this PR?

<!-- Please explain steps to reproduce -->

Download the compiled binary and test out the update functionality.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
