### PR TITLE
chore: update contributing guide to node 18

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,7 @@ You can develop on either: `Windows`, `macOS` or `Linux`.
 
 Requirements:
 
-- [Node.js 16+](https://nodejs.org/en/)
+- [Node.js 18+](https://nodejs.org/en/)
 - [yarn](https://yarnpkg.com/)
 
 Optional Linux requirements:


### PR DESCRIPTION
### What does this PR do?

We now require node 18+ and yarn install fails on 16.

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

N/A

### How to test this PR?

N/A