### PR TITLE
feat: handle 'configured' provider state in tray menu

### DIFF
--- a/packages/main/src/tray-menu.spec.ts
+++ b/packages/main/src/tray-menu.spec.ts
@@ -17,12 +17,14 @@
  ***********************************************************************/
 
 import type { MenuItemConstructorOptions, Tray } from 'electron';
+import { nativeImage } from 'electron';
 import { Menu } from 'electron';
 import { ipcMain } from 'electron';
 import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
 import type { ProviderInfo } from './plugin/api/provider-info';
 import type { AnimatedTray } from './tray-animate-icon';
 import { TrayMenu } from './tray-menu';
+import statusStopped from './assets/status-stopped.png';
 
 let trayMenu: TrayMenu;
 let tray;
@@ -108,4 +110,40 @@ test('Tray update provider not delete provider items', () => {
       it => it.label === 'SomeLabel',
     ),
   ).to.be.not.empty;
+});
+
+test('Tray provider configured state same as stopped', () => {
+  const menuBuild = vi.spyOn(Menu, 'buildFromTemplate');
+
+  trayMenu = new TrayMenu(tray, animatedTray);
+
+  trayMenu.addProviderItems({
+    id: 'testId',
+    name: 'TestProv',
+    internalId: 'internalId',
+    status: 'configured',
+  } as ProviderInfo);
+
+  expect((menuBuild.mock.lastCall?.[0][0] as MenuItemConstructorOptions).icon).eql(
+    nativeImage.createFromDataURL(statusStopped),
+  );
+});
+
+test('Tray provider start enabled when configured state', () => {
+  const menuBuild = vi.spyOn(Menu, 'buildFromTemplate');
+
+  trayMenu = new TrayMenu(tray, animatedTray);
+
+  trayMenu.addProviderItems({
+    id: 'testId',
+    name: 'TestProv',
+    internalId: 'internalId',
+    status: 'configured',
+  } as ProviderInfo);
+
+  const startItem = (menuBuild.mock.lastCall?.[0][0].submenu as Array<MenuItemConstructorOptions>)?.find(
+    it => it.label === 'Start',
+  );
+  expect(startItem).to.be.not.undefined;
+  expect(startItem?.enabled).to.be.true;
 });

--- a/packages/main/src/tray-menu.ts
+++ b/packages/main/src/tray-menu.ts
@@ -293,7 +293,7 @@ export class TrayMenu {
 
     (result.submenu as MenuItemConstructorOptions[]).push({
       label: 'Start',
-      enabled: item.status === 'stopped',
+      enabled: item.status === 'stopped' || item.status === 'configured',
       click: () => {
         this.sendItemClick({ action: 'Start', providerInfo: item });
       },
@@ -370,6 +370,7 @@ export class TrayMenu {
       case 'started':
         image = statusStarted;
         break;
+      case 'configured':
       case 'stopped':
         image = statusStopped;
         break;


### PR DESCRIPTION
### What does this PR do?
PR handle `configured` provider state in tray menu, similar to dashboard, if provider has `configured` state, tray item will have `stopped` icon and `start` submenu item will be enabled, which allow to start provider with `configured` state from tray menu. Otherwise starting of such provider possible only from dashboard.

### Screenshot/screencast of this PR

Before PR:
<img width="1052" alt="Screenshot 2023-05-02 at 16 55 35" src="https://user-images.githubusercontent.com/929743/235687943-95f82c4c-8da7-439e-bf29-e2a903555357.png">

With PR:
<img width="1052" alt="Screenshot 2023-05-02 at 16 54 01" src="https://user-images.githubusercontent.com/929743/235687522-03e1609f-a9df-47ff-b6d4-5ad59830aa28.png">

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?
Part of https://github.com/crc-org/crc-extension/issues/64
<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

### How to test this PR?
Add new provider, set it state as `configured`, ensure that tray menu item for your provider has stopped icon(grey circle) and `start` submenu item is enabled.
<!-- Please explain steps to reproduce -->
