### PR TITLE
fix: error is not reported on UI if it's not logged

### DIFF
--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1277,6 +1277,9 @@ export class PluginSystem {
         }
         try {
           await providerRegistry.createContainerProviderConnection(internalProviderId, params, logger, token);
+        } catch (error) {
+          logger.error(error);
+          throw error;
         } finally {
           logger.onEnd();
         }
@@ -1300,6 +1303,9 @@ export class PluginSystem {
         }
         try {
           await providerRegistry.createKubernetesProviderConnection(internalProviderId, params, logger, token);
+        } catch (error) {
+          logger.error(error);
+          throw error;
         } finally {
           logger.onEnd();
         }


### PR DESCRIPTION
### What does this PR do?
Report the error so it's displayed on the user side


### Screenshot/screencast of this PR


https://user-images.githubusercontent.com/436777/231703361-56751676-0671-49c1-a214-14e7a4ae3c42.mp4



### What issues does this PR fix or reference?
https://github.com/containers/podman-desktop/pull/1980#issuecomment-1503817763

### How to test this PR?

in kind extension, add a throw new Error in the createCluster method

without the fix, it says my cluster has been successfully created

Change-Id: Ifeb8e4f9593acffc7d497284c768e722e61b1c73
