### PR TITLE
feat: Add ability to create an ingress

### DIFF
--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -78,7 +78,7 @@ import { AutostartEngine } from './autostart-engine';
 import { CloseBehavior } from './close-behavior';
 import { TrayIconColor } from './tray-icon-color';
 import { KubernetesClient } from './kubernetes-client';
-import type { V1Pod, V1ConfigMap, V1NamespaceList, V1PodList, V1Service } from '@kubernetes/client-node';
+import type { V1Pod, V1ConfigMap, V1NamespaceList, V1PodList, V1Service, V1Ingress } from '@kubernetes/client-node';
 import type { V1Route } from './api/openshift-types';
 import type { NetworkInspectInfo } from './api/network-info';
 import { FilesystemMonitoring } from './filesystem-monitoring';
@@ -1340,6 +1340,13 @@ export class PluginSystem {
       'kubernetes-client:createService',
       async (_listener, namespace: string, service: V1Service): Promise<V1Service> => {
         return kubernetesClient.createService(namespace, service);
+      },
+    );
+
+    this.ipcHandle(
+      'kubernetes-client:createIngress',
+      async (_listener, namespace: string, ingress: V1Ingress): Promise<V1Ingress> => {
+        return kubernetesClient.createIngress(namespace, ingress);
       },
     );
 

--- a/packages/main/src/plugin/kubernetes-client.spec.ts
+++ b/packages/main/src/plugin/kubernetes-client.spec.ts
@@ -34,6 +34,7 @@ beforeAll(() => {
       CoreV1Api: {},
       AppsV1Api: {},
       CustomObjectsApi: {},
+      NetworkingV1Api: {},
     };
   });
 });
@@ -65,6 +66,20 @@ test('Create Kubernetes resources with apps/v1 resource should return ok', async
 
   await client.createResources('dummy', [{ apiVersion: 'apps/v1', kind: 'Deployment' }]);
   expect(createNamespacedDeploymentMock).toBeCalledWith('default', { apiVersion: 'apps/v1', kind: 'Deployment' });
+});
+
+test('Create Kubernetes resources with networking.k8s.io/v1 resource should return ok', async () => {
+  const client = new KubernetesClient({} as ApiSenderType, configurationRegistry, fileSystemMonitoring);
+  const createNamespacedIngressMock = vi.fn();
+  makeApiClientMock.mockReturnValue({
+    createNamespacedIngress: createNamespacedIngressMock,
+  });
+
+  await client.createResources('dummy', [{ apiVersion: 'networking.k8s.io/v1', kind: 'Ingress' }]);
+  expect(createNamespacedIngressMock).toBeCalledWith('default', {
+    apiVersion: 'networking.k8s.io/v1',
+    kind: 'Ingress',
+  });
 });
 
 test('Create Kubernetes resources with v1 resource in error should return error', async () => {

--- a/packages/main/src/plugin/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes-client.ts
@@ -26,6 +26,7 @@ import type {
   V1Service,
   V1Ingress,
   V1ContainerState,
+  V1APIResource,
 } from '@kubernetes/client-node';
 import { NetworkingV1Api } from '@kubernetes/client-node';
 import { AppsV1Api } from '@kubernetes/client-node';

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -52,7 +52,7 @@ import type {
   PodCreateOptions,
   ContainerCreateOptions as PodmanContainerCreateOptions,
 } from '../../main/src/plugin/dockerode/libpod-dockerode';
-import type { V1ConfigMap, V1NamespaceList, V1Pod, V1PodList, V1Service } from '@kubernetes/client-node';
+import type { V1ConfigMap, V1Ingress, V1NamespaceList, V1Pod, V1PodList, V1Service } from '@kubernetes/client-node';
 import type { Menu } from '../../main/src/plugin/menu-registry';
 import type { MessageBoxOptions, MessageBoxReturnValue } from '../../main/src/plugin/message-box';
 
@@ -1122,6 +1122,13 @@ function initExposure(): void {
     'kubernetesCreateService',
     async (namespace: string, service: V1Service): Promise<V1Service> => {
       return ipcInvoke('kubernetes-client:createService', namespace, service);
+    },
+  );
+
+  contextBridge.exposeInMainWorld(
+    'kubernetesCreateIngress',
+    async (namespace: string, ingress: V1Ingress): Promise<V1Ingress> => {
+      return ipcInvoke('kubernetes-client:createIngress', namespace, ingress);
     },
   );
 

--- a/packages/renderer/src/lib/pod/DeployPodToKube.spec.ts
+++ b/packages/renderer/src/lib/pod/DeployPodToKube.spec.ts
@@ -88,7 +88,11 @@ test('Expect to send telemetry event', async () => {
 
   await fireEvent.click(createButton);
   await waitFor(() =>
-    expect(telemetryTrackMock).toBeCalledWith('deployToKube', { useRoutes: true, useServices: true }),
+    expect(telemetryTrackMock).toBeCalledWith('deployToKube', {
+      useRoutes: true,
+      useServices: true,
+      createIngress: false,
+    }),
   );
 });
 
@@ -109,6 +113,7 @@ test('Expect to send telemetry event with OpenShift', async () => {
       useRoutes: true,
       useServices: true,
       isOpenshift: true,
+      createIngress: false,
     }),
   );
 });
@@ -129,6 +134,7 @@ test('Expect to send telemetry error event', async () => {
       errorMessage: 'Custom Error',
       useRoutes: true,
       useServices: true,
+      createIngress: false,
     }),
   );
 });

--- a/packages/renderer/src/lib/pod/DeployPodToKube.svelte
+++ b/packages/renderer/src/lib/pod/DeployPodToKube.svelte
@@ -367,10 +367,10 @@ function updateKubeResult() {
             id="createIngress"
             class=""
             required />
-          <span class="text-gray-300 text-sm ml-1"
-            >Create a Kubernetes ingress to get access to the exposed ports of this pod. An ingress controller is
-            required on your cluster. This ingress will be created at the default Ingress Controller location (example
-            Podman kind setup: localhost:9090)</span>
+          <span class="text-gray-300 text-sm ml-1">
+            Create an Ingress to get access to the local ports exposed, at the default Ingress Controller location.
+            Example: On default kind cluster created with Podman Desktop, it will be accessible at 'localhost:9090'.
+            Requirements: Your cluster must have an Ingress Controller.</span>
         </div>
       {/if}
 

--- a/packages/renderer/src/lib/pod/DeployPodToKube.svelte
+++ b/packages/renderer/src/lib/pod/DeployPodToKube.svelte
@@ -194,6 +194,7 @@ async function deployToKube() {
     // Must be a number
     if (servicesToCreate.length == 0) {
       deployWarning = 'You need to deploy using services to create an ingress.';
+      deployStarted = false;
       return;
     } else if (servicesToCreate.length == 1) {
       serviceName = servicesToCreate[0].metadata.name;
@@ -203,6 +204,7 @@ async function deployToKube() {
       // warn out if the user did not pick anything (we do not do form validation for this as we're using svelte for the form)
       if (!ingressPort) {
         deployWarning = 'You need to specify a port to create an ingress.';
+        deployStarted = false;
         return;
       }
       const matchingService = servicesToCreate.find(service => service.spec.ports[0].port == ingressPort);

--- a/packages/renderer/src/lib/ui/WarningMessage.svelte
+++ b/packages/renderer/src/lib/ui/WarningMessage.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+import Fa from 'svelte-fa/src/fa.svelte';
+import {
+  faChevronDown,
+  faChevronRight,
+  faExclamationCircle,
+  faTriangleExclamation,
+} from '@fortawesome/free-solid-svg-icons';
+import Tooltip from './Tooltip.svelte';
+
+export let error: string;
+export let icon: boolean = false;
+</script>
+
+{#if icon}
+  {#if error != undefined && error !== ''}
+    <Tooltip tip="{error}" top>
+      <Fa size="18" class="cursor-pointer text-red-500" icon="{faTriangleExclamation}" />
+    </Tooltip>
+  {/if}
+{:else}
+  <div
+    class="text-red-500 p-1 flex flex-row items-center {$$props.class}"
+    class:opacity-0="{error == undefined || error === ''}">
+    <Fa size="18" class="cursor-pointer text-red-500" icon="{faTriangleExclamation}" />
+    <div class="ml-2">{error}</div>
+  </div>
+{/if}


### PR DESCRIPTION
feat: Add ability to create an ingress

### What does this PR do?

* Add the option to create an ingress when deploying to Kubernetes
* Compatible with 'Contour' ingress with Kind

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

https://user-images.githubusercontent.com/6422176/232894496-cbaea036-a14c-46c6-bfa3-bacca629a161.mov




### What issues does this PR fix or reference?

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

Fixes https://github.com/containers/podman-desktop/issues/1322

### How to test this PR?

1. Create a `kind` cluster with port 9090 for http
2. Run 'podman run --name hello -d -p 8080:8080 cdrage/helloworld`
3. Press "Deploy to Kubernetes"
4. Select the ingress option
5. `curl localhost:9090` or visit with the browser.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
