### PR TITLE
feat: add start / stop buttons for compose containers

### DIFF
--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -186,3 +186,64 @@ test('restartContainersByLabel should succeed successfully if project name is pr
   // Expect restartContainer tohave been called 3 times
   expect(restartContainer).toHaveBeenCalledTimes(3);
 });
+
+// Same test but with startContainersByLabel
+
+test('startContainersByLabel should succeed successfully if project name is provided and call startContainer', async () => {
+  const engine = {
+    // Fake that we have 3 containers of the same project
+    listSimpleContainers: vi
+      .fn()
+      .mockResolvedValue([
+        fakeContainerWithComposeProject,
+        fakeContainerWithComposeProject,
+        fakeContainerWithComposeProject,
+      ]),
+    getContainer: vi.fn().mockReturnValue({ start: vi.fn().mockResolvedValue({}) }),
+    listPods: vi.fn().mockResolvedValue([]),
+    startContainer: vi.fn().mockResolvedValue({}),
+  };
+  vi.spyOn(containerRegistry, 'getMatchingEngine').mockReturnValue(engine as unknown as Dockerode);
+  vi.spyOn(containerRegistry, 'listSimpleContainers').mockReturnValue(engine.listSimpleContainers());
+
+  // Spy on startContainer to make sure it's called
+  // it is NOT called if there are no matches.. So it's important tot check this.
+  const startContainer = vi.spyOn(containerRegistry, 'startContainer');
+
+  // Restart all containers in the 'project1' project
+  const result = await containerRegistry.startContainersByLabel('dummy', 'com.docker.compose.project', 'project1');
+  expect(result).toBeUndefined();
+
+  // Expect startContainer to NOT have been called since our containers are "running"
+  expect(startContainer).toHaveBeenCalledTimes(0);
+});
+
+// Same test but with stopContainersByLabel
+test('stopContainersByLabel should succeed successfully if project name is provided and call stopContainer', async () => {
+  const engine = {
+    // Fake that we have 3 containers of the same project
+    listSimpleContainers: vi
+      .fn()
+      .mockResolvedValue([
+        fakeContainerWithComposeProject,
+        fakeContainerWithComposeProject,
+        fakeContainerWithComposeProject,
+      ]),
+    getContainer: vi.fn().mockReturnValue({ stop: vi.fn().mockResolvedValue({}) }),
+    listPods: vi.fn().mockResolvedValue([]),
+    stopContainer: vi.fn().mockResolvedValue({}),
+  };
+  vi.spyOn(containerRegistry, 'getMatchingEngine').mockReturnValue(engine as unknown as Dockerode);
+  vi.spyOn(containerRegistry, 'listSimpleContainers').mockReturnValue(engine.listSimpleContainers());
+
+  // Spy on stopContainer to make sure it's called
+  // it is NOT called if there are no matches.. So it's important tot check this.
+  const stopContainer = vi.spyOn(containerRegistry, 'stopContainer');
+
+  // Restart all containers in the 'project1' project
+  const result = await containerRegistry.stopContainersByLabel('dummy', 'com.docker.compose.project', 'project1');
+  expect(result).toBeUndefined();
+
+  // Expect stopContainer tohave been called 3 times
+  expect(stopContainer).toHaveBeenCalledTimes(3);
+});

--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -215,7 +215,7 @@ test('startContainersByLabel should succeed successfully if project name is prov
   expect(result).toBeUndefined();
 
   // Expect startContainer to NOT have been called since our containers are "running"
-  expect(startContainer).toHaveBeenCalledTimes(0);
+  expect(startContainer).not.toHaveBeenCalled();
 });
 
 // Same test but with stopContainersByLabel
@@ -244,6 +244,6 @@ test('stopContainersByLabel should succeed successfully if project name is provi
   const result = await containerRegistry.stopContainersByLabel('dummy', 'com.docker.compose.project', 'project1');
   expect(result).toBeUndefined();
 
-  // Expect stopContainer tohave been called 3 times
+  // Expect stopContainer to have been called 3 times
   expect(stopContainer).toHaveBeenCalledTimes(3);
 });

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -1079,14 +1079,9 @@ export class ContainerProviderRegistry {
       const containers = await this.listSimpleContainers();
 
       // Find all the containers that are using projectLabel and match the projectName
-      const containersMatchingProject = containers.filter(container => {
-        // dont try to start it if it's already running
-        if (container.State === 'running') {
-          return false;
-        }
-        const labels = container.Labels;
-        return labels && labels[label] === key;
-      });
+      const containersMatchingProject = containers.filter(
+        container => container.State !== 'running' && container.Labels?.[label] === key,
+      );
 
       // Get all the container ids in containersIds
       const containerIds = containersMatchingProject.map(container => container.Id);
@@ -1111,14 +1106,9 @@ export class ContainerProviderRegistry {
       const containers = await this.listSimpleContainers();
 
       // Find all the containers that are using projectLabel and match the projectName
-      const containersMatchingProject = containers.filter(container => {
-        // Only stop it if it's running, so filter out non-running ones.
-        if (container.State !== 'running') {
-          return false;
-        }
-        const labels = container.Labels;
-        return labels && labels[label] === key;
-      });
+      const containersMatchingProject = containers.filter(
+        container => container.State === 'running' && container.Labels?.[label] === key,
+      );
 
       // Get all the container ids in containersIds
       const containerIds = containersMatchingProject.map(container => container.Id);

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -894,6 +894,20 @@ export class PluginSystem {
     );
 
     this.ipcHandle(
+      'container-provider-registry:startContainersByLabel',
+      async (_listener, engine: string, label: string, key: string): Promise<void> => {
+        return containerProviderRegistry.startContainersByLabel(engine, label, key);
+      },
+    );
+
+    this.ipcHandle(
+      'container-provider-registry:stopContainersByLabel',
+      async (_listener, engine: string, label: string, key: string): Promise<void> => {
+        return containerProviderRegistry.stopContainersByLabel(engine, label, key);
+      },
+    );
+
+    this.ipcHandle(
       'container-provider-registry:createAndStartContainer',
       async (_listener, engine: string, options: ContainerCreateOptions): Promise<void> => {
         return containerProviderRegistry.createAndStartContainer(engine, options);

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -334,6 +334,20 @@ function initExposure(): void {
   );
 
   contextBridge.exposeInMainWorld(
+    'startContainersByLabel',
+    async (engine: string, label: string, key: string): Promise<void> => {
+      return ipcInvoke('container-provider-registry:startContainersByLabel', engine, label, key);
+    },
+  );
+
+  contextBridge.exposeInMainWorld(
+    'stopContainersByLabel',
+    async (engine: string, label: string, key: string): Promise<void> => {
+      return ipcInvoke('container-provider-registry:stopContainersByLabel', engine, label, key);
+    },
+  );
+
+  contextBridge.exposeInMainWorld(
     'createAndStartContainer',
     async (engine: string, options: ContainerCreateOptions): Promise<void> => {
       return ipcInvoke('container-provider-registry:createAndStartContainer', engine, options);

--- a/packages/renderer/src/lib/compose/ComposeActions.svelte
+++ b/packages/renderer/src/lib/compose/ComposeActions.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { faArrowsRotate } from '@fortawesome/free-solid-svg-icons';
+import { faPlay, faStop, faArrowsRotate } from '@fortawesome/free-solid-svg-icons';
 import type { ComposeInfoUI } from './ComposeInfoUI';
 import ListItemButtonIcon from '../ui/ListItemButtonIcon.svelte';
 import DropdownMenu from '../ui/DropdownMenu.svelte';
@@ -13,6 +13,27 @@ export let inProgressCallback: (inProgress: boolean, state?: string) => void = (
 export let errorCallback: (erroMessage: string) => void = () => {};
 
 const composeLabel = 'com.docker.compose.project';
+
+async function startCompose(composeInfoUI: ComposeInfoUI) {
+  inProgressCallback(true, 'STARTING');
+  try {
+    await window.startContainersByLabel(composeInfoUI.engineId, composeLabel, composeInfoUI.name);
+  } catch (error) {
+    errorCallback(error);
+  } finally {
+    inProgressCallback(false, 'RUNNING');
+  }
+}
+async function stopCompose(composeInfoUI: ComposeInfoUI) {
+  inProgressCallback(true, 'STOPPING');
+  try {
+    await window.stopContainersByLabel(composeInfoUI.engineId, composeLabel, composeInfoUI.name);
+  } catch (error) {
+    errorCallback(error);
+  } finally {
+    inProgressCallback(false, 'STOPPED');
+  }
+}
 
 async function restartCompose(composeInfoUI: ComposeInfoUI) {
   inProgressCallback(true, 'RESTARTING');
@@ -34,6 +55,22 @@ if (dropdownMenu) {
   actionsStyle = FlatMenu;
 }
 </script>
+
+<ListItemButtonIcon
+  title="Start Compose"
+  onClick="{() => startCompose(compose)}"
+  hidden="{compose.status === 'RUNNING' || compose.status === 'STOPPING'}"
+  detailed="{detailed}"
+  inProgress="{compose.actionInProgress && compose.status === 'STARTING'}"
+  icon="{faPlay}"
+  iconOffset="pl-[0.15rem]" />
+<ListItemButtonIcon
+  title="Stop Compose"
+  onClick="{() => stopCompose(compose)}"
+  hidden="{!(compose.status === 'RUNNING' || compose.status === 'STOPPING')}"
+  detailed="{detailed}"
+  inProgress="{compose.actionInProgress && compose.status === 'STOPPING'}"
+  icon="{faStop}" />
 
 <!-- If dropdownMenu is true, use it, otherwise just show the regular buttons -->
 <svelte:component this="{actionsStyle}">


### PR DESCRIPTION
feat: add start / stop buttons for compose containers

### What does this PR do?

Adds the start / stop button for compose containers to be stopped /
started.

This builds upon https://github.com/containers/podman-desktop/pull/3108
and must be merged before this PR.

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

https://github.com/containers/podman-desktop/assets/6422176/488d95fd-f5fe-4407-9656-f2fa83d8a592


https://github.com/containers/podman-desktop/assets/6422176/d80e7637-c223-4bb8-8675-1dcb8d48818f




### What issues does this PR fix or reference?

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

Closes https://github.com/containers/podman-desktop/issues/3107

### How to test this PR?

1. Deploy a docker-compose example
(https://raw.githubusercontent.com/kubernetes/kompose/main/examples/docker-compose.yaml)
2. Go to the container view in PD
3. Press Start / Stop buttons for the group

<!-- Please explain steps to reproduce -->

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
