### PR TITLE
fix: redirect to previous page when removing a kubernetes connection

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesConnectionRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesConnectionRendering.spec.ts
@@ -1,0 +1,135 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-unused-vars */
+/* eslint-disable @typescript-eslint/no-empty-function */
+
+import '@testing-library/jest-dom/vitest';
+import { test, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import { providerInfos } from '../../stores/providers';
+import type { ProviderContainerConnectionInfo, ProviderInfo } from '../../../../main/src/plugin/api/provider-info';
+import userEvent from '@testing-library/user-event';
+import { router } from 'tinro';
+import PreferencesKubernetesConnectionRendering from './PreferencesKubernetesConnectionRendering.svelte';
+import { lastPage } from '/@/stores/breadcrumb';
+
+test('Expect that removing the connection is going back to the previous page', async () => {
+  const socketPath = '/my/common-socket-path';
+  const kindCluster1 = 'kind cluster 1';
+  const kindCluster2 = 'kind cluster 2';
+  const kindCluster3 = 'kind cluster 3';
+
+  const routerGotoSpy = vi.spyOn(router, 'goto');
+
+  const deleteMock = vi.fn();
+  (window as any).deleteProviderConnectionLifecycle = deleteMock;
+
+  const providerInfo: ProviderInfo = {
+    id: 'kind',
+    name: 'kind',
+    images: {
+      icon: 'img',
+    },
+    status: 'started',
+    warnings: [],
+    containerProviderConnectionCreation: true,
+    detectionChecks: [],
+    containerConnections: [],
+    installationSupport: false,
+    internalId: '0',
+    kubernetesConnections: [
+      {
+        name: kindCluster1,
+        status: 'started',
+        endpoint: {
+          apiURL: 'http://localhost:8080',
+        },
+      },
+      {
+        name: kindCluster2,
+        status: 'stopped',
+        endpoint: {
+          apiURL: 'http://localhost:8181',
+        },
+        lifecycleMethods: ['delete'],
+      },
+      {
+        name: kindCluster3,
+        status: 'started',
+        endpoint: {
+          apiURL: 'http://localhost:8282',
+        },
+      },
+    ],
+    kubernetesProviderConnectionCreation: true,
+    links: [],
+    containerProviderConnectionInitialization: false,
+    containerProviderConnectionCreationDisplayName: 'Podman machine',
+    kubernetesProviderConnectionInitialization: false,
+  };
+
+  // 3 connections with the same socket path
+  providerInfos.set([providerInfo]);
+
+  // encode name with base64 of the second cluster
+  const apiUrlBase64 = Buffer.from('http://localhost:8181').toString('base64');
+
+  // defines a fake lastPage so we can check where we will be redirected
+  lastPage.set({ name: 'Fake Previous', path: '/last' });
+
+  // delete current cluster 2 from the provider info
+  deleteMock.mockImplementation(() => {
+    providerInfos.update(providerInfos =>
+      providerInfos.map(provider => {
+        provider.kubernetesConnections = provider.kubernetesConnections.filter(
+          kubeConnection => kubeConnection.name !== kindCluster2,
+        );
+        return provider;
+      }),
+    );
+  });
+
+  render(PreferencesKubernetesConnectionRendering, {
+    apiUrlBase64,
+    providerInternalId: '0',
+  });
+
+  // expect to have the second machine being displayed (and not the first one that also match socket path)
+  const title = screen.getByRole('heading', { name: 'kind cluster 2', level: 1 });
+  expect(title).toBeInTheDocument();
+
+  // ok now we delete the connection
+  const deleteButton = screen.getByRole('button', { name: 'Delete' });
+
+  // grab current route
+  const currentRoute = window.location;
+  expect(currentRoute.href).toBe('http://localhost:3000/');
+
+  // click on it
+  await userEvent.click(deleteButton);
+
+  // expect that we have called the router when page has been removed
+  // to jump to the previous page
+  expect(routerGotoSpy).toBeCalledWith('/last');
+
+  // grab updated route
+  const afterRoute = window.location;
+  expect(afterRoute.href).toBe('http://localhost:3000/last');
+});

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesConnectionRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesConnectionRendering.svelte
@@ -33,6 +33,7 @@ let configurationKeys: IConfigurationPropertyRecordedSchema[];
 $: configurationKeys = properties
   .filter(property => property.scope === 'KubernetesConnection')
   .sort((a, b) => a.id.localeCompare(b.id));
+let detailsPage: DetailsPage;
 
 let providersUnsubscribe: Unsubscriber;
 onMount(async () => {
@@ -40,11 +41,13 @@ onMount(async () => {
   providersUnsubscribe = providerInfos.subscribe(providerInfosValue => {
     const providers = providerInfosValue;
     providerInfo = providers.find(provider => provider.internalId === providerInternalId);
-    console.log(providerInfo.images.icon);
+
     connectionInfo = providerInfo?.kubernetesConnections?.find(
       connection => connection.endpoint.apiURL === apiURL || connection.name === connectionName,
     );
     if (!connectionInfo) {
+      // closing the page of a connection that has been removed
+      detailsPage.close();
       return;
     }
     connectionName = connectionInfo.name;
@@ -122,7 +125,7 @@ function setNoLogs() {
 
 {#if connectionInfo}
   <div class="bg-charcoal-700 h-full">
-    <DetailsPage title="{connectionInfo.name}">
+    <DetailsPage title="{connectionInfo.name}" bind:this="{detailsPage}">
       <svelte:fragment slot="subtitle">
         <div class="flex flex-row">
           <ConnectionStatus status="{connectionInfo.status}" />


### PR DESCRIPTION
### What does this PR do?
 redirect to previous page when removing a kubernetes connection from details page

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast 
explaining what is doing this PR -->

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/3594

### How to test this PR?

unit test or use the use case of the issue (delete a k8s cluster from the details page)