### PR TITLE
feat: Update extension state, preferences page

### DIFF
--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -122,7 +122,7 @@ export class ExtensionLoader {
       description: extension.manifest.description,
       version: extension.manifest.version,
       publisher: extension.manifest.publisher,
-      state: this.extensionState.get(extension.id) ? (this.extensionState.get(extension.id) || 'stopped' ): 'stopped',
+      state: this.extensionState.get(extension.id) ? this.extensionState.get(extension.id) || 'stopped' : 'stopped',
       id: extension.id,
       path: extension.path,
       removable: extension.removable,

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -725,6 +725,8 @@ export class ExtensionLoader {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   async activateExtension(extension: AnalyzedExtension, extensionMain: any): Promise<void> {
     this.extensionState.set(extension.id, 'starting');
+    this.apiSender.send('extension-starting', {});
+
     const subscriptions: containerDesktopAPI.Disposable[] = [];
 
     const extensionContext: containerDesktopAPI.ExtensionContext = {
@@ -749,6 +751,7 @@ export class ExtensionLoader {
     };
     this.activatedExtensions.set(extension.id, activatedExtension);
     this.extensionState.set(extension.id, 'started');
+    this.apiSender.send('extension-started', {});
   }
 
   async deactivateExtension(extensionId: string): Promise<void> {
@@ -758,6 +761,7 @@ export class ExtensionLoader {
     }
 
     this.extensionState.set(extension.id, 'stopping');
+    this.apiSender.send('extension-stopping', {});
     if (extension.deactivateFunction) {
       await extension.deactivateFunction();
     }
@@ -769,6 +773,7 @@ export class ExtensionLoader {
 
     this.activatedExtensions.delete(extensionId);
     this.extensionState.delete(extension.id);
+    this.apiSender.send('extension-stopped', {});
   }
 
   async stopAllExtensions(): Promise<void> {

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -122,7 +122,7 @@ export class ExtensionLoader {
       description: extension.manifest.description,
       version: extension.manifest.version,
       publisher: extension.manifest.publisher,
-      state: this.extensionState.get(extension.id) ? this.extensionState.get(extension.id) || 'stopped' : 'stopped',
+      state: this.extensionState.get(extension.id) || 'stopped',
       id: extension.id,
       path: extension.path,
       removable: extension.removable,

--- a/packages/renderer/src/lib/ExtensionList.svelte
+++ b/packages/renderer/src/lib/ExtensionList.svelte
@@ -3,7 +3,7 @@ import Fa from 'svelte-fa/src/fa.svelte';
 import { faPuzzlePiece, faTrash } from '@fortawesome/free-solid-svg-icons';
 import { faPlay } from '@fortawesome/free-solid-svg-icons';
 import { faStop } from '@fortawesome/free-solid-svg-icons';
-import { afterUpdate, onMount } from 'svelte';
+import { afterUpdate } from 'svelte';
 import { extensionInfos } from '../stores/extensions';
 import type { ExtensionInfo } from '../../../main/src/plugin/api/extension-info';
 import ErrorMessage from './ui/ErrorMessage.svelte';
@@ -54,15 +54,12 @@ afterUpdate(() => {
 
 async function stopExtension(extension: ExtensionInfo) {
   await window.stopExtension(extension.id);
-  window.dispatchEvent(new CustomEvent('extension-stopped', { detail: extension }));
 }
 async function startExtension(extension: ExtensionInfo) {
   await window.startExtension(extension.id);
-  window.dispatchEvent(new CustomEvent('extension-started', { detail: extension }));
 }
 async function removeExtension(extension: ExtensionInfo) {
   await window.removeExtension(extension.id);
-  window.dispatchEvent(new CustomEvent('extension-removed', { detail: extension }));
 }
 </script>
 

--- a/packages/renderer/src/lib/ExtensionList.svelte
+++ b/packages/renderer/src/lib/ExtensionList.svelte
@@ -8,6 +8,7 @@ import { extensionInfos } from '../stores/extensions';
 import type { ExtensionInfo } from '../../../main/src/plugin/api/extension-info';
 import ErrorMessage from './ui/ErrorMessage.svelte';
 import SettingsPage from './preferences/SettingsPage.svelte';
+import ConnectionStatus from './ui/ConnectionStatus.svelte';
 
 let ociImage: string;
 
@@ -59,7 +60,6 @@ async function startExtension(extension: ExtensionInfo) {
   await window.startExtension(extension.id);
   window.dispatchEvent(new CustomEvent('extension-started', { detail: extension }));
 }
-
 async function removeExtension(extension: ExtensionInfo) {
   await window.removeExtension(extension.id);
   window.dispatchEvent(new CustomEvent('extension-removed', { detail: extension }));
@@ -115,30 +115,31 @@ async function removeExtension(extension: ExtensionInfo) {
       </div>
     </div>
   </div>
-  <div class="shadow overflow-hidden border border-zinc-700 sm mt-2">
-    <table class="min-w-full divide-y divide-gray-800">
-      <tbody class="bg-zinc-900 divide-y divide-zinc-700">
+  <div class="bg-zinc-800 mt-5 rounded-md p-3">
+    <table class="min-w-full">
+      <tbody>
         {#each sortedExtensions as extension}
-          <tr>
-            <td class="px-6 py-2 whitespace-nowrap">
+          <tr class="border-y border-gray-600">
+            <td class="px-6 py-2">
               <div class="flex items-center">
-                <div class="flex-shrink-0 h-10 w-10 py-3" title="Extension {extension.name} is {extension.state}">
+                <div class="flex-shrink-0 h-10 w-10 py-1" title="Extension {extension.name} is {extension.state}">
                   <Fa
-                    class="h-10 w-10 rounded-full {extension.state === 'active' ? 'text-violet-600' : 'text-gray-700'}"
-                    icon="{faPuzzlePiece}" />
+                    class="h-10 w-10 rounded-full {extension.state === 'started' ? 'text-violet-600' : 'text-gray-700'}"
+                    size="25" icon="{faPuzzlePiece}" />
                 </div>
                 <div class="ml-4">
                   <div class="flex flex-row">
                     <div class="text-sm text-gray-200">
-                      {extension.name}
+                      {extension.displayName}
                       {extension.removable ? '(user)' : '(default extension)'}
+                      <span class="text-xs font-extra-light text-gray-500">v{extension.version}</span>
                     </div>
                   </div>
                   <div class="flex flex-row">
                     <div class="text-sm text-gray-400 italic">{extension.description}</div>
                   </div>
-                  <div class="flex flex-row text-xs font-extra-light text-violet-500">
-                    <div>v{extension.version}</div>
+                  <div class="flex">
+                    <ConnectionStatus status="{extension.state}"/>
                   </div>
                 </div>
               </div>
@@ -149,22 +150,21 @@ async function removeExtension(extension: ExtensionInfo) {
                   title="Start extension"
                   on:click="{() => startExtension(extension)}"
                   class="{buttonClass}"
-                  class:hidden="{extension.state === 'active'}"><Fa class="h-4 w-4" icon="{faPlay}" /></button>
+                  class:hidden="{extension.state !== 'stopped'}"><Fa class="h-4 w-4" icon="{faPlay}" /></button>
                 <button
                   title="Stop extension"
                   class="{buttonClass}"
                   on:click="{() => stopExtension(extension)}"
-                  hidden
-                  class:hidden="{extension.state !== 'active'}"><Fa class="h-4 w-4" icon="{faStop}" /></button>
+                  class:hidden="{extension.state !== 'started'}"><Fa class="h-4 w-4" icon="{faStop}" /></button>
 
                 {#if extension.removable}
-                  {#if extension.state === 'inactive'}
+                  {#if extension.state === 'stopped'}
                     <button title="Remove extension" class="{buttonClass}" on:click="{() => removeExtension(extension)}"
                       ><Fa class="h-4 w-4" icon="{faTrash}" /></button>
                   {:else}
                     <div
                       class="m-0.5 text-gray-700 rounded-full inline-flex items-center px-2 py-2 text-center"
-                      title="Active extension cannot be removed.">
+                      title="Running extension cannot be removed.">
                       <Fa class="h-4 w-4" icon="{faTrash}" />
                     </div>
                   {/if}

--- a/packages/renderer/src/lib/ExtensionList.svelte
+++ b/packages/renderer/src/lib/ExtensionList.svelte
@@ -125,7 +125,8 @@ async function removeExtension(extension: ExtensionInfo) {
                 <div class="flex-shrink-0 h-10 w-10 py-1" title="Extension {extension.name} is {extension.state}">
                   <Fa
                     class="h-10 w-10 rounded-full {extension.state === 'started' ? 'text-violet-600' : 'text-gray-700'}"
-                    size="25" icon="{faPuzzlePiece}" />
+                    size="25"
+                    icon="{faPuzzlePiece}" />
                 </div>
                 <div class="ml-4">
                   <div class="flex flex-row">
@@ -139,7 +140,7 @@ async function removeExtension(extension: ExtensionInfo) {
                     <div class="text-sm text-gray-400 italic">{extension.description}</div>
                   </div>
                   <div class="flex">
-                    <ConnectionStatus status="{extension.state}"/>
+                    <ConnectionStatus status="{extension.state}" />
                   </div>
                 </div>
               </div>

--- a/packages/renderer/src/lib/preferences/PreferencesExtensionRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesExtensionRendering.svelte
@@ -2,6 +2,8 @@
 import Route from '../../Route.svelte';
 import { extensionInfos } from '../../stores/extensions';
 import type { ExtensionInfo } from '../../../../main/src/plugin/api/extension-info';
+import SettingsPage from './SettingsPage.svelte';
+import ConnectionStatus from '../ui/ConnectionStatus.svelte';
 export let extensionId: string = undefined;
 
 let extensionInfo: ExtensionInfo;
@@ -9,57 +11,55 @@ $: extensionInfo = $extensionInfos.find(extension => extension.id === extensionI
 
 async function stopExtension() {
   await window.stopExtension(extensionInfo.id);
-  window.dispatchEvent(new CustomEvent('extension-stopped', { detail: extensionInfo }));
 }
 async function startExtension() {
   await window.startExtension(extensionInfo.id);
-  window.dispatchEvent(new CustomEvent('extension-started', { detail: extensionInfo }));
 }
 </script>
 
-<div class="flex flex-1 flex-col bg-zinc-800 px-2">
-  {#if extensionInfo}
-    <Route path="/*" breadcrumb="{extensionInfo.displayName}" let:meta>
-      <div class="pl-1 py-2">
-        <h1 class="capitalize text-xl">{extensionInfo.displayName} Extension</h1>
-        <div class="text-sm italic text-gray-400">{extensionInfo.description}</div>
-      </div>
-
-      <!-- Manage lifecycle-->
-      <div class="pl-1 py-2">
-        <div class="text-sm italic text-gray-400">Status</div>
-        <div class="pl-3 capitalize">{extensionInfo.state}</div>
-      </div>
-
-      <div class="py-2 flex flex:row">
-        <!-- start is enabled only in stopped mode-->
-        <div class="px-2 text-sm italic text-gray-400">
-          <button
-            disabled="{extensionInfo.state !== 'inactive'}"
-            on:click="{() => startExtension()}"
-            class="pf-c-button pf-m-primary"
-            type="button">
-            <span class="pf-c-button__icon pf-m-start">
-              <i class="fas fa-play" aria-hidden="true"></i>
-            </span>
-            Enable
-          </button>
+<SettingsPage title="{extensionInfo.displayName} Extension">
+  <span slot="subtitle">
+    {extensionInfo.description}
+  </span>
+  <div class="bg-zinc-800 mt-5 rounded-md p-3">
+    {#if extensionInfo}
+      <Route path="/*" breadcrumb="{extensionInfo.displayName}" let:meta>
+        <!-- Manage lifecycle-->
+        <div class="flex pb-2">
+          <div class="pr-2">Status</div>
+          <ConnectionStatus status="{extensionInfo.state}" />
         </div>
 
-        <!-- stop is enabled only in started mode-->
-        <div class="px-2 text-sm italic text-gray-400">
-          <button
-            disabled="{extensionInfo.state !== 'active'}"
-            on:click="{() => stopExtension()}"
-            class="pf-c-button pf-m-primary"
-            type="button">
-            <span class="pf-c-button__icon pf-m-start">
-              <i class="fas fa-stop" aria-hidden="true"></i>
-            </span>
-            Disable
-          </button>
+        <div class="py-2 flex flex:row gap-3">
+          <!-- start is enabled only when stopped -->
+          <div class="text-sm italic text-gray-400">
+            <button
+              disabled="{extensionInfo.state !== 'stopped'}"
+              on:click="{() => startExtension()}"
+              class="pf-c-button pf-m-primary"
+              type="button">
+              <span class="pf-c-button__icon pf-m-start">
+                <i class="fas fa-play" aria-hidden="true"></i>
+              </span>
+              Start
+            </button>
+          </div>
+
+          <!-- stop is enabled only when started -->
+          <div class="text-sm italic text-gray-400">
+            <button
+              disabled="{extensionInfo.state !== 'started'}"
+              on:click="{() => stopExtension()}"
+              class="pf-c-button pf-m-primary"
+              type="button">
+              <span class="pf-c-button__icon pf-m-start">
+                <i class="fas fa-stop" aria-hidden="true"></i>
+              </span>
+              Stop
+            </button>
+          </div>
         </div>
-      </div>
-    </Route>
-  {/if}
-</div>
+      </Route>
+    {/if}
+  </div>
+</SettingsPage>

--- a/packages/renderer/src/stores/containers.ts
+++ b/packages/renderer/src/stores/containers.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2022 Red Hat, Inc.
+ * Copyright (C) 2022-2023 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,10 +35,10 @@ export const filtered = derived([searchPattern, containersInfos], ([$searchPatte
 );
 
 // need to refresh when extension is started or stopped
-window?.events.receive('extension-started', () => {
+window.events?.receive('extension-started', () => {
   fetchContainers();
 });
-window?.events.receive('extension-stopped', () => {
+window.events?.receive('extension-stopped', () => {
   fetchContainers();
 });
 

--- a/packages/renderer/src/stores/containers.ts
+++ b/packages/renderer/src/stores/containers.ts
@@ -35,7 +35,10 @@ export const filtered = derived([searchPattern, containersInfos], ([$searchPatte
 );
 
 // need to refresh when extension is started or stopped
-window.addEventListener('extension-started', () => {
+window?.events.receive('extension-started', () => {
+  fetchContainers();
+});
+window?.events.receive('extension-stopped', () => {
   fetchContainers();
 });
 

--- a/packages/renderer/src/stores/extensions.ts
+++ b/packages/renderer/src/stores/extensions.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2022 Red Hat, Inc.
+ * Copyright (C) 2022-2023 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/renderer/src/stores/extensions.ts
+++ b/packages/renderer/src/stores/extensions.ts
@@ -28,17 +28,19 @@ export async function fetchExtensions() {
 export const extensionInfos: Writable<ExtensionInfo[]> = writable([]);
 
 // need to refresh when extension is started or stopped
-window.addEventListener('extension-started', () => {
+window?.events.receive('extension-starting', () => {
   fetchExtensions();
 });
-window.addEventListener('extension-stopped', () => {
-  fetchExtensions();
-});
-window.addEventListener('extension-removed', () => {
-  fetchExtensions();
-});
-
 window?.events.receive('extension-started', () => {
+  fetchExtensions();
+});
+window?.events.receive('extension-stopping', () => {
+  fetchExtensions();
+});
+window?.events.receive('extension-stopped', () => {
+  fetchExtensions();
+});
+window?.events.receive('extension-removed', () => {
   fetchExtensions();
 });
 window.addEventListener('system-ready', () => {

--- a/packages/renderer/src/stores/images.ts
+++ b/packages/renderer/src/stores/images.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2022 Red Hat, Inc.
+ * Copyright (C) 2022-2023 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,10 +34,10 @@ export const filtered = derived([searchPattern, imagesInfos], ([$searchPattern, 
 );
 
 // need to refresh when extension is started or stopped
-window?.events.receive('extension-started', () => {
+window?.events?.receive('extension-started', () => {
   fetchImages();
 });
-window?.events.receive('extension-stopped', () => {
+window?.events?.receive('extension-stopped', () => {
   fetchImages();
 });
 

--- a/packages/renderer/src/stores/images.ts
+++ b/packages/renderer/src/stores/images.ts
@@ -34,10 +34,10 @@ export const filtered = derived([searchPattern, imagesInfos], ([$searchPattern, 
 );
 
 // need to refresh when extension is started or stopped
-window.addEventListener('extension-started', () => {
+window?.events.receive('extension-started', () => {
   fetchImages();
 });
-window.addEventListener('extension-stopped', () => {
+window?.events.receive('extension-stopped', () => {
   fetchImages();
 });
 

--- a/packages/renderer/src/stores/pods.ts
+++ b/packages/renderer/src/stores/pods.ts
@@ -39,10 +39,10 @@ export const filtered = derived([searchPattern, podsInfos], ([$searchPattern, $i
 });
 
 // need to refresh when extension is started or stopped
-window.addEventListener('extension-started', () => {
+window?.events.receive('extension-started', () => {
   fetchPods();
 });
-window.addEventListener('extension-stopped', () => {
+window?.events.receive('extension-stopped', () => {
   fetchPods();
 });
 

--- a/packages/renderer/src/stores/pods.ts
+++ b/packages/renderer/src/stores/pods.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2022 Red Hat, Inc.
+ * Copyright (C) 2022-2023 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,10 +39,10 @@ export const filtered = derived([searchPattern, podsInfos], ([$searchPattern, $i
 });
 
 // need to refresh when extension is started or stopped
-window?.events.receive('extension-started', () => {
+window.events?.receive('extension-started', () => {
   fetchPods();
 });
-window?.events.receive('extension-stopped', () => {
+window.events?.receive('extension-stopped', () => {
   fetchPods();
 });
 

--- a/packages/renderer/src/stores/providers.ts
+++ b/packages/renderer/src/stores/providers.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2022 Red Hat, Inc.
+ * Copyright (C) 2022-2023 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,10 +37,10 @@ export async function fetchProviders() {
 export const providerInfos: Writable<ProviderInfo[]> = writable([]);
 
 // need to refresh when extension is started or stopped
-window?.events.receive('extension-started', () => {
+window?.events?.receive('extension-started', () => {
   fetchProviders();
 });
-window?.events.receive('extension-stopped', () => {
+window?.events?.receive('extension-stopped', () => {
   fetchProviders();
 });
 

--- a/packages/renderer/src/stores/providers.ts
+++ b/packages/renderer/src/stores/providers.ts
@@ -37,10 +37,10 @@ export async function fetchProviders() {
 export const providerInfos: Writable<ProviderInfo[]> = writable([]);
 
 // need to refresh when extension is started or stopped
-window.addEventListener('extension-started', () => {
+window?.events.receive('extension-started', () => {
   fetchProviders();
 });
-window.addEventListener('extension-stopped', () => {
+window?.events.receive('extension-stopped', () => {
   fetchProviders();
 });
 

--- a/packages/renderer/src/stores/volumes.ts
+++ b/packages/renderer/src/stores/volumes.ts
@@ -46,10 +46,10 @@ export const filtered = derived([searchPattern, volumeListInfos], ([$searchPatte
 });
 
 // need to refresh when extension is started or stopped
-window?.events.receive('extension-started', async () => {
+window?.events?.receive('extension-started', async () => {
   await fetchVolumes();
 });
-window?.events.receive('extension-stopped', async () => {
+window?.events?.receive('extension-stopped', async () => {
   await fetchVolumes();
 });
 

--- a/packages/renderer/src/stores/volumes.ts
+++ b/packages/renderer/src/stores/volumes.ts
@@ -46,10 +46,10 @@ export const filtered = derived([searchPattern, volumeListInfos], ([$searchPatte
 });
 
 // need to refresh when extension is started or stopped
-window.addEventListener('extension-started', async () => {
+window?.events.receive('extension-started', async () => {
   await fetchVolumes();
 });
-window.addEventListener('extension-stopped', async () => {
+window?.events.receive('extension-stopped', async () => {
   await fetchVolumes();
 });
 


### PR DESCRIPTION
### What does this PR do?

Updated extensions to have starting/stopping states instead of just active/inactive, updated the preference page to look like others, and fixed UX issues.

Notes:
- Change extension states (active/inactive) to match provider states (stopped, starting, started, stopping).
- Update extension page to use new states. Searched for other users, could not find any.
- Use displayName, and move version to the right of it.
- Add ConnectionStatus component to show current state, consistent with Resources page.
- Fix horizontal width issue (buttons hidden to the right).
- Fix table background/padding to look like Registries page.

IMHO there are still more improvements that should be made to this page (e.g. extension logos, further UX improvements), but this was a reasonable start.

### Screenshot/screencast of this PR

Before:
<img width="822" alt="Screenshot 2023-04-11 at 9 17 33 AM" src="https://user-images.githubusercontent.com/19958075/231182180-aca503b1-1a87-46f1-9850-e2d802f91ac9.png">

After:
<img width="872" alt="Screenshot 2023-04-11 at 9 36 36 AM" src="https://user-images.githubusercontent.com/19958075/231182221-4bfa69be-9c1a-419a-9a72-72f4900ab412.png">

### What issues does this PR fix or reference?

Fixes issue #2015.

### How to test this PR?

Just go to extensions page.