### PR TITLE
chore: use the new process API in podman extension

### DIFF
--- a/extensions/podman/src/compatibility-mode.ts
+++ b/extensions/podman/src/compatibility-mode.ts
@@ -20,7 +20,7 @@ import * as extensionApi from '@podman-desktop/api';
 import * as sudo from 'sudo-prompt';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
-import { execPromise, getPodmanCli } from './podman-cli';
+import { getPodmanCli } from './podman-cli';
 import { findRunningMachine } from './extension';
 
 const podmanSystemdSocket = 'podman.socket';
@@ -126,8 +126,8 @@ export class DarwinSocketCompatibility extends SocketCompatibility {
     );
     if (result === 'Yes') {
       // Await since we must wait for the machine to stop before starting it again
-      await execPromise(getPodmanCli(), ['machine', 'stop', machine]);
-      await execPromise(getPodmanCli(), ['machine', 'start', machine]);
+      await extensionApi.process.exec(getPodmanCli(), ['machine', 'stop', machine]);
+      await extensionApi.process.exec(getPodmanCli(), ['machine', 'start', machine]);
     }
   }
 
@@ -188,7 +188,7 @@ export class LinuxSocketCompatibility extends SocketCompatibility {
 
     try {
       // Have to run via sudo
-      await execPromise('systemctl', fullCommand);
+      await extensionApi.process.exec('systemctl', fullCommand);
     } catch (error) {
       console.error(`Error running systemctl command: ${error}`);
       await extensionApi.window.showErrorMessage(`Error running systemctl command: ${error}`, 'OK');
@@ -207,7 +207,7 @@ export class LinuxSocketCompatibility extends SocketCompatibility {
       // If the user clicked Yes, run the ln command
       if (result === 'Yes') {
         try {
-          await execPromise('pkexec', ['ln', '-s', '/run/podman/podman.sock', '/var/run/docker.sock']);
+          await extensionApi.process.exec('pkexec', ['ln', '-s', '/run/podman/podman.sock', '/var/run/docker.sock']);
           await extensionApi.window.showInformationMessage(
             'Symlink created successfully. The Podman socket is now available at /var/run/docker.sock.',
           );

--- a/extensions/podman/src/extension.spec.ts
+++ b/extensions/podman/src/extension.spec.ts
@@ -19,11 +19,11 @@
 
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 import * as extension from './extension';
-import * as podmanCli from './podman-cli';
 import { getPodmanCli } from './podman-cli';
 import type { Configuration } from '@podman-desktop/api';
 import * as extensionApi from '@podman-desktop/api';
 import * as fs from 'node:fs';
+import { LoggerDelegator } from './util';
 
 const config: Configuration = {
   get: () => {
@@ -127,6 +127,10 @@ vi.mock('@podman-desktop/api', async () => {
     window: {
       showInformationMessage: vi.fn(),
     },
+
+    process: {
+      exec: vi.fn(),
+    },
   };
 });
 
@@ -141,9 +145,9 @@ afterEach(() => {
 });
 
 test('verify create command called with correct values', async () => {
-  const spyExecPromise = vi.spyOn(podmanCli, 'execPromise');
+  const spyExecPromise = vi.spyOn(extensionApi.process, 'exec');
   spyExecPromise.mockImplementation(() => {
-    return Promise.resolve('');
+    return Promise.resolve({} as extensionApi.RunResult);
   });
   await extension.createMachine(
     {
@@ -160,16 +164,15 @@ test('verify create command called with correct values', async () => {
     {
       env: {},
       logger: undefined,
+      token: undefined,
     },
-    undefined,
   );
-  expect(console.error).not.toBeCalled();
 });
 
 test('verify create command called with correct values with user mode networking', async () => {
-  const spyExecPromise = vi.spyOn(podmanCli, 'execPromise');
+  const spyExecPromise = vi.spyOn(extensionApi.process, 'exec');
   spyExecPromise.mockImplementation(() => {
-    return Promise.resolve('');
+    return Promise.resolve({} as extensionApi.RunResult);
   });
   await extension.createMachine(
     {
@@ -195,15 +198,10 @@ test('verify create command called with correct values with user mode networking
     'path',
     '--user-mode-networking',
   ];
-  expect(spyExecPromise).toBeCalledWith(
-    getPodmanCli(),
-    parameters,
-    {
-      env: {},
-      logger: undefined,
-    },
-    undefined,
-  );
+  expect(spyExecPromise).toBeCalledWith(getPodmanCli(), parameters, {
+    env: {},
+    logger: undefined,
+  });
   expect(console.error).not.toBeCalled();
 });
 
@@ -251,34 +249,42 @@ test('if a machine is successfully started it changes its state to started', asy
     return;
   });
 
-  const spyExecPromise = vi.spyOn(podmanCli, 'execPromise');
-  spyExecPromise.mockImplementation(() => {
-    return Promise.resolve('');
-  });
+  const spyExecPromise = vi.spyOn(extensionApi.process, 'exec').mockImplementation(
+    () =>
+      new Promise<extensionApi.RunResult>(resolve => {
+        resolve({} as extensionApi.RunResult);
+      }),
+  );
   await extension.startMachine(provider, machineInfo);
 
   expect(spyExecPromise).toBeCalledWith(getPodmanCli(), ['machine', 'start', 'name'], {
-    logger: undefined,
+    logger: new LoggerDelegator(),
   });
 
   expect(spyUpdateStatus).toBeCalledWith('started');
 });
 
 test('if a machine failed to start with a generic error, this is thrown', async () => {
-  const spyExecPromise = vi.spyOn(podmanCli, 'execPromise');
-  spyExecPromise.mockImplementation(() => {
-    return Promise.reject(new Error('generic error'));
-  });
+  vi.spyOn(extensionApi.process, 'exec').mockImplementation(
+    () =>
+      new Promise<extensionApi.RunResult>((resolve, reject) => {
+        // eslint-disable-next-line prefer-promise-reject-errors
+        reject(new Error('generic error') as extensionApi.RunError);
+      }),
+  );
 
   await expect(extension.startMachine(provider, machineInfo)).rejects.toThrow('generic error');
   expect(console.error).toBeCalled();
 });
 
 test('if a machine failed to start with a wsl distro not found error, the user is asked what to do', async () => {
-  const spyExecPromise = vi.spyOn(podmanCli, 'execPromise');
-  spyExecPromise.mockImplementation(() => {
-    return Promise.reject(new Error('wsl bootstrap script failed: exit status 0xffffffff'));
-  });
+  vi.spyOn(extensionApi.process, 'exec').mockImplementation(
+    () =>
+      new Promise<extensionApi.RunResult>((resolve, reject) => {
+        // eslint-disable-next-line prefer-promise-reject-errors
+        reject(new Error('wsl bootstrap script failed: exit status 0xffffffff') as extensionApi.RunError);
+      }),
+  );
 
   await expect(extension.startMachine(provider, machineInfo)).rejects.toThrow(
     'wsl bootstrap script failed: exit status 0xffffffff',
@@ -292,7 +298,7 @@ test('if a machine failed to start with a wsl distro not found error, the user i
 });
 
 test('if a machine failed to start with a wsl distro not found error but the skipHandleError is false, the error is thrown', async () => {
-  const spyExecPromise = vi.spyOn(podmanCli, 'execPromise');
+  const spyExecPromise = vi.spyOn(extensionApi.process, 'exec');
   spyExecPromise.mockImplementation(() => {
     return Promise.reject(new Error('wsl bootstrap script failed: exit status 0xffffffff'));
   });
@@ -339,10 +345,12 @@ test('test checkDefaultMachine - if there is no machine marked as default, take 
     },
   ];
 
-  const spyExecPromise = vi.spyOn(podmanCli, 'execPromise');
-  spyExecPromise.mockImplementation(() => {
-    return Promise.resolve(JSON.stringify(fakeConnectionJSON));
-  });
+  vi.spyOn(extensionApi.process, 'exec').mockImplementation(
+    () =>
+      new Promise<extensionApi.RunResult>(resolve => {
+        resolve({ stdout: JSON.stringify(fakeConnectionJSON) } as extensionApi.RunResult);
+      }),
+  );
 
   await extension.checkDefaultMachine(fakeJSON);
 
@@ -390,20 +398,24 @@ test('test checkDefaultMachine - if there is no machine marked as default, take 
     },
   ];
 
-  const spyExecPromise = vi.spyOn(podmanCli, 'execPromise');
-  spyExecPromise.mockImplementation(() => {
-    return Promise.resolve(JSON.stringify(fakeConnectionJSON));
-  });
+  vi.spyOn(extensionApi.process, 'exec').mockImplementation(
+    () =>
+      new Promise<extensionApi.RunResult>(resolve => {
+        resolve({ stdout: JSON.stringify(fakeConnectionJSON) } as extensionApi.RunResult);
+      }),
+  );
 
   await extension.checkDefaultMachine(fakeJSON);
   expect(extensionApi.window.showInformationMessage).not.toHaveBeenCalled();
 });
 
 test('test checkDefaultMachine - if user wants to change default machine, check if it is rootful and update connection', async () => {
-  const spyExecPromise = vi.spyOn(podmanCli, 'execPromise');
-  spyExecPromise.mockImplementation(() => {
-    return Promise.resolve(JSON.stringify(fakeMachineInfoJSON));
-  });
+  const spyExecPromise = vi.spyOn(extensionApi.process, 'exec').mockImplementation(
+    () =>
+      new Promise<extensionApi.RunResult>(resolve => {
+        resolve({ stdout: JSON.stringify(fakeMachineInfoJSON) } as extensionApi.RunResult);
+      }),
+  );
 
   const spyPrompt = vi.spyOn(extensionApi.window, 'showInformationMessage');
   spyPrompt.mockResolvedValue('Yes');
@@ -440,10 +452,12 @@ test('test checkDefaultMachine - if user wants to change default machine, check 
 });
 
 test('test checkDefaultMachine - if user wants to change machine, check that it only change the connection once if it is rootless', async () => {
-  const spyExecPromise = vi.spyOn(podmanCli, 'execPromise');
-  spyExecPromise.mockImplementation(() => {
-    return Promise.resolve(JSON.stringify(fakeMachineInfoJSON));
-  });
+  const spyExecPromise = vi.spyOn(extensionApi.process, 'exec').mockImplementation(
+    () =>
+      new Promise<extensionApi.RunResult>(resolve => {
+        resolve({ stdout: JSON.stringify(fakeMachineInfoJSON) } as extensionApi.RunResult);
+      }),
+  );
 
   const spyPrompt = vi.spyOn(extensionApi.window, 'showInformationMessage');
   spyPrompt.mockResolvedValue('Yes');
@@ -475,10 +489,12 @@ test('test checkDefaultMachine - if user wants to change machine, check that it 
 });
 
 test('test checkDefaultMachine - if user wants to change machine, check that it only changes the connection once if it fails at checking rootful because file does not exist', async () => {
-  const spyExecPromise = vi.spyOn(podmanCli, 'execPromise');
-  spyExecPromise.mockImplementation(() => {
-    return Promise.resolve(JSON.stringify(fakeMachineInfoJSON));
-  });
+  const spyExecPromise = vi.spyOn(extensionApi.process, 'exec').mockImplementation(
+    () =>
+      new Promise<extensionApi.RunResult>(resolve => {
+        resolve({ stdout: JSON.stringify(fakeMachineInfoJSON) } as extensionApi.RunResult);
+      }),
+  );
 
   const spyPrompt = vi.spyOn(extensionApi.window, 'showInformationMessage');
   spyPrompt.mockResolvedValue('Yes');
@@ -504,10 +520,12 @@ test('test checkDefaultMachine - if user wants to change machine, check that it 
 });
 
 test('if user wants to change machine, check that it only change the connection once if it fails at checking rootful because file is empty', async () => {
-  const spyExecPromise = vi.spyOn(podmanCli, 'execPromise');
-  spyExecPromise.mockImplementation(() => {
-    return Promise.resolve(JSON.stringify(fakeMachineInfoJSON));
-  });
+  const spyExecPromise = vi.spyOn(extensionApi.process, 'exec').mockImplementation(
+    () =>
+      new Promise<extensionApi.RunResult>(resolve => {
+        resolve({ stdout: JSON.stringify(fakeMachineInfoJSON) } as extensionApi.RunResult);
+      }),
+  );
 
   const spyPrompt = vi.spyOn(extensionApi.window, 'showInformationMessage');
   spyPrompt.mockResolvedValue('Yes');

--- a/extensions/podman/src/podman-cli.ts
+++ b/extensions/podman/src/podman-cli.ts
@@ -15,10 +15,8 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
-import { spawn } from 'node:child_process';
 import { isMac, isWindows } from './util';
-import type { CancellationToken, LifecycleContext, Logger } from '@podman-desktop/api';
-import { configuration } from '@podman-desktop/api';
+import { configuration, process } from '@podman-desktop/api';
 
 const macosExtraPath = '/usr/local/bin:/opt/homebrew/bin:/opt/local/bin:/opt/podman/bin';
 
@@ -56,87 +54,13 @@ export function getCustomBinaryPath(): string | undefined {
   return configuration.getConfiguration('podman').get('binary.path');
 }
 
-export interface ExecOptions {
-  context?: LifecycleContext;
-  logger?: Logger;
-  env?: NodeJS.ProcessEnv;
-}
-
-export function execPromise(
-  command: string,
-  args?: string[],
-  options?: ExecOptions,
-  token?: CancellationToken,
-): Promise<string> {
-  let env = Object.assign({}, process.env); // clone original env object
-
-  // In production mode, applications don't have access to the 'user' path like brew
-  if (isMac() || isWindows()) {
-    env.PATH = getInstallationPath();
-  } else if (env.FLATPAK_ID) {
-    // need to execute the command on the host
-    args = ['--host', command, ...args];
-    command = 'flatpak-spawn';
-  }
-
-  if (options?.env) {
-    env = Object.assign(env, options.env);
-  }
-  return new Promise((resolve, reject) => {
-    let stdOut = '';
-    let stdErr = '';
-    const process = spawn(command, args, { env });
-    // if the token is cancelled, kill the process and reject the promise
-    token?.onCancellationRequested(() => {
-      process.kill();
-      // reject the promise
-      options?.context?.log.error('Execution cancelled');
-      options?.logger?.error('Execution cancelled');
-      reject(new Error('Execution cancelled'));
-    });
-    process.on('error', error => {
-      let content = '';
-      if (stdOut && stdOut !== '') {
-        content += stdOut + '\n';
-      }
-      if (stdErr && stdErr !== '') {
-        content += stdErr + '\n';
-      }
-      options?.context?.log.error(content);
-      options?.logger?.error(content);
-      reject(new Error(content + error));
-    });
-    process.stdout.setEncoding('utf8');
-    process.stdout.on('data', data => {
-      stdOut += data;
-      options?.context?.log.log(data);
-      options?.logger?.log(data);
-    });
-    process.stderr.setEncoding('utf8');
-    process.stderr.on('data', data => {
-      stdErr += data;
-      options?.context?.log.warn(data);
-      options?.logger?.warn(data);
-    });
-
-    process.on('close', exitCode => {
-      if (exitCode !== 0) {
-        options?.context?.log.error(stdErr);
-        options?.logger?.error(stdErr);
-        reject(new Error(stdErr));
-      }
-      resolve(stdOut.trim());
-    });
-  });
-}
-
 export interface InstalledPodman {
   version: string;
 }
 
 export async function getPodmanInstallation(): Promise<InstalledPodman | undefined> {
   try {
-    const versionOut = await execPromise(getPodmanCli(), ['--version']);
+    const { stdout: versionOut } = await process.exec(getPodmanCli(), ['--version']);
     const versionArr = versionOut.split(' ');
     const version = versionArr[versionArr.length - 1];
     return { version };


### PR DESCRIPTION
### What does this PR do?

The following changes proposal provides a refactoring for an existing code to use the new process execution API.

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

need for #3174 

### How to test this PR?

Check that existing features related to podman communication works as before.
