### PR TITLE
feat: show info when wsl distro not found to recreate podman machine (#2276)

### DIFF
--- a/extensions/podman/src/extension.spec.ts
+++ b/extensions/podman/src/extension.spec.ts
@@ -31,6 +31,40 @@ const config: Configuration = {
   update: () => Promise.resolve(),
 };
 
+const provider: extensionApi.Provider = {
+  setContainerProviderConnectionFactory: vi.fn(),
+  setKubernetesProviderConnectionFactory: vi.fn(),
+  registerContainerProviderConnection: vi.fn(),
+  registerKubernetesProviderConnection: vi.fn(),
+  registerLifecycle: vi.fn(),
+  registerInstallation: vi.fn(),
+  registerUpdate: vi.fn(),
+  registerAutostart: vi.fn(),
+  dispose: vi.fn(),
+  name: '',
+  id: '',
+  status: 'started',
+  updateStatus: vi.fn(),
+  onDidUpdateStatus: undefined,
+  version: '',
+  updateVersion: vi.fn(),
+  onDidUpdateVersion: undefined,
+  images: undefined,
+  links: [],
+  detectionChecks: [],
+  updateDetectionChecks: vi.fn(),
+  warnings: [],
+  updateWarnings: vi.fn(),
+  onDidUpdateDetectionChecks: undefined,
+};
+
+const machineInfo: extension.MachineInfo = {
+  cpus: 1,
+  diskSize: 1000000,
+  memory: 10000000,
+  name: 'name',
+};
+
 vi.mock('@podman-desktop/api', async () => {
   return {
     configuration: {
@@ -135,4 +169,65 @@ test('checkDefaultMachine: do not prompt if the running machine is already the d
 
   await extension.checkDefaultMachine(fakeJSON);
   expect(extensionApi.window.showInformationMessage).not.toHaveBeenCalled();
+});
+
+test('if a machine is successfully started it changes its state to started', async () => {
+  const spyUpdateStatus = vi.spyOn(provider, 'updateStatus');
+  spyUpdateStatus.mockImplementation(() => {
+    return;
+  });
+
+  const spyExecPromise = vi.spyOn(podmanCli, 'execPromise');
+  spyExecPromise.mockImplementation(() => {
+    return Promise.resolve('');
+  });
+  await extension.startMachine(provider, machineInfo);
+
+  expect(spyExecPromise).toBeCalledWith(getPodmanCli(), ['machine', 'start', 'name'], {
+    logger: undefined,
+  });
+
+  expect(spyUpdateStatus).toBeCalledWith('started');
+});
+
+test('if a machine failed to start with a generic error, this is thrown', async () => {
+  const spyExecPromise = vi.spyOn(podmanCli, 'execPromise');
+  spyExecPromise.mockImplementation(() => {
+    return Promise.reject(new Error('generic error'));
+  });
+  try {
+    await extension.startMachine(provider, machineInfo);
+  } catch (e) {
+    expect(e.message).equal('generic error');
+  }
+});
+
+test('if a machine failed to start with a wsl distro not found error, the user is asked what to do', async () => {
+  const spyExecPromise = vi.spyOn(podmanCli, 'execPromise');
+  spyExecPromise.mockImplementation(() => {
+    return Promise.reject(new Error('wsl bootstrap script failed: exit status 0xffffffff'));
+  });
+  try {
+    await extension.startMachine(provider, machineInfo);
+  } catch (e) {
+    expect(extensionApi.window.showInformationMessage).toBeCalledWith(
+      "Error while starting Podman Machine 'name'. The WSL bootstrap script failed: exist status 0xffffffff. The machine is probably broken and should be deleted and reinitialized. Do you want to recreate it?",
+      'Yes',
+      'Cancel',
+    );
+    expect(e.message).equal('wsl bootstrap script failed: exit status 0xffffffff');
+  }
+});
+
+test('if a machine failed to start with a wsl distro not found error but the skipHandleError is false, the error is thrown', async () => {
+  const spyExecPromise = vi.spyOn(podmanCli, 'execPromise');
+  spyExecPromise.mockImplementation(() => {
+    return Promise.reject(new Error('wsl bootstrap script failed: exit status 0xffffffff'));
+  });
+  try {
+    await extension.startMachine(provider, machineInfo, undefined, true);
+  } catch (e) {
+    expect(extensionApi.window.showInformationMessage).not.toHaveBeenCalled();
+    expect(e.message).equal('wsl bootstrap script failed: exit status 0xffffffff');
+  }
 });

--- a/extensions/podman/src/extension.spec.ts
+++ b/extensions/podman/src/extension.spec.ts
@@ -211,7 +211,7 @@ test('if a machine failed to start with a wsl distro not found error, the user i
     await extension.startMachine(provider, machineInfo);
   } catch (e) {
     expect(extensionApi.window.showInformationMessage).toBeCalledWith(
-      "Error while starting Podman Machine 'name'. The WSL bootstrap script failed: exist status 0xffffffff. The machine is probably broken and should be deleted and reinitialized. Do you want to recreate it?",
+      `Error while starting Podman Machine '${machineInfo.name}'. The WSL bootstrap script failed: exist status 0xffffffff. The machine is probably broken and should be deleted and reinitialized. Do you want to recreate it?`,
       'Yes',
       'Cancel',
     );

--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -70,7 +70,7 @@ export type MachineJSON = {
   Default: boolean;
 };
 
-type MachineInfo = {
+export type MachineInfo = {
   name: string;
   cpus: number;
   memory: number;
@@ -464,7 +464,7 @@ async function registerProviderFor(provider: extensionApi.Provider, machineInfo:
   storedExtensionContext.subscriptions.push(disposable);
 }
 
-async function startMachine(
+export async function startMachine(
   provider: extensionApi.Provider,
   machineInfo: MachineInfo,
   logger?: extensionApi.Logger,
@@ -529,7 +529,7 @@ async function doHandleWSLDistroNotFoundError(
               'podman.factory.machine.diskSize': machineInfo.diskSize,
             },
             undefined,
-          ); // add machine name
+          );
         } catch (error) {
           console.error(error);
         } finally {

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
@@ -48,9 +48,11 @@ onMount(() => {
 
   providersUnsubscribe = providerInfos.subscribe(providerInfosValue => {
     providers = providerInfosValue;
+    const connectionNames = [];
     providers.forEach(provider => {
       provider.containerConnections.forEach(container => {
         const containerConnectionName = getProviderConnectionName(provider, container);
+        connectionNames.push(containerConnectionName);
         // update the map only if the container state is different from last time
         if (
           !containerConnectionStatus.has(containerConnectionName) ||
@@ -76,6 +78,7 @@ onMount(() => {
       });
       provider.kubernetesConnections.forEach(connection => {
         const containerConnectionName = getProviderConnectionName(provider, connection);
+        connectionNames.push(containerConnectionName);
         // update the map only if the container state is different from last time
         if (
           !containerConnectionStatus.has(containerConnectionName) ||
@@ -99,6 +102,12 @@ onMount(() => {
           }
         }
       });
+    });
+    // if a machine has been deleted we need to clean its old stored status
+    containerConnectionStatus.forEach((v, k) => {
+      if (!connectionNames.find(name => name === k)) {
+        containerConnectionStatus.delete(k);
+      }
     });
     if (isStatusUpdated) {
       isStatusUpdated = false;


### PR DESCRIPTION
### What does this PR do?

It shows a warning message if the error wsl distro not found is detected and ask the user if she wants to delete/recreate the podman machine.

### Screenshot/screencast of this PR

When the machine is started when PD is opened 
![init-at-autostart](https://github.com/containers/podman-desktop/assets/49404737/4e14f3f1-ae99-4aea-a5a6-da138e5a1c06)

if the user do not accept to recreate the machine
![cancel-init-at-autostart](https://github.com/containers/podman-desktop/assets/49404737/fb7d3fd7-0a27-4220-b378-a90c39ad6615)

if the machine is started manually
![init-manually](https://github.com/containers/podman-desktop/assets/49404737/e2a7213c-8a5b-4d05-a8bd-d9f9ec62a188)


### What issues does this PR fix or reference?

it resolves #2276 

### How to test this PR?

1. have a machine
2. delete its wsl instance `wsl --unregister <machine-name>`
3. start PD
