### PR TITLE
fix: allow to resume/see task from creation page

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationRendering.spec.ts
@@ -97,9 +97,8 @@ test('Expect create connection successfully', async () => {
 
   // do we have a task
   const currentConnectionInfoMap = get(createConnectionsInfo);
-
   expect(currentConnectionInfoMap).toBeDefined();
-  const currentConnectionInfo = currentConnectionInfoMap.get('test');
+  const currentConnectionInfo = currentConnectionInfoMap.values().next().value;
   expect(currentConnectionInfo.creationInProgress).toBeTruthy();
   expect(currentConnectionInfo.creationStarted).toBeTruthy();
   expect(currentConnectionInfo.creationSuccessful).toBeFalsy();
@@ -121,9 +120,8 @@ test('Expect create connection successfully', async () => {
 
   // expect it is sucessful
   const currentConnectionInfoAfterMap = get(createConnectionsInfo);
-
   expect(currentConnectionInfoAfterMap).toBeDefined();
-  const currentConnectionInfoAfter = currentConnectionInfoAfterMap.get('test');
+  const currentConnectionInfoAfter = currentConnectionInfoAfterMap.get(2);
 
   expect(currentConnectionInfoAfter.creationInProgress).toBeFalsy();
   expect(currentConnectionInfoAfter.creationStarted).toBeTruthy();
@@ -162,7 +160,7 @@ test('Expect cancelling the creation, trigger the cancellation token', async () 
   const currentConnectionInfoMap = get(createConnectionsInfo);
 
   expect(currentConnectionInfoMap).toBeDefined();
-  const currentConnectionInfo = currentConnectionInfoMap.get('test');
+  const currentConnectionInfo = currentConnectionInfoMap.values().next().value;
 
   expect(currentConnectionInfo).toBeDefined();
   expect(currentConnectionInfo.creationInProgress).toBeTruthy();

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationRendering.spec.ts
@@ -32,6 +32,7 @@ import { createConnectionsInfo } from '/@/stores/create-connections';
 const properties: IConfigurationPropertyRecordedSchema[] = [];
 const providerInfo: ProviderInfo = {
   id: 'test',
+  name: 'test',
 } as unknown as ProviderInfo;
 const propertyScope = 'FOO';
 
@@ -95,9 +96,10 @@ test('Expect create connection successfully', async () => {
   await fireEvent.click(createButton);
 
   // do we have a task
-  const currentConnectionInfo = get(createConnectionsInfo);
+  const currentConnectionInfoMap = get(createConnectionsInfo);
 
-  expect(currentConnectionInfo).toBeDefined();
+  expect(currentConnectionInfoMap).toBeDefined();
+  const currentConnectionInfo = currentConnectionInfoMap.get('test');
   expect(currentConnectionInfo.creationInProgress).toBeTruthy();
   expect(currentConnectionInfo.creationStarted).toBeTruthy();
   expect(currentConnectionInfo.creationSuccessful).toBeFalsy();
@@ -118,7 +120,11 @@ test('Expect create connection successfully', async () => {
   providedKeyLogger(currentConnectionInfo.createKey, 'finish', []);
 
   // expect it is sucessful
-  const currentConnectionInfoAfter = get(createConnectionsInfo);
+  const currentConnectionInfoAfterMap = get(createConnectionsInfo);
+
+  expect(currentConnectionInfoAfterMap).toBeDefined();
+  const currentConnectionInfoAfter = currentConnectionInfoAfterMap.get('test');
+
   expect(currentConnectionInfoAfter.creationInProgress).toBeFalsy();
   expect(currentConnectionInfoAfter.creationStarted).toBeTruthy();
   expect(currentConnectionInfoAfter.creationSuccessful).toBeTruthy();
@@ -153,7 +159,10 @@ test('Expect cancelling the creation, trigger the cancellation token', async () 
   await fireEvent.click(createButton);
 
   // do we have a task
-  const currentConnectionInfo = get(createConnectionsInfo);
+  const currentConnectionInfoMap = get(createConnectionsInfo);
+
+  expect(currentConnectionInfoMap).toBeDefined();
+  const currentConnectionInfo = currentConnectionInfoMap.get('test');
 
   expect(currentConnectionInfo).toBeDefined();
   expect(currentConnectionInfo.creationInProgress).toBeTruthy();

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationRendering.svelte
@@ -62,7 +62,6 @@ $: if (logsTerminal) {
 }
 
 onMount(async () => {
-  cleanup();
   osMemory = await window.getOsMemory();
   osCpu = await window.getOsCpu();
   osFreeDisk = await window.getOsFreeDiskSize();
@@ -98,9 +97,10 @@ onMount(async () => {
   pageIsLoading = false;
 
   // check if we have an existing create action
-  const value = get(createConnectionsInfo);
+  const createConnectionInfoMap = get(createConnectionsInfo);
 
-  if (value) {
+  if (createConnectionInfoMap && createConnectionInfoMap.has(providerInfo.name)) {
+    const value = createConnectionInfoMap.get(providerInfo.name);
     loggerHandlerKey = value.createKey;
     providerInfo = value.providerInfo;
     properties = value.properties;
@@ -111,6 +111,7 @@ onMount(async () => {
     creationStarted = value.creationStarted;
     errorMessage = value.errorMessage;
     creationSuccessful = value.creationSuccessful;
+    tokenId = value.tokenId;
   }
 });
 
@@ -180,7 +181,6 @@ async function cleanup() {
     clearCreateTask(loggerHandlerKey);
     loggerHandlerKey = undefined;
   }
-
   errorMessage = undefined;
   showLogs = false;
   creationInProgress = false;
@@ -194,15 +194,19 @@ async function cleanup() {
 
 // store the key
 function updateStore() {
-  createConnectionsInfo.set({
-    createKey: loggerHandlerKey,
-    providerInfo,
-    properties,
-    propertyScope,
-    creationInProgress,
-    creationSuccessful,
-    creationStarted,
-    errorMessage,
+  createConnectionsInfo.update(map => {
+    map.set(providerInfo.name, {
+      createKey: loggerHandlerKey,
+      providerInfo,
+      properties,
+      propertyScope,
+      creationInProgress,
+      creationSuccessful,
+      creationStarted,
+      errorMessage,
+      tokenId,
+    });
+    return map;
   });
 }
 

--- a/packages/renderer/src/lib/preferences/PreferencesPage.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesPage.svelte
@@ -55,7 +55,13 @@ onMount(async () => {
   <Route path="/provider/:providerInternalId/*" breadcrumb="Resources" let:meta>
     <PreferencesProviderRendering providerInternalId="{meta.params.providerInternalId}" properties="{properties}" />
   </Route>
-  <Route path="/resources" breadcrumb="Resources">
+  <Route path="/provider-task/:providerInternalId/:taskId/*" breadcrumb="Resources" let:meta>
+    <PreferencesProviderRendering
+      providerInternalId="{meta.params.providerInternalId}"
+      properties="{properties}"
+      taskId="{+meta.params.taskId}" />
+  </Route>
+  <Route path="/resources/*" breadcrumb="Resources">
     <PreferencesResourcesRendering />
   </Route>
   <Route path="/registries" breadcrumb="Registries">

--- a/packages/renderer/src/lib/preferences/PreferencesProviderRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesProviderRendering.svelte
@@ -16,6 +16,7 @@ import Fa from 'svelte-fa/src/fa.svelte';
 
 export let properties: IConfigurationPropertyRecordedSchema[] = [];
 export let providerInternalId: string = undefined;
+export let taskId: number = undefined;
 
 let showModal: ProviderInfo = undefined;
 
@@ -189,7 +190,8 @@ async function stopReceivingLogs(provider: ProviderInfo): Promise<void> {
         providerInfo="{providerInfo}"
         properties="{properties}"
         propertyScope="ContainerProviderConnectionFactory"
-        callback="{window.createContainerProviderConnection}" />
+        callback="{window.createContainerProviderConnection}"
+        taskId="{taskId}" />
     {/if}
 
     <!-- Create connection panel-->
@@ -198,7 +200,8 @@ async function stopReceivingLogs(provider: ProviderInfo): Promise<void> {
         providerInfo="{providerInfo}"
         properties="{properties}"
         propertyScope="KubernetesProviderConnectionFactory"
-        callback="{window.createKubernetesProviderConnection}" />
+        callback="{window.createKubernetesProviderConnection}"
+        taskId="{taskId}" />
     {/if}
   </div>
 </Route>

--- a/packages/renderer/src/lib/preferences/preferences-connection-rendering-task.ts
+++ b/packages/renderer/src/lib/preferences/preferences-connection-rendering-task.ts
@@ -88,7 +88,7 @@ export function clearCreateTask(key: symbol): void {
   taskLogOnHolds.delete(key);
   taskLogReplays.delete(key);
   // remove current create
-  createConnectionsInfo.set(undefined);
+  createConnectionsInfo.set(new Map());
 
   // remove the task
   const task = allTasks.get(key);

--- a/packages/renderer/src/stores/create-connections.ts
+++ b/packages/renderer/src/stores/create-connections.ts
@@ -21,8 +21,7 @@ import { writable } from 'svelte/store';
 import type { IConfigurationPropertyRecordedSchema } from '../../../main/src/plugin/configuration-registry';
 import type { ProviderInfo } from '../../../main/src/plugin/api/provider-info';
 
-// current create key
-export const createConnectionsInfo: Writable<{
+interface CreateConnectionInfo {
   createKey: symbol;
   providerInfo: ProviderInfo;
   properties: IConfigurationPropertyRecordedSchema[];
@@ -31,4 +30,8 @@ export const createConnectionsInfo: Writable<{
   creationSuccessful: boolean;
   creationStarted: boolean;
   errorMessage: string;
-}> = writable();
+  tokenId?: number;
+}
+
+// current create key
+export const createConnectionsInfo: Writable<Map<string, CreateConnectionInfo>> = writable(new Map());

--- a/packages/renderer/src/stores/create-connections.ts
+++ b/packages/renderer/src/stores/create-connections.ts
@@ -34,4 +34,4 @@ interface CreateConnectionInfo {
 }
 
 // current create key
-export const createConnectionsInfo: Writable<Map<string, CreateConnectionInfo>> = writable(new Map());
+export const createConnectionsInfo: Writable<Map<number, CreateConnectionInfo>> = writable(new Map());


### PR DESCRIPTION
### What does this PR do?

This allow to resume/see the logs of a running creation task.

### Screenshot/screencast of this PR

![resume-task-create](https://user-images.githubusercontent.com/49404737/234597601-d1518b95-c63e-48b7-94d4-f470cadb7e20.gif)

### What issues does this PR fix or reference?

it fixes #2079 

### How to test this PR?

1. create a podman/kind machine/cluster
2. in the middle of the creation process, change page
3. using the task manager go back to the creation page
