### PR TITLE
fix: generate src-gen folder after install step

### DIFF
--- a/extensions/kind/package.json
+++ b/extensions/kind/package.json
@@ -60,6 +60,7 @@
     }
   },
   "scripts": {
+    "postinstall": "npx ts-node ./scripts/download.ts",
     "build": "npx ts-node ./scripts/download.ts && vite build && node ./scripts/build.js",
     "test": "vitest run --coverage",
     "test:watch": "vitest watch --coverage",


### PR DESCRIPTION
### What does this PR do?
generate src-gen folder after install step

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/2451

### How to test this PR?

execute `yarn` and `yarn watch` on a fresh clone



Change-Id: I41e9935df5687aa885c21129bd7f09c42d7df206