### PR TITLE
fix: make the condition being reactive and not on the loading page

### DIFF
--- a/packages/renderer/src/lib/dashboard/ProviderInstalled.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderInstalled.svelte
@@ -39,6 +39,10 @@ let termFit: FitAddon;
 let installationOptionsMenuVisible = false;
 let installationOptionSelected = InitializeAndStartMode;
 
+// no initialize support, hide the button
+$: initializationButtonVisible =
+  provider.containerProviderConnectionInitialization || provider.kubernetesProviderConnectionInitialization;
+
 async function initializeProvider() {
   initalizeError = undefined;
   logsTerminal.clear();
@@ -108,11 +112,6 @@ onMount(async () => {
 
   // Observe the terminal div
   resizeObserver.observe(logsXtermDiv);
-
-  // no initialize support, hide the button
-  if (!provider.containerProviderConnectionInitialization && !provider.kubernetesProviderConnectionInitialization) {
-    initializationButtonVisible = false;
-  }
 });
 
 onDestroy(() => {


### PR DESCRIPTION
### What does this PR do?
make boolean being reactive on provider change

### Screenshot/screencast of this PR

![image](https://user-images.githubusercontent.com/436777/232045253-e17916eb-81cf-4193-b999-fbab90335c86.png)


### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/2099


### How to test this PR?

no podman machine, start Podman (using production binary mode)

Change-Id: Ia47e7a56632e9da55ad8350f454ef1f66c0dd31b
