### PR TITLE
feat: adding kind.cluster.creation.image configuration property for kind cluster

### DIFF
--- a/extensions/kind/package.json
+++ b/extensions/kind/package.json
@@ -48,7 +48,7 @@
           "scope": "KubernetesProviderConnectionFactory",
           "description": "Setup an ingress controller (Contour https://projectcontour.io)"
         },
-        "kind.cluster.creation.image": {
+        "kind.cluster.creation.controlPlaneImage": {
           "type": "string",
           "default": "",
           "scope": "KubernetesProviderConnectionFactory",

--- a/extensions/kind/package.json
+++ b/extensions/kind/package.json
@@ -47,6 +47,13 @@
           "default": true,
           "scope": "KubernetesProviderConnectionFactory",
           "description": "Setup an ingress controller (Contour https://projectcontour.io)"
+        },
+        "kind.cluster.creation.image": {
+          "type": "string",
+          "default": "",
+          "scope": "KubernetesProviderConnectionFactory",
+          "placeholder": "Leave empty for using latest.",
+          "markdownDescription": "Node’s container image (Available image tags on [kind/releases](https://github.com/kubernetes-sigs/kind/releases))"
         }
       }
     },

--- a/extensions/kind/src/create-cluster.spec.ts
+++ b/extensions/kind/src/create-cluster.spec.ts
@@ -117,10 +117,11 @@ test('expect error if Kubernetes reports error', async () => {
 });
 
 test('check cluster configuration generation', async () => {
-  const conf = getKindClusterConfig('k1', 80, 443);
+  const conf = getKindClusterConfig('k1', 80, 443, 'image: example');
   expect(conf).to.contains('name: k1');
   expect(conf).to.contains('hostPort: 80');
   expect(conf).to.contains('hostPort: 443');
+  expect(conf).to.contains('image: example');
 });
 
 test('check that consilience check returns warning message', async () => {
@@ -143,4 +144,14 @@ test('check that consilience check returns no warning messages', async () => {
   expect(checks).toBeDefined();
   expect(checks).toHaveProperty('records');
   expect(checks.records.length).toBe(0);
+});
+
+test('check that consilience check returns warning message when image has no sha256 digest', async () => {
+  const checks = await connectionAuditor('docker', 'image:tag');
+
+  expect(checks).toBeDefined();
+  expect(checks).toHaveProperty('records');
+  expect(checks.records.length).toBe(1);
+  expect(checks.records[0]).toHaveProperty('type');
+  expect(checks.records[0].type).toBe('warning');
 });

--- a/extensions/kind/src/create-cluster.spec.ts
+++ b/extensions/kind/src/create-cluster.spec.ts
@@ -125,12 +125,12 @@ test('check cluster configuration generation', async () => {
 });
 
 test('check cluster configuration empty string image', async () => {
-  const conf = getKindClusterConfig(null, null, null, '');
+  const conf = getKindClusterConfig(undefined, undefined, undefined, '');
   expect(conf).to.not.contains('image:');
 });
 
 test('check cluster configuration null string image', async () => {
-  const conf = getKindClusterConfig(null, null, null, null);
+  const conf = getKindClusterConfig(undefined, undefined, undefined, undefined);
   expect(conf).to.not.contains('image:');
 });
 

--- a/extensions/kind/src/create-cluster.spec.ts
+++ b/extensions/kind/src/create-cluster.spec.ts
@@ -157,7 +157,7 @@ test('check that consilience check returns no warning messages', async () => {
 });
 
 test('check that consilience check returns warning message when image has no sha256 digest', async () => {
-  const checks = await connectionAuditor('docker', {'kind.cluster.creation.controlPlaneImage': 'image:tag'});
+  const checks = await connectionAuditor('docker', { 'kind.cluster.creation.controlPlaneImage': 'image:tag' });
 
   expect(checks).toBeDefined();
   expect(checks).toHaveProperty('records');
@@ -165,4 +165,3 @@ test('check that consilience check returns warning message when image has no sha
   expect(checks.records[0]).toHaveProperty('type');
   expect(checks.records[0].type).toBe('warning');
 });
-

--- a/extensions/kind/src/create-cluster.spec.ts
+++ b/extensions/kind/src/create-cluster.spec.ts
@@ -117,16 +117,26 @@ test('expect error if Kubernetes reports error', async () => {
 });
 
 test('check cluster configuration generation', async () => {
-  const conf = getKindClusterConfig('k1', 80, 443, 'image: example');
+  const conf = getKindClusterConfig('k1', 80, 443, 'image:tag');
   expect(conf).to.contains('name: k1');
   expect(conf).to.contains('hostPort: 80');
   expect(conf).to.contains('hostPort: 443');
-  expect(conf).to.contains('image: example');
+  expect(conf).to.contains('image: image:tag');
+});
+
+test('check cluster configuration empty string image', async () => {
+  const conf = getKindClusterConfig(null, null, null, '');
+  expect(conf).to.not.contains('image:');
+});
+
+test('check cluster configuration null string image', async () => {
+  const conf = getKindClusterConfig(null, null, null, null);
+  expect(conf).to.not.contains('image:');
 });
 
 test('check that consilience check returns warning message', async () => {
   (getMemTotalInfo as Mock).mockReturnValue(3000000000);
-  const checks = await connectionAuditor('docker');
+  const checks = await connectionAuditor('docker', {});
 
   expect(checks).toBeDefined();
   expect(checks).toHaveProperty('records');
@@ -139,7 +149,7 @@ test('check that consilience check returns warning message', async () => {
 
 test('check that consilience check returns no warning messages', async () => {
   (getMemTotalInfo as Mock).mockReturnValue(6000000001);
-  const checks = await connectionAuditor('docker');
+  const checks = await connectionAuditor('docker', {});
 
   expect(checks).toBeDefined();
   expect(checks).toHaveProperty('records');
@@ -147,7 +157,7 @@ test('check that consilience check returns no warning messages', async () => {
 });
 
 test('check that consilience check returns warning message when image has no sha256 digest', async () => {
-  const checks = await connectionAuditor('docker', 'image:tag');
+  const checks = await connectionAuditor('docker', {'kind.cluster.creation.controlPlaneImage': 'image:tag'});
 
   expect(checks).toBeDefined();
   expect(checks).toHaveProperty('records');
@@ -155,3 +165,4 @@ test('check that consilience check returns warning message when image has no sha
   expect(checks.records[0]).toHaveProperty('type');
   expect(checks.records[0].type).toBe('warning');
 });
+

--- a/extensions/kind/src/create-cluster.ts
+++ b/extensions/kind/src/create-cluster.ts
@@ -27,7 +27,12 @@ import createClusterConfTemplate from './templates/create-cluster-conf.mustache?
 import type { AuditRecord, AuditResult, CancellationToken, AuditRequestItems } from '@podman-desktop/api';
 import ingressManifests from '/@/resources/contour.yaml?raw';
 
-export function getKindClusterConfig(clusterName: string, httpHostPort: number, httpsHostPort: number, controlPlaneImage?: string) {
+export function getKindClusterConfig(
+  clusterName: string,
+  httpHostPort: number,
+  httpsHostPort: number,
+  controlPlaneImage?: string,
+) {
   return mustache.render(createClusterConfTemplate, {
     clusterName: clusterName,
     httpHostPort: httpHostPort,
@@ -59,9 +64,8 @@ export async function setupIngressController(clusterName: string) {
 }
 
 export async function connectionAuditor(provider: string, items: AuditRequestItems): Promise<AuditResult> {
-
   const image = items['kind.cluster.creation.controlPlaneImage'];
-  if(image && !image.includes('@sha256:')) {
+  if (image && !image.includes('@sha256:')) {
     return {
       records: [
         {

--- a/extensions/kind/src/create-cluster.ts
+++ b/extensions/kind/src/create-cluster.ts
@@ -24,9 +24,8 @@ import mustache from 'mustache';
 import { parseAllDocuments } from 'yaml';
 
 import createClusterConfTemplate from './templates/create-cluster-conf.mustache?raw';
-import type { AuditRecord, AuditResult, CancellationToken } from '@podman-desktop/api';
+import type { AuditRecord, AuditResult, CancellationToken, AuditRequestItems } from '@podman-desktop/api';
 import ingressManifests from '/@/resources/contour.yaml?raw';
-import type {AuditRequestItems} from '@podman-desktop/api';
 
 export function getKindClusterConfig(clusterName: string, httpHostPort: number, httpsHostPort: number, controlPlaneImage?: string) {
   return mustache.render(createClusterConfTemplate, {

--- a/extensions/kind/src/create-cluster.ts
+++ b/extensions/kind/src/create-cluster.ts
@@ -26,7 +26,7 @@ import { parseAllDocuments } from 'yaml';
 import createClusterConfTemplate from './templates/create-cluster-conf.mustache?raw';
 import type { AuditRecord, AuditResult, CancellationToken } from '@podman-desktop/api';
 import ingressManifests from '/@/resources/contour.yaml?raw';
-import {AuditRequestItems} from '@podman-desktop/api';
+import type {AuditRequestItems} from '@podman-desktop/api';
 
 export function getKindClusterConfig(clusterName: string, httpHostPort: number, httpsHostPort: number, controlPlaneImage?: string) {
   return mustache.render(createClusterConfTemplate, {
@@ -61,8 +61,8 @@ export async function setupIngressController(clusterName: string) {
 
 export async function connectionAuditor(provider: string, items: AuditRequestItems): Promise<AuditResult> {
 
-  const image = items["kind.cluster.creation.controlPlaneImage"];
-  if(image && !image.includes("@sha256:")) {
+  const image = items['kind.cluster.creation.controlPlaneImage'];
+  if(image && !image.includes('@sha256:')) {
     return {
       records: [
         {

--- a/extensions/kind/src/create-cluster.ts
+++ b/extensions/kind/src/create-cluster.ts
@@ -28,7 +28,7 @@ import type { AuditRecord, AuditResult, CancellationToken } from '@podman-deskto
 import ingressManifests from '/@/resources/contour.yaml?raw';
 import {AuditRequestItems} from '@podman-desktop/api';
 
-export function getKindClusterConfig(clusterName: string, httpHostPort: number, httpsHostPort: number, controlPlaneImage: string | undefined) {
+export function getKindClusterConfig(clusterName: string, httpHostPort: number, httpsHostPort: number, controlPlaneImage?: string) {
   return mustache.render(createClusterConfTemplate, {
     clusterName: clusterName,
     httpHostPort: httpHostPort,

--- a/extensions/kind/src/create-cluster.ts
+++ b/extensions/kind/src/create-cluster.ts
@@ -140,10 +140,7 @@ export async function createCluster(
   }
 
   // grab custom kind node image if defined
-  let controlPlaneImage = null;
-  if (params['kind.cluster.creation.controlPlaneImage']) {
-    controlPlaneImage = params['kind.cluster.creation.controlPlaneImage'];
-  }
+  const controlPlaneImage = params['kind.cluster.creation.controlPlaneImage'];
 
   // create the config file
   const kindClusterConfig = getKindClusterConfig(clusterName, httpHostPort, httpsHostPort, controlPlaneImage);

--- a/extensions/kind/src/extension.ts
+++ b/extensions/kind/src/extension.ts
@@ -63,7 +63,7 @@ async function registerProvider(
       auditItems: async (items: AuditRequestItems) => {
         return await connectionAuditor(
           new ProviderNameExtractor(items).getProviderName(),
-          items['kind.cluster.creation.image']
+          items
         )
       },
     },

--- a/extensions/kind/src/extension.ts
+++ b/extensions/kind/src/extension.ts
@@ -61,10 +61,7 @@ async function registerProvider(
     },
     {
       auditItems: async (items: AuditRequestItems) => {
-        return await connectionAuditor(
-          new ProviderNameExtractor(items).getProviderName(),
-          items,
-        );
+        return await connectionAuditor(new ProviderNameExtractor(items).getProviderName(), items);
       },
     },
   );

--- a/extensions/kind/src/extension.ts
+++ b/extensions/kind/src/extension.ts
@@ -63,7 +63,7 @@ async function registerProvider(
       auditItems: async (items: AuditRequestItems) => {
         return await connectionAuditor(
           new ProviderNameExtractor(items).getProviderName(),
-          items
+          items,
         );
       },
     },

--- a/extensions/kind/src/extension.ts
+++ b/extensions/kind/src/extension.ts
@@ -64,7 +64,7 @@ async function registerProvider(
         return await connectionAuditor(
           new ProviderNameExtractor(items).getProviderName(),
           items
-        )
+        );
       },
     },
   );

--- a/extensions/kind/src/extension.ts
+++ b/extensions/kind/src/extension.ts
@@ -60,8 +60,12 @@ async function registerProvider(
       creationDisplayName: 'Kind cluster',
     },
     {
-      auditItems: async (items: AuditRequestItems) =>
-        await connectionAuditor(new ProviderNameExtractor(items).getProviderName()),
+      auditItems: async (items: AuditRequestItems) => {
+        return await connectionAuditor(
+          new ProviderNameExtractor(items).getProviderName(),
+          items['kind.cluster.creation.image']
+        )
+      },
     },
   );
   extensionContext.subscriptions.push(disposable);

--- a/extensions/kind/src/templates/create-cluster-conf.mustache
+++ b/extensions/kind/src/templates/create-cluster-conf.mustache
@@ -3,6 +3,7 @@ apiVersion: kind.x-k8s.io/v1alpha4
 name: {{{ clusterName }}}
 nodes:
 - role: control-plane
+  {{{ extraConfig }}}
   kubeadmConfigPatches:
   - |
     kind: InitConfiguration

--- a/extensions/kind/src/templates/create-cluster-conf.mustache
+++ b/extensions/kind/src/templates/create-cluster-conf.mustache
@@ -3,7 +3,9 @@ apiVersion: kind.x-k8s.io/v1alpha4
 name: {{{ clusterName }}}
 nodes:
 - role: control-plane
-  {{{ extraConfig }}}
+{{#controlPlaneImage}}
+  image: {{{ controlPlaneImage }}}
+{{/controlPlaneImage}}
   kubeadmConfigPatches:
   - |
     kind: InitConfiguration


### PR DESCRIPTION
### What does this PR do?

The node's container image can be used to specify the Kubernetes version used for the control-planed. For example using `kindest/node:v1.25.8` will create a cluster with Kubernetes 1.25.8.

### Screenshot/screencast of this PR

**Default creation page**

![image](https://github.com/containers/podman-desktop/assets/42176370/a70b79f9-278e-4f81-a5bc-0c34997110a7)

**Custom image creation page**

![image](https://github.com/containers/podman-desktop/assets/42176370/6486e0e2-49eb-4bc0-be00-9c0c43df2cfc)

**Custom image without sha256**

As explained in the official kind documentation
> You can set a specific Kubernetes version by setting the node’s container image. You can find available image tags on the [releases page](https://github.com/kubernetes-sigs/kind/releases). Please include the @sha256: [image digest](https://docs.docker.com/engine/reference/commandline/pull/#pull-an-image-by-digest-immutable-identifier) from the image in the release notes

![image](https://github.com/containers/podman-desktop/assets/42176370/b2a63faf-629f-436d-8496-7c0cd8158679)


### What issues does this PR fix or reference?

Allows to create Kubernetes cluster with specific version.

### How to test this PR?

- [x]: added and changed unit tests for validating the changes.
- [x]: tested to created a cluster with `kindest/node:v1.27.2`
