### PR TITLE
fix: remove sticky position of loader in dashboard UI (#2535)

### DIFF
--- a/packages/renderer/src/lib/dashboard/ProviderConfigured.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderConfigured.svelte
@@ -83,7 +83,7 @@ onMount(() => {
         {/if}
         <div class="flex flex-col text-gray-700">
           <div>Starting</div>
-          <div class="my-2 pr-5">
+          <div class="my-2 pr-5 relative">
             <i class="pf-c-button__progress">
               <span class="pf-c-spinner pf-m-md" role="progressbar">
                 <span class="pf-c-spinner__clipper"></span>

--- a/packages/renderer/src/lib/dashboard/ProviderConfiguring.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderConfiguring.svelte
@@ -108,7 +108,7 @@ onDestroy(() => {
       {/if}
       <div class="flex flex-col text-gray-700">
         <div>Initializing</div>
-        <div class="my-2 pr-5">
+        <div class="my-2 pr-5 relative">
           <i class="pf-c-button__progress">
             <span class="pf-c-spinner pf-m-md" role="progressbar">
               <span class="pf-c-spinner__clipper"></span>

--- a/packages/renderer/src/lib/dashboard/ProviderInstalled.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderInstalled.svelte
@@ -196,7 +196,7 @@ function onInstallationClick() {
       {/if}
       <div class="flex flex-col text-gray-700">
         <div>Initializing</div>
-        <div class="my-2 pr-5">
+        <div class="my-2 pr-5 relative">
           <i class="pf-c-button__progress">
             <span class="pf-c-spinner pf-m-md" role="progressbar">
               <span class="pf-c-spinner__clipper"></span>


### PR DESCRIPTION
### What does this PR do?

it prevents the loader from moving when scrolling the dashboard

### Screenshot/screencast of this PR

![spinner-pos](https://github.com/containers/podman-desktop/assets/49404737/60994c92-5367-4e83-8410-53e6ce7fbe7c)

### What issues does this PR fix or reference?

#2535 

### How to test this PR?

1. initialize and start podman and scroll down/up when the spinner is visible
