### PR TITLE
fix: check that stores are updated after all extensions are started

### DIFF
--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1436,6 +1436,7 @@ export class PluginSystem {
     console.log('System ready. Loading extensions...');
     await this.extensionLoader.start();
     console.log('PluginSystem: initialization done.');
+    apiSender.send('extensions-started');
     autoStartConfiguration.start();
     return this.extensionLoader;
   }

--- a/packages/renderer/src/stores/configurationProperties.ts
+++ b/packages/renderer/src/stores/configurationProperties.ts
@@ -31,6 +31,10 @@ export async function fetchConfigurationProperties() {
 
 export const configurationProperties: Writable<IConfigurationPropertyRecordedSchema[]> = writable([]);
 
+window.events?.receive('extensions-started', () => {
+  fetchConfigurationProperties();
+});
+
 window.addEventListener('extension-started', () => {
   fetchConfigurationProperties();
 });

--- a/packages/renderer/src/stores/extensions.ts
+++ b/packages/renderer/src/stores/extensions.ts
@@ -44,3 +44,7 @@ window?.events.receive('extension-started', () => {
 window.addEventListener('system-ready', () => {
   fetchExtensions();
 });
+
+window.events?.receive('extensions-started', () => {
+  fetchExtensions();
+});

--- a/packages/renderer/src/stores/providers.ts
+++ b/packages/renderer/src/stores/providers.ts
@@ -76,3 +76,6 @@ window?.events?.receive('provider-register-kubernetes-connection', () => {
 window?.events?.receive('provider-unregister-kubernetes-connection', () => {
   fetchProviders();
 });
+window.events?.receive('extensions-started', () => {
+  fetchProviders();
+});

--- a/packages/renderer/src/stores/registries.ts
+++ b/packages/renderer/src/stores/registries.ts
@@ -71,3 +71,7 @@ window.events?.receive('registry-update', () => {
 window.addEventListener('system-ready', () => {
   fetchRegistries();
 });
+
+window.events?.receive('extensions-started', () => {
+  fetchRegistries();
+});


### PR DESCRIPTION
### What does this PR do?
Update stores after extensions are started

### Screenshot/screencast of this PR



### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/2089
fixes https://github.com/containers/podman-desktop/issues/2091

### How to test this PR?

Build a production build and check

Change-Id: I68fe65235679b5f0e65b25a05007aa5692d74957
