### PR TITLE
fix: change the way to distinguish between prod and dev environment

### DIFF
--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -209,12 +209,12 @@ export class ExtensionLoader {
 
     let folders;
     // scan all extensions that we can find from the extensions folder
-    if (import.meta.env.PROD) {
-      // in production mode, use the extensions locally
-      folders = await this.readProductionFolders(path.join(__dirname, '../../../extensions'));
-    } else {
+    if (process.env.NODE_ENV && (process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test')) {
       // in development mode, use the extensions locally
       folders = await this.readDevelopmentFolders(path.join(__dirname, '../../../extensions'));
+    } else {
+      // in production mode, use the extensions locally
+      folders = await this.readProductionFolders(path.join(__dirname, '../../../extensions'));
     }
     const externalExtensions = await this.readExternalFolders();
     // ok now load all extensions from these folders

--- a/packages/main/src/security-restrictions.ts
+++ b/packages/main/src/security-restrictions.ts
@@ -44,7 +44,9 @@ const ALLOWED_ORIGINS_AND_PERMISSIONS = new Map<
     | 'unknown'
   >
 >(
-  process.env.NODE_ENV && (process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test') && import.meta.env.VITE_DEV_SERVER_URL
+  process.env.NODE_ENV &&
+  (process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test') &&
+  import.meta.env.VITE_DEV_SERVER_URL
     ? [[new URL(import.meta.env.VITE_DEV_SERVER_URL).origin, new Set(['clipboard-sanitized-write'])]]
     : [],
 );

--- a/packages/main/src/security-restrictions.ts
+++ b/packages/main/src/security-restrictions.ts
@@ -44,7 +44,7 @@ const ALLOWED_ORIGINS_AND_PERMISSIONS = new Map<
     | 'unknown'
   >
 >(
-  import.meta.env.DEV && import.meta.env.VITE_DEV_SERVER_URL
+  process.env.NODE_ENV && (process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test') && import.meta.env.VITE_DEV_SERVER_URL
     ? [[new URL(import.meta.env.VITE_DEV_SERVER_URL).origin, new Set(['clipboard-sanitized-write'])]]
     : [],
 );

--- a/packages/main/src/system/startup-install.ts
+++ b/packages/main/src/system/startup-install.ts
@@ -43,7 +43,7 @@ export class StartupInstall {
 
   async configure() {
     // development mode, do nothing
-    if (!import.meta.env.PROD) {
+    if (process.env.NODE_ENV && (process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test')) {
       console.log('Development mode, skipping startup install');
       return;
     }

--- a/packages/main/src/tray-animate-icon.ts
+++ b/packages/main/src/tray-animate-icon.ts
@@ -43,10 +43,10 @@ export class AnimatedTray {
     // choose right folder for resources
     // see extraResources in electron-builder config file
     let assetsFolder;
-    if (import.meta.env.PROD) {
-      assetsFolder = path.resolve(process.resourcesPath, 'packages/main/src/assets');
-    } else {
+    if (process.env.NODE_ENV && (process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test')) {
       assetsFolder = path.resolve(__dirname, '../src/assets');
+    } else {
+      assetsFolder = path.resolve(process.resourcesPath, 'packages/main/src/assets');
     }
 
     return assetsFolder;

--- a/tests/e2e.spec.ts
+++ b/tests/e2e.spec.ts
@@ -5,11 +5,11 @@ import { afterAll, beforeAll, expect, test } from 'vitest';
 let electronApp: ElectronApplication;
 
 beforeAll(async () => {
-  electronApp = await electron.launch({ 
-    args: ['.'] },
-  );
-  electronApp.process().stderr?.on('data', (error) => console.log(`stderr: ${error}`));
-  electronApp.process().stdout?.on('data', (out) => console.log(`stdout: ${out}`));
+  electronApp = await electron.launch({
+    args: ['.'],
+  });
+  electronApp.process().stderr?.on('data', error => console.log(`stderr: ${error}`));
+  electronApp.process().stdout?.on('data', out => console.log(`stdout: ${out}`));
 });
 
 afterAll(async () => {
@@ -51,5 +51,5 @@ test('Main window web content', async () => {
 
 export async function delay(ms: number) {
   console.log(`Delaying for ${ms} ms`);
-  return new Promise( resolve => setTimeout(resolve, ms) );
+  return new Promise(resolve => setTimeout(resolve, ms));
 }

--- a/tests/e2e.spec.ts
+++ b/tests/e2e.spec.ts
@@ -5,7 +5,11 @@ import { afterAll, beforeAll, expect, test } from 'vitest';
 let electronApp: ElectronApplication;
 
 beforeAll(async () => {
-  electronApp = await electron.launch({ args: ['.'] });
+  electronApp = await electron.launch({ 
+    args: ['.'] },
+  );
+  electronApp.process().stderr?.on('data', (error) => console.log(`stderr: ${error}`));
+  electronApp.process().stdout?.on('data', (out) => console.log(`stdout: ${out}`));
 });
 
 afterAll(async () => {
@@ -38,7 +42,14 @@ test('Main window state', async () => {
 
 test('Main window web content', async () => {
   const page = await electronApp.firstWindow();
+  await delay(5000);
   const element = await page.$('#app', { strict: true });
   expect(element, 'Cannot find root element').toBeDefined();
   expect((await element.innerHTML()).trim(), 'Window content was empty').not.equal('');
+  await page.screenshot({ path: 'intro.png' });
 });
+
+export async function delay(ms: number) {
+  console.log(`Delaying for ${ms} ms`);
+  return new Promise( resolve => setTimeout(resolve, ms) );
+}

--- a/types/env.d.ts
+++ b/types/env.d.ts
@@ -14,6 +14,10 @@ interface ImportMetaEnv {
    * The value of the variable is set in scripts/watch.js and depend on packages/main/vite.config.js
    */
   readonly VITE_DEV_SERVER_URL: undefined | string;
+  /**
+   * Env. var. dedicated to distinguish between production and test environment
+   */
+  readonly VITE_TEST: undefined | string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
### What does this PR do?

Changes the way how to distinguish between PROD and DEV environment when running e2e tests.

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?
#1780 
<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

### How to test this PR?
```
yarn 
yarn test:e2e -> watch for a properly initialized podman-desktop
```
<!-- Please explain steps to reproduce -->
We just make sure to run e2e tests properly, when we distinguish between prod and dev environment. Some icons were not loaded properly when playwright tests were executed and so the app never loaded up.