### PR TITLE
fix: kind binary is not detected on macOS

### DIFF
--- a/extensions/kind/src/util.ts
+++ b/extensions/kind/src/util.ts
@@ -91,8 +91,10 @@ export function runCliCommand(command: string, args: string[], options?: RunOpti
     // In production mode, applications don't have access to the 'user' path like brew
     if (isMac() || isWindows()) {
       env.PATH = getKindPath();
-      // Escape any whitespaces in command
-      command = `"${command}"`;
+      if (isWindows()) {
+        // Escape any whitespaces in command
+        command = `"${command}"`;
+      }
     } else if (env.FLATPAK_ID) {
       // need to execute the command on the host
       args = ['--host', command, ...args];


### PR DESCRIPTION

### What does this PR do?
backport the fix for podman
https://github.com/containers/podman-desktop/commit/8f56284cb1eff7a1a2da1c1ead6b4cbe2dfe2446

This kind of backport should be gone once we implement https://github.com/containers/podman-desktop/issues/1585

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/1782


### How to test this PR?

Just trying kind it says that kind is not installed but it's like in a dead-end as it's not checking with the right path

Change-Id: Ia2aec4e858efc2cf9cc91b0f96724d9c1444e608

