### PR TITLE
Fix the state of the lima container provider

### DIFF
--- a/extensions/lima/src/extension.ts
+++ b/extensions/lima/src/extension.ts
@@ -27,7 +27,7 @@ function registerProvider(
   providerSocketPath: string,
 ): void {
   let providerState: extensionApi.ProviderConnectionStatus = 'unknown';
-  let containerProviderConnection: extensionApi.ContainerProviderConnection = {
+  const containerProviderConnection: extensionApi.ContainerProviderConnection = {
     name: 'Lima',
     type: 'podman',
     status: () => providerState,
@@ -36,7 +36,7 @@ function registerProvider(
     },
   };
   providerState = 'started';
-  let disposable = provider.registerContainerProviderConnection(containerProviderConnection);
+  const disposable = provider.registerContainerProviderConnection(containerProviderConnection);
   provider.updateStatus('started');
   extensionContext.subscriptions.push(disposable);
   console.log('Lima extension is active');

--- a/extensions/lima/src/extension.ts
+++ b/extensions/lima/src/extension.ts
@@ -26,16 +26,17 @@ function registerProvider(
   provider: extensionApi.Provider,
   providerSocketPath: string,
 ): void {
-  const containerProviderConnection: extensionApi.ContainerProviderConnection = {
+  let providerState: extensionApi.ProviderConnectionStatus = 'unknown';
+  let containerProviderConnection: extensionApi.ContainerProviderConnection = {
     name: 'Lima',
     type: 'podman',
-    status: () => 'unknown',
+    status: () => providerState,
     endpoint: {
       socketPath: providerSocketPath,
     },
   };
-
-  const disposable = provider.registerContainerProviderConnection(containerProviderConnection);
+  providerState = 'started';
+  let disposable = provider.registerContainerProviderConnection(containerProviderConnection);
   provider.updateStatus('started');
   extensionContext.subscriptions.push(disposable);
   console.log('Lima extension is active');


### PR DESCRIPTION

### What does this PR do?

The connection status was always "unknown", so it was not listed as a container engine even if the lima provider was "started".

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?

* #2547

### How to test this PR?

`brew install lima`
`limactl start template://podman`
