### PR TITLE
feat(renderer): Allow to grab version from renderer part

### DIFF
--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1436,6 +1436,10 @@ export class PluginSystem {
       return telemetry.configureTelemetry();
     });
 
+    this.ipcHandle('app:getVersion', async (): Promise<string> => {
+      return app.getVersion();
+    });
+
     const dockerDesktopInstallation = new DockerDesktopInstallation(
       apiSender,
       containerProviderRegistry,

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -1282,6 +1282,10 @@ function initExposure(): void {
       resolveCallback();
     }
   });
+
+  contextBridge.exposeInMainWorld('getPodmanDesktopVersion', async (): Promise<string> => {
+    return ipcInvoke('app:getVersion');
+  });
 }
 
 // expose methods


### PR DESCRIPTION

### What does this PR do?
 Allow to grab version from renderer part
Podman Desktop version can be used by svelte widgets

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

N/A

### How to test this PR?

<!-- Please explain steps to reproduce -->

Change-Id: If8b6054075d676955bcb4f77e2774b7c786f8f3e
