### PR TITLE
feat: add 'name' as property key for configuration

### DIFF
--- a/extensions/podman/package.json
+++ b/extensions/podman/package.json
@@ -33,6 +33,7 @@
       "title": "Podman",
       "properties": {
         "podman.binary.path": {
+          "name": "Path to Podman Binary",
           "type": "string",
           "format": "file",
           "default": "",

--- a/packages/main/src/plugin/configuration-registry.ts
+++ b/packages/main/src/plugin/configuration-registry.ts
@@ -56,6 +56,7 @@ export interface IConfigurationPropertySchema {
   description?: string;
   placeholder?: string;
   markdownDescription?: string;
+  name?: string;
   minimum?: number;
   maximum?: number | string;
   format?: string;

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItem.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItem.svelte
@@ -12,6 +12,7 @@ let recordUI: {
   breadCrumb: string;
   description?: string;
   markdownDescription?: string;
+  name?: string;
   original: IConfigurationPropertyRecordedSchema;
 };
 
@@ -36,7 +37,7 @@ function update() {
   const breadCrumbUI = breadCrumb.replace(/\./g, ' > ').concat(':');
 
   recordUI = {
-    title: startCase(key),
+    title: record.name || startCase(key),
     breadCrumb: breadCrumbUI,
     description: record.description,
     markdownDescription: record.markdownDescription,


### PR DESCRIPTION
feat: add 'name' as property key for configuration

### What does this PR do?

You should be able to make a custom name for the configuration setting
when it's displayed under preferences

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast
explaining what is doing this PR -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop/issues/3832

This is needed to add a custom name for https://github.com/containers/podman-desktop/issues/3709

### How to test this PR?

<!-- Please explain steps to reproduce -->

Open Podman Desktop and look under Preferences / see that the name is
now "Path to Podman Binary" instead of just "Path"

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
