### PR TITLE
feat(main): Implement pulling of images without any container engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "@types/analytics-node": "^3.1.11",
     "@types/dockerode": "^3.3.16",
     "@types/getos": "^3.0.1",
+    "@types/tar": "^6.1.4",
     "@types/tar-fs": "^2.0.1",
     "@types/validator": "^13.7.15",
     "@typescript-eslint/eslint-plugin": "^5.59.1",
@@ -87,6 +88,7 @@
     "electron-builder-notarize": "^1.5.1",
     "electron-devtools-installer": "^3.2.0",
     "eslint": "^8.39.0",
+    "nock": "^13.3.1",
     "playwright": "1.33.0",
     "postcss-import": "^15.1.0",
     "prettier": "^2.8.8",
@@ -114,6 +116,7 @@
     "moment": "^2.29.4",
     "os-locale": "^6.0.2",
     "stream-json": "^1.7.5",
+    "tar": "^6.1.13",
     "tar-fs": "^2.1.1",
     "win-ca": "^3.5.0"
   },

--- a/packages/main/src/plugin/image-registry.spec.ts
+++ b/packages/main/src/plugin/image-registry.spec.ts
@@ -16,19 +16,30 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
+import { beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
 import type { ApiSenderType } from './api';
-import type { Certificates } from './certificates';
 
 import { ImageRegistry } from './image-registry';
 import type { Proxy } from './proxy';
 import type { Telemetry } from './telemetry/telemetry';
+import type { Certificates } from './certificates';
+import nock from 'nock';
+import * as imageRegistryManifestMultiArchJson from '../../tests/resources/data/plugin/image-registry-manifest-multi-arch-index.json';
+import * as imageRegistryManifestJson from '../../tests/resources/data/plugin/image-registry-manifest-index.json';
+import * as imageRegistryConfigJson from '../../tests/resources/data/plugin/image-registry-config.json';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import * as fs from 'node:fs';
+import * as nodeTar from 'tar';
 
-let imageRegistry;
+let imageRegistry: ImageRegistry;
 
-beforeAll(() => {
+beforeAll(async () => {
   const telemetry: Telemetry = {} as Telemetry;
-  const certificates: Certificates = {} as Certificates;
+  const certificates: Certificates = {
+    init: vi.fn(),
+    getAllCertificates: vi.fn(),
+  } as unknown as Certificates;
   const proxy: Proxy = {
     onDidStateChange: vi.fn(),
     onDidUpdateProxy: vi.fn(),
@@ -125,4 +136,227 @@ test('should map ecr', () => {
     '12345.dkr.ecr.us-east-1.amazonaws.com/podman-desktop',
   );
   expect(registryServer).toBe('12345.dkr.ecr.us-east-1.amazonaws.com');
+});
+
+describe('extractImageDataFromImageName', () => {
+  test('library image', () => {
+    const nameAndTag = imageRegistry.extractImageDataFromImageName('httpd');
+    expect(nameAndTag.registry).toBe('index.docker.io');
+    expect(nameAndTag.registryURL).toBe('https://index.docker.io/v2');
+    expect(nameAndTag.tag).toBe('latest');
+    expect(nameAndTag.name).toBe('library/httpd');
+  });
+
+  test('library image with custom tag', () => {
+    const nameAndTag = imageRegistry.extractImageDataFromImageName('httpd:1.2.3');
+    expect(nameAndTag.registry).toBe('index.docker.io');
+    expect(nameAndTag.registryURL).toBe('https://index.docker.io/v2');
+    expect(nameAndTag.tag).toBe('1.2.3');
+    expect(nameAndTag.name).toBe('library/httpd');
+  });
+
+  test('simple image', () => {
+    const nameAndTag = imageRegistry.extractImageDataFromImageName('foo/bar');
+    expect(nameAndTag.registry).toBe('index.docker.io');
+    expect(nameAndTag.registryURL).toBe('https://index.docker.io/v2');
+    expect(nameAndTag.tag).toBe('latest');
+    expect(nameAndTag.name).toBe('foo/bar');
+  });
+
+  test('simple image with custom tag', () => {
+    const nameAndTag = imageRegistry.extractImageDataFromImageName('foo/bar:myTag');
+    expect(nameAndTag.registry).toBe('index.docker.io');
+    expect(nameAndTag.registryURL).toBe('https://index.docker.io/v2');
+    expect(nameAndTag.tag).toBe('myTag');
+    expect(nameAndTag.name).toBe('foo/bar');
+  });
+
+  test('quay.io image', () => {
+    const nameAndTag = imageRegistry.extractImageDataFromImageName('quay.io/foo/bar');
+    expect(nameAndTag.registry).toBe('quay.io');
+    expect(nameAndTag.registryURL).toBe('https://quay.io/v2');
+    expect(nameAndTag.tag).toBe('latest');
+    expect(nameAndTag.name).toBe('foo/bar');
+  });
+
+  test('ghcr.io image', () => {
+    const nameAndTag = imageRegistry.extractImageDataFromImageName(
+      'ghcr.io/redhat-developer/podman-desktop-sandbox-ext:latest',
+    );
+    expect(nameAndTag.registry).toBe('ghcr.io');
+    expect(nameAndTag.registryURL).toBe('https://ghcr.io/v2');
+    expect(nameAndTag.tag).toBe('latest');
+    expect(nameAndTag.name).toBe('redhat-developer/podman-desktop-sandbox-ext');
+  });
+
+  test('ghcr.io image with tag', () => {
+    const nameAndTag = imageRegistry.extractImageDataFromImageName(
+      'ghcr.io/redhat-developer/podman-desktop-sandbox-ext:myTag',
+    );
+    expect(nameAndTag.registry).toBe('ghcr.io');
+    expect(nameAndTag.registryURL).toBe('https://ghcr.io/v2');
+    expect(nameAndTag.tag).toBe('myTag');
+    expect(nameAndTag.name).toBe('redhat-developer/podman-desktop-sandbox-ext');
+  });
+
+  test('localhost image', () => {
+    const nameAndTag = imageRegistry.extractImageDataFromImageName('localhost/myimage');
+    expect(nameAndTag.registry).toBe('localhost');
+    expect(nameAndTag.registryURL).toBe('https://localhost/v2');
+    expect(nameAndTag.tag).toBe('latest');
+    expect(nameAndTag.name).toBe('myimage');
+  });
+
+  test('localhost custom port', () => {
+    const nameAndTag = imageRegistry.extractImageDataFromImageName('localhost:5000/myimage');
+    expect(nameAndTag.registry).toBe('localhost:5000');
+    expect(nameAndTag.registryURL).toBe('https://localhost:5000/v2');
+    expect(nameAndTag.tag).toBe('latest');
+    expect(nameAndTag.name).toBe('myimage');
+  });
+
+  test('invalid image protocol', () => {
+    expect(() => imageRegistry.extractImageDataFromImageName('https://ghcr.io/foo/bar')).toThrow(
+      'Invalid image name: https://ghcr.io/foo/bar',
+    );
+  });
+
+  test('invalid empty', async () => {
+    expect(() => imageRegistry.extractImageDataFromImageName('')).toThrow('Image name is empty');
+  });
+});
+
+test('expect getImageConfigLabels works', async () => {
+  // need to mock the http request
+  const spyGetAuthInfo = vi.spyOn(imageRegistry, 'getAuthInfo');
+  spyGetAuthInfo.mockResolvedValue({ authUrl: 'http://foobar', scheme: 'bearer' });
+
+  // need to mock the http request
+  const spyGetToken = vi.spyOn(imageRegistry, 'getToken');
+  spyGetToken.mockResolvedValue('12345');
+
+  // use nock to mock http responses
+
+  // multi-arch index
+  nock('https://my-podman-desktop-fake-registry.io')
+    .get('/v2/my/extension/manifests/latest')
+    .reply(200, imageRegistryManifestMultiArchJson);
+
+  // image index
+  nock('https://my-podman-desktop-fake-registry.io')
+    .get('/v2/my/extension/manifests/sha256:791352c5f8969387d576cae0586f24a12e716db584c117a15a6138812ddbaef0')
+    .reply(200, imageRegistryManifestJson);
+
+  // config blob
+  nock('https://my-podman-desktop-fake-registry.io')
+    .get('/v2/my/extension/blobs/sha256:2f65da9a67deadfb588660ad7da746c4facba696ea5cf8ab844b281f1c14bb01')
+    .reply(200, imageRegistryConfigJson);
+
+  const labels = await imageRegistry.getImageConfigLabels('my-podman-desktop-fake-registry.io/my/extension');
+  expect(labels).toBeDefined();
+  expect(labels['io.podman-desktop.api.version']).toBe('>= 0.12.0');
+  expect(labels['org.opencontainers.image.title']).toBe('OpenShift Local');
+  expect(labels['org.opencontainers.image.description']).toBe(
+    'Allows the ability to start and stop OpenShift Local and use Podman Desktop to interact with it',
+  );
+  expect(labels['org.opencontainers.image.vendor']).toBeDefined();
+});
+
+test('expect downloadAndExtractImage works', async () => {
+  // need to mock the http request
+  const spyGetAuthInfo = vi.spyOn(imageRegistry, 'getAuthInfo');
+  spyGetAuthInfo.mockResolvedValue({ authUrl: 'http://foobar', scheme: 'bearer' });
+
+  // need to mock the http request
+  const spyGetToken = vi.spyOn(imageRegistry, 'getToken');
+  spyGetToken.mockResolvedValue('12345');
+
+  // use nock to mock http responses
+
+  // multi-arch index
+  nock('https://my-podman-desktop-fake-registry.io')
+    .get('/v2/my/extension/manifests/latest')
+    .reply(200, imageRegistryManifestMultiArchJson);
+
+  // image index
+  nock('https://my-podman-desktop-fake-registry.io')
+    .get('/v2/my/extension/manifests/sha256:791352c5f8969387d576cae0586f24a12e716db584c117a15a6138812ddbaef0')
+    .reply(200, imageRegistryManifestJson);
+
+  // create a tar file with a package.json file inside
+  const tmpTarFolder = path.resolve(os.tmpdir(), 'tar-test-folder');
+
+  const tmpTar1Folder = path.resolve(tmpTarFolder, 'tar1');
+  const tmpTar1File = path.resolve(tmpTar1Folder, '1.tar.gz');
+
+  const tmpTar2Folder = path.resolve(tmpTarFolder, 'tar2');
+  const tmpTar2File = path.resolve(tmpTar2Folder, '2.tar.gz');
+  await fs.promises.mkdir(tmpTar1Folder, { recursive: true });
+  await fs.promises.mkdir(tmpTar2Folder, { recursive: true });
+
+  // write a package.json file inside tar1
+  const packageJson = path.resolve(tmpTar1Folder, 'package.json');
+  const packageJsonContent = JSON.stringify({ name: 'test-package' });
+  fs.writeFileSync(packageJson, packageJsonContent);
+  await nodeTar.create({ gzip: true, file: tmpTar1File, cwd: tmpTar1Folder }, ['package.json']);
+
+  // write a README.MD file inside tar2
+  const readmeMd = path.resolve(tmpTar2Folder, 'README.MD');
+  const readmeMdContent = '# Test Readme';
+  fs.writeFileSync(readmeMd, readmeMdContent);
+  await nodeTar.create({ gzip: true, file: tmpTar2File, cwd: tmpTar2Folder }, ['README.MD']);
+
+  const readTarFile1 = () => {
+    return fs.readFileSync(tmpTar1File);
+  };
+  const readTarFile2 = () => {
+    return fs.readFileSync(tmpTar2File);
+  };
+
+  nock('https://my-podman-desktop-fake-registry.io')
+    .get('/v2/my/extension/blobs/sha256:ec4d84bbb887a9dba10a4551252dde152bbb42e3b02e501b44218c9c5425eac4')
+    .reply(200, readTarFile1(), {
+      'content-type': 'application/octet-stream',
+      'content-disposition': 'attachment; filename=reply_file_2.tar.gz',
+    });
+
+  nock('https://my-podman-desktop-fake-registry.io')
+    .get('/v2/my/extension/blobs/sha256:dc0c1d0e36ea3e0b94af099c9b96012743ae22e1797eaff3308895335513d454')
+    .reply(200, readTarFile2(), {
+      'content-type': 'application/octet-stream',
+      'content-disposition': 'attachment; filename=reply_file_2.tar.gz',
+    });
+
+  const destFolder = path.resolve(os.tmpdir(), 'test-folder');
+  const logFn = vi.fn();
+  try {
+    await imageRegistry.downloadAndExtractImage('my-podman-desktop-fake-registry.io/my/extension', destFolder, logFn);
+
+    // check that the folder exists and files are there
+    const existFolder = fs.existsSync(destFolder);
+    expect(existFolder).toBeTruthy();
+
+    // check that the package.json file exists
+    const existPackageJson = fs.existsSync(path.resolve(destFolder, 'package.json'));
+    expect(existPackageJson).toBeTruthy();
+
+    // check the content
+    const packageJsonContent = fs.readFileSync(path.resolve(destFolder, 'package.json'), 'utf8');
+    expect(packageJsonContent).toBe(packageJsonContent);
+
+    // check that the README.MD file exists
+    const existReadmeMd = fs.existsSync(path.resolve(destFolder, 'README.MD'));
+    expect(existReadmeMd).toBeTruthy();
+
+    // check the content
+    const readmeMdContent = fs.readFileSync(path.resolve(destFolder, 'README.MD'), 'utf8');
+    expect(readmeMdContent).toBe(readmeMdContent);
+
+    // expect some traces in the logger
+    expect(logFn).toHaveBeenCalled();
+  } finally {
+    // remove the folders
+    await fs.promises.rm(tmpTarFolder, { recursive: true });
+    await fs.promises.rm(destFolder, { recursive: true });
+  }
 });

--- a/packages/main/tests/resources/data/plugin/image-registry-config.json
+++ b/packages/main/tests/resources/data/plugin/image-registry-config.json
@@ -1,0 +1,60 @@
+{
+  "architecture": "arm64",
+  "config": {
+    "Env": ["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"],
+    "WorkingDir": "/",
+    "Labels": {
+      "io.podman-desktop.api.version": "\u003e= 0.12.0",
+      "org.opencontainers.image.description": "Allows the ability to start and stop OpenShift Local and use Podman Desktop to interact with it",
+      "org.opencontainers.image.title": "OpenShift Local",
+      "org.opencontainers.image.vendor": "podman-desktop"
+    },
+    "OnBuild": null
+  },
+  "created": "2023-04-27T06:11:21.889865612Z",
+  "history": [
+    {
+      "created": "2023-04-27T06:11:21.77240614Z",
+      "created_by": "LABEL org.opencontainers.image.title=OpenShift Local org.opencontainers.image.description=Allows the ability to start and stop OpenShift Local and use Podman Desktop to interact with it org.opencontainers.image.vendor=podman-desktop io.podman-desktop.api.version=\u003e= 0.12.0",
+      "comment": "buildkit.dockerfile.v0",
+      "empty_layer": true
+    },
+    {
+      "created": "2023-04-27T06:11:21.77240614Z",
+      "created_by": "COPY package.json /extension/ # buildkit",
+      "comment": "buildkit.dockerfile.v0"
+    },
+    {
+      "created": "2023-04-27T06:11:21.826017957Z",
+      "created_by": "COPY LICENSE /extension/ # buildkit",
+      "comment": "buildkit.dockerfile.v0"
+    },
+    {
+      "created": "2023-04-27T06:11:21.84190407Z",
+      "created_by": "COPY README.md /extension/ # buildkit",
+      "comment": "buildkit.dockerfile.v0"
+    },
+    {
+      "created": "2023-04-27T06:11:21.865956692Z",
+      "created_by": "COPY icon.png /extension/ # buildkit",
+      "comment": "buildkit.dockerfile.v0"
+    },
+    {
+      "created": "2023-04-27T06:11:21.889865612Z",
+      "created_by": "COPY dist /extension/dist # buildkit",
+      "comment": "buildkit.dockerfile.v0"
+    }
+  ],
+  "moby.buildkit.buildinfo.v1": "eyJmcm9udGVuZCI6ImRvY2tlcmZpbGUudjAifQ==",
+  "os": "linux",
+  "rootfs": {
+    "type": "layers",
+    "diff_ids": [
+      "sha256:e0b17f06c57c628aa7fee5129869f2036e4025e9f1a579e15652c1145a9869ef",
+      "sha256:f8d5ae6d33ae486fa5c13001a5d1e597c9fa2bc98933db0ae3885dfdc8f8e569",
+      "sha256:b977fadbae132aea8aabdb6410912f2df3103cc9edd3774b69456768c256f129",
+      "sha256:e96a01dd861180049e258943e53c3d31b6e5346817c4d5f14e16b27527d7fd80",
+      "sha256:06ff59acf251c6321a61811923365976d0785a645b0e081f7f4c1b2b9dc44a68"
+    ]
+  }
+}

--- a/packages/main/tests/resources/data/plugin/image-registry-manifest-index.json
+++ b/packages/main/tests/resources/data/plugin/image-registry-manifest-index.json
@@ -1,0 +1,21 @@
+{
+  "mediaType": "application/vnd.oci.image.manifest.v1+json",
+  "schemaVersion": 2,
+  "config": {
+    "mediaType": "application/vnd.oci.image.config.v1+json",
+    "digest": "sha256:2f65da9a67deadfb588660ad7da746c4facba696ea5cf8ab844b281f1c14bb01",
+    "size": 2045
+  },
+  "layers": [
+    {
+      "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+      "digest": "sha256:ec4d84bbb887a9dba10a4551252dde152bbb42e3b02e501b44218c9c5425eac4",
+      "size": 1188
+    },
+    {
+      "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+      "digest": "sha256:dc0c1d0e36ea3e0b94af099c9b96012743ae22e1797eaff3308895335513d454",
+      "size": 4070
+    }
+  ]
+}

--- a/packages/main/tests/resources/data/plugin/image-registry-manifest-multi-arch-index.json
+++ b/packages/main/tests/resources/data/plugin/image-registry-manifest-multi-arch-index.json
@@ -1,0 +1,25 @@
+{
+  "//": "Fake digest with both amd64 and arm64 being the same digest",
+  "mediaType": "application/vnd.oci.image.index.v1+json",
+  "schemaVersion": 2,
+  "manifests": [
+    {
+      "mediaType": "application/vnd.oci.image.manifest.v1+json",
+      "digest": "sha256:791352c5f8969387d576cae0586f24a12e716db584c117a15a6138812ddbaef0",
+      "size": 1236,
+      "platform": {
+        "architecture": "amd64",
+        "os": "linux"
+      }
+    },
+    {
+      "mediaType": "application/vnd.oci.image.manifest.v1+json",
+      "digest": "sha256:791352c5f8969387d576cae0586f24a12e716db584c117a15a6138812ddbaef0",
+      "size": 1236,
+      "platform": {
+        "architecture": "arm64",
+        "os": "linux"
+      }
+    }
+  ]
+}

--- a/packages/main/tsconfig.json
+++ b/packages/main/tsconfig.json
@@ -6,6 +6,7 @@
     "moduleResolution": "Node",
     "skipLibCheck": true,
     "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true,
     "strict": true,
     "isolatedModules": true,
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3463,6 +3463,14 @@
   dependencies:
     "@types/node" "*"
 
+"@types/tar@^6.1.4":
+  version "6.1.4"
+  resolved "https://registry.yarnpkg.com/@types/tar/-/tar-6.1.4.tgz#cf8497e1ebdc09212fd51625cd2eb5ca18365ad1"
+  integrity sha512-Cp4oxpfIzWt7mr2pbhHT2OTXGMAL0szYCzuf8lRWyIMCgsx6/Hfc3ubztuhvzXHXgraTQxyOCmmg7TDGIMIJJQ==
+  dependencies:
+    "@types/node" "*"
+    minipass "^4.0.0"
+
 "@types/testing-library__jest-dom@^5.9.1":
   version "5.14.5"
   resolved "https://registry.yarnpkg.com/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.14.5.tgz#d113709c90b3c75fdb127ec338dad7d5f86c974f"
@@ -9153,6 +9161,11 @@ minipass@^3.0.0:
   dependencies:
     yallist "^4.0.0"
 
+minipass@^4.0.0:
+  version "4.2.8"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-4.2.8.tgz#f0010f64393ecfc1d1ccb5f582bcaf45f48e1a3a"
+  integrity sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==
+
 minizlib@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-2.1.2.tgz#e90d3466ba209b932451508a11ce3d3632145931"
@@ -9297,6 +9310,16 @@ no-case@^3.0.4:
   dependencies:
     lower-case "^2.0.2"
     tslib "^2.0.3"
+
+nock@^13.3.1:
+  version "13.3.1"
+  resolved "https://registry.yarnpkg.com/nock/-/nock-13.3.1.tgz#f22d4d661f7a05ebd9368edae1b5dc0a62d758fc"
+  integrity sha512-vHnopocZuI93p2ccivFyGuUfzjq2fxNyNurp7816mlT5V5HF4SzXu8lvLrVzBbNqzs+ODooZ6OksuSUNM7Njkw==
+  dependencies:
+    debug "^4.1.0"
+    json-stringify-safe "^5.0.1"
+    lodash "^4.17.21"
+    propagate "^2.0.0"
 
 node-addon-api@^1.6.3:
   version "1.7.2"
@@ -10295,6 +10318,11 @@ prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
     loose-envify "^1.4.0"
     object-assign "^4.1.1"
     react-is "^16.13.1"
+
+propagate@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/propagate/-/propagate-2.0.1.tgz#40cdedab18085c792334e64f0ac17256d38f9a45"
+  integrity sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==
 
 property-information@^5.0.0, property-information@^5.3.0:
   version "5.6.0"
@@ -11951,6 +11979,18 @@ tar@^6.1.11:
     chownr "^2.0.0"
     fs-minipass "^2.0.0"
     minipass "^3.0.0"
+    minizlib "^2.1.1"
+    mkdirp "^1.0.3"
+    yallist "^4.0.0"
+
+tar@^6.1.13:
+  version "6.1.13"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.13.tgz#46e22529000f612180601a6fe0680e7da508847b"
+  integrity sha512-jdIBIN6LTIe2jqzay/2vtYLlBHa3JF42ot3h1dW8Q0PaAG4v8rm0cvpVePtau5C6OKXGGcgO9q2AMNSWxiLqKw==
+  dependencies:
+    chownr "^2.0.0"
+    fs-minipass "^2.0.0"
+    minipass "^4.0.0"
     minizlib "^2.1.1"
     mkdirp "^1.0.3"
     yallist "^4.0.0"


### PR DESCRIPTION
### What does this PR do?

Extensions are stored as images on OCI registry. But we may not have a container engine running.
As we were already handling certificates and auth on registries , I added methods to grab the configuration (for labels) and layers (for image content)
On macOS/Windows it may be even be faster to download/extract as it is not done within a VM

it is related to https://github.com/containers/podman-desktop/issues/2200

It will avoid chicken and egg problem when we use these methods

Introduce nock library for http mocking and tar library for tar/gzip support to unpack OCI layers


### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?

Related to #2200 

### How to test this PR?

Unit tests added
Another PR will use these methods


Change-Id: If317c5670252422e37d7b3008d177e956eed6ef6
