### PR TITLE
fix: remove image tag only not the image using id

### DIFF
--- a/packages/renderer/src/lib/ImagesList.svelte
+++ b/packages/renderer/src/lib/ImagesList.svelte
@@ -168,7 +168,7 @@ async function deleteSelectedImages() {
   const selectedImages = images.filter(image => image.selected);
   await selectedImages.reduce((prev: Promise<void>, image) => {
     return prev
-      .then(() => window.deleteImage(image.engineId, `${image.name}:${image.tag}`))
+      .then(() => imageUtils.deleteImage(image))
       .catch((e: unknown) => console.log('error while removing image', e));
   }, Promise.resolve());
   bulkDeleteInProgress = false;

--- a/packages/renderer/src/lib/ImagesList.svelte
+++ b/packages/renderer/src/lib/ImagesList.svelte
@@ -164,21 +164,14 @@ function toggleAllImages(checked: boolean) {
 // delete the items selected in the list
 let bulkDeleteInProgress = false;
 async function deleteSelectedImages() {
+  bulkDeleteInProgress = true;
   const selectedImages = images.filter(image => image.selected);
-
-  if (selectedImages.length > 0) {
-    bulkDeleteInProgress = true;
-    await Promise.all(
-      selectedImages.map(async image => {
-        try {
-          await window.deleteImage(image.engineId, image.id);
-        } catch (e) {
-          console.log('error while removing image', e);
-        }
-      }),
-    );
-    bulkDeleteInProgress = false;
-  }
+  await selectedImages.reduce((prev: Promise<void>, image) => {
+    return prev
+      .then(() => window.deleteImage(image.engineId, `${image.name}:${image.tag}`))
+      .catch((e: unknown) => console.log('error while removing image', e));
+  }, Promise.resolve());
+  bulkDeleteInProgress = false;
 }
 
 let refreshTimeouts: NodeJS.Timeout[] = [];

--- a/packages/renderer/src/lib/image/ImageActions.svelte
+++ b/packages/renderer/src/lib/image/ImageActions.svelte
@@ -8,6 +8,7 @@ import FlatMenu from '../ui/FlatMenu.svelte';
 import { runImageInfo } from '../../stores/run-image-store';
 import type { Menu } from '../../../../main/src/plugin/menu-registry';
 import ContributionActions from '/@/lib/actions/ContributionActions.svelte';
+import { ImageUtils } from './image-utils';
 
 export let onPushImage: (imageInfo: ImageInfoUI) => void;
 export let onRenameImage: (imageInfo: ImageInfoUI) => void;
@@ -19,6 +20,7 @@ export let contributions: Menu[] = [];
 let errorTitle: string | undefined = undefined;
 let errorMessage: string | undefined = undefined;
 let isAuthenticatedForThisImage = false;
+const imageUtils = new ImageUtils();
 
 async function runImage(imageInfo: ImageInfoUI) {
   runImageInfo.set(imageInfo);
@@ -29,7 +31,7 @@ $: window.hasAuthconfigForImage(image.name).then(result => (isAuthenticatedForTh
 
 async function deleteImage(): Promise<void> {
   try {
-    await window.deleteImage(image.engineId, `${image.name}:${image.tag}`);
+    await imageUtils.deleteImage(image);
   } catch (error) {
     errorTitle = 'Error while deleting image';
     errorMessage = String(error);

--- a/packages/renderer/src/lib/image/ImageActions.svelte
+++ b/packages/renderer/src/lib/image/ImageActions.svelte
@@ -29,7 +29,7 @@ $: window.hasAuthconfigForImage(image.name).then(result => (isAuthenticatedForTh
 
 async function deleteImage(): Promise<void> {
   try {
-    await window.deleteImage(image.engineId, image.id);
+    await window.deleteImage(image.engineId, `${image.name}:${image.tag}`);
   } catch (error) {
     errorTitle = 'Error while deleting image';
     errorMessage = String(error);

--- a/packages/renderer/src/lib/image/ImageDetails.svelte
+++ b/packages/renderer/src/lib/image/ImageDetails.svelte
@@ -43,15 +43,13 @@ onMount(() => {
   return imagesInfos.subscribe(images => {
     const matchingImage = images.find(c => c.Id === imageID && c.engineId === engineId);
     if (matchingImage) {
-      try {
-        image = imageUtils.getImageInfoUI(matchingImage, base64RepoTag);
-      } catch (err) {
-        console.error(err);
+      const tempImage = imageUtils.getImageInfoUI(matchingImage, base64RepoTag);
+      if (tempImage) {
+        image = tempImage;
+        return;
       }
-    } else if (detailsPage) {
-      // the image has been deleted
-      detailsPage.close();
     }
+    detailsPage.close();
   });
 });
 </script>

--- a/packages/renderer/src/lib/image/ImageDetails.svelte
+++ b/packages/renderer/src/lib/image/ImageDetails.svelte
@@ -42,14 +42,16 @@ onMount(() => {
   // loading image info
   return imagesInfos.subscribe(images => {
     const matchingImage = images.find(c => c.Id === imageID && c.engineId === engineId);
+    let tempImage;
     if (matchingImage) {
-      const tempImage = imageUtils.getImageInfoUI(matchingImage, base64RepoTag);
-      if (tempImage) {
-        image = tempImage;
-        return;
-      }
+      tempImage = imageUtils.getImageInfoUI(matchingImage, base64RepoTag);
     }
-    detailsPage.close();
+    if (tempImage) {
+      image = tempImage;
+    } else {
+      // the image has been deleted
+      detailsPage.close();
+    }
   });
 });
 </script>

--- a/packages/renderer/src/lib/image/RenameImageModal.svelte
+++ b/packages/renderer/src/lib/image/RenameImageModal.svelte
@@ -62,6 +62,7 @@ async function renameImage(imageName: string, imageTag: string) {
 </script>
 
 <Modal
+  name="Edit Image"
   on:close="{() => {
     closeCallback();
   }}">
@@ -85,6 +86,7 @@ async function renameImage(imageName: string, imageTag: string) {
           class="w-full my-2 p-2 outline-none text-sm bg-charcoal-600 rounded-sm text-gray-700 placeholder-gray-700"
           on:input="{event => validateImageName(event)}"
           aria-invalid="{imageNameErrorMessage !== ''}"
+          aria-label="imageName"
           required />
         {#if imageNameErrorMessage}
           <ErrorMessage error="{imageNameErrorMessage}" />
@@ -100,6 +102,7 @@ async function renameImage(imageName: string, imageTag: string) {
           class="w-full my-2 p-2 outline-none text-sm bg-charcoal-600 rounded-sm text-gray-700 placeholder-gray-700"
           on:input="{event => validateImageTag(event)}"
           aria-invalid="{imageTagErrorMessage !== ''}"
+          aria-label="imageTag"
           required />
         {#if imageTagErrorMessage}
           <ErrorMessage error="{imageTagErrorMessage}" />

--- a/packages/renderer/src/lib/image/image-utils.ts
+++ b/packages/renderer/src/lib/image/image-utils.ts
@@ -126,6 +126,11 @@ export class ImageUtils {
     }
   }
 
+  deleteImage(image: ImageInfoUI) {
+    const imageId = image.name === '<none>' ? image.id : `${image.name}:${image.tag}`;
+    return window.deleteImage(image.engineId, imageId);
+  }
+
   getImageInfoUI(imageInfo: ImageInfo, base64RepoTag: string): ImageInfoUI | undefined {
     const images = this.getImagesInfoUI(imageInfo, []);
     return images.find(image => image.base64RepoTag === base64RepoTag);

--- a/packages/renderer/src/lib/image/image-utils.ts
+++ b/packages/renderer/src/lib/image/image-utils.ts
@@ -126,12 +126,8 @@ export class ImageUtils {
     }
   }
 
-  getImageInfoUI(imageInfo: ImageInfo, base64RepoTag: string): ImageInfoUI {
+  getImageInfoUI(imageInfo: ImageInfo, base64RepoTag: string): ImageInfoUI | undefined {
     const images = this.getImagesInfoUI(imageInfo, []);
-    const matchingImages = images.filter(image => image.base64RepoTag === base64RepoTag);
-    if (matchingImages.length === 1) {
-      return matchingImages[0];
-    }
-    throw new Error(`Unable to find a matching image for id ${imageInfo.Id} and tag ${base64RepoTag}`);
+    return images.find(image => image.base64RepoTag === base64RepoTag);
   }
 }

--- a/tests/src/model/pages/image-details-page.ts
+++ b/tests/src/model/pages/image-details-page.ts
@@ -19,6 +19,7 @@
 import type { Locator, Page } from 'playwright';
 import { BasePage } from './base-page';
 import { RunImagePage } from './run-image-page';
+import { ImageEditPage } from './image-edit-page';
 
 export class ImageDetailsPage extends BasePage {
   readonly name: Locator;
@@ -51,5 +52,10 @@ export class ImageDetailsPage extends BasePage {
   async openRunImage(): Promise<RunImagePage> {
     await this.runImageButton.click();
     return new RunImagePage(this.page, this.imageName);
+  }
+
+  async openEditImage(): Promise<ImageEditPage> {
+    await this.editButton.click();
+    return new ImageEditPage(this.page, this.imageName);
   }
 }

--- a/tests/src/model/pages/image-edit-page.ts
+++ b/tests/src/model/pages/image-edit-page.ts
@@ -1,0 +1,36 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { Locator, Page } from 'playwright';
+import { BasePage } from './base-page';
+
+export class ImageEditPage extends BasePage {
+  readonly name: string;
+  readonly cancelButton: Locator;
+  readonly saveButton: Locator;
+  readonly imageName: Locator;
+  readonly imageTag: Locator;
+  constructor(page: Page, name: string) {
+    super(page);
+    this.imageName = page.getByLabel('imageName');
+    this.cancelButton = page.getByRole('button', { name: 'Cancel' });
+    this.saveButton = page.getByRole('button', { name: 'Save' });
+    this.name = name;
+    this.imageTag = page.getByLabel('imageTag');
+  }
+}


### PR DESCRIPTION
### What does this PR do?

* switches to use name:tag to delete image so only specific tag is deleted not the image itself and all the tags
* run delete commands as a chain to avoid conflicts when deleting different tags of the same image

### Screenshot/screencast of this PR

n/a

### What issues does this PR fix or reference?

Fix #2673

### How to test this PR?

Create different tags for the same image and try to delete them using podman-desktop ui. The selected tag should be deleted, not all the tags of the same image.