### PR TITLE
chore: use app.getAppPath instead of __dirname for dev mode

### DIFF
--- a/packages/main/src/tray-animate-icon.spec.ts
+++ b/packages/main/src/tray-animate-icon.spec.ts
@@ -1,0 +1,79 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { beforeEach, expect, test, vi } from 'vitest';
+import { AnimatedTray } from './tray-animate-icon';
+import * as path from 'path';
+import { app } from 'electron';
+
+// to call protected methods
+class TestAnimatedTray extends AnimatedTray {
+  getAssetsFolder(): string {
+    return super.getAssetsFolder();
+  }
+
+  isProd(): boolean {
+    return super.isProd();
+  }
+}
+
+let testAnimatedTray: TestAnimatedTray;
+vi.mock('electron', async () => {
+  return {
+    app: {
+      getAppPath: () => 'a-custom-appPath',
+    },
+    nativeTheme: {
+      on: vi.fn(),
+    },
+  };
+});
+
+beforeEach(() => {
+  testAnimatedTray = new TestAnimatedTray();
+  vi.clearAllMocks();
+});
+
+test('valid path on Production', () => {
+  // ensure we are on production mode
+  const onSpy = vi.spyOn(testAnimatedTray, 'isProd').mockReturnValue(true);
+
+  const processResourcesPathValue = path.resolve(__dirname, 'process-resourcesPath-value');
+
+  // setup the process resourcesPath property using defineProperty
+  Object.defineProperty(process, 'resourcesPath', {
+    value: processResourcesPathValue,
+    writable: true,
+  });
+  const assetFolder = testAnimatedTray.getAssetsFolder();
+  expect(assetFolder).toBe(path.resolve(processResourcesPathValue, AnimatedTray.MAIN_ASSETS_FOLDER));
+  expect(onSpy).toHaveBeenCalled();
+});
+
+test('valid path on Development', () => {
+  // ensure we are not in prod mode
+  const onSpy = vi.spyOn(testAnimatedTray, 'isProd').mockReturnValue(false);
+  const appPathValue = path.resolve(__dirname, 'appPath-value');
+
+  const spyElectronGetAppPath = vi.spyOn(app, 'getAppPath').mockReturnValue(appPathValue);
+
+  const assetFolder = testAnimatedTray.getAssetsFolder();
+  expect(assetFolder).toBe(path.resolve(appPathValue, AnimatedTray.MAIN_ASSETS_FOLDER));
+  expect(onSpy).toHaveBeenCalled();
+  expect(spyElectronGetAppPath).toHaveBeenCalled();
+});

--- a/packages/main/src/tray-animate-icon.ts
+++ b/packages/main/src/tray-animate-icon.ts
@@ -17,9 +17,9 @@
  ***********************************************************************/
 
 import type { Tray } from 'electron';
+import { app, nativeTheme } from 'electron';
 import * as path from 'path';
 import { isLinux, isMac } from './util';
-import { nativeTheme } from 'electron';
 export type TrayIconStatus = 'initialized' | 'updating' | 'error' | 'ready';
 
 export class AnimatedTray {
@@ -28,6 +28,7 @@ export class AnimatedTray {
   private animatedInterval: NodeJS.Timeout | undefined = undefined;
   private tray: Tray | undefined = undefined;
   private color = 'default'; // default, light, dark
+  static readonly MAIN_ASSETS_FOLDER = 'packages/main/src/assets';
 
   constructor() {
     this.status = 'initialized';
@@ -39,14 +40,18 @@ export class AnimatedTray {
     });
   }
 
+  protected isProd(): boolean {
+    return import.meta.env.PROD;
+  }
+
   protected getAssetsFolder(): string {
     // choose right folder for resources
     // see extraResources in electron-builder config file
     let assetsFolder;
-    if (import.meta.env.PROD) {
-      assetsFolder = path.resolve(process.resourcesPath, 'packages/main/src/assets');
+    if (this.isProd()) {
+      assetsFolder = path.resolve(process.resourcesPath, AnimatedTray.MAIN_ASSETS_FOLDER);
     } else {
-      assetsFolder = path.resolve(__dirname, '../src/assets');
+      assetsFolder = path.resolve(app.getAppPath(), AnimatedTray.MAIN_ASSETS_FOLDER);
     }
 
     return assetsFolder;


### PR DESCRIPTION
Change-Id: I3c79684885ea9035f4d8f0e226e6d9736b186797

### What does this PR do?
replace `__dirname` by electron `app.getAppPath()` to grab development resources


### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?

related to #1780

### How to test this PR?

Development mode should work (you see the tray icon)
(also prod mode should work but we didn't change here)