### PR TITLE
website: fix typo in Flathub name

### DIFF
--- a/website/src/pages/downloads/linux.tsx
+++ b/website/src/pages/downloads/linux.tsx
@@ -83,7 +83,7 @@ export function LinuxDownloads(): JSX.Element {
               <p className="text-lg">
                 Using{' '}
                 <a className="text-purple-500" href="https://flathub.org/apps/details/io.podman_desktop.PodmanDesktop">
-                  FlatHub
+                  Flathub
                 </a>{' '}
                 ? Install in one command:
               </p>


### PR DESCRIPTION
### What does this PR do?

The "h" in Flathub should be lowercase. This PR fixes it.