### PR TITLE
chore: link component

### DIFF
--- a/packages/renderer/src/lib/ui/Link.spec.ts
+++ b/packages/renderer/src/lib/ui/Link.spec.ts
@@ -1,0 +1,77 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import '@testing-library/jest-dom';
+import { test, expect, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import Link from './Link.svelte';
+import { faRocket } from '@fortawesome/free-solid-svg-icons';
+
+test('Check link styling', async () => {
+  render(Link);
+
+  // check for one element of the styling
+  const link = screen.getByRole('link');
+  expect(link).toBeInTheDocument();
+  expect(link).toHaveClass('text-purple-400');
+  expect(link).toHaveClass('hover:underline');
+});
+
+test('Check icon styling', async () => {
+  render(Link, { icon: faRocket });
+
+  // check for the fa SVG child
+  const link = screen.getByRole('link');
+  expect(link).toBeInTheDocument();
+  expect(link.firstChild).toBeInTheDocument();
+  expect(link.firstChild.firstChild).toBeInTheDocument();
+  expect(link.firstChild.firstChild).toHaveClass('svelte-fa');
+});
+
+test('Check href action', async () => {
+  const urlMock = vi.fn();
+  (window as any).openExternal = urlMock;
+  render(Link, { href: 'test' });
+
+  // check href link
+  const link = screen.getByRole('link');
+  expect(link).toBeInTheDocument();
+  expect(urlMock).not.toHaveBeenCalled();
+
+  fireEvent.click(link);
+
+  expect(urlMock).toBeCalledTimes(1);
+});
+
+test('Check on:click action', async () => {
+  const comp = render(Link);
+
+  const clickMock = vi.fn();
+  comp.component.$on('click', clickMock);
+
+  // check on:click
+  const link = screen.getByRole('link');
+  expect(link).toBeInTheDocument();
+  expect(clickMock).not.toHaveBeenCalled();
+
+  fireEvent.click(link);
+
+  expect(clickMock).toBeCalledTimes(1);
+});

--- a/packages/renderer/src/lib/ui/Link.svelte
+++ b/packages/renderer/src/lib/ui/Link.svelte
@@ -1,0 +1,48 @@
+<script lang="ts">
+import { onMount, createEventDispatcher } from 'svelte';
+import Fa from 'svelte-fa/src/fa.svelte';
+
+export let href: string = undefined;
+export let icon: any = undefined;
+
+let iconType: string = undefined;
+
+const dispatch = createEventDispatcher<{ click: undefined }>();
+
+onMount(() => {
+  if (icon?.prefix === 'fas') {
+    iconType = 'fa';
+  } else {
+    iconType = 'unknown';
+  }
+});
+
+function click() {
+  if (href) {
+    window.openExternal(href);
+  } else {
+    dispatch('click');
+  }
+}
+</script>
+
+<!-- svelte-ignore a11y-click-events-have-key-events -->
+<!-- svelte-ignore a11y-missing-attribute -->
+<!-- svelte-ignore a11y-no-redundant-roles -->
+<!-- svelte-ignore a11y-interactive-supports-focus -->
+<a
+  class="text-purple-400 hover:underline {$$props.class || ''}"
+  on:click="{() => click()}"
+  role="link"
+  aria-label="{$$props['aria-label']}">
+  {#if icon}
+    <span class="flex flex-row space-x-2">
+      {#if iconType === 'fa'}
+        <Fa icon="{icon}" />
+      {/if}
+      <span><slot /></span>
+    </span>
+  {:else}
+    <slot />
+  {/if}
+</a>


### PR DESCRIPTION
### What does this PR do?

We have several different styles of 'links' today:
- blue ones with underline hover (e.g. deploy to kube 'restricted')
- blue ones with light hover (e.g. deploy to kube 'Open OpenShift')
- purples ones with dark hover (e.g. deploy to kube routes, dashboard)
- purples ones with no hover (e.g. back link on detail, form pages)
- white ones with hover underline hover (e.g. dialog cancel buttons)

To make things more consistent, and obvious to the user what is clickable, we should reuse a Link component. This PR creates a simple component with an optional icon and either href or on:click support for simplicity & ease of migrating from the existing a/div/spans (which will be done via other PRs).

I tried making the Link a simpler `<Button type="link">`, but buttons have padding and complexity that makes this more complex and hard to directly reuse in either direction. IMHO it makes sense to keep Link and Button independent but share styling; had a brief chat with Mairin that it may make sense to change link Buttons to purple for consistency.

### Screenshot/screencast of this PR

<img width="224" alt="Screenshot 2023-08-14 at 5 07 22 PM" src="https://github.com/containers/podman-desktop/assets/19958075/cf2d771d-ec15-46f2-80e2-ac8345230919">

### What issues does this PR fix or reference?

N/A

### How to test this PR?

N/A, future PRs would use Link in context.