### PR TITLE
chore(tests): include junit,verbose reporters and junit report output…

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -212,7 +212,7 @@ jobs:
       - uses: actions/upload-artifact@v3.1.2
         if: always()
         with:
-          name: tests
+          name: unit-tests
           path: ./tests/output/
 
   smoke-e2e-tests:
@@ -245,5 +245,5 @@ jobs:
       - uses: actions/upload-artifact@v3.1.2
         if: always()
         with:
-          name: tests
+          name: smoke-e2e-tests
           path: ./tests/output/

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -209,12 +209,6 @@ jobs:
       - name: Run svelte check
         run: yarn svelte:check
 
-      - uses: actions/upload-artifact@v3.1.2
-        if: always()
-        with:
-          name: unit-tests
-          path: ./tests/output/
-
   smoke-e2e-tests:
     name: smoke e2e tests
     runs-on: ubuntu-22.04

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -34,7 +34,7 @@ const config = {
      * By default, vitest search test files in all packages.
      * For e2e tests have sense search only is project root tests folder
      */
-    include: ['**/{src,tests}/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+    include: ['**/tests/src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
     exclude: [
       '**/builtin/**',
       '**/node_modules/**',

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -48,6 +48,9 @@ const config = {
      */
     testTimeout: 60_000,
     hookTimeout: 60_000,
+    // test reporters - default for all and junit for CI
+    reporters: process.env.CI ? ['default', 'junit'] : ['default'],
+    outputFile: process.env.CI ? { junit: 'tests/output/junit-results.xml' } : {},
   },
   resolve: {
     alias: {


### PR DESCRIPTION
… file

### What does this PR do?
Adds new reporter (junit) and verbose one, which should mostly be valuable when there are tests failures. It also produces a junit report xml file under `tests/output`, it does not introduce any new location or anything. It can be processed on CI then.

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast 
explaining what is doing this PR -->

### What issues does this PR fix or reference?
#3292 
<!-- Include any related issues from Podman Desktop 
repository (or from another issue tracker). -->

### How to test this PR?
`yarn test:e2e:smoke` -> there will be `tests/output/junit-results.xml` file with all test cases results.
<!-- Please explain steps to reproduce -->
