### PR TITLE
fix: Can't use locally built latest images on Kubernetes clusters

### DIFF
--- a/packages/renderer/src/lib/pod/DeployPodToKube.spec.ts
+++ b/packages/renderer/src/lib/pod/DeployPodToKube.spec.ts
@@ -190,6 +190,7 @@ test('When deploying a pod, volumes should not be added (they are deleted by pod
           {
             name: 'hello',
             image: 'hello-world',
+            imagePullPolicy: 'IfNotPresent',
           },
         ],
       },
@@ -216,6 +217,7 @@ test('When modifying the pod name, metadata.apps.label should also have been cha
           {
             name: 'hello',
             image: 'hello-world',
+            imagePullPolicy: 'IfNotPresent',
           },
         ],
       },
@@ -245,6 +247,7 @@ test('When deploying a pod, restricted security context is added', async () => {
           {
             name: 'hello',
             image: 'hello-world',
+            imagePullPolicy: 'IfNotPresent',
             securityContext: {
               allowPrivilegeEscalation: false,
               capabilities: {

--- a/packages/renderer/src/lib/pod/DeployPodToKube.svelte
+++ b/packages/renderer/src/lib/pod/DeployPodToKube.svelte
@@ -81,6 +81,7 @@ onMount(async () => {
     container.ports?.forEach((port: any) => {
       containerPortArray.push(port.hostPort);
     });
+    container.imagePullPolicy = 'IfNotPresent';
   });
 });
 


### PR DESCRIPTION
Fixes #2661

### What does this PR do?

Allow to deploy locally built images with latest tag on Kubernetes clusters

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

Fixes #2661 

### How to test this PR?

1. Build a local image using latest tag
2. Push that image to your Kubernetes cluster
3. Deploy that image on the Kubernetes cluster
4. Ensure the pod is running