### PR TITLE
chore: refactor stores

### DIFF
--- a/packages/renderer/src/lib/ContainerList.spec.ts
+++ b/packages/renderer/src/lib/ContainerList.spec.ts
@@ -30,14 +30,20 @@ const listContainersMock = vi.fn();
 const getProviderInfosMock = vi.fn();
 
 const deleteContainerMock = vi.fn();
+const listPodsMock = vi.fn();
+
+const kubernetesListPodsMock = vi.fn();
 
 // fake the window.events object
 beforeAll(() => {
   const onDidUpdateProviderStatusMock = vi.fn();
   (window as any).onDidUpdateProviderStatus = onDidUpdateProviderStatusMock;
   onDidUpdateProviderStatusMock.mockImplementation(() => Promise.resolve());
-
+  listPodsMock.mockImplementation(() => Promise.resolve([]));
+  kubernetesListPodsMock.mockImplementation(() => Promise.resolve([]));
   (window as any).listContainers = listContainersMock;
+  (window as any).listPods = listPodsMock;
+  (window as any).kubernetesListPods = kubernetesListPodsMock;
   (window as any).getProviderInfos = getProviderInfosMock;
   (window as any).removePod = vi.fn();
   (window as any).deleteContainer = deleteContainerMock;

--- a/packages/renderer/src/stores/catalog-extensions.spec.ts
+++ b/packages/renderer/src/stores/catalog-extensions.spec.ts
@@ -21,7 +21,11 @@
 import { get } from 'svelte/store';
 import type { Mock } from 'vitest';
 import { expect, test, vi } from 'vitest';
-import { catalogExtensionInfos, fetchCatalogExtensions, initWindowFetchCatalogExtensions } from './catalog-extensions';
+import {
+  catalogExtensionEventStore,
+  catalogExtensionEventStoreInfo,
+  catalogExtensionInfos,
+} from './catalog-extensions';
 import type { CatalogExtension } from '../../../main/src/plugin/extensions-catalog/extensions-catalog-api';
 
 // first, patch window object
@@ -47,15 +51,11 @@ Object.defineProperty(global, 'window', {
 
 beforeAll(() => {
   vi.clearAllMocks();
-});
-
-beforeEach(() => {
-  // init the store
-  initWindowFetchCatalogExtensions();
+  catalogExtensionEventStore.setup();
 });
 
 test('catalog extension should be updated in case of a container is removed', async () => {
-  // initial volume
+  // initial catalog is empty
   getCatalogExtensionsMock.mockResolvedValue([]);
 
   // get list and expect nothing there
@@ -103,7 +103,7 @@ test('catalog extension should be updated in case of a container is removed', as
   expect(getCatalogExtensionsMock).toBeCalled();
 
   // fetch manually
-  await fetchCatalogExtensions();
+  await catalogExtensionEventStoreInfo.fetch();
 
   // check if the catalog has been updated
   const afterCatalogExtensions = get(catalogExtensionInfos);

--- a/packages/renderer/src/stores/event-store-manager.spec.ts
+++ b/packages/renderer/src/stores/event-store-manager.spec.ts
@@ -1,0 +1,102 @@
+/**********************************************************************
+ * Copyright (C) 2022 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { beforeEach, expect, test, vi } from 'vitest';
+import { get } from 'svelte/store';
+import { addStore, allEventStoresInfo, getStore, updateStore } from './event-store-manager';
+import type { EventStoreInfo } from './event-store';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  allEventStoresInfo.set([]);
+});
+
+test('should add object into store-manager', async () => {
+  expect(get(allEventStoresInfo).length).toBe(0);
+
+  const eventStoreInfo: EventStoreInfo = {
+    name: 'test',
+    bufferEvents: [],
+  } as unknown as EventStoreInfo;
+
+  // add it
+  addStore(eventStoreInfo);
+
+  // check size
+  expect(get(allEventStoresInfo).length).toBe(1);
+
+  /// try to add it again
+  addStore(eventStoreInfo);
+
+  // check size (should be the same)
+  expect(get(allEventStoresInfo).length).toBe(1);
+});
+
+test('should get object into store-manager', async () => {
+  const eventStoreInfo: EventStoreInfo = {
+    name: 'test',
+    bufferEvents: [],
+  } as unknown as EventStoreInfo;
+
+  // add it
+  addStore(eventStoreInfo);
+
+  const foundStore = getStore('test');
+
+  expect(foundStore).toBeDefined();
+  expect(foundStore?.name).toBe('test');
+
+  const notFoundStore = getStore('not-found');
+  expect(notFoundStore).toBeUndefined();
+});
+
+test('should update object into store-manager', async () => {
+  const eventStoreInfo: EventStoreInfo = {
+    name: 'test-udpdate',
+    size: 0,
+    bufferEvents: [],
+  } as unknown as EventStoreInfo;
+
+  // add it
+  addStore(eventStoreInfo);
+
+  // grab objects from store
+  const allEvents = get(allEventStoresInfo);
+  expect(allEvents.length).toBe(1);
+  // take first item
+  const storeInfo = allEvents[0];
+  // check the name
+  expect(storeInfo.name).toBe('test-udpdate');
+  expect(storeInfo.size).toBe(0);
+
+  // create a new object with different size
+  const updatedEventStoreInfo: EventStoreInfo = {
+    name: 'test-udpdate',
+    size: 1234,
+  } as unknown as EventStoreInfo;
+  updateStore(updatedEventStoreInfo);
+
+  // grab objects from store
+  const allEventsAfterUpdate = get(allEventStoresInfo);
+  expect(allEventsAfterUpdate.length).toBe(1);
+  // take first item
+  const afterUpdateInfo = allEventsAfterUpdate[0];
+  // check the name
+  expect(afterUpdateInfo.name).toBe('test-udpdate');
+  expect(afterUpdateInfo.size).toBe(1234);
+});

--- a/packages/renderer/src/stores/event-store-manager.ts
+++ b/packages/renderer/src/stores/event-store-manager.ts
@@ -1,0 +1,53 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { get, writable, type Writable } from 'svelte/store';
+import type { EventStoreInfo } from './event-store';
+
+// This class manages access to different event stores
+
+export const allEventStoresInfo: Writable<EventStoreInfo[]> = writable([]);
+
+export function addStore(eventStoreInfo: EventStoreInfo) {
+  const allEvents = get(allEventStoresInfo);
+
+  // search if we have a matching store
+  const index = allEvents.findIndex(storeInfo => storeInfo.name === eventStoreInfo.name);
+  if (index === -1) {
+    allEvents.push(eventStoreInfo);
+    allEventStoresInfo.set(allEvents);
+  }
+}
+
+export function getStore(name: string): EventStoreInfo | undefined {
+  const allEvents = get(allEventStoresInfo);
+  const storeInfo = allEvents.find(storeInfo => storeInfo.name === name);
+  if (storeInfo) {
+    return storeInfo;
+  }
+  return undefined;
+}
+
+export function updateStore(eventStoreInfo: EventStoreInfo): void {
+  const allEvents = get(allEventStoresInfo);
+  const storeInfoIndex = allEvents.findIndex(storeInfo => storeInfo.name === eventStoreInfo.name);
+  if (storeInfoIndex !== -1) {
+    allEvents[storeInfoIndex] = eventStoreInfo;
+    allEventStoresInfo.set(allEvents);
+  }
+}

--- a/packages/renderer/src/stores/event-store.spec.ts
+++ b/packages/renderer/src/stores/event-store.spec.ts
@@ -1,0 +1,157 @@
+/**********************************************************************
+ * Copyright (C) 2022 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { beforeEach, expect, test, vi } from 'vitest';
+import { EventStore } from './event-store';
+import { get, writable, type Writable } from 'svelte/store';
+
+// first, path window object
+const callbacks = new Map<string, any>();
+const eventEmitter = {
+  receive: (message: string, callback: any) => {
+    callbacks.set(message, callback);
+  },
+};
+
+Object.defineProperty(global, 'window', {
+  value: {
+    events: {
+      receive: eventEmitter.receive,
+    },
+    addEventListener: eventEmitter.receive,
+  },
+  writable: true,
+});
+
+beforeEach(() => {
+  callbacks.clear();
+  vi.clearAllMocks();
+});
+
+interface MyCustomTypeInfo {
+  name: string;
+}
+
+test('should call fetch method using window event', async () => {
+  const myStoreInfo: Writable<MyCustomTypeInfo[]> = writable([]);
+  const checkForUpdateMock = vi.fn();
+
+  const windowEventName = 'my-custom-event';
+  const updater = vi.fn();
+
+  // return true to trigger the update
+  checkForUpdateMock.mockResolvedValue(true);
+
+  const eventStore = new EventStore('my-test', myStoreInfo, checkForUpdateMock, [windowEventName], [], updater);
+
+  // callbacks are empty
+  expect(callbacks.size).toBe(0);
+
+  // now call the setup
+  const eventStoreInfo = eventStore.setup();
+
+  // check we have callbacks
+  expect(callbacks.size).toBe(1);
+
+  // now we call the listener
+  const callback = callbacks.get(windowEventName);
+  expect(callback).toBeDefined();
+
+  const myCustomTypeInfo: MyCustomTypeInfo = {
+    name: 'my-custom-type',
+  };
+  updater.mockResolvedValue([myCustomTypeInfo]);
+
+  await callback();
+
+  // check the updater is called
+  expect(updater).toHaveBeenCalled();
+
+  // check the store is updated
+  expect(get(myStoreInfo)).toStrictEqual([myCustomTypeInfo]);
+
+  // check the store is updated
+  expect(get(myStoreInfo)).toStrictEqual([myCustomTypeInfo]);
+
+  // check buffer events
+  expect(eventStoreInfo.bufferEvents.length).toBe(1);
+  expect(eventStoreInfo.bufferEvents[0]).toHaveProperty('name', windowEventName);
+  expect(eventStoreInfo.bufferEvents[0]).toHaveProperty('skipped', false);
+  expect(eventStoreInfo.bufferEvents[0]).toHaveProperty('args', undefined);
+  expect(eventStoreInfo.bufferEvents[0]).toHaveProperty('length', 1);
+});
+
+test('should call fetch method using listener event', async () => {
+  const myStoreInfo: Writable<MyCustomTypeInfo[]> = writable([]);
+  const checkForUpdateMock = vi.fn();
+
+  const windowListenerEventName = 'my-custom-listener-event';
+  const updater = vi.fn();
+
+  // return true to trigger the update
+  checkForUpdateMock.mockResolvedValue(true);
+
+  const eventStore = new EventStore(
+    'my-listener-test',
+    myStoreInfo,
+    checkForUpdateMock,
+    [],
+    [windowListenerEventName],
+    updater,
+  );
+
+  // callbacks are empty
+  expect(callbacks.size).toBe(0);
+
+  // now call the setup
+  const eventStoreInfo = eventStore.setup();
+
+  expect(eventStoreInfo.bufferEvents.length).toBe(0);
+
+  // check we have callbacks
+  expect(callbacks.size).toBe(1);
+
+  // now we call the listener
+  const callback = callbacks.get(windowListenerEventName);
+  expect(callback).toBeDefined();
+
+  const myCustomTypeInfo: MyCustomTypeInfo = {
+    name: 'my-custom-type',
+  };
+  updater.mockResolvedValue([myCustomTypeInfo]);
+
+  await callback();
+
+  // wait updater being called
+  while (updater.mock.calls.length === 0) {
+    await new Promise(resolve => setTimeout(resolve, 100));
+  }
+
+  // check the updater is called
+  expect(updater).toHaveBeenCalled();
+
+  // check the store is updated
+  expect(get(myStoreInfo)).toStrictEqual([myCustomTypeInfo]);
+
+  // check buffer events
+  expect(eventStoreInfo.bufferEvents.length).toBe(1);
+  expect(eventStoreInfo.bufferEvents[0]).toHaveProperty('name', windowListenerEventName);
+  expect(eventStoreInfo.bufferEvents[0]).toHaveProperty('skipped', false);
+  expect(eventStoreInfo.bufferEvents[0]).toHaveProperty('args', undefined);
+  expect(eventStoreInfo.bufferEvents[0]).toHaveProperty('length', 1);
+});

--- a/packages/renderer/src/stores/event-store.ts
+++ b/packages/renderer/src/stores/event-store.ts
@@ -1,0 +1,158 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+// eslint-disable-next-line import/no-duplicates
+import type { Writable } from 'svelte/store';
+// eslint-disable-next-line import/no-duplicates
+import type { ComponentType } from 'svelte';
+
+import { addStore, updateStore } from './event-store-manager';
+import humanizeDuration from 'humanize-duration';
+import DesktopIcon from '../lib/images/DesktopIcon.svelte';
+
+export interface EventStoreInfo {
+  name: string;
+
+  iconComponent?: ComponentType;
+
+  // list last 100 events
+  bufferEvents: {
+    name: string;
+
+    // args of the event
+    args: unknown[];
+
+    date: number;
+    // if the event was skipped
+    skipped: boolean;
+    length?: number;
+
+    // update time in ms
+    humanDuration?: number;
+  }[];
+
+  // number of elements in the store
+  size: number;
+
+  // clear all
+  clearEvents(): void;
+
+  // force a fetch of the data to update the store
+  fetch(): Promise<void>;
+}
+
+// Helper to manage store updated from events
+
+export class EventStore<T> {
+  constructor(
+    private name: string,
+    private store: Writable<T>,
+    private checkForUpdate: (eventName: string, args?: unknown[]) => Promise<boolean>,
+    private windowEvents: string[],
+    private windowListeners: string[],
+    private updater: () => Promise<T>,
+    private iconComponent?: ComponentType,
+  ) {
+    if (!iconComponent) {
+      this.iconComponent = DesktopIcon;
+    }
+  }
+
+  protected async performUpdate(
+    needUpdate: boolean,
+    eventStoreInfo: EventStoreInfo,
+    eventName: string,
+    args?: unknown[],
+  ): Promise<void> {
+    // not intialized yet
+    if (!this.updater) {
+      return;
+    }
+
+    let numberOfResults;
+    let updateDuration;
+    try {
+      if (needUpdate) {
+        const before = performance.now();
+        const result = await this.updater();
+        const after = performance.now();
+        numberOfResults = Array.isArray(result) ? result.length : 0;
+        updateDuration = humanizeDuration(after - before, { units: ['s', 'ms'], round: true, largest: 1 });
+        // update the store
+        if (Array.isArray(result)) {
+          eventStoreInfo.size = (result as Array<unknown>).length;
+        }
+        this.store.set(result);
+      }
+    } finally {
+      // update the info object
+      eventStoreInfo.bufferEvents.push({
+        name: eventName,
+        args: args,
+        date: Date.now(),
+        skipped: !needUpdate,
+        length: numberOfResults,
+        humanDuration: updateDuration,
+      });
+      if (eventStoreInfo.bufferEvents.length > 100) {
+        eventStoreInfo.bufferEvents.shift();
+      }
+      updateStore(eventStoreInfo);
+    }
+  }
+
+  setup(): EventStoreInfo {
+    const bufferEvents = [];
+
+    // register the store in the global list
+    const eventStoreInfo: EventStoreInfo = {
+      name: this.name,
+      bufferEvents,
+      iconComponent: this.iconComponent,
+      size: 0,
+      clearEvents: () => {
+        bufferEvents.length = 0;
+        updateStore(eventStoreInfo);
+      },
+      fetch: async () => {
+        await this.performUpdate(true, eventStoreInfo, 'manual');
+        updateStore(eventStoreInfo);
+      },
+    };
+    addStore(eventStoreInfo);
+
+    const update = async (eventName: string, args?: unknown[]) => {
+      const needUpdate = await this.checkForUpdate(eventName, args);
+      await this.performUpdate(needUpdate, eventStoreInfo, eventName, args);
+    };
+    this.windowEvents.forEach(eventName => {
+      window.events?.receive(eventName, async (args?: unknown[]) => {
+        await update(eventName, args);
+      });
+    });
+
+    this.windowListeners.forEach(eventName => {
+      window.addEventListener(eventName, () => {
+        update(eventName).catch((error: unknown) => {
+          console.error(`Failed to update ${this.name}`, error);
+        });
+      });
+    });
+    return eventStoreInfo;
+  }
+}

--- a/packages/renderer/src/stores/extensions.ts
+++ b/packages/renderer/src/stores/extensions.ts
@@ -16,42 +16,39 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { Writable } from 'svelte/store';
-import { writable } from 'svelte/store';
+import { writable, type Writable } from 'svelte/store';
 import type { ExtensionInfo } from '../../../main/src/plugin/api/extension-info';
+import { EventStore } from './event-store';
 
-export async function fetchExtensions() {
-  const result = await window.listExtensions();
-  result.sort((a, b) => a.displayName.localeCompare(b.displayName));
-  extensionInfos.set(result);
+const windowEvents = [
+  'extension-starting',
+  'extension-started',
+  'extension-stopping',
+  'extension-stopped',
+  'extension-removed',
+  'extensions-started',
+  'extensions-updated',
+];
+const windowListeners = ['system-ready'];
+
+export async function checkForUpdate(): Promise<boolean> {
+  return true;
 }
 
 export const extensionInfos: Writable<ExtensionInfo[]> = writable([]);
 
-// need to refresh when extension is started or stopped
-window?.events?.receive('extension-starting', async () => {
-  await fetchExtensions();
-});
-window?.events?.receive('extension-started', async () => {
-  await fetchExtensions();
-});
-window?.events?.receive('extension-stopping', async () => {
-  await fetchExtensions();
-});
-window?.events?.receive('extension-stopped', async () => {
-  await fetchExtensions();
-});
-window?.events?.receive('extension-removed', async () => {
-  await fetchExtensions();
-});
-window?.events?.receive('extensions-started', async () => {
-  await fetchExtensions();
-});
-window?.events?.receive('extensions-updated', async () => {
-  await fetchExtensions();
-});
-window.addEventListener('system-ready', () => {
-  fetchExtensions().catch((error: unknown) => {
-    console.error('Failed to fetch extensions', error);
-  });
-});
+const eventStore = new EventStore<ExtensionInfo[]>(
+  'extensions',
+  extensionInfos,
+  checkForUpdate,
+  windowEvents,
+  windowListeners,
+  fetchExtensions,
+);
+eventStore.setup();
+
+export async function fetchExtensions(): Promise<ExtensionInfo[]> {
+  const result = await window.listExtensions();
+  result.sort((a, b) => a.displayName.localeCompare(b.displayName));
+  return result;
+}

--- a/packages/renderer/src/stores/registries.ts
+++ b/packages/renderer/src/stores/registries.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2022 Red Hat, Inc.
+ * Copyright (C) 2022-2023 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/renderer/src/stores/volumes.spec.ts
+++ b/packages/renderer/src/stores/volumes.spec.ts
@@ -22,7 +22,7 @@ import { get } from 'svelte/store';
 import type { Mock } from 'vitest';
 import { expect, test, vi } from 'vitest';
 import type { VolumeInspectInfo } from '../../../main/src/plugin/api/volume-info';
-import { fetchVolumes, initWindowFetchVolumes, volumeListInfos } from './volumes';
+import { fetchVolumes, volumeListInfos, volumesEventStore } from './volumes';
 
 // first, path window object
 const callbacks = new Map<string, any>();
@@ -49,11 +49,6 @@ beforeAll(() => {
   vi.clearAllMocks();
 });
 
-beforeEach(() => {
-  // init the store
-  initWindowFetchVolumes();
-});
-
 test('volumes should be updated in case of a container is removed', async () => {
   // initial volume
   listVolumesMock.mockResolvedValue([
@@ -67,6 +62,7 @@ test('volumes should be updated in case of a container is removed', async () => 
       ],
     } as unknown as VolumeInspectInfo,
   ]);
+  volumesEventStore.setup();
 
   const callback = callbacks.get('extensions-already-started');
   // send 'extensions-already-started' event


### PR DESCRIPTION
### What does this PR do?
A lot of stores were having the same pattern with a lot of copy/paste.

Refactor by introducing an EventStore class, allowing to update, fetch, get details on events that triggered the update

It will help to build troubleshooting of these stores as they'll stick to a same design.

Also all stores following this type are now registered in a global store to fetch/investigate/analyze all of them.

From user point-of-view, it should work now as before. Nothing has changed in the stores, they should be updated in the same way

### Screenshot/screencast of this PR

nothing graphical for now

### What issues does this PR fix or reference?

part of https://github.com/containers/podman-desktop/issues/3053

### How to test this PR?

Check that everything is working as before. Containers, extensions, images, pods, volumes, etc.
