### PR TITLE
[WIP]feat: Add authentication and authentication provider api

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -1385,4 +1385,51 @@ declare module '@podman-desktop/api' {
     export function saveImage(engineId: string, id: string, filename: string): Promise<void>;
     export const onEvent: Event<ContainerJSONEvent>;
   }
+
+  export interface AccountInfo {
+    id?: string;
+    label: string;
+  }
+
+  export interface AuthenticationSession {
+    idToken: string | undefined;
+    readonly id: string;
+    readonly accessToken: string;
+    readonly scopes: ReadonlyArray<string>;
+    readonly account: AccountInfo;
+  }
+
+  export interface AuthenicationSessionChangeEvent {
+    provider: AuthenticationProviderInfo;
+  }
+
+  export interface AuthenticationProviderSessionChangeEvent {
+    added?: AuthenticationSession[];
+    changed?: AuthenticationSession[];
+    removed?: AuthenticationSession[];
+  }
+
+  export interface AuthenticationProviderInfo {
+    readonly id: string;
+    readonly displayName: string;
+    readonly accounts: AccountInfo[];
+  }
+
+  export interface AuthenticationGetSessionOptions {
+    createIfNone?: boolean;
+  }
+
+  export interface AuthenticationProvider {
+    onDidChangeSessions: Event<AuthenticationProviderSessionChangeEvent>
+    createSession(scopes: string[]): Promise<AuthenticationSession>;
+    getSessions(scopes?: string[]): Promise<AuthenticationSession[]>;
+    removeSession(id: string): Promise<void>;
+  }
+
+  export namespace authentication {
+    export const onDidChangeSessions: Event<AuthenticationProviderInfo>;
+    export function registerAuthenticationProvider(id: string, displayName: string, provider: AuthenticationProvider): Disposable;
+    export function getSession(providerId: string, scopes: string[], options: AuthenticationGetSessionOptions & {createIfNone: true}): Promise<AuthenticationSession | undefined>;
+    export function removeSession(providerId: string, id: string): Promise<void>;
+  }
 }

--- a/packages/main/src/plugin/authentication.ts
+++ b/packages/main/src/plugin/authentication.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2022 Red Hat, Inc.
+ * Copyright (C) 2023 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/main/src/plugin/authentication.ts
+++ b/packages/main/src/plugin/authentication.ts
@@ -1,0 +1,111 @@
+/**********************************************************************
+ * Copyright (C) 2022 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type {
+  authentication,
+  AuthenticationProvider,
+  AuthenticationSession,
+  AuthenticationProviderInfo,
+  AuthenticationGetSessionOptions,
+  Disposable,
+  Event,
+  AuthenticationProviderSessionChangeEvent,
+} from '@podman-desktop/api';
+import { Emitter } from './events/emitter';
+
+type Authentication = typeof authentication;
+
+export class AuthenticationImpl implements Authentication {
+
+    private _authProviders: Map<string, AuthenticationProvider> = new Map<string, AuthenticationProvider>;
+    private _authProvidersInfo: Map<string, AuthenticationProviderInfo> = new Map<string, AuthenticationProviderInfo>;
+    private _authProviderDisposables: Map<string, Disposable> = new Map<string, Disposable>();
+
+    constructor(private apiSender: any) {
+    }
+
+    public async signIn(providerId: string): Promise<void> {
+      void this.getSession(providerId,['openid']);
+    }
+
+    public async signOut(providerId: string) {
+      const provider = this._authProviders.get(providerId);
+      const sessions = await provider?.getSessions();
+      if (sessions?.length && sessions.length > 0) {
+        this.removeSession(providerId, sessions[0].id);
+      }
+    }
+
+    public getAuthenticationProvidersInfo(): readonly AuthenticationProviderInfo[] {
+      return Array.from(this._authProvidersInfo.values());
+    }
+
+    registerAuthenticationProvider(id: string, displayName: string, provider: AuthenticationProvider): Disposable {
+      const providerInfo = {id, displayName, accounts: []};
+      this._authProvidersInfo.set(id, providerInfo);
+      this._authProviders.set(id, provider);
+      this.apiSender.send('authentication-provider-register');
+      const onDidChangeSessionDisposable = provider.onDidChangeSessions((event: AuthenticationProviderSessionChangeEvent) => {
+        // for added sessions
+        event.added?.forEach(session => {
+          this._authProvidersInfo.get(id)?.accounts.push(session.account)
+        });
+        // for removed session
+        event.removed?.forEach(session => {
+          const providerInfo = this._authProvidersInfo.get(id);
+          if (providerInfo) {
+            const removedIndex = providerInfo.accounts.indexOf(session.account);
+            if (removedIndex >= 0) {
+              providerInfo.accounts.splice(removedIndex, 1);
+            }
+          }
+        });
+        this._onDidChangeSessions.fire(providerInfo);
+        this.apiSender.send('authentication-provider-register');  
+      });
+      this.apiSender.send('authentication-provider-register');
+      return {
+        dispose: () =>{
+          onDidChangeSessionDisposable.dispose();
+          this._authProviders.delete(id);
+          this._authProvidersInfo.delete(id)
+        }
+      };
+    }
+
+    async getSession(contributorId: string, scopes: string[], _options?: AuthenticationGetSessionOptions): Promise<AuthenticationSession | undefined> {
+      const contrib = this._authProviders.get(contributorId);
+      if (contrib) {
+        const activeSessions = await contrib.getSessions();
+        if (activeSessions.length > 0) {
+          return activeSessions[0];
+        } else {
+          return contrib.createSession(scopes);
+        }
+      }
+    }
+
+    async removeSession(contributorId: string, sessionId: string): Promise<void>{
+      const contrib = this._authProviders.get(contributorId);
+      return contrib?.removeSession(sessionId);
+    }
+
+    private readonly _onDidChangeSessions = new Emitter<AuthenticationProviderInfo>();
+    readonly onDidChangeSessions: Event<AuthenticationProviderInfo> =
+      this._onDidChangeSessions.event;
+}

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -46,6 +46,7 @@ import type { MenuRegistry } from '/@/plugin/menu-registry';
 import { desktopAppHomeDir } from '../util';
 import { Emitter } from './events/emitter';
 import { CancellationTokenSource } from './cancellation-token';
+import { AuthenticationImpl } from './authentication';
 
 /**
  * Handle the loading of an extension
@@ -105,6 +106,7 @@ export class ExtensionLoader {
     private proxy: Proxy,
     private containerProviderRegistry: ContainerProviderRegistry,
     private inputQuickPickRegistry: InputQuickPickRegistry,
+    private authentication: AuthenticationImpl,
   ) {}
 
   async listExtensions(): Promise<ExtensionInfo[]> {
@@ -580,7 +582,8 @@ export class ExtensionLoader {
         return containerProviderRegistry.onEvent(listener, thisArg, disposables);
       },
     };
-
+    
+    const authentication = this.authentication;
     return <typeof containerDesktopAPI>{
       // Types
       Disposable: Disposable,
@@ -603,6 +606,7 @@ export class ExtensionLoader {
       StatusBarAlignRight,
       InputBoxValidationSeverity,
       QuickPickItemKind,
+      authentication,
     };
   }
 

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -748,6 +748,21 @@ function initExposure(): void {
     },
   );
 
+  contextBridge.exposeInMainWorld('getAuthenticationProvidersInfo',
+    async (): Promise<readonly containerDesktopAPI.AuthenticationProviderInfo[]> => {
+    return ipcInvoke('authentication-provider-registry:getAuthenticationProvidersInfo');
+  });
+
+  contextBridge.exposeInMainWorld('requestAuthenticationProviderSignIn',
+    async (providerId: string): Promise<void> => {
+    return ipcInvoke('authentication-provider-registry:requestAuthenticationProviderSignIn', providerId);
+  });
+
+  contextBridge.exposeInMainWorld('requestAuthenticationProviderSignOut',
+    async (providerId: string): Promise<void> => {
+    return ipcInvoke('authentication-provider-registry:requestAuthenticationProviderSignOut', providerId);
+  });
+
   contextBridge.exposeInMainWorld(
     'getConfigurationProperties',
     async (): Promise<Record<string, IConfigurationPropertyRecordedSchema>> => {

--- a/packages/renderer/src/PreferencesNavigation.svelte
+++ b/packages/renderer/src/PreferencesNavigation.svelte
@@ -105,6 +105,19 @@ $: addHiddenClass = (provider: ProviderInfo): string =>
     </li>
     <!-- Registries configuration end -->
 
+    <!-- Authentication Providers configuration start -->
+    <li
+      class="pf-c-nav__item flex w-full justify-between {addCurrentClass(
+        '/preferences/authentication-providers',
+      )} hover:text-gray-300 cursor-pointer items-center">
+      <a href="/preferences/authentication-providers" id="configuration-section-authentication" class="pf-c-nav__link">
+        <div class="flex items-center">
+          <span class="hidden md:block group-hover:block">Authentication</span>
+        </div>
+      </a>
+    </li>
+    <!-- Authentication Providers configuration end -->
+
     <!-- Extensions catalog configuration start -->
     <li
       class="pf-c-nav__item pf-m-expandable {addExpandedClass('extensionsCatalog')} {addCurrentClass(

--- a/packages/renderer/src/lib/preferences/PreferencesAuthenticationProvidersRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesAuthenticationProvidersRendering.svelte
@@ -1,0 +1,69 @@
+<script lang="ts">
+    import { authenticationProviders } from '../../stores/authenticationProviders';
+    import DropdownMenu from '../ui/DropdownMenu.svelte';
+    import DropdownMenuItem from '../ui/DropDownMenuItem.svelte';
+    import { faUser } from '@fortawesome/free-solid-svg-icons';
+</script>
+    
+    <div class="flex w-full flex-col p-2 bg-zinc-800">
+      <h1 class="capitalize text-lg font-bold py-8 px-8">Authentication</h1>
+      <div class="container mx-auto">
+        <!-- Registries table start -->
+        <div class="w-full border-t border-b border-gray-600">
+          <div class="flex w-full">
+            <div class="flex-1 text-left py-4 pl-10 text-sm font-bold w-1/4">Provider Name</div>
+            <div class="text-left py-4 text-sm font-bold w-3/4">Logged in as</div>
+          </div>
+    
+          {#each $authenticationProviders as provider}
+            <!-- containerDesktopAPI.Registry row start -->
+            <div class="flex flex-col w-full border-t border-gray-600">
+              <div class="flex flex-row">
+    
+                <!-- Authenication Contributor name -->
+                <div class="flex-1 pt-2 pl-10 pr-5 text-sm w-1/4 m-auto">
+                  <div class="flex items-center w-full h-full">
+                    <div class="flex items-center">
+                      <!-- Only show if a "suggested" registry icon has been added -->
+                        <span>
+                          {provider.displayName}
+                        </span>
+                    </div>
+                  </div>
+                </div>
+    
+                <!-- Username -->
+                <div class="pt-2 pb-2 text-sm w-3/4 m-auto">
+                  <div class="flex flex-row">
+                    <div class="flex items-center w-full">
+                      <span>
+                        {provider.accounts[0] ? provider.accounts[0].label : 'Not logged in'}
+                      </span>
+                    </div>
+                    <DropdownMenu>
+                      <DropdownMenuItem
+                        title="Sign Out"
+                        onClick="{() => window.requestAuthenticationProviderSignOut(provider.id)}"
+                        hidden="{!provider.accounts.length}"
+                        icon="{faUser}" />
+                      <DropdownMenuItem
+                        title="Sign In"
+                        onClick="{() => window.requestAuthenticationProviderSignIn(provider.id)}"
+                        hidden="{!!provider.accounts.length}"
+                        icon="{faUser}" />
+                    </DropdownMenu>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <!-- containerDesktopAPI.Registry row end -->
+          {/each}
+        </div>
+        <!-- Registries table end -->
+      </div>
+    
+      <!-- Spacer start -->
+      <div class="container h-full"></div>
+      <!-- Spacer end -->
+      <!-- Add new registry button end -->
+    </div>

--- a/packages/renderer/src/lib/preferences/PreferencesPage.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesPage.svelte
@@ -14,6 +14,7 @@ import PreferencesPageDockerExtensions from '../docker-extension/PreferencesPage
 import PreferencesProxiesRendering from './PreferencesProxiesRendering.svelte';
 import ExtensionList from '../ExtensionList.svelte';
 import PreferencesResourcesRendering from './PreferencesResourcesRendering.svelte';
+import PreferencesAuthenticationProvidersRendering from './PreferencesAuthenticationProvidersRendering.svelte';
 
 let properties: IConfigurationPropertyRecordedSchema[];
 let defaultPrefPageId: string;
@@ -60,6 +61,9 @@ onMount(async () => {
   </Route>
   <Route path="/registries">
     <PreferencesRegistriesEditing />
+  </Route>
+  <Route path='/authentication-providers'>
+    <PreferencesAuthenticationProvidersRendering />
   </Route>
   <Route path="/proxies">
     <PreferencesProxiesRendering />

--- a/packages/renderer/src/stores/authenticationProviders.ts
+++ b/packages/renderer/src/stores/authenticationProviders.ts
@@ -1,0 +1,36 @@
+/**********************************************************************
+ * Copyright (C) 2022 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type * as containerDesktopAPI from '@podman-desktop/api';
+import { derived, readable, Readable, Writable, writable } from 'svelte/store';
+
+export async function fetchAuthenicationProvidersInfo() {
+  // here we have to rebuld authentication providers with sessinons 
+  // which are not included
+  const authProvidersInfo = await window.getAuthenticationProvidersInfo();
+  authenticationProviders.set(authProvidersInfo);
+}
+
+
+export const authenticationProviders: Writable<readonly containerDesktopAPI.AuthenticationProviderInfo[]> = writable([]);
+
+// need to refresh when new registry are updated/deleted
+window.events?.receive('authentication-provider-register', fetchAuthenicationProvidersInfo);
+window.events?.receive('authentication-provider-unregister', fetchAuthenicationProvidersInfo);
+window.events?.receive('authentication-provider-update', fetchAuthenicationProvidersInfo);
+window.addEventListener('system-ready', fetchAuthenicationProvidersInfo);


### PR DESCRIPTION
### What does this PR do?

* Adds authentication API module to @podman-desktop/api
* Adds Authentication settings page to show available authentication providers
  * Sign In command for provider without active authentication sessions
  * Sign Out command for provider with one auth session

### Screenshot/screencast of this PR

Initial view

<img width="1167" alt="image" src="https://user-images.githubusercontent.com/620330/228168326-a2b7f148-1f5a-4580-a801-7c18709b677a.png">

View after extension with authentication provider is activated and registered provider

<img width="1167" alt="image" src="https://user-images.githubusercontent.com/620330/228168994-8006530d-916e-4151-8c5d-5dfaab3ea906.png">

Sign In command

<img width="1167" alt="image" src="https://user-images.githubusercontent.com/620330/228169282-60057a68-2a43-4a9c-bc69-6a61dfe68654.png">

After successful Sign In the view shows account used to sign in

<img width="1167" alt="image" src="https://user-images.githubusercontent.com/620330/228173776-2b9b7bf9-133e-4760-8ead-3a57cbef6ed3.png">

Sign Out command

<img width="1167" alt="image" src="https://user-images.githubusercontent.com/620330/228173916-ad601c09-2b96-4650-a9a5-bb40c9fad8c9.png">

After signing out view clears account name from the table (see image above after extension installation)


### What issues does this PR fix or reference?

#1702.
PR is blocking https://github.com/redhat-developer/podman-desktop-redhat-account-ext/pull/3

### How to test this PR?

N/A
