### PR TITLE
fix: do not redirect to /pods when deleting pod in containerlist

### DIFF
--- a/packages/renderer/src/lib/ContainerList.svelte
+++ b/packages/renderer/src/lib/ContainerList.svelte
@@ -458,6 +458,7 @@ function errorCallback(container: ContainerInfoUI, errorMessage: string): void {
                       containers: [],
                       kind: 'podman',
                     }}"
+                    redirectAfterDelete="{false}"
                     dropdownMenu="{true}" />
                 {/if}
               </td>

--- a/packages/renderer/src/lib/pod/PodActions.spec.ts
+++ b/packages/renderer/src/lib/pod/PodActions.spec.ts
@@ -1,0 +1,69 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom';
+import { test, expect, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import PodActions from './PodActions.svelte';
+import type { PodInfoUI } from './PodInfoUI';
+import { router } from 'tinro';
+
+const pod: PodInfoUI = {
+  id: 'pod',
+} as PodInfoUI;
+
+const errorCallback = vi.fn();
+
+// mock router import { router } from 'tinro';
+vi.mock('tinro', () => ({
+  router: {
+    goto: vi.fn(),
+  },
+}));
+
+beforeEach(() => {
+  (window as any).kubernetesDeletePod = vi.fn();
+  vi.resetAllMocks();
+  vi.clearAllMocks();
+});
+
+test('Expect to redirect to /pods page after deletion', async () => {
+  render(PodActions, { pod, errorCallback });
+
+  // click on delete button
+  const deleteButton = screen.getByRole('button', { name: 'Delete Pod' });
+  await fireEvent.click(deleteButton);
+
+  expect(errorCallback).not.toHaveBeenCalled();
+
+  // check that router has been called
+  expect(router.goto).toHaveBeenCalledWith('/pods/');
+});
+
+test('Expect no redirect to /pods page after deletion if configured', async () => {
+  render(PodActions, { pod, errorCallback, redirectAfterDelete: false });
+
+  // click on delete button
+  const deleteButton = screen.getByRole('button', { name: 'Delete Pod' });
+  await fireEvent.click(deleteButton);
+
+  expect(errorCallback).not.toHaveBeenCalled();
+
+  // check that router has not been called
+  expect(router.goto).not.toHaveBeenCalledWith('/pods');
+});

--- a/packages/renderer/src/lib/pod/PodActions.svelte
+++ b/packages/renderer/src/lib/pod/PodActions.svelte
@@ -9,6 +9,7 @@ import FlatMenu from '../ui/FlatMenu.svelte';
 export let pod: PodInfoUI;
 export let dropdownMenu = false;
 export let detailed = false;
+export let redirectAfterDelete = true;
 
 export let inProgressCallback: (inProgress: boolean, state?: string) => void = () => {};
 export let errorCallback: (erroMessage: string) => void = () => {};
@@ -54,7 +55,9 @@ async function deletePod(podInfoUI: PodInfoUI): Promise<void> {
     } else {
       await window.kubernetesDeletePod(podInfoUI.name);
     }
-    router.goto('/pods/');
+    if (redirectAfterDelete) {
+      router.goto('/pods/');
+    }
   } catch (error) {
     errorCallback(error);
   } finally {

--- a/packages/renderer/src/lib/pod/PodsList.svelte
+++ b/packages/renderer/src/lib/pod/PodsList.svelte
@@ -303,6 +303,7 @@ function errorCallback(pod: PodInfoUI, errorMessage: string): void {
                 </div>
                 <div class="text-right w-full">
                   <PodActions
+                    redirectAfterDelete="{false}"
                     pod="{pod}"
                     errorCallback="{error => errorCallback(pod, error)}"
                     inProgressCallback="{(flag, state) => inProgressCallback(pod, flag, state)}"

--- a/packages/renderer/src/lib/ui/ListItemButtonIcon.svelte
+++ b/packages/renderer/src/lib/ui/ListItemButtonIcon.svelte
@@ -44,6 +44,7 @@ $: styleClass = detailed
   <!-- enabled button -->
   <button
     title="{title}"
+    aria-label="{title}"
     on:click="{handleClick}"
     class="{styleClass} relative"
     class:disabled="{inProgress}"


### PR DESCRIPTION
### What does this PR do?
do not redirect to /pods when deleting pod in containerlist

### Screenshot/screencast of this PR


### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/2957

### How to test this PR?

Unit test
also try with the test case of the linked issue (delete a pod from container list page)
