### PR TITLE
feat: Show the Lima instance name

### DIFF
--- a/extensions/lima/src/extension.ts
+++ b/extensions/lima/src/extension.ts
@@ -70,8 +70,14 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
 
   if (fs.existsSync(socketPath)) {
     registerProvider(extensionContext, provider, socketPath);
+    const information: extensionApi.ProviderInformation = {
+      symbol: '🛈',
+      name: 'Instance name',
+      details: instanceName as string,
+    };
+    provider.updateWarnings([information]);
   } else {
-    console.error(`Could not find podman socket at ${socketPath}`);
+    console.error(`Could not find ${engineType} socket at ${socketPath}`);
   }
 }
 

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -157,8 +157,10 @@ declare module '@podman-desktop/api' {
   }
 
   // For displaying essential information to the user
+  // "symbol" for the symbol to precede the message, like warning or information
   // "name" of the warning / title and a "details" field for more information
   export interface ProviderInformation {
+    symbol?: string;
     name: string;
     details?: string;
   }

--- a/packages/renderer/src/lib/dashboard/ProviderWarnings.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderWarnings.svelte
@@ -18,7 +18,7 @@ $: {
     {#each providerInfo.warnings as warn}
       <div class="flex-row items-center align-middle mt-0.5">
         <!-- Make line height center-->
-        <span class="ml-1 text-md text-gray-700">⚠</span>
+        <span class="ml-1 text-md text-gray-700">{warn.symbol || '⚠'}</span>
         <span class="ml-1 text-sm text-gray-700">{warn.name}:</span>
         <span class="ml-1 text-sm text-gray-700">{warn.details}</span>
       </div>


### PR DESCRIPTION
### What does this PR do?

Shows the current lima instance, usually it is just "podman" - but if you have overridden it could be "centos-stream"

The UI will just show the containers/images/volumes as "Lima", but can be useful to know which engine is being used

### Screenshot/screencast of this PR

![pd-lima-instance-name](https://github.com/containers/podman-desktop/assets/10364051/cdb5cbe6-c730-449b-917a-f3af1b0ee569)

### What issues does this PR fix or reference?

* #2593

### How to test this PR?

Either use the "docker" type, or set up some custom instance with podman on a different OS through the YAML

The name of the currently used Lima instance, should show up as information on the Podman Desktop dashboard.

----

You can export an environment variable, to interact with it (using the `lima` program) on the command line:

```console
$ export LIMA_INSTANCE=podman
$ lima
```

Or to run podman commands from the terminal, to the same instance shown in the Podman Desktop GUI:

```console
$ export LIMA_INSTANCE=podman
$ podman.lima
```