### PR TITLE
feat(extension-api): Allow to send telemetry data from 3rd party extensions

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -1659,4 +1659,159 @@ declare module '@podman-desktop/api' {
       options?: AuthenticationProviderOptions,
     ): Disposable;
   }
+
+  /**
+   * Namespace describing the environment Podman Desktop runs in.
+   */
+  export namespace env {
+    /**
+     * Indicates whether the users has telemetry enabled.
+     * Can be observed to determine if the extension should send telemetry.
+     */
+    export const isTelemetryEnabled: boolean;
+
+    /**
+     * An {@link Event} which fires when the user enabled or disables telemetry.
+     * `true` if the user has enabled telemetry or `false` if the user has disabled telemetry.
+     */
+    export const onDidChangeTelemetryEnabled: Event<boolean>;
+
+    /**
+     * Creates a new {@link TelemetryLogger telemetry logger}.
+     *
+     * @param sender The telemetry sender that is used by the telemetry logger.
+     * @param options Options for the telemetry logger.
+     * @returns A new telemetry logger
+     */
+    export function createTelemetryLogger(sender?: TelemetrySender, options?: TelemetryLoggerOptions): TelemetryLogger;
+  }
+
+  /**
+   * A special value wrapper denoting a value that is safe to not clean.
+   * This is to be used when you can guarantee no identifiable information is contained in the value and the cleaning is improperly redacting it.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  export class TelemetryTrustedValue<T = any> {
+    readonly value: T;
+
+    constructor(value: T);
+  }
+
+  /**
+   * A telemetry logger which can be used by extensions to log usage and error telementry.
+   *
+   * A logger wraps around an {@link TelemetrySender sender} but it guarantees that
+   * - user settings to disable or tweak telemetry are respected, and that
+   * - potential sensitive data is removed
+   *
+   * It also enables an "echo UI" that prints whatever data is send and it allows the editor
+   * to forward unhandled errors to the respective extensions.
+   *
+   * To get an instance of a `TelemetryLogger`, use
+   * {@link env.createTelemetryLogger `createTelemetryLogger`}.
+   */
+  export interface TelemetryLogger {
+    /**
+     * An {@link Event} which fires when the enablement state of usage or error telemetry changes.
+     */
+    readonly onDidChangeEnableStates: Event<TelemetryLogger>;
+
+    /**
+     * Whether or not usage telemetry is enabled for this logger.
+     */
+    readonly isUsageEnabled: boolean;
+
+    /**
+     * Whether or not error telemetry is enabled for this logger.
+     */
+    readonly isErrorsEnabled: boolean;
+
+    /**
+     * Log a usage event.
+     *
+     * After completing cleaning, telemetry setting checks, and data mix-in calls `TelemetrySender.sendEventData` to log the event.
+     * Automatically supports echoing to extension telemetry output channel.
+     * @param eventName The event name to log
+     * @param data The data to log
+     */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    logUsage(eventName: string, data?: Record<string, any | TelemetryTrustedValue>): void;
+
+    /**
+     * Log an error event.
+     *
+     * After completing cleaning, telemetry setting checks, and data mix-in calls `TelemetrySender.sendEventData` to log the event. Differs from `logUsage` in that it will log the event if the telemetry setting is Error+.
+     * Automatically supports echoing to extension telemetry output channel.
+     * @param eventName The event name to log
+     * @param data The data to log
+     */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    logError(eventName: string, data?: Record<string, any | TelemetryTrustedValue>): void;
+
+    /**
+     * Log an error event.
+     * @param error The error object which contains the stack trace cleaned of PII
+     * @param data Additional data to log alongside the stack trace
+     */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    logError(error: Error, data?: Record<string, any | TelemetryTrustedValue>): void;
+
+    /**
+     * Dispose this object and free resources.
+     */
+    dispose(): void;
+  }
+
+  /**
+   * The telemetry sender is the contract between a telemetry logger and some telemetry service. **Note** that extensions must NOT
+   * call the methods of their sender directly as the logger provides extra guards and cleaning.
+   */
+  export interface TelemetrySender {
+    /**
+     * Function to send event data without a stacktrace. Used within a {@link TelemetryLogger}
+     *
+     * @param eventName The name of the event which you are logging
+     * @param data A serializable key value pair that is being logged
+     */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    sendEventData(eventName: string, data?: Record<string, any>): void;
+
+    /**
+     * Function to send an error. Used within a {@link TelemetryLogger}
+     *
+     * @param error The error being logged
+     * @param data Any additional data to be collected with the exception
+     */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    sendErrorData(error: Error, data?: Record<string, any>): void;
+
+    /**
+     * Optional flush function which will give this sender a chance to send any remaining events
+     * as its {@link TelemetryLogger} is being disposed
+     */
+    flush?(): void | Promise<void>;
+  }
+
+  /**
+   * Options for creating a {@link TelemetryLogger}
+   */
+  export interface TelemetryLoggerOptions {
+    /**
+     * Whether or not you want to avoid having the built-in common properties such as os, extension name, etc injected into the data object.
+     * Defaults to `false` if not defined.
+     */
+    readonly ignoreBuiltInCommonProperties?: boolean;
+
+    /**
+     * Whether or not unhandled errors on the extension host caused by your extension should be logged to your sender.
+     * Defaults to `false` if not defined.
+     */
+    readonly ignoreUnhandledErrors?: boolean;
+
+    /**
+     * Any additional common properties which should be injected into the data object.
+     */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    readonly additionalCommonProperties?: Record<string, any>;
+  }
 }

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -48,6 +48,8 @@ import { Emitter } from './events/emitter';
 import { CancellationTokenSource } from './cancellation-token';
 import type { ApiSenderType } from './api';
 import type { AuthenticationImpl } from './authentication';
+import type { Telemetry } from './telemetry/telemetry';
+import { TelemetryTrustedValue } from './types/telemetry';
 
 /**
  * Handle the loading of an extension
@@ -109,6 +111,7 @@ export class ExtensionLoader {
     private containerProviderRegistry: ContainerProviderRegistry,
     private inputQuickPickRegistry: InputQuickPickRegistry,
     private authenticationProviderRegistry: AuthenticationImpl,
+    private telemetry: Telemetry,
   ) {}
 
   async listExtensions(): Promise<ExtensionInfo[]> {
@@ -600,7 +603,13 @@ export class ExtensionLoader {
     };
 
     const authenticationProviderRegistry = this.authenticationProviderRegistry;
-    const extensionInfo = { id: extManifest.name, label: extManifest.displayName };
+    const extensionInfo = {
+      id: `${extManifest.publisher}.${extManifest.name}`,
+      label: extManifest.displayName,
+      version: extManifest.version,
+      publisher: extManifest.publisher,
+      name: extManifest.name,
+    };
     const authentication: typeof containerDesktopAPI.authentication = {
       getSession: (providerId, scopes, options) => {
         return authenticationProviderRegistry.getSession(extensionInfo, providerId, scopes, options);
@@ -613,13 +622,31 @@ export class ExtensionLoader {
       },
     };
 
+    const telemetry = this.telemetry;
+    const env: typeof containerDesktopAPI.env = {
+      createTelemetryLogger: (
+        sender?: containerDesktopAPI.TelemetrySender | undefined,
+        options?: containerDesktopAPI.TelemetryLoggerOptions | undefined,
+      ) => {
+        return telemetry.createTelemetryLogger(extensionInfo, sender, options);
+      },
+      get isTelemetryEnabled() {
+        return telemetry.isTelemetryEnabled();
+      },
+      onDidChangeTelemetryEnabled: (listener, thisArg, disposables) => {
+        return telemetry.onDidChangeTelemetryEnabled(listener, thisArg, disposables);
+      },
+    };
+
     return <typeof containerDesktopAPI>{
       // Types
       Disposable: Disposable,
       Uri: Uri,
       EventEmitter: Emitter,
       CancellationTokenSource: CancellationTokenSource,
+      TelemetryTrustedValue: TelemetryTrustedValue,
       commands,
+      env,
       registry,
       provider,
       fs,

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -561,6 +561,7 @@ export class PluginSystem {
       containerProviderRegistry,
       inputQuickPickRegistry,
       authentication,
+      telemetry,
     );
     await this.extensionLoader.init();
 

--- a/packages/main/src/plugin/telemetry/telemetry.spec.ts
+++ b/packages/main/src/plugin/telemetry/telemetry.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2022 Red Hat, Inc.
+ * Copyright (C) 2023 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,14 +16,28 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { beforeEach, expect, test, vi } from 'vitest';
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import type { ConfigurationRegistry } from '../configuration-registry';
 
-import { Telemetry } from './telemetry';
+import { Telemetry, TelemetryLoggerImpl } from './telemetry';
+import { TelemetrySettings } from './telemetry-settings';
+import type { ExtensionInfo } from '../api/extension-info';
+import type { TelemetrySender } from '@podman-desktop/api';
+import { TelemetryTrustedValue } from '../types/telemetry';
+
+const getConfigurationMock = vi.fn();
+const onDidChangeConfigurationMock = vi.fn();
+
+const configurationRegistryMock = {
+  getConfiguration: getConfigurationMock,
+  onDidChangeConfiguration: onDidChangeConfigurationMock,
+} as unknown as ConfigurationRegistry;
 
 class TelemetryTest extends Telemetry {
   constructor() {
-    super({} as ConfigurationRegistry);
+    super(configurationRegistryMock);
   }
   public getLastTimeEvents(): Map<string, number> {
     return this.lastTimeEvents;
@@ -32,15 +46,24 @@ class TelemetryTest extends Telemetry {
   public shouldDropEvent(eventName: string): boolean {
     return super.shouldDropEvent(eventName);
   }
+
+  public checkForTelemetryUpdates(): void {
+    super.checkForTelemetryUpdates();
+  }
+
+  public createBuiltinTelemetrySender(extensionInfo: ExtensionInfo): TelemetrySender {
+    return super.createBuiltinTelemetrySender(extensionInfo);
+  }
 }
 
-let telemetry;
+let telemetry: TelemetryTest;
 
 beforeEach(() => {
   telemetry = new TelemetryTest();
 });
 
-beforeEach(() => {
+afterEach(() => {
+  vi.resetAllMocks();
   vi.clearAllMocks();
 });
 
@@ -62,4 +85,124 @@ test('Should not filter out a list event if last event was > 24h', async () => {
   // last call was 25h ago, so it should not be filtered out
   telemetry.getLastTimeEvents().set('listVeryVeryOldime', Date.now() - 1000 * 60 * 60 * 25);
   expect(telemetry.shouldDropEvent('listVeryVeryOldime')).toBeFalsy();
+});
+
+test('Check Telemetry is enabled', async () => {
+  getConfigurationMock.mockReturnValue({
+    get: () => true,
+  });
+
+  const enabled = telemetry.isTelemetryEnabled();
+  expect(enabled).toBeTruthy();
+});
+
+test('Check Telemetry is disabled', async () => {
+  getConfigurationMock.mockReturnValue({
+    get: () => false,
+  });
+
+  const enabled = telemetry.isTelemetryEnabled();
+  expect(enabled).toBeFalsy();
+});
+
+test('Check propagate enablement event if configuration is updated', async () => {
+  let hasBeenEnabled = false;
+  telemetry.onDidChangeTelemetryEnabled(event => {
+    hasBeenEnabled = event;
+  });
+
+  // simulate configuration change
+  onDidChangeConfigurationMock.mockImplementation(callback => {
+    // simulate telemetry.enabled = true
+    callback({ value: true, key: `${TelemetrySettings.SectionName}.${TelemetrySettings.Enabled}` });
+  });
+
+  telemetry.checkForTelemetryUpdates();
+  expect(hasBeenEnabled).toBeTruthy();
+});
+
+describe('TelemetryLoggerImpl', () => {
+  const sendEventDataMock = vi.fn();
+  const sendErrorDataMock = vi.fn();
+  const senderMock = {
+    sendEventData: sendEventDataMock,
+    sendErrorData: sendErrorDataMock,
+  } as unknown as TelemetrySender;
+
+  const dummyExtensionInfo: ExtensionInfo = {
+    name: 'dummy',
+    version: '1.0.0',
+    publisher: 'bar',
+  } as unknown as ExtensionInfo;
+
+  test('check simple event', async () => {
+    const telemetryLogger = new TelemetryLoggerImpl(dummyExtensionInfo, senderMock);
+
+    // defaults are setup
+    expect(telemetryLogger.isUsageEnabled).toBeTruthy();
+    expect(telemetryLogger.isErrorsEnabled).toBeTruthy();
+    telemetryLogger.logUsage('foo');
+    expect(sendEventDataMock).toBeCalledWith('foo', {
+      'common.extensionName': 'bar.dummy',
+      'common.extensionVersion': '1.0.0',
+    });
+  });
+
+  test('check additional properties', async () => {
+    const telemetryLogger = new TelemetryLoggerImpl(dummyExtensionInfo, senderMock, {
+      additionalCommonProperties: { customProp: 'customVal' },
+    });
+
+    telemetryLogger.logUsage('foo');
+    expect(sendEventDataMock).toBeCalledWith(
+      'foo',
+      expect.objectContaining({
+        customProp: 'customVal',
+      }),
+    );
+  });
+
+  test('check TelemetryTrustedValue', async () => {
+    const telemetryLogger = new TelemetryLoggerImpl(dummyExtensionInfo, senderMock);
+
+    telemetryLogger.logUsage('foo', { prop: new TelemetryTrustedValue('bar') });
+    expect(sendEventDataMock).toBeCalledWith(
+      'foo',
+      expect.objectContaining({
+        prop: 'bar',
+      }),
+    );
+  });
+
+  test('check string error event', async () => {
+    const telemetryLogger = new TelemetryLoggerImpl(dummyExtensionInfo, senderMock);
+
+    telemetryLogger.logError('foo');
+    expect(sendErrorDataMock).toBeCalledWith(expect.any(Error), {
+      'common.extensionName': 'bar.dummy',
+      'common.extensionVersion': '1.0.0',
+    });
+  });
+
+  test('check error event', async () => {
+    const telemetryLogger = new TelemetryLoggerImpl(dummyExtensionInfo, senderMock);
+
+    const fakeError = new Error('fake error');
+
+    telemetryLogger.logError(fakeError, { add1: 'val1' });
+    expect(sendErrorDataMock).toBeCalledWith(
+      fakeError,
+      expect.objectContaining({
+        add1: 'val1',
+      }),
+    );
+  });
+
+  test('dispose', async () => {
+    const telemetryLogger = new TelemetryLoggerImpl(dummyExtensionInfo, senderMock);
+
+    expect((telemetryLogger as any).commonProperties).toContain({ 'common.extensionVersion': '1.0.0' });
+    telemetryLogger.dispose();
+    expect((telemetryLogger as any).commonProperties).toStrictEqual({});
+  });
 });

--- a/packages/main/src/plugin/telemetry/telemetry.spec.ts
+++ b/packages/main/src/plugin/telemetry/telemetry.spec.ts
@@ -47,8 +47,8 @@ class TelemetryTest extends Telemetry {
     return super.shouldDropEvent(eventName);
   }
 
-  public checkForTelemetryUpdates(): void {
-    super.checkForTelemetryUpdates();
+  public listenForTelemetryUpdates(): void {
+    super.listenForTelemetryUpdates();
   }
 
   public createBuiltinTelemetrySender(extensionInfo: ExtensionInfo): TelemetrySender {
@@ -117,7 +117,7 @@ test('Check propagate enablement event if configuration is updated', async () =>
     callback({ value: true, key: `${TelemetrySettings.SectionName}.${TelemetrySettings.Enabled}` });
   });
 
-  telemetry.checkForTelemetryUpdates();
+  telemetry.listenForTelemetryUpdates();
   expect(hasBeenEnabled).toBeTruthy();
 });
 

--- a/packages/main/src/plugin/telemetry/telemetry.ts
+++ b/packages/main/src/plugin/telemetry/telemetry.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2022, 2023 Red Hat, Inc.
+ * Copyright (C) 2022-2023 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,8 +24,17 @@ import type { LinuxOs } from 'getos';
 import getos from 'getos';
 import * as osLocale from 'os-locale';
 import { promisify } from 'node:util';
-import type { ConfigurationRegistry, IConfigurationNode } from '../configuration-registry';
+import type { ConfigurationRegistry, IConfigurationNode } from '/@/plugin/configuration-registry';
 import { TelemetrySettings } from './telemetry-settings';
+import type { Event } from '/@/plugin/events/emitter';
+import { Emitter } from '/@/plugin/events/emitter';
+import type {
+  TelemetryLogger,
+  TelemetryLoggerOptions,
+  TelemetrySender,
+  TelemetryTrustedValue,
+} from '@podman-desktop/api';
+import { TelemetryTrustedValue as TypeTelemetryTrustedValue } from '../types/telemetry';
 
 export const TRACK_EVENT_TYPE = 'track';
 export const PAGE_EVENT_TYPE = 'page';
@@ -63,6 +72,9 @@ export class Telemetry {
 
   protected lastTimeEvents: Map<string, number>;
 
+  private readonly _onDidChangeTelemetryEnabled = new Emitter<boolean>();
+  readonly onDidChangeTelemetryEnabled: Event<boolean> = this._onDidChangeTelemetryEnabled.event;
+
   constructor(private configurationRegistry: ConfigurationRegistry) {
     this.identity = new Identity();
     this.lastTimeEvents = new Map();
@@ -95,13 +107,15 @@ export class Telemetry {
     const telemetryConfiguration = this.configurationRegistry.getConfiguration(TelemetrySettings.SectionName);
     const check = telemetryConfiguration.get<boolean>(TelemetrySettings.Check);
 
+    // track changes on enablement
+    this.checkForTelemetryUpdates();
+
     // initalize objects
     this.analytics = new Analytics(Telemetry.SEGMENT_KEY);
 
     // needs to prompt the user for the first time he launches the app
     if (check) {
-      const enabled = telemetryConfiguration.get<boolean>(TelemetrySettings.Enabled);
-      if (enabled === true) {
+      if (this.isTelemetryEnabled()) {
         await this.configureTelemetry();
       } else {
         this.telemetryInitialized = true;
@@ -110,6 +124,61 @@ export class Telemetry {
         this.pendingItems.length = 0;
       }
     }
+  }
+
+  // notify if the configuration change for enablement of the telemetry
+  protected checkForTelemetryUpdates(): void {
+    this.configurationRegistry.onDidChangeConfiguration(e => {
+      if (e.key === `${TelemetrySettings.SectionName}.${TelemetrySettings.Enabled}`) {
+        const val = e.value as boolean;
+        this._onDidChangeTelemetryEnabled.fire(val);
+      }
+    });
+  }
+
+  isTelemetryEnabled(): boolean {
+    const telemetryConfiguration = this.configurationRegistry.getConfiguration(TelemetrySettings.SectionName);
+    const enabled = telemetryConfiguration.get<boolean>(TelemetrySettings.Enabled);
+    return enabled === true;
+  }
+
+  protected createBuiltinTelemetrySender(extensionInfo: {
+    id: string;
+    name: string;
+    publisher: string;
+    version: string;
+  }): TelemetrySender {
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    const thisArg = this;
+    const instanceFlush = this.analytics?.flush;
+    return {
+      // prefix with extension id the event
+      sendEventData(eventName: string, data?: Record<string, unknown>): void {
+        thisArg.track.apply(thisArg, [`${extensionInfo.id}.${eventName}`, data]);
+      },
+      // report using the id of the extension suffixed by error
+      sendErrorData(error: Error, data?: Record<string, unknown>): void {
+        data = data || {};
+        data.sourceError = error.message;
+        thisArg.track.apply(thisArg, [`${extensionInfo.id}.error`, data]);
+      },
+      async flush(): Promise<void> {
+        await instanceFlush?.();
+      },
+    };
+  }
+
+  createTelemetryLogger(
+    extensionInfo: { id: string; name: string; publisher: string; version: string },
+    sender?: TelemetrySender | undefined,
+    options?: TelemetryLoggerOptions | undefined,
+  ): TelemetryLogger {
+    // if no sender, use the built-in
+    if (!sender) {
+      sender = this.createBuiltinTelemetrySender(extensionInfo);
+    }
+
+    return new TelemetryLoggerImpl(extensionInfo, sender, options);
   }
 
   protected async initTelemetry(): Promise<void> {
@@ -293,5 +362,74 @@ export class Telemetry {
       }
     }
     return undefined;
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type RecordInfo = Record<string, any | TelemetryTrustedValue>;
+
+export class TelemetryLoggerImpl implements TelemetryLogger {
+  readonly isUsageEnabled = true;
+  readonly isErrorsEnabled = true;
+
+  private readonly _onDidChangeEnableStates = new Emitter<TelemetryLogger>();
+  readonly onDidChangeEnableStates: Event<TelemetryLogger> = this._onDidChangeEnableStates.event;
+
+  private commonProperties: RecordInfo = {};
+
+  constructor(
+    extensionInfo: { id: string; name: string; publisher: string; version: string },
+    private sender: TelemetrySender,
+    private options?: TelemetryLoggerOptions,
+  ) {
+    this.commonProperties = {
+      'common.extensionName': `${extensionInfo.publisher}.${extensionInfo.name}`,
+      'common.extensionVersion': extensionInfo.version,
+    };
+  }
+
+  setupData(data?: RecordInfo): RecordInfo {
+    data = data || {};
+
+    if (this.options?.additionalCommonProperties) {
+      data = { ...this.options.additionalCommonProperties, ...data };
+    }
+
+    if (!this.options?.ignoreBuiltInCommonProperties) {
+      data = { ...this.commonProperties, ...data };
+    }
+
+    // for each trusted value, extract the value and remove the trusted value wrapper
+    for (const key in data) {
+      const value = data[key];
+      if (value instanceof TypeTelemetryTrustedValue) {
+        data[key] = value.value;
+      }
+    }
+
+    return data;
+  }
+
+  logUsage(eventName: string, data?: RecordInfo): void {
+    data = this.setupData(data);
+    this.sender.sendEventData(eventName, data);
+  }
+
+  logError(eventName: string, data?: RecordInfo): void;
+  logError(error: Error, data?: RecordInfo): void;
+  logError(eventName: string | Error, data?: RecordInfo): void {
+    data = this.setupData(data);
+
+    let error = eventName;
+    if (eventName instanceof Error) {
+      error = eventName;
+    } else {
+      error = new Error(eventName);
+    }
+    this.sender.sendErrorData(error, data);
+  }
+
+  dispose(): void {
+    this.commonProperties = {};
   }
 }

--- a/packages/main/src/plugin/telemetry/telemetry.ts
+++ b/packages/main/src/plugin/telemetry/telemetry.ts
@@ -108,7 +108,7 @@ export class Telemetry {
     const check = telemetryConfiguration.get<boolean>(TelemetrySettings.Check);
 
     // track changes on enablement
-    this.checkForTelemetryUpdates();
+    this.listenForTelemetryUpdates();
 
     // initalize objects
     this.analytics = new Analytics(Telemetry.SEGMENT_KEY);
@@ -127,7 +127,7 @@ export class Telemetry {
   }
 
   // notify if the configuration change for enablement of the telemetry
-  protected checkForTelemetryUpdates(): void {
+  protected listenForTelemetryUpdates(): void {
     this.configurationRegistry.onDidChangeConfiguration(e => {
       if (e.key === `${TelemetrySettings.SectionName}.${TelemetrySettings.Enabled}`) {
         const val = e.value as boolean;

--- a/packages/main/src/plugin/types/telemetry.ts
+++ b/packages/main/src/plugin/types/telemetry.ts
@@ -1,0 +1,21 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+export class TelemetryTrustedValue<T> {
+  constructor(public readonly value: T) {}
+}


### PR DESCRIPTION
### What does this PR do?
extension can know if telemetry is enabled or not, be notified if there is a change or not and it can also provide a custom sender to send telemetry events to its own backend.

Podman Desktop adds some common properties on the events like the extension + version sending the events


### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/1455


### How to test this PR?

Unit tests added.

you can also use in your extension:

```typescript
const telemetryLogger = extensionApi.env.createTelemetryLogger();
telemetryLogger.logUsage('hello');
```

or for errors
```typescript
telemetryLogger.logError(new Error('my Error'));
telemetryLogger.logError('hello');
```


Change-Id: I213b42663d2c642fe9d525d03d9b898416090c88

