### PR TITLE
website: fix Flatpak install instructions

### DIFF
--- a/website/src/pages/downloads/linux.tsx
+++ b/website/src/pages/downloads/linux.tsx
@@ -42,7 +42,7 @@ export function LinuxDownloads(): JSX.Element {
   });
 
   const copyFlathubInstructions = async () => {
-    await navigator.clipboard.writeText('flatpak install --user flathub io.podman_desktop.PodmanDesktop');
+    await navigator.clipboard.writeText('flatpak install flathub io.podman_desktop.PodmanDesktop');
   };
 
   useEffect(() => {


### PR DESCRIPTION
### What does this PR do?

[Text](https://github.com/containers/podman-desktop/blob/main/website/src/pages/downloads/linux.tsx#L99) on the Linux download website is `flatpak install flathub io.podman_desktop.PodmanDesktop`, however the clipboard copy contains additional `--user ` switch that is not present in the original text and is not correct because the default Flathub installation (that most users have) is system, not user. This PR removes the `--user` switch.