### PR TITLE
chore: Add deprecation notice of APP_ICON in extension API

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -573,6 +573,10 @@ declare module '@podman-desktop/api' {
   export enum ProgressLocation {
     /**
      * Show progress bar under app icon in launcher bar.
+     *
+     * @deprecated This value is deprecated as it does not render equally on various supported platforms. It will be
+     * removed in future versions of Podman Desktop. We strongly encourage to use TASK_WIDGET instead.
+     * @see TASK_WIDGET
      */
     APP_ICON = 1,
 


### PR DESCRIPTION
### What does this PR do?

Add a deprecation notice about APP_ICON in the extension API documentation

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

N/A

### How to test this PR?

N/A
