### PR TITLE
fix: ensure PATH is correctly set for kind commands

### DIFF
--- a/extensions/kind/src/create-cluster.spec.ts
+++ b/extensions/kind/src/create-cluster.spec.ts
@@ -35,6 +35,7 @@ vi.mock('@podman-desktop/api', async () => {
 vi.mock('./util', async () => {
   return {
     runCliCommand: vi.fn(),
+    getKindPath: vi.fn(),
   };
 });
 

--- a/extensions/kind/src/create-cluster.ts
+++ b/extensions/kind/src/create-cluster.ts
@@ -19,7 +19,7 @@ import * as extensionApi from '@podman-desktop/api';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
-import { runCliCommand } from './util';
+import { getKindPath, runCliCommand } from './util';
 import mustache from 'mustache';
 import { parseAllDocuments } from 'yaml';
 
@@ -111,6 +111,9 @@ export async function createCluster(
 
   // ok we need to write the file
   await fs.promises.writeFile(tmpFilePath, kindClusterConfig, 'utf8');
+
+  // update PATH to include kind
+  env.PATH = getKindPath();
 
   // now execute the command to create the cluster
   try {

--- a/extensions/kind/src/extension.ts
+++ b/extensions/kind/src/extension.ts
@@ -17,7 +17,7 @@
  ***********************************************************************/
 
 import * as extensionApi from '@podman-desktop/api';
-import { detectKind, runCliCommand } from './util';
+import { detectKind, getKindPath, runCliCommand } from './util';
 import { KindInstaller } from './kind-installer';
 import type { CancellationToken, Logger } from '@podman-desktop/api';
 import { window } from '@podman-desktop/api';
@@ -121,10 +121,11 @@ async function updateClusters(provider: extensionApi.Provider, containers: exten
           await extensionApi.containerEngine.stopContainer(cluster.engineId, cluster.id);
         },
         delete: async (logger): Promise<void> => {
-          const env = process.env;
+          const env = Object.assign({}, process.env);
           if (cluster.engineType === 'podman') {
             env['KIND_EXPERIMENTAL_PROVIDER'] = 'podman';
           }
+          env.PATH = getKindPath();
           await runCliCommand(kindCli, ['delete', 'cluster', '--name', cluster.name], { env, logger });
         },
       };

--- a/extensions/kind/src/util.ts
+++ b/extensions/kind/src/util.ts
@@ -49,7 +49,7 @@ export interface RunOptions {
   logger?: extensionApi.Logger;
 }
 
-const macosExtraPath = '/usr/local/bin:/opt/homebrew/bin:/opt/local/bin';
+const macosExtraPath = '/usr/local/bin:/opt/homebrew/bin:/opt/local/bin:/opt/podman/bin';
 
 export function getKindPath(): string {
   const env = process.env;


### PR DESCRIPTION
### What does this PR do?
Different approach than https://github.com/containers/podman-desktop/pull/2092
here we just set the PATH

Also add `/opt/podman/bin` as kind is calling podman CLI

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

fix https://github.com/containers/podman-desktop/issues/2088


### How to test this PR?

Create kind clusters, delete them, etc

Change-Id: I0f565bafa45db5872dcdfb0950e06b03e9fe3c3e
