### PR TITLE
fix: add maximum activation time for extensions

### DIFF
--- a/packages/main/src/plugin/extension-loader-settings.ts
+++ b/packages/main/src/plugin/extension-loader-settings.ts
@@ -1,0 +1,22 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+export enum ExtensionLoaderSettings {
+  SectionName = 'extensions',
+  MaxActivationTime = 'maxActivationTime',
+}

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -222,7 +222,7 @@ export class ExtensionLoader {
         [ExtensionLoaderSettings.SectionName + '.' + ExtensionLoaderSettings.MaxActivationTime]: {
           description: 'Maximum activation time for an extension, in seconds.',
           type: 'number',
-          default: 5,
+          default: 10,
           minimum: 1,
           maximum: 100,
         },

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -25,7 +25,7 @@ import * as zipper from 'zip-local';
 import type { TrayMenuRegistry } from './tray-menu-registry.js';
 import { Disposable } from './types/disposable.js';
 import type { ProviderRegistry } from './provider-registry.js';
-import type { ConfigurationRegistry } from './configuration-registry.js';
+import type { ConfigurationRegistry, IConfigurationNode } from './configuration-registry.js';
 import type { ImageRegistry } from './image-registry.js';
 import type { MessageBox } from './message-box.js';
 import type { ProgressImpl } from './progress-impl.js';
@@ -65,6 +65,7 @@ import type { Context } from './context/context.js';
 import type { OnboardingRegistry } from './onboarding-registry.js';
 import { createHttpPatchedModules } from './proxy-resolver.js';
 import { ModuleLoader } from './module-loader.js';
+import { ExtensionLoaderSettings } from './extension-loader-settings.js';
 
 /**
  * Handle the loading of an extension
@@ -212,6 +213,23 @@ export class ExtensionLoader {
     this.moduleLoader.addOverride({ '@podman-desktop/api': ext => ext.api }); // add podman desktop API
 
     this.moduleLoader.overrideRequire();
+    // register configuration for the max activation time
+    const maxActivationTimeConfiguration: IConfigurationNode = {
+      id: 'preferences.extension',
+      title: 'Extensions',
+      type: 'object',
+      properties: {
+        [ExtensionLoaderSettings.SectionName + '.' + ExtensionLoaderSettings.MaxActivationTime]: {
+          description: 'Maximum activation time for an extension, in seconds.',
+          type: 'number',
+          default: 5,
+          minimum: 1,
+          maximum: 100,
+        },
+      },
+    };
+
+    this.configurationRegistry.registerConfigurations([maxActivationTimeConfiguration]);
   }
 
   protected async setupScanningDirectory(): Promise<void> {
@@ -1045,10 +1063,35 @@ export class ExtensionLoader {
     const telemetryOptions = { extensionId: extension.id };
     try {
       if (typeof extensionMain?.['activate'] === 'function') {
+        // maximum time to wait for the extension to activate by reading from configuration
+        const delayInSeconds: number =
+          this.configurationRegistry
+            .getConfiguration(ExtensionLoaderSettings.SectionName)
+            .get(ExtensionLoaderSettings.MaxActivationTime) || 5;
+        const delayInMilliseconds = delayInSeconds * 1000;
+
+        // reject a promise after this delay
+        const timeoutPromise = new Promise((_, reject) =>
+          setTimeout(
+            () => reject(new Error(`Extension ${extension.id} activation timed out after ${delayInSeconds} seconds`)),
+            delayInMilliseconds,
+          ),
+        );
+
         // it returns exports
-        console.log(`Activating extension (${extension.id})`);
-        await extensionMain['activate'].apply(undefined, [extensionContext]);
-        console.log(`Activating extension (${extension.id}) ended`);
+        console.log(`Activating extension (${extension.id}) with max activation time of ${delayInSeconds} seconds`);
+
+        const beforeActivateTime = performance.now();
+        const activatePromise = extensionMain['activate'].apply(undefined, [extensionContext]);
+
+        // if extension reach the timeout, do not wait for it to finish and flag as error
+        await Promise.race([activatePromise, timeoutPromise]);
+        const afterActivateTime = performance.now();
+        console.log(
+          `Activating extension (${extension.id}) ended in ${Math.round(
+            afterActivateTime - beforeActivateTime,
+          )} milliseconds`,
+        );
       }
       const id = extension.id;
       const activatedExtension: ActivatedExtension = {


### PR DESCRIPTION
after reaching that time, loader continue without waiting for this extension extension is flagged as a failed extension

fixes https://github.com/containers/podman-desktop/issues/3280 fixes https://github.com/containers/podman-desktop/issues/2993

### What does this PR do?
add maximum activation time for extensions (configurable)

after reaching that time, loader continue without waiting for this extension
extension is flagged as a failed extension

### Screenshot/screencast of this PR
![image](https://github.com/containers/podman-desktop/assets/436777/53caaf88-52dc-45d0-868a-061788a50ec7)



### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/3280
fixes https://github.com/containers/podman-desktop/issues/2993

### How to test this PR?

Unit test is provided

but you can also add a `await new Promise(r => setTimeout(r, 10000));` instruction in one activate method of an extension
(extension should report as having failed)
