### PR TITLE
nit: fix registries not showing username correctly

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesRegistriesEditing.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRegistriesEditing.svelte
@@ -255,7 +255,7 @@ const processPasswordElement = (node: HTMLInputElement, registry: containerDeskt
             </div>
 
             <!-- Username -->
-            <div class="pt-2 pb-2 text-sm w-1/4 m-auto">
+            <div class="pt-4 pb-2 text-sm w-1/4 m-auto">
               {#if originRegistries.some(r => r.serverUrl === registry.serverUrl)}
                 <div class="text-left h-7 pr-5 mt-1.5 mb-0.5 text-sm w-full">
                   <input
@@ -272,7 +272,7 @@ const processPasswordElement = (node: HTMLInputElement, registry: containerDeskt
             </div>
 
             <!-- Password -->
-            <div class="pt-2 pb-2 text-sm w-full w-2/5">
+            <div class="pt-4 pb-2 text-sm w-2/5">
               <div class="flex flex-row">
                 {#if originRegistries.some(r => r.serverUrl === registry.serverUrl)}
                   <div class="flex text-left h-7 pr-5 mt-1.5 mb-0.5 text-sm w-full">


### PR DESCRIPTION
nit: fix registries not showing username correctly

### What does this PR do?

* Updates the registries list to show the username / password / details
  correctly
* Changes by @dgolovin

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

Before:
![Screenshot 2023-03-24 at 10 23 22 AM](https://user-images.githubusercontent.com/6422176/227553061-fbe369cb-c20f-41f5-a1e3-f0b16d48291d.png)

After:
![Screenshot 2023-03-24 at 10 25 06 AM](https://user-images.githubusercontent.com/6422176/227553088-305854a9-6fa7-4bdd-bbbc-0f15c949559f.png)
![Screenshot 2023-03-24 at 10 25 19 AM](https://user-images.githubusercontent.com/6422176/227553110-f73f2e31-8255-446d-afef-5e2be6a5f58b.png)





### What issues does this PR fix or reference?

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->
Closes https://github.com/containers/podman-desktop/issues/1646

### How to test this PR?

<!-- Please explain steps to reproduce -->

`yarn watch`

1. Add login details to the registry
2. Resize your window and see if it messes up the width / details.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
