### PR TITLE
chore(tests): allow naming of e2e videos

### DIFF
--- a/tests/src/container-smoke.spec.ts
+++ b/tests/src/container-smoke.spec.ts
@@ -35,6 +35,7 @@ const containerToRun = 'podman-hello';
 beforeAll(async () => {
   pdRunner = new PodmanDesktopRunner();
   page = await pdRunner.start();
+  pdRunner.setVideoName('containers-e2e');
   const welcomePage = new WelcomePage(page);
   await welcomePage.handleWelcomePage(true);
   // wait giving a time to podman desktop to load up

--- a/tests/src/pull-image-smoke.spec.ts
+++ b/tests/src/pull-image-smoke.spec.ts
@@ -30,6 +30,7 @@ let page: Page;
 beforeAll(async () => {
   pdRunner = new PodmanDesktopRunner();
   page = await pdRunner.start();
+  pdRunner.setVideoName('pull-image-e2e');
 
   const welcomePage = new WelcomePage(page);
   await welcomePage.handleWelcomePage(true);

--- a/tests/src/runner/podman-desktop-runner.ts
+++ b/tests/src/runner/podman-desktop-runner.ts
@@ -29,6 +29,7 @@ export class PodmanDesktopRunner {
   private readonly _profile: string;
   private readonly _customFolder;
   private readonly _testOutput: string;
+  private _videoName: string | undefined;
 
   constructor(profile = '', customFolder = 'podman-desktop') {
     this._running = false;
@@ -36,6 +37,7 @@ export class PodmanDesktopRunner {
     this._testOutput = join('tests', 'output', this._profile);
     this._customFolder = join(this._testOutput, customFolder);
     this._options = this.defaultOptions();
+    this._videoName = undefined;
   }
 
   public async start(): Promise<Page> {
@@ -85,12 +87,26 @@ export class PodmanDesktopRunner {
     await this.getPage().screenshot({ path: join(this._testOutput, 'screenshots', filename) });
   }
 
+  async saveVideoAs(path: string) {
+    const video = this.getPage().video();
+    if (video) {
+      await video.saveAs(path);
+    } else {
+      console.log(`Video file associated was not found`);
+    }
+  }
+
   public async close() {
     if (!this.isRunning()) {
       throw Error('Podman Desktop is not running');
     }
     if (this.getElectronApp()) {
       await this.getElectronApp().close();
+    }
+    if (this._videoName) {
+      const videoPath = join(this._testOutput, 'videos', `${this._videoName}.webm`);
+      await this.saveVideoAs(videoPath);
+      console.log(`Saving a video file as: ${videoPath}`);
     }
     this._running = false;
   }
@@ -126,6 +142,10 @@ export class PodmanDesktopRunner {
 
   public setOptions(value: object) {
     this._options = value;
+  }
+
+  public setVideoName(name: string) {
+    this._videoName = name;
   }
 
   public getTestOutput(): string {

--- a/tests/src/welcome-page-smoke.spec.ts
+++ b/tests/src/welcome-page-smoke.spec.ts
@@ -31,6 +31,7 @@ let page: Page;
 beforeAll(async () => {
   pdRunner = new PodmanDesktopRunner('', 'welcome-podman-desktop');
   page = await pdRunner.start();
+  pdRunner.setVideoName('welcome-page-e2e');
 });
 
 afterAll(async () => {


### PR DESCRIPTION
### What does this PR do?
Allow to set a video name associated with a podman runner lifecycle (start->stop) during e2e workflows.
### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast 
explaining what is doing this PR -->

### What issues does this PR fix or reference?
#3337
<!-- Include any related issues from Podman Desktop 
repository (or from another issue tracker). -->

### How to test this PR?
`yarn test:e2e:smoke`

check output folder: `tests/output/videos/*`
<!-- Please explain steps to reproduce -->
