### PR TITLE
chore: remove blue from palette

### DIFF
--- a/packages/renderer/src/lib/image/PullImage.svelte
+++ b/packages/renderer/src/lib/image/PullImage.svelte
@@ -167,7 +167,7 @@ function validateImageName(event: any): void {
                 <label for="providerChoice">Container Engine:</label>
                 <select
                   id="providerChoice"
-                  class="w-auto border text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block p-2.5 bg-gray-900 border-gray-900 placeholder-gray-700 text-white"
+                  class="w-auto border text-sm rounded-lg focus:ring-purple-500 focus:border-purple-500 block p-2.5 bg-gray-900 border-gray-900 placeholder-gray-700 text-white"
                   name="providerChoice"
                   bind:value="{selectedProviderConnection}">
                   {#each providerConnections as providerConnection}

--- a/packages/renderer/src/lib/image/PushImageModal.svelte
+++ b/packages/renderer/src/lib/image/PushImageModal.svelte
@@ -122,7 +122,7 @@ let pushLogsXtermDiv: HTMLDivElement;
         <label for="modalImageTag" class="block mb-2 text-sm font-medium text-gray-400 dark:text-gray-400"
           >Image Tag</label>
         <select
-          class="border text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 bg-charcoal-600 border-gray-900 placeholder-gray-700 text-white"
+          class="border text-sm rounded-lg focus:ring-purple-500 focus:border-purple-500 block w-full p-2.5 bg-charcoal-600 border-gray-900 placeholder-gray-700 text-white"
           name="imageChoice"
           bind:value="{selectedImageTag}">
           {#each imageTags as imageTag}

--- a/packages/renderer/src/lib/kube/KubePlayYAML.svelte
+++ b/packages/renderer/src/lib/kube/KubePlayYAML.svelte
@@ -206,7 +206,7 @@ async function getKubernetesfileLocation() {
                       class="py-6 block mb-2 text-sm font-medium text-gray-400 dark:text-gray-400"
                       >Container Engine
                       <select
-                        class="border text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 bg-gray-900 border-gray-900 placeholder-gray-700 text-white"
+                        class="border text-sm rounded-lg focus:ring-purple-500 focus:border-purple-500 block w-full p-2.5 bg-gray-900 border-gray-900 placeholder-gray-700 text-white"
                         name="providerChoice"
                         bind:value="{selectedProvider}">
                         {#each providerConnections as providerConnection}

--- a/packages/renderer/src/lib/ui/AuditMessageBox.svelte
+++ b/packages/renderer/src/lib/ui/AuditMessageBox.svelte
@@ -46,10 +46,10 @@ $: errorRecords = auditResult?.records.filter(record => record.type === 'error')
 
 {#if infoRecords && infoRecords.length > 0}
   {#each infoRecords as record}
-    <div class="bg-charcoal-600 border-t-2 border-blue-500 p-4 mb-2" role="alert" aria-label="info">
+    <div class="bg-charcoal-600 border-t-2 border-purple-500 p-4 mb-2" role="alert" aria-label="info">
       <div class="flex flex-row">
         <div class="mr-3">
-          <Fa size="18" class="text-blue-500" icon="{faCircleInfo}" />
+          <Fa size="18" class="text-purple-500" icon="{faCircleInfo}" />
         </div>
         <div class="text-sm text-white">
           {record.record}

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -160,9 +160,6 @@ module.exports = {
         600: tailwindColors.zinc[600],
         700: tailwindColors.zinc[700],
       },
-      'blue': {
-        500: tailwindColors.blue[500],
-      },
       'indigo': { // website only
         500: tailwindColors.indigo[500],
         600: tailwindColors.indigo[600],


### PR DESCRIPTION
### What does this PR do?

For historical/legacy reasons we still have Tailwind blue-500 in our palette. There are only a few references to this color and all should be replaced by purple-500, which is in our palette and specified by the design for outlines like these. Replacing and removing from the palette to avoid future use.

### Screenshot/screencast of this PR

N/A, just minor outline change from blue to purple.

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Open up one of these pages and look at the appropriate field. Most require multiple container engines to see (or hacking the code in dev mode).