### PR TITLE
fix: show current context in quick pick

### DIFF
--- a/extensions/kube-context/src/extension.ts
+++ b/extensions/kube-context/src/extension.ts
@@ -110,7 +110,8 @@ export async function updateContext(
 
   quickPicks = contexts.map(context => {
     return {
-      label: context.name === currentContext ? context.name + ' (current)' : context.name,
+      label: context.name,
+      description: context.name === currentContext ? 'Current Context' : undefined,
       picked: context.name === currentContext,
     };
   });

--- a/extensions/kube-context/src/extension.ts
+++ b/extensions/kube-context/src/extension.ts
@@ -110,7 +110,7 @@ export async function updateContext(
 
   quickPicks = contexts.map(context => {
     return {
-      label: context.name,
+      label: context.name === currentContext ? context.name + ' (current)' : context.name,
       picked: context.name === currentContext,
     };
   });


### PR DESCRIPTION
### What does this PR do?

Even when the quick pick is fixed to show which items are pre-selected (issue #2754 item 2) it is not really clear to the user why one row is highlighted. This adds the text " (current)" to the current Kube context to make this obvious.

### Screenshot/screencast of this PR
<img width="448" alt="Screenshot 2023-06-19 at 9 01 59 AM" src="https://github.com/containers/podman-desktop/assets/19958075/a0a653d0-4891-4632-8aff-15f303929d7b">

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Click on the context status bar to see the quick pick.