### PR TITLE
chore: Remove yellow and add amber to palette

### DIFF
--- a/packages/renderer/src/lib/images/StatusIcon.svelte
+++ b/packages/renderer/src/lib/images/StatusIcon.svelte
@@ -15,7 +15,7 @@ $: solid = status === 'RUNNING' || status === 'STARTING' || status === 'USED' ||
     class="grid place-content-center w-7 h-7 rounded"
     class:bg-green-400="{status === 'RUNNING' || status === 'USED'}"
     class:bg-green-600="{status === 'STARTING'}"
-    class:bg-yellow-600="{status === 'DEGRADED'}"
+    class:bg-amber-600="{status === 'DEGRADED'}"
     class:border-2="{!solid}"
     class:border-gray-700="{!solid}"
     class:text-gray-700="{!solid}"

--- a/packages/renderer/src/lib/pod/DeployPodToKube.svelte
+++ b/packages/renderer/src/lib/pod/DeployPodToKube.svelte
@@ -355,9 +355,9 @@ function updateKubeResult() {
                       <span class="text-red-500">(Terminated)</span>
                     {/if}
                     {#if containerStatus.state?.waiting}
-                      <span class="text-yellow-500">(Waiting)</span>
+                      <span class="text-amber-500">(Waiting)</span>
                       {#if containerStatus.state.waiting.reason}
-                        <span class="text-yellow-500">[{containerStatus.state.waiting.reason}]</span>
+                        <span class="text-amber-500">[{containerStatus.state.waiting.reason}]</span>
                       {/if}
                     {/if}
                   </li>

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -126,6 +126,18 @@ module.exports = {
         800: '#9f2f15',
         900: '#842c18',
       },
+      'amber': {
+         50: tailwindColors.amber[50],
+        100: tailwindColors.amber[100],
+        200: tailwindColors.amber[200],
+        300: tailwindColors.amber[300],
+        400: tailwindColors.amber[400],
+        500: tailwindColors.amber[500],
+        600: tailwindColors.amber[600],
+        700: tailwindColors.amber[700],
+        800: tailwindColors.amber[800],
+        900: tailwindColors.amber[900],
+      },
       transparent: 'transparent',
       black: '#000',
       white: '#fff',
@@ -147,10 +159,6 @@ module.exports = {
       },
       'neutral': {
         900: tailwindColors.neutral[900],
-      },
-      'yellow': {
-        500: tailwindColors.yellow[500],
-        600: tailwindColors.yellow[600],
       },
       'blue': {
         500: tailwindColors.blue[500],


### PR DESCRIPTION
### What does this PR do?

Discussed with Mairin when we needed a warning color elsewhere - this removes the legacy yellow color and adds the full Tailwind amber color to our palette. No visual change, just palette cleanup/improvement.

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Confirm degraded pods and 'waiting' status while deploying to Kube haven't visually changed colors.