### PR TITLE
chore: move getBase64Image to util

### DIFF
--- a/packages/main/src/plugin/authentication.spec.ts
+++ b/packages/main/src/plugin/authentication.spec.ts
@@ -24,6 +24,7 @@ import type {
   Event,
 } from '@podman-desktop/api';
 import { beforeEach, afterEach, expect, test, vi, suite } from 'vitest';
+import type { Mock } from 'vitest';
 import type { ApiSenderType } from './api.js';
 import { AuthenticationImpl } from './authentication.js';
 import type { CommandRegistry } from './command-registry.js';
@@ -49,6 +50,13 @@ import type { Directories } from './directories.js';
 import type { CustomPickRegistry } from './custompick/custompick-registry.js';
 import type { ViewRegistry } from './view-registry.js';
 import type { Context } from './context/context.js';
+import { getBase64Image } from '../util.js';
+
+vi.mock('../util.js', async () => {
+  return {
+    getBase64Image: vi.fn(),
+  };
+});
 
 function randomNumber(n = 5) {
   return Math.round(Math.random() * 10 * n);
@@ -276,7 +284,7 @@ suite('Authentication', () => {
   const BASE64ENCODEDIMAGE = 'BASE64ENCODEDIMAGE';
 
   test('allows images option to be undefined or empty', async () => {
-    vi.spyOn(extLoader, 'getBase64Image').mockImplementation(() => BASE64ENCODEDIMAGE);
+    (getBase64Image as Mock).mockReturnValue(BASE64ENCODEDIMAGE);
     const api = extLoader.createApi('/path', {});
     expect(api).toBeDefined();
     api.authentication.registerAuthenticationProvider('provider1.id', 'Provider1 Label', providerMock);
@@ -297,7 +305,7 @@ suite('Authentication', () => {
   });
 
   test('converts images.icon path to base 64 image when registering provider', async () => {
-    vi.spyOn(extLoader, 'getBase64Image').mockImplementation(() => BASE64ENCODEDIMAGE);
+    (getBase64Image as Mock).mockReturnValue(BASE64ENCODEDIMAGE);
     const api = extLoader.createApi('/path', {});
     expect(api).toBeDefined();
     api.authentication.registerAuthenticationProvider('provider1.id', 'Provider1 Label', providerMock, {
@@ -314,7 +322,7 @@ suite('Authentication', () => {
   });
 
   test('converts images.icon with themes path to base 64 image when registering provider', async () => {
-    vi.spyOn(extLoader, 'getBase64Image').mockImplementation(() => BASE64ENCODEDIMAGE);
+    (getBase64Image as Mock).mockReturnValue(BASE64ENCODEDIMAGE);
     const api = extLoader.createApi('/path', {});
     expect(api).toBeDefined();
     api.authentication.registerAuthenticationProvider('provider2.id', 'Provider2 Label', providerMock, {

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -56,7 +56,7 @@ import { clipboard as electronClipboard } from 'electron';
 import { securityRestrictionCurrentHandler } from '../security-restrictions-handler.js';
 import type { IconRegistry } from './icon-registry.js';
 import type { Directories } from './directories.js';
-import { isLinux, isMac, isWindows } from '../util.js';
+import { getBase64Image, isLinux, isMac, isWindows } from '../util.js';
 import type { CustomPickRegistry } from './custompick/custompick-registry.js';
 import { exec } from './util/exec.js';
 import type { ProviderContainerConnectionInfo, ProviderKubernetesConnectionInfo } from './api/provider-info.js';
@@ -444,16 +444,6 @@ export class ExtensionLoader {
       .map(directory => path.join(folderPath, directory.name, `/builtin/${directory.name}.cdix`));
   }
 
-  getBase64Image(imagePath: string): string {
-    const imageContent = fs.readFileSync(imagePath);
-
-    // convert to base64
-    const base64Content = Buffer.from(imageContent).toString('base64');
-
-    // create base64 image content
-    return `data:image/png;base64,${base64Content}`;
-  }
-
   /**
    * Update the image to be a base64 content
    */
@@ -466,13 +456,19 @@ export class ExtensionLoader {
       return undefined;
     }
     if (typeof image === 'string') {
-      return this.getBase64Image(path.resolve(rootPath, image));
+      return getBase64Image(path.resolve(rootPath, image));
     } else {
       if (image.light) {
-        image.light = this.getBase64Image(path.resolve(rootPath, image.light));
+        const base64Image = getBase64Image(path.resolve(rootPath, image.light));
+        if (base64Image) {
+          image.light = base64Image;
+        }
       }
       if (image.dark) {
-        image.dark = this.getBase64Image(path.resolve(rootPath, image.dark));
+        const base64Image = getBase64Image(path.resolve(rootPath, image.dark));
+        if (base64Image) {
+          image.dark = base64Image;
+        }
       }
       return image;
     }

--- a/packages/main/src/util.spec.ts
+++ b/packages/main/src/util.spec.ts
@@ -1,0 +1,51 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import { beforeEach, expect, test, vi } from 'vitest';
+import * as fs from 'node:fs';
+import { getBase64Image } from './util.js';
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.mock('node:fs');
+});
+
+test('getBase64Image - return undefined if path do not exists', () => {
+  vi.spyOn(fs, 'existsSync').mockReturnValue(false);
+  const result = getBase64Image('unknown');
+  expect(result).toBe(undefined);
+});
+
+test('getBase64Image - return undefined if erroring durin execution', () => {
+  vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+  vi.spyOn(fs, 'readFileSync').mockImplementation(() => {
+    throw new Error('error');
+  });
+  const result = getBase64Image('path');
+  expect(result).toBe(undefined);
+});
+
+test('getBase64Image - return base64 image', () => {
+  const buffer: Buffer = {} as Buffer;
+  vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+  vi.spyOn(fs, 'readFileSync').mockReturnValue('file');
+  vi.spyOn(Buffer, 'from').mockReturnValue(buffer);
+  vi.spyOn(buffer, 'toString').mockReturnValue('image');
+
+  const result = getBase64Image('path');
+  expect(result).toBe('data:image/png;base64,image');
+});

--- a/packages/main/src/util.ts
+++ b/packages/main/src/util.ts
@@ -17,6 +17,7 @@
  ***********************************************************************/
 
 import { BrowserWindow } from 'electron';
+import * as fs from 'fs';
 import * as os from 'os';
 
 const windows = os.platform() === 'win32';
@@ -36,3 +37,20 @@ export function findWindow(): Electron.BrowserWindow | undefined {
 }
 
 export const stoppedExtensions = { val: false };
+
+export function getBase64Image(imagePath: string): string | undefined {
+  try {
+    if (fs.existsSync(imagePath)) {
+      const imageContent = fs.readFileSync(imagePath);
+
+      // convert to base64
+      const base64Content = Buffer.from(imageContent).toString('base64');
+
+      // create base64 image content
+      return `data:image/png;base64,${base64Content}`;
+    }
+  } catch (error) {
+    console.error(`Error while creating base64 image content for ${imagePath}`, error);
+  }
+  return undefined;
+}


### PR DESCRIPTION
### What does this PR do?

it just move the getBase64Image  to util so it can be reused in other places.
Used in #3172 

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

N/A

### How to test this PR?

N/A
