### PR TITLE
chore: Add example image name in placeholder

### DIFF
--- a/packages/renderer/src/lib/image/BuildImageFromContainerfile.svelte
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfile.svelte
@@ -205,7 +205,7 @@ async function initTerminal() {
             bind:value="{containerImageName}"
             name="containerImageName"
             id="containerImageName"
-            placeholder="Enter image name"
+            placeholder="Enter image name (e.g. quay.io/namespace/my-custom-image)"
             class="w-full p-2 outline-none text-sm bg-charcoal-600 rounded-sm text-gray-700 placeholder-gray-700"
             required />
           {#if providerConnections.length > 1}


### PR DESCRIPTION
### What does this PR do?

Adds an example image name (with registry url) to the Image Name field of the build image form.

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


![Screenshot 2023-05-19 at 1 37 00 PM](https://github.com/containers/podman-desktop/assets/4624530/e84d12f1-81e1-4702-9857-06418c495220)

### What issues does this PR fix or reference?

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

Closes: #2251 

### How to test this PR?

<!-- Please explain steps to reproduce -->

1. Navigate to the Image view
2. Click the "Build an Image" button on the top right
3. Clear the default image name ("my-custom-image")
4. See the placeholder text
