### PR TITLE
feat: add compatibility enable / disable button for Linux

### DIFF
--- a/extensions/podman/src/compatibility-mode.spec.ts
+++ b/extensions/podman/src/compatibility-mode.spec.ts
@@ -17,7 +17,7 @@
  ***********************************************************************/
 
 import { expect, test, vi } from 'vitest';
-import { getSocketCompatibility, DarwinSocketCompatibility } from './compatibility-mode';
+import { getSocketCompatibility, DarwinSocketCompatibility, LinuxSocketCompatibility } from './compatibility-mode';
 import * as extensionApi from '@podman-desktop/api';
 
 vi.mock('@podman-desktop/api', () => {
@@ -30,7 +30,7 @@ vi.mock('@podman-desktop/api', () => {
 
 // macOS tests
 
-vi.mock('runSudoMacHelperCommand', () => {
+vi.mock('runSudoCommand', () => {
   return vi.fn();
 });
 
@@ -50,7 +50,7 @@ test('darwin: compatibility mode binary not found failure', async () => {
   expect(extensionApi.window.showErrorMessage).toHaveBeenCalledWith('podman-mac-helper binary not found.', 'OK');
 });
 
-test('darwin: DarwinSocketCompatibility class, test runSudoMacHelperCommand ran within runCommand', async () => {
+test('darwin: DarwinSocketCompatibility class, test runSudoCommand ran within runCommand', async () => {
   // Mock platform to be darwin
   Object.defineProperty(process, 'platform', {
     value: 'darwin',
@@ -63,7 +63,7 @@ test('darwin: DarwinSocketCompatibility class, test runSudoMacHelperCommand ran 
   spyFindPodmanHelper.mockReturnValue('/opt/podman/bin/podman-mac-helper');
 
   // Mock that sudo ran successfully (since we cannot test sudo-prompt in vitest / has to be integration tests)
-  const spyMacHelperCommand = vi.spyOn(socketCompatClass, 'runSudoMacHelperCommand');
+  const spyMacHelperCommand = vi.spyOn(socketCompatClass, 'runSudoCommand');
   spyMacHelperCommand.mockImplementation(() => {
     return Promise.resolve();
   });
@@ -76,19 +76,44 @@ test('darwin: DarwinSocketCompatibility class, test runSudoMacHelperCommand ran 
 });
 
 // Linux tests
+test('linux: compatibility mode pass', async () => {
+  Object.defineProperty(process, 'platform', {
+    value: 'linux',
+  });
+  expect(() => getSocketCompatibility()).toBeTruthy();
+});
 
-test('linux: compatibility mode fail', async () => {
-  // Mock platform to be darwin
+// Fail when trying to use runSystemdCommand with a command that's not "enable" or "disable"
+test('linux: fail when trying to use runSystemdCommand with a command that is not "enable" or "disable"', async () => {
   Object.defineProperty(process, 'platform', {
     value: 'linux',
   });
 
-  // Expect getSocketCompatibility to return error since Linux is not supported yet
-  expect(() => getSocketCompatibility()).toThrowError();
+  const socketCompatClass = new LinuxSocketCompatibility();
+  await expect(socketCompatClass.runSystemdCommand('start', 'enabled')).rejects.toThrowError(
+    'runSystemdCommand only accepts enable or disable as the command',
+  );
+});
+
+test('linux: pass enabling when systemctl command exists', async () => {
+  Object.defineProperty(process, 'platform', {
+    value: 'linux',
+  });
+
+  // Mock that execSync runs successfully
+  vi.mock('child_process', () => {
+    return {
+      execSync: vi.fn(),
+    };
+  });
+
+  const socketCompatClass = new LinuxSocketCompatibility();
+
+  // Expect enable() to pass since systemctl command exists
+  await expect(socketCompatClass.enable()).resolves.toBeUndefined();
 });
 
 // Windows tests
-
 test('windows: compatibility mode fail', async () => {
   // Mock platform to be darwin
   Object.defineProperty(process, 'platform', {

--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -484,8 +484,8 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
   extensionContext.subscriptions.push(disguisedPodmanSocketWatcher);
 
   // Compatibility mode status bar item
-  // only available for macOS (for now).
-  if (isMac()) {
+  // only available for macOS or Linux (for now).
+  if (isMac() || isLinux()) {
     // Get the socketCompatibilityClass for the current OS.
     const socketCompatibilityMode = getSocketCompatibility();
 
@@ -507,6 +507,7 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
       // Manually check to see if the socket is disguised (this will be called when pressing the status bar item)
       const isDisguisedPodmanSocket = await isDisguisedPodman();
 
+      // We use isEnabled() as we do not want to "renable" again if the user has already enabled it.
       if (!isDisguisedPodmanSocket && !socketCompatibilityMode.isEnabled()) {
         const result = await extensionApi.window.showInformationMessage(
           `Do you want to automatically enable Docker socket compatibility mode for Podman?\n\n${socketCompatibilityMode.details}`,


### PR DESCRIPTION
feat: add compatibility enable / disable button for Linux

### What does this PR do?

* Adds a compatibility button that will enable / disable the systemd
  podman.socket that allows Docker compatibility
* Refactors the runSudoHelperCommand function so that both macOS and
  Linux implementations can use it

https://github.com/containers/podman-desktop/pull/1769 should be merged
before this goes in as there will be rebasing / conflicts

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

Closes the rest of https://github.com/containers/podman-desktop/issues/1447

### How to test this PR?

<!-- Please explain steps to reproduce -->

1. Use Linux
2. ~`yarn watch`~ use `yarn compile --linux=flatpak` and install / run the flatpak., this is due to issue #1912 
3. Click on the compatibility mode and follow the steps to enable /
   disable.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
