### PR TITLE
feat: send 'removeExtension' telemetry when user removes extension

### DIFF
--- a/packages/main/src/plugin/extension-loader.spec.ts
+++ b/packages/main/src/plugin/extension-loader.spec.ts
@@ -705,3 +705,21 @@ describe('setContextValue', async () => {
     expect(setValueSpy).toBeCalledWith('publisher.name.onboarding.key', 'value');
   });
 });
+
+describe('Removing extension by user', async () => {
+  const ExtID = 'company.ext-id';
+  test('sends telemetry w/o error when whens succeeds', async () => {
+    extensionLoader.removeExtension = vi.fn();
+    await extensionLoader.removeExtensionPerUserRequest(ExtID);
+    expect(extensionLoader.removeExtension).toBeCalledWith(ExtID);
+    expect(telemetry.track).toBeCalledWith('removeExtension', { extensionId: ExtID });
+  });
+
+  test('sends telemetry w/ error when fails', async () => {
+    const RemoveError = 'Error';
+    extensionLoader.removeExtension = vi.fn().mockRejectedValue(RemoveError);
+    await extensionLoader.removeExtensionPerUserRequest(ExtID).catch(() => undefined);
+    expect(extensionLoader.removeExtension).toBeCalledWith(ExtID);
+    expect(telemetry.track).toBeCalledWith('removeExtension', { extensionId: ExtID, error: RemoveError });
+  });
+});

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -1189,6 +1189,23 @@ export class ExtensionLoader {
     }
   }
 
+  async removeExtensionPerUserRequest(extensionId: string): Promise<void> {
+    const telemetryData: {
+      extensionId: string;
+      error?: unknown;
+    } = {
+      extensionId,
+    };
+    try {
+      await this.removeExtension(extensionId);
+    } catch (error) {
+      telemetryData.error = error;
+      throw error;
+    } finally {
+      await this.telemetry.track('removeExtension', telemetryData);
+    }
+  }
+
   async removeExtension(extensionId: string): Promise<void> {
     const extension = this.analyzedExtensions.get(extensionId);
     if (extension) {

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1397,7 +1397,20 @@ export class PluginSystem {
     this.ipcHandle(
       'extension-loader:removeExtension',
       async (_listener: Electron.IpcMainInvokeEvent, extensionId: string): Promise<void> => {
-        return this.extensionLoader.removeExtension(extensionId);
+        const telemetryData: {
+          extensionId: string;
+          error?: unknown;
+        } = {
+          extensionId,
+        };
+        try {
+          await this.extensionLoader.removeExtension(extensionId);
+        } catch (error) {
+          telemetryData.error = error;
+          throw error;
+        } finally {
+          await telemetry.track('removeExtension', telemetryData);
+        }
       },
     );
 

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1397,20 +1397,7 @@ export class PluginSystem {
     this.ipcHandle(
       'extension-loader:removeExtension',
       async (_listener: Electron.IpcMainInvokeEvent, extensionId: string): Promise<void> => {
-        const telemetryData: {
-          extensionId: string;
-          error?: unknown;
-        } = {
-          extensionId,
-        };
-        try {
-          await this.extensionLoader.removeExtension(extensionId);
-        } catch (error) {
-          telemetryData.error = error;
-          throw error;
-        } finally {
-          await telemetry.track('removeExtension', telemetryData);
-        }
+        return this.extensionLoader.removeExtensionPerUserRequest(extensionId);
       },
     );
 


### PR DESCRIPTION
### What does this PR do?

PR sends 'removeExtension' telemetry event when user request extension to be uninstalled.

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

* #3018 
* https://github.com/redhat-developer/podman-desktop-sandbox-ext/issues/51

### How to test this PR?

N/A