### PR TITLE
fix: interpret arguments given to info command for example

### DIFF
--- a/packages/main/src/plugin/docker-extension/docker-plugin-adapter.ts
+++ b/packages/main/src/plugin/docker-extension/docker-plugin-adapter.ts
@@ -84,7 +84,7 @@ export class DockerPluginAdapter {
             updatedArgs = args;
           }
 
-          const spawnProcess = spawn(updatedCommand, updatedArgs, { env });
+          const spawnProcess = spawn(updatedCommand, updatedArgs, { env, shell: true });
           spawnProcess.stdout.setEncoding('utf8');
           spawnProcess.stdout.on('data', data => {
             execResult.stdout += data;


### PR DESCRIPTION
### What does this PR do?
Plug-ins provide arguments using quotes etc that need to be interpreted for the format expression so it doesn't return a quoted json response like '<my-value />'

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop/issues/3017

### How to test this PR?

<!-- Please explain steps to reproduce -->
