### PR TITLE
fix: Clear message box detail

### DIFF
--- a/packages/renderer/src/lib/dialogs/MessageBox.svelte
+++ b/packages/renderer/src/lib/dialogs/MessageBox.svelte
@@ -26,7 +26,7 @@ const showMessageBoxCallback = async (options?: MessageBoxOptions) => {
   if (options.detail) {
     detail = options.detail;
   } else {
-    detail = null;
+    detail = undefined;
   }
 
   // use provided buttons, or a single 'OK' button if none are provided

--- a/packages/renderer/src/lib/dialogs/MessageBox.svelte
+++ b/packages/renderer/src/lib/dialogs/MessageBox.svelte
@@ -25,6 +25,8 @@ const showMessageBoxCallback = async (options?: MessageBoxOptions) => {
   message = options.message;
   if (options.detail) {
     detail = options.detail;
+  } else {
+    detail = null;
   }
 
   // use provided buttons, or a single 'OK' button if none are provided


### PR DESCRIPTION
### What does this PR do?

The message box detail wasn't being cleared, so if you open one dialog that had a detailed message (e.g. External website) and then open another that doesn't, you still see the original dialog's detailed message.

### Screenshot/screencast of this PR

N/A. You should see the same as issue #2541 but without the odd detailed message (url in this case).

### What issues does this PR fix or reference?

Fixes #2541.

### How to test this PR?

Open an external link, then open another dialog and confirm the url is not there.