### PR TITLE
chore(ci): Update pr-check test step to use unit and component tests only

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -201,7 +201,7 @@ jobs:
         run: yarn format:check
 
       - name: Run unit tests
-        run: yarn test
+        run: yarn test:unit
 
       - name: Run typecheck
         run: yarn typecheck


### PR DESCRIPTION
### What does this PR do?
PR check test step is now using unit and component tests only (`test:unit`) which does not have unstable e2e for now

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?
#2707 
<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

### How to test this PR?

<!-- Please explain steps to reproduce -->
