### PR TITLE
Update MacOS Troubleshooting Docs: rename podman-machine to podman

### DIFF
--- a/website/docs/troubleshooting/troubleshooting-podman-on-macos.md
+++ b/website/docs/troubleshooting/troubleshooting-podman-on-macos.md
@@ -86,10 +86,10 @@ Podman machine is running as a `x86_64` process and it could be due to a dual in
 
 You can
 
-1. Uninstall Podman machine on your `x86_64` brew install (for example from a terminal running under rosetta) `brew uninstall podman-machine`
+1. Uninstall Podman machine on your `x86_64` brew install (for example from a terminal running under rosetta) `brew uninstall podman`
 2. or uninstall brew `x86_64` as most brew receipe have now arm64 support: follow [these instructions](https://github.com/homebrew/install#uninstall-homebrew) from a terminal running under rosetta
 
-Then run a terminal in native mode (default) and install Podman machine `brew install podman-machine`
+Then run a terminal in native mode (default) and install Podman machine `brew install podman`
 
 Finally clean the Podman machine VMs that had been previously created, and create new ones.
 


### PR DESCRIPTION
podman-machine is not a valid brew formula

I ran into this issue where I had to re-install brew because after installing podman it kept pulling the x86_64 default machine instead of aarch64 on an M1 mac. However there is no formula named podman-machine, its just podman. Maybe it was named that in the past when this document was created?

### What does this PR do?
Clarifies that you should uninstall podman with brew because podman-machine is not a valid formula anymore that I can see.


### Screenshot/screencast of this PR

```
rgelobte@rgelobte-mac ~ % brew install podman-machine
Warning: No available formula with the name "podman-machine". Did you mean podman-compose?
==> Downloading https://formulae.brew.sh/api/formula_tap_migrations.jws.json
###################################################################################################################################### 100.0%
==> Downloading https://formulae.brew.sh/api/cask_tap_migrations.jws.json
###################################################################################################################################### 100.0%
==> Searching for similarly named formulae and casks...
==> Formulae
podman-compose

To install podman-compose, run:
  brew install podman-compose
```