### PR TITLE
fix: handle invalid data on xterm logger

### DIFF
--- a/packages/renderer/src/lib/preferences/Util.spec.ts
+++ b/packages/renderer/src/lib/preferences/Util.spec.ts
@@ -1,0 +1,46 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { test, expect, vi } from 'vitest';
+import { writeToTerminal } from './Util';
+
+const xtermMock = {
+  write: vi.fn(),
+};
+
+afterEach(() => {
+  vi.resetAllMocks();
+});
+
+test('write array object', () => {
+  writeToTerminal(xtermMock, ['a', 'b'], 'test');
+  // no error reported
+  expect(xtermMock.write).toBeCalledTimes(2);
+});
+
+test('write invalid object', () => {
+  writeToTerminal(xtermMock, {} as unknown as string[], 'test');
+  // no error reported
+  expect(xtermMock.write).toBeCalledWith(expect.stringContaining('test'));
+});
+
+test('write undefined object', () => {
+  writeToTerminal(xtermMock, undefined as unknown as string[], 'test');
+  // no error reported
+  expect(xtermMock.write).toBeCalledWith(expect.stringContaining('test'));
+});

--- a/packages/renderer/src/lib/preferences/Util.ts
+++ b/packages/renderer/src/lib/preferences/Util.ts
@@ -48,7 +48,7 @@ export function writeToTerminal(xterm: any, data: string[], colorPrefix: string)
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function writeMultilineString(xterm: any, data: string, colorPrefix: string): void {
-  if (data.includes('\n')) {
+  if (data && data.includes && data.includes('\n')) {
     const toWrite = data.split('\n');
     for (const s of toWrite) {
       xterm.write(colorPrefix + s + '\n\r');


### PR DESCRIPTION


### What does this PR do?
sometimes data may be invalid but then utility class should handle this

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

Discovered when checking issue on createCluster with kind

### How to test this PR?

Unit tests added

Change-Id: I3b006dba7b078bb7d6fd913feca377cbbc3ca643
