### PR TITLE
fix: Use extension configuration title instead of id as section name …

### DIFF
--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -372,8 +372,8 @@ export class ExtensionLoader {
     if (extensionConfiguration) {
       // add information about the current extension
       extensionConfiguration.extension = extension;
-      extensionConfiguration.id = 'preferences.' + extensionConfiguration.title;
       extensionConfiguration.title = `Extension: ${extensionConfiguration.title}`;
+      extensionConfiguration.id = 'preferences.' + extension.id;
 
       this.configurationRegistry.registerConfigurations([extensionConfiguration]);
     }

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -372,8 +372,8 @@ export class ExtensionLoader {
     if (extensionConfiguration) {
       // add information about the current extension
       extensionConfiguration.extension = extension;
+      extensionConfiguration.id = 'preferences.' + extensionConfiguration.title;
       extensionConfiguration.title = `Extension: ${extensionConfiguration.title}`;
-      extensionConfiguration.id = 'preferences.' + extension.id;
 
       this.configurationRegistry.registerConfigurations([extensionConfiguration]);
     }

--- a/packages/renderer/src/lib/preferences/PreferencesRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesRendering.spec.ts
@@ -71,3 +71,9 @@ test('Expect to see one record when filtering with unknown keyword', async () =>
   const noSettingsDiv = screen.getAllByText('No Settings Found');
   expect(noSettingsDiv.length > 0).toBe(true);
 });
+
+test('Expect extension title used a section name', async () => {
+  render(PreferencesRendering, { properties: records, key: 'key' });
+  const sectionName = screen.getAllByText('my boolean property');
+  expect(sectionName.length > 0).toBe(true);
+});

--- a/packages/renderer/src/lib/preferences/PreferencesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRendering.svelte
@@ -79,7 +79,7 @@ function updateSearchValue(event: any) {
       {:else}
         {#each [...matchingRecords.keys()].sort((a, b) => a.localeCompare(b)) as configSection}
           <div class="mt-5">
-            <div class="first-letter:uppercase">{configSection.replace('preferences.', '').replace('.', ' ')}</div>
+            <div class="first-letter:uppercase">{matchingRecords.get(configSection).at(0).title}</div>
             {#each matchingRecords.get(configSection) as configItem}
               <div class="bg-charcoal-600 rounded-md mt-2 ml-2">
                 <PreferencesRenderingItem record="{configItem}" />


### PR DESCRIPTION
…in preferences

Fixes #2358

### What does this PR do?

Changes the section part for properties contributed by extensions

### Screenshot/screencast of this PR
Before:

![image](https://github.com/containers/podman-desktop/assets/695993/b231d0a5-3476-4588-a4cd-72903a31cbaa)

After:

![image](https://github.com/containers/podman-desktop/assets/695993/2a64d489-e70f-413c-b26b-f2e07c7b8d3f)


### What issues does this PR fix or reference?

Fixes #2358 

### How to test this PR?

1. Install the OpenShift Local extension
2. Go the the Preferences pages
3. The section for OpenShift Local properties should be Red Hat OpenShift Local instead of Openshift-local