### PR TITLE
feat(extension-api): Allows to provide a markdown description or markdown content

### DIFF
--- a/packages/main/src/plugin/configuration-registry.ts
+++ b/packages/main/src/plugin/configuration-registry.ts
@@ -27,6 +27,7 @@ import { CONFIGURATION_DEFAULT_SCOPE } from './configuration-registry-constants'
 import { desktopAppHomeDir } from '../util';
 
 export type IConfigurationPropertySchemaType =
+  | 'markdown'
   | 'string'
   | 'number'
   | 'integer'
@@ -54,6 +55,7 @@ export interface IConfigurationPropertySchema {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   default?: any;
   description?: string;
+  markdownDescription?: string;
   minimum?: number;
   maximum?: number | string;
   format?: string;
@@ -244,6 +246,7 @@ export class ConfigurationRegistry implements IConfigurationRegistry {
     // for each key being already the default value, remove the entry
     Object.keys(cloneConfig)
       .filter(key => cloneConfig[key] === this.configurationProperties[key]?.default)
+      .filter(key => this.configurationProperties[key]?.type !== 'markdown')
       .forEach(key => {
         delete cloneConfig[key];
       });

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationRendering.svelte
@@ -20,6 +20,7 @@ import { filesize } from 'filesize';
 import { router } from 'tinro';
 import LinearProgress from '../ui/LinearProgress.svelte';
 import Spinner from '../ui/Spinner.svelte';
+import Markdown from '../markdown/Markdown.svelte';
 
 export let properties: IConfigurationPropertyRecordedSchema[] = [];
 export let providerInfo: ProviderInfo;
@@ -345,7 +346,11 @@ async function close() {
           {#each configurationKeys as configurationKey}
             <div class="mb-3">
               <div class="font-semibold text-xs mb-2">
-                {configurationKey.description}:
+                {#if configurationKey.description}
+                  {configurationKey.description}:
+                {:else if configurationKey.markdownDescription && configurationKey.type !== 'markdown'}
+                  <Markdown>{configurationKey.markdownDescription}:</Markdown>
+                {/if}
                 {#if configurationValues.has(configurationKey.id)}
                   {getDisplayConfigurationValue(configurationKey, configurationValues.get(configurationKey.id))}
                 {:else}

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
@@ -4,6 +4,7 @@ import Fa from 'svelte-fa/src/fa.svelte';
 import type { IConfigurationPropertyRecordedSchema } from '../../../../main/src/plugin/configuration-registry';
 import { CONFIGURATION_DEFAULT_SCOPE } from '../../../../main/src/plugin/configuration-registry-constants';
 import ErrorMessage from '../ui/ErrorMessage.svelte';
+import Markdown from '../markdown/Markdown.svelte';
 
 let invalidEntry = false;
 let invalidText = undefined;
@@ -304,6 +305,10 @@ function handleCleanValue(
           <option value="{recordEnum}">{recordEnum}</option>
         {/each}
       </select>
+    {:else if record.type === 'markdown'}
+      <div class="text-sm">
+        <Markdown>{record.markdownDescription}</Markdown>
+      </div>
     {:else}
       <input
         on:input="{event => checkValue(record, event)}"


### PR DESCRIPTION
depends on:
- [ ] https://github.com/containers/podman-desktop/pull/2219

### What does this PR do?
Adds support for markdown description and markdown content

### Screenshot/screencast of this PR

![image](https://user-images.githubusercontent.com/436777/234327330-a982bcd4-3ddc-4d17-a2cb-26138b4d62c2.png)


### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/2152


### How to test this PR?

It requires https://github.com/containers/podman-desktop/pull/2219

Then you can change for example a podman package.json and add custom properties like

```json
        "podman.factory.machine.foo": {
          "type": "markdown",
          "scope": "ContainerProviderConnectionFactory",
          "markdownDescription": "Discover Podman Desktop:\n\n:button[Website]{href=https://podman-desktop.io title=Discover our website}\n\n*This is really nice*"
        },
``` 