### PR TITLE
fix: missing emit so clients on the 'main' side could not be notified

### DIFF
--- a/packages/main/src/plugin/index.spec.ts
+++ b/packages/main/src/plugin/index.spec.ts
@@ -175,3 +175,19 @@ test('Check SecurityRestrictions on known domains', async () => {
   // expect openExternal has been called
   expect(shell.openExternal).toBeCalledWith('https://www.podman-desktop.io');
 });
+
+test('Should apiSender handle local receive events', async () => {
+  const apiSender = pluginSystem.getApiSender(webContents);
+  expect(apiSender).toBeDefined();
+
+  let fooReceived = '';
+  apiSender.receive('foo', (data: any) => {
+    fooReceived = String(data);
+  });
+
+  // try to send data
+  apiSender.send('foo', 'hello-world');
+
+  // data should have been received
+  expect(fooReceived).toBe('hello-world');
+});

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -281,6 +281,7 @@ export class PluginSystem {
           // add to the queue
           queuedEvents.push({ channel, data });
         }
+        eventEmitter.emit(channel, data);
       },
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       receive: (channel: string, func: any) => {


### PR DESCRIPTION
### What does this PR do?

ApiSender sends the data remotely but clients could use it on the main side as well.

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?

related to #2397 

### How to test this PR?

Unit test is provided