### PR TITLE
chore: settings nav item

### DIFF
--- a/packages/renderer/src/PreferencesNavigation.spec.ts
+++ b/packages/renderer/src/PreferencesNavigation.spec.ts
@@ -51,7 +51,7 @@ test('Test rendering of the preferences navigation bar and its items', () => {
   expect(authentication).toBeVisible();
   const extensions = screen.getByRole('link', { name: 'Extensions' });
   expect(extensions).toBeVisible();
-  const desktop = screen.getByRole('link', { name: 'DesktopExtensions' });
+  const desktop = screen.getByRole('link', { name: 'Desktop Extensions' });
   expect(desktop).toBeVisible();
   // ToDo: adding configuration section/items mocks for preferences, issue #2966
 });

--- a/packages/renderer/src/PreferencesNavigation.svelte
+++ b/packages/renderer/src/PreferencesNavigation.svelte
@@ -3,6 +3,7 @@ import { onMount } from 'svelte';
 import { extensionInfos } from './stores/extensions';
 import { configurationProperties } from './stores/configurationProperties';
 import { CONFIGURATION_DEFAULT_SCOPE } from '../../main/src/plugin/configuration-registry-constants';
+import SettingsNavItem from './lib/preferences/SettingsNavItem.svelte';
 
 export let meta;
 
@@ -10,10 +11,6 @@ let configProperties: Map<string, { id: string; title: string }>;
 
 $: configProperties = new Map();
 $: sectionExpanded = {};
-
-function toggleSection(provider: string) {
-  sectionExpanded[provider] = sectionExpanded[provider] === undefined ? true : !sectionExpanded[provider];
-}
 
 onMount(async () => {
   configurationProperties.subscribe(value => {
@@ -35,186 +32,61 @@ onMount(async () => {
       }, new Map());
   });
 });
-
-$: isCurrentPage = (pathParam: string): boolean => meta.url === pathParam;
-$: addExpandedClass = (section: string): string => (sectionExpanded[section] ? 'pf-m-expanded' : '');
-$: addCurrentClass = (pathParam: string): string =>
-  isCurrentPage(pathParam) ? 'dark:text-white pf-m-current' : 'dark:text-gray-700';
-$: isAriaExpanded = (section: string): boolean => (sectionExpanded[section] ? true : false);
-$: addSectionHiddenClass = (section: string): string => (sectionExpanded[section] ? '' : 'hidden');
 </script>
 
 <nav
-  class="z-1 pf-c-nav w-[225px] min-w-[225px] shadow flex-col justify-between flex transition-all duration-500 ease-in-out"
-  style="background-color: rgb(39 39 42 / var(--tw-bg-opacity))"
+  class="z-1 w-[225px] min-w-[225px] shadow flex-col justify-between flex transition-all duration-500 ease-in-out bg-charcoal-700"
   aria-label="PreferencesNavigation">
   <div class="flex items-center">
     <div class="pt-4 px-5 mb-10">
       <p class="text-xl first-letter:uppercase">Settings</p>
     </div>
   </div>
-  <ul class="pf-c-nav__list h-full overflow-hidden hover:overflow-y-auto" style="margin-bottom:auto">
-    <!-- Resources configuration start -->
-    <li
-      class="pf-c-nav__item flex w-full justify-between {addCurrentClass(
-        '/preferences/resources',
-      )} hover:text-gray-400 cursor-pointer items-center">
-      <a
-        href="/preferences/resources"
-        id="configuration-section-resources"
-        class="pf-c-nav__link"
-        aria-label="Resources">
-        <div class="flex items-center">
-          <span class="block group-hover:block">Resources</span>
-        </div>
-      </a>
-    </li>
-    <!-- Resources configuration end -->
+  <div class="h-full overflow-hidden hover:overflow-y-auto" style="margin-bottom:auto">
+    <SettingsNavItem title="Resources" href="/preferences/resources" bind:meta="{meta}" />
 
-    <!-- Proxies configuration start -->
-    <li
-      class="pf-c-nav__item flex w-full justify-between {addCurrentClass(
-        '/preferences/proxies',
-      )} hover:text-gray-400 cursor-pointer items-center">
-      <a href="/preferences/proxies" id="configuration-section-proxy" class="pf-c-nav__link" aria-label="Proxy">
-        <div class="flex items-center">
-          <span class="block group-hover:block">Proxy</span>
-        </div>
-      </a>
-    </li>
-    <!-- Proxies configuration end -->
+    <SettingsNavItem title="Proxy" href="/preferences/proxies" bind:meta="{meta}" />
 
-    <!-- Registries configuration start -->
-    <li
-      class="pf-c-nav__item flex w-full justify-between {addCurrentClass(
-        '/preferences/registries',
-      )} hover:text-gray-400 cursor-pointer items-center">
-      <a
-        href="/preferences/registries"
-        id="configuration-section-registries"
-        class="pf-c-nav__link"
-        aria-label="Registries">
-        <div class="flex items-center">
-          <span class="block group-hover:block">Registries</span>
-        </div>
-      </a>
-    </li>
-    <!-- Registries configuration end -->
+    <SettingsNavItem title="Registries" href="/preferences/registries" bind:meta="{meta}" />
 
-    <!-- Authentication Providers configuration start -->
-    <li
-      class="pf-c-nav__item flex w-full justify-between {addCurrentClass(
-        '/preferences/authentication-providers',
-      )} hover:text-gray-400 cursor-pointer items-center">
-      <a
-        href="/preferences/authentication-providers"
-        id="configuration-section-authentication"
-        class="pf-c-nav__link"
-        aria-label="Authentication">
-        <div class="flex items-center">
-          <span class="block group-hover:block">Authentication</span>
-        </div>
-      </a>
-    </li>
-    <!-- Authentication Providers configuration end -->
+    <SettingsNavItem title="Authentication" href="/preferences/authentication-providers" bind:meta="{meta}" />
 
-    <!-- Extensions catalog configuration start -->
-    <li
-      class="pf-c-nav__item pf-m-expandable {addExpandedClass('extensionsCatalog')} {addCurrentClass(
-        '/preferences/extensions',
-      )} hover:text-gray-400 cursor-pointer items-center">
-      <a
-        href="/preferences/extensions"
-        class="pf-c-nav__link text-left"
-        id="configuration-section-extensions-catalog"
-        aria-label="Extensions"
-        aria-expanded="{isAriaExpanded('extensionsCatalog')}"
-        on:click="{() => toggleSection('extensionsCatalog')}">
-        Extensions
-        <span class="pf-c-nav__toggle">
-          <span class="pf-c-nav__toggle-icon">
-            <i class="fas fa-angle-right" aria-hidden="true"></i>
-          </span>
-        </span>
-      </a>
-      <section class="pf-c-nav__subnav {addSectionHiddenClass('extensionsCatalog')}">
-        <ul class="pf-c-nav__list">
-          {#each $extensionInfos as extension}
-            <li class="pf-c-nav__item {addCurrentClass(`/preferences/extension/${extension.id}`)}">
-              <a
-                href="/preferences/extension/{extension.id}"
-                id="configuration-section-extensions-catalog-{extension.name.toLowerCase()}"
-                class="pf-c-nav__link"
-                style="font-weight: 200"
-                aria-label="{extension.name}">{extension.displayName}</a>
-            </li>
-          {/each}
-        </ul>
-      </section>
-    </li>
-    <!-- Extensions catalog configuration end -->
+    <SettingsNavItem
+      title="Extensions"
+      href="/preferences/extensions"
+      section="{true}"
+      bind:meta="{meta}"
+      bind:expanded="{sectionExpanded['extensionsCatalog']}" />
+    {#if sectionExpanded['extensionsCatalog']}
+      {#each $extensionInfos as extension}
+        <SettingsNavItem
+          title="{extension.displayName}"
+          href="/preferences/extension/{extension.id}"
+          child="{true}"
+          bind:meta="{meta}" />
+      {/each}
+    {/if}
 
-    <!-- Docker desktop extensions configuration start -->
-    <li
-      class="pf-c-nav__item flex w-full justify-between {addCurrentClass(
-        '/preferences/ddExtensions',
-      )} hover:text-gray-400 cursor-pointer items-center">
-      <a
-        href="/preferences/ddExtensions"
-        id="configuration-section-docker-desktop-extensions"
-        class="pf-c-nav__link"
-        aria-label="DesktopExtensions">
-        <div class="flex items-center">
-          <span class="block group-hover:block">Desktop Extensions</span>
-        </div>
-      </a>
-    </li>
-    <!-- Docker desktop extensions configuration start -->
+    <SettingsNavItem title="Desktop Extensions" href="/preferences/ddExtensions" bind:meta="{meta}" />
 
     <!-- Default configuration properties start -->
     {#each Object.entries(configProperties) as [configSection, configItems]}
-      <li
-        class="pf-c-nav__item pf-m-expandable {addExpandedClass(configSection)} {addCurrentClass(
-          `/preferences/default/${configSection}`,
-        )} hover:text-gray-400 cursor-pointer items-center">
-        <a
-          class="pf-c-nav__link"
-          id="configuration-section-{configSection.toLowerCase()}"
-          aria-expanded="{isAriaExpanded(configSection)}"
-          href="/preferences/default/{configSection}"
-          aria-label="{configSection}"
-          on:click="{() => {
-            if (configItems.length > 0) {
-              toggleSection(configSection);
-            }
-          }}">
-          <span class="block group-hover:block mr-5 capitalize">{configSection}</span>
-          {#if configItems.length > 0}
-            <span class="pf-c-nav__toggle">
-              <span class="pf-c-nav__toggle-icon">
-                <i class="fas fa-angle-right" aria-hidden="true"></i>
-              </span>
-            </span>
-          {/if}
-        </a>
-        <section class="pf-c-nav__subnav {addSectionHiddenClass(configSection)}">
-          <ul class="pf-c-nav__list">
-            {#each configItems.sort((a, b) => a.title.localeCompare(b.title)) as configItem}
-              <li class="pf-c-nav__item {addCurrentClass(`/preferences/default/${configItem.id}`)}">
-                <a
-                  href="/preferences/default/{configItem.id}"
-                  id="configuration-section-{configSection.toLowerCase()}-{configItem.title.toLowerCase()}"
-                  class="pf-c-nav__link"
-                  style="font-weight: 200"
-                  aria-label="{configItem.title}"
-                  >{configItem.title}
-                </a>
-              </li>
-            {/each}
-          </ul>
-        </section>
-      </li>
+      <SettingsNavItem
+        title="{configSection}"
+        href="/preferences/default/{configSection}"
+        section="{configItems.length > 0}"
+        bind:meta="{meta}"
+        bind:expanded="{sectionExpanded[configSection]}" />
+      {#if sectionExpanded[configSection]}
+        {#each configItems.sort((a, b) => a.title.localeCompare(b.title)) as configItem}
+          <SettingsNavItem
+            title="{configItem.title}"
+            href="/preferences/default/{configItem.id}"
+            child="{true}"
+            bind:meta="{meta}" />
+        {/each}
+      {/if}
     {/each}
     <!-- Default configuration properties end -->
-  </ul>
+  </div>
 </nav>

--- a/packages/renderer/src/lib/preferences/SettingsNavItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/SettingsNavItem.spec.ts
@@ -79,7 +79,8 @@ test('Expect section styling', async () => {
   expect(element).toBeInTheDocument();
   expect(element.firstChild).toBeInTheDocument();
   expect(element.firstChild.childNodes[2]).toBeInTheDocument();
-  expect(element.firstChild.childNodes[2]).toHaveClass('fas');
+  expect(element.firstChild.childNodes[2].firstChild).toBeInTheDocument();
+  expect(element.firstChild.childNodes[2].firstChild).toHaveClass('fas');
 });
 
 test('Expect sections expand', async () => {
@@ -91,9 +92,12 @@ test('Expect sections expand', async () => {
   expect(element).toBeInTheDocument();
   expect(element.firstChild).toBeInTheDocument();
   expect(element.firstChild.childNodes[2]).toBeInTheDocument();
-  expect(element.firstChild.childNodes[2]).toHaveClass('fa-angle-right');
+  expect(element.firstChild.childNodes[2]).toContainHTML('fa-angle-right');
+  expect(element.firstChild.childNodes[2]).not.toContainHTML('fa-angle-down');
 
   await fireEvent.click(element);
 
-  expect(element.firstChild.childNodes[2]).toHaveClass('fa-angle-down');
+  // since it is animated, we'll test that the down angle has appeared (and
+  // not wait for right angle to disappear)
+  expect(element.firstChild.childNodes[2]).toContainHTML('fa-angle-down');
 });

--- a/packages/renderer/src/lib/preferences/SettingsNavItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/SettingsNavItem.spec.ts
@@ -1,0 +1,99 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import '@testing-library/jest-dom';
+import { test, expect } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import SettingsNavItem from './SettingsNavItem.svelte';
+
+function renderIt(title: string, href: string, meta: any, section?: boolean, child?: boolean): void {
+  render(SettingsNavItem, { title: title, href: href, meta: meta, section: section, child: child });
+}
+
+test('Expect correct role and href', async () => {
+  const title = 'Resources';
+  const href = '/test';
+  renderIt(title, href, { url: href });
+
+  const element = screen.getByLabelText(title);
+  expect(element).toBeInTheDocument();
+  expect(element).toHaveAttribute('href', href);
+});
+
+test('Expect selection styling', async () => {
+  const title = 'Resources';
+  const href = '/test';
+  renderIt(title, href, { url: href });
+
+  const element = screen.getByLabelText(title);
+  expect(element).toBeInTheDocument();
+  expect(element.firstChild).toBeInTheDocument();
+  expect(element.firstChild).toHaveClass('border-purple-500');
+});
+
+test('Expect not to have selection styling', async () => {
+  const title = 'Resources';
+  renderIt(title, '/test', { url: '/elsewhere' });
+
+  const element = screen.getByLabelText(title);
+  expect(element).toBeInTheDocument();
+  expect(element.firstChild).toBeInTheDocument();
+  expect(element.firstChild).not.toHaveClass('border-purple-500');
+  expect(element.firstChild).toHaveClass('border-charcoal-600');
+});
+
+test('Expect child styling', async () => {
+  const title = 'Resources';
+  const href = '/test';
+  renderIt(title, href, { url: href }, false, true);
+
+  const element = screen.getByLabelText(title);
+  expect(element).toBeInTheDocument();
+  expect(element.firstChild).toBeInTheDocument();
+  expect(element.firstChild).toHaveClass('leading-none');
+});
+
+test('Expect section styling', async () => {
+  const title = 'Extensions';
+  const href = '/test';
+  renderIt(title, href, { url: href }, true, false);
+
+  const element = screen.getByLabelText(title);
+  expect(element).toBeInTheDocument();
+  expect(element.firstChild).toBeInTheDocument();
+  expect(element.firstChild.childNodes[2]).toBeInTheDocument();
+  expect(element.firstChild.childNodes[2]).toHaveClass('fas');
+});
+
+test('Expect sections expand', async () => {
+  const title = 'Extensions';
+  const href = '/test';
+  renderIt(title, href, { url: href }, true, false);
+
+  const element = screen.getByLabelText(title);
+  expect(element).toBeInTheDocument();
+  expect(element.firstChild).toBeInTheDocument();
+  expect(element.firstChild.childNodes[2]).toBeInTheDocument();
+  expect(element.firstChild.childNodes[2]).toHaveClass('fa-angle-right');
+
+  await fireEvent.click(element);
+
+  expect(element.firstChild.childNodes[2]).toHaveClass('fa-angle-down');
+});

--- a/packages/renderer/src/lib/preferences/SettingsNavItem.svelte
+++ b/packages/renderer/src/lib/preferences/SettingsNavItem.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+import type { TinroRouteMeta } from 'tinro';
+
+export let title: string;
+export let href: string;
+export let meta: TinroRouteMeta;
+export let section = false;
+export let expanded = false;
+export let child = false;
+
+let selected: boolean;
+$: selected = meta.url === href;
+</script>
+
+<a class="no-underline" href="{href}" aria-label="{title}" on:click="{() => (expanded = !expanded)}">
+  <div
+    class="flex w-full pr-1 justify-between items-center cursor-pointer border-l-[4px] border-charcoal-600"
+    class:text-white="{selected}"
+    class:py-3="{!child}"
+    class:pl-3="{!child}"
+    class:py-2="{child}"
+    class:pl-4="{child}"
+    class:leading-none="{child}"
+    class:text-sm="{child}"
+    class:font-extralight="{child}"
+    class:font-semibold="{!child}"
+    class:bg-charcoal-300="{selected}"
+    class:border-purple-500="{selected}"
+    class:text-gray-400="{!selected}"
+    class:hover:text-gray-300="{!selected}"
+    class:hover:bg-charcoal-500="{!selected}"
+    class:hover:border-charcoal-500="{!selected}">
+    <span class="block group-hover:block" class:capitalize="{!child}">{title}</span>
+    {#if section}
+      <i class="fas {expanded ? 'fa-angle-down' : 'fa-angle-right'} text-lg px-2" aria-hidden="true"></i>
+    {/if}
+  </div>
+</a>

--- a/packages/renderer/src/lib/preferences/SettingsNavItem.svelte
+++ b/packages/renderer/src/lib/preferences/SettingsNavItem.svelte
@@ -10,6 +10,18 @@ export let child = false;
 
 let selected: boolean;
 $: selected = meta.url === href;
+
+function rotate(node, { clockwise = true }) {
+  return {
+    duration: 200,
+    css: (t, u) => {
+      if (!clockwise) u = -u;
+      return `
+        transform: rotate(${u * 90}deg);
+        transform-origin: center center;`;
+    },
+  };
+}
 </script>
 
 <a class="no-underline" href="{href}" aria-label="{title}" on:click="{() => (expanded = !expanded)}">
@@ -32,7 +44,21 @@ $: selected = meta.url === href;
     class:hover:border-charcoal-500="{!selected}">
     <span class="block group-hover:block" class:capitalize="{!child}">{title}</span>
     {#if section}
-      <i class="fas {expanded ? 'fa-angle-down' : 'fa-angle-right'} text-lg px-2" aria-hidden="true"></i>
+      <div class="px-2 relative w-4 h-4">
+        {#if expanded}
+          <i
+            class="fas fa-angle-down text-lg absolute left-0 top-0"
+            aria-hidden="true"
+            in:rotate="{{ clockwise: false }}"
+            out:rotate="{{ clockwise: false }}"></i>
+        {:else}
+          <i
+            class="fas fa-angle-right text-lg absolute left-0 top-0"
+            aria-hidden="true"
+            in:rotate="{{}}"
+            out:rotate="{{}}"></i>
+        {/if}
+      </div>
     {/if}
   </div>
 </a>


### PR DESCRIPTION
### What does this PR do?

I tried the same thing for preferences navigation as I did for the main nav bar in PR #3404: a SettingsNavItem component makes PreferencesNavigation far simpler.

Matching the PF styling was relatively straight-forward, but I have changed five things:
- bg-color corrected to match our design: charcoal-700.
- Ditto for selection bg-color: charcoal-300.
- This makes the hover color indistinguishable, so I went with charcoal-500 for now.
- PF sections (e.g. Extensions) are never selected when expanded. IMHO this is a defect and fixed here as per the screen cap.
- PF has an abnormally large right margin on child elements, I reduced this so there is less wrapping (see OpenShift Local in the screen cap).

PF has a nice fa-angle animation when you expand/collapse the section which I haven't tried to replicate, but in my highly-biased opinion that should not hold this PR up.

### Screenshot/screencast of this PR

Before:

<img width="283" alt="Screenshot 2023-08-03 at 2 44 18 PM" src="https://github.com/containers/podman-desktop/assets/19958075/47ba0ca6-1341-47ad-bcb4-801fe04f76e9">

After:

<img width="283" alt="Screenshot 2023-08-03 at 2 40 10 PM" src="https://github.com/containers/podman-desktop/assets/19958075/c7ba2e84-bd25-4e38-bc8c-910fc9cf4e38">

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Go to each of the pages in Settings and check for visual regressions.