### PR TITLE
fix: Unblock regular Mac download when airgap isn't available

### DIFF
--- a/website/src/pages/downloads/macOS.tsx
+++ b/website/src/pages/downloads/macOS.tsx
@@ -30,10 +30,13 @@ async function grabfilenameforMac(
   const universalMacAirgapDmgAssets = assets.filter(
     asset => (asset.name as string).endsWith('universal.dmg') && asset.name.includes('airgap'),
   );
+  // temporary fix to restore regular Mac downloads even if airgap is not available
+  let universalMacAirgapDmgAsset;
   if (universalMacAirgapDmgAssets.length !== 1) {
-    throw new Error('Unable to find Apple Disk Image for restricted environments');
+    console.log('Error: Unable to find Apple Disk Image for restricted environments');
+  } else {
+    universalMacAirgapDmgAsset = universalMacAirgapDmgAssets[0];
   }
-  const universalMacAirgapDmgAsset = universalMacAirgapDmgAssets[0];
 
   const universalMacDmgResults = assets.filter(
     asset =>
@@ -51,7 +54,7 @@ async function grabfilenameforMac(
     universal: unifiedMacLinj.browser_download_url,
     x64: intelLink.browser_download_url,
     arm64: armLink.browser_download_url,
-    airgapsetup: universalMacAirgapDmgAsset.browser_download_url,
+    airgapsetup: universalMacAirgapDmgAsset?.browser_download_url,
   };
   setDownloadData(data);
 }


### PR DESCRIPTION
### What does this PR do?

Temporary fix, will have to be reviewed later: missing airgap won't error out; regular Mac downloads will work but airgap will still be listed with missing link.

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

Broken Mac download; no issue open yet.

### How to test this PR?

```
yarn compile:current
yarn website:dev
```