### PR TITLE
fix: fix chocolatey update module for workflow

### DIFF
--- a/.github/workflows/publish-to-chocolatey.yaml
+++ b/.github/workflows/publish-to-chocolatey.yaml
@@ -65,7 +65,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install the Chocolatey Automatic Package Updater Module
-        run: cinst au
+        run: choco install au -y
       - name: Build the Podman Desktop chocolatey Package by making sure we're using the latest release
         working-directory: ./.chocolatey/podman-desktop
         run: |


### PR DESCRIPTION
### What does this PR do?

Updates the workflow to use `choco install au -y` as cinst au does not
work anymore.

See the build here: https://github.com/containers/podman-desktop/actions/runs/5533511304/jobs/10097147260

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

N/A

### What issues does this PR fix or reference?

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

See the build here: https://github.com/containers/podman-desktop/actions/runs/5533511304/jobs/10097147260

### How to test this PR?

<!-- Please explain steps to reproduce -->

N/A

Signed-off-by: Charlie Drage <charlie@charliedrage.com>

### What does this PR do?

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

### How to test this PR?

<!-- Please explain steps to reproduce -->
