### PR TITLE
chore: currentRouterPath is not defined so remove code using it

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesConnectionDetailsLogs.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionDetailsLogs.svelte
@@ -14,7 +14,6 @@ import type {
 import { TerminalSettings } from '../../../../main/src/plugin/terminal-settings';
 
 export let providerInternalId: string = undefined;
-export let connection: string = undefined;
 export let connectionInfo: ProviderContainerConnectionInfo | ProviderKubernetesConnectionInfo = undefined;
 export let setNoLogs: () => void;
 export let noLog: boolean;
@@ -28,9 +27,6 @@ let logsXtermDiv: HTMLDivElement;
 // Terminal resize
 let resizeObserver: ResizeObserver;
 let termFit: FitAddon;
-
-// need to refresh logs when container is switched or state changes
-let currentRouterPath: string;
 
 async function refreshTerminal() {
   // missing element, return
@@ -47,12 +43,6 @@ async function refreshTerminal() {
   // disable cursor
   logsTerminal.write('\x1b[?25l');
 
-  // call fit addon each time we resize the window
-  window.addEventListener('resize', () => {
-    if (currentRouterPath === `/container-connection/${providerInternalId}/${connection}/logs`) {
-      termFit?.fit();
-    }
-  });
   termFit.fit();
 }
 

--- a/packages/renderer/src/lib/preferences/PreferencesContainerConnectionRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesContainerConnectionRendering.svelte
@@ -155,7 +155,6 @@ function setNoLogs() {
           <Route path="/logs" breadcrumb="Logs" navigationHint="tab">
             <PreferencesConnectionDetailsLogs
               providerInternalId="{providerInternalId}"
-              connection="{connection}"
               connectionInfo="{connectionInfo}"
               setNoLogs="{setNoLogs}"
               noLog="{noLog}" />

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesConnectionRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesConnectionRendering.svelte
@@ -157,7 +157,6 @@ function setNoLogs() {
           </Route>
           <Route path="/logs" breadcrumb="Logs" navigationHint="tab">
             <PreferencesConnectionDetailsLogs
-              connection="{apiUrlBase64}"
               providerInternalId="{providerInternalId}"
               connectionInfo="{connectionInfo}"
               setNoLogs="{setNoLogs}"


### PR DESCRIPTION
### What does this PR do?
while looking at https://github.com/containers/podman-desktop/issues/3401
I noticed we have a listener and a check using currentRouterPath
but I don't see this value being assigned so I don't know how the condition could be met

anyway the condition would be broken as we arrive from both `/container-connection` and `/kubernetes-connection`
so delete the code

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Logs in Resources Preferences should work as usual
(so check logs for like a podman machine and for a Kind cluster)