### PR TITLE
fix: update kubernetes clusters state on the resources page (#1883)

### DIFF
--- a/packages/main/src/plugin/provider-impl.ts
+++ b/packages/main/src/plugin/provider-impl.ts
@@ -199,9 +199,11 @@ export class ProviderImpl implements Provider, IDisposable {
 
   registerKubernetesProviderConnection(kubernetesProviderConnection: KubernetesProviderConnection): Disposable {
     this.kubernetesProviderConnections.add(kubernetesProviderConnection);
+    const disposable = this.providerRegistry.registerKubernetesConnection(this, kubernetesProviderConnection);
     this.providerRegistry.onDidRegisterKubernetesConnectionCallback(this, kubernetesProviderConnection);
     return Disposable.create(() => {
       this.kubernetesProviderConnections.delete(kubernetesProviderConnection);
+      disposable.dispose();
       this.providerRegistry.onDidUnregisterKubernetesConnectionCallback(this, kubernetesProviderConnection);
     });
   }

--- a/packages/main/src/plugin/provider-registry.spec.ts
+++ b/packages/main/src/plugin/provider-registry.spec.ts
@@ -157,3 +157,22 @@ test('expect isProviderContainerConnection returns false with a ProviderKubernet
   const res = providerRegistry.isProviderContainerConnection(connection);
   expect(res).toBe(false);
 });
+
+test('should register kubernetes provider', async () => {
+  const provider = providerRegistry.createProvider({ id: 'internal', name: 'internal', status: 'installed' });
+  const connection: KubernetesProviderConnection = {
+    name: 'connection',
+    endpoint: {
+      apiURL: 'url',
+    },
+    lifecycle: undefined,
+    status: () => 'started',
+  };
+
+  providerRegistry.registerKubernetesConnection(provider, connection);
+
+  expect(telemetryTrackMock).toHaveBeenLastCalledWith('registerKubernetesProviderConnection', {
+    name: 'connection',
+    total: 1,
+  });
+});


### PR DESCRIPTION
### What does this PR do?

This PR refresh the UI when the state of a kind cluster changes 

### Screenshot/screencast of this PR

![update-kind-cluster-state](https://user-images.githubusercontent.com/49404737/230164670-03fceffe-1035-4a94-84f8-ce74adb3ba02.gif)

### What issues does this PR fix or reference?

it resolves #1883 

### How to test this PR?

1. start/stop a kind cluster and verify the state is updated in the resources page
