### PR TITLE
feat: add compatibility button for Linux using flatpak-spawn

### DIFF
--- a/extensions/podman/src/compatibility-mode.ts
+++ b/extensions/podman/src/compatibility-mode.ts
@@ -20,6 +20,9 @@ import * as extensionApi from '@podman-desktop/api';
 import * as sudo from 'sudo-prompt';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
+import { execPromise } from './podman-cli';
+
+const podmanSystemdSocket = 'podman.socket';
 
 // Create an abstract class for compatibility mode (macOS only)
 // TODO: Windows, Linux
@@ -28,6 +31,12 @@ abstract class SocketCompatibility {
   abstract enable(): Promise<void>;
   abstract disable(): Promise<void>;
   abstract details: string;
+  abstract tooltipText(): string;
+}
+
+export class DarwinSocketCompatibility extends SocketCompatibility {
+  // Shows the details of the compatibility mode on what we do.
+  details = 'The podman-mac-helper binary will be ran. This requires administrative privileges.';
 
   // This will show the "opposite" of what the current state is
   // "Enable" if it's currently disabled, "Disable" if it's currently enabled
@@ -36,11 +45,6 @@ abstract class SocketCompatibility {
     const text = 'macOS Docker socket compatibility for Podman.';
     return this.isEnabled() ? `Disable ${text}` : `Enable ${text}`;
   }
-}
-
-export class DarwinSocketCompatibility extends SocketCompatibility {
-  // Shows the details of the compatibility mode on what we do.
-  details = 'The podman-mac-helper binary will be run. This requires administrative privileges.';
 
   // Find the podman-mac-helper binary which should only be located in either
   // brew or podman's install location
@@ -122,11 +126,87 @@ export class DarwinSocketCompatibility extends SocketCompatibility {
   }
 }
 
-// TODO: Windows, Linux
+export class LinuxSocketCompatibility extends SocketCompatibility {
+  details =
+    'Administrative privileges are required to enable or disable the systemd Podman socket for Docker compatibility.';
+
+  // This will show the "opposite" of what the current state is
+  // "Enable" if it's currently disabled, "Disable" if it's currently enabled
+  // for tooltip text
+  tooltipText(): string {
+    const text = 'Linux Docker socket compatibility for Podman.';
+    return this.isEnabled() ? `Disable ${text}` : `Enable ${text}`;
+  }
+
+  // isEnabled() checks to see if /etc/systemd/system/socket.target.wants/podman.socket exists
+  isEnabled(): boolean {
+    const filename = '/etc/systemd/system/socket.target.wants/podman.socket';
+    return fs.existsSync(filename);
+  }
+
+  // Runs the systemd command either 'enable' or 'disable'
+  async runSystemdCommand(command: string, description: string): Promise<void> {
+    // Only allow enable or disable, throw error if anything else is inputted
+    if (command != 'enable' && command != 'disable') {
+      throw new Error('runSystemdCommand only accepts enable or disable as the command');
+    }
+
+    // Create the full command to run with --now as well as the podman socket name
+    const fullCommand = [command, '--now', podmanSystemdSocket];
+
+    try {
+      // Have to run via sudo
+      await execPromise('systemctl', fullCommand);
+    } catch (error) {
+      console.error(`Error running systemctl command: ${error}`);
+      await extensionApi.window.showErrorMessage(`Error running systemctl command: ${error}`, 'OK');
+      return;
+    }
+
+    // Show information message to the user that they may need to run
+    // ln -s /run/podman/podman.sock /var/run/docker.sock to enable Docker compatibility
+    if (command == 'enable') {
+      // Show information and give the user an option of Yes or Cancel
+      const result = await extensionApi.window.showInformationMessage(
+        'Do you want to create a symlink from /run/podman/podman.sock to /var/run/docker.sock to enable Docker compatibility without having to set the DOCKER_HOST environment variable?',
+        'Yes',
+        'Cancel',
+      );
+      // If the user clicked Yes, run the ln command
+      if (result == 'Yes') {
+        try {
+          await execPromise('pkexec', ['ln', '-s', '/run/podman/podman.sock', '/var/run/docker.sock']);
+          await extensionApi.window.showInformationMessage(
+            'Symlink created successfully. The Podman socket is now available at /var/run/docker.sock.',
+          );
+        } catch (error) {
+          console.error(`Error creating symlink: ${error}`);
+          await extensionApi.window.showErrorMessage(`Error creating symlink: ${error}`, 'OK');
+          return;
+        }
+      }
+    }
+    await extensionApi.window.showInformationMessage(
+      `Podman systemd socket has been ${description} for Docker compatibility.`,
+    );
+  }
+
+  async enable(): Promise<void> {
+    return this.runSystemdCommand('enable', 'enabled');
+  }
+
+  async disable(): Promise<void> {
+    return this.runSystemdCommand('disable', 'disabled');
+  }
+}
+
+// TODO: Windows
 export function getSocketCompatibility(): SocketCompatibility {
   switch (process.platform) {
     case 'darwin':
       return new DarwinSocketCompatibility();
+    case 'linux':
+      return new LinuxSocketCompatibility();
     default:
       throw new Error(`Unsupported platform ${process.platform}`);
   }

--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -639,8 +639,8 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
   extensionContext.subscriptions.push(disguisedPodmanSocketWatcher);
 
   // Compatibility mode status bar item
-  // only available for macOS (for now).
-  if (isMac()) {
+  // only available for macOS or Linux (for now).
+  if (isMac() || isLinux()) {
     // Get the socketCompatibilityClass for the current OS.
     const socketCompatibilityMode = getSocketCompatibility();
 
@@ -662,6 +662,7 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
       // Manually check to see if the socket is disguised (this will be called when pressing the status bar item)
       const isDisguisedPodmanSocket = await isDisguisedPodman();
 
+      // We use isEnabled() as we do not want to "renable" again if the user has already enabled it.
       if (!isDisguisedPodmanSocket && !socketCompatibilityMode.isEnabled()) {
         const result = await extensionApi.window.showInformationMessage(
           `Do you want to automatically enable Docker socket compatibility mode for Podman?\n\n${socketCompatibilityMode.details}`,


### PR DESCRIPTION
feat: add compatibility button for Linux using flatpak-spawn

### What does this PR do?

* Uses flatpak-spawn
* Adds a compatibility button that will enable / disable the systemd
  podman.socket that allows Docker compatibility
* Refactors the runSudoHelperCommand function so that both macOS and
  Linux implementations can use it

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

Closes the rest of https://github.com/containers/podman-desktop/issues/1447

### How to test this PR?

<!-- Please explain steps to reproduce -->

1. Use Linux
2. `yarn watch`
3. Click on the compatibility mode and follow the steps to enable /
   disable.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
