### PR TITLE
fix: allow single domain registry such as localhost:5000

### DIFF
--- a/packages/main/src/plugin/image-registry.spec.ts
+++ b/packages/main/src/plugin/image-registry.spec.ts
@@ -385,6 +385,16 @@ describe('expect checkCredentials', async () => {
     );
   });
 
+  test('expect checkCredentials works with a localhost registry', async () => {
+    const spyGetAuthInfo = vi.spyOn(imageRegistry, 'getAuthInfo');
+    spyGetAuthInfo.mockResolvedValue({ authUrl: 'foo', scheme: 'bearer' });
+
+    const spydoCheckCredentials = vi.spyOn(imageRegistry, 'doCheckCredentials');
+    spydoCheckCredentials.mockResolvedValue();
+
+    await imageRegistry.checkCredentials('localhost:5000', 'my-username', 'my-password');
+  });
+
   test('expect checkCredentials works with ignoring the certificate', async () => {
     const spyGetAuthInfo = vi.spyOn(imageRegistry, 'getAuthInfo');
     spyGetAuthInfo.mockResolvedValue({ authUrl: 'foo', scheme: 'bearer' });
@@ -397,6 +407,18 @@ describe('expect checkCredentials', async () => {
       'my-username',
       'my-password',
       true,
+    );
+  });
+
+  test('test checkCredentials fails with a wrong registry input', async () => {
+    const spyGetAuthInfo = vi.spyOn(imageRegistry, 'getAuthInfo');
+    spyGetAuthInfo.mockResolvedValue({ authUrl: 'foo', scheme: 'bearer' });
+
+    const spydoCheckCredentials = vi.spyOn(imageRegistry, 'doCheckCredentials');
+    spydoCheckCredentials.mockResolvedValue();
+
+    await expect(imageRegistry.checkCredentials(':', 'my-username', 'my-password')).rejects.toThrow(
+      'The format of the Registry Location is incorrect.',
     );
   });
 

--- a/packages/main/src/plugin/image-registry.ts
+++ b/packages/main/src/plugin/image-registry.ts
@@ -24,9 +24,7 @@ import type { Telemetry } from './telemetry/telemetry.js';
 import * as crypto from 'node:crypto';
 import type { HttpsOptions, OptionsOfTextResponseBody } from 'got';
 import got, { HTTPError, RequestError } from 'got';
-import validatorPkg from 'validator';
-// workaround for ESM
-const validator: { isURL: (url: string) => boolean } = validatorPkg as unknown as { isURL: (url: string) => boolean };
+import validator from 'validator';
 
 import { HttpProxyAgent, HttpsProxyAgent } from 'hpagent';
 import type { Certificates } from './certificates.js';
@@ -710,7 +708,15 @@ export class ImageRegistry {
   }
 
   async checkCredentials(serviceUrl: string, username: string, password: string, insecure?: boolean): Promise<void> {
-    if (serviceUrl === undefined || !validator.isURL(serviceUrl)) {
+    // When checking the validation of the URL, do not require a TLD (ex. .com, .org, etc.)
+    // in case we are passing in a local test registry such as http://localhost:5000
+    const urlOptions = {
+      require_tld: false,
+    };
+    const isUrl = validator.default.isURL(serviceUrl, urlOptions);
+
+    // Check if the URL is undefined or not a valid URL
+    if (serviceUrl === undefined || !isUrl) {
       throw Error(
         'The format of the Registry Location is incorrect.\nPlease use the format "registry.location.com" and try again.',
       );


### PR DESCRIPTION
fix: allow single domain registry such as localhost:5000

### What does this PR do?

Allows you to add a registry such as "localhost:5000" for testing
purposes, or domains without an LTD.

You are able to do this through the podman/docker CLI, but not through
podman desktop.

### Screenshot/screencast of this PR

You'll now get an error for login / be able to actually add the registry instead of a format error.

![Screenshot 2023-08-09 at 11 10 01 AM](https://github.com/containers/podman-desktop/assets/6422176/5f465e09-70db-4476-a86c-3340991f0a2a)


### What issues does this PR fix or reference?

Closes https://github.com/containers/podman-desktop/issues/3457

One of the fixes towards completing https://github.com/containers/podman-desktop/issues/3252

### How to test this PR?

1. Add a test registry such as "localhost:5000"
2. You'll now get an error for login instead of 'The format of the
   Registry Location is incorrect'

<!-- Please explain steps to reproduce -->

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
