### PR TITLE
feat(extension-api): Authentication implementation

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -1386,4 +1386,270 @@ declare module '@podman-desktop/api' {
     export function saveImage(engineId: string, id: string, filename: string): Promise<void>;
     export const onEvent: Event<ContainerJSONEvent>;
   }
+
+  /**
+   * Represents a session of a currently logged in user.
+   */
+  export interface AuthenticationSession {
+    /**
+     * The identifier of the authentication session.
+     */
+    readonly id: string;
+
+    /**
+     * The access token.
+     */
+    readonly accessToken: string;
+
+    /**
+     * The account associated with the session.
+     */
+    readonly account: AuthenticationSessionAccountInformation;
+
+    /**
+     * The permissions granted by the session's access token. Available scopes
+     * are defined by the [AuthenticationProvider](#AuthenticationProvider).
+     */
+    readonly scopes: ReadonlyArray<string>;
+  }
+
+  /**
+   * The information of an account associated with an [AuthenticationSession](#AuthenticationSession).
+   */
+  export interface AuthenticationSessionAccountInformation {
+    /**
+     * The unique identifier of the account.
+     */
+    readonly id: string;
+
+    /**
+     * The human-readable name of the account.
+     */
+    readonly label: string;
+  }
+
+  /**
+   * Options to be used when getting an [AuthenticationSession](#AuthenticationSession) from an [AuthenticationProvider](#AuthenticationProvider).
+   */
+  export interface AuthenticationGetSessionOptions {
+    /**
+     * Whether login should be performed if there is no matching session.
+     *
+     * If true, a modal dialog will be shown asking the user to sign in. If false, a numbered badge will be shown
+     * on the accounts activity bar icon. An entry for the extension will be added under the menu to sign in. This
+     * allows quietly prompting the user to sign in.
+     *
+     * If there is a matching session but the extension has not been granted access to it, setting this to true
+     * will also result in an immediate modal dialog, and false will add a numbered badge to the accounts icon.
+     *
+     * Defaults to false.
+     */
+    createIfNone?: boolean;
+
+    /**
+     * Whether the existing user session preference should be cleared.
+     *
+     * For authentication providers that support being signed into multiple accounts at once, the user will be
+     * prompted to select an account to use when [getSession](#authentication.getSession) is called. This preference
+     * is remembered until [getSession](#authentication.getSession) is called with this flag.
+     *
+     * Defaults to false.
+     */
+    clearSessionPreference?: boolean;
+
+    /**
+     * Whether we should attempt to reauthenticate even if there is already a session available.
+     *
+     * If true, a modal dialog will be shown asking the user to sign in again. This is mostly used for scenarios
+     * where the token needs to be re minted because it has lost some authorization.
+     *
+     * If there are no existing sessions and forceNewSession is true, it will behave identically to
+     * {@link AuthenticationGetSessionOptions.createIfNone createIfNone}.
+     *
+     * This defaults to false.
+     */
+    forceNewSession?: boolean | { detail: string };
+
+    /**
+     * Whether we should show the indication to sign in in the Accounts menu.
+     *
+     * If false, the user will be shown a badge on the Accounts menu with an option to sign in for the extension.
+     * If true, no indication will be shown.
+     *
+     * Defaults to false.
+     *
+     * Note: you cannot use this option with any other options that prompt the user like {@link AuthenticationGetSessionOptions.createIfNone createIfNone}.
+     */
+    silent?: boolean;
+  }
+
+  /**
+   * Basic information about an [authenticationProvider](#AuthenticationProvider)
+   */
+  export interface AuthenticationProviderInformation {
+    /**
+     * The unique identifier of the authentication provider.
+     */
+    readonly id: string;
+
+    /**
+     * The human-readable name of the authentication provider.
+     */
+    readonly label: string;
+  }
+
+  /**
+   * An [event](#Event) which fires when an [AuthenticationSession](#AuthenticationSession) is added, removed, or changed.
+   */
+  export interface AuthenticationSessionsChangeEvent {
+    /**
+     * The [authenticationProvider](#AuthenticationProvider) that has had its sessions change.
+     */
+    readonly provider: AuthenticationProviderInformation;
+  }
+
+  /**
+   * Options for creating an [AuthenticationProvider](#AuthenticationProvider).
+   */
+  export interface AuthenticationProviderOptions {
+    /**
+     * Whether it is possible to be signed into multiple accounts at once with this provider.
+     * If not specified, will default to false.
+     */
+    readonly supportsMultipleAccounts?: boolean;
+  }
+
+  /**
+   * An [event](#Event) which fires when an [AuthenticationSession](#AuthenticationSession) is added, removed, or changed.
+   */
+  export interface AuthenticationProviderAuthenticationSessionsChangeEvent {
+    /**
+     * The [AuthenticationSession](#AuthenticationSession)s of the [AuthenticationProvider](#AuthentiationProvider) that have been added.
+     */
+    readonly added?: ReadonlyArray<AuthenticationSession>;
+
+    /**
+     * The [AuthenticationSession](#AuthenticationSession)s of the [AuthenticationProvider](#AuthentiationProvider) that have been removed.
+     */
+    readonly removed?: ReadonlyArray<AuthenticationSession>;
+
+    /**
+     * The [AuthenticationSession](#AuthenticationSession)s of the [AuthenticationProvider](#AuthentiationProvider) that have been changed.
+     * A session changes when its data excluding the id are updated. An example of this is a session refresh that results in a new
+     * access token being set for the session.
+     */
+    readonly changed?: ReadonlyArray<AuthenticationSession>;
+  }
+
+  /**
+   * A provider for performing authentication to a service.
+   */
+  export interface AuthenticationProvider {
+    /**
+     * An [event](#Event) which fires when the array of sessions has changed, or data
+     * within a session has changed.
+     */
+    readonly onDidChangeSessions: Event<AuthenticationProviderAuthenticationSessionsChangeEvent>;
+
+    /**
+     * Get a list of sessions.
+     * @param scopes An optional list of scopes. If provided, the sessions returned should match
+     * these permissions, otherwise all sessions should be returned.
+     * @returns A promise that resolves to an array of authentication sessions.
+     */
+    getSessions(scopes?: string[]): Promise<ReadonlyArray<AuthenticationSession>>;
+
+    /**
+     * Prompts a user to login.
+     *
+     * If login is successful, the onDidChangeSessions event should be fired.
+     *
+     * If login fails, a rejected promise should be returned.
+     *
+     * If the provider has specified that it does not support multiple accounts,
+     * then this should never be called if there is already an existing session matching these
+     * scopes.
+     * @param scopes A list of scopes, permissions, that the new session should be created with.
+     * @returns A promise that resolves to an authentication session.
+     */
+    createSession(scopes: string[]): Promise<AuthenticationSession>;
+
+    /**
+     * Removes the session corresponding to session id.
+     *
+     * If the removal is successful, the onDidChangeSessions event should be fired.
+     *
+     * If a session cannot be removed, the provider should reject with an error message.
+     * @param sessionId The id of the session to remove.
+     */
+    removeSession(sessionId: string): Promise<void>;
+  }
+
+  /**
+   * Namespace for authentication.
+   */
+  export namespace authentication {
+    /**
+     * Get an authentication session matching the desired scopes. Rejects if a provider with providerId is not
+     * registered, or if the user does not consent to sharing authentication information with
+     * the extension. If there are multiple sessions with the same scopes, the user will be shown a
+     * quickpick to select which account they would like to use.
+     *
+     * Currently, there are only two authentication providers that are contributed from built in extensions
+     * to VS Code that implement GitHub and Microsoft authentication: their providerId's are 'github' and 'microsoft'.
+     * @param providerId The id of the provider to use
+     * @param scopes A list of scopes representing the permissions requested. These are dependent on the authentication provider
+     * @param options The [getSessionOptions](#GetSessionOptions) to use
+     * @returns A thenable that resolves to an authentication session
+     */
+    export function getSession(
+      providerId: string,
+      scopes: string[],
+      options: AuthenticationGetSessionOptions & { createIfNone: true },
+    ): Promise<AuthenticationSession | undefined>;
+
+    /**
+     * Get an authentication session matching the desired scopes. Rejects if a provider with providerId is not
+     * registered, or if the user does not consent to sharing authentication information with
+     * the extension. If there are multiple sessions with the same scopes, the user will be shown a
+     * quickpick to select which account they would like to use.
+     *
+     * Currently, there are only two authentication providers that are contributed from built in extensions
+     * to VS Code that implement GitHub and Microsoft authentication: their providerId's are 'github' and 'microsoft'.
+     * @param providerId The id of the provider to use
+     * @param scopes A list of scopes representing the permissions requested. These are dependent on the authentication provider
+     * @param options The [getSessionOptions](#GetSessionOptions) to use
+     * @returns A thenable that resolves to an authentication session if available, or undefined if there are no sessions
+     */
+    export function getSession(
+      providerId: string,
+      scopes: string[],
+      options?: AuthenticationGetSessionOptions,
+    ): Promise<AuthenticationSession | undefined>;
+
+    /**
+     * An [event](#Event) which fires when the authentication sessions of an authentication provider have
+     * been added, removed, or changed.
+     */
+    export const onDidChangeSessions: Event<AuthenticationSessionsChangeEvent>;
+
+    /**
+     * Register an authentication provider.
+     *
+     * There can only be one provider per id and an error is being thrown when an id
+     * has already been used by another provider. Ids are case-sensitive.
+     *
+     * @param id The unique identifier of the provider.
+     * @param label The human-readable name of the provider.
+     * @param provider The authentication provider provider.
+     * @params options Additional options for the provider.
+     * @return A [disposable](#Disposable) that unregisters this provider when being disposed.
+     */
+    export function registerAuthenticationProvider(
+      id: string,
+      label: string,
+      provider: AuthenticationProvider,
+      options?: AuthenticationProviderOptions,
+    ): Disposable;
+  }
 }

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -953,7 +953,7 @@ declare module '@podman-desktop/api' {
      *
      * @param message The message to show.
      * @param items A set of items that will be rendered as actions in the message.
-     * @return A thenable that resolves to the selected item or `undefined` when being dismissed.
+     * @return A promise that resolves to the selected item or `undefined` when being dismissed.
      */
     export function showInformationMessage(message: string, ...items: string[]): Promise<string | undefined>;
 
@@ -963,7 +963,7 @@ declare module '@podman-desktop/api' {
      *
      * @param message The message to show.
      * @param items A set of items that will be rendered as actions in the message.
-     * @return A thenable that resolves to the selected item or `undefined` when being dismissed.
+     * @return A promise that resolves to the selected item or `undefined` when being dismissed.
      */
     export function showWarningMessage(message: string, ...items: string[]): Promise<string | undefined>;
 
@@ -973,7 +973,7 @@ declare module '@podman-desktop/api' {
      *
      * @param message The message to show.
      * @param items A set of items that will be rendered as actions in the message.
-     * @return A thenable that resolves to the selected item or `undefined` when being dismissed.
+     * @return A promise that resolves to the selected item or `undefined` when being dismissed.
      */
     export function showErrorMessage(message: string, ...items: string[]): Promise<string | undefined>;
 
@@ -1600,7 +1600,7 @@ declare module '@podman-desktop/api' {
      * @param providerId The id of the provider to use
      * @param scopes A list of scopes representing the permissions requested. These are dependent on the authentication provider
      * @param options The [getSessionOptions](#GetSessionOptions) to use
-     * @returns A thenable that resolves to an authentication session
+     * @returns A promise that resolves to an authentication session
      */
     export function getSession(
       providerId: string,
@@ -1619,7 +1619,7 @@ declare module '@podman-desktop/api' {
      * @param providerId The id of the provider to use
      * @param scopes A list of scopes representing the permissions requested. These are dependent on the authentication provider
      * @param options The [getSessionOptions](#GetSessionOptions) to use
-     * @returns A thenable that resolves to an authentication session if available, or undefined if there are no sessions
+     * @returns A promise that resolves to an authentication session if available, or undefined if there are no sessions
      */
     export function getSession(
       providerId: string,

--- a/packages/main/src/plugin/authentication.spec.ts
+++ b/packages/main/src/plugin/authentication.spec.ts
@@ -24,9 +24,9 @@ import type {
   Event,
 } from '@podman-desktop/api';
 import { beforeAll, expect, test, vi } from 'vitest';
-import { ApiSenderType } from './api';
+import type { ApiSenderType } from './api';
 import { AuthenticationImpl } from './authentication';
-import { Dialogs } from './dialog-impl';
+import type { Dialogs } from './dialog-impl';
 import { Emitter as EventEmitter } from './events/emitter';
 
 function randomNumber(n = 5) {
@@ -60,7 +60,7 @@ class AuthenticationProviderSingleAccout implements AuthenticationProvider {
   async createSession(scopes: string[]): Promise<AuthenticationSession> {
     return new RandomAuthenticationSession(scopes);
   }
-  async removeSession(sessionId: string): Promise<void> {
+  async removeSession(): Promise<void> {
     this.session = undefined;
   }
 }
@@ -72,13 +72,12 @@ const apiSender: ApiSenderType = {
 
 const dialogs: Dialogs = {
   showDialog: vi.fn(),
-}
+};
 
 let authModule: AuthenticationImpl;
 
 beforeAll(function () {
-  authModule = new AuthenticationImpl(
-    apiSender, dialogs);
+  authModule = new AuthenticationImpl(apiSender, dialogs);
 });
 
 test('Registered authentication provider stored in autentication module', async () => {
@@ -86,8 +85,4 @@ test('Registered authentication provider stored in autentication module', async 
   authModule.registerAuthenticationProvider('company.auth-provider', 'Provider 1', authProvidrer1);
   const providersInfo = await authModule.getAuthenticationProvidersInfo();
   expect(providersInfo).length(1, 'Provider was not registered');
-});
-
-test("Getting an authentication session with 'createIfNone = true' creates new one if not created yet", async () => {
-  
 });

--- a/packages/main/src/plugin/authentication.spec.ts
+++ b/packages/main/src/plugin/authentication.spec.ts
@@ -1,0 +1,83 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type {
+  AuthenticationProvider,
+  AuthenticationProviderAuthenticationSessionsChangeEvent,
+  AuthenticationSession,
+  AuthenticationSessionAccountInformation,
+  Event,
+} from '@podman-desktop/api';
+import { beforeAll, expect, expectTypeOf, test, suite } from 'vitest';
+import { AuthenticationImpl } from './authentication';
+import { Emitter as EventEmitter } from './events/emitter';
+
+function randomNumber(n = 5) {
+  return Math.round(Math.random() * 10 * n);
+}
+
+class RandomAuthenticationSession implements AuthenticationSession {
+  id: string;
+  accessToken: string;
+  account: AuthenticationSessionAccountInformation;
+  constructor(public readonly scopes: readonly string[]) {
+    this.id = `id${randomNumber()}`;
+    this.accessToken = `accessToken${randomNumber()}`;
+    this.account = {
+      id: `${randomNumber()}`,
+      label: `label${randomNumber()}`,
+    };
+  }
+}
+
+class AuthenticationProviderSingleAccout implements AuthenticationProvider {
+  private _onDidChangeSession = new EventEmitter<AuthenticationProviderAuthenticationSessionsChangeEvent>();
+  private session: AuthenticationSession | undefined;
+  onDidChangeSessions: Event<AuthenticationProviderAuthenticationSessionsChangeEvent> = this._onDidChangeSession.event;
+  async getSessions(scopes?: string[] | undefined): Promise<readonly AuthenticationSession[]> {
+    if (scopes) {
+      return [this.session ? this.session : (this.session = await this.createSession(scopes))];
+    }
+    return this.session ? [this.session] : [];
+  }
+  async createSession(scopes: string[]): Promise<AuthenticationSession> {
+    return new RandomAuthenticationSession(scopes);
+  }
+  async removeSession(sessionId: string): Promise<void> {
+    this.session = undefined;
+  }
+}
+
+const apiSender = {
+  send: function () {},
+};
+
+let authModule: AuthenticationImpl;
+
+beforeAll(function () {
+  authModule = new AuthenticationImpl(apiSender);
+});
+
+test('Registered authentication provider stored in autentication module', async () => {
+  const authProvidrer1 = new AuthenticationProviderSingleAccout();
+  authModule.registerAuthenticationProvider('company.auth-provider', 'Provider 1', authProvidrer1);
+  const providersInfo = authModule.getAuthenticationProvidersInfo();
+  expect(providersInfo).length(1, 'Provider was not registered');
+});
+
+test("Getting an authentication session with 'createIfNone = true' creates new one if not created yet", async () => {});

--- a/packages/main/src/plugin/authentication.spec.ts
+++ b/packages/main/src/plugin/authentication.spec.ts
@@ -23,8 +23,10 @@ import type {
   AuthenticationSessionAccountInformation,
   Event,
 } from '@podman-desktop/api';
-import { beforeAll, expect, expectTypeOf, test, suite } from 'vitest';
+import { beforeAll, expect, test, vi } from 'vitest';
+import { ApiSenderType } from './api';
 import { AuthenticationImpl } from './authentication';
+import { Dialogs } from './dialog-impl';
 import { Emitter as EventEmitter } from './events/emitter';
 
 function randomNumber(n = 5) {
@@ -63,21 +65,29 @@ class AuthenticationProviderSingleAccout implements AuthenticationProvider {
   }
 }
 
-const apiSender = {
-  send: function () {},
+const apiSender: ApiSenderType = {
+  send: vi.fn(),
+  receive: vi.fn(),
 };
+
+const dialogs: Dialogs = {
+  showDialog: vi.fn(),
+}
 
 let authModule: AuthenticationImpl;
 
 beforeAll(function () {
-  authModule = new AuthenticationImpl(apiSender);
+  authModule = new AuthenticationImpl(
+    apiSender, dialogs);
 });
 
 test('Registered authentication provider stored in autentication module', async () => {
   const authProvidrer1 = new AuthenticationProviderSingleAccout();
   authModule.registerAuthenticationProvider('company.auth-provider', 'Provider 1', authProvidrer1);
-  const providersInfo = authModule.getAuthenticationProvidersInfo();
+  const providersInfo = await authModule.getAuthenticationProvidersInfo();
   expect(providersInfo).length(1, 'Provider was not registered');
 });
 
-test("Getting an authentication session with 'createIfNone = true' creates new one if not created yet", async () => {});
+test("Getting an authentication session with 'createIfNone = true' creates new one if not created yet", async () => {
+  
+});

--- a/packages/main/src/plugin/authentication.ts
+++ b/packages/main/src/plugin/authentication.ts
@@ -134,6 +134,14 @@ export class AuthenticationImpl {
     throw new Error('The method is not implemented!');
   }
 
+  /**
+   * Check extension access to an account
+   * @param providerId The id of the authentication provider
+   * @param accountName The account name that access is checked for
+   * @param extensionId The id of the extension requesting access
+   * @returns Returns true or false if the user has opted to permanently grant or disallow access, and undefined
+   * if they haven't made a choice yet
+   */
   isAccessAllowed(providerId: string, accountName: string, extensionId: string): boolean | undefined {
     return true; // To be implemented later
   }

--- a/packages/main/src/plugin/authentication.ts
+++ b/packages/main/src/plugin/authentication.ts
@@ -1,0 +1,189 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type {
+  authentication,
+  AuthenticationProvider,
+  AuthenticationSession,
+  AuthenticationSessionsChangeEvent,
+  AuthenticationGetSessionOptions,
+  Event,
+  AuthenticationProviderAuthenticationSessionsChangeEvent,
+  AuthenticationSessionAccountInformation,
+  AuthenticationProviderOptions,
+  Disposable,
+} from '@podman-desktop/api';
+// import { window } from '@podman-desktop/api';
+import { Emitter } from './events/emitter';
+type Authentication = typeof authentication;
+
+/**
+ * Structure to save authentication provider information
+ * with additional metadata
+ */
+export interface ProviderWithMetadata {
+  id: string;
+  label: string;
+  provider: AuthenticationProvider;
+  options: AuthenticationProviderOptions;
+}
+
+export interface AuthenticationProviderInfo {
+  id: string;
+  displayName: string;
+  accounts: AuthenticationSessionAccountInformation[];
+}
+
+export interface ExtensionInfo {
+  id: string;
+  label: string;
+}
+
+export interface AllowedExtension {
+  id: string;
+  name: string;
+  allowed?: boolean;
+}
+
+export class AuthenticationImpl {
+  private _authenticationProviders: Map<string, ProviderWithMetadata> = new Map<string, ProviderWithMetadata>();
+
+  constructor(private apiSender: any) {}
+
+  public async getAuthenticationProvidersInfo(): Promise<AuthenticationProviderInfo[]> {
+    const values = Array.from(this._authenticationProviders.values());
+    const sessionsRequests = values.map(meta => {
+      return meta.provider.getSessions().then(sessions => {
+        return {
+          id: meta.id,
+          displayName: meta.label,
+          accounts: sessions.map(session => ({ id: session.id, label: session.account.label })),
+        };
+      });
+    });
+
+    return await Promise.all(sessionsRequests);
+  }
+
+  public async signOut(providerId: string, sessionId: string) {
+    this.removeSession(providerId, sessionId);
+  }
+
+  registerAuthenticationProvider(
+    id: string,
+    label: string,
+    provider: AuthenticationProvider,
+    options?: AuthenticationProviderOptions,
+  ): Disposable {
+    if (this._authenticationProviders.get(id)) {
+      throw new Error(`An authentication provider with id '${id}' is already registered.`);
+    }
+    this._authenticationProviders.set(id, {
+      id,
+      label,
+      provider,
+      options: options ?? { supportsMultipleAccounts: false },
+    });
+    this.apiSender.send('authentication-provider-update');
+    const onDidChangeSessionDisposable = provider.onDidChangeSessions(
+      (event: AuthenticationProviderAuthenticationSessionsChangeEvent) => {
+        this._onDidChangeSessions.fire({ provider: { id, label } });
+        this.apiSender.send('authentication-provider-update');
+      },
+    );
+    return {
+      dispose: () => {
+        onDidChangeSessionDisposable.dispose();
+        this._authenticationProviders.delete(id);
+      },
+    };
+  }
+
+  addAccountUsage(providerId: string, accountLabel: string, extensionId: string, extensionName: string): void {
+    throw new Error('The method is not implemented!');
+  }
+
+  readAllowedExtensions(providerId: string, accountName: string): AllowedExtension[] {
+    throw new Error('The method is not implemented!');
+  }
+
+  updateAllowedExtension(
+    providerId: string,
+    accountName: string,
+    extensionId: string,
+    extensionName: string,
+    isAllowed: boolean,
+  ): void {
+    throw new Error('The method is not implemented!');
+  }
+
+  isAccessAllowed(providerId: string, accountName: string, extensionId: string): boolean | undefined {
+    return true; // To be implemented later
+  }
+
+  async getSession(
+    requestingExtension: ExtensionInfo,
+    providerId: string,
+    scopes: string[],
+    options: AuthenticationGetSessionOptions & { createIfNone: true },
+  ): Promise<AuthenticationSession | undefined>;
+  async getSession(
+    requestingExtension: ExtensionInfo,
+    providerId: string,
+    scopes: string[],
+    options?: AuthenticationGetSessionOptions,
+  ): Promise<AuthenticationSession | undefined>;
+  async getSession(
+    requestingExtension: ExtensionInfo,
+    providerId: string,
+    scopes: string[],
+    options: AuthenticationGetSessionOptions = {},
+  ): Promise<AuthenticationSession | undefined> {
+    // Error cases
+    if (options.forceNewSession) {
+      throw new Error('Option is not supported. Please remove forceNewSession option.');
+    }
+    if (options.silent) {
+      throw new Error('Option is not supported. Please remove silent option.');
+    }
+    if (options.clearSessionPreference) {
+      throw new Error('Option is not supported. Please remove clearSessionPreference option.');
+    }
+
+    const provider = this._authenticationProviders.get(providerId)?.provider;
+    if (!provider) {
+      // window.showInformationMessage(`Requested authentication provider ${providerId} is not installed.`);
+    } else {
+      const sessions = await provider.getSessions(scopes);
+      if (sessions.length > 0 && this.isAccessAllowed(providerId, sessions[0].account.label, requestingExtension.id)) {
+        return sessions[0];
+      } else {
+        return provider.createSession(scopes);
+      }
+    }
+    return;
+  }
+
+  async removeSession(providerId: string, sessionId: string): Promise<void> {
+    const provider = this._authenticationProviders.get(providerId)?.provider;
+    return provider?.removeSession(sessionId);
+  }
+
+  private readonly _onDidChangeSessions = new Emitter<AuthenticationSessionsChangeEvent>();
+  readonly onDidChangeSessions: Event<AuthenticationSessionsChangeEvent> = this._onDidChangeSessions.event;
+}

--- a/packages/main/src/plugin/authentication.ts
+++ b/packages/main/src/plugin/authentication.ts
@@ -31,6 +31,7 @@ import type {
 // import { window } from '@podman-desktop/api';
 import { Emitter } from './events/emitter';
 import type { ApiSenderType } from './api';
+import { Dialogs } from './dialog-impl';
 
 type Authentication = typeof authentication;
 
@@ -65,7 +66,7 @@ export interface AllowedExtension {
 export class AuthenticationImpl {
   private _authenticationProviders: Map<string, ProviderWithMetadata> = new Map<string, ProviderWithMetadata>();
 
-  constructor(private apiSender: ApiSenderType) {}
+  constructor(private apiSender: ApiSenderType, private dialogs: Dialogs) {}
 
   public async getAuthenticationProvidersInfo(): Promise<AuthenticationProviderInfo[]> {
     const values = Array.from(this._authenticationProviders.values());
@@ -177,7 +178,7 @@ export class AuthenticationImpl {
 
     const provider = this._authenticationProviders.get(providerId)?.provider;
     if (!provider) {
-      // window.showInformationMessage(`Requested authentication provider ${providerId} is not installed.`);
+        await this.dialogs.showDialog('error', 'Authentication Error', `Requested authentication provider ${providerId} is not installed.`, ['Close']);
     } else {
       const sessions = await provider.getSessions(scopes);
       if (sessions.length > 0 && this.isAccessAllowed(providerId, sessions[0].account.label, requestingExtension.id)) {

--- a/packages/main/src/plugin/authentication.ts
+++ b/packages/main/src/plugin/authentication.ts
@@ -175,35 +175,22 @@ export class AuthenticationImpl {
 
     const provider = this._authenticationProviders.get(providerId)?.provider;
     if (!provider) {
-      await this.dialogs.showDialog(
-        'error',
-        'Authentication Error',
-        `Requested authentication provider ${providerId} is not installed.`,
-        ['Close'],
-      );
+      throw new Error(`Requested authentication provider ${providerId} is not installed.`);
     } else {
       const sessions = await provider.getSessions(scopes);
       if (sessions.length > 0 && this.isAccessAllowed(providerId, sessions[0].account.label, requestingExtension.id)) {
         return sessions[0];
-      } else {
-        return provider.createSession(scopes);
       }
+      return provider.createSession(scopes);
     }
-    return;
   }
 
   async removeSession(providerId: string, sessionId: string): Promise<void> {
     const provider = this._authenticationProviders.get(providerId)?.provider;
     if (!provider) {
-      await this.dialogs.showDialog(
-        'error',
-        'Authentication Error',
-        `Requested authentication provider ${providerId} is not installed.`,
-        ['Close'],
-      );
-    } else {
-      return provider.removeSession(sessionId);
+      throw new Error(`Requested authentication provider ${providerId} is not installed.`);
     }
+    return provider.removeSession(sessionId);
   }
 
   private readonly _onDidChangeSessions = new Emitter<AuthenticationSessionsChangeEvent>();

--- a/packages/main/src/plugin/authentication.ts
+++ b/packages/main/src/plugin/authentication.ts
@@ -30,6 +30,8 @@ import type {
 } from '@podman-desktop/api';
 // import { window } from '@podman-desktop/api';
 import { Emitter } from './events/emitter';
+import type { ApiSenderType } from './api';
+
 type Authentication = typeof authentication;
 
 /**
@@ -63,7 +65,7 @@ export interface AllowedExtension {
 export class AuthenticationImpl {
   private _authenticationProviders: Map<string, ProviderWithMetadata> = new Map<string, ProviderWithMetadata>();
 
-  constructor(private apiSender: any) {}
+  constructor(private apiSender: ApiSenderType) {}
 
   public async getAuthenticationProvidersInfo(): Promise<AuthenticationProviderInfo[]> {
     const values = Array.from(this._authenticationProviders.values());

--- a/packages/main/src/plugin/authentication.ts
+++ b/packages/main/src/plugin/authentication.ts
@@ -101,11 +101,11 @@ export class AuthenticationImpl {
       provider,
       options: options ?? { supportsMultipleAccounts: false },
     });
-    this.apiSender.send('authentication-provider-update');
+    this.apiSender.send('authentication-provider-update', {id});
     const onDidChangeSessionDisposable = provider.onDidChangeSessions(
       (event: AuthenticationProviderAuthenticationSessionsChangeEvent) => {
         this._onDidChangeSessions.fire({ provider: { id, label } });
-        this.apiSender.send('authentication-provider-update');
+        this.apiSender.send('authentication-provider-update', {id});
       },
     );
     return {

--- a/packages/main/src/plugin/extension-loader.spec.ts
+++ b/packages/main/src/plugin/extension-loader.spec.ts
@@ -38,7 +38,7 @@ import type { TrayMenuRegistry } from './tray-menu-registry';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import type { ApiSenderType } from './api';
-import { AuthenticationImpl } from './authentication';
+import type { AuthenticationImpl } from './authentication';
 
 class TestExtensionLoader extends ExtensionLoader {
   public async setupScanningDirectory(): Promise<void> {

--- a/packages/main/src/plugin/extension-loader.spec.ts
+++ b/packages/main/src/plugin/extension-loader.spec.ts
@@ -38,6 +38,7 @@ import type { TrayMenuRegistry } from './tray-menu-registry';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import type { ApiSenderType } from './api';
+import { AuthenticationImpl } from './authentication';
 
 class TestExtensionLoader extends ExtensionLoader {
   public async setupScanningDirectory(): Promise<void> {
@@ -87,6 +88,8 @@ const containerProviderRegistry: ContainerProviderRegistry = {} as unknown as Co
 
 const inputQuickPickRegistry: InputQuickPickRegistry = {} as unknown as InputQuickPickRegistry;
 
+const authenticationProviderRegistry: AuthenticationImpl = {} as unknown as AuthenticationImpl;
+
 /* eslint-disable @typescript-eslint/no-empty-function */
 beforeAll(() => {
   extensionLoader = new TestExtensionLoader(
@@ -106,6 +109,7 @@ beforeAll(() => {
     proxy,
     containerProviderRegistry,
     inputQuickPickRegistry,
+    authenticationProviderRegistry,
   );
 });
 

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -47,7 +47,7 @@ import { desktopAppHomeDir } from '../util';
 import { Emitter } from './events/emitter';
 import { CancellationTokenSource } from './cancellation-token';
 import type { ApiSenderType } from './api';
-import { AuthenticationImpl } from './authentication';
+import type { AuthenticationImpl } from './authentication';
 
 /**
  * Handle the loading of an extension
@@ -108,7 +108,7 @@ export class ExtensionLoader {
     private proxy: Proxy,
     private containerProviderRegistry: ContainerProviderRegistry,
     private inputQuickPickRegistry: InputQuickPickRegistry,
-    private authentticationProviderRegistry: AuthenticationImpl,
+    private authenticationProviderRegistry: AuthenticationImpl,
   ) {}
 
   async listExtensions(): Promise<ExtensionInfo[]> {
@@ -599,17 +599,17 @@ export class ExtensionLoader {
       },
     };
 
-    const authentticationProviderRegistry = this.authentticationProviderRegistry;
+    const authenticationProviderRegistry = this.authenticationProviderRegistry;
     const extensionInfo = { id: extManifest.name, label: extManifest.displayName };
     const authentication: typeof containerDesktopAPI.authentication = {
       getSession: (providerId, scopes, options) => {
-        return authentticationProviderRegistry.getSession(extensionInfo, providerId, scopes, options);
+        return authenticationProviderRegistry.getSession(extensionInfo, providerId, scopes, options);
       },
       registerAuthenticationProvider: (id, label, provider, options) => {
-        return authentticationProviderRegistry.registerAuthenticationProvider(id, label, provider, options);
+        return authenticationProviderRegistry.registerAuthenticationProvider(id, label, provider, options);
       },
       onDidChangeSessions: (listener, thisArg, disposables) => {
-        return authentticationProviderRegistry.onDidChangeSessions(listener, thisArg, disposables);
+        return authenticationProviderRegistry.onDidChangeSessions(listener, thisArg, disposables);
       },
     };
 

--- a/packages/main/src/plugin/image-registry.spec.ts
+++ b/packages/main/src/plugin/image-registry.spec.ts
@@ -17,6 +17,7 @@
  ***********************************************************************/
 
 import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
+import { ApiSenderType } from './api';
 import type { Certificates } from './certificates';
 
 import { ImageRegistry } from './image-registry';
@@ -34,7 +35,7 @@ beforeAll(() => {
     isEnabled: vi.fn(),
   } as unknown as Proxy;
 
-  imageRegistry = new ImageRegistry({}, telemetry, certificates, proxy);
+  imageRegistry = new ImageRegistry({} as ApiSenderType, telemetry, certificates, proxy);
 });
 
 beforeEach(() => {

--- a/packages/main/src/plugin/image-registry.spec.ts
+++ b/packages/main/src/plugin/image-registry.spec.ts
@@ -17,7 +17,7 @@
  ***********************************************************************/
 
 import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
-import { ApiSenderType } from './api';
+import type { ApiSenderType } from './api';
 import type { Certificates } from './certificates';
 
 import { ImageRegistry } from './image-registry';

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -94,7 +94,8 @@ import type { UpdateCheckResult } from 'electron-updater';
 import { autoUpdater } from 'electron-updater';
 import { clipboard } from 'electron';
 import type { ApiSenderType } from './api';
-import { AuthenticationImpl, AuthenticationProviderInfo } from './authentication';
+import type { AuthenticationProviderInfo } from './authentication';
+import { AuthenticationImpl } from './authentication';
 
 type LogType = 'log' | 'warn' | 'trace' | 'debug' | 'error';
 
@@ -529,7 +530,7 @@ export class PluginSystem {
     // init welcome configuration
     const welcomeInit = new WelcomeInit(configurationRegistry);
     welcomeInit.init();
-    
+
     const dialogs = new Dialogs();
 
     const authentication = new AuthenticationImpl(apiSender, dialogs);
@@ -1072,13 +1073,19 @@ export class PluginSystem {
       },
     );
 
-    this.ipcHandle('authentication-provider-registry:getAuthenticationProvidersInfo', async (): Promise<readonly AuthenticationProviderInfo[]> => {
-      return authentication.getAuthenticationProvidersInfo();
-    });
+    this.ipcHandle(
+      'authentication-provider-registry:getAuthenticationProvidersInfo',
+      async (): Promise<readonly AuthenticationProviderInfo[]> => {
+        return authentication.getAuthenticationProvidersInfo();
+      },
+    );
 
-    this.ipcHandle('authentication-provider-registry:requestAuthenticationProviderSignOut', async (_listener, providerId: string, sessionId): Promise<void> => {
-      return authentication.signOut(providerId, sessionId);
-    });
+    this.ipcHandle(
+      'authentication-provider-registry:requestAuthenticationProviderSignOut',
+      async (_listener, providerId: string, sessionId): Promise<void> => {
+        return authentication.signOut(providerId, sessionId);
+      },
+    );
 
     this.ipcHandle(
       'configuration-registry:getConfigurationProperties',

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -529,8 +529,10 @@ export class PluginSystem {
     // init welcome configuration
     const welcomeInit = new WelcomeInit(configurationRegistry);
     welcomeInit.init();
+    
+    const dialogs = new Dialogs();
 
-    const authentication = new AuthenticationImpl(apiSender);
+    const authentication = new AuthenticationImpl(apiSender, dialogs);
 
     this.extensionLoader = new ExtensionLoader(
       commandRegistry,
@@ -540,7 +542,7 @@ export class PluginSystem {
       imageRegistry,
       apiSender,
       trayMenuRegistry,
-      new Dialogs(),
+      dialogs,
       new ProgressImpl(),
       new NotificationImpl(),
       statusBarRegistry,


### PR DESCRIPTION
### What does this PR do?

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

Fix #1702 

### How to test this PR?

Build and install Red Hat SSO Authentication extension from 
https://github.com/redhat-developer/podman-desktop-redhat-account-ext

Use tray menu 'Red Hat/Sing In' to trigger login to Red Hat SSO. Sign In menu getting disabled and Sing Out activated.
There is no UI to see Authentication Providers installed, which is part of other PR. 
