### PR TITLE
Update Prune dialog to current design

### DIFF
--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -51,6 +51,7 @@ import type { ImageInspectInfo } from './api/image-inspect-info';
 import type { TrayMenu } from '../tray-menu';
 import { getFreePort } from './util/port';
 import { isLinux, isMac } from '../util';
+import type { MessageBoxOptions, MessageBoxReturnValue } from './message-box';
 import { MessageBox } from './message-box';
 import { ProgressImpl } from './progress-impl';
 import type { ContributionInfo } from './api/contribution-info';
@@ -1037,6 +1038,10 @@ export class PluginSystem {
       return inputQuickPickRegistry.onDidSelectQuickPickItem(id, selectedId);
     });
 
+    this.ipcHandle('showMessageBox', async (_listener, options: MessageBoxOptions): Promise<MessageBoxReturnValue> => {
+      return messageBox.showMessageBox(options);
+    });
+    
     this.ipcHandle('showMessageBox:onSelect', async (_listener, id: number, index: number): Promise<void> => {
       return messageBox.onDidSelectButton(id, index);
     });

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1041,7 +1041,7 @@ export class PluginSystem {
     this.ipcHandle('showMessageBox', async (_listener, options: MessageBoxOptions): Promise<MessageBoxReturnValue> => {
       return messageBox.showMessageBox(options);
     });
-    
+
     this.ipcHandle('showMessageBox:onSelect', async (_listener, id: number, index: number): Promise<void> => {
       return messageBox.onDidSelectButton(id, index);
     });

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -54,6 +54,7 @@ import type {
 } from '../../main/src/plugin/dockerode/libpod-dockerode';
 import type { V1ConfigMap, V1NamespaceList, V1Pod, V1PodList, V1Service } from '@kubernetes/client-node';
 import type { Menu } from '../../main/src/plugin/menu-registry';
+import type { MessageBoxOptions, MessageBoxReturnValue } from '../../main/src/plugin/message-box';
 
 export type DialogResultCallback = (openDialogReturnValue: Electron.OpenDialogReturnValue) => void;
 
@@ -1006,6 +1007,13 @@ function initExposure(): void {
     },
   );
 
+  
+  contextBridge.exposeInMainWorld(
+    'showMessageBox',
+    async (messageBoxOptions: MessageBoxOptions): Promise<MessageBoxReturnValue> => {
+      return ipcInvoke('showMessageBox', messageBoxOptions);
+    },
+  );
   contextBridge.exposeInMainWorld(
     'sendShowMessageBoxOnSelect',
     async (messageBoxId: number, selectedIndex: number): Promise<void> => {

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -1007,7 +1007,6 @@ function initExposure(): void {
     },
   );
 
-  
   contextBridge.exposeInMainWorld(
     'showMessageBox',
     async (messageBoxOptions: MessageBoxOptions): Promise<MessageBoxReturnValue> => {

--- a/packages/renderer/src/lib/engine/Prune.svelte
+++ b/packages/renderer/src/lib/engine/Prune.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-import Modal from '../dialogs/Modal.svelte';
 import type { EngineInfoUI } from './EngineInfoUI';
+import type { MessageBoxReturnValue } from '../../../../main/src/plugin/message-box';
 
 // Imported type for prune (containers, images, pods, volumes)
 export let type: string;
@@ -8,20 +8,26 @@ export let type: string;
 // List of engines that the prune will work on
 export let engines: EngineInfoUI[];
 
-// Functionality for modal
-let openChoiceModal = false;
-function toggleChoiceModal(): void {
-  openChoiceModal = !openChoiceModal;
-}
-function keydownChoice(e: KeyboardEvent) {
-  e.stopPropagation();
-  if (e.key === 'Escape') {
-    toggleChoiceModal();
+async function openPruneDialog(): Promise<void> {
+  let message = 'This action will prune all unused ' + type;
+  if (engines.length > 1) {
+    message += ' from all container engines.';
+  } else {
+    message += ' from the ' + engines[0].name + ' engine.';
+  }
+
+  const result = await window.showMessageBox({
+    title: 'Prune',
+    message: message,
+    buttons: ['Yes', 'No'],
+  });
+
+  if (result && result.response === 0) {
+    prune(type);
   }
 }
 
-// Function to prune the selected type: containers
-// TODO: Add prune for pods, images and volumes in a later PR
+// Function to prune the selected type: containers, pods, images and volumes
 async function prune(type: string) {
   switch (type) {
     case 'containers':
@@ -64,47 +70,12 @@ async function prune(type: string) {
       console.error('Prune type not found');
       break;
   }
-
-  // Close the modal once the prune is completed
-  toggleChoiceModal();
 }
 </script>
 
-<button on:click="{() => toggleChoiceModal()}" class="pf-c-button pf-m-primary" type="button" title="Prune {type}">
+<button on:click="{() => openPruneDialog()}" class="pf-c-button pf-m-primary" type="button" title="Prune {type}">
   <span class="pf-c-button__icon pf-m-start">
     <i class="fas fa-trash" aria-hidden="true"></i>
   </span>
   Prune {type}
 </button>
-
-<!-- Create modal that confirms the user wants to prune the selected type -->
-{#if openChoiceModal}
-  <Modal
-    on:close="{() => {
-      openChoiceModal = false;
-    }}">
-    <div
-      class="inline-block w-full overflow-hidden text-left transition-all transform bg-zinc-800 z-50 h-[200px] rounded-xl shadow-xl shadow-neutral-900"
-      on:keydown="{keydownChoice}">
-      <div class="flex items-center justify-between bg-black px-5 py-4 border-b-2 border-violet-700">
-        <h1 class="text-xl font-bold">Prune unused {type}</h1>
-
-        <button class="hover:text-gray-200 px-2 py-1" on:click="{() => toggleChoiceModal()}">
-          <i class="fas fa-times" aria-hidden="true"></i>
-        </button>
-      </div>
-      <div class="bg-zinc-800 p-5 h-full flex flex-col justify-items-center">
-        {#if engines.length > 1}
-          <span class="pb-3">This action will prune all unused {type} from all container engines.</span>
-        {:else}
-          <span class="pb-3">This action will prune all unused {type} from the {engines[0].name} engine.</span>
-        {/if}
-        <span class="pb-3">Are you sure you want to continue?</span>
-        <div class="pt-5 grid grid-cols-2 gap-10 place-content-center w-full">
-          <button class="pf-c-button pf-m-primary" type="button" on:click="{() => prune(type)}">Yes</button>
-          <button class="pf-c-button pf-m-secondary" type="button" on:click="{() => toggleChoiceModal()}">No</button>
-        </div>
-      </div>
-    </div>
-  </Modal>
-{/if}


### PR DESCRIPTION
### What does this PR do?

Expose the message box API to the renderer (but not extensions) and switch the Prune dialog to use it. This changes the prune dialog to match current design guidelines.

Although we may still need to update the Modal component to the new design, this simplifies the prune code as well.

### Screenshot/screencast of this PR

Before:
<img width="647" alt="Screenshot 2023-04-18 at 10 18 58 AM" src="https://user-images.githubusercontent.com/19958075/232806534-083e3f8e-3179-4402-ac94-6d5c51d0de19.png">

After:
<img width="562" alt="Screenshot 2023-04-18 at 10 14 21 AM" src="https://user-images.githubusercontent.com/19958075/232806583-08d30cfa-f303-49ea-88f7-d60341e26be1.png">

### What issues does this PR fix or reference?

Partial fix for issue #1987.

### How to test this PR?

Prune! Try 'no', 'yes' and cancelling the dialog.