### PR TITLE
chore: allow to specify the name of a modal

### DIFF
--- a/packages/renderer/src/lib/dialogs/Modal.svelte
+++ b/packages/renderer/src/lib/dialogs/Modal.svelte
@@ -34,6 +34,7 @@ const dispatch = createEventDispatcher();
 const close = () => dispatch('close');
 
 let modal: HTMLDivElement;
+export let name = '';
 
 const handle_keydown = e => {
   if (e.key === 'Escape') {
@@ -70,6 +71,6 @@ if (previously_focused) {
 
 <div class="modal-background" on:click="{close}"></div>
 
-<div class="modal" role="dialog" aria-modal="true" bind:this="{modal}">
+<div class="modal" role="dialog" aria-label="{name}" aria-modal="true" bind:this="{modal}">
   <slot />
 </div>


### PR DESCRIPTION

### What does this PR do?
allow to specify the name of a modal
it includes the name in the aria-label

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

Ease component testing

### How to test this PR?

<!-- Please explain steps to reproduce -->
