### PR TITLE
fix(kube-client): handle daemonset and filter out null manifests

### DIFF
--- a/packages/main/src/plugin/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes-client.ts
@@ -565,7 +565,8 @@ export class KubernetesClient {
     const content = await fs.promises.readFile(file, 'utf-8');
 
     const manifests = parseAllDocuments(content, { customTags: this.getTags });
-    return manifests.map(manifest => manifest.toJSON());
+    // filter out null manifests
+    return manifests.map(manifest => manifest.toJSON()).filter(manifest => manifest !== null);
   }
 
   async createResourcesFromFile(context: string, filePath: string, namespace: string): Promise<void> {

--- a/packages/main/src/plugin/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes-client.ts
@@ -606,7 +606,12 @@ export class KubernetesClient {
         await this.createV1Resource(client, manifest, optionalNamespace);
       } else if (groupVersion.group === 'apps') {
         const k8sAppsApi = this.kubeConfig.makeApiClient(AppsV1Api);
-        await k8sAppsApi.createNamespacedDeployment(optionalNamespace || 'default', manifest);
+        const namespaceToUse = optionalNamespace || manifest.metadata?.namespace || 'default';
+        if (manifest.kind === 'Deployment') {
+          await k8sAppsApi.createNamespacedDeployment(namespaceToUse, manifest);
+        } else if (manifest.kind === 'DaemonSet') {
+          await k8sAppsApi.createNamespacedDaemonSet(namespaceToUse, manifest);
+        }
       } else {
         const client = ctx.makeApiClient(CustomObjectsApi);
         await this.createCustomResource(


### PR DESCRIPTION
### What does this PR do?
Playing with random files there are sometimes null manifests (--- separator at the bottom of a file)
Contour was not fully deployed (some resources were not handled correctly)


### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

N/A
### How to test this PR?

<!-- Please explain steps to reproduce -->
