### PR TITLE
fix: move new registry button to header

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesRegistriesEditing.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRegistriesEditing.svelte
@@ -243,6 +243,19 @@ const processPasswordElement = (node: HTMLInputElement, registry: containerDeskt
 </script>
 
 <SettingsPage title="Registries">
+  <svelte:fragment slot="actions">
+    <button
+      on:click="{() => setNewRegistryFormVisible(true)}"
+      class="pf-c-button pf-m-primary transition ease-in-out delay-50 hover:cursor-pointer h-7 w-36 text-sm rounded-md shadow hover:shadow-lg"
+      type="button"
+      disabled="{showNewRegistryForm}">
+      <span class="pf-c-button__icon pf-m-start">
+        <i class="fas fa-plus-circle" aria-hidden="true"></i>
+      </span>
+      Add registry
+    </button>
+  </svelte:fragment>
+
   <div class="container bg-charcoal-600 rounded-md p-3">
     <!-- Registries table start -->
     <div class="w-full border-t border-b border-gray-900">
@@ -621,20 +634,4 @@ const processPasswordElement = (node: HTMLInputElement, registry: containerDeskt
     </div>
     <!-- Registries table end -->
   </div>
-
-  <!-- Spacer start -->
-  <div class="container h-full"></div>
-  <!-- Spacer end -->
-
-  <!-- Add new registry button start -->
-  <div class="flex justify-end pt-4 px-4 w-full">
-    <button
-      on:click="{() => setNewRegistryFormVisible(true)}"
-      class="pf-c-button pf-m-primary transition ease-in-out delay-50 hover:cursor-pointer h-7 w-36 text-sm rounded-md shadow hover:shadow-lg"
-      type="button"
-      disabled="{showNewRegistryForm}">
-      Add registry
-    </button>
-  </div>
-  <!-- Add new registry button end -->
 </SettingsPage>

--- a/packages/renderer/src/lib/preferences/PreferencesRegistriesEditing.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRegistriesEditing.svelte
@@ -243,7 +243,7 @@ const processPasswordElement = (node: HTMLInputElement, registry: containerDeskt
 </script>
 
 <SettingsPage title="Registries">
-  <svelte:fragment slot="actions">
+  <div slot="actions">
     <button
       on:click="{() => setNewRegistryFormVisible(true)}"
       class="pf-c-button pf-m-primary transition ease-in-out delay-50 hover:cursor-pointer h-7 w-36 text-sm rounded-md shadow hover:shadow-lg"
@@ -254,7 +254,7 @@ const processPasswordElement = (node: HTMLInputElement, registry: containerDeskt
       </span>
       Add registry
     </button>
-  </svelte:fragment>
+  </div>
 
   <div class="container bg-charcoal-600 rounded-md p-3">
     <!-- Registries table start -->

--- a/packages/renderer/src/lib/preferences/SettingsPage.svelte
+++ b/packages/renderer/src/lib/preferences/SettingsPage.svelte
@@ -4,9 +4,12 @@ export let title: string;
 
 <div class="flex flex-col min-w-full h-full">
   <div class="min-w-full px-5 py-4">
-    <div>
-      <p class="capitalize text-xl">{title}</p>
-      <p class="text-sm text-gray-700"><slot name="subtitle"><br /></slot></p>
+    <div class="flex flex-row">
+      <div class="grow">
+        <p class="capitalize text-xl">{title}</p>
+        <p class="text-sm text-gray-700"><slot name="subtitle"><br /></slot></p>
+      </div>
+      <slot name="actions" />
     </div>
 
     <slot name="header" />


### PR DESCRIPTION
### What does this PR do?

Fixes the initial/most basic part of issue #3233: adds support for adding actions to the SettingsPage header and moves the Registries page Add registry button from being bottom-right aligned into the header.

### Screenshot/screencast of this PR

<img width="777" alt="Screenshot 2023-07-17 at 4 26 25 PM" src="https://github.com/containers/podman-desktop/assets/19958075/e2fdcfe3-9b4c-42a0-a953-4be661828eaa">

### What issues does this PR fix or reference?

First part of issue #3233.

### How to test this PR?

Open Settings > Registries page and confirm the button still works.