### PR TITLE
fix: create /usr/local/bin directory if it does not exist on binary install

### DIFF
--- a/extensions/compose/src/cli-run.ts
+++ b/extensions/compose/src/cli-run.ts
@@ -21,6 +21,7 @@ import { resolve } from 'node:path';
 import * as path from 'node:path';
 import * as sudo from 'sudo-prompt';
 import * as os from 'node:os';
+import * as fs from 'node:fs';
 import type * as extensionApi from '@podman-desktop/api';
 import type { OS } from './os';
 
@@ -37,6 +38,7 @@ export interface RunOptions {
 }
 
 const macosExtraPath = '/usr/local/bin:/opt/homebrew/bin:/opt/local/bin';
+const localBinDir = '/usr/local/bin';
 
 export class CliRun {
   constructor(private readonly extensionContext: extensionApi.ExtensionContext, private os: OS) {}
@@ -146,8 +148,14 @@ export class CliRun {
       destinationPath = path.join(os.homedir(), 'AppData', 'Local', 'Microsoft', 'WindowsApps', `${binaryName}.exe`);
       command = ['copy', `"${binaryPath}"`, `"${destinationPath}"`];
     } else {
-      destinationPath = path.join('/usr/local/bin', binaryName);
+      destinationPath = path.join(localBinDir, binaryName);
       command = ['cp', binaryPath, destinationPath];
+    }
+
+    // If on macOS or Linux, check to see if the /usr/local/bin directory exists,
+    // if it does not, then add mkdir -p /usr/local/bin to the start of the command when moving the binary.
+    if (system === 'linux' || (system === 'darwin' && !fs.existsSync(localBinDir))) {
+      command.unshift('mkdir', '-p', localBinDir, '&&');
     }
 
     // If windows or mac, use sudo-prompt to elevate the privileges

--- a/extensions/compose/src/cli-run.ts
+++ b/extensions/compose/src/cli-run.ts
@@ -154,7 +154,7 @@ export class CliRun {
 
     // If on macOS or Linux, check to see if the /usr/local/bin directory exists,
     // if it does not, then add mkdir -p /usr/local/bin to the start of the command when moving the binary.
-    if (system === 'linux' || (system === 'darwin' && !fs.existsSync(localBinDir))) {
+    if ((system === 'linux' || system === 'darwin') && !fs.existsSync(localBinDir)) {
       command.unshift('mkdir', '-p', localBinDir, '&&');
     }
 


### PR DESCRIPTION
fix: create /usr/local/bin directory if it does not exist on binary install

### What does this PR do?

* On macOS and Linux we install the binary to /usr/local/bin. However,
  we do not check to see if it exists or create the directory if it it
  does not exist.
* This PR updates the installBinaryToSystem function to check and create
  the bin directory
* Added tests
* No updates to user UI (this all happens behind the scenes)

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

https://github.com/containers/podman-desktop/assets/6422176/d5971702-8aa3-4243-a230-077e53caec0e




### What issues does this PR fix or reference?

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

Closes https://github.com/containers/podman-desktop/issues/3309

### How to test this PR?

1. Modify the `localBinDir` const to `/usr/local/bin/foobar` or a random
   test folder that's non-existant
2. "Install" Compose using the normal functionality
3. Check the directory that the binary has been installed.

<!-- Please explain steps to reproduce -->

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
