### PR TITLE
chore: also remove the PowerShell prompt (`> `) when copying shell-session content.

### DIFF
--- a/website/src/theme/CodeBlock/CopyButton/index.js
+++ b/website/src/theme/CodeBlock/CopyButton/index.js
@@ -26,7 +26,7 @@ export default function CopyButtonWrapper(props) {
     updatedProps?.code?.length > 2 &&
     (updatedProps.code.substring(0, 2) === '$ ' ||
       updatedProps.code.substring(0, 2) === '# ' ||
-      updatedProps.code.substring(0, 2) === '# ')
+      updatedProps.code.substring(0, 2) === '> ')
   ) {
     updatedProps.code = updatedProps.code.substring(2);
   }

--- a/website/src/theme/CodeBlock/CopyButton/index.js
+++ b/website/src/theme/CodeBlock/CopyButton/index.js
@@ -24,7 +24,9 @@ export default function CopyButtonWrapper(props) {
   const updatedProps = { ...props };
   if (
     updatedProps?.code?.length > 2 &&
-    (updatedProps.code.substring(0, 2) === '$ ' || updatedProps.code.substring(0, 2) === '# ')
+    (updatedProps.code.substring(0, 2) === '$ ' ||
+      updatedProps.code.substring(0, 2) === '# ' ||
+      updatedProps.code.substring(0, 2) === '# ')
   ) {
     updatedProps.code = updatedProps.code.substring(2);
   }


### PR DESCRIPTION
### What does this PR do?

* Add `> ` to the ignored prefixes.

* `yarn format:fix`.

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

### How to test this PR?

<!-- Please explain steps to reproduce -->
