### PR TITLE
fix: only delete selected pods

### DIFF
--- a/packages/renderer/src/lib/ContainerList.svelte
+++ b/packages/renderer/src/lib/ContainerList.svelte
@@ -151,7 +151,9 @@ function toggleCheckboxContainerGroup(checked: boolean, containerGroup: Containe
 let bulkDeleteInProgress = false;
 async function deleteSelectedContainers() {
   // delete pods first if any
-  const podGroups = containerGroups.filter(group => group.type === ContainerGroupInfoTypeUI.POD);
+  const podGroups = containerGroups
+    .filter(group => group.type === ContainerGroupInfoTypeUI.POD)
+    .filter(pod => pod.selected);
   if (podGroups.length > 0) {
     await Promise.all(
       podGroups.map(async podGroup => {
@@ -163,7 +165,7 @@ async function deleteSelectedContainers() {
       }),
     );
   }
-  // then containers (that are no inside a pod)
+  // then containers (that are not inside a pod)
   const selectedContainers = containerGroups
     .filter(group => group.type !== ContainerGroupInfoTypeUI.POD)
     .map(group => group.containers)


### PR DESCRIPTION
### What does this PR do?

PR #2979 caused an unfortunate regression - it is missing the filter to only delete *selected* pods.

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

Fixes #3374.

### How to test this PR?

Create at least one pod and a container. Select just the container in the Containers list and delete it from the toolbar Delete action, making sure the pod doesn't get deleted as well.