### PR TITLE
chore: Pull and build images using TerminalWindow

### DIFF
--- a/packages/renderer/src/lib/image/PullImage.spec.ts
+++ b/packages/renderer/src/lib/image/PullImage.spec.ts
@@ -74,7 +74,7 @@ function setup() {
 describe('PullImage', () => {
   test('Expect that textbox is available and button is displayed', async () => {
     setup();
-    render(PullImage, { terminalInitialized: true });
+    render(PullImage);
 
     const entry = screen.getByPlaceholderText('Image name');
     expect(entry).toBeInTheDocument();
@@ -85,7 +85,7 @@ describe('PullImage', () => {
 
   test('Expect that whitespace does not enable button', async () => {
     setup();
-    render(PullImage, { imageToPull: '   ', terminalInitialized: true });
+    render(PullImage, { imageToPull: '   ' });
 
     const button = screen.getByRole('button', { name: buttonText });
     expect(button).toBeInTheDocument();
@@ -94,7 +94,7 @@ describe('PullImage', () => {
 
   test('Expect that valid entry enables button', async () => {
     setup();
-    render(PullImage, { imageToPull: 'some-valid-image', terminalInitialized: true });
+    render(PullImage, { imageToPull: 'some-valid-image' });
 
     const button = screen.getByRole('button', { name: buttonText });
     expect(button).toBeInTheDocument();
@@ -103,7 +103,7 @@ describe('PullImage', () => {
 
   test('Expect that valid entry enables button', async () => {
     setup();
-    render(PullImage, { terminalInitialized: true });
+    render(PullImage);
 
     const button = screen.getByRole('button', { name: buttonText });
     expect(button).toBeInTheDocument();

--- a/packages/renderer/src/lib/image/PullImage.spec.ts
+++ b/packages/renderer/src/lib/image/PullImage.spec.ts
@@ -36,6 +36,10 @@ beforeAll(() => {
     },
   };
   (window as any).telemetryPage = vi.fn();
+  (window as any).getConfigurationValue = vi.fn();
+  (window as any).matchMedia = vi.fn().mockReturnValue({
+    addListener: vi.fn(),
+  });
 });
 
 const buttonText = 'Pull image';

--- a/packages/renderer/src/lib/ui/TerminalWindow.svelte
+++ b/packages/renderer/src/lib/ui/TerminalWindow.svelte
@@ -14,7 +14,7 @@ const dispatch = createEventDispatcher<{ init }>();
 
 async function refreshTerminal() {
   // missing element, return
-  if (!logsXtermDiv) {
+  if (!logsXtermDiv || !window.getConfigurationValue) {
     return;
   }
   // grab font size

--- a/packages/renderer/src/lib/ui/TerminalWindow.svelte
+++ b/packages/renderer/src/lib/ui/TerminalWindow.svelte
@@ -14,7 +14,7 @@ const dispatch = createEventDispatcher<{ init }>();
 
 async function refreshTerminal() {
   // missing element, return
-  if (!logsXtermDiv || !window.getConfigurationValue) {
+  if (!logsXtermDiv) {
     return;
   }
   // grab font size


### PR DESCRIPTION
### What does this PR do?

Reusing the TerminalWindow for the Build and Pull image pages. No visible change, just better code reuse and the listener will be properly removed when not using these pages.


### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Build and pull an image to confirm no regression.