### PR TITLE
docs: add section about usage of ELECTRON_NO_ATTACH_CONSOLE (#1050)

### DIFF
--- a/website/docs/troubleshooting.md
+++ b/website/docs/troubleshooting.md
@@ -261,7 +261,7 @@ You should be a happy camper from here.
 
 #### Issue
 
-When you launch Podman Desktop from the command line in Windows the terminal session attaches to it. You cannot quit the terminal because it will kill Podman Desktop as well.
+When you start Podman Desktop from the command line in Windows the terminal session attaches to it. You cannot quit the terminal because it will kill Podman Desktop as well.
 
 #### Solution
 

--- a/website/docs/troubleshooting.md
+++ b/website/docs/troubleshooting.md
@@ -256,3 +256,13 @@ podman machine init
 ```
 
 You should be a happy camper from here.
+
+### The terminal session attaches to Podman Desktop when launching it from the command line in Windows
+
+#### Issue
+
+When you launch Podman Desktop from the command line in Windows the terminal session attaches to it. You cannot quit the terminal because it will kill Podman Desktop as well.
+
+#### Solution
+
+Set the environment variable `ELECTRON_NO_ATTACH_CONSOLE` to true before launching Podman Desktop. 


### PR DESCRIPTION
### What does this PR do?

This adds a section to the troubleshooting area about the usage of ELECTRON_NO_ATTACH_CONSOLE env variable in Windows

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

it fixes #1050 

### How to test this PR?

N/A
