### PR TITLE
chore: Update detail/terminal/editor background color

### DIFF
--- a/packages/renderer/src/lib/color/color.ts
+++ b/packages/renderer/src/lib/color/color.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2022 Red Hat, Inc.
+ * Copyright (C) 2022-2023 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,5 +17,5 @@
  ***********************************************************************/
 
 export function getPanelDetailColor(): string {
-  return '#1a1624';
+  return '#0f0f11';
 }

--- a/packages/renderer/src/lib/container/ContainerDetails.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetails.svelte
@@ -56,7 +56,7 @@ function errorCallback(errorMessage: string): void {
                 class="text-violet-400 text-base hover:no-underline"
                 href="/containers"
                 title="Go back to containers list">Containers</a>
-              <div class="text-xl mx-2 text-gray-700"></div>
+              <div class="text-xl mx-2 text-gray-700">></div>
               <div class="text-sm font-extralight text-gray-700">Container Details</div>
             </div>
             <div class="text-lg flex flex-row items-start pt-1">

--- a/packages/renderer/src/lib/container/ContainerDetails.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetails.svelte
@@ -56,7 +56,7 @@ function errorCallback(errorMessage: string): void {
                 class="text-violet-400 text-base hover:no-underline"
                 href="/containers"
                 title="Go back to containers list">Containers</a>
-              <div class="text-xl mx-2 text-gray-700">></div>
+              <div class="text-xl mx-2 text-gray-700"></div>
               <div class="text-sm font-extralight text-gray-700">Container Details</div>
             </div>
             <div class="text-lg flex flex-row items-start pt-1">
@@ -107,21 +107,23 @@ function errorCallback(errorMessage: string): void {
           <a href="/containers" title="Close Details" class="mt-2 mr-2 text-gray-900"
             ><i class="fas fa-times" aria-hidden="true"></i></a>
         </div>
-        <Route path="/summary" breadcrumb="Summary">
-          <ContainerDetailsSummary container="{container}" />
-        </Route>
-        <Route path="/logs" breadcrumb="Logs">
-          <ContainerDetailsLogs container="{container}" />
-        </Route>
-        <Route path="/inspect" breadcrumb="Inspect">
-          <ContainerDetailsInspect container="{container}" />
-        </Route>
-        <Route path="/kube" breadcrumb="Kube">
-          <ContainerDetailsKube container="{container}" />
-        </Route>
-        <Route path="/terminal" breadcrumb="Terminal">
-          <ContainerDetailsTerminal container="{container}" />
-        </Route>
+        <div class="h-full bg-charcoal-900">
+          <Route path="/summary" breadcrumb="Summary">
+            <ContainerDetailsSummary container="{container}" />
+          </Route>
+          <Route path="/logs" breadcrumb="Logs">
+            <ContainerDetailsLogs container="{container}" />
+          </Route>
+          <Route path="/inspect" breadcrumb="Inspect">
+            <ContainerDetailsInspect container="{container}" />
+          </Route>
+          <Route path="/kube" breadcrumb="Kube">
+            <ContainerDetailsKube container="{container}" />
+          </Route>
+          <Route path="/terminal" breadcrumb="Terminal">
+            <ContainerDetailsTerminal container="{container}" />
+          </Route>
+        </div>
       </div>
     </div>
   </Route>

--- a/packages/renderer/src/lib/container/ContainerDetailsLogs.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetailsLogs.svelte
@@ -118,18 +118,12 @@ onDestroy(() => {
 });
 </script>
 
-<EmptyScreen
-  icon="{NoLogIcon}"
-  title="No Log"
-  message="Log output of {container.name}"
-  hidden="{noLogs === false}"
-  style="background-color: {getPanelDetailColor()}" />
+<EmptyScreen icon="{NoLogIcon}" title="No Log" message="Log output of {container.name}" hidden="{noLogs === false}" />
 
 <div
   class="min-w-full flex flex-col"
   class:invisible="{noLogs === true}"
   class:h-0="{noLogs === true}"
   class:h-full="{noLogs === false}"
-  style="background-color: {getPanelDetailColor()}"
   bind:this="{logsXtermDiv}">
 </div>

--- a/packages/renderer/src/lib/container/ContainerDetailsSummary.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetailsSummary.svelte
@@ -1,32 +1,29 @@
 <script lang="ts">
 import type { ContainerInfoUI } from './ContainerInfoUI';
-import { getPanelDetailColor } from '../color/color';
 
 export let container: ContainerInfoUI;
 </script>
 
-<div class="h-full" style="background-color: {getPanelDetailColor()}">
-  <div class="flex px-5 py-4 flex-col">
-    <div class="w-full">
-      <table class="h-2">
-        <tr>
-          <td class="pt-2 pr-2">Id</td>
-          <td class="pt-2 pr-2">{container.shortId}</td>
-        </tr>
-        <tr>
-          <td class="pt-2 pr-2">Command</td>
-          <td class="pt-2 pr-2">{container.command}</td>
-        </tr>
-        <tr>
-          <td class="pt-2 pr-2">State</td>
-          <td class="pt-2 pr-2">{container.state}</td>
-        </tr>
-        <tr>
-          <td class="pt-2 pr-2">Ports</td>
-          <td class="pt-2 pr-2" class:hidden="{container.hasPublicPort}">N/A</td>
-          <td class="pt-2 pr-2" class:hidden="{!container.hasPublicPort}">{container.port}</td>
-        </tr>
-      </table>
-    </div>
+<div class="flex px-5 py-4 flex-col">
+  <div class="w-full">
+    <table class="h-2">
+      <tr>
+        <td class="pt-2 pr-2">Id</td>
+        <td class="pt-2 pr-2">{container.shortId}</td>
+      </tr>
+      <tr>
+        <td class="pt-2 pr-2">Command</td>
+        <td class="pt-2 pr-2">{container.command}</td>
+      </tr>
+      <tr>
+        <td class="pt-2 pr-2">State</td>
+        <td class="pt-2 pr-2">{container.state}</td>
+      </tr>
+      <tr>
+        <td class="pt-2 pr-2">Ports</td>
+        <td class="pt-2 pr-2" class:hidden="{container.hasPublicPort}">N/A</td>
+        <td class="pt-2 pr-2" class:hidden="{!container.hasPublicPort}">{container.port}</td>
+      </tr>
+    </table>
   </div>
 </div>

--- a/packages/renderer/src/lib/container/ContainerDetailsTerminal.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetailsTerminal.svelte
@@ -80,10 +80,7 @@ onMount(async () => {
 
 <div class="h-full" bind:this="{terminalXtermDiv}" class:hidden="{container.state !== 'RUNNING'}"></div>
 
-<div
-  class="h-full min-w-full flex flex-col"
-  class:hidden="{container.state === 'RUNNING'}"
-  style="background-color: {getPanelDetailColor()}">
+<div class="h-full min-w-full flex flex-col" class:hidden="{container.state === 'RUNNING'}">
   <div class="pf-c-empty-state h-full">
     <div class="pf-c-empty-state__content">
       <i class="fas fa-terminal pf-c-empty-state__icon" aria-hidden="true"></i>

--- a/packages/renderer/src/lib/image/ImageDetails.svelte
+++ b/packages/renderer/src/lib/image/ImageDetails.svelte
@@ -52,7 +52,7 @@ onMount(() => {
             <div class="flex flew-row items-center">
               <a class="text-violet-400 text-base hover:no-underline" href="/images" title="Go back to images list"
                 >Images</a>
-              <div class="text-xl mx-2 text-gray-700"></div>
+              <div class="text-xl mx-2 text-gray-700">></div>
               <div class="text-sm font-extralight text-gray-700">Image Details</div>
             </div>
             <div class="flex flex-row items-start pt-1">

--- a/packages/renderer/src/lib/image/ImageDetails.svelte
+++ b/packages/renderer/src/lib/image/ImageDetails.svelte
@@ -52,7 +52,7 @@ onMount(() => {
             <div class="flex flew-row items-center">
               <a class="text-violet-400 text-base hover:no-underline" href="/images" title="Go back to images list"
                 >Images</a>
-              <div class="text-xl mx-2 text-gray-700">></div>
+              <div class="text-xl mx-2 text-gray-700"></div>
               <div class="text-sm font-extralight text-gray-700">Image Details</div>
             </div>
             <div class="flex flex-row items-start pt-1">
@@ -92,15 +92,17 @@ onMount(() => {
           <a href="/containers" title="Close Details" class="mt-2 mr-2 text-gray-900"
             ><i class="fas fa-times" aria-hidden="true"></i></a>
         </div>
-        <Route path="/history" breadcrumb="History">
-          <ImageDetailsHistory image="{image}" />
-        </Route>
-        <Route path="/inspect" breadcrumb="Inspect">
-          <ImageDetailsInspect image="{image}" />
-        </Route>
-        <Route path="/summary" breadcrumb="Summary">
-          <ImageDetailsSummary image="{image}" />
-        </Route>
+        <div class="h-full bg-charcoal-900">
+          <Route path="/history" breadcrumb="History">
+            <ImageDetailsHistory image="{image}" />
+          </Route>
+          <Route path="/inspect" breadcrumb="Inspect">
+            <ImageDetailsInspect image="{image}" />
+          </Route>
+          <Route path="/summary" breadcrumb="Summary">
+            <ImageDetailsSummary image="{image}" />
+          </Route>
+        </div>
       </div>
     </div>
   </Route>

--- a/packages/renderer/src/lib/image/ImageDetailsSummary.svelte
+++ b/packages/renderer/src/lib/image/ImageDetailsSummary.svelte
@@ -1,26 +1,22 @@
 <script lang="ts">
-import { getPanelDetailColor } from '../color/color';
-
 import type { ImageInfoUI } from './ImageInfoUI';
 
 export let image: ImageInfoUI;
 </script>
 
-<div class="h-full" style="background-color: {getPanelDetailColor()}">
-  <div class="flex px-5 py-4 flex-col">
-    <table>
-      <tr>
-        <td class="pt-2 pr-2">Id:</td>
-        <td class="pt-2 pr-2">{image.id}</td>
-      </tr>
-      <tr>
-        <td class="pt-2 pr-2">Size:</td>
-        <td class="pt-2 pr-2">{image.humanSize}</td>
-      </tr>
-      <tr>
-        <td class="pt-2 pr-2">Age</td>
-        <td class="pt-2 pr-2">{image.age}</td>
-      </tr>
-    </table>
-  </div>
+<div class="flex px-5 py-4 flex-col">
+  <table>
+    <tr>
+      <td class="pt-2 pr-2">Id:</td>
+      <td class="pt-2 pr-2">{image.id}</td>
+    </tr>
+    <tr>
+      <td class="pt-2 pr-2">Size:</td>
+      <td class="pt-2 pr-2">{image.humanSize}</td>
+    </tr>
+    <tr>
+      <td class="pt-2 pr-2">Age</td>
+      <td class="pt-2 pr-2">{image.age}</td>
+    </tr>
+  </table>
 </div>

--- a/packages/renderer/src/lib/pod/PodDetails.svelte
+++ b/packages/renderer/src/lib/pod/PodDetails.svelte
@@ -66,7 +66,7 @@ function errorCallback(errorMessage: string): void {
           <div class="w-full px-5 pt-5">
             <div class="flex flew-row items-center">
               <a class="text-violet-400 text-base hover:no-underline" href="/pods" title="Go back to pods list">Pods</a>
-              <div class="text-xl mx-2 text-gray-700"></div>
+              <div class="text-xl mx-2 text-gray-700">></div>
               <div class="text-sm font-extralight text-gray-700">Pod Details</div>
             </div>
             <div class="text-lg flex flex-row items-start pt-1">

--- a/packages/renderer/src/lib/pod/PodDetails.svelte
+++ b/packages/renderer/src/lib/pod/PodDetails.svelte
@@ -12,9 +12,6 @@ import PodDetailsSummary from './PodDetailsSummary.svelte';
 import PodDetailsInspect from './PodDetailsInspect.svelte';
 import PodDetailsKube from './PodDetailsKube.svelte';
 import PodDetailsLogs from './PodDetailsLogs.svelte';
-import { faExclamationCircle } from '@fortawesome/free-solid-svg-icons';
-import Tooltip from '../ui/Tooltip.svelte';
-import Fa from 'svelte-fa/src/fa.svelte';
 import DetailsTab from '../ui/DetailsTab.svelte';
 import ErrorMessage from '../ui/ErrorMessage.svelte';
 
@@ -69,7 +66,7 @@ function errorCallback(errorMessage: string): void {
           <div class="w-full px-5 pt-5">
             <div class="flex flew-row items-center">
               <a class="text-violet-400 text-base hover:no-underline" href="/pods" title="Go back to pods list">Pods</a>
-              <div class="text-xl mx-2 text-gray-700">></div>
+              <div class="text-xl mx-2 text-gray-700"></div>
               <div class="text-sm font-extralight text-gray-700">Pod Details</div>
             </div>
             <div class="text-lg flex flex-row items-start pt-1">
@@ -113,18 +110,20 @@ function errorCallback(errorMessage: string): void {
           <a href="/containers" title="Close Details" class="mt-2 mr-2 text-gray-900"
             ><i class="fas fa-times" aria-hidden="true"></i></a>
         </div>
-        <Route path="/summary" breadcrumb="Summary">
-          <PodDetailsSummary pod="{pod}" />
-        </Route>
-        <Route path="/logs" breadcrumb="Logs">
-          <PodDetailsLogs pod="{pod}" />
-        </Route>
-        <Route path="/inspect" breadcrumb="Inspect">
-          <PodDetailsInspect pod="{pod}" />
-        </Route>
-        <Route path="/kube" breadcrumb="Kube">
-          <PodDetailsKube pod="{pod}" />
-        </Route>
+        <div class="h-full bg-charcoal-900">
+          <Route path="/summary" breadcrumb="Summary">
+            <PodDetailsSummary pod="{pod}" />
+          </Route>
+          <Route path="/logs" breadcrumb="Logs">
+            <PodDetailsLogs pod="{pod}" />
+          </Route>
+          <Route path="/inspect" breadcrumb="Inspect">
+            <PodDetailsInspect pod="{pod}" />
+          </Route>
+          <Route path="/kube" breadcrumb="Kube">
+            <PodDetailsKube pod="{pod}" />
+          </Route>
+        </div>
       </div>
     </div>
   </Route>

--- a/packages/renderer/src/lib/pod/PodDetailsLogs.svelte
+++ b/packages/renderer/src/lib/pod/PodDetailsLogs.svelte
@@ -178,18 +178,12 @@ onDestroy(() => {
 });
 </script>
 
-<EmptyScreen
-  icon="{NoLogIcon}"
-  title="No Log"
-  message="Log output of Pod {pod.name}"
-  hidden="{noLogs === false}"
-  style="background-color: {getPanelDetailColor()}" />
+<EmptyScreen icon="{NoLogIcon}" title="No Log" message="Log output of Pod {pod.name}" hidden="{noLogs === false}" />
 
 <div
   class="min-w-full flex flex-col"
   class:invisible="{noLogs === true}"
   class:h-0="{noLogs === true}"
   class:h-full="{noLogs === false}"
-  style="background-color: {getPanelDetailColor()}"
   bind:this="{logsXtermDiv}">
 </div>

--- a/packages/renderer/src/lib/pod/PodDetailsSummary.svelte
+++ b/packages/renderer/src/lib/pod/PodDetailsSummary.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 import { router } from 'tinro';
 
-import { getPanelDetailColor } from '../color/color';
 import type { PodInfoUI } from './PodInfoUI';
 
 export let pod: PodInfoUI;
@@ -11,32 +10,30 @@ function openContainer(containerID: string) {
 }
 </script>
 
-<div class="h-full" style="background-color: {getPanelDetailColor()}">
-  <div class="flex px-5 py-4 flex-col">
-    <div class="w-full">
+<div class="flex px-5 py-4 flex-col">
+  <div class="w-full">
+    <table>
+      <tr>
+        <td class="pt-2 pr-2">Name:</td>
+        <td class="pt-2 pr-2">{pod.name}</td>
+      </tr>
+      <tr>
+        <td class="pt-2 pr-2">Id:</td>
+        <td class="pt-2 pr-2">{pod.id}</td>
+      </tr>
+    </table>
+  </div>
+  {#if pod.containers.length > 0}
+    <div class="w-full my-12">
+      <span>Containers using this pod:</span>
       <table>
-        <tr>
-          <td class="pt-2 pr-2">Name:</td>
-          <td class="pt-2 pr-2">{pod.name}</td>
-        </tr>
-        <tr>
-          <td class="pt-2 pr-2">Id:</td>
-          <td class="pt-2 pr-2">{pod.id}</td>
-        </tr>
+        {#each pod.containers as container}
+          <tr class="cursor-pointer" on:click="{() => openContainer(container.Id)}">
+            <td class="pt-2 pr-2">{container.Names}</td>
+            <td class="pt-2 pr-2">{container.Id}</td>
+          </tr>
+        {/each}
       </table>
     </div>
-    {#if pod.containers.length > 0}
-      <div class="w-full my-12">
-        <span>Containers using this pod:</span>
-        <table>
-          {#each pod.containers as container}
-            <tr class="cursor-pointer" on:click="{() => openContainer(container.Id)}">
-              <td class="pt-2 pr-2">{container.Names}</td>
-              <td class="pt-2 pr-2">{container.Id}</td>
-            </tr>
-          {/each}
-        </table>
-      </div>
-    {/if}
-  </div>
+  {/if}
 </div>

--- a/packages/renderer/src/lib/ui/EmptyScreen.svelte
+++ b/packages/renderer/src/lib/ui/EmptyScreen.svelte
@@ -50,7 +50,7 @@ let copyTextDivElement: HTMLDivElement;
       <h1 class="pf-c-title pf-m-lg">{title}</h1>
       <div class="pf-c-empty-state__body">{message}</div>
       {#if commandline.length > 0}
-        <div class="flex flex-row bg-charcoal-800 w-full items-center p-2 mt-2">
+        <div class="flex flex-row bg-charcoal-900 w-full items-center p-2 mt-2">
           <div bind:this="{copyTextDivElement}" data-testid="copyTextDivElement">{commandline}</div>
           <button title="Copy To Clipboard" class="ml-5 mr-5" on:click="{() => copyRunInstructionToClipboard()}"
             ><Fa class="h-5 w-5 cursor-pointer rounded-full text-3xl text-sky-800" icon="{faPaste}" /></button>

--- a/packages/renderer/src/lib/volume/VolumeDetails.svelte
+++ b/packages/renderer/src/lib/volume/VolumeDetails.svelte
@@ -41,7 +41,7 @@ onMount(() => {
             <div class="flex flew-row items-center">
               <a class="text-violet-400 text-base hover:no-underline" href="/volumes" title="Go back to volumes list"
                 >Volumes</a>
-              <div class="text-xl mx-2 text-gray-700"></div>
+              <div class="text-xl mx-2 text-gray-700">></div>
               <div class="text-sm font-extralight text-gray-700">Volume Details</div>
             </div>
             <div class="text-lg flex flex-row items-start pt-1">

--- a/packages/renderer/src/lib/volume/VolumeDetails.svelte
+++ b/packages/renderer/src/lib/volume/VolumeDetails.svelte
@@ -41,7 +41,7 @@ onMount(() => {
             <div class="flex flew-row items-center">
               <a class="text-violet-400 text-base hover:no-underline" href="/volumes" title="Go back to volumes list"
                 >Volumes</a>
-              <div class="text-xl mx-2 text-gray-700">></div>
+              <div class="text-xl mx-2 text-gray-700"></div>
               <div class="text-sm font-extralight text-gray-700">Volume Details</div>
             </div>
             <div class="text-lg flex flex-row items-start pt-1">
@@ -73,12 +73,14 @@ onMount(() => {
           <a href="/containers" title="Close Details" class="mt-2 mr-2 text-gray-900"
             ><i class="fas fa-times" aria-hidden="true"></i></a>
         </div>
-        <Route path="/summary" breadcrumb="Summary">
-          <VolumeDetailsSummary volume="{volume}" />
-        </Route>
-        <Route path="/inspect" breadcrumb="Inspect">
-          <VolumeDetailsInspect volume="{volume}" />
-        </Route>
+        <div class="h-full bg-charcoal-900">
+          <Route path="/summary" breadcrumb="Summary">
+            <VolumeDetailsSummary volume="{volume}" />
+          </Route>
+          <Route path="/inspect" breadcrumb="Inspect">
+            <VolumeDetailsInspect volume="{volume}" />
+          </Route>
+        </div>
       </div>
     </div>
   </Route>

--- a/packages/renderer/src/lib/volume/VolumeDetailsSummary.svelte
+++ b/packages/renderer/src/lib/volume/VolumeDetailsSummary.svelte
@@ -1,8 +1,6 @@
 <script lang="ts">
 import { router } from 'tinro';
 
-import { getPanelDetailColor } from '../color/color';
-
 import type { VolumeInfoUI } from './VolumeInfoUI';
 
 export let volume: VolumeInfoUI;
@@ -12,36 +10,34 @@ function openContainer(containerID: string) {
 }
 </script>
 
-<div class="h-full" style="background-color: {getPanelDetailColor()}">
-  <div class="flex px-5 py-4 flex-col">
-    <div class="w-full">
-      <table>
-        <tr>
-          <td class="pt-2 pr-2">Name:</td>
-          <td class="pt-2 pr-2">{volume.name}</td>
-        </tr>
-        <tr>
-          <td class="pt-2 pr-2">Size:</td>
-          <td class="pt-2 pr-2">{volume.humanSize}</td>
-        </tr>
-        <tr>
-          <td class="pt-2 pr-2">Age:</td>
-          <td class="pt-2 pr-2">{volume.age}</td>
-        </tr>
-      </table>
-    </div>
-    {#if volume.containersUsage.length > 0}
-      <div class="w-full my-12">
-        <span>Containers using this volume:</span>
-        {#each volume.containersUsage as container}
-          <table>
-            <tr class="cursor-pointer" on:click="{() => openContainer(container.id)}">
-              <td class="pt-2 pr-2">{container.names.join('')}</td>
-              <td class="pt-2 pr-2">{container.id}</td>
-            </tr>
-          </table>
-        {/each}
-      </div>
-    {/if}
+<div class="flex px-5 py-4 flex-col">
+  <div class="w-full">
+    <table>
+      <tr>
+        <td class="pt-2 pr-2">Name:</td>
+        <td class="pt-2 pr-2">{volume.name}</td>
+      </tr>
+      <tr>
+        <td class="pt-2 pr-2">Size:</td>
+        <td class="pt-2 pr-2">{volume.humanSize}</td>
+      </tr>
+      <tr>
+        <td class="pt-2 pr-2">Age:</td>
+        <td class="pt-2 pr-2">{volume.age}</td>
+      </tr>
+    </table>
   </div>
+  {#if volume.containersUsage.length > 0}
+    <div class="w-full my-12">
+      <span>Containers using this volume:</span>
+      {#each volume.containersUsage as container}
+        <table>
+          <tr class="cursor-pointer" on:click="{() => openContainer(container.id)}">
+            <td class="pt-2 pr-2">{container.names.join('')}</td>
+            <td class="pt-2 pr-2">{container.id}</td>
+          </tr>
+        </table>
+      {/each}
+    </div>
+  {/if}
 </div>


### PR DESCRIPTION
### What does this PR do?

Design has picked charcoal-900 from the palette as the correct background color for terminals, editors, and the detail pages. Yes, we thought it was -800 mere hours earlier, but that was too close to the nav background.

This change:
- Updates color.ts with the hex value of charcoal-900. As before there doesn't appear to be a better way to do this.
- Adds a div with the correct background in each of the *Details pages to hold the content. Two reasons for this: avoids flashing when switching between tabs, and reduces the # of places where we need to use the color in each tab.
- Removes style="background-color: {getPanelDetailColor()}" from most of the tab components, and removed a <div> if it was now unnecessary due to the one in the parent *Details page.
- Removes some unused imports from PodDetails page.
- ~~Removes an extraneous > in each of the *Details pages.~~

### Screenshot/screencast of this PR

<img width="346" alt="Screenshot 2023-04-25 at 4 59 08 PM" src="https://user-images.githubusercontent.com/19958075/234402251-16f1dc9f-a740-490c-8f49-924d117f3846.png">

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Go to the details page for containers, pods, images, and volumes, and click on every tab to make sure they all have the same color.