### PR TITLE
fix: Welcome should go behind titlebar to hide nav

### DIFF
--- a/packages/renderer/src/lib/ui/TitleBar.svelte
+++ b/packages/renderer/src/lib/ui/TitleBar.svelte
@@ -16,7 +16,7 @@ onMount(async () => {
   id="navbar"
   class="text-gray-700 {platform === 'win32'
     ? 'bg-[#202020]'
-    : 'bg-charcoal-900'} body-font shadow-titlebar z-999 relative {platform === 'win32'
+    : 'bg-charcoal-900'} body-font shadow-titlebar z-[999] relative {platform === 'win32'
     ? 'min-h-[32px]'
     : 'min-h-[38px]'}"
   style="-webkit-app-region: drag;">

--- a/packages/renderer/src/lib/welcome/WelcomePage.svelte
+++ b/packages/renderer/src/lib/welcome/WelcomePage.svelte
@@ -40,10 +40,10 @@ function closeWelcome() {
 
 {#if showWelcome}
   <div
-    class="flex flex-col flex-auto fixed top-10 left-0 right-0 bottom-0 bg-zinc-700 bg-no-repeat z-50"
+    class="flex flex-col flex-auto fixed top-0 left-0 right-0 bottom-0 bg-zinc-700 bg-no-repeat z-50"
     style="background-image: url({bgImage}); background-position: 50% -175%; background-size: 100% 75%">
     <!-- Header -->
-    <div class="flex flex-row flex-none backdrop-blur p-6">
+    <div class="flex flex-row flex-none backdrop-blur p-6 mt-10">
       <div class="flex flex-auto text-lg font-bold">Get started with Podman Desktop</div>
     </div>
 


### PR DESCRIPTION
### What does this PR do?

Fixes an issue where a sliver of the nav can appear in the welcome screen. There are two things at play here:
- The welcome used to start partially underneath the OS titlebar, but with the new titlebar (which is smaller vertically) there is a gap. Instead of trying to match the new titlebar height this change makes the welcome use the entire window space, and then adds a top margin to position the welcome header back at the same place.
- The title bar z order wasn't doing anything b/c it's not a standard tailwind value, so adding [] puts it back on top of the welcome.

### Screenshot/screencast of this PR

<img width="347" alt="Screenshot 2023-05-16 at 10 34 40 AM" src="https://github.com/containers/podman-desktop/assets/19958075/671d762e-b446-45c1-84a6-c7b0f5f1f2e5">

### What issues does this PR fix or reference?

Fixes #2508.

### How to test this PR?

Delete or edit the configurations settings.json so that the welcome appears again.