### PR TITLE
fix: stop all extensions while quitting the application

### DIFF
--- a/packages/main/src/index.ts
+++ b/packages/main/src/index.ts
@@ -24,7 +24,9 @@ import { isMac, isWindows } from './util';
 import { AnimatedTray } from './tray-animate-icon';
 import { PluginSystem } from './plugin';
 import { StartupInstall } from './system/startup-install';
+import type { ExtensionLoader } from './plugin/extension-loader';
 
+let extensionLoader: ExtensionLoader | undefined;
 /**
  * Prevent multiple instances
  */
@@ -49,6 +51,16 @@ app.on('window-all-closed', () => {
   }
 });
 
+app.on('before-quit', () => {
+  extensionLoader
+    ?.stopAllExtensions()
+    .then(() => {
+      console.log('Stopped all extensions');
+    })
+    .catch(error => {
+      console.log('Error stopping extensions', error);
+    });
+});
 /**
  *  @see https://www.electronjs.org/docs/latest/api/app#appsetappusermodelidid-windows
  */
@@ -82,7 +94,7 @@ app.whenReady().then(
 
     // Start extensions
     const pluginSystem = new PluginSystem(trayMenu);
-    const extensionLoader = await pluginSystem.initExtensions();
+    extensionLoader = await pluginSystem.initExtensions();
 
     // Get the configuration registry (saves all our settings)
     const configurationRegistry = extensionLoader.getConfigurationRegistry();

--- a/packages/main/src/index.ts
+++ b/packages/main/src/index.ts
@@ -51,7 +51,7 @@ app.on('window-all-closed', () => {
   }
 });
 
-app.on('before-quit', () => {
+app.once('before-quit', () => {
   extensionLoader
     ?.stopAllExtensions()
     .then(() => {

--- a/packages/main/src/plugin/index.spec.ts
+++ b/packages/main/src/plugin/index.spec.ts
@@ -32,6 +32,13 @@ const webContents = emitter as unknown as WebContents;
 webContents.send = vi.fn();
 
 beforeAll(() => {
+  vi.mock('electron', () => {
+    return {
+      app: {
+        on: vi.fn(),
+      },
+    };
+  });
   const trayMenuMock = {} as unknown as TrayMenu;
   pluginSystem = new PluginSystem(trayMenuMock);
 });


### PR DESCRIPTION
### What does this PR do?
Will stop all extensions on quitting Podman Desktop
### Screenshot/screencast of this PR
N/A
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?
Part 1 for the fix of https://github.com/containers/podman-desktop/issues/1661
<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

### How to test this PR?
Start Podman Desktop with no machines running. The autostart handler will start a machine. On quit, the machine will be stopped.
<!-- Please explain steps to reproduce -->
