### PR TITLE
nit: fix rendering settings pages

### DIFF
--- a/packages/renderer/src/lib/preferences/SettingsPage.svelte
+++ b/packages/renderer/src/lib/preferences/SettingsPage.svelte
@@ -8,6 +8,6 @@ export let title: string;
       <p class="capitalize text-xl">{title}</p>
       <p class="text-sm text-gray-700"><slot name="subtitle"><br /></slot></p>
     </div>
-    <slot />
   </div>
+  <slot />
 </div>


### PR DESCRIPTION
nit: fix rendering settings pages

### What does this PR do?

Moves the `<slot />` to not be within the title / within the normal
bounds of the div again. Was introduced by: https://github.com/containers/podman-desktop/pull/2280

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

Before:

https://user-images.githubusercontent.com/6422176/235971451-81433760-c89d-42ca-b94d-a1cbf080e977.mov



After:
![Screenshot 2023-05-03 at 11 58 22 AM](https://user-images.githubusercontent.com/6422176/235971632-0a5e368a-c858-46e6-bfcd-390ecda8fd90.png)



### What issues does this PR fix or reference?

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

N/A

### How to test this PR?

"Add registry" button should appear normally now on the settings page

<!-- Please explain steps to reproduce -->

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
