### PR TITLE
fix: do not rely on socket path for unicity

### DIFF
--- a/extensions/podman/src/extension.spec.ts
+++ b/extensions/podman/src/extension.spec.ts
@@ -46,7 +46,7 @@ test('verify create command called with correct values', async () => {
   spyExecPromise.mockImplementation(() => {
     return Promise.resolve('');
   });
-  extension.createMachine(
+  await extension.createMachine(
     {
       'podman.factory.machine.cpus': '2',
       'podman.factory.machine.image-path': 'path',

--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -94,6 +94,7 @@ async function updateMachines(provider: extensionApi.Provider): Promise<void> {
     if (previousStatus !== status) {
       // notify status change
       listeners.forEach(listener => listener(machine.Name, status));
+      podmanMachinesStatuses.set(machine.Name, status);
     }
     podmanMachinesInfo.set(machine.Name, {
       name: machine.Name,
@@ -394,7 +395,9 @@ async function registerProviderFor(provider: extensionApi.Provider, machineInfo:
     },
   };
 
-  monitorPodmanSocket(socketPath, machineInfo.name);
+  // Since Podman 4.5, machines are using the same path for all sockets of machines
+  // so a machine is not distinguishable from another one.
+  // monitorPodmanSocket(socketPath, machineInfo.name);
   containerProviderConnections.set(machineInfo.name, containerProviderConnection);
 
   const disposable = provider.registerContainerProviderConnection(containerProviderConnection);

--- a/packages/main/src/plugin/configuration-impl.ts
+++ b/packages/main/src/plugin/configuration-impl.ts
@@ -124,7 +124,7 @@ export class ConfigurationImpl implements containerDesktopAPI.Configuration {
 
   getConfigurationKey(): string {
     if (this.isContainerProviderConnection(this.scope)) {
-      return `container-connection:${this.scope.endpoint.socketPath}`;
+      return `container-connection:${this.scope.name}.${this.scope.endpoint.socketPath}`;
     } else if (this.isKubernetesProviderConnection(this.scope)) {
       return `kubernetes-connection:${this.scope.endpoint.apiURL}`;
     } else {

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -565,7 +565,8 @@ export class ContainerProviderRegistry {
     // grab all connections
     const matchingContainerProvider = Array.from(this.internalProviders.values()).find(
       containerProvider =>
-        containerProvider.connection.endpoint.socketPath === providerContainerConnectionInfo.endpoint.socketPath,
+        containerProvider.connection.endpoint.socketPath === providerContainerConnectionInfo.endpoint.socketPath &&
+        containerProvider.connection.name === providerContainerConnectionInfo.name,
     );
     if (!matchingContainerProvider || !matchingContainerProvider.api) {
       throw new Error('No provider with a running engine');
@@ -690,7 +691,9 @@ export class ContainerProviderRegistry {
     this.telemetryService.track('createPod');
     // grab all connections
     const matchingContainerProvider = Array.from(this.internalProviders.values()).find(
-      containerProvider => containerProvider.connection.endpoint.socketPath === selectedProvider.endpoint.socketPath,
+      containerProvider =>
+        containerProvider.connection.endpoint.socketPath === selectedProvider.endpoint.socketPath &&
+        containerProvider.connection.name === selectedProvider.name,
     );
     if (!matchingContainerProvider || !matchingContainerProvider.libpodApi) {
       throw new Error('No provider with a running engine');
@@ -1000,7 +1003,9 @@ export class ContainerProviderRegistry {
     this.telemetryService.track('playKube');
     // grab all connections
     const matchingContainerProvider = Array.from(this.internalProviders.values()).find(
-      containerProvider => containerProvider.connection.endpoint.socketPath === selectedProvider.endpoint.socketPath,
+      containerProvider =>
+        containerProvider.connection.endpoint.socketPath === selectedProvider.endpoint.socketPath &&
+        containerProvider.name === selectedProvider.name,
     );
     if (!matchingContainerProvider || !matchingContainerProvider.libpodApi) {
       throw new Error('No provider with a running engine');
@@ -1020,6 +1025,7 @@ export class ContainerProviderRegistry {
     const matchingContainerProvider = Array.from(this.internalProviders.values()).find(
       containerProvider =>
         containerProvider.connection.endpoint.socketPath === selectedProvider.endpoint.socketPath &&
+        containerProvider.connection.name === selectedProvider.name &&
         selectedProvider.status === 'started',
     );
     if (!matchingContainerProvider || !matchingContainerProvider.api) {

--- a/packages/main/src/plugin/provider-impl.ts
+++ b/packages/main/src/plugin/provider-impl.ts
@@ -91,7 +91,8 @@ export class ProviderImpl implements Provider, IDisposable {
     setInterval(async () => {
       this.containerProviderConnections.forEach(providerConnection => {
         const status = providerConnection.status();
-        const key = providerConnection.endpoint.socketPath;
+        // key can't be socket path as for some providers it can be the same
+        const key = `${providerConnection.name}.${providerConnection.endpoint.socketPath}`;
         if (status !== this.containerProviderConnectionsStatuses.get(key)) {
           this.providerRegistry.onDidChangeContainerProviderConnectionStatus(this, providerConnection);
           this.containerProviderConnectionsStatuses.set(key, status);

--- a/packages/main/src/tray-menu.ts
+++ b/packages/main/src/tray-menu.ts
@@ -158,7 +158,7 @@ export class TrayMenu {
       childItems: [],
     };
     this.menuContainerProviderConnectionItems.set(
-      providerContainerConnectionInfoMenuItem.endpoint.socketPath,
+      `${providerContainerConnectionInfoMenuItem.name}.${providerContainerConnectionInfoMenuItem.endpoint.socketPath}`,
       providerContainerConnectionInfoMenuItem,
     );
     this.updateMenu();
@@ -169,7 +169,7 @@ export class TrayMenu {
     providerContainerConnectionInfo: ProviderContainerConnectionInfo,
   ): void {
     const menuProviderItem = this.menuContainerProviderConnectionItems.get(
-      providerContainerConnectionInfo.endpoint.socketPath,
+      `${providerContainerConnectionInfo.name}.${providerContainerConnectionInfo.endpoint.socketPath}`,
     );
     if (menuProviderItem) {
       menuProviderItem.status = providerContainerConnectionInfo.status;
@@ -181,7 +181,9 @@ export class TrayMenu {
     _provider: ProviderInfo,
     providerContainerConnectionInfo: ProviderContainerConnectionInfo,
   ): void {
-    this.menuContainerProviderConnectionItems.delete(providerContainerConnectionInfo.endpoint.socketPath);
+    this.menuContainerProviderConnectionItems.delete(
+      `${providerContainerConnectionInfo.name}.${providerContainerConnectionInfo.endpoint.socketPath}`,
+    );
     this.updateMenu();
   }
 


### PR DESCRIPTION

### What does this PR do?
before podman 4.5, socket path were different for all machines with podman 4.5, socket path is the same for all the machines

so some functions were using the path as a key
then it leads to lot of errors with invalid data, failure to get the right machine, duplicated things, config from other machines, etc.


### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/2338


### How to test this PR?

Create like 5 podman machines with different cpu/memory/disk/etc.

before PR:
Use multiple machines and go to the settings page.
cpu, memory being displayed are the same for machines even if they have different values
All machines might be RUNNING or all Stopped
Tray menu only display one machine

etc.

After
- check cpu/memory/state is correct for all the machines
- check tray menu is ok
- check you're to correctly pull an image

Change-Id: I76e23b1cc2656e6fd61d60a265d0b93698f7196d
