### PR TITLE
chore(tests): include stopping and deleting a container e2e test

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -232,6 +232,14 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18
+      
+      - name: Update podman
+        run: |
+          sudo sh -c "echo 'deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_22.04/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:unstable.list"
+          curl -L https://build.opensuse.org/projects/devel:kubic:libcontainers:unstable/signing_keys/download?kind=gpg | sudo apt-key add -
+          sudo apt-get update -qq
+          sudo apt-get install -y podman
+          podman version
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path

--- a/tests/src/container-smoke.spec.ts
+++ b/tests/src/container-smoke.spec.ts
@@ -30,7 +30,7 @@ import type { ImagesPage } from './model/pages/images-page';
 
 let pdRunner: PodmanDesktopRunner;
 let page: Page;
-const imageToPull = 'docker.io/library/alpine';
+const imageToPull = 'ghcr.io/linuxcontainers/alpine';
 const imageTag = 'latest';
 const containerToRun = 'alpine-container';
 

--- a/tests/src/container-smoke.spec.ts
+++ b/tests/src/container-smoke.spec.ts
@@ -45,8 +45,8 @@ beforeAll(async () => {
   try {
     images = await new NavigationBar(page).openImages();
   } catch (error) {
-    console.log(`TimeError when opening images, taking a screenshot`);
-    await pdRunner.screenshot('timeerror-openImages.png');
+    await pdRunner.screenshot('error-on-open-images.png');
+    throw error;
   }
   await waitWhile(
     async () => await images.pageIsEmpty(),
@@ -58,8 +58,8 @@ beforeAll(async () => {
   try {
     await deleteContainer(page, containerToRun);
   } catch (error) {
-    console.log(`Error opening Containers Page...`);
     await pdRunner.screenshot('error-on-open-containers.png');
+    throw error;
   }
 });
 

--- a/tests/src/model/pages/containers-page.ts
+++ b/tests/src/model/pages/containers-page.ts
@@ -70,11 +70,17 @@ export class ContainersPage extends PodmanDesktopPage {
     const rows = await containersTable.getByRole('row').all();
     for (const row of rows) {
       // test on empty row - contains on 0th position &nbsp; character (ISO 8859-1 character set: 160)
-      const zeroCell = await row.getByRole('cell').nth(0).innerText();
+      const zeroCell = await row.getByRole('cell').nth(0).innerText({ timeout: 500 });
       if (zeroCell.indexOf(String.fromCharCode(160)) === 0) {
         continue;
       }
-      const thirdCell = await row.getByRole('cell').nth(3).innerText();
+      let thirdCell = undefined;
+      try {
+        thirdCell = await row.getByRole('cell').nth(3).innerText({ timeout: 1000 });
+      } catch (error) {
+        thirdCell = await row.getByRole('cell').nth(3).allInnerTexts();
+        console.log(`We got an timeout error on innertext, allinnerTexts: ${thirdCell}`);
+      }
       const index = thirdCell.indexOf(name);
       if (index >= 0) {
         return row;

--- a/tests/src/model/pages/run-image-page.ts
+++ b/tests/src/model/pages/run-image-page.ts
@@ -58,6 +58,7 @@ export class RunImagePage extends PodmanDesktopPage {
       await containers.heading.waitFor({ state: 'visible', timeout: 3000 });
     } catch (error) {
       console.log(`Containers Page seems not to be visible`);
+      // consume the error
     }
     return containers;
   }

--- a/tests/src/model/pages/welcome-page.ts
+++ b/tests/src/model/pages/welcome-page.ts
@@ -53,7 +53,7 @@ export class WelcomePage extends PodmanDesktopPage {
     await this.waitForInitialization();
     if (skipIfNotPresent) {
       try {
-        await this.goToPodmanDesktopButton.waitFor({ state: 'visible', timeout: 1000 });
+        await this.goToPodmanDesktopButton.waitFor({ state: 'visible', timeout: 5000 });
       } catch (err) {
         if ((err as Error).name !== 'TimeoutError') {
           throw err;

--- a/tests/src/model/workbench/navigation.ts
+++ b/tests/src/model/workbench/navigation.ts
@@ -24,12 +24,14 @@ export class NavigationBar {
   }
 
   async openImages(): Promise<ImagesPage> {
-    await this.imagesLink.click();
+    await this.imagesLink.waitFor({ state: 'visible', timeout: 3000 });
+    await this.imagesLink.click({ timeout: 5000 });
     return new ImagesPage(this.page);
   }
 
   async openContainers(): Promise<ContainersPage> {
-    await this.containersLink.click();
+    await this.containersLink.waitFor({ state: 'visible', timeout: 3000 });
+    await this.containersLink.click({ timeout: 5000 });
     return new ContainersPage(this.page);
   }
 }

--- a/tests/src/setupFiles/extended-hooks.ts
+++ b/tests/src/setupFiles/extended-hooks.ts
@@ -1,9 +1,27 @@
-import type { PDRunnerTestContext } from 'vitest';
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { RunnerTestContext } from '../testContext/runner-test-context';
 import { afterEach } from 'vitest';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
-afterEach(async (context: PDRunnerTestContext) => {
+afterEach(async (context: RunnerTestContext) => {
   context.onTestFailed(async () => {
     const normalizedFilePath = context.task.name
       .replace(/'/g, '')


### PR DESCRIPTION
### What does this PR do?
Update podman version which could be a reason for a container e2e tests instability.
### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast 
explaining what is doing this PR -->
Updates podman on GHA linux runner and includes stopping and deleting a container scenario.
### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop 
repository (or from another issue tracker). -->
#3434 
### How to test this PR?
`yarn test:e2e:smoke`
<!-- Please explain steps to reproduce -->
