### PR TITLE
fix: MessageBox should be on top of app navigation

### DIFF
--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -76,6 +76,7 @@ window.events?.receive('display-help', () => {
     <WelcomePage />
 
     <div class="overflow-x-hidden flex flex-1">
+      <MessageBox />
       <AppNavigation meta="{meta}" exitSettingsCallback="{() => router.goto(nonSettingsPage)}" />
       {#if meta.url.startsWith('/preferences')}
         <PreferencesNavigation meta="{meta}" />
@@ -88,7 +89,6 @@ window.events?.receive('display-help', () => {
         <TaskManager />
         <SendFeedback />
         <ToastHandler />
-        <MessageBox />
         <QuickPickInput />
         <Route path="/" breadcrumb="Dashboard Page">
           <DashboardPage />


### PR DESCRIPTION
### What does this PR do?

Moves the message box out so that it fades out and disables the full screen (except titlebar).

### Screenshot/screencast of this PR

Before:
<img width="329" alt="Screenshot 2023-05-18 at 1 10 59 PM" src="https://github.com/containers/podman-desktop/assets/19958075/93376da8-5fc2-4d7e-8ae2-82fba9d21d7e">

After:
<img width="329" alt="Screenshot 2023-05-18 at 1 11 41 PM" src="https://github.com/containers/podman-desktop/assets/19958075/980821b5-0f24-413b-be58-eb3d7bf16834">

### What issues does this PR fix or reference?

Issue #2548.

### How to test this PR?

Just open any message box.