### PR TITLE
feat(kube-client): Add support for deployment and providing a given file path

### DIFF
--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1339,6 +1339,14 @@ export class PluginSystem {
       return kubernetesClient.deletePod(name);
     });
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    this.ipcHandle(
+      'kubernetes-client:createResourcesFromFile',
+      async (_listener, context: string, file: string, namespace: string): Promise<void> => {
+        return kubernetesClient.createResourcesFromFile(context, file, namespace);
+      },
+    );
+
     this.ipcHandle(
       'openshift-client:createRoute',
       async (_listener, namespace: string, route: V1Route): Promise<V1Route> => {

--- a/packages/main/src/plugin/kubernetes-client.spec.ts
+++ b/packages/main/src/plugin/kubernetes-client.spec.ts
@@ -25,12 +25,14 @@ import { KubeConfig } from '@kubernetes/client-node';
 
 const configurationRegistry: ConfigurationRegistry = {} as unknown as ConfigurationRegistry;
 const fileSystemMonitoring: FilesystemMonitoring = new FilesystemMonitoring();
+const makeApiClientMock = vi.fn();
 
 beforeAll(() => {
   vi.mock('@kubernetes/client-node', async () => {
     return {
       KubeConfig: vi.fn(),
       CoreV1Api: {},
+      AppsV1Api: {},
       CustomObjectsApi: {},
     };
   });
@@ -39,7 +41,7 @@ beforeAll(() => {
 beforeEach(() => {
   vi.clearAllMocks();
   KubeConfig.prototype.loadFromFile = vi.fn();
-  KubeConfig.prototype.makeApiClient = vi.fn();
+  KubeConfig.prototype.makeApiClient = makeApiClientMock;
 });
 
 test('Create Kubernetes resources with empty should return ok', async () => {
@@ -52,6 +54,17 @@ test('Create Kubernetes resources with v1 resource should return ok', async () =
   const spy = vi.spyOn(client, 'createV1Resource').mockReturnValue(Promise.resolve());
   await client.createResources('dummy', [{ apiVersion: 'v1', kind: 'Namespace' }]);
   expect(spy).toBeCalled();
+});
+
+test('Create Kubernetes resources with apps/v1 resource should return ok', async () => {
+  const client = new KubernetesClient({} as ApiSenderType, configurationRegistry, fileSystemMonitoring);
+  const createNamespacedDeploymentMock = vi.fn();
+  makeApiClientMock.mockReturnValue({
+    createNamespacedDeployment: createNamespacedDeploymentMock,
+  });
+
+  await client.createResources('dummy', [{ apiVersion: 'apps/v1', kind: 'Deployment' }]);
+  expect(createNamespacedDeploymentMock).toBeCalledWith('default', { apiVersion: 'apps/v1', kind: 'Deployment' });
 });
 
 test('Create Kubernetes resources with v1 resource in error should return error', async () => {

--- a/packages/main/src/plugin/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes-client.ts
@@ -24,10 +24,9 @@ import type {
   V1PodList,
   V1NamespaceList,
   V1Service,
-  V1ContainerState} from '@kubernetes/client-node';
-import {
-  AppsV1Api,
+  V1ContainerState,
 } from '@kubernetes/client-node';
+import { AppsV1Api } from '@kubernetes/client-node';
 import { CustomObjectsApi } from '@kubernetes/client-node';
 import { CoreV1Api, KubeConfig, Log, Watch } from '@kubernetes/client-node';
 import type { V1Route } from './api/openshift-types';
@@ -578,6 +577,9 @@ export class KubernetesClient {
       if (groupVersion.group === '') {
         const client = ctx.makeApiClient(CoreV1Api);
         await this.createV1Resource(client, manifest);
+      } else if (groupVersion.group === 'apps') {
+        const k8sAppsApi = this.kubeConfig.makeApiClient(AppsV1Api);
+        await k8sAppsApi.createNamespacedDeployment(namespace || 'default', manifest);
       } else {
         const client = ctx.makeApiClient(CustomObjectsApi);
         await this.createCustomResource(

--- a/packages/main/src/plugin/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes-client.ts
@@ -570,7 +570,18 @@ export class KubernetesClient {
 
   async createResourcesFromFile(context: string, filePath: string, namespace: string): Promise<void> {
     const manifests = await this.loadManifestsFromFile(filePath);
-    return this.createResources(context, manifests, namespace);
+    try {
+      await this.createResources(context, manifests, namespace);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } catch (error: any) {
+      if (error.response && error.response.body) {
+        if (error.response.body.message) {
+          throw new Error(error.response.body.message);
+        }
+        throw new Error(error.response.body);
+      }
+      throw error;
+    }
   }
 
   /**

--- a/packages/main/src/plugin/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes-client.ts
@@ -585,6 +585,10 @@ export class KubernetesClient {
     ctx.loadFromFile(this.kubeconfigPath);
     ctx.currentContext = context;
     for (const manifest of manifests) {
+      // https://github.com/kubernetes-client/javascript/issues/487
+      if (manifest?.metadata?.creationTimestamp) {
+        manifest.metadata.creationTimestamp = new Date(manifest.metadata.creationTimestamp);
+      }
       const groupVersion = this.groupAndVersion(manifest.apiVersion);
       if (groupVersion.group === '') {
         const client = ctx.makeApiClient(CoreV1Api);

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -1125,6 +1125,13 @@ function initExposure(): void {
   });
 
   contextBridge.exposeInMainWorld(
+    'kubernetesCreateResourcesFromFile',
+    async (context: string, file: string, namespace: string): Promise<void> => {
+      return ipcInvoke('kubernetes-client:createResourcesFromFile', context, file, namespace);
+    },
+  );
+
+  contextBridge.exposeInMainWorld(
     'openshiftCreateRoute',
     async (namespace: string, route: V1Route): Promise<V1Route> => {
       return ipcInvoke('openshift-client:createRoute', namespace, route);


### PR DESCRIPTION
### What does this PR do?
4 commits
- First one introduce a createResourcesFromFile so it can be called by UI. Method will load all yaml inside and create sub resources
- The next one adds the support for deployment as it was not handled by the current method
- the 3rd one allow to specify a namespace
- the last one handle the timestamp correctly (due to a bug and we're already applying that fix elsewhere)

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

Part of #1261 

### How to test this PR?

There is unit test for the createApps