### PR TITLE
Use short id/name for pods and volumes, fix layout

### DIFF
--- a/packages/renderer/src/lib/ContainerDetails.svelte
+++ b/packages/renderer/src/lib/ContainerDetails.svelte
@@ -85,7 +85,7 @@ function errorCallback(errorMessage: string): void {
               </div>
             </section>
           </div>
-          <div class="flex flex-col w-full px-5 pt-5">
+          <div class="flex flex-col px-5 pt-5">
             <div class="flex justify-end">
               <div class="flex items-center w-5">
                 {#if container.actionInProgress}

--- a/packages/renderer/src/lib/image/ImageDetails.svelte
+++ b/packages/renderer/src/lib/image/ImageDetails.svelte
@@ -80,7 +80,7 @@ onMount(() => {
               </div>
             </section>
           </div>
-          <div class="flex flex-col w-full px-5 pt-5">
+          <div class="flex flex-col px-5 pt-5">
             <div class="flex justify-end">
               <ImageActions
                 image="{image}"

--- a/packages/renderer/src/lib/pod/PodDetails.svelte
+++ b/packages/renderer/src/lib/pod/PodDetails.svelte
@@ -78,7 +78,7 @@ function errorCallback(errorMessage: string): void {
               </div>
               <div class="text-lg flex flex-col">
                 <div class="mr-2">{pod.name}</div>
-                <div class="mr-2 pb-4 text-small text-gray-500">{pod.id}</div>
+                <div class="mr-2 pb-4 text-small text-gray-500">{pod.shortId}</div>
               </div>
             </div>
             <section class="pf-c-page__main-tabs pf-m-limit-width">
@@ -94,7 +94,7 @@ function errorCallback(errorMessage: string): void {
               </div>
             </section>
           </div>
-          <div class="flex flex-col w-full px-5 pt-5">
+          <div class="flex flex-col px-5 pt-5">
             <div class="flex justify-end">
               <div class="flex items-center w-5">
                 {#if pod.actionInProgress}

--- a/packages/renderer/src/lib/volume/VolumeDetails.svelte
+++ b/packages/renderer/src/lib/volume/VolumeDetails.svelte
@@ -49,7 +49,7 @@ onMount(() => {
                 <StatusIcon icon="{VolumeIcon}" status="{volume.inUse ? 'USED' : 'UNUSED'}" />
               </div>
               <div class="text-lg flex flex-col">
-                <div class="mr-2">{volume.name}</div>
+                <div class="mr-2">{volume.shortName}</div>
                 <div class="mr-2 pb-4 text-small text-gray-500">{volume.humanSize}</div>
               </div>
             </div>
@@ -65,7 +65,7 @@ onMount(() => {
               </div>
             </section>
           </div>
-          <div class="flex flex-col w-full px-5 pt-5">
+          <div class="flex flex-col px-5 pt-5">
             <div class="flex justify-end">
               <VolumeActions volume="{volume}" detailed="{true}" />
             </div>


### PR DESCRIPTION
### What does this PR do?

The pod id and volume name are long strings, and often cause the action buttons to be pushed off the right of the screen. Using shortId and shortName fix the problem.

Both the left details and right action panel were set to w-full, which would often mean that the details would get wrapped even though there was enough space. Removed the w-full from the action panels so that they never take more space than the width of the buttons.

### Screenshot/screencast of this PR

Before:
![screenshot_from_2023-04-11_14-01-39](https://user-images.githubusercontent.com/19958075/231166148-6d669cf7-5ebf-4e34-b920-f629b5dc63a6.png)

<img width="649" alt="Screenshot 2023-04-11 at 8 16 21 AM" src="https://user-images.githubusercontent.com/19958075/231166221-7530f256-8312-454e-a8ec-36ede2be0f1e.png">

After:
<img width="464" alt="Screenshot 2023-04-11 at 8 20 23 AM" src="https://user-images.githubusercontent.com/19958075/231166302-95e01afb-03de-4a68-bffc-4cbed35a4055.png">

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Open Details tabs on each tab, check for width and look.