### PR TITLE
chore(tests): added coverage for image deletion and renamed image e2e test file

### DIFF
--- a/tests/src/image-smoke.spec.ts
+++ b/tests/src/image-smoke.spec.ts
@@ -24,6 +24,7 @@ import { PodmanDesktopRunner } from './runner/podman-desktop-runner';
 import { WelcomePage } from './model/pages/welcome-page';
 import { ImagesPage } from './model/pages/images-page';
 import { NavigationBar } from './model/workbench/navigation';
+import { ImageDetailsPage } from './model/pages/image-details-page';
 
 let pdRunner: PodmanDesktopRunner;
 let page: Page;
@@ -49,6 +50,8 @@ describe('Image pull verification', async () => {
   test('Pull image', async () => {
     const navBar = new NavigationBar(page);
     const imagesPage = await navBar.openImages();
+    await playExpect(imagesPage.heading).toBeVisible();
+
     const pullImagePage = await imagesPage.openPullImage();
     const updatedImages = await pullImagePage.pullImage('quay.io/podman/hello');
 
@@ -63,5 +66,22 @@ describe('Image pull verification', async () => {
     await playExpect(imageDetailPage.summaryTab).toBeVisible();
     await playExpect(imageDetailPage.historyTab).toBeVisible();
     await playExpect(imageDetailPage.inspectTab).toBeVisible();
+  });
+});
+
+describe('Image delete verification', async () => {
+  test('Delete image from image details', async () => {
+    const imageDetailPage = new ImageDetailsPage(page, 'quay.io/podman/hello');
+
+    await playExpect(imageDetailPage.deleteButton).toBeVisible();
+    await imageDetailPage.deleteButton.click();
+  });
+
+  test('Verify image was deleted', async () => {
+    const imagesPage = new ImagesPage(page);
+    await playExpect(imagesPage.heading).toBeVisible();
+
+    const imageExists = await imagesPage.imageExists('quay.io/podman/hello');
+    playExpect(imageExists).toBeFalsy();
   });
 });

--- a/tests/src/image-smoke.spec.ts
+++ b/tests/src/image-smoke.spec.ts
@@ -46,7 +46,7 @@ beforeEach<RunnerTestContext>(async ctx => {
   ctx.pdRunner = pdRunner;
 });
 
-describe('Image pull verification', async () => {
+describe('Image workflow verification', async () => {
   test('Pull image', async () => {
     const navBar = new NavigationBar(page);
     const imagesPage = await navBar.openImages();
@@ -67,21 +67,16 @@ describe('Image pull verification', async () => {
     await playExpect(imageDetailPage.historyTab).toBeVisible();
     await playExpect(imageDetailPage.inspectTab).toBeVisible();
   });
-});
 
-describe('Image delete verification', async () => {
-  test('Delete image from image details', async () => {
+  test('Delete image', async () => {
     const imageDetailPage = new ImageDetailsPage(page, 'quay.io/podman/hello');
-
     await playExpect(imageDetailPage.deleteButton).toBeVisible();
     await imageDetailPage.deleteButton.click();
-  });
 
-  test('Verify image was deleted', async () => {
     const imagesPage = new ImagesPage(page);
     await playExpect(imagesPage.heading).toBeVisible();
 
-    const imageExists = await imagesPage.imageExists('quay.io/podman/hello');
-    playExpect(imageExists).toBeFalsy();
+    const imageExists = await imagesPage.waitForImageDelete('quay.io/podman/hello');
+    playExpect(imageExists).toBeTruthy();
   });
 });

--- a/tests/src/model/pages/images-page.ts
+++ b/tests/src/model/pages/images-page.ts
@@ -30,7 +30,7 @@ export class ImagesPage extends PodmanDesktopPage {
 
   constructor(page: Page) {
     super(page);
-    this.heading = page.getByRole('heading', { name: 'Images', exact: true });
+    this.heading = page.getByRole('heading', { name: 'images', exact: true });
     this.pullImageButton = page.getByRole('button', { name: 'Pull an image' });
     this.pruneImagesButton = page.getByRole('button', { name: 'Prune images' });
     this.buildImageButton = page.getByRole('button', { name: 'Build an image' });
@@ -89,7 +89,7 @@ export class ImagesPage extends PodmanDesktopPage {
     }
   }
 
-  protected async imageExists(name: string): Promise<boolean> {
+  async imageExists(name: string): Promise<boolean> {
     const result = await this.getImageRowByName(name);
     return result !== undefined;
   }

--- a/tests/src/model/pages/images-page.ts
+++ b/tests/src/model/pages/images-page.ts
@@ -20,7 +20,7 @@ import type { Locator, Page } from 'playwright';
 import { PodmanDesktopPage } from './base-page';
 import { ImageDetailsPage } from './image-details-page';
 import { PullImagePage } from './pull-image-page';
-import { waitUntil } from '../../utility/wait';
+import { waitUntil, waitWhile } from '../../utility/wait';
 
 export class ImagesPage extends PodmanDesktopPage {
   readonly heading: Locator;
@@ -89,13 +89,18 @@ export class ImagesPage extends PodmanDesktopPage {
     }
   }
 
-  async imageExists(name: string): Promise<boolean> {
+  protected async imageExists(name: string): Promise<boolean> {
     const result = await this.getImageRowByName(name);
     return result !== undefined;
   }
 
   async waitForImageExists(name: string): Promise<boolean> {
     await waitUntil(async () => await this.imageExists(name), 3000, 900);
+    return true;
+  }
+
+  async waitForImageDelete(name: string): Promise<boolean> {
+    await waitWhile(async () => await this.imageExists(name), 3000, 900);
     return true;
   }
 }


### PR DESCRIPTION
### What does this PR do?
Implements test cases for deleting image. Renames the pull-image-smoke.spec.ts to image-smoke.spec.ts.

### Screenshot/screencast of this PR

### What issues does this PR fix or reference?
https://github.com/containers/podman-desktop/issues/3552

### How to test this PR?
yarn test:e2e:smoke
