### PR TITLE
feat: render placeholder text for text and file selection fields

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.spec.ts
@@ -124,6 +124,7 @@ test('Expect an input button with Browse as placeholder when record is type stri
   const record: IConfigurationPropertyRecordedSchema = {
     title: 'record',
     parentId: 'parent.record',
+    placeholder: 'Example: text',
     description: 'record-description',
     type: 'string',
     format: 'file',
@@ -131,6 +132,10 @@ test('Expect an input button with Browse as placeholder when record is type stri
   render(PreferencesRenderingItemFormat, {
     record,
   });
+  const readOnlyInput = screen.getByLabelText('record-description');
+  expect(readOnlyInput).toBeInTheDocument();
+  expect(readOnlyInput instanceof HTMLInputElement).toBe(true);
+  expect((readOnlyInput as HTMLInputElement).placeholder).toBe(record.placeholder);
   const input = screen.getByLabelText('button-record-description');
   expect(input).toBeInTheDocument();
   expect(input instanceof HTMLInputElement).toBe(true);
@@ -161,6 +166,7 @@ test('Expect a text input when record is type string', async () => {
     title: 'record',
     parentId: 'parent.record',
     description: 'record-description',
+    placeholder: 'Example: text',
     type: 'string',
   };
   render(PreferencesRenderingItemFormat, {
@@ -171,6 +177,7 @@ test('Expect a text input when record is type string', async () => {
   expect(input instanceof HTMLInputElement).toBe(true);
   expect((input as HTMLInputElement).type).toBe('text');
   expect((input as HTMLSelectElement).name).toBe('record');
+  expect((input as HTMLInputElement).placeholder).toBe(record.placeholder);
 });
 
 test('Expect tooltip text shows info when input is less than minimum', async () => {

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
@@ -318,10 +318,11 @@ function assertNumericValueIsValid(value: number) {
     {:else if record.type === 'string' && record.format === 'file'}
       <div class="w-full flex">
         <input
-          class="grow {!recordValue ? 'mr-3' : ''} py-1 px-2 outline-0 text-sm"
+          class="grow {!recordValue ? 'mr-3' : ''} py-1 px-2 outline-0 text-sm placeholder-gray-900"
           name="{record.id}"
           readonly
           type="text"
+          placeholder="{record.placeholder}"
           value="{recordValue || ''}"
           id="input-standard-{record.id}"
           aria-invalid="{invalidEntry}"
@@ -363,9 +364,10 @@ function assertNumericValueIsValid(value: number) {
     {:else}
       <input
         on:input="{event => checkValue(record, event)}"
-        class="grow py-1 px-2 w-full outline-0 border-b-2 border-gray-800 hover:border-violet-500 focus:border-violet-500"
+        class="grow py-1 px-2 w-full outline-0 border-b-2 border-gray-800 hover:border-violet-500 focus:border-violet-500 placeholder-gray-900"
         name="{record.id}"
         type="text"
+        placeholder="{record.placeholder}"
         bind:value="{recordValue}"
         readonly="{!!record.readonly}"
         id="input-standard-{record.id}"


### PR DESCRIPTION
### What does this PR do?

Renders placeholder text form configuration property attributes for text and file fields

### Screenshot/screencast of this PR

![image](https://github.com/containers/podman-desktop/assets/620330/4d4b611c-773c-4295-a5d5-bc2b31cd0a21)

### What issues does this PR fix or reference?

* #2988
* https://github.com/redhat-developer/podman-desktop-sandbox-ext/issues/53

### How to test this PR?

NA

### Dependencies

* PR #3391