### PR TITLE
fix: mark task completed if there's a failure

### DIFF
--- a/packages/renderer/src/lib/image/build-image-task.ts
+++ b/packages/renderer/src/lib/image/build-image-task.ts
@@ -159,6 +159,7 @@ export function eventCollect(key: symbol, eventName: 'finish' | 'stream' | 'erro
   if (task) {
     if (eventName === 'error') {
       task.status = 'failure';
+      task.state = 'completed';
     } else if (eventName === 'finish') {
       if (task.status !== 'failure') {
         task.status = 'success';

--- a/packages/renderer/src/lib/preferences/preferences-connection-rendering-task.ts
+++ b/packages/renderer/src/lib/preferences/preferences-connection-rendering-task.ts
@@ -167,6 +167,7 @@ export function eventCollect(key: symbol, eventName: 'log' | 'warn' | 'error' | 
     if (eventName === 'error') {
       task.status = 'failure';
       task.error = args.join('\n');
+      task.state = 'completed';
     } else if (eventName === 'finish') {
       if (task.status !== 'failure') {
         task.status = 'success';


### PR DESCRIPTION
### What does this PR do?

If there's a failure (e.g.) creating a Podman machine, the task is never marked complete and so it stays running forever and can't be removed from the Tasks list. This just marks it as complete in this path.

### Screenshot/screencast of this PR

A task run before (top) and after (bottom) this change. Clicking clear will only remove the bottom one:
<img width="321" alt="Screenshot 2023-06-26 at 3 36 04 PM" src="https://github.com/containers/podman-desktop/assets/19958075/7c818d56-8e80-4e88-9391-2a4975e96fe5">

### What issues does this PR fix or reference?

Fixes #2587.

### How to test this PR?

Any failure to create a provider instance will do, but the easiest is to create two Podman machines, start one, then try to start the other.