### PR TITLE
feat: Add Minikube install docs

### DIFF
--- a/website/docs/kubernetes/minikube/index.md
+++ b/website/docs/kubernetes/minikube/index.md
@@ -9,3 +9,11 @@ tags: [migrating-to-kubernetes, minikube]
 # Running Kubernetes on your workstation with Minikube and Podman
 
 Podman Desktop can help you run [Minikube-powered](https://minikube.sigs.k8s.io/) local Kubernetes clusters on a container engine, such as Podman.
+
+#### Procedure
+
+1. Go to **<icon icon="fa-solid fa-cog" size="lg" /> Settings > Extensions**.
+1. Install the _Minikube_ extension:
+   1. Go to **Install a new extension from OCI Image**
+   1. Enter the **Name of the Image**: `ghcr.io/containers/podman-desktop-extension-minikube`
+   1. Click **<icon icon="fa-solid fa-download" size="lg" /> Install extension from the OCI image**


### PR DESCRIPTION
### What does this PR do?

Adds installation instructions for the "minikube" extension, not in featured list

### Screenshot/screencast of this PR

![podman-desktop-install-minikube](https://github.com/containers/podman-desktop/assets/10364051/b5e9cc95-9854-493d-8794-4af418c08cfa)

### What issues does this PR fix or reference?

* #2610

### How to test this PR?

`cd website`
`yarn start`

http://localhost:3000/docs/kubernetes/minikube