### PR TITLE
fix: scan plugins-scanning directory at startup as well

### DIFF
--- a/packages/main/src/plugin/extension-loader.spec.ts
+++ b/packages/main/src/plugin/extension-loader.spec.ts
@@ -157,7 +157,7 @@ test('Should watch for files and load them at startup', async () => {
   await extensionLoader.setupScanningDirectory();
 
   // expect to load only one file (other are invalid files/folder)
-  expect(loadPackagedFileMock).toBeCalledWith(path.join(rootedFakeDirectory, 'foo.cdix'));
+  expect(loadPackagedFileMock).toBeCalledWith(path.join(fakeDirectory, 'foo.cdix'));
 
   // expect watcher is setup
   expect(fsWatchMock).toBeCalledWith(fakeDirectory, expect.anything());

--- a/packages/main/src/plugin/extension-loader.spec.ts
+++ b/packages/main/src/plugin/extension-loader.spec.ts
@@ -157,7 +157,7 @@ test('Should watch for files and load them at startup', async () => {
   await extensionLoader.setupScanningDirectory();
 
   // expect to load only one file (other are invalid files/folder)
-  expect(loadPackagedFileMock).toBeCalledWith(path.resolve(rootedFakeDirectory, 'foo.cdix'));
+  expect(loadPackagedFileMock).toBeCalledWith(path.join(rootedFakeDirectory, 'foo.cdix'));
 
   // expect watcher is setup
   expect(fsWatchMock).toBeCalledWith(fakeDirectory, expect.anything());

--- a/packages/main/src/plugin/extension-loader.spec.ts
+++ b/packages/main/src/plugin/extension-loader.spec.ts
@@ -114,7 +114,6 @@ beforeEach(() => {
 
 test('Should watch for files and load them at startup', async () => {
   const fakeDirectory = '/fake/path/scanning';
-  const rootedFakeDirectory = path.resolve(fakeDirectory);
 
   // fake scanning property
   extensionLoader.setPluginsScanDirectory(fakeDirectory);

--- a/packages/main/src/plugin/extension-loader.spec.ts
+++ b/packages/main/src/plugin/extension-loader.spec.ts
@@ -18,7 +18,7 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { beforeAll, beforeEach, test, vi } from 'vitest';
+import { beforeAll, beforeEach, test, expect, vi } from 'vitest';
 import type { CommandRegistry } from './command-registry';
 import type { ConfigurationRegistry } from './configuration-registry';
 import type { ContainerProviderRegistry } from './container-registry';

--- a/packages/main/src/plugin/extension-loader.spec.ts
+++ b/packages/main/src/plugin/extension-loader.spec.ts
@@ -1,0 +1,217 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { beforeAll, beforeEach, test, vi } from 'vitest';
+import type { CommandRegistry } from './command-registry';
+import type { ConfigurationRegistry } from './configuration-registry';
+import type { ContainerProviderRegistry } from './container-registry';
+import type { Dialogs } from './dialog-impl';
+import { ExtensionLoader } from './extension-loader';
+import type { FilesystemMonitoring } from './filesystem-monitoring';
+import type { ImageRegistry } from './image-registry';
+import type { InputQuickPickRegistry } from './input-quickpick/input-quickpick-registry';
+import type { KubernetesClient } from './kubernetes-client';
+import type { MenuRegistry } from './menu-registry';
+import type { NotificationImpl } from './notification-impl';
+import type { ProgressImpl } from './progress-impl';
+import type { ProviderRegistry } from './provider-registry';
+import type { Proxy } from './proxy';
+import type { StatusBarRegistry } from './statusbar/statusbar-registry';
+import type { TrayMenuRegistry } from './tray-menu-registry';
+import * as fs from 'node:fs';
+
+class TestExtensionLoader extends ExtensionLoader {
+  public async setupScanningDirectory(): Promise<void> {
+    return super.setupScanningDirectory();
+  }
+
+  setPluginsScanDirectory(path: string): void {
+    this.pluginsScanDirectory = path;
+  }
+
+  setWatchTimeout(timeout: number): void {
+    this.watchTimeout = timeout;
+  }
+}
+
+let extensionLoader: TestExtensionLoader;
+
+const commandRegistry: CommandRegistry = {} as unknown as CommandRegistry;
+
+const menuRegistry: MenuRegistry = {} as unknown as MenuRegistry;
+
+const providerRegistry: ProviderRegistry = {} as unknown as ProviderRegistry;
+
+const configurationRegistry: ConfigurationRegistry = {} as unknown as ConfigurationRegistry;
+
+const imageRegistry: ImageRegistry = {} as unknown as ImageRegistry;
+
+const apiSender: any = {};
+
+const trayMenuRegistry: TrayMenuRegistry = {} as unknown as TrayMenuRegistry;
+
+const dialogs: Dialogs = {} as unknown as Dialogs;
+
+const progress: ProgressImpl = {} as ProgressImpl;
+
+const notifications: NotificationImpl = {} as unknown as NotificationImpl;
+
+const statusBarRegistry: StatusBarRegistry = {} as unknown as StatusBarRegistry;
+
+const kubernetesClient: KubernetesClient = {} as unknown as KubernetesClient;
+
+const fileSystemMonitoring: FilesystemMonitoring = {} as unknown as FilesystemMonitoring;
+
+const proxy: Proxy = {} as unknown as Proxy;
+
+const containerProviderRegistry: ContainerProviderRegistry = {} as unknown as ContainerProviderRegistry;
+
+const inputQuickPickRegistry: InputQuickPickRegistry = {} as unknown as InputQuickPickRegistry;
+
+/* eslint-disable @typescript-eslint/no-empty-function */
+beforeAll(() => {
+  extensionLoader = new TestExtensionLoader(
+    commandRegistry,
+    menuRegistry,
+    providerRegistry,
+    configurationRegistry,
+    imageRegistry,
+    apiSender,
+    trayMenuRegistry,
+    dialogs,
+    progress,
+    notifications,
+    statusBarRegistry,
+    kubernetesClient,
+    fileSystemMonitoring,
+    proxy,
+    containerProviderRegistry,
+    inputQuickPickRegistry,
+  );
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+test('Should watch for files and load them at startup', async () => {
+  // fake scanning property
+  extensionLoader.setPluginsScanDirectory('/fake/path/scanning');
+
+  vi.mock('node:fs');
+  // mock fs.watch
+  const fsWatchMock = vi.spyOn(fs, 'watch');
+  fsWatchMock.mockReturnValue({} as fs.FSWatcher);
+
+  // mock fs.existsSync
+  const fsExistsSyncMock = vi.spyOn(fs, 'existsSync');
+  fsExistsSyncMock.mockReturnValue(true);
+
+  // mock fs.promises.readdir
+  const readdirMock = vi.spyOn(fs.promises, 'readdir');
+
+  const ent1 = {
+    isFile: () => true,
+    isDirectory: () => false,
+    name: 'foo.cdix',
+  } as unknown as fs.Dirent;
+
+  const ent2 = {
+    isFile: () => true,
+    isDirectory: () => false,
+    name: 'bar.foo',
+  } as unknown as fs.Dirent;
+
+  const ent3 = {
+    isFile: () => false,
+    isDirectory: () => true,
+    name: 'baz',
+  } as unknown as fs.Dirent;
+  readdirMock.mockResolvedValue([ent1, ent2, ent3]);
+
+  // mock loadPackagedFile
+  const loadPackagedFileMock = vi.spyOn(extensionLoader, 'loadPackagedFile');
+  loadPackagedFileMock.mockResolvedValue();
+
+  await extensionLoader.setupScanningDirectory();
+
+  // expect to load only one file (other are invalid files/folder)
+  expect(loadPackagedFileMock).toBeCalledWith('/fake/path/scanning/foo.cdix');
+
+  // expect watcher is setup
+  expect(fsWatchMock).toBeCalledWith('/fake/path/scanning', expect.anything());
+});
+
+test('Should load file from watching scanning folder', async () => {
+  // fake scanning property
+  extensionLoader.setPluginsScanDirectory('/fake/path/scanning');
+
+  let watchFilename: fs.PathLike | undefined = undefined;
+  let watchListener: fs.WatchListener<string> = {} as unknown as fs.WatchListener<string>;
+
+  // reduce timeout delay for tests
+  extensionLoader.setWatchTimeout(50);
+
+  vi.mock('node:fs');
+  // mock fs.watch
+  const fsWatchMock = vi.spyOn(fs, 'watch');
+  fsWatchMock.mockImplementation((filename: fs.PathLike, listener?: fs.WatchListener<string>): fs.FSWatcher => {
+    watchFilename = filename;
+    if (listener) {
+      watchListener = listener;
+    }
+    return {} as fs.FSWatcher;
+  });
+
+  // mock fs.existsSync
+  const fsExistsSyncMock = vi.spyOn(fs, 'existsSync');
+  fsExistsSyncMock.mockReturnValue(true);
+
+  // mock fs.promises.readdir
+  const readdirMock = vi.spyOn(fs.promises, 'readdir');
+  readdirMock.mockResolvedValue([]);
+
+  // mock loadPackagedFile
+  const loadPackagedFileMock = vi.spyOn(extensionLoader, 'loadPackagedFile');
+  loadPackagedFileMock.mockResolvedValue();
+
+  await extensionLoader.setupScanningDirectory();
+
+  // no loading for now as no files in the folder
+  expect(loadPackagedFileMock).not.toBeCalled();
+
+  // expect watcher is setup
+  expect(fsWatchMock).toBeCalledWith('/fake/path/scanning', expect.anything());
+  expect(watchFilename).toBeDefined();
+  expect(watchListener).toBeDefined();
+
+  expect(watchFilename).toBe('/fake/path/scanning');
+
+  // call the watcher callback
+  if (watchListener) {
+    watchListener('rename', 'watch.cdix');
+  }
+
+  // wait more than the watchListener timeout
+  await new Promise(resolve => setTimeout(resolve, 100));
+
+  // expect to load only one file (other are invalid files/folder)
+  expect(loadPackagedFileMock).toBeCalledWith('/fake/path/scanning/watch.cdix');
+});

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -80,9 +80,11 @@ export class ExtensionLoader {
   private watcherExtensions = new Map<string, containerDesktopAPI.FileSystemWatcher>();
   private reloadInProgressExtensions = new Map<string, boolean>();
 
+  protected watchTimeout = 1000;
+
   // Plugins directory location
   private pluginsDirectory = path.resolve(os.homedir(), desktopAppHomeDir(), 'plugins');
-  private pluginsScanDirectory = path.resolve(os.homedir(), desktopAppHomeDir(), 'plugins-scanning');
+  protected pluginsScanDirectory = path.resolve(os.homedir(), desktopAppHomeDir(), 'plugins-scanning');
 
   // Extensions directory location
   private extensionsStorageDirectory = path.resolve(os.homedir(), desktopAppHomeDir(), 'extensions-storage');
@@ -172,17 +174,31 @@ export class ExtensionLoader {
     }
   }
 
-  async start() {
-    // add watcher to the $HOME/podman-desktop
-
+  protected async setupScanningDirectory(): Promise<void> {
     if (fs.existsSync(this.pluginsScanDirectory)) {
       // add watcher
       fs.watch(this.pluginsScanDirectory, (_, filename) => {
         // need to load the file
         const packagedFile = path.resolve(this.pluginsScanDirectory, filename);
-        setTimeout(() => this.loadPackagedFile(packagedFile), 1000);
+        setTimeout(() => this.loadPackagedFile(packagedFile), this.watchTimeout);
       });
+
+      // scan all files in the directory
+      const entries = await fs.promises.readdir(this.pluginsScanDirectory, { withFileTypes: true });
+      // filter only files
+      const files = entries
+        .filter(entry => entry.isFile())
+        .filter(entry => entry.name.endsWith('.cdix'))
+        .map(file => path.join(this.pluginsScanDirectory, file.name));
+
+      // load all files
+      await Promise.all(files.map(file => this.loadPackagedFile(file)));
     }
+  }
+
+  async start() {
+    // Scan the plugins-scanning directory
+    await this.setupScanningDirectory();
 
     // Create the extensions storage directory if it does not exist
     if (!fs.existsSync(this.extensionsStorageDirectory)) {


### PR DESCRIPTION
### What does this PR do?
scan the directory at startup and not only when there are changes on the folder

Also add unit tests

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop/issues/1681


### How to test this PR?

1. copy a .cdix (extension file) after startup in `plugins-scanning` folder
2. check extension is loaded
3. restart Podman Desktop and check extension is loaded again


Change-Id: I22dd380c79f9b6c3e66467f36a328896ab665e44
