### PR TITLE
chore: enable accessibility when running on Linux platform

### DIFF
--- a/packages/main/src/index.ts
+++ b/packages/main/src/index.ts
@@ -21,7 +21,7 @@ import { app, ipcMain, Tray } from 'electron';
 import './security-restrictions';
 import { createNewWindow, restoreWindow } from '/@/mainWindow.js';
 import { TrayMenu } from './tray-menu.js';
-import { isMac, isWindows, stoppedExtensions } from './util.js';
+import { isLinux, isMac, isWindows, stoppedExtensions } from './util.js';
 import { AnimatedTray } from './tray-animate-icon.js';
 import { PluginSystem } from './plugin/index.js';
 import { StartupInstall } from './system/startup-install.js';
@@ -41,6 +41,13 @@ const argv = process.argv.slice(2);
 const additionalData: AdditionalData = {
   argv: argv,
 };
+
+/**
+ * Add accessibility support on Linux automatically
+ */
+if (isLinux()) {
+  app.commandLine.appendSwitch('force-renderer-accessibility');
+}
 
 /**
  * Prevent multiple instances
@@ -150,6 +157,10 @@ app.on('will-finish-launching', () => {
 
 app.whenReady().then(
   async () => {
+    if (isLinux()) {
+      app.setAccessibilitySupportEnabled(true);
+    }
+
     if (import.meta.env.PROD) {
       if (isWindows()) {
         app.setAsDefaultProtocolClient('podman-desktop', process.execPath, process.argv);


### PR DESCRIPTION
### What does this PR do?
Try to force accessibility when running on Linux

Using draft mode as it might not be the right solution anyway, just trying

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast 
explaining what is doing this PR -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop 
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to reproduce -->
