### PR TITLE
docs: updated Deleting your local Kind-powered Kubernetes cluster to use the UI

### DIFF
--- a/website/docs/kubernetes/kind/deleting-your-kind-cluster.md
+++ b/website/docs/kubernetes/kind/deleting-your-kind-cluster.md
@@ -18,7 +18,7 @@ tags: [migrating-to-kubernetes, kind]
 1. Open **Settings > Resources**.
 1. Find the Kind cluster to delete.
 1. Click <icon icon="fa-solid fa-stop" size="lg" /> to stop the cluster.
-1. Click <icon icon="fa-solid fa-trash" size="lg" />.
+1. Once the cluster is stopped, click <icon icon="fa-solid fa-trash" size="lg" /> to delete it.
 
 #### Verification
 

--- a/website/docs/kubernetes/kind/deleting-your-kind-cluster.md
+++ b/website/docs/kubernetes/kind/deleting-your-kind-cluster.md
@@ -10,13 +10,16 @@ tags: [migrating-to-kubernetes, kind]
 
 #### Prerequisites
 
-* [You configured Podman](creating-a-kind-cluster.md).
-* [You installed Kind](https://kind.sigs.k8s.io/).
+- [You configured Podman](creating-a-kind-cluster.md).
+- [You installed Kind](https://kind.sigs.k8s.io/).
 
 #### Procedure
 
-* Delete the Kind cluster
+1. Open **Settings > Resources**.
+1. Find the kind cluster to delete.
+1. Click <icon icon="fa-solid fa-stop" size="lg" />.
+1. Click <icon icon="fa-solid fa-trash" size="lg" />.
 
-   ```shell-session
-   $ kind delete cluster
-   ```
+#### Verification
+
+1. In **Settings > Resources**, the deleted kind cluster is not visible.

--- a/website/docs/kubernetes/kind/deleting-your-kind-cluster.md
+++ b/website/docs/kubernetes/kind/deleting-your-kind-cluster.md
@@ -17,7 +17,7 @@ tags: [migrating-to-kubernetes, kind]
 
 1. Open **Settings > Resources**.
 1. Find the Kind cluster to delete.
-1. Click <icon icon="fa-solid fa-stop" size="lg" />.
+1. Click <icon icon="fa-solid fa-stop" size="lg" /> to stop the cluster.
 1. Click <icon icon="fa-solid fa-trash" size="lg" />.
 
 #### Verification

--- a/website/docs/kubernetes/kind/deleting-your-kind-cluster.md
+++ b/website/docs/kubernetes/kind/deleting-your-kind-cluster.md
@@ -16,10 +16,10 @@ tags: [migrating-to-kubernetes, kind]
 #### Procedure
 
 1. Open **Settings > Resources**.
-1. Find the kind cluster to delete.
+1. Find the Kind cluster to delete.
 1. Click <icon icon="fa-solid fa-stop" size="lg" />.
 1. Click <icon icon="fa-solid fa-trash" size="lg" />.
 
 #### Verification
 
-1. In **Settings > Resources**, the deleted kind cluster is not visible.
+1. In **Settings > Resources**, the deleted Kind cluster is not visible.


### PR DESCRIPTION
docs: updated Deleting your local Kind-powered Kubernetes cluster to use the UI

refs: https://github.com/containers/podman-desktop/issues/1955