### PR TITLE
feat(dd): allow for contrib manager to handle compose part

### DIFF
--- a/packages/main/src/plugin/contribution-manager.ts
+++ b/packages/main/src/plugin/contribution-manager.ts
@@ -22,7 +22,11 @@ import type { ContributionInfo } from './api/contribution-info.js';
 import type { ApiSenderType } from './api.js';
 import type { Directories } from './directories.js';
 import { getFreePort } from './util/port.js';
+import { exec } from './util/exec.js';
 import * as jsYaml from 'js-yaml';
+import type { RunResult } from '@podman-desktop/api';
+import type { ContainerProviderRegistry } from './container-registry.js';
+import { isLinux, isMac, isWindows } from '../util.js';
 
 export interface DockerExtensionMetadata {
   name: string;
@@ -52,18 +56,24 @@ interface ComposeObject {
  * Contribution manager to provide the list of external OCI contributions
  */
 export class ContributionManager {
-  private contributions: ContributionInfo[] = [];
+  protected contributions: ContributionInfo[] = [];
 
   private static readonly VM_COMPOSE_FILE = 'vm-compose/docker-compose.yaml';
   private static readonly VM_PORTNUMBER_FILE = 'vm-compose/port-number';
 
   private static readonly GLOBAL_PORTS_FILE = 'ports-file';
 
+  protected startedContributions = new Map<string, boolean>();
+
   //an empty svg icon <svg xmlns="http://www.w3.org/2000/svg" width="1" height="1"/>
   private readonly EMPTY_ICON =
     'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxIiBoZWlnaHQ9IjEiLz4=';
 
-  constructor(private apiSender: ApiSenderType, private directories: Directories) {}
+  constructor(
+    private apiSender: ApiSenderType,
+    private directories: Directories,
+    private containerRegistry: ContainerProviderRegistry,
+  ) {}
 
   // load the existing contributions
   async init(): Promise<void> {
@@ -96,6 +106,20 @@ export class ContributionManager {
 
           const uiUri = `file://${path.join(directory, uiMetadata.root, uiMetadata.src)}`;
 
+          // is there a compose-file that has been added ?
+          const composeFile = path.join(directory, ContributionManager.VM_COMPOSE_FILE);
+          let vmCustomizedComposeFile: string | undefined;
+          let vmServicePort: number | undefined;
+          if (fs.existsSync(composeFile)) {
+            vmCustomizedComposeFile = composeFile;
+            // do we have a port to use ?
+            const portFile = path.join(directory, ContributionManager.VM_PORTNUMBER_FILE);
+            if (fs.existsSync(portFile)) {
+              // content is the port number
+              vmServicePort = parseInt(fs.readFileSync(portFile, 'utf-8'));
+            }
+          }
+
           const contribution: ContributionInfo = {
             id: key,
             extensionId,
@@ -103,6 +127,8 @@ export class ContributionManager {
             type: 'docker',
             uiUri,
             icon,
+            vmCustomizedComposeFile,
+            vmServicePort,
             hostEnvPath: path.join(directory, 'host'),
             storagePath: directory,
           };
@@ -114,6 +140,213 @@ export class ContributionManager {
     // flatten
     this.contributions = allContribs.flat();
     this.apiSender.send('contribution-register', this.contributions);
+
+    // start vm engine but do not hold before returning
+    this.startVMs().catch((error: unknown) => {
+      console.log('unable to start VMs', error);
+    });
+  }
+
+  // search docker-compose binary
+  async findComposeBinary(): Promise<string | undefined> {
+    const binaries = [];
+    if (isWindows()) {
+      binaries.push('docker-compose.exe');
+    } else if (isMac()) {
+      binaries.push('/usr/local/bin/docker-compose');
+      binaries.push('/opt/homebrew/bin/docker-compose');
+    } else if (isLinux()) {
+      binaries.push('/usr/bin/docker-compose');
+      binaries.push('/usr/local/bin/docker-compose');
+    }
+
+    // ok, now check if one of them exists
+    for (const binary of binaries) {
+      // unix / mac check if file exists
+      if (!isWindows() && !fs.existsSync(binary)) {
+        continue;
+      }
+
+      // check if docker-compose can be executed
+      try {
+        await exec(binary, ['--version']);
+        // yes, return it
+        return binary;
+      } catch (error) {
+        return undefined;
+      }
+    }
+  }
+
+  async startVM(extensionId: string, vmCustomizedComposeFile?: string, monitorVM?: boolean): Promise<void> {
+    if (!vmCustomizedComposeFile) {
+      console.log(`skip extensionId ${extensionId} start as there is no vmCustomizedComposeFile parameter`);
+      return;
+    }
+    // is it started ? if yes do nothing
+    if (this.startedContributions.get(extensionId)) {
+      console.log(`skip already started VM for extension ${extensionId}`);
+      return;
+    }
+    this.startedContributions.set(extensionId, true);
+
+    // need to start the compose file using docker-compose
+
+    // first, grab directory where to execute compose
+    const composeDirectory = path.dirname(vmCustomizedComposeFile);
+
+    const projectName = this.getComposeProjectNameFromId(extensionId);
+
+    // then execute docker-compose in background
+    const composeArgs = ['-p', projectName, 'up', '-d'];
+    await this.execComposeCommand(composeDirectory, composeArgs);
+
+    // if monitorVM is true, we need to monitor the VM
+
+    if (monitorVM) {
+      // wait that it's in running state (or timeout)
+      await this.waitForRunningState(composeDirectory, projectName);
+    }
+  }
+
+  async waitForAContainerConnection(): Promise<void> {
+    let resolved = false;
+    return new Promise<void>(resolve => {
+      this.apiSender.receive('extensions-started', () => {
+        if (resolved) {
+          return;
+        }
+        // do we have
+        try {
+          this.containerRegistry.getFirstRunningConnection();
+          resolve();
+          resolved = true;
+        } catch (error) {
+          // no we don't, so we wait until we have extension started event
+
+          this.apiSender.receive('provider-change', () => {
+            if (resolved) {
+              return;
+            }
+            try {
+              this.containerRegistry.getFirstRunningConnection();
+              resolve();
+              resolved = true;
+            } catch (error) {
+              console.trace(
+                'Wait for a running container engine to start. Was not able to grab a running engine. Will wait the next provider change',
+                error,
+              );
+            }
+          });
+        }
+      });
+    });
+  }
+
+  // start the VMs of extensions supporting this flag
+  async startVMs(): Promise<void> {
+    // no contributions with vm, skip
+    if (this.contributions.filter(contrib => contrib.vmCustomizedComposeFile).length === 0) {
+      return;
+    }
+
+    // wait that we have a container connection (to execute compose stuff)
+    await this.waitForAContainerConnection();
+
+    for (const contribution of this.contributions) {
+      // start if there is a compose file
+      if (contribution.vmCustomizedComposeFile) {
+        await this.startVM(contribution.extensionId, contribution.vmCustomizedComposeFile);
+      }
+    }
+  }
+
+  async isPodmanDesktopServiceAlive(composeDirectory: string, projectName: string): Promise<boolean> {
+    const psCheck = ['-p', projectName, 'ps', '--format', 'json'];
+
+    const result = await this.execComposeCommand(composeDirectory, psCheck);
+    // parse the result
+    let jsonResultPs;
+    try {
+      jsonResultPs = JSON.parse(result.stdout);
+    } catch (error) {
+      throw new Error(`unable to parse the result of the ps command ${result.stdout}`);
+    }
+
+    // check jsonResultPs is an array
+    if (!Array.isArray(jsonResultPs)) {
+      throw new Error(`unable to parse the result of the ps command ${result.stdout}. Expect array but it is not`);
+    }
+
+    // check we have the podman desktop service running
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const podmanDesktopService = jsonResultPs.find((item: any) => item.Service === 'podman-desktop-socket');
+
+    if (!podmanDesktopService) {
+      throw new Error(`unable to find the podman-desktop-socket service in the ps command ${result.stdout}`);
+    }
+
+    return podmanDesktopService.State === 'running';
+  }
+
+  // wait for at least 30s and then abort
+  async waitForRunningState(composeDirectory: string, projectName: string, maxWait?: number): Promise<void> {
+    // compute current date
+    const startDate = new Date();
+    if (!maxWait) {
+      maxWait = 30 * 1000; // 30s
+    }
+
+    const endDate = new Date(startDate.getTime() + maxWait).getTime();
+
+    let alive = false;
+    try {
+      alive = await this.isPodmanDesktopServiceAlive(composeDirectory, projectName);
+    } catch (error) {
+      console.log('error while checking if podman-desktop-socket is alive', error);
+    }
+
+    // loop until we reach the max duration
+    while (new Date().getTime() < endDate && !alive) {
+      try {
+        alive = await this.isPodmanDesktopServiceAlive(composeDirectory, projectName);
+      } catch (error) {
+        console.log('error appeared while checking if podman-desktop-socket is alive', error);
+      }
+
+      // wait 1second
+      await new Promise(resolve => setTimeout(resolve, 1000));
+    }
+
+    if (!alive) {
+      throw new Error(`The podman-desktop-socket service is not running after ${maxWait}ms`);
+    }
+  }
+
+  // must consist only of lowercase alphanumeric characters, hyphens, and underscores as well as start with a letter or number"
+  getComposeProjectNameFromId(extensionId: string): string {
+    // add also a prefix to avoid collision with other compose files
+    return `podman-desktop-ext-${extensionId.toLowerCase().replace(/[^a-z0-9-]/g, '-')}`;
+  }
+
+  async execComposeCommand(cwd: string, args: string[]): Promise<RunResult> {
+    const composeBinary = await this.findComposeBinary();
+    if (!composeBinary) {
+      throw new Error('Unable to find docker-compose binary');
+    }
+
+    // grab current connection
+    const connection = this.containerRegistry.getFirstRunningConnection();
+    const providerContainerConnectionInfo = connection[0];
+
+    const socketPath = providerContainerConnectionInfo.endpoint.socketPath;
+    const DOCKER_HOST = `unix://${socketPath}`;
+    const env = {
+      // add DOCKER_HOST
+      DOCKER_HOST: DOCKER_HOST,
+    };
+    return exec(composeBinary, args, { env, cwd });
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -181,6 +414,23 @@ export class ContributionManager {
     const matching = this.contributions.find(contribution => contribution.extensionId === extensionId);
     if (!matching) {
       throw new Error('Unable to find the extension' + extensionId);
+    }
+
+    // need to remove all compose containers if any
+    if (matching.vmCustomizedComposeFile) {
+      // need to stop the compose file using docker-compose
+
+      // first, grab directory where to execute compose
+      const composeDirectory = path.dirname(matching.vmCustomizedComposeFile);
+
+      // then execute docker-compose
+      const composeArgs = ['-p', this.getComposeProjectNameFromId(matching.extensionId), 'down'];
+
+      // execute the down command
+      await this.execComposeCommand(composeDirectory, composeArgs);
+
+      // flag as not started
+      this.startedContributions.delete(matching.extensionId);
     }
 
     const extensionPath = matching.storagePath;

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -693,7 +693,7 @@ export class PluginSystem {
     // setup security restrictions on links
     await this.setupSecurityRestrictionsOnLinks(messageBox);
 
-    const contributionManager = new ContributionManager(apiSender, directories);
+    const contributionManager = new ContributionManager(apiSender, directories, containerProviderRegistry);
     this.ipcHandle('container-provider-registry:listContainers', async (): Promise<ContainerInfo[]> => {
       return containerProviderRegistry.listContainers();
     });


### PR DESCRIPTION

### What does this PR do?
it will do compose up and wait a service is started and do compose down (on deletion)

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?

part of https://github.com/containers/podman-desktop/issues/2397

### How to test this PR?

unit tests added
