### PR TITLE
fix: Fix kind not appearing when creating a cluster in production mode

### DIFF
--- a/extensions/kind/src/create-cluster.ts
+++ b/extensions/kind/src/create-cluster.ts
@@ -76,7 +76,7 @@ export async function createCluster(
     provider = params['kind.cluster.creation.provider'];
   }
 
-  const env = Object.assign({}, process.env);
+  const env = process.env;
   // add KIND_EXPERIMENTAL_PROVIDER env variable if needed
   if (provider === 'podman') {
     env['KIND_EXPERIMENTAL_PROVIDER'] = 'podman';

--- a/extensions/kind/src/util.ts
+++ b/extensions/kind/src/util.ts
@@ -97,7 +97,7 @@ export function runCliCommand(
     let stdOut = '';
     let stdErr = '';
     let err = '';
-    let env = Object.assign({}, process.env); // clone original env object
+    const env = options?.env ?? process.env;
 
     // In production mode, applications don't have access to the 'user' path like brew
     if (isMac() || isWindows()) {
@@ -110,10 +110,6 @@ export function runCliCommand(
       // need to execute the command on the host
       args = ['--host', command, ...args];
       command = 'flatpak-spawn';
-    }
-
-    if (options?.env) {
-      env = Object.assign(env, options.env);
     }
 
     const spawnProcess = spawn(command, args, { shell: isWindows(), env });


### PR DESCRIPTION
fix: Fix kind not appearing when creating a cluster in production mode

### What does this PR do?

Fixes the 'env' issue when passing an `env` to runCliCommand which
caused an error of not being able to detect kind properly

There is an odd issue where when copying over the environment variables,
it works in electron's "development" mode, but not in "production".

* runCliCommand has been updated to copy over process.env if options.env
  is null
* RunOptions: env will always be a NodeJS.ProcessEnv, so no need to
  worry about "copying" objects over as it'll always be a complete
  process env variable

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

Fixes https://github.com/containers/podman-desktop/issues/2088

### How to test this PR?

Run `yarn compile`. Run the binary and try to create a `kind` cluster.

<!-- Please explain steps to reproduce -->

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
