### PR TITLE
feat: icons on form pages

### DIFF
--- a/packages/renderer/src/lib/help/HelpPage.svelte
+++ b/packages/renderer/src/lib/help/HelpPage.svelte
@@ -18,6 +18,9 @@ $: contributedLinks = $providerInfos
 </script>
 
 <FormPage title="Help" showBreadcrumb="{false}">
+  <span slot="icon">
+    <i class="fas fa-question-circle fa-2x" aria-hidden="true"></i>
+  </span>
   <div slot="content" class="flex flex-col min-w-full h-fit">
     <div class="min-w-full flex-1 pt-5 px-5 pb-5 space-y-5">
       <!-- Getting Started -->

--- a/packages/renderer/src/lib/image/RunImage.svelte
+++ b/packages/renderer/src/lib/image/RunImage.svelte
@@ -410,6 +410,9 @@ function checkContainerName(event: any) {
 <Route path="/*" let:meta>
   {#if dataReady}
     <FormPage title="Create a container from image {imageDisplayName}:{image.tag}">
+      <span slot="icon">
+        <i class="fas fa-play fa-2x" aria-hidden="true"></i>
+      </span>
       <div slot="content" class="p-5 min-w-full h-fit">
         <div class="bg-charcoal-600 px-6 py-4 space-y-2 lg:px-8 sm:pb-6 xl:pb-8">
           <section class="pf-c-page__main-tabs pf-m-limit-width">

--- a/packages/renderer/src/lib/pod/DeployPodToKube.svelte
+++ b/packages/renderer/src/lib/pod/DeployPodToKube.svelte
@@ -344,6 +344,10 @@ function updateKubeResult() {
 </script>
 
 <FormPage title="Deploy generated pod to Kubernetes">
+  <span slot="icon">
+    <i class="fas fa-rocket fa-2x" aria-hidden="true"></i>
+  </span>
+
   <div slot="content" class="p-5 min-w-full h-fit">
     <div class="bg-charcoal-600 p-5">
       {#if kubeDetails}

--- a/packages/renderer/src/lib/ui/FormPage.svelte
+++ b/packages/renderer/src/lib/ui/FormPage.svelte
@@ -20,6 +20,11 @@ export let showBreadcrumb = true;
         </div>
       {/if}
       <div class="flex flex-row items-center pt-1">
+        {#if $$slots.icon}
+          <div class="pr-3 text-gray-700">
+            <slot name="icon" />
+          </div>
+        {/if}
         <h1 aria-label="{title}" class="text-xl first-letter:uppercase">{title}</h1>
       </div>
     </div>


### PR DESCRIPTION
### What does this PR do?

The design has large icons on every form page. This adds a slot for icons to the page and icons to the existing pages: help, run image, and deploy pod to Kube.

### Screenshot/screencast of this PR

<img width="130" alt="Screenshot 2023-07-07 at 5 20 52 PM" src="https://github.com/containers/podman-desktop/assets/19958075/100d5c6b-5013-4973-9ff5-a18ed78e4774">
<img width="403" alt="Screenshot 2023-07-07 at 5 22 46 PM" src="https://github.com/containers/podman-desktop/assets/19958075/2e7ca494-8716-4178-a0e2-b156c23db884">
<img width="403" alt="Screenshot 2023-07-07 at 5 24 15 PM" src="https://github.com/containers/podman-desktop/assets/19958075/603126df-5c5e-4797-90a0-d51963535449">

### What issues does this PR fix or reference?

Related to issue #2936, but final design is only in penpot.

### How to test this PR?

Open up these three pages to confirm UI looks good.