### PR TITLE
chore: use correct pod icon

### DIFF
--- a/packages/renderer/src/lib/ContainerList.svelte
+++ b/packages/renderer/src/lib/ContainerList.svelte
@@ -394,7 +394,7 @@ function errorCallback(container: ContainerInfoUI, errorMessage: string): void {
         on:click="{() => createPodFromContainers()}"
         title="Create Pod with {selectedItemsNumber} selected items"
         type="button">
-        <i class="fas fa-cubes" aria-hidden="true"></i>
+        <PodIcon size="1em" solid="{true}" />
       </button>
       <span class="pl-2">On {selectedItemsNumber} selected items.</span>
     {/if}

--- a/packages/renderer/src/lib/pod/PodCreateFromContainers.svelte
+++ b/packages/renderer/src/lib/pod/PodCreateFromContainers.svelte
@@ -11,6 +11,7 @@ import StatusIcon from '../images/StatusIcon.svelte';
 import ContainerIcon from '../images/ContainerIcon.svelte';
 import { faTriangleExclamation } from '@fortawesome/free-solid-svg-icons';
 import Fa from 'svelte-fa/src/fa.svelte';
+import PodIcon from '../images/PodIcon.svelte';
 
 let podCreation: PodCreation;
 let createInProgress = false;
@@ -301,9 +302,9 @@ function updatePortExposure(port: number, checked: boolean) {
               aria-label="Create pod"
               class="pf-c-button pf-m-primary"
               type="button">
-              <span class="pf-c-button__icon pf-m-start">
+              <div class="flex flex-row">
                 {#if createInProgress}
-                  <div class="mr-24">
+                  <div class="mr-12">
                     <i class="pf-c-button__progress">
                       <span class="pf-c-spinner pf-m-md" role="progressbar">
                         <span class="pf-c-spinner__clipper"></span>
@@ -313,10 +314,10 @@ function updatePortExposure(port: number, checked: boolean) {
                     </i>
                   </div>
                 {:else}
-                  <i class="fas fa-cube" aria-hidden="true"></i>
+                  <PodIcon class="mr-2" size="1em" solid="{true}" />
                 {/if}
-              </span>
-              Create Pod
+                Create Pod
+              </div>
             </button>
           </div>
         </div>


### PR DESCRIPTION
### What does this PR do?

Nit: update to use the correct pod icon we use everywhere else. Requires changing a span to div so the icon stays on the left of the button text.

### Screenshot/screencast of this PR

<img width="194" alt="Screenshot 2023-06-30 at 9 16 12 AM" src="https://github.com/containers/podman-desktop/assets/19958075/45d049d7-e576-4282-a421-62df65c3bec8">

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Select a container in the containers list, check the Create Pod action, then click and check the form button.