### PR TITLE
fix: image with Cmd or Entrypoint cannot be started

### DIFF
--- a/packages/renderer/src/lib/image/RunImage.spec.ts
+++ b/packages/renderer/src/lib/image/RunImage.spec.ts
@@ -52,7 +52,7 @@ async function waitRender() {
   return result;
 }
 
-async function createRunImage(entrypoint: string | string[], cmd: string[]) {
+async function createRunImage(entrypoint: string | string[] | undefined, cmd: string[] | undefined) {
   runImageInfo.set({
     age: '',
     base64RepoTag: '',
@@ -245,6 +245,19 @@ describe('RunImage', () => {
     );
   });
 
+  test('Expect that image without cmd is sent to API', async () => {
+    await createRunImage(['entrypoint1', 'entrypoint2'], undefined);
+
+    const button = screen.getByRole('button', { name: 'Start Container' });
+
+    await fireEvent.click(button);
+
+    expect(window.createAndStartContainer).toHaveBeenCalledWith(
+      'engineid',
+      expect.objectContaining({ Entrypoint: ['entrypoint1', 'entrypoint2'] }),
+    );
+  });
+
   test('Expect that single array command is sent to API', async () => {
     await createRunImage([], ['command']);
 
@@ -272,6 +285,19 @@ describe('RunImage', () => {
   });
   test('Expect that two elements array command is sent to API', async () => {
     await createRunImage([], ['command1', 'command2']);
+
+    const button = screen.getByRole('button', { name: 'Start Container' });
+
+    await fireEvent.click(button);
+
+    expect(window.createAndStartContainer).toHaveBeenCalledWith(
+      'engineid',
+      expect.objectContaining({ Cmd: ['command1', 'command2'] }),
+    );
+  });
+
+  test('Expect that image without entrypoint is sent to API', async () => {
+    await createRunImage(undefined, ['command1', 'command2']);
 
     const button = screen.getByRole('button', { name: 'Start Container' });
 

--- a/packages/renderer/src/lib/image/RunImage.spec.ts
+++ b/packages/renderer/src/lib/image/RunImage.spec.ts
@@ -52,7 +52,7 @@ async function waitRender() {
   return result;
 }
 
-async function createRunImage(entrypoint: string | string[] | undefined, cmd: string[] | undefined) {
+async function createRunImage(entrypoint?: string | string[], cmd?: string[]) {
   runImageInfo.set({
     age: '',
     base64RepoTag: '',

--- a/packages/renderer/src/lib/image/RunImage.svelte
+++ b/packages/renderer/src/lib/image/RunImage.svelte
@@ -103,14 +103,16 @@ onMount(async () => {
   imageInspectInfo = await window.getImageInspect(image.engineId, image.id);
   exposedPorts = Array.from(Object.keys(imageInspectInfo?.Config?.ExposedPorts || {}));
 
-  command = array2String(imageInspectInfo.Config.Cmd);
+  command = array2String(imageInspectInfo.Config?.Cmd || []);
 
-  if (imageInspectInfo.Config.Entrypoint) {
+  if (imageInspectInfo.Config?.Entrypoint) {
     if (typeof imageInspectInfo.Config.Entrypoint === 'string') {
       entrypoint = imageInspectInfo.Config.Entrypoint;
     } else {
       entrypoint = array2String(imageInspectInfo.Config.Entrypoint);
     }
+  } else {
+    entrypoint = '';
   }
 
   // auto-assign ports from available free port


### PR DESCRIPTION
Fixes #3201

### What does this PR do?

Allow images without Entrypoint or Cmd in metadata to be started

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

Fixes #3201 

### How to test this PR?

1. Pull image docker.io/ashael/pi
2. Start it