### PR TITLE
feat: propose indexed name for new pod

### DIFF
--- a/packages/renderer/src/lib/pod/pod-utils.spec.ts
+++ b/packages/renderer/src/lib/pod/pod-utils.spec.ts
@@ -19,7 +19,8 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import { test, expect } from 'vitest';
-import { ensureRestrictedSecurityContext } from '/@/lib/pod/pod-utils';
+import { ensureRestrictedSecurityContext, PodUtils } from '/@/lib/pod/pod-utils';
+import type { PodInfo } from '../../../../main/src/plugin/api/pod-info';
 
 function verifyPodSecurityContext(containers: any[], type = 'RuntimeDefault') {
   containers.forEach(container => {
@@ -78,4 +79,32 @@ test('Expect security context to be added to dual containers pod', async () => {
   };
   ensureRestrictedSecurityContext(pod);
   verifyPodSecurityContext(pod.spec.containers);
+});
+
+test('Expect return a valid name for a new pod', () => {
+  const podUtils = new PodUtils();
+  const newPodName = podUtils.calculateNewPodName();
+
+  expect(newPodName).toBe('my-pod');
+});
+
+test('Expect return a valid name for a new pod if there is a pod with the same name', () => {
+  const podUtils = new PodUtils();
+  const newPodName = podUtils.calculateNewPodName([{ Name: 'my-pod' } as PodInfo]);
+
+  expect(newPodName).toBe('my-pod-1');
+});
+
+test('Expect return a valid name for a new pod if there is a pods with different names', () => {
+  const podUtils = new PodUtils();
+  const newPodName = podUtils.calculateNewPodName([{ Name: 'my-super-pod' } as PodInfo]);
+
+  expect(newPodName).toBe('my-pod');
+});
+
+test('Expect return a valid name for a new pod if there are pods with the same name', () => {
+  const podUtils = new PodUtils();
+  const newPodName = podUtils.calculateNewPodName([{ Name: 'my-pod' } as PodInfo, { Name: 'my-pod-1' } as PodInfo]);
+
+  expect(newPodName).toBe('my-pod-2');
 });

--- a/packages/renderer/src/lib/pod/pod-utils.ts
+++ b/packages/renderer/src/lib/pod/pod-utils.ts
@@ -64,6 +64,28 @@ export class PodUtils {
       kind: podinfo.kind,
     };
   }
+
+  calculateNewPodName(existedPods?: PodInfo[]) {
+    const proposedPodName = 'my-pod';
+
+    if (!existedPods) {
+      return proposedPodName;
+    }
+
+    const existedNames = existedPods.map(pod => pod.Name);
+
+    if (!existedNames.includes(proposedPodName)) {
+      return proposedPodName;
+    } else {
+      let count = 1;
+      let uniqueName = `${proposedPodName}-${count}`;
+      while (existedNames.includes(uniqueName)) {
+        count++;
+        uniqueName = `${proposedPodName}-${count}`;
+      }
+      return uniqueName;
+    }
+  }
 }
 
 // eslint-disable-next-line  @typescript-eslint/no-explicit-any


### PR DESCRIPTION
### What does this PR do?

Current changes proposal adds an ability to generate a new name for pod if the current one is busy and registered.
In a few words, if there is a pod with name `my-pod`, the new pod name will be `my-pod-1`, `my-pod-2`, etc.

### Screenshot/screencast of this PR

![ScreenFlow](https://github.com/containers/podman-desktop/assets/1968177/142015f0-545c-4d03-96f3-0c49b33fbc67)

### What issues does this PR fix or reference?

#2278 

### How to test this PR?

Create a pod with default name. Then open "create a new pod" page again and you should see that there is a different pod name proposed.
