### PR TITLE
fix: normalize default value for number inputs (#2318)

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationRendering.svelte
@@ -3,7 +3,7 @@ import type { IConfigurationPropertyRecordedSchema } from '../../../../main/src/
 import type { ProviderInfo } from '../../../../main/src/plugin/api/provider-info';
 import PreferencesRenderingItemFormat from './PreferencesRenderingItemFormat.svelte';
 import Logger from './Logger.svelte';
-import { writeToTerminal } from './Util';
+import { getNormalizedDefaultNumberValue, writeToTerminal } from './Util';
 import ErrorMessage from '../ui/ErrorMessage.svelte';
 import {
   clearCreateTask,
@@ -140,9 +140,9 @@ function setConfigurationValue(id: string, value: string) {
 
 function getDisplayConfigurationValue(configurationKey: IConfigurationPropertyRecordedSchema, value?: any) {
   if (configurationKey.format === 'memory' || configurationKey.format === 'diskSize') {
-    return value ? filesize(value) : filesize(configurationKey.default);
+    return value ? filesize(value) : filesize(getNormalizedDefaultNumberValue(configurationKey));
   } else if (configurationKey.format === 'cpu') {
-    return value ? value : configurationKey.default;
+    return value ? value : getNormalizedDefaultNumberValue(configurationKey);
   } else {
     return '';
   }

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
@@ -5,6 +5,7 @@ import type { IConfigurationPropertyRecordedSchema } from '../../../../main/src/
 import { CONFIGURATION_DEFAULT_SCOPE } from '../../../../main/src/plugin/configuration-registry-constants';
 import ErrorMessage from '../ui/ErrorMessage.svelte';
 import Markdown from '../markdown/Markdown.svelte';
+import { getNormalizedDefaultNumberValue } from './Util';
 
 let invalidEntry = false;
 let invalidText = undefined;
@@ -27,7 +28,7 @@ $: recordValue;
 $: updateResetButtonVisibility && updateResetButtonVisibility(recordValue);
 let checkboxValue: boolean = false;
 $: if (resetToDefault) {
-  recordValue = record.default;
+  recordValue = record.type === 'number' ? getNormalizedDefaultNumberValue(record) : record.default;
   if (typeof recordValue === 'boolean') {
     checkboxValue = recordValue;
   }
@@ -45,7 +46,7 @@ $: if (currentRecord !== record) {
       }
     });
   } else if (record.default !== undefined) {
-    recordValue = record.default;
+    recordValue = record.type === 'number' ? getNormalizedDefaultNumberValue(record) : record.default;
     if (record.type === 'boolean') {
       checkboxValue = recordValue;
     }
@@ -231,7 +232,7 @@ function handleCleanValue(
         name="{record.id}"
         min="{record.minimum}"
         max="{record.maximum}"
-        value="{record.default}"
+        value="{getNormalizedDefaultNumberValue(record)}"
         aria-label="{record.description}"
         on:input="{event => handleRangeValue(record.id, event.currentTarget)}"
         class="w-full h-1 bg-[var(--pf-global--primary-color--300)] rounded-lg appearance-none accent-[var(--pf-global--primary-color--300)] cursor-pointer range-xs mt-2" />

--- a/packages/renderer/src/lib/preferences/Util.spec.ts
+++ b/packages/renderer/src/lib/preferences/Util.spec.ts
@@ -17,7 +17,8 @@
  ***********************************************************************/
 
 import { test, expect, vi } from 'vitest';
-import { writeToTerminal } from './Util';
+import { getNormalizedDefaultNumberValue, writeToTerminal } from './Util';
+import type { IConfigurationPropertyRecordedSchema } from '../../../../main/src/plugin/configuration-registry';
 
 const xtermMock = {
   write: vi.fn(),
@@ -43,4 +44,42 @@ test('write undefined object', () => {
   writeToTerminal(xtermMock, undefined as unknown as string[], 'test');
   // no error reported
   expect(xtermMock.write).toBeCalledWith(expect.stringContaining('test'));
+});
+
+test('return default if type is not number', () => {
+  const record: IConfigurationPropertyRecordedSchema = {
+    title: 'my boolean property',
+    id: 'myid',
+    parentId: '',
+    type: 'boolean',
+    default: true,
+  };
+  const res = getNormalizedDefaultNumberValue(record);
+  expect(res).equal(true);
+});
+
+test('return maximum number value if less than default number value', () => {
+  const record: IConfigurationPropertyRecordedSchema = {
+    title: 'my number property',
+    id: 'myid',
+    parentId: '',
+    type: 'number',
+    default: 12,
+    maximum: 10,
+  };
+  const res = getNormalizedDefaultNumberValue(record);
+  expect(res).equal(10);
+});
+
+test('return default number value if less than maximum number value', () => {
+  const record: IConfigurationPropertyRecordedSchema = {
+    title: 'my number property',
+    id: 'myid',
+    parentId: '',
+    type: 'number',
+    default: 8,
+    maximum: 10,
+  };
+  const res = getNormalizedDefaultNumberValue(record);
+  expect(res).equal(8);
 });

--- a/packages/renderer/src/lib/preferences/Util.ts
+++ b/packages/renderer/src/lib/preferences/Util.ts
@@ -21,6 +21,7 @@ import type {
   ProviderInfo,
   ProviderKubernetesConnectionInfo,
 } from '../../../../main/src/plugin/api/provider-info';
+import type { IConfigurationPropertyRecordedSchema } from '../../../../main/src/plugin/configuration-registry';
 
 export interface IConnectionStatus {
   status: string;
@@ -63,4 +64,15 @@ export function getProviderConnectionName(
   providerConnectionInfo: ProviderContainerConnectionInfo | ProviderKubernetesConnectionInfo,
 ): string {
   return `${provider.name}-${providerConnectionInfo.name}`;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function getNormalizedDefaultNumberValue(configurationKey: IConfigurationPropertyRecordedSchema): any {
+  if (!configurationKey.maximum || typeof configurationKey.maximum !== 'number') {
+    return configurationKey.default;
+  }
+  if (configurationKey.maximum > configurationKey.default) {
+    return configurationKey.default;
+  }
+  return configurationKey.maximum;
 }


### PR DESCRIPTION
### What does this PR do?

This PR normalizes the default value if the configuration type is numeric and it has a maximum value. 
If the default is bigger than the maximum, then the maximum is taken as target.

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

this resolves #2318 

### How to test this PR?

1. verify that the slider when creating a podman machine and the preferences numeric inputs still work fine
