### PR TITLE
chore: allow to receive end/error event for container's terminal

### DIFF
--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -1305,6 +1305,8 @@ export class ContainerProviderRegistry {
     engineId: string,
     id: string,
     onData: (data: Buffer) => void,
+    onError: (error: string) => void,
+    onEnd: () => void,
   ): Promise<(param: string) => void> {
     let telemetryOptions = {};
     try {
@@ -1324,6 +1326,14 @@ export class ContainerProviderRegistry {
 
       execStream.on('data', chunk => {
         onData(chunk.toString('utf-8'));
+      });
+
+      execStream.on('error', err => {
+        onError(err.toString());
+      });
+
+      execStream.on('end', () => {
+        onEnd();
       });
 
       return (param: string) => {

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -996,6 +996,14 @@ export class PluginSystem {
           (content: Buffer) => {
             this.getWebContentsSender().send('container-provider-registry:shellInContainer-onData', onDataId, content);
           },
+          (error: string) => {
+            this.getWebContentsSender().send('container-provider-registry:shellInContainer-onError', onDataId, error);
+          },
+          () => {
+            this.getWebContentsSender().send('container-provider-registry:shellInContainer-onEnd', onDataId);
+            // delete the callback
+            containerProviderRegistryShellInContainerSendCallback.delete(onDataId);
+          },
         );
         // store the callback
         containerProviderRegistryShellInContainerSendCallback.set(onDataId, shellInContainerInvocation);

--- a/packages/renderer/src/lib/container/ContainerDetailsTerminal.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetailsTerminal.svelte
@@ -32,7 +32,13 @@ async function executeShellIntoContainer() {
   }
 
   // grab logs of the container
-  const sendCallbackId = await window.shellInContainer(container.engineId, container.id, receiveCallback);
+  const sendCallbackId = await window.shellInContainer(
+    container.engineId,
+    container.id,
+    receiveCallback,
+    () => {},
+    () => {},
+  );
 
   // pass data from xterm to container
   shellTerminal?.onData(data => {


### PR DESCRIPTION
### What does this PR do?
let clients being notified if an error or connection to the shell is dropped

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast 
explaining what is doing this PR -->

### What issues does this PR fix or reference?

related to https://github.com/containers/podman-desktop/issues/502


### How to test this PR?

no changes in the behaviour for now

it's used/tested by https://github.com/containers/podman-desktop/pull/3725