### PR TITLE
feat: send telemety when Create New connection requested

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.spec.ts
@@ -70,6 +70,7 @@ beforeEach(() => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     receive: vi.fn(),
   };
+  (window as any).telemetryTrack = vi.fn();
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (window as any).telemetryPage = vi.fn().mockResolvedValue(undefined);
 });

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.spec.ts
@@ -165,6 +165,11 @@ test('Expect to redirect to create New page if provider is installed', async () 
   const button = screen.getByRole('button', { name: 'Create new foo-provider' });
   expect(button).toBeInTheDocument();
   await userEvent.click(button);
+  // telemetry sent
+  expect(window.telemetryTrack).toBeCalledWith('createNewProviderConnectionPageRequested', {
+    providerId: customProviderInfo.id,
+    name: customProviderInfo.name,
+  });
   // redirect to create new page
   expect(router.goto).toHaveBeenCalledWith(`/preferences/provider/${customProviderInfo.internalId}`);
 });

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
@@ -245,6 +245,10 @@ async function doCreateNew(provider: ProviderInfo, displayName: string) {
     doExecuteAfterInstallation = () => router.goto(`/preferences/provider/${provider.internalId}`);
     performInstallation(provider);
   } else {
+    window.telemetryTrack('createNewProviderConnection', {
+      providerId: provider.id,
+      name: provider.name,
+    });
     router.goto(`/preferences/provider/${provider.internalId}`);
   }
 }

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
@@ -245,7 +245,7 @@ async function doCreateNew(provider: ProviderInfo, displayName: string) {
     doExecuteAfterInstallation = () => router.goto(`/preferences/provider/${provider.internalId}`);
     performInstallation(provider);
   } else {
-    window.telemetryTrack('createNewProviderConnection', {
+    window.telemetryTrack('createNewProviderConnectionPageRequested', {
       providerId: provider.id,
       name: provider.name,
     });


### PR DESCRIPTION
### What does this PR do?

It adds telemetry reporting for the case when 'Create New' button creates new connection. When 'Create New' button sends provider installation request telemetry is handled on main side in installProvider method of ProviderRegistry.

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast 
explaining what is doing this PR -->
N/A

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop 
repository (or from another issue tracker). -->

https://github.com/redhat-developer/podman-desktop-sandbox-ext/issues/51

### How to test this PR?

N/A
