### PR TITLE
fix: images list too wide

### DIFF
--- a/packages/renderer/src/lib/ImagesList.svelte
+++ b/packages/renderer/src/lib/ImagesList.svelte
@@ -271,7 +271,7 @@ function computeInterval(): number {
   </div>
 
   <div class="flex min-w-full h-full overflow-auto" slot="content">
-    <table class="mx-5 min-w-full h-fit" class:hidden="{images.length === 0}">
+    <table class="mx-5 w-full h-fit" class:hidden="{images.length === 0}">
       <!-- title -->
       <thead class="sticky top-0 bg-charcoal-700 z-[2]">
         <tr class="h-7 uppercase text-xs text-gray-600">


### PR DESCRIPTION
### What does this PR do?

The Images list is too wide by default and causes unnecessary scroll bars. This fix makes it consistent with the other lists.

### Screenshot/screencast of this PR

Before:
<img width="767" alt="Screenshot 2023-06-19 at 8 48 31 AM" src="https://github.com/containers/podman-desktop/assets/19958075/204d4f09-d44f-444c-a244-a040b6a3e906">

After:
<img width="767" alt="Screenshot 2023-06-19 at 8 48 04 AM" src="https://github.com/containers/podman-desktop/assets/19958075/077c6b9b-c221-4009-a925-92d69590b976">

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Just open Images list and try different window widths.