### PR TITLE
chore: allow to handle extensions call for execution into a VM/container

### DIFF
--- a/packages/main/src/plugin/docker-extension/docker-plugin-adapter.spec.ts
+++ b/packages/main/src/plugin/docker-extension/docker-plugin-adapter.spec.ts
@@ -1,0 +1,367 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { DockerPluginAdapter } from './docker-plugin-adapter.js';
+import type { ContributionManager } from '../contribution-manager.js';
+import type { ContainerProviderRegistry } from '../container-registry.js';
+import type { SimpleContainerInfo } from '../api/container-info.js';
+import type { IpcMainEvent } from 'electron';
+
+let dockerPluginAdapter: TestDockerPluginAdapter;
+
+vi.mock('electron', () => {
+  const mockIpcMain = {
+    on: vi.fn().mockReturnThis(),
+  };
+  return { ipcMain: mockIpcMain };
+});
+
+const contributionManager = {} as unknown as ContributionManager;
+
+class TestDockerPluginAdapter extends DockerPluginAdapter {
+  async getVmServiceContainer(contributionId: string): Promise<SimpleContainerInfo> {
+    return super.getVmServiceContainer(contributionId);
+  }
+}
+
+const listSimpleContainersMock = vi.fn();
+const execInContainerMock = vi.fn();
+const containerProviderRegistry = {
+  listSimpleContainers: listSimpleContainersMock,
+  execInContainer: execInContainerMock,
+} as unknown as ContainerProviderRegistry;
+
+beforeAll(async () => {
+  dockerPluginAdapter = new TestDockerPluginAdapter(contributionManager, containerProviderRegistry);
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('getVmServiceContainer', async () => {
+  test('Check getVmServiceContainer being found', async () => {
+    const container1 = {
+      Labels: {},
+    };
+
+    // another app
+    const container2 = {
+      Labels: {
+        'io.podman_desktop.PodmanDesktop.extensionName': 'fooBar',
+      },
+    };
+    const extensionName = 'myExtension';
+
+    // 2 plugins, only one is the VM service container
+    const pluginContainer1 = {
+      Labels: {
+        'io.podman_desktop.PodmanDesktop.extensionName': extensionName,
+      },
+    };
+    // this is the container being used as service container
+    const pluginServiceContainer2 = {
+      Labels: {
+        'io.podman_desktop.PodmanDesktop.extensionName': extensionName,
+        'io.podman_desktop.PodmanDesktop.vm-service': 'true',
+      },
+    };
+
+    listSimpleContainersMock.mockResolvedValueOnce([container1, container2, pluginContainer1, pluginServiceContainer2]);
+
+    const result = await dockerPluginAdapter.getVmServiceContainer('myExtension');
+    expect(result).toBeDefined();
+    expect(result).toEqual(pluginServiceContainer2);
+  });
+
+  test('Check getVmServiceContainer app not found', async () => {
+    const container1 = {
+      Labels: {},
+    };
+
+    // another app
+    const container2 = {
+      Labels: {
+        'io.podman_desktop.PodmanDesktop.extensionName': 'fooBar',
+      },
+    };
+    const extensionName = 'myExtension';
+
+    // 2 plugins, only one is the VM service container
+    const pluginContainer1 = {
+      Labels: {
+        'io.podman_desktop.PodmanDesktop.extensionName': extensionName,
+      },
+    };
+    // this is the container being used as service container
+    const pluginServiceContainer2 = {
+      Labels: {
+        'io.podman_desktop.PodmanDesktop.extensionName': extensionName,
+        'io.podman_desktop.PodmanDesktop.vm-service': 'true',
+      },
+    };
+
+    listSimpleContainersMock.mockResolvedValueOnce([container1, container2, pluginContainer1, pluginServiceContainer2]);
+
+    await expect(dockerPluginAdapter.getVmServiceContainer('anotherApp')).rejects.toThrowError(
+      `No container having the label 'io.podman_desktop.PodmanDesktop.extensionName'`,
+    );
+  });
+
+  test('Check getVmServiceContainer vm service not found', async () => {
+    const container1 = {
+      Labels: {},
+    };
+
+    // another app
+    const container2 = {
+      Labels: {
+        'io.podman_desktop.PodmanDesktop.extensionName': 'fooBar',
+      },
+    };
+    const extensionName = 'myExtension';
+
+    // 2 plugins, only one is the VM service container
+    const pluginContainer1 = {
+      Labels: {
+        'io.podman_desktop.PodmanDesktop.extensionName': extensionName,
+      },
+    };
+    // this is the container being used as service container
+    const pluginServiceContainer2 = {
+      Labels: {
+        'io.podman_desktop.PodmanDesktop.extensionName': extensionName,
+        'io.podman_desktop.PodmanDesktop.vm-service': 'false',
+      },
+    };
+
+    listSimpleContainersMock.mockResolvedValueOnce([container1, container2, pluginContainer1, pluginServiceContainer2]);
+
+    await expect(dockerPluginAdapter.getVmServiceContainer('myExtension')).rejects.toThrowError(
+      `No container having the label 'io.podman_desktop.PodmanDesktop.vm-service' == 'true' found.`,
+    );
+  });
+});
+
+describe('handle exec', async () => {
+  test('handle exec inside the VM', async () => {
+    const extensionName = 'myExtension';
+
+    // this is the container being used as service container
+    const pluginServiceContainer = {
+      Labels: {
+        'io.podman_desktop.PodmanDesktop.extensionName': extensionName,
+        'io.podman_desktop.PodmanDesktop.vm-service': 'true',
+      },
+    } as unknown as SimpleContainerInfo;
+
+    const spyGetVmServiceContainer = vi.spyOn(dockerPluginAdapter, 'getVmServiceContainer');
+    spyGetVmServiceContainer.mockResolvedValueOnce(pluginServiceContainer);
+
+    // mock execution
+    execInContainerMock.mockImplementation(
+      async (
+        _engineId: string,
+        _id: string,
+        _command: string[],
+        onStdout: (data: Buffer) => void,
+        onStderr: (data: Buffer) => void,
+      ) => {
+        // write hello world as stdout
+        onStdout(Buffer.from('hello\n'));
+        onStdout(Buffer.from('world\n'));
+
+        // write warning as stderr
+        onStderr(Buffer.from('warning: text1\n'));
+        onStderr(Buffer.from('warning: text2\n'));
+      },
+    );
+
+    const result = await dockerPluginAdapter.handleExec(extensionName, 'VM_SERVICE', 'echo', ['hello', 'world']);
+    expect(result.code).toEqual(0);
+
+    expect(result.stdout).toEqual('hello\nworld\n');
+    expect(result.stderr).toEqual('warning: text1\nwarning: text2\n');
+  });
+
+  test('handle exec with error inside the VM', async () => {
+    const extensionName = 'myExtension';
+
+    // this is the container being used as service container
+    const pluginServiceContainer = {
+      Labels: {
+        'io.podman_desktop.PodmanDesktop.extensionName': extensionName,
+        'io.podman_desktop.PodmanDesktop.vm-service': 'true',
+      },
+    } as unknown as SimpleContainerInfo;
+
+    const spyGetVmServiceContainer = vi.spyOn(dockerPluginAdapter, 'getVmServiceContainer');
+    spyGetVmServiceContainer.mockResolvedValueOnce(pluginServiceContainer);
+
+    // mock execution
+    execInContainerMock.mockImplementation(
+      async (
+        _engineId: string,
+        _id: string,
+        _command: string[],
+        _onStdout: (data: Buffer) => void,
+        _onStderr: (data: Buffer) => void,
+      ) => {
+        throw new Error('This is a test error');
+      },
+    );
+
+    const result = await dockerPluginAdapter.handleExec(extensionName, 'VM_SERVICE', 'echo', ['hello', 'world']);
+    expect(result.code).toEqual(1);
+
+    expect(result.stdout).toEqual('');
+    expect(result.signal).toEqual('Error: This is a test error');
+  });
+});
+
+describe('handle execWithOptions', async () => {
+  test('handle execWithOptions inside the VM', async () => {
+    const extensionName = 'myExtension';
+
+    // this is the container being used as service container
+    const pluginServiceContainer = {
+      Labels: {
+        'io.podman_desktop.PodmanDesktop.extensionName': extensionName,
+        'io.podman_desktop.PodmanDesktop.vm-service': 'true',
+      },
+    } as unknown as SimpleContainerInfo;
+
+    const spyGetVmServiceContainer = vi.spyOn(dockerPluginAdapter, 'getVmServiceContainer');
+    spyGetVmServiceContainer.mockResolvedValueOnce(pluginServiceContainer);
+
+    // mock execution
+    execInContainerMock.mockImplementation(
+      async (
+        _engineId: string,
+        _id: string,
+        _command: string[],
+        onStdout: (data: Buffer) => void,
+        onStderr: (data: Buffer) => void,
+      ) => {
+        // write hello world as stdout
+        onStdout(Buffer.from('hello'));
+        onStdout(Buffer.from('world\n'));
+
+        // write warning as stderr
+        onStderr(Buffer.from('warning: text1\n'));
+        onStderr(Buffer.from('warning: text2\n'));
+      },
+    );
+
+    const replyMock = vi.fn();
+    const ipcMainEventMock = {
+      reply: replyMock,
+    } as unknown as IpcMainEvent;
+
+    const callbackId = 123;
+
+    await dockerPluginAdapter.handleExecWithOptions(
+      ipcMainEventMock,
+      extensionName,
+      'VM_SERVICE',
+      'echo',
+      callbackId,
+      {},
+      ['hello', 'world'],
+    );
+
+    // check event reply
+
+    expect(replyMock).toHaveBeenNthCalledWith(
+      1,
+      'docker-plugin-adapter:execWithOptions-callback-stdout',
+      callbackId,
+      Buffer.from('hello'),
+    );
+    expect(replyMock).toHaveBeenNthCalledWith(
+      2,
+      'docker-plugin-adapter:execWithOptions-callback-stdout',
+      callbackId,
+      Buffer.from('world\n'),
+    );
+
+    expect(replyMock).toHaveBeenNthCalledWith(
+      3,
+      'docker-plugin-adapter:execWithOptions-callback-stderr',
+      callbackId,
+      Buffer.from('warning: text1\n'),
+    );
+    expect(replyMock).toHaveBeenNthCalledWith(
+      4,
+      'docker-plugin-adapter:execWithOptions-callback-stderr',
+      callbackId,
+      Buffer.from('warning: text2\n'),
+    );
+
+    expect(replyMock).toHaveBeenNthCalledWith(5, 'docker-plugin-adapter:execWithOptions-callback-close', callbackId, 0);
+  });
+
+  test('handle execWithOptions inside the VM with error', async () => {
+    const error = new Error('custom error');
+    const extensionName = 'myExtension';
+
+    // this is the container being used as service container
+    const pluginServiceContainer = {
+      Labels: {
+        'io.podman_desktop.PodmanDesktop.extensionName': extensionName,
+        'io.podman_desktop.PodmanDesktop.vm-service': 'true',
+      },
+    } as unknown as SimpleContainerInfo;
+
+    const spyGetVmServiceContainer = vi.spyOn(dockerPluginAdapter, 'getVmServiceContainer');
+    spyGetVmServiceContainer.mockResolvedValueOnce(pluginServiceContainer);
+
+    // mock execution
+    execInContainerMock.mockImplementation(() => {
+      throw error;
+    });
+
+    const replyMock = vi.fn();
+    const ipcMainEventMock = {
+      reply: replyMock,
+    } as unknown as IpcMainEvent;
+
+    const callbackId = 123;
+
+    await dockerPluginAdapter.handleExecWithOptions(
+      ipcMainEventMock,
+      extensionName,
+      'VM_SERVICE',
+      'echo',
+      callbackId,
+      {},
+      ['hello', 'world'],
+    );
+
+    // check event reply with error and close
+    expect(replyMock).toHaveBeenNthCalledWith(
+      1,
+      'docker-plugin-adapter:execWithOptions-callback-error',
+      callbackId,
+      error,
+    );
+    expect(replyMock).toHaveBeenNthCalledWith(2, 'docker-plugin-adapter:execWithOptions-callback-close', callbackId, 1);
+  });
+});

--- a/packages/main/src/plugin/docker-extension/docker-plugin-adapter.ts
+++ b/packages/main/src/plugin/docker-extension/docker-plugin-adapter.ts
@@ -4,6 +4,8 @@ import { ipcMain } from 'electron';
 import * as os from 'node:os';
 import { spawn } from 'child_process';
 import type { ContributionManager } from '../contribution-manager.js';
+import type { ContainerProviderRegistry } from '../container-registry.js';
+import type { SimpleContainerInfo } from '../api/container-info.js';
 
 export interface RawExecResult {
   cmd?: string;
@@ -17,7 +19,7 @@ export interface RawExecResult {
 export class DockerPluginAdapter {
   static MACOS_EXTRA_PATH = '/usr/local/bin:/opt/homebrew/bin:/opt/local/bin:/opt/podman/bin';
 
-  constructor(private contributionManager: ContributionManager) {}
+  constructor(private contributionManager: ContributionManager, private containerRegistry: ContainerProviderRegistry) {}
 
   filterDockerArgs(cmd: string, args: string[]): string[] {
     // filter out the "-v", "/var/run/docker.sock:/var/run/docker.sock" from args
@@ -49,70 +51,241 @@ export class DockerPluginAdapter {
     }
   }
 
+  protected async getVmServiceContainer(contributionId: string): Promise<SimpleContainerInfo> {
+    // found the matching container
+
+    const containers = await this.containerRegistry.listSimpleContainers();
+
+    // filter all containers for this extension (matching 'io.podman_desktop.PodmanDesktop.extensionName' === extensionName)
+    const matchingContainers = containers.filter(
+      container => container.Labels['io.podman_desktop.PodmanDesktop.extensionName'] === contributionId,
+    );
+
+    if (matchingContainers.length === 0) {
+      throw new Error(
+        `No container having the label 'io.podman_desktop.PodmanDesktop.extensionName' == ${contributionId} found.`,
+      );
+    }
+
+    // get the matching container having label 'io.podman_desktop.PodmanDesktop.vm-service'] = 'true';'
+    const vmServiceContainer = matchingContainers.find(
+      container => container.Labels['io.podman_desktop.PodmanDesktop.vm-service'] === 'true',
+    );
+
+    if (!vmServiceContainer) {
+      throw new Error(`No container having the label 'io.podman_desktop.PodmanDesktop.vm-service' == 'true' found.`);
+    }
+    return vmServiceContainer;
+  }
+
+  async handleExec(
+    contributionId: string,
+    launcher: string | undefined,
+    cmd: string,
+    args: string[],
+  ): Promise<RawExecResult> {
+    const execResult: RawExecResult = {
+      cmd,
+      stdout: '',
+      stderr: '',
+    };
+
+    // in case of VM_SERVICE, we need to execute the command in the container
+    if (launcher === 'VM_SERVICE') {
+      const vmServiceContainer = await this.getVmServiceContainer(contributionId);
+
+      // ok we do have the container, let's execute the command in it
+      const containerId = vmServiceContainer.Id;
+      const engineId = vmServiceContainer.engineId;
+
+      // merge command and args
+      const fullCommandLine = [cmd, ...args];
+
+      return new Promise(resolve => {
+        const onStdout = (data: Buffer) => {
+          execResult.stdout += data.toString();
+        };
+        const onStderr = (data: Buffer) => {
+          execResult.stderr += data.toString();
+        };
+
+        this.containerRegistry
+          .execInContainer(engineId, containerId, fullCommandLine, onStdout, onStderr)
+          .then(() => {
+            execResult.code = 0;
+            resolve(execResult);
+          })
+          .catch((error: unknown) => {
+            console.log('got error', error);
+            execResult.code = 1;
+            execResult.killed = true;
+            execResult.signal = String(error);
+            resolve(execResult);
+          });
+      });
+    }
+
+    const env = process.env;
+    if (os.platform() === 'darwin' && env.PATH) {
+      env.PATH = env.PATH.concat(':').concat(DockerPluginAdapter.MACOS_EXTRA_PATH);
+    }
+
+    // In production mode, applications don't have access to the 'user' path like brew
+    return new Promise(resolve => {
+      // need to add launcher as command and we move command as the first arg
+      let updatedCommand;
+      let updatedArgs;
+      if (launcher) {
+        updatedCommand = launcher;
+        updatedArgs = this.filterDockerArgs(cmd, args);
+      } else {
+        this.addExtraPathToEnv(contributionId, env);
+        updatedCommand = cmd;
+        updatedArgs = args;
+      }
+
+      const spawnProcess = spawn(updatedCommand, updatedArgs, { env, shell: true });
+      spawnProcess.stdout.setEncoding('utf8');
+      spawnProcess.stdout.on('data', data => {
+        execResult.stdout += data;
+      });
+      spawnProcess.stderr.setEncoding('utf8');
+      spawnProcess.stderr.on('data', data => {
+        execResult.stderr += data;
+      });
+
+      spawnProcess.on('close', code => {
+        if (code) {
+          execResult.code = code;
+        } else {
+          execResult.code = 0;
+        }
+
+        resolve(execResult);
+      });
+      spawnProcess.on('error', error => {
+        execResult.killed = true;
+        execResult.signal = error.toString();
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (error as any).stderr = execResult.stderr;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (error as any).stdout = execResult.stdout;
+        resolve(error as unknown as RawExecResult);
+      });
+    });
+  }
+
+  async handleExecWithOptions(
+    event: IpcMainEvent,
+    contributionId: string,
+    launcher: string | undefined,
+    cmd: string,
+    streamCallbackId: number,
+    options: { splitOutputLines?: boolean },
+    args: string[],
+  ): Promise<void> {
+    // in case of VM_SERVICE, we need to execute the command in the container
+    if (launcher === 'VM_SERVICE') {
+      // found the matching container
+
+      const vmServiceContainer = await this.getVmServiceContainer(contributionId);
+
+      // ok we do have the container, let's execute the command in it
+      const containerId = vmServiceContainer.Id;
+      const engineId = vmServiceContainer.engineId;
+
+      // merge command and args
+      const fullCommandLine = [cmd, ...args];
+
+      const onStdout = (data: Buffer) => {
+        event.reply('docker-plugin-adapter:execWithOptions-callback-stdout', streamCallbackId, data);
+      };
+      const onStderr = (data: Buffer) => {
+        event.reply('docker-plugin-adapter:execWithOptions-callback-stderr', streamCallbackId, data);
+      };
+
+      try {
+        await this.containerRegistry.execInContainer(engineId, containerId, fullCommandLine, onStdout, onStderr);
+        event.reply('docker-plugin-adapter:execWithOptions-callback-close', streamCallbackId, 0);
+      } catch (error) {
+        event.reply('docker-plugin-adapter:execWithOptions-callback-error', streamCallbackId, error);
+        event.reply('docker-plugin-adapter:execWithOptions-callback-close', streamCallbackId, 1);
+      }
+      return;
+    }
+
+    // need to add launcher as command and we move command as the first arg
+    let updatedCommand;
+    let updatedArgs;
+    const env = process.env;
+    if (os.platform() === 'darwin' && env.PATH) {
+      env.PATH = env.PATH.concat(':').concat(DockerPluginAdapter.MACOS_EXTRA_PATH);
+    }
+    if (launcher) {
+      updatedCommand = launcher;
+      updatedArgs = this.filterDockerArgs(cmd, args);
+    } else {
+      this.addExtraPathToEnv(contributionId, env);
+
+      updatedCommand = cmd;
+      updatedArgs = args;
+    }
+
+    const spawnProcess = spawn(updatedCommand, updatedArgs, { env });
+
+    let isSplitOutputLines = false;
+    if (options.splitOutputLines) {
+      isSplitOutputLines = true;
+    }
+
+    let stdoutLines = '';
+    spawnProcess.stdout.setEncoding('utf8');
+    spawnProcess.stdout.on('data', (data: string) => {
+      if (!isSplitOutputLines) {
+        // send back the data
+        event.reply('docker-plugin-adapter:execWithOptions-callback-stdout', streamCallbackId, data);
+      } else {
+        // append the text
+        stdoutLines += data;
+
+        // iterate on each newLine
+        let index = stdoutLines.indexOf('\n');
+        while (index >= 0) {
+          // we do have newlines
+          const line = stdoutLines.substring(0, index);
+          stdoutLines = stdoutLines.substring(index + 1);
+          event.reply('docker-plugin-adapter:execWithOptions-callback-stdout', streamCallbackId, line);
+
+          // update index
+          index = stdoutLines.indexOf('\n');
+        }
+      }
+    });
+    spawnProcess.stderr.setEncoding('utf8');
+    spawnProcess.stderr.on('data', data => {
+      // send back the data
+      event.reply('docker-plugin-adapter:execWithOptions-callback-stderr', streamCallbackId, data);
+    });
+
+    spawnProcess.on('close', code => {
+      event.reply('docker-plugin-adapter:execWithOptions-callback-close', streamCallbackId, code);
+    });
+    spawnProcess.on('error', error => {
+      event.reply('docker-plugin-adapter:execWithOptions-callback-error', streamCallbackId, error);
+    });
+  }
+
   init() {
     ipcMain.handle(
       'docker-plugin-adapter:exec',
-      (
+      async (
         event: IpcMainInvokeEvent,
         contributionId: string,
         launcher: string | undefined,
         cmd: string,
         args: string[],
       ): Promise<unknown> => {
-        const execResult: RawExecResult = {
-          cmd,
-          stdout: '',
-          stderr: '',
-        };
-
-        const env = process.env;
-        if (os.platform() === 'darwin' && env.PATH) {
-          env.PATH = env.PATH.concat(':').concat(DockerPluginAdapter.MACOS_EXTRA_PATH);
-        }
-
-        // In production mode, applications don't have access to the 'user' path like brew
-        return new Promise(resolve => {
-          // need to add launcher as command and we move command as the first arg
-          let updatedCommand;
-          let updatedArgs;
-          if (launcher) {
-            updatedCommand = launcher;
-            updatedArgs = this.filterDockerArgs(cmd, args);
-          } else {
-            this.addExtraPathToEnv(contributionId, env);
-            updatedCommand = cmd;
-            updatedArgs = args;
-          }
-
-          const spawnProcess = spawn(updatedCommand, updatedArgs, { env, shell: true });
-          spawnProcess.stdout.setEncoding('utf8');
-          spawnProcess.stdout.on('data', data => {
-            execResult.stdout += data;
-          });
-          spawnProcess.stderr.setEncoding('utf8');
-          spawnProcess.stderr.on('data', data => {
-            execResult.stderr += data;
-          });
-
-          spawnProcess.on('close', code => {
-            if (code) {
-              execResult.code = code;
-            } else {
-              execResult.code = 0;
-            }
-
-            resolve(execResult);
-          });
-          spawnProcess.on('error', error => {
-            execResult.killed = true;
-            execResult.signal = error.toString();
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            (error as any).stderr = execResult.stderr;
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            (error as any).stdout = execResult.stdout;
-            resolve(error);
-          });
-        });
+        return this.handleExec(contributionId, launcher, cmd, args);
       },
     );
 
@@ -125,44 +298,13 @@ export class DockerPluginAdapter {
         cmd: string,
         streamCallbackId: number,
         options: { splitOutputLines?: boolean },
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        args: any[],
+        args: string[],
       ): void => {
-        // need to add launcher as command and we move command as the first arg
-        let updatedCommand;
-        let updatedArgs;
-        const env = process.env;
-        if (os.platform() === 'darwin' && env.PATH) {
-          env.PATH = env.PATH.concat(':').concat(DockerPluginAdapter.MACOS_EXTRA_PATH);
-        }
-        if (launcher) {
-          updatedCommand = launcher;
-          updatedArgs = this.filterDockerArgs(cmd, args);
-        } else {
-          this.addExtraPathToEnv(contributionId, env);
-
-          updatedCommand = cmd;
-          updatedArgs = args;
-        }
-
-        const spawnProcess = spawn(updatedCommand, updatedArgs, { env });
-        spawnProcess.stdout.setEncoding('utf8');
-        spawnProcess.stdout.on('data', data => {
-          // send back the data
-          event.reply('docker-plugin-adapter:execWithOptions-callback-stdout', streamCallbackId, data);
-        });
-        spawnProcess.stderr.setEncoding('utf8');
-        spawnProcess.stderr.on('data', data => {
-          // send back the data
-          event.reply('docker-plugin-adapter:execWithOptions-callback-stderr', streamCallbackId, data);
-        });
-
-        spawnProcess.on('close', code => {
-          event.reply('docker-plugin-adapter:execWithOptions-callback-close', streamCallbackId, code);
-        });
-        spawnProcess.on('error', error => {
-          event.reply('docker-plugin-adapter:execWithOptions-callback-error', streamCallbackId, error);
-        });
+        this.handleExecWithOptions(event, contributionId, launcher, cmd, streamCallbackId, options, args).catch(
+          (error: unknown) => {
+            event.reply('docker-plugin-adapter:execWithOptions-callback-error', streamCallbackId, error);
+          },
+        );
       },
     );
   }

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1726,7 +1726,7 @@ export class PluginSystem {
     );
     await dockerDesktopInstallation.init();
 
-    const dockerExtensionAdapter = new DockerPluginAdapter(contributionManager);
+    const dockerExtensionAdapter = new DockerPluginAdapter(contributionManager, containerProviderRegistry);
     dockerExtensionAdapter.init();
 
     const extensionInstaller = new ExtensionInstaller(


### PR DESCRIPTION
### What does this PR do?
Add remote calls to handle exec and execOptions into a container
it's just delegating the calls to containerRegistry.execInContainer

it intercepts calls to delegate by looking at the launcher
`if (launcher === 'VM_SERVICE') {`

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?

part of #2397

### How to test this PR?

Unit tests added