### PR TITLE
docs: a unix scheme is required for DOCKER_HOST

### DIFF
--- a/website/docs/migrating-from-docker/using-the-docker_host-environment-variable.md
+++ b/website/docs/migrating-from-docker/using-the-docker_host-environment-variable.md
@@ -49,10 +49,10 @@ Consider using the `DOCKER_HOST` environment variable to migrate transparently f
      </TabItem>
    </Tabs>
 
-2. Set the `DOCKER_HOST` environment variable to your Podman socket location:
+2. Set the `DOCKER_HOST` environment variable to your Podman socket location. Be sure to add the `unix://` scheme to the path retrieved previously:
 
    ```shell-session
-   $ export DOCKER_HOST=<your_podman_socket_location>
+   $ export DOCKER_HOST=unix://<your_podman_socket_location>
    ```
 
 #### Verification


### PR DESCRIPTION
### What does this PR do?

The docs as-is are confusing, as the paths produced by these commands will not work as shown without knowing adding a `unix://` scheme is needed. Specifically, you need `DOCKER_HOST=unix:///foo/bar/baz`, not `DOCKER_HOST=/foo/bar/baz`.

(I'm deleting the rest of the template as I assume it's not relevant to this kind of PR but if any of it indeed is needed to make it more clear please let me know).