### PR TITLE
chore: Add architecture to telemetry

### DIFF
--- a/packages/main/src/plugin/telemetry/telemetry.ts
+++ b/packages/main/src/plugin/telemetry/telemetry.ts
@@ -261,6 +261,7 @@ export class Telemetry {
       os: {
         name: this.getPlatform(),
         version: os.release(),
+        arch: os.arch(),
       },
       locale,
       location: {


### PR DESCRIPTION
### What does this PR do?

We noticed today that the telemetry data doesn't include architecture, so we can't tell (e.g.) how many Mac or Windows users are on x86 vs arm.

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Enable telemetry, and either set a breakpoint/log or look in Segment to confirm the new attribute is added.