### PR TITLE
feat: add tag and authenticated push capacity to the extension API

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -1483,12 +1483,26 @@ declare module '@podman-desktop/api' {
     Type?: string;
   }
 
+  interface ContainerAuthInfo {
+    username: string;
+    password: string;
+    serveraddress: string;
+    email?: string;
+  }
+
   export namespace containerEngine {
     export function listContainers(): Promise<ContainerInfo[]>;
     export function inspectContainer(engineId: string, id: string): Promise<ContainerInspectInfo>;
     export function startContainer(engineId: string, id: string): Promise<void>;
     export function stopContainer(engineId: string, id: string): Promise<void>;
     export function saveImage(engineId: string, id: string, filename: string): Promise<void>;
+    export function tagImage(engineId: string, imageId: string, repo: string, tag?: string): Promise<void>;
+    export function pushImage(
+      engineId: string,
+      imageId: string,
+      callback: (name: string, data: string) => void,
+      authInfo?: ContainerAuthInfo,
+    ): Promise<void>;
     export const onEvent: Event<ContainerJSONEvent>;
   }
 

--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -1,0 +1,84 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { beforeEach, expect, test, vi } from 'vitest';
+import { ContainerProviderRegistry } from '/@/plugin/container-registry.js';
+import type { Telemetry } from '/@/plugin/telemetry/telemetry.js';
+import type { Certificates } from '/@/plugin/certificates.js';
+import type { Proxy } from '/@/plugin/proxy.js';
+import { ImageRegistry } from '/@/plugin/image-registry.js';
+import type { ApiSenderType } from '/@/plugin/api.js';
+import type Dockerode from 'dockerode';
+
+/* eslint-disable @typescript-eslint/no-empty-function */
+
+vi.mock('dockerode', async () => {
+  return {
+    default: vi.fn(),
+  };
+});
+
+let containerRegistry: ContainerProviderRegistry;
+
+const telemetryTrackMock = vi.fn().mockResolvedValue({});
+const telemetry: Telemetry = { track: telemetryTrackMock } as unknown as Telemetry;
+
+beforeEach(() => {
+  const certificates: Certificates = {
+    init: vi.fn(),
+    getAllCertificates: vi.fn(),
+  } as unknown as Certificates;
+  const proxy: Proxy = {
+    onDidStateChange: vi.fn(),
+    onDidUpdateProxy: vi.fn(),
+    isEnabled: vi.fn(),
+  } as unknown as Proxy;
+
+  const imageRegistry = new ImageRegistry({} as ApiSenderType, telemetry, certificates, proxy);
+  containerRegistry = new ContainerProviderRegistry({} as ApiSenderType, imageRegistry, telemetry);
+});
+
+test('tag should reject if no provider', async () => {
+  await expect(
+    containerRegistry.tagImage('dummy', 'image:latest', 'quay.io/podman-desktop/image'),
+  ).rejects.toThrowError('no engine matching this engine');
+});
+
+test('tag should succeed if provider', async () => {
+  const engine = {
+    getImage: vi.fn().mockReturnValue({ tag: vi.fn().mockResolvedValue({}) }),
+  };
+  vi.spyOn(containerRegistry, 'getMatchingEngine').mockReturnValue(engine as unknown as Dockerode);
+  const result = await containerRegistry.tagImage('dummy', 'image:latest', 'quay.io/podman-desktop/image');
+  expect(result).toBeUndefined();
+});
+
+test('push should reject if no provider', async () => {
+  await expect(containerRegistry.pushImage('dummy', 'image:latest', () => {})).rejects.toThrowError(
+    'no engine matching this engine',
+  );
+});
+
+test('push should succeed if provider', async () => {
+  const engine = {
+    getImage: vi.fn().mockReturnValue({ push: vi.fn().mockResolvedValue({ on: vi.fn() }) }),
+  };
+  vi.spyOn(containerRegistry, 'getMatchingEngine').mockReturnValue(engine as unknown as Dockerode);
+  const result = await containerRegistry.pushImage('dummy', 'image:latest', () => {});
+  expect(result).toBeUndefined();
+});

--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -33,7 +33,13 @@ vi.mock('dockerode', async () => {
   };
 });
 
-let containerRegistry: ContainerProviderRegistry;
+class TestContainerProviderRegistry extends ContainerProviderRegistry {
+  public getMatchingEngine(engineId: string): Dockerode {
+    return super.getMatchingEngine(engineId);
+  }
+}
+
+let containerRegistry: TestContainerProviderRegistry;
 
 const telemetryTrackMock = vi.fn().mockResolvedValue({});
 const telemetry: Telemetry = { track: telemetryTrackMock } as unknown as Telemetry;
@@ -50,7 +56,7 @@ beforeEach(() => {
   } as unknown as Proxy;
 
   const imageRegistry = new ImageRegistry({} as ApiSenderType, telemetry, certificates, proxy);
-  containerRegistry = new ContainerProviderRegistry({} as ApiSenderType, imageRegistry, telemetry);
+  containerRegistry = new TestContainerProviderRegistry({} as ApiSenderType, imageRegistry, telemetry);
 });
 
 test('tag should reject if no provider', async () => {

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -795,6 +795,17 @@ export class ExtensionLoader {
       saveImage(engineId: string, id: string, filename: string) {
         return containerProviderRegistry.saveImage(engineId, id, filename);
       },
+      pushImage(
+        engineId: string,
+        imageId: string,
+        callback: (name: string, data: string) => void,
+        authInfo: containerDesktopAPI.ContainerAuthInfo | undefined,
+      ): Promise<void> {
+        return containerProviderRegistry.pushImage(engineId, imageId, callback, authInfo);
+      },
+      tagImage(engineId: string, imageId: string, repo: string, tag: string | undefined): Promise<void> {
+        return containerProviderRegistry.tagImage(engineId, imageId, repo, tag);
+      },
       onEvent: (listener, thisArg, disposables) => {
         return containerProviderRegistry.onEvent(listener, thisArg, disposables);
       },


### PR DESCRIPTION
Fixes #2830

### What does this PR do?

Extend the API with image tag and push capacity

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

Fixes #2830 

### How to test this PR?

Unit tests have been added
