### PR TITLE
fix: images with spaces in entrypoints or commands fail to start

### DIFF
--- a/packages/renderer/src/lib/image/RunImage.spec.ts
+++ b/packages/renderer/src/lib/image/RunImage.spec.ts
@@ -219,6 +219,19 @@ describe('RunImage', () => {
     );
   });
 
+  test('Expect that single array entrypoint with space is sent to API', async () => {
+    await createRunImage(['entrypoint with space'], []);
+
+    const button = screen.getByRole('button', { name: 'Start Container' });
+
+    await fireEvent.click(button);
+
+    expect(window.createAndStartContainer).toHaveBeenCalledWith(
+      'engineid',
+      expect.objectContaining({ Entrypoint: ['entrypoint with space'] }),
+    );
+  });
+
   test('Expect that two elements array entrypoint is sent to API', async () => {
     await createRunImage(['entrypoint1', 'entrypoint2'], []);
 
@@ -245,6 +258,18 @@ describe('RunImage', () => {
     );
   });
 
+  test('Expect that single array command with space is sent to API', async () => {
+    await createRunImage([], ['command with space']);
+
+    const button = screen.getByRole('button', { name: 'Start Container' });
+
+    await fireEvent.click(button);
+
+    expect(window.createAndStartContainer).toHaveBeenCalledWith(
+      'engineid',
+      expect.objectContaining({ Cmd: ['command with space'] }),
+    );
+  });
   test('Expect that two elements array command is sent to API', async () => {
     await createRunImage([], ['command1', 'command2']);
 

--- a/packages/renderer/src/lib/image/RunImage.svelte
+++ b/packages/renderer/src/lib/image/RunImage.svelte
@@ -15,6 +15,7 @@ import { ContainerUtils } from '../container/container-utils';
 import { containersInfos } from '../../stores/containers';
 import ErrorMessage from '../ui/ErrorMessage.svelte';
 import { splitSpacesHandlingDoubleQuotes } from '../string/string';
+import { array2String } from '/@/lib/string/string.js';
 
 let image: ImageInfoUI;
 
@@ -102,13 +103,13 @@ onMount(async () => {
   imageInspectInfo = await window.getImageInspect(image.engineId, image.id);
   exposedPorts = Array.from(Object.keys(imageInspectInfo?.Config?.ExposedPorts || {}));
 
-  command = imageInspectInfo.Config.Cmd.join(' ');
+  command = array2String(imageInspectInfo.Config.Cmd);
 
   if (imageInspectInfo.Config.Entrypoint) {
     if (typeof imageInspectInfo.Config.Entrypoint === 'string') {
       entrypoint = imageInspectInfo.Config.Entrypoint;
     } else {
-      entrypoint = imageInspectInfo.Config.Entrypoint.join(' ');
+      entrypoint = array2String(imageInspectInfo.Config.Entrypoint);
     }
   }
 

--- a/packages/renderer/src/lib/string/string.ts
+++ b/packages/renderer/src/lib/string/string.ts
@@ -39,3 +39,14 @@ export function splitSpacesHandlingDoubleQuotes(inputString): string[] {
 
   return tokens;
 }
+
+export function quote(str: string): string {
+  if (str.indexOf(' ') !== -1 && str.at(0) !== '"' && str.at(str.length - 1) !== '"') {
+    return '"' + str + '"';
+  }
+  return str;
+}
+
+export function array2String(array: string[]): string {
+  return array.map(str => quote(str)).join(' ');
+}


### PR DESCRIPTION
Relates to #958

### What does this PR do?

Fixes an error related to #958 when entrypoint or commands contains spaces

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

See #958

### How to test this PR?

Try to create a container from the nginx image