### PR TITLE
chore(tests): Add npm test:unit task, runs unit and component tests only (no e2e)

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -200,9 +200,6 @@ jobs:
       - name: Run formatter
         run: yarn format:check
 
-      - name: Run build
-        run: yarn build
-
       - name: Run unit tests
         run: yarn test
 

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -200,6 +200,9 @@ jobs:
       - name: Run formatter
         run: yarn format:check
 
+      - name: Run build
+        run: yarn build
+
       - name: Run unit tests
         run: yarn test
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "compile:next": "cross-env MODE=production npm run build && electron-builder build --publish always --config .electron-builder.config.cjs",
     "compile:pull-request": "cross-env MODE=production npm run build && electron-builder build --publish never --config .electron-builder.config.cjs",
     "compile:current": "cross-env MODE=production npm run build && electron-builder build --config .electron-builder.config.cjs",
-    "test": "npm run test:main && npm run test:preload && npm run test:preload-docker-extension && npm run test:renderer && npm run test:tools && npm run test:e2e && npm run test:extensions",
+    "test": "npm run test:unit && npm run test:e2e",
     "test:unit": "npm run test:main && npm run test:preload && npm run test:preload-docker-extension && npm run test:renderer && npm run test:tools && npm run test:extensions",
     "test:e2e": "cross-env NODE_ENV=development MODE=development DEBUG=pw:browser npm run build && xvfb-maybe vitest run tests",
     "test:main": "vitest run -r packages/main --passWithNoTests --coverage",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "compile:pull-request": "cross-env MODE=production npm run build && electron-builder build --publish never --config .electron-builder.config.cjs",
     "compile:current": "cross-env MODE=production npm run build && electron-builder build --config .electron-builder.config.cjs",
     "test": "npm run test:main && npm run test:preload && npm run test:preload-docker-extension && npm run test:renderer && npm run test:tools && npm run test:e2e && npm run test:extensions",
+    "test:unit": "npm run test:main && npm run test:preload && npm run test:preload-docker-extension && npm run test:renderer && npm run test:tools && npm run test:extensions",
     "test:e2e": "cross-env NODE_ENV=development MODE=development DEBUG=pw:browser npm run build && xvfb-maybe vitest run tests",
     "test:main": "vitest run -r packages/main --passWithNoTests --coverage",
     "test:preload": "vitest run -r packages/preload --passWithNoTests --coverage",


### PR DESCRIPTION
### What does this PR do?
Introduced npm test task that will run unit and component tests only
### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?
#2707 
<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

### How to test this PR?
`yarn test:unit`
<!-- Please explain steps to reproduce -->
