### PR TITLE
fix: load user extensions from plugins as removable

### DIFF
--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -292,7 +292,7 @@ export class ExtensionLoader {
 
       // collect all extensions from the pluginDirectory folders
       const analyzedPluginsDirectoryExtensions: AnalyzedExtension[] = (
-        await Promise.all(pluginDirectories.map(folder => this.analyzeExtension(folder, false)))
+        await Promise.all(pluginDirectories.map(folder => this.analyzeExtension(folder, true)))
       ).filter(extension => extension !== undefined) as AnalyzedExtension[];
       analyzedExtensions.push(...analyzedPluginsDirectoryExtensions);
     }
@@ -1019,7 +1019,7 @@ export class ExtensionLoader {
         // it returns exports
         console.log(`Activating extension (${extension.id})`);
         await extensionMain['activate'].apply(undefined, [extensionContext]);
-        console.log(`Activation extension (${extension.id}) ended`);
+        console.log(`Activating extension (${extension.id}) ended`);
       }
       const id = extension.id;
       const activatedExtension: ActivatedExtension = {
@@ -1031,7 +1031,7 @@ export class ExtensionLoader {
       this.extensionState.set(extension.id, 'started');
       this.apiSender.send('extension-started');
     } catch (err) {
-      console.log(`Activation extension ${extension.id} failed error:${err}`);
+      console.log(`Activating extension ${extension.id} failed error:${err}`);
       this.extensionState.set(extension.id, 'failed');
       this.extensionStateErrors.set(extension.id, err);
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -1058,7 +1058,7 @@ export class ExtensionLoader {
       try {
         await extension.deactivateFunction();
       } catch (err) {
-        console.log(`Deactivation extension ${extension.id} failed error:${err}`);
+        console.log(`Deactivating extension ${extension.id} failed error:${err}`);
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         (telemetryOptions as any).error = err;
       }


### PR DESCRIPTION
### What does this PR do?

Incorrect flag when loading extensions from the /plugins folder was causing them to not be removable.

Also taking this opportunity to change '*activation' to '*activating' so that log messages are consistent.

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

Fixes issue #3149.

### How to test this PR?

Install one of the featured (user-installed) extensions like Sandbox or OpenShift Local if you haven't already. Restart and confirm that they show as `(user)` in `Settings > Extensions`, and the built-in extensions do not.