### PR TITLE
chore: bump version to 1.2.1

### DIFF
--- a/.flatpak-appdata.xml
+++ b/.flatpak-appdata.xml
@@ -42,6 +42,7 @@
   </provides>
   <update_contact>fbenoit_at_redhat_com</update_contact>
   <releases>
+    <release version="1.2.1" date="2023-07-19"/>
     <release version="1.2.0" date="2023-07-12"/>
     <release version="1.1.0" date="2023-06-08"/>
     <release version="1.0.1" date="2023-05-22"/>

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -49,8 +49,9 @@ body:
       label: Version
       description: What version of the software are you running?
       options:
-        - "1.2.0"
+        - "1.2.1"
         - "next (development version)"
+        - "1.2.0"
         - "1.1.0"
         - "1.0.x"
         - "0.15.0"


### PR DESCRIPTION
chore: bump version to 1.2.1

### What does this PR do?

Bumps the version up to 1.2.1

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

### How to test this PR?

<!-- Please explain steps to reproduce -->

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
