### PR TITLE
fix: clear previous error when installing extension

### DIFF
--- a/packages/renderer/src/lib/docker-extension/PreferencesPageDockerExtensions.svelte
+++ b/packages/renderer/src/lib/docker-extension/PreferencesPageDockerExtensions.svelte
@@ -14,6 +14,7 @@ let logs: string[] = [];
 let logElement;
 
 async function installDDExtensionFromImage() {
+  errorInstall = '';
   logs.length = 0;
   installInProgress = true;
 


### PR DESCRIPTION
### What does this PR do?

Title says it all, clear the previous error. Matches code already in the other extension path.

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

Fixes #2463.

### How to test this PR?

Try to install a Docker Desktop extension with an incorrect name, then try a valid one.