### PR TITLE
feat: remember stopped extensions across restart

### DIFF
--- a/packages/main/src/plugin/extension-loader.spec.ts
+++ b/packages/main/src/plugin/extension-loader.spec.ts
@@ -261,22 +261,15 @@ test('Should load file from watching scanning folder', async () => {
 
 test('Verify extension error leads to failed state', async () => {
   const id = 'extension.id';
-  await extensionLoader.activateExtension(
-    {
-      id: id,
-      name: 'id',
-      path: 'dummy',
-      api: {} as typeof containerDesktopAPI,
-      mainPath: '',
-      removable: false,
-      manifest: {},
-    },
-    {
-      activate: () => {
-        throw Error('Failed');
-      },
-    },
-  );
+  await extensionLoader.activateExtension({
+    id: id,
+    name: 'id',
+    path: 'dummy',
+    api: {} as typeof containerDesktopAPI,
+    mainPath: 'missing main',
+    removable: false,
+    manifest: {},
+  });
   expect(extensionLoader.getExtensionState().get(id)).toBe('failed');
 });
 

--- a/packages/main/src/plugin/extension-settings.ts
+++ b/packages/main/src/plugin/extension-settings.ts
@@ -1,0 +1,22 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+export enum ExtensionSettings {
+  SectionName = 'extensions',
+  Disabled = 'disabled',
+}

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1349,9 +1349,9 @@ export class PluginSystem {
     });
 
     this.ipcHandle(
-      'extension-loader:deactivateExtension',
+      'extension-loader:stopExtension',
       async (_listener: Electron.IpcMainInvokeEvent, extensionId: string): Promise<void> => {
-        return this.extensionLoader.deactivateExtension(extensionId);
+        return this.extensionLoader.stopExtension(extensionId);
       },
     );
     this.ipcHandle(

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -942,7 +942,7 @@ function initExposure(): void {
   });
 
   contextBridge.exposeInMainWorld('stopExtension', async (extensionId: string): Promise<void> => {
-    return ipcInvoke('extension-loader:deactivateExtension', extensionId);
+    return ipcInvoke('extension-loader:stopExtension', extensionId);
   });
 
   contextBridge.exposeInMainWorld('startExtension', async (extensionId: string): Promise<void> => {


### PR DESCRIPTION
### What does this PR do?

Introduces a new hidden configuration value 'extensions.disabled' to store an array of disabled extension ids. Disabled extensions are loaded but not activated on startup (with a log message).

When extensions are manually deactivated they're added to the list. Since shutdown and reload also deactivate extensions, a system argument is used to differentiate between the two.

When extensions are (manually) started they are removed from the list before trying to load.

Also renamed *activation > *activating so that the log is consistent.

### Screenshot/screencast of this PR

N/A.

### What issues does this PR fix or reference?

Fixes issue #268.

### How to test this PR?

Go to Settings > Extensions and stop an extension. Restart to confirm extension is still stopped. Start it; stop one or two others; restart and check again. No new errors in the log.