### PR TITLE
fix: Add new extension failed state

### DIFF
--- a/packages/main/src/plugin/api/extension-info.ts
+++ b/packages/main/src/plugin/api/extension-info.ts
@@ -16,6 +16,11 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+export interface ExtensionError {
+  message: string;
+  stack?: string;
+}
+
 export interface ExtensionInfo {
   id: string;
   name: string;
@@ -25,5 +30,6 @@ export interface ExtensionInfo {
   removable: boolean;
   version: string;
   state: string;
+  error?: ExtensionError;
   path: string;
 }

--- a/packages/main/src/plugin/extension-loader.spec.ts
+++ b/packages/main/src/plugin/extension-loader.spec.ts
@@ -96,7 +96,8 @@ const inputQuickPickRegistry: InputQuickPickRegistry = {} as unknown as InputQui
 
 const authenticationProviderRegistry: AuthenticationImpl = {} as unknown as AuthenticationImpl;
 
-const telemetry: Telemetry = { track: vi.fn() } as unknown as Telemetry;
+const telemetryTrackMock = vi.fn();
+const telemetry: Telemetry = { track: telemetryTrackMock } as unknown as Telemetry;
 
 /* eslint-disable @typescript-eslint/no-empty-function */
 beforeAll(() => {
@@ -123,6 +124,7 @@ beforeAll(() => {
 });
 
 beforeEach(() => {
+  telemetryTrackMock.mockImplementation(() => Promise.resolve());
   vi.clearAllMocks();
 });
 

--- a/packages/main/src/plugin/extension-loader.spec.ts
+++ b/packages/main/src/plugin/extension-loader.spec.ts
@@ -53,6 +53,10 @@ class TestExtensionLoader extends ExtensionLoader {
   setWatchTimeout(timeout: number): void {
     this.watchTimeout = timeout;
   }
+
+  getExtensionState() {
+    return this.extensionState;
+  }
 }
 
 let extensionLoader: TestExtensionLoader;
@@ -67,7 +71,7 @@ const configurationRegistry: ConfigurationRegistry = {} as unknown as Configurat
 
 const imageRegistry: ImageRegistry = {} as unknown as ImageRegistry;
 
-const apiSender: ApiSenderType = {} as unknown as ApiSenderType;
+const apiSender: ApiSenderType = { send: vi.fn() } as unknown as ApiSenderType;
 
 const trayMenuRegistry: TrayMenuRegistry = {} as unknown as TrayMenuRegistry;
 
@@ -229,4 +233,24 @@ test('Should load file from watching scanning folder', async () => {
 
   // expect to load only one file (other are invalid files/folder)
   expect(loadPackagedFileMock).toBeCalledWith(path.resolve(rootedFakeDirectory, 'watch.cdix'));
+});
+
+test('Verify extension error leads to errored state', async () => {
+  const id = 'extension.id';
+  await extensionLoader.activateExtension(
+    {
+      id: id,
+      path: 'dummy',
+      api: undefined,
+      mainPath: '',
+      removable: false,
+      manifest: {},
+    },
+    {
+      activate: () => {
+        throw Error('Failed');
+      },
+    },
+  );
+  expect(extensionLoader.getExtensionState().get(id)).toBe('errored');
 });

--- a/packages/main/src/plugin/extension-loader.spec.ts
+++ b/packages/main/src/plugin/extension-loader.spec.ts
@@ -40,6 +40,7 @@ import type { ApiSenderType } from './api';
 import type { AuthenticationImpl } from './authentication';
 import type { MessageBox } from './message-box';
 import type { Telemetry } from './telemetry/telemetry';
+import type * as containerDesktopAPI from '@podman-desktop/api';
 
 class TestExtensionLoader extends ExtensionLoader {
   public async setupScanningDirectory(): Promise<void> {
@@ -241,7 +242,7 @@ test('Verify extension error leads to failed state', async () => {
     {
       id: id,
       path: 'dummy',
-      api: {},
+      api: {} as typeof containerDesktopAPI,
       mainPath: '',
       removable: false,
       manifest: {},

--- a/packages/main/src/plugin/extension-loader.spec.ts
+++ b/packages/main/src/plugin/extension-loader.spec.ts
@@ -241,7 +241,7 @@ test('Verify extension error leads to failed state', async () => {
     {
       id: id,
       path: 'dummy',
-      api: undefined,
+      api: {},
       mainPath: '',
       removable: false,
       manifest: {},

--- a/packages/main/src/plugin/extension-loader.spec.ts
+++ b/packages/main/src/plugin/extension-loader.spec.ts
@@ -235,7 +235,7 @@ test('Should load file from watching scanning folder', async () => {
   expect(loadPackagedFileMock).toBeCalledWith(path.resolve(rootedFakeDirectory, 'watch.cdix'));
 });
 
-test('Verify extension error leads to errored state', async () => {
+test('Verify extension error leads to failed state', async () => {
   const id = 'extension.id';
   await extensionLoader.activateExtension(
     {
@@ -252,5 +252,5 @@ test('Verify extension error leads to errored state', async () => {
       },
     },
   );
-  expect(extensionLoader.getExtensionState().get(id)).toBe('errored');
+  expect(extensionLoader.getExtensionState().get(id)).toBe('failed');
 });

--- a/packages/main/src/plugin/extension-loader.spec.ts
+++ b/packages/main/src/plugin/extension-loader.spec.ts
@@ -95,7 +95,7 @@ const inputQuickPickRegistry: InputQuickPickRegistry = {} as unknown as InputQui
 
 const authenticationProviderRegistry: AuthenticationImpl = {} as unknown as AuthenticationImpl;
 
-const telemetry: Telemetry = {} as unknown as Telemetry;
+const telemetry: Telemetry = { track: vi.fn() } as unknown as Telemetry;
 
 /* eslint-disable @typescript-eslint/no-empty-function */
 beforeAll(() => {

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -803,8 +803,8 @@ export class ExtensionLoader {
       this.extensionState.set(extension.id, 'started');
       this.apiSender.send('extension-started');
     } catch (err) {
-      console.log(`Activation extension ${extension.id} errored error:${err}`);
-      this.extensionState.set(extension.id, 'errored');
+      console.log(`Activation extension ${extension.id} failed error:${err}`);
+      this.extensionState.set(extension.id, 'failed');
     }
   }
 
@@ -821,7 +821,7 @@ export class ExtensionLoader {
       try {
         await extension.deactivateFunction();
       } catch (err) {
-        console.log(`Deactivation extension ${extension.id} errored error:${err}`);
+        console.log(`Deactivation extension ${extension.id} failed error:${err}`);
       }
     }
 

--- a/packages/renderer/src/lib/preferences/PreferencesExtensionRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesExtensionRendering.svelte
@@ -39,7 +39,7 @@ async function removeExtension() {
           <!-- start is enabled only when stopped -->
           <div class="px-2 text-sm italic text-gray-700">
             <button
-              disabled="{extensionInfo.state !== 'stopped'}"
+              disabled="{extensionInfo.state !== 'stopped' && extensionInfo.state !== 'failed'}"
               on:click="{() => startExtension()}"
               class="pf-c-button pf-m-primary"
               type="button">
@@ -68,7 +68,7 @@ async function removeExtension() {
           {#if extensionInfo.removable}
             <div class="px-2 text-sm italic text-gray-700">
               <button
-                disabled="{extensionInfo.state !== 'stopped'}"
+                disabled="{extensionInfo.state !== 'stopped' && extensionInfo.state !== 'failed'}"
                 on:click="{() => removeExtension()}"
                 class="pf-c-button pf-m-primary"
                 type="button">

--- a/packages/renderer/src/lib/preferences/PreferencesExtensionRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesExtensionRendering.svelte
@@ -82,6 +82,15 @@ async function removeExtension() {
             <div class="text-gray-900 items-center px-2 text-sm">Default extension, cannot be removed</div>
           {/if}
         </div>
+        {#if extensionInfo.error}
+          <div class="flex flex-col">
+            <div class="py-2">Extension error: {extensionInfo.error.message}</div>
+            {#if extensionInfo.error.stack}
+              <div class="py-2">Stack trace</div>
+              <div class="py-2">{extensionInfo.error.stack}</div>
+            {/if}
+          </div>
+        {/if}
       </Route>
     {/if}
   </div></SettingsPage>

--- a/packages/renderer/src/lib/preferences/PreferencesExtensionRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesExtensionRendering.svelte
@@ -36,7 +36,7 @@ async function removeExtension() {
         </div>
 
         <div class="py-2 flex flex-row items-center">
-          <!-- start is enabled only when stopped -->
+          <!-- start is enabled only when stopped or failed -->
           <div class="px-2 text-sm italic text-gray-700">
             <button
               disabled="{extensionInfo.state !== 'stopped' && extensionInfo.state !== 'failed'}"
@@ -64,7 +64,7 @@ async function removeExtension() {
             </button>
           </div>
 
-          <!-- delete is enabled only when stopped -->
+          <!-- delete is enabled only when stopped or failed -->
           {#if extensionInfo.removable}
             <div class="px-2 text-sm italic text-gray-700">
               <button

--- a/packages/renderer/src/lib/ui/ConnectionStatus.svelte
+++ b/packages/renderer/src/lib/ui/ConnectionStatus.svelte
@@ -42,6 +42,14 @@ const statusesStyle = new Map<string, connectionStatusStyle>([
       label: 'STOPPING',
     },
   ],
+  [
+    'failed',
+    {
+      bgColor: 'bg-red-500',
+      txtColor: 'text-red-500',
+      label: 'FAILED',
+    },
+  ],
 ]);
 $: statusStyle = statusesStyle.get(status) || {
   bgColor: 'bg-gray-900',


### PR DESCRIPTION
Fixes #2209

### What does this PR do?

Protect extension activation and deactivation from failure and add a new failed state

### Screenshot/screencast of this PR

![image](https://github.com/containers/podman-desktop/assets/695993/7e612ab3-5cf8-4ed9-bed6-9ef17378a9d7)

### What issues does this PR fix or reference?

Fixes #2209 

### How to test this PR?

- Update extension activation function to throw an error
- Launch
- Go to Extensions settings page