### PR TITLE
fix: main nav selection

### DIFF
--- a/packages/renderer/src/lib/ui/NavItem.spec.ts
+++ b/packages/renderer/src/lib/ui/NavItem.spec.ts
@@ -48,6 +48,28 @@ test('Expect selection styling', async () => {
   expect(element.firstChild).toHaveClass('border-l-purple-500');
 });
 
+test('Expect selection styling for encoded URLs', async () => {
+  const tooltip = 'Extensions';
+  const href = '/test page';
+  renderIt(tooltip, href, { url: '/test%20page' });
+
+  const element = screen.getByLabelText(tooltip);
+  expect(element).toBeInTheDocument();
+  expect(element.firstChild).toBeInTheDocument();
+  expect(element.firstChild).toHaveClass('border-l-purple-500');
+});
+
+test('Expect selection styling for sub-pages', async () => {
+  const tooltip = 'Settings';
+  const href = '/prefs/resources';
+  renderIt(tooltip, href, { url: '/prefs/resources' });
+
+  const element = screen.getByLabelText(tooltip);
+  expect(element).toBeInTheDocument();
+  expect(element.firstChild).toBeInTheDocument();
+  expect(element.firstChild).toHaveClass('border-l-purple-500');
+});
+
 test('Expect not to have selection styling', async () => {
   const tooltip = 'Dashboard';
   renderIt(tooltip, '/test', { url: '/elsewhere' });

--- a/packages/renderer/src/lib/ui/NavItem.svelte
+++ b/packages/renderer/src/lib/ui/NavItem.svelte
@@ -8,11 +8,12 @@ export let ariaLabel: string = undefined;
 export let meta: TinroRouteMeta;
 export let onClick: any = undefined;
 
+let uri = encodeURI(href);
 let selected: boolean;
-$: selected = meta.url === href;
+$: selected = meta.url === uri || (uri !== '/' && meta.url.startsWith(uri));
 </script>
 
-<a href="{onClick ? '#top' : href}" aria-label="{ariaLabel ? ariaLabel : tooltip}" on:click|preventDefault="{onClick}">
+<a href="{onClick ? '#top' : uri}" aria-label="{ariaLabel ? ariaLabel : tooltip}" on:click|preventDefault="{onClick}">
   <div
     class="flex w-full py-3 justify-center items-center border-x-[4px] border-charcoal-800 text-white cursor-pointer"
     class:border-l-purple-500="{selected}"


### PR DESCRIPTION
### What does this PR do?

As per issue #3509, the main nav wouldn't show items as selected if they had a space in the URL, or were child pages like settings/resources. This fixes the first issue through URL encoding the href, and the latter by adding back the startsWith() that was special-cased for settings before. New tests added for both cases.

### Screenshot/screencast of this PR

https://github.com/containers/podman-desktop/assets/19958075/da7aca3f-27ad-4994-bcc1-dc08e9940664

### What issues does this PR fix or reference?

Fixes #3509.

### How to test this PR?

Installed a Docker desktop extension whose names includes a space (e.g. 'Disk usage') and confirm you can select it or Settings just like other items.