### PR TITLE
Improved responsiveness: container eng name column

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
@@ -192,17 +192,17 @@ function isContainerConnectionStatusInProgress(
       <div class="bg-zinc-800 mt-5 rounded-md p-3 divide-x divide-gray-600 flex">
         <div>
           <!-- left col - podman icon/name + "create new" button -->
-          <div class="min-w-[150px]">
+          <div class="min-w-[150px] max-w-[200px]">
             <div class="flex">
               {#if provider.images.icon}
                 {#if typeof provider.images.icon === 'string'}
-                  <img src="{provider.images.icon}" alt="{provider.name}" class="max-h-10" />
+                  <img src="{provider.images.icon}" alt="{provider.name}" class="max-w-[40px] h-full" />
                   <!-- TODO check theme used for image, now use dark by default -->
                 {:else}
-                  <img src="{provider.images.icon.dark}" alt="{provider.name}" class="max-h-10" />
+                  <img src="{provider.images.icon.dark}" alt="{provider.name}" class="max-w-[40px]" />
                 {/if}
               {/if}
-              <span class="my-auto text-gray-300 ml-3">{provider.name}</span>
+              <span class="my-auto text-gray-300 ml-3 break-words">{provider.name}</span>
             </div>
             <div class="text-center mt-10">
               {#if provider.containerProviderConnectionCreation}
@@ -221,7 +221,7 @@ function isContainerConnectionStatusInProgress(
           </div>
         </div>
         <!-- podman machines columns -->
-        <div class="grow flex flex-wrap divide-gray-600">
+        <div class="grow flex flex-wrap divide-gray-600 ml-2">
           {#each provider.containerConnections as container}
             <div class="px-5 py-2 w-[240px]">
               <div class="float-right text-gray-700 cursor-not-allowed">


### PR DESCRIPTION
This improves the responsiveness of the left most name column of container engine cards that appear in Settings > Resources, particularly for names that are very long. The column has a min width of 150px and maxes out at 200px at which point it creates line breaks at word boundaries. This commit also helps the images for each engine/orchestrator maintain their aspect ratio in wrapping scenarios.

### What does this PR do?

This improves the responsiveness of the left most name column of
container engine cards that appear in Settings > Resources, particularly
for names that are very long. The column has a min width of 150px and
maxes out at 200px at which point it creates line breaks at word
boundaries. This commit also helps the images for each engine/orchestrator
maintain their aspect ratio in wrapping scenarios.

### Screenshot/screencast of this PR

[responsiveresourcecards.webm](https://user-images.githubusercontent.com/799683/227550396-72f7100a-b9fc-438e-adad-217cd2bb3379.webm)

### What issues does this PR fix or reference?

When the name of a container engine / orchestrator under Settings > Resources is too long, it doesn't wrap and runs into the vertical rule divider.

![image_480](https://user-images.githubusercontent.com/799683/227550733-e8fe92cd-c971-4014-87fd-10d73d0364ba.png)

### How to test this PR?

I used the developer tools in the browser window to input long names to make sure wrapping works ok.
