### PR TITLE
fix: detailspage, resizing & consistency

### DIFF
--- a/packages/renderer/src/lib/container/ContainerDetails.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetails.svelte
@@ -15,6 +15,7 @@ import ContainerDetailsSummary from './ContainerDetailsSummary.svelte';
 import ContainerDetailsInspect from './ContainerDetailsInspect.svelte';
 import ContainerDetailsKube from './ContainerDetailsKube.svelte';
 import ContainerStatistics from './ContainerStatistics.svelte';
+import DetailsPage from '../ui/DetailsPage.svelte';
 import DetailsTab from '../ui/DetailsTab.svelte';
 import ErrorMessage from '../ui/ErrorMessage.svelte';
 
@@ -46,85 +47,56 @@ function errorCallback(errorMessage: string): void {
 </script>
 
 {#if container}
-  <Route path="/*">
-    <div class="w-full h-full">
-      <div class="flex h-full flex-col">
-        <div class="flex w-full flex-row">
-          <div class="w-full px-5 pt-5">
-            <div class="flex flew-row items-center">
-              <a
-                class="text-violet-400 text-base hover:no-underline"
-                href="/containers"
-                title="Go back to containers list">Containers</a>
-              <div class="text-xl mx-2 text-gray-700">></div>
-              <div class="text-sm font-extralight text-gray-700">Container Details</div>
-            </div>
-            <div class="text-lg flex flex-row items-start pt-1">
-              <div class="pr-3 pt-1">
-                <StatusIcon icon="{ContainerIcon}" status="{container.state}" />
-              </div>
-              <div class="text-lg flex flex-col">
-                <div class="mr-2">{container.name}</div>
-                <div class="mr-2 pb-4 text-small text-gray-900" title="{container.image}">{container.shortImage}</div>
-              </div>
-            </div>
-            <section class="pf-c-page__main-tabs pf-m-limit-width">
-              <div class="pf-c-page__main-body">
-                <div class="pf-c-tabs pf-m-page-insets" id="open-tabs-example-tabs-list">
-                  <ul class="pf-c-tabs__list">
-                    <DetailsTab title="Summary" url="summary" />
-                    <DetailsTab title="Logs" url="logs" />
-                    <DetailsTab title="Inspect" url="inspect" />
-
-                    {#if container.engineType === 'podman' && container.groupInfo.type === ContainerGroupInfoTypeUI.STANDALONE}
-                      <DetailsTab title="Kube" url="kube" />
-                    {/if}
-                    <DetailsTab title="Terminal" url="terminal" />
-                  </ul>
-                </div>
-              </div>
-            </section>
-          </div>
-          <div class="flex flex-col px-5 pt-5">
-            <div class="flex justify-end">
-              <div class="flex items-center w-5">
-                {#if container.actionError}
-                  <ErrorMessage error="{container.actionError}" icon />
-                {:else}
-                  <div>&nbsp;</div>
-                {/if}
-              </div>
-              <ContainerActions
-                inProgressCallback="{(flag, state) => inProgressCallback(flag, state)}"
-                errorCallback="{error => errorCallback(error)}"
-                container="{container}"
-                detailed="{true}" />
-            </div>
-            <div class="flex my-2 w-full justify-end">
-              <ContainerStatistics container="{container}" />
-            </div>
-          </div>
-          <a href="/containers" title="Close Details" class="mt-2 mr-2 text-gray-900"
-            ><i class="fas fa-times" aria-hidden="true"></i></a>
-        </div>
-        <div class="h-full bg-charcoal-900">
-          <Route path="/summary" breadcrumb="Summary">
-            <ContainerDetailsSummary container="{container}" />
-          </Route>
-          <Route path="/logs" breadcrumb="Logs">
-            <ContainerDetailsLogs container="{container}" />
-          </Route>
-          <Route path="/inspect" breadcrumb="Inspect">
-            <ContainerDetailsInspect container="{container}" />
-          </Route>
-          <Route path="/kube" breadcrumb="Kube">
-            <ContainerDetailsKube container="{container}" />
-          </Route>
-          <Route path="/terminal" breadcrumb="Terminal">
-            <ContainerDetailsTerminal container="{container}" />
-          </Route>
-        </div>
+  <DetailsPage
+    name="Container Details"
+    title="{container.name}"
+    subtitle="{container.shortImage}"
+    parentName="Containers"
+    parentURL="/containers">
+    <StatusIcon slot="icon" icon="{ContainerIcon}" status="{container.state}" />
+    <div slot="actions" class="flex justify-end">
+      <div class="flex items-center w-5">
+        {#if container.actionError}
+          <ErrorMessage error="{container.actionError}" icon />
+        {:else}
+          <div>&nbsp;</div>
+        {/if}
       </div>
+      <ContainerActions
+        inProgressCallback="{(flag, state) => inProgressCallback(flag, state)}"
+        errorCallback="{error => errorCallback(error)}"
+        container="{container}"
+        detailed="{true}" />
     </div>
-  </Route>
+    <div slot="detail" class="flex py-2 w-full justify-end">
+      <ContainerStatistics container="{container}" />
+    </div>
+    <div slot="tabs" class="pf-c-tabs__list">
+      <DetailsTab title="Summary" url="summary" />
+      <DetailsTab title="Logs" url="logs" />
+      <DetailsTab title="Inspect" url="inspect" />
+
+      {#if container.engineType === 'podman' && container.groupInfo.type === ContainerGroupInfoTypeUI.STANDALONE}
+        <DetailsTab title="Kube" url="kube" />
+      {/if}
+      <DetailsTab title="Terminal" url="terminal" />
+    </div>
+    <span slot="content">
+      <Route path="/summary" breadcrumb="Summary">
+        <ContainerDetailsSummary container="{container}" />
+      </Route>
+      <Route path="/logs" breadcrumb="Logs">
+        <ContainerDetailsLogs container="{container}" />
+      </Route>
+      <Route path="/inspect" breadcrumb="Inspect">
+        <ContainerDetailsInspect container="{container}" />
+      </Route>
+      <Route path="/kube" breadcrumb="Kube">
+        <ContainerDetailsKube container="{container}" />
+      </Route>
+      <Route path="/terminal" breadcrumb="Terminal">
+        <ContainerDetailsTerminal container="{container}" />
+      </Route>
+    </span>
+  </DetailsPage>
 {/if}

--- a/packages/renderer/src/lib/image/ImageDetails.svelte
+++ b/packages/renderer/src/lib/image/ImageDetails.svelte
@@ -11,6 +11,7 @@ import ImageDetailsInspect from './ImageDetailsInspect.svelte';
 import ImageDetailsHistory from './ImageDetailsHistory.svelte';
 import ImageDetailsSummary from './ImageDetailsSummary.svelte';
 import PushImageModal from './PushImageModal.svelte';
+import DetailsPage from '../ui/DetailsPage.svelte';
 import DetailsTab from '../ui/DetailsTab.svelte';
 
 export let imageID: string;
@@ -44,68 +45,34 @@ onMount(() => {
 </script>
 
 {#if image}
-  <Route path="/*">
-    <div class="w-full h-full">
-      <div class="flex h-full flex-col">
-        <div class="flex w-full flex-row">
-          <div class="w-full px-5 pt-5">
-            <div class="flex flew-row items-center">
-              <a class="text-violet-400 text-base hover:no-underline" href="/images" title="Go back to images list"
-                >Images</a>
-              <div class="text-xl mx-2 text-gray-700">></div>
-              <div class="text-sm font-extralight text-gray-700">Image Details</div>
-            </div>
-            <div class="flex flex-row items-start pt-1">
-              <div class="pr-3 pt-1">
-                <StatusIcon icon="{ImageIcon}" status="{image.inUse ? 'USED' : 'UNUSED'}" />
-              </div>
-              <div class="text-lg flex flex-col">
-                <div class="flex flex-row">
-                  <div class="mr-2">{image.name}</div>
-                  <div class="text-base text-violet-400">{image.shortId}</div>
-                </div>
-                <div class="mr-2 pb-4 text-small text-gray-900">{image.tag}</div>
-              </div>
-            </div>
-
-            <section class="pf-c-page__main-tabs pf-m-limit-width">
-              <div class="pf-c-page__main-body">
-                <div class="pf-c-tabs pf-m-page-insets" id="open-tabs-example-tabs-list">
-                  <ul class="pf-c-tabs__list">
-                    <DetailsTab title="Summary" url="summary" />
-                    <DetailsTab title="History" url="history" />
-                    <DetailsTab title="Inspect" url="inspect" />
-                  </ul>
-                </div>
-              </div>
-            </section>
-          </div>
-          <div class="flex flex-col px-5 pt-5">
-            <div class="flex justify-end">
-              <ImageActions
-                image="{image}"
-                onPushImage="{handlePushImageModal}"
-                detailed="{true}"
-                dropdownMenu="{false}" />
-            </div>
-          </div>
-          <a href="/containers" title="Close Details" class="mt-2 mr-2 text-gray-900"
-            ><i class="fas fa-times" aria-hidden="true"></i></a>
-        </div>
-        <div class="h-full bg-charcoal-900">
-          <Route path="/history" breadcrumb="History">
-            <ImageDetailsHistory image="{image}" />
-          </Route>
-          <Route path="/inspect" breadcrumb="Inspect">
-            <ImageDetailsInspect image="{image}" />
-          </Route>
-          <Route path="/summary" breadcrumb="Summary">
-            <ImageDetailsSummary image="{image}" />
-          </Route>
-        </div>
-      </div>
+  <DetailsPage
+    name="Image Details"
+    title="{image.name}"
+    titleDetail="{image.shortId}"
+    subtitle="{image.tag}"
+    parentName="Images"
+    parentURL="/images">
+    <StatusIcon slot="icon" icon="{ImageIcon}" status="{image.inUse ? 'USED' : 'UNUSED'}" />
+    <div slot="actions" class="flex justify-end">
+      <ImageActions image="{image}" onPushImage="{handlePushImageModal}" detailed="{true}" dropdownMenu="{false}" />
     </div>
-  </Route>
+    <div slot="tabs" class="pf-c-tabs__list">
+      <DetailsTab title="Summary" url="summary" />
+      <DetailsTab title="History" url="history" />
+      <DetailsTab title="Inspect" url="inspect" />
+    </div>
+    <span slot="content">
+      <Route path="/history" breadcrumb="History">
+        <ImageDetailsHistory image="{image}" />
+      </Route>
+      <Route path="/inspect" breadcrumb="Inspect">
+        <ImageDetailsInspect image="{image}" />
+      </Route>
+      <Route path="/summary" breadcrumb="Summary">
+        <ImageDetailsSummary image="{image}" />
+      </Route>
+    </span>
+  </DetailsPage>
 {/if}
 
 {#if pushImageModal}

--- a/packages/renderer/src/lib/pod/PodDetails.svelte
+++ b/packages/renderer/src/lib/pod/PodDetails.svelte
@@ -12,6 +12,7 @@ import PodDetailsSummary from './PodDetailsSummary.svelte';
 import PodDetailsInspect from './PodDetailsInspect.svelte';
 import PodDetailsKube from './PodDetailsKube.svelte';
 import PodDetailsLogs from './PodDetailsLogs.svelte';
+import DetailsPage from '../ui/DetailsPage.svelte';
 import DetailsTab from '../ui/DetailsTab.svelte';
 import ErrorMessage from '../ui/ErrorMessage.svelte';
 
@@ -59,72 +60,41 @@ function errorCallback(errorMessage: string): void {
 </script>
 
 {#if pod}
-  <Route path="/*">
-    <div class="w-full h-full">
-      <div class="flex h-full flex-col">
-        <div class="flex w-full flex-row">
-          <div class="w-full px-5 pt-5">
-            <div class="flex flew-row items-center">
-              <a class="text-violet-400 text-base hover:no-underline" href="/pods" title="Go back to pods list">Pods</a>
-              <div class="text-xl mx-2 text-gray-700">></div>
-              <div class="text-sm font-extralight text-gray-700">Pod Details</div>
-            </div>
-            <div class="text-lg flex flex-row items-start pt-1">
-              <div class="pr-3 pt-1">
-                <StatusIcon icon="{PodIcon}" status="{pod.status}" />
-              </div>
-              <div class="text-lg flex flex-col">
-                <div class="mr-2">{pod.name}</div>
-                <div class="mr-2 pb-4 text-small text-gray-900">{pod.shortId}</div>
-              </div>
-            </div>
-            <section class="pf-c-page__main-tabs pf-m-limit-width">
-              <div class="pf-c-page__main-body">
-                <div class="pf-c-tabs pf-m-page-insets" id="open-tabs-example-tabs-list">
-                  <ul class="pf-c-tabs__list">
-                    <DetailsTab title="Summary" url="summary" />
-                    <DetailsTab title="Logs" url="logs" />
-                    <DetailsTab title="Inspect" url="inspect" />
-                    <DetailsTab title="Kube" url="kube" />
-                  </ul>
-                </div>
-              </div>
-            </section>
-          </div>
-          <div class="flex flex-col px-5 pt-5">
-            <div class="flex justify-end">
-              <div class="flex items-center w-5">
-                {#if pod.actionError}
-                  <ErrorMessage error="{pod.actionError}" icon />
-                {:else}
-                  <div>&nbsp;</div>
-                {/if}
-              </div>
-              <PodActions
-                pod="{pod}"
-                inProgressCallback="{(flag, state) => inProgressCallback(flag, state)}"
-                errorCallback="{error => errorCallback(error)}"
-                detailed="{true}" />
-            </div>
-          </div>
-          <a href="/containers" title="Close Details" class="mt-2 mr-2 text-gray-900"
-            ><i class="fas fa-times" aria-hidden="true"></i></a>
-        </div>
-        <div class="h-full bg-charcoal-900">
-          <Route path="/summary" breadcrumb="Summary">
-            <PodDetailsSummary pod="{pod}" />
-          </Route>
-          <Route path="/logs" breadcrumb="Logs">
-            <PodDetailsLogs pod="{pod}" />
-          </Route>
-          <Route path="/inspect" breadcrumb="Inspect">
-            <PodDetailsInspect pod="{pod}" />
-          </Route>
-          <Route path="/kube" breadcrumb="Kube">
-            <PodDetailsKube pod="{pod}" />
-          </Route>
-        </div>
+  <DetailsPage name="Pod Details" title="{pod.name}" subtitle="{pod.shortId}" parentName="Pods" parentURL="/pods">
+    <StatusIcon slot="icon" icon="{PodIcon}" status="{pod.status}" />
+    <div slot="actions" class="flex justify-end">
+      <div class="flex items-center w-5">
+        {#if pod.actionError}
+          <ErrorMessage error="{pod.actionError}" icon />
+        {:else}
+          <div>&nbsp;</div>
+        {/if}
       </div>
+      <PodActions
+        pod="{pod}"
+        inProgressCallback="{(flag, state) => inProgressCallback(flag, state)}"
+        errorCallback="{error => errorCallback(error)}"
+        detailed="{true}" />
     </div>
-  </Route>
+    <div slot="tabs" class="pf-c-tabs__list">
+      <DetailsTab title="Summary" url="summary" />
+      <DetailsTab title="Logs" url="logs" />
+      <DetailsTab title="Inspect" url="inspect" />
+      <DetailsTab title="Kube" url="kube" />
+    </div>
+    <span slot="content">
+      <Route path="/summary" breadcrumb="Summary">
+        <PodDetailsSummary pod="{pod}" />
+      </Route>
+      <Route path="/logs" breadcrumb="Logs">
+        <PodDetailsLogs pod="{pod}" />
+      </Route>
+      <Route path="/inspect" breadcrumb="Inspect">
+        <PodDetailsInspect pod="{pod}" />
+      </Route>
+      <Route path="/kube" breadcrumb="Kube">
+        <PodDetailsKube pod="{pod}" />
+      </Route>
+    </span>
+  </DetailsPage>
 {/if}

--- a/packages/renderer/src/lib/ui/DetailsPage.spec.ts
+++ b/packages/renderer/src/lib/ui/DetailsPage.spec.ts
@@ -1,0 +1,68 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom';
+import { test, expect } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import DetailsPage from './DetailsPage.svelte';
+
+test('Expect title is defined', async () => {
+  const name = 'My Name';
+  const title = 'My Dummy Title';
+  render(DetailsPage, {
+    name,
+    title,
+  });
+
+  const titleElement = screen.getByRole('heading', { level: 1, name: title });
+  expect(titleElement).toBeInTheDocument();
+  expect(titleElement).toHaveTextContent(title);
+});
+
+test('Expect backlink is defined', async () => {
+  const name = 'My Name';
+  const title = 'My Dummy Title';
+  const parentName = 'Parent';
+  const parentURL = '/test';
+  render(DetailsPage, {
+    name,
+    title,
+    parentName,
+    parentURL,
+  });
+
+  const nameElement = screen.getByLabelText('back');
+  expect(nameElement).toBeInTheDocument();
+  expect(nameElement).toHaveTextContent(parentName);
+  expect(nameElement).toHaveAttribute('href', parentURL);
+});
+
+test('Expect close link is defined', async () => {
+  const name = 'My Name';
+  const title = 'My Dummy Title';
+  const parentURL = '/test';
+  render(DetailsPage, {
+    name,
+    title,
+    parentURL,
+  });
+
+  const closeElement = screen.getByTitle('Close Details');
+  expect(closeElement).toBeInTheDocument();
+  expect(closeElement).toHaveAttribute('href', parentURL);
+});

--- a/packages/renderer/src/lib/ui/DetailsPage.svelte
+++ b/packages/renderer/src/lib/ui/DetailsPage.svelte
@@ -1,0 +1,60 @@
+<script lang="ts">
+import Route from '../../Route.svelte';
+
+export let name: string;
+export let title: string;
+export let titleDetail: string = undefined;
+export let subtitle: string = undefined;
+export let parentName: string = undefined;
+export let parentURL: string = undefined;
+</script>
+
+<Route path="/*">
+  <div class="w-full h-full">
+    <div class="flex h-full flex-col">
+      <div class="flex w-full flex-row">
+        <div class="w-full pl-5 pt-5">
+          <div class="flex flew-row items-center">
+            <a
+              class="text-violet-400 text-base hover:no-underline"
+              aria-label="back"
+              href="{parentURL}"
+              title="Go back to {parentName}">{parentName}</a>
+            <div class="text-xl mx-2 text-gray-700">></div>
+            <div class="text-sm font-extralight text-gray-700">{name}</div>
+          </div>
+          <div class="text-lg flex flex-row items-start pt-1">
+            <div class="pr-3 pt-1">
+              <slot name="icon" />
+            </div>
+            <div class="text-lg flex flex-col">
+              <div class="flex flex-row items-baseline">
+                <h1>{title}</h1>
+                <div class="text-base text-violet-400 ml-2" class:hidden="{!titleDetail}">{titleDetail}</div>
+              </div>
+              <div class="mr-2 pb-4 text-small text-gray-900">{subtitle}</div>
+            </div>
+          </div>
+        </div>
+        <div class="flex flex-col pr-2 pt-5">
+          <slot name="actions" />
+          <slot name="detail" />
+        </div>
+        <a href="{parentURL}" title="Close Details" class="mt-2 mr-2 text-gray-900"
+          ><i class="fas fa-times" aria-hidden="true"></i></a>
+      </div>
+      <section class="pf-c-page__main-tabs pf-m-limit-width">
+        <div class="pf-c-page__main-body">
+          <div class="pf-c-tabs pf-m-page-insets" id="open-tabs-example-tabs-list">
+            <ul class="pf-c-tabs__list">
+              <slot name="tabs" />
+            </ul>
+          </div>
+        </div>
+      </section>
+      <div class="h-full bg-charcoal-900">
+        <slot name="content" />
+      </div>
+    </div>
+  </div>
+</Route>

--- a/packages/renderer/src/lib/volume/VolumeDetails.svelte
+++ b/packages/renderer/src/lib/volume/VolumeDetails.svelte
@@ -9,6 +9,7 @@ import VolumeActions from './VolumeActions.svelte';
 import { VolumeUtils } from './volume-utils';
 import VolumeDetailsSummary from '././VolumeDetailsSummary.svelte';
 import VolumeDetailsInspect from './VolumeDetailsInspect.svelte';
+import DetailsPage from '../ui/DetailsPage.svelte';
 import DetailsTab from '../ui/DetailsTab.svelte';
 
 export let volumeName: string;
@@ -33,55 +34,27 @@ onMount(() => {
 </script>
 
 {#if volume}
-  <Route path="/*">
-    <div class="w-full h-full">
-      <div class="flex h-full flex-col">
-        <div class="flex w-full flex-row">
-          <div class="w-full px-5 pt-5">
-            <div class="flex flew-row items-center">
-              <a class="text-violet-400 text-base hover:no-underline" href="/volumes" title="Go back to volumes list"
-                >Volumes</a>
-              <div class="text-xl mx-2 text-gray-700">></div>
-              <div class="text-sm font-extralight text-gray-700">Volume Details</div>
-            </div>
-            <div class="text-lg flex flex-row items-start pt-1">
-              <div class="pr-3 pt-1">
-                <StatusIcon icon="{VolumeIcon}" status="{volume.inUse ? 'USED' : 'UNUSED'}" />
-              </div>
-              <div class="text-lg flex flex-col">
-                <div class="mr-2">{volume.shortName}</div>
-                <div class="mr-2 pb-4 text-small text-gray-900">{volume.humanSize}</div>
-              </div>
-            </div>
-
-            <section class="pf-c-page__main-tabs pf-m-limit-width">
-              <div class="pf-c-page__main-body">
-                <div class="pf-c-tabs pf-m-page-insets" id="open-tabs-example-tabs-list">
-                  <ul class="pf-c-tabs__list">
-                    <DetailsTab title="Summary" url="summary" />
-                    <DetailsTab title="Inspect" url="inspect" />
-                  </ul>
-                </div>
-              </div>
-            </section>
-          </div>
-          <div class="flex flex-col px-5 pt-5">
-            <div class="flex justify-end">
-              <VolumeActions volume="{volume}" detailed="{true}" />
-            </div>
-          </div>
-          <a href="/containers" title="Close Details" class="mt-2 mr-2 text-gray-900"
-            ><i class="fas fa-times" aria-hidden="true"></i></a>
-        </div>
-        <div class="h-full bg-charcoal-900">
-          <Route path="/summary" breadcrumb="Summary">
-            <VolumeDetailsSummary volume="{volume}" />
-          </Route>
-          <Route path="/inspect" breadcrumb="Inspect">
-            <VolumeDetailsInspect volume="{volume}" />
-          </Route>
-        </div>
-      </div>
+  <DetailsPage
+    name="Volume Details"
+    title="{volume.shortName}"
+    subtitle="{volume.humanSize}"
+    parentName="Volumes"
+    parentURL="/volumes">
+    <StatusIcon slot="icon" icon="{VolumeIcon}" status="{volume.inUse ? 'USED' : 'UNUSED'}" />
+    <div slot="actions" class="flex justify-end">
+      <VolumeActions volume="{volume}" detailed="{true}" />
     </div>
-  </Route>
+    <div slot="tabs" class="pf-c-tabs__list">
+      <DetailsTab title="Summary" url="summary" />
+      <DetailsTab title="Inspect" url="inspect" />
+    </div>
+    <span slot="content">
+      <Route path="/summary" breadcrumb="Summary">
+        <VolumeDetailsSummary volume="{volume}" />
+      </Route>
+      <Route path="/inspect" breadcrumb="Inspect">
+        <VolumeDetailsInspect volume="{volume}" />
+      </Route>
+    </span>
+  </DetailsPage>
 {/if}


### PR DESCRIPTION
### What does this PR do?

The four details pages each had a little uniqueness, and some copy/paste errors (e.g. issue #2986 - the close button goes to the wrong place). They also had layout issues when the window is narrower (issue #2322).

This creates a common DetailsPage component to make sure the pages are consistent, and applies it to each page. There are two features that are only used by one page right now (e.g. images have a title detail in purple; containers has statistics detail on the right) but otherwise everything in the same.

Fixed a few layout issues in the component to improve narrow layouts (e.g. extraneous spacing, moved tabs to new row) and fixed the close action. There is still some work that could be done to reduce some of the class attributes that are still required in each page or simplify further, but I think this is a good pass.

### Screenshot/screencast of this PR

Before:
<img width="758" alt="Screenshot 2023-06-23 at 11 29 46 AM" src="https://github.com/containers/podman-desktop/assets/19958075/18f64802-e58b-43af-8947-e1aaaaa519f6">
<img width="758" alt="Screenshot 2023-06-23 at 11 29 59 AM" src="https://github.com/containers/podman-desktop/assets/19958075/214ff3bc-401d-452f-a053-06bc6e3b47f4">

After:
<img width="758" alt="Screenshot 2023-06-23 at 11 27 53 AM" src="https://github.com/containers/podman-desktop/assets/19958075/bcc5cb77-fea5-4934-a220-e79244611b47">
<img width="758" alt="Screenshot 2023-06-23 at 11 28 11 AM" src="https://github.com/containers/podman-desktop/assets/19958075/d650783d-becd-4cd6-b76e-5b24f7725d61">

### What issues does this PR fix or reference?

Fixes #2322.
Fixes #2986.

### How to test this PR?

Open up the details pages on each kind of object.