### PR TITLE
fix: make tooltip not clickable

### DIFF
--- a/packages/renderer/src/lib/ui/Tooltip.svelte
+++ b/packages/renderer/src/lib/ui/Tooltip.svelte
@@ -46,7 +46,7 @@ export let left = false;
     <slot />
   </span>
   <div
-    class="whitespace-nowrap absolute tooltip opacity-0 inline-block transition-opacity duration-150 ease-in-out"
+    class="whitespace-nowrap absolute tooltip opacity-0 inline-block transition-opacity duration-150 ease-in-out pointer-events-none"
     class:left="{left}"
     class:right="{right}"
     class:bottom="{bottom}"


### PR DESCRIPTION
### What does this PR do?
make tooltip not clickable so it is not involved in clicks

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/pull/2286#issuecomment-1548582949


### How to test this PR?

Try to click on a dropdown in container list as reported in the issue link