### PR TITLE
fix: Add Markdown support for showInputBox

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -710,6 +710,11 @@ declare module '@podman-desktop/api' {
     ignoreFocusOut?: boolean;
 
     /**
+     * Set to `true` when value represents a multi line content.
+     */
+    multiline?: boolean;
+
+    /**
      * An optional function that will be called to validate input and to give a hint
      * to the user.
      *

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -694,6 +694,11 @@ declare module '@podman-desktop/api' {
     prompt?: string;
 
     /**
+     * A description of the field to be show (Markdown format)
+     */
+    markdownDescription?;
+
+    /**
      * An optional string to show as placeholder in the input box to guide the user what to type.
      */
     placeHolder?: string;

--- a/packages/main/src/plugin/input-quickpick/input-quickpick-registry.ts
+++ b/packages/main/src/plugin/input-quickpick/input-quickpick-registry.ts
@@ -67,6 +67,7 @@ export class InputQuickPickRegistry {
       title: options?.title,
       valueSelection: options?.valueSelection,
       prompt: options?.prompt,
+      multiline: options?.multiline,
       validate,
     };
 

--- a/packages/main/src/plugin/input-quickpick/input-quickpick-registry.ts
+++ b/packages/main/src/plugin/input-quickpick/input-quickpick-registry.ts
@@ -67,6 +67,7 @@ export class InputQuickPickRegistry {
       title: options?.title,
       valueSelection: options?.valueSelection,
       prompt: options?.prompt,
+      markdownDescription: options?.markdownDescription,
       multiline: options?.multiline,
       validate,
     };

--- a/packages/renderer/src/lib/dialogs/QuickPickInput.spec.ts
+++ b/packages/renderer/src/lib/dialogs/QuickPickInput.spec.ts
@@ -131,14 +131,15 @@ describe('QuickPickInput', () => {
     expect(itemDetail2).toBeInTheDocument();
   });
 
-  test('Expect that prompt is displayed', async () => {
+  test('Expect that description is displayed', async () => {
     const idRequest = 123;
 
     const inputBoxOptions: InputBoxOptions = {
       multiline: false,
       validate: false,
       placeHolder: '',
-      prompt: 'Enter a value',
+      prompt: '',
+      markdownDescription: 'Enter a value',
       id: idRequest,
     };
 
@@ -156,14 +157,15 @@ describe('QuickPickInput', () => {
     expect(paragraph).toBeDefined();
   });
 
-  test('Expect that markdown prompt is displayed', async () => {
+  test('Expect that markdown description is displayed', async () => {
     const idRequest = 123;
 
     const inputBoxOptions: InputBoxOptions = {
       multiline: false,
       validate: false,
       placeHolder: '',
-      prompt: 'Enter a value [See](https://podman-desktop.io)',
+      prompt: '',
+      markdownDescription: 'Enter a value [See](https://podman-desktop.io)',
       id: idRequest,
     };
 

--- a/packages/renderer/src/lib/dialogs/QuickPickInput.spec.ts
+++ b/packages/renderer/src/lib/dialogs/QuickPickInput.spec.ts
@@ -20,10 +20,10 @@
 
 import '@testing-library/jest-dom';
 import { beforeAll, test, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/svelte';
+import { render, screen, within } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import QuickPickInput from './QuickPickInput.svelte';
-import type { QuickPickOptions } from './quickpick-input';
+import type { InputBoxOptions, QuickPickOptions } from './quickpick-input';
 
 const sendShowQuickPickValuesMock = vi.fn();
 const sendShowInputBoxValueMock = vi.fn();
@@ -129,5 +129,80 @@ describe('QuickPickInput', () => {
     expect(itemDescription2).toBeInTheDocument();
     const itemDetail2 = await screen.findByText('my detail2');
     expect(itemDetail2).toBeInTheDocument();
+  });
+
+  test('Expect that prompt is displayed', async () => {
+    const idRequest = 123;
+
+    const inputBoxOptions: InputBoxOptions = {
+      multiline: false,
+      validate: false,
+      placeHolder: '',
+      prompt: 'Enter a value',
+      id: idRequest,
+    };
+
+    receiveFunctionMock.mockImplementation((message: string, callback: (options: InputBoxOptions) => void) => {
+      if (message === 'showInputBox:add') {
+        callback(inputBoxOptions);
+      }
+    });
+
+    render(QuickPickInput, {});
+
+    const section = await screen.findByLabelText('markdown-content');
+    expect(section).toBeInTheDocument();
+    const paragraph = within(section).findByText(/Enter a value/g);
+    expect(paragraph).toBeDefined();
+  });
+
+  test('Expect that markdown prompt is displayed', async () => {
+    const idRequest = 123;
+
+    const inputBoxOptions: InputBoxOptions = {
+      multiline: false,
+      validate: false,
+      placeHolder: '',
+      prompt: 'Enter a value [See](https://podman-desktop.io)',
+      id: idRequest,
+    };
+
+    receiveFunctionMock.mockImplementation((message: string, callback: (options: InputBoxOptions) => void) => {
+      if (message === 'showInputBox:add') {
+        callback(inputBoxOptions);
+      }
+    });
+
+    render(QuickPickInput, {});
+
+    const section = await screen.findByLabelText('markdown-content');
+    expect(section).toBeInTheDocument();
+    const paragraph = await within(section).findByText(/Enter a value/g);
+    expect(paragraph).toBeInTheDocument();
+    const link = await within(paragraph).findByRole('link');
+    expect(link).toBeInTheDocument();
+  });
+
+  test('Expect that multiline is displayed', async () => {
+    const idRequest = 123;
+
+    const inputBoxOptions: InputBoxOptions = {
+      multiline: true,
+      validate: false,
+      placeHolder: '',
+      prompt: 'Enter a value',
+      id: idRequest,
+    };
+
+    receiveFunctionMock.mockImplementation((message: string, callback: (options: InputBoxOptions) => void) => {
+      if (message === 'showInputBox:add') {
+        callback(inputBoxOptions);
+      }
+    });
+
+    render(QuickPickInput, {});
+
+    const area = await screen.findByRole('textbox');
+    expect(area).toBeInTheDocument();
   });
 });

--- a/packages/renderer/src/lib/dialogs/QuickPickInput.svelte
+++ b/packages/renderer/src/lib/dialogs/QuickPickInput.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import { onDestroy, onMount, tick } from 'svelte';
 import type { InputBoxOptions, QuickPickOptions } from './quickpick-input';
+import Markdown from '/@/lib/markdown/Markdown.svelte';
 
 const DEFAULT_PROMPT = "Press 'Enter' to confirm your input or 'Escape' to cancel";
 let inputValue = '';
@@ -8,6 +9,7 @@ let placeHolder = '';
 let prompt = '';
 let currentId = 0;
 let title = '';
+let multiline = false;
 
 let validationEnabled = false;
 let validationError = '';
@@ -36,6 +38,7 @@ const showInputCallback = async (options?: InputBoxOptions) => {
   } else {
     prompt = DEFAULT_PROMPT;
   }
+  multiline = options.multiline;
 
   validationEnabled = options.validate;
   display = true;
@@ -264,15 +267,27 @@ function handleKeydown(e: KeyboardEvent) {
           </div>
         {/if}
         <div class="w-full flex flex-row">
-          <input
-            bind:this="{inputElement}"
-            on:input="{event => onInputChange(event)}"
-            type="text"
-            bind:value="{inputValue}"
-            class="px-1 w-full text-gray-400 bg-zinc-700 border {validationError
-              ? 'border-red-700'
-              : 'border-charcoal-600'} focus:outline-none"
-            placeholder="{placeHolder}" />
+          {#if multiline}
+            <textarea
+              bind:this="{inputElement}"
+              on:input="{event => onInputChange(event)}"
+              type="text"
+              bind:value="{inputValue}"
+              class="px-1 w-full h-20 text-gray-400 bg-zinc-700 border {validationError
+                ? 'border-red-700'
+                : 'border-charcoal-600'} focus:outline-none"
+              placeholder="{placeHolder}"></textarea>
+          {:else}
+            <input
+              bind:this="{inputElement}"
+              on:input="{event => onInputChange(event)}"
+              type="text"
+              bind:value="{inputValue}"
+              class="px-1 w-full text-gray-400 bg-zinc-700 border {validationError
+                ? 'border-red-700'
+                : 'border-charcoal-600'} focus:outline-none"
+              placeholder="{placeHolder}" />
+          {/if}
           {#if quickPickCanPickMany}
             <button
               on:click="{() => validateQuickPick()}"
@@ -284,7 +299,7 @@ function handleKeydown(e: KeyboardEvent) {
           {#if validationError}
             <div class="text-gray-400 border border-red-700 relative w-full bg-red-700 px-1">{validationError}</div>
           {:else}
-            <div class="relative text-gray-400 pt-2 px-1 h-6 overflow-y-auto">{prompt}</div>
+            <div class="relative text-gray-400 pt-2 px-1 h-6 overflow-y-auto"><Markdown>{prompt}</Markdown></div>
           {/if}
         {:else if mode === 'QuickPick'}
           {#each quickPickFilteredItems as item, i}

--- a/packages/renderer/src/lib/dialogs/QuickPickInput.svelte
+++ b/packages/renderer/src/lib/dialogs/QuickPickInput.svelte
@@ -301,9 +301,9 @@ function handleKeydown(e: KeyboardEvent) {
           {#if validationError}
             <div class="text-gray-400 border border-red-700 relative w-full bg-red-700 px-1">{validationError}</div>
           {:else}
-            <div class="relative text-gray-400 pt-2 px-1 h-6 overflow-y-auto">{prompt}</div>
+            <div class="relative text-gray-400 pt-2 px-1 h-7 overflow-y-auto">{prompt}</div>
             {#if markdownDescription?.length > 0}
-              <div class="relative text-gray-400 pt-2 px-1 h-6 overflow-y-auto">
+              <div class="relative text-gray-400 pt-2 px-1 h-fit overflow-y-auto">
                 <Markdown>{markdownDescription}</Markdown>
               </div>
             {/if}

--- a/packages/renderer/src/lib/dialogs/QuickPickInput.svelte
+++ b/packages/renderer/src/lib/dialogs/QuickPickInput.svelte
@@ -7,6 +7,7 @@ const DEFAULT_PROMPT = "Press 'Enter' to confirm your input or 'Escape' to cance
 let inputValue = '';
 let placeHolder = '';
 let prompt = '';
+let markdownDescription = '';
 let currentId = 0;
 let title = '';
 let multiline = false;
@@ -38,6 +39,7 @@ const showInputCallback = async (options?: InputBoxOptions) => {
   } else {
     prompt = DEFAULT_PROMPT;
   }
+  markdownDescription = options.markdownDescription;
   multiline = options.multiline;
 
   validationEnabled = options.validate;
@@ -257,7 +259,7 @@ function handleKeydown(e: KeyboardEvent) {
     <div class=" flex justify-center items-center mt-1">
       <div
         class="bg-charcoal-800 w-[700px] {mode === 'InputBox'
-          ? 'h-16'
+          ? 'h-fit'
           : ''} shadow-sm p-2 rounded shadow-zinc-700 text-sm">
         {#if title}
           <div
@@ -299,7 +301,12 @@ function handleKeydown(e: KeyboardEvent) {
           {#if validationError}
             <div class="text-gray-400 border border-red-700 relative w-full bg-red-700 px-1">{validationError}</div>
           {:else}
-            <div class="relative text-gray-400 pt-2 px-1 h-6 overflow-y-auto"><Markdown>{prompt}</Markdown></div>
+            <div class="relative text-gray-400 pt-2 px-1 h-6 overflow-y-auto">{prompt}</div>
+            {#if markdownDescription?.length > 0}
+              <div class="relative text-gray-400 pt-2 px-1 h-6 overflow-y-auto">
+                <Markdown>{markdownDescription}</Markdown>
+              </div>
+            {/if}
           {/if}
         {:else if mode === 'QuickPick'}
           {#each quickPickFilteredItems as item, i}

--- a/packages/renderer/src/lib/dialogs/QuickPickInput.svelte
+++ b/packages/renderer/src/lib/dialogs/QuickPickInput.svelte
@@ -26,7 +26,7 @@ let quickPickSelectedIndex = 0;
 let quickPickSelectedFilteredIndex = 0;
 let quickPickCanPickMany = false;
 
-let inputElement: HTMLInputElement = undefined;
+let inputElement: HTMLInputElement | HTMLTextAreaElement = undefined;
 
 const showInputCallback = async (options?: InputBoxOptions) => {
   mode = 'InputBox';
@@ -273,7 +273,6 @@ function handleKeydown(e: KeyboardEvent) {
             <textarea
               bind:this="{inputElement}"
               on:input="{event => onInputChange(event)}"
-              type="text"
               bind:value="{inputValue}"
               class="px-1 w-full h-20 text-gray-400 bg-zinc-700 border {validationError
                 ? 'border-red-700'

--- a/packages/renderer/src/lib/dialogs/quickpick-input.ts
+++ b/packages/renderer/src/lib/dialogs/quickpick-input.ts
@@ -36,6 +36,7 @@ export interface InputBoxOptions {
   // if true, the input box will be validated on each keystroke
   validate: boolean;
   prompt: string;
+  markdownDescription?: string;
   multiline: boolean;
   id: number;
   title?: string;

--- a/packages/renderer/src/lib/dialogs/quickpick-input.ts
+++ b/packages/renderer/src/lib/dialogs/quickpick-input.ts
@@ -36,6 +36,7 @@ export interface InputBoxOptions {
   // if true, the input box will be validated on each keystroke
   validate: boolean;
   prompt: string;
+  multiline: boolean;
   id: number;
   title?: string;
 }


### PR DESCRIPTION
Fixes #1920

### What does this PR do?

Enhance showInputBox with multiLine and markdownDescription

### Screenshot/screencast of this PR

![image](https://github.com/containers/podman-desktop/assets/695993/e27e4200-ade4-4092-95de-207b2171885c)

Muliline:

![image](https://github.com/containers/podman-desktop/assets/695993/906e3148-15ed-4734-8ada-6a5319db72e7)


### What issues does this PR fix or reference?

Fixes #1920

### How to test this PR?

Add the following code in _packages/main/src/plugin/index.ts_ line 350:

```
    statusBarRegistry.setEntry('area', false, 0, undefined, 'Area', 'fa fa-bell', true, 'show-area', undefined);
    commandRegistry.registerCommand('show-area', async () => {
      await inputQuickPickRegistry.showInputBox({
        prompt: 'Enter the pull secret',
        markdownDescription: 'To put container images from the regsitry, a *pull secret* is necessary. You can get a pull secret from the [Red Hat OpenShift Local download page](https://developers.redhat.com/products/openshift-local/overview). Use the *"Copy pull secret"* option and paste the content into the field above',
        multiline: true,
      });
    });
```

and click on the first bell in the status area