### PR TITLE
feat: remove icon/title Podman Desktop in the titlebar

### DIFF
--- a/packages/main/src/mainWindow.ts
+++ b/packages/main/src/mainWindow.ts
@@ -56,7 +56,8 @@ async function createWindow() {
 
   if (isMac()) {
     // This property is not available on Linux.
-    browserWindowConstructorOptions.titleBarStyle = 'hiddenInset';
+    browserWindowConstructorOptions.titleBarStyle = 'hidden';
+    browserWindowConstructorOptions.trafficLightPosition = { x: 7, y: 7 };
   }
 
   const browserWindow = new BrowserWindow(browserWindowConstructorOptions);

--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -56,7 +56,10 @@ $: providerConnections = providers
   .flat()
   .filter(providerContainerConnection => providerContainerConnection.status === 'started');
 
-onMount(() => {
+let platform;
+
+onMount(async () => {
+  platform = await window.getOsPlatform();
   providerInfos.subscribe(value => {
     providers = value;
   });
@@ -71,16 +74,11 @@ window.events?.receive('display-help', () => {
 
 <Route path="/*" breadcrumb="Home" let:meta>
   <main class="min-h-screen flex flex-col h-screen bg-zinc-900">
-    <header id="navbar" class="text-gray-700 bg-zinc-900 body-font" style="-webkit-app-region: drag;">
-      <div class="flex mx-auto flex-row p-2 items-center">
-        <div class="flex lg:w-2/5 flex-1 items-center text-base ml-auto"></div>
-        <div
-          class="flex order-none title-font font-medium items-center text-white align-middle justify-center mb-4 md:mb-0">
-          <Logo />
-          <span class="select-none ml-3 text-xl block text-gray-400">Podman Desktop</span>
-        </div>
-        <div class="lg:w-2/5 flex-1 lg:justify-end ml-5 lg:ml-0"></div>
-      </div>
+    <header
+      id="navbar"
+      hidden="{platform !== 'darwin'}"
+      class="text-gray-700 bg-zinc-900 body-font h-7"
+      style="-webkit-app-region: drag;">
     </header>
 
     <WelcomePage />


### PR DESCRIPTION
### What does this PR do?
remove icon/title Podman Desktop in the titlebar
also remove that empty titlebar on Linux and Windows for now until https://github.com/containers/podman-desktop/issues/1802 is designed

### Screenshot/screencast of this PR

![image](https://user-images.githubusercontent.com/436777/234533661-f6e1fde1-d4b6-4f8e-bb12-eb238889971d.png)


### What issues does this PR fix or reference?

related to https://github.com/containers/podman-desktop/issues/1805


### How to test this PR?

Check on Linux, Windows and macOS

Change-Id: Idfc44a0adcaa71089de4757e4efe2d81fd31962b
