### PR TITLE
feat: enable to retrieve lifecycleContext from api

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -423,6 +423,10 @@ declare module '@podman-desktop/api' {
     export const onDidUnregisterContainerConnection: Event<UnregisterContainerConnectionEvent>;
     export const onDidRegisterContainerConnection: Event<RegisterContainerConnectionEvent>;
     export function getContainerConnections(): ProviderContainerConnection[];
+    export function getMatchingProviderLifecycleContext(
+      providerId: string,
+      providerConnectionInfo: ProviderContainerConnectionInfo | ProviderKubernetesConnectionInfo,
+    ): LifecycleContext;
   }
 
   export interface ProxySettings {

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -423,7 +423,16 @@ declare module '@podman-desktop/api' {
     export const onDidUnregisterContainerConnection: Event<UnregisterContainerConnectionEvent>;
     export const onDidRegisterContainerConnection: Event<RegisterContainerConnectionEvent>;
     export function getContainerConnections(): ProviderContainerConnection[];
-    export function getMatchingProviderLifecycleContext(
+    /**
+     * It returns the lifecycle context for the provider connection.
+     * If no context is found it throws an error
+     *
+     * @param providerId the provider id
+     * @param providerConnectionInfo the connection to retrieve the lifecycle context for
+     * @returns the lifecycle context
+     * @throws if no provider with the id has been found or there is no context associate to it.
+     */
+    export function getProviderLifecycleContext(
       providerId: string,
       providerConnectionInfo: ProviderContainerConnectionInfo | ProviderKubernetesConnectionInfo,
     ): LifecycleContext;

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -633,7 +633,7 @@ export class ExtensionLoader {
       getContainerConnections: () => {
         return providerRegistry.getContainerConnections();
       },
-      getMatchingProviderLifecycleContext(
+      getProviderLifecycleContext(
         providerId: string,
         providerConnectionInfo: ProviderContainerConnectionInfo | ProviderKubernetesConnectionInfo,
       ): containerDesktopAPI.LifecycleContext {

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -59,6 +59,7 @@ import type { Directories } from './directories.js';
 import { isLinux, isMac, isWindows } from '../util.js';
 import type { CustomPickRegistry } from './custompick/custompick-registry.js';
 import { exec } from './util/exec.js';
+import type { ProviderContainerConnectionInfo, ProviderKubernetesConnectionInfo } from './api/provider-info.js';
 
 /**
  * Handle the loading of an extension
@@ -631,6 +632,12 @@ export class ExtensionLoader {
       },
       getContainerConnections: () => {
         return providerRegistry.getContainerConnections();
+      },
+      getMatchingProviderLifecycleContext(
+        providerId: string,
+        providerConnectionInfo: ProviderContainerConnectionInfo | ProviderKubernetesConnectionInfo,
+      ): containerDesktopAPI.LifecycleContext {
+        return providerRegistry.getMatchingProviderLifecycleContextByProviderId(providerId, providerConnectionInfo);
       },
     };
 

--- a/packages/main/src/plugin/provider-registry.spec.ts
+++ b/packages/main/src/plugin/provider-registry.spec.ts
@@ -410,3 +410,33 @@ test('should retrieve context of kubernetes provider', async () => {
   expect(initalizeCalled).toBe(true);
   expect(apiSenderSendMock).toBeCalled();
 });
+
+test('should retrieve provider internal id from id', async () => {
+  const provider = providerRegistry.createProvider({ id: 'internal', name: 'internal', status: 'installed' });
+
+  const startMock = vi.fn();
+  const stopMock = vi.fn();
+  provider.registerContainerProviderConnection({
+    name: 'connection',
+    type: 'docker',
+    lifecycle: {
+      start: startMock,
+      stop: stopMock,
+    },
+    endpoint: {
+      socketPath: '/endpoint1.sock',
+    },
+    status() {
+      return 'stopped';
+    },
+  });
+
+  const internalId = providerRegistry.getMatchingProviderInternalId('internal');
+  expect(internalId).toBe('0');
+});
+
+test('should throw error if no provider found with id', async () => {
+  expect(() => providerRegistry.getMatchingProviderInternalId('internal')).toThrowError(
+    'no provider matching provider id internal',
+  );
+});

--- a/packages/main/src/plugin/provider-registry.ts
+++ b/packages/main/src/plugin/provider-registry.ts
@@ -41,7 +41,6 @@ import type {
   ProviderConnectionStatus,
   AuditResult,
   AuditRequestItems,
-  LifecycleContext,
 } from '@podman-desktop/api';
 import type {
   ProviderContainerConnectionInfo,
@@ -691,7 +690,7 @@ export class ProviderRegistry {
   getMatchingProviderLifecycleContextByProviderId(
     providerId: string,
     providerConnectionInfo: ProviderContainerConnectionInfo | ProviderKubernetesConnectionInfo,
-  ): LifecycleContext {
+  ): LifecycleContextImpl {
     const internalId = this.getMatchingProviderInternalId(providerId);
     return this.getMatchingConnectionLifecycleContext(internalId, providerConnectionInfo);
   }

--- a/packages/main/src/plugin/provider-registry.ts
+++ b/packages/main/src/plugin/provider-registry.ts
@@ -41,6 +41,7 @@ import type {
   ProviderConnectionStatus,
   AuditResult,
   AuditRequestItems,
+  LifecycleContext,
 } from '@podman-desktop/api';
 import type {
   ProviderContainerConnectionInfo,
@@ -676,6 +677,23 @@ export class ProviderRegistry {
     }
 
     return context;
+  }
+
+  getMatchingProviderInternalId(providerId: string): string {
+    // need to find the provider
+    const provider = Array.from(this.providers.values()).find(prov => prov.id === providerId);
+    if (!provider) {
+      throw new Error(`no provider matching provider id ${providerId}`);
+    }
+    return provider.internalId;
+  }
+
+  getMatchingProviderLifecycleContextByProviderId(
+    providerId: string,
+    providerConnectionInfo: ProviderContainerConnectionInfo | ProviderKubernetesConnectionInfo,
+  ): LifecycleContext {
+    const internalId = this.getMatchingProviderInternalId(providerId);
+    return this.getMatchingConnectionLifecycleContext(internalId, providerConnectionInfo);
   }
 
   async createContainerProviderConnection(


### PR DESCRIPTION
### What does this PR do?

This adds a function in the api to retrieve a lifecycleContext externally. 
This is needed so external extension can retrieve it and attach it when executing actions. 
The lifecycleContext is initialized in the provider-registry when a container/kube connection is registered.

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

this is part of the splitting of #1923 

### How to test this PR?

N/A
