### PR TITLE
nit: update wording on compatibility mode

### DIFF
--- a/extensions/podman/src/compatibility-mode.ts
+++ b/extensions/podman/src/compatibility-mode.ts
@@ -36,7 +36,8 @@ abstract class SocketCompatibility {
 
 export class DarwinSocketCompatibility extends SocketCompatibility {
   // Shows the details of the compatibility mode on what we do.
-  details = 'The podman-mac-helper binary will be ran. This requires administrative privileges.';
+  details =
+    'The podman-mac-helper binary will be run, linking the Docker socket to Podman. This requires administrative privileges.';
 
   // This will show the "opposite" of what the current state is
   // "Enable" if it's currently disabled, "Disable" if it's currently enabled

--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -665,7 +665,7 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
       // We use isEnabled() as we do not want to "renable" again if the user has already enabled it.
       if (!isDisguisedPodmanSocket && !socketCompatibilityMode.isEnabled()) {
         const result = await extensionApi.window.showInformationMessage(
-          `Do you want to automatically enable Docker socket compatibility mode for Podman?\n\n${socketCompatibilityMode.details}`,
+          `Do you want to enable Docker socket compatibility mode for Podman?\n\n${socketCompatibilityMode.details}`,
           'Enable',
           'Cancel',
         );
@@ -675,7 +675,7 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
         }
       } else {
         const result = await extensionApi.window.showInformationMessage(
-          `Do you want to automatically disable Docker socket compatibility mode for Podman?\n\n${socketCompatibilityMode.details}`,
+          `Do you want to disable Docker socket compatibility mode for Podman?\n\n${socketCompatibilityMode.details}`,
           'Disable',
           'Cancel',
         );

--- a/extensions/podman/src/warnings.ts
+++ b/extensions/podman/src/warnings.ts
@@ -21,7 +21,7 @@ import * as os from 'node:os';
 import * as http from 'node:http';
 
 // Explanations
-const detailsExplanation = 'Docker-specific tools may not work.';
+const detailsExplanation = 'Docker socket is not reachable. Docker specific tools may not work.';
 
 // Default socket paths
 const windowsSocketPath = '//./pipe/docker_engine';


### PR DESCRIPTION
nit: update wording on compatibility mode

### What does this PR do?

Updates the wording displayed with regards to compatibility mode so it's
less confusing / more verbose with what Podman Desktop is doing.

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

Reference: https://github.com/containers/podman-desktop/issues/2406

### How to test this PR?

<!-- Please explain steps to reproduce -->

1. `yarn watch` should show the compatibility information
2. Pressing Docker Socket will show updated information

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
