### PR TITLE
fix: remove catch() call after telemetry.track() call

### DIFF
--- a/packages/main/src/plugin/command-registry.ts
+++ b/packages/main/src/plugin/command-registry.ts
@@ -65,9 +65,7 @@ export class CommandRegistry {
       (telemetryOptions as any).error = err;
       throw err;
     } finally {
-      this.telemetry
-        .track('executeCommand', telemetryOptions)
-        .catch((err: unknown) => console.error('Unable to track', err));
+      this.telemetry.track('executeCommand', telemetryOptions);
     }
   }
 

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -188,13 +188,11 @@ export class ContainerProviderRegistry {
     const providerName = containerProviderConnection.name;
     const id = `${provider.id}.${providerName}`;
     this.containerProviders.set(id, containerProviderConnection);
-    this.telemetryService
-      .track('registerContainerProviderConnection', {
-        name: containerProviderConnection.name,
-        type: containerProviderConnection.type,
-        total: this.containerProviders.size,
-      })
-      .catch((err: unknown) => console.error('Unable to track', err));
+    this.telemetryService.track('registerContainerProviderConnection', {
+      name: containerProviderConnection.name,
+      type: containerProviderConnection.type,
+      total: this.containerProviders.size,
+    });
 
     const internalProvider: InternalContainerProvider = {
       id,
@@ -268,9 +266,10 @@ export class ContainerProviderRegistry {
       }),
     );
     const flatttenedContainers = containers.flat();
-    this.telemetryService
-      .track('listSimpleContainers', Object.assign({ total: flatttenedContainers.length }, telemetryOptions))
-      .catch((err: unknown) => console.error('Unable to track', err));
+    this.telemetryService.track(
+      'listSimpleContainers',
+      Object.assign({ total: flatttenedContainers.length }, telemetryOptions),
+    );
 
     return flatttenedContainers;
   }
@@ -423,9 +422,11 @@ export class ContainerProviderRegistry {
       }),
     );
     const flatttenedContainers = containers.flat();
-    this.telemetryService
-      .track('listContainers', Object.assign({ total: flatttenedContainers.length }, telemetryOptions))
-      .catch((err: unknown) => console.error('Unable to track', err));
+    this.telemetryService.track(
+      'listContainers',
+      Object.assign({ total: flatttenedContainers.length }, telemetryOptions),
+    );
+
     return flatttenedContainers;
   }
 
@@ -450,9 +451,7 @@ export class ContainerProviderRegistry {
       }),
     );
     const flatttenedImages = images.flat();
-    this.telemetryService
-      .track('listImages', Object.assign({ total: flatttenedImages.length }, telemetryOptions))
-      .catch((err: unknown) => console.error('Unable to track', err));
+    this.telemetryService.track('listImages', Object.assign({ total: flatttenedImages.length }, telemetryOptions));
 
     return flatttenedImages;
   }
@@ -480,9 +479,7 @@ export class ContainerProviderRegistry {
       telemetryOptions = { error: error };
       throw error;
     } finally {
-      this.telemetryService
-        .track('pruneImages', telemetryOptions)
-        .catch((err: unknown) => console.error('Unable to track', err));
+      this.telemetryService.track('pruneImages', telemetryOptions);
     }
   }
 
@@ -507,9 +504,7 @@ export class ContainerProviderRegistry {
       }),
     );
     const flatttenedPods = pods.flat();
-    this.telemetryService
-      .track('listPods', Object.assign({ total: flatttenedPods.length }, telemetryOptions))
-      .catch((err: unknown) => console.error('Unable to track', err));
+    this.telemetryService.track('listPods', Object.assign({ total: flatttenedPods.length }, telemetryOptions));
 
     return flatttenedPods;
   }
@@ -535,9 +530,7 @@ export class ContainerProviderRegistry {
       }),
     );
     const flatttenedNetworks = networks.flat();
-    this.telemetryService
-      .track('listNetworks', Object.assign({ total: flatttenedNetworks.length }, telemetryOptions))
-      .catch((err: unknown) => console.error('Unable to track', err));
+    this.telemetryService.track('listNetworks', Object.assign({ total: flatttenedNetworks.length }, telemetryOptions));
 
     return flatttenedNetworks;
   }
@@ -612,9 +605,8 @@ export class ContainerProviderRegistry {
       }),
     );
     const flatttenedVolumes: VolumeListInfo[] = volumes.flat();
-    this.telemetryService
-      .track('listVolumes', Object.assign({ total: flatttenedVolumes.length }, telemetryOptions))
-      .catch((err: unknown) => console.error('Unable to track', err));
+    this.telemetryService.track('listVolumes', Object.assign({ total: flatttenedVolumes.length }, telemetryOptions));
+
     return flatttenedVolumes;
   }
 
@@ -640,9 +632,7 @@ export class ContainerProviderRegistry {
       telemetryOptions = { error: error };
       throw error;
     } finally {
-      this.telemetryService
-        .track('volumeInspect', telemetryOptions)
-        .catch((err: unknown) => console.error('Unable to track', err));
+      this.telemetryService.track('volumeInspect', telemetryOptions);
     }
   }
 
@@ -654,9 +644,7 @@ export class ContainerProviderRegistry {
       telemetryOptions = { error: error };
       throw error;
     } finally {
-      this.telemetryService
-        .track('removeVolume', telemetryOptions)
-        .catch((err: unknown) => console.error('Unable to track', err));
+      this.telemetryService.track('removeVolume', telemetryOptions);
     }
   }
 
@@ -762,9 +750,7 @@ export class ContainerProviderRegistry {
       telemetryOptions = { error: error };
       throw error;
     } finally {
-      this.telemetryService
-        .track('stopContainer', telemetryOptions)
-        .catch((err: unknown) => console.error('Unable to track', err));
+      this.telemetryService.track('stopContainer', telemetryOptions);
     }
   }
 
@@ -777,9 +763,7 @@ export class ContainerProviderRegistry {
       telemetryOptions = { error: error };
       throw error;
     } finally {
-      this.telemetryService
-        .track('deleteImage', telemetryOptions)
-        .catch((err: unknown) => console.error('Unable to track', err));
+      this.telemetryService.track('deleteImage', telemetryOptions);
     }
   }
 
@@ -802,9 +786,10 @@ export class ContainerProviderRegistry {
       telemetryOptions = { error: error };
       throw error;
     } finally {
-      this.telemetryService
-        .track('tagImage', Object.assign({ imageName: this.getImageHash(imageTag) }, telemetryOptions))
-        .catch((err: unknown) => console.error('Unable to track', err));
+      this.telemetryService.track(
+        'tagImage',
+        Object.assign({ imageName: this.getImageHash(imageTag) }, telemetryOptions),
+      );
     }
   }
 
@@ -836,9 +821,10 @@ export class ContainerProviderRegistry {
       telemetryOptions = { error: error };
       throw error;
     } finally {
-      this.telemetryService
-        .track('pushImage', Object.assign({ imageName: this.getImageHash(imageTag) }, telemetryOptions))
-        .catch((err: unknown) => console.error('Unable to track', err));
+      this.telemetryService.track(
+        'pushImage',
+        Object.assign({ imageName: this.getImageHash(imageTag) }, telemetryOptions),
+      );
     }
   }
   async pullImage(
@@ -884,9 +870,10 @@ export class ContainerProviderRegistry {
       telemetryOptions = { error: error };
       throw error;
     } finally {
-      this.telemetryService
-        .track('pullImage', Object.assign({ imageName: this.getImageHash(imageName) }, telemetryOptions))
-        .catch((err: unknown) => console.error('Unable to track', err));
+      this.telemetryService.track(
+        'pullImage',
+        Object.assign({ imageName: this.getImageHash(imageName) }, telemetryOptions),
+      );
     }
   }
 
@@ -902,9 +889,7 @@ export class ContainerProviderRegistry {
       telemetryOptions = { error: error };
       throw error;
     } finally {
-      this.telemetryService
-        .track('pingContainerEngine', telemetryOptions)
-        .catch((err: unknown) => console.error('Unable to track', err));
+      this.telemetryService.track('pingContainerEngine', telemetryOptions);
     }
   }
 
@@ -918,9 +903,7 @@ export class ContainerProviderRegistry {
       telemetryOptions = { error: error };
       throw error;
     } finally {
-      this.telemetryService
-        .track('listContainersFromEngine', telemetryOptions)
-        .catch((err: unknown) => console.error('Unable to track', err));
+      this.telemetryService.track('listContainersFromEngine', telemetryOptions);
     }
   }
 
@@ -933,9 +916,7 @@ export class ContainerProviderRegistry {
       telemetryOptions = { error: error };
       throw error;
     } finally {
-      this.telemetryService
-        .track('deleteContainer', telemetryOptions)
-        .catch((err: unknown) => console.error('Unable to track', err));
+      this.telemetryService.track('deleteContainer', telemetryOptions);
     }
   }
 
@@ -947,9 +928,7 @@ export class ContainerProviderRegistry {
       telemetryOptions = { error: error };
       throw error;
     } finally {
-      this.telemetryService
-        .track('startContainer', telemetryOptions)
-        .catch((err: unknown) => console.error('Unable to track', err));
+      this.telemetryService.track('startContainer', telemetryOptions);
     }
   }
 
@@ -961,9 +940,7 @@ export class ContainerProviderRegistry {
       telemetryOptions = { error: error };
       throw error;
     } finally {
-      this.telemetryService
-        .track('generatePodmanKube', telemetryOptions)
-        .catch((err: unknown) => console.error('Unable to track', err));
+      this.telemetryService.track('generatePodmanKube', telemetryOptions);
     }
   }
 
@@ -975,9 +952,7 @@ export class ContainerProviderRegistry {
       telemetryOptions = { error: error };
       throw error;
     } finally {
-      this.telemetryService
-        .track('startPod', telemetryOptions)
-        .catch((err: unknown) => console.error('Unable to track', err));
+      this.telemetryService.track('startPod', telemetryOptions);
     }
   }
 
@@ -1002,9 +977,7 @@ export class ContainerProviderRegistry {
       telemetryOptions = { error: error };
       throw error;
     } finally {
-      this.telemetryService
-        .track('createPod', telemetryOptions)
-        .catch((err: unknown) => console.error('Unable to track', err));
+      this.telemetryService.track('createPod', telemetryOptions);
     }
   }
 
@@ -1016,9 +989,7 @@ export class ContainerProviderRegistry {
       telemetryOptions = { error: error };
       throw error;
     } finally {
-      this.telemetryService
-        .track('restartPod', telemetryOptions)
-        .catch((err: unknown) => console.error('Unable to track', err));
+      this.telemetryService.track('restartPod', telemetryOptions);
     }
   }
 
@@ -1060,9 +1031,7 @@ export class ContainerProviderRegistry {
       telemetryOptions = { error: error };
       throw error;
     } finally {
-      this.telemetryService
-        .track('replicatePodmanContainer', telemetryOptions)
-        .catch((err: unknown) => console.error('Unable to track', err));
+      this.telemetryService.track('replicatePodmanContainer', telemetryOptions);
     }
   }
 
@@ -1074,9 +1043,7 @@ export class ContainerProviderRegistry {
       telemetryOptions = { error: error };
       throw error;
     } finally {
-      this.telemetryService
-        .track('stopPod', telemetryOptions)
-        .catch((err: unknown) => console.error('Unable to track', err));
+      this.telemetryService.track('stopPod', telemetryOptions);
     }
   }
 
@@ -1088,9 +1055,7 @@ export class ContainerProviderRegistry {
       telemetryOptions = { error: error };
       throw error;
     } finally {
-      this.telemetryService
-        .track('removePod', telemetryOptions)
-        .catch((err: unknown) => console.error('Unable to track', err));
+      this.telemetryService.track('removePod', telemetryOptions);
     }
   }
 
@@ -1102,9 +1067,7 @@ export class ContainerProviderRegistry {
       telemetryOptions = { error: error };
       throw error;
     } finally {
-      this.telemetryService
-        .track('prunePods', telemetryOptions)
-        .catch((err: unknown) => console.error('Unable to track', err));
+      this.telemetryService.track('prunePods', telemetryOptions);
     }
   }
 
@@ -1116,9 +1079,7 @@ export class ContainerProviderRegistry {
       telemetryOptions = { error: error };
       throw error;
     } finally {
-      this.telemetryService
-        .track('pruneContainers', telemetryOptions)
-        .catch((err: unknown) => console.error('Unable to track', err));
+      this.telemetryService.track('pruneContainers', telemetryOptions);
     }
   }
 
@@ -1130,9 +1091,7 @@ export class ContainerProviderRegistry {
       telemetryOptions = { error: error };
       throw error;
     } finally {
-      this.telemetryService
-        .track('pruneVolumes', telemetryOptions)
-        .catch((err: unknown) => console.error('Unable to track', err));
+      this.telemetryService.track('pruneVolumes', telemetryOptions);
     }
   }
 
@@ -1144,9 +1103,7 @@ export class ContainerProviderRegistry {
       telemetryOptions = { error: error };
       throw error;
     } finally {
-      this.telemetryService
-        .track('restartContainer', telemetryOptions)
-        .catch((err: unknown) => console.error('Unable to track', err));
+      this.telemetryService.track('restartContainer', telemetryOptions);
     }
   }
 
@@ -1174,9 +1131,7 @@ export class ContainerProviderRegistry {
       telemetryOptions = { error: error };
       throw error;
     } finally {
-      this.telemetryService
-        .track('restartContainersByLabel', telemetryOptions)
-        .catch((err: unknown) => console.error('Unable to track', err));
+      this.telemetryService.track('restartContainersByLabel', telemetryOptions);
     }
   }
 
@@ -1201,9 +1156,7 @@ export class ContainerProviderRegistry {
       telemetryOptions = { error: error };
       throw error;
     } finally {
-      this.telemetryService
-        .track('startContainersByLabel', telemetryOptions)
-        .catch((err: unknown) => console.error('Unable to track', err));
+      this.telemetryService.track('startContainersByLabel', telemetryOptions);
     }
   }
 
@@ -1228,9 +1181,7 @@ export class ContainerProviderRegistry {
       telemetryOptions = { error: error };
       throw error;
     } finally {
-      this.telemetryService
-        .track('stopContainersByLabel', telemetryOptions)
-        .catch((err: unknown) => console.error('Unable to track', err));
+      this.telemetryService.track('stopContainersByLabel', telemetryOptions);
     }
   }
 
@@ -1253,9 +1204,7 @@ export class ContainerProviderRegistry {
       telemetryOptions = { error: error };
       throw error;
     } finally {
-      this.telemetryService
-        .track('deleteContainersByLabel', telemetryOptions)
-        .catch((err: unknown) => console.error('Unable to track', err));
+      this.telemetryService.track('deleteContainersByLabel', telemetryOptions);
     }
   }
 
@@ -1285,9 +1234,7 @@ export class ContainerProviderRegistry {
       telemetryOptions = { error: error };
       throw error;
     } finally {
-      this.telemetryService
-        .track('logsContainer', telemetryOptions)
-        .catch((err: unknown) => console.error('Unable to track', err));
+      this.telemetryService.track('logsContainer', telemetryOptions);
     }
   }
 
@@ -1386,9 +1333,7 @@ export class ContainerProviderRegistry {
       telemetryOptions = { error: error };
       throw error;
     } finally {
-      this.telemetryService
-        .track('shellInContainer', telemetryOptions)
-        .catch((err: unknown) => console.error('Unable to track', err));
+      this.telemetryService.track('shellInContainer', telemetryOptions);
     }
   }
 
@@ -1409,9 +1354,7 @@ export class ContainerProviderRegistry {
       telemetryOptions = { error: error };
       throw error;
     } finally {
-      this.telemetryService
-        .track('createAndStartContainer', telemetryOptions)
-        .catch((err: unknown) => console.error('Unable to track', err));
+      this.telemetryService.track('createAndStartContainer', telemetryOptions);
     }
   }
 
@@ -1437,9 +1380,7 @@ export class ContainerProviderRegistry {
       telemetryOptions = { error: error };
       throw error;
     } finally {
-      this.telemetryService
-        .track('imageInspect', telemetryOptions)
-        .catch((err: unknown) => console.error('Unable to track', err));
+      this.telemetryService.track('imageInspect', telemetryOptions);
     }
   }
 
@@ -1460,9 +1401,7 @@ export class ContainerProviderRegistry {
       telemetryOptions = { error: error };
       throw error;
     } finally {
-      this.telemetryService
-        .track('imageHistory', telemetryOptions)
-        .catch((err: unknown) => console.error('Unable to track', err));
+      this.telemetryService.track('imageHistory', telemetryOptions);
     }
   }
 
@@ -1489,9 +1428,7 @@ export class ContainerProviderRegistry {
       telemetryOptions = { error: error };
       throw error;
     } finally {
-      this.telemetryService
-        .track('containerInspect', telemetryOptions)
-        .catch((err: unknown) => console.error('Unable to track', err));
+      this.telemetryService.track('containerInspect', telemetryOptions);
     }
   }
 
@@ -1516,9 +1453,7 @@ export class ContainerProviderRegistry {
       telemetryOptions = { error: error };
       throw error;
     } finally {
-      this.telemetryService
-        .track('imageSave', telemetryOptions)
-        .catch((err: unknown) => console.error('Unable to track', err));
+      this.telemetryService.track('imageSave', telemetryOptions);
     }
   }
 
@@ -1544,9 +1479,7 @@ export class ContainerProviderRegistry {
       telemetryOptions = { error: error };
       throw error;
     } finally {
-      this.telemetryService
-        .track('podInspect', telemetryOptions)
-        .catch((err: unknown) => console.error('Unable to track', err));
+      this.telemetryService.track('podInspect', telemetryOptions);
     }
   }
 
@@ -1618,9 +1551,7 @@ export class ContainerProviderRegistry {
       telemetryOptions = { error: error };
       throw error;
     } finally {
-      this.telemetryService
-        .track('containerStats', telemetryOptions)
-        .catch((err: unknown) => console.error('Unable to track', err));
+      this.telemetryService.track('containerStats', telemetryOptions);
     }
   }
 
@@ -1644,9 +1575,7 @@ export class ContainerProviderRegistry {
       telemetryOptions = { error: error };
       throw error;
     } finally {
-      this.telemetryService
-        .track('playKube', telemetryOptions)
-        .catch((err: unknown) => console.error('Unable to track', err));
+      this.telemetryService.track('playKube', telemetryOptions);
     }
   }
 
@@ -1733,9 +1662,7 @@ export class ContainerProviderRegistry {
       telemetryOptions = { error: error };
       throw error;
     } finally {
-      this.telemetryService
-        .track('buildImage', telemetryOptions)
-        .catch((err: unknown) => console.error('Unable to track', err));
+      this.telemetryService.track('buildImage', telemetryOptions);
     }
   }
 }

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -587,9 +587,7 @@ export class ExtensionLoader {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (telemetryOptions as any).error = err;
     } finally {
-      this.telemetry.track('loadExtension', telemetryOptions).catch((error: unknown) => {
-        console.error('error while tracking loadExtension telemetry', error);
-      });
+      this.telemetry.track('loadExtension', telemetryOptions);
     }
   }
 
@@ -1109,9 +1107,7 @@ export class ExtensionLoader {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (telemetryOptions as any).error = err;
     } finally {
-      this.telemetry
-        .track('activateExtension', telemetryOptions)
-        .catch((error: unknown) => console.log(`Failed to track activateExtension telemetry event. Error: ${error}`));
+      this.telemetry.track('activateExtension', telemetryOptions);
     }
   }
 
@@ -1167,9 +1163,7 @@ export class ExtensionLoader {
     this.activatedExtensions.delete(extensionId);
     this.extensionState.set(extension.id, 'stopped');
     this.apiSender.send('extension-stopped');
-    this.telemetry
-      .track('deactivateExtension', telemetryOptions)
-      .catch((error: unknown) => console.log(`Failed to track deactivateExtension telemetry event. Error: ${error}`));
+    this.telemetry.track('deactivateExtension', telemetryOptions);
   }
 
   async stopAllExtensions(): Promise<void> {
@@ -1202,7 +1196,7 @@ export class ExtensionLoader {
       telemetryData.error = error;
       throw error;
     } finally {
-      await this.telemetry.track('removeExtension', telemetryData);
+      this.telemetry.track('removeExtension', telemetryData);
     }
   }
 

--- a/packages/main/src/plugin/extensions-updater/extensions-updater.ts
+++ b/packages/main/src/plugin/extensions-updater/extensions-updater.ts
@@ -179,9 +179,7 @@ export class ExtensionsUpdater {
       const telemetryOptions = {
         extensionsToUpdate: extensionsToUpdateFiltered,
       };
-      this.telemetry.track('extensions-updates-available', telemetryOptions).catch((err: unknown) => {
-        console.error('Error while reporting extensions-updates-available telemetry', err);
-      });
+      this.telemetry.track('extensions-updates-available', telemetryOptions);
     }
   }
 
@@ -222,9 +220,7 @@ export class ExtensionsUpdater {
       console.error(`Error while updating extension ${extensionId}:`, err);
       telemetryOptions.error = err;
     } finally {
-      this.telemetry.track(eventName, telemetryOptions).catch((err: unknown) => {
-        console.error(`Error while tracking ${eventName}`, err);
-      });
+      this.telemetry.track(eventName, telemetryOptions);
     }
   }
 }

--- a/packages/main/src/plugin/image-registry.ts
+++ b/packages/main/src/plugin/image-registry.ts
@@ -143,12 +143,10 @@ export class ImageRegistry {
 
   registerRegistry(registry: containerDesktopAPI.Registry): Disposable {
     this.registries = [...this.registries, registry];
-    this.telemetryService
-      .track('registerRegistry', {
-        serverUrl: this.getRegistryHash(registry),
-        total: this.registries.length,
-      })
-      .catch((err: unknown) => console.error('Unable to track', err));
+    this.telemetryService.track('registerRegistry', {
+      serverUrl: this.getRegistryHash(registry),
+      total: this.registries.length,
+    });
     this.apiSender.send('registry-register', registry);
     this._onDidRegisterRegistry.fire(Object.freeze({ ...registry }));
     return Disposable.create(() => {
@@ -196,12 +194,10 @@ export class ImageRegistry {
       this.registries = filtered;
       this.apiSender.send('registry-unregister', registry);
     }
-    this.telemetryService
-      .track('unregisterRegistry', {
-        serverUrl: this.getRegistryHash(registry),
-        total: this.registries.length,
-      })
-      .catch((err: unknown) => console.error('Unable to track', err));
+    this.telemetryService.track('unregisterRegistry', {
+      serverUrl: this.getRegistryHash(registry),
+      total: this.registries.length,
+    });
   }
 
   getRegistries(): readonly containerDesktopAPI.Registry[] {
@@ -253,18 +249,16 @@ export class ImageRegistry {
       telemetryOptions = { error: error };
       throw error;
     } finally {
-      this.telemetryService
-        .track(
-          'createRegistry',
-          Object.assign(
-            {
-              serverUrlHash: this.getRegistryHash(registryCreateOptions),
-              total: this.registries.length,
-            },
-            telemetryOptions,
-          ),
-        )
-        .catch((err: unknown) => console.error('Unable to track', err));
+      this.telemetryService.track(
+        'createRegistry',
+        Object.assign(
+          {
+            serverUrlHash: this.getRegistryHash(registryCreateOptions),
+            total: this.registries.length,
+          },
+          telemetryOptions,
+        ),
+      );
     }
   }
 
@@ -281,12 +275,10 @@ export class ImageRegistry {
     }
     matchingRegistry.username = registry.username;
     matchingRegistry.secret = registry.secret;
-    this.telemetryService
-      .track('updateRegistry', {
-        serverUrl: this.getRegistryHash(matchingRegistry),
-        total: this.registries.length,
-      })
-      .catch((err: unknown) => console.error('Unable to track', err));
+    this.telemetryService.track('updateRegistry', {
+      serverUrl: this.getRegistryHash(matchingRegistry),
+      total: this.registries.length,
+    });
     this.apiSender.send('registry-update', registry);
     this._onDidUpdateRegistry.fire(Object.freeze(registry));
   }

--- a/packages/main/src/plugin/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes-client.ts
@@ -345,9 +345,7 @@ export class KubernetesClient {
       telemetryOptions = { error: error };
       throw this.wrapK8sClientError(error);
     } finally {
-      this.telemetry
-        .track('kubernetesCreatePod', telemetryOptions)
-        .catch((err: unknown) => console.error('Unable to track', err));
+      this.telemetry.track('kubernetesCreatePod', telemetryOptions);
     }
   }
 
@@ -362,9 +360,7 @@ export class KubernetesClient {
       telemetryOptions = { error: error };
       throw this.wrapK8sClientError(error);
     } finally {
-      this.telemetry
-        .track('kubernetesCreateService', telemetryOptions)
-        .catch((err: unknown) => console.error('Unable to track', err));
+      this.telemetry.track('kubernetesCreateService', telemetryOptions);
     }
   }
 
@@ -379,9 +375,7 @@ export class KubernetesClient {
       telemetryOptions = { error: error };
       throw this.wrapK8sClientError(error);
     } finally {
-      this.telemetry
-        .track('kubernetesCreateIngress', telemetryOptions)
-        .catch((err: unknown) => console.error('Unable to track', err));
+      this.telemetry.track('kubernetesCreateIngress', telemetryOptions);
     }
   }
 
@@ -402,9 +396,7 @@ export class KubernetesClient {
       telemetryOptions = { error: error };
       throw this.wrapK8sClientError(error);
     } finally {
-      this.telemetry
-        .track('kubernetesCreateRoute', telemetryOptions)
-        .catch((err: unknown) => console.error('Unable to track', err));
+      this.telemetry.track('kubernetesCreateRoute', telemetryOptions);
     }
   }
 
@@ -431,9 +423,7 @@ export class KubernetesClient {
       telemetryOptions = { error: error };
       throw this.wrapK8sClientError(error);
     } finally {
-      this.telemetry
-        .track('kubernetesListNamespacePod', telemetryOptions)
-        .catch((err: unknown) => console.error('Unable to track', err));
+      this.telemetry.track('kubernetesListNamespacePod', telemetryOptions);
     }
   }
 
@@ -449,7 +439,7 @@ export class KubernetesClient {
   }
 
   async readPodLog(name: string, container: string, callback: (name: string, data: string) => void): Promise<void> {
-    this.telemetry.track('kubernetesReadPodLog').catch((err: unknown) => console.error('Unable to track', err));
+    this.telemetry.track('kubernetesReadPodLog');
     const ns = this.currentNamespace;
     if (ns) {
       const log = new Log(this.kubeConfig);
@@ -477,9 +467,7 @@ export class KubernetesClient {
       telemetryOptions = { error: error };
       throw this.wrapK8sClientError(error);
     } finally {
-      this.telemetry
-        .track('kubernetesDeletePod', telemetryOptions)
-        .catch((err: unknown) => console.error('Unable to track', err));
+      this.telemetry.track('kubernetesDeletePod', telemetryOptions);
     }
   }
 
@@ -497,9 +485,7 @@ export class KubernetesClient {
       telemetryOptions = { error: error };
       throw this.wrapK8sClientError(error);
     } finally {
-      this.telemetry
-        .track('kubernetesReadNamespacedPod', telemetryOptions)
-        .catch((err: unknown) => console.error('Unable to track', err));
+      this.telemetry.track('kubernetesReadNamespacedPod', telemetryOptions);
     }
   }
 
@@ -517,9 +503,7 @@ export class KubernetesClient {
       telemetryOptions = { error: error };
       throw this.wrapK8sClientError(error);
     } finally {
-      this.telemetry
-        .track('kubernetesReadNamespacedConfigMap', telemetryOptions)
-        .catch((err: unknown) => console.error('Unable to track', err));
+      this.telemetry.track('kubernetesReadNamespacedConfigMap', telemetryOptions);
     }
   }
 
@@ -539,9 +523,7 @@ export class KubernetesClient {
       telemetryOptions = { error: error };
       throw this.wrapK8sClientError(error);
     } finally {
-      this.telemetry
-        .track('kubernetesListNamespaces', telemetryOptions)
-        .catch((err: unknown) => console.error('Unable to track', err));
+      this.telemetry.track('kubernetesListNamespaces', telemetryOptions);
     }
   }
 
@@ -718,9 +700,7 @@ export class KubernetesClient {
       telemetryOptions = { error: error };
       throw error;
     } finally {
-      this.telemetry
-        .track('kubernetesCreateResourcesFromFile', telemetryOptions)
-        .catch((err: unknown) => console.error('Unable to track', err));
+      this.telemetry.track('kubernetesCreateResourcesFromFile', telemetryOptions);
     }
   }
 
@@ -800,9 +780,10 @@ export class KubernetesClient {
       telemetryOptions = { error: error };
       throw error;
     } finally {
-      this.telemetry
-        .track('kubernetesCreateResource', Object.assign({ manifestsSize: manifests?.length }, telemetryOptions))
-        .catch((err: unknown) => console.error('Unable to track', err));
+      this.telemetry.track(
+        'kubernetesCreateResource',
+        Object.assign({ manifestsSize: manifests?.length }, telemetryOptions),
+      );
     }
   }
 }

--- a/packages/main/src/plugin/provider-registry.ts
+++ b/packages/main/src/plugin/provider-registry.ts
@@ -180,9 +180,7 @@ export class ProviderRegistry {
     if (providerOptions.version) {
       trackOpts.version = providerOptions.version;
     }
-    this.telemetryService
-      .track('createProvider', trackOpts)
-      .catch((err: unknown) => console.error('Unable to track', err));
+    this.telemetryService.track('createProvider', trackOpts);
     this.apiSender.send('provider-create', id);
     providerImpl.onDidUpdateVersion(() => this.apiSender.send('provider:update-version'));
     return providerImpl;
@@ -408,11 +406,9 @@ export class ProviderRegistry {
     if (!providerInstall) {
       throw new Error(`No matching installation for provider ${provider.internalId}`);
     }
-    this.telemetryService
-      .track('installProvider', {
-        name: provider.name,
-      })
-      .catch((err: unknown) => console.error('Unable to track', err));
+    this.telemetryService.track('installProvider', {
+      name: provider.name,
+    });
     return providerInstall.install(new LoggerImpl());
   }
 
@@ -424,11 +420,9 @@ export class ProviderRegistry {
       throw new Error(`No matching update for provider ${provider.internalId}`);
     }
 
-    this.telemetryService
-      .track('updateProvider', {
-        name: provider.name,
-      })
-      .catch((err: unknown) => console.error('Unable to track', err));
+    this.telemetryService.track('updateProvider', {
+      name: provider.name,
+    });
     return providerUpdate.update(new LoggerImpl());
   }
 
@@ -473,21 +467,17 @@ export class ProviderRegistry {
     }
 
     if (provider?.containerProviderConnectionFactory?.initialize) {
-      this.telemetryService
-        .track('initializeProvider', {
-          name: provider.name,
-        })
-        .catch((err: unknown) => console.error('Unable to track', err));
+      this.telemetryService.track('initializeProvider', {
+        name: provider.name,
+      });
 
       return provider.containerProviderConnectionFactory.initialize();
     }
 
     if (provider?.kubernetesProviderConnectionFactory?.initialize) {
-      this.telemetryService
-        .track('initializeProvider', {
-          name: provider.name,
-        })
-        .catch((err: unknown) => console.error('Unable to track', err));
+      this.telemetryService.track('initializeProvider', {
+        name: provider.name,
+      });
 
       return provider.kubernetesProviderConnectionFactory.initialize();
     }
@@ -722,7 +712,7 @@ export class ProviderRegistry {
       telemetryData.error = err;
       throw err;
     } finally {
-      await this.telemetryService.track('createProviderConnection', telemetryData);
+      this.telemetryService.track('createProviderConnection', telemetryData);
     }
   }
 
@@ -931,9 +921,7 @@ export class ProviderRegistry {
     if (!lifecycle?.delete) {
       throw new Error('The container connection does not support delete lifecycle');
     }
-    this.telemetryService
-      .track('deleteProviderConnection', { name: providerConnectionInfo.name })
-      .catch((err: unknown) => console.error('Unable to track', err));
+    this.telemetryService.track('deleteProviderConnection', { name: providerConnectionInfo.name });
     return lifecycle.delete(logHandler);
   }
 
@@ -1031,12 +1019,10 @@ export class ProviderRegistry {
     const providerName = kubernetesProviderConnection.name;
     const id = `${provider.id}.${providerName}`;
     this.kubernetesProviders.set(id, kubernetesProviderConnection);
-    this.telemetryService
-      .track('registerKubernetesProviderConnection', {
-        name: kubernetesProviderConnection.name,
-        total: this.kubernetesProviders.size,
-      })
-      .catch((err: unknown) => console.error('Unable to track', err));
+    this.telemetryService.track('registerKubernetesProviderConnection', {
+      name: kubernetesProviderConnection.name,
+      total: this.kubernetesProviders.size,
+    });
 
     let previousStatus = kubernetesProviderConnection.status();
 

--- a/packages/main/src/plugin/telemetry/telemetry.ts
+++ b/packages/main/src/plugin/telemetry/telemetry.ts
@@ -161,17 +161,13 @@ export class Telemetry {
     return {
       // prefix with extension id the event
       sendEventData(eventName: string, data?: Record<string, unknown>): void {
-        thisArg.track.apply(thisArg, [`${extensionInfo.id}.${eventName}`, data]).catch((err: unknown) => {
-          console.log(`Error sending event ${eventName}: ${err}`);
-        });
+        thisArg.track.apply(thisArg, [`${extensionInfo.id}.${eventName}`, data]);
       },
       // report using the id of the extension suffixed by error
       sendErrorData(error: Error, data?: Record<string, unknown>): void {
         data = data || {};
         data.sourceError = error.message;
-        thisArg.track.apply(thisArg, [`${extensionInfo.id}.error`, data]).catch((err: unknown) => {
-          console.log(`Error sending error event: ${err}`);
-        });
+        thisArg.track.apply(thisArg, [`${extensionInfo.id}.error`, data]);
       },
       async flush(): Promise<void> {
         await instanceFlush?.();
@@ -296,7 +292,7 @@ export class Telemetry {
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  async track(event: EventType, eventProperties?: any): Promise<void> {
+  track(event: EventType, eventProperties?: any): void {
     // skip event ?
     if (this.shouldDropEvent(event)) {
       return;
@@ -308,7 +304,7 @@ export class Telemetry {
     if (!this.telemetryEnabled) {
       return;
     }
-    this.internalTrack(event, eventProperties).catch((err: unknown) => {
+    void this.internalTrack(event, eventProperties).catch((err: unknown) => {
       console.log(`Error sending event: ${event}`, err);
     });
   }

--- a/packages/main/src/plugin/telemetry/telemetry.ts
+++ b/packages/main/src/plugin/telemetry/telemetry.ts
@@ -304,7 +304,7 @@ export class Telemetry {
     if (!this.telemetryEnabled) {
       return;
     }
-    void this.internalTrack(event, eventProperties).catch((err: unknown) => {
+    this.internalTrack(event, eventProperties).catch((err: unknown) => {
       console.log(`Error sending event: ${event}`, err);
     });
   }

--- a/packages/main/src/plugin/tray-menu-registry.ts
+++ b/packages/main/src/plugin/tray-menu-registry.ts
@@ -83,9 +83,7 @@ export class TrayMenuRegistry {
     });
 
     ipcMain.on('tray:menu-provider-click', (_, param: { action: string; providerInfo: ProviderInfo }) => {
-      this.telemetryService
-        .track('tray:menu-provider-click', { action: param.action, name: param.providerInfo.name })
-        .catch((err: unknown) => console.error('Unable to track', err));
+      this.telemetryService.track('tray:menu-provider-click', { action: param.action, name: param.providerInfo.name });
       const provider = this.providers.get(param.providerInfo.internalId);
       if (provider) {
         if (param.action === 'Start') {
@@ -110,12 +108,10 @@ export class TrayMenuRegistry {
           providerContainerConnectionInfo: ProviderContainerConnectionInfo;
         },
       ) => {
-        this.telemetryService
-          .track('tray:menu-provider-container-connection-click', {
-            action: param.action,
-            name: param.providerContainerConnectionInfo.name,
-          })
-          .catch((err: unknown) => console.error('Unable to track', err));
+        this.telemetryService.track('tray:menu-provider-container-connection-click', {
+          action: param.action,
+          name: param.providerContainerConnectionInfo.name,
+        });
 
         const provider = this.providers.get(param.providerInfo.internalId);
         if (provider) {


### PR DESCRIPTION
### What does this PR do?

* removes .catch() call folovint trace() call because it is already intersepted after this.internalTrack() call and never happens in clients that calls track() method
* ignores promise returned from this.internalTrack and marks track method as returning void. That gets rid of mistakes like waiting for promise returned form track() to resolve and also makes linter happy when track called without following catch() call
* formats code after catch() call is removed

### Screenshot/screencast of this PR

n/a

### What issues does this PR fix or reference?

n/a

### How to test this PR?

n/a