### PR TITLE
fix: Async telemetry startup

### DIFF
--- a/packages/main/src/plugin/telemetry/telemetry.ts
+++ b/packages/main/src/plugin/telemetry/telemetry.ts
@@ -118,10 +118,12 @@ export class Telemetry {
       },
     });
 
-    // needs to prompt the user for the first time he launches the app
     if (check) {
+      // the user has been prompted, either configure the telemetry system or disable it based on their preference
       if (this.isTelemetryEnabled()) {
-        await this.configureTelemetry();
+        this.configureTelemetry().catch((err: unknown) => {
+          console.log(`Error initializing telemetry: ${err}`);
+        });
       } else {
         this.telemetryInitialized = true;
 

--- a/packages/main/src/plugin/telemetry/telemetry.ts
+++ b/packages/main/src/plugin/telemetry/telemetry.ts
@@ -122,7 +122,7 @@ export class Telemetry {
       // the user has been prompted, either configure the telemetry system or disable it based on their preference
       if (this.isTelemetryEnabled()) {
         this.configureTelemetry().catch((err: unknown) => {
-          console.log(`Error initializing telemetry: ${err}`);
+          console.error(`Error initializing telemetry: ${err}`);
         });
       } else {
         this.telemetryInitialized = true;


### PR DESCRIPTION
### What does this PR do?

When the user has enabled telemetry we currently block initialization until we are able to configure telemetry and send the first event out. This can delay startup unnecessarily if there are any DNS/network issues. I can't see any issues with just making this async; we already queue up pending events.

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

None, see background in issue #1633.

### How to test this PR?

No visible change/error during startup. You can add a delay in configureTelemetry() to tell the difference, or logging to confirm that events are still being sent.