### PR TITLE
fix: missing checkbox tooltips

### DIFF
--- a/packages/renderer/src/lib/ContainerList.svelte
+++ b/packages/renderer/src/lib/ContainerList.svelte
@@ -449,6 +449,7 @@ function errorCallback(container: ContainerInfoUI, errorMessage: string): void {
               </td>
               <td class="px-2">
                 <Checkbox
+                  title="Toggle {containerGroup.type}"
                   bind:checked="{containerGroup.selected}"
                   on:click="{event => toggleCheckboxContainerGroup(event.detail, containerGroup)}" />
               </td>
@@ -528,7 +529,7 @@ function errorCallback(container: ContainerInfoUI, errorMessage: string): void {
                     : ''}">
                 </td>
                 <td class="px-2">
-                  <Checkbox bind:checked="{container.selected}" />
+                  <Checkbox title="Toggle container" bind:checked="{container.selected}" />
                 </td>
                 <td class="flex flex-row justify-center h-12">
                   <div class="grid place-content-center ml-3 mr-4">

--- a/packages/renderer/src/lib/ImagesList.svelte
+++ b/packages/renderer/src/lib/ImagesList.svelte
@@ -259,6 +259,7 @@ function computeInterval(): number {
           <th class="whitespace-nowrap w-5"></th>
           <th class="px-2 w-5">
             <Checkbox
+              title="Toggle all"
               bind:checked="{selectedAllCheckboxes}"
               indeterminate="{selectedItemsNumber > 0 && !selectedAllCheckboxes}"
               on:click="{event => toggleAllImages(event.detail)}" />
@@ -276,6 +277,7 @@ function computeInterval(): number {
             <td class="rounded-tl-lg rounded-bl-lg w-5"> </td>
             <td class="px-2">
               <Checkbox
+                title="Toggle image"
                 bind:checked="{image.selected}"
                 disabled="{image.inUse}"
                 disabledTooltip="Image is used by a container" />

--- a/packages/renderer/src/lib/pod/PodsList.svelte
+++ b/packages/renderer/src/lib/pod/PodsList.svelte
@@ -225,6 +225,7 @@ function errorCallback(pod: PodInfoUI, errorMessage: string): void {
           <th class="whitespace-nowrap w-5"></th>
           <th class="px-2 w-5">
             <Checkbox
+              title="Toggle all"
               bind:checked="{selectedAllCheckboxes}"
               indeterminate="{selectedItemsNumber > 0 && !selectedAllCheckboxes}"
               on:click="{checked => toggleAllPods(checked.detail)}" />
@@ -240,7 +241,7 @@ function errorCallback(pod: PodInfoUI, errorMessage: string): void {
           <tr class="group h-12 bg-charcoal-800 hover:bg-zinc-700">
             <td class="rounded-tl-lg rounded-bl-lg w-5"> </td>
             <td class="px-2">
-              <Checkbox bind:checked="{pod.selected}" />
+              <Checkbox title="Toggle pod" bind:checked="{pod.selected}" />
             </td>
             <td class="bg-charcoal-800 group-hover:bg-zinc-700 flex flex-row justify-center h-12">
               <div class="grid place-content-center ml-3 mr-4">

--- a/packages/renderer/src/lib/ui/Checkbox.spec.ts
+++ b/packages/renderer/src/lib/ui/Checkbox.spec.ts
@@ -1,0 +1,78 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import '@testing-library/jest-dom';
+import { test, expect } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import Checkbox from './Checkbox.svelte';
+
+function getPeer(checkbox: HTMLElement) {
+  return checkbox.parentElement.children[1];
+}
+
+test('Basic check', async () => {
+  render(Checkbox);
+
+  // check element exists and is enabled
+  const checkbox = screen.getByRole('checkbox');
+  expect(checkbox).toBeInTheDocument();
+  expect(checkbox).toBeEnabled();
+});
+
+test('Check disabled state', async () => {
+  render(Checkbox, { disabled: true });
+
+  // check element is disabled
+  const checkbox = screen.getByRole('checkbox');
+  expect(checkbox).toBeInTheDocument();
+  expect(checkbox).toBeDisabled();
+
+  // check the peer, since we do our own styling
+  const peer = getPeer(checkbox);
+  expect(peer).toBeInTheDocument();
+  expect(peer).toHaveClass('cursor-not-allowed');
+});
+
+test('Check tooltips', async () => {
+  const title = 'My title';
+  render(Checkbox, { title: title });
+
+  // check for one element of the styling
+  const checkbox = screen.getByRole('checkbox');
+  expect(checkbox).toBeInTheDocument();
+
+  // check the peer, since we do our own styling
+  const peer = getPeer(checkbox);
+  expect(peer).toBeInTheDocument();
+  expect(peer).toHaveAttribute('title', title);
+});
+
+test('Check disabled tooltips', async () => {
+  const title = 'My disabled tooltip';
+  render(Checkbox, { disabled: true, disabledTooltip: title });
+
+  const checkbox = screen.getByRole('checkbox');
+  expect(checkbox).toBeInTheDocument();
+
+  // check the peer, since we do our own styling
+  const peer = getPeer(checkbox);
+  expect(peer).toBeInTheDocument();
+  expect(peer).toHaveAttribute('title', title);
+});

--- a/packages/renderer/src/lib/ui/Checkbox.svelte
+++ b/packages/renderer/src/lib/ui/Checkbox.svelte
@@ -27,7 +27,7 @@ function onClick(checked: boolean) {
     on:click="{event => onClick(event.currentTarget.checked)}" />
   <div
     class="grid place-content-center"
-    title="{disabled ? disabledTooltip : ''}"
+    title="{disabled ? disabledTooltip : title}"
     class:cursor-pointer="{!disabled}"
     class:cursor-not-allowed="{disabled}">
     {#if disabled}

--- a/packages/renderer/src/lib/volume/VolumesList.svelte
+++ b/packages/renderer/src/lib/volume/VolumesList.svelte
@@ -215,6 +215,7 @@ function computeInterval(): number {
           <th class="whitespace-nowrap w-5"></th>
           <th class="px-2 w-5">
             <Checkbox
+              title="Toggle all"
               bind:checked="{selectedAllCheckboxes}"
               indeterminate="{selectedItemsNumber > 0 && !selectedAllCheckboxes}"
               on:click="{event => toggleAllVolumes(event.detail)}" />
@@ -232,6 +233,7 @@ function computeInterval(): number {
             <td class="rounded-tl-lg rounded-bl-lg w-5"> </td>
             <td class="px-2">
               <Checkbox
+                title="Toggle volume"
                 bind:checked="{volume.selected}"
                 disabled="{volume.inUse}"
                 disabledTooltip="Volume is used by a container" />


### PR DESCRIPTION
### What does this PR do?

The Container list had a title (tooltip) for the checkbox that toggles everything, but it wasn't visible. This fixes that tooltip and adds consistent tooltips to the checkboxes in all four lists (Container, Image, Pod, Volume).

### Screenshot/screencast of this PR

N/A, just adds tooltips

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Check tooltips on the checkboxes on all four pages.