### PR TITLE
Revert "fix: Kind clusters not cleaned up when stopping podman machine (#2306)

### DIFF
--- a/packages/main/src/plugin/provider-impl.ts
+++ b/packages/main/src/plugin/provider-impl.ts
@@ -214,11 +214,7 @@ export class ProviderImpl implements Provider, IDisposable {
 
   registerContainerProviderConnection(containerProviderConnection: ContainerProviderConnection): Disposable {
     this.containerProviderConnections.add(containerProviderConnection);
-    const disposable = this.containerRegistry.registerContainerConnection(
-      this,
-      containerProviderConnection,
-      this.providerRegistry,
-    );
+    const disposable = this.containerRegistry.registerContainerConnection(this, containerProviderConnection);
     this.providerRegistry.onDidRegisterContainerConnectionCallback(this, containerProviderConnection);
 
     return Disposable.create(() => {

--- a/packages/main/src/plugin/provider-registry.spec.ts
+++ b/packages/main/src/plugin/provider-registry.spec.ts
@@ -239,13 +239,6 @@ test('should send events when starting a container connection', async () => {
     },
   });
 
-  let onBeforeDidUpdateContainerConnectionCalled = false;
-  providerRegistry.onBeforeDidUpdateContainerConnection(event => {
-    expect(event.connection.name).toBe(connection.name);
-    expect(event.connection.type).toBe(connection.type);
-    expect(event.status).toBe('started');
-    onBeforeDidUpdateContainerConnectionCalled = true;
-  });
   let onDidUpdateContainerConnectionCalled = false;
   providerRegistry.onDidUpdateContainerConnection(event => {
     expect(event.connection.name).toBe(connection.name);
@@ -253,21 +246,12 @@ test('should send events when starting a container connection', async () => {
     expect(event.status).toBe('started');
     onDidUpdateContainerConnectionCalled = true;
   });
-  let onAfterDidUpdateContainerConnectionCalled = false;
-  providerRegistry.onAfterDidUpdateContainerConnection(event => {
-    expect(event.connection.name).toBe(connection.name);
-    expect(event.connection.type).toBe(connection.type);
-    expect(event.status).toBe('started');
-    onAfterDidUpdateContainerConnectionCalled = true;
-  });
 
   await providerRegistry.startProviderConnection('0', connection);
 
   expect(startMock).toBeCalled();
   expect(stopMock).not.toBeCalled();
-  expect(onBeforeDidUpdateContainerConnectionCalled).toBeTruthy();
   expect(onDidUpdateContainerConnectionCalled).toBeTruthy();
-  expect(onAfterDidUpdateContainerConnectionCalled).toBeTruthy();
 });
 
 test('should send events when stopping a container connection', async () => {
@@ -298,13 +282,6 @@ test('should send events when stopping a container connection', async () => {
     },
   });
 
-  let onBeforeDidUpdateContainerConnectionCalled = false;
-  providerRegistry.onBeforeDidUpdateContainerConnection(event => {
-    expect(event.connection.name).toBe(connection.name);
-    expect(event.connection.type).toBe(connection.type);
-    expect(event.status).toBe('stopped');
-    onBeforeDidUpdateContainerConnectionCalled = true;
-  });
   let onDidUpdateContainerConnectionCalled = false;
   providerRegistry.onDidUpdateContainerConnection(event => {
     expect(event.connection.name).toBe(connection.name);
@@ -312,21 +289,12 @@ test('should send events when stopping a container connection', async () => {
     expect(event.status).toBe('stopped');
     onDidUpdateContainerConnectionCalled = true;
   });
-  let onAfterDidUpdateContainerConnectionCalled = false;
-  providerRegistry.onAfterDidUpdateContainerConnection(event => {
-    expect(event.connection.name).toBe(connection.name);
-    expect(event.connection.type).toBe(connection.type);
-    expect(event.status).toBe('stopped');
-    onAfterDidUpdateContainerConnectionCalled = true;
-  });
 
   await providerRegistry.stopProviderConnection('0', connection);
 
   expect(stopMock).toBeCalled();
   expect(startMock).not.toBeCalled();
-  expect(onBeforeDidUpdateContainerConnectionCalled).toBeTruthy();
   expect(onDidUpdateContainerConnectionCalled).toBeTruthy();
-  expect(onAfterDidUpdateContainerConnectionCalled).toBeTruthy();
 });
 
 test('runAutostartContainer should start container and send event', async () => {

--- a/packages/main/src/plugin/provider-registry.ts
+++ b/packages/main/src/plugin/provider-registry.ts
@@ -97,15 +97,9 @@ export class ProviderRegistry {
   private readonly _onDidUpdateProvider = new Emitter<ProviderEvent>();
   readonly onDidUpdateProvider: Event<ProviderEvent> = this._onDidUpdateProvider.event;
 
-  private readonly _onBeforeDidUpdateContainerConnection = new Emitter<UpdateContainerConnectionEvent>();
-  readonly onBeforeDidUpdateContainerConnection: Event<UpdateContainerConnectionEvent> =
-    this._onBeforeDidUpdateContainerConnection.event;
   private readonly _onDidUpdateContainerConnection = new Emitter<UpdateContainerConnectionEvent>();
   readonly onDidUpdateContainerConnection: Event<UpdateContainerConnectionEvent> =
     this._onDidUpdateContainerConnection.event;
-  private readonly _onAfterDidUpdateContainerConnection = new Emitter<UpdateContainerConnectionEvent>();
-  readonly onAfterDidUpdateContainerConnection: Event<UpdateContainerConnectionEvent> =
-    this._onAfterDidUpdateContainerConnection.event;
 
   private readonly _onDidUpdateKubernetesConnection = new Emitter<UpdateKubernetesConnectionEvent>();
   readonly onDidUpdateKubernetesConnection: Event<UpdateKubernetesConnectionEvent> =
@@ -790,7 +784,7 @@ export class ProviderRegistry {
       await lifecycle.start(context, logHandler);
     } finally {
       if (this.isProviderContainerConnection(providerConnectionInfo)) {
-        const event = {
+        this._onDidUpdateContainerConnection.fire({
           providerId: internalProviderId,
           connection: {
             name: providerConnectionInfo.name,
@@ -801,10 +795,7 @@ export class ProviderRegistry {
             },
           },
           status: providerConnectionInfo.status,
-        };
-        this._onBeforeDidUpdateContainerConnection.fire(event);
-        this._onDidUpdateContainerConnection.fire(event);
-        this._onAfterDidUpdateContainerConnection.fire(event);
+        });
       } else {
         this._onDidUpdateKubernetesConnection.fire({
           providerId: internalProviderId,
@@ -843,7 +834,7 @@ export class ProviderRegistry {
       await lifecycle.stop(context, logHandler);
     } finally {
       if (this.isProviderContainerConnection(providerConnectionInfo)) {
-        const event = {
+        this._onDidUpdateContainerConnection.fire({
           providerId: internalProviderId,
           connection: {
             name: providerConnectionInfo.name,
@@ -854,10 +845,7 @@ export class ProviderRegistry {
             },
           },
           status: providerConnectionInfo.status,
-        };
-        this._onBeforeDidUpdateContainerConnection.fire(event);
-        this._onDidUpdateContainerConnection.fire(event);
-        this._onAfterDidUpdateContainerConnection.fire(event);
+        });
       } else {
         this._onDidUpdateKubernetesConnection.fire({
           providerId: internalProviderId,


### PR DESCRIPTION
### What does this PR do?
This reverts commit a1e80ae011c8a64a6098b9a13494267f150be281.

I didn't pay attention but the PR cleared out the timer that was monitoring the status.
Then, all external actions are now not anymore monitored.

For now, if Podman is started through the automatic start, it does a 'podman machine start', then it registers a ContainerConnection and only after a while it becomes "ready" but as there is not anymore the time it's never updated/refreshed

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop/issues/2417

### How to test this PR?

Use autostart feature of Podman Desktop. It's broken, we don't see the containers/images/etc as Podman Desktop still think the connection is not ready