### PR TITLE
feat: add autostart podman engine configuration to display in podman onboarding (#3718)

### DIFF
--- a/extensions/podman/package.json
+++ b/extensions/podman/package.json
@@ -185,7 +185,14 @@
         {
           "id": "podmanInstalled",
           "title": "Podman successfully installed",
-          "when": "!onboardingContext:podmanIsNotInstalled"
+          "when": "!onboardingContext:podmanIsNotInstalled",
+          "content": [
+            [
+              {
+                "value": "${configuration:preferences.podman-desktop.podman.engine.autostart}"
+              }
+            ]
+          ]
         },
         {
           "id": "preCreatePodmanMachine",

--- a/packages/main/src/plugin/autostart-engine.spec.ts
+++ b/packages/main/src/plugin/autostart-engine.spec.ts
@@ -23,6 +23,7 @@ import type { Directories } from './directories.js';
 import type { ProviderRegistry } from './provider-registry.js';
 import { AutostartEngine } from './autostart-engine.js';
 import type { Configuration } from '@podman-desktop/api';
+import { CONFIGURATION_DEFAULT_SCOPE, CONFIGURATION_ONBOARDING_SCOPE } from './configuration-registry-constants.js';
 
 let configurationRegistry: ConfigurationRegistry;
 let providerRegistry: ProviderRegistry;
@@ -73,6 +74,7 @@ test('Check that default value is false if provider autostart setting is undefin
         description: `Autostart ${extensionDisplayName} engine when launching Podman Desktop`,
         type: 'boolean',
         default: false,
+        scope: [CONFIGURATION_DEFAULT_SCOPE, CONFIGURATION_ONBOARDING_SCOPE],
       },
     },
   };
@@ -114,6 +116,7 @@ test('Check that default value is true if neither provider autostart setting nor
         description: `Autostart ${extensionDisplayName} engine when launching Podman Desktop`,
         type: 'boolean',
         default: true,
+        scope: [CONFIGURATION_DEFAULT_SCOPE, CONFIGURATION_ONBOARDING_SCOPE],
       },
     },
   };

--- a/packages/main/src/plugin/autostart-engine.ts
+++ b/packages/main/src/plugin/autostart-engine.ts
@@ -19,6 +19,7 @@
 import { Disposable } from './types/disposable.js';
 import type { ConfigurationRegistry, IConfigurationNode } from './configuration-registry.js';
 import type { ProviderRegistry } from './provider-registry.js';
+import { CONFIGURATION_DEFAULT_SCOPE, CONFIGURATION_ONBOARDING_SCOPE } from './configuration-registry-constants.js';
 
 export class AutostartEngine {
   private providerExtension = new Map<string, string>();
@@ -58,6 +59,7 @@ export class AutostartEngine {
           description: `Autostart ${extensionDisplayName} engine when launching Podman Desktop`,
           type: 'boolean',
           default: autostart !== undefined ? autostart : true,
+          scope: [CONFIGURATION_DEFAULT_SCOPE, CONFIGURATION_ONBOARDING_SCOPE],
         },
       },
     };

--- a/packages/main/src/plugin/configuration-registry-constants.ts
+++ b/packages/main/src/plugin/configuration-registry-constants.ts
@@ -17,3 +17,4 @@
  ***********************************************************************/
 
 export const CONFIGURATION_DEFAULT_SCOPE = 'DEFAULT';
+export const CONFIGURATION_ONBOARDING_SCOPE = 'Onboarding';

--- a/packages/main/src/plugin/configuration-registry.ts
+++ b/packages/main/src/plugin/configuration-registry.ts
@@ -71,7 +71,8 @@ export type ConfigurationScope =
   | 'ContainerConnection'
   | 'KubernetesConnection'
   | 'ContainerProviderConnectionFactory'
-  | 'KubernetesProviderConnectionFactory';
+  | 'KubernetesProviderConnectionFactory'
+  | 'Onboarding';
 
 export interface IConfigurationExtensionInfo {
   id: string;

--- a/packages/renderer/src/lib/onboarding/OnboardingItem.spec.ts
+++ b/packages/renderer/src/lib/onboarding/OnboardingItem.spec.ts
@@ -22,6 +22,7 @@ import OnboardingItem from './OnboardingItem.svelte';
 import type { OnboardingStepItem } from '../../../../main/src/plugin/api/onboarding';
 import { ContextUI } from '../context/context';
 import { configurationProperties } from '/@/stores/configurationProperties';
+import { CONFIGURATION_ONBOARDING_SCOPE } from '../../../../main/src/plugin/configuration-registry-constants';
 
 test('Expect button html when passing a button tag in markdown', async () => {
   const textComponent: OnboardingStepItem = {
@@ -86,6 +87,7 @@ test('Expect boolean configuration placeholder to be replaced with a checkbox', 
       id: 'extension.boolean.prop',
       type: 'boolean',
       default: false,
+      scope: CONFIGURATION_ONBOARDING_SCOPE,
     },
   ]);
   render(OnboardingItem, {
@@ -118,6 +120,7 @@ test('Expect when configuration placeholder is type string and format file to be
       id: 'extension.format.prop',
       type: 'string',
       format: 'file',
+      scope: CONFIGURATION_ONBOARDING_SCOPE,
     },
   ]);
   render(OnboardingItem, {
@@ -151,6 +154,7 @@ test('Expect a type text configuration placeholder to be replaced by a text inpu
       hidden: false,
       id: 'extension.text.prop',
       type: 'string',
+      scope: CONFIGURATION_ONBOARDING_SCOPE,
     },
   ]);
   render(OnboardingItem, {

--- a/packages/renderer/src/lib/onboarding/OnboardingItem.svelte
+++ b/packages/renderer/src/lib/onboarding/OnboardingItem.svelte
@@ -7,6 +7,8 @@ import { SCOPE_ONBOARDING } from './onboarding-utils';
 import type { IConfigurationPropertyRecordedSchema } from '../../../../main/src/plugin/configuration-registry';
 import { configurationProperties } from '/@/stores/configurationProperties';
 import PreferencesRenderingItem from '../preferences/PreferencesRenderingItem.svelte';
+import { CONFIGURATION_ONBOARDING_SCOPE } from '../../../../main/src/plugin/configuration-registry-constants';
+import { isTargetScope } from '../preferences/Util';
 export let extension: string;
 export let item: OnboardingStepItem;
 export let getContext: () => ContextUI;
@@ -31,7 +33,11 @@ onMount(() => {
     const matches = [...item.value.matchAll(configurationRegex)];
     if (matches.length > 0 && matches[0].length > 1) {
       configurationItem = configurationItems.find(
-        config => !config.hidden && config.extension?.id === extension && config.id === matches[0][1],
+        config =>
+          !config.hidden &&
+          isTargetScope(CONFIGURATION_ONBOARDING_SCOPE, config.scope) &&
+          config.extension?.id === extension &&
+          config.id === matches[0][1],
       );
     }
   });


### PR DESCRIPTION
### What does this PR do?

This PR adds a filter so that only the configurations with the "Onboarding" scope will be displayed during the onboarding workflow.
It also adds the configuration to enable the podman engine autostart.

### Screenshot/screencast of this PR

![image](https://github.com/containers/podman-desktop/assets/49404737/d3d39ad5-c5cf-4b90-9a09-61ed3092db91)

### What issues does this PR fix or reference?

it resolves #3718 

### How to test this PR?

1. when following the onboarding from scratch, after having installed podman, you should see the setting (in the "podman successfully installed" step). Right now, you can even see it after clicking on the clog icon when podman is already installed (this will be fixed in next PRs). 
