### PR TITLE
feat: support port ranges when starting a container (#3204)

### DIFF
--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -47,7 +47,7 @@ import type { PullEvent } from './api/pull-event.js';
 import type { ExtensionInfo } from './api/extension-info.js';
 import type { ImageInspectInfo } from './api/image-inspect-info.js';
 import type { TrayMenu } from '../tray-menu.js';
-import { getFreePort } from './util/port.js';
+import { getFreePort, getFreePortRange } from './util/port.js';
 import { isLinux, isMac } from '../util.js';
 import type { MessageBoxOptions, MessageBoxReturnValue } from './message-box.js';
 import { MessageBox } from './message-box.js';
@@ -1152,6 +1152,10 @@ export class PluginSystem {
 
     this.ipcHandle('system:get-free-port', async (_, port: number): Promise<number> => {
       return getFreePort(port);
+    });
+
+    this.ipcHandle('system:get-free-port-range', async (_, rangeSize: number): Promise<string> => {
+      return getFreePortRange(rangeSize);
     });
 
     this.ipcHandle(

--- a/packages/main/src/plugin/util/port.spec.ts
+++ b/packages/main/src/plugin/util/port.spec.ts
@@ -1,0 +1,36 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { expect, test } from 'vitest';
+import * as port from './port.js';
+import * as net from 'net';
+
+test('return port range starting with port 9000', async () => {
+  const range = await port.getFreePortRange(3);
+
+  expect(range).toBe('9000-9002');
+});
+
+test('return port range starting with port 9001 if 9000 is busy', async () => {
+  const server = net.createServer();
+  server.listen(9000);
+  const range = await port.getFreePortRange(3);
+
+  expect(range).toBe('9001-9003');
+  server.close();
+});

--- a/packages/main/src/plugin/util/port.ts
+++ b/packages/main/src/plugin/util/port.ts
@@ -50,9 +50,9 @@ export async function getFreePortRange(rangeSize: number): Promise<string> {
       ++port;
       startPort = port;
     }
-  } while (port + 1 - startPort !== rangeSize);
+  } while (port + 1 - startPort <= rangeSize);
 
-  return `${startPort}-${port}`;
+  return `${startPort}-${port - 1}`;
 }
 
 export function isFreePort(port: number): Promise<boolean> {

--- a/packages/main/src/plugin/util/port.ts
+++ b/packages/main/src/plugin/util/port.ts
@@ -35,3 +35,32 @@ export function getFreePort(port = 0): Promise<number> {
       .listen(port),
   );
 }
+
+/**
+ * Find a free port range
+ */
+export async function getFreePortRange(rangeSize: number): Promise<string> {
+  let port = 9000;
+  let startPort = port;
+
+  while (port - startPort !== rangeSize) {
+    if (await isFreePort(port)) {
+      ++port;
+    } else {
+      ++port;
+      startPort = port;
+    }
+  }
+
+  return `${startPort}-${port}`;
+}
+
+function isFreePort(port: number): Promise<boolean> {
+  const server = net.createServer();
+  return new Promise((resolve, reject) =>
+    server
+      .on('error', (error: NodeJS.ErrnoException) => (error.code === 'EADDRINUSE' ? resolve(false) : reject(error)))
+      .on('listening', () => server.close(() => resolve(true)))
+      .listen(port),
+  );
+}

--- a/packages/main/src/plugin/util/port.ts
+++ b/packages/main/src/plugin/util/port.ts
@@ -43,19 +43,19 @@ export async function getFreePortRange(rangeSize: number): Promise<string> {
   let port = 9000;
   let startPort = port;
 
-  while (port - startPort !== rangeSize) {
+  do {
     if (await isFreePort(port)) {
       ++port;
     } else {
       ++port;
       startPort = port;
     }
-  }
+  } while (port + 1 - startPort !== rangeSize);
 
   return `${startPort}-${port}`;
 }
 
-function isFreePort(port: number): Promise<boolean> {
+export function isFreePort(port: number): Promise<boolean> {
   const server = net.createServer();
   return new Promise((resolve, reject) =>
     server

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -1064,6 +1064,10 @@ function initExposure(): void {
     return ipcInvoke('system:get-free-port', port);
   });
 
+  contextBridge.exposeInMainWorld('getFreePortRange', async (rangeSize: number): Promise<string> => {
+    return ipcInvoke('system:get-free-port-range', rangeSize);
+  });
+
   type LogFunction = (...data: unknown[]) => void;
 
   let onDataCallbacksStartReceiveLogsId = 0;

--- a/packages/renderer/src/lib/image/RunImage.spec.ts
+++ b/packages/renderer/src/lib/image/RunImage.spec.ts
@@ -25,6 +25,7 @@ import { runImageInfo } from '../../stores/run-image-store';
 import RunImage from '/@/lib/image/RunImage.svelte';
 import type { ImageInspectInfo } from '../../../../main/src/plugin/api/image-inspect-info';
 import { mockBreadcrumb } from '../../stores/breadcrumb';
+import userEvent from '@testing-library/user-event';
 
 // fake the window.events object
 beforeAll(() => {
@@ -306,6 +307,32 @@ describe('RunImage', () => {
     expect(window.createAndStartContainer).toHaveBeenCalledWith(
       'engineid',
       expect.objectContaining({ Cmd: ['command1', 'command2'] }),
+    );
+  });
+
+  test('Expect to see an error if the container/host ranges have different size', async () => {
+    await createRunImage(undefined, ['command1', 'command2']);
+
+    const customMappingButton = screen.getByRole('button', { name: 'Add custom port mapping' });
+    await fireEvent.click(customMappingButton);
+
+    const hostInput = screen.getByLabelText('host port');
+    await userEvent.click(hostInput);
+    await userEvent.clear(hostInput);
+    await userEvent.keyboard('9000-9001');
+
+    const containerInput = screen.getByLabelText('container port');
+    await userEvent.click(containerInput);
+    await userEvent.clear(containerInput);
+    await userEvent.keyboard('9000-9003');
+
+    const button = screen.getByRole('button', { name: 'Start Container' });
+
+    await fireEvent.click(button);
+
+    const errorComponent = screen.getByLabelText('createError');
+    expect(errorComponent.textContent.trim()).toBe(
+      'Error: host and container port ranges (9000-9001:9000-9003) have different lengths: 2 vs 4',
     );
   });
 });


### PR DESCRIPTION
### What does this PR do?

it adds the logic to handle port ranges in the form of <port>-<port>

### Screenshot/screencast of this PR

![range_port](https://github.com/containers/podman-desktop/assets/49404737/da66b67a-0884-40b1-85bd-a9c3ea2f3f9e)

### What issues does this PR fix or reference?

it resolves #3204 

### How to test this PR?

1. start a container by mapping a range of ports and check that it actually worked by inspecting it


