### PR TITLE
fix: Clean up extensions preferences and fix scrolling

### DIFF
--- a/packages/renderer/src/lib/ExtensionList.svelte
+++ b/packages/renderer/src/lib/ExtensionList.svelte
@@ -3,7 +3,7 @@ import Fa from 'svelte-fa/src/fa.svelte';
 import { faPuzzlePiece, faTrash } from '@fortawesome/free-solid-svg-icons';
 import { faPlay } from '@fortawesome/free-solid-svg-icons';
 import { faStop } from '@fortawesome/free-solid-svg-icons';
-import { afterUpdate, onMount } from 'svelte';
+import { afterUpdate } from 'svelte';
 import { extensionInfos } from '../stores/extensions';
 import type { ExtensionInfo } from '../../../main/src/plugin/api/extension-info';
 import ErrorMessage from './ui/ErrorMessage.svelte';
@@ -115,22 +115,23 @@ async function removeExtension(extension: ExtensionInfo) {
       </div>
     </div>
   </div>
-  <div class="shadow overflow-hidden border border-zinc-700 sm mt-2">
-    <table class="min-w-full divide-y divide-gray-800">
-      <tbody class="bg-zinc-900 divide-y divide-zinc-700">
+  <div class="bg-zinc-800 mt-5 rounded-md p-3">
+    <table class="min-w-full">
+      <tbody>
         {#each sortedExtensions as extension}
-          <tr>
-            <td class="px-6 py-2 whitespace-nowrap">
+          <tr class="border-y border-gray-600">
+            <td class="px-6 py-2">
               <div class="flex items-center">
                 <div class="flex-shrink-0 h-10 w-10 py-3" title="Extension {extension.name} is {extension.state}">
                   <Fa
                     class="h-10 w-10 rounded-full {extension.state === 'active' ? 'text-violet-600' : 'text-gray-700'}"
+                    size="25"
                     icon="{faPuzzlePiece}" />
                 </div>
                 <div class="ml-4">
                   <div class="flex flex-row">
                     <div class="text-sm text-gray-200">
-                      {extension.name}
+                      {extension.displayName}
                       {extension.removable ? '(user)' : '(default extension)'}
                     </div>
                   </div>
@@ -143,7 +144,7 @@ async function removeExtension(extension: ExtensionInfo) {
                 </div>
               </div>
             </td>
-            <td class="px-6 py-2 whitespace-nowrap">
+            <td class="px-2 py-2 whitespace-nowrap">
               <div class="flex flex-row justify-end">
                 <button
                   title="Start extension"

--- a/packages/renderer/src/lib/preferences/PreferencesExtensionRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesExtensionRendering.svelte
@@ -2,6 +2,7 @@
 import Route from '../../Route.svelte';
 import { extensionInfos } from '../../stores/extensions';
 import type { ExtensionInfo } from '../../../../main/src/plugin/api/extension-info';
+import SettingsPage from './SettingsPage.svelte';
 export let extensionId: string = undefined;
 
 let extensionInfo: ExtensionInfo;
@@ -17,49 +18,48 @@ async function startExtension() {
 }
 </script>
 
-<div class="flex flex-1 flex-col bg-zinc-800 px-2">
-  {#if extensionInfo}
-    <Route path="/*" breadcrumb="{extensionInfo.displayName}" let:meta>
-      <div class="pl-1 py-2">
-        <h1 class="capitalize text-xl">{extensionInfo.displayName} Extension</h1>
-        <div class="text-sm italic text-gray-400">{extensionInfo.description}</div>
-      </div>
-
-      <!-- Manage lifecycle-->
-      <div class="pl-1 py-2">
-        <div class="text-sm italic text-gray-400">Status</div>
-        <div class="pl-3 capitalize">{extensionInfo.state}</div>
-      </div>
-
-      <div class="py-2 flex flex:row">
-        <!-- start is enabled only in stopped mode-->
-        <div class="px-2 text-sm italic text-gray-400">
-          <button
-            disabled="{extensionInfo.state !== 'inactive'}"
-            on:click="{() => startExtension()}"
-            class="pf-c-button pf-m-primary"
-            type="button">
-            <span class="pf-c-button__icon pf-m-start">
-              <i class="fas fa-play" aria-hidden="true"></i>
-            </span>
-            Enable
-          </button>
+<SettingsPage title="{extensionInfo.displayName} Extension">
+  <span slot="subtitle">
+    {extensionInfo.description}
+  </span>
+  <div class="bg-zinc-800 mt-5 rounded-md p-3">
+    {#if extensionInfo}
+      <Route path="/*" breadcrumb="{extensionInfo.displayName}" let:meta>
+        <!-- Manage lifecycle-->
+        <div class="pl-1 py-2">
+          <div class="text-sm italic text-gray-400">Status</div>
+          <div class="pl-3 capitalize">{extensionInfo.state}</div>
         </div>
 
-        <!-- stop is enabled only in started mode-->
-        <div class="px-2 text-sm italic text-gray-400">
-          <button
-            disabled="{extensionInfo.state !== 'active'}"
-            on:click="{() => stopExtension()}"
-            class="pf-c-button pf-m-primary"
-            type="button">
-            <span class="pf-c-button__icon pf-m-start">
-              <i class="fas fa-stop" aria-hidden="true"></i>
-            </span>
-            Disable
-          </button>
+        <div class="py-2 flex flex:row">
+          <!-- start is enabled only in stopped mode-->
+          <div class="px-2 text-sm italic text-gray-400">
+            <button
+              disabled="{extensionInfo.state !== 'inactive'}"
+              on:click="{() => startExtension()}"
+              class="pf-c-button pf-m-primary"
+              type="button">
+              <span class="pf-c-button__icon pf-m-start">
+                <i class="fas fa-play" aria-hidden="true"></i>
+              </span>
+              Enable
+            </button>
+          </div>
+
+          <!-- stop is enabled only in started mode-->
+          <div class="px-2 text-sm italic text-gray-400">
+            <button
+              disabled="{extensionInfo.state !== 'active'}"
+              on:click="{() => stopExtension()}"
+              class="pf-c-button pf-m-primary"
+              type="button">
+              <span class="pf-c-button__icon pf-m-start">
+                <i class="fas fa-stop" aria-hidden="true"></i>
+              </span>
+              Disable
+            </button>
+          </div>
         </div>
-      </div>
-    </Route>
-  {/if}
-</div>
+      </Route>
+    {/if}
+  </div></SettingsPage>


### PR DESCRIPTION
### What does this PR do?

Minimal change to bring the Extensions and child pages up to the current settings page design. This is not meant to be a full redesign, just an initial first pass.

### Screenshot/screencast of this PR

Before:
<img width="837" alt="Screenshot 2023-04-14 at 8 21 40 AM" src="https://user-images.githubusercontent.com/19958075/232042136-0687fbc4-15e0-4a3c-ac1f-440aae7036d6.png">
<img width="558" alt="Screenshot 2023-04-14 at 8 21 55 AM" src="https://user-images.githubusercontent.com/19958075/232042139-1abfcd7e-df89-41a3-bdce-e985f1096f95.png">

After:
<img width="741" alt="Screenshot 2023-04-14 at 8 20 46 AM" src="https://user-images.githubusercontent.com/19958075/232042191-1cefd082-1054-45b1-84e6-d8d83ce026bf.png">
<img width="741" alt="Screenshot 2023-04-14 at 8 21 01 AM" src="https://user-images.githubusercontent.com/19958075/232042193-afa52a7e-ac85-45a3-9474-51b5a236c8e6.png">

### What issues does this PR fix or reference?

Fixes issue #2015.

### How to test this PR?

Just go to Settings > Extensions and the child pages.