### PR TITLE
fix: add a strict undefined check to messagebox result (#3692)

### DIFF
--- a/packages/main/src/plugin/message-box.spec.ts
+++ b/packages/main/src/plugin/message-box.spec.ts
@@ -1,0 +1,39 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { expect, test, vi } from 'vitest';
+import { MessageBox } from './message-box.js';
+import type { ApiSenderType } from './api.js';
+
+test('Should return first item if button clicked is the first', async () => {
+  const messageBox = new MessageBox({} as ApiSenderType);
+  vi.spyOn(messageBox, 'showMessageBox').mockResolvedValue({
+    response: 0,
+  });
+  const result = await messageBox.showDialog('info', 'title', 'message', ['ok', 'cancel']);
+  expect(result).toBe('ok');
+});
+
+test('Should return second item if button clicked is the second', async () => {
+  const messageBox = new MessageBox({} as ApiSenderType);
+  vi.spyOn(messageBox, 'showMessageBox').mockResolvedValue({
+    response: 1,
+  });
+  const result = await messageBox.showDialog('info', 'title', 'message', ['ok', 'cancel']);
+  expect(result).toBe('cancel');
+});

--- a/packages/main/src/plugin/message-box.ts
+++ b/packages/main/src/plugin/message-box.ts
@@ -101,7 +101,7 @@ export class MessageBox {
       type: type,
     });
 
-    if (result.response && result.response >= 0) {
+    if (result.response !== undefined && result.response >= 0) {
       return items[result.response];
     }
 


### PR DESCRIPTION
### What does this PR do?

it fixes the issue related to when clicking the first button of a messagebox. Its index (0) was interpreted as false, resulting in an undefined result instead of the first item.

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

it resolves #3692

### How to test this PR?

1. open a dialog and click on the first action. E.g if you execute the podman onboarding, verify that it works when you click on the `install` button