### PR TITLE
fix: avoid unhandled error when starting with invalid kubeconfig file

### DIFF
--- a/packages/main/src/plugin/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes-client.ts
@@ -240,9 +240,14 @@ export class KubernetesClient {
         }
       }
     } catch (err) {
-      const namespaces = await ctx.makeApiClient(CoreV1Api).listNamespace();
-      if (namespaces?.body?.items.length > 0) {
-        namespace = namespaces?.body?.items[0].metadata?.name;
+      try {
+        const namespaces = await ctx.makeApiClient(CoreV1Api).listNamespace();
+        if (namespaces?.body?.items.length > 0) {
+          namespace = namespaces?.body?.items[0].metadata?.name;
+        }
+      } catch (error) {
+        // unable to list namespaces, can be due to a connection refused (cluster not up)
+        console.trace('unable to list namespaces', error);
       }
     }
     if (!namespace) {


### PR DESCRIPTION
### What does this PR do?
catch/Log the error

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/2052

### How to test this PR?

use a $HOME/.kube/config file with a non-reachable cluster

Change-Id: I14debf79edab0ce557990ba8153d647434214e38
