### PR TITLE
fix: Kind image load does not show notification anymore

### DIFF
--- a/extensions/kind/src/image-handler.ts
+++ b/extensions/kind/src/image-handler.ts
@@ -57,14 +57,12 @@ export class ImageHandler {
         } else {
           env['KIND_EXPERIMENTAL_PROVIDER'] = 'docker';
         }
-        const result = await runCliCommand(kindCli, ['load', 'image-archive', '-n', selectedCluster.label, filename], {
+        await runCliCommand(kindCli, ['load', 'image-archive', '-n', selectedCluster.label, filename], {
           env: env,
         });
-        if (result.exitCode === 0) {
-          extensionApi.window.showNotification({
-            body: `Image ${image.name} pushed to Kind cluster ${selectedCluster.label}`,
-          });
-        }
+        extensionApi.window.showNotification({
+          body: `Image ${image.name} pushed to Kind cluster ${selectedCluster.label}`,
+        });
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : '' + error;
         throw new Error(


### PR DESCRIPTION
Fixes #2225

### What does this PR do?

Make notification to be displayed after an image has been pushed to the Kind cluster

### Screenshot/screencast of this PR



### What issues does this PR fix or reference?

Fixes #2225 

### How to test this PR?

Push an image to the Kind cluster and you should see a notification