### PR TITLE
fix: start extensions once UI and System are ready

### DIFF
--- a/packages/main/src/index.ts
+++ b/packages/main/src/index.ts
@@ -25,8 +25,6 @@ import { AnimatedTray } from './tray-animate-icon';
 import { PluginSystem } from './plugin';
 import { StartupInstall } from './system/startup-install';
 
-export const UPDATER_UPDATE_AVAILABLE_ICON = 'fa fa-exclamation-triangle';
-
 /**
  * Prevent multiple instances
  */

--- a/packages/main/src/plugin/index.spec.ts
+++ b/packages/main/src/plugin/index.spec.ts
@@ -1,0 +1,61 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
+import type { TrayMenu } from '../tray-menu';
+import { EventEmitter } from 'node:events';
+import { PluginSystem } from './index';
+import type { WebContents } from 'electron';
+
+let pluginSystem: PluginSystem;
+
+const emitter = new EventEmitter();
+const webContents = emitter as unknown as WebContents;
+
+// add send method
+webContents.send = vi.fn();
+
+beforeAll(() => {
+  const trayMenuMock = {} as unknown as TrayMenu;
+  pluginSystem = new PluginSystem(trayMenuMock);
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+test('Should queue events until we are ready', async () => {
+  const apiSender = pluginSystem.getApiSender(webContents);
+  expect(apiSender).toBeDefined();
+
+  // try to send data
+  apiSender.send('foo', 'hello-world');
+
+  // data should not be sent because it is not yet ready
+  expect(webContents.send).not.toBeCalled();
+
+  // ready on server side
+  pluginSystem.markAsReady();
+
+  // notify the app is loaded on client side
+  emitter.emit('dom-ready');
+
+  // data should be sent when flushing queue
+  expect(webContents.send).toBeCalledWith('api-sender', 'foo', 'hello-world');
+});

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -22,7 +22,6 @@
 import * as os from 'node:os';
 import * as path from 'path';
 import type * as containerDesktopAPI from '@podman-desktop/api';
-import { UPDATER_UPDATE_AVAILABLE_ICON } from '..';
 import { CommandRegistry } from './command-registry';
 import { ContainerProviderRegistry } from './container-registry';
 import { ExtensionLoader } from './extension-loader';
@@ -96,6 +95,8 @@ import { clipboard } from 'electron';
 import type { ApiSenderType } from './api';
 
 type LogType = 'log' | 'warn' | 'trace' | 'debug' | 'error';
+
+export const UPDATER_UPDATE_AVAILABLE_ICON = 'fa fa-exclamation-triangle';
 
 export interface LoggerWithEnd extends containerDesktopAPI.Logger {
   // when task is finished, this function is called

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1364,12 +1364,16 @@ export class PluginSystem {
 
     await contributionManager.init();
 
+    this.markAsReady();
     await this.extensionLoader.start();
-    this.isReady = true;
     console.log('PluginSystem: initialization done.');
     apiSender.send('extension-system', `${this.isReady}`);
     autoStartConfiguration.start();
     return this.extensionLoader;
+  }
+
+  markAsReady(): void {
+    this.isReady = true;
   }
 
   getLogHandlerCreateConnection(channel: string, loggerId: string): LoggerWithEnd {

--- a/packages/renderer/src/Loader.svelte
+++ b/packages/renderer/src/Loader.svelte
@@ -12,7 +12,7 @@ let loadingSequence;
 onMount(async () => {
   loadingSequence = setInterval(() => {
     toggle = !toggle;
-  }, 2000);
+  }, 100);
   // check if the server side is ready
   try {
     const isReady = await window.extensionSystemIsReady();
@@ -30,7 +30,7 @@ onDestroy(() => {
 });
 
 // Wait that the server-side is ready
-window.events.receive('extension-system', (value: string) => {
+window.events.receive('starting-extensions', (value: string) => {
   systemReady = value === 'true';
   if (systemReady) {
     window.dispatchEvent(new CustomEvent('system-ready', {}));


### PR DESCRIPTION
### What does this PR do?
Ensure extensions are started once UI and Plugin System is initialized
before we were waiting the end of the extensions to hide the 'initialize' method
but if an extension was prompting for input it was not displayed.

Now, it correctly waits the prompt.

I've done some chore using extra commits to make it more readable.

### Screenshot/screencast of this PR

we have the prompt when starting Podman Desktop 
![image](https://user-images.githubusercontent.com/436777/228871298-3eed5097-466a-4a6d-86cf-6729525f6d79.png)


### What issues does this PR fix or reference?

Fixes #1760 

### How to test this PR?

Unit tests
You can also use the test case of the referenced issue.
