### PR TITLE
chore: fix running tests directly from the IDE

### DIFF
--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,12 +1,12 @@
 /**********************************************************************
  * Copyright (C) 2022 Red Hat, Inc.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,9 +16,13 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+const { join } = require('path');
+
 module.exports = {
   plugins: {
-    tailwindcss: {},
+    tailwindcss: {
+      config: join(__dirname, 'tailwind.config.cjs'),
+    },
     'postcss-import': {},
     autoprefixer: {},
   },


### PR DESCRIPTION
### What does this PR do?

This changes proposal provides a fix for running tests (mainly UI) directly from the IDE, e.g. WebStorm. Initial problem was in that when we try to run some of UI tests directly from the IDE we could get the following error:
```
TypeError: [postcss] Cannot read properties of undefined (reading 'config')
```
Now it is possible to run any UI test directly from the IDE without any problems and exceptions.

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

N/A

### How to test this PR?

If you are user of WebStorm, try to run any UI test directly from the IDE.
