### PR TITLE
chore: troubleshooting buttons

### DIFF
--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingContainerEngineGrabContainers.svelte
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingContainerEngineGrabContainers.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
+import { faSignal } from '@fortawesome/free-solid-svg-icons';
 import type { ProviderContainerConnectionInfo } from '../../../../main/src/plugin/api/provider-info';
+import Button from '../ui/Button.svelte';
 
 import ErrorMessage from '../ui/ErrorMessage.svelte';
 
@@ -30,13 +32,13 @@ async function grabContainers() {
 
 <div class="flex flex-row items-center">
   <div class="w-36">
-    <button
-      disabled="{listInProgress}"
-      class="px-3 my-1 text-sm font-medium text-center text-white bg-violet-600 rounded-sm hover:bg-dustypurple-800 focus:ring-2 focus:outline-none focus:ring-dustypurple-700 w-full"
-      title="Check containers"
-      on:click="{() => grabContainers()}">
+    <Button
+      bind:inProgress="{listInProgress}"
+      class="my-1 w-full"
+      on:click="{() => grabContainers()}"
+      icon="{faSignal}">
       Check containers
-    </button>
+    </Button>
   </div>
   <div role="status" class="mx-2">{listContainersResult}</div>
   {#if listError}

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingContainerEnginePing.svelte
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingContainerEnginePing.svelte
@@ -3,6 +3,8 @@ import type { ProviderContainerConnectionInfo } from '../../../../main/src/plugi
 
 import { Buffer } from 'buffer';
 import ErrorMessage from '../ui/ErrorMessage.svelte';
+import Button from '../ui/Button.svelte';
+import { faSignal } from '@fortawesome/free-solid-svg-icons';
 
 export let providerContainerEngine: ProviderContainerConnectionInfo;
 
@@ -31,13 +33,13 @@ async function pingConnection() {
 
 <div class="flex flex-row items-center">
   <div class="w-36">
-    <button
-      disabled="{pingInProgress}"
-      class="px-3 my-1 text-sm font-medium text-center text-white bg-violet-600 rounded-sm hover:bg-dustypurple-800 focus:ring-2 focus:outline-none focus:ring-dustypurple-700 w-full"
-      title="Ping"
-      on:click="{() => pingConnection()}">
+    <Button
+      bind:inProgress="{pingInProgress}"
+      class="my-1 w-full"
+      on:click="{() => pingConnection()}"
+      icon="{faSignal}">
       Ping
-    </button>
+    </Button>
   </div>
   <div role="status" class="mx-2">{pingResult}</div>
   {#if pingError}

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingContainerEngineReconnect.svelte
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingContainerEngineReconnect.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+import { faPlug } from '@fortawesome/free-solid-svg-icons';
+import Button from '../ui/Button.svelte';
 import ErrorMessage from '../ui/ErrorMessage.svelte';
 
 let reconnectInProgress = false;
@@ -24,13 +26,14 @@ async function reconnectContainerProviders() {
 </script>
 
 <div class="flex flex-row items-center">
-  <button
-    disabled="{reconnectInProgress}"
-    class="px-3 my-1 text-sm font-medium text-center text-white bg-violet-600 rounded-sm hover:bg-dustypurple-800 focus:ring-2 focus:outline-none focus:ring-dustypurple-700"
-    title="Establish again connection to the socket of container engines"
-    on:click="{() => reconnectContainerProviders()}">
+  <Button
+    class="my-1"
+    bind:inProgress="{reconnectInProgress}"
+    title="Re-establish connection to the container engine sockets"
+    on:click="{() => reconnectContainerProviders()}"
+    icon="{faPlug}">
     Reconnect providers
-  </button>
+  </Button>
   <div role="status" class="mx-2">{reconnectResult}</div>
   {#if reconnectError}
     <ErrorMessage class="mx-2" error="{reconnectError}" />

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingPageStore.svelte
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingPageStore.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+import { faRefresh } from '@fortawesome/free-solid-svg-icons';
+import Button from '../ui/Button.svelte';
 import TroubleshootingPageStoreDetails from './TroubleshootingPageStoreDetails.svelte';
 import type { EventStoreInfo } from '/@/stores/event-store';
 
@@ -31,14 +33,14 @@ let openDetails = false;
   </div>
   <div class="text-sm">({eventStoreInfo.size} items)</div>
   <div class="">
-    <button
-      disabled="{fetchInProgress}"
-      class="px-3 my-1 text-sm font-medium text-center text-white bg-violet-600 rounded-sm hover:bg-dustypurple-800 focus:ring-2 focus:outline-none focus:ring-dustypurple-700 w-full"
-      title="Refresh"
+    <Button
+      bind:inProgress="{fetchInProgress}"
+      class="my-1"
       aria-label="Refresh"
-      on:click="{() => fetch()}">
+      on:click="{() => fetch()}"
+      icon="{faRefresh}">
       Refresh
-    </button>
+    </Button>
   </div>
   {#if eventStoreInfo.bufferEvents.length > 0}
     {@const lastUpdate = eventStoreInfo.bufferEvents[eventStoreInfo.bufferEvents.length - 1]}

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingPageStoreDetails.svelte
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingPageStoreDetails.svelte
@@ -4,6 +4,8 @@ import type { EventStoreInfo } from '/@/stores/event-store';
 
 import moment from 'moment';
 import humanizeDuration from 'humanize-duration';
+import Button from '../ui/Button.svelte';
+import { faRefresh, faTrash } from '@fortawesome/free-solid-svg-icons';
 
 export let closeCallback: () => void;
 
@@ -42,13 +44,8 @@ async function fetch(): Promise<void> {
           <div class="mx-2 flex flex-row items-center">
             Size: <div role="status" aria-label="size">{eventStoreInfo.size}</div>
             <div class="mx-2">
-              <button
-                disabled="{fetchInProgress}"
-                class="px-3 my-1 text-sm font-medium text-center text-white bg-violet-600 rounded-sm hover:bg-dustypurple-800 focus:ring-2 focus:outline-none focus:ring-dustypurple-700"
-                title="Refresh"
-                on:click="{() => fetch()}">
-                Refresh
-              </button>
+              <Button class="my-1" bind:inProgress="{fetchInProgress}" on:click="{() => fetch()}" icon="{faRefresh}"
+                >Refresh</Button>
             </div>
           </div>
         </div>
@@ -59,13 +56,12 @@ async function fetch(): Promise<void> {
             <div class="pb-2 text-lg">
               Updating events:
               {#if eventStoreInfo.bufferEvents.length > 0}
-                <button
-                  disabled="{fetchInProgress}"
-                  class="px-3 my-1 text-sm font-medium text-center text-white bg-violet-600 rounded-sm hover:bg-dustypurple-800 focus:ring-2 focus:outline-none focus:ring-dustypurple-700"
-                  title="Refresh"
-                  on:click="{() => eventStoreInfo.clearEvents()}">
-                  Clear events
-                </button>
+                <Button
+                  class="my-1"
+                  bind:inProgress="{fetchInProgress}"
+                  title="Clear events"
+                  on:click="{() => eventStoreInfo.clearEvents()}"
+                  icon="{faTrash}">Clear</Button>
               {/if}
             </div>
             {#if eventStoreInfo.bufferEvents.length > 0}
@@ -105,10 +101,8 @@ async function fetch(): Promise<void> {
 
         <div class="text-xs text-gray-800 mt-2 text-center">Track events that have updated the store</div>
         <div class="flex flex-row justify-end w-full pt-2">
-          <button aria-label="Cancel" class="text-xs hover:underline mr-3" on:click="{() => closeCallback()}"
-            >Cancel</button>
-          <button class="pf-c-button pf-m-primary" type="button" aria-label="Next" on:click="{() => closeCallback()}"
-            >OK</button>
+          <Button aria-label="Cancel" class="mr-3" type="link" on:click="{() => closeCallback()}">Cancel</Button>
+          <Button aria-label="OK" on:click="{() => closeCallback()}">OK</Button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
### What does this PR do?

Updating all of the buttons in troubleshooting to our own button component.

With the updated design buttons don't show the 'in progress' spinner unless they have icons, so I added some generic fa icons. I also removed a couple titles (tooltips) that were identical to the button text, simplified some styling using space-x-, removing divs that are no longer needed, etc.

### Screenshot/screencast of this PR

https://github.com/containers/podman-desktop/assets/19958075/b9848282-a02f-495b-a84e-613bbf554674

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Open troubleshooting page, click on buttons and check for styling issues.