### PR TITLE
fix: allow to have the initialize working for k8s providers

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -226,15 +226,16 @@ declare module '@podman-desktop/api' {
 
   // create programmatically a ContainerProviderConnection
   export interface ContainerProviderConnectionFactory {
-    initialize(): Promise<void>;
+    initialize?(): Promise<void>;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     create(params: { [key: string]: any }, logger?: Logger, token?: CancellationToken): Promise<void>;
   }
 
   // create a kubernetes provider
   export interface KubernetesProviderConnectionFactory {
+    initialize?(): Promise<void>;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    create(params: { [key: string]: any }, logger?: Logger): Promise<void>;
+    create?(params: { [key: string]: any }, logger?: Logger): Promise<void>;
   }
 
   export interface Link {

--- a/packages/main/src/plugin/api/provider-info.ts
+++ b/packages/main/src/plugin/api/provider-info.ts
@@ -57,9 +57,13 @@ export interface ProviderInfo {
   lifecycleMethods?: LifecycleMethod[];
   // can create provider connection from ContainerProviderConnectionFactory params
   containerProviderConnectionCreation: boolean;
+  // can initialize provider connection from ContainerProviderConnectionFactory params
+  containerProviderConnectionInitialization: boolean;
 
   // can create provider connection from KubernetesProviderConnectionFactory params
   kubernetesProviderConnectionCreation: boolean;
+  // can initialize provider connection from KubernetesProviderConnectionFactory params
+  kubernetesProviderConnectionInitialization: boolean;
 
   version?: string;
 

--- a/packages/main/src/plugin/provider-registry.spec.ts
+++ b/packages/main/src/plugin/provider-registry.spec.ts
@@ -1,0 +1,103 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-empty-function */
+
+import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
+import type { ContainerProviderRegistry } from './container-registry';
+
+import { ProviderRegistry } from './provider-registry';
+import type { Telemetry } from './telemetry/telemetry';
+
+let providerRegistry: ProviderRegistry;
+
+const telemetryTrackMock = vi.fn();
+const apiSenderSendMock = vi.fn();
+beforeAll(() => {
+  const telemetry: Telemetry = {
+    track: telemetryTrackMock,
+  } as unknown as Telemetry;
+  const apiSender = {
+    send: apiSenderSendMock,
+  };
+  const containerRegistry: ContainerProviderRegistry = {} as ContainerProviderRegistry;
+  providerRegistry = new ProviderRegistry(apiSender, containerRegistry, telemetry);
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+test('should initialize provider if there is kubernetes connection provider', async () => {
+  let providerInternalId;
+
+  apiSenderSendMock.mockImplementation((message, data) => {
+    expect(message).toBe('provider-create');
+    providerInternalId = data;
+  });
+
+  const provider = providerRegistry.createProvider({ id: 'internal', name: 'internal', status: 'installed' });
+
+  let initalizeCalled = false;
+  provider.setKubernetesProviderConnectionFactory({
+    initialize: async () => {
+      initalizeCalled = true;
+    },
+  });
+
+  expect(providerInternalId).toBeDefined();
+  await providerRegistry.initializeProvider(providerInternalId);
+
+  expect(telemetryTrackMock).toHaveBeenNthCalledWith(1, 'createProvider', {
+    name: 'internal',
+    status: 'installed',
+  });
+
+  expect(initalizeCalled).toBe(true);
+  expect(apiSenderSendMock).toBeCalled();
+});
+
+test('should initialize provider if there is container connection provider', async () => {
+  let providerInternalId;
+
+  apiSenderSendMock.mockImplementation((message, data) => {
+    expect(message).toBe('provider-create');
+    providerInternalId = data;
+  });
+
+  const provider = providerRegistry.createProvider({ id: 'internal', name: 'internal', status: 'installed' });
+
+  let initalizeCalled = false;
+  provider.setContainerProviderConnectionFactory({
+    initialize: async () => {
+      initalizeCalled = true;
+    },
+    create: async () => {},
+  });
+
+  expect(providerInternalId).toBeDefined();
+  await providerRegistry.initializeProvider(providerInternalId);
+
+  expect(telemetryTrackMock).toHaveBeenNthCalledWith(1, 'createProvider', {
+    name: 'internal',
+    status: 'installed',
+  });
+
+  expect(initalizeCalled).toBe(true);
+  expect(apiSenderSendMock).toBeCalled();
+});

--- a/packages/main/src/tray-menu.ts
+++ b/packages/main/src/tray-menu.ts
@@ -82,6 +82,8 @@ export class TrayMenu {
             installationSupport: false,
             containerProviderConnectionCreation: false,
             kubernetesProviderConnectionCreation: false,
+            containerProviderConnectionInitialization: false,
+            kubernetesProviderConnectionInitialization: false,
           });
         }
         this.updateMenu();

--- a/packages/renderer/src/lib/dashboard/ProviderInstalled.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderInstalled.svelte
@@ -108,6 +108,11 @@ onMount(async () => {
 
   // Observe the terminal div
   resizeObserver.observe(logsXtermDiv);
+
+  // no initialize support, hide the button
+  if (!provider.containerProviderConnectionInitialization && !provider.kubernetesProviderConnectionInitialization) {
+    initializationButtonVisible = false;
+  }
 });
 
 onDestroy(() => {

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.spec.ts
@@ -49,6 +49,8 @@ const providerInfo: ProviderInfo = {
   kubernetesConnections: [],
   kubernetesProviderConnectionCreation: true,
   links: undefined,
+  containerProviderConnectionInitialization: false,
+  kubernetesProviderConnectionInitialization: false,
 };
 
 beforeEach(() => {


### PR DESCRIPTION
### What does this PR do?
Make it possible to call initialize on kube providers

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/1701


### How to test this PR?

Follow the steps of the issue

Change-Id: If9caff49a5a06cf19ac808796362566a3dcb00a7

