### PR TITLE
fix: disable next button and show try again when onboarding failed (#3616)

### DIFF
--- a/packages/renderer/src/lib/onboarding/Onboarding.spec.ts
+++ b/packages/renderer/src/lib/onboarding/Onboarding.spec.ts
@@ -1,0 +1,84 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import '@testing-library/jest-dom/vitest';
+import { test, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import Onboarding from './Onboarding.svelte';
+import { ContextUI } from '../context/context';
+import { onboardingList } from '/@/stores/onboarding';
+import { context } from '/@/stores/context';
+
+async function waitRender(customProperties: object): Promise<void> {
+  const result = render(Onboarding, { ...customProperties });
+  // wait that result.component.$$.ctx[0] is set
+  while (result.component.$$.ctx[0] === undefined) {
+    await new Promise(resolve => setTimeout(resolve, 100));
+  }
+}
+
+test('Expect to have the "Try again" button disabled if the step represent a failed state', async () => {
+  (window as any).resetOnboarding = vi.fn();
+  (window as any).updateStepState = vi.fn();
+
+  onboardingList.set([
+    {
+      extension: 'id',
+      title: 'onboarding',
+      steps: [
+        {
+          id: 'step',
+          title: 'step',
+          state: 'failed',
+          completionEvents: ['onCommand:command'],
+        },
+      ],
+    },
+  ]);
+  context.set(new ContextUI());
+  await waitRender({
+    extensionIds: ['id'],
+  });
+  const button = screen.getByRole('button', { name: 'Try again' });
+  expect(button).toBeInTheDocument();
+});
+
+test('Expect not to have the "Try again" button disabled if the step represent a completed state', async () => {
+  (window as any).resetOnboarding = vi.fn();
+  (window as any).updateStepState = vi.fn();
+
+  onboardingList.set([
+    {
+      extension: 'id',
+      title: 'onboarding',
+      steps: [
+        {
+          id: 'step',
+          title: 'step',
+          state: 'completed',
+          completionEvents: ['onCommand:command'],
+        },
+      ],
+    },
+  ]);
+  context.set(new ContextUI());
+  await waitRender({
+    extensionIds: ['id'],
+  });
+  const button = screen.queryByRole('button', { name: 'Try again' });
+  expect(button).not.toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/onboarding/Onboarding.spec.ts
+++ b/packages/renderer/src/lib/onboarding/Onboarding.spec.ts
@@ -44,7 +44,7 @@ test('Expect to have the "Try again" button disabled if the step represent a fai
           id: 'step',
           title: 'step',
           state: 'failed',
-          completionEvents: ['onCommand:command'],
+          completionEvents: [],
         },
       ],
     },
@@ -55,6 +55,8 @@ test('Expect to have the "Try again" button disabled if the step represent a fai
   });
   const button = screen.getByRole('button', { name: 'Try again' });
   expect(button).toBeInTheDocument();
+  const infoMessage = screen.queryByLabelText('next-info-message');
+  expect(infoMessage).not.toBeInTheDocument();
 });
 
 test('Expect not to have the "Try again" button disabled if the step represent a completed state', async () => {
@@ -70,7 +72,7 @@ test('Expect not to have the "Try again" button disabled if the step represent a
           id: 'step',
           title: 'step',
           state: 'completed',
-          completionEvents: ['onCommand:command'],
+          completionEvents: [],
         },
       ],
     },
@@ -81,4 +83,6 @@ test('Expect not to have the "Try again" button disabled if the step represent a
   });
   const button = screen.queryByRole('button', { name: 'Try again' });
   expect(button).not.toBeInTheDocument();
+  const infoMessage = screen.getByLabelText('next-info-message');
+  expect(infoMessage).toBeInTheDocument();
 });

--- a/packages/renderer/src/lib/onboarding/Onboarding.svelte
+++ b/packages/renderer/src/lib/onboarding/Onboarding.svelte
@@ -362,9 +362,11 @@ async function cleanContext() {
 
     {#if !activeStep.step.completionEvents || activeStep.step.completionEvents.length === 0}
       <div class="grow"></div>
-      <div class="mb-10 mx-auto text-sm">
-        Press the <span class="bg-purple-700 p-0.5">Next</span> button below to proceed.
-      </div>
+      {#if activeStep.step.state !== 'failed'}
+        <div class="mb-10 mx-auto text-sm" aria-label="next-info-message">
+          Press the <span class="bg-purple-700 p-0.5">Next</span> button below to proceed.
+        </div>
+      {/if}
       <div class="flex flex-row-reverse p-6 bg-charcoal-700">
         <button
           class="py-1.5 px-5 rounded-md text-sm"

--- a/packages/renderer/src/lib/onboarding/Onboarding.svelte
+++ b/packages/renderer/src/lib/onboarding/Onboarding.svelte
@@ -19,6 +19,7 @@ import {
   STATUS_SKIPPED,
 } from './onboarding-utils';
 import { lastPage } from '/@/stores/breadcrumb';
+import Button from '../ui/Button.svelte';
 
 interface ActiveOnboardingStep {
   onboarding: OnboardingInfo;
@@ -37,6 +38,8 @@ let displayCancelSetup = false;
 let displayResetSetup = false;
 
 let executedCommands: string[] = [];
+
+let firstStart = true;
 /*
 $: enableNextButton = false;*/
 let onboardingUnsubscribe: Unsubscriber;
@@ -46,15 +49,28 @@ onMount(async () => {
   onboardingUnsubscribe = onboardingList.subscribe(onboardingItems => {
     if (!onboardings) {
       onboardings = onboardingItems.filter(o => extensionIds.find(extensionId => o.extension === extensionId));
-      startOnboarding();
+      if (!started) {
+        startOnboarding().then(isStartedByMe => {
+          if (isStartedByMe) {
+            assertStepCompleted().finally(() => (firstStart = false));
+          }
+        });
+      }
     }
   });
 
   // eslint-disable-next-line @typescript-eslint/no-misused-promises
   contextsUnsubscribe = context.subscribe(async value => {
     globalContext = value;
-    const gotStarted = await startOnboarding();
-    if (!gotStarted) {
+    if (!started) {
+      const isStartedByMe = await startOnboarding();
+      if (isStartedByMe) {
+        firstStart = false;
+        await assertStepCompleted();
+        return;
+      }
+    }
+    if (!firstStart) {
       await assertStepCompleted();
     }
   });
@@ -322,6 +338,12 @@ async function cleanContext() {
       {/if}
     </div>
 
+    {#if activeStep.step.state === 'failed'}
+      <div class="mx-auto mt-4">
+        <Button on:click="{() => restartSetup()}">Try again</Button>
+      </div>
+    {/if}
+
     <div class="flex flex-col mx-auto">
       {#if activeStep.step.content}
         {#each activeStep.step.content as row}
@@ -344,7 +366,12 @@ async function cleanContext() {
         Press the <span class="bg-purple-700 p-0.5">Next</span> button below to proceed.
       </div>
       <div class="flex flex-row-reverse p-6 bg-charcoal-700">
-        <button class="bg-purple-700 py-1.5 px-5 rounded-md text-sm" on:click="{() => next()}">Next</button>
+        <button
+          class="py-1.5 px-5 rounded-md text-sm"
+          class:bg-purple-700="{activeStep.step.state !== 'failed'}"
+          class:bg-charcoal-50="{activeStep.step.state === 'failed'}"
+          disabled="{activeStep.step.state === 'failed'}"
+          on:click="{() => next()}">Next</button>
         <button class="bg-purple-700 py-1.5 px-5 mr-2 rounded-md text-sm" on:click="{() => setDisplayCancelSetup(true)}"
           >Cancel</button>
       </div>

--- a/packages/renderer/src/lib/onboarding/Onboarding.svelte
+++ b/packages/renderer/src/lib/onboarding/Onboarding.svelte
@@ -20,6 +20,7 @@ import {
 } from './onboarding-utils';
 import { lastPage } from '/@/stores/breadcrumb';
 import Button from '../ui/Button.svelte';
+import Link from '../ui/Link.svelte';
 
 interface ActiveOnboardingStep {
   onboarding: OnboardingInfo;
@@ -365,6 +366,10 @@ async function cleanContext() {
       {#if activeStep.step.state !== 'failed'}
         <div class="mb-10 mx-auto text-sm" aria-label="next-info-message">
           Press the <span class="bg-purple-700 p-0.5">Next</span> button below to proceed.
+        </div>
+      {:else}
+        <div class="mb-10 mx-auto text-sm" aria-label="exit-info-message">
+          <Link on:click="{() => setDisplayCancelSetup(true)}">Exit</Link> the setup. You can try again later.
         </div>
       {/if}
       <div class="flex flex-row-reverse p-6 bg-charcoal-700">


### PR DESCRIPTION
### What does this PR do?

When the onboarding is in a failed state, it disable the `Next` button and it displays the `Try again` button that allows to restart the workflow

### Screenshot/screencast of this PR

![onboarding_try_again_2](https://github.com/containers/podman-desktop/assets/49404737/0b5940af-02ab-41c4-9e26-7058be27f1b5)

### What issues does this PR fix or reference?

it resolves #3616 

### How to test this PR?

1. start podman onboarding
2. click no when it asks to install podman
3. you should see the "failed installation" page and can re-try by clicking on the `try again` button
