### PR TITLE
fix: allow BASIC authentication (all caps)

### DIFF
--- a/packages/main/src/plugin/image-registry.spec.ts
+++ b/packages/main/src/plugin/image-registry.spec.ts
@@ -106,6 +106,15 @@ test('Should extract auth registry with Amazon ECR registry', async () => {
   expect(authInfo?.scope).toBeUndefined();
 });
 
+test('Should be able to use a local Sonatype Nexus instance that uses localhost and BASIC response', async () => {
+  const authInfo = imageRegistry.extractAuthData('BASIC realm="http://localhost:8082",service="test.sonatype.com"');
+  expect(authInfo).toBeDefined();
+  expect(authInfo?.authUrl).toBe('http://localhost:8082');
+  expect(authInfo?.scheme).toBe('BASIC');
+  expect(authInfo?.service).toBe('test.sonatype.com');
+  expect(authInfo?.scope).toBeUndefined();
+});
+
 test('Should extract auth registry with quay.io registry', async () => {
   const authInfo = imageRegistry.extractAuthData('Bearer realm="https://quay.io/v2/auth",service="quay.io"');
   expect(authInfo).toBeDefined();
@@ -113,6 +122,12 @@ test('Should extract auth registry with quay.io registry', async () => {
   expect(authInfo?.authUrl).toBe('https://quay.io/v2/auth');
   expect(authInfo?.service).toBe('quay.io');
   expect(authInfo?.scope).toBeUndefined();
+});
+
+test('Expect extractAuthData to fail since its not Bearer, Basic or BASIC. ', async () => {
+  const authInfo = imageRegistry.extractAuthData('Foobar realm="https://quay.io/v2/auth",service="quay.io"');
+  // Expect it to be undefined since its not Bearer, Basic or BASIC.
+  expect(authInfo).toBeUndefined();
 });
 
 test('should map short name to hub server', () => {

--- a/packages/main/src/plugin/image-registry.ts
+++ b/packages/main/src/plugin/image-registry.ts
@@ -300,7 +300,7 @@ export class ImageRegistry {
     // Www-Authenticate: Bearer realm="https://auth.docker.io/token",service="registry.docker.io",scope="repository:samalba/my-app:pull,push"
     // need to extract realm, service and scope parameters with a regexp
     const WWW_AUTH_REGEXP =
-      /(?<scheme>Bearer|Basic) realm="(?<realm>[^"]+)"(,service="(?<service>[^"]+)")?(,scope="(?<scope>[^"]+)")?/;
+      /(?<scheme>Bearer|Basic|BASIC) realm="(?<realm>[^"]+)"(,service="(?<service>[^"]+)")?(,scope="(?<scope>[^"]+)")?/;
 
     const parsed = WWW_AUTH_REGEXP.exec(wwwAuthenticate);
     if (parsed?.groups) {


### PR DESCRIPTION
fix: allow BASIC authentication (all caps)

### What does this PR do?

Allows registries that have BASIC in the header instead of Basic to be
extractable using the extractAuthData function.

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast
explaining what is doing this PR -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop/issues/3470

### How to test this PR?

BEFORE TESTING:

Patch in https://github.com/containers/podman-desktop/pull/3468 to remove the invalid `The format of the
Registry Location is incorrect`. Or remove the line https://github.com/containers/podman-desktop/pull/3468/files#diff-18bc4f2318c7a0814b55328a4186d337972e6bcdd4c09b33d9b9353c47c2c5ffL713 before running.

1. Deploy a Sonatype Nexus registry using:
`podman run -d -p 8081:8081 -p 8082:8082 -p 443:443 --name nexus sonatype/nexus3` and setup an accesible docker registry
2. OR run a fake registry using this python script: https://gist.github.com/cdrage/07220d49e99ed54e0f5f0e3e6ab74758
3. Add the registry (example: localhost:8000)
4. You should now receive a timeout / authentication error rather than
   "Invalid URL"

<!-- Please explain steps to reproduce -->

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
