### PR TITLE
chore: prefer podman type connections about docker connections when asking for a connection

### DIFF
--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -623,7 +623,13 @@ export class ContainerProviderRegistry {
     // prefer podman over other engines
     // sort by podman first as container type
     matchingContainerProviders.sort((a, b) => {
-      return b[1].connection.type.localeCompare(a[1].connection.type);
+      if (a[1].connection.type === 'podman' && b[1].connection.type === 'podman') {
+        return 0;
+      } else if (a[1].connection.type === 'podman' && b[1].connection.type !== 'podman') {
+        return -1;
+      } else {
+        return 1;
+      }
     });
 
     const matchingConnection = matchingContainerProviders[0];

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -86,8 +86,8 @@ export class ContainerProviderRegistry {
     libPodDockerode.enhancePrototypeWithLibPod();
   }
 
-  private containerProviders: Map<string, containerDesktopAPI.ContainerProviderConnection> = new Map();
-  private internalProviders: Map<string, InternalContainerProvider> = new Map();
+  protected containerProviders: Map<string, containerDesktopAPI.ContainerProviderConnection> = new Map();
+  protected internalProviders: Map<string, InternalContainerProvider> = new Map();
 
   handleEvents(api: Dockerode) {
     const eventEmitter = new EventEmitter();
@@ -610,6 +610,7 @@ export class ContainerProviderRegistry {
     return engine.libpodApi;
   }
 
+  // prefer podman over docker
   public getFirstRunningConnection(): [ProviderContainerConnectionInfo, Dockerode] {
     // grab all connections
     const matchingContainerProviders = Array.from(this.internalProviders.entries()).filter(
@@ -618,6 +619,12 @@ export class ContainerProviderRegistry {
     if (!matchingContainerProviders || matchingContainerProviders.length === 0) {
       throw new Error('No provider with a running engine');
     }
+
+    // prefer podman over other engines
+    // sort by podman first as container type
+    matchingContainerProviders.sort((a, b) => {
+      return b[1].connection.type.localeCompare(a[1].connection.type);
+    });
 
     const matchingConnection = matchingContainerProviders[0];
     if (!matchingConnection[1].api) {


### PR DESCRIPTION
### What does this PR do?
For some cases, like executing some commands for Docker Desktop we need a socket but in case of multiple engine running, we need to use one it will use the first available running socket but trying first on the podman type connections over docker type connections.


### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

#2397 

### How to test this PR?

unit tests included