### PR TITLE
fix: update empty screen clipboard

### DIFF
--- a/packages/renderer/src/lib/ui/EmptyScreen.svelte
+++ b/packages/renderer/src/lib/ui/EmptyScreen.svelte
@@ -51,9 +51,13 @@ let copyTextDivElement: HTMLDivElement;
       <div class="pf-c-empty-state__body">{message}</div>
       {#if commandline.length > 0}
         <div class="flex flex-row bg-charcoal-900 w-full items-center justify-between rounded-sm p-3 mt-4">
-          <div class="font-mono text-gray-400" bind:this="{copyTextDivElement}" data-testid="copyTextDivElement">{commandline}</div>
+          <div class="font-mono text-gray-400" bind:this="{copyTextDivElement}" data-testid="copyTextDivElement">
+            {commandline}
+          </div>
           <button title="Copy To Clipboard" class="ml-5" on:click="{() => copyRunInstructionToClipboard()}"
-            ><Fa class="h-5 w-5 cursor-pointer text-xl text-purple-500 hover:text-purple-600" icon="{faPaste}" /></button>
+            ><Fa
+              class="h-5 w-5 cursor-pointer text-xl text-purple-500 hover:text-purple-600"
+              icon="{faPaste}" /></button>
         </div>
       {/if}
     </div>

--- a/packages/renderer/src/lib/ui/EmptyScreen.svelte
+++ b/packages/renderer/src/lib/ui/EmptyScreen.svelte
@@ -50,10 +50,10 @@ let copyTextDivElement: HTMLDivElement;
       <h1 class="pf-c-title pf-m-lg">{title}</h1>
       <div class="pf-c-empty-state__body">{message}</div>
       {#if commandline.length > 0}
-        <div class="flex flex-row bg-charcoal-900 w-full items-center p-2 mt-2">
-          <div bind:this="{copyTextDivElement}" data-testid="copyTextDivElement">{commandline}</div>
-          <button title="Copy To Clipboard" class="ml-5 mr-5" on:click="{() => copyRunInstructionToClipboard()}"
-            ><Fa class="h-5 w-5 cursor-pointer rounded-full text-3xl text-sky-800" icon="{faPaste}" /></button>
+        <div class="flex flex-row bg-charcoal-900 w-full items-center justify-between rounded-sm p-3 mt-4">
+          <div class="font-mono text-gray-400" bind:this="{copyTextDivElement}" data-testid="copyTextDivElement">{commandline}</div>
+          <button title="Copy To Clipboard" class="ml-5" on:click="{() => copyRunInstructionToClipboard()}"
+            ><Fa class="h-5 w-5 cursor-pointer text-xl text-purple-500 hover:text-purple-600" icon="{faPaste}" /></button>
         </div>
       {/if}
     </div>


### PR DESCRIPTION
### What does this PR do?

I noticed the copy command icon on the empty screen was in an odd color (sky) that we don't use anywhere else, then fixed a few other inconsistencies while I was at it:
- Changed clipboard icon from sky to purple and added a hover (matching button color and hover).
- Fixed padding and right-justified the icon.
- Changed command font to monospaced and color to gray-400 instead of white.

### Screenshot/screencast of this PR

Before:
<img width="379" alt="Screenshot 2023-05-18 at 2 05 12 PM" src="https://github.com/containers/podman-desktop/assets/19958075/25c1f2c6-5f16-44f5-b85a-bbf23bfed2aa">

After:
<img width="379" alt="Screenshot 2023-05-18 at 3 07 44 PM" src="https://github.com/containers/podman-desktop/assets/19958075/c924bfde-2c5f-4438-b7d9-cfc096ca7b87">

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Start an empty podman machine and look at all the empty pages.