### PR TITLE
Fix Delete command for connection do delete correct one

### DIFF
--- a/packages/main/src/plugin/provider-registry.ts
+++ b/packages/main/src/plugin/provider-registry.ts
@@ -709,7 +709,7 @@ export class ProviderRegistry {
 
     // grab the correct container connection
     const containerConnection = provider.containerConnections.find(
-      connection => connection.endpoint.socketPath === providerContainerConnectionInfo.endpoint.socketPath,
+      connection => connection.endpoint.socketPath === providerContainerConnectionInfo.endpoint.socketPath  && connection.name === providerContainerConnectionInfo.name,
     );
     if (!containerConnection) {
       throw new Error(`no container connection matching provider id ${internalProviderId}`);
@@ -726,7 +726,7 @@ export class ProviderRegistry {
 
     // grab the correct kubernetes connection
     const kubernetesConnection = provider.kubernetesConnections.find(
-      connection => connection.endpoint.apiURL === providerContainerConnectionInfo.endpoint.apiURL,
+      connection => connection.endpoint.apiURL === providerContainerConnectionInfo.endpoint.apiURL && connection.name === providerContainerConnectionInfo.name,
     );
     if (!kubernetesConnection) {
       throw new Error(`no kubernetes connection matching provider id ${internalProviderId}`);

--- a/packages/main/src/plugin/provider-registry.ts
+++ b/packages/main/src/plugin/provider-registry.ts
@@ -709,7 +709,9 @@ export class ProviderRegistry {
 
     // grab the correct container connection
     const containerConnection = provider.containerConnections.find(
-      connection => connection.endpoint.socketPath === providerContainerConnectionInfo.endpoint.socketPath  && connection.name === providerContainerConnectionInfo.name,
+      connection =>
+        connection.endpoint.socketPath === providerContainerConnectionInfo.endpoint.socketPath &&
+        connection.name === providerContainerConnectionInfo.name,
     );
     if (!containerConnection) {
       throw new Error(`no container connection matching provider id ${internalProviderId}`);
@@ -726,7 +728,9 @@ export class ProviderRegistry {
 
     // grab the correct kubernetes connection
     const kubernetesConnection = provider.kubernetesConnections.find(
-      connection => connection.endpoint.apiURL === providerContainerConnectionInfo.endpoint.apiURL && connection.name === providerContainerConnectionInfo.name,
+      connection =>
+        connection.endpoint.apiURL === providerContainerConnectionInfo.endpoint.apiURL &&
+        connection.name === providerContainerConnectionInfo.name,
     );
     if (!kubernetesConnection) {
       throw new Error(`no kubernetes connection matching provider id ${internalProviderId}`);

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionActions.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionActions.svelte
@@ -17,6 +17,7 @@ export let updateConnectionStatus: (
   providerConnectionInfo: ProviderContainerConnectionInfo | ProviderKubernetesConnectionInfo,
   action?: string,
   error?: string,
+  inProgress?: boolean,
 ) => void;
 export let addConnectionToRestartingQueue: (connection: IConnectionRestart) => void;
 $: connectionStatus = connectionStatuses;
@@ -115,8 +116,10 @@ async function deleteConnectionProvider(
         loggerHandlerKey,
         eventCollect,
       );
+      updateConnectionStatus(provider, providerConnectionInfo, 'delete', undefined, false);
     }
   } catch (e) {
+    updateConnectionStatus(provider, providerConnectionInfo, 'delete', e);
     console.error(e);
   }
 }

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
@@ -166,7 +166,7 @@ function updateContainerStatus(
   containerConnectionInfo: ProviderContainerConnectionInfo,
   action?: string,
   error?: string,
-  inProgress?: boolean
+  inProgress?: boolean,
 ): void {
   const containerConnectionName = getProviderConnectionName(provider, containerConnectionInfo);
   if (error) {

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
@@ -166,6 +166,7 @@ function updateContainerStatus(
   containerConnectionInfo: ProviderContainerConnectionInfo,
   action?: string,
   error?: string,
+  inProgress?: boolean
 ): void {
   const containerConnectionName = getProviderConnectionName(provider, containerConnectionInfo);
   if (error) {
@@ -177,7 +178,7 @@ function updateContainerStatus(
     });
   } else if (action) {
     containerConnectionStatus.set(containerConnectionName, {
-      inProgress: true,
+      inProgress: inProgress === undefined ? true : inProgress,
       action: action,
       status: containerConnectionInfo.status,
     });


### PR DESCRIPTION
### What does this PR do?

It fixes search for connection targeted by lifecycle command. Instead of using url or socket only it also adds name into find function predicate. 

It also updates delete command inProgress status after it is finished or failed with error.

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

Fixes #2289.

### How to test this PR?

* add two podman machines
* delete last one
* last one should be deleted
