### PR TITLE
nit: add notification after pushing kind image

### DIFF
--- a/extensions/kind/src/image-handler.spec.ts
+++ b/extensions/kind/src/image-handler.spec.ts
@@ -30,6 +30,7 @@ vi.mock('@podman-desktop/api', async () => {
     },
     window: {
       showNotification: vi.fn(),
+      showInformationMessage: vi.fn(),
     },
   };
 });
@@ -74,6 +75,19 @@ test('expect image name to be given', async () => {
     undefined,
   );
   expect(extensionApi.containerEngine.saveImage).toBeCalledWith('dummy', 'myimage', expect.anything());
+});
+
+test('expect getting showInformationMessage when image is pushed', async () => {
+  (extensionApi.containerEngine.saveImage as Mock).mockImplementation(
+    (engineId: string, id: string, filename: string) => fs.promises.open(filename, 'w'),
+  );
+
+  await imageHandler.moveImage(
+    { engineId: 'dummy', name: 'myimage' },
+    [{ name: 'c1', engineType: 'podman', status: 'started', apiPort: 9443 }],
+    undefined,
+  );
+  expect(extensionApi.window.showInformationMessage).toBeCalledWith('Image myimage pushed to Kind cluster: c1');
 });
 
 test('expect image name and tag to be given', async () => {


### PR DESCRIPTION
nit: add notification after pushing kind image

### What does this PR do?

* Changes confirmation to show information message, not
  notification.
* Refactors function a bit to give more details when erroring /
  reorganize

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

N/A

### What issues does this PR fix or reference?

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

Part of https://github.com/containers/podman-desktop/issues/2231
Closes https://github.com/containers/podman-desktop/issues/2166

Helps create some logging / information to diagnose / make it reproduceable.

### How to test this PR?

<!-- Please explain steps to reproduce -->

Push image to Kind cluster, should function as normal but give dialog
after.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
