### PR TITLE
fix: handle invalid kubeconfig file

### DIFF
--- a/extensions/kube-context/src/extension.ts
+++ b/extensions/kube-context/src/extension.ts
@@ -52,7 +52,7 @@ export async function updateContext(
   const kubeConfig = jsYaml.load(kubeConfigRawContent);
 
   // get the current context
-  const currentContext = kubeConfig ? kubeConfig['current-context'] : undefined;
+  const currentContext = kubeConfig?.['current-context'];
 
   // get all contexts
   const contexts: KubeContext[] = kubeConfig?.['contexts'] ? kubeConfig['contexts'] : [];


### PR DESCRIPTION
Fixes #3029

### What does this PR do?

Handle errors happening when kubeconfig has invalid content

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

Fixes #3029

### How to test this PR?

Modify content of $HOME/.kube/config and launch Podman Desktop