### PR TITLE
feat: add user mode networking parameter for Podman machine

### DIFF
--- a/extensions/podman/package.json
+++ b/extensions/podman/package.json
@@ -105,6 +105,12 @@
           "default": true,
           "scope": "ContainerProviderConnectionFactory",
           "description": "Machine with root privileges"
+        },
+        "podman.factory.machine.user-mode-networking": {
+          "type": "boolean",
+          "default": false,
+          "scope": "ContainerProviderConnectionFactory",
+          "description": "User mode networking"
         }
       }
     },

--- a/extensions/podman/package.json
+++ b/extensions/podman/package.json
@@ -110,7 +110,7 @@
           "type": "boolean",
           "default": false,
           "scope": "ContainerProviderConnectionFactory",
-          "description": "User mode networking",
+          "markdownDescription": "User mode networking (traffic relayed by a user process). See [documentation](https://docs.podman.io/en/latest/markdown/podman-machine-init.1.html#user-mode-networking).",
           "when": "podman.isUserModeNetworkingSupported == true"
         }
       }

--- a/extensions/podman/package.json
+++ b/extensions/podman/package.json
@@ -110,7 +110,8 @@
           "type": "boolean",
           "default": false,
           "scope": "ContainerProviderConnectionFactory",
-          "description": "User mode networking"
+          "description": "User mode networking",
+          "when": "podman.isUserModeNetworkingSupported == true"
         }
       }
     },

--- a/extensions/podman/src/extension.spec.ts
+++ b/extensions/podman/src/extension.spec.ts
@@ -24,6 +24,7 @@ import { getPodmanCli } from './podman-cli';
 import type { Configuration } from '@podman-desktop/api';
 import * as extensionApi from '@podman-desktop/api';
 import * as fs from 'node:fs';
+import { isWindows } from './util';
 
 const config: Configuration = {
   get: () => {
@@ -156,6 +157,50 @@ test('verify create command called with correct values', async () => {
   expect(spyExecPromise).toBeCalledWith(
     getPodmanCli(),
     ['machine', 'init', '--cpus', '2', '--memory', '999', '--disk-size', '232', '--image-path', 'path'],
+    {
+      env: {},
+      logger: undefined,
+    },
+    undefined,
+  );
+  expect(console.error).not.toBeCalled();
+});
+
+test('verify create command called with correct values with user mode networking', async () => {
+  const spyExecPromise = vi.spyOn(podmanCli, 'execPromise');
+  spyExecPromise.mockImplementation(() => {
+    return Promise.resolve('');
+  });
+  await extension.createMachine(
+    {
+      'podman.factory.machine.cpus': '2',
+      'podman.factory.machine.image-path': 'path',
+      'podman.factory.machine.memory': '1048000000',
+      'podman.factory.machine.diskSize': '250000000000',
+      'podman.factory.machine.user-mode-networking': true,
+    },
+    undefined,
+    undefined,
+    '4.6.0',
+  );
+  const parameters = [
+    'machine',
+    'init',
+    '--cpus',
+    '2',
+    '--memory',
+    '1048',
+    '--disk-size',
+    '250',
+    '--image-path',
+    'path',
+  ];
+  if (isWindows()) {
+    parameters.push('--user-mode-networking');
+  }
+  expect(spyExecPromise).toBeCalledWith(
+    getPodmanCli(),
+    parameters,
     {
       env: {},
       logger: undefined,

--- a/extensions/podman/src/extension.spec.ts
+++ b/extensions/podman/src/extension.spec.ts
@@ -24,7 +24,6 @@ import { getPodmanCli } from './podman-cli';
 import type { Configuration } from '@podman-desktop/api';
 import * as extensionApi from '@podman-desktop/api';
 import * as fs from 'node:fs';
-import { isWindows } from './util';
 
 const config: Configuration = {
   get: () => {
@@ -181,7 +180,6 @@ test('verify create command called with correct values with user mode networking
     },
     undefined,
     undefined,
-    '4.6.0',
   );
   const parameters = [
     'machine',
@@ -194,10 +192,8 @@ test('verify create command called with correct values with user mode networking
     '232',
     '--image-path',
     'path',
+    '--user-mode-networking',
   ];
-  if (isWindows()) {
-    parameters.push('--user-mode-networking');
-  }
   expect(spyExecPromise).toBeCalledWith(
     getPodmanCli(),
     parameters,

--- a/extensions/podman/src/extension.spec.ts
+++ b/extensions/podman/src/extension.spec.ts
@@ -189,9 +189,9 @@ test('verify create command called with correct values with user mode networking
     '--cpus',
     '2',
     '--memory',
-    '1048',
+    '999',
     '--disk-size',
-    '250',
+    '232',
     '--image-path',
     'path',
   ];

--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -85,7 +85,7 @@ export type MachineInfo = {
   cpus: number;
   memory: number;
   diskSize: number;
-  userModeNetworking?: boolean;
+  userModeNetworking: boolean;
 };
 
 async function updateMachines(provider: extensionApi.Provider): Promise<void> {
@@ -112,12 +112,14 @@ async function updateMachines(provider: extensionApi.Provider): Promise<void> {
       listeners.forEach(listener => listener(machine.Name, status));
       podmanMachinesStatuses.set(machine.Name, status);
     }
+
+    const userModeNetworking = isWindows() ? machine.UserModeNetworking : true;
     podmanMachinesInfo.set(machine.Name, {
       name: machine.Name,
       memory: parseInt(machine.Memory),
       cpus: machine.CPUs,
       diskSize: parseInt(machine.DiskSize),
-      userModeNetworking: isWindows() ? machine.UserModeNetworking : true,
+      userModeNetworking: userModeNetworking,
     });
 
     if (!podmanMachinesStatuses.has(machine.Name)) {
@@ -1041,6 +1043,7 @@ export async function deactivate(): Promise<void> {
 
 const PODMAN_MINIMUM_VERSION_FOR_USER_MODE_NETWORKING = '4.6.0';
 
+// Checks if user mode networking is supported. Only Windows platform allows this parameter to be tuned
 export function isUserModeNetworkingSupported(podmanVersion: string) {
   return isWindows() && compareVersions(podmanVersion, PODMAN_MINIMUM_VERSION_FOR_USER_MODE_NETWORKING) >= 0;
 }

--- a/extensions/podman/src/podman-install.spec.ts
+++ b/extensions/podman/src/podman-install.spec.ts
@@ -40,6 +40,7 @@ vi.mock('./util', async () => {
   return {
     getAssetsFolder: vi.fn().mockReturnValue(''),
     runCliCommand: vi.fn(),
+    appHomeDir: vi.fn().mockReturnValue(''),
   };
 });
 

--- a/extensions/podman/src/podman-install.ts
+++ b/extensions/podman/src/podman-install.ts
@@ -29,6 +29,7 @@ import { getAssetsFolder, runCliCommand } from './util';
 import { getDetectionChecks } from './detection-checks';
 import { BaseCheck } from './base-check';
 import { MacCPUCheck, MacMemoryCheck, MacPodmanInstallCheck, MacVersionCheck } from './macos-checks';
+import { isUserModeNetworkingSupported, USER_MODE_NETWORKING_SUPPORTED_KEY } from './extension';
 
 const readFile = promisify(fs.readFile);
 const writeFile = promisify(fs.writeFile);
@@ -128,6 +129,10 @@ export class PodmanInstall {
       // write podman version
       if (newInstalledPodman) {
         this.podmanInfo.podmanVersion = newInstalledPodman.version;
+        extensionApi.context.setValue(
+          USER_MODE_NETWORKING_SUPPORTED_KEY,
+          isUserModeNetworkingSupported(newInstalledPodman.version),
+        );
       }
       // update detections checks
       provider.updateDetectionChecks(getDetectionChecks(newInstalledPodman));

--- a/extensions/podman/src/podman-install.ts
+++ b/extensions/podman/src/podman-install.ts
@@ -178,6 +178,10 @@ export class PodmanInstall {
         provider.updateDetectionChecks(getDetectionChecks(installedPodman));
         provider.updateVersion(updateInfo.bundledVersion);
         this.podmanInfo.ignoreVersionUpdate = undefined;
+        extensionApi.context.setValue(
+          USER_MODE_NETWORKING_SUPPORTED_KEY,
+          isUserModeNetworkingSupported(updateInfo.bundledVersion),
+        );
       } else if (answer === 'Ignore') {
         this.podmanInfo.ignoreVersionUpdate = updateInfo.bundledVersion;
       }

--- a/packages/main/src/plugin/configuration-registry.ts
+++ b/packages/main/src/plugin/configuration-registry.ts
@@ -63,6 +63,7 @@ export interface IConfigurationPropertySchema {
   readonly?: boolean;
   hidden?: boolean;
   enum?: string[];
+  when?: string;
 }
 
 export type ConfigurationScope =

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationRendering.svelte
@@ -15,7 +15,7 @@ import {
 } from './preferences-connection-rendering-task';
 /* eslint-disable import/no-duplicates */
 // https://github.com/import-js/eslint-plugin-import/issues/1479
-import { get } from 'svelte/store';
+import { get, type Unsubscriber } from 'svelte/store';
 import { onDestroy, onMount } from 'svelte';
 /* eslint-enable import/no-duplicates */
 import { createConnectionsInfo } from '/@/stores/create-connections';
@@ -30,6 +30,9 @@ import AuditMessageBox from '../ui/AuditMessageBox.svelte';
 import EmptyScreen from '../ui/EmptyScreen.svelte';
 import { faCubes } from '@fortawesome/free-solid-svg-icons';
 import Button from '../ui/Button.svelte';
+import type { ContextUI } from '/@/lib/context/context';
+import { ContextKeyExpr } from '/@/lib/context/contextKey';
+import { context } from '/@/stores/context';
 
 export let properties: IConfigurationPropertyRecordedSchema[] = [];
 export let providerInfo: ProviderInfo;
@@ -69,7 +72,11 @@ let errorMessage = undefined;
 
 let formEl;
 
+let globalContext: ContextUI;
+
 $: connectionAuditResult = undefined;
+
+let contextsUnsubscribe: Unsubscriber;
 
 // reconnect the logger handler
 $: if (logsTerminal && loggerHandlerKey) {
@@ -80,13 +87,20 @@ $: if (logsTerminal && loggerHandlerKey) {
   }
 }
 
+function isPropertyValidInContext(when: string, context: ContextUI) {
+  const expr = ContextKeyExpr.deserialize(when);
+  return expr.evaluate(context);
+}
+
 onMount(async () => {
   osMemory = await window.getOsMemory();
   osCpu = await window.getOsCpu();
   osFreeDisk = await window.getOsFreeDiskSize();
+  contextsUnsubscribe = context.subscribe(value => (globalContext = value));
   configurationKeys = properties
     .filter(property => property.scope === propertyScope)
     .filter(property => property.id.startsWith(providerInfo.id))
+    .filter(property => !property.when || isPropertyValidInContext(property.when, globalContext))
     .map(property => {
       switch (property.maximum) {
         case 'HOST_TOTAL_DISKSIZE': {
@@ -147,6 +161,9 @@ onMount(async () => {
 onDestroy(() => {
   if (loggerHandlerKey) {
     disconnectUI(loggerHandlerKey);
+  }
+  if (contextsUnsubscribe) {
+    contextsUnsubscribe();
   }
 });
 


### PR DESCRIPTION
Fixes #2865

### What does this PR do?

Add a new parameter user-mode-networking when creating Podman machine. This parameter will be accessible only on Windows and for Podman 4.6.0

### Screenshot/screencast of this PR

![user-mode-networking-new](https://github.com/containers/podman-desktop/assets/620330/2f521576-b6a6-42b5-b24d-08df5b432608)

### What issues does this PR fix or reference?

Fixes #2865 

### How to test this PR?

Create a Podman machine and set the new parameter
