### PR TITLE
feat: Sort extensions by display name

### DIFF
--- a/packages/renderer/src/PreferencesNavigation.svelte
+++ b/packages/renderer/src/PreferencesNavigation.svelte
@@ -46,8 +46,6 @@ $: addCurrentClass = (pathParam: string): string =>
   isCurrentPage(pathParam) ? 'dark:text-white pf-m-current' : 'dark:text-gray-700';
 $: isAriaExpanded = (section: string): boolean => (sectionExpanded[section] ? true : false);
 $: addSectionHiddenClass = (section: string): string => (sectionExpanded[section] ? '' : 'hidden');
-
-$: sortedExtensions = $extensionInfos.sort((a, b) => a.displayName.localeCompare(b.displayName));
 </script>
 
 <nav
@@ -132,7 +130,7 @@ $: sortedExtensions = $extensionInfos.sort((a, b) => a.displayName.localeCompare
       </a>
       <section class="pf-c-nav__subnav {addSectionHiddenClass('extensionsCatalog')}">
         <ul class="pf-c-nav__list">
-          {#each sortedExtensions as extension}
+          {#each $extensionInfos as extension}
             <li class="pf-c-nav__item {addCurrentClass(`/preferences/extension/${extension.name}`)}">
               <a
                 href="/preferences/extension/{extension.name}"

--- a/packages/renderer/src/PreferencesNavigation.svelte
+++ b/packages/renderer/src/PreferencesNavigation.svelte
@@ -46,6 +46,8 @@ $: addCurrentClass = (pathParam: string): string =>
   isCurrentPage(pathParam) ? 'dark:text-white pf-m-current' : 'dark:text-gray-700';
 $: isAriaExpanded = (section: string): boolean => (sectionExpanded[section] ? true : false);
 $: addSectionHiddenClass = (section: string): string => (sectionExpanded[section] ? '' : 'hidden');
+
+$: sortedExtensions = $extensionInfos.sort((a, b) => a.displayName.localeCompare(b.displayName));
 </script>
 
 <nav
@@ -130,12 +132,13 @@ $: addSectionHiddenClass = (section: string): string => (sectionExpanded[section
       </a>
       <section class="pf-c-nav__subnav {addSectionHiddenClass('extensionsCatalog')}">
         <ul class="pf-c-nav__list">
-          {#each extensions as extension}
+          {#each sortedExtensions as extension}
             <li class="pf-c-nav__item {addCurrentClass(`/preferences/extension/${extension.name}`)}">
               <a
                 href="/preferences/extension/{extension.name}"
                 id="configuration-section-extensions-catalog-{extension.name.toLowerCase()}"
-                class="pf-c-nav__link">{extension.displayName}</a>
+                class="pf-c-nav__link"
+                style="font-weight: 200">{extension.displayName}</a>
             </li>
           {/each}
         </ul>

--- a/packages/renderer/src/lib/preferences/PreferencesExtensionList.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesExtensionList.svelte
@@ -18,7 +18,7 @@ let logs: string[] = [];
 
 let logElement;
 
-$: sortedExtensions = $extensionInfos.sort((a, b) => a.name.localeCompare(b.name));
+$: sortedExtensions = $extensionInfos.sort((a, b) => a.displayName.localeCompare(b.displayName));
 
 const buttonClass: string =
   'm-0.5 text-gray-400 hover:bg-zinc-800 hover:text-violet-600 font-medium rounded-full inline-flex items-center px-2 py-2 text-center';

--- a/packages/renderer/src/lib/preferences/PreferencesExtensionList.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesExtensionList.svelte
@@ -18,8 +18,6 @@ let logs: string[] = [];
 
 let logElement;
 
-$: sortedExtensions = $extensionInfos.sort((a, b) => a.displayName.localeCompare(b.displayName));
-
 const buttonClass: string =
   'm-0.5 text-gray-400 hover:bg-zinc-800 hover:text-violet-600 font-medium rounded-full inline-flex items-center px-2 py-2 text-center';
 
@@ -116,7 +114,7 @@ async function removeExtension(extension: ExtensionInfo) {
   <div class="bg-zinc-800 mt-5 rounded-md p-3">
     <table class="min-w-full">
       <tbody>
-        {#each sortedExtensions as extension}
+        {#each $extensionInfos as extension}
           <tr class="border-y border-gray-900">
             <td class="px-6 py-2">
               <div class="flex items-center">

--- a/packages/renderer/src/stores/extensions.ts
+++ b/packages/renderer/src/stores/extensions.ts
@@ -22,7 +22,7 @@ import type { ExtensionInfo } from '../../../main/src/plugin/api/extension-info'
 
 export async function fetchExtensions() {
   const result = await window.listExtensions();
-  extensionInfos.set(result);
+  extensionInfos.set(result.sort((a, b) => a.displayName.localeCompare(b.displayName)));
 }
 
 export const extensionInfos: Writable<ExtensionInfo[]> = writable([]);


### PR DESCRIPTION
### What does this PR do?

Extensions should be sorted in both the Settings > Extensions page and in the child list by their display name. This incidentally fixes issue #2130, which was caused by the children being out of order alphabetically.

While fixing this I reduced the font weight of the extension child items to match the Setting > Preferences children in the navigation (and verified with mairin).

### Screenshot/screencast of this PR

<img width="498" alt="Screenshot 2023-04-25 at 12 26 40 PM" src="https://user-images.githubusercontent.com/19958075/234341812-056dfa58-5036-4e75-a142-1156a3cef558.png">

### What issues does this PR fix or reference?

Issue #2130.

### How to test this PR?

Open Settings > Extensions and confirm the alphabetical order both on the page and the child nav items. Select each nav item in various orders to confirm fix for 
