### PR TITLE
chore: unify directories used by Podman Desktop and allow to override

### DIFF
--- a/packages/main/src/plugin/authentication.spec.ts
+++ b/packages/main/src/plugin/authentication.spec.ts
@@ -45,6 +45,7 @@ import type { Telemetry } from './telemetry/telemetry.js';
 import type { TrayMenuRegistry } from './tray-menu-registry.js';
 import type { Proxy } from './proxy.js';
 import type { IconRegistry } from './icon-registry.js';
+import type { Directories } from './directories.js';
 
 function randomNumber(n = 5) {
   return Math.round(Math.random() * 10 * n);
@@ -89,6 +90,12 @@ const apiSender: ApiSenderType = {
 };
 
 let authModule: AuthenticationImpl;
+
+const directories = {
+  getPluginsDirectory: () => '/fake-plugins-directory',
+  getPluginsScanDirectory: () => '/fake-plugins-scanning-directory',
+  getExtensionsStorageDirectory: () => '/fake-extensions-storage-directory',
+} as unknown as Directories;
 
 beforeEach(function () {
   authModule = new AuthenticationImpl(apiSender);
@@ -246,6 +253,7 @@ suite('Authentication', () => {
       authentication,
       vi.fn() as unknown as IconRegistry,
       vi.fn() as unknown as Telemetry,
+      directories,
     );
     providerMock = {
       onDidChangeSessions: vi.fn(),

--- a/packages/main/src/plugin/close-behavior.spec.ts
+++ b/packages/main/src/plugin/close-behavior.spec.ts
@@ -19,6 +19,7 @@ import { beforeEach, test, expect, vi } from 'vitest';
 import { CloseBehavior } from './close-behavior.js';
 import { ConfigurationRegistry } from './configuration-registry.js';
 import * as util from '../util.js';
+import type { Directories } from './directories.js';
 
 vi.mock('./util', () => {
   return {
@@ -30,7 +31,7 @@ let closeBehavior: CloseBehavior;
 let configurationRegistry: ConfigurationRegistry;
 
 beforeEach(() => {
-  configurationRegistry = new ConfigurationRegistry();
+  configurationRegistry = new ConfigurationRegistry({} as Directories);
   closeBehavior = new CloseBehavior(configurationRegistry);
 });
 

--- a/packages/main/src/plugin/configuration-registry.spec.ts
+++ b/packages/main/src/plugin/configuration-registry.spec.ts
@@ -16,21 +16,29 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
+import { beforeAll, describe, expect, test, vi } from 'vitest';
 import * as fs from 'node:fs';
 import type { IConfigurationNode } from './configuration-registry.js';
 import { ConfigurationRegistry } from './configuration-registry.js';
+import type { Directories } from './directories.js';
 
 let configurationRegistry: ConfigurationRegistry;
 
 // mock the fs methods
 const readFileSync = vi.spyOn(fs, 'readFileSync');
 
+const getConfigurationDirectoryMock = vi.fn();
+const directories = {
+  getConfigurationDirectory: getConfigurationDirectoryMock,
+} as unknown as Directories;
+
 beforeAll(() => {
   // mock the fs module
   vi.mock('node:fs');
 
-  configurationRegistry = new ConfigurationRegistry();
+  getConfigurationDirectoryMock.mockReturnValue('/my-config-dir');
+
+  configurationRegistry = new ConfigurationRegistry(directories);
   readFileSync.mockReturnValue(JSON.stringify({}));
 
   configurationRegistry.init();
@@ -49,10 +57,6 @@ beforeAll(() => {
   };
 
   configurationRegistry.registerConfigurations([node]);
-});
-
-beforeEach(() => {
-  vi.clearAllMocks();
 });
 
 describe('should be notified when a configuration is changed', async () => {

--- a/packages/main/src/plugin/configuration-registry.ts
+++ b/packages/main/src/plugin/configuration-registry.ts
@@ -17,14 +17,13 @@
  ***********************************************************************/
 
 import * as path from 'path';
-import * as os from 'os';
 import * as fs from 'fs';
 import type * as containerDesktopAPI from '@podman-desktop/api';
 import { ConfigurationImpl } from './configuration-impl.js';
 import type { Event } from './events/emitter.js';
 import { Emitter } from './events/emitter.js';
 import { CONFIGURATION_DEFAULT_SCOPE } from './configuration-registry-constants.js';
-import { desktopAppHomeDir } from '../util.js';
+import type { Directories } from './directories.js';
 
 export type IConfigurationPropertySchemaType =
   | 'markdown'
@@ -113,7 +112,7 @@ export class ConfigurationRegistry implements IConfigurationRegistry {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private configurationValues: Map<string, any>;
 
-  constructor() {
+  constructor(private directories: Directories) {
     this.configurationProperties = {};
     this.configurationContributors = [];
     this.configurationValues = new Map();
@@ -121,9 +120,8 @@ export class ConfigurationRegistry implements IConfigurationRegistry {
   }
 
   protected getSettingsFile(): string {
-    const configurationDirectory = path.resolve(os.homedir(), desktopAppHomeDir(), 'configuration');
     // create directory if it does not exist
-    return path.resolve(configurationDirectory, 'settings.json');
+    return path.resolve(this.directories.getConfigurationDirectory(), 'settings.json');
   }
 
   public init(): void {

--- a/packages/main/src/plugin/contribution-manager.ts
+++ b/packages/main/src/plugin/contribution-manager.ts
@@ -17,11 +17,10 @@
  ***********************************************************************/
 
 import * as path from 'node:path';
-import * as os from 'node:os';
 import * as fs from 'node:fs';
 import type { ContributionInfo } from './api/contribution-info.js';
-import { desktopAppHomeDir } from '../util.js';
 import type { ApiSenderType } from './api.js';
+import type { Directories } from './directories.js';
 
 /**
  * Contribution manager to provide the list of external OCI contributions
@@ -33,12 +32,12 @@ export class ContributionManager {
   private readonly EMPTY_ICON =
     'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxIiBoZWlnaHQ9IjEiLz4=';
 
-  constructor(private apiSender: ApiSenderType) {}
+  constructor(private apiSender: ApiSenderType, private directories: Directories) {}
 
   // load the existing contributions
   async init(): Promise<void> {
     // create directory if not there
-    const contributionsFolder = this.getContributionStorageDir();
+    const contributionsFolder = this.directories.getContributionStorageDir();
     if (!fs.existsSync(contributionsFolder)) {
       fs.mkdirSync(contributionsFolder);
     }
@@ -136,10 +135,6 @@ export class ContributionManager {
         },
       );
     });
-  }
-
-  public getContributionStorageDir(): string {
-    return path.resolve(os.homedir(), desktopAppHomeDir(), 'contributions');
   }
 
   getExtensionPath(extensionId: string): string | undefined {

--- a/packages/main/src/plugin/directories.spec.ts
+++ b/packages/main/src/plugin/directories.spec.ts
@@ -1,0 +1,80 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+import { Directories } from './directories.js';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+class TestDirectories extends Directories {
+  public getDesktopAppHomeDir(): string {
+    return this.desktopAppHomeDir;
+  }
+}
+
+let directories: TestDirectories;
+
+const originalProcessEnv = process.env;
+
+beforeEach(() => {
+  // mock the env variable
+  process.env = Object.assign({}, process.env);
+
+  // mock the fs module
+  vi.mock('node:fs');
+
+  // mock the existSync and mkdir methods
+  const existSyncSpy = vi.spyOn(fs, 'existsSync');
+  existSyncSpy.mockImplementation(() => true);
+
+  const mkdirSpy = vi.spyOn(fs, 'mkdirSync');
+  mkdirSpy.mockImplementation(() => Promise.resolve(''));
+});
+
+afterEach(() => {
+  process.env = originalProcessEnv;
+});
+
+test('should use default path', async () => {
+  directories = new TestDirectories();
+  const result = directories.getDesktopAppHomeDir();
+
+  // desktop app home dir should start with user's home dir
+  expect(result.startsWith(os.homedir())).toBeTruthy();
+
+  // should ends with the default path
+  expect(result.endsWith(Directories.XDG_DATA_DIRECTORY)).toBeTruthy();
+});
+
+test('should override default path', async () => {
+  const wantedDirectory = '/fake-directory';
+
+  // add the env variable
+  process.env[Directories.PODMAN_DESKTOP_HOME_DIR] = wantedDirectory;
+
+  directories = new TestDirectories();
+  const result = directories.getDesktopAppHomeDir();
+
+  // desktop app home dir should not start anymore with user's home dir
+  expect(result.startsWith(os.homedir())).toBeFalsy();
+
+  // should not ends with the default path
+  expect(result.endsWith(Directories.XDG_DATA_DIRECTORY)).toBeFalsy();
+
+  // should be the directory provided as env var
+  expect(result).toEqual(wantedDirectory);
+});

--- a/packages/main/src/plugin/directories.ts
+++ b/packages/main/src/plugin/directories.ts
@@ -1,0 +1,71 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import * as path from 'node:path';
+import * as os from 'node:os';
+import * as fs from 'node:fs';
+
+// handle the different directories for the different OSes for Podman Desktop
+export class Directories {
+  static readonly XDG_DATA_DIRECTORY = '.local/share/containers/podman-desktop';
+
+  public static readonly PODMAN_DESKTOP_HOME_DIR = 'PODMAN_DESKTOP_HOME_DIR';
+
+  private configurationDirectory: string;
+  private pluginsDirectory: string;
+  private pluginsScanDirectory: string;
+  private extensionsStorageDirectory: string;
+  private contributionStorageDirectory: string;
+  protected desktopAppHomeDir: string;
+
+  constructor() {
+    // read ENV VAR to override the Desktop App Home Dir
+    this.desktopAppHomeDir =
+      process.env[Directories.PODMAN_DESKTOP_HOME_DIR] || path.resolve(os.homedir(), Directories.XDG_DATA_DIRECTORY);
+
+    // create the Desktop App Home Dir if it does not exist
+    if (!fs.existsSync(this.desktopAppHomeDir)) {
+      fs.mkdirSync(this.desktopAppHomeDir, { recursive: true });
+    }
+    this.configurationDirectory = path.resolve(this.desktopAppHomeDir, 'configuration');
+    this.pluginsDirectory = path.resolve(this.desktopAppHomeDir, 'plugins');
+    this.pluginsScanDirectory = path.resolve(this.desktopAppHomeDir, 'plugins-scanning');
+    this.extensionsStorageDirectory = path.resolve(this.desktopAppHomeDir, 'extensions-storage');
+    this.contributionStorageDirectory = path.resolve(this.desktopAppHomeDir, 'contributions');
+  }
+
+  getConfigurationDirectory(): string {
+    return this.configurationDirectory;
+  }
+
+  getPluginsDirectory(): string {
+    return this.pluginsDirectory;
+  }
+
+  getPluginsScanDirectory(): string {
+    return this.pluginsScanDirectory;
+  }
+
+  getExtensionsStorageDirectory(): string {
+    return this.extensionsStorageDirectory;
+  }
+
+  public getContributionStorageDir(): string {
+    return this.contributionStorageDirectory;
+  }
+}

--- a/packages/main/src/plugin/docker-extension/docker-desktop-installation.ts
+++ b/packages/main/src/plugin/docker-extension/docker-desktop-installation.ts
@@ -28,12 +28,14 @@ import type Dockerode from 'dockerode';
 import type { PullEvent } from '../api/pull-event.js';
 import type { ContributionManager } from '../contribution-manager.js';
 import type { ApiSenderType } from '../api.js';
+import type { Directories } from '../directories.js';
 
 export class DockerDesktopInstallation {
   constructor(
     private apiSender: ApiSenderType,
     private containerRegistry: ContainerProviderRegistry,
     private contributionManager: ContributionManager,
+    private directories: Directories,
   ) {}
 
   async extractDockerDesktopFiles(
@@ -256,10 +258,7 @@ export class DockerDesktopInstallation {
           const tmpTarPath = path.join(os.tmpdir(), `${imageNameWithoutSpecialChars}-tmp.tar`);
 
           // final folder
-          const finalFolderPath = path.join(
-            this.contributionManager.getContributionStorageDir(),
-            imageNameWithoutSpecialChars,
-          );
+          const finalFolderPath = path.join(this.directories.getContributionStorageDir(), imageNameWithoutSpecialChars);
 
           reportLog('Grabbing image content...');
           await this.exportContentOfContainer(providerConnection, foundMatchingImage.Id, tmpTarPath);

--- a/packages/main/src/plugin/extension-loader.spec.ts
+++ b/packages/main/src/plugin/extension-loader.spec.ts
@@ -43,6 +43,7 @@ import type { MessageBox } from './message-box.js';
 import type { Telemetry } from './telemetry/telemetry.js';
 import type * as containerDesktopAPI from '@podman-desktop/api';
 import type { IconRegistry } from './icon-registry.js';
+import type { Directories } from './directories.js';
 
 class TestExtensionLoader extends ExtensionLoader {
   public async setupScanningDirectory(): Promise<void> {
@@ -103,6 +104,12 @@ const iconRegistry: IconRegistry = {} as unknown as IconRegistry;
 const telemetryTrackMock = vi.fn();
 const telemetry: Telemetry = { track: telemetryTrackMock } as unknown as Telemetry;
 
+const directories = {
+  getPluginsDirectory: () => '/fake-plugins-directory',
+  getPluginsScanDirectory: () => '/fake-plugins-scanning-directory',
+  getExtensionsStorageDirectory: () => '/fake-extensions-storage-directory',
+} as unknown as Directories;
+
 /* eslint-disable @typescript-eslint/no-empty-function */
 beforeAll(() => {
   extensionLoader = new TestExtensionLoader(
@@ -125,6 +132,7 @@ beforeAll(() => {
     authenticationProviderRegistry,
     iconRegistry,
     telemetry,
+    directories,
   );
 });
 

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -18,7 +18,6 @@
 
 import type * as containerDesktopAPI from '@podman-desktop/api';
 import * as path from 'path';
-import * as os from 'os';
 import * as fs from 'fs';
 import type { CommandRegistry } from './command-registry.js';
 import type { ExtensionError, ExtensionInfo, ExtensionUpdateInfo } from './api/extension-info.js';
@@ -47,7 +46,6 @@ import type { ContainerProviderRegistry } from './container-registry.js';
 import type { InputQuickPickRegistry } from './input-quickpick/input-quickpick-registry.js';
 import { QuickPickItemKind, InputBoxValidationSeverity } from './input-quickpick/input-quickpick-registry.js';
 import type { MenuRegistry } from '/@/plugin/menu-registry.js';
-import { desktopAppHomeDir } from '../util.js';
 import { Emitter } from './events/emitter.js';
 import { CancellationTokenSource } from './cancellation-token.js';
 import type { ApiSenderType } from './api.js';
@@ -57,6 +55,7 @@ import { TelemetryTrustedValue } from './types/telemetry.js';
 import { clipboard as electronClipboard } from 'electron';
 import { securityRestrictionCurrentHandler } from '../security-restrictions-handler.js';
 import type { IconRegistry } from './icon-registry.js';
+import type { Directories } from './directories.js';
 
 /**
  * Handle the loading of an extension
@@ -105,11 +104,11 @@ export class ExtensionLoader {
   protected watchTimeout = 1000;
 
   // Plugins directory location
-  private pluginsDirectory = path.resolve(os.homedir(), desktopAppHomeDir(), 'plugins');
-  protected pluginsScanDirectory = path.resolve(os.homedir(), desktopAppHomeDir(), 'plugins-scanning');
+  private pluginsDirectory;
+  protected pluginsScanDirectory;
 
   // Extensions directory location
-  private extensionsStorageDirectory = path.resolve(os.homedir(), desktopAppHomeDir(), 'extensions-storage');
+  private extensionsStorageDirectory;
 
   constructor(
     private commandRegistry: CommandRegistry,
@@ -131,7 +130,12 @@ export class ExtensionLoader {
     private authenticationProviderRegistry: AuthenticationImpl,
     private iconRegistry: IconRegistry,
     private telemetry: Telemetry,
-  ) {}
+    directories: Directories,
+  ) {
+    this.pluginsDirectory = directories.getPluginsDirectory();
+    this.pluginsScanDirectory = directories.getPluginsScanDirectory();
+    this.extensionsStorageDirectory = directories.getExtensionsStorageDirectory();
+  }
 
   mapError(err: unknown): ExtensionError | undefined {
     if (err) {

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -108,6 +108,7 @@ import { ExtensionsUpdater } from './extensions-updater/extensions-updater.js';
 import type { CatalogExtension } from './extensions-catalog/extensions-catalog-api.js';
 import { IconRegistry } from './icon-registry.js';
 import type { IconInfo } from './api/icon-info.js';
+import { Directories } from './directories.js';
 
 type LogType = 'log' | 'warn' | 'trace' | 'debug' | 'error';
 
@@ -345,8 +346,9 @@ export class PluginSystem {
     const apiSender = this.getApiSender(this.getWebContentsSender());
 
     const iconRegistry = new IconRegistry(apiSender);
+    const directories = new Directories();
 
-    const configurationRegistry = new ConfigurationRegistry();
+    const configurationRegistry = new ConfigurationRegistry(directories);
     configurationRegistry.init();
 
     const telemetry = new Telemetry(configurationRegistry);
@@ -658,6 +660,7 @@ export class PluginSystem {
       authentication,
       iconRegistry,
       telemetry,
+      directories,
     );
     await this.extensionLoader.init();
 
@@ -671,7 +674,7 @@ export class PluginSystem {
     // setup security restrictions on links
     await this.setupSecurityRestrictionsOnLinks(messageBox);
 
-    const contributionManager = new ContributionManager(apiSender);
+    const contributionManager = new ContributionManager(apiSender, directories);
     this.ipcHandle('container-provider-registry:listContainers', async (): Promise<ContainerInfo[]> => {
       return containerProviderRegistry.listContainers();
     });
@@ -1640,6 +1643,7 @@ export class PluginSystem {
       apiSender,
       containerProviderRegistry,
       contributionManager,
+      directories,
     );
     await dockerDesktopInstallation.init();
 

--- a/packages/main/src/util.ts
+++ b/packages/main/src/util.ts
@@ -31,11 +31,6 @@ const linux = os.platform() === 'linux';
 export function isLinux(): boolean {
   return linux;
 }
-const xdgDataDirectory = '.local/share/containers';
-export function desktopAppHomeDir(): string {
-  return xdgDataDirectory + '/podman-desktop';
-}
-
 export function findWindow(): Electron.BrowserWindow | undefined {
   return BrowserWindow.getAllWindows().find(w => !w.isDestroyed());
 }


### PR DESCRIPTION

### What does this PR do?
unify directories used by Podman Desktop and allow to override
Default path can be overrided to setup all folders in an alternate folder
It will be used for https://github.com/containers/podman-desktop/issues/2837


### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

#2837 

### How to test this PR?

Everything should work as before (extensions should be still there, same configuration, etc)
added unit tests