### PR TITLE
feat: add a way to debug stores in troubleshooting page

### DIFF
--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingDevToolsConsoleLogs.svelte
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingDevToolsConsoleLogs.svelte
@@ -24,7 +24,7 @@ function copyLogsToClipboard() {
 }
 </script>
 
-<div class="flex flex-col bg-zinc-700 m-4 p-4 mb-10">
+<div class="flex flex-col bg-zinc-700 m-4 p-4">
   <div class="flex flex-row align-middle items-center w-full">
     <Fa size="40" icon="{faFileLines}" />
     <div class="mx-2 text-xl">Logs</div>

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingPage.svelte
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingPage.svelte
@@ -2,6 +2,7 @@
 import NavPage from '../ui/NavPage.svelte';
 import TroubleshootingDevToolsConsoleLogs from './TroubleshootingDevToolsConsoleLogs.svelte';
 import TroubleshootingPageProviders from './TroubleshootingPageProviders.svelte';
+import TroubleshootingPageStores from './TroubleshootingPageStores.svelte';
 </script>
 
 <NavPage title="Troubleshooting" searchEnabled="{false}">
@@ -9,5 +10,7 @@ import TroubleshootingPageProviders from './TroubleshootingPageProviders.svelte'
     <TroubleshootingPageProviders />
 
     <TroubleshootingDevToolsConsoleLogs />
+
+    <TroubleshootingPageStores />
   </div>
 </NavPage>

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingPageStore.spec.ts
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingPageStore.spec.ts
@@ -1,0 +1,74 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import '@testing-library/jest-dom';
+import { beforeAll, test, expect, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import TroubleshootingPageStore from './TroubleshootingPageStore.svelte';
+import type { EventStoreInfo } from '/@/stores/event-store';
+
+beforeAll(() => {});
+
+test('Check store info is displayed and clicking on buttons works', async () => {
+  const clearEventsMock = vi.fn();
+  const fetchMock = vi.fn();
+
+  const eventStoreInfo: EventStoreInfo = {
+    name: 'my-test-store',
+    size: 3,
+    bufferEvents: [],
+    clearEvents: clearEventsMock,
+    fetch: fetchMock,
+  };
+
+  render(TroubleshootingPageStore, { eventStoreInfo });
+
+  // expect to have the Refresh button
+  const refreshButton = screen.getByRole('button', { name: 'Refresh' });
+  expect(refreshButton).toBeInTheDocument();
+
+  // click on it
+  await fireEvent.click(refreshButton);
+
+  // expect to have fetch method called
+  expect(fetchMock).toHaveBeenCalled();
+
+  // check we have open details button
+  const openDetailsButton = screen.getByRole('button', { name: 'Open Details' });
+  expect(openDetailsButton).toBeInTheDocument();
+
+  // click on it
+  await fireEvent.click(openDetailsButton);
+
+  // expect to have dialog being displayed when clicking on the button
+  const details = screen.getByRole('dialog', { name: 'Details of my-test-store' });
+
+  expect(details).toBeInTheDocument();
+
+  // expect to have the Cancel button
+  const cancelButton = screen.getByRole('button', { name: 'Cancel' });
+  expect(cancelButton).toBeInTheDocument();
+
+  // click on it
+  await fireEvent.click(cancelButton);
+
+  // dialog should be hidden now
+  expect(details).not.toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingPageStore.svelte
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingPageStore.svelte
@@ -1,0 +1,57 @@
+<script lang="ts">
+import TroubleshootingPageStoreDetails from './TroubleshootingPageStoreDetails.svelte';
+import type { EventStoreInfo } from '/@/stores/event-store';
+
+export let eventStoreInfo: EventStoreInfo;
+
+let fetchInProgress = false;
+async function fetch(): Promise<void> {
+  fetchInProgress = true;
+  try {
+    await eventStoreInfo.fetch();
+  } finally {
+    fetchInProgress = false;
+  }
+}
+
+let openDetails = false;
+</script>
+
+<div class="flex flex-col bg-charcoal-600 p-2 items-center rounded w-full">
+  <div><svelte:component this="{eventStoreInfo.iconComponent}" size="20" /></div>
+  <div class="text-xl">
+    <button
+      disabled="{fetchInProgress}"
+      class="underline outline-none"
+      title="Open Details"
+      aria-label="Open Details"
+      on:click="{() => (openDetails = true)}">
+      {eventStoreInfo.name}
+    </button>
+  </div>
+  <div class="text-sm">({eventStoreInfo.size} items)</div>
+  <div class="">
+    <button
+      disabled="{fetchInProgress}"
+      class="px-3 my-1 text-sm font-medium text-center text-white bg-violet-600 rounded-sm hover:bg-dustypurple-800 focus:ring-2 focus:outline-none focus:ring-dustypurple-700 w-full"
+      title="Refresh"
+      aria-label="Refresh"
+      on:click="{() => fetch()}">
+      Refresh
+    </button>
+  </div>
+  {#if eventStoreInfo.bufferEvents.length > 0}
+    {@const lastUpdate = eventStoreInfo.bufferEvents[eventStoreInfo.bufferEvents.length - 1]}
+    {#if lastUpdate.humanDuration}
+      <div class="text-xs italic" title="Time to update">{lastUpdate.humanDuration}</div>
+    {/if}
+  {/if}
+
+  {#if openDetails}
+    <TroubleshootingPageStoreDetails
+      closeCallback="{() => {
+        openDetails = false;
+      }}"
+      eventStoreInfo="{eventStoreInfo}" />
+  {/if}
+</div>

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingPageStoreDetails.spec.ts
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingPageStoreDetails.spec.ts
@@ -1,0 +1,140 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import '@testing-library/jest-dom';
+import { beforeAll, test, expect, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import TroubleshootingPageStoreDetails from './TroubleshootingPageStoreDetails.svelte';
+import type { EventStoreInfo } from '/@/stores/event-store';
+import userEvent from '@testing-library/user-event';
+
+beforeAll(() => {});
+
+test('Check details are displayed and works', async () => {
+  const clearEventsMock = vi.fn();
+  const fetchMock = vi.fn();
+  const closeCallback = vi.fn();
+
+  const bufferEvent = {
+    name: 'my-test-event',
+    args: [],
+    length: 5,
+    date: new Date().getTime(),
+    skipped: false,
+  };
+
+  const eventStoreInfo: EventStoreInfo = {
+    name: 'my-test-store',
+    size: 3,
+    bufferEvents: [bufferEvent],
+    clearEvents: clearEventsMock,
+    fetch: fetchMock,
+  };
+
+  render(TroubleshootingPageStoreDetails, { eventStoreInfo, closeCallback });
+
+  // find the label with name size
+  const sizeStatus = screen.getByRole('status', { name: 'size' });
+  expect(sizeStatus).toBeInTheDocument();
+  // value should be 3
+  expect(sizeStatus).toHaveTextContent('3');
+
+  // and check we have buffer events
+  const bufferEvents = screen.getByRole('list', { name: 'buffer-events' });
+  expect(bufferEvents).toBeInTheDocument();
+
+  // expect to have li item in the list
+  const bufferEvent1 = screen.getByRole('listitem', { name: 'my-test-event' });
+  expect(bufferEvent1).toBeInTheDocument();
+  // now check the text content
+  expect(bufferEvent1).toHaveTextContent(`Grab ${bufferEvent.length} items from '${bufferEvent.name}' event`);
+});
+
+test('Check close button', async () => {
+  const clearEventsMock = vi.fn();
+  const fetchMock = vi.fn();
+  const closeCallback = vi.fn();
+
+  const eventStoreInfo: EventStoreInfo = {
+    name: 'my-test-store',
+    size: 3,
+    bufferEvents: [],
+    clearEvents: clearEventsMock,
+    fetch: fetchMock,
+  };
+
+  render(TroubleshootingPageStoreDetails, { eventStoreInfo, closeCallback });
+
+  // expect to have the close button
+  const closeButton = screen.getByRole('button', { name: 'Close' });
+  expect(closeButton).toBeInTheDocument();
+
+  // click on close button and expect close callback to be called
+  expect(closeCallback).not.toBeCalled();
+  await fireEvent.click(closeButton);
+  expect(closeCallback).toBeCalled();
+});
+
+test('Check Cancel button', async () => {
+  const clearEventsMock = vi.fn();
+  const fetchMock = vi.fn();
+  const closeCallback = vi.fn();
+
+  const eventStoreInfo: EventStoreInfo = {
+    name: 'my-test-store',
+    size: 3,
+    bufferEvents: [],
+    clearEvents: clearEventsMock,
+    fetch: fetchMock,
+  };
+
+  render(TroubleshootingPageStoreDetails, { eventStoreInfo, closeCallback });
+
+  // expect to have the close button
+  const cancelButton = screen.getByRole('button', { name: 'Cancel' });
+  expect(cancelButton).toBeInTheDocument();
+
+  // click on Cancel button and expect close callback to be called
+  expect(closeCallback).not.toBeCalled();
+  await fireEvent.click(cancelButton);
+  expect(closeCallback).toBeCalled();
+});
+
+test('Check ESC key', async () => {
+  const clearEventsMock = vi.fn();
+  const fetchMock = vi.fn();
+  const closeCallback = vi.fn();
+
+  const eventStoreInfo: EventStoreInfo = {
+    name: 'my-test-store',
+    size: 3,
+    bufferEvents: [],
+    clearEvents: clearEventsMock,
+    fetch: fetchMock,
+  };
+
+  render(TroubleshootingPageStoreDetails, { eventStoreInfo, closeCallback });
+
+  // click on Cancel button and expect close callback to be called
+  expect(closeCallback).not.toBeCalled();
+  // now, press the ESC key
+  await userEvent.keyboard('{Escape}');
+  expect(closeCallback).toBeCalled();
+});

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingPageStoreDetails.svelte
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingPageStoreDetails.svelte
@@ -1,0 +1,115 @@
+<script lang="ts">
+import Modal from '../dialogs/Modal.svelte';
+import type { EventStoreInfo } from '/@/stores/event-store';
+
+import moment from 'moment';
+import humanizeDuration from 'humanize-duration';
+
+export let closeCallback: () => void;
+
+export let eventStoreInfo: EventStoreInfo;
+
+let fetchInProgress = false;
+async function fetch(): Promise<void> {
+  fetchInProgress = true;
+  try {
+    await eventStoreInfo.fetch();
+  } finally {
+    fetchInProgress = false;
+  }
+}
+</script>
+
+<Modal name="Details of {eventStoreInfo.name}" on:close="{() => closeCallback()}">
+  <div
+    class="inline-block w-full overflow-hidden text-left transition-all transform bg-charcoal-600 z-50 rounded-xl shadow-xl shadow-neutral-900">
+    <div class="flex items-center justify-between px-5 py-4 mb-4">
+      <h1 class="text-md font-semibold">
+        <div class="flex flex-row items-center">
+          <svelte:component this="{eventStoreInfo.iconComponent}" size="20" />
+          <div class="mx-2">Details of {eventStoreInfo.name} store</div>
+        </div>
+      </h1>
+      <button class="hover:text-gray-300 px-2 py-1" aria-label="Close" on:click="{() => closeCallback()}">
+        <i class="fas fa-times" aria-hidden="true"></i>
+      </button>
+    </div>
+    <div class="overflow-y-auto px-4 pb-4">
+      <div class="flex flex-col rounded-lg">
+        <div class="bg-charcoal-800 w-full p-4 mb-4">
+          <div class="pb-2 text-lg">Info:</div>
+
+          <div class="mx-2 flex flex-row items-center">
+            Size: <div role="status" aria-label="size">{eventStoreInfo.size}</div>
+            <div class="mx-2">
+              <button
+                disabled="{fetchInProgress}"
+                class="px-3 my-1 text-sm font-medium text-center text-white bg-violet-600 rounded-sm hover:bg-dustypurple-800 focus:ring-2 focus:outline-none focus:ring-dustypurple-700"
+                title="Refresh"
+                on:click="{() => fetch()}">
+                Refresh
+              </button>
+            </div>
+          </div>
+        </div>
+
+        <!-- Display buffer events-->
+        <div class="pb-4">
+          <div class="bg-charcoal-800 w-full p-4 h-45">
+            <div class="pb-2 text-lg">
+              Updating events:
+              {#if eventStoreInfo.bufferEvents.length > 0}
+                <button
+                  disabled="{fetchInProgress}"
+                  class="px-3 my-1 text-sm font-medium text-center text-white bg-violet-600 rounded-sm hover:bg-dustypurple-800 focus:ring-2 focus:outline-none focus:ring-dustypurple-700"
+                  title="Refresh"
+                  on:click="{() => eventStoreInfo.clearEvents()}">
+                  Clear events
+                </button>
+              {/if}
+            </div>
+            {#if eventStoreInfo.bufferEvents.length > 0}
+              {@const reverseOrderedBufferEvents = [...eventStoreInfo.bufferEvents].reverse()}
+
+              <ul class="h-32 overflow-auto list-disc list-inside text-xs" aria-label="buffer-events">
+                {#each reverseOrderedBufferEvents as bufferEvent}
+                  <li aria-label="{bufferEvent.name}">
+                    {#if bufferEvent.skipped}
+                      Skipped event
+                    {:else}
+                      Grab {bufferEvent.length} items from
+                    {/if}
+
+                    '{bufferEvent.name}' event
+                    {#if bufferEvent.args?.length > 0}
+                      ({bufferEvent.args})
+                    {/if}
+
+                    {humanizeDuration(moment().diff(bufferEvent.date), { round: true, largest: 1 })} ago.
+
+                    {#if bufferEvent.humanDuration}
+                      Took {bufferEvent.humanDuration}.
+                    {/if}
+
+                    {#if bufferEvent.skipped}
+                      (ignoring)
+                    {/if}
+                  </li>
+                {/each}
+              </ul>
+            {:else}
+              <div class="h-32 flex flex-row mx-auto text-xs text-gray-800 text-center">No buffer events</div>
+            {/if}
+          </div>
+        </div>
+
+        <div class="text-xs text-gray-800 mt-2 text-center">Track events that have updated the store</div>
+        <div class="flex flex-row justify-end w-full pt-2">
+          <button aria-label="Cancel" class="text-xs hover:underline mr-3" on:click="{() => closeCallback()}"
+            >Cancel</button>
+          <button class="pf-c-button pf-m-primary" type="button" aria-label="Next" on:click="{() => closeCallback()}"
+            >OK</button>
+        </div>
+      </div>
+    </div>
+  </div></Modal>

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingPageStores.spec.ts
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingPageStores.spec.ts
@@ -1,0 +1,34 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import '@testing-library/jest-dom';
+import { beforeAll, test, expect } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import TroubleshootingPageStores from './TroubleshootingPageStores.svelte';
+
+beforeAll(() => {});
+
+test('Check stores widget is there', async () => {
+  render(TroubleshootingPageStores, {});
+
+  // get the h2 title
+  const title = screen.getByRole('heading', { name: 'Stores' });
+  expect(title).toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingPageStores.svelte
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingPageStores.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+import { onMount, onDestroy } from 'svelte';
+
+import { type Unsubscriber } from 'svelte/store';
+import type { EventStoreInfo } from '/@/stores/event-store';
+import { allEventStoresInfo } from '/@/stores/event-store-manager';
+import TroubleshootingPageStore from './TroubleshootingPageStore.svelte';
+import Fa from 'svelte-fa/src/fa.svelte';
+import { faDatabase } from '@fortawesome/free-solid-svg-icons';
+
+let allEventstores: EventStoreInfo[] = [];
+
+let allEventsUnsubscriber: Unsubscriber;
+
+onMount(() => {
+  allEventsUnsubscriber = allEventStoresInfo.subscribe(value => {
+    // sort the store
+    value.sort((a, b) => a.name.localeCompare(b.name));
+    allEventstores = value;
+  });
+});
+
+onDestroy(() => {
+  allEventsUnsubscriber?.();
+});
+</script>
+
+<div class="flex flex-col bg-zinc-700 m-4 p-4">
+  <div class="flex flex-row align-middle items-center w-full mb-4">
+    <Fa size="40" icon="{faDatabase}" />
+    <h2 class="mx-2 text-xl">Stores</h2>
+  </div>
+
+  <div class="grid grid-cols-2 lg:grid-cols-4 gap-x-4 gap-y-4">
+    {#each allEventstores as eventStore (eventStore.name)}
+      <TroubleshootingPageStore eventStoreInfo="{eventStore}" />
+    {/each}
+  </div>
+</div>


### PR DESCRIPTION
### What does this PR do?

Improve self-troubleshooting page

With the refactoring of the stores, https://github.com/containers/podman-desktop/pull/3101

now we're able to get more data/statistics from them

Number of elements in the store
event that triggered the update
time when it was updated last time
number of elements fetched at that time

allow to clear all history of events and manually fetch again the data to repopulate the store



### Screenshot/screencast of this PR


https://github.com/containers/podman-desktop/assets/436777/f48560b8-2453-474a-b902-b885369b6a19



### What issues does this PR fix or reference?

Fixes #3053 

### How to test this PR?

Go to the troubleshooting page, and you can see time to update the stores, events that triggered the update, etc.

also component tests added