### PR TITLE
feat: display featured extensions in the welcome page

### DIFF
--- a/packages/renderer/src/lib/welcome/WelcomePage.spec.ts
+++ b/packages/renderer/src/lib/welcome/WelcomePage.spec.ts
@@ -22,17 +22,23 @@ import '@testing-library/jest-dom';
 import { beforeAll, test, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/svelte';
 import WelcomePage from './WelcomePage.svelte';
-import type { Unsubscriber } from 'svelte/store';
+import { get, type Unsubscriber } from 'svelte/store';
 import { router } from 'tinro';
+import { featuredExtensionInfos } from '/@/stores/featuredExtensions';
+import type { FeaturedExtension } from '../../../../main/src/plugin/featured/featured-api';
 
 let routerUnsubscribe: Unsubscriber;
 let path: string;
+
+const getFeaturedExtensionsMock = vi.fn();
 
 // fake the window.events object
 beforeAll(() => {
   (window as any).getConfigurationValue = vi.fn();
   (window as any).updateConfigurationValue = vi.fn();
-
+  (window as any).getPodmanDesktopVersion = vi.fn();
+  (window as any).telemetryConfigure = vi.fn();
+  (window as any).getFeaturedExtensions = getFeaturedExtensionsMock;
   (window.events as unknown) = {
     receive: (_channel: string, func: any) => {
       func();
@@ -99,4 +105,53 @@ test('Expect that telemetry UI is visible when necessary', async () => {
   await render(WelcomePage, { showWelcome: true, showTelemetry: true });
   const checkbox = screen.getByRole('checkbox', { name: 'Enable telemetry' });
   expect(checkbox).toBeInTheDocument();
+});
+
+test('Expect that featured extensions are displayed', async () => {
+  const featuredExtension1: FeaturedExtension = {
+    builtin: true,
+    id: 'foo.bar',
+    displayName: 'FooBar',
+    description: 'Foobar description',
+    icon: 'data:image/png;base64,foobar',
+    categories: [],
+    fetchable: true,
+    fetchLink: 'oci-hello/world',
+    fetchVersion: '1.2.3',
+    installed: true,
+  };
+
+  const featuredExtension2: FeaturedExtension = {
+    builtin: true,
+    id: 'foo.baz',
+    displayName: 'FooBaz',
+    description: 'Foobaz description',
+    icon: 'data:image/png;base64,foobaz',
+    categories: [],
+    fetchable: false,
+    installed: false,
+  };
+
+  getFeaturedExtensionsMock.mockResolvedValue([featuredExtension1, featuredExtension2]);
+
+  // ask to update the featured Extensions store
+  window.dispatchEvent(new CustomEvent('system-ready'));
+
+  // wait store are populated
+  while (get(featuredExtensionInfos).length === 0) {
+    await new Promise(resolve => setTimeout(resolve, 500));
+  }
+
+  await render(WelcomePage, { showWelcome: true });
+  const imageExt1 = screen.getByRole('img', { name: 'FooBar logo' });
+  // expect the image to be there
+  expect(imageExt1).toBeInTheDocument();
+  // expect image source is correct
+  expect(imageExt1).toHaveAttribute('src', 'data:image/png;base64,foobar');
+
+  const imageExt2 = screen.getByRole('img', { name: 'FooBaz logo' });
+  // expect the image to be there
+  expect(imageExt2).toBeInTheDocument();
+  // expect image source is correct
+  expect(imageExt2).toHaveAttribute('src', 'data:image/png;base64,foobaz');
 });

--- a/packages/renderer/src/lib/welcome/WelcomePage.svelte
+++ b/packages/renderer/src/lib/welcome/WelcomePage.svelte
@@ -2,10 +2,12 @@
 import bgImage from './background.png';
 import DesktopIcon from '../images/DesktopIcon.svelte';
 import Fa from 'svelte-fa/src/fa.svelte';
-import { faCircle, faCheck } from '@fortawesome/free-solid-svg-icons';
-import { onMount, onDestroy } from 'svelte';
+import { faCheck } from '@fortawesome/free-solid-svg-icons';
+import { onMount } from 'svelte';
 import { WelcomeUtils } from './welcome-utils';
 import { router } from 'tinro';
+import { featuredExtensionInfos } from '/@/stores/featuredExtensions';
+import Tooltip from '../ui/Tooltip.svelte';
 
 export let showWelcome = false;
 export let showTelemetry = false;
@@ -13,6 +15,7 @@ export let showTelemetry = false;
 let telemetry = true;
 
 const welcomeUtils = new WelcomeUtils();
+let podmanDesktopVersion;
 
 onMount(async () => {
   const ver = await welcomeUtils.getVersion();
@@ -24,6 +27,7 @@ onMount(async () => {
   if (!telemetryPrompt) {
     showTelemetry = true;
   }
+  podmanDesktopVersion = await window.getPodmanDesktopVersion();
 });
 
 function closeWelcome() {
@@ -46,27 +50,37 @@ function closeWelcome() {
     <!-- Body -->
     <div class="flex flex-col justify-center content-center flex-auto backdrop-blur p-2 overflow-y-auto">
       <div class="flex justify-center p-2"><DesktopIcon /></div>
-      <div class="flex justify-center text-lg font-bold p-4">
-        <span class="mr-2">🎉</span>Welcome to Podman Desktop!
+      <div class="flex justify-center text-lg font-bold p-2">
+        <span class="mr-2">🎉</span>Welcome to Podman Desktop v{podmanDesktopVersion} !
       </div>
-      <div class="flex flex-row justify-center p-4">
-        <div class="bg-charcoal-600 rounded-lg p-5 text-sm space-y-3">
-          <div class="font-bold">Podman Desktop supports many container engines, including:</div>
-          <div class="flex flex-row px-5 justify-center">
-            <div class="flex flex-row px-4">
-              <div class="flex flex-row place-items-center p-1">
-                <div><Fa size="10" class="text-violet-600" icon="{faCircle}" /></div>
-                <div class="px-2">Podman</div>
+      <div class="flex flex-row justify-center">
+        <div class="bg-charcoal-500 px-4 pb-4 pt-2 rounded">
+          <div class="flex justify-center text-sm text-gray-700 pb-2">
+            <div>Podman desktop supports many container engines and orchestrators, such as:</div>
+          </div>
+          <div class="grid grid-cols-3 gap-3">
+            {#each $featuredExtensionInfos as featuredExtension}
+              <div
+                class="rounded-md
+           bg-charcoal-700 flex flex-row justify-center border-charcoal-700 p-2">
+                <div class="place-items-top flex flex-col flex-1">
+                  <div class="flex flex-row place-items-center flex-1">
+                    <div>
+                      <img
+                        alt="{featuredExtension.displayName} logo"
+                        class="max-h-6 max-w-[24px] h-auto w-auto"
+                        src="{featuredExtension.icon}" />
+                    </div>
+                    <div
+                      class="flex flex-1 mx-2 underline decoration-2 decoration-dotted underline-offset-2 cursor-default justify-center">
+                      <Tooltip tip="{featuredExtension.description}" top>
+                        {featuredExtension.displayName}
+                      </Tooltip>
+                    </div>
+                  </div>
+                </div>
               </div>
-              <div class="flex flex-row place-items-center p-1">
-                <div><Fa size="10" class="text-violet-600" icon="{faCircle}" /></div>
-                <div class="px-2">Docker</div>
-              </div>
-              <div class="flex flex-row place-items-center p-1">
-                <div><Fa size="10" class="text-violet-600" icon="{faCircle}" /></div>
-                <div class="px-2">Lima</div>
-              </div>
-            </div>
+            {/each}
           </div>
         </div>
       </div>


### PR DESCRIPTION
Requires: 

 - [ ] : https://github.com/containers/podman-desktop/pull/2346

### What does this PR do?
Display the featured extensions in the welcome screen instead of a generic text
Also display the version of Podman Desktop

### Screenshot/screencast of this PR

Before:
![image](https://user-images.githubusercontent.com/436777/236216543-d1373b5b-709f-4497-91c9-bc22429d6338.png)


After:
![image](https://user-images.githubusercontent.com/436777/236215906-e9e015e6-6067-4425-b992-2a5ae2e5409c.png)


### What issues does this PR fix or reference?

related to https://github.com/containers/podman-desktop/issues/1901


### How to test this PR?


Change-Id: I08b0eb85523652a474026ef2d8e7fb0d1f029964

It requires commits from
- https://github.com/containers/podman-desktop/pull/2346

There are component tests

How to reproduce: (wipe all your settings or patch WelcomePage.svelte with showWelcome = true instead of showWelcome = false)
