### PR TITLE
chore: Move preferences search into header

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRendering.svelte
@@ -48,7 +48,7 @@ function updateSearchValue(event: any) {
 
 <Route path="/" breadcrumb="{key}">
   <SettingsPage title="Preferences">
-    <div class="bg-charcoal-900">
+    <div class="mt-4" slot="header">
       <div
         class="flex items-center text-gray-700 rounded-sm rounded-lg border-2 border-charcoal-900 focus-within:border-violet-500">
         <input
@@ -73,12 +73,12 @@ function updateSearchValue(event: any) {
         </svg>
       </div>
     </div>
-    <div class="flex flex-col min-w-full rounded-md">
+    <div class="flex flex-col min-w-full rounded-md space-y-5">
       {#if matchingRecords.size === 0}
-        <div class="mt-5">No Settings Found</div>
+        <div>No Settings Found</div>
       {:else}
         {#each [...matchingRecords.keys()].sort((a, b) => a.localeCompare(b)) as configSection}
-          <div class="mt-5">
+          <div>
             <div class="first-letter:uppercase">{matchingRecords.get(configSection).at(0).title}</div>
             {#each matchingRecords.get(configSection) as configItem}
               <div class="bg-charcoal-600 rounded-md mt-2 ml-2">

--- a/packages/renderer/src/lib/preferences/SettingsPage.svelte
+++ b/packages/renderer/src/lib/preferences/SettingsPage.svelte
@@ -3,13 +3,15 @@ export let title: string;
 </script>
 
 <div class="flex flex-col min-w-full h-full">
-  <div class="min-w-full pt-4 pb-4 px-5">
+  <div class="min-w-full px-5 py-4">
     <div>
       <p class="capitalize text-xl">{title}</p>
       <p class="text-sm text-gray-700"><slot name="subtitle"><br /></slot></p>
     </div>
+
+    <slot name="header" />
   </div>
-  <div class="flex flex-col min-w-full h-full mt-4 pb-4 px-5 overflow-y-auto">
+  <div class="flex flex-col min-w-full h-full px-5 py-4 overflow-y-auto">
     <slot />
   </div>
 </div>


### PR DESCRIPTION
### What does this PR do?

Follow up from PR #2863: the search bar for preferences should be in the header and always visible.

I started to add a search capability to SettingsPage similar to NavPage, but I don't think the extra code and complexity is worth it when this is the only page that has search within Settings. This just adds a slot to the header, uses it in preferences, and makes the necessary formatting changes.

Minor tweak to merge pt/mt + pb into a py.

### Screenshot/screencast of this PR

<img width="785" alt="Screenshot 2023-06-16 at 2 14 38 PM" src="https://github.com/containers/podman-desktop/assets/19958075/89399565-0bed-4e64-bbc4-38b7c8b84501">

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Go to Settings > Preferences. Confirm scrollbar works as expected, search is in the header and works.