### PR TITLE
chore: use publisher.extensionName as extension identifier instead of just the extension name

### DIFF
--- a/packages/main/src/plugin/extension-loader.spec.ts
+++ b/packages/main/src/plugin/extension-loader.spec.ts
@@ -243,6 +243,7 @@ test('Verify extension error leads to failed state', async () => {
   await extensionLoader.activateExtension(
     {
       id: id,
+      name: 'id',
       path: 'dummy',
       api: {} as typeof containerDesktopAPI,
       mainPath: '',

--- a/packages/main/src/plugin/featured/featured.spec.ts
+++ b/packages/main/src/plugin/featured/featured.spec.ts
@@ -87,7 +87,7 @@ test('getFeaturedExtensions should check installable extensions', async () => {
   listExtensionsMock.mockReturnValue([
     {
       publisher: 'podman-desktop',
-      id: 'podman',
+      id: 'podman-desktop.podman',
       // make it a built-in extension (cannot be removed, just disabled)
       removable: false,
     },

--- a/packages/main/src/plugin/featured/featured.ts
+++ b/packages/main/src/plugin/featured/featured.ts
@@ -63,9 +63,7 @@ export class Featured {
       };
 
       // check if the extension is installed
-      const extensionInfo = extensionInfos.find(
-        extensionInfo => `${extensionInfo.publisher}.${extensionInfo.id}` === extensionToCheck.extensionId,
-      );
+      const extensionInfo = extensionInfos.find(extensionInfo => extensionInfo.id === extensionToCheck.extensionId);
       if (extensionInfo) {
         // found it so we can flag them as installed/fetched
         featuredExtension.installed = true;

--- a/packages/renderer/src/PreferencesNavigation.svelte
+++ b/packages/renderer/src/PreferencesNavigation.svelte
@@ -131,9 +131,9 @@ $: addSectionHiddenClass = (section: string): string => (sectionExpanded[section
       <section class="pf-c-nav__subnav {addSectionHiddenClass('extensionsCatalog')}">
         <ul class="pf-c-nav__list">
           {#each $extensionInfos as extension}
-            <li class="pf-c-nav__item {addCurrentClass(`/preferences/extension/${extension.name}`)}">
+            <li class="pf-c-nav__item {addCurrentClass(`/preferences/extension/${extension.id}`)}">
               <a
-                href="/preferences/extension/{extension.name}"
+                href="/preferences/extension/{extension.id}"
                 id="configuration-section-extensions-catalog-{extension.name.toLowerCase()}"
                 class="pf-c-nav__link"
                 style="font-weight: 200">{extension.displayName}</a>


### PR DESCRIPTION
### What does this PR do?
avoid potential collision if it is just the name
migrate extension storage from old path to the new path

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

Ensure ids are the identifier : publisherName.extensionName

### How to test this PR?

Should work as before (like browsing extensions in settings page)

Change-Id: Ib872bb654e2961513f7367eff6dcb7e258b6d2e0
