### PR TITLE
fix: updating videos to be adaptive for mobile

### DIFF
--- a/website/blog/2023-01-18-release-0.11.md
+++ b/website/blog/2023-01-18-release-0.11.md
@@ -39,13 +39,13 @@ Please note, that those binaries are available only on releases and not the pre-
 
 There is also an optional way to provide a custom Podman machine image in the create machine form. By providing the path to the image you want, Podman Desktop will create a machine with that image. Leaving the field empty will use the default image (the one included in the binary).
 
-<ReactPlayer playing controls url='https://user-images.githubusercontent.com/436777/210508524-45005536-ac74-4074-92c1-2b3ca51d0073.mp4' />
+<ReactPlayer playing controls url='https://user-images.githubusercontent.com/436777/210508524-45005536-ac74-4074-92c1-2b3ca51d0073.mp4' width='100%' height='100%' />
 
 ### Feedback within Podman Desktop [#1078](https://github.com/containers/podman-desktop/pull/1078)
 
 Submitting feedback on Podman Desktop is getting easier as it is possible directly within the tool. This will help to get more information about the issues you are facing and will help us to improve the tool.
 
-<ReactPlayer playing controls url='https://user-images.githubusercontent.com/436777/208938878-948a2764-d73b-4584-a80d-497c052482c1.mp4' />
+<ReactPlayer playing controls url='https://user-images.githubusercontent.com/436777/208938878-948a2764-d73b-4584-a80d-497c052482c1.mp4' width='100%' height='100%' />
 
 Please feel free to submit any feedback you have, we are looking forward to hearing from you!
 
@@ -70,7 +70,7 @@ This is the warning for Mac users:
 
 In some context, users need the ability to disable and re-enable the proxy configuration very quickly, without having to entirely reconfigure it. This is now possible from the Podman Desktop settings page, where a toggle to enable/disable the proxy configuration has been added.
 
-<ReactPlayer playing controls url='https://user-images.githubusercontent.com/436777/205955418-670bc37c-a74f-40ef-bc60-8d9d013aa0dc.mp4' />
+<ReactPlayer playing controls url='https://user-images.githubusercontent.com/436777/205955418-670bc37c-a74f-40ef-bc60-8d9d013aa0dc.mp4' width='100%' height='100%' />
 
 Note: extensions can read this information and then update the proxy configuration.
 
@@ -98,7 +98,7 @@ The experience of configuring a registry is getting simplified for the most popu
 - IBM Container Registry
 - Google Container Registry
 
-<ReactPlayer playing controls url='https://user-images.githubusercontent.com/6422176/214332937-eb1d9050-0d32-4bc4-8393-49b4583b1390.mov' />
+<ReactPlayer playing controls url='https://user-images.githubusercontent.com/6422176/214332937-eb1d9050-0d32-4bc4-8393-49b4583b1390.mov' width='100%' height='100%' />
 
 ### UI/UX Improvements
 
@@ -112,29 +112,29 @@ The pods details view provides the ability to view the logs of each containers t
 
 When starting/stopping or deleting a container, a spinner is now displayed. In case of error, a message indicating that the action failed will also be better indicated.
 
-<ReactPlayer playing controls url='https://user-images.githubusercontent.com/436777/211531610-2347d302-4918-46ae-a5a2-c80fac0314f5.mp4' />
+<ReactPlayer playing controls url='https://user-images.githubusercontent.com/436777/211531610-2347d302-4918-46ae-a5a2-c80fac0314f5.mp4' width='100%' height='100%' />
 
 For containers that exit immediately or short-lived containers, the feedback is also improved and include report of error now provide a better feedback to the user [#1161](https://github.com/containers/podman-desktop/pull/1161).
 
-<ReactPlayer playing controls url='https://user-images.githubusercontent.com/436777/211831905-ebf596d5-efc8-4f55-8cb8-3f31655388b9.mp4' />
+<ReactPlayer playing controls url='https://user-images.githubusercontent.com/436777/211831905-ebf596d5-efc8-4f55-8cb8-3f31655388b9.mp4' width='100%' height='100%' />
 
 #### Allows to change the default font size for the editor [#1160](https://github.com/containers/podman-desktop/pull/1160)
 
 An editor is used in several screens of Podman Desktop, from the inspect screen to container's outputs and Kubernetes YAML. The default font size is 10 pixels. It's now possible to adjust the font size to the one the one you prefer. This setting is persisted and will be used for all the editors of Podman Desktop and available from the preferences page (Settings -> Preferences).
 
-<ReactPlayer playing controls url='https://user-images.githubusercontent.com/436777/211778161-130ff733-b2ca-4306-bea3-d031196c3b29.mp4' />
+<ReactPlayer playing controls url='https://user-images.githubusercontent.com/436777/211778161-130ff733-b2ca-4306-bea3-d031196c3b29.mp4' width='100%' height='100%' />
 
 #### Keep expanded state of pods when refreshing containers [#1042](https://github.com/containers/podman-desktop/pull/1042)
 
 When switching from different screens of the application or simply refreshing the list of containers, the expanded state of each item in the list is now persisted and will be properly restored.
 
-<ReactPlayer playing controls url='https://user-images.githubusercontent.com/436777/207864147-b68ea9bd-0ca9-42dc-882e-b8a705233749.mp4' />
+<ReactPlayer playing controls url='https://user-images.githubusercontent.com/436777/207864147-b68ea9bd-0ca9-42dc-882e-b8a705233749.mp4' width='100%' height='100%' />
 
 #### Click on the Pod name redirects to the Pod details page [#1159](https://github.com/containers/podman-desktop/pull/1159)
 
 The list of containers also displays pods, now clicking on the pod name directly redirects to the Pod details page.
 
-<ReactPlayer playing controls url='https://user-images.githubusercontent.com/436777/211770946-2255f39f-7e2e-48ad-9ead-bcbfe6a115a7.mp4' />
+<ReactPlayer playing controls url='https://user-images.githubusercontent.com/436777/211770946-2255f39f-7e2e-48ad-9ead-bcbfe6a115a7.mp4' width='100%' height='100%' />
 
 #### Improved styles of buttons for actions [#984](https://github.com/containers/podman-desktop/pull/984)
 

--- a/website/blog/2023-03-29-release-0.13.md
+++ b/website/blog/2023-03-29-release-0.13.md
@@ -74,7 +74,7 @@ The other settings pages have been updated for consistency with this new design.
 
 A new alert button will appear in the status bar when future updates are available.
 
-<ReactPlayer playing controls url='https://user-images.githubusercontent.com/436777/227596136-c6123d5c-d9ae-4fb3-a569-0cfaaeebf09c.mp4' />
+<ReactPlayer playing controls url='https://user-images.githubusercontent.com/436777/227596136-c6123d5c-d9ae-4fb3-a569-0cfaaeebf09c.mp4' width='100%' height='100%' />
 
 #### Prune buttons [#1481](https://github.com/containers/podman-desktop/pull/1481), [#1482](https://github.com/containers/podman-desktop/pull/1482), [#1484](https://github.com/containers/podman-desktop/pull/1484)
 

--- a/website/blog/2023-04-14-release-0.14.md
+++ b/website/blog/2023-04-14-release-0.14.md
@@ -72,7 +72,7 @@ Within Podman Desktop we have started with two ways to interact with the cluster
 The first is the ability to play local YAML files on your Kind (or any other Kubernetes!) cluster [1261](https://github.com/containers/podman-desktop/issues/1261). This allows you to take existing Kubernetes YAML definitons -
 your deployments, services, or other objects - and deploy it to the cluster.
 
-<ReactPlayer playing controls url="https://user-images.githubusercontent.com/436777/231812563-ece0a56a-b347-48f8-a3a7-400eb9449037.mp4" />
+<ReactPlayer playing controls url="https://user-images.githubusercontent.com/436777/231812563-ece0a56a-b347-48f8-a3a7-400eb9449037.mp4" width='100%' height='100%' />
 
 As you deploy pods, they will automatically appear in the list of **Pods** [1263](https://github.com/containers/podman-desktop/issues/1263), allowing you to start, stop, and interact them just like pods running on Podman.
 

--- a/website/blog/2023-05-02-release-0.15.md
+++ b/website/blog/2023-05-02-release-0.15.md
@@ -46,7 +46,7 @@ but you still couldn't access your containers without the corresponding ingress.
 This release adds a simple checkbox you can use when deploying to Kind to create an ingress and
 make your service accessible [#1322](https://github.com/containers/podman-desktop/issues/1322).
 
-<ReactPlayer playing controls url="https://user-images.githubusercontent.com/6422176/232894496-cbaea036-a14c-46c6-bfa3-bacca629a161.mov"/>
+<ReactPlayer playing controls url="https://user-images.githubusercontent.com/6422176/232894496-cbaea036-a14c-46c6-bfa3-bacca629a161.mov" width='100%' height='100%' />
 
 ### Podliness: Ability to Choose External Ports when Podifying Containers
 

--- a/website/blog/2023-06-08-release-1.1.md
+++ b/website/blog/2023-06-08-release-1.1.md
@@ -44,7 +44,7 @@ Podman Desktop [#2655](https://github.com/containers/podman-desktop/pull/2655).
 We've also added options in **<icon icon="fa-solid fa-cog" size="lg" />Settings > Preferences** to
 automatically check for and install extension updates.
 
-<ReactPlayer playing controls url="https://user-images.githubusercontent.com/436777/241246481-305d215f-2a5c-46e8-9cc3-ecd90a6bd2bc.mp4" />
+<ReactPlayer playing controls url="https://user-images.githubusercontent.com/436777/241246481-305d215f-2a5c-46e8-9cc3-ecd90a6bd2bc.mp4" width='100%' height='100%' />
 
 ![Update extensions](img/podman-desktop-release-1.1/update-extensions.png)
 
@@ -62,7 +62,7 @@ engine type Lima runs on and override the instance name [#2674](https://github.c
 
 We have a new loading screen, Podman Desktop style! [#2743](https://github.com/containers/podman-desktop/pull/2743).
 
-<ReactPlayer playing controls url="https://user-images.githubusercontent.com/436777/243706137-324b5870-f6a0-4bc1-ac91-e8b45c374c90.mp4" />
+<ReactPlayer playing controls url="https://user-images.githubusercontent.com/436777/243706137-324b5870-f6a0-4bc1-ac91-e8b45c374c90.mp4" width='100%' height='100%' />
 
 ---
 

--- a/website/blog/2023-07-12-release-1.2.md
+++ b/website/blog/2023-07-12-release-1.2.md
@@ -33,19 +33,19 @@ In the last month we've been addind support for more Compose features. Before yo
 
 Stay tuned as we add even more features to Compose! If you have any feedback or feature requests, feel free to open an issue or start a discussion on GitHub.
 
-<ReactPlayer playing controls url="https://user-images.githubusercontent.com/6422176/253331226-d80e7637-c223-4bb8-8675-1dcb8d48818f.mov" />
+<ReactPlayer playing controls url="https://user-images.githubusercontent.com/6422176/253331226-d80e7637-c223-4bb8-8675-1dcb8d48818f.mov" width='100%' height='100%' />
 
 ### Kubernetes context on the status bar
 
 With Kubernetes context on the status bar, you can switch from one context to another in just a couple of clicks. Easily switch to a different cluster all together. If there are multiple contexts available, you can now click and pick which one to use.
 
-<ReactPlayer playing controls url="https://user-images.githubusercontent.com/19958075/243804525-242b02b4-fc3c-415b-be08-24eb1933adc5.mov" />
+<ReactPlayer playing controls url="https://user-images.githubusercontent.com/19958075/243804525-242b02b4-fc3c-415b-be08-24eb1933adc5.mov" width='100%' height='100%' />
 
 ### Rename images
 
 Deployed an image but now you need to rename it / add a new tag? Podman Desktop allows you to edit an image now. Thanks to an awesome contributor [@tuckerrc](https://github.com/tuckerrc) who added the new feature.
 
-<ReactPlayer playing controls url="https://user-images.githubusercontent.com/436777/251759557-bd15a631-93ee-4383-a81c-8ef3934dfb59.mp4" />
+<ReactPlayer playing controls url="https://user-images.githubusercontent.com/436777/251759557-bd15a631-93ee-4383-a81c-8ef3934dfb59.mp4" width='100%' height='100%' />
 
 ### Troubleshooting page
 
@@ -53,13 +53,13 @@ Developing an extension for Podman Desktop? Want to view the logs of Podman Desk
 
 Click on the lightbulb button on the bottom right to access the page.
 
-<ReactPlayer playing controls url="https://user-images.githubusercontent.com/436777/248210601-e0a5deb0-44ad-4eea-9b24-134754fede80.mp4" />
+<ReactPlayer playing controls url="https://user-images.githubusercontent.com/436777/248210601-e0a5deb0-44ad-4eea-9b24-134754fede80.mp4" width='100%' height='100%' />
 
 ### Protocol handler support
 
 Podman Desktop now supports protocol handling when using the terminal! Want to access your favourite extension directly from a script or the terminal? If you type in `open podman-desktop:extension/redhat.openshift-local` in the terminal, Podman Desktop will automatically load up to the correct extension.
 
-<ReactPlayer playing controls url="https://user-images.githubusercontent.com/436777/243304511-b11ad1e4-4c2f-455c-957a-01653d2a93c8.mp4" />
+<ReactPlayer playing controls url="https://user-images.githubusercontent.com/436777/243304511-b11ad1e4-4c2f-455c-957a-01653d2a93c8.mp4" width='100%' height='100%' />
 
 ---
 


### PR DESCRIPTION
### What does this PR do?

we use ReactPlayer for displaying the video demos of features in release notes. unfortunately ootb ReactPlayer hardcodes the width of videos at 640px which can break the layout on mobile. I have adjusted all of the usages of ReactPlayer in the blog posts under website/blog that use it, tested and they scale properly on all mobile sizes now.
### Screenshot/screencast of this PR

#### Before
![IMG_0407](https://github.com/containers/podman-desktop/assets/799683/fb250976-dd57-44de-981a-6b435f2eb096)

#### After

![Screenshot from 2023-07-14 12-21-01](https://github.com/containers/podman-desktop/assets/799683/3a7fba6f-b15d-42f3-b582-e02d8e9f6db5)

### What issues does this PR fix or reference?

We didn't file an issue for this, it's just a PR. (Sorry)

### How to test this PR?

Load one of the following blog release notes posts:

- website/blog/2023-01-18-release-0.11
- website/blog/2023-03-29-release-0.13
- website/blog/2023-04-14-release-0.14
- website/blog/2023-05-02-release-0.15
- website/blog/2023-06-08-release-1.1
- website/blog/2023-07-12-release-1.2

Make sure the video does create a horizontal scroll or pop out awkwardly horizontally in the layout (as in the before screenshot above.) It should scale to the width of the page and look natural.


Signed-off-by: Máirín Duffy <duffy@redhat.com>