### PR TITLE
fix: do not display error on local builds

### DIFF
--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -424,8 +424,14 @@ export class PluginSystem {
       });
 
       autoUpdater.on('error', error => {
-        console.error('unable to check for updates', error);
         updateInProgress = false;
+        // local build not pushed to GitHub so prevent any 'update'
+        if (error?.message?.includes('No published versions on GitHub')) {
+          console.log('Cannot check for updates, no published versions on GitHub');
+          defaultVersionEntry();
+          return;
+        }
+        console.error('unable to check for updates', error);
         dialog.showErrorBox('Error: ', error == null ? 'unknown' : (error.stack || error).toString());
       });
 


### PR DESCRIPTION
### What does this PR do?
Do not display error on local builds

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/1851

### How to test this PR?

`yarn compile:current` and execute the build

before:
Error Dialog Box

after:
No Error Dialog Box



Change-Id: I647389fc42917fb468ce4d8fc4c0649ab238e757
