### PR TITLE
fix: File preference alignment

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
@@ -240,7 +240,7 @@ function handleCleanValue(
     {:else if record.type === 'string' && record.format === 'file'}
       <div class="w-full flex">
         <input
-          class="w-5/6 {!recordValue ? 'mr-3' : ''} py-1 px-2 outline-0 text-sm"
+          class="grow {!recordValue ? 'mr-3' : ''} py-1 px-2 outline-0 text-sm"
           name="{record.id}"
           readonly
           type="text"


### PR DESCRIPTION
### What does this PR do?

I noticed during the demo today that if your screen is wide, any file preferences do not take the full width: there is a gap on the right of the Browse button. This just fixes the alignment by making the file input grow.

### Screenshot/screencast of this PR

Before:
<img width="1060" alt="Screenshot 2023-04-04 at 5 51 14 PM" src="https://user-images.githubusercontent.com/19958075/229931153-910b42fd-ba10-45af-9fdc-8717ff4125af.png">

After:
<img width="1060" alt="Screenshot 2023-04-04 at 5 51 30 PM" src="https://user-images.githubusercontent.com/19958075/229931183-ce6b6589-6c42-4331-b4af-f7d551286933.png">

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Go to preferences and make your screen fairly wide.
