### PR TITLE
feat: add delete button for compose

### DIFF
--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -211,7 +211,7 @@ test('startContainersByLabel should succeed successfully if project name is prov
   const startContainer = vi.spyOn(containerRegistry, 'startContainer');
 
   // Restart all containers in the 'project1' project
-  const result = await containerRegistry.startContainersByLabel('dummy', 'com.docker.compose.project', 'project1');
+  const result = await containerRegistry.startContainersByLabel({ engineId: 'dummy', label: 'com.docker.compose.project', key: 'project1' });
   expect(result).toBeUndefined();
 
   // Expect startContainer to NOT have been called since our containers are "running"
@@ -246,4 +246,35 @@ test('stopContainersByLabel should succeed successfully if project name is provi
 
   // Expect stopContainer to have been called 3 times
   expect(stopContainer).toHaveBeenCalledTimes(3);
+});
+
+// Test deleting containers by label
+test('deleteContainersByLabel should succeed successfully if project name is provided and call deleteContainer', async () => {
+  const engine = {
+    // Fake that we have 3 containers of the same project
+    listSimpleContainers: vi
+      .fn()
+      .mockResolvedValue([
+        fakeContainerWithComposeProject,
+        fakeContainerWithComposeProject,
+        fakeContainerWithComposeProject,
+        fakeContainer,
+      ]),
+    getContainer: vi.fn().mockReturnValue({ remove: vi.fn().mockResolvedValue({}) }),
+    listPods: vi.fn().mockResolvedValue([]),
+    deleteContainer: vi.fn().mockResolvedValue({}),
+  };
+  vi.spyOn(containerRegistry, 'getMatchingEngine').mockReturnValue(engine as unknown as Dockerode);
+  vi.spyOn(containerRegistry, 'listSimpleContainers').mockReturnValue(engine.listSimpleContainers());
+
+  // Spy on deleteContainer to make sure it's called
+  // it is NOT called if there are no matches.. So it's important to check this.
+  const deleteContainer = vi.spyOn(containerRegistry, 'deleteContainer');
+
+  // Delete all containers in the 'project1' project
+  const result = await containerRegistry.deleteContainersByLabel('dummy', 'com.docker.compose.project', 'project1');
+  expect(result).toBeUndefined();
+
+  // Expect deleteContainer tohave been called 3 times
+  expect(deleteContainer).toHaveBeenCalledTimes(3);
 });

--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -210,8 +210,8 @@ test('startContainersByLabel should succeed successfully if project name is prov
   // it is NOT called if there are no matches.. So it's important tot check this.
   const startContainer = vi.spyOn(containerRegistry, 'startContainer');
 
-  // Restart all containers in the 'project1' project
-  const result = await containerRegistry.startContainersByLabel({ engineId: 'dummy', label: 'com.docker.compose.project', key: 'project1' });
+  // Start all containers in the 'project1' project
+  const result = await containerRegistry.startContainersByLabel('dummy', 'com.docker.compose.project', 'project1');
   expect(result).toBeUndefined();
 
   // Expect startContainer to NOT have been called since our containers are "running"

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -1125,6 +1125,31 @@ export class ContainerProviderRegistry {
     }
   }
 
+    // Delete all containers that match a certain label and key
+    async deleteContainersByLabel(engineId: string, label: string, key: string): Promise<void> {
+      let telemetryOptions = {};
+      try {
+        // Get all the containers using listSimpleContainers
+        const containers = await this.listSimpleContainers();
+  
+        // Find all the containers that are using projectLabel and match the projectName
+        const containersMatchingProject = containers.filter(container => container.Labels?.[label] === key);
+  
+        // Get all the container ids in containersIds
+        const containerIds = containersMatchingProject.map(container => container.Id);
+  
+        // Delete all the containers in containerIds
+        await Promise.all(containerIds.map(containerId => this.deleteContainer(engineId, containerId)));
+      } catch (error) {
+        telemetryOptions = { error: error };
+        throw error;
+      } finally {
+        this.telemetryService
+          .track('deleteContainersByLabel', telemetryOptions)
+          .catch((err: unknown) => console.error('Unable to track', err));
+      }
+    }
+
   async logsContainer(engineId: string, id: string, callback: (name: string, data: string) => void): Promise<void> {
     let telemetryOptions = {};
     try {

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -1125,30 +1125,30 @@ export class ContainerProviderRegistry {
     }
   }
 
-    // Delete all containers that match a certain label and key
-    async deleteContainersByLabel(engineId: string, label: string, key: string): Promise<void> {
-      let telemetryOptions = {};
-      try {
-        // Get all the containers using listSimpleContainers
-        const containers = await this.listSimpleContainers();
-  
-        // Find all the containers that are using projectLabel and match the projectName
-        const containersMatchingProject = containers.filter(container => container.Labels?.[label] === key);
-  
-        // Get all the container ids in containersIds
-        const containerIds = containersMatchingProject.map(container => container.Id);
-  
-        // Delete all the containers in containerIds
-        await Promise.all(containerIds.map(containerId => this.deleteContainer(engineId, containerId)));
-      } catch (error) {
-        telemetryOptions = { error: error };
-        throw error;
-      } finally {
-        this.telemetryService
-          .track('deleteContainersByLabel', telemetryOptions)
-          .catch((err: unknown) => console.error('Unable to track', err));
-      }
+  // Delete all containers that match a certain label and key
+  async deleteContainersByLabel(engineId: string, label: string, key: string): Promise<void> {
+    let telemetryOptions = {};
+    try {
+      // Get all the containers using listSimpleContainers
+      const containers = await this.listSimpleContainers();
+
+      // Find all the containers that are using projectLabel and match the projectName
+      const containersMatchingProject = containers.filter(container => container.Labels?.[label] === key);
+
+      // Get all the container ids in containersIds
+      const containerIds = containersMatchingProject.map(container => container.Id);
+
+      // Delete all the containers in containerIds
+      await Promise.all(containerIds.map(containerId => this.deleteContainer(engineId, containerId)));
+    } catch (error) {
+      telemetryOptions = { error: error };
+      throw error;
+    } finally {
+      this.telemetryService
+        .track('deleteContainersByLabel', telemetryOptions)
+        .catch((err: unknown) => console.error('Unable to track', err));
     }
+  }
 
   async logsContainer(engineId: string, id: string, callback: (name: string, data: string) => void): Promise<void> {
     let telemetryOptions = {};

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -908,6 +908,13 @@ export class PluginSystem {
     );
 
     this.ipcHandle(
+      'container-provider-registry:deleteContainersByLabel',
+      async (_listener, engine: string, label: string, key: string): Promise<void> => {
+        return containerProviderRegistry.deleteContainersByLabel(engine, label, key);
+      },
+    );
+
+    this.ipcHandle(
       'container-provider-registry:createAndStartContainer',
       async (_listener, engine: string, options: ContainerCreateOptions): Promise<void> => {
         return containerProviderRegistry.createAndStartContainer(engine, options);

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -348,6 +348,13 @@ function initExposure(): void {
   );
 
   contextBridge.exposeInMainWorld(
+    'deleteContainersByLabel',
+    async (engine: string, label: string, key: string): Promise<void> => {
+      return ipcInvoke('container-provider-registry:deleteContainersByLabel', engine, label, key);
+    },
+  );
+
+  contextBridge.exposeInMainWorld(
     'createAndStartContainer',
     async (engine: string, options: ContainerCreateOptions): Promise<void> => {
       return ipcInvoke('container-provider-registry:createAndStartContainer', engine, options);

--- a/packages/renderer/src/lib/compose/ComposeActions.svelte
+++ b/packages/renderer/src/lib/compose/ComposeActions.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { faPlay, faStop, faArrowsRotate } from '@fortawesome/free-solid-svg-icons';
+import { faTrash, faPlay, faStop, faArrowsRotate } from '@fortawesome/free-solid-svg-icons';
 import type { ComposeInfoUI } from './ComposeInfoUI';
 import ListItemButtonIcon from '../ui/ListItemButtonIcon.svelte';
 import DropdownMenu from '../ui/DropdownMenu.svelte';
@@ -28,6 +28,17 @@ async function stopCompose(composeInfoUI: ComposeInfoUI) {
   inProgressCallback(true, 'STOPPING');
   try {
     await window.stopContainersByLabel(composeInfoUI.engineId, composeLabel, composeInfoUI.name);
+  } catch (error) {
+    errorCallback(error);
+  } finally {
+    inProgressCallback(false, 'STOPPED');
+  }
+}
+
+async function deleteCompose(composeInfoUI: ComposeInfoUI) {
+  inProgressCallback(true, 'DELETING');
+  try {
+    await window.deleteContainersByLabel(composeInfoUI.engineId, composeLabel, composeInfoUI.name);
   } catch (error) {
     errorCallback(error);
   } finally {
@@ -64,6 +75,7 @@ if (dropdownMenu) {
   inProgress="{compose.actionInProgress && compose.status === 'STARTING'}"
   icon="{faPlay}"
   iconOffset="pl-[0.15rem]" />
+
 <ListItemButtonIcon
   title="Stop Compose"
   onClick="{() => stopCompose(compose)}"
@@ -71,6 +83,13 @@ if (dropdownMenu) {
   detailed="{detailed}"
   inProgress="{compose.actionInProgress && compose.status === 'STOPPING'}"
   icon="{faStop}" />
+
+  <ListItemButtonIcon
+  title="Delete Compose"
+  onClick="{() => deleteCompose(compose)}"
+  icon="{faTrash}"
+  detailed="{detailed}"
+  inProgress="{compose.actionInProgress && compose.status === 'DELETING'}" />
 
 <!-- If dropdownMenu is true, use it, otherwise just show the regular buttons -->
 <svelte:component this="{actionsStyle}">

--- a/packages/renderer/src/lib/compose/ComposeActions.svelte
+++ b/packages/renderer/src/lib/compose/ComposeActions.svelte
@@ -84,7 +84,7 @@ if (dropdownMenu) {
   inProgress="{compose.actionInProgress && compose.status === 'STOPPING'}"
   icon="{faStop}" />
 
-  <ListItemButtonIcon
+<ListItemButtonIcon
   title="Delete Compose"
   onClick="{() => deleteCompose(compose)}"
   icon="{faTrash}"


### PR DESCRIPTION
feat: add delete button for compose

### What does this PR do?

Adds a delete button for a group of compose containers.

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

https://github.com/containers/podman-desktop/assets/6422176/289177d7-176b-4fa0-bdcf-6b5cc5e1fd52




### What issues does this PR fix or reference?

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

Closes https://github.com/containers/podman-desktop/issues/3106

### How to test this PR?

1. Deploy a docker-compose example
(https://raw.githubusercontent.com/kubernetes/kompose/main/examples/docker-compose.yaml)
2. Go to the container view in PD
3. Press trash / delete button.

<!-- Please explain steps to reproduce -->

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
