### PR TITLE
feat: add ability to add insecure registry / skipping cert verify

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -445,6 +445,7 @@ declare module '@podman-desktop/api' {
     serverUrl: string;
     username: string;
     secret: string;
+    ignoreInvalidCert?: boolean;
   }
 
   export interface RegistryProvider {

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -445,7 +445,7 @@ declare module '@podman-desktop/api' {
     serverUrl: string;
     username: string;
     secret: string;
-    ignoreInvalidCert?: boolean;
+    insecure?: boolean;
   }
 
   export interface RegistryProvider {

--- a/packages/main/src/plugin/image-registry.spec.ts
+++ b/packages/main/src/plugin/image-registry.spec.ts
@@ -385,6 +385,21 @@ describe('expect checkCredentials', async () => {
     );
   });
 
+  test('expect checkCredentials works with ignoring the certificate', async () => {
+    const spyGetAuthInfo = vi.spyOn(imageRegistry, 'getAuthInfo');
+    spyGetAuthInfo.mockResolvedValue({ authUrl: 'foo', scheme: 'bearer' });
+
+    const spydoCheckCredentials = vi.spyOn(imageRegistry, 'doCheckCredentials');
+    spydoCheckCredentials.mockResolvedValue();
+
+    await imageRegistry.checkCredentials(
+      'my-podman-desktop-fake-registry.io/my/extension',
+      'my-username',
+      'my-password',
+      true,
+    );
+  });
+
   test('expect checkCredentials fails', async () => {
     const spyGetAuthInfo = vi.spyOn(imageRegistry, 'getAuthInfo');
     spyGetAuthInfo.mockResolvedValue({ authUrl: 'foo', scheme: 'bearer' });

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1156,6 +1156,18 @@ export class PluginSystem {
       },
     );
 
+    // Check credentials for a registry
+    this.ipcHandle(
+      'image-registry:checkCredentials',
+      async (_listener, registryCreateOptions: containerDesktopAPI.RegistryCreateOptions): Promise<void> => {
+        return imageRegistry.checkCredentials(
+          registryCreateOptions.serverUrl,
+          registryCreateOptions.username,
+          registryCreateOptions.secret,
+        );
+      },
+    );
+
     this.ipcHandle(
       'image-registry:createRegistry',
       async (

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -779,6 +779,13 @@ function initExposure(): void {
   );
 
   contextBridge.exposeInMainWorld(
+    'checkImageCredentials',
+    async (registryCreateOptions: containerDesktopAPI.RegistryCreateOptions): Promise<void> => {
+      return ipcInvoke('image-registry:checkCredentials', registryCreateOptions);
+    },
+  );
+
+  contextBridge.exposeInMainWorld(
     'updateImageRegistry',
     async (registry: containerDesktopAPI.Registry): Promise<void> => {
       return ipcInvoke('image-registry:updateRegistry', registry);

--- a/packages/renderer/src/lib/preferences/PreferencesRegistriesEditing.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRegistriesEditing.svelte
@@ -196,7 +196,7 @@ async function loginToRegistry(registry: containerDesktopAPI.Registry) {
         buttons: ['Yes', 'No'],
       });
       if (result && result.response === 0) {
-        registry.ignoreInvalidCert = true;
+        registry.insecure = true;
       } else {
         setErrorResponse(registry.serverUrl, error.message);
         loggingIn = false;


### PR DESCRIPTION
draft: add ability to add insecure registry / skipping cert verify

### What does this PR do?

Adds the ability to prompt the user that the certificate is unverifiable
but they can add it / skip the verification process if they wish.

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

https://github.com/containers/podman-desktop/assets/6422176/ec1de47b-e478-40e7-8a3f-052519c95fc3



### What issues does this PR fix or reference?

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

### How to test this PR?

<!-- Please explain steps to reproduce -->

You must have a registry setup that has a self-signed certificate.

If you wish to test this out against an already setup one, use https://registry.k8s.land

1. Add the registry `registry.k8s.land`
2. Login with `foo` as username, `bar` as password.
2. Podman Desktop should prompt that it is unverifiable / cert does not
   work
3. PD should successfully add the registry
