### PR TITLE
chore: update website to handle the arm64 binaries for Windows

### DIFF
--- a/website/src/pages/downloads/windows.tsx
+++ b/website/src/pages/downloads/windows.tsx
@@ -50,7 +50,7 @@ async function grabfilenameforWindows(
     asset =>
       (asset.name as string).endsWith('arm64.exe') &&
       !asset.name.includes('airgap') &&
-      asset.name !== setupX64Asset?.name,
+      asset.name !== setupArm64Asset?.name,
   );
   const binaryArm64 = binaryOnlyArm64WindowsAssets?.[0]?.browser_download_url;
 
@@ -125,10 +125,10 @@ export function WindowsDownloads(): JSX.Element {
             </caption>
           </div>
           <div className="mt-4">
-            <div>Other downloads for Windows:</div>
+            <div>Other Windows downloads:</div>
 
             <div className="pt-4 pb-4 flex flex-col">
-              <div className="">Windows installer:</div>
+              <div className="">Installer:</div>
               <div className="flex flex-row justify-center">
                 <Link
                   className="underline inline-flex dark:text-white text-purple-500 hover:text-purple-200 py-2 px-3 font-semibold text-md"


### PR DESCRIPTION
### What does this PR do?
update website to handle the arm64 binaries for Windows

### Screenshot/screencast of this PR

Before:
![image](https://github.com/containers/podman-desktop/assets/436777/14e19748-2c94-4ce4-a1a4-62ea54bad5a2)

After:
![image](https://github.com/containers/podman-desktop/assets/436777/8af84bb0-34b1-4118-8d74-ce55fbfd1c05)


<!-- Please include a screenshot or a screencast 
explaining what is doing this PR -->

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/3443

### How to test this PR?

replace in `website/src/pages/downloads/windows.tsx`

```
-  const result = await fetch('https://api.github.com/repos/containers/podman-desktop/releases/latest');
+  const result = await fetch('https://api.github.com/repos/containers/podman-desktop/releases/118401175');
```


note: only merge this PR once 1.4.x is released