### PR TITLE
nit: add prettierignore for website/build dir

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+website/build/


### PR DESCRIPTION
nit: add prettierignore for website/build dir

### What does this PR do?

* Adds prettierignore for the website build directory, as each time we
  use format:fix or format:check we check the build directory which is
  unecessary.

```
website/blog/2023-05-02-release-0.15.md 20ms
website/blog/2023-05-17-release-1.0.md 27ms
website/build/assets/js/01a85c17.41d48dfc.js 20ms
website/build/assets/js/03ccf92d.f1abd038.js 2ms
website/build/assets/js/059d1c6a.2c296bfa.js 38ms
website/build/assets/js/07f59c2a.742d5d92.js 32ms
website/build/assets/js/09905e74.c5bf8efb.js 19ms
website/build/assets/js/0d040286.4ef398fa.js 1ms
website/build/assets/js/0e384e19.7a5b19a3.js 11ms
website/build/assets/js/12c198af.7569c286.js 2ms
website/build/assets/js/12f1535e.c1bd3a19.js 8ms
website/build/assets/js/14cba94d.f6e60ad6.js 2ms
website/build/assets/js/17896441.8d349880.js 32ms
website/build/assets/js/1947.68058711.js 18ms
website/build/assets/js/1a4e3797.58823d5f.js 152ms
website/build/assets/js/1be78505.0f60c21e.js 24ms
website/build/assets/js/1df93b7f.925f31c4.js 25ms
website/build/assets/js/2ae2e7fe.cdd7459f.js 1ms
website/build/assets/js/2d81b9d5.0bc95205.js 8ms
website/build/assets/js/3289a752.b246610e.js 18ms
website/build/assets/js/3720c009.bd5c4d02.js 7ms
website/build/assets/js/382c5d2b.13840be4.js 1ms
website/build/assets/js/3893.deb4d224.js 4ms
website/build/assets/js/38a042e4.07f5ab2f.js 19ms
website/build/assets/js/3c6cc7c6.ba14e6b5.js 7ms
website/build/assets/js/3e03f778.1a5ca803.js 1ms
website/build/assets/js/3ed6e2e9.19b81e9a.js 1ms
website/build/assets/js/3fed3fa8.c26c79e4.js 8ms
```

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

N/A, see logs

### What issues does this PR fix or reference?

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

N/A

### How to test this PR?

<!-- Please explain steps to reproduce -->

Run `yarn format:fix` and you should no longer see website/build output.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
