### PR TITLE
chore: increase memory for eslint and use cache for prettier and eslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,12 +57,13 @@
     "test:tools": "vitest run tools --passWithNoTests --coverage",
     "test:watch": "vitest watch",
     "watch": "node scripts/watch.cjs",
-    "format:check": "prettier --check \"{extensions,packages,tests,types}/**/*.{ts,svelte}\" \"extensions/*/scripts/build.js\" \"website/**/*.{md,js}\" \"website/src/**/*.{css,tsx}\"",
-    "format:fix": "prettier --write \"{extensions,packages,tests,types,tools}/**/*.{ts,svelte}\" \"extensions/*/scripts/build.js\" \"website/**/*.{md,js}\" \"website/src/**/*.{css,tsx}\"",
+    "format:check": "prettier --cache --check \"{extensions,packages,tests,types}/**/*.{ts,svelte}\" \"extensions/*/scripts/build.js\" \"website/**/*.{md,js}\" \"website/src/**/*.{css,tsx}\"",
+    "format:fix": "prettier --cache --write \"{extensions,packages,tests,types,tools}/**/*.{ts,svelte}\" \"extensions/*/scripts/build.js\" \"website/**/*.{md,js}\" \"website/src/**/*.{css,tsx}\"",
     "markdownlint:check": "markdownlint-cli2 \"website/**/*.md\" \"#website/node_modules\"",
     "markdownlint:fix": "markdownlint-cli2-fix \"website/**/*.md\" \"#website/node_modules\"",
-    "lint:check": "eslint . --ext js,ts,tsx,svelte",
-    "lint:fix": "eslint . --fix --ext js,ts,tsx,svelte",
+    "lint:clean": "rimraf .eslintcache",
+    "lint:check": "node --max-old-space-size=4096 node_modules/eslint/bin/eslint.js --cache . --ext js,ts,tsx,svelte",
+    "lint:fix": "node --max-old-space-size=4096 node_modules/eslint/bin/eslint.js --cache . --fix --ext js,ts,tsx,svelte",
     "svelte:check": "svelte-check",
     "typecheck:main": "tsc --noEmit -p packages/main/tsconfig.json",
     "typecheck:preload": "tsc --noEmit -p packages/preload/tsconfig.json",
@@ -75,8 +76,8 @@
   },
   "lint-staged": {
     "*.{js,ts,tsx,svelte}": [
-      "eslint --cache --fix",
-      "prettier --write"
+      "node --max-old-space-size=4096 node_modules/eslint/bin/eslint.js --cache --fix",
+      "prettier --cache --write"
     ],
     "*.{md,css,json}": "prettier --write"
   },


### PR DESCRIPTION
### What does this PR do?
linter may use more memory than the default, so specify more memory
use `--cache` option on linter and prettier (I'm using the --cache option since a week and it works fine)

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?

reported on discord channel by @afbjorklund 

### How to test this PR?

PR check should be green

Signed-off-by: Florent Benoit <fbenoit@redhat.com>
