### PR TITLE
feat: make numeric input editable (#1986)

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.spec.ts
@@ -25,6 +25,7 @@ import { test, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/svelte';
 import type { IConfigurationPropertyRecordedSchema } from '../../../../main/src/plugin/configuration-registry';
 import PreferencesRenderingItemFormat from './PreferencesRenderingItemFormat.svelte';
+import userEvent from '@testing-library/user-event';
 
 beforeAll(() => {
   (window as any).getConfigurationValue = vi.fn();
@@ -170,4 +171,48 @@ test('Expect a text input when record is type string', async () => {
   expect(input instanceof HTMLInputElement).toBe(true);
   expect((input as HTMLInputElement).type).toBe('text');
   expect((input as HTMLSelectElement).name).toBe('record');
+});
+
+test('Expect tooltip text shows info when input is less than minimum', async () => {
+  const record: IConfigurationPropertyRecordedSchema = {
+    id: 'record',
+    title: 'record',
+    parentId: 'parent.record',
+    description: 'record-description',
+    type: 'number',
+    minimum: 1,
+    maximum: 34,
+  };
+  await render(PreferencesRenderingItemFormat, {
+    record,
+  });
+  const input = screen.getByLabelText('record-description');
+  await userEvent.click(input);
+  await userEvent.clear(input);
+  await userEvent.keyboard('0');
+  const tooltip = screen.getByLabelText('tooltip');
+  expect(tooltip).toBeInTheDocument();
+  expect(tooltip.textContent).toBe('The value must be greater than or equal to 1');
+});
+
+test('Expect tooltip text shows info when input is empty', async () => {
+  const record: IConfigurationPropertyRecordedSchema = {
+    id: 'record',
+    title: 'record',
+    parentId: 'parent.record',
+    description: 'record-description',
+    type: 'number',
+    minimum: 1,
+    maximum: 34,
+  };
+  await render(PreferencesRenderingItemFormat, {
+    record,
+  });
+  const input = screen.getByLabelText('record-description');
+  await userEvent.click(input);
+  await userEvent.clear(input);
+  await userEvent.keyboard('40');
+  const tooltip = screen.getByLabelText('tooltip');
+  expect(tooltip).toBeInTheDocument();
+  expect(tooltip.textContent).toBe('The value must be less than or equal to 34');
 });

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.spec.ts
@@ -192,7 +192,7 @@ test('Expect tooltip text shows info when input is less than minimum', async () 
   await userEvent.keyboard('0');
   const tooltip = screen.getByLabelText('tooltip');
   expect(tooltip).toBeInTheDocument();
-  expect(tooltip.textContent).toBe('The value must be greater than or equal to 1');
+  expect(tooltip.textContent).toBe('The value cannot be less than 1');
 });
 
 test('Expect tooltip text shows info when input is empty', async () => {
@@ -214,5 +214,5 @@ test('Expect tooltip text shows info when input is empty', async () => {
   await userEvent.keyboard('40');
   const tooltip = screen.getByLabelText('tooltip');
   expect(tooltip).toBeInTheDocument();
-  expect(tooltip.textContent).toBe('The value must be less than or equal to 34');
+  expect(tooltip.textContent).toBe('The value cannot be greater than 34');
 });

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
@@ -217,8 +217,8 @@ function onNumberInputKeyPress(event: any) {
 function onNumberInputChange(event: any) {
   if (event.target.value === '') {
     numberInputInvalid = true;
-    numberInputErrorMessage = `The value must be greater than or equal to ${record.minimum}${
-      record.maximum ? ` and less than or equal to ${record.maximum}` : ''
+    numberInputErrorMessage = `The value cannot be less than ${record.minimum}${
+      record.maximum ? ` or greater than ${record.maximum}` : ''
     }`;
     clearTimeout(recordUpdateTimeout);
     return;
@@ -233,13 +233,13 @@ function onNumberInputChange(event: any) {
 function assertNumericValueIsValid(value: number) {
   if (record.maximum && typeof record.maximum === 'number' && value > record.maximum) {
     numberInputInvalid = true;
-    numberInputErrorMessage = `The value must be less than or equal to ${record.maximum}`;
+    numberInputErrorMessage = `The value cannot be greater than ${record.maximum}`;
     clearTimeout(recordUpdateTimeout);
     return false;
   }
   if (record.minimum && typeof record.minimum === 'number' && value < record.minimum) {
     numberInputInvalid = true;
-    numberInputErrorMessage = `The value must be greater than or equal to ${record.minimum}`;
+    numberInputErrorMessage = `The value cannot be less than ${record.minimum}`;
     clearTimeout(recordUpdateTimeout);
     return false;
   }

--- a/packages/renderer/src/lib/ui/Tooltip.svelte
+++ b/packages/renderer/src/lib/ui/Tooltip.svelte
@@ -20,6 +20,11 @@
   transform: translateX(100%);
   margin-right: -8px;
 }
+.tooltip.top-left {
+  left: 0;
+  transform: translate(-80%, -100%);
+  margin-top: -8px;
+}
 .tooltip-slot:hover + .tooltip {
   opacity: 1;
   visibility: initial;
@@ -29,6 +34,7 @@
 <script>
 export let tip = '';
 export let top = false;
+export let topLeft = false;
 export let right = false;
 export let bottom = false;
 export let left = false;
@@ -43,9 +49,10 @@ export let left = false;
     class:left="{left}"
     class:right="{right}"
     class:bottom="{bottom}"
-    class:top="{top}">
+    class:top="{top}"
+    class:top-left="{topLeft}">
     {#if tip}
-      <div class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs">{tip}</div>
+      <div class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs" aria-label="tooltip">{tip}</div>
     {/if}
   </div>
 </div>


### PR DESCRIPTION
### What does this PR do?

This PR removes the readonly attribute to the numeric input so user can type the value manually.
If the value is invalid because it is greater/less than the maximum/minimum a tooltip appears and the bottom border becomes red

### Screenshot/screencast of this PR

![numeric-val-2](https://user-images.githubusercontent.com/49404737/236468847-bd823031-6dac-4e76-a17e-c0f32085b3af.gif)

### What issues does this PR fix or reference?

it resolves #1986 

### How to test this PR?

1. go to the preferences page, edit a numeric input and check that everything works fine
