### PR TITLE
feat: adding conditional visibility for preference item

### DIFF
--- a/extensions/kind/package.json
+++ b/extensions/kind/package.json
@@ -48,11 +48,24 @@
           "scope": "KubernetesProviderConnectionFactory",
           "description": "Setup an ingress controller (Contour https://projectcontour.io)"
         },
+        "kind.cluster.creation.switchControlPlaneImage": {
+          "type": "boolean",
+          "default": false,
+          "scope": "KubernetesProviderConnectionFactory",
+          "description": "Using custom node’s container image"
+        },
         "kind.cluster.creation.controlPlaneImage": {
           "type": "string",
           "default": "",
           "scope": "KubernetesProviderConnectionFactory",
-          "placeholder": "Leave empty for using latest.",
+          "hidden": {
+            "key": "kind.cluster.creation.switchControlPlaneImage",
+            "operator": "NotEqual",
+            "values": [
+              "true"
+            ]
+          },
+          "placeholder": "kindest/node:v1.27.3@sha256:...",
           "markdownDescription": "Node’s container image (Available image tags on [kind/releases](https://github.com/kubernetes-sigs/kind/releases))"
         }
       }

--- a/packages/main/src/plugin/configuration-registry.ts
+++ b/packages/main/src/plugin/configuration-registry.ts
@@ -61,9 +61,17 @@ export interface IConfigurationPropertySchema {
   format?: string;
   scope?: ConfigurationScope;
   readonly?: boolean;
-  hidden?: boolean;
+  hidden?: boolean | HiddenConfiguration;
   enum?: string[];
   when?: string;
+}
+
+export type OperatorConfiguration = 'NotEqual' | 'Equal' | 'Gt' | 'In' | 'Lt' | 'NotIn';
+
+export interface HiddenConfiguration {
+  key: string;
+  operator: OperatorConfiguration;
+  values: string[];
 }
 
 export type ConfigurationScope =

--- a/packages/renderer/src/PreferencesNavigation.svelte
+++ b/packages/renderer/src/PreferencesNavigation.svelte
@@ -14,22 +14,22 @@ $: sectionExpanded = {};
 
 onMount(async () => {
   configurationProperties.subscribe(value => {
-    configProperties = value
-      .filter(property => property.scope === CONFIGURATION_DEFAULT_SCOPE)
-      .filter(property => !property.hidden)
-      .reduce((map, property) => {
-        let [parentLeftId] = property.parentId.split('.');
-
-        if (map[parentLeftId] === undefined) {
-          map[parentLeftId] = [];
-        }
-
-        let children = map[parentLeftId].find(item => item.id === property.parentId);
-        if (children === undefined) {
-          map[parentLeftId].push({ id: property.parentId, title: property.title });
-        }
+    configProperties = value.reduce((map, property) => {
+      if (property.scope !== CONFIGURATION_DEFAULT_SCOPE || ('boolean' === typeof property.hidden && !property.hidden))
         return map;
-      }, new Map());
+
+      let [parentLeftId] = property.parentId.split('.');
+
+      if (map[parentLeftId] === undefined) {
+        map[parentLeftId] = [];
+      }
+
+      let children = map[parentLeftId].find(item => item.id === property.parentId);
+      if (children === undefined) {
+        map[parentLeftId].push({ id: property.parentId, title: property.title });
+      }
+      return map;
+    }, new Map());
   });
 });
 </script>

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationRendering.svelte
@@ -103,16 +103,11 @@ function evaluateHiddenConfigurations() {
   const updatedHiddenConfiguration = new Map<string, boolean>();
 
   configurationKeys.forEach(configurationKey => {
-    if (!isHiddenConfiguration(configurationKey.hidden)) {
-      console.log(configurationKey.id, 'is not HiddenConfiguration');
-      return;
-    }
+    if (!isHiddenConfiguration(configurationKey.hidden)) return;
 
     const hiddenConf = configurationKey.hidden as HiddenConfiguration;
     const targetValue = configurationValues.get(hiddenConf.key);
     const strTargetValue = `${targetValue}`;
-
-    console.log('hiddenConf', hiddenConf, strTargetValue);
 
     switch (hiddenConf.operator) {
       case 'NotEqual':
@@ -138,7 +133,6 @@ function evaluateHiddenConfigurations() {
     }
   });
 
-  console.log('POST hiddenConfiguration: ', updatedHiddenConfiguration);
   hiddenConfigurationStore.set(updatedHiddenConfiguration);
 }
 

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
@@ -18,6 +18,8 @@ export let resetToDefault = false;
 export let enableAutoSave = false;
 
 export let setRecordValue = (_id: string, _value: string) => {};
+export let onRecordChange = (_id: string, _value: string) => {};
+
 export let enableSlider = false;
 export let record: IConfigurationPropertyRecordedSchema;
 
@@ -56,6 +58,7 @@ $: if (currentRecord !== record) {
   currentRecord = record;
   invalidText = undefined;
   invalidEntry = false;
+  onRecordChange(record.id, recordValue);
 }
 
 function invalid() {
@@ -65,6 +68,10 @@ function invalid() {
 
 function valid() {
   validRecord();
+}
+
+function handleChange() {
+  onRecordChange(record.id, recordValue);
 }
 
 function checkValue(record: IConfigurationPropertyRecordedSchema, event: any) {
@@ -226,6 +233,7 @@ function onNumberInputChange(event: any) {
   const resultingValue = Number(event.target.value);
   if (assertNumericValueIsValid(resultingValue)) {
     autoSave();
+    handleChange();
   }
 }
 
@@ -258,6 +266,7 @@ function assertNumericValueIsValid(value: number) {
           on:input="{event => {
             recordValue = !checkboxValue;
             checkValue(record, event);
+            handleChange();
           }}"
           class="sr-only peer"
           bind:checked="{checkboxValue}"
@@ -280,7 +289,10 @@ function assertNumericValueIsValid(value: number) {
         max="{record.maximum}"
         value="{getNormalizedDefaultNumberValue(record)}"
         aria-label="{record.description}"
-        on:input="{event => handleRangeValue(record.id, event.currentTarget)}"
+        on:input="{event => {
+          handleRangeValue(record.id, event.currentTarget);
+          handleChange();
+        }}"
         class="w-full h-1 bg-[var(--pf-global--primary-color--300)] rounded-lg appearance-none accent-[var(--pf-global--primary-color--300)] cursor-pointer range-xs mt-2" />
     {:else if record.type === 'number'}
       <div
@@ -289,7 +301,10 @@ function assertNumericValueIsValid(value: number) {
         class:border-red-500="{numberInputInvalid}">
         <button
           data-action="decrement"
-          on:click="{e => decrement(e, record)}"
+          on:click="{e => {
+            decrement(e, record);
+            handleChange();
+          }}"
           disabled="{!canDecrement(recordValue, record.minimum)}"
           class="w-11 text-white {!canDecrement(recordValue, record.minimum)
             ? 'bg-charcoal-600 text-charcoal-100 border-t border-l border-charcoal-800'
@@ -302,13 +317,22 @@ function assertNumericValueIsValid(value: number) {
             class="w-[50px] outline-none focus:outline-none text-center text-white text-sm py-0.5"
             name="{record.id}"
             bind:value="{recordValue}"
-            on:keypress="{event => onNumberInputKeyPress(event)}"
-            on:input="{event => onNumberInputChange(event)}"
+            on:keypress="{event => {
+              onNumberInputKeyPress(event);
+              handleChange();
+            }}"
+            on:input="{event => {
+              onNumberInputChange(event);
+              handleChange();
+            }}"
             aria-label="{record.description}" />
         </Tooltip>
         <button
           data-action="increment"
-          on:click="{e => increment(e, record)}"
+          on:click="{e => {
+            increment(e, record);
+            handleChange();
+          }}"
           disabled="{!canIncrement(recordValue, record.maximum)}"
           class="w-11 text-white {!canIncrement(recordValue, record.maximum)
             ? 'bg-charcoal-600 text-charcoal-100 border-t border-l border-charcoal-800'
@@ -332,11 +356,17 @@ function assertNumericValueIsValid(value: number) {
           class="relative cursor-pointer right-5"
           class:hidden="{!recordValue}"
           aria-label="clear"
-          on:click="{event => handleCleanValue(event)}">
+          on:click="{event => {
+            handleCleanValue(event);
+            handleChange();
+          }}">
           <Fa icon="{faXmark}" />
         </button>
         <Button
-          on:click="{() => selectFilePath()}"
+          on:click="{() => {
+            selectFilePath();
+            handleChange();
+          }}"
           id="rendering.FilePath.{record.id}"
           aria-invalid="{invalidEntry}"
           aria-label="button-{record.description}">Browse ...</Button>
@@ -346,7 +376,10 @@ function assertNumericValueIsValid(value: number) {
         class="border-b block w-full p-1 bg-zinc-700 border-violet-500 text-white text-sm checked:bg-violet-50"
         name="{record.id}"
         id="input-standard-{record.id}"
-        on:input="{event => checkValue(record, event)}"
+        on:input="{event => {
+          checkValue(record, event);
+          handleChange();
+        }}"
         bind:value="{recordValue}"
         aria-invalid="{invalidEntry}"
         aria-label="{record.description}">
@@ -360,7 +393,10 @@ function assertNumericValueIsValid(value: number) {
       </div>
     {:else}
       <input
-        on:input="{event => checkValue(record, event)}"
+        on:input="{event => {
+          checkValue(record, event);
+          handleChange();
+        }}"
         class="grow py-1 px-2 w-full outline-0 border-b-2 border-gray-800 hover:border-violet-500 focus:border-violet-500 placeholder-gray-900"
         name="{record.id}"
         type="text"


### PR DESCRIPTION
I taught at first that https://github.com/containers/podman-desktop/pull/3251/files would add a `when` condition that would allow to set some condition on other field, but apparently not. Maybe it planed in the future and therefore I could probably adapt my code. @benoitf what do you think ?

### What does this PR do?

It allows to set condition on the hidden property used in `package.json`. For example, following this PR I made adding an __advanced__ feature (https://github.com/containers/podman-desktop/pull/3508), we though it would be interesting to hide in behind something.

### Screenshot/screencast of this PR

| Switch off | Switch On |
| --- | --- |
|  <img width="577" alt="image" src="https://github.com/containers/podman-desktop/assets/42176370/9817db5f-13b0-4499-bf8f-ad6aaed1984d"> | <img width="573" alt="image" src="https://github.com/containers/podman-desktop/assets/42176370/5f5af339-942d-41cf-9586-58a279bb1d52"> |

The `hidden` property can now be either a boolean or a `HiddenConfiguration`, here is an example inside a `package.json`

```json
"hidden": {
    "key": "kind.cluster.creation.switchControlPlaneImage",
    "operator": "NotEqual",
    "values": ["true"]
},
```

It is inspired by [kubernetes scheduling operators](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#operators).

> In this example only one condition is possible, but this is a very small change to add more.

### Testing

- [ ] Add unit test (todo)