### PR TITLE
chore: Remove PatternFly form use

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationRendering.svelte
@@ -351,7 +351,7 @@ async function close() {
       {/if}
 
       <div class="p-3 mt-4 w-4/5 {creationInProgress ? 'opacity-40 pointer-events-none' : ''}">
-        <form novalidate class="pf-c-form p-2" on:submit|preventDefault="{handleOnSubmit}">
+        <form novalidate class="p-2 space-y-7" on:submit|preventDefault="{handleOnSubmit}">
           {#each configurationKeys as configurationKey}
             <div class="mb-2.5">
               <div class="font-semibold text-xs">

--- a/packages/renderer/src/lib/preferences/PreferencesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRendering.svelte
@@ -50,7 +50,7 @@ function updateSearchValue(event: any) {
   <SettingsPage title="Preferences">
     <div class="bg-charcoal-900">
       <div
-        class="flex items-center text-gray-700 rounded-sm rounded-lg focus-within:border-2 focus-within:border-violet-500">
+        class="flex items-center text-gray-700 rounded-sm rounded-lg border-2 border-charcoal-900 focus-within:border-violet-500">
         <input
           on:input="{e => updateSearchValue(e)}"
           class="w-full bg-charcoal-900 py-1 px-3 outline-0 text-sm"

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
@@ -250,7 +250,7 @@ function assertNumericValueIsValid(value: number) {
 </script>
 
 <div class="flex flex-row mb-1 pt-2">
-  <div class="flex flex-col mx-2 text-start w-full justify-center items-start pf-c-form__group-control">
+  <div class="flex flex-col text-start w-full justify-center items-start">
     {#if record.type === 'boolean'}
       <label class="relative inline-flex items-center cursor-pointer">
         <span class="text-xs {checkboxValue ? 'text-white' : 'text-gray-700'} mr-3"
@@ -365,7 +365,7 @@ function assertNumericValueIsValid(value: number) {
     {:else}
       <input
         on:input="{event => checkValue(record, event)}"
-        class="pf-c-form-control outline-0"
+        class="grow py-1 px-2 w-full outline-0 border-b-2 border-gray-800 hover:border-violet-500 focus:border-violet-500"
         name="{record.id}"
         type="text"
         bind:value="{recordValue}"

--- a/packages/renderer/src/override.css
+++ b/packages/renderer/src/override.css
@@ -13,8 +13,6 @@
 
   --pf-global--BackgroundColor--300: #222222; /*charcoal-700*/
 
-  --pf-c-form__helper-text--m-error--Color: #ff0000;
-
   --pf-global--LineHeight--md: 0.9rem;
   --pf-global--FontWeight--normal: 100;
   --pf-c-nav__link--after--BorderColor: #7c3aed;
@@ -25,7 +23,6 @@
   --pf-c-nav__link--before--BorderBottomWidth: 0;
   --pf-c-nav__link--FontWeight: 600;
   --pf-c-nav__link--m-current--BackgroundColor: #36363d; /*charcoal-500*/
-
 
   --pf-c-nav__link--PaddingTop: 13px;
   --pf-c-nav__link--PaddingBottom: 13px;
@@ -47,7 +44,6 @@
   --pf-c-tabs__link--m-current--after--BorderColor: #8b5cf6;
  }
 
-
 .pf-c-button {
   --pf-c-button--FontSize: 13px;
 }
@@ -56,23 +52,4 @@
   --pf-c-button--m-secondary--Color: #ddd;
   --pf-c-button--m-secondary--BackgroundColor: transparent;
   --pf-c-button--after--BorderColor: rgb(229,231,235);
-}
-
-nav .pf-c-badge.pf-m-read {
-  --pf-c-badge--Color: #fff;
-  --pf-c-badge--BackgroundColor: #8b5cf6;
-}
-
-.pf-c-form {
-  --pf-c-form--GridGap: 1rem;
-  overflow-y: hidden;
-}
-
-.pf-c-form .pf-u-min-height {
-  --pf-u-min-height--MinHeight: 3.3rem;
-}
-
-.pf-c-modal-box {
-  --pf-c-modal-box__body--PaddingTop: 3.5rem;
-  --pf-c-modal-box__header--body--PaddingTop: 1.5rem;
 }


### PR DESCRIPTION
### What does this PR do?

After PR #2604 I noticed that we were only using PatternFly form classes in a couple remaining places. Maybe it's just me, but I thought this was a good time to remove this use, remove overrides, and fix minor issues with formatting. This should give us the same look with one less dependency on PF.

### Screenshot/screencast of this PR

N/A, should be no visible change.

### What issues does this PR fix or reference?

One part of issue #1617.

### How to test this PR?

Create a Podman machine and edit preferences to ensure no visible regression.