### PR TITLE
chore: use aria label and heading to retrieve title of pages

### DIFF
--- a/packages/renderer/src/lib/ui/NavPage.spec.ts
+++ b/packages/renderer/src/lib/ui/NavPage.spec.ts
@@ -1,0 +1,33 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom';
+import { test, expect } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import NavPage from './NavPage.svelte';
+
+test('Expect title is defined', async () => {
+  const title = 'My Dummy Title';
+  render(NavPage, {
+    title,
+  });
+  const headingElement = screen.getByRole('heading', { level: 1, name: title });
+  expect(headingElement).toBeInTheDocument();
+  // check the text
+  expect(headingElement).toHaveTextContent(title);
+});

--- a/packages/renderer/src/lib/ui/NavPage.svelte
+++ b/packages/renderer/src/lib/ui/NavPage.svelte
@@ -8,7 +8,7 @@ export let searchEnabled: boolean = true;
   <div class="min-w-full pt-4" class:pb-4="{!searchEnabled}">
     <div class="flex">
       <div class="px-5">
-        <p class="text-xl first-letter:uppercase">{title}</p>
+        <h1 aria-label="{title}" class="text-xl first-letter:uppercase">{title}</h1>
       </div>
       <div class="flex flex-1 justify-end">
         <div class="px-5">


### PR DESCRIPTION

### What does this PR do?
it's helpful for UI tests else we don't have headings

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?

related to https://github.com/containers/podman-desktop/issues/1780

### How to test this PR?

Rendering should be as usual for all titles of the main screen


Change-Id: If078c9e940d65ac979acc78a4be20a9951aa1f1a
