### PR TITLE
chore(ci): Adding separate e2e smoke tests on PR check

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -203,6 +203,9 @@ jobs:
       - name: Run unit tests
         run: yarn test:unit
 
+      - name: Run E2E smoke tests
+        run: yarn test:e2e:smoke
+
       - name: Run typecheck
         run: yarn typecheck
 

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -215,7 +215,7 @@ jobs:
           name: tests
           path: ./tests/output/
 
-  e2e-tests:
+  smoke-e2e-tests:
     name: smoke e2e tests
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -172,7 +172,7 @@ jobs:
 
   lint-format-unit:
     name: linter, formatters and unit tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -172,7 +172,7 @@ jobs:
 
   lint-format-unit:
     name: linter, formatters and unit tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -203,14 +203,44 @@ jobs:
       - name: Run unit tests
         run: yarn test:unit
 
-      - name: Run E2E smoke tests
-        run: yarn test:e2e:smoke
-
       - name: Run typecheck
         run: yarn typecheck
 
       - name: Run svelte check
         run: yarn svelte:check
+
+      - uses: actions/upload-artifact@v3.1.2
+        if: always()
+        with:
+          name: tests
+          path: ./tests/output/
+
+  e2e-tests:
+    name: smoke e2e tests
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "dir=$(yarn cache dir)" >> ${GITHUB_OUTPUT}
+
+      - uses: actions/cache@v3
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Execute yarn
+        run: yarn --frozen-lockfile
+
+      - name: Run E2E smoke tests
+        run: yarn test:e2e:smoke
 
       - uses: actions/upload-artifact@v3.1.2
         if: always()

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "compile:next": "cross-env MODE=production npm run build && electron-builder build --publish always --config .electron-builder.config.cjs",
     "compile:pull-request": "cross-env MODE=production npm run build && electron-builder build --publish never --config .electron-builder.config.cjs",
     "compile:current": "cross-env MODE=production npm run build && electron-builder build --config .electron-builder.config.cjs",
-    "test": "npm run test:unit && npm run test:e2e",
+    "test": "npm run test:unit && npm run test:e2e:smoke",
     "test:unit": "npm run test:main && npm run test:preload && npm run test:preload-docker-extension && npm run test:renderer && npm run test:tools && npm run test:extensions",
     "test:e2e:smoke": "cross-env NODE_ENV=development MODE=development DEBUG=pw:browser npm run build && xvfb-maybe vitest run tests",
     "test:main": "vitest run -r packages/main --passWithNoTests --coverage",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "compile:current": "cross-env MODE=production npm run build && electron-builder build --config .electron-builder.config.cjs",
     "test": "npm run test:unit && npm run test:e2e",
     "test:unit": "npm run test:main && npm run test:preload && npm run test:preload-docker-extension && npm run test:renderer && npm run test:tools && npm run test:extensions",
-    "test:e2e": "cross-env NODE_ENV=development MODE=development DEBUG=pw:browser npm run build && xvfb-maybe vitest run tests",
+    "test:e2e:smoke": "cross-env NODE_ENV=development MODE=development DEBUG=pw:browser npm run build && xvfb-maybe vitest run tests",
     "test:main": "vitest run -r packages/main --passWithNoTests --coverage",
     "test:preload": "vitest run -r packages/preload --passWithNoTests --coverage",
     "test:preload-docker-extension": "vitest run -r packages/preload-docker-extension --passWithNoTests --coverage",

--- a/tests/src/e2e.spec.ts
+++ b/tests/src/e2e.spec.ts
@@ -35,7 +35,7 @@ afterAll(async () => {
   await electronApp.close();
 });
 
-test.skip('Check welcome page is displayed and that we are redirected to the main page where dashboard page is there', async () => {
+test('Check welcome page is displayed and that we are redirected to the main page where dashboard page is there', async () => {
   // Direct Electron console to Node terminal.
   page.on('console', console.log);
 


### PR DESCRIPTION
### What does this PR do?
Reenabled PR check with e2e smoke tests in it. `test:e2e` npm task is renamed to `test:e2e:smoke`.
### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?
#2707 
<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

### How to test this PR?

<!-- Please explain steps to reproduce -->
