### PR TITLE
chore: fix airgap assemblies

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -129,6 +129,8 @@ jobs:
           - os: "windows-2022"
             airgap: "true"
           - os: "macos-11"
+          - os: "macos-11"
+            airgap: "true"
           - os: "ubuntu-20.04"
     timeout-minutes: 60
     env:

--- a/extensions/podman/scripts/build.js
+++ b/extensions/podman/scripts/build.js
@@ -35,7 +35,10 @@ if (fs.existsSync(builtinDirectory)) {
   fs.rmSync(builtinDirectory, { recursive: true, force: true });
 }
 
-zipper.sync.zip(path.resolve(__dirname, '../')).compress().save(destFile);
+const zip = zipper.sync.zip(path.resolve(__dirname, '../'));
+// delete assets from cdix file
+zip.lowLevel().remove('assets');
+zip.compress().save(destFile);
 
 // create unzipped built-in
 mkdirp(unzippedDirectory).then(() => {


### PR DESCRIPTION
### What does this PR do?
avoid to store the assets folder (as in v0.15.0)

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

airgap releases

### How to test this PR?

in `extensions/podman` folder, `AIRGAP_DOWNLOAD=1 yarn build`command should not copy assets folder to cdix folder

Change-Id: I430444315a1dcb46a2ee59f80a6a5f0d0cf6c0ab
