### PR TITLE
chore: lift up vale rules

### DIFF
--- a/.github/workflows/pr-check-vale.yaml
+++ b/.github/workflows/pr-check-vale.yaml
@@ -36,4 +36,5 @@ jobs:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         with:
           files: website
-          fail_on_error: true
+          fail_on_error: false
+

--- a/.vale.ini
+++ b/.vale.ini
@@ -16,12 +16,22 @@
 ;
 ; SPDX-License-Identifier: Apache-2.0
 ;
-MinAlertLevel = suggestion
+MinAlertLevel = warning
 Packages = RedHat
 StylesPath = .vale/styles
 
 [*.md]
 BasedOnStyles = RedHat,PodmanDesktop
+RedHat.PascalCamelCase = suggestion
+RedHat.Slash = suggestion
+RedHat.Spelling = suggestion
+RedHat.Usage = suggestion
 
-RedHat.PascalCamelCase = OFF
-RedHat.Slash = OFF
+[website/blog/*.md]
+BasedOnStyles = RedHat,PodmanDesktop
+RedHat.Headings = suggestion
+RedHat.PascalCamelCase = suggestion
+RedHat.PassiveVoice = suggestion
+RedHat.Slash = suggestion
+RedHat.Spelling = suggestion
+RedHat.Usage = suggestion

--- a/.vale.ini
+++ b/.vale.ini
@@ -28,10 +28,5 @@ RedHat.Spelling = suggestion
 RedHat.Usage = suggestion
 
 [website/blog/*.md]
-BasedOnStyles = RedHat,PodmanDesktop
 RedHat.Headings = suggestion
-RedHat.PascalCamelCase = suggestion
 RedHat.PassiveVoice = suggestion
-RedHat.Slash = suggestion
-RedHat.Spelling = suggestion
-RedHat.Usage = suggestion


### PR DESCRIPTION
* Display only alerts with severity `warning` by default
* Decrease some rules severity
* Display alerts on pull requests but don't fail the build
