### PR TITLE
fix: Refactor Kubernetes client with respect to OpenShift and Microshift

### DIFF
--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1407,6 +1407,10 @@ export class PluginSystem {
       },
     );
 
+    this.ipcHandle('kubernetes-client:isAPIGroupSupported', async (_listener, group): Promise<boolean> => {
+      return kubernetesClient.isAPIGroupSupported(group);
+    });
+
     this.ipcHandle('kubernetes-client:getCurrentContextName', async (): Promise<string | undefined> => {
       return kubernetesClient.getCurrentContextName();
     });

--- a/packages/main/src/plugin/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes-client.ts
@@ -86,7 +86,7 @@ function toPodInfo(pod: V1Pod): PodInfo {
   };
 }
 
-const PROJECT_API_GROUP = 'project.openshift.io';
+const OPENSHIFT_PROJECT_API_GROUP = 'project.openshift.io';
 
 /**
  * Handle calls to kubernetes API
@@ -257,11 +257,11 @@ export class KubernetesClient {
     let namespace;
 
     try {
-      const projectGroupSupported = await this.isAPIGroupSupported(PROJECT_API_GROUP);
+      const projectGroupSupported = await this.isAPIGroupSupported(OPENSHIFT_PROJECT_API_GROUP);
       if (projectGroupSupported) {
         const projects = await ctx
           .makeApiClient(CustomObjectsApi)
-          .listClusterCustomObject('project.openshift.io', 'v1', 'projects');
+          .listClusterCustomObject(OPENSHIFT_PROJECT_API_GROUP, 'v1', 'projects');
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         if ((projects?.body as any)?.items.length > 0) {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -1114,6 +1114,10 @@ function initExposure(): void {
     },
   );
 
+  contextBridge.exposeInMainWorld('kubernetesisAPIGroupSupported', async (group: string): Promise<boolean> => {
+    return ipcInvoke('kubernetes-client:isAPIGroupSupported', group);
+  });
+
   contextBridge.exposeInMainWorld('kubernetesCreatePod', async (namespace: string, pod: V1Pod): Promise<V1Pod> => {
     return ipcInvoke('kubernetes-client:createPod', namespace, pod);
   });

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -1114,7 +1114,7 @@ function initExposure(): void {
     },
   );
 
-  contextBridge.exposeInMainWorld('kubernetesisAPIGroupSupported', async (group: string): Promise<boolean> => {
+  contextBridge.exposeInMainWorld('kubernetesIsAPIGroupSupported', async (group: string): Promise<boolean> => {
     return ipcInvoke('kubernetes-client:isAPIGroupSupported', group);
   });
 

--- a/packages/renderer/src/lib/pod/DeployPodToKube.spec.ts
+++ b/packages/renderer/src/lib/pod/DeployPodToKube.spec.ts
@@ -35,7 +35,7 @@ const telemetryTrackMock = vi.fn();
 const kubernetesCreatePodMock = vi.fn();
 const kubernetesCreateIngressMock = vi.fn();
 const kubernetesCreateServiceMock = vi.fn();
-const kubernetesisAPIGroupSupported = vi.fn();
+const kubernetesIsAPIGroupSupported = vi.fn();
 
 beforeEach(() => {
   Object.defineProperty(window, 'generatePodmanKube', {
@@ -63,8 +63,8 @@ beforeEach(() => {
   Object.defineProperty(window, 'kubernetesCreateService', {
     value: kubernetesCreateServiceMock,
   });
-  Object.defineProperty(window, 'kubernetesisAPIGroupSupported', {
-    value: kubernetesisAPIGroupSupported,
+  Object.defineProperty(window, 'kubernetesIsAPIGroupSupported', {
+    value: kubernetesIsAPIGroupSupported,
   });
   Object.defineProperty(window, 'telemetryTrack', {
     value: telemetryTrackMock,
@@ -134,7 +134,7 @@ test('Expect to send telemetry event with OpenShift', async () => {
       consoleURL: 'https://console-openshift-console.apps.cluster-1.example.com',
     },
   });
-  kubernetesisAPIGroupSupported.mockResolvedValue(true);
+  kubernetesIsAPIGroupSupported.mockResolvedValue(true);
   await waitRender({});
   const createButton = screen.getByRole('button', { name: 'Deploy' });
   expect(createButton).toBeInTheDocument();

--- a/packages/renderer/src/lib/pod/DeployPodToKube.spec.ts
+++ b/packages/renderer/src/lib/pod/DeployPodToKube.spec.ts
@@ -178,6 +178,9 @@ test('When deploying a pod, volumes should not be added (they are deleted by pod
   expect(createButton).toBeInTheDocument();
   expect(createButton).toBeEnabled();
 
+  const useRestricted = screen.getByTestId('useRestricted');
+  await fireEvent.click(useRestricted);
+
   // Press the deploy button
   await fireEvent.click(createButton);
 

--- a/packages/renderer/src/lib/pod/DeployPodToKube.spec.ts
+++ b/packages/renderer/src/lib/pod/DeployPodToKube.spec.ts
@@ -35,6 +35,7 @@ const telemetryTrackMock = vi.fn();
 const kubernetesCreatePodMock = vi.fn();
 const kubernetesCreateIngressMock = vi.fn();
 const kubernetesCreateServiceMock = vi.fn();
+const kubernetesisAPIGroupSupported = vi.fn();
 
 beforeEach(() => {
   Object.defineProperty(window, 'generatePodmanKube', {
@@ -61,6 +62,9 @@ beforeEach(() => {
   });
   Object.defineProperty(window, 'kubernetesCreateService', {
     value: kubernetesCreateServiceMock,
+  });
+  Object.defineProperty(window, 'kubernetesisAPIGroupSupported', {
+    value: kubernetesisAPIGroupSupported,
   });
   Object.defineProperty(window, 'telemetryTrack', {
     value: telemetryTrackMock,
@@ -129,8 +133,9 @@ test('Expect to send telemetry event with OpenShift', async () => {
     data: {
       consoleURL: 'https://console-openshift-console.apps.cluster-1.example.com',
     },
-  }),
-    await waitRender({});
+  });
+  kubernetesisAPIGroupSupported.mockResolvedValue(true);
+  await waitRender({});
   const createButton = screen.getByRole('button', { name: 'Deploy' });
   expect(createButton).toBeInTheDocument();
   expect(createButton).toBeEnabled();

--- a/packages/renderer/src/lib/pod/DeployPodToKube.svelte
+++ b/packages/renderer/src/lib/pod/DeployPodToKube.svelte
@@ -22,7 +22,7 @@ let deployError = '';
 let deployWarning = '';
 let updatePodInterval: NodeJS.Timeout;
 let openshiftConsoleURL: string;
-let routeGroupSupported = false;
+let openshiftRouteGroupSupported = false;
 
 let deployUsingServices = true;
 let deployUsingRoutes = true;
@@ -63,7 +63,7 @@ onMount(async () => {
 
   // check if there is OpenShift and then grab openshift console URL
   try {
-    routeGroupSupported = await window.kubernetesisAPIGroupSupported('route.openshift.io');
+    openshiftRouteGroupSupported = await window.kubernetesIsAPIGroupSupported('route.openshift.io');
     const openshiftConfigMap = await window.kubernetesReadNamespacedConfigMap(
       'console-public',
       'openshift-config-managed',
@@ -160,7 +160,7 @@ async function deployToKube() {
           };
           servicesToCreate.push(service);
 
-          if (routeGroupSupported && deployUsingRoutes) {
+          if (openshiftRouteGroupSupported && deployUsingRoutes) {
             // Create OpenShift route object
             const route = {
               apiVersion: 'route.openshift.io/v1',
@@ -252,7 +252,7 @@ async function deployToKube() {
     useRoutes: deployUsingRoutes,
     createIngress: createIngress,
   };
-  if (routeGroupSupported) {
+  if (openshiftRouteGroupSupported) {
     eventProperties['isOpenshift'] = true;
   }
 
@@ -364,7 +364,7 @@ function updateKubeResult() {
       </div>
 
       <!-- Only show for non-OpenShift deployments (we use routes for OpenShift) -->
-      {#if !routeGroupSupported && deployUsingServices}
+      {#if !openshiftRouteGroupSupported && deployUsingServices}
         <div class="pt-2 pb-4">
           <label for="createIngress" class="block mb-1 text-sm font-medium text-gray-300"
             >Expose service locally using Kubernetes Ingress:</label>
@@ -403,7 +403,7 @@ function updateKubeResult() {
       {/if}
 
       <!-- Allow to create routes for OpenShift clusters -->
-      {#if routeGroupSupported}
+      {#if openshiftRouteGroupSupported}
         <div class="pt-2 m-2">
           <label for="routes" class="block mb-1 text-sm font-medium text-gray-400">Create OpenShift routes:</label>
           <input type="checkbox" bind:checked="{deployUsingRoutes}" name="useRoutes" id="useRoutes" class="" required />

--- a/packages/renderer/src/lib/pod/DeployPodToKube.svelte
+++ b/packages/renderer/src/lib/pod/DeployPodToKube.svelte
@@ -22,6 +22,7 @@ let deployError = '';
 let deployWarning = '';
 let updatePodInterval: NodeJS.Timeout;
 let openshiftConsoleURL: string;
+let routeGroupSupported = false;
 
 let deployUsingServices = true;
 let deployUsingRoutes = true;
@@ -62,6 +63,7 @@ onMount(async () => {
 
   // check if there is OpenShift and then grab openshift console URL
   try {
+    routeGroupSupported = await window.kubernetesisAPIGroupSupported('route.openshift.io');
     const openshiftConfigMap = await window.kubernetesReadNamespacedConfigMap(
       'console-public',
       'openshift-config-managed',
@@ -158,7 +160,7 @@ async function deployToKube() {
           };
           servicesToCreate.push(service);
 
-          if (openshiftConsoleURL && deployUsingRoutes) {
+          if (routeGroupSupported && deployUsingRoutes) {
             // Create OpenShift route object
             const route = {
               apiVersion: 'route.openshift.io/v1',
@@ -250,7 +252,7 @@ async function deployToKube() {
     useRoutes: deployUsingRoutes,
     createIngress: createIngress,
   };
-  if (openshiftConsoleURL) {
+  if (routeGroupSupported) {
     eventProperties['isOpenshift'] = true;
   }
 
@@ -362,7 +364,7 @@ function updateKubeResult() {
       </div>
 
       <!-- Only show for non-OpenShift deployments (we use routes for OpenShift) -->
-      {#if !openshiftConsoleURL && deployUsingServices}
+      {#if !routeGroupSupported && deployUsingServices}
         <div class="pt-2 pb-4">
           <label for="createIngress" class="block mb-1 text-sm font-medium text-gray-300"
             >Expose service locally using Kubernetes Ingress:</label>
@@ -401,7 +403,7 @@ function updateKubeResult() {
       {/if}
 
       <!-- Allow to create routes for OpenShift clusters -->
-      {#if openshiftConsoleURL}
+      {#if routeGroupSupported}
         <div class="pt-2 m-2">
           <label for="routes" class="block mb-1 text-sm font-medium text-gray-400">Create OpenShift routes:</label>
           <input type="checkbox" bind:checked="{deployUsingRoutes}" name="useRoutes" id="useRoutes" class="" required />

--- a/packages/renderer/src/lib/pod/pod-utils.spec.ts
+++ b/packages/renderer/src/lib/pod/pod-utils.spec.ts
@@ -1,0 +1,81 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { test, expect } from 'vitest';
+import { ensureRestrictedSecurityContext } from '/@/lib/pod/pod-utils';
+
+function verifyPodSecurityContext(containers: any[], type = 'RuntimeDefault') {
+  containers.forEach(container => {
+    const securityContext = container.securityContext;
+    expect(securityContext).toBeDefined();
+    expect(securityContext.allowPrivilegeEscalation).toBeFalsy();
+    expect(securityContext.runAsNonRoot).toBeTruthy();
+    expect(securityContext.seccompProfile).toBeDefined();
+    expect(securityContext.seccompProfile.type).toBe(type);
+    expect(securityContext.capabilities).toBeDefined();
+    expect(securityContext.capabilities.drop).toBeDefined();
+    expect(securityContext.capabilities.drop).toContain('ALL');
+  });
+}
+
+test('Expect security context to be added to single container pod', async () => {
+  const pod = {
+    kind: 'Pod',
+    apiversion: 'v1',
+    spec: {
+      containers: [{ image: 'image' }],
+    },
+  };
+  ensureRestrictedSecurityContext(pod);
+  verifyPodSecurityContext(pod.spec.containers);
+});
+
+test('Expect security context to be keep seccompProfile.type', async () => {
+  const pod = {
+    kind: 'Pod',
+    apiversion: 'v1',
+    spec: {
+      containers: [
+        {
+          image: 'image',
+          securityContext: {
+            seccompProfile: {
+              type: 'Localhost',
+            },
+          },
+        },
+      ],
+    },
+  };
+  ensureRestrictedSecurityContext(pod);
+  verifyPodSecurityContext(pod.spec.containers, 'Localhost');
+});
+
+test('Expect security context to be added to dual containers pod', async () => {
+  const pod = {
+    kind: 'Pod',
+    apiversion: 'v1',
+    spec: {
+      containers: [{ image: 'image1' }, { image: 'image2' }],
+    },
+  };
+  ensureRestrictedSecurityContext(pod);
+  verifyPodSecurityContext(pod.spec.containers);
+});


### PR DESCRIPTION
Fixes #2260

### What does this PR do?

Handle raw Kubernetes, OpenShift and Microshift clusters accordingly. On Microshift and OpenShift, deploy should create routes. On other clusters, ingresses should be used. On Microshift and raw Kubernetes, namespaces should be used and projects on OpenShift clusters.

I added support for the Restricted security profile which is required by Microshift and enabled it by default for simpler workflows on MicroShift. Let me know WDYT
Please also note that the link to the Kubernetes documentation won't work until #2230 is fixed

### Screenshot/screencast of this PR

![microshift](https://user-images.githubusercontent.com/695993/236149974-4746dda8-94ec-48a8-a4b7-ce98fb3eea56.gif)

### What issues does this PR fix or reference?

Fixes #2260

### How to test this PR?

Deploy a container to one of those clusters
