### PR TITLE
chore: add aria-based labels in App and Preferences navigation

### DIFF
--- a/packages/renderer/src/AppNavigation.spec.ts
+++ b/packages/renderer/src/AppNavigation.spec.ts
@@ -31,7 +31,7 @@ beforeAll(() => {
   };
 });
 
-test('Test navigation bar gets right role and aria-label', () => {
+test('Test rendering of the navigation bar with empty items', () => {
   render(AppNavigation, {
     meta: {
       url: '/',
@@ -40,14 +40,6 @@ test('Test navigation bar gets right role and aria-label', () => {
 
   const navigationBar = screen.getByRole('navigation', { name: 'AppNavigation' });
   expect(navigationBar).toBeInTheDocument();
-});
-
-test('Test rendering of the navigation bar with empty items', () => {
-  render(AppNavigation, {
-    meta: {
-      url: '/',
-    },
-  });
 
   const dasboard = screen.getByRole('link', { name: 'Dashboard' });
   expect(dasboard).toBeInTheDocument();

--- a/packages/renderer/src/AppNavigation.spec.ts
+++ b/packages/renderer/src/AppNavigation.spec.ts
@@ -40,7 +40,6 @@ test('Test navigation bar gets right role and aria-label', () => {
 
   const navigationBar = screen.getByRole('navigation', { name: 'AppNavigation' });
   expect(navigationBar).toBeInTheDocument();
-  expect('AppNavigation').toEqual(navigationBar.getAttribute('aria-label'));
 });
 
 test('Test rendering of the navigation bar with empty items', () => {

--- a/packages/renderer/src/AppNavigation.svelte
+++ b/packages/renderer/src/AppNavigation.svelte
@@ -91,7 +91,7 @@ export let meta;
 <svelte:window />
 <nav
   class="pf-c-nav group w-[54px] min-w-[54px] flex flex-col justify-between hover:overflow-y-none"
-  aria-label="Global">
+  aria-label="AppNavigation">
   <ul class="pf-c-nav__list">
     <li
       class="pf-c-nav__item flex w-full {meta.url === '/'

--- a/packages/renderer/src/PreferencesNavigation.spec.ts
+++ b/packages/renderer/src/PreferencesNavigation.spec.ts
@@ -40,7 +40,6 @@ test('Test that Settings navigation bar has right role and aria-label', () => {
 
   const navigationBar = screen.getByRole('navigation', { name: 'PreferencesNavigation' });
   expect(navigationBar).toBeVisible();
-  expect('PreferencesNavigation').toEqual(navigationBar.getAttribute('aria-label'));
 });
 
 test('Test preferences items are discoverable using aria roles and labels', () => {

--- a/packages/renderer/src/PreferencesNavigation.spec.ts
+++ b/packages/renderer/src/PreferencesNavigation.spec.ts
@@ -31,7 +31,7 @@ beforeAll(() => {
   };
 });
 
-test('Test that Settings navigation bar has right role and aria-label', () => {
+test('Test rendering of the preferences navigation bar and its items', () => {
   render(PreferencesNavigation, {
     meta: {
       url: '/',
@@ -40,14 +40,6 @@ test('Test that Settings navigation bar has right role and aria-label', () => {
 
   const navigationBar = screen.getByRole('navigation', { name: 'PreferencesNavigation' });
   expect(navigationBar).toBeVisible();
-});
-
-test('Test preferences items are discoverable using aria roles and labels', () => {
-  render(PreferencesNavigation, {
-    meta: {
-      url: '/',
-    },
-  });
 
   const resources = screen.getByRole('link', { name: 'Resources' });
   expect(resources).toBeVisible();

--- a/packages/renderer/src/PreferencesNavigation.spec.ts
+++ b/packages/renderer/src/PreferencesNavigation.spec.ts
@@ -19,7 +19,7 @@
 import '@testing-library/jest-dom';
 import { beforeAll, test, expect } from 'vitest';
 import { render, screen } from '@testing-library/svelte';
-import AppNavigation from './AppNavigation.svelte';
+import PreferencesNavigation from './PreferencesNavigation.svelte';
 
 // fake the window.events object
 beforeAll(() => {
@@ -31,35 +31,36 @@ beforeAll(() => {
   };
 });
 
-test('Test navigation bar gets right role and aria-label', () => {
-  render(AppNavigation, {
+test('Test that Settings navigation bar has right role and aria-label', () => {
+  render(PreferencesNavigation, {
     meta: {
       url: '/',
     },
   });
 
-  const navigationBar = screen.getByRole('navigation', { name: 'AppNavigation' });
-  expect(navigationBar).toBeInTheDocument();
-  expect('AppNavigation').toEqual(navigationBar.getAttribute('aria-label'));
+  const navigationBar = screen.getByRole('navigation', { name: 'PreferencesNavigation' });
+  expect(navigationBar).toBeVisible();
+  expect('PreferencesNavigation').toEqual(navigationBar.getAttribute('aria-label'));
 });
 
-test('Test rendering of the navigation bar with empty items', () => {
-  render(AppNavigation, {
+test('Test preferences items are discoverable using aria roles and labels', () => {
+  render(PreferencesNavigation, {
     meta: {
       url: '/',
     },
   });
 
-  const dasboard = screen.getByRole('link', { name: 'Dashboard' });
-  expect(dasboard).toBeInTheDocument();
-  const containers = screen.getByRole('link', { name: 'Containers' });
-  expect(containers).toBeInTheDocument();
-  const pods = screen.getByRole('link', { name: 'Pods' });
-  expect(pods).toBeInTheDocument();
-  const images = screen.getByRole('link', { name: 'Images' });
-  expect(images).toBeInTheDocument();
-  const volumes = screen.getByRole('link', { name: 'Volumes' });
-  expect(volumes).toBeInTheDocument();
-  const settings = screen.getByRole('link', { name: 'Settings' });
-  expect(settings).toBeInTheDocument();
+  const resources = screen.getByRole('link', { name: 'Resources' });
+  expect(resources).toBeVisible();
+  const proxy = screen.getByRole('link', { name: 'Proxy' });
+  expect(proxy).toBeVisible();
+  const registries = screen.getByRole('link', { name: 'Registries' });
+  expect(registries).toBeVisible();
+  const authentication = screen.getByRole('link', { name: 'Authentication' });
+  expect(authentication).toBeVisible();
+  const extensions = screen.getByRole('link', { name: 'Extensions' });
+  expect(extensions).toBeVisible();
+  const desktop = screen.getByRole('link', { name: 'DesktopExtensions' });
+  expect(desktop).toBeVisible();
+  // ToDo: adding configuration section/items mocks for preferences, issue #2966
 });

--- a/packages/renderer/src/PreferencesNavigation.svelte
+++ b/packages/renderer/src/PreferencesNavigation.svelte
@@ -206,7 +206,7 @@ $: addSectionHiddenClass = (section: string): string => (sectionExpanded[section
                   id="configuration-section-{configSection.toLowerCase()}-{configItem.title.toLowerCase()}"
                   class="pf-c-nav__link"
                   style="font-weight: 200"
-                  aria-label="{configItem}"
+                  aria-label="{configItem.title}"
                   >{configItem.title}
                 </a>
               </li>

--- a/packages/renderer/src/PreferencesNavigation.svelte
+++ b/packages/renderer/src/PreferencesNavigation.svelte
@@ -47,7 +47,7 @@ $: addSectionHiddenClass = (section: string): string => (sectionExpanded[section
 <nav
   class="z-1 pf-c-nav w-[250px] min-w-[200px] shadow flex-col justify-between flex transition-all duration-500 ease-in-out"
   style="background-color: rgb(39 39 42 / var(--tw-bg-opacity))"
-  aria-label="Global">
+  aria-label="PreferencesNavigation">
   <div class="flex items-center">
     <div class="pt-4 px-5 mb-10">
       <p class="text-xl first-letter:uppercase">Settings</p>
@@ -59,7 +59,11 @@ $: addSectionHiddenClass = (section: string): string => (sectionExpanded[section
       class="pf-c-nav__item flex w-full justify-between {addCurrentClass(
         '/preferences/resources',
       )} hover:text-gray-400 cursor-pointer items-center">
-      <a href="/preferences/resources" id="configuration-section-resources" class="pf-c-nav__link">
+      <a
+        href="/preferences/resources"
+        id="configuration-section-resources"
+        class="pf-c-nav__link"
+        aria-label="Resources">
         <div class="flex items-center">
           <span class="block group-hover:block">Resources</span>
         </div>
@@ -72,7 +76,7 @@ $: addSectionHiddenClass = (section: string): string => (sectionExpanded[section
       class="pf-c-nav__item flex w-full justify-between {addCurrentClass(
         '/preferences/proxies',
       )} hover:text-gray-400 cursor-pointer items-center">
-      <a href="/preferences/proxies" id="configuration-section-proxy" class="pf-c-nav__link">
+      <a href="/preferences/proxies" id="configuration-section-proxy" class="pf-c-nav__link" aria-label="Proxy">
         <div class="flex items-center">
           <span class="block group-hover:block">Proxy</span>
         </div>
@@ -85,7 +89,11 @@ $: addSectionHiddenClass = (section: string): string => (sectionExpanded[section
       class="pf-c-nav__item flex w-full justify-between {addCurrentClass(
         '/preferences/registries',
       )} hover:text-gray-400 cursor-pointer items-center">
-      <a href="/preferences/registries" id="configuration-section-registries" class="pf-c-nav__link">
+      <a
+        href="/preferences/registries"
+        id="configuration-section-registries"
+        class="pf-c-nav__link"
+        aria-label="Registries">
         <div class="flex items-center">
           <span class="block group-hover:block">Registries</span>
         </div>
@@ -98,7 +106,11 @@ $: addSectionHiddenClass = (section: string): string => (sectionExpanded[section
       class="pf-c-nav__item flex w-full justify-between {addCurrentClass(
         '/preferences/authentication-providers',
       )} hover:text-gray-400 cursor-pointer items-center">
-      <a href="/preferences/authentication-providers" id="configuration-section-authentication" class="pf-c-nav__link">
+      <a
+        href="/preferences/authentication-providers"
+        id="configuration-section-authentication"
+        class="pf-c-nav__link"
+        aria-label="Authentication">
         <div class="flex items-center">
           <span class="hidden md:block group-hover:block">Authentication</span>
         </div>
@@ -115,6 +127,7 @@ $: addSectionHiddenClass = (section: string): string => (sectionExpanded[section
         href="/preferences/extensions"
         class="pf-c-nav__link text-left"
         id="configuration-section-extensions-catalog"
+        aria-label="Extensions"
         aria-expanded="{isAriaExpanded('extensionsCatalog')}"
         on:click="{() => toggleSection('extensionsCatalog')}">
         Extensions
@@ -132,7 +145,8 @@ $: addSectionHiddenClass = (section: string): string => (sectionExpanded[section
                 href="/preferences/extension/{extension.id}"
                 id="configuration-section-extensions-catalog-{extension.name.toLowerCase()}"
                 class="pf-c-nav__link"
-                style="font-weight: 200">{extension.displayName}</a>
+                style="font-weight: 200"
+                aria-label="{extension.name}">{extension.displayName}</a>
             </li>
           {/each}
         </ul>
@@ -145,7 +159,11 @@ $: addSectionHiddenClass = (section: string): string => (sectionExpanded[section
       class="pf-c-nav__item flex w-full justify-between {addCurrentClass(
         '/preferences/ddExtensions',
       )} hover:text-gray-400 cursor-pointer items-center">
-      <a href="/preferences/ddExtensions" id="configuration-section-docker-desktop-extensions" class="pf-c-nav__link">
+      <a
+        href="/preferences/ddExtensions"
+        id="configuration-section-docker-desktop-extensions"
+        class="pf-c-nav__link"
+        aria-label="DesktopExtensions">
         <div class="flex items-center">
           <span class="block group-hover:block">Desktop Extensions</span>
         </div>
@@ -164,6 +182,7 @@ $: addSectionHiddenClass = (section: string): string => (sectionExpanded[section
           id="configuration-section-{configSection.toLowerCase()}"
           aria-expanded="{isAriaExpanded(configSection)}"
           href="/preferences/default/{configSection}"
+          aria-label="{configSection}"
           on:click="{() => {
             if (configItems.length > 0) {
               toggleSection(configSection);
@@ -186,7 +205,10 @@ $: addSectionHiddenClass = (section: string): string => (sectionExpanded[section
                   href="/preferences/default/{configItem.id}"
                   id="configuration-section-{configSection.toLowerCase()}-{configItem.title.toLowerCase()}"
                   class="pf-c-nav__link"
-                  style="font-weight: 200">{configItem.title}</a>
+                  style="font-weight: 200"
+                  aria-label="{configItem}"
+                  >{configItem.title}
+                </a>
               </li>
             {/each}
           </ul>


### PR DESCRIPTION
### What does this PR do?
Changes Application and Preferences navigation aria label from Global
Adds some other labels for Settings items
New test for PreferencesNavigation.svelte page
### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?
#2967 
<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

### How to test this PR?
```
yarn install
yarn run test:renderer
```
<!-- Please explain steps to reproduce -->
