### PR TITLE
chore: Use palette color

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
@@ -290,7 +290,7 @@ function assertNumericValueIsValid(value: number) {
         value="{getNormalizedDefaultNumberValue(record)}"
         aria-label="{record.description}"
         on:input="{event => handleRangeValue(record.id, event.currentTarget)}"
-        class="w-full h-1 bg-[var(--pf-global--primary-color--300)] rounded-lg appearance-none accent-[var(--pf-global--primary-color--300)] cursor-pointer range-xs mt-2" />
+        class="w-full h-1 bg-purple-500 rounded-lg appearance-none accent-purple-500 cursor-pointer range-xs mt-2" />
     {:else if record.type === 'number'}
       <div
         class="flex flex-row rounded-sm bg-zinc-700 text-sm divide-x divide-charcoal-800 w-24 border-b"


### PR DESCRIPTION
### What does this PR do?

Use a direct palette color for numeric sliders (e.g. Podman machine creation) instead of PF variables that were slightly off.

### Screenshot/screencast of this PR

N/A, can't visually tell the difference.

### What issues does this PR fix or reference?

Part of issue #3800.

### How to test this PR?

Create a Podman machine, make sure sliders look the same as before.