### PR TITLE
feat: support multiple configuration scopes

### DIFF
--- a/packages/main/src/plugin/configuration-registry.spec.ts
+++ b/packages/main/src/plugin/configuration-registry.spec.ts
@@ -111,4 +111,28 @@ describe('should be notified when a configuration is changed', async () => {
     expect(called).toBeTruthy();
     expect(expectAffectsConfiguration).toBeFalsy();
   });
+
+  test('affectsConfiguration called twice when updating value with two scopes', async () => {
+    let expectAffectsConfiguration: boolean;
+    let called = false;
+    let callNumber = 0;
+    let updatedValue: unknown;
+    configurationRegistry.onDidChangeConfiguration(() => {
+      callNumber += 1;
+    });
+    configurationRegistry.onDidChangeConfigurationAPI(e => {
+      called = true;
+      // use a parent property name
+      expectAffectsConfiguration = e.affectsConfiguration('my.fake');
+      if (expectAffectsConfiguration) {
+        updatedValue = configurationRegistry.getConfiguration('my.fake')?.get<string>('property');
+      }
+    });
+
+    await configurationRegistry.updateConfigurationValue('my.fake.property', 'myValue', ['DEFAULT', 'scope']);
+
+    expect(called).toBeTruthy();
+    expect(callNumber).toBe(2);
+    expect(updatedValue).toEqual('myValue');
+  });
 });

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1364,7 +1364,7 @@ export class PluginSystem {
         _listener: Electron.IpcMainInvokeEvent,
         key: string,
         value: unknown,
-        scope?: containerDesktopAPI.ConfigurationScope,
+        scope?: containerDesktopAPI.ConfigurationScope | containerDesktopAPI.ConfigurationScope[],
       ): Promise<void> => {
         return configurationRegistry.updateConfigurationValue(key, value, scope);
       },

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -941,8 +941,12 @@ function initExposure(): void {
 
   contextBridge.exposeInMainWorld(
     'updateConfigurationValue',
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    async (key: string, value: any, scope?: containerDesktopAPI.ConfigurationScope): Promise<void> => {
+    async (
+      key: string,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      value: any,
+      scope?: containerDesktopAPI.ConfigurationScope | containerDesktopAPI.ConfigurationScope[],
+    ): Promise<void> => {
       return ipcInvoke('configuration-registry:updateConfigurationValue', key, value, scope);
     },
   );

--- a/packages/renderer/src/lib/preferences/PreferencesPage.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesPage.svelte
@@ -3,7 +3,6 @@ import { configurationProperties } from '../../stores/configurationProperties';
 import { onMount } from 'svelte';
 import Route from '../../Route.svelte';
 import type { IConfigurationPropertyRecordedSchema } from '../../../../main/src/plugin/configuration-registry';
-import { CONFIGURATION_DEFAULT_SCOPE } from '../../../../main/src/plugin/configuration-registry-constants';
 import PreferencesRendering from './PreferencesRendering.svelte';
 import PreferencesContainerConnectionRendering from './PreferencesContainerConnectionRendering.svelte';
 import PreferencesKubernetesConnectionRendering from './PreferencesKubernetesConnectionRendering.svelte';
@@ -17,6 +16,7 @@ import PreferencesResourcesRendering from './PreferencesResourcesRendering.svelt
 import PreferencesAuthenticationProvidersRendering from './PreferencesAuthenticationProvidersRendering.svelte';
 import PreferencesInstallExtensionFromId from './PreferencesInstallExtensionFromId.svelte';
 import Onboarding from '../onboarding/Onboarding.svelte';
+import { isDefaultScope } from './Util';
 
 let properties: IConfigurationPropertyRecordedSchema[];
 let defaultPrefPageId: string;
@@ -26,7 +26,7 @@ onMount(async () => {
     properties = value;
 
     const iterator = value
-      .filter(property => property.scope === CONFIGURATION_DEFAULT_SCOPE)
+      .filter(property => isDefaultScope(property.scope))
       .values()
       .next().value;
 

--- a/packages/renderer/src/lib/preferences/PreferencesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRendering.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
 import type { IConfigurationPropertyRecordedSchema } from '../../../../main/src/plugin/configuration-registry';
-import { CONFIGURATION_DEFAULT_SCOPE } from '../../../../main/src/plugin/configuration-registry-constants';
 
 import PreferencesRenderingItem from './PreferencesRenderingItem.svelte';
 import SettingsPage from './SettingsPage.svelte';
 import Route from '../../Route.svelte';
+import { isDefaultScope } from './Util';
 
 export let properties: IConfigurationPropertyRecordedSchema[] = [];
 export let key: string;
@@ -16,9 +16,7 @@ export let searchValue = '';
 $: searchValue;
 
 $: matchingRecords = properties
-  .filter(
-    property => property.parentId.startsWith(key) && property.scope === CONFIGURATION_DEFAULT_SCOPE && !property.hidden,
-  )
+  .filter(property => property.parentId.startsWith(key) && isDefaultScope(property.scope) && !property.hidden)
   .filter(
     property =>
       !searchValue ||

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
@@ -5,7 +5,7 @@ import type { IConfigurationPropertyRecordedSchema } from '../../../../main/src/
 import { CONFIGURATION_DEFAULT_SCOPE } from '../../../../main/src/plugin/configuration-registry-constants';
 import ErrorMessage from '../ui/ErrorMessage.svelte';
 import Markdown from '../markdown/Markdown.svelte';
-import { getNormalizedDefaultNumberValue } from './Util';
+import { getNormalizedDefaultNumberValue, isDefaultScope } from './Util';
 import Tooltip from '../ui/Tooltip.svelte';
 import Button from '../ui/Button.svelte';
 
@@ -38,9 +38,9 @@ $: if (resetToDefault) {
 }
 
 $: if (currentRecord !== record) {
-  if (record.scope === CONFIGURATION_DEFAULT_SCOPE) {
+  if (isDefaultScope(record.scope)) {
     if (record.id) {
-      window.getConfigurationValue(record.id, record.scope).then(value => {
+      window.getConfigurationValue(record.id, CONFIGURATION_DEFAULT_SCOPE).then(value => {
         recordValue = value;
         if (record.type === 'boolean') {
           recordValue = !!value;

--- a/packages/renderer/src/lib/preferences/Util.spec.ts
+++ b/packages/renderer/src/lib/preferences/Util.spec.ts
@@ -17,7 +17,7 @@
  ***********************************************************************/
 
 import { test, expect, vi, afterEach } from 'vitest';
-import { getNormalizedDefaultNumberValue, writeToTerminal } from './Util';
+import { getNormalizedDefaultNumberValue, isTargetScope, writeToTerminal } from './Util';
 import type { IConfigurationPropertyRecordedSchema } from '../../../../main/src/plugin/configuration-registry';
 
 const xtermMock = {
@@ -121,4 +121,29 @@ test('return default number value if less than maximum number value', () => {
   };
   const res = getNormalizedDefaultNumberValue(record);
   expect(res).equal(8);
+});
+
+test('return false if scope is undefined and targetScope is defined', () => {
+  const result = isTargetScope('DEFAULT', undefined);
+  expect(result).toBe(false);
+});
+
+test('return false if scope is an array and targetScope is not contained in it', () => {
+  const result = isTargetScope('DEFAULT', ['Onboarding']);
+  expect(result).toBe(false);
+});
+
+test('return false if scope is a string and it is different from targetScope', () => {
+  const result = isTargetScope('DEFAULT', 'Onboarding');
+  expect(result).toBe(false);
+});
+
+test('return true if scope is an array and targetScope is contained in it', () => {
+  const result = isTargetScope('DEFAULT', ['scope', 'DEFAULT']);
+  expect(result).toBe(true);
+});
+
+test('return true if scope is a string and it is equal to targetScope', () => {
+  const result = isTargetScope('DEFAULT', 'DEFAULT');
+  expect(result).toBe(true);
 });

--- a/packages/renderer/src/lib/preferences/Util.ts
+++ b/packages/renderer/src/lib/preferences/Util.ts
@@ -16,12 +16,14 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { ConfigurationScope } from '@podman-desktop/api';
 import type {
   ProviderContainerConnectionInfo,
   ProviderInfo,
   ProviderKubernetesConnectionInfo,
 } from '../../../../main/src/plugin/api/provider-info';
 import type { IConfigurationPropertyRecordedSchema } from '../../../../main/src/plugin/configuration-registry';
+import { CONFIGURATION_DEFAULT_SCOPE } from '../../../../main/src/plugin/configuration-registry-constants';
 
 export interface IProviderConnectionConfigurationPropertyRecorded extends IConfigurationPropertyRecordedSchema {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -90,4 +92,18 @@ export function getNormalizedDefaultNumberValue(configurationKey: IConfiguration
     return configurationKey.default;
   }
   return configurationKey.maximum;
+}
+
+export function isDefaultScope(scope?: ConfigurationScope | ConfigurationScope[]): boolean {
+  return isTargetScope(CONFIGURATION_DEFAULT_SCOPE, scope);
+}
+
+export function isTargetScope(
+  targetScope: ConfigurationScope,
+  scope?: ConfigurationScope | ConfigurationScope[],
+): boolean {
+  if (Array.isArray(scope) && scope.find(s => s === targetScope)) {
+    return true;
+  }
+  return scope === targetScope;
 }


### PR DESCRIPTION
### What does this PR do?

This PR adds the logic to support multiple scopes in a configuration. It will be used to add a configuration that contains an onboarding scope to specify which settings can be shown in the onboarding workflow

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

it is part of #3718 

### How to test this PR?

run tests
