### PR TITLE
chore: Add gap between preference description and control

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItem.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItem.svelte
@@ -73,7 +73,7 @@ $: resetToDefault = false;
         </div>
       {/if}
     </div>
-    <div class="pt-1 text-gray-400 text-xs">{recordUI.description}</div>
+    <div class="pt-1 text-gray-400 text-xs pr-2">{recordUI.description}</div>
     {#if recordUI.original.type === 'string' && (!recordUI.original.enum || recordUI.original.enum.length === 0)}
       <PreferencesRenderingItemFormat
         showUpdate="{false}"


### PR DESCRIPTION
### What does this PR do?

Add a small gap to avoid having a property description touch the control.

### Screenshot/screencast of this PR

Before:
<img width="185" alt="gap" src="https://user-images.githubusercontent.com/19958075/230418755-c9f62045-a916-4def-a33b-f1d4cf78cbec.png">

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Change the width of the preferences page and see that the descriptions won't 'hit' the controls anymore.
