### PR TITLE
fix: remove steps from top header in onboarding (#3674)

### DIFF
--- a/extensions/podman/package.json
+++ b/extensions/podman/package.json
@@ -120,7 +120,6 @@
       "steps": [
         {
           "id": "checkPodmanInstalled",
-          "label": "Check Podman",
           "title": "Checking for Podman installation",
           "command": "podman.onboarding.checkPodmanInstalled",
           "completionEvents": [
@@ -129,13 +128,11 @@
         },
         {
           "id": "startPodmanInstallation",
-          "label": "Start Setup",
           "title": "We could not find Podman. Let's install it!",
           "when": "onboardingContext:podmanIsNotInstalled == true"
         },
         {
           "id": "checkPodmanRequirements",
-          "label": "Check System",
           "title": "Checking for system requirements to install Podman",
           "when": "onboardingContext:podmanIsNotInstalled == true",
           "command": "podman.onboarding.checkPodmanRequirements",
@@ -145,7 +142,6 @@
         },
         {
           "id": "missingRequirementView",
-          "label": "Fix System",
           "title": "Some system requirements are missing",
           "when": "onboardingContext:requirementsStatus == failed && onboardingContext:podmanIsNotInstalled == true",
           "completionEvents": [
@@ -174,7 +170,6 @@
         },
         {
           "id": "installPodmanView",
-          "label": "Install Podman",
           "title": "Installing Podman",
           "description": "Once installed, we will enable and configure the extension",
           "when": "onboardingContext:podmanIsNotInstalled == true",
@@ -185,15 +180,15 @@
         },
         {
           "id": "podmanFailedInstallation",
-          "label": "Done",
           "title": "Failed installing Podman",
-          "when": "onboardingContext:podmanIsNotInstalled == true"
+          "when": "onboardingContext:podmanIsNotInstalled == true",
+          "state": "failed"
         },
         {
           "id": "podmanInstalled",
-          "label": "Done",
           "title": "Podman successfully installed",
-          "when": "onboardingContext:podmanIsNotInstalled == false"
+          "when": "onboardingContext:podmanIsNotInstalled == false",
+          "state": "succeeded"
         }
       ]
     }

--- a/packages/main/src/plugin/api/onboarding.ts
+++ b/packages/main/src/plugin/api/onboarding.ts
@@ -41,10 +41,10 @@ export interface OnboardingStepTextItem extends OnboardingBaseItem {
 export type OnboardingStepItem = OnboardingStepTextItem | OnboardingStepButtonItem;
 
 export type OnboardingStatus = 'completed' | 'failed' | 'skipped';
+export type OnboardingState = 'completed' | 'failed';
 
 export interface OnboardingStep {
   id: string;
-  label: string;
   title: string;
   description?: string;
   media?: { path: string; altText: string };
@@ -55,6 +55,7 @@ export interface OnboardingStep {
   when?: string;
   status?: OnboardingStatus;
   showNext?: boolean;
+  state?: OnboardingState;
 }
 
 export interface Onboarding {


### PR DESCRIPTION
### What does this PR do?

This PR removes the steps from the top header (the current implementation only works with a single extension workflow, i'll re-add them in another PR when i'll work on supporting multiple onboardings in sequence).

It also adds a new property `state` to tell PD which is the default state of a step so we can show the `try again` button (in next PR) or consider the workflow completed.

### Screenshot/screencast of this PR

![onboarding_no_steps](https://github.com/containers/podman-desktop/assets/49404737/91737e3c-f4e4-450d-8260-172cce4e79ad)

### What issues does this PR fix or reference?

it resolves #3674

### How to test this PR?

1. the behavior is the same as before. The only difference is that there are no steps in the header. Just launch the podman onboarding.
