### PR TITLE
chore: avoid to rename to something that already exists

### DIFF
--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -820,7 +820,7 @@ export class ExtensionLoader {
     const oldStoragePath = path.resolve(this.extensionsStorageDirectory, extension.name);
 
     // Migrate old storage path to new storage path
-    if (fs.existsSync(oldStoragePath)) {
+    if (fs.existsSync(oldStoragePath) && !fs.existsSync(storagePath)) {
       await fs.promises.rename(oldStoragePath, storagePath);
     }
 


### PR DESCRIPTION
### What does this PR do?
avoid to rename to something that already exists

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

Extension storage id change

### How to test this PR?

Launch both old versions of Podman Desktop and new one

Change-Id: Ifa264f0e1e573758bf9de21668d70ad76937e195
