### PR TITLE
fix: store error for build

### DIFF
--- a/packages/renderer/src/lib/image/build-image-task.spec.ts
+++ b/packages/renderer/src/lib/image/build-image-task.spec.ts
@@ -66,3 +66,20 @@ test('check reconnect', async () => {
   expect(newCallback.onStream).toHaveBeenCalledWith('hello\rworld\rduring disconnect\r');
   expect(newCallback.onEnd).toHaveBeenCalledTimes(1);
 });
+
+// If we error, then we should be able to see the error displayed
+test('check error', async () => {
+  const dummyCallback: BuildImageCallback = {
+    onStream: vi.fn(),
+    onError: vi.fn(),
+    onEnd: vi.fn(),
+  };
+
+  const key = startBuild('foo', dummyCallback);
+
+  eventCollect(key.buildImageKey, 'stream', 'hello');
+  eventCollect(key.buildImageKey, 'error', 'world');
+
+  expect(dummyCallback.onStream).toHaveBeenCalledWith('hello');
+  expect(dummyCallback.onError).toHaveBeenCalledWith('world');
+});

--- a/packages/renderer/src/lib/image/build-image-task.ts
+++ b/packages/renderer/src/lib/image/build-image-task.ts
@@ -158,6 +158,8 @@ export function eventCollect(key: symbol, eventName: 'finish' | 'stream' | 'erro
   const task = allTasks.get(key);
   if (task) {
     if (eventName === 'error') {
+      // If we errored out, we should store the error message in the task so it is correctly displayed
+      task.error = data;
       task.status = 'failure';
       task.state = 'completed';
     } else if (eventName === 'finish') {


### PR DESCRIPTION
### What does this PR do?

When building, we did not previously store the error.

This fixes the Task notification by storing the error when we encounter
it within build-image-task.ts

Added tests

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

Closes https://github.com/containers/podman-desktop/issues/3026

### How to test this PR?

1. Purposely build a failing Dockerfile
2. Check Tasks that it shows the error

<!-- Please explain steps to reproduce -->

Signed-off-by: Charlie Drage <charlie@charliedrage.com>

### What does this PR do?

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

### How to test this PR?

<!-- Please explain steps to reproduce -->
