### PR TITLE
fix: set ipv4 over ipv6 by default

### DIFF
--- a/packages/main/src/index.ts
+++ b/packages/main/src/index.ts
@@ -25,6 +25,7 @@ import { AnimatedTray } from './tray-animate-icon';
 import { PluginSystem } from './plugin';
 import { StartupInstall } from './system/startup-install';
 import type { ExtensionLoader } from './plugin/extension-loader';
+import dns from 'node:dns';
 
 let extensionLoader: ExtensionLoader | undefined;
 /**
@@ -94,6 +95,11 @@ app.whenReady().then(
     // We use 'activate' within whenReady in order to gracefully start on macOS, see this link:
     // https://www.electronjs.org/docs/latest/tutorial/quick-start#open-a-window-if-none-are-open-macos
     app.on('activate', createNewWindow);
+
+    // prefer ipv4 over ipv6
+    // TODO: Needs to be there until Happy Eyeballs(https://en.wikipedia.org/wiki/Happy_Eyeballs) is implemented
+    // which is the case in Node.js 20+ https://github.com/nodejs/node/issues/41625
+    dns.setDefaultResultOrder('ipv4first');
 
     // Setup the default tray icon + menu items
     const animatedTray = new AnimatedTray();


### PR DESCRIPTION
### What does this PR do?
it can cause troubles with some extensions

It'll possible to drop that preference with Happy Eyeballs implemented in Node.js 20+ but electron embeds for now Node.js 18

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

Fixes #2255 

### How to test this PR?

Try the usecase provided by the issue

Without the fix: connection refused on ipv6 interface
With the fix: connection works


Change-Id: If6d74033a2aa68534403f7ce5e96afa10efd56e5

