### PR TITLE
chore: details & form page links

### DIFF
--- a/packages/renderer/src/lib/ui/DetailsPage.spec.ts
+++ b/packages/renderer/src/lib/ui/DetailsPage.spec.ts
@@ -17,8 +17,8 @@
  ***********************************************************************/
 
 import '@testing-library/jest-dom';
-import { test, expect } from 'vitest';
-import { render, screen } from '@testing-library/svelte';
+import { test, expect, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/svelte';
 import DetailsPage from './DetailsPage.svelte';
 import { lastPage, currentPage } from '../../stores/breadcrumb';
 import type { TinroBreadcrumb } from 'tinro';
@@ -57,7 +57,13 @@ test('Expect backlink is defined', async () => {
   const backElement = screen.getByLabelText('back');
   expect(backElement).toBeInTheDocument();
   expect(backElement).toHaveTextContent(backName);
-  expect(backElement).toHaveAttribute('href', backPath);
+
+  const urlMock = vi.fn();
+  (window as any).openExternal = urlMock;
+
+  fireEvent.click(backElement);
+
+  expect(urlMock).toBeCalledWith('/back');
 });
 
 test('Expect close link is defined', async () => {

--- a/packages/renderer/src/lib/ui/DetailsPage.svelte
+++ b/packages/renderer/src/lib/ui/DetailsPage.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import { lastPage, currentPage } from '../../stores/breadcrumb';
 import { router } from 'tinro';
+import Link from './Link.svelte';
 
 export let title: string;
 export let titleDetail: string = undefined;
@@ -16,11 +17,7 @@ export function close(): void {
     <div class="flex w-full flex-row">
       <div class="w-full pl-5 pt-4">
         <div class="flex flew-row items-center">
-          <a
-            class="text-violet-400 text-base hover:no-underline"
-            aria-label="back"
-            href="{$lastPage.path}"
-            title="Go back to {$lastPage.name}">{$lastPage.name}</a>
+          <Link aria-label="back" href="{$lastPage.path}" title="Go back to {$lastPage.name}">{$lastPage.name}</Link>
           <div class="text-xl mx-2 text-gray-700">></div>
           <div class="text-sm font-extralight text-gray-700" aria-label="name">{$currentPage.name}</div>
         </div>

--- a/packages/renderer/src/lib/ui/FormPage.spec.ts
+++ b/packages/renderer/src/lib/ui/FormPage.spec.ts
@@ -17,8 +17,8 @@
  ***********************************************************************/
 
 import '@testing-library/jest-dom';
-import { test, expect } from 'vitest';
-import { render, screen } from '@testing-library/svelte';
+import { test, expect, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/svelte';
 import FormPage from './FormPage.svelte';
 import { lastPage, currentPage } from '../../stores/breadcrumb';
 import type { TinroBreadcrumb } from 'tinro';
@@ -70,7 +70,13 @@ test('Expect backlink is defined', async () => {
   const backElement = screen.getByLabelText('back');
   expect(backElement).toBeInTheDocument();
   expect(backElement).toHaveTextContent(backName);
-  expect(backElement).toHaveAttribute('href', backPath);
+
+  const urlMock = vi.fn();
+  (window as any).openExternal = urlMock;
+
+  fireEvent.click(backElement);
+
+  expect(urlMock).toBeCalledWith('/back');
 });
 
 test('Expect close link is defined', async () => {

--- a/packages/renderer/src/lib/ui/FormPage.svelte
+++ b/packages/renderer/src/lib/ui/FormPage.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { lastPage, currentPage } from '../../stores/breadcrumb';
+import Link from './Link.svelte';
 
 export let title: string;
 export let showBreadcrumb = true;
@@ -10,11 +11,7 @@ export let showBreadcrumb = true;
     <div class="flex flex-col w-full h-fit">
       {#if showBreadcrumb}
         <div class="flex flew-row items-center">
-          <a
-            aria-label="back"
-            class="text-violet-400 text-base hover:no-underline"
-            href="{$lastPage.path}"
-            title="Go back to {$lastPage.name}">{$lastPage.name}</a>
+          <Link aria-label="back" href="{$lastPage.path}" title="Go back to {$lastPage.name}">{$lastPage.name}</Link>
           <div class="text-xl mx-2 text-gray-700">></div>
           <div class="grow text-sm font-extralight text-gray-700" aria-label="name">{$currentPage.name}</div>
           <a href="{$lastPage.path}" title="Close" class="justify-self-end text-gray-900">


### PR DESCRIPTION
### What does this PR do?

Updates the back link on details and form pages to use the Link component. Visually the only difference is that they now change on hover.

Updated test. Since Link uses on:click we can't test for the href, but we can go one step further instead and confirm clicking the link works.

### Screenshot/screencast of this PR

<img width="224" alt="Screenshot 2023-08-15 at 4 15 07 PM" src="https://github.com/containers/podman-desktop/assets/19958075/d678bfb4-9139-4ea7-97f0-1587e52c5e3d">

(image shown after PR #3542, without it they'll just be underlines)

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Open any details (e.g. Pod Detail or Image Detail) and any form page (e.g. Deploy Pod to Kube or Run Image).
