### PR TITLE
feat: UI support for markdown preference descriptions

### DIFF
--- a/packages/main/src/plugin/telemetry/telemetry.ts
+++ b/packages/main/src/plugin/telemetry/telemetry.ts
@@ -87,8 +87,8 @@ export class Telemetry {
       type: 'object',
       properties: {
         [TelemetrySettings.SectionName + '.' + TelemetrySettings.Enabled]: {
-          description:
-            'Help Red Hat improve Podman Desktop by allowing anonymous usage data to be collected. Privacy statement at https://developers.redhat.com/article/tool-data-collection',
+          markdownDescription:
+            'Help improve Podman Desktop by allowing anonymous usage data to be sent to Red Hat. Read our [Privacy statement](https://developers.redhat.com/article/tool-data-collection)',
           type: 'boolean',
           default: true,
         },

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItem.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItem.svelte
@@ -3,6 +3,7 @@ import { afterUpdate } from 'svelte';
 
 import type { IConfigurationPropertyRecordedSchema } from '../../../../main/src/plugin/configuration-registry';
 import PreferencesRenderingItemFormat from './PreferencesRenderingItemFormat.svelte';
+import Markdown from '../markdown/Markdown.svelte';
 
 export let record: IConfigurationPropertyRecordedSchema;
 
@@ -10,6 +11,7 @@ let recordUI: {
   title: string;
   breadCrumb: string;
   description: string;
+  markdownDescription: string;
   original: IConfigurationPropertyRecordedSchema;
 };
 
@@ -37,6 +39,7 @@ function update() {
     title: startCase(key),
     breadCrumb: breadCrumbUI,
     description: record.description,
+    markdownDescription: record.markdownDescription,
     original: record,
   };
 }
@@ -73,7 +76,13 @@ $: resetToDefault = false;
         </div>
       {/if}
     </div>
-    <div class="pt-1 text-gray-700 text-xs pr-2">{recordUI.description}</div>
+    {#if recordUI.markdownDescription}
+      <div class="pt-1 text-gray-700 text-xs pr-2">
+        <Markdown>{recordUI.markdownDescription}</Markdown>
+      </div>
+    {:else}
+      <div class="pt-1 text-gray-700 text-xs pr-2">{recordUI.description}</div>
+    {/if}
     {#if recordUI.original.type === 'string' && (!recordUI.original.enum || recordUI.original.enum.length === 0)}
       <PreferencesRenderingItemFormat
         showUpdate="{false}"


### PR DESCRIPTION
### What does this PR do?

Allow preference descriptions to use markdown, and update the telemetry description to include a proper link to our privacy statement. This would be _so_ much better with a fix for issue #2230, but I don't think that's a blocker since this is shorter, less ugly, and already easier to copy the link (Copy Link popup vs previous requirement to select the right text and copy).

### Screenshot/screencast of this PR

<img width="544" alt="Screenshot 2023-04-26 at 3 23 28 PM" src="https://user-images.githubusercontent.com/19958075/234681355-222718a9-19ba-4b11-9fa9-27e7d04b34c8.png">

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Open Settings > Preferences and verify the link exists for telemetry.