### PR TITLE
fix: do not remove registries when podman extension is stopping

### DIFF
--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -823,7 +823,7 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
 
   // register the registries
   const registrySetup = new RegistrySetup();
-  await registrySetup.setup(extensionContext);
+  await registrySetup.setup();
 
   const podmanConfiguration = new PodmanConfiguration();
   await podmanConfiguration.init();


### PR DESCRIPTION

### What does this PR do?
do not remove registries when podman extension is stopping

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

fixes #3135 

### How to test this PR?

Use the issue test case