### PR TITLE
feat: grab usage data of volumes only on demand

### DIFF
--- a/packages/renderer/src/lib/volume/VolumesList.spec.ts
+++ b/packages/renderer/src/lib/volume/VolumesList.spec.ts
@@ -24,7 +24,7 @@ import { render, screen } from '@testing-library/svelte';
 import VolumesList from './VolumesList.svelte';
 import { get } from 'svelte/store';
 import { providerInfos } from '/@/stores/providers';
-import { fetchVolumes, resetInitializationVolumes, volumeListInfos } from '/@/stores/volumes';
+import { volumeListInfos, volumesEventStore } from '/@/stores/volumes';
 
 const listVolumesMock = vi.fn();
 const getProviderInfosMock = vi.fn();
@@ -51,6 +51,7 @@ beforeAll(() => {
 
 beforeEach(() => {
   vi.resetAllMocks();
+  vi.clearAllMocks();
   onDidUpdateProviderStatusMock.mockImplementation(() => Promise.resolve());
   getProviderInfosMock.mockResolvedValue([]);
 });
@@ -63,7 +64,7 @@ async function waitRender(customProperties: object): Promise<void> {
   }
 }
 
-test('Expect fetching in progress being displayed', async () => {
+test('Expect No Container Engine being displayed', async () => {
   listVolumesMock.mockResolvedValue([]);
   getProviderInfosMock.mockResolvedValue([
     {
@@ -83,9 +84,7 @@ test('Expect fetching in progress being displayed', async () => {
   expect(noEngine).toBeInTheDocument();
 });
 
-test('Expect no container engines being displayed', async () => {
-  resetInitializationVolumes();
-  listVolumesMock.mockResolvedValue([]);
+test('Expect volumes being displayed once extensions are started (without size data)', async () => {
   getProviderInfosMock.mockResolvedValue([
     {
       name: 'podman',
@@ -99,21 +98,57 @@ test('Expect no container engines being displayed', async () => {
       ],
     },
   ]);
+
+  listVolumesMock.mockResolvedValue([
+    {
+      Volumes: [
+        {
+          Driver: 'local',
+          Labels: {},
+          Mountpoint: '/var/lib/containers/storage/volumes/fedora/_data',
+          Name: '0052074a2ade930338c00aea982a90e4243e6cf58ba920eb411c388630b8c967',
+          Options: {},
+          Scope: 'local',
+          engineName: 'Podman',
+          engineId: 'podman.Podman Machine',
+          UsageData: { RefCount: 1, Size: -1 },
+          containersUsage: [],
+        },
+      ],
+    },
+  ]);
+
   window.dispatchEvent(new CustomEvent('extensions-already-started'));
   window.dispatchEvent(new CustomEvent('provider-lifecycle-change'));
 
+  // ask to fetch the volumes
+  const volumesEventStoreInfo = volumesEventStore.setup();
+
+  await volumesEventStoreInfo.fetch();
+
+  // first call is with listing without details
+  expect(listVolumesMock).toHaveBeenNthCalledWith(1, false);
+
   // wait store are populated
+  while (get(volumeListInfos).length === 0) {
+    await new Promise(resolve => setTimeout(resolve, 500));
+  }
   while (get(providerInfos).length === 0) {
     await new Promise(resolve => setTimeout(resolve, 500));
   }
 
   await waitRender({});
 
-  const noEngine = screen.getByRole('heading', { name: 'Fetching volumes...' });
-  expect(noEngine).toBeInTheDocument();
+  const volumeName = screen.getByRole('cell', { name: '0052074a2ade' });
+  // expect size to be N/A
+  const volumeSize = screen.getByRole('cell', { name: 'N/A' });
+  expect(volumeName).toBeInTheDocument();
+  expect(volumeSize).toBeInTheDocument();
+
+  expect(volumeName.compareDocumentPosition(volumeSize)).toBe(4);
 });
 
-test('Expect volumes being displayed once extensions are started', async () => {
+test('Expect volumes being displayed once extensions are started (with size data)', async () => {
   getProviderInfosMock.mockResolvedValue([
     {
       name: 'podman',
@@ -151,7 +186,12 @@ test('Expect volumes being displayed once extensions are started', async () => {
   window.dispatchEvent(new CustomEvent('provider-lifecycle-change'));
 
   // ask to fetch the volumes
-  await fetchVolumes();
+  const volumesEventStoreInfo = volumesEventStore.setup();
+
+  await volumesEventStoreInfo.fetch('fetchUsage');
+
+  // first call is with listing with details
+  expect(listVolumesMock).toHaveBeenNthCalledWith(1, true);
 
   // wait store are populated
   while (get(volumeListInfos).length === 0) {

--- a/packages/renderer/src/lib/volume/volume-utils.ts
+++ b/packages/renderer/src/lib/volume/volume-utils.ts
@@ -39,6 +39,10 @@ export class VolumeUtils {
   }
 
   getSize(volumeInfo: VolumeInfo): string {
+    // handle missing case
+    if (volumeInfo.UsageData?.Size === -1) {
+      return 'N/A';
+    }
     if (volumeInfo.UsageData?.Size) {
       return `${filesize(volumeInfo.UsageData?.Size, { roundingMethod: 'round' })}`;
     }

--- a/packages/renderer/src/stores/volumes.spec.ts
+++ b/packages/renderer/src/stores/volumes.spec.ts
@@ -22,7 +22,7 @@ import { get } from 'svelte/store';
 import type { Mock } from 'vitest';
 import { expect, test, vi } from 'vitest';
 import type { VolumeInspectInfo } from '../../../main/src/plugin/api/volume-info';
-import { fetchVolumes, volumeListInfos, volumesEventStore } from './volumes';
+import { fetchVolumesWithData, volumeListInfos, volumesEventStore } from './volumes';
 
 // first, path window object
 const callbacks = new Map<string, any>();
@@ -70,7 +70,7 @@ test('volumes should be updated in case of a container is removed', async () => 
   await callback();
 
   // now ready to fetch volumes
-  await fetchVolumes();
+  await fetchVolumesWithData();
 
   // now get list
   const volumes = get(volumeListInfos);

--- a/packages/renderer/src/stores/volumes.ts
+++ b/packages/renderer/src/stores/volumes.ts
@@ -52,8 +52,10 @@ export async function checkForUpdate(eventName: string): Promise<boolean> {
 export const volumeListInfos: Writable<VolumeListInfo[]> = writable([]);
 
 // use helper here as window methods are initialized after the store in tests
-const listVolumes = (): Promise<VolumeListInfo[]> => {
-  return window.listVolumes();
+const listVolumes = (...args: unknown[]): Promise<VolumeListInfo[]> => {
+  const fetchUsage = args?.length > 0 && args[0] === 'fetchUsage';
+
+  return window.listVolumes(fetchUsage);
 };
 
 export const volumesEventStore = new EventStore<VolumeListInfo[]>(
@@ -84,13 +86,6 @@ export const filtered = derived([searchPattern, volumeListInfos], ([$searchPatte
   });
 });
 
-export let volumesInitialized = false;
-
-export const fetchVolumes = async () => {
-  await volumesEventStoreInfo.fetch();
-  volumesInitialized = true;
-};
-
-export const resetInitializationVolumes = () => {
-  volumesInitialized = false;
+export const fetchVolumesWithData = async () => {
+  await volumesEventStoreInfo.fetch('fetchUsage');
 };


### PR DESCRIPTION
### What does this PR do?

it is the last PR related to limit the calls to the REST API here it avoids to call the system/df call that can be expensive on podman in rootful mode
debounce/throttle/reduce the calls were also done to reduce a huge number of calls to the REST API

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast 
explaining what is doing this PR -->

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/3376


### How to test this PR?

1. Run a podman machine in rootul mode
1. Spawn 5 containers 
```
  podman run -d docker.io/redis/redis-stack:latest
  podman run -d docker.io/redis/redis-stack:latest
  podman run -d docker.io/redis/redis-stack:latest
  podman run -d docker.io/redis/redis-stack:latest
  podman run -d docker.io/redis/redis-stack:latest
```

now start Podman Desktop and do some actions, it should not take long to have the UI being refreshed

then, click on `Collect usage data` in volumes page, here it should take longer.

unit tests are also provided
