### PR TITLE
fix: compose deactivate function never called

### DIFF
--- a/extensions/compose/src/extension.ts
+++ b/extensions/compose/src/extension.ts
@@ -41,7 +41,7 @@ async function postActivate(extensionContext: extensionApi.ExtensionContext): Pr
   const os = new OS();
   const cliRun = new CliRun(extensionContext, os);
   const podmanComposeGenerator = new ComposeWrapperGenerator(os, path.resolve(extensionContext.storagePath, 'bin'));
-  const composeExtension = new ComposeExtension(
+  composeExtension = new ComposeExtension(
     extensionContext,
     new Detect(cliRun, os, extensionContext.storagePath),
     new ComposeGitHubReleases(octokit),


### PR DESCRIPTION
### What does this PR do?
Makes sure that compose deactivate is called.

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?
#2921 
<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

### How to test this PR?
`yarn install`
`yarn compile`
start locally built podman desktop
watch the log in the output on the app. quit
expect to see a `stopping compose extension` message
<!-- Please explain steps to reproduce -->
