### PR TITLE
feat: extend connection lifecycle context function to work with kubernetes connection

### DIFF
--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1132,11 +1132,11 @@ export class PluginSystem {
         _listener,
         providerId: string,
         callbackId: number,
-        containerConnectionInfo?: ProviderContainerConnectionInfo,
+        connectionInfo?: ProviderContainerConnectionInfo | ProviderKubernetesConnectionInfo,
       ): Promise<void> => {
         let context;
-        if (containerConnectionInfo) {
-          context = providerRegistry.getMatchingContainerLifecycleContext(providerId, containerConnectionInfo);
+        if (connectionInfo) {
+          context = providerRegistry.getMatchingConnectionLifecycleContext(providerId, connectionInfo);
         } else {
           context = providerRegistry.getMatchingLifecycleContext(providerId);
         }
@@ -1159,11 +1159,11 @@ export class PluginSystem {
       async (
         _listener,
         providerId: string,
-        containerConnectionInfo?: ProviderContainerConnectionInfo,
+        connectionInfo?: ProviderContainerConnectionInfo | ProviderKubernetesConnectionInfo,
       ): Promise<void> => {
         let context;
-        if (containerConnectionInfo) {
-          context = providerRegistry.getMatchingContainerLifecycleContext(providerId, containerConnectionInfo);
+        if (connectionInfo) {
+          context = providerRegistry.getMatchingConnectionLifecycleContext(providerId, connectionInfo);
         } else {
           context = providerRegistry.getMatchingLifecycleContext(providerId);
         }

--- a/packages/main/src/plugin/provider-registry.ts
+++ b/packages/main/src/plugin/provider-registry.ts
@@ -664,11 +664,11 @@ export class ProviderRegistry {
     return context;
   }
 
-  getMatchingContainerLifecycleContext(
-    providerId: string,
-    providerContainerConnectionInfo: ProviderContainerConnectionInfo,
+  getMatchingConnectionLifecycleContext(
+    internalId: string,
+    providerContainerConnectionInfo: ProviderContainerConnectionInfo | ProviderKubernetesConnectionInfo,
   ): LifecycleContextImpl {
-    const connection = this.getMatchingContainerConnectionFromProvider(providerId, providerContainerConnectionInfo);
+    const connection = this.getMatchingConnectionFromProvider(internalId, providerContainerConnectionInfo);
 
     const context = this.connectionLifecycleContexts.get(connection);
     if (!context) {

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -1062,7 +1062,7 @@ function initExposure(): void {
       log: LogFunction,
       warn: LogFunction,
       error: LogFunction,
-      containerConnectionInfo?: ProviderContainerConnectionInfo,
+      connectionInfo?: ProviderContainerConnectionInfo | ProviderKubernetesConnectionInfo,
     ): Promise<void> => {
       onDataCallbacksStartReceiveLogsId++;
       const logger: containerDesktopAPI.Logger = {
@@ -1075,7 +1075,7 @@ function initExposure(): void {
         'provider-registry:startReceiveLogs',
         providerId,
         onDataCallbacksStartReceiveLogsId,
-        containerConnectionInfo,
+        connectionInfo,
       );
     },
   );
@@ -1098,8 +1098,11 @@ function initExposure(): void {
 
   contextBridge.exposeInMainWorld(
     'stopReceiveLogs',
-    async (providerId: string, containerConnectionInfo?: ProviderContainerConnectionInfo): Promise<void> => {
-      return ipcInvoke('provider-registry:stopReceiveLogs', providerId, containerConnectionInfo);
+    async (
+      providerId: string,
+      connectionInfo?: ProviderContainerConnectionInfo | ProviderKubernetesConnectionInfo,
+    ): Promise<void> => {
+      return ipcInvoke('provider-registry:stopReceiveLogs', providerId, connectionInfo);
     },
   );
 


### PR DESCRIPTION
### What does this PR do?

This PR extends the function to retrieve lifecycle context to kubernetes connection.

Nothing changes from the current behavior.

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

this is part of the splitting of https://github.com/containers/podman-desktop/pull/1923

### How to test this PR?

N/A
