### PR TITLE
fix: remove cancel button when on final onboarding step (#3771)

### DIFF
--- a/extensions/podman/package.json
+++ b/extensions/podman/package.json
@@ -205,7 +205,7 @@
           "id": "podmanSuccessfullySetup",
           "title": "Podman successfully setup",
           "when": "onboardingContext:podmanIsNotInstalled == false",
-          "state": "succeeded"
+          "state": "completed"
         }
       ]
     }

--- a/packages/renderer/src/lib/onboarding/Onboarding.spec.ts
+++ b/packages/renderer/src/lib/onboarding/Onboarding.spec.ts
@@ -31,7 +31,7 @@ async function waitRender(customProperties: object): Promise<void> {
   }
 }
 
-test('Expect to have the "Try again" button disabled if the step represent a failed state', async () => {
+test('Expect to have the "Try again" and Cancel buttons if the step represent a failed state', async () => {
   (window as any).resetOnboarding = vi.fn();
   (window as any).updateStepState = vi.fn();
 
@@ -55,11 +55,13 @@ test('Expect to have the "Try again" button disabled if the step represent a fai
   });
   const button = screen.getByRole('button', { name: 'Try again' });
   expect(button).toBeInTheDocument();
+  const buttonCancel = screen.getByRole('button', { name: 'Cancel setup' });
+  expect(buttonCancel).toBeInTheDocument();
   const infoMessage = screen.queryByLabelText('next-info-message');
   expect(infoMessage).not.toBeInTheDocument();
 });
 
-test('Expect not to have the "Try again" button disabled if the step represent a completed state', async () => {
+test('Expect not to have the "Try again" and "Cancel" buttons if the step represent a completed state', async () => {
   (window as any).resetOnboarding = vi.fn();
   (window as any).updateStepState = vi.fn();
 
@@ -81,8 +83,10 @@ test('Expect not to have the "Try again" button disabled if the step represent a
   await waitRender({
     extensionIds: ['id'],
   });
-  const button = screen.queryByRole('button', { name: 'Try again' });
-  expect(button).not.toBeInTheDocument();
+  const buttonTryAgain = screen.queryByRole('button', { name: 'Try again' });
+  expect(buttonTryAgain).not.toBeInTheDocument();
+  const buttonCancel = screen.queryByRole('button', { name: 'Cancel setup' });
+  expect(buttonCancel).not.toBeInTheDocument();
   const infoMessage = screen.getByLabelText('next-info-message');
   expect(infoMessage).toBeInTheDocument();
 });

--- a/packages/renderer/src/lib/onboarding/Onboarding.svelte
+++ b/packages/renderer/src/lib/onboarding/Onboarding.svelte
@@ -386,8 +386,12 @@ async function cleanContext() {
           class:bg-charcoal-50="{activeStep.step.state === 'failed'}"
           disabled="{activeStep.step.state === 'failed'}"
           on:click="{() => next()}">Next</button>
-        <button class="bg-purple-700 py-1.5 px-5 mr-2 rounded-md text-sm" on:click="{() => setDisplayCancelSetup(true)}"
-          >Cancel</button>
+        {#if activeStep.step.state !== 'completed'}
+          <button
+            aria-label="Cancel setup"
+            class="bg-purple-700 py-1.5 px-5 mr-2 rounded-md text-sm"
+            on:click="{() => setDisplayCancelSetup(true)}">Cancel</button>
+        {/if}
       </div>
     {/if}
   </div>


### PR DESCRIPTION
### What does this PR do?

This PR removes the cancel button on the final step that represent the completed onboarding state. Once at the end, it does not make sense to show the cancel button.

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

it fixes #3771 

### How to test this PR?

1. run the onboarding and check there is no cancel button in the final step
