### PR TITLE
fix: Prompt user when proxy may require restarting resources

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesProxiesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesProxiesRendering.svelte
@@ -31,7 +31,7 @@ async function updateProxySettings() {
   let message = 'Proxy settings have been applied.';
   let type = 'info';
   if (runningProviders) {
-    message += ' You may need to restart running container engines for the changes to take effect.';
+    message += ' You might need to restart running container engines for the changes to take effect.';
     type = 'warning';
   }
 

--- a/packages/renderer/src/lib/preferences/PreferencesProxiesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesProxiesRendering.svelte
@@ -15,16 +15,9 @@ async function updateProxySettings() {
   await window.updateProxySettings(proxySettings);
 
   // loop over all providers and container connections to see if there are any running engines
-  let runningProviders = false;
   const providerInfos = await window.getProviderInfos();
-  providerInfos.forEach(async provider => {
-    let connections = provider.containerConnections;
-    connections.forEach(async connection => {
-      if (connection.status !== 'stopped') {
-        runningProviders = true;
-      }
-    });
-  });
+  const runningProviders =
+    providerInfos.filter(p => p.containerConnections.filter(c => c.status !== 'stopped').length > 0).length > 0;
 
   // show a simple message to confirm that the settings are applied,
   // or a longer warning if the user may need to take action
@@ -39,7 +32,7 @@ async function updateProxySettings() {
     title: 'Proxy Settings',
     type: type,
     message: message,
-    buttons: ['Ok'],
+    buttons: ['OK'],
   });
 }
 

--- a/packages/renderer/src/lib/preferences/PreferencesProxiesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesProxiesRendering.svelte
@@ -13,6 +13,34 @@ onMount(async () => {
 
 async function updateProxySettings() {
   await window.updateProxySettings(proxySettings);
+
+  // loop over all providers and container connections to see if there are any running engines
+  let runningProviders = false;
+  const providerInfos = await window.getProviderInfos();
+  providerInfos.forEach(async provider => {
+    let connections = provider.containerConnections;
+    connections.forEach(async connection => {
+      if (connection.status !== 'stopped') {
+        runningProviders = true;
+      }
+    });
+  });
+
+  // show a simple message to confirm that the settings are applied,
+  // or a longer warning if the user may need to take action
+  let message = 'Proxy settings have been applied.';
+  let type = 'info';
+  if (runningProviders) {
+    message += ' You may need to restart running container engines for the changes to take effect.';
+    type = 'warning';
+  }
+
+  window.showMessageBox({
+    title: 'Proxy Settings',
+    type: type,
+    message: message,
+    buttons: ['Ok'],
+  });
 }
 
 async function updateProxyState() {
@@ -50,7 +78,7 @@ async function updateProxyState() {
           id="httpProxy"
           disabled="{!proxyState}"
           bind:value="{proxySettings.httpProxy}"
-          class="w-full outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700"
+          class="w-full p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700"
           required />
       </div>
       <div>
@@ -79,19 +107,21 @@ async function updateProxyState() {
           disabled="{!proxyState}"
           bind:value="{proxySettings.noProxy}"
           placeholder="Example: *.domain.com, 192.168.*.*"
-          class="w-full outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700"
+          class="w-full p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700"
           required />
       </div>
-      {#if proxyState}
-        <div class="my-2">
-          <button on:click="{() => updateProxySettings()}" class="w-full pf-c-button pf-m-primary" type="button">
-            <span class="pf-c-button__icon pf-m-start">
-              <i class="fas fa-pen" aria-hidden="true"></i>
-            </span>
-            Update
-          </button>
-        </div>
-      {/if}
+      <div class="my-2 pt-4">
+        <button
+          on:click="{() => updateProxySettings()}"
+          disabled="{!proxyState}"
+          class="w-full pf-c-button pf-m-primary"
+          type="button">
+          <span class="pf-c-button__icon pf-m-start">
+            <i class="fas fa-pen" aria-hidden="true"></i>
+          </span>
+          Update
+        </button>
+      </div>
     {/if}
   </div>
 </SettingsPage>


### PR DESCRIPTION
### What does this PR do?

Adds a simple info prompt when applying Proxy settings so that you know they were applied successfully. If there are any running container engines, the prompt adds a warning that you may need to restart them.

Minor changes to page layout for consistency: fields now have same padding, button has same padding and is disabled instead of hidden.

### Screenshot/screencast of this PR

#### Before
<img width="805" alt="Screenshot 2023-05-19 at 10 48 06 AM" src="https://github.com/containers/podman-desktop/assets/19958075/06fd16ee-8838-4cfb-bc63-fe3edb615998">

#### After
<img width="765" alt="Screenshot 2023-05-19 at 10 47 16 AM" src="https://github.com/containers/podman-desktop/assets/19958075/c60b5c13-d71b-4d3b-bbc8-cacb401e8a75">

No running container engine:
<img width="554" alt="Screenshot 2023-05-19 at 10 37 43 AM" src="https://github.com/containers/podman-desktop/assets/19958075/b6fc7bbe-ce6d-43cd-a1a8-dcfbf6049ab4">

Running container engine:
<img width="552" alt="Screenshot 2023-05-19 at 11 02 08 AM" src="https://github.com/containers/podman-desktop/assets/19958075/a73c96b8-2953-4a3d-8bdf-9d36b673796f">

### What issues does this PR fix or reference?

Fixes #1918.

### How to test this PR?

Change proxy settings with and without a running container engine.