### PR TITLE
fix: wait the podman process to end before log the error (#2002)

### DIFF
--- a/extensions/podman/src/podman-cli.ts
+++ b/extensions/podman/src/podman-cli.ts
@@ -111,20 +111,12 @@ export function execPromise(
     process.stderr.setEncoding('utf8');
     process.stderr.on('data', data => {
       stdErr += data;
-      options?.logger?.error(data);
     });
 
     process.on('close', exitCode => {
-      let content = '';
-      if (stdOut && stdOut !== '') {
-        content += stdOut + '\n';
-      }
-      if (stdErr && stdErr !== '') {
-        content += stdErr + '\n';
-      }
-
       if (exitCode !== 0) {
-        reject(new Error(content));
+        options?.logger?.error(stdErr);
+        reject(new Error(stdErr));
       }
       resolve(stdOut.trim());
     });

--- a/extensions/podman/src/podman-cli.ts
+++ b/extensions/podman/src/podman-cli.ts
@@ -111,6 +111,7 @@ export function execPromise(
     process.stderr.setEncoding('utf8');
     process.stderr.on('data', data => {
       stdErr += data;
+      options?.logger?.warn(data);
     });
 
     process.on('close', exitCode => {


### PR DESCRIPTION
### What does this PR do?

This PR avoid sending an error to the logger used by the task manager when something is written to stderr. It waits that the process ends with an exit code different than 0.

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

it fixes #2002 

### How to test this PR?

1. start/stop a podman machine and check that everything works fine. It would be great if you were able to reproduce the same error i had somehow.
@slemeur i remember you posted a similar issue on slack. If you are able to reproduce the bug consistently can you try this fix?
