### PR TITLE
fix: Kind clusters not cleaned up when stopping podman machine

### DIFF
--- a/extensions/podman/src/extension.spec.ts
+++ b/extensions/podman/src/extension.spec.ts
@@ -433,11 +433,7 @@ test('if a machine is successfully reporting telemetry', async () => {
     expect.objectContaining({ hostCpus: expect.anything() }),
   );
 
-  expect(spyExecPromise).toBeCalledWith(
-    expect.stringContaining('podman'),
-    ['machine', 'start', 'name'],
-    expect.anything(),
-  );
+  expect(spyExecPromise).toBeCalledWith(getPodmanCli(), ['machine', 'start', 'name'], expect.anything());
 });
 
 test('if a machine is successfully reporting an error in telemetry', async () => {
@@ -458,11 +454,7 @@ test('if a machine is successfully reporting an error in telemetry', async () =>
     expect.objectContaining({ hostCpus: expect.anything(), error: customError }),
   );
 
-  expect(spyExecPromise).toBeCalledWith(
-    expect.stringContaining('podman'),
-    ['machine', 'start', 'name'],
-    expect.anything(),
-  );
+  expect(spyExecPromise).toBeCalledWith(getPodmanCli(), ['machine', 'start', 'name'], expect.anything());
 });
 
 test('if a machine failed to start with a generic error, this is thrown', async () => {

--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -557,7 +557,7 @@ async function registerProviderFor(provider: extensionApi.Provider, machineInfo:
       await extensionApi.process.exec(getPodmanCli(), ['machine', 'stop', machineInfo.name], {
         logger: new LoggerDelegator(context, logger),
       });
-      provider.updateStatus('ready');
+      provider.updateStatus('stopped');
     },
     delete: async (logger): Promise<void> => {
       await extensionApi.process.exec(getPodmanCli(), ['machine', 'rm', '-f', machineInfo.name], { logger });

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -248,13 +248,7 @@ export class ContainerProviderRegistry {
           this.apiSender.send('provider-change', {});
         }
         if (newStatus === 'started') {
-          internalProvider.api = new Dockerode({ socketPath: containerProviderConnection.endpoint.socketPath });
-          if (containerProviderConnection.type === 'podman') {
-            internalProvider.libpodApi = internalProvider.api as unknown as LibPod;
-          }
-          this.handleEvents(internalProvider.api);
-          this.internalProviders.set(id, internalProvider);
-          this.apiSender.send('provider-change', {});
+          this.setupConnectionAPI(internalProvider, containerProviderConnection);
         }
       }
       previousStatus = event.status;

--- a/packages/main/src/plugin/provider-impl.ts
+++ b/packages/main/src/plugin/provider-impl.ts
@@ -230,7 +230,11 @@ export class ProviderImpl implements Provider, IDisposable {
 
   registerContainerProviderConnection(containerProviderConnection: ContainerProviderConnection): Disposable {
     this.containerProviderConnections.add(containerProviderConnection);
-    const disposable = this.containerRegistry.registerContainerConnection(this, containerProviderConnection);
+    const disposable = this.containerRegistry.registerContainerConnection(
+      this,
+      containerProviderConnection,
+      this.providerRegistry,
+    );
     this.providerRegistry.onDidRegisterContainerConnectionCallback(this, containerProviderConnection);
 
     return Disposable.create(() => {

--- a/packages/main/src/plugin/provider-registry.spec.ts
+++ b/packages/main/src/plugin/provider-registry.spec.ts
@@ -302,6 +302,13 @@ test('should send events when starting a container connection', async () => {
     },
   });
 
+  let onBeforeDidUpdateContainerConnectionCalled = false;
+  providerRegistry.onBeforeDidUpdateContainerConnection(event => {
+    expect(event.connection.name).toBe(connection.name);
+    expect(event.connection.type).toBe(connection.type);
+    expect(event.status).toBe('started');
+    onBeforeDidUpdateContainerConnectionCalled = true;
+  });
   let onDidUpdateContainerConnectionCalled = false;
   providerRegistry.onDidUpdateContainerConnection(event => {
     expect(event.connection.name).toBe(connection.name);
@@ -309,12 +316,21 @@ test('should send events when starting a container connection', async () => {
     expect(event.status).toBe('started');
     onDidUpdateContainerConnectionCalled = true;
   });
+  let onAfterDidUpdateContainerConnectionCalled = false;
+  providerRegistry.onAfterDidUpdateContainerConnection(event => {
+    expect(event.connection.name).toBe(connection.name);
+    expect(event.connection.type).toBe(connection.type);
+    expect(event.status).toBe('started');
+    onAfterDidUpdateContainerConnectionCalled = true;
+  });
 
   await providerRegistry.startProviderConnection('0', connection);
 
   expect(startMock).toBeCalled();
   expect(stopMock).not.toBeCalled();
+  expect(onBeforeDidUpdateContainerConnectionCalled).toBeTruthy();
   expect(onDidUpdateContainerConnectionCalled).toBeTruthy();
+  expect(onAfterDidUpdateContainerConnectionCalled).toBeTruthy();
 });
 
 test('should send events when stopping a container connection', async () => {
@@ -349,6 +365,13 @@ test('should send events when stopping a container connection', async () => {
     },
   });
 
+  let onBeforeDidUpdateContainerConnectionCalled = false;
+  providerRegistry.onBeforeDidUpdateContainerConnection(event => {
+    expect(event.connection.name).toBe(connection.name);
+    expect(event.connection.type).toBe(connection.type);
+    expect(event.status).toBe('stopped');
+    onBeforeDidUpdateContainerConnectionCalled = true;
+  });
   let onDidUpdateContainerConnectionCalled = false;
   providerRegistry.onDidUpdateContainerConnection(event => {
     expect(event.connection.name).toBe(connection.name);
@@ -356,12 +379,21 @@ test('should send events when stopping a container connection', async () => {
     expect(event.status).toBe('stopped');
     onDidUpdateContainerConnectionCalled = true;
   });
+  let onAfterDidUpdateContainerConnectionCalled = false;
+  providerRegistry.onAfterDidUpdateContainerConnection(event => {
+    expect(event.connection.name).toBe(connection.name);
+    expect(event.connection.type).toBe(connection.type);
+    expect(event.status).toBe('stopped');
+    onAfterDidUpdateContainerConnectionCalled = true;
+  });
 
   await providerRegistry.stopProviderConnection('0', connection);
 
   expect(stopMock).toBeCalled();
   expect(startMock).not.toBeCalled();
+  expect(onBeforeDidUpdateContainerConnectionCalled).toBeTruthy();
   expect(onDidUpdateContainerConnectionCalled).toBeTruthy();
+  expect(onAfterDidUpdateContainerConnectionCalled).toBeTruthy();
 });
 
 test('runAutostartContainer should start container and send event', async () => {

--- a/packages/main/src/plugin/provider-registry.ts
+++ b/packages/main/src/plugin/provider-registry.ts
@@ -101,9 +101,15 @@ export class ProviderRegistry {
   private readonly _onDidUpdateProvider = new Emitter<ProviderEvent>();
   readonly onDidUpdateProvider: Event<ProviderEvent> = this._onDidUpdateProvider.event;
 
+  private readonly _onBeforeDidUpdateContainerConnection = new Emitter<UpdateContainerConnectionEvent>();
+  readonly onBeforeDidUpdateContainerConnection: Event<UpdateContainerConnectionEvent> =
+    this._onBeforeDidUpdateContainerConnection.event;
   private readonly _onDidUpdateContainerConnection = new Emitter<UpdateContainerConnectionEvent>();
   readonly onDidUpdateContainerConnection: Event<UpdateContainerConnectionEvent> =
     this._onDidUpdateContainerConnection.event;
+  private readonly _onAfterDidUpdateContainerConnection = new Emitter<UpdateContainerConnectionEvent>();
+  readonly onAfterDidUpdateContainerConnection: Event<UpdateContainerConnectionEvent> =
+    this._onAfterDidUpdateContainerConnection.event;
 
   private readonly _onDidUpdateKubernetesConnection = new Emitter<UpdateKubernetesConnectionEvent>();
   readonly onDidUpdateKubernetesConnection: Event<UpdateKubernetesConnectionEvent> =
@@ -861,7 +867,7 @@ export class ProviderRegistry {
       await lifecycle.start(context, logHandler);
     } finally {
       if (this.isProviderContainerConnection(providerConnectionInfo)) {
-        this._onDidUpdateContainerConnection.fire({
+        const event = {
           providerId: internalProviderId,
           connection: {
             name: providerConnectionInfo.name,
@@ -872,7 +878,10 @@ export class ProviderRegistry {
             },
           },
           status: providerConnectionInfo.status,
-        });
+        };
+        this._onBeforeDidUpdateContainerConnection.fire(event);
+        this._onDidUpdateContainerConnection.fire(event);
+        this._onAfterDidUpdateContainerConnection.fire(event);
       } else {
         this._onDidUpdateKubernetesConnection.fire({
           providerId: internalProviderId,
@@ -911,7 +920,7 @@ export class ProviderRegistry {
       await lifecycle.stop(context, logHandler);
     } finally {
       if (this.isProviderContainerConnection(providerConnectionInfo)) {
-        this._onDidUpdateContainerConnection.fire({
+        const event = {
           providerId: internalProviderId,
           connection: {
             name: providerConnectionInfo.name,
@@ -922,7 +931,10 @@ export class ProviderRegistry {
             },
           },
           status: providerConnectionInfo.status,
-        });
+        };
+        this._onBeforeDidUpdateContainerConnection.fire(event);
+        this._onDidUpdateContainerConnection.fire(event);
+        this._onAfterDidUpdateContainerConnection.fire(event);
       } else {
         this._onDidUpdateKubernetesConnection.fire({
           providerId: internalProviderId,

--- a/packages/main/src/plugin/provider-registry.ts
+++ b/packages/main/src/plugin/provider-registry.ts
@@ -927,8 +927,6 @@ export class ProviderRegistry {
     }
 
     try {
-      await lifecycle.stop(context, logHandler);
-    } finally {
       if (this.isProviderContainerConnection(providerConnectionInfo)) {
         const event = {
           providerId: provider.id,
@@ -958,6 +956,9 @@ export class ProviderRegistry {
           status: 'stopped',
         });
       }
+      await lifecycle.stop(context, logHandler);
+    } catch (err) {
+      console.warn(`Can't stop connection ${provider.id}.${providerConnectionInfo.name}`, err);
     }
   }
 

--- a/packages/main/src/plugin/provider-registry.ts
+++ b/packages/main/src/plugin/provider-registry.ts
@@ -863,36 +863,41 @@ export class ProviderRegistry {
       throw new Error('The connection does not have context to start');
     }
 
+    const provider = this.providers.get(internalProviderId);
+    if (!provider) {
+      throw new Error('Cannot find provider');
+    }
+
     try {
       await lifecycle.start(context, logHandler);
     } finally {
       if (this.isProviderContainerConnection(providerConnectionInfo)) {
         const event = {
-          providerId: internalProviderId,
+          providerId: provider.id,
           connection: {
             name: providerConnectionInfo.name,
             type: providerConnectionInfo.type,
             endpoint: providerConnectionInfo.endpoint,
             status: (): ProviderConnectionStatus => {
-              return providerConnectionInfo.status;
+              return 'started';
             },
           },
-          status: providerConnectionInfo.status,
+          status: 'started' as ProviderConnectionStatus,
         };
         this._onBeforeDidUpdateContainerConnection.fire(event);
         this._onDidUpdateContainerConnection.fire(event);
         this._onAfterDidUpdateContainerConnection.fire(event);
       } else {
         this._onDidUpdateKubernetesConnection.fire({
-          providerId: internalProviderId,
+          providerId: provider.id,
           connection: {
             name: providerConnectionInfo.name,
             endpoint: providerConnectionInfo.endpoint,
             status: (): ProviderConnectionStatus => {
-              return providerConnectionInfo.status;
+              return 'started';
             },
           },
-          status: providerConnectionInfo.status,
+          status: 'started',
         });
       }
     }
@@ -916,36 +921,41 @@ export class ProviderRegistry {
       throw new Error('The connection does not have context to start');
     }
 
+    const provider = this.providers.get(internalProviderId);
+    if (!provider) {
+      throw new Error('Cannot find provider');
+    }
+
     try {
       await lifecycle.stop(context, logHandler);
     } finally {
       if (this.isProviderContainerConnection(providerConnectionInfo)) {
         const event = {
-          providerId: internalProviderId,
+          providerId: provider.id,
           connection: {
             name: providerConnectionInfo.name,
             type: providerConnectionInfo.type,
             endpoint: providerConnectionInfo.endpoint,
             status: (): ProviderConnectionStatus => {
-              return providerConnectionInfo.status;
+              return 'stopped';
             },
           },
-          status: providerConnectionInfo.status,
+          status: 'stopped' as ProviderConnectionStatus,
         };
         this._onBeforeDidUpdateContainerConnection.fire(event);
         this._onDidUpdateContainerConnection.fire(event);
         this._onAfterDidUpdateContainerConnection.fire(event);
       } else {
         this._onDidUpdateKubernetesConnection.fire({
-          providerId: internalProviderId,
+          providerId: provider.id,
           connection: {
             name: providerConnectionInfo.name,
             endpoint: providerConnectionInfo.endpoint,
             status: (): ProviderConnectionStatus => {
-              return providerConnectionInfo.status;
+              return 'stopped';
             },
           },
-          status: providerConnectionInfo.status,
+          status: 'stopped',
         });
       }
     }


### PR DESCRIPTION
Fixes #2143

### What does this PR do?

Reset/initialize container connections

### Screenshot/screencast of this PR

![stop](https://github.com/containers/podman-desktop/assets/695993/38fa57cc-a0f4-4a3a-8251-b0fbcdc1cd7c)

### What issues does this PR fix or reference?

Fixes #2143 

### How to test this PR?

1. Create a kind cluster
2. Stop the podman machine -> Kind cluster should disappear
3. Restart the podman machine -> Kind cluster should reappear


<!-- Please explain steps to reproduce -->
