### PR TITLE
feat: add environment-related utility API

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -1974,6 +1974,102 @@ declare module '@podman-desktop/api' {
   }
 
   /**
+   * Options for running a command.
+   */
+  export interface RunOptions {
+    /**
+     * Environment variables to set for the command.
+     */
+    env?: { [key: string]: string };
+
+    /**
+     * A cancellation token used to request cancellation.
+     */
+    token?: CancellationToken;
+
+    /**
+     * A logger used to track execution events.
+     */
+    logger?: Logger;
+  }
+
+  /**
+   * Represents the result of running a command.
+   */
+  export interface RunResult {
+    /**
+     * The command that was executed.
+     */
+    command: string;
+
+    /**
+     * The standard output (stdout) content of the command.
+     */
+    stdout: string;
+
+    /**
+     * The standard error (stderr) content of the command.
+     */
+    stderr: string;
+  }
+
+  /**
+   * Represents an error that occurred during the execution of a command.
+   */
+  export interface RunError extends Error {
+    /**
+     * The error message.
+     */
+    message: string;
+
+    /**
+     * The exit code of the command.
+     */
+    exitCode: number;
+
+    /**
+     * The command that was executed.
+     */
+    command: string;
+
+    /**
+     * The standard output (stdout) content of the command.
+     */
+    stdout: string;
+
+    /**
+     * The standard error (stderr) content of the command.
+     */
+    stderr: string;
+
+    /**
+     * Indicates whether the execution was cancelled.
+     */
+    cancelled: boolean;
+
+    /**
+     * Indicates whether the process was forcefully killed.
+     */
+    killed: boolean;
+  }
+
+  /**
+   * Namespace for environment-related utilities.
+   */
+  export namespace process {
+    /**
+     * Executes the provided command and returns an object containing the exit code,
+     * stdout, and stderr content.
+     * @param command The command to execute.
+     * @param args The command arguments.
+     * @param options Options, such as environment variables.
+     * @returns A promise that resolves to a RunResult object.
+     * @throws {@link RunError} if provided command can not be executed.
+     */
+    export function exec(command: string, args?: string[], options?: RunOptions): Promise<RunResult>;
+  }
+
+  /**
    * A special value wrapper denoting a value that is safe to not clean.
    * This is to be used when you can guarantee no identifiable information is contained in the value and the cleaning is improperly redacting it.
    */

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -58,6 +58,7 @@ import type { IconRegistry } from './icon-registry.js';
 import type { Directories } from './directories.js';
 import { isLinux, isMac, isWindows } from '../util.js';
 import type { CustomPickRegistry } from './custompick/custompick-registry.js';
+import { exec } from './util/exec.js';
 
 /**
  * Handle the loading of an extension
@@ -901,6 +902,16 @@ export class ExtensionLoader {
       },
     };
 
+    const process: typeof containerDesktopAPI.process = {
+      exec: (
+        command: string,
+        args?: string[],
+        options?: containerDesktopAPI.RunOptions,
+      ): Promise<containerDesktopAPI.RunResult> => {
+        return exec(command, args, options);
+      },
+    };
+
     return <typeof containerDesktopAPI>{
       // Types
       Disposable: Disposable,
@@ -910,6 +921,7 @@ export class ExtensionLoader {
       TelemetryTrustedValue: TelemetryTrustedValue,
       commands,
       env,
+      process,
       registry,
       provider,
       fs,

--- a/packages/main/src/plugin/util/exec.spec.ts
+++ b/packages/main/src/plugin/util/exec.spec.ts
@@ -1,0 +1,178 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { expect, describe, test, vi, beforeEach, afterEach } from 'vitest';
+import { getInstallationPath, macosExtraPath, exec } from './exec.js';
+import * as util from '../../util.js';
+import type { ChildProcessWithoutNullStreams } from 'child_process';
+import { spawn } from 'child_process';
+import type { Readable } from 'node:stream';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+describe('exec', () => {
+  test('should run the command and resolve with the result', async () => {
+    const command = 'echo';
+    const args = ['Hello, World!'];
+
+    vi.mock('child_process', () => {
+      return {
+        spawn: vi.fn(),
+      };
+    });
+
+    const on: any = vi.fn().mockImplementationOnce((event: string, cb: (arg0: string) => string) => {
+      if (event === 'data') {
+        cb('Hello, World!');
+      }
+    }) as unknown as Readable;
+    const spawnMock = vi.mocked(spawn).mockReturnValue({
+      stdout: { on, setEncoding: vi.fn() },
+      stderr: { on, setEncoding: vi.fn() },
+      on: vi.fn().mockImplementation((event: string, cb: (arg0: number) => void) => {
+        if (event === 'exit') {
+          cb(0);
+        }
+      }),
+    } as any);
+
+    const { stdout } = await exec(command, args);
+
+    expect(spawnMock).toHaveBeenCalledWith(command, args, { env: expect.any(Object) });
+    expect(stdout).toBeDefined();
+    expect(stdout).toContain('Hello, World!');
+  });
+
+  test('should reject with an error when the command execution fails', async () => {
+    const command = 'nonexistent-command';
+
+    vi.mock('child_process', () => {
+      return {
+        spawn: vi.fn(),
+      };
+    });
+
+    const on: any = vi.fn().mockImplementationOnce((event: string, cb: (arg0: string) => string) => {
+      if (event === 'data') {
+        cb('');
+      }
+    }) as unknown as Readable;
+    vi.mocked(spawn).mockReturnValue({
+      stdout: { on, setEncoding: vi.fn() },
+      stderr: { on, setEncoding: vi.fn() },
+      on: vi.fn().mockImplementation((event: string, cb: (arg0: number) => void) => {
+        if (event === 'exit') {
+          cb(1);
+        }
+      }),
+    } as any);
+
+    await expect(exec(command)).rejects.toThrowError(/Command execution failed with exit code 1/);
+  });
+
+  test('should reject with an error when the execution is cancelled', async () => {
+    const command = 'sleep';
+    const args = ['1'];
+    const cancellationToken = {
+      isCancellationRequested: true,
+      onCancellationRequested: vi.fn(),
+    };
+    const options = {
+      token: cancellationToken,
+      logger: { log: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    };
+
+    vi.mock('child_process', () => {
+      return {
+        spawn: vi.fn(),
+      };
+    });
+
+    const childProcessMock: unknown = {
+      killed: false,
+      stdout: { on: vi.fn(), setEncoding: vi.fn() },
+      stderr: { on: vi.fn(), setEncoding: vi.fn() },
+      on: vi.fn().mockImplementation((event: string, cb: (arg0: number) => void) => {
+        if (event === 'exit') {
+          cb(0);
+        }
+      }),
+      kill: vi.fn(),
+    };
+    vi.mocked(spawn).mockReturnValue(childProcessMock as ChildProcessWithoutNullStreams);
+
+    vi.mocked(cancellationToken.onCancellationRequested).mockImplementationOnce((handler: () => void) => {
+      handler();
+    });
+
+    await expect(exec(command, args, options)).rejects.toThrowError(/Execution cancelled/);
+
+    expect((childProcessMock as any).kill).toHaveBeenCalled();
+    expect(options.logger.error).toHaveBeenCalledWith('Execution cancelled');
+  });
+});
+
+vi.mock('./util', () => {
+  return {
+    isWindows: vi.fn(),
+    isMac: vi.fn(),
+  };
+});
+
+describe('getInstallationPath', () => {
+  let originalPath: string | undefined;
+
+  beforeEach(() => {
+    originalPath = process.env.PATH;
+  });
+
+  afterEach(() => {
+    process.env.PATH = originalPath;
+  });
+
+  test('should return the installation path for Windows', () => {
+    vi.spyOn(util, 'isWindows').mockImplementation(() => true);
+    vi.spyOn(util, 'isMac').mockImplementation(() => false);
+    process.env.PATH = '';
+
+    const path = getInstallationPath();
+
+    expect(path).toBe('c:\\Program Files\\RedHat\\Podman;');
+  });
+
+  test('should return the installation path for macOS', () => {
+    vi.spyOn(util, 'isWindows').mockImplementation(() => false);
+    vi.spyOn(util, 'isMac').mockImplementation(() => true);
+
+    process.env.PATH = '/usr/bin';
+
+    const path = getInstallationPath();
+
+    expect(path).toBe(`/usr/bin:${macosExtraPath}`);
+  });
+
+  test('should return the installation path for other platforms', () => {
+    vi.spyOn(util, 'isWindows').mockImplementation(() => false);
+    vi.spyOn(util, 'isMac').mockImplementation(() => false);
+    process.env.PATH = '/usr/bin'; // Example PATH for other platforms
+
+    const path = getInstallationPath();
+
+    expect(path).toBe('/usr/bin');
+  });
+});

--- a/packages/main/src/plugin/util/exec.ts
+++ b/packages/main/src/plugin/util/exec.ts
@@ -1,0 +1,144 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { ChildProcessWithoutNullStreams } from 'child_process';
+import { spawn } from 'child_process';
+import type { RunError, RunOptions, RunResult } from '@podman-desktop/api';
+import { isMac, isWindows } from '../../util.js';
+
+export const macosExtraPath = '/usr/local/bin:/opt/homebrew/bin:/opt/local/bin:/opt/podman/bin';
+
+export function exec(command: string, args?: string[], options?: RunOptions): Promise<RunResult> {
+  let env = Object.assign({}, process.env);
+
+  if (isMac() || isWindows()) {
+    env.PATH = getInstallationPath();
+  } else if (env.FLATPAK_ID) {
+    args = ['--host', command, ...(args || [])];
+    command = 'flatpak-spawn';
+  }
+
+  if (options?.env) {
+    env = Object.assign(env, options.env);
+  }
+
+  return new Promise((resolve, reject) => {
+    let stdout = '';
+    let stderr = '';
+
+    const childProcess: ChildProcessWithoutNullStreams = spawn(command, args, { env });
+
+    options?.token?.onCancellationRequested(() => {
+      if (!childProcess.killed) {
+        childProcess.kill();
+        options?.logger?.error('Execution cancelled');
+        const errResult: RunError = {
+          name: 'Execution cancelled',
+          message: 'Failed to execute command: Execution cancelled',
+          exitCode: 1,
+          command,
+          stdout: stdout.trim(),
+          stderr: stderr.trim(),
+          cancelled: true,
+          killed: childProcess.killed,
+        };
+        reject(errResult);
+      }
+      options?.logger?.error('Failed to execute cancel: Process has been already killed');
+      const errResult: RunError = {
+        name: 'Failed to execute cancel: Process has been already killed',
+        message: 'Failed to execute cancel: Process has been already killed',
+        exitCode: 1,
+        command,
+        stdout: stdout.trim(),
+        stderr: stderr.trim(),
+        cancelled: false,
+        killed: childProcess.killed,
+      };
+      reject(errResult);
+    });
+
+    childProcess.stdout.setEncoding('utf8');
+    childProcess.stderr.setEncoding('utf8');
+
+    childProcess.stdout.on('data', data => {
+      stdout += data.toString();
+      options?.logger?.log(data);
+    });
+
+    childProcess.stderr.on('data', data => {
+      stderr += data.toString();
+      options?.logger?.warn(data);
+    });
+
+    childProcess.on('error', error => {
+      options?.logger?.error(`Failed to execute command: ${error.message}`);
+      const errResult: RunError = {
+        name: error.name,
+        message: `Failed to execute command: ${error.message}`,
+        exitCode: 1,
+        command,
+        stdout: stdout.trim(),
+        stderr: stderr.trim(),
+        cancelled: false,
+        killed: childProcess.killed,
+      };
+      reject(errResult);
+    });
+
+    childProcess.on('exit', exitCode => {
+      if (exitCode === 0) {
+        const result: RunResult = {
+          command,
+          stdout: stdout.trim(),
+          stderr: stderr.trim(),
+        };
+        resolve(result);
+      } else {
+        options?.logger?.error(`Command execution failed with exit code ${exitCode}`);
+        const errResult: RunError = {
+          name: `Command execution failed with exit code ${exitCode}`,
+          message: `Command execution failed with exit code ${exitCode}`,
+          exitCode: exitCode || 1,
+          command,
+          stdout: stdout.trim(),
+          stderr: stderr.trim(),
+          cancelled: false,
+          killed: childProcess.killed,
+        };
+        reject(errResult);
+      }
+    });
+  });
+}
+
+export function getInstallationPath(): string {
+  const env = process.env;
+
+  if (isWindows()) {
+    return `c:\\Program Files\\RedHat\\Podman;${env.PATH}`;
+  } else if (isMac()) {
+    if (!env.PATH) {
+      return macosExtraPath;
+    } else {
+      return env.PATH.concat(':').concat(macosExtraPath);
+    }
+  } else {
+    return env.PATH || '';
+  }
+}


### PR DESCRIPTION
### What does this PR do?

Proposal to add a new `process` namespace with new method: 
```typescript
    /**
     * Run provided command, returning an object that contains the exit code, stdout, and stderr content.
     * Does not reject the promise if the exit code is not 0.
     * @param command The command to execute.
     * @param args The command arguments.
     * @param options Options, such as environment variables.
     * @returns A promise that resolves to a RunResult object.
     */
    export function runCliCommand(command: string, args: string[], options?: RunOptions): Promise<RunResult>;
```

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

#1585 

### How to test this PR?

New API should be available from the extensions.
