### PR TITLE
chore: switch to node16 modules instead of node modules in main package

### DIFF
--- a/packages/main/src/index.spec.ts
+++ b/packages/main/src/index.spec.ts
@@ -17,9 +17,9 @@
  ***********************************************************************/
 
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
-import { handleOpenUrl, mainWindowDeferred } from './index';
+import { handleOpenUrl, mainWindowDeferred } from './index.js';
 import type { BrowserWindow } from 'electron';
-import { Deferred } from './plugin/util/deferred';
+import { Deferred } from './plugin/util/deferred.js';
 const consoleLogMock = vi.fn();
 const originalConsoleLog = console.log;
 

--- a/packages/main/src/index.ts
+++ b/packages/main/src/index.ts
@@ -19,15 +19,15 @@
 import type { BrowserWindow } from 'electron';
 import { app, ipcMain, Tray } from 'electron';
 import './security-restrictions';
-import { createNewWindow, restoreWindow } from '/@/mainWindow';
-import { TrayMenu } from './tray-menu';
-import { isMac, isWindows, stoppedExtensions } from './util';
-import { AnimatedTray } from './tray-animate-icon';
-import { PluginSystem } from './plugin';
-import { StartupInstall } from './system/startup-install';
-import type { ExtensionLoader } from './plugin/extension-loader';
+import { createNewWindow, restoreWindow } from '/@/mainWindow.js';
+import { TrayMenu } from './tray-menu.js';
+import { isMac, isWindows, stoppedExtensions } from './util.js';
+import { AnimatedTray } from './tray-animate-icon.js';
+import { PluginSystem } from './plugin/index.js';
+import { StartupInstall } from './system/startup-install.js';
+import type { ExtensionLoader } from './plugin/extension-loader.js';
 import dns from 'node:dns';
-import { Deferred } from './plugin/util/deferred';
+import { Deferred } from './plugin/util/deferred.js';
 
 let extensionLoader: ExtensionLoader | undefined;
 

--- a/packages/main/src/mainWindow.ts
+++ b/packages/main/src/mainWindow.ts
@@ -22,8 +22,8 @@ import contextMenu from 'electron-context-menu';
 import { aboutMenuItem } from 'electron-util';
 import { join } from 'path';
 import { URL } from 'url';
-import type { ConfigurationRegistry } from './plugin/configuration-registry';
-import { isLinux, isMac, stoppedExtensions } from './util';
+import type { ConfigurationRegistry } from './plugin/configuration-registry.js';
+import { isLinux, isMac, stoppedExtensions } from './util.js';
 
 async function createWindow(): Promise<BrowserWindow> {
   const INITIAL_APP_WIDTH = 1050;

--- a/packages/main/src/plugin/api.ts
+++ b/packages/main/src/plugin/api.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { ContainerInfo } from './api/container-info';
+import type { ContainerInfo } from './api/container-info.js';
 
 export interface RemoteAPI {
   // eslint-disable-next-line @typescript-eslint/ban-types

--- a/packages/main/src/plugin/api/pod-info.ts
+++ b/packages/main/src/plugin/api/pod-info.ts
@@ -16,7 +16,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { PodInfo as LibPodPodInfo, PodInspectInfo as LibPodPodInspectInfo } from '../dockerode/libpod-dockerode';
+import type {
+  PodInfo as LibPodPodInfo,
+  PodInspectInfo as LibPodPodInspectInfo,
+} from '../dockerode/libpod-dockerode.js';
 
 export interface PodInfo extends LibPodPodInfo {
   engineId: string;

--- a/packages/main/src/plugin/authentication.spec.ts
+++ b/packages/main/src/plugin/authentication.spec.ts
@@ -24,26 +24,26 @@ import type {
   Event,
 } from '@podman-desktop/api';
 import { beforeEach, afterEach, expect, test, vi, suite } from 'vitest';
-import type { ApiSenderType } from './api';
-import { AuthenticationImpl } from './authentication';
-import type { CommandRegistry } from './command-registry';
-import type { ConfigurationRegistry } from './configuration-registry';
-import type { ContainerProviderRegistry } from './container-registry';
-import { Emitter as EventEmitter } from './events/emitter';
-import { ExtensionLoader } from './extension-loader';
-import type { FilesystemMonitoring } from './filesystem-monitoring';
-import type { ImageRegistry } from './image-registry';
-import type { InputQuickPickRegistry } from './input-quickpick/input-quickpick-registry';
-import type { KubernetesClient } from './kubernetes-client';
-import type { MenuRegistry } from './menu-registry';
-import type { MessageBox } from './message-box';
-import type { NotificationImpl } from './notification-impl';
-import type { ProgressImpl } from './progress-impl';
-import type { ProviderRegistry } from './provider-registry';
-import type { StatusBarRegistry } from './statusbar/statusbar-registry';
-import type { Telemetry } from './telemetry/telemetry';
-import type { TrayMenuRegistry } from './tray-menu-registry';
-import type { Proxy } from './proxy';
+import type { ApiSenderType } from './api.js';
+import { AuthenticationImpl } from './authentication.js';
+import type { CommandRegistry } from './command-registry.js';
+import type { ConfigurationRegistry } from './configuration-registry.js';
+import type { ContainerProviderRegistry } from './container-registry.js';
+import { Emitter as EventEmitter } from './events/emitter.js';
+import { ExtensionLoader } from './extension-loader.js';
+import type { FilesystemMonitoring } from './filesystem-monitoring.js';
+import type { ImageRegistry } from './image-registry.js';
+import type { InputQuickPickRegistry } from './input-quickpick/input-quickpick-registry.js';
+import type { KubernetesClient } from './kubernetes-client.js';
+import type { MenuRegistry } from './menu-registry.js';
+import type { MessageBox } from './message-box.js';
+import type { NotificationImpl } from './notification-impl.js';
+import type { ProgressImpl } from './progress-impl.js';
+import type { ProviderRegistry } from './provider-registry.js';
+import type { StatusBarRegistry } from './statusbar/statusbar-registry.js';
+import type { Telemetry } from './telemetry/telemetry.js';
+import type { TrayMenuRegistry } from './tray-menu-registry.js';
+import type { Proxy } from './proxy.js';
 
 function randomNumber(n = 5) {
   return Math.round(Math.random() * 10 * n);

--- a/packages/main/src/plugin/authentication.ts
+++ b/packages/main/src/plugin/authentication.ts
@@ -27,8 +27,8 @@ import type {
   Disposable,
   ProviderImages,
 } from '@podman-desktop/api';
-import { Emitter } from './events/emitter';
-import type { ApiSenderType } from './api';
+import { Emitter } from './events/emitter.js';
+import type { ApiSenderType } from './api.js';
 
 /**
  * Structure to save authentication provider information

--- a/packages/main/src/plugin/autostart-engine.ts
+++ b/packages/main/src/plugin/autostart-engine.ts
@@ -16,8 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { ConfigurationRegistry, IConfigurationNode } from './configuration-registry';
-import type { ProviderRegistry } from './provider-registry';
+import type { ConfigurationRegistry, IConfigurationNode } from './configuration-registry.js';
+import type { ProviderRegistry } from './provider-registry.js';
 
 export class AutostartEngine {
   constructor(private configurationRegistry: ConfigurationRegistry, private providerRegistry: ProviderRegistry) {}

--- a/packages/main/src/plugin/cancellation-token-registry.spec.ts
+++ b/packages/main/src/plugin/cancellation-token-registry.spec.ts
@@ -17,8 +17,8 @@
  ***********************************************************************/
 
 import { beforeAll, expect, expectTypeOf, test } from 'vitest';
-import { CancellationTokenSource } from './cancellation-token';
-import { CancellationTokenRegistry } from './cancellation-token-registry';
+import { CancellationTokenSource } from './cancellation-token.js';
+import { CancellationTokenRegistry } from './cancellation-token-registry.js';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let cancellationTokenRegistry: any;

--- a/packages/main/src/plugin/cancellation-token-registry.ts
+++ b/packages/main/src/plugin/cancellation-token-registry.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { CancellationTokenSource } from './cancellation-token';
+import { CancellationTokenSource } from './cancellation-token.js';
 
 export class CancellationTokenRegistry {
   private callbackId = 0;

--- a/packages/main/src/plugin/cancellation-token.spec.ts
+++ b/packages/main/src/plugin/cancellation-token.spec.ts
@@ -17,8 +17,8 @@
  ***********************************************************************/
 
 import { beforeAll, beforeEach, expect, expectTypeOf, test, vi, vitest } from 'vitest';
-import { CancellationTokenImpl } from './cancellation-token';
-import { CancellationTokenRegistry } from './cancellation-token-registry';
+import { CancellationTokenImpl } from './cancellation-token.js';
+import { CancellationTokenRegistry } from './cancellation-token-registry.js';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let cancellationTokenRegistry: any;

--- a/packages/main/src/plugin/cancellation-token.ts
+++ b/packages/main/src/plugin/cancellation-token.ts
@@ -17,8 +17,8 @@
  ***********************************************************************/
 
 import type * as extensionApi from '@podman-desktop/api';
-import { Emitter } from './events/emitter';
-import type { IDisposable } from './types/disposable';
+import { Emitter } from './events/emitter.js';
+import type { IDisposable } from './types/disposable.js';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const shortcutEvent: extensionApi.Event<any> = Object.freeze(function (callback, context?): IDisposable {

--- a/packages/main/src/plugin/certificate.spec.ts
+++ b/packages/main/src/plugin/certificate.spec.ts
@@ -17,7 +17,7 @@
  ***********************************************************************/
 
 import { beforeEach, expect, test, vi } from 'vitest';
-import { Certificates } from './certificates';
+import { Certificates } from './certificates.js';
 
 let certificate: Certificates;
 

--- a/packages/main/src/plugin/certificates.ts
+++ b/packages/main/src/plugin/certificates.ts
@@ -16,8 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { isLinux, isMac, isWindows } from '../util';
-import { spawnWithPromise } from './util/spawn-promise';
+import { isLinux, isMac, isWindows } from '../util.js';
+import { spawnWithPromise } from './util/spawn-promise.js';
 import * as https from 'node:https';
 import * as tls from 'node:tls';
 import * as fs from 'node:fs';

--- a/packages/main/src/plugin/close-behavior.spec.ts
+++ b/packages/main/src/plugin/close-behavior.spec.ts
@@ -16,9 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 import { beforeEach, test, expect, vi } from 'vitest';
-import { CloseBehavior } from './close-behavior';
-import { ConfigurationRegistry } from './configuration-registry';
-import * as util from '../util';
+import { CloseBehavior } from './close-behavior.js';
+import { ConfigurationRegistry } from './configuration-registry.js';
+import * as util from '../util.js';
 
 vi.mock('./util', () => {
   return {

--- a/packages/main/src/plugin/close-behavior.ts
+++ b/packages/main/src/plugin/close-behavior.ts
@@ -16,8 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { isLinux } from '../util';
-import type { ConfigurationRegistry, IConfigurationNode } from './configuration-registry';
+import { isLinux } from '../util.js';
+import type { ConfigurationRegistry, IConfigurationNode } from './configuration-registry.js';
 
 export class CloseBehavior {
   constructor(private configurationRegistry: ConfigurationRegistry) {}

--- a/packages/main/src/plugin/command-registry.ts
+++ b/packages/main/src/plugin/command-registry.ts
@@ -16,8 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { Disposable } from './types/disposable';
-import type { Telemetry } from './telemetry/telemetry';
+import { Disposable } from './types/disposable.js';
+import type { Telemetry } from './telemetry/telemetry.js';
 
 export interface CommandHandler {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/main/src/plugin/configuration-impl.ts
+++ b/packages/main/src/plugin/configuration-impl.ts
@@ -17,7 +17,7 @@
  ***********************************************************************/
 
 import type * as containerDesktopAPI from '@podman-desktop/api';
-import { CONFIGURATION_DEFAULT_SCOPE } from './configuration-registry-constants';
+import { CONFIGURATION_DEFAULT_SCOPE } from './configuration-registry-constants.js';
 
 /**
  * Local view of the configuration values for a given scope

--- a/packages/main/src/plugin/configuration-registry.spec.ts
+++ b/packages/main/src/plugin/configuration-registry.spec.ts
@@ -18,8 +18,8 @@
 
 import { beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
 import * as fs from 'node:fs';
-import type { IConfigurationNode } from './configuration-registry';
-import { ConfigurationRegistry } from './configuration-registry';
+import type { IConfigurationNode } from './configuration-registry.js';
+import { ConfigurationRegistry } from './configuration-registry.js';
 
 let configurationRegistry: ConfigurationRegistry;
 

--- a/packages/main/src/plugin/configuration-registry.ts
+++ b/packages/main/src/plugin/configuration-registry.ts
@@ -20,11 +20,11 @@ import * as path from 'path';
 import * as os from 'os';
 import * as fs from 'fs';
 import type * as containerDesktopAPI from '@podman-desktop/api';
-import { ConfigurationImpl } from './configuration-impl';
-import type { Event } from './events/emitter';
-import { Emitter } from './events/emitter';
-import { CONFIGURATION_DEFAULT_SCOPE } from './configuration-registry-constants';
-import { desktopAppHomeDir } from '../util';
+import { ConfigurationImpl } from './configuration-impl.js';
+import type { Event } from './events/emitter.js';
+import { Emitter } from './events/emitter.js';
+import { CONFIGURATION_DEFAULT_SCOPE } from './configuration-registry-constants.js';
+import { desktopAppHomeDir } from '../util.js';
 
 export type IConfigurationPropertySchemaType =
   | 'markdown'

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -17,39 +17,39 @@
  ***********************************************************************/
 
 import type * as containerDesktopAPI from '@podman-desktop/api';
-import { Disposable } from './types/disposable';
+import { Disposable } from './types/disposable.js';
 import Dockerode from 'dockerode';
-import StreamValues from 'stream-json/streamers/StreamValues';
-import type { ContainerCreateOptions, ContainerInfo, SimpleContainerInfo } from './api/container-info';
-import type { ImageInfo } from './api/image-info';
-import type { PodInfo, PodInspectInfo } from './api/pod-info';
-import type { ImageInspectInfo } from './api/image-inspect-info';
-import type { ProviderContainerConnectionInfo } from './api/provider-info';
-import type { ImageRegistry } from './image-registry';
-import type { PullEvent } from './api/pull-event';
-import type { Telemetry } from './telemetry/telemetry';
+import StreamValues from 'stream-json/streamers/StreamValues.js';
+import type { ContainerCreateOptions, ContainerInfo, SimpleContainerInfo } from './api/container-info.js';
+import type { ImageInfo } from './api/image-info.js';
+import type { PodInfo, PodInspectInfo } from './api/pod-info.js';
+import type { ImageInspectInfo } from './api/image-inspect-info.js';
+import type { ProviderContainerConnectionInfo } from './api/provider-info.js';
+import type { ImageRegistry } from './image-registry.js';
+import type { PullEvent } from './api/pull-event.js';
+import type { Telemetry } from './telemetry/telemetry.js';
 import * as crypto from 'node:crypto';
 import moment from 'moment';
 const tar: { pack: (dir: string) => NodeJS.ReadableStream } = require('tar-fs');
 import { EventEmitter } from 'node:events';
-import type { ContainerInspectInfo } from './api/container-inspect-info';
-import type { HistoryInfo } from './api/history-info';
+import type { ContainerInspectInfo } from './api/container-inspect-info.js';
+import type { HistoryInfo } from './api/history-info.js';
 import type {
   LibPod,
   PlayKubeInfo,
   PodCreateOptions,
   ContainerCreateOptions as PodmanContainerCreateOptions,
   PodInfo as LibpodPodInfo,
-} from './dockerode/libpod-dockerode';
-import { LibpodDockerode } from './dockerode/libpod-dockerode';
-import type { ContainerStatsInfo } from './api/container-stats-info';
-import type { VolumeInfo, VolumeInspectInfo, VolumeListInfo } from './api/volume-info';
-import type { NetworkInspectInfo } from './api/network-info';
-import type { Event } from './events/emitter';
-import { Emitter } from './events/emitter';
+} from './dockerode/libpod-dockerode.js';
+import { LibpodDockerode } from './dockerode/libpod-dockerode.js';
+import type { ContainerStatsInfo } from './api/container-stats-info.js';
+import type { VolumeInfo, VolumeInspectInfo, VolumeListInfo } from './api/volume-info.js';
+import type { NetworkInspectInfo } from './api/network-info.js';
+import type { Event } from './events/emitter.js';
+import { Emitter } from './events/emitter.js';
 import fs from 'node:fs';
 import { pipeline } from 'node:stream/promises';
-import type { ApiSenderType } from './api';
+import type { ApiSenderType } from './api.js';
 export interface InternalContainerProvider {
   name: string;
   id: string;

--- a/packages/main/src/plugin/contribution-manager.ts
+++ b/packages/main/src/plugin/contribution-manager.ts
@@ -19,9 +19,9 @@
 import * as path from 'node:path';
 import * as os from 'node:os';
 import * as fs from 'node:fs';
-import type { ContributionInfo } from './api/contribution-info';
-import { desktopAppHomeDir } from '../util';
-import type { ApiSenderType } from './api';
+import type { ContributionInfo } from './api/contribution-info.js';
+import { desktopAppHomeDir } from '../util.js';
+import type { ApiSenderType } from './api.js';
 
 /**
  * Contribution manager to provide the list of external OCI contributions

--- a/packages/main/src/plugin/docker-extension/docker-desktop-installation.ts
+++ b/packages/main/src/plugin/docker-extension/docker-desktop-installation.ts
@@ -18,16 +18,16 @@
 
 import type { IpcMainEvent, IpcMainInvokeEvent } from 'electron';
 import { ipcMain } from 'electron';
-import type { ContainerProviderRegistry } from '../container-registry';
+import type { ContainerProviderRegistry } from '../container-registry.js';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
 import { readFile, cp } from 'node:fs/promises';
 import * as tarFs from 'tar-fs';
 import type Dockerode from 'dockerode';
-import type { PullEvent } from '../api/pull-event';
-import type { ContributionManager } from '../contribution-manager';
-import type { ApiSenderType } from '../api';
+import type { PullEvent } from '../api/pull-event.js';
+import type { ContributionManager } from '../contribution-manager.js';
+import type { ApiSenderType } from '../api.js';
 
 export class DockerDesktopInstallation {
   constructor(

--- a/packages/main/src/plugin/docker-extension/docker-plugin-adapter.ts
+++ b/packages/main/src/plugin/docker-extension/docker-plugin-adapter.ts
@@ -3,7 +3,7 @@ import { ipcMain } from 'electron';
 
 import * as os from 'node:os';
 import { spawn } from 'child_process';
-import type { ContributionManager } from '../contribution-manager';
+import type { ContributionManager } from '../contribution-manager.js';
 
 export interface RawExecResult {
   cmd?: string;

--- a/packages/main/src/plugin/editor-init.ts
+++ b/packages/main/src/plugin/editor-init.ts
@@ -16,8 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { IConfigurationNode, IConfigurationRegistry } from './configuration-registry';
-import { EditorSettings } from './editor-settings';
+import type { IConfigurationNode, IConfigurationRegistry } from './configuration-registry.js';
+import { EditorSettings } from './editor-settings.js';
 
 export class EditorInit {
   constructor(private configurationRegistry: IConfigurationRegistry) {}

--- a/packages/main/src/plugin/events/emitter.ts
+++ b/packages/main/src/plugin/events/emitter.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/ban-types */
-import type { IDisposable } from '../types/disposable';
+import type { IDisposable } from '../types/disposable.js';
 
 export type DisposableGroup = { push(disposable: IDisposable): void } | { add(disposable: IDisposable): void };
 

--- a/packages/main/src/plugin/extension-loader.spec.ts
+++ b/packages/main/src/plugin/extension-loader.spec.ts
@@ -19,28 +19,28 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import { beforeAll, beforeEach, test, expect, vi } from 'vitest';
-import type { CommandRegistry } from './command-registry';
-import type { ConfigurationRegistry } from './configuration-registry';
-import type { ContainerProviderRegistry } from './container-registry';
-import type { AnalyzedExtension } from './extension-loader';
-import { ExtensionLoader } from './extension-loader';
-import type { FilesystemMonitoring } from './filesystem-monitoring';
-import type { ImageRegistry } from './image-registry';
-import type { InputQuickPickRegistry } from './input-quickpick/input-quickpick-registry';
-import type { KubernetesClient } from './kubernetes-client';
-import type { MenuRegistry } from './menu-registry';
-import type { NotificationImpl } from './notification-impl';
-import type { ProgressImpl } from './progress-impl';
-import type { ProviderRegistry } from './provider-registry';
-import type { Proxy } from './proxy';
-import type { StatusBarRegistry } from './statusbar/statusbar-registry';
-import type { TrayMenuRegistry } from './tray-menu-registry';
+import type { CommandRegistry } from './command-registry.js';
+import type { ConfigurationRegistry } from './configuration-registry.js';
+import type { ContainerProviderRegistry } from './container-registry.js';
+import type { AnalyzedExtension } from './extension-loader.js';
+import { ExtensionLoader } from './extension-loader.js';
+import type { FilesystemMonitoring } from './filesystem-monitoring.js';
+import type { ImageRegistry } from './image-registry.js';
+import type { InputQuickPickRegistry } from './input-quickpick/input-quickpick-registry.js';
+import type { KubernetesClient } from './kubernetes-client.js';
+import type { MenuRegistry } from './menu-registry.js';
+import type { NotificationImpl } from './notification-impl.js';
+import type { ProgressImpl } from './progress-impl.js';
+import type { ProviderRegistry } from './provider-registry.js';
+import type { Proxy } from './proxy.js';
+import type { StatusBarRegistry } from './statusbar/statusbar-registry.js';
+import type { TrayMenuRegistry } from './tray-menu-registry.js';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import type { ApiSenderType } from './api';
-import type { AuthenticationImpl } from './authentication';
-import type { MessageBox } from './message-box';
-import type { Telemetry } from './telemetry/telemetry';
+import type { ApiSenderType } from './api.js';
+import type { AuthenticationImpl } from './authentication.js';
+import type { MessageBox } from './message-box.js';
+import type { Telemetry } from './telemetry/telemetry.js';
 import type * as containerDesktopAPI from '@podman-desktop/api';
 
 class TestExtensionLoader extends ExtensionLoader {

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -20,42 +20,42 @@ import type * as containerDesktopAPI from '@podman-desktop/api';
 import * as path from 'path';
 import * as os from 'os';
 import * as fs from 'fs';
-import type { CommandRegistry } from './command-registry';
-import type { ExtensionError, ExtensionInfo, ExtensionUpdateInfo } from './api/extension-info';
+import type { CommandRegistry } from './command-registry.js';
+import type { ExtensionError, ExtensionInfo, ExtensionUpdateInfo } from './api/extension-info.js';
 import * as zipper from 'zip-local';
-import type { TrayMenuRegistry } from './tray-menu-registry';
-import { Disposable } from './types/disposable';
-import type { ProviderRegistry } from './provider-registry';
-import type { ConfigurationRegistry } from './configuration-registry';
-import type { ImageRegistry } from './image-registry';
-import type { MessageBox } from './message-box';
-import type { ProgressImpl } from './progress-impl';
-import { ProgressLocation } from './progress-impl';
-import type { NotificationImpl } from './notification-impl';
+import type { TrayMenuRegistry } from './tray-menu-registry.js';
+import { Disposable } from './types/disposable.js';
+import type { ProviderRegistry } from './provider-registry.js';
+import type { ConfigurationRegistry } from './configuration-registry.js';
+import type { ImageRegistry } from './image-registry.js';
+import type { MessageBox } from './message-box.js';
+import type { ProgressImpl } from './progress-impl.js';
+import { ProgressLocation } from './progress-impl.js';
+import type { NotificationImpl } from './notification-impl.js';
 import {
   StatusBarItemImpl,
   StatusBarAlignLeft,
   StatusBarAlignRight,
   StatusBarItemDefaultPriority,
-} from './statusbar/statusbar-item';
-import type { StatusBarRegistry } from './statusbar/statusbar-registry';
-import type { FilesystemMonitoring } from './filesystem-monitoring';
-import { Uri } from './types/uri';
-import type { KubernetesClient } from './kubernetes-client';
-import type { Proxy } from './proxy';
-import type { ContainerProviderRegistry } from './container-registry';
-import type { InputQuickPickRegistry } from './input-quickpick/input-quickpick-registry';
-import { QuickPickItemKind, InputBoxValidationSeverity } from './input-quickpick/input-quickpick-registry';
-import type { MenuRegistry } from '/@/plugin/menu-registry';
-import { desktopAppHomeDir } from '../util';
-import { Emitter } from './events/emitter';
-import { CancellationTokenSource } from './cancellation-token';
-import type { ApiSenderType } from './api';
-import type { AuthenticationImpl } from './authentication';
-import type { Telemetry } from './telemetry/telemetry';
-import { TelemetryTrustedValue } from './types/telemetry';
+} from './statusbar/statusbar-item.js';
+import type { StatusBarRegistry } from './statusbar/statusbar-registry.js';
+import type { FilesystemMonitoring } from './filesystem-monitoring.js';
+import { Uri } from './types/uri.js';
+import type { KubernetesClient } from './kubernetes-client.js';
+import type { Proxy } from './proxy.js';
+import type { ContainerProviderRegistry } from './container-registry.js';
+import type { InputQuickPickRegistry } from './input-quickpick/input-quickpick-registry.js';
+import { QuickPickItemKind, InputBoxValidationSeverity } from './input-quickpick/input-quickpick-registry.js';
+import type { MenuRegistry } from '/@/plugin/menu-registry.js';
+import { desktopAppHomeDir } from '../util.js';
+import { Emitter } from './events/emitter.js';
+import { CancellationTokenSource } from './cancellation-token.js';
+import type { ApiSenderType } from './api.js';
+import type { AuthenticationImpl } from './authentication.js';
+import type { Telemetry } from './telemetry/telemetry.js';
+import { TelemetryTrustedValue } from './types/telemetry.js';
 import { clipboard as electronClipboard } from 'electron';
-import { securityRestrictionCurrentHandler } from '../security-restrictions-handler';
+import { securityRestrictionCurrentHandler } from '../security-restrictions-handler.js';
 
 /**
  * Handle the loading of an extension

--- a/packages/main/src/plugin/extensions-catalog/extensions-catalog.spec.ts
+++ b/packages/main/src/plugin/extensions-catalog/extensions-catalog.spec.ts
@@ -19,10 +19,10 @@
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 
 import nock from 'nock';
-import { ExtensionsCatalog } from './extensions-catalog';
-import type { Certificates } from '../certificates';
-import type { Proxy } from '../proxy';
-import { Emitter } from '../events/emitter';
+import { ExtensionsCatalog } from './extensions-catalog.js';
+import type { Certificates } from '../certificates.js';
+import type { Proxy } from '../proxy.js';
+import { Emitter } from '../events/emitter.js';
 import type { ProxySettings } from '@podman-desktop/api';
 
 let extensionsCatalog: ExtensionsCatalog;

--- a/packages/main/src/plugin/extensions-catalog/extensions-catalog.ts
+++ b/packages/main/src/plugin/extensions-catalog/extensions-catalog.ts
@@ -19,10 +19,13 @@
 import { HttpProxyAgent, HttpsProxyAgent } from 'hpagent';
 import type { HttpsOptions, OptionsOfTextResponseBody } from 'got';
 import got from 'got';
-import type { Certificates } from '/@/plugin/certificates';
-import type { Proxy } from '/@/plugin/proxy';
+import type { Certificates } from '/@/plugin/certificates.js';
+import type { Proxy } from '/@/plugin/proxy.js';
 import type * as podmanDesktopAPI from '@podman-desktop/api';
-import type { CatalogExtension, CatalogFetchableExtension } from '/@/plugin/extensions-catalog/extensions-catalog-api';
+import type {
+  CatalogExtension,
+  CatalogFetchableExtension,
+} from '/@/plugin/extensions-catalog/extensions-catalog-api.js';
 
 /**
  * Allow to grab content from the online extensions catalog.

--- a/packages/main/src/plugin/extensions-updater/extensions-updater.spec.ts
+++ b/packages/main/src/plugin/extensions-updater/extensions-updater.spec.ts
@@ -18,15 +18,15 @@
 
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 
-import { ExtensionsUpdater } from './extensions-updater';
+import { ExtensionsUpdater } from './extensions-updater.js';
 
-import type { ExtensionsCatalog } from '../extensions-catalog/extensions-catalog';
-import type { ExtensionLoader } from '../extension-loader';
-import type { ConfigurationRegistry } from '../configuration-registry';
-import type { ExtensionInstaller } from '../install/extension-installer';
-import type { Telemetry } from '../telemetry/telemetry';
-import type { CatalogExtension } from '../extensions-catalog/extensions-catalog-api';
-import type { ExtensionInfo } from '../api/extension-info';
+import type { ExtensionsCatalog } from '../extensions-catalog/extensions-catalog.js';
+import type { ExtensionLoader } from '../extension-loader.js';
+import type { ConfigurationRegistry } from '../configuration-registry.js';
+import type { ExtensionInstaller } from '../install/extension-installer.js';
+import type { Telemetry } from '../telemetry/telemetry.js';
+import type { CatalogExtension } from '../extensions-catalog/extensions-catalog-api.js';
+import type { ExtensionInfo } from '../api/extension-info.js';
 
 let extensionsUpdater: ExtensionsUpdater;
 

--- a/packages/main/src/plugin/extensions-updater/extensions-updater.ts
+++ b/packages/main/src/plugin/extensions-updater/extensions-updater.ts
@@ -16,14 +16,14 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { ConfigurationRegistry, IConfigurationNode } from '/@/plugin/configuration-registry';
-import { ExtensionsUpdaterSettings } from './extensions-updater-settings';
-import type { ExtensionsCatalog } from '/@/plugin/extensions-catalog/extensions-catalog';
-import type { Telemetry } from '/@/plugin/telemetry/telemetry';
-import type { ExtensionLoader } from '/@/plugin/extension-loader';
+import type { ConfigurationRegistry, IConfigurationNode } from '/@/plugin/configuration-registry.js';
+import { ExtensionsUpdaterSettings } from './extensions-updater-settings.js';
+import type { ExtensionsCatalog } from '/@/plugin/extensions-catalog/extensions-catalog.js';
+import type { Telemetry } from '/@/plugin/telemetry/telemetry.js';
+import type { ExtensionLoader } from '/@/plugin/extension-loader.js';
 import { compareVersions } from 'compare-versions';
-import type { ExtensionUpdateInfo } from '/@/plugin/api/extension-info';
-import type { ExtensionInstaller } from '/@/plugin/install/extension-installer';
+import type { ExtensionUpdateInfo } from '/@/plugin/api/extension-info.js';
+import type { ExtensionInstaller } from '/@/plugin/install/extension-installer.js';
 
 export class ExtensionsUpdater {
   static readonly CHECK_FOR_UPDATES_INTERVAL = 1000 * 60 * 60 * 12; // 12 hours

--- a/packages/main/src/plugin/featured/featured.spec.ts
+++ b/packages/main/src/plugin/featured/featured.spec.ts
@@ -18,9 +18,9 @@
 
 import { afterEach, beforeAll, beforeEach, expect, test, vi } from 'vitest';
 
-import { Featured } from './featured';
-import type { ExtensionLoader } from '../extension-loader';
-import type { ExtensionsCatalog } from '../extensions-catalog/extensions-catalog';
+import { Featured } from './featured.js';
+import type { ExtensionLoader } from '../extension-loader.js';
+import type { ExtensionsCatalog } from '../extensions-catalog/extensions-catalog.js';
 
 let featured: Featured;
 

--- a/packages/main/src/plugin/featured/featured.ts
+++ b/packages/main/src/plugin/featured/featured.ts
@@ -17,10 +17,10 @@
  ***********************************************************************/
 
 import { featured as featuredJSONFile } from '../../../../../featured.json';
-import type { CatalogFetchableExtension } from '../extensions-catalog/extensions-catalog-api';
-import type { ExtensionsCatalog } from '../extensions-catalog/extensions-catalog';
-import type { ExtensionLoader } from '/@/plugin/extension-loader';
-import type { FeaturedExtension } from '/@/plugin/featured/featured-api';
+import type { CatalogFetchableExtension } from '../extensions-catalog/extensions-catalog-api.js';
+import type { ExtensionsCatalog } from '../extensions-catalog/extensions-catalog.js';
+import type { ExtensionLoader } from '/@/plugin/extension-loader.js';
+import type { FeaturedExtension } from '/@/plugin/featured/featured-api.js';
 
 /**
  * Manages the Featured extensions

--- a/packages/main/src/plugin/filesystem-monitoring.ts
+++ b/packages/main/src/plugin/filesystem-monitoring.ts
@@ -17,10 +17,10 @@
  ***********************************************************************/
 
 import type * as containerDesktopAPI from '@podman-desktop/api';
-import { Emitter } from './events/emitter';
-import { Disposable } from './types/disposable';
+import { Emitter } from './events/emitter.js';
+import { Disposable } from './types/disposable.js';
 import * as chokidar from 'chokidar';
-import { Uri } from './types/uri';
+import { Uri } from './types/uri.js';
 
 export class FileSystemWatcherImpl implements containerDesktopAPI.FileSystemWatcher {
   constructor(path: string) {

--- a/packages/main/src/plugin/image-registry.spec.ts
+++ b/packages/main/src/plugin/image-registry.spec.ts
@@ -17,12 +17,12 @@
  ***********************************************************************/
 
 import { beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
-import type { ApiSenderType } from './api';
+import type { ApiSenderType } from './api.js';
 
-import { ImageRegistry } from './image-registry';
-import type { Proxy } from './proxy';
-import type { Telemetry } from './telemetry/telemetry';
-import type { Certificates } from './certificates';
+import { ImageRegistry } from './image-registry.js';
+import type { Proxy } from './proxy.js';
+import type { Telemetry } from './telemetry/telemetry.js';
+import type { Certificates } from './certificates.js';
 import nock from 'nock';
 import * as imageRegistryManifestMultiArchJson from '../../tests/resources/data/plugin/image-registry-manifest-multi-arch-index.json';
 import * as imageRegistryManifestJson from '../../tests/resources/data/plugin/image-registry-manifest-index.json';
@@ -368,4 +368,32 @@ test('expect downloadAndExtractImage works', async () => {
     await fs.promises.rm(tmpTarFolder, { recursive: true });
     await fs.promises.rm(destFolder, { recursive: true });
   }
+});
+
+describe('expect checkCredentials', async () => {
+  test('expect checkCredentials works', async () => {
+    const spyGetAuthInfo = vi.spyOn(imageRegistry, 'getAuthInfo');
+    spyGetAuthInfo.mockResolvedValue({ authUrl: 'foo', scheme: 'bearer' });
+
+    const spydoCheckCredentials = vi.spyOn(imageRegistry, 'doCheckCredentials');
+    spydoCheckCredentials.mockResolvedValue();
+
+    await imageRegistry.checkCredentials(
+      'my-podman-desktop-fake-registry.io/my/extension',
+      'my-username',
+      'my-password',
+    );
+  });
+
+  test('expect checkCredentials fails', async () => {
+    const spyGetAuthInfo = vi.spyOn(imageRegistry, 'getAuthInfo');
+    spyGetAuthInfo.mockResolvedValue({ authUrl: 'foo', scheme: 'bearer' });
+
+    const spydoCheckCredentials = vi.spyOn(imageRegistry, 'doCheckCredentials');
+    spydoCheckCredentials.mockResolvedValue();
+
+    await expect(imageRegistry.checkCredentials('----', 'my-username', 'my-password')).rejects.toThrow(
+      'The format of the Registry Location is incorrect.',
+    );
+  });
 });

--- a/packages/main/src/plugin/image-registry.ts
+++ b/packages/main/src/plugin/image-registry.ts
@@ -16,19 +16,22 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { Disposable } from './types/disposable';
+import { Disposable } from './types/disposable.js';
 import type * as containerDesktopAPI from '@podman-desktop/api';
-import { Emitter } from './events/emitter';
+import { Emitter } from './events/emitter.js';
 import type * as Dockerode from 'dockerode';
-import type { Telemetry } from './telemetry/telemetry';
+import type { Telemetry } from './telemetry/telemetry.js';
 import * as crypto from 'node:crypto';
 import type { HttpsOptions, OptionsOfTextResponseBody } from 'got';
 import got, { HTTPError, RequestError } from 'got';
-import validator from 'validator';
+import validatorPkg from 'validator';
+// workaround for ESM
+const validator: { isURL: (url: string) => boolean } = validatorPkg as unknown as { isURL: (url: string) => boolean };
+
 import { HttpProxyAgent, HttpsProxyAgent } from 'hpagent';
-import type { Certificates } from './certificates';
-import type { Proxy } from './proxy';
-import type { ApiSenderType } from './api';
+import type { Certificates } from './certificates.js';
+import type { Proxy } from './proxy.js';
+import type { ApiSenderType } from './api.js';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import * as fs from 'node:fs';

--- a/packages/main/src/plugin/index.spec.ts
+++ b/packages/main/src/plugin/index.spec.ts
@@ -18,13 +18,13 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
-import type { TrayMenu } from '../tray-menu';
+import type { TrayMenu } from '../tray-menu.js';
 import { EventEmitter } from 'node:events';
-import { PluginSystem } from './index';
+import { PluginSystem } from './index.js';
 import type { WebContents } from 'electron';
 import { shell, clipboard } from 'electron';
-import type { MessageBox } from './message-box';
-import { securityRestrictionCurrentHandler } from '../security-restrictions-handler';
+import type { MessageBox } from './message-box.js';
+import { securityRestrictionCurrentHandler } from '../security-restrictions-handler.js';
 
 let pluginSystem: PluginSystem;
 

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -22,15 +22,15 @@
 import * as os from 'node:os';
 import * as path from 'path';
 import type * as containerDesktopAPI from '@podman-desktop/api';
-import { CommandRegistry } from './command-registry';
-import { ContainerProviderRegistry } from './container-registry';
-import { ExtensionLoader } from './extension-loader';
-import { TrayMenuRegistry } from './tray-menu-registry';
-import { ProviderRegistry } from './provider-registry';
-import type { IConfigurationPropertyRecordedSchema } from './configuration-registry';
-import { ConfigurationRegistry } from './configuration-registry';
-import { TerminalInit } from './terminal-init';
-import { ImageRegistry } from './image-registry';
+import { CommandRegistry } from './command-registry.js';
+import { ContainerProviderRegistry } from './container-registry.js';
+import { ExtensionLoader } from './extension-loader.js';
+import { TrayMenuRegistry } from './tray-menu-registry.js';
+import { ProviderRegistry } from './provider-registry.js';
+import type { IConfigurationPropertyRecordedSchema } from './configuration-registry.js';
+import { ConfigurationRegistry } from './configuration-registry.js';
+import { TerminalInit } from './terminal-init.js';
+import { ImageRegistry } from './image-registry.js';
 import { EventEmitter } from 'node:events';
 import type {
   PreflightCheckEvent,
@@ -38,70 +38,74 @@ import type {
   ProviderContainerConnectionInfo,
   ProviderInfo,
   ProviderKubernetesConnectionInfo,
-} from './api/provider-info';
+} from './api/provider-info.js';
 import type { WebContents } from 'electron';
 import { app, ipcMain, BrowserWindow, shell, clipboard } from 'electron';
-import type { ContainerCreateOptions, ContainerInfo, SimpleContainerInfo } from './api/container-info';
-import type { ImageInfo } from './api/image-info';
-import type { PullEvent } from './api/pull-event';
-import type { ExtensionInfo } from './api/extension-info';
-import type { ImageInspectInfo } from './api/image-inspect-info';
-import type { TrayMenu } from '../tray-menu';
-import { getFreePort } from './util/port';
-import { isLinux, isMac } from '../util';
-import type { MessageBoxOptions, MessageBoxReturnValue } from './message-box';
-import { MessageBox } from './message-box';
-import { ProgressImpl } from './progress-impl';
-import type { ContributionInfo } from './api/contribution-info';
-import { ContributionManager } from './contribution-manager';
-import { DockerDesktopInstallation } from './docker-extension/docker-desktop-installation';
-import { DockerPluginAdapter } from './docker-extension/docker-plugin-adapter';
-import { PAGE_EVENT_TYPE, Telemetry } from './telemetry/telemetry';
-import { NotificationImpl } from './notification-impl';
-import { StatusBarRegistry } from './statusbar/statusbar-registry';
-import type { StatusBarEntryDescriptor } from './statusbar/statusbar-registry';
+import type { ContainerCreateOptions, ContainerInfo, SimpleContainerInfo } from './api/container-info.js';
+import type { ImageInfo } from './api/image-info.js';
+import type { PullEvent } from './api/pull-event.js';
+import type { ExtensionInfo } from './api/extension-info.js';
+import type { ImageInspectInfo } from './api/image-inspect-info.js';
+import type { TrayMenu } from '../tray-menu.js';
+import { getFreePort } from './util/port.js';
+import { isLinux, isMac } from '../util.js';
+import type { MessageBoxOptions, MessageBoxReturnValue } from './message-box.js';
+import { MessageBox } from './message-box.js';
+import { ProgressImpl } from './progress-impl.js';
+import type { ContributionInfo } from './api/contribution-info.js';
+import { ContributionManager } from './contribution-manager.js';
+import { DockerDesktopInstallation } from './docker-extension/docker-desktop-installation.js';
+import { DockerPluginAdapter } from './docker-extension/docker-plugin-adapter.js';
+import { PAGE_EVENT_TYPE, Telemetry } from './telemetry/telemetry.js';
+import { NotificationImpl } from './notification-impl.js';
+import { StatusBarRegistry } from './statusbar/statusbar-registry.js';
+import type { StatusBarEntryDescriptor } from './statusbar/statusbar-registry.js';
 import type { IpcMainInvokeEvent } from 'electron/main';
-import type { ContainerInspectInfo } from './api/container-inspect-info';
-import type { HistoryInfo } from './api/history-info';
-import type { PodInfo, PodInspectInfo } from './api/pod-info';
-import type { VolumeInspectInfo, VolumeListInfo } from './api/volume-info';
-import type { ContainerStatsInfo } from './api/container-stats-info';
+import type { ContainerInspectInfo } from './api/container-inspect-info.js';
+import type { HistoryInfo } from './api/history-info.js';
+import type { PodInfo, PodInspectInfo } from './api/pod-info.js';
+import type { VolumeInspectInfo, VolumeListInfo } from './api/volume-info.js';
+import type { ContainerStatsInfo } from './api/container-stats-info.js';
 import type {
   PlayKubeInfo,
   PodCreateOptions,
   ContainerCreateOptions as PodmanContainerCreateOptions,
-} from './dockerode/libpod-dockerode';
+} from './dockerode/libpod-dockerode.js';
 import type Dockerode from 'dockerode';
-import { AutostartEngine } from './autostart-engine';
-import { CloseBehavior } from './close-behavior';
-import { TrayIconColor } from './tray-icon-color';
-import { KubernetesClient } from './kubernetes-client';
+import { AutostartEngine } from './autostart-engine.js';
+import { CloseBehavior } from './close-behavior.js';
+import { TrayIconColor } from './tray-icon-color.js';
+import { KubernetesClient } from './kubernetes-client.js';
 import type { V1Pod, V1ConfigMap, V1NamespaceList, V1PodList, V1Service, V1Ingress } from '@kubernetes/client-node';
-import type { V1Route } from './api/openshift-types';
-import type { NetworkInspectInfo } from './api/network-info';
-import { FilesystemMonitoring } from './filesystem-monitoring';
-import { Certificates } from './certificates';
-import { Proxy } from './proxy';
-import { EditorInit } from './editor-init';
-import { WelcomeInit } from './welcome/welcome-init';
-import { ExtensionInstaller } from './install/extension-installer';
-import { InputQuickPickRegistry } from './input-quickpick/input-quickpick-registry';
-import type { Menu } from '/@/plugin/menu-registry';
-import { MenuRegistry } from '/@/plugin/menu-registry';
-import { CancellationTokenRegistry } from './cancellation-token-registry';
+import type { V1Route } from './api/openshift-types.js';
+import type { NetworkInspectInfo } from './api/network-info.js';
+import { FilesystemMonitoring } from './filesystem-monitoring.js';
+import { Certificates } from './certificates.js';
+import { Proxy } from './proxy.js';
+import { EditorInit } from './editor-init.js';
+import { WelcomeInit } from './welcome/welcome-init.js';
+import { ExtensionInstaller } from './install/extension-installer.js';
+import { InputQuickPickRegistry } from './input-quickpick/input-quickpick-registry.js';
+import type { Menu } from '/@/plugin/menu-registry.js';
+import { MenuRegistry } from '/@/plugin/menu-registry.js';
+import { CancellationTokenRegistry } from './cancellation-token-registry.js';
 import type { UpdateCheckResult } from 'electron-updater';
 import { autoUpdater } from 'electron-updater';
-import type { ApiSenderType } from './api';
-import type { AuthenticationProviderInfo } from './authentication';
-import { AuthenticationImpl } from './authentication';
-import checkDiskSpace from 'check-disk-space';
-import { TaskManager } from '/@/plugin/task-manager';
-import { Featured } from './featured/featured';
-import type { FeaturedExtension } from './featured/featured-api';
-import { ExtensionsCatalog } from './extensions-catalog/extensions-catalog';
-import { securityRestrictionCurrentHandler } from '../security-restrictions-handler';
-import { ExtensionsUpdater } from './extensions-updater/extensions-updater';
-import type { CatalogExtension } from './extensions-catalog/extensions-catalog-api';
+import type { ApiSenderType } from './api.js';
+import type { AuthenticationProviderInfo } from './authentication.js';
+import { AuthenticationImpl } from './authentication.js';
+import checkDiskSpacePkg from 'check-disk-space';
+// workaround for ESM
+const checkDiskSpace: (path: string) => Promise<{ free: number }> = checkDiskSpacePkg as unknown as (
+  path: string,
+) => Promise<{ free: number }>;
+import { TaskManager } from '/@/plugin/task-manager.js';
+import { Featured } from './featured/featured.js';
+import type { FeaturedExtension } from './featured/featured-api.js';
+import { ExtensionsCatalog } from './extensions-catalog/extensions-catalog.js';
+import { securityRestrictionCurrentHandler } from '../security-restrictions-handler.js';
+import { ExtensionsUpdater } from './extensions-updater/extensions-updater.js';
+import type { CatalogExtension } from './extensions-catalog/extensions-catalog-api.js';
 
 type LogType = 'log' | 'warn' | 'trace' | 'debug' | 'error';
 

--- a/packages/main/src/plugin/input-quickpick/input-quickpick-registry.ts
+++ b/packages/main/src/plugin/input-quickpick/input-quickpick-registry.ts
@@ -22,8 +22,8 @@ import type {
   InputBoxValidationMessage,
   QuickPickOptions,
 } from '@podman-desktop/api';
-import type { ApiSenderType } from '../api';
-import { Deferred } from '../util/deferred';
+import type { ApiSenderType } from '../api.js';
+import { Deferred } from '../util/deferred.js';
 
 export class InputQuickPickRegistry {
   private callbackId = 0;

--- a/packages/main/src/plugin/install/extension-installer.spec.ts
+++ b/packages/main/src/plugin/install/extension-installer.spec.ts
@@ -18,10 +18,10 @@
 
 import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
 
-import { ExtensionInstaller } from './extension-installer';
-import type { ApiSenderType } from '../api';
-import type { ExtensionLoader } from '../extension-loader';
-import type { ImageRegistry } from '../image-registry';
+import { ExtensionInstaller } from './extension-installer.js';
+import type { ApiSenderType } from '../api.js';
+import type { ExtensionLoader } from '../extension-loader.js';
+import type { ImageRegistry } from '../image-registry.js';
 import * as path from 'node:path';
 
 let extensionInstaller: ExtensionInstaller;

--- a/packages/main/src/plugin/install/extension-installer.ts
+++ b/packages/main/src/plugin/install/extension-installer.ts
@@ -23,9 +23,9 @@ import * as path from 'node:path';
 import * as os from 'node:os';
 import { cp } from 'node:fs/promises';
 import * as tarFs from 'tar-fs';
-import type { ExtensionLoader } from '../extension-loader';
-import type { ApiSenderType } from '../api';
-import type { ImageRegistry } from '../image-registry';
+import type { ExtensionLoader } from '../extension-loader.js';
+import type { ApiSenderType } from '../api.js';
+import type { ImageRegistry } from '../image-registry.js';
 
 export class ExtensionInstaller {
   constructor(

--- a/packages/main/src/plugin/kubernetes-client.spec.ts
+++ b/packages/main/src/plugin/kubernetes-client.spec.ts
@@ -17,12 +17,12 @@
  ***********************************************************************/
 
 import { beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
-import { KubernetesClient } from './kubernetes-client';
-import type { ApiSenderType } from './api';
-import type { ConfigurationRegistry } from './configuration-registry';
-import { FilesystemMonitoring } from './filesystem-monitoring';
+import { KubernetesClient } from './kubernetes-client.js';
+import type { ApiSenderType } from './api.js';
+import type { ConfigurationRegistry } from './configuration-registry.js';
+import { FilesystemMonitoring } from './filesystem-monitoring.js';
 import { KubeConfig } from '@kubernetes/client-node';
-import type { Telemetry } from '/@/plugin/telemetry/telemetry';
+import type { Telemetry } from '/@/plugin/telemetry/telemetry.js';
 
 const configurationRegistry: ConfigurationRegistry = {} as unknown as ConfigurationRegistry;
 const fileSystemMonitoring: FilesystemMonitoring = new FilesystemMonitoring();

--- a/packages/main/src/plugin/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes-client.ts
@@ -40,20 +40,20 @@ import {
   Watch,
   VersionApi,
 } from '@kubernetes/client-node';
-import type { V1Route } from './api/openshift-types';
+import type { V1Route } from './api/openshift-types.js';
 import type * as containerDesktopAPI from '@podman-desktop/api';
-import { Emitter } from './events/emitter';
-import { Uri } from './types/uri';
+import { Emitter } from './events/emitter.js';
+import { Uri } from './types/uri.js';
 import { homedir } from 'node:os';
 import { resolve } from 'node:path';
 import { existsSync } from 'node:fs';
-import type { ConfigurationRegistry, IConfigurationNode } from './configuration-registry';
-import type { FilesystemMonitoring } from './filesystem-monitoring';
-import type { PodInfo } from './api/pod-info';
+import type { ConfigurationRegistry, IConfigurationNode } from './configuration-registry.js';
+import type { FilesystemMonitoring } from './filesystem-monitoring.js';
+import type { PodInfo } from './api/pod-info.js';
 import { PassThrough } from 'node:stream';
-import type { ApiSenderType } from './api';
+import type { ApiSenderType } from './api.js';
 import { parseAllDocuments } from 'yaml';
-import type { Telemetry } from '/@/plugin/telemetry/telemetry';
+import type { Telemetry } from '/@/plugin/telemetry/telemetry.js';
 
 function toContainerStatus(state: V1ContainerState | undefined): string {
   if (state) {

--- a/packages/main/src/plugin/menu-registry.spec.ts
+++ b/packages/main/src/plugin/menu-registry.spec.ts
@@ -17,9 +17,9 @@
  ***********************************************************************/
 
 import { beforeAll, beforeEach, expect, expectTypeOf, test, vi } from 'vitest';
-import { MenuRegistry } from './menu-registry';
-import { CommandRegistry } from './command-registry';
-import type { Telemetry } from '/@/plugin/telemetry/telemetry';
+import { MenuRegistry } from './menu-registry.js';
+import { CommandRegistry } from './command-registry.js';
+import type { Telemetry } from '/@/plugin/telemetry/telemetry.js';
 
 let menuRegistry: MenuRegistry;
 let commandRegistry;

--- a/packages/main/src/plugin/menu-registry.ts
+++ b/packages/main/src/plugin/menu-registry.ts
@@ -15,7 +15,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
-import type { CommandRegistry } from './command-registry';
+import type { CommandRegistry } from './command-registry.js';
 
 export interface Menu {
   command: string;

--- a/packages/main/src/plugin/message-box.ts
+++ b/packages/main/src/plugin/message-box.ts
@@ -15,7 +15,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
-import { Deferred } from './util/deferred';
+import { Deferred } from './util/deferred.js';
 
 type DialogType = 'none' | 'info' | 'error' | 'question' | 'warning';
 

--- a/packages/main/src/plugin/notification-impl.ts
+++ b/packages/main/src/plugin/notification-impl.ts
@@ -18,7 +18,7 @@
 
 import type * as containerDesktopAPI from '@podman-desktop/api';
 import { Notification } from 'electron';
-import { Disposable } from './types/disposable';
+import { Disposable } from './types/disposable.js';
 
 export class NotificationImpl {
   showNotification(options: containerDesktopAPI.NotificationOptions): Disposable {

--- a/packages/main/src/plugin/progress-impl.spec.ts
+++ b/packages/main/src/plugin/progress-impl.spec.ts
@@ -19,9 +19,9 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 
 import { beforeEach, expect, test, vi } from 'vitest';
-import type { ApiSenderType } from './api';
-import { ProgressImpl, ProgressLocation } from './progress-impl';
-import { TaskManager } from './task-manager';
+import type { ApiSenderType } from './api.js';
+import { ProgressImpl, ProgressLocation } from './progress-impl.js';
+import { TaskManager } from './task-manager.js';
 
 const apiSenderSendMock = vi.fn();
 

--- a/packages/main/src/plugin/progress-impl.ts
+++ b/packages/main/src/plugin/progress-impl.ts
@@ -16,9 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 import type * as extensionApi from '@podman-desktop/api';
-import { findWindow } from '../util';
-import { CancellationTokenImpl } from './cancellation-token';
-import type { TaskManager } from '/@/plugin/task-manager';
+import { findWindow } from '../util.js';
+import { CancellationTokenImpl } from './cancellation-token.js';
+import type { TaskManager } from '/@/plugin/task-manager.js';
 
 export enum ProgressLocation {
   /**

--- a/packages/main/src/plugin/provider-impl.ts
+++ b/packages/main/src/plugin/provider-impl.ts
@@ -16,9 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { Disposable } from './types/disposable';
-import type { IDisposable } from './types/disposable';
-import type { ContainerProviderRegistry } from './container-registry';
+import { Disposable } from './types/disposable.js';
+import type { IDisposable } from './types/disposable.js';
+import type { ContainerProviderRegistry } from './container-registry.js';
 
 import type {
   ContainerProviderConnection,
@@ -39,8 +39,8 @@ import type {
   KubernetesProviderConnectionFactory,
   ProviderInformation,
 } from '@podman-desktop/api';
-import type { ProviderRegistry } from './provider-registry';
-import { Emitter } from './events/emitter';
+import type { ProviderRegistry } from './provider-registry.js';
+import { Emitter } from './events/emitter.js';
 
 export class ProviderImpl implements Provider, IDisposable {
   private containerProviderConnections: Set<ContainerProviderConnection>;

--- a/packages/main/src/plugin/provider-registry.spec.ts
+++ b/packages/main/src/plugin/provider-registry.spec.ts
@@ -19,13 +19,13 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 
 import { beforeEach, expect, test, vi } from 'vitest';
-import type { ContainerProviderRegistry } from './container-registry';
+import type { ContainerProviderRegistry } from './container-registry.js';
 
-import { ProviderRegistry } from './provider-registry';
-import type { Telemetry } from './telemetry/telemetry';
+import { ProviderRegistry } from './provider-registry.js';
+import type { Telemetry } from './telemetry/telemetry.js';
 import type { ContainerProviderConnection, KubernetesProviderConnection } from '@podman-desktop/api';
-import type { ProviderContainerConnectionInfo, ProviderKubernetesConnectionInfo } from './api/provider-info';
-import type { ApiSenderType } from './api';
+import type { ProviderContainerConnectionInfo, ProviderKubernetesConnectionInfo } from './api/provider-info.js';
+import type { ApiSenderType } from './api.js';
 
 let providerRegistry: ProviderRegistry;
 

--- a/packages/main/src/plugin/provider-registry.ts
+++ b/packages/main/src/plugin/provider-registry.ts
@@ -46,15 +46,15 @@ import type {
   ProviderKubernetesConnectionInfo,
   LifecycleMethod,
   PreflightChecksCallback,
-} from './api/provider-info';
-import type { ContainerProviderRegistry } from './container-registry';
-import type { Event } from './events/emitter';
-import { Emitter } from './events/emitter';
-import { LifecycleContextImpl, LoggerImpl } from './lifecycle-context';
-import { ProviderImpl } from './provider-impl';
-import type { Telemetry } from './telemetry/telemetry';
-import { Disposable } from './types/disposable';
-import type { ApiSenderType } from './api';
+} from './api/provider-info.js';
+import type { ContainerProviderRegistry } from './container-registry.js';
+import type { Event } from './events/emitter.js';
+import { Emitter } from './events/emitter.js';
+import { LifecycleContextImpl, LoggerImpl } from './lifecycle-context.js';
+import { ProviderImpl } from './provider-impl.js';
+import type { Telemetry } from './telemetry/telemetry.js';
+import { Disposable } from './types/disposable.js';
+import type { ApiSenderType } from './api.js';
 
 export type ProviderEventListener = (name: string, providerInfo: ProviderInfo) => void;
 export type ProviderLifecycleListener = (

--- a/packages/main/src/plugin/proxy.ts
+++ b/packages/main/src/plugin/proxy.ts
@@ -17,8 +17,8 @@
  ***********************************************************************/
 
 import type { ProxySettings, Event } from '@podman-desktop/api';
-import type { ConfigurationRegistry, IConfigurationNode } from './configuration-registry';
-import { Emitter } from './events/emitter';
+import type { ConfigurationRegistry, IConfigurationNode } from './configuration-registry.js';
+import { Emitter } from './events/emitter.js';
 
 /**
  * Handle proxy settings for Podman Desktop

--- a/packages/main/src/plugin/statusbar/statusbar-item.ts
+++ b/packages/main/src/plugin/statusbar/statusbar-item.ts
@@ -18,7 +18,7 @@
 
 import type { StatusBarAlignment, StatusBarItem } from '@podman-desktop/api';
 import crypto from 'node:crypto';
-import type { StatusBarRegistry } from './statusbar-registry';
+import type { StatusBarRegistry } from './statusbar-registry.js';
 
 export const StatusBarAlignLeft = 'LEFT';
 export const StatusBarAlignRight = 'RIGHT';

--- a/packages/main/src/plugin/statusbar/statusbar-registry.ts
+++ b/packages/main/src/plugin/statusbar/statusbar-registry.ts
@@ -16,8 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { ApiSenderType } from '../api';
-import type { IDisposable } from '../types/disposable';
+import type { ApiSenderType } from '../api.js';
+import type { IDisposable } from '../types/disposable.js';
 
 export const STATUS_BAR_UPDATED_EVENT_NAME = 'status-bar-updated';
 

--- a/packages/main/src/plugin/task-manager.ts
+++ b/packages/main/src/plugin/task-manager.ts
@@ -16,8 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { ApiSenderType } from './api';
-import type { Task } from '/@/plugin/api/task';
+import type { ApiSenderType } from './api.js';
+import type { Task } from '/@/plugin/api/task.js';
 
 /**
  * Contribution manager to provide the list of external OCI contributions

--- a/packages/main/src/plugin/telemetry/telemetry.spec.ts
+++ b/packages/main/src/plugin/telemetry/telemetry.spec.ts
@@ -19,13 +19,13 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
-import type { ConfigurationRegistry } from '../configuration-registry';
+import type { ConfigurationRegistry } from '../configuration-registry.js';
 
-import { Telemetry, TelemetryLoggerImpl } from './telemetry';
-import { TelemetrySettings } from './telemetry-settings';
-import type { ExtensionInfo } from '../api/extension-info';
+import { Telemetry, TelemetryLoggerImpl } from './telemetry.js';
+import { TelemetrySettings } from './telemetry-settings.js';
+import type { ExtensionInfo } from '../api/extension-info.js';
 import type { TelemetrySender } from '@podman-desktop/api';
-import { TelemetryTrustedValue } from '../types/telemetry';
+import { TelemetryTrustedValue } from '../types/telemetry.js';
 
 const getConfigurationMock = vi.fn();
 const onDidChangeConfigurationMock = vi.fn();

--- a/packages/main/src/plugin/telemetry/telemetry.ts
+++ b/packages/main/src/plugin/telemetry/telemetry.ts
@@ -18,24 +18,24 @@
 
 import Analytics from 'analytics-node';
 import { app } from 'electron';
-import { Identity } from './identity';
+import { Identity } from './identity.js';
 import * as os from 'node:os';
 import type { LinuxOs } from 'getos';
 import getos from 'getos';
 import * as osLocale from 'os-locale';
 import { promisify } from 'node:util';
-import type { ConfigurationRegistry, IConfigurationNode } from '../configuration-registry';
-import { TelemetrySettings } from './telemetry-settings';
-import type { Event } from '../events/emitter';
-import { Emitter } from '../events/emitter';
+import type { ConfigurationRegistry, IConfigurationNode } from '../configuration-registry.js';
+import { TelemetrySettings } from './telemetry-settings.js';
+import type { Event } from '../events/emitter.js';
+import { Emitter } from '../events/emitter.js';
 import type {
   TelemetryLogger,
   TelemetryLoggerOptions,
   TelemetrySender,
   TelemetryTrustedValue,
 } from '@podman-desktop/api';
-import { TelemetryTrustedValue as TypeTelemetryTrustedValue } from '../types/telemetry';
-import { stoppedExtensions } from '../../util';
+import { TelemetryTrustedValue as TypeTelemetryTrustedValue } from '../types/telemetry.js';
+import { stoppedExtensions } from '../../util.js';
 
 export const TRACK_EVENT_TYPE = 'track';
 export const PAGE_EVENT_TYPE = 'page';

--- a/packages/main/src/plugin/terminal-init.ts
+++ b/packages/main/src/plugin/terminal-init.ts
@@ -16,8 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { IConfigurationNode, IConfigurationRegistry } from './configuration-registry';
-import { TerminalSettings } from './terminal-settings';
+import type { IConfigurationNode, IConfigurationRegistry } from './configuration-registry.js';
+import { TerminalSettings } from './terminal-settings.js';
 
 export class TerminalInit {
   private static DEFAULT_LINE_HEIGHT = 1;

--- a/packages/main/src/plugin/tray-icon-color.ts
+++ b/packages/main/src/plugin/tray-icon-color.ts
@@ -16,8 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { ConfigurationRegistry, IConfigurationNode } from './configuration-registry';
-import type { ProviderRegistry } from './provider-registry';
+import type { ConfigurationRegistry, IConfigurationNode } from './configuration-registry.js';
+import type { ProviderRegistry } from './provider-registry.js';
 
 export class TrayIconColor {
   constructor(private configurationRegistry: ConfigurationRegistry, private providerRegistry: ProviderRegistry) {}

--- a/packages/main/src/plugin/tray-menu-registry.spec.ts
+++ b/packages/main/src/plugin/tray-menu-registry.spec.ts
@@ -18,12 +18,12 @@
 
 import { ipcMain } from 'electron';
 import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
-import type { TrayMenu } from '../tray-menu';
-import type { ProviderInfo } from './api/provider-info';
-import type { CommandRegistry } from './command-registry';
-import type { ProviderRegistry } from './provider-registry';
-import type { Telemetry } from './telemetry/telemetry';
-import { TrayMenuRegistry } from './tray-menu-registry';
+import type { TrayMenu } from '../tray-menu.js';
+import type { ProviderInfo } from './api/provider-info.js';
+import type { CommandRegistry } from './command-registry.js';
+import type { ProviderRegistry } from './provider-registry.js';
+import type { Telemetry } from './telemetry/telemetry.js';
+import { TrayMenuRegistry } from './tray-menu-registry.js';
 
 let menuRegistry: TrayMenuRegistry;
 let trayMenu: TrayMenu;

--- a/packages/main/src/plugin/tray-menu-registry.ts
+++ b/packages/main/src/plugin/tray-menu-registry.ts
@@ -18,13 +18,13 @@
 
 import type { ProviderConnectionStatus, ProviderStatus } from '@podman-desktop/api';
 import { ipcMain, dialog } from 'electron';
-import type { TrayMenu } from '../tray-menu';
-import type { ProviderContainerConnectionInfo, ProviderInfo } from './api/provider-info';
-import type { MenuItem } from './api/tray-menu-info';
-import type { CommandRegistry } from './command-registry';
-import type { ProviderRegistry } from './provider-registry';
-import type { Telemetry } from './telemetry/telemetry';
-import { Disposable } from './types/disposable';
+import type { TrayMenu } from '../tray-menu.js';
+import type { ProviderContainerConnectionInfo, ProviderInfo } from './api/provider-info.js';
+import type { MenuItem } from './api/tray-menu-info.js';
+import type { CommandRegistry } from './command-registry.js';
+import type { ProviderRegistry } from './provider-registry.js';
+import type { Telemetry } from './telemetry/telemetry.js';
+import { Disposable } from './types/disposable.js';
 
 export interface TrayProviderConnectionInfo {
   name: string;

--- a/packages/main/src/plugin/types/uri.spec.ts
+++ b/packages/main/src/plugin/types/uri.spec.ts
@@ -18,7 +18,7 @@
 
 import { afterEach, expect, test, vi } from 'vitest';
 
-import { Uri } from './uri';
+import { Uri } from './uri.js';
 
 afterEach(() => {
   vi.resetAllMocks();

--- a/packages/main/src/plugin/util/spawn-promise.spec.ts
+++ b/packages/main/src/plugin/util/spawn-promise.spec.ts
@@ -19,7 +19,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import { beforeEach, expect, test, vi } from 'vitest';
-import { spawnWithPromise } from './spawn-promise';
+import { spawnWithPromise } from './spawn-promise.js';
 import { spawn } from 'node:child_process';
 import type { Readable } from 'node:stream';
 

--- a/packages/main/src/plugin/welcome/welcome-init.ts
+++ b/packages/main/src/plugin/welcome/welcome-init.ts
@@ -16,8 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { IConfigurationNode, IConfigurationRegistry } from '../configuration-registry';
-import { WelcomeSettings } from './welcome-settings';
+import type { IConfigurationNode, IConfigurationRegistry } from '../configuration-registry.js';
+import { WelcomeSettings } from './welcome-settings.js';
 
 export class WelcomeInit {
   constructor(private configurationRegistry: IConfigurationRegistry) {}

--- a/packages/main/src/security-restrictions.ts
+++ b/packages/main/src/security-restrictions.ts
@@ -18,7 +18,7 @@
 
 import { app, shell } from 'electron';
 import { URL } from 'url';
-import { securityRestrictionCurrentHandler } from './security-restrictions-handler';
+import { securityRestrictionCurrentHandler } from './security-restrictions-handler.js';
 
 /**
  * List of origins that you allow open INSIDE the application and permissions for each of them.

--- a/packages/main/src/system/macos-startup.ts
+++ b/packages/main/src/system/macos-startup.ts
@@ -19,7 +19,7 @@
 import { app } from 'electron';
 import fs from 'node:fs';
 import path from 'node:path';
-import type { ConfigurationRegistry } from '../plugin/configuration-registry';
+import type { ConfigurationRegistry } from '../plugin/configuration-registry.js';
 
 /**
  * On macOS, startup on login is done via a plist file

--- a/packages/main/src/system/startup-install.ts
+++ b/packages/main/src/system/startup-install.ts
@@ -17,9 +17,9 @@
  ***********************************************************************/
 
 import * as os from 'node:os';
-import type { ConfigurationRegistry, IConfigurationNode } from '../plugin/configuration-registry';
-import { MacosStartup } from './macos-startup';
-import { WindowsStartup } from './windows-startup';
+import type { ConfigurationRegistry, IConfigurationNode } from '../plugin/configuration-registry.js';
+import { MacosStartup } from './macos-startup.js';
+import { WindowsStartup } from './windows-startup.js';
 
 export class StartupInstall {
   private osStartup: MacosStartup | WindowsStartup | undefined;

--- a/packages/main/src/system/windows-startup.ts
+++ b/packages/main/src/system/windows-startup.ts
@@ -19,7 +19,7 @@
 import { app } from 'electron';
 import fs from 'node:fs';
 import path from 'node:path';
-import type { ConfigurationRegistry } from '../plugin/configuration-registry';
+import type { ConfigurationRegistry } from '../plugin/configuration-registry.js';
 
 /**
  * On Windows, launching program automatically on startup is done via %APPDATA%\Roaming\Microsoft\Windows\Start Menu\Programs\Startup folder

--- a/packages/main/src/tray-animate-icon.spec.ts
+++ b/packages/main/src/tray-animate-icon.spec.ts
@@ -17,7 +17,7 @@
  ***********************************************************************/
 
 import { beforeEach, expect, test, vi } from 'vitest';
-import { AnimatedTray } from './tray-animate-icon';
+import { AnimatedTray } from './tray-animate-icon.js';
 import * as path from 'path';
 import { app } from 'electron';
 

--- a/packages/main/src/tray-animate-icon.ts
+++ b/packages/main/src/tray-animate-icon.ts
@@ -19,7 +19,7 @@
 import type { Tray } from 'electron';
 import { app, nativeTheme } from 'electron';
 import * as path from 'path';
-import { isLinux, isMac } from './util';
+import { isLinux, isMac } from './util.js';
 export type TrayIconStatus = 'initialized' | 'updating' | 'error' | 'ready';
 
 export class AnimatedTray {

--- a/packages/main/src/tray-menu.spec.ts
+++ b/packages/main/src/tray-menu.spec.ts
@@ -19,9 +19,9 @@
 import type { MenuItemConstructorOptions, Tray } from 'electron';
 import { nativeImage, Menu, ipcMain } from 'electron';
 import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
-import type { ProviderInfo } from './plugin/api/provider-info';
-import type { AnimatedTray } from './tray-animate-icon';
-import { TrayMenu } from './tray-menu';
+import type { ProviderInfo } from './plugin/api/provider-info.js';
+import type { AnimatedTray } from './tray-animate-icon.js';
+import { TrayMenu } from './tray-menu.js';
 import statusStopped from './assets/status-stopped.png';
 
 let trayMenu: TrayMenu;

--- a/packages/main/src/tray-menu.ts
+++ b/packages/main/src/tray-menu.ts
@@ -22,10 +22,10 @@ import type { MenuItemConstructorOptions, Tray, NativeImage } from 'electron';
 import statusStarted from './assets/status-started.png';
 import statusStopped from './assets/status-stopped.png';
 import statusUnknown from './assets/status-unknown.png';
-import { findWindow, isMac } from './util';
+import { findWindow, isMac } from './util.js';
 import statusBusy from './assets/status-busy.png';
-import type { AnimatedTray, TrayIconStatus } from './tray-animate-icon';
-import type { ProviderContainerConnectionInfo, ProviderInfo } from './plugin/api/provider-info';
+import type { AnimatedTray, TrayIconStatus } from './tray-animate-icon.js';
+import type { ProviderContainerConnectionInfo, ProviderInfo } from './plugin/api/provider-info.js';
 
 // extends type from the plugin
 interface ProviderMenuItem extends ProviderInfo {

--- a/packages/main/tsconfig.json
+++ b/packages/main/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
-    "module": "esnext",
+    "module": "node16",
     "target": "esnext",
     "sourceMap": false,
-    "moduleResolution": "Node",
+    "moduleResolution": "node16",
     "skipLibCheck": true,
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,


### PR DESCRIPTION

### What does this PR do?
moving to something up-to-date :-)
will allow to bump got library

It was straightforward except for two libraries: `check-disk-usage` and `validator`. There are workarounds (we specify the function that is available manually)

For now, all imports in main package need to be suffixed by '.js' (you can browse typescript/esm docs)

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

### How to test this PR?


But please check 'creating a new podman machine' (it should check the disk space using `check-disk-usage` library)

and try to add a valid registry URL and invalid registry URL (for `validator` library)



Change-Id: I854c62df5ba99d0bdc0b6f0f42bb653c7c990e8b
