### PR TITLE
feat: add restart button after enabling / disabling mac os compatibility

### DIFF
--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -823,6 +823,45 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
   await podmanConfiguration.init();
 }
 
+// Restart current machine
+export async function restartCurrentMachine(): Promise<void> {
+  // Find the machines
+  const machineListOutput = await execPromise(getPodmanCli(), ['machine', 'list', '--format', 'json']);
+  const machines = JSON.parse(machineListOutput) as MachineJSON[];
+
+  // Find the autostarted machine and check its status
+  const currentMachine: MachineJSON = machines.find(machine => machine?.Name === autoMachineName);
+
+  // If it's not running or starting, we can't restart it
+  if (!currentMachine?.Running && !currentMachine?.Starting) {
+    console.log('No machine to restart');
+    autoMachineStarted = false;
+    return;
+  }
+
+  // Restart the current machine
+  console.log('restarting autostarted machine', autoMachineName);
+  await execPromise(getPodmanCli(), ['machine', 'restart', autoMachineName]);
+}
+
+// Function that checks to see if the default machine is running and return a boolean
+export async function findRunningMachine(): Promise<string> {
+  let runningMachine: string;
+
+  // Find the machines
+  const machineListOutput = await execPromise(getPodmanCli(), ['machine', 'list', '--format', 'json']);
+  const machines = JSON.parse(machineListOutput) as MachineJSON[];
+
+  // Find the machine that is running
+  const found: MachineJSON = machines.find(machine => machine?.Running);
+
+  if (found) {
+    runningMachine = found.Name;
+  }
+
+  return runningMachine;
+}
+
 async function stopAutoStartedMachine() {
   if (!autoMachineStarted) {
     console.log('No machine to stop');


### PR DESCRIPTION
feat: add restart button after enabling / disabling mac os compatibility

### What does this PR do?

* Adds a button that will ask if the user if they'd like to restart the
  podman machine to enable compatibility mode

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

https://github.com/containers/podman-desktop/assets/6422176/cbd56816-0f06-406d-bf9a-51cee63f6ce5




### What issues does this PR fix or reference?

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

Fixes https://github.com/containers/podman-desktop/issues/2406

### How to test this PR?

1. Press the compatibility button while on Mac OS
2. Enable / Disable
3. At the end it should ask if you'd like to restart your podman machine
4. Click and it will restart.

<!-- Please explain steps to reproduce -->
