### PR TITLE
feat: add support for protocol handler 'podman-desktop:'

### DIFF
--- a/.electron-builder.config.cjs
+++ b/.electron-builder.config.cjs
@@ -142,6 +142,11 @@ const config = {
       },
     ],
   },
+  protocols: {
+    name: 'Podman Desktop',
+    schemes: ['podman-desktop'],
+    role: "Editor"
+  },
   publish: {
     provider: 'github',
     timeout: 10000,

--- a/packages/main/src/index.spec.ts
+++ b/packages/main/src/index.spec.ts
@@ -1,0 +1,158 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+import { handleOpenUrl, mainWindowDeferred } from './index';
+import type { BrowserWindow } from 'electron';
+import { Deferred } from './plugin/util/deferred';
+const consoleLogMock = vi.fn();
+const originalConsoleLog = console.log;
+
+/* eslint-disable @typescript-eslint/no-empty-function */
+
+vi.mock('electron-is-dev', async () => {
+  return {};
+});
+vi.mock('electron-context-menu', async () => {
+  return {
+    default: vi.fn(),
+  };
+});
+vi.mock('electron-util', async () => {
+  return {
+    aboutMenuItem: vi.fn(),
+  };
+});
+
+vi.mock('./plugin', async () => {
+  const extensionLoader = {
+    getConfigurationRegistry: vi.fn(),
+  };
+  return {
+    PluginSystem: vi.fn().mockImplementation(() => {
+      return {
+        initExtensions: vi.fn().mockImplementation(() => extensionLoader),
+      };
+    }),
+  };
+});
+
+vi.mock('electron', async () => {
+  class MyCustomWindow {
+    constructor() {}
+
+    loadURL() {}
+    setBounds() {}
+
+    on() {}
+
+    static getAllWindows() {
+      return [];
+    }
+  }
+
+  return {
+    autoUpdater: {
+      on: vi.fn(),
+    },
+
+    screen: {
+      getCursorScreenPoint: vi.fn(),
+      getDisplayNearestPoint: vi.fn().mockImplementation(() => {
+        const workArea = { x: 0, y: 0, width: 0, height: 0 };
+        return { workArea };
+      }),
+    },
+    app: {
+      getAppPath: () => 'a-custom-appPath',
+      getPath: () => 'a-custom-path',
+      disableHardwareAcceleration: vi.fn(),
+      requestSingleInstanceLock: vi.fn().mockReturnValue(true),
+      quit: vi.fn(),
+      on: vi.fn(),
+      once: vi.fn(),
+      whenReady: vi.fn().mockReturnValue(new Promise(() => {})),
+    },
+    ipcMain: {
+      on: vi.fn(),
+      emit: vi.fn(),
+      handle: vi.fn(),
+    },
+    nativeTheme: {
+      on: vi.fn(),
+    },
+    Menu: {
+      buildFromTemplate: vi.fn(),
+      getApplicationMenu: vi.fn(),
+    },
+    BrowserWindow: MyCustomWindow /*{
+      getAllWindows: vi.fn().mockReturnValue([]),
+    },*/,
+    Tray: vi.fn().mockImplementation(() => {
+      return {
+        tray: vi.fn(),
+        setImage: vi.fn(),
+        setToolTip: vi.fn(),
+        setContextMenu: vi.fn(),
+      };
+    }),
+  };
+});
+
+beforeEach(() => {
+  console.log = consoleLogMock;
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  console.log = originalConsoleLog;
+});
+
+test('should send the URL to open when mainWindow is created', async () => {
+  handleOpenUrl('podman-desktop:extension/my.extension');
+
+  const deferredCall = new Deferred<boolean>();
+  const sendMock = vi.fn().mockImplementation(() => {
+    deferredCall.resolve(true);
+  });
+  const fakeWindow = {
+    isDestroyed: vi.fn(),
+    webContents: {
+      send: sendMock,
+    },
+  } as unknown as BrowserWindow;
+
+  mainWindowDeferred.resolve(fakeWindow);
+
+  // wait sendMock being called
+  await deferredCall.promise;
+
+  expect(sendMock).toHaveBeenCalledWith('podman-desktop-protocol:install-extension', 'my.extension');
+});
+
+test('should not send the URL for invalid URLs', async () => {
+  handleOpenUrl('podman-desktop:foobar');
+
+  const sendMock = vi.fn();
+
+  // expect an error
+  expect(consoleLogMock).toHaveBeenCalledWith(
+    'url podman-desktop:foobar does not start with podman-desktop:extension/, skipping.',
+  );
+  expect(sendMock).not.toHaveBeenCalled();
+});

--- a/packages/main/src/index.ts
+++ b/packages/main/src/index.ts
@@ -16,6 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { BrowserWindow } from 'electron';
 import { app, ipcMain, Tray } from 'electron';
 import './security-restrictions';
 import { createNewWindow, restoreWindow } from '/@/mainWindow';
@@ -26,19 +27,73 @@ import { PluginSystem } from './plugin';
 import { StartupInstall } from './system/startup-install';
 import type { ExtensionLoader } from './plugin/extension-loader';
 import dns from 'node:dns';
+import { Deferred } from './plugin/util/deferred';
 
 let extensionLoader: ExtensionLoader | undefined;
+
+type AdditionalData = {
+  argv: string[];
+};
+
+export const mainWindowDeferred = new Deferred<BrowserWindow>();
+
+const argv = process.argv.slice(2);
+const additionalData: AdditionalData = {
+  argv: argv,
+};
+
 /**
  * Prevent multiple instances
  */
-const isSingleInstance = app.requestSingleInstanceLock();
+// provide additional data to the second instance
+const isSingleInstance = app.requestSingleInstanceLock(additionalData);
 if (!isSingleInstance) {
   app.quit();
   process.exit(0);
 }
-app.on('second-instance', () => {
+
+const handleAdditionalProtocolLauncherArgs = (args: ReadonlyArray<string>) => {
+  // On Windows protocol handler will call the app with '<url>' args
+  // on macOS it's done with 'open-url' event
+  if (isWindows()) {
+    // now search if we have 'open-url' in the list of args and give it to the handler
+    for (const arg of args) {
+      if (arg.startsWith('podman-desktop:extension/')) {
+        handleOpenUrl(arg);
+      }
+    }
+  }
+};
+
+export const handleOpenUrl = (url: string) => {
+  // if the url starts with podman-desktop:extension/<id>
+  // we need to install the extension
+  if (!url.startsWith('podman-desktop:extension/')) {
+    console.log(`url ${url} does not start with podman-desktop:extension/, skipping.`);
+    return;
+  }
+  // grab the extension id
+  const extensionId = url.substring('podman-desktop:extension/'.length);
+
+  // wait that the window is ready
+  mainWindowDeferred.promise
+    .then(w => {
+      w.webContents.send('podman-desktop-protocol:install-extension', extensionId);
+    })
+    .catch((error: unknown) => {
+      console.error('Error sending open-url event to webcontents', error);
+    });
+};
+
+// do not use _args as it may contain additional arguments
+app.on('second-instance', (_event, _args, _workingDirectory, additionalData: unknown) => {
+  // if we are on Windows, we need to handle the protocol
+  if (isWindows() && additionalData && (additionalData as AdditionalData).argv) {
+    handleAdditionalProtocolLauncherArgs((additionalData as AdditionalData).argv);
+  }
+
   restoreWindow().catch((error: unknown) => {
-    console.log('Error restoring window', error);
+    console.error('Error restoring window', error);
   });
 });
 
@@ -84,26 +139,47 @@ if (isWindows()) {
 
 let tray: Tray | null = null;
 
+// Handle the open-url event (macOS/Linux). For Windows, it needs to be handle in the second-instance event
+app.on('will-finish-launching', () => {
+  app.on('open-url', (event, url) => {
+    event.preventDefault();
+    // delegate to the handler
+    handleOpenUrl(url);
+  });
+});
+
 app.whenReady().then(
   async () => {
+    if (import.meta.env.PROD) {
+      if (isWindows()) {
+        app.setAsDefaultProtocolClient('podman-desktop', process.execPath, process.argv);
+      } else {
+        app.setAsDefaultProtocolClient('podman-desktop');
+      }
+    }
+
     // We must create the window first before initialization so that we can load the
     // configuration as well as plugins
     // The window is hiddenly created and shown when ready
 
     // Platforms: Linux, macOS, Windows
     // Create the main window
-    createNewWindow().catch((error: unknown) => {
-      console.log('Error creating window', error);
-    });
+    createNewWindow()
+      .then(w => mainWindowDeferred.resolve(w))
+      .catch((error: unknown) => {
+        console.error('Error creating window', error);
+      });
 
     // Platforms: macOS
     // Required for macOS to start the app correctly (this is will be shown in the dock)
     // We use 'activate' within whenReady in order to gracefully start on macOS, see this link:
     // https://www.electronjs.org/docs/latest/tutorial/quick-start#open-a-window-if-none-are-open-macos
     app.on('activate', () => {
-      createNewWindow().catch((error: unknown) => {
-        console.log('Error creating window', error);
-      });
+      createNewWindow()
+        .then(w => mainWindowDeferred.resolve(w))
+        .catch((error: unknown) => {
+          console.log('Error creating window', error);
+        });
     });
 
     // prefer ipv4 over ipv6

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -135,6 +135,11 @@ function initExposure(): void {
     }
   });
 
+  // Handle protocol to install extensions by delegating to the renderer process
+  ipcRenderer.on('podman-desktop-protocol:install-extension', (_, extensionId: string) => {
+    apiSender.send('install-extension:from-id', extensionId);
+  });
+
   contextBridge.exposeInMainWorld('extensionSystemIsReady', async (): Promise<boolean> => {
     return ipcInvoke('extension-system:isReady');
   });

--- a/packages/renderer/src/Loader.spec.ts
+++ b/packages/renderer/src/Loader.spec.ts
@@ -1,0 +1,80 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { expect, test, vi } from 'vitest';
+import Loader from './Loader.svelte';
+import { render } from '@testing-library/svelte';
+import { router } from 'tinro';
+
+// first, patch window object
+const callbacks = new Map<string, any>();
+const eventEmitter = {
+  receive: (message: string, callback: any) => {
+    callbacks.set(message, callback);
+  },
+};
+
+// mock the router
+vi.mock('tinro', () => {
+  return {
+    router: {
+      goto: vi.fn(),
+    },
+  };
+});
+
+Object.defineProperty(global, 'window', {
+  value: {
+    events: {
+      receive: eventEmitter.receive,
+    },
+    addEventListener: eventEmitter.receive,
+  },
+  writable: true,
+});
+
+beforeAll(() => {
+  vi.clearAllMocks();
+});
+
+test('Loader should redirect to the installation page when receiving the event', async () => {
+  const dummyExtensionId = 'my.customExtensionId';
+
+  // rendering the component
+  render(Loader, { props: {} });
+
+  // send the install-extension:from-id event
+  const callbackInstallExtension = callbacks.get('install-extension:from-id');
+  // send 'install-extension:from-id' event
+  expect(callbackInstallExtension).toBeDefined();
+  await callbackInstallExtension(dummyExtensionId);
+
+  // check that we didn't redirect to the installation page as system is not yet ready
+  expect(router.goto).not.toHaveBeenCalled();
+
+  // send the system-ready event
+  const callback = callbacks.get('system-ready');
+  // send 'system-ready' event
+  expect(callback).toBeDefined();
+  await callback();
+
+  // check that we have been redirected
+  expect(router.goto).toHaveBeenCalledWith(`/preferences/extensions/install-from-id/${dummyExtensionId}`);
+});

--- a/packages/renderer/src/Loader.svelte
+++ b/packages/renderer/src/Loader.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-import { onDestroy, onMount } from 'svelte';
+import { onDestroy, onMount, tick } from 'svelte';
+import { router } from 'tinro';
 import App from './App.svelte';
 import SealRocket from './lib/images/SealRocket.svelte';
 
@@ -31,6 +32,25 @@ onMount(async () => {
 onDestroy(() => {
   if (loadingSequence) {
     clearInterval(loadingSequence);
+  }
+});
+
+// receive events from main process to install a new extension
+window.events?.receive('install-extension:from-id', extensionId => {
+  const action = async () => {
+    const redirectPage = `/preferences/extensions/install-from-id/${extensionId}`;
+    // need to open the extension page
+    await tick();
+    router.goto(redirectPage);
+  };
+
+  if (!systemReady) {
+    // need to wait for the system to be ready, so we delay the install
+    window.addEventListener('system-ready', () => {
+      action();
+    });
+  } else {
+    action();
   }
 });
 

--- a/packages/renderer/src/lib/preferences/PreferencesInstallExtensionFromId.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesInstallExtensionFromId.spec.ts
@@ -1,0 +1,163 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import '@testing-library/jest-dom';
+import { beforeAll, test, expect, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import PreferencesInstallExtensionFromId from './PreferencesInstallExtensionFromId.svelte';
+import type { CatalogExtension } from '../../../../main/src/plugin/extensions-catalog/extensions-catalog-api';
+import { catalogExtensionInfos } from '/@/stores/catalog-extensions';
+import { extensionInfos } from '/@/stores/extensions';
+
+const extensionInstallFromImageMock = vi.fn();
+
+// fake the window.events object
+beforeAll(() => {
+  (window as any).extensionInstallFromImage = extensionInstallFromImageMock;
+  (window.events as unknown) = {
+    receive: (_channel: string, func: any) => {
+      func();
+    },
+  };
+});
+
+test('Expect that the EmptyScreen is displayed if extension is not found', async () => {
+  const extensionId = 'my.extension';
+
+  render(PreferencesInstallExtensionFromId, { extensionId });
+
+  // expect to have the empty screen
+  const heading = screen.getByRole('heading', { name: 'Extension not found' });
+  // expect the heading to be there
+  expect(heading).toBeInTheDocument();
+});
+
+test('Expect that the install button is there and can click on it to install', async () => {
+  const extensionId = 'my.extension';
+
+  // mock the catalog
+  const catalogExtensions: CatalogExtension[] = [
+    {
+      id: 'my.extension',
+      extensionName: 'FOOName',
+      displayName: 'foo.bar Extension',
+      publisherName: 'Foo',
+      versions: [
+        {
+          version: '1.0.0',
+          preview: false,
+          ociUri: 'oci://foo/bar:1.0.0',
+          files: [],
+        },
+      ],
+    },
+  ];
+  catalogExtensionInfos.set(catalogExtensions);
+
+  render(PreferencesInstallExtensionFromId, { extensionId });
+
+  // expect to have the button if installable
+  const installButton = screen.getByRole('button', { name: 'Install...' });
+  // expect the button to be there
+  expect(installButton).toBeInTheDocument();
+
+  // mock the install function
+  extensionInstallFromImageMock.mockImplementation(async () => {
+    // need to update extensions being installed
+    extensionInfos.set([
+      {
+        id: 'my.extension',
+        description: 'foo.bar Extension',
+        displayName: 'foo.bar Extension',
+        publisher: 'Foo',
+        name: 'FOOName',
+        removable: true,
+        version: '1.0.0',
+        state: 'installed',
+        path: 'foo-path',
+      },
+    ]);
+  });
+
+  // click on the button
+  await fireEvent.click(installButton);
+
+  // install should have been called
+  expect(extensionInstallFromImageMock).toHaveBeenCalled();
+
+  // now, expect the button to be gone
+  const installButtonAfterClick = screen.queryByRole('button', { name: 'Install...' });
+  expect(installButtonAfterClick).not.toBeInTheDocument();
+
+  // wait for the install to be done
+  await new Promise(r => setTimeout(r, 300));
+
+  // and expect to have 'installed' label
+  const installedLabel = screen.getByText('Installed');
+  expect(installedLabel).toBeInTheDocument();
+});
+
+test('Expect that the installed label is there if extension is already installed', async () => {
+  const extensionId = 'my.extension';
+
+  // mock the catalog
+  const catalogExtensions: CatalogExtension[] = [
+    {
+      id: 'my.extension',
+      extensionName: 'FOOName',
+      displayName: 'foo.bar Extension',
+      publisherName: 'Foo',
+      versions: [
+        {
+          version: '1.0.0',
+          preview: false,
+          ociUri: 'oci://foo/bar:1.0.0',
+          files: [],
+        },
+      ],
+    },
+  ];
+  catalogExtensionInfos.set(catalogExtensions);
+
+  // mock extension being installed
+  extensionInfos.set([
+    {
+      id: 'my.extension',
+      description: 'foo.bar Extension',
+      displayName: 'foo.bar Extension',
+      publisher: 'Foo',
+      name: 'FOOName',
+      removable: true,
+      version: '1.0.0',
+      state: 'installed',
+      path: 'foo-path',
+    },
+  ]);
+
+  render(PreferencesInstallExtensionFromId, { extensionId });
+
+  // now, expect the button to be gone
+  const installButtonAfterClick = screen.queryByRole('button', { name: 'Install...' });
+  expect(installButtonAfterClick).not.toBeInTheDocument();
+
+  // and expect to have 'installed' label
+  const installedLabel = screen.getByText('Installed');
+  expect(installedLabel).toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/preferences/PreferencesInstallExtensionFromId.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesInstallExtensionFromId.svelte
@@ -1,0 +1,199 @@
+<style>
+.progress-bar::-webkit-progress-bar {
+  background-color: #ccc;
+}
+
+.progress-bar::-webkit-progress-value {
+  background-color: currentColor;
+}
+</style>
+
+<script lang="ts">
+import type { CatalogExtension } from '../../../../main/src/plugin/extensions-catalog/extensions-catalog-api';
+import type { ExtensionInfo } from '../../../../main/src/plugin/api/extension-info';
+import type { Unsubscriber } from 'svelte/store';
+
+import { onDestroy, onMount } from 'svelte';
+import SettingsPage from '/@/lib/preferences/SettingsPage.svelte';
+import { catalogExtensionInfos } from '/@/stores/catalog-extensions';
+import EmptyScreen from '/@/lib/ui/EmptyScreen.svelte';
+import { faPuzzlePiece } from '@fortawesome/free-solid-svg-icons';
+import Markdown from '/@/lib/markdown/Markdown.svelte';
+import { extensionInfos } from '/@/stores/extensions';
+import ErrorMessage from '/@/lib/ui/ErrorMessage.svelte';
+
+export let extensionId: string = undefined;
+
+let installedExtensions: ExtensionInfo[] = [];
+let extensionDetails: CatalogExtension = undefined;
+let extensions = [];
+let title;
+let readmeContent = '';
+
+// get the content of the URL and return it using FETCH API
+async function fetchReadmeContent(url: string): Promise<void> {
+  if (!url) {
+    return;
+  }
+  const response = await fetch(url);
+  const data = await response.text();
+  readmeContent = data;
+}
+
+$: extensionDetails = extensions.find(e => e.id === extensionId);
+
+$: title = extensionDetails
+  ? `Installing extension ${extensionDetails.extensionName} from ${extensionDetails.publisherName}...`
+  : `Installing extension with id '${extensionId}'...`;
+$: nonPreviewVersions = extensionDetails ? extensionDetails.versions.filter(v => v.preview === false) : [];
+$: latestVersion = nonPreviewVersions.length > 0 ? nonPreviewVersions[0] : undefined;
+$: latestVersionNumber = latestVersion ? `v${latestVersion.version}` : '';
+$: latestVersionOciLink = latestVersion ? latestVersion.ociUri : undefined;
+$: latestVersionIcon = latestVersion ? latestVersion.files.find(f => f.assetType === 'icon')?.data : undefined;
+$: latestVersionReadme = latestVersion ? latestVersion.files.find(f => f.assetType === 'README')?.data : undefined;
+$: latestVersionReadmeContent = fetchReadmeContent(latestVersionReadme);
+$: isInstalled = installedExtensions.find(e => e.id === extensionId) !== undefined;
+
+let installInProgress = false;
+
+let logs = [];
+let errorInstall = '';
+
+let percentage = 0;
+
+async function installExtension() {
+  if (!latestVersionOciLink) {
+    console.log('no oci link found for this extension');
+    return;
+  }
+
+  console.log('User asked to install the extension', extensionId);
+  logs = [];
+
+  installInProgress = true;
+  errorInstall = '';
+  percentage = 0;
+
+  // do a trim on the image name
+  const ociImage = latestVersionOciLink;
+
+  try {
+    // download image
+    await window.extensionInstallFromImage(
+      ociImage,
+      (data: string) => {
+        logs = [...logs, data];
+        console.log('data', data);
+
+        // try to extract percentage from string like
+        // data Downloading sha256:e8d2c9e5c69499c41ba39b7828c00e55087572884cac466b4d1b47243b085c7d.tar - 11% - (55132/521578)
+        const percentageMatch = data.match(/(\d+)%/);
+        if (percentageMatch) {
+          percentage = parseInt(percentageMatch[1]);
+        }
+      },
+      (error: string) => {
+        console.log(`got an error when installing ${extensionId}`, error);
+        installInProgress = false;
+        errorInstall = error;
+      },
+    );
+    logs = [...logs, '☑️ installation finished !'];
+    percentage = 100;
+  } catch (error) {
+    console.log('error', error);
+  }
+  installInProgress = false;
+}
+
+let subscribeCatalogExtensions: Unsubscriber;
+let subscribeInstalledExtensions: Unsubscriber;
+
+onMount(() => {
+  subscribeInstalledExtensions = extensionInfos.subscribe(e => {
+    installedExtensions = e;
+  });
+
+  subscribeCatalogExtensions = catalogExtensionInfos.subscribe(e => {
+    extensions = e;
+  });
+});
+
+onDestroy(() => {
+  subscribeCatalogExtensions?.();
+  subscribeInstalledExtensions?.();
+});
+</script>
+
+<SettingsPage title="{title}">
+  {#if extensionDetails}
+    <div class="bg-charcoal-600 mt-5 rounded-md p-3">
+      <div class="bg-charcoal-700 rounded-md p-3">
+        <div class="flex flex-row">
+          <div>
+            {#if latestVersionIcon}
+              <img alt="{extensionDetails.extensionName} icon" src="{latestVersionIcon}" class="w-20 h-20 rounded-md" />
+            {/if}
+          </div>
+
+          <div class="flex flex-col ml-2">
+            <div class="text-2xl text-gray-300">
+              {extensionDetails.extensionName}
+              {latestVersionNumber}
+            </div>
+            <div class="text-sm text-gray-300">
+              {extensionDetails.displayName}
+            </div>
+            <div class="flex">
+              {#if installInProgress}
+                <div
+                  class="px-3 my-1 text-sm font-medium text-center text-white bg-violet-600 rounded-sm focus:outline-none cursor-default"
+                  title="Extension {extensionDetails.extensionName} is already installed.">
+                  Installing...
+                </div>
+              {:else if !isInstalled}
+                <button
+                  class="px-3 my-1 text-sm font-medium text-center text-white bg-violet-600 rounded-sm hover:bg-dustypurple-800 focus:ring-2 focus:outline-none focus:ring-dustypurple-700"
+                  title="Install extension {extensionDetails.extensionName}"
+                  on:click="{() => installExtension()}">
+                  Install...
+                </button>
+              {:else}
+                <div
+                  class="px-3 my-1 text-sm font-medium text-center text-white bg-violet-600 rounded-sm focus:outline-none cursor-default"
+                  title="Extension {extensionDetails.extensionName} is already installed.">
+                  Installed
+                </div>
+              {/if}
+            </div>
+          </div>
+        </div>
+        <div class="py-2">
+          {#if installInProgress}
+            <div class="flex flex-row items-center">
+              <progress
+                class="w-full appearance-none border-none h-1 text-violet-700 text-base progress-bar"
+                max="100"
+                value="{percentage}"></progress>
+              <div class="ml-2 text-violet-400">{percentage}%</div>
+            </div>
+          {:else}
+            &nbsp;
+            {#if errorInstall}
+              <ErrorMessage error="{errorInstall}" />
+            {/if}
+          {/if}
+        </div>
+      </div>
+
+      <div class="bg-charcoal-700 rounded-md mt-4 p-3">
+        <Markdown markdown="{readmeContent}" />
+      </div>
+    </div>
+  {:else}
+    <EmptyScreen
+      title="Extension not found"
+      message="Extension with id '{extensionId}' is not available in the catalog"
+      icon="{faPuzzlePiece}" />
+  {/if}
+</SettingsPage>

--- a/packages/renderer/src/lib/preferences/PreferencesPage.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesPage.svelte
@@ -15,6 +15,7 @@ import PreferencesProxiesRendering from './PreferencesProxiesRendering.svelte';
 import PreferencesExtensionList from './PreferencesExtensionList.svelte';
 import PreferencesResourcesRendering from './PreferencesResourcesRendering.svelte';
 import PreferencesAuthenticationProvidersRendering from './PreferencesAuthenticationProvidersRendering.svelte';
+import PreferencesInstallExtensionFromId from './PreferencesInstallExtensionFromId.svelte';
 
 let properties: IConfigurationPropertyRecordedSchema[];
 let defaultPrefPageId: string;
@@ -75,6 +76,10 @@ onMount(async () => {
   </Route>
   <Route path="/extensions" breadcrumb="Extensions">
     <PreferencesExtensionList />
+  </Route>
+
+  <Route path="/extensions/install-from-id/:extensionId" breadcrumb="Install Extension from id" let:meta>
+    <PreferencesInstallExtensionFromId extensionId="{meta.params.extensionId}" />
   </Route>
 
   <Route path="/container-connection/:provider/:connection/*" breadcrumb="Container Engine" let:meta>


### PR DESCRIPTION

### What does this PR do?
Allow to install extensions with
`open podman-desktop:extension/redhat.openshift-local` For example


### Screenshot/screencast of this PR


https://github.com/containers/podman-desktop/assets/436777/b11ad1e4-4c2f-455c-957a-01653d2a93c8



### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop/issues/2316

### How to test this PR?

Open URL like `open podman-desktop:extension/redhat.openshift-local` or `podman-desktop:extension/redhat.redhat-sandbox` or invalid URL like `podman-desktop:extension/my.extension`

Might require to use the binary (not development mode)