### PR TITLE
chore: consistent image between containers and images for empty screen

### DIFF
--- a/packages/renderer/src/lib/image/ImageEmptyScreen.svelte
+++ b/packages/renderer/src/lib/image/ImageEmptyScreen.svelte
@@ -7,4 +7,4 @@ import ImageIcon from '../images/ImageIcon.svelte';
   icon="{ImageIcon}"
   title="No images"
   message="Pull a first image using the following command line:"
-  commandline="podman pull redhat/ubi8-micro" />
+  commandline="podman pull quay.io/podman/hello" />


### PR DESCRIPTION
### What does this PR do?
We're using two different set of images in container list and image list

Should stick to one example for the image, the hello world

### Screenshot/screencast of this PR

![image](https://github.com/containers/podman-desktop/assets/436777/448c6c6a-1420-4b57-97b3-780b86133c25)


### What issues does this PR fix or reference?

reported by @cfergeau 

### How to test this PR?

Go to images page (without any images in the container engine)
Ensure 'quay.io/podman/hello' is displayed
click on the copy to dashboard link and paste it on a terminal

image should be pulled

Signed-off-by: Florent Benoit <fbenoit@redhat.com>
