### PR TITLE
fix: undo change that broke the website

### DIFF
--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -16,13 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-const { join } = require('path');
-
 module.exports = {
   plugins: {
-    tailwindcss: {
-      config: join(__dirname, 'tailwind.config.cjs'),
-    },
+    tailwindcss: {},
     'postcss-import': {},
     autoprefixer: {},
   },


### PR DESCRIPTION
### What does this PR do?

Undoes PR #2971 which caused regressions to the website:
![Screenshot from 2023-06-23 19-33-27](https://github.com/containers/podman-desktop/assets/19958075/9f280877-798d-4f90-925b-80171e5ddf5e)

### How to test this PR?

yarn website:dev