### PR TITLE
feat: Fixed, simple navigation bar

### DIFF
--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -45,8 +45,8 @@ router.mode.hash();
 //remember from where we come to preference pages
 let nonSettingsPage = '/';
 router.subscribe(function (navigation) {
-  if (navigation.from !== undefined && !navigation.from.startsWith('/preferences')) {
-    nonSettingsPage = navigation.from;
+  if (navigation.url !== undefined && !navigation.url.startsWith('/preferences')) {
+    nonSettingsPage = navigation.url;
   }
 });
 
@@ -86,10 +86,9 @@ window.events?.receive('display-help', () => {
     <WelcomePage />
 
     <div class="overflow-x-hidden flex flex-1">
+      <AppNavigation meta="{meta}" exitSettingsCallback="{() => router.goto(nonSettingsPage)}" />
       {#if meta.url.startsWith('/preferences')}
-        <PreferencesNavigation meta="{meta}" exitSettingsCallback="{() => router.goto(nonSettingsPage)}" />
-      {:else}
-        <AppNavigation meta="{meta}" />
+        <PreferencesNavigation meta="{meta}" />
       {/if}
 
       <div

--- a/packages/renderer/src/PreferencesNavigation.svelte
+++ b/packages/renderer/src/PreferencesNavigation.svelte
@@ -4,7 +4,6 @@ import { extensionInfos } from './stores/extensions';
 import { configurationProperties } from './stores/configurationProperties';
 import { CONFIGURATION_DEFAULT_SCOPE } from '../../main/src/plugin/configuration-registry-constants';
 
-export let exitSettingsCallback: () => void;
 export let meta;
 
 let extensions, configProperties: Map<string, { id: string; title: string }>;
@@ -54,7 +53,7 @@ $: addSectionHiddenClass = (section: string): string => (sectionExpanded[section
   style="background-color: rgb(39 39 42 / var(--tw-bg-opacity))"
   aria-label="Global">
   <div class="flex items-center">
-    <div class="pt-5 px-5 mb-10">
+    <div class="pt-4 px-5 mb-10">
       <p class="text-xl first-letter:uppercase">Settings</p>
     </div>
   </div>
@@ -198,17 +197,5 @@ $: addSectionHiddenClass = (section: string): string => (sectionExpanded[section
       </li>
     {/each}
     <!-- Default configuration properties end -->
-  </ul>
-
-  <ul class="pf-c-nav__list">
-    <li
-      class="pf-c-nav__item pf-c-nav__link flex w-full justify-between dark:text-gray-400 hover:text-gray-300 cursor-pointer items-center h-[50px] min-h-[50px]"
-      style="margin-top:auto"
-      on:click="{exitSettingsCallback}">
-      <div class="flex items-center" style="margin-top:4px">
-        <i class="fa fa-angle-left"></i>
-        <span class="block group-hover:block mx-2">Exit settings</span>
-      </div>
-    </li>
   </ul>
 </nav>


### PR DESCRIPTION
### What does this PR do?

I had no clue I'd end up working on this today, but after a long day I thought I'd try one topic that came up earlier and it turned out to be pretty straight-forward.

This changes the main navigation to be a fixed width icon bar that is always visible.

- Removed all titles and counter badges. Added tooltips.
- There were several redundant divs and unused code removed. I tried scanning all other classes to fix inconsistencies.
- Extensions were expandable before - I made the call to remove the Extensions icon and always include them.
- I made the Settings title have slightly less top padding so that it is at the same position as other titles like Images/Container list.
- Removed Exit Settings link.

### Screenshot/screencast of this PR

<img width="432" alt="Screenshot 2023-04-19 at 5 40 56 PM" src="https://user-images.githubusercontent.com/19958075/233208896-e2a50108-a556-4f3b-8237-9dae84823fbe.png">

### What issues does this PR fix or reference?

Fixes issue #2167 and issue #1648.

### How to test this PR?

It's pretty obvious. ;-) Check formatting of main navigation & settings pages.