### PR TITLE
refactoring: item formats from renderer/preferences in separate files

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationRendering.svelte
@@ -47,7 +47,7 @@ export let taskId: number | undefined = undefined;
 export let disableEmptyScreen = false;
 export let hideCloseButton = false;
 
-$: configurationValues = new Map<string, string>();
+$: configurationValues = new Map<string, string | boolean | number>();
 let creationInProgress = false;
 let creationStarted = false;
 let creationSuccessful = false;
@@ -201,7 +201,7 @@ async function handleValidComponent() {
   }
 }
 
-function setConfigurationValue(id: string, value: string) {
+function setConfigurationValue(id: string, value: string | boolean | number) {
   configurationValues.set(id, value);
   configurationValues = configurationValues;
 }

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.spec.ts
@@ -217,7 +217,7 @@ test('Expect tooltip text shows info when input is less than minimum', async () 
   expect(tooltip.textContent).toBe('The value cannot be less than 1');
 });
 
-test('Expect tooltip text shows info when input is empty', async () => {
+test('Expect tooltip text shows info when input is higher than maximum', async () => {
   const record: IConfigurationPropertyRecordedSchema = {
     id: 'record',
     title: 'record',

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.spec.ts
@@ -38,7 +38,7 @@ async function awaitRender(record: IConfigurationPropertyRecordedSchema, customP
     initialValue: getInitialValue(record),
     ...customProperties,
   });
-  while (result.component.$$.ctx[2] === undefined) {
+  while (result.component.$$.ctx[3] === undefined) {
     await new Promise(resolve => setTimeout(resolve, 100));
   }
 }

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
@@ -1,14 +1,15 @@
 <script lang="ts">
-import { faXmark } from '@fortawesome/free-solid-svg-icons';
-import Fa from 'svelte-fa';
 import type { IConfigurationPropertyRecordedSchema } from '../../../../main/src/plugin/configuration-registry';
 import ErrorMessage from '../ui/ErrorMessage.svelte';
 import Markdown from '../markdown/Markdown.svelte';
 import { getNormalizedDefaultNumberValue } from './Util';
-import Tooltip from '../ui/Tooltip.svelte';
-import Button from '../ui/Button.svelte';
+import BooleanItem from '/@/lib/preferences/item-formats/BooleanItem.svelte';
+import SliderItem from '/@/lib/preferences/item-formats/SliderItem.svelte';
+import NumberItem from '/@/lib/preferences/item-formats/NumberItem.svelte';
+import FileItem from '/@/lib/preferences/item-formats/FileItem.svelte';
+import EnumItem from '/@/lib/preferences/item-formats/EnumItem.svelte';
+import StringItem from '/@/lib/preferences/item-formats/StringItem.svelte';
 
-let invalidEntry = false;
 let invalidText: string | undefined = undefined;
 export let invalidRecord = (_error: string) => {};
 export let validRecord = () => {};
@@ -48,59 +49,9 @@ $: if (currentRecord !== record) {
   });
 
   currentRecord = record;
-  invalidText = undefined;
-  invalidEntry = false;
-}
-
-function invalid() {
-  // call the callback
-  if (invalidText) {
-    invalidRecord(invalidText);
-  }
-}
-
-function valid() {
-  validRecord();
-}
-
-function checkValue(record: IConfigurationPropertyRecordedSchema, event: any) {
-  clearTimeout(recordUpdateTimeout);
-  const userValue = event.target.value;
-  if (record.type === 'number') {
-    const numberValue = parseFloat(userValue);
-    if (userValue === '') {
-      invalidEntry = true;
-      invalidText = 'Expecting a number';
-      return invalid();
-    }
-    if (isNaN(numberValue)) {
-      invalidEntry = true;
-      invalidText = `${userValue} is not a number`;
-      return invalid();
-    }
-
-    // check range
-    if (record.minimum && numberValue < record.minimum) {
-      invalidEntry = true;
-      invalidText = 'Minimun value is ' + record.minimum;
-      return invalid();
-    }
-    if (record.maximum && typeof record.maximum === 'number' && numberValue > record.maximum) {
-      invalidEntry = true;
-      invalidText = 'Maximum value is ' + record.maximum;
-      return invalid();
-    }
-  }
-  valid();
-  autoSave();
-  invalidEntry = false;
-  invalidText = undefined;
 }
 
 function update(record: IConfigurationPropertyRecordedSchema) {
-  // reset invalid
-  invalidEntry = false;
-
   let value: any = recordValue;
   if (record.type === 'number') {
     value = parseFloat(value);
@@ -113,55 +64,9 @@ function update(record: IConfigurationPropertyRecordedSchema) {
     try {
       window.updateConfigurationValue(record.id, value, record.scope);
     } catch (error) {
-      invalidEntry = true;
       invalidText = String(error);
     }
   }
-}
-
-async function selectFilePath() {
-  clearTimeout(recordUpdateTimeout);
-  const result = await window.openFileDialog(`Select ${record.description}`);
-  if (!result.canceled && result.filePaths.length === 1) {
-    recordValue = result.filePaths[0];
-    autoSave();
-  }
-}
-
-function decrement(
-  e: MouseEvent & {
-    currentTarget: EventTarget & HTMLButtonElement;
-  },
-  record: IConfigurationPropertyRecordedSchema,
-) {
-  clearTimeout(recordUpdateTimeout);
-  const target = getCurrentNumericInputElement(e.currentTarget);
-  let value = Number(target.value);
-  if (canDecrement(value, record.minimum)) {
-    value--;
-    recordValue = value;
-    autoSave();
-  }
-  assertNumericValueIsValid(value);
-  e.preventDefault();
-}
-
-function increment(
-  e: MouseEvent & {
-    currentTarget: EventTarget & HTMLButtonElement;
-  },
-  record: IConfigurationPropertyRecordedSchema,
-) {
-  clearTimeout(recordUpdateTimeout);
-  const target = getCurrentNumericInputElement(e.currentTarget);
-  let value = Number(target.value);
-  if (canIncrement(value, record.maximum)) {
-    value++;
-    recordValue = value;
-    autoSave();
-  }
-  assertNumericValueIsValid(value);
-  e.preventDefault();
 }
 
 function autoSave() {
@@ -170,210 +75,44 @@ function autoSave() {
   }
 }
 
-function getCurrentNumericInputElement(e: HTMLButtonElement) {
-  const btn = e.parentNode?.parentElement?.querySelector('button[data-action="decrement"]');
-  return btn?.nextElementSibling?.firstElementChild?.firstElementChild as unknown as HTMLInputElement;
-}
+function onChange(recordId: string, value: boolean | string | number) {
+  recordValue = value;
+  switch (typeof value) {
+    case 'boolean':
+      break;
+    case 'number':
+      break;
+    case 'string':
+      setRecordValue(recordId, value);
+      break;
 
-function canDecrement(value: number | string, minimumValue?: number) {
-  if (typeof value === 'string') {
-    value = Number(value);
+      validRecord();
+      autoSave();
   }
-  return !minimumValue || value > minimumValue;
-}
-
-function canIncrement(value: number | string, maximumValue?: number | string) {
-  if (typeof value === 'string') {
-    value = Number(value);
-  }
-  return !maximumValue || (typeof maximumValue === 'number' && value < maximumValue);
-}
-
-function handleRangeValue(id: string | undefined, target: HTMLInputElement) {
-  if (!id) {
-    return;
-  }
-  setRecordValue(id, target.value);
-}
-
-function handleCleanValue(
-  event: MouseEvent & {
-    currentTarget: EventTarget & HTMLButtonElement;
-  },
-) {
-  recordValue = '';
-  event.preventDefault();
-}
-
-let numberInputInvalid = false;
-let numberInputErrorMessage = '';
-function onNumberInputKeyPress(event: any) {
-  // if the key is not a number skip it
-  if (isNaN(Number(event.key))) {
-    event.preventDefault();
-  }
-}
-
-function onNumberInputChange(event: any) {
-  if (event.target.value === '') {
-    numberInputInvalid = true;
-    numberInputErrorMessage = `The value cannot be less than ${record.minimum}${
-      record.maximum ? ` or greater than ${record.maximum}` : ''
-    }`;
-    clearTimeout(recordUpdateTimeout);
-    return;
-  }
-  // if the resulting value is greater than the maximum or less than the minimum skip it
-  const resultingValue = Number(event.target.value);
-  if (assertNumericValueIsValid(resultingValue)) {
-    autoSave();
-  }
-}
-
-function assertNumericValueIsValid(value: number) {
-  if (record.maximum && typeof record.maximum === 'number' && value > record.maximum) {
-    numberInputInvalid = true;
-    numberInputErrorMessage = `The value cannot be greater than ${record.maximum}`;
-    clearTimeout(recordUpdateTimeout);
-    return false;
-  }
-  if (record.minimum && typeof record.minimum === 'number' && value < record.minimum) {
-    numberInputInvalid = true;
-    numberInputErrorMessage = `The value cannot be less than ${record.minimum}`;
-    clearTimeout(recordUpdateTimeout);
-    return false;
-  }
-  numberInputErrorMessage = '';
-  numberInputInvalid = false;
-  return true;
 }
 </script>
 
 <div class="flex flex-row mb-1 pt-2">
   <div class="flex flex-col text-start w-full justify-center items-start">
     {#if record.type === 'boolean'}
-      <label class="relative inline-flex items-center cursor-pointer">
-        <span class="text-xs {checkboxValue ? 'text-white' : 'text-gray-700'} mr-3"
-          >{checkboxValue ? 'Enabled' : 'Disabled'}</span>
-        <input
-          on:input="{event => {
-            recordValue = !checkboxValue;
-            checkValue(record, event);
-          }}"
-          class="sr-only peer"
-          bind:checked="{checkboxValue}"
-          name="{record.id}"
-          type="checkbox"
-          disabled="{!!record.readonly}"
-          id="input-standard-{record.id}"
-          aria-invalid="{invalidEntry}"
-          aria-label="{record.description || record.markdownDescription}" />
-        <div
-          class="w-8 h-[20px] bg-gray-900 rounded-full peer peer-checked:after:translate-x-full after:bg-charcoal-600 after:content-[''] after:absolute after:top-[4px] after:left-[61px] after:rounded-full after:h-3 after:w-3 after:transition-all peer-checked:bg-violet-600">
-        </div>
-      </label>
+      <BooleanItem record="{record}" checked="{checkboxValue}" onChange="{onChange}" />
     {:else if enableSlider && record.type === 'number' && typeof record.maximum === 'number'}
-      <input
-        id="input-slider-{record.id}"
-        type="range"
-        name="{record.id}"
-        min="{record.minimum}"
-        max="{record.maximum}"
-        value="{getNormalizedDefaultNumberValue(record)}"
-        aria-label="{record.description}"
-        on:input="{event => handleRangeValue(record.id, event.currentTarget)}"
-        class="w-full h-1 bg-purple-500 rounded-lg appearance-none accent-purple-500 cursor-pointer range-xs mt-2" />
+      <SliderItem record="{record}" value="{getNormalizedDefaultNumberValue(record)}" onChange="{onChange}" />
     {:else if record.type === 'number'}
-      <div
-        class="flex flex-row rounded-sm bg-zinc-700 text-sm divide-x divide-charcoal-800 w-24 border-b"
-        class:border-violet-500="{!numberInputInvalid}"
-        class:border-red-500="{numberInputInvalid}">
-        <button
-          data-action="decrement"
-          on:click="{e => decrement(e, record)}"
-          disabled="{!canDecrement(recordValue, record.minimum)}"
-          class="w-11 text-white {!canDecrement(recordValue, record.minimum)
-            ? 'bg-charcoal-600 text-charcoal-100 border-t border-l border-charcoal-800'
-            : 'hover:text-gray-900 hover:bg-gray-700'} cursor-pointer outline-none">
-          <span class="m-auto font-thin">−</span>
-        </button>
-        <Tooltip topLeft tip="{numberInputErrorMessage}">
-          <input
-            type="text"
-            class="w-[50px] outline-none focus:outline-none text-center text-white text-sm py-0.5"
-            name="{record.id}"
-            bind:value="{recordValue}"
-            on:keypress="{event => onNumberInputKeyPress(event)}"
-            on:input="{event => onNumberInputChange(event)}"
-            aria-label="{record.description}" />
-        </Tooltip>
-        <button
-          data-action="increment"
-          on:click="{e => increment(e, record)}"
-          disabled="{!canIncrement(recordValue, record.maximum)}"
-          class="w-11 text-white {!canIncrement(recordValue, record.maximum)
-            ? 'bg-charcoal-600 text-charcoal-100 border-t border-l border-charcoal-800'
-            : 'hover:text-gray-900 hover:bg-gray-700'} cursor-pointer outline-none">
-          <span class="m-auto font-thin">+</span>
-        </button>
-      </div>
+      <NumberItem record="{record}" value="{recordValue}" onChange="{onChange}" invalidRecord="{invalidRecord}" />
     {:else if record.type === 'string' && record.format === 'file'}
-      <div class="w-full flex">
-        <input
-          class="grow {!recordValue ? 'mr-3' : ''} py-1 px-2 outline-0 text-sm placeholder-gray-900"
-          name="{record.id}"
-          readonly
-          type="text"
-          placeholder="{record.placeholder}"
-          value="{recordValue || ''}"
-          id="input-standard-{record.id}"
-          aria-invalid="{invalidEntry}"
-          aria-label="{record.description}" />
-        <button
-          class="relative cursor-pointer right-5"
-          class:hidden="{!recordValue}"
-          aria-label="clear"
-          on:click="{event => handleCleanValue(event)}">
-          <Fa icon="{faXmark}" />
-        </button>
-        <Button
-          on:click="{() => selectFilePath()}"
-          id="rendering.FilePath.{record.id}"
-          aria-invalid="{invalidEntry}"
-          aria-label="button-{record.description}">Browse ...</Button>
-      </div>
+      <FileItem record="{record}" value="{recordValue}" onChange="{onChange}" />
     {:else if record.type === 'string' && record.enum && record.enum.length > 0}
-      <select
-        class="border-b block w-full p-1 bg-zinc-700 border-violet-500 text-white text-sm checked:bg-violet-50"
-        name="{record.id}"
-        id="input-standard-{record.id}"
-        on:input="{event => checkValue(record, event)}"
-        bind:value="{recordValue}"
-        aria-invalid="{invalidEntry}"
-        aria-label="{record.description}">
-        {#each record.enum as recordEnum}
-          <option value="{recordEnum}">{recordEnum}</option>
-        {/each}
-      </select>
+      <EnumItem record="{record}" value="{recordValue}" onChange="{onChange}" />
     {:else if record.type === 'markdown'}
       <div class="text-sm">
         <Markdown>{record.markdownDescription}</Markdown>
       </div>
     {:else}
-      <input
-        on:input="{event => checkValue(record, event)}"
-        class="grow py-1 px-2 w-full outline-0 border-b-2 border-gray-800 hover:border-violet-500 focus:border-violet-500 placeholder-gray-900"
-        name="{record.id}"
-        type="text"
-        placeholder="{record.placeholder}"
-        bind:value="{recordValue}"
-        readonly="{!!record.readonly}"
-        id="input-standard-{record.id}"
-        aria-invalid="{invalidEntry}"
-        aria-label="{record.description}" />
+      <StringItem record="{record}" value="{recordValue}" onChange="{onChange}" />
     {/if}
 
-    {#if invalidEntry}
+    {#if invalidText}
       <ErrorMessage error="{invalidText}." />
     {/if}
   </div>

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
@@ -112,7 +112,7 @@ async function onChange(recordId: string, value: boolean | string | number): Pro
 </script>
 
 <div class="flex flex-row mb-1 pt-2">
-  <div class="flex flex-col text-start w-full justify-center items-start">
+  <div class="flex flex-col text-start w-full justify-center items-end">
     {#if record.type === 'boolean'}
       <BooleanItem record="{record}" checked="{!!recordValue}" onChange="{onChange}" />
     {:else if record.type === 'number'}
@@ -123,10 +123,7 @@ async function onChange(recordId: string, value: boolean | string | number): Pro
           record="{record}"
           value="{typeof recordValue === 'number' ? recordValue : getNormalizedDefaultNumberValue(record)}"
           onChange="{onChange}"
-          invalidRecord="{_error => {
-            invalidText = _error;
-            invalidRecord(_error);
-          }}" />
+          invalidRecord="{invalidRecord}" />
       {/if}
     {:else if record.type === 'string' && (typeof recordValue === 'string' || recordValue === undefined)}
       {#if record.format === 'file'}

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
@@ -109,17 +109,19 @@ function onChange(recordId: string, value: boolean | string | number) {
   <div class="flex flex-col text-start w-full justify-center items-start">
     {#if record.type === 'boolean'}
       <BooleanItem record="{record}" checked="{!!recordValue}" onChange="{onChange}" />
-    {:else if enableSlider && record.type === 'number' && typeof record.maximum === 'number'}
-      <SliderItem record="{record}" value="{getNormalizedDefaultNumberValue(record)}" onChange="{onChange}" />
     {:else if record.type === 'number'}
-      <NumberItem
-        record="{record}"
-        value="{getNormalizedDefaultNumberValue(record)}"
-        onChange="{onChange}"
-        invalidRecord="{_error => {
-          invalidText = _error;
-          invalidRecord(_error);
-        }}" />
+      {#if enableSlider && typeof record.maximum === 'number'}
+        <SliderItem record="{record}" value="{getNormalizedDefaultNumberValue(record)}" onChange="{onChange}" />
+      {:else}
+        <NumberItem
+          record="{record}"
+          value="{typeof recordValue === 'number' ? recordValue : getNormalizedDefaultNumberValue(record)}"
+          onChange="{onChange}"
+          invalidRecord="{_error => {
+            invalidText = _error;
+            invalidRecord(_error);
+          }}" />
+      {/if}
     {:else if record.type === 'string' && (typeof recordValue === 'string' || recordValue === undefined)}
       {#if record.format === 'file'}
         <FileItem record="{record}" value="{recordValue}" onChange="{onChange}" />

--- a/packages/renderer/src/lib/preferences/Util.spec.ts
+++ b/packages/renderer/src/lib/preferences/Util.spec.ts
@@ -17,7 +17,13 @@
  ***********************************************************************/
 
 import { test, expect, vi, afterEach } from 'vitest';
-import { getNormalizedDefaultNumberValue, isPropertyValidInContext, isTargetScope, writeToTerminal } from './Util';
+import {
+  getNormalizedDefaultNumberValue,
+  isPropertyValidInContext,
+  isTargetScope,
+  uncertainStringToNumber,
+  writeToTerminal,
+} from './Util';
 import type { IConfigurationPropertyRecordedSchema } from '../../../../main/src/plugin/configuration-registry';
 import { ContextUI } from '../context/context';
 
@@ -172,4 +178,20 @@ test('test isPropertyValidInContext with valid when statements', () => {
   contextMock.setValue('config.test2', true);
   expect(isPropertyValidInContext('config.test && config.test2', contextMock)).toBe(false);
   expect(isPropertyValidInContext('config.test && !config.test2', contextMock)).toBe(false);
+});
+
+test('Expect to receive the same number passed as arg', async () => {
+  const value = 0;
+  expect(uncertainStringToNumber(value)).toBe(value);
+});
+
+test('Expect to receive a number if a number as string is passed as arg', async () => {
+  const value = 10;
+  const valueAsString = '10';
+  expect(uncertainStringToNumber(valueAsString)).toBe(value);
+});
+
+test('Expect to receive a NaN if a not number string is passed as arg', async () => {
+  const valueAsString = 'unknown';
+  expect(uncertainStringToNumber(valueAsString)).toBe(NaN);
 });

--- a/packages/renderer/src/lib/preferences/Util.ts
+++ b/packages/renderer/src/lib/preferences/Util.ts
@@ -96,6 +96,7 @@ export function getNormalizedDefaultNumberValue(configurationKey: IConfiguration
   return configurationKey.maximum;
 }
 
+<<<<<<< HEAD
 export function isDefaultScope(scope?: ConfigurationScope | ConfigurationScope[]): boolean {
   return isTargetScope(CONFIGURATION_DEFAULT_SCOPE, scope);
 }
@@ -144,4 +145,15 @@ export function isPropertyValidInContext(when: string | undefined, context: Cont
 export function uncertainStringToNumber(value: string | number): number {
   if (typeof value === 'number') return value;
   return parseFloat(value);
+=======
+export function uncertainStringToNumber(value: string | number | undefined): number {
+  switch (typeof value) {
+    case 'number':
+      return value;
+    case 'string':
+      return parseFloat(value);
+    default:
+      return NaN;
+  }
+>>>>>>> 8c04b4ad2 (fix: linter)
 }

--- a/packages/renderer/src/lib/preferences/Util.ts
+++ b/packages/renderer/src/lib/preferences/Util.ts
@@ -140,3 +140,8 @@ export function isPropertyValidInContext(when: string | undefined, context: Cont
   }
   return false;
 }
+
+export function uncertainStringToNumber(value: string | number): number {
+  if (typeof value === 'number') return value;
+  return parseFloat(value);
+}

--- a/packages/renderer/src/lib/preferences/Util.ts
+++ b/packages/renderer/src/lib/preferences/Util.ts
@@ -96,7 +96,6 @@ export function getNormalizedDefaultNumberValue(configurationKey: IConfiguration
   return configurationKey.maximum;
 }
 
-<<<<<<< HEAD
 export function isDefaultScope(scope?: ConfigurationScope | ConfigurationScope[]): boolean {
   return isTargetScope(CONFIGURATION_DEFAULT_SCOPE, scope);
 }
@@ -145,15 +144,4 @@ export function isPropertyValidInContext(when: string | undefined, context: Cont
 export function uncertainStringToNumber(value: string | number): number {
   if (typeof value === 'number') return value;
   return parseFloat(value);
-=======
-export function uncertainStringToNumber(value: string | number | undefined): number {
-  switch (typeof value) {
-    case 'number':
-      return value;
-    case 'string':
-      return parseFloat(value);
-    default:
-      return NaN;
-  }
->>>>>>> 8c04b4ad2 (fix: linter)
 }

--- a/packages/renderer/src/lib/preferences/item-formats/BooleanItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/item-formats/BooleanItem.spec.ts
@@ -42,3 +42,35 @@ test('Checkbox no default', async () => {
   expect(input instanceof HTMLInputElement).toBe(true);
   expect((input as HTMLInputElement).checked).toBe(false);
 });
+
+test('Expect to see the checkbox disabled / unable to press when readonly is passed into record', async () => {
+  const record: IConfigurationPropertyRecordedSchema = {
+    title: 'my boolean property',
+    id: 'myid',
+    parentId: '',
+    type: 'boolean',
+    default: true,
+    readonly: true,
+  };
+  // remove display name
+  render(BooleanItem, { record, checked: record.default });
+  const button = screen.getByRole('checkbox');
+  expect(button).toBeInTheDocument();
+  expect(button).toBeChecked();
+  expect(button).toBeDisabled();
+});
+
+test('Expect to see checkbox not checked if default is false', async () => {
+  const record: IConfigurationPropertyRecordedSchema = {
+    title: 'my boolean property',
+    id: 'myid',
+    parentId: '',
+    type: 'boolean',
+    default: false,
+  };
+  // remove display name
+  render(BooleanItem, { record, checked: record.default });
+  const button = screen.getByRole('checkbox');
+  expect(button).toBeInTheDocument();
+  expect(button).not.toBeChecked();
+});

--- a/packages/renderer/src/lib/preferences/item-formats/BooleanItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/item-formats/BooleanItem.spec.ts
@@ -1,0 +1,44 @@
+import '@testing-library/jest-dom/vitest';
+import { test, expect, vi, beforeAll } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import type { IConfigurationPropertyRecordedSchema } from '../../../../../main/src/plugin/configuration-registry';
+import BooleanItem from '/@/lib/preferences/item-formats/BooleanItem.svelte';
+
+beforeAll(() => {
+  (window as any).getConfigurationValue = vi.fn();
+});
+
+test('Checkbox checked', async () => {
+  const record: IConfigurationPropertyRecordedSchema = {
+    id: 'record',
+    title: 'record',
+    parentId: 'parent.record',
+    description: 'record-description',
+    type: 'boolean',
+    default: true,
+  };
+
+  render(BooleanItem, { record, checked: record.default });
+  const input = screen.getByLabelText('record-description');
+  expect(input).toBeInTheDocument();
+
+  expect(input instanceof HTMLInputElement).toBe(true);
+  expect((input as HTMLInputElement).checked).toBe(true);
+});
+
+test('Checkbox no default', async () => {
+  const record: IConfigurationPropertyRecordedSchema = {
+    id: 'record',
+    title: 'record',
+    parentId: 'parent.record',
+    description: 'record-description',
+    type: 'boolean',
+  };
+
+  render(BooleanItem, { record, checked: record.default });
+  const input = screen.getByLabelText('record-description');
+  expect(input).toBeInTheDocument();
+
+  expect(input instanceof HTMLInputElement).toBe(true);
+  expect((input as HTMLInputElement).checked).toBe(false);
+});

--- a/packages/renderer/src/lib/preferences/item-formats/BooleanItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/item-formats/BooleanItem.spec.ts
@@ -2,7 +2,7 @@ import '@testing-library/jest-dom/vitest';
 import { test, expect, vi, beforeAll } from 'vitest';
 import { render, screen } from '@testing-library/svelte';
 import type { IConfigurationPropertyRecordedSchema } from '../../../../../main/src/plugin/configuration-registry';
-import BooleanItem from '/@/lib/preferences/item-formats/BooleanItem.svelte';
+import BooleanItem from './BooleanItem.svelte';
 
 beforeAll(() => {
   (window as any).getConfigurationValue = vi.fn();

--- a/packages/renderer/src/lib/preferences/item-formats/BooleanItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/BooleanItem.svelte
@@ -7,7 +7,7 @@ export let onChange = (_id: string, _value: boolean) => {};
 
 function onInput(event: Event) {
   const target = event.target as HTMLInputElement;
-  if (target.checked !== checked) onChange(record.id, target.checked);
+  if (record.id && target.checked !== checked) onChange(record.id, target.checked);
 }
 </script>
 

--- a/packages/renderer/src/lib/preferences/item-formats/BooleanItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/BooleanItem.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+import type { IConfigurationPropertyRecordedSchema } from '../../../../../main/src/plugin/configuration-registry';
+
+export let record: IConfigurationPropertyRecordedSchema;
+export let checked = false;
+export let onChange = (_id: string, _value: boolean) => {};
+
+function onInput(event: Event) {
+  const target = event.target as HTMLInputElement;
+  if (target.checked !== checked) onChange(record.id, target.checked);
+}
+</script>
+
+<label class="relative inline-flex items-center cursor-pointer">
+  <span class="text-xs {checked ? 'text-white' : 'text-gray-700'} mr-3">{checked ? 'Enabled' : 'Disabled'}</span>
+  <input
+    on:input="{onInput}"
+    class="sr-only peer"
+    bind:checked="{checked}"
+    name="{record.id}"
+    type="checkbox"
+    readonly="{!!record.readonly}"
+    id="input-standard-{record.id}"
+    aria-label="{record.description || record.markdownDescription}" />
+  <div
+    class="w-8 h-[20px] bg-gray-900 rounded-full peer peer-checked:after:translate-x-full after:bg-charcoal-600 after:content-[''] after:absolute after:top-[4px] after:left-[61px] after:rounded-full after:h-3 after:w-3 after:transition-all peer-checked:bg-violet-600">
+  </div>
+</label>

--- a/packages/renderer/src/lib/preferences/item-formats/BooleanItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/BooleanItem.svelte
@@ -3,11 +3,15 @@ import type { IConfigurationPropertyRecordedSchema } from '../../../../../main/s
 
 export let record: IConfigurationPropertyRecordedSchema;
 export let checked = false;
-export let onChange = (_id: string, _value: boolean) => {};
+export let onChange = async (_id: string, _value: boolean) => {};
+let invalidEntry = false;
 
 function onInput(event: Event) {
+  invalidEntry = false;
   const target = event.target as HTMLInputElement;
-  if (record.id && target.checked !== checked) onChange(record.id, target.checked);
+  if (record.id && target.checked !== checked) {
+    onChange(record.id, target.checked).catch((_: unknown) => (invalidEntry = true));
+  }
 }
 </script>
 
@@ -20,7 +24,9 @@ function onInput(event: Event) {
     name="{record.id}"
     type="checkbox"
     readonly="{!!record.readonly}"
+    disabled="{!!record.readonly}"
     id="input-standard-{record.id}"
+    aria-invalid="{invalidEntry}"
     aria-label="{record.description || record.markdownDescription}" />
   <div
     class="w-8 h-[20px] bg-gray-900 rounded-full peer peer-checked:after:translate-x-full after:bg-charcoal-600 after:content-[''] after:absolute after:top-[4px] after:left-[61px] after:rounded-full after:h-3 after:w-3 after:transition-all peer-checked:bg-violet-600">

--- a/packages/renderer/src/lib/preferences/item-formats/EnumItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/item-formats/EnumItem.spec.ts
@@ -1,0 +1,46 @@
+import '@testing-library/jest-dom/vitest';
+import { test, expect, vi, beforeAll } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import type { IConfigurationPropertyRecordedSchema } from '../../../../../main/src/plugin/configuration-registry';
+import EnumItem from './EnumItem.svelte';
+
+beforeAll(() => {
+  (window as any).getConfigurationValue = vi.fn();
+});
+
+test('Enum without default', async () => {
+  const record: IConfigurationPropertyRecordedSchema = {
+    id: 'record',
+    title: 'record',
+    parentId: 'parent.record',
+    description: 'record-description',
+    enum: ['hello', 'world'],
+  };
+
+  render(EnumItem, { record });
+  const input = screen.getByLabelText('record-description');
+  expect(input).toBeInTheDocument();
+
+  expect(input instanceof HTMLSelectElement).toBe(true);
+  expect((input as HTMLSelectElement).selectedIndex).toBe(0);
+});
+
+test('Enum with default', async () => {
+  const record: IConfigurationPropertyRecordedSchema = {
+    id: 'record',
+    title: 'record',
+    parentId: 'parent.record',
+    description: 'record-description',
+    enum: ['hello', 'world'],
+    default: 'world',
+  };
+
+  render(EnumItem, { record, value: record.default });
+  const input = screen.getByLabelText('record-description');
+  expect(input).toBeInTheDocument();
+
+  expect(input instanceof HTMLSelectElement).toBe(true);
+  expect((input as HTMLSelectElement).selectedIndex).toBe(1);
+  expect((input as HTMLSelectElement).selectedOptions.length).toBe(1);
+  expect((input as HTMLSelectElement).selectedOptions[0].text).toBe('world');
+});

--- a/packages/renderer/src/lib/preferences/item-formats/EnumItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/EnumItem.svelte
@@ -7,7 +7,7 @@ export let onChange = (_id: string, _value: string) => {};
 function onInput(event: Event) {
   const target = event.target as HTMLInputElement;
   console.log(event);
-  if (target.value !== value) onChange(record.id, target.value);
+  if (record.id && target.value !== value) onChange(record.id, target.value);
 }
 </script>
 
@@ -18,7 +18,9 @@ function onInput(event: Event) {
   on:input="{onInput}"
   bind:value="{value}"
   aria-label="{record.description}">
-  {#each record.enum as recordEnum}
-    <option value="{recordEnum}">{recordEnum}</option>
-  {/each}
+  {#if record.enum}
+    {#each record.enum as recordEnum}
+      <option value="{recordEnum}">{recordEnum}</option>
+    {/each}
+  {/if}
 </select>

--- a/packages/renderer/src/lib/preferences/item-formats/EnumItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/EnumItem.svelte
@@ -2,11 +2,15 @@
 import type { IConfigurationPropertyRecordedSchema } from '../../../../../main/src/plugin/configuration-registry';
 export let record: IConfigurationPropertyRecordedSchema;
 export let value: string | undefined;
-export let onChange = (_id: string, _value: string) => {};
+export let onChange = async (_id: string, _value: string) => {};
+
+let invalidEntry = false;
 
 function onInput(event: Event) {
+  invalidEntry = false;
   const target = event.target as HTMLInputElement;
-  if (record.id && target.value !== value) onChange(record.id, target.value);
+  if (record.id && target.value !== value)
+    onChange(record.id, target.value).catch((_: unknown) => (invalidEntry = true));
 }
 </script>
 
@@ -16,6 +20,7 @@ function onInput(event: Event) {
   id="input-standard-{record.id}"
   on:input="{onInput}"
   bind:value="{value}"
+  aria-invalid="{invalidEntry}"
   aria-label="{record.description}">
   {#if record.enum}
     {#each record.enum as recordEnum}

--- a/packages/renderer/src/lib/preferences/item-formats/EnumItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/EnumItem.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+import type { IConfigurationPropertyRecordedSchema } from '../../../../../main/src/plugin/configuration-registry';
+export let record: IConfigurationPropertyRecordedSchema;
+export let value: string | undefined;
+export let onChange = (_id: string, _value: string) => {};
+
+function onInput(event: Event) {
+  const target = event.target as HTMLInputElement;
+  console.log(event);
+  if (target.value !== value) onChange(record.id, target.value);
+}
+</script>
+
+<select
+  class="border-b block w-full p-1 bg-zinc-700 border-violet-500 text-white text-sm checked:bg-violet-50"
+  name="{record.id}"
+  id="input-standard-{record.id}"
+  on:input="{onInput}"
+  bind:value="{value}"
+  aria-label="{record.description}">
+  {#each record.enum as recordEnum}
+    <option value="{recordEnum}">{recordEnum}</option>
+  {/each}
+</select>

--- a/packages/renderer/src/lib/preferences/item-formats/EnumItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/EnumItem.svelte
@@ -6,7 +6,6 @@ export let onChange = (_id: string, _value: string) => {};
 
 function onInput(event: Event) {
   const target = event.target as HTMLInputElement;
-  console.log(event);
   if (record.id && target.value !== value) onChange(record.id, target.value);
 }
 </script>

--- a/packages/renderer/src/lib/preferences/item-formats/FileItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/item-formats/FileItem.spec.ts
@@ -1,0 +1,26 @@
+import '@testing-library/jest-dom/vitest';
+import { test, expect, vi, beforeAll } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import type { IConfigurationPropertyRecordedSchema } from '../../../../../main/src/plugin/configuration-registry';
+import FileItem from '/@/lib/preferences/item-formats/FileItem.svelte';
+
+beforeAll(() => {
+  (window as any).getConfigurationValue = vi.fn();
+});
+
+test('Ensure HTMLInputElement', async () => {
+  const record: IConfigurationPropertyRecordedSchema = {
+    id: 'record',
+    title: 'record',
+    parentId: 'parent.record',
+    description: 'record-description',
+    type: 'string',
+    format: 'file',
+  };
+
+  render(FileItem, { record, value: undefined });
+  const input = screen.getByLabelText('record-description');
+  expect(input).toBeInTheDocument();
+
+  expect(input instanceof HTMLInputElement).toBe(true);
+});

--- a/packages/renderer/src/lib/preferences/item-formats/FileItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/item-formats/FileItem.spec.ts
@@ -3,9 +3,12 @@ import { test, expect, vi, beforeAll } from 'vitest';
 import { render, screen } from '@testing-library/svelte';
 import type { IConfigurationPropertyRecordedSchema } from '../../../../../main/src/plugin/configuration-registry';
 import FileItem from './FileItem.svelte';
+import userEvent from '@testing-library/user-event';
 
+const openFileDialogMock = vi.fn();
 beforeAll(() => {
   (window as any).getConfigurationValue = vi.fn();
+  (window as any).openFileDialog = openFileDialogMock;
 });
 
 test('Ensure HTMLInputElement', async () => {
@@ -23,4 +26,27 @@ test('Ensure HTMLInputElement', async () => {
   expect(input).toBeInTheDocument();
 
   expect(input instanceof HTMLInputElement).toBe(true);
+});
+
+test('Ensure clicking on Browser invoke openFileDialog', async () => {
+  openFileDialogMock.mockResolvedValue({
+    id: undefined,
+    canceled: true,
+    filePaths: [],
+  });
+  const record: IConfigurationPropertyRecordedSchema = {
+    id: 'record',
+    title: 'record',
+    parentId: 'parent.record',
+    description: 'record-description',
+    type: 'string',
+    format: 'file',
+  };
+
+  render(FileItem, { record, value: '' });
+  const input = screen.getByRole('button', { name: `button-${record.description}` });
+  expect(input).toBeInTheDocument();
+  await userEvent.click(input);
+
+  expect(openFileDialogMock).toBeCalled();
 });

--- a/packages/renderer/src/lib/preferences/item-formats/FileItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/item-formats/FileItem.spec.ts
@@ -2,7 +2,7 @@ import '@testing-library/jest-dom/vitest';
 import { test, expect, vi, beforeAll } from 'vitest';
 import { render, screen } from '@testing-library/svelte';
 import type { IConfigurationPropertyRecordedSchema } from '../../../../../main/src/plugin/configuration-registry';
-import FileItem from '/@/lib/preferences/item-formats/FileItem.svelte';
+import FileItem from './FileItem.svelte';
 
 beforeAll(() => {
   (window as any).getConfigurationValue = vi.fn();
@@ -18,7 +18,7 @@ test('Ensure HTMLInputElement', async () => {
     format: 'file',
   };
 
-  render(FileItem, { record, value: undefined });
+  render(FileItem, { record, value: '' });
   const input = screen.getByLabelText('record-description');
   expect(input).toBeInTheDocument();
 

--- a/packages/renderer/src/lib/preferences/item-formats/FileItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/FileItem.svelte
@@ -8,7 +8,7 @@ export let value: string | undefined;
 export let onChange = (_id: string, _value: string) => {};
 async function selectFilePath() {
   const result = await window.openFileDialog(`Select ${record.description}`);
-  if (!result.canceled && result.filePaths.length === 1) {
+  if (record.id && !result.canceled && result.filePaths.length === 1) {
     onChange(record.id, result.filePaths[0]);
   }
 }
@@ -18,7 +18,7 @@ function handleCleanValue(
     currentTarget: EventTarget & HTMLButtonElement;
   },
 ) {
-  onChange(record.id, '');
+  if (record.id) onChange(record.id, '');
   event.preventDefault();
 }
 </script>

--- a/packages/renderer/src/lib/preferences/item-formats/FileItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/FileItem.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 import type { IConfigurationPropertyRecordedSchema } from '../../../../../main/src/plugin/configuration-registry';
-import Fa from 'svelte-fa/src/fa.svelte';
+import Fa from 'svelte-fa';
 import { faXmark } from '@fortawesome/free-solid-svg-icons';
 import Button from '../../ui/Button.svelte';
 export let record: IConfigurationPropertyRecordedSchema;

--- a/packages/renderer/src/lib/preferences/item-formats/FileItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/FileItem.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+import type { IConfigurationPropertyRecordedSchema } from '../../../../../main/src/plugin/configuration-registry';
+import Fa from 'svelte-fa/src/fa.svelte';
+import { faXmark } from '@fortawesome/free-solid-svg-icons';
+import Button from '../../ui/Button.svelte';
+export let record: IConfigurationPropertyRecordedSchema;
+export let value: string | undefined;
+export let onChange = (_id: string, _value: string) => {};
+async function selectFilePath() {
+  const result = await window.openFileDialog(`Select ${record.description}`);
+  if (!result.canceled && result.filePaths.length === 1) {
+    onChange(record.id, result.filePaths[0]);
+  }
+}
+
+function handleCleanValue(
+  event: MouseEvent & {
+    currentTarget: EventTarget & HTMLButtonElement;
+  },
+) {
+  onChange(record.id, '');
+  event.preventDefault();
+}
+</script>
+
+<div class="w-full flex">
+  <input
+    class="grow {!value ? 'mr-3' : ''} py-1 px-2 outline-0 text-sm placeholder-gray-900"
+    name="{record.id}"
+    readonly
+    type="text"
+    placeholder="{record.placeholder}"
+    value="{value}"
+    id="input-standard-{record.id}"
+    aria-label="{record.description}" />
+  <button
+    class="relative cursor-pointer right-5"
+    class:hidden="{!value}"
+    aria-label="clear"
+    on:click="{event => handleCleanValue(event)}">
+    <Fa icon="{faXmark}" />
+  </button>
+  <Button
+    on:click="{() => selectFilePath()}"
+    id="rendering.FilePath.{record.id}"
+    aria-label="button-{record.description}">Browse ...</Button>
+</div>

--- a/packages/renderer/src/lib/preferences/item-formats/FileItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/FileItem.svelte
@@ -4,12 +4,16 @@ import Fa from 'svelte-fa/src/fa.svelte';
 import { faXmark } from '@fortawesome/free-solid-svg-icons';
 import Button from '../../ui/Button.svelte';
 export let record: IConfigurationPropertyRecordedSchema;
-export let value: string | undefined;
-export let onChange = (_id: string, _value: string) => {};
+export let value: string;
+export let onChange = async (_id: string, _value: string) => {};
+
+let invalidEntry = false;
+
 async function selectFilePath() {
+  invalidEntry = false;
   const result = await window.openFileDialog(`Select ${record.description}`);
   if (record.id && !result.canceled && result.filePaths.length === 1) {
-    onChange(record.id, result.filePaths[0]);
+    onChange(record.id, result.filePaths[0]).catch((_: unknown) => (invalidEntry = true));
   }
 }
 
@@ -30,8 +34,9 @@ function handleCleanValue(
     readonly
     type="text"
     placeholder="{record.placeholder}"
-    value="{value}"
+    value="{value || ''}"
     id="input-standard-{record.id}"
+    aria-invalid="{invalidEntry}"
     aria-label="{record.description}" />
   <button
     class="relative cursor-pointer right-5"
@@ -43,5 +48,6 @@ function handleCleanValue(
   <Button
     on:click="{() => selectFilePath()}"
     id="rendering.FilePath.{record.id}"
+    aria-invalid="{invalidEntry}"
     aria-label="button-{record.description}">Browse ...</Button>
 </div>

--- a/packages/renderer/src/lib/preferences/item-formats/NumberItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/item-formats/NumberItem.spec.ts
@@ -3,6 +3,7 @@ import { test, expect, vi, beforeAll } from 'vitest';
 import { render, screen } from '@testing-library/svelte';
 import type { IConfigurationPropertyRecordedSchema } from '../../../../../main/src/plugin/configuration-registry';
 import NumberItem from './NumberItem.svelte';
+import userEvent from '@testing-library/user-event';
 
 beforeAll(() => {
   (window as any).getConfigurationValue = vi.fn();
@@ -18,12 +19,16 @@ test('Expect tooltip if NaN provided as value', async () => {
     minimum: 1,
     maximum: 34,
   };
-  const value = NaN;
+  const value = 2;
   render(NumberItem, { record, value });
+
   const input = screen.getByLabelText('record-description');
   expect(input).toBeInTheDocument();
+  await userEvent.click(input);
+  await userEvent.clear(input);
+  await userEvent.keyboard('unknown');
 
   const tooltip = screen.getByLabelText('tooltip');
   expect(tooltip).toBeInTheDocument();
-  expect(tooltip.textContent).toBe('Expecting a number');
+  expect(tooltip.textContent).toContain('Expecting a number');
 });

--- a/packages/renderer/src/lib/preferences/item-formats/NumberItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/item-formats/NumberItem.spec.ts
@@ -9,7 +9,7 @@ beforeAll(() => {
   (window as any).getConfigurationValue = vi.fn();
 });
 
-test('Expect tooltip if NaN provided as value', async () => {
+test('Expect tooltip if value input is NaN', async () => {
   const record: IConfigurationPropertyRecordedSchema = {
     id: 'record',
     title: 'record',
@@ -31,4 +31,82 @@ test('Expect tooltip if NaN provided as value', async () => {
   const tooltip = screen.getByLabelText('tooltip');
   expect(tooltip).toBeInTheDocument();
   expect(tooltip.textContent).toContain('Expecting a number');
+});
+
+test('Expect decrement button disabled if value is less than minimum', async () => {
+  const record: IConfigurationPropertyRecordedSchema = {
+    id: 'record',
+    title: 'record',
+    parentId: 'parent.record',
+    description: 'record-description',
+    type: 'number',
+    minimum: 1,
+    maximum: 34,
+  };
+  const value = 0;
+  render(NumberItem, { record, value });
+
+  const input = screen.getByLabelText('decrement');
+  expect(input).toBeInTheDocument();
+  expect(input).toBeDisabled();
+});
+
+test('Expect increment button disabled if value is less than minimum', async () => {
+  const record: IConfigurationPropertyRecordedSchema = {
+    id: 'record',
+    title: 'record',
+    parentId: 'parent.record',
+    description: 'record-description',
+    type: 'number',
+    minimum: 1,
+    maximum: 34,
+  };
+  const value = 35;
+  render(NumberItem, { record, value });
+
+  const input = screen.getByLabelText('increment');
+  expect(input).toBeInTheDocument();
+  expect(input).toBeDisabled();
+});
+
+test('Expect increment button only works one if maximum value is reached after one click', async () => {
+  const record: IConfigurationPropertyRecordedSchema = {
+    id: 'record',
+    title: 'record',
+    parentId: 'parent.record',
+    description: 'record-description',
+    type: 'number',
+    minimum: 1,
+    maximum: 34,
+  };
+  const value = 33;
+  render(NumberItem, { record, value });
+
+  const input = screen.getByLabelText('increment');
+  expect(input).toBeInTheDocument();
+  expect(input).toBeEnabled();
+  await userEvent.click(input);
+
+  expect(input).toBeDisabled();
+});
+
+test('Expect decrement button only works one if minimum value is reached after one click', async () => {
+  const record: IConfigurationPropertyRecordedSchema = {
+    id: 'record',
+    title: 'record',
+    parentId: 'parent.record',
+    description: 'record-description',
+    type: 'number',
+    minimum: 1,
+    maximum: 34,
+  };
+  const value = 2;
+  render(NumberItem, { record, value });
+
+  const input = screen.getByLabelText('decrement');
+  expect(input).toBeInTheDocument();
+  expect(input).toBeEnabled();
+  await userEvent.click(input);
+
+  expect(input).toBeDisabled();
 });

--- a/packages/renderer/src/lib/preferences/item-formats/NumberItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/item-formats/NumberItem.spec.ts
@@ -1,0 +1,29 @@
+import '@testing-library/jest-dom/vitest';
+import { test, expect, vi, beforeAll } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import type { IConfigurationPropertyRecordedSchema } from '../../../../../main/src/plugin/configuration-registry';
+import NumberItem from './NumberItem.svelte';
+
+beforeAll(() => {
+  (window as any).getConfigurationValue = vi.fn();
+});
+
+test('Expect tooltip if NaN provided as value', async () => {
+  const record: IConfigurationPropertyRecordedSchema = {
+    id: 'record',
+    title: 'record',
+    parentId: 'parent.record',
+    description: 'record-description',
+    type: 'number',
+    minimum: 1,
+    maximum: 34,
+  };
+  const value = NaN;
+  render(NumberItem, { record, value });
+  const input = screen.getByLabelText('record-description');
+  expect(input).toBeInTheDocument();
+
+  const tooltip = screen.getByLabelText('tooltip');
+  expect(tooltip).toBeInTheDocument();
+  expect(tooltip.textContent).toBe('Expecting a number');
+});

--- a/packages/renderer/src/lib/preferences/item-formats/NumberItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/NumberItem.svelte
@@ -1,0 +1,116 @@
+<script lang="ts">
+import type { IConfigurationPropertyRecordedSchema } from '../../../../../main/src/plugin/configuration-registry';
+import Tooltip from '/@/lib/ui/Tooltip.svelte';
+import { uncertainStringToNumber } from '../Util';
+
+export let record: IConfigurationPropertyRecordedSchema;
+export let value: number;
+export let onChange = (_id: string, _value: number) => {};
+export let invalidRecord = (_error: string) => {};
+
+let numberInputInvalid = false;
+let numberInputErrorMessage = '';
+
+function onInput(event: Event) {
+  numberInputInvalid = false;
+  const target = event.currentTarget as HTMLInputElement;
+
+  const _value: number = uncertainStringToNumber(target.value);
+  if (!assertNumericValueIsValid(_value)) {
+    invalidRecord(numberInputErrorMessage);
+    return;
+  }
+
+  if (_value !== value) {
+    onChange(record.id, _value);
+  }
+}
+
+function onNumberInputKeyPress(event: any) {
+  // if the key is not a number skip it
+  if (isNaN(Number(event.key))) {
+    event.preventDefault();
+  }
+}
+
+function onDecrement(
+  e: MouseEvent & {
+    currentTarget: EventTarget & HTMLButtonElement;
+  },
+) {
+  onChange(record.id, value - 1);
+  e.preventDefault();
+}
+
+function onIncrement(
+  e: MouseEvent & {
+    currentTarget: EventTarget & HTMLButtonElement;
+  },
+) {
+  onChange(record.id, value + 1);
+  e.preventDefault();
+}
+
+function canDecrement(minimumValue?: number) {
+  return !minimumValue || value > minimumValue;
+}
+
+function assertNumericValueIsValid(value: number) {
+  if (isNaN(value)) {
+    numberInputInvalid = true;
+    numberInputErrorMessage = 'Expecting a number';
+    return false;
+  }
+
+  if (record.maximum && typeof record.maximum === 'number' && value > record.maximum) {
+    numberInputInvalid = true;
+    numberInputErrorMessage = `The value cannot be greater than ${record.maximum}`;
+    return false;
+  }
+  if (record.minimum && typeof record.minimum === 'number' && value < record.minimum) {
+    numberInputInvalid = true;
+    numberInputErrorMessage = `The value cannot be less than ${record.minimum}`;
+    return false;
+  }
+  numberInputErrorMessage = '';
+  numberInputInvalid = false;
+  return true;
+}
+function canIncrement(maximumValue?: number | string) {
+  return !maximumValue || (typeof maximumValue === 'number' && value < maximumValue);
+}
+</script>
+
+<div
+  class="flex flex-row rounded-sm bg-zinc-700 text-sm divide-x divide-charcoal-800 w-24 border-b"
+  class:border-violet-500="{!numberInputInvalid}"
+  class:border-red-500="{numberInputInvalid}">
+  <button
+    data-action="decrement"
+    on:click="{onDecrement}"
+    disabled="{!canDecrement(record.minimum)}"
+    class="w-11 text-white {!canDecrement(record.minimum)
+      ? 'bg-charcoal-600 text-charcoal-100 border-t border-l border-charcoal-800'
+      : 'hover:text-gray-900 hover:bg-gray-700'} cursor-pointer outline-none">
+    <span class="m-auto font-thin">−</span>
+  </button>
+  <Tooltip topLeft tip="{numberInputErrorMessage}">
+    <input
+      type="text"
+      class="w-[50px] outline-none focus:outline-none text-center text-white text-sm py-0.5"
+      name="{record.id}"
+      bind:value="{value}"
+      on:keypress="{event => onNumberInputKeyPress(event)}"
+      on:input="{onInput}"
+      aria-label="{record.description}" />
+  </Tooltip>
+  <button
+    data-action="increment"
+    on:click="{onIncrement}"
+    disabled="{!canIncrement(record.maximum)}"
+    class="w-11 text-white {!canIncrement(record.maximum)
+      ? 'bg-charcoal-600 text-charcoal-100 border-t border-l border-charcoal-800'
+      : 'hover:text-gray-900 hover:bg-gray-700'} cursor-pointer outline-none">
+    <span class="m-auto font-thin">+</span>
+  </button>
+</div>

--- a/packages/renderer/src/lib/preferences/item-formats/NumberItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/NumberItem.svelte
@@ -24,17 +24,20 @@ onMount(() => {
 });
 
 function onInput(event: Event) {
+  // clear the timeout so if there was an old call to onChange pending is deleted. We will create a new one soon
   clearTimeout(valueUpdateTimeout);
   const target = event.currentTarget as HTMLInputElement;
-
+  // convert string to number
   const _value: number = uncertainStringToNumber(target.value);
+  recordValue = _value;
+  // if number is not valid, like NaN return
   if (!assertNumericValueIsValid(_value)) {
     invalidRecord(numberInputErrorMessage);
     return;
   }
-
-  if (record.id && _value !== value) {
-    valueUpdateTimeout = setTimeout(() => onChange(record.id!, _value), 500);
+  // if the value is different from the original update
+  if (record.id && recordValue !== value) {
+    valueUpdateTimeout = setTimeout(() => onChange(record.id!, recordValue), 500);
   }
 }
 
@@ -50,11 +53,19 @@ function onDecrement(
     currentTarget: EventTarget & HTMLButtonElement;
   },
 ) {
+  // clear the timeout so if there was an old call to onChange pending is deleted. We will create a new one soon
   clearTimeout(valueUpdateTimeout);
-  if (record.id && canDecrement()) {
+  // if we can decrement
+  if (record.id && canDecrement(recordValue)) {
+    // update record
     recordValue -= 1;
-    valueUpdateTimeout = setTimeout(() => onChange(record.id!, recordValue), 500);
+    // verify it is valid
+    // it may happen that the value is greater than min but also greater than max so we need to check if we can update it
+    if (assertNumericValueIsValid(recordValue)) {
+      valueUpdateTimeout = setTimeout(() => onChange(record.id!, recordValue), 500);
+    }
   }
+
   e.preventDefault();
 }
 
@@ -63,16 +74,23 @@ function onIncrement(
     currentTarget: EventTarget & HTMLButtonElement;
   },
 ) {
+  // clear the timeout so if there was an old call to onChange pending is deleted. We will create a new one soon
   clearTimeout(valueUpdateTimeout);
-  if (record.id && canIncrement()) {
+  // if we can increment
+  if (record.id && canIncrement(recordValue)) {
+    // update record
     recordValue += 1;
-    valueUpdateTimeout = setTimeout(() => onChange(record.id!, recordValue), 500);
+    // verify it is valid
+    // it may happen that the value is less than max but also less than min so we need to check if we can update it
+    if (assertNumericValueIsValid(recordValue)) {
+      valueUpdateTimeout = setTimeout(() => onChange(record.id!, recordValue), 500);
+    }
   }
   e.preventDefault();
 }
 
-function canDecrement() {
-  return !record.minimum || recordValue > record.minimum;
+function canDecrement(value: number) {
+  return !record.minimum || value > record.minimum;
 }
 
 function assertNumericValueIsValid(value: number) {
@@ -98,8 +116,8 @@ function assertNumericValueIsValid(value: number) {
   numberInputInvalid = false;
   return true;
 }
-function canIncrement() {
-  return !record.maximum || (typeof record.maximum === 'number' && recordValue < record.maximum);
+function canIncrement(value: number) {
+  return !record.maximum || (typeof record.maximum === 'number' && value < record.maximum);
 }
 </script>
 
@@ -110,8 +128,8 @@ function canIncrement() {
   <button
     data-action="decrement"
     on:click="{onDecrement}"
-    disabled="{!canDecrement()}"
-    class="w-11 text-white {!canDecrement()
+    disabled="{!canDecrement(recordValue)}"
+    class="w-11 text-white {!canDecrement(recordValue)
       ? 'bg-charcoal-600 text-charcoal-100 border-t border-l border-charcoal-800'
       : 'hover:text-gray-900 hover:bg-gray-700'} cursor-pointer outline-none">
     <span class="m-auto font-thin">−</span>
@@ -129,8 +147,8 @@ function canIncrement() {
   <button
     data-action="increment"
     on:click="{onIncrement}"
-    disabled="{!canIncrement()}"
-    class="w-11 text-white {!canIncrement()
+    disabled="{!canIncrement(recordValue)}"
+    class="w-11 text-white {!canIncrement(recordValue)
       ? 'bg-charcoal-600 text-charcoal-100 border-t border-l border-charcoal-800'
       : 'hover:text-gray-900 hover:bg-gray-700'} cursor-pointer outline-none">
     <span class="m-auto font-thin">+</span>

--- a/packages/renderer/src/lib/preferences/item-formats/NumberItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/NumberItem.svelte
@@ -26,7 +26,7 @@ function onInput(event: Event) {
     return;
   }
 
-  if (_value !== value) {
+  if (record.id && _value !== value) {
     onChange(record.id, _value);
   }
 }
@@ -51,6 +51,7 @@ function onDecrement(
     currentTarget: EventTarget & HTMLButtonElement;
   },
 ) {
+  if (!record.id) return;
   validRecord();
   onChange(record.id, value - 1);
   e.preventDefault();
@@ -61,6 +62,7 @@ function onIncrement(
     currentTarget: EventTarget & HTMLButtonElement;
   },
 ) {
+  if (!record.id) return;
   validRecord();
   onChange(record.id, value + 1);
   e.preventDefault();

--- a/packages/renderer/src/lib/preferences/item-formats/NumberItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/NumberItem.svelte
@@ -2,17 +2,22 @@
 import type { IConfigurationPropertyRecordedSchema } from '../../../../../main/src/plugin/configuration-registry';
 import Tooltip from '/@/lib/ui/Tooltip.svelte';
 import { uncertainStringToNumber } from '../Util';
+import { onMount } from 'svelte';
 
 export let record: IConfigurationPropertyRecordedSchema;
 export let value: number;
 export let onChange = (_id: string, _value: number) => {};
 export let invalidRecord = (_error: string) => {};
 
-let numberInputInvalid = false;
 let numberInputErrorMessage = '';
+let numberInputInvalid = false;
+
+onMount(async () => {
+  assertNumericValueIsValid(value);
+});
 
 function onInput(event: Event) {
-  numberInputInvalid = false;
+  validRecord();
   const target = event.currentTarget as HTMLInputElement;
 
   const _value: number = uncertainStringToNumber(target.value);
@@ -24,6 +29,14 @@ function onInput(event: Event) {
   if (_value !== value) {
     onChange(record.id, _value);
   }
+}
+
+function validRecord() {
+  if (numberInputInvalid) {
+    value = 0;
+  }
+  numberInputInvalid = false;
+  numberInputErrorMessage = '';
 }
 
 function onNumberInputKeyPress(event: any) {
@@ -38,6 +51,7 @@ function onDecrement(
     currentTarget: EventTarget & HTMLButtonElement;
   },
 ) {
+  validRecord();
   onChange(record.id, value - 1);
   e.preventDefault();
 }
@@ -47,6 +61,7 @@ function onIncrement(
     currentTarget: EventTarget & HTMLButtonElement;
   },
 ) {
+  validRecord();
   onChange(record.id, value + 1);
   e.preventDefault();
 }

--- a/packages/renderer/src/lib/preferences/item-formats/NumberItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/NumberItem.svelte
@@ -29,12 +29,12 @@ function onInput(event: Event) {
   const target = event.currentTarget as HTMLInputElement;
   // convert string to number
   const _value: number = uncertainStringToNumber(target.value);
-  recordValue = _value;
-  // if number is not valid, like NaN return
+  // if number is not valid (NaN), return
   if (!assertNumericValueIsValid(_value)) {
     invalidRecord(numberInputErrorMessage);
     return;
   }
+  recordValue = _value;
   // if the value is different from the original update
   if (record.id && recordValue !== value) {
     valueUpdateTimeout = setTimeout(() => onChange(record.id!, recordValue), 500);
@@ -127,6 +127,7 @@ function canIncrement(value: number) {
   class:border-red-500="{numberInputInvalid}">
   <button
     data-action="decrement"
+    aria-label="decrement"
     on:click="{onDecrement}"
     disabled="{!canDecrement(recordValue)}"
     class="w-11 text-white {!canDecrement(recordValue)
@@ -146,6 +147,7 @@ function canIncrement(value: number) {
   </Tooltip>
   <button
     data-action="increment"
+    aria-label="increment"
     on:click="{onIncrement}"
     disabled="{!canIncrement(recordValue)}"
     class="w-11 text-white {!canIncrement(recordValue)

--- a/packages/renderer/src/lib/preferences/item-formats/SliderItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/item-formats/SliderItem.spec.ts
@@ -1,0 +1,27 @@
+import '@testing-library/jest-dom/vitest';
+import { test, expect, vi, beforeAll } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import type { IConfigurationPropertyRecordedSchema } from '../../../../../main/src/plugin/configuration-registry';
+import SliderItem from '/@/lib/preferences/item-formats/SliderItem.svelte';
+
+beforeAll(() => {
+  (window as any).getConfigurationValue = vi.fn();
+});
+
+test('Ensure HTMLInputElement', async () => {
+  const record: IConfigurationPropertyRecordedSchema = {
+    id: 'record',
+    title: 'record',
+    parentId: 'parent.record',
+    description: 'record-description',
+    type: 'number',
+    minimum: 4,
+    maximum: 34,
+  };
+
+  render(SliderItem, { record });
+  const input = screen.getByLabelText('record-description');
+  expect(input).toBeInTheDocument();
+
+  expect(input instanceof HTMLInputElement).toBe(true);
+});

--- a/packages/renderer/src/lib/preferences/item-formats/SliderItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/item-formats/SliderItem.spec.ts
@@ -19,7 +19,7 @@ test('Ensure HTMLInputElement', async () => {
     maximum: 34,
   };
 
-  render(SliderItem, { record });
+  render(SliderItem, { record, value: 15 });
   const input = screen.getByLabelText('record-description');
   expect(input).toBeInTheDocument();
 

--- a/packages/renderer/src/lib/preferences/item-formats/SliderItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/item-formats/SliderItem.spec.ts
@@ -2,7 +2,7 @@ import '@testing-library/jest-dom/vitest';
 import { test, expect, vi, beforeAll } from 'vitest';
 import { render, screen } from '@testing-library/svelte';
 import type { IConfigurationPropertyRecordedSchema } from '../../../../../main/src/plugin/configuration-registry';
-import SliderItem from '/@/lib/preferences/item-formats/SliderItem.svelte';
+import SliderItem from './SliderItem.svelte';
 
 beforeAll(() => {
   (window as any).getConfigurationValue = vi.fn();

--- a/packages/renderer/src/lib/preferences/item-formats/SliderItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/SliderItem.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+import type { IConfigurationPropertyRecordedSchema } from '../../../../../main/src/plugin/configuration-registry';
+import { uncertainStringToNumber } from '../Util';
+
+export let record: IConfigurationPropertyRecordedSchema;
+export let value: number = uncertainStringToNumber(record.maximum);
+export let onChange = (_id: string, _value: number) => {};
+
+function onInput(event: Event) {
+  const target = event.currentTarget as HTMLInputElement;
+  const _value = uncertainStringToNumber(target.value);
+  if (_value !== value) onChange(record.id, _value);
+}
+</script>
+
+<input
+  id="input-slider-{record.id}"
+  type="range"
+  name="{record.id}"
+  min="{record.minimum}"
+  max="{record.maximum}"
+  value="{value}"
+  aria-label="{record.description}"
+  on:input="{onInput}"
+  class="w-full h-1 bg-[var(--pf-global--primary-color--300)] rounded-lg appearance-none accent-[var(--pf-global--primary-color--300)] cursor-pointer range-xs mt-2" />

--- a/packages/renderer/src/lib/preferences/item-formats/SliderItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/SliderItem.svelte
@@ -3,8 +3,8 @@ import type { IConfigurationPropertyRecordedSchema } from '../../../../../main/s
 import { uncertainStringToNumber } from '../Util';
 
 export let record: IConfigurationPropertyRecordedSchema;
-export let value: number = uncertainStringToNumber(record.maximum);
-export let onChange = (_id: string, _value: number) => {};
+export let value: number;
+export let onChange = async (_id: string, _value: number) => {};
 
 function onInput(event: Event) {
   const target = event.currentTarget as HTMLInputElement;

--- a/packages/renderer/src/lib/preferences/item-formats/SliderItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/SliderItem.svelte
@@ -9,7 +9,7 @@ export let onChange = (_id: string, _value: number) => {};
 function onInput(event: Event) {
   const target = event.currentTarget as HTMLInputElement;
   const _value = uncertainStringToNumber(target.value);
-  if (_value !== value) onChange(record.id, _value);
+  if (record.id && _value !== value) onChange(record.id, _value);
 }
 </script>
 

--- a/packages/renderer/src/lib/preferences/item-formats/StringItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/item-formats/StringItem.spec.ts
@@ -2,7 +2,7 @@ import '@testing-library/jest-dom/vitest';
 import { test, expect, vi, beforeAll } from 'vitest';
 import { render, screen } from '@testing-library/svelte';
 import type { IConfigurationPropertyRecordedSchema } from '../../../../../main/src/plugin/configuration-registry';
-import StringItem from '/@/lib/preferences/item-formats/StringItem.svelte';
+import StringItem from './StringItem.svelte';
 
 beforeAll(() => {
   (window as any).getConfigurationValue = vi.fn();

--- a/packages/renderer/src/lib/preferences/item-formats/StringItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/item-formats/StringItem.spec.ts
@@ -1,0 +1,25 @@
+import '@testing-library/jest-dom/vitest';
+import { test, expect, vi, beforeAll } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import type { IConfigurationPropertyRecordedSchema } from '../../../../../main/src/plugin/configuration-registry';
+import StringItem from '/@/lib/preferences/item-formats/StringItem.svelte';
+
+beforeAll(() => {
+  (window as any).getConfigurationValue = vi.fn();
+});
+
+test('Ensure HTMLInputElement', async () => {
+  const record: IConfigurationPropertyRecordedSchema = {
+    id: 'record',
+    title: 'record',
+    parentId: 'parent.record',
+    description: 'record-description',
+    type: 'string',
+  };
+
+  render(StringItem, { record, value: '' });
+  const input = screen.getByLabelText('record-description');
+  expect(input).toBeInTheDocument();
+
+  expect(input instanceof HTMLInputElement).toBe(true);
+});

--- a/packages/renderer/src/lib/preferences/item-formats/StringItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/item-formats/StringItem.spec.ts
@@ -23,3 +23,35 @@ test('Ensure HTMLInputElement', async () => {
 
   expect(input instanceof HTMLInputElement).toBe(true);
 });
+
+test('Ensure placeholder is correctly used', async () => {
+  const record: IConfigurationPropertyRecordedSchema = {
+    id: 'record',
+    title: 'record',
+    parentId: 'parent.record',
+    description: 'record-description',
+    type: 'string',
+    placeholder: 'placeholder',
+  };
+
+  render(StringItem, { record, value: '' });
+  const input = screen.getByLabelText('record-description');
+  expect(input).toBeInTheDocument();
+  expect((input as HTMLInputElement).placeholder).toBe(record.placeholder);
+});
+
+test('Ensure HTMLInputElement', async () => {
+  const record: IConfigurationPropertyRecordedSchema = {
+    id: 'record',
+    title: 'record',
+    parentId: 'parent.record',
+    description: 'record-description',
+    type: 'string',
+    readonly: true,
+  };
+
+  render(StringItem, { record, value: '' });
+  const input = screen.getByLabelText('record-description');
+  expect(input).toBeInTheDocument();
+  expect((input as HTMLInputElement).readOnly).toBeTruthy();
+});

--- a/packages/renderer/src/lib/preferences/item-formats/StringItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/StringItem.svelte
@@ -6,7 +6,7 @@ export let onChange = (_id: string, _value: string) => {};
 
 function onInput(event: Event) {
   const target = event.target as HTMLInputElement;
-  if (target.value !== value) onChange(record.id, value);
+  if (record.id && target.value !== value) onChange(record.id, target.value);
 }
 </script>
 

--- a/packages/renderer/src/lib/preferences/item-formats/StringItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/StringItem.svelte
@@ -2,11 +2,14 @@
 import type { IConfigurationPropertyRecordedSchema } from '../../../../../main/src/plugin/configuration-registry';
 export let record: IConfigurationPropertyRecordedSchema;
 export let value: string | undefined;
-export let onChange = (_id: string, _value: string) => {};
+export let onChange = async (_id: string, _value: string) => {};
+
+let invalidEntry = false;
 
 function onInput(event: Event) {
   const target = event.target as HTMLInputElement;
-  if (record.id && target.value !== value) onChange(record.id, target.value);
+  if (record.id && target.value !== value)
+    onChange(record.id, target.value).catch((_: unknown) => (invalidEntry = true));
 }
 </script>
 
@@ -19,4 +22,5 @@ function onInput(event: Event) {
   bind:value="{value}"
   readonly="{!!record.readonly}"
   id="input-standard-{record.id}"
+  aria-invalid="{invalidEntry}"
   aria-label="{record.description}" />

--- a/packages/renderer/src/lib/preferences/item-formats/StringItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/StringItem.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+import type { IConfigurationPropertyRecordedSchema } from '../../../../../main/src/plugin/configuration-registry';
+export let record: IConfigurationPropertyRecordedSchema;
+export let value: string | undefined;
+export let onChange = (_id: string, _value: string) => {};
+
+function onInput(event: Event) {
+  const target = event.target as HTMLInputElement;
+  if (target.value !== value) onChange(record.id, value);
+}
+</script>
+
+<input
+  on:input="{onInput}"
+  class="grow py-1 px-2 w-full outline-0 border-b-2 border-gray-800 hover:border-violet-500 focus:border-violet-500 placeholder-gray-900"
+  name="{record.id}"
+  type="text"
+  placeholder="{record.placeholder}"
+  bind:value="{value}"
+  readonly="{!!record.readonly}"
+  id="input-standard-{record.id}"
+  aria-label="{record.description}" />


### PR DESCRIPTION
### What does this PR do?

The [PreferencesRenderingItemFormat.svelte](https://github.com/containers/podman-desktop/blob/main/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte) is a relatively complex file handling a lot of logic and managing different possible input component (checkbox, range input, number input, text input). 

The goal of this PR is to extract the logic of each individual component to different files for handling the logic of validating/handling changes in a dedicated way for each. Making the parent component easier to understand and to update.

This PR is open in the context of the following PR https://github.com/containers/podman-desktop/pull/3723
