### PR TITLE
feat: add dialog to set currently running podman machine to default

### DIFF
--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -60,7 +60,7 @@ const containerProviderConnections = new Map<string, extensionApi.ContainerProvi
 let isDisguisedPodmanSocket = true;
 let disguisedPodmanSocketWatcher: extensionApi.FileSystemWatcher;
 
-type MachineJSON = {
+export type MachineJSON = {
   Name: string;
   CPUs: number;
   Memory: string;
@@ -200,11 +200,12 @@ async function updateMachines(provider: extensionApi.Provider): Promise<void> {
   await checkDefaultMachine(machines);
 }
 
-async function checkDefaultMachine(machines: MachineJSON[]): Promise<void> {
+export async function checkDefaultMachine(machines: MachineJSON[]): Promise<void> {
   // As a last check, let's see if the machine that is running is set by default or not on the CLI.
   // if it isn't, we should prompt the user to set it as default, or else podman CLI commands will not work
   const runningMachine = machines.find(machine => machine.Running);
   const defaultMachine = machines.find(machine => machine.Default);
+
   if (defaultMachineNotify && defaultMachineMonitor && runningMachine && !runningMachine.Default) {
     // Make sure we do notifyDefault = false so we don't keep notifying the user when this dialog is open.
     defaultMachineMonitor = false;


### PR DESCRIPTION
feat: add dialog to set currently running podman machine to default

### What does this PR do?

* Creates a dialog / notification that informs the user that the
  currently running podman machine is not set as the default and CLI
  commands will not work with Podman.
* Add buttons to ignore / cancel the notification as well.

### Screenshot/screencast of this PR

https://user-images.githubusercontent.com/6422176/234071072-8f9ea40c-c05a-4209-85a7-b5ab04a55aaa.mov

### What issues does this PR fix or reference?

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

Closes https://github.com/containers/podman-desktop/issues/2096

### How to test this PR?

See video. Otherwise, you can do:

```
podman machine create test-vm
podman system connection default test-vm
# you should see pop up on podman desktop
# to set the default
# use list to see the changes
podman system connection list
```

<!-- Please explain steps to reproduce -->

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
