### PR TITLE
feat: Allow to open external links if user confirms

### DIFF
--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -39,7 +39,6 @@ import type { FilesystemMonitoring } from './filesystem-monitoring';
 import { Uri } from './types/uri';
 import type { KubernetesClient } from './kubernetes-client';
 import type { Proxy } from './proxy';
-import { shell as electronShell } from 'electron';
 import type { ContainerProviderRegistry } from './container-registry';
 import type { InputQuickPickRegistry } from './input-quickpick/input-quickpick-registry';
 import { QuickPickItemKind, InputBoxValidationSeverity } from './input-quickpick/input-quickpick-registry';
@@ -52,6 +51,7 @@ import type { AuthenticationImpl } from './authentication';
 import type { Telemetry } from './telemetry/telemetry';
 import { TelemetryTrustedValue } from './types/telemetry';
 import { clipboard as electronClipboard } from 'electron';
+import { securityRestrictionCurrentHandler } from '../security-restrictions-handler';
 /**
  * Handle the loading of an extension
  */
@@ -642,9 +642,10 @@ export class ExtensionLoader {
     const telemetry = this.telemetry;
     const env: typeof containerDesktopAPI.env = {
       openExternal: async (uri: containerDesktopAPI.Uri): Promise<boolean> => {
+        const url = uri.toString();
         try {
-          await electronShell.openExternal(uri.toString());
-          return true;
+          const result = await securityRestrictionCurrentHandler.handler?.(url);
+          return result || false;
         } catch (error) {
           console.error(`Unable to open external link  ${uri.toString()} from extension ${extensionInfo.id}`, error);
           return false;

--- a/packages/main/src/security-restrictions-handler.ts
+++ b/packages/main/src/security-restrictions-handler.ts
@@ -1,0 +1,24 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+// callback to use for handling unknown URLS
+type SecurityRestrictionHandler = (url: string) => Promise<boolean>;
+
+export const securityRestrictionCurrentHandler: { handler: SecurityRestrictionHandler | undefined } = {
+  handler: undefined,
+};


### PR DESCRIPTION
### What does this PR do?
Ask user before opening a link
User can also copy the link and open the link where he wants

All external links are now following the same approach for opening.

### Screenshot/screencast of this PR


https://github.com/containers/podman-desktop/assets/436777/bf4515d8-7cf4-43b0-8790-df9e60a42baa


### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/2230

### How to test this PR?

Click on provider links, in markdown description, etc.
Unit tests added

Change-Id: I1665e7bfb74229cd7e0104e36226e3be4adebf79
