### PR TITLE
chore(deps-dev): bump @tsconfig/svelte from 3.0.0 to 4.0.1

### DIFF
--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -17,7 +17,7 @@
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/svelte": "^3.2.2",
     "@testing-library/user-event": "^14.4.3",
-    "@tsconfig/svelte": "^3.0.0",
+    "@tsconfig/svelte": "^4.0.1",
     "@typescript-eslint/eslint-plugin": "5.58.0",
     "autoprefixer": "^10.4.14",
     "filesize": "^10.0.7",

--- a/packages/renderer/src/lib/ContainerDetails.svelte
+++ b/packages/renderer/src/lib/ContainerDetails.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { ContainerGroupInfoTypeUI, ContainerInfoUI } from './container/ContainerInfoUI';
+import { ContainerGroupInfoTypeUI, type ContainerInfoUI } from './container/ContainerInfoUI';
 import Route from '../Route.svelte';
 import ContainerIcon from './images/ContainerIcon.svelte';
 import StatusIcon from './images/StatusIcon.svelte';

--- a/packages/renderer/src/lib/ContainerList.svelte
+++ b/packages/renderer/src/lib/ContainerList.svelte
@@ -7,7 +7,7 @@ import ContainerIcon from './images/ContainerIcon.svelte';
 import ContainerGroupIcon from './container/ContainerGroupIcon.svelte';
 import StatusIcon from './images/StatusIcon.svelte';
 import { router } from 'tinro';
-import { ContainerGroupInfoTypeUI, ContainerGroupInfoUI, ContainerInfoUI } from './container/ContainerInfoUI';
+import { ContainerGroupInfoTypeUI, type ContainerGroupInfoUI, type ContainerInfoUI } from './container/ContainerInfoUI';
 import ContainerActions from './container/ContainerActions.svelte';
 import PodActions from './pod/PodActions.svelte';
 import ContainerEmptyScreen from './container/ContainerEmptyScreen.svelte';

--- a/packages/renderer/src/lib/container/ContainerActions.svelte
+++ b/packages/renderer/src/lib/container/ContainerActions.svelte
@@ -1,17 +1,10 @@
 <script lang="ts">
-import {
-  faAlignLeft,
-  faEllipsisVertical,
-  faFileCode,
-  faPlay,
-  faRocket,
-  faTerminal,
-} from '@fortawesome/free-solid-svg-icons';
+import { faAlignLeft, faFileCode, faPlay, faRocket, faTerminal } from '@fortawesome/free-solid-svg-icons';
 import { faStop } from '@fortawesome/free-solid-svg-icons';
 import { faArrowsRotate } from '@fortawesome/free-solid-svg-icons';
 import { faTrash } from '@fortawesome/free-solid-svg-icons';
 import { faExternalLinkSquareAlt } from '@fortawesome/free-solid-svg-icons';
-import { ContainerGroupInfoTypeUI, ContainerInfoUI } from './ContainerInfoUI';
+import { ContainerGroupInfoTypeUI, type ContainerInfoUI } from './ContainerInfoUI';
 
 import { router } from 'tinro';
 import ListItemButtonIcon from '../ui/ListItemButtonIcon.svelte';

--- a/packages/renderer/src/lib/dashboard/ProviderConfigured.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderConfigured.svelte
@@ -8,7 +8,7 @@ import ProviderUpdateButton from './ProviderUpdateButton.svelte';
 import { Steps } from 'svelte-steps';
 
 import { onMount } from 'svelte';
-import { InitializationMode, InitializeAndStartMode, InitializationSteps } from './ProviderInitUtils';
+import { type InitializationMode, InitializeAndStartMode, InitializationSteps } from './ProviderInitUtils';
 
 export let provider: ProviderInfo;
 export let initializationMode: InitializationMode;

--- a/packages/renderer/src/lib/dashboard/ProviderInstalled.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderInstalled.svelte
@@ -11,7 +11,7 @@ import 'xterm/css/xterm.css';
 import { TerminalSettings } from '../../../../main/src/plugin/terminal-settings';
 import { getPanelDetailColor } from '../color/color';
 import {
-  InitializationMode,
+  type InitializationMode,
   InitializationSteps,
   InitializeAndStartMode,
   InitializeOnlyMode,

--- a/packages/renderer/src/lib/image/BuildImageFromContainerfile.svelte
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfile.svelte
@@ -10,7 +10,7 @@ import { providerInfos } from '../../stores/providers';
 import NavPage from '../ui/NavPage.svelte';
 import NoContainerEngineEmptyScreen from './NoContainerEngineEmptyScreen.svelte';
 import {
-  BuildImageCallback,
+  type BuildImageCallback,
   clearBuildTask,
   disconnectUI,
   eventCollect,

--- a/packages/renderer/src/lib/pod/PodCreateFromContainers.svelte
+++ b/packages/renderer/src/lib/pod/PodCreateFromContainers.svelte
@@ -2,7 +2,7 @@
 import { providerInfos } from '../../stores/providers';
 import { onDestroy, onMount } from 'svelte';
 import type { ProviderContainerConnectionInfo, ProviderInfo } from '../../../../main/src/plugin/api/provider-info';
-import { PodCreation, podCreationHolder } from '../../stores/creation-from-containers-store';
+import { type PodCreation, podCreationHolder } from '../../stores/creation-from-containers-store';
 import NavPage from '../ui/NavPage.svelte';
 import { router } from 'tinro';
 import type { Unsubscriber } from 'svelte/store';

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionActions.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionActions.svelte
@@ -6,8 +6,8 @@ import type {
   ProviderKubernetesConnectionInfo,
 } from '../../../../main/src/plugin/api/provider-info';
 import LoadingIconButton from '../ui/LoadingIconButton.svelte';
-import { ConnectionCallback, eventCollect, startTask } from './preferences-connection-rendering-task';
-import { getProviderConnectionName, IConnectionRestart, IConnectionStatus } from './Util';
+import { type ConnectionCallback, eventCollect, startTask } from './preferences-connection-rendering-task';
+import { getProviderConnectionName, type IConnectionRestart, type IConnectionStatus } from './Util';
 
 export let connectionStatuses: Map<string, IConnectionStatus>;
 export let provider: ProviderInfo;

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationRendering.svelte
@@ -7,7 +7,7 @@ import { writeToTerminal } from './Util';
 import ErrorMessage from '../ui/ErrorMessage.svelte';
 import {
   clearCreateTask,
-  ConnectionCallback,
+  type ConnectionCallback,
   disconnectUI,
   eventCollect,
   reconnectUI,

--- a/packages/renderer/src/lib/preferences/PreferencesContainerConnectionRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesContainerConnectionRendering.svelte
@@ -13,7 +13,7 @@ import { writeToTerminal } from './Util';
 import ErrorMessage from '../ui/ErrorMessage.svelte';
 import Route from '../../Route.svelte';
 import { filesize } from 'filesize';
-import { ConnectionCallback, eventCollect, startTask } from './preferences-connection-rendering-task';
+import { type ConnectionCallback, eventCollect, startTask } from './preferences-connection-rendering-task';
 
 export let properties: IConfigurationPropertyRecordedSchema[] = [];
 export let providerInternalId: string = undefined;

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
@@ -14,7 +14,7 @@ import { router } from 'tinro';
 import SettingsPage from './SettingsPage.svelte';
 import ConnectionStatus from '../ui/ConnectionStatus.svelte';
 import { eventCollect } from './preferences-connection-rendering-task';
-import { getProviderConnectionName, IConnectionRestart, IConnectionStatus } from './Util';
+import { getProviderConnectionName, type IConnectionRestart, type IConnectionStatus } from './Util';
 import EngineIcon from '../ui/EngineIcon.svelte';
 import EmptyScreen from '../ui/EmptyScreen.svelte';
 import PreferencesConnectionActions from './PreferencesConnectionActions.svelte';

--- a/packages/renderer/src/lib/task-manager/TaskManagerItem.svelte
+++ b/packages/renderer/src/lib/task-manager/TaskManagerItem.svelte
@@ -2,8 +2,8 @@
 import { faClose, faInfoCircle, faSquareCheck, faTriangleExclamation } from '@fortawesome/free-solid-svg-icons';
 import { createEventDispatcher, onMount } from 'svelte';
 import Fa from 'svelte-fa/src/fa.svelte';
-import { TaskManager, TaskUI } from './task-manager';
-import { removeTask, Task } from '/@/stores/tasks';
+import { TaskManager, type TaskUI } from './task-manager';
+import { removeTask, type Task } from '/@/stores/tasks';
 
 export let task: Task;
 

--- a/packages/renderer/tsconfig.json
+++ b/packages/renderer/tsconfig.json
@@ -5,7 +5,6 @@
     "module": "esnext",
     "resolveJsonModule": true,
     "preserveValueImports": false,
-    "ignoreDeprecations": "5.0",
     "baseUrl": ".",
     "paths": {
       "/@/*": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -2947,10 +2947,10 @@
   resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.2.tgz#423c77877d0569db20e1fc80885ac4118314010e"
   integrity sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==
 
-"@tsconfig/svelte@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@tsconfig/svelte/-/svelte-3.0.0.tgz#b06e059209f04c414de0069f2f0e2796d979fc6f"
-  integrity sha512-pYrtLtOwku/7r1i9AMONsJMVYAtk3hzOfiGNekhtq5tYBGA7unMve8RvUclKLMT3PrihvJqUmzsRGh0RP84hKg==
+"@tsconfig/svelte@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@tsconfig/svelte/-/svelte-4.0.1.tgz#f36c1085fbdd868c10fb0426141956483dd4867b"
+  integrity sha512-B+XlGpmuAQzJqDoBATNCvEPqQg0HkO7S8pM14QDI5NsmtymzRexQ1N+nX2H6RTtFbuFgaZD4I8AAi8voGg0GLg==
 
 "@types/analytics-node@^3.1.11":
   version "3.1.11"


### PR DESCRIPTION

### What does this PR do?
Update to the latest configuration of tsconfig/svelte that is now using `"verbatimModuleSyntax": true,`

Also fix all the imports not being compliant


### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?

https://github.com/containers/podman-desktop/pull/1860

### How to test this PR?

Should work as before


Change-Id: I64da34ee8fb149069310b6ba8d5efb7f9608e14f
