### PR TITLE
fix: warning should be amber

### DIFF
--- a/packages/renderer/src/lib/ui/WarningMessage.svelte
+++ b/packages/renderer/src/lib/ui/WarningMessage.svelte
@@ -10,14 +10,14 @@ export let icon = false;
 {#if icon}
   {#if error !== undefined && error !== ''}
     <Tooltip tip="{error}" top>
-      <Fa size="18" class="cursor-pointer text-red-500" icon="{faTriangleExclamation}" />
+      <Fa size="18" class="cursor-pointer text-amber-500" icon="{faTriangleExclamation}" />
     </Tooltip>
   {/if}
 {:else}
   <div
-    class="text-red-500 p-1 flex flex-row items-center {$$props.class}"
+    class="text-amber-500 p-1 flex flex-row items-top {$$props.class}"
     class:opacity-0="{error === undefined || error === ''}">
-    <Fa size="18" class="cursor-pointer text-red-500" icon="{faTriangleExclamation}" />
+    <Fa size="18" class="cursor-pointer text-amber-500 mt-1" icon="{faTriangleExclamation}" />
     <div class="ml-2">{error}</div>
   </div>
 {/if}


### PR DESCRIPTION
### What does this PR do?

Change WarningMessage to be amber-500 and fix top alignment.

### Screenshot/screencast of this PR

<img width="122" alt="Screenshot 2023-07-07 at 3 27 17 PM" src="https://github.com/containers/podman-desktop/assets/19958075/9a503068-4b6f-46a1-9c67-2492461d441b">

### What issues does this PR fix or reference?

Fixes issue #3049.

### How to test this PR?

Generate a warning message (see original issue, or on in dev mode fake one).