### PR TITLE
fix: kind cluster should appear on stop/start of Podman machine

### DIFF
--- a/extensions/kind/src/extension.spec.ts
+++ b/extensions/kind/src/extension.spec.ts
@@ -1,0 +1,59 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { beforeEach, expect, test, vi } from 'vitest';
+import * as podmanDesktopApi from '@podman-desktop/api';
+import { refreshKindClustersOnProviderConnectionUpdate } from './extension';
+
+vi.mock('@podman-desktop/api', async () => {
+  return {
+    provider: {
+      onDidUpdateContainerConnection: vi.fn(),
+    },
+
+    containerEngine: {
+      listContainers: vi.fn(),
+    },
+  };
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+test('check we received notifications ', async () => {
+  const onDidUpdateContainerConnectionMock = vi.fn();
+  (podmanDesktopApi.provider as any).onDidUpdateContainerConnection = onDidUpdateContainerConnectionMock;
+
+  const listContainersMock = vi.fn();
+  (podmanDesktopApi.containerEngine as any).listContainers = listContainersMock;
+  listContainersMock.mockResolvedValue([]);
+
+  let callbackCalled = false;
+  onDidUpdateContainerConnectionMock.mockImplementation((callback: any) => {
+    callback();
+    callbackCalled = true;
+  });
+
+  const fakeProvider = {} as unknown as podmanDesktopApi.Provider;
+  await refreshKindClustersOnProviderConnectionUpdate(fakeProvider);
+  expect(callbackCalled).toBeTruthy();
+  expect(listContainersMock).toBeCalledTimes(1);
+});


### PR DESCRIPTION
### What does this PR do?
Ensure that we track events on connections, clean, and scan containers


### Screenshot/screencast of this PR

https://user-images.githubusercontent.com/436777/231505914-4d4ddfa9-b8c1-4ea8-be80-fbca3ab86c0e.mp4



### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop/issues/2031

### How to test this PR?

Look at the issue.
Start and stopping a machine should display/hide the cluster

Change-Id: I46774510cff83a51cb8f07132e171f12a6856739
