### PR TITLE
docs: add small note on binary extensions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,6 +129,8 @@ yarn compile:current
 
 This will create a binary according to your local system and output it to the `dist/` folder.
 
+> **_NOTE:_** macOS and Windows create binaries while Linux will create a `.flatpak`. Make sure your flatpak dependencies are installed for successful compiling on Linux.
+
 ## Submitting Pull Requests
 
 ### Process


### PR DESCRIPTION
docs: add small note on binary extensions

### What does this PR do?

Adds a small note on binary extensions / compilation for Linux flatpak
support.

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

N/A

### What issues does this PR fix or reference?

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

N/A

### How to test this PR?

<!-- Please explain steps to reproduce -->

N/A

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
