### PR TITLE
fix: kube event error when switching context

### DIFF
--- a/packages/main/src/plugin/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes-client.ts
@@ -220,8 +220,8 @@ export class KubernetesClient {
           '/api/v1/namespaces/' + ns + '/pods',
           {},
           () => this.apiSender.send('pod-event'),
-          // eslint-disable-next-line @typescript-eslint/no-empty-function
-          () => {},
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (err: any) => console.warn('Kube watch ended', err.toString()),
         )
         .then(req => (this.kubeWatcher = req))
         .catch((err: unknown) => console.error('Kube event error', err));

--- a/packages/main/src/plugin/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes-client.ts
@@ -220,7 +220,8 @@ export class KubernetesClient {
           '/api/v1/namespaces/' + ns + '/pods',
           {},
           () => this.apiSender.send('pod-event'),
-          (err: unknown) => console.error('Kube event error', err),
+          // eslint-disable-next-line @typescript-eslint/no-empty-function
+          () => {},
         )
         .then(req => (this.kubeWatcher = req))
         .catch((err: unknown) => console.error('Kube event error', err));


### PR DESCRIPTION
Fixes #3035

### What does this PR do?

Removes the log message when Kube context is switched

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

#3035 
### How to test this PR?

Switch from one Kubernetes context to another and check the error message is not logged anymore
