### PR TITLE
feat: Reports warnings on failed kube deploy, fixes error out

### DIFF
--- a/packages/renderer/src/lib/kube/KubePlayYAML.spec.ts
+++ b/packages/renderer/src/lib/kube/KubePlayYAML.spec.ts
@@ -1,0 +1,142 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom';
+import { test, expect, vi } from 'vitest';
+import { providerInfos } from '../../stores/providers';
+import { render, screen } from '@testing-library/svelte';
+import KubePlayYAML from './KubePlayYAML.svelte';
+import type { ProviderStatus } from '@podman-desktop/api';
+import type { ProviderContainerConnectionInfo } from '../../../../main/src/plugin/api/provider-info';
+import userEvent from '@testing-library/user-event';
+import type { PlayKubeInfo } from '../../../../main/src/plugin/dockerode/libpod-dockerode';
+
+const mockedErroredPlayKubeInfo: PlayKubeInfo = {
+  Pods: [
+    {
+      ContainerErrors: ['error 1', 'error 2'],
+      Containers: ['container 1', 'container 2'],
+      Id: 'pod-id',
+      InitContainers: ['init-container 1', 'init-container 2'],
+      Logs: ['log 1', 'log 2'],
+    },
+  ],
+  RmReport: [
+    {
+      Err: 'rm error',
+      Id: 'rm-id',
+    },
+  ],
+  Secrets: [
+    {
+      CreateReport: {
+        ID: 'secret-id',
+      },
+    },
+  ],
+  StopReport: [
+    {
+      Err: 'stop error',
+      Id: 'stop-id',
+    },
+  ],
+  Volumes: [
+    {
+      Name: 'volume 1',
+    },
+    {
+      Name: 'volume 2',
+    },
+  ],
+};
+
+// fake the window.events object
+beforeAll(() => {
+  (window.events as unknown) = {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    receive: (_channel: string, func: any) => {
+      func();
+    },
+  };
+  (window as any).getConfigurationValue = vi.fn();
+  (window as any).matchMedia = vi.fn().mockReturnValue({
+    addListener: vi.fn(),
+  });
+  (window as any).openFileDialog = vi.fn().mockResolvedValue({ canceled: false, filePaths: ['Containerfile'] });
+  (window as any).telemetryPage = vi.fn();
+  (window as any).kubernetesGetCurrentContextName = vi.fn();
+  (window as any).kubernetesGetCurrentNamespace = vi.fn();
+  (window as any).kubernetesListNamespaces = vi.fn();
+});
+
+function setup() {
+  const pStatus: ProviderStatus = 'started';
+  const pInfo: ProviderContainerConnectionInfo = {
+    name: 'test',
+    status: 'started',
+    endpoint: {
+      socketPath: '',
+    },
+    type: 'podman',
+  };
+  const providerInfo = {
+    id: 'test',
+    internalId: 'id',
+    name: '',
+    containerConnections: [pInfo],
+    kubernetesConnections: undefined,
+    status: pStatus,
+    containerProviderConnectionCreation: false,
+    containerProviderConnectionInitialization: false,
+    kubernetesProviderConnectionCreation: false,
+    kubernetesProviderConnectionInitialization: false,
+    links: undefined,
+    detectionChecks: undefined,
+    warnings: undefined,
+    images: undefined,
+    installationSupport: undefined,
+  };
+  providerInfos.set([providerInfo]);
+}
+
+test('error: When pressing the Play button, expect us to show the errors to the user', async () => {
+  (window as any).playKube = vi.fn().mockResolvedValue(mockedErroredPlayKubeInfo);
+
+  // Render the component
+  setup();
+  render(KubePlayYAML, {});
+
+  // Simulate selecting a file
+  const fileInput = screen.getByRole('textbox', { name: 'Kubernetes YAML file' });
+  expect(fileInput).toBeInTheDocument();
+  await userEvent.click(fileInput);
+
+  // Simulate selecting a runtime
+  const runtimeOption = screen.getByText('Using a Podman container engine');
+  expect(runtimeOption).toBeInTheDocument();
+
+  // Simulate clicking the "Play" button
+  const playButton = screen.getByRole('button', { name: 'Play' });
+  expect(playButton).toBeInTheDocument();
+  await userEvent.click(playButton);
+
+  // Since we error out with the mocked kubePlay function (see very top of tests)
+  // Expect the following error to be in in the document.
+  const error = screen.getByText('The following pods were created but failed to start: error 1, error 2');
+  expect(error).toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/kube/KubePlayYAML.svelte
+++ b/packages/renderer/src/lib/kube/KubePlayYAML.svelte
@@ -69,7 +69,11 @@ async function playKubeFile(): Promise<void> {
         // but if failed to start. We will add this to the "warning" section as we were able to create the
         // We add this with comma deliminated errors
         if (playKubeResultJSON.Pods.length > 0) {
-          const containerErrors = playKubeResultJSON.Pods.filter(pod => pod.ContainerErrors.length > 0);
+          // Filter out the pods that have container errors, but check to see that container errors exists first
+          const containerErrors = playKubeResultJSON.Pods.filter(
+            pod => pod.ContainerErrors && pod.ContainerErrors.length > 0,
+          );
+
           // For each Pod that has container errors, we will add the container errors to the warning message
           if (containerErrors.length > 0) {
             runWarning = `The following pods were created but failed to start: ${containerErrors


### PR DESCRIPTION
feat: Reports warnings on failed kube deploy, fixes error out

### What does this PR do?

This updates the Play Kubernetes YAML section similar to the output of "Deploy to Kubernetes".

* Reports warnings when encountering container errors when using Play
  Kubernetes
* Fixes the error / warning output that was not appearing correctly.

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

https://github.com/containers/podman-desktop/assets/6422176/3d7a2a1a-68c6-4623-9470-ec2b74cad682




### What issues does this PR fix or reference?

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

Closes https://github.com/containers/podman-desktop/issues/2621
Closes https://github.com/containers/podman-desktop/issues/3033

### How to test this PR?

1. Press Play Kubernetes
2. Use the following YAML:

```
# Save the output of this file and use kubectl create -f to import
# it into Kubernetes.
#
# Created with podman-4.5.1
apiVersion: v1
kind: Pod
metadata:
  annotations:
    io.podman.annotations.ulimit: nofile=524288:524288,nproc=7248:7248
  creationTimestamp: "2023-06-27T17:47:37Z"
  labels:
    app: reverentrobinson-pod
  name: reverentrobinson-pod
spec:
  containers:
  - image: docker.io/cdrage/helloworld:latest
    name: reverentrobinson
    ports:
    - containerPort: 80
      hostPort: 9000
    tty: true
```
3. Should appear correctly.
4. Try deploying again / you'll now get the correct erroring / warning.

<!-- Please explain steps to reproduce -->

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
