### PR TITLE
fix: catch error when extension loader fails to start

### DIFF
--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1455,9 +1455,14 @@ export class PluginSystem {
 
     apiSender.send('starting-extensions', `${this.isReady}`);
     console.log('System ready. Loading extensions...');
-    await this.extensionLoader.start();
-    console.log('PluginSystem: initialization done.');
-    apiSender.send('extensions-started');
+    try {
+      await this.extensionLoader.start();
+      console.log('PluginSystem: initialization done.');
+      apiSender.send('extensions-started');
+    } catch (e) {
+      console.error(e);
+    }
+        
     autoStartConfiguration.start();
     return this.extensionLoader;
   }


### PR DESCRIPTION
### What does this PR do?

This PR just catch the error if the extension loader fails. 
So far, if a plugin failed the autostart never got triggered. This way the autostart is called correctly even if a third party plugin fails to start 

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

N/A

### How to test this PR?

I have the PD sandbox extension installed. It failed when starting PD so the autostart never gets triggered . The error i face
`
TPError: Response code 401 (Unauthorized)
    at Request.<anonymous> (C:\Users\.local\share\containers\podman-desktop\plugins\ghcrioredhatdeveloperpodmandesktopsandboxext\dist\extension.js:192736:42)
`

So to test it, i guess you just need to install the PD sandbox extension and check that the autostart still work