### PR TITLE
chore: introduce type for apiSender instead of any

### DIFF
--- a/packages/main/src/plugin/api.ts
+++ b/packages/main/src/plugin/api.ts
@@ -22,3 +22,10 @@ export interface RemoteAPI {
   // eslint-disable-next-line @typescript-eslint/ban-types
   listContainers(options?: {}): Promise<ContainerInfo[]>;
 }
+
+export type ApiSenderType = {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  send: (channel: string, data?: any) => void;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  receive: (channel: string, func: any) => void;
+};

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -49,6 +49,7 @@ import type { Event } from './events/emitter';
 import { Emitter } from './events/emitter';
 import fs from 'node:fs';
 import { pipeline } from 'node:stream/promises';
+import type { ApiSenderType } from './api';
 export interface InternalContainerProvider {
   name: string;
   id: string;
@@ -74,8 +75,11 @@ export class ContainerProviderRegistry {
   private readonly _onEvent = new Emitter<JSONEvent>();
   readonly onEvent: Event<JSONEvent> = this._onEvent.event;
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  constructor(private apiSender: any, private imageRegistry: ImageRegistry, private telemetryService: Telemetry) {
+  constructor(
+    private apiSender: ApiSenderType,
+    private imageRegistry: ImageRegistry,
+    private telemetryService: Telemetry,
+  ) {
     const libPodDockerode = new LibpodDockerode();
     libPodDockerode.enhancePrototypeWithLibPod();
   }

--- a/packages/main/src/plugin/contribution-manager.ts
+++ b/packages/main/src/plugin/contribution-manager.ts
@@ -21,6 +21,7 @@ import * as os from 'node:os';
 import * as fs from 'node:fs';
 import type { ContributionInfo } from './api/contribution-info';
 import { desktopAppHomeDir } from '../util';
+import type { ApiSenderType } from './api';
 
 /**
  * Contribution manager to provide the list of external OCI contributions
@@ -32,8 +33,7 @@ export class ContributionManager {
   private readonly EMPTY_ICON =
     'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxIiBoZWlnaHQ9IjEiLz4=';
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  constructor(private apiSender: any) {}
+  constructor(private apiSender: ApiSenderType) {}
 
   // load the existing contributions
   async init(): Promise<void> {

--- a/packages/main/src/plugin/docker-extension/docker-desktop-installation.ts
+++ b/packages/main/src/plugin/docker-extension/docker-desktop-installation.ts
@@ -27,10 +27,11 @@ import * as tarFs from 'tar-fs';
 import type Dockerode from 'dockerode';
 import type { PullEvent } from '../api/pull-event';
 import type { ContributionManager } from '../contribution-manager';
+import type { ApiSenderType } from '../api';
+
 export class DockerDesktopInstallation {
   constructor(
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    private apiSender: any,
+    private apiSender: ApiSenderType,
     private containerRegistry: ContainerProviderRegistry,
     private contributionManager: ContributionManager,
   ) {}

--- a/packages/main/src/plugin/extension-loader.spec.ts
+++ b/packages/main/src/plugin/extension-loader.spec.ts
@@ -37,6 +37,7 @@ import type { StatusBarRegistry } from './statusbar/statusbar-registry';
 import type { TrayMenuRegistry } from './tray-menu-registry';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import type { ApiSenderType } from './api';
 
 class TestExtensionLoader extends ExtensionLoader {
   public async setupScanningDirectory(): Promise<void> {
@@ -64,7 +65,7 @@ const configurationRegistry: ConfigurationRegistry = {} as unknown as Configurat
 
 const imageRegistry: ImageRegistry = {} as unknown as ImageRegistry;
 
-const apiSender: any = {};
+const apiSender: ApiSenderType = {} as unknown as ApiSenderType;
 
 const trayMenuRegistry: TrayMenuRegistry = {} as unknown as TrayMenuRegistry;
 

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -46,6 +46,7 @@ import type { MenuRegistry } from '/@/plugin/menu-registry';
 import { desktopAppHomeDir } from '../util';
 import { Emitter } from './events/emitter';
 import { CancellationTokenSource } from './cancellation-token';
+import type { ApiSenderType } from './api';
 
 /**
  * Handle the loading of an extension
@@ -95,8 +96,7 @@ export class ExtensionLoader {
     private providerRegistry: ProviderRegistry,
     private configurationRegistry: ConfigurationRegistry,
     private imageRegistry: ImageRegistry,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    private apiSender: any,
+    private apiSender: ApiSenderType,
     private trayMenuRegistry: TrayMenuRegistry,
     private dialogs: Dialogs,
     private progress: ProgressImpl,

--- a/packages/main/src/plugin/image-registry.ts
+++ b/packages/main/src/plugin/image-registry.ts
@@ -29,6 +29,7 @@ import validator from 'validator';
 import { HttpProxyAgent, HttpsProxyAgent } from 'hpagent';
 import type { Certificates } from './certificates';
 import type { Proxy } from './proxy';
+import type { ApiSenderType } from './api';
 
 export interface RegistryAuthInfo {
   authUrl: string;
@@ -57,8 +58,7 @@ export class ImageRegistry {
   private proxyEnabled: boolean;
 
   constructor(
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    private apiSender: any,
+    private apiSender: ApiSenderType,
     private telemetryService: Telemetry,
     private certificates: Certificates,
     private proxy: Proxy,

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -93,6 +93,7 @@ import { CancellationTokenRegistry } from './cancellation-token-registry';
 import type { UpdateCheckResult } from 'electron-updater';
 import { autoUpdater } from 'electron-updater';
 import { clipboard } from 'electron';
+import type { ApiSenderType } from './api';
 
 type LogType = 'log' | 'warn' | 'trace' | 'debug' | 'error';
 
@@ -245,7 +246,7 @@ export class PluginSystem {
     this.redirectLogging();
 
     const eventEmitter = new EventEmitter();
-    const apiSender = {
+    const apiSender: ApiSenderType = {
       send: (channel: string, data: string) => {
         // send only if the UI is ready
         if (this.uiReady && this.isReady) {

--- a/packages/main/src/plugin/input-quickpick/input-quickpick-registry.ts
+++ b/packages/main/src/plugin/input-quickpick/input-quickpick-registry.ts
@@ -22,6 +22,7 @@ import type {
   InputBoxValidationMessage,
   QuickPickOptions,
 } from '@podman-desktop/api';
+import type { ApiSenderType } from '../api';
 import { Deferred } from '../util/deferred';
 
 export class InputQuickPickRegistry {
@@ -43,8 +44,7 @@ export class InputQuickPickRegistry {
     }
   >();
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  constructor(private apiSender: any) {}
+  constructor(private apiSender: ApiSenderType) {}
 
   async showInputBox(options?: InputBoxOptions, token?: CancellationToken): Promise<string | undefined> {
     // keep track of this request

--- a/packages/main/src/plugin/install/extension-installer.ts
+++ b/packages/main/src/plugin/install/extension-installer.ts
@@ -27,10 +27,11 @@ import * as tarFs from 'tar-fs';
 import type Dockerode from 'dockerode';
 import type { PullEvent } from '../api/pull-event';
 import type { ExtensionLoader } from '../extension-loader';
+import type { ApiSenderType } from '../api';
+
 export class ExtensionInstaller {
   constructor(
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    private apiSender: any,
+    private apiSender: ApiSenderType,
     private containerRegistry: ContainerProviderRegistry,
     private extensionLoader: ExtensionLoader,
   ) {}

--- a/packages/main/src/plugin/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes-client.ts
@@ -38,6 +38,7 @@ import type { ConfigurationRegistry, IConfigurationNode } from './configuration-
 import type { FilesystemMonitoring } from './filesystem-monitoring';
 import type { PodInfo } from './api/pod-info';
 import { PassThrough } from 'node:stream';
+import type { ApiSenderType } from './api';
 
 function toContainerStatus(state: V1ContainerState | undefined): string {
   if (state) {
@@ -102,8 +103,7 @@ export class KubernetesClient {
     this._onDidUpdateKubeconfig.event;
 
   constructor(
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    private apiSender: any,
+    private apiSender: ApiSenderType,
     private configurationRegistry: ConfigurationRegistry,
     private fileSystemMonitoring: FilesystemMonitoring,
   ) {

--- a/packages/main/src/plugin/provider-registry.ts
+++ b/packages/main/src/plugin/provider-registry.ts
@@ -51,6 +51,7 @@ import { LifecycleContextImpl, LoggerImpl } from './lifecycle-context';
 import { ProviderImpl } from './provider-impl';
 import type { Telemetry } from './telemetry/telemetry';
 import { Disposable } from './types/disposable';
+import type { ApiSenderType } from './api';
 
 export type ProviderEventListener = (name: string, providerInfo: ProviderInfo) => void;
 export type ProviderLifecycleListener = (
@@ -105,8 +106,7 @@ export class ProviderRegistry {
     this._onDidRegisterContainerConnection.event;
 
   constructor(
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    private apiSender: any,
+    private apiSender: ApiSenderType,
     private containerRegistry: ContainerProviderRegistry,
     private telemetryService: Telemetry,
   ) {

--- a/packages/main/src/plugin/statusbar/statusbar-registry.ts
+++ b/packages/main/src/plugin/statusbar/statusbar-registry.ts
@@ -16,6 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { ApiSenderType } from '../api';
 import type { IDisposable } from '../types/disposable';
 
 export const STATUS_BAR_UPDATED_EVENT_NAME = 'status-bar-updated';
@@ -40,8 +41,7 @@ export interface StatusBarEntryDescriptor {
 export class StatusBarRegistry implements IDisposable {
   private readonly entries: Map<string, StatusBarEntryDescriptor> = new Map();
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  constructor(private apiSender: any) {}
+  constructor(private apiSender: ApiSenderType) {}
 
   removeEntry(id: string) {
     const entry = this.entries.get(id);


### PR DESCRIPTION
### What does this PR do?
while working on https://github.com/containers/podman-desktop/issues/1760 I noticed we were missing a type of apiSender

Add the type to avoid any

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Should work/compile as before. It is like a no-op

Change-Id: I8c7abb02606a07a016686466830fee1940c15483
