### PR TITLE
chore: extension events

### DIFF
--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -778,22 +778,26 @@ export class ExtensionLoader {
       extensionContext,
     };
     this.activatedExtensions.set(extension.id, activatedExtension);
+    this.apiSender.send('extension-started');
   }
 
   async deactivateExtension(extensionId: string): Promise<void> {
     const extension = this.activatedExtensions.get(extensionId);
-    if (extension) {
-      if (extension.deactivateFunction) {
-        await extension.deactivateFunction();
-      }
-
-      // dispose subscriptions
-      extension.extensionContext.subscriptions.forEach(async subscription => {
-        await subscription.dispose();
-      });
-
-      this.activatedExtensions.delete(extensionId);
+    if (!extension) {
+      return;
     }
+
+    if (extension.deactivateFunction) {
+      await extension.deactivateFunction();
+    }
+
+    // dispose subscriptions
+    extension.extensionContext.subscriptions.forEach(async subscription => {
+      await subscription.dispose();
+    });
+
+    this.activatedExtensions.delete(extensionId);
+    this.apiSender.send('extension-stopped');
   }
 
   async stopAllExtensions(): Promise<void> {
@@ -820,7 +824,7 @@ export class ExtensionLoader {
         throw new Error(`Extension ${extensionId} is not removable`);
       }
       this.analyzedExtensions.delete(extensionId);
-      this.apiSender.send('extension-removed', {});
+      this.apiSender.send('extension-removed');
     }
   }
 

--- a/packages/renderer/src/lib/preferences/PreferencesExtensionList.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesExtensionList.svelte
@@ -53,16 +53,13 @@ afterUpdate(() => {
 
 async function stopExtension(extension: ExtensionInfo) {
   await window.stopExtension(extension.id);
-  window.dispatchEvent(new CustomEvent('extension-stopped', { detail: extension }));
 }
 async function startExtension(extension: ExtensionInfo) {
   await window.startExtension(extension.id);
-  window.dispatchEvent(new CustomEvent('extension-started', { detail: extension }));
 }
 
 async function removeExtension(extension: ExtensionInfo) {
   await window.removeExtension(extension.id);
-  window.dispatchEvent(new CustomEvent('extension-removed', { detail: extension }));
 }
 </script>
 

--- a/packages/renderer/src/lib/preferences/PreferencesExtensionRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesExtensionRendering.svelte
@@ -10,11 +10,9 @@ $: extensionInfo = $extensionInfos.find(extension => extension.id === extensionI
 
 async function stopExtension() {
   await window.stopExtension(extensionInfo.id);
-  window.dispatchEvent(new CustomEvent('extension-stopped', { detail: extensionInfo }));
 }
 async function startExtension() {
   await window.startExtension(extensionInfo.id);
-  window.dispatchEvent(new CustomEvent('extension-started', { detail: extensionInfo }));
 }
 </script>
 

--- a/packages/renderer/src/stores/configurationProperties.ts
+++ b/packages/renderer/src/stores/configurationProperties.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2022 Red Hat, Inc.
+ * Copyright (C) 2022-2023 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,11 +34,10 @@ export const configurationProperties: Writable<IConfigurationPropertyRecordedSch
 window.events?.receive('extensions-started', () => {
   fetchConfigurationProperties();
 });
-
-window.addEventListener('extension-started', () => {
+window.events?.receive('extension-started', () => {
   fetchConfigurationProperties();
 });
-window.addEventListener('extension-stopped', () => {
+window.events?.receive('extension-stopped', () => {
   fetchConfigurationProperties();
 });
 window.addEventListener('system-ready', () => {

--- a/packages/renderer/src/stores/containers.ts
+++ b/packages/renderer/src/stores/containers.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2022 Red Hat, Inc.
+ * Copyright (C) 2022-2023 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,8 +34,8 @@ export const filtered = derived([searchPattern, containersInfos], ([$searchPatte
   $containersInfos.filter(containerInfo => findMatchInLeaves(containerInfo, $searchPattern.toLowerCase())),
 );
 
-// need to refresh when extension is started or stopped
-window.addEventListener('extension-started', () => {
+// need to refresh when extension is started
+window.events?.receive('extension-started', () => {
   fetchContainers();
 });
 

--- a/packages/renderer/src/stores/extensions.ts
+++ b/packages/renderer/src/stores/extensions.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2022 Red Hat, Inc.
+ * Copyright (C) 2022-2023 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,17 +28,13 @@ export async function fetchExtensions() {
 export const extensionInfos: Writable<ExtensionInfo[]> = writable([]);
 
 // need to refresh when extension is started or stopped
-window.addEventListener('extension-started', () => {
-  fetchExtensions();
-});
-window.addEventListener('extension-stopped', () => {
-  fetchExtensions();
-});
-window.addEventListener('extension-removed', () => {
-  fetchExtensions();
-});
-
 window?.events.receive('extension-started', () => {
+  fetchExtensions();
+});
+window?.events.receive('extension-stopped', () => {
+  fetchExtensions();
+});
+window?.events.receive('extension-removed', () => {
   fetchExtensions();
 });
 window.addEventListener('system-ready', () => {

--- a/packages/renderer/src/stores/images.ts
+++ b/packages/renderer/src/stores/images.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2022 Red Hat, Inc.
+ * Copyright (C) 2022-2023 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,10 +34,10 @@ export const filtered = derived([searchPattern, imagesInfos], ([$searchPattern, 
 );
 
 // need to refresh when extension is started or stopped
-window.addEventListener('extension-started', () => {
+window?.events.receive('extension-started', () => {
   fetchImages();
 });
-window.addEventListener('extension-stopped', () => {
+window?.events.receive('extension-stopped', () => {
   fetchImages();
 });
 

--- a/packages/renderer/src/stores/pods.ts
+++ b/packages/renderer/src/stores/pods.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2022 Red Hat, Inc.
+ * Copyright (C) 2022-2023 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,10 +39,10 @@ export const filtered = derived([searchPattern, podsInfos], ([$searchPattern, $i
 });
 
 // need to refresh when extension is started or stopped
-window.addEventListener('extension-started', () => {
+window.events?.receive('extension-started', () => {
   fetchPods();
 });
-window.addEventListener('extension-stopped', () => {
+window.events?.receive('extension-stopped', () => {
   fetchPods();
 });
 

--- a/packages/renderer/src/stores/providers.ts
+++ b/packages/renderer/src/stores/providers.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2022 Red Hat, Inc.
+ * Copyright (C) 2022-2023 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,10 +37,10 @@ export async function fetchProviders() {
 export const providerInfos: Writable<ProviderInfo[]> = writable([]);
 
 // need to refresh when extension is started or stopped
-window.addEventListener('extension-started', () => {
+window?.events?.receive('extension-started', () => {
   fetchProviders();
 });
-window.addEventListener('extension-stopped', () => {
+window?.events?.receive('extension-stopped', () => {
   fetchProviders();
 });
 

--- a/packages/renderer/src/stores/volumes.ts
+++ b/packages/renderer/src/stores/volumes.ts
@@ -46,10 +46,10 @@ export const filtered = derived([searchPattern, volumeListInfos], ([$searchPatte
 });
 
 // need to refresh when extension is started or stopped
-window.addEventListener('extension-started', async () => {
+window?.events?.receive('extension-started', async () => {
   await fetchVolumes();
 });
-window.addEventListener('extension-stopped', async () => {
+window?.events?.receive('extension-stopped', async () => {
   await fetchVolumes();
 });
 


### PR DESCRIPTION
### What does this PR do?

The main extensions loader was firing an extension-removed event, but all other extension lifecycle events (including a second extension-removed) were fired within the renderer level. This adds an extension-started and -stopped event to the loader, and migrates all the listeners to use these events instead. IMHO it is simpler and safer down the road when a change event comes from the thing doing the change, and isn't reliant on multiple UIs triggering the change to also fire an event.

The comment in containers.ts said it was listening to extension started and stopped events, but the code was only listening to started. I tested the code and it is getting several provider-change events when extensions change, so I've fixed the comment instead of the code.

extensions.ts was listening for the UI extension-removed event even though there was one from the loader, so I've made it consistent.

### Screenshot/screencast of this PR

N/A, no visible change.

### What issues does this PR fix or reference?

This is a fix towards issue #1810; having consistent events will make it easier to fix the UI actions.

### How to test this PR?

Start/stop extensions from both the main and individual extension pages.