### PR TITLE
fix: replace backslash/slash on windows when building image (#3465)

### DIFF
--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -58,6 +58,7 @@ import type { ApiSenderType } from './api.js';
 import type { Stream } from 'stream';
 import { Writable } from 'stream';
 import datejs from 'date.js';
+import { isWindows } from '../util.js';
 
 export interface InternalContainerProvider {
   name: string;
@@ -1663,6 +1664,10 @@ export class ContainerProviderRegistry {
         `Uploading the build context from ${containerBuildContextDirectory}...Can take a while...\r\n`,
       );
       const tarStream = tar.pack(containerBuildContextDirectory);
+      if (isWindows()) {
+        relativeContainerfilePath = relativeContainerfilePath.replace(/\\/g, '/');
+      }
+
       let streamingPromise: Stream;
       try {
         streamingPromise = (await matchingContainerProvider.api.buildImage(tarStream, {


### PR DESCRIPTION
### What does this PR do?

This PR replaces backslashes to slashes on windows when building an image so that the correct internal dockerfile path can be found

### Screenshot/screencast of this PR

![quarkus_build](https://github.com/containers/podman-desktop/assets/49404737/46c2250d-abf8-436d-8d7a-2538edeaea0a)

### What issues does this PR fix or reference?

it resolves #3465 

### How to test this PR?

1. Generate application from code.quarkus.io
2. run mvnw package
3. Try to build from Podman Desktop (make sure the build context directory is the root of the application
