### PR TITLE
feat(tests): add navigation bar e2e tests

### DIFF
--- a/tests/src/e2e.spec.ts
+++ b/tests/src/e2e.spec.ts
@@ -6,6 +6,7 @@ import { expect as playExpect } from '@playwright/test';
 import { existsSync } from 'node:fs';
 import { rm } from 'node:fs/promises';
 
+const navBarItems = ['Dashboard', 'Containers', 'Images', 'Pods', 'Volumes', 'Settings'];
 let electronApp: ElectronApplication;
 let page: Page;
 
@@ -35,67 +36,79 @@ afterAll(async () => {
 });
 
 describe('Basic e2e verification of podman desktop start', async () => {
-  test('Check the Welcome page is displayed', async () => {
-    // Direct Electron console to Node terminal.
-    page.on('console', console.log);
+  describe('Welcome page handling', async () => {
+    test('Check the Welcome page is displayed', async () => {
+      // Direct Electron console to Node terminal.
+      page.on('console', console.log);
 
-    const window: JSHandle<BrowserWindow> = await electronApp.browserWindow(page);
+      const window: JSHandle<BrowserWindow> = await electronApp.browserWindow(page);
 
-    const windowState = await window.evaluate(
-      (mainWindow): Promise<{ isVisible: boolean; isDevToolsOpened: boolean; isCrashed: boolean }> => {
-        const getState = () => ({
-          isVisible: mainWindow.isVisible(),
-          isDevToolsOpened: mainWindow.webContents.isDevToolsOpened(),
-          isCrashed: mainWindow.webContents.isCrashed(),
-        });
+      const windowState = await window.evaluate(
+        (mainWindow): Promise<{ isVisible: boolean; isDevToolsOpened: boolean; isCrashed: boolean }> => {
+          const getState = () => ({
+            isVisible: mainWindow.isVisible(),
+            isDevToolsOpened: mainWindow.webContents.isDevToolsOpened(),
+            isCrashed: mainWindow.webContents.isCrashed(),
+          });
 
-        return new Promise(resolve => {
-          /**
-           * The main window is created hidden, and is shown only when it is ready.
-           * See {@link ../packages/main/src/mainWindow.ts} function
-           */
-          if (mainWindow.isVisible()) {
-            resolve(getState());
-          } else mainWindow.once('ready-to-show', () => resolve(getState()));
-        });
-      },
-    );
-    expect(windowState.isCrashed, 'The app has crashed').toBeFalsy();
-    expect(windowState.isVisible, 'The main window was not visible').toBeTruthy();
+          return new Promise(resolve => {
+            /**
+             * The main window is created hidden, and is shown only when it is ready.
+             * See {@link ../packages/main/src/mainWindow.ts} function
+             */
+            if (mainWindow.isVisible()) {
+              resolve(getState());
+            } else mainWindow.once('ready-to-show', () => resolve(getState()));
+          });
+        },
+      );
+      expect(windowState.isCrashed, 'The app has crashed').toBeFalsy();
+      expect(windowState.isVisible, 'The main window was not visible').toBeTruthy();
 
-    await page.screenshot({ path: 'tests/output/screenshots/screenshot-welcome-page-init.png', fullPage: true });
+      await page.screenshot({ path: 'tests/output/screenshots/screenshot-welcome-page-init.png', fullPage: true });
 
-    const welcomeMessage = page.locator('text=/Welcome to Podman Desktop.*/');
-    await playExpect(welcomeMessage).toBeVisible();
-  });
-
-  test('Telemetry checkbox is present, set to true, consent can be changed', async () => {
-    // wait for the initial screen to be loaded
-    const telemetryConsent = page.getByText('Telemetry');
-    expect(telemetryConsent).not.undefined;
-    expect(await telemetryConsent.isChecked()).to.be.true;
-
-    await telemetryConsent.click();
-    expect(await telemetryConsent.isChecked()).to.be.false;
-  });
-
-  test('Redirection from Welcome page to Dashboard works', async () => {
-    const goToPodmanDesktopButton = page.locator('button:text("Go to Podman Desktop")');
-    // wait for visibility
-    await goToPodmanDesktopButton.waitFor({ state: 'visible' });
-
-    await page.screenshot({ path: 'tests/output/screenshots/screenshot-welcome-page-display.png', fullPage: true });
-
-    // click on the button
-    await goToPodmanDesktopButton.click();
-
-    await page.screenshot({
-      path: 'tests/output/screenshots/screenshot-welcome-page-redirect-to-dashboard.png',
-      fullPage: true,
+      const welcomeMessage = page.locator('text=/Welcome to Podman Desktop.*/');
+      await playExpect(welcomeMessage).toBeVisible();
     });
 
-    // check we have the dashboard page
-    const dashboardTitle = page.getByRole('heading', { name: 'Dashboard' });
-    await playExpect(dashboardTitle).toBeVisible();
+    test('Telemetry checkbox is present, set to true, consent can be changed', async () => {
+      // wait for the initial screen to be loaded
+      const telemetryConsent = page.getByText('Telemetry');
+      expect(telemetryConsent).not.undefined;
+      expect(await telemetryConsent.isChecked()).to.be.true;
+
+      await telemetryConsent.click();
+      expect(await telemetryConsent.isChecked()).to.be.false;
+    });
+
+    test('Redirection from Welcome page to Dashboard works', async () => {
+      const goToPodmanDesktopButton = page.locator('button:text("Go to Podman Desktop")');
+      // wait for visibility
+      await goToPodmanDesktopButton.waitFor({ state: 'visible' });
+
+      await page.screenshot({ path: 'tests/output/screenshots/screenshot-welcome-page-display.png', fullPage: true });
+
+      // click on the button
+      await goToPodmanDesktopButton.click();
+
+      await page.screenshot({
+        path: 'tests/output/screenshots/screenshot-welcome-page-redirect-to-dashboard.png',
+        fullPage: true,
+      });
+
+      // check we have the dashboard page
+      const dashboardTitle = page.getByRole('heading', { name: 'Dashboard' });
+      await playExpect(dashboardTitle).toBeVisible();
+    });
+  });
+
+  describe('Navigation Bar test', async () => {
+    test('Verify are present in Navigation Bar', async () => {
+      const navBar = page.locator('nav[aria-label="Global"]');
+      for (const item of navBarItems) {
+        const locator = navBar.locator(`a[aria-label="${item}"]`);
+        await playExpect(locator).toBeVisible();
+      }
+    });
   });
 });

--- a/tests/src/e2e.spec.ts
+++ b/tests/src/e2e.spec.ts
@@ -103,10 +103,11 @@ describe('Basic e2e verification of podman desktop start', async () => {
   });
 
   describe('Navigation Bar test', async () => {
-    test('Verify are present in Navigation Bar', async () => {
-      const navBar = page.locator('nav[aria-label="Global"]');
+    test('Verify navigation items are present', async () => {
+      const navBar = page.getByRole('navigation').and(page.getByLabel('Global'));
+      await playExpect(navBar).toBeVisible();
       for (const item of navBarItems) {
-        const locator = navBar.locator(`a[aria-label="${item}"]`);
+        const locator = navBar.getByRole('link').and(navBar.getByLabel(item));
         await playExpect(locator).toBeVisible();
       }
     });

--- a/tests/src/e2e.spec.ts
+++ b/tests/src/e2e.spec.ts
@@ -104,10 +104,10 @@ describe('Basic e2e verification of podman desktop start', async () => {
 
   describe('Navigation Bar test', async () => {
     test('Verify navigation items are present', async () => {
-      const navBar = page.getByRole('navigation').and(page.getByLabel('Global'));
+      const navBar = page.getByRole('navigation', { name: 'AppNavigation' });
       await playExpect(navBar).toBeVisible();
       for (const item of navBarItems) {
-        const locator = navBar.getByRole('link').and(navBar.getByLabel(item));
+        const locator = navBar.getByRole('link', { name: item, exact: true });
         await playExpect(locator).toBeVisible();
       }
     });


### PR DESCRIPTION
### What does this PR do?
Adds new e2e tests - navigation bar tests.
Next steps are to divide tests into separate files and make sure that we can have various suites - smoke/full.
### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
### What issues does this PR fix or reference?
https://github.com/containers/podman-desktop/issues/2972
<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

### How to test this PR?
remove `settings.json` or `telemetry.*` and `welcome.version` keys
settings file is in `~/.local/share/containers/podman-desktop/configuration`
```
yarn install
yarn run test:e2e:smoke
```
<!-- Please explain steps to reproduce -->
