### PR TITLE
feat: add start / stop buttons for compose containers

### DIFF
--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -153,3 +153,64 @@ test('restartContainersByLabel should succeed successfully if project name is pr
   // Expect restartContainer tohave been called 3 times
   expect(restartContainer).toHaveBeenCalledTimes(3);
 });
+
+// Same test but with startContainersByLabel
+
+test('startContainersByLabel should succeed successfully if project name is provided and call startContainer', async () => {
+  const engine = {
+    // Fake that we have 3 containers of the same project
+    listSimpleContainers: vi
+      .fn()
+      .mockResolvedValue([
+        fakeContainerWithComposeProject,
+        fakeContainerWithComposeProject,
+        fakeContainerWithComposeProject,
+      ]),
+    getContainer: vi.fn().mockReturnValue({ start: vi.fn().mockResolvedValue({}) }),
+    listPods: vi.fn().mockResolvedValue([]),
+    startContainer: vi.fn().mockResolvedValue({}),
+  };
+  vi.spyOn(containerRegistry, 'getMatchingEngine').mockReturnValue(engine as unknown as Dockerode);
+  vi.spyOn(containerRegistry, 'listSimpleContainers').mockReturnValue(engine.listSimpleContainers());
+
+  // Spy on startContainer to make sure it's called
+  // it is NOT called if there are no matches.. So it's important tot check this.
+  const startContainer = vi.spyOn(containerRegistry, 'startContainer');
+
+  // Restart all containers in the 'project1' project
+  const result = await containerRegistry.startContainersByLabel('dummy', 'com.docker.compose.project', 'project1');
+  expect(result).toBeUndefined();
+
+  // Expect startContainer to NOT have been called since our containers are "running"
+  expect(startContainer).toHaveBeenCalledTimes(0);
+});
+
+// Same test but with stopContainersByLabel
+test('stopContainersByLabel should succeed successfully if project name is provided and call stopContainer', async () => {
+  const engine = {
+    // Fake that we have 3 containers of the same project
+    listSimpleContainers: vi
+      .fn()
+      .mockResolvedValue([
+        fakeContainerWithComposeProject,
+        fakeContainerWithComposeProject,
+        fakeContainerWithComposeProject,
+      ]),
+    getContainer: vi.fn().mockReturnValue({ stop: vi.fn().mockResolvedValue({}) }),
+    listPods: vi.fn().mockResolvedValue([]),
+    stopContainer: vi.fn().mockResolvedValue({}),
+  };
+  vi.spyOn(containerRegistry, 'getMatchingEngine').mockReturnValue(engine as unknown as Dockerode);
+  vi.spyOn(containerRegistry, 'listSimpleContainers').mockReturnValue(engine.listSimpleContainers());
+
+  // Spy on stopContainer to make sure it's called
+  // it is NOT called if there are no matches.. So it's important tot check this.
+  const stopContainer = vi.spyOn(containerRegistry, 'stopContainer');
+
+  // Restart all containers in the 'project1' project
+  const result = await containerRegistry.stopContainersByLabel('dummy', 'com.docker.compose.project', 'project1');
+  expect(result).toBeUndefined();
+
+  // Expect stopContainer tohave been called 3 times
+  expect(stopContainer).toHaveBeenCalledTimes(3);
+});

--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -125,7 +125,7 @@ test('push should succeed if provider', async () => {
   expect(result).toBeUndefined();
 });
 
-test('restartContainersByProject should succeed successfully if project name is provided and call restartContainer', async () => {
+test('restartContainersByLabel should succeed successfully if project name is provided and call restartContainer', async () => {
   const engine = {
     // Fake that we have 3 containers of the same project
     listSimpleContainers: vi
@@ -147,7 +147,7 @@ test('restartContainersByProject should succeed successfully if project name is 
   const restartContainer = vi.spyOn(containerRegistry, 'restartContainer');
 
   // Restart all containers in the 'project1' project
-  const result = await containerRegistry.restartContainersByProject('dummy', 'project1');
+  const result = await containerRegistry.restartContainersByLabel('dummy', 'com.docker.compose.project', 'project1');
   expect(result).toBeUndefined();
 
   // Expect restartContainer tohave been called 3 times

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -1042,20 +1042,18 @@ export class ContainerProviderRegistry {
   }
 
   // Find all containers that match the against the given project name to
-  // the label com.docker.compose.project
-  // and then restart all the containers that match that label
-  async restartContainersByProject(engineId: string, projectName: string): Promise<void> {
+  // the label com.docker.compose.project (for example)
+  // and then restart all the containers that have the following label AND key
+  async restartContainersByLabel(engineId: string, label: string, key: string): Promise<void> {
     let telemetryOptions = {};
     try {
-      const projectLabel = 'com.docker.compose.project';
-
       // Get all the containers using listSimpleContainers
       const containers = await this.listSimpleContainers();
 
       // Find all the containers that are using projectLabel and match the projectName
       const containersMatchingProject = containers.filter(container => {
         const labels = container.Labels;
-        return labels && labels[projectLabel] === projectName;
+        return labels && labels[label] === key;
       });
 
       // Get all the container ids in containersIds

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -883,6 +883,14 @@ export class PluginSystem {
         return containerProviderRegistry.restartContainer(engine, containerId);
       },
     );
+
+    this.ipcHandle(
+      'container-provider-registry:restartContainersByProject',
+      async (_listener, engine: string, projectName: string): Promise<void> => {
+        return containerProviderRegistry.restartContainersByProject(engine, projectName);
+      },
+    );
+
     this.ipcHandle(
       'container-provider-registry:createAndStartContainer',
       async (_listener, engine: string, options: ContainerCreateOptions): Promise<void> => {

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -885,9 +885,9 @@ export class PluginSystem {
     );
 
     this.ipcHandle(
-      'container-provider-registry:restartContainersByProject',
-      async (_listener, engine: string, projectName: string): Promise<void> => {
-        return containerProviderRegistry.restartContainersByProject(engine, projectName);
+      'container-provider-registry:restartContainersByLabel',
+      async (_listener, engine: string, label: string, key: string): Promise<void> => {
+        return containerProviderRegistry.restartContainersByLabel(engine, label, key);
       },
     );
 

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -892,6 +892,20 @@ export class PluginSystem {
     );
 
     this.ipcHandle(
+      'container-provider-registry:startContainersByLabel',
+      async (_listener, engine: string, label: string, key: string): Promise<void> => {
+        return containerProviderRegistry.startContainersByLabel(engine, label, key);
+      },
+    );
+
+    this.ipcHandle(
+      'container-provider-registry:stopContainersByLabel',
+      async (_listener, engine: string, label: string, key: string): Promise<void> => {
+        return containerProviderRegistry.stopContainersByLabel(engine, label, key);
+      },
+    );
+
+    this.ipcHandle(
       'container-provider-registry:createAndStartContainer',
       async (_listener, engine: string, options: ContainerCreateOptions): Promise<void> => {
         return containerProviderRegistry.createAndStartContainer(engine, options);

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -334,6 +334,20 @@ function initExposure(): void {
   );
 
   contextBridge.exposeInMainWorld(
+    'startContainersByLabel',
+    async (engine: string, label: string, key: string): Promise<void> => {
+      return ipcInvoke('container-provider-registry:startContainersByLabel', engine, label, key);
+    },
+  );
+
+  contextBridge.exposeInMainWorld(
+    'stopContainersByLabel',
+    async (engine: string, label: string, key: string): Promise<void> => {
+      return ipcInvoke('container-provider-registry:stopContainersByLabel', engine, label, key);
+    },
+  );
+
+  contextBridge.exposeInMainWorld(
     'createAndStartContainer',
     async (engine: string, options: ContainerCreateOptions): Promise<void> => {
       return ipcInvoke('container-provider-registry:createAndStartContainer', engine, options);

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -327,9 +327,9 @@ function initExposure(): void {
   });
 
   contextBridge.exposeInMainWorld(
-    'restartContainersByProject',
-    async (engine: string, projectName: string): Promise<void> => {
-      return ipcInvoke('container-provider-registry:restartContainersByProject', engine, projectName);
+    'restartContainersByLabel',
+    async (engine: string, label: string, key: string): Promise<void> => {
+      return ipcInvoke('container-provider-registry:restartContainersByLabel', engine, label, key);
     },
   );
 

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -327,6 +327,13 @@ function initExposure(): void {
   });
 
   contextBridge.exposeInMainWorld(
+    'restartContainersByProject',
+    async (engine: string, projectName: string): Promise<void> => {
+      return ipcInvoke('container-provider-registry:restartContainersByProject', engine, projectName);
+    },
+  );
+
+  contextBridge.exposeInMainWorld(
     'createAndStartContainer',
     async (engine: string, options: ContainerCreateOptions): Promise<void> => {
       return ipcInvoke('container-provider-registry:createAndStartContainer', engine, options);

--- a/packages/renderer/src/lib/ContainerList.svelte
+++ b/packages/renderer/src/lib/ContainerList.svelte
@@ -30,6 +30,7 @@ import { containerGroupsInfo } from '../stores/containerGroups';
 import Checkbox from './ui/Checkbox.svelte';
 import type { PodInfo } from '../../../main/src/plugin/api/pod-info';
 import { PodUtils } from '../lib/pod/pod-utils';
+import ComposeActions from './compose/ComposeActions.svelte';
 
 const containerUtils = new ContainerUtils();
 let openChoiceModal = false;
@@ -490,6 +491,15 @@ function errorCallback(container: ContainerInfoUI, errorMessage: string): void {
                       kind: 'podman',
                     }}"
                     redirectAfterDelete="{false}"
+                    dropdownMenu="{true}" />
+                {/if}
+                {#if containerGroup.type === ContainerGroupInfoTypeUI.COMPOSE}
+                  <ComposeActions
+                    compose="{{
+                      status: containerGroup.status,
+                      name: containerGroup.name,
+                      engineId: containerGroup.engineId,
+                    }}"
                     dropdownMenu="{true}" />
                 {/if}
               </td>

--- a/packages/renderer/src/lib/compose/ComposeActions.svelte
+++ b/packages/renderer/src/lib/compose/ComposeActions.svelte
@@ -12,10 +12,12 @@ export let detailed = false;
 export let inProgressCallback: (inProgress: boolean, state?: string) => void = () => {};
 export let errorCallback: (erroMessage: string) => void = () => {};
 
+const composeLabel = 'com.docker.compose.project';
+
 async function restartCompose(composeInfoUI: ComposeInfoUI) {
   inProgressCallback(true, 'RESTARTING');
   try {
-    await window.restartContainersByProject(composeInfoUI.engineId, composeInfoUI.name);
+    await window.restartContainersByLabel(composeInfoUI.engineId, composeLabel, composeInfoUI.name);
   } catch (error) {
     errorCallback(error);
   } finally {

--- a/packages/renderer/src/lib/compose/ComposeActions.svelte
+++ b/packages/renderer/src/lib/compose/ComposeActions.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { faArrowsRotate } from '@fortawesome/free-solid-svg-icons';
+import { faPlay, faStop, faArrowsRotate } from '@fortawesome/free-solid-svg-icons';
 import type { ComposeInfoUI } from './ComposeInfoUI';
 import ListItemButtonIcon from '../ui/ListItemButtonIcon.svelte';
 import DropdownMenu from '../ui/DropdownMenu.svelte';
@@ -25,6 +25,28 @@ async function restartCompose(composeInfoUI: ComposeInfoUI) {
   }
 }
 
+async function startCompose(composeInfoUI: ComposeInfoUI) {
+  inProgressCallback(true, 'STARTING');
+  try {
+    await window.startContainersByLabel(composeInfoUI.engineId, composeLabel, composeInfoUI.name);
+  } catch (error) {
+    errorCallback(error);
+  } finally {
+    inProgressCallback(false, 'RUNNING');
+  }
+}
+
+async function stopCompose(composeInfoUI: ComposeInfoUI) {
+  inProgressCallback(true, 'STOPPING');
+  try {
+    await window.stopContainersByLabel(composeInfoUI.engineId, composeLabel, composeInfoUI.name);
+  } catch (error) {
+    errorCallback(error);
+  } finally {
+    inProgressCallback(false, 'STOPPED');
+  }
+}
+
 // If dropdownMenu = true, we'll change style to the imported dropdownMenu style
 // otherwise, leave blank.
 let actionsStyle;
@@ -34,6 +56,22 @@ if (dropdownMenu) {
   actionsStyle = FlatMenu;
 }
 </script>
+
+<ListItemButtonIcon
+  title="Start Compose"
+  onClick="{() => startCompose(compose)}"
+  hidden="{compose.status === 'RUNNING' || compose.status === 'STOPPING'}"
+  detailed="{detailed}"
+  inProgress="{compose.actionInProgress && compose.status === 'STARTING'}"
+  icon="{faPlay}"
+  iconOffset="pl-[0.15rem]" />
+<ListItemButtonIcon
+  title="Stop Compose"
+  onClick="{() => stopCompose(compose)}"
+  hidden="{!(compose.status === 'RUNNING' || compose.status === 'STOPPING')}"
+  detailed="{detailed}"
+  inProgress="{compose.actionInProgress && compose.status === 'STOPPING'}"
+  icon="{faStop}" />
 
 <!-- If dropdownMenu is true, use it, otherwise just show the regular buttons -->
 <svelte:component this="{actionsStyle}">

--- a/packages/renderer/src/lib/compose/ComposeActions.svelte
+++ b/packages/renderer/src/lib/compose/ComposeActions.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+import { faArrowsRotate } from '@fortawesome/free-solid-svg-icons';
+import type { ComposeInfoUI } from './ComposeInfoUI';
+import ListItemButtonIcon from '../ui/ListItemButtonIcon.svelte';
+import DropdownMenu from '../ui/DropdownMenu.svelte';
+import FlatMenu from '../ui/FlatMenu.svelte';
+
+export let compose: ComposeInfoUI;
+export let dropdownMenu = false;
+export let detailed = false;
+
+export let inProgressCallback: (inProgress: boolean, state?: string) => void = () => {};
+export let errorCallback: (erroMessage: string) => void = () => {};
+
+async function restartCompose(composeInfoUI: ComposeInfoUI) {
+  inProgressCallback(true, 'RESTARTING');
+  try {
+    await window.restartContainersByProject(composeInfoUI.engineId, composeInfoUI.name);
+  } catch (error) {
+    errorCallback(error);
+  } finally {
+    inProgressCallback(false);
+  }
+}
+
+// If dropdownMenu = true, we'll change style to the imported dropdownMenu style
+// otherwise, leave blank.
+let actionsStyle;
+if (dropdownMenu) {
+  actionsStyle = DropdownMenu;
+} else {
+  actionsStyle = FlatMenu;
+}
+</script>
+
+<!-- If dropdownMenu is true, use it, otherwise just show the regular buttons -->
+<svelte:component this="{actionsStyle}">
+  <ListItemButtonIcon
+    title="Restart Compose"
+    onClick="{() => restartCompose(compose)}"
+    menu="{dropdownMenu}"
+    detailed="{detailed}"
+    icon="{faArrowsRotate}" />
+</svelte:component>

--- a/packages/renderer/src/lib/compose/ComposeInfoUI.ts
+++ b/packages/renderer/src/lib/compose/ComposeInfoUI.ts
@@ -1,0 +1,25 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+export interface ComposeInfoUI {
+  engineId: string;
+  name: string;
+  status: string;
+  actionInProgress?: boolean;
+  actionError?: string;
+}

--- a/packages/renderer/src/lib/container/container-utils.ts
+++ b/packages/renderer/src/lib/container/container-utils.ts
@@ -145,6 +145,7 @@ export class ContainerUtils {
       return {
         name: composeProject,
         type: ContainerGroupInfoTypeUI.COMPOSE,
+        engineId: containerInfo.engineId,
       };
     }
 

--- a/packages/renderer/src/lib/pod/PodActions.svelte
+++ b/packages/renderer/src/lib/pod/PodActions.svelte
@@ -16,6 +16,7 @@ export let errorCallback: (erroMessage: string) => void = () => {};
 
 async function startPod(podInfoUI: PodInfoUI) {
   inProgressCallback(true, 'STARTING');
+  console.log('pod: ', pod);
   try {
     await window.startPod(podInfoUI.engineId, podInfoUI.id);
   } catch (error) {

--- a/packages/renderer/src/lib/pod/PodActions.svelte
+++ b/packages/renderer/src/lib/pod/PodActions.svelte
@@ -16,7 +16,6 @@ export let errorCallback: (erroMessage: string) => void = () => {};
 
 async function startPod(podInfoUI: PodInfoUI) {
   inProgressCallback(true, 'STARTING');
-  console.log('pod: ', pod);
   try {
     await window.startPod(podInfoUI.engineId, podInfoUI.id);
   } catch (error) {


### PR DESCRIPTION
feat: add start / stop buttons for compose containers

### What does this PR do?

Adds the start / stop button for compose containers to be stopped /
started.

This builds upon https://github.com/containers/podman-desktop/pull/3108
and must be merged before this PR.

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

Closes https://github.com/containers/podman-desktop/issues/3107

### How to test this PR?

1. Deploy a docker-compose example
(https://raw.githubusercontent.com/kubernetes/kompose/main/examples/docker-compose.yaml)
2. Go to the container view in PD
3. Press Start / Stop buttons for the group

<!-- Please explain steps to reproduce -->
