### PR TITLE
feat: Container/Pod action spinners

### DIFF
--- a/packages/renderer/src/lib/ContainerDetails.svelte
+++ b/packages/renderer/src/lib/ContainerDetails.svelte
@@ -88,20 +88,7 @@ function errorCallback(errorMessage: string): void {
           <div class="flex flex-col px-5 pt-5">
             <div class="flex justify-end">
               <div class="flex items-center w-5">
-                {#if container.actionInProgress}
-                  <svg
-                    class="animate-spin -ml-1 mr-3 h-5 w-5 text-white"
-                    xmlns="http://www.w3.org/2000/svg"
-                    fill="none"
-                    viewBox="0 0 24 24">
-                    <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-                    <path
-                      class="opacity-75"
-                      fill="currentColor"
-                      d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                    ></path>
-                  </svg>
-                {:else if container.actionError}
+                {#if container.actionError}
                   <ErrorMessage error="{container.actionError}" icon />
                 {:else}
                   <div>&nbsp;</div>

--- a/packages/renderer/src/lib/ContainerList.svelte
+++ b/packages/renderer/src/lib/ContainerList.svelte
@@ -529,21 +529,7 @@ function errorCallback(container: ContainerInfoUI, errorMessage: string): void {
                     : ''} {index === containerGroup.containers.length - 1 ? 'rounded-br-lg' : ''}">
                   <div class="flex w-full">
                     <div class="flex items-center w-5">
-                      {#if container.actionInProgress}
-                        <svg
-                          class="animate-spin -ml-1 mr-3 h-5 w-5 text-white"
-                          xmlns="http://www.w3.org/2000/svg"
-                          fill="none"
-                          viewBox="0 0 24 24">
-                          <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"
-                          ></circle>
-                          <path
-                            class="opacity-75"
-                            fill="currentColor"
-                            d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                          ></path>
-                        </svg>
-                      {:else if container.actionError}
+                      {#if container.actionError}
                         <ErrorMessage error="{container.actionError}" icon />
                       {:else}
                         <div>&nbsp;</div>

--- a/packages/renderer/src/lib/container/ContainerActions.svelte
+++ b/packages/renderer/src/lib/container/ContainerActions.svelte
@@ -98,7 +98,8 @@ if (dropdownMenu) {
   hidden="{container.state === 'RUNNING' || container.state === 'STOPPING'}"
   detailed="{detailed}"
   inProgress="{container.actionInProgress && container.state === 'STARTING'}"
-  icon="{faPlay}" />
+  icon="{faPlay}"
+  iconOffset="pl-[0.15rem]" />
 
 <ListItemButtonIcon
   title="Stop Container"

--- a/packages/renderer/src/lib/container/ContainerActions.svelte
+++ b/packages/renderer/src/lib/container/ContainerActions.svelte
@@ -40,7 +40,7 @@ async function restartContainer(containerInfo: ContainerInfoUI) {
 }
 
 async function stopContainer(containerInfo: ContainerInfoUI) {
-  inProgressCallback(true);
+  inProgressCallback(true, 'STOPPING');
   try {
     await window.stopContainer(containerInfo.engineId, containerInfo.id);
   } catch (error) {
@@ -59,7 +59,7 @@ function openLogs(containerInfo: ContainerInfoUI): void {
 }
 
 async function deleteContainer(containerInfo: ContainerInfoUI): Promise<void> {
-  inProgressCallback(true);
+  inProgressCallback(true, 'DELETING');
   try {
     await window.deleteContainer(containerInfo.engineId, containerInfo.id);
     router.goto('/containers/');
@@ -95,22 +95,25 @@ if (dropdownMenu) {
 <ListItemButtonIcon
   title="Start Container"
   onClick="{() => startContainer(container)}"
-  hidden="{container.state === 'RUNNING'}"
+  hidden="{container.state === 'RUNNING' || container.state === 'STOPPING'}"
   detailed="{detailed}"
+  inProgress="{container.actionInProgress && container.state === 'STARTING'}"
   icon="{faPlay}" />
 
 <ListItemButtonIcon
   title="Stop Container"
   onClick="{() => stopContainer(container)}"
-  hidden="{!(container.state === 'RUNNING')}"
+  hidden="{!(container.state === 'RUNNING' || container.state === 'STOPPING')}"
   detailed="{detailed}"
+  inProgress="{container.actionInProgress && container.state === 'STOPPING'}"
   icon="{faStop}" />
 
 <ListItemButtonIcon
   title="Delete Container"
   onClick="{() => deleteContainer(container)}"
   icon="{faTrash}"
-  detailed="{detailed}" />
+  detailed="{detailed}"
+  inProgress="{container.actionInProgress && container.state === 'DELETING'}" />
 
 <!-- If dropdownMenu is true, use it, otherwise just show the regular buttons -->
 <svelte:component this="{actionsStyle}">

--- a/packages/renderer/src/lib/container/ContainerActions.svelte
+++ b/packages/renderer/src/lib/container/ContainerActions.svelte
@@ -24,7 +24,7 @@ async function startContainer(containerInfo: ContainerInfoUI) {
   } catch (error) {
     errorCallback(error);
   } finally {
-    inProgressCallback(false);
+    inProgressCallback(false, 'RUNNING');
   }
 }
 
@@ -46,7 +46,7 @@ async function stopContainer(containerInfo: ContainerInfoUI) {
   } catch (error) {
     errorCallback(error);
   } finally {
-    inProgressCallback(false);
+    inProgressCallback(false, 'STOPPED');
   }
 }
 

--- a/packages/renderer/src/lib/pod/PodActions.svelte
+++ b/packages/renderer/src/lib/pod/PodActions.svelte
@@ -23,7 +23,7 @@ async function startPod(podInfoUI: PodInfoUI) {
   } catch (error) {
     errorCallback(error);
   } finally {
-    inProgressCallback(false);
+    inProgressCallback(false, 'RUNNING');
   }
 }
 
@@ -45,7 +45,7 @@ async function stopPod(podInfoUI: PodInfoUI) {
   } catch (error) {
     errorCallback(error);
   } finally {
-    inProgressCallback(false);
+    inProgressCallback(false, 'STOPPED');
   }
 }
 

--- a/packages/renderer/src/lib/pod/PodActions.svelte
+++ b/packages/renderer/src/lib/pod/PodActions.svelte
@@ -39,7 +39,7 @@ async function restartPod(podInfoUI: PodInfoUI) {
 }
 
 async function stopPod(podInfoUI: PodInfoUI) {
-  inProgressCallback(true);
+  inProgressCallback(true, 'STOPPING');
   try {
     await window.stopPod(podInfoUI.engineId, podInfoUI.id);
   } catch (error) {
@@ -49,8 +49,8 @@ async function stopPod(podInfoUI: PodInfoUI) {
   }
 }
 
-async function removePod(podInfoUI: PodInfoUI): Promise<void> {
-  inProgressCallback(true, 'REMOVING');
+async function deletePod(podInfoUI: PodInfoUI): Promise<void> {
+  inProgressCallback(true, 'DELETING');
   try {
     if (pod.kind === 'podman') {
       await window.removePod(podInfoUI.engineId, podInfoUI.id);
@@ -86,17 +86,24 @@ if (dropdownMenu) {
   <ListItemButtonIcon
     title="Start Pod"
     onClick="{() => startPod(pod)}"
-    hidden="{pod.status === 'RUNNING'}"
+    hidden="{pod.status === 'RUNNING' || pod.status === 'STOPPING'}"
     detailed="{detailed}"
+    inProgress="{pod.actionInProgress && pod.status === 'STARTING'}"
     icon="{faPlay}" />
   <ListItemButtonIcon
     title="Stop Pod"
     onClick="{() => stopPod(pod)}"
-    hidden="{!(pod.status === 'RUNNING')}"
+    hidden="{!(pod.status === 'RUNNING' || pod.status === 'STOPPING')}"
     detailed="{detailed}"
+    inProgress="{pod.actionInProgress && pod.status === 'STOPPING'}"
     icon="{faStop}" />
 {/if}
-<ListItemButtonIcon title="Delete Pod" onClick="{() => removePod(pod)}" icon="{faTrash}" detailed="{detailed}" />
+<ListItemButtonIcon
+  title="Delete Pod"
+  onClick="{() => deletePod(pod)}"
+  icon="{faTrash}"
+  detailed="{detailed}"
+  inProgress="{pod.actionInProgress && pod.status === 'DELETING'}" />
 
 <!-- If dropdownMenu is true, use it, otherwise just show the regular buttons -->
 <svelte:component this="{actionsStyle}">

--- a/packages/renderer/src/lib/pod/PodActions.svelte
+++ b/packages/renderer/src/lib/pod/PodActions.svelte
@@ -89,7 +89,8 @@ if (dropdownMenu) {
     hidden="{pod.status === 'RUNNING' || pod.status === 'STOPPING'}"
     detailed="{detailed}"
     inProgress="{pod.actionInProgress && pod.status === 'STARTING'}"
-    icon="{faPlay}" />
+    icon="{faPlay}"
+    iconOffset="pl-[0.15rem]" />
   <ListItemButtonIcon
     title="Stop Pod"
     onClick="{() => stopPod(pod)}"

--- a/packages/renderer/src/lib/pod/PodDetails.svelte
+++ b/packages/renderer/src/lib/pod/PodDetails.svelte
@@ -97,20 +97,7 @@ function errorCallback(errorMessage: string): void {
           <div class="flex flex-col px-5 pt-5">
             <div class="flex justify-end">
               <div class="flex items-center w-5">
-                {#if pod.actionInProgress}
-                  <svg
-                    class="animate-spin -ml-1 mr-3 h-5 w-5 text-white"
-                    xmlns="http://www.w3.org/2000/svg"
-                    fill="none"
-                    viewBox="0 0 24 24">
-                    <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-                    <path
-                      class="opacity-75"
-                      fill="currentColor"
-                      d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                    ></path>
-                  </svg>
-                {:else if pod.actionError}
+                {#if pod.actionError}
                   <ErrorMessage error="{pod.actionError}" icon />
                 {:else}
                   <div>&nbsp;</div>

--- a/packages/renderer/src/lib/pod/PodsList.svelte
+++ b/packages/renderer/src/lib/pod/PodsList.svelte
@@ -315,20 +315,7 @@ function errorCallback(pod: PodInfoUI, errorMessage: string): void {
             <td class="pl-6 text-right whitespace-nowrap rounded-tr-lg rounded-br-lg">
               <div class="flex w-full">
                 <div class="flex items-center w-5">
-                  {#if pod.actionInProgress}
-                    <svg
-                      class="animate-spin -ml-1 mr-3 h-5 w-5 text-white"
-                      xmlns="http://www.w3.org/2000/svg"
-                      fill="none"
-                      viewBox="0 0 24 24">
-                      <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-                      <path
-                        class="opacity-75"
-                        fill="currentColor"
-                        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                      ></path>
-                    </svg>
-                  {:else if pod.actionError}
+                  {#if pod.actionError}
                     <ErrorMessage error="{pod.actionError}" icon />
                   {:else}
                     <div>&nbsp;</div>

--- a/packages/renderer/src/lib/ui/ListItemButtonIcon.svelte
+++ b/packages/renderer/src/lib/ui/ListItemButtonIcon.svelte
@@ -11,8 +11,11 @@ export let onClick: () => void = () => {};
 export let menu: boolean = false;
 export let detailed: boolean = false;
 export let inProgress: boolean = false;
+export let iconOffset: string = '';
 let positionLeftClass = 'left-1';
 if (detailed) positionLeftClass = 'left-2';
+let positionTopClass = 'top-1';
+if (detailed) positionTopClass = '[0.2rem]';
 
 const buttonDetailedClass: string =
   'mx-1 text-gray-300 bg-zinc-900 hover:text-violet-600 font-medium rounded-lg text-sm inline-flex items-center px-3 py-2 text-center';
@@ -45,10 +48,10 @@ $: styleClass = detailed
     class="{styleClass} relative"
     class:disabled="{inProgress}"
     class:hidden="{hidden}">
-    <Fa class="h-4 w-4" icon="{icon}" />
+    <Fa class="h-4 w-4 {iconOffset}" icon="{icon}" />
     <div
       aria-label="spinner"
-      class="w-6 h-6 rounded-full animate-spin border border-solid border-violet-500 border-t-transparent absolute top-1 {positionLeftClass}"
+      class="w-6 h-6 rounded-full animate-spin border border-solid border-violet-500 border-t-transparent absolute {positionTopClass} {positionLeftClass}"
       class:hidden="{!inProgress}">
     </div>
   </button>

--- a/packages/renderer/src/lib/ui/ListItemButtonIcon.svelte
+++ b/packages/renderer/src/lib/ui/ListItemButtonIcon.svelte
@@ -10,6 +10,9 @@ export let enabled: boolean = true;
 export let onClick: () => void = () => {};
 export let menu: boolean = false;
 export let detailed: boolean = false;
+export let inProgress: boolean = false;
+let positionLeftClass = 'left-1';
+if (detailed) positionLeftClass = 'left-2';
 
 const buttonDetailedClass: string =
   'mx-1 text-gray-300 bg-zinc-900 hover:text-violet-600 font-medium rounded-lg text-sm inline-flex items-center px-3 py-2 text-center';
@@ -22,10 +25,10 @@ const buttonDisabledClass: string =
 
 $: handleClick = enabled ? onClick : () => {};
 $: styleClass = detailed
-  ? enabled
+  ? enabled && !inProgress
     ? buttonDetailedClass
     : buttonDetailedDisabledClass
-  : enabled
+  : enabled && !inProgress
   ? buttonClass
   : buttonDisabledClass;
 </script>
@@ -36,7 +39,17 @@ $: styleClass = detailed
   <DropdownMenuItem title="{title}" icon="{icon}" hidden="{hidden}" onClick="{handleClick}" />
 {:else}
   <!-- enabled button -->
-  <button title="{title}" on:click="{handleClick}" class="{styleClass}" class:hidden="{hidden}">
+  <button
+    title="{title}"
+    on:click="{handleClick}"
+    class="{styleClass} relative"
+    class:disabled="{inProgress}"
+    class:hidden="{hidden}">
     <Fa class="h-4 w-4" icon="{icon}" />
+    <div
+      aria-label="spinner"
+      class="w-6 h-6 rounded-full animate-spin border border-solid border-violet-500 border-t-transparent absolute top-1 {positionLeftClass}"
+      class:hidden="{!inProgress}">
+    </div>
   </button>
 {/if}

--- a/packages/renderer/src/lib/ui/ListItemButtonIcon.svelte
+++ b/packages/renderer/src/lib/ui/ListItemButtonIcon.svelte
@@ -23,7 +23,7 @@ const buttonClass: string =
 const buttonDisabledClass: string =
   'm-0.5 text-gray-700 font-medium rounded-full inline-flex items-center px-2 py-2 text-center';
 
-$: handleClick = enabled ? onClick : () => {};
+$: handleClick = enabled && !inProgress ? onClick : () => {};
 $: styleClass = detailed
   ? enabled && !inProgress
     ? buttonDetailedClass


### PR DESCRIPTION
### What does this PR do?

While testing Kind I really got to like the new spinner actions, and thought we should make the container & pod, list & details pages match. It wasn't too hard to replicate. This disables actions when they're in progress, and adds the same spinner as used in Settings > Resources. Removes the old common spinner from all four pages.

### Screenshot/screencast of this PR

https://user-images.githubusercontent.com/19958075/232052104-acb56cb4-1006-422b-9abb-70f42687996e.mov

### What issues does this PR fix or reference?

Fixes issue #2101.

### How to test this PR?

Start, stop, and delete both containers and pods, from both the main lists and details page. There is still sometimes a slight glitch where the 'old' action appears for a ms after it is done, but that's related to how we are updating progress vs state and not directly related to this change.