### PR TITLE
fix: Rename default Kind cluster

### DIFF
--- a/extensions/kind/package.json
+++ b/extensions/kind/package.json
@@ -16,7 +16,7 @@
       "properties": {
         "kind.cluster.creation.name": {
           "type": "string",
-          "default": "podman-desktop",
+          "default": "kind-cluster",
           "scope": "KubernetesProviderConnectionFactory",
           "description": "Name"
         },


### PR DESCRIPTION
### What does this PR do?

Change the default name of a kind cluster from "podman-desktop" to "kind-cluster".

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

Fixes #1952.

### How to test this PR?

Create a kind cluster.