### PR TITLE
chore: pf buttons settings

### DIFF
--- a/packages/renderer/src/lib/docker-extension/PreferencesPageDockerExtensions.svelte
+++ b/packages/renderer/src/lib/docker-extension/PreferencesPageDockerExtensions.svelte
@@ -4,7 +4,8 @@ import { afterUpdate } from 'svelte';
 import { contributions } from '../../stores/contribs';
 import ErrorMessage from '../ui/ErrorMessage.svelte';
 import SettingsPage from '../preferences/SettingsPage.svelte';
-import Spinner from '../ui/Spinner.svelte';
+import Button from '../ui/Button.svelte';
+import { faArrowCircleDown } from '@fortawesome/free-solid-svg-icons';
 
 export let ociImage: string = undefined;
 
@@ -73,19 +74,13 @@ function deleteContribution(extensionName: string) {
       </div>
     </div>
 
-    <button
+    <Button
       on:click="{() => installDDExtensionFromImage()}"
-      disabled="{ociImage === undefined || ociImage.trim() === '' || installInProgress}"
-      class="pf-c-button pf-m-primary"
-      type="button">
-      {#if installInProgress}
-        <Spinner />
-      {/if}
-      <span class="pf-c-button__icon pf-m-start">
-        <i class="fas fa-arrow-circle-down ml-6" aria-hidden="true"></i>
-      </span>
+      inProgress="{installInProgress}"
+      disabled="{ociImage === undefined || ociImage.trim() === ''}"
+      icon="{faArrowCircleDown}">
       Install extension from the OCI image
-    </button>
+    </Button>
 
     <div
       class:opacity-0="{logs.length === 0}"

--- a/packages/renderer/src/lib/preferences/PreferencesExtensionList.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesExtensionList.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 import Fa from 'svelte-fa/src/fa.svelte';
-import { faPuzzlePiece, faTrash, faPlay, faStop } from '@fortawesome/free-solid-svg-icons';
+import { faPuzzlePiece, faTrash, faPlay, faStop, faArrowCircleDown } from '@fortawesome/free-solid-svg-icons';
 import { afterUpdate } from 'svelte';
 import { extensionInfos } from '../../stores/extensions';
 import type { ExtensionInfo } from '../../../../main/src/plugin/api/extension-info';
@@ -8,7 +8,7 @@ import ErrorMessage from '../ui/ErrorMessage.svelte';
 import SettingsPage from '../preferences/SettingsPage.svelte';
 import ConnectionStatus from '../ui/ConnectionStatus.svelte';
 import FeaturedExtensions from '../featured/FeaturedExtensions.svelte';
-import Spinner from '../ui/Spinner.svelte';
+import Button from '../ui/Button.svelte';
 
 export let ociImage: string = undefined;
 
@@ -87,19 +87,14 @@ async function updateExtension(extension: ExtensionInfo, ociUri: string) {
             class="w-1/2 p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700"
             required />
 
-          <button
+          <Button
             on:click="{() => installExtensionFromImage()}"
-            disabled="{ociImage === undefined || ociImage.trim() === '' || installInProgress}"
-            class="w-full pf-c-button pf-m-primary"
-            type="button">
-            {#if installInProgress}
-              <Spinner />
-            {/if}
-            <span class="pf-c-button__icon pf-m-start">
-              <i class="fas fa-arrow-circle-down" aria-hidden="true"></i>
-            </span>
+            disabled="{ociImage === undefined || ociImage.trim() === ''}"
+            class="w-full"
+            inProgress="{installInProgress}"
+            icon="{faArrowCircleDown}">
             Install extension from the OCI image
-          </button>
+          </Button>
         </div>
 
         <div class="container w-full flex-col">

--- a/packages/renderer/src/lib/preferences/PreferencesExtensionRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesExtensionRendering.svelte
@@ -4,6 +4,8 @@ import { extensionInfos } from '../../stores/extensions';
 import type { ExtensionInfo } from '../../../../main/src/plugin/api/extension-info';
 import SettingsPage from './SettingsPage.svelte';
 import ExtensionStatus from '../ui/ExtensionStatus.svelte';
+import Button from '../ui/Button.svelte';
+import { faPlay, faStop, faTrash } from '@fortawesome/free-solid-svg-icons';
 
 export let extensionId: string = undefined;
 
@@ -38,45 +40,30 @@ async function removeExtension() {
         <div class="py-2 flex flex-row items-center">
           <!-- start is enabled only when stopped or failed -->
           <div class="px-2 text-sm italic text-gray-700">
-            <button
+            <Button
               disabled="{extensionInfo.state !== 'stopped' && extensionInfo.state !== 'failed'}"
               on:click="{() => startExtension()}"
-              class="pf-c-button pf-m-primary"
-              type="button">
-              <span class="pf-c-button__icon pf-m-start">
-                <i class="fas fa-play" aria-hidden="true"></i>
-              </span>
+              icon="{faPlay}">
               Enable
-            </button>
+            </Button>
           </div>
 
           <!-- stop is enabled only when started -->
           <div class="px-2 text-sm italic text-gray-700">
-            <button
-              disabled="{extensionInfo.state !== 'started'}"
-              on:click="{() => stopExtension()}"
-              class="pf-c-button pf-m-primary"
-              type="button">
-              <span class="pf-c-button__icon pf-m-start">
-                <i class="fas fa-stop" aria-hidden="true"></i>
-              </span>
+            <Button disabled="{extensionInfo.state !== 'started'}" on:click="{() => stopExtension()}" icon="{faStop}">
               Disable
-            </button>
+            </Button>
           </div>
 
           <!-- delete is enabled only when stopped or failed -->
           {#if extensionInfo.removable}
             <div class="px-2 text-sm italic text-gray-700">
-              <button
+              <Button
                 disabled="{extensionInfo.state !== 'stopped' && extensionInfo.state !== 'failed'}"
                 on:click="{() => removeExtension()}"
-                class="pf-c-button pf-m-primary"
-                type="button">
-                <span class="pf-c-button__icon pf-m-start">
-                  <i class="fas fa-trash" aria-hidden="true"></i>
-                </span>
+                icon="{faTrash}">
                 Remove
-              </button>
+              </Button>
             </div>
           {:else}
             <div class="text-gray-900 items-center px-2 text-sm">Default extension, cannot be removed</div>

--- a/packages/renderer/src/lib/preferences/PreferencesProxiesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesProxiesRendering.svelte
@@ -2,6 +2,8 @@
 import type { ProxySettings } from '@podman-desktop/api';
 import { onMount } from 'svelte';
 import SettingsPage from './SettingsPage.svelte';
+import Button from '../ui/Button.svelte';
+import { faPen } from '@fortawesome/free-solid-svg-icons';
 
 let proxySettings: ProxySettings;
 let proxyState: boolean;
@@ -104,16 +106,9 @@ async function updateProxyState() {
           required />
       </div>
       <div class="my-2 pt-4">
-        <button
-          on:click="{() => updateProxySettings()}"
-          disabled="{!proxyState}"
-          class="w-full pf-c-button pf-m-primary"
-          type="button">
-          <span class="pf-c-button__icon pf-m-start">
-            <i class="fas fa-pen" aria-hidden="true"></i>
-          </span>
+        <Button on:click="{() => updateProxySettings()}" disabled="{!proxyState}" class="w-full" icon="{faPen}">
           Update
-        </button>
+        </Button>
       </div>
     {/if}
   </div>

--- a/packages/renderer/src/lib/preferences/PreferencesRegistriesEditing.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRegistriesEditing.svelte
@@ -4,8 +4,9 @@ import { onMount } from 'svelte';
 import { registriesInfos, registriesSuggestedInfos } from '../../stores/registries';
 import DropdownMenu from '../ui/DropdownMenu.svelte';
 import DropdownMenuItem from '../ui/DropDownMenuItem.svelte';
-import { faTrash, faUser, faUserPen } from '@fortawesome/free-solid-svg-icons';
+import { faPlusCircle, faTrash, faUser, faUserPen } from '@fortawesome/free-solid-svg-icons';
 import SettingsPage from './SettingsPage.svelte';
+import Button from '../ui/Button.svelte';
 
 // contains the original instances of registries when user clicks on `Edit password` menu item
 // to be able to roll back changes when `Cancel` button is clicked
@@ -244,16 +245,9 @@ const processPasswordElement = (node: HTMLInputElement, registry: containerDeskt
 
 <SettingsPage title="Registries">
   <div slot="actions">
-    <button
-      on:click="{() => setNewRegistryFormVisible(true)}"
-      class="pf-c-button pf-m-primary transition ease-in-out delay-50 hover:cursor-pointer h-7 w-36 text-sm rounded-md shadow hover:shadow-lg"
-      type="button"
-      disabled="{showNewRegistryForm}">
-      <span class="pf-c-button__icon pf-m-start">
-        <i class="fas fa-plus-circle" aria-hidden="true"></i>
-      </span>
+    <Button on:click="{() => setNewRegistryFormVisible(true)}" icon="{faPlusCircle}" disabled="{showNewRegistryForm}">
       Add registry
-    </button>
+    </Button>
   </div>
 
   <div class="container bg-charcoal-600 rounded-md p-3">
@@ -304,7 +298,7 @@ const processPasswordElement = (node: HTMLInputElement, registry: containerDeskt
                     class="block px-3 block w-full h-full transition ease-in-out delay-50 bg-charcoal-800 text-gray-700 placeholder-gray-700 rounded-sm focus:outline-none" />
                 </div>
               {:else if !registry.username && !registry.secret}
-                <button class="font-bold" on:click="{() => markRegistryAsModified(registry)}">Login now</button>
+                <Button on:click="{() => markRegistryAsModified(registry)}">Login now</Button>
               {:else}
                 {registry.username}
               {/if}
@@ -348,21 +342,10 @@ const processPasswordElement = (node: HTMLInputElement, registry: containerDeskt
                     </div>
                   </div>
                   <div class="h-7 text-sm">
-                    <button
-                      on:click="{() => loginToRegistry(registry)}"
-                      disabled="{loggingIn}"
-                      class="pf-c-button pf-m-primary transition ease-in-out delay-50 hover:cursor-pointer w-full h-full rounded-md shadow hover:shadow-lg"
-                      type="button">
-                      Login
-                    </button>
+                    <Button on:click="{() => loginToRegistry(registry)}" inProgress="{loggingIn}">Login</Button>
                   </div>
                   <div class="h-7 text-sm">
-                    <button
-                      on:click="{() => markRegistryAsClean(registry)}"
-                      class="transition ease-in-out delay-50 hover:cursor-pointer w-16 h-full"
-                      type="button">
-                      Cancel
-                    </button>
+                    <Button on:click="{() => markRegistryAsClean(registry)}" type="link">Cancel</Button>
                   </div>
                 {:else}
                   <!-- Password field start -->
@@ -506,34 +489,22 @@ const processPasswordElement = (node: HTMLInputElement, registry: containerDeskt
 
                 <div class="flex text-sm">
                   {#if listedSuggestedRegistries[i]}
-                    <button
+                    <Button
                       on:click="{() => loginToRegistry(newRegistryRequest)}"
                       disabled="{!newRegistryRequest.serverUrl ||
                         !newRegistryRequest.username ||
-                        !newRegistryRequest.secret ||
-                        loggingIn}"
-                      class="inline pf-c-button pf-m-primary transition ease-in-out delay-50 hover:cursor-pointer h-full rounded-md shadow hover:shadow-lg justify-center"
-                      type="button">
+                        !newRegistryRequest.secret}"
+                      inProgress="{loggingIn}">
                       Login
-                    </button>
+                    </Button>
                   {/if}
                 </div>
                 <div class="flex text-sm">
                   <div class="h-7 pr-5 text-sm">
                     {#if listedSuggestedRegistries[i]}
-                      <button
-                        on:click="{() => hideSuggestedRegistries()}"
-                        class="transition ease-in-out delay-50 hover:cursor-pointer h-full justify-center w-16"
-                        type="button">
-                        Cancel
-                      </button>
+                      <Button on:click="{() => hideSuggestedRegistries()}" type="link">Cancel</Button>
                     {:else}
-                      <button
-                        on:click="{() => setNewSuggestedRegistryFormVisible(i, registry)}"
-                        class="inline pf-c-button pf-m-primary transition ease-in-out delay-50 hover:cursor-pointer h-full rounded-md shadow hover:shadow-lg justify-center pb-1"
-                        type="button">
-                        Configure
-                      </button>
+                      <Button on:click="{() => setNewSuggestedRegistryFormVisible(i, registry)}">Configure</Button>
                     {/if}
                   </div>
                 </div>
@@ -601,24 +572,17 @@ const processPasswordElement = (node: HTMLInputElement, registry: containerDeskt
                 </div>
 
                 <div class="flex text-sm">
-                  <button
+                  <Button
                     on:click="{() => loginToRegistry(newRegistryRequest)}"
                     disabled="{!newRegistryRequest.serverUrl ||
                       !newRegistryRequest.username ||
-                      !newRegistryRequest.secret ||
-                      loggingIn}"
-                    class="inline pf-c-button pf-m-primary transition ease-in-out delay-50 hover:cursor-pointer h-full rounded-md shadow hover:shadow-lg justify-center"
-                    type="button">
+                      !newRegistryRequest.secret}"
+                    inProgress="{loggingIn}">
                     Login
-                  </button>
+                  </Button>
                 </div>
                 <div class="flex text-sm">
-                  <button
-                    on:click="{() => setNewRegistryFormVisible(false)}"
-                    class="transition ease-in-out delay-50 hover:cursor-pointer h-full justify-center w-16"
-                    type="button">
-                    Cancel
-                  </button>
+                  <Button on:click="{() => setNewRegistryFormVisible(false)}" type="link">Cancel</Button>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
### What does this PR do?

Changes the buttons on the Settings > Extensions, Docker Extensions, Registries, and Proxy pages to our own buttons. Minor visual consistency improvements, e.g. they get lighter on hover.

I didn't see an obvious icon to add to the Registries Login buttons so they look & behave exactly like before (disable on click, but no busy spinner).

### Screenshot/screencast of this PR

<img width="201" alt="Screenshot 2023-07-27 at 4 59 21 PM" src="https://github.com/containers/podman-desktop/assets/19958075/51887780-9214-42dd-9acd-5fc0456166e7">
<img width="288" alt="Screenshot 2023-07-27 at 4 59 42 PM" src="https://github.com/containers/podman-desktop/assets/19958075/b15e9c5a-357b-40e4-bd5e-8bc0a95ff477">

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Just open these pages and confirm no visual regression.