### PR TITLE
fix: Podman dashboard still proposes to update after podman installation

### DIFF
--- a/packages/renderer/src/lib/dashboard/ProviderConfigured.spec.ts
+++ b/packages/renderer/src/lib/dashboard/ProviderConfigured.spec.ts
@@ -1,0 +1,41 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import '@testing-library/jest-dom';
+import { beforeAll, test } from 'vitest';
+import { verifyStatus } from './ProviderStatusTestHelper';
+import ProviderConfigured from '/@/lib/dashboard/ProviderConfigured.svelte';
+
+// fake the window.events object
+beforeAll(() => {
+  (window.events as unknown) = {
+    receive: (_channel: string, func: any) => {
+      func();
+    },
+  };
+});
+
+test('Expect configured provider shows update button', async () => {
+  verifyStatus(ProviderConfigured, 'configured', false);
+});
+
+test('Expect configured provider does not show update button if version same', async () => {
+  verifyStatus(ProviderConfigured, 'configured', true);
+});

--- a/packages/renderer/src/lib/dashboard/ProviderConfigured.spec.ts
+++ b/packages/renderer/src/lib/dashboard/ProviderConfigured.spec.ts
@@ -19,12 +19,13 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import '@testing-library/jest-dom';
-import { beforeAll, test } from 'vitest';
-import { verifyStatus } from './ProviderStatusTestHelper';
+import { beforeAll, test, vi } from 'vitest';
+import { verifyStatus } from './ProviderStatusTestHelper.spec';
 import ProviderConfigured from '/@/lib/dashboard/ProviderConfigured.svelte';
 
 // fake the window.events object
 beforeAll(() => {
+  (window as any).startProvider = vi.fn();
   (window.events as unknown) = {
     receive: (_channel: string, func: any) => {
       func();

--- a/packages/renderer/src/lib/dashboard/ProviderConfigured.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderConfigured.svelte
@@ -5,7 +5,7 @@ import PreflightChecks from './PreflightChecks.svelte';
 import ProviderLinks from './ProviderLinks.svelte';
 import ProviderLogo from './ProviderLogo.svelte';
 import ProviderUpdateButton from './ProviderUpdateButton.svelte';
-import { Steps } from 'svelte-steps';
+import Steps from 'svelte-steps/Steps.svelte';
 
 import { onMount } from 'svelte';
 import { InitializeAndStartMode, InitializationSteps, type InitializationContext } from './ProviderInitUtils';
@@ -100,7 +100,7 @@ onMount(() => {
       <ErrorMessage class="flex flex-col mt-2 my-2 text-sm" error="{runError}" />
     {/if}
   </div>
-  {#if provider.updateInfo}
+  {#if provider.version !== provider.updateInfo?.version}
     <div class="mt-10 mb-1 w-full flex justify-around">
       <ProviderUpdateButton onPreflightChecks="{checks => (preflightChecks = checks)}" provider="{provider}" />
     </div>

--- a/packages/renderer/src/lib/dashboard/ProviderInstalled.spec.ts
+++ b/packages/renderer/src/lib/dashboard/ProviderInstalled.spec.ts
@@ -25,6 +25,7 @@ import ProviderInstalled from '/@/lib/dashboard/ProviderInstalled.svelte';
 import type { ProviderInfo } from '../../../../main/src/plugin/api/provider-info';
 import { InitializeAndStartMode } from '/@/lib/dashboard/ProviderInitUtils';
 import userEvent from '@testing-library/user-event';
+import { verifyStatus } from './ProviderStatusTestHelper';
 
 vi.mock('xterm', () => {
   return {
@@ -79,4 +80,12 @@ test('Expect installed provider shows button', async () => {
 
   expect((initializationContext as any).promise).toBeDefined();
   expect(window.initializeProvider).toHaveBeenCalled();
+});
+
+test('Expect installed provider shows update button', async () => {
+  verifyStatus(ProviderInstalled, 'installed', false);
+});
+
+test('Expect installed provider does not show update button if version same', async () => {
+  verifyStatus(ProviderInstalled, 'installed', true);
 });

--- a/packages/renderer/src/lib/dashboard/ProviderInstalled.spec.ts
+++ b/packages/renderer/src/lib/dashboard/ProviderInstalled.spec.ts
@@ -25,7 +25,7 @@ import ProviderInstalled from '/@/lib/dashboard/ProviderInstalled.svelte';
 import type { ProviderInfo } from '../../../../main/src/plugin/api/provider-info';
 import { InitializeAndStartMode } from '/@/lib/dashboard/ProviderInitUtils';
 import userEvent from '@testing-library/user-event';
-import { verifyStatus } from './ProviderStatusTestHelper';
+import { verifyStatus } from './ProviderStatusTestHelper.spec';
 
 vi.mock('xterm', () => {
   return {

--- a/packages/renderer/src/lib/dashboard/ProviderInstalled.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderInstalled.svelte
@@ -219,7 +219,7 @@ function onInstallationClick() {
     </div>
   </div>
 
-  {#if provider.updateInfo}
+  {#if provider.version !== provider.updateInfo?.version}
     <div class="mt-10 mb-1 w-full flex justify-around">
       <ProviderUpdateButton onPreflightChecks="{checks => (preflightChecks = checks)}" provider="{provider}" />
     </div>

--- a/packages/renderer/src/lib/dashboard/ProviderReady.spec.ts
+++ b/packages/renderer/src/lib/dashboard/ProviderReady.spec.ts
@@ -1,0 +1,41 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import '@testing-library/jest-dom';
+import { beforeAll, test } from 'vitest';
+import { verifyStatus } from './ProviderStatusTestHelper';
+import ProviderReady from '/@/lib/dashboard/ProviderReady.svelte';
+
+// fake the window.events object
+beforeAll(() => {
+  (window.events as unknown) = {
+    receive: (_channel: string, func: any) => {
+      func();
+    },
+  };
+});
+
+test('Expect ready provider shows update button', async () => {
+  verifyStatus(ProviderReady, 'ready', false);
+});
+
+test('Expect ready provider does not show update button if version same', async () => {
+  verifyStatus(ProviderReady, 'ready', true);
+});

--- a/packages/renderer/src/lib/dashboard/ProviderReady.spec.ts
+++ b/packages/renderer/src/lib/dashboard/ProviderReady.spec.ts
@@ -20,7 +20,7 @@
 
 import '@testing-library/jest-dom';
 import { beforeAll, test } from 'vitest';
-import { verifyStatus } from './ProviderStatusTestHelper';
+import { verifyStatus } from './ProviderStatusTestHelper.spec';
 import ProviderReady from '/@/lib/dashboard/ProviderReady.svelte';
 
 // fake the window.events object

--- a/packages/renderer/src/lib/dashboard/ProviderStatusTestHelper.spec.ts
+++ b/packages/renderer/src/lib/dashboard/ProviderStatusTestHelper.spec.ts
@@ -70,3 +70,7 @@ export function verifyStatus<C extends SvelteComponent>(
     expect(updateButton).toBeInTheDocument();
   }
 }
+
+test('vitest does not accept helper files without a test', () => {
+  expect(true).toBeTruthy();
+});

--- a/packages/renderer/src/lib/dashboard/ProviderStatusTestHelper.ts
+++ b/packages/renderer/src/lib/dashboard/ProviderStatusTestHelper.ts
@@ -1,0 +1,72 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import type { ComponentProps, SvelteComponent } from 'svelte';
+
+import { render, screen } from '@testing-library/svelte';
+import type { ProviderStatus } from '@podman-desktop/api';
+import type { ProviderInfo } from '../../../../main/src/plugin/api/provider-info';
+import { InitializeAndStartMode } from '/@/lib/dashboard/ProviderInitUtils';
+import { expect } from 'vitest';
+
+type Constructor<T> = new (...args: any[]) => T;
+
+type SvelteComponentOptions<C extends SvelteComponent> = ComponentProps<C> | { props: ComponentProps<C> };
+
+export function verifyStatus<C extends SvelteComponent>(
+  component: Constructor<C>,
+  status: ProviderStatus,
+  sameVersions: boolean,
+): void {
+  const provider: ProviderInfo = {
+    containerConnections: [],
+    containerProviderConnectionCreation: false,
+    containerProviderConnectionInitialization: false,
+    detectionChecks: [],
+    id: 'myproviderid',
+    images: {},
+    installationSupport: false,
+    internalId: 'myproviderid',
+    kubernetesConnections: [],
+    kubernetesProviderConnectionCreation: false,
+    kubernetesProviderConnectionInitialization: false,
+    links: [],
+    name: 'MyProvider',
+    status: status,
+    warnings: [],
+    version: '1.0.0',
+    updateInfo: {
+      version: sameVersions ? '1.0.0' : '1.0.1',
+    },
+  };
+
+  const initializationContext = { mode: InitializeAndStartMode };
+  render(component, {
+    provider: provider,
+    initializationContext: initializationContext,
+  } as unknown as SvelteComponentOptions<C>);
+
+  const updateButton = screen.queryByRole('button', { name: 'Update to 1.0.1' });
+  if (sameVersions) {
+    expect(updateButton).not.toBeInTheDocument();
+  } else {
+    expect(updateButton).toBeInTheDocument();
+  }
+}


### PR DESCRIPTION
Fixes #1498

### What does this PR do?

Ensure the Update to ... is not shown anymore after update has been processed

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

Fixes #1498 

### How to test this PR?

1. Have Podman 4.4.4 installed
2. Launch Podman Desktop
3. Update to 4.5.0 is shown
4. Update to 4.5.0
5. Update to 4.5.0 not shown anymore