### PR TITLE
fix: stop autostarted VM when podman extension is deactivated

### DIFF
--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -666,7 +666,7 @@ async function stopAutoStartedMachine() {
     autoMachineStarted = false;
     return;
   }
-  console.log('stopping machine', autoMachineName);
+  console.log('stopping autostarted machine', autoMachineName);
   await execPromise(getPodmanCli(), ['machine', 'stop', autoMachineName]);
 }
 

--- a/packages/main/src/index.ts
+++ b/packages/main/src/index.ts
@@ -51,14 +51,17 @@ app.on('window-all-closed', () => {
   }
 });
 
-app.once('before-quit', () => {
-  extensionLoader
+app.once('before-quit', async event => {
+  event.preventDefault();
+  await extensionLoader
     ?.stopAllExtensions()
     .then(() => {
       console.log('Stopped all extensions');
+      app.quit();
     })
     .catch(error => {
       console.log('Error stopping extensions', error);
+      app.quit();
     });
 });
 /**

--- a/packages/main/src/index.ts
+++ b/packages/main/src/index.ts
@@ -20,7 +20,7 @@ import { app, ipcMain, Tray } from 'electron';
 import './security-restrictions';
 import { createNewWindow, restoreWindow } from '/@/mainWindow';
 import { TrayMenu } from './tray-menu';
-import { isMac, isWindows } from './util';
+import { isMac, isWindows, stoppedExtensions } from './util';
 import { AnimatedTray } from './tray-animate-icon';
 import { PluginSystem } from './plugin';
 import { StartupInstall } from './system/startup-install';
@@ -51,9 +51,9 @@ app.on('window-all-closed', () => {
   }
 });
 
-let stoppedAllExtensions = false;
-app.on('before-quit', async event => {
-  if (stoppedAllExtensions) {
+app.once('before-quit', async event => {
+  if (!extensionLoader) {
+    stoppedExtensions.val = true;
     return;
   }
   event.preventDefault();
@@ -66,7 +66,7 @@ app.on('before-quit', async event => {
       console.log('Error stopping extensions', error);
     })
     .finally(() => {
-      stoppedAllExtensions = true;
+      stoppedExtensions.val = true;
       app.quit();
     });
 });

--- a/packages/main/src/index.ts
+++ b/packages/main/src/index.ts
@@ -51,16 +51,22 @@ app.on('window-all-closed', () => {
   }
 });
 
-app.once('before-quit', async event => {
+let stoppedAllExtensions = false;
+app.on('before-quit', async event => {
+  if (stoppedAllExtensions) {
+    return;
+  }
   event.preventDefault();
   await extensionLoader
     ?.stopAllExtensions()
     .then(() => {
       console.log('Stopped all extensions');
-      app.quit();
     })
     .catch(error => {
       console.log('Error stopping extensions', error);
+    })
+    .finally(() => {
+      stoppedAllExtensions = true;
       app.quit();
     });
 });

--- a/packages/main/src/mainWindow.ts
+++ b/packages/main/src/mainWindow.ts
@@ -152,8 +152,13 @@ async function createWindow() {
     }
   });
 
+  let destroyed = false;
   app.on('before-quit', () => {
+    if (destroyed) {
+      return;
+    }
     browserWindow.destroy();
+    destroyed = true;
   });
 
   contextMenu({

--- a/packages/main/src/mainWindow.ts
+++ b/packages/main/src/mainWindow.ts
@@ -25,7 +25,7 @@ const { aboutMenuItem } = require('electron-util');
 import { join } from 'path';
 import { URL } from 'url';
 import type { ConfigurationRegistry } from './plugin/configuration-registry';
-import { isLinux, isMac } from './util';
+import { isLinux, isMac, stoppedExtensions } from './util';
 
 async function createWindow() {
   const INITIAL_APP_WIDTH = 1050;
@@ -154,7 +154,7 @@ async function createWindow() {
 
   let destroyed = false;
   app.on('before-quit', () => {
-    if (destroyed) {
+    if (destroyed || !stoppedExtensions.val) {
       return;
     }
     browserWindow.destroy();

--- a/packages/main/src/plugin/telemetry/telemetry.ts
+++ b/packages/main/src/plugin/telemetry/telemetry.ts
@@ -35,6 +35,7 @@ import type {
   TelemetryTrustedValue,
 } from '@podman-desktop/api';
 import { TelemetryTrustedValue as TypeTelemetryTrustedValue } from '../types/telemetry';
+import { stoppedExtensions } from '/@/util';
 
 export const TRACK_EVENT_TYPE = 'track';
 export const PAGE_EVENT_TYPE = 'page';
@@ -202,7 +203,7 @@ export class Telemetry {
     let sendShutdownAnalytics = false;
 
     app.on('before-quit', async e => {
-      if (!sendShutdownAnalytics) {
+      if (!sendShutdownAnalytics && stoppedExtensions.val) {
         e.preventDefault();
         await this.internalTrack(SHUTDOWN_EVENT_TYPE);
         await this.analytics?.flush();

--- a/packages/main/src/util.ts
+++ b/packages/main/src/util.ts
@@ -39,3 +39,5 @@ export function desktopAppHomeDir(): string {
 export function findWindow(): Electron.BrowserWindow | undefined {
   return BrowserWindow.getAllWindows().find(w => !w.isDestroyed());
 }
+
+export const stoppedExtensions = { val: false };


### PR DESCRIPTION
### What does this PR do?
Stop an autostarted VM when podman extension is deactivated 
### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->
Fixes #1661 
### How to test this PR?
This is the second part for the fix of #1661. Start podman desktop with no machine running. It will autostart a machine. Quitting the app will stop the autostarted machine.
<!-- Please explain steps to reproduce -->
