### PR TITLE
fix: handle null value in container command (#3620)

### DIFF
--- a/packages/main/src/plugin/api/container-info.ts
+++ b/packages/main/src/plugin/api/container-info.ts
@@ -40,7 +40,7 @@ export interface ContainerInfo {
   Names: string[];
   Image: string;
   ImageID: string;
-  Command: string;
+  Command?: string;
   Created: number;
   Ports: ContainerPortInfo[];
   Labels: { [label: string]: string };

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -303,7 +303,7 @@ export class ContainerProviderRegistry {
             Names: string[];
             Image: string;
             ImageID: string;
-            Command: string;
+            Command?: string;
             Created: number;
             Ports: ContainerPortInfo[];
             Labels: { [label: string]: string };
@@ -354,7 +354,7 @@ export class ContainerProviderRegistry {
                 Created: moment(podmanContainer.Created).unix(),
                 State: podmanContainer.State,
                 StartedAt,
-                Command: podmanContainer.Command[0],
+                Command: podmanContainer.Command?.length > 0 ? podmanContainer.Command[0] : undefined,
                 Labels,
                 Ports,
               };

--- a/packages/renderer/src/lib/container/ContainerDetailsSummary.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetailsSummary.svelte
@@ -11,7 +11,7 @@ export let container: ContainerInfoUI;
         <td class="pt-2 pr-2">Id</td>
         <td class="pt-2 pr-2">{container.shortId}</td>
       </tr>
-      <tr>
+      <tr class:hidden="{!container.command}">
         <td class="pt-2 pr-2">Command</td>
         <td class="pt-2 pr-2">{container.command}</td>
       </tr>

--- a/packages/renderer/src/lib/container/ContainerInfoUI.ts
+++ b/packages/renderer/src/lib/container/ContainerInfoUI.ts
@@ -57,7 +57,7 @@ export interface ContainerInfoUI {
   ports: Port[];
   portsAsString: string;
   displayPort: string;
-  command: string;
+  command?: string;
   hasPublicPort: boolean;
   openingUrl?: string;
   groupInfo: ContainerGroupPartInfoUI;


### PR DESCRIPTION
### What does this PR do?

It handles the null value in container command so that it doesn't throw an error, resulting in an empty container list

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

it resolves #3620 

### How to test this PR?

1. create a container with an image having a null command (such as `docker.io/ashael/pi:latest`)
