### PR TITLE
fix: fix loader not centered horizontally

### DIFF
--- a/packages/renderer/src/Loader.svelte
+++ b/packages/renderer/src/Loader.svelte
@@ -82,7 +82,7 @@ window.events.receive('starting-extensions', (value: string) => {
 </script>
 
 {#if !systemReady}
-  <main class="min-h-screen flex flex-col h-screen">
+  <main class="min-h-screen w-screen flex flex-col h-screen">
     <div class="min-h-full min-w-full flex flex-col">
       <div class="pf-c-empty-state h-full">
         <div class="pf-c-empty-state__content">


### PR DESCRIPTION

### What does this PR do?
Loader not centered

### Screenshot/screencast of this PR

![image](https://github.com/containers/podman-desktop/assets/436777/2c1bf96c-1b3a-4f9c-84b6-a5bccc89f32f)



### What issues does this PR fix or reference?


### How to test this PR?

you can remove assignment of systemReady in Loader.svelte to always see the loading screen