### PR TITLE
fix: limit tabbing within messagebox & quickpick

### DIFF
--- a/packages/renderer/src/lib/dialogs/MessageBox.svelte
+++ b/packages/renderer/src/lib/dialogs/MessageBox.svelte
@@ -99,6 +99,10 @@ function clickButton(index: number) {
 }
 
 function handleKeydown(e: KeyboardEvent) {
+  if (!display) {
+    return;
+  }
+
   if (e.key === 'Escape') {
     // if there is a cancel button use its id, otherwise undefined
     window.sendShowMessageBoxOnSelect(currentId, cancelId >= 0 ? cancelId : undefined);

--- a/packages/renderer/src/lib/dialogs/MessageBox.svelte
+++ b/packages/renderer/src/lib/dialogs/MessageBox.svelte
@@ -18,6 +18,7 @@ let buttonOrder;
 let display = false;
 
 let inputElement: HTMLInputElement = undefined;
+let messageBox: HTMLDivElement;
 
 const showMessageBoxCallback = async (options?: MessageBoxOptions) => {
   currentId = options.id;
@@ -104,6 +105,21 @@ function handleKeydown(e: KeyboardEvent) {
     cleanup();
     e.preventDefault();
   }
+
+  if (e.key === 'Tab') {
+    // trap focus
+    const nodes = messageBox.querySelectorAll<HTMLElement>('*');
+    const tabbable = Array.from(nodes).filter(n => n.tabIndex >= 0);
+
+    let index = tabbable.indexOf(document.activeElement as HTMLElement);
+    if (index === -1 && e.shiftKey) index = 0;
+
+    index += tabbable.length + (e.shiftKey ? -1 : 1);
+    index %= tabbable.length;
+
+    tabbable[index].focus();
+    e.preventDefault();
+  }
 }
 </script>
 
@@ -112,7 +128,9 @@ function handleKeydown(e: KeyboardEvent) {
 {#if display}
   <!-- Create overlay-->
   <div class="fixed top-0 left-0 right-0 bottom-0 bg-black bg-opacity-60 bg-blend-multiply h-full grid z-50">
-    <div class="flex flex-col place-self-center w-[550px] rounded-xl bg-charcoal-800 shadow-xl shadow-black">
+    <div
+      class="flex flex-col place-self-center w-[550px] rounded-xl bg-charcoal-800 shadow-xl shadow-black"
+      bind:this="{messageBox}">
       <div class="flex items-center justify-between pl-4 pr-3 py-3 space-x-2 text-gray-400">
         {#if type === 'error'}
           <Fa class="h-4 w-4 text-red-500" icon="{faCircleExclamation}" />

--- a/packages/renderer/src/lib/dialogs/QuickPickInput.svelte
+++ b/packages/renderer/src/lib/dialogs/QuickPickInput.svelte
@@ -179,6 +179,10 @@ function clickQuickPickItem(item: any, index: number) {
 }
 
 function handleKeydown(e: KeyboardEvent) {
+  if (!display) {
+    return;
+  }
+
   if (e.key === 'Escape') {
     // In case of validating error, do not proceed
     if (validationError) {
@@ -244,6 +248,21 @@ function handleKeydown(e: KeyboardEvent) {
       e.preventDefault();
       return;
     }
+  }
+
+  if (e.key === 'Tab') {
+    // trap focus
+    const nodes = outerDiv.querySelectorAll<HTMLElement>('*');
+    const tabbable = Array.from(nodes).filter(n => n.tabIndex >= 0);
+
+    let index = tabbable.indexOf(document.activeElement as HTMLElement);
+    if (index === -1 && e.shiftKey) index = 0;
+
+    index += tabbable.length + (e.shiftKey ? -1 : 1);
+    index %= tabbable.length;
+
+    tabbable[index].focus();
+    e.preventDefault();
   }
 }
 


### PR DESCRIPTION
### What does this PR do?

The MessageBox and QuickPick weren't doing anything special with tabbing, so if you tabbed it would cycle through everything in the background as well - e.g. every action on every container if you were on the Containers page.

This uses the same code as Modal to limit tabbing to what's visible within the MessageBox and QuickPick. Both were listening to keyboard events even when closed so added an if to avoid that.

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

Fixes at least part of #2356.

### How to test this PR?

Open a message box (e.g. Prune, Install Kind, or Compose) and a quickpick (e.g. Kubernetes context, compose version) to confirm that tabbing is limited to the controls within the dialog.