### PR TITLE
feat: add setup buttons in resource page (#3676)

### DIFF
--- a/packages/main/src/plugin/api/provider-info.ts
+++ b/packages/main/src/plugin/api/provider-info.ts
@@ -50,6 +50,7 @@ export interface ProviderKubernetesConnectionInfo {
 export interface ProviderInfo {
   internalId: string;
   id: string;
+  extension: string;
   name: string;
   containerConnections: ProviderContainerConnectionInfo[];
   kubernetesConnections: ProviderKubernetesConnectionInfo[];

--- a/packages/main/src/plugin/api/provider-info.ts
+++ b/packages/main/src/plugin/api/provider-info.ts
@@ -50,7 +50,7 @@ export interface ProviderKubernetesConnectionInfo {
 export interface ProviderInfo {
   internalId: string;
   id: string;
-  extension: string;
+  extensionId: string;
   name: string;
   containerConnections: ProviderContainerConnectionInfo[];
   kubernetesConnections: ProviderKubernetesConnectionInfo[];

--- a/packages/main/src/plugin/api/provider-info.ts
+++ b/packages/main/src/plugin/api/provider-info.ts
@@ -50,7 +50,7 @@ export interface ProviderKubernetesConnectionInfo {
 export interface ProviderInfo {
   internalId: string;
   id: string;
-  extensionId: string;
+  readonly extensionId: string;
   name: string;
   containerConnections: ProviderContainerConnectionInfo[];
   kubernetesConnections: ProviderKubernetesConnectionInfo[];

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -625,7 +625,7 @@ export class ExtensionLoader {
           images.icon = instance.updateImage(images.icon, extensionPath);
           images.logo = instance.updateImage(images.logo, extensionPath);
         }
-        return providerRegistry.createProvider(providerOptions);
+        return providerRegistry.createProvider(extensionInfo.id, providerOptions);
       },
       onDidUpdateProvider: (listener, thisArg, disposables) => {
         return providerRegistry.onDidUpdateProvider(listener, thisArg, disposables);

--- a/packages/main/src/plugin/provider-impl.ts
+++ b/packages/main/src/plugin/provider-impl.ts
@@ -75,6 +75,7 @@ export class ProviderImpl implements Provider, IDisposable {
 
   constructor(
     private _internalId: string,
+    private _extension: string,
     private providerOptions: ProviderOptions,
     private providerRegistry: ProviderRegistry,
     private containerRegistry: ContainerProviderRegistry,
@@ -173,6 +174,10 @@ export class ProviderImpl implements Provider, IDisposable {
 
   get internalId(): string {
     return this._internalId;
+  }
+
+  get extension(): string {
+    return this._extension;
   }
 
   get id(): string {

--- a/packages/main/src/plugin/provider-impl.ts
+++ b/packages/main/src/plugin/provider-impl.ts
@@ -75,7 +75,7 @@ export class ProviderImpl implements Provider, IDisposable {
 
   constructor(
     private _internalId: string,
-    readonly extension: string,
+    readonly extensionId: string,
     private providerOptions: ProviderOptions,
     private providerRegistry: ProviderRegistry,
     private containerRegistry: ContainerProviderRegistry,

--- a/packages/main/src/plugin/provider-impl.ts
+++ b/packages/main/src/plugin/provider-impl.ts
@@ -75,7 +75,7 @@ export class ProviderImpl implements Provider, IDisposable {
 
   constructor(
     private _internalId: string,
-    private _extension: string,
+    readonly extension: string,
     private providerOptions: ProviderOptions,
     private providerRegistry: ProviderRegistry,
     private containerRegistry: ContainerProviderRegistry,
@@ -174,10 +174,6 @@ export class ProviderImpl implements Provider, IDisposable {
 
   get internalId(): string {
     return this._internalId;
-  }
-
-  get extension(): string {
-    return this._extension;
   }
 
   get id(): string {

--- a/packages/main/src/plugin/provider-registry.spec.ts
+++ b/packages/main/src/plugin/provider-registry.spec.ts
@@ -57,7 +57,7 @@ test('should initialize provider if there is kubernetes connection provider', as
     providerInternalId = data;
   });
 
-  const provider = providerRegistry.createProvider({ id: 'internal', name: 'internal', status: 'installed' });
+  const provider = providerRegistry.createProvider('id', { id: 'internal', name: 'internal', status: 'installed' });
 
   let initalizeCalled = false;
   provider.setKubernetesProviderConnectionFactory({
@@ -90,7 +90,7 @@ test('should send version event if update', async () => {
     }
   });
 
-  const provider = providerRegistry.createProvider({ id: 'internal', name: 'internal', status: 'installed' });
+  const provider = providerRegistry.createProvider('id', { id: 'internal', name: 'internal', status: 'installed' });
 
   let updateCalled = false;
   provider.registerUpdate({
@@ -122,7 +122,7 @@ test('should initialize provider if there is container connection provider', asy
     providerInternalId = data;
   });
 
-  const provider = providerRegistry.createProvider({ id: 'internal', name: 'internal', status: 'installed' });
+  const provider = providerRegistry.createProvider('id', { id: 'internal', name: 'internal', status: 'installed' });
 
   let initalizeCalled = false;
   provider.setContainerProviderConnectionFactory({
@@ -199,7 +199,7 @@ test('expect isProviderContainerConnection returns false with a ProviderKubernet
 });
 
 test('should register kubernetes provider', async () => {
-  const provider = providerRegistry.createProvider({ id: 'internal', name: 'internal', status: 'installed' });
+  const provider = providerRegistry.createProvider('id', { id: 'internal', name: 'internal', status: 'installed' });
   const connection: KubernetesProviderConnection = {
     name: 'connection',
     endpoint: {
@@ -218,7 +218,7 @@ test('should register kubernetes provider', async () => {
 });
 
 test('should send events when starting a container connection', async () => {
-  const provider = providerRegistry.createProvider({ id: 'internal', name: 'internal', status: 'installed' });
+  const provider = providerRegistry.createProvider('id', { id: 'internal', name: 'internal', status: 'installed' });
   const connection: ProviderContainerConnectionInfo = {
     name: 'connection',
     type: 'docker',
@@ -261,7 +261,7 @@ test('should send events when starting a container connection', async () => {
 });
 
 test('should send events when stopping a container connection', async () => {
-  const provider = providerRegistry.createProvider({ id: 'internal', name: 'internal', status: 'installed' });
+  const provider = providerRegistry.createProvider('id', { id: 'internal', name: 'internal', status: 'installed' });
   const connection: ProviderContainerConnectionInfo = {
     name: 'connection',
     type: 'docker',
@@ -304,7 +304,7 @@ test('should send events when stopping a container connection', async () => {
 });
 
 test('runAutostartContainer should start container and send event', async () => {
-  const provider = providerRegistry.createProvider({ id: 'internal', name: 'internal', status: 'installed' });
+  const provider = providerRegistry.createProvider('id', { id: 'internal', name: 'internal', status: 'installed' });
 
   const autostartMock = vi.fn();
 
@@ -329,7 +329,7 @@ test('runAutostartContainer should start container and send event', async () => 
 });
 
 test('should retrieve context of container provider', async () => {
-  const provider = providerRegistry.createProvider({ id: 'internal', name: 'internal', status: 'installed' });
+  const provider = providerRegistry.createProvider('id', { id: 'internal', name: 'internal', status: 'installed' });
   const connection: ProviderContainerConnectionInfo = {
     name: 'connection',
     type: 'docker',
@@ -368,7 +368,7 @@ test('should retrieve context of kubernetes provider', async () => {
     providerInternalId = data;
   });
 
-  const provider = providerRegistry.createProvider({ id: 'internal', name: 'internal', status: 'installed' });
+  const provider = providerRegistry.createProvider('id', { id: 'internal', name: 'internal', status: 'installed' });
 
   let initalizeCalled = false;
   provider.setKubernetesProviderConnectionFactory({
@@ -412,7 +412,7 @@ test('should retrieve context of kubernetes provider', async () => {
 });
 
 test('should retrieve provider internal id from id', async () => {
-  const provider = providerRegistry.createProvider({ id: 'internal', name: 'internal', status: 'installed' });
+  const provider = providerRegistry.createProvider('id', { id: 'internal', name: 'internal', status: 'installed' });
 
   const startMock = vi.fn();
   const stopMock = vi.fn();

--- a/packages/main/src/plugin/provider-registry.ts
+++ b/packages/main/src/plugin/provider-registry.ts
@@ -582,7 +582,7 @@ export class ProviderRegistry {
     const providerInfo: ProviderInfo = {
       id: provider.id,
       internalId: provider.internalId,
-      extension: provider.extension,
+      extensionId: provider.extensionId,
       name: provider.name,
       containerConnections,
       kubernetesConnections,

--- a/packages/main/src/plugin/provider-registry.ts
+++ b/packages/main/src/plugin/provider-registry.ts
@@ -167,9 +167,9 @@ export class ProviderRegistry {
     }, 2000);
   }
 
-  createProvider(providerOptions: ProviderOptions): Provider {
+  createProvider(extensionId: string, providerOptions: ProviderOptions): Provider {
     const id = `${this.count}`;
-    const providerImpl = new ProviderImpl(id, providerOptions, this, this.containerRegistry);
+    const providerImpl = new ProviderImpl(id, extensionId, providerOptions, this, this.containerRegistry);
     this.count++;
     this.providers.set(id, providerImpl);
     this.listeners.forEach(listener => listener('provider:create', this.getProviderInfo(providerImpl)));
@@ -582,6 +582,7 @@ export class ProviderRegistry {
     const providerInfo: ProviderInfo = {
       id: provider.id,
       internalId: provider.internalId,
+      extension: provider.extension,
       name: provider.name,
       containerConnections,
       kubernetesConnections,

--- a/packages/main/src/tray-menu.ts
+++ b/packages/main/src/tray-menu.ts
@@ -84,6 +84,7 @@ export class TrayMenu {
             kubernetesProviderConnectionCreation: false,
             containerProviderConnectionInitialization: false,
             kubernetesProviderConnectionInitialization: false,
+            extension: '',
           });
         }
         this.updateMenu();

--- a/packages/main/src/tray-menu.ts
+++ b/packages/main/src/tray-menu.ts
@@ -84,7 +84,7 @@ export class TrayMenu {
             kubernetesProviderConnectionCreation: false,
             containerProviderConnectionInitialization: false,
             kubernetesProviderConnectionInitialization: false,
-            extension: '',
+            extensionId: '',
           });
         }
         this.updateMenu();

--- a/packages/renderer/src/lib/dashboard/ProviderInstalled.spec.ts
+++ b/packages/renderer/src/lib/dashboard/ProviderInstalled.spec.ts
@@ -63,7 +63,7 @@ test('Expect installed provider shows button', async () => {
     name: 'MyProvider',
     status: 'installed',
     warnings: [],
-    extension: '',
+    extensionId: '',
   };
 
   const initializationContext: InitializationContext = { mode: InitializeAndStartMode };

--- a/packages/renderer/src/lib/dashboard/ProviderInstalled.spec.ts
+++ b/packages/renderer/src/lib/dashboard/ProviderInstalled.spec.ts
@@ -23,7 +23,7 @@ import { beforeAll, test, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/svelte';
 import ProviderInstalled from '/@/lib/dashboard/ProviderInstalled.svelte';
 import type { ProviderInfo } from '../../../../main/src/plugin/api/provider-info';
-import { InitializeAndStartMode } from '/@/lib/dashboard/ProviderInitUtils';
+import { InitializeAndStartMode, type InitializationContext } from '/@/lib/dashboard/ProviderInitUtils';
 import userEvent from '@testing-library/user-event';
 import { verifyStatus } from './ProviderStatusTestHelper.spec';
 
@@ -63,9 +63,10 @@ test('Expect installed provider shows button', async () => {
     name: 'MyProvider',
     status: 'installed',
     warnings: [],
+    extension: '',
   };
 
-  const initializationContext = { mode: InitializeAndStartMode };
+  const initializationContext: InitializationContext = { mode: InitializeAndStartMode };
   render(ProviderInstalled, { provider: provider, initializationContext: initializationContext });
 
   const providerText = screen.getByText(

--- a/packages/renderer/src/lib/dashboard/ProviderStatusTestHelper.spec.ts
+++ b/packages/renderer/src/lib/dashboard/ProviderStatusTestHelper.spec.ts
@@ -55,7 +55,7 @@ export function verifyStatus<C extends SvelteComponent>(
     updateInfo: {
       version: sameVersions ? '1.0.0' : '1.0.1',
     },
-    extension: '',
+    extensionId: '',
   };
 
   const initializationContext = { mode: InitializeAndStartMode };

--- a/packages/renderer/src/lib/dashboard/ProviderStatusTestHelper.spec.ts
+++ b/packages/renderer/src/lib/dashboard/ProviderStatusTestHelper.spec.ts
@@ -55,6 +55,7 @@ export function verifyStatus<C extends SvelteComponent>(
     updateInfo: {
       version: sameVersions ? '1.0.0' : '1.0.1',
     },
+    extension: '',
   };
 
   const initializationContext = { mode: InitializeAndStartMode };

--- a/packages/renderer/src/lib/pod/PodCreateFromContainers.spec.ts
+++ b/packages/renderer/src/lib/pod/PodCreateFromContainers.spec.ts
@@ -54,7 +54,7 @@ const providerInfo: ProviderInfo = {
   containerProviderConnectionInitialization: false,
   containerProviderConnectionCreationDisplayName: 'Podman machine',
   kubernetesProviderConnectionInitialization: false,
-  extension: '',
+  extensionId: '',
 };
 
 const podCreation: PodCreation = {

--- a/packages/renderer/src/lib/pod/PodCreateFromContainers.spec.ts
+++ b/packages/renderer/src/lib/pod/PodCreateFromContainers.spec.ts
@@ -54,6 +54,7 @@ const providerInfo: ProviderInfo = {
   containerProviderConnectionInitialization: false,
   containerProviderConnectionCreationDisplayName: 'Podman machine',
   kubernetesProviderConnectionInitialization: false,
+  extension: '',
 };
 
 const podCreation: PodCreation = {

--- a/packages/renderer/src/lib/pod/PodsList.spec.ts
+++ b/packages/renderer/src/lib/pod/PodsList.spec.ts
@@ -55,7 +55,7 @@ const provider: ProviderInfo = {
   name: 'MyProvider',
   status: 'started',
   warnings: [],
-  extension: '',
+  extensionId: '',
 };
 
 const pod1: PodInfo = {

--- a/packages/renderer/src/lib/pod/PodsList.spec.ts
+++ b/packages/renderer/src/lib/pod/PodsList.spec.ts
@@ -55,6 +55,7 @@ const provider: ProviderInfo = {
   name: 'MyProvider',
   status: 'started',
   warnings: [],
+  extension: '',
 };
 
 const pod1: PodInfo = {

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionActions.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionActions.spec.ts
@@ -46,7 +46,7 @@ const containerProviderInfo: ProviderInfo = {
   links: [],
   containerProviderConnectionInitialization: false,
   kubernetesProviderConnectionInitialization: false,
-  extension: '',
+  extensionId: '',
 };
 
 const containerConnection: ProviderContainerConnectionInfo = {

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionActions.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionActions.spec.ts
@@ -46,6 +46,7 @@ const containerProviderInfo: ProviderInfo = {
   links: [],
   containerProviderConnectionInitialization: false,
   kubernetesProviderConnectionInitialization: false,
+  extension: '',
 };
 
 const containerConnection: ProviderContainerConnectionInfo = {

--- a/packages/renderer/src/lib/preferences/PreferencesContainerConnectionRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesContainerConnectionRendering.spec.ts
@@ -81,7 +81,7 @@ test('Expect that the right machine is displayed', async () => {
     containerProviderConnectionInitialization: false,
     containerProviderConnectionCreationDisplayName: 'Podman machine',
     kubernetesProviderConnectionInitialization: false,
-    extension: '',
+    extensionId: '',
   };
 
   // 3 connections with the same socket path
@@ -159,7 +159,7 @@ test('Expect that removing the connection is going back to the previous page', a
     containerProviderConnectionInitialization: false,
     containerProviderConnectionCreationDisplayName: 'Podman machine',
     kubernetesProviderConnectionInitialization: false,
-    extension: '',
+    extensionId: '',
   };
 
   // 3 connections with the same socket path

--- a/packages/renderer/src/lib/preferences/PreferencesContainerConnectionRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesContainerConnectionRendering.spec.ts
@@ -81,6 +81,7 @@ test('Expect that the right machine is displayed', async () => {
     containerProviderConnectionInitialization: false,
     containerProviderConnectionCreationDisplayName: 'Podman machine',
     kubernetesProviderConnectionInitialization: false,
+    extension: '',
   };
 
   // 3 connections with the same socket path
@@ -158,6 +159,7 @@ test('Expect that removing the connection is going back to the previous page', a
     containerProviderConnectionInitialization: false,
     containerProviderConnectionCreationDisplayName: 'Podman machine',
     kubernetesProviderConnectionInitialization: false,
+    extension: '',
   };
 
   // 3 connections with the same socket path

--- a/packages/renderer/src/lib/preferences/PreferencesExtensionRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesExtensionRendering.svelte
@@ -6,7 +6,6 @@ import SettingsPage from './SettingsPage.svelte';
 import ExtensionStatus from '../ui/ExtensionStatus.svelte';
 import Button from '../ui/Button.svelte';
 import { faPlay, faPuzzlePiece, faStop, faTrash } from '@fortawesome/free-solid-svg-icons';
-import { router } from 'tinro';
 import EmptyScreen from '../ui/EmptyScreen.svelte';
 
 export let extensionId: string | undefined = undefined;
@@ -14,8 +13,6 @@ export let extensionId: string | undefined = undefined;
 let extensionInfo: ExtensionInfo | undefined;
 
 $: extensionInfo = $extensionInfos.find(extension => extension.id === extensionId);
-$: hideOnboardingButton = true;
-$: hasOnboarding(extensionId).then(value => (hideOnboardingButton = value));
 
 async function stopExtension() {
   if (extensionInfo) {
@@ -32,14 +29,6 @@ async function removeExtension() {
     window.location.href = '#/preferences/extensions';
     await window.removeExtension(extensionInfo.id);
   }
-}
-
-async function hasOnboarding(extensionId?: string): Promise<boolean> {
-  if (!extensionId) {
-    return false;
-  }
-  const onboarding = await window.getOnboarding(extensionId);
-  return !onboarding;
 }
 </script>
 
@@ -92,11 +81,6 @@ async function hasOnboarding(extensionId?: string): Promise<boolean> {
             {/if}
           </div>
 
-          <div class="px-2 text-sm italic text-gray-700" class:hidden="{hideOnboardingButton}">
-            <Button icon="{faPlay}" on:click="{() => router.goto(`/preferences/onboarding/${extensionInfo?.id}`)}">
-              Onboarding
-            </Button>
-          </div>
           {#if extensionInfo.error}
             <div class="flex flex-col">
               <div class="py-2">Extension error: {extensionInfo.error.message}</div>

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesConnectionRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesConnectionRendering.spec.ts
@@ -83,6 +83,7 @@ test('Expect that removing the connection is going back to the previous page', a
     containerProviderConnectionInitialization: false,
     containerProviderConnectionCreationDisplayName: 'Podman machine',
     kubernetesProviderConnectionInitialization: false,
+    extension: '',
   };
 
   // 3 connections with the same socket path

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesConnectionRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesConnectionRendering.spec.ts
@@ -83,7 +83,7 @@ test('Expect that removing the connection is going back to the previous page', a
     containerProviderConnectionInitialization: false,
     containerProviderConnectionCreationDisplayName: 'Podman machine',
     kubernetesProviderConnectionInitialization: false,
-    extension: '',
+    extensionId: '',
   };
 
   // 3 connections with the same socket path

--- a/packages/renderer/src/lib/preferences/PreferencesProviderInstallationModal.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesProviderInstallationModal.spec.ts
@@ -52,6 +52,7 @@ const providerInfo: ProviderInfo = {
   containerProviderConnectionInitialization: false,
   containerProviderConnectionCreationDisplayName: 'Podman machine',
   kubernetesProviderConnectionInitialization: false,
+  extension: '',
 };
 
 const closeCallback = vi.fn();

--- a/packages/renderer/src/lib/preferences/PreferencesProviderInstallationModal.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesProviderInstallationModal.spec.ts
@@ -52,7 +52,7 @@ const providerInfo: ProviderInfo = {
   containerProviderConnectionInitialization: false,
   containerProviderConnectionCreationDisplayName: 'Podman machine',
   kubernetesProviderConnectionInitialization: false,
-  extension: '',
+  extensionId: '',
 };
 
 const closeCallback = vi.fn();

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.spec.ts
@@ -30,7 +30,7 @@ import type { OnboardingInfo } from '../../../../main/src/plugin/api/onboarding'
 const providerInfo: ProviderInfo = {
   id: 'podman',
   name: 'podman',
-  extension: 'id',
+  extensionId: 'id',
   images: {
     icon: 'img',
   },

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.spec.ts
@@ -24,10 +24,13 @@ import { providerInfos } from '../../stores/providers';
 import type { ProviderInfo } from '../../../../main/src/plugin/api/provider-info';
 import userEvent from '@testing-library/user-event';
 import { router } from 'tinro';
+import { onboardingList } from '/@/stores/onboarding';
+import type { OnboardingInfo } from '../../../../main/src/plugin/api/onboarding';
 
 const providerInfo: ProviderInfo = {
   id: 'podman',
   name: 'podman',
+  extension: 'id',
   images: {
     icon: 'img',
   },
@@ -216,4 +219,28 @@ test('Expect to directly install the provider if requirements are met', async ()
   // all requirements are met so the installProvider function is called
   expect(installPreflightMock).toBeCalled();
   expect(installProviderMock).toBeCalled();
+});
+
+test('Expect to redirect to onboarding page if setup button is clicked', async () => {
+  // clone providerInfo and change id and status
+  const customProviderInfo: ProviderInfo = { ...providerInfo };
+  // remove display name
+  customProviderInfo.containerProviderConnectionCreationDisplayName = undefined;
+  customProviderInfo.status = 'not-installed';
+  // change name of the provider
+  customProviderInfo.name = 'foo-provider';
+  providerInfos.set([customProviderInfo]);
+
+  const onboarding: OnboardingInfo = {
+    extension: 'id',
+    steps: [],
+    title: 'onboarding',
+  };
+  onboardingList.set([onboarding]);
+  render(PreferencesResourcesRendering, {});
+  const button = screen.getByRole('button', { name: 'Setup foo-provider' });
+  expect(button).toBeInTheDocument();
+  await userEvent.click(button);
+  // redirect to create new page
+  expect(router.goto).toHaveBeenCalledWith(`/preferences/onboarding/id`);
 });

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { faArrowUpRightFromSquare } from '@fortawesome/free-solid-svg-icons';
+import { faArrowUpRightFromSquare, faGear } from '@fortawesome/free-solid-svg-icons';
 import Fa from 'svelte-fa/src/fa.svelte';
 import { providerInfos } from '../../stores/providers';
 import type {
@@ -32,11 +32,13 @@ import PreferencesConnectionsEmptyRendering from './PreferencesConnectionsEmptyR
 import PreferencesProviderInstallationModal from './PreferencesProviderInstallationModal.svelte';
 import { Buffer } from 'buffer';
 import Button from '../ui/Button.svelte';
+import { onboardingList } from '/@/stores/onboarding';
 
 export let properties: IConfigurationPropertyRecordedSchema[] = [];
 let providers: ProviderInfo[] = [];
 $: containerConnectionStatus = new Map<string, IConnectionStatus>();
 $: providerInstallationInProgress = new Map<string, boolean>();
+$: extensionOnboarding = new Map<string, boolean>();
 
 let isStatusUpdated = false;
 let displayInstallModal = false;
@@ -51,6 +53,8 @@ let restartingQueue: IConnectionRestart[] = [];
 
 let providersUnsubscribe: Unsubscriber;
 let configurationPropertiesUnsubscribe: Unsubscriber;
+let onboardingsUnsubscribe: Unsubscriber;
+
 onMount(() => {
   configurationPropertiesUnsubscribe = configurationProperties.subscribe(value => {
     properties = value;
@@ -134,6 +138,16 @@ onMount(() => {
       containerConnectionStatus = containerConnectionStatus;
     }
   });
+
+  onboardingsUnsubscribe = onboardingList.subscribe(onboardingItems => {
+    extensionOnboarding = new Map<string, boolean>();
+    onboardingItems.forEach(o => {
+      // maybe the boolean value should represent if the onboarding has been completed, to show the setup button or not
+      // now true by default
+      extensionOnboarding.set(o.extension, true);
+    });
+    extensionOnboarding = extensionOnboarding;
+  });
 });
 
 function getContainerRestarting(provider: string, container: string): IConnectionRestart {
@@ -150,6 +164,9 @@ onDestroy(() => {
   }
   if (configurationPropertiesUnsubscribe) {
     configurationPropertiesUnsubscribe();
+  }
+  if (onboardingsUnsubscribe) {
+    onboardingsUnsubscribe();
   }
 });
 
@@ -310,7 +327,7 @@ function hideInstallModal() {
       <div class="bg-charcoal-600 mb-5 rounded-md p-3 divide-x divide-gray-900 flex">
         <div>
           <!-- left col - provider icon/name + "create new" button -->
-          <div class="min-w-[150px] max-w-[200px]">
+          <div class="min-w-[170px] max-w-[200px]">
             <div class="flex">
               {#if provider.images.icon}
                 {#if typeof provider.images.icon === 'string'}
@@ -323,28 +340,47 @@ function hideInstallModal() {
               <span class="my-auto text-gray-400 ml-3 break-words">{provider.name}</span>
             </div>
             <div class="text-center mt-10">
-              {#if provider.containerProviderConnectionCreation || provider.kubernetesProviderConnectionCreation}
-                {@const providerDisplayName =
-                  (provider.containerProviderConnectionCreation
-                    ? provider.containerProviderConnectionCreationDisplayName || undefined
-                    : provider.kubernetesProviderConnectionCreation
-                    ? provider.kubernetesProviderConnectionCreationDisplayName
-                    : undefined) || provider.name}
-                {@const buttonTitle =
-                  (provider.containerProviderConnectionCreation
-                    ? provider.containerProviderConnectionCreationButtonTitle || undefined
-                    : provider.kubernetesProviderConnectionCreation
-                    ? provider.kubernetesProviderConnectionCreationButtonTitle
-                    : undefined) || 'Create new'}
-                <!-- create new provider button -->
-                <Tooltip tip="Create new {providerDisplayName}" bottom>
-                  <Button
-                    aria-label="Create new {providerDisplayName}"
-                    inProgress="{providerInstallationInProgress.get(provider.name)}"
-                    on:click="{() => doCreateNew(provider, providerDisplayName)}">
-                    {buttonTitle} ...
-                  </Button>
-                </Tooltip>
+              {#if extensionOnboarding.get(provider.extension) && provider.status === 'not-installed'}
+                <Button
+                  aria-label="Setup {provider.name}"
+                  title="Setup {provider.name}"
+                  on:click="{() => router.goto(`/preferences/onboarding/${provider.extension}`)}">
+                  Setup ...
+                </Button>
+              {:else}
+                <div class="flex flex-row justify-around">
+                  {#if provider.containerProviderConnectionCreation || provider.kubernetesProviderConnectionCreation}
+                    {@const providerDisplayName =
+                      (provider.containerProviderConnectionCreation
+                        ? provider.containerProviderConnectionCreationDisplayName || undefined
+                        : provider.kubernetesProviderConnectionCreation
+                        ? provider.kubernetesProviderConnectionCreationDisplayName
+                        : undefined) || provider.name}
+                    {@const buttonTitle =
+                      (provider.containerProviderConnectionCreation
+                        ? provider.containerProviderConnectionCreationButtonTitle || undefined
+                        : provider.kubernetesProviderConnectionCreation
+                        ? provider.kubernetesProviderConnectionCreationButtonTitle
+                        : undefined) || 'Create new'}
+                    <!-- create new provider button -->
+                    <Tooltip tip="Create new {providerDisplayName}" bottom>
+                      <Button
+                        aria-label="Create new {providerDisplayName}"
+                        inProgress="{providerInstallationInProgress.get(provider.name)}"
+                        on:click="{() => doCreateNew(provider, providerDisplayName)}">
+                        {buttonTitle} ...
+                      </Button>
+                    </Tooltip>
+                  {/if}
+                  {#if extensionOnboarding.get(provider.extension)}
+                    <Button
+                      aria-label="Setup {provider.name}"
+                      title="Setup {provider.name}"
+                      on:click="{() => router.goto(`/preferences/onboarding/${provider.extension}`)}">
+                      <Fa size="14" icon="{faGear}" />
+                    </Button>
+                  {/if}
+                </div>
               {/if}
             </div>
           </div>

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
@@ -340,11 +340,11 @@ function hideInstallModal() {
               <span class="my-auto text-gray-400 ml-3 break-words">{provider.name}</span>
             </div>
             <div class="text-center mt-10">
-              {#if extensionOnboarding.get(provider.extension) && provider.status === 'not-installed'}
+              {#if extensionOnboarding.get(provider.extensionId) && provider.status === 'not-installed'}
                 <Button
                   aria-label="Setup {provider.name}"
                   title="Setup {provider.name}"
-                  on:click="{() => router.goto(`/preferences/onboarding/${provider.extension}`)}">
+                  on:click="{() => router.goto(`/preferences/onboarding/${provider.extensionId}`)}">
                   Setup ...
                 </Button>
               {:else}
@@ -372,11 +372,11 @@ function hideInstallModal() {
                       </Button>
                     </Tooltip>
                   {/if}
-                  {#if extensionOnboarding.get(provider.extension)}
+                  {#if extensionOnboarding.get(provider.extensionId)}
                     <Button
                       aria-label="Setup {provider.name}"
                       title="Setup {provider.name}"
-                      on:click="{() => router.goto(`/preferences/onboarding/${provider.extension}`)}">
+                      on:click="{() => router.goto(`/preferences/onboarding/${provider.extensionId}`)}">
                       <Fa size="14" icon="{faGear}" />
                     </Button>
                   {/if}


### PR DESCRIPTION
### What does this PR do?

it shows the setup button to start the onboarding in the resources page
if the provider is not installed it displays the `setup` button, if the provider is installed it displays the `create new..` (if available) and the gear button

### Screenshot/screencast of this PR

![onboarding_button_resources](https://github.com/containers/podman-desktop/assets/49404737/ab1ca1ee-113e-4239-995f-21457ed856c6)

### What issues does this PR fix or reference?

it resolves #3676 

### How to test this PR?

1. uninstall podman
2. go to the resources page
3. check that there is the setup button
4. run the workflow
5. check that there is the create new ... and gear buttons
