### PR TITLE
fix: units used for podman machine parameters

### DIFF
--- a/extensions/podman/src/extension.spec.ts
+++ b/extensions/podman/src/extension.spec.ts
@@ -101,14 +101,14 @@ test('verify create command called with correct values', async () => {
     {
       'podman.factory.machine.cpus': '2',
       'podman.factory.machine.image-path': 'path',
-      'podman.factory.machine.memory': '1048000000',
-      'podman.factory.machine.diskSize': '250000000000',
+      'podman.factory.machine.memory': '1048000000', // 1048MB = 999.45MiB
+      'podman.factory.machine.diskSize': '250000000000', // 250GB = 232.83GiB
     },
     undefined,
   );
   expect(spyExecPromise).toBeCalledWith(
     getPodmanCli(),
-    ['machine', 'init', '--cpus', '2', '--memory', '1048', '--disk-size', '250', '--image-path', 'path'],
+    ['machine', 'init', '--cpus', '2', '--memory', '999', '--disk-size', '232', '--image-path', 'path'],
     {
       env: {},
       logger: undefined,

--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -918,15 +918,15 @@ export async function createMachine(
   // memory
   if (params['podman.factory.machine.memory']) {
     parameters.push('--memory');
-    const memoryAsMB = +params['podman.factory.machine.memory'] / (1000 * 1000);
-    parameters.push(Math.floor(memoryAsMB).toString());
+    const memoryAsMiB = +params['podman.factory.machine.memory'] / (1024 * 1024);
+    parameters.push(Math.floor(memoryAsMiB).toString());
   }
 
   // disk size
   if (params['podman.factory.machine.diskSize']) {
     parameters.push('--disk-size');
-    const diskAsGB = +params['podman.factory.machine.diskSize'] / (1000 * 1000 * 1000);
-    parameters.push(Math.floor(diskAsGB).toString());
+    const diskAsGiB = +params['podman.factory.machine.diskSize'] / (1024 * 1024 * 1024);
+    parameters.push(Math.floor(diskAsGiB).toString());
   }
 
   // disk size


### PR DESCRIPTION
The podman parameters uses binary sizes for input, but Podman Desktop was trying to pass decimal sizes resulting in them being slightly off.

Since podman machine init only accepts integer parameters, there will be some round-off errors when converting the actual values from bytes.

### What does this PR do?

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?

Closes #3062

### How to test this PR?

<!-- Please explain steps to reproduce -->

Create a new Podman Machine, compare the resulting values with the input parameters.

There will be some round-off errors due to the unit conversion, but it should be closer...

The round-off errors are worse for the disk (given in GiB), than for the memory (in MiB):

```
NAME                    VM TYPE     CREATED       LAST UP        CPUS        MEMORY      DISK SIZE
podman-machine-default  qemu        1 second ago  7 minutes ago  2           3.999GB     9.664GB
```