### PR TITLE
feat: adding more control to context through when property

### DIFF
--- a/extensions/kind/package.json
+++ b/extensions/kind/package.json
@@ -48,12 +48,19 @@
           "scope": "KubernetesProviderConnectionFactory",
           "description": "Setup an ingress controller (Contour https://projectcontour.io)"
         },
+        "kind.cluster.creation.usingControlPlaneImage": {
+          "type": "boolean",
+          "default": false,
+          "scope": "KubernetesProviderConnectionFactory",
+          "description": "Using custom node’s container image."
+        },
         "kind.cluster.creation.controlPlaneImage": {
           "type": "string",
           "default": "",
           "scope": "KubernetesProviderConnectionFactory",
-          "placeholder": "Leave empty for using latest.",
-          "markdownDescription": "Node’s container image (Available image tags on [kind/releases](https://github.com/kubernetes-sigs/kind/releases))"
+          "placeholder": "e.g. kindest/node:v1.27.3@sha256:3966ac761ae",
+          "markdownDescription": "Node’s container image (Available image tags on [kind/releases](https://github.com/kubernetes-sigs/kind/releases))",
+          "when": "kind.cluster.creation.usingControlPlaneImage == true"
         }
       }
     },

--- a/extensions/kind/src/create-cluster.ts
+++ b/extensions/kind/src/create-cluster.ts
@@ -69,12 +69,14 @@ export async function connectionAuditor(provider: string, items: AuditRequestIte
     records: records,
   };
 
-  const image = items['kind.cluster.creation.controlPlaneImage'];
-  if (image && !image.includes('@sha256:')) {
-    records.push({
-      type: 'warning',
-      record: 'It is recommend to include the @sha256:{image digest} for the image used.',
-    });
+  if (items['kind.cluster.creation.usingControlPlaneImage']) {
+    const image = items['kind.cluster.creation.controlPlaneImage'];
+    if (image && !image.includes('@sha256:')) {
+      records.push({
+        type: 'warning',
+        record: 'It is recommend to include the @sha256:{image digest} for the image used.',
+      });
+    }
   }
 
   const providerSocket = extensionApi.provider
@@ -140,7 +142,10 @@ export async function createCluster(
   }
 
   // grab custom kind node image if defined
-  const controlPlaneImage = params['kind.cluster.creation.controlPlaneImage'];
+  let controlPlaneImage = undefined;
+  if (params['kind.cluster.creation.usingControlPlaneImage']) {
+    controlPlaneImage = params['kind.cluster.creation.controlPlaneImage'];
+  }
 
   // create the config file
   const kindClusterConfig = getKindClusterConfig(clusterName, httpHostPort, httpsHostPort, controlPlaneImage);

--- a/packages/renderer/src/lib/context/context.ts
+++ b/packages/renderer/src/lib/context/context.ts
@@ -30,6 +30,12 @@ export class ContextUI implements IContext {
     this._value = {};
   }
 
+  public static fromExisting(_value: Record<string, any>) {
+    const context = new ContextUI();
+    context._value = _value;
+    return context;
+  }
+
   get value(): Record<string, any> {
     return { ...this._value };
   }

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
@@ -1,15 +1,16 @@
 <script lang="ts">
-import { faXmark } from '@fortawesome/free-solid-svg-icons';
-import Fa from 'svelte-fa/src/fa.svelte';
 import type { IConfigurationPropertyRecordedSchema } from '../../../../main/src/plugin/configuration-registry';
 import { CONFIGURATION_DEFAULT_SCOPE } from '../../../../main/src/plugin/configuration-registry-constants';
 import ErrorMessage from '../ui/ErrorMessage.svelte';
 import Markdown from '../markdown/Markdown.svelte';
 import { getNormalizedDefaultNumberValue } from './Util';
-import Tooltip from '../ui/Tooltip.svelte';
-import Button from '../ui/Button.svelte';
+import BooleanItem from '/@/lib/preferences/item-formats/BooleanItem.svelte';
+import SliderItem from '/@/lib/preferences/item-formats/SliderItem.svelte';
+import NumberItem from '/@/lib/preferences/item-formats/NumberItem.svelte';
+import FileItem from '/@/lib/preferences/item-formats/FileItem.svelte';
+import EnumItem from '/@/lib/preferences/item-formats/EnumItem.svelte';
+import StringItem from '/@/lib/preferences/item-formats/StringItem.svelte';
 
-let invalidEntry = false;
 let invalidText = undefined;
 export let invalidRecord = (_error: string) => {};
 export let validRecord = () => {};
@@ -22,7 +23,6 @@ export let enableSlider = false;
 export let record: IConfigurationPropertyRecordedSchema;
 
 let currentRecord: IConfigurationPropertyRecordedSchema;
-let recordUpdateTimeout: NodeJS.Timeout;
 
 let recordValue: any;
 $: recordValue;
@@ -54,57 +54,9 @@ $: if (currentRecord !== record) {
   }
 
   currentRecord = record;
-  invalidText = undefined;
-  invalidEntry = false;
-}
-
-function invalid() {
-  // call the callback
-  invalidRecord(invalidText);
-}
-
-function valid() {
-  validRecord();
-}
-
-function checkValue(record: IConfigurationPropertyRecordedSchema, event: any) {
-  clearTimeout(recordUpdateTimeout);
-  const userValue = event.target.value;
-  if (record.type === 'number') {
-    const numberValue = parseFloat(userValue);
-    if (userValue === '') {
-      invalidEntry = true;
-      invalidText = 'Expecting a number';
-      return invalid();
-    }
-    if (isNaN(numberValue)) {
-      invalidEntry = true;
-      invalidText = `${userValue} is not a number`;
-      return invalid();
-    }
-
-    // check range
-    if (record.minimum && numberValue < record.minimum) {
-      invalidEntry = true;
-      invalidText = 'Minimun value is ' + record.minimum;
-      return invalid();
-    }
-    if (record.maximum && typeof record.maximum === 'number' && numberValue > record.maximum) {
-      invalidEntry = true;
-      invalidText = 'Maximum value is ' + record.maximum;
-      return invalid();
-    }
-  }
-  valid();
-  autoSave();
-  invalidEntry = false;
-  invalidText = undefined;
 }
 
 function update(record: IConfigurationPropertyRecordedSchema) {
-  // reset invalid
-  invalidEntry = false;
-
   let value: any = recordValue;
   if (record.type === 'number') {
     value = parseFloat(value);
@@ -116,54 +68,9 @@ function update(record: IConfigurationPropertyRecordedSchema) {
   try {
     window.updateConfigurationValue(record.id, value, record.scope);
   } catch (error) {
-    invalidEntry = true;
     invalidText = error;
+    invalidRecord(error);
   }
-}
-
-async function selectFilePath() {
-  clearTimeout(recordUpdateTimeout);
-  const result = await window.openFileDialog(`Select ${record.description}`);
-  if (!result.canceled && result.filePaths.length === 1) {
-    recordValue = result.filePaths[0];
-    autoSave();
-  }
-}
-
-function decrement(
-  e: MouseEvent & {
-    currentTarget: EventTarget & HTMLButtonElement;
-  },
-  record: IConfigurationPropertyRecordedSchema,
-) {
-  clearTimeout(recordUpdateTimeout);
-  const target = getCurrentNumericInputElement(e.currentTarget);
-  let value = Number(target.value);
-  if (canDecrement(value, record.minimum)) {
-    value--;
-    recordValue = value;
-    autoSave();
-  }
-  assertNumericValueIsValid(value);
-  e.preventDefault();
-}
-
-function increment(
-  e: MouseEvent & {
-    currentTarget: EventTarget & HTMLButtonElement;
-  },
-  record: IConfigurationPropertyRecordedSchema,
-) {
-  clearTimeout(recordUpdateTimeout);
-  const target = getCurrentNumericInputElement(e.currentTarget);
-  let value = Number(target.value);
-  if (canIncrement(value, record.maximum)) {
-    value++;
-    recordValue = value;
-    autoSave();
-  }
-  assertNumericValueIsValid(value);
-  e.preventDefault();
 }
 
 function autoSave() {
@@ -172,207 +79,46 @@ function autoSave() {
   }
 }
 
-function getCurrentNumericInputElement(e: HTMLButtonElement) {
-  const btn = e.parentNode.parentElement.querySelector('button[data-action="decrement"]');
-  return btn.nextElementSibling.firstElementChild.firstElementChild as unknown as HTMLInputElement;
-}
+function onChange(recordId: string, value: boolean | string | number) {
+  console.log(recordId, value, typeof value);
+  recordValue = value;
 
-function canDecrement(value: number | string, minimumValue?: number) {
-  if (typeof value === 'string') {
-    value = Number(value);
+  switch (typeof value) {
+    case 'boolean':
+      break;
+    case 'number':
+      break;
+    case 'string':
+      setRecordValue(recordId, value);
+      break;
   }
-  return !minimumValue || value > minimumValue;
-}
 
-function canIncrement(value: number | string, maximumValue?: number | string) {
-  if (typeof value === 'string') {
-    value = Number(value);
-  }
-  return !maximumValue || (typeof maximumValue === 'number' && value < maximumValue);
-}
-
-function handleRangeValue(id: string, target: HTMLInputElement) {
-  setRecordValue(id, target.value);
-}
-
-function handleCleanValue(
-  event: MouseEvent & {
-    currentTarget: EventTarget & HTMLButtonElement;
-  },
-) {
-  recordValue = '';
-  event.preventDefault();
-}
-
-let numberInputInvalid = false;
-let numberInputErrorMessage = '';
-function onNumberInputKeyPress(event: any) {
-  // if the key is not a number skip it
-  if (isNaN(Number(event.key))) {
-    event.preventDefault();
-  }
-}
-
-function onNumberInputChange(event: any) {
-  if (event.target.value === '') {
-    numberInputInvalid = true;
-    numberInputErrorMessage = `The value cannot be less than ${record.minimum}${
-      record.maximum ? ` or greater than ${record.maximum}` : ''
-    }`;
-    clearTimeout(recordUpdateTimeout);
-    return;
-  }
-  // if the resulting value is greater than the maximum or less than the minimum skip it
-  const resultingValue = Number(event.target.value);
-  if (assertNumericValueIsValid(resultingValue)) {
-    autoSave();
-  }
-}
-
-function assertNumericValueIsValid(value: number) {
-  if (record.maximum && typeof record.maximum === 'number' && value > record.maximum) {
-    numberInputInvalid = true;
-    numberInputErrorMessage = `The value cannot be greater than ${record.maximum}`;
-    clearTimeout(recordUpdateTimeout);
-    return false;
-  }
-  if (record.minimum && typeof record.minimum === 'number' && value < record.minimum) {
-    numberInputInvalid = true;
-    numberInputErrorMessage = `The value cannot be less than ${record.minimum}`;
-    clearTimeout(recordUpdateTimeout);
-    return false;
-  }
-  numberInputErrorMessage = '';
-  numberInputInvalid = false;
-  return true;
+  validRecord();
+  autoSave();
 }
 </script>
 
 <div class="flex flex-row mb-1 pt-2">
   <div class="flex flex-col text-start w-full justify-center items-start">
     {#if record.type === 'boolean'}
-      <label class="relative inline-flex items-center cursor-pointer">
-        <span class="text-xs {checkboxValue ? 'text-white' : 'text-gray-700'} mr-3"
-          >{checkboxValue ? 'Enabled' : 'Disabled'}</span>
-        <input
-          on:input="{event => {
-            recordValue = !checkboxValue;
-            checkValue(record, event);
-          }}"
-          class="sr-only peer"
-          bind:checked="{checkboxValue}"
-          name="{record.id}"
-          type="checkbox"
-          readonly="{!!record.readonly}"
-          id="input-standard-{record.id}"
-          aria-invalid="{invalidEntry}"
-          aria-label="{record.description || record.markdownDescription}" />
-        <div
-          class="w-8 h-[20px] bg-gray-900 rounded-full peer peer-checked:after:translate-x-full after:bg-charcoal-600 after:content-[''] after:absolute after:top-[4px] after:left-[61px] after:rounded-full after:h-3 after:w-3 after:transition-all peer-checked:bg-violet-600">
-        </div>
-      </label>
+      <BooleanItem record="{record}" checked="{checkboxValue}" onChange="{onChange}" />
     {:else if enableSlider && record.type === 'number' && typeof record.maximum === 'number'}
-      <input
-        id="input-slider-{record.id}"
-        type="range"
-        name="{record.id}"
-        min="{record.minimum}"
-        max="{record.maximum}"
-        value="{getNormalizedDefaultNumberValue(record)}"
-        aria-label="{record.description}"
-        on:input="{event => handleRangeValue(record.id, event.currentTarget)}"
-        class="w-full h-1 bg-[var(--pf-global--primary-color--300)] rounded-lg appearance-none accent-[var(--pf-global--primary-color--300)] cursor-pointer range-xs mt-2" />
+      <SliderItem record="{record}" value="{getNormalizedDefaultNumberValue(record)}" onChange="{onChange}" />
     {:else if record.type === 'number'}
-      <div
-        class="flex flex-row rounded-sm bg-zinc-700 text-sm divide-x divide-charcoal-800 w-24 border-b"
-        class:border-violet-500="{!numberInputInvalid}"
-        class:border-red-500="{numberInputInvalid}">
-        <button
-          data-action="decrement"
-          on:click="{e => decrement(e, record)}"
-          disabled="{!canDecrement(recordValue, record.minimum)}"
-          class="w-11 text-white {!canDecrement(recordValue, record.minimum)
-            ? 'bg-charcoal-600 text-charcoal-100 border-t border-l border-charcoal-800'
-            : 'hover:text-gray-900 hover:bg-gray-700'} cursor-pointer outline-none">
-          <span class="m-auto font-thin">−</span>
-        </button>
-        <Tooltip topLeft tip="{numberInputErrorMessage}">
-          <input
-            type="text"
-            class="w-[50px] outline-none focus:outline-none text-center text-white text-sm py-0.5"
-            name="{record.id}"
-            bind:value="{recordValue}"
-            on:keypress="{event => onNumberInputKeyPress(event)}"
-            on:input="{event => onNumberInputChange(event)}"
-            aria-label="{record.description}" />
-        </Tooltip>
-        <button
-          data-action="increment"
-          on:click="{e => increment(e, record)}"
-          disabled="{!canIncrement(recordValue, record.maximum)}"
-          class="w-11 text-white {!canIncrement(recordValue, record.maximum)
-            ? 'bg-charcoal-600 text-charcoal-100 border-t border-l border-charcoal-800'
-            : 'hover:text-gray-900 hover:bg-gray-700'} cursor-pointer outline-none">
-          <span class="m-auto font-thin">+</span>
-        </button>
-      </div>
+      <NumberItem record="{record}" value="{recordValue}" onChange="{onChange}" invalidRecord="{invalidRecord}" />
     {:else if record.type === 'string' && record.format === 'file'}
-      <div class="w-full flex">
-        <input
-          class="grow {!recordValue ? 'mr-3' : ''} py-1 px-2 outline-0 text-sm placeholder-gray-900"
-          name="{record.id}"
-          readonly
-          type="text"
-          placeholder="{record.placeholder}"
-          value="{recordValue || ''}"
-          id="input-standard-{record.id}"
-          aria-invalid="{invalidEntry}"
-          aria-label="{record.description}" />
-        <button
-          class="relative cursor-pointer right-5"
-          class:hidden="{!recordValue}"
-          aria-label="clear"
-          on:click="{event => handleCleanValue(event)}">
-          <Fa icon="{faXmark}" />
-        </button>
-        <Button
-          on:click="{() => selectFilePath()}"
-          id="rendering.FilePath.{record.id}"
-          aria-invalid="{invalidEntry}"
-          aria-label="button-{record.description}">Browse ...</Button>
-      </div>
+      <FileItem record="{record}" value="{recordValue}" onChange="{onChange}" />
     {:else if record.type === 'string' && record.enum && record.enum.length > 0}
-      <select
-        class="border-b block w-full p-1 bg-zinc-700 border-violet-500 text-white text-sm checked:bg-violet-50"
-        name="{record.id}"
-        id="input-standard-{record.id}"
-        on:input="{event => checkValue(record, event)}"
-        bind:value="{recordValue}"
-        aria-invalid="{invalidEntry}"
-        aria-label="{record.description}">
-        {#each record.enum as recordEnum}
-          <option value="{recordEnum}">{recordEnum}</option>
-        {/each}
-      </select>
+      <EnumItem record="{record}" value="{recordValue}" onChange="{onChange}" />
     {:else if record.type === 'markdown'}
       <div class="text-sm">
         <Markdown>{record.markdownDescription}</Markdown>
       </div>
     {:else}
-      <input
-        on:input="{event => checkValue(record, event)}"
-        class="grow py-1 px-2 w-full outline-0 border-b-2 border-gray-800 hover:border-violet-500 focus:border-violet-500 placeholder-gray-900"
-        name="{record.id}"
-        type="text"
-        placeholder="{record.placeholder}"
-        bind:value="{recordValue}"
-        readonly="{!!record.readonly}"
-        id="input-standard-{record.id}"
-        aria-invalid="{invalidEntry}"
-        aria-label="{record.description}" />
+      <StringItem record="{record}" value="{recordValue}" onChange="{onChange}" />
     {/if}
 
-    {#if invalidEntry}
+    {#if invalidText}
       <ErrorMessage error="{invalidText}." />
     {/if}
   </div>

--- a/packages/renderer/src/lib/preferences/Util.ts
+++ b/packages/renderer/src/lib/preferences/Util.ts
@@ -91,3 +91,8 @@ export function getNormalizedDefaultNumberValue(configurationKey: IConfiguration
   }
   return configurationKey.maximum;
 }
+
+export function uncertainStringToNumber(value: string | number): number {
+  if (typeof value === 'number') return value;
+  return parseFloat(value);
+}

--- a/packages/renderer/src/lib/preferences/item-formats/BooleanItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/BooleanItem.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+import type { IConfigurationPropertyRecordedSchema } from '../../../../../main/src/plugin/configuration-registry';
+
+export let record: IConfigurationPropertyRecordedSchema;
+export let checked = false;
+export let onChange = (_id: string, _value: boolean) => {};
+
+function onInput(event: Event) {
+  const target = event.target as HTMLInputElement;
+  if (target.checked !== checked) onChange(record.id, target.checked);
+}
+</script>
+
+<label class="relative inline-flex items-center cursor-pointer">
+  <span class="text-xs {checked ? 'text-white' : 'text-gray-700'} mr-3">{checked ? 'Enabled' : 'Disabled'}</span>
+  <input
+    on:input="{onInput}"
+    class="sr-only peer"
+    bind:checked="{checked}"
+    name="{record.id}"
+    type="checkbox"
+    readonly="{!!record.readonly}"
+    id="input-standard-{record.id}"
+    aria-label="{record.description || record.markdownDescription}" />
+  <div
+    class="w-8 h-[20px] bg-gray-900 rounded-full peer peer-checked:after:translate-x-full after:bg-charcoal-600 after:content-[''] after:absolute after:top-[4px] after:left-[61px] after:rounded-full after:h-3 after:w-3 after:transition-all peer-checked:bg-violet-600">
+  </div>
+</label>

--- a/packages/renderer/src/lib/preferences/item-formats/EnumItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/EnumItem.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+import type { IConfigurationPropertyRecordedSchema } from '../../../../../main/src/plugin/configuration-registry';
+export let record: IConfigurationPropertyRecordedSchema;
+export let value: string | undefined;
+export let onChange = (_id: string, _value: string) => {};
+
+function onInput(event: Event) {
+  const target = event.target as HTMLInputElement;
+  console.log(event);
+  if (target.value !== value) onChange(record.id, target.value);
+}
+</script>
+
+<select
+  class="border-b block w-full p-1 bg-zinc-700 border-violet-500 text-white text-sm checked:bg-violet-50"
+  name="{record.id}"
+  id="input-standard-{record.id}"
+  on:input="{onInput}"
+  bind:value="{value}"
+  aria-label="{record.description}">
+  {#each record.enum as recordEnum}
+    <option value="{recordEnum}">{recordEnum}</option>
+  {/each}
+</select>

--- a/packages/renderer/src/lib/preferences/item-formats/FileItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/FileItem.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+import type { IConfigurationPropertyRecordedSchema } from '../../../../../main/src/plugin/configuration-registry';
+import Fa from 'svelte-fa/src/fa.svelte';
+import { faXmark } from '@fortawesome/free-solid-svg-icons';
+import Button from '../../ui/Button.svelte';
+export let record: IConfigurationPropertyRecordedSchema;
+export let value: string | undefined;
+export let onChange = (_id: string, _value: string) => {};
+async function selectFilePath() {
+  const result = await window.openFileDialog(`Select ${record.description}`);
+  if (!result.canceled && result.filePaths.length === 1) {
+    onChange(record.id, result.filePaths[0]);
+  }
+}
+
+function handleCleanValue(
+  event: MouseEvent & {
+    currentTarget: EventTarget & HTMLButtonElement;
+  },
+) {
+  onChange(record.id, '');
+  event.preventDefault();
+}
+</script>
+
+<div class="w-full flex">
+  <input
+    class="grow {!value ? 'mr-3' : ''} py-1 px-2 outline-0 text-sm placeholder-gray-900"
+    name="{record.id}"
+    readonly
+    type="text"
+    placeholder="{record.placeholder}"
+    value="{value}"
+    id="input-standard-{record.id}"
+    aria-label="{record.description}" />
+  <button
+    class="relative cursor-pointer right-5"
+    class:hidden="{!value}"
+    aria-label="clear"
+    on:click="{event => handleCleanValue(event)}">
+    <Fa icon="{faXmark}" />
+  </button>
+  <Button
+    on:click="{() => selectFilePath()}"
+    id="rendering.FilePath.{record.id}"
+    aria-label="button-{record.description}">Browse ...</Button>
+</div>

--- a/packages/renderer/src/lib/preferences/item-formats/NumberItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/item-formats/NumberItem.spec.ts
@@ -1,0 +1,29 @@
+import '@testing-library/jest-dom/vitest';
+import { test, expect, vi, beforeAll } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import type { IConfigurationPropertyRecordedSchema } from '../../../../../main/src/plugin/configuration-registry';
+import NumberItem from './NumberItem.svelte';
+
+beforeAll(() => {
+  (window as any).getConfigurationValue = vi.fn();
+});
+
+test('Expect tooltip if NaN provided as value', async () => {
+  const record: IConfigurationPropertyRecordedSchema = {
+    id: 'record',
+    title: 'record',
+    parentId: 'parent.record',
+    description: 'record-description',
+    type: 'number',
+    minimum: 1,
+    maximum: 34,
+  };
+  const value = NaN;
+  render(NumberItem, { record, value });
+  const input = screen.getByLabelText('record-description');
+  expect(input).toBeInTheDocument();
+
+  const tooltip = screen.getByLabelText('tooltip');
+  expect(tooltip).toBeInTheDocument();
+  expect(tooltip.textContent).toBe('Expecting a number');
+});

--- a/packages/renderer/src/lib/preferences/item-formats/NumberItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/NumberItem.svelte
@@ -1,0 +1,116 @@
+<script lang="ts">
+import type { IConfigurationPropertyRecordedSchema } from '../../../../../main/src/plugin/configuration-registry';
+import Tooltip from '/@/lib/ui/Tooltip.svelte';
+import { uncertainStringToNumber } from '../Util';
+
+export let record: IConfigurationPropertyRecordedSchema;
+export let value: number;
+export let onChange = (_id: string, _value: number) => {};
+export let invalidRecord = (_error: string) => {};
+
+let numberInputInvalid = false;
+let numberInputErrorMessage = '';
+
+function onInput(event: Event) {
+  numberInputInvalid = false;
+  const target = event.currentTarget as HTMLInputElement;
+
+  const _value: number = uncertainStringToNumber(target.value);
+  if (!assertNumericValueIsValid(_value)) {
+    invalidRecord(numberInputErrorMessage);
+    return;
+  }
+
+  if (_value !== value) {
+    onChange(record.id, _value);
+  }
+}
+
+function onNumberInputKeyPress(event: any) {
+  // if the key is not a number skip it
+  if (isNaN(Number(event.key))) {
+    event.preventDefault();
+  }
+}
+
+function onDecrement(
+  e: MouseEvent & {
+    currentTarget: EventTarget & HTMLButtonElement;
+  },
+) {
+  onChange(record.id, value - 1);
+  e.preventDefault();
+}
+
+function onIncrement(
+  e: MouseEvent & {
+    currentTarget: EventTarget & HTMLButtonElement;
+  },
+) {
+  onChange(record.id, value + 1);
+  e.preventDefault();
+}
+
+function canDecrement(minimumValue?: number) {
+  return !minimumValue || value > minimumValue;
+}
+
+function assertNumericValueIsValid(value: number) {
+  if (isNaN(value)) {
+    numberInputInvalid = true;
+    numberInputErrorMessage = 'Expecting a number';
+    return false;
+  }
+
+  if (record.maximum && typeof record.maximum === 'number' && value > record.maximum) {
+    numberInputInvalid = true;
+    numberInputErrorMessage = `The value cannot be greater than ${record.maximum}`;
+    return false;
+  }
+  if (record.minimum && typeof record.minimum === 'number' && value < record.minimum) {
+    numberInputInvalid = true;
+    numberInputErrorMessage = `The value cannot be less than ${record.minimum}`;
+    return false;
+  }
+  numberInputErrorMessage = '';
+  numberInputInvalid = false;
+  return true;
+}
+function canIncrement(maximumValue?: number | string) {
+  return !maximumValue || (typeof maximumValue === 'number' && value < maximumValue);
+}
+</script>
+
+<div
+  class="flex flex-row rounded-sm bg-zinc-700 text-sm divide-x divide-charcoal-800 w-24 border-b"
+  class:border-violet-500="{!numberInputInvalid}"
+  class:border-red-500="{numberInputInvalid}">
+  <button
+    data-action="decrement"
+    on:click="{onDecrement}"
+    disabled="{!canDecrement(record.minimum)}"
+    class="w-11 text-white {!canDecrement(record.minimum)
+      ? 'bg-charcoal-600 text-charcoal-100 border-t border-l border-charcoal-800'
+      : 'hover:text-gray-900 hover:bg-gray-700'} cursor-pointer outline-none">
+    <span class="m-auto font-thin">−</span>
+  </button>
+  <Tooltip topLeft tip="{numberInputErrorMessage}">
+    <input
+      type="text"
+      class="w-[50px] outline-none focus:outline-none text-center text-white text-sm py-0.5"
+      name="{record.id}"
+      bind:value="{value}"
+      on:keypress="{event => onNumberInputKeyPress(event)}"
+      on:input="{onInput}"
+      aria-label="{record.description}" />
+  </Tooltip>
+  <button
+    data-action="increment"
+    on:click="{onIncrement}"
+    disabled="{!canIncrement(record.maximum)}"
+    class="w-11 text-white {!canIncrement(record.maximum)
+      ? 'bg-charcoal-600 text-charcoal-100 border-t border-l border-charcoal-800'
+      : 'hover:text-gray-900 hover:bg-gray-700'} cursor-pointer outline-none">
+    <span class="m-auto font-thin">+</span>
+  </button>
+</div>

--- a/packages/renderer/src/lib/preferences/item-formats/NumberItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/NumberItem.svelte
@@ -2,17 +2,22 @@
 import type { IConfigurationPropertyRecordedSchema } from '../../../../../main/src/plugin/configuration-registry';
 import Tooltip from '/@/lib/ui/Tooltip.svelte';
 import { uncertainStringToNumber } from '../Util';
+import { onMount } from 'svelte';
 
 export let record: IConfigurationPropertyRecordedSchema;
 export let value: number;
 export let onChange = (_id: string, _value: number) => {};
 export let invalidRecord = (_error: string) => {};
 
-let numberInputInvalid = false;
 let numberInputErrorMessage = '';
+let numberInputInvalid = false;
+
+onMount(async () => {
+  assertNumericValueIsValid(value);
+});
 
 function onInput(event: Event) {
-  numberInputInvalid = false;
+  validRecord();
   const target = event.currentTarget as HTMLInputElement;
 
   const _value: number = uncertainStringToNumber(target.value);
@@ -24,6 +29,14 @@ function onInput(event: Event) {
   if (_value !== value) {
     onChange(record.id, _value);
   }
+}
+
+function validRecord() {
+  if (numberInputInvalid) {
+    value = 0;
+  }
+  numberInputInvalid = false;
+  numberInputErrorMessage = '';
 }
 
 function onNumberInputKeyPress(event: any) {
@@ -38,6 +51,7 @@ function onDecrement(
     currentTarget: EventTarget & HTMLButtonElement;
   },
 ) {
+  validRecord();
   onChange(record.id, value - 1);
   e.preventDefault();
 }
@@ -47,6 +61,7 @@ function onIncrement(
     currentTarget: EventTarget & HTMLButtonElement;
   },
 ) {
+  validRecord();
   onChange(record.id, value + 1);
   e.preventDefault();
 }

--- a/packages/renderer/src/lib/preferences/item-formats/SliderItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/SliderItem.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+import type { IConfigurationPropertyRecordedSchema } from '../../../../../main/src/plugin/configuration-registry';
+import { uncertainStringToNumber } from '../Util';
+
+export let record: IConfigurationPropertyRecordedSchema;
+export let value: number = uncertainStringToNumber(record.maximum);
+export let onChange = (_id: string, _value: number) => {};
+
+function onInput(event: Event) {
+  const target = event.currentTarget as HTMLInputElement;
+  const _value = uncertainStringToNumber(target.value);
+  if (_value !== value) onChange(record.id, _value);
+}
+</script>
+
+<input
+  id="input-slider-{record.id}"
+  type="range"
+  name="{record.id}"
+  min="{record.minimum}"
+  max="{record.maximum}"
+  value="{value}"
+  aria-label="{record.description}"
+  on:input="{onInput}"
+  class="w-full h-1 bg-[var(--pf-global--primary-color--300)] rounded-lg appearance-none accent-[var(--pf-global--primary-color--300)] cursor-pointer range-xs mt-2" />

--- a/packages/renderer/src/lib/preferences/item-formats/StringItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/StringItem.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+import type { IConfigurationPropertyRecordedSchema } from '../../../../../main/src/plugin/configuration-registry';
+export let record: IConfigurationPropertyRecordedSchema;
+export let value: string | undefined;
+export let onChange = (_id: string, _value: string) => {};
+
+function onInput(event: Event) {
+  const target = event.target as HTMLInputElement;
+  if (target.value !== value) onChange(record.id, value);
+}
+</script>
+
+<input
+  on:input="{onInput}"
+  class="grow py-1 px-2 w-full outline-0 border-b-2 border-gray-800 hover:border-violet-500 focus:border-violet-500 placeholder-gray-900"
+  name="{record.id}"
+  type="text"
+  placeholder="{record.placeholder}"
+  bind:value="{value}"
+  readonly="{!!record.readonly}"
+  id="input-standard-{record.id}"
+  aria-label="{record.description}" />


### PR DESCRIPTION
### What does this PR do?

The `when` property defined in [IConfigurationPropertySchema](https://github.com/containers/podman-desktop/blob/398a19c083a5153ad0982cd37c5ceacac65a6375/packages/main/src/plugin/configuration-registry.ts#L51) allows to set condition on the visibility of an item. But in the current implementation, it only include the global context, and not the context it is in (the values of the other field in the form it is in).

The goal is to allow conditional visibility based on other option. To demonstrate this, I added in the `package.json` of the kind extension a switch, and a when condition on it, showing or not a field.

### Screenshot/screencast of this PR

| Switch off | Switch on |
| --- | --- |
| <img width="393" alt="image" src="https://github.com/containers/podman-desktop/assets/42176370/83a4cb4c-e391-482a-972b-b432bcc869c1"> |  <img width="400" alt="image" src="https://github.com/containers/podman-desktop/assets/42176370/6f9df1ae-ddcc-4e05-be8e-1d93083ecf61"> |

### Changes

This PR include a refactoring of the [PreferencesRenderingItemFormat.svelte](https://github.com/containers/podman-desktop/blob/main/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte) 

- It includes separate component for each input type allowed (`string`, `boolean`, `enum`, range` and `number`)
> This allow more control on each type, and simplify the understanding of the file.

- The `when` was only checked once, in `onMount`, now it is check dynamically every time a field is updated.

### How to test this PR?

<!-- Please explain steps to reproduce -->
