### PR TITLE
chore: provider links

### DIFF
--- a/packages/renderer/src/lib/dashboard/ProviderLinks.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderLinks.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import type { ProviderInfo } from '../../../../main/src/plugin/api/provider-info';
+import Link from '../ui/Link.svelte';
 
 export let provider: ProviderInfo;
 </script>
@@ -8,11 +9,9 @@ export let provider: ProviderInfo;
   <div class="mt-10 flex flex-row justify-around">
     {#each provider.links as link}
       {#if link.group === undefined}
-        <p
-          on:click="{() => window.openExternal(link.url)}"
-          class="text-sm text-center cursor-pointer text-violet-400 hover:text-violet-600 hover:no-underline">
+        <Link class="text-sm" href="{link.url}">
           {link.title}
-        </p>
+        </Link>
       {/if}
     {/each}
   </div>


### PR DESCRIPTION
### What does this PR do?

Just switches provider links to use the Link component for consistency.

### Screenshot/screencast of this PR

<img width="378" alt="Screenshot 2023-08-15 at 5 04 52 PM" src="https://github.com/containers/podman-desktop/assets/19958075/f1339179-3bbb-4003-8535-0524f5bf617a">

(shown with PR #3542, prior to this the hover will just show an underline)

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Open Dashboard.