### PR TITLE
chore(tests): Improve e2e test to handle welcome page and telemetry

### DIFF
--- a/tests/src/e2e.spec.ts
+++ b/tests/src/e2e.spec.ts
@@ -1,13 +1,12 @@
 import type { BrowserWindow } from 'electron';
 import type { ElectronApplication, JSHandle, Page } from 'playwright';
 import { _electron as electron } from 'playwright';
-import { afterAll, beforeAll, expect, test } from 'vitest';
+import { afterAll, beforeAll, expect, test, describe } from 'vitest';
 import { expect as playExpect } from '@playwright/test';
 import { existsSync } from 'node:fs';
 import { rm } from 'node:fs/promises';
 
 let electronApp: ElectronApplication;
-
 let page: Page;
 
 beforeAll(async () => {
@@ -35,53 +34,68 @@ afterAll(async () => {
   await electronApp.close();
 });
 
-test('Check welcome page is displayed and that we are redirected to the main page where dashboard page is there', async () => {
-  // Direct Electron console to Node terminal.
-  page.on('console', console.log);
+describe('Basic e2e verification of podman desktop start', async () => {
+  test('Check the Welcome page is displayed', async () => {
+    // Direct Electron console to Node terminal.
+    page.on('console', console.log);
 
-  const window: JSHandle<BrowserWindow> = await electronApp.browserWindow(page);
+    const window: JSHandle<BrowserWindow> = await electronApp.browserWindow(page);
 
-  const windowState = await window.evaluate(
-    (mainWindow): Promise<{ isVisible: boolean; isDevToolsOpened: boolean; isCrashed: boolean }> => {
-      const getState = () => ({
-        isVisible: mainWindow.isVisible(),
-        isDevToolsOpened: mainWindow.webContents.isDevToolsOpened(),
-        isCrashed: mainWindow.webContents.isCrashed(),
-      });
+    const windowState = await window.evaluate(
+      (mainWindow): Promise<{ isVisible: boolean; isDevToolsOpened: boolean; isCrashed: boolean }> => {
+        const getState = () => ({
+          isVisible: mainWindow.isVisible(),
+          isDevToolsOpened: mainWindow.webContents.isDevToolsOpened(),
+          isCrashed: mainWindow.webContents.isCrashed(),
+        });
 
-      return new Promise(resolve => {
-        /**
-         * The main window is created hidden, and is shown only when it is ready.
-         * See {@link ../packages/main/src/mainWindow.ts} function
-         */
-        if (mainWindow.isVisible()) {
-          resolve(getState());
-        } else mainWindow.once('ready-to-show', () => resolve(getState()));
-      });
-    },
-  );
+        return new Promise(resolve => {
+          /**
+           * The main window is created hidden, and is shown only when it is ready.
+           * See {@link ../packages/main/src/mainWindow.ts} function
+           */
+          if (mainWindow.isVisible()) {
+            resolve(getState());
+          } else mainWindow.once('ready-to-show', () => resolve(getState()));
+        });
+      },
+    );
+    expect(windowState.isCrashed, 'The app has crashed').toBeFalsy();
+    expect(windowState.isVisible, 'The main window was not visible').toBeTruthy();
 
-  await page.screenshot({ path: 'tests/output/screenshots/screenshot-welcome-page-init.png', fullPage: true });
+    await page.screenshot({ path: 'tests/output/screenshots/screenshot-welcome-page-init.png', fullPage: true });
 
-  // wait for the initial screen to be loaded
-  const goToPodmanDesktopButton = page.locator('button:text("Go to Podman Desktop")');
-  // wait for visibility
-  await goToPodmanDesktopButton.waitFor({ state: 'visible' });
-
-  await page.screenshot({ path: 'tests/output/screenshots/screenshot-welcome-page-display.png', fullPage: true });
-
-  // click on the button
-  await goToPodmanDesktopButton.click();
-
-  await page.screenshot({
-    path: 'tests/output/screenshots/screenshot-welcome-page-redirect-to-dashboard.png',
-    fullPage: true,
+    const welcomeMessage = page.locator('text=/Welcome to Podman Desktop.*/');
+    await playExpect(welcomeMessage).toBeVisible();
   });
 
-  // check we have the dashboard page
-  const dashboardTitle = page.getByRole('heading', { name: 'Dashboard' });
-  await playExpect(dashboardTitle).toBeVisible();
+  test('Telemetry checkbox is present, set to true, consent can be changed', async () => {
+    // wait for the initial screen to be loaded
+    const telemetryConsent = page.getByText('Telemetry');
+    expect(telemetryConsent).not.undefined;
+    expect(await telemetryConsent.isChecked()).to.be.true;
 
-  expect(windowState.isCrashed, 'The app has crashed').toBeFalsy();
-  expect(windowState.isVisible, 'The main window was not visible').toBeTruthy();
+    await telemetryConsent.click();
+    expect(await telemetryConsent.isChecked()).to.be.false;
+  });
+
+  test('Redirection from Welcome page to Dashboard works', async () => {
+    const goToPodmanDesktopButton = page.locator('button:text("Go to Podman Desktop")');
+    // wait for visibility
+    await goToPodmanDesktopButton.waitFor({ state: 'visible' });
+
+    await page.screenshot({ path: 'tests/output/screenshots/screenshot-welcome-page-display.png', fullPage: true });
+
+    // click on the button
+    await goToPodmanDesktopButton.click();
+
+    await page.screenshot({
+      path: 'tests/output/screenshots/screenshot-welcome-page-redirect-to-dashboard.png',
+      fullPage: true,
+    });
+
+    // check we have the dashboard page
+    const dashboardTitle = page.getByRole('heading', { name: 'Dashboard' });
+    await playExpect(dashboardTitle).toBeVisible();
+  });
 });


### PR DESCRIPTION
### What does this PR do?
Improve e2e test case into more logical units
 - verifies welcome page was opened on application start up
 - telemetry default value is correct and can be changed
 - welcome page can be closed and redirects into dashboard

### Screenshot/screencast of this PR
Something like this:
```
 ❯ tests/src/e2e.spec.ts (3)
   ❯ Basic e2e verification of podman desktop start (3)
     ✓ Check the Welcome page is displayed 761ms
     ✓ Telemetry checkbox is present, set to true, consent can be changed
     ✓ Redirection from Welcome page to Dashboard works
 ✓ tests/src/e2e.spec.ts (3) 3242ms

 Test Files  1 passed (1)
      Tests  3 passed (3)
   Start at  20:37:31
   Duration  4.75s (transform 50ms, setup 0ms, collect 239ms, tests 3.24s, environment 302ms, prepare 102ms)

Done in 5.33s.
```

GHA e2e smoke run shows:
![Screenshot_20230614_204223](https://github.com/containers/podman-desktop/assets/19164299/aba5f9e6-aa0b-44c8-9a62-375d692f8650)

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?
fixes #1474 
<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

### How to test this PR?
remove `~/.local/share/containers/podman-desktop/configuration/settings.json`
`yarn test:e2e:smoke`
<!-- Please explain steps to reproduce -->
