### PR TITLE
fix(e2e): really wait for the image being there

### DIFF
--- a/tests/src/container-smoke.spec.ts
+++ b/tests/src/container-smoke.spec.ts
@@ -18,7 +18,7 @@
 
 import type { Page } from 'playwright';
 import type { RunnerTestContext } from './testContext/runner-test-context';
-import { afterAll, beforeAll, test, describe, beforeEach } from 'vitest';
+import { afterAll, beforeAll, test, describe, beforeEach, expect } from 'vitest';
 import { expect as playExpect } from '@playwright/test';
 import { PodmanDesktopRunner } from './runner/podman-desktop-runner';
 import { WelcomePage } from './model/pages/welcome-page';
@@ -67,7 +67,9 @@ describe('Verification of container creation workflow', async () => {
     let images = await navigationBar.openImages();
     const pullImagePage = await images.openPullImage();
     images = await pullImagePage.pullImage(imageToPull, imageTag, 45000);
-    playExpect(await images.imageExists(imageToPull)).toBeTruthy();
+
+    const exists = await images.waitForImageExists(imageToPull);
+    expect(exists, `${imageToPull} image is not present in the list of images`).toBeTruthy();
     await pdRunner.screenshot('containers-pull-image.png');
   }, 60000);
 

--- a/tests/src/model/pages/images-page.ts
+++ b/tests/src/model/pages/images-page.ts
@@ -89,7 +89,7 @@ export class ImagesPage extends PodmanDesktopPage {
     }
   }
 
-  async imageExists(name: string): Promise<boolean> {
+  protected async imageExists(name: string): Promise<boolean> {
     const result = await this.getImageRowByName(name);
     return result !== undefined;
   }


### PR DESCRIPTION
related to https://github.com/containers/podman-desktop/issues/3581
Signed-off-by: Florent Benoit <fbenoit@redhat.com>

### What does this PR do?
really wait for the image being there

apply the same thing that I did for the image check but on the container check

we need to wait, not check that promise is existing

make method as protected to be sure we don't call it externally

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast 
explaining what is doing this PR -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop 
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to reproduce -->
