### PR TITLE
feat: Update extension states and fix button enablement

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesExtensionList.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesExtensionList.svelte
@@ -8,6 +8,7 @@ import { extensionInfos } from '../../stores/extensions';
 import type { ExtensionInfo } from '../../../../main/src/plugin/api/extension-info';
 import ErrorMessage from '../ui/ErrorMessage.svelte';
 import SettingsPage from '../preferences/SettingsPage.svelte';
+import ConnectionStatus from '../ui/ConnectionStatus.svelte';
 
 let ociImage: string;
 
@@ -121,7 +122,7 @@ async function removeExtension(extension: ExtensionInfo) {
               <div class="flex items-center">
                 <div class="flex-shrink-0 h-10 w-10 py-3" title="Extension {extension.name} is {extension.state}">
                   <Fa
-                    class="h-10 w-10 rounded-full {extension.state === 'active' ? 'text-violet-600' : 'text-gray-700'}"
+                    class="h-10 w-10 rounded-full {extension.state === 'started' ? 'text-violet-600' : 'text-gray-700'}"
                     size="25"
                     icon="{faPuzzlePiece}" />
                 </div>
@@ -130,13 +131,14 @@ async function removeExtension(extension: ExtensionInfo) {
                     <div class="text-sm text-gray-200">
                       {extension.displayName}
                       {extension.removable ? '(user)' : '(default extension)'}
+                      <span class="text-xs font-extra-light text-gray-500">v{extension.version}</span>
                     </div>
                   </div>
                   <div class="flex flex-row">
                     <div class="text-sm text-gray-400 italic">{extension.description}</div>
                   </div>
-                  <div class="flex flex-row text-xs font-extra-light text-violet-500">
-                    <div>v{extension.version}</div>
+                  <div class="flex">
+                    <ConnectionStatus status="{extension.state}" />
                   </div>
                 </div>
               </div>
@@ -147,22 +149,22 @@ async function removeExtension(extension: ExtensionInfo) {
                   title="Start extension"
                   on:click="{() => startExtension(extension)}"
                   class="{buttonClass}"
-                  class:hidden="{extension.state === 'active'}"><Fa class="h-4 w-4" icon="{faPlay}" /></button>
+                  class:hidden="{extension.state !== 'stopped'}"><Fa class="h-4 w-4" icon="{faPlay}" /></button>
                 <button
                   title="Stop extension"
                   class="{buttonClass}"
                   on:click="{() => stopExtension(extension)}"
                   hidden
-                  class:hidden="{extension.state !== 'active'}"><Fa class="h-4 w-4" icon="{faStop}" /></button>
+                  class:hidden="{extension.state !== 'started'}"><Fa class="h-4 w-4" icon="{faStop}" /></button>
 
                 {#if extension.removable}
-                  {#if extension.state === 'inactive'}
+                  {#if extension.state === 'stopped'}
                     <button title="Remove extension" class="{buttonClass}" on:click="{() => removeExtension(extension)}"
                       ><Fa class="h-4 w-4" icon="{faTrash}" /></button>
                   {:else}
                     <div
                       class="m-0.5 text-gray-700 rounded-full inline-flex items-center px-2 py-2 text-center"
-                      title="Active extension cannot be removed.">
+                      title="Running extension cannot be removed.">
                       <Fa class="h-4 w-4" icon="{faTrash}" />
                     </div>
                   {/if}

--- a/packages/renderer/src/lib/preferences/PreferencesExtensionRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesExtensionRendering.svelte
@@ -3,6 +3,8 @@ import Route from '../../Route.svelte';
 import { extensionInfos } from '../../stores/extensions';
 import type { ExtensionInfo } from '../../../../main/src/plugin/api/extension-info';
 import SettingsPage from './SettingsPage.svelte';
+import ConnectionStatus from '../ui/ConnectionStatus.svelte';
+
 export let extensionId: string = undefined;
 
 let extensionInfo: ExtensionInfo;
@@ -24,37 +26,37 @@ async function startExtension() {
     {#if extensionInfo}
       <Route path="/*" breadcrumb="{extensionInfo.displayName}" let:meta>
         <!-- Manage lifecycle-->
-        <div class="pl-1 py-2">
-          <div class="text-sm italic text-gray-400">Status</div>
-          <div class="pl-3 capitalize">{extensionInfo.state}</div>
+        <div class="flex pb-2">
+          <div class="pr-2">Status</div>
+          <ConnectionStatus status="{extensionInfo.state}" />
         </div>
 
         <div class="py-2 flex flex:row">
           <!-- start is enabled only in stopped mode-->
           <div class="px-2 text-sm italic text-gray-400">
             <button
-              disabled="{extensionInfo.state !== 'inactive'}"
+              disabled="{extensionInfo.state !== 'stopped'}"
               on:click="{() => startExtension()}"
               class="pf-c-button pf-m-primary"
               type="button">
               <span class="pf-c-button__icon pf-m-start">
                 <i class="fas fa-play" aria-hidden="true"></i>
               </span>
-              Enable
+              Start
             </button>
           </div>
 
           <!-- stop is enabled only in started mode-->
           <div class="px-2 text-sm italic text-gray-400">
             <button
-              disabled="{extensionInfo.state !== 'active'}"
+              disabled="{extensionInfo.state !== 'started'}"
               on:click="{() => stopExtension()}"
               class="pf-c-button pf-m-primary"
               type="button">
               <span class="pf-c-button__icon pf-m-start">
                 <i class="fas fa-stop" aria-hidden="true"></i>
               </span>
-              Disable
+              Stop
             </button>
           </div>
         </div>

--- a/packages/renderer/src/stores/extensions.ts
+++ b/packages/renderer/src/stores/extensions.ts
@@ -28,7 +28,13 @@ export async function fetchExtensions() {
 export const extensionInfos: Writable<ExtensionInfo[]> = writable([]);
 
 // need to refresh when extension is started or stopped
+window?.events.receive('extension-starting', () => {
+  fetchExtensions();
+});
 window?.events.receive('extension-started', () => {
+  fetchExtensions();
+});
+window?.events.receive('extension-stopping', () => {
   fetchExtensions();
 });
 window?.events.receive('extension-stopped', () => {


### PR DESCRIPTION
### What does this PR do?

- Switches the extension 'active' and 'inactive' states to 'started' and 'stopped' to match the existing events and the states used elsewhere (e.g. container engines).
- Adds two new states to extensions: 'starting' and 'stopping', and associated events for both.
- Updates the extension store to listen for the new events. Other places listening to extensions (e.g. the other stores) don't need to listen to these events because they only care about the started/stopped states.
- Updated actions on both extension pages to consistent terms and enable/disable with correct states.
- Now that the states match, both extension pages can also use ConnectionStatus to show extension state.

### Screenshot/screencast of this PR

<img width="475" alt="Screenshot 2023-04-21 at 10 29 47 AM" src="https://user-images.githubusercontent.com/19958075/233662582-aac6ac85-bea5-4d79-836b-c13894944e06.png">
<img width="379" alt="Screenshot 2023-04-21 at 10 30 10 AM" src="https://user-images.githubusercontent.com/19958075/233662583-e268c08f-cba6-42e3-b322-df41c182b194.png">

### What issues does this PR fix or reference?

Fixes issue #1810.

### How to test this PR?

Add the following to an extension's activate() and deactivate() methods so that it is slow enough to see what's going on, then confirm that you can start and stop it from both settings pages, the action enablement and status are consistent, and you cannot start an extension twice.
```
await new Promise(resolve => {
    setTimeout(resolve, 3000);
  });
```