### PR TITLE
fix: troubleshooting still waiting after failure

### DIFF
--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingContainerEngineGrabContainers.spec.ts
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingContainerEngineGrabContainers.spec.ts
@@ -72,7 +72,7 @@ test('Check containers button is available and get error', async () => {
   // check that we have the ping result
   const pingResult = screen.getByRole('status', { name: '' });
   expect(pingResult).toBeInTheDocument();
-  expect(pingResult).toHaveTextContent('...Waiting for response...');
+  expect(pingResult).toHaveTextContent('Failed');
 
   // and no error
   const errorMesssage = screen.getByRole('alert', { name: 'Error Message Content' });

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingContainerEngineGrabContainers.svelte
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingContainerEngineGrabContainers.svelte
@@ -16,10 +16,10 @@ async function grabContainers() {
   listContainersResult = '...Waiting for response...';
   try {
     const result = await window.listContainersFromEngine(providerContainerEngine);
-
     listContainersResult = `Responded: ${result.length} containers`;
   } catch (e) {
     listError = e;
+    listContainersResult = 'Failed';
   } finally {
     listInProgress = false;
   }

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingContainerEnginePing.spec.ts
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingContainerEnginePing.spec.ts
@@ -72,7 +72,7 @@ test('Check ping button is available and get error', async () => {
   // check that we have the ping result
   const pingResult = screen.getByRole('status', { name: '' });
   expect(pingResult).toBeInTheDocument();
-  expect(pingResult).toHaveTextContent('...Waiting for response...');
+  expect(pingResult).toHaveTextContent('Failed');
 
   // and no error
   const errorMesssage = screen.getByRole('alert', { name: 'Error Message Content' });

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingContainerEnginePing.svelte
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingContainerEnginePing.svelte
@@ -19,6 +19,7 @@ async function pingConnection() {
     const result = await window.pingContainerEngine(providerContainerEngine);
     pingResult = `Responded: ${Buffer.from(String(result)).toString()}`;
   } catch (e) {
+    pingResult = 'Failed';
     pingError = e;
   } finally {
     pingInProgress = false;


### PR DESCRIPTION
### What does this PR do?

Minor fix - when the troubleshooting page 'Ping' or 'Grab containers' buttons fail to connect, they still say '...Waiting for response...' along with the error message. This just updates the text to say 'Failed' and updates the tests as well.

### Screenshot/screencast of this PR

Before:
<img width="582" alt="Screenshot 2023-07-27 at 8 05 55 AM" src="https://github.com/containers/podman-desktop/assets/19958075/7a38c95c-35cb-4367-ad48-35f7a1ee4658">

After:
<img width="474" alt="Screenshot 2023-07-27 at 8 05 36 AM" src="https://github.com/containers/podman-desktop/assets/19958075/56fd2df1-95bc-4d24-9257-fa030f0be083">

### What issues does this PR fix or reference?

N/A

### How to test this PR?

I originally hit this because I had a hung podman machine and tested the fix against that. If you can't recreate a similar situation, in dev mode you can recreate by adding an appropriate 'throw Error()' as I did for the screenshots. :)