### PR TITLE
feat: extend podman start/stop to receive custom lifecyclecontext

### DIFF
--- a/extensions/podman/src/extension.spec.ts
+++ b/extensions/podman/src/extension.spec.ts
@@ -232,7 +232,7 @@ test('if a machine failed to start with a wsl distro not found error but the ski
   spyExecPromise.mockImplementation(() => {
     return Promise.reject(new Error('wsl bootstrap script failed: exit status 0xffffffff'));
   });
-  await expect(extension.startMachine(provider, machineInfo, undefined, true)).rejects.toThrow(
+  await expect(extension.startMachine(provider, machineInfo, undefined, undefined, true)).rejects.toThrow(
     'wsl bootstrap script failed: exit status 0xffffffff',
   );
   expect(extensionApi.window.showInformationMessage).not.toHaveBeenCalled();


### PR DESCRIPTION
### What does this PR do?

This PR allows to pass a custom lifecycle context to the podman start/stop so to being able to retrieve logs in the details page

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

this is part of the splitting of #1923 

### How to test this PR?

N/A
