### PR TITLE
fix: don't show exception to user

### DIFF
--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -774,6 +774,9 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
       args = ['--host', 'podman', ...args];
     }
     const podmanProcess = spawn(command, args);
+    podmanProcess.on('error', err => {
+      console.error('Failed to spawn process.', err);
+    });
 
     // check for up to 5s to see if the socket is being made available
     const socketPath = getLinuxSocketPath();


### PR DESCRIPTION
### What does this PR do?


There is already a nice explanation on why the detection failed, so no need to show an exception dialog about failing to start it.

### Screenshot/screencast of this PR

![Screenshot from 2023-06-27 17-31-44](https://github.com/containers/podman-desktop/assets/10364051/a64c955b-6461-4ca4-938b-20de525e7ebe)

### What issues does this PR fix or reference?

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

### How to test this PR?

On Linux: Don't install `podman` in the PATH, or only install `podman-remote`. Run Podman Desktop.

The error is posted in the console log, and the interface shows that podman could not be detected:

<img alt="podman-missing" src="https://github.com/containers/podman-desktop/assets/10364051/14147fd7-9036-4486-90ac-fc0c682b755c" width="600" />

```
[podman] Failed to spawn process. Error: spawn podman ENOENT
    at ChildProcess._handle.onexit (node:internal/child_process:283:19)
    at onErrorNT (node:internal/child_process:476:16)
    at process.processTicksAndRejections (node:internal/process/task_queues:82:21) {
  errno: -2,
  code: 'ENOENT',
  syscall: 'spawn podman',
  path: 'podman',
  spawnargs: [ 'system', 'service', '--time=0' ]
}
```

----

Installing (**and** starting, preferrably!) Podman Engine needs to be done, _before_ starting the application.

* #2903

```
    sudo yum install -y podman

    systemctl --user enable podman.socket
    systemctl --user start podman.socket

    sudo loginctl enable-linger $USER
```
