### PR TITLE
fix: Make Resources the default Settings page

### DIFF
--- a/packages/renderer/src/AppNavigation.svelte
+++ b/packages/renderer/src/AppNavigation.svelte
@@ -236,7 +236,7 @@ export let meta;
       class="pf-c-nav__item flex w-full justify-between {meta.url.startsWith('/preferences')
         ? 'dark:text-white pf-m-current'
         : 'dark:text-gray-400'} hover:text-gray-300 cursor-pointer items-center mb-6">
-      <a href="/preferences" class="pf-c-nav__link">
+      <a href="/preferences/resources" class="pf-c-nav__link">
         <div class="flex items-center">
           <svg
             id="settings"


### PR DESCRIPTION
### What does this PR do?

Changes the default settings page to Resources. It's at the top of the list, and it's where I want to go 90% of the time.

### Screenshot/screencast of this PR

https://user-images.githubusercontent.com/19958075/232058900-5edd6145-a6fd-49d8-949b-a5d38a3a5aee.mov

### What issues does this PR fix or reference?

Fixes issue #2105.

### How to test this PR?

Click on Settings!