### PR TITLE
feat(extension): Allows to override the create button title

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -231,6 +231,9 @@ declare module '@podman-desktop/api' {
 
     // Optional display name when creating the provider. For example 'Podman Machine' or 'Kind Cluster', etc.
     creationDisplayName?: string;
+
+    // Optional button title when creating the provider. Default is 'Create new'.
+    creationButtonTitle?: string;
   }
 
   // create programmatically a ContainerProviderConnection

--- a/packages/main/src/plugin/api/provider-info.ts
+++ b/packages/main/src/plugin/api/provider-info.ts
@@ -63,6 +63,9 @@ export interface ProviderInfo {
   // optional creation name (if defined)
   containerProviderConnectionCreationDisplayName?: string;
 
+  // optional creation button title (if defined)
+  containerProviderConnectionCreationButtonTitle?: string;
+
   // can create provider connection from KubernetesProviderConnectionFactory params
   kubernetesProviderConnectionCreation: boolean;
   // can initialize provider connection from KubernetesProviderConnectionFactory params
@@ -70,6 +73,9 @@ export interface ProviderInfo {
 
   // optional creation name (if defined)
   kubernetesProviderConnectionCreationDisplayName?: string;
+
+  // optional creation button title (if defined)
+  kubernetesProviderConnectionCreationButtonTitle?: string;
 
   version?: string;
 

--- a/packages/main/src/plugin/provider-registry.ts
+++ b/packages/main/src/plugin/provider-registry.ts
@@ -553,6 +553,8 @@ export class ProviderRegistry {
     let containerProviderConnectionCreation = false;
     const containerProviderConnectionCreationDisplayName =
       provider.containerProviderConnectionFactory?.creationDisplayName;
+    const containerProviderConnectionCreationButtonTitle =
+      provider.containerProviderConnectionFactory?.creationButtonTitle;
     if (provider.containerProviderConnectionFactory) {
       containerProviderConnectionCreation = true;
     }
@@ -561,6 +563,8 @@ export class ProviderRegistry {
     let kubernetesProviderConnectionInitialization = false;
     const kubernetesProviderConnectionCreationDisplayName =
       provider.kubernetesProviderConnectionFactory?.creationDisplayName;
+    const kubernetesProviderConnectionCreationButtonTitle =
+      provider.kubernetesProviderConnectionFactory?.creationButtonTitle;
     if (provider.kubernetesProviderConnectionFactory && provider.kubernetesProviderConnectionFactory.initialize) {
       kubernetesProviderConnectionInitialization = true;
     }
@@ -582,8 +586,10 @@ export class ProviderRegistry {
       kubernetesProviderConnectionCreation,
       containerProviderConnectionInitialization,
       containerProviderConnectionCreationDisplayName,
+      containerProviderConnectionCreationButtonTitle,
       kubernetesProviderConnectionInitialization,
       kubernetesProviderConnectionCreationDisplayName,
+      kubernetesProviderConnectionCreationButtonTitle,
       links: provider.links,
       detectionChecks: provider.detectionChecks,
       images: provider.images,

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.spec.ts
@@ -72,16 +72,21 @@ test('Expect to see elements regarding default provider name', async () => {
   render(PreferencesResourcesRendering, {});
   const button = screen.getByRole('button', { name: 'Create new foo-provider' });
   expect(button).toBeInTheDocument();
+  // expect default create title
+  expect(button).toHaveTextContent('Create new ...');
 });
 
 test('Expect to see elements regarding foo provider', async () => {
   // clone providerInfo and change id to foo
   const customProviderInfo: ProviderInfo = { ...providerInfo };
   customProviderInfo.containerProviderConnectionCreationDisplayName = 'foo';
+  customProviderInfo.containerProviderConnectionCreationButtonTitle = 'Connect';
   providerInfos.set([customProviderInfo]);
   render(PreferencesResourcesRendering, {});
   const button = screen.getByRole('button', { name: 'Create new foo' });
   expect(button).toBeInTheDocument();
+  // expect custom create title
+  expect(button).toHaveTextContent('Connect ...');
 });
 
 test('Expect to see elements regarding podman provider', async () => {

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
@@ -243,6 +243,12 @@ async function startConnectionProvider(
                       : provider.kubernetesProviderConnectionCreation
                       ? provider.kubernetesProviderConnectionCreationDisplayName
                       : undefined) || provider.name}
+                  {@const buttonTitle =
+                    (provider.containerProviderConnectionCreation
+                      ? provider.containerProviderConnectionCreationButtonTitle || undefined
+                      : provider.kubernetesProviderConnectionCreation
+                      ? provider.kubernetesProviderConnectionCreationButtonTitle
+                      : undefined) || 'Create new'}
                   <!-- create new provider button -->
                   <Tooltip tip="Create new {providerDisplayName}" bottom>
                     <button
@@ -250,7 +256,7 @@ async function startConnectionProvider(
                       aria-label="Create new {providerDisplayName}"
                       type="button"
                       on:click="{() => router.goto(`/preferences/provider/${provider.internalId}`)}">
-                      Create new ...
+                      {buttonTitle} ...
                     </button>
                   </Tooltip>
                 {/if}


### PR DESCRIPTION
### What does this PR do?
Allow to customize the `Create new ...` button title

### Screenshot/screencast of this PR

![image](https://user-images.githubusercontent.com/436777/234575328-b47669a7-6123-4763-9eec-e596d8bd0369.png)

(for example here it displays Connect)

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/2147

### How to test this PR?

Add for example in podman extension

```diff
diff --git a/extensions/podman/src/extension.ts b/extensions/podman/src/extension.ts
index 4946c3ae..b5c66e72 100644
--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -585,6 +585,7 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
       initialize: () => createMachine({}, undefined),
       create: createMachine,
       creationDisplayName: 'Podman machine',
+      creationButtonTitle: 'Connect',
     });
   }
```

