### PR TITLE
fix: set rootful connection when starting rootful machine (#2582)

### DIFF
--- a/extensions/podman/src/util.ts
+++ b/extensions/podman/src/util.ts
@@ -18,7 +18,6 @@
 
 import * as os from 'node:os';
 import * as path from 'node:path';
-import * as fs from 'node:fs';
 import { spawn } from 'node:child_process';
 import { getInstallationPath } from './podman-cli';
 
@@ -106,18 +105,6 @@ export function runCliCommand(command: string, args: string[], options?: RunOpti
 
     spawnProcess.on('close', exitCode => {
       resolve({ exitCode, stdOut: output, stdErr: err });
-    });
-  });
-}
-
-export function readFile(path: string): Promise<string> {
-  return new Promise((resolve, reject) => {
-    fs.readFile(path, 'utf8', (err, data) => {
-      if (err) {
-        reject(err);
-      } else {
-        resolve(data);
-      }
     });
   });
 }

--- a/extensions/podman/src/util.ts
+++ b/extensions/podman/src/util.ts
@@ -18,6 +18,7 @@
 
 import * as os from 'node:os';
 import * as path from 'node:path';
+import * as fs from 'node:fs';
 import { spawn } from 'node:child_process';
 import { getInstallationPath } from './podman-cli';
 
@@ -105,6 +106,18 @@ export function runCliCommand(command: string, args: string[], options?: RunOpti
 
     spawnProcess.on('close', exitCode => {
       resolve({ exitCode, stdOut: output, stdErr: err });
+    });
+  });
+}
+
+export function readFile(path: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    fs.readFile(path, 'utf8', (err, data) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(data);
+      }
     });
   });
 }


### PR DESCRIPTION
### What does this PR do?

This PR set the default connection to the rootful one if the machine has been originally created rootful

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

it resolves #2582 

### How to test this PR?

1. create a rootful machine
2. start it when the default is a different machine
3. it should ask if you want to switch default -> yes
4. verify that the rootful connection has been selected
