### PR TITLE
feat: show lima version

### DIFF
--- a/extensions/lima/package.json
+++ b/extensions/lima/package.json
@@ -20,6 +20,12 @@
     "configuration": {
       "title": "Lima",
       "properties": {
+        "lima.binary.path": {
+          "type": "string",
+          "format": "file",
+          "default": "",
+          "description": "Custom path to limactl binary (Default is blank)"
+        },
         "lima.type": {
           "type": "string",
           "default": "podman",

--- a/extensions/lima/src/extension.ts
+++ b/extensions/lima/src/extension.ts
@@ -22,6 +22,7 @@ import * as os from 'os';
 import * as fs from 'fs';
 
 import { configuration } from '@podman-desktop/api';
+import { getLimaInstallation } from './limactl';
 
 type limaProviderType = 'docker' | 'podman' | 'kubernetes';
 
@@ -68,12 +69,16 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
   const socketPath = path.resolve(limaHome, instanceName + '/sock/' + engineType + '.sock');
   const configPath = path.resolve(limaHome, instanceName + '/copied-from-guest/kubeconfig.yaml');
 
+  const installedLima = await getLimaInstallation();
+  const version: string | undefined = installedLima?.version;
+
   let provider;
   if (fs.existsSync(socketPath) || fs.existsSync(configPath)) {
     provider = extensionApi.provider.createProvider({
       name: 'Lima',
       id: 'lima',
       status: 'unknown',
+      version,
       images: {
         icon: './icon.png',
         logo: {

--- a/extensions/lima/src/limactl.ts
+++ b/extensions/lima/src/limactl.ts
@@ -1,0 +1,68 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import * as extensionApi from '@podman-desktop/api';
+
+const macosExtraPath = '/usr/local/bin:/opt/homebrew/bin:/opt/local/bin';
+
+export function getInstallationPath(): string {
+  const env = process.env;
+  if (extensionApi.env.isMac) {
+    if (!env.PATH) {
+      return macosExtraPath;
+    } else {
+      return env.PATH.concat(':').concat(macosExtraPath);
+    }
+  } else {
+    return env.PATH;
+  }
+}
+
+export function getLimactl(): string {
+  // If we have a custom binary path regardless if we are running Windows or not
+  const customBinaryPath = getCustomBinaryPath();
+  if (customBinaryPath) {
+    return customBinaryPath;
+  }
+
+  if (extensionApi.env.isWindows) {
+    return 'limactl.exe';
+  }
+  return 'limactl';
+}
+
+// Get the limactl binary path from configuration lima.binary.path
+// return string or undefined
+export function getCustomBinaryPath(): string | undefined {
+  return extensionApi.configuration.getConfiguration('lima').get('binary.path');
+}
+
+export interface InstalledLima {
+  version: string;
+}
+
+export async function getLimaInstallation(): Promise<InstalledLima | undefined> {
+  try {
+    const { stdout: versionOut } = await extensionApi.process.exec(getLimactl(), ['--version']);
+    const versionArr = versionOut.split(' ');
+    const version = versionArr[versionArr.length - 1];
+    return { version };
+  } catch (err) {
+    // no limactl binary
+    return undefined;
+  }
+}


### PR DESCRIPTION
### What does this PR do?

Finds the location of the `limactl` binary, and show the version of Lima.

### Screenshot/screencast of this PR

![podman-desktop-lima-version](https://github.com/containers/podman-desktop/assets/10364051/27f436d2-94a0-4283-9f6a-40c2e25eb86f)

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop 
repository (or from another issue tracker). -->

### How to test this PR?

`brew install lima`
`limactl start template://podman`