### PR TITLE
chore: remove neutral from palette

### DIFF
--- a/packages/renderer/src/lib/ContainerList.svelte
+++ b/packages/renderer/src/lib/ContainerList.svelte
@@ -644,7 +644,7 @@ function errorCallback(container: ContainerInfoUI, errorMessage: string): void {
       openChoiceModal = false;
     }}">
     <button
-      class="inline-block w-full overflow-hidden text-left transition-all transform bg-charcoal-600 z-50 h-[200px] rounded-xl shadow-xl shadow-neutral-900"
+      class="inline-block w-full overflow-hidden text-left transition-all transform bg-charcoal-600 z-50 h-[200px] rounded-xl shadow-xl shadow-charcoal-900"
       on:keydown="{keydownChoice}">
       <div class="flex items-center justify-between bg-black px-5 py-4 border-b-2 border-violet-700">
         <h1 class="text-xl font-bold">Create a new container</h1>

--- a/packages/renderer/src/lib/feedback/SendFeedback.svelte
+++ b/packages/renderer/src/lib/feedback/SendFeedback.svelte
@@ -52,7 +52,7 @@ async function sendFeedback(): Promise<void> {
 {#if displayModal}
   <Modal on:close="{() => hideModal()}">
     <div
-      class="inline-block w-full overflow-hidden text-left transition-all transform bg-charcoal-600 z-50 rounded-xl shadow-xl shadow-neutral-900">
+      class="inline-block w-full overflow-hidden text-left transition-all transform bg-charcoal-600 z-50 rounded-xl shadow-xl shadow-charcoal-900">
       <div class="flex items-center justify-between bg-black px-5 py-4 border-b-2 border-violet-700">
         <h1 class="text-xl font-bold">Share your feedback</h1>
 

--- a/packages/renderer/src/lib/preferences/PreferencesProviderInstallationModal.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesProviderInstallationModal.svelte
@@ -21,7 +21,7 @@ function openLink(e: MouseEvent, url: string): void {
 {#if providerToBeInstalled}
   <Modal on:close="{() => closeCallback()}">
     <div
-      class="inline-block w-full overflow-hidden text-left transition-all transform bg-charcoal-600 z-50 rounded-xl shadow-xl shadow-neutral-900"
+      class="inline-block w-full overflow-hidden text-left transition-all transform bg-charcoal-600 z-50 rounded-xl shadow-xl shadow-charcoal-900"
       aria-label="install provider">
       <div class="flex items-center justify-between px-5 py-4 mb-4">
         <h1 class="text-md font-semibold">Create a new {providerToBeInstalled.displayName}</h1>

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingPageStoreDetails.svelte
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingPageStoreDetails.svelte
@@ -24,7 +24,7 @@ async function fetch(): Promise<void> {
 
 <Modal name="Details of {eventStoreInfo.name}" on:close="{() => closeCallback()}">
   <div
-    class="inline-block w-full overflow-hidden text-left transition-all transform bg-charcoal-600 z-50 rounded-xl shadow-xl shadow-neutral-900">
+    class="inline-block w-full overflow-hidden text-left transition-all transform bg-charcoal-600 z-50 rounded-xl shadow-xl shadow-charcoal-900">
     <div class="flex items-center justify-between px-5 py-4 mb-4">
       <h1 class="text-md font-semibold">
         <div class="flex flex-row items-center">

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -160,9 +160,6 @@ module.exports = {
         600: tailwindColors.zinc[600],
         700: tailwindColors.zinc[700],
       },
-      'neutral': {
-        900: tailwindColors.neutral[900],
-      },
       'blue': {
         500: tailwindColors.blue[500],
       },


### PR DESCRIPTION
### What does this PR do?

Neutral-900 was in our palette for legacy reasons, and despite a friendly comment to not use it :), copy/paste wins and we added a new use lately. This just replaces all uses with charcoal-900, which is almost indistinguishable but matches other UI slightly better, and removes the color from the palette.

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Open up a couple of these Modals and confirm UI looks ok.