### PR TITLE
chore: reduce initial REST API calls

### DIFF
--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -117,6 +117,9 @@ export class PluginSystem {
   // ready is when we've finished to initialize extension system
   private isReady = false;
 
+  // ready when all extensions have been started
+  private isExtensionsStarted = false;
+
   // notified when UI is dom-ready
   private uiReady = false;
 
@@ -323,6 +326,10 @@ export class PluginSystem {
     this.uiReady = false;
     this.ipcHandle('extension-system:isReady', async (): Promise<boolean> => {
       return this.isReady;
+    });
+
+    this.ipcHandle('extension-system:isExtensionsStarted', async (): Promise<boolean> => {
+      return this.isExtensionsStarted;
     });
 
     // redirect main process logs to the extension loader
@@ -1567,11 +1574,19 @@ export class PluginSystem {
 
     apiSender.send('starting-extensions', `${this.isReady}`);
     console.log('System ready. Loading extensions...');
-    await this.extensionLoader.start();
-    console.log('PluginSystem: initialization done.');
-    apiSender.send('extensions-started');
+    try {
+      await this.extensionLoader.start();
+      console.log('PluginSystem: initialization done.');
+    } finally {
+      apiSender.send('extensions-started');
+      this.markAsExtensionsStarted();
+    }
     autoStartConfiguration.start();
     return this.extensionLoader;
+  }
+
+  markAsExtensionsStarted(): void {
+    this.isExtensionsStarted = true;
   }
 
   markAsReady(): void {

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -138,6 +138,10 @@ function initExposure(): void {
     return ipcInvoke('extension-system:isReady');
   });
 
+  contextBridge.exposeInMainWorld('extensionSystemIsExtensionsStarted', async (): Promise<boolean> => {
+    return ipcInvoke('extension-system:isExtensionsStarted');
+  });
+
   contextBridge.exposeInMainWorld('listContainers', async (): Promise<ContainerInfo[]> => {
     return ipcInvoke('container-provider-registry:listContainers');
   });

--- a/packages/renderer/src/Loader.svelte
+++ b/packages/renderer/src/Loader.svelte
@@ -20,6 +20,11 @@ onMount(async () => {
     if (systemReady) {
       window.dispatchEvent(new CustomEvent('system-ready', {}));
     }
+
+    const extensionsStarted = await window.extensionSystemIsExtensionsStarted();
+    if (extensionsStarted) {
+      window.dispatchEvent(new CustomEvent('extensions-already-started', {}));
+    }
   } catch (error) {}
 });
 

--- a/packages/renderer/src/lib/ImagestList.spec.ts
+++ b/packages/renderer/src/lib/ImagestList.spec.ts
@@ -38,6 +38,7 @@ beforeAll(() => {
   (window as any).hasAuthconfigForImage = vi.fn();
   (window as any).hasAuthconfigForImage.mockImplementation(() => Promise.resolve(false));
 
+  (window as any).listContainers = vi.fn();
   (window as any).listImages = listImagesMock;
   (window as any).getProviderInfos = getProviderInfosMock;
 
@@ -107,6 +108,7 @@ test('Expect images being ordered by newest first', async () => {
     },
   ]);
 
+  window.dispatchEvent(new CustomEvent('extensions-already-started'));
   window.dispatchEvent(new CustomEvent('provider-lifecycle-change'));
   window.dispatchEvent(new CustomEvent('image-build'));
 

--- a/packages/renderer/src/lib/volume/VolumesList.spec.ts
+++ b/packages/renderer/src/lib/volume/VolumesList.spec.ts
@@ -1,0 +1,149 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import '@testing-library/jest-dom';
+import { beforeAll, test, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import VolumesList from './VolumesList.svelte';
+import { get } from 'svelte/store';
+import { providerInfos } from '/@/stores/providers';
+import { fetchVolumes, volumeListInfos } from '/@/stores/volumes';
+
+const listVolumesMock = vi.fn();
+const getProviderInfosMock = vi.fn();
+
+// fake the window.events object
+beforeAll(() => {
+  (window as any).getConfigurationValue = vi.fn();
+  (window as any).updateConfigurationValue = vi.fn();
+  (window as any).getContributedMenus = vi.fn();
+  (window as any).onDidUpdateProviderStatus = vi.fn();
+  (window as any).listVolumes = listVolumesMock;
+  (window as any).listImages = vi.fn();
+
+  (window as any).getProviderInfos = getProviderInfosMock;
+
+  (window.events as unknown) = {
+    receive: (_channel: string, func: any) => {
+      func();
+    },
+  };
+});
+
+async function waitRender(customProperties: object): Promise<void> {
+  const result = render(VolumesList, { ...customProperties });
+  // wait that result.component.$$.ctx[2] is set
+  while (result.component.$$.ctx[2] === undefined) {
+    await new Promise(resolve => setTimeout(resolve, 100));
+  }
+}
+
+test('Expect fetching in progress being displayed', async () => {
+  listVolumesMock.mockResolvedValue([]);
+  getProviderInfosMock.mockResolvedValue([
+    {
+      name: 'podman',
+      status: 'started',
+      internalId: 'podman-internal-id',
+      containerConnections: [
+        {
+          name: 'podman-machine-default',
+          status: 'started',
+        },
+      ],
+    },
+  ]);
+  await render(VolumesList);
+  const noEngine = screen.getByRole('heading', { name: 'No Container Engine' });
+  expect(noEngine).toBeInTheDocument();
+});
+
+test('Expect no container engines being displayed', async () => {
+  window.dispatchEvent(new CustomEvent('extensions-already-started'));
+  window.dispatchEvent(new CustomEvent('provider-lifecycle-change'));
+
+  // wait store are populated
+  while (get(providerInfos).length === 0) {
+    await new Promise(resolve => setTimeout(resolve, 500));
+  }
+
+  await waitRender({});
+
+  const noEngine = screen.getByRole('heading', { name: 'Fetching volumes...' });
+  expect(noEngine).toBeInTheDocument();
+});
+
+test('Expect volumes being displayed once extensions are started', async () => {
+  getProviderInfosMock.mockResolvedValue([
+    {
+      name: 'podman',
+      status: 'started',
+      internalId: 'podman-internal-id',
+      containerConnections: [
+        {
+          name: 'podman-machine-default',
+          status: 'started',
+        },
+      ],
+    },
+  ]);
+
+  listVolumesMock.mockResolvedValue([
+    {
+      Volumes: [
+        {
+          Driver: 'local',
+          Labels: {},
+          Mountpoint: '/var/lib/containers/storage/volumes/fedora/_data',
+          Name: '0052074a2ade930338c00aea982a90e4243e6cf58ba920eb411c388630b8c967',
+          Options: {},
+          Scope: 'local',
+          engineName: 'Podman',
+          engineId: 'podman.Podman Machine',
+          UsageData: { RefCount: 1, Size: 89 },
+          containersUsage: [],
+        },
+      ],
+    },
+  ]);
+
+  window.dispatchEvent(new CustomEvent('extensions-already-started'));
+  window.dispatchEvent(new CustomEvent('provider-lifecycle-change'));
+
+  // ask to fetch the volumes
+  await fetchVolumes();
+
+  // wait store are populated
+  while (get(volumeListInfos).length === 0) {
+    await new Promise(resolve => setTimeout(resolve, 500));
+  }
+  while (get(providerInfos).length === 0) {
+    await new Promise(resolve => setTimeout(resolve, 500));
+  }
+
+  await waitRender({});
+
+  const volumeName = screen.getByRole('cell', { name: '0052074a2ade' });
+  const volumeSize = screen.getByRole('cell', { name: '89 B' });
+  expect(volumeName).toBeInTheDocument();
+  expect(volumeSize).toBeInTheDocument();
+
+  expect(volumeName.compareDocumentPosition(volumeSize)).toBe(4);
+});

--- a/packages/renderer/src/stores/volumes.ts
+++ b/packages/renderer/src/stores/volumes.ts
@@ -20,9 +20,17 @@ import type { Writable } from 'svelte/store';
 import { writable, derived } from 'svelte/store';
 import type { VolumeListInfo } from '../../../main/src/plugin/api/volume-info';
 import { findMatchInLeaves } from './search-util';
+
+let readyToUpdate = false;
+export let volumesInitialized = false;
+
 export async function fetchVolumes() {
+  if (!readyToUpdate) {
+    return;
+  }
   const result = await window.listVolumes();
   volumeListInfos.set(result);
+  volumesInitialized = true;
 }
 
 export const volumeListInfos: Writable<VolumeListInfo[]> = writable([]);
@@ -45,41 +53,52 @@ export const filtered = derived([searchPattern, volumeListInfos], ([$searchPatte
   });
 });
 
-// need to refresh when extension is started or stopped
-window?.events?.receive('extension-started', async () => {
-  await fetchVolumes();
-});
-window?.events?.receive('extension-stopped', async () => {
-  await fetchVolumes();
-});
+export function initWindowFetchVolumes() {
+  // need to refresh when extension is started or stopped
+  window?.events?.receive('extension-started', async () => {
+    await fetchVolumes();
+  });
+  window?.events?.receive('extension-stopped', async () => {
+    await fetchVolumes();
+  });
 
-window?.events.receive('provider-change', async () => {
-  await fetchVolumes();
-});
-window.addEventListener('system-ready', async () => {
-  await fetchVolumes();
-});
+  window?.events?.receive('provider-change', async () => {
+    await fetchVolumes();
+  });
 
-window.events?.receive('container-stopped-event', async () => {
-  await fetchVolumes();
-});
+  window?.events?.receive('container-stopped-event', async () => {
+    await fetchVolumes();
+  });
 
-window.events?.receive('container-die-event', async () => {
-  await fetchVolumes();
-});
+  window?.events?.receive('container-die-event', async () => {
+    await fetchVolumes();
+  });
 
-window.events?.receive('container-kill-event', async () => {
-  await fetchVolumes();
-});
+  window?.events?.receive('container-kill-event', async () => {
+    await fetchVolumes();
+  });
 
-window.events?.receive('container-started-event', async () => {
-  await fetchVolumes();
-});
+  window?.events?.receive('container-started-event', async () => {
+    await fetchVolumes();
+  });
 
-window.events?.receive('container-removed-event', async () => {
-  await fetchVolumes();
-});
+  window?.events?.receive('container-removed-event', async () => {
+    await fetchVolumes();
+  });
 
-window.events?.receive('volume-event', async () => {
-  await fetchVolumes();
-});
+  window?.events?.receive('volume-event', async () => {
+    await fetchVolumes();
+  });
+
+  window?.events?.receive('extensions-started', async () => {
+    // make it ready to update
+    readyToUpdate = true;
+  });
+
+  window.addEventListener('extensions-already-started', async () => {
+    // make it ready to update
+    readyToUpdate = true;
+  });
+}
+
+initWindowFetchVolumes();


### PR DESCRIPTION
### What does this PR do?
When Podman Desktop starts, it tries to fetch and refresh data like containers, images, volumes, pods a lot of time.
For example after an extension is started, etc.
But podman REST API has no cache and getting volume data like the size can take 5+s

so, instead of that, performs only one fetch for containers, images and pods when Podman Desktop is started
and then for volumes, first initialization occurs only if we ask for it.

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

Fixes #2375 
Fixes #2310
Fixes #2259

### How to test this PR?

Unit tests

but also try to use Podman Desktop with large images/volumes

Change-Id: I761f508ff3389a1253fb3ff273a84bb586d1c391
