### PR TITLE
fix: if kubeconfig is empty, does not try to do things, abort

### DIFF
--- a/extensions/kube-context/package.json
+++ b/extensions/kube-context/package.json
@@ -32,6 +32,7 @@
     "7zip-min": "^1.4.4",
     "@types/js-yaml": "^4.0.5",
     "mkdirp": "^3.0.1",
+    "vitest": "^0.32.0",
     "zip-local": "^0.3.5"
   }
 }

--- a/extensions/kube-context/src/extension.spec.ts
+++ b/extensions/kube-context/src/extension.spec.ts
@@ -1,0 +1,45 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { beforeEach, expect, test, vi } from 'vitest';
+import type * as podmanDesktopApi from '@podman-desktop/api';
+import * as fs from 'node:fs';
+import { updateContext } from './extension';
+
+vi.mock('@podman-desktop/api', async () => {
+  return {};
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+test('check empty kubeconfig file', async () => {
+  const readFileMock = vi.spyOn(fs.promises, 'readFile');
+  const consoleErrorSpy = vi.spyOn(console, 'error');
+
+  // provide empty kubeconfig file
+  readFileMock.mockResolvedValue('');
+  const fakeContext = {} as podmanDesktopApi.ExtensionContext;
+
+  const fakeFile = '/fake/kubeconfig/file';
+  await updateContext(fakeContext, fakeFile);
+  expect(consoleErrorSpy).toBeCalledWith(`Kubeconfig file at '${fakeFile}' is empty. Skipping.`);
+});

--- a/extensions/kube-context/src/extension.ts
+++ b/extensions/kube-context/src/extension.ts
@@ -41,9 +41,17 @@ async function deleteContext(): Promise<void> {
   }
 }
 
-async function updateContext(extensionContext: extensionApi.ExtensionContext, kubeconfigFile: string): Promise<void> {
+export async function updateContext(
+  extensionContext: extensionApi.ExtensionContext,
+  kubeconfigFile: string,
+): Promise<void> {
   // read the kubeconfig file using fs
   const kubeConfigRawContent = await fs.promises.readFile(kubeconfigFile, 'utf-8');
+
+  if (kubeConfigRawContent.length === 0) {
+    console.error(`Kubeconfig file at '${kubeconfigFile}' is empty. Skipping.`);
+    return;
+  }
 
   // parse the content using jsYaml
   const kubeConfig = jsYaml.load(kubeConfigRawContent);

--- a/packages/main/src/plugin/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes-client.ts
@@ -298,6 +298,13 @@ export class KubernetesClient {
   }
 
   async refresh() {
+    // check the file is empty
+    const fileContent = await fs.promises.readFile(this.kubeconfigPath);
+    if (fileContent.length === 0) {
+      console.error(`Kubeconfig file at ${this.kubeconfigPath} is empty. Skipping.`);
+      return;
+    }
+
     // perform it under a try/catch block as the file may not be valid for the kubernetes-javascript client library
     try {
       this.kubeConfig.loadFromFile(this.kubeconfigPath);


### PR DESCRIPTION
### What does this PR do?
Allow to use empty kubeconfig file without throwing tons of errors

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/2683


### How to test this PR?

Unit tests or try to do a symlink of /dev/null or use empty kubeconfig file