### PR TITLE
chore: replace pf tabs

### DIFF
--- a/packages/renderer/src/lib/image/RunImage.svelte
+++ b/packages/renderer/src/lib/image/RunImage.svelte
@@ -16,6 +16,7 @@ import { containersInfos } from '../../stores/containers';
 import ErrorMessage from '../ui/ErrorMessage.svelte';
 import { splitSpacesHandlingDoubleQuotes } from '../string/string';
 import { array2String } from '/@/lib/string/string.js';
+import DetailsTab from '../ui/DetailsTab.svelte';
 
 let image: ImageInfoUI;
 
@@ -408,7 +409,7 @@ function checkContainerName(event: any) {
 }
 </script>
 
-<Route path="/*" let:meta>
+<Route path="/*">
   {#if dataReady}
     <FormPage title="Create a container from image {imageDisplayName}:{image.tag}">
       <svelte:fragment slot="icon">
@@ -416,50 +417,12 @@ function checkContainerName(event: any) {
       </svelte:fragment>
       <div slot="content" class="p-5 min-w-full h-fit">
         <div class="bg-charcoal-600 px-6 py-4 space-y-2 lg:px-8 sm:pb-6 xl:pb-8">
-          <section class="pf-c-page__main-tabs pf-m-limit-width">
-            <div class="pf-c-page__main-body">
-              <div class="pf-c-tabs pf-m-page-insets" id="open-tabs-example-tabs-list">
-                <ul class="pf-c-tabs__list">
-                  <li class="pf-c-tabs__item" class:pf-m-current="{meta.url === '/images/run/basic'}">
-                    <a
-                      href="{meta.match}/basic"
-                      class="pf-c-tabs__link"
-                      aria-controls="open-tabs-example-tabs-list-details-panel"
-                      id="open-tabs-example-tabs-list-details-link">
-                      <span class="pf-c-tabs__item-text">Basic</span>
-                    </a>
-                  </li>
-                  <li class="pf-c-tabs__item" class:pf-m-current="{meta.url === '/images/run/advanced'}">
-                    <a
-                      href="{meta.match}/advanced"
-                      class="pf-c-tabs__link"
-                      aria-controls="open-tabs-example-tabs-list-details-panel"
-                      id="open-tabs-example-tabs-list-details-link">
-                      <span class="pf-c-tabs__item-text">Advanced</span>
-                    </a>
-                  </li>
-                  <li class="pf-c-tabs__item" class:pf-m-current="{meta.url === '/images/run/networking'}">
-                    <a
-                      href="{meta.match}/networking"
-                      class="pf-c-tabs__link"
-                      aria-controls="open-tabs-example-tabs-list-yaml-panel"
-                      id="open-tabs-example-tabs-list-yaml-link">
-                      <span class="pf-c-tabs__item-text">Networking</span>
-                    </a>
-                  </li>
-                  <li class="pf-c-tabs__item" class:pf-m-current="{meta.url === '/images/run/security'}">
-                    <a
-                      href="{meta.pattern}/security"
-                      class="pf-c-tabs__link"
-                      aria-controls="open-tabs-example-tabs-list-yaml-panel"
-                      id="open-tabs-example-tabs-list-yaml-link">
-                      <span class="pf-c-tabs__item-text">Security</span>
-                    </a>
-                  </li>
-                </ul>
-              </div>
-            </div>
-          </section>
+          <div class="flex flex-row px-2 border-b border-charcoal-400">
+            <DetailsTab title="Basic" url="basic" />
+            <DetailsTab title="Advanced" url="advanced" />
+            <DetailsTab title="Networking" url="networking" />
+            <DetailsTab title="Security" url="security" />
+          </div>
           <div>
             <Route path="/basic" breadcrumb="Basic" navigationHint="tab">
               <div class="h-96 overflow-y-auto pr-4">

--- a/packages/renderer/src/lib/ui/DetailsPage.svelte
+++ b/packages/renderer/src/lib/ui/DetailsPage.svelte
@@ -41,15 +41,9 @@ export let subtitle: string = undefined;
       <a href="{$lastPage.path}" title="Close Details" class="mt-2 mr-2 text-gray-900"
         ><i class="fas fa-times" aria-hidden="true"></i></a>
     </div>
-    <section class="pf-c-page__main-tabs pf-m-limit-width">
-      <div class="pf-c-page__main-body">
-        <div class="pf-c-tabs pf-m-page-insets" id="open-tabs-example-tabs-list">
-          <ul class="pf-c-tabs__list">
-            <slot name="tabs" />
-          </ul>
-        </div>
-      </div>
-    </section>
+    <div class="flex flex-row px-2 border-b border-charcoal-400">
+      <slot name="tabs" />
+    </div>
     <div class="h-full bg-charcoal-900">
       <slot name="content" />
     </div>

--- a/packages/renderer/src/lib/ui/DetailsTab.svelte
+++ b/packages/renderer/src/lib/ui/DetailsTab.svelte
@@ -7,12 +7,15 @@ export let title;
 let baseURL = $router.path.substring(0, $router.path.lastIndexOf('/'));
 </script>
 
-<li class="pf-c-tabs__item" class:pf-m-current="{$router.path === baseURL + '/' + url}">
+<div
+  class="px-4 pb-2 border-b-[3px] border-charcoal-700 whitespace-nowrap hover:cursor-pointer hover:border-purple-500"
+  class:border-purple-500="{$router.path === baseURL + '/' + url}">
   <a
     href="{baseURL}/{url}"
-    class="pf-c-tabs__link"
-    aria-controls="open-tabs-example-tabs-list-{url}-panel"
-    id="open-tabs-example-tabs-list-{url}-link">
-    <span class="pf-c-tabs__item-text">{title}</span>
+    class="text-gray-600 no-underline"
+    class:text-white="{$router.path === baseURL + '/' + url}"
+    aria-controls="open-tabs-list-{url}-panel"
+    id="open-tabs-list-{url}-link">
+    {title}
   </a>
-</li>
+</div>

--- a/packages/renderer/src/lib/ui/DetailsTab.svelte
+++ b/packages/renderer/src/lib/ui/DetailsTab.svelte
@@ -8,11 +8,12 @@ let baseURL = $router.path.substring(0, $router.path.lastIndexOf('/'));
 </script>
 
 <div
-  class="px-4 pb-2 border-b-[3px] border-charcoal-700 whitespace-nowrap hover:cursor-pointer hover:border-purple-500"
-  class:border-purple-500="{$router.path === baseURL + '/' + url}">
+  class="pb-2 border-b-[3px] border-charcoal-700 whitespace-nowrap hover:cursor-pointer"
+  class:border-purple-500="{$router.path === baseURL + '/' + url}"
+  class:hover:border-charcoal-100="{$router.path !== baseURL + '/' + url}">
   <a
     href="{baseURL}/{url}"
-    class="text-gray-600 no-underline"
+    class="px-4 py-2 text-gray-600 no-underline"
     class:text-white="{$router.path === baseURL + '/' + url}"
     aria-controls="open-tabs-list-{url}-panel"
     id="open-tabs-list-{url}-link">

--- a/packages/renderer/src/override.css
+++ b/packages/renderer/src/override.css
@@ -39,11 +39,6 @@
   --pf-c-nav__link--m-current--after--BorderColor: #8b5cf6;
 }
 
-.pf-c-tabs__link::after {
-  --pf-c-tabs__link--after--BorderColor: #8b5cf6;
-  --pf-c-tabs__link--m-current--after--BorderColor: #8b5cf6;
-}
-
 .pf-c-button {
   --pf-c-button--FontSize: 13px;
 }


### PR DESCRIPTION
### What does this PR do?

I was curious what we still use PatternFly for and noticed this one. IMHO the Tailwind equivalent is shorter code, simpler to understand what it does, and without any dependency. Plus, we could already use DetailsTab for the only other place we use tabs - RunImage.

If someone feels strongly I could rename 'DetailsTab' to something like 'Tab' since it is now used outside of the details page.

### Screenshot/screencast of this PR

Before:
<img width="603" alt="Screenshot 2023-07-17 at 10 22 03 PM" src="https://github.com/containers/podman-desktop/assets/19958075/285db2b3-8d18-4bc1-891a-7ed3820e89d3">
<img width="603" alt="Screenshot 2023-07-17 at 10 24 17 PM" src="https://github.com/containers/podman-desktop/assets/19958075/2bbb1f24-f7e2-4998-ab3c-6ffcc6986b06">

After:
<img width="603" alt="Screenshot 2023-07-17 at 10 18 21 PM" src="https://github.com/containers/podman-desktop/assets/19958075/a345f598-007c-40de-80b9-46165665a07d">
<img width="603" alt="Screenshot 2023-07-17 at 10 18 06 PM" src="https://github.com/containers/podman-desktop/assets/19958075/f533ebaf-c49d-4bd0-978c-ef83ce040019">

Or did I mix these up? ;-)

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Open details pages and run image form, and confirm no visual regression.