### PR TITLE
chore: Clean up src/lib folder

### DIFF
--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -16,7 +16,7 @@ import PreferencesPage from './lib/preferences/PreferencesPage.svelte';
 import BuildImageFromContainerfile from './lib/image/BuildImageFromContainerfile.svelte';
 import PullImage from './lib/image/PullImage.svelte';
 import DockerExtension from './lib/docker-extension/DockerExtension.svelte';
-import ContainerDetails from './lib/ContainerDetails.svelte';
+import ContainerDetails from './lib/container/ContainerDetails.svelte';
 import { providerInfos } from './stores/providers';
 import type { ProviderInfo } from '../../main/src/plugin/api/provider-info';
 import WelcomePage from './lib/welcome/WelcomePage.svelte';

--- a/packages/renderer/src/lib/container/ContainerDetails.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetails.svelte
@@ -1,22 +1,22 @@
 <script lang="ts">
-import { ContainerGroupInfoTypeUI, type ContainerInfoUI } from './container/ContainerInfoUI';
-import Route from '../Route.svelte';
-import ContainerIcon from './images/ContainerIcon.svelte';
-import StatusIcon from './images/StatusIcon.svelte';
+import { ContainerGroupInfoTypeUI, type ContainerInfoUI } from './ContainerInfoUI';
+import Route from '../../Route.svelte';
+import ContainerIcon from '../images/ContainerIcon.svelte';
+import StatusIcon from '../images/StatusIcon.svelte';
 
 import 'xterm/css/xterm.css';
 import ContainerDetailsTerminal from './ContainerDetailsTerminal.svelte';
 import ContainerDetailsLogs from './ContainerDetailsLogs.svelte';
-import ContainerActions from './container/ContainerActions.svelte';
+import ContainerActions from './ContainerActions.svelte';
 import { onMount } from 'svelte';
-import { containersInfos } from '../stores/containers';
-import { ContainerUtils } from './container/container-utils';
+import { containersInfos } from '../../stores/containers';
+import { ContainerUtils } from './container-utils';
 import ContainerDetailsSummary from './ContainerDetailsSummary.svelte';
 import ContainerDetailsInspect from './ContainerDetailsInspect.svelte';
 import ContainerDetailsKube from './ContainerDetailsKube.svelte';
-import ContainerStatistics from './container/ContainerStatistics.svelte';
-import DetailsTab from './ui/DetailsTab.svelte';
-import ErrorMessage from './ui/ErrorMessage.svelte';
+import ContainerStatistics from './ContainerStatistics.svelte';
+import DetailsTab from '../ui/DetailsTab.svelte';
+import ErrorMessage from '../ui/ErrorMessage.svelte';
 
 export let containerID: string;
 

--- a/packages/renderer/src/lib/container/ContainerDetailsInspect.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetailsInspect.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-import type { ContainerInfoUI } from './container/ContainerInfoUI';
+import type { ContainerInfoUI } from './ContainerInfoUI';
 import { onMount } from 'svelte';
-import MonacoEditor from './editor/MonacoEditor.svelte';
+import MonacoEditor from '../editor/MonacoEditor.svelte';
 
 export let container: ContainerInfoUI;
 

--- a/packages/renderer/src/lib/container/ContainerDetailsKube.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetailsKube.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-import type { ContainerInfoUI } from './container/ContainerInfoUI';
+import type { ContainerInfoUI } from './ContainerInfoUI';
 import { onMount } from 'svelte';
-import MonacoEditor from './editor/MonacoEditor.svelte';
+import MonacoEditor from '../editor/MonacoEditor.svelte';
 
 export let container: ContainerInfoUI;
 

--- a/packages/renderer/src/lib/container/ContainerDetailsLogs.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetailsLogs.svelte
@@ -1,15 +1,15 @@
 <script lang="ts">
-import type { ContainerInfoUI } from './container/ContainerInfoUI';
+import type { ContainerInfoUI } from './ContainerInfoUI';
 import { onDestroy, onMount } from 'svelte';
 import { Terminal } from 'xterm';
 import { FitAddon } from 'xterm-addon-fit';
 import 'xterm/css/xterm.css';
-import { TerminalSettings } from '../../../main/src/plugin/terminal-settings';
-import { getPanelDetailColor } from './color/color';
+import { TerminalSettings } from '../../../../main/src/plugin/terminal-settings';
+import { getPanelDetailColor } from '../color/color';
 
-import { isMultiplexedLog } from './stream/stream-utils';
-import EmptyScreen from './ui/EmptyScreen.svelte';
-import NoLogIcon from './ui/NoLogIcon.svelte';
+import { isMultiplexedLog } from '../stream/stream-utils';
+import EmptyScreen from '../ui/EmptyScreen.svelte';
+import NoLogIcon from '../ui/NoLogIcon.svelte';
 
 export let container: ContainerInfoUI;
 

--- a/packages/renderer/src/lib/container/ContainerDetailsSummary.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetailsSummary.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-import type { ContainerInfoUI } from './container/ContainerInfoUI';
-import { getPanelDetailColor } from './color/color';
+import type { ContainerInfoUI } from './ContainerInfoUI';
+import { getPanelDetailColor } from '../color/color';
 
 export let container: ContainerInfoUI;
 </script>

--- a/packages/renderer/src/lib/container/ContainerDetailsTerminal.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetailsTerminal.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
-import type { ContainerInfoUI } from './container/ContainerInfoUI';
-import { TerminalSettings } from '../../../main/src/plugin/terminal-settings';
+import type { ContainerInfoUI } from './ContainerInfoUI';
+import { TerminalSettings } from '../../../../main/src/plugin/terminal-settings';
 import { router } from 'tinro';
 import { onMount } from 'svelte';
 import { Terminal } from 'xterm';
 import { FitAddon } from 'xterm-addon-fit';
 import 'xterm/css/xterm.css';
-import { getPanelDetailColor } from './color/color';
+import { getPanelDetailColor } from '../color/color';
 
 export let container: ContainerInfoUI;
 let terminalXtermDiv: HTMLDivElement;

--- a/packages/renderer/src/lib/preferences/PreferencesExtensionList.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesExtensionList.svelte
@@ -4,10 +4,10 @@ import { faPuzzlePiece, faTrash } from '@fortawesome/free-solid-svg-icons';
 import { faPlay } from '@fortawesome/free-solid-svg-icons';
 import { faStop } from '@fortawesome/free-solid-svg-icons';
 import { afterUpdate } from 'svelte';
-import { extensionInfos } from '../stores/extensions';
-import type { ExtensionInfo } from '../../../main/src/plugin/api/extension-info';
-import ErrorMessage from './ui/ErrorMessage.svelte';
-import SettingsPage from './preferences/SettingsPage.svelte';
+import { extensionInfos } from '../../stores/extensions';
+import type { ExtensionInfo } from '../../../../main/src/plugin/api/extension-info';
+import ErrorMessage from '../ui/ErrorMessage.svelte';
+import SettingsPage from '../preferences/SettingsPage.svelte';
 
 let ociImage: string;
 

--- a/packages/renderer/src/lib/preferences/PreferencesPage.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesPage.svelte
@@ -12,7 +12,7 @@ import PreferencesExtensionRendering from './PreferencesExtensionRendering.svelt
 import PreferencesRegistriesEditing from './PreferencesRegistriesEditing.svelte';
 import PreferencesPageDockerExtensions from '../docker-extension/PreferencesPageDockerExtensions.svelte';
 import PreferencesProxiesRendering from './PreferencesProxiesRendering.svelte';
-import ExtensionList from '../ExtensionList.svelte';
+import PreferencesExtensionList from './PreferencesExtensionList.svelte';
 import PreferencesResourcesRendering from './PreferencesResourcesRendering.svelte';
 import PreferencesAuthenticationProvidersRendering from './PreferencesAuthenticationProvidersRendering.svelte';
 
@@ -68,7 +68,7 @@ onMount(async () => {
     <PreferencesProxiesRendering />
   </Route>
   <Route path="/extensions" breadcrumb="Extensions">
-    <ExtensionList />
+    <PreferencesExtensionList />
   </Route>
 
   <Route path="/container-connection/:provider/:connection/*" breadcrumb="Container Engine" let:meta>


### PR DESCRIPTION
### What does this PR do?

All detail pages (pods, images, volumes) are in their own respective folders except for ContainerDetails. All preferences are in the /preferences folder except for the ExtensionList. This just moves each of these pages into the normal locations that we've been putting everything else, and fixes the references to them.

No functional/UI changes, this just cleans up the renderer/src/lib folder, which makes it easier and more consistent to find things.

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Just confirm extension settings and container details page (including each tab) still works as normal.