### PR TITLE
chore: pf-empty screen

### DIFF
--- a/packages/renderer/src/lib/container/ContainerDetailsTerminal.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetailsTerminal.svelte
@@ -7,6 +7,8 @@ import { Terminal } from 'xterm';
 import { FitAddon } from 'xterm-addon-fit';
 import 'xterm/css/xterm.css';
 import { getPanelDetailColor } from '../color/color';
+import EmptyScreen from '../ui/EmptyScreen.svelte';
+import NoLogIcon from '../ui/NoLogIcon.svelte';
 
 export let container: ContainerInfoUI;
 let terminalXtermDiv: HTMLDivElement;
@@ -80,14 +82,8 @@ onMount(async () => {
 
 <div class="h-full" bind:this="{terminalXtermDiv}" class:hidden="{container.state !== 'RUNNING'}"></div>
 
-<div class="h-full min-w-full flex flex-col" class:hidden="{container.state === 'RUNNING'}">
-  <div class="pf-c-empty-state h-full">
-    <div class="pf-c-empty-state__content">
-      <i class="fas fa-terminal pf-c-empty-state__icon" aria-hidden="true"></i>
-
-      <h1 class="pf-c-title pf-m-lg">No Terminal</h1>
-
-      <div class="pf-c-empty-state__body">Container is not running</div>
-    </div>
-  </div>
-</div>
+<EmptyScreen
+  hidden="{container.state === 'RUNNING'}"
+  icon="{NoLogIcon}"
+  title="No Terminal"
+  message="Container is not running" />

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationRendering.svelte
@@ -27,6 +27,9 @@ import Markdown from '../markdown/Markdown.svelte';
 import type { Terminal } from 'xterm';
 import type { AuditRequestItems } from '@podman-desktop/api';
 import AuditMessageBox from '../ui/AuditMessageBox.svelte';
+import EmptyScreen from '../ui/EmptyScreen.svelte';
+import { faCubes } from '@fortawesome/free-solid-svg-icons';
+import Button from '../ui/Button.svelte';
 
 export let properties: IConfigurationPropertyRecordedSchema[] = [];
 export let providerInfo: ProviderInfo;
@@ -299,22 +302,16 @@ async function close() {
 
 <div class="flex flex-col w-full h-full overflow-hidden">
   {#if creationSuccessful}
-    <div class="pf-c-empty-state h-full px-6">
-      <div class="pf-c-empty-state__content">
-        <i class="fas fa-cubes pf-c-empty-state__icon" aria-hidden="true"></i>
-        <h1 class="pf-c-title pf-m-lg">Creation</h1>
-        <div class="pf-c-empty-state__body">Successful operation</div>
-        <button
-          on:click="{() => {
-            cleanup();
-            router.goto('/preferences/resources');
-          }}"
-          class="pf-c-button pf-m-primary"
-          type="button">
-          Go back to resources
-        </button>
-      </div>
-    </div>
+    <EmptyScreen icon="{faCubes}" title="Creation" message="Successful operation">
+      <Button
+        class="py-3"
+        on:click="{() => {
+          cleanup();
+          router.goto('/preferences/resources');
+        }}">
+        Go back to resources
+      </Button>
+    </EmptyScreen>
   {:else}
     <div class="my-2 px-6">
       {#if providerInfo?.images?.icon}

--- a/packages/renderer/src/lib/ui/EmptyScreen.svelte
+++ b/packages/renderer/src/lib/ui/EmptyScreen.svelte
@@ -28,42 +28,35 @@ let copyTextDivElement: HTMLDivElement;
 </script>
 
 <div
-  class="h-full min-w-full flex flex-col {$$props.class || ''}"
+  class="flex flex-row w-full h-full justify-center {$$props.class || ''}"
   class:hidden="{hidden}"
   style="{$$props.style}"
   aria-label="{$$props['aria-label']}">
-  <div class="pf-c-empty-state h-full">
-    <div class="pf-c-empty-state__content">
-      <p class="pf-c-empty-state__body">
-        {#if processed}
-          {#if fontAwesomeIcon}
-            <Fa
-              icon="{icon}"
-              size="55"
-              class="cursor-pointer pf-c-empty-state__icon"
-              style="display:inline-block; text-align: center" />
-          {:else}
-            <svelte:component
-              this="{icon}"
-              size="55"
-              class="pf-c-empty-state__icon"
-              style="display:inline-block; text-align: center" />
-          {/if}
+  <div class="flex flex-col h-full justify-center text-center space-y-3">
+    <div class="flex justify-center text-gray-700 py-2">
+      {#if processed}
+        {#if fontAwesomeIcon}
+          <Fa icon="{icon}" size="55" />
+        {:else}
+          <svelte:component this="{icon}" size="55" solid="{false}" />
         {/if}
-      </p>
-      <h1 class="pf-c-title pf-m-lg">{title}</h1>
-      <div class="pf-c-empty-state__body">{message}</div>
-      {#if commandline.length > 0}
-        <div class="flex flex-row bg-charcoal-900 w-full items-center justify-between rounded-sm p-3 mt-4">
-          <div class="font-mono text-gray-400" bind:this="{copyTextDivElement}" data-testid="copyTextDivElement">
-            {commandline}
-          </div>
-          <button title="Copy To Clipboard" class="ml-5" on:click="{() => copyRunInstructionToClipboard()}"
-            ><Fa
-              class="h-5 w-5 cursor-pointer text-xl text-purple-500 hover:text-purple-600"
-              icon="{faPaste}" /></button>
-        </div>
       {/if}
     </div>
+    <h1 class="text-xl">{title}</h1>
+    <span class="text-gray-700">{message}</span>
+    {#if commandline.length > 0}
+      <div class="flex flex-row bg-charcoal-900 items-center justify-between rounded-sm p-3 mt-4">
+        <div class="font-mono text-gray-400" bind:this="{copyTextDivElement}" data-testid="copyTextDivElement">
+          {commandline}
+        </div>
+        <button title="Copy To Clipboard" class="ml-5" on:click="{() => copyRunInstructionToClipboard()}"
+          ><Fa class="h-5 w-5 cursor-pointer text-xl text-purple-500 hover:text-purple-600" icon="{faPaste}" /></button>
+      </div>
+    {/if}
+    {#if $$slots}
+      <div class="py-2">
+        <slot />
+      </div>
+    {/if}
   </div>
 </div>


### PR DESCRIPTION
### What does this PR do?

We have three places where we were using the PF pf-c-empty classes: the EmptyScreen and two places where for I'll assume for historical reasons we weren't using the EmptyScreen. (and in the case of ContainerDetailsTerminal was also using a different terminal icon than all other places)

This replaces the EmptyScreen PF classes with our own, simpler styling that gives the identical look, and updates both of the other instances to use the EmptyScreen component. The connection creation screen needs a button under the text, so I added a slot to the empty screen.

### Screenshot/screencast of this PR

N/A, differences should not be noticeable.

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Create a Podman machine, and visit a few of the other empty screens (e.g. no pods, stopped container for no terminal/logs, or stop extensions to see no images)