### PR TITLE
chore: rename starting / stopping to enabling / disabling

### DIFF
--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -204,7 +204,7 @@ export class ExtensionLoader {
     const extension = await this.analyzeExtension(unpackedDirectory, true);
     if (extension) {
       await this.loadExtension(extension);
-      this.apiSender.send('extension-started', {});
+      this.apiSender.send('extension-enabled', {});
     }
   }
 
@@ -967,9 +967,9 @@ export class ExtensionLoader {
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   async activateExtension(extension: AnalyzedExtension, extensionMain: any): Promise<void> {
-    this.extensionState.set(extension.id, 'starting');
+    this.extensionState.set(extension.id, 'enabling');
     this.extensionStateErrors.delete(extension.id);
-    this.apiSender.send('extension-starting', {});
+    this.apiSender.send('extension-enabling', {});
 
     const subscriptions: containerDesktopAPI.Disposable[] = [];
 
@@ -1005,8 +1005,8 @@ export class ExtensionLoader {
         extensionContext,
       };
       this.activatedExtensions.set(extension.id, activatedExtension);
-      this.extensionState.set(extension.id, 'started');
-      this.apiSender.send('extension-started');
+      this.extensionState.set(extension.id, 'enabled');
+      this.apiSender.send('extension-enabled');
     } catch (err) {
       console.log(`Activation extension ${extension.id} failed error:${err}`);
       this.extensionState.set(extension.id, 'failed');
@@ -1028,8 +1028,8 @@ export class ExtensionLoader {
 
     const telemetryOptions = { extensionId: extension.id };
 
-    this.extensionState.set(extension.id, 'stopping');
-    this.apiSender.send('extension-stopping');
+    this.extensionState.set(extension.id, 'disabling');
+    this.apiSender.send('extension-disabling');
 
     if (extension.deactivateFunction) {
       try {
@@ -1061,8 +1061,8 @@ export class ExtensionLoader {
       }
     }
     this.activatedExtensions.delete(extensionId);
-    this.extensionState.set(extension.id, 'stopped');
-    this.apiSender.send('extension-stopped');
+    this.extensionState.set(extension.id, 'disabled');
+    this.apiSender.send('extension-disabled');
     this.telemetry
       .track('deactivateExtension', telemetryOptions)
       .catch((error: unknown) => console.log(`Failed to track deactivateExtension telemetry event. Error: ${error}`));
@@ -1074,7 +1074,7 @@ export class ExtensionLoader {
     );
   }
 
-  async startExtension(extensionId: string): Promise<void> {
+  async enableExtension(extensionId: string): Promise<void> {
     const extension = this.analyzedExtensions.get(extensionId);
     if (extension) {
       const analyzedExtension = await this.analyzeExtension(extension.path, extension.removable);

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1310,9 +1310,9 @@ export class PluginSystem {
       },
     );
     this.ipcHandle(
-      'extension-loader:startExtension',
+      'extension-loader:enableExtension',
       async (_listener: Electron.IpcMainInvokeEvent, extensionId: string): Promise<void> => {
-        return this.extensionLoader.startExtension(extensionId);
+        return this.extensionLoader.enableExtension(extensionId);
       },
     );
     this.ipcHandle(

--- a/packages/main/src/plugin/install/extension-installer.spec.ts
+++ b/packages/main/src/plugin/install/extension-installer.spec.ts
@@ -87,7 +87,7 @@ test('should install an image if labels are correct', async () => {
   expect(sendEnd).toHaveBeenCalledWith('Extension Successfully installed.');
 
   // extension started
-  expect(apiSenderSendMock).toHaveBeenCalledWith('extension-started', {});
+  expect(apiSenderSendMock).toHaveBeenCalledWith('extension-enabled', {});
 });
 
 test('should fail if extension is already installed', async () => {

--- a/packages/main/src/plugin/install/extension-installer.ts
+++ b/packages/main/src/plugin/install/extension-installer.ts
@@ -169,7 +169,7 @@ export class ExtensionInstaller {
     }
 
     sendEnd('Extension Successfully installed.');
-    this.apiSender.send('extension-started', {});
+    this.apiSender.send('extension-enabled', {});
   }
 
   async init(): Promise<void> {

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -906,12 +906,12 @@ function initExposure(): void {
     return ipcInvoke('extension-loader:listExtensions');
   });
 
-  contextBridge.exposeInMainWorld('stopExtension', async (extensionId: string): Promise<void> => {
+  contextBridge.exposeInMainWorld('disableExtension', async (extensionId: string): Promise<void> => {
     return ipcInvoke('extension-loader:deactivateExtension', extensionId);
   });
 
-  contextBridge.exposeInMainWorld('startExtension', async (extensionId: string): Promise<void> => {
-    return ipcInvoke('extension-loader:startExtension', extensionId);
+  contextBridge.exposeInMainWorld('enableExtension', async (extensionId: string): Promise<void> => {
+    return ipcInvoke('extension-loader:enableExtension', extensionId);
   });
 
   contextBridge.exposeInMainWorld('updateExtension', async (extensionId: string, ociUri: string): Promise<void> => {

--- a/packages/renderer/src/lib/preferences/PreferencesExtensionList.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesExtensionList.svelte
@@ -51,11 +51,11 @@ afterUpdate(() => {
   }
 });
 
-async function stopExtension(extension: ExtensionInfo) {
-  await window.stopExtension(extension.id);
+async function disableExtension(extension: ExtensionInfo) {
+  await window.disableExtension(extension.id);
 }
-async function startExtension(extension: ExtensionInfo) {
-  await window.startExtension(extension.id);
+async function enableExtension(extension: ExtensionInfo) {
+  await window.enableExtension(extension.id);
 }
 
 async function removeExtension(extension: ExtensionInfo) {
@@ -164,13 +164,13 @@ async function updateExtension(extension: ExtensionInfo, ociUri: string) {
                 <div class="flex flex-row justify-end">
                   <button
                     title="Start extension"
-                    on:click="{() => startExtension(extension)}"
+                    on:click="{() => enableExtension(extension)}"
                     class="{buttonClass}"
                     class:hidden="{extension.state !== 'stopped'}"><Fa class="h-4 w-4" icon="{faPlay}" /></button>
                   <button
                     title="Stop extension"
                     class="{buttonClass}"
-                    on:click="{() => stopExtension(extension)}"
+                    on:click="{() => disableExtension(extension)}"
                     hidden
                     class:hidden="{extension.state !== 'started'}"><Fa class="h-4 w-4" icon="{faStop}" /></button>
 

--- a/packages/renderer/src/lib/preferences/PreferencesExtensionRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesExtensionRendering.spec.ts
@@ -52,14 +52,14 @@ function setup(state: string): string {
   return extensionInfo.id;
 }
 describe('PreferencesExtensionRendering', () => {
-  test('Expect that the buttons have the correct state when an extension is stopped', async () => {
-    const id = setup('stopped');
+  test('Expect that the buttons have the correct state when an extension is disabled', async () => {
+    const id = setup('disabled');
     render(PreferencesExtensionRendering, { extensionId: id });
 
-    const start = screen.getByRole('button', { name: 'Start' });
+    const start = screen.getByRole('button', { name: 'Enable' });
     expect(start).toBeInTheDocument();
     expect(start).toBeEnabled();
-    const stop = screen.getByRole('button', { name: 'Stop' });
+    const stop = screen.getByRole('button', { name: 'Disable' });
     expect(stop).toBeInTheDocument();
     expect(stop).toBeDisabled();
     const remove = screen.getByRole('button', { name: 'Remove' });
@@ -67,14 +67,14 @@ describe('PreferencesExtensionRendering', () => {
     expect(remove).toBeEnabled();
   });
 
-  test('Expect that the buttons have the correct state when an extension is started', async () => {
-    const id = setup('started');
+  test('Expect that the buttons have the correct state when an extension is enabled', async () => {
+    const id = setup('enabled');
     render(PreferencesExtensionRendering, { extensionId: id });
 
-    const start = screen.getByRole('button', { name: 'Start' });
+    const start = screen.getByRole('button', { name: 'Enable' });
     expect(start).toBeInTheDocument();
     expect(start).toBeDisabled();
-    const stop = screen.getByRole('button', { name: 'Stop' });
+    const stop = screen.getByRole('button', { name: 'Disable' });
     expect(stop).toBeInTheDocument();
     expect(stop).toBeEnabled();
     const remove = screen.getByRole('button', { name: 'Remove' });
@@ -82,14 +82,14 @@ describe('PreferencesExtensionRendering', () => {
     expect(remove).toBeDisabled();
   });
 
-  test('Expect that the buttons have the correct state when an extension is starting', async () => {
-    const id = setup('starting');
+  test('Expect that the buttons have the correct state when an extension is enabling', async () => {
+    const id = setup('enabling');
     render(PreferencesExtensionRendering, { extensionId: id });
 
-    const start = screen.getByRole('button', { name: 'Start' });
+    const start = screen.getByRole('button', { name: 'Enable' });
     expect(start).toBeInTheDocument();
     expect(start).toBeDisabled();
-    const stop = screen.getByRole('button', { name: 'Stop' });
+    const stop = screen.getByRole('button', { name: 'Disable' });
     expect(stop).toBeInTheDocument();
     expect(stop).toBeDisabled();
     const remove = screen.getByRole('button', { name: 'Remove' });
@@ -97,14 +97,14 @@ describe('PreferencesExtensionRendering', () => {
     expect(remove).toBeDisabled();
   });
 
-  test('Expect that the buttons have the correct state when an extension is stopping', async () => {
-    const id = setup('stopping');
+  test('Expect that the buttons have the correct state when an extension is disabling', async () => {
+    const id = setup('disabling');
     render(PreferencesExtensionRendering, { extensionId: id });
 
-    const start = screen.getByRole('button', { name: 'Start' });
+    const start = screen.getByRole('button', { name: 'Enable' });
     expect(start).toBeInTheDocument();
     expect(start).toBeDisabled();
-    const stop = screen.getByRole('button', { name: 'Stop' });
+    const stop = screen.getByRole('button', { name: 'Disable' });
     expect(stop).toBeInTheDocument();
     expect(stop).toBeDisabled();
     const remove = screen.getByRole('button', { name: 'Remove' });

--- a/packages/renderer/src/lib/preferences/PreferencesExtensionRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesExtensionRendering.svelte
@@ -10,11 +10,11 @@ export let extensionId: string = undefined;
 let extensionInfo: ExtensionInfo;
 $: extensionInfo = $extensionInfos.find(extension => extension.id === extensionId);
 
-async function stopExtension() {
-  await window.stopExtension(extensionInfo.id);
+async function disableExtension() {
+  await window.disableExtension(extensionInfo.id);
 }
-async function startExtension() {
-  await window.startExtension(extensionInfo.id);
+async function enableExtension() {
+  await window.enableExtension(extensionInfo.id);
 }
 async function removeExtension() {
   window.location.href = '#/preferences/extensions';
@@ -36,39 +36,39 @@ async function removeExtension() {
         </div>
 
         <div class="py-2 flex flex-row items-center">
-          <!-- start is enabled only when stopped or failed -->
+          <!-- start is enabled only when disabled or failed -->
           <div class="px-2 text-sm italic text-gray-700">
             <button
-              disabled="{extensionInfo.state !== 'stopped' && extensionInfo.state !== 'failed'}"
-              on:click="{() => startExtension()}"
+              disabled="{extensionInfo.state !== 'disabled' && extensionInfo.state !== 'failed'}"
+              on:click="{() => enableExtension()}"
               class="pf-c-button pf-m-primary"
               type="button">
               <span class="pf-c-button__icon pf-m-start">
                 <i class="fas fa-play" aria-hidden="true"></i>
               </span>
-              Start
+              Enable
             </button>
           </div>
 
-          <!-- stop is enabled only when started -->
+          <!-- stop is enabled only when enabled -->
           <div class="px-2 text-sm italic text-gray-700">
             <button
-              disabled="{extensionInfo.state !== 'started'}"
-              on:click="{() => stopExtension()}"
+              disabled="{extensionInfo.state !== 'enabled'}"
+              on:click="{() => disableExtension()}"
               class="pf-c-button pf-m-primary"
               type="button">
               <span class="pf-c-button__icon pf-m-start">
                 <i class="fas fa-stop" aria-hidden="true"></i>
               </span>
-              Stop
+              Disable
             </button>
           </div>
 
-          <!-- delete is enabled only when stopped or failed -->
+          <!-- delete is enabled only when disabled or failed -->
           {#if extensionInfo.removable}
             <div class="px-2 text-sm italic text-gray-700">
               <button
-                disabled="{extensionInfo.state !== 'stopped' && extensionInfo.state !== 'failed'}"
+                disabled="{extensionInfo.state !== 'disabled' && extensionInfo.state !== 'failed'}"
                 on:click="{() => removeExtension()}"
                 class="pf-c-button pf-m-primary"
                 type="button">

--- a/packages/renderer/src/lib/ui/ConnectionStatus.spec.ts
+++ b/packages/renderer/src/lib/ui/ConnectionStatus.spec.ts
@@ -24,48 +24,48 @@ import ConnectionStatus from './ConnectionStatus.svelte';
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-empty-function */
 
-test('Expect green text and icon when connection is running', async () => {
-  render(ConnectionStatus, { status: 'started' });
+test('Expect green text and icon when connection is ENABLED', async () => {
+  render(ConnectionStatus, { status: 'enabled' });
   const icon = screen.getByLabelText('connection-status-icon');
   const label = screen.getByLabelText('connection-status-label');
   expect(icon).toBeInTheDocument();
   expect(icon).toHaveClass('bg-green-500');
   expect(label).toBeInTheDocument();
   expect(label).toHaveClass('text-green-500');
-  expect(label).toHaveTextContent('RUNNING');
+  expect(label).toHaveTextContent('ENABLED');
 });
 
-test('Expect green text and icon when connection is starting', async () => {
-  render(ConnectionStatus, { status: 'starting' });
+test('Expect green text and icon when connection is enabling', async () => {
+  render(ConnectionStatus, { status: 'enabling' });
   const icon = screen.getByLabelText('connection-status-icon');
   const label = screen.getByLabelText('connection-status-label');
   expect(icon).toBeInTheDocument();
   expect(icon).toHaveClass('bg-green-500');
   expect(label).toBeInTheDocument();
   expect(label).toHaveClass('text-green-500');
-  expect(label).toHaveTextContent('STARTING');
+  expect(label).toHaveTextContent('ENABLING');
 });
 
-test('Expect green text and icon when connection is stopped', async () => {
-  render(ConnectionStatus, { status: 'stopped' });
+test('Expect green text and icon when connection is disabled', async () => {
+  render(ConnectionStatus, { status: 'disabled' });
   const icon = screen.getByLabelText('connection-status-icon');
   const label = screen.getByLabelText('connection-status-label');
   expect(icon).toBeInTheDocument();
   expect(icon).toHaveClass('bg-gray-900');
   expect(label).toBeInTheDocument();
   expect(label).toHaveClass('text-gray-900');
-  expect(label).toHaveTextContent('OFF');
+  expect(label).toHaveTextContent('DISABLED');
 });
 
-test('Expect green text and icon when connection is stopping', async () => {
-  render(ConnectionStatus, { status: 'stopping' });
+test('Expect green text and icon when connection is disabling', async () => {
+  render(ConnectionStatus, { status: 'disabling' });
   const icon = screen.getByLabelText('connection-status-icon');
   const label = screen.getByLabelText('connection-status-label');
   expect(icon).toBeInTheDocument();
   expect(icon).toHaveClass('bg-red-500');
   expect(label).toBeInTheDocument();
   expect(label).toHaveClass('text-red-500');
-  expect(label).toHaveTextContent('STOPPING');
+  expect(label).toHaveTextContent('DISABLING');
 });
 
 test('Expect green text and icon when connection is unknown', async () => {

--- a/packages/renderer/src/lib/ui/ConnectionStatus.svelte
+++ b/packages/renderer/src/lib/ui/ConnectionStatus.svelte
@@ -11,35 +11,35 @@ const roundIconStyle = 'my-auto w-3 h-3 rounded-full';
 const labelStyle = 'my-auto ml-1 font-bold text-[9px]';
 const statusesStyle = new Map<string, connectionStatusStyle>([
   [
-    'started',
+    'enabled',
     {
       bgColor: 'bg-green-500',
       txtColor: 'text-green-500',
-      label: 'RUNNING',
+      label: 'ENABLED',
     },
   ],
   [
-    'starting',
+    'enabling',
     {
       bgColor: 'bg-green-500',
       txtColor: 'text-green-500',
-      label: 'STARTING',
+      label: 'ENABLING',
     },
   ],
   [
-    'stopped',
+    'disabled',
     {
       bgColor: 'bg-gray-900',
       txtColor: 'text-gray-900',
-      label: 'OFF',
+      label: 'DISABLED',
     },
   ],
   [
-    'stopping',
+    'disabling',
     {
       bgColor: 'bg-red-500',
       txtColor: 'text-red-500',
-      label: 'STOPPING',
+      label: 'DISABLING',
     },
   ],
   [

--- a/packages/renderer/src/stores/configurationProperties.ts
+++ b/packages/renderer/src/stores/configurationProperties.ts
@@ -34,10 +34,10 @@ export const configurationProperties: Writable<IConfigurationPropertyRecordedSch
 window.events?.receive('extensions-started', async () => {
   await fetchConfigurationProperties();
 });
-window.events?.receive('extension-started', async () => {
+window.events?.receive('extension-enabled', async () => {
   await fetchConfigurationProperties();
 });
-window.events?.receive('extension-stopped', async () => {
+window.events?.receive('extension-disabled', async () => {
   await fetchConfigurationProperties();
 });
 window.addEventListener('system-ready', () => {

--- a/packages/renderer/src/stores/containers.ts
+++ b/packages/renderer/src/stores/containers.ts
@@ -41,7 +41,7 @@ export const filtered = derived([searchPattern, containersInfos], ([$searchPatte
 );
 
 // need to refresh when extension is started
-window.events?.receive('extension-started', async () => {
+window.events?.receive('extension-enabled', async () => {
   await fetchContainers();
 });
 

--- a/packages/renderer/src/stores/extensions.ts
+++ b/packages/renderer/src/stores/extensions.ts
@@ -29,16 +29,16 @@ export async function fetchExtensions() {
 export const extensionInfos: Writable<ExtensionInfo[]> = writable([]);
 
 // need to refresh when extension is started or stopped
-window?.events?.receive('extension-starting', async () => {
+window?.events?.receive('extension-enabling', async () => {
   await fetchExtensions();
 });
-window?.events?.receive('extension-started', async () => {
+window?.events?.receive('extension-enabled', async () => {
   await fetchExtensions();
 });
-window?.events?.receive('extension-stopping', async () => {
+window?.events?.receive('extension-disabling', async () => {
   await fetchExtensions();
 });
-window?.events?.receive('extension-stopped', async () => {
+window?.events?.receive('extension-disabled', async () => {
   await fetchExtensions();
 });
 window?.events?.receive('extension-removed', async () => {

--- a/packages/renderer/src/stores/featuredExtensions.ts
+++ b/packages/renderer/src/stores/featuredExtensions.ts
@@ -28,16 +28,16 @@ export async function fetchFeaturedExtensions() {
 export const featuredExtensionInfos: Writable<FeaturedExtension[]> = writable([]);
 
 // need to refresh when extension is started or stopped
-window?.events?.receive('extension-starting', async () => {
+window?.events?.receive('extension-enabling', async () => {
   await fetchFeaturedExtensions();
 });
-window?.events?.receive('extension-started', async () => {
+window?.events?.receive('extension-enabled', async () => {
   await fetchFeaturedExtensions();
 });
-window?.events?.receive('extension-stopping', async () => {
+window?.events?.receive('extension-disabling', async () => {
   await fetchFeaturedExtensions();
 });
-window?.events?.receive('extension-stopped', async () => {
+window?.events?.receive('extension-disabled', async () => {
   await fetchFeaturedExtensions();
 });
 window?.events?.receive('extension-removed', async () => {

--- a/packages/renderer/src/stores/icons.ts
+++ b/packages/renderer/src/stores/icons.ts
@@ -38,7 +38,7 @@ export const iconsInfos: Writable<IconInfo[]> = writable([]);
 window.events?.receive('icon-update', async () => {
   await fetchIcons();
 });
-window.events?.receive('extension-stopped', async () => {
+window.events?.receive('extension-disabled', async () => {
   await fetchIcons();
 });
 

--- a/packages/renderer/src/stores/images.ts
+++ b/packages/renderer/src/stores/images.ts
@@ -41,10 +41,10 @@ export const filtered = derived([searchPattern, imagesInfos], ([$searchPattern, 
 );
 
 // need to refresh when extension is started or stopped
-window?.events?.receive('extension-started', async () => {
+window?.events?.receive('extension-enabled', async () => {
   await fetchImages();
 });
-window?.events?.receive('extension-stopped', async () => {
+window?.events?.receive('extension-disabled', async () => {
   await fetchImages();
 });
 

--- a/packages/renderer/src/stores/pods.ts
+++ b/packages/renderer/src/stores/pods.ts
@@ -46,10 +46,10 @@ export const filtered = derived([searchPattern, podsInfos], ([$searchPattern, $i
 });
 
 // need to refresh when extension is started or stopped
-window.events?.receive('extension-started', async () => {
+window.events?.receive('extension-enabled', async () => {
   await fetchPods();
 });
-window.events?.receive('extension-stopped', async () => {
+window.events?.receive('extension-disabled', async () => {
   await fetchPods();
 });
 

--- a/packages/renderer/src/stores/providers.ts
+++ b/packages/renderer/src/stores/providers.ts
@@ -43,10 +43,10 @@ export async function fetchProviders() {
 export const providerInfos: Writable<ProviderInfo[]> = writable([]);
 
 // need to refresh when extension is started or stopped
-window?.events?.receive('extension-started', async () => {
+window?.events?.receive('extension-enabled', async () => {
   await fetchProviders();
 });
-window?.events?.receive('extension-stopped', async () => {
+window?.events?.receive('extension-disabled', async () => {
   await fetchProviders();
 });
 

--- a/packages/renderer/src/stores/volumes.ts
+++ b/packages/renderer/src/stores/volumes.ts
@@ -54,10 +54,10 @@ export const filtered = derived([searchPattern, volumeListInfos], ([$searchPatte
 
 export function initWindowFetchVolumes() {
   // need to refresh when extension is started or stopped
-  window?.events?.receive('extension-started', async () => {
+  window?.events?.receive('extension-enabled', async () => {
     await fetchVolumes();
   });
-  window?.events?.receive('extension-stopped', async () => {
+  window?.events?.receive('extension-disabled', async () => {
     await fetchVolumes();
   });
 


### PR DESCRIPTION
chore: rename starting / stopping to enabling / disabling

### What does this PR do?

For providers it makes sense to have starting / stopping / stopped.

For extensions, it should be enable / disable / enabling / disabling
since they are extensions that you turn off and on, not something that
is "running" in the background.

Using the starting / stopping / stopped terms for extensions is
confusing.

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

https://github.com/containers/podman-desktop/assets/6422176/e8914923-e19b-4dd2-bad7-ab35dd7251fe




### What issues does this PR fix or reference?

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

Closes https://github.com/containers/podman-desktop/issues/2534
Closes https://github.com/containers/podman-desktop/issues/2379

### How to test this PR?

<!-- Please explain steps to reproduce -->

Go to extensions page, you should now see enable / disable rather that
start / stop.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
