### PR TITLE
fix: Unable to do a new build if the previous one failed

### DIFF
--- a/packages/renderer/src/lib/image/BuildImageFromContainerfile.spec.ts
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfile.spec.ts
@@ -1,0 +1,117 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import '@testing-library/jest-dom';
+import { test, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import { providerInfos } from '../../stores/providers';
+import type { ProviderStatus } from '@podman-desktop/api';
+import type { ProviderContainerConnectionInfo } from '../../../../main/src/plugin/api/provider-info';
+import userEvent from '@testing-library/user-event';
+import BuildImageFromContainerfile from '/@/lib/image/BuildImageFromContainerfile.svelte';
+
+// fake the window.events object
+beforeAll(() => {
+  (window.events as unknown) = {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    receive: (_channel: string, func: any) => {
+      func();
+    },
+  };
+  (window as any).getConfigurationValue = vi.fn();
+  (window as any).matchMedia = vi.fn().mockReturnValue({
+    addListener: vi.fn(),
+  });
+  (window as any).openFileDialog = vi.fn().mockResolvedValue({ canceled: false, filePaths: ['Containerfile'] });
+  (window as any).telemetryPage = vi.fn();
+});
+
+// the build image page expects to have a valid provider connection, so let's mock one
+function setup() {
+  const pStatus: ProviderStatus = 'started';
+  const pInfo: ProviderContainerConnectionInfo = {
+    name: 'test',
+    status: 'started',
+    endpoint: {
+      socketPath: '',
+    },
+    type: 'podman',
+  };
+  const providerInfo = {
+    id: 'test',
+    internalId: 'id',
+    name: '',
+    containerConnections: [pInfo],
+    kubernetesConnections: undefined,
+    status: pStatus,
+    containerProviderConnectionCreation: false,
+    containerProviderConnectionInitialization: false,
+    kubernetesProviderConnectionCreation: false,
+    kubernetesProviderConnectionInitialization: false,
+    links: undefined,
+    detectionChecks: undefined,
+    warnings: undefined,
+    images: undefined,
+    installationSupport: undefined,
+  };
+  providerInfos.set([providerInfo]);
+}
+
+test('Expect Build button is disabled', async () => {
+  setup();
+  render(BuildImageFromContainerfile, {});
+
+  const buildButton = screen.getByRole('button', { name: 'Build' });
+  expect(buildButton).toBeInTheDocument();
+  expect(buildButton).toBeDisabled();
+});
+
+test('Expect Build button is enabled', async () => {
+  setup();
+  render(BuildImageFromContainerfile, {});
+
+  const containerFilePath = screen.getByRole('textbox', { name: 'Containerfile path' });
+
+  expect(containerFilePath).toBeInTheDocument();
+  await userEvent.click(containerFilePath);
+
+  const buildButton = screen.getByRole('button', { name: 'Build' });
+  expect(buildButton).toBeInTheDocument();
+  expect(buildButton).toBeEnabled();
+});
+
+test('Expect Done button is enabled once build is done', async () => {
+  setup();
+  render(BuildImageFromContainerfile, {});
+
+  const containerFilePath = screen.getByRole('textbox', { name: 'Containerfile path' });
+
+  expect(containerFilePath).toBeInTheDocument();
+  await userEvent.click(containerFilePath);
+
+  const buildButton = screen.getByRole('button', { name: 'Build' });
+  expect(buildButton).toBeInTheDocument();
+  expect(buildButton).toBeEnabled();
+  await userEvent.click(buildButton);
+
+  const doneButton = screen.getByRole('button', { name: 'Done' });
+  expect(doneButton).toBeInTheDocument();
+  expect(doneButton).toBeEnabled();
+});

--- a/packages/renderer/src/lib/image/build-image-task.spec.ts
+++ b/packages/renderer/src/lib/image/build-image-task.spec.ts
@@ -51,16 +51,16 @@ test('check reconnect', async () => {
   const firstKey = startBuild('foo', dummyCallback);
 
   // stream some stuff
-  eventCollect(firstKey, 'stream', 'hello');
-  eventCollect(firstKey, 'stream', 'world');
+  eventCollect(firstKey.buildImageKey, 'stream', 'hello');
+  eventCollect(firstKey.buildImageKey, 'stream', 'world');
 
-  disconnectUI(firstKey);
+  disconnectUI(firstKey.buildImageKey);
 
   // send event while there is no UI connected
-  eventCollect(firstKey, 'stream', 'during disconnect');
-  eventCollect(firstKey, 'finish', '');
+  eventCollect(firstKey.buildImageKey, 'stream', 'during disconnect');
+  eventCollect(firstKey.buildImageKey, 'finish', '');
 
-  reconnectUI(firstKey, newCallback);
+  reconnectUI(firstKey.buildImageKey, newCallback);
 
   // check that we've replayed everything (including events that happened while there was no UI connected)
   expect(newCallback.onStream).toHaveBeenCalledWith('hello\rworld\rduring disconnect\r');

--- a/packages/renderer/src/lib/image/build-image-task.ts
+++ b/packages/renderer/src/lib/image/build-image-task.ts
@@ -17,7 +17,7 @@
  ***********************************************************************/
 
 import { router } from 'tinro';
-import { buildImagesInfo } from '/@/stores/build-images';
+import { type BuildImageInfo, buildImagesInfo } from '/@/stores/build-images';
 import { createTask, removeTask } from '/@/stores/tasks';
 import type { Task } from '../../../../main/src/plugin/api/task';
 
@@ -59,7 +59,7 @@ const buildReplays = new Map<symbol, BuildReplay>();
 const allTasks = new Map<symbol, Task>();
 
 // new build is occuring, needs to compute a new key and prepare replay data
-export function startBuild(imageName: string, buildImageCallback: BuildImageCallback): symbol {
+export function startBuild(imageName: string, buildImageCallback: BuildImageCallback): BuildImageInfo {
   const key = getKey();
   buildCallbacks.set(key, buildImageCallback);
 
@@ -76,24 +76,24 @@ export function startBuild(imageName: string, buildImageCallback: BuildImageCall
 
   // create a new replay value
   buildReplays.set(key, { stream: '', error: '', end: false });
-  return key;
+  return { buildImageKey: key, buildRunning: true };
 }
 
 // clear all data related to the given build
-export function clearBuildTask(key: symbol): void {
-  buildCallbacks.delete(key);
-  buildOnHolds.delete(key);
-  buildReplays.delete(key);
+export function clearBuildTask(info: BuildImageInfo): void {
+  buildCallbacks.delete(info.buildImageKey);
+  buildOnHolds.delete(info.buildImageKey);
+  buildReplays.delete(info.buildImageKey);
   // remove current build
   buildImagesInfo.set(undefined);
 
   // remove the task
-  const task = allTasks.get(key);
+  const task = allTasks.get(info.buildImageKey);
   if (task) {
     removeTask(task.id);
   }
 
-  allTasks.delete(key);
+  allTasks.delete(info.buildImageKey);
 }
 
 // client is leaving the page, disconnect the UI

--- a/packages/renderer/src/stores/build-images.ts
+++ b/packages/renderer/src/stores/build-images.ts
@@ -19,5 +19,10 @@
 import type { Writable } from 'svelte/store';
 import { writable } from 'svelte/store';
 
+export interface BuildImageInfo {
+  buildImageKey: symbol;
+  buildRunning: boolean;
+}
+
 // current build key
-export const buildImagesInfo: Writable<{ buildImageKey: symbol }> = writable();
+export const buildImagesInfo: Writable<BuildImageInfo> = writable();


### PR DESCRIPTION
### What does this PR do?

Handle errors in the Build from container file page:

- Allow to repeat build operation
- Keep logs of last build until Done is clicked

### Screenshot/screencast of this PR

![build](https://github.com/containers/podman-desktop/assets/695993/7b1fa8b3-3c07-496f-822a-cff58de982a8)

### What issues does this PR fix or reference?

Fixes #2517 

### How to test this PR?

1. Create a wrong Containerfile (FROM dummy)
2. Open the Build from Containerfile
3. Click the Build
4. Go somewhere else
5. Reopen the Build from Containerfile
6. Logs should still be there
7. Click Done
8. Go somewhere else
9. Reopen the Build from Containerfile
10. Logs should not be there anymore