### PR TITLE
chore: pf deploy pods

### DIFF
--- a/packages/renderer/src/lib/pod/DeployPodToKube.svelte
+++ b/packages/renderer/src/lib/pod/DeployPodToKube.svelte
@@ -8,6 +8,8 @@ import type { V1NamespaceList } from '@kubernetes/client-node/dist/api';
 import ErrorMessage from '../ui/ErrorMessage.svelte';
 import WarningMessage from '../ui/WarningMessage.svelte';
 import { ensureRestrictedSecurityContext } from '/@/lib/pod/pod-utils';
+import Button from '../ui/Button.svelte';
+import { faRocket } from '@fortawesome/free-solid-svg-icons';
 
 export let resourceId: string;
 export let engineId: string;
@@ -494,17 +496,14 @@ function updateKubeResult() {
       {/if}
 
       {#if !deployStarted}
-        <div class="pt-2 m-2">
-          <button
+        <div class="pt-4">
+          <Button
             on:click="{() => deployToKube()}"
-            class="w-full pf-c-button pf-m-primary"
-            type="button"
+            class="w-full"
+            icon="{faRocket}"
             disabled="{bodyPod?.metadata?.name === ''}">
-            <span class="pf-c-button__icon pf-m-start">
-              <i class="fas fa-rocket" aria-hidden="true"></i>
-            </span>
             Deploy
-          </button>
+          </Button>
         </div>
       {/if}
 
@@ -581,7 +580,9 @@ function updateKubeResult() {
       {/if}
 
       {#if deployFinished}
-        <button on:click="{() => goBackToHistory()}" class="pt-4 w-full pf-c-button pf-m-primary">Done</button>
+        <div class="pt-4">
+          <Button on:click="{() => goBackToHistory()}" class="w-full">Done</Button>
+        </div>
       {/if}
     </div>
   </div>


### PR DESCRIPTION
### What does this PR do?

Changes the two buttons on the Deploy to Kube page from PF buttons to our own Button component. Moves the Deploy button from being in the middle of the page and disappearing after click to being at the bottom, having a spinner during deploy, and then being replaced by the Done button.

Also removes unnecessary Pattern Fly styling from 'Open in OpenShift console' so that it's just a normal link.

### Screenshot/screencast of this PR

N/A, visual change is minimal.

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Deploy to Kubernetes!