### PR TITLE
feat: Add API to provide icons for authentication providers

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -1623,6 +1623,8 @@ declare module '@podman-desktop/api' {
      * If not specified, will default to false.
      */
     readonly supportsMultipleAccounts?: boolean;
+
+    readonly images?: ProviderImages;
   }
 
   /**

--- a/packages/main/src/plugin/authentication.ts
+++ b/packages/main/src/plugin/authentication.ts
@@ -25,6 +25,7 @@ import type {
   AuthenticationSessionAccountInformation,
   AuthenticationProviderOptions,
   Disposable,
+  ProviderImages,
 } from '@podman-desktop/api';
 import { Emitter } from './events/emitter';
 import type { ApiSenderType } from './api';
@@ -45,6 +46,7 @@ export interface AuthenticationProviderInfo {
   displayName: string;
   accounts: AuthenticationSessionAccountInformation[];
   sessionRequests?: SessionRequestInfo[];
+  images?: ProviderImages;
 }
 
 export interface ExtensionInfo {
@@ -91,6 +93,7 @@ export class AuthenticationImpl {
           displayName: meta.label,
           accounts: sessions.map(session => ({ id: session.id, label: session.account.label })),
           sessionRequests,
+          images: meta.options.images,
         };
       });
     });

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -632,6 +632,13 @@ export class ExtensionLoader {
         return authenticationProviderRegistry.getSession(extensionInfo, providerId, scopes, options);
       },
       registerAuthenticationProvider: (id, label, provider, options) => {
+        // update path of images using the extension path
+        if (options?.images) {
+          const images = options.images;
+          instance.updateImage.bind(instance);
+          images.icon = instance.updateImage(images.icon, extensionPath);
+          images.logo = instance.updateImage(images.logo, extensionPath);
+        }
         return authenticationProviderRegistry.registerAuthenticationProvider(id, label, provider, options);
       },
       onDidChangeSessions: (listener, thisArg, disposables) => {


### PR DESCRIPTION
### What does this PR do?

It adds API to configure authentication provider icons to show them in authentication settings UI

### Screenshot/screencast of this PR

When an Icon is configured for provider

![image](https://github.com/containers/podman-desktop/assets/620330/f832984c-6d98-442d-bb90-4dc4eb2ff443)

When an icon is not configured the default icon is shown

![image](https://github.com/containers/podman-desktop/assets/620330/5b4b5333-06b8-4f15-b223-99dd06b5ad55)

### What issues does this PR fix or reference?

N/A

### How to test this PR?

N/A