### PR TITLE
chore(tests): containers e2e test

### DIFF
--- a/tests/src/container-smoke.spec.ts
+++ b/tests/src/container-smoke.spec.ts
@@ -1,0 +1,135 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { Page } from 'playwright';
+import { afterAll, beforeAll, test, describe } from 'vitest';
+import { expect as playExpect } from '@playwright/test';
+import { PodmanDesktopRunner } from './runner/podman-desktop-runner';
+import { WelcomePage } from './model/pages/welcome-page';
+import { NavigationBar } from './model/workbench/navigation';
+import { waitUntil, waitWhile } from './utility/wait';
+import { deleteContainer, deleteImage } from './utility/operations';
+import { ContainerState } from './model/core/states';
+
+let pdRunner: PodmanDesktopRunner;
+let page: Page;
+const imageToPull = 'quay.io/podman/hello';
+const imageTag = 'latest';
+const containerToRun = 'podman-hello';
+
+beforeAll(async () => {
+  pdRunner = new PodmanDesktopRunner();
+  page = await pdRunner.start();
+  const welcomePage = new WelcomePage(page);
+  await welcomePage.handleWelcomePage(true);
+  // wait giving a time to podman desktop to load up
+  const images = await new NavigationBar(page).openImages();
+  await waitWhile(
+    async () => await images.pageIsEmpty(),
+    5000,
+    1000,
+    false,
+    'Images page is empty, there are no images present',
+  );
+  await deleteContainer(page, containerToRun);
+});
+
+afterAll(async () => {
+  await deleteContainer(page, containerToRun);
+  await deleteImage(page, imageToPull);
+  await pdRunner.close();
+}, 90000);
+
+describe('Verification of container creation workflow', async () => {
+  test(`Pulling of '${imageToPull}:${imageTag}' image`, async () => {
+    const navigationBar = new NavigationBar(page);
+    let images = await navigationBar.openImages();
+    const pullImagePage = await images.openPullImage();
+    images = await pullImagePage.pullImage(imageToPull, imageTag, 45000);
+    playExpect(await images.imageExists(imageToPull)).toBeTruthy();
+    await pdRunner.screenshot('containers-pull-image.png');
+  }, 60000);
+
+  test(`Start a container '${containerToRun}'`, async () => {
+    const navigationBar = new NavigationBar(page);
+    const images = await navigationBar.openImages();
+    const imageDetails = await images.openImageDetails(imageToPull);
+    const runImage = await imageDetails.openRunImage();
+    await pdRunner.screenshot('containers-run-image.png');
+    const containers = await runImage.startContainer(containerToRun);
+    await waitUntil(async () => containers.containerExists(containerToRun), 10000, 1000);
+    await pdRunner.screenshot('containers-container-exists.png');
+    await waitUntil(async () => {
+      const containerDetails = await containers.openContainersDetails(containerToRun);
+      return (await containerDetails.getState()) === ContainerState.Exited;
+    }, 5000);
+  });
+
+  test('Open a container details', async () => {
+    const navigationBar = new NavigationBar(page);
+    const containers = await navigationBar.openContainers();
+    const containersDetails = await containers.openContainersDetails(containerToRun);
+    await playExpect(containersDetails.heading).toBeVisible();
+    await playExpect(containersDetails.heading).toContainText(containerToRun);
+    // test state of container in summary tab
+    await pdRunner.screenshot('containers-container-details.png');
+    const containerState = await containersDetails.getState();
+    playExpect(containerState).toContain(ContainerState.Exited);
+    // check Logs output
+    await containersDetails.activateTab('Logs');
+    const helloWorldMessage = containersDetails.getPage().getByText('Hello Podman World');
+    await playExpect(helloWorldMessage).toBeVisible();
+    // Switch between various other tabs, no checking of the content
+    await containersDetails.activateTab('Inspect');
+    await containersDetails.activateTab('Kube');
+    await containersDetails.activateTab('Terminal');
+    // TODO: After updating of accessibility of various element in containers pages, we can extend test
+  });
+
+  test.skip('Stopping a container', async () => {
+    const navigationBar = new NavigationBar(page);
+    const containers = await navigationBar.openContainers();
+    const containersDetails = await containers.openContainersDetails(containerToRun);
+    await playExpect(containersDetails.heading).toBeVisible();
+    await playExpect(containersDetails.heading).toContainText(containerToRun);
+    // test state of container in summary tab
+    playExpect(await containersDetails.getState()).toContain(ContainerState.Running);
+    await containersDetails.stopContainer();
+    try {
+      await waitUntil(async () => (await containersDetails.getState()) === ContainerState.Exited, 15000);
+      await playExpect(await containersDetails.getStateLocator()).toHaveText(ContainerState.Exited);
+    } catch (error) {
+      await pdRunner.screenshot('containers--container-stop-failed.png');
+      throw error;
+    }
+    const startButton = containersDetails.getPage().getByRole('button', { name: 'Start Container', exact: true });
+    await playExpect(startButton).toBeVisible();
+    await pdRunner.screenshot('containers-container-stopped.png');
+  });
+
+  test.skip('Deleting a container', async () => {
+    const navigationBar = new NavigationBar(page);
+    const containers = await navigationBar.openContainers();
+    const containersDetails = await containers.openContainersDetails(containerToRun);
+    await playExpect(containersDetails.heading).toContainText(containerToRun);
+    const containersPage = await containersDetails.deleteContainer(10000);
+    playExpect(containersPage).toBeDefined();
+    playExpect(await containersPage.containerExists(containerToRun)).toBeFalsy();
+    await pdRunner.screenshot('containers-container-deleted.png');
+  });
+});

--- a/tests/src/model/core/states.ts
+++ b/tests/src/model/core/states.ts
@@ -16,16 +16,14 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { Page } from 'playwright';
-
-export abstract class PodmanDesktopPage {
-  readonly page: Page;
-
-  constructor(page: Page) {
-    this.page = page;
-  }
-
-  public getPage(): Page {
-    return this.page;
-  }
+export enum ContainerState {
+  Starting = 'STARTING',
+  Stopping = 'STOPPING',
+  Running = 'RUNNING',
+  Error = 'ERROR',
+  Exited = 'EXITED',
+  Deleting = 'DELETING',
+  Created = 'CREATED',
+  Paused = 'PAUSED',
+  Unknown = 'UNKNOWN',
 }

--- a/tests/src/model/pages/container-details-page.ts
+++ b/tests/src/model/pages/container-details-page.ts
@@ -1,0 +1,95 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { Locator, Page } from 'playwright';
+import { PodmanDesktopPage } from './base-page';
+import { ContainersPage } from './containers-page';
+import { waitUntil, waitWhile } from '../../utility/wait';
+import { ContainerState } from '../core/states';
+
+export class ContainerDetailsPage extends PodmanDesktopPage {
+  readonly labelName: Locator;
+  readonly heading: Locator;
+  readonly closeLink: Locator;
+  readonly backToContainersLink: Locator;
+  readonly containerName: string;
+
+  static readonly SUMMARY_TAB = 'Summary';
+  static readonly LOGS_TAB = 'Logs';
+  static readonly KUBE_TAB = 'Kube';
+  static readonly TERMINAL_TAB = 'Terminal';
+  static readonly INSPECT_TAB = 'Inspect';
+
+  constructor(page: Page, name: string) {
+    super(page);
+    this.containerName = name;
+    this.labelName = page.getByLabel('name').and(page.getByText('Container Details'));
+    this.heading = page.getByRole('heading', { name: this.containerName });
+    this.closeLink = page.getByRole('link', { name: 'Close Details' });
+    this.backToContainersLink = page.getByRole('link', { name: 'Go back to Containers' });
+  }
+
+  async activateTab(tabName: string) {
+    const tabItem = this.page.getByRole('link', { name: tabName });
+    await tabItem.waitFor({ state: 'visible', timeout: 2000 });
+    await tabItem.click();
+  }
+
+  async getStateLocator(): Promise<Locator> {
+    await this.activateTab(ContainerDetailsPage.SUMMARY_TAB);
+    const summaryTable = this.getPage().getByRole('table');
+    const stateRow = summaryTable.locator('tr:has-text("State")');
+    const stateCell = stateRow.getByRole('cell').nth(1);
+    await stateCell.waitFor({ state: 'visible', timeout: 500 });
+    return stateCell;
+  }
+
+  async getState(): Promise<string> {
+    const stateCell = await this.getStateLocator();
+    return await stateCell.innerText({ timeout: 300 });
+  }
+
+  async stopContainer(failIfStopped = false): Promise<void> {
+    try {
+      await waitUntil(async () => (await this.getState()) === ContainerState.Running, 3000, 900);
+      const stopButton = this.page.getByRole('button').and(this.page.getByLabel('Stop Container'));
+      await stopButton.waitFor({ state: 'visible', timeout: 2000 });
+      await stopButton.click();
+    } catch (error) {
+      if (failIfStopped) {
+        throw Error(
+          `Container is not running, its state is: ${await this.getState()}, stop button not available: ${error}`,
+        );
+      }
+    }
+  }
+
+  async deleteContainer(timeout: number): Promise<ContainersPage> {
+    const deleteButton = this.page.getByRole('button').and(this.page.getByLabel('Delete Container'));
+    await deleteButton.click();
+    await waitWhile(
+      async () => await this.heading.isVisible(),
+      timeout,
+      1000,
+      true,
+      `Container was not deleted in ${timeout / 1000}s`,
+    );
+    // after delete is successful we expect to see containers page
+    return new ContainersPage(this.page);
+  }
+}

--- a/tests/src/model/pages/containers-page.ts
+++ b/tests/src/model/pages/containers-page.ts
@@ -1,0 +1,88 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { Locator, Page } from 'playwright';
+import { PodmanDesktopPage } from './base-page';
+import { ContainerDetailsPage } from './container-details-page';
+
+export class ContainersPage extends PodmanDesktopPage {
+  readonly heading: Locator;
+  readonly pruneContainersButton: Locator;
+  readonly createContainerButton: Locator;
+  readonly playKubernetesYAMLButton: Locator;
+
+  constructor(page: Page) {
+    super(page);
+    this.heading = this.page.getByRole('heading', { name: 'Containers', exact: true });
+    this.pruneContainersButton = this.page.getByRole('button', { name: 'Prune containers' });
+    this.createContainerButton = this.page.getByRole('button', { name: 'Create a container' });
+    this.playKubernetesYAMLButton = this.page.getByRole('button', { name: 'Play Kubernetes YAML' });
+  }
+
+  async getTable(): Promise<Locator> {
+    if (!(await this.pageIsEmpty())) {
+      return this.page.getByRole('table');
+    } else {
+      throw Error('Containers page is empty, there are no containers');
+    }
+  }
+
+  async pageIsEmpty(): Promise<boolean> {
+    const noContainersHeading = this.page.getByRole('heading', { name: 'No containers', exact: true });
+    try {
+      await noContainersHeading.waitFor({ state: 'visible', timeout: 500 });
+    } catch (err) {
+      return false;
+    }
+    return true;
+  }
+
+  async openContainersDetails(name: string): Promise<ContainerDetailsPage> {
+    const containerRow = await this.getContainerRowByName(name);
+    if (containerRow === undefined) {
+      throw Error(`Container: '${name}' does not exist`);
+    }
+    const containerRowName = containerRow.getByRole('cell').nth(3);
+    await containerRowName.click();
+    return new ContainerDetailsPage(this.page, name);
+  }
+
+  async getContainerRowByName(name: string): Promise<Locator | undefined> {
+    if (await this.pageIsEmpty()) {
+      return undefined;
+    }
+    const containersTable = await this.getTable();
+    const rows = await containersTable.getByRole('row').all();
+    for (const row of rows) {
+      // test on empty row - contains on 0th position &nbsp; character (ISO 8859-1 character set: 160)
+      const zeroCell = await row.getByRole('cell').nth(0).innerText();
+      if (zeroCell.indexOf(String.fromCharCode(160)) === 0) {
+        continue;
+      }
+      const thirdCell = await row.getByRole('cell').nth(3).innerText();
+      const index = thirdCell.indexOf(name);
+      if (index >= 0) {
+        return row;
+      }
+    }
+  }
+
+  async containerExists(name: string): Promise<boolean> {
+    return (await this.getContainerRowByName(name)) !== undefined ? true : false;
+  }
+}

--- a/tests/src/model/pages/image-details-page.ts
+++ b/tests/src/model/pages/image-details-page.ts
@@ -18,12 +18,13 @@
 
 import type { Locator, Page } from 'playwright';
 import { PodmanDesktopPage } from './base-page';
+import { RunImagePage } from './run-image-page';
 
 export class ImageDetailsPage extends PodmanDesktopPage {
   readonly name: Locator;
   readonly imageName: string;
   readonly heading: Locator;
-  readonly runButton: Locator;
+  readonly runImageButton: Locator;
   readonly deleteButton: Locator;
   readonly editButton: Locator;
   readonly summaryTab: Locator;
@@ -37,7 +38,7 @@ export class ImageDetailsPage extends PodmanDesktopPage {
     this.name = page.getByLabel('name').and(page.getByText('Image Details'));
     this.imageName = name;
     this.heading = page.getByRole('heading', { name: this.imageName });
-    this.runButton = page.getByRole('button', { name: 'Run Image' });
+    this.runImageButton = page.getByRole('button', { name: 'Run Image' });
     this.deleteButton = page.getByRole('button', { name: 'Delete Image' });
     this.editButton = page.getByRole('button', { name: 'Edit Image' });
     this.summaryTab = page.getByText('Summary');
@@ -45,5 +46,10 @@ export class ImageDetailsPage extends PodmanDesktopPage {
     this.inspectTab = page.getByText('Inspect');
     this.closeLink = page.getByRole('link', { name: 'Close Details' });
     this.backToImagesLink = page.getByRole('link', { name: 'Go back to Images' });
+  }
+
+  async openRunImage(): Promise<RunImagePage> {
+    await this.runImageButton.click();
+    return new RunImagePage(this.page, this.imageName);
   }
 }

--- a/tests/src/model/pages/pull-image-page.ts
+++ b/tests/src/model/pages/pull-image-page.ts
@@ -15,43 +15,41 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
-
 import type { Locator, Page } from 'playwright';
 import { PodmanDesktopPage } from './base-page';
 import { ImagesPage } from './images-page';
 
 export class PullImagePage extends PodmanDesktopPage {
   readonly heading: Locator;
-  readonly imageInput: Locator;
-  readonly pullButton: Locator;
-  readonly doneButton: Locator;
+  readonly pullImageButton: Locator;
   readonly closeLink: Locator;
   readonly backToImagesLink: Locator;
   readonly manageRegistriesButton: Locator;
+  readonly imageToPullLabel: Locator;
+  readonly imageNameInput: Locator;
 
   constructor(page: Page) {
     super(page);
     this.heading = page.getByRole('heading', { name: 'Pull Image From a Registry' });
-    this.imageInput = page.getByLabel('imageName');
-    this.pullButton = page.getByRole('button', { name: 'Pull image' });
-    this.doneButton = page.getByRole('button', { name: 'Done' });
+    this.pullImageButton = page.getByRole('button', { name: 'Pull image' });
     this.closeLink = page.getByRole('link', { name: 'Close' });
     this.backToImagesLink = page.getByRole('link', { name: 'Go back to Images' });
     this.manageRegistriesButton = page.getByRole('button', { name: 'Manage registries' });
+    this.imageToPullLabel = page.getByLabel('Image to Pull');
+    this.imageNameInput = page.getByLabel('imageName');
   }
 
-  async pullImage(image: string): Promise<ImagesPage> {
-    await this.imageInput.fill(image);
-
-    if (await this.pullButton.isEnabled()) {
-      await this.pullButton.click();
+  async pullImage(imageName: string, tag = '', timeout = 10000): Promise<ImagesPage> {
+    const fullImageName = `${imageName}${tag.length === 0 ? '' : ':' + tag}`;
+    await this.imageNameInput.fill(fullImageName);
+    if (await this.pullImageButton.isEnabled()) {
+      await this.pullImageButton.click();
     } else {
-      throw Error('Pull image button is not enabled, verify image name');
+      throw Error(`Pull image button is not enabled, pulling of '${fullImageName}' failed, verify image name`);
     }
-
-    await this.doneButton.waitFor({ state: 'visible' });
-    await this.doneButton.click();
-
+    const doneButton = this.page.getByRole('button', { name: 'Done' });
+    await doneButton.waitFor({ state: 'visible', timeout: timeout });
+    await doneButton.click();
     return new ImagesPage(this.page);
   }
 }

--- a/tests/src/model/pages/run-image-page.ts
+++ b/tests/src/model/pages/run-image-page.ts
@@ -1,0 +1,64 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { Locator, Page } from 'playwright';
+import { PodmanDesktopPage } from './base-page';
+import { ContainersPage } from './containers-page';
+
+export class RunImagePage extends PodmanDesktopPage {
+  readonly name: Locator;
+  readonly heading: Locator;
+  readonly closeLink: Locator;
+  readonly backToImageDetailsLink: Locator;
+  readonly imageName: string;
+  readonly startContainerButton: Locator;
+
+  constructor(page: Page, name: string) {
+    super(page);
+    this.imageName = name;
+    this.name = page.getByLabel('name').and(page.getByText('Run Image'));
+    this.heading = page.getByRole('heading', { name: this.imageName });
+    this.closeLink = page.getByRole('link', { name: 'Close' });
+    this.backToImageDetailsLink = page.getByRole('link', { name: 'Go back to Image Details' });
+    this.startContainerButton = page.getByRole('button', { name: 'Start Container' });
+  }
+
+  async activateTab(name: string) {
+    const tabactive = this.page.getByRole('link', { name: name, exact: true }).and(this.page.getByText(name));
+    await tabactive.click();
+  }
+
+  async startContainer(customName = ''): Promise<ContainersPage> {
+    if (customName !== '') {
+      await this.activateTab('Basic');
+      // ToDo: improve UI side with aria-labels
+      const textbox = this.page.locator(`input[type='text'][name='modalContainerName']`);
+      await textbox.fill(customName);
+    }
+    await this.startContainerButton.waitFor({ state: 'visible', timeout: 1000 });
+    await this.startContainerButton.click();
+    // wait for containers page to appear
+    const containers = new ContainersPage(this.page);
+    try {
+      await containers.heading.waitFor({ state: 'visible', timeout: 3000 });
+    } catch (error) {
+      console.log(`Containers Page seems not to be visible`);
+    }
+    return containers;
+  }
+}

--- a/tests/src/model/workbench/navigation.ts
+++ b/tests/src/model/workbench/navigation.ts
@@ -1,0 +1,35 @@
+import type { Locator, Page } from 'playwright';
+import { ImagesPage } from '../pages/images-page';
+import { ContainersPage } from '../pages/containers-page';
+
+export class NavigationBar {
+  readonly page: Page;
+  readonly navigationLocator: Locator;
+  readonly imagesLink: Locator;
+  readonly containersLink: Locator;
+  readonly volumesLink: Locator;
+  readonly podsLink: Locator;
+  readonly dashboardLink: Locator;
+  readonly settingsLink: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.navigationLocator = this.page.getByRole('navigation', { name: 'AppNavigation' });
+    this.imagesLink = this.page.getByRole('link', { name: 'Images' });
+    this.containersLink = this.page.getByRole('link', { name: 'Containers' });
+    this.podsLink = this.page.getByRole('link', { name: 'Pods' });
+    this.volumesLink = this.page.getByRole('link', { name: 'Volumes' });
+    this.dashboardLink = this.page.getByRole('link', { name: 'Dashboard' });
+    this.settingsLink = this.page.getByRole('link', { name: 'Settings' });
+  }
+
+  async openImages(): Promise<ImagesPage> {
+    await this.imagesLink.click();
+    return new ImagesPage(this.page);
+  }
+
+  async openContainers(): Promise<ContainersPage> {
+    await this.containersLink.click();
+    return new ContainersPage(this.page);
+  }
+}

--- a/tests/src/pull-image-smoke.spec.ts
+++ b/tests/src/pull-image-smoke.spec.ts
@@ -22,6 +22,7 @@ import { expect as playExpect } from '@playwright/test';
 import { PodmanDesktopRunner } from './runner/podman-desktop-runner';
 import { WelcomePage } from './model/pages/welcome-page';
 import { ImagesPage } from './model/pages/images-page';
+import { NavigationBar } from './model/workbench/navigation';
 
 let pdRunner: PodmanDesktopRunner;
 let page: Page;
@@ -40,13 +41,9 @@ afterAll(async () => {
 
 describe('Image pull verification', async () => {
   test('Pull image', async () => {
-    const navBar = page.getByRole('navigation', { name: 'AppNavigation' });
-    const imageLink = navBar.getByRole('link', { name: 'Images' });
-    await playExpect(imageLink).toBeVisible();
-    await imageLink.click();
-
-    const imagesPage = new ImagesPage(page);
-    const pullImagePage = await imagesPage.pullImage();
+    const navBar = new NavigationBar(page);
+    const imagesPage = await navBar.openImages();
+    const pullImagePage = await imagesPage.openPullImage();
     const updatedImages = await pullImagePage.pullImage('quay.io/podman/hello');
 
     playExpect(updatedImages.imageExists('quay.io/podman/hello')).toBeTruthy();

--- a/tests/src/runner/podman-desktop-runner.ts
+++ b/tests/src/runner/podman-desktop-runner.ts
@@ -27,12 +27,14 @@ export class PodmanDesktopRunner {
   private _app: ElectronApplication | undefined;
   private _page: Page | undefined;
   private readonly _profile: string;
+  private readonly _customFolder;
   private readonly _testOutput: string;
 
-  constructor(profile = '') {
+  constructor(profile = '', customFolder = 'podman-desktop') {
     this._running = false;
     this._profile = profile;
     this._testOutput = join('tests', 'output', this._profile);
+    this._customFolder = join(this._testOutput, customFolder);
     this._options = this.defaultOptions();
   }
 
@@ -50,6 +52,11 @@ export class PodmanDesktopRunner {
     this._page = await this.getElectronApp().firstWindow();
     // Direct Electron console to Node terminal.
     this.getPage().on('console', console.log);
+
+    // also get stderr from the node process
+    this._app.process().stderr?.on('data', data => {
+      console.log(`STDERR: ${data}`);
+    });
 
     return this._page;
   }
@@ -75,7 +82,7 @@ export class PodmanDesktopRunner {
   }
 
   public async screenshot(filename: string) {
-    await this.getPage().screenshot({ path: join(this._testOutput, 'screenshots', filename), fullPage: true });
+    await this.getPage().screenshot({ path: join(this._testOutput, 'screenshots', filename) });
   }
 
   public async close() {
@@ -107,7 +114,7 @@ export class PodmanDesktopRunner {
 
   private setupPodmanDesktopCustomFolder(): object {
     const env: { [key: string]: string } = Object.assign({}, process.env as { [key: string]: string });
-    const dir = join(this._testOutput, 'podman-desktop');
+    const dir = join(this._customFolder);
     console.log(`podman desktop custom config will be written to: ${dir}`);
     env.PODMAN_DESKTOP_HOME_DIR = dir;
     return env;

--- a/tests/src/utility/cleanup.ts
+++ b/tests/src/utility/cleanup.ts
@@ -24,8 +24,9 @@ import { rm } from 'node:fs/promises';
  * @param path path to a folder to be force removed recursively
  */
 export async function removeFolderIfExists(path: string) {
+  console.log(`Cleaning up folder: ${path}`);
   if (existsSync(path)) {
-    console.log(`Cleaning up folder: ${path}`);
+    console.log(`Folder found, removing...`);
     await rm(path, { recursive: true, force: true });
   }
 }

--- a/tests/src/utility/operations.ts
+++ b/tests/src/utility/operations.ts
@@ -1,0 +1,99 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { Page } from 'playwright';
+import { NavigationBar } from '../model/workbench/navigation';
+import { waitWhile } from './wait';
+
+/**
+ * Stop and delete container defined by its name
+ * @param page playwright's page object
+ * @param name name of container to be removed
+ */
+export async function deleteContainer(page: Page, name: string) {
+  const navigationBar = new NavigationBar(page);
+  const containers = await navigationBar.openContainers();
+  const container = await containers.getContainerRowByName(name);
+  // check for container existence
+  if (container === undefined) {
+    console.log(`container '${name}' does not exist, skipping...`);
+  } else {
+    // stop container first, might not be running
+    try {
+      const stopButton = container.getByRole('button').and(container.getByLabel('Stop Container'));
+      await stopButton.waitFor({ state: 'visible', timeout: 2000 });
+      await stopButton.click();
+    } catch (error) {
+      // omit the exception
+    }
+    // delete the container
+    const deleteButton = container.getByRole('button').and(container.getByLabel('Delete Container'));
+    await deleteButton.click();
+    // wait for container to disappear
+    try {
+      console.log(`Waiting for container to get deleted ...`);
+      await waitWhile(async () => {
+        const result = await containers.getContainerRowByName(name);
+        return result ? true : false;
+      }, 5000);
+    } catch (error) {
+      if ((error as Error).message.indexOf('Containers page is empty') < 0) {
+        throw Error(`Error waiting for container '${name}' to get removed, ${error}`);
+      }
+    }
+  }
+}
+
+/**
+ * Delete image defined by its name
+ * @param page playwright's page object
+ * @param name name of image to be removed
+ */
+export async function deleteImage(page: Page, name: string) {
+  const navigationBar = new NavigationBar(page);
+  const images = await navigationBar.openImages();
+  const row = await images.getImageRowByName(name);
+  if (row === undefined) {
+    console.log(`image '${name}' does not exist, skipping...`);
+  } else {
+    const deleteButton = row.getByRole('button', { name: 'Delete Image' });
+    if (await deleteButton.isEnabled({ timeout: 2000 })) {
+      await deleteButton.click();
+    } else {
+      throw Error(`Cannot delete image ${name}, because it is in use`);
+    }
+    // wait for image to disappear
+    try {
+      console.log(`image deleting, waiting...`);
+      await waitWhile(
+        async () => {
+          const images = await new NavigationBar(page).openImages();
+          const result = await images.getImageRowByName(name);
+          return result ? true : false;
+        },
+        10000,
+        1000,
+        false,
+      );
+    } catch (error) {
+      if ((error as Error).message.indexOf('Images page is empty') < 0) {
+        throw Error(`Error waiting for image '${name}' to get removed, ${error}`);
+      }
+    }
+  }
+}

--- a/tests/src/utility/wait.ts
+++ b/tests/src/utility/wait.ts
@@ -1,0 +1,113 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+export async function wait(
+  waitFunction: () => Promise<boolean>,
+  until: boolean,
+  timeout: number,
+  diff: number,
+  sendError: boolean,
+  errorMessage: string,
+): Promise<void> {
+  let time = timeout;
+  while (time > 0) {
+    const waitFuncResult = await waitFunction();
+    if (waitFuncResult === until) {
+      return;
+    }
+    time = time - diff;
+    await delay(diff);
+  }
+  const message =
+    errorMessage || errorMessage.length === 0
+      ? `Timeout (${timeout} ms) was reach while waiting for condition (${waitFunction.name}) to become '${String(
+          until,
+        )}'`
+      : errorMessage;
+  if (sendError) {
+    throw Error(message);
+  }
+}
+
+/**
+ * Waiting function that tests the condition (callback) to become true until timeout is reached,
+ * error is thrown if not fulfilled
+ * @param waitFunction a callback returning Promise<boolean>
+ * @param timeout timeout in ms
+ * @param diff a diff (number) in ms defining the delay between each cycle
+ *
+ * Example: await waitUntil(() => dialogIsOpen(), 1000, 250, 'Dialog window was not openend as expected in 1 s');
+ */
+export async function waitUntil(
+  waitFunction: () => Promise<boolean>,
+  timeout = 3000,
+  diff = 500,
+  sendError = true,
+  message = '',
+): Promise<void> {
+  await wait(waitFunction, true, timeout, diff, sendError, message);
+}
+
+/**
+ * Waiting function that tests the condition (callback) to become false until timeout is reached,
+ * error is thrown if not fulfilled
+ * @param waitFunction a callback returning Promise<boolean>
+ * @param timeout timeout in ms
+ * @param diff a diff (number) in ms defining the delay between each cycle
+ *
+ * Example: await waitWhile(() => dialogIsOpen(), 1000, 250, 'Dialog window was not closed as expected in 1 s');
+ */
+export async function waitWhile(
+  waitFunction: () => Promise<boolean>,
+  timeout = 3000,
+  diff = 500,
+  sendError = true,
+  message = '',
+): Promise<void> {
+  await wait(waitFunction, false, timeout, diff, sendError, message);
+}
+
+/**
+ * Standard delay function
+ * @param ms number of ms to sleep for
+ * @returns promise void
+ */
+export async function delay(ms: number): Promise<void> {
+  return new Promise(resolve => {
+    setTimeout(resolve, ms);
+  });
+}
+
+export async function executeWithTimeout(
+  callback: () => Promise<void>,
+  timeout: number,
+  error = 'Timeout reached while waiting for a function to finish',
+) {
+  let cancelTimeout: NodeJS.Timeout;
+
+  const timeoutPromise = new Promise((_, reject) => {
+    cancelTimeout = setTimeout(() => {
+      reject(new Error(error));
+    }, timeout);
+  });
+
+  return Promise.race([callback, timeoutPromise]).then(result => {
+    clearTimeout(cancelTimeout);
+    return result;
+  });
+}

--- a/tests/src/welcome-page-smoke.spec.ts
+++ b/tests/src/welcome-page-smoke.spec.ts
@@ -23,16 +23,13 @@ import { expect as playExpect } from '@playwright/test';
 import { PodmanDesktopRunner } from './runner/podman-desktop-runner';
 import { WelcomePage } from './model/pages/welcome-page';
 import { DashboardPage } from './model/pages/dashboard-page';
-import { removeFolderIfExists } from './utility/cleanup';
-import { join } from 'path';
+import { NavigationBar } from './model/workbench/navigation';
 
-const navBarItems = ['Dashboard', 'Containers', 'Images', 'Pods', 'Volumes', 'Settings'];
 let pdRunner: PodmanDesktopRunner;
 let page: Page;
 
 beforeAll(async () => {
-  await removeFolderIfExists(join('tests', 'output', 'podman-desktop'));
-  pdRunner = new PodmanDesktopRunner();
+  pdRunner = new PodmanDesktopRunner('', 'welcome-podman-desktop');
   page = await pdRunner.start();
 });
 
@@ -102,13 +99,15 @@ describe('Basic e2e verification of podman desktop start', async () => {
   });
 
   describe('Navigation Bar test', async () => {
-    test('Verify navigation items are present', async () => {
-      const navBar = page.getByRole('navigation', { name: 'AppNavigation' });
-      await playExpect(navBar).toBeVisible();
-      for (const item of navBarItems) {
-        const locator = navBar.getByRole('link', { name: item, exact: true });
-        await playExpect(locator).toBeVisible();
-      }
+    test('Verify navigation items are visible', async () => {
+      const navigationBar = new NavigationBar(page);
+      await playExpect(navigationBar.navigationLocator).toBeVisible();
+      await playExpect(navigationBar.dashboardLink).toBeVisible();
+      await playExpect(navigationBar.imagesLink).toBeVisible();
+      await playExpect(navigationBar.podsLink).toBeVisible();
+      await playExpect(navigationBar.containersLink).toBeVisible();
+      await playExpect(navigationBar.volumesLink).toBeVisible();
+      await playExpect(navigationBar.settingsLink).toBeVisible();
     });
   });
 });


### PR DESCRIPTION
### What does this PR do?
Adds e2e tests for starting the container, includes page object models and other utilities
### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?
fixes #2850 
<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

### How to test this PR?
`yarn test:e2e:smoke`
<!-- Please explain steps to reproduce -->
