### PR TITLE
fix: add check before writing to terminal

### DIFF
--- a/packages/renderer/src/lib/preferences/Util.spec.ts
+++ b/packages/renderer/src/lib/preferences/Util.spec.ts
@@ -34,16 +34,41 @@ test('write array object', () => {
   expect(xtermMock.write).toBeCalledTimes(2);
 });
 
-test('write invalid object', () => {
-  writeToTerminal(xtermMock, {} as unknown as string[], 'test');
+test('write array of array object', () => {
+  writeToTerminal(
+    xtermMock,
+    [
+      ['a', 'b'],
+      ['c', 'd'],
+    ],
+    'test',
+  );
   // no error reported
-  expect(xtermMock.write).toBeCalledWith(expect.stringContaining('test'));
+  expect(xtermMock.write).toBeCalledTimes(4);
+});
+
+test('write array with mixed values', () => {
+  writeToTerminal(xtermMock, [undefined, undefined, 'ok'], 'test');
+  // no error reported
+  expect(xtermMock.write).toBeCalledTimes(1);
+});
+
+test('write array of array object', () => {
+  writeToTerminal(xtermMock, [], 'test');
+  // no error reported
+  expect(xtermMock.write).not.toBeCalled();
+});
+
+test('write invalid object', () => {
+  writeToTerminal(xtermMock, {} as unknown as any[], 'test');
+  // it should not write as xterm.write is called with a valid string
+  expect(xtermMock.write).not.toBeCalled();
 });
 
 test('write undefined object', () => {
-  writeToTerminal(xtermMock, undefined as unknown as string[], 'test');
-  // no error reported
-  expect(xtermMock.write).toBeCalledWith(expect.stringContaining('test'));
+  writeToTerminal(xtermMock, undefined as unknown as any[], 'test');
+  // it should not write as xterm.write is called with a valid string
+  expect(xtermMock.write).not.toBeCalled();
 });
 
 test('return default if type is not number', () => {

--- a/packages/renderer/src/lib/preferences/Util.spec.ts
+++ b/packages/renderer/src/lib/preferences/Util.spec.ts
@@ -31,6 +31,8 @@ afterEach(() => {
 test('write array object', () => {
   writeToTerminal(xtermMock, ['a', 'b'], 'test');
   // no error reported
+  expect(xtermMock.write).toHaveBeenNthCalledWith(1, expect.stringContaining('a'));
+  expect(xtermMock.write).toHaveBeenNthCalledWith(2, expect.stringContaining('b'));
   expect(xtermMock.write).toBeCalledTimes(2);
 });
 
@@ -44,6 +46,10 @@ test('write array of array object', () => {
     'test',
   );
   // no error reported
+  expect(xtermMock.write).toHaveBeenNthCalledWith(1, expect.stringContaining('a'));
+  expect(xtermMock.write).toHaveBeenNthCalledWith(2, expect.stringContaining('b'));
+  expect(xtermMock.write).toHaveBeenNthCalledWith(3, expect.stringContaining('c'));
+  expect(xtermMock.write).toHaveBeenNthCalledWith(4, expect.stringContaining('d'));
   expect(xtermMock.write).toBeCalledTimes(4);
 });
 
@@ -51,12 +57,20 @@ test('write array with mixed values', () => {
   writeToTerminal(xtermMock, [undefined, undefined, 'ok'], 'test');
   // no error reported
   expect(xtermMock.write).toBeCalledTimes(1);
+  expect(xtermMock.write).toBeCalledWith(expect.stringContaining('ok'));
 });
 
 test('write array of array object', () => {
   writeToTerminal(xtermMock, [], 'test');
   // no error reported
   expect(xtermMock.write).not.toBeCalled();
+});
+
+test('write multiline string', () => {
+  writeToTerminal(xtermMock, ['a\nb\n'], 'test');
+  // no error reported
+  expect(xtermMock.write).toHaveBeenNthCalledWith(1, expect.stringContaining('a'));
+  expect(xtermMock.write).toHaveBeenNthCalledWith(2, expect.stringContaining('b'));
 });
 
 test('write invalid object', () => {

--- a/packages/renderer/src/lib/preferences/Util.ts
+++ b/packages/renderer/src/lib/preferences/Util.ts
@@ -37,13 +37,21 @@ export interface IConnectionRestart {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function writeToTerminal(xterm: any, data: string[], colorPrefix: string): void {
+export function writeToTerminal(xterm: any, data: any[], colorPrefix: string): void {
   if (Array.isArray(data)) {
-    for (const it of data) {
-      writeMultilineString(xterm, it, colorPrefix);
-    }
-  } else {
+    writeArrayToTerminal(xterm, data, colorPrefix);
+  } else if (typeof data === 'string') {
     writeMultilineString(xterm, data, colorPrefix);
+  }
+}
+
+function writeArrayToTerminal(xterm: any, data: any[], colorPrefix: string) {
+  for (const content of data) {
+    if (Array.isArray(content)) {
+      writeArrayToTerminal(xterm, content, colorPrefix);
+    } else if (typeof content === 'string') {
+      writeMultilineString(xterm, content, colorPrefix);
+    }
   }
 }
 


### PR DESCRIPTION
### What does this PR do?

This PR makes the writeToTerminal more robust by filtering invalid values and managing arrays of arrays (i don't have the error i faced but it happened when working with logs).
The behavior should be like before as if it receive a valid array of string nothing changes

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

it is part of the splitting of https://github.com/containers/podman-desktop/pull/1923

### How to test this PR?

1. start a podman machine and check that the logs are printed as before
