### PR TITLE
feat: refactor preferences layout (#1779)

### DIFF
--- a/extensions/podman/package.json
+++ b/extensions/podman/package.json
@@ -22,6 +22,7 @@
       "properties": {
         "podman.binary.path": {
           "type": "string",
+          "format": "file",
           "default": "",
           "description": "Custom path to Podman binary (Default is blank)"
         },

--- a/packages/main/src/plugin/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes-client.ts
@@ -124,6 +124,7 @@ export class KubernetesClient {
           description: 'Kubeconfig path to use for accessing clusters. (Default is usually ~/.kube/config)',
           type: 'string',
           default: defaultKubeconfigPath,
+          format: 'file',
         },
       },
     };

--- a/packages/renderer/src/lib/preferences/PreferencesPage.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesPage.svelte
@@ -34,7 +34,7 @@ onMount(async () => {
 });
 </script>
 
-<div class="flex h-full px-3 py-3 bg-zinc-900">
+<div class="flex flex-col h-full bg-zinc-900">
   <Route path="/*" breadcrumb="Preferences">
     {#if defaultPrefPageId !== undefined}
       <PreferencesRendering key="{defaultPrefPageId}" properties="{properties}" />

--- a/packages/renderer/src/lib/preferences/PreferencesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRendering.svelte
@@ -5,30 +5,39 @@ import { CONFIGURATION_DEFAULT_SCOPE } from '../../../../main/src/plugin/configu
 import PreferencesRenderingItem from './PreferencesRenderingItem.svelte';
 import SettingsPage from './SettingsPage.svelte';
 import Route from '../../Route.svelte';
+import { onMount } from 'svelte';
 
 export let properties: IConfigurationPropertyRecordedSchema[] = [];
 export let key: string;
 
-let title;
+let matchingRecords: Map<string, IConfigurationPropertyRecordedSchema[]>;
 
-$: title = key.replaceAll('.', ' ');
-$: matchingRecords = properties.filter(
-  property => property.parentId.startsWith(key) && property.scope === CONFIGURATION_DEFAULT_SCOPE && !property.hidden,
-);
+$: matchingRecords = properties
+  .filter(
+    property => property.parentId.startsWith(key) && property.scope === CONFIGURATION_DEFAULT_SCOPE && !property.hidden,
+  )
+  .reduce((map, property) => {
+    if (!map.has(property.parentId)) {
+      map.set(property.parentId, []);
+    }
+    map.get(property.parentId).push(property);
+    return map;
+  }, new Map<string, IConfigurationPropertyRecordedSchema[]>());
 </script>
 
 <Route path="/" breadcrumb="{key}" let:meta>
   <SettingsPage title="Preferences">
-    <table class="divide-y divide-zinc-800 min-w-full mt-5 rounded-md p-3">
-      <tbody class="bg-zinc-800 divide-y-8 divide-zinc-900">
-        {#each matchingRecords as record}
-          <tr>
-            <td>
-              <PreferencesRenderingItem record="{record}" />
-            </td>
-          </tr>
-        {/each}
-      </tbody>
-    </table>
+    <div class="flex flex-col min-w-full rounded-md px-3">
+      {#each [...matchingRecords.keys()].sort((a, b) => a.localeCompare(b)) as configSection}
+        <div class="mt-5">
+          <div class="first-letter:uppercase">{configSection.replace('preferences.', '').replace('.', ' ')}</div>
+          {#each matchingRecords.get(configSection) as configItem}
+            <div class="bg-zinc-800 rounded-md mt-2 ml-2">
+              <PreferencesRenderingItem record="{configItem}" />
+            </div>
+          {/each}
+        </div>
+      {/each}
+    </div>
   </SettingsPage>
 </Route>

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItem.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItem.svelte
@@ -45,11 +45,21 @@ $: {
 }
 </script>
 
-<div class="flex flex-col px-2 pt-2">
-  <div class="flex">
-    <div class="capitalize">{recordUI.breadCrumb}</div>
-    <div class="pl-2 text-violet-400">{recordUI.title}</div>
+<div class="flex flex-row px-2 py-2 justify-between w-full">
+  <div
+    class="flex flex-col {recordUI.original.type === 'string' &&
+    (!recordUI.original.enum || recordUI.original.enum.length === 0)
+      ? 'w-full'
+      : ''}">
+    <div class="text-sm">
+      {recordUI.title}
+    </div>
+    <div class="pt-1 text-gray-400 text-xs">{recordUI.description}</div>
+    {#if recordUI.original.type === 'string' && (!recordUI.original.enum || recordUI.original.enum.length === 0)}
+      <PreferencesRenderingItemFormat showUpdate="{false}" record="{recordUI.original}" showResetToDefault="{true}" />
+    {/if}
   </div>
-  <div class="pt-2 text-gray-400">{recordUI.description}</div>
-  <PreferencesRenderingItemFormat showUpdate="{true}" record="{recordUI.original}" />
+  {#if recordUI.original.type !== 'string' || (recordUI.original.enum && recordUI.original.enum.length > 0)}
+    <PreferencesRenderingItemFormat showUpdate="{false}" record="{recordUI.original}" showResetToDefault="{true}" />
+  {/if}
 </div>

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItem.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItem.svelte
@@ -43,6 +43,18 @@ function update() {
 $: {
   update();
 }
+
+function updateResetButtonVisibility(recordValue: any) {
+  showResetButton =
+    recordUI.original.default !== undefined && recordValue !== undefined && recordValue != recordUI.original.default;
+}
+
+function doResetToDefault() {
+  resetToDefault = true;
+}
+
+$: showResetButton = false;
+$: resetToDefault = false;
 </script>
 
 <div class="flex flex-row px-2 py-2 justify-between w-full">
@@ -51,15 +63,30 @@ $: {
     (!recordUI.original.enum || recordUI.original.enum.length === 0)
       ? 'w-full'
       : ''}">
-    <div class="text-sm">
+    <div class="flex flex-row text-sm">
       {recordUI.title}
+      {#if showResetButton}
+        <div class="ml-2">
+          <button class="text-xs text-violet-500 float-right" on:click="{() => doResetToDefault()}">
+            <i class="fas fa-undo" aria-hidden="true"></i>
+          </button>
+        </div>
+      {/if}
     </div>
     <div class="pt-1 text-gray-400 text-xs">{recordUI.description}</div>
     {#if recordUI.original.type === 'string' && (!recordUI.original.enum || recordUI.original.enum.length === 0)}
-      <PreferencesRenderingItemFormat showUpdate="{false}" record="{recordUI.original}" showResetToDefault="{true}" />
+      <PreferencesRenderingItemFormat
+        showUpdate="{false}"
+        record="{recordUI.original}"
+        updateResetButtonVisibility="{updateResetButtonVisibility}"
+        resetToDefault="{resetToDefault}" />
     {/if}
   </div>
   {#if recordUI.original.type !== 'string' || (recordUI.original.enum && recordUI.original.enum.length > 0)}
-    <PreferencesRenderingItemFormat showUpdate="{false}" record="{recordUI.original}" showResetToDefault="{true}" />
+    <PreferencesRenderingItemFormat
+      showUpdate="{false}"
+      record="{recordUI.original}"
+      updateResetButtonVisibility="{updateResetButtonVisibility}"
+      resetToDefault="{resetToDefault}" />
   {/if}
 </div>

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItem.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItem.svelte
@@ -67,7 +67,7 @@ $: resetToDefault = false;
       {recordUI.title}
       {#if showResetButton}
         <div class="ml-2">
-          <button class="text-xs text-violet-500 float-right" on:click="{() => doResetToDefault()}">
+          <button class="text-xs text-violet-500" on:click="{() => doResetToDefault()}">
             <i class="fas fa-undo" aria-hidden="true"></i>
           </button>
         </div>

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
@@ -8,12 +8,14 @@ let invalidText = undefined;
 export let showUpdate = false;
 export let invalidRecord = (error: string) => {};
 export let validRecord = () => {};
+export let showResetToDefault = false;
 
 export let record: IConfigurationPropertyRecordedSchema;
 
 let currentRecord: IConfigurationPropertyRecordedSchema;
+let recordUpdateTimeout: NodeJS.Timeout;
 
-let recordValue;
+$: recordValue = record.default;
 let checkboxValue: boolean = false;
 $: if (currentRecord !== record) {
   if (record.scope === CONFIGURATION_DEFAULT_SCOPE) {
@@ -42,6 +44,7 @@ function valid() {
 }
 
 function checkValue(record: IConfigurationPropertyRecordedSchema, event: any) {
+  clearTimeout(recordUpdateTimeout);
   const userValue = event.target.value;
   if (record.type === 'number') {
     const numberValue = parseFloat(userValue);
@@ -69,6 +72,7 @@ function checkValue(record: IConfigurationPropertyRecordedSchema, event: any) {
     }
   }
   valid();
+  recordUpdateTimeout = setTimeout(() => update(record), 1000);
   invalidEntry = false;
   invalidText = undefined;
 }
@@ -93,42 +97,136 @@ function update(record: IConfigurationPropertyRecordedSchema) {
   }
 }
 
+function resetToDefault() {
+  if (record.default) {
+    recordValue = record.default;
+    update(record);
+  }
+}
+
 async function selectFilePath() {
+  clearTimeout(recordUpdateTimeout);
   const result = await window.openFileDialog(`Select ${record.description}`);
   if (!result.canceled && result.filePaths.length === 1) {
     recordValue = result.filePaths[0];
+    recordUpdateTimeout = setTimeout(() => update(record), 1000);
   }
+}
+
+function decrement(e: HTMLButtonElement, record: IConfigurationPropertyRecordedSchema) {
+  clearTimeout(recordUpdateTimeout);
+  const target = getCurrentNumericInputElement(e);
+  let value = Number(target.value);
+  if (canDecrement(value, record.minimum)) {
+    value--;
+    recordValue = value;
+    recordUpdateTimeout = setTimeout(() => update(record), 1000);
+  }
+}
+
+function increment(e: HTMLButtonElement, record: IConfigurationPropertyRecordedSchema) {
+  clearTimeout(recordUpdateTimeout);
+  const target = getCurrentNumericInputElement(e);
+  let value = Number(target.value);
+  if (canIncrement(value, record.maximum)) {
+    value++;
+    recordValue = value;
+    recordUpdateTimeout = setTimeout(() => update(record), 1000);
+  }
+}
+
+function getCurrentNumericInputElement(e: HTMLButtonElement) {
+  const btn = e.parentNode.parentElement.querySelector('button[data-action="decrement"]');
+  return btn.nextElementSibling as unknown as HTMLInputElement;
+}
+
+function canDecrement(value: number | string, minimumValue?: number) {
+  if (typeof value === 'string') {
+    value = Number(value);
+  }
+  return !minimumValue || value > minimumValue;
+}
+
+function canIncrement(value: number | string, maximumValue?: number) {
+  if (typeof value === 'string') {
+    value = Number(value);
+  }
+  return !maximumValue || value < maximumValue;
 }
 </script>
 
-<div class="flex flex-row mb-2 pt-2">
-  <div class="flex flex-col mx-2 w-full text-start justify-center items-start pf-c-form__group-control">
+<div class="flex flex-row mb-1 pt-2">
+  <div class="flex flex-col mx-2 text-start w-full justify-center items-start pf-c-form__group-control">
     {#if record.type === 'boolean'}
-      <input
-        on:input="{event => checkValue(record, event)}"
-        class="pf-c-check__input"
-        bind:checked="{checkboxValue}"
-        name="{record.id}"
-        type="checkbox"
-        readonly="{!!record.readonly}"
-        id="input-standard-{record.id}"
-        aria-invalid="{invalidEntry}"
-        aria-label="{record.description}" />
+      <label class="relative inline-flex items-center cursor-pointer">
+        <span class="text-xs {checkboxValue ? 'text-white' : 'text-gray-400'} mr-3"
+          >{checkboxValue ? 'Enabled' : 'Disabled'}</span>
+        <input
+          on:input="{event => checkValue(record, event)}"
+          class="sr-only peer"
+          bind:checked="{checkboxValue}"
+          name="{record.id}"
+          type="checkbox"
+          readonly="{!!record.readonly}"
+          id="input-standard-{record.id}"
+          aria-invalid="{invalidEntry}"
+          aria-label="{record.description}" />
+        <div
+          class="w-9 h-5 bg-gray-500 rounded-full peer peer-checked:after:translate-x-full after:bg-zinc-800 after:content-[''] after:absolute after:top-0.5 after:left-[59px] after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:bg-violet-600">
+        </div>
+      </label>
+    {:else if record.type === 'number'}
+      <div
+        class="flex flex-row rounded-sm bg-zinc-700 text-sm divide-x divide-zinc-900 w-24 border-b border-violet-500">
+        <button
+          data-action="decrement"
+          on:click="{e => decrement(e.currentTarget, record)}"
+          disabled="{!canDecrement(recordValue, record.minimum)}"
+          class="w-11 text-white {!canDecrement(recordValue, record.minimum)
+            ? 'bg-zinc-900 text-zinc-700'
+            : 'hover:text-gray-700 hover:bg-gray-400'} cursor-pointer outline-none">
+          <span class="m-auto font-thin">−</span>
+        </button>
+        <input
+          type="text"
+          readonly
+          class="w-full outline-none focus:outline-none text-center text-white text-sm py-0.5"
+          value="{recordValue}" />
+        <button
+          data-action="increment"
+          on:click="{e => increment(e.currentTarget, record)}"
+          disabled="{!canIncrement(recordValue, record.maximum)}"
+          class="w-11 text-white {!canIncrement(recordValue, record.maximum)
+            ? 'bg-zinc-900 text-zinc-700'
+            : 'hover:text-gray-700 hover:bg-gray-400'} cursor-pointer outline-none">
+          <span class="m-auto font-thin">+</span>
+        </button>
+      </div>
     {:else if record.type === 'string' && record.format === 'file'}
-      <input
-        name="{record.id}"
-        on:click="{() => selectFilePath()}"
-        id="rendering.FilePath.{record.id}"
-        bind:value="{recordValue}"
-        readonly
-        aria-invalid="{invalidEntry}"
-        aria-label="{record.description}"
-        placeholder="Select {record.description}..."
-        class="w-full p-2 outline-none text-sm bg-zinc-900 rounded-sm text-gray-400 placeholder-gray-400 cursor-pointer"
-        required />
+      <div class="w-full flex">
+        <input
+          class="w-5/6 mr-3 py-1 px-2 outline-0 text-sm"
+          name="{record.id}"
+          readonly
+          type="text"
+          value="{recordValue || ''}"
+          id="input-standard-{record.id}"
+          aria-invalid="{invalidEntry}"
+          aria-label="{record.description}" />
+        <input
+          name="{record.id}"
+          on:click="{() => selectFilePath()}"
+          id="rendering.FilePath.{record.id}"
+          readonly
+          aria-invalid="{invalidEntry}"
+          aria-label="{record.description}"
+          placeholder="Browse ..."
+          class="bg-violet-500 p-1 text-xs text-center hover:bg-zinc-700 placeholder-white rounded-sm cursor-pointer outline-0"
+          required />
+      </div>
     {:else if record.type === 'string' && record.enum && record.enum.length > 0}
       <select
-        class="border-b text-md focus:ring-blue-500 focus:border-blue-500 block w-full p-1 bg-zinc-700 border-gray-500 placeholder-gray-400 text-white"
+        class="border-b block w-full p-1 bg-zinc-700 border-violet-500 text-white text-sm checked:bg-violet-50"
         name="{record.id}"
         id="input-standard-{record.id}"
         on:input="{event => checkValue(record, event)}"
@@ -154,6 +252,15 @@ async function selectFilePath() {
 
     {#if invalidEntry}
       <ErrorMessage error="{invalidText}." />
+    {/if}
+    {#if showResetToDefault && record.default}
+      <div class="mt-2 w-full">
+        <button class="text-xs text-gray-400 float-right" on:click="{() => resetToDefault()}">
+          <span class="pf-c-button__icon pf-m-start">
+            <i class="fas fa-undo" aria-hidden="true"></i>
+          </span> Reset to default
+        </button>
+      </div>
     {/if}
   </div>
   {#if showUpdate}

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
@@ -181,7 +181,7 @@ function canIncrement(value: number | string, maximumValue?: number) {
           aria-invalid="{invalidEntry}"
           aria-label="{record.description}" />
         <div
-          class="w-9 h-5 bg-gray-500 rounded-full peer peer-checked:after:translate-x-full after:bg-zinc-800 after:content-[''] after:absolute after:top-0.5 after:left-[59px] after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:bg-violet-600">
+          class="w-8 h-[20px] bg-gray-500 rounded-full peer peer-checked:after:translate-x-full after:bg-zinc-800 after:content-[''] after:absolute after:top-[4px] after:left-[61px] after:rounded-full after:h-3 after:w-3 after:transition-all peer-checked:bg-violet-600">
         </div>
       </label>
     {:else if record.type === 'number'}
@@ -192,7 +192,7 @@ function canIncrement(value: number | string, maximumValue?: number) {
           on:click="{e => decrement(e.currentTarget, record)}"
           disabled="{!canDecrement(recordValue, record.minimum)}"
           class="w-11 text-white {!canDecrement(recordValue, record.minimum)
-            ? 'bg-zinc-900 text-zinc-700'
+            ? 'bg-charcoal-600 text-charcoal-100 border-t border-l border-zinc-900'
             : 'hover:text-gray-700 hover:bg-gray-400'} cursor-pointer outline-none">
           <span class="m-auto font-thin">−</span>
         </button>
@@ -206,7 +206,7 @@ function canIncrement(value: number | string, maximumValue?: number) {
           on:click="{e => increment(e.currentTarget, record)}"
           disabled="{!canIncrement(recordValue, record.maximum)}"
           class="w-11 text-white {!canIncrement(recordValue, record.maximum)
-            ? 'bg-zinc-900 text-zinc-700'
+            ? 'bg-charcoal-600 text-charcoal-100 border-t border-l border-zinc-900'
             : 'hover:text-gray-700 hover:bg-gray-400'} cursor-pointer outline-none">
           <span class="m-auto font-thin">+</span>
         </button>


### PR DESCRIPTION
### What does this PR do?

This PR refactors the existing layout of the preferences page as shown in #183  

It doesn't include the search bar and the treeview as they will be handled in separate PRs.

It includes a new layout, the reset button and the autosave mechanism.

### Screenshot/screencast of this PR

![new-preferences-layout-2](https://user-images.githubusercontent.com/49404737/229498507-e754b55c-dcbd-486d-9ee3-a1fe3bed7271.gif)

### What issues does this PR fix or reference?

it is part of #1779 

### How to test this PR?

1. go to settings -> preferences
2. update your setting and check that they are correctly saved
