### PR TITLE
feat: Add UI to show auth provider provided or default icon in authentication settings

### DIFF
--- a/packages/renderer/src/lib/images/KeyIcon.svelte
+++ b/packages/renderer/src/lib/images/KeyIcon.svelte
@@ -3,6 +3,8 @@ export let size: string = '40';
 </script>
 
 <svg
+  {...$$restProps}
+  role="img"
   xmlns:xlink="http://www.w3.org/1999/xlink"
   width="{size}"
   xmlns="http://www.w3.org/2000/svg"

--- a/packages/renderer/src/lib/preferences/PreferencesAuthenticationProvidersRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesAuthenticationProvidersRendering.spec.ts
@@ -134,3 +134,53 @@ test('Expect Sign in menu item to be visible when there are session requests', a
   fireEvent.click(menuItems[0]);
   expect(requestSignInMock).toBeCalled();
 });
+
+test('Expects default icon to be used when provider has no images option', async () => {
+  authenticationProviders.set(testProividersInfoWithSessionRequests);
+  const { container } = render(PreferencesAuthenticationProvidersRendering, {});
+  screen.getByRole('img', {
+    name: `Default Key Icon for ${testProividersInfoWithSessionRequests[0].displayName} provider`,
+    hidden: true,
+  });
+  const key = container.querySelector('[aria-label=\'Key Icon\']');
+  console.log(key);
+});
+
+test('Expects images.icon option to be used when no themes are present', () => {
+  const providerWithImageIcon = [
+    {
+      id: 'test',
+      displayName: 'Test Authentication Provider',
+      accounts: [],
+      images: {
+        icon: './icon.png',
+      },
+      sessionRequests: [],
+    },
+  ];
+  authenticationProviders.set(providerWithImageIcon);
+  render(PreferencesAuthenticationProvidersRendering, {});
+  screen.getByRole('img', { name: `Icon for ${testProividersInfoWithSessionRequests[0].displayName} provider` });
+});
+
+test('Expects images.icon.dark option to be used when themes are present', () => {
+  const providerWithImageIcon = [
+    {
+      id: 'test',
+      displayName: 'Test Authentication Provider',
+      accounts: [],
+      images: {
+        icon: {
+          dark: './icon.png',
+          light: './icon.png',
+        },
+      },
+      sessionRequests: [],
+    },
+  ];
+  authenticationProviders.set(providerWithImageIcon);
+  render(PreferencesAuthenticationProvidersRendering, {});
+  screen.getByRole('img', {
+    name: `Dark theme icon for ${testProividersInfoWithSessionRequests[0].displayName} provider`,
+  });
+});

--- a/packages/renderer/src/lib/preferences/PreferencesAuthenticationProvidersRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesAuthenticationProvidersRendering.spec.ts
@@ -139,7 +139,7 @@ test('Expects default icon to be used when provider has no images option', async
   authenticationProviders.set(testProividersInfoWithSessionRequests);
   render(PreferencesAuthenticationProvidersRendering, {});
   screen.getByRole('img', {
-    name: `Default Key Icon for ${testProividersInfoWithSessionRequests[0].displayName} provider`,
+    name: `Default icon for ${testProividersInfoWithSessionRequests[0].displayName} provider`,
   });
 });
 

--- a/packages/renderer/src/lib/preferences/PreferencesAuthenticationProvidersRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesAuthenticationProvidersRendering.spec.ts
@@ -178,6 +178,6 @@ test('Expects images.icon.dark option to be used when themes are present', () =>
   authenticationProviders.set(providerWithImageIcon);
   render(PreferencesAuthenticationProvidersRendering, {});
   screen.getByRole('img', {
-    name: `Dark theme icon for ${testProividersInfoWithSessionRequests[0].displayName} provider`,
+    name: `Dark color theme icon for ${testProividersInfoWithSessionRequests[0].displayName} provider`,
   });
 });

--- a/packages/renderer/src/lib/preferences/PreferencesAuthenticationProvidersRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesAuthenticationProvidersRendering.spec.ts
@@ -140,10 +140,7 @@ test('Expects default icon to be used when provider has no images option', async
   const { container } = render(PreferencesAuthenticationProvidersRendering, {});
   screen.getByRole('img', {
     name: `Default Key Icon for ${testProividersInfoWithSessionRequests[0].displayName} provider`,
-    hidden: true,
   });
-  const key = container.querySelector("[aria-label='Key Icon']");
-  console.log(key);
 });
 
 test('Expects images.icon option to be used when no themes are present', () => {

--- a/packages/renderer/src/lib/preferences/PreferencesAuthenticationProvidersRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesAuthenticationProvidersRendering.spec.ts
@@ -142,7 +142,7 @@ test('Expects default icon to be used when provider has no images option', async
     name: `Default Key Icon for ${testProividersInfoWithSessionRequests[0].displayName} provider`,
     hidden: true,
   });
-  const key = container.querySelector('[aria-label=\'Key Icon\']');
+  const key = container.querySelector("[aria-label='Key Icon']");
   console.log(key);
 });
 

--- a/packages/renderer/src/lib/preferences/PreferencesAuthenticationProvidersRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesAuthenticationProvidersRendering.spec.ts
@@ -137,7 +137,7 @@ test('Expect Sign in menu item to be visible when there are session requests', a
 
 test('Expects default icon to be used when provider has no images option', async () => {
   authenticationProviders.set(testProividersInfoWithSessionRequests);
-  const { container } = render(PreferencesAuthenticationProvidersRendering, {});
+  render(PreferencesAuthenticationProvidersRendering, {});
   screen.getByRole('img', {
     name: `Default Key Icon for ${testProividersInfoWithSessionRequests[0].displayName} provider`,
   });

--- a/packages/renderer/src/lib/preferences/PreferencesAuthenticationProvidersRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesAuthenticationProvidersRendering.svelte
@@ -34,7 +34,7 @@ import DropdownMenuItem from '../ui/DropDownMenuItem.svelte';
                 {:else}
                   <img
                     src="{provider.images.icon.dark}"
-                    alt="Dark theme icon for {provider.displayName} provider"
+                    alt="Dark color theme icon for {provider.displayName} provider"
                     class="max-w-[40px]" />
                 {/if}
               {:else}
@@ -42,7 +42,7 @@ import DropdownMenuItem from '../ui/DropDownMenuItem.svelte';
                   this="{KeyIcon}"
                   size="40"
                   alt="{provider.displayName}"
-                  aria-label="Default Key Icon for {provider.displayName} provider" />
+                  aria-label="Default icon for {provider.displayName} provider" />
               {/if}
             </div>
           </div>

--- a/packages/renderer/src/lib/preferences/PreferencesAuthenticationProvidersRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesAuthenticationProvidersRendering.svelte
@@ -25,13 +25,24 @@ import DropdownMenuItem from '../ui/DropDownMenuItem.svelte';
             <div class="flex">
               {#if provider?.images?.icon}
                 {#if typeof provider.images.icon === 'string'}
-                  <img src="{provider.images.icon}" alt="{provider.displayName}" class="max-w-[40px] h-full" />
+                  <img
+                    src="{provider.images.icon}"
+                    alt="{provider.displayName}"
+                    aria-label="Icon for {provider.displayName} provider"
+                    class="max-w-[40px] h-full" />
                   <!-- TODO check theme used for image, now use dark by default -->
                 {:else}
-                  <img src="{provider.images.icon.dark}" alt="{provider.displayName}" class="max-w-[40px]" />
+                  <img
+                    src="{provider.images.icon.dark}"
+                    alt="Dark theme icon for {provider.displayName} provider"
+                    class="max-w-[40px]" />
                 {/if}
               {:else}
-                <svelte:component this="{KeyIcon}" size="40" />
+                <svelte:component
+                  this="{KeyIcon}"
+                  size="40"
+                  alt="{provider.displayName}"
+                  aria-label="Default Key Icon for {provider.displayName} provider" />
               {/if}
             </div>
           </div>

--- a/packages/renderer/src/lib/preferences/PreferencesAuthenticationProvidersRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesAuthenticationProvidersRendering.svelte
@@ -21,6 +21,20 @@ import DropdownMenuItem from '../ui/DropDownMenuItem.svelte';
       <!-- Registered Authentication Provider row start -->
       <div class="flex flex-col w-full">
         <div class="flex rounded-md border-0" style="background-color: rgb(39 39 42 / var(--tw-bg-opacity))">
+          <div class="ml-4 flex items-center">
+            <div class="flex">
+              {#if provider?.images?.icon}
+                {#if typeof provider.images.icon === 'string'}
+                  <img src="{provider.images.icon}" alt="{provider.displayName}" class="max-w-[40px] h-full" />
+                  <!-- TODO check theme used for image, now use dark by default -->
+                {:else}
+                  <img src="{provider.images.icon.dark}" alt="{provider.displayName}" class="max-w-[40px]" />
+                {/if}
+              {:else}
+                <svelte:component this="{KeyIcon}" size="40" />
+              {/if}
+            </div>
+          </div>
           <!-- Authentication Provider name and status item start -->
           <div class="px-5 py-2 text-sm w-1/3 m-auto">
             <div class="flex flex-col">


### PR DESCRIPTION
### What does this PR do?

Add UI components to show auth provider provided icon or default one on authentication page

### Screenshot/screencast of this PR

See PR #2446.

### What issues does this PR fix or reference?

N/A

### How to test this PR?

N/A