### PR TITLE
fix: when changing the kubernetes pod name, also change the app name

### DIFF
--- a/packages/renderer/src/lib/pod/DeployPodToKube.spec.ts
+++ b/packages/renderer/src/lib/pod/DeployPodToKube.spec.ts
@@ -197,7 +197,33 @@ test('When deploying a pod, volumes should not be added (they are deleted by pod
   );
 });
 
-test('When deploying a pod, restricted security context is added after enabling', async () => {
+// After modifying the pod name, metadata.apps.label should also have been changed
+test('When modifying the pod name, metadata.apps.label should also have been changed', async () => {
+  await waitRender({});
+  const createButton = screen.getByRole('button', { name: 'Deploy' });
+  expect(createButton).toBeInTheDocument();
+  expect(createButton).toBeEnabled();
+
+  // Press the deploy button
+  await fireEvent.click(createButton);
+
+  // Expect kubernetesCreatePod to be called with default namespace and a modified bodyPod with volumes removed
+  await waitFor(() =>
+    expect(kubernetesCreatePodMock).toBeCalledWith('default', {
+      metadata: { name: 'hello' },
+      spec: {
+        containers: [
+          {
+            name: 'hello',
+            image: 'hello-world',
+          },
+        ],
+      },
+    }),
+  );
+});
+
+test('When deploying a pod, restricted security context is added', async () => {
   await waitRender({});
   const createButton = screen.getByRole('button', { name: 'Deploy' });
   expect(createButton).toBeInTheDocument();

--- a/packages/renderer/src/lib/pod/DeployPodToKube.svelte
+++ b/packages/renderer/src/lib/pod/DeployPodToKube.svelte
@@ -327,6 +327,14 @@ async function deployToKube() {
 
 $: bodyPod && updateKubeResult();
 
+// Update bodyPod.metadata.labels.app to be the same as bodyPod.metadata.name
+// If statement required as bodyPod.metadata is undefined when bodyPod is undefined
+$: {
+  if (bodyPod && bodyPod.metadata && bodyPod.metadata.labels) {
+    bodyPod.metadata.labels.app = bodyPod.metadata.name;
+  }
+}
+
 function updateKubeResult() {
   kubeDetails = jsYaml.dump(bodyPod, { noArrayIndent: true, quotingType: '"', lineWidth: -1 });
 }


### PR DESCRIPTION
fix: when changing the kubernetes pod name, also change the app name

### What does this PR do?

Changing the name is broken at the moment. This fixes the issue of
updating the app name so your service and ingress can access the pod.

### Screenshot/screencast of this PR


https://user-images.githubusercontent.com/6422176/236853829-14b08a7d-3092-477d-a71f-bed725302a08.mov

### What issues does this PR fix or reference?

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

Fixes https://github.com/containers/podman-desktop/issues/2148

### How to test this PR?

1. `podman run --name hello -d -p 8080:8080 cdrage/helloworld`
2. Deploy to Kubernetes
3. Change the name to anything else. You should see it update in the
   name as well as the app name
4. Select service + ingress, disable security context generation.
5. You should see it deployed to localhost:9090 successfully.

<!-- Please explain steps to reproduce -->

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
