### PR TITLE
fix: Quick pick click to close and over nav bar

### DIFF
--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -77,6 +77,7 @@ window.events?.receive('display-help', () => {
 
     <div class="overflow-x-hidden flex flex-1">
       <MessageBox />
+      <QuickPickInput />
       <AppNavigation meta="{meta}" exitSettingsCallback="{() => router.goto(nonSettingsPage)}" />
       {#if meta.url.startsWith('/preferences')}
         <PreferencesNavigation meta="{meta}" />
@@ -89,7 +90,6 @@ window.events?.receive('display-help', () => {
         <TaskManager />
         <SendFeedback />
         <ToastHandler />
-        <QuickPickInput />
         <Route path="/" breadcrumb="Dashboard Page">
           <DashboardPage />
         </Route>

--- a/packages/renderer/src/lib/dialogs/QuickPickInput.svelte
+++ b/packages/renderer/src/lib/dialogs/QuickPickInput.svelte
@@ -27,6 +27,7 @@ let quickPickSelectedFilteredIndex = 0;
 let quickPickCanPickMany = false;
 
 let inputElement: HTMLInputElement | HTMLTextAreaElement = undefined;
+let comp;
 
 const showInputCallback = async (options?: InputBoxOptions) => {
   mode = 'InputBox';
@@ -247,17 +248,24 @@ function handleKeydown(e: KeyboardEvent) {
     }
   }
 }
+
+function handleMousedown(e: MouseEvent) {
+  if (comp && !comp.contains(e.target) && !e.defaultPrevented) {
+    window.sendShowQuickPickValues(currentId, []);
+    cleanup();
+  }
+}
 </script>
 
-<svelte:window on:keydown="{handleKeydown}" />
+<svelte:window on:keydown="{handleKeydown}" on:mousedown="{handleMousedown}"/>
 
 {#if display}
   <!-- Create overlay-->
   <div class="fixed top-0 left-0 right-0 bottom-0 bg-black bg-opacity-60 h-full z-40"></div>
 
   <div class="absolute m-auto left-0 right-0 z-50">
-    <div class=" flex justify-center items-center mt-1">
-      <div
+    <div class="flex justify-center items-center mt-1">
+      <div bind:this={comp}
         class="bg-charcoal-800 w-[700px] {mode === 'InputBox'
           ? 'h-fit'
           : ''} shadow-sm p-2 rounded shadow-zinc-700 text-sm">

--- a/packages/renderer/src/lib/dialogs/QuickPickInput.svelte
+++ b/packages/renderer/src/lib/dialogs/QuickPickInput.svelte
@@ -27,7 +27,7 @@ let quickPickSelectedFilteredIndex = 0;
 let quickPickCanPickMany = false;
 
 let inputElement: HTMLInputElement | HTMLTextAreaElement = undefined;
-let comp;
+let outerDiv: HTMLDivElement = undefined;
 
 const showInputCallback = async (options?: InputBoxOptions) => {
   mode = 'InputBox';
@@ -250,7 +250,7 @@ function handleKeydown(e: KeyboardEvent) {
 }
 
 function handleMousedown(e: MouseEvent) {
-  if (comp && !comp.contains(e.target) && !e.defaultPrevented) {
+  if (outerDiv && !e.defaultPrevented && e.target instanceof Node && !outerDiv.contains(e.target)) {
     window.sendShowQuickPickValues(currentId, []);
     cleanup();
   }
@@ -265,7 +265,7 @@ function handleMousedown(e: MouseEvent) {
 
   <div class="absolute m-auto left-0 right-0 z-50">
     <div class="flex justify-center items-center mt-1">
-      <div bind:this={comp}
+      <div bind:this={outerDiv}
         class="bg-charcoal-800 w-[700px] {mode === 'InputBox'
           ? 'h-fit'
           : ''} shadow-sm p-2 rounded shadow-zinc-700 text-sm">

--- a/packages/renderer/src/lib/dialogs/QuickPickInput.svelte
+++ b/packages/renderer/src/lib/dialogs/QuickPickInput.svelte
@@ -257,7 +257,7 @@ function handleMousedown(e: MouseEvent) {
 }
 </script>
 
-<svelte:window on:keydown="{handleKeydown}" on:mousedown="{handleMousedown}"/>
+<svelte:window on:keydown="{handleKeydown}" on:mousedown="{handleMousedown}" />
 
 {#if display}
   <!-- Create overlay-->
@@ -265,7 +265,8 @@ function handleMousedown(e: MouseEvent) {
 
   <div class="absolute m-auto left-0 right-0 z-50">
     <div class="flex justify-center items-center mt-1">
-      <div bind:this={outerDiv}
+      <div
+        bind:this="{outerDiv}"
         class="bg-charcoal-800 w-[700px] {mode === 'InputBox'
           ? 'h-fit'
           : ''} shadow-sm p-2 rounded shadow-zinc-700 text-sm">


### PR DESCRIPTION
### What does this PR do?

Fixes two of the problems from issue #2754:
- Clicking outside of the quick pick or input will close it (same behaviour as Esc).
- Quick pick moved 'up' to same place as message box so that it is over top of the main nav bar.

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

Fixes 2/3 of issue #2754.

### How to test this PR?

Open a quickpick, confirm the nav bar is faded out and clicking outside closes it, but clicking inside still selects an item.