### PR TITLE
docs: replace broken link to podman.io

### DIFF
--- a/website/docs/Installation/linux-install/index.md
+++ b/website/docs/Installation/linux-install/index.md
@@ -21,7 +21,7 @@ Alternatively, you can install Podman Desktop from:
 #### Prerequisites
 
 - [Flatpak](https://flatpak.org/setup/)
-- [Podman](https://podman.io/whatis.html) stable version
+- [Podman](https://podman.io/) stable version
 
 #### Procedure
 

--- a/website/docs/Installation/linux-install/installing-podman-desktop-from-a-compressed-tar-file.md
+++ b/website/docs/Installation/linux-install/installing-podman-desktop-from-a-compressed-tar-file.md
@@ -15,7 +15,7 @@ Consider installing from an archive rather than [from Flathub](../linux-install)
 
 #### Prerequisites
 
-- [Podman](https://podman.io/whatis.html) stable version
+- [Podman](https://podman.io/) stable version
 
 #### Procedure
 

--- a/website/docs/Installation/linux-install/installing-podman-desktop-from-a-flatpak-bundle.md
+++ b/website/docs/Installation/linux-install/installing-podman-desktop-from-a-flatpak-bundle.md
@@ -16,7 +16,7 @@ Consider installing a Flatpak bundle rather than [from Flathub](../linux-install
 #### Prerequisites
 
 - [Flatpak](https://flatpak.org/setup/)
-- [Podman](https://podman.io/whatis.html) stable version
+- [Podman](https://podman.io/) stable version
 
 #### Procedure
 


### PR DESCRIPTION
With the new website, it has been moved to a separate site and the links to the old documentation does not work anymore.

### What does this PR do?

Update link that was broken when podman.io went to podman.io_old

~~https://podman.io/whatis.html~~

### Screenshot/screencast of this PR

Link "Podman" to [podman.io](https://podman.io/), and hope users can find the Download:

![podman-download](https://github.com/containers/podman-desktop/assets/10364051/22fcf0e2-0766-4de1-8d18-9703e9623286)

It doesn't actually download anything, instead it links to the current install documentation.

### What issues does this PR fix or reference?

* #2901

### How to test this PR?

http://localhost:3000/docs/Installation/linux-install