### PR TITLE
fix: Copy button doesn't work in containers section

### DIFF
--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -92,6 +92,7 @@ import { MenuRegistry } from '/@/plugin/menu-registry';
 import { CancellationTokenRegistry } from './cancellation-token-registry';
 import type { UpdateCheckResult } from 'electron-updater';
 import { autoUpdater } from 'electron-updater';
+import { clipboard } from 'electron';
 
 type LogType = 'log' | 'warn' | 'trace' | 'debug' | 'error';
 
@@ -846,6 +847,10 @@ export class PluginSystem {
 
     this.ipcHandle('command-registry:executeCommand', async (_, command: string, ...args: unknown[]): Promise<void> => {
       return commandRegistry.executeCommand(command, ...args);
+    });
+
+    this.ipcHandle('clipboard:writeText', async (_, text: string, type?: 'selection' | 'clipboard'): Promise<void> => {
+      return clipboard.writeText(text, type);
     });
 
     this.ipcHandle(

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -679,6 +679,13 @@ function initExposure(): void {
     return ipcInvoke('command-registry:executeCommand', command, ...args);
   });
 
+  contextBridge.exposeInMainWorld(
+    'clipboardWriteText',
+    async (text: string, type?: 'selection' | 'clipboard'): Promise<void> => {
+      return ipcInvoke('clipboard:writeText', text, type);
+    },
+  );
+
   let onDidUpdateProviderStatusId = 0;
   const onDidUpdateProviderStatuses = new Map<number, (providerInfo: ProviderInfo) => void>();
 

--- a/packages/renderer/src/lib/ui/EmptyScreen.spec.ts
+++ b/packages/renderer/src/lib/ui/EmptyScreen.spec.ts
@@ -1,0 +1,34 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+
+import '@testing-library/jest-dom';
+import { test, expect } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import EmptyScreen from './EmptyScreen.svelte';
+
+test('Expect copy in clipboard', async () => {
+  render(EmptyScreen, {commandline: 'podman run hello:world'});
+  const button = screen.getByRole('button');
+  expect(button).toBeInTheDocument();
+  expect(button).toBeEnabled();
+  button.click();
+  const div = screen.getByTestId('copyTextDivElement');
+  expect(div).toBeInTheDocument();
+});
+

--- a/packages/renderer/src/lib/ui/EmptyScreen.spec.ts
+++ b/packages/renderer/src/lib/ui/EmptyScreen.spec.ts
@@ -33,5 +33,5 @@ test('Expect copy in clipboard', async () => {
   expect(button).toBeInTheDocument();
   expect(button).toBeEnabled();
   await fireEvent.click(button);
-  expect(mock).toBeCalledTimes(1);
+  expect(mock).toBeCalledWith('podman run hello:world');
 });

--- a/packages/renderer/src/lib/ui/EmptyScreen.spec.ts
+++ b/packages/renderer/src/lib/ui/EmptyScreen.spec.ts
@@ -25,7 +25,6 @@ import EmptyScreen from './EmptyScreen.svelte';
 /* eslint-disable @typescript-eslint/no-empty-function */
 
 test('Expect copy in clipboard', async () => {
-  console.log('start test');
   const mock = vi.fn().mockImplementation(() => {});
   (window as any).clipboardWriteText = mock;
   render(EmptyScreen, { commandline: 'podman run hello:world' });

--- a/packages/renderer/src/lib/ui/EmptyScreen.spec.ts
+++ b/packages/renderer/src/lib/ui/EmptyScreen.spec.ts
@@ -16,19 +16,22 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-
 import '@testing-library/jest-dom';
-import { test, expect } from 'vitest';
-import { render, screen } from '@testing-library/svelte';
+import { test, expect, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/svelte';
 import EmptyScreen from './EmptyScreen.svelte';
 
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-empty-function */
+
 test('Expect copy in clipboard', async () => {
-  render(EmptyScreen, {commandline: 'podman run hello:world'});
+  console.log('start test');
+  const mock = vi.fn().mockImplementation(() => {});
+  (window as any).clipboardWriteText = mock;
+  render(EmptyScreen, { commandline: 'podman run hello:world' });
   const button = screen.getByRole('button');
   expect(button).toBeInTheDocument();
   expect(button).toBeEnabled();
-  button.click();
-  const div = screen.getByTestId('copyTextDivElement');
-  expect(div).toBeInTheDocument();
+  await fireEvent.click(button);
+  expect(mock).toBeCalledTimes(1);
 });
-

--- a/packages/renderer/src/lib/ui/EmptyScreen.svelte
+++ b/packages/renderer/src/lib/ui/EmptyScreen.svelte
@@ -21,7 +21,7 @@ onMount(() => {
 });
 
 function copyRunInstructionToClipboard() {
-  const text = copyTextDivElement?.innerText;
+  const text = copyTextDivElement?.textContent;
   window.clipboardWriteText(text);
 }
 

--- a/packages/renderer/src/lib/ui/EmptyScreen.svelte
+++ b/packages/renderer/src/lib/ui/EmptyScreen.svelte
@@ -22,7 +22,7 @@ onMount(() => {
 
 function copyRunInstructionToClipboard() {
   const text = copyTextDivElement?.innerText;
-  navigator.clipboard.writeText(text);
+  window.clipboardWriteText(text);
 }
 
 let copyTextDivElement: HTMLDivElement;
@@ -52,7 +52,7 @@ let copyTextDivElement: HTMLDivElement;
       <div class="pf-c-empty-state__body">{message}</div>
       {#if commandline.length > 0}
         <div class="flex flex-row bg-gray-800 w-full items-center p-2 mt-2">
-          <div bind:this="{copyTextDivElement}">{commandline}</div>
+          <div bind:this="{copyTextDivElement}" data-testid="copyTextDivElement">{commandline}</div>
           <button title="Copy To Clipboard" class="ml-5 mr-5" on:click="{() => copyRunInstructionToClipboard()}"
             ><Fa class="h-5 w-5 cursor-pointer rounded-full text-3xl text-sky-800" icon="{faPaste}" /></button>
         </div>


### PR DESCRIPTION
Fixes #1736

### What does this PR do?

Fix the copy to clipboard feature for production bits

### Screenshot/screencast of this PR


### What issues does this PR fix or reference?

Fixes #1736 
### How to test this PR?

- Generate the production bits
- Launch
- Go the empty containers tab and copy the instruction to clipboard
- Ensure data is in clipboard

<!-- Please explain steps to reproduce -->
