### PR TITLE
fix: internal hrefs in link component

### DIFF
--- a/packages/renderer/src/lib/dashboard/ProviderLinks.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderLinks.svelte
@@ -9,7 +9,7 @@ export let provider: ProviderInfo;
   <div class="mt-10 flex flex-row justify-around">
     {#each provider.links as link}
       {#if link.group === undefined}
-        <Link class="text-sm" href="{link.url}">
+        <Link class="text-sm" externalRef="{link.url}">
           {link.title}
         </Link>
       {/if}

--- a/packages/renderer/src/lib/pod/DeployPodToKube.svelte
+++ b/packages/renderer/src/lib/pod/DeployPodToKube.svelte
@@ -406,7 +406,7 @@ function updateKubeResult() {
           required />
         <span class="text-gray-400 text-sm ml-1">
           Update Kubernetes manifest to respect the Pod security <Link
-            href="https://kubernetes.io/docs/concepts/security/pod-security-standards#restricted"
+            externalRef="https://kubernetes.io/docs/concepts/security/pod-security-standards#restricted"
             >restricted profile</Link
           >.</span>
       </div>

--- a/packages/renderer/src/lib/ui/DetailsPage.spec.ts
+++ b/packages/renderer/src/lib/ui/DetailsPage.spec.ts
@@ -22,6 +22,16 @@ import { fireEvent, render, screen } from '@testing-library/svelte';
 import DetailsPage from './DetailsPage.svelte';
 import { lastPage, currentPage } from '../../stores/breadcrumb';
 import type { TinroBreadcrumb } from 'tinro';
+import { router } from 'tinro';
+
+// mock the router
+vi.mock('tinro', () => {
+  return {
+    router: {
+      goto: vi.fn(),
+    },
+  };
+});
 
 test('Expect title is defined', async () => {
   const title = 'My Dummy Title';
@@ -58,12 +68,9 @@ test('Expect backlink is defined', async () => {
   expect(backElement).toBeInTheDocument();
   expect(backElement).toHaveTextContent(backName);
 
-  const urlMock = vi.fn();
-  (window as any).openExternal = urlMock;
-
   fireEvent.click(backElement);
 
-  expect(urlMock).toBeCalledWith('/back');
+  expect(router.goto).toBeCalledWith('/back');
 });
 
 test('Expect close link is defined', async () => {

--- a/packages/renderer/src/lib/ui/DetailsPage.svelte
+++ b/packages/renderer/src/lib/ui/DetailsPage.svelte
@@ -17,7 +17,8 @@ export function close(): void {
     <div class="flex w-full flex-row">
       <div class="w-full pl-5 pt-4">
         <div class="flex flew-row items-center">
-          <Link aria-label="back" href="{$lastPage.path}" title="Go back to {$lastPage.name}">{$lastPage.name}</Link>
+          <Link aria-label="back" internalRef="{$lastPage.path}" title="Go back to {$lastPage.name}"
+            >{$lastPage.name}</Link>
           <div class="text-xl mx-2 text-gray-700">></div>
           <div class="text-sm font-extralight text-gray-700" aria-label="name">{$currentPage.name}</div>
         </div>

--- a/packages/renderer/src/lib/ui/FormPage.spec.ts
+++ b/packages/renderer/src/lib/ui/FormPage.spec.ts
@@ -22,6 +22,16 @@ import { fireEvent, render, screen } from '@testing-library/svelte';
 import FormPage from './FormPage.svelte';
 import { lastPage, currentPage } from '../../stores/breadcrumb';
 import type { TinroBreadcrumb } from 'tinro';
+import { router } from 'tinro';
+
+// mock the router
+vi.mock('tinro', () => {
+  return {
+    router: {
+      goto: vi.fn(),
+    },
+  };
+});
 
 test('Expect title is defined', async () => {
   const title = 'My Dummy Title';
@@ -71,12 +81,9 @@ test('Expect backlink is defined', async () => {
   expect(backElement).toBeInTheDocument();
   expect(backElement).toHaveTextContent(backName);
 
-  const urlMock = vi.fn();
-  (window as any).openExternal = urlMock;
-
   fireEvent.click(backElement);
 
-  expect(urlMock).toBeCalledWith('/back');
+  expect(router.goto).toBeCalledWith('/back');
 });
 
 test('Expect close link is defined', async () => {

--- a/packages/renderer/src/lib/ui/FormPage.svelte
+++ b/packages/renderer/src/lib/ui/FormPage.svelte
@@ -11,7 +11,8 @@ export let showBreadcrumb = true;
     <div class="flex flex-col w-full h-fit">
       {#if showBreadcrumb}
         <div class="flex flew-row items-center">
-          <Link aria-label="back" href="{$lastPage.path}" title="Go back to {$lastPage.name}">{$lastPage.name}</Link>
+          <Link aria-label="back" internalRef="{$lastPage.path}" title="Go back to {$lastPage.name}"
+            >{$lastPage.name}</Link>
           <div class="text-xl mx-2 text-gray-700">></div>
           <div class="grow text-sm font-extralight text-gray-700" aria-label="name">{$currentPage.name}</div>
           <a href="{$lastPage.path}" title="Close" class="justify-self-end text-gray-900">

--- a/packages/renderer/src/lib/ui/Link.spec.ts
+++ b/packages/renderer/src/lib/ui/Link.spec.ts
@@ -59,7 +59,7 @@ test('Check icon styling', async () => {
 test('Check href action', async () => {
   const urlMock = vi.fn();
   (window as any).openExternal = urlMock;
-  render(Link, { href: 'http://test.com' });
+  render(Link, { externalRef: 'http://test.com' });
 
   // check href link
   const link = screen.getByRole('link');
@@ -75,7 +75,7 @@ test('Check href action', async () => {
 test('Check local href action', async () => {
   const urlMock = vi.fn();
   (window as any).openExternal = urlMock;
-  render(Link, { href: '/Pods' });
+  render(Link, { internalRef: '/Pods' });
 
   // check href link
   const link = screen.getByRole('link');

--- a/packages/renderer/src/lib/ui/Link.spec.ts
+++ b/packages/renderer/src/lib/ui/Link.spec.ts
@@ -74,6 +74,7 @@ test('Check href action', async () => {
 
 test('Check local href action', async () => {
   const urlMock = vi.fn();
+  (window as any).openExternal = urlMock;
   render(Link, { href: '/Pods' });
 
   // check href link

--- a/packages/renderer/src/lib/ui/Link.spec.ts
+++ b/packages/renderer/src/lib/ui/Link.spec.ts
@@ -23,6 +23,16 @@ import { test, expect, vi } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/svelte';
 import Link from './Link.svelte';
 import { faRocket } from '@fortawesome/free-solid-svg-icons';
+import { router } from 'tinro';
+
+// mock the router
+vi.mock('tinro', () => {
+  return {
+    router: {
+      goto: vi.fn(),
+    },
+  };
+});
 
 test('Check link styling', async () => {
   render(Link);
@@ -49,7 +59,7 @@ test('Check icon styling', async () => {
 test('Check href action', async () => {
   const urlMock = vi.fn();
   (window as any).openExternal = urlMock;
-  render(Link, { href: 'test' });
+  render(Link, { href: 'http://test.com' });
 
   // check href link
   const link = screen.getByRole('link');
@@ -59,6 +69,21 @@ test('Check href action', async () => {
   fireEvent.click(link);
 
   expect(urlMock).toBeCalledTimes(1);
+  expect(router.goto).not.toHaveBeenCalled();
+});
+
+test('Check local href action', async () => {
+  const urlMock = vi.fn();
+  render(Link, { href: '/Pods' });
+
+  // check href link
+  const link = screen.getByRole('link');
+  expect(link).toBeInTheDocument();
+
+  fireEvent.click(link);
+
+  expect(router.goto).toBeCalledTimes(1);
+  expect(urlMock).not.toHaveBeenCalled();
 });
 
 test('Check on:click action', async () => {

--- a/packages/renderer/src/lib/ui/Link.svelte
+++ b/packages/renderer/src/lib/ui/Link.svelte
@@ -20,10 +20,10 @@ onMount(() => {
 
 function click() {
   if (href) {
-    if (href.startsWith('/')) {
-      router.goto(href);
-    } else {
+    if (href.startsWith('http')) {
       window.openExternal(href);
+    } else {
+      router.goto(href);
     }
   } else {
     dispatch('click');

--- a/packages/renderer/src/lib/ui/Link.svelte
+++ b/packages/renderer/src/lib/ui/Link.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import { onMount, createEventDispatcher } from 'svelte';
 import Fa from 'svelte-fa/src/fa.svelte';
+import { router } from 'tinro';
 
 export let href: string = undefined;
 export let icon: any = undefined;
@@ -19,7 +20,11 @@ onMount(() => {
 
 function click() {
   if (href) {
-    window.openExternal(href);
+    if (href.startsWith('/')) {
+      router.goto(href);
+    } else {
+      window.openExternal(href);
+    }
   } else {
     dispatch('click');
   }

--- a/packages/renderer/src/lib/ui/Link.svelte
+++ b/packages/renderer/src/lib/ui/Link.svelte
@@ -3,7 +3,8 @@ import { onMount, createEventDispatcher } from 'svelte';
 import Fa from 'svelte-fa/src/fa.svelte';
 import { router } from 'tinro';
 
-export let href: string = undefined;
+export let internalRef: string = undefined;
+export let externalRef: string = undefined;
 export let icon: any = undefined;
 
 let iconType: string = undefined;
@@ -19,12 +20,10 @@ onMount(() => {
 });
 
 function click() {
-  if (href) {
-    if (href.startsWith('http')) {
-      window.openExternal(href);
-    } else {
-      router.goto(href);
-    }
+  if (internalRef) {
+    router.goto(internalRef);
+  } else if (externalRef) {
+    window.openExternal(externalRef);
   } else {
     dispatch('click');
   }


### PR DESCRIPTION
### What does this PR do?

As per bug #3565, I managed to break the Link component so that it does not work for internal hrefs. This changes the Link to support three options:
 - internalRef uses tinro router.goto() to navigate to another page.
 - externalRef - uses window.openExternal() to open in external browser.
 - on:click - used for more complicated/programmatic callbacks that need to trigger a function.

Added test for the first option that wasn't working before, and updates Details and Form page tests to check the correct case.

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

Fixes #3565.

### How to test this PR?

Open a page like Container Details or Image Details, and try to click the back link to Containers or Images. 
