### PR TITLE
Add sign in commands for authentication provider

### DIFF
--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -796,6 +796,10 @@ function initExposure(): void {
     },
   );
 
+  contextBridge.exposeInMainWorld('requestAuthenticationProviderSignIn', async (requestId: string): Promise<void> => {
+    return ipcInvoke('authentication-provider-registry:requestAuthenticationProviderSignIn', requestId);
+  });
+
   contextBridge.exposeInMainWorld(
     'getConfigurationProperties',
     async (): Promise<Record<string, IConfigurationPropertyRecordedSchema>> => {

--- a/packages/renderer/src/lib/preferences/PreferencesAuthenticationProvidersRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesAuthenticationProvidersRendering.spec.ts
@@ -41,6 +41,7 @@ test('Expect that page shows registered authentication providers without account
       id: 'test',
       displayName: 'Test Authentication Provider',
       accounts: [],
+      sessionRequests: [],
     },
   ]);
   render(PreferencesAuthenticationProvidersRendering, {});
@@ -60,6 +61,7 @@ const testProvidersInfo = [
         label: 'Test Account',
       },
     ],
+    sessionRequests: [],
   },
 ];
 

--- a/packages/renderer/src/lib/preferences/PreferencesAuthenticationProvidersRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesAuthenticationProvidersRendering.spec.ts
@@ -24,8 +24,6 @@ import { test, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/svelte';
 import { authenticationProviders } from '../../stores/authenticationProviders';
 import PreferencesAuthenticationProvidersRendering from './PreferencesAuthenticationProvidersRendering.svelte';
-import { AuthenticationProviderInfo } from '../../../../main/src/plugin/authentication';
-import { fieldEnds } from 'tar';
 
 afterEach(() => {
   vi.clearAllMocks();

--- a/packages/renderer/src/lib/preferences/PreferencesAuthenticationProvidersRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesAuthenticationProvidersRendering.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
 import { authenticationProviders } from '../../stores/authenticationProviders';
-import { faCircle, faRightFromBracket } from '@fortawesome/free-solid-svg-icons';
+import { faCircle, faRightFromBracket, faArrowRightToBracket } from '@fortawesome/free-solid-svg-icons';
 import SettingsPage from './SettingsPage.svelte';
 import Fa from 'svelte-fa/src/fa.svelte';
 import KeyIcon from '../images/KeyIcon.svelte';
 import EmptyScreen from '../ui/EmptyScreen.svelte';
+import DropdownMenu from '../ui/DropdownMenu.svelte';
+import DropdownMenuItem from '../ui/DropDownMenuItem.svelte';
 </script>
 
 <SettingsPage title="Authentication">
@@ -61,6 +63,18 @@ import EmptyScreen from '../ui/EmptyScreen.svelte';
             </div>
           </div>
           <!-- Authentication Provider Session label start -->
+          <div class="ml-4 flex items-center">
+            {#if provider.sessionRequests.length > 0}
+              <DropdownMenu>
+                {#each provider.sessionRequests as request}
+                  <DropdownMenuItem
+                    title="Sign in to use {request.extensionLabel}"
+                    onClick="{() => window.requestAuthenticationProviderSignIn(request.id)}"
+                    icon="{faArrowRightToBracket}" />
+                {/each}
+              </DropdownMenu>
+            {/if}
+          </div>
         </div>
       </div>
       <!-- Registered Authentication Provider row end -->


### PR DESCRIPTION
### What does this PR do?

Adds context menu to provider items on Authentication settings page. Each menu Item represents non silent session request sent by clients.

### Screenshot/screencast of this PR

For single request

![image](https://github.com/containers/podman-desktop/assets/620330/b0d7c2ee-97fc-441f-acad-3ed3db0e9a2a)

For 2 requests

![image](https://github.com/containers/podman-desktop/assets/620330/4593e14a-dd48-4227-b9a6-11d71d505c4b)

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?

Fixes #2140.

### How to test this PR?

<!-- Please explain steps to reproduce -->
