### PR TITLE
fix: Don't scroll beyond last line

### DIFF
--- a/packages/renderer/src/lib/editor/MonacoEditor.svelte
+++ b/packages/renderer/src/lib/editor/MonacoEditor.svelte
@@ -48,6 +48,7 @@ onMount(async () => {
     readOnly: true,
     theme: 'podmanDesktopTheme',
     automaticLayout: true,
+    scrollBeyondLastLine: false,
   });
 
   return () => {


### PR DESCRIPTION
### What does this PR do?

See issue #2511. This changes a setting in Monaco so that scrolling doesn't extend a full page beyond the last line. To me, I don't see any need to scroll beyond the bottom of a file, and this improves the accuracy of the scrollbar.

### Screenshot/screencast of this PR

Before:
<img width="877" alt="Screenshot 2023-05-18 at 9 37 08 AM" src="https://github.com/containers/podman-desktop/assets/19958075/44b7fe93-f636-42f2-9f60-675a99ed33d2">

After:
<img width="877" alt="Screenshot 2023-05-18 at 9 37 59 AM" src="https://github.com/containers/podman-desktop/assets/19958075/201a8275-68ad-4df3-95c6-4fef030cb2ab">

### What issues does this PR fix or reference?

Fixes #2511.

### How to test this PR?

Open container/pod/etc details and go to YAML page, deploy to Kube, etc - basically scan as many places where we embed Monaco as an editor window as possible.