### PR TITLE
fix: menus are not unregistered upon extension deactivation

### DIFF
--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -797,6 +797,18 @@ export class ExtensionLoader {
     });
 
     this.activatedExtensions.delete(extensionId);
+
+    const analyzedExtension = this.analyzedExtensions.get(extensionId);
+    if (analyzedExtension) {
+      const extensionConfiguration = analyzedExtension.manifest?.contributes?.configuration;
+      if (extensionConfiguration) {
+        this.configurationRegistry.deregisterConfigurations([extensionConfiguration]);
+      }
+      const menus = analyzedExtension.manifest?.contributes?.menus;
+      if (menus) {
+        this.menuRegistry.unregisterMenus(menus);
+      }
+    }
     this.apiSender.send('extension-stopped');
   }
 

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -796,8 +796,6 @@ export class ExtensionLoader {
       await subscription.dispose();
     });
 
-    this.activatedExtensions.delete(extensionId);
-
     const analyzedExtension = this.analyzedExtensions.get(extensionId);
     if (analyzedExtension) {
       const extensionConfiguration = analyzedExtension.manifest?.contributes?.configuration;
@@ -809,6 +807,7 @@ export class ExtensionLoader {
         this.menuRegistry.unregisterMenus(menus);
       }
     }
+    this.activatedExtensions.delete(extensionId);
     this.apiSender.send('extension-stopped');
   }
 


### PR DESCRIPTION
Fixes #2069

### What does this PR do?

Unregister contributed menus when extension is stopped

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?

Fixes #2069

### How to test this PR?

Stop and start Kind extension and make sure the Push to cluster menu appears only once on the Images tab