### PR TITLE
feat: reduce API calls when listing containers

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,6 +136,7 @@
     "check-disk-space": "^3.4.0",
     "chokidar": "^3.5.3",
     "compare-versions": "^6.1.0",
+    "date.js": "^0.3.3",
     "dockerode": "^3.3.5",
     "electron-context-menu": "^3.6.1",
     "electron-updater": "6.1.1",

--- a/packages/main/src/plugin/api/container-info.ts
+++ b/packages/main/src/plugin/api/container-info.ts
@@ -18,7 +18,14 @@
 
 import type Dockerode from 'dockerode';
 
-export interface ContainerInfo extends Dockerode.ContainerInfo {
+export interface ContainerPortInfo {
+  IP: string;
+  PrivatePort: number;
+  PublicPort: number;
+  Type: string;
+}
+
+export interface ContainerInfo {
   engineId: string;
   engineName: string;
   engineType: 'podman' | 'docker';
@@ -29,6 +36,16 @@ export interface ContainerInfo extends Dockerode.ContainerInfo {
     status: string;
     engineId: string;
   };
+  Id: string;
+  Names: string[];
+  Image: string;
+  ImageID: string;
+  Command: string;
+  Created: number;
+  Ports: ContainerPortInfo[];
+  Labels: { [label: string]: string };
+  State: string;
+  Status?: string;
 }
 
 export interface SimpleContainerInfo extends Dockerode.ContainerInfo {

--- a/packages/renderer/src/lib/container/ContainerDetails.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerDetails.spec.ts
@@ -45,9 +45,6 @@ const myContainer: ContainerInfo = {
   Created: 0,
   Ports: undefined,
   State: undefined,
-  HostConfig: undefined,
-  NetworkSettings: undefined,
-  Mounts: undefined,
 };
 
 const deleteContainerMock = vi.fn();

--- a/types/additional.d.ts
+++ b/types/additional.d.ts
@@ -1,3 +1,4 @@
 declare module 'win-ca/api';
 declare module 'zip-local';
 declare module 'micromark-extension-directive';
+declare module 'date.js';

--- a/yarn.lock
+++ b/yarn.lock
@@ -5904,6 +5904,13 @@ data-urls@^4.0.0:
     whatwg-mimetype "^3.0.0"
     whatwg-url "^12.0.0"
 
+date.js@^0.3.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/date.js/-/date.js-0.3.3.tgz#ef1e92332f507a638795dbb985e951882e50bbda"
+  integrity sha512-HgigOS3h3k6HnW011nAb43c5xx5rBXk8P2v/WIT9Zv4koIaVXiH2BURguI78VVp+5Qc076T7OR378JViCnZtBw==
+  dependencies:
+    debug "~3.1.0"
+
 debug@2.6.9, debug@^2.2.0, debug@^2.6.0, debug@^2.6.8:
   version "2.6.9"
   resolved "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz"
@@ -5924,6 +5931,13 @@ debug@^3.2.7:
   integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
   dependencies:
     ms "^2.1.1"
+
+debug@~3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
+  dependencies:
+    ms "2.0.0"
 
 decamelize-keys@^1.1.0:
   version "1.1.1"


### PR DESCRIPTION
### What does this PR do?
Long time ago there was a time drift issue on macOS so we were computing on our side the delta and adjusted the date of container's uptime.  https://github.com/containers/podman/issues/11541

so, remove the call to `/info` to get backend time.

Then, as we need to display uptime for containers using StartedAt field.
But as this field was not present on container listing, we were inspecting running containers using the inspect call.

Podman API provides this result when listing containers. But code is mostly using types of the compat container API

so:
- remove calls to all inspect API (so one less call for each running container)
- if container engine is podman, list containers using the Podman REST API and then convert Podman listContainers result to the compat API (so no need to change rendering part, etc)
- for docker as we don't have the field, use the 'status' field with the uptime (like 'Up 2 seconds') and convert that data to a StartedAt so again no need to change rendering part.


### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

related to https://github.com/containers/podman-desktop/issues/3376

### How to test this PR?

there are unit tests

But you should check if your containers are correctly listed in containers page, either using a podman engine or a docker engine.

you might need to cherry-pick https://github.com/containers/podman-desktop/pull/3488 for seeing the 'not running containers'