### PR TITLE
fix: keep stdout and stderr in the error object for Docker Desktop extensions

### DIFF
--- a/packages/main/src/plugin/docker-extension/docker-plugin-adapter.ts
+++ b/packages/main/src/plugin/docker-extension/docker-plugin-adapter.ts
@@ -106,6 +106,10 @@ export class DockerPluginAdapter {
           spawnProcess.on('error', error => {
             execResult.killed = true;
             execResult.signal = error.toString();
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (error as any).stderr = execResult.stderr;
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (error as any).stdout = execResult.stdout;
             resolve(error);
           });
         });

--- a/packages/preload-docker-extension/src/index.ts
+++ b/packages/preload-docker-extension/src/index.ts
@@ -85,11 +85,9 @@ export class DockerExtensionPreload {
       execOptions,
     );
     if (rawResult.error) {
-      const error: any = { toString: () => rawResult.stderr };
-      error.stderr = rawResult.stderr;
-      error.stdout = rawResult.stdout;
-      throw error;
+      throw rawResult.error;
     }
+
     if (rawResult.code !== 0) {
       const error: any = { toString: () => rawResult.stderr };
       error.stderr = rawResult.stderr;

--- a/packages/preload-docker-extension/src/index.ts
+++ b/packages/preload-docker-extension/src/index.ts
@@ -84,9 +84,6 @@ export class DockerExtensionPreload {
       _args,
       execOptions,
     );
-    if (rawResult.error) {
-      throw rawResult.error;
-    }
 
     if (rawResult.code !== 0) {
       const error: any = { toString: () => rawResult.stderr };

--- a/packages/preload-docker-extension/src/index.ts
+++ b/packages/preload-docker-extension/src/index.ts
@@ -85,10 +85,16 @@ export class DockerExtensionPreload {
       execOptions,
     );
     if (rawResult.error) {
-      throw new Error(rawResult.error);
+      const error: any = { toString: () => rawResult.stderr };
+      error.stderr = rawResult.stderr;
+      error.stdout = rawResult.stdout;
+      throw error;
     }
     if (rawResult.code !== 0) {
-      throw new Error(`Command failed: ${rawResult.stderr}`);
+      const error: any = { toString: () => rawResult.stderr };
+      error.stderr = rawResult.stderr;
+      error.stdout = rawResult.stdout;
+      throw error;
     }
 
     const execResult: dockerDesktopAPI.ExecResult = rawResult;


### PR DESCRIPTION

### What does this PR do?
Keep stdout ad stderr in the error object for Docker Desktop extensions
it looks like some extensions expect to find it

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop/issues/3017

### How to test this PR?

<!-- Please explain steps to reproduce -->
