### PR TITLE
fix: default last page

### DIFF
--- a/packages/renderer/src/stores/breadcrumb.ts
+++ b/packages/renderer/src/stores/breadcrumb.ts
@@ -20,11 +20,12 @@ import type { Writable } from 'svelte/store';
 import { writable } from 'svelte/store';
 import type { TinroBreadcrumb } from 'tinro';
 
-export const currentPage: Writable<TinroBreadcrumb> = writable({ name: 'Unknown', path: '/' } as TinroBreadcrumb);
-export const lastPage: Writable<TinroBreadcrumb> = writable({ name: 'Unknown', path: '/' } as TinroBreadcrumb);
+const home = { name: 'Home', path: '/' } as TinroBreadcrumb;
+export const currentPage: Writable<TinroBreadcrumb> = writable(home);
+export const lastPage: Writable<TinroBreadcrumb> = writable(home);
 
-export const listPage: Writable<TinroBreadcrumb> = writable();
-export const detailsPage: Writable<TinroBreadcrumb> = writable();
+export const listPage: Writable<TinroBreadcrumb> = writable(home);
+export const detailsPage: Writable<TinroBreadcrumb> = writable(home);
 
 export function mockBreadcrumb() {
   listPage.set({ name: 'List', path: '/list' } as TinroBreadcrumb);


### PR DESCRIPTION
### What does this PR do?

Breadcrumbs are getting cleared after sleep/hibernate, or when making some changes during yarn test. If one of the Details was left open, this means the `list` page is lost/unknown, which causes an HMR error.

I've tried to research how Svelte stores are persisted and Electron stores cache, and there isn't much useful. It looks like at some point we may want to persist the breadcrumbs (and potentially other stores) like this: https://stackoverflow.com/questions/56488202/how-to-persist-svelte-store

For now, that seems overkill to me - it's not critical that the back-link is correct as long as it doesn't HMR, and we can always persist later. This commit just sets a default list page to avoid the error.

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

Fixes #3334.

### How to test this PR?

Open a Details page, then sleep/hibernate. When you restart the back-link should be `Home` instead of erroring.