### PR TITLE
chore: add missing fields that are in the catalog of extensions online

### DIFF
--- a/packages/main/src/plugin/extensions-catalog/extensions-catalog-api.ts
+++ b/packages/main/src/plugin/extensions-catalog/extensions-catalog-api.ts
@@ -40,4 +40,10 @@ interface CatalogExtensionVersion {
   version: string;
   ociUri: string;
   preview: boolean;
+  files: CatalogExtensionVersionFile[];
+}
+
+interface CatalogExtensionVersionFile {
+  assetType: 'icon' | 'LICENSE' | 'README';
+  data: string;
 }

--- a/packages/main/src/plugin/extensions-catalog/extensions-catalog.spec.ts
+++ b/packages/main/src/plugin/extensions-catalog/extensions-catalog.spec.ts
@@ -27,6 +27,11 @@ import type { ProxySettings } from '@podman-desktop/api';
 
 let extensionsCatalog: ExtensionsCatalog;
 
+const fooAssetIcon = {
+  assetType: 'icon',
+  data: 'fooIcon',
+};
+
 const fakePublishedExtension1 = {
   publisher: {
     publisherName: 'foo',
@@ -42,6 +47,7 @@ const fakePublishedExtension1 = {
       preview: false,
       lastUpdated: '2021-01-01T00:00:00.000Z',
       ociUri: 'oci-registry.foo/foo/bar',
+      files: [fooAssetIcon],
     },
   ],
 };
@@ -160,6 +166,7 @@ test('should get all extensions', async () => {
     ociUri: 'oci-registry.foo/foo/bar',
     preview: false,
     version: '1.0.0',
+    files: [fooAssetIcon],
   });
   // no error
   expect(console.error).not.toBeCalled();

--- a/packages/main/src/plugin/extensions-catalog/extensions-catalog.ts
+++ b/packages/main/src/plugin/extensions-catalog/extensions-catalog.ts
@@ -98,6 +98,7 @@ export class ExtensionsCatalog {
               version: version.version,
               preview: version.preview,
               ociUri: version.ociUri,
+              files: version.files,
             };
           }),
         };
@@ -211,6 +212,12 @@ interface InternalCatalogExtensionVersionJSON {
   version: string;
   ociUri: string;
   preview: boolean;
+  files: InternalCatalogExtensionVersionFileJSON[];
+}
+
+interface InternalCatalogExtensionVersionFileJSON {
+  assetType: 'icon' | 'LICENSE' | 'README';
+  data: string;
 }
 
 interface InternalCatalogJSON {

--- a/packages/main/src/plugin/extensions-updater/extensions-updater.spec.ts
+++ b/packages/main/src/plugin/extensions-updater/extensions-updater.spec.ts
@@ -40,6 +40,7 @@ const catalogExtension1: CatalogExtension = {
       version: '2.0.0',
       preview: false,
       ociUri: 'oci-registry.foo/foo/bar1',
+      files: [],
     },
   ],
 };
@@ -54,6 +55,7 @@ const catalogExtension2: CatalogExtension = {
       version: '4.0.0',
       preview: false,
       ociUri: 'oci-registry.foo/foo/bar2',
+      files: [],
     },
   ],
 };


### PR DESCRIPTION

### What does this PR do?
some fields were not exposed in the API of Podman Desktop but they are on https://registry.podman-desktop.io/api/extensions.json

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

#2316 

### How to test this PR?

N/A


Change-Id: Iee402ea70d4ef7488c429f4df1d0f325cb878f71
