### PR TITLE
nit: fix autostart not working

### DIFF
--- a/packages/renderer/src/lib/dashboard/DashboardPage.svelte
+++ b/packages/renderer/src/lib/dashboard/DashboardPage.svelte
@@ -8,7 +8,7 @@ import ProviderStopped from './ProviderStopped.svelte';
 import ProviderStarting from './ProviderStarting.svelte';
 import NavPage from '../ui/NavPage.svelte';
 import type { InitializationContext } from './ProviderInitUtils';
-import { InitializeAndStartMode } from './ProviderInitUtils';
+import { DoNothingMode } from './ProviderInitUtils';
 import FeaturedExtensions from '/@/lib/featured/FeaturedExtensions.svelte';
 import ProviderConfiguring from '/@/lib/dashboard/ProviderConfiguring.svelte';
 
@@ -28,7 +28,7 @@ function getInitializationContext(id: string) {
   if (providerInitContexts.has(id)) {
     context = providerInitContexts.get(id);
   } else {
-    context = { mode: InitializeAndStartMode };
+    context = { mode: DoNothingMode };
     providerInitContexts.set(id, context);
   }
   return context;

--- a/packages/renderer/src/lib/dashboard/ProviderConfigured.spec.ts
+++ b/packages/renderer/src/lib/dashboard/ProviderConfigured.spec.ts
@@ -23,9 +23,15 @@ import { beforeAll, test, vi } from 'vitest';
 import { verifyStatus } from './ProviderStatusTestHelper.spec';
 import ProviderConfigured from '/@/lib/dashboard/ProviderConfigured.svelte';
 
-// fake the window.events object
 beforeAll(() => {
   (window as any).startProvider = vi.fn();
+
+  // mock that autostart is configured as true
+  (window.getConfigurationValue as unknown) = (_key: string) => {
+    return true;
+  };
+
+  // fake the window.events object
   (window.events as unknown) = {
     receive: (_channel: string, func: any) => {
       func();

--- a/packages/renderer/src/lib/dashboard/ProviderConfigured.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderConfigured.svelte
@@ -39,7 +39,11 @@ async function runProvider() {
   runInProgress = false;
 }
 
-onMount(() => {
+onMount(async () => {
+  // Get the autostart configuration setting. If it's disabled, we do *not* want to start the current container provider.
+  const autostart = await window.getConfigurationValue<boolean>('preferences.engine.autostart');
+  runAtStart = autostart && initializationContext.mode === InitializeAndStartMode;
+
   if (runAtStart) {
     runProvider();
   }

--- a/packages/renderer/src/lib/dashboard/ProviderConfigured.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderConfigured.svelte
@@ -42,7 +42,7 @@ async function runProvider() {
 onMount(async () => {
   // Get the autostart configuration setting. If it's disabled, we do *not* want to start the current container provider.
   const autostart = await window.getConfigurationValue<boolean>('preferences.engine.autostart');
-  runAtStart = autostart && initializationContext.mode === InitializeAndStartMode;
+  runAtStart = autostart || initializationContext.mode === InitializeAndStartMode;
 
   if (runAtStart) {
     runProvider();

--- a/packages/renderer/src/lib/dashboard/ProviderConfigured.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderConfigured.svelte
@@ -26,7 +26,6 @@ async function runProvider() {
   runAtStart = false;
   try {
     await window.startProvider(provider.internalId);
-    // wait that status is updated
     await new Promise<void>(resolve => {
       window.events.receive('provider-change', () => {
         resolve();
@@ -39,11 +38,7 @@ async function runProvider() {
   runInProgress = false;
 }
 
-onMount(async () => {
-  // Get the autostart configuration setting. If it's disabled, we do *not* want to start the current container provider.
-  const autostart = await window.getConfigurationValue<boolean>('preferences.engine.autostart');
-  runAtStart = autostart || initializationContext.mode === InitializeAndStartMode;
-
+onMount(() => {
   if (runAtStart) {
     runProvider();
   }

--- a/packages/renderer/src/lib/dashboard/ProviderInitUtils.ts
+++ b/packages/renderer/src/lib/dashboard/ProviderInitUtils.ts
@@ -19,10 +19,11 @@ import { faPlay, faWrench } from '@fortawesome/free-solid-svg-icons';
 import Fa from 'svelte-fa/src/fa.svelte';
 import type { ProviderDetectionCheck } from '@podman-desktop/api';
 
+export const DoNothingMode = 'Do nothing';
 export const InitializeOnlyMode = 'Initialize';
 export const InitializeAndStartMode = 'Initialize and start';
 
-export type InitializationMode = typeof InitializeOnlyMode | typeof InitializeAndStartMode;
+export type InitializationMode = typeof DoNothingMode | typeof InitializeOnlyMode | typeof InitializeAndStartMode;
 
 export interface InitializationContext {
   mode: InitializationMode;


### PR DESCRIPTION
nit: fix autostart not working

### What does this PR do?

Fixes autostart not working correctly.

This bug occurs during onMount when ProviderConfigured.svelte is loaded
and does runProvider without checking the autostart configuration.

Very small change / nit.

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


https://github.com/containers/podman-desktop/assets/6422176/19f9de01-0fc7-4787-95c7-188501030933



### What issues does this PR fix or reference?

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

Fixes https://github.com/containers/podman-desktop/issues/2781

### How to test this PR?

1. Disable autostart
2. Stop podman machine
3. Exit PD
4. Start PD, it should still stay stopped.

<!-- Please explain steps to reproduce -->

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
