### PR TITLE
feat: extend context and contextkey service

### DIFF
--- a/packages/renderer/src/lib/context/context.spec.ts
+++ b/packages/renderer/src/lib/context/context.spec.ts
@@ -1,0 +1,38 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { expect, test } from 'vitest';
+import { ContextUI } from './context';
+
+test('check that value is correctly returned', async () => {
+  const context = new ContextUI(0);
+  context.setValue('key', 'value');
+
+  const value = context.getValue('key');
+  expect(value).toBe('value');
+});
+
+test('check that value of a dotted key is correctly returned', async () => {
+  const context = new ContextUI(0);
+  context.setValue('key', {
+    first: 'value',
+  });
+
+  const value = context.getValue('key.first');
+  expect(value).toBe('value');
+});

--- a/packages/renderer/src/lib/context/context.ts
+++ b/packages/renderer/src/lib/context/context.ts
@@ -59,11 +59,36 @@ export class ContextUI implements IContext {
   }
 
   getValue<T>(key: string): T | undefined {
-    const ret = this._value[key];
+    const ret = this._value[key] || this.getDottedKeyValue(key);
     if (typeof ret === 'undefined' && this._parent) {
-      return this._parent.getValue<T>(key);
+      return this._parent.getValue<T>(key) || this._parent.getDottedKeyValue<T>(key);
     }
     return ret;
+  }
+
+  /**
+   * A key could represent a complex value like the property of an object
+   *
+   * E.g command.status - this function retrieves the value of "command" from the context
+   * and look for its "status" property value
+   *
+   * @param key the key
+   * @param context the context where to look for the value
+   * @returns the value of the complex key or undefined
+   */
+  getDottedKeyValue<T>(key: string): T | undefined {
+    if (!key) {
+      return undefined;
+    }
+    const bits = key.split('.');
+    let contextValue = this.getValue<T>(bits[0]);
+    if (contextValue === undefined) {
+      return undefined;
+    }
+    for (let i = 1; i < bits.length; i++) {
+      contextValue = contextValue[bits[i]];
+    }
+    return contextValue;
   }
 
   updateParent(parent: ContextUI): void {

--- a/packages/renderer/src/lib/context/contextKey.spec.ts
+++ b/packages/renderer/src/lib/context/contextKey.spec.ts
@@ -15,13 +15,21 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+// based on https://github.com/microsoft/vscode/blob/76415ef0b1f60e0479bdfee173c1a4f97e785b52/src/vs/platform/contextkey/test/common/contextkey.test.ts
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
+/* eslint-disable sonarjs/no-redundant-boolean */
+/* eslint-disable sonarjs/no-identical-expressions */
 
 import assert from 'assert';
 import { suite, test } from 'vitest';
 
-import { ContextKeyExpr } from './contextKey.js';
+import { ContextKeyExpr, implies, type ContextKeyExpression } from './contextKey.js';
+import { isLinux, isMac, isWindows } from '../../../../main/src/util.js';
 
 function createContext(ctx: any) {
   return {
@@ -31,16 +39,162 @@ function createContext(ctx: any) {
   };
 }
 
+function strImplies(p0: string, q0: string): boolean {
+  const p = ContextKeyExpr.deserialize(p0)!;
+  const q = ContextKeyExpr.deserialize(q0)!;
+  return implies(p, q);
+}
+
 suite('ContextKeyExpr', () => {
   test('ContextKeyExpr.equals', () => {
-    const a = ContextKeyExpr.and(ContextKeyExpr.equals('b1', 'bb1'), ContextKeyExpr.equals('b2', 'bb2'))!;
-    const b = ContextKeyExpr.and(ContextKeyExpr.equals('b2', 'bb2'), ContextKeyExpr.equals('b1', 'bb1'))!;
+    const a = ContextKeyExpr.and(
+      ContextKeyExpr.has('a1'),
+      ContextKeyExpr.and(ContextKeyExpr.has('and.a')),
+      ContextKeyExpr.has('a2'),
+      ContextKeyExpr.regex('d3', /d.*/),
+      ContextKeyExpr.regex('d4', /\*\*3*/),
+      ContextKeyExpr.equals('b1', 'bb1'),
+      ContextKeyExpr.equals('b2', 'bb2'),
+      ContextKeyExpr.notEquals('c1', 'cc1'),
+      ContextKeyExpr.notEquals('c2', 'cc2'),
+      ContextKeyExpr.not('d1'),
+      ContextKeyExpr.not('d2'),
+    )!;
+    const b = ContextKeyExpr.and(
+      ContextKeyExpr.equals('b2', 'bb2'),
+      ContextKeyExpr.notEquals('c1', 'cc1'),
+      ContextKeyExpr.not('d1'),
+      ContextKeyExpr.regex('d4', /\*\*3*/),
+      ContextKeyExpr.notEquals('c2', 'cc2'),
+      ContextKeyExpr.has('a2'),
+      ContextKeyExpr.equals('b1', 'bb1'),
+      ContextKeyExpr.regex('d3', /d.*/),
+      ContextKeyExpr.has('a1'),
+      ContextKeyExpr.and(ContextKeyExpr.equals('and.a', true)),
+      ContextKeyExpr.not('d2'),
+    )!;
     assert(a.equals(b), 'expressions should be equal');
   });
 
-  test('ContextKeyEqualsExpr', () => {
-    const a_cequalsb = ContextKeyExpr.deserialize('a == b')!;
-    assert.strictEqual(a_cequalsb.evaluate(createContext({ a: 'b' })), true);
+  test('issue #134942: Equals in comparator expressions', () => {
+    function testEquals(expr: ContextKeyExpression | undefined, str: string): void {
+      const deserialized = ContextKeyExpr.deserialize(str);
+      assert.ok(expr);
+      assert.ok(deserialized);
+      assert.strictEqual(expr.equals(deserialized), true, str);
+    }
+    testEquals(ContextKeyExpr.greater('value', 0), 'value > 0');
+    testEquals(ContextKeyExpr.greaterEquals('value', 0), 'value >= 0');
+    testEquals(ContextKeyExpr.smaller('value', 0), 'value < 0');
+    testEquals(ContextKeyExpr.smallerEquals('value', 0), 'value <= 0');
+  });
+
+  test('normalize', () => {
+    const key1IsTrue = ContextKeyExpr.equals('key1', true);
+    const key1IsNotFalse = ContextKeyExpr.notEquals('key1', false);
+    const key1IsFalse = ContextKeyExpr.equals('key1', false);
+    const key1IsNotTrue = ContextKeyExpr.notEquals('key1', true);
+
+    assert.ok(key1IsTrue.equals(ContextKeyExpr.has('key1')));
+    assert.ok(key1IsNotFalse.equals(ContextKeyExpr.has('key1')));
+    assert.ok(key1IsFalse.equals(ContextKeyExpr.not('key1')));
+    assert.ok(key1IsNotTrue.equals(ContextKeyExpr.not('key1')));
+  });
+
+  test('evaluate', () => {
+    const context = createContext({
+      a: true,
+      b: false,
+      c: '5',
+      d: 'd',
+    });
+    function testExpression(expr: string, expected: boolean): void {
+      const rules = ContextKeyExpr.deserialize(expr);
+      assert.strictEqual(rules!.evaluate(context), expected, expr);
+    }
+    function testBatch(expr: string, value: any): void {
+      /* eslint-disable eqeqeq */
+      testExpression(expr, !!value);
+      testExpression(expr + ' == true', !!value);
+      testExpression(expr + ' != true', !value);
+      testExpression(expr + ' == false', !value);
+      testExpression(expr + ' != false', !!value);
+      testExpression(expr + ' == 5', value == <any>'5');
+      testExpression(expr + ' != 5', value != <any>'5');
+      testExpression('!' + expr, !value);
+      testExpression(expr + ' =~ /d.*/', /d.*/.test(value));
+      testExpression(expr + ' =~ /D/i', /D/i.test(value));
+      /* eslint-enable eqeqeq */
+    }
+
+    testBatch('a', true);
+    testBatch('b', false);
+    testBatch('c', '5');
+    testBatch('d', 'd');
+    testBatch('z', undefined);
+
+    testExpression('true', true);
+    testExpression('false', false);
+    testExpression('a && !b', true && !false);
+    testExpression('a && b', true && false);
+    testExpression('a && !b && c == 5', true && !false && '5' === '5');
+    testExpression('d =~ /e.*/', false);
+
+    // precedence test: false && true || true === true because && is evaluated first
+    testExpression('b && a || a', true);
+
+    testExpression('a || b', true);
+    testExpression('b || b', false);
+    testExpression('b && a || a && b', false);
+  });
+
+  test('negate', () => {
+    function testNegate(expr: string, expected: string): void {
+      const actual = ContextKeyExpr.deserialize(expr)!.negate().serialize();
+      assert.strictEqual(actual, expected);
+    }
+    testNegate('true', 'false');
+    testNegate('false', 'true');
+    testNegate('a', '!a');
+    testNegate('a && b || c', '!a && !c || !b && !c');
+    testNegate('a && b || c || d', '!a && !c && !d || !b && !c && !d');
+    testNegate('!a && !b || !c && !d', 'a && c || a && d || b && c || b && d');
+    testNegate(
+      '!a && !b || !c && !d || !e && !f',
+      'a && c && e || a && c && f || a && d && e || a && d && f || b && c && e || b && c && f || b && d && e || b && d && f',
+    );
+  });
+
+  test('false, true', () => {
+    function testNormalize(expr: string, expected: string): void {
+      const actual = ContextKeyExpr.deserialize(expr)!.serialize();
+      assert.strictEqual(actual, expected);
+    }
+    testNormalize('true', 'true');
+    testNormalize('!true', 'false');
+    testNormalize('false', 'false');
+    testNormalize('!false', 'true');
+    testNormalize('a && true', 'a');
+    testNormalize('a && false', 'false');
+    testNormalize('a || true', 'true');
+    testNormalize('a || false', 'a');
+    testNormalize('isMac', isMac() ? 'true' : 'false');
+    testNormalize('isLinux', isLinux() ? 'true' : 'false');
+    testNormalize('isWindows', isWindows() ? 'true' : 'false');
+  });
+
+  test('issue #101015: distribute OR', () => {
+    function t(expr1: string, expr2: string, expected: string | undefined): void {
+      const e1 = ContextKeyExpr.deserialize(expr1);
+      const e2 = ContextKeyExpr.deserialize(expr2);
+      const actual = ContextKeyExpr.and(e1, e2)?.serialize();
+      assert.strictEqual(actual, expected);
+    }
+    t('a', 'b', 'a && b');
+    t('a || b', 'c', 'a && c || b && c');
+    t('a || b', 'c || d', 'a && c || a && d || b && c || b && d');
+    t('a || b', 'c && d', 'a && c && d || b && c && d');
+    t('a || b', 'c && d || e', 'a && e || b && e || a && c && d || b && c && d');
   });
 
   test('ContextKeyInExpr', () => {
@@ -71,5 +225,155 @@ suite('ContextKeyExpr', () => {
     assert.strictEqual(aNotInB.evaluate(createContext({ a: 'x', b: { x: false } })), false);
     assert.strictEqual(aNotInB.evaluate(createContext({ a: 'x', b: { x: true } })), false);
     assert.strictEqual(aNotInB.evaluate(createContext({ a: 'prototype', b: {} })), true);
+  });
+
+  test('issue #106524: distributing AND should normalize', () => {
+    const actual = ContextKeyExpr.and(
+      ContextKeyExpr.or(ContextKeyExpr.has('a'), ContextKeyExpr.has('b')),
+      ContextKeyExpr.has('c'),
+    );
+    const expected = ContextKeyExpr.or(
+      ContextKeyExpr.and(ContextKeyExpr.has('a'), ContextKeyExpr.has('c')),
+      ContextKeyExpr.and(ContextKeyExpr.has('b'), ContextKeyExpr.has('c')),
+    );
+    assert.strictEqual(actual!.equals(expected!), true);
+  });
+
+  test('issue #129625: Removes duplicated terms in OR expressions', () => {
+    const expr = ContextKeyExpr.or(ContextKeyExpr.has('A'), ContextKeyExpr.has('B'), ContextKeyExpr.has('A'))!;
+    assert.strictEqual(expr.serialize(), 'A || B');
+  });
+
+  test('Resolves true constant OR expressions', () => {
+    const expr = ContextKeyExpr.or(ContextKeyExpr.has('A'), ContextKeyExpr.not('A'))!;
+    assert.strictEqual(expr.serialize(), 'true');
+  });
+
+  test('Resolves false constant AND expressions', () => {
+    const expr = ContextKeyExpr.and(ContextKeyExpr.has('A'), ContextKeyExpr.not('A'))!;
+    assert.strictEqual(expr.serialize(), 'false');
+  });
+
+  test('issue #129625: Removes duplicated terms in AND expressions', () => {
+    const expr = ContextKeyExpr.and(ContextKeyExpr.has('A'), ContextKeyExpr.has('B'), ContextKeyExpr.has('A'))!;
+    assert.strictEqual(expr.serialize(), 'A && B');
+  });
+
+  test('issue #129625: Remove duplicated terms when negating', () => {
+    const expr = ContextKeyExpr.and(
+      ContextKeyExpr.has('A'),
+      ContextKeyExpr.or(ContextKeyExpr.has('B1'), ContextKeyExpr.has('B2')),
+    )!;
+    assert.strictEqual(expr.serialize(), 'A && B1 || A && B2');
+    assert.strictEqual(expr.negate()!.serialize(), '!A || !A && !B1 || !A && !B2 || !B1 && !B2');
+    assert.strictEqual(expr.negate()!.negate()!.serialize(), 'A && B1 || A && B2');
+    assert.strictEqual(expr.negate()!.negate()!.negate()!.serialize(), '!A || !A && !B1 || !A && !B2 || !B1 && !B2');
+  });
+
+  test('issue #129625: remove redundant terms in OR expressions', () => {
+    assert.strictEqual(strImplies('a && b', 'a'), true);
+    assert.strictEqual(strImplies('a', 'a && b'), false);
+  });
+
+  test('implies', () => {
+    assert.strictEqual(strImplies('a', 'a'), true);
+    assert.strictEqual(strImplies('a', 'a || b'), true);
+    assert.strictEqual(strImplies('a', 'a && b'), false);
+    assert.strictEqual(strImplies('a', 'a && b || a && c'), false);
+    assert.strictEqual(strImplies('a && b', 'a'), true);
+    assert.strictEqual(strImplies('a && b', 'b'), true);
+    assert.strictEqual(strImplies('a && b', 'a && b || c'), true);
+    assert.strictEqual(strImplies('a || b', 'a || c'), false);
+    assert.strictEqual(strImplies('a || b', 'a || b'), true);
+    assert.strictEqual(strImplies('a && b', 'a && b'), true);
+    assert.strictEqual(strImplies('a || b', 'a || b || c'), true);
+    assert.strictEqual(strImplies('c && a && b', 'c && a'), true);
+  });
+
+  test('Greater, GreaterEquals, Smaller, SmallerEquals evaluate', () => {
+    function checkEvaluate(expr: string, ctx: any, expected: any): void {
+      const _expr = ContextKeyExpr.deserialize(expr)!;
+      assert.strictEqual(_expr.evaluate(createContext(ctx)), expected);
+    }
+
+    checkEvaluate('a > 1', {}, false);
+    checkEvaluate('a > 1', { a: 0 }, false);
+    checkEvaluate('a > 1', { a: 1 }, false);
+    checkEvaluate('a > 1', { a: 2 }, true);
+    checkEvaluate('a > 1', { a: '0' }, false);
+    checkEvaluate('a > 1', { a: '1' }, false);
+    checkEvaluate('a > 1', { a: '2' }, true);
+    checkEvaluate('a > 1', { a: 'a' }, false);
+
+    checkEvaluate('a > 10', { a: 2 }, false);
+    checkEvaluate('a > 10', { a: 11 }, true);
+    checkEvaluate('a > 10', { a: '11' }, true);
+    checkEvaluate('a > 10', { a: '2' }, false);
+    checkEvaluate('a > 10', { a: '11' }, true);
+
+    checkEvaluate('a > 1.1', { a: 1 }, false);
+    checkEvaluate('a > 1.1', { a: 2 }, true);
+    checkEvaluate('a > 1.1', { a: 11 }, true);
+    checkEvaluate('a > 1.1', { a: '1.1' }, false);
+    checkEvaluate('a > 1.1', { a: '2' }, true);
+    checkEvaluate('a > 1.1', { a: '11' }, true);
+
+    checkEvaluate('a > b', { a: 'b' }, false);
+    checkEvaluate('a > b', { a: 'c' }, false);
+    checkEvaluate('a > b', { a: 1000 }, false);
+
+    checkEvaluate('a >= 2', { a: '1' }, false);
+    checkEvaluate('a >= 2', { a: '2' }, true);
+    checkEvaluate('a >= 2', { a: '3' }, true);
+
+    checkEvaluate('a < 2', { a: '1' }, true);
+    checkEvaluate('a < 2', { a: '2' }, false);
+    checkEvaluate('a < 2', { a: '3' }, false);
+
+    checkEvaluate('a <= 2', { a: '1' }, true);
+    checkEvaluate('a <= 2', { a: '2' }, true);
+    checkEvaluate('a <= 2', { a: '3' }, false);
+  });
+
+  test('Greater, GreaterEquals, Smaller, SmallerEquals negate', () => {
+    function checkNegate(expr: string, expected: string): void {
+      const a = ContextKeyExpr.deserialize(expr)!;
+      const b = a.negate();
+      assert.strictEqual(b.serialize(), expected);
+    }
+
+    checkNegate('a > 1', 'a <= 1');
+    checkNegate('a > 1.1', 'a <= 1.1');
+    checkNegate('a > b', 'a <= b');
+
+    checkNegate('a >= 1', 'a < 1');
+    checkNegate('a >= 1.1', 'a < 1.1');
+    checkNegate('a >= b', 'a < b');
+
+    checkNegate('a < 1', 'a >= 1');
+    checkNegate('a < 1.1', 'a >= 1.1');
+    checkNegate('a < b', 'a >= b');
+
+    checkNegate('a <= 1', 'a > 1');
+    checkNegate('a <= 1.1', 'a > 1.1');
+    checkNegate('a <= b', 'a > b');
+  });
+
+  test('issue #111899: context keys can use `<` or `>` ', () => {
+    const actual = ContextKeyExpr.deserialize('editorTextFocus && vim.active && vim.use<C-r>')!;
+    assert.ok(
+      actual.equals(
+        ContextKeyExpr.and(
+          ContextKeyExpr.has('editorTextFocus'),
+          ContextKeyExpr.has('vim.active'),
+          ContextKeyExpr.has('vim.use<C-r>'),
+        )!,
+      ),
+    );
+  });
+
+  test('ContextKeyEqualsExpr', () => {
+    const a_cequalsb = ContextKeyExpr.deserialize('a == b')!;
+    assert.strictEqual(a_cequalsb.evaluate(createContext({ a: 'b' })), true);
   });
 });

--- a/packages/renderer/src/lib/context/contextKey.spec.ts
+++ b/packages/renderer/src/lib/context/contextKey.spec.ts
@@ -18,7 +18,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 
-import * as assert from 'assert';
+import assert from 'assert';
 import { suite, test } from 'vitest';
 
 import { ContextKeyExpr } from './contextKey.js';
@@ -32,6 +32,17 @@ function createContext(ctx: any) {
 }
 
 suite('ContextKeyExpr', () => {
+  test('ContextKeyExpr.equals', () => {
+    const a = ContextKeyExpr.and(ContextKeyExpr.equals('b1', 'bb1'), ContextKeyExpr.equals('b2', 'bb2'))!;
+    const b = ContextKeyExpr.and(ContextKeyExpr.equals('b2', 'bb2'), ContextKeyExpr.equals('b1', 'bb1'))!;
+    assert(a.equals(b), 'expressions should be equal');
+  });
+
+  test('ContextKeyEqualsExpr', () => {
+    const a_cequalsb = ContextKeyExpr.deserialize('a == b')!;
+    assert.strictEqual(a_cequalsb.evaluate(createContext({ a: 'b' })), true);
+  });
+
   test('ContextKeyInExpr', () => {
     const ainb = ContextKeyExpr.deserialize('a in b')!;
     assert.strictEqual(ainb.evaluate(createContext({ a: 3, b: [3, 2, 1] })), true);

--- a/packages/renderer/src/lib/context/contextKey.spec.ts
+++ b/packages/renderer/src/lib/context/contextKey.spec.ts
@@ -21,9 +21,6 @@
  *--------------------------------------------------------------------------------------------*/
 // based on https://github.com/microsoft/vscode/blob/76415ef0b1f60e0479bdfee173c1a4f97e785b52/src/vs/platform/contextkey/test/common/contextkey.test.ts
 /* eslint-disable @typescript-eslint/no-explicit-any */
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
-/* eslint-disable sonarjs/no-redundant-boolean */
-/* eslint-disable sonarjs/no-identical-expressions */
 
 import assert from 'assert';
 import { suite, test } from 'vitest';
@@ -40,8 +37,8 @@ function createContext(ctx: any) {
 }
 
 function strImplies(p0: string, q0: string): boolean {
-  const p = ContextKeyExpr.deserialize(p0)!;
-  const q = ContextKeyExpr.deserialize(q0)!;
+  const p = ContextKeyExpr.deserialize(p0);
+  const q = ContextKeyExpr.deserialize(q0);
   return implies(p, q);
 }
 
@@ -59,7 +56,7 @@ suite('ContextKeyExpr', () => {
       ContextKeyExpr.notEquals('c2', 'cc2'),
       ContextKeyExpr.not('d1'),
       ContextKeyExpr.not('d2'),
-    )!;
+    );
     const b = ContextKeyExpr.and(
       ContextKeyExpr.equals('b2', 'bb2'),
       ContextKeyExpr.notEquals('c1', 'cc1'),
@@ -72,7 +69,7 @@ suite('ContextKeyExpr', () => {
       ContextKeyExpr.has('a1'),
       ContextKeyExpr.and(ContextKeyExpr.equals('and.a', true)),
       ContextKeyExpr.not('d2'),
-    )!;
+    );
     assert(a.equals(b), 'expressions should be equal');
   });
 
@@ -110,7 +107,7 @@ suite('ContextKeyExpr', () => {
     });
     function testExpression(expr: string, expected: boolean): void {
       const rules = ContextKeyExpr.deserialize(expr);
-      assert.strictEqual(rules!.evaluate(context), expected, expr);
+      assert.strictEqual(rules.evaluate(context), expected, expr);
     }
     function testBatch(expr: string, value: any): void {
       /* eslint-disable eqeqeq */
@@ -133,11 +130,14 @@ suite('ContextKeyExpr', () => {
     testBatch('d', 'd');
     testBatch('z', undefined);
 
+    const truthyValue = true;
+    const falsyValue = false;
+    const five = '5';
     testExpression('true', true);
     testExpression('false', false);
-    testExpression('a && !b', true && !false);
-    testExpression('a && b', true && false);
-    testExpression('a && !b && c == 5', true && !false && '5' === '5');
+    testExpression('a && !b', truthyValue && !falsyValue);
+    testExpression('a && b', truthyValue && falsyValue);
+    testExpression('a && !b && c == 5', truthyValue && !falsyValue && five === '5');
     testExpression('d =~ /e.*/', false);
 
     // precedence test: false && true || true === true because && is evaluated first
@@ -150,7 +150,7 @@ suite('ContextKeyExpr', () => {
 
   test('negate', () => {
     function testNegate(expr: string, expected: string): void {
-      const actual = ContextKeyExpr.deserialize(expr)!.negate().serialize();
+      const actual = ContextKeyExpr.deserialize(expr).negate().serialize();
       assert.strictEqual(actual, expected);
     }
     testNegate('true', 'false');
@@ -167,7 +167,7 @@ suite('ContextKeyExpr', () => {
 
   test('false, true', () => {
     function testNormalize(expr: string, expected: string): void {
-      const actual = ContextKeyExpr.deserialize(expr)!.serialize();
+      const actual = ContextKeyExpr.deserialize(expr).serialize();
       assert.strictEqual(actual, expected);
     }
     testNormalize('true', 'true');
@@ -198,7 +198,7 @@ suite('ContextKeyExpr', () => {
   });
 
   test('ContextKeyInExpr', () => {
-    const ainb = ContextKeyExpr.deserialize('a in b')!;
+    const ainb = ContextKeyExpr.deserialize('a in b');
     assert.strictEqual(ainb.evaluate(createContext({ a: 3, b: [3, 2, 1] })), true);
     assert.strictEqual(ainb.evaluate(createContext({ a: 3, b: [1, 2, 3] })), true);
     assert.strictEqual(ainb.evaluate(createContext({ a: 3, b: [1, 2] })), false);
@@ -213,7 +213,7 @@ suite('ContextKeyExpr', () => {
   });
 
   test('ContextKeyNotInExpr', () => {
-    const aNotInB = ContextKeyExpr.deserialize('a not in b')!;
+    const aNotInB = ContextKeyExpr.deserialize('a not in b');
     assert.strictEqual(aNotInB.evaluate(createContext({ a: 3, b: [3, 2, 1] })), false);
     assert.strictEqual(aNotInB.evaluate(createContext({ a: 3, b: [1, 2, 3] })), false);
     assert.strictEqual(aNotInB.evaluate(createContext({ a: 3, b: [1, 2] })), true);
@@ -236,26 +236,26 @@ suite('ContextKeyExpr', () => {
       ContextKeyExpr.and(ContextKeyExpr.has('a'), ContextKeyExpr.has('c')),
       ContextKeyExpr.and(ContextKeyExpr.has('b'), ContextKeyExpr.has('c')),
     );
-    assert.strictEqual(actual!.equals(expected!), true);
+    assert.strictEqual(actual.equals(expected), true);
   });
 
   test('issue #129625: Removes duplicated terms in OR expressions', () => {
-    const expr = ContextKeyExpr.or(ContextKeyExpr.has('A'), ContextKeyExpr.has('B'), ContextKeyExpr.has('A'))!;
+    const expr = ContextKeyExpr.or(ContextKeyExpr.has('A'), ContextKeyExpr.has('B'), ContextKeyExpr.has('A'));
     assert.strictEqual(expr.serialize(), 'A || B');
   });
 
   test('Resolves true constant OR expressions', () => {
-    const expr = ContextKeyExpr.or(ContextKeyExpr.has('A'), ContextKeyExpr.not('A'))!;
+    const expr = ContextKeyExpr.or(ContextKeyExpr.has('A'), ContextKeyExpr.not('A'));
     assert.strictEqual(expr.serialize(), 'true');
   });
 
   test('Resolves false constant AND expressions', () => {
-    const expr = ContextKeyExpr.and(ContextKeyExpr.has('A'), ContextKeyExpr.not('A'))!;
+    const expr = ContextKeyExpr.and(ContextKeyExpr.has('A'), ContextKeyExpr.not('A'));
     assert.strictEqual(expr.serialize(), 'false');
   });
 
   test('issue #129625: Removes duplicated terms in AND expressions', () => {
-    const expr = ContextKeyExpr.and(ContextKeyExpr.has('A'), ContextKeyExpr.has('B'), ContextKeyExpr.has('A'))!;
+    const expr = ContextKeyExpr.and(ContextKeyExpr.has('A'), ContextKeyExpr.has('B'), ContextKeyExpr.has('A'));
     assert.strictEqual(expr.serialize(), 'A && B');
   });
 
@@ -263,11 +263,11 @@ suite('ContextKeyExpr', () => {
     const expr = ContextKeyExpr.and(
       ContextKeyExpr.has('A'),
       ContextKeyExpr.or(ContextKeyExpr.has('B1'), ContextKeyExpr.has('B2')),
-    )!;
+    );
     assert.strictEqual(expr.serialize(), 'A && B1 || A && B2');
-    assert.strictEqual(expr.negate()!.serialize(), '!A || !A && !B1 || !A && !B2 || !B1 && !B2');
-    assert.strictEqual(expr.negate()!.negate()!.serialize(), 'A && B1 || A && B2');
-    assert.strictEqual(expr.negate()!.negate()!.negate()!.serialize(), '!A || !A && !B1 || !A && !B2 || !B1 && !B2');
+    assert.strictEqual(expr.negate().serialize(), '!A || !A && !B1 || !A && !B2 || !B1 && !B2');
+    assert.strictEqual(expr.negate().negate().serialize(), 'A && B1 || A && B2');
+    assert.strictEqual(expr.negate().negate().negate().serialize(), '!A || !A && !B1 || !A && !B2 || !B1 && !B2');
   });
 
   test('issue #129625: remove redundant terms in OR expressions', () => {
@@ -292,7 +292,7 @@ suite('ContextKeyExpr', () => {
 
   test('Greater, GreaterEquals, Smaller, SmallerEquals evaluate', () => {
     function checkEvaluate(expr: string, ctx: any, expected: any): void {
-      const _expr = ContextKeyExpr.deserialize(expr)!;
+      const _expr = ContextKeyExpr.deserialize(expr);
       assert.strictEqual(_expr.evaluate(createContext(ctx)), expected);
     }
 
@@ -337,7 +337,7 @@ suite('ContextKeyExpr', () => {
 
   test('Greater, GreaterEquals, Smaller, SmallerEquals negate', () => {
     function checkNegate(expr: string, expected: string): void {
-      const a = ContextKeyExpr.deserialize(expr)!;
+      const a = ContextKeyExpr.deserialize(expr);
       const b = a.negate();
       assert.strictEqual(b.serialize(), expected);
     }
@@ -360,20 +360,20 @@ suite('ContextKeyExpr', () => {
   });
 
   test('issue #111899: context keys can use `<` or `>` ', () => {
-    const actual = ContextKeyExpr.deserialize('editorTextFocus && vim.active && vim.use<C-r>')!;
+    const actual = ContextKeyExpr.deserialize('editorTextFocus && vim.active && vim.use<C-r>');
     assert.ok(
       actual.equals(
         ContextKeyExpr.and(
           ContextKeyExpr.has('editorTextFocus'),
           ContextKeyExpr.has('vim.active'),
           ContextKeyExpr.has('vim.use<C-r>'),
-        )!,
+        ),
       ),
     );
   });
 
   test('ContextKeyEqualsExpr', () => {
-    const a_cequalsb = ContextKeyExpr.deserialize('a == b')!;
+    const a_cequalsb = ContextKeyExpr.deserialize('a == b');
     assert.strictEqual(a_cequalsb.evaluate(createContext({ a: 'b' })), true);
   });
 });

--- a/packages/renderer/src/lib/context/contextKey.ts
+++ b/packages/renderer/src/lib/context/contextKey.ts
@@ -22,26 +22,63 @@
 // based on https://github.com/microsoft/vscode/blob/3eed9319874b7ca037128962593b6a8630869253/src/vs/platform/contextkey/common/contextkey.ts
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable sonarjs/no-identical-functions */
+/* eslint-disable sonarjs/no-nested-switch */
 
 import type { LexingError, Token } from './scanner.js';
 import { Scanner, TokenType } from './scanner.js';
 import type { ContextKeyValue, IContext } from '../../../../main/src/plugin/api/context-info.js';
+import { isLinux, isMac, isWindows } from '../../../../main/src/util.js';
+import { CharCode } from '../../../../main/src/plugin/util/charCode.js';
+import type { IDisposable } from '../../../../main/src/plugin/types/disposable.js';
+import type { Event } from '@podman-desktop/api';
+
+const CONSTANT_VALUES = new Map<string, boolean>();
+CONSTANT_VALUES.set('false', false);
+CONSTANT_VALUES.set('true', true);
+CONSTANT_VALUES.set('isMac', isMac());
+CONSTANT_VALUES.set('isLinux', isLinux());
+CONSTANT_VALUES.set('isWindows', isWindows());
+
+/** allow register constant context keys that are known only after startup; requires running `substituteConstants` on the context key - https://github.com/microsoft/vscode/issues/174218#issuecomment-1437972127 */
+export function setConstant(key: string, value: boolean) {
+  if (CONSTANT_VALUES.get(key) !== undefined) {
+    throw new Error('contextkey.setConstant(k, v) invoked with already set constant `k`');
+  }
+
+  CONSTANT_VALUES.set(key, value);
+}
 
 const hasOwnProperty = Object.prototype.hasOwnProperty;
 
 export const enum ContextKeyExprType {
   False = 0,
   True = 1,
+  Defined = 2,
+  Not = 3,
   Equals = 4,
   NotEquals = 5,
   And = 6,
+  Regex = 7,
+  NotRegex = 8,
   Or = 9,
   In = 10,
   NotIn = 11,
+  Greater = 12,
+  GreaterEquals = 13,
+  Smaller = 14,
+  SmallerEquals = 15,
 }
 
 export interface IContextKeyExprMapper {
+  mapDefined(key: string): ContextKeyExpression;
+  mapNot(key: string): ContextKeyExpression;
   mapEquals(key: string, value: any): ContextKeyExpression;
+  mapNotEquals(key: string, value: any): ContextKeyExpression;
+  mapGreater(key: string, value: any): ContextKeyExpression;
+  mapGreaterEquals(key: string, value: any): ContextKeyExpression;
+  mapSmaller(key: string, value: any): ContextKeyExpression;
+  mapSmallerEquals(key: string, value: any): ContextKeyExpression;
+  mapRegex(key: string, regexp: RegExp | undefined): ContextKeyRegexExpr;
   mapIn(key: string, valueKey: string): ContextKeyInExpr;
   mapNotIn(key: string, valueKey: string): ContextKeyNotInExpr;
 }
@@ -60,11 +97,20 @@ export interface IContextKeyExpression {
 export type ContextKeyExpression =
   | ContextKeyFalseExpr
   | ContextKeyTrueExpr
+  | ContextKeyDefinedExpr
+  | ContextKeyNotExpr
   | ContextKeyEqualsExpr
+  | ContextKeyNotEqualsExpr
+  | ContextKeyRegexExpr
+  | ContextKeyNotRegexExpr
   | ContextKeyAndExpr
   | ContextKeyOrExpr
   | ContextKeyInExpr
-  | ContextKeyNotInExpr;
+  | ContextKeyNotInExpr
+  | ContextKeyGreaterExpr
+  | ContextKeyGreaterEqualsExpr
+  | ContextKeySmallerExpr
+  | ContextKeySmallerEqualsExpr;
 
 /*
 
@@ -123,9 +169,9 @@ export type ParsingError = {
 
 const errorEmptyString = 'Empty context key expression';
 const hintEmptyString =
-  'Did you forget to write an expression? You can also put "false" or "true" to always evaluate to false or true, respectively.';
-const errorNoInAfterNot = '"in" after "not".';
-const errorClosingParenthesis = 'closing parenthesis ")"';
+  "Did you forget to write an expression? You can also put 'false' or 'true' to always evaluate to false or true, respectively.";
+const errorNoInAfterNot = "'in' after 'not'.";
+const errorClosingParenthesis = "closing parenthesis ')'";
 const errorUnexpectedToken = 'Unexpected token';
 const hintUnexpectedToken = 'Did you forget to put && or || before the token?';
 const errorUnexpectedEOF = 'Unexpected end of expression';
@@ -239,6 +285,28 @@ export class Parser {
   }
 
   private _term(): ContextKeyExpression | undefined {
+    if (this._matchOne(TokenType.Neg)) {
+      const peek = this._peek();
+      switch (peek.type) {
+        case TokenType.True:
+          this._advance();
+          return ContextKeyFalseExpr.INSTANCE;
+        case TokenType.False:
+          this._advance();
+          return ContextKeyTrueExpr.INSTANCE;
+        case TokenType.LParen: {
+          this._advance();
+          const expr = this._expr();
+          this._consume(TokenType.RParen, errorClosingParenthesis);
+          return expr?.negate();
+        }
+        case TokenType.Str:
+          this._advance();
+          return ContextKeyNotExpr.create(peek.lexeme);
+        default:
+          throw this._errExpectedButGot("KEY | true | false | '(' expression ')'", peek);
+      }
+    }
     return this._primary();
   }
 
@@ -265,6 +333,126 @@ export class Parser {
         const key = peek.lexeme;
         this._advance();
 
+        // =~ regex
+        if (this._matchOne(TokenType.RegexOp)) {
+          // @ulugbekna: we need to reconstruct the regex from the tokens because some extensions use unescaped slashes in regexes
+          const expr = this._peek();
+
+          if (!this._config.regexParsingWithErrorRecovery) {
+            this._advance();
+            if (expr.type !== TokenType.RegexStr) {
+              throw this._errExpectedButGot('REGEX', expr);
+            }
+            const regexLexeme = expr.lexeme;
+            const closingSlashIndex = regexLexeme.lastIndexOf('/');
+            const flags =
+              closingSlashIndex === regexLexeme.length - 1
+                ? undefined
+                : this._removeFlagsGY(regexLexeme.substring(closingSlashIndex + 1));
+            let regexp: RegExp;
+            try {
+              regexp = new RegExp(regexLexeme.substring(1, closingSlashIndex), flags);
+            } catch (e) {
+              throw this._errExpectedButGot('REGEX', expr);
+            }
+            return ContextKeyRegexExpr.create(key, regexp);
+          }
+
+          switch (expr.type) {
+            case TokenType.RegexStr:
+            case TokenType.Error: {
+              // also handle an ErrorToken in case of smth such as /(/file)/
+              const lexemeReconstruction = [expr.lexeme]; // /REGEX/ or /REGEX/FLAGS
+              this._advance();
+
+              let followingToken = this._peek();
+              let parenBalance = 0;
+              for (let i = 0; i < expr.lexeme.length; i++) {
+                if (expr.lexeme.charCodeAt(i) === CharCode.OpenParen) {
+                  parenBalance++;
+                } else if (expr.lexeme.charCodeAt(i) === CharCode.CloseParen) {
+                  parenBalance--;
+                }
+              }
+
+              while (
+                !this._isAtEnd() &&
+                followingToken.type !== TokenType.And &&
+                followingToken.type !== TokenType.Or
+              ) {
+                switch (followingToken.type) {
+                  case TokenType.LParen:
+                    parenBalance++;
+                    break;
+                  case TokenType.RParen:
+                    parenBalance--;
+                    break;
+                  case TokenType.RegexStr:
+                  case TokenType.QuotedStr:
+                    for (let i = 0; i < followingToken.lexeme.length; i++) {
+                      if (followingToken.lexeme.charCodeAt(i) === CharCode.OpenParen) {
+                        parenBalance++;
+                      } else if (expr.lexeme.charCodeAt(i) === CharCode.CloseParen) {
+                        parenBalance--;
+                      }
+                    }
+                }
+                if (parenBalance < 0) {
+                  break;
+                }
+                lexemeReconstruction.push(Scanner.getLexeme(followingToken));
+                this._advance();
+                followingToken = this._peek();
+              }
+
+              const regexLexeme = lexemeReconstruction.join('');
+              const closingSlashIndex = regexLexeme.lastIndexOf('/');
+              const flags =
+                closingSlashIndex === regexLexeme.length - 1
+                  ? undefined
+                  : this._removeFlagsGY(regexLexeme.substring(closingSlashIndex + 1));
+              let regexp: RegExp | undefined;
+              try {
+                regexp = new RegExp(regexLexeme.substring(1, closingSlashIndex), flags);
+              } catch (e) {
+                throw this._errExpectedButGot('REGEX', expr);
+              }
+              return ContextKeyExpr.regex(key, regexp);
+            }
+
+            case TokenType.QuotedStr: {
+              const serializedValue = expr.lexeme;
+              this._advance();
+              // replicate old regex parsing behavior
+
+              let regex: RegExp | undefined = undefined;
+
+              if (!isFalsyOrWhitespace(serializedValue)) {
+                const start = serializedValue.indexOf('/');
+                const end = serializedValue.lastIndexOf('/');
+                if (start !== end && start >= 0) {
+                  const value = serializedValue.slice(start + 1, end);
+                  const caseIgnoreFlag = serializedValue[end + 1] === 'i' ? 'i' : '';
+                  try {
+                    regex = new RegExp(value, caseIgnoreFlag);
+                  } catch (_e) {
+                    throw this._errExpectedButGot('REGEX', expr);
+                  }
+                }
+              }
+
+              if (regex === undefined) {
+                throw this._errExpectedButGot('REGEX', expr);
+              }
+
+              return ContextKeyRegexExpr.create(key, regex);
+            }
+
+            default:
+              throw this._errExpectedButGot('REGEX', this._peek());
+          }
+        }
+
         // [ 'not' 'in' value ]
         if (this._matchOne(TokenType.Not)) {
           this._consume(TokenType.In, errorNoInAfterNot);
@@ -272,19 +460,68 @@ export class Parser {
           return ContextKeyExpr.notIn(key, right);
         }
 
-        // [ ('==' | 'in') value ]
+        // [ ('==' | '!=' | '<' | '<=' | '>' | '>=' | 'in') value ]
         const maybeOp = this._peek().type;
-        if (maybeOp === TokenType.In) {
-          this._advance();
-          return ContextKeyExpr.in(key, this._value());
-        } else if (maybeOp === TokenType.Eq) {
-          this._advance();
+        switch (maybeOp) {
+          case TokenType.Eq: {
+            this._advance();
 
-          const right = this._value();
-          return ContextKeyExpr.equals(key, right);
-        } else {
-          this._parsingErrors.push({ message: errorUnexpectedToken, offset: peek.offset, lexeme: '' });
-          throw Parser._parseError;
+            const right = this._value();
+            if (this._previous().type === TokenType.QuotedStr) {
+              // to preserve old parser behavior: "foo == 'true'" is preserved as "foo == 'true'", but "foo == true" is optimized as "foo"
+              return ContextKeyExpr.equals(key, right);
+            }
+            switch (right) {
+              case 'true':
+                return ContextKeyExpr.has(key);
+              case 'false':
+                return ContextKeyExpr.not(key);
+              default:
+                return ContextKeyExpr.equals(key, right);
+            }
+          }
+
+          case TokenType.NotEq: {
+            this._advance();
+
+            const right = this._value();
+            if (this._previous().type === TokenType.QuotedStr) {
+              // same as above with "foo != 'true'"
+              return ContextKeyExpr.notEquals(key, right);
+            }
+            switch (right) {
+              case 'true':
+                return ContextKeyExpr.not(key);
+              case 'false':
+                return ContextKeyExpr.has(key);
+              default:
+                return ContextKeyExpr.notEquals(key, right);
+            }
+          }
+          // TODO: ContextKeyExpr.smaller(key, right) accepts only `number` as `right` AND during eval of this node, we just eval to `false` if `right` is not a number
+          // consequently, package.json linter should _warn_ the user if they're passing undesired things to ops
+          case TokenType.Lt:
+            this._advance();
+            return ContextKeySmallerExpr.create(key, this._value());
+
+          case TokenType.LtEq:
+            this._advance();
+            return ContextKeySmallerEqualsExpr.create(key, this._value());
+
+          case TokenType.Gt:
+            this._advance();
+            return ContextKeyGreaterExpr.create(key, this._value());
+
+          case TokenType.GtEq:
+            this._advance();
+            return ContextKeyGreaterEqualsExpr.create(key, this._value());
+
+          case TokenType.In:
+            this._advance();
+            return ContextKeyExpr.in(key, this._value());
+
+          default:
+            return ContextKeyExpr.has(key);
         }
       }
 
@@ -312,6 +549,12 @@ export class Parser {
       case TokenType.QuotedStr:
         this._advance();
         return token.lexeme;
+      case TokenType.True:
+        this._advance();
+        return 'true';
+      case TokenType.False:
+        this._advance();
+        return 'false';
       case TokenType.In: // we support `in` as a value, e.g., "when": "languageId == in" - exists in existing extensions
         this._advance();
         return 'in';
@@ -320,6 +563,11 @@ export class Parser {
         // we do not call `_advance` on purpose - we don't want to eat unintended tokens
         return '';
     }
+  }
+
+  private _flagsGYRe = /g|y/g;
+  private _removeFlagsGY(flags: string): string {
+    return flags.replaceAll(this._flagsGYRe, '');
   }
 
   // careful: this can throw if current token is the initial one (ie index = 0)
@@ -379,8 +627,26 @@ export abstract class ContextKeyExpr {
   public static true(): ContextKeyExpression {
     return ContextKeyTrueExpr.INSTANCE;
   }
+  public static has(key: string): ContextKeyExpression {
+    return ContextKeyDefinedExpr.create(key);
+  }
   public static equals(key: string, value: any): ContextKeyExpression {
     return ContextKeyEqualsExpr.create(key, value);
+  }
+  public static notEquals(key: string, value: any): ContextKeyExpression {
+    return ContextKeyNotEqualsExpr.create(key, value);
+  }
+  public static regex(key: string, value: RegExp): ContextKeyExpression {
+    return ContextKeyRegexExpr.create(key, value);
+  }
+  public static in(key: string, value: string): ContextKeyExpression {
+    return ContextKeyInExpr.create(key, value);
+  }
+  public static notIn(key: string, value: string): ContextKeyExpression {
+    return ContextKeyNotInExpr.create(key, value);
+  }
+  public static not(key: string): ContextKeyExpression {
+    return ContextKeyNotExpr.create(key);
   }
   public static and(...expr: Array<ContextKeyExpression | undefined>): ContextKeyExpression | undefined {
     return ContextKeyAndExpr.create(expr, undefined, true);
@@ -388,11 +654,17 @@ export abstract class ContextKeyExpr {
   public static or(...expr: Array<ContextKeyExpression | undefined>): ContextKeyExpression | undefined {
     return ContextKeyOrExpr.create(expr, undefined, true);
   }
-  public static in(key: string, value: string): ContextKeyExpression {
-    return ContextKeyInExpr.create(key, value);
+  public static greater(key: string, value: number): ContextKeyExpression {
+    return ContextKeyGreaterExpr.create(key, value);
   }
-  public static notIn(key: string, value: string): ContextKeyExpression {
-    return ContextKeyNotInExpr.create(key, value);
+  public static greaterEquals(key: string, value: number): ContextKeyExpression {
+    return ContextKeyGreaterEqualsExpr.create(key, value);
+  }
+  public static smaller(key: string, value: number): ContextKeyExpression {
+    return ContextKeySmallerExpr.create(key, value);
+  }
+  public static smallerEquals(key: string, value: number): ContextKeyExpression {
+    return ContextKeySmallerEqualsExpr.create(key, value);
   }
 
   private static _parser = new Parser({ regexParsingWithErrorRecovery: false });
@@ -406,58 +678,43 @@ export abstract class ContextKeyExpr {
   }
 }
 
-export class ContextKeyEqualsExpr implements IContextKeyExpression {
-  public static create(key: string, value: any, negated: ContextKeyExpression = undefined): ContextKeyExpression {
-    return new ContextKeyEqualsExpr(key, value, negated);
-  }
+export function validateWhenClauses(whenClauses: string[]): any {
+  const parser = new Parser({ regexParsingWithErrorRecovery: false }); // we run with no recovery to guide users to use correct regexes
 
-  public readonly type = ContextKeyExprType.Equals;
+  return whenClauses.map(whenClause => {
+    parser.parse(whenClause);
 
-  private constructor(
-    private readonly key: string,
-    private readonly value: any,
-    private negated: ContextKeyExpression | undefined,
-  ) {}
-
-  public cmp(other: ContextKeyExpression): number {
-    if (other.type !== this.type) {
-      return this.type - other.type;
+    if (parser.lexingErrors.length > 0) {
+      return parser.lexingErrors.map((se: LexingError) => ({
+        errorMessage: se.additionalInfo ? `Unexpected token. Hint: ${se.additionalInfo}` : 'Unexpected token.',
+        offset: se.offset,
+        length: se.lexeme.length,
+      }));
+    } else if (parser.parsingErrors.length > 0) {
+      return parser.parsingErrors.map((pe: ParsingError) => ({
+        errorMessage: pe.additionalInfo ? `${pe.message}. ${pe.additionalInfo}` : pe.message,
+        offset: pe.offset,
+        length: pe.lexeme.length,
+      }));
+    } else {
+      return [];
     }
-    return cmp2(this.key, this.value, other.key, other.value);
-  }
+  });
+}
 
-  public equals(other: ContextKeyExpression): boolean {
-    if (other.type === this.type) {
-      return this.key === other.key && this.value === other.value;
-    }
+export function expressionsAreEqualWithConstantSubstitution(
+  a: ContextKeyExpression | undefined,
+  b: ContextKeyExpression | undefined,
+): boolean {
+  const aExpr = a ? a.substituteConstants() : undefined;
+  const bExpr = b ? b.substituteConstants() : undefined;
+  if (!aExpr && !bExpr) {
+    return true;
+  }
+  if (!aExpr || !bExpr) {
     return false;
   }
-
-  public substituteConstants(): ContextKeyExpression | undefined {
-    return this;
-  }
-
-  public evaluate(context: IContext): boolean {
-    // Intentional ==
-    // eslint-disable-next-line eqeqeq
-    return context.getValue(this.key) == this.value;
-  }
-
-  public serialize(): string {
-    return `${this.key} == '${this.value}'`;
-  }
-
-  public keys(): string[] {
-    return [this.key];
-  }
-
-  public map(mapFnc: IContextKeyExprMapper): ContextKeyExpression {
-    return mapFnc.mapEquals(this.key, this.value);
-  }
-
-  public negate(): ContextKeyExpression {
-    return this.negated;
-  }
+  return aExpr.equals(bExpr);
 }
 
 function cmp(a: ContextKeyExpression, b: ContextKeyExpression): number {
@@ -544,6 +801,805 @@ export class ContextKeyTrueExpr implements IContextKeyExpression {
   }
 }
 
+export class ContextKeyDefinedExpr implements IContextKeyExpression {
+  public static create(key: string, negated: ContextKeyExpression | undefined = undefined): ContextKeyExpression {
+    const constantValue = CONSTANT_VALUES.get(key);
+    if (typeof constantValue === 'boolean') {
+      return constantValue ? ContextKeyTrueExpr.INSTANCE : ContextKeyFalseExpr.INSTANCE;
+    }
+    return new ContextKeyDefinedExpr(key, negated);
+  }
+
+  public readonly type = ContextKeyExprType.Defined;
+
+  protected constructor(readonly key: string, private negated: ContextKeyExpression | undefined) {}
+
+  public cmp(other: ContextKeyExpression): number {
+    if (other.type !== this.type) {
+      return this.type - other.type;
+    }
+    return cmp1(this.key, other.key);
+  }
+
+  public equals(other: ContextKeyExpression): boolean {
+    if (other.type === this.type) {
+      return this.key === other.key;
+    }
+    return false;
+  }
+
+  public substituteConstants(): ContextKeyExpression | undefined {
+    const constantValue = CONSTANT_VALUES.get(this.key);
+    if (typeof constantValue === 'boolean') {
+      return constantValue ? ContextKeyTrueExpr.INSTANCE : ContextKeyFalseExpr.INSTANCE;
+    }
+    return this;
+  }
+
+  public evaluate(context: IContext): boolean {
+    return !!context.getValue(this.key);
+  }
+
+  public serialize(): string {
+    return this.key;
+  }
+
+  public keys(): string[] {
+    return [this.key];
+  }
+
+  public map(mapFnc: IContextKeyExprMapper): ContextKeyExpression {
+    return mapFnc.mapDefined(this.key);
+  }
+
+  public negate(): ContextKeyExpression {
+    if (!this.negated) {
+      this.negated = ContextKeyNotExpr.create(this.key, this);
+    }
+    return this.negated;
+  }
+}
+
+export class ContextKeyEqualsExpr implements IContextKeyExpression {
+  public static create(
+    key: string,
+    value: any,
+    negated: ContextKeyExpression | undefined = undefined,
+  ): ContextKeyExpression {
+    if (typeof value === 'boolean') {
+      return value ? ContextKeyDefinedExpr.create(key, negated) : ContextKeyNotExpr.create(key, negated);
+    }
+    const constantValue = CONSTANT_VALUES.get(key);
+    if (typeof constantValue === 'boolean') {
+      const trueValue = constantValue ? 'true' : 'false';
+      return value === trueValue ? ContextKeyTrueExpr.INSTANCE : ContextKeyFalseExpr.INSTANCE;
+    }
+    return new ContextKeyEqualsExpr(key, value, negated);
+  }
+
+  public readonly type = ContextKeyExprType.Equals;
+
+  private constructor(
+    private readonly key: string,
+    private readonly value: any,
+    private negated: ContextKeyExpression | undefined,
+  ) {}
+
+  public cmp(other: ContextKeyExpression): number {
+    if (other.type !== this.type) {
+      return this.type - other.type;
+    }
+    return cmp2(this.key, this.value, other.key, other.value);
+  }
+
+  public equals(other: ContextKeyExpression): boolean {
+    if (other.type === this.type) {
+      return this.key === other.key && this.value === other.value;
+    }
+    return false;
+  }
+
+  public substituteConstants(): ContextKeyExpression | undefined {
+    const constantValue = CONSTANT_VALUES.get(this.key);
+    if (typeof constantValue === 'boolean') {
+      const trueValue = constantValue ? 'true' : 'false';
+      return this.value === trueValue ? ContextKeyTrueExpr.INSTANCE : ContextKeyFalseExpr.INSTANCE;
+    }
+    return this;
+  }
+
+  public evaluate(context: IContext): boolean {
+    // Intentional ==
+    // eslint-disable-next-line eqeqeq
+    return context.getValue(this.key) == this.value;
+  }
+
+  public serialize(): string {
+    return `${this.key} == '${this.value}'`;
+  }
+
+  public keys(): string[] {
+    return [this.key];
+  }
+
+  public map(mapFnc: IContextKeyExprMapper): ContextKeyExpression {
+    return mapFnc.mapEquals(this.key, this.value);
+  }
+
+  public negate(): ContextKeyExpression {
+    if (!this.negated) {
+      this.negated = ContextKeyNotEqualsExpr.create(this.key, this.value, this);
+    }
+    return this.negated;
+  }
+}
+
+export class ContextKeyInExpr implements IContextKeyExpression {
+  public static create(key: string, valueKey: string): ContextKeyInExpr {
+    return new ContextKeyInExpr(key, valueKey);
+  }
+
+  public readonly type = ContextKeyExprType.In;
+  private negated: ContextKeyExpression | undefined = undefined;
+
+  private constructor(private readonly key: string, private readonly valueKey: string) {}
+
+  public cmp(other: ContextKeyExpression): number {
+    if (other.type !== this.type) {
+      return this.type - other.type;
+    }
+    return cmp2(this.key, this.valueKey, other.key, other.valueKey);
+  }
+
+  public equals(other: ContextKeyExpression): boolean {
+    if (other.type === this.type) {
+      return this.key === other.key && this.valueKey === other.valueKey;
+    }
+    return false;
+  }
+
+  public substituteConstants(): ContextKeyExpression | undefined {
+    return this;
+  }
+
+  public evaluate(context: IContext): boolean {
+    const source = context.getValue(this.valueKey);
+
+    const item = context.getValue(this.key);
+
+    if (Array.isArray(source)) {
+      return source.includes(item as any);
+    }
+
+    if (typeof item === 'string' && typeof source === 'object' && source !== undefined) {
+      return hasOwnProperty.call(source, item);
+    }
+    return false;
+  }
+
+  public serialize(): string {
+    return `${this.key} in '${this.valueKey}'`;
+  }
+
+  public keys(): string[] {
+    return [this.key, this.valueKey];
+  }
+
+  public map(mapFnc: IContextKeyExprMapper): ContextKeyInExpr {
+    return mapFnc.mapIn(this.key, this.valueKey);
+  }
+
+  public negate(): ContextKeyExpression {
+    if (!this.negated) {
+      this.negated = ContextKeyNotInExpr.create(this.key, this.valueKey);
+    }
+    return this.negated;
+  }
+}
+
+export class ContextKeyNotInExpr implements IContextKeyExpression {
+  public static create(key: string, valueKey: string): ContextKeyNotInExpr {
+    return new ContextKeyNotInExpr(key, valueKey);
+  }
+
+  public readonly type = ContextKeyExprType.NotIn;
+
+  private readonly _negated: ContextKeyInExpr;
+
+  private constructor(private readonly key: string, private readonly valueKey: string) {
+    this._negated = ContextKeyInExpr.create(key, valueKey);
+  }
+
+  public cmp(other: ContextKeyExpression): number {
+    if (other.type !== this.type) {
+      return this.type - other.type;
+    }
+    return this._negated.cmp(other._negated);
+  }
+
+  public equals(other: ContextKeyExpression): boolean {
+    if (other.type === this.type) {
+      return this._negated.equals(other._negated);
+    }
+    return false;
+  }
+
+  public substituteConstants(): ContextKeyExpression | undefined {
+    return this;
+  }
+
+  public evaluate(context: IContext): boolean {
+    return !this._negated.evaluate(context);
+  }
+
+  public serialize(): string {
+    return `${this.key} not in '${this.valueKey}'`;
+  }
+
+  public keys(): string[] {
+    return this._negated.keys();
+  }
+
+  public map(mapFnc: IContextKeyExprMapper): ContextKeyExpression {
+    return mapFnc.mapNotIn(this.key, this.valueKey);
+  }
+
+  public negate(): ContextKeyExpression {
+    return this._negated;
+  }
+}
+
+export class ContextKeyNotEqualsExpr implements IContextKeyExpression {
+  public static create(
+    key: string,
+    value: any,
+    negated: ContextKeyExpression | undefined = undefined,
+  ): ContextKeyExpression {
+    if (typeof value === 'boolean') {
+      if (value) {
+        return ContextKeyNotExpr.create(key, negated);
+      }
+      return ContextKeyDefinedExpr.create(key, negated);
+    }
+    const constantValue = CONSTANT_VALUES.get(key);
+    if (typeof constantValue === 'boolean') {
+      const falseValue = constantValue ? 'true' : 'false';
+      return value === falseValue ? ContextKeyFalseExpr.INSTANCE : ContextKeyTrueExpr.INSTANCE;
+    }
+    return new ContextKeyNotEqualsExpr(key, value, negated);
+  }
+
+  public readonly type = ContextKeyExprType.NotEquals;
+
+  private constructor(
+    private readonly key: string,
+    private readonly value: any,
+    private negated: ContextKeyExpression | undefined,
+  ) {}
+
+  public cmp(other: ContextKeyExpression): number {
+    if (other.type !== this.type) {
+      return this.type - other.type;
+    }
+    return cmp2(this.key, this.value, other.key, other.value);
+  }
+
+  public equals(other: ContextKeyExpression): boolean {
+    if (other.type === this.type) {
+      return this.key === other.key && this.value === other.value;
+    }
+    return false;
+  }
+
+  public substituteConstants(): ContextKeyExpression | undefined {
+    const constantValue = CONSTANT_VALUES.get(this.key);
+    if (typeof constantValue === 'boolean') {
+      const falseValue = constantValue ? 'true' : 'false';
+      return this.value === falseValue ? ContextKeyFalseExpr.INSTANCE : ContextKeyTrueExpr.INSTANCE;
+    }
+    return this;
+  }
+
+  public evaluate(context: IContext): boolean {
+    // Intentional !=
+    // eslint-disable-next-line eqeqeq
+    return context.getValue(this.key) != this.value;
+  }
+
+  public serialize(): string {
+    return `${this.key} != '${this.value}'`;
+  }
+
+  public keys(): string[] {
+    return [this.key];
+  }
+
+  public map(mapFnc: IContextKeyExprMapper): ContextKeyExpression {
+    return mapFnc.mapNotEquals(this.key, this.value);
+  }
+
+  public negate(): ContextKeyExpression {
+    if (!this.negated) {
+      this.negated = ContextKeyEqualsExpr.create(this.key, this.value, this);
+    }
+    return this.negated;
+  }
+}
+
+export class ContextKeyNotExpr implements IContextKeyExpression {
+  public static create(key: string, negated: ContextKeyExpression | undefined = undefined): ContextKeyExpression {
+    const constantValue = CONSTANT_VALUES.get(key);
+    if (typeof constantValue === 'boolean') {
+      return constantValue ? ContextKeyFalseExpr.INSTANCE : ContextKeyTrueExpr.INSTANCE;
+    }
+    return new ContextKeyNotExpr(key, negated);
+  }
+
+  public readonly type = ContextKeyExprType.Not;
+
+  private constructor(private readonly key: string, private negated: ContextKeyExpression | undefined) {}
+
+  public cmp(other: ContextKeyExpression): number {
+    if (other.type !== this.type) {
+      return this.type - other.type;
+    }
+    return cmp1(this.key, other.key);
+  }
+
+  public equals(other: ContextKeyExpression): boolean {
+    if (other.type === this.type) {
+      return this.key === other.key;
+    }
+    return false;
+  }
+
+  public substituteConstants(): ContextKeyExpression | undefined {
+    const constantValue = CONSTANT_VALUES.get(this.key);
+    if (typeof constantValue === 'boolean') {
+      return constantValue ? ContextKeyFalseExpr.INSTANCE : ContextKeyTrueExpr.INSTANCE;
+    }
+    return this;
+  }
+
+  public evaluate(context: IContext): boolean {
+    return !context.getValue(this.key);
+  }
+
+  public serialize(): string {
+    return `!${this.key}`;
+  }
+
+  public keys(): string[] {
+    return [this.key];
+  }
+
+  public map(mapFnc: IContextKeyExprMapper): ContextKeyExpression {
+    return mapFnc.mapNot(this.key);
+  }
+
+  public negate(): ContextKeyExpression {
+    if (!this.negated) {
+      this.negated = ContextKeyDefinedExpr.create(this.key, this);
+    }
+    return this.negated;
+  }
+}
+
+function withFloatOrStr<T extends ContextKeyExpression>(
+  value: any,
+  callback: (value: number | string) => T,
+): T | ContextKeyFalseExpr {
+  if (typeof value === 'string') {
+    const n = parseFloat(value);
+    if (!isNaN(n)) {
+      value = n;
+    }
+  }
+  if (typeof value === 'string' || typeof value === 'number') {
+    return callback(value);
+  }
+  return ContextKeyFalseExpr.INSTANCE;
+}
+
+export class ContextKeyGreaterExpr implements IContextKeyExpression {
+  public static create(
+    key: string,
+    _value: any,
+    negated: ContextKeyExpression | undefined = undefined,
+  ): ContextKeyExpression {
+    return withFloatOrStr(_value, value => new ContextKeyGreaterExpr(key, value, negated));
+  }
+
+  public readonly type = ContextKeyExprType.Greater;
+
+  private constructor(
+    private readonly key: string,
+    private readonly value: number | string,
+    private negated: ContextKeyExpression | undefined,
+  ) {}
+
+  public cmp(other: ContextKeyExpression): number {
+    if (other.type !== this.type) {
+      return this.type - other.type;
+    }
+    return cmp2(this.key, this.value, other.key, other.value);
+  }
+
+  public equals(other: ContextKeyExpression): boolean {
+    if (other.type === this.type) {
+      return this.key === other.key && this.value === other.value;
+    }
+    return false;
+  }
+
+  public substituteConstants(): ContextKeyExpression | undefined {
+    return this;
+  }
+
+  public evaluate(context: IContext): boolean {
+    if (typeof this.value === 'string') {
+      return false;
+    }
+    return parseFloat(<any>context.getValue(this.key)) > this.value;
+  }
+
+  public serialize(): string {
+    return `${this.key} > ${this.value}`;
+  }
+
+  public keys(): string[] {
+    return [this.key];
+  }
+
+  public map(mapFnc: IContextKeyExprMapper): ContextKeyExpression {
+    return mapFnc.mapGreater(this.key, this.value);
+  }
+
+  public negate(): ContextKeyExpression {
+    if (!this.negated) {
+      this.negated = ContextKeySmallerEqualsExpr.create(this.key, this.value, this);
+    }
+    return this.negated;
+  }
+}
+
+export class ContextKeyGreaterEqualsExpr implements IContextKeyExpression {
+  public static create(
+    key: string,
+    _value: any,
+    negated: ContextKeyExpression | undefined = undefined,
+  ): ContextKeyExpression {
+    return withFloatOrStr(_value, value => new ContextKeyGreaterEqualsExpr(key, value, negated));
+  }
+
+  public readonly type = ContextKeyExprType.GreaterEquals;
+
+  private constructor(
+    private readonly key: string,
+    private readonly value: number | string,
+    private negated: ContextKeyExpression | undefined,
+  ) {}
+
+  public cmp(other: ContextKeyExpression): number {
+    if (other.type !== this.type) {
+      return this.type - other.type;
+    }
+    return cmp2(this.key, this.value, other.key, other.value);
+  }
+
+  public equals(other: ContextKeyExpression): boolean {
+    if (other.type === this.type) {
+      return this.key === other.key && this.value === other.value;
+    }
+    return false;
+  }
+
+  public substituteConstants(): ContextKeyExpression | undefined {
+    return this;
+  }
+
+  public evaluate(context: IContext): boolean {
+    if (typeof this.value === 'string') {
+      return false;
+    }
+    return parseFloat(<any>context.getValue(this.key)) >= this.value;
+  }
+
+  public serialize(): string {
+    return `${this.key} >= ${this.value}`;
+  }
+
+  public keys(): string[] {
+    return [this.key];
+  }
+
+  public map(mapFnc: IContextKeyExprMapper): ContextKeyExpression {
+    return mapFnc.mapGreaterEquals(this.key, this.value);
+  }
+
+  public negate(): ContextKeyExpression {
+    if (!this.negated) {
+      this.negated = ContextKeySmallerExpr.create(this.key, this.value, this);
+    }
+    return this.negated;
+  }
+}
+
+export class ContextKeySmallerExpr implements IContextKeyExpression {
+  public static create(
+    key: string,
+    _value: any,
+    negated: ContextKeyExpression | undefined = undefined,
+  ): ContextKeyExpression {
+    return withFloatOrStr(_value, value => new ContextKeySmallerExpr(key, value, negated));
+  }
+
+  public readonly type = ContextKeyExprType.Smaller;
+
+  private constructor(
+    private readonly key: string,
+    private readonly value: number | string,
+    private negated: ContextKeyExpression | undefined,
+  ) {}
+
+  public cmp(other: ContextKeyExpression): number {
+    if (other.type !== this.type) {
+      return this.type - other.type;
+    }
+    return cmp2(this.key, this.value, other.key, other.value);
+  }
+
+  public equals(other: ContextKeyExpression): boolean {
+    if (other.type === this.type) {
+      return this.key === other.key && this.value === other.value;
+    }
+    return false;
+  }
+
+  public substituteConstants(): ContextKeyExpression | undefined {
+    return this;
+  }
+
+  public evaluate(context: IContext): boolean {
+    if (typeof this.value === 'string') {
+      return false;
+    }
+    return parseFloat(<any>context.getValue(this.key)) < this.value;
+  }
+
+  public serialize(): string {
+    return `${this.key} < ${this.value}`;
+  }
+
+  public keys(): string[] {
+    return [this.key];
+  }
+
+  public map(mapFnc: IContextKeyExprMapper): ContextKeyExpression {
+    return mapFnc.mapSmaller(this.key, this.value);
+  }
+
+  public negate(): ContextKeyExpression {
+    if (!this.negated) {
+      this.negated = ContextKeyGreaterEqualsExpr.create(this.key, this.value, this);
+    }
+    return this.negated;
+  }
+}
+
+export class ContextKeySmallerEqualsExpr implements IContextKeyExpression {
+  public static create(
+    key: string,
+    _value: any,
+    negated: ContextKeyExpression | undefined = undefined,
+  ): ContextKeyExpression {
+    return withFloatOrStr(_value, value => new ContextKeySmallerEqualsExpr(key, value, negated));
+  }
+
+  public readonly type = ContextKeyExprType.SmallerEquals;
+
+  private constructor(
+    private readonly key: string,
+    private readonly value: number | string,
+    private negated: ContextKeyExpression | undefined,
+  ) {}
+
+  public cmp(other: ContextKeyExpression): number {
+    if (other.type !== this.type) {
+      return this.type - other.type;
+    }
+    return cmp2(this.key, this.value, other.key, other.value);
+  }
+
+  public equals(other: ContextKeyExpression): boolean {
+    if (other.type === this.type) {
+      return this.key === other.key && this.value === other.value;
+    }
+    return false;
+  }
+
+  public substituteConstants(): ContextKeyExpression | undefined {
+    return this;
+  }
+
+  public evaluate(context: IContext): boolean {
+    if (typeof this.value === 'string') {
+      return false;
+    }
+    return parseFloat(<any>context.getValue(this.key)) <= this.value;
+  }
+
+  public serialize(): string {
+    return `${this.key} <= ${this.value}`;
+  }
+
+  public keys(): string[] {
+    return [this.key];
+  }
+
+  public map(mapFnc: IContextKeyExprMapper): ContextKeyExpression {
+    return mapFnc.mapSmallerEquals(this.key, this.value);
+  }
+
+  public negate(): ContextKeyExpression {
+    if (!this.negated) {
+      this.negated = ContextKeyGreaterExpr.create(this.key, this.value, this);
+    }
+    return this.negated;
+  }
+}
+
+export class ContextKeyRegexExpr implements IContextKeyExpression {
+  public static create(key: string, regexp: RegExp | undefined): ContextKeyRegexExpr {
+    return new ContextKeyRegexExpr(key, regexp);
+  }
+
+  public readonly type = ContextKeyExprType.Regex;
+  private negated: ContextKeyExpression | undefined = undefined;
+
+  private constructor(private readonly key: string, private readonly regexp: RegExp | undefined) {
+    //
+  }
+
+  public cmp(other: ContextKeyExpression): number {
+    if (other.type !== this.type) {
+      return this.type - other.type;
+    }
+    if (this.key < other.key) {
+      return -1;
+    }
+    if (this.key > other.key) {
+      return 1;
+    }
+    const thisSource = this.regexp ? this.regexp.source : '';
+    const otherSource = other.regexp ? other.regexp.source : '';
+    if (thisSource < otherSource) {
+      return -1;
+    }
+    if (thisSource > otherSource) {
+      return 1;
+    }
+    return 0;
+  }
+
+  public equals(other: ContextKeyExpression): boolean {
+    if (other.type === this.type) {
+      const thisSource = this.regexp ? this.regexp.source : '';
+      const otherSource = other.regexp ? other.regexp.source : '';
+      return this.key === other.key && thisSource === otherSource;
+    }
+    return false;
+  }
+
+  public substituteConstants(): ContextKeyExpression | undefined {
+    return this;
+  }
+
+  public evaluate(context: IContext): boolean {
+    const value = context.getValue<any>(this.key);
+    return this.regexp ? this.regexp.test(value) : false;
+  }
+
+  public serialize(): string {
+    const value = this.regexp ? `/${this.regexp.source}/${this.regexp.flags}` : '/invalid/';
+    return `${this.key} =~ ${value}`;
+  }
+
+  public keys(): string[] {
+    return [this.key];
+  }
+
+  public map(mapFnc: IContextKeyExprMapper): ContextKeyRegexExpr {
+    return mapFnc.mapRegex(this.key, this.regexp);
+  }
+
+  public negate(): ContextKeyExpression {
+    if (!this.negated) {
+      this.negated = ContextKeyNotRegexExpr.create(this);
+    }
+    return this.negated;
+  }
+}
+
+export class ContextKeyNotRegexExpr implements IContextKeyExpression {
+  public static create(actual: ContextKeyRegexExpr): ContextKeyExpression {
+    return new ContextKeyNotRegexExpr(actual);
+  }
+
+  public readonly type = ContextKeyExprType.NotRegex;
+
+  private constructor(private readonly _actual: ContextKeyRegexExpr) {
+    //
+  }
+
+  public cmp(other: ContextKeyExpression): number {
+    if (other.type !== this.type) {
+      return this.type - other.type;
+    }
+    return this._actual.cmp(other._actual);
+  }
+
+  public equals(other: ContextKeyExpression): boolean {
+    if (other.type === this.type) {
+      return this._actual.equals(other._actual);
+    }
+    return false;
+  }
+
+  public substituteConstants(): ContextKeyExpression | undefined {
+    return this;
+  }
+
+  public evaluate(context: IContext): boolean {
+    return !this._actual.evaluate(context);
+  }
+
+  public serialize(): string {
+    return `!(${this._actual.serialize()})`;
+  }
+
+  public keys(): string[] {
+    return this._actual.keys();
+  }
+
+  public map(mapFnc: IContextKeyExprMapper): ContextKeyExpression {
+    return new ContextKeyNotRegexExpr(this._actual.map(mapFnc));
+  }
+
+  public negate(): ContextKeyExpression {
+    return this._actual;
+  }
+}
+
+/**
+ * @returns the same instance if nothing changed.
+ */
+function eliminateConstantsInArray(arr: ContextKeyExpression[]): (ContextKeyExpression | undefined)[] {
+  // Allocate array only if there is a difference
+  let newArr: (ContextKeyExpression | undefined)[] | undefined = undefined;
+  for (let i = 0, len = arr.length; i < len; i++) {
+    const newExpr = arr[i].substituteConstants();
+
+    if (arr[i] !== newExpr && newArr === undefined) {
+      // something has changed!
+      // allocate array on first difference
+      newArr = [];
+      for (let j = 0; j < i; j++) {
+        newArr[j] = arr[j];
+      }
+    }
+
+    if (newArr !== undefined) {
+      newArr[i] = newExpr;
+    }
+  }
+
+  if (newArr === undefined) {
+    return arr;
+  }
+  return newArr;
+}
+
 export class ContextKeyAndExpr implements IContextKeyExpression {
   public static create(
     _expr: ReadonlyArray<ContextKeyExpression | undefined>,
@@ -595,7 +1651,12 @@ export class ContextKeyAndExpr implements IContextKeyExpression {
   }
 
   public substituteConstants(): ContextKeyExpression | undefined {
-    return this;
+    const exprArr = eliminateConstantsInArray(this.expr);
+    if (exprArr === this.expr) {
+      // no change
+      return this;
+    }
+    return ContextKeyAndExpr.create(exprArr, this.negated, false);
   }
 
   public evaluate(context: IContext): boolean {
@@ -608,8 +1669,8 @@ export class ContextKeyAndExpr implements IContextKeyExpression {
   }
 
   private static _normalizeArr(
-    arr: ReadonlyArray<ContextKeyExpression | null | undefined>,
-    negated: ContextKeyExpression | null,
+    arr: ReadonlyArray<ContextKeyExpression | undefined>,
+    negated: ContextKeyExpression | undefined,
     extraRedundantCheck: boolean,
   ): ContextKeyExpression | undefined {
     const expr: ContextKeyExpression[] = [];
@@ -707,6 +1768,7 @@ export class ContextKeyAndExpr implements IContextKeyExpression {
           }
         }
       }
+
       if (expr.length === 1) {
         return expr[0];
       }
@@ -748,8 +1810,8 @@ export class ContextKeyAndExpr implements IContextKeyExpression {
 
 export class ContextKeyOrExpr implements IContextKeyExpression {
   public static create(
-    _expr: ReadonlyArray<ContextKeyExpression | null | undefined>,
-    negated: ContextKeyExpression | null,
+    _expr: ReadonlyArray<ContextKeyExpression | undefined>,
+    negated: ContextKeyExpression | undefined,
     extraRedundantCheck: boolean,
   ): ContextKeyExpression | undefined {
     return ContextKeyOrExpr._normalizeArr(_expr, negated, extraRedundantCheck);
@@ -757,7 +1819,10 @@ export class ContextKeyOrExpr implements IContextKeyExpression {
 
   public readonly type = ContextKeyExprType.Or;
 
-  private constructor(public readonly expr: ContextKeyExpression[], private negated: ContextKeyExpression | null) {}
+  private constructor(
+    public readonly expr: ContextKeyExpression[],
+    private negated: ContextKeyExpression | undefined,
+  ) {}
 
   public cmp(other: ContextKeyExpression): number {
     if (other.type !== this.type) {
@@ -882,6 +1947,7 @@ export class ContextKeyOrExpr implements IContextKeyExpression {
           }
         }
       }
+
       if (expr.length === 1) {
         return expr[0];
       }
@@ -938,122 +2004,59 @@ export class ContextKeyOrExpr implements IContextKeyExpression {
   }
 }
 
-export class ContextKeyInExpr implements IContextKeyExpression {
-  public static create(key: string, valueKey: string): ContextKeyInExpr {
-    return new ContextKeyInExpr(key, valueKey);
-  }
-
-  public readonly type = ContextKeyExprType.In;
-  private negated: ContextKeyExpression | undefined = undefined;
-
-  private constructor(private readonly key: string, private readonly valueKey: string) {}
-
-  public cmp(other: ContextKeyExpression): number {
-    if (other.type !== this.type) {
-      return this.type - other.type;
-    }
-    return cmp2(this.key, this.valueKey, other.key, other.valueKey);
-  }
-
-  public equals(other: ContextKeyExpression): boolean {
-    if (other.type === this.type) {
-      return this.key === other.key && this.valueKey === other.valueKey;
-    }
-    return false;
-  }
-
-  public substituteConstants(): ContextKeyExpression | undefined {
-    return this;
-  }
-
-  public evaluate(context: IContext): boolean {
-    const source = context.getValue(this.valueKey);
-
-    const item = context.getValue(this.key);
-
-    if (Array.isArray(source)) {
-      // if item is undefined, the user has passed a string that has to be found in source
-      if (!item) {
-        return source.includes(this.key);
-      }
-      return source.includes(item as any);
-    }
-
-    if (typeof item === 'string' && source && typeof source === 'object') {
-      return hasOwnProperty.call(source, item);
-    }
-    return false;
-  }
-
-  public serialize(): string {
-    return `${this.key} in '${this.valueKey}'`;
-  }
-
-  public keys(): string[] {
-    return [this.key, this.valueKey];
-  }
-
-  public map(mapFnc: IContextKeyExprMapper): ContextKeyInExpr {
-    return mapFnc.mapIn(this.key, this.valueKey);
-  }
-
-  public negate(): ContextKeyExpression {
-    if (!this.negated) {
-      this.negated = ContextKeyNotInExpr.create(this.key, this.valueKey);
-    }
-    return this.negated;
-  }
+export interface ContextKeyInfo {
+  readonly key: string;
+  readonly type?: string;
+  readonly description?: string;
 }
 
-export class ContextKeyNotInExpr implements IContextKeyExpression {
-  public static create(key: string, valueKey: string): ContextKeyNotInExpr {
-    return new ContextKeyNotInExpr(key, valueKey);
+export class RawContextKey<T extends ContextKeyValue> extends ContextKeyDefinedExpr {
+  private static _info: ContextKeyInfo[] = [];
+
+  static all(): IterableIterator<ContextKeyInfo> {
+    return RawContextKey._info.values();
   }
 
-  public readonly type = ContextKeyExprType.NotIn;
+  private readonly _defaultValue: T | undefined;
 
-  private readonly _negated: ContextKeyInExpr;
+  constructor(
+    key: string,
+    defaultValue: T | undefined,
+    metaOrHide?: string | true | { type: string; description: string },
+  ) {
+    super(key, undefined);
+    this._defaultValue = defaultValue;
 
-  private constructor(private readonly key: string, private readonly valueKey: string) {
-    this._negated = ContextKeyInExpr.create(key, valueKey);
-  }
-
-  public cmp(other: ContextKeyExpression): number {
-    if (other.type !== this.type) {
-      return this.type - other.type;
+    // collect all context keys into a central place
+    if (typeof metaOrHide === 'object') {
+      RawContextKey._info.push({ ...metaOrHide, key });
+    } else if (metaOrHide !== true) {
+      RawContextKey._info.push({
+        key,
+        description: metaOrHide,
+        type: defaultValue !== undefined ? typeof defaultValue : undefined,
+      });
     }
-    return this._negated.cmp(other._negated);
   }
 
-  public equals(other: ContextKeyExpression): boolean {
-    if (other.type === this.type) {
-      return this._negated.equals(other._negated);
-    }
-    return false;
+  public bindTo(target: IContextKeyService): IContextKey<T> {
+    return target.createKey(this.key, this._defaultValue);
   }
 
-  public substituteConstants(): ContextKeyExpression | undefined {
-    return this;
+  public getValue(target: IContextKeyService): T | undefined {
+    return target.getContextKeyValue<T>(this.key);
   }
 
-  public evaluate(context: IContext): boolean {
-    return !this._negated.evaluate(context);
+  public toNegated(): ContextKeyExpression {
+    return this.negate();
   }
 
-  public serialize(): string {
-    return `${this.key} not in '${this.valueKey}'`;
+  public isEqualTo(value: any): ContextKeyExpression {
+    return ContextKeyEqualsExpr.create(this.key, value);
   }
 
-  public keys(): string[] {
-    return this._negated.keys();
-  }
-
-  public map(mapFnc: IContextKeyExprMapper): ContextKeyExpression {
-    return mapFnc.mapNotIn(this.key, this.valueKey);
-  }
-
-  public negate(): ContextKeyExpression {
-    return this._negated;
+  public notEqualsTo(value: any): ContextKeyExpression {
+    return ContextKeyNotEqualsExpr.create(this.key, value);
   }
 }
 
@@ -1080,6 +2083,36 @@ export interface IContextKeyChangeEvent {
   allKeysContainedIn(keys: IReadableSet<string>): boolean;
 }
 
+export type IScopedContextKeyService = IContextKeyService & IDisposable;
+
+export interface IContextKeyService {
+  readonly _serviceBrand: undefined;
+
+  onDidChangeContext: Event<IContextKeyChangeEvent>;
+  /* eslint-disable-next-line @typescript-eslint/ban-types */
+  bufferChangeEvents(callback: Function): void;
+
+  createKey<T extends ContextKeyValue>(key: string, defaultValue: T | undefined): IContextKey<T>;
+  contextMatchesRules(rules: ContextKeyExpression | undefined): boolean;
+  getContextKeyValue<T>(key: string): T | undefined;
+
+  createScoped(target: IContextKeyServiceTarget): IScopedContextKeyService;
+  createOverlay(overlay: Iterable<[string, any]>): IContextKeyService;
+  getContext(target: IContextKeyServiceTarget | undefined): IContext;
+
+  updateParent(parentContextKeyService: IContextKeyService): void;
+}
+
+function cmp1(key1: string, key2: string): number {
+  if (key1 < key2) {
+    return -1;
+  }
+  if (key1 > key2) {
+    return 1;
+  }
+  return 0;
+}
+
 function cmp2(key1: string, value1: any, key2: string, value2: any): number {
   if (key1 < key2) {
     return -1;
@@ -1097,32 +2130,69 @@ function cmp2(key1: string, value1: any, key2: string, value2: any): number {
 }
 
 /**
- * @returns the same instance if nothing changed.
+ * Returns true if it is provable `p` implies `q`.
  */
-function eliminateConstantsInArray(arr: ContextKeyExpression[]): (ContextKeyExpression | undefined)[] {
-  // Allocate array only if there is a difference
-  let newArr: (ContextKeyExpression | undefined)[] | undefined = undefined;
-  for (let i = 0, len = arr.length; i < len; i++) {
-    const newExpr = arr[i].substituteConstants();
+export function implies(p: ContextKeyExpression, q: ContextKeyExpression): boolean {
+  if (p.type === ContextKeyExprType.False || q.type === ContextKeyExprType.True) {
+    // false implies anything
+    // anything implies true
+    return true;
+  }
 
-    if (arr[i] !== newExpr && newArr === undefined) {
-      // something has changed!
-      // allocate array on first difference
-      newArr = [];
-      for (let j = 0; j < i; j++) {
-        newArr[j] = arr[j];
+  if (p.type === ContextKeyExprType.Or) {
+    if (q.type === ContextKeyExprType.Or) {
+      // `a || b || c` can only imply something like `a || b || c || d`
+      return allElementsIncluded(p.expr, q.expr);
+    }
+    return false;
+  }
+
+  if (q.type === ContextKeyExprType.Or) {
+    for (const element of q.expr) {
+      if (implies(p, element)) {
+        return true;
       }
     }
+    return false;
+  }
 
-    if (newArr !== undefined) {
-      newArr[i] = newExpr;
+  if (p.type === ContextKeyExprType.And) {
+    if (q.type === ContextKeyExprType.And) {
+      // `a && b && c` implies `a && c`
+      return allElementsIncluded(q.expr, p.expr);
+    }
+    for (const element of p.expr) {
+      if (implies(element, q)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  return p.equals(q);
+}
+
+/**
+ * Returns true if all elements in `p` are also present in `q`.
+ * The two arrays are assumed to be sorted
+ */
+function allElementsIncluded(p: ContextKeyExpression[], q: ContextKeyExpression[]): boolean {
+  let pIndex = 0;
+  let qIndex = 0;
+  while (pIndex < p.length && qIndex < q.length) {
+    const cmp = p[pIndex].cmp(q[qIndex]);
+
+    if (cmp < 0) {
+      // an element from `p` is missing from `q`
+      return false;
+    } else if (cmp === 0) {
+      pIndex++;
+      qIndex++;
+    } else {
+      qIndex++;
     }
   }
-
-  if (newArr === undefined) {
-    return arr;
-  }
-  return newArr;
+  return pIndex === p.length;
 }
 
 function getTerminals(node: ContextKeyExpression) {
@@ -1130,4 +2200,11 @@ function getTerminals(node: ContextKeyExpression) {
     return node.expr;
   }
   return [node];
+}
+
+function isFalsyOrWhitespace(str: string | undefined): boolean {
+  if (!str || typeof str !== 'string') {
+    return true;
+  }
+  return str.trim().length === 0;
 }

--- a/packages/renderer/src/lib/context/scanner.spec.ts
+++ b/packages/renderer/src/lib/context/scanner.spec.ts
@@ -1,0 +1,534 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+// based on https://github.com/microsoft/vscode/blob/76415ef0b1f60e0479bdfee173c1a4f97e785b52/src/vs/platform/contextkey/test/common/scanner.test.ts
+/* eslint-disable no-useless-escape */
+
+import * as assert from 'assert';
+import { TokenType, type Token, Scanner } from './scanner';
+
+function tokenTypeToStr(token: Token) {
+  switch (token.type) {
+    case TokenType.LParen:
+      return '(';
+    case TokenType.RParen:
+      return ')';
+    case TokenType.Neg:
+      return '!';
+    case TokenType.Eq:
+      return token.isTripleEq ? '===' : '==';
+    case TokenType.NotEq:
+      return token.isTripleEq ? '!==' : '!=';
+    case TokenType.Lt:
+      return '<';
+    case TokenType.LtEq:
+      return '<=';
+    case TokenType.Gt:
+      return '>';
+    case TokenType.GtEq:
+      return '>=';
+    case TokenType.RegexOp:
+      return '=~';
+    case TokenType.RegexStr:
+      return 'RegexStr';
+    case TokenType.True:
+      return 'true';
+    case TokenType.False:
+      return 'false';
+    case TokenType.In:
+      return 'in';
+    case TokenType.Not:
+      return 'not';
+    case TokenType.And:
+      return '&&';
+    case TokenType.Or:
+      return '||';
+    case TokenType.Str:
+      return 'Str';
+    case TokenType.QuotedStr:
+      return 'QuotedStr';
+    case TokenType.Error:
+      return 'ErrorToken';
+    case TokenType.EOF:
+      return 'EOF';
+  }
+}
+
+function scan(input: string) {
+  return new Scanner()
+    .reset(input)
+    .scan()
+    .map((token: Token) => {
+      return 'lexeme' in token
+        ? {
+            type: tokenTypeToStr(token),
+            offset: token.offset,
+            lexeme: token.lexeme,
+          }
+        : {
+            type: tokenTypeToStr(token),
+            offset: token.offset,
+          };
+    });
+}
+
+test('foo.bar<C-shift+2>', () => {
+  const input = 'foo.bar<C-shift+2>';
+  assert.deepStrictEqual(scan(input), [
+    { type: 'Str', lexeme: 'foo.bar<C-shift+2>', offset: 0 },
+    { type: 'EOF', offset: 18 },
+  ]);
+});
+
+test('!foo', () => {
+  const input = '!foo';
+  assert.deepStrictEqual(scan(input), [
+    { type: '!', offset: 0 },
+    { type: 'Str', lexeme: 'foo', offset: 1 },
+    { type: 'EOF', offset: 4 },
+  ]);
+});
+
+test('foo === bar', () => {
+  const input = 'foo === bar';
+  assert.deepStrictEqual(scan(input), [
+    { type: 'Str', offset: 0, lexeme: 'foo' },
+    { type: '===', offset: 4 },
+    { type: 'Str', offset: 8, lexeme: 'bar' },
+    { type: 'EOF', offset: 11 },
+  ]);
+});
+
+test('foo  !== bar', () => {
+  const input = 'foo  !== bar';
+  assert.deepStrictEqual(scan(input), [
+    { type: 'Str', offset: 0, lexeme: 'foo' },
+    { type: '!==', offset: 5 },
+    { type: 'Str', offset: 9, lexeme: 'bar' },
+    { type: 'EOF', offset: 12 },
+  ]);
+});
+
+test('!(foo && bar)', () => {
+  const input = '!(foo && bar)';
+  assert.deepStrictEqual(scan(input), [
+    { type: '!', offset: 0 },
+    { type: '(', offset: 1 },
+    { type: 'Str', lexeme: 'foo', offset: 2 },
+    { type: '&&', offset: 6 },
+    { type: 'Str', lexeme: 'bar', offset: 9 },
+    { type: ')', offset: 12 },
+    { type: 'EOF', offset: 13 },
+  ]);
+});
+
+test('=~ ', () => {
+  const input = '=~ ';
+  assert.deepStrictEqual(scan(input), [
+    { type: '=~', offset: 0 },
+    { type: 'EOF', offset: 3 },
+  ]);
+});
+
+test('foo =~ /bar/', () => {
+  const input = 'foo =~ /bar/';
+  assert.deepStrictEqual(scan(input), [
+    { type: 'Str', lexeme: 'foo', offset: 0 },
+    { type: '=~', offset: 4 },
+    { type: 'RegexStr', lexeme: '/bar/', offset: 7 },
+    { type: 'EOF', offset: 12 },
+  ]);
+});
+
+test('foo =~ /zee/i', () => {
+  const input = 'foo =~ /zee/i';
+  assert.deepStrictEqual(scan(input), [
+    { type: 'Str', lexeme: 'foo', offset: 0 },
+    { type: '=~', offset: 4 },
+    { type: 'RegexStr', lexeme: '/zee/i', offset: 7 },
+    { type: 'EOF', offset: 13 },
+  ]);
+});
+
+test('foo =~ /zee/gm', () => {
+  const input = 'foo =~ /zee/gm';
+  assert.deepStrictEqual(scan(input), [
+    { type: 'Str', lexeme: 'foo', offset: 0 },
+    { type: '=~', offset: 4 },
+    { type: 'RegexStr', lexeme: '/zee/gm', offset: 7 },
+    { type: 'EOF', offset: 14 },
+  ]);
+});
+
+test('foo in barrr  ', () => {
+  const input = 'foo in barrr  ';
+  assert.deepStrictEqual(scan(input), [
+    { type: 'Str', lexeme: 'foo', offset: 0 },
+    { type: 'in', offset: 4 },
+    { type: 'Str', lexeme: 'barrr', offset: 7 },
+    { type: 'EOF', offset: 14 },
+  ]);
+});
+
+test('resource =~ //FileCabinet/(SuiteScripts|Templates/(E-mail%20Templates|Marketing%20Templates)|Web%20Site%20Hosting%20Files)(/.*)*$/', () => {
+  const input =
+    'resource =~ //FileCabinet/(SuiteScripts|Templates/(E-mail%20Templates|Marketing%20Templates)|Web%20Site%20Hosting%20Files)(/.*)*$/';
+  assert.deepStrictEqual(scan(input), [
+    { type: 'Str', offset: 0, lexeme: 'resource' },
+    { type: '=~', offset: 9 },
+    { type: 'RegexStr', offset: 12, lexeme: '//' },
+    { type: 'Str', offset: 14, lexeme: 'FileCabinet/' },
+    { type: '(', offset: 26 },
+    { type: 'Str', offset: 27, lexeme: 'SuiteScripts' },
+    { type: 'ErrorToken', offset: 39, lexeme: '|' },
+    { type: 'Str', offset: 40, lexeme: 'Templates/' },
+    { type: '(', offset: 50 },
+    { type: 'Str', offset: 51, lexeme: 'E-mail%20Templates' },
+    { type: 'ErrorToken', offset: 69, lexeme: '|' },
+    { type: 'Str', offset: 70, lexeme: 'Marketing%20Templates' },
+    { type: ')', offset: 91 },
+    { type: 'ErrorToken', offset: 92, lexeme: '|' },
+    { type: 'Str', offset: 93, lexeme: 'Web%20Site%20Hosting%20Files' },
+    { type: ')', offset: 121 },
+    { type: '(', offset: 122 },
+    { type: 'RegexStr', offset: 123, lexeme: '/.*)*$/' },
+    { type: 'EOF', offset: 130 },
+  ]);
+});
+
+test('editorLangId in testely.supportedLangIds && resourceFilename =~ /^.+(.test.(w+))$/gm', () => {
+  const input = 'editorLangId in testely.supportedLangIds && resourceFilename =~ /^.+(.test.(w+))$/gm';
+  assert.deepStrictEqual(scan(input), [
+    { type: 'Str', lexeme: 'editorLangId', offset: 0 },
+    { type: 'in', offset: 13 },
+    { type: 'Str', lexeme: 'testely.supportedLangIds', offset: 16 },
+    { type: '&&', offset: 41 },
+    { type: 'Str', lexeme: 'resourceFilename', offset: 44 },
+    { type: '=~', offset: 61 },
+    { type: 'RegexStr', lexeme: '/^.+(.test.(w+))$/gm', offset: 64 },
+    { type: 'EOF', offset: 84 },
+  ]);
+});
+
+test('!(foo && bar) && baz', () => {
+  const input = '!(foo && bar) && baz';
+  assert.deepStrictEqual(scan(input), [
+    { type: '!', offset: 0 },
+    { type: '(', offset: 1 },
+    { type: 'Str', lexeme: 'foo', offset: 2 },
+    { type: '&&', offset: 6 },
+    { type: 'Str', lexeme: 'bar', offset: 9 },
+    { type: ')', offset: 12 },
+    { type: '&&', offset: 14 },
+    { type: 'Str', lexeme: 'baz', offset: 17 },
+    { type: 'EOF', offset: 20 },
+  ]);
+});
+
+test('foo.bar:zed==completed - equality with no space', () => {
+  const input = 'foo.bar:zed==completed';
+  assert.deepStrictEqual(scan(input), [
+    { type: 'Str', lexeme: 'foo.bar:zed', offset: 0 },
+    { type: '==', offset: 11 },
+    { type: 'Str', lexeme: 'completed', offset: 13 },
+    { type: 'EOF', offset: 22 },
+  ]);
+});
+
+test('a && b || c', () => {
+  const input = 'a && b || c';
+  assert.deepStrictEqual(scan(input), [
+    { type: 'Str', lexeme: 'a', offset: 0 },
+    { type: '&&', offset: 2 },
+    { type: 'Str', lexeme: 'b', offset: 5 },
+    { type: '||', offset: 7 },
+    { type: 'Str', lexeme: 'c', offset: 10 },
+    { type: 'EOF', offset: 11 },
+  ]);
+});
+
+test('fooBar && baz.jar && fee.bee<K-loo+1>', () => {
+  const input = 'fooBar && baz.jar && fee.bee<K-loo+1>';
+  assert.deepStrictEqual(scan(input), [
+    { type: 'Str', lexeme: 'fooBar', offset: 0 },
+    { type: '&&', offset: 7 },
+    { type: 'Str', lexeme: 'baz.jar', offset: 10 },
+    { type: '&&', offset: 18 },
+    { type: 'Str', lexeme: 'fee.bee<K-loo+1>', offset: 21 },
+    { type: 'EOF', offset: 37 },
+  ]);
+});
+
+test('foo.barBaz<C-r> < 2', () => {
+  const input = 'foo.barBaz<C-r> < 2';
+  assert.deepStrictEqual(scan(input), [
+    { type: 'Str', lexeme: 'foo.barBaz<C-r>', offset: 0 },
+    { type: '<', offset: 16 },
+    { type: 'Str', lexeme: '2', offset: 18 },
+    { type: 'EOF', offset: 19 },
+  ]);
+});
+
+test('foo.bar >= -1', () => {
+  const input = 'foo.bar >= -1';
+  assert.deepStrictEqual(scan(input), [
+    { type: 'Str', lexeme: 'foo.bar', offset: 0 },
+    { type: '>=', offset: 8 },
+    { type: 'Str', lexeme: '-1', offset: 11 },
+    { type: 'EOF', offset: 13 },
+  ]);
+});
+
+test('foo.bar <= -1', () => {
+  const input = 'foo.bar <= -1';
+  assert.deepStrictEqual(scan(input), [
+    { type: 'Str', lexeme: 'foo.bar', offset: 0 },
+    { type: '<=', offset: 8 },
+    { type: 'Str', lexeme: '-1', offset: 11 },
+    { type: 'EOF', offset: 13 },
+  ]);
+});
+
+test('resource =~ /\\/Objects\\/.+\\.xml$/', () => {
+  const input = 'resource =~ /\\/Objects\\/.+\\.xml$/';
+  assert.deepStrictEqual(scan(input), [
+    { type: 'Str', lexeme: 'resource', offset: 0 },
+    { type: '=~', offset: 9 },
+    { type: 'RegexStr', lexeme: '/\\/Objects\\/.+\\.xml$/', offset: 12 },
+    { type: 'EOF', offset: 33 },
+  ]);
+});
+
+test('view == vsc-packages-activitybar-folders && vsc-packages-folders-loaded', () => {
+  const input = 'view == vsc-packages-activitybar-folders && vsc-packages-folders-loaded';
+  assert.deepStrictEqual(scan(input), [
+    { type: 'Str', lexeme: 'view', offset: 0 },
+    { type: '==', offset: 5 },
+    { type: 'Str', lexeme: 'vsc-packages-activitybar-folders', offset: 8 },
+    { type: '&&', offset: 41 },
+    { type: 'Str', lexeme: 'vsc-packages-folders-loaded', offset: 44 },
+    { type: 'EOF', offset: 71 },
+  ]);
+});
+
+test('sfdx:project_opened && resource =~ /.*\\/functions\\/.*\\/[^\\/]+(\\/[^\\/]+.(ts|js|java|json|toml))?$/ && resourceFilename != package.json && resourceFilename != package-lock.json && resourceFilename != tsconfig.json', () => {
+  const input =
+    'sfdx:project_opened && resource =~ /.*\\/functions\\/.*\\/[^\\/]+(\\/[^\\/]+.(ts|js|java|json|toml))?$/ && resourceFilename != package.json && resourceFilename != package-lock.json && resourceFilename != tsconfig.json';
+  assert.deepStrictEqual(scan(input), [
+    { type: 'Str', lexeme: 'sfdx:project_opened', offset: 0 },
+    { type: '&&', offset: 20 },
+    { type: 'Str', lexeme: 'resource', offset: 23 },
+    { type: '=~', offset: 32 },
+    { type: 'RegexStr', lexeme: '/.*\\/functions\\/.*\\/[^\\/]+(\\/[^\\/]+.(ts|js|java|json|toml))?$/', offset: 35 },
+    { type: '&&', offset: 98 },
+    { type: 'Str', lexeme: 'resourceFilename', offset: 101 },
+    { type: '!=', offset: 118 },
+    { type: 'Str', lexeme: 'package.json', offset: 121 },
+    { type: '&&', offset: 134 },
+    { type: 'Str', lexeme: 'resourceFilename', offset: 137 },
+    { type: '!=', offset: 154 },
+    { type: 'Str', lexeme: 'package-lock.json', offset: 157 },
+    { type: '&&', offset: 175 },
+    { type: 'Str', lexeme: 'resourceFilename', offset: 178 },
+    { type: '!=', offset: 195 },
+    { type: 'Str', lexeme: 'tsconfig.json', offset: 198 },
+    { type: 'EOF', offset: 211 },
+  ]);
+});
+
+test("view =~ '/(servers)/' && viewItem =~ '/^(Starting|Started|Debugging|Stopping|Stopped)/'", () => {
+  const input = "view =~ '/(servers)/' && viewItem =~ '/^(Starting|Started|Debugging|Stopping|Stopped)/'";
+  assert.deepStrictEqual(scan(input), [
+    { type: 'Str', lexeme: 'view', offset: 0 },
+    { type: '=~', offset: 5 },
+    { type: 'QuotedStr', lexeme: '/(servers)/', offset: 9 },
+    { type: '&&', offset: 22 },
+    { type: 'Str', lexeme: 'viewItem', offset: 25 },
+    { type: '=~', offset: 34 },
+    { type: 'QuotedStr', lexeme: '/^(Starting|Started|Debugging|Stopping|Stopped)/', offset: 38 },
+    { type: 'EOF', offset: 87 },
+  ]);
+});
+
+test('resourcePath =~ /.md(.yml|.txt)*$/gim', () => {
+  const input = 'resourcePath =~ /.md(.yml|.txt)*$/gim';
+  assert.deepStrictEqual(scan(input), [
+    { type: 'Str', offset: 0, lexeme: 'resourcePath' },
+    { type: '=~', offset: 13 },
+    { type: 'RegexStr', offset: 16, lexeme: '/.md(.yml|.txt)*$/gim' },
+    { type: 'EOF', offset: 37 },
+  ]);
+});
+
+test("foo === bar'", () => {
+  const input = "foo === bar'";
+  assert.deepStrictEqual(scan(input), [
+    { type: 'Str', offset: 0, lexeme: 'foo' },
+    { type: '===', offset: 4 },
+    { type: 'Str', offset: 8, lexeme: 'bar' },
+    { type: 'ErrorToken', offset: 11, lexeme: "'" },
+    { type: 'EOF', offset: 12 },
+  ]);
+});
+
+test("foo === '", () => {
+  const input = "foo === '";
+  assert.deepStrictEqual(scan(input), [
+    { type: 'Str', offset: 0, lexeme: 'foo' },
+    { type: '===', offset: 4 },
+    { type: 'ErrorToken', offset: 8, lexeme: "'" },
+    { type: 'EOF', offset: 9 },
+  ]);
+});
+
+test("foo && 'bar - unterminated single quote", () => {
+  const input = "foo && 'bar";
+  assert.deepStrictEqual(scan(input), [
+    { type: 'Str', lexeme: 'foo', offset: 0 },
+    { type: '&&', offset: 4 },
+    { type: 'ErrorToken', offset: 7, lexeme: "'bar" },
+    { type: 'EOF', offset: 11 },
+  ]);
+});
+
+test('vim<c-r> == 1 && vim<2 <= 3', () => {
+  const input = 'vim<c-r> == 1 && vim<2 <= 3';
+  assert.deepStrictEqual(scan(input), [
+    { type: 'Str', lexeme: 'vim<c-r>', offset: 0 },
+    { type: '==', offset: 9 },
+    { type: 'Str', lexeme: '1', offset: 12 },
+    { type: '&&', offset: 14 },
+    { type: 'Str', lexeme: 'vim<2', offset: 17 },
+    { type: '<=', offset: 23 },
+    { type: 'Str', lexeme: '3', offset: 26 },
+    { type: 'EOF', offset: 27 },
+  ]);
+});
+
+test('vim<c-r>==1 && vim<2<=3', () => {
+  const input = 'vim<c-r>==1 && vim<2<=3';
+  assert.deepStrictEqual(scan(input), [
+    { type: 'Str', offset: 0, lexeme: 'vim<c-r>' },
+    { type: '==', offset: 8 },
+    { type: 'Str', offset: 10, lexeme: '1' },
+    { type: '&&', offset: 12 },
+    { type: 'Str', offset: 15, lexeme: 'vim<2<' },
+    { type: 'ErrorToken', offset: 21, lexeme: '=' },
+    { type: 'Str', offset: 22, lexeme: '3' },
+    { type: 'EOF', offset: 23 },
+  ]);
+});
+
+test('foo|bar', () => {
+  const input = 'foo|bar';
+  assert.deepStrictEqual(scan(input), [
+    { type: 'Str', offset: 0, lexeme: 'foo' },
+    { type: 'ErrorToken', offset: 3, lexeme: '|' },
+    { type: 'Str', offset: 4, lexeme: 'bar' },
+    { type: 'EOF', offset: 7 },
+  ]);
+});
+
+test('resource =~ //foo/(barr|door/(Foo-Bar%20Templates|Soo%20Looo)|Web%20Site%Jjj%20Llll)(/.*)*$/', () => {
+  const input = 'resource =~ //foo/(barr|door/(Foo-Bar%20Templates|Soo%20Looo)|Web%20Site%Jjj%20Llll)(/.*)*$/';
+  assert.deepStrictEqual(scan(input), [
+    { type: 'Str', offset: 0, lexeme: 'resource' },
+    { type: '=~', offset: 9 },
+    { type: 'RegexStr', offset: 12, lexeme: '//' },
+    { type: 'Str', offset: 14, lexeme: 'foo/' },
+    { type: '(', offset: 18 },
+    { type: 'Str', offset: 19, lexeme: 'barr' },
+    { type: 'ErrorToken', offset: 23, lexeme: '|' },
+    { type: 'Str', offset: 24, lexeme: 'door/' },
+    { type: '(', offset: 29 },
+    { type: 'Str', offset: 30, lexeme: 'Foo-Bar%20Templates' },
+    { type: 'ErrorToken', offset: 49, lexeme: '|' },
+    { type: 'Str', offset: 50, lexeme: 'Soo%20Looo' },
+    { type: ')', offset: 60 },
+    { type: 'ErrorToken', offset: 61, lexeme: '|' },
+    { type: 'Str', offset: 62, lexeme: 'Web%20Site%Jjj%20Llll' },
+    { type: ')', offset: 83 },
+    { type: '(', offset: 84 },
+    { type: 'RegexStr', offset: 85, lexeme: '/.*)*$/' },
+    { type: 'EOF', offset: 92 },
+  ]);
+});
+
+test('/((/foo/(?!bar)(.*)/)|((/src/).*/)).*$/', () => {
+  const input = '/((/foo/(?!bar)(.*)/)|((/src/).*/)).*$/';
+  assert.deepStrictEqual(scan(input), [
+    { type: 'RegexStr', offset: 0, lexeme: '/((/' },
+    { type: 'Str', offset: 4, lexeme: 'foo/' },
+    { type: '(', offset: 8 },
+    { type: 'Str', offset: 9, lexeme: '?' },
+    { type: '!', offset: 10 },
+    { type: 'Str', offset: 11, lexeme: 'bar' },
+    { type: ')', offset: 14 },
+    { type: '(', offset: 15 },
+    { type: 'Str', offset: 16, lexeme: '.*' },
+    { type: ')', offset: 18 },
+    { type: 'RegexStr', offset: 19, lexeme: '/)|((/s' },
+    { type: 'Str', offset: 26, lexeme: 'rc/' },
+    { type: ')', offset: 29 },
+    { type: 'Str', offset: 30, lexeme: '.*/' },
+    { type: ')', offset: 33 },
+    { type: ')', offset: 34 },
+    { type: 'Str', offset: 35, lexeme: '.*$/' },
+    { type: 'EOF', offset: 39 },
+  ]);
+});
+
+test('resourcePath =~ //foo/barr// || resourcePath =~ //view/(jarrr|doooor|bees)/(web|templates)// && resourceExtname in foo.Bar', () => {
+  const input =
+    'resourcePath =~ //foo/barr// || resourcePath =~ //view/(jarrr|doooor|bees)/(web|templates)// && resourceExtname in foo.Bar';
+  assert.deepStrictEqual(scan(input), [
+    { type: 'Str', offset: 0, lexeme: 'resourcePath' },
+    { type: '=~', offset: 13 },
+    { type: 'RegexStr', offset: 16, lexeme: '//' },
+    { type: 'Str', offset: 18, lexeme: 'foo/barr//' },
+    { type: '||', offset: 29 },
+    { type: 'Str', offset: 32, lexeme: 'resourcePath' },
+    { type: '=~', offset: 45 },
+    { type: 'RegexStr', offset: 48, lexeme: '//' },
+    { type: 'Str', offset: 50, lexeme: 'view/' },
+    { type: '(', offset: 55 },
+    { type: 'Str', offset: 56, lexeme: 'jarrr' },
+    { type: 'ErrorToken', offset: 61, lexeme: '|' },
+    { type: 'Str', offset: 62, lexeme: 'doooor' },
+    { type: 'ErrorToken', offset: 68, lexeme: '|' },
+    { type: 'Str', offset: 69, lexeme: 'bees' },
+    { type: ')', offset: 73 },
+    { type: 'RegexStr', offset: 74, lexeme: '/(web|templates)/' },
+    { type: 'ErrorToken', offset: 91, lexeme: '/ && resourceExtname in foo.Bar' },
+    { type: 'EOF', offset: 122 },
+  ]);
+});
+
+test('foo =~ /file:// || bar', () => {
+  const input = JSON.parse('"foo =~ /file:// || bar"');
+  assert.deepStrictEqual(scan(input), [
+    { type: 'Str', offset: 0, lexeme: 'foo' },
+    { type: '=~', offset: 4 },
+    { type: 'RegexStr', offset: 7, lexeme: '/file:/' },
+    { type: 'ErrorToken', offset: 14, lexeme: '/ || bar' },
+    { type: 'EOF', offset: 22 },
+  ]);
+});

--- a/packages/renderer/src/lib/context/scanner.ts
+++ b/packages/renderer/src/lib/context/scanner.ts
@@ -26,7 +26,15 @@ import { CharCode } from '../../../../main/src/plugin/util/charCode';
 export const enum TokenType {
   LParen,
   RParen,
+  Neg,
   Eq,
+  NotEq,
+  Lt,
+  LtEq,
+  Gt,
+  GtEq,
+  RegexOp,
+  RegexStr,
   True,
   False,
   In,
@@ -42,7 +50,15 @@ export const enum TokenType {
 export type Token =
   | { type: TokenType.LParen; offset: number }
   | { type: TokenType.RParen; offset: number }
+  | { type: TokenType.Neg; offset: number }
   | { type: TokenType.Eq; offset: number; isTripleEq: boolean }
+  | { type: TokenType.NotEq; offset: number; isTripleEq: boolean }
+  | { type: TokenType.Lt; offset: number }
+  | { type: TokenType.LtEq; offset: number }
+  | { type: TokenType.Gt; offset: number }
+  | { type: TokenType.GtEq; offset: number }
+  | { type: TokenType.RegexOp; offset: number }
+  | { type: TokenType.RegexStr; offset: number; lexeme: string }
   | { type: TokenType.True; offset: number }
   | { type: TokenType.False; offset: number }
   | { type: TokenType.In; offset: number }
@@ -58,6 +74,12 @@ type KeywordTokenType = TokenType.Not | TokenType.In | TokenType.False | TokenTy
 type TokenTypeWithoutLexeme =
   | TokenType.LParen
   | TokenType.RParen
+  | TokenType.Neg
+  | TokenType.Lt
+  | TokenType.LtEq
+  | TokenType.Gt
+  | TokenType.GtEq
+  | TokenType.RegexOp
   | TokenType.True
   | TokenType.False
   | TokenType.In
@@ -76,6 +98,23 @@ export type LexingError = {
   lexeme: string;
   additionalInfo?: string;
 };
+
+function hintDidYouMean(...meant: string[]) {
+  switch (meant.length) {
+    case 1:
+      return `Did you mean ${meant[0]}?`;
+    case 2:
+      return `Did you mean ${meant[0]} or ${meant[1]}?`;
+    case 3:
+      return `Did you mean ${meant[0]}, ${meant[1]} or ${meant[2]}?`;
+    default: // we just don't expect that many
+      return undefined;
+  }
+}
+
+const hintDidYouForgetToOpenOrCloseQuote = 'Did you forget to open or close the quote?';
+const hintDidYouForgetToEscapeSlash =
+  "Did you forget to escape the '/' (slash) character? Put two backslashes before it to escape, e.g., '\\\\/\\'.";
 
 /**
  * A simple scanner for context keys.
@@ -99,8 +138,24 @@ export class Scanner {
         return '(';
       case TokenType.RParen:
         return ')';
+      case TokenType.Neg:
+        return '!';
       case TokenType.Eq:
         return token.isTripleEq ? '===' : '==';
+      case TokenType.NotEq:
+        return token.isTripleEq ? '!==' : '!=';
+      case TokenType.Lt:
+        return '<';
+      case TokenType.LtEq:
+        return '<=';
+      case TokenType.Gt:
+        return '>=';
+      case TokenType.GtEq:
+        return '>=';
+      case TokenType.RegexOp:
+        return '=~';
+      case TokenType.RegexStr:
+        return token.lexeme;
       case TokenType.True:
         return 'true';
       case TokenType.False:
@@ -125,6 +180,8 @@ export class Scanner {
         throw new Error(`unhandled token type: ${JSON.stringify(token)}; have you forgotten to add a case?`);
     }
   }
+
+  private static _regexFlags = new Set(['i', 'g', 's', 'm', 'y', 'u'].map(ch => ch.charCodeAt(0)));
 
   private static _keywords = new Map<string, KeywordTokenType>([
     ['not', TokenType.Not],
@@ -166,27 +223,57 @@ export class Scanner {
         case CharCode.CloseParen:
           this._addToken(TokenType.RParen);
           break;
+
+        case CharCode.ExclamationMark:
+          if (this._match(CharCode.Equals)) {
+            const isTripleEq = this._match(CharCode.Equals); // eat last `=` if `!==`
+            this._tokens.push({ type: TokenType.NotEq, offset: this._start, isTripleEq });
+          } else {
+            this._addToken(TokenType.Neg);
+          }
+          break;
+
+        case CharCode.SingleQuote:
+          this._quotedString();
+          break;
+        case CharCode.Slash:
+          this._regex();
+          break;
+
         case CharCode.Equals:
           if (this._match(CharCode.Equals)) {
             // support `==`
             const isTripleEq = this._match(CharCode.Equals); // eat last `=` if `===`
             this._tokens.push({ type: TokenType.Eq, offset: this._start, isTripleEq });
+          } else if (this._match(CharCode.Tilde)) {
+            this._addToken(TokenType.RegexOp);
+          } else {
+            this._error(hintDidYouMean('==', '=~'));
           }
           break;
+
+        case CharCode.LessThan:
+          this._addToken(this._match(CharCode.Equals) ? TokenType.LtEq : TokenType.Lt);
+          break;
+
+        case CharCode.GreaterThan:
+          this._addToken(this._match(CharCode.Equals) ? TokenType.GtEq : TokenType.Gt);
+          break;
+
         case CharCode.Ampersand:
           if (this._match(CharCode.Ampersand)) {
             this._addToken(TokenType.And);
+          } else {
+            this._error(hintDidYouMean('&&'));
           }
           break;
 
         case CharCode.Pipe:
           if (this._match(CharCode.Pipe)) {
             this._addToken(TokenType.Or);
+          } else {
+            this._error(hintDidYouMean('||'));
           }
-          break;
-
-        case CharCode.SingleQuote:
-          this._quotedString();
           break;
 
         // TODO@ulugbekna: 1) rewrite using a regex 2) reconsider what characters are considered whitespace, including unicode, nbsp, etc.
@@ -240,8 +327,8 @@ export class Scanner {
   }
 
   // u - unicode, y - sticky
-  // TODO@ulugbekna: we accept double quotes as part of the string rather than as a delimiter (to preserve old parser's behavior)
-  // eslint-disable-next-line no-useless-escape
+  // TODO we accept double quotes as part of the string rather than as a delimiter (to preserve old parser's behavior)
+  /* eslint-disable-next-line no-useless-escape */
   private stringRe = /[a-zA-Z0-9_<>\-\./\\:\*\?\+\[\]\^,#@;"%\$\p{L}-]+/uy;
   private _string() {
     this.stringRe.lastIndex = this._start;
@@ -261,12 +348,11 @@ export class Scanner {
   // captures the lexeme without the leading and trailing '
   private _quotedString() {
     while (this._peek() !== CharCode.SingleQuote && !this._isAtEnd()) {
-      // TODO@ulugbekna: add support for escaping ' ?
       this._advance();
     }
 
     if (this._isAtEnd()) {
-      this._error('Did you forget to open or close the quote?');
+      this._error(hintDidYouForgetToOpenOrCloseQuote);
       return;
     }
 
@@ -278,6 +364,55 @@ export class Scanner {
       lexeme: this._input.substring(this._start + 1, this._current - 1),
       offset: this._start + 1,
     });
+  }
+
+  /*
+   * Lexing a regex expression: /.../[igsmyu]*
+   * Based on https://github.com/microsoft/TypeScript/blob/9247ef115e617805983740ba795d7a8164babf89/src/compiler/scanner.ts#L2129-L2181
+   *
+   * Note that we want slashes within a regex to be escaped, e.g., /file:\\/\\/\\// should match `file:///`
+   */
+  private _regex() {
+    let p = this._current;
+
+    let inEscape = false;
+    let inCharacterClass = false;
+    /* eslint-disable-next-line no-constant-condition */
+    while (true) {
+      if (p >= this._input.length) {
+        this._current = p;
+        this._error(hintDidYouForgetToEscapeSlash);
+        return;
+      }
+
+      const ch = this._input.charCodeAt(p);
+
+      if (inEscape) {
+        // parsing an escape character
+        inEscape = false;
+      } else if (ch === CharCode.Slash && !inCharacterClass) {
+        // end of regex
+        p++;
+        break;
+      } else if (ch === CharCode.OpenSquareBracket) {
+        inCharacterClass = true;
+      } else if (ch === CharCode.Backslash) {
+        inEscape = true;
+      } else if (ch === CharCode.CloseSquareBracket) {
+        inCharacterClass = false;
+      }
+      p++;
+    }
+
+    // Consume flags
+    while (p < this._input.length && Scanner._regexFlags.has(this._input.charCodeAt(p))) {
+      p++;
+    }
+
+    this._current = p;
+
+    const lexeme = this._input.substring(this._start, this._current);
+    this._tokens.push({ type: TokenType.RegexStr, lexeme, offset: this._start });
   }
 
   private _isAtEnd() {


### PR DESCRIPTION
### What does this PR do?

This PR extends the context/contextkey implemention.
The context is now able to retrieve values using complex keys such as 'key.prop1.prop2'. This way if the context value is an object we can get a property value.

The contextKey is extended to support and, or, equal, not equal, true, false, Lt, LtEq, Gt, GtEq, EOF, RegexOp and RegexStr operations.

All of this will be used in the onboarding PR.

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

N/A, this is part of the onboarding PR

### How to test this PR?

run tests
