### PR TITLE
fix: load compose logs async not await

### DIFF
--- a/packages/renderer/src/lib/compose/ComposeDetailsLogs.spec.ts
+++ b/packages/renderer/src/lib/compose/ComposeDetailsLogs.spec.ts
@@ -1,0 +1,65 @@
+import '@testing-library/jest-dom';
+import { test, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import { mockBreadcrumb } from '../../stores/breadcrumb';
+import ComposeDetailsLogs from './ComposeDetailsLogs.svelte';
+import type { ComposeInfoUI } from './ComposeInfoUI';
+import { ContainerGroupInfoTypeUI, type ContainerInfoUI } from '../container/ContainerInfoUI';
+
+vi.mock('xterm', () => {
+  return {
+    Terminal: vi.fn().mockReturnValue({ loadAddon: vi.fn(), open: vi.fn(), write: vi.fn(), clear: vi.fn() }),
+  };
+});
+
+beforeAll(() => {
+  (window as any).getConfigurationValue = vi.fn();
+  (window as any).ResizeObserver = vi.fn().mockReturnValue({ observe: vi.fn(), unobserve: vi.fn() });
+  (window as any).telemetryPage = vi.fn().mockResolvedValue(undefined);
+  (window as any).logsContainer = vi.fn().mockResolvedValue(undefined);
+  (window as any).refreshTerminal = vi.fn();
+  mockBreadcrumb();
+});
+
+const containerInfoUIMock: ContainerInfoUI = {
+  id: 'foobar',
+  shortId: 'foobar',
+  name: 'foobar',
+  image: 'foobar',
+  shortImage: 'foobar',
+  engineId: 'foobar',
+  engineName: 'foobar',
+  engineType: 'podman',
+  state: 'running',
+  uptime: 'foobar',
+  startedAt: 'foobar',
+  ports: [],
+  portsAsString: 'foobar',
+  displayPort: 'foobar',
+  command: 'foobar',
+  hasPublicPort: false,
+  groupInfo: {
+    name: 'foobar',
+    type: ContainerGroupInfoTypeUI.COMPOSE,
+  },
+  selected: false,
+  created: 0,
+  labels: {},
+};
+
+const composeInfoUIMock: ComposeInfoUI = {
+  engineId: 'foobar',
+  engineType: 'podman',
+  name: 'foobar',
+  status: 'running',
+  containers: [containerInfoUIMock],
+};
+
+test('Render compose logs and expect EmptyScreen and no loading via logsContainer', async () => {
+  // Mock compose has no containers, so expect No Log to appear
+  render(ComposeDetailsLogs, { compose: composeInfoUIMock });
+
+  // Expect no logs since we mock logs
+  const heading = screen.getByRole('heading', { name: 'No Log' });
+  expect(heading).toBeInTheDocument();
+});


### PR DESCRIPTION
fix: load compose logs async not await

### What does this PR do?

* Loads all the compose containers asynchronously rather than using await.
* Adds simple tests for No logs, however, will have to add integration
  test for loading logs correcctly

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


https://github.com/containers/podman-desktop/assets/6422176/3fb4556f-9746-45d3-91a7-23877f7c1ced



### What issues does this PR fix or reference?

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

Closes https://github.com/containers/podman-desktop/issues/3349

### How to test this PR?

<!-- Please explain steps to reproduce -->

1. Test using Docker Compose example: https://gist.githubusercontent.com/benoitf/a94cff3545cb0992007dd1fc58287816/raw/d0b33311834d84ec1d6830b32a167af80c84926e/docker-compose-example.yaml
2. Compose logs will appear asynchronously now / while podman desktop
   retrieves the logs, rather than await for each container

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
