### PR TITLE
fix: Correctly deletes volumes from pod before deploying to k8s

### DIFF
--- a/packages/renderer/src/lib/pod/DeployPodToKube.svelte
+++ b/packages/renderer/src/lib/pod/DeployPodToKube.svelte
@@ -254,7 +254,34 @@ async function deployToKube() {
     eventProperties['isOpenshift'] = true;
   }
 
+  let previousPod = bodyPod;
+
   try {
+    // In order to deploy to Kubernetes, we must remove volumes for the pod as we do not support them
+    // if we are deploying using services, remove the hostPort as well as volumeMounts from the container
+    if (bodyPod?.spec?.volumes) {
+      delete bodyPod.spec.volumes;
+    }
+
+    if (deployUsingServices) {
+      bodyPod.spec?.containers?.forEach((container: any) => {
+        // UNUSED
+        // Delete all volume mounts
+        if (container.volumeMounts) {
+          delete container.volumeMounts;
+        }
+
+        // UNUSED
+        // Delete all hostPorts
+        if (container.ports) {
+          container.ports.forEach((port: any) => {
+            delete port.hostPort;
+          });
+        }
+      });
+    }
+
+    // create pod
     createdPod = await window.kubernetesCreatePod(currentNamespace, bodyPod);
 
     // create services
@@ -279,35 +306,14 @@ async function deployToKube() {
     // update status
     updatePodInterval = setInterval(updatePod, 2000);
   } catch (error) {
+    // Revert back to the previous bodyPod so the user can hit deploy again
+    // we only update the bodyPod if we successfully create the pod.
+    bodyPod = previousPod;
     window.telemetryTrack('deployToKube', { ...eventProperties, errorMessage: error.message });
     deployError = error;
     deployStarted = false;
     deployFinished = false;
     return;
-  }
-
-  // Only on a successful deploy, do we want to update the kubeDetails with the removed fields
-  // to show the "final" version of the pod that was deployed.
-  if (bodyPod?.spec?.volumes) {
-    delete bodyPod.spec.volumes;
-  }
-
-  if (deployUsingServices) {
-    bodyPod.spec?.containers?.forEach((container: any) => {
-      // UNUSED
-      // Delete all volume mounts
-      if (container.volumeMounts) {
-        delete container.volumeMounts;
-      }
-
-      // UNUSED
-      // Delete all hostPorts
-      if (container.ports) {
-        container.ports.forEach((port: any) => {
-          delete port.hostPort;
-        });
-      }
-    });
   }
 }
 
@@ -358,7 +364,7 @@ function updateKubeResult() {
       <!-- Only show for non-OpenShift deployments (we use routes for OpenShift) -->
       {#if !openshiftConsoleURL && deployUsingServices}
         <div class="pt-2 pb-4">
-          <label for="ingress" class="block mb-1 text-sm font-medium text-gray-300"
+          <label for="createIngress" class="block mb-1 text-sm font-medium text-gray-300"
             >Expose service locally using Kubernetes Ingress:</label>
           <input
             type="checkbox"


### PR DESCRIPTION
fix: Correctly deletes volumes from pod before deploying to k8s

### What does this PR do?

A change caused by
https://github.com/containers/podman-desktop/pull/2149 incorrectly
deleting the "volume" section after deployment, not before.

So Podman Desktop was trying to deploy a pod with a volume, which we do
not support.

Tests added so it does not happen again.

This PR:
* Reverts back to the original change of removing the volumes before
  deployment
* If a deployment fails, continue to use the original bodyPod so we can
  press "deploy" again.

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

N/A. Should function normally now.

### What issues does this PR fix or reference?

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

Closes https://github.com/containers/podman-desktop/issues/2291

### How to test this PR?

1. `podman run --name hello -d -p 8080:8080 -v $HOME/foobar:$HOME/foobar
   cdrage/helloworld`
2. Click "Deploy to Kubernetes"
3. Select ingress + Deploy

Should function as normal.

<!-- Please explain steps to reproduce -->
