### PR TITLE
chore: stick to Node.js 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "@types/dockerode": "^3.3.19",
     "@types/getos": "^3.0.1",
     "@types/js-yaml": "^4.0.5",
+    "@types/node": "^18",
     "@types/tar": "^6.1.5",
     "@types/tar-fs": "^2.0.1",
     "@types/validator": "^13.11.1",
@@ -153,6 +154,7 @@
   },
   "resolutions": {
     "trim": "0.0.3",
-    "ssh2": "1.11.0"
+    "ssh2": "1.11.0",
+    "@types/node": "^18"
   }
 }

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -50,6 +50,7 @@ import { Emitter } from './events/emitter.js';
 import fs from 'node:fs';
 import { pipeline } from 'node:stream/promises';
 import type { ApiSenderType } from './api.js';
+import type { Stream } from 'stream';
 import { Writable } from 'stream';
 
 export interface InternalContainerProvider {
@@ -1595,13 +1596,13 @@ export class ContainerProviderRegistry {
         `Uploading the build context from ${containerBuildContextDirectory}...Can take a while...\r\n`,
       );
       const tarStream = tar.pack(containerBuildContextDirectory);
-      let streamingPromise;
+      let streamingPromise: Stream;
       try {
-        streamingPromise = await matchingContainerProvider.api.buildImage(tarStream, {
+        streamingPromise = (await matchingContainerProvider.api.buildImage(tarStream, {
           registryconfig,
           dockerfile: relativeContainerfilePath,
           t: imageName,
-        });
+        })) as unknown as Stream;
       } catch (error: unknown) {
         console.log('error in buildImage', error);
         const errorMessage = error instanceof Error ? error.message : '' + error;

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -237,12 +237,14 @@ export class ExtensionLoader {
       // add watcher
       fs.watch(this.pluginsScanDirectory, (_, filename) => {
         // need to load the file
-        const packagedFile = path.resolve(this.pluginsScanDirectory, filename);
-        setTimeout(() => {
-          this.loadPackagedFile(packagedFile).catch((error: unknown) => {
-            console.error('Error while loadPackagedFile', error);
-          });
-        }, this.watchTimeout);
+        if (filename) {
+          const packagedFile = path.resolve(this.pluginsScanDirectory, filename);
+          setTimeout(() => {
+            this.loadPackagedFile(packagedFile).catch((error: unknown) => {
+              console.error('Error while loadPackagedFile', error);
+            });
+          }, this.watchTimeout);
+        }
       });
 
       // scan all files in the directory

--- a/yarn.lock
+++ b/yarn.lock
@@ -3441,20 +3441,10 @@
   resolved "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz"
   integrity sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==
 
-"@types/node@*", "@types/node@^18.11.17", "@types/node@^18.11.18":
-  version "18.15.11"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.15.11.tgz#b3b790f09cb1696cffcec605de025b088fa4225f"
-  integrity sha512-E5Kwq2n4SbMzQOn6wnmBjuK9ouqlURrcZDVfbo9ftDDTFt3nk7ZKK4GMOzoYgnpQJKcxwQw+lGaBvvlMo0qN/Q==
-
-"@types/node@20.4.7":
-  version "20.4.7"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.4.7.tgz#74d323a93f1391a63477b27b9aec56669c98b2ab"
-  integrity sha512-bUBrPjEry2QUTsnuEjzjbS7voGWCc30W0qzgMf90GPeDGFRakvrz47ju+oqDAKCXLUCe39u57/ORMl/O/04/9g==
-
-"@types/node@^17.0.5":
-  version "17.0.23"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.23.tgz#3b41a6e643589ac6442bdbd7a4a3ded62f33f7da"
-  integrity sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw==
+"@types/node@*", "@types/node@20.4.7", "@types/node@^17.0.5", "@types/node@^18", "@types/node@^18.11.17", "@types/node@^18.11.18":
+  version "18.17.4"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.17.4.tgz#bf8ae9875528929cc9930dc3f066cd0481fe1231"
+  integrity sha512-ATL4WLgr7/W40+Sp1WnNTSKbgVn6Pvhc/2RHAdt8fl6NsQyp4oPCi2eKcGOvA494bwf1K/W6nGgZ9TwDqvpjdw==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"


### PR DESCRIPTION

### What does this PR do?
some dependencies depend on 17 or 20 but we are using Node.js 18 so stick to that version


### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast 
explaining what is doing this PR -->

### What issues does this PR fix or reference?

It's related to one PR to bump a dependency that is bringing Node.js 20 types and then it's making code check fails.
https://github.com/containers/podman-desktop/pull/3500

### How to test this PR?

All tests should pass