### PR TITLE
fix: Do not display full sha256 in container list

### DIFF
--- a/packages/renderer/src/lib/ContainerDetails.svelte
+++ b/packages/renderer/src/lib/ContainerDetails.svelte
@@ -65,7 +65,7 @@ function errorCallback(errorMessage: string): void {
               </div>
               <div class="text-lg flex flex-col">
                 <div class="mr-2">{container.name}</div>
-                <div class="mr-2 pb-4 text-small text-gray-500">{container.image}</div>
+                <div class="mr-2 pb-4 text-small text-gray-500" title="{container.image}">{container.shortImage}</div>
               </div>
             </div>
             <section class="pf-c-page__main-tabs pf-m-limit-width">

--- a/packages/renderer/src/lib/ContainerList.svelte
+++ b/packages/renderer/src/lib/ContainerList.svelte
@@ -515,7 +515,7 @@ function errorCallback(container: ContainerInfoUI, errorMessage: string): void {
                   on:click="{() => openDetailsContainer(container)}">
                   <div class="flex items-center">
                     <div class="text-sm text-gray-400 overflow-hidden text-ellipsis" title="{container.image}">
-                      {container.image}
+                      {container.shortImage}
                     </div>
                   </div></td>
                 <td class="whitespace-nowrap pl-4">

--- a/packages/renderer/src/lib/container/ContainerInfoUI.ts
+++ b/packages/renderer/src/lib/container/ContainerInfoUI.ts
@@ -44,6 +44,7 @@ export interface ContainerInfoUI {
   shortId: string;
   name: string;
   image: string;
+  shortImage: string;
   engineId: string;
   engineName: string;
   engineType: 'podman' | 'docker';

--- a/packages/renderer/src/lib/container/container-utils.spec.ts
+++ b/packages/renderer/src/lib/container/container-utils.spec.ts
@@ -18,6 +18,7 @@
 
 import { beforeEach, expect, test, vi } from 'vitest';
 import { ContainerUtils } from './container-utils';
+import type { ContainerInfo } from '../../../../main/src/plugin/api/container-info';
 
 let containerUtils: ContainerUtils;
 
@@ -29,4 +30,20 @@ beforeEach(() => {
 test('should expect valid memory usage', async () => {
   const size = containerUtils.getMemoryPercentageUsageTitle(4, 1000000);
   expect(size).toBe('4.00% (1 MB)');
+});
+
+test('should expect short image for sha256', async () => {
+  const containerInfo = {
+    Image: 'docker.io/kindest/node@sha256:61b92f38dff6ccc29969e7aa154d34e38b89443af1a2c14e6cfbd2df6419c66f',
+  } as unknown as ContainerInfo;
+  const image = containerUtils.getShortImage(containerInfo);
+  expect(image).toBe('docker.io/kindest/node@sha256:61b92f3');
+});
+
+test('should expect full name for images', async () => {
+  const containerInfo = {
+    Image: 'docker.io/kindest/node:foobar',
+  } as unknown as ContainerInfo;
+  const image = containerUtils.getShortImage(containerInfo);
+  expect(image).toBe('docker.io/kindest/node:foobar');
 });

--- a/packages/renderer/src/lib/container/container-utils.ts
+++ b/packages/renderer/src/lib/container/container-utils.ts
@@ -67,6 +67,16 @@ export class ContainerUtils {
     return containerInfo.Image;
   }
 
+  getShortImage(containerInfo: ContainerInfo): string {
+    // if image has a digest, keep only first 7 digits
+    const image = containerInfo.Image;
+    const shaIndex = image.indexOf('@sha256:');
+    if (shaIndex > 0) {
+      return image.substring(0, shaIndex + 15);
+    }
+    return image;
+  }
+
   getPort(containerInfo: ContainerInfo): string {
     const ports = containerInfo.Ports?.filter(port => port.PublicPort).map(port => port.PublicPort);
 
@@ -116,6 +126,7 @@ export class ContainerUtils {
       shortId: containerInfo.Id.substring(0, 8),
       name: this.getName(containerInfo),
       image: this.getImage(containerInfo),
+      shortImage: this.getShortImage(containerInfo),
       state: this.getState(containerInfo),
       startedAt: containerInfo.StartedAt,
       uptime: this.getUptime(containerInfo),


### PR DESCRIPTION
### What does this PR do?
truncate to 7 digits for sha256 images in container list
hovering still displays all digits

### Screenshot/screencast of this PR

![image](https://user-images.githubusercontent.com/436777/231727025-5a5c2ffa-634a-4512-ab65-32b9c9d24a94.png)

![image](https://user-images.githubusercontent.com/436777/231747287-7800f27e-f703-4210-b6a5-d53a5e96bbe3.png)

![image](https://user-images.githubusercontent.com/436777/231748841-2d8eeeb3-d21e-49ae-9ab3-f33f152391cc.png)


### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/2043

### How to test this PR?

Start a kind cluster and look at container list

Change-Id: Ib221e327f79434b5538d0e68a68944ceb8484b8f
