### PR TITLE
fix: Push image modal styling

### DIFF
--- a/packages/renderer/src/lib/dialogs/Modal.svelte
+++ b/packages/renderer/src/lib/dialogs/Modal.svelte
@@ -5,7 +5,7 @@
   left: 0;
   width: 100%;
   height: 100%;
-  background: rgba(0, 0, 0, 0.3);
+  background: rgba(0, 0, 0, 0.6);
 }
 
 .modal {

--- a/packages/renderer/src/lib/image/PushImageModal.svelte
+++ b/packages/renderer/src/lib/image/PushImageModal.svelte
@@ -112,76 +112,53 @@ let pushLogsXtermDiv: HTMLDivElement;
   on:close="{() => {
     closeCallback();
   }}">
-  <!-- svelte-ignore a11y-autofocus -->
-  <div
-    class="modal z-50 w-full h-full top-0 left-0 flex items-center justify-center p-8 lg:p-0"
-    tabindex="{0}"
-    autofocus
-    on:keydown="{keydownDockerfileChoice}">
-    <div class="modal-overlay fixed w-full h-full bg-gray-900 opacity-50"></div>
+  <div class="modal flex flex-col place-self-center bg-zinc-900 shadow-xl shadow-black">
+    <div class="flex items-center justify-between px-6 py-5 space-x-2">
+      <h1 class="grow text-lg font-bold capitalize">Push Image</h1>
 
-    <div class="relative px-4 w-full max-w-4xl h-full md:h-auto">
-      <div class="relative bg-white rounded-lg shadow dark:bg-gray-900">
-        <div class="relative bg-white rounded-lg shadow dark:bg-gray-900">
-          <div class="flex justify-end p-2">
-            <button
-              on:click="{() => closeCallback()}"
-              type="button"
-              class="text-gray-700 bg-transparent hover:bg-gray-300 hover:text-gray-900 rounded-lg text-sm p-1.5 ml-auto inline-flex items-center dark:hover:bg-gray-900 dark:hover:text-white"
-              data-modal-toggle="authentication-modal">
-              <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"
-                ><path
-                  fill-rule="evenodd"
-                  d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
-                  clip-rule="evenodd"></path
-                ></svg>
-            </button>
-          </div>
-          <div class="px-6 pb-4 space-y-6 lg:px-8 sm:pb-6 xl:pb-8">
-            <h3 class="text-xl font-medium text-gray-900 dark:text-white">Pushing image</h3>
-
-            <div>
-              <label for="modalImageTag" class="block mb-2 text-sm font-medium text-gray-400 dark:text-gray-400"
-                >Image Tag</label>
-              <select
-                class="border text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 bg-gray-900 border-gray-900 placeholder-gray-700 text-white"
-                name="imageChoice"
-                bind:value="{selectedImageTag}">
-                {#each imageTags as imageTag}
-                  <option value="{imageTag}">{imageTag}</option>
-                {/each}
-              </select>
-            </div>
-
-            {#if !pushFinished}
-              <button
-                class="pf-c-button pf-m-primary"
-                disabled="{pushInProgress}"
-                type="button"
-                on:click="{() => {
-                  pushImage(selectedImageTag);
-                }}">
-                {#if pushInProgress === true}
-                  <i class="pf-c-button__progress">
-                    <span class="pf-c-spinner pf-m-md" role="progressbar">
-                      <span class="pf-c-spinner__clipper"></span>
-                      <span class="pf-c-spinner__lead-ball"></span>
-                      <span class="pf-c-spinner__tail-ball"></span>
-                    </span>
-                  </i>
-                {:else}
-                  <i class="fas fa-arrow-circle-up" aria-hidden="true"></i>
-                {/if}
-                Push image</button>
-            {:else}
-              <button class="pf-c-button pf-m-primary" type="button" on:click="{() => pushImageFinished()}">
-                Done</button>
-            {/if}
-
-            <div bind:this="{pushLogsXtermDiv}"></div>
-          </div>
-        </div>
-      </div>
+      <button class="hover:text-gray-300 py-1" on:click="{() => closeCallback()}">
+        <i class="fas fa-times" aria-hidden="true"></i>
+      </button>
     </div>
-  </div>
-</Modal>
+
+    <div class="flex flex-col px-10 py-4 text-sm leading-5 space-y-5">
+      <div>
+        <label for="modalImageTag" class="block mb-2 text-sm font-medium text-gray-400 dark:text-gray-400"
+          >Image Tag</label>
+        <select
+          class="border text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 bg-zinc-800 border-gray-900 placeholder-gray-700 text-white"
+          name="imageChoice"
+          bind:value="{selectedImageTag}">
+          {#each imageTags as imageTag}
+            <option value="{imageTag}">{imageTag}</option>
+          {/each}
+        </select>
+      </div>
+
+      {#if !pushFinished}
+        <button
+          class="pf-c-button pf-m-primary"
+          disabled="{pushInProgress}"
+          type="button"
+          on:click="{() => {
+            pushImage(selectedImageTag);
+          }}">
+          {#if pushInProgress === true}
+            <i class="pf-c-button__progress">
+              <span class="pf-c-spinner pf-m-md" role="progressbar">
+                <span class="pf-c-spinner__clipper"></span>
+                <span class="pf-c-spinner__lead-ball"></span>
+                <span class="pf-c-spinner__tail-ball"></span>
+              </span>
+            </i>
+          {:else}
+            <i class="fas fa-arrow-circle-up" aria-hidden="true"></i>
+          {/if}
+          Push image</button>
+      {:else}
+        <button class="pf-c-button pf-m-primary" type="button" on:click="{() => pushImageFinished()}"> Done</button>
+      {/if}
+
+      <div bind:this="{pushLogsXtermDiv}"></div>
+    </div>
+  </div></Modal>


### PR DESCRIPTION
### What does this PR do?

The push image modal had some slightly unique styling before, but changing the palette has tipped it well over the edge into unusable territory. This fix updates all modals to the same transparency as the newer dialogs, and reuses the same outer divs as the dialogs for pushing images.

Long term I would prefer to embed the outer box and title bar in the Modal component for consistency, but since there are 8 dialogs all with their own styling today that is a bigger change that I don't want to attempt now.

### Screenshot/screencast of this PR

<img width="642" alt="Screenshot 2023-04-26 at 12 57 16 PM" src="https://user-images.githubusercontent.com/19958075/234660955-5df05172-4e4d-4f12-bbe7-b2384787ee91.png">

### What issues does this PR fix or reference?

Fixes #2250

### How to test this PR?

Login to a registry and then try to push an image.