### PR TITLE
feat: Allow to install in one click featured extensions (if not installed)

### DIFF
--- a/packages/renderer/src/lib/dashboard/DashboardPage.svelte
+++ b/packages/renderer/src/lib/dashboard/DashboardPage.svelte
@@ -10,6 +10,7 @@ import ProviderStopped from './ProviderStopped.svelte';
 import ProviderStarting from './ProviderStarting.svelte';
 import NavPage from '../ui/NavPage.svelte';
 import type { InitializationMode } from './ProviderInitUtils';
+import FeaturedExtensions from '/@/lib/featured/FeaturedExtensions.svelte';
 
 const providerInitMode = new Map<string, InitializationMode>();
 
@@ -74,6 +75,8 @@ function updateInitializationMode(id: string, mode: InitializationMode) {
             <ProviderStopped provider="{providerStopped}" />
           {/each}
         {/if}
+
+        <FeaturedExtensions />
       </div>
     </div>
   </div>

--- a/packages/renderer/src/lib/featured/FeaturedExtensionDownload.spec.ts
+++ b/packages/renderer/src/lib/featured/FeaturedExtensionDownload.spec.ts
@@ -1,0 +1,98 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import '@testing-library/jest-dom';
+import { beforeAll, test, expect, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import FeaturedExtensionDownload from './FeaturedExtensionDownload.svelte';
+import type { FeaturedExtension } from '../../../../main/src/plugin/featured/featured-api';
+
+const extensionInstallFromImageMock = vi.fn();
+
+// fake the window.events object
+beforeAll(() => {
+  (window as any).extensionInstallFromImage = extensionInstallFromImageMock;
+  (window.events as unknown) = {
+    receive: (_channel: string, func: any) => {
+      func();
+    },
+  };
+});
+
+test('Expect that the install button is hidden if extension is not installable', async () => {
+  const featuredExtension: FeaturedExtension = {
+    builtin: true,
+    id: 'foo.bar',
+    displayName: 'FooBar',
+    description: 'This is FooBar description',
+    icon: 'data:image/png;base64,foobar',
+    categories: [],
+    fetchable: false,
+    installed: false,
+  };
+
+  await render(FeaturedExtensionDownload, { featuredExtension });
+
+  // expect to have the button if installable
+  const installButton = screen.queryByRole('button', { name: 'Install foo.bar Extension' });
+  // expect the button is not there
+  expect(installButton).not.toBeInTheDocument();
+});
+
+test('Expect that we can see the button and click on the install', async () => {
+  const featuredExtension: FeaturedExtension = {
+    builtin: true,
+    id: 'foo.bar',
+    displayName: 'FooBar',
+    description: 'This is FooBar description',
+    icon: 'data:image/png;base64,foobar',
+    categories: [],
+    fetchable: true,
+    fetchLink: 'oci-hello/world',
+    fetchVersion: '1.2.3',
+    installed: false,
+  };
+
+  const { component } = await render(FeaturedExtensionDownload, { featuredExtension });
+
+  // expect to have the button if installable
+  const installButton = screen.getByRole('button', { name: 'Install foo.bar Extension' });
+  // expect the button to be there
+  expect(installButton).toBeInTheDocument();
+
+  // mock the install function
+  extensionInstallFromImageMock.mockImplementation(async () => {
+    featuredExtension.installed = true;
+    featuredExtension.fetchable = false;
+    await component.$set({ featuredExtension });
+  });
+
+  // click on the button
+  await fireEvent.click(installButton);
+
+  // install should have been called
+  expect(extensionInstallFromImageMock).toHaveBeenCalled();
+
+  // now, expect the button to be gone
+  // expect the button to be there
+  const installButtonAfterClick = screen.queryByRole('button', { name: 'Install foo.bar Extension' });
+  // expect the button is not there
+  expect(installButtonAfterClick).not.toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/featured/FeaturedExtensionDownload.svelte
+++ b/packages/renderer/src/lib/featured/FeaturedExtensionDownload.svelte
@@ -1,0 +1,79 @@
+<script lang="ts">
+import type { FeaturedExtension } from '../../../../main/src/plugin/featured/featured-api';
+import { faCheckCircle, faDownload } from '@fortawesome/free-solid-svg-icons';
+import Fa from 'svelte-fa/src/fa.svelte';
+import LoadingIcon from '../ui/LoadingIcon.svelte';
+import ErrorMessage from '../ui/ErrorMessage.svelte';
+
+export let featuredExtension: FeaturedExtension;
+
+let installInProgress = false;
+
+let logs = [];
+let errorInstall = '';
+
+let percentage = '0%';
+
+async function installExtension() {
+  console.log('User asked to install the extension with the following properties', featuredExtension);
+  logs = [];
+
+  installInProgress = true;
+
+  // do a trim on the image name
+  const ociImage = featuredExtension.fetchLink.trim();
+
+  try {
+    // download image
+    await window.extensionInstallFromImage(
+      ociImage,
+      (data: string) => {
+        logs = [...logs, data];
+        console.log('data', data);
+
+        // try to extract percentage from string like
+        // data Downloading sha256:e8d2c9e5c69499c41ba39b7828c00e55087572884cac466b4d1b47243b085c7d.tar - 11% - (55132/521578)
+        const percentageMatch = data.match(/(\d+)%/);
+        if (percentageMatch) {
+          percentage = percentageMatch[1] + '%';
+        }
+      },
+      (error: string) => {
+        console.log(`got an error when installing ${featuredExtension.id}`, error);
+        installInProgress = false;
+        errorInstall = error;
+      },
+    );
+    logs = [...logs, '☑️ installation finished !'];
+    percentage = '100%';
+  } catch (error) {
+    console.log('error', error);
+  }
+  installInProgress = false;
+}
+</script>
+
+<button
+  aria-label="Install {featuredExtension.id} Extension"
+  on:click="{() => installExtension()}"
+  hidden="{!featuredExtension.fetchable}"
+  title="Install {featuredExtension.displayName} v{featuredExtension.fetchVersion} Extension"
+  class="border-2 relative rounded border-dustypurple-700 text-dustypurple-700 hover:bg-charcoal-800 hover:text-dustypurple-600 w-10 p-2 text-center cursor-pointer flex flex-row">
+  <!--<Fa  class="ml-1.5" size="16" icon={faDownload} />-->
+  <span class="ml-0.5"></span>
+  <LoadingIcon
+    icon="{faDownload}"
+    iconSize="16"
+    loadingWidthClass="w-7"
+    loadingHeightClass="h-7"
+    positionTopClass="top-[2px]"
+    positionLeftClass="left-[4px]"
+    loading="{installInProgress}" />
+  <span
+    class:hidden="{!installInProgress}"
+    class="absolute -top-[15px] right-0 text-dustypurple-500"
+    style="font-size: 8px">{percentage}</span>
+  <div class:hidden="{!errorInstall}" class="absolute w-56 -top-[25px] right-0" style="font-size: 8px">
+    <ErrorMessage error="{errorInstall}" />
+  </div>
+</button>

--- a/packages/renderer/src/lib/featured/FeaturedExtensions.spec.ts
+++ b/packages/renderer/src/lib/featured/FeaturedExtensions.spec.ts
@@ -1,0 +1,127 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import '@testing-library/jest-dom';
+import { beforeAll, test, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import { get } from 'svelte/store';
+import FeaturedExtensions from './FeaturedExtensions.svelte';
+import { featuredExtensionInfos } from '/@/stores/featuredExtensions';
+import type { FeaturedExtension } from '../../../../main/src/plugin/featured/featured-api';
+
+const getFeaturedExtensionsMock = vi.fn();
+
+// fake the window.events object
+beforeAll(() => {
+  (window as any).getFeaturedExtensions = getFeaturedExtensionsMock;
+  (window.events as unknown) = {
+    receive: (_channel: string, func: any) => {
+      func();
+    },
+  };
+});
+
+test('Expect that featured extensions are displayed', async () => {
+  const featuredExtension1: FeaturedExtension = {
+    builtin: true,
+    id: 'foo.bar',
+    displayName: 'FooBar',
+    description: 'This is FooBar description',
+    icon: 'data:image/png;base64,foobar',
+    categories: [],
+    fetchable: true,
+    fetchLink: 'oci-hello/world',
+    fetchVersion: '1.2.3',
+    installed: false,
+  };
+
+  const featuredExtension2: FeaturedExtension = {
+    builtin: true,
+    id: 'foo.baz',
+    displayName: 'FooBaz',
+    description: 'Foobaz description',
+    icon: 'data:image/png;base64,foobaz',
+    categories: [],
+    fetchable: false,
+    installed: true,
+  };
+
+  const featuredExtension3: FeaturedExtension = {
+    builtin: true,
+    id: 'foo.bar',
+    displayName: 'Bar',
+    description: 'FooBar not fetchable description',
+    icon: 'data:image/png;base64,bar',
+    categories: [],
+    fetchable: false,
+    installed: false,
+  };
+
+  getFeaturedExtensionsMock.mockResolvedValue([featuredExtension1, featuredExtension2, featuredExtension3]);
+
+  // ask to update the featured Extensions store
+  window.dispatchEvent(new CustomEvent('system-ready'));
+
+  // wait store are populated
+  while (get(featuredExtensionInfos).length === 0) {
+    await new Promise(resolve => setTimeout(resolve, 500));
+  }
+
+  await render(FeaturedExtensions);
+
+  // get by title
+  const firstExtension = screen.getByTitle('This is FooBar description');
+  expect(firstExtension).toBeInTheDocument();
+
+  const imageExt1 = screen.getByRole('img', { name: 'FooBar logo' });
+  // expect the image to be there
+  expect(imageExt1).toBeInTheDocument();
+  // expect image source is correct
+  expect(imageExt1).toHaveAttribute('src', 'data:image/png;base64,foobar');
+
+  // Not installed so it should have a button to install
+  const installButton = screen.getByRole('button', { name: 'Install foo.bar Extension' });
+  // expect the button to be there
+  expect(installButton).toBeInTheDocument();
+
+  // get by title
+  const secondExtension = screen.getByTitle('Foobaz description');
+  expect(secondExtension).toBeInTheDocument();
+  // contains the text installed
+  expect(secondExtension).toHaveTextContent(/.*installed/);
+
+  const imageExt2 = screen.getByRole('img', { name: 'FooBaz logo' });
+  // expect the image to be there
+  expect(imageExt2).toBeInTheDocument();
+  // expect image source is correct
+  expect(imageExt2).toHaveAttribute('src', 'data:image/png;base64,foobaz');
+
+  // get by title
+  const thirdExtension = screen.getByTitle('FooBar not fetchable description');
+  expect(thirdExtension).toBeInTheDocument();
+  // contains the text installed
+  expect(thirdExtension).toHaveTextContent(/.*N\/A/);
+
+  const imageExt3 = screen.getByRole('img', { name: 'Bar logo' });
+  // expect the image to be there
+  expect(imageExt3).toBeInTheDocument();
+  // expect image source is correct
+  expect(imageExt3).toHaveAttribute('src', 'data:image/png;base64,bar');
+});

--- a/packages/renderer/src/lib/featured/FeaturedExtensions.svelte
+++ b/packages/renderer/src/lib/featured/FeaturedExtensions.svelte
@@ -1,0 +1,46 @@
+<script lang="ts">
+import { featuredExtensionInfos } from '/@/stores/featuredExtensions';
+import { faCheckCircle, faCircleXmark, faDownload } from '@fortawesome/free-solid-svg-icons';
+import Fa from 'svelte-fa/src/fa.svelte';
+import FeaturedExtensionDownload from './FeaturedExtensionDownload.svelte';
+</script>
+
+<!--Title-->
+<p class="text-lg first-letter:uppercase font-bold">featured extensions:</p>
+<div class="grid md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 gap-3 pb-4">
+  {#each $featuredExtensionInfos as featuredExtension}
+    <div
+      title="{featuredExtension.description}"
+      class="rounded-md
+               bg-charcoal-800 flex flex-row justify-center p-4 h-20 border-2 border-charcoal-800 hover:border-dustypurple-500">
+      <div class=" flex flex-col flex-1">
+        <div class="flex flex-row place-items-center flex-1">
+          <div>
+            <img
+              class="w-12 h-12 object-contain"
+              alt="{featuredExtension.displayName} logo"
+              src="{featuredExtension.icon}" />
+          </div>
+          <div class="flex flex-1 mx-2 cursor-default font-bold justify-start">
+            {featuredExtension.displayName}
+          </div>
+          <div class="h-full w-18 flex flex-col items-end place-content-center">
+            {#if featuredExtension.installed}
+              <div class="text-dustypurple-700 p-1 text-center flex flex-row place-items-center">
+                <Fa class="ml-1.5 mr-2" size="18" icon="{faCheckCircle}" />
+                <div class="uppercase font-bold text-xs cursor-default">installed</div>
+              </div>
+            {:else if featuredExtension.fetchable}
+              <FeaturedExtensionDownload featuredExtension="{featuredExtension}" />
+            {:else}
+              <div class="text-charcoal-300 p-1 text-center flex flex-row place-items-center">
+                <Fa class="ml-1.5 mr-1" size="18" icon="{faCircleXmark}" />
+                <div class="uppercase text-xs cursor-default font-extralight">N/A</div>
+              </div>
+            {/if}
+          </div>
+        </div>
+      </div>
+    </div>
+  {/each}
+</div>

--- a/packages/renderer/src/lib/preferences/PreferencesExtensionList.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesExtensionList.svelte
@@ -9,6 +9,7 @@ import type { ExtensionInfo } from '../../../../main/src/plugin/api/extension-in
 import ErrorMessage from '../ui/ErrorMessage.svelte';
 import SettingsPage from '../preferences/SettingsPage.svelte';
 import ConnectionStatus from '../ui/ConnectionStatus.svelte';
+import FeaturedExtensions from '../featured/FeaturedExtensions.svelte';
 
 export let ociImage: string = undefined;
 
@@ -66,120 +67,129 @@ async function removeExtension(extension: ExtensionInfo) {
 
 <SettingsPage title="Extensions">
   <div class="bg-charcoal-600 mt-5 rounded-md p-3">
-    <h1 class="text-lg mb-2">Install a new extension from OCI Image</h1>
+    <div class="bg-charcoal-700 rounded-md p-3">
+      <FeaturedExtensions />
+    </div>
 
-    <div class="flex flex-col w-full">
-      <div class="flex flex-row mb-2 w-full space-x-8 items-center">
-        <input
-          name="ociImage"
-          id="ociImage"
-          bind:value="{ociImage}"
-          placeholder="Name of the Image"
-          class="w-1/2 p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700"
-          required />
+    <div class="bg-charcoal-700 mt-5 rounded-md p-3">
+      <h1 class="text-lg mb-2">Install a new extension from OCI Image</h1>
 
-        <button
-          on:click="{() => installExtensionFromImage()}"
-          disabled="{ociImage === undefined || ociImage.trim() === '' || installInProgress}"
-          class="w-full pf-c-button pf-m-primary"
-          type="button">
-          {#if installInProgress}
-            <i class="pf-c-button__progress">
-              <span class="pf-c-spinner pf-m-md" role="progressbar">
-                <span class="pf-c-spinner__clipper"></span>
-                <span class="pf-c-spinner__lead-ball"></span>
-                <span class="pf-c-spinner__tail-ball"></span>
-              </span>
-            </i>
-          {/if}
-          <span class="pf-c-button__icon pf-m-start">
-            <i class="fas fa-arrow-circle-down" aria-hidden="true"></i>
-          </span>
-          Install extension from the OCI image
-        </button>
-      </div>
+      <div class="flex flex-col w-full">
+        <div class="flex flex-row mb-2 w-full space-x-8 items-center">
+          <input
+            name="ociImage"
+            id="ociImage"
+            bind:value="{ociImage}"
+            placeholder="Name of the Image"
+            class="w-1/2 p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700"
+            required />
 
-      <div class="container w-full flex-col">
-        <div
-          class:opacity-0="{logs.length === 0}"
-          bind:this="{logElement}"
-          class="bg-zinc-700 text-gray-300 mt-4 mb-3 p-1 h-16 overflow-y-auto">
-          {#each logs as log}
-            <p class="font-light text-sm">{log}</p>
-          {/each}
+          <button
+            on:click="{() => installExtensionFromImage()}"
+            disabled="{ociImage === undefined || ociImage.trim() === '' || installInProgress}"
+            class="w-full pf-c-button pf-m-primary"
+            type="button">
+            {#if installInProgress}
+              <i class="pf-c-button__progress">
+                <span class="pf-c-spinner pf-m-md" role="progressbar">
+                  <span class="pf-c-spinner__clipper"></span>
+                  <span class="pf-c-spinner__lead-ball"></span>
+                  <span class="pf-c-spinner__tail-ball"></span>
+                </span>
+              </i>
+            {/if}
+            <span class="pf-c-button__icon pf-m-start">
+              <i class="fas fa-arrow-circle-down" aria-hidden="true"></i>
+            </span>
+            Install extension from the OCI image
+          </button>
         </div>
 
-        <ErrorMessage error="{errorInstall}" />
+        <div class="container w-full flex-col">
+          <div
+            class:opacity-0="{logs.length === 0}"
+            bind:this="{logElement}"
+            class="bg-zinc-700 text-gray-300 mt-4 mb-3 p-1 h-16 overflow-y-auto">
+            {#each logs as log}
+              <p class="font-light text-sm">{log}</p>
+            {/each}
+          </div>
+
+          <ErrorMessage error="{errorInstall}" />
+        </div>
       </div>
     </div>
-  </div>
-  <div class="bg-charcoal-600 mt-5 rounded-md p-3">
-    <table class="min-w-full">
-      <tbody>
-        {#each $extensionInfos as extension}
-          <tr class="border-y border-gray-900">
-            <td class="px-6 py-2">
-              <div class="flex items-center">
-                <div class="flex-shrink-0 h-10 w-10 py-3" title="Extension {extension.name} is {extension.state}">
-                  <Fa
-                    class="h-10 w-10 rounded-full {extension.state === 'started' ? 'text-violet-600' : 'text-gray-900'}"
-                    size="25"
-                    icon="{faPuzzlePiece}" />
-                </div>
-                <div class="ml-4">
-                  <div class="flex flex-row">
-                    <div class="text-sm text-gray-300">
-                      {extension.displayName}
-                      {extension.removable ? '(user)' : '(default extension)'}
-                      <span class="text-xs font-extra-light text-gray-900">v{extension.version}</span>
+    <div class="bg-charcoal-600 mt-5 rounded-md p-3">
+      <table class="min-w-full">
+        <tbody>
+          {#each $extensionInfos as extension}
+            <tr class="border-y border-gray-900">
+              <td class="px-6 py-2">
+                <div class="flex items-center">
+                  <div class="flex-shrink-0 h-10 w-10 py-3" title="Extension {extension.name} is {extension.state}">
+                    <Fa
+                      class="h-10 w-10 rounded-full {extension.state === 'started'
+                        ? 'text-violet-600'
+                        : 'text-gray-900'}"
+                      size="25"
+                      icon="{faPuzzlePiece}" />
+                  </div>
+                  <div class="ml-4">
+                    <div class="flex flex-row">
+                      <div class="text-sm text-gray-300">
+                        {extension.displayName}
+                        {extension.removable ? '(user)' : '(default extension)'}
+                        <span class="text-xs font-extra-light text-gray-900">v{extension.version}</span>
+                      </div>
+                    </div>
+                    <div class="flex flex-row">
+                      <div class="text-sm text-gray-700 italic">{extension.description}</div>
+                    </div>
+                    <div class="flex">
+                      <ConnectionStatus status="{extension.state}" />
                     </div>
                   </div>
-                  <div class="flex flex-row">
-                    <div class="text-sm text-gray-700 italic">{extension.description}</div>
-                  </div>
-                  <div class="flex">
-                    <ConnectionStatus status="{extension.state}" />
-                  </div>
                 </div>
-              </div>
-            </td>
-            <td class="px-2 py-2 whitespace-nowrap">
-              <div class="flex flex-row justify-end">
-                <button
-                  title="Start extension"
-                  on:click="{() => startExtension(extension)}"
-                  class="{buttonClass}"
-                  class:hidden="{extension.state !== 'stopped'}"><Fa class="h-4 w-4" icon="{faPlay}" /></button>
-                <button
-                  title="Stop extension"
-                  class="{buttonClass}"
-                  on:click="{() => stopExtension(extension)}"
-                  hidden
-                  class:hidden="{extension.state !== 'started'}"><Fa class="h-4 w-4" icon="{faStop}" /></button>
+              </td>
+              <td class="px-2 py-2 whitespace-nowrap">
+                <div class="flex flex-row justify-end">
+                  <button
+                    title="Start extension"
+                    on:click="{() => startExtension(extension)}"
+                    class="{buttonClass}"
+                    class:hidden="{extension.state !== 'stopped'}"><Fa class="h-4 w-4" icon="{faPlay}" /></button>
+                  <button
+                    title="Stop extension"
+                    class="{buttonClass}"
+                    on:click="{() => stopExtension(extension)}"
+                    hidden
+                    class:hidden="{extension.state !== 'started'}"><Fa class="h-4 w-4" icon="{faStop}" /></button>
 
-                {#if extension.removable}
-                  {#if extension.state === 'stopped'}
-                    <button title="Remove extension" class="{buttonClass}" on:click="{() => removeExtension(extension)}"
-                      ><Fa class="h-4 w-4" icon="{faTrash}" /></button>
+                  {#if extension.removable}
+                    {#if extension.state === 'stopped'}
+                      <button
+                        title="Remove extension"
+                        class="{buttonClass}"
+                        on:click="{() => removeExtension(extension)}"><Fa class="h-4 w-4" icon="{faTrash}" /></button>
+                    {:else}
+                      <div
+                        class="m-0.5 text-gray-900 rounded-full inline-flex items-center px-2 py-2 text-center"
+                        title="Running extension cannot be removed.">
+                        <Fa class="h-4 w-4" icon="{faTrash}" />
+                      </div>
+                    {/if}
                   {:else}
                     <div
                       class="m-0.5 text-gray-900 rounded-full inline-flex items-center px-2 py-2 text-center"
-                      title="Running extension cannot be removed.">
+                      title="Default extension. Cannot be removed.">
                       <Fa class="h-4 w-4" icon="{faTrash}" />
                     </div>
                   {/if}
-                {:else}
-                  <div
-                    class="m-0.5 text-gray-900 rounded-full inline-flex items-center px-2 py-2 text-center"
-                    title="Default extension. Cannot be removed.">
-                    <Fa class="h-4 w-4" icon="{faTrash}" />
-                  </div>
-                {/if}
-              </div>
-            </td>
-          </tr>
-        {/each}
-      </tbody>
-    </table>
-  </div>
-</SettingsPage>
+                </div>
+              </td>
+            </tr>
+          {/each}
+        </tbody>
+      </table>
+    </div>
+  </div></SettingsPage>


### PR DESCRIPTION
Requires: 
 - [x] : https://github.com/containers/podman-desktop/pull/2346

### What does this PR do?
Display a widget in dashboard and extensions list to install featured extension in one click

### Screenshot/screencast of this PR


https://user-images.githubusercontent.com/436777/236219250-babe29aa-b793-47b7-a052-92e8a623aed7.mp4



### What issues does this PR fix or reference?

related to https://github.com/containers/podman-desktop/issues/1901


### How to test this PR?

It requires commits from
- https://github.com/containers/podman-desktop/pull/2346

There are component tests

How to test: Launch Podman Desktop (and check that for example you don't already have SandBox or OpenShift Local being installed)

Then click on the download icon and wait a little, then extension should be there


Change-Id: I495ad06dd7f27a3779195c3fc503dae3dd6e0cc3
