### PR TITLE
feat: Add restart functionality for compose grouped containers

### DIFF
--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -63,6 +63,38 @@ const fakeContainerWithComposeProject: Dockerode.ContainerInfo = {
   },
 };
 
+const fakeContainer: Dockerode.ContainerInfo = {
+  Id: '1234',
+  Names: ['/container2'],
+  Image: 'image2',
+  ImageID: 'image2',
+  Command: 'command2',
+  Created: 1234567890,
+  State: 'running',
+  Status: 'running',
+  Ports: [],
+  Labels: {},
+  Mounts: [],
+  HostConfig: {
+    NetworkMode: 'bridge',
+  },
+  NetworkSettings: {
+    Networks: {
+      bridge: {
+        IPAddress: '',
+        IPPrefixLen: 0,
+        Gateway: '',
+        NetworkID: '',
+        EndpointID: '',
+        IPv6Gateway: '',
+        GlobalIPv6Address: '',
+        GlobalIPv6PrefixLen: 0,
+        MacAddress: '',
+      },
+    },
+  },
+};
+
 vi.mock('dockerode', async () => {
   return {
     default: vi.fn(),
@@ -134,6 +166,7 @@ test('restartContainersByLabel should succeed successfully if project name is pr
         fakeContainerWithComposeProject,
         fakeContainerWithComposeProject,
         fakeContainerWithComposeProject,
+        fakeContainer,
       ]),
     getContainer: vi.fn().mockReturnValue({ restart: vi.fn().mockResolvedValue({}) }),
     listPods: vi.fn().mockResolvedValue([]),
@@ -143,7 +176,7 @@ test('restartContainersByLabel should succeed successfully if project name is pr
   vi.spyOn(containerRegistry, 'listSimpleContainers').mockReturnValue(engine.listSimpleContainers());
 
   // Spy on restartContainer to make sure it's called
-  // it is NOT called if there are no matches.. So it's important tot check this.
+  // it is NOT called if there are no matches.. So it's important to check this.
   const restartContainer = vi.spyOn(containerRegistry, 'restartContainer');
 
   // Restart all containers in the 'project1' project

--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -125,7 +125,7 @@ test('push should succeed if provider', async () => {
   expect(result).toBeUndefined();
 });
 
-test('restartContainersByProject should succeed successfully if project name is provided and call restartContainer', async () => {
+test('restartContainersByLabel should succeed successfully if project name is provided and call restartContainer', async () => {
   const engine = {
     // Fake that we have 3 containers of the same project
     listSimpleContainers: vi
@@ -147,7 +147,7 @@ test('restartContainersByProject should succeed successfully if project name is 
   const restartContainer = vi.spyOn(containerRegistry, 'restartContainer');
 
   // Restart all containers in the 'project1' project
-  const result = await containerRegistry.restartContainersByProject('dummy', 'project1');
+  const result = await containerRegistry.restartContainersByLabel('dummy', 'com.docker.compose.project', 'project1');
   expect(result).toBeUndefined();
 
   // Expect restartContainer tohave been called 3 times

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -1042,20 +1042,18 @@ export class ContainerProviderRegistry {
   }
 
   // Find all containers that match the against the given project name to
-  // the label com.docker.compose.project
-  // and then restart all the containers that match that label
-  async restartContainersByProject(engineId: string, projectName: string): Promise<void> {
+  // the label com.docker.compose.project (for example)
+  // and then restart all the containers that have the following label AND key
+  async restartContainersByLabel(engineId: string, label: string, key: string): Promise<void> {
     let telemetryOptions = {};
     try {
-      const projectLabel = 'com.docker.compose.project';
-
       // Get all the containers using listSimpleContainers
       const containers = await this.listSimpleContainers();
 
       // Find all the containers that are using projectLabel and match the projectName
       const containersMatchingProject = containers.filter(container => {
         const labels = container.Labels;
-        return labels && labels[projectLabel] === projectName;
+        return labels && labels[label] === key;
       });
 
       // Get all the container ids in containersIds
@@ -1068,7 +1066,7 @@ export class ContainerProviderRegistry {
       throw error;
     } finally {
       this.telemetryService
-        .track('restartProjectContainers', telemetryOptions)
+        .track('restartContainersByLabel', telemetryOptions)
         .catch((err: unknown) => console.error('Unable to track', err));
     }
   }

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -883,6 +883,14 @@ export class PluginSystem {
         return containerProviderRegistry.restartContainer(engine, containerId);
       },
     );
+
+    this.ipcHandle(
+      'container-provider-registry:restartContainersByProject',
+      async (_listener, engine: string, projectName: string): Promise<void> => {
+        return containerProviderRegistry.restartContainersByProject(engine, projectName);
+      },
+    );
+
     this.ipcHandle(
       'container-provider-registry:createAndStartContainer',
       async (_listener, engine: string, options: ContainerCreateOptions): Promise<void> => {

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -885,9 +885,9 @@ export class PluginSystem {
     );
 
     this.ipcHandle(
-      'container-provider-registry:restartContainersByProject',
-      async (_listener, engine: string, projectName: string): Promise<void> => {
-        return containerProviderRegistry.restartContainersByProject(engine, projectName);
+      'container-provider-registry:restartContainersByLabel',
+      async (_listener, engine: string, label: string, key: string): Promise<void> => {
+        return containerProviderRegistry.restartContainersByLabel(engine, label, key);
       },
     );
 

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -327,9 +327,9 @@ function initExposure(): void {
   });
 
   contextBridge.exposeInMainWorld(
-    'restartContainersByProject',
-    async (engine: string, projectName: string): Promise<void> => {
-      return ipcInvoke('container-provider-registry:restartContainersByProject', engine, projectName);
+    'restartContainersByLabel',
+    async (engine: string, label: string, key: string): Promise<void> => {
+      return ipcInvoke('container-provider-registry:restartContainersByLabel', engine, label, key);
     },
   );
 

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -327,6 +327,13 @@ function initExposure(): void {
   });
 
   contextBridge.exposeInMainWorld(
+    'restartContainersByProject',
+    async (engine: string, projectName: string): Promise<void> => {
+      return ipcInvoke('container-provider-registry:restartContainersByProject', engine, projectName);
+    },
+  );
+
+  contextBridge.exposeInMainWorld(
     'createAndStartContainer',
     async (engine: string, options: ContainerCreateOptions): Promise<void> => {
       return ipcInvoke('container-provider-registry:createAndStartContainer', engine, options);

--- a/packages/renderer/src/lib/ContainerList.svelte
+++ b/packages/renderer/src/lib/ContainerList.svelte
@@ -30,6 +30,7 @@ import { containerGroupsInfo } from '../stores/containerGroups';
 import Checkbox from './ui/Checkbox.svelte';
 import type { PodInfo } from '../../../main/src/plugin/api/pod-info';
 import { PodUtils } from '../lib/pod/pod-utils';
+import ComposeActions from './compose/ComposeActions.svelte';
 
 const containerUtils = new ContainerUtils();
 let openChoiceModal = false;
@@ -490,6 +491,15 @@ function errorCallback(container: ContainerInfoUI, errorMessage: string): void {
                       kind: 'podman',
                     }}"
                     redirectAfterDelete="{false}"
+                    dropdownMenu="{true}" />
+                {/if}
+                {#if containerGroup.type === ContainerGroupInfoTypeUI.COMPOSE}
+                  <ComposeActions
+                    compose="{{
+                      status: containerGroup.status,
+                      name: containerGroup.name,
+                      engineId: containerGroup.engineId,
+                    }}"
                     dropdownMenu="{true}" />
                 {/if}
               </td>

--- a/packages/renderer/src/lib/compose/ComposeActions.svelte
+++ b/packages/renderer/src/lib/compose/ComposeActions.svelte
@@ -12,10 +12,12 @@ export let detailed = false;
 export let inProgressCallback: (inProgress: boolean, state?: string) => void = () => {};
 export let errorCallback: (erroMessage: string) => void = () => {};
 
+const composeLabel = 'com.docker.compose.project';
+
 async function restartCompose(composeInfoUI: ComposeInfoUI) {
   inProgressCallback(true, 'RESTARTING');
   try {
-    await window.restartContainersByProject(composeInfoUI.engineId, composeInfoUI.name);
+    await window.restartContainersByLabel(composeInfoUI.engineId, composeLabel, composeInfoUI.name);
   } catch (error) {
     errorCallback(error);
   } finally {

--- a/packages/renderer/src/lib/compose/ComposeActions.svelte
+++ b/packages/renderer/src/lib/compose/ComposeActions.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+import { faArrowsRotate } from '@fortawesome/free-solid-svg-icons';
+import type { ComposeInfoUI } from './ComposeInfoUI';
+import ListItemButtonIcon from '../ui/ListItemButtonIcon.svelte';
+import DropdownMenu from '../ui/DropdownMenu.svelte';
+import FlatMenu from '../ui/FlatMenu.svelte';
+
+export let compose: ComposeInfoUI;
+export let dropdownMenu = false;
+export let detailed = false;
+
+export let inProgressCallback: (inProgress: boolean, state?: string) => void = () => {};
+export let errorCallback: (erroMessage: string) => void = () => {};
+
+async function restartCompose(composeInfoUI: ComposeInfoUI) {
+  inProgressCallback(true, 'RESTARTING');
+  try {
+    await window.restartContainersByProject(composeInfoUI.engineId, composeInfoUI.name);
+  } catch (error) {
+    errorCallback(error);
+  } finally {
+    inProgressCallback(false);
+  }
+}
+
+// If dropdownMenu = true, we'll change style to the imported dropdownMenu style
+// otherwise, leave blank.
+let actionsStyle;
+if (dropdownMenu) {
+  actionsStyle = DropdownMenu;
+} else {
+  actionsStyle = FlatMenu;
+}
+</script>
+
+<!-- If dropdownMenu is true, use it, otherwise just show the regular buttons -->
+<svelte:component this="{actionsStyle}">
+  <ListItemButtonIcon
+    title="Restart Compose"
+    onClick="{() => restartCompose(compose)}"
+    menu="{dropdownMenu}"
+    detailed="{detailed}"
+    icon="{faArrowsRotate}" />
+</svelte:component>

--- a/packages/renderer/src/lib/compose/ComposeInfoUI.ts
+++ b/packages/renderer/src/lib/compose/ComposeInfoUI.ts
@@ -1,0 +1,25 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+export interface ComposeInfoUI {
+  engineId: string;
+  name: string;
+  status: string;
+  actionInProgress?: boolean;
+  actionError?: string;
+}

--- a/packages/renderer/src/lib/container/container-utils.ts
+++ b/packages/renderer/src/lib/container/container-utils.ts
@@ -145,6 +145,7 @@ export class ContainerUtils {
       return {
         name: composeProject,
         type: ContainerGroupInfoTypeUI.COMPOSE,
+        engineId: containerInfo.engineId,
       };
     }
 

--- a/packages/renderer/src/lib/pod/PodActions.svelte
+++ b/packages/renderer/src/lib/pod/PodActions.svelte
@@ -16,6 +16,7 @@ export let errorCallback: (erroMessage: string) => void = () => {};
 
 async function startPod(podInfoUI: PodInfoUI) {
   inProgressCallback(true, 'STARTING');
+  console.log('pod: ', pod);
   try {
     await window.startPod(podInfoUI.engineId, podInfoUI.id);
   } catch (error) {

--- a/packages/renderer/src/lib/pod/PodActions.svelte
+++ b/packages/renderer/src/lib/pod/PodActions.svelte
@@ -16,7 +16,6 @@ export let errorCallback: (erroMessage: string) => void = () => {};
 
 async function startPod(podInfoUI: PodInfoUI) {
   inProgressCallback(true, 'STARTING');
-  console.log('pod: ', pod);
   try {
     await window.startPod(podInfoUI.engineId, podInfoUI.id);
   } catch (error) {


### PR DESCRIPTION
feat: Add restart functionality for compose grouped containers

### What does this PR do?

Adds a button to the group in order to restart all the containers as
part of the compose group.

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


https://github.com/containers/podman-desktop/assets/6422176/13f41275-855e-4894-9ef5-4fea3bc097a8



### What issues does this PR fix or reference?

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

Closes https://github.com/containers/podman-desktop/issues/3102

### How to test this PR?

<!-- Please explain steps to reproduce -->

1. Deploy a docker-compose example
   (https://raw.githubusercontent.com/kubernetes/kompose/main/examples/docker-compose.yaml)
2. Go to the container view in PD
3. Press "Restart Compose"

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
