### PR TITLE
fix: error message when HttpProxyAgent creation fails mention 'https proxy agent'

### DIFF
--- a/packages/main/src/plugin/image-registry.ts
+++ b/packages/main/src/plugin/image-registry.ts
@@ -335,7 +335,7 @@ export class ImageRegistry {
             proxy: httpProxyUrl,
           });
         } catch (error) {
-          throw new Error(`Failed to create https proxy agent from ${httpProxyUrl}: ${error}`);
+          throw new Error(`Failed to create http proxy agent from ${httpProxyUrl}: ${error}`);
         }
       }
       if (httpsProxyUrl) {


### PR DESCRIPTION
### What does this PR do?

Updated message to mention correct `http proxy agent` instead of `https proxy agent`.

### Screenshot/screencast of this PR

n/a

### What issues does this PR fix or reference?

n/a

### How to test this PR?

n/a