### PR TITLE
fix: Improve task names

### DIFF
--- a/packages/renderer/src/lib/image/build-image-task.ts
+++ b/packages/renderer/src/lib/image/build-image-task.ts
@@ -64,7 +64,7 @@ export function startBuild(imageName: string, buildImageCallback: BuildImageCall
   buildCallbacks.set(key, buildImageCallback);
 
   // start a task
-  const task = createTask(imageName);
+  const task = createTask('Build ' + imageName);
 
   // go to the images build
   task.gotoTask = () => {

--- a/packages/renderer/src/lib/image/build-image-task.ts
+++ b/packages/renderer/src/lib/image/build-image-task.ts
@@ -64,7 +64,7 @@ export function startBuild(imageName: string, buildImageCallback: BuildImageCall
   buildCallbacks.set(key, buildImageCallback);
 
   // start a task
-  const task = createTask('Build ' + imageName);
+  const task = createTask(`Build ${imageName}`);
 
   // go to the images build
   task.gotoTask = () => {

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionActions.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionActions.svelte
@@ -32,7 +32,7 @@ async function startConnectionProvider(
       if (!loggerHandlerKey) {
         updateConnectionStatus(provider, providerConnectionInfo, 'start');
         loggerHandlerKey = startTask(
-          `Start ${provider.name} ${providerConnectionInfo.name}`,
+          `Start ${providerConnectionInfo.name}`,
           `/preferences/resources`,
           getLoggerHandler(provider, providerConnectionInfo),
         );
@@ -56,7 +56,7 @@ async function restartConnectionProvider(
   if (providerConnectionInfo.status === 'started') {
     updateConnectionStatus(provider, providerConnectionInfo, 'restart');
     const loggerHandlerKey = startTask(
-      `Restart ${provider.name} ${providerConnectionInfo.name}`,
+      `Restart ${providerConnectionInfo.name}`,
       `/preferences/resources`,
       getLoggerHandler(provider, providerConnectionInfo),
     );
@@ -82,7 +82,7 @@ async function stopConnectionProvider(
     if (providerConnectionInfo.status === 'started') {
       updateConnectionStatus(provider, providerConnectionInfo, 'stop');
       const loggerHandlerKey = startTask(
-        `Stop ${provider.name} ${providerConnectionInfo.name}`,
+        `Stop ${providerConnectionInfo.name}`,
         `/preferences/resources`,
         getLoggerHandler(provider, providerConnectionInfo),
       );
@@ -106,7 +106,7 @@ async function deleteConnectionProvider(
     if (providerConnectionInfo.status === 'stopped' || providerConnectionInfo.status === 'unknown') {
       updateConnectionStatus(provider, providerConnectionInfo, 'delete');
       const loggerHandlerKey = startTask(
-        `Delete ${provider.name} ${providerConnectionInfo.name}`,
+        `Delete ${providerConnectionInfo.name}`,
         `/preferences/resources`,
         getLoggerHandler(provider, providerConnectionInfo),
       );

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationRendering.svelte
@@ -45,11 +45,11 @@ let showLogs = false;
 let tokenId: number;
 
 const providerDisplayName =
-      (providerInfo.containerProviderConnectionCreation
-        ? providerInfo.containerProviderConnectionCreationDisplayName || undefined
-        : providerInfo.kubernetesProviderConnectionCreation
-        ? providerInfo.kubernetesProviderConnectionCreationDisplayName
-        : undefined) || providerInfo.name;
+  (providerInfo.containerProviderConnectionCreation
+    ? providerInfo.containerProviderConnectionCreationDisplayName || undefined
+    : providerInfo.kubernetesProviderConnectionCreation
+    ? providerInfo.kubernetesProviderConnectionCreationDisplayName
+    : undefined) || providerInfo.name;
 
 let osMemory, osCpu, osFreeDisk;
 // get only ContainerProviderConnectionFactory scope fields that are starting by the provider id
@@ -241,7 +241,8 @@ async function handleOnSubmit(e) {
     tokenId = await window.getCancellableTokenSource();
     // clear terminal
     logsTerminal?.clear();
-    loggerHandlerKey = startTask(`Create ${providerDisplayName}`,
+    loggerHandlerKey = startTask(
+      `Create ${providerDisplayName}`,
       `/preferences/provider-task/${providerInfo.internalId}/${taskId}`,
       getLoggerHandler(),
     );

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationRendering.svelte
@@ -44,6 +44,13 @@ export let pageIsLoading = true;
 let showLogs = false;
 let tokenId: number;
 
+const providerDisplayName =
+      (providerInfo.containerProviderConnectionCreation
+        ? providerInfo.containerProviderConnectionCreationDisplayName || undefined
+        : providerInfo.kubernetesProviderConnectionCreation
+        ? providerInfo.kubernetesProviderConnectionCreationDisplayName
+        : undefined) || providerInfo.name;
+
 let osMemory, osCpu, osFreeDisk;
 // get only ContainerProviderConnectionFactory scope fields that are starting by the provider id
 let configurationKeys: IConfigurationPropertyRecordedSchema[] = [];
@@ -234,8 +241,7 @@ async function handleOnSubmit(e) {
     tokenId = await window.getCancellableTokenSource();
     // clear terminal
     logsTerminal?.clear();
-    loggerHandlerKey = startTask(
-      `Creating a ${providerInfo.name} provider`,
+    loggerHandlerKey = startTask(`Create ${providerDisplayName}`,
       `/preferences/provider-task/${providerInfo.internalId}/${taskId}`,
       getLoggerHandler(),
     );
@@ -295,12 +301,6 @@ async function close() {
         {/if}
       {/if}
     </div>
-    {@const providerDisplayName =
-      (providerInfo.containerProviderConnectionCreation
-        ? providerInfo.containerProviderConnectionCreationDisplayName || undefined
-        : providerInfo.kubernetesProviderConnectionCreation
-        ? providerInfo.kubernetesProviderConnectionCreationDisplayName
-        : undefined) || providerInfo.name}
     <h1 class="font-semibold">
       {creationInProgress ? 'Creating' : 'Create a'}
       {providerDisplayName}

--- a/packages/renderer/src/lib/preferences/PreferencesContainerConnectionRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesContainerConnectionRendering.svelte
@@ -98,7 +98,7 @@ async function startConnection() {
   lifecycleError = undefined;
   try {
     const loggerHandlerKey = startTask(
-      `Start ${providerInfo.name} ${containerConnectionInfo.name}`,
+      `Start ${containerConnectionInfo.name}`,
       `/preferences/resources`,
       getLoggerHandler(),
     );
@@ -116,7 +116,7 @@ async function startConnection() {
 async function stopConnection() {
   lifecycleError = undefined;
   const loggerHandlerKey = startTask(
-    `Stop ${providerInfo.name} ${containerConnectionInfo.name}`,
+    `Stop ${containerConnectionInfo.name}`,
     `/preferences/resources`,
     getLoggerHandler(),
   );
@@ -131,7 +131,7 @@ async function stopConnection() {
 async function deleteConnection() {
   lifecycleError = undefined;
   const loggerHandlerKey = startTask(
-    `Delete ${providerInfo.name} ${containerConnectionInfo.name}`,
+    `Delete ${containerConnectionInfo.name}`,
     `/preferences/resources`,
     getLoggerHandler(),
   );


### PR DESCRIPTION
### What does this PR do?

Task names were inconsistent:
- Most described the task ('Create X') others what it was doing ('Creating X'), made this consistent using the task.
- Actions on providers were including the provider name, which made it too long to fit in the task manager, removed this.
- Creation tasks called everything a provider (e.g. 'Creating a Kind provider'), switched to use the same display name as the UI (e.g. 'Create Kind cluster').
- Build task just used the image name, added 'Build' for consistency.

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

Fixed #2605.

### How to test this PR?

Create a couple providers, start/stop instances, and attempt to build a container file.