### PR TITLE
feat: onboarding add link micromark for commands

### DIFF
--- a/packages/renderer/src/lib/markdown/Markdown.spec.ts
+++ b/packages/renderer/src/lib/markdown/Markdown.spec.ts
@@ -73,3 +73,30 @@ describe('Custom button', () => {
     );
   });
 });
+
+describe('Custom link', () => {
+  test('Expect link to be rendered as a link without attributes', async () => {
+    await waitRender({ markdown: ':link[Name of the link]' });
+    const markdownContent = screen.getByRole('region', { name: 'markdown-content' });
+    expect(markdownContent).toBeInTheDocument();
+    expect(markdownContent).toContainHTML('<a>Name of the link</a>');
+  });
+
+  test('Expect link to be rendered as a link with all attributes', async () => {
+    await waitRender({ markdown: ':link[Name of the link]{href=https://my-link title="tooltip text"}' });
+    const markdownLink = screen.getByRole('link');
+    expect(markdownLink).toBeInTheDocument();
+    expect(markdownLink).toHaveTextContent('Name of the link');
+    expect(markdownLink).toHaveAttribute('href', 'https://my-link');
+    expect(markdownLink).toHaveAttribute('title', 'tooltip text');
+  });
+
+  test('Expect link to be rendered as a link without href and with command attribute', async () => {
+    await waitRender({ markdown: ':link[Name of the link]{command=example.onboarding.command.checkRequirements}' });
+    const markdownContent = screen.getByRole('region', { name: 'markdown-content' });
+    expect(markdownContent).toBeInTheDocument();
+    expect(markdownContent).toContainHTML(
+      '<a data-command="example.onboarding.command.checkRequirements">Name of the link</a>',
+    );
+  });
+});

--- a/packages/renderer/src/lib/markdown/Markdown.svelte
+++ b/packages/renderer/src/lib/markdown/Markdown.svelte
@@ -1,3 +1,5 @@
+<!-- The markdown rendered has it's own style that you'll have to customize / check against podman desktop 
+UI guidelines -->
 <style>
 .markdown > :global(p) {
   line-height: revert;
@@ -30,6 +32,7 @@ import { onDestroy, onMount } from 'svelte';
 import { micromark } from 'micromark';
 import { directive, directiveHtml } from 'micromark-extension-directive';
 import { button } from './micromark-button-directive';
+import { link } from './micromark-link-directive';
 
 let text: string;
 let html: string;
@@ -37,35 +40,53 @@ let html: string;
 // Optional attribute to specify the markdown to use
 // the user can use: <Markdown>**bold</Markdown> or <Markdown markdown="**bold**" /> syntax
 export let markdown = '';
+
+// Button micromark related:
+//
+// In progress execution callbacks for all markdown buttons.
 export let inProgressMarkdownCommandExecutionCallback: (
   command: string,
   state: 'starting' | 'failed' | 'successful',
   value?: unknown,
 ) => void = () => {};
 
+// Create an event listener for updating the in-progress markdown command execution callback
+const eventListeners: ((e: any) => void)[] = [];
+
+// Render the markdown or the html+micromark markdown reactively
 $: markdown
   ? (html = micromark(markdown, {
       extensions: [directive()],
-      htmlExtensions: [directiveHtml({ button })],
+      htmlExtensions: [directiveHtml({ button, link })],
     }))
   : undefined;
-
-const eventListeners: ((e: any) => void)[] = [];
 
 onMount(() => {
   if (markdown) {
     text = markdown;
   }
-  // provide our custom extension that allow to create buttons
+
+  // Provide micromark + extensions
   html = micromark(text, {
     extensions: [directive()],
-    htmlExtensions: [directiveHtml({ button })],
+    htmlExtensions: [directiveHtml({ button, link })],
   });
 
+  // We create a click listener in order to execute any internal commands using:
+  // window.executeCommand()
+  // We add the clickListener here since we're unable to add it in the directive typescript file.
   const clickListener = (e: any) => {
-    if (e.target instanceof HTMLButtonElement) {
-      const command = e.target.dataset.command;
-      if (command && !e.target.disabled) {
+    // Retrieve the command within the dataset
+    const command = e.target.dataset.command;
+
+    // Only check if the command exists and the target is not disabled
+    if (command && !e.target.disabled) {
+      // If the target is an instance of a button element, we know that we are going to execute either
+      // a command or hyperlink
+      if (e.target instanceof HTMLButtonElement) {
+        // If the command exists and the button is not disabled, we execute the command
+        // we'll also be updating the inProgressMarkdownCommandExecutionCallback so we have
+        // real-time updates on the button
         inProgressMarkdownCommandExecutionCallback(command, 'starting');
         e.target.disabled = true;
         e.target.firstChild.style.display = 'inline-block';
@@ -77,18 +98,26 @@ onMount(() => {
             e.target.disabled = false;
             e.target.firstChild.style.display = 'none';
           });
+      } else if (e.target instanceof HTMLAnchorElement) {
+        // Execute the command since it's a simple "link" to it
+        // usually associated with a dialog / quickpick action.
+        window.executeCommand(command);
       }
     }
   };
+
+  // Push the click listener to the eventListeners array so we can remove it on destroy
   eventListeners.push(clickListener);
   document.addEventListener('click', clickListener);
 });
+
+// Remove on destroy / make sure we do not listen anymore.
 onDestroy(() => {
   eventListeners.forEach(listener => document.removeEventListener('click', listener));
 });
 </script>
 
-<!-- placeholder to grab the content if people are using <Markdown>**bold</Markdown> -->
+<!-- Placeholder to grab the content if people are using <Markdown>**bold</Markdown> -->
 <span contenteditable="false" bind:textContent="{text}" class="hidden">
   <slot />
 </span>

--- a/packages/renderer/src/lib/markdown/micromark-button-directive.ts
+++ b/packages/renderer/src/lib/markdown/micromark-button-directive.ts
@@ -22,47 +22,54 @@
 /**
  * Allow to generate a custom button markdown directive
  * syntax is the following:
+ * :button[Name of the button]{command=command.example title="tooltip text"}
+ * or
  * :button[Name of the button]{href=http://my-link title="tooltip text"}
  */
-
 /**
  * @this {import('micromark-util-types').CompileContext}
  * @type {import('micromark-extension-directive').Handle}
  */
 export function button(d: any) {
+  // Make sure it's not part of a text directive
   if (d.type !== 'textDirective') {
     return false;
   }
 
-  // create button html if it has command attribute
+  // Make sure {command=example} has been passed in
   if (d.attributes && 'command' in d.attributes) {
+    // Make this a button if it's a command
     this.tag(
       '<button class="px-4 py-[6px] rounded-[4px] text-white text-[13px] whitespace-nowrap bg-purple-600 hover:bg-purple-500 no-underline" data-command="' +
         this.encode(d.attributes.command) +
         '">',
     );
 
+    // Add the "progress" spinner
+    // TODO: Remove cloudfoundry to tailwind
     this.tag(
       '<i class="pf-c-button__progress" style="position: relative; margin-right:5px; display: none;"><span class="pf-c-spinner pf-m-sm" role="progressbar"><span class="pf-c-spinner__clipper">' +
         '</span><span class="pf-c-spinner__lead-ball"></span><span class="pf-c-spinner__tail-ball"></span></span></i>',
     );
 
+    // Add any labels and close the button
     this.raw(d.label || '');
     this.tag('</button>');
   } else {
-    // it is a link
+    // If href is passed in, make this an anchor tag but make it look like a button
     this.tag(
       '<a class="px-4 py-[6px] rounded-[4px] text-white text-[13px] whitespace-nowrap bg-purple-600 hover:bg-purple-500 no-underline"',
     );
 
+    // Href & title
     if (d.attributes && 'href' in d.attributes) {
       this.tag(' href="' + this.encode(d.attributes.href) + '"');
     }
-
     if (d.attributes && 'title' in d.attributes) {
       this.tag(' title="' + this.encode(d.attributes.title) + '"');
     }
 
+    // Add the closing tags + labels (if any)
     this.tag('>');
     this.raw(d.label || '');
     this.tag('</a>');

--- a/packages/renderer/src/lib/markdown/micromark-link-directive.ts
+++ b/packages/renderer/src/lib/markdown/micromark-link-directive.ts
@@ -1,0 +1,59 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+// @ts-nocheck
+
+/**
+ * Allow to generate a link markdown directive that executes a command
+ * syntax is the following:
+ * :link[Name of the command link]{command=command.example title="tooltip text"}
+ * or
+ * :link[Name of the command link]{href=http://my-link title="tooltip text"}
+ */
+/**
+ * @this {import('micromark-util-types').CompileContext}
+ * @type {import('micromark-extension-directive').Handle}
+ */
+export function link(d: any) {
+  // Make sure it's not part of a text directive
+  if (d.type !== 'textDirective') {
+    return false;
+  }
+
+  // Add the anchor tag
+  this.tag('<a ');
+
+  // If it's a command {command=example} add the data-command attribute,
+  // otherwise add the href {href=https://foobar.com} attribute
+  if (d.attributes && 'command' in d.attributes) {
+    this.tag(' data-command="' + this.encode(d.attributes.command) + '"');
+  } else if (d.attributes && 'href' in d.attributes) {
+    this.tag(' href="' + this.encode(d.attributes.href) + '"');
+  }
+
+  // Add the title attribute if it's passed in
+  if (d.attributes && 'title' in d.attributes) {
+    this.tag(' title="' + this.encode(d.attributes.title) + '"');
+  }
+
+  // Close the tags and add the label (if any)
+  this.tag('>');
+  this.raw(d.label || '');
+  this.tag('</a>');
+}


### PR DESCRIPTION
feat: onboarding add link micromark for commands

### What does this PR do?

* Adds the ability to define
  `:link[command]{command=podman.onboarding.checkPodmanRequirements}`
  within `package.json` onboarding section and have it show up as a link
  that's clickable to a command that's executed. This helps add the
  ability for commands such as an "install version quickpick" to be used
* Added comments due to no comments in markdown section.
* You can also still use
  `:link[command]{href=https://foobar.com}` similar to how button
  micromark does

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast
explaining what is doing this PR -->


https://github.com/containers/podman-desktop/assets/6422176/7c2520b7-5fd3-4a02-9a67-415f4c6e16c2



### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop/issues/3710

### How to test this PR?

Add `:link[command]{command=podman.onboarding.checkPodmanRequirements}`
or a different test command to a "section" part of onboarding in
`package.json` of podman and click on the link. It'll run the command.

<!-- Please explain steps to reproduce -->

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
