### PR TITLE
chore: pd buttons

### DIFF
--- a/packages/renderer/src/app.css
+++ b/packages/renderer/src/app.css
@@ -9,3 +9,37 @@ a {
   -webkit-user-drag: none;
   -webkit-app-region: no-drag;
 }
+
+@layer components {
+  .pd-button {
+    @apply relative px-4 py-[6px] rounded-[4px] box-border text-white text-[13px] whitespace-nowrap select-none;
+  }
+
+  .pd-primary:disabled {
+    @apply bg-charcoal-50;
+  }
+
+  .pd-primary {
+    @apply bg-purple-500 border-none;
+  }
+
+  .pd-primary:hover:enabled {
+    @apply bg-purple-400;
+  }
+
+  .pd-secondary {
+    @apply border-[1px] border-gray-200;
+  }
+
+  .pd-secondary:hover:enabled {
+    @apply border-purple-500 text-purple-500;
+  }
+
+  .pd-button-icon {
+    @apply p-0 m-0 bg-transparent;
+  }
+
+  .pd-start {
+    @apply mr-1;
+  }
+}

--- a/packages/renderer/src/lib/ContainerList.svelte
+++ b/packages/renderer/src/lib/ContainerList.svelte
@@ -394,8 +394,8 @@ function errorCallback(container: ContainerInfoUI, errorMessage: string): void {
     {#if $containersInfos.length > 0}
       <Prune type="containers" engines="{enginesList}" />
     {/if}
-    <button on:click="{() => toggleCreateContainer()}" class="pf-c-button pf-m-primary" type="button">
-      <span class="pf-c-button__icon pf-m-start">
+    <button on:click="{() => toggleCreateContainer()}" class="pd-button pd-primary" type="button">
+      <span class="pd-button-icon pd-start">
         <i class="fas fa-plus-circle" aria-hidden="true"></i>
       </span>
       Create a container
@@ -407,12 +407,12 @@ function errorCallback(container: ContainerInfoUI, errorMessage: string): void {
   <div slot="bottom-additional-actions" class="flex flex-row justify-start items-center w-full">
     {#if selectedItemsNumber > 0}
       <button
-        class="pf-c-button pf-m-primary"
+        class="pd-button pd-primary"
         on:click="{() => deleteSelectedContainers()}"
         aria-label="Delete selected containers and pods"
         title="Delete {selectedItemsNumber} selected items"
         type="button">
-        <span class="pf-c-button__icon pf-m-start">
+        <span class="pd-button-icon pd-start">
           {#if bulkDeleteInProgress}
             <div class="mr-4">
               <Spinner />
@@ -424,7 +424,7 @@ function errorCallback(container: ContainerInfoUI, errorMessage: string): void {
       </button>
       <div class="px-1"></div>
       <button
-        class="pf-c-button pf-m-primary"
+        class="pd-button pd-primary"
         on:click="{() => createPodFromContainers()}"
         title="Create Pod with {selectedItemsNumber} selected items"
         type="button">
@@ -657,9 +657,9 @@ function errorCallback(container: ContainerInfoUI, errorMessage: string): void {
         </ul>
 
         <div class="pt-5 grid grid-cols-2 gap-10 place-content-center w-full">
-          <button class="pf-c-button pf-m-primary" type="button" on:click="{() => fromDockerfile()}"
+          <button class="pd-button pd-primary" type="button" on:click="{() => fromDockerfile()}"
             >Containerfile or Dockerfile</button>
-          <button class="pf-c-button pf-m-secondary" type="button" on:click="{() => fromExistingImage()}"
+          <button class="pd-button pd-secondary" type="button" on:click="{() => fromExistingImage()}"
             >Existing image</button>
         </div>
       </div>

--- a/packages/renderer/src/lib/ImagesList.svelte
+++ b/packages/renderer/src/lib/ImagesList.svelte
@@ -233,20 +233,20 @@ function computeInterval(): number {
     {/if}
     <button
       on:click="{() => gotoPullImage()}"
-      class="pf-c-button pf-m-primary"
+      class="pd-button pd-primary"
       type="button"
       title="Pull Image From a Registry">
-      <span class="pf-c-button__icon pf-m-start">
+      <span class="pd-button-icon pd-start">
         <i class="fas fa-arrow-circle-down" aria-hidden="true"></i>
       </span>
       Pull an image
     </button>
     <button
       on:click="{() => gotoBuildImage()}"
-      class="pf-c-button pf-m-primary"
+      class="pd-button pd-primary"
       type="button"
       title="Build Image from Containerfile">
-      <span class="pf-c-button__icon pf-m-start">
+      <span class="pd-button-icon pd-start">
         <i class="fas fa-cube" aria-hidden="true"></i>
       </span>
       Build an image
@@ -256,11 +256,11 @@ function computeInterval(): number {
   <div slot="bottom-additional-actions" class="flex flex-row justify-start items-center w-full">
     {#if selectedItemsNumber > 0}
       <button
-        class="pf-c-button pf-m-primary"
+        class="pd-button pd-primary"
         on:click="{() => deleteSelectedImages()}"
         title="Delete {selectedItemsNumber} selected items"
         type="button">
-        <span class="pf-c-button__icon pf-m-start">
+        <span class="pd-button-icon">
           {#if bulkDeleteInProgress}
             <div class="mr-4">
               <Spinner />

--- a/packages/renderer/src/lib/dialogs/MessageBox.svelte
+++ b/packages/renderer/src/lib/dialogs/MessageBox.svelte
@@ -172,9 +172,9 @@ function handleKeydown(e: KeyboardEvent) {
               >Cancel</button>
           {:else}
             <button
-              class="pf-c-button transition ease-in-out delay-50 hover:cursor-pointer h-full rounded-md shadow hover:shadow-lg justify-center pb-1"
-              class:pf-m-primary="{defaultId === i}"
-              class:pf-m-secondary="{defaultId !== i}"
+              class="pd-button transition ease-in-out delay-50 shadow hover:shadow-lg"
+              class:pd-primary="{defaultId === i}"
+              class:pd-secondary="{defaultId !== i}"
               on:click="{() => clickButton(i)}">{buttons[i]}</button>
           {/if}
         {/each}

--- a/packages/renderer/src/lib/engine/Prune.svelte
+++ b/packages/renderer/src/lib/engine/Prune.svelte
@@ -72,12 +72,8 @@ async function prune(type: string) {
 }
 </script>
 
-<button
-  on:click="{() => openPruneDialog()}"
-  class="pf-c-button pf-m-primary"
-  type="button"
-  title="Remove unused images">
-  <span class="pf-c-button__icon pf-m-start">
+<button on:click="{() => openPruneDialog()}" class="pd-button pd-primary" type="button" title="Remove unused images">
+  <span class="pd-button-icon pd-start">
     <i class="fas fa-trash" aria-hidden="true"></i>
   </span>
   Prune {type}

--- a/packages/renderer/src/lib/image/BuildImageFromContainerfile.svelte
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfile.svelte
@@ -202,9 +202,9 @@ async function getContainerBuildContextDirectory() {
             <button
               on:click="{() => buildContainerImage()}"
               disabled="{hasInvalidFields}"
-              class="w-full pf-c-button pf-m-primary"
+              class="w-full pd-button pd-primary"
               type="button">
-              <span class="pf-c-button__icon pf-m-start">
+              <span class="pd-button__icon pd-start">
                 <i class="fas fa-cube" aria-hidden="true"></i>
               </span>
               Build
@@ -212,7 +212,7 @@ async function getContainerBuildContextDirectory() {
           {/if}
 
           {#if buildFinished}
-            <button on:click="{() => cleanupBuild()}" class="w-full pf-c-button pf-m-primary">Done</button>
+            <button on:click="{() => cleanupBuild()}" class="w-full pd-button pd-primary">Done</button>
           {/if}
         </div>
 

--- a/packages/renderer/src/lib/image/PullImage.svelte
+++ b/packages/renderer/src/lib/image/PullImage.svelte
@@ -118,8 +118,8 @@ function validateImageName(event): void {
   </svelte:fragment>
 
   <svelte:fragment slot="actions">
-    <button on:click="{() => gotoManageRegistries()}" class="pf-c-button pf-m-primary" type="button">
-      <span class="pf-c-button__icon pf-m-start">
+    <button on:click="{() => gotoManageRegistries()}" class="pd-button pd-primary" type="button">
+      <span class="pd-button-icon pd-start">
         <i class="fas fa-cog" aria-hidden="true"></i>
       </span>
       Manage registries
@@ -173,20 +173,19 @@ function validateImageName(event): void {
           <div class="w-full flex flex-col justify-end">
             {#if !pullFinished}
               <button
-                class="pf-c-button pf-m-primary"
+                class="pd-button pd-primary"
                 disabled="{!imageToPull || imageToPull.trim() === '' || pullInProgress}"
                 type="submit"
                 on:click="{() => pullImage()}">
                 {#if pullInProgress === true}
                   <Spinner />
                 {/if}
-                <span class="pf-c-button__icon pf-m-start">
+                <span class="pd-button-icon pd-start">
                   <i class="fas fa-arrow-circle-down" aria-hidden="true"></i>
                 </span>
                 Pull image</button>
             {:else}
-              <button class="pf-c-button pf-m-primary" type="button" on:click="{() => pullImageFinished()}">
-                Done</button>
+              <button class="pd-button pd-primary" type="button" on:click="{() => pullImageFinished()}"> Done</button>
             {/if}
             {#if pullError}
               <ErrorMessage error="{pullError}" />

--- a/packages/renderer/src/lib/image/PushImageModal.svelte
+++ b/packages/renderer/src/lib/image/PushImageModal.svelte
@@ -132,7 +132,7 @@ let pushLogsXtermDiv: HTMLDivElement;
 
       {#if !pushFinished}
         <button
-          class="pf-c-button pf-m-primary"
+          class="pd-button pd-primary"
           disabled="{pushInProgress}"
           type="button"
           on:click="{() => {
@@ -145,7 +145,7 @@ let pushLogsXtermDiv: HTMLDivElement;
           {/if}
           Push image</button>
       {:else}
-        <button class="pf-c-button pf-m-primary" type="button" on:click="{() => pushImageFinished()}"> Done</button>
+        <button class="pd-button pd-primary" type="button" on:click="{() => pushImageFinished()}"> Done</button>
       {/if}
 
       <div bind:this="{pushLogsXtermDiv}"></div>

--- a/packages/renderer/src/lib/image/RenameImageModal.svelte
+++ b/packages/renderer/src/lib/image/RenameImageModal.svelte
@@ -105,7 +105,7 @@ async function renameImage(imageName: string, imageTag: string) {
         {/if}
         <div class="w-full mt-6 grid grid-cols-4 gap-6">
           <button
-            class="pf-c-button pf-m-secondary col-start-3"
+            class="pd-button pd-secondary col-start-3"
             type="button"
             name="Cancel"
             on:click="{() => {
@@ -114,7 +114,7 @@ async function renameImage(imageName: string, imageTag: string) {
             Cancel
           </button>
           <button
-            class="pf-c-button pf-m-primary col-start-4"
+            class="pd-button pd-primary col-start-4"
             type="button"
             name="Save"
             disabled="{disableSave(imageName, imageTag)}"

--- a/packages/renderer/src/lib/image/RunContainerModal.svelte
+++ b/packages/renderer/src/lib/image/RunContainerModal.svelte
@@ -160,8 +160,8 @@ async function startContainer() {
                 {/each}
               </div>
 
-              <button on:click="{() => startContainer()}" class="w-full pf-c-button pf-m-primary">
-                <span class="pf-c-button__icon pf-m-start">
+              <button on:click="{() => startContainer()}" class="w-full pd-button pd-primary">
+                <span class="pd-button-icon pd-start">
                   <i class="fas fa-play" aria-hidden="true"></i>
                 </span>
                 Start Container</button>

--- a/packages/renderer/src/lib/image/RunImage.svelte
+++ b/packages/renderer/src/lib/image/RunImage.svelte
@@ -515,7 +515,7 @@ function checkContainerName(event: any) {
                 <button
                   class="pt-3 pb-2 outline-none text-sm rounded-sm bg-transparent placeholder-gray-700"
                   on:click="{addHostContainerPorts}">
-                  <span class="pf-c-button__icon pf-m-start">
+                  <span class="pd-button-icon pd-start">
                     <i class="fas fa-plus-circle"></i>
                   </span>
                   Add custom port mapping</button>
@@ -892,11 +892,8 @@ function checkContainerName(event: any) {
           </div>
 
           <div class="pt-2 border-zinc-600 border-t-2"></div>
-          <button
-            on:click="{() => startContainer()}"
-            class="w-full pf-c-button pf-m-primary pt-6"
-            disabled="{invalidFields}">
-            <span class="pf-c-button__icon pf-m-start">
+          <button on:click="{() => startContainer()}" class="w-full pd-button pd-primary" disabled="{invalidFields}">
+            <span class="pd-button-icon pd-start">
               <i class="fas fa-play" aria-hidden="true"></i>
             </span>
             Start Container</button>

--- a/packages/renderer/src/lib/kube/KubePlayButton.svelte
+++ b/packages/renderer/src/lib/kube/KubePlayButton.svelte
@@ -9,7 +9,7 @@ function runContainerYaml(): void {
 
 <button
   on:click="{() => runContainerYaml()}"
-  class="pf-c-button pf-m-primary"
+  class="pd-button pd-primary"
   type="button"
   title="Play pod/containers from kubernetes YAML file ">
   <div class="flex flex-row align-text-top justify-start items-center">

--- a/packages/renderer/src/lib/kube/KubePlayYAML.svelte
+++ b/packages/renderer/src/lib/kube/KubePlayYAML.svelte
@@ -277,7 +277,7 @@ async function getKubernetesfileLocation() {
           <button
             on:click="{() => playKubeFile()}"
             disabled="{hasInvalidFields || runStarted}"
-            class="w-full pf-c-button pf-m-primary"
+            class="w-full pd-button pd-primary"
             type="button">
             <div class="flex flex-row align-text-top justify-center items-center">
               {#if runStarted}
@@ -327,7 +327,7 @@ async function getKubernetesfileLocation() {
         {/if}
 
         {#if runFinished}
-          <button on:click="{() => goBackToHistory()}" class="pt-4 w-full pf-c-button pf-m-primary">Done</button>
+          <button on:click="{() => goBackToHistory()}" class="pt-4 w-full pd-button pd-primary">Done</button>
         {/if}
       </div>
     </div>

--- a/packages/renderer/src/lib/pod/PodCreateFromContainers.svelte
+++ b/packages/renderer/src/lib/pod/PodCreateFromContainers.svelte
@@ -294,7 +294,7 @@ function updatePortExposure(port: number, checked: boolean) {
 
         <div class="w-full grid justify-items-end">
           <div>
-            <button class="pf-c-button underline hover:text-gray-400" on:click="{() => router.goto('/containers')}">
+            <button class="pd-button underline hover:text-gray-400" on:click="{() => router.goto('/containers')}">
               Close
             </button>
             <button
@@ -303,7 +303,7 @@ function updatePortExposure(port: number, checked: boolean) {
                 createPodFromContainers();
               }}"
               aria-label="Create pod"
-              class="pf-c-button pf-m-primary"
+              class="pd-button pd-primary"
               type="button">
               <div class="flex flex-row">
                 {#if createInProgress}

--- a/packages/renderer/src/lib/pod/PodsList.svelte
+++ b/packages/renderer/src/lib/pod/PodsList.svelte
@@ -208,11 +208,11 @@ function errorCallback(pod: PodInfoUI, errorMessage: string): void {
   <div slot="bottom-additional-actions" class="flex flex-row justify-start items-center w-full">
     {#if selectedItemsNumber > 0}
       <button
-        class="pf-c-button pf-m-primary"
+        class="pd-button pd-primary"
         on:click="{() => deleteSelectedPods()}"
         title="Delete {selectedItemsNumber} selected items"
         type="button">
-        <span class="pf-c-button__icon pf-m-start">
+        <span class="pd-button-icon">
           {#if bulkDeleteInProgress}
             <div class="mr-4">
               <Spinner />

--- a/packages/renderer/src/lib/volume/VolumesList.svelte
+++ b/packages/renderer/src/lib/volume/VolumesList.svelte
@@ -198,11 +198,11 @@ function computeInterval(): number {
   <div slot="bottom-additional-actions" class="flex flex-row justify-start items-center w-full">
     {#if selectedItemsNumber > 0}
       <button
-        class="pf-c-button pf-m-primary"
+        class="pd-button pd-primary"
         on:click="{() => deleteSelectedVolumes()}"
         title="Delete {selectedItemsNumber} selected items"
         type="button">
-        <span class="pf-c-button__icon pf-m-start">
+        <span class="pd-button-icon">
           {#if bulkDeleteInProgress}
             <div class="mr-4">
               <Spinner />


### PR DESCRIPTION
### What does this PR do?

We currently use PatternFly classes like pf-c-button, pf-m-primary, pf-c-button__icon, and pf-m-start to style our buttons. Although they're powerful and we have a similar design, they tie us to PatternFly and its choices, and weren't really meant for desktop apps or dark mode. There are a few minor differences from our original design:
- slightly more button rounding
- in dark mode the hover should be lighter, not darker
- disabled buttons should be lighter

This change uses @layer to define our own CCS classes, then changes the lists, most form pages, and the messagebox to use it. This is just a start to use the buttons in some core areas; after this PR it is very easy work to search & replace all other instances in a batch or two.

Why our own CCS classes vs a component? For really lightweight styling this is preferable, and in this case makes it an easy search & replace to switch. I've used the pd- prefix to keep our own custom classes easily recognizable and searchable. See more here:
https://tailwindcss.com/docs/reusing-styles#extracting-classes-with-apply

### Screenshot/screencast of this PR

<img width="290" alt="Screenshot 2023-07-24 at 4 56 40 PM" src="https://github.com/containers/podman-desktop/assets/19958075/493c25b2-f41f-44ff-bc94-42b0453b117c">

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Just bring up the UI in these places and confirm minor design changes.