### PR TITLE
chore: Use bootstrap color for Steps

### DIFF
--- a/packages/renderer/src/lib/dashboard/ProviderConfigured.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderConfigured.svelte
@@ -74,12 +74,7 @@ onMount(() => {
     {#if runAtStart || runInProgress}
       <div class="mt-5">
         {#if initializationContext.mode === InitializeAndStartMode}
-          <Steps
-            steps="{InitializationSteps}"
-            size="1.7rem"
-            line="1px"
-            current="{1}"
-            clickable="{false}" />
+          <Steps steps="{InitializationSteps}" size="1.7rem" line="1px" current="{1}" clickable="{false}" />
         {/if}
         <div class="flex flex-col text-gray-700">
           <div>Starting</div>

--- a/packages/renderer/src/lib/dashboard/ProviderConfigured.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderConfigured.svelte
@@ -76,7 +76,6 @@ onMount(() => {
         {#if initializationContext.mode === InitializeAndStartMode}
           <Steps
             steps="{InitializationSteps}"
-            primary="var(--pf-global--primary-color--300)"
             size="1.7rem"
             line="1px"
             current="{1}"

--- a/packages/renderer/src/lib/dashboard/ProviderConfigured.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderConfigured.svelte
@@ -5,7 +5,7 @@ import PreflightChecks from './PreflightChecks.svelte';
 import ProviderLinks from './ProviderLinks.svelte';
 import ProviderLogo from './ProviderLogo.svelte';
 import ProviderUpdateButton from './ProviderUpdateButton.svelte';
-import { Steps } from 'svelte-steps';
+import Steps from '../ui/Steps.svelte';
 
 import { onMount } from 'svelte';
 import { InitializeAndStartMode, InitializationSteps, type InitializationContext } from './ProviderInitUtils';
@@ -74,7 +74,7 @@ onMount(() => {
     {#if runAtStart || runInProgress}
       <div class="mt-5">
         {#if initializationContext.mode === InitializeAndStartMode}
-          <Steps steps="{InitializationSteps}" size="1.7rem" line="1px" current="{1}" clickable="{false}" />
+          <Steps steps="{InitializationSteps}" current="{1}" />
         {/if}
         <div class="flex flex-col text-gray-700">
           <div>Starting</div>

--- a/packages/renderer/src/lib/dashboard/ProviderConfiguring.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderConfiguring.svelte
@@ -101,7 +101,6 @@ onDestroy(() => {
       {#if initializationContext.mode === InitializeAndStartMode}
         <Steps
           steps="{InitializationSteps}"
-          primary="var(--pf-global--primary-color--300)"
           size="1.7rem"
           line="1px"
           current="{0}"

--- a/packages/renderer/src/lib/dashboard/ProviderConfiguring.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderConfiguring.svelte
@@ -11,7 +11,7 @@ import 'xterm/css/xterm.css';
 import { TerminalSettings } from '../../../../main/src/plugin/terminal-settings';
 import { getPanelDetailColor } from '../color/color';
 import { type InitializationContext, InitializationSteps, InitializeAndStartMode } from './ProviderInitUtils';
-import { Steps } from 'svelte-steps';
+import Steps from '../ui/Steps.svelte';
 import Spinner from '../ui/Spinner.svelte';
 
 export let provider: ProviderInfo;
@@ -99,7 +99,7 @@ onDestroy(() => {
 
     <div class="mt-5">
       {#if initializationContext.mode === InitializeAndStartMode}
-        <Steps steps="{InitializationSteps}" size="1.7rem" line="1px" current="{0}" clickable="{false}" />
+        <Steps steps="{InitializationSteps}" />
       {/if}
       <div class="flex flex-col text-gray-700">
         <div>Initializing</div>

--- a/packages/renderer/src/lib/dashboard/ProviderConfiguring.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderConfiguring.svelte
@@ -99,12 +99,7 @@ onDestroy(() => {
 
     <div class="mt-5">
       {#if initializationContext.mode === InitializeAndStartMode}
-        <Steps
-          steps="{InitializationSteps}"
-          size="1.7rem"
-          line="1px"
-          current="{0}"
-          clickable="{false}" />
+        <Steps steps="{InitializationSteps}" size="1.7rem" line="1px" current="{0}" clickable="{false}" />
       {/if}
       <div class="flex flex-col text-gray-700">
         <div>Initializing</div>

--- a/packages/renderer/src/lib/dashboard/ProviderInstalled.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderInstalled.svelte
@@ -189,7 +189,6 @@ function onInstallationClick() {
       {#if installationOptionSelected === InitializeAndStartMode}
         <Steps
           steps="{InitializationSteps}"
-          primary="var(--pf-global--primary-color--300)"
           size="1.7rem"
           line="1px"
           current="{0}"

--- a/packages/renderer/src/lib/dashboard/ProviderInstalled.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderInstalled.svelte
@@ -187,12 +187,7 @@ function onInstallationClick() {
 
     <div class="mt-5" class:hidden="{!initializeInProgress}">
       {#if installationOptionSelected === InitializeAndStartMode}
-        <Steps
-          steps="{InitializationSteps}"
-          size="1.7rem"
-          line="1px"
-          current="{0}"
-          clickable="{false}" />
+        <Steps steps="{InitializationSteps}" size="1.7rem" line="1px" current="{0}" clickable="{false}" />
       {/if}
       <div class="flex flex-col text-gray-700">
         <div>Initializing</div>

--- a/packages/renderer/src/lib/dashboard/ProviderInstalled.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderInstalled.svelte
@@ -17,7 +17,7 @@ import {
   InitializeAndStartMode,
   InitializeOnlyMode,
 } from './ProviderInitUtils';
-import { Steps } from 'svelte-steps';
+import Steps from '../ui/Steps.svelte';
 import Spinner from '../ui/Spinner.svelte';
 
 export let provider: ProviderInfo;
@@ -187,7 +187,7 @@ function onInstallationClick() {
 
     <div class="mt-5" class:hidden="{!initializeInProgress}">
       {#if installationOptionSelected === InitializeAndStartMode}
-        <Steps steps="{InitializationSteps}" size="1.7rem" line="1px" current="{0}" clickable="{false}" />
+        <Steps steps="{InitializationSteps}" />
       {/if}
       <div class="flex flex-col text-gray-700">
         <div>Initializing</div>

--- a/packages/renderer/src/lib/ui/Steps.spec.ts
+++ b/packages/renderer/src/lib/ui/Steps.spec.ts
@@ -1,0 +1,33 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import '@testing-library/jest-dom/vitest';
+import { test, expect } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import Steps from './Steps.svelte';
+
+test('Check step styling', async () => {
+  render(Steps, { steps: ['One', 'Two'] });
+
+  // check the div has the correct class
+  const step = screen.getByTestId('step-div');
+  expect(step).toBeInTheDocument();
+  expect(step).toHaveClass('bootstrap-color');
+});

--- a/packages/renderer/src/lib/ui/Steps.svelte
+++ b/packages/renderer/src/lib/ui/Steps.svelte
@@ -1,0 +1,16 @@
+<style>
+.bootstrap-color {
+  --bs-primary: theme(colors.purple.500);
+}
+</style>
+
+<script lang="ts">
+import { Steps } from 'svelte-steps';
+
+export let steps: any[];
+export let current = 0;
+</script>
+
+<div class="bootstrap-color" data-testid="step-div">
+  <Steps steps="{steps}" size="1.7rem" line="1px" current="{current}" clickable="{false}" />
+</div>

--- a/packages/renderer/src/override.css
+++ b/packages/renderer/src/override.css
@@ -16,8 +16,6 @@
   --pf-global--LineHeight--md: 0.9rem;
   --pf-global--FontWeight--normal: 100;
   --pf-global--BackgroundColor: #ff0000;
-
-  --bs-primary: #8c4afd;
 }
 
 .pf-c-button {

--- a/packages/renderer/src/override.css
+++ b/packages/renderer/src/override.css
@@ -16,6 +16,8 @@
   --pf-global--LineHeight--md: 0.9rem;
   --pf-global--FontWeight--normal: 100;
   --pf-global--BackgroundColor: #ff0000;
+
+  --bs-primary: #8c4afd;
 }
 
 .pf-c-button {


### PR DESCRIPTION
### What does this PR do?

We use the Steps Tailwind component for configuring providers. It uses Bootstrap and defaults to using the Bootstrap primary color. Currently we override this on each instance using a PatternFly variable (which for some historical reason is slightly off our current palette color).

This change sets the Bootstrap primary color to the (corrected) same value as our palette color, which means we do not need to override the value on each individual Steps.

This is a real preference/complexity call. Ideally I'd rather use our palette colors as CSS variables directly (but that seems over-complicated for a case like this [1]), or we could define our own variable name and continue to use it in each Steps. Maybe it's better to keep the override per-component so we don't forget where it comes from? I'm proposing this change b/c it is the least code and removes one more reference to PatternFly, since we're getting close to where we could remove it entirely. This is simplest code overall, and would work if we had other Bootstrap components. If anyone prefers another option, please suggest.

[1] https://tailwindcss.com/docs/customizing-colors#using-css-variables

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

Part of issue #3800.

### How to test this PR?

Run through installation for a new provider, should be no visual change and steps highlight as before.