### PR TITLE
fix: add timeout checking docker socket

### DIFF
--- a/extensions/podman/src/warnings.ts
+++ b/extensions/podman/src/warnings.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2022 Red Hat, Inc.
+ * Copyright (C) 2022-2023 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -67,19 +67,23 @@ export async function isDisguisedPodman(): Promise<boolean> {
   };
 
   return new Promise<boolean>(resolve => {
-    const req = http.get(podmanPingUrl, res => {
-      res.on('data', () => {
-        // do nothing
-      });
+    const req = http
+      .get(podmanPingUrl, res => {
+        res.on('data', () => {
+          // do nothing
+        });
 
-      res.on('end', () => {
-        if (res.statusCode === 200) {
-          resolve(true);
-        } else {
-          resolve(false);
-        }
+        res.on('end', () => {
+          if (res.statusCode === 200) {
+            resolve(true);
+          } else {
+            resolve(false);
+          }
+        });
+      })
+      .setTimeout(5000, function () {
+        resolve(false);
       });
-    });
 
     req.once('error', err => {
       console.debug('Error while pinging docker as podman', err);


### PR DESCRIPTION
### What does this PR do?

Narrowed issue #3272 down to a missing timeout in isDisguisedPodman(). It looks like the socket is there but never responds, which means that we never allow the Podman extension to start. From googling Node HTTP does not appear to have any default timeout (and if it does, I've waited minutes).

Added a 5s timeout. Maybe there is a better values, but this gives it a chance even on a slower machine, and the 5s delay for full startup isn't noticeable.

I presume we should put timeouts on most (all?) of our HTTP requests just in case we ever hit similar problems? I could take a pass via another PR.

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

Fixes #3272.

### How to test this PR?

Confirm Podman extension starts up normally.