### PR TITLE
feat: send telemetry when creating new provider connection closed/canceled

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationRendering.spec.ts
@@ -23,11 +23,14 @@
 import '@testing-library/jest-dom/vitest';
 import { test, expect, vi, beforeAll } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/svelte';
+import { router } from 'tinro';
 import PreferencesConnectionCreationRendering from './PreferencesConnectionCreationRendering.svelte';
 import type { IConfigurationPropertyRecordedSchema } from '../../../../main/src/plugin/configuration-registry';
 import type { ProviderInfo } from '../../../../main/src/plugin/api/provider-info';
 import { get } from 'svelte/store';
 import { createConnectionsInfo } from '/@/stores/create-connections';
+
+type LoggerEventName = 'log' | 'warn' | 'error' | 'finish';
 
 const properties: IConfigurationPropertyRecordedSchema[] = [];
 const providerInfo: ProviderInfo = {
@@ -72,24 +75,61 @@ test('Expect that the create button is available', async () => {
   expect(createButton).toBeEnabled();
 });
 
-test('Expect create connection successfully', async () => {
-  let providedKeyLogger:
-    | ((key: symbol, eventName: 'log' | 'warn' | 'error' | 'finish', args: string[]) => void)
-    | undefined;
+function mockCallback(
+  callback: (keyLogger: (key: symbol, eventName: LoggerEventName, args: string[]) => void) => Promise<void>,
+) {
+  return vi
+    .fn()
+    .mockImplementation(async function (
+      _id: string,
+      _params: unknown,
+      _key: unknown,
+      keyLogger: (key: symbol, eventName: LoggerEventName, args: string[]) => void,
+    ): Promise<void> {
+      // keep reference
+      callback(keyLogger);
+    });
+}
 
-  const callback = vi.fn();
-  callback.mockImplementation(async function (
-    _id: string,
-    _params: unknown,
-    _key: unknown,
-    keyLogger: (key: symbol, eventName: 'log' | 'warn' | 'error' | 'finish', args: string[]) => void,
-  ): Promise<void> {
-    // keep reference
+test('Expect Close button redirects to Resources page', async () => {
+  const gotoSpy = vi.spyOn(router, 'goto');
+
+  let providedKeyLogger: ((key: symbol, eventName: LoggerEventName, args: string[]) => void) | undefined;
+
+  const callback = mockCallback(async keyLogger => {
     providedKeyLogger = keyLogger;
   });
 
   // eslint-disable-next-line @typescript-eslint/await-thenable
-  await render(PreferencesConnectionCreationRendering, {
+  render(PreferencesConnectionCreationRendering, {
+    properties,
+    providerInfo,
+    propertyScope,
+    callback,
+    pageIsLoading: false,
+    taskId: 2,
+  });
+
+  const closeButton = screen.getByRole('button', { name: 'Close page' });
+  expect(closeButton).toBeInTheDocument();
+
+  await fireEvent.click(closeButton);
+  expect(gotoSpy).toBeCalledWith('/preferences/resources');
+  expect(window.telemetryTrack).toBeCalledWith('createNewProviderConnectionPageUserClosed', {
+    providerId: providerInfo.id,
+    name: providerInfo.name,
+  });
+});
+
+test('Expect create connection successfully', async () => {
+  let providedKeyLogger: ((key: symbol, eventName: LoggerEventName, args: string[]) => void) | undefined;
+
+  const callback = mockCallback(async keyLogger => {
+    providedKeyLogger = keyLogger;
+  });
+
+  // eslint-disable-next-line @typescript-eslint/await-thenable
+  render(PreferencesConnectionCreationRendering, {
     properties,
     providerInfo,
     propertyScope,
@@ -140,17 +180,9 @@ test('Expect create connection successfully', async () => {
 });
 
 test('Expect cancelling the creation, trigger the cancellation token', async () => {
-  let providedKeyLogger:
-    | ((key: symbol, eventName: 'log' | 'warn' | 'error' | 'finish', args: unknown[]) => void)
-    | undefined;
+  let providedKeyLogger: ((key: symbol, eventName: LoggerEventName, args: string[]) => void) | undefined;
 
-  const callback = vi.fn();
-  callback.mockImplementation(async function (
-    _id: string,
-    _params: unknown,
-    _key: unknown,
-    keyLogger: (key: symbol, eventName: 'log' | 'warn' | 'error' | 'finish', args: unknown[]) => void,
-  ): Promise<void> {
+  const callback = mockCallback(async keyLogger => {
     // keep reference
     providedKeyLogger = keyLogger;
   });
@@ -200,6 +232,12 @@ test('Expect cancelling the creation, trigger the cancellation token', async () 
     providedKeyLogger(currentConnectionInfo.createKey, 'finish', []);
   }
 
+  expect(window.telemetryTrack).toBeCalledWith('createNewProviderConnectionRequestUserCanceled', {
+    providerId: providerInfo.id,
+    name: providerInfo.name,
+  });
   // expect it is sucessful
   expect(cancelTokenMock).toBeCalled;
 });
+
+test('Expect close button to redirect to resources page', async () => {});

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationRendering.spec.ts
@@ -45,6 +45,7 @@ beforeAll(() => {
   (window as any).getOsFreeDiskSize = vi.fn();
   (window as any).getCancellableTokenSource = vi.fn();
   (window as any).auditConnectionParameters = vi.fn();
+  (window as any).telemetryTrack = vi.fn();
 
   Object.defineProperty(window, 'matchMedia', {
     value: () => {

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationRendering.svelte
@@ -325,6 +325,10 @@ async function cancel() {
     creationCancelled = true;
     tokenId = undefined;
   }
+  window.telemetryTrack('cancelCreateNewProviderConnection', {
+    providerId: providerInfo.id,
+    name: providerInfo.name,
+  });
 }
 
 async function close() {

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationRendering.svelte
@@ -333,6 +333,10 @@ async function cancel() {
 
 async function close() {
   cleanup();
+  window.telemetryTrack('closeCreateNewProviderConnection', {
+    providerId: providerInfo.id,
+    name: providerInfo.name,
+  });
 }
 </script>
 

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationRendering.svelte
@@ -319,7 +319,7 @@ async function handleOnSubmit(e: any) {
   }
 }
 
-async function cancel() {
+async function cancelCreation() {
   if (tokenId) {
     await window.cancelToken(tokenId);
     creationCancelled = true;
@@ -331,8 +331,12 @@ async function cancel() {
   });
 }
 
-async function close() {
+async function closePanel() {
   cleanup();
+}
+
+function closePage() {
+  router.goto('/preferences/resources');
   window.telemetryTrack('createNewProviderConnectionPageUserClosed', {
     providerId: providerInfo.id,
     name: providerInfo.name,
@@ -391,11 +395,11 @@ async function close() {
                   aria-label="Cancel creation"
                   class="text-xs {errorMessage ? 'mr-3' : ''} hover:underline {tokenId ? '' : 'hidden'}"
                   disabled="{!tokenId}"
-                  on:click="{cancel}">Cancel</button>
+                  on:click="{cancelCreation}">Cancel</button>
                 <button
                   class="text-xs hover:underline {creationInProgress ? 'hidden' : ''}"
                   aria-label="Close panel"
-                  on:click="{close}">Close</button>
+                  on:click="{closePanel}">Close</button>
               </div>
             </div>
             <div id="log" class="pt-2 h-80 {showLogs ? '' : 'hidden'}">
@@ -440,7 +444,7 @@ async function close() {
             {/each}
             <div class="w-full">
               <div class="float-right">
-                <Button type="link" on:click="{() => router.goto('/preferences/resources')}">Close</Button>
+                <Button type="link" aria-label="Close page" on:click="{closePage}">Close</Button>
                 <Button
                   disabled="{!isValid}"
                   inProgress="{creationInProgress}"

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationRendering.svelte
@@ -325,7 +325,7 @@ async function cancel() {
     creationCancelled = true;
     tokenId = undefined;
   }
-  window.telemetryTrack('cancelCreateNewProviderConnection', {
+  window.telemetryTrack('createNewProviderConnectionRequestUserCanceled', {
     providerId: providerInfo.id,
     name: providerInfo.name,
   });
@@ -333,7 +333,7 @@ async function cancel() {
 
 async function close() {
   cleanup();
-  window.telemetryTrack('closeCreateNewProviderConnection', {
+  window.telemetryTrack('createNewProviderConnectionPageUserClosed', {
     providerId: providerInfo.id,
     name: providerInfo.name,
   });


### PR DESCRIPTION
### What does this PR do?

It adds telemetry reporting when 'Cancel' pressed in 'Create New Provider Connection' form 

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

https://github.com/redhat-developer/podman-desktop-sandbox-ext/issues/51

### How to test this PR?

<!-- Please explain steps to reproduce -->
