### PR TITLE
feat: Telemetry prompt in Welcome page

### DIFF
--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1375,6 +1375,10 @@ export class PluginSystem {
       return telemetry.track(PAGE_EVENT_TYPE, { name: name });
     });
 
+    this.ipcHandle('telemetry:configure', async (): Promise<void> => {
+      return telemetry.configureTelemetry();
+    });
+
     const dockerDesktopInstallation = new DockerDesktopInstallation(
       apiSender,
       containerProviderRegistry,

--- a/packages/main/src/plugin/telemetry/telemetry-settings.ts
+++ b/packages/main/src/plugin/telemetry/telemetry-settings.ts
@@ -1,0 +1,23 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+export enum TelemetrySettings {
+  SectionName = 'telemetry',
+  Check = 'check',
+  Enabled = 'enabled',
+}

--- a/packages/main/src/plugin/telemetry/telemetry.ts
+++ b/packages/main/src/plugin/telemetry/telemetry.ts
@@ -100,8 +100,9 @@ export class Telemetry {
     // needs to prompt the user for the first time he launches the app
     if (check) {
       const enabled = telemetryConfiguration.get<boolean>(TelemetrySettings.Enabled);
-      if (enabled === true) await this.configureTelemetry();
-      else {
+      if (enabled === true) {
+        await this.configureTelemetry();
+      } else {
         this.telemetryInitialized = true;
 
         // clear pending items
@@ -121,7 +122,9 @@ export class Telemetry {
   }
 
   async configureTelemetry(): Promise<void> {
-    if (this.telemetryInitialized) return;
+    if (this.telemetryInitialized) {
+      return;
+    }
 
     await this.initTelemetry();
 

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -1177,6 +1177,10 @@ function initExposure(): void {
     return ipcInvoke('telemetry:page', name);
   });
 
+  contextBridge.exposeInMainWorld('telemetryConfigure', async (): Promise<void> => {
+    return ipcInvoke('telemetry:configure');
+  });
+
   let onDataCallbacksShellInContainerExtensionInstallId = 0;
   const onDataCallbacksShellInContainerExtension = new Map<number, (data: string) => void>();
   const onDataCallbacksShellInContainerExtensionError = new Map<number, (data: string) => void>();

--- a/packages/renderer/src/lib/welcome/WelcomePage.spec.ts
+++ b/packages/renderer/src/lib/welcome/WelcomePage.spec.ts
@@ -83,3 +83,20 @@ test('Expect that the settings button closes the window and opens the settings',
   // and we're in the preferences
   expect(path).toBe('/preferences');
 });
+
+test('Expect that telemetry UI is hidden when telemetry has already been prompted', async () => {
+  await render(WelcomePage, { showWelcome: true, showTelemetry: false });
+  let checkbox;
+  try {
+    checkbox = screen.getByRole('checkbox', { name: 'Enable telemetry' });
+  } catch {
+    // ignore errors
+  }
+  expect(checkbox).toBe(undefined);
+});
+
+test('Expect that telemetry UI is visible when necessary', async () => {
+  await render(WelcomePage, { showWelcome: true, showTelemetry: true });
+  const checkbox = screen.getByRole('checkbox', { name: 'Enable telemetry' });
+  expect(checkbox).toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/welcome/WelcomePage.svelte
+++ b/packages/renderer/src/lib/welcome/WelcomePage.svelte
@@ -21,12 +21,16 @@ onMount(async () => {
     showWelcome = true;
   }
   const telemetryPrompt = await welcomeUtils.havePromptedForTelemetry();
-  if (!telemetryPrompt) showTelemetry = true;
+  if (!telemetryPrompt) {
+    showTelemetry = true;
+  }
 });
 
 function closeWelcome() {
   showWelcome = false;
-  if (showTelemetry) welcomeUtils.enableTelemetry(telemetry);
+  if (showTelemetry) {
+    welcomeUtils.setTelemetry(telemetry);
+  }
 }
 </script>
 

--- a/packages/renderer/src/lib/welcome/welcome-utils.ts
+++ b/packages/renderer/src/lib/welcome/welcome-utils.ts
@@ -17,6 +17,7 @@
  ***********************************************************************/
 
 import { WelcomeSettings } from '../../../../main/src/plugin/welcome/welcome-settings';
+import { TelemetrySettings } from '../../../../main/src/plugin/telemetry/telemetry-settings';
 import { CONFIGURATION_DEFAULT_SCOPE } from '../../../../main/src/plugin/configuration-registry-constants';
 
 export class WelcomeUtils {
@@ -28,6 +29,31 @@ export class WelcomeUtils {
     window.updateConfigurationValue(
       WelcomeSettings.SectionName + '.' + WelcomeSettings.Version,
       val,
+      CONFIGURATION_DEFAULT_SCOPE,
+    );
+  }
+
+  havePromptedForTelemetry(): Promise<boolean> {
+    return window.getConfigurationValue<boolean>(TelemetrySettings.SectionName + '.' + TelemetrySettings.Check);
+  }
+
+  async enableTelemetry(telemetry: boolean) {
+    console.log('Telemetry enablement: ' + telemetry);
+
+    // store if the user said yes or no to telemetry
+    window.updateConfigurationValue(
+      TelemetrySettings.SectionName + '.' + TelemetrySettings.Enabled,
+      telemetry,
+      CONFIGURATION_DEFAULT_SCOPE,
+    );
+
+    // trigger telemetry system initialization
+    if (telemetry) window.telemetryConfigure();
+
+    // save the fact that we've prompted
+    window.updateConfigurationValue(
+      TelemetrySettings.SectionName + '.' + TelemetrySettings.Check,
+      true,
       CONFIGURATION_DEFAULT_SCOPE,
     );
   }

--- a/packages/renderer/src/lib/welcome/welcome-utils.ts
+++ b/packages/renderer/src/lib/welcome/welcome-utils.ts
@@ -37,7 +37,7 @@ export class WelcomeUtils {
     return window.getConfigurationValue<boolean>(TelemetrySettings.SectionName + '.' + TelemetrySettings.Check);
   }
 
-  async enableTelemetry(telemetry: boolean) {
+  async setTelemetry(telemetry: boolean) {
     console.log('Telemetry enablement: ' + telemetry);
 
     // store if the user said yes or no to telemetry


### PR DESCRIPTION
### What does this PR do?

Moving the telemetry prompt from a standalone dialog to a section in the Welcome page. This indirectly fixes the problem of the prompt appearing underneath the main window on some OSes and provides a more natural experience.

The telemetry prompt enablement is intentionally independent from the welcome, so for example:
- New users will see the welcome with telemetry.
- Someone who used an older release (e.g. 0.11, prior to welcome) will have already responded to telemetry, so they will see the welcome without it.
- If we improve the welcome in a future release, likewise new users would see both but upgrading users wouldn't be prompted for telemetry again.

Implementation notes:
- Extracted telemetry constants into a settings file so that they can be used elsewhere cleanly.
- Removed telemetry dialog and exposed configureTelemetry() to trigger the telemetry system.
- The render layer needs to be able to access the trigger, so I exposed it to the window via index.ts.
- Added functions to welcome-utils.ts to check if we need to prompt for telemetry, and save the result.
- Added new section to WelcomePage and reformatted the container engines to match design.
- Added tests to verify when telemetry section appears.

### Screenshot/screencast of this PR

<img width="1040" alt="Screenshot 2023-04-03 at 12 55 00 PM" src="https://user-images.githubusercontent.com/19958075/229577331-365a9a01-0426-4482-a95d-f5dfe39af90a.png">

### What issues does this PR fix or reference?

Issue #664.

### How to test this PR?

To see the welcome and telemetry prompt again, delete the configuration file (e.g. .local/share/containers/podman-desktop/configuration/settings.json on Mac) or remove the telemetry and welcome settings.