### PR TITLE
chore: pill hover style and button/link consistency

### DIFF
--- a/packages/renderer/src/lib/ui/Button.spec.ts
+++ b/packages/renderer/src/lib/ui/Button.spec.ts
@@ -29,7 +29,7 @@ test('Check primary button styling', async () => {
   // check for one element of the styling
   const button = screen.getByRole('button');
   expect(button).toBeInTheDocument();
-  expect(button).toHaveClass('bg-purple-500');
+  expect(button).toHaveClass('bg-purple-600');
 });
 
 test('Check primary button is the default', async () => {
@@ -38,7 +38,7 @@ test('Check primary button is the default', async () => {
   // check for one element of the styling
   const button = screen.getByRole('button');
   expect(button).toBeInTheDocument();
-  expect(button).toHaveClass('bg-purple-500');
+  expect(button).toHaveClass('bg-purple-600');
 });
 
 test('Check secondary button styling', async () => {
@@ -50,11 +50,13 @@ test('Check secondary button styling', async () => {
   expect(button).toHaveClass('border-gray-200');
 });
 
-test('Check default button styling', async () => {
+test('Check link button styling', async () => {
   render(Button, { type: 'link' });
 
-  // check for one element of the styling
+  // check for a few elements of the styling
   const button = screen.getByRole('button');
   expect(button).toBeInTheDocument();
-  expect(button).toHaveClass('hover:underline');
+  expect(button).toHaveClass('border-none');
+  expect(button).toHaveClass('hover:bg-white');
+  expect(button).toHaveClass('hover:bg-opacity-10');
 });

--- a/packages/renderer/src/lib/ui/Button.svelte
+++ b/packages/renderer/src/lib/ui/Button.svelte
@@ -32,11 +32,11 @@ $: {
     }
   } else {
     if (type === 'primary') {
-      classes = 'bg-purple-500 border-none hover:bg-purple-400';
+      classes = 'bg-purple-600 border-none text-white hover:bg-purple-500';
     } else if (type === 'secondary') {
-      classes = 'border-[1px] border-gray-200 hover:border-purple-500 hover:text-purple-500';
+      classes = 'border-[1px] border-gray-200 text-white hover:border-purple-500 hover:text-purple-500';
     } else {
-      classes = 'border-none hover:underline';
+      classes = 'border-none text-purple-400 hover:bg-white hover:bg-opacity-10';
     }
   }
 }
@@ -44,7 +44,7 @@ $: {
 
 <button
   type="button"
-  class="relative px-4 py-[6px] rounded-[4px] box-border text-white text-[13px] whitespace-nowrap select-none {classes} {$$props.class ||
+  class="relative px-4 py-[6px] rounded-[4px] box-border text-[13px] whitespace-nowrap select-none transition-all {classes} {$$props.class ||
     ''}"
   title="{title}"
   aria-label="{$$props['aria-label']}"

--- a/packages/renderer/src/lib/ui/Link.spec.ts
+++ b/packages/renderer/src/lib/ui/Link.spec.ts
@@ -31,7 +31,8 @@ test('Check link styling', async () => {
   const link = screen.getByRole('link');
   expect(link).toBeInTheDocument();
   expect(link).toHaveClass('text-purple-400');
-  expect(link).toHaveClass('hover:underline');
+  expect(link).toHaveClass('hover:bg-white');
+  expect(link).toHaveClass('hover:bg-opacity-10');
 });
 
 test('Check icon styling', async () => {

--- a/packages/renderer/src/lib/ui/Link.svelte
+++ b/packages/renderer/src/lib/ui/Link.svelte
@@ -31,7 +31,8 @@ function click() {
 <!-- svelte-ignore a11y-no-redundant-roles -->
 <!-- svelte-ignore a11y-interactive-supports-focus -->
 <a
-  class="text-purple-400 hover:underline {$$props.class || ''}"
+  class="text-purple-400 hover:bg-white hover:bg-opacity-10 transition-all rounded-[4px] p-0.5 no-underline {$$props.class ||
+    ''}"
   on:click="{() => click()}"
   role="link"
   aria-label="{$$props['aria-label']}">


### PR DESCRIPTION
### What does this PR do?

Mairin and I had a couple discussions about button/link consistency and hover styling. In our current styling there are a few small inconsistencies:
- buttons and things you can click on are generally purple, except link buttons (e.g. cancel on dialogs)
- buttons, link buttons, and links are all slightly different
- link underlines are a bit webby

We came up with the following changes that tie everything together a little better:
- link buttons should be purple, just like links (and buttons)
- hover for links and link buttons should be a very light background pill the same shape as a button, with no underline. Links have minimal padding just so the text doesn't go outside of the pill, link buttons are full sized buttons
- add transition so there's a subtle fade effect
- while we're at it, buttons were slightly bright so going from -500/-400 to -600/-500

Updated tests to match.

### Screenshot/screencast of this PR

https://github.com/containers/podman-desktop/assets/19958075/884f3f6a-324a-4868-841d-a1017c7ef088

<img width="224" alt="Screenshot 2023-08-15 at 4 15 07 PM" src="https://github.com/containers/podman-desktop/assets/19958075/b82fc7cc-2ab2-4f89-bf15-75da80fb29b1">

### What issues does this PR fix or reference?

N/A

### How to test this PR?

View any dialog with a cancel button; no use of Links yet.