### PR TITLE
chore: rename param of getMatchingProvider to clarify the expected value

### DIFF
--- a/packages/main/src/plugin/provider-registry.ts
+++ b/packages/main/src/plugin/provider-registry.ts
@@ -646,11 +646,11 @@ export class ProviderRegistry {
   }
 
   // helper method
-  protected getMatchingProvider(providerId: string): ProviderImpl {
+  protected getMatchingProvider(internalId: string): ProviderImpl {
     // need to find the provider
-    const provider = this.providers.get(providerId);
+    const provider = this.providers.get(internalId);
     if (!provider) {
-      throw new Error(`no provider matching provider id ${providerId}`);
+      throw new Error(`no provider matching provider id ${internalId}`);
     }
     return provider;
   }


### PR DESCRIPTION
### What does this PR do?

It just renames the param value of the getMatchingProvider  function to clarify the expected value.
A provider has both an internalid and an id, so providerID could lead to misunderstanding

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

N/A

### How to test this PR?

N/A
