### PR TITLE
feat(extension-api): Allow to open external URL

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -1685,6 +1685,14 @@ declare module '@podman-desktop/api' {
     export const onDidChangeTelemetryEnabled: Event<boolean>;
 
     /**
+     * Opens a link externally using the default application. Depending on the
+     *
+     * @param target The uri that should be opened.
+     * @returns A promise indicating if open was successful.
+     */
+    export function openExternal(uri: Uri): Promise<boolean>;
+
+    /**
      * Creates a new {@link TelemetryLogger telemetry logger}.
      *
      * @param sender The telemetry sender that is used by the telemetry logger.

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -39,6 +39,7 @@ import type { FilesystemMonitoring } from './filesystem-monitoring';
 import { Uri } from './types/uri';
 import type { KubernetesClient } from './kubernetes-client';
 import type { Proxy } from './proxy';
+import { shell as electronShell } from 'electron';
 import type { ContainerProviderRegistry } from './container-registry';
 import type { InputQuickPickRegistry } from './input-quickpick/input-quickpick-registry';
 import { QuickPickItemKind, InputBoxValidationSeverity } from './input-quickpick/input-quickpick-registry';
@@ -627,6 +628,15 @@ export class ExtensionLoader {
 
     const telemetry = this.telemetry;
     const env: typeof containerDesktopAPI.env = {
+      openExternal: async (uri: containerDesktopAPI.Uri): Promise<boolean> => {
+        try {
+          await electronShell.openExternal(uri.toString());
+          return true;
+        } catch (error) {
+          console.error(`Unable to open external link  ${uri.toString()} from extension ${extensionInfo.id}`, error);
+          return false;
+        }
+      },
       createTelemetryLogger: (
         sender?: containerDesktopAPI.TelemetrySender | undefined,
         options?: containerDesktopAPI.TelemetryLoggerOptions | undefined,


### PR DESCRIPTION

### What does this PR do?
Allow to open external URL

### Screenshot/screencast of this PR

n/A

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/1891


### How to test this PR?


```typescript
  const openExternalItem = extensionApi.window.createStatusBarItem();
  openExternalItem.text = 'openExternal';
  openExternalItem.command = 'my-openExternal';
  openExternalItem.show();

  extensionApi.commands.registerCommand('my-openExternal', async () => {
    const uri = extensionApi.Uri.parse('https://www.google.fr');
    await extensionApi.env.openExternal(uri);
  });
```


Change-Id: Iec588ab3143b3513feadd0e3d729d5cd62888f3e
