### PR TITLE
fix: Use custom checkbox styling

### DIFF
--- a/packages/renderer/src/lib/ContainerList.svelte
+++ b/packages/renderer/src/lib/ContainerList.svelte
@@ -130,7 +130,8 @@ function computeInterval(): number {
   return 60 * 60 * 24 * SECOND;
 }
 
-function toggleCheckboxContainerGroup(value: boolean, containerGroup: ContainerGroupInfoUI) {
+function toggleCheckboxContainerGroup(target: EventTarget, containerGroup: ContainerGroupInfoUI) {
+  const value = (<HTMLInputElement>target).checked;
   // need to apply that on all containers
   containerGroup.containers.forEach(container => (container.selected = value));
 }
@@ -294,7 +295,8 @@ function toggleContainerGroup(containerGroup: ContainerGroupInfoUI) {
   containerGroups = containerGroups.map(group => (group.name === containerGroup.name ? containerGroup : group));
 }
 
-function toggleAllContainerGroups(value: boolean) {
+function toggleAllContainerGroups(target: EventTarget) {
+  const value = (<HTMLInputElement>target).checked;
   const toggleContainers = containerGroups;
   toggleContainers
     .filter(group => group.type !== ContainerGroupInfoTypeUI.STANDALONE)
@@ -384,7 +386,7 @@ function errorCallback(container: ContainerInfoUI, errorMessage: string): void {
             <Checkbox
               bind:checked="{selectedAllCheckboxes}"
               indeterminate="{selectedItemsNumber > 0 && !selectedAllCheckboxes}"
-              on:click="{event => toggleAllContainerGroups(event.currentTarget.checked)}" />
+              on:click="{event => toggleAllContainerGroups(event.currentTarget)}" />
           </th>
           <th class="text-center font-extrabold w-10 px-2">Status</th>
           <th class="w-10">Name</th>
@@ -411,7 +413,7 @@ function errorCallback(container: ContainerInfoUI, errorMessage: string): void {
               <td class="px-2">
                 <Checkbox
                   bind:checked="{containerGroup.selected}"
-                  on:click="{event => toggleCheckboxContainerGroup(event.currentTarget.checked, containerGroup)}" />
+                  on:click="{event => toggleCheckboxContainerGroup(event.currentTarget, containerGroup)}" />
               </td>
               <td class="flex flex-row justify-center h-12" title="{containerGroup.type}">
                 <div class="grid place-content-center ml-3 mr-4">

--- a/packages/renderer/src/lib/ContainerList.svelte
+++ b/packages/renderer/src/lib/ContainerList.svelte
@@ -382,7 +382,7 @@ function errorCallback(container: ContainerInfoUI, errorMessage: string): void {
           <th class="whitespace-nowrap w-5"></th>
           <th class="px-2 w-5">
             <Checkbox
-              bind:selected="{selectedAllCheckboxes}"
+              bind:checked="{selectedAllCheckboxes}"
               indeterminate="{selectedItemsNumber > 0 && !selectedAllCheckboxes}"
               on:click="{event => toggleAllContainerGroups(event.currentTarget.checked)}" />
           </th>
@@ -410,7 +410,7 @@ function errorCallback(container: ContainerInfoUI, errorMessage: string): void {
               </td>
               <td class="px-2">
                 <Checkbox
-                  bind:selected="{containerGroup.selected}"
+                  bind:checked="{containerGroup.selected}"
                   on:click="{event => toggleCheckboxContainerGroup(event.currentTarget.checked, containerGroup)}" />
               </td>
               <td class="flex flex-row justify-center h-12" title="{containerGroup.type}">
@@ -478,7 +478,7 @@ function errorCallback(container: ContainerInfoUI, errorMessage: string): void {
                     : ''}">
                 </td>
                 <td class="px-2">
-                  <Checkbox bind:selected="{container.selected}" />
+                  <Checkbox bind:checked="{container.selected}" />
                 </td>
                 <td class="flex flex-row justify-center h-12">
                   <div class="grid place-content-center ml-3 mr-4">

--- a/packages/renderer/src/lib/ContainerList.svelte
+++ b/packages/renderer/src/lib/ContainerList.svelte
@@ -130,10 +130,9 @@ function computeInterval(): number {
   return 60 * 60 * 24 * SECOND;
 }
 
-function toggleCheckboxContainerGroup(target: EventTarget, containerGroup: ContainerGroupInfoUI) {
-  const value = (<HTMLInputElement>target).checked;
+function toggleCheckboxContainerGroup(checked: boolean, containerGroup: ContainerGroupInfoUI) {
   // need to apply that on all containers
-  containerGroup.containers.forEach(container => (container.selected = value));
+  containerGroup.containers.forEach(container => (container.selected = checked));
 }
 
 // delete the items selected in the list
@@ -295,13 +294,12 @@ function toggleContainerGroup(containerGroup: ContainerGroupInfoUI) {
   containerGroups = containerGroups.map(group => (group.name === containerGroup.name ? containerGroup : group));
 }
 
-function toggleAllContainerGroups(target: EventTarget) {
-  const value = (<HTMLInputElement>target).checked;
+function toggleAllContainerGroups(checked: boolean) {
   const toggleContainers = containerGroups;
   toggleContainers
     .filter(group => group.type !== ContainerGroupInfoTypeUI.STANDALONE)
-    .forEach(group => (group.selected = value));
-  toggleContainers.forEach(group => group.containers.forEach(container => (container.selected = value)));
+    .forEach(group => (group.selected = checked));
+  toggleContainers.forEach(group => group.containers.forEach(container => (container.selected = checked)));
   containerGroups = toggleContainers;
 }
 
@@ -386,7 +384,7 @@ function errorCallback(container: ContainerInfoUI, errorMessage: string): void {
             <Checkbox
               bind:checked="{selectedAllCheckboxes}"
               indeterminate="{selectedItemsNumber > 0 && !selectedAllCheckboxes}"
-              on:click="{event => toggleAllContainerGroups(event.currentTarget)}" />
+              on:click="{event => toggleAllContainerGroups(event.detail)}" />
           </th>
           <th class="text-center font-extrabold w-10 px-2">Status</th>
           <th class="w-10">Name</th>
@@ -413,7 +411,7 @@ function errorCallback(container: ContainerInfoUI, errorMessage: string): void {
               <td class="px-2">
                 <Checkbox
                   bind:checked="{containerGroup.selected}"
-                  on:click="{event => toggleCheckboxContainerGroup(event.currentTarget, containerGroup)}" />
+                  on:click="{event => toggleCheckboxContainerGroup(event.detail, containerGroup)}" />
               </td>
               <td class="flex flex-row justify-center h-12" title="{containerGroup.type}">
                 <div class="grid place-content-center ml-3 mr-4">

--- a/packages/renderer/src/lib/ContainerList.svelte
+++ b/packages/renderer/src/lib/ContainerList.svelte
@@ -26,6 +26,7 @@ import KubePlayButton from './kube/KubePlayButton.svelte';
 import Prune from './engine/Prune.svelte';
 import type { EngineInfoUI } from './engine/EngineInfoUI';
 import { containerGroupsInfo } from '../stores/containerGroups';
+import Checkbox from './ui/Checkbox.svelte';
 
 const containerUtils = new ContainerUtils();
 let openChoiceModal = false;
@@ -379,13 +380,12 @@ function errorCallback(container: ContainerInfoUI, errorMessage: string): void {
       <thead>
         <tr class="h-7 uppercase text-xs text-gray-600">
           <th class="whitespace-nowrap w-5"></th>
-          <th class="px-2 w-5"
-            ><input
-              type="checkbox"
+          <th class="px-2 w-5">
+            <Checkbox
+              bind:selected="{selectedAllCheckboxes}"
               indeterminate="{selectedItemsNumber > 0 && !selectedAllCheckboxes}"
-              bind:checked="{selectedAllCheckboxes}"
-              on:click="{event => toggleAllContainerGroups(event.currentTarget.checked)}"
-              class="cursor-pointer invert hue-rotate-[218deg] brightness-75" /></th>
+              on:click="{event => toggleAllContainerGroups(event.currentTarget.checked)}" />
+          </th>
           <th class="text-center font-extrabold w-10 px-2">Status</th>
           <th class="w-10">Name</th>
           <th>Image</th>
@@ -409,11 +409,9 @@ function errorCallback(container: ContainerInfoUI, errorMessage: string): void {
                   icon="{containerGroup.expanded ? faChevronDown : faChevronRight}" />
               </td>
               <td class="px-2">
-                <input
-                  type="checkbox"
-                  on:click="{event => toggleCheckboxContainerGroup(event.currentTarget.checked, containerGroup)}"
-                  bind:checked="{containerGroup.selected}"
-                  class=" cursor-pointer invert hue-rotate-[218deg] brightness-75" />
+                <Checkbox
+                  bind:selected="{containerGroup.selected}"
+                  on:click="{event => toggleCheckboxContainerGroup(event.currentTarget.checked, containerGroup)}" />
               </td>
               <td class="flex flex-row justify-center h-12" title="{containerGroup.type}">
                 <div class="grid place-content-center ml-3 mr-4">
@@ -480,10 +478,7 @@ function errorCallback(container: ContainerInfoUI, errorMessage: string): void {
                     : ''}">
                 </td>
                 <td class="px-2">
-                  <input
-                    type="checkbox"
-                    bind:checked="{container.selected}"
-                    class="cursor-pointer invert hue-rotate-[218deg] brightness-75" />
+                  <Checkbox bind:selected="{container.selected}" />
                 </td>
                 <td class="flex flex-row justify-center h-12">
                   <div class="grid place-content-center ml-3 mr-4">

--- a/packages/renderer/src/lib/ImagesList.svelte
+++ b/packages/renderer/src/lib/ImagesList.svelte
@@ -22,6 +22,7 @@ import Prune from './engine/Prune.svelte';
 import type { EngineInfoUI } from './engine/EngineInfoUI';
 import type { Menu } from '../../../main/src/plugin/menu-registry';
 import { MenuContext } from '../../../main/src/plugin/menu-registry';
+import Checkbox from './ui/Checkbox.svelte';
 
 let searchTerm = '';
 $: searchPattern.set(searchTerm);
@@ -46,7 +47,7 @@ $: providerConnections = $providerInfos
 $: selectedItemsNumber = images.filter(image => image.selected).length;
 
 // do we need to unselect all checkboxes if we don't have all items being selected ?
-$: selectedAllCheckboxes = images.filter(image => !image.inUse).every(image => image.selected);
+$: selectedAllCheckboxes = images.every(image => image.selected);
 
 let allChecked = false;
 const imageUtils = new ImageUtils();
@@ -276,12 +277,11 @@ function computeInterval(): number {
         <tr class="h-7 uppercase text-xs text-gray-600">
           <th class="whitespace-nowrap w-5"></th>
           <th class="px-2 w-5">
-            <input
-              type="checkbox"
+            <Checkbox
+              bind:selected="{allChecked}"
               indeterminate="{selectedItemsNumber > 0 && !selectedAllCheckboxes}"
-              bind:checked="{allChecked}"
-              on:click="{event => toggleAllImages(event.currentTarget.checked)}"
-              class="cursor-pointer invert hue-rotate-[218deg] brightness-75" /></th>
+              on:click="{event => toggleAllImages(event.currentTarget.checked)}" />
+          </th>
           <th class="text-center font-extrabold w-10 px-2">status</th>
           <th class="w-10">Name</th>
           <th class="px-6 whitespace-nowrap w-10">age</th>
@@ -294,15 +294,10 @@ function computeInterval(): number {
           <tr class="group h-12 bg-charcoal-800 hover:bg-zinc-700">
             <td class="rounded-tl-lg rounded-bl-lg w-5"> </td>
             <td class="px-2">
-              <input
-                type="checkbox"
-                bind:checked="{image.selected}"
+              <Checkbox
+                bind:selected="{image.selected}"
                 disabled="{image.inUse}"
-                class:cursor-pointer="{!image.inUse}"
-                class:cursor-not-allowed="{image.inUse}"
-                class:opacity-10="{image.inUse}"
-                title="{image.inUse ? 'Image is used by a container' : ''}"
-                class=" invert hue-rotate-[218deg] brightness-75" />
+                disabledTooltip="Image is used by a container" />
             </td>
             <td class="bg-charcoal-800 group-hover:bg-zinc-700 flex flex-row justify-center content-center h-12">
               <div class="grid place-content-center ml-3 mr-4">

--- a/packages/renderer/src/lib/ImagesList.svelte
+++ b/packages/renderer/src/lib/ImagesList.svelte
@@ -143,7 +143,8 @@ function openDetailsImage(image: ImageInfoUI) {
   router.goto(`/images/${image.id}/${image.engineId}/${image.base64RepoTag}/summary`);
 }
 
-function toggleAllImages(value: boolean) {
+function toggleAllImages(target: EventTarget) {
+  const value = (<HTMLInputElement>target).checked;
   const toggleImages = images;
   // filter out all images used by a container
   toggleImages.filter(image => !image.inUse).forEach(image => (image.selected = value));
@@ -280,7 +281,7 @@ function computeInterval(): number {
             <Checkbox
               bind:checked="{allChecked}"
               indeterminate="{selectedItemsNumber > 0 && !selectedAllCheckboxes}"
-              on:click="{event => toggleAllImages(event.currentTarget.checked)}" />
+              on:click="{event => toggleAllImages(event.currentTarget)}" />
           </th>
           <th class="text-center font-extrabold w-10 px-2">status</th>
           <th class="w-10">Name</th>

--- a/packages/renderer/src/lib/ImagesList.svelte
+++ b/packages/renderer/src/lib/ImagesList.svelte
@@ -278,7 +278,7 @@ function computeInterval(): number {
           <th class="whitespace-nowrap w-5"></th>
           <th class="px-2 w-5">
             <Checkbox
-              bind:selected="{allChecked}"
+              bind:checked="{allChecked}"
               indeterminate="{selectedItemsNumber > 0 && !selectedAllCheckboxes}"
               on:click="{event => toggleAllImages(event.currentTarget.checked)}" />
           </th>
@@ -295,7 +295,7 @@ function computeInterval(): number {
             <td class="rounded-tl-lg rounded-bl-lg w-5"> </td>
             <td class="px-2">
               <Checkbox
-                bind:selected="{image.selected}"
+                bind:checked="{image.selected}"
                 disabled="{image.inUse}"
                 disabledTooltip="Image is used by a container" />
             </td>

--- a/packages/renderer/src/lib/ImagesList.svelte
+++ b/packages/renderer/src/lib/ImagesList.svelte
@@ -44,12 +44,11 @@ $: providerConnections = $providerInfos
   .filter(providerContainerConnection => providerContainerConnection.status === 'started');
 
 // number of selected items in the list
-$: selectedItemsNumber = images.filter(image => image.selected).length;
+$: selectedItemsNumber = images.filter(image => !image.inUse).filter(image => image.selected).length;
 
 // do we need to unselect all checkboxes if we don't have all items being selected ?
-$: selectedAllCheckboxes = images.every(image => image.selected);
+$: selectedAllCheckboxes = images.filter(image => !image.inUse).every(image => image.selected);
 
-let allChecked = false;
 const imageUtils = new ImageUtils();
 
 function updateImages() {
@@ -279,7 +278,7 @@ function computeInterval(): number {
           <th class="whitespace-nowrap w-5"></th>
           <th class="px-2 w-5">
             <Checkbox
-              bind:checked="{allChecked}"
+              bind:checked="{selectedAllCheckboxes}"
               indeterminate="{selectedItemsNumber > 0 && !selectedAllCheckboxes}"
               on:click="{event => toggleAllImages(event.currentTarget)}" />
           </th>

--- a/packages/renderer/src/lib/ImagesList.svelte
+++ b/packages/renderer/src/lib/ImagesList.svelte
@@ -142,11 +142,10 @@ function openDetailsImage(image: ImageInfoUI) {
   router.goto(`/images/${image.id}/${image.engineId}/${image.base64RepoTag}/summary`);
 }
 
-function toggleAllImages(target: EventTarget) {
-  const value = (<HTMLInputElement>target).checked;
+function toggleAllImages(checked: boolean) {
   const toggleImages = images;
   // filter out all images used by a container
-  toggleImages.filter(image => !image.inUse).forEach(image => (image.selected = value));
+  toggleImages.filter(image => !image.inUse).forEach(image => (image.selected = checked));
   images = toggleImages;
 }
 
@@ -280,7 +279,7 @@ function computeInterval(): number {
             <Checkbox
               bind:checked="{selectedAllCheckboxes}"
               indeterminate="{selectedItemsNumber > 0 && !selectedAllCheckboxes}"
-              on:click="{event => toggleAllImages(event.currentTarget)}" />
+              on:click="{event => toggleAllImages(event.detail)}" />
           </th>
           <th class="text-center font-extrabold w-10 px-2">status</th>
           <th class="w-10">Name</th>

--- a/packages/renderer/src/lib/pod/PodsList.svelte
+++ b/packages/renderer/src/lib/pod/PodsList.svelte
@@ -244,7 +244,7 @@ function errorCallback(pod: PodInfoUI, errorMessage: string): void {
           <th class="whitespace-nowrap w-5"></th>
           <th class="px-2 w-5">
             <Checkbox
-              bind:selected="{allChecked}"
+              bind:checked="{allChecked}"
               indeterminate="{selectedItemsNumber > 0 && !selectedAllCheckboxes}"
               on:click="{event => toggleAllPods(event.currentTarget.checked)}" />
           </th>
@@ -259,7 +259,7 @@ function errorCallback(pod: PodInfoUI, errorMessage: string): void {
           <tr class="group h-12 bg-charcoal-800 hover:bg-zinc-700">
             <td class="rounded-tl-lg rounded-bl-lg w-5"> </td>
             <td class="px-2">
-              <Checkbox bind:selected="{pod.selected}" />
+              <Checkbox bind:checked="{pod.selected}" />
             </td>
             <td class="bg-charcoal-800 group-hover:bg-zinc-700 flex flex-row justify-center h-12">
               <div class="grid place-content-center ml-3 mr-4">

--- a/packages/renderer/src/lib/pod/PodsList.svelte
+++ b/packages/renderer/src/lib/pod/PodsList.svelte
@@ -93,8 +93,7 @@ onDestroy(() => {
   }
 });
 
-function toggleAllPods(target: EventTarget) {
-  const checked = (<HTMLInputElement>target).checked;
+function toggleAllPods(checked: boolean) {
   const togglePods = pods;
   togglePods.forEach(pod => (pod.selected = checked));
   pods = togglePods;
@@ -244,7 +243,7 @@ function errorCallback(pod: PodInfoUI, errorMessage: string): void {
             <Checkbox
               bind:checked="{selectedAllCheckboxes}"
               indeterminate="{selectedItemsNumber > 0 && !selectedAllCheckboxes}"
-              on:click="{event => toggleAllPods(event.currentTarget)}" />
+              on:click="{checked => toggleAllPods(checked.detail)}" />
           </th>
           <th class="text-center font-extrabold w-10 px-2">Status</th>
           <th>Name</th>

--- a/packages/renderer/src/lib/pod/PodsList.svelte
+++ b/packages/renderer/src/lib/pod/PodsList.svelte
@@ -22,6 +22,7 @@ import { faExclamationCircle } from '@fortawesome/free-solid-svg-icons';
 import Prune from '../engine/Prune.svelte';
 import type { EngineInfoUI } from '../engine/EngineInfoUI';
 import ErrorMessage from '../ui/ErrorMessage.svelte';
+import Checkbox from '../ui/Checkbox.svelte';
 
 let searchTerm = '';
 $: searchPattern.set(searchTerm);
@@ -241,13 +242,12 @@ function errorCallback(pod: PodInfoUI, errorMessage: string): void {
       <thead>
         <tr class="h-7 uppercase text-xs text-gray-600">
           <th class="whitespace-nowrap w-5"></th>
-          <th class="px-2 w-5"
-            ><input
-              type="checkbox"
+          <th class="px-2 w-5">
+            <Checkbox
+              bind:selected="{allChecked}"
               indeterminate="{selectedItemsNumber > 0 && !selectedAllCheckboxes}"
-              bind:checked="{allChecked}"
-              on:click="{event => toggleAllPods(event.currentTarget.checked)}"
-              class="cursor-pointer invert hue-rotate-[218deg] brightness-75" /></th>
+              on:click="{event => toggleAllPods(event.currentTarget.checked)}" />
+          </th>
           <th class="text-center font-extrabold w-10 px-2">Status</th>
           <th>Name</th>
           <th class="whitespace-nowrap px-6">age</th>
@@ -259,10 +259,7 @@ function errorCallback(pod: PodInfoUI, errorMessage: string): void {
           <tr class="group h-12 bg-charcoal-800 hover:bg-zinc-700">
             <td class="rounded-tl-lg rounded-bl-lg w-5"> </td>
             <td class="px-2">
-              <input
-                type="checkbox"
-                bind:checked="{pod.selected}"
-                class="cursor-pointer invert hue-rotate-[218deg] brightness-75" />
+              <Checkbox bind:selected="{pod.selected}" />
             </td>
             <td class="bg-charcoal-800 group-hover:bg-zinc-700 flex flex-row justify-center h-12">
               <div class="grid place-content-center ml-3 mr-4">

--- a/packages/renderer/src/lib/pod/PodsList.svelte
+++ b/packages/renderer/src/lib/pod/PodsList.svelte
@@ -48,8 +48,6 @@ $: selectedItemsNumber = pods.filter(pod => pod.selected).length;
 // do we need to unselect all checkboxes if we don't have all items being selected ?
 $: selectedAllCheckboxes = pods.every(pod => pod.selected);
 
-let allChecked = false;
-
 const podUtils = new PodUtils();
 
 let podsUnsubscribe: Unsubscriber;
@@ -244,7 +242,7 @@ function errorCallback(pod: PodInfoUI, errorMessage: string): void {
           <th class="whitespace-nowrap w-5"></th>
           <th class="px-2 w-5">
             <Checkbox
-              bind:checked="{allChecked}"
+              bind:checked="{selectedAllCheckboxes}"
               indeterminate="{selectedItemsNumber > 0 && !selectedAllCheckboxes}"
               on:click="{event => toggleAllPods(event.currentTarget)}" />
           </th>

--- a/packages/renderer/src/lib/pod/PodsList.svelte
+++ b/packages/renderer/src/lib/pod/PodsList.svelte
@@ -95,10 +95,10 @@ onDestroy(() => {
   }
 });
 
-function toggleAllPods(value: boolean) {
+function toggleAllPods(target: EventTarget) {
+  const checked = (<HTMLInputElement>target).checked;
   const togglePods = pods;
-  // filter out all images used by a container
-  togglePods.forEach(pod => (pod.selected = value));
+  togglePods.forEach(pod => (pod.selected = checked));
   pods = togglePods;
 }
 
@@ -246,7 +246,7 @@ function errorCallback(pod: PodInfoUI, errorMessage: string): void {
             <Checkbox
               bind:checked="{allChecked}"
               indeterminate="{selectedItemsNumber > 0 && !selectedAllCheckboxes}"
-              on:click="{event => toggleAllPods(event.currentTarget.checked)}" />
+              on:click="{event => toggleAllPods(event.currentTarget)}" />
           </th>
           <th class="text-center font-extrabold w-10 px-2">Status</th>
           <th>Name</th>

--- a/packages/renderer/src/lib/ui/Checkbox.svelte
+++ b/packages/renderer/src/lib/ui/Checkbox.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import Fa from 'svelte-fa/src/fa.svelte';
+import { createEventDispatcher } from 'svelte';
 import { faCheckSquare, faMinusSquare, faSquare } from '@fortawesome/free-solid-svg-icons';
 import { faSquare as faOutlineSquare } from '@fortawesome/free-regular-svg-icons';
 
@@ -7,6 +8,12 @@ export let checked: boolean = false;
 export let disabled: boolean = false;
 export let indeterminate: boolean = false;
 export let disabledTooltip: string = '';
+
+const dispatch = createEventDispatcher<{ click: boolean }>();
+
+function onClick(checked: boolean) {
+  dispatch('click', checked);
+}
 </script>
 
 <label>
@@ -16,7 +23,7 @@ export let disabledTooltip: string = '';
     disabled="{disabled}"
     indeterminate="{indeterminate}"
     class="sr-only"
-    on:click />
+    on:click="{event => onClick(event.currentTarget.checked)}" />
   <div
     class="grid place-content-center"
     title="{disabled ? disabledTooltip : ''}"

--- a/packages/renderer/src/lib/ui/Checkbox.svelte
+++ b/packages/renderer/src/lib/ui/Checkbox.svelte
@@ -3,7 +3,7 @@ import Fa from 'svelte-fa/src/fa.svelte';
 import { faCheckSquare, faMinusSquare, faSquare } from '@fortawesome/free-solid-svg-icons';
 import { faSquare as faOutlineSquare } from '@fortawesome/free-regular-svg-icons';
 
-export let selected: boolean = false;
+export let checked: boolean = false;
 export let disabled: boolean = false;
 export let indeterminate: boolean = false;
 export let disabledTooltip: string = '';
@@ -12,7 +12,7 @@ export let disabledTooltip: string = '';
 <label>
   <input
     type="checkbox"
-    bind:checked="{selected}"
+    bind:checked="{checked}"
     disabled="{disabled}"
     indeterminate="{indeterminate}"
     class="sr-only"
@@ -26,7 +26,7 @@ export let disabledTooltip: string = '';
       <Fa size="18" icon="{faSquare}" class="text-charcoal-300" />
     {:else if indeterminate}
       <Fa size="18" icon="{faMinusSquare}" class="text-dustypurple-500" />
-    {:else if selected}
+    {:else if checked}
       <Fa size="18" icon="{faCheckSquare}" class="text-purple-500" />
     {:else}
       <Fa size="18" icon="{faOutlineSquare}" class="text-gray-400" />

--- a/packages/renderer/src/lib/ui/Checkbox.svelte
+++ b/packages/renderer/src/lib/ui/Checkbox.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+import Fa from 'svelte-fa/src/fa.svelte';
+import { faCheckSquare, faMinusSquare, faSquare } from '@fortawesome/free-solid-svg-icons';
+import { faSquare as faOutlineSquare } from '@fortawesome/free-regular-svg-icons';
+
+export let selected: boolean = false;
+export let disabled: boolean = false;
+export let indeterminate: boolean = false;
+export let disabledTooltip: string = '';
+</script>
+
+<label>
+  <input
+    type="checkbox"
+    bind:checked="{selected}"
+    disabled="{disabled}"
+    indeterminate="{indeterminate}"
+    class="sr-only"
+    on:click />
+  <div
+    class="grid place-content-center"
+    title="{disabled ? disabledTooltip : ''}"
+    class:cursor-pointer="{!disabled}"
+    class:cursor-not-allowed="{disabled}">
+    {#if disabled}
+      <Fa size="18" icon="{faSquare}" class="text-charcoal-300" />
+    {:else if indeterminate}
+      <Fa size="18" icon="{faMinusSquare}" class="text-dustypurple-500" />
+    {:else if selected}
+      <Fa size="18" icon="{faCheckSquare}" class="text-purple-500" />
+    {:else}
+      <Fa size="18" icon="{faOutlineSquare}" class="text-gray-400" />
+    {/if}
+  </div>
+</label>

--- a/packages/renderer/src/lib/volume/VolumesList.svelte
+++ b/packages/renderer/src/lib/volume/VolumesList.svelte
@@ -115,11 +115,10 @@ onDestroy(() => {
   }
 });
 
-function toggleAllVolumes(target: EventTarget) {
-  const value = (<HTMLInputElement>target).checked;
+function toggleAllVolumes(checked: boolean) {
   const toggleVolumes = volumes;
   // filter out all volumes used by a container
-  toggleVolumes.filter(volume => !volume.inUse).forEach(volume => (volume.selected = value));
+  toggleVolumes.filter(volume => !volume.inUse).forEach(volume => (volume.selected = checked));
   volumes = toggleVolumes;
 }
 
@@ -237,7 +236,7 @@ function computeInterval(): number {
             <Checkbox
               bind:checked="{selectedAllCheckboxes}"
               indeterminate="{selectedItemsNumber > 0 && !selectedAllCheckboxes}"
-              on:click="{event => toggleAllVolumes(event.currentTarget)}" />
+              on:click="{event => toggleAllVolumes(event.detail)}" />
           </th>
           <th class="text-center font-extrabold w-10 px-2">status</th>
           <th class="w-10">Name</th>

--- a/packages/renderer/src/lib/volume/VolumesList.svelte
+++ b/packages/renderer/src/lib/volume/VolumesList.svelte
@@ -236,7 +236,7 @@ function computeInterval(): number {
           <th class="whitespace-nowrap w-5"></th>
           <th class="px-2 w-5">
             <Checkbox
-              bind:selected="{allChecked}"
+              bind:checked="{allChecked}"
               indeterminate="{selectedItemsNumber > 0 && !selectedAllCheckboxes}"
               on:click="{event => toggleAllVolumes(event.currentTarget.checked)}" />
           </th>
@@ -253,7 +253,7 @@ function computeInterval(): number {
             <td class="rounded-tl-lg rounded-bl-lg w-5"> </td>
             <td class="px-2">
               <Checkbox
-                bind:selected="{volume.selected}"
+                bind:checked="{volume.selected}"
                 disabled="{volume.inUse}"
                 disabledTooltip="Volume is used by a container" />
             </td>

--- a/packages/renderer/src/lib/volume/VolumesList.svelte
+++ b/packages/renderer/src/lib/volume/VolumesList.svelte
@@ -32,12 +32,10 @@ $: providerConnections = $providerInfos
   .filter(providerContainerConnection => providerContainerConnection.status === 'started');
 
 // number of selected items in the list
-$: selectedItemsNumber = volumes.filter(volume => volume.selected).length;
+$: selectedItemsNumber = volumes.filter(volume => !volume.inUse).filter(volume => volume.selected).length;
 
 // do we need to unselect all checkboxes if we don't have all items being selected ?
-$: selectedAllCheckboxes = volumes.every(volume => volume.selected);
-
-let allChecked = false;
+$: selectedAllCheckboxes = volumes.filter(volume => !volume.inUse).every(volume => volume.selected);
 
 const volumeUtils = new VolumeUtils();
 
@@ -237,7 +235,7 @@ function computeInterval(): number {
           <th class="whitespace-nowrap w-5"></th>
           <th class="px-2 w-5">
             <Checkbox
-              bind:checked="{allChecked}"
+              bind:checked="{selectedAllCheckboxes}"
               indeterminate="{selectedItemsNumber > 0 && !selectedAllCheckboxes}"
               on:click="{event => toggleAllVolumes(event.currentTarget)}" />
           </th>

--- a/packages/renderer/src/lib/volume/VolumesList.svelte
+++ b/packages/renderer/src/lib/volume/VolumesList.svelte
@@ -17,6 +17,7 @@ import Prune from '../engine/Prune.svelte';
 import moment from 'moment';
 import type { EngineInfoUI } from '../engine/EngineInfoUI';
 import EmptyScreen from '../ui/EmptyScreen.svelte';
+import Checkbox from '../ui/Checkbox.svelte';
 
 let searchTerm = '';
 $: searchPattern.set(searchTerm);
@@ -233,13 +234,12 @@ function computeInterval(): number {
       <thead>
         <tr class="h-7 uppercase text-xs text-gray-600">
           <th class="whitespace-nowrap w-5"></th>
-          <th class="px-2 w-5"
-            ><input
-              type="checkbox"
+          <th class="px-2 w-5">
+            <Checkbox
+              bind:selected="{allChecked}"
               indeterminate="{selectedItemsNumber > 0 && !selectedAllCheckboxes}"
-              bind:checked="{allChecked}"
-              on:click="{event => toggleAllVolumes(event.currentTarget.checked)}"
-              class="cursor-pointer invert hue-rotate-[218deg] brightness-75" /></th>
+              on:click="{event => toggleAllVolumes(event.currentTarget.checked)}" />
+          </th>
           <th class="text-center font-extrabold w-10 px-2">status</th>
           <th class="w-10">Name</th>
           <th class="px-6 whitespace-nowrap">age</th>
@@ -252,15 +252,10 @@ function computeInterval(): number {
           <tr class="group h-12 bg-charcoal-800 hover:bg-zinc-700">
             <td class="rounded-tl-lg rounded-bl-lg w-5"> </td>
             <td class="px-2">
-              <input
-                type="checkbox"
-                bind:checked="{volume.selected}"
+              <Checkbox
+                bind:selected="{volume.selected}"
                 disabled="{volume.inUse}"
-                class:cursor-pointer="{!volume.inUse}"
-                class:cursor-not-allowed="{volume.inUse}"
-                class:opacity-10="{volume.inUse}"
-                title="{volume.inUse ? 'Volume is used by a container' : ''}"
-                class="cursor-pointer invert hue-rotate-[218deg] brightness-75" />
+                disabledTooltip="Volume is used by a container" />
             </td>
             <td class="bg-charcoal-800 group-hover:bg-zinc-700 flex flex-row justify-center h-12">
               <div class="grid place-content-center ml-3 mr-4">

--- a/packages/renderer/src/lib/volume/VolumesList.svelte
+++ b/packages/renderer/src/lib/volume/VolumesList.svelte
@@ -117,7 +117,8 @@ onDestroy(() => {
   }
 });
 
-function toggleAllVolumes(value: boolean) {
+function toggleAllVolumes(target: EventTarget) {
+  const value = (<HTMLInputElement>target).checked;
   const toggleVolumes = volumes;
   // filter out all volumes used by a container
   toggleVolumes.filter(volume => !volume.inUse).forEach(volume => (volume.selected = value));
@@ -238,7 +239,7 @@ function computeInterval(): number {
             <Checkbox
               bind:checked="{allChecked}"
               indeterminate="{selectedItemsNumber > 0 && !selectedAllCheckboxes}"
-              on:click="{event => toggleAllVolumes(event.currentTarget.checked)}" />
+              on:click="{event => toggleAllVolumes(event.currentTarget)}" />
           </th>
           <th class="text-center font-extrabold w-10 px-2">status</th>
           <th class="w-10">Name</th>


### PR DESCRIPTION
### What does this PR do?

Uses a custom checkbox with FA icons to replace standard input checkboxes. This allows us to change the styling and avoid being too similar with the Stop button, plus the styling is now in one place.

Fixed one minor bug where the image list was different from other lists: the header would never show the intermediate state when there are images that can't be deleted, since they were not being considered in selectedAllCheckboxes.

I have only replaced the checkboxes in the main lists and have not tried to replace all checkboxes (e.g. when deploying pod to Kube). If we like this styling then we should likely follow up via another PR to make everything consistent.

### Screenshot/screencast of this PR

https://github.com/containers/podman-desktop/assets/19958075/f2bc5b63-cd64-42cd-878b-64eea0edf5a3

### What issues does this PR fix or reference?

Fixes #2458.

### How to test this PR?

Open all four lists and select individual and header checkboxes to make sure there is no regression.