### PR TITLE
feat: Kube context on statusbar

### DIFF
--- a/extensions/kube-context/src/extension.ts
+++ b/extensions/kube-context/src/extension.ts
@@ -35,6 +35,10 @@ async function deleteContext(): Promise<void> {
   menuItemsRegistered.forEach(item => {
     item.dispose();
   });
+
+  if (statusBarItem) {
+    statusBarItem.dispose();
+  }
 }
 
 async function updateContext(extensionContext: extensionApi.ExtensionContext, kubeconfigFile: string): Promise<void> {
@@ -75,6 +79,16 @@ async function updateContext(extensionContext: extensionApi.ExtensionContext, ku
   const subscription = extensionApi.tray.registerMenuItem(item);
   menuItemsRegistered.push(subscription);
   extensionContext.subscriptions.push(subscription);
+
+  // create a status bar item to show the current context and allow switching
+  if (!statusBarItem) {
+    statusBarItem = extensionApi.window.createStatusBarItem();
+    statusBarItem.command = 'kubecontext.quickpick';
+    statusBarItem.tooltip = 'Current Kubernetes context';
+    statusBarItem.iconClass = 'fa fa-server';
+    statusBarItem.show();
+    extensionContext.subscriptions.push(statusBarItem);
+  }
 
   if (currentContext) {
     if (currentContext.length <= 20)
@@ -121,17 +135,6 @@ async function setContext(newContext: string) {
 
 export async function activate(extensionContext: extensionApi.ExtensionContext): Promise<void> {
   console.log('starting extension kube-context');
-
-  // create a status bar item to show the current context and allow switching
-  if (!statusBarItem) {
-    statusBarItem = extensionApi.window.createStatusBarItem();
-    statusBarItem.text = 'No context';
-    statusBarItem.command = 'kubecontext.quickpick';
-    statusBarItem.tooltip = 'Current Kubernetes context';
-    statusBarItem.iconClass = 'fa fa-server';
-    statusBarItem.show();
-    extensionContext.subscriptions.push(statusBarItem);
-  }
 
   // grab current file
   const kubeconfigUri = extensionApi.kubernetes.getKubeconfig();

--- a/extensions/kube-context/src/extension.ts
+++ b/extensions/kube-context/src/extension.ts
@@ -128,7 +128,7 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
     statusBarItem.text = 'No context';
     statusBarItem.command = 'kubecontext.quickpick';
     statusBarItem.tooltip = 'Current Kubernetes context';
-    statusBarItem.iconClass = 'fa fa-cog';
+    statusBarItem.iconClass = 'fa fa-server';
     statusBarItem.show();
     extensionContext.subscriptions.push(statusBarItem);
   }

--- a/extensions/kube-context/src/extension.ts
+++ b/extensions/kube-context/src/extension.ts
@@ -91,12 +91,14 @@ async function updateContext(extensionContext: extensionApi.ExtensionContext, ku
   }
 
   if (currentContext) {
-    if (currentContext.length <= 20)
+    if (currentContext.length <= 20) {
       statusBarItem.text = currentContext;
-    else
+    } else {
       statusBarItem.text = currentContext.substring(0, 20) + '...';
-  } else
+    }
+  } else {
     statusBarItem.text = 'No context';
+  }
 
   quickPicks = contexts.map(context => {
     return {
@@ -164,12 +166,12 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
   extensionContext.subscriptions.push(switchCommand);
 
   const quickPickCommand = extensionApi.commands.registerCommand('kubecontext.quickpick', async () => {
-      const selectedContext = await extensionApi.window.showQuickPick(quickPicks, {
-        placeHolder: 'Select a Kubernetes context',
-      });
-      if (selectedContext) {
-        await setContext(selectedContext.label);
-      }
+    const selectedContext = await extensionApi.window.showQuickPick(quickPicks, {
+      placeHolder: 'Select a Kubernetes context',
+    });
+    if (selectedContext) {
+      await setContext(selectedContext.label);
+    }
   });
   extensionContext.subscriptions.push(quickPickCommand);
 }


### PR DESCRIPTION
### What does this PR do?

This adds the current Kubernetes context to the status bar. When you click on it, a quick pick allows you to switch the context. The name is capped at 20 characters.

This duplicates function already available in the system tray. Some notes:
- The system tray is handy for when you don't have the dashboard open, so should be kept.
- When the dashboard is open you can now see the current context at a glance.
- The system tray is often 'far away' on screen, and viewing/changing is awkward compared to a quick popup.
- Some OS don't have a system tray.

### Screenshot/screencast of this PR

https://github.com/containers/podman-desktop/assets/19958075/242b02b4-fc3c-415b-be08-24eb1933adc5

### What issues does this PR fix or reference?

Fixes #2309.

### How to test this PR?

Confirm the current context is shown. Change it via the quick pick and system tray to confirm that both are updated. 