### PR TITLE
feat: add ability to view compose logs

### DIFF
--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -27,6 +27,7 @@ import VolumesList from './lib/volume/VolumesList.svelte';
 import VolumeDetails from './lib/volume/VolumeDetails.svelte';
 import KubePlayYAML from './lib/kube/KubePlayYAML.svelte';
 import PodDetails from './lib/pod/PodDetails.svelte';
+import ComposeDetails from './lib/compose/ComposeDetails.svelte';
 import PodCreateFromContainers from './lib/pod/PodCreateFromContainers.svelte';
 import DeployPodToKube from './lib/pod/DeployPodToKube.svelte';
 import RunImage from './lib/image/RunImage.svelte';
@@ -128,7 +129,10 @@ window.events?.receive('display-troubleshooting', () => {
             resourceId="{decodeURI(meta.params.resourceId)}"
             engineId="{decodeURI(meta.params.engineId)}" />
         </Route>
-        <Route path="/pods/:kind/:name/:engineId/*" breadcrumb="Pod Details" let:meta navigationHint="details">
+        <Route path="/compose/:name/:engineId/*" breadcrumb="Compose Details" let:meta>
+          <ComposeDetails composeName="{decodeURI(meta.params.name)}" engineId="{decodeURI(meta.params.engineId)}" />
+        </Route>
+        <Route path="/pods/:kind/:name/:engineId/*" breadcrumb="Pod Details" let:meta>
           <PodDetails
             podName="{decodeURI(meta.params.name)}"
             engineId="{decodeURI(meta.params.engineId)}"

--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -129,10 +129,10 @@ window.events?.receive('display-troubleshooting', () => {
             resourceId="{decodeURI(meta.params.resourceId)}"
             engineId="{decodeURI(meta.params.engineId)}" />
         </Route>
-        <Route path="/compose/:name/:engineId/*" breadcrumb="Compose Details" let:meta>
+        <Route path="/compose/:name/:engineId/*" breadcrumb="Compose Details" let:meta navigationHint="details">
           <ComposeDetails composeName="{decodeURI(meta.params.name)}" engineId="{decodeURI(meta.params.engineId)}" />
         </Route>
-        <Route path="/pods/:kind/:name/:engineId/*" breadcrumb="Pod Details" let:meta>
+        <Route path="/pods/:kind/:name/:engineId/*" breadcrumb="Pod Details" let:meta navigationHint="details">
           <PodDetails
             podName="{decodeURI(meta.params.name)}"
             engineId="{decodeURI(meta.params.engineId)}"

--- a/packages/renderer/src/lib/ContainerList.svelte
+++ b/packages/renderer/src/lib/ContainerList.svelte
@@ -303,6 +303,8 @@ function keydownChoice(e: KeyboardEvent) {
 function openGroupDetails(containerGroup: ContainerGroupInfoUI): void {
   if (containerGroup.type === ContainerGroupInfoTypeUI.POD) {
     router.goto(`/pods/podman/${encodeURI(containerGroup.name)}/${encodeURI(containerGroup.engineId)}/logs`);
+  } else if (containerGroup.type === ContainerGroupInfoTypeUI.COMPOSE) {
+    router.goto(`/compose/${encodeURI(containerGroup.name)}/${encodeURI(containerGroup.engineId)}/logs`);
   }
 }
 
@@ -494,6 +496,7 @@ function errorCallback(container: ContainerInfoUI, errorMessage: string): void {
                       status: containerGroup.status,
                       name: containerGroup.name,
                       engineId: containerGroup.engineId,
+                      containers: [],
                     }}"
                     dropdownMenu="{true}" />
                 {/if}

--- a/packages/renderer/src/lib/compose/ComposeDetails.spec.ts
+++ b/packages/renderer/src/lib/compose/ComposeDetails.spec.ts
@@ -33,7 +33,11 @@ test('Simple test that compose logs are clickable and loadable', async () => {
   render(ComposeDetails, { composeName: 'foobar', engineId: 'engine' });
   // Click on the logs href
   const logsHref = screen.getByRole('link', { name: 'Logs' });
-  fireEvent.click(logsHref);
+  await fireEvent.click(logsHref);
+
+  // Checks that the 'emptyscreen' of the logs is displayed
+  // which should display "Log output of foobar"
+  expect(screen.getByText('Log output of foobar')).toBeInTheDocument();
 });
 
 test('Simple test that compose name is displayed', async () => {

--- a/packages/renderer/src/lib/compose/ComposeDetails.spec.ts
+++ b/packages/renderer/src/lib/compose/ComposeDetails.spec.ts
@@ -1,0 +1,42 @@
+import '@testing-library/jest-dom';
+import { test, expect, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import ComposeDetails from './ComposeDetails.svelte';
+import { mockBreadcrumb } from '../../stores/breadcrumb';
+
+vi.mock('xterm', () => {
+  return {
+    Terminal: vi.fn().mockReturnValue({ loadAddon: vi.fn(), open: vi.fn(), write: vi.fn(), clear: vi.fn() }),
+  };
+});
+
+beforeAll(() => {
+  (window.events as unknown) = {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    receive: (_channel: string, func: any) => {
+      func();
+    },
+  };
+  (window as any).getConfigurationValue = vi.fn();
+  (window as any).matchMedia = vi.fn().mockReturnValue({
+    addListener: vi.fn(),
+  });
+  (window as any).telemetryPage = vi.fn().mockReturnValue({
+    sendPageView: vi.fn(),
+  });
+  (window as any).ResizeObserver = vi.fn().mockReturnValue({ observe: vi.fn(), unobserve: vi.fn() });
+  (window as any).initializeProvider = vi.fn().mockResolvedValue([]);
+  mockBreadcrumb();
+});
+
+test('Simple test that compose logs are clickable and loadable', async () => {
+  render(ComposeDetails, { composeName: 'foobar', engineId: 'engine' });
+  // Click on the logs href
+  const logsHref = screen.getByRole('link', { name: 'Logs' });
+  fireEvent.click(logsHref);
+});
+
+test('Simple test that compose name is displayed', async () => {
+  render(ComposeDetails, { composeName: 'foobar', engineId: 'engine' });
+  expect(screen.getByText('foobar')).toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/compose/ComposeDetails.svelte
+++ b/packages/renderer/src/lib/compose/ComposeDetails.svelte
@@ -3,8 +3,6 @@ import Route from '../../Route.svelte';
 import ComposeIcon from '../images/PodIcon.svelte';
 import StatusIcon from '../images/StatusIcon.svelte';
 import ComposeActions from './ComposeActions.svelte';
-import DetailsPage from '../ui/DetailsPage.svelte';
-import DetailsTab from '../ui/DetailsTab.svelte';
 import type { Unsubscriber } from 'svelte/store';
 import { onDestroy, onMount } from 'svelte';
 import { containersInfos } from '/@/stores/containers';
@@ -12,6 +10,8 @@ import type { ComposeInfoUI } from './ComposeInfoUI';
 import { ContainerUtils } from '../container/container-utils';
 import ComposeDetailsLogs from './ComposeDetailsLogs.svelte';
 import type { ContainerInfoUI } from '../container/ContainerInfoUI';
+import DetailsPage from '../ui/DetailsPage.svelte';
+import Tab from '../ui/Tab.svelte';
 
 export let composeName: string;
 export let engineId: string;
@@ -75,19 +75,19 @@ onDestroy(() => {
 {#if compose}
   <DetailsPage title="{composeName}" subtitle="">
     <StatusIcon slot="icon" icon="{ComposeIcon}" status="{compose.status}" />
-    <div slot="actions" class="flex justify-end">
+    <svelte:fragment slot="actions">
       <div class="flex items-center w-5">
         <div>&nbsp;</div>
       </div>
-      <ComposeActions compose="{compose}" dropdownMenu="{true}" />
-    </div>
-    <div slot="tabs" class="pf-c-tabs__list">
-      <DetailsTab title="Logs" url="logs" />
-    </div>
-    <span slot="content">
+      <ComposeActions compose="{compose}" detailed="{true}" />
+    </svelte:fragment>
+    <svelte:fragment slot="tabs">
+      <Tab title="Logs" url="logs" />
+    </svelte:fragment>
+    <svelte:fragment slot="content">
       <Route path="/logs" breadcrumb="Logs" navigationHint="tab">
         <ComposeDetailsLogs compose="{compose}" />
       </Route>
-    </span>
+    </svelte:fragment>
   </DetailsPage>
 {/if}

--- a/packages/renderer/src/lib/compose/ComposeDetails.svelte
+++ b/packages/renderer/src/lib/compose/ComposeDetails.svelte
@@ -1,0 +1,93 @@
+<script lang="ts">
+import Route from '../../Route.svelte';
+import ComposeIcon from '../images/PodIcon.svelte';
+import StatusIcon from '../images/StatusIcon.svelte';
+import ComposeActions from './ComposeActions.svelte';
+import DetailsPage from '../ui/DetailsPage.svelte';
+import DetailsTab from '../ui/DetailsTab.svelte';
+import type { Unsubscriber } from 'svelte/store';
+import { onDestroy, onMount } from 'svelte';
+import { containersInfos } from '/@/stores/containers';
+import type { ComposeInfoUI } from './ComposeInfoUI';
+import { ContainerUtils } from '../container/container-utils';
+import ComposeDetailsLogs from './ComposeDetailsLogs.svelte';
+import type { ContainerInfoUI } from '../container/ContainerInfoUI';
+
+export let composeName: string;
+export let engineId: string;
+
+const containerUtils = new ContainerUtils();
+let composeUnsubscribe: Unsubscriber;
+
+let compose: ComposeInfoUI;
+
+onMount(() => {
+  // We will use the containersInfos store to get every container that matches
+  // the label com.docker.compose.project={composeName}
+  // We only care about the status. Check each containersMatchingProject status and if every container is RUNNING, set status to RUNNING,
+  // else let status be 'STOPPED'
+  composeUnsubscribe = containersInfos.subscribe(containers => {
+    let convertedContainers: ContainerInfoUI[];
+    let status: string;
+
+    // Get all containers that match the composeName we are looking at
+    const containersMatchingProject = containers.filter(container => {
+      return container?.Labels['com.docker.compose.project'] === composeName;
+    });
+
+    // Update our current status
+    if (containersMatchingProject.length === 0) {
+      status = 'STOPPED';
+    } else {
+      const allRunning = containersMatchingProject.every(container => {
+        return container?.State === 'running';
+      });
+      if (allRunning) {
+        status = 'RUNNING';
+      } else {
+        status = 'STOPPED';
+      }
+    }
+
+    // Convert each matching container to the ComposeInfoContainerUI type and add it to compose.containers
+    convertedContainers = containersMatchingProject.map(container => {
+      return containerUtils.getContainerInfoUI(container);
+    });
+
+    // Make sure we update the compose object with the name, status, engineID, containers, etc.
+    // or else logging will not appear correctly when loading (it'll see empty containers..)
+    compose = {
+      name: composeName,
+      engineId: engineId,
+      status: status,
+      containers: convertedContainers,
+    };
+  });
+});
+
+onDestroy(() => {
+  if (composeUnsubscribe) {
+    composeUnsubscribe();
+  }
+});
+</script>
+
+{#if compose}
+  <DetailsPage title="{composeName}" subtitle="">
+    <StatusIcon slot="icon" icon="{ComposeIcon}" status="{compose.status}" />
+    <div slot="actions" class="flex justify-end">
+      <div class="flex items-center w-5">
+        <div>&nbsp;</div>
+      </div>
+      <ComposeActions compose="{compose}" dropdownMenu="{true}" />
+    </div>
+    <div slot="tabs" class="pf-c-tabs__list">
+      <DetailsTab title="Logs" url="logs" />
+    </div>
+    <span slot="content">
+      <Route path="/logs" breadcrumb="Logs" navigationHint="tab">
+        <ComposeDetailsLogs compose="{compose}" />
+      </Route>
+    </span>
+  </DetailsPage>
+{/if}

--- a/packages/renderer/src/lib/compose/ComposeDetailsLogs.svelte
+++ b/packages/renderer/src/lib/compose/ComposeDetailsLogs.svelte
@@ -9,6 +9,7 @@ import { isMultiplexedLog } from '../stream/stream-utils';
 import EmptyScreen from '../ui/EmptyScreen.svelte';
 import NoLogIcon from '../ui/NoLogIcon.svelte';
 import type { ComposeInfoUI } from './ComposeInfoUI';
+import { ansi256Colours, colourizedANSIContainerName } from '../editor/editor-utils';
 
 export let compose: ComposeInfoUI;
 
@@ -36,31 +37,9 @@ let currentRouterPath: string;
 // Router path for the logging
 let logsRouterPath = `/compose/${encodeURI(compose.name)}/${encodeURI(compose.engineId)}/logs`;
 
-// An array of readable ANSI escape sequence colours against a black terminal background
-// these are the most "readable" colours against a black background
-// No colours like grey, normal blue (cyan instead) or red, since they don't appear very well.
-const ansi256Colors = [
-  '\u001b[36m', // cyan
-  '\u001b[33m', // yellow
-  '\u001b[32m', // green
-  '\u001b[35m', // magenta
-  '\u001b[34m', // blue
-  '\u001b[36;1m', // bright cyan
-  '\u001b[33;1m', // bright yellow
-  '\u001b[32;1m', // bright green
-  '\u001b[35;1m', // bright magenta
-  '\u001b[34;1m', // bright blue
-];
-
 // Create a map that will store the ANSI 256 colour for each container name
 // if we run out of colours, we'll start from the beginning.
 const colourizedContainerName = new Map<string, string>();
-
-// Function that takes the container name and ANSI colour and encapsulates the name in the colour,
-// making sure that we reset the colour back to white after the name.
-function colourizedANSIContainerName(name: string, colour: string) {
-  return `${colour}${name}\u001b[0m`;
-}
 
 // Callback for logs which will output the logs to the terminal
 function callback(name: string, data: string) {
@@ -150,11 +129,9 @@ async function refreshTerminal() {
 
 onMount(async () => {
   compose.containers.forEach((container, index) => {
-    const colour = ansi256Colors[index % ansi256Colors.length];
+    const colour = ansi256Colours[index % ansi256Colours.length];
     colourizedContainerName.set(container.name, colourizedANSIContainerName(container.name, colour));
   });
-
-  console.log('colors:', colourizedContainerName);
 
   // Refresh the terminal on initial load
   await refreshTerminal();

--- a/packages/renderer/src/lib/compose/ComposeDetailsLogs.svelte
+++ b/packages/renderer/src/lib/compose/ComposeDetailsLogs.svelte
@@ -1,0 +1,186 @@
+<script lang="ts">
+import { onDestroy, onMount } from 'svelte';
+import { Terminal } from 'xterm';
+import { FitAddon } from 'xterm-addon-fit';
+import 'xterm/css/xterm.css';
+import { TerminalSettings } from '../../../../main/src/plugin/terminal-settings';
+import { getPanelDetailColor } from '../color/color';
+import { isMultiplexedLog } from '../stream/stream-utils';
+import EmptyScreen from '../ui/EmptyScreen.svelte';
+import NoLogIcon from '../ui/NoLogIcon.svelte';
+import type { ComposeInfoUI } from './ComposeInfoUI';
+
+export let compose: ComposeInfoUI;
+
+// Logging element
+let logsXtermDiv: HTMLDivElement;
+let refCompose;
+
+// Log initialization
+let noLogs = true;
+let logsTerminal: Terminal;
+
+$: {
+  if (refCompose && refCompose.status !== compose.status) {
+    logsTerminal?.clear();
+    fetchComposeLogs();
+  }
+  refCompose = compose;
+}
+
+// Terminal resize
+let resizeObserver: ResizeObserver;
+let termFit: FitAddon;
+let currentRouterPath: string;
+
+// Router path for the logging
+let logsRouterPath = `/compose/${encodeURI(compose.name)}/${encodeURI(compose.engineId)}/logs`;
+
+// An array of readable ANSI escape sequence colours against a black terminal background
+// these are the most "readable" colours against a black background
+// No colours like grey, normal blue (cyan instead) or red, since they don't appear very well.
+const ansi256Colors = [
+  '\u001b[36m', // cyan
+  '\u001b[33m', // yellow
+  '\u001b[32m', // green
+  '\u001b[35m', // magenta
+  '\u001b[34m', // blue
+  '\u001b[36;1m', // bright cyan
+  '\u001b[33;1m', // bright yellow
+  '\u001b[32;1m', // bright green
+  '\u001b[35;1m', // bright magenta
+  '\u001b[34;1m', // bright blue
+];
+
+// Create a map that will store the ANSI 256 colour for each container name
+// if we run out of colours, we'll start from the beginning.
+const colourizedContainerName = new Map<string, string>();
+
+// Function that takes the container name and ANSI colour and encapsulates the name in the colour,
+// making sure that we reset the colour back to white after the name.
+function colourizedANSIContainerName(name: string, colour: string) {
+  return `${colour}${name}\u001b[0m`;
+}
+
+// Callback for logs which will output the logs to the terminal
+function callback(name: string, data: string) {
+  if (name === 'first-message') {
+    noLogs = false;
+  } else if (name === 'data') {
+    noLogs = false;
+    // 1: STDOUT
+    // 2: STDERR
+    logsTerminal?.write(data + '\r');
+  }
+}
+
+// Fetches the logs for each container in the compose group
+async function fetchComposeLogs() {
+  // Figure out how much spacing to put for the naming of the containers
+  let maxNameLength = 0;
+  compose.containers.forEach(container => {
+    if (container.name.length > maxNameLength) {
+      maxNameLength = container.name.length;
+    }
+  });
+
+  // Go trhrough the array of containers in the compose group
+  // and create a custom logsContainer window for each container, we use a custom logsCallback
+  // in order to add padding to each output / make it look nice.
+  for (let container of compose.containers) {
+    // Set a customer callback that will add the container name and padding
+    const logsCallback = (name: string, data: string) => {
+      const padding = ' '.repeat(maxNameLength - container.name.length);
+      const colouredName = colourizedContainerName.get(container.name);
+
+      let content;
+      if (isMultiplexedLog(data)) {
+        content = data.substring(8);
+      } else {
+        content = data;
+      }
+
+      callback(name, `${colouredName} ${padding} | ${content}`);
+    };
+
+    // Get the logs for the container
+    await window.logsContainer(container.engineId, container.id, logsCallback);
+  }
+}
+
+async function refreshTerminal() {
+  // missing element, return
+  if (!logsXtermDiv) {
+    console.log('missing xterm div, exiting...');
+    return;
+  }
+  // grab font size
+  const fontSize = await window.getConfigurationValue<number>(
+    TerminalSettings.SectionName + '.' + TerminalSettings.FontSize,
+  );
+  const lineHeight = await window.getConfigurationValue<number>(
+    TerminalSettings.SectionName + '.' + TerminalSettings.LineHeight,
+  );
+
+  logsTerminal = new Terminal({
+    fontSize,
+    lineHeight,
+    disableStdin: true,
+    theme: {
+      background: getPanelDetailColor(),
+    },
+    convertEol: true,
+  });
+  termFit = new FitAddon();
+  logsTerminal.loadAddon(termFit);
+
+  logsTerminal.open(logsXtermDiv);
+
+  // disable cursor
+  logsTerminal.write('\x1b[?25l');
+
+  // call fit addon each time we resize the window
+  window.addEventListener('resize', () => {
+    if (currentRouterPath === logsRouterPath) {
+      termFit.fit();
+    }
+  });
+  termFit.fit();
+}
+
+onMount(async () => {
+  compose.containers.forEach((container, index) => {
+    const colour = ansi256Colors[index % ansi256Colors.length];
+    colourizedContainerName.set(container.name, colourizedANSIContainerName(container.name, colour));
+  });
+
+  console.log('colors:', colourizedContainerName);
+
+  // Refresh the terminal on initial load
+  await refreshTerminal();
+  fetchComposeLogs();
+
+  // Resize the terminal each time we change the div size
+  resizeObserver = new ResizeObserver(() => {
+    termFit?.fit();
+  });
+
+  // Observe the terminal div
+  resizeObserver.observe(logsXtermDiv);
+});
+
+onDestroy(() => {
+  // Cleanup the observer on destroy
+  resizeObserver?.unobserve(logsXtermDiv);
+});
+</script>
+
+<EmptyScreen icon="{NoLogIcon}" title="No Log" message="Log output of {compose.name}" hidden="{noLogs === false}" />
+
+<div
+  class="min-w-full flex flex-col"
+  class:invisible="{noLogs === true}"
+  class:h-0="{noLogs === true}"
+  class:h-full="{noLogs === false}"
+  bind:this="{logsXtermDiv}">
+</div>

--- a/packages/renderer/src/lib/compose/ComposeInfoUI.ts
+++ b/packages/renderer/src/lib/compose/ComposeInfoUI.ts
@@ -16,10 +16,13 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { ContainerInfoUI } from '../container/ContainerInfoUI';
+
 export interface ComposeInfoUI {
   engineId: string;
   name: string;
   status: string;
   actionInProgress?: boolean;
   actionError?: string;
+  containers: ContainerInfoUI[];
 }

--- a/packages/renderer/src/lib/editor/editor-utils.ts
+++ b/packages/renderer/src/lib/editor/editor-utils.ts
@@ -1,0 +1,39 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+// An array of readable ANSI escape sequence colours against a black terminal background
+// these are the most "readable" colours against a black background
+// No colours like grey, normal blue (cyan instead) or red, since they don't appear very well.
+export const ansi256Colours = [
+  '\u001b[36m', // cyan
+  '\u001b[33m', // yellow
+  '\u001b[32m', // green
+  '\u001b[35m', // magenta
+  '\u001b[34m', // blue
+  '\u001b[36;1m', // bright cyan
+  '\u001b[33;1m', // bright yellow
+  '\u001b[32;1m', // bright green
+  '\u001b[35;1m', // bright magenta
+  '\u001b[34;1m', // bright blue
+];
+
+// Function that takes the container name and ANSI colour and encapsulates the name in the colour,
+// making sure that we reset the colour back to white after the name.
+export function colourizedANSIContainerName(name: string, colour: string) {
+  return `${colour}${name}\u001b[0m`;
+}

--- a/packages/renderer/src/lib/pod/PodDetailsLogs.svelte
+++ b/packages/renderer/src/lib/pod/PodDetailsLogs.svelte
@@ -7,6 +7,7 @@ import { TerminalSettings } from '../../../../main/src/plugin/terminal-settings'
 import { getPanelDetailColor } from '../color/color';
 import type { PodInfoUI } from './PodInfoUI';
 import { isMultiplexedLog } from '../stream/stream-utils';
+import { ansi256Colours, colourizedANSIContainerName } from '../editor/editor-utils';
 import EmptyScreen from '../ui/EmptyScreen.svelte';
 import NoLogIcon from '../ui/NoLogIcon.svelte';
 
@@ -34,35 +35,13 @@ let termFit: FitAddon;
 let currentRouterPath: string;
 let logsRouterPath = `/pods/${encodeURI(pod.kind)}/${encodeURI(pod.name)}/${encodeURI(pod.engineId)}/logs`;
 
-// An array of readable ANSI escape sequence colours against a black terminal background
-// these are the most "readable" colours against a black background
-// No colours like grey, normal blue (cyan instead) or red, since they don't appear very well.
-const ansi256Colors = [
-  '\u001b[36m', // cyan
-  '\u001b[33m', // yellow
-  '\u001b[32m', // green
-  '\u001b[35m', // magenta
-  '\u001b[34m', // blue
-  '\u001b[36;1m', // bright cyan
-  '\u001b[33;1m', // bright yellow
-  '\u001b[32;1m', // bright green
-  '\u001b[35;1m', // bright magenta
-  '\u001b[34;1m', // bright blue
-];
-
 // Create a map that will store the ANSI 256 colour for each container name
 // if we run out of colours, we'll start from the beginning.
 const colourizedContainerName = new Map<string, string>();
 pod.containers.forEach((container, index) => {
-  const colour = ansi256Colors[index % ansi256Colors.length];
+  const colour = ansi256Colours[index % ansi256Colours.length];
   colourizedContainerName.set(container.Names, colourizedANSIContainerName(container.Names, colour));
 });
-
-// Function that takes the container name and ANSI colour and encapsulates the name in the colour,
-// making sure that we reset the colour back to white after the name.
-function colourizedANSIContainerName(name: string, colour: string) {
-  return `${colour}${name}\u001b[0m`;
-}
 
 // Callback for logs which will output the logs to the terminal
 function callback(name: string, data: string) {


### PR DESCRIPTION
feat: add ability to view compose logs

### What does this PR do?

When clicking on the group of containers, you can now view the logs of
the entire group of compose containers.

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

![Screenshot 2023-07-11 at 12 48 47 PM](https://github.com/containers/podman-desktop/assets/6422176/743a4ffc-e291-4697-8ac5-8052cc921946)


### What issues does this PR fix or reference?

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

Closes https://github.com/containers/podman-desktop/issues/3103

### How to test this PR?

1. Deploy a docker-compose example
(https://raw.githubusercontent.com/kubernetes/kompose/main/examples/docker-compose.yaml)
2. Go to the container view in PD
3. Press on the container group
4. View the logs

<!-- Please explain steps to reproduce -->

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
