### PR TITLE
feat: add ability to install docker-compose binary system-wide

### DIFF
--- a/extensions/compose/package.json
+++ b/extensions/compose/package.json
@@ -26,7 +26,8 @@
   "dependencies": {
     "@octokit/rest": "^19.0.11",
     "mustache": "^4.2.0",
-    "shell-path": "^3.0.0"
+    "shell-path": "^3.0.0",
+    "sudo-prompt": "^9.2.1"
   },
   "devDependencies": {
     "7zip-min": "^1.4.3",

--- a/extensions/compose/src/cli-run.spec.ts
+++ b/extensions/compose/src/cli-run.spec.ts
@@ -1,0 +1,55 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { beforeEach, expect, test, vi } from 'vitest';
+import type * as extensionApi from '@podman-desktop/api';
+import type { OS } from './os';
+import { CliRun } from './cli-run';
+
+vi.mock('@podman-desktop/api', async () => {
+  return {
+    window: {
+      showInformationMessage: vi.fn().mockReturnValue(Promise.resolve('Yes')),
+      showErrorMessage: vi.fn(),
+      withProgress: vi.fn(),
+      showNotification: vi.fn(),
+    },
+    ProgressLocation: {
+      APP_ICON: 1,
+    },
+  };
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+test('error: expect installBinaryToSystem to fail with a non existing binary', async () => {
+  // Mock the platform to be linux
+  Object.defineProperty(process, 'platform', {
+    value: 'linux',
+  });
+
+  // Create the CliRun object to call installBinaryToSystem
+  let fakeContext: extensionApi.ExtensionContext;
+  let fakeOs: OS;
+  const cliRun = new CliRun(fakeContext, fakeOs);
+
+  // Expect await installBinaryToSystem to throw an error
+  await expect(cliRun.installBinaryToSystem('test', 'tmpBinary')).rejects.toThrowError();
+});

--- a/extensions/compose/src/cli-run.ts
+++ b/extensions/compose/src/cli-run.ts
@@ -18,6 +18,9 @@
 
 import { spawn } from 'node:child_process';
 import { resolve } from 'node:path';
+import * as path from 'node:path';
+import * as sudo from 'sudo-prompt';
+import * as os from 'node:os';
 import type * as extensionApi from '@podman-desktop/api';
 import type { OS } from './os';
 
@@ -115,5 +118,67 @@ export class CliRun {
         resolve({ exitCode, stdOut, stdErr, error: err });
       });
     });
+  }
+
+  // Takes a binary path (e.g. /tmp/docker-compose) and installs it to the system. Renames it based on binaryName
+  // supports Windows, Linux and macOS
+  // If using Windows or Mac, we will use sudo-prompt in order to elevate the privileges
+  // If using Linux, we'll use pkexec and polkit support to ask for privileges.
+  // When running in a flatpak, we'll use flatpak-spawn to execute the command on the host
+  async installBinaryToSystem(binaryPath: string, binaryName: string): Promise<void> {
+    const system = process.platform;
+
+    // Before copying the file, make sure it's executable (chmod +x) for Linux and Mac
+    if (system === 'linux' || system === 'darwin') {
+      try {
+        await this.runCommand('chmod', ['+x', binaryPath]);
+        console.log(`Made ${binaryPath} executable`);
+      } catch (error) {
+        throw new Error(`Error making binary executable: ${error}`);
+      }
+    }
+
+    // Create the appropriate destination path (Windows uses AppData/Local, Linux and Mac use /usr/local/bin)
+    // and the appropriate command to move the binary to the destination path
+    let destinationPath: string;
+    let command: string[];
+    if (system == 'win32') {
+      destinationPath = path.join(os.homedir(), 'AppData', 'Local', 'Microsoft', 'WindowsApps', `${binaryName}.exe`);
+      command = ['copy', `"${binaryPath}"`, `"${destinationPath}"`];
+    } else {
+      destinationPath = path.join('/usr/local/bin', binaryName);
+      command = ['cp', binaryPath, destinationPath];
+    }
+
+    // If windows or mac, use sudo-prompt to elevate the privileges
+    // if Linux, use sudo and polkit support
+    if (system === 'win32' || system === 'darwin') {
+      return new Promise<void>((resolve, reject) => {
+        // Convert the command array to a string for sudo prompt
+        // the name is used for the prompt
+        const sudoOptions = {
+          name: 'Binary Installation',
+        };
+        const sudoCommand = command.join(' ');
+        sudo.exec(sudoCommand, sudoOptions, error => {
+          if (error) {
+            console.error(`Failed to install '${binaryName}' binary: ${error}`);
+            reject(error);
+          } else {
+            console.log(`Successfully installed '${binaryName}' binary.`);
+            resolve();
+          }
+        });
+      });
+    } else {
+      try {
+        // Use pkexec in order to elevate the prileges / ask for password for copying to /usr/local/bin
+        await this.runCommand('pkexec', command);
+        console.log(`Successfully installed '${binaryName}' binary.`);
+      } catch (error) {
+        console.error(`Failed to install '${binaryName}' binary: ${error}`);
+        throw error;
+      }
+    }
   }
 }


### PR DESCRIPTION
feat: add ability to install docker-compose binary system-wide

### What does this PR do?

* Adds a prompt after installation to local storage directory, if we
  want to install docker-compose system wide.
* Added tests

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

https://github.com/containers/podman-desktop/assets/6422176/80402f15-0402-42d4-af0c-3773e0d0bd17



### What issues does this PR fix or reference?

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

Closes https://github.com/containers/podman-desktop/issues/1974

It does NOT close
https://github.com/containers/podman-desktop/issues/2709 though as the
issue with the "add to $PATH wrapper" still exists

### How to test this PR?

1. Remove your docker-compose binary from
   ~/.local/share/containers/podman-desktop
2. Test the functionality by re-installing compose by clicking the
   button
3. Type `whereis docker-compose` to confirm it has been installed
   system-wide

<!-- Please explain steps to reproduce -->
