### PR TITLE
fix: replace backslash with slash so to support rendering on Windows (#3120)

### DIFF
--- a/packages/main/src/plugin/api/font-info.ts
+++ b/packages/main/src/plugin/api/font-info.ts
@@ -18,6 +18,7 @@
 
 export interface FontSource {
   readonly location: string;
+  readonly browserURL: string;
   readonly format: string;
 }
 

--- a/packages/main/src/plugin/icon-registry.spec.ts
+++ b/packages/main/src/plugin/icon-registry.spec.ts
@@ -25,6 +25,12 @@ import type { AnalyzedExtension } from './extension-loader.js';
 let iconRegistry: IconRegistry;
 const apiSenderSendMock = vi.fn();
 
+vi.mock('../util', async () => {
+  return {
+    isWindows: () => false,
+  };
+});
+
 beforeAll(async () => {
   iconRegistry = new IconRegistry({
     send: apiSenderSendMock,
@@ -75,6 +81,7 @@ test('should register icon contribution', async () => {
     {
       format: 'woff2',
       location: `${extensionPath}/${fontPath}`,
+      browserURL: `${extensionPath}/${fontPath}`,
     },
   ]);
   expect(icon.definition.font?.fontId).toBe(`${extensionId}-${fontPath}`);

--- a/packages/main/src/plugin/icon-registry.spec.ts
+++ b/packages/main/src/plugin/icon-registry.spec.ts
@@ -81,7 +81,7 @@ test('should register icon contribution', async () => {
     {
       format: 'woff2',
       location: `${extensionPath}/${fontPath}`,
-      browserURL: `${extensionPath}/${fontPath}`,
+      browserURL: `url('file://${extensionPath}/${fontPath}')`,
     },
   ]);
   expect(icon.definition.font?.fontId).toBe(`${extensionId}-${fontPath}`);

--- a/packages/main/src/plugin/icon-registry.ts
+++ b/packages/main/src/plugin/icon-registry.ts
@@ -96,10 +96,11 @@ export class IconRegistry {
       // fontId is based on the extension id and the font path
       const fontId = `${extension.id}-${defaultAttributes.fontPath}`;
 
-      let browserURL = iconFontLocation;
+      let cleanedIconFontLocation = iconFontLocation.replace(/'/g, '%27');
       if (isWindows()) {
-        browserURL = browserURL.replace(/\\/g, '/');
+        cleanedIconFontLocation = cleanedIconFontLocation.replace(/\\/g, '/');
       }
+      const browserURL = `url('file://${cleanedIconFontLocation}')`;
 
       // font definition
       const fontDefinition: FontDefinition = {

--- a/packages/main/src/plugin/icon-registry.ts
+++ b/packages/main/src/plugin/icon-registry.ts
@@ -16,6 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import { isWindows } from '../util.js';
 import type { ApiSenderType } from './api.js';
 import type { FontDefinition } from './api/font-info.js';
 import type { IconDefinition, IconInfo } from './api/icon-info.js';
@@ -95,10 +96,15 @@ export class IconRegistry {
       // fontId is based on the extension id and the font path
       const fontId = `${extension.id}-${defaultAttributes.fontPath}`;
 
+      let browserURL = iconFontLocation;
+      if (isWindows()) {
+        browserURL = browserURL.replace(/\\/g, '/');
+      }
+
       // font definition
       const fontDefinition: FontDefinition = {
         fontId,
-        src: [{ location: iconFontLocation, format }],
+        src: [{ location: iconFontLocation, browserURL, format }],
       };
 
       // register font

--- a/packages/renderer/src/lib/style/IconsStyle.spec.ts
+++ b/packages/renderer/src/lib/style/IconsStyle.spec.ts
@@ -43,7 +43,7 @@ test('Check containers button is available and click on it', async () => {
         src: [
           {
             location: 'my-font.woff',
-            browserURL: 'my-font.woff',
+            browserURL: "url('file://my-font.woff')",
             format: 'woff2',
           },
         ],

--- a/packages/renderer/src/lib/style/IconsStyle.spec.ts
+++ b/packages/renderer/src/lib/style/IconsStyle.spec.ts
@@ -34,6 +34,7 @@ beforeAll(() => {
 });
 
 test('Check containers button is available and click on it', async () => {
+  const file = 'file://my-font.woff';
   const icon: IconInfo = {
     id: 'my-icon-id',
     definition: {
@@ -43,7 +44,7 @@ test('Check containers button is available and click on it', async () => {
         src: [
           {
             location: 'my-font.woff',
-            browserURL: "url('file://my-font.woff')",
+            browserURL: `url('${file}')`,
             format: 'woff2',
           },
         ],

--- a/packages/renderer/src/lib/style/IconsStyle.spec.ts
+++ b/packages/renderer/src/lib/style/IconsStyle.spec.ts
@@ -43,6 +43,7 @@ test('Check containers button is available and click on it', async () => {
         src: [
           {
             location: 'my-font.woff',
+            browserURL: 'my-font.woff',
             format: 'woff2',
           },
         ],

--- a/packages/renderer/src/lib/style/IconsStyle.svelte
+++ b/packages/renderer/src/lib/style/IconsStyle.svelte
@@ -18,10 +18,6 @@ function createStyleSheet(): HTMLStyleElement {
   return style;
 }
 
-export function toUrl(location: string) {
-  return `url('file://${location.replace(/'/g, '%27')}')`;
-}
-
 onMount(() => {
   createStyleSheet();
 
@@ -46,7 +42,7 @@ onMount(() => {
     });
 
     fontsToAdd.forEach(font => {
-      const src = font.src.map(l => `${toUrl(l.browserURL)} format('${l.format}')`).join(', ');
+      const src = font.src.map(l => `${l.browserURL} format('${l.format}')`).join(', ');
       styles.push(
         `@font-face { src: ${src}; font-family: '${font.fontId.replace(/'/g, '%27')}'; font-display: block; }`,
       );

--- a/packages/renderer/src/lib/style/IconsStyle.svelte
+++ b/packages/renderer/src/lib/style/IconsStyle.svelte
@@ -46,7 +46,7 @@ onMount(() => {
     });
 
     fontsToAdd.forEach(font => {
-      const src = font.src.map(l => `${toUrl(l.location)} format('${l.format}')`).join(', ');
+      const src = font.src.map(l => `${toUrl(l.browserURL)} format('${l.format}')`).join(', ');
       styles.push(
         `@font-face { src: ${src}; font-family: '${font.fontId.replace(/'/g, '%27')}'; font-display: block; }`,
       );


### PR DESCRIPTION
### What does this PR do?

This PR replaces backslashes with slashes when creating the url of a font style.
On Windows backslashes get removed and it results in a wrong url.

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

this fixes #3120 

### How to test this PR?

N/A
This is useful for #1899 to work
