### PR TITLE
chore: ensures jobs are using the current LTS version of Ubuntu

### DIFF
--- a/.github/workflows/next-build.yaml
+++ b/.github/workflows/next-build.yaml
@@ -31,7 +31,7 @@ jobs:
 
   tag:
     name: Tagging
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       githubTag: ${{ steps.TAG_UTIL.outputs.githubTag}}
       desktopVersion: ${{ steps.TAG_UTIL.outputs.desktopVersion}}
@@ -75,7 +75,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2022, ubuntu-20.04, macos-11]
+        os: [windows-2022, ubuntu-22.04, macos-11]
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v3
@@ -95,7 +95,7 @@ jobs:
         run: echo "dir=$(yarn cache dir)" >> ${env:GITHUB_OUTPUT}
 
       - name: Get yarn cache directory path (mac/Linux)
-        if: ${{ matrix.os=='ubuntu-20.04' || matrix.os=='macos-11' }}
+        if: ${{ matrix.os=='ubuntu-22.04' || matrix.os=='macos-11' }}
         id: yarn-cache-dir-path-unix
         run: echo "dir=$(yarn cache dir)" >> ${GITHUB_OUTPUT}
 
@@ -109,7 +109,7 @@ jobs:
             ${{ runner.os }}-yarn-
 
       - uses: actions/cache@v3
-        if: ${{ matrix.os=='ubuntu-20.04' || matrix.os=='macos-11' }}
+        if: ${{ matrix.os=='ubuntu-22.04' || matrix.os=='macos-11' }}
         id: yarn-cache-unix
         with:
           path: ${{ steps.yarn-cache-dir-path-unix.outputs.dir }}
@@ -127,7 +127,7 @@ jobs:
           yarn --frozen-lockfile --network-timeout 180000
 
       - name: Install flatpak on Linux
-        if: ${{ matrix.os=='ubuntu-20.04' }}
+        if: ${{ matrix.os=='ubuntu-22.04' }}
         run: |
           sudo apt-get update
           sudo apt-get install flatpak -y
@@ -162,7 +162,7 @@ jobs:
   release:
     needs: [tag, build]
     name: Release
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: id
         run: echo the release id is ${{ needs.tag.outputs.releaseId}}
@@ -177,7 +177,7 @@ jobs:
   publish:
     needs: [tag, release]
     name: Publish
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/.github/workflows/pr-check-vale.yaml
+++ b/.github/workflows/pr-check-vale.yaml
@@ -26,7 +26,7 @@ on:
 jobs:
   vale:
     name: runner / vale
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: errata-ai/vale-action@d074f98809cbae059386851971544a281fd9f593 # reviewdog branch, https://github.com/errata-ai/vale-action/commit/d074f98809cbae059386851971544a281fd9f593

--- a/.github/workflows/pr-check-website.yaml
+++ b/.github/workflows/pr-check-website.yaml
@@ -27,7 +27,7 @@ on:
 jobs:
   website-build:
     name: build website
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -67,7 +67,7 @@ jobs:
 
   linux:
     name: Linux
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 40
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -172,7 +172,7 @@ jobs:
 
   lint-format-unit:
     name: linter, formatters and unit tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/.github/workflows/publish-to-chocolatey.yaml
+++ b/.github/workflows/publish-to-chocolatey.yaml
@@ -1,12 +1,12 @@
 #
 # Copyright (C) 2022 Red Hat, Inc.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 # SPDX-License-Identifier: Apache-2.0
- 
+
 name: Publish update to Chocolatey
 
 on:
@@ -26,7 +26,7 @@ on:
       force:
         description: 'Force the push of the package'
         required: false
-        default: 'false'        
+        default: 'false'
   repository_dispatch:
     types: [ publish-to-chocolatey ]
 
@@ -34,7 +34,7 @@ jobs:
 
   version:
     name: Extracting version
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       desktopVersion: ${{ steps.VERSION.outputs.desktopVersion}}
 
@@ -65,7 +65,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install the Chocolatey Automatic Package Updater Module
-        run: cinst au      
+        run: cinst au
       - name: Build the Podman Desktop chocolatey Package by making sure we're using the latest release
         working-directory: ./.chocolatey/podman-desktop
         run: |

--- a/.github/workflows/publish-to-winget.yaml
+++ b/.github/workflows/publish-to-winget.yaml
@@ -1,12 +1,12 @@
 #
 # Copyright (C) 2022 Red Hat, Inc.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 # SPDX-License-Identifier: Apache-2.0
- 
+
 name: Publish update to Winget
 
 on:
@@ -30,7 +30,7 @@ jobs:
 
   version:
     name: Extracting version
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       desktopVersion: ${{ steps.VERSION.outputs.desktopVersion}}
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,7 +35,7 @@ jobs:
 
   tag:
     name: Tagging
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       githubTag: ${{ steps.TAG_UTIL.outputs.githubTag}}
       desktopVersion: ${{ steps.TAG_UTIL.outputs.desktopVersion}}
@@ -131,7 +131,7 @@ jobs:
           - os: "macos-11"
           - os: "macos-11"
             airgap: "true"
-          - os: "ubuntu-20.04"
+          - os: "ubuntu-22.04"
     timeout-minutes: 60
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -153,7 +153,7 @@ jobs:
         run: echo "dir=$(yarn cache dir)" >> ${env:GITHUB_OUTPUT}
 
       - name: Get yarn cache directory path (mac/Linux)
-        if: ${{ matrix.os=='ubuntu-20.04' || matrix.os=='macos-11' }}
+        if: ${{ matrix.os=='ubuntu-22.04' || matrix.os=='macos-11' }}
         id: yarn-cache-dir-path-unix
         run: echo "dir=$(yarn cache dir)" >> ${GITHUB_OUTPUT}
 
@@ -167,7 +167,7 @@ jobs:
             ${{ runner.os }}-yarn-
 
       - uses: actions/cache@v3
-        if: ${{ matrix.os=='ubuntu-20.04' || matrix.os=='macos-11' }}
+        if: ${{ matrix.os=='ubuntu-22.04' || matrix.os=='macos-11' }}
         id: yarn-cache-unix
         with:
           path: ${{ steps.yarn-cache-dir-path-unix.outputs.dir }}
@@ -184,7 +184,7 @@ jobs:
           yarn --frozen-lockfile --network-timeout 180000
 
       - name: Install flatpak on Linux
-        if: ${{ matrix.os=='ubuntu-20.04' }}
+        if: ${{ matrix.os=='ubuntu-22.04' }}
         run: |
           sudo apt-get update
           sudo apt-get install flatpak -y
@@ -220,7 +220,7 @@ jobs:
   release:
     needs: [tag, build]
     name: Release
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: id
         run: echo the release id is ${{ needs.tag.outputs.releaseId}}
@@ -235,7 +235,7 @@ jobs:
   publish:
     needs: [tag, release]
     name: Publish
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/.github/workflows/website-next.yaml
+++ b/.github/workflows/website-next.yaml
@@ -1,12 +1,12 @@
 #
 # Copyright (C) 2022 Red Hat, Inc.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 # SPDX-License-Identifier: Apache-2.0
- 
+
 name: Publish Website
 
 on:
@@ -29,11 +29,11 @@ on:
 
 env:
   GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-  
+
 jobs:
   deploy:
     name: Build and deploy website
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION

### What does this PR do?
ensures jobs are using the current LTS version of Ubuntu

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

Consistency between old jobs using 20.04, some 22.04 and one using latest alias

### How to test this PR?

PR checks should be green

Change-Id: Id51f4cdf99a94f4bb37711f5f15aa881f6daf7d2
