### PR TITLE
fix: fix sidebar and page size

### DIFF
--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -95,7 +95,7 @@ window.events?.receive('display-help', () => {
       {/if}
 
       <div
-        class="z-0 w-full h-full flex flex-col overflow-y-scroll;"
+        class="z-0 w-full h-full min-h-fit flex flex-col overflow-y-scroll"
         class:bg-charcoal-700="{!meta.url.startsWith('/preferences')}"
         class:bg-charcoal-800="{meta.url.startsWith('/preferences')}">
         <TaskManager />

--- a/packages/renderer/src/AppNavigation.svelte
+++ b/packages/renderer/src/AppNavigation.svelte
@@ -89,7 +89,8 @@ export let meta;
 
 <svelte:window />
 <nav
-  class="pf-c-nav z-0 group w-[54px] min-w-[54px] flex flex-col justify-between overflow-hidden hover:overflow-y-auto"
+  class="pf-c-nav z-0 group w-[54px] min-w-[54px] flex flex-col justify-between overflow-hidden hover:overflow-y-auto top-0"
+  style="position: sticky"
   aria-label="Global">
   <ul class="pf-c-nav__list">
     <li

--- a/packages/renderer/src/PreferencesNavigation.svelte
+++ b/packages/renderer/src/PreferencesNavigation.svelte
@@ -49,8 +49,8 @@ $: addSectionHiddenClass = (section: string): string => (sectionExpanded[section
 </script>
 
 <nav
-  class="pf-c-nav z-0 w-[250px] min-w-[200px] flex-col justify-between flex transition-all duration-500 ease-in-out shadow-nav"
-  style="background-color: rgb(39 39 42 / var(--tw-bg-opacity))"
+  class="pf-c-nav z-0 w-[250px] min-w-[200px] flex-col justify-between flex transition-all duration-500 ease-in-out shadow-nav top-0"
+  style="background-color: rgb(39 39 42 / var(--tw-bg-opacity)); position: sticky"
   aria-label="Global">
   <div class="flex items-center">
     <div class="pt-4 px-5 mb-10">

--- a/packages/renderer/src/lib/ui/NavPage.svelte
+++ b/packages/renderer/src/lib/ui/NavPage.svelte
@@ -4,7 +4,7 @@ export let searchTerm = '';
 export let searchEnabled: boolean = true;
 </script>
 
-<div class="flex flex-col min-h-full min-w-full shadow-pageheader">
+<div class="flex flex-col min-h-full min-w-fit w-full shadow-pageheader">
   <div class="min-w-full pt-4" class:pb-4="{!searchEnabled}">
     <div class="flex">
       <div class="px-5">


### PR DESCRIPTION
### What does this PR do?

This PR fixes a problem with the sidebar not having the right height when going on a page with a long list and also the size of the internal page (the background wasn't taking the full height and the full width resulting in having a part black and one gray)

### Screenshot/screencast of this PR

![fix-ui](https://user-images.githubusercontent.com/49404737/235883024-297d25d8-f953-499e-83a4-92a9700f5f28.gif)

### What issues does this PR fix or reference?

it fixes #2320 and maybe #2322

### How to test this PR?

1. start PD and check that the sidebar and background on pages that are larger than the window works correctly
