### PR TITLE
feat: install provider if not installed when clicking on create new button (#2706)

### DIFF
--- a/packages/renderer/src/lib/dashboard/PreflightChecks.svelte
+++ b/packages/renderer/src/lib/dashboard/PreflightChecks.svelte
@@ -11,28 +11,36 @@ function openLink(e: MouseEvent, url: string): void {
 </script>
 
 {#if preflightChecks.length > 0}
-  <div class="flex flex-col w-full mt-5 px-5 pt-5 pb-0 rounded-lg bg-zinc-600">
+  <div class="flex flex-col w-full mt-5 px-5 pt-5 pb-1 rounded-lg bg-zinc-600">
     {#each preflightChecks as preCheck}
-      <div class="flex flex-col">
-        <p class="mb-4 items-center list-inside">
+      <div class="flex flex-row mb-4">
+        <div>
           {#if preCheck.successful === undefined}
             <svg class="pf-c-spinner pf-m-sm" role="progressbar" viewBox="0 0 100 100" aria-label="Checkin...">
               <circle class="pf-c-spinner__path" cx="50" cy="50" r="45" fill="none"></circle>
             </svg>
           {:else}
             {preCheck.successful ? '✅' : '❌'}
-          {/if}
-          {preCheck.name}
-        </p>
-        {#if preCheck.description}
-          Details: <p class="text-gray-400 w-full break-all">{preCheck.description}</p>
-          {#if preCheck.docLinks}
-            See:
-            {#each preCheck.docLinks as link}
-              <a href="{link.url}" target="_blank" on:click="{e => openLink(e, link.url)}">{link.title}</a>
-            {/each}
-          {/if}
+          {/if}          
+        </div>
+        <div class="flex flex-col ml-1">
+          <span>{preCheck.name}</span>
+          {#if preCheck.description}
+          <div class="flex flex-col mt-2 basis-1/4">
+            <span>Details:</span>
+            <span class="text-gray-500 w-full mt-0.5">{preCheck.description}</span>
+            {#if preCheck.docLinks}
+              <div class="flex flex-row mt-0.5">
+                <span class="mr-1">See:</span>
+                {#each preCheck.docLinks as link}
+                  <a href="{link.url}" target="_blank" class="mr-1" on:click="{e => openLink(e, link.url)}">{link.title}</a>
+                {/each}
+              </div>              
+            {/if}
+          </div>          
         {/if}
+        </div>
+        
       </div>
     {/each}
   </div>

--- a/packages/renderer/src/lib/dashboard/PreflightChecks.svelte
+++ b/packages/renderer/src/lib/dashboard/PreflightChecks.svelte
@@ -11,36 +11,28 @@ function openLink(e: MouseEvent, url: string): void {
 </script>
 
 {#if preflightChecks.length > 0}
-  <div class="flex flex-col w-full mt-5 px-5 pt-5 pb-1 rounded-lg bg-zinc-600">
+  <div class="flex flex-col w-full mt-5 px-5 pt-5 pb-0 rounded-lg bg-zinc-600">
     {#each preflightChecks as preCheck}
-      <div class="flex flex-row mb-4">
-        <div>
+      <div class="flex flex-col">
+        <p class="mb-4 items-center list-inside">
           {#if preCheck.successful === undefined}
             <svg class="pf-c-spinner pf-m-sm" role="progressbar" viewBox="0 0 100 100" aria-label="Checkin...">
               <circle class="pf-c-spinner__path" cx="50" cy="50" r="45" fill="none"></circle>
             </svg>
           {:else}
             {preCheck.successful ? '✅' : '❌'}
-          {/if}          
-        </div>
-        <div class="flex flex-col ml-1">
-          <span>{preCheck.name}</span>
-          {#if preCheck.description}
-          <div class="flex flex-col mt-2 basis-1/4">
-            <span>Details:</span>
-            <span class="text-gray-500 w-full mt-0.5">{preCheck.description}</span>
-            {#if preCheck.docLinks}
-              <div class="flex flex-row mt-0.5">
-                <span class="mr-1">See:</span>
-                {#each preCheck.docLinks as link}
-                  <a href="{link.url}" target="_blank" class="mr-1" on:click="{e => openLink(e, link.url)}">{link.title}</a>
-                {/each}
-              </div>              
-            {/if}
-          </div>          
+          {/if}
+          {preCheck.name}
+        </p>
+        {#if preCheck.description}
+          Details: <p class="text-gray-400 w-full break-all">{preCheck.description}</p>
+          {#if preCheck.docLinks}
+            See:
+            {#each preCheck.docLinks as link}
+              <a href="{link.url}" target="_blank" on:click="{e => openLink(e, link.url)}">{link.title}</a>
+            {/each}
+          {/if}
         {/if}
-        </div>
-        
       </div>
     {/each}
   </div>

--- a/packages/renderer/src/lib/preferences/PreferencesProviderInstallationModal.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesProviderInstallationModal.spec.ts
@@ -1,0 +1,144 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom';
+import { test, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import type { ProviderInfo } from '../../../../main/src/plugin/api/provider-info';
+import userEvent from '@testing-library/user-event';
+import PreferencesProviderInstallationModal from './PreferencesProviderInstallationModal.svelte';
+
+const providerInfo: ProviderInfo = {
+  id: 'podman',
+  name: 'podman',
+  images: {
+    icon: 'img',
+  },
+  status: 'started',
+  warnings: undefined,
+  containerProviderConnectionCreation: true,
+  detectionChecks: undefined,
+  containerConnections: [
+    {
+      name: 'machine',
+      status: 'started',
+      endpoint: {
+        socketPath: 'socket',
+      },
+      lifecycleMethods: ['start', 'stop', 'delete'],
+      type: 'podman',
+    },
+  ],
+  installationSupport: undefined,
+  internalId: '0',
+  kubernetesConnections: [],
+  kubernetesProviderConnectionCreation: true,
+  links: undefined,
+  containerProviderConnectionInitialization: false,
+  containerProviderConnectionCreationDisplayName: 'Podman machine',
+  kubernetesProviderConnectionInitialization: false,
+};
+
+const closeCallback = vi.fn();
+const doCreateNew = vi.fn();
+
+test('Expect to call closeCallback if clicking on Close', async () => {
+  render(PreferencesProviderInstallationModal, {
+    providerToBeInstalled: {
+      provider: providerInfo,
+      displayName: 'provider',
+    },
+    closeCallback,
+    doCreateNew,
+    preflightChecks: [],
+  });
+
+  const button = screen.getByRole('button', { name: 'Close' });
+  expect(button).toBeInTheDocument();
+
+  await userEvent.click(button);
+  expect(closeCallback).toBeCalled;
+});
+
+test('Expect to call closeCallback if clicking on Cancel', async () => {
+  render(PreferencesProviderInstallationModal, {
+    providerToBeInstalled: {
+      provider: providerInfo,
+      displayName: 'provider',
+    },
+    closeCallback,
+    doCreateNew,
+    preflightChecks: [],
+  });
+
+  const button = screen.getByRole('button', { name: 'Cancel' });
+  expect(button).toBeInTheDocument();
+
+  await userEvent.click(button);
+  expect(closeCallback).toBeCalled;
+});
+
+test('Expect to call doCreateNew if clicking on Next', async () => {
+  render(PreferencesProviderInstallationModal, {
+    providerToBeInstalled: {
+      provider: providerInfo,
+      displayName: 'provider',
+    },
+    closeCallback,
+    doCreateNew,
+    preflightChecks: [],
+  });
+
+  const button = screen.getByRole('button', { name: 'Next' });
+  expect(button).toBeInTheDocument();
+
+  await userEvent.click(button);
+  expect(doCreateNew).toBeCalled;
+});
+
+test('Expect no modal if providerToBeInstalled is undefined', async () => {
+  render(PreferencesProviderInstallationModal, {
+    providerToBeInstalled: undefined,
+    closeCallback,
+    doCreateNew,
+    preflightChecks: [],
+  });
+
+  const modal = screen.queryByLabelText('install provider');
+  expect(modal).not.toBeInTheDocument();
+});
+
+test('Expect preflight check entry if preflights checks has some value', async () => {
+  render(PreferencesProviderInstallationModal, {
+    providerToBeInstalled: {
+      provider: providerInfo,
+      displayName: 'provider',
+    },
+    closeCallback,
+    doCreateNew,
+    preflightChecks: [
+      {
+        name: 'check',
+        description: 'description',
+      },
+    ],
+  });
+
+  const span = screen.getByLabelText('description');
+  expect(span).toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/preferences/PreferencesProviderInstallationModal.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesProviderInstallationModal.svelte
@@ -68,7 +68,7 @@ function openLink(e: MouseEvent, url: string): void {
               type="button"
               aria-label="Next"
               on:click="{() => doCreateNew(providerToBeInstalled.provider, providerToBeInstalled.displayName)}"
-              >Next</button>
+              >Retry</button>
           </div>
         </div>
       </div>

--- a/packages/renderer/src/lib/preferences/PreferencesProviderInstallationModal.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesProviderInstallationModal.svelte
@@ -1,0 +1,77 @@
+<script lang="ts">
+import { faCircleXmark } from '@fortawesome/free-solid-svg-icons';
+import Fa from 'svelte-fa/src/fa.svelte';
+import Modal from '../dialogs/Modal.svelte';
+import ProviderLogo from '../dashboard/ProviderLogo.svelte';
+import type { ProviderInfo, CheckStatus } from '../../../../main/src/plugin/api/provider-info';
+
+export let providerToBeInstalled: { provider: ProviderInfo; displayName: string };
+export let preflightChecks: CheckStatus[];
+export let closeCallback: () => void;
+export let doCreateNew: (provider: ProviderInfo, displayName: string) => void;
+
+function openLink(e: MouseEvent, url: string): void {
+  e.preventDefault();
+  e.stopPropagation();
+  window.openExternal(url);
+}
+</script>
+
+{#if providerToBeInstalled}
+  <Modal on:close="{() => closeCallback()}">
+    <div
+      class="inline-block w-full overflow-hidden text-left transition-all transform bg-charcoal-600 z-50 rounded-xl shadow-xl shadow-neutral-900"
+      aria-label="install provider">
+      <div class="flex items-center justify-between px-5 py-4 mb-4">
+        <h1 class="text-md font-semibold">Create a new {providerToBeInstalled.displayName}</h1>
+        <button class="hover:text-gray-300 px-2 py-1" aria-label="Close" on:click="{() => closeCallback()}">
+          <i class="fas fa-times" aria-hidden="true"></i>
+        </button>
+      </div>
+      <div class="overflow-y-auto px-4 pb-4">
+        <div class="flex flex-col rounded-lg">
+          <div class="mx-auto max-w-[250px] mb-5">
+            <ProviderLogo provider="{providerToBeInstalled.provider}" />
+          </div>
+          <div class="flex flex-row mx-auto text-md">Some system requirements are missing.</div>
+          <div class="flex flex-col min-h-[150px] mt-5 mx-auto py-4 px-10 rounded-md bg-charcoal-800">
+            {#each preflightChecks as preCheck}
+              <div class="flex flex-row mb-2 mx-auto">
+                <Fa icon="{faCircleXmark}" class="text-red-500 mt-0.5" />
+                <div class="flex flex-col ml-1 text-sm">
+                  {#if preCheck.description}
+                    <span class="w-full" aria-label="{preCheck.description}">{preCheck.description}</span>
+                    {#if preCheck.docLinks}
+                      <div class="flex flex-row mt-0.5">
+                        <span class="mr-1">See:</span>
+                        {#each preCheck.docLinks as link}
+                          <a href="{link.url}" target="_blank" class="mr-1" on:click="{e => openLink(e, link.url)}"
+                            >{link.title}</a>
+                        {/each}
+                      </div>
+                    {/if}
+                  {:else}
+                    {preCheck.name}
+                  {/if}
+                </div>
+              </div>
+            {/each}
+          </div>
+          <div class="text-xs text-gray-800 mt-2 text-center">
+            Be sure that your system fulfills all the requirements above before proceeding
+          </div>
+          <div class="flex flex-row justify-end w-full pt-2">
+            <button aria-label="Cancel" class="text-xs hover:underline mr-3" on:click="{() => closeCallback()}"
+              >Cancel</button>
+            <button
+              class="pf-c-button pf-m-primary"
+              type="button"
+              aria-label="Next"
+              on:click="{() => doCreateNew(providerToBeInstalled.provider, providerToBeInstalled.displayName)}"
+              >Next</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </Modal>
+{/if}

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
@@ -26,7 +26,6 @@ import PreferencesConnectionActions from './PreferencesConnectionActions.svelte'
 import PreferencesConnectionsEmptyRendering from './PreferencesConnectionsEmptyRendering.svelte';
 import Modal from '../dialogs/Modal.svelte';
 import ProviderLogo from '../dashboard/ProviderLogo.svelte';
-import PreflightChecks from '../dashboard/PreflightChecks.svelte';
 
 interface IProviderContainerConfigurationPropertyRecorded extends IConfigurationPropertyRecordedSchema {
   value?: any;

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
@@ -467,7 +467,7 @@ function openLink(e: MouseEvent, url: string): void {
           <div class="flex flex-row mx-auto text-md">
             Some system requirements are missing.
           </div>
-          <div class="flex flex-col min-w-[500px] min-h-[150px] mt-5 mx-auto p-4 rounded-md bg-charcoal-800">
+          <div class="flex flex-col min-h-[150px] mt-5 mx-auto py-4 px-10 rounded-md bg-charcoal-800">
             {#each preflightChecks as preCheck}
               <div class="flex flex-row mb-2 mx-auto">
                 <Fa icon="{faCircleXmark}" class="text-red-500 mt-0.5" />

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { faArrowUpRightFromSquare, faCircleXmark } from '@fortawesome/free-solid-svg-icons';
+import { faArrowUpRightFromSquare } from '@fortawesome/free-solid-svg-icons';
 import Fa from 'svelte-fa/src/fa.svelte';
 import { providerInfos } from '../../stores/providers';
 import type {
@@ -24,8 +24,7 @@ import EngineIcon from '../ui/EngineIcon.svelte';
 import EmptyScreen from '../ui/EmptyScreen.svelte';
 import PreferencesConnectionActions from './PreferencesConnectionActions.svelte';
 import PreferencesConnectionsEmptyRendering from './PreferencesConnectionsEmptyRendering.svelte';
-import Modal from '../dialogs/Modal.svelte';
-import ProviderLogo from '../dashboard/ProviderLogo.svelte';
+import PreferencesProviderInstallationModal from './PreferencesProviderInstallationModal.svelte';
 
 interface IProviderContainerConfigurationPropertyRecorded extends IConfigurationPropertyRecordedSchema {
   value?: any;
@@ -285,12 +284,6 @@ async function performInstallation(provider: ProviderInfo) {
 function hideInstallModal() {
   displayInstallModal = false;
 }
-
-function openLink(e: MouseEvent, url: string): void {
-  e.preventDefault();
-  e.stopPropagation();
-  window.openExternal(url);
-}
 </script>
 
 <SettingsPage title="Resources">
@@ -448,61 +441,11 @@ function openLink(e: MouseEvent, url: string): void {
       {/each}
     {/if}
   </div>
-  {#if displayInstallModal && providerToBeInstalled}
-    <Modal on:close="{() => hideInstallModal()}">
-      <div
-        class="inline-block w-full overflow-hidden text-left transition-all transform bg-charcoal-600 z-50 rounded-xl shadow-xl shadow-neutral-900"
-        aria-label="install provider">
-        <div class="flex items-center justify-between px-5 py-4 mb-4">
-          <h1 class="text-md font-semibold">Create a new {providerToBeInstalled.displayName}</h1>
-          <button class="hover:text-gray-300 px-2 py-1" on:click="{() => hideInstallModal()}">
-            <i class="fas fa-times" aria-hidden="true"></i>
-          </button>
-        </div>
-        <div class="overflow-y-auto px-4 pb-4">
-          <div class="flex flex-col rounded-lg">
-            <div class="mx-auto max-w-[250px] mb-5">
-              <ProviderLogo provider="{providerToBeInstalled.provider}" />
-            </div>
-            <div class="flex flex-row mx-auto text-md">Some system requirements are missing.</div>
-            <div class="flex flex-col min-h-[150px] mt-5 mx-auto py-4 px-10 rounded-md bg-charcoal-800">
-              {#each preflightChecks as preCheck}
-                <div class="flex flex-row mb-2 mx-auto">
-                  <Fa icon="{faCircleXmark}" class="text-red-500 mt-0.5" />
-                  <div class="flex flex-col ml-1 text-sm">
-                    {#if preCheck.description}
-                      <span class="w-full">{preCheck.description}</span>
-                      {#if preCheck.docLinks}
-                        <div class="flex flex-row mt-0.5">
-                          <span class="mr-1">See:</span>
-                          {#each preCheck.docLinks as link}
-                            <a href="{link.url}" target="_blank" class="mr-1" on:click="{e => openLink(e, link.url)}"
-                              >{link.title}</a>
-                          {/each}
-                        </div>
-                      {/if}
-                    {:else}
-                      {preCheck.name}
-                    {/if}
-                  </div>
-                </div>
-              {/each}
-            </div>
-            <div class="text-xs text-gray-800 mt-2 text-center">
-              Be sure that your system fulfills all the requirements above before proceeding
-            </div>
-            <div class="flex flex-row justify-end w-full pt-2">
-              <button aria-label="Cancel" class="text-xs hover:underline mr-3" on:click="{() => hideInstallModal()}"
-                >Cancel</button>
-              <button
-                class="pf-c-button pf-m-primary"
-                type="button"
-                on:click="{() => doCreateNew(providerToBeInstalled.provider, providerToBeInstalled.displayName)}"
-                >Next</button>
-            </div>
-          </div>
-        </div>
-      </div>
-    </Modal>
+  {#if displayInstallModal}
+    <PreferencesProviderInstallationModal
+      providerToBeInstalled="{providerToBeInstalled}"
+      preflightChecks="{preflightChecks}"
+      closeCallback="{hideInstallModal}"
+      doCreateNew="{doCreateNew}" />
   {/if}
 </SettingsPage>

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
@@ -40,7 +40,7 @@ $: providerInstallationInProgress = new Map<string, boolean>();
 
 let isStatusUpdated = false;
 let displayInstallModal = false;
-let installModalProvider: { provider: ProviderInfo, displayName: string };
+let providerToBeInstalled: { provider: ProviderInfo; displayName: string };
 let doExecuteAfterInstallation: () => void;
 $: preflightChecks = [];
 
@@ -58,11 +58,13 @@ onMount(() => {
     providers = providerInfosValue;
     const connectionNames = [];
     providers.forEach(provider => {
-      if (installModalProvider 
-          && doExecuteAfterInstallation 
-          && provider.name === installModalProvider.provider.name 
-          && (provider.status === 'ready' || provider.status === 'installed')) {
-        installModalProvider = undefined;
+      if (
+        providerToBeInstalled &&
+        doExecuteAfterInstallation &&
+        provider.name === providerToBeInstalled.provider.name &&
+        (provider.status === 'ready' || provider.status === 'installed')
+      ) {
+        providerToBeInstalled = undefined;
         doExecuteAfterInstallation();
       }
 
@@ -231,10 +233,10 @@ async function startConnectionProvider(
 
 async function doCreateNew(provider: ProviderInfo, displayName: string) {
   displayInstallModal = false;
-  if (provider.status == 'not-installed') {
+  if (provider.status === 'not-installed') {
     providerInstallationInProgress.set(provider.name, true);
     providerInstallationInProgress = providerInstallationInProgress;
-    installModalProvider = { provider, displayName };
+    providerToBeInstalled = { provider, displayName };
     doExecuteAfterInstallation = () => router.goto(`/preferences/provider/${provider.internalId}`);
     performInstallation(provider);
   } else {
@@ -263,7 +265,7 @@ async function performInstallation(provider: ProviderInfo) {
         currentCheck = status;
         if (currentCheck.successful === false) {
           preflightChecks = [...checksStatus, currentCheck];
-        }        
+        }
       },
     });
   } catch (err) {
@@ -343,16 +345,16 @@ function openLink(e: MouseEvent, url: string): void {
                       class="pf-c-button pf-m-primary"
                       aria-label="Create new {providerDisplayName}"
                       type="button"
-                      on:click="{() => doCreateNew(provider, providerDisplayName)}">                      
-                        {#if providerInstallationInProgress.get(provider.name) === true}                        
-                          <i class="pf-c-button__progress">
-                            <span class="pf-c-spinner pf-m-md" role="progressbar">
-                              <span class="pf-c-spinner__clipper"></span>
-                              <span class="pf-c-spinner__lead-ball"></span>
-                              <span class="pf-c-spinner__tail-ball"></span>
-                            </span>
-                          </i>
-                        {/if}                      
+                      on:click="{() => doCreateNew(provider, providerDisplayName)}">
+                      {#if providerInstallationInProgress.get(provider.name) === true}
+                        <i class="pf-c-button__progress">
+                          <span class="pf-c-spinner pf-m-md" role="progressbar">
+                            <span class="pf-c-spinner__clipper"></span>
+                            <span class="pf-c-spinner__lead-ball"></span>
+                            <span class="pf-c-spinner__tail-ball"></span>
+                          </span>
+                        </i>
+                      {/if}
                       {buttonTitle} ...
                     </button>
                   </Tooltip>
@@ -446,66 +448,61 @@ function openLink(e: MouseEvent, url: string): void {
       {/each}
     {/if}
   </div>
-  {#if displayInstallModal && installModalProvider}
-  <Modal on:close="{() => hideInstallModal()}">
-    <div
-      class="inline-block w-full overflow-hidden text-left transition-all transform bg-charcoal-600 z-50 rounded-xl shadow-xl shadow-neutral-900">
-      
+  {#if displayInstallModal && providerToBeInstalled}
+    <Modal on:close="{() => hideInstallModal()}">
+      <div
+        class="inline-block w-full overflow-hidden text-left transition-all transform bg-charcoal-600 z-50 rounded-xl shadow-xl shadow-neutral-900"
+        aria-label="install provider">
         <div class="flex items-center justify-between px-5 py-4 mb-4">
-          <h1 class="text-md font-semibold">Create a new {installModalProvider.displayName}</h1>
-  
+          <h1 class="text-md font-semibold">Create a new {providerToBeInstalled.displayName}</h1>
           <button class="hover:text-gray-300 px-2 py-1" on:click="{() => hideInstallModal()}">
             <i class="fas fa-times" aria-hidden="true"></i>
           </button>
         </div>
-      <div class="overflow-y-auto px-4 pb-4">        
-        <div class="flex flex-col rounded-lg">
-          <div class="mx-auto max-w-[250px] mb-5">
-            <ProviderLogo provider="{installModalProvider.provider}" />
-          </div>
-          <div class="flex flex-row mx-auto text-md">
-            Some system requirements are missing.
-          </div>
-          <div class="flex flex-col min-h-[150px] mt-5 mx-auto py-4 px-10 rounded-md bg-charcoal-800">
-            {#each preflightChecks as preCheck}
-              <div class="flex flex-row mb-2 mx-auto">
-                <Fa icon="{faCircleXmark}" class="text-red-500 mt-0.5" />
-                <div class="flex flex-col ml-1 text-sm">
-                  {#if preCheck.description}                  
-                    <span class="w-full">{preCheck.description}</span>
-                    {#if preCheck.docLinks}
-                      <div class="flex flex-row mt-0.5">
-                        <span class="mr-1">See:</span>
-                        {#each preCheck.docLinks as link}
-                          <a href="{link.url}" target="_blank" class="mr-1" on:click="{e => openLink(e, link.url)}">{link.title}</a>
-                        {/each}
-                      </div>              
+        <div class="overflow-y-auto px-4 pb-4">
+          <div class="flex flex-col rounded-lg">
+            <div class="mx-auto max-w-[250px] mb-5">
+              <ProviderLogo provider="{providerToBeInstalled.provider}" />
+            </div>
+            <div class="flex flex-row mx-auto text-md">Some system requirements are missing.</div>
+            <div class="flex flex-col min-h-[150px] mt-5 mx-auto py-4 px-10 rounded-md bg-charcoal-800">
+              {#each preflightChecks as preCheck}
+                <div class="flex flex-row mb-2 mx-auto">
+                  <Fa icon="{faCircleXmark}" class="text-red-500 mt-0.5" />
+                  <div class="flex flex-col ml-1 text-sm">
+                    {#if preCheck.description}
+                      <span class="w-full">{preCheck.description}</span>
+                      {#if preCheck.docLinks}
+                        <div class="flex flex-row mt-0.5">
+                          <span class="mr-1">See:</span>
+                          {#each preCheck.docLinks as link}
+                            <a href="{link.url}" target="_blank" class="mr-1" on:click="{e => openLink(e, link.url)}"
+                              >{link.title}</a>
+                          {/each}
+                        </div>
+                      {/if}
+                    {:else}
+                      {preCheck.name}
                     {/if}
-                  
-                  {:else}
-                    {preCheck.name}          
-                {/if}
-
+                  </div>
                 </div>
-                
-              </div>
-            {/each}
+              {/each}
+            </div>
+            <div class="text-xs text-gray-800 mt-2 text-center">
+              Be sure that your system fulfills all the requirements above before proceeding
+            </div>
+            <div class="flex flex-row justify-end w-full pt-2">
+              <button aria-label="Cancel" class="text-xs hover:underline mr-3" on:click="{() => hideInstallModal()}"
+                >Cancel</button>
+              <button
+                class="pf-c-button pf-m-primary"
+                type="button"
+                on:click="{() => doCreateNew(providerToBeInstalled.provider, providerToBeInstalled.displayName)}"
+                >Next</button>
+            </div>
           </div>
-          <div class="text-xs text-gray-800 mt-2  text-center">
-            Be sure that your system fulfills all the requirements above before proceeding
-          </div>
-          <div class="flex flex-row justify-end w-full pt-2">
-            <button aria-label="Cancel" class="text-xs hover:underline mr-3" on:click="{() => hideInstallModal()}"
-              >Cancel</button>
-            <button
-              class="pf-c-button pf-m-primary"
-              type="button"
-              on:click="{() => doCreateNew(installModalProvider.provider, installModalProvider.displayName)}">Next</button>
-          </div>
-        </div>        
+        </div>
       </div>
-    </div>
-  </Modal>
+    </Modal>
   {/if}
-
 </SettingsPage>


### PR DESCRIPTION
### What does this PR do?

It checks if the provider is installed before proceeding to the `create new` page.

- if installed, it works as before.
- If not installed, it performs a check of the prerequisites, if everything is ok it asks the user to confirm the installation, if something is missing the user is asked to fix it

### Screenshot/screencast of this PR

If we can proceed with the installation
![install-podman](https://github.com/containers/podman-desktop/assets/49404737/9a16f5c0-d462-4d69-b95e-7c0dde471a85)

When some requirement is missing
![requirements-podman-new-2](https://github.com/containers/podman-desktop/assets/49404737/ddd66883-68f1-4d28-873f-8f7ccecba7a0)

### What issues does this PR fix or reference?

it resolves #2706 and https://github.com/containers/podman-desktop/issues/2553

### How to test this PR?

1. uninstall podman
2. go to the resources page and click on `create new` button

I have to write some tests but I wanted to hear from you if this workflow is ok. 
@mairin after talking with Florent this morning we agreed on proceeding with a dialog and then using this PR to discuss if there is a better way to drive this workflow. As a reminder, we started talking about it before devtools week https://github.com/containers/podman-desktop/issues/2706 .