### PR TITLE
chore: ensure when calling method, object is defined

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesProviderRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesProviderRendering.svelte
@@ -20,7 +20,7 @@ export let properties: IConfigurationPropertyRecordedSchema[] = [];
 export let providerInternalId: string | undefined = undefined;
 export let taskId: number | undefined = undefined;
 
-let showModal: ProviderInfo | undefined = undefined;
+let showModalProviderInfo: ProviderInfo | undefined = undefined;
 
 let providerLifecycleError = '';
 router.subscribe(() => {
@@ -50,21 +50,15 @@ async function stopProvider(): Promise<void> {
   window.dispatchEvent(new CustomEvent('provider-lifecycle-change'));
 }
 
-async function startReceivingLogs(provider: ProviderInfo | undefined): Promise<void> {
-  if (!provider) {
-    return;
-  }
+async function startReceivingLogs(providerInternalId: string): Promise<void> {
   const logHandler = (newContent: any[]) => {
     writeToTerminal(logsTerminal, newContent, '\x1b[37m');
   };
-  window.startReceiveLogs(provider.internalId, logHandler, logHandler, logHandler);
+  window.startReceiveLogs(providerInternalId, logHandler, logHandler, logHandler);
 }
 
-async function stopReceivingLogs(provider: ProviderInfo | undefined): Promise<void> {
-  if (!provider) {
-    return;
-  }
-  await window.stopReceiveLogs(provider.internalId);
+async function stopReceivingLogs(providerInternalId: string): Promise<void> {
+  await window.stopReceiveLogs(providerInternalId);
 }
 </script>
 
@@ -107,7 +101,7 @@ async function stopReceivingLogs(provider: ProviderInfo | undefined): Promise<vo
         <div class="px-2 text-sm italic text-gray-700">
           <Button
             on:click="{() => {
-              showModal = providerInfo;
+              showModalProviderInfo = providerInfo;
               // startReceivinLogs(providerInfo);
             }}"
             icon="{faHistory}">
@@ -142,15 +136,18 @@ async function stopReceivingLogs(provider: ProviderInfo | undefined): Promise<vo
     {/if}
   </div>
 </Route>
-{#if showModal}
+{#if showModalProviderInfo}
+  {@const showModalProviderInfoInternalId = showModalProviderInfo.internalId}
   <Modal
     on:close="{() => {
-      stopReceivingLogs(showModal);
-      showModal = undefined;
+      stopReceivingLogs(showModalProviderInfoInternalId);
+      showModalProviderInfo = undefined;
     }}">
     <div id="log" style="height: 400px; width: 647px;">
       <div style="width:100%; height:100%; flexDirection: column;">
-        <TerminalWindow bind:terminal="{logsTerminal}" on:init="{() => startReceivingLogs(showModal)}" />
+        <TerminalWindow
+          bind:terminal="{logsTerminal}"
+          on:init="{() => startReceivingLogs(showModalProviderInfoInternalId)}" />
       </div>
     </div>
   </Modal>


### PR DESCRIPTION
### What does this PR do?
when fixing lot of svelte checks, I could have used more simple code. As there were lot of files being changed, change was merged but now I'm addressing feedback

here it ensures we have an object when calling method (no longer checking if object is defined)
also replace showModal variable by adding providerInfo as we might think it was a boolean variable

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast 
explaining what is doing this PR -->

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/pull/3679#discussion_r1306018073

### How to test this PR?

<!-- Please explain steps to reproduce -->
