### PR TITLE
fix: Pull image form resets to initial state when Enter key

### DIFF
--- a/packages/renderer/src/lib/image/PullImage.svelte
+++ b/packages/renderer/src/lib/image/PullImage.svelte
@@ -247,7 +247,7 @@ function validateImageName(event): void {
               <button
                 class="pf-c-button pf-m-primary"
                 disabled="{!imageToPull || imageToPull.trim() === '' || pullInProgress}"
-                type="button"
+                type="submit"
                 on:click="{() => pullImage()}">
                 {#if pullInProgress === true}
                   <i class="pf-c-button__progress">


### PR DESCRIPTION
Fixes #2494

### What does this PR do?

Allow image pull to be launched if Enter key is typed

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

Fixes #2494

### How to test this PR?

Go to the pull image from enter the image name and press ENTER