### PR TITLE
fix: respect LIMA_HOME environment variable

### DIFF
--- a/extensions/lima/src/extension.ts
+++ b/extensions/lima/src/extension.ts
@@ -48,8 +48,8 @@ function registerProvider(
 export async function activate(extensionContext: extensionApi.ExtensionContext): Promise<void> {
   const engineType = configuration.getConfiguration('lima').get('type') || 'podman';
   const instanceName = configuration.getConfiguration('lima').get('name') || engineType;
-  const limaHome = os.homedir(); // TODO: look for the LIMA_HOME environment variable
-  const socketPath = path.resolve(limaHome, '.lima/' + instanceName + '/sock/' + engineType + '.sock');
+  const limaHome = 'LIMA_HOME' in process.env ? process.env['LIMA_HOME'] : os.homedir() + '/.lima';
+  const socketPath = path.resolve(limaHome, instanceName + '/sock/' + engineType + '.sock');
 
   let provider;
   if (fs.existsSync(socketPath)) {


### PR DESCRIPTION
### What does this PR do?

In some environments, it might be desirable to **not** use the regular `HOME` environment variable (`~`)...

For instance, when /home is on a shared filesystem but you want your instances on a local filesystem.

In those cases, you can override `LIMA_HOME`

Note: the LIMA_HOME defaults to `~/.lima`

See https://github.com/lima-vm/lima/blob/master/docs/internal.md#lima-home-directory-lima_home

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

### How to test this PR?

<!-- Please explain steps to reproduce -->

export LIMA_HOME=/tmp/home/lima

See that it is looking for sockets there:

`[lima] Could not find podman socket at /tmp/home/lima/podman/sock/podman.sock`

Could also verify that it still works OK.