### PR TITLE
feat(kind): Add telemetry to see what is happening

### DIFF
--- a/extensions/kind/src/create-cluster.spec.ts
+++ b/extensions/kind/src/create-cluster.spec.ts
@@ -48,7 +48,7 @@ const telemetryLoggerMock = {
 test('expect error is cli returns non zero exit code', async () => {
   try {
     (runCliCommand as Mock).mockReturnValue({ exitCode: -1, error: 'error' });
-    await createCluster({}, undefined, '', telemetryLoggerMock);
+    await createCluster({}, undefined, '', undefined, telemetryLoggerMock);
   } catch (err) {
     expect(err).to.be.a('Error');
     expect(err.message).equal('Failed to create kind cluster. error');
@@ -58,15 +58,10 @@ test('expect error is cli returns non zero exit code', async () => {
 
 test('expect cluster to be created', async () => {
   (runCliCommand as Mock).mockReturnValue({ exitCode: 0 });
-  await createCluster({}, undefined, '', telemetryLoggerMock);
+  await createCluster({}, undefined, '', undefined, telemetryLoggerMock);
   expect(telemetryLogUsageMock).toHaveBeenNthCalledWith(
     1,
     'createCluster',
-    expect.objectContaining({ provider: 'docker', httpsHostPort: 9443, httpHostPort: 9090 }),
-  );
-  expect(telemetryLogUsageMock).toHaveBeenNthCalledWith(
-    2,
-    'createClusterSuccess',
     expect.objectContaining({ provider: 'docker' }),
   );
   expect(telemetryLogErrorMock).not.toBeCalled();

--- a/extensions/kind/src/create-cluster.ts
+++ b/extensions/kind/src/create-cluster.ts
@@ -39,6 +39,7 @@ export async function createCluster(
   logger: extensionApi.Logger,
   kindCli: string,
   token?: CancellationToken,
+  telemetryLogger: extensionApi.TelemetryLogger,
 ): Promise<void> {
   let clusterName = 'kind';
   if (params['kind.cluster.creation.name']) {
@@ -81,6 +82,8 @@ export async function createCluster(
   // ok we need to write the file
   await fs.promises.writeFile(tmpFilePath, kindClusterConfig, 'utf8');
 
+  telemetryLogger.logUsage('createCluster', { provider, httpHostPort, httpsHostPort });
+
   // now execute the command to create the cluster
   const result = await runCliCommand(kindCli, ['create', 'cluster', '--config', tmpFilePath], { env, logger }, token);
 
@@ -88,6 +91,9 @@ export async function createCluster(
   await fs.promises.rm(tmpDirectory, { recursive: true });
 
   if (result.exitCode !== 0) {
+    telemetryLogger.logError('createCluster', { provider, error: result.error, stdErr: result.stdErr });
     throw new Error(`Failed to create kind cluster. ${result.error}`);
+  } else {
+    telemetryLogger.logUsage('createClusterSuccess', { provider });
   }
 }

--- a/extensions/kind/src/create-cluster.ts
+++ b/extensions/kind/src/create-cluster.ts
@@ -82,8 +82,6 @@ export async function createCluster(
   // ok we need to write the file
   await fs.promises.writeFile(tmpFilePath, kindClusterConfig, 'utf8');
 
-  telemetryLogger.logUsage('createCluster', { provider, httpHostPort, httpsHostPort });
-
   // now execute the command to create the cluster
   const result = await runCliCommand(kindCli, ['create', 'cluster', '--config', tmpFilePath], { env, logger }, token);
 
@@ -91,9 +89,15 @@ export async function createCluster(
   await fs.promises.rm(tmpDirectory, { recursive: true });
 
   if (result.exitCode !== 0) {
-    telemetryLogger.logError('createCluster', { provider, error: result.error, stdErr: result.stdErr });
+    telemetryLogger.logError('createCluster', {
+      provider,
+      httpHostPort,
+      httpsHostPort,
+      error: result.error,
+      stdErr: result.stdErr,
+    });
     throw new Error(`Failed to create kind cluster. ${result.error}`);
   } else {
-    telemetryLogger.logUsage('createClusterSuccess', { provider });
+    telemetryLogger.logUsage('createCluster', { provider, httpHostPort, httpsHostPort });
   }
 }

--- a/extensions/kind/src/kind-installer.spec.ts
+++ b/extensions/kind/src/kind-installer.spec.ts
@@ -44,8 +44,15 @@ vi.mock('@octokit/rest', () => {
   };
 });
 
+const telemetryLogUsageMock = vi.fn();
+const telemetryLogErrorMock = vi.fn();
+const telemetryLoggerMock = {
+  logUsage: telemetryLogUsageMock,
+  logError: telemetryLogErrorMock,
+} as unknown as extensionApi.TelemetryLogger;
+
 beforeEach(() => {
-  installer = new KindInstaller('.');
+  installer = new KindInstaller('.', telemetryLoggerMock);
   vi.clearAllMocks();
 });
 
@@ -66,6 +73,11 @@ test('expect showNotification to be called', async () => {
     };
   });
   const result = await installer.performInstall();
+  expect(telemetryLogErrorMock).not.toBeCalled();
+  expect(telemetryLogUsageMock).toHaveBeenNthCalledWith(1, 'install-kind-prompt');
+  expect(telemetryLogUsageMock).toHaveBeenNthCalledWith(2, 'install-kind-prompt-yes');
+  expect(telemetryLogUsageMock).toHaveBeenNthCalledWith(3, 'install-kind-success');
+
   expect(result).toBeDefined();
   expect(result).toBeTruthy();
   expect(spy).toBeCalled();

--- a/extensions/kind/src/kind-installer.spec.ts
+++ b/extensions/kind/src/kind-installer.spec.ts
@@ -76,7 +76,7 @@ test('expect showNotification to be called', async () => {
   expect(telemetryLogErrorMock).not.toBeCalled();
   expect(telemetryLogUsageMock).toHaveBeenNthCalledWith(1, 'install-kind-prompt');
   expect(telemetryLogUsageMock).toHaveBeenNthCalledWith(2, 'install-kind-prompt-yes');
-  expect(telemetryLogUsageMock).toHaveBeenNthCalledWith(3, 'install-kind-success');
+  expect(telemetryLogUsageMock).toHaveBeenNthCalledWith(3, 'install-kind-downloaded');
 
   expect(result).toBeDefined();
   expect(result).toBeTruthy();

--- a/extensions/kind/src/kind-installer.ts
+++ b/extensions/kind/src/kind-installer.ts
@@ -135,7 +135,7 @@ export class KindInstaller {
                 const stat = fs.statSync(destFile);
                 fs.chmodSync(destFile, stat.mode | fs.constants.S_IXUSR);
               }
-              this.telemetryLogger.logUsage('install-kind-success');
+              this.telemetryLogger.logUsage('install-kind-downloaded');
               extensionApi.window.showNotification({ body: 'Kind is successfully installed.' });
               return true;
             }

--- a/extensions/kind/src/kind-installer.ts
+++ b/extensions/kind/src/kind-installer.ts
@@ -59,7 +59,7 @@ export class KindInstaller {
 
   private assetPromise: Promise<AssetInfo>;
 
-  constructor(private readonly storagePath: string) {
+  constructor(private readonly storagePath: string, private telemetryLogger: extensionApi.TelemetryLogger) {
     this.assetNames.set(WINDOWS_X64_PLATFORM, WINDOWS_X64_ASSET_NAME);
     this.assetNames.set(LINUX_X64_PLATFORM, LINUX_X64_ASSET_NAME);
     this.assetNames.set(LINUX_ARM64_PLATFORM, LINUX_ARM64_ASSET_NAME);
@@ -102,12 +102,14 @@ export class KindInstaller {
   }
 
   async performInstall(): Promise<boolean> {
+    this.telemetryLogger.logUsage('install-kind-prompt');
     const dialogResult = await extensionApi.window.showInformationMessage(
       'kind is not installed on this system, would you like to install Kind ?',
       'Yes',
       'No',
     );
     if (dialogResult === 'Yes') {
+      this.telemetryLogger.logUsage('install-kind-prompt-yes');
       return extensionApi.window.withProgress({ location: ProgressLocation.APP_ICON }, async progress => {
         progress.report({ increment: 5 });
         try {
@@ -133,6 +135,7 @@ export class KindInstaller {
                 const stat = fs.statSync(destFile);
                 fs.chmodSync(destFile, stat.mode | fs.constants.S_IXUSR);
               }
+              this.telemetryLogger.logUsage('install-kind-success');
               extensionApi.window.showNotification({ body: 'Kind is successfully installed.' });
               return true;
             }
@@ -141,6 +144,8 @@ export class KindInstaller {
           progress.report({ increment: -1 });
         }
       });
+    } else {
+      this.telemetryLogger.logUsage('install-kind-prompt-no');
     }
     return false;
   }


### PR DESCRIPTION



### What does this PR do?
Send some telemetry events about kind support (success/error)
like: click on Download kind, accept or not, succeed or not
create cluster with provider being selected, if there is success or not

depends on 
-  https://github.com/containers/podman-desktop/pull/1996


Also log usage of create clusters

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/1954


### How to test this PR?

Look at unit tests
Look at segment debugger


Change-Id: I7f7a59360e5ed32edc3a6b4d4593c9771928705e
