### PR TITLE
feat: added context getValue in extension API

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -2254,5 +2254,16 @@ declare module '@podman-desktop/api' {
      */
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     export function setValue(key: string, value: any, scope?: 'onboarding'): void;
+
+    /**
+     * Retrieve a value from the context.
+     *
+     * @param key the key to retrieve the value for
+     * @param scope the scope to use to retrieve the value
+     * @return the value for the given key or undefined if not set.
+     *
+     */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    export function getValue(key: string, scope?: 'onboarding'): any;
   }
 }

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -942,6 +942,13 @@ export class ExtensionLoader {
         }
         this.context.setValue(key, value);
       },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      getValue: (key: string, scope?: 'onboarding'): any => {
+        if (scope === 'onboarding') {
+          key = `${extensionInfo.id}.${scope}.${key}`;
+        }
+        return this.context.getValue(key);
+      },
     };
 
     return <typeof containerDesktopAPI>{


### PR DESCRIPTION
feat: added context getValue in extension API

### What does this PR do?

While implementing the onboarding compose sequence, I noticed that there
is no getValue, despite us having setValue in the extension API.

We actually *test* getValue, but we do not let it be accessible by the
api.

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast
explaining what is doing this PR -->

N/A

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop/issues/3825

### How to test this PR?

Within `extensions/podman/extension.ts` you can try getting a set value,
for example:

```
extensionApi.context.getValue(USER_MODE_NETWORKING_SUPPORTED_KEY);
```

<!-- Please explain steps to reproduce -->

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
