### PR TITLE
Send telemetry when `Create` button pressed in new provider connection form

### DIFF
--- a/packages/main/src/plugin/provider-registry.ts
+++ b/packages/main/src/plugin/provider-registry.ts
@@ -706,7 +706,7 @@ export class ProviderRegistry {
     const provider = this.getMatchingProvider(internalProviderId);
     const telemetryData: {
       providerId: string;
-      error?: Error;
+      error?: unknown;
       name: string;
     } = {
       providerId: provider.id,
@@ -714,12 +714,13 @@ export class ProviderRegistry {
     };
     try {
       if (!provider.containerProviderConnectionFactory) {
-        const error = new Error('The provider does not support container connection creation');
-        telemetryData.error = error;
-        throw error;
+        throw new Error('The provider does not support container connection creation');
       }
       // create a logger
       return provider.containerProviderConnectionFactory.create(params, logHandler, token);
+    } catch (err) {
+      telemetryData.error = err;
+      throw err;
     } finally {
       await this.telemetryService.track('createProviderConnection', telemetryData);
     }


### PR DESCRIPTION
### What does this PR do?

It adds telemetry track call with extension ID, name and optional error information when 'Create' button clicked in new provider connection form.

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

https://github.com/redhat-developer/podman-desktop-sandbox-ext/issues/51

### How to test this PR?

N/A
