### PR TITLE
chore: add aria labels into navigation items

### DIFF
--- a/packages/renderer/src/AppNavigation.spec.ts
+++ b/packages/renderer/src/AppNavigation.spec.ts
@@ -1,0 +1,46 @@
+import '@testing-library/jest-dom';
+import { beforeAll, test, expect } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import AppNavigation from './AppNavigation.svelte';
+
+// fake the window.events object
+beforeAll(() => {
+  (window.events as unknown) = {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    receive: (_channel: string, func: any) => {
+      func();
+    },
+  };
+});
+
+async function waitRender(customProperties: object): Promise<void> {
+  const result = render(AppNavigation, { ...customProperties });
+  // wait that result.component.$$.ctx[2] is set
+  while (result.component.$$.ctx[2] === undefined) {
+    await new Promise(resolve => setTimeout(resolve, 100));
+  }
+}
+
+describe('AppNavigation testing suite', async () => {
+  test('Test rendering of the navigation bar with empty items', async () => {
+    await waitRender({
+      exitSettingsCallback: () => {},
+      meta: {
+        url: '/',
+      },
+    });
+
+    const dasboard = screen.getByRole('link', { name: 'Dashboard' });
+    expect(dasboard).toBeInTheDocument();
+    const containers = screen.getByRole('link', { name: 'Containers' });
+    expect(containers).toBeInTheDocument();
+    const pods = screen.getByRole('link', { name: 'Pods' });
+    expect(pods).toBeInTheDocument();
+    const images = screen.getByRole('link', { name: 'Images' });
+    expect(images).toBeInTheDocument();
+    const volumes = screen.getByRole('link', { name: 'Volumes' });
+    expect(volumes).toBeInTheDocument();
+    const settings = screen.getByRole('link', { name: 'Settings' });
+    expect(settings).toBeInTheDocument();
+  });
+});

--- a/packages/renderer/src/AppNavigation.spec.ts
+++ b/packages/renderer/src/AppNavigation.spec.ts
@@ -13,34 +13,23 @@ beforeAll(() => {
   };
 });
 
-async function waitRender(customProperties: object): Promise<void> {
-  const result = render(AppNavigation, { ...customProperties });
-  // wait that result.component.$$.ctx[2] is set
-  while (result.component.$$.ctx[2] === undefined) {
-    await new Promise(resolve => setTimeout(resolve, 100));
-  }
-}
-
-describe('AppNavigation testing suite', async () => {
-  test('Test rendering of the navigation bar with empty items', async () => {
-    await waitRender({
-      exitSettingsCallback: () => {},
-      meta: {
-        url: '/',
-      },
-    });
-
-    const dasboard = screen.getByRole('link', { name: 'Dashboard' });
-    expect(dasboard).toBeInTheDocument();
-    const containers = screen.getByRole('link', { name: 'Containers' });
-    expect(containers).toBeInTheDocument();
-    const pods = screen.getByRole('link', { name: 'Pods' });
-    expect(pods).toBeInTheDocument();
-    const images = screen.getByRole('link', { name: 'Images' });
-    expect(images).toBeInTheDocument();
-    const volumes = screen.getByRole('link', { name: 'Volumes' });
-    expect(volumes).toBeInTheDocument();
-    const settings = screen.getByRole('link', { name: 'Settings' });
-    expect(settings).toBeInTheDocument();
+test('Test rendering of the navigation bar with empty items', () => {
+  render(AppNavigation, {
+    meta: {
+      url: '/',
+    },
   });
+
+  const dasboard = screen.getByRole('link', { name: 'Dashboard' });
+  expect(dasboard).toBeInTheDocument();
+  const containers = screen.getByRole('link', { name: 'Containers' });
+  expect(containers).toBeInTheDocument();
+  const pods = screen.getByRole('link', { name: 'Pods' });
+  expect(pods).toBeInTheDocument();
+  const images = screen.getByRole('link', { name: 'Images' });
+  expect(images).toBeInTheDocument();
+  const volumes = screen.getByRole('link', { name: 'Volumes' });
+  expect(volumes).toBeInTheDocument();
+  const settings = screen.getByRole('link', { name: 'Settings' });
+  expect(settings).toBeInTheDocument();
 });

--- a/packages/renderer/src/AppNavigation.spec.ts
+++ b/packages/renderer/src/AppNavigation.spec.ts
@@ -1,3 +1,21 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
 import '@testing-library/jest-dom';
 import { beforeAll, test, expect } from 'vitest';
 import { render, screen } from '@testing-library/svelte';

--- a/packages/renderer/src/AppNavigation.svelte
+++ b/packages/renderer/src/AppNavigation.svelte
@@ -98,7 +98,7 @@ export let meta;
       class="pf-c-nav__item flex w-full justify-between {meta.url === '/'
         ? 'pf-m-current'
         : ''} hover:text-gray-400 cursor-pointer items-center mb-6">
-      <a href="/" class="pf-c-nav__link flex">
+      <a href="/" class="pf-c-nav__link flex" aria-label="Dashboard">
         <Tooltip tip="Dashboard" right>
           <div class="flex items-center w-full h-full">
             <svg
@@ -127,7 +127,7 @@ export let meta;
       class="pf-c-nav__item flex w-full justify-between {meta.url.startsWith('/containers')
         ? 'pf-m-current'
         : ''} hover:text-gray-400 cursor-pointer items-center mb-6">
-      <a href="/containers" class="pf-c-nav__link">
+      <a href="/containers" class="pf-c-nav__link" aria-label="Containers">
         <Tooltip tip="Containers{containerCount}" right>
           <div class="flex items-center w-full h-full">
             <ContainerIcon size="24" />
@@ -139,7 +139,7 @@ export let meta;
       class="pf-c-nav__item flex w-full justify-between {meta.url === '/pods'
         ? 'dark:text-white pf-m-current'
         : 'dark:text-gray-700'} hover:text-gray-400 cursor-pointer items-center mb-6">
-      <a href="/pods" class="pf-c-nav__link">
+      <a href="/pods" class="pf-c-nav__link" aria-label="Pods">
         <Tooltip tip="Pods{podCount}" right>
           <div class="flex items-center w-full h-full">
             <PodIcon size="24" />
@@ -151,7 +151,7 @@ export let meta;
       class="pf-c-nav__item flex w-full justify-between {meta.url === '/images'
         ? 'dark:text-white pf-m-current'
         : 'dark:text-gray-700'} hover:text-gray-400 cursor-pointer items-center mb-6">
-      <a href="/images" class="pf-c-nav__link">
+      <a href="/images" class="pf-c-nav__link" aria-label="Images">
         <Tooltip tip="Images{imageCount}" right>
           <div class="flex items-center w-full h-full">
             <ImageIcon size="24" />
@@ -163,7 +163,7 @@ export let meta;
       class="pf-c-nav__item flex w-full justify-between {meta.url === '/volumes'
         ? 'dark:text-white pf-m-current'
         : 'dark:text-gray-700'} hover:text-gray-400 cursor-pointer items-center mb-6">
-      <a href="/volumes" class="pf-c-nav__link flex">
+      <a href="/volumes" class="pf-c-nav__link flex" aria-label="Volumes">
         <Tooltip tip="Volumes{volumeCount}" right>
           <div class="flex items-center w-full h-full">
             <VolumeIcon size="24" />
@@ -179,7 +179,7 @@ export let meta;
         class="pf-c-nav__item flex w-full justify-between {meta.url === '/contribs/{contribution.name}'
           ? 'dark:text-white pf-m-current'
           : 'dark:text-gray-700'} hover:text-gray-400 cursor-pointer items-center mb-6">
-        <a href="/contribs/{contribution.name}" class="pf-c-nav__link">
+        <a href="/contribs/{contribution.name}" class="pf-c-nav__link" aria-label="{contribution.name}">
           <Tooltip tip="{contribution.name}" right>
             <div class="flex items-center w-full h-full">
               <img src="{contribution.icon}" width="24" height="24" alt="{contribution.name}" />
@@ -198,7 +198,8 @@ export let meta;
       <a
         href="#top"
         class="pf-c-nav__link"
-        on:click|preventDefault="{() => clickSettings(meta.url.startsWith('/preferences'))}">
+        on:click|preventDefault="{() => clickSettings(meta.url.startsWith('/preferences'))}"
+        aria-label="Settings">
         <Tooltip tip="Settings" right>
           <div class="flex items-center w-full h-full">
             <svg


### PR DESCRIPTION
### What does this PR do?
Introduces aria labels into navigation bar of the app. so that we do not have to rely on text values when searching for particular DOM elements. Makes it easier to use accessibility tools to work with the app.

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?
#2708 
<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

### How to test this PR?
New test should be part of `yarn test:renderer` npm task.
<!-- Please explain steps to reproduce -->
