### PR TITLE
docs: fix typo in package name gcc-c++

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,7 @@ Optional Linux requirements:
 - GNU C and C++ compiler
   Fedora/RHEL
   ```sh
-  dnf install gpp-c++
+  dnf install gcc-c++
   ```
   Ubuntu/Debian
   ```sh


### PR DESCRIPTION
### What does this PR do?

This PR fixes a typo in CONTRIBUTING.md in the gcc-c++ package name.

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

N/A

### How to test this PR?

N/A
