### PR TITLE
feat: Close details page if object is deleted

### DIFF
--- a/packages/renderer/src/lib/ContainerList.svelte
+++ b/packages/renderer/src/lib/ContainerList.svelte
@@ -485,7 +485,6 @@ function errorCallback(container: ContainerInfoUI, errorMessage: string): void {
                       containers: [],
                       kind: 'podman',
                     }}"
-                    redirectAfterDelete="{false}"
                     dropdownMenu="{true}" />
                 {/if}
                 {#if containerGroup.type === ContainerGroupInfoTypeUI.COMPOSE}

--- a/packages/renderer/src/lib/container/ContainerActions.svelte
+++ b/packages/renderer/src/lib/container/ContainerActions.svelte
@@ -68,7 +68,6 @@ async function deleteContainer(): Promise<void> {
   inProgressCallback(true, 'DELETING');
   try {
     await window.deleteContainer(container.engineId, container.id);
-    router.goto('/containers/');
   } catch (error) {
     errorCallback(error);
   } finally {

--- a/packages/renderer/src/lib/container/ContainerDetails.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerDetails.spec.ts
@@ -1,0 +1,98 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom';
+import { test, expect, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/svelte';
+
+import ContainerDetails from './ContainerDetails.svelte';
+import { get } from 'svelte/store';
+import { containersInfos } from '/@/stores/containers';
+import type { ContainerInfo } from '../../../../main/src/plugin/api/container-info';
+
+import { router } from 'tinro';
+import { lastPage } from '/@/stores/breadcrumb';
+
+const listContainersMock = vi.fn();
+
+const myContainer: ContainerInfo = {
+  Id: 'myContainer',
+  Labels: undefined,
+  Status: 'running',
+  engineId: 'engine0',
+  engineName: 'podman',
+  engineType: 'podman',
+  StartedAt: undefined,
+  Names: ['name0'],
+  Image: '',
+  ImageID: undefined,
+  Command: undefined,
+  Created: 0,
+  Ports: undefined,
+  State: undefined,
+  HostConfig: undefined,
+  NetworkSettings: undefined,
+  Mounts: undefined,
+};
+
+const deleteContainerMock = vi.fn();
+
+beforeAll(() => {
+  (window as any).listContainers = listContainersMock;
+  (window as any).deleteContainer = deleteContainerMock;
+});
+
+test('Expect redirect to previous page if container is deleted', async () => {
+  const routerGotoSpy = vi.spyOn(router, 'goto');
+  listContainersMock.mockResolvedValue([myContainer]);
+  window.dispatchEvent(new CustomEvent('extensions-already-started'));
+  while (get(containersInfos).length !== 1) {
+    await new Promise(resolve => setTimeout(resolve, 500));
+  }
+
+  // remove myContainer from the store when we call 'deleteContainer'
+  // it will then refresh the store and update ContainerDetails page
+  deleteContainerMock.mockImplementation(() => {
+    containersInfos.update(containers => containers.filter(container => container.Id !== myContainer.Id));
+  });
+
+  // defines a fake lastPage so we can check where we will be redirected
+  lastPage.set({ name: 'Fake Previous', path: '/last' });
+
+  // render the component
+  render(ContainerDetails, { containerID: 'myContainer' });
+
+  // grab current route
+  const currentRoute = window.location;
+  expect(currentRoute.href).toBe('http://localhost:3000/');
+
+  // click on delete container button
+  const deleteButton = screen.getByRole('button', { name: 'Delete Container' });
+  await fireEvent.click(deleteButton);
+
+  // check that delete method has been called
+  expect(deleteContainerMock).toHaveBeenCalled();
+
+  // expect that we have called the router when page has been removed
+  // to jump to the previous page
+  expect(routerGotoSpy).toBeCalledWith('/last');
+
+  // grab updated route
+  const afterRoute = window.location;
+  expect(afterRoute.href).toBe('http://localhost:3000/last');
+});

--- a/packages/renderer/src/lib/container/ContainerDetails.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetails.svelte
@@ -22,14 +22,22 @@ import ErrorMessage from '../ui/ErrorMessage.svelte';
 export let containerID: string;
 
 let container: ContainerInfoUI;
+let detailsPage: DetailsPage;
+
 onMount(() => {
   const containerUtils = new ContainerUtils();
   // loading container info
-  containersInfos.subscribe(containers => {
+  return containersInfos.subscribe(containers => {
     const matchingContainer = containers.find(c => c.Id === containerID);
+    let newContainer: ContainerInfoUI;
     if (matchingContainer) {
-      container = containerUtils.getContainerInfoUI(matchingContainer);
+      newContainer = containerUtils.getContainerInfoUI(matchingContainer);
     }
+    if (container && !newContainer && detailsPage) {
+      // the container has been deleted
+      detailsPage.close();
+    }
+    container = newContainer;
   });
 });
 
@@ -47,7 +55,7 @@ function errorCallback(errorMessage: string): void {
 </script>
 
 {#if container}
-  <DetailsPage title="{container.name}" subtitle="{container.shortImage}">
+  <DetailsPage title="{container.name}" subtitle="{container.shortImage}" bind:this="{detailsPage}">
     <StatusIcon slot="icon" icon="{ContainerIcon}" status="{container.state}" />
     <svelte:fragment slot="actions">
       <div class="flex items-center w-5">

--- a/packages/renderer/src/lib/container/ContainerDetails.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetails.svelte
@@ -29,15 +29,12 @@ onMount(() => {
   // loading container info
   return containersInfos.subscribe(containers => {
     const matchingContainer = containers.find(c => c.Id === containerID);
-    let newContainer: ContainerInfoUI;
     if (matchingContainer) {
-      newContainer = containerUtils.getContainerInfoUI(matchingContainer);
-    }
-    if (container && !newContainer && detailsPage) {
+      container = containerUtils.getContainerInfoUI(matchingContainer);
+    } else if (detailsPage) {
       // the container has been deleted
       detailsPage.close();
     }
-    container = newContainer;
   });
 });
 

--- a/packages/renderer/src/lib/image/ImageActions.svelte
+++ b/packages/renderer/src/lib/image/ImageActions.svelte
@@ -36,7 +36,6 @@ $: window.hasAuthconfigForImage(image.name).then(result => (isAuthenticatedForTh
 async function deleteImage(): Promise<void> {
   try {
     await window.deleteImage(image.engineId, image.id);
-    router.goto('/images/');
   } catch (error) {
     errorTitle = 'Error while deleting image';
     errorMessage = error;

--- a/packages/renderer/src/lib/image/ImageDetails.spec.ts
+++ b/packages/renderer/src/lib/image/ImageDetails.spec.ts
@@ -1,0 +1,97 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom';
+import { test, expect, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/svelte';
+
+import ImageDetails from './ImageDetails.svelte';
+import { get } from 'svelte/store';
+import { imagesInfos } from '/@/stores/images';
+import type { ImageInfo } from '../../../../main/src/plugin/api/image-info';
+
+import { router } from 'tinro';
+import { lastPage } from '/@/stores/breadcrumb';
+
+const listImagesMock = vi.fn();
+
+const myImage: ImageInfo = {
+  Id: 'myImage',
+  Labels: undefined,
+  engineId: 'engine0',
+  engineName: 'podman',
+  ParentId: undefined,
+  RepoTags: ['myImageTag'],
+  Created: 0,
+  Size: 0,
+  VirtualSize: 0,
+  SharedSize: 0,
+  Containers: 0,
+};
+
+const deleteImageMock = vi.fn();
+const hasAuthMock = vi.fn();
+
+beforeAll(() => {
+  (window as any).listImages = listImagesMock;
+  (window as any).deleteImage = deleteImageMock;
+  (window as any).hasAuthconfigForImage = hasAuthMock;
+});
+
+test('Expect redirect to previous page if image is deleted', async () => {
+  const routerGotoSpy = vi.spyOn(router, 'goto');
+  listImagesMock.mockResolvedValue([myImage]);
+  window.dispatchEvent(new CustomEvent('extensions-already-started'));
+  while (get(imagesInfos).length !== 1) {
+    await new Promise(resolve => setTimeout(resolve, 500));
+  }
+
+  // remove myImage from the store when we call 'deleteImage'
+  // it will then refresh the store and update ImageDetails page
+  deleteImageMock.mockImplementation(() => {
+    imagesInfos.update(images => images.filter(image => image.Id !== myImage.Id));
+  });
+  hasAuthMock.mockImplementation(() => {
+    return new Promise(() => false);
+  });
+
+  // defines a fake lastPage so we can check where we will be redirected
+  lastPage.set({ name: 'Fake Previous', path: '/last' });
+
+  // render the component
+  render(ImageDetails, { imageID: 'myImage', engineId: 'engine0', base64RepoTag: 'bXlJbWFnZVRhZw==' });
+
+  // grab current route
+  const currentRoute = window.location;
+  expect(currentRoute.href).toBe('http://localhost:3000/');
+
+  // click on delete image button
+  const deleteButton = screen.getByRole('button', { name: 'Delete Image' });
+  await fireEvent.click(deleteButton);
+
+  // check that delete method has been called
+  expect(deleteImageMock).toHaveBeenCalled();
+
+  // expect that we have called the router when page has been removed
+  // to jump to the previous page
+  expect(routerGotoSpy).toBeCalledWith('/last');
+
+  // grab updated route
+  const afterRoute = window.location;
+  expect(afterRoute.href).toBe('http://localhost:3000/last');
+});

--- a/packages/renderer/src/lib/image/ImageDetails.svelte
+++ b/packages/renderer/src/lib/image/ImageDetails.svelte
@@ -35,24 +35,32 @@ function closeModals() {
 }
 
 let image: ImageInfoUI;
+let detailsPage: DetailsPage;
+
 onMount(() => {
   const imageUtils = new ImageUtils();
-  // loading container info
-  imagesInfos.subscribe(images => {
+  // loading image info
+  return imagesInfos.subscribe(images => {
     const matchingImage = images.find(c => c.Id === imageID && c.engineId === engineId);
+    let newImage: ImageInfoUI;
     if (matchingImage) {
       try {
-        image = imageUtils.getImageInfoUI(matchingImage, base64RepoTag);
+        newImage = imageUtils.getImageInfoUI(matchingImage, base64RepoTag);
       } catch (err) {
         console.error(err);
       }
     }
+    if (image && !newImage && detailsPage) {
+      // the image has been deleted
+      detailsPage.close();
+    }
+    image = newImage;
   });
 });
 </script>
 
 {#if image}
-  <DetailsPage title="{image.name}" titleDetail="{image.shortId}" subtitle="{image.tag}">
+  <DetailsPage title="{image.name}" titleDetail="{image.shortId}" subtitle="{image.tag}" bind:this="{detailsPage}">
     <StatusIcon slot="icon" icon="{ImageIcon}" status="{image.inUse ? 'USED' : 'UNUSED'}" />
     <ImageActions
       slot="actions"

--- a/packages/renderer/src/lib/image/ImageDetails.svelte
+++ b/packages/renderer/src/lib/image/ImageDetails.svelte
@@ -42,19 +42,16 @@ onMount(() => {
   // loading image info
   return imagesInfos.subscribe(images => {
     const matchingImage = images.find(c => c.Id === imageID && c.engineId === engineId);
-    let newImage: ImageInfoUI;
     if (matchingImage) {
       try {
-        newImage = imageUtils.getImageInfoUI(matchingImage, base64RepoTag);
+        image = imageUtils.getImageInfoUI(matchingImage, base64RepoTag);
       } catch (err) {
         console.error(err);
       }
-    }
-    if (image && !newImage && detailsPage) {
+    } else if (detailsPage) {
       // the image has been deleted
       detailsPage.close();
     }
-    image = newImage;
   });
 });
 </script>

--- a/packages/renderer/src/lib/pod/PodActions.spec.ts
+++ b/packages/renderer/src/lib/pod/PodActions.spec.ts
@@ -56,7 +56,7 @@ test('Expect to redirect to /pods page after deletion', async () => {
 });
 
 test('Expect no redirect to /pods page after deletion if configured', async () => {
-  render(PodActions, { pod, errorCallback, redirectAfterDelete: false });
+  render(PodActions, { pod, errorCallback });
 
   // click on delete button
   const deleteButton = screen.getByRole('button', { name: 'Delete Pod' });

--- a/packages/renderer/src/lib/pod/PodActions.spec.ts
+++ b/packages/renderer/src/lib/pod/PodActions.spec.ts
@@ -21,7 +21,6 @@ import { test, expect, vi } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/svelte';
 import PodActions from './PodActions.svelte';
 import type { PodInfoUI } from './PodInfoUI';
-import { router } from 'tinro';
 
 const pod: PodInfoUI = {
   id: 'pod',
@@ -29,20 +28,13 @@ const pod: PodInfoUI = {
 
 const errorCallback = vi.fn();
 
-// mock router import { router } from 'tinro';
-vi.mock('tinro', () => ({
-  router: {
-    goto: vi.fn(),
-  },
-}));
-
 beforeEach(() => {
   (window as any).kubernetesDeletePod = vi.fn();
   vi.resetAllMocks();
   vi.clearAllMocks();
 });
 
-test('Expect to redirect to /pods page after deletion', async () => {
+test('Expect no error deleting pod', async () => {
   render(PodActions, { pod, errorCallback });
 
   // click on delete button
@@ -50,20 +42,4 @@ test('Expect to redirect to /pods page after deletion', async () => {
   await fireEvent.click(deleteButton);
 
   expect(errorCallback).not.toHaveBeenCalled();
-
-  // check that router has been called
-  expect(router.goto).toHaveBeenCalledWith('/pods/');
-});
-
-test('Expect no redirect to /pods page after deletion if configured', async () => {
-  render(PodActions, { pod, errorCallback });
-
-  // click on delete button
-  const deleteButton = screen.getByRole('button', { name: 'Delete Pod' });
-  await fireEvent.click(deleteButton);
-
-  expect(errorCallback).not.toHaveBeenCalled();
-
-  // check that router has not been called
-  expect(router.goto).not.toHaveBeenCalledWith('/pods');
 });

--- a/packages/renderer/src/lib/pod/PodActions.svelte
+++ b/packages/renderer/src/lib/pod/PodActions.svelte
@@ -9,7 +9,6 @@ import FlatMenu from '../ui/FlatMenu.svelte';
 export let pod: PodInfoUI;
 export let dropdownMenu = false;
 export let detailed = false;
-export let redirectAfterDelete = true;
 
 export let inProgressCallback: (inProgress: boolean, state?: string) => void = () => {};
 export let errorCallback: (erroMessage: string) => void = () => {};
@@ -54,9 +53,6 @@ async function deletePod(podInfoUI: PodInfoUI): Promise<void> {
       await window.removePod(podInfoUI.engineId, podInfoUI.id);
     } else {
       await window.kubernetesDeletePod(podInfoUI.name);
-    }
-    if (redirectAfterDelete) {
-      router.goto('/pods/');
     }
   } catch (error) {
     errorCallback(error);

--- a/packages/renderer/src/lib/pod/PodDetails.spec.ts
+++ b/packages/renderer/src/lib/pod/PodDetails.spec.ts
@@ -1,0 +1,97 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom';
+import { test, expect, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/svelte';
+
+import PodDetails from './PodDetails.svelte';
+import { get } from 'svelte/store';
+import { podsInfos } from '/@/stores/pods';
+import type { PodInfo } from '../../../../main/src/plugin/api/pod-info';
+
+import { router } from 'tinro';
+import { lastPage } from '/@/stores/breadcrumb';
+
+const listPodsMock = vi.fn();
+const kubernetesListPodsMock = vi.fn();
+
+const myPod: PodInfo = {
+  Cgroup: '',
+  Containers: [],
+  Created: '',
+  Id: 'beab25123a40',
+  InfraId: 'pod1',
+  Labels: {},
+  Name: 'myPod',
+  Namespace: '',
+  Networks: [],
+  Status: 'running',
+  engineId: 'engine0',
+  engineName: 'podman',
+  kind: 'podman',
+};
+
+const removePodMock = vi.fn();
+
+beforeAll(() => {
+  (window as any).listPods = listPodsMock;
+  (window as any).kubernetesListPods = kubernetesListPodsMock;
+  (window as any).removePod = removePodMock;
+});
+
+test('Expect redirect to previous page if pod is deleted', async () => {
+  const routerGotoSpy = vi.spyOn(router, 'goto');
+  listPodsMock.mockResolvedValue([myPod]);
+  kubernetesListPodsMock.mockResolvedValue([]);
+  window.dispatchEvent(new CustomEvent('extensions-already-started'));
+  while (get(podsInfos).length !== 1) {
+    await new Promise(resolve => setTimeout(resolve, 500));
+  }
+
+  // remove myPod from the store when we call 'removePod'
+  // it will then refresh the store and update PodsDetails page
+  removePodMock.mockImplementation(() => {
+    podsInfos.update(pods => pods.filter(pod => pod.Id !== myPod.Id));
+  });
+
+  // defines a fake lastPage so we can check where we will be redirected
+  lastPage.set({ name: 'Fake Previous', path: '/last' });
+
+  // render the component
+  render(PodDetails, { podName: 'myPod', engineId: 'engine0', kind: 'podman' });
+
+  // grab current route
+  const currentRoute = window.location;
+  expect(currentRoute.href).toBe('http://localhost:3000/');
+
+  // click on delete pod button
+  const deleteButton = screen.getByRole('button', { name: 'Delete Pod' });
+  await fireEvent.click(deleteButton);
+
+  // check that remove method has been called
+  expect(removePodMock).toHaveBeenCalled();
+
+  // expect that we have called the router when page has been removed
+  // to jump to the previous page
+  expect(routerGotoSpy).toBeCalledWith('/last');
+
+  // grab updated route
+  const afterRoute = window.location;
+  expect(afterRoute.href).toBe('http://localhost:3000/last');
+});

--- a/packages/renderer/src/lib/pod/PodDetails.svelte
+++ b/packages/renderer/src/lib/pod/PodDetails.svelte
@@ -29,19 +29,16 @@ onMount(() => {
     const matchingPod = pods.find(
       podInPods => podInPods.Name === podName && podInPods.engineId === engineId && kind === podInPods.kind,
     );
-    let newPod: PodInfoUI;
     if (matchingPod) {
       try {
-        newPod = podUtils.getPodInfoUI(matchingPod);
+        pod = podUtils.getPodInfoUI(matchingPod);
       } catch (err) {
         console.error(err);
       }
-    }
-    if (pod && !newPod && detailsPage) {
+    } else if (detailsPage) {
       // the pod has been deleted
       detailsPage.close();
     }
-    pod = newPod;
   });
 });
 

--- a/packages/renderer/src/lib/pod/PodsList.svelte
+++ b/packages/renderer/src/lib/pod/PodsList.svelte
@@ -298,7 +298,6 @@ function errorCallback(pod: PodInfoUI, errorMessage: string): void {
                 </div>
                 <div class="text-right w-full">
                   <PodActions
-                    redirectAfterDelete="{false}"
                     pod="{pod}"
                     errorCallback="{error => errorCallback(pod, error)}"
                     inProgressCallback="{(flag, state) => inProgressCallback(pod, flag, state)}"

--- a/packages/renderer/src/lib/ui/DetailsPage.svelte
+++ b/packages/renderer/src/lib/ui/DetailsPage.svelte
@@ -1,9 +1,14 @@
 <script lang="ts">
 import { lastPage, currentPage } from '../../stores/breadcrumb';
+import { router } from 'tinro';
 
 export let title: string;
 export let titleDetail: string = undefined;
 export let subtitle: string = undefined;
+
+export function close(): void {
+  router.goto($lastPage.path);
+}
 </script>
 
 <div class="w-full h-full">

--- a/packages/renderer/src/lib/volume/VolumeActions.svelte
+++ b/packages/renderer/src/lib/volume/VolumeActions.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 import { faTrash } from '@fortawesome/free-solid-svg-icons';
 import type { VolumeInfoUI } from './VolumeInfoUI';
-import { router } from 'tinro';
 import ListItemButtonIcon from '../ui/ListItemButtonIcon.svelte';
 
 export let volume: VolumeInfoUI;
@@ -9,7 +8,6 @@ export let detailed = false;
 
 async function removeVolume(): Promise<void> {
   await window.removeVolume(volume.engineId, volume.name);
-  router.goto('/volumes/');
 }
 </script>
 

--- a/packages/renderer/src/lib/volume/VolumeDetails.spec.ts
+++ b/packages/renderer/src/lib/volume/VolumeDetails.spec.ts
@@ -1,0 +1,98 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom';
+import { test, expect, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/svelte';
+
+import VolumeDetails from './VolumeDetails.svelte';
+import { get } from 'svelte/store';
+import { volumeListInfos } from '/@/stores/volumes';
+import type { VolumeListInfo } from '../../../../main/src/plugin/api/volume-info';
+
+import { router } from 'tinro';
+import { lastPage } from '/@/stores/breadcrumb';
+
+const listVolumesMock = vi.fn();
+
+const myVolume: VolumeListInfo = {
+  engineId: 'engine0',
+  engineName: 'podman',
+  Volumes: [
+    {
+      Name: 'myVolume',
+      engineId: 'engine0',
+      engineName: 'podman',
+      CreatedAt: undefined,
+      containersUsage: undefined,
+      Driver: undefined,
+      Mountpoint: undefined,
+      Labels: undefined,
+      Scope: 'local',
+      Options: undefined,
+    },
+  ],
+  Warnings: undefined,
+};
+
+const removeVolumeMock = vi.fn();
+
+beforeAll(() => {
+  (window as any).listVolumes = listVolumesMock;
+  (window as any).removeVolume = removeVolumeMock;
+});
+
+test('Expect redirect to previous page if volume is deleted', async () => {
+  const routerGotoSpy = vi.spyOn(router, 'goto');
+  listVolumesMock.mockResolvedValue([myVolume]);
+  window.dispatchEvent(new CustomEvent('extensions-already-started'));
+  while (get(volumeListInfos).length !== 1) {
+    await new Promise(resolve => setTimeout(resolve, 500));
+  }
+
+  // remove myVolume from the store when we call 'removeVolume'
+  // it will then refresh the store and update VolumeDetails page
+  removeVolumeMock.mockImplementation(() => {
+    volumeListInfos.update(volumes => volumes.filter(volume => volume.engineId !== myVolume.engineId));
+  });
+
+  // defines a fake lastPage so we can check where we will be redirected
+  lastPage.set({ name: 'Fake Previous', path: '/last' });
+
+  // render the component
+  render(VolumeDetails, { volumeName: 'myVolume', engineId: 'engine0' });
+
+  // grab current route
+  const currentRoute = window.location;
+  expect(currentRoute.href).toBe('http://localhost:3000/');
+
+  // click on delete volume button
+  const deleteButton = screen.getByRole('button', { name: 'Delete Volume' });
+  await fireEvent.click(deleteButton);
+
+  // check that remove method has been called
+  expect(removeVolumeMock).toHaveBeenCalled();
+
+  // expect that we have called the router when page has been removed
+  // to jump to the previous page
+  expect(routerGotoSpy).toBeCalledWith('/last');
+
+  // grab updated route
+  const afterRoute = window.location;
+  expect(afterRoute.href).toBe('http://localhost:3000/last');
+});

--- a/packages/renderer/src/lib/volume/VolumeDetails.svelte
+++ b/packages/renderer/src/lib/volume/VolumeDetails.svelte
@@ -16,25 +16,33 @@ export let volumeName: string;
 export let engineId: string;
 
 let volume: VolumeInfoUI;
+let detailsPage: DetailsPage;
+
 onMount(() => {
   const volumeUtils = new VolumeUtils();
   // loading volume info
-  volumeListInfos.subscribe(volumes => {
+  return volumeListInfos.subscribe(volumes => {
     const allVolumes = volumes.map(volumeListInfo => volumeListInfo.Volumes).flat();
     const matchingVolume = allVolumes.find(volume => volume.Name === volumeName && volume.engineId === engineId);
+    let newVolume: VolumeInfoUI;
     if (matchingVolume) {
       try {
-        volume = volumeUtils.toVolumeInfoUI(matchingVolume);
+        newVolume = volumeUtils.toVolumeInfoUI(matchingVolume);
       } catch (err) {
         console.error(err);
       }
     }
+    if (volume && !newVolume && detailsPage) {
+      // the volume has been deleted
+      detailsPage.close();
+    }
+    volume = newVolume;
   });
 });
 </script>
 
 {#if volume}
-  <DetailsPage title="{volume.shortName}" subtitle="{volume.humanSize}">
+  <DetailsPage title="{volume.shortName}" subtitle="{volume.humanSize}" bind:this="{detailsPage}">
     <StatusIcon slot="icon" icon="{VolumeIcon}" status="{volume.inUse ? 'USED' : 'UNUSED'}" />
     <VolumeActions slot="actions" volume="{volume}" detailed="{true}" />
     <svelte:fragment slot="tabs">

--- a/packages/renderer/src/lib/volume/VolumeDetails.svelte
+++ b/packages/renderer/src/lib/volume/VolumeDetails.svelte
@@ -24,19 +24,16 @@ onMount(() => {
   return volumeListInfos.subscribe(volumes => {
     const allVolumes = volumes.map(volumeListInfo => volumeListInfo.Volumes).flat();
     const matchingVolume = allVolumes.find(volume => volume.Name === volumeName && volume.engineId === engineId);
-    let newVolume: VolumeInfoUI;
     if (matchingVolume) {
       try {
-        newVolume = volumeUtils.toVolumeInfoUI(matchingVolume);
+        volume = volumeUtils.toVolumeInfoUI(matchingVolume);
       } catch (err) {
         console.error(err);
       }
-    }
-    if (volume && !newVolume && detailsPage) {
+    } else if (detailsPage) {
       // the volume has been deleted
       detailsPage.close();
     }
-    volume = newVolume;
   });
 });
 </script>


### PR DESCRIPTION
### What does this PR do?

Automatically closes a details page when the object you're looking at gets deleted.

Added a close() function on DetailsPage so that child pages do not need to import lastPage and router. This means they do need to bind DetailsPage, but that seemed like simpler logic/less dependencies to me.

Each page just checks if they had the object before and can no longer find it. If it is gone, close the page.

This change was meant to handle external deletion, but once it is in there is no longer a need for any of the delete actions to call router.goto() when the user triggers deletion, so these can be removed. If the user triggers the action from a page like Images the goto wasn't doing anything, and if they are in Image Details this new mechanism will do the same thing and revert to the previous page.

The pods page was unsubscribing the listener, but I've switched it to return the unsubscribe so the destroy is handled by Svelte - no need for onDestroy() or imports. The other three pages weren't unsubscribing the listener, so I've fixed that by adding a return statement.

The redirectAfterDelete from PR #2963 can also be cleaned up. Plus, we get a minor bug fix b/c if you went from Containers > Pod Details and delete the pod it will now correctly go back to Containers instead of Pods.

The PodActions test will fail because it is checking for the explicit redirect when a pod (that's not registered) gets deleted. Putting this up to start review of the rest and decide if we just delete the test or these is something else I can do.

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

Fixes #3217.

### How to test this PR?

Create and delete lots of things! Take various paths in the UI, try deleting from the lists or details page, and try deleting from the command line as well.