### PR TITLE
nit: no breadcrumb for authentication

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesPage.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesPage.svelte
@@ -68,7 +68,7 @@ onMount(async () => {
   <Route path="/registries" breadcrumb="Registries">
     <PreferencesRegistriesEditing />
   </Route>
-  <Route path="/authentication-providers">
+  <Route path="/authentication-providers" breadcrumb="Authentication">
     <PreferencesAuthenticationProvidersRendering />
   </Route>
   <Route path="/proxies" breadcrumb="Proxy">


### PR DESCRIPTION
### What does this PR do?

I noticed the authentication page has no breadcrumb, which indirectly means we are not tracking it in telemetry.

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

N/A

### How to test this PR?

You could check that the telemetry is now being sent... but that's likely overkill.