### PR TITLE
fix: Kind move image does not really move the image on the cluster

### DIFF
--- a/extensions/kind/src/image-handler.spec.ts
+++ b/extensions/kind/src/image-handler.spec.ts
@@ -1,0 +1,90 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { beforeEach, expect, test, vi } from 'vitest';
+import type { Mock } from 'vitest';
+import { ImageHandler } from './image-handler';
+import * as extensionApi from '@podman-desktop/api';
+import * as fs from 'node:fs';
+
+let imageHandler: ImageHandler;
+vi.mock('@podman-desktop/api', async () => {
+  return {
+    containerEngine: {
+      saveImage: vi.fn(),
+    },
+    window: {
+      showNotification: vi.fn(),
+    },
+  };
+});
+
+vi.mock('./util', async () => {
+  return {
+    runCliCommand: vi.fn().mockReturnValue({ exitCode: 0 }),
+  };
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  imageHandler = new ImageHandler();
+});
+
+test('expect error to be raised if no image is given', async () => {
+  try {
+    await imageHandler.moveImage({ engineId: 'dummy' }, [], undefined);
+  } catch (err) {
+    expect(err).to.be.a('Error');
+    expect(err.message).equal('Image selection not supported yet');
+  }
+});
+
+test('expect error to be raised if no clusters are given', async () => {
+  try {
+    await imageHandler.moveImage({ engineId: 'dummy', name: 'myimage' }, [], undefined);
+  } catch (err) {
+    expect(err).to.be.a('Error');
+    expect(err.message).equal('No Kind clusters to push to');
+  }
+});
+
+test('expect image name to be given', async () => {
+  (extensionApi.containerEngine.saveImage as Mock).mockImplementation(
+    (engineId: string, id: string, filename: string) => fs.promises.open(filename, 'w'),
+  );
+
+  await imageHandler.moveImage(
+    { engineId: 'dummy', name: 'myimage' },
+    [{ name: 'c1', engineType: 'podman', status: 'started', apiPort: 9443 }],
+    undefined,
+  );
+  expect(extensionApi.containerEngine.saveImage).toBeCalledWith('dummy', 'myimage', expect.anything());
+});
+
+test('expect image name and tag to be given', async () => {
+  (extensionApi.containerEngine.saveImage as Mock).mockImplementation(
+    (engineId: string, id: string, filename: string) => fs.promises.open(filename, 'w'),
+  );
+
+  await imageHandler.moveImage(
+    { engineId: 'dummy', name: 'myimage', tag: '1.0' },
+    [{ name: 'c1', engineType: 'podman', status: 'started', apiPort: 9443 }],
+    undefined,
+  );
+  expect(extensionApi.containerEngine.saveImage).toBeCalledWith('dummy', 'myimage:1.0', expect.anything());
+});

--- a/extensions/kind/src/image-handler.ts
+++ b/extensions/kind/src/image-handler.ts
@@ -1,0 +1,79 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import type { KindCluster } from './extension';
+import * as extensionApi from '@podman-desktop/api';
+import { tmpName } from 'tmp-promise';
+import { runCliCommand } from './util';
+import * as fs from 'node:fs';
+
+type ImageInfo = { engineId: string; name?: string; tag?: string };
+
+export class ImageHandler {
+  async moveImage(image: ImageInfo, kindClusters: KindCluster[], kindCli: string) {
+    if (!image.name) {
+      throw new Error('Image selection not supported yet');
+    }
+    const clusters = kindClusters.filter(cluster => cluster.status === 'started');
+    let selectedCluster: { label: string; engineType: string };
+
+    if (clusters.length == 0) {
+      throw new Error('No Kind clusters to push to');
+    } else if (clusters.length == 1) {
+      selectedCluster = { label: clusters[0].name, engineType: clusters[0].engineType };
+    } else {
+      selectedCluster = await extensionApi.window.showQuickPick(
+        clusters.map(cluster => {
+          return { label: cluster.name, engineType: cluster.engineType };
+        }),
+        { placeHolder: 'Select a Kind cluster to push to' },
+      );
+    }
+    if (selectedCluster) {
+      const filename = await tmpName();
+      try {
+        let name = image.name;
+        if (image.tag) {
+          name = name + ':' + image.tag;
+        }
+        await extensionApi.containerEngine.saveImage(image.engineId, name, filename);
+        const env = process.env;
+        if (selectedCluster.engineType === 'podman') {
+          env['KIND_EXPERIMENTAL_PROVIDER'] = 'podman';
+        } else {
+          env['KIND_EXPERIMENTAL_PROVIDER'] = 'docker';
+        }
+        const result = await runCliCommand(kindCli, ['load', 'image-archive', '-n', selectedCluster.label, filename], {
+          env: env,
+        });
+        if (result.exitCode === 0) {
+          extensionApi.window.showNotification({
+            body: `Image ${image.name} pushed to Kind cluster ${selectedCluster.label}`,
+          });
+        } else {
+          throw new Error(
+            `Error while pushing image ${image.name} to Kind cluster ${selectedCluster.label}: ${result.error}`,
+          );
+        }
+      } catch (err) {
+        throw new Error(`Error while pushing image ${image.name} to Kind cluster ${selectedCluster.label}: ${err}`);
+      } finally {
+        fs.promises.rm(filename);
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes #1746

### What does this PR do?

Fixes Kind move image to clusters that lost real image name thus defeat cachinng

### Screenshot/screencast of this PR

![move-image](https://user-images.githubusercontent.com/695993/228518734-a1b58dc1-c923-4c41-9d85-641c971e33f3.gif)


<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?

Fixes #1746

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

### How to test this PR?

1. Create a kind cluster
2. Create an image on podman
3. Move that image to the Kind cluster
4. On the kind container (called kind-cluster_name), open a terminal and issues the command: crictl images. You should see an images called xxx/import-date). The correct name should be the same as the original one.

