### PR TITLE
fix: display ports in container summary page (#2331)

### DIFF
--- a/packages/renderer/src/lib/container/container-utils.spec.ts
+++ b/packages/renderer/src/lib/container/container-utils.spec.ts
@@ -47,3 +47,40 @@ test('should expect full name for images', async () => {
   const image = containerUtils.getShortImage(containerInfo);
   expect(image).toBe('docker.io/kindest/node:foobar');
 });
+
+test('should expect empty string when there are no public ports', async () => {
+  const containerInfo = {
+    Image: 'docker.io/kindest/node:foobar',
+  } as unknown as ContainerInfo;
+  const ports = containerUtils.getPortsAsString(containerInfo);
+  expect(ports).toBe('');
+});
+
+test('should expect port as string when there is one public ports', async () => {
+  const containerInfo = {
+    Image: 'docker.io/kindest/node:foobar',
+    Ports: [
+      {
+        PublicPort: 80,
+      },
+    ],
+  } as unknown as ContainerInfo;
+  const ports = containerUtils.getPortsAsString(containerInfo);
+  expect(ports).toBe('80');
+});
+
+test('should expect ports as string when there are multiple public ports', async () => {
+  const containerInfo = {
+    Image: 'docker.io/kindest/node:foobar',
+    Ports: [
+      {
+        PublicPort: 80,
+      },
+      {
+        PublicPort: 8022,
+      },
+    ],
+  } as unknown as ContainerInfo;
+  const ports = containerUtils.getPortsAsString(containerInfo);
+  expect(ports).toBe('80, 8022');
+});

--- a/packages/renderer/src/lib/container/container-utils.ts
+++ b/packages/renderer/src/lib/container/container-utils.ts
@@ -200,7 +200,7 @@ export class ContainerUtils {
   }
 
   getPortsAsString(containerInfo: ContainerInfo): string {
-    const ports = containerInfo.Ports;
+    const ports = this.getPorts(containerInfo);
     if (ports.length > 1) {
       return `${ports.join(', ')}`;
     } else if (ports.length === 1) {


### PR DESCRIPTION
### What does this PR do?

This PR fixes the `getPortsAsString` function. It now works with actual public ports and display them correctly

### Screenshot/screencast of this PR

![image](https://user-images.githubusercontent.com/49404737/235970894-be3c94ba-43e9-4f37-ae01-e66ea4452a0c.png)

### What issues does this PR fix or reference?

it resolves #2331 

### How to test this PR?

1. open a container with 1+ ports and check that the ports are displayed as expected
