### PR TITLE
fix: don't report error message is user cancelled Podman installation

### DIFF
--- a/extensions/podman/src/podman-install.spec.ts
+++ b/extensions/podman/src/podman-install.spec.ts
@@ -1,0 +1,95 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { WinInstaller } from './podman-install';
+import { beforeEach, expect, type Mock, test, vi } from 'vitest';
+import * as extensionApi from '@podman-desktop/api';
+import * as fs from 'node:fs';
+import { runCliCommand } from './util';
+
+vi.mock('@podman-desktop/api', async () => {
+  return {
+    window: {
+      withProgress: vi.fn(),
+      showNotification: vi.fn(),
+      showErrorMessage: vi.fn(),
+    },
+    ProgressLocation: {},
+  };
+});
+
+vi.mock('./util', async () => {
+  return {
+    getAssetsFolder: vi.fn().mockReturnValue(''),
+    runCliCommand: vi.fn(),
+  };
+});
+
+const progress = {
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  report: () => {},
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+test('expect update on windows to show notification in case of 0 exit code', async () => {
+  vi.spyOn(extensionApi.window, 'withProgress').mockImplementation((options, task) => {
+    return task(progress, undefined);
+  });
+
+  vi.mock('node:fs');
+  vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+  (runCliCommand as Mock).mockResolvedValue({ exitCode: 0 });
+
+  const installer = new WinInstaller();
+  const result = await installer.update();
+  expect(result).toBeTruthy();
+  expect(extensionApi.window.showNotification).toHaveBeenCalled();
+});
+
+test('expect update on windows not to show notification in case of 1602 exit code', async () => {
+  vi.spyOn(extensionApi.window, 'withProgress').mockImplementation((options, task) => {
+    return task(progress, undefined);
+  });
+
+  vi.mock('node:fs');
+  vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+  (runCliCommand as Mock).mockResolvedValue({ exitCode: 1602 });
+
+  const installer = new WinInstaller();
+  const result = await installer.update();
+  expect(result).toBeTruthy();
+  expect(extensionApi.window.showNotification).not.toHaveBeenCalled();
+});
+
+test('expect update on windows to throw error if non zero exit code', async () => {
+  vi.spyOn(extensionApi.window, 'withProgress').mockImplementation((options, task) => {
+    return task(progress, undefined);
+  });
+
+  vi.mock('node:fs');
+  vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+  (runCliCommand as Mock).mockResolvedValue({ exitCode: -1, stdErr: 'CustomError' });
+
+  const installer = new WinInstaller();
+  const result = await installer.update();
+  expect(result).toBeFalsy();
+  expect(extensionApi.window.showErrorMessage).toHaveBeenCalled();
+});

--- a/extensions/podman/src/podman-install.ts
+++ b/extensions/podman/src/podman-install.ts
@@ -247,7 +247,7 @@ abstract class BaseInstaller implements Installer {
   }
 }
 
-class WinInstaller extends BaseInstaller {
+export class WinInstaller extends BaseInstaller {
   getUpdatePreflightChecks(): extensionApi.InstallCheck[] {
     return [];
   }
@@ -272,11 +272,14 @@ class WinInstaller extends BaseInstaller {
       try {
         if (fs.existsSync(setupPath)) {
           const runResult = await runCliCommand(setupPath, ['/install', '/norestart']);
-          if (runResult.exitCode !== 0) {
-            throw new Error(runResult.stdErr);
+          //check if user cancelled installation see https://learn.microsoft.com/en-us/previous-versions//aa368542(v=vs.85)
+          if (runResult.exitCode != 1602) {
+            if (runResult.exitCode !== 0) {
+              throw new Error(runResult.stdErr);
+            }
+            progress.report({ increment: 80 });
+            extensionApi.window.showNotification({ body: 'Podman is successfully installed.' });
           }
-          progress.report({ increment: 80 });
-          extensionApi.window.showNotification({ body: 'Podman is successfully installed.' });
           return true;
         } else {
           throw new Error(`Can't find Podman setup package! Path: ${setupPath} doesn't exists.`);


### PR DESCRIPTION
Fixes #1825

### What does this PR do?

Handle Windows Podman installer exit code if user cancelled

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

Fixes #1825 

### How to test this PR?

1. Have Podman 4.4.4 installed
2. Launch Podman Desktop
3. Click the Update to 4.5.0
4. Cancel the installation