### PR TITLE
chore: Consistency for extension description and publisher

### DIFF
--- a/extensions/compose/package.json
+++ b/extensions/compose/package.json
@@ -1,9 +1,9 @@
 {
   "name": "compose",
   "displayName": "Compose",
-  "description": "Install Compose binary to work with Podman Engine.",
+  "description": "Install Compose binary to work with Podman",
   "version": "0.0.1",
-  "publisher": "benoitf",
+  "publisher": "podman-desktop",
   "license": "Apache-2.0",
   "engines": {
     "podman-desktop": "^0.0.1"

--- a/extensions/docker/package.json
+++ b/extensions/docker/package.json
@@ -1,10 +1,10 @@
 {
   "name": "docker",
   "displayName": "Docker",
-  "description": "Docker extension for Podman Desktop",
+  "description": "Integration for Docker engine",
   "version": "0.0.1",
   "icon": "icon.png",
-  "publisher": "benoitf",
+  "publisher": "podman-desktop",
   "license": "Apache-2.0",
   "engines": {
     "podman-desktop": "^0.0.1"

--- a/extensions/kind/package.json
+++ b/extensions/kind/package.json
@@ -1,10 +1,10 @@
 {
   "name": "kind",
   "displayName": "Kind",
-  "description": "Create a Kind cluster: Creates a Kubernetes cluster with a single node.",
+  "description": "Integration for Kind: run local Kubernetes clusters using container “nodes”",
   "version": "0.0.1",
   "icon": "icon.png",
-  "publisher": "benoitf",
+  "publisher": "podman-desktop",
   "license": "Apache-2.0",
   "engines": {
     "podman-desktop": "^0.0.1"

--- a/extensions/kube-context/package.json
+++ b/extensions/kube-context/package.json
@@ -1,10 +1,10 @@
 {
   "name": "kube-context",
   "displayName": "Kube Context",
-  "description": "Allows the ability to switch between Kubernetes contexts",
+  "description": "Easily switch between Kubernetes contexts",
   "version": "0.0.1",
   "icon": "icon.png",
-  "publisher": "benoitf",
+  "publisher": "podman-desktop",
   "license": "Apache-2.0",
   "engines": {
     "podman-desktop": "^0.0.1"

--- a/extensions/lima/package.json
+++ b/extensions/lima/package.json
@@ -1,10 +1,10 @@
 {
   "name": "lima",
   "displayName": "Lima",
-  "description": "Enable and disable Lima: Linux virtual machines (typically macOS)",
+  "description": "Integration for Lima: Linux virtual machines (typically macOS)",
   "version": "0.0.1",
   "icon": "icon.png",
-  "publisher": "benoitf",
+  "publisher": "podman-desktop",
   "license": "Apache-2.0",
   "engines": {
     "podman-desktop": "^0.0.1"

--- a/extensions/podman/package.json
+++ b/extensions/podman/package.json
@@ -1,10 +1,10 @@
 {
   "name": "podman",
   "displayName": "Podman",
-  "description": "Enable support for controlling Podman and Podman Machines",
+  "description": "Integration for Podman and Podman Machines",
   "version": "0.0.1",
   "icon": "icon.png",
-  "publisher": "benoitf",
+  "publisher": "podman-desktop",
   "license": "Apache-2.0",
   "engines": {
     "podman-desktop": "^0.0.1"

--- a/extensions/registries/package.json
+++ b/extensions/registries/package.json
@@ -1,9 +1,9 @@
 {
   "name": "registries",
   "displayName": "Registries",
-  "description": "Package a list of default registries for Podman Desktop to consume such as Quay, DockerHub, GitHub, etc.",
+  "description": "Adds default registries for Quay, DockerHub, GitHub, and Google Container Registry",
   "version": "0.0.1",
-  "publisher": "cdrage",
+  "publisher": "podman-desktop",
   "license": "Apache-2.0",
   "engines": {
     "podman-desktop": "^0.0.1"


### PR DESCRIPTION
### What does this PR do?

Changes the publisher for all of our built-in extensions to 'podman-desktop' instead of the original committer's name. While I was at it I tried to make the descriptions less wordy and more consistent (e.g. 'integration' for external tools, removed ending periods)

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

Fixes #2194.

### How to test this PR?

Just view the text, or load and go to the Settings > Extensions.