### PR TITLE
fix(updates): Rework update mechanism

### DIFF
--- a/packages/main/src/index.ts
+++ b/packages/main/src/index.ts
@@ -27,25 +27,6 @@ import { StartupInstall } from './system/startup-install';
 
 export const UPDATER_UPDATE_AVAILABLE_ICON = 'fa fa-exclamation-triangle';
 
-// Check for updates when initially ready as well as set a 6 hour interval for any checks
-if (import.meta.env.PROD) {
-  import('electron-updater').then(({ autoUpdater }) => {
-    app
-      .whenReady()
-      .then(() => {
-        // Check for updates on startup
-        autoUpdater.checkForUpdatesAndNotify();
-
-        // Create an interval to check for updates every 12 hours / notify the user
-        setInterval(() => {
-          autoUpdater.checkForUpdatesAndNotify();
-          // check every 12 hours
-        }, 1000 * 60 * 60 * 12);
-      })
-      .catch(e => console.error('Failed to start auto-updater:', e));
-  });
-}
-
 /**
  * Prevent multiple instances
  */

--- a/packages/main/src/mainWindow.ts
+++ b/packages/main/src/mainWindow.ts
@@ -17,6 +17,7 @@
  ***********************************************************************/
 
 import type { BrowserWindowConstructorOptions, FileFilter } from 'electron';
+import { autoUpdater } from 'electron';
 import { Menu } from 'electron';
 import { BrowserWindow, ipcMain, app, dialog, screen, nativeTheme } from 'electron';
 import contextMenu from 'electron-context-menu';
@@ -119,7 +120,20 @@ async function createWindow() {
     configurationRegistry = data;
   });
 
+  // receive the message because an update is in progress and we need to quit the app
+  let quitAfterUpdate = false;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  autoUpdater.on('before-quit-for-update', () => {
+    quitAfterUpdate = true;
+  });
+
   browserWindow.on('close', e => {
+    if (quitAfterUpdate) {
+      browserWindow.destroy();
+      app.quit();
+      return;
+    }
+
     const closeBehaviorConfiguration = configurationRegistry?.getConfiguration('preferences');
     let exitonclose = isLinux(); // default value, which we will use unless the user preference is available.
     if (closeBehaviorConfiguration) {


### PR DESCRIPTION


### What does this PR do?
While trying the update, it was working but user got several error messages
Now:
- ensure that when we check for updates, we do not download artifacts (so if user do not want to update, there is no silent update)
- ensure that we're event based (notify user when update is downloaded, etc)
- ask the user if he wants to restart Podman Desktop once the update has been successfully downloaded

### Screenshot/screencast of this PR

https://user-images.githubusercontent.com/436777/227596136-c6123d5c-d9ae-4fb3-a569-0cfaaeebf09c.mp4

### What issues does this PR fix or reference?

Fixes #1806 


### How to test this PR?

I don't know how to test the PR on your own as it's requiring signed binaries

I did some signed binaries for macOS there:
https://github.com/benoitf/desktop/releases/tag/v0.2.15

it's a faked Podman Desktop test `v0.2.15` app that will ask you to update to a `v0.2.210` version
