### PR TITLE
fix: handle path with spaces on kind installation (#2653)

### DIFF
--- a/extensions/kind/src/util.ts
+++ b/extensions/kind/src/util.ts
@@ -193,7 +193,7 @@ export async function installBinaryToSystem(binaryPath: string, binaryName: stri
   let command: string[];
   if (system == 'win32') {
     destinationPath = path.join(os.homedir(), 'AppData', 'Local', 'Microsoft', 'WindowsApps', `${binaryName}.exe`);
-    command = ['copy', binaryPath, destinationPath];
+    command = ['copy', `"${binaryPath}"`, `"${destinationPath}"`];
   } else {
     destinationPath = path.join('/usr/local/bin', binaryName);
     command = ['cp', binaryPath, destinationPath];


### PR DESCRIPTION
### What does this PR do?

This PR handles paths with spaces so to avoid an error when installing kind

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

it resolves #2653 

### How to test this PR?

1. on windows work with a user containing a space
2. install kind
