### PR TITLE
feat: add arm64 binaries for Windows

### DIFF
--- a/.electron-builder.config.cjs
+++ b/.electron-builder.config.cjs
@@ -74,13 +74,22 @@ const config = {
   },
   files: ['packages/**/dist/**', 'extensions/**/builtin/*.cdix/**'],
   portable: {
-    artifactName: `podman-desktop${artifactNameSuffix}-\${version}.\${ext}`,
+    artifactName: `podman-desktop${artifactNameSuffix}-\${version}-\${arch}.\${ext}`,
   },
   nsis: {
-    artifactName: `podman-desktop${artifactNameSuffix}-\${version}-setup.\${ext}`,
+    artifactName: `podman-desktop${artifactNameSuffix}-\${version}-setup-\${arch}.\${ext}`,
   },
   win: {
-    target: ['portable', 'nsis'],
+    target: [
+      {
+        target: 'portable',
+        arch: ['x64', 'arm64'],
+      },
+      {
+        target: 'nsis',
+        arch: ['x64', 'arm64'],
+      },
+    ],
     sign: configuration => azureCodeSign(configuration.path),
   },
   flatpak: {

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -62,8 +62,23 @@ jobs:
 
       - uses: actions/upload-artifact@v3.1.2
         with:
-          name: windows-exe
-          path: ./dist/podman-desktop*.exe
+          name: windows-installer-x64
+          path: ./dist/podman-desktop*-setup-x64.exe
+
+      - uses: actions/upload-artifact@v3.1.2
+        with:
+          name: windows-installer-arm64
+          path: ./dist/podman-desktop*-setup-arm64.exe
+
+      - uses: actions/upload-artifact@v3.1.2
+        with:
+          name: windows-exe-x64
+          path: ./dist/podman-desktop*-next-x64.exe
+
+      - uses: actions/upload-artifact@v3.1.2
+        with:
+          name: windows-exe-arm64
+          path: ./dist/podman-desktop*-next-arm64.exe
 
   linux:
     name: Linux


### PR DESCRIPTION

### What does this PR do?
add arm64 binaries for Windows

include the arch in the filename

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast 
explaining what is doing this PR -->

### What issues does this PR fix or reference?

related to https://github.com/containers/podman-desktop/issues/3443


### How to test this PR?

Execute binaries on arm64 and x84