### PR TITLE
feat: add lima kubernetes provider type

### DIFF
--- a/extensions/lima/package.json
+++ b/extensions/lima/package.json
@@ -25,7 +25,8 @@
           "default": "podman",
           "enum": [
             "podman",
-            "docker"
+            "docker",
+            "kubernetes"
           ],
           "description": "Engine type (requires restart of extension)"
         },

--- a/extensions/lima/src/extension.ts
+++ b/extensions/lima/src/extension.ts
@@ -23,25 +23,41 @@ import * as fs from 'fs';
 
 import { configuration } from '@podman-desktop/api';
 
+type limaProviderType = 'docker' | 'podman' | 'kubernetes';
+
 function registerProvider(
   extensionContext: extensionApi.ExtensionContext,
   provider: extensionApi.Provider,
-  providerSocketPath: string,
+  providerPath: string,
 ): void {
   let providerState: extensionApi.ProviderConnectionStatus = 'unknown';
-  const providerType: 'docker' | 'podman' = configuration.getConfiguration('lima').get('type');
-  const containerProviderConnection: extensionApi.ContainerProviderConnection = {
-    name: 'Lima',
-    type: providerType,
-    status: () => providerState,
-    endpoint: {
-      socketPath: providerSocketPath,
-    },
-  };
-  providerState = 'started';
-  const disposable = provider.registerContainerProviderConnection(containerProviderConnection);
-  provider.updateStatus('started');
-  extensionContext.subscriptions.push(disposable);
+  const providerType: limaProviderType = configuration.getConfiguration('lima').get('type');
+  if (providerType === 'podman' || providerType === 'docker') {
+    const connection: extensionApi.ContainerProviderConnection = {
+      name: 'Lima',
+      type: providerType,
+      status: () => providerState,
+      endpoint: {
+        socketPath: providerPath,
+      },
+    };
+    providerState = 'started';
+    const disposable = provider.registerContainerProviderConnection(connection);
+    provider.updateStatus('started');
+    extensionContext.subscriptions.push(disposable);
+  } else if (providerType === 'kubernetes') {
+    const connection: extensionApi.KubernetesProviderConnection = {
+      name: 'Lima',
+      status: () => providerState,
+      endpoint: {
+        apiURL: 'https://localhost:6443',
+      },
+    };
+    providerState = 'started';
+    const disposable = provider.registerKubernetesProviderConnection(connection);
+    provider.updateStatus('started');
+    extensionContext.subscriptions.push(disposable);
+  }
   console.log('Lima extension is active');
 }
 
@@ -50,9 +66,10 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
   const instanceName = configuration.getConfiguration('lima').get('name') || engineType;
   const limaHome = 'LIMA_HOME' in process.env ? process.env['LIMA_HOME'] : os.homedir() + '/.lima';
   const socketPath = path.resolve(limaHome, instanceName + '/sock/' + engineType + '.sock');
+  const configPath = path.resolve(limaHome, instanceName + '/copied-from-guest/kubeconfig.yaml');
 
   let provider;
-  if (fs.existsSync(socketPath)) {
+  if (fs.existsSync(socketPath) || fs.existsSync(configPath)) {
     provider = extensionApi.provider.createProvider({
       name: 'Lima',
       id: 'lima',
@@ -71,7 +88,12 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
   if (fs.existsSync(socketPath)) {
     registerProvider(extensionContext, provider, socketPath);
   } else {
-    console.error(`Could not find podman socket at ${socketPath}`);
+    console.error(`Could not find socket at ${socketPath}`);
+  }
+  if (fs.existsSync(configPath)) {
+    registerProvider(extensionContext, provider, configPath);
+  } else {
+    console.error(`Could not find config at ${configPath}`);
   }
 }
 

--- a/website/docs/kubernetes/index.md
+++ b/website/docs/kubernetes/index.md
@@ -11,4 +11,5 @@ tags: [migrating-to-kubernetes]
 Podman Desktop and Podman have many features allowing easy migration from containers to Kubernetes:
 
 - [Kind support](kubernetes/kind)
+- [Lima support](kubernetes/lima)
 - [Minikube support](kubernetes/minikube)

--- a/website/docs/kubernetes/lima/index.md
+++ b/website/docs/kubernetes/lima/index.md
@@ -1,0 +1,17 @@
+---
+sidebar_position: 10
+title: Working with Lima
+description: Lima is one way to get Kubernetes running on your workstation.
+keywords: [podman desktop, containers, migrating, kubernetes, lima]
+tags: [migrating-to-kubernetes, lima]
+---
+
+# Running Kubernetes on your workstation with Lima
+
+With Podman Desktop, you can work on [Lima-powered](https://lima-vm.io/) local Kubernetes clusters.
+
+#### Procedure
+
+1. [Start a Lima instance running Kubernetes](/docs/Installation/creating-a-lima-instance-with-podman-desktop)
+1. [Configure the path to the kubeconfig file](/docs/kubernetes/configuring-access-to-a-kubernetes-cluster)
+1. Set the Kubernetes context to the Lima cluster


### PR DESCRIPTION
### What does this PR do?

Adds a "kubernetes" type, to the Lima provider

### Screenshot/screencast of this PR

![podman-desktop-lima-kubernetes](https://github.com/containers/podman-desktop/assets/10364051/cc24179c-e43c-4de0-b3b4-f199d263f6b5)

### What issues does this PR fix or reference?

Closes #3258

* #3258

### How to test this PR?

`brew install lima`

`limactl start template://k8s`

copy-paste the kubeconfig path, from the `limactl` output to the Lima preferences

<details>
copy-paste the kubeconfig path, from Resources > Lima to Preferences > kubeconfig

![podman-desktop-lima-kubeconfig](https://github.com/containers/podman-desktop/assets/10364051/a42079d6-cd41-4849-82e3-59faae9d6cdc)

![podman-desktop-preferences-kubeconfig](https://github.com/containers/podman-desktop/assets/10364051/bf04cfdf-a9b2-471e-bf78-6e57f01d5107)
</details>

Hopefully this step can be automated in the future, when multiple config is supported.

----

Haven't found where to set the kubeconfig yet, seems to be mostly about kubecontext ?

Workaround is to manually set in preferences, to replace the default `~/.kube/config`

It would be nice if Podman Desktop could support having multiple files in KUBECONFIG:

https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/