### PR TITLE
fix: allow to enable/disable autosave on input item

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItem.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItem.svelte
@@ -79,7 +79,8 @@ $: resetToDefault = false;
         showUpdate="{false}"
         record="{recordUI.original}"
         updateResetButtonVisibility="{updateResetButtonVisibility}"
-        resetToDefault="{resetToDefault}" />
+        resetToDefault="{resetToDefault}"
+        enableAutoCompletion="{true}" />
     {/if}
   </div>
   {#if recordUI.original.type !== 'string' || (recordUI.original.enum && recordUI.original.enum.length > 0)}
@@ -87,6 +88,7 @@ $: resetToDefault = false;
       showUpdate="{false}"
       record="{recordUI.original}"
       updateResetButtonVisibility="{updateResetButtonVisibility}"
-      resetToDefault="{resetToDefault}" />
+      resetToDefault="{resetToDefault}"
+      enableAutoCompletion="{true}" />
   {/if}
 </div>

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItem.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItem.svelte
@@ -80,7 +80,7 @@ $: resetToDefault = false;
         record="{recordUI.original}"
         updateResetButtonVisibility="{updateResetButtonVisibility}"
         resetToDefault="{resetToDefault}"
-        enableAutoCompletion="{true}" />
+        enableAutoSave="{true}" />
     {/if}
   </div>
   {#if recordUI.original.type !== 'string' || (recordUI.original.enum && recordUI.original.enum.length > 0)}
@@ -89,6 +89,6 @@ $: resetToDefault = false;
       record="{recordUI.original}"
       updateResetButtonVisibility="{updateResetButtonVisibility}"
       resetToDefault="{resetToDefault}"
-      enableAutoCompletion="{true}" />
+      enableAutoSave="{true}" />
   {/if}
 </div>

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.spec.ts
@@ -16,13 +16,22 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-unused-vars */
+/* eslint-disable @typescript-eslint/no-empty-function */
+
 import '@testing-library/jest-dom';
-import { test, expect } from 'vitest';
+import { test, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/svelte';
+import type { IConfigurationPropertyRecordedSchema } from '../../../../main/src/plugin/configuration-registry';
 import PreferencesRenderingItemFormat from './PreferencesRenderingItemFormat.svelte';
 
+beforeAll(() => {
+  (window as any).getConfigurationValue = vi.fn();
+});
+
 test('Expect to see checkbox enabled', async () => {
-  const record = {
+  const record: IConfigurationPropertyRecordedSchema = {
     title: 'my boolean property',
     id: 'myid',
     parentId: '',
@@ -30,14 +39,14 @@ test('Expect to see checkbox enabled', async () => {
     default: true,
   };
   // remove display name
-  render(PreferencesRenderingItemFormat, { record: record });
+  render(PreferencesRenderingItemFormat, { record });
   const button = screen.getByRole('checkbox');
   expect(button).toBeInTheDocument();
   expect(button).toBeChecked();
 });
 
 test('Expect to see checkbox enabled', async () => {
-  const record = {
+  const record: IConfigurationPropertyRecordedSchema = {
     title: 'my boolean property',
     id: 'myid',
     parentId: '',
@@ -45,8 +54,110 @@ test('Expect to see checkbox enabled', async () => {
     default: false,
   };
   // remove display name
-  render(PreferencesRenderingItemFormat, { record: record });
+  render(PreferencesRenderingItemFormat, { record });
   const button = screen.getByRole('checkbox');
   expect(button).toBeInTheDocument();
   expect(button).not.toBeChecked();
+});
+
+test('Expect a checkbox when record is type boolean', async () => {
+  const record: IConfigurationPropertyRecordedSchema = {
+    title: 'record',
+    parentId: 'parent.record',
+    description: 'record-description',
+    type: 'boolean',
+  };
+  await render(PreferencesRenderingItemFormat, {
+    record,
+  });
+  const input = screen.getByLabelText('record-description');
+  expect(input).toBeInTheDocument();
+  expect(input instanceof HTMLInputElement).toBe(true);
+  expect((input as HTMLInputElement).type).toBe('checkbox');
+});
+
+test('Expect a slider when record and its maximum are type number and enableSlider is true', async () => {
+  const record: IConfigurationPropertyRecordedSchema = {
+    title: 'record',
+    parentId: 'parent.record',
+    description: 'record-description',
+    type: 'number',
+    minimum: 1,
+    maximum: 34,
+  };
+  await render(PreferencesRenderingItemFormat, {
+    record,
+    enableSlider: true,
+  });
+  const input = screen.getByLabelText('record-description');
+  expect(input).toBeInTheDocument();
+  expect(input instanceof HTMLInputElement).toBe(true);
+  expect((input as HTMLInputElement).type).toBe('range');
+});
+
+test('Expect a text input when record is type number and enableSlider is false', async () => {
+  const record: IConfigurationPropertyRecordedSchema = {
+    title: 'record',
+    parentId: 'parent.record',
+    description: 'record-description',
+    type: 'number',
+    minimum: 1,
+    maximum: 34,
+  };
+  await render(PreferencesRenderingItemFormat, {
+    record,
+  });
+  const input = screen.getByLabelText('record-description');
+  expect(input).toBeInTheDocument();
+  expect(input instanceof HTMLInputElement).toBe(true);
+  expect((input as HTMLInputElement).type).toBe('text');
+});
+
+test('Expect an input button with Browse as placeholder when record is type string and format file', async () => {
+  const record: IConfigurationPropertyRecordedSchema = {
+    title: 'record',
+    parentId: 'parent.record',
+    description: 'record-description',
+    type: 'string',
+    format: 'file',
+  };
+  await render(PreferencesRenderingItemFormat, {
+    record,
+  });
+  const input = screen.getByLabelText('button-record-description');
+  expect(input).toBeInTheDocument();
+  expect(input instanceof HTMLInputElement).toBe(true);
+  expect((input as HTMLInputElement).placeholder).toBe('Browse ...');
+});
+
+test('Expect a select when record is type string and has enum values', async () => {
+  const record: IConfigurationPropertyRecordedSchema = {
+    title: 'record',
+    parentId: 'parent.record',
+    description: 'record-description',
+    type: 'string',
+    enum: ['first', 'second'],
+  };
+  await render(PreferencesRenderingItemFormat, {
+    record,
+  });
+  const input = screen.getByLabelText('record-description');
+  expect(input).toBeInTheDocument();
+  expect(input instanceof HTMLSelectElement).toBe(true);
+});
+
+test('Expect a text input when record is type string', async () => {
+  const record: IConfigurationPropertyRecordedSchema = {
+    title: 'record',
+    parentId: 'parent.record',
+    description: 'record-description',
+    type: 'string',
+  };
+  await render(PreferencesRenderingItemFormat, {
+    record,
+  });
+  const input = screen.getByLabelText('record-description');
+  expect(input).toBeInTheDocument();
+  expect(input instanceof HTMLInputElement).toBe(true);
+  expect((input as HTMLInputElement).type).toBe('text');
 });

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
@@ -230,6 +230,7 @@ function handleCleanValue(
         min="{record.minimum}"
         max="{record.maximum}"
         value="{record.default}"
+        aria-label="{record.description}"
         on:input="{event => handleRangeValue(record.id, event.currentTarget)}"
         class="w-full h-1 bg-[var(--pf-global--primary-color--300)] rounded-lg appearance-none accent-[var(--pf-global--primary-color--300)] cursor-pointer range-xs" />
     {:else if record.type === 'number'}
@@ -248,7 +249,8 @@ function handleCleanValue(
           type="text"
           readonly
           class="w-full outline-none focus:outline-none text-center text-white text-sm py-0.5"
-          value="{recordValue}" />
+          value="{recordValue}"
+          aria-label="{record.description}" />
         <button
           data-action="increment"
           on:click="{e => increment(e, record)}"
@@ -283,7 +285,7 @@ function handleCleanValue(
           id="rendering.FilePath.{record.id}"
           readonly
           aria-invalid="{invalidEntry}"
-          aria-label="{record.description}"
+          aria-label="button-{record.description}"
           placeholder="Browse ..."
           class="bg-violet-500 p-1 text-xs text-center hover:bg-zinc-700 placeholder-white rounded-sm cursor-pointer outline-0"
           required />

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
@@ -12,7 +12,7 @@ export let invalidRecord = (error: string) => {};
 export let validRecord = () => {};
 export let updateResetButtonVisibility = (recordValue: any) => {};
 export let resetToDefault = false;
-export let enableAutoCompletion = false;
+export let enableAutoSave = false;
 
 export let setRecordValue = (id: string, value: string) => {};
 export let enableSlider = false;
@@ -162,7 +162,7 @@ function increment(
 }
 
 function autoSave() {
-  if (enableAutoCompletion) {
+  if (enableAutoSave) {
     recordUpdateTimeout = setTimeout(() => update(record), 1000);
   }
 }


### PR DESCRIPTION
### What does this PR do?

This PR allows to set up the autosave when necessary.
The `PreferencesRenderingItemFormat` is currently used in the preferences page and the creation page. Autosaving must be enabled only in the former page. 

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

N/A

### How to test this PR?

1. try to update a preference and change properties when creating a new resource. You should no face any misbehavior.
