### PR TITLE
fix: consistent max width and padding in settings

### DIFF
--- a/packages/renderer/src/lib/docker-extension/PreferencesPageDockerExtensions.svelte
+++ b/packages/renderer/src/lib/docker-extension/PreferencesPageDockerExtensions.svelte
@@ -59,7 +59,7 @@ function deleteContribution(extensionName: string) {
       the OpenShift extension.
     </p>
 
-    <div class="container mx-auto w-full mt-4 flex-col">
+    <div class="container w-full mt-4 flex-col">
       <div class="flex flex-col mb-4">
         <label for="ociImage" class="block mb-2 text-sm font-medium text-gray-400">Image name:</label>
         <input

--- a/packages/renderer/src/lib/preferences/PreferencesAuthenticationProvidersRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesAuthenticationProvidersRendering.svelte
@@ -10,7 +10,7 @@ import DropdownMenuItem from '../ui/DropDownMenuItem.svelte';
 </script>
 
 <SettingsPage title="Authentication">
-  <div class="container w-full h-full">
+  <div class="container h-full">
     <!-- Authentication Providers table start -->
     <EmptyScreen
       icon="{KeyIcon}"

--- a/packages/renderer/src/lib/preferences/PreferencesExtensionRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesExtensionRendering.svelte
@@ -26,7 +26,7 @@ async function removeExtension() {
   <span slot="subtitle">
     {extensionInfo.description}
   </span>
-  <div class="bg-charcoal-600 rounded-md p-3">
+  <div class="flex flex-col bg-charcoal-600 rounded-md p-3">
     {#if extensionInfo}
       <Route path="/*" breadcrumb="{extensionInfo.displayName}">
         <!-- Manage lifecycle-->

--- a/packages/renderer/src/lib/preferences/PreferencesProxiesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesProxiesRendering.svelte
@@ -42,7 +42,7 @@ async function updateProxyState() {
 </script>
 
 <SettingsPage title="Proxy Settings">
-  <div class="container mx-auto bg-charcoal-600 rounded-md p-3">
+  <div class="flex flex-col bg-charcoal-600 rounded-md p-3 space-y-2">
     <!-- if proxy is not enabled, display a toggle -->
 
     <label for="toggle-proxy" class="inline-flex relative items-center mt-1 mb-4 cursor-pointer">
@@ -60,10 +60,10 @@ async function updateProxyState() {
     </label>
 
     {#if proxySettings}
-      <div>
+      <div class="space-y-2">
         <label
           for="httpProxy"
-          class="block mb-2 text-sm font-medium {proxyState
+          class="mb-2 text-sm font-medium {proxyState
             ? 'text-gray-400 dark:text-gray-400'
             : 'text-gray-900 dark:text-gray-900'}">Web Proxy (HTTP):</label>
         <input
@@ -74,10 +74,10 @@ async function updateProxyState() {
           class="w-full p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700"
           required />
       </div>
-      <div>
+      <div class="space-y-2">
         <label
           for="httpsProxy"
-          class="pt-4 block mb-2 text-sm font-medium {proxyState
+          class="pt-4 mb-2 text-sm font-medium {proxyState
             ? 'text-gray-400 dark:text-gray-400'
             : 'text-gray-900 dark:text-gray-900'}">Secure Web Proxy (HTTPS):</label>
         <input
@@ -88,10 +88,10 @@ async function updateProxyState() {
           class="w-full p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700"
           required />
       </div>
-      <div>
+      <div class="space-y-2">
         <label
           for="httpProxy"
-          class="pt-4 block mb-2 text-sm font-medium {proxyState
+          class="pt-4 mb-2 text-sm font-medium {proxyState
             ? 'text-gray-400 dark:text-gray-400'
             : 'text-gray-900 dark:text-gray-900'}">Bypass proxy settings for these hosts and domains:</label>
         <input

--- a/packages/renderer/src/lib/preferences/PreferencesRegistriesEditing.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRegistriesEditing.svelte
@@ -243,7 +243,7 @@ const processPasswordElement = (node: HTMLInputElement, registry: containerDeskt
 </script>
 
 <SettingsPage title="Registries">
-  <div class="container mx-auto bg-charcoal-600 rounded-md p-3">
+  <div class="container bg-charcoal-600 rounded-md p-3">
     <!-- Registries table start -->
     <div class="w-full border-t border-b border-gray-900">
       <div class="flex w-full">

--- a/packages/renderer/src/lib/preferences/PreferencesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRendering.svelte
@@ -73,7 +73,7 @@ function updateSearchValue(event: any) {
         </svg>
       </div>
     </div>
-    <div class="flex flex-col min-w-full rounded-md space-y-5">
+    <div class="flex flex-col space-y-5">
       {#if matchingRecords.size === 0}
         <div>No Settings Found</div>
       {:else}

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
@@ -291,7 +291,7 @@ function hideInstallModal() {
       href="/preferences/extensions"
       class="text-gray-700 underline underline-offset-2">Extensions</a>
   </span>
-  <div class="w-full h-full">
+  <div class="h-full">
     <EmptyScreen
       aria-label="no-resource-panel"
       icon="{EngineIcon}"

--- a/packages/renderer/src/lib/preferences/SettingsPage.svelte
+++ b/packages/renderer/src/lib/preferences/SettingsPage.svelte
@@ -11,7 +11,9 @@ export let title: string;
 
     <slot name="header" />
   </div>
-  <div class="flex flex-col min-w-full h-full px-5 py-4 overflow-y-auto">
-    <slot />
+  <div class="flex flex-row min-w-full h-full px-5 py-4 overflow-y-auto">
+    <div class="flex flex-col grow max-w-[905px] mx-auto">
+      <slot />
+    </div>
   </div>
 </div>


### PR DESCRIPTION
### What does this PR do?

Currently, each settings page has different maximum width and alignment. Most page are always full width; proxy/registry are centred after a max width; auth is left justified after a max width.

This fix makes them all consistent: full width on smaller screens, and when the width gets over 905px (*) they are centred.

Had to fix the proxy page a little b/c it was using block elements that don't expand correctly.

(*) Why 905px? This is the current sweet-spot where the Settings > Resources page just has three columns. The built-in sizes don't quite work: max-w-screen-md is too narrow and a couple pages like resources look squished; max-w-screen-lg is really wide and simpler pages like proxy and preferences are stretched.

### Screenshot/screencast of this PR

Before:
https://github.com/containers/podman-desktop/assets/19958075/892470f2-048d-469c-b458-0fbcf4b9d605

After:
https://github.com/containers/podman-desktop/assets/19958075/1d1810a6-38a1-4c6b-a4ed-1fd8f44830d0

### What issues does this PR fix or reference?

Fixes #3230.

### How to test this PR?

Go to each Settings page with a small width, then make your window really wide and go to each page again.