### PR TITLE
fix: only restart if a machine is running

### DIFF
--- a/extensions/podman/src/compatibility-mode.spec.ts
+++ b/extensions/podman/src/compatibility-mode.spec.ts
@@ -21,6 +21,7 @@
 import { afterEach, expect, test, vi } from 'vitest';
 import { getSocketCompatibility, DarwinSocketCompatibility, LinuxSocketCompatibility } from './compatibility-mode';
 import * as extensionApi from '@podman-desktop/api';
+import * as extension from './extension';
 
 vi.mock('@podman-desktop/api', () => {
   return {
@@ -35,7 +36,6 @@ vi.mock('@podman-desktop/api', () => {
 });
 
 // macOS tests
-
 vi.mock('runSudoMacHelperCommand', () => {
   return vi.fn();
 });
@@ -43,16 +43,6 @@ vi.mock('runSudoMacHelperCommand', () => {
 afterEach(() => {
   vi.resetAllMocks();
   vi.restoreAllMocks();
-});
-
-// mock isDefaultMachineRunning from extension to always return true
-// this is to prevent execPromise to be ran within it and cause errors
-vi.mock('./extension', () => {
-  return {
-    findRunningMachine: () => {
-      return 'default';
-    },
-  };
 });
 
 test('darwin: compatibility mode binary not found failure', async () => {
@@ -110,6 +100,11 @@ test('darwin: DarwinSocketCompatibility class, test promptRestart ran within run
         resolve({} as extensionApi.RunResult);
       }),
   );
+
+  const spyFindRunningMachine = vi.spyOn(extension, 'findRunningMachine');
+  spyFindRunningMachine.mockImplementation(() => {
+    return Promise.resolve('default');
+  });
 
   // Mock that enable ran successfully
   const spyEnable = vi.spyOn(socketCompatClass, 'runCommand');
@@ -201,4 +196,49 @@ test('windows: compatibility mode fail', async () => {
 
   // Expect getSocketCompatibility to return error since Linux is not supported yet
   expect(() => getSocketCompatibility()).toThrowError();
+});
+
+test('darwin: test promptRestart IS NOT ran when findRunningMachine returns undefined for enable AND disable', async () => {
+  // Mock platform to be darwin
+  Object.defineProperty(process, 'platform', {
+    value: 'darwin',
+  });
+
+  const socketCompatClass = new DarwinSocketCompatibility();
+
+  // Mock execPromise was ran successfully
+  vi.mock('execPromise', () => {
+    return Promise.resolve();
+  });
+
+  // Mock that enable ran successfully
+  const spyEnable = vi.spyOn(socketCompatClass, 'runCommand');
+  spyEnable.mockImplementation(() => {
+    return Promise.resolve();
+  });
+
+  // Mock that disable ran successfully
+  const spyDisable = vi.spyOn(socketCompatClass, 'runCommand');
+  spyDisable.mockImplementation(() => {
+    return Promise.resolve();
+  });
+
+  // Mock that findRunningMachine returns undefined
+  vi.mock('./extension', () => {
+    return {
+      findRunningMachine: () => {
+        return Promise.resolve();
+      },
+    };
+  });
+
+  const spyPromptRestart = vi.spyOn(extensionApi.window, 'showInformationMessage');
+
+  // Enable shouldn't call promptRestart
+  await socketCompatClass.enable();
+  expect(spyPromptRestart).not.toHaveBeenCalled();
+
+  // Disable shouldn't call promptRestart
+  await socketCompatClass.disable();
+  expect(spyPromptRestart).not.toHaveBeenCalled();
 });

--- a/extensions/podman/src/compatibility-mode.ts
+++ b/extensions/podman/src/compatibility-mode.ts
@@ -119,15 +119,17 @@ export class DarwinSocketCompatibility extends SocketCompatibility {
 
   // Prompt the user that you need to restart the current podman machine for the changes to take effect
   async promptRestart(machine: string): Promise<void> {
-    const result = await extensionApi.window.showInformationMessage(
-      `Restarting your Podman machine is required to apply the changes. Would you like to restart the Podman machine '${machine}' now?`,
-      'Yes',
-      'Cancel',
-    );
-    if (result === 'Yes') {
-      // Await since we must wait for the machine to stop before starting it again
-      await extensionApi.process.exec(getPodmanCli(), ['machine', 'stop', machine]);
-      await extensionApi.process.exec(getPodmanCli(), ['machine', 'start', machine]);
+    if (machine) {
+      const result = await extensionApi.window.showInformationMessage(
+        `Restarting your Podman machine is required to apply the changes. Would you like to restart the Podman machine '${machine}' now?`,
+        'Yes',
+        'Cancel',
+      );
+      if (result === 'Yes') {
+        // Await since we must wait for the machine to stop before starting it again
+        await extensionApi.process.exec(getPodmanCli(), ['machine', 'stop', machine]);
+        await extensionApi.process.exec(getPodmanCli(), ['machine', 'start', machine]);
+      }
     }
   }
 
@@ -137,24 +139,14 @@ export class DarwinSocketCompatibility extends SocketCompatibility {
     await this.runCommand('install', 'enabled');
 
     // Prompt the user to restart the podman machine if it's running
-    const isRunning = await findRunningMachine();
-    if (isRunning !== '') {
-      await this.promptRestart(isRunning);
-    }
-
-    return Promise.resolve();
+    return findRunningMachine().then(isRunning => this.promptRestart(isRunning));
   }
 
   async disable(): Promise<void> {
     await this.runCommand('uninstall', 'disabled');
 
     // Prompt the user to restart the podman machine if it's running
-    const isRunning = await findRunningMachine();
-    if (isRunning !== '') {
-      await this.promptRestart(isRunning);
-    }
-
-    return Promise.resolve();
+    return findRunningMachine().then(isRunning => this.promptRestart(isRunning));
   }
 }
 

--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -1017,7 +1017,7 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
   await podmanConfiguration.init();
 }
 
-// Function that checks to see if the default machine is running and return a boolean
+// Function that checks to see if the default machine is running and return a string
 export async function findRunningMachine(): Promise<string> {
   let runningMachine: string;
 


### PR DESCRIPTION
fix: only restart if a machine is running

### What does this PR do?

No matter what, it would try to restart regardless if a machine was
running or not.

This is because the if statement was: `if (isRunning !== '')` which will
always return true even if isRunning was undefined.

The if statement has now been changes to `if (isRunning)` meaning it
will only run if isRunning is defined (not '').

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast
explaining what is doing this PR -->

N/A. The prompt will not appear when trying to restart it if there is no
machine running.

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop/issues/3321

### How to test this PR?

<!-- Please explain steps to reproduce -->

Click on Docker Compatibility with a Podman Machine stopped. You should
not get the prompt to restart the podman machine.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
