### PR TITLE
fix: fix final onboarding redirection (#3702)

### DIFF
--- a/packages/renderer/src/lib/onboarding/Onboarding.svelte
+++ b/packages/renderer/src/lib/onboarding/Onboarding.svelte
@@ -18,6 +18,7 @@ import {
   STATUS_COMPLETED,
   STATUS_SKIPPED,
 } from './onboarding-utils';
+import { lastPage } from '/@/stores/breadcrumb';
 
 interface ActiveOnboardingStep {
   onboarding: OnboardingInfo;
@@ -118,7 +119,7 @@ async function setActiveStep() {
   }
 
   // if it reaches this point it means that the onboarding is fully completed and the user is redirected to the dashboard
-  router.goto('/');
+  router.goto($lastPage.path);
 }
 
 function normalize(when: string, extension: string): string {
@@ -231,7 +232,7 @@ async function cancelSetup() {
   // TODO: it cancels all running commands
   // it redirect the user to the dashboard
   await cleanContext();
-  router.goto('/');
+  router.goto($lastPage.path);
 }
 
 async function restartSetup() {

--- a/packages/renderer/src/lib/preferences/PreferencesPage.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesPage.svelte
@@ -83,7 +83,7 @@ onMount(async () => {
     <PreferencesInstallExtensionFromId extensionId="{meta.params.extensionId}" />
   </Route>
 
-  <Route path="/onboarding/:extensionId" breadcrumb="Extension Onboarding" let:meta>
+  <Route path="/onboarding/:extensionId" breadcrumb="Extension Onboarding" let:meta navigationHint="details">
     <Onboarding extensionIds="{[meta.params.extensionId]}" />
   </Route>
 


### PR DESCRIPTION
### What does this PR do?

N:B: this is built over #3680. I'll rebase it once that is merged.

this PR fixes the final redirection of the onboarding. Instead of using the fixed '/' it leverages the `$lastpage.path`.
So if it get started from the resources page, the user gets redirected back there. If the onboarding gets started when opening PD first time, the user gets redirected to the dashboard (lastPage would be '/')

### Screenshot/screencast of this PR

![redirect_last_page](https://github.com/containers/podman-desktop/assets/49404737/90d2c3c4-7b49-4b24-8ef3-13d84fadb33f)

### What issues does this PR fix or reference?

it resolves #3702 

### How to test this PR?

1. start the onboarding from the resources page. Cancel or complete it and see that you're redirected to the resources page
