### PR TITLE
feat: dynamic breadcrumbs

### DIFF
--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -87,10 +87,10 @@ window.events?.receive('display-troubleshooting', () => {
         <Route path="/" breadcrumb="Dashboard Page">
           <DashboardPage />
         </Route>
-        <Route path="/containers" breadcrumb="Containers" navLevel="list">
+        <Route path="/containers" breadcrumb="Containers" navigationHint="root">
           <ContainerList searchTerm="{meta.query.filter || ''}" />
         </Route>
-        <Route path="/containers/:id/*" breadcrumb="Container Details" let:meta navLevel="details">
+        <Route path="/containers/:id/*" breadcrumb="Container Details" let:meta navigationHint="details">
           <ContainerDetails containerID="{meta.params.id}" />
         </Route>
 
@@ -98,10 +98,14 @@ window.events?.receive('display-troubleshooting', () => {
           <KubePlayYAML />
         </Route>
 
-        <Route path="/images" breadcrumb="Images" navLevel="list">
+        <Route path="/images" breadcrumb="Images" navigationHint="root">
           <ImagesList />
         </Route>
-        <Route path="/images/:id/:engineId/:base64RepoTag/*" breadcrumb="Image Details" let:meta navLevel="details">
+        <Route
+          path="/images/:id/:engineId/:base64RepoTag/*"
+          breadcrumb="Image Details"
+          let:meta
+          navigationHint="details">
           <ImageDetails
             imageID="{meta.params.id}"
             engineId="{decodeURI(meta.params.engineId)}"
@@ -116,7 +120,7 @@ window.events?.receive('display-troubleshooting', () => {
         <Route path="/images/pull" breadcrumb="Pull an Image">
           <PullImage />
         </Route>
-        <Route path="/pods" breadcrumb="Pods" navLevel="list">
+        <Route path="/pods" breadcrumb="Pods" navigationHint="root">
           <PodsList />
         </Route>
         <Route path="/deploy-to-kube/:resourceId/:engineId/*" breadcrumb="Deploy to Kubernetes" let:meta>
@@ -124,7 +128,7 @@ window.events?.receive('display-troubleshooting', () => {
             resourceId="{decodeURI(meta.params.resourceId)}"
             engineId="{decodeURI(meta.params.engineId)}" />
         </Route>
-        <Route path="/pods/:kind/:name/:engineId/*" breadcrumb="Pod Details" let:meta navLevel="details">
+        <Route path="/pods/:kind/:name/:engineId/*" breadcrumb="Pod Details" let:meta navigationHint="details">
           <PodDetails
             podName="{decodeURI(meta.params.name)}"
             engineId="{decodeURI(meta.params.engineId)}"
@@ -133,10 +137,10 @@ window.events?.receive('display-troubleshooting', () => {
         <Route path="/pod-create-from-containers" breadcrumb="Create Pod">
           <PodCreateFromContainers />
         </Route>
-        <Route path="/volumes" breadcrumb="Volumes" navLevel="list">
+        <Route path="/volumes" breadcrumb="Volumes" navigationHint="root">
           <VolumesList />
         </Route>
-        <Route path="/volumes/:name/:engineId/*" breadcrumb="Volume Details" let:meta navLevel="details">
+        <Route path="/volumes/:name/:engineId/*" breadcrumb="Volume Details" let:meta navigationHint="details">
           <VolumeDetails volumeName="{decodeURI(meta.params.name)}" engineId="{decodeURI(meta.params.engineId)}" />
         </Route>
         <Route path="/providers" breadcrumb="Providers">

--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -87,59 +87,56 @@ window.events?.receive('display-troubleshooting', () => {
         <Route path="/" breadcrumb="Dashboard Page">
           <DashboardPage />
         </Route>
-        <Route path="/containers" breadcrumb="Containers">
+        <Route path="/containers" breadcrumb="Containers" navLevel="list">
           <ContainerList searchTerm="{meta.query.filter || ''}" />
         </Route>
-        <Route path="/containers/:id/*" breadcrumb="Container Details" let:meta>
+        <Route path="/containers/:id/*" breadcrumb="Container Details" let:meta navLevel="details">
           <ContainerDetails containerID="{meta.params.id}" />
         </Route>
 
-        <Route path="/kube/play" breadcrumb="Play Pods or Containers from a Kubernetes YAML File">
+        <Route path="/kube/play" breadcrumb="Play Kubernetes YAML">
           <KubePlayYAML />
         </Route>
 
-        <Route path="/images" breadcrumb="Images">
+        <Route path="/images" breadcrumb="Images" navLevel="list">
           <ImagesList />
         </Route>
-        <Route path="/images/:id/:engineId/:base64RepoTag/*" breadcrumb="Image Details" let:meta>
+        <Route path="/images/:id/:engineId/:base64RepoTag/*" breadcrumb="Image Details" let:meta navLevel="details">
           <ImageDetails
             imageID="{meta.params.id}"
             engineId="{decodeURI(meta.params.engineId)}"
             base64RepoTag="{meta.params.base64RepoTag}" />
         </Route>
-        <Route path="/images/build" breadcrumb="Build Image from Containerfile">
+        <Route path="/images/build" breadcrumb="Build an Image">
           <BuildImageFromContainerfile />
         </Route>
-        <Route path="/images/run/*" breadcrumb="Create a container from image">
+        <Route path="/images/run/*" breadcrumb="Run Image">
           <RunImage />
         </Route>
-        <Route path="/images/pull" breadcrumb="Pull Image From a Registry">
+        <Route path="/images/pull" breadcrumb="Pull an Image">
           <PullImage />
         </Route>
-        <Route path="/pods" breadcrumb="Pods">
+        <Route path="/pods" breadcrumb="Pods" navLevel="list">
           <PodsList />
         </Route>
-        <Route
-          path="/deploy-to-kube/:resourceId/:engineId/*"
-          breadcrumb="Generated pod to deploy to Kubernetes"
-          let:meta>
+        <Route path="/deploy-to-kube/:resourceId/:engineId/*" breadcrumb="Deploy to Kubernetes" let:meta>
           <DeployPodToKube
             resourceId="{decodeURI(meta.params.resourceId)}"
             engineId="{decodeURI(meta.params.engineId)}" />
         </Route>
-        <Route path="/pods/:kind/:name/:engineId/*" breadcrumb="Pod Details" let:meta>
+        <Route path="/pods/:kind/:name/:engineId/*" breadcrumb="Pod Details" let:meta navLevel="details">
           <PodDetails
             podName="{decodeURI(meta.params.name)}"
             engineId="{decodeURI(meta.params.engineId)}"
             kind="{decodeURI(meta.params.kind)}" />
         </Route>
-        <Route path="/pod-create-from-containers" breadcrumb="Create a pod from containers">
+        <Route path="/pod-create-from-containers" breadcrumb="Create Pod">
           <PodCreateFromContainers />
         </Route>
-        <Route path="/volumes" breadcrumb="Volumes">
+        <Route path="/volumes" breadcrumb="Volumes" navLevel="list">
           <VolumesList />
         </Route>
-        <Route path="/volumes/:name/:engineId/*" breadcrumb="Volume Details" let:meta>
+        <Route path="/volumes/:name/:engineId/*" breadcrumb="Volume Details" let:meta navLevel="details">
           <VolumeDetails volumeName="{decodeURI(meta.params.name)}" engineId="{decodeURI(meta.params.engineId)}" />
         </Route>
         <Route path="/providers" breadcrumb="Providers">

--- a/packages/renderer/src/Route.svelte
+++ b/packages/renderer/src/Route.svelte
@@ -3,13 +3,14 @@ import { createRouteObject } from 'tinro/dist/tinro_lib';
 import type { TinroBreadcrumb, TinroRouteMeta } from 'tinro';
 import { TelemetryService } from './TelemetryService';
 import { lastPage, currentPage, listPage, detailsPage } from './stores/breadcrumb';
+import type { NavigationHint } from './Route';
 
 export let path = '/*';
 export let fallback = false;
 export let redirect = false;
 export let firstmatch = false;
 export let breadcrumb = null;
-export let navLevel = undefined;
+export let navigationHint: NavigationHint = undefined;
 
 let showContent = false;
 let params: Record<string, string> = {};
@@ -35,13 +36,13 @@ function processMetaBreadcrumbs(breadcrumbs?: Array<TinroBreadcrumb>) {
     const curPage = breadcrumbs[breadcrumbs.length - 1];
     if (!curPage) return;
 
-    if (navLevel === 'list') {
+    if (navigationHint === 'root') {
       listPage.set(curPage);
       detailsPage.set(undefined);
-    } else if (navLevel === 'details') {
+    } else if (navigationHint === 'details') {
       detailsPage.set(curPage);
       lastPage.set($listPage);
-    } else if (navLevel === 'tab') {
+    } else if (navigationHint === 'tab') {
       // if we're on a details tab, fix the breadcrumb to come back to this tab
       const path = curPage.path.substring(0, curPage.path.lastIndexOf('/'));
       if ($detailsPage?.path.startsWith(path)) {
@@ -56,7 +57,7 @@ function processMetaBreadcrumbs(breadcrumbs?: Array<TinroBreadcrumb>) {
     }
 
     // set the current page to this route, unless we're on a tab
-    if (navLevel !== 'tab') {
+    if (navigationHint !== 'tab') {
       currentPage.set(curPage);
     }
 

--- a/packages/renderer/src/Route.svelte
+++ b/packages/renderer/src/Route.svelte
@@ -33,6 +33,8 @@ const route = createRouteObject({
 function processMetaBreadcrumbs(breadcrumbs?: Array<TinroBreadcrumb>) {
   if (breadcrumbs) {
     const curPage = breadcrumbs[breadcrumbs.length - 1];
+    if (!curPage) return;
+
     if (navLevel === 'list') {
       listPage.set(curPage);
       detailsPage.set(undefined);

--- a/packages/renderer/src/Route.svelte
+++ b/packages/renderer/src/Route.svelte
@@ -2,12 +2,14 @@
 import { createRouteObject } from 'tinro/dist/tinro_lib';
 import type { TinroBreadcrumb, TinroRouteMeta } from 'tinro';
 import { TelemetryService } from './TelemetryService';
+import { lastPage, currentPage, listPage, detailsPage } from './stores/breadcrumb';
 
 export let path = '/*';
 export let fallback = false;
 export let redirect = false;
 export let firstmatch = false;
 export let breadcrumb = null;
+export let navLevel = undefined;
 
 let showContent = false;
 let params: Record<string, string> = {};
@@ -30,6 +32,32 @@ const route = createRouteObject({
 
 function processMetaBreadcrumbs(breadcrumbs?: Array<TinroBreadcrumb>) {
   if (breadcrumbs) {
+    const curPage = breadcrumbs[breadcrumbs.length - 1];
+    if (navLevel === 'list') {
+      listPage.set(curPage);
+      detailsPage.set(undefined);
+    } else if (navLevel === 'details') {
+      detailsPage.set(curPage);
+      lastPage.set($listPage);
+    } else if (navLevel === 'tab') {
+      // if we're on a details tab, fix the breadcrumb to come back to this tab
+      const path = curPage.path.substring(0, curPage.path.lastIndexOf('/'));
+      if ($detailsPage?.path.startsWith(path)) {
+        $detailsPage.path = curPage.path;
+      } else {
+        // otherwise, set the last page normally
+        lastPage.set($detailsPage ? $detailsPage : $listPage);
+      }
+    } else {
+      // set the last page to either details or list page
+      lastPage.set($detailsPage ? $detailsPage : $listPage);
+    }
+
+    // set the current page to this route, unless we're on a tab
+    if (navLevel !== 'tab') {
+      currentPage.set(curPage);
+    }
+
     TelemetryService.getService().handlePageOpen(breadcrumbs.map(breadcrumb => breadcrumb.name).join('/'));
   }
 }

--- a/packages/renderer/src/Route.ts
+++ b/packages/renderer/src/Route.ts
@@ -1,0 +1,26 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/**
+ * Navigation hints for setting current page and history (breadcrumbs):
+ *  root    - root pages that reset the history
+ *  details - additional pages that should be tracked in the history
+ *  tab     - tabs or other sub-pages that affect the URL, but do not
+ *            change what the 'current' page is.
+ */
+export type NavigationHint = 'root' | 'details' | 'tab';

--- a/packages/renderer/src/lib/container/ContainerDetails.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetails.svelte
@@ -47,12 +47,7 @@ function errorCallback(errorMessage: string): void {
 </script>
 
 {#if container}
-  <DetailsPage
-    name="Container Details"
-    title="{container.name}"
-    subtitle="{container.shortImage}"
-    parentName="Containers"
-    parentURL="/containers">
+  <DetailsPage title="{container.name}" subtitle="{container.shortImage}">
     <StatusIcon slot="icon" icon="{ContainerIcon}" status="{container.state}" />
     <div slot="actions" class="flex justify-end">
       <div class="flex items-center w-5">
@@ -82,19 +77,19 @@ function errorCallback(errorMessage: string): void {
       <DetailsTab title="Terminal" url="terminal" />
     </div>
     <span slot="content">
-      <Route path="/summary" breadcrumb="Summary">
+      <Route path="/summary" breadcrumb="Summary" navLevel="tab">
         <ContainerDetailsSummary container="{container}" />
       </Route>
-      <Route path="/logs" breadcrumb="Logs">
+      <Route path="/logs" breadcrumb="Logs" navLevel="tab">
         <ContainerDetailsLogs container="{container}" />
       </Route>
-      <Route path="/inspect" breadcrumb="Inspect">
+      <Route path="/inspect" breadcrumb="Inspect" navLevel="tab">
         <ContainerDetailsInspect container="{container}" />
       </Route>
-      <Route path="/kube" breadcrumb="Kube">
+      <Route path="/kube" breadcrumb="Kube" navLevel="tab">
         <ContainerDetailsKube container="{container}" />
       </Route>
-      <Route path="/terminal" breadcrumb="Terminal">
+      <Route path="/terminal" breadcrumb="Terminal" navLevel="tab">
         <ContainerDetailsTerminal container="{container}" />
       </Route>
     </span>

--- a/packages/renderer/src/lib/container/ContainerDetails.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetails.svelte
@@ -77,19 +77,19 @@ function errorCallback(errorMessage: string): void {
       <DetailsTab title="Terminal" url="terminal" />
     </div>
     <span slot="content">
-      <Route path="/summary" breadcrumb="Summary" navLevel="tab">
+      <Route path="/summary" breadcrumb="Summary" navigationHint="tab">
         <ContainerDetailsSummary container="{container}" />
       </Route>
-      <Route path="/logs" breadcrumb="Logs" navLevel="tab">
+      <Route path="/logs" breadcrumb="Logs" navigationHint="tab">
         <ContainerDetailsLogs container="{container}" />
       </Route>
-      <Route path="/inspect" breadcrumb="Inspect" navLevel="tab">
+      <Route path="/inspect" breadcrumb="Inspect" navigationHint="tab">
         <ContainerDetailsInspect container="{container}" />
       </Route>
-      <Route path="/kube" breadcrumb="Kube" navLevel="tab">
+      <Route path="/kube" breadcrumb="Kube" navigationHint="tab">
         <ContainerDetailsKube container="{container}" />
       </Route>
-      <Route path="/terminal" breadcrumb="Terminal" navLevel="tab">
+      <Route path="/terminal" breadcrumb="Terminal" navigationHint="tab">
         <ContainerDetailsTerminal container="{container}" />
       </Route>
     </span>

--- a/packages/renderer/src/lib/help/HelpPage.svelte
+++ b/packages/renderer/src/lib/help/HelpPage.svelte
@@ -17,7 +17,7 @@ $: contributedLinks = $providerInfos
   }, new Map<string, ProviderLinks[]>());
 </script>
 
-<FormPage title="Help">
+<FormPage title="Help" showBreadcrumb="{false}">
   <div slot="content" class="flex flex-col min-w-full h-fit">
     <div class="min-w-full flex-1 pt-5 px-5 pb-5 space-y-5">
       <!-- Getting Started -->

--- a/packages/renderer/src/lib/image/ImageDetails.svelte
+++ b/packages/renderer/src/lib/image/ImageDetails.svelte
@@ -45,13 +45,7 @@ onMount(() => {
 </script>
 
 {#if image}
-  <DetailsPage
-    name="Image Details"
-    title="{image.name}"
-    titleDetail="{image.shortId}"
-    subtitle="{image.tag}"
-    parentName="Images"
-    parentURL="/images">
+  <DetailsPage title="{image.name}" titleDetail="{image.shortId}" subtitle="{image.tag}">
     <StatusIcon slot="icon" icon="{ImageIcon}" status="{image.inUse ? 'USED' : 'UNUSED'}" />
     <div slot="actions" class="flex justify-end">
       <ImageActions image="{image}" onPushImage="{handlePushImageModal}" detailed="{true}" dropdownMenu="{false}" />
@@ -62,14 +56,14 @@ onMount(() => {
       <DetailsTab title="Inspect" url="inspect" />
     </div>
     <span slot="content">
-      <Route path="/history" breadcrumb="History">
+      <Route path="/summary" breadcrumb="Summary" navLevel="tab">
+        <ImageDetailsSummary image="{image}" />
+      </Route>
+      <Route path="/history" breadcrumb="History" navLevel="tab">
         <ImageDetailsHistory image="{image}" />
       </Route>
-      <Route path="/inspect" breadcrumb="Inspect">
+      <Route path="/inspect" breadcrumb="Inspect" navLevel="tab">
         <ImageDetailsInspect image="{image}" />
-      </Route>
-      <Route path="/summary" breadcrumb="Summary">
-        <ImageDetailsSummary image="{image}" />
       </Route>
     </span>
   </DetailsPage>

--- a/packages/renderer/src/lib/image/ImageDetails.svelte
+++ b/packages/renderer/src/lib/image/ImageDetails.svelte
@@ -56,13 +56,13 @@ onMount(() => {
       <DetailsTab title="Inspect" url="inspect" />
     </div>
     <span slot="content">
-      <Route path="/summary" breadcrumb="Summary" navLevel="tab">
+      <Route path="/summary" breadcrumb="Summary" navigationHint="tab">
         <ImageDetailsSummary image="{image}" />
       </Route>
-      <Route path="/history" breadcrumb="History" navLevel="tab">
+      <Route path="/history" breadcrumb="History" navigationHint="tab">
         <ImageDetailsHistory image="{image}" />
       </Route>
-      <Route path="/inspect" breadcrumb="Inspect" navLevel="tab">
+      <Route path="/inspect" breadcrumb="Inspect" navigationHint="tab">
         <ImageDetailsInspect image="{image}" />
       </Route>
     </span>

--- a/packages/renderer/src/lib/image/RunImage.spec.ts
+++ b/packages/renderer/src/lib/image/RunImage.spec.ts
@@ -24,6 +24,7 @@ import { fireEvent, render, screen } from '@testing-library/svelte';
 import { runImageInfo } from '../../stores/run-image-store';
 import RunImage from '/@/lib/image/RunImage.svelte';
 import type { ImageInspectInfo } from '../../../../main/src/plugin/api/image-inspect-info';
+import { mockBreadcrumb } from '../../stores/breadcrumb';
 
 // fake the window.events object
 beforeAll(() => {
@@ -37,6 +38,8 @@ beforeAll(() => {
   (window as any).listNetworks = vi.fn().mockResolvedValue([]);
   (window as any).listContainers = vi.fn().mockResolvedValue([]);
   (window as any).createAndStartContainer = vi.fn();
+
+  mockBreadcrumb();
 });
 
 async function waitRender() {

--- a/packages/renderer/src/lib/image/RunImage.svelte
+++ b/packages/renderer/src/lib/image/RunImage.svelte
@@ -15,6 +15,7 @@ import { ContainerUtils } from '../container/container-utils';
 import { containersInfos } from '../../stores/containers';
 import ErrorMessage from '../ui/ErrorMessage.svelte';
 import { splitSpacesHandlingDoubleQuotes } from '../string/string';
+
 let image: ImageInfoUI;
 
 let imageInspectInfo: ImageInspectInfo;
@@ -456,7 +457,7 @@ function checkContainerName(event: any) {
             </div>
           </section>
           <div>
-            <Route path="/basic" breadcrumb="Basic" navLevel="tab">
+            <Route path="/basic" breadcrumb="Basic" navigationHint="tab">
               <div class="h-96 overflow-y-auto pr-4">
                 <label for="modalContainerName" class="block mb-2 text-sm font-medium text-gray-400 dark:text-gray-400"
                   >Container name:</label>
@@ -603,7 +604,7 @@ function checkContainerName(event: any) {
                 {/each}
               </div>
             </Route>
-            <Route path="/advanced" breadcrumb="Advanced" navLevel="tab">
+            <Route path="/advanced" breadcrumb="Advanced" navigationHint="tab">
               <div class="h-96 overflow-y-auto pr-4">
                 <!-- Use tty -->
                 <label for="containerTty" class="block mb-2 text-sm font-medium text-gray-400 dark:text-gray-400"
@@ -672,7 +673,7 @@ function checkContainerName(event: any) {
               </div>
             </Route>
 
-            <Route path="/security" breadcrumb="Security" navLevel="tab">
+            <Route path="/security" breadcrumb="Security" navigationHint="tab">
               <div class="h-96 overflow-y-auto pr-4">
                 <!-- Privileged-->
                 <label for="containerPrivileged" class="block mb-2 text-sm font-medium text-gray-400 dark:text-gray-400"
@@ -793,7 +794,7 @@ function checkContainerName(event: any) {
               </div>
             </Route>
 
-            <Route path="/networking" breadcrumb="Networking" navLevel="tab">
+            <Route path="/networking" breadcrumb="Networking" navigationHint="tab">
               <div class="h-96 overflow-y-auto pr-4">
                 <!-- hostname-->
                 <label for="containerHostname" class="block mb-2 text-sm font-medium text-gray-400 dark:text-gray-400"

--- a/packages/renderer/src/lib/image/RunImage.svelte
+++ b/packages/renderer/src/lib/image/RunImage.svelte
@@ -408,11 +408,7 @@ function checkContainerName(event: any) {
 
 <Route path="/*" let:meta>
   {#if dataReady}
-    <FormPage
-      name="Run Image"
-      title="Create a container from image {imageDisplayName}:{image.tag}"
-      parentName="Images"
-      parentURL="/images">
+    <FormPage title="Create a container from image {imageDisplayName}:{image.tag}">
       <div slot="content" class="p-5 min-w-full h-fit">
         <div class="bg-charcoal-600 px-6 py-4 space-y-2 lg:px-8 sm:pb-6 xl:pb-8">
           <section class="pf-c-page__main-tabs pf-m-limit-width">
@@ -460,7 +456,7 @@ function checkContainerName(event: any) {
             </div>
           </section>
           <div>
-            <Route path="/basic" breadcrumb="Basic">
+            <Route path="/basic" breadcrumb="Basic" navLevel="tab">
               <div class="h-96 overflow-y-auto pr-4">
                 <label for="modalContainerName" class="block mb-2 text-sm font-medium text-gray-400 dark:text-gray-400"
                   >Container name:</label>
@@ -607,7 +603,7 @@ function checkContainerName(event: any) {
                 {/each}
               </div>
             </Route>
-            <Route path="/advanced" breadcrumb="Advanced">
+            <Route path="/advanced" breadcrumb="Advanced" navLevel="tab">
               <div class="h-96 overflow-y-auto pr-4">
                 <!-- Use tty -->
                 <label for="containerTty" class="block mb-2 text-sm font-medium text-gray-400 dark:text-gray-400"
@@ -676,7 +672,7 @@ function checkContainerName(event: any) {
               </div>
             </Route>
 
-            <Route path="/security" breadcrumb="Security">
+            <Route path="/security" breadcrumb="Security" navLevel="tab">
               <div class="h-96 overflow-y-auto pr-4">
                 <!-- Privileged-->
                 <label for="containerPrivileged" class="block mb-2 text-sm font-medium text-gray-400 dark:text-gray-400"
@@ -797,7 +793,7 @@ function checkContainerName(event: any) {
               </div>
             </Route>
 
-            <Route path="/networking" breadcrumb="Networking">
+            <Route path="/networking" breadcrumb="Networking" navLevel="tab">
               <div class="h-96 overflow-y-auto pr-4">
                 <!-- hostname-->
                 <label for="containerHostname" class="block mb-2 text-sm font-medium text-gray-400 dark:text-gray-400"

--- a/packages/renderer/src/lib/pod/DeployPodToKube.svelte
+++ b/packages/renderer/src/lib/pod/DeployPodToKube.svelte
@@ -343,7 +343,7 @@ function updateKubeResult() {
 }
 </script>
 
-<FormPage name="Deploy to Kubernetes" title="Deploy generated pod to Kubernetes" parentName="Pods" parentURL="/pods">
+<FormPage title="Deploy generated pod to Kubernetes">
   <div slot="content" class="p-5 min-w-full h-fit">
     <div class="bg-charcoal-600 p-5">
       {#if kubeDetails}

--- a/packages/renderer/src/lib/pod/PodDetails.svelte
+++ b/packages/renderer/src/lib/pod/PodDetails.svelte
@@ -83,16 +83,16 @@ function errorCallback(errorMessage: string): void {
       <DetailsTab title="Kube" url="kube" />
     </div>
     <span slot="content">
-      <Route path="/summary" breadcrumb="Summary" navLevel="tab">
+      <Route path="/summary" breadcrumb="Summary" navigationHint="tab">
         <PodDetailsSummary pod="{pod}" />
       </Route>
-      <Route path="/logs" breadcrumb="Logs" navLevel="tab">
+      <Route path="/logs" breadcrumb="Logs" navigationHint="tab">
         <PodDetailsLogs pod="{pod}" />
       </Route>
-      <Route path="/inspect" breadcrumb="Inspect" navLevel="tab">
+      <Route path="/inspect" breadcrumb="Inspect" navigationHint="tab">
         <PodDetailsInspect pod="{pod}" />
       </Route>
-      <Route path="/kube" breadcrumb="Kube" navLevel="tab">
+      <Route path="/kube" breadcrumb="Kube" navigationHint="tab">
         <PodDetailsKube pod="{pod}" />
       </Route>
     </span>

--- a/packages/renderer/src/lib/pod/PodDetails.svelte
+++ b/packages/renderer/src/lib/pod/PodDetails.svelte
@@ -60,7 +60,7 @@ function errorCallback(errorMessage: string): void {
 </script>
 
 {#if pod}
-  <DetailsPage name="Pod Details" title="{pod.name}" subtitle="{pod.shortId}" parentName="Pods" parentURL="/pods">
+  <DetailsPage title="{pod.name}" subtitle="{pod.shortId}">
     <StatusIcon slot="icon" icon="{PodIcon}" status="{pod.status}" />
     <div slot="actions" class="flex justify-end">
       <div class="flex items-center w-5">
@@ -83,16 +83,16 @@ function errorCallback(errorMessage: string): void {
       <DetailsTab title="Kube" url="kube" />
     </div>
     <span slot="content">
-      <Route path="/summary" breadcrumb="Summary">
+      <Route path="/summary" breadcrumb="Summary" navLevel="tab">
         <PodDetailsSummary pod="{pod}" />
       </Route>
-      <Route path="/logs" breadcrumb="Logs">
+      <Route path="/logs" breadcrumb="Logs" navLevel="tab">
         <PodDetailsLogs pod="{pod}" />
       </Route>
-      <Route path="/inspect" breadcrumb="Inspect">
+      <Route path="/inspect" breadcrumb="Inspect" navLevel="tab">
         <PodDetailsInspect pod="{pod}" />
       </Route>
-      <Route path="/kube" breadcrumb="Kube">
+      <Route path="/kube" breadcrumb="Kube" navLevel="tab">
         <PodDetailsKube pod="{pod}" />
       </Route>
     </span>

--- a/packages/renderer/src/lib/ui/DetailsPage.spec.ts
+++ b/packages/renderer/src/lib/ui/DetailsPage.spec.ts
@@ -20,12 +20,12 @@ import '@testing-library/jest-dom';
 import { test, expect } from 'vitest';
 import { render, screen } from '@testing-library/svelte';
 import DetailsPage from './DetailsPage.svelte';
+import { lastPage, currentPage } from '../../stores/breadcrumb';
+import type { TinroBreadcrumb } from 'tinro';
 
 test('Expect title is defined', async () => {
-  const name = 'My Name';
   const title = 'My Dummy Title';
   render(DetailsPage, {
-    name,
     title,
   });
 
@@ -34,35 +34,40 @@ test('Expect title is defined', async () => {
   expect(titleElement).toHaveTextContent(title);
 });
 
-test('Expect backlink is defined', async () => {
-  const name = 'My Name';
-  const title = 'My Dummy Title';
-  const parentName = 'Parent';
-  const parentURL = '/test';
+test('Expect name is defined', async () => {
+  const name = 'My Dummy Name';
+  currentPage.set({ name: name, path: '/' } as TinroBreadcrumb);
   render(DetailsPage, {
-    name,
-    title,
-    parentName,
-    parentURL,
+    title: 'No Title',
   });
 
-  const nameElement = screen.getByLabelText('back');
+  const nameElement = screen.getByLabelText('name');
   expect(nameElement).toBeInTheDocument();
-  expect(nameElement).toHaveTextContent(parentName);
-  expect(nameElement).toHaveAttribute('href', parentURL);
+  expect(nameElement).toHaveTextContent(name);
+});
+
+test('Expect backlink is defined', async () => {
+  const backName = 'Last page';
+  const backPath = '/back';
+  lastPage.set({ name: backName, path: backPath } as TinroBreadcrumb);
+  render(DetailsPage, {
+    title: 'No Title',
+  });
+
+  const backElement = screen.getByLabelText('back');
+  expect(backElement).toBeInTheDocument();
+  expect(backElement).toHaveTextContent(backName);
+  expect(backElement).toHaveAttribute('href', backPath);
 });
 
 test('Expect close link is defined', async () => {
-  const name = 'My Name';
-  const title = 'My Dummy Title';
-  const parentURL = '/test';
+  const backPath = '/back';
+  lastPage.set({ name: 'Back', path: backPath } as TinroBreadcrumb);
   render(DetailsPage, {
-    name,
-    title,
-    parentURL,
+    title: 'No Title',
   });
 
   const closeElement = screen.getByTitle('Close Details');
   expect(closeElement).toBeInTheDocument();
-  expect(closeElement).toHaveAttribute('href', parentURL);
+  expect(closeElement).toHaveAttribute('href', backPath);
 });

--- a/packages/renderer/src/lib/ui/DetailsPage.svelte
+++ b/packages/renderer/src/lib/ui/DetailsPage.svelte
@@ -17,7 +17,7 @@ export let subtitle: string = undefined;
             href="{$lastPage.path}"
             title="Go back to {$lastPage.name}">{$lastPage.name}</a>
           <div class="text-xl mx-2 text-gray-700">></div>
-          <div class="text-sm font-extralight text-gray-700">{$currentPage.name}</div>
+          <div class="text-sm font-extralight text-gray-700" aria-label="name">{$currentPage.name}</div>
         </div>
         <div class="text-lg flex flex-row items-start pt-1">
           <div class="pr-3 pt-1">

--- a/packages/renderer/src/lib/ui/DetailsPage.svelte
+++ b/packages/renderer/src/lib/ui/DetailsPage.svelte
@@ -1,60 +1,55 @@
 <script lang="ts">
-import Route from '../../Route.svelte';
+import { lastPage, currentPage } from '../../stores/breadcrumb';
 
-export let name: string;
 export let title: string;
 export let titleDetail: string = undefined;
 export let subtitle: string = undefined;
-export let parentName: string = undefined;
-export let parentURL: string = undefined;
 </script>
 
-<Route path="/*">
-  <div class="w-full h-full">
-    <div class="flex h-full flex-col">
-      <div class="flex w-full flex-row">
-        <div class="w-full pl-5 pt-5">
-          <div class="flex flew-row items-center">
-            <a
-              class="text-violet-400 text-base hover:no-underline"
-              aria-label="back"
-              href="{parentURL}"
-              title="Go back to {parentName}">{parentName}</a>
-            <div class="text-xl mx-2 text-gray-700">></div>
-            <div class="text-sm font-extralight text-gray-700">{name}</div>
+<div class="w-full h-full">
+  <div class="flex h-full flex-col">
+    <div class="flex w-full flex-row">
+      <div class="w-full pl-5 pt-4">
+        <div class="flex flew-row items-center">
+          <a
+            class="text-violet-400 text-base hover:no-underline"
+            aria-label="back"
+            href="{$lastPage.path}"
+            title="Go back to {$lastPage.name}">{$lastPage.name}</a>
+          <div class="text-xl mx-2 text-gray-700">></div>
+          <div class="text-sm font-extralight text-gray-700">{$currentPage.name}</div>
+        </div>
+        <div class="text-lg flex flex-row items-start pt-1">
+          <div class="pr-3 pt-1">
+            <slot name="icon" />
           </div>
-          <div class="text-lg flex flex-row items-start pt-1">
-            <div class="pr-3 pt-1">
-              <slot name="icon" />
+          <div class="text-lg flex flex-col">
+            <div class="flex flex-row items-baseline">
+              <h1>{title}</h1>
+              <div class="text-base text-violet-400 ml-2" class:hidden="{!titleDetail}">{titleDetail}</div>
             </div>
-            <div class="text-lg flex flex-col">
-              <div class="flex flex-row items-baseline">
-                <h1>{title}</h1>
-                <div class="text-base text-violet-400 ml-2" class:hidden="{!titleDetail}">{titleDetail}</div>
-              </div>
-              <div class="mr-2 pb-4 text-small text-gray-900">{subtitle}</div>
-            </div>
+            <div class="mr-2 pb-4 text-small text-gray-900">{subtitle}</div>
           </div>
         </div>
-        <div class="flex flex-col pr-2 pt-5">
-          <slot name="actions" />
-          <slot name="detail" />
-        </div>
-        <a href="{parentURL}" title="Close Details" class="mt-2 mr-2 text-gray-900"
-          ><i class="fas fa-times" aria-hidden="true"></i></a>
       </div>
-      <section class="pf-c-page__main-tabs pf-m-limit-width">
-        <div class="pf-c-page__main-body">
-          <div class="pf-c-tabs pf-m-page-insets" id="open-tabs-example-tabs-list">
-            <ul class="pf-c-tabs__list">
-              <slot name="tabs" />
-            </ul>
-          </div>
-        </div>
-      </section>
-      <div class="h-full bg-charcoal-900">
-        <slot name="content" />
+      <div class="flex flex-col pr-2 pt-5">
+        <slot name="actions" />
+        <slot name="detail" />
       </div>
+      <a href="{$lastPage.path}" title="Close Details" class="mt-2 mr-2 text-gray-900"
+        ><i class="fas fa-times" aria-hidden="true"></i></a>
+    </div>
+    <section class="pf-c-page__main-tabs pf-m-limit-width">
+      <div class="pf-c-page__main-body">
+        <div class="pf-c-tabs pf-m-page-insets" id="open-tabs-example-tabs-list">
+          <ul class="pf-c-tabs__list">
+            <slot name="tabs" />
+          </ul>
+        </div>
+      </div>
+    </section>
+    <div class="h-full bg-charcoal-900">
+      <slot name="content" />
     </div>
   </div>
-</Route>
+</div>

--- a/packages/renderer/src/lib/ui/FormPage.spec.ts
+++ b/packages/renderer/src/lib/ui/FormPage.spec.ts
@@ -20,12 +20,12 @@ import '@testing-library/jest-dom';
 import { test, expect } from 'vitest';
 import { render, screen } from '@testing-library/svelte';
 import FormPage from './FormPage.svelte';
+import { lastPage, currentPage } from '../../stores/breadcrumb';
+import type { TinroBreadcrumb } from 'tinro';
 
 test('Expect title is defined', async () => {
-  const name = 'My Name';
   const title = 'My Dummy Title';
   render(FormPage, {
-    name,
     title,
   });
 
@@ -34,35 +34,53 @@ test('Expect title is defined', async () => {
   expect(titleElement).toHaveTextContent(title);
 });
 
-test('Expect backlink is defined', async () => {
-  const name = 'My Name';
-  const title = 'My Dummy Title';
-  const parentName = 'Parent';
-  const parentURL = '/test';
+test('Expect no backlink or close is defined', async () => {
   render(FormPage, {
-    name,
-    title,
-    parentName,
-    parentURL,
+    title: 'No Title',
+    showBreadcrumb: false,
   });
 
-  const nameElement = screen.getByLabelText('back');
+  const backElement = screen.queryByLabelText('back');
+  expect(backElement).not.toBeInTheDocument();
+
+  const closeElement = screen.queryByTitle('Close');
+  expect(closeElement).not.toBeInTheDocument();
+});
+
+test('Expect name is defined', async () => {
+  const name = 'My Dummy Name';
+  currentPage.set({ name: name, path: '/' } as TinroBreadcrumb);
+  render(FormPage, {
+    title: 'No Title',
+  });
+
+  const nameElement = screen.getByLabelText('name');
   expect(nameElement).toBeInTheDocument();
-  expect(nameElement).toHaveTextContent(parentName);
-  expect(nameElement).toHaveAttribute('href', parentURL);
+  expect(nameElement).toHaveTextContent(name);
+});
+
+test('Expect backlink is defined', async () => {
+  const backName = 'Last page';
+  const backPath = '/back';
+  lastPage.set({ name: backName, path: backPath } as TinroBreadcrumb);
+  render(FormPage, {
+    title: 'No Title',
+  });
+
+  const backElement = screen.getByLabelText('back');
+  expect(backElement).toBeInTheDocument();
+  expect(backElement).toHaveTextContent(backName);
+  expect(backElement).toHaveAttribute('href', backPath);
 });
 
 test('Expect close link is defined', async () => {
-  const name = 'My Name';
-  const title = 'My Dummy Title';
-  const parentURL = '/test';
+  const backPath = '/back';
+  lastPage.set({ name: 'Back', path: backPath } as TinroBreadcrumb);
   render(FormPage, {
-    name,
-    title,
-    parentURL,
+    title: 'No Title',
   });
 
   const closeElement = screen.getByTitle('Close');
   expect(closeElement).toBeInTheDocument();
-  expect(closeElement).toHaveAttribute('href', parentURL);
+  expect(closeElement).toHaveAttribute('href', backPath);
 });

--- a/packages/renderer/src/lib/ui/FormPage.svelte
+++ b/packages/renderer/src/lib/ui/FormPage.svelte
@@ -1,29 +1,31 @@
 <script lang="ts">
-export let name: string = undefined;
+import { lastPage, currentPage } from '../../stores/breadcrumb';
+
 export let title: string;
-export let parentName: string = undefined;
-export let parentURL: string = undefined;
+export let showBreadcrumb = true;
 </script>
 
 <div class="flex flex-col w-full h-full shadow-pageheader">
   <div class="flex flex-row w-full h-fit px-5 py-4">
     <div class="flex flex-col w-full h-fit">
-      {#if parentName}
+      {#if showBreadcrumb}
         <div class="flex flew-row items-center">
           <a
             aria-label="back"
             class="text-violet-400 text-base hover:no-underline"
-            href="{parentURL}"
-            title="Go back to {parentName}">{parentName}</a>
+            href="{$lastPage.path}"
+            title="Go back to {$lastPage.name}">{$lastPage.name}</a>
           <div class="text-xl mx-2 text-gray-700">></div>
-          <div class="text-sm font-extralight text-gray-700">{name}</div>
+          <div class="text-sm font-extralight text-gray-700">{$currentPage.name}</div>
         </div>
       {/if}
-      <h1 aria-label="{title}" class="text-xl first-letter:uppercase">{title}</h1>
+      <div class="flex flex-row items-center pt-1">
+        <h1 aria-label="{title}" class="text-xl first-letter:uppercase">{title}</h1>
+      </div>
     </div>
     <div class="flex flex-1 justify-end">
-      {#if parentURL}
-        <a href="{parentURL}" title="Close" class="mt-2 mr-2 text-gray-900">
+      {#if showBreadcrumb}
+        <a href="{$lastPage.path}" title="Close" class="mt-2 mr-2 text-gray-900">
           <i class="fas fa-times" aria-hidden="true"></i>
         </a>
       {/if}

--- a/packages/renderer/src/lib/ui/FormPage.svelte
+++ b/packages/renderer/src/lib/ui/FormPage.svelte
@@ -16,7 +16,7 @@ export let showBreadcrumb = true;
             href="{$lastPage.path}"
             title="Go back to {$lastPage.name}">{$lastPage.name}</a>
           <div class="text-xl mx-2 text-gray-700">></div>
-          <div class="text-sm font-extralight text-gray-700">{$currentPage.name}</div>
+          <div class="text-sm font-extralight text-gray-700" aria-label="name">{$currentPage.name}</div>
         </div>
       {/if}
       <div class="flex flex-row items-center pt-1">

--- a/packages/renderer/src/lib/volume/VolumeDetails.svelte
+++ b/packages/renderer/src/lib/volume/VolumeDetails.svelte
@@ -44,10 +44,10 @@ onMount(() => {
       <DetailsTab title="Inspect" url="inspect" />
     </div>
     <span slot="content">
-      <Route path="/summary" breadcrumb="Summary" navLevel="tab">
+      <Route path="/summary" breadcrumb="Summary" navigationHint="tab">
         <VolumeDetailsSummary volume="{volume}" />
       </Route>
-      <Route path="/inspect" breadcrumb="Inspect" navLevel="tab">
+      <Route path="/inspect" breadcrumb="Inspect" navigationHint="tab">
         <VolumeDetailsInspect volume="{volume}" />
       </Route>
     </span>

--- a/packages/renderer/src/lib/volume/VolumeDetails.svelte
+++ b/packages/renderer/src/lib/volume/VolumeDetails.svelte
@@ -34,12 +34,7 @@ onMount(() => {
 </script>
 
 {#if volume}
-  <DetailsPage
-    name="Volume Details"
-    title="{volume.shortName}"
-    subtitle="{volume.humanSize}"
-    parentName="Volumes"
-    parentURL="/volumes">
+  <DetailsPage title="{volume.shortName}" subtitle="{volume.humanSize}">
     <StatusIcon slot="icon" icon="{VolumeIcon}" status="{volume.inUse ? 'USED' : 'UNUSED'}" />
     <div slot="actions" class="flex justify-end">
       <VolumeActions volume="{volume}" detailed="{true}" />
@@ -49,10 +44,10 @@ onMount(() => {
       <DetailsTab title="Inspect" url="inspect" />
     </div>
     <span slot="content">
-      <Route path="/summary" breadcrumb="Summary">
+      <Route path="/summary" breadcrumb="Summary" navLevel="tab">
         <VolumeDetailsSummary volume="{volume}" />
       </Route>
-      <Route path="/inspect" breadcrumb="Inspect">
+      <Route path="/inspect" breadcrumb="Inspect" navLevel="tab">
         <VolumeDetailsInspect volume="{volume}" />
       </Route>
     </span>

--- a/packages/renderer/src/stores/breadcrumb.ts
+++ b/packages/renderer/src/stores/breadcrumb.ts
@@ -25,3 +25,9 @@ export const lastPage: Writable<TinroBreadcrumb> = writable({ name: 'Unknown', p
 
 export const listPage: Writable<TinroBreadcrumb> = writable();
 export const detailsPage: Writable<TinroBreadcrumb> = writable();
+
+export function mockBreadcrumb() {
+  listPage.set({ name: 'List', path: '/list' } as TinroBreadcrumb);
+  lastPage.set({ name: 'Previous', path: '/last' } as TinroBreadcrumb);
+  currentPage.set({ name: 'Current', path: '/current' } as TinroBreadcrumb);
+}

--- a/packages/renderer/src/stores/breadcrumb.ts
+++ b/packages/renderer/src/stores/breadcrumb.ts
@@ -1,0 +1,27 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { Writable } from 'svelte/store';
+import { writable } from 'svelte/store';
+import type { TinroBreadcrumb } from 'tinro';
+
+export const currentPage: Writable<TinroBreadcrumb> = writable({ name: 'Unknown', path: '/' } as TinroBreadcrumb);
+export const lastPage: Writable<TinroBreadcrumb> = writable({ name: 'Unknown', path: '/' } as TinroBreadcrumb);
+
+export const listPage: Writable<TinroBreadcrumb> = writable();
+export const detailsPage: Writable<TinroBreadcrumb> = writable();


### PR DESCRIPTION
### What does this PR do?

See issue #3114 for background.

In order to avoid duplicate/different breadcrumb strings, this change uses the existing Route breadcrumb as the name of each page. This requires a one-time change to some of the existing breadcrumbs to match the corresponding action/what we should actually call the page.

We have three special kinds of Routes:
- the main nav lists
- the details pages
- tabs

The first two are the only ones you can go 'back' to, and can only be one (list > action) or two (list > details > action) levels deep. Tabs affect the current URL but don't affect what the 'current' page is. A new navLevel property is added to tag these special routes.

In order to keep things relatively simple we'll just track the first two kinds of routes as properties in a store and set a lastPage whenever we enter a route. Likewise, the current page changes for any route except tabs, but detail routes are special since they need to change the back-link. For instance, if you click on Image Details > Inspect, then Run Image, cancelling should return you to Inspect instead of the image summary.

Someone may ask: why are breadcrumbs put in a store vs a Route property like meta? Because a visual page like Details is rendered from several routes (/, /containers/:id/, /containers/:id/xyz) and getting the main page to have the correct name and URL for a tab when we haven't gotten to that route yet is more complicated than simply sharing a store.

- Detailed change notes -

Route/breadcrumb:
- Use navLevel as described above to keep track of current list/details pages and set last/current page in breadcrumb store.

App:
- Fix breadcrumb names and set basic navLevels.

Details pages:
- Use breadcrumb in DetailsPage, add navLevel to tabs and remove parent from *Details pages.

Form pages:
- Use breadcrumb in FormPage and remove parent from the two pages that use it.
- Added showBreadcrumb property so Help page can still turn it off.
- Set navLevel in RunImage so that the current page name doesn't pick up the tab name.

### Screenshot/screencast of this PR

<img width="277" alt="Screenshot 2023-07-05 at 9 16 08 AM" src="https://github.com/containers/podman-desktop/assets/19958075/98831863-ce07-4c0c-b774-6ceb4671982f">
<img width="277" alt="Screenshot 2023-07-05 at 9 16 31 AM" src="https://github.com/containers/podman-desktop/assets/19958075/b131fba8-a986-458f-8918-eb0641646284">
<img width="277" alt="Screenshot 2023-07-05 at 9 16 42 AM" src="https://github.com/containers/podman-desktop/assets/19958075/755c249a-bd38-4585-8595-86ba923613dc">

### What issues does this PR fix or reference?

Fixes issue #3114.

### How to test this PR?

Go to each details page to confirm breadcrumb looks correct. Go to containers list and select a pod to confirm the breadcrumb is now Containers > Pod Details.

Go to each of the form pages: Help (no breadcrumb), Run Image, Deploy Pod to Kubernetes to confirm the page name and breadcrumb at the top. Try these actions from both the list and details pages to confirm the breadcrumb is different and correct in both cases.

On the image details page select the History or Inspect tab before using Run Image, and confirm the breadcrumb or close goes back to the correct tab.