### PR TITLE
fix: volume list always fetched the volumes

### DIFF
--- a/packages/renderer/src/lib/volume/VolumesList.svelte
+++ b/packages/renderer/src/lib/volume/VolumesList.svelte
@@ -52,11 +52,6 @@ onMount(async () => {
     } finally {
       fetchingInProgress = false;
     }
-  } else {
-    // fetch in background
-    fetchVolumes().catch((error: unknown) => {
-      console.error('unable to fetch the volumes', error);
-    });
   }
 
   volumesUnsubscribe = filtered.subscribe(value => {


### PR DESCRIPTION
Fixes #3376

### What does this PR do?

Remove fetch of volumes when displaying the volume list

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

Fixes #3376 

### How to test this PR?

Go to the volumes list and monitor REST call in the Podman VM with: `journalctl -f`