### PR TITLE
chore: remove usage of await on non-promises

### DIFF
--- a/scripts/watch.cjs
+++ b/scripts/watch.cjs
@@ -177,15 +177,15 @@ const setupBuiltinExtensionApiWatcher = name => {
     });
 
     await viteDevServer.listen();
-    await setupBuiltinExtensionApiWatcher('compose');
-    await setupBuiltinExtensionApiWatcher('docker');
-    await setupBuiltinExtensionApiWatcher('kube-context');
-    await setupBuiltinExtensionApiWatcher('lima');
-    await setupBuiltinExtensionApiWatcher('podman');
-    await setupBuiltinExtensionApiWatcher('kind');
-    await setupBuiltinExtensionApiWatcher('registries');
+    setupBuiltinExtensionApiWatcher('compose');
+    setupBuiltinExtensionApiWatcher('docker');
+    setupBuiltinExtensionApiWatcher('kube-context');
+    setupBuiltinExtensionApiWatcher('lima');
+    setupBuiltinExtensionApiWatcher('podman');
+    setupBuiltinExtensionApiWatcher('kind');
+    setupBuiltinExtensionApiWatcher('registries');
     for (const extension of extensions) {
-      await setupExtensionApiWatcher(extension);
+      setupExtensionApiWatcher(extension);
     }
     await setupPreloadPackageWatcher(viteDevServer);
     await setupPreloadDockerExtensionPackageWatcher(viteDevServer);


### PR DESCRIPTION
Change-Id: Ib1a71cafd4c5a55726c0c5d6402f42248013f6be

### What does this PR do?
We should not use await if not a promise

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

sonarcloud

### How to test this PR?

`yarn watch` should work as before