### PR TITLE
fix: remove extension filesystem watcher when it is deactivated

### DIFF
--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -868,6 +868,9 @@ export class ExtensionLoader {
       }
     }
 
+    const watcher = this.watcherExtensions.get(extensionId);
+    watcher?.dispose();
+
     // dispose subscriptions
     for (const subscription of extension.extensionContext.subscriptions) {
       await subscription.dispose();


### PR DESCRIPTION
### What does this PR do?

This is required to avoid providers duplication in dev mode when reloadin extensio collides with extension activation when installed again during the same session.

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

https://github.com/redhat-developer/podman-desktop-sandbox-ext/issues/55

### How to test this PR?

1. Install Sandbox Extension
2. Remove it
3. Install again
4. Open resources page and there should be only one sandbox provider
