### PR TITLE
fix: mounts can be null when using older podman

### DIFF
--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -569,7 +569,7 @@ export class ContainerProviderRegistry {
 
             // compute containers using this volume
             const containersUsingThisVolume = containers
-              .filter(container => container.Mounts.find(mount => mount.Name === volumeInfo.Name))
+              .filter(container => container.Mounts?.find(mount => mount.Name === volumeInfo.Name))
               .map(container => {
                 return { id: container.Id, names: container.Names };
               });


### PR DESCRIPTION
### What does this PR do?

Older versions of podman has Mounts: null, so the feature of listing containers using a volume does not work.

But it is better to leave that extra information out from the volume list, than to throw an error during `find`

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast 
explaining what is doing this PR -->

### What issues does this PR fix or reference?

Closes #3804

### How to test this PR?

<!-- Please explain steps to reproduce -->
