### PR TITLE
feat: allow showing binary filesize

### DIFF
--- a/extensions/podman/package.json
+++ b/extensions/podman/package.json
@@ -37,6 +37,7 @@
         "podman.machine.memory": {
           "type": "number",
           "format": "memory",
+          "binary": false,
           "minimum": 1000000000,
           "default": 4000000000,
           "scope": "ContainerConnection",
@@ -45,6 +46,7 @@
         "podman.machine.diskSize": {
           "type": "number",
           "format": "diskSize",
+          "binary": false,
           "default": 100000000000,
           "scope": "ContainerConnection",
           "description": "Disk size"
@@ -67,6 +69,7 @@
         "podman.factory.machine.memory": {
           "type": "number",
           "format": "memory",
+          "binary": false,
           "minimum": 1000000000,
           "default": 4000000000,
           "maximum": "HOST_TOTAL_MEMORY",
@@ -76,6 +79,7 @@
         "podman.factory.machine.diskSize": {
           "type": "number",
           "format": "diskSize",
+          "binary": false,
           "default": 100000000000,
           "minimum": 10000000000,
           "maximum": "HOST_TOTAL_DISKSIZE",

--- a/packages/main/src/plugin/configuration-registry.ts
+++ b/packages/main/src/plugin/configuration-registry.ts
@@ -58,6 +58,7 @@ export interface IConfigurationPropertySchema {
   minimum?: number;
   maximum?: number | string;
   format?: string;
+  binary?: boolean;
   scope?: ConfigurationScope;
   readonly?: boolean;
   hidden?: boolean;

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationRendering.svelte
@@ -171,7 +171,10 @@ function setConfigurationValue(id: string, value: string) {
 
 function getDisplayConfigurationValue(configurationKey: IConfigurationPropertyRecordedSchema, value?: any) {
   if (configurationKey.format === 'memory' || configurationKey.format === 'diskSize') {
-    return value ? filesize(value) : filesize(getNormalizedDefaultNumberValue(configurationKey));
+    const base = configurationKey.binary ? 2 : 10;
+    return value
+      ? filesize(value, { base: base })
+      : filesize(getNormalizedDefaultNumberValue(configurationKey), { base: base });
   } else if (configurationKey.format === 'cpu') {
     return value ? value : getNormalizedDefaultNumberValue(configurationKey);
   } else {


### PR DESCRIPTION
### What does this PR do?

The podman machine provider wants to use decimal sizes (KB, 1000) but the lima instance provider prefers binary sizes (KiB, 1024).

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

```console
$ podman machine ls
NAME                    VM TYPE     CREATED      LAST UP     CPUS        MEMORY      DISK SIZE
podman-machine-default  qemu        10 days ago  7 days ago  1           2.147GB     10.74GB
$ limactl ls podman
NAME      STATUS     SSH            VMTYPE    ARCH      CPUS    MEMORY    DISK      DIR
podman    Stopped    127.0.0.1:0    qemu      x86_64    4       4GiB      100GiB    ~/.lima/podman
```

### What issues does this PR fix or reference?

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

### How to test this PR?

<!-- Please explain steps to reproduce -->
