### PR TITLE
fix: do not forget to dispose the watcher

### DIFF
--- a/extensions/kube-context/src/extension.ts
+++ b/extensions/kube-context/src/extension.ts
@@ -155,16 +155,19 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
   }
 
   // update context menu on change
-  extensionApi.kubernetes.onDidUpdateKubeconfig(async (event: extensionApi.KubeconfigUpdateEvent) => {
-    // update the tray everytime .kube/config file is updated
-    if (event.type === 'UPDATE' || event.type === 'CREATE') {
-      kubeconfigFile = event.location.fsPath;
-      await updateContext(extensionContext, kubeconfigFile);
-    } else if (event.type === 'DELETE') {
-      await deleteContext();
-      kubeconfigFile = undefined;
-    }
-  });
+  const disposeOnDidUpdate = extensionApi.kubernetes.onDidUpdateKubeconfig(
+    async (event: extensionApi.KubeconfigUpdateEvent) => {
+      // update the tray everytime .kube/config file is updated
+      if (event.type === 'UPDATE' || event.type === 'CREATE') {
+        kubeconfigFile = event.location.fsPath;
+        await updateContext(extensionContext, kubeconfigFile);
+      } else if (event.type === 'DELETE') {
+        await deleteContext();
+        kubeconfigFile = undefined;
+      }
+    },
+  );
+  extensionContext.subscriptions.push(disposeOnDidUpdate);
 
   const switchCommand = extensionApi.commands.registerCommand('kubecontext.switch', async (newContext: string) => {
     await setContext(newContext);


### PR DESCRIPTION
Signed-off-by: Florent Benoit <fbenoit@redhat.com>

### What does this PR do?
Each time you stop an extension the listener is not removed
so when we enable again the extension it's listening again but all events are received/managed twice (new code and old code)

With the fix, we don't have old listeners that are still running so it's not adding it again.

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast 
explaining what is doing this PR -->

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/3528

### How to test this PR?

So it can't be reproduced with the steps of the issue.
The root problem is that extension has been stopped/started multiple times

To proceed, use a blank `.kube/config` file, start Podman Desktop then remove the file, stop the extension
restart the extension and provides again an empty `.kube/config` `{}` content

Each time you stop/add extension etc it's duplicated.

With the fix, we don't have old listeners that are still running so it's not adding it again.

Note: I don't see how to do a good unit test. Because we're mocking API anyways.