### PR TITLE
docs: update discord chat links

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,11 +89,11 @@ Discussions are done using [Github Discussions](https://github.com/containers/po
 
 General questions & development:
 
-* [#general on Discord](https://discordapp.com/invite/TCTB38RWpf)
+* [#podman-desktop on the Podman Discord](https://discord.com/invite/x5GzFF6QH4)
 * [#podman-desktop@libera.chat on IRC](https://libera.chat/)
 * [#podman-desktop@fedora.im on Matrix](https://chat.fedoraproject.org/#/room/#podman-desktop:fedora.im)
 
-Note: All channels are bridged. Chat on either: Discord, IRC or Matrix!
+Note: All channels are bridged. Chat on either: Discord, IRC or Matrix and it'll appear on all three!
 
 Kubernetes questions & development:
 

--- a/packages/renderer/src/lib/help/HelpPage.svelte
+++ b/packages/renderer/src/lib/help/HelpPage.svelte
@@ -53,10 +53,10 @@
       <li class="pb-2">
         <i class="fas fa-comments" aria-hidden="true"></i>
         <p
-          on:click="{() => window.openExternal('https://discordapp.com/invite/TCTB38RWpf')}"
+          on:click="{() => window.openExternal('https://discord.com/invite/x5GzFF6QH4')}"
           title="https://discordapp.com/invite/TCTB38RWpf"
           class="text-sm inline-flex ml-1 cursor-pointer text-violet-400 hover:text-violet-600 hover:no-underline">
-          General questions (bridged with IRC & Matrix): Join #general on Discord
+          General questions (bridged with IRC & Matrix): Join #podman-desktop on Discord
         </p>
       </li>
       <li class="pb-2">

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -138,8 +138,8 @@ const config = {
                 href: 'https://github.com/containers/podman-desktop',
               },
               {
-                label: 'General chat (bridged): #general on Discord',
-                href: 'https://discordapp.com/invite/TCTB38RWpf',
+                label: 'General chat (bridged): #podman-desktop on Discord',
+                href: 'https://discord.com/invite/x5GzFF6QH4',
               },
               {
                 label: 'General chat (bridged): #podman-desktop@libera.chat on IRC',


### PR DESCRIPTION
docs: update discord chat links

### What does this PR do?

Updates the Discord chat links now that we've moved to the Podman server
under the #podman-desktop channel.

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

N/A

### What issues does this PR fix or reference?

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

Fixes:  https://github.com/containers/podman-desktop/issues/1688

### How to test this PR?

<!-- Please explain steps to reproduce -->

N/A

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
