### PR TITLE
feat: add loading icons to resources start/stop/delete/restart buttons

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
@@ -289,6 +289,18 @@ function getContainerConnectionName(
 ): string {
   return `${provider.name}-${containerConnectionInfo.name}`;
 }
+
+function getStyleByState(state: IContainerStatus, action: string) {
+  if (
+    (action === 'start' && (state.inProgress || state.status !== 'stopped')) ||
+    ((action === 'stop' || action === 'restart') && (state.inProgress || state.status !== 'started')) ||
+    (action === 'delete' && (state.inProgress || (state.status !== 'stopped' && state.status !== 'unknown')))
+  ) {
+    return 'text-gray-700 cursor-not-allowed';
+  } else {
+    return 'hover:text-gray-400';
+  }
+}
 </script>
 
 <SettingsPage title="Resources">
@@ -374,102 +386,88 @@ function getContainerConnectionName(
                   {/each}
                 </div>
               {/if}
-              {#if containerConnectionStatus.has(
-                `${provider.name}-${container.name}`,
-              )}
-              {@const state = containerConnectionStatus.get(
-                `${provider.name}-${container.name}`,
-              )}
-              {#if container.lifecycleMethods && container.lifecycleMethods.length > 0}
-                <div class="mt-2 relative">
-                  <!-- TODO: see action available like machine infos -->
-                  <div class="flex bg-zinc-900 w-fit rounded-lg m-auto">
-                    {#if container.lifecycleMethods.includes('start')}
-                      <Tooltip tip="Start" bottom>
-                        <button
-                          aria-label="Start"
-                          class="ml-5 mr-2.5 my-2 {state.inProgress || state.status !== 'stopped'
-                            ? 'text-gray-700 cursor-not-allowed'
-                            : 'hover:text-gray-400'}"
-                          on:click="{() => startContainerProvider(provider, container)}"
-                          disabled="{state.inProgress || state.status !== 'stopped'}">
-                          <LoadingIcon
-                            icon="{faPlay}"
-                            loadingWidthClass="w-6"
-                            loadingHeightClass="h-6"
-                            positionTopClass="top-1"
-                            positionLeftClass="left-[0.77rem]"
-                            loading="{state.inProgress && state.action === 'start'}" />
-                        </button>
-                      </Tooltip>
-                    {/if}
-                    {#if container.lifecycleMethods.includes('start') && container.lifecycleMethods.includes('stop')}
-                      <Tooltip tip="Restart" bottom>
-                        <button
-                          aria-label="Restart"
-                          class="mx-2.5 my-2 {state.inProgress || state.status !== 'started'
-                            ? 'text-gray-700 cursor-not-allowed'
-                            : 'hover:text-gray-400'}"
-                          on:click="{() => restartContainerProvider(provider, container)}"
-                          disabled="{state.inProgress || state.status !== 'started'}">
-                          <LoadingIcon
-                            icon="{faRotateRight}"
-                            loadingWidthClass="w-6"
-                            loadingHeightClass="h-6"
-                            positionTopClass="top-1"
-                            positionLeftClass="left-1.5"
-                            loading="{state.inProgress && state.action === 'restart'}" />
-                        </button>
-                      </Tooltip>
-                    {/if}
-                    {#if container.lifecycleMethods.includes('stop')}
-                      <Tooltip tip="Stop" bottom>
-                        <button
-                          aria-label="Stop"
-                          class="mx-2.5 my-2 {state.inProgress || state.status !== 'started'
-                            ? 'text-gray-700 cursor-not-allowed'
-                            : 'hover:text-gray-400'}"
-                          on:click="{() => stopContainerProvider(provider, container)}"
-                          disabled="{state.inProgress || state.status !== 'started'}">
-                          <LoadingIcon
-                            icon="{faStop}"
-                            loadingWidthClass="w-6"
-                            loadingHeightClass="h-6"
-                            positionTopClass="top-1"
-                            positionLeftClass="left-[0.22rem]"
-                            loading="{state.inProgress && state.action === 'stop'}" />
-                        </button>
-                      </Tooltip>
-                    {/if}
-                    {#if container.lifecycleMethods.includes('delete')}
-                      <Tooltip tip="Delete" bottom>
-                        <button
-                          aria-label="Delete"
-                          class="mx-2.5 mr-5 mb-2 text-sm {state.inProgress || (state.status !== 'stopped' &&
-                            container.status !== 'unknown')
-                            ? 'text-gray-700 cursor-not-allowed mt-2'
-                            : 'hover:text-gray-400 mt-[0.55rem]'}"
-                          on:click="{() => deleteContainerProvider(provider, container)}"
-                          disabled="{state.inProgress || (state.status !== 'stopped' && state.status !== 'unknown')}">
-                          <LoadingIcon
-                            icon="{faTrash}"
-                            loadingWidthClass="w-6"
-                            loadingHeightClass="h-6"
-                            positionTopClass="top-1"
-                            positionLeftClass="left-1"
-                            loading="{state.inProgress && state.action === 'delete'}" />
-                        </button>
-                      </Tooltip>
-                    {/if}
+              {#if containerConnectionStatus.has(getContainerConnectionName(provider, container))}
+                {@const state = containerConnectionStatus.get(getContainerConnectionName(provider, container))}
+                {#if container.lifecycleMethods && container.lifecycleMethods.length > 0}
+                  <div class="mt-2 relative">
+                    <!-- TODO: see action available like machine infos -->
+                    <div class="flex bg-zinc-900 w-fit rounded-lg m-auto">
+                      {#if container.lifecycleMethods.includes('start')}
+                        <Tooltip tip="Start" bottom>
+                          <button
+                            aria-label="Start"
+                            class="ml-5 mr-2.5 my-2 {getStyleByState(state, 'start')}"
+                            on:click="{() => startContainerProvider(provider, container)}"
+                            disabled="{state.inProgress || state.status !== 'stopped'}">
+                            <LoadingIcon
+                              icon="{faPlay}"
+                              loadingWidthClass="w-6"
+                              loadingHeightClass="h-6"
+                              positionTopClass="top-1"
+                              positionLeftClass="left-[0.77rem]"
+                              loading="{state.inProgress && state.action === 'start'}" />
+                          </button>
+                        </Tooltip>
+                      {/if}
+                      {#if container.lifecycleMethods.includes('start') && container.lifecycleMethods.includes('stop')}
+                        <Tooltip tip="Restart" bottom>
+                          <button
+                            aria-label="Restart"
+                            class="mx-2.5 my-2 {getStyleByState(state, 'stop')}"
+                            on:click="{() => restartContainerProvider(provider, container)}"
+                            disabled="{state.inProgress || state.status !== 'started'}">
+                            <LoadingIcon
+                              icon="{faRotateRight}"
+                              loadingWidthClass="w-6"
+                              loadingHeightClass="h-6"
+                              positionTopClass="top-1"
+                              positionLeftClass="left-1.5"
+                              loading="{state.inProgress && state.action === 'restart'}" />
+                          </button>
+                        </Tooltip>
+                      {/if}
+                      {#if container.lifecycleMethods.includes('stop')}
+                        <Tooltip tip="Stop" bottom>
+                          <button
+                            aria-label="Stop"
+                            class="mx-2.5 my-2 {getStyleByState(state, 'restart')}"
+                            on:click="{() => stopContainerProvider(provider, container)}"
+                            disabled="{state.inProgress || state.status !== 'started'}">
+                            <LoadingIcon
+                              icon="{faStop}"
+                              loadingWidthClass="w-6"
+                              loadingHeightClass="h-6"
+                              positionTopClass="top-1"
+                              positionLeftClass="left-[0.22rem]"
+                              loading="{state.inProgress && state.action === 'stop'}" />
+                          </button>
+                        </Tooltip>
+                      {/if}
+                      {#if container.lifecycleMethods.includes('delete')}
+                        <Tooltip tip="Delete" bottom>
+                          <button
+                            aria-label="Delete"
+                            class="mx-2.5 mr-5 mb-2 text-sm mt-2 {getStyleByState(state, 'delete')}"
+                            on:click="{() => deleteContainerProvider(provider, container)}"
+                            disabled="{state.inProgress || (state.status !== 'stopped' && state.status !== 'unknown')}">
+                            <LoadingIcon
+                              icon="{faTrash}"
+                              loadingWidthClass="w-6"
+                              loadingHeightClass="h-6"
+                              positionTopClass="top-1"
+                              positionLeftClass="left-1"
+                              loading="{state.inProgress && state.action === 'delete'}" />
+                          </button>
+                        </Tooltip>
+                      {/if}
+                    </div>
                   </div>
-                </div>
-              {/if}
+                {/if}
               {/if}
               <div class="mt-1.5 text-gray-500 text-[9px]">
                 <div>{provider.name} {provider.version ? `v${provider.version}` : ''}</div>
               </div>
             </div>
-            
           {/each}
           {#each provider.kubernetesConnections as kubeConnection}
             <div class="px-5 py-2 w-[240px]">

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
@@ -15,15 +15,9 @@ import SettingsPage from './SettingsPage.svelte';
 import ConnectionStatus from '../ui/ConnectionStatus.svelte';
 import { ConnectionCallback, eventCollect, startTask } from './preferences-connection-rendering-task';
 import { createConnectionsInfo } from '/@/stores/create-connections';
+import type { IContainerStatus } from './Util';
 import LoadingIcon from '../ui/LoadingIcon.svelte';
-
-interface IContainerStatus {
-  status: string;
-  action?: string;
-  inProgress: boolean;
-  failedAction?: string;
-  error?: string;
-}
+import LoadingIconButton from '../ui/LoadingIconButton.svelte';
 
 interface IProviderContainerConfigurationPropertyRecorded extends IConfigurationPropertyRecordedSchema {
   value?: any;
@@ -289,18 +283,6 @@ function getContainerConnectionName(
 ): string {
   return `${provider.name}-${containerConnectionInfo.name}`;
 }
-
-function getStyleByState(state: IContainerStatus, action: string) {
-  if (
-    (action === 'start' && (state.inProgress || state.status !== 'stopped')) ||
-    ((action === 'stop' || action === 'restart') && (state.inProgress || state.status !== 'started')) ||
-    (action === 'delete' && (state.inProgress || (state.status !== 'stopped' && state.status !== 'unknown')))
-  ) {
-    return 'text-gray-700 cursor-not-allowed';
-  } else {
-    return 'hover:text-gray-400';
-  }
-}
 </script>
 
 <SettingsPage title="Resources">
@@ -393,72 +375,40 @@ function getStyleByState(state: IContainerStatus, action: string) {
                     <!-- TODO: see action available like machine infos -->
                     <div class="flex bg-zinc-900 w-fit rounded-lg m-auto">
                       {#if container.lifecycleMethods.includes('start')}
-                        <Tooltip tip="Start" bottom>
-                          <button
-                            aria-label="Start"
-                            class="ml-5 mr-2.5 my-2 {getStyleByState(state, 'start')}"
-                            on:click="{() => startContainerProvider(provider, container)}"
-                            disabled="{state.inProgress || state.status !== 'stopped'}">
-                            <LoadingIcon
-                              icon="{faPlay}"
-                              loadingWidthClass="w-6"
-                              loadingHeightClass="h-6"
-                              positionTopClass="top-1"
-                              positionLeftClass="left-[0.77rem]"
-                              loading="{state.inProgress && state.action === 'start'}" />
-                          </button>
-                        </Tooltip>
+                        <div class="ml-2">
+                          <LoadingIconButton
+                            clickAction="{() => startContainerProvider(provider, container)}"
+                            action="start"
+                            icon="{faPlay}"
+                            state="{state}"
+                            leftPosition="left-[0.15rem]" />
+                        </div>
                       {/if}
                       {#if container.lifecycleMethods.includes('start') && container.lifecycleMethods.includes('stop')}
-                        <Tooltip tip="Restart" bottom>
-                          <button
-                            aria-label="Restart"
-                            class="mx-2.5 my-2 {getStyleByState(state, 'stop')}"
-                            on:click="{() => restartContainerProvider(provider, container)}"
-                            disabled="{state.inProgress || state.status !== 'started'}">
-                            <LoadingIcon
-                              icon="{faRotateRight}"
-                              loadingWidthClass="w-6"
-                              loadingHeightClass="h-6"
-                              positionTopClass="top-1"
-                              positionLeftClass="left-1.5"
-                              loading="{state.inProgress && state.action === 'restart'}" />
-                          </button>
-                        </Tooltip>
+                        <LoadingIconButton
+                          clickAction="{() => restartContainerProvider(provider, container)}"
+                          action="restart"
+                          icon="{faRotateRight}"
+                          state="{state}"
+                          leftPosition="left-1.5" />
                       {/if}
                       {#if container.lifecycleMethods.includes('stop')}
-                        <Tooltip tip="Stop" bottom>
-                          <button
-                            aria-label="Stop"
-                            class="mx-2.5 my-2 {getStyleByState(state, 'restart')}"
-                            on:click="{() => stopContainerProvider(provider, container)}"
-                            disabled="{state.inProgress || state.status !== 'started'}">
-                            <LoadingIcon
-                              icon="{faStop}"
-                              loadingWidthClass="w-6"
-                              loadingHeightClass="h-6"
-                              positionTopClass="top-1"
-                              positionLeftClass="left-[0.22rem]"
-                              loading="{state.inProgress && state.action === 'stop'}" />
-                          </button>
-                        </Tooltip>
+                        <LoadingIconButton
+                          clickAction="{() => stopContainerProvider(provider, container)}"
+                          action="stop"
+                          icon="{faStop}"
+                          state="{state}"
+                          leftPosition="left-[0.22rem]" />
                       {/if}
                       {#if container.lifecycleMethods.includes('delete')}
-                        <Tooltip tip="Delete" bottom>
-                          <button
-                            aria-label="Delete"
-                            class="mx-2.5 mr-5 mb-2 text-sm mt-2 {getStyleByState(state, 'delete')}"
-                            on:click="{() => deleteContainerProvider(provider, container)}"
-                            disabled="{state.inProgress || (state.status !== 'stopped' && state.status !== 'unknown')}">
-                            <LoadingIcon
-                              icon="{faTrash}"
-                              loadingWidthClass="w-6"
-                              loadingHeightClass="h-6"
-                              positionTopClass="top-1"
-                              positionLeftClass="left-1"
-                              loading="{state.inProgress && state.action === 'delete'}" />
-                          </button>
-                        </Tooltip>
+                        <div class="mr-2 text-sm">
+                          <LoadingIconButton
+                            clickAction="{() => deleteContainerProvider(provider, container)}"
+                            action="delete"
+                            icon="{faTrash}"
+                            state="{state}"
+                            leftPosition="left-1" />
+                        </div>
                       {/if}
                     </div>
                   </div>

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
@@ -79,7 +79,7 @@ onMount(() => {
               action: undefined,
               status: container.status,
             });
-          }          
+          }
         }
       });
     });

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
@@ -272,6 +272,7 @@ function setContainerStatusUpdateFailed(
   const currentStatus = containerConnectionStatus.get(containerConnectionName);
   containerConnectionStatus.set(containerConnectionName, {
     ...currentStatus,
+    inProgress: false,
     error,
   });
   containerConnectionStatus = containerConnectionStatus;

--- a/packages/renderer/src/lib/preferences/Util.ts
+++ b/packages/renderer/src/lib/preferences/Util.ts
@@ -20,7 +20,6 @@ export interface IContainerStatus {
   status: string;
   action?: string;
   inProgress: boolean;
-  failedAction?: string;
   error?: string;
 }
 

--- a/packages/renderer/src/lib/preferences/Util.ts
+++ b/packages/renderer/src/lib/preferences/Util.ts
@@ -16,6 +16,14 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+export interface IContainerStatus {
+  status: string;
+  action?: string;
+  inProgress: boolean;
+  failedAction?: string;
+  error?: string;
+}
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function writeToTerminal(xterm: any, data: string[], colorPrefix: string): void {
   if (Array.isArray(data)) {

--- a/packages/renderer/src/lib/ui/LoadingIcon.svelte
+++ b/packages/renderer/src/lib/ui/LoadingIcon.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+import type { IconDefinition } from '@fortawesome/free-solid-svg-icons';
+import Fa from 'svelte-fa/src/fa.svelte';
+
+export let icon: IconDefinition;
+export let loadingWidthClass: string;
+export let loadingHeightClass: string;
+export let positionTopClass: string;
+export let positionLeftClass: string;
+export let loading: boolean;
+</script>
+
+<div>
+  <Fa icon="{icon}" />
+  <div
+    aria-label="spinner"
+    class="{loading
+      ? ''
+      : 'hidden'} {loadingWidthClass} {loadingHeightClass} rounded-full animate-spin border border-solid border-violet-500 border-t-transparent absolute {positionTopClass} {positionLeftClass}">
+  </div>
+</div>

--- a/packages/renderer/src/lib/ui/LoadingIconButton.svelte
+++ b/packages/renderer/src/lib/ui/LoadingIconButton.svelte
@@ -1,0 +1,53 @@
+<script lang="ts">
+import type { IconDefinition } from '@fortawesome/free-solid-svg-icons';
+import type { IContainerStatus } from '../preferences/Util';
+import LoadingIcon from './LoadingIcon.svelte';
+import Tooltip from './Tooltip.svelte';
+
+export let action: string;
+export let icon: IconDefinition;
+export let state: IContainerStatus;
+export let leftPosition: string;
+export let clickAction: () => {};
+
+$: disable =
+  state.inProgress ||
+  (action === 'start' && state.status !== 'stopped') ||
+  (action === 'restart' && state.status !== 'started') ||
+  (action === 'stop' && state.status !== 'started') ||
+  (action === 'delete' && state.status !== 'stopped' && state.status !== 'unknown');
+
+$: loading = state.inProgress && action === state.action;
+
+function capitalizeFirstLetter(text: string): string {
+  return text.charAt(0).toUpperCase() + text.slice(1);
+}
+
+function getStyleByState(state: IContainerStatus, action: string) {
+  if (
+    (action === 'start' && (state.inProgress || state.status !== 'stopped')) ||
+    ((action === 'stop' || action === 'restart') && (state.inProgress || state.status !== 'started')) ||
+    (action === 'delete' && (state.inProgress || (state.status !== 'stopped' && state.status !== 'unknown')))
+  ) {
+    return 'text-gray-700 cursor-not-allowed';
+  } else {
+    return 'hover:text-gray-400';
+  }
+}
+</script>
+
+<Tooltip tip="{capitalizeFirstLetter(action)}" bottom>
+  <button
+    aria-label="{capitalizeFirstLetter(action)}"
+    class="mx-2.5 my-2 {getStyleByState(state, action)}"
+    on:click="{clickAction}"
+    disabled="{disable}">
+    <LoadingIcon
+      icon="{icon}"
+      loadingWidthClass="w-6"
+      loadingHeightClass="h-6"
+      positionTopClass="top-1"
+      positionLeftClass="{leftPosition}"
+      loading="{loading}" />
+  </button>
+</Tooltip>


### PR DESCRIPTION
### What does this PR do?

This PR add a loading icon to the start/stop/delete/restart buttons so user have an immediate visual feedback of what's happening.

### Screenshot/screencast of this PR

![loadingbuttons](https://user-images.githubusercontent.com/49404737/227783890-0a3e399a-ef71-4cca-8104-c4a642861f8c.gif)

### What issues does this PR fix or reference?

this is part of #1337 

### How to test this PR?

1. go to settings -> resources -> start/stop/restart/delete a machine
