### PR TITLE
feat: logs all network connection to a file

### DIFF
--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -145,7 +145,7 @@ export class ExtensionLoader {
     private telemetry: Telemetry,
     private viewRegistry: ViewRegistry,
     private context: Context,
-    directories: Directories,
+    private directories: Directories,
   ) {
     this.pluginsDirectory = directories.getPluginsDirectory();
     this.pluginsScanDirectory = directories.getPluginsScanDirectory();
@@ -1167,6 +1167,10 @@ export class ExtensionLoader {
 
   getPluginsDirectory(): string {
     return this.pluginsDirectory;
+  }
+
+  getDirectories(): Directories {
+    return this.directories;
   }
 
   setExtensionsUpdates(extensionsToUpdate: ExtensionUpdateInfo[]): void {


### PR DESCRIPTION
### What does this PR do?
Log network requests to a log file

the file is displayed in the log

cannot merge to main like this as we should not log all the time

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast 
explaining what is doing this PR -->

### What issues does this PR fix or reference?

related to https://github.com/containers/podman-desktop/issues/2690

### How to test this PR?

Click on the light bulb in status bar

search for `main ↪️ Net-logs written to ..../.local/share/containers/podman-desktop/extensions-storage/net-logs/net-logs.json` in the Logs section


Then you can open this file with tooling or with https://netlog-viewer.appspot.com/ application

It does not log everything as it is in 'captureMode'

> captureMode string (optional) - What kinds of data should be captured. By default, only metadata about requests will be captured. Setting this to includeSensitive will include cookies and authentication data. Setting it to everything will include all bytes transferred on sockets. Can be default, includeSensitive or everything.
