### PR TITLE
fix: ensure PATH is correctly set when calling runCliCommand for kind extension

### DIFF
--- a/extensions/kind/src/image-handler.spec.ts
+++ b/extensions/kind/src/image-handler.spec.ts
@@ -21,6 +21,7 @@ import type { Mock } from 'vitest';
 import { ImageHandler } from './image-handler';
 import * as extensionApi from '@podman-desktop/api';
 import * as fs from 'node:fs';
+import { getKindPath, runCliCommand } from './util';
 
 let imageHandler: ImageHandler;
 vi.mock('@podman-desktop/api', async () => {
@@ -38,6 +39,7 @@ vi.mock('@podman-desktop/api', async () => {
 vi.mock('./util', async () => {
   return {
     runCliCommand: vi.fn().mockReturnValue({ exitCode: 0 }),
+    getKindPath: vi.fn(),
   };
 });
 
@@ -101,4 +103,27 @@ test('expect image name and tag to be given', async () => {
     undefined,
   );
   expect(extensionApi.containerEngine.saveImage).toBeCalledWith('dummy', 'myimage:1.0', expect.anything());
+});
+
+test('expect cli is called with right PATH', async () => {
+  (extensionApi.containerEngine.saveImage as Mock).mockImplementation(
+    (engineId: string, id: string, filename: string) => fs.promises.open(filename, 'w'),
+  );
+
+  (getKindPath as Mock).mockReturnValue('my-custom-path');
+
+  await imageHandler.moveImage(
+    { engineId: 'dummy', name: 'myimage' },
+    [{ name: 'c1', engineType: 'podman', status: 'started', apiPort: 9443 }],
+    undefined,
+  );
+  expect(getKindPath).toBeCalled();
+
+  expect(runCliCommand).toBeCalledTimes(1);
+  // grab the env parameter of the first call to runCliCommand
+  const props = (runCliCommand as Mock).mock.calls[0][2];
+  expect(props).to.have.property('env');
+  const env = props.env;
+  expect(env).to.have.property('PATH');
+  expect(env.PATH).toBe('my-custom-path');
 });

--- a/extensions/kind/src/image-handler.ts
+++ b/extensions/kind/src/image-handler.ts
@@ -18,7 +18,7 @@
 import type { KindCluster } from './extension';
 import * as extensionApi from '@podman-desktop/api';
 import { tmpName } from 'tmp-promise';
-import { runCliCommand } from './util';
+import { getKindPath, runCliCommand } from './util';
 import * as fs from 'node:fs';
 
 type ImageInfo = { engineId: string; name?: string; tag?: string };
@@ -55,7 +55,7 @@ export class ImageHandler {
     if (selectedCluster) {
       let name = image.name;
       let filename: string;
-      const env = process.env;
+      const env = Object.assign({}, process.env);
 
       // Create a name:tag string for the image
       if (image.tag) {
@@ -69,6 +69,7 @@ export class ImageHandler {
         env['KIND_EXPERIMENTAL_PROVIDER'] = 'docker';
       }
 
+      env.PATH = getKindPath();
       try {
         // Create a temporary file to store the image
         filename = await tmpName();


### PR DESCRIPTION
### What does this PR do?
Sets the PATH correctly before calling the command

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/2447


### How to test this PR?

Look at test case of https://github.com/containers/podman-desktop/issues/2447


Change-Id: Ibea3021ff7d793dd24cf6a7a613f068af410c05a
