### PR TITLE
fix: reset error message each time we pull image

### DIFF
--- a/packages/renderer/src/lib/image/PullImage.svelte
+++ b/packages/renderer/src/lib/image/PullImage.svelte
@@ -76,6 +76,9 @@ async function pullImage() {
   await tick();
   logsPull?.reset();
 
+  // reset error
+  pullError = '';
+
   pullInProgress = true;
   try {
     await window.pullImage(selectedProviderConnection, imageToPull.trim(), callback);


### PR DESCRIPTION
### What does this PR do?
reset error message each time we pull image
so we don't see previous error message in case of success

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast 
explaining what is doing this PR -->

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/3498

### How to test this PR?

Test usecase of the issue but there is also unit test