### PR TITLE
feat: prompt user for binary global install

### DIFF
--- a/extensions/kind/package.json
+++ b/extensions/kind/package.json
@@ -42,7 +42,6 @@
           "scope": "KubernetesProviderConnectionFactory",
           "description": "HTTPS Port"
         }
-
       }
     },
     "menus": {
@@ -61,9 +60,10 @@
     "watch": "vite build -w"
   },
   "dependencies": {
-    "@podman-desktop/api": "^0.0.1",
     "@octokit/rest": "^19.0.7",
-    "mustache": "^4.2.0"
+    "@podman-desktop/api": "^0.0.1",
+    "mustache": "^4.2.0",
+    "sudo-prompt": "^9.2.1"
   },
   "devDependencies": {
     "7zip-min": "^1.4.4",

--- a/extensions/kind/src/kind-installer.spec.ts
+++ b/extensions/kind/src/kind-installer.spec.ts
@@ -16,9 +16,11 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import { tmpName } from 'tmp-promise';
 import { beforeEach, expect, test, vi } from 'vitest';
 import { KindInstaller } from './kind-installer';
 import * as extensionApi from '@podman-desktop/api';
+import { installBinaryToSystem } from './util';
 
 let installer: KindInstaller;
 
@@ -26,6 +28,7 @@ vi.mock('@podman-desktop/api', async () => {
   return {
     window: {
       showInformationMessage: vi.fn().mockReturnValue(Promise.resolve('Yes')),
+      showErrorMessage: vi.fn(),
       withProgress: vi.fn(),
       showNotification: vi.fn(),
     },
@@ -51,9 +54,47 @@ const telemetryLoggerMock = {
   logError: telemetryLogErrorMock,
 } as unknown as extensionApi.TelemetryLogger;
 
+vi.mock('runCliCommand', async () => {
+  return vi.fn();
+});
+
 beforeEach(() => {
   installer = new KindInstaller('.', telemetryLoggerMock);
   vi.clearAllMocks();
+});
+
+test('expect installBinaryToSystem to succesfully pass with a binary', async () => {
+  // Mock process.platform to be linux
+  // to avoid the usage of sudo-prompt (we cannot test that in unit tests)
+  Object.defineProperty(process, 'platform', {
+    value: 'linux',
+  });
+
+  // Create a tmp file using tmp-promise
+  const filename = await tmpName();
+
+  // "Install" the binary, this should pass sucessfully
+  try {
+    await installBinaryToSystem(filename, 'tmpBinary');
+  } catch (err) {
+    expect(err).toBeUndefined();
+  }
+});
+
+test('error: expect installBinaryToSystem to fail with a non existing binary', async () => {
+  Object.defineProperty(process, 'platform', {
+    value: 'linux',
+  });
+
+  // Run installBinaryToSystem with a non-binary file
+  try {
+    await installBinaryToSystem('test', 'tmpBinary');
+    // Expect that showErrorMessage is called
+    expect(extensionApi.window.showErrorMessage).toHaveBeenCalled();
+  } catch (err) {
+    expect(err).to.be.a('Error');
+    expect(err).toBeDefined();
+  }
 });
 
 test('expect showNotification to be called', async () => {
@@ -72,6 +113,8 @@ test('expect showNotification to be called', async () => {
       dispose: () => {},
     };
   });
+
+  // Check that install passes
   const result = await installer.performInstall();
   expect(telemetryLogErrorMock).not.toBeCalled();
   expect(telemetryLogUsageMock).toHaveBeenNthCalledWith(1, 'install-kind-prompt');
@@ -80,5 +123,10 @@ test('expect showNotification to be called', async () => {
 
   expect(result).toBeDefined();
   expect(result).toBeTruthy();
+
+  // Check that showNotification is called
   expect(spy).toBeCalled();
+
+  // Expect showInformationMessage to be shown and be asking for installing it system wide
+  expect(extensionApi.window.showInformationMessage).toBeCalled();
 });

--- a/extensions/kind/src/util.ts
+++ b/extensions/kind/src/util.ts
@@ -20,6 +20,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import type { ChildProcess } from 'node:child_process';
 import { spawn } from 'node:child_process';
+import * as sudo from 'sudo-prompt';
 import type * as extensionApi from '@podman-desktop/api';
 import type { KindInstaller } from './kind-installer';
 import type { CancellationToken } from '@podman-desktop/api';
@@ -154,6 +155,68 @@ export function runCliCommand(
       resolve({ exitCode, stdOut, stdErr, error: err });
     });
   });
+}
+
+// Takes a binary path (e.g. /tmp/kind) and installs it to the system. Renames it based on binaryName
+// supports Windows, Linux and macOS
+// If using Windows or Mac, we will use sudo-prompt in order to elevate the privileges
+// If using Linux, we'll use pkexec and polkit support to ask for privileges.
+// When running in a flatpak, we'll use flatpak-spawn to execute the command on the host
+export async function installBinaryToSystem(binaryPath: string, binaryName: string): Promise<void> {
+  const system = process.platform;
+
+  // Before copying the file, make sure it's executable (chmod +x) for Linux and Mac
+  if (system === 'linux' || system === 'darwin') {
+    try {
+      await runCliCommand('chmod', ['+x', binaryPath]);
+      console.log(`Made ${binaryPath} executable`);
+    } catch (error) {
+      throw new Error(`Error making binary executable: ${error}`);
+    }
+  }
+
+  // Create the appropriate destination path (Windows uses AppData/Local, Linux and Mac use /usr/local/bin)
+  // and the appropriate command to move the binary to the destination path
+  let destinationPath: string;
+  let command: string[];
+  if (system == 'win32') {
+    destinationPath = path.join(os.homedir(), 'AppData', 'Local', 'Microsoft', 'WindowsApps', `${binaryName}.exe`);
+    command = ['copy', binaryPath, destinationPath];
+  } else {
+    destinationPath = path.join('/usr/local/bin', binaryName);
+    command = ['cp', binaryPath, destinationPath];
+  }
+
+  // If windows or mac, use sudo-prompt to elevate the privileges
+  // if Linux, use sudo and polkit support
+  if (system === 'win32' || system === 'darwin') {
+    return new Promise<void>((resolve, reject) => {
+      // Convert the command array to a string for sudo prompt
+      // the name is used for the prompt
+      const sudoOptions = {
+        name: `${binaryName} Binary Installation`,
+      };
+      const sudoCommand = command.join(' ');
+      sudo.exec(sudoCommand, sudoOptions, error => {
+        if (error) {
+          console.error(`Failed to install '${binaryName}' binary: ${error}`);
+          reject(error);
+        } else {
+          console.log(`Successfully installed '${binaryName}' binary.`);
+          resolve();
+        }
+      });
+    });
+  } else {
+    try {
+      // Use pkexec in order to elevate the prileges / ask for password for copying to /usr/local/bin
+      await runCliCommand('pkexec', command);
+      console.log(`Successfully installed '${binaryName}' binary.`);
+    } catch (error) {
+      console.error(`Failed to install '${binaryName}' binary: ${error}`);
+      throw error;
+    }
+  }
 }
 
 function killProcess(spawnProcess: ChildProcess) {


### PR DESCRIPTION
feat: prompt user for binary global install

### What does this PR do?

* Asks the user after Kind download if they would like to install the
  binary globally to be used in the command line
* Works for Linux / Mac / Windows

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

![Screenshot 2023-04-05 at 3 42 05 PM](https://user-images.githubusercontent.com/6422176/230199255-68816312-054b-410f-ab33-eadc707e7517.png)

https://user-images.githubusercontent.com/6422176/231498942-61c402a3-1d98-426f-b005-d572611d90bf.mov




### What issues does this PR fix or reference?

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

Closes https://github.com/containers/podman-desktop/issues/1516

### How to test this PR?

1. Remove the kind binary from your
   `.local/share/containers/podman-desktop` folder so you can trigger a
   new download
 2. `yarn watch`
 3. Click on the kind button and follow the prompts

<!-- Please explain steps to reproduce -->

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
