### PR TITLE
fix: settings navigation bar resizing

### DIFF
--- a/packages/renderer/src/PreferencesNavigation.svelte
+++ b/packages/renderer/src/PreferencesNavigation.svelte
@@ -45,7 +45,7 @@ $: addSectionHiddenClass = (section: string): string => (sectionExpanded[section
 </script>
 
 <nav
-  class="z-1 pf-c-nav w-[250px] min-w-[200px] shadow flex-col justify-between flex transition-all duration-500 ease-in-out"
+  class="z-1 pf-c-nav w-[225px] min-w-[225px] shadow flex-col justify-between flex transition-all duration-500 ease-in-out"
   style="background-color: rgb(39 39 42 / var(--tw-bg-opacity))"
   aria-label="PreferencesNavigation">
   <div class="flex items-center">
@@ -112,7 +112,7 @@ $: addSectionHiddenClass = (section: string): string => (sectionExpanded[section
         class="pf-c-nav__link"
         aria-label="Authentication">
         <div class="flex items-center">
-          <span class="hidden md:block group-hover:block">Authentication</span>
+          <span class="block group-hover:block">Authentication</span>
         </div>
       </a>
     </li>


### PR DESCRIPTION
### What does this PR do?

The Settings navigation bar is unnecessarily resizing slightly as you make the window wider or narrower. Worse, Authentication is oddly set to disappear at widths smaller than 768px.

Set a fixed size in the middle of the current sizes and made Authentication styling match other items.

### Screenshot/screencast of this PR
Before:
https://github.com/containers/podman-desktop/assets/19958075/44c020bf-8b08-4e7a-bc69-72c58a529fa4

### What issues does this PR fix or reference?

Related to/found when fixing issue #3230, but not directly related.

### How to test this PR?

Open Settings and confirm the navigation no longer gets slightly bigger and smaller as you make the window width change.