### PR TITLE
fix: Avoid creating duplicate registries

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesRegistriesEditing.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesRegistriesEditing.spec.ts
@@ -1,0 +1,79 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-unused-vars */
+/* eslint-disable @typescript-eslint/no-empty-function */
+
+import '@testing-library/jest-dom';
+import { test, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import PreferencesRegistriesEditing from './PreferencesRegistriesEditing.svelte';
+import { registriesInfos } from '../../stores/registries';
+import type { Registry } from '@podman-desktop/api';
+
+beforeAll(() => {
+  (window as any).window.ddExtensionInstall = vi.fn();
+  (window as any).window.getImageRegistryProviderNames = vi.fn();
+});
+
+describe('PreferencesRegistriesEditing', () => {
+  test('Expect that add registry button is visible and enabled', async () => {
+    render(PreferencesRegistriesEditing, {});
+
+    const button = screen.getByRole('button', { name: 'Add registry' });
+    expect(button).toBeInTheDocument();
+    expect(button).toBeEnabled();
+  });
+
+  test('Expect that existing registries are visible', async () => {
+    const name = 'custom-container-registry';
+    const registry: Registry = {
+      source: 'test',
+      serverUrl: 'https://test.com',
+      name: name,
+      username: 'user',
+      secret: 'secret',
+    };
+    registriesInfos.set([registry]);
+    render(PreferencesRegistriesEditing, {});
+
+    const entry2 = screen.getByText(name);
+    expect(entry2).toBeInTheDocument();
+
+    // can still add more registries
+    const button = screen.getByRole('button', { name: 'Add registry' });
+    expect(button).toBeInTheDocument();
+    expect(button).toBeEnabled();
+  });
+
+  test('Expect that adding a registry enables a form, and Login button is initially disabled', async () => {
+    render(PreferencesRegistriesEditing, { showNewRegistryForm: true });
+
+    const button = screen.getByRole('button', { name: 'Add registry' });
+    expect(button).toBeInTheDocument();
+    expect(button).toBeDisabled();
+
+    const entry = screen.getByPlaceholderText('URL (HTTPS only)');
+    expect(entry).toBeInTheDocument();
+
+    const loginButton = screen.getByRole('button', { name: 'Login' });
+    expect(loginButton).toBeInTheDocument();
+    expect(loginButton).toBeDisabled();
+  });
+});

--- a/packages/renderer/src/lib/preferences/PreferencesRegistriesEditing.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRegistriesEditing.svelte
@@ -20,7 +20,7 @@ let errorResponses: { serverUrl: string; error: string }[] = [];
 let showPasswordForServerUrls: string[] = [];
 
 // show or hide new registry form
-let showNewRegistryForm = false;
+export let showNewRegistryForm = false;
 
 // at this moment it should be `podman`, but later can be any
 let defaultProviderSourceName: string;
@@ -47,7 +47,7 @@ const newRegistryRequest = {
 
 onMount(async () => {
   let providerSourceNames = await window.getImageRegistryProviderNames();
-  if (providerSourceNames.length > 0) {
+  if (providerSourceNames && providerSourceNames.length > 0) {
     defaultProviderSourceName = providerSourceNames[0];
   }
 });

--- a/packages/renderer/src/lib/preferences/PreferencesRegistriesEditing.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRegistriesEditing.svelte
@@ -34,6 +34,9 @@ let suggestedRegistries: containerDesktopAPI.RegistrySuggestedProvider[] = [];
 // List of registries to keep track of hidden / unhidden inputs
 let listedSuggestedRegistries = [];
 
+// Busy flag while attempting login
+let loggingIn = false;
+
 // used when user tries to add new registry
 const newRegistryRequest = {
   source: '',
@@ -173,6 +176,7 @@ function clearSavedCredentials() {
 }
 
 async function loginToRegistry(registry: containerDesktopAPI.Registry) {
+  loggingIn = true;
   clearErrorResponse(registry.serverUrl);
   setPasswordForRegistryVisible(registry, false);
 
@@ -197,6 +201,7 @@ async function loginToRegistry(registry: containerDesktopAPI.Registry) {
       originRegistries = originRegistries.filter(r => r.serverUrl !== registry.serverUrl);
     }
   }
+  loggingIn = false;
 }
 
 function removeExistingRegistry(registry: containerDesktopAPI.Registry) {
@@ -229,9 +234,9 @@ const processPasswordElement = (node: HTMLInputElement, registry: containerDeskt
       {#each $registriesInfos as registry}
         <!-- containerDesktopAPI.Registry row start -->
         <div class="flex flex-col w-full border-t border-gray-900">
-          <div class="flex flex-row">
-            <div class="flex-1 pt-2 pl-5 pr-5 text-sm w-auto m-auto">
-              <div class="flex items-center w-full h-full">
+          <div class="flex flex-row items-center pt-4 pb-3">
+            <div class="flex-1 pl-5 pr-5 text-sm w-auto m-auto">
+              <div class="flex w-full h-full">
                 <div class="flex items-center">
                   <!-- Only show if a "suggested" registry icon has been added -->
                   {#if registry.icon}
@@ -255,7 +260,7 @@ const processPasswordElement = (node: HTMLInputElement, registry: containerDeskt
             </div>
 
             <!-- Username -->
-            <div class="pt-4 pb-2 text-sm w-1/4 m-auto">
+            <div class="text-sm w-1/4 m-auto">
               {#if originRegistries.some(r => r.serverUrl === registry.serverUrl)}
                 <div class="text-left h-7 pr-5 mt-1.5 mb-0.5 text-sm w-full">
                   <input
@@ -272,12 +277,12 @@ const processPasswordElement = (node: HTMLInputElement, registry: containerDeskt
             </div>
 
             <!-- Password -->
-            <div class="pt-4 pb-2 text-sm w-2/5">
+            <div class="text-sm w-2/5">
               <div class="flex flex-row">
                 {#if originRegistries.some(r => r.serverUrl === registry.serverUrl)}
-                  <div class="flex text-left h-7 pr-5 mt-1.5 mb-0.5 text-sm w-full">
+                  <div class="flex text-left h-7 pr-5 text-sm w-full">
                     <div class="relative flex-1">
-                      <div class="absolute inset-y-0 right-0 flex items-center px-1">
+                      <div class="absolute inset-y-0 right-0 flex px-1">
                         <input
                           id="password-toggle-{registry.serverUrl}"
                           class="hidden"
@@ -308,15 +313,16 @@ const processPasswordElement = (node: HTMLInputElement, registry: containerDeskt
                         class="px-3 block w-full h-full transition ease-in-out delay-50 bg-charcoal-800 text-gray-700 placeholder-gray-700 rounded-sm focus:outline-none pr-10" />
                     </div>
                   </div>
-                  <div class="h-7 mt-1.5 mb-0.5 text-sm">
+                  <div class="h-7 text-sm">
                     <button
                       on:click="{() => loginToRegistry(registry)}"
+                      disabled="{loggingIn}"
                       class="pf-c-button pf-m-primary transition ease-in-out delay-50 hover:cursor-pointer w-full h-full rounded-md shadow hover:shadow-lg"
                       type="button">
                       Login
                     </button>
                   </div>
-                  <div class="h-7 mt-1.5 mb-0.5 text-sm">
+                  <div class="h-7 text-sm">
                     <button
                       on:click="{() => markRegistryAsClean(registry)}"
                       class="transition ease-in-out delay-50 hover:cursor-pointer w-16 h-full"
@@ -400,9 +406,9 @@ const processPasswordElement = (node: HTMLInputElement, registry: containerDeskt
       {#each $registriesSuggestedInfos as registry, i (registry)}
         <!-- Add new registry form start -->
         <div class="flex flex-col w-full border-t border-gray-900">
-          <div class="flex flex-row">
-            <div class="flex-1 pt-2 pl-5 pr-5 text-sm w-auto m-auto">
-              <div class="flex items-center w-full h-full">
+          <div class="flex flex-row items-center pt-4 pb-3">
+            <div class="flex-1 pl-5 pr-5 text-sm w-auto m-auto">
+              <div class="flex w-full h-full">
                 <div class="flex items-center">
                   {#if registry.icon}
                     <img
@@ -411,7 +417,7 @@ const processPasswordElement = (node: HTMLInputElement, registry: containerDeskt
                       width="24"
                       height="24" />
                   {/if}
-                  <!-- By defualt, just show the name, but if we go to add it, show the full URL including https -->
+                  <!-- By default, just show the name, but if we go to add it, show the full URL including https -->
                   <span class="ml-2 text-gray-700">
                     {#if listedSuggestedRegistries[i]}
                       https://{registry.url}
@@ -422,20 +428,20 @@ const processPasswordElement = (node: HTMLInputElement, registry: containerDeskt
                 </div>
               </div>
             </div>
-            <div class="flex pt-4 pb-2 pr-5 text-sm w-1/4">
+            <div class="flex pr-5 text-sm w-1/4">
               {#if listedSuggestedRegistries[i]}
                 <input
                   type="text"
                   placeholder="Username"
                   bind:value="{newRegistryRequest.username}"
-                  class="px-3 block w-full h-7 pr-5 mb-0.5 transition ease-in-out delay-50 bg-charcoal-800 text-gray-700 placeholder-gray-700 rounded-sm focus:outline-none" />
+                  class="px-3 block w-full h-7 pr-5 transition ease-in-out delay-50 bg-charcoal-800 text-gray-700 placeholder-gray-700 rounded-sm focus:outline-none" />
               {/if}
             </div>
-            <div class="pt-4 pb-2 text-sm w-2/5">
-              <div class="flex flex-row">
+            <div class="text-sm w-2/5">
+              <div class="flex flex-row items-center">
                 <div class="relative flex-1 mr-5">
                   {#if listedSuggestedRegistries[i]}
-                    <div class="absolute inset-y-0 right-0 flex items-center">
+                    <div class="absolute inset-y-0 right-0 flex">
                       <input
                         id="password-toggle-new-registry"
                         class="hidden"
@@ -470,7 +476,8 @@ const processPasswordElement = (node: HTMLInputElement, registry: containerDeskt
                       on:click="{() => loginToRegistry(newRegistryRequest)}"
                       disabled="{!newRegistryRequest.serverUrl ||
                         !newRegistryRequest.username ||
-                        !newRegistryRequest.secret}"
+                        !newRegistryRequest.secret ||
+                        loggingIn}"
                       class="inline pf-c-button pf-m-primary transition ease-in-out delay-50 hover:cursor-pointer h-full rounded-md shadow hover:shadow-lg justify-center"
                       type="button">
                       Login
@@ -478,7 +485,7 @@ const processPasswordElement = (node: HTMLInputElement, registry: containerDeskt
                   {/if}
                 </div>
                 <div class="flex text-sm">
-                  <div class="h-7 mt-1.5 mb-0.5 pr-5 text-sm">
+                  <div class="h-7 pr-5 text-sm">
                     {#if listedSuggestedRegistries[i]}
                       <button
                         on:click="{() => hideSuggestedRegistries()}"
@@ -513,25 +520,25 @@ const processPasswordElement = (node: HTMLInputElement, registry: containerDeskt
       {#if showNewRegistryForm}
         <!-- Add new registry form start -->
         <div class="flex flex-col w-full border-t border-gray-900">
-          <div class="flex flex-row">
-            <div class="flex-1 pt-2 pl-10 pr-5 text-sm w-auto m-auto">
+          <div class="flex flex-row items-center pt-4 pb-3">
+            <div class="flex-1 pl-10 pr-5 text-sm w-auto m-auto">
               <input
                 type="text"
                 placeholder="URL (HTTPS only)"
                 bind:value="{newRegistryRequest.serverUrl}"
-                class="px-3 block w-full h-7 pr-5 mb-0.5 transition ease-in-out delay-50 bg-charcoal-800 text-gray-700 placeholder-gray-700 rounded-sm focus:outline-none" />
+                class="px-3 block w-full h-7 pr-5 transition ease-in-out delay-50 bg-charcoal-800 text-gray-700 placeholder-gray-700 rounded-sm focus:outline-none" />
             </div>
-            <div class="flex pt-4 pb-2 pr-5 text-sm w-1/4">
+            <div class="flex pr-5 text-sm w-1/4">
               <input
                 type="text"
                 placeholder="Username"
                 bind:value="{newRegistryRequest.username}"
-                class="px-3 block w-full h-7 pr-5 mb-0.5 transition ease-in-out delay-50 bg-charcoal-800 text-gray-700 placeholder-gray-700 rounded-sm focus:outline-none" />
+                class="px-3 block w-full h-7 pr-5 transition ease-in-out delay-50 bg-charcoal-800 text-gray-700 placeholder-gray-700 rounded-sm focus:outline-none" />
             </div>
-            <div class="pt-4 pb-2 text-sm w-2/5">
+            <div class="text-sm w-2/5">
               <div class="flex flex-row">
                 <div class="relative flex-1 mr-5">
-                  <div class="absolute inset-y-0 right-0 flex items-center">
+                  <div class="absolute inset-y-0 right-0 flex">
                     <input
                       id="password-toggle-new-registry"
                       class="hidden"
@@ -564,7 +571,8 @@ const processPasswordElement = (node: HTMLInputElement, registry: containerDeskt
                     on:click="{() => loginToRegistry(newRegistryRequest)}"
                     disabled="{!newRegistryRequest.serverUrl ||
                       !newRegistryRequest.username ||
-                      !newRegistryRequest.secret}"
+                      !newRegistryRequest.secret ||
+                      loggingIn}"
                     class="inline pf-c-button pf-m-primary transition ease-in-out delay-50 hover:cursor-pointer h-full rounded-md shadow hover:shadow-lg justify-center"
                     type="button">
                     Login


### PR DESCRIPTION
### What does this PR do?

The fix to disable the Login button is simple: use a loggingIn flag that disables the Login buttons while it is processing.

However, while testing this I kept getting distracted by the fact that the user/password/cancel controls were not vertically aligned and the show/hide password wasn't centered in the password box. I removed most of the top/bottom vertical padding and used items-center to center all of the rows vertically.

### Screenshot/screencast of this PR

Before:
<img width="764" alt="Screenshot 2023-05-08 at 9 29 27 AM" src="https://user-images.githubusercontent.com/19958075/236919841-7a645ff4-2285-4141-8731-ea3244851265.png">

After:
<img width="764" alt="Screenshot 2023-05-08 at 9 27 54 AM" src="https://user-images.githubusercontent.com/19958075/236919817-d3c7986a-941b-49df-b1b2-1366ec7f5b6f.png">

### What issues does this PR fix or reference?

Fixes #2334.

### How to test this PR?

Create a registry and try to click on Login twice, to confirm you can't do this and the bug is fixed. Check vertical alignment of the entire form, for both suggested and regular registries.