### PR TITLE
nit: change wording from started to enabled / etc.

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesExtensionRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesExtensionRendering.spec.ts
@@ -56,10 +56,10 @@ describe('PreferencesExtensionRendering', () => {
     const id = setup('stopped');
     render(PreferencesExtensionRendering, { extensionId: id });
 
-    const start = screen.getByRole('button', { name: 'Start' });
+    const start = screen.getByRole('button', { name: 'Enable' });
     expect(start).toBeInTheDocument();
     expect(start).toBeEnabled();
-    const stop = screen.getByRole('button', { name: 'Stop' });
+    const stop = screen.getByRole('button', { name: 'Disable' });
     expect(stop).toBeInTheDocument();
     expect(stop).toBeDisabled();
     const remove = screen.getByRole('button', { name: 'Remove' });
@@ -71,10 +71,10 @@ describe('PreferencesExtensionRendering', () => {
     const id = setup('started');
     render(PreferencesExtensionRendering, { extensionId: id });
 
-    const start = screen.getByRole('button', { name: 'Start' });
+    const start = screen.getByRole('button', { name: 'Enable' });
     expect(start).toBeInTheDocument();
     expect(start).toBeDisabled();
-    const stop = screen.getByRole('button', { name: 'Stop' });
+    const stop = screen.getByRole('button', { name: 'Disable' });
     expect(stop).toBeInTheDocument();
     expect(stop).toBeEnabled();
     const remove = screen.getByRole('button', { name: 'Remove' });
@@ -86,10 +86,10 @@ describe('PreferencesExtensionRendering', () => {
     const id = setup('starting');
     render(PreferencesExtensionRendering, { extensionId: id });
 
-    const start = screen.getByRole('button', { name: 'Start' });
+    const start = screen.getByRole('button', { name: 'Enable' });
     expect(start).toBeInTheDocument();
     expect(start).toBeDisabled();
-    const stop = screen.getByRole('button', { name: 'Stop' });
+    const stop = screen.getByRole('button', { name: 'Disable' });
     expect(stop).toBeInTheDocument();
     expect(stop).toBeDisabled();
     const remove = screen.getByRole('button', { name: 'Remove' });
@@ -101,10 +101,10 @@ describe('PreferencesExtensionRendering', () => {
     const id = setup('stopping');
     render(PreferencesExtensionRendering, { extensionId: id });
 
-    const start = screen.getByRole('button', { name: 'Start' });
+    const start = screen.getByRole('button', { name: 'Enable' });
     expect(start).toBeInTheDocument();
     expect(start).toBeDisabled();
-    const stop = screen.getByRole('button', { name: 'Stop' });
+    const stop = screen.getByRole('button', { name: 'Disable' });
     expect(stop).toBeInTheDocument();
     expect(stop).toBeDisabled();
     const remove = screen.getByRole('button', { name: 'Remove' });

--- a/packages/renderer/src/lib/preferences/PreferencesExtensionRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesExtensionRendering.svelte
@@ -3,7 +3,7 @@ import Route from '../../Route.svelte';
 import { extensionInfos } from '../../stores/extensions';
 import type { ExtensionInfo } from '../../../../main/src/plugin/api/extension-info';
 import SettingsPage from './SettingsPage.svelte';
-import ConnectionStatus from '../ui/ConnectionStatus.svelte';
+import ExtensionStatus from '../ui/ExtensionStatus.svelte';
 
 export let extensionId: string = undefined;
 
@@ -32,7 +32,7 @@ async function removeExtension() {
         <!-- Manage lifecycle-->
         <div class="flex pb-2">
           <div class="pr-2">Status</div>
-          <ConnectionStatus status="{extensionInfo.state}" />
+          <ExtensionStatus status="{extensionInfo.state}" />
         </div>
 
         <div class="py-2 flex flex-row items-center">
@@ -46,7 +46,7 @@ async function removeExtension() {
               <span class="pf-c-button__icon pf-m-start">
                 <i class="fas fa-play" aria-hidden="true"></i>
               </span>
-              Start
+              Enable
             </button>
           </div>
 
@@ -60,7 +60,7 @@ async function removeExtension() {
               <span class="pf-c-button__icon pf-m-start">
                 <i class="fas fa-stop" aria-hidden="true"></i>
               </span>
-              Stop
+              Disable
             </button>
           </div>
 

--- a/packages/renderer/src/lib/ui/ExtensionStatus.spec.ts
+++ b/packages/renderer/src/lib/ui/ExtensionStatus.spec.ts
@@ -1,0 +1,80 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom';
+import { test, expect } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import ExtensionStatus from './ExtensionStatus.svelte';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-empty-function */
+
+test('Expect green text and icon when connection is running', async () => {
+  render(ExtensionStatus, { status: 'started' });
+  const icon = screen.getByLabelText('connection-status-icon');
+  const label = screen.getByLabelText('connection-status-label');
+  expect(icon).toBeInTheDocument();
+  expect(icon).toHaveClass('bg-green-500');
+  expect(label).toBeInTheDocument();
+  expect(label).toHaveClass('text-green-500');
+  expect(label).toHaveTextContent('ENABLED');
+});
+
+test('Expect green text and icon when connection is starting', async () => {
+  render(ExtensionStatus, { status: 'starting' });
+  const icon = screen.getByLabelText('connection-status-icon');
+  const label = screen.getByLabelText('connection-status-label');
+  expect(icon).toBeInTheDocument();
+  expect(icon).toHaveClass('bg-green-500');
+  expect(label).toBeInTheDocument();
+  expect(label).toHaveClass('text-green-500');
+  expect(label).toHaveTextContent('ENABLING');
+});
+
+test('Expect green text and icon when connection is stopped', async () => {
+  render(ExtensionStatus, { status: 'stopped' });
+  const icon = screen.getByLabelText('connection-status-icon');
+  const label = screen.getByLabelText('connection-status-label');
+  expect(icon).toBeInTheDocument();
+  expect(icon).toHaveClass('bg-gray-900');
+  expect(label).toBeInTheDocument();
+  expect(label).toHaveClass('text-gray-900');
+  expect(label).toHaveTextContent('DISABLED');
+});
+
+test('Expect green text and icon when connection is stopping', async () => {
+  render(ExtensionStatus, { status: 'stopping' });
+  const icon = screen.getByLabelText('connection-status-icon');
+  const label = screen.getByLabelText('connection-status-label');
+  expect(icon).toBeInTheDocument();
+  expect(icon).toHaveClass('bg-red-500');
+  expect(label).toBeInTheDocument();
+  expect(label).toHaveClass('text-red-500');
+  expect(label).toHaveTextContent('DISABLING');
+});
+
+test('Expect green text and icon when connection is unknown', async () => {
+  render(ExtensionStatus, { status: 'unknown' });
+  const icon = screen.getByLabelText('connection-status-icon');
+  const label = screen.getByLabelText('connection-status-label');
+  expect(icon).toBeInTheDocument();
+  expect(icon).toHaveClass('bg-gray-900');
+  expect(label).toBeInTheDocument();
+  expect(label).toHaveClass('text-gray-900');
+  expect(label).toHaveTextContent('UNKNOWN');
+});

--- a/packages/renderer/src/lib/ui/ExtensionStatus.svelte
+++ b/packages/renderer/src/lib/ui/ExtensionStatus.svelte
@@ -1,0 +1,62 @@
+<script lang="ts">
+export let status: string;
+
+interface connectionStatusStyle {
+  bgColor: string;
+  txtColor: string;
+  label: string;
+}
+
+const roundIconStyle = 'my-auto w-3 h-3 rounded-full';
+const labelStyle = 'my-auto ml-1 font-bold text-[9px]';
+const statusesStyle = new Map<string, connectionStatusStyle>([
+  [
+    'started',
+    {
+      bgColor: 'bg-green-500',
+      txtColor: 'text-green-500',
+      label: 'ENABLED',
+    },
+  ],
+  [
+    'starting',
+    {
+      bgColor: 'bg-green-500',
+      txtColor: 'text-green-500',
+      label: 'ENABLING',
+    },
+  ],
+  [
+    'stopped',
+    {
+      bgColor: 'bg-gray-900',
+      txtColor: 'text-gray-900',
+      label: 'DISABLED',
+    },
+  ],
+  [
+    'stopping',
+    {
+      bgColor: 'bg-red-500',
+      txtColor: 'text-red-500',
+      label: 'DISABLING',
+    },
+  ],
+  [
+    'failed',
+    {
+      bgColor: 'bg-red-500',
+      txtColor: 'text-red-500',
+      label: 'FAILED',
+    },
+  ],
+]);
+$: statusStyle = statusesStyle.get(status) || {
+  bgColor: 'bg-gray-900',
+  txtColor: 'text-gray-900',
+  label: status.toUpperCase(),
+};
+</script>
+
+<div aria-label="connection-status-icon" class="{roundIconStyle} {statusStyle.bgColor}"></div>
+<span aria-label="connection-status-label" class="{labelStyle} {statusStyle.txtColor}">{statusStyle.label}</span>


### PR DESCRIPTION
nit: change wording from started to enabled / etc.

### What does this PR do?

For providers it makes sense to have starting / stopping / stopped.

For extensions, it should be enable / disable / enabling / disabling
since they are extensions that you turn off and on, not something that
is "running" in the background.

Using the starting / stopping / stopped terms for extensions is
confusing.

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

https://github.com/containers/podman-desktop/assets/6422176/e8914923-e19b-4dd2-bad7-ab35dd7251fe

### What issues does this PR fix or reference?

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

Closes https://github.com/containers/podman-desktop/issues/2534
Closes https://github.com/containers/podman-desktop/issues/2379

### How to test this PR?

<!-- Please explain steps to reproduce -->

Go to extensions page, you should now see enable / disable rather that
start / stop.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
