### PR TITLE
chore: update markdown button

### DIFF
--- a/packages/renderer/src/lib/markdown/Markdown.spec.ts
+++ b/packages/renderer/src/lib/markdown/Markdown.spec.ts
@@ -48,15 +48,17 @@ describe('Custom button', () => {
     await waitRender({ markdown: ':button[Name of the button]' });
     const markdownContent = screen.getByRole('region', { name: 'markdown-content' });
     expect(markdownContent).toBeInTheDocument();
-    expect(markdownContent).toContainHTML('<a class="pf-c-button pf-m-primary" >Name of the button</a>');
+    expect(markdownContent).toContainHTML(
+      '<a class="px-4 py-[6px] rounded-[4px] text-white text-[13px] whitespace-nowrap bg-purple-600 hover:bg-purple-500 no-underline">Name of the button</a>',
+    );
   });
 
   test('Expect with all attributes', async () => {
     await waitRender({ markdown: ':button[Name of the button]{href=http://my-link title="tooltip text"}' });
-    const markdownContent = screen.getByRole('region', { name: 'markdown-content' });
-    expect(markdownContent).toBeInTheDocument();
-    expect(markdownContent).toContainHTML(
-      '<a class="pf-c-button pf-m-primary" href="http://my-link" title="tooltip text" >Name of the button</a>',
-    );
+    const markdownButton = screen.getByRole('link');
+    expect(markdownButton).toBeInTheDocument();
+    expect(markdownButton).toHaveTextContent('Name of the button');
+    expect(markdownButton).toHaveAttribute('href', 'http://my-link');
+    expect(markdownButton).toHaveAttribute('title', 'tooltip text');
   });
 });

--- a/packages/renderer/src/lib/markdown/Markdown.spec.ts
+++ b/packages/renderer/src/lib/markdown/Markdown.spec.ts
@@ -54,11 +54,11 @@ describe('Custom button', () => {
   });
 
   test('Expect with all attributes', async () => {
-    await waitRender({ markdown: ':button[Name of the button]{href=http://my-link title="tooltip text"}' });
+    await waitRender({ markdown: ':button[Name of the button]{href=https://my-link title="tooltip text"}' });
     const markdownButton = screen.getByRole('link');
     expect(markdownButton).toBeInTheDocument();
     expect(markdownButton).toHaveTextContent('Name of the button');
-    expect(markdownButton).toHaveAttribute('href', 'http://my-link');
+    expect(markdownButton).toHaveAttribute('href', 'https://my-link');
     expect(markdownButton).toHaveAttribute('title', 'tooltip text');
   });
 });

--- a/packages/renderer/src/lib/markdown/micromark-button-directive.ts
+++ b/packages/renderer/src/lib/markdown/micromark-button-directive.ts
@@ -31,7 +31,9 @@ export function button(d) {
     return false;
   }
 
-  this.tag('<a class="pf-c-button pf-m-primary"');
+  this.tag(
+    '<a class="px-4 py-[6px] rounded-[4px] text-white text-[13px] whitespace-nowrap bg-purple-600 hover:bg-purple-500 no-underline"',
+  );
 
   if (d.attributes && 'href' in d.attributes) {
     this.tag(' href="' + this.encode(d.attributes.href) + '"');


### PR DESCRIPTION
### What does this PR do?

Buttons generated via markdown weren't matching our regular Button component. I don't love replicating these classes here, but I don't see a simpler way at the moment and this gives it the identical styling. Broke the test html into separate lines so it is testing for the different bits specifically vs the full exact string (and we don't need to duplicate the full set of classes again).

### Screenshot/screencast of this PR

N/A, markdown buttons have minor style differences, e.g. hover is lighter.

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Go to create a Sandbox instance and confirm the 'Login' and 'Create' buttons match.