### PR TITLE
feat(extension-api): Allow to use the clipboard within extensions

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -1700,6 +1700,11 @@ declare module '@podman-desktop/api' {
      * @returns A new telemetry logger
      */
     export function createTelemetryLogger(sender?: TelemetrySender, options?: TelemetryLoggerOptions): TelemetryLogger;
+
+    /**
+     * The system clipboard.
+     */
+    export const clipboard: Clipboard;
   }
 
   /**
@@ -1829,5 +1834,22 @@ declare module '@podman-desktop/api' {
      */
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     readonly additionalCommonProperties?: Record<string, any>;
+  }
+
+  /**
+   * The clipboard provides read and write access to the system's clipboard.
+   */
+  export interface Clipboard {
+    /**
+     * Read the current clipboard contents as text.
+     * @returns A Promise that resolves to a string.
+     */
+    readText(): Promise<string>;
+
+    /**
+     * Writes text into the clipboard.
+     * @returns A Promise that resolves when writing happened.
+     */
+    writeText(value: string): Promise<void>;
   }
 }

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -51,7 +51,7 @@ import type { ApiSenderType } from './api';
 import type { AuthenticationImpl } from './authentication';
 import type { Telemetry } from './telemetry/telemetry';
 import { TelemetryTrustedValue } from './types/telemetry';
-
+import { clipboard as electronClipboard } from 'electron';
 /**
  * Handle the loading of an extension
  */
@@ -648,6 +648,16 @@ export class ExtensionLoader {
       },
       onDidChangeTelemetryEnabled: (listener, thisArg, disposables) => {
         return telemetry.onDidChangeTelemetryEnabled(listener, thisArg, disposables);
+      },
+      get clipboard(): containerDesktopAPI.Clipboard {
+        return {
+          readText: async () => {
+            return electronClipboard.readText();
+          },
+          writeText: async value => {
+            return electronClipboard.writeText(value);
+          },
+        };
       },
     };
 


### PR DESCRIPTION
### What does this PR do?
allow to read or write to the clipboard

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/1890

### How to test this PR?

```typescript
  const readItem = extensionApi.window.createStatusBarItem();
  readItem.text = 'read';
  readItem.command = 'read-clipboard';
  readItem.show();

  extensionApi.commands.registerCommand('read-clipboard', async () => {
    const text = await extensionApi.env.clipboard.readText();
    extensionApi.window.showInformationMessage(text);
  });

  const writeItem = extensionApi.window.createStatusBarItem();
  writeItem.text = 'write';
  writeItem.command = 'write-clipboard';
  writeItem.show();

  extensionApi.commands.registerCommand('write-clipboard', async () => {
    const text = await extensionApi.window.showInputBox({ placeHolder: 'Enter text to write to clipboard' });
    await extensionApi.env.clipboard.writeText(text);
  });
```

Change-Id: I072c681e8f8d10ec49a7b5af36a2b3a209ba538e
