### PR TITLE
fix: Kind actions shouldn't move

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
@@ -320,14 +320,13 @@ async function startConnectionProvider(
                 <div class="flex mt-1">
                   <ConnectionStatus status="{kubeConnection.status}" />
                 </div>
-                {#if kubeConnection.status === 'started'}
-                  <div class="mt-2">
-                    <div class="text-gray-400 text-xs">Kubernetes endpoint</div>
-                    <div class="mt-1">
-                      <span class="my-auto text-xs">{kubeConnection.endpoint.apiURL}</span>
-                    </div>
+                <div class="mt-2">
+                  <div class="text-gray-400 text-xs">Kubernetes endpoint</div>
+                  <div class="mt-1">
+                    <span class="my-auto text-xs" class:text-gray-500="{kubeConnection.status !== 'started'}"
+                      >{kubeConnection.endpoint.apiURL}</span>
                   </div>
-                {/if}
+                </div>
                 <PreferencesConnectionActions
                   provider="{provider}"
                   connection="{kubeConnection}"


### PR DESCRIPTION
### What does this PR do?

Simple fix for moving actions - keep the endpoint label always visible and enable/disable the endpoint text based on state. We could hide the endpoint entirely when it's not running, but I don't think that's necessary.

### Screenshot/screencast of this PR

https://user-images.githubusercontent.com/19958075/232056601-389e224d-d38b-49a6-8000-3f43518a3f41.mov

### What issues does this PR fix or reference?

Fixes issue #2097.

### How to test this PR?

Go to Settings > Resources and start/stop a Kind cluster.