### PR TITLE
chore: set local URL in development mode

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -6,10 +6,12 @@ const darkCodeTheme = require('prism-react-renderer/themes/dracula');
 
 const title = 'podman desktop';
 
+const inDevMode = process.env.NODE_ENV === 'development';
+
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   title: 'Podman Desktop',
-  url: 'https://podman-desktop.io',
+  url: inDevMode ? 'http://localhost:3000' : 'https://podman-desktop.io',
   baseUrl: '/',
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',


### PR DESCRIPTION

### What does this PR do?

When trying the website in development mode locally, some links are generated using the public URL which is podman-desktop.io

So if you have some new links/images they might reference links that are still not yet available remotely

Here it'll resolve them locally so if it works locally, after the merge it will also work in production mode

an example is the `twitter:image` links for example that will use the docusaurus config URL object and if you want to check locally it won't work as the link being generated is using podman-desktop.io

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast 
explaining what is doing this PR -->

### What issues does this PR fix or reference?

https://github.com/containers/podman-desktop/pull/3614/files#r1306822710

### How to test this PR?

<!-- Please explain steps to reproduce -->
