### PR TITLE
fix: do not block startup while waiting for kube resource refresh

### DIFF
--- a/packages/main/src/plugin/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes-client.ts
@@ -168,7 +168,9 @@ export class KubernetesClient {
       // check if path exists
       if (existsSync(userKubeconfigPath)) {
         this.kubeconfigPath = userKubeconfigPath;
-        await this.refresh();
+        this.refresh()
+          .then(() => console.log('Refresh of kube resources on startup complete'))
+          .catch((err) => console.log('Refresh of kube resources on startup failed'));
       } else {
         console.error(`Kubeconfig path ${userKubeconfigPath} provided does not exist. Skipping.`);
       }

--- a/packages/main/src/plugin/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes-client.ts
@@ -170,7 +170,7 @@ export class KubernetesClient {
         this.kubeconfigPath = userKubeconfigPath;
         this.refresh()
           .then(() => console.log('Refresh of kube resources on startup complete'))
-          .catch(() => console.log('Refresh of kube resources on startup failed'));
+          .catch(() => console.error('Refresh of kube resources on startup failed'));
       } else {
         console.error(`Kubeconfig path ${userKubeconfigPath} provided does not exist. Skipping.`);
       }

--- a/packages/main/src/plugin/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes-client.ts
@@ -170,7 +170,7 @@ export class KubernetesClient {
         this.kubeconfigPath = userKubeconfigPath;
         this.refresh()
           .then(() => console.log('Refresh of kube resources on startup complete'))
-          .catch((err) => console.log('Refresh of kube resources on startup failed'));
+          .catch(() => console.log('Refresh of kube resources on startup failed'));
       } else {
         console.error(`Kubeconfig path ${userKubeconfigPath} provided does not exist. Skipping.`);
       }

--- a/packages/main/src/plugin/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes-client.ts
@@ -168,9 +168,7 @@ export class KubernetesClient {
       // check if path exists
       if (existsSync(userKubeconfigPath)) {
         this.kubeconfigPath = userKubeconfigPath;
-        this.refresh()
-          .then(() => console.log('Refresh of kube resources on startup complete'))
-          .catch(() => console.error('Refresh of kube resources on startup failed'));
+        this.refresh().catch(() => console.error('Refresh of kube resources on startup failed'));
       } else {
         console.error(`Kubeconfig path ${userKubeconfigPath} provided does not exist. Skipping.`);
       }


### PR DESCRIPTION
### What does this PR do?

If the current cluster context defined in the user's kube config is not accessible, the startup of Podman Desktop can take 1-2 minutes. This PR fixes the slow initialisation issue mentioned by me in #1633. 

This PR may not be the optimal fix, but I am opening it in case it is considered a valid temporary workaround.

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

#1633 

### How to test this PR?

These steps are specific to my scenario. I assume the same steps could work with Minikube etc.

1. Deploy OpenShift local on a remote Fedora machine.
2. `oc login` to the remote instance form the machine running Podman Deskop (to update `~/.kube/config`)
3. Power down the remote machine.
4. Start Podman Desktop

The Podman Desktop "initialising" screen should be displayed for 1-2 minutes, then log that it failed to fetch API groups before Podman Desktop finishes initialising as shown in this screenshot:

![Screenshot 2023-06-15 at 10 57 19 AM](https://github.com/containers/podman-desktop/assets/1303687/05607b58-0dc4-482b-bff3-0d2beaf55226)


