### PR TITLE
fix: Can't install extensions on Windows 10

### DIFF
--- a/packages/main/src/plugin/certificates.ts
+++ b/packages/main/src/plugin/certificates.ts
@@ -76,7 +76,7 @@ export class Certificates {
   async retrieveWindowsCertificates(): Promise<string[]> {
     // delegate to the win-ca module
     const winCaRetrieval = new Promise<string[]>(resolve => {
-      const CAs: string[] = [];
+      const CAs: string[] = [...tls.rootCertificates];
 
       if (import.meta.env.PROD) {
         const rootExePath = path.join(process.resourcesPath, 'win-ca', 'roots.exe');


### PR DESCRIPTION
Fixes #2761

### What does this PR do?

Append the default root certificates from Node to the one from Windows

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

Fixes #2761 

### How to test this PR?

1. Generate the production bits
2. Run it on Windows 10
3. Ensure extensions are not marked N/A on the Featured extension panel
4. Install one of the extensions
