### PR TITLE
Introduce e2e GHA workflow that runs on push to main branch

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,90 @@
+#
+# Copyright (C) 2022 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: e2e tests
+
+on:
+  # workflow dispatch option
+  workflow_dispatch:
+    inputs:
+      fork:
+        description: 'Fork to run'
+        required: true
+        default: 'containers'
+        type: string
+      branch:
+        description: 'branch to run'
+        required: true
+        default: 'main'
+        type: string
+
+jobs:
+  e2e-run:
+    # Job configuration
+    runs-on: ${{ matrix.os }}
+    
+    strategy:
+      # easily extend with macos-latest(13) and windows-latest(2022)
+      matrix:
+        os: [ubuntu-22.04]
+        node: [16]
+      fail-fast: false
+    
+    timeout-minutes: 60
+    
+    # job execution
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "dir=$(yarn cache dir)" >> ${GITHUB_OUTPUT}
+
+      - name: Run yarn cache
+        continue-on-error: true
+        uses: actions/cache@v3
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      
+      - name: Execute yarn
+        run: yarn --frozen-lockfile --network-timeout 180000
+
+      - name: Get podman version
+        if: runner.os == 'Linux'
+        run: |
+          podman version | true
+
+      - name: Run E2E tests
+        run: yarn test:e2e
+
+      # Archiving integration tests artifacts
+      - name: Upload test artifacts
+        uses: actions/upload-artifact@v2
+        with: 
+          name: artifacts-${{ matrix.os }}
+          path: |
+            tests/**/*.png
+            tests/**/*.log
+            tests/**/*.webm
+          retention-days: 2

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "test": "npm run test:unit && npm run test:e2e:smoke",
     "test:unit": "npm run test:main && npm run test:preload && npm run test:preload-docker-extension && npm run test:renderer && npm run test:tools && npm run test:extensions",
     "test:e2e:smoke": "cross-env NODE_ENV=development MODE=development DEBUG=pw:browser npm run build && xvfb-maybe vitest run tests",
+    "test:e2e": "test:e2e:smoke",
     "test:main": "vitest run -r packages/main --passWithNoTests --coverage",
     "test:preload": "vitest run -r packages/preload --passWithNoTests --coverage",
     "test:preload-docker-extension": "vitest run -r packages/preload-docker-extension --passWithNoTests --coverage",


### PR DESCRIPTION
### What does this PR do?
Add e2e GHA workflow. To be run on push to a main branch. Does not block PR if unstable. Re-enables e2e tests.
### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?
#2707 
<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

### How to test this PR?

<!-- Please explain steps to reproduce -->
