### PR TITLE
chore: change deploy to kube links

### DIFF
--- a/packages/renderer/src/lib/pod/DeployPodToKube.svelte
+++ b/packages/renderer/src/lib/pod/DeployPodToKube.svelte
@@ -9,7 +9,8 @@ import ErrorMessage from '../ui/ErrorMessage.svelte';
 import WarningMessage from '../ui/WarningMessage.svelte';
 import { ensureRestrictedSecurityContext } from '/@/lib/pod/pod-utils';
 import Button from '../ui/Button.svelte';
-import { faRocket } from '@fortawesome/free-solid-svg-icons';
+import { faExternalLink, faRocket } from '@fortawesome/free-solid-svg-icons';
+import Link from '../ui/Link.svelte';
 
 export let resourceId: string;
 export let engineId: string;
@@ -403,9 +404,10 @@ function updateKubeResult() {
           data-testid="useRestricted"
           class=""
           required />
-        <span class="text-gray-400 text-sm ml-1"
-          >Update Kubernetes manifest to respect the Pod security <a
-            href="https://kubernetes.io/docs/concepts/security/pod-security-standards#restricted">restricted profile</a
+        <span class="text-gray-400 text-sm ml-1">
+          Update Kubernetes manifest to respect the Pod security <Link
+            href="https://kubernetes.io/docs/concepts/security/pod-security-standards#restricted"
+            >restricted profile</Link
           >.</span>
       </div>
 
@@ -513,12 +515,8 @@ function updateKubeResult() {
             <div>Created pod:</div>
             {#if openshiftConsoleURL && createdPod?.metadata?.name}
               <div class="justify-end flex flex-1">
-                <div class="pf-c-button pf-m-link cursor-pointer" on:click="{() => openOpenshiftConsole()}">
-                  <span class="pf-c-button__icon pf-m-start">
-                    <i class="fas fa-external-link-alt" aria-hidden="true"></i>
-                  </span>
-                  Open in OpenShift console
-                </div>
+                <Link class="text-sm" icon="{faExternalLink}" on:click="{() => openOpenshiftConsole()}"
+                  >Open in OpenShift console</Link>
               </div>
             {/if}
           </div>
@@ -561,11 +559,7 @@ function updateKubeResult() {
                 {#each createdRoutes as createdRoute}
                   <li class="pt-2">
                     Port {createdRoute.spec.port.targetPort} is reachable with route
-                    <span
-                      class="cursor-pointer text-violet-400 hover:text-violet-600 hover:no-underline"
-                      on:click="{() => {
-                        openRoute(createdRoute);
-                      }}">{createdRoute.metadata.name}</span>
+                    <Link on:click="{() => openRoute(createdRoute)}">{createdRoute.metadata.name}</Link>
                   </li>
                 {/each}
               </ul>


### PR DESCRIPTION
### What does this PR do?

The deploy pod to Kubernetes form has three 'links', all with different normal and hover styles. This moves all three to the Link component for consistency.

### Screenshot/screencast of this PR

Before:

<img width="932" alt="Screenshot 2023-08-14 at 11 24 14 AM" src="https://github.com/containers/podman-desktop/assets/19958075/2d0c0f94-5a56-4388-bd0f-22b27a0e957b">

After:

<img width="936" alt="Screenshot 2023-08-15 at 9 19 46 PM" src="https://github.com/containers/podman-desktop/assets/19958075/761923fb-1055-46f0-bd63-e3bbfc7b6fe7">

(shown before #3542, after there is slight padding around 'restricted profile' and hover links become a hover highlight 'pill')

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Open the page and deploy a pod to see and confirm all three links.