### PR TITLE
feat: Allow Podman machine create with root privileges

### DIFF
--- a/extensions/podman/package.json
+++ b/extensions/podman/package.json
@@ -87,7 +87,12 @@
           "format": "file",
           "scope": "ContainerProviderConnectionFactory",
           "description": "Image Path (Optional)"
-        }
+        },
+        "podman.factory.machine.rootful": {
+                  "type": "boolean",
+                  "scope": "ContainerProviderConnectionFactory",
+                  "description": "Machine with root privileges"
+      }
       }
     }
   },

--- a/extensions/podman/src/extension.spec.ts
+++ b/extensions/podman/src/extension.spec.ts
@@ -46,7 +46,7 @@ test('verify create command called with correct values', async () => {
   spyExecPromise.mockImplementation(() => {
     return Promise.resolve('');
   });
-  extension.createMachine(
+  await extension.createMachine(
     {
       'podman.factory.machine.cpus': '2',
       'podman.factory.machine.image-path': 'path',
@@ -71,7 +71,7 @@ test('verify create command called with correct values in rootful mode', async (
   spyExecPromise.mockImplementation(() => {
     return Promise.resolve('');
   });
-  extension.createMachine(
+  await extension.createMachine(
     {
       'podman.factory.machine.cpus': '2',
       'podman.factory.machine.image-path': 'path',

--- a/extensions/podman/src/extension.spec.ts
+++ b/extensions/podman/src/extension.spec.ts
@@ -65,3 +65,29 @@ test('verify create command called with correct values', async () => {
     undefined,
   );
 });
+
+test('verify create command called with correct values in rootful mode', async () => {
+  const spyExecPromise = vi.spyOn(podmanCli, 'execPromise');
+  spyExecPromise.mockImplementation(() => {
+    return Promise.resolve('');
+  });
+  extension.createMachine(
+    {
+      'podman.factory.machine.cpus': '2',
+      'podman.factory.machine.image-path': 'path',
+      'podman.factory.machine.memory': '1048000000',
+      'podman.factory.machine.diskSize': '250000000000',
+      'podman.factory.machine.rootful': true,
+    },
+    undefined,
+  );
+  expect(spyExecPromise).toBeCalledWith(
+    getPodmanCli(),
+    ['machine', 'init', '--cpus', '2', '--memory', '1048', '--disk-size', '250', '--image-path', 'path', '--rootful'],
+    {
+      env: {},
+      logger: undefined,
+    },
+    undefined,
+  );
+});

--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -752,12 +752,17 @@ export async function createMachine(
     }
   }
 
+  // rootful
+  if (params['podman.factory.machine.rootful']) {
+    parameters.push('--rootful');
+  }
+
   // name at the end
   if (params['podman.factory.machine.name']) {
     parameters.push(params['podman.factory.machine.name']);
   }
 
-  // name at the end
+  // starts now
   if (params['podman.factory.machine.now']) {
     parameters.push('--now');
   }


### PR DESCRIPTION
Fixes #2078

### What does this PR do?

Add a new flag to allow Podman machine to be created with root privileges

### Screenshot/screencast of this PR

![image](https://github.com/containers/podman-desktop/assets/695993/5cf6895e-a3c6-4130-8ce0-85a9de1aea29)


### What issues does this PR fix or reference?

Fixes #2078

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

### How to test this PR?

- Create a new Podman machine with the new flag enabled
- Verify the machine is rootful
