### PR TITLE
feat: setup ingress for Kind clusters

### DIFF
--- a/extensions/kind/.gitignore
+++ b/extensions/kind/.gitignore
@@ -1,1 +1,2 @@
-src/contour.yaml
+src-generated
+

--- a/extensions/kind/.gitignore
+++ b/extensions/kind/.gitignore
@@ -1,0 +1,1 @@
+src/contour.yaml

--- a/extensions/kind/package.json
+++ b/extensions/kind/package.json
@@ -46,7 +46,7 @@
           "type": "boolean",
           "default": true,
           "scope": "KubernetesProviderConnectionFactory",
-          "description": "Setup an ingress controller"
+          "description": "Setup an ingress controller (Contour https://projectcontour.io)"
         }
       }
     },

--- a/extensions/kind/package.json
+++ b/extensions/kind/package.json
@@ -41,6 +41,12 @@
           "default": 9443,
           "scope": "KubernetesProviderConnectionFactory",
           "description": "HTTPS Port"
+        },
+        "kind.cluster.creation.ingress": {
+          "type": "boolean",
+          "default": true,
+          "scope": "KubernetesProviderConnectionFactory",
+          "description": "Setup an ingress controller"
         }
       }
     },
@@ -54,7 +60,7 @@
     }
   },
   "scripts": {
-    "build": "vite build && node ./scripts/build.js",
+    "build": "npx ts-node ./scripts/download.ts && vite build && node ./scripts/build.js",
     "test": "vitest run --coverage",
     "test:watch": "vitest watch --coverage",
     "watch": "vite build -w"

--- a/extensions/kind/scripts/download.ts
+++ b/extensions/kind/scripts/download.ts
@@ -38,7 +38,7 @@ const octokit = new Octokit(octokitOptions);
 export {};
 
 async function download(tagVersion: string, repoPath: string, fileName: string): Promise<void> {
-  const destDir = path.resolve(__dirname, '..', 'src');
+  const destDir = path.resolve(__dirname, '..', 'src-generated');
   if (!fs.existsSync(destDir)) {
     fs.mkdirSync(destDir);
   }

--- a/extensions/kind/scripts/download.ts
+++ b/extensions/kind/scripts/download.ts
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { Octokit } from 'octokit';
+import type { OctokitOptions } from '@octokit/core/dist-types/types';
+
+const CONTOUR_ORG = 'projectcontour';
+const CONTOUR_REPO = 'contour';
+const CONTOUR_DEPLOY_FILE = 'contour.yaml';
+const CONTOUR_DEPLOY_PATH = 'examples/render';
+const CONTOUR_VERSION = 'v1.24.2';
+
+const octokitOptions: OctokitOptions = {};
+if (process.env.GITHUB_TOKEN) {
+  octokitOptions.auth = process.env.GITHUB_TOKEN;
+}
+const octokit = new Octokit(octokitOptions);
+
+// to make this file a module
+export {};
+
+async function download(tagVersion: string, repoPath: string, fileName: string): Promise<void> {
+  const destDir = path.resolve(__dirname, '..', 'src');
+  if (!fs.existsSync(destDir)) {
+    fs.mkdirSync(destDir);
+  }
+  const destFile = path.resolve(destDir, fileName);
+  console.log(
+    `Downloading Contour manifests from https://github.com/${CONTOUR_ORG}/${CONTOUR_REPO}/${CONTOUR_DEPLOY_PATH}/${CONTOUR_DEPLOY_FILE} version ${tagVersion}`,
+  );
+  // await downloadFile(url, destFile);
+  const manifests = await octokit.rest.repos.getContent({
+    owner: CONTOUR_ORG,
+    repo: CONTOUR_REPO,
+    path: repoPath + '/' + fileName,
+    ref: tagVersion,
+    headers: {
+      accept: 'application/json',
+    },
+  });
+  let buffer;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  if ((manifests.data as any).encoding && (manifests.data as any).encoding === 'base64') {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    buffer = Buffer.from((manifests.data as any).content, 'base64');
+  } else {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    buffer = Buffer.from((manifests.data as any).content);
+  }
+
+  fs.writeFileSync(destFile, buffer);
+  console.log(`Downloaded to ${destFile}`);
+}
+
+// grab the manifests from the given URL
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+// download the file from the given URL and store the content in destFile
+download(CONTOUR_VERSION, CONTOUR_DEPLOY_PATH, CONTOUR_DEPLOY_FILE);

--- a/extensions/kind/src/create-cluster.spec.ts
+++ b/extensions/kind/src/create-cluster.spec.ts
@@ -79,7 +79,12 @@ test('expect cluster to be created with ingress', async () => {
     error: vi.fn(),
     warn: vi.fn(),
   };
-  await createCluster({ 'kind.cluster.creation.ingress': true }, logger, '');
+  await createCluster({ 'kind.cluster.creation.ingress': true }, logger, '', telemetryLoggerMock, undefined);
+  expect(telemetryLogUsageMock).toHaveBeenNthCalledWith(
+    1,
+    'createCluster',
+    expect.objectContaining({ provider: 'docker' }),
+  );
   expect(extensionApi.kubernetes.createResources).toBeCalled();
 });
 
@@ -92,11 +97,15 @@ test('expect error if Kubernetes reports error', async () => {
       warn: vi.fn(),
     };
     (extensionApi.kubernetes.createResources as Mock).mockRejectedValue(new Error('Kubernetes error'));
-    await createCluster({ 'kind.cluster.creation.ingress': true }, logger, '');
+    await createCluster({ 'kind.cluster.creation.ingress': true }, logger, '', telemetryLoggerMock, undefined);
   } catch (err) {
     expect(extensionApi.kubernetes.createResources).toBeCalled();
     expect(err).to.be.a('Error');
-    expect(err.message).equal('Kubernetes error');
+    expect(err.message).equal('Failed to create kind cluster. Kubernetes error');
+    expect(telemetryLogErrorMock).toBeCalledWith(
+      'createCluster',
+      expect.objectContaining({ error: 'Kubernetes error' }),
+    );
   }
 });
 

--- a/extensions/kind/src/create-cluster.spec.ts
+++ b/extensions/kind/src/create-cluster.spec.ts
@@ -79,7 +79,7 @@ test('expect cluster to be created with ingress', async () => {
     error: vi.fn(),
     warn: vi.fn(),
   };
-  await createCluster({ 'kind.cluster.creation.ingress': true }, logger, '', telemetryLoggerMock, undefined);
+  await createCluster({ 'kind.cluster.creation.ingress': 'on' }, logger, '', telemetryLoggerMock, undefined);
   expect(telemetryLogUsageMock).toHaveBeenNthCalledWith(
     1,
     'createCluster',

--- a/extensions/kind/src/create-cluster.ts
+++ b/extensions/kind/src/create-cluster.ts
@@ -97,7 +97,7 @@ export async function createCluster(
   let ingressController = false;
 
   if (params['kind.cluster.creation.ingress']) {
-    ingressController = params['kind.cluster.creation.ingress'];
+    ingressController = params['kind.cluster.creation.ingress'] === 'on';
   }
 
   // create the config file
@@ -115,10 +115,10 @@ export async function createCluster(
   // now execute the command to create the cluster
   try {
     await runCliCommand(kindCli, ['create', 'cluster', '--config', tmpFilePath], { env, logger }, token);
-if (ingressController) {
-    logger.log('Creating ingress controller resources');
-    await setupIngressController(clusterName);
-  }
+    if (ingressController) {
+      logger.log('Creating ingress controller resources');
+      await setupIngressController(clusterName);
+    }
     telemetryLogger.logUsage('createCluster', { provider, httpHostPort, httpsHostPort });
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : error;

--- a/extensions/kind/src/create-cluster.ts
+++ b/extensions/kind/src/create-cluster.ts
@@ -25,7 +25,7 @@ import { parseAllDocuments } from 'yaml';
 
 import createClusterConfTemplate from './templates/create-cluster-conf.mustache?raw';
 import type { CancellationToken } from '@podman-desktop/api';
-import ingressManifests from './contour.yaml?raw';
+import ingressManifests from '/@gen/contour.yaml?raw';
 
 export function getKindClusterConfig(clusterName: string, httpHostPort: number, httpsHostPort: number) {
   return mustache.render(createClusterConfTemplate, {

--- a/extensions/kind/src/create-cluster.ts
+++ b/extensions/kind/src/create-cluster.ts
@@ -119,13 +119,14 @@ export async function createCluster(
       logger.log('Creating ingress controller resources');
       await setupIngressController(clusterName);
     }
-    telemetryLogger.logUsage('createCluster', { provider, httpHostPort, httpsHostPort });
+    telemetryLogger.logUsage('createCluster', { provider, httpHostPort, httpsHostPort, ingressController });
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : error;
     telemetryLogger.logError('createCluster', {
       provider,
       httpHostPort,
       httpsHostPort,
+      ingressController,
       error: errorMessage,
       stdErr: errorMessage,
     });

--- a/extensions/kind/src/create-cluster.ts
+++ b/extensions/kind/src/create-cluster.ts
@@ -15,15 +15,17 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
-import type * as extensionApi from '@podman-desktop/api';
+import * as extensionApi from '@podman-desktop/api';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
 import { runCliCommand } from './util';
 import mustache from 'mustache';
+import { parseAllDocuments } from 'yaml';
 
 import createClusterConfTemplate from './templates/create-cluster-conf.mustache?raw';
 import type { CancellationToken } from '@podman-desktop/api';
+import ingressManifests from './contour.yaml?raw';
 
 export function getKindClusterConfig(clusterName: string, httpHostPort: number, httpsHostPort: number) {
   return mustache.render(createClusterConfTemplate, {
@@ -31,6 +33,28 @@ export function getKindClusterConfig(clusterName: string, httpHostPort: number, 
     httpHostPort: httpHostPort,
     httpsHostPort: httpsHostPort,
   });
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function getTags(tags: any[]): any[] {
+  for (const tag of tags) {
+    if (tag.tag === 'tag:yaml.org,2002:int') {
+      const newTag = { ...tag };
+      newTag.test = /^(0[0-7][0-7][0-7])$/;
+      newTag.resolve = str => parseInt(str, 8);
+      tags.unshift(newTag);
+      break;
+    }
+  }
+  return tags;
+}
+
+export async function setupIngressController(clusterName: string) {
+  const manifests = parseAllDocuments(ingressManifests, { customTags: getTags });
+  await extensionApi.kubernetes.createResources(
+    'kind-' + clusterName,
+    manifests.map(manifest => manifest.toJSON()),
+  );
 }
 
 export async function createCluster(
@@ -70,6 +94,12 @@ export async function createCluster(
     httpsHostPort = params['kind.cluster.creation.https.port'];
   }
 
+  let ingressController = false;
+
+  if (params['kind.cluster.creation.ingress']) {
+    ingressController = params['kind.cluster.creation.ingress'];
+  }
+
   // create the config file
   const kindClusterConfig = getKindClusterConfig(clusterName, httpHostPort, httpsHostPort);
 
@@ -85,6 +115,10 @@ export async function createCluster(
   // now execute the command to create the cluster
   try {
     await runCliCommand(kindCli, ['create', 'cluster', '--config', tmpFilePath], { env, logger }, token);
+if (ingressController) {
+    logger.log('Creating ingress controller resources');
+    await setupIngressController(clusterName);
+  }
     telemetryLogger.logUsage('createCluster', { provider, httpHostPort, httpsHostPort });
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : error;

--- a/extensions/kind/tsconfig.json
+++ b/extensions/kind/tsconfig.json
@@ -20,5 +20,18 @@
     "src",
     "types/*.d.ts",
     "../../types/**/*.d.ts"
-]
+],
+"ts-node": {
+  "compilerOptions": {
+    "module": "CommonJS",
+    "lib": [
+      "ES2020",
+      "DOM"
+    ],
+    "types": [
+      "node"
+    ]
+  }
+}
+
 }

--- a/extensions/kind/types/template.d.ts
+++ b/extensions/kind/types/template.d.ts
@@ -20,3 +20,8 @@ declare module '*.mustache' {
   const contents: string;
   export = contents;
 }
+
+declare module '*.yaml' {
+  const contents: string;
+  export = contents;
+}

--- a/extensions/kind/vite.config.js
+++ b/extensions/kind/vite.config.js
@@ -1,12 +1,12 @@
 /**********************************************************************
  * Copyright (C) 2023 Red Hat, Inc.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -32,6 +32,7 @@ const config = {
   resolve: {
     alias: {
       '/@/': join(PACKAGE_ROOT, 'src') + '/',
+      '/@gen/': join(PACKAGE_ROOT, 'src-generated') + '/',
     },
   },
   build: {

--- a/extensions/kind/vitest.config.js
+++ b/extensions/kind/vitest.config.js
@@ -1,12 +1,12 @@
 /**********************************************************************
  * Copyright (C) 2023 Red Hat, Inc.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,6 +18,7 @@
 
 import path from 'node:path';
 import { coverageConfig, testConfig } from '../../vitest-shared-extensions.config';
+import {join} from 'path';
 
 const PACKAGE_ROOT = __dirname;
 const PACKAGE_NAME = 'extensions/kind';
@@ -30,6 +31,7 @@ const config = {
   resolve: {
     alias: {
       '@podman-desktop/api': path.resolve('../../', '__mocks__/@podman-desktop/api.js'),
+      '/@gen/': join(PACKAGE_ROOT, 'src-generated') + '/',
     },
   },
 };

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -591,7 +591,7 @@ export class ExtensionLoader {
       onDidUpdateKubeconfig: (listener, thisArg, disposables) => {
         return kubernetesClient.onDidUpdateKubeconfig(listener, thisArg, disposables);
       },
-      createResources: (context, manifests): Promise<void> => {
+      async createResources(context, manifests): Promise<void> {
         return kubernetesClient.createResources(context, manifests);
       },
     };

--- a/packages/main/src/plugin/kubernetes-client.spec.ts
+++ b/packages/main/src/plugin/kubernetes-client.spec.ts
@@ -38,7 +38,7 @@ beforeAll(() => {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  KubeConfig.prototype.loadFromOptions = vi.fn();
+  KubeConfig.prototype.loadFromFile = vi.fn();
   KubeConfig.prototype.makeApiClient = vi.fn();
 });
 

--- a/packages/main/src/plugin/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes-client.ts
@@ -532,12 +532,8 @@ export class KubernetesClient {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   async createResources(context: string, manifests: any[]): Promise<void> {
     const ctx = new KubeConfig();
-    ctx.loadFromOptions({
-      currentContext: context,
-      clusters: this.kubeConfig.clusters,
-      contexts: this.kubeConfig.contexts,
-      users: this.kubeConfig.users,
-    });
+    ctx.loadFromFile(this.kubeconfigPath);
+    ctx.currentContext = context;
     for (const manifest of manifests) {
       const groupVersion = this.groupAndVersion(manifest.apiVersion);
       if (groupVersion.group === '') {


### PR DESCRIPTION
Fixes #1675

### What does this PR do?

Allow to create a Kind cluster with an ingress controller (Contour)

### Screenshot/screencast of this PR

![kind-ingress](https://user-images.githubusercontent.com/695993/230328543-71a6d2a4-b6ac-44dd-9219-d0a864dd44f9.gif)


### What issues does this PR fix or reference?

Fixes #1675

### How to test this PR?

1. Create a Kind cluster with the Ingress controller option
2. Run `kubectl apply -f https://projectcontour.io/examples/httpbin.yaml`
3. Open http://localhost:9090
