### PR TITLE
feat: add "deploy to kubernetes" button for compose group

### DIFF
--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -278,3 +278,26 @@ test('deleteContainersByLabel should succeed successfully if project name is pro
   // Expect deleteContainer tohave been called 3 times
   expect(deleteContainer).toHaveBeenCalledTimes(3);
 });
+
+test('test listSimpleContainersByLabel with compose label', async () => {
+  const engine = {
+    // Fake that we have 3 containers of the same project
+    listSimpleContainers: vi
+      .fn()
+      .mockResolvedValue([
+        fakeContainerWithComposeProject,
+        fakeContainerWithComposeProject,
+        fakeContainerWithComposeProject,
+        fakeContainer,
+      ]),
+    listPods: vi.fn().mockResolvedValue([]),
+  };
+  vi.spyOn(containerRegistry, 'getMatchingEngine').mockReturnValue(engine as unknown as Dockerode);
+  vi.spyOn(containerRegistry, 'listSimpleContainers').mockReturnValue(engine.listSimpleContainers());
+
+  // List all containers with the label 'com.docker.compose.project' and value 'project1'
+  const result = await containerRegistry.listSimpleContainersByLabel('com.docker.compose.project', 'project1');
+
+  // We expect ONLY to return 3 since the last container does not have the correct label.
+  expect(result).toHaveLength(3);
+});

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -265,6 +265,18 @@ export class ContainerProviderRegistry {
     return flatttenedContainers;
   }
 
+  // listSimpleContainers by matching label and key
+  async listSimpleContainersByLabel(label: string, key: string): Promise<SimpleContainerInfo[]> {
+    // Get all the containers using listSimpleContainers
+    const containers = await this.listSimpleContainers();
+
+    // Find all the containers that match the label + key
+    return containers.filter(container => {
+      const labels = container.Labels;
+      return labels && labels[label] === key;
+    });
+  }
+
   async listContainers(): Promise<ContainerInfo[]> {
     let telemetryOptions = {};
     const containers = await Promise.all(

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -688,6 +688,14 @@ export class PluginSystem {
     this.ipcHandle('container-provider-registry:listContainers', async (): Promise<ContainerInfo[]> => {
       return containerProviderRegistry.listContainers();
     });
+
+    this.ipcHandle(
+      'container-provider-registry:listSimpleContainersByLabel',
+      async (_listener, label: string, key: string): Promise<SimpleContainerInfo[]> => {
+        return containerProviderRegistry.listSimpleContainersByLabel(label, key);
+      },
+    );
+
     this.ipcHandle('container-provider-registry:listSimpleContainers', async (): Promise<SimpleContainerInfo[]> => {
       return containerProviderRegistry.listSimpleContainers();
     });

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -23,7 +23,11 @@
 import type * as containerDesktopAPI from '@podman-desktop/api';
 import { contextBridge, ipcRenderer } from 'electron';
 import EventEmitter from 'events';
-import type { ContainerCreateOptions, ContainerInfo } from '../../main/src/plugin/api/container-info';
+import type {
+  ContainerCreateOptions,
+  ContainerInfo,
+  SimpleContainerInfo,
+} from '../../main/src/plugin/api/container-info';
 import type { ContributionInfo } from '../../main/src/plugin/api/contribution-info';
 import type { ImageInfo } from '../../main/src/plugin/api/image-info';
 import type { VolumeInspectInfo, VolumeListInfo } from '../../main/src/plugin/api/volume-info';
@@ -177,6 +181,13 @@ function initExposure(): void {
   contextBridge.exposeInMainWorld('listContainers', async (): Promise<ContainerInfo[]> => {
     return ipcInvoke('container-provider-registry:listContainers');
   });
+
+  contextBridge.exposeInMainWorld(
+    'listSimpleContainersByLabel',
+    async (label: string, key: string): Promise<SimpleContainerInfo[]> => {
+      return ipcInvoke('container-provider-registry:listSimpleContainersByLabel', label, key);
+    },
+  );
 
   contextBridge.exposeInMainWorld('listImages', async (): Promise<ImageInfo[]> => {
     return ipcInvoke('container-provider-registry:listImages');

--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -129,7 +129,15 @@ window.events?.receive('display-troubleshooting', () => {
         <Route path="/deploy-to-kube/:resourceId/:engineId/*" breadcrumb="Deploy to Kubernetes" let:meta>
           <DeployPodToKube
             resourceId="{decodeURI(meta.params.resourceId)}"
-            engineId="{decodeURI(meta.params.engineId)}" />
+            engineId="{decodeURI(meta.params.engineId)}"
+            type="container" />
+        </Route>
+        <!-- Same DeployPodToKube route, but instead we pass in the compose group name, then redirect to DeployPodToKube -->
+        <Route path="/compose/deploy-to-kube/:composeGroupName/:engineId/*" breadcrumb="Deploy to Kubernetes" let:meta>
+          <DeployPodToKube
+            resourceId="{decodeURI(meta.params.composeGroupName)}"
+            engineId="{decodeURI(meta.params.engineId)}"
+            type="compose" />
         </Route>
         <Route path="/compose/:name/:engineId/*" breadcrumb="Compose Details" let:meta navigationHint="details">
           <ComposeDetails composeName="{decodeURI(meta.params.name)}" engineId="{decodeURI(meta.params.engineId)}" />

--- a/packages/renderer/src/lib/ContainerList.svelte
+++ b/packages/renderer/src/lib/ContainerList.svelte
@@ -532,6 +532,7 @@ function errorCallback(container: ContainerInfoUI, errorMessage: string): void {
                       status: containerGroup.status,
                       name: containerGroup.name,
                       engineId: containerGroup.engineId,
+                      engineType: containerGroup.engineType,
                       containers: [],
                     }}"
                     dropdownMenu="{true}" />

--- a/packages/renderer/src/lib/compose/ComposeActions.svelte
+++ b/packages/renderer/src/lib/compose/ComposeActions.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
-import { faFileCode, faTrash, faPlay, faStop, faArrowsRotate } from '@fortawesome/free-solid-svg-icons';
+import { faFileCode, faTrash, faPlay, faStop, faArrowsRotate, faRocket } from '@fortawesome/free-solid-svg-icons';
 import type { ComposeInfoUI } from './ComposeInfoUI';
 import { router } from 'tinro';
 import ListItemButtonIcon from '../ui/ListItemButtonIcon.svelte';
 import DropdownMenu from '../ui/DropdownMenu.svelte';
 import FlatMenu from '../ui/FlatMenu.svelte';
+import { router } from 'tinro';
 
 export let compose: ComposeInfoUI;
 export let dropdownMenu = false;
@@ -58,6 +59,10 @@ async function restartCompose(composeInfoUI: ComposeInfoUI) {
   }
 }
 
+function deployToKubernetes(): void {
+  router.goto(`/compose/deploy-to-kube/${compose.name}/${compose.engineId}`);
+}
+
 function openGenerateKube(): void {
   router.goto(`/compose/${encodeURI(compose.name)}/${encodeURI(compose.engineId)}/kube`);
 }
@@ -98,14 +103,18 @@ if (dropdownMenu) {
 
 <!-- If dropdownMenu is true, use it, otherwise just show the regular buttons -->
 <svelte:component this="{actionsStyle}">
-  {#if !detailed}
+  <ListItemButtonIcon
+    title="Deploy to Kubernetes"
+    onClick="{() => deployToKubernetes()}"
+    menu="{dropdownMenu}"
+    detailed="{detailed}"
+    icon="{faRocket}" />
     <ListItemButtonIcon
       title="Generate Kube"
       onClick="{() => openGenerateKube()}"
       menu="{dropdownMenu}"
       detailed="{detailed}"
       icon="{faFileCode}" />
-  {/if}
   <ListItemButtonIcon
     title="Restart Compose"
     onClick="{() => restartCompose(compose)}"

--- a/packages/renderer/src/lib/compose/ComposeActions.svelte
+++ b/packages/renderer/src/lib/compose/ComposeActions.svelte
@@ -5,7 +5,6 @@ import { router } from 'tinro';
 import ListItemButtonIcon from '../ui/ListItemButtonIcon.svelte';
 import DropdownMenu from '../ui/DropdownMenu.svelte';
 import FlatMenu from '../ui/FlatMenu.svelte';
-import { router } from 'tinro';
 
 export let compose: ComposeInfoUI;
 export let dropdownMenu = false;
@@ -75,6 +74,8 @@ if (dropdownMenu) {
 } else {
   actionsStyle = FlatMenu;
 }
+
+console.log('compose: ', compose);
 </script>
 
 <ListItemButtonIcon
@@ -107,14 +108,15 @@ if (dropdownMenu) {
     title="Deploy to Kubernetes"
     onClick="{() => deployToKubernetes()}"
     menu="{dropdownMenu}"
+    hidden="{!(compose.engineType === 'podman')}"
     detailed="{detailed}"
     icon="{faRocket}" />
-    <ListItemButtonIcon
-      title="Generate Kube"
-      onClick="{() => openGenerateKube()}"
-      menu="{dropdownMenu}"
-      detailed="{detailed}"
-      icon="{faFileCode}" />
+  <ListItemButtonIcon
+    title="Generate Kube"
+    onClick="{() => openGenerateKube()}"
+    menu="{dropdownMenu}"
+    detailed="{detailed}"
+    icon="{faFileCode}" />
   <ListItemButtonIcon
     title="Restart Compose"
     onClick="{() => restartCompose(compose)}"

--- a/packages/renderer/src/lib/compose/ComposeDetails.svelte
+++ b/packages/renderer/src/lib/compose/ComposeDetails.svelte
@@ -22,6 +22,9 @@ let composeUnsubscribe: Unsubscriber;
 
 let compose: ComposeInfoUI;
 
+// Assume that the engine type is podman until we find a compose group that is docker
+let engineType: 'docker' | 'podman' = 'podman';
+
 onMount(() => {
   // We will use the containersInfos store to get every container that matches
   // the label com.docker.compose.project={composeName}
@@ -55,11 +58,17 @@ onMount(() => {
       return containerUtils.getContainerInfoUI(container);
     });
 
+    // Get the engine type from the first container in the list (if it exists)
+    if (convertedContainers.length > 0) {
+      engineType = convertedContainers[0].engineType;
+    }
+
     // Make sure we update the compose object with the name, status, engineID, containers, etc.
     // or else logging will not appear correctly when loading (it'll see empty containers..)
     compose = {
       name: composeName,
       engineId: engineId,
+      engineType: engineType,
       status: status,
       containers: convertedContainers,
     };

--- a/packages/renderer/src/lib/compose/ComposeInfoUI.ts
+++ b/packages/renderer/src/lib/compose/ComposeInfoUI.ts
@@ -20,6 +20,7 @@ import type { ContainerInfoUI } from '../container/ContainerInfoUI';
 
 export interface ComposeInfoUI {
   engineId: string;
+  engineType: 'podman' | 'docker';
   name: string;
   status: string;
   actionInProgress?: boolean;

--- a/packages/renderer/src/lib/container/ContainerInfoUI.ts
+++ b/packages/renderer/src/lib/container/ContainerInfoUI.ts
@@ -35,6 +35,7 @@ export interface ContainerGroupPartInfoUI {
   id?: string;
   engineId?: string;
   engineName?: string;
+  engineType?: 'podman' | 'docker';
   shortId?: string;
   status?: string;
   humanCreationDate?: string;

--- a/packages/renderer/src/lib/container/container-utils.ts
+++ b/packages/renderer/src/lib/container/container-utils.ts
@@ -157,6 +157,7 @@ export class ContainerUtils {
         name: composeProject,
         type: ContainerGroupInfoTypeUI.COMPOSE,
         engineId: containerInfo.engineId,
+        engineType: containerInfo.engineType,
       };
     }
 
@@ -169,6 +170,7 @@ export class ContainerUtils {
         id: podInfo.id,
         status: (podInfo.status || '').toUpperCase(),
         engineId: containerInfo.engineId,
+        engineType: containerInfo.engineType,
       };
     }
 
@@ -177,6 +179,7 @@ export class ContainerUtils {
       name: this.getName(containerInfo),
       type: ContainerGroupInfoTypeUI.STANDALONE,
       status: (containerInfo.Status || '').toUpperCase(),
+      engineType: containerInfo.engineType,
     };
   }
 
@@ -198,6 +201,7 @@ export class ContainerUtils {
             id: group.id,
             status: group.status,
             engineId: group.engineId,
+            engineType: group.engineType,
             containers: [],
           });
         }

--- a/packages/renderer/src/lib/pod/DeployPodToKube.spec.ts
+++ b/packages/renderer/src/lib/pod/DeployPodToKube.spec.ts
@@ -36,6 +36,7 @@ const kubernetesCreatePodMock = vi.fn();
 const kubernetesCreateIngressMock = vi.fn();
 const kubernetesCreateServiceMock = vi.fn();
 const kubernetesIsAPIGroupSupported = vi.fn();
+const listSimpleContainersByLabelMock = vi.fn();
 
 beforeEach(() => {
   Object.defineProperty(window, 'generatePodmanKube', {
@@ -69,6 +70,9 @@ beforeEach(() => {
   Object.defineProperty(window, 'telemetryTrack', {
     value: telemetryTrackMock,
   });
+  Object.defineProperty(window, 'listSimpleContainersByLabel', {
+    value: listSimpleContainersByLabelMock,
+  });
 
   // podYaml with volumes
   const podYaml = {
@@ -97,6 +101,18 @@ beforeEach(() => {
     },
   };
   generatePodmanKubeMock.mockResolvedValue(jsYaml.dump(podYaml));
+
+  // Mock listSimpleContainersByLabel with a SimpleContainerInfo[] array of 1 container
+  const simpleContainerInfo = {
+    id: '1234',
+    name: 'hello',
+    image: 'hello-world',
+    status: 'running',
+    labels: {
+      'com.docker.compose.project': 'hello',
+    },
+  };
+  listSimpleContainersByLabelMock.mockResolvedValue([simpleContainerInfo]);
 });
 
 afterEach(() => {
@@ -182,6 +198,33 @@ test('When deploying a pod, volumes should not be added (they are deleted by pod
   await fireEvent.click(createButton);
 
   // Expect kubernetesCreatePod to be called with default namespace and a modified bodyPod with volumes removed
+  await waitFor(() =>
+    expect(kubernetesCreatePodMock).toBeCalledWith('default', {
+      metadata: { name: 'hello' },
+      spec: {
+        containers: [
+          {
+            name: 'hello',
+            image: 'hello-world',
+            imagePullPolicy: 'IfNotPresent',
+          },
+        ],
+      },
+    }),
+  );
+});
+
+// Test deploying a compose group of containers
+test('Test deploying a group of compose containers with type compose still functions the same as normal deploy', async () => {
+  await waitRender({ type: 'compose' });
+  const createButton = screen.getByRole('button', { name: 'Deploy' });
+  expect(createButton).toBeInTheDocument();
+  expect(createButton).toBeEnabled();
+
+  // Press the deploy button
+  await fireEvent.click(createButton);
+
+  // Expect to return the correct create pod yaml
   await waitFor(() =>
     expect(kubernetesCreatePodMock).toBeCalledWith('default', {
       metadata: { name: 'hello' },


### PR DESCRIPTION
feat: add "deploy to kubernetes" button for compose group

### What does this PR do?

* Adds button to Deploy to Kubernetes for a Compose group
* Utilizes DeployPodToKube same code, but added a "compose" type
* Adds a new function for listSimpleContainersByLabel for an easier way
  to find containers by label that you only need the name / id of.

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

https://github.com/containers/podman-desktop/assets/6422176/1ce57225-3422-4d36-8d09-b70a2825869f


### What issues does this PR fix or reference?

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

Closes https://github.com/containers/podman-desktop/issues/3104

### How to test this PR?

1. Deploy a Docker Compose example
2. Click on the "hamburger" button to bring up the Deploy To Kubernetes
   button.
3. Deploy to Kubernetes and make sure it's deployed correctly.

<!-- Please explain steps to reproduce -->

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
