### PR TITLE
feat: add open exposed url to pod details

### DIFF
--- a/packages/renderer/src/lib/container/container-utils.ts
+++ b/packages/renderer/src/lib/container/container-utils.ts
@@ -113,6 +113,12 @@ export class ContainerUtils {
     }
   }
 
+  getOpeningUrls(containerInfo: ContainerInfo): string[] {
+    return containerInfo.Ports?.filter(port => port.PublicPort)
+      .map(port => port.PublicPort)
+      .map(port => `http://localhost:${port}`);
+  }
+
   getEngineId(containerInfo: ContainerInfo): string {
     return containerInfo.engineId;
   }

--- a/packages/renderer/src/lib/pod/PodActions.spec.ts
+++ b/packages/renderer/src/lib/pod/PodActions.spec.ts
@@ -17,28 +17,44 @@
  ***********************************************************************/
 
 import '@testing-library/jest-dom/vitest';
-import { test, expect, vi, beforeEach } from 'vitest';
+import { test, expect, vi, beforeEach, afterEach } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/svelte';
 import PodActions from './PodActions.svelte';
 import type { PodInfoUI } from './PodInfoUI';
+import type { ContainerInfo, Port } from '@podman-desktop/api';
 
 const pod: PodInfoUI = {
   id: 'pod',
+  containers: [{ Id: 'pod' }],
+  status: 'RUNNING',
+  kind: 'podman',
 } as PodInfoUI;
 
 const errorCallback = vi.fn();
+const listContainersMock = vi.fn();
 const getContributedMenusMock = vi.fn();
 
 beforeEach(() => {
   (window as any).kubernetesDeletePod = vi.fn();
-  vi.resetAllMocks();
-  vi.clearAllMocks();
+  (window as any).listContainers = listContainersMock;
+  (window as any).removePod = vi.fn();
+
+  listContainersMock.mockResolvedValue([
+    { Id: 'pod', Ports: [{ PublicPort: 8080 } as Port] as Port[] } as ContainerInfo,
+  ]);
 
   (window as any).getContributedMenus = getContributedMenusMock;
   getContributedMenusMock.mockImplementation(() => Promise.resolve([]));
 });
 
+afterEach(() => {
+  vi.resetAllMocks();
+  vi.clearAllMocks();
+});
+
 test('Expect no error deleting pod', async () => {
+  listContainersMock.mockResolvedValue([]);
+
   render(PodActions, { pod, errorCallback });
 
   // click on delete button

--- a/packages/renderer/src/lib/pod/PodDetails.spec.ts
+++ b/packages/renderer/src/lib/pod/PodDetails.spec.ts
@@ -29,6 +29,7 @@ import { router } from 'tinro';
 import { lastPage } from '/@/stores/breadcrumb';
 
 const listPodsMock = vi.fn();
+const listContainersMock = vi.fn();
 const kubernetesListPodsMock = vi.fn();
 
 const myPod: PodInfo = {
@@ -52,6 +53,7 @@ const getContributedMenusMock = vi.fn();
 
 beforeAll(() => {
   (window as any).listPods = listPodsMock;
+  (window as any).listContainers = listContainersMock.mockResolvedValue([]);
   (window as any).kubernetesListPods = kubernetesListPodsMock;
   (window as any).removePod = removePodMock;
   (window as any).getContributedMenus = getContributedMenusMock;

--- a/packages/renderer/src/lib/pod/PodsList.spec.ts
+++ b/packages/renderer/src/lib/pod/PodsList.spec.ts
@@ -31,6 +31,7 @@ import { router } from 'tinro';
 
 const getProvidersInfoMock = vi.fn();
 const listPodsMock = vi.fn();
+const listContainersMock = vi.fn();
 const kubernetesListPodsMock = vi.fn();
 const getContributedMenusMock = vi.fn();
 
@@ -260,6 +261,7 @@ const ocppod: PodInfo = {
 beforeAll(() => {
   (window as any).getProviderInfos = getProvidersInfoMock;
   (window as any).listPods = listPodsMock;
+  (window as any).listContainers = listContainersMock.mockResolvedValue([]);
   (window as any).kubernetesListPods = kubernetesListPodsMock;
   (window as any).onDidUpdateProviderStatus = vi.fn().mockResolvedValue(undefined);
   (window.events as unknown) = {

--- a/packages/renderer/src/lib/ui/DropDownMenuItem.svelte
+++ b/packages/renderer/src/lib/ui/DropDownMenuItem.svelte
@@ -16,8 +16,8 @@ const disabledClasses = 'text-gray-900 bg-charcoal-800';
   <!-- Use a div + onclick so there's no "blind spots" for when clicking-->
   <div class="{`p-3 ${enabled ? enabledClasses : disabledClasses}`}" role="none" on:click="{onClick}">
     <span title="{title}" class="group flex items-center text-sm no-underline whitespace-nowrap" tabindex="-1">
-      <Fa class="h-4 w-4 text-md mr-2" icon="{icon}" />
-      {title}
+      <Fa class="h-4 w-4 text-md" icon="{icon}" />
+      {#if title}<span class="ml-2">{title}</span>{/if}
     </span>
   </div>
 {/if}

--- a/packages/renderer/src/lib/ui/DropDownMenuItems.svelte
+++ b/packages/renderer/src/lib/ui/DropDownMenuItems.svelte
@@ -21,6 +21,7 @@ onMount(() => {
 </script>
 
 <div
+  title="Drop Down Menu Items"
   bind:clientHeight="{dropDownHeight}"
   bind:this="{dropDownElement}"
   class="origin-top-right absolute right-0 z-10 m-2 rounded-md shadow-lg bg-charcoal-600 ring-2 ring-purple-900 hover:ring-purple-700 divide-y divide-charcoal-600 focus:outline-none">

--- a/packages/renderer/src/lib/ui/DropdownMenu.svelte
+++ b/packages/renderer/src/lib/ui/DropdownMenu.svelte
@@ -1,9 +1,14 @@
 <script lang="ts">
 import { faEllipsisVertical } from '@fortawesome/free-solid-svg-icons';
+import type { IconDefinition } from '@fortawesome/free-solid-svg-icons';
 import Fa from 'svelte-fa';
 import DropDownMenuItems from './DropDownMenuItems.svelte';
 
 export let onBeforeToggle = () => {};
+export let icon: IconDefinition = faEllipsisVertical;
+export let shownAsMenuActionItem = false;
+export let hidden = false;
+
 // Show and hide the menu using clickOutside
 let showMenu = false;
 
@@ -26,30 +31,34 @@ function toggleMenu() {
 
 // If we click outside the menu, close the menu
 function onWindowClick(e: any) {
-  showMenu = outsideWindow.contains(e.target);
+  if (!hidden) showMenu = outsideWindow.contains(e.target);
 }
 </script>
 
 <!-- Required in order for Svelte to track all key presses and if you pressed "ESC" -->
 <svelte:window on:keyup="{handleEscape}" on:click="{onWindowClick}" />
 
-<!-- Create a "kebab" menu for additional actions. -->
-<div class="relative inline-block text-left">
-  <!-- Button for the dropdown menu -->
-  <button
-    aria-label="kebab menu"
-    on:click="{e => {
-      // keep track of the cursor position
-      clientY = e.clientY;
-      toggleMenu();
-    }}"
-    bind:this="{outsideWindow}"
-    class="mr-2 text-gray-400 hover:bg-charcoal-800 hover:text-purple-400 font-medium rounded-md inline-flex items-center px-2 py-2 text-center">
-    <Fa class="h-4 w-4" icon="{faEllipsisVertical}" />
-  </button>
+{#if !hidden}
+  <!-- Create a "kebab" menu for additional actions. -->
+  <div class="relative inline-block text-left">
+    <!-- Button for the dropdown menu -->
+    <button
+      aria-label="kebab menu"
+      on:click="{e => {
+        // keep track of the cursor position
+        clientY = e.clientY;
+        toggleMenu();
+      }}"
+      bind:this="{outsideWindow}"
+      class="text-gray-400 {shownAsMenuActionItem
+        ? 'bg-charcoal-800 px-3'
+        : 'hover:bg-charcoal-800 mr-2'} hover:text-purple-400 font-medium rounded-md inline-flex items-center px-2 py-2 text-center">
+      <Fa class="h-4 w-4" icon="{icon}" />
+    </button>
 
-  <!-- Dropdown menu for all other actions -->
-  {#if showMenu}
-    <DropDownMenuItems clientY="{clientY}"><slot /></DropDownMenuItems>
-  {/if}
-</div>
+    <!-- Dropdown menu for all other actions -->
+    {#if showMenu}
+      <DropDownMenuItems clientY="{clientY}"><slot /></DropDownMenuItems>
+    {/if}
+  </div>
+{/if}


### PR DESCRIPTION
### What does this PR do?

Adds a button to pod details to open the exposed url.

### Screenshot/screencast of this PR

<img width="1162" src="https://github.com/containers/podman-desktop/assets/1968177/df4e58f0-4091-4080-8fdb-2f567518d163">

### What issues does this PR fix or reference?

#2978 

### How to test this PR?

There is an open url button near refresh button in top right corner of pod details.
