### PR TITLE
chore: NavPage content slot

### DIFF
--- a/packages/renderer/src/lib/ContainerList.svelte
+++ b/packages/renderer/src/lib/ContainerList.svelte
@@ -370,7 +370,7 @@ function errorCallback(container: ContainerInfoUI, errorMessage: string): void {
     {/if}
   </div>
 
-  <div class="flex min-w-full h-full overflow-auto" slot="table">
+  <div class="flex min-w-full h-full overflow-auto" slot="content">
     <table class="mx-5 w-full h-fit" class:hidden="{containerGroups.length === 0}">
       <!-- title -->
       <thead class="sticky top-0 bg-charcoal-700 z-[2]">

--- a/packages/renderer/src/lib/ImagesList.svelte
+++ b/packages/renderer/src/lib/ImagesList.svelte
@@ -270,7 +270,7 @@ function computeInterval(): number {
     {/if}
   </div>
 
-  <div class="flex min-w-full h-full overflow-auto" slot="table">
+  <div class="flex min-w-full h-full overflow-auto" slot="content">
     <table class="mx-5 min-w-full h-fit" class:hidden="{images.length === 0}">
       <!-- title -->
       <thead class="sticky top-0 bg-charcoal-700 z-[2]">

--- a/packages/renderer/src/lib/dashboard/DashboardPage.svelte
+++ b/packages/renderer/src/lib/dashboard/DashboardPage.svelte
@@ -36,7 +36,7 @@ function getInitializationContext(id: string) {
 </script>
 
 <NavPage searchEnabled="{false}" title="Dashboard">
-  <div slot="empty" class="flex flex-col h-full bg-charcoal-700 shadow-nav pt-5 overflow-hidden">
+  <div slot="content" class="flex flex-col h-full bg-charcoal-700 shadow-nav pt-5 overflow-hidden">
     <div class="min-w-full flex-1 overflow-auto">
       <div class="px-5 space-y-5 h-full">
         <!-- Provider is ready display a box to indicate some information -->

--- a/packages/renderer/src/lib/help/HelpPage.svelte
+++ b/packages/renderer/src/lib/help/HelpPage.svelte
@@ -18,7 +18,7 @@ $: contributedLinks = $providerInfos
 </script>
 
 <NavPage searchEnabled="{false}" title="Help">
-  <div slot="empty" class="flex flex-col min-h-full bg-zinc-700">
+  <div slot="content" class="flex flex-col min-h-full bg-zinc-700">
     <div class="min-w-full flex-1 pt-5 px-5 pb-5 space-y-5">
       <!-- Getting Started -->
       <div class="bg-charcoal-600 px-3 pt-3 pb-3 rounded-lg">

--- a/packages/renderer/src/lib/image/BuildImageFromContainerfile.svelte
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfile.svelte
@@ -130,7 +130,7 @@ async function getContainerBuildContextDirectory() {
 </script>
 
 <NavPage title="Build Image from Containerfile" searchEnabled="{false}">
-  <div slot="empty" class="p-5">
+  <div slot="content" class="p-5">
     {#if providerConnections.length === 0}
       <NoContainerEngineEmptyScreen />
     {:else}

--- a/packages/renderer/src/lib/image/PullImage.svelte
+++ b/packages/renderer/src/lib/image/PullImage.svelte
@@ -123,7 +123,7 @@ function validateImageName(event): void {
     </button>
   </div>
 
-  <div slot="empty" class="p-5">
+  <div slot="content" class="p-5">
     {#if providerConnections.length === 0}
       <NoContainerEngineEmptyScreen />
     {:else}

--- a/packages/renderer/src/lib/image/RunImage.svelte
+++ b/packages/renderer/src/lib/image/RunImage.svelte
@@ -388,7 +388,7 @@ function checkContainerName(event: any) {
 <Route path="/*" let:meta>
   {#if dataReady}
     <NavPage title="Create a container from image {imageDisplayName}:{image.tag}" searchEnabled="{false}">
-      <div slot="empty" class="bg-zinc-700 p-5 h-full">
+      <div slot="content" class="bg-zinc-700 p-5 h-full">
         <div class="bg-charcoal-600 px-6 py-4 space-y-2 lg:px-8 sm:pb-6 xl:pb-8">
           <section class="pf-c-page__main-tabs pf-m-limit-width">
             <div class="pf-c-page__main-body">

--- a/packages/renderer/src/lib/kube/KubePlayYAML.svelte
+++ b/packages/renderer/src/lib/kube/KubePlayYAML.svelte
@@ -125,7 +125,7 @@ async function getKubernetesfileLocation() {
 
 {#if providerConnections.length > 0}
   <NavPage title="Play Pods or Containers from a Kubernetes YAML File" searchEnabled="{false}">
-    <div slot="empty" class="bg-charcoal-700 p-5 h-full">
+    <div slot="content" class="bg-charcoal-700 p-5 h-full">
       <div class="bg-charcoal-800 px-6 py-4 space-y-6 lg:px-8 sm:pb-6 xl:pb-8 rounded-lg">
         <div class="text-xl font-medium">Select file:</div>
         <div hidden="{runStarted}">

--- a/packages/renderer/src/lib/pod/DeployPodToKube.svelte
+++ b/packages/renderer/src/lib/pod/DeployPodToKube.svelte
@@ -344,7 +344,7 @@ function updateKubeResult() {
 </script>
 
 <NavPage title="Deploy generated pod to Kubernetes" searchEnabled="{false}">
-  <div slot="empty" class="p-5 bg-zinc-700 h-full">
+  <div slot="content" class="p-5 bg-zinc-700 h-full">
     <div class="bg-charcoal-600 h-full p-5">
       {#if kubeDetails}
         <p>Generated pod to deploy to Kubernetes:</p>

--- a/packages/renderer/src/lib/pod/PodCreateFromContainers.svelte
+++ b/packages/renderer/src/lib/pod/PodCreateFromContainers.svelte
@@ -186,7 +186,7 @@ function updatePortExposure(port: number, checked: boolean) {
 </script>
 
 <NavPage title="Copy containers to a pod" searchEnabled="{false}">
-  <div class="w-full h-full min-w-fit" slot="empty">
+  <div class="w-full h-full min-w-fit" slot="content">
     <div class="m-5 p-6 h-full bg-charcoal-800 rounded-sm text-gray-700">
       <div class="w-4/5 min-w-[500px]">
         {#if podCreation}

--- a/packages/renderer/src/lib/pod/PodsList.svelte
+++ b/packages/renderer/src/lib/pod/PodsList.svelte
@@ -231,7 +231,7 @@ function errorCallback(pod: PodInfoUI, errorMessage: string): void {
     {/if}
   </div>
 
-  <div class="flex min-w-full h-full overflow-auto" slot="table">
+  <div class="flex min-w-full h-full overflow-auto" slot="content">
     <table class="mx-5 w-full h-fit" class:hidden="{pods.length === 0}">
       <!-- title -->
       <thead class="sticky top-0 bg-charcoal-700 z-[2]">

--- a/packages/renderer/src/lib/ui/NavPage.svelte
+++ b/packages/renderer/src/lib/ui/NavPage.svelte
@@ -46,8 +46,6 @@ export let searchEnabled = true;
       </div>
     {/if}
 
-    <slot name="table" />
-
-    <slot name="empty" />
+    <slot name="content" />
   </div>
 </div>

--- a/packages/renderer/src/lib/volume/VolumesList.svelte
+++ b/packages/renderer/src/lib/volume/VolumesList.svelte
@@ -226,7 +226,7 @@ function computeInterval(): number {
     {/if}
   </div>
 
-  <div class="flex min-w-full h-full overflow-auto" slot="table">
+  <div class="flex min-w-full h-full overflow-auto" slot="content">
     <table class="mx-5 w-full h-fit" class:hidden="{volumes.length === 0}">
       <!-- title -->
       <thead class="sticky top-0 bg-charcoal-700 z-[2]">


### PR DESCRIPTION
### What does this PR do?

Follow-up post PR #2863: there is no real need for table vs empty slots in NavPage, there is always a fixed header and a content area. Nothing was using both slots.

This commit merges down to one 'content' slot.

### Screenshot/screencast of this PR

N/A, no visible change.

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Hit several main nav pages and confirm no regression.