### PR TITLE
chore: add method to grab all extensions from the catalog

### DIFF
--- a/packages/main/src/plugin/extensions-catalog/extensions-catalog-api.ts
+++ b/packages/main/src/plugin/extensions-catalog/extensions-catalog-api.ts
@@ -26,3 +26,18 @@ export interface CatalogFetchableExtension {
   link: string;
   version: string;
 }
+
+// exposed extensions
+export interface CatalogExtension {
+  id: string;
+  publisherName: string;
+  extensionName: string;
+  displayName: string;
+  versions: CatalogExtensionVersion[];
+}
+
+interface CatalogExtensionVersion {
+  version: string;
+  ociUri: string;
+  preview: boolean;
+}


### PR DESCRIPTION
### What does this PR do?
add a method to provide all extensions from the catalog
and not only the featured extensions

Also cache the data to not send too many requests to the registry

### Screenshot/screencast of this PR


### What issues does this PR fix or reference?

related to https://github.com/containers/podman-desktop/issues/2184

### How to test this PR?

Should work as before (for featured extensions)
unit tests added


Change-Id: Idd87e9c7c61d67ee75923cd69840005fd5b71e82
