### PR TITLE
chore: reduce inkscape/sodipodi warnings in dev/test

### DIFF
--- a/packages/renderer/src/lib/images/WindowsExitIcon.svelte
+++ b/packages/renderer/src/lib/images/WindowsExitIcon.svelte
@@ -11,40 +11,6 @@ export let size = 16;
   version="1.1"
   id="svg10085"
   xmlns="http://www.w3.org/2000/svg">
-  <sodipodi:namedview
-    id="namedview10087"
-    pagecolor="#ffffff"
-    bordercolor="#666666"
-    borderopacity="1.0"
-    inkscape:showpageshadow="2"
-    inkscape:pageopacity="0"
-    inkscape:pagecheckerboard="true"
-    inkscape:deskcolor="#d1d1d1"
-    inkscape:document-units="px"
-    showgrid="true"
-    showguides="false"
-    inkscape:zoom="58.9375"
-    inkscape:cx="8"
-    inkscape:cy="8.0169671"
-    inkscape:window-width="1920"
-    inkscape:window-height="1131"
-    inkscape:window-x="0"
-    inkscape:window-y="0"
-    inkscape:window-maximized="1"
-    inkscape:current-layer="g18715">
-    <inkscape:grid type="xygrid" id="grid10569"></inkscape:grid>
-  </sodipodi:namedview>
-  <defs id="defs10082">
-    <inkscape:path-effect effect="spiro" id="path-effect18723" is_visible="true" lpeversion="1"></inkscape:path-effect>
-    <inkscape:path-effect effect="spiro" id="path-effect18719" is_visible="true" lpeversion="1"></inkscape:path-effect>
-    <inkscape:path-effect effect="spiro" id="path-effect8380" is_visible="true" lpeversion="1"></inkscape:path-effect>
-    <inkscape:path-effect effect="spiro" id="path-effect8384" is_visible="true" lpeversion="1"></inkscape:path-effect>
-    <inkscape:path-effect effect="spiro" id="path-effect19377" is_visible="true" lpeversion="1"></inkscape:path-effect>
-    <inkscape:path-effect effect="spiro" id="path-effect19381" is_visible="true" lpeversion="1"></inkscape:path-effect>
-    <inkscape:path-effect effect="spiro" id="path-effect21676" is_visible="true" lpeversion="1"></inkscape:path-effect>
-    <inkscape:path-effect effect="spiro" id="path-effect8380-3" is_visible="true" lpeversion="1"></inkscape:path-effect>
-    <inkscape:path-effect effect="spiro" id="path-effect8384-6" is_visible="true" lpeversion="1"></inkscape:path-effect>
-  </defs>
   <g id="layer1">
     <g
       id="g18715"

--- a/packages/renderer/src/lib/images/WindowsMaxIcon.svelte
+++ b/packages/renderer/src/lib/images/WindowsMaxIcon.svelte
@@ -11,40 +11,6 @@ export let size = 16;
   version="1.1"
   id="svg10085"
   xmlns="http://www.w3.org/2000/svg">
-  <sodipodi:namedview
-    id="namedview10087"
-    pagecolor="#ffffff"
-    bordercolor="#666666"
-    borderopacity="1.0"
-    inkscape:showpageshadow="2"
-    inkscape:pageopacity="0"
-    inkscape:pagecheckerboard="true"
-    inkscape:deskcolor="#d1d1d1"
-    inkscape:document-units="px"
-    showgrid="true"
-    showguides="false"
-    inkscape:zoom="58.625"
-    inkscape:cx="6.2771855"
-    inkscape:cy="8.2132196"
-    inkscape:window-width="1920"
-    inkscape:window-height="1131"
-    inkscape:window-x="0"
-    inkscape:window-y="0"
-    inkscape:window-maximized="1"
-    inkscape:current-layer="layer1">
-    <inkscape:grid type="xygrid" id="grid10569"></inkscape:grid>
-  </sodipodi:namedview>
-  <defs id="defs10082">
-    <inkscape:path-effect effect="spiro" id="path-effect18723" is_visible="true" lpeversion="1"></inkscape:path-effect>
-    <inkscape:path-effect effect="spiro" id="path-effect18719" is_visible="true" lpeversion="1"></inkscape:path-effect>
-    <inkscape:path-effect effect="spiro" id="path-effect8380" is_visible="true" lpeversion="1"></inkscape:path-effect>
-    <inkscape:path-effect effect="spiro" id="path-effect8384" is_visible="true" lpeversion="1"></inkscape:path-effect>
-    <inkscape:path-effect effect="spiro" id="path-effect19377" is_visible="true" lpeversion="1"></inkscape:path-effect>
-    <inkscape:path-effect effect="spiro" id="path-effect19381" is_visible="true" lpeversion="1"></inkscape:path-effect>
-    <inkscape:path-effect effect="spiro" id="path-effect21676" is_visible="true" lpeversion="1"></inkscape:path-effect>
-    <inkscape:path-effect effect="spiro" id="path-effect8380-3" is_visible="true" lpeversion="1"></inkscape:path-effect>
-    <inkscape:path-effect effect="spiro" id="path-effect8384-6" is_visible="true" lpeversion="1"></inkscape:path-effect>
-  </defs>
   <g id="layer1">
     <rect
       style="fill:none;stroke:#ffffff;stroke-width:0.999998;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4.4;stroke-dasharray:none;stroke-opacity:1"

--- a/packages/renderer/src/lib/images/WindowsMinIcon.svelte
+++ b/packages/renderer/src/lib/images/WindowsMinIcon.svelte
@@ -11,40 +11,6 @@ export let size = 16;
   version="1.1"
   id="svg10085"
   xmlns="http://www.w3.org/2000/svg">
-  <sodipodi:namedview
-    id="namedview10087"
-    pagecolor="#ffffff"
-    bordercolor="#666666"
-    borderopacity="1.0"
-    inkscape:showpageshadow="2"
-    inkscape:pageopacity="0"
-    inkscape:pagecheckerboard="true"
-    inkscape:deskcolor="#d1d1d1"
-    inkscape:document-units="px"
-    showgrid="true"
-    showguides="false"
-    inkscape:zoom="41.454135"
-    inkscape:cx="7.9847282"
-    inkscape:cy="8.2138971"
-    inkscape:window-width="1920"
-    inkscape:window-height="1131"
-    inkscape:window-x="0"
-    inkscape:window-y="0"
-    inkscape:window-maximized="1"
-    inkscape:current-layer="layer1">
-    <inkscape:grid type="xygrid" id="grid10569"></inkscape:grid>
-  </sodipodi:namedview>
-  <defs id="defs10082">
-    <inkscape:path-effect effect="spiro" id="path-effect18723" is_visible="true" lpeversion="1"></inkscape:path-effect>
-    <inkscape:path-effect effect="spiro" id="path-effect18719" is_visible="true" lpeversion="1"></inkscape:path-effect>
-    <inkscape:path-effect effect="spiro" id="path-effect8380" is_visible="true" lpeversion="1"></inkscape:path-effect>
-    <inkscape:path-effect effect="spiro" id="path-effect8384" is_visible="true" lpeversion="1"></inkscape:path-effect>
-    <inkscape:path-effect effect="spiro" id="path-effect19377" is_visible="true" lpeversion="1"></inkscape:path-effect>
-    <inkscape:path-effect effect="spiro" id="path-effect19381" is_visible="true" lpeversion="1"></inkscape:path-effect>
-    <inkscape:path-effect effect="spiro" id="path-effect21676" is_visible="true" lpeversion="1"></inkscape:path-effect>
-    <inkscape:path-effect effect="spiro" id="path-effect8380-3" is_visible="true" lpeversion="1"></inkscape:path-effect>
-    <inkscape:path-effect effect="spiro" id="path-effect8384-6" is_visible="true" lpeversion="1"></inkscape:path-effect>
-  </defs>
   <g id="layer1">
     <path
       style="fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"

--- a/packages/renderer/src/lib/images/WindowsUnmaxIcon.svelte
+++ b/packages/renderer/src/lib/images/WindowsUnmaxIcon.svelte
@@ -11,40 +11,6 @@ export let size = 16;
   version="1.1"
   id="svg10085"
   xmlns="http://www.w3.org/2000/svg">
-  <sodipodi:namedview
-    id="namedview10087"
-    pagecolor="#ffffff"
-    bordercolor="#666666"
-    borderopacity="1.0"
-    inkscape:showpageshadow="2"
-    inkscape:pageopacity="0"
-    inkscape:pagecheckerboard="true"
-    inkscape:deskcolor="#d1d1d1"
-    inkscape:document-units="px"
-    showgrid="true"
-    showguides="false"
-    inkscape:zoom="41.763494"
-    inkscape:cx="7.9974151"
-    inkscape:cy="8.0812204"
-    inkscape:window-width="1920"
-    inkscape:window-height="1131"
-    inkscape:window-x="0"
-    inkscape:window-y="0"
-    inkscape:window-maximized="1"
-    inkscape:current-layer="g22446">
-    <inkscape:grid type="xygrid" id="grid10569"></inkscape:grid>
-  </sodipodi:namedview>
-  <defs id="defs10082">
-    <inkscape:path-effect effect="spiro" id="path-effect18723" is_visible="true" lpeversion="1"></inkscape:path-effect>
-    <inkscape:path-effect effect="spiro" id="path-effect18719" is_visible="true" lpeversion="1"></inkscape:path-effect>
-    <inkscape:path-effect effect="spiro" id="path-effect8380" is_visible="true" lpeversion="1"></inkscape:path-effect>
-    <inkscape:path-effect effect="spiro" id="path-effect8384" is_visible="true" lpeversion="1"></inkscape:path-effect>
-    <inkscape:path-effect effect="spiro" id="path-effect19377" is_visible="true" lpeversion="1"></inkscape:path-effect>
-    <inkscape:path-effect effect="spiro" id="path-effect19381" is_visible="true" lpeversion="1"></inkscape:path-effect>
-    <inkscape:path-effect effect="spiro" id="path-effect21676" is_visible="true" lpeversion="1"></inkscape:path-effect>
-    <inkscape:path-effect effect="spiro" id="path-effect8380-3" is_visible="true" lpeversion="1"></inkscape:path-effect>
-    <inkscape:path-effect effect="spiro" id="path-effect8384-6" is_visible="true" lpeversion="1"></inkscape:path-effect>
-  </defs>
   <g id="layer1">
     <g
       id="g8366"


### PR DESCRIPTION
### What does this PR do?

When starting in watch mode or running tests, there is a *lot* of extraneous console output like the following below, where sodipodi/inkscape attributes trigger vite-plugin-svelte warnings. As an example were just shy of 400 lines in the e2e test I was trying to debug.

By definition these attributes are not used at runtime and can be safely removed to make these files marginally smaller and remove this output.

[vite-plugin-svelte] /src/lib/images/WindowsExitIcon.svelte:32:4 Attributes should not contain ':' characters to prevent ambiguity with Svelte directives
30:     inkscape:window-x="0"
31:     inkscape:window-y="0"
32:     inkscape:window-maximized="1"
        ^
33:     inkscape:current-layer="g18715">
34:     <inkscape:grid type="xygrid" id="grid10569"></inkscape:grid>

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Open on Windows and confirm no regression to control buttons.