### PR TITLE
fix: make Markdown rendering working for headings and lists

### DIFF
--- a/packages/renderer/src/lib/markdown/Markdown.svelte
+++ b/packages/renderer/src/lib/markdown/Markdown.svelte
@@ -1,6 +1,27 @@
 <style>
 .markdown > :global(p) {
+  line-height: revert;
   padding-bottom: 8px;
+  margin-bottom: 8px;
+}
+
+.markdown > :global(h1),
+:global(h2),
+:global(h3),
+:global(h4),
+:global(h5) {
+  font-size: revert;
+  line-height: normal;
+  font-weight: revert;
+  border-bottom: 1px solid #444;
+  margin-bottom: 20px;
+}
+
+.markdown > :global(ul) {
+  line-height: normal;
+  list-style: revert;
+  margin: revert;
+  padding: revert;
 }
 </style>
 
@@ -16,6 +37,14 @@ let html;
 // Optional attribute to specify the markdown to use
 // the user can use: <Markdown>**bold</Markdown> or <Markdown markdown="**bold**" /> syntax
 export let markdown = '';
+
+$: markdown
+  ? (html = micromark(markdown, {
+      extensions: [directive()],
+      htmlExtensions: [directiveHtml({ button })],
+    }))
+  : undefined;
+
 onMount(() => {
   if (markdown) {
     text = markdown;


### PR DESCRIPTION
### What does this PR do?
tailwind and patternfly reset some styles so it looks pretty bad
Here we apply again (revert) some styles for headings and lists

### Screenshot/screencast of this PR

Before:
![image](https://github.com/containers/podman-desktop/assets/436777/6127f9be-e85b-4d2a-a71f-4c2860186813)

After:
![image](https://github.com/containers/podman-desktop/assets/436777/ff0ec344-ec90-42f9-aed3-148b658d18f2)


### What issues does this PR fix or reference?

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

### How to test this PR?

I'm not able to provide a unit or componet test as the Component by itself works
it's when some upper components have patternfly and tailwind included that the style is being resetted.


Replace App.svelte by
```svelte
<script lang="ts">
import './app.css';
import '@patternfly/patternfly/patternfly.css';
import '@patternfly/patternfly/patternfly-addons.css';
import '@patternfly/patternfly/patternfly-theme-dark.css';
import './override.css';

import Markdown from './lib/markdown/Markdown.svelte';
import { onMount } from 'svelte';
let readmeContent = '';

// get the content of the URL and return it using FETCH API
async function fetchReadmeContent(url: string): Promise<void> {
  if (!url) {
    return;
  }
  const response = await fetch(url);
  const data = await response.text();
  readmeContent = data;
}

onMount(() => {
  fetchReadmeContent('https://raw.githubusercontent.com/crc-org/crc-extension/main/README.md');
});
</script>

<div class="bg-charcoal-700 rounded-md mt-4 p-3">
  <Markdown markdown="{readmeContent}" />
</div>


```
(you can swap the markdown file in the onMount directive)



Change-Id: Ie22f34d165f0801e60c0b5291acbfdb36ecadb27
