### PR TITLE
fix: Settings page cleanup

### DIFF
--- a/packages/renderer/src/lib/ExtensionList.svelte
+++ b/packages/renderer/src/lib/ExtensionList.svelte
@@ -7,6 +7,7 @@ import { afterUpdate, onMount } from 'svelte';
 import { extensionInfos } from '../stores/extensions';
 import type { ExtensionInfo } from '../../../main/src/plugin/api/extension-info';
 import ErrorMessage from './ui/ErrorMessage.svelte';
+import SettingsPage from './preferences/SettingsPage.svelte';
 
 let ociImage: string;
 
@@ -65,12 +66,7 @@ async function removeExtension(extension: ExtensionInfo) {
 }
 </script>
 
-<div class="flex flex-1 flex-col p-2 bg-zinc-900">
-  <div>
-    <p class="capitalize text-xl">Extensions</p>
-    <p class="text-sm text-gray-400"><br /></p>
-  </div>
-
+<SettingsPage title="Extensions">
   <div class="bg-zinc-800 mt-5 rounded-md p-3">
     <h1 class="text-lg mb-2">Install a new extension from OCI Image</h1>
 
@@ -186,4 +182,4 @@ async function removeExtension(extension: ExtensionInfo) {
       </tbody>
     </table>
   </div>
-</div>
+</SettingsPage>

--- a/packages/renderer/src/lib/ExtensionList.svelte
+++ b/packages/renderer/src/lib/ExtensionList.svelte
@@ -65,10 +65,13 @@ async function removeExtension(extension: ExtensionInfo) {
 }
 </script>
 
-<div class="flex flex-1 flex-col p-2 bg-zinc-800">
-  <h1 class="capitalize text-xl">Extensions List</h1>
+<div class="flex flex-1 flex-col p-2 bg-zinc-900">
+  <div>
+    <p class="capitalize text-xl">Extensions</p>
+    <p class="text-sm text-gray-400"><br /></p>
+  </div>
 
-  <div class="bg-zinc-800 border border-zinc-700 p-4 mt-2">
+  <div class="bg-zinc-800 mt-5 rounded-md p-3">
     <h1 class="text-lg mb-2">Install a new extension from OCI Image</h1>
 
     <div class="flex flex-col w-full">

--- a/packages/renderer/src/lib/docker-extension/PreferencesPageDockerExtensions.svelte
+++ b/packages/renderer/src/lib/docker-extension/PreferencesPageDockerExtensions.svelte
@@ -43,27 +43,33 @@ function deleteContribution(extensionName: string) {
 }
 </script>
 
-<div class="flex flex-1 flex-col p-2 bg-zinc-800">
-  <p class="capitalize text-xl">Docker Desktop Extensions</p>
-  <p class="text-xs">There is an ongoing support of Docker Desktop UI extensions from Podman Desktop.</p>
-  <p class="text-xs italic">
-    Not all are guaranteed to work but you can add their OCI Image below to try and load them.
-  </p>
-  <p class="text-xs italic">
-    Example: aquasec/trivy-docker-extension:latest for Trivy extension or redhatdeveloper/openshift-dd-ext:latest for
-    the OpenShift extension.
-  </p>
+<div class="flex flex-1 flex-col p-2 bg-zinc-900">
+  <div>
+    <p class="capitalize text-xl">Docker Desktop Extensions</p>
+    <p class="text-sm text-gray-400"><br /></p>
+  </div>
 
-  <div class="container mx-auto w-full mt-4 flex-col">
-    <div class="flex flex-col mb-4">
-      <label for="ociImage" class="block mb-2 text-sm font-medium text-gray-300">Image name:</label>
-      <input
-        name="ociImage"
-        id="ociImage"
-        bind:value="{ociImage}"
-        placeholder="Name of the Image"
-        class="text-sm rounded-lg focus:ring-purple-500 focus:border-purple-500 block p-2.5 bg-gray-600 border-gray-500 placeholder-gray-400 text-white"
-        required />
+  <div class="bg-zinc-800 mt-5 rounded-md p-3">
+    <p class="text-xs">There is an ongoing support of Docker Desktop UI extensions from Podman Desktop.</p>
+    <p class="text-xs italic">
+      Not all are guaranteed to work but you can add their OCI Image below to try and load them.
+    </p>
+    <p class="text-xs italic">
+      Example: aquasec/trivy-docker-extension:latest for Trivy extension or redhatdeveloper/openshift-dd-ext:latest for
+      the OpenShift extension.
+    </p>
+
+    <div class="container mx-auto w-full mt-4 flex-col">
+      <div class="flex flex-col mb-4">
+        <label for="ociImage" class="block mb-2 text-sm font-medium text-gray-300">Image name:</label>
+        <input
+          name="ociImage"
+          id="ociImage"
+          bind:value="{ociImage}"
+          placeholder="Name of the Image"
+          class="text-sm rounded-lg focus:ring-purple-500 focus:border-purple-500 block p-2.5 bg-gray-600 border-gray-500 placeholder-gray-400 text-white"
+          required />
+      </div>
     </div>
 
     <button

--- a/packages/renderer/src/lib/docker-extension/PreferencesPageDockerExtensions.svelte
+++ b/packages/renderer/src/lib/docker-extension/PreferencesPageDockerExtensions.svelte
@@ -3,6 +3,8 @@ import { afterUpdate } from 'svelte';
 
 import { contributions } from '../../stores/contribs';
 import ErrorMessage from '../ui/ErrorMessage.svelte';
+import SettingsPage from '../preferences/SettingsPage.svelte';
+
 let ociImage: string;
 
 let installInProgress: boolean = false;
@@ -43,12 +45,7 @@ function deleteContribution(extensionName: string) {
 }
 </script>
 
-<div class="flex flex-1 flex-col p-2 bg-zinc-900">
-  <div>
-    <p class="capitalize text-xl">Docker Desktop Extensions</p>
-    <p class="text-sm text-gray-400"><br /></p>
-  </div>
-
+<SettingsPage title="Docker Desktop Extensions">
   <div class="bg-zinc-800 mt-5 rounded-md p-3">
     <p class="text-xs">There is an ongoing support of Docker Desktop UI extensions from Podman Desktop.</p>
     <p class="text-xs italic">
@@ -128,4 +125,4 @@ function deleteContribution(extensionName: string) {
       </div>
     </div>
   {/if}
-</div>
+</SettingsPage>

--- a/packages/renderer/src/lib/preferences/PreferencesProxiesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesProxiesRendering.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import type { ProxySettings } from '@podman-desktop/api';
 import { onMount } from 'svelte';
+import SettingsPage from './SettingsPage.svelte';
 
 let proxySettings: ProxySettings;
 let proxyState: boolean;
@@ -19,12 +20,7 @@ async function updateProxyState() {
 }
 </script>
 
-<div class="flex flex-1 flex-col p-2 bg-zinc-900">
-  <div>
-    <p class="capitalize text-xl">Proxy settings</p>
-    <p class="text-sm text-gray-400"><br /></p>
-  </div>
-
+<SettingsPage title="Proxy Settings">
   <div class="container mx-auto bg-zinc-800 mt-5 rounded-md p-3">
     <!-- if proxy is not enabled, display a toggle -->
 
@@ -98,4 +94,4 @@ async function updateProxyState() {
       {/if}
     {/if}
   </div>
-</div>
+</SettingsPage>

--- a/packages/renderer/src/lib/preferences/PreferencesProxiesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesProxiesRendering.svelte
@@ -19,13 +19,16 @@ async function updateProxyState() {
 }
 </script>
 
-<div class="flex flex-1 flex-col p-2 bg-zinc-800">
-  <h1 class="capitalize text-xl">Proxy settings</h1>
+<div class="flex flex-1 flex-col p-2 bg-zinc-900">
+  <div>
+    <p class="capitalize text-xl">Proxy settings</p>
+    <p class="text-sm text-gray-400"><br /></p>
+  </div>
 
-  <div class="container mx-auto">
+  <div class="container mx-auto bg-zinc-800 mt-5 rounded-md p-3">
     <!-- if proxy is not enabled, display a toggle -->
 
-    <label for="toggle-proxy" class="inline-flex relative items-center my-5 cursor-pointer">
+    <label for="toggle-proxy" class="inline-flex relative items-center mt-2 mb-5 cursor-pointer">
       <input
         type="checkbox"
         bind:checked="{proxyState}"
@@ -51,7 +54,7 @@ async function updateProxyState() {
           id="httpProxy"
           disabled="{!proxyState}"
           bind:value="{proxySettings.httpProxy}"
-          class="ml-2 w-full p-2 outline-none text-sm bg-zinc-900 rounded-sm text-gray-400 placeholder-gray-400"
+          class="w-full p-2 outline-none text-sm bg-zinc-900 rounded-sm text-gray-400 placeholder-gray-400"
           required />
       </div>
       <div>
@@ -65,7 +68,7 @@ async function updateProxyState() {
           id="httpsProxy"
           disabled="{!proxyState}"
           bind:value="{proxySettings.httpsProxy}"
-          class="ml-2 w-full p-2 outline-none text-sm bg-zinc-900 rounded-sm text-gray-400 placeholder-gray-400"
+          class="w-full p-2 outline-none text-sm bg-zinc-900 rounded-sm text-gray-400 placeholder-gray-400"
           required />
       </div>
       <div>
@@ -80,7 +83,7 @@ async function updateProxyState() {
           disabled="{!proxyState}"
           bind:value="{proxySettings.noProxy}"
           placeholder="Example: *.domain.com, 192.168.*.*"
-          class="ml-2 w-full p-2 outline-none text-sm bg-zinc-900 rounded-sm text-gray-400 placeholder-gray-400"
+          class="w-full p-2 outline-none text-sm bg-zinc-900 rounded-sm text-gray-400 placeholder-gray-400"
           required />
       </div>
       {#if proxyState}

--- a/packages/renderer/src/lib/preferences/PreferencesRegistriesEditing.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRegistriesEditing.svelte
@@ -215,13 +215,17 @@ const processPasswordElement = (node: HTMLInputElement, registry: containerDeskt
 };
 </script>
 
-<div class="flex w-full flex-col p-2 bg-zinc-800">
-  <h1 class="capitalize text-lg font-bold py-8 px-8">Registries</h1>
-  <div class="container mx-auto">
+<div class="flex flex-1 flex-col p-2 bg-zinc-900">
+  <div>
+    <p class="capitalize text-xl">Registries</p>
+    <p class="text-sm text-gray-400"><br /></p>
+  </div>
+
+  <div class="container mx-auto bg-zinc-800 mt-5 rounded-md p-3">
     <!-- Registries table start -->
     <div class="w-full border-t border-b border-gray-600">
       <div class="flex w-full">
-        <div class="flex-1 text-left py-4 pl-10 text-sm font-bold w-auto">Registry Location</div>
+        <div class="flex-1 text-left py-4 pl-5 text-sm font-bold w-auto">Registry Location</div>
         <div class="text-left py-4 text-sm font-bold w-1/4">Username</div>
         <div class="text-left py-4 text-sm font-bold w-2/5">Password</div>
       </div>
@@ -230,7 +234,7 @@ const processPasswordElement = (node: HTMLInputElement, registry: containerDeskt
         <!-- containerDesktopAPI.Registry row start -->
         <div class="flex flex-col w-full border-t border-gray-600">
           <div class="flex flex-row">
-            <div class="flex-1 pt-2 pl-10 pr-5 text-sm w-auto m-auto">
+            <div class="flex-1 pt-2 pl-5 pr-5 text-sm w-auto m-auto">
               <div class="flex items-center w-full h-full">
                 <div class="flex items-center">
                   <!-- Only show if a "suggested" registry icon has been added -->
@@ -401,7 +405,7 @@ const processPasswordElement = (node: HTMLInputElement, registry: containerDeskt
         <!-- Add new registry form start -->
         <div class="flex flex-col w-full border-t border-gray-600">
           <div class="flex flex-row">
-            <div class="flex-1 pt-2 pl-10 pr-5 text-sm w-auto m-auto">
+            <div class="flex-1 pt-2 pl-5 pr-5 text-sm w-auto m-auto">
               <div class="flex items-center w-full h-full">
                 <div class="flex items-center">
                   {#if registry.icon}
@@ -478,7 +482,7 @@ const processPasswordElement = (node: HTMLInputElement, registry: containerDeskt
                   {/if}
                 </div>
                 <div class="flex text-sm">
-                  <div class="h-7 mt-1.5 mb-0.5 text-sm">
+                  <div class="h-7 mt-1.5 mb-0.5 pr-5 text-sm">
                     {#if listedSuggestedRegistries[i]}
                       <button
                         on:click="{() => hideSuggestedRegistries()}"

--- a/packages/renderer/src/lib/preferences/PreferencesRegistriesEditing.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRegistriesEditing.svelte
@@ -7,6 +7,7 @@ import DropdownMenuItem from '../ui/DropDownMenuItem.svelte';
 import { faTrash } from '@fortawesome/free-solid-svg-icons';
 import { faUser } from '@fortawesome/free-solid-svg-icons';
 import { faUserPen } from '@fortawesome/free-solid-svg-icons';
+import SettingsPage from './SettingsPage.svelte';
 
 // contains the original instances of registries when user clicks on `Edit password` menu item
 // to be able to roll back changes when `Cancel` button is clicked
@@ -215,12 +216,7 @@ const processPasswordElement = (node: HTMLInputElement, registry: containerDeskt
 };
 </script>
 
-<div class="flex flex-1 flex-col p-2 bg-zinc-900">
-  <div>
-    <p class="capitalize text-xl">Registries</p>
-    <p class="text-sm text-gray-400"><br /></p>
-  </div>
-
+<SettingsPage title="Registries">
   <div class="container mx-auto bg-zinc-800 mt-5 rounded-md p-3">
     <!-- Registries table start -->
     <div class="w-full border-t border-b border-gray-600">
@@ -612,4 +608,4 @@ const processPasswordElement = (node: HTMLInputElement, registry: containerDeskt
     </button>
   </div>
   <!-- Add new registry button end -->
-</div>
+</SettingsPage>

--- a/packages/renderer/src/lib/preferences/PreferencesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRendering.svelte
@@ -3,6 +3,7 @@ import type { IConfigurationPropertyRecordedSchema } from '../../../../main/src/
 import { CONFIGURATION_DEFAULT_SCOPE } from '../../../../main/src/plugin/configuration-registry-constants';
 
 import PreferencesRenderingItem from './PreferencesRenderingItem.svelte';
+import SettingsPage from './SettingsPage.svelte';
 
 export let properties: IConfigurationPropertyRecordedSchema[] = [];
 export let key: string;
@@ -15,9 +16,9 @@ $: matchingRecords = properties.filter(
 );
 </script>
 
-<div class="flex flex-1 flex-col">
-  <table class="divide-y divide-gray-800 mt-2 min-w-full">
-    <tbody class="bg-zinc-800 divide-y-8 divide-zinc-700">
+<SettingsPage title="Preferences">
+  <table class="divide-y divide-zinc-800 min-w-full mt-5 rounded-md p-3">
+    <tbody class="bg-zinc-800 divide-y-8 divide-zinc-900">
       {#each matchingRecords as record}
         <tr>
           <td>
@@ -27,4 +28,4 @@ $: matchingRecords = properties.filter(
       {/each}
     </tbody>
   </table>
-</div>
+</SettingsPage>

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItem.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItem.svelte
@@ -45,7 +45,7 @@ $: {
 }
 </script>
 
-<div class="flex flex-col px-3 pt-3">
+<div class="flex flex-col px-2 pt-2">
   <div class="flex">
     <div class="capitalize">{recordUI.breadCrumb}</div>
     <div class="pl-2 text-violet-400">{recordUI.title}</div>

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItem.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItem.svelte
@@ -45,7 +45,7 @@ $: {
 }
 </script>
 
-<div class="flex flex-col px-2 pt-2">
+<div class="flex flex-col px-3 pt-3">
   <div class="flex">
     <div class="capitalize">{recordUI.breadCrumb}</div>
     <div class="pl-2 text-violet-400">{recordUI.title}</div>

--- a/packages/renderer/src/lib/preferences/SettingsPage.svelte
+++ b/packages/renderer/src/lib/preferences/SettingsPage.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+export let title: string;
+</script>
+
+<div class="flex flex-1 flex-col p-2 bg-zinc-900">
+  <div>
+    <p class="capitalize text-xl">{title}</p>
+    <p class="text-sm text-gray-400"><br /></p>
+  </div>
+  <slot />
+</div>


### PR DESCRIPTION
### What does this PR do?

It was bugging me that the settings/preferences pages all look completely different based on when they were implemented. Even the Registries page that was done fairly recently didn't match the latest Resources page.

This PR does a really quick pass at:
- Making the title, top-spacing, and background match.
- Using the same colour grey box with rounded corners and padding on each page.
- Two really minor things to start making the rest consistent or closer to current design: removed proxy input fields left margin and evened out the right and left padding on Registries.

This pass does not replace a full design cleanup, it just fixes the most glaring differences.

### Screenshot/screencast of this PR

<img width="257" alt="Screenshot 2023-03-24 at 10 09 04 AM" src="https://user-images.githubusercontent.com/19958075/227550136-5ede28a9-8fad-4ba8-be1e-4e2b7b6e8f7a.png">
<img width="257" alt="Screenshot 2023-03-24 at 10 09 12 AM" src="https://user-images.githubusercontent.com/19958075/227550145-738c2fb6-07e9-498c-af37-695b1cd4adb7.png">
<img width="257" alt="Screenshot 2023-03-24 at 10 18 35 AM" src="https://user-images.githubusercontent.com/19958075/227550148-39a1a699-9ea1-45c1-99fc-73d248633029.png">
<img width="257" alt="Screenshot 2023-03-24 at 10 18 46 AM" src="https://user-images.githubusercontent.com/19958075/227550153-a53637e2-114f-4065-9af3-0035f593aaf5.png">
<img width="257" alt="Screenshot 2023-03-24 at 10 18 54 AM" src="https://user-images.githubusercontent.com/19958075/227550160-ed3b2cf4-c481-4f70-aafa-4c5269164448.png">

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Click through all the settings pages to make sure they match.