### PR TITLE
feat: send telemetry when user installs or removes extension

### DIFF
--- a/packages/renderer/src/TelemetryService.ts
+++ b/packages/renderer/src/TelemetryService.ts
@@ -16,6 +16,11 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+export const EXTENSION_INSTALL_EVENT_TYPE = 'extension-install';
+export const EXTENSION_REMOVE_EVENT_TYPE = 'extension-remove';
+
+export type ExtensionTelemetryEventType = typeof EXTENSION_INSTALL_EVENT_TYPE | typeof EXTENSION_REMOVE_EVENT_TYPE;
+
 export class TelemetryService {
   private static instance: TelemetryService;
 
@@ -45,5 +50,9 @@ export class TelemetryService {
         });
       }
     }, 200);
+  }
+
+  public handleExtensionEvent(event: ExtensionTelemetryEventType, id: string, featured: boolean, error: string) {
+    window.telemetryTrack(event, { id, featured, error });
   }
 }

--- a/packages/renderer/src/lib/featured/FeaturedExtensionDownload.spec.ts
+++ b/packages/renderer/src/lib/featured/FeaturedExtensionDownload.spec.ts
@@ -29,6 +29,7 @@ const extensionInstallFromImageMock = vi.fn();
 // fake the window.events object
 beforeAll(() => {
   (window as any).extensionInstallFromImage = extensionInstallFromImageMock;
+  (window as any).telemetryTrack = vi.fn();
   (window.events as unknown) = {
     receive: (_channel: string, func: any) => {
       func();

--- a/packages/renderer/src/lib/featured/FeaturedExtensionDownload.svelte
+++ b/packages/renderer/src/lib/featured/FeaturedExtensionDownload.svelte
@@ -3,6 +3,7 @@ import type { FeaturedExtension } from '../../../../main/src/plugin/featured/fea
 import { faDownload } from '@fortawesome/free-solid-svg-icons';
 import LoadingIcon from '../ui/LoadingIcon.svelte';
 import ErrorMessage from '../ui/ErrorMessage.svelte';
+import { TelemetryService, EXTENSION_INSTALL_EVENT_TYPE } from '../../TelemetryService';
 
 export let featuredExtension: FeaturedExtension;
 
@@ -14,6 +15,7 @@ let errorInstall = '';
 let percentage = '0%';
 
 async function installExtension() {
+  let installError: string;
   console.log('User asked to install the extension with the following properties', featuredExtension);
   logs = [];
 
@@ -46,8 +48,17 @@ async function installExtension() {
     logs = [...logs, '☑️ installation finished !'];
     percentage = '100%';
   } catch (error) {
+    installError = `${error}`;
     console.log('error', error);
+  } finally {
+    TelemetryService.getService().handleExtensionEvent(
+      EXTENSION_INSTALL_EVENT_TYPE,
+      featuredExtension.id,
+      true,
+      installError,
+    );
   }
+
   installInProgress = false;
 }
 </script>

--- a/packages/renderer/src/lib/preferences/PreferencesExtensionList.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesExtensionList.svelte
@@ -8,6 +8,7 @@ import ErrorMessage from '../ui/ErrorMessage.svelte';
 import SettingsPage from '../preferences/SettingsPage.svelte';
 import ConnectionStatus from '../ui/ConnectionStatus.svelte';
 import FeaturedExtensions from '../featured/FeaturedExtensions.svelte';
+import { TelemetryService, EXTENSION_REMOVE_EVENT_TYPE } from '../../TelemetryService';
 
 export let ociImage: string = undefined;
 
@@ -59,7 +60,15 @@ async function startExtension(extension: ExtensionInfo) {
 }
 
 async function removeExtension(extension: ExtensionInfo) {
-  await window.removeExtension(extension.id);
+  let removeError: string;
+  try {
+    await window.removeExtension(extension.id);
+  } catch (err) {
+    removeError = `${err}`;
+    console.log('error', err);
+  } finally {
+    TelemetryService.getService().handleExtensionEvent(EXTENSION_REMOVE_EVENT_TYPE, extension.id, false, removeError);
+  }
 }
 
 async function updateExtension(extension: ExtensionInfo, ociUri: string) {

--- a/packages/renderer/src/lib/preferences/PreferencesExtensionRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesExtensionRendering.svelte
@@ -4,6 +4,7 @@ import { extensionInfos } from '../../stores/extensions';
 import type { ExtensionInfo } from '../../../../main/src/plugin/api/extension-info';
 import SettingsPage from './SettingsPage.svelte';
 import ConnectionStatus from '../ui/ConnectionStatus.svelte';
+import { EXTENSION_REMOVE_EVENT_TYPE, TelemetryService } from '../../TelemetryService';
 
 export let extensionId: string = undefined;
 
@@ -18,7 +19,20 @@ async function startExtension() {
 }
 async function removeExtension() {
   window.location.href = '#/preferences/extensions';
-  await window.removeExtension(extensionInfo.id);
+  let removeError: string;
+  try {
+    await window.removeExtension(extensionInfo.id);
+  } catch (err) {
+    removeError = `${err}`;
+    console.log('error', err);
+  } finally {
+    TelemetryService.getService().handleExtensionEvent(
+      EXTENSION_REMOVE_EVENT_TYPE,
+      extensionInfo.id,
+      false,
+      removeError,
+    );
+  }
 }
 </script>
 

--- a/packages/renderer/src/lib/preferences/PreferencesInstallExtensionFromId.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesInstallExtensionFromId.spec.ts
@@ -31,6 +31,7 @@ const extensionInstallFromImageMock = vi.fn();
 // fake the window.events object
 beforeAll(() => {
   (window as any).extensionInstallFromImage = extensionInstallFromImageMock;
+  (window as any).telemetryTrack = vi.fn();
   (window.events as unknown) = {
     receive: (_channel: string, func: any) => {
       func();

--- a/packages/renderer/src/lib/preferences/PreferencesInstallExtensionFromId.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesInstallExtensionFromId.svelte
@@ -21,6 +21,7 @@ import { faPuzzlePiece } from '@fortawesome/free-solid-svg-icons';
 import Markdown from '/@/lib/markdown/Markdown.svelte';
 import { extensionInfos } from '/@/stores/extensions';
 import ErrorMessage from '/@/lib/ui/ErrorMessage.svelte';
+import { EXTENSION_INSTALL_EVENT_TYPE, TelemetryService } from '/@/TelemetryService';
 
 export let extensionId: string = undefined;
 
@@ -63,7 +64,14 @@ let percentage = 0;
 
 async function installExtension() {
   if (!latestVersionOciLink) {
-    console.log('no oci link found for this extension');
+    const errorMessage = 'no oci link found for this extension';
+    console.log(errorMessage);
+    TelemetryService.getService().handleExtensionEvent(
+      EXTENSION_INSTALL_EVENT_TYPE,
+      extensionDetails.id,
+      false,
+      errorMessage,
+    );
     return;
   }
 
@@ -101,7 +109,15 @@ async function installExtension() {
     logs = [...logs, '☑️ installation finished !'];
     percentage = 100;
   } catch (error) {
+    errorInstall = `${error}`;
     console.log('error', error);
+  } finally {
+    TelemetryService.getService().handleExtensionEvent(
+      EXTENSION_INSTALL_EVENT_TYPE,
+      extensionDetails.id,
+      false,
+      errorInstall,
+    );
   }
   installInProgress = false;
 }


### PR DESCRIPTION
### What does this PR do?

### Screenshot/screencast of this PR

This PR add telemetry for user requests to install or remove extension. 

### What issues does this PR fix or reference?

Fix #3018.

### How to test this PR?

Enable telemetry, install and remove extension, then check telemetry reporting for new events 'extension-install' and 'extension-remove'.
