### PR TITLE
feat(dd): add support for backend extensions of Docker Desktop

### DIFF
--- a/packages/main/src/plugin/docker-extension/docker-desktop-installation.spec.ts
+++ b/packages/main/src/plugin/docker-extension/docker-desktop-installation.spec.ts
@@ -36,9 +36,15 @@ let dockerDesktopInstallation: TestDockerDesktopInstallation;
 
 const contributionManagerLoadMetadataMock = vi.fn();
 const contributionManagerInitMock = vi.fn();
+const contributionManagerFindComposeBinaryMock = vi.fn();
+const contributionManagerEnhanceComposeFileMock = vi.fn();
+const containerProviderStartVMMock = vi.fn();
 const contributionManager = {
   init: contributionManagerInitMock,
   loadMetadata: contributionManagerLoadMetadataMock,
+  findComposeBinary: contributionManagerFindComposeBinaryMock,
+  enhanceComposeFile: contributionManagerEnhanceComposeFileMock,
+  startVM: containerProviderStartVMMock,
 } as unknown as ContributionManager;
 
 const containerProviderGetFirstRunningConnectionMock = vi.fn();
@@ -318,8 +324,17 @@ test('Check handlePluginInstall', async () => {
   // mock extractDockerDesktopFiles
   vi.spyOn(dockerDesktopInstallation, 'extractDockerDesktopFiles').mockResolvedValue();
 
+  // mock findComposeBinary
+  contributionManagerFindComposeBinaryMock.mockResolvedValue('/my-compose-binary');
+
+  // mock enhanceComposeFile
+  contributionManagerEnhanceComposeFileMock.mockResolvedValue('/my-enhanced-compose-file.yaml');
+
   contributionManagerLoadMetadataMock.mockResolvedValue({
     name: 'My Extension',
+    vm: {
+      composefile: 'docker-compose.yaml',
+    },
   });
 
   const logCallbackId = 2503;
@@ -336,4 +351,6 @@ test('Check handlePluginInstall', async () => {
 
   // contribution manager is called
   expect(contributionManagerInitMock).toBeCalled();
+
+  expect(containerProviderStartVMMock).toBeCalledWith('My Extension', '/my-enhanced-compose-file.yaml', true);
 });

--- a/packages/preload-docker-extension/src/index.ts
+++ b/packages/preload-docker-extension/src/index.ts
@@ -295,40 +295,44 @@ export class DockerExtensionPreload {
       hostname,
     };
 
+    const vmServicePort = urlParams.get('vmServicePort') || undefined;
+
+    // do we have a service being exposed ?
+    const doRequest = async (config: RequestConfig): Promise<unknown> => {
+      if (vmServicePort) {
+        return ipcRenderer.invoke('docker-desktop-adapter:extensionVMServiceRequest', vmServicePort, config);
+      } else {
+        throw new Error(`no service port defined for request ${config}`);
+      }
+    };
+
     const extensionVMService: dockerDesktopAPI.HttpService = {
       get: async (url: string): Promise<unknown> => {
-        console.error('extensionVMService.get not implemented', url);
-        return {} as any;
+        return doRequest({ url, method: 'GET', headers: {}, data: undefined });
       },
       post: async (url: string, data: any): Promise<unknown> => {
-        console.error('extensionVMService.post not implemented', url, data);
-        return {} as any;
+        return doRequest({ url, method: 'POST', headers: {}, data });
       },
       put: async (url: string, data: any): Promise<unknown> => {
-        console.error('extensionVMService.put not implemented', url, data);
-        return {} as any;
+        return doRequest({ url, method: 'PUT', headers: {}, data });
       },
       patch: async (url: string, data: any): Promise<unknown> => {
-        console.error('extensionVMService.patch not implemented', url, data);
-        return {} as any;
+        return doRequest({ url, method: 'PATCH', headers: {}, data });
       },
       delete: async (url: string): Promise<unknown> => {
-        console.error('extensionVMService.delete not implemented', url);
-        return {} as any;
+        return doRequest({ url, method: 'DELETE', headers: {}, data: undefined });
       },
       head: async (url: string): Promise<unknown> => {
-        console.error('extensionVMService.head not implemented', url);
-        return {} as any;
+        return doRequest({ url, method: 'HEAD', headers: {}, data: undefined });
       },
       request: async (config: RequestConfig): Promise<unknown> => {
-        console.error('extensionVMService.request not implemented', config);
-        return {} as any;
+        return doRequest(config);
       },
     };
 
     const extensionCliVM: dockerDesktopAPI.ExtensionCli = {
-      //FIXME:
-      exec: {} as any,
+      // need to call exec inside a container for the VM service
+      exec: this.getExec('VM_SERVICE'),
     };
 
     const extensionVM: dockerDesktopAPI.ExtensionVM = {

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -1229,7 +1229,7 @@ function initExposure(): void {
   });
 
   contextBridge.exposeInMainWorld('ddExtensionDelete', async (extensionName: string): Promise<void> => {
-    return ipcRenderer.invoke('docker-desktop-plugin:delete', extensionName);
+    return ipcInvoke('docker-desktop-plugin:delete', extensionName);
   });
 
   contextBridge.exposeInMainWorld('getDDPreloadPath', async (): Promise<string> => {

--- a/packages/renderer/src/lib/docker-extension/DockerExtension.svelte
+++ b/packages/renderer/src/lib/docker-extension/DockerExtension.svelte
@@ -41,7 +41,7 @@ window.events?.receive('dev-tools:open-extension', extensionId => {
   <Route path="/*" breadcrumb="{name}">
     <webview
       id="dd-webview-{webviewId}"
-      src="{source}?extensionName={currentContrib.extensionId}&arch={arch}&hostname={hostname}&platform={platform}"
+      src="{source}?extensionName={currentContrib.extensionId}&arch={arch}&hostname={hostname}&platform={platform}&vmServicePort={currentContrib.vmServicePort}"
       preload="{preloadPath}"
       style="height: 100%; width: 100%"></webview>
   </Route>


### PR DESCRIPTION
### What does this PR do?

Add support for backend extensions of Docker Desktop

### Screenshot/screencast of this PR



### What issues does this PR fix or reference?

fix https://github.com/containers/podman-desktop/issues/2397

### How to test this PR?

Unit tests are there but it needs checks on different system like Windows


First, you need a valid '`docker-compose` binary existing as extensions rely on compose stuff.

You can try `tailscale` but I found some bugs that I reported here https://github.com/tailscale/docker-extension/pulls
so instead of using the 'official image' you should try using `quay.io/fbenoit/tailscale-docker-extension:20230731` (that includes the 2 PRs)

You could check if the extension reported in the issue works

Go to settings/Docker Desktop extensions and try to install `digmaai/digma-docker-extension:0.6.52`




