### PR TITLE
chore: wait for images being displayed

### DIFF
--- a/tests/src/model/pages/images-page.ts
+++ b/tests/src/model/pages/images-page.ts
@@ -20,6 +20,7 @@ import type { Locator, Page } from 'playwright';
 import { PodmanDesktopPage } from './base-page';
 import { ImageDetailsPage } from './image-details-page';
 import { PullImagePage } from './pull-image-page';
+import { waitUntil } from '../../utility/wait';
 
 export class ImagesPage extends PodmanDesktopPage {
   readonly heading: Locator;
@@ -89,6 +90,12 @@ export class ImagesPage extends PodmanDesktopPage {
   }
 
   async imageExists(name: string): Promise<boolean> {
-    return (await this.getImageRowByName(name)) !== undefined ? true : false;
+    const result = await this.getImageRowByName(name);
+    return result !== undefined;
+  }
+
+  async waitForImageExists(name: string): Promise<boolean> {
+    await waitUntil(async () => await this.imageExists(name), 3000, 900);
+    return true;
   }
 }

--- a/tests/src/pull-image-smoke.spec.ts
+++ b/tests/src/pull-image-smoke.spec.ts
@@ -18,7 +18,7 @@
 
 import type { Page } from 'playwright';
 import type { RunnerTestContext } from './testContext/runner-test-context';
-import { afterAll, beforeAll, test, describe, beforeEach } from 'vitest';
+import { afterAll, beforeAll, test, describe, beforeEach, expect } from 'vitest';
 import { expect as playExpect } from '@playwright/test';
 import { PodmanDesktopRunner } from './runner/podman-desktop-runner';
 import { WelcomePage } from './model/pages/welcome-page';
@@ -52,7 +52,8 @@ describe('Image pull verification', async () => {
     const pullImagePage = await imagesPage.openPullImage();
     const updatedImages = await pullImagePage.pullImage('quay.io/podman/hello');
 
-    playExpect(updatedImages.imageExists('quay.io/podman/hello')).toBeTruthy();
+    const exists = await updatedImages.waitForImageExists('quay.io/podman/hello');
+    expect(exists, 'quay.io/podman/hello image not present in the list of images').toBeTruthy();
   });
 
   test('Check image details', async () => {


### PR DESCRIPTION
### What does this PR do?
The current test is checking that we have a promise (it does not wait the end of the promise)
`playExpect(updatedImages.imageExists('quay.io/podman/hello')).toBeTruthy();`

and we were not waiting that image was displayed in the list to return true

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

Some flaky tests

### How to test this PR?

PR check should be green