### PR TITLE
feat: show warnings on pod creation and two containers use the same port (#2240)

### DIFF
--- a/packages/renderer/src/lib/container/ContainerInfoUI.ts
+++ b/packages/renderer/src/lib/container/ContainerInfoUI.ts
@@ -16,6 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { Port } from '@podman-desktop/api';
+
 // type of groups
 export enum ContainerGroupInfoTypeUI {
   STANDALONE = 'standalone',
@@ -51,7 +53,7 @@ export interface ContainerInfoUI {
   state: string;
   uptime: string;
   startedAt: string;
-  ports: number[];
+  ports: Port[];
   portsAsString: string;
   displayPort: string;
   command: string;

--- a/packages/renderer/src/lib/container/container-utils.ts
+++ b/packages/renderer/src/lib/container/container-utils.ts
@@ -22,6 +22,7 @@ import { ContainerGroupInfoTypeUI } from './ContainerInfoUI';
 import moment from 'moment';
 import humanizeDuration from 'humanize-duration';
 import { filesize } from 'filesize';
+import type { Port } from '@podman-desktop/api';
 export class ContainerUtils {
   getName(containerInfo: ContainerInfo) {
     // part of a compose ?
@@ -77,12 +78,12 @@ export class ContainerUtils {
     return image;
   }
 
-  getPorts(containerInfo: ContainerInfo): number[] {
-    return containerInfo.Ports?.filter(port => port.PublicPort).map(port => port.PublicPort) || [];
+  getPorts(containerInfo: ContainerInfo): Port[] {
+    return containerInfo.Ports?.filter(port => port.PublicPort).map(port => port) || [];
   }
 
   getDisplayPort(containerInfo: ContainerInfo): string {
-    const ports = this.getPorts(containerInfo);
+    const ports = this.getPorts(containerInfo).map(port => port.PublicPort);
     if (ports.length === 0) {
       return '';
     }
@@ -208,7 +209,7 @@ export class ContainerUtils {
   }
 
   getPortsAsString(containerInfo: ContainerInfo): string {
-    const ports = this.getPorts(containerInfo);
+    const ports = this.getPorts(containerInfo).map(port => port.PublicPort);
     if (ports.length > 1) {
       return `${ports.join(', ')}`;
     } else if (ports.length === 1) {

--- a/packages/renderer/src/lib/pod/PodCreateFromContainers.spec.ts
+++ b/packages/renderer/src/lib/pod/PodCreateFromContainers.spec.ts
@@ -62,7 +62,45 @@ const podCreation: PodCreation = {
       engineId: 'podman',
       id: 'id',
       name: 'cont_1',
-      ports: [9090, 8080],
+      ports: [
+        {
+          PublicPort: 9090,
+          IP: 'ip',
+          PrivatePort: 80,
+          Type: 'type',
+        },
+        {
+          PublicPort: 8080,
+          IP: 'ip',
+          PrivatePort: 81,
+          Type: 'type',
+        },
+      ],
+    },
+  ],
+  name: 'pod',
+};
+
+const podCreationSamePortContainers: PodCreation = {
+  containers: [
+    {
+      engineId: 'podman',
+      id: 'id',
+      name: 'cont_1',
+      ports: [
+        {
+          PublicPort: 9090,
+          IP: 'ip',
+          PrivatePort: 80,
+          Type: 'type',
+        },
+        {
+          PublicPort: 8080,
+          IP: 'ip',
+          PrivatePort: 80,
+          Type: 'type',
+        },
+      ],
     },
   ],
   name: 'pod',
@@ -204,4 +242,13 @@ test('Show error if pod creation fails', async () => {
 
   const exposedPortsLabel = await screen.findByText('error create pod');
   expect(exposedPortsLabel).toBeInTheDocument();
+});
+
+test('Show warning if multiple containers use the same port', async () => {
+  providerInfos.set([providerInfo]);
+  podCreationHolder.set(podCreationSamePortContainers);
+
+  render(PodCreateFromContainers, {});
+  const warningLabel = await screen.findByLabelText('warning');
+  expect(warningLabel).toBeInTheDocument();
 });

--- a/packages/renderer/src/lib/pod/PodCreateFromContainers.spec.ts
+++ b/packages/renderer/src/lib/pod/PodCreateFromContainers.spec.ts
@@ -252,3 +252,12 @@ test('Show warning if multiple containers use the same port', async () => {
   const warningLabel = await screen.findByLabelText('warning');
   expect(warningLabel).toBeInTheDocument();
 });
+
+test('Do not show warning if multiple containers use different ports', async () => {
+  providerInfos.set([providerInfo]);
+  podCreationHolder.set(podCreation);
+
+  render(PodCreateFromContainers, {});
+  const warningLabel = screen.queryByLabelText('warning');
+  expect(warningLabel).not.toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/pod/PodCreateFromContainers.svelte
+++ b/packages/renderer/src/lib/pod/PodCreateFromContainers.svelte
@@ -133,6 +133,7 @@ onMount(() => {
     mapPortPrivate.forEach((value, key) => {
       if (value.length < 2) {
         mapPortPrivate.delete(key);
+        return;
       }
       const indexContainersItem = getIndexSameContainersItems(value);
       if (indexContainersItem !== undefined) {

--- a/packages/renderer/src/stores/creation-from-containers-store.ts
+++ b/packages/renderer/src/stores/creation-from-containers-store.ts
@@ -16,6 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { Port } from '@podman-desktop/api';
 import type { Writable } from 'svelte/store';
 import { writable } from 'svelte/store';
 
@@ -23,7 +24,7 @@ export interface PodCreationContainer {
   id: string;
   name: string;
   engineId: string;
-  ports: number[];
+  ports: Port[];
 }
 
 export interface PodCreation {


### PR DESCRIPTION
### What does this PR do?

This PR proposes a way to guide users in case they try to create a pod with multiple containers and two or more of them use the same port

### Screenshot/screencast of this PR

![same-port-containers](https://github.com/containers/podman-desktop/assets/49404737/22fa98da-278f-4658-94cc-9e6be6081c4b)

### What issues does this PR fix or reference?

it resolves #2240 

### How to test this PR?

1. select two containers using the same port
2. create a pod from them
3. in the create pod page you should see the warning
