### PR TITLE
feat: Auto-population of container image name

### DIFF
--- a/packages/renderer/src/lib/image/BuildImageFromContainerfile.svelte
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfile.svelte
@@ -113,6 +113,13 @@ async function getContainerfileLocation() {
   if (!result.canceled && result.filePaths.length === 1) {
     containerFilePath = result.filePaths[0];
     hasInvalidFields = false;
+
+    // Extract the name of the folder containing the Containerfile
+    const folderName = containerFilePath.split('/').slice(-2, -1)[0];
+
+    // Set containerImageName to folderName
+    containerImageName = folderName;
+
     if (!containerBuildContextDirectory) {
       // select the parent directory of the file as default
       containerBuildContextDirectory = containerFilePath.replace(/\\/g, '/').replace(/\/[^\/]*$/, '');


### PR DESCRIPTION
### What does this PR do?

Allows for setting the default image name to the folder name that contains the Containerfile

### Screenshot/screencast of this PR

![Kapture 2023-06-16 at 17 31 18](https://github.com/containers/podman-desktop/assets/54345140/6b8307a5-47d8-4a1f-bfb4-dfc3326632b6)

### What issues does this PR fix or reference?

#2713

### How to test this PR?

1. From Images menu, click **Build an image**
2. **Select** the Dockerfile/Containerfile from a directory
3. The image name will auto-populate based on the directory name instead of `my-custom-name
