### PR TITLE
chore: use vite to package the extension

### DIFF
--- a/extensions/kind/package.json
+++ b/extensions/kind/package.json
@@ -55,8 +55,8 @@
     }
   },
   "scripts": {
-    "build": "tsc && node ./scripts/build.js",
-    "watch": "tsc -w"
+    "build": "vite build && node ./scripts/build.js",
+    "watch": "vite build --watch"
   },
   "dependencies": {
     "@podman-desktop/api": "^0.0.1",
@@ -65,6 +65,7 @@
   "devDependencies": {
     "7zip-min": "^1.4.4",
     "mkdirp": "^2.1.6",
+    "vite": "^4.2.1",
     "zip-local": "^0.3.5"
   }
 }

--- a/extensions/kind/vite.config.js
+++ b/extensions/kind/vite.config.js
@@ -1,0 +1,61 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import {join} from 'path';
+import {builtinModules} from 'module';
+
+const PACKAGE_ROOT = __dirname;
+
+/**
+ * @type {import('vite').UserConfig}
+ * @see https://vitejs.dev/config/
+ */
+const config = {
+  mode: process.env.MODE,
+  root: PACKAGE_ROOT,
+  envDir: process.cwd(),
+  resolve: {
+    alias: {
+      '/@/': join(PACKAGE_ROOT, 'src') + '/',
+    },
+  },
+  build: {
+    sourcemap: 'inline',
+    target: 'esnext',
+    outDir: 'dist',
+    assetsDir: '.',
+    minify: process.env.MODE === 'production' ? 'esbuild' : false,
+    lib: {
+      entry: 'src/extension.ts',
+      formats: ['cjs'],
+    },
+    rollupOptions: {
+      external: [
+        '@podman-desktop/api',
+        ...builtinModules.flatMap(p => [p, `node:${p}`]),
+      ],
+      output: {
+        entryFileNames: '[name].js',
+      },
+    },
+    emptyOutDir: true,
+    reportCompressedSize: false,
+  },
+};
+
+export default config;


### PR DESCRIPTION
### What does this PR do?

it allows to package/inline all the dependencies
else it does not work in production assembly due to the missing `@octokit/rest` fixes https://github.com/containers/podman-desktop/issues/1783


### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?

fixes #1783 

### How to test this PR?

Check it is still working with the kind extension in development mode

then, copy for example `extensions/podman/scripts/build.js` to `extensions/kind/scripts/build.js` and perform `yarn compile:current` to produce a production binary
Launch it, kind should be there and working