### PR TITLE
chore: apply prettier on *.json files and *.md files

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -36,8 +36,8 @@
         "parser": "@typescript-eslint/parser"
       }
     }
-]
-,  "settings": {
+  ],
+  "settings": {
     "import/resolver": {
       "typescript": true,
       "node": true,
@@ -69,29 +69,21 @@
     "@typescript-eslint/no-misused-promises": "error",
     "@typescript-eslint/prefer-optional-chain": "error",
 
-  /**
-   * Having a semicolon helps the optimizer interpret your code correctly.
-   * This avoids rare errors in optimized code.
-   * @see https://twitter.com/alex_kozack/status/1364210394328408066
-   */
-    "semi": [
-      "error",
-      "always"
-    ],
+    /**
+     * Having a semicolon helps the optimizer interpret your code correctly.
+     * This avoids rare errors in optimized code.
+     * @see https://twitter.com/alex_kozack/status/1364210394328408066
+     */
+    "semi": ["error", "always"],
     /**
      * This will make the history of changes in the hit a little cleaner
      */
-    "comma-dangle": [
-      "warn",
-      "always-multiline"
-    ],
+    "comma-dangle": ["warn", "always-multiline"],
     /**
      * Just for beauty
      */
-    "quotes": [
-      "warn", "single"
-    ],
-    "import/no-duplicates" : "error",
+    "quotes": ["warn", "single"],
+    "import/no-duplicates": "error",
     "import/no-unresolved": "off",
     "import/default": "off",
     "import/no-named-as-default-member": "off",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,11 +145,13 @@ Check the npm script tasks in our `package.json` for more options.
 ### Step 5. Run E2E tests
 
 In case of adding new feature, it is always suitable to make sure we do not bring any new regression. For this purpose we are using the E2E tests. They can be run using `yarn`:
+
 ```sh
 yarn test:e2e:smoke
 ```
 
 Although, there are requirements that need to be fulfilled before running the tests in order to make them pass:
+
 - remove `settings.json` from `~/.local/share/containers/podman-desktop/configuration/` or if you do not want to lose your settings, remove the objects from the file with keys `"welcome.version"` and `"telemetry.*"`
 
 ### Step 6. Code coverage
@@ -177,6 +179,7 @@ For a detailed information about the code coverage you can search the mentioned 
 `test-resources/coverage/extensions/compose/lcov-report/index.html`
 
 When contribuing the new code, you should consider not lowering overall code coverage.
+
 ### Step 7. Code formatter / linter
 
 We use `prettier` as a formatter and `eslint` for linting.

--- a/packages/renderer/.eslintrc.json
+++ b/packages/renderer/.eslintrc.json
@@ -17,5 +17,5 @@
     "svelte/no-at-html-tags": "off",
     "no-useless-escape": "off",
     "no-empty": "off"
-    }
+  }
 }


### PR DESCRIPTION
### What does this PR do?
apply prettier on *.json files and *.md files

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

with husky/pre-commit files will be auto-formatted

### How to test this PR?

no changes except formatting (check using ignore whitespaces)

Signed-off-by: Florent Benoit <fbenoit@redhat.com>
