### PR TITLE
fix: enhance error message when image is not there

### DIFF
--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -862,6 +862,11 @@ export class ContainerProviderRegistry {
 
       return promise;
     } catch (error) {
+      // Provides a better error message for 403 errors
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      if (error instanceof Error && (error as any)?.statusCode === 403) {
+        error.message = `access to image "${imageName}" is denied (403 error). Can also be that image does not exist.`;
+      }
       telemetryOptions = { error: error };
       throw error;
     } finally {

--- a/packages/renderer/src/lib/image/PullImage.svelte
+++ b/packages/renderer/src/lib/image/PullImage.svelte
@@ -86,7 +86,7 @@ async function pullImage() {
     pullFinished = true;
   } catch (error) {
     const errorMessage = error.message ? error.message : error;
-    pullError = 'Could not connect to ' + selectedProviderConnection.name + ': ' + errorMessage;
+    pullError = `Error while pulling image from ${selectedProviderConnection.name}: ${errorMessage}`;
     pullInProgress = false;
   }
 }


### PR DESCRIPTION

Signed-off-by: Florent Benoit <fbenoit@redhat.com>

### What does this PR do?
Replace `[Object object]` by a message saying that access to the image is denied (and it could be that the image does not exist as well)


### Screenshot/screencast of this PR

![image](https://github.com/containers/podman-desktop/assets/436777/fb2f11fa-d542-488f-b3d3-5203fd02a1d8)

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/3496

### How to test this PR?

unit test added
