### PR TITLE
chore: button component

### DIFF
--- a/packages/renderer/src/lib/ContainerList.svelte
+++ b/packages/renderer/src/lib/ContainerList.svelte
@@ -19,7 +19,7 @@ import NoContainerEngineEmptyScreen from './image/NoContainerEngineEmptyScreen.s
 import moment from 'moment';
 import { get, type Unsubscriber } from 'svelte/store';
 import NavPage from './ui/NavPage.svelte';
-import { faChevronDown, faChevronRight } from '@fortawesome/free-solid-svg-icons';
+import { faChevronDown, faChevronRight, faPlusCircle, faTrash } from '@fortawesome/free-solid-svg-icons';
 import Fa from 'svelte-fa/src/fa.svelte';
 import ErrorMessage from './ui/ErrorMessage.svelte';
 import { podCreationHolder } from '../stores/creation-from-containers-store';
@@ -394,10 +394,7 @@ function errorCallback(container: ContainerInfoUI, errorMessage: string): void {
     {#if $containersInfos.length > 0}
       <Prune type="containers" engines="{enginesList}" />
     {/if}
-    <Button on:click="{() => toggleCreateContainer()}" type="primary">
-      <i slot="icon" class="fas fa-plus-circle" aria-hidden="true"></i>
-      Create a container
-    </Button>
+    <Button on:click="{() => toggleCreateContainer()}" icon="{faPlusCircle}">Create a container</Button>
     {#if providerPodmanConnections.length > 0}
       <KubePlayButton />
     {/if}
@@ -409,16 +406,12 @@ function errorCallback(container: ContainerInfoUI, errorMessage: string): void {
         aria-label="Delete selected containers and pods"
         title="Delete {selectedItemsNumber} selected items"
         bind:inProgress="{bulkDeleteInProgress}"
-        type="primary">
-        <i slot="icon" class="fas fa-trash" aria-hidden="true"></i>
-      </Button>
+        icon="{faTrash}" />
       <div class="px-1"></div>
       <Button
         on:click="{() => createPodFromContainers()}"
         title="Create Pod with {selectedItemsNumber} selected items"
-        type="primary">
-        <PodIcon slot="icon" size="1em" solid="{true}" />
-      </Button>
+        icon="{PodIcon}" />
       <span class="pl-2">On {selectedItemsNumber} selected items.</span>
     {/if}
   </div>

--- a/packages/renderer/src/lib/ContainerList.svelte
+++ b/packages/renderer/src/lib/ContainerList.svelte
@@ -32,10 +32,10 @@ import Checkbox from './ui/Checkbox.svelte';
 import type { PodInfo } from '../../../main/src/plugin/api/pod-info';
 import { PodUtils } from '../lib/pod/pod-utils';
 import ComposeActions from './compose/ComposeActions.svelte';
-import Spinner from './ui/Spinner.svelte';
 import { CONTAINER_LIST_VIEW } from './view/views';
 import type { ViewInfoUI } from '../../../main/src/plugin/api/view-info';
 import type { ContextUI } from './context/context';
+import Button from './ui/Button.svelte';
 
 const containerUtils = new ContainerUtils();
 let openChoiceModal = false;
@@ -394,42 +394,31 @@ function errorCallback(container: ContainerInfoUI, errorMessage: string): void {
     {#if $containersInfos.length > 0}
       <Prune type="containers" engines="{enginesList}" />
     {/if}
-    <button on:click="{() => toggleCreateContainer()}" class="pf-c-button pf-m-primary" type="button">
-      <span class="pf-c-button__icon pf-m-start">
-        <i class="fas fa-plus-circle" aria-hidden="true"></i>
-      </span>
+    <Button on:click="{() => toggleCreateContainer()}" type="primary">
+      <i slot="icon" class="fas fa-plus-circle" aria-hidden="true"></i>
       Create a container
-    </button>
+    </Button>
     {#if providerPodmanConnections.length > 0}
       <KubePlayButton />
     {/if}
   </div>
   <div slot="bottom-additional-actions" class="flex flex-row justify-start items-center w-full">
     {#if selectedItemsNumber > 0}
-      <button
-        class="pf-c-button pf-m-primary"
+      <Button
         on:click="{() => deleteSelectedContainers()}"
         aria-label="Delete selected containers and pods"
         title="Delete {selectedItemsNumber} selected items"
-        type="button">
-        <span class="pf-c-button__icon pf-m-start">
-          {#if bulkDeleteInProgress}
-            <div class="mr-4">
-              <Spinner />
-            </div>
-          {:else}
-            <i class="fas fa-trash" aria-hidden="true"></i>
-          {/if}
-        </span>
-      </button>
+        bind:inProgress="{bulkDeleteInProgress}"
+        type="primary">
+        <i slot="icon" class="fas fa-trash" aria-hidden="true"></i>
+      </Button>
       <div class="px-1"></div>
-      <button
-        class="pf-c-button pf-m-primary"
+      <Button
         on:click="{() => createPodFromContainers()}"
         title="Create Pod with {selectedItemsNumber} selected items"
-        type="button">
-        <PodIcon size="1em" solid="{true}" />
-      </button>
+        type="primary">
+        <PodIcon slot="icon" size="1em" solid="{true}" />
+      </Button>
       <span class="pl-2">On {selectedItemsNumber} selected items.</span>
     {/if}
   </div>
@@ -657,10 +646,8 @@ function errorCallback(container: ContainerInfoUI, errorMessage: string): void {
         </ul>
 
         <div class="pt-5 grid grid-cols-2 gap-10 place-content-center w-full">
-          <button class="pf-c-button pf-m-primary" type="button" on:click="{() => fromDockerfile()}"
-            >Containerfile or Dockerfile</button>
-          <button class="pf-c-button pf-m-secondary" type="button" on:click="{() => fromExistingImage()}"
-            >Existing image</button>
+          <Button type="primary" on:click="{() => fromDockerfile()}">Containerfile or Dockerfile</Button>
+          <Button type="secondary" on:click="{() => fromExistingImage()}">Existing image</Button>
         </div>
       </div>
     </div>

--- a/packages/renderer/src/lib/ImagesList.svelte
+++ b/packages/renderer/src/lib/ImagesList.svelte
@@ -24,7 +24,7 @@ import type { EngineInfoUI } from './engine/EngineInfoUI';
 import type { Menu } from '../../../main/src/plugin/menu-registry';
 import { MenuContext } from '../../../main/src/plugin/menu-registry';
 import Checkbox from './ui/Checkbox.svelte';
-import Spinner from './ui/Spinner.svelte';
+import Button from './ui/Button.svelte';
 
 let searchTerm = '';
 $: searchPattern.set(searchTerm);
@@ -231,45 +231,25 @@ function computeInterval(): number {
     {#if $imagesInfos.length > 0}
       <Prune type="images" engines="{enginesList}" />
     {/if}
-    <button
-      on:click="{() => gotoPullImage()}"
-      class="pf-c-button pf-m-primary"
-      type="button"
-      title="Pull Image From a Registry">
-      <span class="pf-c-button__icon pf-m-start">
-        <i class="fas fa-arrow-circle-down" aria-hidden="true"></i>
-      </span>
+    <Button on:click="{() => gotoPullImage()}" type="primary" title="Pull Image From a Registry">
+      <i slot="icon" class="fas fa-arrow-circle-down" aria-hidden="true"></i>
       Pull an image
-    </button>
-    <button
-      on:click="{() => gotoBuildImage()}"
-      class="pf-c-button pf-m-primary"
-      type="button"
-      title="Build Image from Containerfile">
-      <span class="pf-c-button__icon pf-m-start">
-        <i class="fas fa-cube" aria-hidden="true"></i>
-      </span>
+    </Button>
+    <Button on:click="{() => gotoBuildImage()}" title="Build Image from Containerfile" type="primary">
+      <i slot="icon" class="fas fa-cube" aria-hidden="true"></i>
       Build an image
-    </button>
+    </Button>
   </div>
 
   <div slot="bottom-additional-actions" class="flex flex-row justify-start items-center w-full">
     {#if selectedItemsNumber > 0}
-      <button
-        class="pf-c-button pf-m-primary"
+      <Button
         on:click="{() => deleteSelectedImages()}"
         title="Delete {selectedItemsNumber} selected items"
-        type="button">
-        <span class="pf-c-button__icon pf-m-start">
-          {#if bulkDeleteInProgress}
-            <div class="mr-4">
-              <Spinner />
-            </div>
-          {:else}
-            <i class="fas fa-trash" aria-hidden="true"></i>
-          {/if}
-        </span>
-      </button>
+        bind:inProgress="{bulkDeleteInProgress}"
+        type="primary">
+        <i slot="icon" class="fas fa-trash" aria-hidden="true"></i>
+      </Button>
       <span class="pl-2">On {selectedItemsNumber} selected items.</span>
     {/if}
   </div>

--- a/packages/renderer/src/lib/ImagesList.svelte
+++ b/packages/renderer/src/lib/ImagesList.svelte
@@ -25,6 +25,7 @@ import type { Menu } from '../../../main/src/plugin/menu-registry';
 import { MenuContext } from '../../../main/src/plugin/menu-registry';
 import Checkbox from './ui/Checkbox.svelte';
 import Button from './ui/Button.svelte';
+import { faArrowCircleDown, faCube, faTrash } from '@fortawesome/free-solid-svg-icons';
 
 let searchTerm = '';
 $: searchPattern.set(searchTerm);
@@ -231,12 +232,10 @@ function computeInterval(): number {
     {#if $imagesInfos.length > 0}
       <Prune type="images" engines="{enginesList}" />
     {/if}
-    <Button on:click="{() => gotoPullImage()}" type="primary" title="Pull Image From a Registry">
-      <i slot="icon" class="fas fa-arrow-circle-down" aria-hidden="true"></i>
+    <Button on:click="{() => gotoPullImage()}" title="Pull Image From a Registry" icon="{faArrowCircleDown}">
       Pull an image
     </Button>
-    <Button on:click="{() => gotoBuildImage()}" title="Build Image from Containerfile" type="primary">
-      <i slot="icon" class="fas fa-cube" aria-hidden="true"></i>
+    <Button on:click="{() => gotoBuildImage()}" title="Build Image from Containerfile" icon="{faCube}">
       Build an image
     </Button>
   </div>
@@ -247,9 +246,7 @@ function computeInterval(): number {
         on:click="{() => deleteSelectedImages()}"
         title="Delete {selectedItemsNumber} selected items"
         bind:inProgress="{bulkDeleteInProgress}"
-        type="primary">
-        <i slot="icon" class="fas fa-trash" aria-hidden="true"></i>
-      </Button>
+        icon="{faTrash}" />
       <span class="pl-2">On {selectedItemsNumber} selected items.</span>
     {/if}
   </div>

--- a/packages/renderer/src/lib/dialogs/MessageBox.svelte
+++ b/packages/renderer/src/lib/dialogs/MessageBox.svelte
@@ -4,6 +4,8 @@ import Fa from 'svelte-fa/src/fa.svelte';
 import { faCircleQuestion, faCircle } from '@fortawesome/free-regular-svg-icons';
 import { faCircleExclamation, faInfo, faTriangleExclamation } from '@fortawesome/free-solid-svg-icons';
 import type { MessageBoxOptions } from './messagebox-input';
+import Button from '../ui/Button.svelte';
+import type { ButtonType } from '../ui/Button';
 
 let currentId = 0;
 let title;
@@ -125,6 +127,14 @@ function handleKeydown(e: KeyboardEvent) {
     e.preventDefault();
   }
 }
+
+function getButtonType(b: boolean): ButtonType {
+  if (b) {
+    return 'primary';
+  } else {
+    return 'secondary';
+  }
+}
 </script>
 
 <svelte:window on:keydown="{handleKeydown}" />
@@ -168,14 +178,9 @@ function handleKeydown(e: KeyboardEvent) {
       <div class="px-5 py-5 mt-2 flex flex-row w-full justify-end space-x-5">
         {#each buttonOrder as i}
           {#if i === cancelId}
-            <button aria-label="Cancel" class="text-xs hover:underline" on:click="{() => clickButton(i)}"
-              >Cancel</button>
+            <Button aria-label="Cancel" on:click="{() => clickButton(i)}">Cancel</Button>
           {:else}
-            <button
-              class="pf-c-button transition ease-in-out delay-50 hover:cursor-pointer h-full rounded-md shadow hover:shadow-lg justify-center pb-1"
-              class:pf-m-primary="{defaultId === i}"
-              class:pf-m-secondary="{defaultId !== i}"
-              on:click="{() => clickButton(i)}">{buttons[i]}</button>
+            <Button type="{getButtonType(defaultId === i)}" on:click="{() => clickButton(i)}">{buttons[i]}</Button>
           {/if}
         {/each}
       </div>

--- a/packages/renderer/src/lib/dialogs/MessageBox.svelte
+++ b/packages/renderer/src/lib/dialogs/MessageBox.svelte
@@ -178,7 +178,7 @@ function getButtonType(b: boolean): ButtonType {
       <div class="px-5 py-5 mt-2 flex flex-row w-full justify-end space-x-5">
         {#each buttonOrder as i}
           {#if i === cancelId}
-            <Button aria-label="Cancel" on:click="{() => clickButton(i)}">Cancel</Button>
+            <Button type="link" aria-label="Cancel" on:click="{() => clickButton(i)}">Cancel</Button>
           {:else}
             <Button type="{getButtonType(defaultId === i)}" on:click="{() => clickButton(i)}">{buttons[i]}</Button>
           {/if}

--- a/packages/renderer/src/lib/engine/Prune.svelte
+++ b/packages/renderer/src/lib/engine/Prune.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import Button from '../ui/Button.svelte';
 import type { EngineInfoUI } from './EngineInfoUI';
 
 // Imported type for prune (containers, images, pods, volumes)
@@ -72,13 +73,7 @@ async function prune(type: string) {
 }
 </script>
 
-<button
-  on:click="{() => openPruneDialog()}"
-  class="pf-c-button pf-m-primary"
-  type="button"
-  title="Remove unused images">
-  <span class="pf-c-button__icon pf-m-start">
-    <i class="fas fa-trash" aria-hidden="true"></i>
-  </span>
+<Button on:click="{() => openPruneDialog()}" title="Remove unused images" type="primary">
+  <i slot="icon" class="fas fa-trash" aria-hidden="true"></i>
   Prune {type}
-</button>
+</Button>

--- a/packages/renderer/src/lib/engine/Prune.svelte
+++ b/packages/renderer/src/lib/engine/Prune.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { faTrash } from '@fortawesome/free-solid-svg-icons';
 import Button from '../ui/Button.svelte';
 import type { EngineInfoUI } from './EngineInfoUI';
 
@@ -73,7 +74,6 @@ async function prune(type: string) {
 }
 </script>
 
-<Button on:click="{() => openPruneDialog()}" title="Remove unused images" type="primary">
-  <i slot="icon" class="fas fa-trash" aria-hidden="true"></i>
+<Button on:click="{() => openPruneDialog()}" title="Remove unused images" icon="{faTrash}">
   Prune {type}
 </Button>

--- a/packages/renderer/src/lib/image/BuildImageFromContainerfile.svelte
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfile.svelte
@@ -21,6 +21,7 @@ import { type BuildImageInfo, buildImagesInfo } from '/@/stores/build-images';
 import TerminalWindow from '../ui/TerminalWindow.svelte';
 import type { Terminal } from 'xterm';
 import Button from '../ui/Button.svelte';
+import { faCube } from '@fortawesome/free-solid-svg-icons';
 
 let buildFinished = false;
 let containerImageName = 'my-custom-image';
@@ -204,14 +205,13 @@ async function getContainerBuildContextDirectory() {
               on:click="{() => buildContainerImage()}"
               disabled="{hasInvalidFields}"
               class="w-full"
-              type="primary">
-              <i slot="icon" class="fas fa-cube" aria-hidden="true"></i>
+              icon="{faCube}">
               Build
             </Button>
           {/if}
 
           {#if buildFinished}
-            <Button type="primary" on:click="{() => cleanupBuild()}" class="w-full">Done</Button>
+            <Button on:click="{() => cleanupBuild()}" class="w-full">Done</Button>
           {/if}
         </div>
 

--- a/packages/renderer/src/lib/image/BuildImageFromContainerfile.svelte
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfile.svelte
@@ -20,6 +20,7 @@ import {
 import { type BuildImageInfo, buildImagesInfo } from '/@/stores/build-images';
 import TerminalWindow from '../ui/TerminalWindow.svelte';
 import type { Terminal } from 'xterm';
+import Button from '../ui/Button.svelte';
 
 let buildFinished = false;
 let containerImageName = 'my-custom-image';
@@ -199,20 +200,18 @@ async function getContainerBuildContextDirectory() {
 
         <div class="w-full flex flex-row space-x-4">
           {#if !buildImageInfo?.buildRunning}
-            <button
+            <Button
               on:click="{() => buildContainerImage()}"
               disabled="{hasInvalidFields}"
-              class="w-full pf-c-button pf-m-primary"
-              type="button">
-              <span class="pf-c-button__icon pf-m-start">
-                <i class="fas fa-cube" aria-hidden="true"></i>
-              </span>
+              class="w-full"
+              type="primary">
+              <i slot="icon" class="fas fa-cube" aria-hidden="true"></i>
               Build
-            </button>
+            </Button>
           {/if}
 
           {#if buildFinished}
-            <button on:click="{() => cleanupBuild()}" class="w-full pf-c-button pf-m-primary">Done</button>
+            <Button type="primary" on:click="{() => cleanupBuild()}" class="w-full">Done</Button>
           {/if}
         </div>
 

--- a/packages/renderer/src/lib/image/PullImage.svelte
+++ b/packages/renderer/src/lib/image/PullImage.svelte
@@ -10,7 +10,7 @@ import FormPage from '../ui/FormPage.svelte';
 import ErrorMessage from '../ui/ErrorMessage.svelte';
 import TerminalWindow from '../ui/TerminalWindow.svelte';
 import type { Terminal } from 'xterm';
-import Spinner from '../ui/Spinner.svelte';
+import Button from '../ui/Button.svelte';
 
 let logsPull: Terminal;
 let pullError = '';
@@ -102,12 +102,15 @@ onMount(() => {
 });
 
 let imageNameInvalid = undefined;
+let imageNameIsInvalid = imageToPull === undefined || imageToPull.trim() === '';
 function validateImageName(event): void {
   imageToPull = event.target.value;
   if (imageToPull === undefined || imageToPull.trim() === '') {
+    imageNameIsInvalid = true;
     imageNameInvalid = 'Please enter a value';
   } else {
-    imageNameInvalid = '';
+    imageNameIsInvalid = false;
+    imageNameInvalid = undefined;
   }
 }
 </script>
@@ -118,12 +121,10 @@ function validateImageName(event): void {
   </svelte:fragment>
 
   <svelte:fragment slot="actions">
-    <button on:click="{() => gotoManageRegistries()}" class="pf-c-button pf-m-primary" type="button">
-      <span class="pf-c-button__icon pf-m-start">
-        <i class="fas fa-cog" aria-hidden="true"></i>
-      </span>
+    <Button on:click="{() => gotoManageRegistries()}" type="primary">
+      <i slot="icon" class="fas fa-cog" aria-hidden="true"></i>
       Manage registries
-    </button>
+    </Button>
   </svelte:fragment>
 
   <div slot="content" class="p-5 min-w-full h-fit">
@@ -172,21 +173,16 @@ function validateImageName(event): void {
         <footer>
           <div class="w-full flex flex-col justify-end">
             {#if !pullFinished}
-              <button
-                class="pf-c-button pf-m-primary"
-                disabled="{!imageToPull || imageToPull.trim() === '' || pullInProgress}"
-                type="submit"
-                on:click="{() => pullImage()}">
-                {#if pullInProgress === true}
-                  <Spinner />
-                {/if}
-                <span class="pf-c-button__icon pf-m-start">
-                  <i class="fas fa-arrow-circle-down" aria-hidden="true"></i>
-                </span>
-                Pull image</button>
+              <Button
+                type="primary"
+                bind:disabled="{imageNameIsInvalid}"
+                on:click="{() => pullImage()}"
+                bind:inProgress="{pullInProgress}">
+                <i slot="icon" class="fas fa-arrow-circle-down" aria-hidden="true"></i>
+                Pull image
+              </Button>
             {:else}
-              <button class="pf-c-button pf-m-primary" type="button" on:click="{() => pullImageFinished()}">
-                Done</button>
+              <Button type="primary" on:click="{() => pullImageFinished()}">Done</Button>
             {/if}
             {#if pullError}
               <ErrorMessage error="{pullError}" />

--- a/packages/renderer/src/lib/image/PullImage.svelte
+++ b/packages/renderer/src/lib/image/PullImage.svelte
@@ -11,6 +11,7 @@ import ErrorMessage from '../ui/ErrorMessage.svelte';
 import TerminalWindow from '../ui/TerminalWindow.svelte';
 import type { Terminal } from 'xterm';
 import Button from '../ui/Button.svelte';
+import { faArrowCircleDown, faCog } from '@fortawesome/free-solid-svg-icons';
 
 let logsPull: Terminal;
 let pullError = '';
@@ -121,10 +122,7 @@ function validateImageName(event): void {
   </svelte:fragment>
 
   <svelte:fragment slot="actions">
-    <Button on:click="{() => gotoManageRegistries()}" type="primary">
-      <i slot="icon" class="fas fa-cog" aria-hidden="true"></i>
-      Manage registries
-    </Button>
+    <Button on:click="{() => gotoManageRegistries()}" icon="{faCog}">Manage registries</Button>
   </svelte:fragment>
 
   <div slot="content" class="p-5 min-w-full h-fit">
@@ -174,15 +172,14 @@ function validateImageName(event): void {
           <div class="w-full flex flex-col justify-end">
             {#if !pullFinished}
               <Button
-                type="primary"
+                icon="{faArrowCircleDown}"
                 bind:disabled="{imageNameIsInvalid}"
                 on:click="{() => pullImage()}"
                 bind:inProgress="{pullInProgress}">
-                <i slot="icon" class="fas fa-arrow-circle-down" aria-hidden="true"></i>
                 Pull image
               </Button>
             {:else}
-              <Button type="primary" on:click="{() => pullImageFinished()}">Done</Button>
+              <Button on:click="{() => pullImageFinished()}">Done</Button>
             {/if}
             {#if pullError}
               <ErrorMessage error="{pullError}" />

--- a/packages/renderer/src/lib/image/PushImageModal.svelte
+++ b/packages/renderer/src/lib/image/PushImageModal.svelte
@@ -6,7 +6,7 @@ import { FitAddon } from 'xterm-addon-fit';
 import { TerminalSettings } from '../../../../main/src/plugin/terminal-settings';
 import Modal from '../dialogs/Modal.svelte';
 import type { ImageInfoUI } from './ImageInfoUI';
-import Spinner from '../ui/Spinner.svelte';
+import Button from '../ui/Button.svelte';
 
 export let closeCallback: () => void;
 export let imageInfoToPush: ImageInfoUI;
@@ -131,21 +131,17 @@ let pushLogsXtermDiv: HTMLDivElement;
       </div>
 
       {#if !pushFinished}
-        <button
-          class="pf-c-button pf-m-primary"
-          disabled="{pushInProgress}"
-          type="button"
+        <Button
+          type="primary"
           on:click="{() => {
             pushImage(selectedImageTag);
-          }}">
-          {#if pushInProgress === true}
-            <Spinner />
-          {:else}
-            <i class="fas fa-arrow-circle-up" aria-hidden="true"></i>
-          {/if}
-          Push image</button>
+          }}"
+          bind:inProgress="{pushInProgress}">
+          <i slot="icon" class="fas fa-arrow-circle-up" aria-hidden="true"></i>
+          Push image
+        </Button>
       {:else}
-        <button class="pf-c-button pf-m-primary" type="button" on:click="{() => pushImageFinished()}"> Done</button>
+        <Button type="primary" on:click="{() => pushImageFinished()}">Done</Button>
       {/if}
 
       <div bind:this="{pushLogsXtermDiv}"></div>

--- a/packages/renderer/src/lib/image/PushImageModal.svelte
+++ b/packages/renderer/src/lib/image/PushImageModal.svelte
@@ -7,6 +7,7 @@ import { TerminalSettings } from '../../../../main/src/plugin/terminal-settings'
 import Modal from '../dialogs/Modal.svelte';
 import type { ImageInfoUI } from './ImageInfoUI';
 import Button from '../ui/Button.svelte';
+import { faCircleArrowUp } from '@fortawesome/free-solid-svg-icons';
 
 export let closeCallback: () => void;
 export let imageInfoToPush: ImageInfoUI;
@@ -132,16 +133,15 @@ let pushLogsXtermDiv: HTMLDivElement;
 
       {#if !pushFinished}
         <Button
-          type="primary"
+          icon="{faCircleArrowUp}"
           on:click="{() => {
             pushImage(selectedImageTag);
           }}"
           bind:inProgress="{pushInProgress}">
-          <i slot="icon" class="fas fa-arrow-circle-up" aria-hidden="true"></i>
           Push image
         </Button>
       {:else}
-        <Button type="primary" on:click="{() => pushImageFinished()}">Done</Button>
+        <Button on:click="{() => pushImageFinished()}">Done</Button>
       {/if}
 
       <div bind:this="{pushLogsXtermDiv}"></div>

--- a/packages/renderer/src/lib/image/RenameImageModal.svelte
+++ b/packages/renderer/src/lib/image/RenameImageModal.svelte
@@ -107,6 +107,7 @@ async function renameImage(imageName: string, imageTag: string) {
         <div class="w-full mt-6 grid grid-cols-4 gap-6">
           <Button
             class="pcol-start-3"
+            type="link"
             on:click="{() => {
               closeCallback();
             }}">Cancel</Button>

--- a/packages/renderer/src/lib/image/RenameImageModal.svelte
+++ b/packages/renderer/src/lib/image/RenameImageModal.svelte
@@ -4,6 +4,7 @@ import { router } from 'tinro';
 import Modal from '../dialogs/Modal.svelte';
 import type { ImageInfoUI } from './ImageInfoUI';
 import ErrorMessage from '../ui/ErrorMessage.svelte';
+import Button from '../ui/Button.svelte';
 
 export let closeCallback: () => void;
 export let detailed = false;
@@ -104,25 +105,17 @@ async function renameImage(imageName: string, imageTag: string) {
           <ErrorMessage error="{imageTagErrorMessage}" />
         {/if}
         <div class="w-full mt-6 grid grid-cols-4 gap-6">
-          <button
-            class="pf-c-button pf-m-secondary col-start-3"
-            type="button"
-            name="Cancel"
+          <Button
+            class="pcol-start-3"
             on:click="{() => {
               closeCallback();
-            }}">
-            Cancel
-          </button>
-          <button
-            class="pf-c-button pf-m-primary col-start-4"
-            type="button"
-            name="Save"
+            }}">Cancel</Button>
+          <Button
+            class="col-start-4"
             disabled="{disableSave(imageName, imageTag)}"
             on:click="{() => {
               renameImage(imageName, imageTag);
-            }}">
-            Save
-          </button>
+            }}">Save</Button>
         </div>
       </div>
     </div>

--- a/packages/renderer/src/lib/image/RunContainerModal.svelte
+++ b/packages/renderer/src/lib/image/RunContainerModal.svelte
@@ -4,6 +4,7 @@ import type { ImageInspectInfo } from '../../../../main/src/plugin/api/image-ins
 import type { ContainerCreateOptions } from '../../../../main/src/plugin/api/container-info';
 import { onMount } from 'svelte';
 import Modal from '../dialogs/Modal.svelte';
+import Button from '../ui/Button.svelte';
 
 export let image: ImageInfoUI;
 export let closeCallback: () => void;
@@ -160,11 +161,10 @@ async function startContainer() {
                 {/each}
               </div>
 
-              <button on:click="{() => startContainer()}" class="w-full pf-c-button pf-m-primary">
-                <span class="pf-c-button__icon pf-m-start">
-                  <i class="fas fa-play" aria-hidden="true"></i>
-                </span>
-                Start Container</button>
+              <Button on:click="{() => startContainer()}" class="w-full">
+                <i slot="icon" class="fas fa-play" aria-hidden="true"></i>
+                Start Container
+              </Button>
             </div>
           </div>
         </div>

--- a/packages/renderer/src/lib/image/RunContainerModal.svelte
+++ b/packages/renderer/src/lib/image/RunContainerModal.svelte
@@ -5,6 +5,7 @@ import type { ContainerCreateOptions } from '../../../../main/src/plugin/api/con
 import { onMount } from 'svelte';
 import Modal from '../dialogs/Modal.svelte';
 import Button from '../ui/Button.svelte';
+import { faPlay } from '@fortawesome/free-solid-svg-icons';
 
 export let image: ImageInfoUI;
 export let closeCallback: () => void;
@@ -161,10 +162,7 @@ async function startContainer() {
                 {/each}
               </div>
 
-              <Button on:click="{() => startContainer()}" class="w-full">
-                <i slot="icon" class="fas fa-play" aria-hidden="true"></i>
-                Start Container
-              </Button>
+              <Button on:click="{() => startContainer()}" class="w-full" icon="{faPlay}">Start Container</Button>
             </div>
           </div>
         </div>

--- a/packages/renderer/src/lib/image/RunImage.svelte
+++ b/packages/renderer/src/lib/image/RunImage.svelte
@@ -17,6 +17,7 @@ import ErrorMessage from '../ui/ErrorMessage.svelte';
 import { splitSpacesHandlingDoubleQuotes } from '../string/string';
 import { array2String } from '/@/lib/string/string.js';
 import Tab from '../ui/Tab.svelte';
+import Button from '../ui/Button.svelte';
 
 let image: ImageInfoUI;
 
@@ -512,13 +513,10 @@ function checkContainerName(event: any) {
                   </div>
                 {/each}
 
-                <button
-                  class="pt-3 pb-2 outline-none text-sm rounded-sm bg-transparent placeholder-gray-700"
-                  on:click="{addHostContainerPorts}">
-                  <span class="pf-c-button__icon pf-m-start">
-                    <i class="fas fa-plus-circle"></i>
-                  </span>
-                  Add custom port mapping</button>
+                <Button class="pt-3 pb-2" on:click="{addHostContainerPorts}">
+                  <i slot="icon" class="fas fa-plus-circle"></i>
+                  Add custom port mapping
+                </Button>
                 <!-- Display the list of existing hostContainerPortMappings -->
                 {#each hostContainerPortMappings as hostContainerPortMapping, index}
                   <div class="flex flex-row justify-center items-center w-full py-1">
@@ -892,14 +890,10 @@ function checkContainerName(event: any) {
           </div>
 
           <div class="pt-2 border-zinc-600 border-t-2"></div>
-          <button
-            on:click="{() => startContainer()}"
-            class="w-full pf-c-button pf-m-primary pt-6"
-            disabled="{invalidFields}">
-            <span class="pf-c-button__icon pf-m-start">
-              <i class="fas fa-play" aria-hidden="true"></i>
-            </span>
-            Start Container</button>
+          <Button on:click="{() => startContainer()}" class="w-full" type="primary" bind:disabled="{invalidFields}">
+            <i slot="icon" class="fas fa-play" aria-hidden="true"></i>
+            Start Container
+          </Button>
           <ErrorMessage class="py-2 text-sm" error="{createError}" />
         </div>
       </div>

--- a/packages/renderer/src/lib/image/RunImage.svelte
+++ b/packages/renderer/src/lib/image/RunImage.svelte
@@ -5,7 +5,7 @@ import type { ContainerCreateOptions, HostConfig } from '../../../../main/src/pl
 import type { ImageInspectInfo } from '../../../../main/src/plugin/api/image-inspect-info';
 import FormPage from '../ui/FormPage.svelte';
 import type { ImageInfoUI } from './ImageInfoUI';
-import { faFolderOpen, faMinusCircle, faPlusCircle } from '@fortawesome/free-solid-svg-icons';
+import { faFolderOpen, faMinusCircle, faPlay, faPlusCircle } from '@fortawesome/free-solid-svg-icons';
 import Fa from 'svelte-fa/src/fa.svelte';
 import { router } from 'tinro';
 import Route from '../../Route.svelte';
@@ -513,8 +513,7 @@ function checkContainerName(event: any) {
                   </div>
                 {/each}
 
-                <Button class="pt-3 pb-2" on:click="{addHostContainerPorts}">
-                  <i slot="icon" class="fas fa-plus-circle"></i>
+                <Button class="pt-3 pb-2" on:click="{addHostContainerPorts}" icon="{faPlusCircle}" type="link">
                   Add custom port mapping
                 </Button>
                 <!-- Display the list of existing hostContainerPortMappings -->
@@ -890,8 +889,7 @@ function checkContainerName(event: any) {
           </div>
 
           <div class="pt-2 border-zinc-600 border-t-2"></div>
-          <Button on:click="{() => startContainer()}" class="w-full" type="primary" bind:disabled="{invalidFields}">
-            <i slot="icon" class="fas fa-play" aria-hidden="true"></i>
+          <Button on:click="{() => startContainer()}" class="w-full" icon="{faPlay}" bind:disabled="{invalidFields}">
             Start Container
           </Button>
           <ErrorMessage class="py-2 text-sm" error="{createError}" />

--- a/packages/renderer/src/lib/kube/KubePlayButton.svelte
+++ b/packages/renderer/src/lib/kube/KubePlayButton.svelte
@@ -1,19 +1,14 @@
 <script lang="ts">
 import { router } from 'tinro';
 import KubePlayIcon from './KubePlayIcon.svelte';
+import Button from '../ui/Button.svelte';
 
 function runContainerYaml(): void {
   router.goto('/kube/play');
 }
 </script>
 
-<button
-  on:click="{() => runContainerYaml()}"
-  class="pf-c-button pf-m-primary"
-  type="button"
-  title="Play pod/containers from kubernetes YAML file ">
-  <div class="flex flex-row align-text-top justify-start items-center">
-    <KubePlayIcon />
-    Play Kubernetes YAML
-  </div>
-</button>
+<Button on:click="{() => runContainerYaml()}" title="Play pod/containers from kubernetes YAML file" type="primary">
+  <KubePlayIcon slot="icon" />
+  Play Kubernetes YAML
+</Button>

--- a/packages/renderer/src/lib/kube/KubePlayButton.svelte
+++ b/packages/renderer/src/lib/kube/KubePlayButton.svelte
@@ -8,7 +8,9 @@ function runContainerYaml(): void {
 }
 </script>
 
-<Button on:click="{() => runContainerYaml()}" title="Play pod/containers from kubernetes YAML file" type="primary">
-  <KubePlayIcon slot="icon" />
+<Button
+  on:click="{() => runContainerYaml()}"
+  title="Play pod/containers from kubernetes YAML file"
+  icon="{KubePlayIcon}">
   Play Kubernetes YAML
 </Button>

--- a/packages/renderer/src/lib/kube/KubePlayIcon.svelte
+++ b/packages/renderer/src/lib/kube/KubePlayIcon.svelte
@@ -2,13 +2,7 @@
 export let size = '13px';
 </script>
 
-<svg
-  class="mr-1"
-  width="{size}"
-  height="{size}"
-  version="1.1"
-  viewBox="0 0 18.035 17.5"
-  xmlns="http://www.w3.org/2000/svg">
+<svg width="{size}" height="{size}" version="1.1" viewBox="0 0 18.035 17.5" xmlns="http://www.w3.org/2000/svg">
   <g transform="translate(-.99263 -1.1742)">
     <g
       transform="matrix(1.0149 0 0 1.0149 16.902 -2.6987)"

--- a/packages/renderer/src/lib/kube/KubePlayYAML.svelte
+++ b/packages/renderer/src/lib/kube/KubePlayYAML.svelte
@@ -14,7 +14,7 @@ import WarningMessage from '../ui/WarningMessage.svelte';
 import type { V1NamespaceList } from '@kubernetes/client-node/dist/api';
 import { faCircleCheck } from '@fortawesome/free-solid-svg-icons';
 import Fa from 'svelte-fa/src/fa.svelte';
-import Spinner from '../ui/Spinner.svelte';
+import Button from '../ui/Button.svelte';
 
 let runStarted = false;
 let runFinished = false;
@@ -274,23 +274,15 @@ async function getKubernetesfileLocation() {
         </div>
 
         {#if !runFinished}
-          <button
+          <Button
             on:click="{() => playKubeFile()}"
             disabled="{hasInvalidFields || runStarted}"
-            class="w-full pf-c-button pf-m-primary"
-            type="button">
-            <div class="flex flex-row align-text-top justify-center items-center">
-              {#if runStarted}
-                <div class="mr-4">
-                  <Spinner />
-                </div>
-              {:else}
-                <KubePlayIcon />
-              {/if}
-
-              Play
-            </div>
-          </button>
+            class="w-full"
+            type="primary"
+            bind:inProgress="{runStarted}">
+            <KubePlayIcon slot="icon" />
+            Play
+          </Button>
         {/if}
         {#if runStarted}
           <div class="text-gray-700 text-sm">
@@ -327,7 +319,7 @@ async function getKubernetesfileLocation() {
         {/if}
 
         {#if runFinished}
-          <button on:click="{() => goBackToHistory()}" class="pt-4 w-full pf-c-button pf-m-primary">Done</button>
+          <Button on:click="{() => goBackToHistory()}" class="pt-4 w-full" title="Done" type="primary" />
         {/if}
       </div>
     </div>

--- a/packages/renderer/src/lib/kube/KubePlayYAML.svelte
+++ b/packages/renderer/src/lib/kube/KubePlayYAML.svelte
@@ -278,9 +278,8 @@ async function getKubernetesfileLocation() {
             on:click="{() => playKubeFile()}"
             disabled="{hasInvalidFields || runStarted}"
             class="w-full"
-            type="primary"
-            bind:inProgress="{runStarted}">
-            <KubePlayIcon slot="icon" />
+            bind:inProgress="{runStarted}"
+            icon="{KubePlayIcon}">
             Play
           </Button>
         {/if}

--- a/packages/renderer/src/lib/pod/PodCreateFromContainers.svelte
+++ b/packages/renderer/src/lib/pod/PodCreateFromContainers.svelte
@@ -294,17 +294,16 @@ function updatePortExposure(port: number, checked: boolean) {
 
         <div class="w-full grid justify-items-end">
           <div>
-            <Button title="Close" on:click="{() => router.goto('/containers')}" />
+            <Button type="link" on:click="{() => router.goto('/containers')}">Close</Button>
             <Button
-              title="Create Pod"
-              type="primary"
+              icon="{PodIcon}"
               bind:disabled="{createInProgress}"
               on:click="{() => {
                 createPodFromContainers();
               }}"
               bind:inProgress="{createInProgress}"
               aria-label="Create pod">
-              <PodIcon slot="icon" size="1em" solid="{true}" />
+              Create Pod
             </Button>
           </div>
         </div>

--- a/packages/renderer/src/lib/pod/PodCreateFromContainers.svelte
+++ b/packages/renderer/src/lib/pod/PodCreateFromContainers.svelte
@@ -12,7 +12,7 @@ import ContainerIcon from '../images/ContainerIcon.svelte';
 import { faTriangleExclamation } from '@fortawesome/free-solid-svg-icons';
 import Fa from 'svelte-fa/src/fa.svelte';
 import PodIcon from '../images/PodIcon.svelte';
-import Spinner from '../ui/Spinner.svelte';
+import Button from '../ui/Button.svelte';
 
 let podCreation: PodCreation;
 let createInProgress = false;
@@ -294,28 +294,18 @@ function updatePortExposure(port: number, checked: boolean) {
 
         <div class="w-full grid justify-items-end">
           <div>
-            <button class="pf-c-button underline hover:text-gray-400" on:click="{() => router.goto('/containers')}">
-              Close
-            </button>
-            <button
-              disabled="{createInProgress}"
+            <Button title="Close" on:click="{() => router.goto('/containers')}" />
+            <Button
+              title="Create Pod"
+              type="primary"
+              bind:disabled="{createInProgress}"
               on:click="{() => {
                 createPodFromContainers();
               }}"
-              aria-label="Create pod"
-              class="pf-c-button pf-m-primary"
-              type="button">
-              <div class="flex flex-row">
-                {#if createInProgress}
-                  <div class="mr-12">
-                    <Spinner />
-                  </div>
-                {:else}
-                  <PodIcon class="mr-2" size="1em" solid="{true}" />
-                {/if}
-                Create Pod
-              </div>
-            </button>
+              bind:inProgress="{createInProgress}"
+              aria-label="Create pod">
+              <PodIcon slot="icon" size="1em" solid="{true}" />
+            </Button>
           </div>
         </div>
 

--- a/packages/renderer/src/lib/pod/PodsList.svelte
+++ b/packages/renderer/src/lib/pod/PodsList.svelte
@@ -21,7 +21,7 @@ import Prune from '../engine/Prune.svelte';
 import type { EngineInfoUI } from '../engine/EngineInfoUI';
 import ErrorMessage from '../ui/ErrorMessage.svelte';
 import Checkbox from '../ui/Checkbox.svelte';
-import Spinner from '../ui/Spinner.svelte';
+import Button from '../ui/Button.svelte';
 
 let searchTerm = '';
 $: searchPattern.set(searchTerm);
@@ -207,21 +207,13 @@ function errorCallback(pod: PodInfoUI, errorMessage: string): void {
 
   <div slot="bottom-additional-actions" class="flex flex-row justify-start items-center w-full">
     {#if selectedItemsNumber > 0}
-      <button
-        class="pf-c-button pf-m-primary"
+      <Button
         on:click="{() => deleteSelectedPods()}"
         title="Delete {selectedItemsNumber} selected items"
-        type="button">
-        <span class="pf-c-button__icon pf-m-start">
-          {#if bulkDeleteInProgress}
-            <div class="mr-4">
-              <Spinner />
-            </div>
-          {:else}
-            <i class="fas fa-trash" aria-hidden="true"></i>
-          {/if}
-        </span>
-      </button>
+        inProgress="{bulkDeleteInProgress}"
+        type="primary">
+        <i slot="icon" class="fas fa-trash" aria-hidden="true"></i>
+      </Button>
       <span class="pl-2">On {selectedItemsNumber} selected items.</span>
     {/if}
   </div>

--- a/packages/renderer/src/lib/pod/PodsList.svelte
+++ b/packages/renderer/src/lib/pod/PodsList.svelte
@@ -22,6 +22,7 @@ import type { EngineInfoUI } from '../engine/EngineInfoUI';
 import ErrorMessage from '../ui/ErrorMessage.svelte';
 import Checkbox from '../ui/Checkbox.svelte';
 import Button from '../ui/Button.svelte';
+import { faTrash } from '@fortawesome/free-solid-svg-icons';
 
 let searchTerm = '';
 $: searchPattern.set(searchTerm);
@@ -211,9 +212,7 @@ function errorCallback(pod: PodInfoUI, errorMessage: string): void {
         on:click="{() => deleteSelectedPods()}"
         title="Delete {selectedItemsNumber} selected items"
         inProgress="{bulkDeleteInProgress}"
-        type="primary">
-        <i slot="icon" class="fas fa-trash" aria-hidden="true"></i>
-      </Button>
+        icon="{faTrash}" />
       <span class="pl-2">On {selectedItemsNumber} selected items.</span>
     {/if}
   </div>

--- a/packages/renderer/src/lib/ui/Button.spec.ts
+++ b/packages/renderer/src/lib/ui/Button.spec.ts
@@ -1,0 +1,51 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import '@testing-library/jest-dom';
+import { test, expect } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import Button from './Button.svelte';
+
+test('Check primary button styling', async () => {
+  render(Button, { type: 'primary' });
+
+  // check for one element of the styling
+  const button = screen.getByRole('button');
+  expect(button).toBeInTheDocument();
+  expect(button).toHaveClass('bg-purple-500');
+});
+
+test('Check secondary button styling', async () => {
+  render(Button, { type: 'secondary' });
+
+  // check for one element of the styling
+  const button = screen.getByRole('button');
+  expect(button).toBeInTheDocument();
+  expect(button).toHaveClass('border-gray-200');
+});
+
+test('Check default button styling', async () => {
+  render(Button);
+
+  // check for one element of the styling
+  const button = screen.getByRole('button');
+  expect(button).toBeInTheDocument();
+  expect(button).toHaveClass('hover:underline');
+});

--- a/packages/renderer/src/lib/ui/Button.spec.ts
+++ b/packages/renderer/src/lib/ui/Button.spec.ts
@@ -32,6 +32,15 @@ test('Check primary button styling', async () => {
   expect(button).toHaveClass('bg-purple-500');
 });
 
+test('Check primary button is the default', async () => {
+  render(Button);
+
+  // check for one element of the styling
+  const button = screen.getByRole('button');
+  expect(button).toBeInTheDocument();
+  expect(button).toHaveClass('bg-purple-500');
+});
+
 test('Check secondary button styling', async () => {
   render(Button, { type: 'secondary' });
 
@@ -42,7 +51,7 @@ test('Check secondary button styling', async () => {
 });
 
 test('Check default button styling', async () => {
-  render(Button);
+  render(Button, { type: 'link' });
 
   // check for one element of the styling
   const button = screen.getByRole('button');

--- a/packages/renderer/src/lib/ui/Button.svelte
+++ b/packages/renderer/src/lib/ui/Button.svelte
@@ -1,0 +1,52 @@
+<script lang="ts">
+import type { ButtonType } from './Button';
+import Spinner from './Spinner.svelte';
+
+export let title: string = undefined;
+export let inProgress = false;
+export let disabled = false;
+export let type: ButtonType = undefined;
+
+let classes = '';
+$: {
+  if (disabled || inProgress) {
+    if (type === 'primary' || type === 'secondary') {
+      classes = 'bg-charcoal-50';
+    } else {
+      classes = 'text-charcoal-50 no-underline';
+    }
+  } else {
+    if (type === 'primary') {
+      classes = 'bg-purple-500 border-none hover:bg-purple-400';
+    } else if (type === 'secondary') {
+      classes = 'border-[1px] border-gray-200 hover:border-purple-500 hover:text-purple-500';
+    } else {
+      classes = 'border-none hover:underline';
+    }
+  }
+}
+</script>
+
+<button
+  type="button"
+  class="relative px-4 py-[6px] rounded-[4px] box-border text-white text-[13px] whitespace-nowrap select-none {classes} {$$props.class ||
+    ''}"
+  title="{title}"
+  aria-label="{$$props['aria-label']}"
+  on:click
+  disabled="{disabled || inProgress}">
+  {#if $$slots.icon}
+    <div class="flex flex-row p-0 m-0 bg-transparent justify-center space-x-[4px]">
+      {#if inProgress}
+        <Spinner size="sm" style="position: relative" />
+      {:else}
+        <slot name="icon" />
+      {/if}
+      {#if $$slots.default}
+        <span><slot /></span>
+      {/if}
+    </div>
+  {:else}
+    <slot />
+  {/if}
+</button>

--- a/packages/renderer/src/lib/ui/Button.svelte
+++ b/packages/renderer/src/lib/ui/Button.svelte
@@ -1,11 +1,26 @@
 <script lang="ts">
 import type { ButtonType } from './Button';
+import { onMount } from 'svelte';
+import Fa from 'svelte-fa/src/fa.svelte';
 import Spinner from './Spinner.svelte';
 
 export let title: string = undefined;
 export let inProgress = false;
 export let disabled = false;
-export let type: ButtonType = undefined;
+export let type: ButtonType = 'primary';
+export let icon: any = undefined;
+
+let iconType: string = undefined;
+
+onMount(() => {
+  if (icon?.prefix === 'fas') {
+    iconType = 'fa';
+  } else if (icon?.name.includes('PodIcon')) {
+    iconType = 'pd';
+  } else {
+    iconType = 'unknown';
+  }
+});
 
 let classes = '';
 $: {
@@ -35,12 +50,16 @@ $: {
   aria-label="{$$props['aria-label']}"
   on:click
   disabled="{disabled || inProgress}">
-  {#if $$slots.icon}
+  {#if icon}
     <div class="flex flex-row p-0 m-0 bg-transparent justify-center space-x-[4px]">
       {#if inProgress}
-        <Spinner size="sm" style="position: relative" />
-      {:else}
-        <slot name="icon" />
+        <Spinner size="sm" relative="{true}" />
+      {:else if iconType === 'fa'}
+        <Fa icon="{icon}" />
+      {:else if iconType === 'pd'}
+        <svelte:component this="{icon}" size="1em" solid="{true}" />
+      {:else if iconType === 'unknown'}
+        <svelte:component this="{icon}" />
       {/if}
       {#if $$slots.default}
         <span><slot /></span>

--- a/packages/renderer/src/lib/ui/Button.ts
+++ b/packages/renderer/src/lib/ui/Button.ts
@@ -1,0 +1,25 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/**
+ * Type of button:
+ *  primary   - a main action
+ *  secondary - a secondary action
+ *  undefined - close, cancel, or other non-default button
+ */
+export type ButtonType = 'primary' | 'secondary' | undefined;

--- a/packages/renderer/src/lib/ui/Button.ts
+++ b/packages/renderer/src/lib/ui/Button.ts
@@ -18,8 +18,8 @@
 
 /**
  * Type of button:
- *  primary   - a main action
+ *  primary   - a main action (the default)
  *  secondary - a secondary action
- *  undefined - close, cancel, or other non-default button
+ *  link      - close, cancel, or other non-default button
  */
-export type ButtonType = 'primary' | 'secondary' | undefined;
+export type ButtonType = 'primary' | 'secondary' | 'link';

--- a/packages/renderer/src/lib/ui/ButtonSpec.spec.ts
+++ b/packages/renderer/src/lib/ui/ButtonSpec.spec.ts
@@ -35,7 +35,7 @@ test('Check button text', async () => {
 test('Check icon', async () => {
   render(ButtonSpec);
 
-  // check icon matches
-  const icon = screen.getByLabelText('icon');
+  // check icon exists
+  const icon = screen.getByRole('img', { hidden: true });
   expect(icon).toBeInTheDocument();
 });

--- a/packages/renderer/src/lib/ui/ButtonSpec.spec.ts
+++ b/packages/renderer/src/lib/ui/ButtonSpec.spec.ts
@@ -1,0 +1,41 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import '@testing-library/jest-dom';
+import { test, expect } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import ButtonSpec from './ButtonSpec.svelte';
+
+test('Check button text', async () => {
+  render(ButtonSpec);
+
+  // check text matches
+  const button = screen.getByRole('button');
+  expect(button).toBeInTheDocument();
+  expect(button).toHaveTextContent('Click me');
+});
+
+test('Check icon', async () => {
+  render(ButtonSpec);
+
+  // check icon matches
+  const icon = screen.getByLabelText('icon');
+  expect(icon).toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/ui/ButtonSpec.svelte
+++ b/packages/renderer/src/lib/ui/ButtonSpec.svelte
@@ -1,8 +1,6 @@
 <script lang="ts">
+import { faLightbulb } from '@fortawesome/free-solid-svg-icons';
 import Button from './Button.svelte';
 </script>
 
-<Button title="Tooltip">
-  <i slot="icon" class="fas fa-lightbulb" aria-label="icon"></i>
-  Click me
-</Button>
+<Button title="Tooltip" icon="{faLightbulb}">Click me</Button>

--- a/packages/renderer/src/lib/ui/ButtonSpec.svelte
+++ b/packages/renderer/src/lib/ui/ButtonSpec.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+import Button from './Button.svelte';
+</script>
+
+<Button title="Tooltip">
+  <i slot="icon" class="fas fa-lightbulb" aria-label="icon"></i>
+  Click me
+</Button>

--- a/packages/renderer/src/lib/ui/Spinner.svelte
+++ b/packages/renderer/src/lib/ui/Spinner.svelte
@@ -2,7 +2,7 @@
 export let size = 'md';
 </script>
 
-<i class="pf-c-button__progress">
+<i class="pf-c-button__progress {$$props.class || ''}" style="{$$props.style || ''}">
   <span class="pf-c-spinner pf-m-{size}" role="progressbar">
     <span class="pf-c-spinner__clipper"></span>
     <span class="pf-c-spinner__lead-ball"></span>

--- a/packages/renderer/src/lib/ui/Spinner.svelte
+++ b/packages/renderer/src/lib/ui/Spinner.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
 export let size = 'md';
+export let relative = false;
 </script>
 
-<i class="pf-c-button__progress {$$props.class || ''}" style="{$$props.style || ''}">
+<i class="pf-c-button__progress" style="{relative ? 'position: relative' : ''}">
   <span class="pf-c-spinner pf-m-{size}" role="progressbar">
     <span class="pf-c-spinner__clipper"></span>
     <span class="pf-c-spinner__lead-ball"></span>

--- a/packages/renderer/src/lib/volume/VolumesList.svelte
+++ b/packages/renderer/src/lib/volume/VolumesList.svelte
@@ -19,6 +19,7 @@ import type { EngineInfoUI } from '../engine/EngineInfoUI';
 import EmptyScreen from '../ui/EmptyScreen.svelte';
 import Checkbox from '../ui/Checkbox.svelte';
 import Button from '../ui/Button.svelte';
+import { faTrash } from '@fortawesome/free-solid-svg-icons';
 
 let searchTerm = '';
 $: searchPattern.set(searchTerm);
@@ -201,9 +202,7 @@ function computeInterval(): number {
         on:click="{() => deleteSelectedVolumes()}"
         title="Delete {selectedItemsNumber} selected items"
         inProgress="{bulkDeleteInProgress}"
-        type="primary">
-        <i slot="icon" class="fas fa-trash" aria-hidden="true"></i>
-      </Button>
+        icon="{faTrash}" />
       <span class="pl-2">On {selectedItemsNumber} selected items.</span>
     {/if}
   </div>

--- a/packages/renderer/src/lib/volume/VolumesList.svelte
+++ b/packages/renderer/src/lib/volume/VolumesList.svelte
@@ -18,7 +18,7 @@ import moment from 'moment';
 import type { EngineInfoUI } from '../engine/EngineInfoUI';
 import EmptyScreen from '../ui/EmptyScreen.svelte';
 import Checkbox from '../ui/Checkbox.svelte';
-import Spinner from '../ui/Spinner.svelte';
+import Button from '../ui/Button.svelte';
 
 let searchTerm = '';
 $: searchPattern.set(searchTerm);
@@ -197,21 +197,13 @@ function computeInterval(): number {
 
   <div slot="bottom-additional-actions" class="flex flex-row justify-start items-center w-full">
     {#if selectedItemsNumber > 0}
-      <button
-        class="pf-c-button pf-m-primary"
+      <Button
         on:click="{() => deleteSelectedVolumes()}"
         title="Delete {selectedItemsNumber} selected items"
-        type="button">
-        <span class="pf-c-button__icon pf-m-start">
-          {#if bulkDeleteInProgress}
-            <div class="mr-4">
-              <Spinner />
-            </div>
-          {:else}
-            <i class="fas fa-trash" aria-hidden="true"></i>
-          {/if}
-        </span>
-      </button>
+        inProgress="{bulkDeleteInProgress}"
+        type="primary">
+        <i slot="icon" class="fas fa-trash" aria-hidden="true"></i>
+      </Button>
       <span class="pl-2">On {selectedItemsNumber} selected items.</span>
     {/if}
   </div>


### PR DESCRIPTION
### What does this PR do?

We currently use PatternFly classes like pf-c-button, pf-m-primary, pf-c-button__icon, and pf-m-start to style our buttons. Although they're powerful and we have a similar design, they tie us to PatternFly and its choices, and weren't really meant for desktop apps or dark mode. There are a few minor differences from our original design:
- slightly more button rounding
- in dark mode the hover should be lighter, not darker
- disabled buttons should be lighter
- spinner should replace button icon when there's progress
and this is repeated styles that aren't in a component.

This change adds a new Button component with support for styling, icons, and an inProgress spinner. It adds tests, and switches the buttons for the main lists, most form pages, and the MessageBox.

This is just a start to use the buttons in some core areas; after this PR there would need to be one or two more to replace all other instances.

### Screenshot/screencast of this PR

<img width="513" alt="Screenshot 2023-07-25 at 3 25 00 PM" src="https://github.com/containers/podman-desktop/assets/19958075/8a92ac23-19ce-4e61-a84e-a5e07910b5f7">

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Go to all of these places and confirm that the buttons behave correctly, including disabled and in-progress states where applicable.