### PR TITLE
fix: only show empty screen when no pods

### DIFF
--- a/packages/renderer/src/lib/pod/PodsList.svelte
+++ b/packages/renderer/src/lib/pod/PodsList.svelte
@@ -316,7 +316,7 @@ function errorCallback(pod: PodInfoUI, errorMessage: string): void {
       </tbody>
     </table>
 
-    {#if providerConnections.length === 0}
+    {#if $filtered.length === 0 && providerConnections.length === 0}
       <NoContainerEngineEmptyScreen />
     {:else if $filtered.length === 0}
       <PodEmptyScreen />


### PR DESCRIPTION
### What does this PR do?

See issue #2923 for the problem.

The 'no container engine' empty screen is a little off here since Kubernetes pods can be detected, or you could install a Kubernetes provider instead of a container engine to fix it. Doubly so since pods can be picked up via the Kube context even if there are no Kubernetes providers installed.

I tried to come up with something more clever, but checking for other providers or changing the text of the screen seems much more complicated and I still couldn't find a path that would cover every case or be a significant improvement. The simplest solution seems to be just not showing the screen if we've found any pods.

### Screenshot/screencast of this PR

N/A, normal pod list.

### What issues does this PR fix or reference?

Fixes #2923.

### How to test this PR?

See issue #2923 and try various combinations of no pods vs pods in Podman vs Kubernetes pods.