### PR TITLE
fix: avoid dialog box if unable to check for updates

### DIFF
--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -443,7 +443,6 @@ export class PluginSystem {
           return;
         }
         console.error('unable to check for updates', error);
-        dialog.showErrorBox('Error: ', error == null ? 'unknown' : (error.stack || error).toString());
       });
 
       // check for updates now


### PR DESCRIPTION
### What does this PR do?
It can disturb users and can be related to network issues so we should not report with dialogs, only keep in console log 


### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop/issues/2046

### How to test this PR?



Change-Id: Ib4fe059dc33f829d388c9114e1e5feedd5a3e922
