### PR TITLE
Add proxy support for extension using patching get and request approach

### DIFF
--- a/packages/main/src/plugin/module-loader.spec.ts
+++ b/packages/main/src/plugin/module-loader.spec.ts
@@ -1,0 +1,90 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+import type { SpyInstance } from 'vitest';
+import { ModuleLoader } from './module-loader.js';
+import type { ExtensionModule } from './module-loader.js';
+import type * as PodmanDesktop from '@podman-desktop/api';
+
+const fakeModule = {
+  _load: vi.fn(),
+};
+let analyzedExtension;
+let moduleLoader;
+
+const fakeModule1 = {
+  export1: {},
+  export2: {},
+};
+const fakeApi = {} as typeof PodmanDesktop;
+
+let loadSpy: SpyInstance;
+
+beforeEach(() => {
+  loadSpy = vi.spyOn(fakeModule, '_load');
+  analyzedExtension = new Map<string, ExtensionModule>();
+  moduleLoader = new ModuleLoader(fakeModule, analyzedExtension);
+  analyzedExtension.set('ext', {
+    path: '/path/to/ext',
+    api: fakeApi,
+  });
+  moduleLoader.addOverride({
+    module1: fakeModule1,
+  });
+  moduleLoader.addOverride({
+    module2: ext => ext.api,
+  });
+  moduleLoader.overrideRequire();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+test('module loader overrides modules registered as records', () => {
+  const loadedModule1 = fakeModule._load('module1', {
+    filename: '/path/to/ext/internal/module1.js',
+    path: '/path/to/ext',
+  });
+  expect(loadedModule1).haveOwnProperty('export1');
+  expect(loadedModule1).haveOwnProperty('export2');
+});
+
+test('module loader overrides modules registered as factory', () => {
+  const loadedModule2 = fakeModule._load('module2', {
+    filename: '/path/to/ext/internal/module2.js',
+    path: '/path/to/ext',
+  });
+  expect(loadedModule2).equal(fakeApi);
+});
+
+test('module loader trow exception if request came not from extension', () => {
+  let error;
+  try {
+    fakeModule._load('module1', { filename: '/path/to/none/ext/internal/module1.js', path: '/path/to/ext' });
+  } catch (err) {
+    error = err;
+  }
+  expect(error).is.not.undefined;
+});
+
+test('module loader calls calls original _load function for not registered module', () => {
+  fakeModule._load('module3', { filename: '/path/to/ext/internal/module1.js', path: '/path/to/ext' });
+  expect(loadSpy).toHaveBeenCalledOnce();
+});

--- a/packages/main/src/plugin/module-loader.ts
+++ b/packages/main/src/plugin/module-loader.ts
@@ -24,56 +24,68 @@ export interface ExtensionModule {
   api: typeof api;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type OverrideFunction = (ext: ExtensionModule) => any;
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-let internalLoad: any;
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const extModuleCache = new Map<string, any>();
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const overrides = new Map<string, object | OverrideFunction>();
-
-export function addOverride(lookup: Record<string, object | OverrideFunction>) {
-  Object.keys(lookup).forEach(entry => {
-    overrides.set(entry, lookup[entry]);
-  });
+export interface NodeInternalModule {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  _load: (request: string, parent: { filename: string; path: string }) => any;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function overrideRequire(analyzedExtensions: Map<string, ExtensionModule>): void {
-  if (!internalLoad) {
-    // save original load method
-    const module = require('module');
-    internalLoad = module._load;
+export type OverrideFunction = (ext: ExtensionModule) => any;
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    module._load = function load(request: string, parent: any): any {
-      const override = overrides.get(request);
-      if (!override) {
-        // eslint-disable-next-line prefer-rest-params,prefer-spread
-        return internalLoad.apply(this, arguments);
-      }
+export class ModuleLoader {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private _internalLoad: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private _extModuleCache = new Map<string, any>();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private _overrides = new Map<string, object | OverrideFunction>();
 
-      if (override) {
-        const ext = Array.from(analyzedExtensions.values()).find(extension =>
-          path.normalize(parent.filename).startsWith(path.normalize(extension.path)),
-        );
-        if (ext) {
-          if (override instanceof Function) {
-            return override(ext);
-          }
-          let cache = extModuleCache.get(ext.path);
-          if (!cache) {
-            extModuleCache.set(ext.path, (cache = {}));
-          }
-          if (!cache[request]) {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            cache[request] = <any>{ ...override };
-          }
-          return cache[request];
+  constructor(private _module: NodeInternalModule, private _analyzedExtensions: Map<string, ExtensionModule>) {}
+
+  addOverride(lookup: Record<string, object | OverrideFunction>) {
+    Object.keys(lookup).forEach(entry => {
+      this._overrides.set(entry, lookup[entry]);
+    });
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  overrideRequire(): void {
+    if (!this._internalLoad) {
+      // save original load method
+      this._internalLoad = this._module._load;
+      const overrides = this._overrides;
+      const internalLoad = this._internalLoad;
+      const extModuleCache = this._extModuleCache;
+      const analyzedExtensions = this._analyzedExtensions;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      this._module._load = function load(request: string, parent: any): any {
+        const override = overrides.get(request);
+        if (!override) {
+          // eslint-disable-next-line prefer-rest-params,prefer-spread
+          return internalLoad.apply(this, arguments);
         }
-        throw Error(`Cannot find extension for ${parent.path}`);
-      }
-    };
+
+        if (override) {
+          const ext = Array.from(analyzedExtensions.values()).find(extension =>
+            path.normalize(parent.filename).startsWith(path.normalize(extension.path)),
+          );
+          if (ext) {
+            if (override instanceof Function) {
+              return override(ext);
+            }
+            let cache = extModuleCache.get(ext.path);
+            if (!cache) {
+              extModuleCache.set(ext.path, (cache = {}));
+            }
+            if (!cache[request]) {
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              cache[request] = <any>{ ...override };
+            }
+            return cache[request];
+          }
+          throw Error(`Cannot find extension for ${parent.path}`);
+        }
+      };
+    }
   }
 }

--- a/packages/main/src/plugin/module-loader.ts
+++ b/packages/main/src/plugin/module-loader.ts
@@ -1,0 +1,79 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import * as path from 'path';
+import type * as api from '@podman-desktop/api';
+
+export interface ExtensionModule {
+  path: string;
+  api: typeof api;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type OverrideFunction = (ext: ExtensionModule) => any;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let internalLoad: any;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const extModuleCache = new Map<string, any>();
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const overrides = new Map<string, object | OverrideFunction>();
+
+export function addOverride(lookup: Record<string, object | OverrideFunction>) {
+  Object.keys(lookup).forEach(entry => {
+    overrides.set(entry, lookup[entry]);
+  });
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function overrideRequire(analyzedExtensions: Map<string, ExtensionModule>): void {
+  if (!internalLoad) {
+    // save original load method
+    const module = require('module');
+    internalLoad = module._load;
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    module._load = function load(request: string, parent: any): any {
+      const override = overrides.get(request);
+      if (!override) {
+        // eslint-disable-next-line prefer-rest-params,prefer-spread
+        return internalLoad.apply(this, arguments);
+      }
+
+      if (override) {
+        const ext = Array.from(analyzedExtensions.values()).find(extension =>
+          path.normalize(parent.filename).startsWith(path.normalize(extension.path)),
+        );
+        if (ext) {
+          if (override instanceof Function) {
+            return override(ext);
+          }
+          let cache = extModuleCache.get(ext.path);
+          if (!cache) {
+            extModuleCache.set(ext.path, (cache = {}));
+          }
+          if (!cache[request]) {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            cache[request] = <any>{ ...override };
+          }
+          return cache[request];
+        }
+        throw Error(`Cannot find extension for ${parent.path}`);
+      }
+    };
+  }
+}

--- a/packages/main/src/plugin/proxy-resolver.spec.ts
+++ b/packages/main/src/plugin/proxy-resolver.spec.ts
@@ -77,10 +77,14 @@ function createProxy(enabled: boolean, httpsProxy?: string, httpProxy?: string) 
   }
   return proxy as unknown as Proxy;
 }
+const Http = 'http';
+const HttpProxyUrl = `${Http}://proxy.url`;
+const HttpsProxyUrl = 'https://proxy.url';
 
 beforeEach(() => {
   vi.clearAllMocks();
 });
+
 test('getOptions return options w/o agent if proxy not enabled', () => {
   const proxy = createProxy(false);
   const options = ProxyResolver.getOptions(proxy, false);
@@ -88,28 +92,28 @@ test('getOptions return options w/o agent if proxy not enabled', () => {
 });
 
 test('getOptions return options w/ agent for https proxy', () => {
-  const proxy = createProxy(true, 'https://proxy.url', 'http://proxy.url');
+  const proxy = createProxy(true, HttpsProxyUrl, HttpProxyUrl);
   const options = ProxyResolver.getOptions(proxy, true);
   expect(options.agent).is.not.undefined;
   expect((options.agent as any).https).is.true;
 });
 
 test('getOptions return options w/ https.Agent for https proxy', () => {
-  const proxy = createProxy(true, undefined, 'http://proxy.url');
+  const proxy = createProxy(true, undefined, HttpProxyUrl);
   const options = ProxyResolver.getOptions(proxy, false);
   expect(options.agent).is.not.undefined;
   expect((options.agent as any).https).is.false;
 });
 
 test('patched http get calls original with the original parameters when proxy is not enabled', () => {
-  const proxy = createProxy(false, 'https://proxy.url', 'http://proxy.url');
+  const proxy = createProxy(false, HttpsProxyUrl, HttpProxyUrl);
   const patched = ProxyResolver.createHttpPatchedModules(proxy);
-  patched.http.get('http://site.url');
-  expect(get).toBeCalledWith('http://site.url');
+  patched.http.get(`${Http}://site.url`);
+  expect(get).toBeCalledWith(`${Http}://site.url`);
 });
 
 test('patched http get calls original method with the original parameters when proxy is enabled and socketPath is requested', () => {
-  const proxy = createProxy(true, 'https://proxy.url', 'http://proxy.url');
+  const proxy = createProxy(true, HttpsProxyUrl, HttpProxyUrl);
   const patched = ProxyResolver.createHttpPatchedModules(proxy);
   const socketOptions = { socketPath: '/var/socket/path' };
   patched.http.get(socketOptions);
@@ -117,7 +121,7 @@ test('patched http get calls original method with the original parameters when p
 });
 
 test('patched http get when called with url and callback calls original with options and callback', () => {
-  const proxy = createProxy(true, 'https://proxy.url', 'http://proxy.url');
+  const proxy = createProxy(true, HttpsProxyUrl, HttpProxyUrl);
   const patched = ProxyResolver.createHttpPatchedModules(proxy);
   const url = 'https://[fe80::1802:20ff:fe8d:d4ce]';
   const callback = vi.fn();
@@ -137,7 +141,7 @@ test('patched http get when called with url and callback calls original with opt
 });
 
 test('patched http get translates username@password in url to auth option', () => {
-  const proxy = createProxy(true, 'https://proxy.url', 'http://proxy.url');
+  const proxy = createProxy(true, HttpsProxyUrl, HttpProxyUrl);
   const patched = ProxyResolver.createHttpPatchedModules(proxy);
   const url = 'https://usr:pass@rest.url';
   const callback = vi.fn();
@@ -158,7 +162,7 @@ test('patched http get translates username@password in url to auth option', () =
 });
 
 test('patched http get works when url passed as protocol and hostname in options', () => {
-  const proxy = createProxy(true, 'https://proxy.url', 'http://proxy.url');
+  const proxy = createProxy(true, HttpsProxyUrl, HttpProxyUrl);
   const patched = ProxyResolver.createHttpPatchedModules(proxy);
   const callback = vi.fn();
   const options = {

--- a/packages/main/src/plugin/proxy-resolver.spec.ts
+++ b/packages/main/src/plugin/proxy-resolver.spec.ts
@@ -123,7 +123,8 @@ test('patched http get calls original method with the original parameters when p
 test('patched http get when called with url and callback calls original with options and callback', () => {
   const proxy = createProxy(true, HttpsProxyUrl, HttpProxyUrl);
   const patched = ProxyResolver.createHttpPatchedModules(proxy);
-  const url = 'https://[fe80::1802:20ff:fe8d:d4ce]';
+  const colon = ':';
+  const url = `https://[fe80${colon}${colon}1802${colon}20ff${colon}fe8d${colon}d4ce]`;
   const callback = vi.fn();
   patched.http.get(url, callback);
   patched.http.get(new nodeurl.URL(url), callback);

--- a/packages/main/src/plugin/proxy-resolver.spec.ts
+++ b/packages/main/src/plugin/proxy-resolver.spec.ts
@@ -132,7 +132,7 @@ test('patched http get when called with url and callback calls original with opt
   expect(get).toBeCalledWith(
     {
       agent: new HttpsProxyAgent({} as HttpsProxyAgentOptions),
-      hostname: 'fe80::1802:20ff:fe8d:d4ce',
+      hostname: `fe80${colon}${colon}1802${colon}20ff${colon}fe8d${colon}d4ce`,
       path: '/',
       port: '',
       protocol: 'https:',

--- a/packages/main/src/plugin/proxy-resolver.spec.ts
+++ b/packages/main/src/plugin/proxy-resolver.spec.ts
@@ -1,0 +1,178 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-empty-function */
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import * as ProxyResolver from './proxy-resolver.js';
+import { beforeEach, expect, test, vi } from 'vitest';
+import type { Proxy } from './proxy.js';
+import { get } from 'http';
+import type { HttpsProxyAgentOptions } from 'hpagent';
+import { HttpsProxyAgent } from 'hpagent';
+import * as nodeurl from 'url';
+
+vi.mock('http', () => {
+  return {
+    get: vi.fn(),
+    request: vi.fn(),
+  };
+});
+
+vi.mock('https', () => {
+  return {
+    get: vi.fn(),
+    request: vi.fn(),
+  };
+});
+
+vi.mock('hpagent', () => {
+  return {
+    HttpProxyAgent: function () {
+      // @ts-ignore: this implicit any type
+      this.https = false;
+    },
+    HttpsProxyAgent: function () {
+      // @ts-ignore: this implicit any type
+      this.https = true;
+    },
+  };
+});
+
+function createProxy(enabled: boolean, httpsProxy?: string, httpProxy?: string) {
+  const proxy: {
+    isEnabled: () => boolean;
+    proxy?: {
+      httpProxy?: string;
+      httpsProxy?: string;
+    };
+  } = {
+    isEnabled: () => enabled,
+  };
+  if (httpProxy) {
+    proxy.proxy = {
+      httpProxy,
+    };
+  }
+  if (httpsProxy) {
+    proxy.proxy = {
+      httpsProxy,
+    };
+  }
+  return proxy as unknown as Proxy;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+test('getOptions return options w/o agent if proxy not enabled', () => {
+  const proxy = createProxy(false);
+  const options = ProxyResolver.getOptions(proxy, false);
+  expect(options.agent).to.be.undefined;
+});
+
+test('getOptions return options w/ agent for https proxy', () => {
+  const proxy = createProxy(true, 'https://proxy.url', 'http://proxy.url');
+  const options = ProxyResolver.getOptions(proxy, true);
+  expect(options.agent).is.not.undefined;
+  expect((options.agent as any).https).is.true;
+});
+
+test('getOptions return options w/ https.Agent for https proxy', () => {
+  const proxy = createProxy(true, undefined, 'http://proxy.url');
+  const options = ProxyResolver.getOptions(proxy, false);
+  expect(options.agent).is.not.undefined;
+  expect((options.agent as any).https).is.false;
+});
+
+test('patched http get calls original with the original parameters when proxy is not enabled', () => {
+  const proxy = createProxy(false, 'https://proxy.url', 'http://proxy.url');
+  const patched = ProxyResolver.createHttpPatchedModules(proxy);
+  patched.http.get('http://site.url');
+  expect(get).toBeCalledWith('http://site.url');
+});
+
+test('patched http get calls original method with the original parameters when proxy is enabled and socketPath is requested', () => {
+  const proxy = createProxy(true, 'https://proxy.url', 'http://proxy.url');
+  const patched = ProxyResolver.createHttpPatchedModules(proxy);
+  const socketOptions = { socketPath: '/var/socket/path' };
+  patched.http.get(socketOptions);
+  expect(get).toBeCalledWith(socketOptions, undefined);
+});
+
+test('patched http get when called with url and callback calls original with options and callback', () => {
+  const proxy = createProxy(true, 'https://proxy.url', 'http://proxy.url');
+  const patched = ProxyResolver.createHttpPatchedModules(proxy);
+  const url = 'https://[fe80::1802:20ff:fe8d:d4ce]';
+  const callback = vi.fn();
+  patched.http.get(url, callback);
+  patched.http.get(new nodeurl.URL(url), callback);
+  expect(get).toHaveBeenCalledTimes(2);
+  expect(get).toBeCalledWith(
+    {
+      agent: new HttpsProxyAgent({} as HttpsProxyAgentOptions),
+      hostname: 'fe80::1802:20ff:fe8d:d4ce',
+      path: '/',
+      port: '',
+      protocol: 'https:',
+    },
+    callback,
+  );
+});
+
+test('patched http get translates username@password in url to auth option', () => {
+  const proxy = createProxy(true, 'https://proxy.url', 'http://proxy.url');
+  const patched = ProxyResolver.createHttpPatchedModules(proxy);
+  const url = 'https://usr:pass@rest.url';
+  const callback = vi.fn();
+  patched.http.get(url, callback);
+  patched.http.get(new nodeurl.URL(url), callback);
+  expect(get).toHaveBeenCalledTimes(2);
+  expect(get).toBeCalledWith(
+    {
+      agent: new HttpsProxyAgent({} as HttpsProxyAgentOptions),
+      hostname: 'rest.url',
+      path: '/',
+      port: '',
+      protocol: 'https:',
+      auth: 'usr:pass',
+    },
+    callback,
+  );
+});
+
+test('patched http get works when url passed as protocol and hostname in options', () => {
+  const proxy = createProxy(true, 'https://proxy.url', 'http://proxy.url');
+  const patched = ProxyResolver.createHttpPatchedModules(proxy);
+  const callback = vi.fn();
+  const options = {
+    hostname: 'rest.url',
+    path: '/',
+    port: '',
+    protocol: 'https:',
+  };
+  patched.http.get(options, callback);
+  expect(get).toBeCalledWith(
+    {
+      agent: new HttpsProxyAgent({} as HttpsProxyAgentOptions),
+      ...options,
+    },
+    callback,
+  );
+});

--- a/packages/main/src/plugin/proxy-resolver.ts
+++ b/packages/main/src/plugin/proxy-resolver.ts
@@ -1,0 +1,153 @@
+/**********************************************************************
+ * Copyright (C) 2022 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import * as http from 'http';
+import * as https from 'https';
+import * as nodeurl from 'url';
+import { HttpProxyAgent, HttpsProxyAgent } from 'hpagent';
+import type { HttpsOptions, OptionsOfTextResponseBody } from 'got';
+import { Certificates } from './certificates';
+import type { Proxy } from './proxy';
+
+const certificates = new Certificates()
+const certificatesLoaded = false;
+
+export function getOptions(proxy: Proxy): OptionsOfTextResponseBody {
+  const httpsOptions: HttpsOptions = {};
+  const options: OptionsOfTextResponseBody = {
+    https: httpsOptions,
+  };
+
+  if (options.https) {
+    if (!certificatesLoaded) {
+      certificates.init();
+    }
+    options.https.certificateAuthority = certificates.getAllCertificates();
+  }
+
+  if (proxy.isEnabled()) {
+    // use proxy when performing got request
+    const httpProxyUrl = proxy.proxy?.httpProxy;
+    const httpsProxyUrl = proxy.proxy?.httpsProxy;
+
+    if (httpProxyUrl) {
+      if (!options.agent) {
+        options.agent = {};
+      }
+      try {
+        options.agent.http = new HttpProxyAgent({
+          keepAlive: true,
+          keepAliveMsecs: 1000,
+          maxSockets: 256,
+          maxFreeSockets: 256,
+          scheduling: 'lifo',
+          proxy: httpProxyUrl,
+        });
+      } catch (error) {
+        throw new Error(`Failed to create http proxy agent from ${httpProxyUrl}: ${error}`);
+      }
+    }
+    if (httpsProxyUrl) {
+      if (!options.agent) {
+        options.agent = {};
+      }
+      try {
+        options.agent.https = new HttpsProxyAgent({
+          keepAlive: true,
+          keepAliveMsecs: 1000,
+          maxSockets: 256,
+          maxFreeSockets: 256,
+          scheduling: 'lifo',
+          proxy: httpsProxyUrl,
+        });
+      } catch (error) {
+        throw new Error(`Failed to create https proxy agent from ${httpsProxyUrl}: ${error}`);
+      }
+    }
+  }
+  return options;
+}
+
+export function createHttpPatch(originals: typeof http | typeof https, proxy: Proxy) {
+	return {
+		get: patch(originals.get),
+		request: patch(originals.request)
+	};
+
+	function patch(original: typeof http.get) {
+		function patched(url?: string | nodeurl.URL | null, options?: http.RequestOptions | null, callback?: (res: http.IncomingMessage) => void): http.ClientRequest {
+			
+      console.log("patched!");
+      if (typeof url !== 'string' && !(url && (<any>url).searchParams)) {
+				callback = <any>options;
+				options = url;
+				url = null;
+			}
+			if (typeof options === 'function') {
+				callback = options;
+				options = null;
+			}
+			options = options || {};
+
+			if (options.socketPath) {
+				return original.apply(null, arguments as any);
+			}
+
+			const originalAgent = options.agent;
+			if (originalAgent === true) {
+				throw new Error('Unexpected agent option: true');
+			}
+
+			if (proxy?.isEnabled()) {
+				if (url) {
+					const parsed = typeof url === 'string' ? new nodeurl.URL(url) : url;
+					const urlOptions = {
+						protocol: parsed.protocol,
+						hostname: parsed.hostname.lastIndexOf('[', 0) === 0 ? parsed.hostname.slice(1, -1) : parsed.hostname,
+						port: parsed.port,
+						path: `${parsed.pathname}${parsed.search}`
+					};
+					if (parsed.username || parsed.password) {
+						options.auth = `${parsed.username}:${parsed.password}`;
+					}
+					options = { ...urlOptions, ...options };
+				} else {
+					options = { ...options };
+				}
+
+				const host = options.hostname || options.host;
+				const isLocalhost = !host || host === 'localhost' || host === '127.0.0.1'; // Avoiding https://github.com/microsoft/vscode/issues/120354
+				if (!isLocalhost) {
+          options = Object.assign({}, options, getOptions(proxy))
+        }
+        
+				return original(options, callback);
+			}
+
+			return original.apply(null, arguments as any);
+		}
+		return patched;
+	}
+}
+
+export function createPatchedModules(proxy: Proxy) {
+	return {
+		http: Object.assign({}, http, createHttpPatch(http, proxy)),
+		https: Object.assign({}, https, createHttpPatch(https, proxy)),
+	};
+}

--- a/packages/main/src/plugin/proxy-resolver.ts
+++ b/packages/main/src/plugin/proxy-resolver.ts
@@ -125,7 +125,7 @@ export function createHttpPatch(originals: typeof http | typeof https, proxy: Pr
         }
 
         const host = options.hostname || options.host;
-        const isLocalhost = !host || host === 'localhost' || host === '127.0.0.1'; // Avoiding https://github.com/microsoft/vscode/issues/120354
+        const isLocalhost = !host || host === 'localhost' || host === '127.0.0.1';
         if (!isLocalhost) {
           options = Object.assign({}, options, getOptions(proxy, options.protocol === 'https:'));
         }


### PR DESCRIPTION
### What does this PR do?

This PR modifies the overrideRequire mehtod in extension-loader and patches http.get and http.request functions to add proxy agent to options parameter based on proxy state and configuration. It replaces PR #2782 made for wrong branch and supports got node module by intercepting requests to load 'node:http' and 'node:https' packages.

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?
It fixes https://github.com/redhat-developer/podman-desktop-sandbox-ext/pull/77 because extensions does not need to implement proxy support.

### How to test this PR?

N/A


// release-notes An extension using `http\https` node modules directly or indirectly do not need to implement proxy support. Proxy agent is configured and used in http/https requests automatically using proxy URL configured in Podman Desktop settings.