### PR TITLE
chore: use fragments to simplify styling

### DIFF
--- a/packages/renderer/src/lib/container/ContainerDetails.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetails.svelte
@@ -49,7 +49,7 @@ function errorCallback(errorMessage: string): void {
 {#if container}
   <DetailsPage title="{container.name}" subtitle="{container.shortImage}">
     <StatusIcon slot="icon" icon="{ContainerIcon}" status="{container.state}" />
-    <div slot="actions" class="flex justify-end">
+    <svelte:fragment slot="actions">
       <div class="flex items-center w-5">
         {#if container.actionError}
           <ErrorMessage error="{container.actionError}" icon />
@@ -62,11 +62,11 @@ function errorCallback(errorMessage: string): void {
         errorCallback="{error => errorCallback(error)}"
         container="{container}"
         detailed="{true}" />
-    </div>
+    </svelte:fragment>
     <div slot="detail" class="flex py-2 w-full justify-end">
       <ContainerStatistics container="{container}" />
     </div>
-    <div slot="tabs" class="pf-c-tabs__list">
+    <svelte:fragment slot="tabs">
       <DetailsTab title="Summary" url="summary" />
       <DetailsTab title="Logs" url="logs" />
       <DetailsTab title="Inspect" url="inspect" />
@@ -75,8 +75,8 @@ function errorCallback(errorMessage: string): void {
         <DetailsTab title="Kube" url="kube" />
       {/if}
       <DetailsTab title="Terminal" url="terminal" />
-    </div>
-    <span slot="content">
+    </svelte:fragment>
+    <svelte:fragment slot="content">
       <Route path="/summary" breadcrumb="Summary" navigationHint="tab">
         <ContainerDetailsSummary container="{container}" />
       </Route>
@@ -92,6 +92,6 @@ function errorCallback(errorMessage: string): void {
       <Route path="/terminal" breadcrumb="Terminal" navigationHint="tab">
         <ContainerDetailsTerminal container="{container}" />
       </Route>
-    </span>
+    </svelte:fragment>
   </DetailsPage>
 {/if}

--- a/packages/renderer/src/lib/help/HelpPage.svelte
+++ b/packages/renderer/src/lib/help/HelpPage.svelte
@@ -18,9 +18,9 @@ $: contributedLinks = $providerInfos
 </script>
 
 <FormPage title="Help" showBreadcrumb="{false}">
-  <span slot="icon">
+  <svelte:fragment slot="icon">
     <i class="fas fa-question-circle fa-2x" aria-hidden="true"></i>
-  </span>
+  </svelte:fragment>
   <div slot="content" class="flex flex-col min-w-full h-fit">
     <div class="min-w-full flex-1 pt-5 px-5 pb-5 space-y-5">
       <!-- Getting Started -->

--- a/packages/renderer/src/lib/image/BuildImageFromContainerfile.svelte
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfile.svelte
@@ -134,9 +134,9 @@ async function getContainerBuildContextDirectory() {
 </script>
 
 <FormPage title="Build Image from Containerfile">
-  <span slot="icon">
+  <svelte:fragment slot="icon">
     <i class="fas fa-cube fa-2x" aria-hidden="true"></i>
-  </span>
+  </svelte:fragment>
   <div slot="content" class="p-5 min-w-full h-fit">
     {#if providerConnections.length === 0}
       <NoContainerEngineEmptyScreen />

--- a/packages/renderer/src/lib/image/ImageDetails.svelte
+++ b/packages/renderer/src/lib/image/ImageDetails.svelte
@@ -54,20 +54,19 @@ onMount(() => {
 {#if image}
   <DetailsPage title="{image.name}" titleDetail="{image.shortId}" subtitle="{image.tag}">
     <StatusIcon slot="icon" icon="{ImageIcon}" status="{image.inUse ? 'USED' : 'UNUSED'}" />
-    <div slot="actions" class="flex justify-end">
-      <ImageActions
-        image="{image}"
-        onPushImage="{handlePushImageModal}"
-        onRenameImage="{handleRenameImageModal}"
-        detailed="{true}"
-        dropdownMenu="{false}" />
-    </div>
-    <div slot="tabs" class="pf-c-tabs__list">
+    <ImageActions
+      slot="actions"
+      image="{image}"
+      onPushImage="{handlePushImageModal}"
+      onRenameImage="{handleRenameImageModal}"
+      detailed="{true}"
+      dropdownMenu="{false}" />
+    <svelte:fragment slot="tabs">
       <DetailsTab title="Summary" url="summary" />
       <DetailsTab title="History" url="history" />
       <DetailsTab title="Inspect" url="inspect" />
-    </div>
-    <span slot="content">
+    </svelte:fragment>
+    <svelte:fragment slot="content">
       <Route path="/summary" breadcrumb="Summary" navigationHint="tab">
         <ImageDetailsSummary image="{image}" />
       </Route>
@@ -77,7 +76,7 @@ onMount(() => {
       <Route path="/inspect" breadcrumb="Inspect" navigationHint="tab">
         <ImageDetailsInspect image="{image}" />
       </Route>
-    </span>
+    </svelte:fragment>
   </DetailsPage>
 {/if}
 

--- a/packages/renderer/src/lib/image/PullImage.svelte
+++ b/packages/renderer/src/lib/image/PullImage.svelte
@@ -112,18 +112,18 @@ function validateImageName(event): void {
 </script>
 
 <FormPage title="Pull Image From a Registry">
-  <span slot="icon">
+  <svelte:fragment slot="icon">
     <i class="fas fa-arrow-circle-down fa-2x" aria-hidden="true"></i>
-  </span>
+  </svelte:fragment>
 
-  <div slot="actions" class="space-x-2 flex flex-nowrap">
+  <svelte:fragment slot="actions">
     <button on:click="{() => gotoManageRegistries()}" class="pf-c-button pf-m-primary" type="button">
       <span class="pf-c-button__icon pf-m-start">
         <i class="fas fa-cog" aria-hidden="true"></i>
       </span>
       Manage registries
     </button>
-  </div>
+  </svelte:fragment>
 
   <div slot="content" class="p-5 min-w-full h-fit">
     {#if providerConnections.length === 0}

--- a/packages/renderer/src/lib/image/RunImage.svelte
+++ b/packages/renderer/src/lib/image/RunImage.svelte
@@ -411,9 +411,9 @@ function checkContainerName(event: any) {
 <Route path="/*" let:meta>
   {#if dataReady}
     <FormPage title="Create a container from image {imageDisplayName}:{image.tag}">
-      <span slot="icon">
+      <svelte:fragment slot="icon">
         <i class="fas fa-play fa-2x" aria-hidden="true"></i>
-      </span>
+      </svelte:fragment>
       <div slot="content" class="p-5 min-w-full h-fit">
         <div class="bg-charcoal-600 px-6 py-4 space-y-2 lg:px-8 sm:pb-6 xl:pb-8">
           <section class="pf-c-page__main-tabs pf-m-limit-width">

--- a/packages/renderer/src/lib/kube/KubePlayYAML.svelte
+++ b/packages/renderer/src/lib/kube/KubePlayYAML.svelte
@@ -152,9 +152,8 @@ async function getKubernetesfileLocation() {
 
 {#if providerConnections.length > 0}
   <FormPage title="Play Pods or Containers from a Kubernetes YAML File">
-    <span slot="icon">
-      <KubePlayIcon size="30px" />
-    </span>
+    <KubePlayIcon slot="icon" size="30px" />
+
     <div slot="content" class="p-5 min-w-full h-fit">
       <div class="bg-charcoal-800 px-6 py-4 space-y-6 lg:px-8 sm:pb-6 xl:pb-8 rounded-lg">
         <div class="text-xl font-medium">Select file:</div>

--- a/packages/renderer/src/lib/pod/DeployPodToKube.svelte
+++ b/packages/renderer/src/lib/pod/DeployPodToKube.svelte
@@ -344,9 +344,7 @@ function updateKubeResult() {
 </script>
 
 <FormPage title="Deploy generated pod to Kubernetes">
-  <span slot="icon">
-    <i class="fas fa-rocket fa-2x" aria-hidden="true"></i>
-  </span>
+  <i class="fas fa-rocket fa-2x" slot="icon" aria-hidden="true"></i>
 
   <div slot="content" class="p-5 min-w-full h-fit">
     <div class="bg-charcoal-600 p-5">

--- a/packages/renderer/src/lib/pod/PodCreateFromContainers.svelte
+++ b/packages/renderer/src/lib/pod/PodCreateFromContainers.svelte
@@ -184,9 +184,7 @@ function updatePortExposure(port: number, checked: boolean) {
 </script>
 
 <FormPage title="Copy containers to a pod">
-  <span slot="icon">
-    <PodIcon solid="{true}" />
-  </span>
+  <PodIcon slot="icon" solid="{true}" />
 
   <div class="min-w-full h-fit" slot="content">
     <div class="m-5 p-6 bg-charcoal-800 rounded-sm text-gray-700">

--- a/packages/renderer/src/lib/pod/PodDetails.svelte
+++ b/packages/renderer/src/lib/pod/PodDetails.svelte
@@ -62,7 +62,7 @@ function errorCallback(errorMessage: string): void {
 {#if pod}
   <DetailsPage title="{pod.name}" subtitle="{pod.shortId}">
     <StatusIcon slot="icon" icon="{PodIcon}" status="{pod.status}" />
-    <div slot="actions" class="flex justify-end">
+    <svelte:fragment slot="actions">
       <div class="flex items-center w-5">
         {#if pod.actionError}
           <ErrorMessage error="{pod.actionError}" icon />
@@ -75,14 +75,14 @@ function errorCallback(errorMessage: string): void {
         inProgressCallback="{(flag, state) => inProgressCallback(flag, state)}"
         errorCallback="{error => errorCallback(error)}"
         detailed="{true}" />
-    </div>
-    <div slot="tabs" class="pf-c-tabs__list">
+    </svelte:fragment>
+    <svelte:fragment slot="tabs">
       <DetailsTab title="Summary" url="summary" />
       <DetailsTab title="Logs" url="logs" />
       <DetailsTab title="Inspect" url="inspect" />
       <DetailsTab title="Kube" url="kube" />
-    </div>
-    <span slot="content">
+    </svelte:fragment>
+    <svelte:fragment slot="content">
       <Route path="/summary" breadcrumb="Summary" navigationHint="tab">
         <PodDetailsSummary pod="{pod}" />
       </Route>
@@ -95,6 +95,6 @@ function errorCallback(errorMessage: string): void {
       <Route path="/kube" breadcrumb="Kube" navigationHint="tab">
         <PodDetailsKube pod="{pod}" />
       </Route>
-    </span>
+    </svelte:fragment>
   </DetailsPage>
 {/if}

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingPage.svelte
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingPage.svelte
@@ -6,9 +6,7 @@ import TroubleshootingPageStores from './TroubleshootingPageStores.svelte';
 </script>
 
 <FormPage title="Troubleshooting" showBreadcrumb="{false}">
-  <span slot="icon">
-    <i class="fas fa-lightbulb fa-2x" aria-hidden="true"></i>
-  </span>
+  <i slot="icon" class="fas fa-lightbulb fa-2x" aria-hidden="true"></i>
 
   <div slot="content" class="flex flex-col space-y-4 p-4">
     <TroubleshootingPageProviders />

--- a/packages/renderer/src/lib/ui/DetailsPage.svelte
+++ b/packages/renderer/src/lib/ui/DetailsPage.svelte
@@ -33,7 +33,9 @@ export let subtitle: string = undefined;
         </div>
       </div>
       <div class="flex flex-col pr-2 pt-5">
-        <slot name="actions" />
+        <div class="flex justify-end space-x-2">
+          <slot name="actions" />
+        </div>
         <slot name="detail" />
       </div>
       <a href="{$lastPage.path}" title="Close Details" class="mt-2 mr-2 text-gray-900"

--- a/packages/renderer/src/lib/ui/FormPage.svelte
+++ b/packages/renderer/src/lib/ui/FormPage.svelte
@@ -30,8 +30,8 @@ export let showBreadcrumb = true;
         {/if}
         <h1 aria-label="{title}" class="grow text-xl first-letter:uppercase">{title}</h1>
         {#if $$slots.actions}
-          <div class="flex justify-self-end pl-3">
-            <slot name="actions">&nbsp;</slot>
+          <div class="flex flex-nowrap justify-self-end pl-3 space-x-2">
+            <slot name="actions" />
           </div>
         {/if}
       </div>

--- a/packages/renderer/src/lib/ui/FormPageSpec.svelte
+++ b/packages/renderer/src/lib/ui/FormPageSpec.svelte
@@ -3,13 +3,9 @@ import FormPage from './FormPage.svelte';
 </script>
 
 <FormPage title="Test component" showBreadcrumb="{false}">
-  <span slot="icon">
-    <i class="fas fa-lightbulb fa-2x" aria-label="icon"></i>
-  </span>
+  <i slot="icon" class="fas fa-lightbulb fa-2x" aria-label="icon"></i>
 
-  <span slot="actions">
-    <i class="fas fa-lightbulb fa-2x" aria-label="actions"></i>
-  </span>
+  <i slot="actions" class="fas fa-lightbulb fa-2x" aria-label="actions"></i>
 
   <div slot="content" class="flex flex-col">
     <i class="fas fa-lightbulb fa-2x" aria-label="content"></i>

--- a/packages/renderer/src/lib/ui/ListItemButtonIcon.svelte
+++ b/packages/renderer/src/lib/ui/ListItemButtonIcon.svelte
@@ -18,9 +18,9 @@ let positionTopClass = 'top-1';
 if (detailed) positionTopClass = '[0.2rem]';
 
 const buttonDetailedClass =
-  'mx-1 text-gray-400 bg-charcoal-800 hover:text-violet-600 font-medium rounded-lg text-sm inline-flex items-center px-3 py-2 text-center';
+  'text-gray-400 bg-charcoal-800 hover:text-violet-600 font-medium rounded-lg text-sm inline-flex items-center px-3 py-2 text-center';
 const buttonDetailedDisabledClass =
-  'mx-1 text-gray-900 bg-charcoal-800 font-medium rounded-lg text-sm inline-flex items-center px-3 py-2 text-center';
+  'text-gray-900 bg-charcoal-800 font-medium rounded-lg text-sm inline-flex items-center px-3 py-2 text-center';
 const buttonClass =
   'm-0.5 text-gray-400 hover:bg-charcoal-600 hover:text-violet-600 font-medium rounded-full inline-flex items-center px-2 py-2 text-center';
 const buttonDisabledClass =

--- a/packages/renderer/src/lib/volume/VolumeDetails.svelte
+++ b/packages/renderer/src/lib/volume/VolumeDetails.svelte
@@ -36,20 +36,18 @@ onMount(() => {
 {#if volume}
   <DetailsPage title="{volume.shortName}" subtitle="{volume.humanSize}">
     <StatusIcon slot="icon" icon="{VolumeIcon}" status="{volume.inUse ? 'USED' : 'UNUSED'}" />
-    <div slot="actions" class="flex justify-end">
-      <VolumeActions volume="{volume}" detailed="{true}" />
-    </div>
-    <div slot="tabs" class="pf-c-tabs__list">
+    <VolumeActions slot="actions" volume="{volume}" detailed="{true}" />
+    <svelte:fragment slot="tabs">
       <DetailsTab title="Summary" url="summary" />
       <DetailsTab title="Inspect" url="inspect" />
-    </div>
-    <span slot="content">
+    </svelte:fragment>
+    <svelte:fragment slot="content">
       <Route path="/summary" breadcrumb="Summary" navigationHint="tab">
         <VolumeDetailsSummary volume="{volume}" />
       </Route>
       <Route path="/inspect" breadcrumb="Inspect" navigationHint="tab">
         <VolumeDetailsInspect volume="{volume}" />
       </Route>
-    </span>
+    </svelte:fragment>
   </DetailsPage>
 {/if}


### PR DESCRIPTION
### What does this PR do?

When creating the details and form pages something was nagging me about having divs with formatting and spans in each of the child components. Mainly, I had forgotten about Svelte fragments. This change just cleans that up:

- Switch spans to svelte:fragments or put the slot directly on the contained component. This isn't a huge improvement, but it simplifies the code slightly and removes one level of html hierarchy in the rendered page.
- Switch details page tabs from divs to fragments. This removes the need for the PatternFly class in each page.
- Switch actions slots to fragments. This means that the shared component is responsible for laying out buttons instead of each page, so I've taken the opportunity to also remove the mx-1 margin from ListActionButtonIcon and use space-x-2 instead. This fixes some minor layout issues where the margin on both ends of the action bar caused buttons to not line up correctly.

### Screenshot/screencast of this PR

N/A. It does fix a slight action alignment issue on some pages but not worth screen-capping.

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Open each details page and several form pages (e.g. help, run image, pull image) to confirm no regressions.