### PR TITLE
fix: allow to cancel creation of new kubernetes connection

### DIFF
--- a/extensions/kind/src/create-cluster.ts
+++ b/extensions/kind/src/create-cluster.ts
@@ -23,6 +23,7 @@ import { runCliCommand } from './util';
 import mustache from 'mustache';
 
 import createClusterConfTemplate from './templates/create-cluster-conf.mustache?raw';
+import type { CancellationToken } from '@podman-desktop/api';
 
 export function getKindClusterConfig(clusterName: string, httpHostPort: number, httpsHostPort: number) {
   return mustache.render(createClusterConfTemplate, {
@@ -37,6 +38,7 @@ export async function createCluster(
   params: { [key: string]: any },
   logger: extensionApi.Logger,
   kindCli: string,
+  token?: CancellationToken,
 ): Promise<void> {
   let clusterName = 'kind';
   if (params['kind.cluster.creation.name']) {
@@ -80,7 +82,7 @@ export async function createCluster(
   await fs.promises.writeFile(tmpFilePath, kindClusterConfig, 'utf8');
 
   // now execute the command to create the cluster
-  const result = await runCliCommand(kindCli, ['create', 'cluster', '--config', tmpFilePath], { env, logger });
+  const result = await runCliCommand(kindCli, ['create', 'cluster', '--config', tmpFilePath], { env, logger }, token);
 
   // delete temporary directory/file
   await fs.promises.rm(tmpDirectory, { recursive: true });

--- a/extensions/kind/src/extension.ts
+++ b/extensions/kind/src/extension.ts
@@ -19,7 +19,7 @@
 import * as extensionApi from '@podman-desktop/api';
 import { detectKind } from './util';
 import { KindInstaller } from './kind-installer';
-import type { Logger } from '@podman-desktop/api';
+import type { CancellationToken, Logger } from '@podman-desktop/api';
 import { window } from '@podman-desktop/api';
 import { ImageHandler } from './image-handler';
 import { createCluster } from './create-cluster';
@@ -50,7 +50,8 @@ const imageHandler = new ImageHandler();
 function registerProvider(extensionContext: extensionApi.ExtensionContext, provider: extensionApi.Provider): void {
   const disposable = provider.setKubernetesProviderConnectionFactory({
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    create: (params: { [key: string]: any }, logger?: Logger) => createCluster(params, logger, kindCli),
+    create: (params: { [key: string]: any }, logger?: Logger, token?: CancellationToken) =>
+      createCluster(params, logger, kindCli, token),
     creationDisplayName: 'Kind cluster',
   });
   extensionContext.subscriptions.push(disposable);

--- a/extensions/kind/src/util.ts
+++ b/extensions/kind/src/util.ts
@@ -120,7 +120,7 @@ export function runCliCommand(
       } else {
         spawnProcess.kill();
       }
-
+      options?.logger?.error('Execution cancelled');
       // reject the promise
       reject(new Error('Execution cancelled'));
     });

--- a/extensions/kind/src/util.ts
+++ b/extensions/kind/src/util.ts
@@ -18,6 +18,7 @@
 
 import * as os from 'node:os';
 import * as path from 'node:path';
+import type { ChildProcess } from 'node:child_process';
 import { spawn } from 'node:child_process';
 import type * as extensionApi from '@podman-desktop/api';
 import type { KindInstaller } from './kind-installer';
@@ -115,11 +116,7 @@ export function runCliCommand(
 
     // if the token is cancelled, kill the process and reject the promise
     token?.onCancellationRequested(() => {
-      if (isWindows()) {
-        spawn('taskkill', ['/pid', spawnProcess.pid?.toString(), '/f', '/t']);
-      } else {
-        spawnProcess.kill();
-      }
+      killProcess(spawnProcess);
       options?.logger?.error('Execution cancelled');
       // reject the promise
       reject(new Error('Execution cancelled'));
@@ -157,4 +154,12 @@ export function runCliCommand(
       resolve({ exitCode, stdOut, stdErr, error: err });
     });
   });
+}
+
+function killProcess(spawnProcess: ChildProcess) {
+  if (isWindows()) {
+    spawn('taskkill', ['/pid', spawnProcess.pid?.toString(), '/f', '/t']);
+  } else {
+    spawnProcess.kill();
+  }
 }

--- a/extensions/podman/src/podman-cli.ts
+++ b/extensions/podman/src/podman-cli.ts
@@ -89,6 +89,7 @@ export function execPromise(
     token?.onCancellationRequested(() => {
       process.kill();
       // reject the promise
+      options?.logger?.error('Execution cancelled');
       reject(new Error('Execution cancelled'));
     });
     process.on('error', error => {

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -242,7 +242,7 @@ declare module '@podman-desktop/api' {
   // create a kubernetes provider
   export interface KubernetesProviderConnectionFactory extends ProviderConnectionFactory {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    create?(params: { [key: string]: any }, logger?: Logger): Promise<void>;
+    create?(params: { [key: string]: any }, logger?: Logger, token?: CancellationToken): Promise<void>;
   }
 
   export interface Link {

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1285,10 +1285,15 @@ export class PluginSystem {
         internalProviderId: string,
         params: { [key: string]: unknown },
         loggerId: string,
+        tokenId?: number,
       ): Promise<void> => {
         const logger = this.getLogHandlerCreateConnection('provider-registry:taskConnection-onData', loggerId);
-
-        await providerRegistry.createKubernetesProviderConnection(internalProviderId, params, logger);
+        let token;
+        if (tokenId) {
+          const tokenSource = cancellationTokenRegistry.getCancellationTokenSource(tokenId);
+          token = tokenSource?.token;
+        }
+        await providerRegistry.createKubernetesProviderConnection(internalProviderId, params, logger, token);
         logger.onEnd();
       },
     );

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1273,8 +1273,11 @@ export class PluginSystem {
           const tokenSource = cancellationTokenRegistry.getCancellationTokenSource(tokenId);
           token = tokenSource?.token;
         }
-        await providerRegistry.createContainerProviderConnection(internalProviderId, params, logger, token);
-        logger.onEnd();
+        try {
+          await providerRegistry.createContainerProviderConnection(internalProviderId, params, logger, token);
+        } finally {
+          logger.onEnd();
+        }
       },
     );
 
@@ -1293,8 +1296,11 @@ export class PluginSystem {
           const tokenSource = cancellationTokenRegistry.getCancellationTokenSource(tokenId);
           token = tokenSource?.token;
         }
-        await providerRegistry.createKubernetesProviderConnection(internalProviderId, params, logger, token);
-        logger.onEnd();
+        try {
+          await providerRegistry.createKubernetesProviderConnection(internalProviderId, params, logger, token);
+        } finally {
+          logger.onEnd();
+        }
       },
     );
 

--- a/packages/main/src/plugin/provider-registry.ts
+++ b/packages/main/src/plugin/provider-registry.ts
@@ -635,6 +635,7 @@ export class ProviderRegistry {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     params: { [key: string]: any },
     logHandler: Logger,
+    token?: CancellationToken,
   ): Promise<void> {
     // grab the correct provider
     const provider = this.getMatchingProvider(internalProviderId);
@@ -642,7 +643,7 @@ export class ProviderRegistry {
     if (!provider.kubernetesProviderConnectionFactory?.create) {
       throw new Error('The provider does not support kubernetes connection creation');
     }
-    return provider.kubernetesProviderConnectionFactory.create(params, logHandler);
+    return provider.kubernetesProviderConnectionFactory.create(params, logHandler, token);
   }
 
   // helper method

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -550,6 +550,7 @@ function initExposure(): void {
       params: { [key: string]: any },
       key: symbol,
       keyLogger: (key: symbol, eventName: 'log' | 'warn' | 'error' | 'finish', args: unknown[]) => void,
+      tokenId?: number,
     ): Promise<void> => {
       onDataCallbacksTaskConnectionId++;
       onDataCallbacksTaskConnectionKeys.set(onDataCallbacksTaskConnectionId, key);
@@ -559,6 +560,7 @@ function initExposure(): void {
         internalProviderId,
         params,
         onDataCallbacksTaskConnectionId,
+        tokenId,
       );
     },
   );

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationRendering.svelte
@@ -166,14 +166,11 @@ function getLoggerHandler(): ConnectionCallback {
 async function ended() {
   creationInProgress = false;
   tokenId = undefined;
-  if (creationCancelled || creationFailed) {
-    // the creation has been cancelled or failed
-    updateStore();
-  } else {
+  if (!creationCancelled && !creationFailed) {
     window.dispatchEvent(new CustomEvent('provider-lifecycle-change'));
     creationSuccessful = true;
-    updateStore();
   }
+  updateStore();
 }
 
 async function cleanup() {

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationRendering.svelte
@@ -37,6 +37,7 @@ let creationInProgress = false;
 let creationStarted = false;
 let creationSuccessful = false;
 let creationCancelled = false;
+let creationFailed = false;
 export let pageIsLoading = true;
 let showLogs = false;
 let tokenId: number;
@@ -153,6 +154,7 @@ function getLoggerHandler(): ConnectionCallback {
       writeToTerminal(logsTerminal, args, '\x1b[33m');
     },
     error: args => {
+      creationFailed = true;
       writeToTerminal(logsTerminal, args, '\x1b[1;31m');
     },
     onEnd: () => {
@@ -164,15 +166,14 @@ function getLoggerHandler(): ConnectionCallback {
 async function ended() {
   creationInProgress = false;
   tokenId = undefined;
-  if (creationCancelled) {
-    // the creation has been cancelled
+  if (creationCancelled || creationFailed) {
+    // the creation has been cancelled or failed
     updateStore();
-    return;
+  } else {
+    window.dispatchEvent(new CustomEvent('provider-lifecycle-change'));
+    creationSuccessful = true;
+    updateStore();
   }
-
-  window.dispatchEvent(new CustomEvent('provider-lifecycle-change'));
-  creationSuccessful = true;
-  updateStore();
 }
 
 async function cleanup() {
@@ -186,6 +187,7 @@ async function cleanup() {
   showLogs = false;
   creationInProgress = false;
   creationStarted = false;
+  creationFailed = false;
   creationCancelled = false;
   creationSuccessful = false;
   updateStore();
@@ -219,6 +221,8 @@ async function handleOnSubmit(e) {
   // send the data to the right provider
   creationInProgress = true;
   creationStarted = true;
+  creationFailed = false;
+  creationCancelled = false;
 
   try {
     tokenId = await window.getCancellableTokenSource();
@@ -233,7 +237,6 @@ async function handleOnSubmit(e) {
     await callback(providerInfo.internalId, data, loggerHandlerKey, eventCollect, tokenId);
   } catch (error) {
     //display error
-    creationInProgress = false;
     tokenId = undefined;
     // filter cancellation message to avoid displaying error and allow user to restart the creation
     if (error.message && error.message.indexOf('Execution cancelled') >= 0) {
@@ -248,7 +251,6 @@ async function cancel() {
   if (tokenId) {
     await window.cancelToken(tokenId);
     creationCancelled = true;
-    creationInProgress = false;
     tokenId = undefined;
   }
 }


### PR DESCRIPTION
### What does this PR do?

This PR allows to cancel the creation of a new kind connection. It also fixes a misbehavior on the task manager (if the creation was cancelled the task appeared to be on running)

### Screenshot/screencast of this PR

![cancel-kube-creation](https://user-images.githubusercontent.com/49404737/230148117-191b7691-6650-41d6-a277-ba9b021d70f8.gif)

### What issues does this PR fix or reference?

it is part of #1337 

### How to test this PR?

1. create a new kind cluster and cancel the creation
