### PR TITLE
chore: Reusable Terminal window

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationRendering.svelte
@@ -2,7 +2,7 @@
 import type { IConfigurationPropertyRecordedSchema } from '../../../../main/src/plugin/configuration-registry';
 import type { ProviderInfo } from '../../../../main/src/plugin/api/provider-info';
 import PreferencesRenderingItemFormat from './PreferencesRenderingItemFormat.svelte';
-import Logger from './Logger.svelte';
+import TerminalWindow from '../ui/TerminalWindow.svelte';
 import { getNormalizedDefaultNumberValue, writeToTerminal } from './Util';
 import ErrorMessage from '../ui/ErrorMessage.svelte';
 import {
@@ -21,6 +21,7 @@ import { router } from 'tinro';
 import LinearProgress from '../ui/LinearProgress.svelte';
 import Spinner from '../ui/Spinner.svelte';
 import Markdown from '../markdown/Markdown.svelte';
+import type { Terminal } from 'xterm';
 
 export let properties: IConfigurationPropertyRecordedSchema[] = [];
 export let providerInfo: ProviderInfo;
@@ -155,7 +156,7 @@ function getDisplayConfigurationValue(configurationKey: IConfigurationPropertyRe
   }
 }
 
-let logsTerminal;
+let logsTerminal: Terminal;
 let loggerHandlerKey: symbol | undefined = undefined;
 
 function getLoggerHandler(): ConnectionCallback {
@@ -339,7 +340,7 @@ async function close() {
           </div>
           <div id="log" class="pt-2 h-80 {showLogs ? '' : 'hidden'}">
             <div class="w-full h-full">
-              <Logger bind:logsTerminal="{logsTerminal}" onInit="{() => {}}" />
+              <TerminalWindow bind:terminal="{logsTerminal}" />
             </div>
           </div>
         </div>

--- a/packages/renderer/src/lib/preferences/PreferencesContainerConnectionRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesContainerConnectionRendering.svelte
@@ -8,12 +8,13 @@ import { beforeUpdate, onMount } from 'svelte';
 import type { ProviderContainerConnectionInfo, ProviderInfo } from '../../../../main/src/plugin/api/provider-info';
 import { router } from 'tinro';
 import Modal from '../dialogs/Modal.svelte';
-import Logger from './Logger.svelte';
+import TerminalWindow from '../ui/TerminalWindow.svelte';
 import { writeToTerminal } from './Util';
 import ErrorMessage from '../ui/ErrorMessage.svelte';
 import Route from '../../Route.svelte';
 import { filesize } from 'filesize';
 import { type ConnectionCallback, eventCollect, startTask } from './preferences-connection-rendering-task';
+import type { Terminal } from 'xterm';
 
 export let properties: IConfigurationPropertyRecordedSchema[] = [];
 export let providerInternalId: string = undefined;
@@ -146,9 +147,9 @@ async function deleteConnection() {
 
 let showModal: ProviderInfo = undefined;
 
-let logsTerminal;
+let logsTerminal: Terminal;
 
-async function startReceivinLogs(provider: ProviderInfo): Promise<void> {
+async function startReceivingLogs(provider: ProviderInfo): Promise<void> {
   const logHandler = (newContent: any[], colorPrefix: string) => {
     writeToTerminal(logsTerminal, newContent, colorPrefix);
   };
@@ -295,7 +296,7 @@ async function stopReceivingLogs(provider: ProviderInfo): Promise<void> {
     <h2 slot="header">Logs</h2>
     <div id="log" style="height: 400px; width: 650px;">
       <div style="width:100%; height:100%;">
-        <Logger bind:logsTerminal="{logsTerminal}" onInit="{() => startReceivinLogs(showModal)}" />
+        <TerminalWindow bind:terminal="{logsTerminal}" on:init="{() => startReceivingLogs(showModal)}" />
       </div>
     </div>
   </Modal>

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesConnectionRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesConnectionRendering.svelte
@@ -8,9 +8,10 @@ import { onMount } from 'svelte';
 import type { ProviderInfo, ProviderKubernetesConnectionInfo } from '../../../../main/src/plugin/api/provider-info';
 import { router } from 'tinro';
 import Modal from '../dialogs/Modal.svelte';
-import Logger from './Logger.svelte';
+import TerminalWindow from '../ui/TerminalWindow.svelte';
 import ErrorMessage from '../ui/ErrorMessage.svelte';
 import Route from '../../Route.svelte';
+import type { Terminal } from 'xterm';
 
 export let properties: IConfigurationPropertyRecordedSchema[] = [];
 export let providerInternalId: string = undefined;
@@ -102,7 +103,7 @@ async function deleteConnection() {
 
 let showModal: ProviderInfo = undefined;
 
-let logsTerminal;
+let logsTerminal: Terminal;
 
 async function stopReceivingLogs(provider: ProviderInfo): Promise<void> {
   // await window.stopReceiveLogs(provider.internalId, kubernetesConnectionInfo);
@@ -228,7 +229,7 @@ async function stopReceivingLogs(provider: ProviderInfo): Promise<void> {
     <h2 slot="header">Logs</h2>
     <div id="log" style="height: 400px; width: 650px;">
       <div style="width:100%; height:100%;">
-        <Logger bind:logsTerminal="{logsTerminal}" onInit="{() => {}}" />
+        <TerminalWindow bind:terminal="{logsTerminal}" />
       </div>
     </div>
   </Modal>

--- a/packages/renderer/src/lib/preferences/PreferencesProviderRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesProviderRendering.svelte
@@ -6,13 +6,14 @@ import { onMount } from 'svelte';
 import type { ProviderInfo } from '../../../../main/src/plugin/api/provider-info';
 import { router } from 'tinro';
 import Modal from '../dialogs/Modal.svelte';
-import Logger from './Logger.svelte';
+import TerminalWindow from '../ui/TerminalWindow.svelte';
 import { writeToTerminal } from './Util';
 import PreferencesConnectionCreationRendering from './PreferencesConnectionCreationRendering.svelte';
 import ErrorMessage from '../ui/ErrorMessage.svelte';
 import Route from '../../Route.svelte';
 import { faXmark } from '@fortawesome/free-solid-svg-icons';
 import Fa from 'svelte-fa/src/fa.svelte';
+import type { Terminal } from 'xterm';
 
 export let properties: IConfigurationPropertyRecordedSchema[] = [];
 export let providerInternalId: string = undefined;
@@ -37,7 +38,7 @@ let providerInfo: ProviderInfo;
 $: providerInfo = providers.filter(provider => provider.internalId === providerInternalId)[0];
 let waiting = false;
 
-let logsTerminal;
+let logsTerminal: Terminal;
 
 async function startProvider(): Promise<void> {
   waiting = true;
@@ -53,7 +54,7 @@ async function stopProvider(): Promise<void> {
   waiting = false;
 }
 
-async function startReceivinLogs(provider: ProviderInfo): Promise<void> {
+async function startReceivingLogs(provider: ProviderInfo): Promise<void> {
   const logHandler = (newContent: any[]) => {
     writeToTerminal(logsTerminal, newContent, '\x1b[37m');
   };
@@ -166,7 +167,7 @@ async function stopReceivingLogs(provider: ProviderInfo): Promise<void> {
     <h2 slot="header">Logs</h2>
     <div id="log" style="height: 400px; width: 647px;">
       <div style="width:100%; height:100%; flexDirection: column;">
-        <Logger bind:logsTerminal="{logsTerminal}" onInit="{() => startReceivinLogs(showModal)}" />
+        <TerminalWindow bind:terminal="{logsTerminal}" on:init="{() => startReceivingLogs(showModal)}" />
       </div>
     </div>
   </Modal>


### PR DESCRIPTION
### What does this PR do?

We use the xterm Terminal in many places: process output, container terminal & logs, etc. Most of this is copy/paste code, but I've found several places with slight differences or even bugs (e.g. listener never removed).

This is step 1 of trying to create a common TerminalWindow (best name I could come up with that didn't conflict with 'Terminal') component from the existing Logger:
- Move and repurpose preferences Logger component as a common UI component.
- Change onInit() to an event, which is cleaner and doesn't require every user to declare it.
- Minor cleanup and changes like property renaming to be more general.

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Check all of the Settings screens that have terminal windows for no visible regressions.