### PR TITLE
feat: Allow creating lima instances

### DIFF
--- a/extensions/lima/package.json
+++ b/extensions/lima/package.json
@@ -33,6 +33,71 @@
           "type": "string",
           "default": "",
           "description": "Instance name (default is same name as type)"
+        },
+        "lima.machine.cpus": {
+          "type": "number",
+          "format": "cpu",
+          "minimum": 1,
+          "default": 4,
+          "scope": "ContainerConnection",
+          "description": "CPU(s)"
+        },
+        "lima.machine.memory": {
+          "type": "number",
+          "format": "memory",
+          "minimum": 1073741824,
+          "default": 4294967296,
+          "scope": "ContainerConnection",
+          "description": "Memory"
+        },
+        "lima.machine.diskSize": {
+          "type": "number",
+          "format": "diskSize",
+          "default": 107374182400,
+          "scope": "ContainerConnection",
+          "description": "Disk"
+        },
+        "lima.factory.instance.name": {
+          "type": "string",
+          "default": "podman",
+          "scope": "ContainerProviderConnectionFactory",
+          "description": "Name"
+        },
+        "lima.factory.instance.cpus": {
+          "type": "number",
+          "format": "cpu",
+          "minimum": 1,
+          "default": 4,
+          "maximum": "HOST_TOTAL_CPU",
+          "scope": "ContainerProviderConnectionFactory",
+          "description": "CPU(s)"
+        },
+        "lima.factory.instance.memory": {
+          "type": "number",
+          "format": "memory",
+          "minimum": 1073741824,
+          "default": 4294967296,
+          "maximum": "HOST_TOTAL_MEMORY",
+          "scope": "ContainerProviderConnectionFactory",
+          "description": "Memory"
+        },
+        "lima.factory.instance.diskSize": {
+          "type": "number",
+          "format": "diskSize",
+          "default": 107374182400,
+          "scope": "ContainerProviderConnectionFactory",
+          "description": "Disk"
+        },
+        "lima.factory.instance.template": {
+          "type": "string",
+          "default": "template://podman",
+          "scope": "ContainerProviderConnectionFactory",
+          "description": "Template"
+        },
+        "lima.factory.instance.rootful": {
+          "type": "boolean",
+          "scope": "ContainerProviderConnectionFactory",
+          "description": "Machine with root privileges"
         }
       }
     }

--- a/extensions/lima/src/limactl.ts
+++ b/extensions/lima/src/limactl.ts
@@ -1,0 +1,110 @@
+/**********************************************************************
+ * Copyright (C) 2022 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import { spawn } from 'node:child_process';
+import { isMac, isWindows } from './util';
+import type { CancellationToken, Logger } from '@podman-desktop/api';
+
+const macosExtraPath = '/usr/local/bin:/opt/homebrew/bin:/opt/local/bin:/opt/podman/bin';
+
+export function getInstallationPath(): string {
+  const env = process.env;
+  if (isMac()) {
+    if (!env.PATH) {
+      return macosExtraPath;
+    } else {
+      return env.PATH.concat(':').concat(macosExtraPath);
+    }
+  } else {
+    return env.PATH;
+  }
+}
+
+export function getLimactl(): string {
+  if (isWindows()) {
+    return 'limactl.exe';
+  }
+  return 'limactl';
+}
+
+export interface ExecOptions {
+  logger?: Logger;
+  env?: NodeJS.ProcessEnv;
+}
+
+export function execPromise(
+  command: string,
+  args?: string[],
+  options?: ExecOptions,
+  token?: CancellationToken,
+): Promise<string> {
+  let env = Object.assign({}, process.env); // clone original env object
+
+  // In production mode, applications don't have access to the 'user' path like brew
+  if (isMac() || isWindows()) {
+    env.PATH = getInstallationPath();
+  } else if (env.FLATPAK_ID) {
+    // need to execute the command on the host
+    args = ['--host', command, ...args];
+    command = 'flatpak-spawn';
+  }
+
+  if (options?.env) {
+    env = Object.assign(env, options.env);
+  }
+  return new Promise((resolve, reject) => {
+    let stdOut = '';
+    let stdErr = '';
+    const process = spawn(command, args, { env });
+    // if the token is cancelled, kill the process and reject the promise
+    token?.onCancellationRequested(() => {
+      process.kill();
+      // reject the promise
+      options?.logger?.error('Execution cancelled');
+      reject(new Error('Execution cancelled'));
+    });
+    process.on('error', error => {
+      let content = '';
+      if (stdOut && stdOut !== '') {
+        content += stdOut + '\n';
+      }
+      if (stdErr && stdErr !== '') {
+        content += stdErr + '\n';
+      }
+      options?.logger?.error(content);
+      reject(new Error(content + error));
+    });
+    process.stdout.setEncoding('utf8');
+    process.stdout.on('data', data => {
+      stdOut += data;
+      options?.logger?.log(data);
+    });
+    process.stderr.setEncoding('utf8');
+    process.stderr.on('data', data => {
+      stdErr += data;
+      options?.logger?.warn(data);
+    });
+
+    process.on('close', exitCode => {
+      if (exitCode !== 0) {
+        options?.logger?.error(stdErr);
+        reject(new Error(stdErr));
+      }
+      resolve(stdOut.trim());
+    });
+  });
+}

--- a/extensions/lima/src/util.ts
+++ b/extensions/lima/src/util.ts
@@ -1,0 +1,95 @@
+/**********************************************************************
+ * Copyright (C) 2022 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import * as os from 'node:os';
+import { spawn } from 'node:child_process';
+import { getInstallationPath } from './limactl';
+
+const windows = os.platform() === 'win32';
+export function isWindows(): boolean {
+  return windows;
+}
+const mac = os.platform() === 'darwin';
+export function isMac(): boolean {
+  return mac;
+}
+const linux = os.platform() === 'linux';
+export function isLinux(): boolean {
+  return linux;
+}
+
+/**
+ * @returns true if app running in dev mode
+ */
+export function isDev(): boolean {
+  const isEnvSet = 'ELECTRON_IS_DEV' in process.env;
+  const envSet = Number.parseInt(process.env.ELECTRON_IS_DEV, 10) === 1;
+  return isEnvSet ? envSet : false;
+}
+
+export interface SpawnResult {
+  exitCode: number;
+  stdOut: string;
+  stdErr: string;
+}
+
+export interface RunOptions {
+  env?: NodeJS.ProcessEnv;
+}
+
+export function runCliCommand(command: string, args: string[], options?: RunOptions): Promise<SpawnResult> {
+  return new Promise((resolve, reject) => {
+    let output = '';
+    let err = '';
+    let env = Object.assign({}, process.env); // clone original env object
+
+    // In production mode, applications don't have access to the 'user' path like brew
+    if (isMac() || isWindows()) {
+      env.PATH = getInstallationPath();
+      if (isWindows()) {
+        // Escape any whitespaces in command
+        command = `"${command}"`;
+      }
+    } else if (env.FLATPAK_ID) {
+      // need to execute the command on the host
+      args = ['--host', command, ...args];
+      command = 'flatpak-spawn';
+    }
+
+    if (options?.env) {
+      env = Object.assign(env, options.env);
+    }
+
+    const spawnProcess = spawn(command, args, { shell: isWindows(), env });
+    spawnProcess.on('error', err => {
+      reject(err);
+    });
+    spawnProcess.stdout.setEncoding('utf8');
+    spawnProcess.stdout.on('data', data => {
+      output += data;
+    });
+    spawnProcess.stderr.setEncoding('utf8');
+    spawnProcess.stderr.on('data', data => {
+      err += data;
+    });
+
+    spawnProcess.on('close', exitCode => {
+      resolve({ exitCode, stdOut: output, stdErr: err });
+    });
+  });
+}


### PR DESCRIPTION
### What does this PR do?

Allow to create a new lima instance from the GUI, instead of having to do it through the CLI.

### Screenshot/screencast of this PR

<img alt="podman-desktop-lima-create" src="https://github.com/containers/podman-desktop/assets/10364051/afb8c9cc-b3c8-4491-a56c-eb4808edaa1b" width="405" height="455">

### What issues does this PR fix or reference?

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

### How to test this PR?

`brew install lima`

Setting the provider type might be something of a problem, it is not yet implemented here.

There is probably a lot more code needed, if wanting to monitor the existing lima instances.