### PR TITLE
fix: do not see restart action for k8s pods

### DIFF
--- a/packages/renderer/src/lib/pod/PodActions.svelte
+++ b/packages/renderer/src/lib/pod/PodActions.svelte
@@ -115,11 +115,11 @@ if (dropdownMenu) {
       menu="{dropdownMenu}"
       detailed="{detailed}"
       icon="{faRocket}" />
+    <ListItemButtonIcon
+      title="Restart Pod"
+      onClick="{() => restartPod(pod)}"
+      menu="{dropdownMenu}"
+      detailed="{detailed}"
+      icon="{faArrowsRotate}" />
   {/if}
-  <ListItemButtonIcon
-    title="Restart Pod"
-    onClick="{() => restartPod(pod)}"
-    menu="{dropdownMenu}"
-    detailed="{detailed}"
-    icon="{faArrowsRotate}" />
 </svelte:component>


### PR DESCRIPTION
### What does this PR do?
include the restart within the if block


### Screenshot/screencast of this PR



### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/2035


### How to test this PR?

List all pods from a k8s cluster, you should not see the restart action

Change-Id: I88a3821c0b80ac754d7a2cf2d1ab3b4962244e9b
