### PR TITLE
fix: dispose kind install button when extension is deactivated (#3586)

### DIFF
--- a/extensions/kind/src/extension.ts
+++ b/extensions/kind/src/extension.ts
@@ -303,6 +303,7 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
             (err: unknown) => window.showErrorMessage('Kind installation failed ' + err),
           ),
         ),
+        statusBarItem,
       );
       statusBarItem.show();
     }


### PR DESCRIPTION
### What does this PR do?

It adds the statusBarItem to the context subscriptions so that it's automatically disposed when the extension is disabled.

### Screenshot/screencast of this PR

![kind_install_button](https://github.com/containers/podman-desktop/assets/49404737/196b6ca1-d607-43ba-b424-f2f25fc9f8c4)

### What issues does this PR fix or reference?

it resolves #3586 

### How to test this PR?

1. enable kind extension 
2. check you see the kind install button
3. disable the kind extension
4. check that the kind install button is not in the status bar anymore
5. repeat 1-2
