### PR TITLE
chore: ignore typescript version being supported for eslint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -20,6 +20,7 @@
     "ecmaVersion": 12,
     "sourceType": "module",
     "extraFileExtensions": [".svelte"],
+    "warnOnUnsupportedTypeScriptVersion": false,
     "project": [
       "packages/*/tsconfig.json",
       "./website/tsconfig.json",


### PR DESCRIPTION

### What does this PR do?

Avoid to see this message
```
=============

WARNING: You are currently running a version of TypeScript which is not officially supported by @typescript-eslint/typescript-estree.

You may find that it works just fine, or you may not.

SUPPORTED TYPESCRIPT VERSIONS: >=3.3.1 <5.1.0

YOUR TYPESCRIPT VERSION: 5.1.3

Please only submit bug reports when using the officially supported version.

```


### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?

https://github.com/typescript-eslint/typescript-eslint/issues/6934

### How to test this PR?

Test `lint:fix` or `lint:check` task, no warning should be emitted

