### PR TITLE
feat: adds logsContainer function in api

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -1630,6 +1630,11 @@ declare module '@podman-desktop/api' {
     export function listContainers(): Promise<ContainerInfo[]>;
     export function inspectContainer(engineId: string, id: string): Promise<ContainerInspectInfo>;
     export function startContainer(engineId: string, id: string): Promise<void>;
+    export function logsContainer(
+      engineId: string,
+      id: string,
+      callback: (name: string, data: string) => void,
+    ): Promise<void>;
     export function stopContainer(engineId: string, id: string): Promise<void>;
     export function saveImage(engineId: string, id: string, filename: string): Promise<void>;
     export function tagImage(engineId: string, imageId: string, repo: string, tag?: string): Promise<void>;

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -808,6 +808,9 @@ export class ExtensionLoader {
       startContainer(engineId: string, id: string) {
         return containerProviderRegistry.startContainer(engineId, id);
       },
+      logsContainer(engineId: string, id: string, callback: (name: string, data: string) => void) {
+        return containerProviderRegistry.logsContainer(engineId, id, callback);
+      },
       stopContainer(engineId: string, id: string) {
         return containerProviderRegistry.stopContainer(engineId, id);
       },


### PR DESCRIPTION
### What does this PR do?

This adds the logsContainer function in the api so that external extension can use it.
This is needed by https://github.com/containers/podman-desktop/pull/1923 so the kind extension can attach a custom log callback to it

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

this is part of the splitting of #1923 

### How to test this PR?

N/A
