### PR TITLE
feat: using bash if available otherwise sh in terminal

### DIFF
--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -1312,7 +1312,7 @@ export class ContainerProviderRegistry {
         AttachStdin: true,
         AttachStdout: true,
         AttachStderr: true,
-        Cmd: ['/bin/sh'],
+        Cmd: ['/bin/sh', '-c', 'clear; (bash || sh)'],
         Tty: true,
       });
 

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -1312,7 +1312,7 @@ export class ContainerProviderRegistry {
         AttachStdin: true,
         AttachStdout: true,
         AttachStderr: true,
-        Cmd: ['/bin/sh', '-c', '(bash || clear && sh)'],
+        Cmd: ['/bin/sh', '-c', 'if command -v bash >/dev/null 2>&1; then bash; else sh; fi'],
         Tty: true,
       });
 

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -1312,7 +1312,7 @@ export class ContainerProviderRegistry {
         AttachStdin: true,
         AttachStdout: true,
         AttachStderr: true,
-        Cmd: ['/bin/sh', '-c', 'clear; (bash || sh)'],
+        Cmd: ['/bin/sh', '-c', '(bash || clear && sh)'],
         Tty: true,
       });
 


### PR DESCRIPTION
### What does this PR do?

The default behavior of the terminal is to use /bin/sh, which is available usually on all containers, so it makes sense to use it. However, most of the time, bash is also available, and it is usually preferred. This PR changes the default CMD to the following command `/bin/sh -c clear; (bash || sh)`

### Screenshot/screencast of this PR

<img width="592" alt="image" src="https://github.com/containers/podman-desktop/assets/42176370/6d10f5b1-310a-426f-a989-876d1392e628">

> Here we can see that it opened the bash.
<!-- Please include a screenshot or a screencast 
explaining what is doing this PR -->

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop/issues/3758

### How to test this PR?

<!-- Please explain steps to reproduce -->
