### PR TITLE
feat: add logic to display setting using specific syntax (#3714)

### DIFF
--- a/packages/renderer/src/lib/onboarding/OnboardingItem.spec.ts
+++ b/packages/renderer/src/lib/onboarding/OnboardingItem.spec.ts
@@ -21,6 +21,7 @@ import { render, screen } from '@testing-library/svelte';
 import OnboardingItem from './OnboardingItem.svelte';
 import type { OnboardingStepItem } from '../../../../main/src/plugin/api/onboarding';
 import { ContextUI } from '../context/context';
+import { configurationProperties } from '/@/stores/configurationProperties';
 
 test('Expect button html when passing a button tag in markdown', async () => {
   const textComponent: OnboardingStepItem = {
@@ -67,4 +68,101 @@ test('Expect placeholders are replaced when passing a text component with placeh
   const markdownSection = screen.getByLabelText('markdown-content');
   expect(markdownSection).toBeInTheDocument();
   expect(markdownSection.innerHTML.includes('placeholder content')).toBe(true);
+});
+
+test('Expect boolean configuration placeholder to be replaced with a checkbox', async () => {
+  const textComponent: OnboardingStepItem = {
+    value: '${configuration:extension.boolean.prop}',
+  };
+  configurationProperties.set([
+    {
+      parentId: '',
+      title: 'record',
+      description: 'record-description',
+      extension: {
+        id: 'extension',
+      },
+      hidden: false,
+      id: 'extension.boolean.prop',
+      type: 'boolean',
+      default: false,
+    },
+  ]);
+  render(OnboardingItem, {
+    extension: 'extension',
+    item: textComponent,
+    getContext: vi.fn(),
+    inProgressCommandExecution: vi.fn(),
+  });
+  const input = screen.getByLabelText('record-description');
+  expect(input).toBeInTheDocument();
+  expect(input instanceof HTMLInputElement).toBe(true);
+  expect((input as HTMLInputElement).type).toBe('checkbox');
+  expect((input as HTMLInputElement).name).toBe('extension.boolean.prop');
+});
+
+test('Expect when configuration placeholder is type string and format file to be replaced with an input button with Browse', async () => {
+  const textComponent: OnboardingStepItem = {
+    value: '${configuration:extension.format.prop}',
+  };
+  configurationProperties.set([
+    {
+      parentId: '',
+      title: 'record',
+      placeholder: 'Example: text',
+      description: 'record-description',
+      extension: {
+        id: 'extension',
+      },
+      hidden: false,
+      id: 'extension.format.prop',
+      type: 'string',
+      format: 'file',
+    },
+  ]);
+  render(OnboardingItem, {
+    extension: 'extension',
+    item: textComponent,
+    getContext: vi.fn(),
+    inProgressCommandExecution: vi.fn(),
+  });
+  const readOnlyInput = screen.getByLabelText('record-description');
+  expect(readOnlyInput).toBeInTheDocument();
+  expect(readOnlyInput instanceof HTMLInputElement).toBe(true);
+  expect((readOnlyInput as HTMLInputElement).placeholder).toBe('Example: text');
+  const input = screen.getByLabelText('button-record-description');
+  expect(input).toBeInTheDocument();
+  expect(input.textContent).toBe('Browse ...');
+});
+
+test('Expect a type text configuration placeholder to be replaced by a text input', async () => {
+  const textComponent: OnboardingStepItem = {
+    value: '${configuration:extension.text.prop}',
+  };
+  configurationProperties.set([
+    {
+      parentId: '',
+      title: 'record',
+      placeholder: 'Example: text',
+      description: 'record-description',
+      extension: {
+        id: 'extension',
+      },
+      hidden: false,
+      id: 'extension.text.prop',
+      type: 'string',
+    },
+  ]);
+  render(OnboardingItem, {
+    extension: 'extension',
+    item: textComponent,
+    getContext: vi.fn(),
+    inProgressCommandExecution: vi.fn(),
+  });
+  const input = screen.getByLabelText('record-description');
+  expect(input).toBeInTheDocument();
+  expect(input instanceof HTMLInputElement).toBe(true);
+  expect((input as HTMLInputElement).type).toBe('text');
+  expect((input as HTMLSelectElement).name).toBe('extension.text.prop');
+  expect((input as HTMLInputElement).placeholder).toBe('Example: text');
 });

--- a/packages/renderer/src/lib/onboarding/OnboardingItem.svelte
+++ b/packages/renderer/src/lib/onboarding/OnboardingItem.svelte
@@ -4,6 +4,9 @@ import type { OnboardingStepItem } from '../../../../main/src/plugin/api/onboard
 import Markdown from '../markdown/Markdown.svelte';
 import type { ContextUI } from '../context/context';
 import { SCOPE_ONBOARDING } from './onboarding-utils';
+import type { IConfigurationPropertyRecordedSchema } from '../../../../main/src/plugin/configuration-registry';
+import { configurationProperties } from '/@/stores/configurationProperties';
+import PreferencesRenderingItem from '../preferences/PreferencesRenderingItem.svelte';
 export let extension: string;
 export let item: OnboardingStepItem;
 export let getContext: () => ContextUI;
@@ -14,10 +17,25 @@ export let inProgressCommandExecution: (
 ) => void;
 
 const onboardingContextRegex = new RegExp(/\${onboardingContext:(.+?)}/g);
+const configurationRegex = new RegExp(/\${configuration:(.+?)}/g);
 const globalContextRegex = new RegExp(/\${onContext:(.+?)}/g);
 let html: string;
+$: html;
+let configurationItems: IConfigurationPropertyRecordedSchema[];
+let configurationItem: IConfigurationPropertyRecordedSchema | undefined;
+$: configurationItem;
 
 onMount(() => {
+  configurationProperties.subscribe(value => {
+    configurationItems = value;
+    const matches = [...item.value.matchAll(configurationRegex)];
+    if (matches.length > 0 && matches[0].length > 1) {
+      configurationItem = configurationItems.find(
+        config => !config.hidden && config.extension?.id === extension && config.id === matches[0][1],
+      );
+    }
+  });
+
   const itemHtml = replacePlaceholders(item.value);
   html = itemHtml;
 });
@@ -26,22 +44,25 @@ function replacePlaceholders(label: string): string {
   let newLabel = label;
   newLabel = replacePlaceHoldersRegex(onboardingContextRegex, newLabel, `${extension}.${SCOPE_ONBOARDING}`);
   newLabel = replacePlaceHoldersRegex(globalContextRegex, newLabel);
+  newLabel = replacePlaceHoldersRegex(configurationRegex, newLabel, undefined, '');
   return newLabel;
 }
 
-function replacePlaceHoldersRegex(regex: RegExp, label: string, prefix?: string) {
+function replacePlaceHoldersRegex(regex: RegExp, label: string, prefix?: string, replacement?: string) {
   const matches = [...label.matchAll(regex)];
   for (const match of matches) {
-    label = getNewValue(label, match, prefix);
+    label = getNewValue(label, match, prefix, replacement);
   }
   return label;
 }
 
-function getNewValue(label: string, matchArray: RegExpMatchArray, prefix?: string) {
+function getNewValue(label: string, matchArray: RegExpMatchArray, prefix?: string, replacement?: string) {
   if (matchArray.length > 1) {
     const key = prefix ? `${prefix}.${matchArray[1]}` : matchArray[1];
-    const replacement = getContext().getValue(key);
-    if (replacement) {
+    if (replacement === undefined) {
+      replacement = getContext().getValue(key);
+    }
+    if (replacement !== undefined) {
       return label.replace(matchArray[0], replacement.toString());
     }
   }
@@ -52,5 +73,10 @@ function getNewValue(label: string, matchArray: RegExpMatchArray, prefix?: strin
 <div class="flex justify-center {item.highlight ? 'bg-charcoal-600' : ''} p-3 m-2 rounded-md min-w-[500px]">
   {#if html}
     <Markdown inProgressMarkdownCommandExecutionCallback="{inProgressCommandExecution}">{html}</Markdown>
+  {/if}
+  {#if configurationItem}
+    <div class="min-w-[500px] bg-charcoal-600 rounded-md">
+      <PreferencesRenderingItem record="{configurationItem}" />
+    </div>
   {/if}
 </div>


### PR DESCRIPTION
### What does this PR do?

This PR adds the logic to render the component associated to a setting (as done in the preferences page e.g boolean type -> toggle) using the keyword `${configuration:<setting-name>}`.

An extension can only render the setting that it registers.

### Screenshot/screencast of this PR

This is an example using the binary-path setting (not included in this PR) to show the final result
the onboarding code is `"value": "${configuration:podman.binary.path}"`

![onboarding_setting](https://github.com/containers/podman-desktop/assets/49404737/32f33a32-552c-441f-a578-8a5d44f449ab)

### What issues does this PR fix or reference?

it resolves #3714 

### How to test this PR?

run tests
