### PR TITLE
chore: update to playwright 1.35.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "website:dev": "cd website && yarn run docusaurus start"
   },
   "devDependencies": {
-    "@playwright/test": "^1.34.3",
+    "@playwright/test": "^1.35.0",
     "@rollup/plugin-commonjs": "^25.0.0",
     "@rollup/plugin-json": "^6.0.0",
     "@rollup/plugin-node-resolve": "^15.1.0",
@@ -101,7 +101,7 @@
     "eslint-plugin-redundant-undefined": "^0.4.0",
     "eslint-plugin-sonarjs": "^0.19.0",
     "nock": "^13.3.1",
-    "playwright": "1.34.3",
+    "playwright": "1.35.0",
     "postcss-import": "^15.1.0",
     "prettier": "^2.8.8",
     "prettier-plugin-svelte": "^2.10.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2643,13 +2643,13 @@
     picocolors "^1.0.0"
     tslib "^2.5.0"
 
-"@playwright/test@^1.34.3":
-  version "1.34.3"
-  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.34.3.tgz#d9f1ac3f1a09633b5ca5351c50c308bf802bde53"
-  integrity sha512-zPLef6w9P6T/iT6XDYG3mvGOqOyb6eHaV9XtkunYs0+OzxBtrPAAaHotc0X+PJ00WPPnLfFBTl7mf45Mn8DBmw==
+"@playwright/test@^1.35.0":
+  version "1.35.0"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.35.0.tgz#532603399a0dd46731fbc31a0df5ce357dafa486"
+  integrity sha512-6qXdd5edCBynOwsz1YcNfgX8tNWeuS9fxy5o59D0rvHXxRtjXRebB4gE4vFVfEMXl/z8zTnAzfOs7aQDEs8G4Q==
   dependencies:
     "@types/node" "*"
-    playwright-core "1.34.3"
+    playwright-core "1.35.0"
   optionalDependencies:
     fsevents "2.3.2"
 
@@ -10431,17 +10431,17 @@ pkg-up@^3.1.0:
   dependencies:
     find-up "^3.0.0"
 
-playwright-core@1.34.3:
-  version "1.34.3"
-  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.34.3.tgz#bc906ea1b26bb66116ce329436ee59ba2e78fe9f"
-  integrity sha512-2pWd6G7OHKemc5x1r1rp8aQcpvDh7goMBZlJv6Co5vCNLVcQJdhxRL09SGaY6HcyHH9aT4tiynZabMofVasBYw==
+playwright-core@1.35.0:
+  version "1.35.0"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.35.0.tgz#b7871b742b4a5c8714b7fa2f570c280a061cb414"
+  integrity sha512-muMXyPmIx/2DPrCHOD1H1ePT01o7OdKxKj2ebmCAYvqhUy+Y1bpal7B0rdoxros7YrXI294JT/DWw2LqyiqTPA==
 
-playwright@1.34.3:
-  version "1.34.3"
-  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.34.3.tgz#6dca584e52e3ebc3392435c8dadf4953c792f016"
-  integrity sha512-UOOVE4ZbGfGkP1KVqWTdXOmm8Pw2pBhfbmlqKMkpiRCQjL5W+J+xRQXpgutFr0iM4pWl8g0GyyASMsqjQfFohw==
+playwright@1.35.0:
+  version "1.35.0"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.35.0.tgz#4e3b3ea2495d6fd671700f77b2f97b3adedf80f1"
+  integrity sha512-xhFhsoBmKPQfj3dM+HbIiFVlqRCZp2rwdJd/QFd9YBuidabo3TkVv0iuxPQ4vZoMwtSI7qzjY93f5ohdC97hww==
   dependencies:
-    playwright-core "1.34.3"
+    playwright-core "1.35.0"
 
 plist@^3.0.1, plist@^3.0.4:
   version "3.0.6"


### PR DESCRIPTION
### What does this PR do?
update both playwright and playwright/test dependency to 1.35.0

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

N/A

### How to test this PR?

remove skip to the e2e test 
remove settings
```
rm ~/.local/share/containers/podman-desktop/configuration/settings.json
```

and run `yarn test:e2e`