### PR TITLE
chore: Replace zinc-800 and -900

### DIFF
--- a/packages/renderer/src/lib/ContainerList.svelte
+++ b/packages/renderer/src/lib/ContainerList.svelte
@@ -391,9 +391,9 @@ function errorCallback(container: ContainerInfoUI, errorMessage: string): void {
       {#each containerGroups as containerGroup}
         <tbody>
           {#if containerGroup.type === ContainerGroupInfoTypeUI.COMPOSE || containerGroup.type === ContainerGroupInfoTypeUI.POD}
-            <tr class="group h-12 bg-zinc-900 hover:bg-zinc-700">
+            <tr class="group h-12 bg-charcoal-800 hover:bg-zinc-700">
               <td
-                class="bg-zinc-900 group-hover:bg-zinc-700 pl-2 w-3 rounded-tl-lg"
+                class="bg-charcoal-800 group-hover:bg-zinc-700 pl-2 w-3 rounded-tl-lg"
                 class:rounded-bl-lg="{!containerGroup.expanded}"
                 on:click="{() => toggleContainerGroup(containerGroup)}">
                 <Fa
@@ -465,7 +465,7 @@ function errorCallback(container: ContainerInfoUI, errorMessage: string): void {
           <!-- Display each container of this group -->
           {#if containerGroup.expanded}
             {#each containerGroup.containers as container, index}
-              <tr class="group h-12 bg-zinc-900 hover:bg-zinc-700">
+              <tr class="group h-12 bg-charcoal-800 hover:bg-zinc-700">
                 <td
                   class="{containerGroup.type === ContainerGroupInfoTypeUI.STANDALONE ? 'rounded-tl-lg' : ''} {index ===
                   containerGroup.containers.length - 1
@@ -568,7 +568,7 @@ function errorCallback(container: ContainerInfoUI, errorMessage: string): void {
       openChoiceModal = false;
     }}">
     <div
-      class="inline-block w-full overflow-hidden text-left transition-all transform bg-zinc-800 z-50 h-[200px] rounded-xl shadow-xl shadow-neutral-900"
+      class="inline-block w-full overflow-hidden text-left transition-all transform bg-charcoal-600 z-50 h-[200px] rounded-xl shadow-xl shadow-neutral-900"
       on:keydown="{keydownChoice}">
       <div class="flex items-center justify-between bg-black px-5 py-4 border-b-2 border-violet-700">
         <h1 class="text-xl font-bold">Create a new container</h1>
@@ -577,7 +577,7 @@ function errorCallback(container: ContainerInfoUI, errorMessage: string): void {
           <i class="fas fa-times" aria-hidden="true"></i>
         </button>
       </div>
-      <div class="bg-zinc-800 p-5 h-full flex flex-col justify-items-center">
+      <div class="bg-charcoal-600 p-5 h-full flex flex-col justify-items-center">
         <span class="pb-3">Choose the following:</span>
         <ul class="list-disc ml-8 space-y-2">
           <li>Create a container from a Containerfile</li>

--- a/packages/renderer/src/lib/ImagesList.svelte
+++ b/packages/renderer/src/lib/ImagesList.svelte
@@ -283,7 +283,7 @@ function computeInterval(): number {
       </thead>
       <tbody class="">
         {#each images as image}
-          <tr class="group h-12 bg-zinc-900 hover:bg-zinc-700">
+          <tr class="group h-12 bg-charcoal-800 hover:bg-zinc-700">
             <td class="rounded-tl-lg rounded-bl-lg w-5"> </td>
             <td class="px-2">
               <input
@@ -296,7 +296,7 @@ function computeInterval(): number {
                 title="{image.inUse ? 'Image is used by a container' : ''}"
                 class=" invert hue-rotate-[218deg] brightness-75" />
             </td>
-            <td class="bg-zinc-900 group-hover:bg-zinc-700 flex flex-row justify-center content-center h-12">
+            <td class="bg-charcoal-800 group-hover:bg-zinc-700 flex flex-row justify-center content-center h-12">
               <div class="grid place-content-center ml-3 mr-4">
                 <StatusIcon icon="{ImageIcon}" status="{image.inUse ? 'USED' : 'UNUSED'}" />
               </div>

--- a/packages/renderer/src/lib/dashboard/ProviderConfigured.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderConfigured.svelte
@@ -46,7 +46,7 @@ onMount(() => {
 });
 </script>
 
-<div class="p-2 flex flex-col bg-zinc-900 rounded-lg">
+<div class="p-2 flex flex-col bg-charcoal-800 rounded-lg">
   <ProviderLogo provider="{provider}" />
   <div class="flex flex-col items-center text-center">
     <p class="text-xl text-gray-400">

--- a/packages/renderer/src/lib/dashboard/ProviderInstalled.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderInstalled.svelte
@@ -131,7 +131,7 @@ function onInstallationClick() {
 }
 </script>
 
-<div class="p-2 flex flex-col bg-zinc-900 rounded-lg">
+<div class="p-2 flex flex-col bg-charcoal-800 rounded-lg">
   <ProviderLogo provider="{provider}" />
   <div class="flex flex-col items-center text-center">
     <p class="text-xl text-gray-400">
@@ -159,7 +159,7 @@ function onInstallationClick() {
         </button>
       </div>
       <div class="-z-1 min-w-[130px] m-auto bg-primary text-[13px]" class:hidden="{!installationOptionsMenuVisible}">
-        <ul class="w-full outline-none bg-zinc-900 rounded-sm text-gray-700 placeholder-gray-700">
+        <ul class="w-full outline-none bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700">
           <li>
             <button
               class="w-full p-2 {installationOptionSelected === InitializeOnlyMode

--- a/packages/renderer/src/lib/dashboard/ProviderNotInstalled.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderNotInstalled.svelte
@@ -14,7 +14,7 @@ let detectionChecks: ProviderDetectionCheck[] = [];
 let preflightChecks: CheckStatus[] = [];
 </script>
 
-<div class="p-2 flex flex-col bg-zinc-900 rounded-lg">
+<div class="p-2 flex flex-col bg-charcoal-800 rounded-lg">
   <ProviderLogo provider="{provider}" />
   <div class="flex flex-col items-center text-center">
     <p class="text-xl text-gray-400">

--- a/packages/renderer/src/lib/dashboard/ProviderReady.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderReady.svelte
@@ -11,7 +11,7 @@ export let provider: ProviderInfo;
 let preflightChecks: CheckStatus[] = [];
 </script>
 
-<div class="p-2 flex flex-col bg-zinc-900 rounded-lg">
+<div class="p-2 flex flex-col bg-charcoal-800 rounded-lg">
   <ProviderLogo provider="{provider}" />
   <div class="flex flex-col items-center text-center">
     <p class="text-xl text-gray-400">

--- a/packages/renderer/src/lib/dashboard/ProviderStarting.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderStarting.svelte
@@ -6,7 +6,7 @@ import ProviderLogo from './ProviderLogo.svelte';
 export let provider: ProviderInfo;
 </script>
 
-<div class="p-2 flex flex-col bg-zinc-900 rounded-lg">
+<div class="p-2 flex flex-col bg-charcoal-800 rounded-lg">
   <ProviderLogo provider="{provider}" />
   <div class="flex flex-col items-center text-center">
     <p class="text-xl text-gray-400">

--- a/packages/renderer/src/lib/dashboard/ProviderStopped.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderStopped.svelte
@@ -6,7 +6,7 @@ import ProviderLogo from './ProviderLogo.svelte';
 export let provider: ProviderInfo;
 </script>
 
-<div class="p-2 flex flex-col bg-zinc-900 rounded-lg">
+<div class="p-2 flex flex-col bg-charcoal-800 rounded-lg">
   <ProviderLogo provider="{provider}" />
   <div class="flex flex-col items-center text-center">
     <p class="text-xl text-gray-400">

--- a/packages/renderer/src/lib/dialogs/QuickPickInput.svelte
+++ b/packages/renderer/src/lib/dialogs/QuickPickInput.svelte
@@ -253,11 +253,13 @@ function handleKeydown(e: KeyboardEvent) {
   <div class="absolute m-auto left-0 right-0 z-50">
     <div class=" flex justify-center items-center mt-1">
       <div
-        class="bg-zinc-900 w-[700px] {mode === 'InputBox' ? 'h-16' : ''} shadow-sm p-2 rounded shadow-zinc-700 text-sm">
+        class="bg-charcoal-800 w-[700px] {mode === 'InputBox'
+          ? 'h-16'
+          : ''} shadow-sm p-2 rounded shadow-zinc-700 text-sm">
         {#if title}
           <div
             aria-label="title"
-            class="w-full bg-zinc-800 rounded-sm text-center max-w-[700px] truncate cursor-default">
+            class="w-full bg-charcoal-600 rounded-sm text-center max-w-[700px] truncate cursor-default">
             {title}
           </div>
         {/if}
@@ -269,12 +271,12 @@ function handleKeydown(e: KeyboardEvent) {
             bind:value="{inputValue}"
             class="px-1 w-full text-gray-400 bg-zinc-700 border {validationError
               ? 'border-red-700'
-              : 'border-zinc-800'} focus:outline-none"
+              : 'border-charcoal-600'} focus:outline-none"
             placeholder="{placeHolder}" />
           {#if quickPickCanPickMany}
             <button
               on:click="{() => validateQuickPick()}"
-              class="text-gray-400 bg-violet-600 border border-zinc-800 focus:outline-none px-1">OK</button>
+              class="text-gray-400 bg-violet-600 border border-charcoal-600 focus:outline-none px-1">OK</button>
           {/if}
         </div>
 
@@ -289,7 +291,7 @@ function handleKeydown(e: KeyboardEvent) {
             <div
               class="flex w-full flex-row {i === quickPickSelectedFilteredIndex
                 ? 'bg-violet-500'
-                : 'hover:bg-zinc-800'} ">
+                : 'hover:bg-charcoal-600'} ">
               {#if quickPickCanPickMany}
                 <input type="checkbox" class="mx-1 outline-none" bind:checked="{item.checkbox}" />
               {/if}

--- a/packages/renderer/src/lib/docker-extension/PreferencesPageDockerExtensions.svelte
+++ b/packages/renderer/src/lib/docker-extension/PreferencesPageDockerExtensions.svelte
@@ -48,7 +48,7 @@ function deleteContribution(extensionName: string) {
 </script>
 
 <SettingsPage title="Docker Desktop Extensions">
-  <div class="bg-zinc-800 mt-5 rounded-md p-3">
+  <div class="bg-charcoal-600 mt-5 rounded-md p-3">
     <p class="text-xs">There is an ongoing support of Docker Desktop UI extensions from Podman Desktop.</p>
     <p class="text-xs italic">
       Not all are guaranteed to work but you can add their OCI Image below to try and load them.
@@ -66,7 +66,7 @@ function deleteContribution(extensionName: string) {
           id="ociImage"
           bind:value="{ociImage}"
           placeholder="Name of the Image"
-          class="text-sm rounded-sm focus:ring-purple-500 focus:border-purple-500 block p-2.5 bg-zinc-900 border-gray-900 placeholder-gray-400 text-white"
+          class="text-sm rounded-sm focus:ring-purple-500 focus:border-purple-500 block p-2.5 bg-charcoal-800 border-gray-900 placeholder-gray-400 text-white"
           required />
       </div>
     </div>

--- a/packages/renderer/src/lib/feedback/SendFeedback.svelte
+++ b/packages/renderer/src/lib/feedback/SendFeedback.svelte
@@ -51,7 +51,7 @@ async function sendFeedback(): Promise<void> {
 {#if displayModal}
   <Modal on:close="{() => hideModal()}">
     <div
-      class="inline-block w-full overflow-hidden text-left transition-all transform bg-zinc-800 z-50 rounded-xl shadow-xl shadow-neutral-900">
+      class="inline-block w-full overflow-hidden text-left transition-all transform bg-charcoal-600 z-50 rounded-xl shadow-xl shadow-neutral-900">
       <div class="flex items-center justify-between bg-black px-5 py-4 border-b-2 border-violet-700">
         <h1 class="text-xl font-bold">Share your feedback</h1>
 
@@ -100,7 +100,8 @@ async function sendFeedback(): Promise<void> {
           id="tellUsWhyFeedback"
           bind:value="{tellUsWhyFeedback}"
           placeholder="Leave blank to generate a name"
-          class="w-full p-2 outline-none text-sm bg-zinc-900 rounded-sm text-gray-700 placeholder-gray-700"></textarea>
+          class="w-full p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700"
+        ></textarea>
 
         <label for="contactInformation" class="block mt-4 mb-2 text-sm font-medium text-gray-400 dark:text-gray-400"
           >Share your contact information if you'd like us to answer you:</label>
@@ -110,7 +111,7 @@ async function sendFeedback(): Promise<void> {
           id="contactInformation"
           bind:value="{contactInformation}"
           placeholder="Enter email address, phone number or leave blank for anonymous feedback"
-          class="w-full p-2 outline-none text-sm bg-zinc-900 rounded-sm text-gray-700 placeholder-gray-700" />
+          class="w-full p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700" />
 
         <div class="pt-5 flex flex-row w-full">
           {#if smileyRating === 0}

--- a/packages/renderer/src/lib/help/HelpPage.svelte
+++ b/packages/renderer/src/lib/help/HelpPage.svelte
@@ -21,7 +21,7 @@ $: contributedLinks = $providerInfos
   <div slot="empty" class="flex flex-col min-h-full bg-zinc-700">
     <div class="min-w-full flex-1 pt-5 px-5 pb-5 space-y-5">
       <!-- Getting Started -->
-      <div class="bg-zinc-800 px-3 pt-3 pb-3 rounded-lg">
+      <div class="bg-charcoal-600 px-3 pt-3 pb-3 rounded-lg">
         <div class="text-lg">Getting Started</div>
         <div class="grid grid-cols-1 md:grid-cols-2 py-3">
           <div
@@ -67,7 +67,7 @@ $: contributedLinks = $providerInfos
       {#if contributedLinks.size > 0}
         {#each [...contributedLinks] as [group, links]}
           {#if links.length > 0}
-            <div class="bg-zinc-800 px-3 pt-3 pb-3 rounded-lg">
+            <div class="bg-charcoal-600 px-3 pt-3 pb-3 rounded-lg">
               <div class="text-lg">{group}</div>
               <div class="grid grid-cols-1 md:grid-cols-2 py-3">
                 {#each links as link, index}
@@ -93,7 +93,7 @@ $: contributedLinks = $providerInfos
       {/if}
 
       <!-- Get in Touch -->
-      <div class="bg-zinc-800 px-3 pt-3 pb-3 rounded-lg">
+      <div class="bg-charcoal-600 px-3 pt-3 pb-3 rounded-lg">
         <div class="text-lg">Get in Touch</div>
         <div class="grid grid-cols-1 md:grid-cols-2 py-3">
           <div
@@ -128,7 +128,7 @@ $: contributedLinks = $providerInfos
       </div>
 
       <!-- Communication -->
-      <div class="bg-zinc-800 px-3 pt-3 pb-3 rounded-lg">
+      <div class="bg-charcoal-600 px-3 pt-3 pb-3 rounded-lg">
         <div class="text-lg">Communication</div>
         <div class="grid grid-cols-1 md:grid-cols-2 py-3">
           <div

--- a/packages/renderer/src/lib/image/PushImageModal.svelte
+++ b/packages/renderer/src/lib/image/PushImageModal.svelte
@@ -112,7 +112,7 @@ let pushLogsXtermDiv: HTMLDivElement;
   on:close="{() => {
     closeCallback();
   }}">
-  <div class="modal flex flex-col place-self-center bg-zinc-900 shadow-xl shadow-black">
+  <div class="modal flex flex-col place-self-center bg-charcoal-800 shadow-xl shadow-black">
     <div class="flex items-center justify-between px-6 py-5 space-x-2">
       <h1 class="grow text-lg font-bold capitalize">Push Image</h1>
 
@@ -126,7 +126,7 @@ let pushLogsXtermDiv: HTMLDivElement;
         <label for="modalImageTag" class="block mb-2 text-sm font-medium text-gray-400 dark:text-gray-400"
           >Image Tag</label>
         <select
-          class="border text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 bg-zinc-800 border-gray-900 placeholder-gray-700 text-white"
+          class="border text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 bg-charcoal-600 border-gray-900 placeholder-gray-700 text-white"
           name="imageChoice"
           bind:value="{selectedImageTag}">
           {#each imageTags as imageTag}

--- a/packages/renderer/src/lib/image/RunImage.svelte
+++ b/packages/renderer/src/lib/image/RunImage.svelte
@@ -389,7 +389,7 @@ function checkContainerName(event: any) {
   {#if dataReady}
     <NavPage title="Create a container from image {imageDisplayName}:{image.tag}" searchEnabled="{false}">
       <div slot="empty" class="bg-zinc-700 p-5 h-full">
-        <div class="bg-zinc-800 px-6 py-4 space-y-2 lg:px-8 sm:pb-6 xl:pb-8">
+        <div class="bg-charcoal-600 px-6 py-4 space-y-2 lg:px-8 sm:pb-6 xl:pb-8">
           <section class="pf-c-page__main-tabs pf-m-limit-width">
             <div class="pf-c-page__main-body">
               <div class="pf-c-tabs pf-m-page-insets" id="open-tabs-example-tabs-list">
@@ -446,21 +446,22 @@ function checkContainerName(event: any) {
                   name="modalContainerName"
                   id="modalContainerName"
                   placeholder="Leave blank to generate a name"
-                  class="w-full p-2 outline-none text-sm bg-zinc-900 rounded-sm text-gray-700 placeholder-gray-700 border {containerNameError
+                  class="w-full p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700 border {containerNameError
                     ? 'border-red-500'
-                    : 'border-zinc-900'}" />
+                    : 'border-charcoal-800'}" />
                 <ErrorMessage class="h-1 text-sm" error="{containerNameError}" />
                 <label for="volumes" class="pt-4 block mb-2 text-sm font-medium text-gray-400 dark:text-gray-400"
                   >Volumes:</label>
                 <!-- Display the list of volumes -->
                 {#each volumeMounts as volumeMount, index}
                   <div class="flex flex-row justify-center items-center w-full py-1">
-                    <div class="flex w-full flex-row bg-zinc-900 rounded-sm text-sm text-gray-700 placeholder-gray-700">
+                    <div
+                      class="flex w-full flex-row bg-charcoal-800 rounded-sm text-sm text-gray-700 placeholder-gray-700">
                       <input
                         type="text"
                         bind:value="{volumeMount.source}"
                         placeholder="Path on the host"
-                        class="ml-2 w-full p-2 outline-none bg-zinc-900" />
+                        class="ml-2 w-full p-2 outline-none bg-charcoal-800" />
                       <button
                         title="Open dialog to select a directory"
                         class="p-2 outline-none text-gray-700"
@@ -472,15 +473,15 @@ function checkContainerName(event: any) {
                       type="text"
                       bind:value="{volumeMount.target}"
                       placeholder="Path inside the container"
-                      class="ml-2 w-full p-2 outline-none text-sm bg-zinc-900 rounded-sm text-gray-700 placeholder-gray-700" />
+                      class="ml-2 w-full p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700" />
                     <button
-                      class="ml-2 p-2 outline-none text-sm bg-zinc-900 rounded-sm text-gray-700 placeholder-gray-700"
+                      class="ml-2 p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700"
                       hidden="{index === volumeMounts.length - 1}"
                       on:click="{() => deleteVolumeMount(index)}">
                       <Fa class="h-4 w-4 text-xl" icon="{faMinusCircle}" />
                     </button>
                     <button
-                      class="ml-2 p-2 outline-none text-sm bg-zinc-900 rounded-sm text-gray-700 placeholder-gray-700"
+                      class="ml-2 p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700"
                       hidden="{index < volumeMounts.length - 1}"
                       on:click="{addVolumeMount}">
                       <Fa class="h-4 w-4 text-xl" icon="{faPlusCircle}" />
@@ -500,7 +501,7 @@ function checkContainerName(event: any) {
                       type="text"
                       bind:value="{containerPortMapping[index]}"
                       placeholder="Enter value for port {port}"
-                      class="ml-2 w-full p-2 outline-none text-sm bg-zinc-900 rounded-sm text-gray-700 placeholder-gray-700" />
+                      class="ml-2 w-full p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700" />
                   </div>
                 {/each}
 
@@ -518,14 +519,14 @@ function checkContainerName(event: any) {
                       type="text"
                       bind:value="{hostContainerPortMapping.hostPort}"
                       placeholder="Host Port"
-                      class="w-full p-2 outline-none text-sm bg-zinc-900 rounded-sm text-gray-700 placeholder-gray-700" />
+                      class="w-full p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700" />
                     <input
                       type="text"
                       bind:value="{hostContainerPortMapping.containerPort}"
                       placeholder="Container Port"
-                      class="ml-2 w-full p-2 outline-none text-sm bg-zinc-900 rounded-sm text-gray-700 placeholder-gray-700" />
+                      class="ml-2 w-full p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700" />
                     <button
-                      class="ml-2 p-2 outline-none text-sm bg-zinc-900 rounded-sm text-gray-700 placeholder-gray-700"
+                      class="ml-2 p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700"
                       on:click="{() => deleteHostContainerPorts(index)}">
                       <Fa class="h-4 w-4 text-xl" icon="{faMinusCircle}" />
                     </button>
@@ -542,21 +543,21 @@ function checkContainerName(event: any) {
                       type="text"
                       bind:value="{environmentVariable.key}"
                       placeholder="Name"
-                      class="w-full p-2 outline-none text-sm bg-zinc-900 rounded-sm text-gray-700 placeholder-gray-700" />
+                      class="w-full p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700" />
 
                     <input
                       type="text"
                       bind:value="{environmentVariable.value}"
                       placeholder="Value (leave blank for empty)"
-                      class="ml-2 w-full p-2 outline-none text-sm bg-zinc-900 rounded-sm text-gray-700 placeholder-gray-700" />
+                      class="ml-2 w-full p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700" />
                     <button
-                      class="ml-2 p-2 outline-none text-sm bg-zinc-900 rounded-sm text-gray-700 placeholder-gray-700"
+                      class="ml-2 p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700"
                       hidden="{index === environmentVariables.length - 1}"
                       on:click="{() => deleteEnvVariable(index)}">
                       <Fa class="h-4 w-4 text-xl" icon="{faMinusCircle}" />
                     </button>
                     <button
-                      class="ml-2 p-2 outline-none text-sm bg-zinc-900 rounded-sm text-gray-700 placeholder-gray-700"
+                      class="ml-2 p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700"
                       hidden="{index < environmentVariables.length - 1}"
                       on:click="{addEnvVariable}">
                       <Fa class="h-4 w-4 text-xl" icon="{faPlusCircle}" />
@@ -583,7 +584,7 @@ function checkContainerName(event: any) {
                     type="text"
                     bind:value="{runUser}"
                     placeholder="If you specify a username, user must exist in /etc/passwd file (use user id instead)"
-                    class="ml-2 w-full p-2 outline-none text-sm bg-zinc-900 rounded-sm text-gray-700 placeholder-gray-700" />
+                    class="ml-2 w-full p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700" />
                 </div>
 
                 <!-- Autoremove-->
@@ -605,7 +606,7 @@ function checkContainerName(event: any) {
                     >Policy name:</span>
 
                   <select
-                    class="w-full p-2 outline-none text-sm bg-zinc-900 rounded-sm text-gray-700 placeholder-gray-700"
+                    class="w-full p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700"
                     name="restartPolicyName"
                     bind:value="{restartPolicyName}">
                     <option value="">No restart</option>
@@ -628,7 +629,7 @@ function checkContainerName(event: any) {
                     min="0"
                     bind:value="{restartPolicyMaxRetryCount}"
                     placeholder="Number of times to retry before giving up"
-                    class="w-full p-2 outline-none text-sm bg-zinc-900 rounded-sm text-gray-700 placeholder-gray-700"
+                    class="w-full p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700"
                     disabled="{restartPolicyName !== 'on-failure'}" />
                 </div>
               </div>
@@ -664,16 +665,16 @@ function checkContainerName(event: any) {
                       type="text"
                       bind:value="{securityOpt}"
                       placeholder="Enter a security option (Ex. seccomp=/path/to/profile.json)"
-                      class="ml-2 w-full p-2 outline-none text-sm bg-zinc-900 rounded-sm text-gray-700 placeholder-gray-700" />
+                      class="ml-2 w-full p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700" />
 
                     <button
-                      class="ml-2 p-2 outline-none text-sm bg-zinc-900 rounded-sm text-gray-700 placeholder-gray-700"
+                      class="ml-2 p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700"
                       hidden="{index === securityOpts.length - 1}"
                       on:click="{() => deleteSecurityOpt(index)}">
                       <Fa class="h-4 w-4 text-xl" icon="{faMinusCircle}" />
                     </button>
                     <button
-                      class="ml-2 p-2 outline-none text-sm bg-zinc-900 rounded-sm text-gray-700 placeholder-gray-700"
+                      class="ml-2 p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700"
                       hidden="{index < securityOpts.length - 1}"
                       on:click="{addSecurityOpt}">
                       <Fa class="h-4 w-4 text-xl" icon="{faPlusCircle}" />
@@ -696,16 +697,16 @@ function checkContainerName(event: any) {
                       type="text"
                       bind:value="{capAdd}"
                       placeholder="Enter a kernel capability (Ex. SYS_ADMIN)"
-                      class="ml-4 w-full p-2 outline-none text-sm bg-zinc-900 rounded-sm text-gray-700 placeholder-gray-700" />
+                      class="ml-4 w-full p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700" />
 
                     <button
-                      class="ml-2 p-2 outline-none text-sm bg-zinc-900 rounded-sm text-gray-700 placeholder-gray-700"
+                      class="ml-2 p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700"
                       hidden="{index === capAdds.length - 1}"
                       on:click="{() => deleteCapAdd(index)}">
                       <Fa class="h-4 w-4 text-xl" icon="{faMinusCircle}" />
                     </button>
                     <button
-                      class="ml-2 p-2 outline-none text-sm bg-zinc-900 rounded-sm text-gray-700 placeholder-gray-700"
+                      class="ml-2 p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700"
                       hidden="{index < capAdds.length - 1}"
                       on:click="{addCapAdd}">
                       <Fa class="h-4 w-4 text-xl" icon="{faPlusCircle}" />
@@ -723,16 +724,16 @@ function checkContainerName(event: any) {
                       type="text"
                       bind:value="{capDrop}"
                       placeholder="Enter a kernel capability (Ex. SYS_ADMIN)"
-                      class="ml-4 w-full p-2 outline-none text-sm bg-zinc-900 rounded-sm text-gray-700 placeholder-gray-700" />
+                      class="ml-4 w-full p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700" />
 
                     <button
-                      class="ml-2 p-2 outline-none text-sm bg-zinc-900 rounded-sm text-gray-700 placeholder-gray-700"
+                      class="ml-2 p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700"
                       hidden="{index === capDrops.length - 1}"
                       on:click="{() => deleteCappDrop(index)}">
                       <Fa class="h-4 w-4 text-xl" icon="{faMinusCircle}" />
                     </button>
                     <button
-                      class="ml-2 p-2 outline-none text-sm bg-zinc-900 rounded-sm text-gray-700 placeholder-gray-700"
+                      class="ml-2 p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700"
                       hidden="{index < capDrops.length - 1}"
                       on:click="{addCapDrop}">
                       <Fa class="h-4 w-4 text-xl" icon="{faPlusCircle}" />
@@ -750,7 +751,7 @@ function checkContainerName(event: any) {
                     type="text"
                     bind:value="{userNamespace}"
                     placeholder="Enter a user namespace"
-                    class="ml-2 w-full p-2 outline-none text-sm bg-zinc-900 rounded-sm text-gray-700 placeholder-gray-700" />
+                    class="ml-2 w-full p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700" />
                 </div>
               </div>
             </Route>
@@ -765,7 +766,7 @@ function checkContainerName(event: any) {
                     type="text"
                     bind:value="{hostname}"
                     placeholder="Must be a valid RFC 1123 hostname"
-                    class="ml-2 w-full p-2 outline-none text-sm bg-zinc-900 rounded-sm text-gray-700 placeholder-gray-700" />
+                    class="ml-2 w-full p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700" />
                 </div>
 
                 <!-- DNS -->
@@ -778,16 +779,16 @@ function checkContainerName(event: any) {
                       type="text"
                       bind:value="{dnsServer}"
                       placeholder="IP Address"
-                      class="ml-2 w-full p-2 outline-none text-sm bg-zinc-900 rounded-sm text-gray-700 placeholder-gray-700" />
+                      class="ml-2 w-full p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700" />
 
                     <button
-                      class="ml-2 p-2 outline-none text-sm bg-zinc-900 rounded-sm text-gray-700 placeholder-gray-700"
+                      class="ml-2 p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700"
                       hidden="{index === dnsServers.length - 1}"
                       on:click="{() => deleteDnsServer(index)}">
                       <Fa class="h-4 w-4 text-xl" icon="{faMinusCircle}" />
                     </button>
                     <button
-                      class="ml-2 p-2 outline-none text-sm bg-zinc-900 rounded-sm text-gray-700 placeholder-gray-700"
+                      class="ml-2 p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700"
                       hidden="{index < dnsServers.length - 1}"
                       on:click="{addDnsServer}">
                       <Fa class="h-4 w-4 text-xl" icon="{faPlusCircle}" />
@@ -806,21 +807,21 @@ function checkContainerName(event: any) {
                       type="text"
                       bind:value="{extraHost.host}"
                       placeholder="Hostname"
-                      class="ml-2 w-full p-2 outline-none text-sm bg-zinc-900 rounded-sm text-gray-700 placeholder-gray-700" />
+                      class="ml-2 w-full p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700" />
 
                     <input
                       type="text"
                       bind:value="{extraHost.ip}"
                       placeholder="IP Address"
-                      class="ml-2 w-full p-2 outline-none text-sm bg-zinc-900 rounded-sm text-gray-700 placeholder-gray-700" />
+                      class="ml-2 w-full p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700" />
                     <button
-                      class="ml-2 p-2 outline-none text-sm bg-zinc-900 rounded-sm text-gray-700 placeholder-gray-700"
+                      class="ml-2 p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700"
                       hidden="{index === extraHosts.length - 1}"
                       on:click="{() => deleteExtraHost(index)}">
                       <Fa class="h-4 w-4 text-xl" icon="{faMinusCircle}" />
                     </button>
                     <button
-                      class="ml-2 p-2 outline-none text-sm bg-zinc-900 rounded-sm text-gray-700 placeholder-gray-700"
+                      class="ml-2 p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700"
                       hidden="{index < extraHosts.length - 1}"
                       on:click="{addExtraHost}">
                       <Fa class="h-4 w-4 text-xl" icon="{faPlusCircle}" />
@@ -837,7 +838,7 @@ function checkContainerName(event: any) {
                   <span class="text-sm w-28 inline-block align-middle whitespace-nowrap text-gray-700">Mode:</span>
 
                   <select
-                    class="w-full p-2 outline-none text-sm bg-zinc-900 rounded-sm text-gray-700 placeholder-gray-700"
+                    class="w-full p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700"
                     name="providerChoice"
                     bind:value="{networkingMode}">
                     <option value="bridge">Creates a network stack on the default bridge (default)</option>
@@ -853,7 +854,7 @@ function checkContainerName(event: any) {
                   <div class="flex flex-row justify-center items-center w-full py-1">
                     <span class="text-sm w-28 inline-block align-middle whitespace-nowrap text-gray-700">Network:</span>
                     <select
-                      class="w-full p-2 outline-none text-sm bg-zinc-900 rounded-sm text-gray-700 placeholder-gray-700"
+                      class="w-full p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700"
                       disabled="{networkingMode !== 'choice-network'}"
                       name="networkingModeUserNetwork"
                       bind:value="{networkingModeUserNetwork}">
@@ -869,7 +870,7 @@ function checkContainerName(event: any) {
                     <span class="text-sm w-28 inline-block align-middle whitespace-nowrap text-gray-700"
                       >Container:</span>
                     <select
-                      class="w-full p-2 outline-none text-sm bg-zinc-900 rounded-sm text-gray-700 placeholder-gray-700"
+                      class="w-full p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700"
                       disabled="{networkingMode !== 'choice-container'}"
                       name="networkingModeUserContainer"
                       bind:value="{networkingModeUserContainer}">

--- a/packages/renderer/src/lib/pod/DeployPodToKube.svelte
+++ b/packages/renderer/src/lib/pod/DeployPodToKube.svelte
@@ -334,7 +334,7 @@ function updateKubeResult() {
 
 <NavPage title="Deploy generated pod to Kubernetes" searchEnabled="{false}">
   <div slot="empty" class="p-5 bg-zinc-700 h-full">
-    <div class="bg-zinc-800 h-full p-5">
+    <div class="bg-charcoal-600 h-full p-5">
       {#if kubeDetails}
         <p>Generated pod to deploy to Kubernetes:</p>
         <div class="h-1/3 pt-2">
@@ -350,7 +350,7 @@ function updateKubeResult() {
             bind:value="{bodyPod.metadata.name}"
             name="podName"
             id="podName"
-            class=" cursor-default w-full p-2 outline-none text-sm bg-zinc-900 rounded-sm text-gray-700 placeholder-gray-700"
+            class=" cursor-default w-full p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700"
             required />
         </div>
       {/if}
@@ -412,7 +412,7 @@ function updateKubeResult() {
             bind:value="{ingressPort}"
             name="serviceName"
             id="serviceName"
-            class=" cursor-default w-full p-2 outline-none text-sm bg-zinc-900 rounded-sm text-gray-400 placeholder-gray-400"
+            class=" cursor-default w-full p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-400 placeholder-gray-400"
             required>
             <option value="" disabled selected>Select a port</option>
             {#each containerPortArray as port}
@@ -444,7 +444,7 @@ function updateKubeResult() {
             name="defaultContextName"
             id="defaultContextName"
             readonly
-            class="cursor-default w-full p-2 outline-none text-sm bg-zinc-900 rounded-sm text-gray-700 placeholder-gray-700"
+            class="cursor-default w-full p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700"
             required />
         </div>
       {/if}
@@ -453,7 +453,7 @@ function updateKubeResult() {
         <div class="pt-2">
           <label for="namespaceToUse" class="block mb-1 text-sm font-medium text-gray-400">Kubernetes namespace:</label>
           <select
-            class="w-full p-2 outline-none text-sm bg-zinc-900 rounded-sm text-gray-700 placeholder-gray-700"
+            class="w-full p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700"
             name="namespaceChoice"
             bind:value="{currentNamespace}">
             {#each allNamespaces.items as namespace}
@@ -488,7 +488,7 @@ function updateKubeResult() {
       {/if}
 
       {#if createdPod}
-        <div class="bg-zinc-900 p-5 my-4">
+        <div class="bg-charcoal-800 p-5 my-4">
           <div class="flex flex-row items-center">
             <div>Created pod:</div>
             {#if openshiftConsoleURL && createdPod?.metadata?.name}

--- a/packages/renderer/src/lib/pod/PodCreateFromContainers.svelte
+++ b/packages/renderer/src/lib/pod/PodCreateFromContainers.svelte
@@ -215,7 +215,7 @@ function updatePortExposure(port: number, checked: boolean) {
               class="p-2 block mb-2 text-sm font-medium rounded bg-zinc-700 text-gray-300 dark:text-gray-300"
               >Container Engine
               <select
-                class="w-full p-2 outline-none text-sm bg-zinc-900 rounded-sm text-gray-400 placeholder-gray-400"
+                class="w-full p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-400 placeholder-gray-400"
                 name="providerChoice"
                 bind:value="{selectedProvider}">
                 {#each providerConnections as providerConnection}

--- a/packages/renderer/src/lib/pod/PodsList.svelte
+++ b/packages/renderer/src/lib/pod/PodsList.svelte
@@ -267,7 +267,7 @@ function errorCallback(pod: PodInfoUI, errorMessage: string): void {
       </thead>
       <tbody class="">
         {#each pods as pod}
-          <tr class="group h-12 bg-zinc-900 hover:bg-zinc-700">
+          <tr class="group h-12 bg-charcoal-800 hover:bg-zinc-700">
             <td class="rounded-tl-lg rounded-bl-lg w-5"> </td>
             <td class="px-2">
               <input
@@ -275,7 +275,7 @@ function errorCallback(pod: PodInfoUI, errorMessage: string): void {
                 bind:checked="{pod.selected}"
                 class="cursor-pointer invert hue-rotate-[218deg] brightness-75" />
             </td>
-            <td class="bg-zinc-900 group-hover:bg-zinc-700 flex flex-row justify-center h-12">
+            <td class="bg-charcoal-800 group-hover:bg-zinc-700 flex flex-row justify-center h-12">
               <div class="grid place-content-center ml-3 mr-4">
                 <StatusIcon icon="{PodIcon}" status="{pod.status}" />
               </div>

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionActions.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionActions.svelte
@@ -144,7 +144,7 @@ function getLoggerHandler(
   {#if connection.lifecycleMethods && connection.lifecycleMethods.length > 0}
     <div class="mt-2 relative">
       <!-- TODO: see action available like machine infos -->
-      <div class="flex bg-zinc-900 w-fit rounded-lg m-auto">
+      <div class="flex bg-charcoal-800 w-fit rounded-lg m-auto">
         {#if connection.lifecycleMethods.includes('start')}
           <div class="ml-2">
             <LoadingIconButton

--- a/packages/renderer/src/lib/preferences/PreferencesContainerConnectionRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesContainerConnectionRendering.svelte
@@ -167,7 +167,7 @@ async function stopReceivingLogs(provider: ProviderInfo): Promise<void> {
 </script>
 
 <Route path="/*" breadcrumb="{connectionName} Settings" let:meta>
-  <div class="flex flex-1 flex-col bg-zinc-800 px-2">
+  <div class="flex flex-1 flex-col bg-charcoal-600 px-2">
     <div class="flex flex-row align-middle my-4">
       <div class="capitalize text-xl">{connectionName} settings</div>
       {#if providerInfo?.containerProviderConnectionCreation}

--- a/packages/renderer/src/lib/preferences/PreferencesExtensionList.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesExtensionList.svelte
@@ -19,7 +19,7 @@ let logs: string[] = [];
 let logElement;
 
 const buttonClass: string =
-  'm-0.5 text-gray-400 hover:bg-zinc-800 hover:text-violet-600 font-medium rounded-full inline-flex items-center px-2 py-2 text-center';
+  'm-0.5 text-gray-400 hover:bg-charcoal-600 hover:text-violet-600 font-medium rounded-full inline-flex items-center px-2 py-2 text-center';
 
 async function installExtensionFromImage() {
   errorInstall = '';
@@ -65,7 +65,7 @@ async function removeExtension(extension: ExtensionInfo) {
 </script>
 
 <SettingsPage title="Extensions">
-  <div class="bg-zinc-800 mt-5 rounded-md p-3">
+  <div class="bg-charcoal-600 mt-5 rounded-md p-3">
     <h1 class="text-lg mb-2">Install a new extension from OCI Image</h1>
 
     <div class="flex flex-col w-full">
@@ -75,7 +75,7 @@ async function removeExtension(extension: ExtensionInfo) {
           id="ociImage"
           bind:value="{ociImage}"
           placeholder="Name of the Image"
-          class="w-1/2 p-2 outline-none text-sm bg-zinc-900 rounded-sm text-gray-700 placeholder-gray-700"
+          class="w-1/2 p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700"
           required />
 
         <button
@@ -113,7 +113,7 @@ async function removeExtension(extension: ExtensionInfo) {
       </div>
     </div>
   </div>
-  <div class="bg-zinc-800 mt-5 rounded-md p-3">
+  <div class="bg-charcoal-600 mt-5 rounded-md p-3">
     <table class="min-w-full">
       <tbody>
         {#each $extensionInfos as extension}

--- a/packages/renderer/src/lib/preferences/PreferencesExtensionRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesExtensionRendering.svelte
@@ -26,7 +26,7 @@ async function removeExtension() {
   <span slot="subtitle">
     {extensionInfo.description}
   </span>
-  <div class="bg-zinc-800 mt-5 rounded-md p-3">
+  <div class="bg-charcoal-600 mt-5 rounded-md p-3">
     {#if extensionInfo}
       <Route path="/*" breadcrumb="{extensionInfo.displayName}" let:meta>
         <!-- Manage lifecycle-->

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesConnectionRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesConnectionRendering.svelte
@@ -110,7 +110,7 @@ async function stopReceivingLogs(provider: ProviderInfo): Promise<void> {
 </script>
 
 <Route path="/*" breadcrumb="{connectionName} Settings" let:meta>
-  <div class="flex flex-1 flex-col bg-zinc-800 px-2">
+  <div class="flex flex-1 flex-col bg-charcoal-600 px-2">
     <div class="flex flex-row align-middle my-4">
       <div class="capitalize text-xl">{connectionName}</div>
       {#if providerInfo?.containerProviderConnectionCreation}

--- a/packages/renderer/src/lib/preferences/PreferencesProviderRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesProviderRendering.svelte
@@ -66,7 +66,7 @@ async function stopReceivingLogs(provider: ProviderInfo): Promise<void> {
 </script>
 
 <Route path="/*" breadcrumb="{providerInfo?.name}" let:meta>
-  <div class="flex flex-1 flex-col bg-zinc-900 px-6 py-1">
+  <div class="flex flex-1 flex-col bg-charcoal-800 px-6 py-1">
     <div>
       <button
         aria-label="Close"

--- a/packages/renderer/src/lib/preferences/PreferencesProxiesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesProxiesRendering.svelte
@@ -21,7 +21,7 @@ async function updateProxyState() {
 </script>
 
 <SettingsPage title="Proxy Settings">
-  <div class="container mx-auto bg-zinc-800 mt-5 rounded-md p-3">
+  <div class="container mx-auto bg-charcoal-600 mt-5 rounded-md p-3">
     <!-- if proxy is not enabled, display a toggle -->
 
     <label for="toggle-proxy" class="inline-flex relative items-center mt-2 mb-5 cursor-pointer">
@@ -50,7 +50,7 @@ async function updateProxyState() {
           id="httpProxy"
           disabled="{!proxyState}"
           bind:value="{proxySettings.httpProxy}"
-          class="w-full outline-none text-sm bg-zinc-900 rounded-sm text-gray-700 placeholder-gray-700"
+          class="w-full outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700"
           required />
       </div>
       <div>
@@ -64,7 +64,7 @@ async function updateProxyState() {
           id="httpsProxy"
           disabled="{!proxyState}"
           bind:value="{proxySettings.httpsProxy}"
-          class="w-full p-2 outline-none text-sm bg-zinc-900 rounded-sm text-gray-700 placeholder-gray-700"
+          class="w-full p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700"
           required />
       </div>
       <div>
@@ -79,7 +79,7 @@ async function updateProxyState() {
           disabled="{!proxyState}"
           bind:value="{proxySettings.noProxy}"
           placeholder="Example: *.domain.com, 192.168.*.*"
-          class="w-full outline-none text-sm bg-zinc-900 rounded-sm text-gray-700 placeholder-gray-700"
+          class="w-full outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700"
           required />
       </div>
       {#if proxyState}

--- a/packages/renderer/src/lib/preferences/PreferencesRegistriesEditing.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRegistriesEditing.svelte
@@ -217,7 +217,7 @@ const processPasswordElement = (node: HTMLInputElement, registry: containerDeskt
 </script>
 
 <SettingsPage title="Registries">
-  <div class="container mx-auto bg-zinc-800 mt-5 rounded-md p-3">
+  <div class="container mx-auto bg-charcoal-600 mt-5 rounded-md p-3">
     <!-- Registries table start -->
     <div class="w-full border-t border-b border-gray-900">
       <div class="flex w-full">
@@ -262,7 +262,7 @@ const processPasswordElement = (node: HTMLInputElement, registry: containerDeskt
                     type="text"
                     placeholder="Username"
                     bind:value="{registry.username}"
-                    class="block px-3 block w-full h-full transition ease-in-out delay-50 bg-zinc-900 text-gray-700 placeholder-gray-700 rounded-sm focus:outline-none" />
+                    class="block px-3 block w-full h-full transition ease-in-out delay-50 bg-charcoal-800 text-gray-700 placeholder-gray-700 rounded-sm focus:outline-none" />
                 </div>
               {:else if !registry.username && !registry.secret}
                 <button class="font-bold" on:click="{() => markRegistryAsModified(registry)}">Login now</button>
@@ -305,7 +305,7 @@ const processPasswordElement = (node: HTMLInputElement, registry: containerDeskt
                         type="password"
                         placeholder="Password"
                         bind:value="{registry.secret}"
-                        class="px-3 block w-full h-full transition ease-in-out delay-50 bg-zinc-900 text-gray-700 placeholder-gray-700 rounded-sm focus:outline-none pr-10" />
+                        class="px-3 block w-full h-full transition ease-in-out delay-50 bg-charcoal-800 text-gray-700 placeholder-gray-700 rounded-sm focus:outline-none pr-10" />
                     </div>
                   </div>
                   <div class="h-7 mt-1.5 mb-0.5 text-sm">
@@ -428,7 +428,7 @@ const processPasswordElement = (node: HTMLInputElement, registry: containerDeskt
                   type="text"
                   placeholder="Username"
                   bind:value="{newRegistryRequest.username}"
-                  class="px-3 block w-full h-7 pr-5 mb-0.5 transition ease-in-out delay-50 bg-zinc-900 text-gray-700 placeholder-gray-700 rounded-sm focus:outline-none" />
+                  class="px-3 block w-full h-7 pr-5 mb-0.5 transition ease-in-out delay-50 bg-charcoal-800 text-gray-700 placeholder-gray-700 rounded-sm focus:outline-none" />
               {/if}
             </div>
             <div class="pt-4 pb-2 text-sm w-2/5">
@@ -460,7 +460,7 @@ const processPasswordElement = (node: HTMLInputElement, registry: containerDeskt
                       type="password"
                       placeholder="Password"
                       bind:value="{newRegistryRequest.secret}"
-                      class="px-3 block w-full h-7 transition ease-in-out delay-50 bg-zinc-900 text-gray-700 placeholder-gray-700 rounded-sm focus:outline-none pr-10" />
+                      class="px-3 block w-full h-7 transition ease-in-out delay-50 bg-charcoal-800 text-gray-700 placeholder-gray-700 rounded-sm focus:outline-none pr-10" />
                   {/if}
                 </div>
 
@@ -519,14 +519,14 @@ const processPasswordElement = (node: HTMLInputElement, registry: containerDeskt
                 type="text"
                 placeholder="URL (HTTPS only)"
                 bind:value="{newRegistryRequest.serverUrl}"
-                class="px-3 block w-full h-7 pr-5 mb-0.5 transition ease-in-out delay-50 bg-zinc-900 text-gray-700 placeholder-gray-700 rounded-sm focus:outline-none" />
+                class="px-3 block w-full h-7 pr-5 mb-0.5 transition ease-in-out delay-50 bg-charcoal-800 text-gray-700 placeholder-gray-700 rounded-sm focus:outline-none" />
             </div>
             <div class="flex pt-4 pb-2 pr-5 text-sm w-1/4">
               <input
                 type="text"
                 placeholder="Username"
                 bind:value="{newRegistryRequest.username}"
-                class="px-3 block w-full h-7 pr-5 mb-0.5 transition ease-in-out delay-50 bg-zinc-900 text-gray-700 placeholder-gray-700 rounded-sm focus:outline-none" />
+                class="px-3 block w-full h-7 pr-5 mb-0.5 transition ease-in-out delay-50 bg-charcoal-800 text-gray-700 placeholder-gray-700 rounded-sm focus:outline-none" />
             </div>
             <div class="pt-4 pb-2 text-sm w-2/5">
               <div class="flex flex-row">
@@ -556,7 +556,7 @@ const processPasswordElement = (node: HTMLInputElement, registry: containerDeskt
                     type="password"
                     placeholder="Password"
                     bind:value="{newRegistryRequest.secret}"
-                    class="px-3 block w-full h-7 transition ease-in-out delay-50 bg-zinc-900 text-gray-700 placeholder-gray-700 rounded-sm focus:outline-none pr-10" />
+                    class="px-3 block w-full h-7 transition ease-in-out delay-50 bg-charcoal-800 text-gray-700 placeholder-gray-700 rounded-sm focus:outline-none pr-10" />
                 </div>
 
                 <div class="flex text-sm">

--- a/packages/renderer/src/lib/preferences/PreferencesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRendering.svelte
@@ -81,7 +81,7 @@ function updateSearchValue(event: any) {
           <div class="mt-5">
             <div class="first-letter:uppercase">{configSection.replace('preferences.', '').replace('.', ' ')}</div>
             {#each matchingRecords.get(configSection) as configItem}
-              <div class="bg-zinc-800 rounded-md mt-2 ml-2">
+              <div class="bg-charcoal-600 rounded-md mt-2 ml-2">
                 <PreferencesRenderingItem record="{configItem}" />
               </div>
             {/each}

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
@@ -222,7 +222,7 @@ function handleCleanValue(
           aria-invalid="{invalidEntry}"
           aria-label="{record.description || record.markdownDescription}" />
         <div
-          class="w-8 h-[20px] bg-gray-900 rounded-full peer peer-checked:after:translate-x-full after:bg-zinc-800 after:content-[''] after:absolute after:top-[4px] after:left-[61px] after:rounded-full after:h-3 after:w-3 after:transition-all peer-checked:bg-violet-600">
+          class="w-8 h-[20px] bg-gray-900 rounded-full peer peer-checked:after:translate-x-full after:bg-charcoal-600 after:content-[''] after:absolute after:top-[4px] after:left-[61px] after:rounded-full after:h-3 after:w-3 after:transition-all peer-checked:bg-violet-600">
         </div>
       </label>
     {:else if enableSlider && record.type === 'number' && typeof record.maximum === 'number'}
@@ -238,13 +238,13 @@ function handleCleanValue(
         class="w-full h-1 bg-[var(--pf-global--primary-color--300)] rounded-lg appearance-none accent-[var(--pf-global--primary-color--300)] cursor-pointer range-xs mt-2" />
     {:else if record.type === 'number'}
       <div
-        class="flex flex-row rounded-sm bg-zinc-700 text-sm divide-x divide-zinc-900 w-24 border-b border-violet-500">
+        class="flex flex-row rounded-sm bg-zinc-700 text-sm divide-x divide-charcoal-800 w-24 border-b border-violet-500">
         <button
           data-action="decrement"
           on:click="{e => decrement(e, record)}"
           disabled="{!canDecrement(recordValue, record.minimum)}"
           class="w-11 text-white {!canDecrement(recordValue, record.minimum)
-            ? 'bg-charcoal-600 text-charcoal-100 border-t border-l border-zinc-900'
+            ? 'bg-charcoal-600 text-charcoal-100 border-t border-l border-charcoal-800'
             : 'hover:text-gray-900 hover:bg-gray-700'} cursor-pointer outline-none">
           <span class="m-auto font-thin">−</span>
         </button>
@@ -260,7 +260,7 @@ function handleCleanValue(
           on:click="{e => increment(e, record)}"
           disabled="{!canIncrement(recordValue, record.maximum)}"
           class="w-11 text-white {!canIncrement(recordValue, record.maximum)
-            ? 'bg-charcoal-600 text-charcoal-100 border-t border-l border-zinc-900'
+            ? 'bg-charcoal-600 text-charcoal-100 border-t border-l border-charcoal-800'
             : 'hover:text-gray-900 hover:bg-gray-700'} cursor-pointer outline-none">
           <span class="m-auto font-thin">+</span>
         </button>

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
@@ -218,11 +218,11 @@ async function startConnectionProvider(
           icon="{EngineIcon}"
           title="No resources found"
           message="Start an extension that manages containers or Kubernetes engines"
-          class="bg-zinc-800 mt-5 pb-10" />
+          class="bg-charcoal-600 mt-5 pb-10" />
       </div>
     {:else}
       {#each providers as provider}
-        <div class="bg-zinc-800 mt-5 rounded-md p-3 divide-x divide-gray-900 flex">
+        <div class="bg-charcoal-600 mt-5 rounded-md p-3 divide-x divide-gray-900 flex">
           <div>
             <!-- left col - provider icon/name + "create new" button -->
             <div class="min-w-[150px] max-w-[200px]">

--- a/packages/renderer/src/lib/task-manager/TaskManager.svelte
+++ b/packages/renderer/src/lib/task-manager/TaskManager.svelte
@@ -53,13 +53,13 @@ window.events?.receive('toggle-task-manager', () => {
 <svelte:window on:keyup="{handleEscape}" />
 
 {#if showTaskManager}
-  <div title="Tasks manager" class="fixed bottom-9 right-4 bg-zinc-900 h-96 w-80 z-40">
+  <div title="Tasks manager" class="fixed bottom-9 right-4 bg-charcoal-800 h-96 w-80 z-40">
     <!-- Draw the arrow below the box-->
     <div
       class="absolute bottom-0 z-50 right-[17px] transform -translate-x-1/2 translate-y-1/2 rotate-45 w-4 h-4 {$tasksInfo.length >
       0
-        ? 'bg-zinc-900'
-        : 'bg-zinc-800'} border-r border-b border-zinc-600">
+        ? 'bg-charcoal-800'
+        : 'bg-charcoal-600'} border-r border-b border-zinc-600">
     </div>
 
     <div title="" class="flex flex-col h-full w-full border border-zinc-600">
@@ -71,11 +71,11 @@ window.events?.receive('toggle-task-manager', () => {
           <div class="text-xs uppercase ml-2">tasks</div>
           <div class="flex-1"></div>
           <!--
-          <div title="Toggle Do Not Disturb Mode" class="cursor-pointer hover:bg-zinc-800 p-1">
+          <div title="Toggle Do Not Disturb Mode" class="cursor-pointer hover:bg-charcoal-600 p-1">
             <BellSlashIcon size="15" />
           </div>
           -->
-          <button on:click="{() => hide()}" title="Hide (Escape)" class="cursor-pointer hover:bg-zinc-800 p-1 ml-1">
+          <button on:click="{() => hide()}" title="Hide (Escape)" class="cursor-pointer hover:bg-charcoal-600 p-1 ml-1">
             <Fa icon="{faChevronDown}" size="15" />
           </button>
         </div>
@@ -87,7 +87,7 @@ window.events?.receive('toggle-task-manager', () => {
           {#if runningTasks.length > 0}
             <div class="flex bg-zinc-700 px-4">
               <TaskManagerGroup
-                lineColor="bg-zinc-800"
+                lineColor="bg-charcoal-600"
                 icon="{faCircle}"
                 tasks="{runningTasks}"
                 title="running tasks" />
@@ -96,7 +96,7 @@ window.events?.receive('toggle-task-manager', () => {
 
           <!-- completed tasks-->
           {#if completedTasks.length > 0}
-            <div class="flex bg-zinc-800 pt-1 px-4">
+            <div class="flex bg-charcoal-600 pt-1 px-4">
               <TaskManagerGroup
                 lineColor="bg-zinc-400"
                 icon="{faCheck}"

--- a/packages/renderer/src/lib/task-manager/TaskManagerEmptyScreen.svelte
+++ b/packages/renderer/src/lib/task-manager/TaskManagerEmptyScreen.svelte
@@ -2,7 +2,7 @@
 import TaskIcon from '../images/TaskIcon.svelte';
 </script>
 
-<div class="flex flex-row grow bg-zinc-800 items-center justify-center">
+<div class="flex flex-row grow bg-charcoal-600 items-center justify-center">
   <div class="flex flex-col items-center">
     <div class=""><TaskIcon /></div>
 

--- a/packages/renderer/src/lib/task-manager/TaskManagerItem.svelte
+++ b/packages/renderer/src/lib/task-manager/TaskManagerItem.svelte
@@ -59,7 +59,7 @@ function gotoTask(taskUI: TaskUI) {
         {#if taskUI.state === 'completed'}
           <button
             title="Clear notification"
-            class="hover:bg-zinc-900 hover:text-purple-500"
+            class="hover:bg-charcoal-800 hover:text-purple-500"
             on:click="{() => closeCompleted(taskUI)}"><Fa size="12" icon="{faClose}" /></button>
         {/if}
       </div>

--- a/packages/renderer/src/lib/ui/DropDownMenuItems.svelte
+++ b/packages/renderer/src/lib/ui/DropDownMenuItems.svelte
@@ -23,6 +23,6 @@ onMount(() => {
 <div
   bind:clientHeight="{dropDownHeight}"
   bind:this="{dropDownElement}"
-  class="origin-top-right absolute right-0 z-10 m-2 rounded-md shadow-lg bg-zinc-900 ring-1 ring-black ring-opacity-5 divide-y divide-gray-900 focus:outline-none">
+  class="origin-top-right absolute right-0 z-10 m-2 rounded-md shadow-lg bg-charcoal-800 ring-1 ring-black ring-opacity-5 divide-y divide-gray-900 focus:outline-none">
   <slot />
 </div>

--- a/packages/renderer/src/lib/ui/DropdownMenu.svelte
+++ b/packages/renderer/src/lib/ui/DropdownMenu.svelte
@@ -41,7 +41,7 @@ function onWindowClick(e) {
       toggleMenu();
     }}"
     bind:this="{outsideWindow}"
-    class="mr-2 text-gray-400 hover:bg-zinc-900 hover:text-violet-600 font-medium rounded-full inline-flex items-center px-2 py-2 text-center">
+    class="mr-2 text-gray-400 hover:bg-charcoal-800 hover:text-violet-600 font-medium rounded-full inline-flex items-center px-2 py-2 text-center">
     <Fa class="h-4 w-4" icon="{faEllipsisVertical}" />
   </button>
 

--- a/packages/renderer/src/lib/ui/ListItemButtonIcon.svelte
+++ b/packages/renderer/src/lib/ui/ListItemButtonIcon.svelte
@@ -18,11 +18,11 @@ let positionTopClass = 'top-1';
 if (detailed) positionTopClass = '[0.2rem]';
 
 const buttonDetailedClass: string =
-  'mx-1 text-gray-400 bg-zinc-900 hover:text-violet-600 font-medium rounded-lg text-sm inline-flex items-center px-3 py-2 text-center';
+  'mx-1 text-gray-400 bg-charcoal-800 hover:text-violet-600 font-medium rounded-lg text-sm inline-flex items-center px-3 py-2 text-center';
 const buttonDetailedDisabledClass: string =
-  'mx-1 text-gray-900 bg-zinc-900 font-medium rounded-lg text-sm inline-flex items-center px-3 py-2 text-center';
+  'mx-1 text-gray-900 bg-charcoal-800 font-medium rounded-lg text-sm inline-flex items-center px-3 py-2 text-center';
 const buttonClass: string =
-  'm-0.5 text-gray-400 hover:bg-zinc-800 hover:text-violet-600 font-medium rounded-full inline-flex items-center px-2 py-2 text-center';
+  'm-0.5 text-gray-400 hover:bg-charcoal-600 hover:text-violet-600 font-medium rounded-full inline-flex items-center px-2 py-2 text-center';
 const buttonDisabledClass: string =
   'm-0.5 text-gray-900 font-medium rounded-full inline-flex items-center px-2 py-2 text-center';
 

--- a/packages/renderer/src/lib/ui/NavPage.svelte
+++ b/packages/renderer/src/lib/ui/NavPage.svelte
@@ -19,7 +19,7 @@ export let searchEnabled: boolean = true;
     {#if searchEnabled}
       <div class="flex flex-row pt-2 pb-4">
         <div class="pl-5 lg:w-[35rem] w-[22rem]">
-          <div class="flex items-center bg-zinc-900 text-gray-700 rounded-sm">
+          <div class="flex items-center bg-charcoal-800 text-gray-700 rounded-sm">
             <svg
               xmlns="http://www.w3.org/2000/svg"
               class="w-5 h-5 ml-2 mr-2"
@@ -37,7 +37,7 @@ export let searchEnabled: boolean = true;
               type="text"
               name="containerSearchName"
               placeholder="Search {title}...."
-              class="w-full py-2 outline-none text-sm bg-zinc-900 rounded-sm text-gray-700 placeholder-gray-700" />
+              class="w-full py-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700" />
           </div>
         </div>
         <div class="flex flex-1 px-5">

--- a/packages/renderer/src/lib/ui/Tooltip.svelte
+++ b/packages/renderer/src/lib/ui/Tooltip.svelte
@@ -45,7 +45,7 @@ export let left = false;
     class:bottom="{bottom}"
     class:top="{top}">
     {#if tip}
-      <div class="inline-block py-2 px-4 rounded-md bg-zinc-900 text-xs">{tip}</div>
+      <div class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs">{tip}</div>
     {/if}
   </div>
 </div>

--- a/packages/renderer/src/lib/volume/VolumesList.svelte
+++ b/packages/renderer/src/lib/volume/VolumesList.svelte
@@ -232,7 +232,7 @@ function computeInterval(): number {
       </thead>
       <tbody class="">
         {#each volumes as volume}
-          <tr class="group h-12 bg-zinc-900 hover:bg-zinc-700">
+          <tr class="group h-12 bg-charcoal-800 hover:bg-zinc-700">
             <td class="rounded-tl-lg rounded-bl-lg w-5"> </td>
             <td class="px-2">
               <input
@@ -245,7 +245,7 @@ function computeInterval(): number {
                 title="{volume.inUse ? 'Volume is used by a container' : ''}"
                 class="cursor-pointer invert hue-rotate-[218deg] brightness-75" />
             </td>
-            <td class="bg-zinc-900 group-hover:bg-zinc-700 flex flex-row justify-center h-12">
+            <td class="bg-charcoal-800 group-hover:bg-zinc-700 flex flex-row justify-center h-12">
               <div class="grid place-content-center ml-3 mr-4">
                 <StatusIcon icon="{VolumeIcon}" status="{volume.inUse ? 'USED' : 'UNUSED'}" />
               </div>

--- a/packages/renderer/src/lib/welcome/WelcomePage.svelte
+++ b/packages/renderer/src/lib/welcome/WelcomePage.svelte
@@ -50,7 +50,7 @@ function closeWelcome() {
         <span class="mr-2">🎉</span>Welcome to Podman Desktop!
       </div>
       <div class="flex flex-row justify-center p-4">
-        <div class="bg-zinc-800 rounded-lg p-5 text-sm space-y-3">
+        <div class="bg-charcoal-600 rounded-lg p-5 text-sm space-y-3">
           <div class="font-bold">Podman Desktop supports many container engines, including:</div>
           <div class="flex flex-row px-5 justify-center">
             <div class="flex flex-row px-4">
@@ -122,7 +122,7 @@ function closeWelcome() {
     {/if}
 
     <!-- Footer - button bar -->
-    <div class="flex justify-end flex-none bg-zinc-800 p-8">
+    <div class="flex justify-end flex-none bg-charcoal-600 p-8">
       <div class="flex flex-row">
         <button
           class="pf-c-button pf-m-primary w-30 px-6"

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -159,8 +159,6 @@ module.exports = {
         400: tailwindColors.zinc[400],
         600: tailwindColors.zinc[600],
         700: tailwindColors.zinc[700],
-        800: tailwindColors.zinc[800],
-        900: tailwindColors.zinc[900],
       },
       'neutral': {
         900: tailwindColors.neutral[900],

--- a/website/src/pages/core-values/index.tsx
+++ b/website/src/pages/core-values/index.tsx
@@ -9,7 +9,7 @@ import { faSimplybuilt } from '@fortawesome/free-brands-svg-icons';
 function CoreValueHead() {
   return (
     <div>
-      <section className="text-gray-900 dark:text-gray-700 dark:bg-zinc-800 bg-zinc-200 body-font">
+      <section className="text-gray-900 dark:text-gray-700 dark:bg-charcoal-600 bg-zinc-200 body-font">
         <div className="container mx-auto flex px-5 py-24 items-center justify-center flex-col">
           <div className="text-center lg:w-2/3 w-full">
             <h1 className="title-font sm:text-4xl text-3xl lg:text-6xl mb-4 font-medium text-gray-900 dark:text-white">
@@ -26,7 +26,7 @@ function CoreValueHead() {
 function FastAndLight() {
   return (
     <div>
-      <section className="text-gray-900 dark:text-gray-700 dark:bg-zinc-900 bg-zinc-100 body-font">
+      <section className="text-gray-900 dark:text-gray-700 dark:bg-charcoal-800 bg-zinc-100 body-font">
         <div className="container mx-auto flex px-5 py-24 md:flex-row flex-col items-center">
           <div className="lg:flex-grow md:w-1/2 lg:pr-24 md:pr-16 flex flex-col md:items-start md:text-left mb-16 md:mb-0 items-center text-center">
             <h1 className="title-font sm:text-4xl text-3xl mb-4 font-medium text-gray-900 dark:text-white">
@@ -51,7 +51,7 @@ function FastAndLight() {
 
 function Open() {
   return (
-    <section className="text-gray-900 dark:text-gray-700 dark:bg-zinc-800 bg-zinc-200 body-font">
+    <section className="text-gray-900 dark:text-gray-700 dark:bg-charcoal-600 bg-zinc-200 body-font">
       <div className="container mx-auto flex px-5 py-24 md:flex-row flex-col items-center">
         <div className="lg:w-1/3 md:w-1/2 w-1/3 flex justify-center gap-10 text-purple-700">
           <FontAwesomeIcon icon={faBoxOpen} size="8x" />
@@ -74,7 +74,7 @@ function Open() {
 function Simple() {
   return (
     <div>
-      <section className="text-gray-900 dark:text-gray-700 dark:bg-zinc-900 bg-zinc-100 body-font">
+      <section className="text-gray-900 dark:text-gray-700 dark:bg-charcoal-800 bg-zinc-100 body-font">
         <div className="container mx-auto flex px-5 py-24 md:flex-row flex-col items-center">
           <div className="lg:flex-grow md:w-1/2 lg:pr-24 md:pr-16 flex flex-col md:items-start md:text-left mb-16 md:mb-0 items-center text-center">
             <h1 className="title-font sm:text-4xl text-3xl mb-4 font-medium text-gray-900 dark:text-white">
@@ -102,7 +102,7 @@ function Simple() {
 
 function ExtensibleWorkflow() {
   return (
-    <section className="text-gray-900 dark:text-gray-700 dark:bg-zinc-800 bg-zinc-200 body-font">
+    <section className="text-gray-900 dark:text-gray-700 dark:bg-charcoal-600 bg-zinc-200 body-font">
       <div className="container mx-auto flex px-5 py-24 md:flex-row flex-col items-center">
         <div className="lg:w-1/3 md:w-1/2 w-1/3 flex justify-center gap-10 text-purple-700">
           <FontAwesomeIcon icon={faChartLine} size="8x" />

--- a/website/src/pages/downloads/linux.tsx
+++ b/website/src/pages/downloads/linux.tsx
@@ -91,7 +91,7 @@ export function LinuxDownloads(): JSX.Element {
                     <path d="M12 2.604l-.43.283L0 10.459v6.752l6.393 4.184L12 17.725l5.607 3.671L24 17.211v-6.752L12 2.604zm0 .828l5.434 3.556-2.717 1.778L12 10.545l-2.717-1.78-2.717-1.777L12 3.432zM6.39 7.104l5.434 3.556-5.408 3.54-5.434-3.557 5.409-3.54zm11.22 0l5.431 3.554-5.434 3.557-5.433-3.555 5.435-3.556zM.925 10.867l5.379 3.52a.123.08 0 00.027.013v5.647l-5.406-3.54v-5.64zm11.213.115l5.408 3.54v5.664l-5.408-3.54v-5.664z" />
                   </svg>
                 </p>
-                <div className="dark:bg-zinc-900/50 bg-zinc-300/50 p-1 text-xl dark:text-purple-200 text-purple-600 flex flex-row">
+                <div className="dark:bg-charcoal-800/50 bg-zinc-300/50 p-1 text-xl dark:text-purple-200 text-purple-600 flex flex-row">
                   <div className="w-72 truncate">
                     <FontAwesomeIcon size="xs" icon={faTerminal} className="mx-2 mt-3" />
                     flatpak install flathub io.podman_desktop.PodmanDesktop

--- a/website/src/pages/downloads/macOS.tsx
+++ b/website/src/pages/downloads/macOS.tsx
@@ -119,7 +119,7 @@ export function MacOSDownloads(): JSX.Element {
                 <p className="text-xl p-1">
                   <FontAwesomeIcon size="sm" icon={faBeer} className="mx-1 mt-2" />
                 </p>
-                <div className="dark:bg-zinc-900/50 bg-zinc-300/50 p-1 truncate">
+                <div className="dark:bg-charcoal-800/50 bg-zinc-300/50 p-1 truncate">
                   <p className="text-xl dark:text-purple-200 text-purple-600">
                     <FontAwesomeIcon size="xs" icon={faTerminal} className="mx-2 mt-3" />
                     brew install podman-desktop

--- a/website/src/pages/downloads/windows.tsx
+++ b/website/src/pages/downloads/windows.tsx
@@ -111,7 +111,7 @@ export function WindowsDownloads(): JSX.Element {
                 <p className="text-xl p-1">
                   <FontAwesomeIcon size="sm" icon={faMicrosoft} className="mx-1 mt-2" />
                 </p>
-                <div className="dark:bg-zinc-900/50 bg-zinc-300/50 p-1 text-xl dark:text-purple-200 text-purple-600 flex flex-row">
+                <div className="dark:bg-charcoal-800/50 bg-zinc-300/50 p-1 text-xl dark:text-purple-200 text-purple-600 flex flex-row">
                   <div className="w-72 truncate">
                     <FontAwesomeIcon size="xs" icon={faTerminal} className="mx-2 mt-3" />
                     winget install -e --id RedHat.Podman-Desktop

--- a/website/src/pages/features/index.tsx
+++ b/website/src/pages/features/index.tsx
@@ -8,7 +8,7 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 function FeatureManageContainers() {
   return (
     <div>
-      <section className="text-gray-900 bg-zinc-200 dark:bg-zinc-800 dark:text-gray-700 body-font">
+      <section className="text-gray-900 bg-zinc-200 dark:bg-charcoal-600 dark:text-gray-700 body-font">
         <div className="container mx-auto flex px-5 py-24 md:flex-row flex-col items-center">
           <div className="lg:flex-grow md:w-1/2 lg:pr-24 md:pr-16 flex flex-col md:items-start md:text-left mb-16 md:mb-0 items-center text-center">
             <h1 className="title-font sm:text-4xl text-3xl mb-4 font-medium text-gray-900 dark:text-white">
@@ -37,7 +37,7 @@ function FeatureManageContainers() {
 
 function FeatureManageImages() {
   return (
-    <section className="text-gray-900 bg-zinc-100 dark:text-gray-700 dark:bg-zinc-900 body-font">
+    <section className="text-gray-900 bg-zinc-100 dark:text-gray-700 dark:bg-charcoal-800 body-font">
       <div className="container mx-auto flex px-5 py-24 md:flex-row flex-col items-center">
         <div className="w-5/6 mb-10 md:mb-0">
           <ThemedImage
@@ -68,7 +68,7 @@ function FeatureManageImages() {
 function FeatureManagementFromTrayIcon() {
   return (
     <div>
-      <section className="text-gray-900 bg-zinc-200 dark:bg-zinc-800 dark:text-gray-700 body-font">
+      <section className="text-gray-900 bg-zinc-200 dark:bg-charcoal-600 dark:text-gray-700 body-font">
         <div className="container mx-auto flex px-5 py-24 md:flex-row flex-col items-center">
           <div className="lg:flex-grow md:w-1/2 lg:pr-24 md:pr-16 flex flex-col md:items-start md:text-left mb-16 md:mb-0 items-center text-center">
             <h1 className="title-font sm:text-4xl text-3xl mb-4 font-medium text-gray-900 dark:text-white">
@@ -104,7 +104,7 @@ function FeatureManagementFromTrayIcon() {
 function FeatureManageResources() {
   return (
     <div>
-      <section className="text-gray-900 bg-zinc-100 dark:bg-zinc-900 dark:text-gray-700 body-font">
+      <section className="text-gray-900 bg-zinc-100 dark:bg-charcoal-800 dark:text-gray-700 body-font">
         <div className="container mx-auto flex px-5 py-24 md:flex-row flex-col items-center">
           <div className="lg:w-5/6 md:w-4/5 w-5/6 flex flex:col gap-10">
             <ThemedImage
@@ -135,7 +135,7 @@ function FeatureManageResources() {
 function FeatureManagePods() {
   return (
     <div>
-      <section className="text-gray-900 bg-zinc-200 dark:bg-zinc-800 dark:text-gray-700 body-font">
+      <section className="text-gray-900 bg-zinc-200 dark:bg-charcoal-600 dark:text-gray-700 body-font">
         <div className="container mx-auto flex px-5 py-24 md:flex-row flex-col items-center">
           <div className="lg:flex-grow md:w-1/2 lg:pr-24 md:pr-16 flex flex-col md:items-start md:text-left mb-16 md:mb-0 items-center text-center">
             <h1 className="title-font sm:text-4xl text-3xl mb-4 font-medium text-gray-900 dark:text-white">
@@ -170,7 +170,7 @@ function FeatureManagePods() {
 
 function FeatureDDExtensions() {
   return (
-    <section className="text-gray-900 bg-zinc-100 dark:bg-zinc-900 dark:text-gray-700 body-font">
+    <section className="text-gray-900 bg-zinc-100 dark:bg-charcoal-800 dark:text-gray-700 body-font">
       <div className="container mx-auto flex px-5 py-24 md:flex-row flex-col items-center">
         <div className="lg:w-5/6 md:w-4/5 w-5/6 flex flex:col gap-10">
           <ThemedImage

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -145,7 +145,7 @@ function WorkInProgress() {
 
 function KeepUpToDate() {
   return (
-    <section className="text-gray-900 dark:text-gray-400 dark:bg-zinc-900 bg-zinc-100 body-font">
+    <section className="text-gray-900 dark:text-gray-400 dark:bg-charcoal-800 bg-zinc-100 body-font">
       <div className="container px-5 py-24 mx-auto flex flex-wrap">
         <div className="flex flex-col text-center w-full mb-5">
           <SectionTitle name="update" />
@@ -184,7 +184,7 @@ function KeepUpToDate() {
 
 function Extensibility() {
   return (
-    <section className="text-gray-900 dark:text-gray-400 dark:bg-zinc-800 bg-zinc-200 body-font">
+    <section className="text-gray-900 dark:text-gray-400 dark:bg-charcoal-600 bg-zinc-200 body-font">
       <div className="container px-5 py-24 mx-auto flex flex-wrap">
         <div className="flex flex-col text-center w-full mb-5">
           <SectionTitle name="extensibility" />
@@ -251,7 +251,7 @@ function Extensibility() {
 
 function Configure() {
   return (
-    <section className="text-gray-900 dark:text-gray-400 dark:bg-zinc-900 bg-zinc-100 body-font py-24">
+    <section className="text-gray-900 dark:text-gray-400 dark:bg-charcoal-800 bg-zinc-100 body-font py-24">
       <div className="container px-5 mx-auto flex flex-wrap">
         <div className="flex flex-col text-center w-full mb-5">
           <SectionTitle name="Configure" />
@@ -319,7 +319,7 @@ function Configure() {
 
 function EnterpriseReady() {
   return (
-    <section className="text-gray-900 dark:text-gray-400 dark:bg-zinc-800 bg-zinc-200 body-font py-24">
+    <section className="text-gray-900 dark:text-gray-400 dark:bg-charcoal-600 bg-zinc-200 body-font py-24">
       <div className="container px-5 mx-auto flex flex-wrap">
         <div className="flex flex-col text-center w-full mb-5">
           <SectionTitle name="enterprise" />
@@ -377,7 +377,7 @@ const copyBrewInstructions = () => {
 
 function RunAnywhere() {
   return (
-    <section className="text-gray-900 dark:text-gray-400 dark:bg-zinc-800 bg-zinc-200 body-font">
+    <section className="text-gray-900 dark:text-gray-400 dark:bg-charcoal-600 bg-zinc-200 body-font">
       <div className="container px-5 py-24 mx-auto flex flex-wrap">
         <div className="flex flex-col text-center w-full mb-5">
           <h2 className="max-w-lg mb-6 font-sans text-3xl font-bold leading-none tracking-tight text-gray-900 dark:text-white sm:text-4xl md:mx-auto">
@@ -389,7 +389,7 @@ function RunAnywhere() {
         </div>
         <div className="flex flex-wrap w-full justify-center">
           <div className="p-4 w-11/12 md:w-1/2 lg:w-1/3">
-            <div className="flex rounded-lg h-full bg-zinc-100 dark:bg-zinc-900 bg-opacity-60 p-8 flex-col">
+            <div className="flex rounded-lg h-full bg-zinc-100 dark:bg-charcoal-800 bg-opacity-60 p-8 flex-col">
               <Link
                 title="Download for Windows"
                 className="no-underline hover:no-underline text-gray-900 dark:text-white hover:dark:text-violet-600 "
@@ -408,7 +408,7 @@ function RunAnywhere() {
             </div>
           </div>
           <div className="p-4 w-11/12 md:w-1/2 lg:w-1/3">
-            <div className="flex rounded-lg h-full bg-zinc-100 dark:bg-zinc-900 bg-opacity-60 p-8 flex-col">
+            <div className="flex rounded-lg h-full bg-zinc-100 dark:bg-charcoal-800 bg-opacity-60 p-8 flex-col">
               <Link
                 title="Download for macOS"
                 className="no-underline hover:no-underline text-gray-900 dark:text-white hover:dark:text-violet-600 "
@@ -436,7 +436,7 @@ function RunAnywhere() {
             </div>
           </div>
           <div className="p-4 w-11/12 md:w-1/2 lg:w-1/3">
-            <div className="flex rounded-lg h-full bg-zinc-100 dark:bg-zinc-900 bg-opacity-60 p-8 flex-col">
+            <div className="flex rounded-lg h-full bg-zinc-100 dark:bg-charcoal-800 bg-opacity-60 p-8 flex-col">
               <Link
                 title="Download for Linux"
                 className="no-underline hover:no-underline text-gray-900 dark:text-white hover:dark:text-violet-600 "
@@ -461,7 +461,7 @@ function RunAnywhere() {
 
 function MainFeatures() {
   return (
-    <section className="text-gray-900 dark:text-gray-400 dark:bg-zinc-900 bg-zinc-100 body-font py-24">
+    <section className="text-gray-900 dark:text-gray-400 dark:bg-charcoal-800 bg-zinc-100 body-font py-24">
       <div className="container px-5 mx-auto flex flex-wrap">
         <div className="flex flex-col text-center w-full mb-5">
           <SectionTitle name="features" />
@@ -564,7 +564,7 @@ function MainFeatures() {
 
 function Pods() {
   return (
-    <section className="text-gray-900 dark:text-gray-400 dark:bg-zinc-800 bg-zinc-200 body-font py-24">
+    <section className="text-gray-900 dark:text-gray-400 dark:bg-charcoal-600 bg-zinc-200 body-font py-24">
       <div className="container px-5 mx-auto flex flex-wrap">
         <div className="flex flex-col text-center w-full mb-5">
           <SectionTitle name="features" />


### PR DESCRIPTION
### What does this PR do?

Two of the legacy zinc variant colors in our palette have identical rgb values in charcoal. This removes these two zinc variant colors from the palette and replaces all of the references to the identical charcoal.
- zinc-800 -> charcoal-600 (#27272a)
- zinc-900 -> charcoal-800 (#18181b)

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Just confirm no visual change.