### PR TITLE
fix: Avoid messagebox expanding offscreen

### DIFF
--- a/packages/renderer/src/lib/dialogs/MessageBox.svelte
+++ b/packages/renderer/src/lib/dialogs/MessageBox.svelte
@@ -136,11 +136,13 @@ function handleKeydown(e: KeyboardEvent) {
         </button>
       </div>
 
-      <div class="px-10 py-4 text-sm text-gray-500 leading-5">{message}</div>
+      <div class="max-h-80 overflow-auto">
+        <div class="px-10 py-4 text-sm text-gray-500 leading-5">{message}</div>
 
-      {#if detail}
-        <div class="px-10 pb-4 text-sm text-gray-500 leading-5">{detail}</div>
-      {/if}
+        {#if detail}
+          <div class="px-10 pb-4 text-sm text-gray-500 leading-5">{detail}</div>
+        {/if}
+      </div>
 
       <div class="px-5 py-5 mt-2 flex flex-row w-full justify-end space-x-5">
         {#each buttonOrder as i}


### PR DESCRIPTION
### What does this PR do?

Just sets a max height and auto-scroll so that the message box never expands too high for the screen. Dialogs with regular messages are unaffected.

### Screenshot/screencast of this PR

<img width="553" alt="Screenshot 2023-06-08 at 8 45 36 AM" src="https://github.com/containers/podman-desktop/assets/19958075/13362d0c-278e-4075-a16e-0e66b19006e7">

### What issues does this PR fix or reference?

Fixes #2771.

### How to test this PR?

Confirm regular dialogs have no change, then edit one of them (e.g. `extensions/podman/src/extesion.ts` above) to send a really long message.