### PR TITLE
feat(api): add listContainers method using Podman API (and not Docker API)

### DIFF
--- a/packages/main/src/plugin/dockerode/libpod-dockerode.spec.ts
+++ b/packages/main/src/plugin/dockerode/libpod-dockerode.spec.ts
@@ -16,7 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { beforeAll, test } from 'vitest';
+/* eslint-disable no-null/no-null */
+
+import { beforeAll, expect, test } from 'vitest';
 import { type LibPod, LibpodDockerode } from '/@/plugin/dockerode/libpod-dockerode.js';
 import Dockerode from 'dockerode';
 import nock from 'nock';
@@ -42,4 +44,50 @@ test('Check force is given with remove pod options', async () => {
     .reply(200);
   const api = new Dockerode({ protocol: 'http', host: 'localhost' });
   await (api as unknown as LibPod).removePod('dummy', { force: true });
+});
+
+test('Check list of containers using Podman API', async () => {
+  const jsonContainers = [
+    {
+      AutoRemove: false,
+      Command: ['httpd-foreground'],
+      Created: '2023-08-09T13:49:31.12068064+02:00',
+      CreatedAt: '',
+      Exited: false,
+      ExitedAt: 1691582587,
+      ExitCode: 0,
+      Id: '37a54a845ef27a212634ef00c994c0793b5f19ec16853d606beb1c929461c1cd',
+      Image: 'docker.io/library/httpd:latest',
+      ImageID: '911d72fc5020723f0c003a134a8d2f062b4aea884474a11d1db7dcd28ce61d6a',
+      IsInfra: false,
+      Labels: null,
+      Mounts: [],
+      Names: ['gallant_solomon'],
+      Namespaces: {},
+      Networks: ['podman'],
+      Pid: 1738,
+      Pod: '',
+      PodName: '',
+      Ports: [
+        {
+          host_ip: '',
+          container_port: 80,
+          host_port: 9090,
+          range: 1,
+          protocol: 'tcp',
+        },
+      ],
+      Size: null,
+      StartedAt: 1691585124,
+      State: 'running',
+      Status: '',
+    },
+  ];
+
+  nock('http://localhost').get('/v4.2.0/libpod/containers/json').reply(200, jsonContainers);
+  const api = new Dockerode({ protocol: 'http', host: 'localhost' });
+  const listOfContainers = await (api as unknown as LibPod).listPodmanContainers();
+  expect(listOfContainers.length).toBe(1);
+  const firstContainer = listOfContainers[0];
+  expect(firstContainer.Id).toBe('37a54a845ef27a212634ef00c994c0793b5f19ec16853d606beb1c929461c1cd');
 });

--- a/packages/main/src/plugin/dockerode/libpod-dockerode.ts
+++ b/packages/main/src/plugin/dockerode/libpod-dockerode.ts
@@ -99,11 +99,25 @@ export interface PodRemoveOptions {
   force: boolean;
 }
 
+export interface PodmanContainerInfo {
+  Id: string;
+  Names: string[];
+  ImageID: string;
+  Image: string;
+  Created: string;
+  State: string;
+  StartedAt: number;
+  Command: string[];
+  Labels: { [label: string]: string };
+  Ports: { host_ip: string; container_port: number; host_port: number; range?: string; protocol: string }[];
+}
+
 // API of libpod that we want to expose on our side
 export interface LibPod {
   createPod(podOptions: PodCreateOptions): Promise<{ Id: string }>;
   createPodmanContainer(containerCreateOptions: ContainerCreateOptions): Promise<{ Id: string; Warnings: string[] }>;
   listPods(): Promise<PodInfo[]>;
+  listPodmanContainers(opts?: { all: boolean }): Promise<PodmanContainerInfo[]>;
   prunePods(): Promise<void>;
   getPodInspect(podId: string): Promise<PodInspectInfo>;
   startPod(podId: string): Promise<void>;
@@ -122,6 +136,27 @@ export class LibpodDockerode {
   enhancePrototypeWithLibPod() {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const prototypeOfDockerode = Dockerode.prototype as any;
+    // add listPodmanContainers
+    prototypeOfDockerode.listPodmanContainers = function (opts?: { all: boolean }) {
+      const optsf = {
+        path: '/v4.2.0/libpod/containers/json',
+        method: 'GET',
+        options: opts,
+        statusCodes: {
+          200: true,
+          400: 'bad parameter',
+          500: 'server error',
+        },
+      };
+      return new Promise((resolve, reject) => {
+        this.modem.dial(optsf, (err: unknown, data: unknown) => {
+          if (err) {
+            return reject(err);
+          }
+          resolve(data);
+        });
+      });
+    };
 
     // add createPodmanContainer
     prototypeOfDockerode.createPodmanContainer = function (containerCreateOptions: ContainerCreateOptions) {


### PR DESCRIPTION
### What does this PR do?

Add the podman API way of getting the list of containers

when using this call, we do have the StartedAt field that we don't have using the Docker/Compat API so it's harder to know when containers has been started (and there are inspect calls for now in Podman Desktop)

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

https://github.com/containers/podman-desktop/issues/3376

### How to test this PR?

unit test provided
