### PR TITLE
fix: Remove extra margin from resource creation

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationRendering.svelte
@@ -352,8 +352,8 @@ async function close() {
       <div class="p-3 mt-4 w-4/5 {creationInProgress ? 'opacity-40 pointer-events-none' : ''}">
         <form novalidate class="pf-c-form p-2" on:submit|preventDefault="{handleOnSubmit}">
           {#each configurationKeys as configurationKey}
-            <div class="mb-3">
-              <div class="font-semibold text-xs mb-2">
+            <div class="mb-2.5">
+              <div class="font-semibold text-xs">
                 {#if configurationKey.description}
                   {configurationKey.description}:
                 {:else if configurationKey.markdownDescription && configurationKey.type !== 'markdown'}

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
@@ -234,7 +234,7 @@ function handleCleanValue(
         value="{record.default}"
         aria-label="{record.description}"
         on:input="{event => handleRangeValue(record.id, event.currentTarget)}"
-        class="w-full h-1 bg-[var(--pf-global--primary-color--300)] rounded-lg appearance-none accent-[var(--pf-global--primary-color--300)] cursor-pointer range-xs" />
+        class="w-full h-1 bg-[var(--pf-global--primary-color--300)] rounded-lg appearance-none accent-[var(--pf-global--primary-color--300)] cursor-pointer range-xs mt-2" />
     {:else if record.type === 'number'}
       <div
         class="flex flex-row rounded-sm bg-zinc-700 text-sm divide-x divide-zinc-900 w-24 border-b border-violet-500">


### PR DESCRIPTION
### What does this PR do?

There is an extra margin between the labels and fields on the resource creation pages, and this removes it. I also made the padding between properties just slightly smaller. This is enough to make the entire page just a little shorter and fix issue #2271.

This made it obvious that sliders (e.g. for Podman CPU creation) were missing a top margin, so I added that.

### Screenshot/screencast of this PR

Before:
<img width="679" alt="Screenshot 2023-05-01 at 3 16 41 PM" src="https://user-images.githubusercontent.com/19958075/235514139-17fc70eb-58fc-4f48-ba60-49f37fd7dba1.png">

After:
<img width="679" alt="Screenshot 2023-05-01 at 3 16 06 PM" src="https://user-images.githubusercontent.com/19958075/235514113-ef407754-475a-4e91-aff6-422cda51646b.png">

### What issues does this PR fix or reference?

Fixes #2271.

### How to test this PR?

Open the pages to create a Podman machine and Kind cluster and confirm they still visually look good.