### PR TITLE
feat: Fixed headers, improved scrollbars

### DIFF
--- a/packages/renderer/index.html
+++ b/packages/renderer/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Podman Desktop</title>
   </head>
-  <body>
+  <body class="overflow-hidden">
     <div id="app"></div>
     <script type="module" src="/src/main.ts"></script>
   </body>

--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -55,12 +55,12 @@ window.events?.receive('display-help', () => {
 </script>
 
 <Route path="/*" breadcrumb="Home" let:meta>
-  <main class="min-h-screen flex flex-col h-screen bg-charcoal-800">
+  <main class="flex flex-col w-screen h-screen overflow-hidden bg-charcoal-800">
     <TitleBar />
 
     <WelcomePage />
 
-    <div class="overflow-x-hidden flex flex-1">
+    <div class="flex flex-row w-full h-full overflow-hidden">
       <MessageBox />
       <QuickPickInput />
       <AppNavigation meta="{meta}" exitSettingsCallback="{() => router.goto(nonSettingsPage)}" />
@@ -69,7 +69,7 @@ window.events?.receive('display-help', () => {
       {/if}
 
       <div
-        class="z-0 w-full h-full min-h-fit flex flex-col overflow-y-scroll"
+        class="flex flex-col w-full h-full overflow-hidden"
         class:bg-charcoal-700="{!meta.url.startsWith('/preferences')}"
         class:bg-charcoal-800="{meta.url.startsWith('/preferences')}">
         <TaskManager />

--- a/packages/renderer/src/AppNavigation.svelte
+++ b/packages/renderer/src/AppNavigation.svelte
@@ -90,12 +90,11 @@ export let meta;
 
 <svelte:window />
 <nav
-  class="pf-c-nav z-[9] group w-[54px] min-w-[54px] flex flex-col justify-between hover:overflow-y-none top-0"
-  style="position: sticky"
+  class="pf-c-nav group w-[54px] min-w-[54px] flex flex-col justify-between hover:overflow-y-none"
   aria-label="Global">
   <ul class="pf-c-nav__list">
     <li
-      class="pf-c-nav__item flex w-full justify-between {meta.url === '/'
+      class="pf-c-nav__item flex w-full {meta.url === '/'
         ? 'pf-m-current'
         : ''} hover:text-gray-400 cursor-pointer items-center mb-6">
       <a href="/" class="pf-c-nav__link flex" aria-label="Dashboard">

--- a/packages/renderer/src/lib/ContainerList.svelte
+++ b/packages/renderer/src/lib/ContainerList.svelte
@@ -370,10 +370,10 @@ function errorCallback(container: ContainerInfoUI, errorMessage: string): void {
     {/if}
   </div>
 
-  <div class="min-w-full flex" slot="table">
-    <table class="mx-5 w-full" class:hidden="{containerGroups.length === 0}">
+  <div class="flex min-w-full h-full overflow-auto" class:hidden="{containerGroups.length === 0}" slot="table">
+    <table class="mx-5 w-full h-fit">
       <!-- title -->
-      <thead>
+      <thead class="sticky top-0 bg-charcoal-700 z-[2]">
         <tr class="h-7 uppercase text-xs text-gray-600">
           <th class="whitespace-nowrap w-5"></th>
           <th class="px-2 w-5">
@@ -549,9 +549,7 @@ function errorCallback(container: ContainerInfoUI, errorMessage: string): void {
         <tr><td class="leading-[8px]">&nbsp;</td></tr>
       {/each}
     </table>
-  </div>
 
-  <div slot="empty" class="min-h-full">
     {#if providerConnections.length === 0}
       <NoContainerEngineEmptyScreen />
     {:else if $filtered.length === 0}

--- a/packages/renderer/src/lib/ContainerList.svelte
+++ b/packages/renderer/src/lib/ContainerList.svelte
@@ -370,8 +370,8 @@ function errorCallback(container: ContainerInfoUI, errorMessage: string): void {
     {/if}
   </div>
 
-  <div class="flex min-w-full h-full overflow-auto" class:hidden="{containerGroups.length === 0}" slot="table">
-    <table class="mx-5 w-full h-fit">
+  <div class="flex min-w-full h-full overflow-auto" slot="table">
+    <table class="mx-5 w-full h-fit" class:hidden="{containerGroups.length === 0}">
       <!-- title -->
       <thead class="sticky top-0 bg-charcoal-700 z-[2]">
         <tr class="h-7 uppercase text-xs text-gray-600">

--- a/packages/renderer/src/lib/ImagesList.svelte
+++ b/packages/renderer/src/lib/ImagesList.svelte
@@ -270,8 +270,8 @@ function computeInterval(): number {
     {/if}
   </div>
 
-  <div class="flex min-w-full h-full overflow-auto" class:hidden="{images.length === 0}" slot="table">
-    <table class="mx-5 min-w-full h-fit">
+  <div class="flex min-w-full h-full overflow-auto" slot="table">
+    <table class="mx-5 min-w-full h-fit" class:hidden="{images.length === 0}">
       <!-- title -->
       <thead class="sticky top-0 bg-charcoal-700 z-[2]">
         <tr class="h-7 uppercase text-xs text-gray-600">

--- a/packages/renderer/src/lib/ImagesList.svelte
+++ b/packages/renderer/src/lib/ImagesList.svelte
@@ -270,10 +270,10 @@ function computeInterval(): number {
     {/if}
   </div>
 
-  <div class="min-w-full flex" slot="table">
-    <table class="mx-5 w-full" class:hidden="{images.length === 0}">
+  <div class="flex min-w-full h-full overflow-auto" class:hidden="{images.length === 0}" slot="table">
+    <table class="mx-5 min-w-full h-fit">
       <!-- title -->
-      <thead>
+      <thead class="sticky top-0 bg-charcoal-700 z-[2]">
         <tr class="h-7 uppercase text-xs text-gray-600">
           <th class="whitespace-nowrap w-5"></th>
           <th class="px-2 w-5">
@@ -289,7 +289,7 @@ function computeInterval(): number {
           <th class="text-right pr-2">Actions</th>
         </tr>
       </thead>
-      <tbody class="">
+      <tbody>
         {#each images as image}
           <tr class="group h-12 bg-charcoal-800 hover:bg-zinc-700">
             <td class="rounded-tl-lg rounded-bl-lg w-5"> </td>
@@ -347,8 +347,7 @@ function computeInterval(): number {
         {/each}
       </tbody>
     </table>
-  </div>
-  <div slot="empty" class="min-h-full">
+
     {#if providerConnections.length === 0}
       <NoContainerEngineEmptyScreen />
     {:else if $filtered.length === 0}

--- a/packages/renderer/src/lib/dashboard/DashboardPage.svelte
+++ b/packages/renderer/src/lib/dashboard/DashboardPage.svelte
@@ -36,9 +36,9 @@ function getInitializationContext(id: string) {
 </script>
 
 <NavPage searchEnabled="{false}" title="Dashboard">
-  <div slot="empty" class="flex flex-col min-h-full bg-charcoal-700 shadow-nav">
-    <div class="min-w-full flex-1">
-      <div class="pt-5 px-5 space-y-5">
+  <div slot="empty" class="flex flex-col h-full bg-charcoal-700 shadow-nav pt-5 overflow-hidden">
+    <div class="min-w-full flex-1 overflow-auto">
+      <div class="px-5 space-y-5 h-full">
         <!-- Provider is ready display a box to indicate some information -->
         {#if providersReady.length > 0}
           {#each providersReady as providerReady}

--- a/packages/renderer/src/lib/docker-extension/PreferencesPageDockerExtensions.svelte
+++ b/packages/renderer/src/lib/docker-extension/PreferencesPageDockerExtensions.svelte
@@ -49,7 +49,7 @@ function deleteContribution(extensionName: string) {
 </script>
 
 <SettingsPage title="Docker Desktop Extensions">
-  <div class="bg-charcoal-600 mt-5 rounded-md p-3">
+  <div class="bg-charcoal-600 rounded-md p-3">
     <p class="text-xs">There is an ongoing support of Docker Desktop UI extensions from Podman Desktop.</p>
     <p class="text-xs italic">
       Not all are guaranteed to work but you can add their OCI Image below to try and load them.
@@ -105,9 +105,9 @@ function deleteContribution(extensionName: string) {
   </div>
 
   {#if $contributions.length > 0}
-    <div class="flex border-t-2 border-purple-500 flex-1 flex-col m-4 p-2">
+    <div class="flex border-t-2 border-purple-500 flex-1 flex-col mt-4 p-2">
       <p>Installed extensions:</p>
-      <div class="grid gap-4 grid-cols-4 py-4">
+      <div class="grid gap-4 grid-cols-4 pt-4">
         {#each $contributions as contribution, index}
           <div class="flex flex-col bg-purple-600 h-[100px]">
             <div class="flex justify-end flex-wrap">

--- a/packages/renderer/src/lib/pod/PodsList.svelte
+++ b/packages/renderer/src/lib/pod/PodsList.svelte
@@ -231,10 +231,10 @@ function errorCallback(pod: PodInfoUI, errorMessage: string): void {
     {/if}
   </div>
 
-  <div class="min-w-full flex" slot="table">
-    <table class="mx-5 w-full" class:hidden="{pods.length === 0}">
+  <div class="flex min-w-full h-full overflow-auto" class:hidden="{pods.length === 0}" slot="table">
+    <table class="mx-5 w-full h-fit">
       <!-- title -->
-      <thead>
+      <thead class="sticky top-0 bg-charcoal-700 z-[2]">
         <tr class="h-7 uppercase text-xs text-gray-600">
           <th class="whitespace-nowrap w-5"></th>
           <th class="px-2 w-5">
@@ -249,7 +249,7 @@ function errorCallback(pod: PodInfoUI, errorMessage: string): void {
           <th class="text-right pr-2">Actions</th>
         </tr>
       </thead>
-      <tbody class="">
+      <tbody>
         {#each pods as pod}
           <tr class="group h-12 bg-charcoal-800 hover:bg-zinc-700">
             <td class="rounded-tl-lg rounded-bl-lg w-5"> </td>
@@ -315,8 +315,7 @@ function errorCallback(pod: PodInfoUI, errorMessage: string): void {
         {/each}
       </tbody>
     </table>
-  </div>
-  <div slot="empty" class="min-h-full">
+
     {#if providerConnections.length === 0}
       <NoContainerEngineEmptyScreen />
     {:else if $filtered.length === 0}

--- a/packages/renderer/src/lib/pod/PodsList.svelte
+++ b/packages/renderer/src/lib/pod/PodsList.svelte
@@ -231,8 +231,8 @@ function errorCallback(pod: PodInfoUI, errorMessage: string): void {
     {/if}
   </div>
 
-  <div class="flex min-w-full h-full overflow-auto" class:hidden="{pods.length === 0}" slot="table">
-    <table class="mx-5 w-full h-fit">
+  <div class="flex min-w-full h-full overflow-auto" slot="table">
+    <table class="mx-5 w-full h-fit" class:hidden="{pods.length === 0}">
       <!-- title -->
       <thead class="sticky top-0 bg-charcoal-700 z-[2]">
         <tr class="h-7 uppercase text-xs text-gray-600">

--- a/packages/renderer/src/lib/preferences/PreferencesAuthenticationProvidersRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesAuthenticationProvidersRendering.svelte
@@ -10,7 +10,7 @@ import DropdownMenuItem from '../ui/DropDownMenuItem.svelte';
 </script>
 
 <SettingsPage title="Authentication">
-  <div class="container w-full h-full mt-5">
+  <div class="container w-full h-full">
     <!-- Authentication Providers table start -->
     <EmptyScreen
       icon="{KeyIcon}"

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationRendering.svelte
@@ -274,7 +274,7 @@ async function close() {
 }
 </script>
 
-<div class="flex flex-1 flex-col">
+<div class="flex flex-1 flex-col h-full px-6 overflow-auto">
   {#if creationSuccessful}
     <div class="pf-c-empty-state h-full">
       <div class="pf-c-empty-state__content">

--- a/packages/renderer/src/lib/preferences/PreferencesExtensionList.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesExtensionList.svelte
@@ -68,8 +68,8 @@ async function updateExtension(extension: ExtensionInfo, ociUri: string) {
 </script>
 
 <SettingsPage title="Extensions">
-  <div class="bg-charcoal-600 mt-5 rounded-md p-3">
-    <div class="bg-charcoal-700 rounded-md p-3">
+  <div class="bg-charcoal-600 rounded-md p-3">
+    <div class="bg-charcoal-700 mb-4 rounded-md p-3">
       <FeaturedExtensions />
     </div>
 

--- a/packages/renderer/src/lib/preferences/PreferencesExtensionRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesExtensionRendering.svelte
@@ -26,7 +26,7 @@ async function removeExtension() {
   <span slot="subtitle">
     {extensionInfo.description}
   </span>
-  <div class="bg-charcoal-600 mt-5 rounded-md p-3">
+  <div class="bg-charcoal-600 rounded-md p-3">
     {#if extensionInfo}
       <Route path="/*" breadcrumb="{extensionInfo.displayName}">
         <!-- Manage lifecycle-->

--- a/packages/renderer/src/lib/preferences/PreferencesPage.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesPage.svelte
@@ -36,7 +36,7 @@ onMount(async () => {
 });
 </script>
 
-<div class="flex flex-col h-full px-5">
+<div class="flex flex-col h-full">
   <Route path="/*" breadcrumb="Preferences">
     {#if defaultPrefPageId !== undefined}
       <PreferencesRendering key="{defaultPrefPageId}" properties="{properties}" />

--- a/packages/renderer/src/lib/preferences/PreferencesProviderRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesProviderRendering.svelte
@@ -22,7 +22,7 @@ export let taskId: number = undefined;
 let showModal: ProviderInfo = undefined;
 
 let providerLifecycleError = '';
-router.subscribe(() => {
+router.subscribe(async route => {
   providerLifecycleError = '';
 });
 
@@ -36,17 +36,22 @@ onMount(() => {
 
 let providerInfo: ProviderInfo;
 $: providerInfo = providers.filter(provider => provider.internalId === providerInternalId)[0];
+let waiting = false;
 
 let logsTerminal: Terminal;
 
 async function startProvider(): Promise<void> {
+  waiting = true;
   await window.startProviderLifecycle(providerInfo.internalId);
   window.dispatchEvent(new CustomEvent('provider-lifecycle-change'));
+  waiting = false;
 }
 
 async function stopProvider(): Promise<void> {
+  waiting = true;
   await window.stopProviderLifecycle(providerInfo.internalId);
   window.dispatchEvent(new CustomEvent('provider-lifecycle-change'));
+  waiting = false;
 }
 
 async function startReceivingLogs(provider: ProviderInfo): Promise<void> {
@@ -61,9 +66,9 @@ async function stopReceivingLogs(provider: ProviderInfo): Promise<void> {
 }
 </script>
 
-<Route path="/*" breadcrumb="{providerInfo?.name}">
-  <div class="flex flex-1 flex-col bg-charcoal-800 px-6 py-1">
-    <div>
+<Route path="/*" breadcrumb="{providerInfo?.name}" let:meta>
+  <div class="flex flex-1 flex-col bg-charcoal-800 py-1 h-full">
+    <div class="px-6">
       <button
         aria-label="Close"
         class="hover:text-gray-700 float-right text-lg"
@@ -71,15 +76,15 @@ async function stopReceivingLogs(provider: ProviderInfo): Promise<void> {
         <Fa icon="{faXmark}" />
       </button>
     </div>
-    <h1 class="capitalize text-sm">Resources > {providerInfo?.name}</h1>
+    <h1 class="capitalize text-sm px-6">Resources > {providerInfo?.name}</h1>
     <!-- Manage lifecycle-->
     {#if providerInfo?.lifecycleMethods}
-      <div class="pl-1 py-2">
+      <div class="pl-1 py-2 px-6">
         <div class="text-sm italic text-gray-700">Status</div>
         <div class="pl-3">{providerInfo.status}</div>
       </div>
 
-      <div class="py-2 flex flex:row">
+      <div class="py-2 px-6 flex flex:row">
         <!-- start is enabled only in stopped mode-->
         {#if providerInfo?.lifecycleMethods.includes('start')}
           <div class="px-2 text-sm italic text-gray-700">

--- a/packages/renderer/src/lib/preferences/PreferencesProviderRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesProviderRendering.svelte
@@ -22,7 +22,7 @@ export let taskId: number = undefined;
 let showModal: ProviderInfo = undefined;
 
 let providerLifecycleError = '';
-router.subscribe(async route => {
+router.subscribe(() => {
   providerLifecycleError = '';
 });
 
@@ -36,22 +36,17 @@ onMount(() => {
 
 let providerInfo: ProviderInfo;
 $: providerInfo = providers.filter(provider => provider.internalId === providerInternalId)[0];
-let waiting = false;
 
 let logsTerminal: Terminal;
 
 async function startProvider(): Promise<void> {
-  waiting = true;
   await window.startProviderLifecycle(providerInfo.internalId);
   window.dispatchEvent(new CustomEvent('provider-lifecycle-change'));
-  waiting = false;
 }
 
 async function stopProvider(): Promise<void> {
-  waiting = true;
   await window.stopProviderLifecycle(providerInfo.internalId);
   window.dispatchEvent(new CustomEvent('provider-lifecycle-change'));
-  waiting = false;
 }
 
 async function startReceivingLogs(provider: ProviderInfo): Promise<void> {
@@ -66,7 +61,7 @@ async function stopReceivingLogs(provider: ProviderInfo): Promise<void> {
 }
 </script>
 
-<Route path="/*" breadcrumb="{providerInfo?.name}" let:meta>
+<Route path="/*" breadcrumb="{providerInfo?.name}">
   <div class="flex flex-1 flex-col bg-charcoal-800 py-1 h-full">
     <div class="px-6">
       <button

--- a/packages/renderer/src/lib/preferences/PreferencesProxiesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesProxiesRendering.svelte
@@ -42,10 +42,10 @@ async function updateProxyState() {
 </script>
 
 <SettingsPage title="Proxy Settings">
-  <div class="container mx-auto bg-charcoal-600 mt-5 rounded-md p-3">
+  <div class="container mx-auto bg-charcoal-600 rounded-md p-3">
     <!-- if proxy is not enabled, display a toggle -->
 
-    <label for="toggle-proxy" class="inline-flex relative items-center mt-2 mb-5 cursor-pointer">
+    <label for="toggle-proxy" class="inline-flex relative items-center mt-1 mb-4 cursor-pointer">
       <input
         type="checkbox"
         bind:checked="{proxyState}"

--- a/packages/renderer/src/lib/preferences/PreferencesRegistriesEditing.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRegistriesEditing.svelte
@@ -220,7 +220,7 @@ const processPasswordElement = (node: HTMLInputElement, registry: containerDeskt
 </script>
 
 <SettingsPage title="Registries">
-  <div class="container mx-auto bg-charcoal-600 mt-5 rounded-md p-3">
+  <div class="container mx-auto bg-charcoal-600 rounded-md p-3">
     <!-- Registries table start -->
     <div class="w-full border-t border-b border-gray-900">
       <div class="flex w-full">
@@ -604,7 +604,7 @@ const processPasswordElement = (node: HTMLInputElement, registry: containerDeskt
   <!-- Spacer end -->
 
   <!-- Add new registry button start -->
-  <div class="flex justify-end py-4 px-4 w-full">
+  <div class="flex justify-end pt-4 px-4 w-full">
     <button
       on:click="{() => setNewRegistryFormVisible(true)}"
       class="pf-c-button pf-m-primary transition ease-in-out delay-50 hover:cursor-pointer h-7 w-36 text-sm rounded-md shadow hover:shadow-lg"

--- a/packages/renderer/src/lib/preferences/PreferencesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRendering.svelte
@@ -46,7 +46,7 @@ function updateSearchValue(event: any) {
 }
 </script>
 
-<Route path="/" breadcrumb="{key}">
+<Route path="/" breadcrumb="{key}" let:meta>
   <SettingsPage title="Preferences">
     <div class="bg-charcoal-900">
       <div
@@ -73,8 +73,8 @@ function updateSearchValue(event: any) {
         </svg>
       </div>
     </div>
-    <div class="flex flex-col min-w-full rounded-md px-3">
-      {#if matchingRecords.size === 0}
+    <div class="flex flex-col min-w-full rounded-md">
+      {#if matchingRecords.size == 0}
         <div class="mt-5">No Settings Found</div>
       {:else}
         {#each [...matchingRecords.keys()].sort((a, b) => a.localeCompare(b)) as configSection}

--- a/packages/renderer/src/lib/preferences/PreferencesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRendering.svelte
@@ -46,7 +46,7 @@ function updateSearchValue(event: any) {
 }
 </script>
 
-<Route path="/" breadcrumb="{key}" let:meta>
+<Route path="/" breadcrumb="{key}">
   <SettingsPage title="Preferences">
     <div class="bg-charcoal-900">
       <div
@@ -74,7 +74,7 @@ function updateSearchValue(event: any) {
       </div>
     </div>
     <div class="flex flex-col min-w-full rounded-md">
-      {#if matchingRecords.size == 0}
+      {#if matchingRecords.size === 0}
         <div class="mt-5">No Settings Found</div>
       {:else}
         {#each [...matchingRecords.keys()].sort((a, b) => a.localeCompare(b)) as configSection}

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.spec.ts
@@ -148,7 +148,7 @@ test('Expect to be start, delete actions disabled and stop, restart enabled when
 test('Expect to see the no resource message when there is no providers', async () => {
   providerInfos.set([]);
   render(PreferencesResourcesRendering, {});
-  const panel = screen.getByLabelText('no-resource-panel');
+  const panel = screen.getByText('No resources found');
   expect(panel).toBeInTheDocument();
 });
 

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.spec.ts
@@ -148,7 +148,7 @@ test('Expect to be start, delete actions disabled and stop, restart enabled when
 test('Expect to see the no resource message when there is no providers', async () => {
   providerInfos.set([]);
   render(PreferencesResourcesRendering, {});
-  const panel = screen.getByText('No resources found');
+  const panel = screen.getByLabelText('no-resource-panel');
   expect(panel).toBeInTheDocument();
 });
 

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
@@ -221,7 +221,7 @@ async function startConnectionProvider(
       class="text-gray-700 underline underline-offset-2">Extensions</a>
   </span>
   <div class="w-full h-full">
-    <EmptyScreen
+    <EmptyScreen aria-label="no-resource-panel" 
       icon="{EngineIcon}"
       title="No resources found"
       message="Start an extension that manages containers or Kubernetes engines"

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
@@ -221,7 +221,8 @@ async function startConnectionProvider(
       class="text-gray-700 underline underline-offset-2">Extensions</a>
   </span>
   <div class="w-full h-full">
-    <EmptyScreen aria-label="no-resource-panel" 
+    <EmptyScreen
+      aria-label="no-resource-panel"
       icon="{EngineIcon}"
       title="No resources found"
       message="Start an extension that manages containers or Kubernetes engines"

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
@@ -302,7 +302,7 @@ function hideInstallModal() {
       </div>
     {:else}
       {#each providers as provider}
-        <div class="bg-charcoal-600 mt-5 rounded-md p-3 divide-x divide-gray-900 flex">
+        <div class="bg-charcoal-600 mb-5 rounded-md p-3 divide-x divide-gray-900 flex">
           <div>
             <!-- left col - provider icon/name + "create new" button -->
             <div class="min-w-[150px] max-w-[200px]">

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
@@ -3,7 +3,6 @@ import { faArrowUpRightFromSquare } from '@fortawesome/free-solid-svg-icons';
 import Fa from 'svelte-fa/src/fa.svelte';
 import { providerInfos } from '../../stores/providers';
 import type {
-  CheckStatus,
   ProviderContainerConnectionInfo,
   ProviderInfo,
   ProviderKubernetesConnectionInfo,
@@ -11,7 +10,7 @@ import type {
 import { onDestroy, onMount } from 'svelte';
 import type { IConfigurationPropertyRecordedSchema } from '../../../../main/src/plugin/configuration-registry';
 import { configurationProperties } from '../../stores/configurationProperties';
-import type { ContainerProviderConnection } from '@podman-desktop/api';
+import type { ContainerProviderConnection, provider } from '@podman-desktop/api';
 import type { Unsubscriber } from 'svelte/store';
 import Tooltip from '../ui/Tooltip.svelte';
 import { filesize } from 'filesize';
@@ -24,7 +23,6 @@ import EngineIcon from '../ui/EngineIcon.svelte';
 import EmptyScreen from '../ui/EmptyScreen.svelte';
 import PreferencesConnectionActions from './PreferencesConnectionActions.svelte';
 import PreferencesConnectionsEmptyRendering from './PreferencesConnectionsEmptyRendering.svelte';
-import PreferencesProviderInstallationModal from './PreferencesProviderInstallationModal.svelte';
 
 interface IProviderContainerConfigurationPropertyRecorded extends IConfigurationPropertyRecordedSchema {
   value?: any;
@@ -35,13 +33,8 @@ interface IProviderContainerConfigurationPropertyRecorded extends IConfiguration
 export let properties: IConfigurationPropertyRecordedSchema[] = [];
 let providers: ProviderInfo[] = [];
 $: containerConnectionStatus = new Map<string, IConnectionStatus>();
-$: providerInstallationInProgress = new Map<string, boolean>();
 
 let isStatusUpdated = false;
-let displayInstallModal = false;
-let providerToBeInstalled: { provider: ProviderInfo; displayName: string };
-let doExecuteAfterInstallation: () => void;
-$: preflightChecks = [];
 
 let configurationKeys: IConfigurationPropertyRecordedSchema[];
 let restartingQueue: IConnectionRestart[] = [];
@@ -57,16 +50,6 @@ onMount(() => {
     providers = providerInfosValue;
     const connectionNames = [];
     providers.forEach(provider => {
-      if (
-        providerToBeInstalled &&
-        doExecuteAfterInstallation &&
-        provider.name === providerToBeInstalled.provider.name &&
-        (provider.status === 'ready' || provider.status === 'installed')
-      ) {
-        providerToBeInstalled = undefined;
-        doExecuteAfterInstallation();
-      }
-
       provider.containerConnections.forEach(container => {
         const containerConnectionName = getProviderConnectionName(provider, container);
         connectionNames.push(containerConnectionName);
@@ -159,7 +142,7 @@ $: Promise.all(
   providers.map(async provider => {
     const providerContainer = await Promise.all(
       provider.containerConnections.map(async container => {
-        return await Promise.all(
+        const containerConfigurations = await Promise.all(
           configurationKeys.map(async configurationKey => {
             return {
               ...configurationKey,
@@ -172,6 +155,7 @@ $: Promise.all(
             };
           }),
         );
+        return containerConfigurations;
       }),
     );
     return providerContainer.flat();
@@ -228,223 +212,146 @@ async function startConnectionProvider(
     eventCollect,
   );
 }
-
-async function doCreateNew(provider: ProviderInfo, displayName: string) {
-  displayInstallModal = false;
-  if (provider.status === 'not-installed') {
-    providerInstallationInProgress.set(provider.name, true);
-    providerInstallationInProgress = providerInstallationInProgress;
-    providerToBeInstalled = { provider, displayName };
-    doExecuteAfterInstallation = () => router.goto(`/preferences/provider/${provider.internalId}`);
-    performInstallation(provider);
-  } else {
-    router.goto(`/preferences/provider/${provider.internalId}`);
-  }
-}
-
-async function performInstallation(provider: ProviderInfo) {
-  const checksStatus = [];
-  let checkSuccess = false;
-  let currentCheck: CheckStatus;
-  try {
-    checkSuccess = await window.runInstallPreflightChecks(provider.internalId, {
-      endCheck: status => {
-        if (currentCheck) {
-          currentCheck = status;
-        } else {
-          return;
-        }
-        if (currentCheck.successful === false) {
-          checksStatus.push(currentCheck);
-          preflightChecks = checksStatus;
-        }
-      },
-      startCheck: status => {
-        currentCheck = status;
-        if (currentCheck.successful === false) {
-          preflightChecks = [...checksStatus, currentCheck];
-        }
-      },
-    });
-  } catch (err) {
-    console.error(err);
-  }
-  if (checkSuccess) {
-    await window.installProvider(provider.internalId);
-    // reset checks
-    preflightChecks = [];
-  } else {
-    displayInstallModal = true;
-  }
-  providerInstallationInProgress.set(provider.name, false);
-  providerInstallationInProgress = providerInstallationInProgress;
-}
-
-function hideInstallModal() {
-  displayInstallModal = false;
-}
 </script>
 
 <SettingsPage title="Resources">
-  <span slot="subtitle" class="{providers.length > 0 ? '' : 'hidden'}">
+  <span slot="subtitle" class:hidden="{providers.length === 0}">
     Additional provider information is available under <a
       href="/preferences/extensions"
       class="text-gray-700 underline underline-offset-2">Extensions</a>
   </span>
-  <div>
-    {#if providers.length === 0}
-      <div aria-label="no-resource-panel">
-        <EmptyScreen
-          icon="{EngineIcon}"
-          title="No resources found"
-          message="Start an extension that manages containers or Kubernetes engines"
-          class="bg-charcoal-600 mt-5 pb-10" />
-      </div>
-    {:else}
-      {#each providers as provider}
-        <div class="bg-charcoal-600 mb-5 rounded-md p-3 divide-x divide-gray-900 flex">
-          <div>
-            <!-- left col - provider icon/name + "create new" button -->
-            <div class="min-w-[150px] max-w-[200px]">
-              <div class="flex">
-                {#if provider.images.icon}
-                  {#if typeof provider.images.icon === 'string'}
-                    <img src="{provider.images.icon}" alt="{provider.name}" class="max-w-[40px] h-full" />
-                    <!-- TODO check theme used for image, now use dark by default -->
-                  {:else}
-                    <img src="{provider.images.icon.dark}" alt="{provider.name}" class="max-w-[40px]" />
-                  {/if}
+  <div class="w-full h-full">
+    <EmptyScreen
+      icon="{EngineIcon}"
+      title="No resources found"
+      message="Start an extension that manages containers or Kubernetes engines"
+      hidden="{providers.length > 0}" />
+    {#each providers as provider}
+      <div class="bg-charcoal-600 mb-5 rounded-md p-3 divide-x divide-gray-900 flex">
+        <div>
+          <!-- left col - provider icon/name + "create new" button -->
+          <div class="min-w-[150px] max-w-[200px]">
+            <div class="flex">
+              {#if provider.images.icon}
+                {#if typeof provider.images.icon === 'string'}
+                  <img src="{provider.images.icon}" alt="{provider.name}" class="max-w-[40px] h-full" />
+                  <!-- TODO check theme used for image, now use dark by default -->
+                {:else}
+                  <img src="{provider.images.icon.dark}" alt="{provider.name}" class="max-w-[40px]" />
                 {/if}
-                <span class="my-auto text-gray-400 ml-3 break-words">{provider.name}</span>
-              </div>
-              <div class="text-center mt-10">
-                {#if provider.containerProviderConnectionCreation || provider.kubernetesProviderConnectionCreation}
-                  {@const providerDisplayName =
-                    (provider.containerProviderConnectionCreation
-                      ? provider.containerProviderConnectionCreationDisplayName || undefined
-                      : provider.kubernetesProviderConnectionCreation
-                      ? provider.kubernetesProviderConnectionCreationDisplayName
-                      : undefined) || provider.name}
-                  {@const buttonTitle =
-                    (provider.containerProviderConnectionCreation
-                      ? provider.containerProviderConnectionCreationButtonTitle || undefined
-                      : provider.kubernetesProviderConnectionCreation
-                      ? provider.kubernetesProviderConnectionCreationButtonTitle
-                      : undefined) || 'Create new'}
-                  <!-- create new provider button -->
-                  <Tooltip tip="Create new {providerDisplayName}" bottom>
-                    <button
-                      class="pf-c-button pf-m-primary"
-                      aria-label="Create new {providerDisplayName}"
-                      type="button"
-                      on:click="{() => doCreateNew(provider, providerDisplayName)}">
-                      {#if providerInstallationInProgress.get(provider.name) === true}
-                        <i class="pf-c-button__progress">
-                          <span class="pf-c-spinner pf-m-md" role="progressbar">
-                            <span class="pf-c-spinner__clipper"></span>
-                            <span class="pf-c-spinner__lead-ball"></span>
-                            <span class="pf-c-spinner__tail-ball"></span>
-                          </span>
-                        </i>
-                      {/if}
-                      {buttonTitle} ...
-                    </button>
-                  </Tooltip>
-                {/if}
-              </div>
+              {/if}
+              <span class="my-auto text-gray-400 ml-3 break-words">{provider.name}</span>
+            </div>
+            <div class="text-center mt-10">
+              {#if provider.containerProviderConnectionCreation || provider.kubernetesProviderConnectionCreation}
+                {@const providerDisplayName =
+                  (provider.containerProviderConnectionCreation
+                    ? provider.containerProviderConnectionCreationDisplayName || undefined
+                    : provider.kubernetesProviderConnectionCreation
+                    ? provider.kubernetesProviderConnectionCreationDisplayName
+                    : undefined) || provider.name}
+                {@const buttonTitle =
+                  (provider.containerProviderConnectionCreation
+                    ? provider.containerProviderConnectionCreationButtonTitle || undefined
+                    : provider.kubernetesProviderConnectionCreation
+                    ? provider.kubernetesProviderConnectionCreationButtonTitle
+                    : undefined) || 'Create new'}
+                <!-- create new provider button -->
+                <Tooltip tip="Create new {providerDisplayName}" bottom>
+                  <button
+                    class="pf-c-button pf-m-primary"
+                    aria-label="Create new {providerDisplayName}"
+                    type="button"
+                    on:click="{() => router.goto(`/preferences/provider/${provider.internalId}`)}">
+                    {buttonTitle} ...
+                  </button>
+                </Tooltip>
+              {/if}
             </div>
           </div>
-          <!-- providers columns -->
-          <div class="grow flex flex-wrap divide-gray-900 ml-2">
-            <PreferencesConnectionsEmptyRendering
-              message="{provider.emptyConnectionMarkdownDescription}"
-              hidden="{provider.containerConnections.length > 0 || provider.kubernetesConnections.length > 0}" />
-            {#each provider.containerConnections as container}
-              <div class="px-5 py-2 w-[240px]">
-                <div class="float-right text-gray-900 cursor-not-allowed">
-                  <Fa icon="{faArrowUpRightFromSquare}" />
-                </div>
-                <div class="{container.status !== 'started' ? 'text-gray-900' : ''} text-sm">
-                  {container.name}
-                </div>
-                <div class="flex">
-                  <ConnectionStatus status="{container.status}" />
-                  {#if containerConnectionStatus.has(getProviderConnectionName(provider, container))}
-                    {@const status = containerConnectionStatus.get(getProviderConnectionName(provider, container))}
-                    {#if status.error}
-                      <button
-                        class="ml-3 text-[9px] text-red-500 underline"
-                        on:click="{() => window.events?.send('toggle-task-manager', '')}"
-                        >{status.action} failed</button>
-                    {/if}
-                  {/if}
-                </div>
-
-                {#if providerContainerConfiguration.has(provider.internalId)}
-                  <div class="flex mt-3 {container.status !== 'started' ? 'text-gray-900' : ''}">
-                    {#each providerContainerConfiguration
-                      .get(provider.internalId)
-                      .filter(conf => conf.container === container.name) as connectionSetting}
-                      {#if connectionSetting.format === 'cpu'}
-                        <div class="mr-4">
-                          <div class="text-[9px]">{connectionSetting.description}</div>
-                          <div class="text-xs">{connectionSetting.value}</div>
-                        </div>
-                      {:else if connectionSetting.format === 'memory' || connectionSetting.format === 'diskSize'}
-                        <div class="mr-4">
-                          <div class="text-[9px]">{connectionSetting.description}</div>
-                          <div class="text-xs">{filesize(connectionSetting.value)}</div>
-                        </div>
-                      {:else}
-                        {connectionSetting.description}: {connectionSetting.value}
-                      {/if}
-                    {/each}
-                  </div>
-                {/if}
-                <PreferencesConnectionActions
-                  provider="{provider}"
-                  connection="{container}"
-                  connectionStatuses="{containerConnectionStatus}"
-                  updateConnectionStatus="{updateContainerStatus}"
-                  addConnectionToRestartingQueue="{addConnectionToRestartingQueue}" />
-                <div class="mt-1.5 text-gray-900 text-[9px]">
-                  <div>{provider.name} {provider.version ? `v${provider.version}` : ''}</div>
-                </div>
-              </div>
-            {/each}
-            {#each provider.kubernetesConnections as kubeConnection}
-              <div class="px-5 py-2 w-[240px]">
-                <div class="text-sm">
-                  {kubeConnection.name}
-                </div>
-                <div class="flex mt-1">
-                  <ConnectionStatus status="{kubeConnection.status}" />
-                </div>
-                <div class="mt-2">
-                  <div class="text-gray-700 text-xs">Kubernetes endpoint</div>
-                  <div class="mt-1">
-                    <span class="my-auto text-xs" class:text-gray-900="{kubeConnection.status !== 'started'}"
-                      >{kubeConnection.endpoint.apiURL}</span>
-                  </div>
-                </div>
-                <PreferencesConnectionActions
-                  provider="{provider}"
-                  connection="{kubeConnection}"
-                  connectionStatuses="{containerConnectionStatus}"
-                  updateConnectionStatus="{updateContainerStatus}"
-                  addConnectionToRestartingQueue="{addConnectionToRestartingQueue}" />
-              </div>
-            {/each}
-          </div>
         </div>
-      {/each}
-    {/if}
+        <!-- providers columns -->
+        <div class="grow flex flex-wrap divide-gray-900 ml-2">
+          <PreferencesConnectionsEmptyRendering
+            message="{provider.emptyConnectionMarkdownDescription}"
+            hidden="{provider.containerConnections.length > 0 || provider.kubernetesConnections.length > 0}" />
+          {#each provider.containerConnections as container}
+            <div class="px-5 py-2 w-[240px]">
+              <div class="float-right text-gray-900 cursor-not-allowed">
+                <Fa icon="{faArrowUpRightFromSquare}" />
+              </div>
+              <div class="{container.status !== 'started' ? 'text-gray-900' : ''} text-sm">
+                {container.name}
+              </div>
+              <div class="flex">
+                <ConnectionStatus status="{container.status}" />
+                {#if containerConnectionStatus.has(getProviderConnectionName(provider, container))}
+                  {@const status = containerConnectionStatus.get(getProviderConnectionName(provider, container))}
+                  {#if status.error}
+                    <button
+                      class="ml-3 text-[9px] text-red-500 underline"
+                      on:click="{() => window.events?.send('toggle-task-manager', '')}">{status.action} failed</button>
+                  {/if}
+                {/if}
+              </div>
+
+              {#if providerContainerConfiguration.has(provider.internalId)}
+                <div class="flex mt-3 {container.status !== 'started' ? 'text-gray-900' : ''}">
+                  {#each providerContainerConfiguration
+                    .get(provider.internalId)
+                    .filter(conf => conf.container === container.name) as connectionSetting}
+                    {#if connectionSetting.format === 'cpu'}
+                      <div class="mr-4">
+                        <div class="text-[9px]">{connectionSetting.description}</div>
+                        <div class="text-xs">{connectionSetting.value}</div>
+                      </div>
+                    {:else if connectionSetting.format === 'memory' || connectionSetting.format === 'diskSize'}
+                      <div class="mr-4">
+                        <div class="text-[9px]">{connectionSetting.description}</div>
+                        <div class="text-xs">{filesize(connectionSetting.value)}</div>
+                      </div>
+                    {:else}
+                      {connectionSetting.description}: {connectionSetting.value}
+                    {/if}
+                  {/each}
+                </div>
+              {/if}
+              <PreferencesConnectionActions
+                provider="{provider}"
+                connection="{container}"
+                connectionStatuses="{containerConnectionStatus}"
+                updateConnectionStatus="{updateContainerStatus}"
+                addConnectionToRestartingQueue="{addConnectionToRestartingQueue}" />
+              <div class="mt-1.5 text-gray-900 text-[9px]">
+                <div>{provider.name} {provider.version ? `v${provider.version}` : ''}</div>
+              </div>
+            </div>
+          {/each}
+          {#each provider.kubernetesConnections as kubeConnection}
+            <div class="px-5 py-2 w-[240px]">
+              <div class="text-sm">
+                {kubeConnection.name}
+              </div>
+              <div class="flex mt-1">
+                <ConnectionStatus status="{kubeConnection.status}" />
+              </div>
+              <div class="mt-2">
+                <div class="text-gray-700 text-xs">Kubernetes endpoint</div>
+                <div class="mt-1">
+                  <span class="my-auto text-xs" class:text-gray-900="{kubeConnection.status !== 'started'}"
+                    >{kubeConnection.endpoint.apiURL}</span>
+                </div>
+              </div>
+              <PreferencesConnectionActions
+                provider="{provider}"
+                connection="{kubeConnection}"
+                connectionStatuses="{containerConnectionStatus}"
+                updateConnectionStatus="{updateContainerStatus}"
+                addConnectionToRestartingQueue="{addConnectionToRestartingQueue}" />
+            </div>
+          {/each}
+        </div>
+      </div>
+    {/each}
   </div>
-  {#if displayInstallModal}
-    <PreferencesProviderInstallationModal
-      providerToBeInstalled="{providerToBeInstalled}"
-      preflightChecks="{preflightChecks}"
-      closeCallback="{hideInstallModal}"
-      doCreateNew="{doCreateNew}" />
-  {/if}
 </SettingsPage>

--- a/packages/renderer/src/lib/preferences/SettingsPage.svelte
+++ b/packages/renderer/src/lib/preferences/SettingsPage.svelte
@@ -2,14 +2,14 @@
 export let title: string;
 </script>
 
-<div class="flex flex-col min-h-full min-w-full">
+<div class="flex flex-col min-w-full h-full">
   <div class="min-w-full pt-4 pb-4 px-5">
     <div>
       <p class="capitalize text-xl">{title}</p>
       <p class="text-sm text-gray-700"><slot name="subtitle"><br /></slot></p>
     </div>
   </div>
-  <div class="flex flex-col mt-4 pb-4 px-5 overflow-y-auto">
+  <div class="flex flex-col min-w-full h-full mt-4 pb-4 px-5 overflow-y-auto">
     <slot />
   </div>
 </div>

--- a/packages/renderer/src/lib/preferences/SettingsPage.svelte
+++ b/packages/renderer/src/lib/preferences/SettingsPage.svelte
@@ -3,11 +3,13 @@ export let title: string;
 </script>
 
 <div class="flex flex-col min-h-full min-w-full">
-  <div class="min-w-full pt-4 pb-4">
+  <div class="min-w-full pt-4 pb-4 px-5">
     <div>
       <p class="capitalize text-xl">{title}</p>
       <p class="text-sm text-gray-700"><slot name="subtitle"><br /></slot></p>
     </div>
   </div>
-  <slot />
+  <div class="flex flex-col mt-4 pb-4 px-5 overflow-y-auto">
+    <slot />
+  </div>
 </div>

--- a/packages/renderer/src/lib/ui/EmptyScreen.svelte
+++ b/packages/renderer/src/lib/ui/EmptyScreen.svelte
@@ -27,7 +27,11 @@ function copyRunInstructionToClipboard() {
 let copyTextDivElement: HTMLDivElement;
 </script>
 
-<div class="h-full min-w-full flex flex-col {$$props.class || ''}" class:hidden="{hidden}" style="{$$props.style}" aria-label="{$$props['aria-label']}">
+<div
+  class="h-full min-w-full flex flex-col {$$props.class || ''}"
+  class:hidden="{hidden}"
+  style="{$$props.style}"
+  aria-label="{$$props['aria-label']}">
   <div class="pf-c-empty-state h-full">
     <div class="pf-c-empty-state__content">
       <p class="pf-c-empty-state__body">

--- a/packages/renderer/src/lib/ui/EmptyScreen.svelte
+++ b/packages/renderer/src/lib/ui/EmptyScreen.svelte
@@ -27,7 +27,7 @@ function copyRunInstructionToClipboard() {
 let copyTextDivElement: HTMLDivElement;
 </script>
 
-<div class="h-full min-w-full flex flex-col ${$$props.class || ''}" class:hidden="{hidden}" style="{$$props.style}">
+<div class="h-full min-w-full flex flex-col {$$props.class || ''}" class:hidden="{hidden}" style="{$$props.style}" aria-label="{$$props['aria-label']}">
   <div class="pf-c-empty-state h-full">
     <div class="pf-c-empty-state__content">
       <p class="pf-c-empty-state__body">

--- a/packages/renderer/src/lib/ui/NavPage.svelte
+++ b/packages/renderer/src/lib/ui/NavPage.svelte
@@ -4,8 +4,8 @@ export let searchTerm = '';
 export let searchEnabled = true;
 </script>
 
-<div class="flex flex-col min-h-full min-w-fit w-full shadow-pageheader">
-  <div class="min-w-full pt-4" class:pb-4="{!searchEnabled}">
+<div class="flex flex-col w-full h-full shadow-pageheader">
+  <div class="flex flex-col w-full h-full pt-4">
     <div class="flex">
       <div class="px-5">
         <h1 aria-label="{title}" class="text-xl first-letter:uppercase">{title}</h1>
@@ -47,9 +47,7 @@ export let searchEnabled = true;
     {/if}
 
     <slot name="table" />
-  </div>
 
-  <div class="flex flex-col container flex-1 min-w-full">
     <slot name="empty" />
   </div>
 </div>

--- a/packages/renderer/src/lib/volume/VolumesList.svelte
+++ b/packages/renderer/src/lib/volume/VolumesList.svelte
@@ -226,10 +226,10 @@ function computeInterval(): number {
     {/if}
   </div>
 
-  <div class="min-w-full flex" slot="table">
-    <table class="mx-5 w-full" class:hidden="{volumes.length === 0}">
+  <div class="flex min-w-full h-full overflow-auto" class:hidden="{volumes.length === 0}" slot="table">
+    <table class="mx-5 w-full h-fit">
       <!-- title -->
-      <thead>
+      <thead class="sticky top-0 bg-charcoal-700 z-[2]">
         <tr class="h-7 uppercase text-xs text-gray-600">
           <th class="whitespace-nowrap w-5"></th>
           <th class="px-2 w-5">
@@ -245,7 +245,7 @@ function computeInterval(): number {
           <th class="text-right pr-2">Actions</th>
         </tr>
       </thead>
-      <tbody class="">
+      <tbody>
         {#each volumes as volume}
           <tr class="group h-12 bg-charcoal-800 hover:bg-zinc-700">
             <td class="rounded-tl-lg rounded-bl-lg w-5"> </td>
@@ -295,8 +295,7 @@ function computeInterval(): number {
         {/each}
       </tbody>
     </table>
-  </div>
-  <div slot="empty" class="min-h-full">
+
     {#if providerConnections.length === 0}
       <NoContainerEngineEmptyScreen />
     {:else if fetchingInProgress}

--- a/packages/renderer/src/lib/volume/VolumesList.svelte
+++ b/packages/renderer/src/lib/volume/VolumesList.svelte
@@ -226,8 +226,8 @@ function computeInterval(): number {
     {/if}
   </div>
 
-  <div class="flex min-w-full h-full overflow-auto" class:hidden="{volumes.length === 0}" slot="table">
-    <table class="mx-5 w-full h-fit">
+  <div class="flex min-w-full h-full overflow-auto" slot="table">
+    <table class="mx-5 w-full h-fit" class:hidden="{volumes.length === 0}">
       <!-- title -->
       <thead class="sticky top-0 bg-charcoal-700 z-[2]">
         <tr class="h-7 uppercase text-xs text-gray-600">


### PR DESCRIPTION
### What does this PR do?

I have hit and tried to fix scrolling issues twice in the past and failed. This time I had a little help from Mairin and was a little more determined. This change makes all headers fixed (including titles and table headers) and moves all scrollbars to the 'content' area of the page.

Some notes:
- To keep headers & titles fixed and scroll the contents below, there were several places where padding needed to be moved 'up' or 'down' one level so that scrollbars are always on the correct/right edge.
- Likewise, once we have scrollbars in the correct places, it was clearer that (e.g.) several Settings pages had different top or bottom padding, had to fix these.
- I'm not entirely sure why the NavPage had separate table vs empty slots, but keeping them separate was causing layout issues. Most pages are no longer using both.

Intentionally left for future PRs:
- We can remove one of the NavPage `table` and `empty` slots and rename the other.
- The Settings > Preferences search should be part of the header now.
- In Settings > Resources > Create, the breadcrumb is in the header but the icon/title probably should be too?

### Screenshot/screencast of this PR

Before:
<img width="1162" alt="Screenshot 2023-06-13 at 1 39 26 PM" src="https://github.com/containers/podman-desktop/assets/19958075/a00a82a9-4b2b-4d7a-bb30-2f8ec0f7200d">

After:

https://github.com/containers/podman-desktop/assets/19958075/df37327d-8e9f-4743-abfb-ccbf384a7850

### What issues does this PR fix or reference?

Fixes #2864.
Fixes #2182.

### How to test this PR?

Open every screen, make window too big and too small and confirm content looks good. Stop all providers, do the same.