### PR TITLE
test: override configuration directory

### DIFF
--- a/tests/src/e2e.spec.ts
+++ b/tests/src/e2e.spec.ts
@@ -17,8 +17,12 @@ beforeAll(async () => {
     await rm('tests/output', { recursive: true, force: true });
   }
 
+  const env: { [key: string]: string } = Object.assign({}, process.env as { [key: string]: string });
+  env.PODMAN_DESKTOP_HOME_DIR = 'tests/output/podman-desktop';
+
   electronApp = await electron.launch({
     args: ['.'],
+    env,
     recordVideo: {
       dir: 'tests/output/videos',
       size: {


### PR DESCRIPTION
### What does this PR do?
Avoid to clean things before running tests as a separate configuration folder is always used

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/2837

### How to test this PR?

lauch e2e tests without cleaning conf folder and launch again, they should always work