### PR TITLE
feat: Select engine for Lima provider

### DIFF
--- a/extensions/lima/package.json
+++ b/extensions/lima/package.json
@@ -16,7 +16,26 @@
         "command": "docker.info",
         "title": "Lima: Specific info about Lima"
       }
-    ]
+    ],
+    "configuration": {
+      "title": "Lima",
+      "properties": {
+        "lima.type": {
+          "type": "string",
+          "default": "podman",
+          "enum": [
+            "podman",
+            "docker"
+          ],
+          "description": "Engine type (requires restart of extension)"
+        },
+        "lima.name": {
+          "type": "string",
+          "default": "",
+          "description": "Instance name (default is same name as type)"
+        }
+      }
+    }
   },
   "scripts": {
     "build": "tsc && node ./scripts/build.js",

--- a/extensions/lima/src/extension.ts
+++ b/extensions/lima/src/extension.ts
@@ -21,15 +21,18 @@ import * as path from 'path';
 import * as os from 'os';
 import * as fs from 'fs';
 
+import { configuration } from '@podman-desktop/api';
+
 function registerProvider(
   extensionContext: extensionApi.ExtensionContext,
   provider: extensionApi.Provider,
   providerSocketPath: string,
 ): void {
   let providerState: extensionApi.ProviderConnectionStatus = 'unknown';
+  const providerType: 'docker' | 'podman' = configuration.getConfiguration('lima').get('type');
   const containerProviderConnection: extensionApi.ContainerProviderConnection = {
     name: 'Lima',
-    type: 'podman',
+    type: providerType,
     status: () => providerState,
     endpoint: {
       socketPath: providerSocketPath,
@@ -43,7 +46,10 @@ function registerProvider(
 }
 
 export async function activate(extensionContext: extensionApi.ExtensionContext): Promise<void> {
-  const socketPath = path.resolve(os.homedir(), '.lima/podman/sock/podman.sock');
+  const engineType = configuration.getConfiguration('lima').get('type') || 'podman';
+  const instanceName = configuration.getConfiguration('lima').get('name') || engineType;
+  const limaHome = os.homedir(); // TODO: look for the LIMA_HOME environment variable
+  const socketPath = path.resolve(limaHome, '.lima/' + instanceName + '/sock/' + engineType + '.sock');
 
   let provider;
   if (fs.existsSync(socketPath)) {


### PR DESCRIPTION
Choose between podman and docker, for engine type

Also allow overriding the default instance name

### What does this PR do?

Adds the opportunity to change the engine for Lima, from Podman to Docker, or to override the instance name.

Previously both were hardcoded to "podman", so it was not possible to use another engine or any other name.

### Screenshot/screencast of this PR

![pd-preferences-lima-type](https://github.com/containers/podman-desktop/assets/10364051/0a6a293b-b18e-4222-9c40-abd6c114d464)

### What issues does this PR fix or reference?

* #2593

### How to test this PR?

Start the docker instance, `limactl start template://docker`

Change the preferences for Lima, to engine type "docker"

Restart the extension (stop and start), to change the connection

Check that the containers and images are now from docker.lima