### PR TITLE
docs: lima is not a container engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ Check the downloads page on [podman-desktop.io/downloads](https://podman-desktop
 
 - [Podman container engine](https://github.com/containers/podman)
 - [crc](https://github.com/code-ready/crc)
-- [Podman Lima machines](https://github.com/lima-vm/lima)
-- [Docker](https://github.com/moby/moby)
+- [Lima virtual machines](https://github.com/lima-vm/lima)
+- [Docker container engine](https://github.com/moby/moby)
 
 #### Podman engine update support
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Check the downloads page on [podman-desktop.io/downloads](https://podman-desktop
 - [Podman container engine](https://github.com/containers/podman)
 - [crc](https://github.com/code-ready/crc)
 - [Lima virtual machines](https://github.com/lima-vm/lima)
-- [Docker container engine](https://github.com/moby/moby)
+- [Docker container engine](https://github.com/docker/docker)
 
 #### Podman engine update support
 

--- a/website/docs/extensions/index.md
+++ b/website/docs/extensions/index.md
@@ -10,7 +10,8 @@ tags: [migrating-to-kubernetes]
 
 Podman Desktop extensions contribute to:
 
-- Container engine support, such as Podman, Docker, Lima.
+- Container engine support, such as Podman, Docker.
+- Virtual machine support, such as Lima.
 - Podman Desktop extension points such as tray icon menu, status bar items, icons, menus, and commands.
 - Integration with third parties tools, such as Kind or Compose.
 

--- a/website/src/pages/extend/index.tsx
+++ b/website/src/pages/extend/index.tsx
@@ -45,7 +45,7 @@ export default function Home(): JSX.Element {
             </h1>
             <p>Podman Desktop is using plug-ins under the hood to manage the different container engine.</p>
             <p>By adding a new plugin, you can extend the capabilities of Podman Desktop.</p>
-            <p>For example plug a new container Engine likes Podman, Docker, Lima, etc.</p>
+            <p>For example plug a new container engine like Podman, Docker, or use Lima.</p>
 
             <ThemedImage
               className="py-4"

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -299,7 +299,7 @@ function Configure() {
                   Container Engines
                 </h2>
                 <p className="leading-relaxed text-base">
-                  Handle multiple container engines at the same time: Podman, Docker, and Lima.
+                  Handle multiple container engines at the same time: Podman, Docker.
                 </p>
               </div>
             </div>


### PR DESCRIPTION
You can use Lima to run different container engines, such as containerd or Docker or Podman but it runs virtual machines.

Currently containerd is *only* supported through Kubernetes, there is no direct support for "nerdctl" in Podman Desktop.

### What does this PR do?

Rewrite text where Lima is a container engine, replacing it with virtual machine.

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?

* https://github.com/containers/podman-desktop/issues/2693

### How to test this PR?

<!-- Please explain steps to reproduce -->
