### PR TITLE
fix: remove redundant step completion check when onboarding gets started (#3783)

### DIFF
--- a/packages/renderer/src/lib/onboarding/Onboarding.svelte
+++ b/packages/renderer/src/lib/onboarding/Onboarding.svelte
@@ -50,14 +50,14 @@ onMount(async () => {
   onboardingUnsubscribe = onboardingList.subscribe(onboardingItems => {
     if (!onboardings) {
       onboardings = onboardingItems.filter(o => extensionIds.find(extensionId => o.extension === extensionId));
-      startOnboarding();
+      startOnboarding().catch((err: unknown) => console.warn(String(err)));
     }
   });
 
   // eslint-disable-next-line @typescript-eslint/no-misused-promises
   contextsUnsubscribe = context.subscribe(value => {
     globalContext = value;
-    startOnboarding();
+    startOnboarding().catch((err: unknown) => console.warn(String(err)));
   });
 });
 


### PR DESCRIPTION
### What does this PR do?

This PR removes a redundant step completion check when the onboarding gets started.

So basically what happens that causes https://github.com/containers/podman-desktop/issues/3783 is:

onboarding gets started -> it loops over all steps to find the one to display -> podman is already installed so the final step with the when clause `podmanIsInstalled` is picked -> another check on the step is executed and bc the step is the last one and completed the user is redirected to the resources page.

There is no need to check if the step is completed for the second time because the check is already performed during the selection of the step to display.

This fixes the behavior to ... you already completed the setup (installed podman, created a machine, started it) and click on the onboarding again? You see the last page with the setup success message or with some other message that we add

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

it fixes #3783 

### How to test this PR?

1. run the onboarding
2. complete it
3. run it again, you should end up to the last page (atm it's the "Podman successfully installed" step)
