### PR TITLE
fix: avoid "Create New VM" option for podman if podman is not installed

### DIFF
--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -202,6 +202,14 @@ async function updateMachines(provider: extensionApi.Provider): Promise<void> {
   await checkDefaultMachine(machines);
 }
 
+function cleanupMachines(): void {
+  currentConnections.forEach(disposable => disposable.dispose());
+  currentConnections.clear();
+  containerProviderConnections.clear();
+  podmanMachinesInfo.clear();
+  podmanMachinesStatuses.clear();
+}
+
 export async function checkDefaultMachine(machines: MachineJSON[]): Promise<void> {
   // As a last check, let's see if the machine that is running is set by default or not on the CLI.
   // if it isn't, we should prompt the user to set it as default, or else podman CLI commands will not work
@@ -390,6 +398,7 @@ async function monitorProvider(provider: extensionApi.Provider) {
       // update version
       if (!installedPodman) {
         provider.updateStatus('not-installed');
+        cleanupMachines();
       } else if (installedPodman.version) {
         provider.updateVersion(installedPodman.version);
         // update provider status if someone has installed podman externally

--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -395,6 +395,7 @@ async function monitorProvider(provider: extensionApi.Provider) {
         // update provider status if someone has installed podman externally
         if (provider.status === 'not-installed') {
           provider.updateStatus('installed');
+          registerContainerConnectionFactory(provider);
         }
       }
     } catch (error) {

--- a/extensions/podman/src/podman-install.spec.ts
+++ b/extensions/podman/src/podman-install.spec.ts
@@ -37,6 +37,7 @@ vi.mock('./util', async () => {
   return {
     getAssetsFolder: vi.fn().mockReturnValue(''),
     runCliCommand: vi.fn(),
+    appHomeDir: vi.fn().mockReturnValue(''),
   };
 });
 

--- a/extensions/podman/src/podman-install.ts
+++ b/extensions/podman/src/podman-install.ts
@@ -29,6 +29,7 @@ import { getAssetsFolder, runCliCommand } from './util';
 import { getDetectionChecks } from './detection-checks';
 import { BaseCheck } from './base-check';
 import { MacCPUCheck, MacMemoryCheck, MacPodmanInstallCheck, MacVersionCheck } from './macos-checks';
+import { registerContainerConnectionFactory } from './extension';
 
 const readFile = promisify(fs.readFile);
 const writeFile = promisify(fs.writeFile);
@@ -128,6 +129,7 @@ export class PodmanInstall {
       // write podman version
       if (newInstalledPodman) {
         this.podmanInfo.podmanVersion = newInstalledPodman.version;
+        registerContainerConnectionFactory(provider);
       }
       // update detections checks
       provider.updateDetectionChecks(getDetectionChecks(newInstalledPodman));

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
@@ -18,7 +18,13 @@ import { router } from 'tinro';
 import SettingsPage from './SettingsPage.svelte';
 import ConnectionStatus from '../ui/ConnectionStatus.svelte';
 import { eventCollect } from './preferences-connection-rendering-task';
-import { getProviderConnectionName, type IConnectionRestart, type IConnectionStatus } from './Util';
+import {
+  canCreateKubernetesConnection,
+  canCreateContainerConnection,
+  getProviderConnectionName,
+  type IConnectionRestart,
+  type IConnectionStatus,
+} from './Util';
 import EngineIcon from '../ui/EngineIcon.svelte';
 import EmptyScreen from '../ui/EmptyScreen.svelte';
 import PreferencesConnectionActions from './PreferencesConnectionActions.svelte';
@@ -247,7 +253,7 @@ async function startConnectionProvider(
                 <span class="my-auto text-gray-400 ml-3 break-words">{provider.name}</span>
               </div>
               <div class="text-center mt-10">
-                {#if provider.containerProviderConnectionCreation || provider.kubernetesProviderConnectionCreation}
+                {#if canCreateContainerConnection(provider) || canCreateKubernetesConnection(provider)}
                   {@const providerDisplayName =
                     (provider.containerProviderConnectionCreation
                       ? provider.containerProviderConnectionCreationDisplayName || undefined

--- a/packages/renderer/src/lib/preferences/Util.ts
+++ b/packages/renderer/src/lib/preferences/Util.ts
@@ -76,3 +76,19 @@ export function getNormalizedDefaultNumberValue(configurationKey: IConfiguration
   }
   return configurationKey.maximum;
 }
+
+export function canCreateContainerConnection(providerInfo: ProviderInfo): boolean {
+  return (
+    providerInfo.containerProviderConnectionCreation &&
+    providerInfo.status != 'not-installed' &&
+    providerInfo.status != 'error'
+  );
+}
+
+export function canCreateKubernetesConnection(providerInfo: ProviderInfo): boolean {
+  return (
+    providerInfo.kubernetesProviderConnectionCreation &&
+    providerInfo.status != 'not-installed' &&
+    providerInfo.status != 'error'
+  );
+}


### PR DESCRIPTION
### What does this PR do?

Prevent Create Podman machine to be displayed if Podman is not installed

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

Fixes #2553

### How to test this PR?

1. Uninstall Podman
2. Launch Podman Desktop
3. Go to the resource pages --> No more Create Podman machine