### PR TITLE
tests: add e2e test for pulling the podman hello image

### DIFF
--- a/tests/src/e2e.pull-the-podman-hello-image.spec.ts
+++ b/tests/src/e2e.pull-the-podman-hello-image.spec.ts
@@ -1,0 +1,123 @@
+import type { ElectronApplication, Page } from 'playwright';
+import { _electron as electron } from 'playwright';
+import { afterAll, beforeAll, test, describe } from 'vitest';
+import { existsSync } from 'node:fs';
+import { rm } from 'node:fs/promises';
+
+const outputDir = 'tests/output/pull-the-podman-hello-image/';
+let electronApp: ElectronApplication;
+let page: Page;
+
+beforeAll(async () => {
+  // remove all videos/screenshots
+  if (existsSync(outputDir)) {
+    console.log('Cleaning up output folder...');
+    await rm(outputDir, { recursive: true, force: true });
+  }
+
+  electronApp = await electron.launch({
+    args: ['.'],
+    recordVideo: {
+      dir: outputDir,
+      size: {
+        width: 1050,
+        height: 700,
+      },
+    },
+  });
+
+  page = await electronApp.firstWindow();
+});
+
+afterAll(async () => {
+  await electronApp.close();
+});
+
+describe('Pulling the quay.io/podman/hello image', async () => {
+  test('Go to Images', async () => {
+    const goToImages = page.getByLabel('Images');
+    await goToImages.waitFor({ state: 'visible' });
+    await page.screenshot({ path: outputDir + 'screenshot-dashboard.png', fullPage: true });
+    await goToImages.click();
+  });
+
+  test('Click Pull an image', async () => {
+    const clickPullAnImage = page.getByRole('button', { name: 'Pull an Image' });
+    await clickPullAnImage.waitFor({ state: 'visible' });
+    await page.screenshot({ path: outputDir + 'screenshot-images.png', fullPage: true });
+    await clickPullAnImage.click();
+  });
+
+  test('Image to pull: enter quay.io/podman/hello', async () => {
+    const imageToPull = page.getByLabel('imageName');
+    await imageToPull.waitFor({ state: 'visible' });
+    await page.screenshot({ path: outputDir + 'screenshot-pull-image-from-a-registry.png', fullPage: true });
+    await imageToPull.fill('quay.io/podman/hello');
+  });
+
+  test('Click **Pull image**', async () => {
+    const clickPullImage = page.getByRole('button', { name: 'Pull image' });
+    await clickPullImage.waitFor({ state: 'visible' });
+    await page.screenshot({
+      path: outputDir + 'screenshot-pull-quay-io-podman-hello-image-from-a-registry.png',
+      fullPage: true,
+    });
+    await clickPullImage.click();
+  });
+
+  test('Click **Done**', async () => {
+    const clickDone = page.getByRole('button', { name: 'Done' });
+    await clickDone.waitFor({ state: 'visible' });
+    await page.screenshot({
+      path: outputDir + 'screenshot-pull-quay-io-podman-hello-image-from-a-registry.png',
+      fullPage: true,
+    });
+    await clickDone.click();
+  });
+
+  test('Go to **Images**', async () => {
+    const goToImages = page.getByRole('heading', { level: 1, name: 'images' });
+    await goToImages.waitFor({ state: 'visible' });
+  });
+
+  test('Search: enter quay.io/podman/hello', async () => {
+    const imageToSearch = page.getByPlaceholder('Search Images');
+    await imageToSearch.waitFor({ state: 'visible' });
+    await page.screenshot({ path: outputDir + 'screenshot-images-pulled.png', fullPage: true });
+    await imageToSearch.fill('quay.io/podman/hello');
+  });
+
+  test('Click quay.io/podman/hello in the results table', async () => {
+    const imageToClick = page.getByText('quay.io/podman/hello').last();
+    await imageToClick.waitFor({ state: 'visible' });
+    await page.screenshot({ path: outputDir + 'screenshot-images-found-quay-io-podman-hello.png', fullPage: true });
+    await imageToClick.click();
+  });
+
+  test('Go to Summary', async () => {
+    const goToSummary = page.getByText('Summary').first();
+    await goToSummary.waitFor({ state: 'visible' });
+    await page.screenshot({ path: outputDir + 'screenshot-image-details-summary.png', fullPage: true });
+    await goToSummary.click();
+  });
+
+  test('Go to History', async () => {
+    const goToHistory = page.getByText('History').first();
+    await goToHistory.waitFor({ state: 'visible' });
+    await page.screenshot({ path: outputDir + 'screenshot-image-details-summary.png', fullPage: true });
+    await goToHistory.click();
+  });
+
+  test('Go to Inspect', async () => {
+    const goToInspect = page.getByText('Inspect').first();
+    await goToInspect.waitFor({ state: 'visible' });
+    await page.screenshot({ path: outputDir + 'screenshot-image-details-summary.png', fullPage: true });
+    await goToInspect.click();
+  });
+
+  test('Last screenshot', async () => {
+    const goToInspect = page.getByText('Inspect').first();
+    await goToInspect.waitFor({ state: 'visible' });
+    await page.screenshot({ path: outputDir + 'screenshot-image-details-inspect.png', fullPage: true });
+  });
+});


### PR DESCRIPTION
### What does this PR do?

feat: added e2e test for pulling the podman hello image.

I tried to stay as close as possible to the documentation at https://podman-desktop.io/docs/getting-started/pulling-an-image as a mean to test also that the docs stay accurate.

Meaning:

1. The tests are using visible elements that are described in the docs rather than structural elements invisible to the user.
2. Tests will fail when the visible elements change, and the documentation needs an update.

The tests are also generating screenshots and videos that we could use for the docs (later).

### Screenshot/screencast of this PR


### What issues does this PR fix or reference?



### How to test this PR?

1. Test is passing:

```
$ xvfb-maybe  vitest run tests/src/e2e.pull-the-podman-hello-image.spec.ts

RUN  v0.32.2 /home/ffloreth/src/gh/themr0c/podman-desktop

stdout | unknown test
Cleaning up output folder...

 ✓ tests/src/e2e.pull-the-podman-hello-image.spec.ts (12) 29690ms

 Test Files  1 passed (1)
      Tests  12 passed (12)
   Start at  14:56:05
   Duration  33.24s (transform 318ms, setup 0ms, collect 510ms, tests 29.69s, environment 779ms, prepare 508ms)
```

3. Screenshots and videos of the test results are generated in the `tests/output/pull-the-podman-hello-image/ directory.

```
ls tests/output/pull-the-podman-hello-image/ -1
3f3f326725e509b3dd29aa016e94fa02.webm
60963c839fb2d19febe5d1e7bd8139b9.webm
screenshot-dashboard.png
screenshot-image-details-inspect.png
screenshot-image-details-summary.png
screenshot-images-found-quay-io-podman-hello.png
screenshot-images.png
screenshot-images-pulled.png
screenshot-pull-image-from-a-registry.png
screenshot-pull-quay-io-podman-hello-image-from-a-registry.png
```

