### PR TITLE
fix: release-notes-generator run failure

### DIFF
--- a/.github/workflows/release-notes.yaml
+++ b/.github/workflows/release-notes.yaml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Generate the release notes document
         run: |
-          node tools/dist/release-notes-generator.js --milestone ${{ github.event.inputs.milestone }} >release-notes.md
+          node tools/dist/release-notes-generator.cjs --milestone ${{ github.event.inputs.milestone }} >release-notes.md
 
       - name: Archive the generated release notes
         uses: actions/upload-artifact@v3

--- a/tools/package.json
+++ b/tools/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "Generates release notes",
   "main": "index.js",
+  "type": "module",
   "author": "The Podman Desktop team",
   "license": "MIT",
   "scripts": {

--- a/tools/package.json
+++ b/tools/package.json
@@ -7,7 +7,7 @@
   "author": "The Podman Desktop team",
   "license": "MIT",
   "scripts": {
-    "build": "tsc"
+    "build": "vite build"
   },
   "dependencies": {
     "@octokit/graphql": "^5.0.6"

--- a/tools/src/release-notes-generator.ts
+++ b/tools/src/release-notes-generator.ts
@@ -15,7 +15,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
-import { Generator } from './generator';
+import { Generator } from './generator.js';
 
 async function run() {
   let token = process.env.GITHUB_TOKEN;

--- a/tools/src/release-notes-generator.ts
+++ b/tools/src/release-notes-generator.ts
@@ -15,7 +15,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
-import { Generator } from './generator.js';
+import { Generator } from './generator';
 
 async function run() {
   let token = process.env.GITHUB_TOKEN;

--- a/tools/vite.config.js
+++ b/tools/vite.config.js
@@ -1,0 +1,60 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import {join} from 'path';
+import {builtinModules} from 'module';
+
+const PACKAGE_ROOT = __dirname;
+
+/**
+ * @type {import('vite').UserConfig}
+ * @see https://vitejs.dev/config/
+ */
+const config = {
+  mode: process.env.MODE,
+  root: PACKAGE_ROOT,
+  envDir: process.cwd(),
+  resolve: {
+    alias: {
+      '/@/': join(PACKAGE_ROOT, 'src') + '/',
+    },
+  },
+  build: {
+    sourcemap: 'inline',
+    target: 'esnext',
+    outDir: 'dist',
+    assetsDir: '.',
+    minify: process.env.MODE === 'production' ? 'esbuild' : false,
+    lib: {
+      entry: 'src/release-notes-generator.ts',
+      formats: ['cjs'],
+    },
+    rollupOptions: {
+      external: [
+        ...builtinModules.flatMap(p => [p, `node:${p}`]),
+      ],
+      output: {
+        entryFileNames: '[name].cjs',
+      },
+    },
+    emptyOutDir: true,
+    reportCompressedSize: false,
+  },
+};
+
+export default config;


### PR DESCRIPTION
Relates to #1458

### What does this PR do?

Fixes error while running the release-notes-generator

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

Fixes #1458

### How to test this PR?

1. `cd tools`
2. `yarn build`
3. `node dist/release-notes-generator.js`