### PR TITLE
fix: fix binary location for podman-mac-helper

### DIFF
--- a/extensions/podman/src/compatibility-mode.spec.ts
+++ b/extensions/podman/src/compatibility-mode.spec.ts
@@ -75,6 +75,36 @@ test('darwin: DarwinSocketCompatibility class, test runSudoMacHelperCommand ran 
   expect(spyMacHelperCommand).toHaveBeenCalled();
 });
 
+test('darwin: mock fs.existsSync returns /usr/local/bin/podman-mac-helper', async () => {
+  // Mock platform to be darwin
+  Object.defineProperty(process, 'platform', {
+    value: 'darwin',
+  });
+
+  // mock existsSync to return true only if '/usr/local/bin/podman-mac-helper' is passed in,
+  // forcing it to return false for all other paths.
+  // this imitates that the binary is found in /usr/local/bin and not other folders
+  vi.mock('fs', () => {
+    return {
+      existsSync: (path: string) => {
+        if (path === '/usr/local/bin/podman-mac-helper') {
+          return true;
+        }
+        return false;
+      },
+    };
+  });
+
+  // Mock that the binary is found
+  const socketCompatClass = new DarwinSocketCompatibility();
+
+  // Run findPodmanHelper
+  const binaryPath = socketCompatClass.findPodmanHelper();
+
+  // Expect binaryPath to be /usr/local/bin/podman-mac-helper
+  expect(binaryPath).toBe('/usr/local/bin/podman-mac-helper');
+});
+
 // Linux tests
 
 test('linux: compatibility mode fail', async () => {

--- a/extensions/podman/src/compatibility-mode.ts
+++ b/extensions/podman/src/compatibility-mode.ts
@@ -47,11 +47,14 @@ export class DarwinSocketCompatibility extends SocketCompatibility {
   findPodmanHelper(): string {
     const homebrewPath = '/opt/homebrew/bin/podman-mac-helper';
     const podmanPath = '/opt/podman/bin/podman-mac-helper';
+    const userBinaryPath = '/usr/local/bin/podman-mac-helper';
 
     if (fs.existsSync(homebrewPath)) {
       return homebrewPath;
     } else if (fs.existsSync(podmanPath)) {
       return podmanPath;
+    } else if (fs.existsSync(userBinaryPath)) {
+      return userBinaryPath;
     } else {
       return '';
     }


### PR DESCRIPTION
fix: fix binary location for podman-mac-helper

### What does this PR do?

Sometimes the user may have installed the podman-mac-helper binary
manually to /usr/local/bin.

We use full binary paths (not PATH env variable) due to how sudo-prompt
works. So a searchable path must be provided.

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

N/A

### What issues does this PR fix or reference?

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

Closes https://github.com/containers/podman-desktop/issues/1940

### How to test this PR?

<!-- Please explain steps to reproduce -->

1. Make sure `whereis podman-mac-helper` only has
   /usr/local/bin/podman-mac-herlp
2. Run Docker Compatibility button, it should work as intended / normal

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
