### PR TITLE
fix: Allow extension to customize their display name for creating new instance

### DIFF
--- a/extensions/kind/src/extension.ts
+++ b/extensions/kind/src/extension.ts
@@ -51,6 +51,7 @@ function registerProvider(extensionContext: extensionApi.ExtensionContext, provi
   const disposable = provider.setKubernetesProviderConnectionFactory({
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     create: (params: { [key: string]: any }, logger?: Logger) => createCluster(params, logger, kindCli),
+    creationDisplayName: 'Kind cluster',
   });
   extensionContext.subscriptions.push(disposable);
   console.log('kind extension is active');

--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -665,6 +665,7 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
     provider.setContainerProviderConnectionFactory({
       initialize: () => createFunction({}, undefined),
       create: createFunction,
+      creationDisplayName: 'Podman machine',
     });
   }
 

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -224,16 +224,23 @@ declare module '@podman-desktop/api' {
     status(): ProviderConnectionStatus;
   }
 
-  // create programmatically a ContainerProviderConnection
-  export interface ContainerProviderConnectionFactory {
+  // common set of options for creating a provider
+  export interface ProviderConnectionFactory {
+    // Allow to initialize a provider
     initialize?(): Promise<void>;
+
+    // Optional display name when creating the provider. For example 'Podman Machine' or 'Kind Cluster', etc.
+    creationDisplayName?: string;
+  }
+
+  // create programmatically a ContainerProviderConnection
+  export interface ContainerProviderConnectionFactory extends ProviderConnectionFactory {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     create(params: { [key: string]: any }, logger?: Logger, token?: CancellationToken): Promise<void>;
   }
 
   // create a kubernetes provider
-  export interface KubernetesProviderConnectionFactory {
-    initialize?(): Promise<void>;
+  export interface KubernetesProviderConnectionFactory extends ProviderConnectionFactory {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     create?(params: { [key: string]: any }, logger?: Logger): Promise<void>;
   }

--- a/packages/main/src/plugin/api/provider-info.ts
+++ b/packages/main/src/plugin/api/provider-info.ts
@@ -60,10 +60,16 @@ export interface ProviderInfo {
   // can initialize provider connection from ContainerProviderConnectionFactory params
   containerProviderConnectionInitialization: boolean;
 
+  // optional creation name (if defined)
+  containerProviderConnectionCreationDisplayName?: string;
+
   // can create provider connection from KubernetesProviderConnectionFactory params
   kubernetesProviderConnectionCreation: boolean;
   // can initialize provider connection from KubernetesProviderConnectionFactory params
   kubernetesProviderConnectionInitialization: boolean;
+
+  // optional creation name (if defined)
+  kubernetesProviderConnectionCreationDisplayName?: string;
 
   version?: string;
 

--- a/packages/main/src/plugin/provider-registry.ts
+++ b/packages/main/src/plugin/provider-registry.ts
@@ -506,12 +506,16 @@ export class ProviderRegistry {
 
     // container connection factory ?
     let containerProviderConnectionCreation = false;
+    const containerProviderConnectionCreationDisplayName =
+      provider.containerProviderConnectionFactory?.creationDisplayName;
     if (provider.containerProviderConnectionFactory) {
       containerProviderConnectionCreation = true;
     }
 
     // kubernetes connection factory ?
     let kubernetesProviderConnectionInitialization = false;
+    const kubernetesProviderConnectionCreationDisplayName =
+      provider.kubernetesProviderConnectionFactory?.creationDisplayName;
     if (provider.kubernetesProviderConnectionFactory && provider.kubernetesProviderConnectionFactory.initialize) {
       kubernetesProviderConnectionInitialization = true;
     }
@@ -532,7 +536,9 @@ export class ProviderRegistry {
       containerProviderConnectionCreation,
       kubernetesProviderConnectionCreation,
       containerProviderConnectionInitialization,
+      containerProviderConnectionCreationDisplayName,
       kubernetesProviderConnectionInitialization,
+      kubernetesProviderConnectionCreationDisplayName,
       links: provider.links,
       detectionChecks: provider.detectionChecks,
       images: provider.images,

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.spec.ts
@@ -50,6 +50,7 @@ const providerInfo: ProviderInfo = {
   kubernetesProviderConnectionCreation: true,
   links: undefined,
   containerProviderConnectionInitialization: false,
+  containerProviderConnectionCreationDisplayName: 'Podman machine',
   kubernetesProviderConnectionInitialization: false,
 };
 
@@ -60,10 +61,33 @@ beforeEach(() => {
   };
 });
 
+test('Expect to see elements regarding default provider name', async () => {
+  // clone providerInfo and change id to foo
+  const customProviderInfo: ProviderInfo = { ...providerInfo };
+  // remove display name
+  customProviderInfo.containerProviderConnectionCreationDisplayName = undefined;
+  // change name of the provider
+  customProviderInfo.name = 'foo-provider';
+  providerInfos.set([customProviderInfo]);
+  render(PreferencesResourcesRendering, {});
+  const button = screen.getByRole('button', { name: 'Create new foo-provider' });
+  expect(button).toBeInTheDocument();
+});
+
+test('Expect to see elements regarding foo provider', async () => {
+  // clone providerInfo and change id to foo
+  const customProviderInfo: ProviderInfo = { ...providerInfo };
+  customProviderInfo.containerProviderConnectionCreationDisplayName = 'foo';
+  providerInfos.set([customProviderInfo]);
+  render(PreferencesResourcesRendering, {});
+  const button = screen.getByRole('button', { name: 'Create new foo' });
+  expect(button).toBeInTheDocument();
+});
+
 test('Expect to see elements regarding podman provider', async () => {
   providerInfos.set([providerInfo]);
   render(PreferencesResourcesRendering, {});
-  const button = screen.getByRole('button', { name: 'Create new podman machine' });
+  const button = screen.getByRole('button', { name: 'Create new Podman machine' });
   expect(button).toBeInTheDocument();
 });
 

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
@@ -183,7 +183,7 @@ async function startContainerProvider(
     {#each $providerInfos as provider}
       <div class="bg-zinc-800 mt-5 rounded-md p-3 divide-x divide-gray-600 flex">
         <div>
-          <!-- left col - podman icon/name + "create new" button -->
+          <!-- left col - provider icon/name + "create new" button -->
           <div class="min-w-[150px] max-w-[200px]">
             <div class="flex">
               {#if provider.images.icon}
@@ -198,11 +198,17 @@ async function startContainerProvider(
             </div>
             <div class="text-center mt-10">
               {#if provider.containerProviderConnectionCreation || provider.kubernetesProviderConnectionCreation}
-                <!-- create new podman machine button -->
-                <Tooltip tip="Create new {provider.name} machine" bottom>
+                {@const providerDisplayName =
+                  (provider.containerProviderConnectionCreation
+                    ? provider.containerProviderConnectionCreationDisplayName || undefined
+                    : provider.kubernetesProviderConnectionCreation
+                    ? provider.kubernetesProviderConnectionCreationDisplayName
+                    : undefined) || provider.name}
+                <!-- create new provider button -->
+                <Tooltip tip="Create new {providerDisplayName}" bottom>
                   <button
                     class="pf-c-button pf-m-primary"
-                    aria-label="Create new {provider.name} machine"
+                    aria-label="Create new {providerDisplayName}"
                     type="button"
                     on:click="{() => router.goto(`/preferences/provider/${provider.internalId}`)}">
                     Create new ...


### PR DESCRIPTION
### What does this PR do?
Extensions can configure the name to be displayed when we create a new instance

### Screenshot/screencast of this PR

![Screenshot 2023-04-03 at 10 37 16](https://user-images.githubusercontent.com/436777/229456676-cdef5a12-1347-4cae-a1df-af8303ae6f6a.png)

![Screenshot 2023-04-03 at 10 37 19](https://user-images.githubusercontent.com/436777/229456666-a4c1ffdb-bfd1-4688-a7d2-7ab7024cd7d4.png)

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/1877

### How to test this PR?

Look at 'Create new...' button in resources page. It should say' Podman machine' or 'Kind cluster'
Unit tests provided



Change-Id: Ifa68c12e13dd24c1bb0455b551b780f927134d6e
