### PR TITLE
feat: alert user when engine container actions fail

### DIFF
--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -362,10 +362,10 @@ function prettyMachineName(machineName: string): string {
 
 async function registerProviderFor(provider: extensionApi.Provider, machineInfo: MachineInfo, socketPath: string) {
   const lifecycle: extensionApi.ProviderConnectionLifecycle = {
-    start: async (context): Promise<void> => {
+    start: async (context, logger): Promise<void> => {
       try {
         // start the machine
-        await execPromise(getPodmanCli(), ['machine', 'start', machineInfo.name], { logger: context.log });
+        await execPromise(getPodmanCli(), ['machine', 'start', machineInfo.name], { logger });
         provider.updateStatus('started');
       } catch (err) {
         console.error(err);
@@ -373,12 +373,12 @@ async function registerProviderFor(provider: extensionApi.Provider, machineInfo:
         throw err;
       }
     },
-    stop: async (context): Promise<void> => {
-      await execPromise(getPodmanCli(), ['machine', 'stop', machineInfo.name], { logger: context.log });
+    stop: async (context, logger): Promise<void> => {
+      await execPromise(getPodmanCli(), ['machine', 'stop', machineInfo.name], { logger });
       provider.updateStatus('ready');
     },
-    delete: async (): Promise<void> => {
-      await execPromise(getPodmanCli(), ['machine', 'rm', '-f', machineInfo.name]);
+    delete: async (logger): Promise<void> => {
+      await execPromise(getPodmanCli(), ['machine', 'rm', '-f', machineInfo.name], { logger });
     },
   };
 

--- a/extensions/podman/src/podman-cli.ts
+++ b/extensions/podman/src/podman-cli.ts
@@ -17,7 +17,7 @@
  ***********************************************************************/
 import { spawn } from 'node:child_process';
 import { isMac, isWindows } from './util';
-import type { CancellationToken, Logger } from '@podman-desktop/api';
+import { CancellationToken, Logger, window } from '@podman-desktop/api';
 import { configuration } from '@podman-desktop/api';
 
 const macosExtraPath = '/usr/local/bin:/opt/homebrew/bin:/opt/local/bin:/opt/podman/bin';
@@ -99,6 +99,8 @@ export function execPromise(
       if (stdErr && stdErr !== '') {
         content += stdErr + '\n';
       }
+      options?.logger?.error(content);
+      showNotification(content);
       reject(content + error);
     });
     process.stdout.setEncoding('utf8');
@@ -110,6 +112,7 @@ export function execPromise(
     process.stderr.on('data', data => {
       stdErr += data;
       options?.logger?.error(data);
+      showNotification(data);
     });
 
     process.on('close', exitCode => {
@@ -126,6 +129,14 @@ export function execPromise(
       }
       resolve(stdOut.trim());
     });
+  });
+}
+
+function showNotification(body: string) {
+  window.showNotification({
+    silent: false,
+    title: "Podman machine",
+    body
   });
 }
 

--- a/extensions/podman/src/podman-cli.ts
+++ b/extensions/podman/src/podman-cli.ts
@@ -17,7 +17,8 @@
  ***********************************************************************/
 import { spawn } from 'node:child_process';
 import { isMac, isWindows } from './util';
-import { CancellationToken, Logger, window } from '@podman-desktop/api';
+import type { CancellationToken, Logger } from '@podman-desktop/api';
+import { window } from '@podman-desktop/api';
 import { configuration } from '@podman-desktop/api';
 
 const macosExtraPath = '/usr/local/bin:/opt/homebrew/bin:/opt/local/bin:/opt/podman/bin';
@@ -135,8 +136,8 @@ export function execPromise(
 function showNotification(body: string) {
   window.showNotification({
     silent: false,
-    title: "Podman machine",
-    body
+    title: 'Podman machine',
+    body,
   });
 }
 

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -197,9 +197,9 @@ declare module '@podman-desktop/api' {
   }
 
   export interface ProviderConnectionLifecycle {
-    start?(startContext: LifecycleContext): Promise<void>;
-    stop?(stopContext: LifecycleContext): Promise<void>;
-    delete?(): Promise<void>;
+    start?(startContext: LifecycleContext, logger?: Logger): Promise<void>;
+    stop?(stopContext: LifecycleContext, logger?: Logger): Promise<void>;
+    delete?(logger?: Logger): Promise<void>;
   }
 
   export interface ContainerProviderConnectionEndpoint {

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1184,8 +1184,11 @@ export class PluginSystem {
         _listener: Electron.IpcMainInvokeEvent,
         providerId: string,
         providerContainerConnectionInfo: ProviderContainerConnectionInfo,
+        loggerId: string
       ): Promise<void> => {
-        return providerRegistry.startProviderConnection(providerId, providerContainerConnectionInfo);
+        const logger = this.getLogHandlerCreateConnection('provider-registry:taskConnection-onData', loggerId);
+        providerRegistry.startProviderConnection(providerId, providerContainerConnectionInfo, logger);
+        logger.onEnd();
       },
     );
 
@@ -1195,8 +1198,11 @@ export class PluginSystem {
         _listener: Electron.IpcMainInvokeEvent,
         providerId: string,
         providerContainerConnectionInfo: ProviderContainerConnectionInfo,
+        loggerId: string
       ): Promise<void> => {
-        return providerRegistry.stopProviderConnection(providerId, providerContainerConnectionInfo);
+        const logger = this.getLogHandlerCreateConnection('provider-registry:taskConnection-onData', loggerId);
+        providerRegistry.stopProviderConnection(providerId, providerContainerConnectionInfo, logger);
+        logger.onEnd();
       },
     );
 
@@ -1206,8 +1212,11 @@ export class PluginSystem {
         _listener: Electron.IpcMainInvokeEvent,
         providerId: string,
         providerContainerConnectionInfo: ProviderContainerConnectionInfo,
+        loggerId: string
       ): Promise<void> => {
-        return providerRegistry.deleteProviderConnection(providerId, providerContainerConnectionInfo);
+        const logger = this.getLogHandlerCreateConnection('provider-registry:taskConnection-onData', loggerId);
+        providerRegistry.deleteProviderConnection(providerId, providerContainerConnectionInfo, logger);
+        logger.onEnd();
       },
     );
 
@@ -1220,7 +1229,7 @@ export class PluginSystem {
         loggerId: string,
         tokenId?: number,
       ): Promise<void> => {
-        const logger = this.getLogHandlerCreateConnection(loggerId);
+        const logger = this.getLogHandlerCreateConnection('provider-registry:taskConnection-onData', loggerId);
         let token;
         if (tokenId) {
           const tokenSource = cancellationTokenRegistry.getCancellationTokenSource(tokenId);
@@ -1239,7 +1248,7 @@ export class PluginSystem {
         params: { [key: string]: unknown },
         loggerId: string,
       ): Promise<void> => {
-        const logger = this.getLogHandlerCreateConnection(loggerId);
+        const logger = this.getLogHandlerCreateConnection('provider-registry:taskConnection-onData', loggerId);
 
         await providerRegistry.createKubernetesProviderConnection(internalProviderId, params, logger);
         logger.onEnd();
@@ -1352,19 +1361,19 @@ export class PluginSystem {
     return this.extensionLoader;
   }
 
-  getLogHandlerCreateConnection(loggerId: string): LoggerWithEnd {
+  getLogHandlerCreateConnection(channel: string, loggerId: string): LoggerWithEnd {
     return {
       log: (...data: unknown[]) => {
-        this.getWebContentsSender().send('provider-registry:createConnection-onData', loggerId, 'log', data);
+        this.getWebContentsSender().send(channel, loggerId, 'log', data);
       },
       warn: (...data: unknown[]) => {
-        this.getWebContentsSender().send('provider-registry:createConnection-onData', loggerId, 'warn', data);
+        this.getWebContentsSender().send(channel, loggerId, 'warn', data);
       },
       error: (...data: unknown[]) => {
-        this.getWebContentsSender().send('provider-registry:createConnection-onData', loggerId, 'error', data);
+        this.getWebContentsSender().send(channel, loggerId, 'error', data);
       },
       onEnd: () => {
-        this.getWebContentsSender().send('provider-registry:createConnection-onData', loggerId, 'finish');
+        this.getWebContentsSender().send(channel, loggerId, 'finish');
       },
     };
   }

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1187,7 +1187,7 @@ export class PluginSystem {
         loggerId: string,
       ): Promise<void> => {
         const logger = this.getLogHandlerCreateConnection('provider-registry:taskConnection-onData', loggerId);
-        providerRegistry.startProviderConnection(providerId, providerContainerConnectionInfo, logger);
+        await providerRegistry.startProviderConnection(providerId, providerContainerConnectionInfo, logger);
         logger.onEnd();
       },
     );
@@ -1201,7 +1201,7 @@ export class PluginSystem {
         loggerId: string,
       ): Promise<void> => {
         const logger = this.getLogHandlerCreateConnection('provider-registry:taskConnection-onData', loggerId);
-        providerRegistry.stopProviderConnection(providerId, providerContainerConnectionInfo, logger);
+        await providerRegistry.stopProviderConnection(providerId, providerContainerConnectionInfo, logger);
         logger.onEnd();
       },
     );
@@ -1215,7 +1215,7 @@ export class PluginSystem {
         loggerId: string,
       ): Promise<void> => {
         const logger = this.getLogHandlerCreateConnection('provider-registry:taskConnection-onData', loggerId);
-        providerRegistry.deleteProviderConnection(providerId, providerContainerConnectionInfo, logger);
+        await providerRegistry.deleteProviderConnection(providerId, providerContainerConnectionInfo, logger);
         logger.onEnd();
       },
     );

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1184,7 +1184,7 @@ export class PluginSystem {
         _listener: Electron.IpcMainInvokeEvent,
         providerId: string,
         providerContainerConnectionInfo: ProviderContainerConnectionInfo,
-        loggerId: string
+        loggerId: string,
       ): Promise<void> => {
         const logger = this.getLogHandlerCreateConnection('provider-registry:taskConnection-onData', loggerId);
         providerRegistry.startProviderConnection(providerId, providerContainerConnectionInfo, logger);
@@ -1198,7 +1198,7 @@ export class PluginSystem {
         _listener: Electron.IpcMainInvokeEvent,
         providerId: string,
         providerContainerConnectionInfo: ProviderContainerConnectionInfo,
-        loggerId: string
+        loggerId: string,
       ): Promise<void> => {
         const logger = this.getLogHandlerCreateConnection('provider-registry:taskConnection-onData', loggerId);
         providerRegistry.stopProviderConnection(providerId, providerContainerConnectionInfo, logger);
@@ -1212,7 +1212,7 @@ export class PluginSystem {
         _listener: Electron.IpcMainInvokeEvent,
         providerId: string,
         providerContainerConnectionInfo: ProviderContainerConnectionInfo,
-        loggerId: string
+        loggerId: string,
       ): Promise<void> => {
         const logger = this.getLogHandlerCreateConnection('provider-registry:taskConnection-onData', loggerId);
         providerRegistry.deleteProviderConnection(providerId, providerContainerConnectionInfo, logger);

--- a/packages/main/src/plugin/provider-registry.ts
+++ b/packages/main/src/plugin/provider-registry.ts
@@ -638,7 +638,7 @@ export class ProviderRegistry {
   async startProviderConnection(
     internalProviderId: string,
     providerContainerConnectionInfo: ProviderContainerConnectionInfo,
-    logHandler: Logger,
+    logHandler?: Logger,
   ): Promise<void> {
     // grab the correct provider
     const connection = this.getMatchingContainerConnectionFromProvider(
@@ -662,7 +662,7 @@ export class ProviderRegistry {
   async stopProviderConnection(
     internalProviderId: string,
     providerContainerConnectionInfo: ProviderContainerConnectionInfo,
-    logHandler: Logger,
+    logHandler?: Logger,
   ): Promise<void> {
     // grab the correct provider
     const connection = this.getMatchingContainerConnectionFromProvider(
@@ -686,7 +686,7 @@ export class ProviderRegistry {
   async deleteProviderConnection(
     internalProviderId: string,
     providerContainerConnectionInfo: ProviderContainerConnectionInfo,
-    logHandler: Logger,
+    logHandler?: Logger,
   ): Promise<void> {
     // grab the correct provider
     const connection = this.getMatchingContainerConnectionFromProvider(

--- a/packages/main/src/plugin/provider-registry.ts
+++ b/packages/main/src/plugin/provider-registry.ts
@@ -638,7 +638,7 @@ export class ProviderRegistry {
   async startProviderConnection(
     internalProviderId: string,
     providerContainerConnectionInfo: ProviderContainerConnectionInfo,
-    logHandler: Logger
+    logHandler: Logger,
   ): Promise<void> {
     // grab the correct provider
     const connection = this.getMatchingContainerConnectionFromProvider(
@@ -662,7 +662,7 @@ export class ProviderRegistry {
   async stopProviderConnection(
     internalProviderId: string,
     providerContainerConnectionInfo: ProviderContainerConnectionInfo,
-    logHandler: Logger
+    logHandler: Logger,
   ): Promise<void> {
     // grab the correct provider
     const connection = this.getMatchingContainerConnectionFromProvider(
@@ -686,7 +686,7 @@ export class ProviderRegistry {
   async deleteProviderConnection(
     internalProviderId: string,
     providerContainerConnectionInfo: ProviderContainerConnectionInfo,
-    logHandler: Logger
+    logHandler: Logger,
   ): Promise<void> {
     // grab the correct provider
     const connection = this.getMatchingContainerConnectionFromProvider(

--- a/packages/main/src/plugin/provider-registry.ts
+++ b/packages/main/src/plugin/provider-registry.ts
@@ -638,6 +638,7 @@ export class ProviderRegistry {
   async startProviderConnection(
     internalProviderId: string,
     providerContainerConnectionInfo: ProviderContainerConnectionInfo,
+    logHandler: Logger
   ): Promise<void> {
     // grab the correct provider
     const connection = this.getMatchingContainerConnectionFromProvider(
@@ -655,12 +656,13 @@ export class ProviderRegistry {
       throw new Error('The connection does not have context to start');
     }
 
-    return lifecycle.start(context);
+    return lifecycle.start(context, logHandler);
   }
 
   async stopProviderConnection(
     internalProviderId: string,
     providerContainerConnectionInfo: ProviderContainerConnectionInfo,
+    logHandler: Logger
   ): Promise<void> {
     // grab the correct provider
     const connection = this.getMatchingContainerConnectionFromProvider(
@@ -678,12 +680,13 @@ export class ProviderRegistry {
       throw new Error('The connection does not have context to start');
     }
 
-    return lifecycle.stop(context);
+    return lifecycle.stop(context, logHandler);
   }
 
   async deleteProviderConnection(
     internalProviderId: string,
     providerContainerConnectionInfo: ProviderContainerConnectionInfo,
+    logHandler: Logger
   ): Promise<void> {
     // grab the correct provider
     const connection = this.getMatchingContainerConnectionFromProvider(
@@ -696,7 +699,7 @@ export class ProviderRegistry {
       throw new Error('The container connection does not support delete lifecycle');
     }
     this.telemetryService.track('deleteProviderConnection', { name: providerContainerConnectionInfo.name });
-    return lifecycle.delete();
+    return lifecycle.delete(logHandler);
   }
 
   onDidRegisterContainerConnectionCallback(

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -585,7 +585,12 @@ function initExposure(): void {
 
   contextBridge.exposeInMainWorld(
     'startProviderConnectionLifecycle',
-    async (providerId: string, providerContainerConnectionInfo: ProviderContainerConnectionInfo, key: symbol, keyLogger: (key: symbol, eventName: 'log' | 'warn' | 'error' | 'finish', args: unknown[]) => void): Promise<void> => {
+    async (
+      providerId: string,
+      providerContainerConnectionInfo: ProviderContainerConnectionInfo,
+      key: symbol,
+      keyLogger: (key: symbol, eventName: 'log' | 'warn' | 'error' | 'finish', args: unknown[]) => void,
+    ): Promise<void> => {
       onDataCallbacksTaskConnectionId++;
       onDataCallbacksTaskConnectionKeys.set(onDataCallbacksTaskConnectionId, key);
       onDataCallbacksTaskConnectionLogs.set(onDataCallbacksTaskConnectionId, keyLogger);
@@ -593,14 +598,19 @@ function initExposure(): void {
         'provider-registry:startProviderConnectionLifecycle',
         providerId,
         providerContainerConnectionInfo,
-        onDataCallbacksTaskConnectionId
+        onDataCallbacksTaskConnectionId,
       );
     },
   );
 
   contextBridge.exposeInMainWorld(
     'stopProviderConnectionLifecycle',
-    async (providerId: string, providerContainerConnectionInfo: ProviderContainerConnectionInfo, key: symbol, keyLogger: (key: symbol, eventName: 'log' | 'warn' | 'error' | 'finish', args: unknown[]) => void): Promise<void> => {
+    async (
+      providerId: string,
+      providerContainerConnectionInfo: ProviderContainerConnectionInfo,
+      key: symbol,
+      keyLogger: (key: symbol, eventName: 'log' | 'warn' | 'error' | 'finish', args: unknown[]) => void,
+    ): Promise<void> => {
       onDataCallbacksTaskConnectionId++;
       onDataCallbacksTaskConnectionKeys.set(onDataCallbacksTaskConnectionId, key);
       onDataCallbacksTaskConnectionLogs.set(onDataCallbacksTaskConnectionId, keyLogger);
@@ -608,14 +618,19 @@ function initExposure(): void {
         'provider-registry:stopProviderConnectionLifecycle',
         providerId,
         providerContainerConnectionInfo,
-        onDataCallbacksTaskConnectionId
+        onDataCallbacksTaskConnectionId,
       );
     },
   );
 
   contextBridge.exposeInMainWorld(
     'deleteProviderConnectionLifecycle',
-    async (providerId: string, providerContainerConnectionInfo: ProviderContainerConnectionInfo, key: symbol, keyLogger: (key: symbol, eventName: 'log' | 'warn' | 'error' | 'finish', args: unknown[]) => void): Promise<void> => {
+    async (
+      providerId: string,
+      providerContainerConnectionInfo: ProviderContainerConnectionInfo,
+      key: symbol,
+      keyLogger: (key: symbol, eventName: 'log' | 'warn' | 'error' | 'finish', args: unknown[]) => void,
+    ): Promise<void> => {
       onDataCallbacksTaskConnectionId++;
       onDataCallbacksTaskConnectionKeys.set(onDataCallbacksTaskConnectionId, key);
       onDataCallbacksTaskConnectionLogs.set(onDataCallbacksTaskConnectionId, keyLogger);
@@ -623,7 +638,7 @@ function initExposure(): void {
         'provider-registry:deleteProviderConnectionLifecycle',
         providerId,
         providerContainerConnectionInfo,
-        onDataCallbacksTaskConnectionId
+        onDataCallbacksTaskConnectionId,
       );
     },
   );

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -511,13 +511,13 @@ function initExposure(): void {
     },
   );
 
-  let onDataCallbacksCreateConnectionId = 0;
+  let onDataCallbacksTaskConnectionId = 0;
 
-  const onDataCallbacksCreateConnectionLogs = new Map<
+  const onDataCallbacksTaskConnectionLogs = new Map<
     number,
     (key: symbol, eventName: 'log' | 'warn' | 'error' | 'finish', args: unknown[]) => void
   >();
-  const onDataCallbacksCreateConnectionKeys = new Map<number, symbol>();
+  const onDataCallbacksTaskConnectionKeys = new Map<number, symbol>();
 
   contextBridge.exposeInMainWorld(
     'createContainerProviderConnection',
@@ -529,14 +529,14 @@ function initExposure(): void {
       keyLogger: (key: symbol, eventName: 'log' | 'warn' | 'error' | 'finish', args: unknown[]) => void,
       tokenId?: number,
     ): Promise<void> => {
-      onDataCallbacksCreateConnectionId++;
-      onDataCallbacksCreateConnectionKeys.set(onDataCallbacksCreateConnectionId, key);
-      onDataCallbacksCreateConnectionLogs.set(onDataCallbacksCreateConnectionId, keyLogger);
+      onDataCallbacksTaskConnectionId++;
+      onDataCallbacksTaskConnectionKeys.set(onDataCallbacksTaskConnectionId, key);
+      onDataCallbacksTaskConnectionLogs.set(onDataCallbacksTaskConnectionId, keyLogger);
       return ipcInvoke(
         'provider-registry:createContainerProviderConnection',
         internalProviderId,
         params,
-        onDataCallbacksCreateConnectionId,
+        onDataCallbacksTaskConnectionId,
         tokenId,
       );
     },
@@ -551,24 +551,24 @@ function initExposure(): void {
       key: symbol,
       keyLogger: (key: symbol, eventName: 'log' | 'warn' | 'error' | 'finish', args: unknown[]) => void,
     ): Promise<void> => {
-      onDataCallbacksCreateConnectionId++;
-      onDataCallbacksCreateConnectionKeys.set(onDataCallbacksCreateConnectionId, key);
-      onDataCallbacksCreateConnectionLogs.set(onDataCallbacksCreateConnectionId, keyLogger);
+      onDataCallbacksTaskConnectionId++;
+      onDataCallbacksTaskConnectionKeys.set(onDataCallbacksTaskConnectionId, key);
+      onDataCallbacksTaskConnectionLogs.set(onDataCallbacksTaskConnectionId, keyLogger);
       return ipcInvoke(
         'provider-registry:createKubernetesProviderConnection',
         internalProviderId,
         params,
-        onDataCallbacksCreateConnectionId,
+        onDataCallbacksTaskConnectionId,
       );
     },
   );
 
   ipcRenderer.on(
-    'provider-registry:createConnection-onData',
-    (_, onDataCallbacksCreateConnectionId: number, channel: string, data: unknown[]) => {
+    'provider-registry:taskConnection-onData',
+    (_, onDataCallbacksTaskConnectionId: number, channel: string, data: unknown[]) => {
       // grab callback from the map
-      const callback = onDataCallbacksCreateConnectionLogs.get(onDataCallbacksCreateConnectionId);
-      const key = onDataCallbacksCreateConnectionKeys.get(onDataCallbacksCreateConnectionId);
+      const callback = onDataCallbacksTaskConnectionLogs.get(onDataCallbacksTaskConnectionId);
+      const key = onDataCallbacksTaskConnectionKeys.get(onDataCallbacksTaskConnectionId);
       if (callback && key) {
         if (channel === 'log') {
           callback(key, 'log', data);
@@ -585,33 +585,45 @@ function initExposure(): void {
 
   contextBridge.exposeInMainWorld(
     'startProviderConnectionLifecycle',
-    async (providerId: string, providerContainerConnectionInfo: ProviderContainerConnectionInfo): Promise<void> => {
+    async (providerId: string, providerContainerConnectionInfo: ProviderContainerConnectionInfo, key: symbol, keyLogger: (key: symbol, eventName: 'log' | 'warn' | 'error' | 'finish', args: unknown[]) => void): Promise<void> => {
+      onDataCallbacksTaskConnectionId++;
+      onDataCallbacksTaskConnectionKeys.set(onDataCallbacksTaskConnectionId, key);
+      onDataCallbacksTaskConnectionLogs.set(onDataCallbacksTaskConnectionId, keyLogger);
       return ipcInvoke(
         'provider-registry:startProviderConnectionLifecycle',
         providerId,
         providerContainerConnectionInfo,
+        onDataCallbacksTaskConnectionId
       );
     },
   );
 
   contextBridge.exposeInMainWorld(
     'stopProviderConnectionLifecycle',
-    async (providerId: string, providerContainerConnectionInfo: ProviderContainerConnectionInfo): Promise<void> => {
+    async (providerId: string, providerContainerConnectionInfo: ProviderContainerConnectionInfo, key: symbol, keyLogger: (key: symbol, eventName: 'log' | 'warn' | 'error' | 'finish', args: unknown[]) => void): Promise<void> => {
+      onDataCallbacksTaskConnectionId++;
+      onDataCallbacksTaskConnectionKeys.set(onDataCallbacksTaskConnectionId, key);
+      onDataCallbacksTaskConnectionLogs.set(onDataCallbacksTaskConnectionId, keyLogger);
       return ipcInvoke(
         'provider-registry:stopProviderConnectionLifecycle',
         providerId,
         providerContainerConnectionInfo,
+        onDataCallbacksTaskConnectionId
       );
     },
   );
 
   contextBridge.exposeInMainWorld(
     'deleteProviderConnectionLifecycle',
-    async (providerId: string, providerContainerConnectionInfo: ProviderContainerConnectionInfo): Promise<void> => {
+    async (providerId: string, providerContainerConnectionInfo: ProviderContainerConnectionInfo, key: symbol, keyLogger: (key: symbol, eventName: 'log' | 'warn' | 'error' | 'finish', args: unknown[]) => void): Promise<void> => {
+      onDataCallbacksTaskConnectionId++;
+      onDataCallbacksTaskConnectionKeys.set(onDataCallbacksTaskConnectionId, key);
+      onDataCallbacksTaskConnectionLogs.set(onDataCallbacksTaskConnectionId, keyLogger);
       return ipcInvoke(
         'provider-registry:deleteProviderConnectionLifecycle',
         providerId,
         providerContainerConnectionInfo,
+        onDataCallbacksTaskConnectionId
       );
     },
   );

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationRendering.svelte
@@ -2,17 +2,16 @@
 import type { IConfigurationPropertyRecordedSchema } from '../../../../main/src/plugin/configuration-registry';
 import type { ProviderInfo } from '../../../../main/src/plugin/api/provider-info';
 import PreferencesRenderingItemFormat from './PreferencesRenderingItemFormat.svelte';
-import type { Logger as LoggerType } from '@podman-desktop/api';
 import Logger from './Logger.svelte';
 import { writeToTerminal } from './Util';
 import ErrorMessage from '../ui/ErrorMessage.svelte';
 import {
   clearCreateTask,
-  CreateConnectionCallback,
+  ConnectionCallback,
   disconnectUI,
   eventCollect,
   reconnectUI,
-  startCreate,
+  startTask,
 } from './preferences-connection-rendering-task';
 import { get } from 'svelte/store';
 import { createConnectionsInfo } from '/@/stores/create-connections';
@@ -85,7 +84,7 @@ onDestroy(() => {
 let logsTerminal;
 let loggerHandlerKey: symbol | undefined = undefined;
 
-function getLoggerHandler(): CreateConnectionCallback {
+function getLoggerHandler(): ConnectionCallback {
   return {
     log: args => {
       writeToTerminal(logsTerminal, args, '\x1b[37m');
@@ -153,9 +152,9 @@ async function handleOnSubmit(e) {
   try {
     // clear terminal
     logsTerminal?.clear();
-    loggerHandlerKey = startCreate(
+    loggerHandlerKey = startTask(
       `Creating a ${providerInfo.name} provider`,
-      providerInfo.internalId,
+      `/preferences/provider/${providerInfo.internalId}`,
       getLoggerHandler(),
     );
     updateStore();

--- a/packages/renderer/src/lib/preferences/PreferencesContainerConnectionRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesContainerConnectionRendering.svelte
@@ -86,14 +86,10 @@ router.subscribe(async route => {
 
 function getLoggerHandler(): ConnectionCallback {
   return {
-    log: () => {      
-    },
-    warn: () => {      
-    },
-    error: () => {
-    },
-    onEnd: () => {
-    },
+    log: () => {},
+    warn: () => {},
+    error: () => {},
+    onEnd: () => {},
   };
 }
 
@@ -105,7 +101,12 @@ async function startConnection() {
       `/preferences/resources`,
       getLoggerHandler(),
     );
-    await window.startProviderConnectionLifecycle(providerInfo.internalId, containerConnectionInfo, loggerHandlerKey, eventCollect);
+    await window.startProviderConnectionLifecycle(
+      providerInfo.internalId,
+      containerConnectionInfo,
+      loggerHandlerKey,
+      eventCollect,
+    );
   } catch (err) {
     lifecycleError = err;
   }
@@ -118,7 +119,12 @@ async function stopConnection() {
     `/preferences/resources`,
     getLoggerHandler(),
   );
-  await window.stopProviderConnectionLifecycle(providerInfo.internalId, containerConnectionInfo, loggerHandlerKey, eventCollect);
+  await window.stopProviderConnectionLifecycle(
+    providerInfo.internalId,
+    containerConnectionInfo,
+    loggerHandlerKey,
+    eventCollect,
+  );
 }
 
 async function deleteConnection() {
@@ -128,7 +134,12 @@ async function deleteConnection() {
     `/preferences/resources`,
     getLoggerHandler(),
   );
-  await window.deleteProviderConnectionLifecycle(providerInfo.internalId, containerConnectionInfo, loggerHandlerKey, eventCollect);
+  await window.deleteProviderConnectionLifecycle(
+    providerInfo.internalId,
+    containerConnectionInfo,
+    loggerHandlerKey,
+    eventCollect,
+  );
   router.goto('/preferences/providers');
 }
 

--- a/packages/renderer/src/lib/preferences/PreferencesContainerConnectionRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesContainerConnectionRendering.svelte
@@ -12,6 +12,7 @@ import Logger from './Logger.svelte';
 import { writeToTerminal } from './Util';
 import ErrorMessage from '../ui/ErrorMessage.svelte';
 import { filesize } from 'filesize';
+import { ConnectionCallback, eventCollect, startTask } from './preferences-connection-rendering-task';
 
 export let properties: IConfigurationPropertyRecordedSchema[] = [];
 export let providerInternalId: string = undefined;
@@ -82,10 +83,29 @@ let lifecycleError = '';
 router.subscribe(async route => {
   lifecycleError = '';
 });
+
+function getLoggerHandler(): ConnectionCallback {
+  return {
+    log: () => {      
+    },
+    warn: () => {      
+    },
+    error: () => {
+    },
+    onEnd: () => {
+    },
+  };
+}
+
 async function startConnection() {
   lifecycleError = undefined;
   try {
-    await window.startProviderConnectionLifecycle(providerInfo.internalId, containerConnectionInfo);
+    const loggerHandlerKey = startTask(
+      `Start ${providerInfo.name} ${containerConnectionInfo.name}`,
+      `/preferences/resources`,
+      getLoggerHandler(),
+    );
+    await window.startProviderConnectionLifecycle(providerInfo.internalId, containerConnectionInfo, loggerHandlerKey, eventCollect);
   } catch (err) {
     lifecycleError = err;
   }
@@ -93,12 +113,22 @@ async function startConnection() {
 
 async function stopConnection() {
   lifecycleError = undefined;
-  await window.stopProviderConnectionLifecycle(providerInfo.internalId, containerConnectionInfo);
+  const loggerHandlerKey = startTask(
+    `Stop ${providerInfo.name} ${containerConnectionInfo.name}`,
+    `/preferences/resources`,
+    getLoggerHandler(),
+  );
+  await window.stopProviderConnectionLifecycle(providerInfo.internalId, containerConnectionInfo, loggerHandlerKey, eventCollect);
 }
 
 async function deleteConnection() {
   lifecycleError = undefined;
-  await window.deleteProviderConnectionLifecycle(providerInfo.internalId, containerConnectionInfo);
+  const loggerHandlerKey = startTask(
+    `Delete ${providerInfo.name} ${containerConnectionInfo.name}`,
+    `/preferences/resources`,
+    getLoggerHandler(),
+  );
+  await window.deleteProviderConnectionLifecycle(providerInfo.internalId, containerConnectionInfo, loggerHandlerKey, eventCollect);
   router.goto('/preferences/providers');
 }
 

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
@@ -154,7 +154,9 @@ async function startContainerProvider(
         eventCollect,
       );
     }
-  } catch (e) {}
+  } catch (e) {
+    console.error(e);
+  }
 }
 
 async function stopContainerProvider(
@@ -179,7 +181,9 @@ async function stopContainerProvider(
         eventCollect,
       );
     }
-  } catch (e) {}
+  } catch (e) {
+    console.error(e);
+  }
 }
 
 async function restartContainerProvider(
@@ -214,7 +218,9 @@ async function deleteContainerProvider(
         eventCollect,
       );
     }
-  } catch (e) {}
+  } catch (e) {
+    console.error(e);
+  }
 }
 
 function setContainerStatusIsChanging(

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
@@ -132,48 +132,29 @@ function getLoggerHandler(
   };
 }
 
-// store the key
-function updateStore(
-  providerInfo: ProviderInfo,
-  propertyScope: string,
-  inProgress: boolean,
-  successful: boolean,
-  started: boolean,
-  error: string,
-) {
-  createConnectionsInfo.set({
-    createKey: loggerHandlerKey,
-    providerInfo,
-    properties,
-    propertyScope,
-    creationInProgress: inProgress,
-    creationSuccessful: successful,
-    creationStarted: started,
-    errorMessage: error,
-  });
-}
-
 async function startContainerProvider(
   provider: ProviderInfo,
   containerConnectionInfo: ProviderContainerConnectionInfo,
   loggerHandlerKey?: symbol,
 ): Promise<void> {
-  if (containerConnectionInfo.status === 'stopped') {
-    setContainerStatusIsChanging(provider, containerConnectionInfo);
-    if (!loggerHandlerKey) {
-      loggerHandlerKey = startTask(
-        `Start ${provider.name} ${containerConnectionInfo.name}`,
-        `/preferences/resources`,
-        getLoggerHandler(provider, containerConnectionInfo),
+  try {
+    if (containerConnectionInfo.status === 'stopped') {
+      setContainerStatusIsChanging(provider, containerConnectionInfo);
+      if (!loggerHandlerKey) {
+        loggerHandlerKey = startTask(
+          `Start ${provider.name} ${containerConnectionInfo.name}`,
+          `/preferences/resources`,
+          getLoggerHandler(provider, containerConnectionInfo),
+        );
+      }
+      await window.startProviderConnectionLifecycle(
+        provider.internalId,
+        containerConnectionInfo,
+        loggerHandlerKey,
+        eventCollect,
       );
     }
-    await window.startProviderConnectionLifecycle(
-      provider.internalId,
-      containerConnectionInfo,
-      loggerHandlerKey,
-      eventCollect,
-    );
-  }
+  } catch (e) {}
 }
 
 async function stopContainerProvider(
@@ -181,22 +162,24 @@ async function stopContainerProvider(
   containerConnectionInfo: ProviderContainerConnectionInfo,
   loggerHandlerKey?: symbol,
 ): Promise<void> {
-  if (containerConnectionInfo.status === 'started') {
-    setContainerStatusIsChanging(provider, containerConnectionInfo);
-    if (!loggerHandlerKey) {
-      loggerHandlerKey = startTask(
-        `Stop ${provider.name} ${containerConnectionInfo.name}`,
-        `/preferences/resources`,
-        getLoggerHandler(provider, containerConnectionInfo),
+  try {
+    if (containerConnectionInfo.status === 'started') {
+      setContainerStatusIsChanging(provider, containerConnectionInfo);
+      if (!loggerHandlerKey) {
+        loggerHandlerKey = startTask(
+          `Stop ${provider.name} ${containerConnectionInfo.name}`,
+          `/preferences/resources`,
+          getLoggerHandler(provider, containerConnectionInfo),
+        );
+      }
+      await window.stopProviderConnectionLifecycle(
+        provider.internalId,
+        containerConnectionInfo,
+        loggerHandlerKey,
+        eventCollect,
       );
     }
-    await window.stopProviderConnectionLifecycle(
-      provider.internalId,
-      containerConnectionInfo,
-      loggerHandlerKey,
-      eventCollect,
-    );
-  }
+  } catch (e) {}
 }
 
 async function restartContainerProvider(
@@ -216,20 +199,22 @@ async function deleteContainerProvider(
   provider: ProviderInfo,
   containerConnectionInfo: ProviderContainerConnectionInfo,
 ): Promise<void> {
-  if (containerConnectionInfo.status === 'stopped' || containerConnectionInfo.status === 'unknown') {
-    setContainerStatusIsChanging(provider, containerConnectionInfo);
-    const loggerHandlerKey = startTask(
-      `Delete ${provider.name} ${containerConnectionInfo.name}`,
-      `/preferences/resources`,
-      getLoggerHandler(provider, containerConnectionInfo),
-    );
-    await window.deleteProviderConnectionLifecycle(
-      provider.internalId,
-      containerConnectionInfo,
-      loggerHandlerKey,
-      eventCollect,
-    );
-  }
+  try {
+    if (containerConnectionInfo.status === 'stopped' || containerConnectionInfo.status === 'unknown') {
+      setContainerStatusIsChanging(provider, containerConnectionInfo);
+      const loggerHandlerKey = startTask(
+        `Delete ${provider.name} ${containerConnectionInfo.name}`,
+        `/preferences/resources`,
+        getLoggerHandler(provider, containerConnectionInfo),
+      );
+      await window.deleteProviderConnectionLifecycle(
+        provider.internalId,
+        containerConnectionInfo,
+        loggerHandlerKey,
+        eventCollect,
+      );
+    }
+  } catch (e) {}
 }
 
 function setContainerStatusIsChanging(

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
@@ -118,7 +118,10 @@ $: providerContainerConfiguration = tmpProviderContainerConfiguration
     return map;
   }, new Map<string, IProviderContainerConfigurationPropertyRecorded[]>());
 
-function getLoggerHandler(provider: ProviderInfo, containerConnectionInfo: ProviderContainerConnectionInfo): ConnectionCallback {
+function getLoggerHandler(
+  provider: ProviderInfo,
+  containerConnectionInfo: ProviderContainerConnectionInfo,
+): ConnectionCallback {
   return {
     log: () => {},
     warn: () => {},
@@ -130,7 +133,14 @@ function getLoggerHandler(provider: ProviderInfo, containerConnectionInfo: Provi
 }
 
 // store the key
-function updateStore(providerInfo: ProviderInfo, propertyScope: string, inProgress: boolean, successful: boolean, started: boolean, error: string) {
+function updateStore(
+  providerInfo: ProviderInfo,
+  propertyScope: string,
+  inProgress: boolean,
+  successful: boolean,
+  started: boolean,
+  error: string,
+) {
   createConnectionsInfo.set({
     createKey: loggerHandlerKey,
     providerInfo,
@@ -146,7 +156,7 @@ function updateStore(providerInfo: ProviderInfo, propertyScope: string, inProgre
 async function startContainerProvider(
   provider: ProviderInfo,
   containerConnectionInfo: ProviderContainerConnectionInfo,
-  loggerHandlerKey?: symbol
+  loggerHandlerKey?: symbol,
 ): Promise<void> {
   if (containerConnectionInfo.status === 'stopped') {
     setContainerStatusIsChanging(provider, containerConnectionInfo);
@@ -156,15 +166,20 @@ async function startContainerProvider(
         `/preferences/resources`,
         getLoggerHandler(provider, containerConnectionInfo),
       );
-    }    
-    await window.startProviderConnectionLifecycle(provider.internalId, containerConnectionInfo, loggerHandlerKey, eventCollect);
-  }  
+    }
+    await window.startProviderConnectionLifecycle(
+      provider.internalId,
+      containerConnectionInfo,
+      loggerHandlerKey,
+      eventCollect,
+    );
+  }
 }
 
 async function stopContainerProvider(
   provider: ProviderInfo,
   containerConnectionInfo: ProviderContainerConnectionInfo,
-  loggerHandlerKey?: symbol
+  loggerHandlerKey?: symbol,
 ): Promise<void> {
   if (containerConnectionInfo.status === 'started') {
     setContainerStatusIsChanging(provider, containerConnectionInfo);
@@ -174,8 +189,13 @@ async function stopContainerProvider(
         `/preferences/resources`,
         getLoggerHandler(provider, containerConnectionInfo),
       );
-    }    
-    await window.stopProviderConnectionLifecycle(provider.internalId, containerConnectionInfo, loggerHandlerKey, eventCollect);
+    }
+    await window.stopProviderConnectionLifecycle(
+      provider.internalId,
+      containerConnectionInfo,
+      loggerHandlerKey,
+      eventCollect,
+    );
   }
 }
 
@@ -203,7 +223,12 @@ async function deleteContainerProvider(
       `/preferences/resources`,
       getLoggerHandler(provider, containerConnectionInfo),
     );
-    await window.deleteProviderConnectionLifecycle(provider.internalId, containerConnectionInfo, loggerHandlerKey, eventCollect);
+    await window.deleteProviderConnectionLifecycle(
+      provider.internalId,
+      containerConnectionInfo,
+      loggerHandlerKey,
+      eventCollect,
+    );
   }
 }
 
@@ -222,7 +247,7 @@ function setContainerStatusUpdateFailed(
   provider: ProviderInfo,
   containerConnectionInfo: ProviderContainerConnectionInfo,
   failedAction: string,
-  error: string
+  error: string,
 ): void {
   const containerConnectionName = getContainerConnectionName(provider, containerConnectionInfo);
   const currentStatus = containerConnectionStatus.get(containerConnectionName);
@@ -306,7 +331,10 @@ function isContainerConnectionStatusInProgress(
                 {#if containerConnectionStatus.has(getContainerConnectionName(provider, container))}
                   {@const status = containerConnectionStatus.get(getContainerConnectionName(provider, container))}
                   {#if status.error}
-                    <button class="ml-3 text-[9px] text-red-500 underline" on:click="{() => window.events?.send('toggle-task-manager', '')}">{status.failedAction} failed</button>
+                    <button
+                      class="ml-3 text-[9px] text-red-500 underline"
+                      on:click="{() => window.events?.send('toggle-task-manager', '')}"
+                      >{status.failedAction} failed</button>
                   {/if}
                 {/if}
               </div>

--- a/packages/renderer/src/lib/preferences/preferences-connection-rendering-task.spec.ts
+++ b/packages/renderer/src/lib/preferences/preferences-connection-rendering-task.spec.ts
@@ -18,19 +18,19 @@
 
 import { get } from 'svelte/store';
 import { beforeEach, expect, test, vi } from 'vitest';
-import type { CreateConnectionCallback } from './preferences-connection-rendering-task';
+import { ConnectionCallback, startTask } from './preferences-connection-rendering-task';
 import { disconnectUI, eventCollect, reconnectUI } from './preferences-connection-rendering-task';
-import { startCreate, clearCreateTask } from './preferences-connection-rendering-task';
+import { clearCreateTask } from './preferences-connection-rendering-task';
 import { tasksInfo } from '/@/stores/tasks';
 
-const dummyCallback: CreateConnectionCallback = {
+const dummyCallback: ConnectionCallback = {
   log: vi.fn(),
   error: vi.fn(),
   warn: vi.fn(),
   onEnd: vi.fn(),
 };
 
-const newCallback: CreateConnectionCallback = {
+const newCallback: ConnectionCallback = {
   log: vi.fn(),
   error: vi.fn(),
   warn: vi.fn(),
@@ -43,7 +43,7 @@ beforeEach(() => {
 
 test('check start build', async () => {
   const id = '1';
-  const key = startCreate('foo', id, dummyCallback);
+  const key = startTask('foo', id, dummyCallback);
   expect(key).toBeDefined();
   const allTasks = get(tasksInfo);
   const matchingTask = allTasks.find(task => task.id === id);
@@ -55,7 +55,7 @@ test('check start build', async () => {
 });
 
 test('check reconnect', async () => {
-  const firstKey = startCreate('bar', '2', dummyCallback);
+  const firstKey = startTask('bar', '2', dummyCallback);
 
   // stream some stuff
   eventCollect(firstKey, 'log', ['hello']);
@@ -75,7 +75,7 @@ test('check reconnect', async () => {
 });
 
 test('check events', async () => {
-  const firstKey = startCreate('baz', '3', dummyCallback);
+  const firstKey = startTask('baz', 'url', dummyCallback);
 
   // stream some stuff
   eventCollect(firstKey, 'log', ['hello']);

--- a/packages/renderer/src/lib/preferences/preferences-connection-rendering-task.spec.ts
+++ b/packages/renderer/src/lib/preferences/preferences-connection-rendering-task.spec.ts
@@ -18,7 +18,8 @@
 
 import { get } from 'svelte/store';
 import { beforeEach, expect, test, vi } from 'vitest';
-import { ConnectionCallback, startTask } from './preferences-connection-rendering-task';
+import type { ConnectionCallback } from './preferences-connection-rendering-task';
+import { startTask } from './preferences-connection-rendering-task';
 import { disconnectUI, eventCollect, reconnectUI } from './preferences-connection-rendering-task';
 import { clearCreateTask } from './preferences-connection-rendering-task';
 import { tasksInfo } from '/@/stores/tasks';

--- a/packages/renderer/src/lib/preferences/preferences-connection-rendering-task.ts
+++ b/packages/renderer/src/lib/preferences/preferences-connection-rendering-task.ts
@@ -20,7 +20,7 @@ import { createConnectionsInfo } from '/@/stores/create-connections';
 import { router } from 'tinro';
 
 import type { Logger as LoggerType } from '@podman-desktop/api';
-import { Task } from '/@/stores/tasks';
+import type { Task } from '/@/stores/tasks';
 import { createTask, removeTask } from '/@/stores/tasks';
 
 export interface ConnectionCallback extends LoggerType {
@@ -62,11 +62,7 @@ const taskLogOnHolds = new Map<symbol, TaskHold>();
 const taskLogReplays = new Map<symbol, TaskReplay>();
 const allTasks = new Map<symbol, Task>();
 
-export function startTask(
-  name: string,
-  goToUrl: string,
-  createCallback: ConnectionCallback
-): symbol {
+export function startTask(name: string, goToUrl: string, createCallback: ConnectionCallback): symbol {
   const key = getKey();
   taskLogCallbacks.set(key, createCallback);
 
@@ -172,7 +168,7 @@ export function eventCollect(key: symbol, eventName: 'log' | 'warn' | 'error' | 
   if (task) {
     if (eventName === 'error') {
       task.status = 'failure';
-      task.error = args.join("\n");
+      task.error = args.join('\n');
     } else if (eventName === 'finish') {
       if (task.status !== 'failure') {
         task.status = 'success';

--- a/packages/renderer/src/lib/task-manager/TaskManagerItem.svelte
+++ b/packages/renderer/src/lib/task-manager/TaskManagerItem.svelte
@@ -13,6 +13,7 @@ const dispatch = createEventDispatcher();
 let taskUI: TaskUI;
 $: taskUI = taskManager.toTaskUi(task);
 
+let showError = false;
 let icon;
 let iconColor;
 onMount(() => {
@@ -62,6 +63,9 @@ function gotoTask(taskUI: TaskUI) {
         {/if}
       </div>
     </div>
+    {#if taskUI.error}
+      <div class:hidden="{!showError}" class="text-xs my-2 break-words">{taskUI.error}</div>
+    {/if}
     <!-- age -->
     <div class="text-gray-400 text-xs">{taskUI.age}</div>
 
@@ -86,8 +90,15 @@ function gotoTask(taskUI: TaskUI) {
 
     <!-- if failed task, display the error-->
     {#if taskUI.status === 'failure'}
-      <div class="flex flex-col w-full items-end text-purple-300 text-xs">
-        <div>View Error ></div>
+      <div class="flex flex-col w-full items-end">
+        <button on:click="{() => showError = !showError}" class="text-purple-300 text-xs">
+          View Error 
+          {#if showError} 
+            <i class="fas fa-chevron-up" />
+          {:else}
+            <i class="fas fa-chevron-down" />
+          {/if}
+        </button>
       </div>
     {/if}
   </div>

--- a/packages/renderer/src/lib/task-manager/TaskManagerItem.svelte
+++ b/packages/renderer/src/lib/task-manager/TaskManagerItem.svelte
@@ -91,12 +91,12 @@ function gotoTask(taskUI: TaskUI) {
     <!-- if failed task, display the error-->
     {#if taskUI.status === 'failure'}
       <div class="flex flex-col w-full items-end">
-        <button on:click="{() => showError = !showError}" class="text-purple-300 text-xs">
-          View Error 
-          {#if showError} 
-            <i class="fas fa-chevron-up" />
+        <button on:click="{() => (showError = !showError)}" class="text-purple-300 text-xs">
+          View Error
+          {#if showError}
+            <i class="fas fa-chevron-up"></i>
           {:else}
-            <i class="fas fa-chevron-down" />
+            <i class="fas fa-chevron-down"></i>
           {/if}
         </button>
       </div>

--- a/packages/renderer/src/lib/task-manager/task-manager.ts
+++ b/packages/renderer/src/lib/task-manager/task-manager.ts
@@ -37,6 +37,7 @@ export class TaskManager {
       status: task.status,
       hasGotoTask: false,
       age: `${humanizeDuration(new Date().getTime() - task.started, { round: true, largest: 1 })} ago`,
+      error: task.error,
     };
 
     if (task.status === 'in-progress') {

--- a/packages/renderer/src/stores/tasks.ts
+++ b/packages/renderer/src/stores/tasks.ts
@@ -19,14 +19,18 @@
 import type { Writable } from 'svelte/store';
 import { writable } from 'svelte/store';
 
+type TaskState = 'running' | 'completed';
+type TaskStatus = 'in-progress' | 'success' | 'failure';
+
 export interface Task {
   id: string;
   name: string;
   started: number;
-  state: 'running' | 'completed';
-  status: 'in-progress' | 'success' | 'failure';
+  state: TaskState;
+  status: TaskStatus;
   progress?: number;
   gotoTask?: () => void;
+  error?: string;
 }
 
 /**


### PR DESCRIPTION
### What does this PR do?

This PR shows a short message next to the status in the resources page and add the full error text in the task view.

To keep it simple i didn't create any new component to show the full error, we can discuss what and where to create it here.
 
### Screenshot/screencast of this PR

![error-message-start](https://user-images.githubusercontent.com/49404737/228444181-f5bc4a3b-650a-461a-96c7-5420399cbc12.gif)

### What issues does this PR fix or reference?

this is part of #1337 
this fixes https://github.com/containers/podman-desktop/issues/1809

### How to test this PR?

1.  Just start a podman machine that cannot be started. I just brutally added the same error text as in the issue to see how a long message would look like in the task view.
