### PR TITLE
fix: website is using the new palette colors but definition are not there

### DIFF
--- a/website/tailwind.config.js
+++ b/website/tailwind.config.js
@@ -1,10 +1,13 @@
 const defaultTheme = require('tailwindcss/defaultTheme');
+const rootTailWindConfig = require('../tailwind.config.cjs');
 
 module.exports = {
   content: ['./src/**/*.{js,jsx,ts,tsx}'],
   darkMode: 'class',
   theme: {
     extend: {
+      // share same color palette of Podman Desktop UI
+      colors: rootTailWindConfig.theme.colors,
       backgroundImage: {
         'hero-pattern': 'url(/img/gradients.png)',
       },


### PR DESCRIPTION



### What does this PR do?
website has been updated to use charcoal colors but it was not defined in the website tailwind configuration, only in the Product.

### Screenshot/screencast of this PR

![image](https://user-images.githubusercontent.com/436777/237024719-33cbbcbf-1f6b-493d-96b8-fdd85f8633b5.png)


### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/2380

### How to test this PR?

Check the netlify deploy

Change-Id: Ib683ee51176d89879d6e87170e46efb5b24788ad

