### PR TITLE
Removing double titlebar on Linux

### DIFF
--- a/packages/main/src/mainWindow.ts
+++ b/packages/main/src/mainWindow.ts
@@ -53,7 +53,12 @@ async function createWindow() {
   };
 
   // frameless window
-  browserWindowConstructorOptions.titleBarStyle = 'hidden';
+  if (isLinux()) {
+    browserWindowConstructorOptions.frame = false;
+  } else {
+    browserWindowConstructorOptions.titleBarStyle = 'hidden';
+  }
+
   if (isMac()) {
     // change position of traffic light buttons
     browserWindowConstructorOptions.trafficLightPosition = { x: 20, y: 13 };


### PR DESCRIPTION
Electron doesn't support titleBarStyle on Linux, so to remove the redundant titlebar and use the custom titlebar, we must use a frameless window.

### What does this PR do?

Removes the extra (less nice) titlebar on Linux.

### Screenshot/screencast of this PR

#### Before
![Screenshot from 2023-05-11 14-11-45](https://github.com/containers/podman-desktop/assets/799683/94a61ba2-e69c-43ac-ad1d-67f80263ad4f)

#### After
![Screenshot from 2023-05-11 15-52-38](https://github.com/containers/podman-desktop/assets/799683/707b2eda-4a3d-4fda-9260-b349f9ce88e8)

### What issues does this PR fix or reference?

https://github.com/containers/podman-desktop/issues/1805

### How to test this PR?

Run on Linux and make sure there is only one black titlebar as shown in after screenshot above.
Run on Windows and make sure there's one titlebar.
Run on MacOS and make sure there's a titlebar.
