### PR TITLE
chore(tests): setup testing application in with detached devtools

### DIFF
--- a/tests/src/runner/podman-desktop-runner.ts
+++ b/tests/src/runner/podman-desktop-runner.ts
@@ -109,9 +109,8 @@ export class PodmanDesktopRunner {
     const window: JSHandle<BrowserWindow> = await this.getBrowserWindow();
 
     await window.evaluate((mainWindow): Promise<void> => {
-      mainWindow.webContents.closeDevTools();
-      mainWindow.maximize();
       mainWindow.webContents.openDevTools({ mode: 'detach' });
+      mainWindow.focus();
       return new Promise(resolve => {
         if (mainWindow.isVisible()) {
           resolve();
@@ -148,8 +147,8 @@ export class PodmanDesktopRunner {
       recordVideo: {
         dir: directory,
         size: {
-          width: 1280,
-          height: 720,
+          width: 1050,
+          height: 700,
         },
       },
     };

--- a/tests/src/welcome-page-smoke.spec.ts
+++ b/tests/src/welcome-page-smoke.spec.ts
@@ -16,8 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { BrowserWindow } from 'electron';
-import type { JSHandle, Page } from 'playwright';
+import type { Page } from 'playwright';
 import type { RunnerTestContext } from './testContext/runner-test-context';
 import { afterAll, beforeAll, expect, test, describe, beforeEach } from 'vitest';
 import { expect as playExpect } from '@playwright/test';
@@ -45,27 +44,7 @@ beforeEach<RunnerTestContext>(async ctx => {
 describe('Basic e2e verification of podman desktop start', async () => {
   describe('Welcome page handling', async () => {
     test('Check the Welcome page is displayed', async () => {
-      const window: JSHandle<BrowserWindow> = await pdRunner.getBrowserWindow();
-
-      const windowState = await window.evaluate(
-        (mainWindow): Promise<{ isVisible: boolean; isDevToolsOpened: boolean; isCrashed: boolean }> => {
-          const getState = () => ({
-            isVisible: mainWindow.isVisible(),
-            isDevToolsOpened: mainWindow.webContents.isDevToolsOpened(),
-            isCrashed: mainWindow.webContents.isCrashed(),
-          });
-
-          return new Promise(resolve => {
-            /**
-             * The main window is created hidden, and is shown only when it is ready.
-             * See {@link ../packages/main/src/mainWindow.ts} function
-             */
-            if (mainWindow.isVisible()) {
-              resolve(getState());
-            } else mainWindow.once('ready-to-show', () => resolve(getState()));
-          });
-        },
-      );
+      const windowState = await pdRunner.getApplicationState();
       expect(windowState.isCrashed, 'The app has crashed').toBeFalsy();
       expect(windowState.isVisible, 'The main window was not visible').toBeTruthy();
 


### PR DESCRIPTION
### What does this PR do?
It opens dev tools in detach mode, so it does not overlap over tested window.

### Screenshot/screencast of this PR
tb added after e2e tests.
Before:
After:

<!-- Please include a screenshot or a screencast 
explaining what is doing this PR -->

### What issues does this PR fix or reference?
#3434 
<!-- Include any related issues from Podman Desktop 
repository (or from another issue tracker). -->

### How to test this PR?
`yarn test:e2e:smoke`
<!-- Please explain steps to reproduce -->

It should now run in "fullscreen" and devtools windows should not be attached.