### PR TITLE
nit: make warnings more subtle

### DIFF
--- a/extensions/podman/src/warnings.ts
+++ b/extensions/podman/src/warnings.ts
@@ -21,8 +21,7 @@ import * as os from 'node:os';
 import * as http from 'node:http';
 
 // Explanations
-const detailsExplanation = 'Podman is not emulating the default Docker socket path: ';
-const detailsNotWorking = '. Docker-specific tools may not work.';
+const detailsExplanation = 'Docker-specific tools may not work.';
 
 // Default socket paths
 const windowsSocketPath = '//./pipe/docker_engine';
@@ -35,21 +34,19 @@ export function getDisguisedPodmanInformation(): extensionApi.ProviderInformatio
   // Set the details message based on the OS
   switch (os.platform()) {
     case 'win32':
-      details = detailsExplanation.concat(windowsSocketPath, detailsNotWorking);
+      details = detailsExplanation;
       break;
     case 'darwin':
       // Due to how `podman-mac-helper` does not (by default) map the emulator to /var/run/docker.sock, we need to explain
       // that the user must go on the Podman Desktop website for more information. This is because the user must manually
       // map the socket to /var/run/docker.sock if not done by `podman machine` already (podman machine automatically maps the socket if Docker is not running)
       details = detailsExplanation.concat(
-        defaultSocketPath,
-        detailsNotWorking,
         // eslint-disable-next-line quotes
         ` Press 'Docker Compatibility' button to enable.`,
       );
       break;
     default:
-      details = detailsExplanation.concat(defaultSocketPath, detailsNotWorking);
+      details = detailsExplanation;
       break;
   }
 

--- a/packages/renderer/src/lib/dashboard/ProviderWarnings.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderWarnings.svelte
@@ -16,9 +16,10 @@ $: {
   <!-- TODO: Add dismiss button / ignore warning? -->
   {#if providerInfo?.warnings?.length > 0}
     {#each providerInfo.warnings as warn}
-      <div class="flex-row items-center mt-0.5">
-        ⚠️
-        <span class="ml-1 text-sm text-gray-200 font-semibold">{warn.name}:</span>
+      <div class="flex-row items-center align-middle mt-0.5">
+        <!-- Make line height center-->
+        <span class="ml-1 text-md text-gray-400">⚠</span>
+        <span class="ml-1 text-sm text-gray-400">{warn.name}:</span>
         <span class="ml-1 text-sm text-gray-400">{warn.details}</span>
       </div>
     {/each}


### PR DESCRIPTION
nit: make warnings more subtle

### What does this PR do?

Temporary measure until we implement a better dashboard UI, but reduce
the "boldness" of the warnings and make it more subtle as to not
distract from other parts of Podman Desktop.

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
![Screenshot 2023-04-05 at 12 38 51 PM](https://user-images.githubusercontent.com/6422176/230147332-8ea7baf2-55b8-4507-8ed5-aa0d480b8970.png)



### What issues does this PR fix or reference?

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

### How to test this PR?

<!-- Please explain steps to reproduce -->

`yarn watch`

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
