### PR TITLE
feat: add meaningful tooltip for build, pull, prune image button

### DIFF
--- a/packages/renderer/src/lib/ImagesList.svelte
+++ b/packages/renderer/src/lib/ImagesList.svelte
@@ -220,13 +220,21 @@ function computeInterval(): number {
     {#if $imagesInfos.length > 0}
       <Prune type="images" engines="{enginesList}" />
     {/if}
-    <button on:click="{() => gotoPullImage()}" class="pf-c-button pf-m-primary" type="button">
+    <button
+      on:click="{() => gotoPullImage()}"
+      class="pf-c-button pf-m-primary"
+      type="button"
+      title="Pull Image From a Registry">
       <span class="pf-c-button__icon pf-m-start">
         <i class="fas fa-arrow-circle-down" aria-hidden="true"></i>
       </span>
       Pull an image
     </button>
-    <button on:click="{() => gotoBuildImage()}" class="pf-c-button pf-m-primary" type="button">
+    <button
+      on:click="{() => gotoBuildImage()}"
+      class="pf-c-button pf-m-primary"
+      type="button"
+      title="Build Image from Containerfile">
       <span class="pf-c-button__icon pf-m-start">
         <i class="fas fa-cube" aria-hidden="true"></i>
       </span>

--- a/packages/renderer/src/lib/engine/Prune.svelte
+++ b/packages/renderer/src/lib/engine/Prune.svelte
@@ -73,7 +73,11 @@ async function prune(type: string) {
 }
 </script>
 
-<button on:click="{() => openPruneDialog()}" class="pf-c-button pf-m-primary" type="button" title="Prune {type}">
+<button
+  on:click="{() => openPruneDialog()}"
+  class="pf-c-button pf-m-primary"
+  type="button"
+  title="Remove unused images">
   <span class="pf-c-button__icon pf-m-start">
     <i class="fas fa-trash" aria-hidden="true"></i>
   </span>


### PR DESCRIPTION
### What does this PR do?

### Screenshot/screencast of this PR

Change tooltip for `Prune images`

![image](https://github.com/containers/podman-desktop/assets/961094/02f06063-e6be-4cd3-be0c-061ee154a429)

Add tooltip for button `Pull an image`

![image](https://github.com/containers/podman-desktop/assets/961094/cd416c1d-9d47-4f88-af50-e1b1f645c534)

Add tooltip for button `Build an image`

![image](https://github.com/containers/podman-desktop/assets/961094/667f7abd-05d4-4dba-9e67-049311564a90)


### What issues does this PR fix or reference?

#2016

### How to test this PR?


