### PR TITLE
chore: basic formatting in settings.json

### DIFF
--- a/packages/main/src/plugin/configuration-registry.ts
+++ b/packages/main/src/plugin/configuration-registry.ts
@@ -248,7 +248,7 @@ export class ConfigurationRegistry implements IConfigurationRegistry {
       .forEach(key => {
         delete cloneConfig[key];
       });
-    fs.writeFileSync(this.getSettingsFile(), JSON.stringify(cloneConfig));
+    fs.writeFileSync(this.getSettingsFile(), JSON.stringify(cloneConfig, undefined, 2));
   }
 
   /**


### PR DESCRIPTION
### What does this PR do?

As we add more configuration it's getting harder to read settings.json while debugging. This just puts each value on its own line with 2 space indents.

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Change a value in preferences. The configuration file (e.g. .local/share/containers/podman-desktop/configuration/settings.json) will change from looking like:
`{ "welcome.version": "initial", "telemetry.check": true, "editor.integrated.fontSize": 14, ...`

to:
```
{
  "welcome.version": "initial",
  "telemetry.check": true,
  "editor.integrated.fontSize": 14, ...
```