### PR TITLE
fix: add podman in PATH after updating process env PATH (#3729)

### DIFF
--- a/packages/main/src/plugin/util/exec.spec.ts
+++ b/packages/main/src/plugin/util/exec.spec.ts
@@ -189,6 +189,26 @@ describe('getInstallationPath', () => {
     expect(path).toBe('c:\\Program Files\\RedHat\\Podman;');
   });
 
+  test('should return the installation path for Windows with pre-filled PATH', () => {
+    vi.spyOn(util, 'isWindows').mockImplementation(() => true);
+    vi.spyOn(util, 'isMac').mockImplementation(() => false);
+    process.env.PATH = 'c:\\Local';
+
+    const path = getInstallationPath();
+
+    expect(path).toBe('c:\\Program Files\\RedHat\\Podman;c:\\Local');
+  });
+
+  test('should return the installation path for Windows with defined param', () => {
+    vi.spyOn(util, 'isWindows').mockImplementation(() => true);
+    vi.spyOn(util, 'isMac').mockImplementation(() => false);
+    process.env.PATH = 'c:\\Local';
+
+    const path = getInstallationPath('c:\\Directory');
+
+    expect(path).toBe('c:\\Program Files\\RedHat\\Podman;c:\\Directory');
+  });
+
   test('should return the installation path for macOS', () => {
     vi.spyOn(util, 'isWindows').mockImplementation(() => false);
     vi.spyOn(util, 'isMac').mockImplementation(() => true);
@@ -200,6 +220,17 @@ describe('getInstallationPath', () => {
     expect(path).toBe(`/usr/bin:${macosExtraPath}`);
   });
 
+  test('should return the installation path for macOS with defined param', () => {
+    vi.spyOn(util, 'isWindows').mockImplementation(() => false);
+    vi.spyOn(util, 'isMac').mockImplementation(() => true);
+
+    process.env.PATH = '/usr/bin';
+
+    const path = getInstallationPath('/usr/other');
+
+    expect(path).toBe(`/usr/other:${macosExtraPath}`);
+  });
+
   test('should return the installation path for other platforms', () => {
     vi.spyOn(util, 'isWindows').mockImplementation(() => false);
     vi.spyOn(util, 'isMac').mockImplementation(() => false);
@@ -208,5 +239,15 @@ describe('getInstallationPath', () => {
     const path = getInstallationPath();
 
     expect(path).toBe('/usr/bin');
+  });
+
+  test('should return the installation path for other platforms with defined param', () => {
+    vi.spyOn(util, 'isWindows').mockImplementation(() => false);
+    vi.spyOn(util, 'isMac').mockImplementation(() => false);
+    process.env.PATH = '/usr/bin'; // Example PATH for other platforms
+
+    const path = getInstallationPath('/usr/other');
+
+    expect(path).toBe('/usr/other');
   });
 });


### PR DESCRIPTION
### What does this PR do?

it just change the order of when the PATH env is filled with podman.
If the exec receive an env using options, it first set it and then pass it to the function that adds the podman path.

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

it fixes #3729 

### How to test this PR?

1. remove podman from your PATH
2. try to create a kind cluster
3. for the rest, everything should work as before
