### PR TITLE
chore(tests): setup after test hooks to take a screenhot on failure

### DIFF
--- a/tests/src/container-smoke.spec.ts
+++ b/tests/src/container-smoke.spec.ts
@@ -17,7 +17,8 @@
  ***********************************************************************/
 
 import type { Page } from 'playwright';
-import { afterAll, beforeAll, test, describe } from 'vitest';
+import type { PDRunnerTestContext } from 'vitest';
+import { afterAll, beforeAll, test, describe, beforeEach } from 'vitest';
 import { expect as playExpect } from '@playwright/test';
 import { PodmanDesktopRunner } from './runner/podman-desktop-runner';
 import { WelcomePage } from './model/pages/welcome-page';
@@ -47,6 +48,10 @@ beforeAll(async () => {
     'Images page is empty, there are no images present',
   );
   await deleteContainer(page, containerToRun);
+});
+
+beforeEach<PDRunnerTestContext>(async ctx => {
+  ctx.pdRunner = pdRunner;
 });
 
 afterAll(async () => {

--- a/tests/src/container-smoke.spec.ts
+++ b/tests/src/container-smoke.spec.ts
@@ -17,7 +17,7 @@
  ***********************************************************************/
 
 import type { Page } from 'playwright';
-import type { PDRunnerTestContext } from 'vitest';
+import type { RunnerTestContext } from './testContext/runner-test-context';
 import { afterAll, beforeAll, test, describe, beforeEach } from 'vitest';
 import { expect as playExpect } from '@playwright/test';
 import { PodmanDesktopRunner } from './runner/podman-desktop-runner';
@@ -50,7 +50,7 @@ beforeAll(async () => {
   await deleteContainer(page, containerToRun);
 });
 
-beforeEach<PDRunnerTestContext>(async ctx => {
+beforeEach<RunnerTestContext>(async ctx => {
   ctx.pdRunner = pdRunner;
 });
 

--- a/tests/src/pull-image-smoke.spec.ts
+++ b/tests/src/pull-image-smoke.spec.ts
@@ -17,7 +17,8 @@
  ***********************************************************************/
 
 import type { Page } from 'playwright';
-import { afterAll, beforeAll, test, describe } from 'vitest';
+import type { PDRunnerTestContext } from 'vitest';
+import { afterAll, beforeAll, test, describe, beforeEach } from 'vitest';
 import { expect as playExpect } from '@playwright/test';
 import { PodmanDesktopRunner } from './runner/podman-desktop-runner';
 import { WelcomePage } from './model/pages/welcome-page';
@@ -37,6 +38,10 @@ beforeAll(async () => {
 
 afterAll(async () => {
   await pdRunner.close();
+});
+
+beforeEach<PDRunnerTestContext>(async ctx => {
+  ctx.pdRunner = pdRunner;
 });
 
 describe('Image pull verification', async () => {

--- a/tests/src/pull-image-smoke.spec.ts
+++ b/tests/src/pull-image-smoke.spec.ts
@@ -17,7 +17,7 @@
  ***********************************************************************/
 
 import type { Page } from 'playwright';
-import type { PDRunnerTestContext } from 'vitest';
+import type { RunnerTestContext } from './testContext/runner-test-context';
 import { afterAll, beforeAll, test, describe, beforeEach } from 'vitest';
 import { expect as playExpect } from '@playwright/test';
 import { PodmanDesktopRunner } from './runner/podman-desktop-runner';
@@ -40,7 +40,7 @@ afterAll(async () => {
   await pdRunner.close();
 });
 
-beforeEach<PDRunnerTestContext>(async ctx => {
+beforeEach<RunnerTestContext>(async ctx => {
   ctx.pdRunner = pdRunner;
 });
 

--- a/tests/src/setupFiles/extended-hooks.ts
+++ b/tests/src/setupFiles/extended-hooks.ts
@@ -1,0 +1,23 @@
+import type { PDRunnerTestContext } from 'vitest';
+import { afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+afterEach(async (context: PDRunnerTestContext) => {
+  context.onTestFailed(async () => {
+    const normalizedFilePath = context.task.name
+      .replace(/'/g, '')
+      .replace(/\//g, '_')
+      .replace(/:/g, '_')
+      .replace(/ /g, '_');
+    let fileName = `${normalizedFilePath}_failure`;
+    let counter = 0;
+    while (fs.existsSync(path.resolve(context.pdRunner.getTestOutput(), 'screenshots', `${fileName}.png`))) {
+      counter++;
+      fileName = `${fileName}_${counter}`;
+      if (counter > 10) break;
+    }
+    console.log(`Screenshot of the failed test will be saved to: ${fileName}`);
+    await context.pdRunner.screenshot(`${fileName}.png`);
+  });
+});

--- a/tests/src/testContext/runner-test-context.ts
+++ b/tests/src/testContext/runner-test-context.ts
@@ -1,8 +1,6 @@
 import type { TestContext } from 'vitest';
 import type { PodmanDesktopRunner } from '../runner/podman-desktop-runner';
 
-declare module 'vitest' {
-  export interface PDRunnerTestContext extends TestContext {
-    pdRunner: PodmanDesktopRunner;
-  }
+export interface RunnerTestContext extends TestContext {
+  pdRunner: PodmanDesktopRunner;
 }

--- a/tests/src/testContext/runner-test-context.ts
+++ b/tests/src/testContext/runner-test-context.ts
@@ -1,0 +1,8 @@
+import type { TestContext } from 'vitest';
+import type { PodmanDesktopRunner } from '../runner/podman-desktop-runner';
+
+declare module 'vitest' {
+  export interface PDRunnerTestContext extends TestContext {
+    pdRunner: PodmanDesktopRunner;
+  }
+}

--- a/tests/src/welcome-page-smoke.spec.ts
+++ b/tests/src/welcome-page-smoke.spec.ts
@@ -18,7 +18,7 @@
 
 import type { BrowserWindow } from 'electron';
 import type { JSHandle, Page } from 'playwright';
-import type { PDRunnerTestContext } from 'vitest';
+import type { RunnerTestContext } from './testContext/runner-test-context';
 import { afterAll, beforeAll, expect, test, describe, beforeEach } from 'vitest';
 import { expect as playExpect } from '@playwright/test';
 import { PodmanDesktopRunner } from './runner/podman-desktop-runner';
@@ -38,7 +38,7 @@ afterAll(async () => {
   await pdRunner.close();
 });
 
-beforeEach<PDRunnerTestContext>(async ctx => {
+beforeEach<RunnerTestContext>(async ctx => {
   ctx.pdRunner = pdRunner;
 });
 

--- a/tests/src/welcome-page-smoke.spec.ts
+++ b/tests/src/welcome-page-smoke.spec.ts
@@ -18,7 +18,8 @@
 
 import type { BrowserWindow } from 'electron';
 import type { JSHandle, Page } from 'playwright';
-import { afterAll, beforeAll, expect, test, describe } from 'vitest';
+import type { PDRunnerTestContext } from 'vitest';
+import { afterAll, beforeAll, expect, test, describe, beforeEach } from 'vitest';
 import { expect as playExpect } from '@playwright/test';
 import { PodmanDesktopRunner } from './runner/podman-desktop-runner';
 import { WelcomePage } from './model/pages/welcome-page';
@@ -35,6 +36,10 @@ beforeAll(async () => {
 
 afterAll(async () => {
   await pdRunner.close();
+});
+
+beforeEach<PDRunnerTestContext>(async ctx => {
+  ctx.pdRunner = pdRunner;
 });
 
 describe('Basic e2e verification of podman desktop start', async () => {

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -29,6 +29,7 @@ const config = {
     globals: true,
     environment: 'jsdom',
     globalSetup: './tests/src/globalSetup/global-setup.ts',
+    setupFiles: './tests/src/setupFiles/extended-hooks.ts',
     /**
      * By default, vitest search test files in all packages.
      * For e2e tests have sense search only is project root tests folder


### PR DESCRIPTION
### What does this PR do?
I allows to take a screenshot in an afterEach hook defined globally using setupFile on a test failure and save it.

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast 
explaining what is doing this PR -->

### What issues does this PR fix or reference?
#3409 
<!-- Include any related issues from Podman Desktop 
repository (or from another issue tracker). -->

### How to test this PR?
Add a manual test failure into one of the e2e spec files (ie. `expect(1).toBeFalsy()`)
and run `yarn test:e2e:smoke`
<!-- Please explain steps to reproduce -->
