### PR TITLE
fix: Kind clusters not cleaned up when stopping podman machine

### DIFF
--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -176,7 +176,6 @@ export class ContainerProviderRegistry {
     providerRegistry.onBeforeDidUpdateContainerConnection(event => {
       if (event.providerId === provider.id && event.connection.name === containerProviderConnection.name) {
         const newStatus = event.status;
-        console.log(` New status ${newStatus}`);
         if (newStatus === 'stopped') {
           internalProvider.api = undefined;
           internalProvider.libpodApi = undefined;

--- a/packages/main/src/plugin/provider-impl.ts
+++ b/packages/main/src/plugin/provider-impl.ts
@@ -210,7 +210,11 @@ export class ProviderImpl implements Provider, IDisposable {
 
   registerContainerProviderConnection(containerProviderConnection: ContainerProviderConnection): Disposable {
     this.containerProviderConnections.add(containerProviderConnection);
-    const disposable = this.containerRegistry.registerContainerConnection(this, containerProviderConnection);
+    const disposable = this.containerRegistry.registerContainerConnection(
+      this,
+      containerProviderConnection,
+      this.providerRegistry,
+    );
     this.providerRegistry.onDidRegisterContainerConnectionCallback(this, containerProviderConnection);
 
     return Disposable.create(() => {

--- a/packages/main/src/plugin/provider-registry.spec.ts
+++ b/packages/main/src/plugin/provider-registry.spec.ts
@@ -206,6 +206,13 @@ test('should send events when starting a container connection', async () => {
     },
   });
 
+  let onBeforeDidUpdateContainerConnectionCalled = false;
+  providerRegistry.onBeforeDidUpdateContainerConnection(event => {
+    expect(event.connection.name).toBe(connection.name);
+    expect(event.connection.type).toBe(connection.type);
+    expect(event.status).toBe('started');
+    onBeforeDidUpdateContainerConnectionCalled = true;
+  });
   let onDidUpdateContainerConnectionCalled = false;
   providerRegistry.onDidUpdateContainerConnection(event => {
     expect(event.connection.name).toBe(connection.name);
@@ -213,12 +220,21 @@ test('should send events when starting a container connection', async () => {
     expect(event.status).toBe('started');
     onDidUpdateContainerConnectionCalled = true;
   });
+  let onAfterDidUpdateContainerConnectionCalled = false;
+  providerRegistry.onAfterDidUpdateContainerConnection(event => {
+    expect(event.connection.name).toBe(connection.name);
+    expect(event.connection.type).toBe(connection.type);
+    expect(event.status).toBe('started');
+    onAfterDidUpdateContainerConnectionCalled = true;
+  });
 
   await providerRegistry.startProviderConnection('0', connection);
 
   expect(startMock).toBeCalled();
   expect(stopMock).not.toBeCalled();
+  expect(onBeforeDidUpdateContainerConnectionCalled).toBeTruthy();
   expect(onDidUpdateContainerConnectionCalled).toBeTruthy();
+  expect(onAfterDidUpdateContainerConnectionCalled).toBeTruthy();
 });
 
 test('should send events when stopping a container connection', async () => {
@@ -249,6 +265,13 @@ test('should send events when stopping a container connection', async () => {
     },
   });
 
+  let onBeforeDidUpdateContainerConnectionCalled = false;
+  providerRegistry.onBeforeDidUpdateContainerConnection(event => {
+    expect(event.connection.name).toBe(connection.name);
+    expect(event.connection.type).toBe(connection.type);
+    expect(event.status).toBe('stopped');
+    onBeforeDidUpdateContainerConnectionCalled = true;
+  });
   let onDidUpdateContainerConnectionCalled = false;
   providerRegistry.onDidUpdateContainerConnection(event => {
     expect(event.connection.name).toBe(connection.name);
@@ -256,12 +279,21 @@ test('should send events when stopping a container connection', async () => {
     expect(event.status).toBe('stopped');
     onDidUpdateContainerConnectionCalled = true;
   });
+  let onAfterDidUpdateContainerConnectionCalled = false;
+  providerRegistry.onAfterDidUpdateContainerConnection(event => {
+    expect(event.connection.name).toBe(connection.name);
+    expect(event.connection.type).toBe(connection.type);
+    expect(event.status).toBe('stopped');
+    onAfterDidUpdateContainerConnectionCalled = true;
+  });
 
   await providerRegistry.stopProviderConnection('0', connection);
 
   expect(stopMock).toBeCalled();
   expect(startMock).not.toBeCalled();
+  expect(onBeforeDidUpdateContainerConnectionCalled).toBeTruthy();
   expect(onDidUpdateContainerConnectionCalled).toBeTruthy();
+  expect(onAfterDidUpdateContainerConnectionCalled).toBeTruthy();
 });
 
 test('runAutostartContainer should start container and send event', async () => {

--- a/packages/main/src/plugin/provider-registry.ts
+++ b/packages/main/src/plugin/provider-registry.ts
@@ -97,9 +97,15 @@ export class ProviderRegistry {
   private readonly _onDidUpdateProvider = new Emitter<ProviderEvent>();
   readonly onDidUpdateProvider: Event<ProviderEvent> = this._onDidUpdateProvider.event;
 
+  private readonly _onBeforeDidUpdateContainerConnection = new Emitter<UpdateContainerConnectionEvent>();
+  readonly onBeforeDidUpdateContainerConnection: Event<UpdateContainerConnectionEvent> =
+    this._onBeforeDidUpdateContainerConnection.event;
   private readonly _onDidUpdateContainerConnection = new Emitter<UpdateContainerConnectionEvent>();
   readonly onDidUpdateContainerConnection: Event<UpdateContainerConnectionEvent> =
     this._onDidUpdateContainerConnection.event;
+  private readonly _onAfterDidUpdateContainerConnection = new Emitter<UpdateContainerConnectionEvent>();
+  readonly onAfterDidUpdateContainerConnection: Event<UpdateContainerConnectionEvent> =
+    this._onAfterDidUpdateContainerConnection.event;
 
   private readonly _onDidUpdateKubernetesConnection = new Emitter<UpdateKubernetesConnectionEvent>();
   readonly onDidUpdateKubernetesConnection: Event<UpdateKubernetesConnectionEvent> =
@@ -777,7 +783,7 @@ export class ProviderRegistry {
       await lifecycle.start(context, logHandler);
     } finally {
       if (this.isProviderContainerConnection(providerConnectionInfo)) {
-        this._onDidUpdateContainerConnection.fire({
+        const event = {
           providerId: internalProviderId,
           connection: {
             name: providerConnectionInfo.name,
@@ -788,7 +794,10 @@ export class ProviderRegistry {
             },
           },
           status: providerConnectionInfo.status,
-        });
+        };
+        this._onBeforeDidUpdateContainerConnection.fire(event);
+        this._onDidUpdateContainerConnection.fire(event);
+        this._onAfterDidUpdateContainerConnection.fire(event);
       } else {
         this._onDidUpdateKubernetesConnection.fire({
           providerId: internalProviderId,
@@ -827,7 +836,7 @@ export class ProviderRegistry {
       await lifecycle.stop(context, logHandler);
     } finally {
       if (this.isProviderContainerConnection(providerConnectionInfo)) {
-        this._onDidUpdateContainerConnection.fire({
+        const event = {
           providerId: internalProviderId,
           connection: {
             name: providerConnectionInfo.name,
@@ -838,7 +847,10 @@ export class ProviderRegistry {
             },
           },
           status: providerConnectionInfo.status,
-        });
+        };
+        this._onBeforeDidUpdateContainerConnection.fire(event);
+        this._onDidUpdateContainerConnection.fire(event);
+        this._onAfterDidUpdateContainerConnection.fire(event);
       } else {
         this._onDidUpdateKubernetesConnection.fire({
           providerId: internalProviderId,


### PR DESCRIPTION
Fixes #2143

### What does this PR do?

Reset/initialize container connections 

### Screenshot/screencast of this PR

![restart](https://user-images.githubusercontent.com/695993/235698236-da76c6c0-ad46-49c8-88db-c2884a2271ad.gif)


### What issues does this PR fix or reference?

Fixes #2143 

### How to test this PR?

1. Create a kind cluster
2. Stop the podman machine -> Kind cluster should disappear
3. Restart the podman machine -> Kind cluster should reappear