### PR TITLE
chore(ui,tests): introduce ARIA roles and attributes into images, con…

### DIFF
--- a/packages/renderer/src/lib/ui/NavPage.svelte
+++ b/packages/renderer/src/lib/ui/NavPage.svelte
@@ -5,19 +5,19 @@ export let searchEnabled = true;
 </script>
 
 <div class="flex flex-col w-full h-full shadow-pageheader">
-  <div class="flex flex-col w-full h-full pt-4">
-    <div class="flex pb-2">
+  <div class="flex flex-col w-full h-full pt-4" role="region" aria-label="{title}">
+    <div class="flex pb-2" role="region" aria-label="header">
       <div class="px-5">
-        <h1 aria-label="{title}" class="text-xl first-letter:uppercase">{title}</h1>
+        <h1 class="text-xl first-letter:uppercase">{title}</h1>
       </div>
       <div class="flex flex-1 justify-end">
-        <div class="px-5">
+        <div class="px-5" role="group" aria-label="additionalActions">
           <slot name="additional-actions">&nbsp;</slot>
         </div>
       </div>
     </div>
     {#if searchEnabled}
-      <div class="flex flex-row pb-4">
+      <div class="flex flex-row pb-4" role="region" aria-label="search">
         <div class="pl-5 lg:w-[35rem] w-[22rem]">
           <div class="flex items-center bg-charcoal-800 text-gray-700 rounded-sm">
             <svg
@@ -40,13 +40,13 @@ export let searchEnabled = true;
               class="w-full py-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700" />
           </div>
         </div>
-        <div class="flex flex-1 px-5">
+        <div class="flex flex-1 px-5" role="group" aria-label="bottomAdditionalActions">
           <slot name="bottom-additional-actions">&nbsp;</slot>
         </div>
       </div>
     {/if}
 
-    <div class="flex w-full h-full overflow-auto">
+    <div class="flex w-full h-full overflow-auto" role="region" aria-label="content">
       <slot name="content" />
     </div>
   </div>

--- a/tests/src/model/pages/base-page.ts
+++ b/tests/src/model/pages/base-page.ts
@@ -20,6 +20,7 @@ import type { Page } from 'playwright';
 
 export abstract class BasePage {
   readonly page: Page;
+  // TODO: extract header and content locators into base class, add that roles into all pages
 
   constructor(page: Page) {
     this.page = page;

--- a/tests/src/model/pages/base-page.ts
+++ b/tests/src/model/pages/base-page.ts
@@ -18,7 +18,7 @@
 
 import type { Page } from 'playwright';
 
-export abstract class PodmanDesktopPage {
+export abstract class BasePage {
   readonly page: Page;
 
   constructor(page: Page) {

--- a/tests/src/model/pages/container-details-page.ts
+++ b/tests/src/model/pages/container-details-page.ts
@@ -17,12 +17,12 @@
  ***********************************************************************/
 
 import type { Locator, Page } from 'playwright';
-import { PodmanDesktopPage } from './base-page';
+import { BasePage } from './base-page';
 import { ContainersPage } from './containers-page';
 import { waitUntil, waitWhile } from '../../utility/wait';
 import { ContainerState } from '../core/states';
 
-export class ContainerDetailsPage extends PodmanDesktopPage {
+export class ContainerDetailsPage extends BasePage {
   readonly labelName: Locator;
   readonly heading: Locator;
   readonly closeLink: Locator;

--- a/tests/src/model/pages/containers-page.ts
+++ b/tests/src/model/pages/containers-page.ts
@@ -17,39 +17,27 @@
  ***********************************************************************/
 
 import type { Locator, Page } from 'playwright';
-import { PodmanDesktopPage } from './base-page';
+import { MainPage } from './main-page';
 import { ContainerDetailsPage } from './container-details-page';
 
-export class ContainersPage extends PodmanDesktopPage {
-  readonly heading: Locator;
+export class ContainersPage extends MainPage {
   readonly pruneContainersButton: Locator;
   readonly createContainerButton: Locator;
   readonly playKubernetesYAMLButton: Locator;
+  readonly deleteSelectedButton: Locator;
+  readonly createPodButton: Locator;
 
   constructor(page: Page) {
-    super(page);
-    this.heading = this.page.getByRole('heading', { name: 'Containers', exact: true });
-    this.pruneContainersButton = this.page.getByRole('button', { name: 'Prune containers' });
-    this.createContainerButton = this.page.getByRole('button', { name: 'Create a container' });
-    this.playKubernetesYAMLButton = this.page.getByRole('button', { name: 'Play Kubernetes YAML' });
-  }
-
-  async getTable(): Promise<Locator> {
-    if (!(await this.pageIsEmpty())) {
-      return this.page.getByRole('table');
-    } else {
-      throw Error('Containers page is empty, there are no containers');
-    }
-  }
-
-  async pageIsEmpty(): Promise<boolean> {
-    const noContainersHeading = this.page.getByRole('heading', { name: 'No containers', exact: true });
-    try {
-      await noContainersHeading.waitFor({ state: 'visible', timeout: 500 });
-    } catch (err) {
-      return false;
-    }
-    return true;
+    super(page, 'containers');
+    this.pruneContainersButton = this.additionalActions.getByRole('button', { name: 'Prune containers' });
+    this.createContainerButton = this.additionalActions.getByRole('button', { name: 'Create a container' });
+    this.playKubernetesYAMLButton = this.additionalActions.getByRole('button', { name: 'Play Kubernetes YAML' });
+    this.deleteSelectedButton = this.bottomAdditionalActions.getByRole('button', {
+      name: 'Delete selected containers and pods',
+    });
+    this.createPodButton = this.bottomAdditionalActions.getByRole('button', {
+      name: /Create Pod with \d+ selected items/,
+    });
   }
 
   async openContainersDetails(name: string): Promise<ContainerDetailsPage> {

--- a/tests/src/model/pages/containers-page.ts
+++ b/tests/src/model/pages/containers-page.ts
@@ -24,20 +24,12 @@ export class ContainersPage extends MainPage {
   readonly pruneContainersButton: Locator;
   readonly createContainerButton: Locator;
   readonly playKubernetesYAMLButton: Locator;
-  readonly deleteSelectedButton: Locator;
-  readonly createPodButton: Locator;
 
   constructor(page: Page) {
     super(page, 'containers');
     this.pruneContainersButton = this.additionalActions.getByRole('button', { name: 'Prune containers' });
     this.createContainerButton = this.additionalActions.getByRole('button', { name: 'Create a container' });
     this.playKubernetesYAMLButton = this.additionalActions.getByRole('button', { name: 'Play Kubernetes YAML' });
-    this.deleteSelectedButton = this.bottomAdditionalActions.getByRole('button', {
-      name: 'Delete selected containers and pods',
-    });
-    this.createPodButton = this.bottomAdditionalActions.getByRole('button', {
-      name: /Create Pod with \d+ selected items/,
-    });
   }
 
   async openContainersDetails(name: string): Promise<ContainerDetailsPage> {

--- a/tests/src/model/pages/dashboard-page.ts
+++ b/tests/src/model/pages/dashboard-page.ts
@@ -17,17 +17,23 @@
  ***********************************************************************/
 
 import type { Locator, Page } from 'playwright';
-import { PodmanDesktopPage } from './base-page';
+import { BasePage } from './base-page';
 
-export class DashboardPage extends PodmanDesktopPage {
+export class DashboardPage extends BasePage {
+  readonly mainPage: Locator;
+  readonly header: Locator;
+  readonly content: Locator;
   readonly heading: Locator;
   readonly devSandboxBox: Locator;
   readonly devSandboxStatus: Locator;
 
   constructor(page: Page) {
     super(page);
-    this.heading = page.getByRole('heading', { name: 'Dashboard' });
-    this.devSandboxBox = page.getByTitle('Free remote OpenShift sandbox environment for immediate access');
-    this.devSandboxStatus = page.getByText('Developer Sandbox is running');
+    this.mainPage = page.getByRole('region', { name: 'Dashboard' });
+    this.header = this.mainPage.getByRole('region', { name: 'header' });
+    this.content = this.mainPage.getByRole('region', { name: 'content' });
+    this.heading = this.header.getByRole('heading', { name: 'dashboard' });
+    this.devSandboxBox = this.content.getByTitle('Free remote OpenShift sandbox environment for immediate access');
+    this.devSandboxStatus = this.content.getByText('Developer Sandbox is running');
   }
 }

--- a/tests/src/model/pages/image-details-page.ts
+++ b/tests/src/model/pages/image-details-page.ts
@@ -17,10 +17,10 @@
  ***********************************************************************/
 
 import type { Locator, Page } from 'playwright';
-import { PodmanDesktopPage } from './base-page';
+import { BasePage } from './base-page';
 import { RunImagePage } from './run-image-page';
 
-export class ImageDetailsPage extends PodmanDesktopPage {
+export class ImageDetailsPage extends BasePage {
   readonly name: Locator;
   readonly imageName: string;
   readonly heading: Locator;

--- a/tests/src/model/pages/images-page.ts
+++ b/tests/src/model/pages/images-page.ts
@@ -17,44 +17,29 @@
  ***********************************************************************/
 
 import type { Locator, Page } from 'playwright';
-import { PodmanDesktopPage } from './base-page';
+import { MainPage } from './main-page';
 import { ImageDetailsPage } from './image-details-page';
 import { PullImagePage } from './pull-image-page';
 import { waitUntil, waitWhile } from '../../utility/wait';
 
-export class ImagesPage extends PodmanDesktopPage {
-  readonly heading: Locator;
+export class ImagesPage extends MainPage {
   readonly pullImageButton: Locator;
   readonly pruneImagesButton: Locator;
   readonly buildImageButton: Locator;
+  readonly deleteSelectedButton: Locator;
 
   constructor(page: Page) {
-    super(page);
-    this.heading = page.getByRole('heading', { name: 'images', exact: true });
-    this.pullImageButton = page.getByRole('button', { name: 'Pull an image' });
-    this.pruneImagesButton = page.getByRole('button', { name: 'Prune images' });
-    this.buildImageButton = page.getByRole('button', { name: 'Build an image' });
-  }
-
-  async pageIsEmpty(): Promise<boolean> {
-    const noImagesHeading = this.page.getByRole('heading', { name: 'No images', exact: true });
-    try {
-      await noImagesHeading.waitFor({ state: 'visible', timeout: 500 });
-    } catch (err) {
-      return false;
-    }
-    return true;
-  }
-
-  async getTable(): Promise<Locator> {
-    if (!(await this.pageIsEmpty())) {
-      return this.page.getByRole('table');
-    } else {
-      throw Error('Images page is empty, there are no images');
-    }
+    super(page, 'images');
+    this.pullImageButton = this.additionalActions.getByRole('button', { name: 'Pull an image' });
+    this.pruneImagesButton = this.additionalActions.getByRole('button', { name: 'Prune images' });
+    this.buildImageButton = this.additionalActions.getByRole('button', { name: 'Build an image' });
+    this.deleteSelectedButton = this.bottomAdditionalActions.getByRole('button', { name: /Delete \d+ selected items/ });
   }
 
   async openPullImage(): Promise<PullImagePage> {
+    if (await this.noContainerEngine()) {
+      throw Error('No Container Engine is present, cannot pull an image');
+    }
     await this.pullImageButton.click();
     return new PullImagePage(this.page);
   }

--- a/tests/src/model/pages/images-page.ts
+++ b/tests/src/model/pages/images-page.ts
@@ -26,14 +26,12 @@ export class ImagesPage extends MainPage {
   readonly pullImageButton: Locator;
   readonly pruneImagesButton: Locator;
   readonly buildImageButton: Locator;
-  readonly deleteSelectedButton: Locator;
 
   constructor(page: Page) {
     super(page, 'images');
     this.pullImageButton = this.additionalActions.getByRole('button', { name: 'Pull an image' });
     this.pruneImagesButton = this.additionalActions.getByRole('button', { name: 'Prune images' });
     this.buildImageButton = this.additionalActions.getByRole('button', { name: 'Build an image' });
-    this.deleteSelectedButton = this.bottomAdditionalActions.getByRole('button', { name: /Delete \d+ selected items/ });
   }
 
   async openPullImage(): Promise<PullImagePage> {

--- a/tests/src/model/pages/main-page.ts
+++ b/tests/src/model/pages/main-page.ts
@@ -1,0 +1,82 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { Locator, Page } from 'playwright';
+import { BasePage } from './base-page';
+
+/**
+ * Abstract representation of a visual page objects of the main content pages of Podman Desktop app: Images,
+ * Containers, Volumes and Pods.
+ * Is not intended to be directly used, but rather by particular page's implementation.
+ */
+export abstract class MainPage extends BasePage {
+  readonly title: string;
+  readonly mainPage: Locator;
+  readonly header: Locator;
+  readonly search: Locator;
+  readonly content: Locator;
+  readonly additionalActions: Locator;
+  readonly bottomAdditionalActions: Locator;
+  readonly heading: Locator;
+
+  constructor(page: Page, title: string) {
+    super(page);
+    this.title = title;
+    this.mainPage = page.getByRole('region', { name: this.title });
+    this.header = this.mainPage.getByRole('region', { name: 'header' });
+    this.search = this.mainPage.getByRole('region', { name: 'search' });
+    this.content = this.mainPage.getByRole('region', { name: 'content' });
+    this.additionalActions = this.header.getByRole('group', { name: 'additionalActions' });
+    this.bottomAdditionalActions = this.header.getByRole('group', { name: 'bottomAdditionalActions' });
+    this.heading = this.header.getByRole('heading', { name: this.title });
+  }
+
+  /**
+   * Check the presence of items in main page's content.
+   * @returns true, if there are any items present in the content's table, false otherwise
+   */
+  async pageIsEmpty(): Promise<boolean> {
+    if (!(await this.noContainerEngine())) {
+      const noImagesHeading = this.content.getByRole('heading', { name: `No ${this.title}`, exact: true });
+      try {
+        await noImagesHeading.waitFor({ state: 'visible', timeout: 500 });
+      } catch (err) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  async noContainerEngine(): Promise<boolean> {
+    const noContainerEngineHeading = this.content.getByRole('heading', { name: 'No Container Engine', exact: true });
+    try {
+      await noContainerEngineHeading.waitFor({ state: 'visible', timeout: 500 });
+    } catch (err) {
+      return false;
+    }
+    return true;
+  }
+
+  async getTable(): Promise<Locator> {
+    if (!(await this.pageIsEmpty())) {
+      return this.content.getByRole('table');
+    } else {
+      throw Error('Images page is empty, there are no images');
+    }
+  }
+}

--- a/tests/src/model/pages/pull-image-page.ts
+++ b/tests/src/model/pages/pull-image-page.ts
@@ -16,10 +16,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 import type { Locator, Page } from 'playwright';
-import { PodmanDesktopPage } from './base-page';
+import { BasePage } from './base-page';
 import { ImagesPage } from './images-page';
 
-export class PullImagePage extends PodmanDesktopPage {
+export class PullImagePage extends BasePage {
   readonly heading: Locator;
   readonly pullImageButton: Locator;
   readonly closeLink: Locator;

--- a/tests/src/model/pages/run-image-page.ts
+++ b/tests/src/model/pages/run-image-page.ts
@@ -17,10 +17,10 @@
  ***********************************************************************/
 
 import type { Locator, Page } from 'playwright';
-import { PodmanDesktopPage } from './base-page';
+import { BasePage } from './base-page';
 import { ContainersPage } from './containers-page';
 
-export class RunImagePage extends PodmanDesktopPage {
+export class RunImagePage extends BasePage {
   readonly name: Locator;
   readonly heading: Locator;
   readonly closeLink: Locator;

--- a/tests/src/model/pages/settings-page.ts
+++ b/tests/src/model/pages/settings-page.ts
@@ -17,9 +17,9 @@
  ***********************************************************************/
 
 import type { Locator, Page } from 'playwright';
-import { PodmanDesktopPage } from './base-page';
+import { BasePage } from './base-page';
 
-export abstract class SettingsPage extends PodmanDesktopPage {
+export abstract class SettingsPage extends BasePage {
   readonly tabName: string;
 
   constructor(page: Page, tabName: string) {

--- a/tests/src/model/pages/welcome-page.ts
+++ b/tests/src/model/pages/welcome-page.ts
@@ -17,10 +17,10 @@
  ***********************************************************************/
 
 import type { Locator, Page } from 'playwright';
-import { PodmanDesktopPage } from './base-page';
+import { BasePage } from './base-page';
 import { expect } from '@playwright/test';
 
-export class WelcomePage extends PodmanDesktopPage {
+export class WelcomePage extends BasePage {
   readonly welcomeMessage: Locator;
   readonly telemetryConsent: Locator;
   readonly goToPodmanDesktopButton: Locator;


### PR DESCRIPTION
…tainers pages

### What does this PR do?
Introduces some ARIA elements (roles and attributes) into "main" podman desktop pages (Images, containers, etc.). At the same time it also refactors test page objects into more logical and hierarchical structure.

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast 
explaining what is doing this PR -->

### What issues does this PR fix or reference?
#3338
<!-- Include any related issues from Podman Desktop 
repository (or from another issue tracker). -->

### How to test this PR?
E2E Tests should not be broken after this change.
`yarn run test:e2e:smoke`
<!-- Please explain steps to reproduce -->
