### PR TITLE
feat: add starting / stopping call backs for compose group

### DIFF
--- a/packages/renderer/src/lib/ContainerList.svelte
+++ b/packages/renderer/src/lib/ContainerList.svelte
@@ -377,6 +377,22 @@ function inProgressCallback(container: ContainerInfoUI, inProgress: boolean, sta
   containerGroups = [...containerGroups];
 }
 
+// Go through each container passed in and update the progress
+function composeGroupInProgressCallback(containers: ContainerInfoUI[], inProgress: boolean, state?: string): void {
+  containers.forEach(container => {
+    container.actionInProgress = inProgress;
+    // reset error when starting task
+    if (inProgress) {
+      container.actionError = '';
+    }
+    if (state) {
+      container.state = state;
+    }
+  });
+
+  containerGroups = [...containerGroups];
+}
+
 function errorCallback(container: ContainerInfoUI, errorMessage: string): void {
   container.actionError = errorMessage;
   container.state = 'ERROR';
@@ -513,7 +529,9 @@ function errorCallback(container: ContainerInfoUI, errorMessage: string): void {
                       engineType: containerGroup.engineType,
                       containers: [],
                     }}"
-                    dropdownMenu="{true}" />
+                    dropdownMenu="{true}"
+                    inProgressCallback="{(containers, flag, state) =>
+                      composeGroupInProgressCallback(containerGroup.containers, flag, state)}" />
                 {/if}
               </td>
             </tr>

--- a/packages/renderer/src/lib/ContainerListCompose.spec.ts
+++ b/packages/renderer/src/lib/ContainerListCompose.spec.ts
@@ -1,0 +1,136 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import '@testing-library/jest-dom';
+import { beforeAll, test, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/svelte';
+import ContainerList from './ContainerList.svelte';
+import { containersInfos } from '../stores/containers';
+import { get } from 'svelte/store';
+import { providerInfos } from '../stores/providers';
+
+const listContainersMock = vi.fn();
+const getProviderInfosMock = vi.fn();
+
+const listPodsMock = vi.fn();
+
+const kubernetesListPodsMock = vi.fn();
+
+const deleteContainersByLabelMock = vi.fn();
+
+// fake the window.events object
+beforeAll(() => {
+  const onDidUpdateProviderStatusMock = vi.fn();
+  (window as any).onDidUpdateProviderStatus = onDidUpdateProviderStatusMock;
+  onDidUpdateProviderStatusMock.mockImplementation(() => Promise.resolve());
+  listPodsMock.mockImplementation(() => Promise.resolve([]));
+  kubernetesListPodsMock.mockImplementation(() => Promise.resolve([]));
+  (window as any).listContainers = listContainersMock;
+  (window as any).listPods = listPodsMock;
+  (window as any).kubernetesListPods = kubernetesListPodsMock;
+  (window as any).getProviderInfos = getProviderInfosMock;
+  (window as any).deleteContainersByLabel = deleteContainersByLabelMock;
+
+  (window.events as unknown) = {
+    receive: (_channel: string, func: any) => {
+      func();
+    },
+  };
+});
+
+async function waitRender(customProperties: object): Promise<void> {
+  const result = render(ContainerList, { ...customProperties });
+  // wait that result.component.$$.ctx[2] is set
+  while (result.component.$$.ctx[2] === undefined) {
+    await new Promise(resolve => setTimeout(resolve, 100));
+  }
+}
+
+test('Expect no container engines being displayed', async () => {
+  render(ContainerList);
+  const noEngine = screen.getByRole('heading', { name: 'No Container Engine' });
+  expect(noEngine).toBeInTheDocument();
+});
+
+test('Delete a group of compose containers succesfully', async () => {
+  getProviderInfosMock.mockResolvedValue([
+    {
+      name: 'podman',
+      status: 'started',
+      internalId: 'podman-internal-id',
+      containerConnections: [
+        {
+          name: 'podman-machine-default',
+          status: 'started',
+        },
+      ],
+    },
+  ]);
+
+  const groupName = 'compose-group';
+  const mockedContainers = [
+    {
+      Id: 'container1',
+      Image: 'docker.io/kindest/node:foobar',
+      Labels: { 'com.docker.compose.project': groupName },
+      Names: ['container1'],
+      State: 'RUNNING',
+    },
+    {
+      Id: 'container2',
+      Image: 'docker.io/kindest/node:foobar',
+      Labels: { 'com.docker.compose.project': groupName },
+      Names: ['container2'],
+      State: 'RUNNING',
+    },
+  ];
+  listContainersMock.mockResolvedValue(mockedContainers);
+
+  // Send over custom events to simulate PD being started
+  window.dispatchEvent(new CustomEvent('extensions-already-started'));
+  window.dispatchEvent(new CustomEvent('provider-lifecycle-change'));
+  window.dispatchEvent(new CustomEvent('tray:update-provider'));
+
+  // Wait for the store to get populated
+  while (get(containersInfos).length === 0) {
+    await new Promise(resolve => setTimeout(resolve, 500));
+  }
+
+  while (get(providerInfos).length === 0) {
+    await new Promise(resolve => setTimeout(resolve, 500));
+  }
+  await waitRender({});
+
+  // Find the 'Delete Compose' button for the compose group
+  const deleteButton = screen.getByRole('button', { name: 'Delete Compose' });
+  expect(deleteButton).toBeInTheDocument();
+
+  // Click on it
+  await fireEvent.click(deleteButton);
+
+  // wait deleteContainerMock is called
+  while (deleteContainersByLabelMock.mock.calls.length === 0) {
+    await new Promise(resolve => setTimeout(resolve, 100));
+  }
+
+  // Expect deleteContainerMock to be called / successfully clicked
+  expect(deleteContainersByLabelMock).toBeCalledWith(undefined, 'com.docker.compose.project', groupName);
+  expect(deleteContainersByLabelMock).toBeCalledTimes(1);
+});

--- a/packages/renderer/src/lib/compose/ComposeActions.svelte
+++ b/packages/renderer/src/lib/compose/ComposeActions.svelte
@@ -5,56 +5,57 @@ import { router } from 'tinro';
 import ListItemButtonIcon from '../ui/ListItemButtonIcon.svelte';
 import DropdownMenu from '../ui/DropdownMenu.svelte';
 import FlatMenu from '../ui/FlatMenu.svelte';
+import type { ContainerInfoUI } from '../container/ContainerInfoUI';
 
 export let compose: ComposeInfoUI;
 export let dropdownMenu = false;
 export let detailed = false;
 
-export let inProgressCallback: (inProgress: boolean, state?: string) => void = () => {};
+export let inProgressCallback: (containers: ContainerInfoUI[], inProgress: boolean, state?: string) => void = () => {};
 export let errorCallback: (erroMessage: string) => void = () => {};
 
 const composeLabel = 'com.docker.compose.project';
 
 async function startCompose(composeInfoUI: ComposeInfoUI) {
-  inProgressCallback(true, 'STARTING');
+  inProgressCallback(composeInfoUI.containers, true, 'STARTING');
   try {
     await window.startContainersByLabel(composeInfoUI.engineId, composeLabel, composeInfoUI.name);
   } catch (error) {
     errorCallback(error);
   } finally {
-    inProgressCallback(false, 'RUNNING');
+    inProgressCallback(composeInfoUI.containers, false, 'RUNNING');
   }
 }
 async function stopCompose(composeInfoUI: ComposeInfoUI) {
-  inProgressCallback(true, 'STOPPING');
+  inProgressCallback(composeInfoUI.containers, true, 'STOPPING');
   try {
     await window.stopContainersByLabel(composeInfoUI.engineId, composeLabel, composeInfoUI.name);
   } catch (error) {
     errorCallback(error);
   } finally {
-    inProgressCallback(false, 'STOPPED');
+    inProgressCallback(composeInfoUI.containers, false, 'STOPPED');
   }
 }
 
 async function deleteCompose(composeInfoUI: ComposeInfoUI) {
-  inProgressCallback(true, 'DELETING');
+  inProgressCallback(composeInfoUI.containers, true, 'DELETING');
   try {
     await window.deleteContainersByLabel(composeInfoUI.engineId, composeLabel, composeInfoUI.name);
   } catch (error) {
     errorCallback(error);
   } finally {
-    inProgressCallback(false, 'STOPPED');
+    inProgressCallback(composeInfoUI.containers, false, 'STOPPED');
   }
 }
 
 async function restartCompose(composeInfoUI: ComposeInfoUI) {
-  inProgressCallback(true, 'RESTARTING');
+  inProgressCallback(composeInfoUI.containers, true, 'RESTARTING');
   try {
     await window.restartContainersByLabel(composeInfoUI.engineId, composeLabel, composeInfoUI.name);
   } catch (error) {
     errorCallback(error);
   } finally {
-    inProgressCallback(false);
+    inProgressCallback(composeInfoUI.containers, false);
   }
 }
 


### PR DESCRIPTION
feat: add starting / stopping call backs for compose group

### What does this PR do?

When deleting / starting a group of containers, the starting / stopping
callbacks weren't correctly added. This PR adds the feature of
"STARTING" and "STOPPING" showing.

Tests:
* Unsure how to correctly add tests since "STOPPING" or "STARTING" 
disappears almost immediately, so instead added tests (there weren't any
tests before) for deleting an entire group of containers.
* Tests are in a new file as ContainerList.spec.ts for some reason does not
completely clear the containerInfos store.. even after adding clear / clear mock
calls, it does not work. Having it in a new file does.

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


https://github.com/containers/podman-desktop/assets/6422176/42e493d7-c1c8-4b85-bb00-1008eb0ed2ac



### What issues does this PR fix or reference?

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

Closes https://github.com/containers/podman-desktop/issues/3123

### How to test this PR?

1. Deploy a Docker Compose example.
2. Stop / start the group. It should now show STARTING or STOPPING.

<!-- Please explain steps to reproduce -->

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
