### PR TITLE
nit: fix length of template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,12 +2,13 @@
 
 ### Screenshot/screencast of this PR
 
-<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
+<!-- Please include a screenshot or a screencast 
+explaining what is doing this PR -->
 
 ### What issues does this PR fix or reference?
 
-<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
--->
+<!-- Include any related issues from Podman Desktop 
+repository (or from another issue tracker). -->
 
 ### How to test this PR?
 


### PR DESCRIPTION
nit: fix length of template

### What does this PR do?

Fix the length of the template so the width is under 100 characters.
Each time that you run the 'verify' git scripts, it complains about the
comments being too long. So you always have to remove the "Include any
related issues" part.

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast
explaining what is doing this PR -->

N/A

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

N/A

### How to test this PR?

N/A

<!-- Please explain steps to reproduce -->

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
