### PR TITLE
feat: Do not use any container engine to pull Podman Desktop extension images

### DIFF
--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1457,7 +1457,7 @@ export class PluginSystem {
     const dockerExtensionAdapter = new DockerPluginAdapter(contributionManager);
     dockerExtensionAdapter.init();
 
-    const extensionInstaller = new ExtensionInstaller(apiSender, containerProviderRegistry, this.extensionLoader);
+    const extensionInstaller = new ExtensionInstaller(apiSender, this.extensionLoader, imageRegistry);
     await extensionInstaller.init();
 
     await contributionManager.init();

--- a/packages/main/src/plugin/install/extension-installer.ts
+++ b/packages/main/src/plugin/install/extension-installer.ts
@@ -18,22 +18,20 @@
 
 import type { IpcMainEvent } from 'electron';
 import { ipcMain } from 'electron';
-import type { ContainerProviderRegistry } from '../container-registry';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
 import { cp } from 'node:fs/promises';
 import * as tarFs from 'tar-fs';
-import type Dockerode from 'dockerode';
-import type { PullEvent } from '../api/pull-event';
 import type { ExtensionLoader } from '../extension-loader';
 import type { ApiSenderType } from '../api';
+import type { ImageRegistry } from '../image-registry';
 
 export class ExtensionInstaller {
   constructor(
     private apiSender: ApiSenderType,
-    private containerRegistry: ContainerProviderRegistry,
     private extensionLoader: ExtensionLoader,
+    private imageRegistry: ImageRegistry,
   ) {}
 
   async extractExtensionFiles(tmpFolderPath: string, finalFolderPath: string, reportLog: (message: string) => void) {
@@ -94,33 +92,6 @@ export class ExtensionInstaller {
     });
   }
 
-  async exportContentOfContainer(providerConnection: Dockerode, imageId: string, tmpTarPath: string): Promise<void> {
-    // export the content of the image
-    const containerFromImage = await providerConnection.createContainer({ Image: imageId, Entrypoint: ['/bin/sh'] });
-    const exportResult = await containerFromImage.export();
-
-    const fileWriteStream = fs.createWriteStream(tmpTarPath, {
-      flags: 'w',
-    });
-
-    return new Promise<void>((resolve, reject) => {
-      exportResult.on('close', () => {
-        fileWriteStream.close();
-
-        // ok we can remove the container
-        containerFromImage.remove().then(() => resolve(undefined));
-      });
-
-      exportResult.on('data', chunk => {
-        fileWriteStream.write(chunk);
-      });
-
-      exportResult.on('error', error => {
-        reject(error);
-      });
-    });
-  }
-
   async init(): Promise<void> {
     ipcMain.on(
       'extension-installer:install-from-image',
@@ -129,76 +100,33 @@ export class ExtensionInstaller {
           event.reply('extension-installer:install-from-image-log', logCallbackId, message);
         };
 
-        // use first working connection
-        let providerConnectionDetails;
+        imageName = imageName.trim();
+        reportLog(`Analyzing image ${imageName}...`);
+        let imageConfigLabels;
         try {
-          providerConnectionDetails = this.containerRegistry.getFirstRunningConnection();
+          imageConfigLabels = await this.imageRegistry.getImageConfigLabels(imageName);
         } catch (error) {
           event.reply(
             'extension-installer:install-from-image-error',
             logCallbackId,
-            'No provider is running. Please start a provider.',
+            'Error while analyzing image: ' + error,
           );
           return;
         }
 
-        const providerConnectionInfo = providerConnectionDetails[0];
-        const providerConnection = providerConnectionDetails[1];
-        reportLog(`Pulling image ${imageName}...`);
-
-        try {
-          await this.containerRegistry.pullImage(providerConnectionInfo, imageName, (pullEvent: PullEvent) => {
-            if (pullEvent.progress || pullEvent.progressDetail) {
-              console.log(pullEvent.progress);
-            } else if (pullEvent.status) {
-              reportLog(pullEvent.status);
-            }
-          });
-        } catch (error) {
+        if (!imageConfigLabels) {
           event.reply(
             'extension-installer:install-from-image-error',
             logCallbackId,
-            'Error while pulling image: ' + error,
+            `Image ${imageName} is not a Podman Desktop Extension. Unable to grab image config labels.`,
           );
           return;
         }
 
-        // ok search the image
-        const images = await providerConnection.listImages();
-        const foundMatchingImage = images.find(image =>
-          image.RepoTags?.find(tag => tag.includes(imageName) || imageName.includes(tag)),
-        );
-
-        if (!foundMatchingImage) {
-          event.reply(
-            'extension-installer:install-from-image-error',
-            logCallbackId,
-            `Not able to pull image ${imageName}`,
-          );
-          return;
-        }
-
-        // get the image information
-        const image = await providerConnection.getImage(foundMatchingImage.Id);
-        reportLog('Check if image is a Podman Desktop Extension...');
-
-        // analyze the image
-        const imageAnalysis = await image.inspect();
-
-        // check if it's a Podman Desktop Extension
-        const labels = imageAnalysis.Config.Labels;
-        if (!labels) {
-          event.reply(
-            'extension-installer:install-from-image-error',
-            logCallbackId,
-            `Image ${imageName} is not a Podman Desktop Extension`,
-          );
-          return;
-        }
-        const titleLabel = labels['org.opencontainers.image.title'];
-        const descriptionLabel = labels['org.opencontainers.image.description'];
-        const vendorLabel = labels['org.opencontainers.image.vendor'];
-        const apiVersion = labels['io.podman-desktop.api.version'];
+        const titleLabel = imageConfigLabels['org.opencontainers.image.title'];
+        const descriptionLabel = imageConfigLabels['org.opencontainers.image.description'];
+        const vendorLabel = imageConfigLabels['org.opencontainers.image.vendor'];
+        const apiVersion = imageConfigLabels['io.podman-desktop.api.version'];
 
         if (!titleLabel || !descriptionLabel || !vendorLabel || !apiVersion) {
           event.reply(
@@ -223,9 +151,6 @@ export class ExtensionInstaller {
         // tmp folder
         const tmpFolderPath = path.join(os.tmpdir(), `/tmp/${imageNameWithoutSpecialChars}-tmp`);
 
-        // tmp tar file
-        const tmpTarPath = path.join(os.tmpdir(), `${imageNameWithoutSpecialChars}-tmp.tar`);
-
         // final folder
         const finalFolderPath = path.join(this.extensionLoader.getPluginsDirectory(), imageNameWithoutSpecialChars);
 
@@ -244,22 +169,10 @@ export class ExtensionInstaller {
           return;
         }
 
-        reportLog('Grabbing image content...');
-        await this.exportContentOfContainer(providerConnection, foundMatchingImage.Id, tmpTarPath);
-
-        // delete image
-        await image.remove();
-
-        reportLog('Extracting image content...');
-        try {
-          await this.unpackTarFile(tmpTarPath, tmpFolderPath);
-        } finally {
-          // delete the tmp tar file
-          fs.unlinkSync(tmpTarPath);
-        }
+        reportLog('Downloading and extract layers...');
+        await this.imageRegistry.downloadAndExtractImage(imageName, tmpFolderPath, reportLog);
 
         event.reply('extension-installer:install-from-image-log', logCallbackId, 'Filtering image content...');
-
         await this.extractExtensionFiles(tmpFolderPath, finalFolderPath, reportLog);
 
         // refresh contributions


### PR DESCRIPTION
Depends on
- [x] : https://github.com/containers/podman-desktop/pull/2272

### What does this PR do?
Do not use any container engine to pull Podman Desktop extension images

### Screenshot/screencast of this PR


N/A
### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/2200

### How to test this PR?

It requires https://github.com/containers/podman-desktop/pull/2272
Then, by having all container engines being shut down, try to pull images of extensions
it should work as before



Change-Id: Id56077edb7c4296b9188295e90c8a11702b6af35
