### PR TITLE
fix: display context name for Kubernetes pods

### DIFF
--- a/packages/main/src/plugin/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes-client.ts
@@ -68,7 +68,7 @@ function toContainerStatus(state: V1ContainerState | undefined): string {
   return 'Unknown';
 }
 
-function toPodInfo(pod: V1Pod, contextName: string | undefined): PodInfo {
+function toPodInfo(pod: V1Pod, contextName?: string): PodInfo {
   const containers =
     pod.status?.containerStatuses?.map(status => {
       return {
@@ -88,7 +88,7 @@ function toPodInfo(pod: V1Pod, contextName: string | undefined): PodInfo {
     Namespace: pod.metadata?.namespace || '',
     Networks: [],
     Status: pod.status?.phase || '',
-    engineId: contextName || 'kubernetes',
+    engineId: contextName ?? 'kubernetes',
     engineName: 'Kubernetes',
     kind: 'kubernetes',
   };

--- a/packages/main/src/plugin/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes-client.ts
@@ -68,7 +68,7 @@ function toContainerStatus(state: V1ContainerState | undefined): string {
   return 'Unknown';
 }
 
-function toPodInfo(pod: V1Pod): PodInfo {
+function toPodInfo(pod: V1Pod, contextName: string | undefined): PodInfo {
   const containers =
     pod.status?.containerStatuses?.map(status => {
       return {
@@ -88,7 +88,7 @@ function toPodInfo(pod: V1Pod): PodInfo {
     Namespace: pod.metadata?.namespace || '',
     Networks: [],
     Status: pod.status?.phase || '',
-    engineId: 'kubernetes',
+    engineId: contextName || 'kubernetes',
     engineName: 'Kubernetes',
     kind: 'kubernetes',
   };
@@ -435,7 +435,7 @@ export class KubernetesClient {
     const connected = await this.checkConnection();
     if (ns && connected) {
       const pods = await this.listNamespacedPod(ns);
-      return pods.items.map(pod => toPodInfo(pod));
+      return pods.items.map(pod => toPodInfo(pod, this.getCurrentContextName()));
     }
     return [];
   }

--- a/packages/main/src/plugin/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes-client.ts
@@ -89,7 +89,7 @@ function toPodInfo(pod: V1Pod, contextName?: string): PodInfo {
     Networks: [],
     Status: pod.status?.phase || '',
     engineId: contextName ?? 'kubernetes',
-    engineName: 'Kubernetes',
+    engineName: 'k8s',
     kind: 'kubernetes',
   };
 }

--- a/packages/renderer/src/lib/pod/PodsList.spec.ts
+++ b/packages/renderer/src/lib/pod/PodsList.spec.ts
@@ -101,7 +101,7 @@ const kubepod1: PodInfo = {
   Networks: [],
   Status: 'running',
   engineId: 'context1',
-  engineName: 'Kubernetes',
+  engineName: 'k8s',
   kind: 'kubernetes',
 };
 
@@ -117,7 +117,7 @@ const kubepod2: PodInfo = {
   Networks: [],
   Status: 'running',
   engineId: 'context2',
-  engineName: 'Kubernetes',
+  engineName: 'k8s',
   kind: 'kubernetes',
 };
 
@@ -205,7 +205,7 @@ test('Expect single kubernetes pod being displayed', async () => {
   }
 
   render(PodsList);
-  const pod1Details = screen.getByRole('cell', { name: 'kubepod1 beab2512 0 container Kubernetes context1 tooltip' });
+  const pod1Details = screen.getByRole('cell', { name: 'kubepod1 beab2512 0 container k8s context1 tooltip' });
   expect(pod1Details).toBeInTheDocument();
 });
 
@@ -225,8 +225,8 @@ test('Expect 2 kubernetes pods being displayed', async () => {
   }
 
   render(PodsList);
-  const pod1Details = screen.getByRole('cell', { name: 'kubepod1 beab2512 0 container Kubernetes context1 tooltip' });
+  const pod1Details = screen.getByRole('cell', { name: 'kubepod1 beab2512 0 container k8s context1 tooltip' });
   expect(pod1Details).toBeInTheDocument();
-  const pod2Details = screen.getByRole('cell', { name: 'kubepod2 e8129c57 0 container Kubernetes context2 tooltip' });
+  const pod2Details = screen.getByRole('cell', { name: 'kubepod2 e8129c57 0 container k8s context2 tooltip' });
   expect(pod2Details).toBeInTheDocument();
 });

--- a/packages/renderer/src/lib/pod/PodsList.spec.ts
+++ b/packages/renderer/src/lib/pod/PodsList.spec.ts
@@ -100,8 +100,8 @@ const kubepod1: PodInfo = {
   Namespace: '',
   Networks: [],
   Status: 'running',
-  engineId: 'kubernetes',
-  engineName: 'kubernetes',
+  engineId: 'context1',
+  engineName: 'Kubernetes',
   kind: 'kubernetes',
 };
 
@@ -116,8 +116,8 @@ const kubepod2: PodInfo = {
   Namespace: '',
   Networks: [],
   Status: 'running',
-  engineId: 'kubernetes',
-  engineName: 'kubernetes',
+  engineId: 'context2',
+  engineName: 'Kubernetes',
   kind: 'kubernetes',
 };
 
@@ -205,7 +205,7 @@ test('Expect single kubernetes pod being displayed', async () => {
   }
 
   render(PodsList);
-  const pod1Details = screen.getByRole('cell', { name: 'kubepod1 beab2512 0 container kubernetes' });
+  const pod1Details = screen.getByRole('cell', { name: 'kubepod1 beab2512 0 container Kubernetes context1 tooltip' });
   expect(pod1Details).toBeInTheDocument();
 });
 
@@ -225,8 +225,8 @@ test('Expect 2 kubernetes pods being displayed', async () => {
   }
 
   render(PodsList);
-  const pod1Details = screen.getByRole('cell', { name: 'kubepod1 beab2512 0 container kubernetes' });
+  const pod1Details = screen.getByRole('cell', { name: 'kubepod1 beab2512 0 container Kubernetes context1 tooltip' });
   expect(pod1Details).toBeInTheDocument();
-  const pod2Details = screen.getByRole('cell', { name: 'kubepod2 e8129c57 0 container kubernetes' });
+  const pod2Details = screen.getByRole('cell', { name: 'kubepod2 e8129c57 0 container Kubernetes context2 tooltip' });
   expect(pod2Details).toBeInTheDocument();
 });

--- a/packages/renderer/src/lib/pod/PodsList.svelte
+++ b/packages/renderer/src/lib/pod/PodsList.svelte
@@ -286,7 +286,9 @@ function errorCallback(pod: PodInfoUI, errorMessage: string): void {
                   </div>
                   <div class="flex flex-row text-xs font-extra-light text-gray-900">
                     <div class="px-2 inline-flex text-xs font-extralight rounded-full bg-slate-800 text-slate-400">
-                      {pod.engineName}
+                      {pod.engineName}{#if pod.kind === 'kubernetes'}<div class="ml-1">
+                          <Tooltip tip="{pod.engineId}" top>{pod.engineId.substring(0, 16)}</Tooltip>
+                        </div>{/if}
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
Fixes #2154

### What does this PR do?

Display the Kubernetes context name for Kubernetes pods. As the context can be long (Sandbox), it is shortened to 16 characters and tooltip shows the whole context name

### Screenshot/screencast of this PR

![context](https://github.com/containers/podman-desktop/assets/695993/42d2762d-e69e-46e7-a373-833338fa9f0b)

### What issues does this PR fix or reference?

Fixes #2154

### How to test this PR?

1. Have one pods running on Kubernetes
2. Go to the Pods list tab
