### PR TITLE
fix: Improve look of dialog/message box

### DIFF
--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -12,6 +12,7 @@
   "devDependencies": {
     "@fortawesome/free-brands-svg-icons": "^6.4.0",
     "@fortawesome/free-solid-svg-icons": "^6.4.0",
+    "@fortawesome/free-regular-svg-icons": "^6.4.0",
     "@patternfly/patternfly": "^4.224.2",
     "@sveltejs/vite-plugin-svelte": "^2.1.1",
     "@testing-library/jest-dom": "^5.16.5",

--- a/packages/renderer/src/lib/dialogs/MessageBox.svelte
+++ b/packages/renderer/src/lib/dialogs/MessageBox.svelte
@@ -1,12 +1,8 @@
 <script lang="ts">
 import { onDestroy, onMount, tick } from 'svelte';
 import Fa from 'svelte-fa/src/fa.svelte';
-import {
-  faCircleExclamation,
-  faTriangleExclamation,
-  faCircleInfo,
-  faCircleQuestion,
-} from '@fortawesome/free-solid-svg-icons';
+import { faCircleQuestion, faCircle } from '@fortawesome/free-regular-svg-icons';
+import { faCircleExclamation, faInfo, faTriangleExclamation } from '@fortawesome/free-solid-svg-icons';
 import type { MessageBoxOptions } from './messagebox-input';
 
 let currentId = 0;
@@ -114,32 +110,37 @@ function handleKeydown(e: KeyboardEvent) {
 
 {#if display}
   <!-- Create overlay-->
-  <div class="fixed top-0 left-0 right-0 bottom-0 bg-black bg-opacity-60 h-full grid z-50">
-    <div class="flex flex-col place-self-center w-[550px] rounded-xl bg-zinc-900 shadow-xl shadow-black">
-      <div class="flex items-center justify-between px-6 py-5 space-x-2">
+  <div class="fixed top-0 left-0 right-0 bottom-0 bg-black bg-opacity-60 bg-blend-multiply h-full grid z-50">
+    <div class="flex flex-col place-self-center w-[550px] rounded-xl bg-charcoal-800 shadow-xl shadow-black">
+      <div class="flex items-center justify-between pl-4 pr-3 py-3 space-x-2 text-gray-400">
         {#if type === 'error'}
-          <Fa class="h-4 w-4" icon="{faCircleExclamation}" />
+          <Fa class="h-4 w-4 text-red-500" icon="{faCircleExclamation}" />
         {:else if type === 'warning'}
-          <Fa class="h-4 w-4" icon="{faTriangleExclamation}" />
+          <Fa class="h-4 w-4 text-amber-400" icon="{faTriangleExclamation}" />
         {:else if type === 'info'}
-          <Fa class="h-4 w-4" icon="{faCircleInfo}" />
+          <div class="flex">
+            <Fa class="h-4 w-4 place-content-center" icon="{faCircle}" />
+            <Fa class="h-4 w-4 place-content-center -ml-4 mt-px text-xs" icon="{faInfo}" />
+          </div>
         {:else if type === 'question'}
           <Fa class="h-4 w-4" icon="{faCircleQuestion}" />
         {/if}
         <h1 class="grow text-lg font-bold capitalize">{title}</h1>
 
-        <button class="hover:text-gray-300 py-1" on:click="{() => clickButton(cancelId >= 0 ? cancelId : undefined)}">
+        <button
+          class="p-2 hover:text-gray-300 hover:bg-charcoal-500 rounded-full cursor-pointer"
+          on:click="{() => clickButton(cancelId >= 0 ? cancelId : undefined)}">
           <i class="fas fa-times" aria-hidden="true"></i>
         </button>
       </div>
 
-      <div class="px-10 py-4 text-sm leading-5">{message}</div>
+      <div class="px-10 py-4 text-sm text-gray-500 leading-5">{message}</div>
 
       {#if detail}
-        <div class="px-10 pb-4 text-sm leading-5">{detail}</div>
+        <div class="px-10 pb-4 text-sm text-gray-500 leading-5">{detail}</div>
       {/if}
 
-      <div class="px-6 py-5 mt-2 flex flex-row w-full justify-end space-x-5">
+      <div class="px-5 py-5 mt-2 flex flex-row w-full justify-end space-x-5">
         {#each buttonOrder as i}
           {#if i == cancelId}
             <button aria-label="Cancel" class="text-xs hover:underline" on:click="{() => clickButton(i)}"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2109,6 +2109,13 @@
   dependencies:
     "@fortawesome/fontawesome-common-types" "6.4.0"
 
+"@fortawesome/free-regular-svg-icons@^6.4.0":
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-6.4.0.tgz#cacc53bd8d832d46feead412d9ea9ce80a55e13a"
+  integrity sha512-ZfycI7D0KWPZtf7wtMFnQxs8qjBXArRzczABuMQqecA/nXohquJ5J/RCR77PmY5qGWkxAZDxpnUFVXKwtY/jPw==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "6.4.0"
+
 "@fortawesome/free-solid-svg-icons@^6.4.0":
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.4.0.tgz#48c0e790847fa56299e2f26b82b39663b8ad7119"


### PR DESCRIPTION
### What does this PR do?

This adds a bunch of subtle changes, primarily in response to issue #2241:
- Outer padding reduced to make it look more like a native dialog than webapp.
- Missing close button hover added, using a circle to match our other action buttons.
- Text reduced from white to gray-400/500.
- Switched from filled to outline icons for info & warning to match elsewhere and draw less attention. Added dependency on fort-awesome to pick up regular (non-solid) icons, but since there is still no outlined circle-info so we need to build our own. It's not perfect, but as good as I could get it.
- In order to draw more attention to warning and error dialogs, color was added.
- Minor changes to palette colors and background blend based on chat with Mairin.

Depends on changes in PR #2281.

### Screenshot/screencast of this PR

Before:
<img width="555" alt="Screenshot 2023-05-01 at 1 45 47 PM" src="https://user-images.githubusercontent.com/19958075/235519541-6713f772-3aa6-449b-a877-3d0f5b524d09.png">

After:
<img width="556" alt="Screenshot 2023-05-01 at 3 38 28 PM" src="https://user-images.githubusercontent.com/19958075/235519561-66e5388b-e29b-4a5c-acca-e6b02bb52921.png">

Prior icons:
<img width="106" alt="Screenshot 2023-04-28 at 10 52 56 AM" src="https://user-images.githubusercontent.com/19958075/235519515-e3f9f465-2444-4b6f-84b2-12570fc16cbc.png">

New icons:
<img width="104" alt="Screenshot 2023-05-01 at 3 24 51 PM" src="https://user-images.githubusercontent.com/19958075/235519467-982e5656-44f6-4f65-8c52-71899f583c3b.png">

### What issues does this PR fix or reference?
Fix for most of the problems in issue #2241.

### How to test this PR?
Open a few dialogs, e.g. docker compose, Kind install, or version/update.