### PR TITLE
feat(extension-api): allow to be notified on change on provider connections

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -357,6 +357,18 @@ declare module '@podman-desktop/api' {
     status: ProviderStatus;
   }
 
+  export interface UpdateContainerConnectionEvent {
+    providerId: string;
+    connection: ContainerProviderConnection;
+    status: ProviderConnectionStatus;
+  }
+
+  export interface UpdateKubernetesConnectionEvent {
+    providerId: string;
+    connection: KubernetesProviderConnection;
+    status: ProviderConnectionStatus;
+  }
+
   export interface UnregisterContainerConnectionEvent {
     providerId: string;
   }
@@ -378,6 +390,8 @@ declare module '@podman-desktop/api' {
   export namespace provider {
     export function createProvider(provider: ProviderOptions): Provider;
     export const onDidUpdateProvider: Event<ProviderEvent>;
+    export const onDidUpdateContainerConnection: Event<UpdateContainerConnectionEvent>;
+    export const onDidUpdateKubernetesConnection: Event<UpdateKubernetesConnectionEvent>;
     export const onDidUnregisterContainerConnection: Event<UnregisterContainerConnectionEvent>;
     export const onDidRegisterContainerConnection: Event<RegisterContainerConnectionEvent>;
     export function getContainerConnections(): ProviderContainerConnection[];

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -420,6 +420,12 @@ export class ExtensionLoader {
       onDidUpdateProvider: (listener, thisArg, disposables) => {
         return providerRegistry.onDidUpdateProvider(listener, thisArg, disposables);
       },
+      onDidUpdateContainerConnection: (listener, thisArg, disposables) => {
+        return providerRegistry.onDidUpdateContainerConnection(listener, thisArg, disposables);
+      },
+      onDidUpdateKubernetesConnection: (listener, thisArg, disposables) => {
+        return providerRegistry.onDidUpdateKubernetesConnection(listener, thisArg, disposables);
+      },
       onDidUnregisterContainerConnection: (listener, thisArg, disposables) => {
         return providerRegistry.onDidUnregisterContainerConnection(listener, thisArg, disposables);
       },


### PR DESCRIPTION
### What does this PR do?
stopping or starting a container/kube connection should send events so clients can be notified

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?

Will help for https://github.com/containers/podman-desktop/issues/2031


### How to test this PR?

Unit tests provided

Change-Id: Iead6d583c615000c5a3593c772f160f73fbd5bde
