### PR TITLE
feat(terminal): session to the terminal is reused

### DIFF
--- a/packages/renderer/src/lib/container/ContainerDetailsTerminal.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerDetailsTerminal.spec.ts
@@ -1,0 +1,100 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+import { test, expect, vi, beforeAll } from 'vitest';
+import { render, waitFor } from '@testing-library/svelte';
+import ContainerDetailsTerminal from './ContainerDetailsTerminal.svelte';
+import type { ContainerInfoUI } from './ContainerInfoUI';
+import { get } from 'svelte/store';
+import { containerTerminals } from '/@/stores/container-terminal-store';
+
+const getConfigurationValueMock = vi.fn();
+const shellInContainerMock = vi.fn();
+
+beforeAll(() => {
+  (window as any).getConfigurationValue = getConfigurationValueMock;
+  (window as any).shellInContainer = shellInContainerMock;
+
+  (window as any).matchMedia = vi.fn().mockReturnValue({
+    addListener: vi.fn(),
+  });
+});
+
+test('expect being able to reconnect ', async () => {
+  const container: ContainerInfoUI = {
+    id: 'myContainer',
+    state: 'RUNNING',
+    engineId: 'podman',
+  } as unknown as ContainerInfoUI;
+
+  let onDataCallback: (data: Buffer) => void = () => {};
+
+  const sendCallbackId = 12345;
+  shellInContainerMock.mockImplementation(
+    (
+      _engineId: string,
+      _containerId: string,
+      onData: (data: Buffer) => void,
+      _onError: (error: string) => void,
+      _onEnd: () => void,
+    ) => {
+      onDataCallback = onData;
+      // return a callback id
+      return sendCallbackId;
+    },
+  );
+
+  // render the component with a terminal
+  const renderObject = render(ContainerDetailsTerminal, { container, screenReaderMode: true });
+
+  // wait shellInContainerMock is called
+  await waitFor(() => expect(shellInContainerMock).toHaveBeenCalled());
+
+  // write some data on the terminal
+  onDataCallback(Buffer.from('hello\nworld'));
+
+  // wait 1s
+  await new Promise(resolve => setTimeout(resolve, 1000));
+
+  // search a div having aria-live="assertive" attribute
+  const terminalLinesLiveRegion = renderObject.container.querySelector('div[aria-live="assertive"]');
+
+  // check the content
+  expect(terminalLinesLiveRegion).toHaveTextContent('hello world');
+
+  // should be no terminal being stored
+  const terminals = get(containerTerminals);
+  expect(terminals.length).toBe(0);
+
+  // destroy the object
+  renderObject.component.$destroy();
+
+  // now, check that we have a terminal that is in the store
+  const terminalsAfterDestroy = get(containerTerminals);
+  expect(terminalsAfterDestroy.length).toBe(1);
+
+  // ok, now render a new terminal widget, it should reuse data from the store
+  render(ContainerDetailsTerminal, { container, screenReaderMode: true });
+
+  // wait 1s that everything is done
+  await new Promise(resolve => setTimeout(resolve, 1000));
+
+  // no new call to shellInContainerMock should be done
+  expect(shellInContainerMock).toHaveBeenCalledTimes(1);
+});

--- a/packages/renderer/src/stores/container-terminal-store.spec.ts
+++ b/packages/renderer/src/stores/container-terminal-store.spec.ts
@@ -1,0 +1,55 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { get } from 'svelte/store';
+import { beforeAll, expect, test, vi } from 'vitest';
+import { containerTerminals, getExistingTerminal, registerTerminal } from './container-terminal-store';
+import { containersInfos } from './containers';
+
+beforeAll(() => {
+  vi.clearAllMocks();
+});
+
+test('get a terminal', async () => {
+  // register a new terminal
+  registerTerminal({ engineId: 'podman', containerId: 'container1', callbackId: 1, terminal: {} as any });
+
+  // try to grab the terminal
+  const terminal1 = getExistingTerminal('podman', 'container1');
+  expect(terminal1).toBeDefined();
+
+  // try to grab an unexisting terminal
+  const terminal2 = getExistingTerminal('podman', 'container2');
+  expect(terminal2).toBeUndefined();
+});
+
+test('terminals should be updated in case of a matching container is removed', async () => {
+  // set list of terminals
+  registerTerminal({ engineId: 'podman', containerId: 'container1', callbackId: 1, terminal: {} as any });
+
+  // now, assume we don't have anymore containers
+  containersInfos.set([]);
+
+  // grab again the list of terminals
+  const updatedTerminals = get(containerTerminals);
+
+  // check that the terminal has been removed
+  expect(updatedTerminals.length).toBe(0);
+});

--- a/packages/renderer/src/stores/container-terminal-store.ts
+++ b/packages/renderer/src/stores/container-terminal-store.ts
@@ -1,0 +1,78 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { Writable } from 'svelte/store';
+import { get, writable } from 'svelte/store';
+import type { Terminal } from 'xterm';
+import { containersInfos } from './containers';
+
+// keep data of a terminal bound to a container
+export interface TerminalOfContainer {
+  // engine id of the container
+  engineId: string;
+
+  // container's id
+  containerId: string;
+
+  // id of the callbacks
+  callbackId?: number;
+
+  terminal: Terminal;
+}
+
+/**
+ * Defines the store used to have terminals inside containers
+ */
+export const containerTerminals: Writable<TerminalOfContainer[]> = writable([]);
+
+containersInfos.subscribe(containers => {
+  // search if we have a matching container from the list of terminals
+  const terminals = get(containerTerminals);
+  const toRemove: TerminalOfContainer[] = [];
+  terminals.forEach(terminal => {
+    const found = containers.find(
+      container => container.Id === terminal.containerId && container.engineId === terminal.engineId,
+    );
+    if (!found) {
+      toRemove.push(terminal);
+    }
+  });
+
+  // remove the terminals that are not matching anymore
+  toRemove.forEach(terminal => {
+    containerTerminals.update(terminals => {
+      const index = terminals.indexOf(terminal);
+      if (index > -1) {
+        terminals.splice(index, 1);
+      }
+      return terminals;
+    });
+  });
+});
+
+export function registerTerminal(terminal: TerminalOfContainer) {
+  containerTerminals.update(terminals => {
+    terminals.push(terminal);
+    return terminals;
+  });
+}
+
+export function getExistingTerminal(engineId: string, containerId: string): TerminalOfContainer | undefined {
+  const terminals = get(containerTerminals);
+  return terminals.find(terminal => terminal.engineId === engineId && terminal.containerId === containerId);
+}


### PR DESCRIPTION
### What does this PR do?
persists the terminal's session to a store, so we can see again the terminal's connection when switching from tab to tab and we don't start a new session

also we reconnect in case of connection's failure or if we end the current connection

- [x]  it includes commits from a separate PR https://github.com/containers/podman-desktop/pull/3724
this PR needs to be merged first

for the tests of the terminal it sets `screenReaderMode` so accessibility elements are added in the rendering.

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast 
explaining what is doing this PR -->

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/502

### How to test this PR?

Go to the terminal's of a container, go to another tab and then come back to the terminal's tab
you should see the previous content and be able to continue

if you exit from the terminal (like using `exit` or <kbd>control</kbd>+<kbd>d</kbd> you're automatically reconnected
