### PR TITLE
nit: by default, don't deploy updated security context

### DIFF
--- a/packages/renderer/src/lib/pod/DeployPodToKube.spec.ts
+++ b/packages/renderer/src/lib/pod/DeployPodToKube.spec.ts
@@ -178,9 +178,6 @@ test('When deploying a pod, volumes should not be added (they are deleted by pod
   expect(createButton).toBeInTheDocument();
   expect(createButton).toBeEnabled();
 
-  const useRestricted = screen.getByTestId('useRestricted');
-  await fireEvent.click(useRestricted);
-
   // Press the deploy button
   await fireEvent.click(createButton);
 
@@ -200,11 +197,15 @@ test('When deploying a pod, volumes should not be added (they are deleted by pod
   );
 });
 
-test('When deploying a pod, restricted security context is added', async () => {
+test('When deploying a pod, restricted security context is added after enabling', async () => {
   await waitRender({});
   const createButton = screen.getByRole('button', { name: 'Deploy' });
   expect(createButton).toBeInTheDocument();
   expect(createButton).toBeEnabled();
+
+  // Click restricted
+  const useRestricted = screen.getByTestId('useRestricted');
+  await fireEvent.click(useRestricted);
 
   // Press the deploy button
   await fireEvent.click(createButton);

--- a/packages/renderer/src/lib/pod/DeployPodToKube.svelte
+++ b/packages/renderer/src/lib/pod/DeployPodToKube.svelte
@@ -27,7 +27,7 @@ let openshiftRouteGroupSupported = false;
 
 let deployUsingServices = true;
 let deployUsingRoutes = true;
-let deployUsingRestrictedSecurityContext = true;
+let deployUsingRestrictedSecurityContext = false;
 let createdPod = undefined;
 let bodyPod;
 


### PR DESCRIPTION
nit: by default, don't deploy updated security context

### What does this PR do?

When deploying to Kind or a typical Kubernetes cluster using the
deploy to Kubernetes button, most examples will fail since they are using
root / port 80 (guestbook-go, redis, helloworld).

The security context should be disabled by default unless explicitley
marked as true.

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

N/A

### How to test this PR?

<!-- Please explain steps to reproduce -->

Use Deploy to Kubernetes, it'll be marked as unchecked by default.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
