### PR TITLE
feat(component): allow to specify the size in LoadingIcon component

### DIFF
--- a/packages/renderer/src/lib/ui/LoadingIcon.spec.ts
+++ b/packages/renderer/src/lib/ui/LoadingIcon.spec.ts
@@ -1,0 +1,71 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom';
+import { test, expect } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import LoadingIcon from './LoadingIcon.svelte';
+import { faPlayCircle } from '@fortawesome/free-solid-svg-icons';
+
+test('Expect default size', async () => {
+  const icon = faPlayCircle;
+  const loadingWidthClass = 'w-10';
+  const loadingHeightClass = 'h-10';
+  const positionTopClass = '';
+  const positionLeftClass = '';
+  const loading = true;
+  const iconSize = '';
+  render(LoadingIcon, {
+    icon,
+    iconSize,
+    loadingHeightClass,
+    loadingWidthClass,
+    positionTopClass,
+    positionLeftClass,
+    loading,
+  });
+  const loadingIcon = screen.getByRole('img', { hidden: true, name: '' });
+  expect(loadingIcon).toBeInTheDocument();
+
+  // check the font-size attribute of the loading icon is not set
+  expect(loadingIcon).toHaveAttribute('style', expect.not.stringContaining('font-size'));
+});
+
+test('Expect specified size', async () => {
+  const icon = faPlayCircle;
+  const loadingWidthClass = 'w-10';
+  const loadingHeightClass = 'h-10';
+  const positionTopClass = '';
+  const positionLeftClass = '';
+  const loading = true;
+  const iconSize = '20';
+  render(LoadingIcon, {
+    icon,
+    iconSize,
+    loadingHeightClass,
+    loadingWidthClass,
+    positionTopClass,
+    positionLeftClass,
+    loading,
+  });
+  const loadingIcon = screen.getByRole('img', { hidden: true, name: '' });
+  expect(loadingIcon).toBeInTheDocument();
+
+  // check the font-size attribute of the loading icon is set to 20
+  expect(loadingIcon).toHaveAttribute('style', expect.stringContaining('font-size:20;'));
+});

--- a/packages/renderer/src/lib/ui/LoadingIcon.svelte
+++ b/packages/renderer/src/lib/ui/LoadingIcon.svelte
@@ -8,10 +8,11 @@ export let loadingHeightClass: string;
 export let positionTopClass: string;
 export let positionLeftClass: string;
 export let loading: boolean;
+export let iconSize = '';
 </script>
 
 <div>
-  <Fa icon="{icon}" />
+  <Fa size="{iconSize}" icon="{icon}" />
   <div
     aria-label="spinner"
     class="{loading


### PR DESCRIPTION


Change-Id: I736d6172adc355b5d07ab93ec0005b7b92f47e96

### What does this PR do?
Allow to specify the size of the fa icon
it is still optional

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

N/A

### How to test this PR?

unit test provided