### PR TITLE
fix: Missing black and white in palette

### DIFF
--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -127,6 +127,8 @@ module.exports = {
         900: '#842c18',
       },
       transparent: 'transparent',
+      black: '#000',
+      white: '#fff',
       // The remaining colors below are not part of our palette and are only here
       // to maintain existing code. No new use.
       'slate': {


### PR DESCRIPTION
### What does this PR do?

Some regressions are pretty black and white. I didn't notice that Tailwind has these by default, and we use them in a few places, e.g. white text and fading out the background (black with opacity) for dialogs.

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Open a dialog (e.g. compose) and confirm that the background is faded out.