### PR TITLE
fix: website check targets

### DIFF
--- a/website/.eslintignore
+++ b/website/.eslintignore
@@ -1,0 +1,2 @@
+/build
+*.config.js

--- a/website/.gitignore
+++ b/website/.gitignore
@@ -8,6 +8,9 @@
 .docusaurus
 .cache-loader
 
+# Cache
+.eslintcache
+
 # Misc
 .DS_Store
 .env.local

--- a/website/.prettierignore
+++ b/website/.prettierignore
@@ -1,0 +1,2 @@
+.docusaurus
+/build/

--- a/website/package.json
+++ b/website/package.json
@@ -13,10 +13,10 @@
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
     "typecheck": "tsc",
-    "format:check": "prettier --check 'src/**/*.{css,ts,tsx}'",
-    "format:fix": "prettier --write 'src/**/*.{css,ts,tsx}'",
-    "lint:check": "eslint . --ext js,ts,tsx",
-    "lint:fix": "eslint . --fix --ext js,ts,tsx"
+    "format:check": "prettier --check '**/*.{md,js}' 'src/**/*.{css,ts,tsx}'",
+    "format:fix": "prettier --write '**/*.{md,js}' 'src/**/*.{css,ts,tsx}'",
+    "lint:check": "cd .. && eslint website --ext js,ts,tsx",
+    "lint:fix": "cd .. && eslint website --fix --ext js,ts,tsx"
   },
   "dependencies": {
     "@docusaurus/core": "2.4.1",

--- a/website/package.json
+++ b/website/package.json
@@ -13,12 +13,13 @@
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
     "typecheck": "tsc",
-    "format:check": "prettier --check '**/*.{md,js}' 'src/**/*.{css,ts,tsx}'",
-    "format:fix": "prettier --write '**/*.{md,js}' 'src/**/*.{css,ts,tsx}'",
+    "format:check": "prettier --cache --check '**/*.{md,js}' 'src/**/*.{css,ts,tsx}'",
+    "format:fix": "prettier --cache --write '**/*.{md,js}' 'src/**/*.{css,ts,tsx}'",
     "markdownlint:check": "markdownlint-cli2 --config ../.markdownlint.yaml \"**/*.md\" \"#node_modules\"",
     "markdownlint:fix": "markdownlint-cli2-fix --config ../.markdownlint.yaml \"**/*.md\" \"#node_modules\"",
-    "lint:check": "cd .. && eslint website --ext js,ts,tsx",
-    "lint:fix": "cd .. && eslint website --fix --ext js,ts,tsx"
+    "lint:check": "cd .. && eslint --cache --cache-location website/.eslintcache website --ext js,ts,tsx",
+    "lint:fix": "cd .. && eslint --cache --cache-location website/.eslintcache website --fix --ext js,ts,tsx",
+    "lint:clean": "rimraf .eslintcache"
   },
   "dependencies": {
     "@docusaurus/core": "2.4.1",

--- a/website/package.json
+++ b/website/package.json
@@ -15,6 +15,8 @@
     "typecheck": "tsc",
     "format:check": "prettier --check '**/*.{md,js}' 'src/**/*.{css,ts,tsx}'",
     "format:fix": "prettier --write '**/*.{md,js}' 'src/**/*.{css,ts,tsx}'",
+    "markdownlint:check": "markdownlint-cli2 --config ../.markdownlint.yaml \"**/*.md\" \"#node_modules\"",
+    "markdownlint:fix": "markdownlint-cli2-fix --config ../.markdownlint.yaml \"**/*.md\" \"#node_modules\"",
     "lint:check": "cd .. && eslint website --ext js,ts,tsx",
     "lint:fix": "cd .. && eslint website --fix --ext js,ts,tsx"
   },


### PR DESCRIPTION
### What does this PR do?

It was only possible to check the much bigger top-level targets...

But it should be possible to format and lint also the website dir.

### Screenshot/screencast of this PR

```console
$ cd website
$ yarn lint:check && yarn format:check
yarn run v1.22.19
$ eslint . --ext js,ts,tsx
=============

WARNING: You are currently running a version of TypeScript which is not officially supported by @typescript-eslint/typescript-estree.

You may find that it works just fine, or you may not.

SUPPORTED TYPESCRIPT VERSIONS: >=3.3.1 <5.1.0

YOUR TYPESCRIPT VERSION: 5.1.3

Please only submit bug reports when using the officially supported version.

=============
Done in 4.71s.
yarn run v1.22.19
$ prettier --check '**/*.{md,js}' 'src/**/*.{css,ts,tsx}'
Checking formatting...
All matched files use Prettier code style!
Done in 2.67s.

```
### What issues does this PR fix or reference?

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

### How to test this PR?

`cd website`
`yarn run`