### PR TITLE
fix: get params when creating container/kube connection (#2013)

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.spec.ts
@@ -62,6 +62,7 @@ test('Expect to see checkbox enabled', async () => {
 
 test('Expect a checkbox when record is type boolean', async () => {
   const record: IConfigurationPropertyRecordedSchema = {
+    id: 'record',
     title: 'record',
     parentId: 'parent.record',
     description: 'record-description',
@@ -74,10 +75,12 @@ test('Expect a checkbox when record is type boolean', async () => {
   expect(input).toBeInTheDocument();
   expect(input instanceof HTMLInputElement).toBe(true);
   expect((input as HTMLInputElement).type).toBe('checkbox');
+  expect((input as HTMLInputElement).name).toBe('record');
 });
 
 test('Expect a slider when record and its maximum are type number and enableSlider is true', async () => {
   const record: IConfigurationPropertyRecordedSchema = {
+    id: 'record',
     title: 'record',
     parentId: 'parent.record',
     description: 'record-description',
@@ -93,10 +96,12 @@ test('Expect a slider when record and its maximum are type number and enableSlid
   expect(input).toBeInTheDocument();
   expect(input instanceof HTMLInputElement).toBe(true);
   expect((input as HTMLInputElement).type).toBe('range');
+  expect((input as HTMLInputElement).name).toBe('record');
 });
 
 test('Expect a text input when record is type number and enableSlider is false', async () => {
   const record: IConfigurationPropertyRecordedSchema = {
+    id: 'record',
     title: 'record',
     parentId: 'parent.record',
     description: 'record-description',
@@ -111,6 +116,7 @@ test('Expect a text input when record is type number and enableSlider is false',
   expect(input).toBeInTheDocument();
   expect(input instanceof HTMLInputElement).toBe(true);
   expect((input as HTMLInputElement).type).toBe('text');
+  expect((input as HTMLInputElement).name).toBe('record');
 });
 
 test('Expect an input button with Browse as placeholder when record is type string and format file', async () => {
@@ -132,6 +138,7 @@ test('Expect an input button with Browse as placeholder when record is type stri
 
 test('Expect a select when record is type string and has enum values', async () => {
   const record: IConfigurationPropertyRecordedSchema = {
+    id: 'record',
     title: 'record',
     parentId: 'parent.record',
     description: 'record-description',
@@ -144,10 +151,12 @@ test('Expect a select when record is type string and has enum values', async () 
   const input = screen.getByLabelText('record-description');
   expect(input).toBeInTheDocument();
   expect(input instanceof HTMLSelectElement).toBe(true);
+  expect((input as HTMLSelectElement).name).toBe('record');
 });
 
 test('Expect a text input when record is type string', async () => {
   const record: IConfigurationPropertyRecordedSchema = {
+    id: 'record',
     title: 'record',
     parentId: 'parent.record',
     description: 'record-description',
@@ -160,4 +169,5 @@ test('Expect a text input when record is type string', async () => {
   expect(input).toBeInTheDocument();
   expect(input instanceof HTMLInputElement).toBe(true);
   expect((input as HTMLInputElement).type).toBe('text');
+  expect((input as HTMLSelectElement).name).toBe('record');
 });

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
@@ -227,6 +227,7 @@ function handleCleanValue(
       <input
         id="input-slider-{record.id}"
         type="range"
+        name="{record.id}"
         min="{record.minimum}"
         max="{record.maximum}"
         value="{record.default}"
@@ -249,6 +250,7 @@ function handleCleanValue(
           type="text"
           readonly
           class="w-full outline-none focus:outline-none text-center text-white text-sm py-0.5"
+          name="{record.id}"
           value="{recordValue}"
           aria-label="{record.description}" />
         <button
@@ -280,7 +282,6 @@ function handleCleanValue(
           <Fa icon="{faXmark}" />
         </button>
         <input
-          name="{record.id}"
           on:click="{() => selectFilePath()}"
           id="rendering.FilePath.{record.id}"
           readonly


### PR DESCRIPTION
### What does this PR do?

It adds the name property to all inputs so that they are taken into account when filling the formData which send the values when creating a new connection 

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

part of #2013 

### How to test this PR?

1. create a new podman machine or kind cluster

P.S: I verified by debugging if the issue was fixed. All the params/values are sent correctly and used when executing the command. However on windows the cpus used are always 12 so i guess there is an issue in the cli. But this fixes the problem on PD
