### PR TITLE
feat: initial onboarding implementation - podman installation

### DIFF
--- a/extensions/podman/package.json
+++ b/extensions/podman/package.json
@@ -124,13 +124,13 @@
           "id": "startPodmanInstallation",
           "label": "Start Setup",
           "title": "We could not find Podman. Let's install it!",
-          "when": "onContext:podmanIsNotInstalled == true"
+          "when": "onboardingContext:podmanIsNotInstalled == true"
         },
         {
           "id": "checkPodmanRequirements",
           "label": "Check System",
           "title": "Checking for system requirements to install Podman",
-          "when": "onContext:podmanIsNotInstalled == true",
+          "when": "onboardingContext:podmanIsNotInstalled == true",
           "command": "podman.onboarding.checkPodmanRequirements",
           "completionEvents": [
             "onCommand:podman.onboarding.checkPodmanRequirements"
@@ -140,14 +140,14 @@
           "id": "missingRequirementView",
           "label": "Fix System",
           "title": "Some system requirements are missing",
-          "when": "onContext:requirementsStatus == failed && onContext:podmanIsNotInstalled == true",
+          "when": "onboardingContext:requirementsStatus == failed && onboardingContext:podmanIsNotInstalled == true",
           "completionEvents": [
-            "onContext:requirementsStatus == ok"
+            "onboardingContext:requirementsStatus == ok"
           ],
           "content": [
             [
               {
-                "value": "${onContext:warningsMarkdown}",
+                "value": "${onboardingContext:warningsMarkdown}",
                 "highlight": true
               }
             ],
@@ -170,7 +170,7 @@
           "label": "Install Podman",
           "title": "Installing Podman",
           "description": "Once installed, we will enable and configure the extension",
-          "when": "onContext:podmanIsNotInstalled == true",
+          "when": "onboardingContext:podmanIsNotInstalled == true",
           "command": "podman.onboarding.installPodman",
           "completionEvents": [
             "onCommand:podman.onboarding.installPodman"
@@ -180,13 +180,13 @@
           "id": "podmanFailedInstallation",
           "label": "Done",
           "title": "Failed installing Podman",
-          "when": "onContext:podmanIsNotInstalled == true"
+          "when": "onboardingContext:podmanIsNotInstalled == true"
         },
         {
           "id": "podmanInstalled",
           "label": "Done",
           "title": "Podman successfully installed",
-          "when": "onContext:podmanIsNotInstalled == false"
+          "when": "onboardingContext:podmanIsNotInstalled == false"
         }
       ]
     }

--- a/extensions/podman/package.json
+++ b/extensions/podman/package.json
@@ -15,6 +15,18 @@
       {
         "command": "podman.info",
         "title": "podman: Specific info about podman"
+      },
+      {
+        "command": "podman.onboarding.checkPodmanInstalled",
+        "title": "podman: Check podman installation"
+      },
+      {
+        "command": "podman.onboarding.checkPodmanRequirements",
+        "title": "podman: Check system requirements to install podman"
+      },
+      {
+        "command": "podman.onboarding.installPodman",
+        "title": "podman: Install podman"
       }
     ],
     "configuration": {
@@ -95,6 +107,152 @@
           "description": "Machine with root privileges"
         }
       }
+    },
+    "onboarding": {
+      "title": "Get started with Podman Desktop",
+      "steps": [
+        {
+          "id": "podmanSetup",
+          "title": "Podman Setup",
+          "commands": [
+            {
+              "id": "checkPodmanInstalled",
+              "command": "podman.onboarding.checkPodmanInstalled",
+              "response": {
+                "status": "string",
+                "installed": "string"
+              }
+            },
+            {
+              "id": "checkPodmanRequirements",
+              "command": "podman.onboarding.checkPodmanRequirements",
+              "response": {
+                "status": "string",
+                "warningsMarkdown": "string"
+              }
+            },
+            {
+              "id": "installPodman",
+              "command": "podman.onboarding.installPodman",
+              "response": {
+                "status": "string"
+              }
+            }
+          ],
+          "views": [
+            {
+              "id": "checkPodmanInstalledView",
+              "title": "Checking for Podman installation",
+              "media": {
+                "path": "icon.png",
+                "altText": "podman logo"
+              },
+              "commandAtActivation": [
+                {
+                  "command": "checkPodmanInstalled"
+                }
+              ],
+              "completionEvents": [
+                "onCommandResult:checkPodmanInstalled"
+              ]
+            },
+            {
+              "id": "startPodmanInstallation",
+              "title": "We could not find Podman. Let's install it!",
+              "media": {
+                "path": "icon.png",
+                "altText": "podman logo"
+              },
+              "when": "onCommandResult:checkPodmanInstalled.installed == failed"
+            },
+            {
+              "id": "checkPodmanRequirements",
+              "title": "Checking for system requirements to install Podman",
+              "media": {
+                "path": "icon.png",
+                "altText": "podman logo"
+              },
+              "when": "onCommandResult:checkPodmanInstalled.installed == failed",
+              "commandAtActivation": [
+                {
+                  "command": "checkPodmanRequirements"
+                }
+              ],
+              "completionEvents": [
+                "onCommandResult:checkPodmanRequirements"
+              ]
+            },
+            {
+              "id": "missingRequirementView",
+              "title": "Some system requirements are missing",
+              "media": {
+                "path": "icon.png",
+                "altText": "podman logo"
+              },
+              "when": "onCommandResult:checkPodmanRequirements.status == failed && onCommandResult:checkPodmanInstalled.installed == failed",
+              "completionEvents": [
+                "onCommandResult:checkPodmanRequirements.status == ok"
+              ],
+              "content": [
+                [
+                  {
+                    "value": "${checkPodmanRequirements.warningsMarkdown}",
+                    "template": "dark_bg"
+                  }
+                ],
+                [
+                  {
+                    "value": "When possible, we've provided information on how to address these requirements."
+                  }
+                ],
+                [
+                  {
+                    "label": "Check requirements again",
+                    "command": "checkPodmanRequirements",
+                    "component": "button"
+                  }
+                ]
+              ]
+            },
+            {
+              "id": "installPodman",
+              "title": "Installing Podman",
+              "description": "Once installed, we will enable and configure the extension",
+              "media": {
+                "path": "icon.png",
+                "altText": "podman logo"
+              },
+              "when": "onCommandResult:checkPodmanInstalled.installed == failed",
+              "commandAtActivation": [
+                {
+                  "command": "installPodman"
+                }
+              ],
+              "completionEvents": [
+                "onCommandResult:installPodman"
+              ]
+            },
+            {
+              "id": "podmanFailedInstallation",
+              "title": "Failed installing Podman",
+              "media": {
+                "path": "icon.png",
+                "altText": "podman logo"
+              },
+              "when": "onCommandResult:installPodman.status == failed && onCommandResult:checkPodmanInstalled.installed == failed"
+            },
+            {
+              "id": "podmanInstalled",
+              "title": "Podman successfully installed",
+              "media": {
+                "path": "icon.png",
+                "altText": "podman logo"
+              },
+              "when": "onCommandResult:installPodman.status == ok || onCommandResult:checkPodmanInstalled.installed == ok"
+            }
+          ]
+        }
+      ]
     }
   },
   "scripts": {

--- a/extensions/podman/package.json
+++ b/extensions/podman/package.json
@@ -109,148 +109,88 @@
       }
     },
     "onboarding": {
-      "title": "Get started with Podman Desktop",
+      "title": "Podman Setup",
+      "media": {
+        "path": "icon.png",
+        "altText": "podman logo"
+      },
       "steps": [
         {
-          "id": "podmanSetup",
-          "title": "Podman Setup",
-          "commands": [
-            {
-              "id": "checkPodmanInstalled",
-              "command": "podman.onboarding.checkPodmanInstalled",
-              "response": {
-                "status": "string",
-                "installed": "string"
-              }
-            },
-            {
-              "id": "checkPodmanRequirements",
-              "command": "podman.onboarding.checkPodmanRequirements",
-              "response": {
-                "status": "string",
-                "warningsMarkdown": "string"
-              }
-            },
-            {
-              "id": "installPodman",
-              "command": "podman.onboarding.installPodman",
-              "response": {
-                "status": "string"
-              }
-            }
-          ],
-          "views": [
-            {
-              "id": "checkPodmanInstalledView",
-              "title": "Checking for Podman installation",
-              "media": {
-                "path": "icon.png",
-                "altText": "podman logo"
-              },
-              "commandAtActivation": [
-                {
-                  "command": "checkPodmanInstalled"
-                }
-              ],
-              "completionEvents": [
-                "checkPodmanInstalled"
-              ]
-            },
-            {
-              "id": "startPodmanInstallation",
-              "title": "We could not find Podman. Let's install it!",
-              "media": {
-                "path": "icon.png",
-                "altText": "podman logo"
-              },
-              "when": "checkPodmanInstalled.installed == failed"
-            },
-            {
-              "id": "checkPodmanRequirements",
-              "title": "Checking for system requirements to install Podman",
-              "media": {
-                "path": "icon.png",
-                "altText": "podman logo"
-              },
-              "when": "checkPodmanInstalled.installed == failed",
-              "commandAtActivation": [
-                {
-                  "command": "checkPodmanRequirements"
-                }
-              ],
-              "completionEvents": [
-                "checkPodmanRequirements"
-              ]
-            },
-            {
-              "id": "missingRequirementView",
-              "title": "Some system requirements are missing",
-              "media": {
-                "path": "icon.png",
-                "altText": "podman logo"
-              },
-              "when": "checkPodmanRequirements.status == failed && checkPodmanInstalled.installed == failed",
-              "completionEvents": [
-                "checkPodmanRequirements.status == ok"
-              ],
-              "content": [
-                [
-                  {
-                    "value": "${checkPodmanRequirements.warningsMarkdown}",
-                    "template": "dark_bg"
-                  }
-                ],
-                [
-                  {
-                    "value": "When possible, we've provided information on how to address these requirements."
-                  }
-                ],
-                [
-                  {
-                    "label": "Check requirements again",
-                    "command": "checkPodmanRequirements",
-                    "component": "button"
-                  }
-                ]
-              ]
-            },
-            {
-              "id": "installPodmanView",
-              "title": "Installing Podman",
-              "description": "Once installed, we will enable and configure the extension",
-              "media": {
-                "path": "icon.png",
-                "altText": "podman logo"
-              },
-              "when": "checkPodmanInstalled.installed == failed",
-              "commandAtActivation": [
-                {
-                  "command": "installPodman"
-                }
-              ],
-              "completionEvents": [
-                "installPodman"
-              ]
-            },
-            {
-              "id": "podmanFailedInstallation",
-              "title": "Failed installing Podman",
-              "media": {
-                "path": "icon.png",
-                "altText": "podman logo"
-              },
-              "when": "installPodman.status == failed && checkPodmanInstalled.installed == failed"
-            },
-            {
-              "id": "podmanInstalled",
-              "title": "Podman successfully installed",
-              "media": {
-                "path": "icon.png",
-                "altText": "podman logo"
-              },
-              "when": "installPodman.status == ok || checkPodmanInstalled.installed == ok"
-            }
+          "id": "checkPodmanInstalled",
+          "label": "Check Podman",
+          "title": "Checking for Podman installation",
+          "command": "podman.onboarding.checkPodmanInstalled",
+          "completionEvents": [
+            "onCommand:podman.onboarding.checkPodmanInstalled"
           ]
+        },
+        {
+          "id": "startPodmanInstallation",
+          "label": "Start Setup",
+          "title": "We could not find Podman. Let's install it!",
+          "when": "onboarding.podman.isNotInstalled == true"
+        },
+        {
+          "id": "checkPodmanRequirements",
+          "label": "Check System",
+          "title": "Checking for system requirements to install Podman",
+          "when": "onboarding.podman.isNotInstalled == true",
+          "command": "podman.onboarding.checkPodmanRequirements",
+          "completionEvents": [
+            "onCommand:podman.onboarding.checkPodmanRequirements"
+          ]
+        },
+        {
+          "id": "missingRequirementView",
+          "label": "Fix System",
+          "title": "Some system requirements are missing",
+          "when": "onboarding.podman.requirementsStatus == failed && onboarding.podman.isNotInstalled == true",
+          "completionEvents": [
+            "onContext:onboarding.podman.requirementsStatus == ok"
+          ],
+          "content": [
+            [
+              {
+                "value": "${onContext:onboarding.podman.warningsMarkdown}",
+                "highlight": true
+              }
+            ],
+            [
+              {
+                "value": "When possible, we've provided information on how to address these requirements."
+              }
+            ],
+            [
+              {
+                "label": "Check requirements again",
+                "command": "podman.onboarding.checkPodmanRequirements",
+                "component": "button"
+              }
+            ]
+          ]
+        },
+        {
+          "id": "installPodmanView",
+          "label": "Install Podman",
+          "title": "Installing Podman",
+          "description": "Once installed, we will enable and configure the extension",
+          "when": "onboarding.podman.isNotInstalled == true",
+          "command": "podman.onboarding.installPodman",
+          "completionEvents": [
+            "onCommand:podman.onboarding.installPodman"
+          ]
+        },
+        {
+          "id": "podmanFailedInstallation",
+          "label": "Done",
+          "title": "Failed installing Podman",
+          "when": "onboarding.podman.isNotInstalled == true"
+        },
+        {
+          "id": "podmanInstalled",
+          "label": "Done",
+          "title": "Podman successfully installed",
+          "when": "onboarding.podman.isNotInstalled == false"
         }
       ]
     }

--- a/extensions/podman/package.json
+++ b/extensions/podman/package.json
@@ -110,10 +110,6 @@
     },
     "onboarding": {
       "title": "Podman Setup",
-      "media": {
-        "path": "icon.png",
-        "altText": "podman logo"
-      },
       "steps": [
         {
           "id": "checkPodmanInstalled",
@@ -128,13 +124,13 @@
           "id": "startPodmanInstallation",
           "label": "Start Setup",
           "title": "We could not find Podman. Let's install it!",
-          "when": "onboarding.podman.isNotInstalled == true"
+          "when": "onContext:podmanIsNotInstalled == true"
         },
         {
           "id": "checkPodmanRequirements",
           "label": "Check System",
           "title": "Checking for system requirements to install Podman",
-          "when": "onboarding.podman.isNotInstalled == true",
+          "when": "onContext:podmanIsNotInstalled == true",
           "command": "podman.onboarding.checkPodmanRequirements",
           "completionEvents": [
             "onCommand:podman.onboarding.checkPodmanRequirements"
@@ -144,14 +140,14 @@
           "id": "missingRequirementView",
           "label": "Fix System",
           "title": "Some system requirements are missing",
-          "when": "onboarding.podman.requirementsStatus == failed && onboarding.podman.isNotInstalled == true",
+          "when": "onContext:requirementsStatus == failed && onContext:podmanIsNotInstalled == true",
           "completionEvents": [
-            "onContext:onboarding.podman.requirementsStatus == ok"
+            "onContext:requirementsStatus == ok"
           ],
           "content": [
             [
               {
-                "value": "${onContext:onboarding.podman.warningsMarkdown}",
+                "value": "${onContext:warningsMarkdown}",
                 "highlight": true
               }
             ],
@@ -174,7 +170,7 @@
           "label": "Install Podman",
           "title": "Installing Podman",
           "description": "Once installed, we will enable and configure the extension",
-          "when": "onboarding.podman.isNotInstalled == true",
+          "when": "onContext:podmanIsNotInstalled == true",
           "command": "podman.onboarding.installPodman",
           "completionEvents": [
             "onCommand:podman.onboarding.installPodman"
@@ -184,13 +180,13 @@
           "id": "podmanFailedInstallation",
           "label": "Done",
           "title": "Failed installing Podman",
-          "when": "onboarding.podman.isNotInstalled == true"
+          "when": "onContext:podmanIsNotInstalled == true"
         },
         {
           "id": "podmanInstalled",
           "label": "Done",
           "title": "Podman successfully installed",
-          "when": "onboarding.podman.isNotInstalled == false"
+          "when": "onContext:podmanIsNotInstalled == false"
         }
       ]
     }

--- a/extensions/podman/package.json
+++ b/extensions/podman/package.json
@@ -153,7 +153,7 @@
                 }
               ],
               "completionEvents": [
-                "onCommandResult:checkPodmanInstalled"
+                "checkPodmanInstalled"
               ]
             },
             {
@@ -163,7 +163,7 @@
                 "path": "icon.png",
                 "altText": "podman logo"
               },
-              "when": "onCommandResult:checkPodmanInstalled.installed == failed"
+              "when": "checkPodmanInstalled.installed == failed"
             },
             {
               "id": "checkPodmanRequirements",
@@ -172,14 +172,14 @@
                 "path": "icon.png",
                 "altText": "podman logo"
               },
-              "when": "onCommandResult:checkPodmanInstalled.installed == failed",
+              "when": "checkPodmanInstalled.installed == failed",
               "commandAtActivation": [
                 {
                   "command": "checkPodmanRequirements"
                 }
               ],
               "completionEvents": [
-                "onCommandResult:checkPodmanRequirements"
+                "checkPodmanRequirements"
               ]
             },
             {
@@ -189,9 +189,9 @@
                 "path": "icon.png",
                 "altText": "podman logo"
               },
-              "when": "onCommandResult:checkPodmanRequirements.status == failed && onCommandResult:checkPodmanInstalled.installed == failed",
+              "when": "checkPodmanRequirements.status == failed && checkPodmanInstalled.installed == failed",
               "completionEvents": [
-                "onCommandResult:checkPodmanRequirements.status == ok"
+                "checkPodmanRequirements.status == ok"
               ],
               "content": [
                 [
@@ -215,21 +215,21 @@
               ]
             },
             {
-              "id": "installPodman",
+              "id": "installPodmanView",
               "title": "Installing Podman",
               "description": "Once installed, we will enable and configure the extension",
               "media": {
                 "path": "icon.png",
                 "altText": "podman logo"
               },
-              "when": "onCommandResult:checkPodmanInstalled.installed == failed",
+              "when": "checkPodmanInstalled.installed == failed",
               "commandAtActivation": [
                 {
                   "command": "installPodman"
                 }
               ],
               "completionEvents": [
-                "onCommandResult:installPodman"
+                "installPodman"
               ]
             },
             {
@@ -239,7 +239,7 @@
                 "path": "icon.png",
                 "altText": "podman logo"
               },
-              "when": "onCommandResult:installPodman.status == failed && onCommandResult:checkPodmanInstalled.installed == failed"
+              "when": "installPodman.status == failed && checkPodmanInstalled.installed == failed"
             },
             {
               "id": "podmanInstalled",
@@ -248,7 +248,7 @@
                 "path": "icon.png",
                 "altText": "podman logo"
               },
-              "when": "onCommandResult:installPodman.status == ok || onCommandResult:checkPodmanInstalled.installed == ok"
+              "when": "installPodman.status == ok || checkPodmanInstalled.installed == ok"
             }
           ]
         }

--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -889,7 +889,7 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
     console.error('Error while monitoring provider', error);
   });
 
-  const onboardingCheckInstalltionCommand = extensionApi.commands.registerCommand(
+  const onboardingCheckInstallationCommand = extensionApi.commands.registerCommand(
     'podman.onboarding.checkPodmanInstalled',
     async () => {
       const installation = await getPodmanInstallation();
@@ -966,7 +966,7 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
   );
 
   extensionContext.subscriptions.push(
-    onboardingCheckInstalltionCommand,
+    onboardingCheckInstallationCommand,
     onboardingCheckReqsCommand,
     onboardingInstallPodmanCommand,
   );

--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -893,10 +893,8 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
     'podman.onboarding.checkPodmanInstalled',
     async () => {
       const installation = await getPodmanInstallation();
-      return {
-        status: 'completed',
-        installed: installation ? 'ok' : 'failed',
-      };
+      const installed = installation ? true : false;
+      extensionApi.context.setOnboardingValue('podman.isNotInstalled', !installed);
     },
   );
 
@@ -947,10 +945,8 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
         }
       }
 
-      return {
-        status: successful ? 'ok' : 'failed',
-        warningsMarkdown: warningsMarkdown,
-      };
+      extensionApi.context.setOnboardingValue('podman.requirementsStatus', successful ? 'ok' : 'failed');
+      extensionApi.context.setOnboardingValue('podman.warningsMarkdown', warningsMarkdown);
     },
   );
 
@@ -960,14 +956,11 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
       try {
         await podmanInstall.doInstallPodman(provider);
         const installation = await getPodmanInstallation();
-        return {
-          status: installation ? 'ok' : 'failed',
-        };
+        const installed = installation ? true : false;
+        extensionApi.context.setOnboardingValue('podman.isNotInstalled', !installed);
       } catch (e) {
         console.error(e);
-        return {
-          status: 'failed',
-        };
+        extensionApi.context.setOnboardingValue('podman.isNotInstalled', true);
       }
     },
   );

--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -959,8 +959,9 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
     async () => {
       try {
         await podmanInstall.doInstallPodman(provider);
+        const installation = await getPodmanInstallation();
         return {
-          status: 'ok',
+          status: installation ? 'ok' : 'failed',
         };
       } catch (e) {
         console.error(e);

--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -894,7 +894,7 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
     async () => {
       const installation = await getPodmanInstallation();
       const installed = installation ? true : false;
-      extensionApi.context.setOnboardingValue('podman.isNotInstalled', !installed);
+      extensionApi.context.setValue('podmanIsNotInstalled', !installed, 'onboarding');
     },
   );
 
@@ -945,8 +945,8 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
         }
       }
 
-      extensionApi.context.setOnboardingValue('podman.requirementsStatus', successful ? 'ok' : 'failed');
-      extensionApi.context.setOnboardingValue('podman.warningsMarkdown', warningsMarkdown);
+      extensionApi.context.setValue('requirementsStatus', successful ? 'ok' : 'failed', 'onboarding');
+      extensionApi.context.setValue('warningsMarkdown', warningsMarkdown, 'onboarding');
     },
   );
 
@@ -957,10 +957,10 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
         await podmanInstall.doInstallPodman(provider);
         const installation = await getPodmanInstallation();
         const installed = installation ? true : false;
-        extensionApi.context.setOnboardingValue('podman.isNotInstalled', !installed);
+        extensionApi.context.setValue('podmanIsNotInstalled', !installed, 'onboarding');
       } catch (e) {
         console.error(e);
-        extensionApi.context.setOnboardingValue('podman.isNotInstalled', true);
+        extensionApi.context.setValue('podmanIsNotInstalled', true, 'onboarding');
       }
     },
   );

--- a/packages/main/src/plugin/api/onboarding.ts
+++ b/packages/main/src/plugin/api/onboarding.ts
@@ -22,59 +22,39 @@ export interface OnboardingCommandResponse {
   body: any;
 }
 
-export interface OnboardingCommand {
-  id: string;
-  command: string;
-  response?: { [key: string]: any };
-  args?: string[];
-}
-
-export interface OnboardingCommandAtActivation {
-  command: string;
-}
-
 export interface OnboardingBaseItem {
   id: string;
-  template?: 'dark_bg';
+  highlight?: boolean;
 }
 
-export interface OnboardingViewButtonItem extends OnboardingBaseItem {
+export interface OnboardingStepButtonItem extends OnboardingBaseItem {
   component: 'button';
   label: string;
   command: string;
 }
 
-export interface OnboardingViewTextItem extends OnboardingBaseItem {
+export interface OnboardingStepTextItem extends OnboardingBaseItem {
   component: 'text';
   value: string;
 }
 
-export type OnboardingViewItem = OnboardingViewTextItem | OnboardingViewButtonItem;
+export type OnboardingStepItem = OnboardingStepTextItem | OnboardingStepButtonItem;
 
-export type OnboardingStepStatus = 'completed' | 'failed' | 'skipped';
-
-export interface OnboardingStepView {
-  id: string;
-  title: string;
-  description?: string;
-  media?: { path: string; altText: string };
-  commandAtActivation?: OnboardingCommandAtActivation[];
-  enableCompletionEvents?: string[];
-  completionEvents?: string[];
-  content?: OnboardingViewItem[][];
-  when?: string;
-  status?: OnboardingStepStatus;
-  showNext?: boolean;
-}
+export type OnboardingStatus = 'completed' | 'failed' | 'skipped';
 
 export interface OnboardingStep {
   id: string;
+  label: string;
   title: string;
   description?: string;
-  commands: OnboardingCommand[];
-  views: OnboardingStepView[];
   media?: { path: string; altText: string };
-  status?: OnboardingStepStatus;
+  command?: string;
+  enableCompletionEvents?: string[];
+  completionEvents?: string[];
+  content?: OnboardingStepItem[][];
+  when?: string;
+  status?: OnboardingStatus;
+  showNext?: boolean;
 }
 
 export interface Onboarding {
@@ -86,4 +66,5 @@ export interface Onboarding {
 
 export interface OnboardingInfo extends Onboarding {
   extension: string;
+  status?: OnboardingStatus;
 }

--- a/packages/main/src/plugin/api/onboarding.ts
+++ b/packages/main/src/plugin/api/onboarding.ts
@@ -26,7 +26,7 @@ export interface OnboardingCommand {
   id: string;
   command: string;
   response?: { [key: string]: any };
-  args: string[];
+  args?: string[];
 }
 
 export interface OnboardingCommandAtActivation {
@@ -56,13 +56,13 @@ export type OnboardingStepStatus = 'completed' | 'failed' | 'skipped';
 export interface OnboardingStepView {
   id: string;
   title: string;
-  description: string;
-  media: { path: string; altText: string };
-  commandAtActivation: OnboardingCommandAtActivation[];
-  enableCompletionEvents: string[];
-  completionEvents: string[];
-  content: OnboardingViewItem[][];
-  when: string;
+  description?: string;
+  media?: { path: string; altText: string };
+  commandAtActivation?: OnboardingCommandAtActivation[];
+  enableCompletionEvents?: string[];
+  completionEvents?: string[];
+  content?: OnboardingViewItem[][];
+  when?: string;
   status?: OnboardingStepStatus;
   showNext?: boolean;
 }
@@ -70,10 +70,10 @@ export interface OnboardingStepView {
 export interface OnboardingStep {
   id: string;
   title: string;
-  description: string;
+  description?: string;
   commands: OnboardingCommand[];
   views: OnboardingStepView[];
-  media: { path: string; altText: string };
+  media?: { path: string; altText: string };
   status?: OnboardingStepStatus;
 }
 

--- a/packages/main/src/plugin/api/onboarding.ts
+++ b/packages/main/src/plugin/api/onboarding.ts
@@ -1,0 +1,89 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+export interface OnboardingCommandResponse {
+  status: 'succeeded' | 'failed';
+  body: any;
+}
+
+export interface OnboardingCommand {
+  id: string;
+  command: string;
+  response?: { [key: string]: any };
+  args: string[];
+}
+
+export interface OnboardingCommandAtActivation {
+  command: string;
+}
+
+export interface OnboardingBaseItem {
+  id: string;
+  template?: 'dark_bg';
+}
+
+export interface OnboardingViewButtonItem extends OnboardingBaseItem {
+  component: 'button';
+  label: string;
+  command: string;
+}
+
+export interface OnboardingViewTextItem extends OnboardingBaseItem {
+  component: 'text';
+  value: string;
+}
+
+export type OnboardingViewItem = OnboardingViewTextItem | OnboardingViewButtonItem;
+
+export type OnboardingStepStatus = 'completed' | 'failed' | 'skipped';
+
+export interface OnboardingStepView {
+  id: string;
+  title: string;
+  description: string;
+  media: { path: string; altText: string };
+  commandAtActivation: OnboardingCommandAtActivation[];
+  enableCompletionEvents: string[];
+  completionEvents: string[];
+  content: OnboardingViewItem[][];
+  when: string;
+  status: OnboardingStepStatus;
+  showNext?: boolean;
+}
+
+export interface OnboardingStep {
+  id: string;
+  title: string;
+  description: string;
+  commands: OnboardingCommand[];
+  views: OnboardingStepView[];
+  media: { path: string; altText: string };
+  status: OnboardingStepStatus;
+}
+
+export interface Onboarding {
+  title: string;
+  description?: string;
+  media?: { path: string; altText: string };
+  steps: OnboardingStep[];
+}
+
+export interface OnboardingInfo extends Onboarding {
+  extension: string;
+}

--- a/packages/main/src/plugin/api/onboarding.ts
+++ b/packages/main/src/plugin/api/onboarding.ts
@@ -63,7 +63,7 @@ export interface OnboardingStepView {
   completionEvents: string[];
   content: OnboardingViewItem[][];
   when: string;
-  status: OnboardingStepStatus;
+  status?: OnboardingStepStatus;
   showNext?: boolean;
 }
 
@@ -74,7 +74,7 @@ export interface OnboardingStep {
   commands: OnboardingCommand[];
   views: OnboardingStepView[];
   media: { path: string; altText: string };
-  status: OnboardingStepStatus;
+  status?: OnboardingStepStatus;
 }
 
 export interface Onboarding {

--- a/packages/main/src/plugin/authentication.spec.ts
+++ b/packages/main/src/plugin/authentication.spec.ts
@@ -59,7 +59,6 @@ vi.mock('../util.js', async () => {
   };
 });
 
-
 function randomNumber(n = 5) {
   return Math.round(Math.random() * 10 * n);
 }

--- a/packages/main/src/plugin/authentication.spec.ts
+++ b/packages/main/src/plugin/authentication.spec.ts
@@ -50,6 +50,7 @@ import type { Directories } from './directories.js';
 import type { CustomPickRegistry } from './custompick/custompick-registry.js';
 import type { ViewRegistry } from './view-registry.js';
 import type { Context } from './context/context.js';
+import type { OnboardingRegistry } from './onboarding-registry.js';
 import { getBase64Image } from '../util.js';
 
 vi.mock('../util.js', async () => {
@@ -57,6 +58,7 @@ vi.mock('../util.js', async () => {
     getBase64Image: vi.fn(),
   };
 });
+
 
 function randomNumber(n = 5) {
   return Math.round(Math.random() * 10 * n);
@@ -264,6 +266,7 @@ suite('Authentication', () => {
       vi.fn() as unknown as CustomPickRegistry,
       authentication,
       vi.fn() as unknown as IconRegistry,
+      vi.fn() as unknown as OnboardingRegistry,
       vi.fn() as unknown as Telemetry,
       vi.fn() as unknown as ViewRegistry,
       vi.fn() as unknown as Context,

--- a/packages/main/src/plugin/context/context.ts
+++ b/packages/main/src/plugin/context/context.ts
@@ -48,12 +48,14 @@ export class Context implements IContext {
     return false;
   }
 
-  removeValue(key: string): boolean {
+  removeValue(key: string, doNotNotify?: boolean): boolean {
     if (key in this._value) {
       delete this._value[key];
-      this.apiSender.send('context-key-removed', {
-        key,
-      });
+      if (!doNotNotify) {
+        this.apiSender.send('context-key-removed', {
+          key,
+        });
+      }
       return true;
     }
     return false;

--- a/packages/main/src/plugin/extension-loader.spec.ts
+++ b/packages/main/src/plugin/extension-loader.spec.ts
@@ -47,6 +47,7 @@ import type { Directories } from './directories.js';
 import type { CustomPickRegistry } from './custompick/custompick-registry.js';
 import type { ViewRegistry } from './view-registry.js';
 import { Context } from './context/context.js';
+import type { OnboardingRegistry } from './onboarding-registry.js';
 
 class TestExtensionLoader extends ExtensionLoader {
   public async setupScanningDirectory(): Promise<void> {
@@ -110,6 +111,8 @@ const authenticationProviderRegistry: AuthenticationImpl = {} as unknown as Auth
 
 const iconRegistry: IconRegistry = {} as unknown as IconRegistry;
 
+const onboardingRegistry: OnboardingRegistry = {} as unknown as OnboardingRegistry;
+
 const telemetryTrackMock = vi.fn();
 const telemetry: Telemetry = { track: telemetryTrackMock } as unknown as Telemetry;
 
@@ -145,6 +148,7 @@ beforeAll(() => {
     customPickRegistry,
     authenticationProviderRegistry,
     iconRegistry,
+    onboardingRegistry,
     telemetry,
     viewRegistry,
     context,

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -62,6 +62,7 @@ import { exec } from './util/exec.js';
 import type { ProviderContainerConnectionInfo, ProviderKubernetesConnectionInfo } from './api/provider-info.js';
 import type { ViewRegistry } from './view-registry.js';
 import type { Context } from './context/context.js';
+import type { OnboardingRegistry } from './onboarding-registry.js';
 
 /**
  * Handle the loading of an extension
@@ -136,6 +137,7 @@ export class ExtensionLoader {
     private customPickRegistry: CustomPickRegistry,
     private authenticationProviderRegistry: AuthenticationImpl,
     private iconRegistry: IconRegistry,
+    private onboardingRegistry: OnboardingRegistry,
     private telemetry: Telemetry,
     private viewRegistry: ViewRegistry,
     private context: Context,
@@ -535,6 +537,11 @@ export class ExtensionLoader {
     const views = extension.manifest?.contributes?.views;
     if (views) {
       this.viewRegistry.registerViews(extension.id, views);
+    }
+
+    const onboarding = extension.manifest?.contributes?.onboarding;
+    if (onboarding) {
+      this.onboardingRegistry.registerOnboarding(extension, onboarding);
     }
 
     this.analyzedExtensions.set(extension.id, extension);
@@ -1123,6 +1130,11 @@ export class ExtensionLoader {
       const views = analyzedExtension.manifest?.contributes?.views;
       if (views) {
         this.viewRegistry.unregisterViews(extensionId);
+      }
+
+      const onboarding = analyzedExtension.manifest?.contributes?.onboarding;
+      if (onboarding) {
+        this.onboardingRegistry.unregisterOnboarding(extensionId);
       }
     }
     this.activatedExtensions.delete(extensionId);

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -380,7 +380,7 @@ export class PluginSystem {
     const inputQuickPickRegistry = new InputQuickPickRegistry(apiSender);
     const fileSystemMonitoring = new FilesystemMonitoring();
     const customPickRegistry = new CustomPickRegistry(apiSender);
-    const onboardingRegistry = new OnboardingRegistry(apiSender, commandRegistry, configurationRegistry, context);
+    const onboardingRegistry = new OnboardingRegistry(configurationRegistry, context);
     const kubernetesClient = new KubernetesClient(apiSender, configurationRegistry, fileSystemMonitoring, telemetry);
     await kubernetesClient.init();
     const closeBehaviorConfiguration = new CloseBehavior(configurationRegistry);
@@ -1748,6 +1748,10 @@ export class PluginSystem {
 
     this.ipcHandle('onboardingRegistry:resetOnboarding', async (_listener, extensions: string[]): Promise<void> => {
       return onboardingRegistry.resetOnboarding(extensions);
+    });
+
+    this.ipcHandle('onboardingRegistry:setRunningOnboarding', async (_listener, extension: string): Promise<void> => {
+      return onboardingRegistry.setRunningOnboarding(extension);
     });
 
     const dockerDesktopInstallation = new DockerDesktopInstallation(

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -380,7 +380,7 @@ export class PluginSystem {
     const inputQuickPickRegistry = new InputQuickPickRegistry(apiSender);
     const fileSystemMonitoring = new FilesystemMonitoring();
     const customPickRegistry = new CustomPickRegistry(apiSender);
-    const onboardingRegistry = new OnboardingRegistry(apiSender, commandRegistry);
+    const onboardingRegistry = new OnboardingRegistry(apiSender, commandRegistry, configurationRegistry);
     const kubernetesClient = new KubernetesClient(apiSender, configurationRegistry, fileSystemMonitoring, telemetry);
     await kubernetesClient.init();
     const closeBehaviorConfiguration = new CloseBehavior(configurationRegistry);
@@ -1730,6 +1730,10 @@ export class PluginSystem {
 
     this.ipcHandle('onboardingRegistry:listOnboarding', async (): Promise<OnboardingInfo[]> => {
       return onboardingRegistry.listOnboarding();
+    });
+
+    this.ipcHandle('onboardingRegistry:getOnboarding', async (_listener, extension: string): Promise<OnboardingInfo | undefined> => {
+      return onboardingRegistry.getOnboarding(extension);
     });
 
     this.ipcHandle(

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1750,10 +1750,6 @@ export class PluginSystem {
       return onboardingRegistry.resetOnboarding(extensions);
     });
 
-    this.ipcHandle('onboardingRegistry:setRunningOnboarding', async (_listener, extension: string): Promise<void> => {
-      return onboardingRegistry.setRunningOnboarding(extension);
-    });
-
     const dockerDesktopInstallation = new DockerDesktopInstallation(
       apiSender,
       containerProviderRegistry,

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1732,21 +1732,40 @@ export class PluginSystem {
       return onboardingRegistry.listOnboarding();
     });
 
-    this.ipcHandle('onboardingRegistry:getOnboarding', async (_listener, extension: string): Promise<OnboardingInfo | undefined> => {
-      return onboardingRegistry.getOnboarding(extension);
-    });
+    this.ipcHandle(
+      'onboardingRegistry:getOnboarding',
+      async (_listener, extension: string): Promise<OnboardingInfo | undefined> => {
+        return onboardingRegistry.getOnboarding(extension);
+      },
+    );
 
     this.ipcHandle(
       'onboardingRegistry:executeOnboardingCommand',
-      /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-      async (_listener, executionId: number, extension: string, stepId: string, commandId: string, args?: any[]): Promise<void> => {
+      async (
+        _listener,
+        executionId: number,
+        extension: string,
+        stepId: string,
+        commandId: string,
+        /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+        args?: any[],
+      ): Promise<void> => {
         return onboardingRegistry.executeOnboardingCommand(executionId, extension, stepId, commandId, args);
       },
     );
 
-    this.ipcHandle('onboardingRegistry:updateStepState', async (_listener, status: OnboardingStepStatus, extension: string, stepId: string, viewId?: string): Promise<void> => {
-      return onboardingRegistry.updateStepState(status, extension, stepId, viewId);
-    });
+    this.ipcHandle(
+      'onboardingRegistry:updateStepState',
+      async (
+        _listener,
+        status: OnboardingStepStatus,
+        extension: string,
+        stepId: string,
+        viewId?: string,
+      ): Promise<void> => {
+        return onboardingRegistry.updateStepState(status, extension, stepId, viewId);
+      },
+    );
 
     this.ipcHandle('onboardingRegistry:resetOnboarding', async (_listener, extension: string): Promise<void> => {
       return onboardingRegistry.resetOnboarding(extension);

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1740,13 +1740,6 @@ export class PluginSystem {
     );
 
     this.ipcHandle(
-      'onboardingRegistry:executeOnboardingCommand',
-      async (_listener, executionId: number, extension: string, command: string): Promise<void> => {
-        return onboardingRegistry.executeOnboardingCommand(executionId, extension, command);
-      },
-    );
-
-    this.ipcHandle(
       'onboardingRegistry:updateStepState',
       async (_listener, status: OnboardingStatus, extension: string, stepId?: string): Promise<void> => {
         return onboardingRegistry.updateStepState(status, extension, stepId);

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -114,7 +114,7 @@ import { ViewRegistry } from './view-registry.js';
 import type { ViewInfoUI } from './api/view-info.js';
 import { Context } from './context/context.js';
 import { OnboardingRegistry } from './onboarding-registry.js';
-import type { OnboardingInfo } from './api/onboarding.js';
+import type { OnboardingInfo, OnboardingStepStatus } from './api/onboarding.js';
 import { OnboardingUtils } from './onboarding/onboarding-utils.js';
 
 type LogType = 'log' | 'warn' | 'trace' | 'debug' | 'error';
@@ -1739,10 +1739,18 @@ export class PluginSystem {
     this.ipcHandle(
       'onboardingRegistry:executeOnboardingCommand',
       /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-      async (_listener, extension: string, stepId: string, commandId: string, args?: any[]): Promise<void> => {
-        return onboardingRegistry.executeOnboardingCommand(extension, stepId, commandId, args);
+      async (_listener, executionId: number, extension: string, stepId: string, commandId: string, args?: any[]): Promise<void> => {
+        return onboardingRegistry.executeOnboardingCommand(executionId, extension, stepId, commandId, args);
       },
     );
+
+    this.ipcHandle('onboardingRegistry:updateStepState', async (_listener, status: OnboardingStepStatus, extension: string, stepId: string, viewId?: string): Promise<void> => {
+      return onboardingRegistry.updateStepState(status, extension, stepId, viewId);
+    });
+
+    this.ipcHandle('onboardingRegistry:resetOnboarding', async (_listener, extension: string): Promise<void> => {
+      return onboardingRegistry.resetOnboarding(extension);
+    });
 
     const dockerDesktopInstallation = new DockerDesktopInstallation(
       apiSender,

--- a/packages/main/src/plugin/onboarding-registry.spec.ts
+++ b/packages/main/src/plugin/onboarding-registry.spec.ts
@@ -1,0 +1,194 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { beforeEach, expect, expectTypeOf, test, vi } from 'vitest';
+import { OnboardingRegistry } from './onboarding-registry.js';
+import { CommandRegistry } from './command-registry.js';
+import type { Telemetry } from './telemetry/telemetry.js';
+import type { ApiSenderType } from './api.js';
+import type { ConfigurationRegistry } from './configuration-registry.js';
+import type { AnalyzedExtension } from './extension-loader.js';
+import * as fs from 'node:fs';
+
+let onboardingRegistry: OnboardingRegistry;
+let commandRegistry: CommandRegistry;
+const extensionId = 'myextension.id';
+const stepId = 'podmanSetup';
+const viewId = 'checkPodmanInstalledView';
+
+const getConfigMock = vi.fn();
+const getConfigurationMock = vi.fn();
+getConfigurationMock.mockReturnValue({
+  get: getConfigMock,
+});
+const configurationRegistry = {
+  registerConfigurations: vi.fn(),
+  onDidChangeConfiguration: vi.fn(),
+  getConfiguration: getConfigurationMock,
+} as unknown as ConfigurationRegistry;
+
+const readFileSync = vi.spyOn(fs, 'readFileSync');
+const bufferFrom = vi.spyOn(Buffer, 'from');
+
+/* eslint-disable @typescript-eslint/no-empty-function */
+beforeEach(() => {
+  vi.clearAllMocks();
+  commandRegistry = new CommandRegistry({} as Telemetry);
+  onboardingRegistry = new OnboardingRegistry({} as ApiSenderType, commandRegistry, configurationRegistry);
+  const manifest = {
+    contributes: {
+      onboarding: {
+        title: 'Get started with Podman Desktop',
+        steps: [
+          {
+            id: stepId,
+            title: 'Podman Setup',
+            commands: [
+              {
+                id: 'checkPodmanInstalled',
+                command: 'podman.onboarding.checkPodmanInstalled',
+                response: {
+                  status: 'string',
+                  installed: 'string',
+                },
+              },
+            ],
+            views: [
+              {
+                id: viewId,
+                title: 'Checking for Podman installation',
+                media: {
+                  path: 'icon.png',
+                  altText: 'podman logo',
+                },
+                commandAtActivation: [
+                  {
+                    command: 'checkPodmanInstalled',
+                  },
+                ],
+                completionEvents: ['checkPodmanInstalled'],
+              },
+            ],
+          },
+        ],
+      },
+    },
+  };
+
+  const extensionPath = '/root/path';
+  const extension = {
+    path: extensionPath,
+    id: extensionId,
+  } as AnalyzedExtension;
+  onboardingRegistry.registerOnboarding(extension, manifest.contributes.onboarding);
+  getConfigMock.mockReturnValue(true);
+
+  vi.mock('node:fs');
+  readFileSync.mockReturnValue(JSON.stringify({}));
+  bufferFrom.mockReturnValue(Buffer.from(''));
+});
+
+test('Should return no onboarding if experimental onboarding setting is disabled', async () => {
+  getConfigMock.mockReturnValue(false);
+  const onbording = onboardingRegistry.getOnboarding(extensionId);
+  expect(onbording).toBe(undefined);
+});
+
+test('Should return no onboarding for unknown extension', async () => {
+  const onbording = onboardingRegistry.getOnboarding('unknown');
+  expect(onbording).toBe(undefined);
+});
+
+test('Should onboarding for known extension', async () => {
+  const onbording = onboardingRegistry.getOnboarding(extensionId);
+  expect(onbording).toBeDefined();
+  expect(onbording?.title).toBe('Get started with Podman Desktop');
+});
+
+test('Should not find onboarding after unregistered', async () => {
+  onboardingRegistry.unregisterOnboarding(extensionId);
+  const onbording = onboardingRegistry.getOnboarding(extensionId);
+  expect(onbording).toBe(undefined);
+});
+
+test('Should return list of registered onboarding', async () => {
+  const onboarding = onboardingRegistry.listOnboarding();
+  expect(onboarding).toBeDefined();
+  expectTypeOf(onboarding).toBeArray();
+  expect(onboarding.length).toBe(1);
+  expect(onboarding[0].title).toBe('Get started with Podman Desktop');
+});
+
+test('Should update state of step', async () => {
+  onboardingRegistry.updateStepState('completed', extensionId, stepId);
+  const onboarding = onboardingRegistry.getOnboarding(extensionId);
+  expect(onboarding).toBeDefined();
+  expect(onboarding?.steps[0].status).toBeDefined();
+  expect(onboarding?.steps[0].status).toBe('completed');
+});
+
+test('Should update state of view', async () => {
+  onboardingRegistry.updateStepState('completed', extensionId, stepId, viewId);
+  const onboarding = onboardingRegistry.getOnboarding(extensionId);
+  expect(onboarding).toBeDefined();
+  expect(onboarding?.steps[0].status).toBe(undefined);
+  expect(onboarding?.steps[0].views[0].status).toBeDefined();
+  expect(onboarding?.steps[0].views[0].status).toBe('completed');
+});
+
+test('Should throw if no onboarding for that extension', async () => {
+  expect(() => onboardingRegistry.updateStepState('completed', 'unknown', stepId)).toThrowError(
+    'No onboarding for extension unknown',
+  );
+});
+
+test('Should throw if no step in onboarding for that extension', async () => {
+  expect(() => onboardingRegistry.updateStepState('completed', extensionId, 'unknown')).toThrowError(
+    `No onboarding step with id unknown for extension ${extensionId}`,
+  );
+});
+
+test('Should throw if no view in that step in onboarding for that extension', async () => {
+  expect(() => onboardingRegistry.updateStepState('completed', extensionId, stepId, 'unknown')).toThrowError(
+    `No onboarding view with id unknown in step with id ${stepId} for extension ${extensionId}`,
+  );
+});
+
+test('Should reset all states', async () => {
+  // update state so they are not undefined
+  onboardingRegistry.updateStepState('completed', extensionId, stepId);
+  onboardingRegistry.updateStepState('completed', extensionId, stepId, viewId);
+  let onboarding = onboardingRegistry.getOnboarding(extensionId);
+  // verify update went well
+  expect(onboarding).toBeDefined();
+  expect(onboarding?.steps[0].status).toBeDefined();
+  expect(onboarding?.steps[0].status).toBe('completed');
+  expect(onboarding?.steps[0].views[0].status).toBeDefined();
+  expect(onboarding?.steps[0].views[0].status).toBe('completed');
+  // reset all states
+  onboardingRegistry.resetOnboarding(extensionId);
+  // check states have been reset
+  onboarding = onboardingRegistry.getOnboarding(extensionId);
+  expect(onboarding).toBeDefined();
+  expect(onboarding?.steps[0].status).toBe(undefined);
+  expect(onboarding?.steps[0].views[0].status).toBe(undefined);
+});
+
+test('Should throw if no onboarding for that extension', async () => {
+  expect(() => onboardingRegistry.resetOnboarding('unknown')).toThrowError('No onboarding for extension unknown');
+});

--- a/packages/main/src/plugin/onboarding-registry.ts
+++ b/packages/main/src/plugin/onboarding-registry.ts
@@ -78,30 +78,6 @@ export class OnboardingRegistry {
     return this.onboardingInfos;
   }
 
-  async executeOnboardingCommand(executionId: number, extension: string, command: string): Promise<void> {
-    try {
-      // retrieve context for extension
-      const response = await this.commandRegistry.executeCommand<{ [key: string]: any }>(command);
-      this.apiSender.send('onboarding:command-executed', {
-        executionId,
-        extension,
-        command,
-        status: 'succeeded',
-        body: response,
-      });
-    } catch (e) {
-      this.apiSender.send('onboarding:command-executed', {
-        executionId,
-        extension,
-        command,
-        status: 'failed',
-        body: {
-          error: e,
-        },
-      });
-    }
-  }
-
   updateStepState(status: OnboardingStatus, extension: string, stepId?: string): void {
     const onboarding = this.onboardingInfos.find(onboarding => onboarding.extension === extension);
     if (!onboarding) {

--- a/packages/main/src/plugin/onboarding-registry.ts
+++ b/packages/main/src/plugin/onboarding-registry.ts
@@ -26,7 +26,6 @@ import type { Context } from './context/context.js';
 
 export class OnboardingRegistry {
   private onboardingInfos: Map<string, OnboardingInfo> = new Map<string, OnboardingInfo>();
-  private runningOnboardingExtension: string | undefined = undefined;
 
   constructor(private configurationRegistry: ConfigurationRegistry, private context: Context) {}
 
@@ -45,10 +44,6 @@ export class OnboardingRegistry {
       return this.onboardingInfos.get(extension);
     }
     return undefined;
-  }
-
-  getRunningOnboardingExtensionId(): string | undefined {
-    return this.runningOnboardingExtension;
   }
 
   createOnboardingInfo(extension: AnalyzedExtension, onboarding: Onboarding): OnboardingInfo {
@@ -82,15 +77,6 @@ export class OnboardingRegistry {
     return Array.from(this.onboardingInfos.values());
   }
 
-  /**
-   * it sets the extension which is currently running its onboarding
-   *
-   * @param extensionId extension used to retrieve the onboarding
-   */
-  setRunningOnboarding(extensionId?: string) {
-    this.runningOnboardingExtension = extensionId;
-  }
-
   updateStepState(status: OnboardingStatus, extension: string, stepId?: string): void {
     const onboarding = this.onboardingInfos.get(extension);
     if (!onboarding) {
@@ -104,8 +90,6 @@ export class OnboardingRegistry {
       step.status = status;
     } else {
       onboarding.status = status;
-      // when it updates the onboarding status, it is completed so it resets the running onboarding value
-      this.setRunningOnboarding(undefined);
     }
   }
 

--- a/packages/main/src/plugin/onboarding-registry.ts
+++ b/packages/main/src/plugin/onboarding-registry.ts
@@ -23,12 +23,16 @@ import type { Onboarding, OnboardingInfo, OnboardingStepStatus } from './api/onb
 import type { CommandRegistry } from './command-registry.js';
 import type { ApiSenderType } from './api.js';
 import type { AnalyzedExtension } from './extension-loader.js';
-import { ConfigurationRegistry } from './configuration-registry.js';
+import type { ConfigurationRegistry } from './configuration-registry.js';
 
 export class OnboardingRegistry {
   private onboardingInfos: OnboardingInfo[] = [];
 
-  constructor(private apiSender: ApiSenderType, private commandRegistry: CommandRegistry, private configurationRegistry: ConfigurationRegistry) {}
+  constructor(
+    private apiSender: ApiSenderType,
+    private commandRegistry: CommandRegistry,
+    private configurationRegistry: ConfigurationRegistry,
+  ) {}
 
   registerOnboarding(extension: AnalyzedExtension, onboarding: Onboarding): void {
     const onInfo = this.createOnboardingInfo(extension, onboarding);
@@ -44,7 +48,7 @@ export class OnboardingRegistry {
     if (isOnboardingEnabled) {
       return this.onboardingInfos.find(onboarding => onboarding.extension === extension);
     }
-    return undefined;    
+    return undefined;
   }
 
   createOnboardingInfo(extension: AnalyzedExtension, onboarding: Onboarding): OnboardingInfo {
@@ -91,7 +95,13 @@ export class OnboardingRegistry {
     return this.onboardingInfos;
   }
 
-  async executeOnboardingCommand(executionId: number, extension: string, stepId: string, commandId: string, args?: any[]): Promise<void> {
+  async executeOnboardingCommand(
+    executionId: number,
+    extension: string,
+    stepId: string,
+    commandId: string,
+    args?: any[],
+  ): Promise<void> {
     const onboarding = this.onboardingInfos.find(onboarding => onboarding.extension === extension);
     if (onboarding) {
       const step = onboarding.steps.find(step => step.id === stepId);
@@ -145,7 +155,7 @@ export class OnboardingRegistry {
     if (viewId) {
       const view = step.views.find(view => view.id === viewId);
       if (!view) {
-        throw new Error(`No onboarding view with id ${viewId} in step with id ${stepId} for extension ${extension}`);        
+        throw new Error(`No onboarding view with id ${viewId} in step with id ${stepId} for extension ${extension}`);
       }
       view.status = status;
     } else {

--- a/packages/main/src/plugin/onboarding-registry.ts
+++ b/packages/main/src/plugin/onboarding-registry.ts
@@ -1,0 +1,123 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import * as path from 'path';
+import * as fs from 'fs';
+import type { Onboarding, OnboardingInfo } from './api/onboarding.js';
+import type { CommandRegistry } from './command-registry.js';
+import type { ApiSenderType } from './api.js';
+import type { AnalyzedExtension } from './extension-loader.js';
+
+export class OnboardingRegistry {
+  private onboardingInfos: OnboardingInfo[] = [];
+
+  constructor(private apiSender: ApiSenderType, private commandRegistry: CommandRegistry) {}
+
+  registerOnboarding(extension: AnalyzedExtension, onboarding: Onboarding): void {
+    const onInfo = this.createOnboardingInfo(extension, onboarding);
+    this.onboardingInfos.push(onInfo);
+  }
+
+  unregisterOnboarding(extension: string): void {
+    this.onboardingInfos = this.onboardingInfos.filter(onboarding => onboarding.extension !== extension);
+  }
+
+  createOnboardingInfo(extension: AnalyzedExtension, onboarding: Onboarding): OnboardingInfo {
+    //TODO we need to check the onboarding has a valid schema. contains atleast a step and substep
+    this.convertImages(extension.path, onboarding);
+    return {
+      ...onboarding,
+      extension: extension.id,
+    };
+  }
+
+  convertImages(rootPath: string, onboarding: Onboarding) {
+    if (onboarding.media?.path) {
+      onboarding.media.path = this.getBase64Image(rootPath, onboarding.media.path);
+    }
+
+    for (const step of onboarding.steps) {
+      if (step.media?.path) {
+        step.media.path = this.getBase64Image(rootPath, step.media.path);
+      }
+      for (const view of step.views) {
+        if (view.media?.path) {
+          view.media.path = this.getBase64Image(rootPath, view.media.path);
+        }
+      }
+    }
+  }
+
+  // Return the base64 of the file
+  getBase64Image(rootPath: string, file: string): string {
+    try {
+      const imageContent = fs.readFileSync(path.resolve(rootPath, file));
+      // convert to base64
+      const base64Content = Buffer.from(imageContent).toString('base64');
+      // create base64 image content
+      return `data:image/png;base64,${base64Content}`;
+    } catch (e) {
+      console.error(e);
+      return '';
+    }
+  }
+
+  listOnboarding(): OnboardingInfo[] {
+    return this.onboardingInfos;
+  }
+
+  async executeOnboardingCommand(extension: string, stepId: string, commandId: string, args?: any[]): Promise<void> {
+    const onboarding = this.onboardingInfos.find(onboarding => onboarding.extension === extension);
+    if (onboarding) {
+      const step = onboarding.steps.find(step => step.id === stepId);
+      if (step) {
+        const commandToExecute = step.commands.find(cmd => cmd.id === commandId);
+        if (commandToExecute) {
+          try {
+            const response = await this.commandRegistry.executeCommand<{ [key: string]: any }>(
+              commandToExecute?.command,
+              args,
+            );
+            this.apiSender.send('onboarding:command-executed', {
+              command: commandId,
+              status: 'succeeded',
+              body: response,
+            });
+          } catch (e) {
+            this.apiSender.send('onboarding:command-executed', {
+              command: commandId,
+              status: 'failed',
+              body: {
+                error: e,
+              },
+            });
+          }
+          return;
+        }
+      }
+    }
+    this.apiSender.send('onboarding:command-executed', {
+      command: commandId,
+      status: 'failed',
+      body: {
+        error: 'Unable to execute the command',
+      },
+    });
+  }
+}

--- a/packages/main/src/plugin/onboarding-registry.ts
+++ b/packages/main/src/plugin/onboarding-registry.ts
@@ -57,18 +57,27 @@ export class OnboardingRegistry {
 
   convertImages(extension: AnalyzedExtension, onboarding: Onboarding) {
     if (onboarding.media?.path) {
-      onboarding.media.path = getBase64Image(path.resolve(extension.path, onboarding.media.path));
+      const base64Image = getBase64Image(path.resolve(extension.path, onboarding.media.path));
+      if (base64Image) {
+        onboarding.media.path = base64Image;
+      }
     } else if (extension.manifest?.icon) {
-      // if no image has been set for the onboarding, it uses the extension icon
-      onboarding.media = {
-        path: getBase64Image(path.resolve(extension.path, extension.manifest.icon)),
-        altText: 'icon',
-      };
+      const base64Image = getBase64Image(path.resolve(extension.path, extension.manifest.icon));
+      if (base64Image) {
+        // if no image has been set for the onboarding, it uses the extension icon
+        onboarding.media = {
+          path: base64Image,
+          altText: 'icon',
+        };
+      }
     }
 
     for (const step of onboarding.steps) {
       if (step.media?.path) {
-        step.media.path = getBase64Image(path.resolve(extension.path, step.media.path));
+        const base64Image = getBase64Image(path.resolve(extension.path, step.media.path));
+        if (base64Image) {
+          step.media.path = base64Image;
+        }
       }
     }
   }

--- a/packages/main/src/plugin/onboarding-registry.ts
+++ b/packages/main/src/plugin/onboarding-registry.ts
@@ -23,11 +23,12 @@ import type { Onboarding, OnboardingInfo } from './api/onboarding.js';
 import type { CommandRegistry } from './command-registry.js';
 import type { ApiSenderType } from './api.js';
 import type { AnalyzedExtension } from './extension-loader.js';
+import { ConfigurationRegistry } from './configuration-registry.js';
 
 export class OnboardingRegistry {
   private onboardingInfos: OnboardingInfo[] = [];
 
-  constructor(private apiSender: ApiSenderType, private commandRegistry: CommandRegistry) {}
+  constructor(private apiSender: ApiSenderType, private commandRegistry: CommandRegistry, private configurationRegistry: ConfigurationRegistry) {}
 
   registerOnboarding(extension: AnalyzedExtension, onboarding: Onboarding): void {
     const onInfo = this.createOnboardingInfo(extension, onboarding);
@@ -36,6 +37,14 @@ export class OnboardingRegistry {
 
   unregisterOnboarding(extension: string): void {
     this.onboardingInfos = this.onboardingInfos.filter(onboarding => onboarding.extension !== extension);
+  }
+
+  getOnboarding(extension: string): OnboardingInfo | undefined {
+    const isOnboardingEnabled = this.configurationRegistry.getConfiguration('experimental').get('onboarding');
+    if (isOnboardingEnabled) {
+      return this.onboardingInfos.find(onboarding => onboarding.extension === extension);
+    }
+    return undefined;    
   }
 
   createOnboardingInfo(extension: AnalyzedExtension, onboarding: Onboarding): OnboardingInfo {

--- a/packages/main/src/plugin/onboarding/onboarding-utils.ts
+++ b/packages/main/src/plugin/onboarding/onboarding-utils.ts
@@ -30,7 +30,7 @@ export class OnboardingUtils {
         ['experimental.onboarding']: {
           description: 'When enabled, it is possible to use the onboarding workflow.',
           type: 'boolean',
-          default: true,
+          default: false,
           hidden: true,
         },
       },

--- a/packages/main/src/plugin/onboarding/onboarding-utils.ts
+++ b/packages/main/src/plugin/onboarding/onboarding-utils.ts
@@ -1,0 +1,41 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { IConfigurationNode, IConfigurationRegistry } from '../configuration-registry.js';
+
+export class OnboardingUtils {
+  constructor(private configurationRegistry: IConfigurationRegistry) {}
+
+  init() {
+    const onboardingConfiguration: IConfigurationNode = {
+      id: 'experimental.onboarding',
+      title: 'Enable Onboarding',
+      type: 'object',
+      properties: {
+        ['experimental.onboarding']: {
+          description: 'When enabled, it is possible to use the onboarding workflow.',
+          type: 'boolean',
+          default: false,
+          hidden: true,
+        },
+      },
+    };
+
+    this.configurationRegistry.registerConfigurations([onboardingConfiguration]);
+  }
+}

--- a/packages/main/src/plugin/onboarding/onboarding-utils.ts
+++ b/packages/main/src/plugin/onboarding/onboarding-utils.ts
@@ -30,7 +30,7 @@ export class OnboardingUtils {
         ['experimental.onboarding']: {
           description: 'When enabled, it is possible to use the onboarding workflow.',
           type: 'boolean',
-          default: false,
+          default: true,
           hidden: true,
         },
       },

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -1498,9 +1498,12 @@ function initExposure(): void {
     },
   );
 
-  contextBridge.exposeInMainWorld('updateStepState', async (status: OnboardingStepStatus, extension: string, stepId: string, viewId?: string): Promise<void> => {
-    return ipcInvoke('onboardingRegistry:updateStepState', status, extension, stepId, viewId);
-  });
+  contextBridge.exposeInMainWorld(
+    'updateStepState',
+    async (status: OnboardingStepStatus, extension: string, stepId: string, viewId?: string): Promise<void> => {
+      return ipcInvoke('onboardingRegistry:updateStepState', status, extension, stepId, viewId);
+    },
+  );
 
   contextBridge.exposeInMainWorld('resetOnboarding', async (extension: string): Promise<void> => {
     return ipcInvoke('onboardingRegistry:resetOnboarding', extension);

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -1500,6 +1500,10 @@ function initExposure(): void {
   contextBridge.exposeInMainWorld('resetOnboarding', async (extensions: string[]): Promise<void> => {
     return ipcInvoke('onboardingRegistry:resetOnboarding', extensions);
   });
+
+  contextBridge.exposeInMainWorld('setRunningOnboarding', async (extension: string): Promise<void> => {
+    return ipcInvoke('onboardingRegistry:setRunningOnboarding', extension);
+  });
 }
 
 // expose methods

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -1486,7 +1486,7 @@ function initExposure(): void {
     return ipcInvoke('onboardingRegistry:listOnboarding');
   });
 
-  contextBridge.exposeInMainWorld('getOnboarding', async (extension: string): Promise<OnboardingInfo[]> => {
+  contextBridge.exposeInMainWorld('getOnboarding', async (extension: string): Promise<OnboardingInfo | undefined> => {
     return ipcInvoke('onboardingRegistry:getOnboarding', extension);
   });
 

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -65,7 +65,7 @@ import type { Menu } from '../../main/src/plugin/menu-registry';
 import type { MessageBoxOptions, MessageBoxReturnValue } from '../../main/src/plugin/message-box';
 import type { ViewInfoUI } from '../../main/src/plugin/api/view-info';
 import type { ContextInfo } from '../../main/src/plugin/api/context-info';
-import type { OnboardingInfo } from '../../main/src/plugin/api/onboarding';
+import type { OnboardingInfo, OnboardingStepStatus } from '../../main/src/plugin/api/onboarding';
 
 export type DialogResultCallback = (openDialogReturnValue: Electron.OpenDialogReturnValue) => void;
 
@@ -1493,10 +1493,18 @@ function initExposure(): void {
   contextBridge.exposeInMainWorld(
     'executeOnboardingCommand',
     /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-    async (extension: string, stepId: string, commandId: string, args?: any[]): Promise<void> => {
-      return ipcInvoke('onboardingRegistry:executeOnboardingCommand', extension, stepId, commandId, args);
+    async (executionId: number, extension: string, stepId: string, commandId: string, args?: any[]): Promise<void> => {
+      return ipcInvoke('onboardingRegistry:executeOnboardingCommand', executionId, extension, stepId, commandId, args);
     },
   );
+
+  contextBridge.exposeInMainWorld('updateStepState', async (status: OnboardingStepStatus, extension: string, stepId: string, viewId?: string): Promise<void> => {
+    return ipcInvoke('onboardingRegistry:updateStepState', status, extension, stepId, viewId);
+  });
+
+  contextBridge.exposeInMainWorld('resetOnboarding', async (extension: string): Promise<void> => {
+    return ipcInvoke('onboardingRegistry:resetOnboarding', extension);
+  });
 }
 
 // expose methods

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -1500,10 +1500,6 @@ function initExposure(): void {
   contextBridge.exposeInMainWorld('resetOnboarding', async (extensions: string[]): Promise<void> => {
     return ipcInvoke('onboardingRegistry:resetOnboarding', extensions);
   });
-
-  contextBridge.exposeInMainWorld('setRunningOnboarding', async (extension: string): Promise<void> => {
-    return ipcInvoke('onboardingRegistry:setRunningOnboarding', extension);
-  });
 }
 
 // expose methods

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -1491,13 +1491,6 @@ function initExposure(): void {
   });
 
   contextBridge.exposeInMainWorld(
-    'executeOnboardingCommand',
-    async (executionId: number, extension: string, command: string): Promise<void> => {
-      return ipcInvoke('onboardingRegistry:executeOnboardingCommand', executionId, extension, command);
-    },
-  );
-
-  contextBridge.exposeInMainWorld(
     'updateStepState',
     async (status: OnboardingStatus, extension: string, stepId?: string): Promise<void> => {
       return ipcInvoke('onboardingRegistry:updateStepState', status, extension, stepId);

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -1486,6 +1486,10 @@ function initExposure(): void {
     return ipcInvoke('onboardingRegistry:listOnboarding');
   });
 
+  contextBridge.exposeInMainWorld('getOnboarding', async (extension: string): Promise<OnboardingInfo[]> => {
+    return ipcInvoke('onboardingRegistry:getOnboarding', extension);
+  });
+
   contextBridge.exposeInMainWorld(
     'executeOnboardingCommand',
     /* eslint-disable-next-line @typescript-eslint/no-explicit-any */

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -65,7 +65,7 @@ import type { Menu } from '../../main/src/plugin/menu-registry';
 import type { MessageBoxOptions, MessageBoxReturnValue } from '../../main/src/plugin/message-box';
 import type { ViewInfoUI } from '../../main/src/plugin/api/view-info';
 import type { ContextInfo } from '../../main/src/plugin/api/context-info';
-import type { OnboardingInfo, OnboardingStepStatus } from '../../main/src/plugin/api/onboarding';
+import type { OnboardingInfo, OnboardingStatus } from '../../main/src/plugin/api/onboarding';
 
 export type DialogResultCallback = (openDialogReturnValue: Electron.OpenDialogReturnValue) => void;
 
@@ -1492,21 +1492,20 @@ function initExposure(): void {
 
   contextBridge.exposeInMainWorld(
     'executeOnboardingCommand',
-    /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-    async (executionId: number, extension: string, stepId: string, commandId: string, args?: any[]): Promise<void> => {
-      return ipcInvoke('onboardingRegistry:executeOnboardingCommand', executionId, extension, stepId, commandId, args);
+    async (executionId: number, extension: string, command: string): Promise<void> => {
+      return ipcInvoke('onboardingRegistry:executeOnboardingCommand', executionId, extension, command);
     },
   );
 
   contextBridge.exposeInMainWorld(
     'updateStepState',
-    async (status: OnboardingStepStatus, extension: string, stepId: string, viewId?: string): Promise<void> => {
-      return ipcInvoke('onboardingRegistry:updateStepState', status, extension, stepId, viewId);
+    async (status: OnboardingStatus, extension: string, stepId?: string): Promise<void> => {
+      return ipcInvoke('onboardingRegistry:updateStepState', status, extension, stepId);
     },
   );
 
-  contextBridge.exposeInMainWorld('resetOnboarding', async (extension: string): Promise<void> => {
-    return ipcInvoke('onboardingRegistry:resetOnboarding', extension);
+  contextBridge.exposeInMainWorld('resetOnboarding', async (extensions: string[]): Promise<void> => {
+    return ipcInvoke('onboardingRegistry:resetOnboarding', extensions);
   });
 }
 

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -65,6 +65,7 @@ import type { Menu } from '../../main/src/plugin/menu-registry';
 import type { MessageBoxOptions, MessageBoxReturnValue } from '../../main/src/plugin/message-box';
 import type { ViewInfoUI } from '../../main/src/plugin/api/view-info';
 import type { ContextInfo } from '../../main/src/plugin/api/context-info';
+import type { OnboardingInfo } from '../../main/src/plugin/api/onboarding';
 
 export type DialogResultCallback = (openDialogReturnValue: Electron.OpenDialogReturnValue) => void;
 
@@ -1480,6 +1481,18 @@ function initExposure(): void {
   contextBridge.exposeInMainWorld('windowClose', async (): Promise<void> => {
     return ipcInvoke('window:close');
   });
+
+  contextBridge.exposeInMainWorld('listOnboarding', async (): Promise<OnboardingInfo[]> => {
+    return ipcInvoke('onboardingRegistry:listOnboarding');
+  });
+
+  contextBridge.exposeInMainWorld(
+    'executeOnboardingCommand',
+    /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+    async (extension: string, stepId: string, commandId: string, args?: any[]): Promise<void> => {
+      return ipcInvoke('onboardingRegistry:executeOnboardingCommand', extension, stepId, commandId, args);
+    },
+  );
 }
 
 // expose methods

--- a/packages/renderer/src/lib/onboarding/Onboarding.svelte
+++ b/packages/renderer/src/lib/onboarding/Onboarding.svelte
@@ -1,0 +1,284 @@
+<script lang="ts">
+import { extensionInfos } from '../../stores/extensions';
+import type { ExtensionInfo } from '../../../../main/src/plugin/api/extension-info';
+import { onDestroy, onMount } from 'svelte';
+import type { OnboardingInfo, OnboardingStep, OnboardingStepView } from '../../../../main/src/plugin/api/onboarding';
+import { faCircle } from '@fortawesome/free-regular-svg-icons';
+import {
+  faCircleCheck,
+  faCircleQuestion,
+  faCircle as faFilledCircle,
+  faForward,
+} from '@fortawesome/free-solid-svg-icons';
+import Fa from 'svelte-fa/src/fa.svelte';
+import type { Unsubscriber } from 'svelte/store';
+import { onboardingList } from '/@/stores/onboarding';
+import OnboardingItem from './OnboardingItem.svelte';
+import type { ContextUI } from '../context/context';
+import { contexts } from '/@/stores/contexts';
+import { ContextKeyExpr } from '../context/contextKey';
+import { router } from 'tinro';
+
+interface ActiveStep {
+  step: OnboardingStep;
+  view: OnboardingStepView;
+}
+
+export let extensionId: string = undefined;
+
+let extensionInfo: ExtensionInfo;
+$: extensionInfo = $extensionInfos.find(extension => extension.id === extensionId);
+let onboarding: OnboardingInfo;
+let activeStep: ActiveStep;
+$: activeStep;
+
+$: executing = false;
+let context: ContextUI;
+let displayCancelSetup = false;
+/*
+$: enableNextButton = false;*/
+let onboardingUnsubscribe: Unsubscriber;
+let contextsUnsubscribe: Unsubscriber;
+onMount(async () => {
+  onboardingUnsubscribe = onboardingList.subscribe(onboardingItems => {
+    if (!onboarding) {
+      onboarding = onboardingItems.filter(o => o.extension === extensionId)[0];
+      setActiveStep();
+    }
+  });
+
+  contextsUnsubscribe = contexts.subscribe(value => {
+    console.log(value);
+    context = value.find(ctx => ctx.extension === extensionId);
+  });
+});
+
+onDestroy(() => {
+  if (onboardingUnsubscribe) {
+    onboardingUnsubscribe();
+  }
+  if (contextsUnsubscribe) {
+    contextsUnsubscribe();
+  }
+});
+
+function setActiveStep() {
+  if (!onboarding) {
+    console.error(`Unable to retrieve the onboarding workflow for ${extensionInfo?.displayName}`);
+    return;
+  }
+  for (const step of onboarding.steps) {
+    if (!step.status) {
+      for (const view of step.views) {
+        if (!view.status) {
+          let whenDeserialized;
+          if (view.when) {
+            whenDeserialized = ContextKeyExpr.deserialize(view.when);
+          }
+          if (!view.when || whenDeserialized?.evaluate(context)) {
+            activeStep = {
+              step,
+              view,
+            };
+            doExecuteCommandsAtActivation(activeStep);
+            return;
+          } else {
+            view.status = 'skipped';
+            continue;
+          }
+        }
+      }
+    }
+  }
+
+  // if it reaches this point it means that the onboarding is fully completed and the user is redirected to the dashboard
+  router.goto('/');
+}
+
+async function doExecuteCommandsAtActivation(active: ActiveStep) {
+  for (const cmd of active.view.commandAtActivation || []) {
+    setExecuting(true);
+    await window.executeOnboardingCommand(extensionId, active.step.id, cmd.command);
+    setExecuting(false);
+  }
+}
+
+let eventsCompleted: string[] = [];
+window.events?.receive('onboarding:command-executed', result => {
+  if (result.status === 'failed') {
+    console.error(`Failed at executing command ${result.command}: ${result.body.error}`);
+    return;
+  }
+  context?.setValue(result.command, result.body);
+  if (!eventsCompleted.includes(`onCommandResult:${result.command}`)) {
+    eventsCompleted.push(`onCommandResult:${result.command}`);
+  }
+  assertStepCompleted();
+});
+
+function assertStepCompleted() {
+  const isCompleted =
+    !activeStep.view.completionEvents ||
+    activeStep.view.completionEvents.length === 0 ||
+    activeStep.view.completionEvents.every(cmp => {
+      // check if eventCompleted contains the event required by the step to be considered complete
+      if (eventsCompleted.includes(cmp)) {
+        return true;
+      }
+      // check if cmp string stem is in eventCompleted and find the value required from context
+      const completionEventDeserialized = ContextKeyExpr.deserialize(cmp);
+      return completionEventDeserialized.evaluate(context);
+    });
+
+  if (isCompleted) {
+    activeStep.view.status = 'completed';
+    const views = activeStep.step.views;
+    // if completed view is the last of the whole step, mark this as completed
+    if (views[views.length - 1].id === activeStep.view.id) {
+      activeStep.step.status = 'completed';
+    }
+    resetUI();
+    setActiveStep();
+  }
+}
+
+function resetUI() {
+  eventsCompleted = [];
+}
+
+function setExecuting(isExecuting: boolean) {
+  executing = isExecuting;
+}
+
+function next() {
+  assertStepCompleted();
+}
+
+function setDisplayCancelSetup(display: boolean) {
+  displayCancelSetup = display;
+}
+
+function cancelSetup() {
+  // TODO: it cancels all running commands
+  // it redirect the user to the dashboard
+  router.goto('/');
+}
+</script>
+
+{#if onboarding}
+  <div class="flex flex-col bg-[#36373a] h-full">
+    <div class="flex flex-row justify-between mb-20">
+      {#if activeStep.step.media}
+        <img
+          class="w-14 h-14 object-contain"
+          alt="{activeStep.step.media.altText}"
+          src="{activeStep.step.media.path}" />
+      {/if}
+      <div class="flex flex-col ml-8 my-2">
+        <div class="text-lg font-bold text-white">{activeStep.step.title}</div>
+        {#if activeStep.step.description}
+          <div class="text-sm text-white">{activeStep.step.description}</div>
+        {/if}
+        <button
+          class="flex flex-row text-xs items-center hover:underline"
+          on:click="{() => setDisplayCancelSetup(true)}">
+          <span class="mr-1">Skip this entire setup</span>
+          <Fa icon="{faForward}" size="12" />
+        </button>
+      </div>
+      <div class="flex flex-row mt-1 mr-2">
+        {#each onboarding.steps as step}
+          <div class="flex flex-col mr-2">
+            <div class="flex justify-center mb-2">
+              {#if step.id === activeStep.step.id}
+                <Fa class="place-content-center text-purple-500" size="24" icon="{faFilledCircle}" />
+              {:else if step.status === 'completed'}
+                <Fa class="place-content-center" size="24" icon="{faCircleCheck}" />
+              {:else}
+                <Fa class="place-content-center" size="24" icon="{faCircle}" />
+              {/if}
+            </div>
+            <div class="text-sm">{step.title}</div>
+          </div>
+        {/each}
+      </div>
+    </div>
+    <div class="w-[450px] flex flex-col mx-auto">
+      {#if activeStep.view.media}
+        <div class="mx-auto">
+          <img
+            class="w-24 h-24 object-contain"
+            alt="{activeStep.view.media.altText}"
+            src="{activeStep.view.media.path}" />
+        </div>
+      {/if}
+      <div class="flex flex-row mx-auto">
+        {#if executing}
+          <div class="mt-1 mr-6">
+            <i class="pf-c-button__progress text-purple-400">
+              <span class="pf-c-spinner pf-m-md" role="progressbar">
+                <span class="pf-c-spinner__clipper"></span>
+                <span class="pf-c-spinner__lead-ball"></span>
+                <span class="pf-c-spinner__tail-ball"></span>
+              </span>
+            </i>
+          </div>
+        {/if}
+        <div class="text-lg text-white">{activeStep.view.title}</div>
+      </div>
+      {#if activeStep.view.description}
+        <div class="text-sm text-white mx-auto">{activeStep.view.description}</div>
+      {/if}
+    </div>
+
+    <div class="flex flex-col mx-auto">
+      {#if activeStep.view.content}
+        {#each activeStep.view.content as row}
+          <div class="flex flex-row mx-auto">
+            {#each row as item}
+              <OnboardingItem
+                item="{item}"
+                extensionId="{extensionId}"
+                step="{activeStep.step.id}"
+                context="{context}"
+                setExecuting="{setExecuting}" />
+            {/each}
+          </div>
+        {/each}
+      {/if}
+    </div>
+
+    {#if !activeStep.view.completionEvents || activeStep.view.completionEvents.length === 0}
+      <div class="grow"></div>
+      <div class="mb-10 mx-auto text-sm">
+        Press the <span class="bg-purple-700 p-0.5">Next</span> button below to proceed.
+      </div>
+      <div class="flex flex-row-reverse p-6 bg-charcoal-600">
+        <button class="bg-purple-700 py-1.5 px-5 rounded-md text-sm" on:click="{() => next()}">Next</button>
+        <button class="bg-purple-700 py-1.5 px-5 mr-2 rounded-md text-sm" on:click="{() => setDisplayCancelSetup(true)}"
+          >Cancel</button>
+      </div>
+    {/if}
+  </div>
+{/if}
+{#if displayCancelSetup}
+  <!-- Create overlay-->
+  <div class="fixed top-0 left-0 right-0 bottom-0 bg-black bg-opacity-60 bg-blend-multiply h-full grid z-50">
+    <div class="flex flex-col place-self-center w-[550px] rounded-xl bg-charcoal-800 shadow-xl shadow-black">
+      <div class="flex items-center justify-between pl-4 pr-3 py-3 space-x-2 text-gray-400">
+        <Fa class="h-4 w-4" icon="{faCircleQuestion}" />
+        <span class="grow text-md font-bold capitalize">Skip the entire setup?</span>
+      </div>
+
+      <div class="px-10 py-4 text-sm text-gray-500 leading-5">
+        If you exit, you can complete your setup later from the Resources page. Do you want to skip it?
+      </div>
+
+      <div class="px-5 py-5 mt-2 flex flex-row w-full justify-end space-x-5">
+        <button aria-label="Cancel" class="text-xs hover:underline" on:click="{() => setDisplayCancelSetup(false)}"
+          >Cancel</button>
+        <button class="bg-purple-700 py-1.5 px-5 mr-2 rounded-md text-xs" on:click="{() => cancelSetup()}">Ok</button>
+      </div>
+    </div>
+  </div>
+{/if}

--- a/packages/renderer/src/lib/onboarding/Onboarding.svelte
+++ b/packages/renderer/src/lib/onboarding/Onboarding.svelte
@@ -108,8 +108,6 @@ async function setActiveStep() {
   }
   for (const onboarding of onboardings) {
     if (!onboarding.status) {
-      //set active onboarding
-      await window.setRunningOnboarding(onboarding.extension);
       for (let i = 0; i < onboarding.steps.length; i++) {
         const step = onboarding.steps[i];
         if (!step.status) {

--- a/packages/renderer/src/lib/onboarding/Onboarding.svelte
+++ b/packages/renderer/src/lib/onboarding/Onboarding.svelte
@@ -125,11 +125,15 @@ async function setActiveStep() {
 async function doExecuteCommandsAtActivation(active: ActiveStep) {
   for (const cmd of active.view.commandAtActivation || []) {
     setExecuting(true);
-    ++executionId;
-    executions.push(executionId);
-    await window.executeOnboardingCommand(executionId, extensionId, active.step.id, cmd.command);
+    await window.executeOnboardingCommand(getExecutionId(), extensionId, active.step.id, cmd.command);
     setExecuting(false);
   }
+}
+
+function getExecutionId(): number {
+  ++executionId;
+  executions.push(executionId);
+  return executionId;
 }
 
 let eventsCompleted: string[] = [];
@@ -322,7 +326,8 @@ function cleanContext() {
                 extensionId="{extensionId}"
                 step="{activeStep.step.id}"
                 context="{context}"
-                setExecuting="{setExecuting}" />
+                setExecuting="{setExecuting}"
+                getExecutionId="{getExecutionId}" />
             {/each}
           </div>
         {/each}

--- a/packages/renderer/src/lib/onboarding/Onboarding.svelte
+++ b/packages/renderer/src/lib/onboarding/Onboarding.svelte
@@ -13,7 +13,7 @@ import { router } from 'tinro';
 import { context } from '/@/stores/context';
 import {
   ON_COMMAND_PREFIX,
-  ON_CONTEXT_PREFIX,
+  ONBOARDING_CONTEXT_PREFIX,
   SCOPE_ONBOARDING,
   STATUS_COMPLETED,
   STATUS_SKIPPED,
@@ -140,7 +140,7 @@ async function setActiveStep() {
 }
 
 function normalize(when: string, extension: string): string {
-  return when.replaceAll(ON_CONTEXT_PREFIX, `${extension}.${SCOPE_ONBOARDING}.`);
+  return when.replaceAll(ONBOARDING_CONTEXT_PREFIX, `${extension}.${SCOPE_ONBOARDING}.`);
 }
 
 async function doExecuteCommand(command: string) {
@@ -163,8 +163,8 @@ async function assertStepCompleted() {
       }
 
       // check if cmp string is an onContext event, check the value from context
-      if (cmp.startsWith(ON_CONTEXT_PREFIX)) {
-        cmp = cmp.replace(ON_CONTEXT_PREFIX, `${activeStep.onboarding.extension}.${SCOPE_ONBOARDING}.`);
+      if (cmp.startsWith(ONBOARDING_CONTEXT_PREFIX)) {
+        cmp = cmp.replace(ONBOARDING_CONTEXT_PREFIX, `${activeStep.onboarding.extension}.${SCOPE_ONBOARDING}.`);
         const completionEventDeserialized = ContextKeyExpr.deserialize(cmp);
         if (!globalContext) {
           return false;

--- a/packages/renderer/src/lib/onboarding/Onboarding.svelte
+++ b/packages/renderer/src/lib/onboarding/Onboarding.svelte
@@ -2,7 +2,12 @@
 import { extensionInfos } from '../../stores/extensions';
 import type { ExtensionInfo } from '../../../../main/src/plugin/api/extension-info';
 import { onDestroy, onMount } from 'svelte';
-import type { OnboardingInfo, OnboardingStep, OnboardingStepStatus, OnboardingStepView } from '../../../../main/src/plugin/api/onboarding';
+import type {
+  OnboardingInfo,
+  OnboardingStep,
+  OnboardingStepStatus,
+  OnboardingStepView,
+} from '../../../../main/src/plugin/api/onboarding';
 import { faCircle } from '@fortawesome/free-regular-svg-icons';
 import {
   faCircleCheck,
@@ -45,16 +50,18 @@ $: enableNextButton = false;*/
 let onboardingUnsubscribe: Unsubscriber;
 let contextsUnsubscribe: Unsubscriber;
 onMount(async () => {
-  onboardingUnsubscribe = onboardingList.subscribe(async onboardingItems => {
+  // eslint-disable-next-line @typescript-eslint/no-misused-promises
+  onboardingUnsubscribe = onboardingList.subscribe(onboardingItems => {
     if (!onboarding) {
       onboarding = onboardingItems.find(o => o.extension === extensionId);
-      await startOnboarding();
+      startOnboarding();
     }
   });
 
-  contextsUnsubscribe = contexts.subscribe(async value => {
+  // eslint-disable-next-line @typescript-eslint/no-misused-promises
+  contextsUnsubscribe = contexts.subscribe(value => {
     context = value.find(ctx => ctx.extension === extensionId);
-    await startOnboarding();
+    startOnboarding();
   });
 });
 
@@ -67,7 +74,7 @@ async function startOnboarding() {
       setDisplayResetSetup(true);
     } else {
       await restartSetup();
-    }      
+    }
   }
 }
 
@@ -87,7 +94,7 @@ async function setActiveStep() {
   }
   for (const step of onboarding.steps) {
     if (!step.status) {
-      for (let i=0; i<step.views.length; i++) {
+      for (let i = 0; i < step.views.length; i++) {
         const view = step.views[i];
         if (!view.status) {
           let whenDeserialized;
@@ -128,7 +135,7 @@ async function doExecuteCommandsAtActivation(active: ActiveStep) {
 let eventsCompleted: string[] = [];
 window.events?.receive('onboarding:command-executed', async result => {
   // this is a hack to keep the state safe whean receiving multiple events for the same action
-  const indexExecution = executions.indexOf(result.executionId);  
+  const indexExecution = executions.indexOf(result.executionId);
   if (indexExecution === -1) {
     return;
   }
@@ -370,11 +377,13 @@ function cleanContext() {
       </div>
 
       <div class="px-5 py-5 mt-2 flex flex-row w-full justify-end space-x-5">
-        <button aria-label="Cancel" class="text-xs hover:underline" on:click="{() => {
-          setDisplayResetSetup(false);
-          cancelSetup();
-        }}"
-          >No</button>
+        <button
+          aria-label="Cancel"
+          class="text-xs hover:underline"
+          on:click="{() => {
+            setDisplayResetSetup(false);
+            cancelSetup();
+          }}">No</button>
         <button class="bg-purple-700 py-1.5 px-5 mr-2 rounded-md text-xs" on:click="{() => restartSetup()}">Yes</button>
       </div>
     </div>

--- a/packages/renderer/src/lib/onboarding/OnboardingItem.spec.ts
+++ b/packages/renderer/src/lib/onboarding/OnboardingItem.spec.ts
@@ -1,0 +1,76 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import '@testing-library/jest-dom';
+import { test, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import OnboardingItem from './OnboardingItem.svelte';
+import type { OnboardingStepItem } from '../../../../main/src/plugin/api/onboarding';
+import { ContextUI } from '../context/context';
+
+test('Expect button html when passing a button component', async () => {
+  const buttonComponent: OnboardingStepItem = {
+    component: 'button',
+    command: 'command',
+    label: 'button',
+    id: 'id',
+  };
+  render(OnboardingItem, {
+    extension: 'extension',
+    item: buttonComponent,
+    getContext: vi.fn(),
+    executeCommand: vi.fn(),
+  });
+  const button = screen.getByRole('button', { name: 'button' });
+  expect(button).toBeInTheDocument();
+});
+
+test('Expect markdown html when passing a text component', async () => {
+  const textComponent: OnboardingStepItem = {
+    component: 'text',
+    id: 'text',
+    value: 'html content here',
+  };
+  render(OnboardingItem, {
+    extension: 'extension',
+    item: textComponent,
+    getContext: vi.fn(),
+    executeCommand: vi.fn(),
+  });
+  const markdownSection = screen.getByLabelText('markdown-content');
+  expect(markdownSection).toBeInTheDocument();
+  expect(markdownSection.innerHTML.includes('html content here')).toBe(true);
+});
+
+test('Expect placeholders are replaced when passing a text component with placeholders', async () => {
+  const textComponent: OnboardingStepItem = {
+    component: 'text',
+    id: 'text',
+    value: '${onboardingContext:text}',
+  };
+  const context = new ContextUI();
+  context.setValue('extension.onboarding.text', 'placeholder content');
+  render(OnboardingItem, {
+    extension: 'extension',
+    item: textComponent,
+    getContext: () => context,
+    executeCommand: vi.fn(),
+  });
+  const markdownSection = screen.getByLabelText('markdown-content');
+  expect(markdownSection).toBeInTheDocument();
+  expect(markdownSection.innerHTML.includes('placeholder content')).toBe(true);
+});

--- a/packages/renderer/src/lib/onboarding/OnboardingItem.svelte
+++ b/packages/renderer/src/lib/onboarding/OnboardingItem.svelte
@@ -23,7 +23,9 @@ onMount(() => {
       const buttonId = e.target.id;
       let command = buttons.get(buttonId);
       if (command) {
-        executeCommand(command);
+        executeCommand(command).catch((error: unknown) => {
+          console.error(`error while executing command ${command}`, error);
+        });
       }
     }
   };

--- a/packages/renderer/src/lib/onboarding/OnboardingItem.svelte
+++ b/packages/renderer/src/lib/onboarding/OnboardingItem.svelte
@@ -8,6 +8,7 @@ export let step: string;
 export let extensionId: string;
 export let context: ContextUI;
 export let setExecuting: (isExecuting: boolean) => void;
+export let getExecutionId: () => number;
 const re = new RegExp(/\${(.+?)}/g);
 let html;
 let isMarkdown = false;
@@ -22,7 +23,7 @@ onMount(() => {
       let command = buttons.get(buttonId);
       if (command) {
         setExecuting(true);
-        await window.executeOnboardingCommand(extensionId, step, command);
+        await window.executeOnboardingCommand(getExecutionId(), extensionId, step, command);
         setExecuting(false);
       }
     }
@@ -55,7 +56,8 @@ function createItem(item: OnboardingViewItem): string {
 function replacePlaceholders(label: string): string {
   let newLabel = label;
   let arr;
-  while ((arr = re.exec(newLabel)) !== undefined) {
+  // eslint-disable-next-line eqeqeq
+  while ((arr = re.exec(newLabel)) != undefined) {
     if (arr.length > 1) {
       const replacement = context.getDottedKeyValue(arr[1]);
       if (replacement) {

--- a/packages/renderer/src/lib/onboarding/OnboardingItem.svelte
+++ b/packages/renderer/src/lib/onboarding/OnboardingItem.svelte
@@ -2,7 +2,6 @@
 import { onDestroy, onMount } from 'svelte';
 import type { OnboardingViewItem } from '../../../../main/src/plugin/api/onboarding';
 import Markdown from '../markdown/Markdown.svelte';
-import { getContextDotsKeyValue } from '../context/contextKey';
 import type { ContextUI } from '../context/context';
 export let item: OnboardingViewItem;
 export let step: string;
@@ -58,7 +57,7 @@ function replacePlaceholders(label: string): string {
   let arr;
   while ((arr = re.exec(newLabel)) !== undefined) {
     if (arr.length > 1) {
-      const replacement = getContextDotsKeyValue(arr[1], context);
+      const replacement = context.getDottedKeyValue(arr[1]);
       if (replacement) {
         newLabel = newLabel.replace(arr[0], replacement.toString());
       }

--- a/packages/renderer/src/lib/onboarding/OnboardingItem.svelte
+++ b/packages/renderer/src/lib/onboarding/OnboardingItem.svelte
@@ -3,6 +3,8 @@ import { onDestroy, onMount } from 'svelte';
 import type { OnboardingStepItem } from '../../../../main/src/plugin/api/onboarding';
 import Markdown from '../markdown/Markdown.svelte';
 import type { ContextUI } from '../context/context';
+import { SCOPE_ONBOARDING } from './onboarding-utils';
+export let extension: string;
 export let item: OnboardingStepItem;
 export let getContext: () => ContextUI;
 export let executeCommand: (command: string) => Promise<void>;
@@ -55,7 +57,7 @@ function replacePlaceholders(label: string): string {
   // eslint-disable-next-line eqeqeq
   while ((arr = re.exec(newLabel)) != undefined) {
     if (arr.length > 1) {
-      const replacement = getContext().getValue(arr[1]);
+      const replacement = getContext().getValue(`${extension}.${SCOPE_ONBOARDING}.${arr[1]}`);
       if (replacement) {
         newLabel = newLabel.replace(arr[0], replacement.toString());
       }

--- a/packages/renderer/src/lib/onboarding/OnboardingItem.svelte
+++ b/packages/renderer/src/lib/onboarding/OnboardingItem.svelte
@@ -18,17 +18,16 @@ const eventListeners = [];
 onMount(() => {
   const itemHtml = createItem(item);
   html = itemHtml;
-  const clickListener = async e => {
+  const clickListener = e => {
     if (e.target instanceof HTMLButtonElement) {
       const buttonId = e.target.id;
       let command = buttons.get(buttonId);
       if (command) {
-        await executeCommand(command);
+        executeCommand(command);
       }
     }
   };
   eventListeners.push(clickListener);
-  /* eslint-disable @typescript-eslint/no-misused-promises */
   document.addEventListener('click', clickListener);
 });
 onDestroy(() => {
@@ -61,20 +60,19 @@ function replacePlaceholders(label: string): string {
 }
 
 function replacePlaceHoldersRegex(regex: RegExp, label: string, prefix?: string) {
-  let arr;
-  // eslint-disable-next-line eqeqeq
-  while ((arr = regex.exec(label)) != undefined) {
-    label = getNewValue(label, arr, prefix);
+  const matches = [...label.matchAll(regex)];
+  for (const match of matches) {
+    label = getNewValue(label, match, prefix);
   }
   return label;
 }
 
-function getNewValue(label: string, execArray: RegExpExecArray, prefix?: string) {
-  if (execArray.length > 1) {
-    const key = prefix ? `${prefix}.${execArray[1]}` : execArray[1];
+function getNewValue(label: string, matchArray: RegExpMatchArray, prefix?: string) {
+  if (matchArray.length > 1) {
+    const key = prefix ? `${prefix}.${matchArray[1]}` : matchArray[1];
     const replacement = getContext().getValue(key);
     if (replacement) {
-      return label.replace(execArray[0], replacement.toString());
+      return label.replace(matchArray[0], replacement.toString());
     }
   }
   return label;

--- a/packages/renderer/src/lib/onboarding/OnboardingItem.svelte
+++ b/packages/renderer/src/lib/onboarding/OnboardingItem.svelte
@@ -1,0 +1,81 @@
+<script lang="ts">
+import { onDestroy, onMount } from 'svelte';
+import type { OnboardingViewItem } from '../../../../main/src/plugin/api/onboarding';
+import Markdown from '../markdown/Markdown.svelte';
+import { getContextDotsKeyValue } from '../context/contextKey';
+import type { ContextUI } from '../context/context';
+export let item: OnboardingViewItem;
+export let step: string;
+export let extensionId: string;
+export let context: ContextUI;
+export let setExecuting: (isExecuting: boolean) => void;
+const re = new RegExp(/\${(.+?)}/g);
+let html;
+let isMarkdown = false;
+$: buttons = new Map<string, string>();
+const eventListeners = [];
+onMount(() => {
+  const itemHtml = createItem(item);
+  html = itemHtml;
+  const clickListener = async e => {
+    if (e.target instanceof HTMLButtonElement) {
+      const buttonId = e.target.id;
+      let command = buttons.get(buttonId);
+      if (command) {
+        setExecuting(true);
+        await window.executeOnboardingCommand(extensionId, step, command);
+        setExecuting(false);
+      }
+    }
+  };
+  eventListeners.push(clickListener);
+  /* eslint-disable @typescript-eslint/no-misused-promises */
+  document.addEventListener('click', clickListener);
+});
+onDestroy(() => {
+  eventListeners.forEach(listener => document.removeEventListener('click', listener));
+});
+function createItem(item: OnboardingViewItem): string {
+  let html = '';
+  switch (item.component) {
+    case 'button': {
+      const buttonId = `button-${buttons.size}`;
+      const value = `<button id="${buttonId}" class="bg-purple-700 py-2 px-2.5 rounded-md">${item.label}</button>`;
+      buttons.set(buttonId, item.command);
+      buttons = buttons;
+      html = value;
+      break;
+    }
+    default: {
+      html = replacePlaceholders(item.value);
+      isMarkdown = true;
+    }
+  }
+  return html;
+}
+function replacePlaceholders(label: string): string {
+  let newLabel = label;
+  let arr;
+  while ((arr = re.exec(newLabel)) !== undefined) {
+    if (arr.length > 1) {
+      const replacement = getContextDotsKeyValue(arr[1], context);
+      if (replacement) {
+        newLabel = newLabel.replace(arr[0], replacement.toString());
+      }
+    }
+  }
+  return newLabel;
+}
+</script>
+
+<div
+  class="flex justify-center {item.template === 'dark_bg' ? 'bg-charcoal-600' : ''} p-3 m-2 rounded-md min-w-[500px]">
+  {#if html}
+    {#if !isMarkdown}
+      <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+      {@html html}
+    {:else}
+      <Markdown>{html}</Markdown>
+    {/if}
+  {/if}
+</div>

--- a/packages/renderer/src/lib/onboarding/onboarding-utils.ts
+++ b/packages/renderer/src/lib/onboarding/onboarding-utils.ts
@@ -1,0 +1,24 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+export const SCOPE_ONBOARDING = 'onboarding';
+
+export const STATUS_COMPLETED = 'completed';
+export const STATUS_SKIPPED = 'skipped';
+
+export const ON_COMMAND_PREFIX = 'onCommand:';
+export const ON_CONTEXT_PREFIX = 'onContext:';

--- a/packages/renderer/src/lib/onboarding/onboarding-utils.ts
+++ b/packages/renderer/src/lib/onboarding/onboarding-utils.ts
@@ -21,4 +21,4 @@ export const STATUS_COMPLETED = 'completed';
 export const STATUS_SKIPPED = 'skipped';
 
 export const ON_COMMAND_PREFIX = 'onCommand:';
-export const ON_CONTEXT_PREFIX = 'onContext:';
+export const ONBOARDING_CONTEXT_PREFIX = 'onboardingContext:';

--- a/packages/renderer/src/lib/preferences/PreferencesExtensionRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesExtensionRendering.spec.ts
@@ -19,13 +19,15 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import '@testing-library/jest-dom';
-import { test, expect } from 'vitest';
+import { test, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/svelte';
 import PreferencesExtensionRendering from './PreferencesExtensionRendering.svelte';
 import { extensionInfos } from '../../stores/extensions';
 
+const getOnboardingMock = vi.fn();
 // fake the window.events object
 beforeAll(() => {
+  (window as any).getOnboarding = getOnboardingMock;
   (window.events as unknown) = {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     receive: (_channel: string, func: any) => {

--- a/packages/renderer/src/lib/preferences/PreferencesExtensionRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesExtensionRendering.svelte
@@ -7,11 +7,14 @@ import ExtensionStatus from '../ui/ExtensionStatus.svelte';
 import Button from '../ui/Button.svelte';
 import { faPlay, faStop, faTrash } from '@fortawesome/free-solid-svg-icons';
 import { router } from 'tinro';
+import { onMount } from 'svelte';
 
 export let extensionId: string = undefined;
 
 let extensionInfo: ExtensionInfo;
 $: extensionInfo = $extensionInfos.find(extension => extension.id === extensionId);
+$: hideOnboardingButton = true;
+$: hasOnboarding(extensionId).then(value => hideOnboardingButton = value);
 
 async function stopExtension() {
   await window.stopExtension(extensionInfo.id);
@@ -22,6 +25,11 @@ async function startExtension() {
 async function removeExtension() {
   window.location.href = '#/preferences/extensions';
   await window.removeExtension(extensionInfo.id);
+}
+
+async function hasOnboarding(extensionId: string): Promise<boolean> {
+  const onboarding = await window.getOnboarding(extensionId);
+  return !onboarding;
 }
 </script>
 
@@ -71,7 +79,8 @@ async function removeExtension() {
           {/if}
         </div>
 
-        <div class="px-2 text-sm italic text-gray-700">
+        <div class="px-2 text-sm italic text-gray-700"
+          class:hidden="{hideOnboardingButton}">
           <button
             on:click="{() => router.goto(`/preferences/onboarding/${extensionInfo.id}`)}"
             class="pf-c-button pf-m-primary"

--- a/packages/renderer/src/lib/preferences/PreferencesExtensionRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesExtensionRendering.svelte
@@ -6,6 +6,7 @@ import SettingsPage from './SettingsPage.svelte';
 import ExtensionStatus from '../ui/ExtensionStatus.svelte';
 import Button from '../ui/Button.svelte';
 import { faPlay, faStop, faTrash } from '@fortawesome/free-solid-svg-icons';
+import { router } from 'tinro';
 
 export let extensionId: string = undefined;
 
@@ -68,6 +69,18 @@ async function removeExtension() {
           {:else}
             <div class="text-gray-900 items-center px-2 text-sm">Default extension, cannot be removed</div>
           {/if}
+        </div>
+
+        <div class="px-2 text-sm italic text-gray-700">
+          <button
+            on:click="{() => router.goto(`/preferences/onboarding/${extensionInfo.id}`)}"
+            class="pf-c-button pf-m-primary"
+            type="button">
+            <span class="pf-c-button__icon pf-m-start">
+              <i class="fas fa-play" aria-hidden="true"></i>
+            </span>
+            Onboarding
+          </button>
         </div>
         {#if extensionInfo.error}
           <div class="flex flex-col">

--- a/packages/renderer/src/lib/preferences/PreferencesExtensionRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesExtensionRendering.svelte
@@ -7,14 +7,13 @@ import ExtensionStatus from '../ui/ExtensionStatus.svelte';
 import Button from '../ui/Button.svelte';
 import { faPlay, faStop, faTrash } from '@fortawesome/free-solid-svg-icons';
 import { router } from 'tinro';
-import { onMount } from 'svelte';
 
 export let extensionId: string = undefined;
 
 let extensionInfo: ExtensionInfo;
 $: extensionInfo = $extensionInfos.find(extension => extension.id === extensionId);
 $: hideOnboardingButton = true;
-$: hasOnboarding(extensionId).then(value => hideOnboardingButton = value);
+$: hasOnboarding(extensionId).then(value => (hideOnboardingButton = value));
 
 async function stopExtension() {
   await window.stopExtension(extensionInfo.id);
@@ -79,8 +78,7 @@ async function hasOnboarding(extensionId: string): Promise<boolean> {
           {/if}
         </div>
 
-        <div class="px-2 text-sm italic text-gray-700"
-          class:hidden="{hideOnboardingButton}">
+        <div class="px-2 text-sm italic text-gray-700" class:hidden="{hideOnboardingButton}">
           <button
             on:click="{() => router.goto(`/preferences/onboarding/${extensionInfo.id}`)}"
             class="pf-c-button pf-m-primary"

--- a/packages/renderer/src/lib/preferences/PreferencesPage.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesPage.svelte
@@ -16,6 +16,7 @@ import PreferencesExtensionList from './PreferencesExtensionList.svelte';
 import PreferencesResourcesRendering from './PreferencesResourcesRendering.svelte';
 import PreferencesAuthenticationProvidersRendering from './PreferencesAuthenticationProvidersRendering.svelte';
 import PreferencesInstallExtensionFromId from './PreferencesInstallExtensionFromId.svelte';
+import Onboarding from '../onboarding/Onboarding.svelte';
 
 let properties: IConfigurationPropertyRecordedSchema[];
 let defaultPrefPageId: string;
@@ -80,6 +81,10 @@ onMount(async () => {
 
   <Route path="/extensions/install-from-id/:extensionId" breadcrumb="Install Extension from id" let:meta>
     <PreferencesInstallExtensionFromId extensionId="{meta.params.extensionId}" />
+  </Route>
+
+  <Route path="/onboarding/:extensionId" breadcrumb="Extension Onboarding" let:meta>
+    <Onboarding extensionId="{meta.params.extensionId}" />
   </Route>
 
   <Route

--- a/packages/renderer/src/lib/preferences/PreferencesPage.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesPage.svelte
@@ -84,7 +84,7 @@ onMount(async () => {
   </Route>
 
   <Route path="/onboarding/:extensionId" breadcrumb="Extension Onboarding" let:meta>
-    <Onboarding extensionId="{meta.params.extensionId}" />
+    <Onboarding extensionIds="{[meta.params.extensionId]}" />
   </Route>
 
   <Route

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
@@ -232,12 +232,12 @@ async function startConnectionProvider(
 
 async function doCreateNew(provider: ProviderInfo, displayName: string) {
   displayInstallModal = false;
-  if (provider.status === 'not-installed') {    
+  if (provider.status === 'not-installed') {
     providerInstallationInProgress.set(provider.name, true);
     providerInstallationInProgress = providerInstallationInProgress;
     providerToBeInstalled = { provider, displayName };
     doExecuteAfterInstallation = () => router.goto(`/preferences/provider/${provider.internalId}`);
-    performInstallation(provider);    
+    performInstallation(provider);
   } else {
     router.goto(`/preferences/provider/${provider.internalId}`);
   }

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
@@ -233,11 +233,16 @@ async function startConnectionProvider(
 async function doCreateNew(provider: ProviderInfo, displayName: string) {
   displayInstallModal = false;
   if (provider.status === 'not-installed') {
-    providerInstallationInProgress.set(provider.name, true);
-    providerInstallationInProgress = providerInstallationInProgress;
-    providerToBeInstalled = { provider, displayName };
-    doExecuteAfterInstallation = () => router.goto(`/preferences/provider/${provider.internalId}`);
-    performInstallation(provider);
+    const onboarding = window.getOnboarding(provider.id);
+    if (onboarding) {
+      router.goto(`/preferences/onboarding/${provider.id}`)
+    } else {
+      providerInstallationInProgress.set(provider.name, true);
+      providerInstallationInProgress = providerInstallationInProgress;
+      providerToBeInstalled = { provider, displayName };
+      doExecuteAfterInstallation = () => router.goto(`/preferences/provider/${provider.internalId}`);
+      performInstallation(provider);
+    }    
   } else {
     router.goto(`/preferences/provider/${provider.internalId}`);
   }

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
@@ -232,17 +232,12 @@ async function startConnectionProvider(
 
 async function doCreateNew(provider: ProviderInfo, displayName: string) {
   displayInstallModal = false;
-  if (provider.status === 'not-installed') {
-    const onboarding = window.getOnboarding(provider.id);
-    if (onboarding) {
-      router.goto(`/preferences/onboarding/${provider.id}`)
-    } else {
-      providerInstallationInProgress.set(provider.name, true);
-      providerInstallationInProgress = providerInstallationInProgress;
-      providerToBeInstalled = { provider, displayName };
-      doExecuteAfterInstallation = () => router.goto(`/preferences/provider/${provider.internalId}`);
-      performInstallation(provider);
-    }    
+  if (provider.status === 'not-installed') {    
+    providerInstallationInProgress.set(provider.name, true);
+    providerInstallationInProgress = providerInstallationInProgress;
+    providerToBeInstalled = { provider, displayName };
+    doExecuteAfterInstallation = () => router.goto(`/preferences/provider/${provider.internalId}`);
+    performInstallation(provider);    
   } else {
     router.goto(`/preferences/provider/${provider.internalId}`);
   }

--- a/packages/renderer/src/stores/onboarding.spec.ts
+++ b/packages/renderer/src/stores/onboarding.spec.ts
@@ -1,0 +1,88 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { get } from 'svelte/store';
+import type { Mock } from 'vitest';
+import { expect, test, vi } from 'vitest';
+import type { OnboardingInfo } from '../../../main/src/plugin/api/onboarding';
+import { fetchOnboarding, onboardingEventStore, onboardingList } from './onboarding';
+
+// first, path window object
+const callbacks = new Map<string, any>();
+const eventEmitter = {
+  receive: (message: string, callback: any) => {
+    callbacks.set(message, callback);
+  },
+};
+
+const listOnboardingMock: Mock<any, Promise<OnboardingInfo[]>> = vi.fn();
+
+Object.defineProperty(global, 'window', {
+  value: {
+    listOnboarding: listOnboardingMock,
+    events: {
+      receive: eventEmitter.receive,
+    },
+    addEventListener: eventEmitter.receive,
+  },
+  writable: true,
+});
+
+beforeAll(() => {
+  vi.clearAllMocks();
+});
+
+test('onboarding should be updated in case of an extension is stopped', async () => {
+  // initial view
+  listOnboardingMock.mockResolvedValue([
+    {
+      extension: 'extension',
+      title: 'title',
+      decription: 'description',
+      steps: [],
+    } as unknown as OnboardingInfo,
+  ]);
+  onboardingEventStore.setup();
+
+  const callback = callbacks.get('extensions-already-started');
+  // send 'extensions-already-started' event
+  expect(callback).toBeDefined();
+  await callback();
+
+  // now ready to fetch volumes
+  await fetchOnboarding();
+
+  // now get list
+  const onboardingList1 = get(onboardingList);
+  expect(onboardingList1.length).toBe(1);
+  expect(onboardingList1[0].extension).toEqual('extension');
+
+  // ok now mock the listVolumes function to return an empty list
+  listOnboardingMock.mockResolvedValue([]);
+
+  // call 'container-removed-event' event
+  const extensionStoppedCallback = callbacks.get('extension-stopped');
+  expect(extensionStoppedCallback).toBeDefined();
+  await extensionStoppedCallback();
+
+  // check if the volumes are updated
+  const onboardingList2 = get(onboardingList);
+  expect(onboardingList2.length).toBe(0);
+});

--- a/packages/renderer/src/stores/onboarding.spec.ts
+++ b/packages/renderer/src/stores/onboarding.spec.ts
@@ -74,15 +74,15 @@ test('onboarding should be updated in case of an extension is stopped', async ()
   expect(onboardingList1.length).toBe(1);
   expect(onboardingList1[0].extension).toEqual('extension');
 
-  // ok now mock the listVolumes function to return an empty list
+  // ok now mock the listOnboarding function to return an empty list
   listOnboardingMock.mockResolvedValue([]);
 
-  // call 'container-removed-event' event
+  // call 'extension-stopped' event
   const extensionStoppedCallback = callbacks.get('extension-stopped');
   expect(extensionStoppedCallback).toBeDefined();
   await extensionStoppedCallback();
 
-  // check if the volumes are updated
+  // check if the onboardings are updated
   const onboardingList2 = get(onboardingList);
   expect(onboardingList2.length).toBe(0);
 });

--- a/packages/renderer/src/stores/onboarding.ts
+++ b/packages/renderer/src/stores/onboarding.ts
@@ -41,7 +41,7 @@ const listOnboarding = (): Promise<OnboardingInfo[]> => {
   return window.listOnboarding();
 };
 
-const onboardingEventStore = new EventStore<OnboardingInfo[]>(
+export const onboardingEventStore = new EventStore<OnboardingInfo[]>(
   'onboarding',
   onboardingList,
   checkForUpdate,
@@ -49,4 +49,8 @@ const onboardingEventStore = new EventStore<OnboardingInfo[]>(
   windowListeners,
   listOnboarding,
 );
-onboardingEventStore.setup();
+const onboardingEventStoreInfo = onboardingEventStore.setup();
+
+export const fetchOnboarding = async () => {
+  await onboardingEventStoreInfo.fetch();
+};

--- a/packages/renderer/src/stores/onboarding.ts
+++ b/packages/renderer/src/stores/onboarding.ts
@@ -1,0 +1,52 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { Writable } from 'svelte/store';
+import { writable } from 'svelte/store';
+import type { OnboardingInfo } from '../../../main/src/plugin/api/onboarding';
+import { EventStore } from './event-store';
+
+const windowEvents = ['extension-stopped', 'extensions-started'];
+const windowListeners = ['extensions-already-started'];
+
+let readyToUpdate = false;
+
+export async function checkForUpdate(eventName: string): Promise<boolean> {
+  if ('extensions-already-started' === eventName) {
+    readyToUpdate = true;
+  }
+
+  // do not fetch until extensions are all started
+  return readyToUpdate;
+}
+export const onboardingList: Writable<OnboardingInfo[]> = writable([]);
+
+// use helper here as window methods are initialized after the store in tests
+const listOnboarding = (): Promise<OnboardingInfo[]> => {
+  return window.listOnboarding();
+};
+
+const onboardingEventStore = new EventStore<OnboardingInfo[]>(
+  'onboarding',
+  onboardingList,
+  checkForUpdate,
+  windowEvents,
+  windowListeners,
+  listOnboarding,
+);
+onboardingEventStore.setup();


### PR DESCRIPTION
### What does this PR do?

This is the initial implementation for the onboarding feature.
It only covers a simple onboarding for podman. Check system requirements -> install podman -> yay! done.

The onboarding can only be started in the podman extension page so far. I'll refactor it in next PR. Starting it from the `create new..` button in the resources page or when PD gets started was a bit more complex and i'd like to keep this PR simple and focus on the workflow. 
BTW, the `onboarding button` will only be visible if the experimental onboarding setting (hidden by default) is set to true. 
So a user who wants to try it should edit the settings file manually.
A normal user will never see this or access to the onboarding.

In the video below i show what happens when you follow the workflow and it fails somehow, what happens if it succeed, the messages that popup to ask the user to restart the onboarding, the cancel and skip buttons

https://drive.google.com/file/d/1dxcuzc8gzUyoe_wh_DAVrvgIIsi4Z5Jx/view?usp=sharing

In this second video i show how the errors are displayed if the system requirements step fails somehow (i had to fake it by updating the code).

https://drive.google.com/file/d/1TQnpdW_0o6wSf_vSzlfjbV64k3AqrraG/view?usp=sharing

Everything is created by reading the package.json file

### Screenshot/screencast of this PR

https://drive.google.com/file/d/1dxcuzc8gzUyoe_wh_DAVrvgIIsi4Z5Jx/view?usp=sharing

https://drive.google.com/file/d/1TQnpdW_0o6wSf_vSzlfjbV64k3AqrraG/view?usp=sharing

### What issues does this PR fix or reference?

#3172 

### How to test this PR?

1. uninstall podman
2. set the onboarding setting to true (go to `.local\share\containers\podman-desktop\configuration\settings.json` and add `"experimental.onboarding":true`)
3. start PD, go to settings, extension , podman , click on the onboarding button

I still have to write some test for the onboarding.svelte file but you can play with it, suggest changes, etc..
