### PR TITLE
chore: add descriptions for kind and podman

### DIFF
--- a/extensions/kind/src/extension.ts
+++ b/extensions/kind/src/extension.ts
@@ -185,7 +185,7 @@ async function createProvider(
   extensionContext: extensionApi.ExtensionContext,
   telemetryLogger: extensionApi.TelemetryLogger,
 ): Promise<void> {
-  const provider = extensionApi.provider.createProvider({
+  const providerOptions: extensionApi.ProviderOptions = {
     name: 'Kind',
     id: 'kind',
     status: 'unknown',
@@ -196,7 +196,14 @@ async function createProvider(
         light: './logo-light.png',
       },
     },
-  });
+  };
+
+  // Empty connection descriptive message
+  providerOptions.emptyConnectionMarkdownDescription = `
+  Kind is a Kubernetes utility for running local clusters using single-container "nodes", providing an easy way to create and manage Kubernetes environments for development and testing.\n\nMore information: [kind.sigs.k8s.io](https://kind.sigs.k8s.io/)`;
+
+  const provider = extensionApi.provider.createProvider(providerOptions);
+
   extensionContext.subscriptions.push(provider);
   await registerProvider(extensionContext, provider, telemetryLogger);
   extensionContext.subscriptions.push(

--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -587,6 +587,10 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
     logo: './logo.png',
   };
 
+  // Empty connection descriptive message
+  providerOptions.emptyConnectionMarkdownDescription =
+    'Podman is a lightweight, open-source container runtime and image management tool that enables users to run and manage containers without the need for a separate daemon.\n\nMore information: [podman.io](https://podman.io/)';
+
   const corePodmanEngineLinkGroup = 'Core Podman Engine';
 
   // add links


### PR DESCRIPTION
chore: add descriptions for kind and podman

### What does this PR do?

* Adds descriptions for empty connections for both kind and podman.

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

![Screenshot 2023-06-26 at 12 44 42 PM](https://github.com/containers/podman-desktop/assets/6422176/29c4ba43-14a7-4951-ba72-34ced44c3854)


### What issues does this PR fix or reference?

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

Closes https://github.com/containers/podman-desktop/issues/2839

### How to test this PR?

`yarn watch`

Look at Settings -> Resources

<!-- Please explain steps to reproduce -->

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
