### PR TITLE
feat: allow to define the ports to open when podifying (#1017)

### DIFF
--- a/packages/renderer/src/lib/ContainerList.svelte
+++ b/packages/renderer/src/lib/ContainerList.svelte
@@ -169,7 +169,7 @@ function createPodFromContainers() {
   const podCreation = {
     name: 'my-pod',
     containers: selectedContainers.map(container => {
-      return { id: container.id, name: container.name, engineId: container.engineId, ports: container.port };
+      return { id: container.id, name: container.name, engineId: container.engineId, ports: container.ports };
     }),
   };
 

--- a/packages/renderer/src/lib/container/ContainerDetailsSummary.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetailsSummary.svelte
@@ -2,6 +2,16 @@
 import type { ContainerInfoUI } from './ContainerInfoUI';
 
 export let container: ContainerInfoUI;
+
+function printPorts(ports: number[]): string {
+  if (ports.length > 1) {
+    return `${ports.join(', ')}`;
+  } else if (ports.length === 1) {
+    return `${ports[0]}`;
+  } else {
+    return '';
+  }
+}
 </script>
 
 <div class="flex px-5 py-4 flex-col">
@@ -22,7 +32,7 @@ export let container: ContainerInfoUI;
       <tr>
         <td class="pt-2 pr-2">Ports</td>
         <td class="pt-2 pr-2" class:hidden="{container.hasPublicPort}">N/A</td>
-        <td class="pt-2 pr-2" class:hidden="{!container.hasPublicPort}">{container.port}</td>
+        <td class="pt-2 pr-2" class:hidden="{!container.hasPublicPort}">{printPorts(container.ports)}</td>
       </tr>
     </table>
   </div>

--- a/packages/renderer/src/lib/container/ContainerDetailsSummary.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetailsSummary.svelte
@@ -2,16 +2,6 @@
 import type { ContainerInfoUI } from './ContainerInfoUI';
 
 export let container: ContainerInfoUI;
-
-function printPorts(ports: number[]): string {
-  if (ports.length > 1) {
-    return `${ports.join(', ')}`;
-  } else if (ports.length === 1) {
-    return `${ports[0]}`;
-  } else {
-    return '';
-  }
-}
 </script>
 
 <div class="flex px-5 py-4 flex-col">
@@ -32,7 +22,7 @@ function printPorts(ports: number[]): string {
       <tr>
         <td class="pt-2 pr-2">Ports</td>
         <td class="pt-2 pr-2" class:hidden="{container.hasPublicPort}">N/A</td>
-        <td class="pt-2 pr-2" class:hidden="{!container.hasPublicPort}">{printPorts(container.ports)}</td>
+        <td class="pt-2 pr-2" class:hidden="{!container.hasPublicPort}">{container.portsAsString}</td>
       </tr>
     </table>
   </div>

--- a/packages/renderer/src/lib/container/ContainerInfoUI.ts
+++ b/packages/renderer/src/lib/container/ContainerInfoUI.ts
@@ -52,6 +52,7 @@ export interface ContainerInfoUI {
   uptime: string;
   startedAt: string;
   ports: number[];
+  portsAsString: string;
   displayPort: string;
   command: string;
   hasPublicPort: boolean;

--- a/packages/renderer/src/lib/container/ContainerInfoUI.ts
+++ b/packages/renderer/src/lib/container/ContainerInfoUI.ts
@@ -51,7 +51,7 @@ export interface ContainerInfoUI {
   state: string;
   uptime: string;
   startedAt: string;
-  port: string;
+  ports: number[];
   displayPort: string;
   command: string;
   hasPublicPort: boolean;

--- a/packages/renderer/src/lib/container/container-utils.ts
+++ b/packages/renderer/src/lib/container/container-utils.ts
@@ -77,24 +77,16 @@ export class ContainerUtils {
     return image;
   }
 
-  getPort(containerInfo: ContainerInfo): string {
-    const ports = containerInfo.Ports?.filter(port => port.PublicPort).map(port => port.PublicPort);
-
-    if (ports && ports.length > 1) {
-      return ports.join(', ');
-    } else if (ports && ports.length === 1) {
-      return `${ports[0]}`;
-    } else {
-      return '';
-    }
+  getPorts(containerInfo: ContainerInfo): number[] {
+    return containerInfo.Ports?.filter(port => port.PublicPort).map(port => port.PublicPort) || [];
   }
 
   getDisplayPort(containerInfo: ContainerInfo): string {
-    const ports = this.getPort(containerInfo);
-    if (ports === '') {
+    const ports = this.getPorts(containerInfo);
+    if (ports.length === 0) {
       return '';
     }
-    return `PORT${ports.indexOf(',') > 0 ? 'S' : ''} ${ports}`;
+    return `PORT${ports.length > 1 ? 'S' : ''} ${ports}`;
   }
 
   hasPublicPort(containerInfo: ContainerInfo): boolean {
@@ -134,7 +126,7 @@ export class ContainerUtils {
       engineName: this.getEngineName(containerInfo),
       engineType: containerInfo.engineType,
       command: containerInfo.Command,
-      port: this.getPort(containerInfo),
+      ports: this.getPorts(containerInfo),
       displayPort: this.getDisplayPort(containerInfo),
       hasPublicPort: this.hasPublicPort(containerInfo),
       openingUrl: this.getOpeningUrl(containerInfo),

--- a/packages/renderer/src/lib/container/container-utils.ts
+++ b/packages/renderer/src/lib/container/container-utils.ts
@@ -127,6 +127,7 @@ export class ContainerUtils {
       engineType: containerInfo.engineType,
       command: containerInfo.Command,
       ports: this.getPorts(containerInfo),
+      portsAsString: this.getPortsAsString(containerInfo),
       displayPort: this.getDisplayPort(containerInfo),
       hasPublicPort: this.hasPublicPort(containerInfo),
       openingUrl: this.getOpeningUrl(containerInfo),
@@ -196,5 +197,16 @@ export class ContainerUtils {
 
   getMemoryUsageTitle(usedMemory: number): string {
     return `${filesize(usedMemory)}`;
+  }
+
+  getPortsAsString(containerInfo: ContainerInfo): string {
+    const ports = containerInfo.Ports;
+    if (ports.length > 1) {
+      return `${ports.join(', ')}`;
+    } else if (ports.length === 1) {
+      return `${ports[0]}`;
+    } else {
+      return '';
+    }
   }
 }

--- a/packages/renderer/src/lib/pod/PodCreateFromContainers.spec.ts
+++ b/packages/renderer/src/lib/pod/PodCreateFromContainers.spec.ts
@@ -1,0 +1,207 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom';
+import { test, expect, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { providerInfos } from '../../stores/providers';
+import type { ProviderInfo } from '../../../../main/src/plugin/api/provider-info';
+import { podCreationHolder, type PodCreation } from '/@/stores/creation-from-containers-store';
+import PodCreateFromContainers from './PodCreateFromContainers.svelte';
+import type { ContainerInspectInfo } from '@podman-desktop/api';
+
+const providerInfo: ProviderInfo = {
+  id: 'podman',
+  name: 'podman',
+  images: {
+    icon: 'img',
+  },
+  status: 'started',
+  warnings: undefined,
+  containerProviderConnectionCreation: true,
+  detectionChecks: undefined,
+  containerConnections: [
+    {
+      name: 'machine',
+      status: 'started',
+      endpoint: {
+        socketPath: 'socket',
+      },
+      lifecycleMethods: ['start', 'stop', 'delete'],
+      type: 'podman',
+    },
+  ],
+  installationSupport: undefined,
+  internalId: '0',
+  kubernetesConnections: [],
+  kubernetesProviderConnectionCreation: true,
+  links: undefined,
+  containerProviderConnectionInitialization: false,
+  containerProviderConnectionCreationDisplayName: 'Podman machine',
+  kubernetesProviderConnectionInitialization: false,
+};
+
+const podCreation: PodCreation = {
+  containers: [
+    {
+      engineId: 'podman',
+      id: 'id',
+      name: 'cont_1',
+      ports: [9090, 8080],
+    },
+  ],
+  name: 'pod',
+};
+
+const containerInspectInfo: ContainerInspectInfo = {
+  engineId: '',
+  engineName: '',
+  Id: '',
+  Created: '',
+  Path: '',
+  Args: [],
+  State: {
+    Status: '',
+    Running: false,
+    Paused: false,
+    Restarting: false,
+    OOMKilled: false,
+    Dead: false,
+    Pid: 0,
+    ExitCode: 0,
+    Error: '',
+    StartedAt: '',
+    FinishedAt: '',
+    Health: {
+      Status: '',
+      FailingStreak: 0,
+      Log: [],
+    },
+  },
+  Image: '',
+  ResolvConfPath: '',
+  HostnamePath: '',
+  HostsPath: '',
+  LogPath: '',
+  Name: '',
+  RestartCount: 0,
+  Driver: '',
+  Platform: '',
+  MountLabel: '',
+  ProcessLabel: '',
+  AppArmorProfile: '',
+  HostConfig: {
+    PortBindings: {
+      9090: [
+        {
+          HostPort: 8383,
+          HostIp: '',
+        },
+      ],
+    },
+  },
+  GraphDriver: {
+    Name: '',
+    Data: {
+      DeviceId: '',
+      DeviceName: '',
+      DeviceSize: '',
+    },
+  },
+  Mounts: [],
+  Config: {
+    Hostname: '',
+    Domainname: '',
+    User: '',
+    AttachStdin: false,
+    AttachStdout: false,
+    AttachStderr: false,
+    ExposedPorts: {},
+    Tty: false,
+    OpenStdin: false,
+    StdinOnce: false,
+    Env: [],
+    Cmd: [],
+    Image: '',
+    Volumes: {},
+    WorkingDir: '',
+    Entrypoint: '',
+    OnBuild: undefined,
+    Labels: {},
+  },
+  NetworkSettings: {
+    Bridge: '',
+    SandboxID: '',
+    HairpinMode: false,
+    LinkLocalIPv6Address: '',
+    LinkLocalIPv6PrefixLen: 0,
+    Ports: {},
+    SandboxKey: '',
+    SecondaryIPAddresses: undefined,
+    SecondaryIPv6Addresses: undefined,
+    EndpointID: '',
+    Gateway: '',
+    GlobalIPv6Address: '',
+    GlobalIPv6PrefixLen: 0,
+    IPAddress: '',
+    IPPrefixLen: 0,
+    IPv6Gateway: '',
+    MacAddress: '',
+    Networks: {},
+    Node: {
+      ID: '',
+      IP: '',
+      Addr: '',
+      Name: '',
+      Cpus: 0,
+      Memory: 0,
+      Labels: undefined,
+    },
+  },
+};
+
+test('Expect to see name input, containers and exposed ports list', async () => {
+  providerInfos.set([providerInfo]);
+  podCreationHolder.set(podCreation);
+
+  render(PodCreateFromContainers, {});
+  const nameInput = screen.getByRole('textbox', { name: 'Pod name' });
+  expect(nameInput).toBeInTheDocument();
+  const containersLabel = screen.getByLabelText('Containers');
+  expect(containersLabel).toBeInTheDocument();
+  const exposedPortsLabel = screen.getByLabelText('Exposed ports');
+  expect(exposedPortsLabel).toBeInTheDocument();
+});
+
+test('Show error if pod creation fails', async () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (window as any).getContainerInspect = vi.fn().mockResolvedValue(containerInspectInfo);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (window as any).createPod = vi.fn().mockRejectedValue('error create pod');
+  providerInfos.set([providerInfo]);
+  podCreationHolder.set(podCreation);
+
+  render(PodCreateFromContainers, {});
+  const createPodButton = screen.getByRole('button', { name: 'Create pod' });
+  // expect to have indication why the button is disabled
+  expect(createPodButton).toBeInTheDocument();
+  await fireEvent.click(createPodButton);
+
+  const exposedPortsLabel = await screen.findByText('error create pod');
+  expect(exposedPortsLabel).toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/pod/PodCreateFromContainers.svelte
+++ b/packages/renderer/src/lib/pod/PodCreateFromContainers.svelte
@@ -7,10 +7,13 @@ import NavPage from '../ui/NavPage.svelte';
 import { router } from 'tinro';
 import type { Unsubscriber } from 'svelte/store';
 import ErrorMessage from '../ui/ErrorMessage.svelte';
+import StatusIcon from '../images/StatusIcon.svelte';
+import ContainerIcon from '../images/ContainerIcon.svelte';
 
 let podCreation: PodCreation;
 let createInProgress = false;
 let createError = undefined;
+$: mapPortExposed = new Map<number, { exposed: boolean; container: string }>();
 
 let providers: ProviderInfo[] = [];
 $: providerConnections = providers
@@ -59,7 +62,14 @@ async function doCreatePodFromContainers() {
   );
 
   // make it flat and remove undefined values
-  const portmappings = portmappingsArray.flat().filter(portmapping => portmapping !== undefined);
+  const portmappings = portmappingsArray
+    .flat()
+    .filter(
+      portmapping =>
+        portmapping !== undefined &&
+        mapPortExposed.has(portmapping.host_port) &&
+        mapPortExposed.get(portmapping.host_port).exposed,
+    );
 
   // first create pod
   const { Id, engineId } = await window.createPod(selectedProvider, { name: podCreation.name, portmappings });
@@ -106,6 +116,14 @@ onMount(() => {
 
   podCreationUnsubscribe = podCreationHolder.subscribe(value => {
     podCreation = value;
+    podCreation.containers.forEach(container => {
+      container.ports.forEach(port => {
+        mapPortExposed.set(port, {
+          exposed: true,
+          container: container.name,
+        });
+      });
+    });
   });
 });
 
@@ -119,95 +137,132 @@ onDestroy(() => {
   // reset
   podCreationHolder.set(undefined);
 });
+
+function updatePortExposure(port: number, checked: boolean) {
+  const val = mapPortExposed.get(port);
+  if (val) {
+    mapPortExposed.set(port, {
+      exposed: checked,
+      container: val.container,
+    });
+    mapPortExposed = mapPortExposed;
+  }
+}
 </script>
 
 <NavPage title="Copy containers to a pod" searchEnabled="{false}">
-  <div class="w-full h-full" slot="empty">
-    <div class="m-5 p-5 h-full bg-zinc-900 rounded-sm text-gray-700">
-      {#if podCreation}
-        <div class="">
-          <label
-            for="podName"
-            class="p-2 block mb-2 text-sm font-medium rounded bg-zinc-700 text-gray-400 dark:text-gray-400"
-            >Name of the pod:
-            <input
-              name="podName"
-              id="podName"
-              bind:value="{podCreation.name}"
-              placeholder="Select name of the pod..."
-              class="w-full p-2 outline-none text-sm bg-zinc-900 rounded-sm text-gray-700 placeholder-gray-700"
-              required />
-          </label>
-        </div>
+  <div class="w-full h-full min-w-fit" slot="empty">
+    <div class="m-5 p-6 h-full bg-charcoal-800 rounded-sm text-gray-700">
+      <div class="w-4/5 min-w-[500px]">
+        {#if podCreation}
+          <div class="">
+            <label for="podName" class="block mb-2 text-sm font-medium rounded text-gray-400 dark:text-gray-400"
+              >Name of the pod:
+              <input
+                name="podName"
+                id="podName"
+                bind:value="{podCreation.name}"
+                placeholder="Select name of the pod..."
+                class="w-full mt-1 p-2 outline-0 text-sm bg-charcoal-500 focus:bg-charcoal-900 border-violet-700 border-b focus:border-violet-700 focus:border rounded-sm text-gray-500 focus:text-gray-700 placeholder-gray-700"
+                required />
+            </label>
+          </div>
 
-        <div class="">
-          <label
-            for="podName"
-            class="p-2 block mb-2 text-sm font-medium rounded bg-zinc-700 text-gray-400 dark:text-gray-400"
-            >Containers to replicate to the pod:
+          <div class="mb-2">
+            <span class="block text-sm font-medium rounded text-gray-400 dark:text-gray-400"
+              >Containers to replicate to the pod:</span>
+          </div>
+          <div class="max-w-full bg-charcoal-900 mb-4 max-h-40 overflow-y-auto">
+            {#each podCreation.containers as container, index}
+              <div class="p-2 flex flex-row items-center text-gray-700">
+                <div class="w-10"><StatusIcon icon="{ContainerIcon}" status="STOPPED" /></div>
+                <div class="w-16 pl-3">{index + 1}.</div>
+                <div class="grow">{container.name}</div>
+                <div class="w-28">({container.id.substring(0, 7)})</div>
+              </div>
+            {/each}
+          </div>
 
-            <table>
-              {#each podCreation.containers as container, index}
-                <tr class="w-full p-2 outline-none text-sm bg-zinc-900 rounded-sm text-gray-700 placeholder-gray-700">
-                  <td class="px-2">{index + 1}.</td>
-                  <td class="px-2">{container.name}</td>
-                  <td class="px-2">({container.id.substring(0, 7)})</td>
-                </tr>
+          {#if mapPortExposed.size > 0}
+            <div class="mb-2">
+              <span class="block text-sm font-medium rounded text-gray-400 dark:text-gray-400"
+                >All selected ports will be exposed:</span>
+            </div>
+            <div class="bg-charcoal-900 mb-4 max-h-40 overflow-y-auto">
+              {#each [...mapPortExposed] as [port, value]}
+                <div class="p-2 flex flex-row align-items text-gray-700">
+                  <input
+                    type="checkbox"
+                    class="mr-5"
+                    checked="{value.exposed}"
+                    on:click="{event => updatePortExposure(port, event.currentTarget.checked)}" />
+                  <div class="w-28 mr-5">
+                    <span class="text-sm">Port {port.toString()}</span>
+                  </div>
+                  <span class="text-sm">{value.container}</span>
+                </div>
               {/each}
-            </table>
-          </label>
-        </div>
-      {/if}
-
-      <div>
-        {#if providerConnections.length > 1}
-          <label
-            for="providerConnectionName"
-            class="p-2 block mb-2 text-sm font-medium rounded bg-zinc-700 text-gray-400 dark:text-gray-400"
-            >Container Engine
-            <select
-              class="w-full p-2 outline-none text-sm bg-zinc-900 rounded-sm text-gray-700 placeholder-gray-700"
-              name="providerChoice"
-              bind:value="{selectedProvider}">
-              {#each providerConnections as providerConnection}
-                <option value="{providerConnection}">{providerConnection.name}</option>
-              {/each}
-            </select>
-          </label>
+            </div>
+          {/if}
         {/if}
-        {#if providerConnections.length == 1}
-          <input type="hidden" name="providerChoice" readonly bind:value="{selectedProviderConnection.name}" />
+
+        <div>
+          {#if providerConnections.length > 1}
+            <label
+              for="providerConnectionName"
+              class="p-2 block mb-2 text-sm font-medium rounded bg-zinc-700 text-gray-300 dark:text-gray-300"
+              >Container Engine
+              <select
+                class="w-full p-2 outline-none text-sm bg-zinc-900 rounded-sm text-gray-400 placeholder-gray-400"
+                name="providerChoice"
+                bind:value="{selectedProvider}">
+                {#each providerConnections as providerConnection}
+                  <option value="{providerConnection}">{providerConnection.name}</option>
+                {/each}
+              </select>
+            </label>
+          {/if}
+          {#if providerConnections.length == 1}
+            <input type="hidden" name="providerChoice" readonly bind:value="{selectedProviderConnection.name}" />
+          {/if}
+        </div>
+
+        <div class="w-full">
+          <div class="float-right">
+            <button class="pf-c-button underline hover:text-gray-400" on:click="{() => router.goto('/containers')}">
+              Close
+            </button>
+            <button
+              disabled="{createInProgress}"
+              on:click="{() => {
+                createPodFromContainers();
+              }}"
+              class="pf-c-button pf-m-primary"
+              type="button">
+              <span class="pf-c-button__icon pf-m-start">
+                {#if createInProgress}
+                  <div class="mr-24">
+                    <i class="pf-c-button__progress">
+                      <span class="pf-c-spinner pf-m-md" role="progressbar">
+                        <span class="pf-c-spinner__clipper"></span>
+                        <span class="pf-c-spinner__lead-ball"></span>
+                        <span class="pf-c-spinner__tail-ball"></span>
+                      </span>
+                    </i>
+                  </div>
+                {:else}
+                  <i class="fas fa-cube" aria-hidden="true"></i>
+                {/if}
+              </span>
+              Create Pod
+            </button>
+          </div>
+        </div>
+
+        {#if createError}
+          <ErrorMessage class="pt-2 text-sm" error="{createError}" />
         {/if}
       </div>
-
-      <button
-        disabled="{createInProgress}"
-        on:click="{() => {
-          createPodFromContainers();
-        }}"
-        class="w-full pf-c-button pf-m-primary"
-        type="button">
-        <span class="pf-c-button__icon pf-m-start">
-          {#if createInProgress}
-            <div class="mr-4">
-              <i class="pf-c-button__progress">
-                <span class="pf-c-spinner pf-m-md" role="progressbar">
-                  <span class="pf-c-spinner__clipper"></span>
-                  <span class="pf-c-spinner__lead-ball"></span>
-                  <span class="pf-c-spinner__tail-ball"></span>
-                </span>
-              </i>
-            </div>
-          {:else}
-            <i class="fas fa-cube" aria-hidden="true"></i>
-          {/if}
-        </span>
-        Create Pod using these containers
-      </button>
-
-      {#if createError}
-        <ErrorMessage class="pt-2 text-sm" error="{createError}" />
-      {/if}
     </div>
   </div>
 </NavPage>

--- a/packages/renderer/src/lib/pod/PodCreateFromContainers.svelte
+++ b/packages/renderer/src/lib/pod/PodCreateFromContainers.svelte
@@ -12,7 +12,7 @@ import ContainerIcon from '../images/ContainerIcon.svelte';
 
 let podCreation: PodCreation;
 let createInProgress = false;
-$: createError = undefined;
+let createError = undefined;
 $: mapPortExposed = new Map<number, { exposed: boolean; container: string }>();
 
 let providers: ProviderInfo[] = [];

--- a/packages/renderer/src/lib/pod/PodCreateFromContainers.svelte
+++ b/packages/renderer/src/lib/pod/PodCreateFromContainers.svelte
@@ -155,18 +155,18 @@ function updatePortExposure(port: number, checked: boolean) {
     <div class="m-5 p-6 h-full bg-charcoal-800 rounded-sm text-gray-700">
       <div class="w-4/5 min-w-[500px]">
         {#if podCreation}
-          <div class="">
-            <label for="podName" class="block mb-2 text-sm font-medium rounded text-gray-400 dark:text-gray-400"
-              >Name of the pod:
-              <input
-                name="podName"
-                id="podName"
-                bind:value="{podCreation.name}"
-                placeholder="Select name of the pod..."
-                aria-label="Pod name"
-                class="w-full mt-1 p-2 outline-0 text-sm bg-charcoal-500 focus:bg-charcoal-900 border-violet-700 border-b focus:border-violet-700 focus:border rounded-sm text-gray-500 focus:text-gray-700 placeholder-gray-700"
-                required />
-            </label>
+          <div class="mb-2">
+            <span class="block text-sm font-medium rounded text-gray-400 dark:text-gray-400">Name of the pod:</span>
+          </div>
+          <div class="mb-4">
+            <input
+              name="podName"
+              id="podName"
+              bind:value="{podCreation.name}"
+              placeholder="Select name of the pod..."
+              aria-label="Pod name"
+              class="w-full mt-1 p-2 outline-0 text-sm bg-charcoal-500 focus:bg-charcoal-900 border-violet-700 border-b focus:border-violet-700 focus:border rounded-sm text-gray-500 focus:text-gray-700 placeholder-gray-700"
+              required />
           </div>
 
           <div class="mb-2">

--- a/packages/renderer/src/lib/pod/PodCreateFromContainers.svelte
+++ b/packages/renderer/src/lib/pod/PodCreateFromContainers.svelte
@@ -156,7 +156,7 @@ function updatePortExposure(port: number, checked: boolean) {
       <div class="w-4/5 min-w-[500px]">
         {#if podCreation}
           <div class="mb-2">
-            <span class="block text-sm font-medium rounded text-gray-400 dark:text-gray-400">Name of the pod:</span>
+            <span class="block text-sm font-semibold rounded text-gray-400 dark:text-gray-400">Name of the pod:</span>
           </div>
           <div class="mb-4">
             <input
@@ -170,7 +170,7 @@ function updatePortExposure(port: number, checked: boolean) {
           </div>
 
           <div class="mb-2">
-            <span class="block text-sm font-medium rounded text-gray-400 dark:text-gray-400" aria-label="Containers"
+            <span class="block text-sm font-semibold rounded text-gray-400 dark:text-gray-400" aria-label="Containers"
               >Containers to replicate to the pod:</span>
           </div>
           <div class="max-w-full bg-charcoal-900 mb-4 max-h-40 overflow-y-auto">
@@ -187,7 +187,7 @@ function updatePortExposure(port: number, checked: boolean) {
           {#if mapPortExposed.size > 0}
             <div class="mb-2">
               <span
-                class="block text-sm font-medium rounded text-gray-400 dark:text-gray-400"
+                class="block text-sm font-semibold rounded text-gray-400 dark:text-gray-400"
                 aria-label="Exposed ports">All selected ports will be exposed:</span>
             </div>
             <div class="bg-charcoal-900 mb-4 max-h-40 overflow-y-auto">

--- a/packages/renderer/src/lib/pod/PodCreateFromContainers.svelte
+++ b/packages/renderer/src/lib/pod/PodCreateFromContainers.svelte
@@ -12,7 +12,7 @@ import ContainerIcon from '../images/ContainerIcon.svelte';
 
 let podCreation: PodCreation;
 let createInProgress = false;
-let createError = undefined;
+$: createError = undefined;
 $: mapPortExposed = new Map<number, { exposed: boolean; container: string }>();
 
 let providers: ProviderInfo[] = [];
@@ -163,13 +163,14 @@ function updatePortExposure(port: number, checked: boolean) {
                 id="podName"
                 bind:value="{podCreation.name}"
                 placeholder="Select name of the pod..."
+                aria-label="Pod name"
                 class="w-full mt-1 p-2 outline-0 text-sm bg-charcoal-500 focus:bg-charcoal-900 border-violet-700 border-b focus:border-violet-700 focus:border rounded-sm text-gray-500 focus:text-gray-700 placeholder-gray-700"
                 required />
             </label>
           </div>
 
           <div class="mb-2">
-            <span class="block text-sm font-medium rounded text-gray-400 dark:text-gray-400"
+            <span class="block text-sm font-medium rounded text-gray-400 dark:text-gray-400" aria-label="Containers"
               >Containers to replicate to the pod:</span>
           </div>
           <div class="max-w-full bg-charcoal-900 mb-4 max-h-40 overflow-y-auto">
@@ -185,8 +186,9 @@ function updatePortExposure(port: number, checked: boolean) {
 
           {#if mapPortExposed.size > 0}
             <div class="mb-2">
-              <span class="block text-sm font-medium rounded text-gray-400 dark:text-gray-400"
-                >All selected ports will be exposed:</span>
+              <span
+                class="block text-sm font-medium rounded text-gray-400 dark:text-gray-400"
+                aria-label="Exposed ports">All selected ports will be exposed:</span>
             </div>
             <div class="bg-charcoal-900 mb-4 max-h-40 overflow-y-auto">
               {#each [...mapPortExposed] as [port, value]}
@@ -237,6 +239,7 @@ function updatePortExposure(port: number, checked: boolean) {
               on:click="{() => {
                 createPodFromContainers();
               }}"
+              aria-label="Create pod"
               class="pf-c-button pf-m-primary"
               type="button">
               <span class="pf-c-button__icon pf-m-start">

--- a/packages/renderer/src/stores/creation-from-containers-store.ts
+++ b/packages/renderer/src/stores/creation-from-containers-store.ts
@@ -23,6 +23,7 @@ export interface PodCreationContainer {
   id: string;
   name: string;
   engineId: string;
+  ports: number[];
 }
 
 export interface PodCreation {


### PR DESCRIPTION
### What does this PR do?

it allow users to define the ports to open when podifying 

### Screenshot/screencast of this PR

![expose-port-pod](https://user-images.githubusercontent.com/49404737/234527674-ed14f52c-8f66-445f-8038-c8135bb61136.gif)

### What issues does this PR fix or reference?

it fixes #1017 

### How to test this PR?

1. select 1+ containers with ports
2. deselect all ports or some of them
3. create a pod
4. verify that the ports you deselected are not opened

What should it happen when the user selects two containers with the same port? Only one container is displayed in the list and an error message explains what happened?? Only show the warning??

@mairin as i added a new part I also updated the rest with your design https://github.com/containers/podman-desktop/issues/2183 . As the port list is a new stuff, let me know if that's ok or i need to change it


