### PR TITLE
feat: add actions to kind clusters in resources page (#1953)

### DIFF
--- a/extensions/kind/src/extension.ts
+++ b/extensions/kind/src/extension.ts
@@ -118,7 +118,11 @@ async function updateClusters(provider: extensionApi.Provider, containers: exten
           await extensionApi.containerEngine.stopContainer(cluster.engineId, cluster.id);
         },
         delete: async (logger): Promise<void> => {
-          await runCliCommand(kindCli, ['delete', 'clusters', cluster.name], { logger });
+          const env = process.env;
+          if (cluster.engineType === 'podman') {
+            env['KIND_EXPERIMENTAL_PROVIDER'] = 'podman';
+          }
+          await runCliCommand(kindCli, ['delete', 'cluster', '--name', cluster.name], { env, logger });
         },
       };
       // create a new connection

--- a/extensions/kind/src/extension.ts
+++ b/extensions/kind/src/extension.ts
@@ -17,7 +17,7 @@
  ***********************************************************************/
 
 import * as extensionApi from '@podman-desktop/api';
-import { detectKind } from './util';
+import { detectKind, runCliCommand } from './util';
 import { KindInstaller } from './kind-installer';
 import type { CancellationToken, Logger } from '@podman-desktop/api';
 import { window } from '@podman-desktop/api';
@@ -64,7 +64,7 @@ function registerProvider(
 
 // search for clusters
 async function updateClusters(provider: extensionApi.Provider, containers: extensionApi.ContainerInfo[]) {
-  kindClusters = containers.map(container => {
+  const kindContainers = containers.map(container => {
     const clusterName = container.Labels['io.x-k8s.kind.cluster'];
     const clusterStatus = container.State;
 
@@ -84,15 +84,43 @@ async function updateClusters(provider: extensionApi.Provider, containers: exten
       status,
       apiPort: listeningPort?.PublicPort || 0,
       engineType: container.engineType,
+      engineId: container.engineId,
+      id: container.Id,
+    };
+  });
+  kindClusters = kindContainers.map(container => {
+    return {
+      name: container.name,
+      status: container.status,
+      apiPort: container.apiPort,
+      engineType: container.engineType,
     };
   });
 
-  kindClusters.forEach(cluster => {
+  kindContainers.forEach(cluster => {
     const item = registeredKubernetesConnections.find(item => item.connection.name === cluster.name);
     const status = () => {
       return cluster.status;
     };
     if (!item) {
+      const lifecycle: extensionApi.ProviderConnectionLifecycle = {
+        start: async (): Promise<void> => {
+          try {
+            // start the container
+            await extensionApi.containerEngine.startContainer(cluster.engineId, cluster.id);
+          } catch (err) {
+            console.error(err);
+            // propagate the error
+            throw err;
+          }
+        },
+        stop: async (): Promise<void> => {
+          await extensionApi.containerEngine.stopContainer(cluster.engineId, cluster.id);
+        },
+        delete: async (logger): Promise<void> => {
+          await runCliCommand(kindCli, ['delete', 'clusters', cluster.name], { logger });
+        },
+      };
       // create a new connection
       const connection: extensionApi.KubernetesProviderConnection = {
         name: cluster.name,
@@ -100,6 +128,7 @@ async function updateClusters(provider: extensionApi.Provider, containers: exten
         endpoint: {
           apiURL: `https://localhost:${cluster.apiPort}`,
         },
+        lifecycle,
       };
       const disposable = provider.registerKubernetesProviderConnection(connection);
 

--- a/extensions/kind/src/image-handler.ts
+++ b/extensions/kind/src/image-handler.ts
@@ -64,13 +64,12 @@ export class ImageHandler {
           extensionApi.window.showNotification({
             body: `Image ${image.name} pushed to Kind cluster ${selectedCluster.label}`,
           });
-        } else {
-          throw new Error(
-            `Error while pushing image ${image.name} to Kind cluster ${selectedCluster.label}: ${result.error}`,
-          );
         }
-      } catch (err) {
-        throw new Error(`Error while pushing image ${image.name} to Kind cluster ${selectedCluster.label}: ${err}`);
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : '' + error;
+        throw new Error(
+          `Error while pushing image ${image.name} to Kind cluster ${selectedCluster.label}: ${errorMessage}`,
+        );
       } finally {
         fs.promises.rm(filename);
       }

--- a/extensions/kind/src/util.ts
+++ b/extensions/kind/src/util.ts
@@ -38,7 +38,6 @@ export function isLinux(): boolean {
 }
 
 export interface SpawnResult {
-  exitCode: number;
   stdOut: string;
   stdErr: string;
   error: undefined | string;
@@ -67,10 +66,8 @@ export function getKindPath(): string {
 // search if kind is available in the path
 export async function detectKind(pathAddition: string, installer: KindInstaller): Promise<string> {
   try {
-    const result = await runCliCommand('kind', ['--version'], { env: { PATH: getKindPath() } });
-    if (result.exitCode === 0) {
-      return 'kind';
-    }
+    await runCliCommand('kind', ['--version'], { env: { PATH: getKindPath() } });
+    return 'kind';
   } catch (e) {
     // ignore and try another way
   }
@@ -78,12 +75,10 @@ export async function detectKind(pathAddition: string, installer: KindInstaller)
   const assetInfo = await installer.getAssetInfo();
   if (assetInfo) {
     try {
-      const result = await runCliCommand(assetInfo.name, ['--version'], {
+      await runCliCommand(assetInfo.name, ['--version'], {
         env: { PATH: getKindPath().concat(path.delimiter).concat(pathAddition) },
       });
-      if (result.exitCode === 0) {
-        return pathAddition.concat(path.sep).concat(isWindows() ? assetInfo.name + '.exe' : assetInfo.name);
-      }
+      return pathAddition.concat(path.sep).concat(isWindows() ? assetInfo.name + '.exe' : assetInfo.name);
     } catch (e) {
       // ignore
     }
@@ -163,7 +158,7 @@ export function runCliCommand(
 
     spawnProcess.on('close', exitCode => {
       if (exitCode == 0) {
-        resolve({ exitCode, stdOut, stdErr, error: err });
+        resolve({ stdOut, stdErr, error: err });
       } else {
         if (options?.logger) {
           options.logger.error(stdErr);

--- a/extensions/kind/src/util.ts
+++ b/extensions/kind/src/util.ts
@@ -80,7 +80,7 @@ export async function detectKind(pathAddition: string, installer: KindInstaller)
       });
       return pathAddition.concat(path.sep).concat(isWindows() ? assetInfo.name + '.exe' : assetInfo.name);
     } catch (e) {
-      // ignore
+      console.error(e);
     }
   }
   return undefined;

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -1398,6 +1398,8 @@ declare module '@podman-desktop/api' {
   export namespace containerEngine {
     export function listContainers(): Promise<ContainerInfo[]>;
     export function inspectContainer(engineId: string, id: string): Promise<ContainerInspectInfo>;
+    export function startContainer(engineId: string, id: string): Promise<void>;
+    export function stopContainer(engineId: string, id: string): Promise<void>;
     export function saveImage(engineId: string, id: string, filename: string): Promise<void>;
     export const onEvent: Event<ContainerJSONEvent>;
   }

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -598,6 +598,12 @@ export class ExtensionLoader {
       inspectContainer(engineId: string, id: string): Promise<containerDesktopAPI.ContainerInspectInfo> {
         return containerProviderRegistry.getContainerInspect(engineId, id);
       },
+      startContainer(engineId: string, id: string) {
+        return containerProviderRegistry.startContainer(engineId, id);
+      },
+      stopContainer(engineId: string, id: string) {
+        return containerProviderRegistry.stopContainer(engineId, id);
+      },
       saveImage(engineId: string, id: string, filename: string) {
         return containerProviderRegistry.saveImage(engineId, id, filename);
       },

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionActions.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionActions.spec.ts
@@ -1,0 +1,219 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom';
+import { test, expect } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import type {
+  ProviderContainerConnectionInfo,
+  ProviderInfo,
+  ProviderKubernetesConnectionInfo,
+} from '../../../../main/src/plugin/api/provider-info';
+import type { IConnectionStatus } from './Util';
+import { getProviderConnectionName } from './Util';
+import PreferencesConnectionActions from './PreferencesConnectionActions.svelte';
+
+const containerProviderInfo: ProviderInfo = {
+  id: 'provider',
+  name: 'provider',
+  images: {
+    icon: 'img',
+  },
+  status: 'started',
+  warnings: undefined,
+  containerProviderConnectionCreation: true,
+  detectionChecks: undefined,
+  containerConnections: [],
+  installationSupport: undefined,
+  internalId: '0',
+  kubernetesConnections: [],
+  kubernetesProviderConnectionCreation: true,
+  links: undefined,
+  containerProviderConnectionInitialization: false,
+  kubernetesProviderConnectionInitialization: false,
+};
+
+const containerConnection: ProviderContainerConnectionInfo = {
+  name: 'machine',
+  status: 'started',
+  endpoint: {
+    socketPath: 'socket',
+  },
+  lifecycleMethods: ['start', 'stop', 'delete'],
+  type: 'podman',
+};
+
+const kubernetesConnection: ProviderKubernetesConnectionInfo = {
+  name: 'machine',
+  status: 'started',
+  endpoint: {
+    apiURL: 'url',
+  },
+  lifecycleMethods: ['start', 'stop', 'delete'],
+};
+
+const updateConnectionStatus = () => {
+  //nothing
+};
+
+const addConnectionToRestartingQueue = () => {
+  //nothing
+};
+
+const connectionStatuses = new Map<string, IConnectionStatus>();
+
+const connectionStatus: IConnectionStatus = {
+  status: 'started',
+  inProgress: false,
+};
+
+test('if container connection has start lifecycle method, start button has to be visible', () => {
+  const customProviderInfo: ProviderInfo = { ...containerProviderInfo, name: 'podman' };
+  const connectionName = getProviderConnectionName(customProviderInfo, containerConnection);
+  connectionStatuses.set(connectionName, connectionStatus);
+
+  render(PreferencesConnectionActions, {
+    connectionStatuses,
+    provider: customProviderInfo,
+    connection: containerConnection,
+    updateConnectionStatus,
+    addConnectionToRestartingQueue,
+  });
+  const button = screen.getByRole('button', { name: 'Start' });
+  expect(button).toBeInTheDocument();
+});
+
+test('if container connection has stop lifecycle method, stop button has to be visible', () => {
+  const customProviderInfo: ProviderInfo = { ...containerProviderInfo, name: 'podman' };
+  const connectionName = getProviderConnectionName(customProviderInfo, containerConnection);
+  connectionStatuses.set(connectionName, connectionStatus);
+
+  render(PreferencesConnectionActions, {
+    connectionStatuses,
+    provider: customProviderInfo,
+    connection: containerConnection,
+    updateConnectionStatus,
+    addConnectionToRestartingQueue,
+  });
+  const button = screen.getByRole('button', { name: 'Stop' });
+  expect(button).toBeInTheDocument();
+});
+
+test('if container connection has start and stop lifecycle methods, restart button has to be visible', () => {
+  const customProviderInfo: ProviderInfo = { ...containerProviderInfo, name: 'podman' };
+  const connectionName = getProviderConnectionName(customProviderInfo, containerConnection);
+  connectionStatuses.set(connectionName, connectionStatus);
+
+  render(PreferencesConnectionActions, {
+    connectionStatuses,
+    provider: customProviderInfo,
+    connection: containerConnection,
+    updateConnectionStatus,
+    addConnectionToRestartingQueue,
+  });
+  const startButton = screen.getByRole('button', { name: 'Start' });
+  expect(startButton).toBeInTheDocument();
+  const stopButton = screen.getByRole('button', { name: 'Stop' });
+  expect(stopButton).toBeInTheDocument();
+  const restartButton = screen.getByRole('button', { name: 'Restart' });
+  expect(restartButton).toBeInTheDocument();
+});
+
+test('if container connection has delete lifecycle method, delete button has to be visible', () => {
+  const customProviderInfo: ProviderInfo = { ...containerProviderInfo, name: 'podman' };
+  const connectionName = getProviderConnectionName(customProviderInfo, containerConnection);
+  connectionStatuses.set(connectionName, connectionStatus);
+
+  render(PreferencesConnectionActions, {
+    connectionStatuses,
+    provider: customProviderInfo,
+    connection: containerConnection,
+    updateConnectionStatus,
+    addConnectionToRestartingQueue,
+  });
+  const button = screen.getByRole('button', { name: 'Delete' });
+  expect(button).toBeInTheDocument();
+});
+
+test('if kubernetes connection has start lifecycle method, start button has to be visible', () => {
+  const customProviderInfo: ProviderInfo = { ...containerProviderInfo, name: 'kube' };
+  const connectionName = getProviderConnectionName(customProviderInfo, kubernetesConnection);
+  connectionStatuses.set(connectionName, connectionStatus);
+
+  render(PreferencesConnectionActions, {
+    connectionStatuses,
+    provider: customProviderInfo,
+    connection: kubernetesConnection,
+    updateConnectionStatus,
+    addConnectionToRestartingQueue,
+  });
+  const button = screen.getByRole('button', { name: 'Start' });
+  expect(button).toBeInTheDocument();
+});
+
+test('if kubernetes connection has stop lifecycle method, stop button has to be visible', () => {
+  const customProviderInfo: ProviderInfo = { ...containerProviderInfo, name: 'kube' };
+  const connectionName = getProviderConnectionName(customProviderInfo, kubernetesConnection);
+  connectionStatuses.set(connectionName, connectionStatus);
+
+  render(PreferencesConnectionActions, {
+    connectionStatuses,
+    provider: customProviderInfo,
+    connection: kubernetesConnection,
+    updateConnectionStatus,
+    addConnectionToRestartingQueue,
+  });
+  const button = screen.getByRole('button', { name: 'Stop' });
+  expect(button).toBeInTheDocument();
+});
+
+test('if kubernetes connection has start and stop lifecycle methods, restart button has to be visible', () => {
+  const customProviderInfo: ProviderInfo = { ...containerProviderInfo, name: 'kube' };
+  const connectionName = getProviderConnectionName(customProviderInfo, kubernetesConnection);
+  connectionStatuses.set(connectionName, connectionStatus);
+
+  render(PreferencesConnectionActions, {
+    connectionStatuses,
+    provider: customProviderInfo,
+    connection: kubernetesConnection,
+    updateConnectionStatus,
+    addConnectionToRestartingQueue,
+  });
+  const startButton = screen.getByRole('button', { name: 'Start' });
+  expect(startButton).toBeInTheDocument();
+  const stopButton = screen.getByRole('button', { name: 'Stop' });
+  expect(stopButton).toBeInTheDocument();
+  const restartButton = screen.getByRole('button', { name: 'Restart' });
+  expect(restartButton).toBeInTheDocument();
+});
+
+test('if kubernetes connection has delete lifecycle method, delete button has to be visible', () => {
+  const customProviderInfo: ProviderInfo = { ...containerProviderInfo, name: 'kube' };
+  const connectionName = getProviderConnectionName(customProviderInfo, kubernetesConnection);
+  connectionStatuses.set(connectionName, connectionStatus);
+
+  render(PreferencesConnectionActions, {
+    connectionStatuses,
+    provider: customProviderInfo,
+    connection: kubernetesConnection,
+    updateConnectionStatus,
+    addConnectionToRestartingQueue,
+  });
+  const button = screen.getByRole('button', { name: 'Delete' });
+  expect(button).toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionActions.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionActions.svelte
@@ -11,7 +11,7 @@ import { getProviderConnectionName, IConnectionRestart, IConnectionStatus } from
 
 export let connectionStatuses: Map<string, IConnectionStatus>;
 export let provider: ProviderInfo;
-export let container: ProviderContainerConnectionInfo | ProviderKubernetesConnectionInfo;
+export let connection: ProviderContainerConnectionInfo | ProviderKubernetesConnectionInfo;
 export let updateConnectionStatus: (
   provider: ProviderInfo,
   providerConnectionInfo: ProviderContainerConnectionInfo | ProviderKubernetesConnectionInfo,
@@ -136,42 +136,42 @@ function getLoggerHandler(
 }
 </script>
 
-{#if connectionStatus.has(getProviderConnectionName(provider, container))}
-  {@const state = connectionStatus.get(getProviderConnectionName(provider, container))}
-  {#if container.lifecycleMethods && container.lifecycleMethods.length > 0}
+{#if connectionStatus.has(getProviderConnectionName(provider, connection))}
+  {@const state = connectionStatus.get(getProviderConnectionName(provider, connection))}
+  {#if connection.lifecycleMethods && connection.lifecycleMethods.length > 0}
     <div class="mt-2 relative">
       <!-- TODO: see action available like machine infos -->
       <div class="flex bg-zinc-900 w-fit rounded-lg m-auto">
-        {#if container.lifecycleMethods.includes('start')}
+        {#if connection.lifecycleMethods.includes('start')}
           <div class="ml-2">
             <LoadingIconButton
-              clickAction="{() => startConnectionProvider(provider, container)}"
+              clickAction="{() => startConnectionProvider(provider, connection)}"
               action="start"
               icon="{faPlay}"
               state="{state}"
               leftPosition="left-[0.15rem]" />
           </div>
         {/if}
-        {#if container.lifecycleMethods.includes('start') && container.lifecycleMethods.includes('stop')}
+        {#if connection.lifecycleMethods.includes('start') && connection.lifecycleMethods.includes('stop')}
           <LoadingIconButton
-            clickAction="{() => restartConnectionProvider(provider, container)}"
+            clickAction="{() => restartConnectionProvider(provider, connection)}"
             action="restart"
             icon="{faRotateRight}"
             state="{state}"
             leftPosition="left-1.5" />
         {/if}
-        {#if container.lifecycleMethods.includes('stop')}
+        {#if connection.lifecycleMethods.includes('stop')}
           <LoadingIconButton
-            clickAction="{() => stopConnectionProvider(provider, container)}"
+            clickAction="{() => stopConnectionProvider(provider, connection)}"
             action="stop"
             icon="{faStop}"
             state="{state}"
             leftPosition="left-[0.22rem]" />
         {/if}
-        {#if container.lifecycleMethods.includes('delete')}
+        {#if connection.lifecycleMethods.includes('delete')}
           <div class="mr-2 text-sm">
             <LoadingIconButton
-              clickAction="{() => deleteConnectionProvider(provider, container)}"
+              clickAction="{() => deleteConnectionProvider(provider, connection)}"
               action="delete"
               icon="{faTrash}"
               state="{state}"


### PR DESCRIPTION
### What does this PR do?

Adds start, restart, stop, delete actions to kind cluster in resources page

### Screenshot/screencast of this PR

![start-stop-delete-kind](https://user-images.githubusercontent.com/49404737/230980659-8ec3a978-60d2-43da-b03c-0f651769bf7d.gif)

### What issues does this PR fix or reference?

it resolves #1953
fixes https://github.com/containers/podman-desktop/issues/2029

### How to test this PR?

1. settings -> resources -> start, stop, delete a kind cluster