### PR TITLE
feat: show docker version

### DIFF
--- a/extensions/docker/src/docker-cli.ts
+++ b/extensions/docker/src/docker-cli.ts
@@ -1,0 +1,61 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import * as extensionApi from '@podman-desktop/api';
+
+const macosExtraPath = '/usr/local/bin:/opt/homebrew/bin:/opt/local/bin';
+
+export function getInstallationPath(): string {
+  const env = process.env;
+  if (extensionApi.env.isMac) {
+    if (!env.PATH) {
+      return macosExtraPath;
+    } else {
+      return env.PATH.concat(':').concat(macosExtraPath);
+    }
+  } else {
+    return env.PATH;
+  }
+}
+
+export function getDockerCli(): string {
+  if (extensionApi.env.isWindows) {
+    return 'docker.exe';
+  }
+  return 'docker';
+}
+
+export interface InstalledDocker {
+  version: string;
+}
+
+export async function getDockerInstallation(): Promise<InstalledDocker | undefined> {
+  try {
+    let { stdout: versionOut } = await extensionApi.process.exec(getDockerCli(), ['--version']);
+    if (!versionOut.startsWith('Docker')) {
+      // could be the podman-docker wrapper script
+      return undefined;
+    }
+    versionOut = versionOut.replace(/, build .*$/, '');
+    const versionArr = versionOut.split(' ');
+    const version = versionArr[versionArr.length - 1];
+    return { version };
+  } catch (err) {
+    // no docker binary
+    return undefined;
+  }
+}


### PR DESCRIPTION

### What does this PR do?

Show the version of Docker CLI same as way as for Podman CLI.

In the future, they might be able to show the server version.

### Screenshot/screencast of this PR

![podman-desktop-dashboard-versions](https://github.com/containers/podman-desktop/assets/10364051/7f82f34a-600f-4a3f-83a9-50430a9194ca)

### What issues does this PR fix or reference?

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

### How to test this PR?

<!-- Please explain steps to reproduce -->
