### PR TITLE
fix: hang on exit when telemetry endpoint is unreachable

### DIFF
--- a/packages/main/src/plugin/telemetry/telemetry.ts
+++ b/packages/main/src/plugin/telemetry/telemetry.ts
@@ -112,7 +112,11 @@ export class Telemetry {
     this.listenForTelemetryUpdates();
 
     // initalize objects
-    this.analytics = new Analytics(Telemetry.SEGMENT_KEY);
+    this.analytics = new Analytics(Telemetry.SEGMENT_KEY, {
+      errorHandler: err => {
+        console.log(`Telemetry request error: ${err}`);
+      },
+    });
 
     // needs to prompt the user for the first time he launches the app
     if (check) {
@@ -205,8 +209,12 @@ export class Telemetry {
     app.on('before-quit', async e => {
       if (!sendShutdownAnalytics && stoppedExtensions.val) {
         e.preventDefault();
-        await this.internalTrack(SHUTDOWN_EVENT_TYPE);
-        await this.analytics?.flush();
+        try {
+          await this.internalTrack(SHUTDOWN_EVENT_TYPE);
+          await this.analytics?.flush();
+        } catch (err) {
+          console.log(`Telemetry error on shutdown: ${err}`);
+        }
         sendShutdownAnalytics = true;
         app.quit();
       }


### PR DESCRIPTION
### What does this PR do?

Fixes a hang on exit and some aborted initialization code paths when there is a connectivity issue with the telemetry endpoint (e.g. when an ad-blocking appliance is in use, wifi issues etc).

The problem occurs due to Axios throwing socket errors which lead to unexpected rejected promises. These can interrupt critical code paths, such as the shutdown sequence, where the quit event is indefinitely cancelled:

```
8:05:10 AM [main] (node:72942) UnhandledPromiseRejectionWarning: Error: connect ECONNREFUSED 0.0.0.0:443
    at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1494:16)
(node:72942) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 21)
```

### How to test this PR?

Disable internet connection, try to quit podman desktop. Observe that while the main window closes the application is still running and can only be terminated via SIGKILL


Fixes https://github.com/containers/podman-desktop/issues/1812