### PR TITLE
fix: Default value for boolean configuration is not properly handled

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.spec.ts
@@ -1,0 +1,52 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom';
+import { test, expect } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import PreferencesRenderingItemFormat from './PreferencesRenderingItemFormat.svelte';
+
+test('Expect to see checkbox enabled', async () => {
+  const record = {
+    title: 'my boolean property',
+    id: 'myid',
+    parentId: '',
+    type: 'boolean',
+    default: true,
+  };
+  // remove display name
+  render(PreferencesRenderingItemFormat, { record: record });
+  const button = screen.getByRole('checkbox');
+  expect(button).toBeInTheDocument();
+  expect(button).toBeChecked();
+});
+
+test('Expect to see checkbox enabled', async () => {
+  const record = {
+    title: 'my boolean property',
+    id: 'myid',
+    parentId: '',
+    type: 'boolean',
+    default: false,
+  };
+  // remove display name
+  render(PreferencesRenderingItemFormat, { record: record });
+  const button = screen.getByRole('checkbox');
+  expect(button).toBeInTheDocument();
+  expect(button).not.toBeChecked();
+});

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
@@ -44,6 +44,9 @@ $: if (currentRecord !== record) {
     });
   } else if (record.default !== undefined) {
     recordValue = record.default;
+    if (record.type === 'boolean') {
+      checkboxValue = recordValue;
+    }
   }
 
   currentRecord = record;


### PR DESCRIPTION
Fixes #1978

### What does this PR do?

Fixes the checkbox default state if the configuration property is boolean and has a default value of true

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?

Fixes #1978 

### How to test this PR?

Unit test provided
