### PR TITLE
fix: set proxy env variable when launching process

### DIFF
--- a/packages/main/src/plugin/authentication.spec.ts
+++ b/packages/main/src/plugin/authentication.spec.ts
@@ -52,6 +52,7 @@ import type { ViewRegistry } from './view-registry.js';
 import type { Context } from './context/context.js';
 import type { OnboardingRegistry } from './onboarding-registry.js';
 import { getBase64Image } from '../util.js';
+import type { Exec } from './util/exec.js';
 
 vi.mock('../util.js', async () => {
   return {
@@ -270,6 +271,7 @@ suite('Authentication', () => {
       vi.fn() as unknown as ViewRegistry,
       vi.fn() as unknown as Context,
       directories,
+      vi.fn() as unknown as Exec,
     );
     providerMock = {
       onDidChangeSessions: vi.fn(),

--- a/packages/main/src/plugin/contribution-manager.spec.ts
+++ b/packages/main/src/plugin/contribution-manager.spec.ts
@@ -31,6 +31,7 @@ import * as exec from './util/exec.js';
 import type { RunResult } from '@podman-desktop/api';
 import { EventEmitter } from 'stream-json/Assembler.js';
 import type { ContributionInfo } from './api/contribution-info.js';
+import type { Proxy } from './proxy.js';
 let contributionManager: TestContributionManager;
 
 let composeFileExample: any;
@@ -86,8 +87,12 @@ const directories = {
   getExtensionsStorageDirectory: () => '/fake-extensions-storage-directory',
 } as unknown as Directories;
 
+const proxy = {
+  isEnabled: vi.fn().mockReturnValue(false),
+} as unknown as Proxy;
+
 beforeAll(() => {
-  contributionManager = new TestContributionManager(apiSender, directories, containerProviderRegistry);
+  contributionManager = new TestContributionManager(apiSender, directories, containerProviderRegistry, proxy);
 });
 
 const originalConsoleLogMethod = console.log;
@@ -435,7 +440,7 @@ describe('startVms', () => {
 
 describe('startVM', () => {
   beforeAll(() => {
-    contributionManager = new TestContributionManager(apiSender, directories, containerProviderRegistry);
+    contributionManager = new TestContributionManager(apiSender, directories, containerProviderRegistry, proxy);
   });
 
   test('start a VM without compose file', async () => {
@@ -473,7 +478,7 @@ describe('startVM', () => {
 
 describe('isPodmanDesktopServiceAlive', () => {
   beforeAll(() => {
-    contributionManager = new TestContributionManager(apiSender, directories, containerProviderRegistry);
+    contributionManager = new TestContributionManager(apiSender, directories, containerProviderRegistry, proxy);
   });
 
   test('is Alive', async () => {
@@ -544,7 +549,7 @@ describe('isPodmanDesktopServiceAlive', () => {
 
 describe('waitForRunningState', () => {
   beforeAll(() => {
-    contributionManager = new TestContributionManager(apiSender, directories, containerProviderRegistry);
+    contributionManager = new TestContributionManager(apiSender, directories, containerProviderRegistry, proxy);
   });
 
   test('should work after few times', async () => {
@@ -597,6 +602,7 @@ test('execComposeCommand', async () => {
   // check
   expect(exec.exec).toBeCalledWith(
     '/my/compose',
+    proxy,
     ['arg1', 'arg2'],
     expect.objectContaining({ env: { DOCKER_HOST: 'unix:///my/socket' }, cwd: '/fake/directory' }),
   );

--- a/packages/main/src/plugin/contribution-manager.spec.ts
+++ b/packages/main/src/plugin/contribution-manager.spec.ts
@@ -27,7 +27,7 @@ import type { Directories } from './directories.js';
 import * as jsYaml from 'js-yaml';
 import type { ContainerProviderRegistry } from './container-registry.js';
 import * as util from '../util.js';
-import * as exec from './util/exec.js';
+import { Exec } from './util/exec.js';
 import type { RunResult } from '@podman-desktop/api';
 import { EventEmitter } from 'stream-json/Assembler.js';
 import type { ContributionInfo } from './api/contribution-info.js';
@@ -91,8 +91,10 @@ const proxy = {
   isEnabled: vi.fn().mockReturnValue(false),
 } as unknown as Proxy;
 
+const exec = new Exec(proxy);
+
 beforeAll(() => {
-  contributionManager = new TestContributionManager(apiSender, directories, containerProviderRegistry, proxy);
+  contributionManager = new TestContributionManager(apiSender, directories, containerProviderRegistry, exec);
 });
 
 const originalConsoleLogMethod = console.log;
@@ -440,7 +442,7 @@ describe('startVms', () => {
 
 describe('startVM', () => {
   beforeAll(() => {
-    contributionManager = new TestContributionManager(apiSender, directories, containerProviderRegistry, proxy);
+    contributionManager = new TestContributionManager(apiSender, directories, containerProviderRegistry, exec);
   });
 
   test('start a VM without compose file', async () => {
@@ -478,7 +480,7 @@ describe('startVM', () => {
 
 describe('isPodmanDesktopServiceAlive', () => {
   beforeAll(() => {
-    contributionManager = new TestContributionManager(apiSender, directories, containerProviderRegistry, proxy);
+    contributionManager = new TestContributionManager(apiSender, directories, containerProviderRegistry, exec);
   });
 
   test('is Alive', async () => {
@@ -549,7 +551,7 @@ describe('isPodmanDesktopServiceAlive', () => {
 
 describe('waitForRunningState', () => {
   beforeAll(() => {
-    contributionManager = new TestContributionManager(apiSender, directories, containerProviderRegistry, proxy);
+    contributionManager = new TestContributionManager(apiSender, directories, containerProviderRegistry, exec);
   });
 
   test('should work after few times', async () => {
@@ -602,7 +604,6 @@ test('execComposeCommand', async () => {
   // check
   expect(exec.exec).toBeCalledWith(
     '/my/compose',
-    proxy,
     ['arg1', 'arg2'],
     expect.objectContaining({ env: { DOCKER_HOST: 'unix:///my/socket' }, cwd: '/fake/directory' }),
   );

--- a/packages/main/src/plugin/contribution-manager.ts
+++ b/packages/main/src/plugin/contribution-manager.ts
@@ -22,12 +22,11 @@ import type { ContributionInfo } from './api/contribution-info.js';
 import type { ApiSenderType } from './api.js';
 import type { Directories } from './directories.js';
 import { getFreePort } from './util/port.js';
-import { exec } from './util/exec.js';
+import type { Exec } from './util/exec.js';
 import * as jsYaml from 'js-yaml';
 import type { RunResult } from '@podman-desktop/api';
 import type { ContainerProviderRegistry } from './container-registry.js';
 import { isLinux, isMac, isWindows } from '../util.js';
-import type { Proxy } from './proxy.js';
 
 export interface DockerExtensionMetadata {
   name: string;
@@ -74,7 +73,7 @@ export class ContributionManager {
     private apiSender: ApiSenderType,
     private directories: Directories,
     private containerRegistry: ContainerProviderRegistry,
-    private proxy: Proxy,
+    private exec: Exec,
   ) {}
 
   // load the existing contributions
@@ -171,7 +170,7 @@ export class ContributionManager {
 
       // check if docker-compose can be executed
       try {
-        await exec(binary, this.proxy, ['--version']);
+        await this.exec.exec(binary, ['--version']);
         // yes, return it
         return binary;
       } catch (error) {
@@ -348,7 +347,7 @@ export class ContributionManager {
       // add DOCKER_HOST
       DOCKER_HOST: DOCKER_HOST,
     };
-    return exec(composeBinary, this.proxy, args, { env, cwd });
+    return this.exec.exec(composeBinary, args, { env, cwd });
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/main/src/plugin/contribution-manager.ts
+++ b/packages/main/src/plugin/contribution-manager.ts
@@ -27,6 +27,7 @@ import * as jsYaml from 'js-yaml';
 import type { RunResult } from '@podman-desktop/api';
 import type { ContainerProviderRegistry } from './container-registry.js';
 import { isLinux, isMac, isWindows } from '../util.js';
+import type { Proxy } from './proxy.js';
 
 export interface DockerExtensionMetadata {
   name: string;
@@ -73,6 +74,7 @@ export class ContributionManager {
     private apiSender: ApiSenderType,
     private directories: Directories,
     private containerRegistry: ContainerProviderRegistry,
+    private proxy: Proxy,
   ) {}
 
   // load the existing contributions
@@ -169,7 +171,7 @@ export class ContributionManager {
 
       // check if docker-compose can be executed
       try {
-        await exec(binary, ['--version']);
+        await exec(binary, this.proxy, ['--version']);
         // yes, return it
         return binary;
       } catch (error) {
@@ -346,7 +348,7 @@ export class ContributionManager {
       // add DOCKER_HOST
       DOCKER_HOST: DOCKER_HOST,
     };
-    return exec(composeBinary, args, { env, cwd });
+    return exec(composeBinary, this.proxy, args, { env, cwd });
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/main/src/plugin/extension-loader.spec.ts
+++ b/packages/main/src/plugin/extension-loader.spec.ts
@@ -48,6 +48,7 @@ import type { CustomPickRegistry } from './custompick/custompick-registry.js';
 import type { ViewRegistry } from './view-registry.js';
 import { Context } from './context/context.js';
 import type { OnboardingRegistry } from './onboarding-registry.js';
+import { Exec } from './util/exec.js';
 
 class TestExtensionLoader extends ExtensionLoader {
   public async setupScanningDirectory(): Promise<void> {
@@ -133,6 +134,8 @@ const directories = {
   getExtensionsStorageDirectory: () => '/fake-extensions-storage-directory',
 } as unknown as Directories;
 
+const exec = new Exec(proxy);
+
 /* eslint-disable @typescript-eslint/no-empty-function */
 beforeAll(() => {
   extensionLoader = new TestExtensionLoader(
@@ -160,6 +163,7 @@ beforeAll(() => {
     viewRegistry,
     context,
     directories,
+    exec,
   );
 });
 

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -58,7 +58,7 @@ import type { IconRegistry } from './icon-registry.js';
 import type { Directories } from './directories.js';
 import { getBase64Image, isLinux, isMac, isWindows } from '../util.js';
 import type { CustomPickRegistry } from './custompick/custompick-registry.js';
-import { exec } from './util/exec.js';
+import type { Exec } from './util/exec.js';
 import type { ProviderContainerConnectionInfo, ProviderKubernetesConnectionInfo } from './api/provider-info.js';
 import type { ViewRegistry } from './view-registry.js';
 import type { Context } from './context/context.js';
@@ -147,6 +147,7 @@ export class ExtensionLoader {
     private viewRegistry: ViewRegistry,
     private context: Context,
     directories: Directories,
+    private exec: Exec,
   ) {
     this.pluginsDirectory = directories.getPluginsDirectory();
     this.pluginsScanDirectory = directories.getPluginsScanDirectory();
@@ -930,7 +931,7 @@ export class ExtensionLoader {
         args?: string[],
         options?: containerDesktopAPI.RunOptions,
       ): Promise<containerDesktopAPI.RunResult> => {
-        return exec(command, this.proxy, args, options);
+        return this.exec.exec(command, args, options);
       },
     };
 

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -930,7 +930,7 @@ export class ExtensionLoader {
         args?: string[],
         options?: containerDesktopAPI.RunOptions,
       ): Promise<containerDesktopAPI.RunResult> => {
-        return exec(command, args, options);
+        return exec(command, this.proxy, args, options);
       },
     };
 

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -121,6 +121,7 @@ import { Context } from './context/context.js';
 import { OnboardingRegistry } from './onboarding-registry.js';
 import type { OnboardingInfo, OnboardingStatus } from './api/onboarding.js';
 import { OnboardingUtils } from './onboarding/onboarding-utils.js';
+import { Exec } from './util/exec.js';
 
 type LogType = 'log' | 'warn' | 'trace' | 'debug' | 'error';
 
@@ -369,6 +370,8 @@ export class PluginSystem {
 
     const proxy = new Proxy(configurationRegistry);
     await proxy.init();
+
+    const exec = new Exec(proxy);
 
     const commandRegistry = new CommandRegistry(telemetry);
     const menuRegistry = new MenuRegistry(commandRegistry);
@@ -685,6 +688,7 @@ export class PluginSystem {
       viewRegistry,
       context,
       directories,
+      exec,
     );
     await this.extensionLoader.init();
 
@@ -698,7 +702,7 @@ export class PluginSystem {
     // setup security restrictions on links
     await this.setupSecurityRestrictionsOnLinks(messageBox);
 
-    const contributionManager = new ContributionManager(apiSender, directories, containerProviderRegistry, proxy);
+    const contributionManager = new ContributionManager(apiSender, directories, containerProviderRegistry, exec);
     this.ipcHandle('container-provider-registry:listContainers', async (): Promise<ContainerInfo[]> => {
       return containerProviderRegistry.listContainers();
     });

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -698,7 +698,7 @@ export class PluginSystem {
     // setup security restrictions on links
     await this.setupSecurityRestrictionsOnLinks(messageBox);
 
-    const contributionManager = new ContributionManager(apiSender, directories, containerProviderRegistry);
+    const contributionManager = new ContributionManager(apiSender, directories, containerProviderRegistry, proxy);
     this.ipcHandle('container-provider-registry:listContainers', async (): Promise<ContainerInfo[]> => {
       return containerProviderRegistry.listContainers();
     });

--- a/packages/main/src/plugin/util/exec.ts
+++ b/packages/main/src/plugin/util/exec.ts
@@ -20,14 +20,27 @@ import type { ChildProcessWithoutNullStreams } from 'child_process';
 import { spawn } from 'child_process';
 import type { RunError, RunOptions, RunResult } from '@podman-desktop/api';
 import { isMac, isWindows } from '../../util.js';
+import type { Proxy } from '../proxy.js';
 
 export const macosExtraPath = '/usr/local/bin:/opt/homebrew/bin:/opt/local/bin:/opt/podman/bin';
 
-export function exec(command: string, args?: string[], options?: RunOptions): Promise<RunResult> {
+export function exec(command: string, proxy: Proxy, args?: string[], options?: RunOptions): Promise<RunResult> {
   let env = Object.assign({}, process.env);
 
   if (options?.env) {
     env = Object.assign(env, options.env);
+  }
+
+  if (proxy.isEnabled()) {
+    if (proxy.proxy?.httpsProxy) {
+      env.HTTPS_PROXY = 'http://' + proxy.proxy.httpsProxy;
+    }
+    if (proxy.proxy?.httpProxy) {
+      env.HTTP_PROXY = 'http://' + proxy.proxy.httpProxy;
+    }
+    if (proxy.proxy?.noProxy) {
+      env.NO_PROXY = proxy.proxy.noProxy;
+    }
   }
 
   if (isMac() || isWindows()) {

--- a/packages/main/src/plugin/util/exec.ts
+++ b/packages/main/src/plugin/util/exec.ts
@@ -24,115 +24,67 @@ import type { Proxy } from '../proxy.js';
 
 export const macosExtraPath = '/usr/local/bin:/opt/homebrew/bin:/opt/local/bin:/opt/podman/bin';
 
-export function exec(command: string, proxy: Proxy, args?: string[], options?: RunOptions): Promise<RunResult> {
-  let env = Object.assign({}, process.env);
+export class Exec {
+  constructor(private proxy: Proxy) {}
 
-  if (options?.env) {
-    env = Object.assign(env, options.env);
-  }
+  exec(command: string, args?: string[], options?: RunOptions): Promise<RunResult> {
+    let env = Object.assign({}, process.env);
 
-  if (proxy.isEnabled()) {
-    if (proxy.proxy?.httpsProxy) {
-      env.HTTPS_PROXY = 'http://' + proxy.proxy.httpsProxy;
+    if (options?.env) {
+      env = Object.assign(env, options.env);
     }
-    if (proxy.proxy?.httpProxy) {
-      env.HTTP_PROXY = 'http://' + proxy.proxy.httpProxy;
-    }
-    if (proxy.proxy?.noProxy) {
-      env.NO_PROXY = proxy.proxy.noProxy;
-    }
-  }
 
-  if (isMac() || isWindows()) {
-    env.PATH = getInstallationPath(env.PATH);
-  } else if (env.FLATPAK_ID) {
-    args = ['--host', command, ...(args || [])];
-    command = 'flatpak-spawn';
-  }
-
-  let cwd: string;
-  if (options?.cwd) {
-    cwd = options.cwd;
-  }
-
-  return new Promise((resolve, reject) => {
-    let stdout = '';
-    let stderr = '';
-
-    const childProcess: ChildProcessWithoutNullStreams = spawn(command, args, { env, cwd });
-
-    options?.token?.onCancellationRequested(() => {
-      if (!childProcess.killed) {
-        childProcess.kill();
-        options?.logger?.error('Execution cancelled');
-        const errResult: RunError = {
-          name: 'Execution cancelled',
-          message: 'Failed to execute command: Execution cancelled',
-          exitCode: 1,
-          command,
-          stdout: stdout.trim(),
-          stderr: stderr.trim(),
-          cancelled: true,
-          killed: childProcess.killed,
-        };
-        reject(errResult);
+    if (this.proxy.isEnabled()) {
+      if (this.proxy.proxy?.httpsProxy) {
+        env.HTTPS_PROXY = `http://${this.proxy.proxy.httpsProxy}`;
       }
-      options?.logger?.error('Failed to execute cancel: Process has been already killed');
-      const errResult: RunError = {
-        name: 'Failed to execute cancel: Process has been already killed',
-        message: 'Failed to execute cancel: Process has been already killed',
-        exitCode: 1,
-        command,
-        stdout: stdout.trim(),
-        stderr: stderr.trim(),
-        cancelled: false,
-        killed: childProcess.killed,
-      };
-      reject(errResult);
-    });
+      if (this.proxy.proxy?.httpProxy) {
+        env.HTTP_PROXY = `http://${this.proxy.proxy.httpProxy}`;
+      }
+      if (this.proxy.proxy?.noProxy) {
+        env.NO_PROXY = this.proxy.proxy.noProxy;
+      }
+    }
 
-    childProcess.stdout.setEncoding('utf8');
-    childProcess.stderr.setEncoding('utf8');
+    if (isMac() || isWindows()) {
+      env.PATH = getInstallationPath(env.PATH);
+    } else if (env.FLATPAK_ID) {
+      args = ['--host', command, ...(args || [])];
+      command = 'flatpak-spawn';
+    }
 
-    childProcess.stdout.on('data', data => {
-      stdout += data.toString();
-      options?.logger?.log(data);
-    });
+    let cwd: string;
+    if (options?.cwd) {
+      cwd = options.cwd;
+    }
 
-    childProcess.stderr.on('data', data => {
-      stderr += data.toString();
-      options?.logger?.warn(data);
-    });
+    return new Promise((resolve, reject) => {
+      let stdout = '';
+      let stderr = '';
 
-    childProcess.on('error', error => {
-      options?.logger?.error(`Failed to execute command: ${error.message}`);
-      const errResult: RunError = {
-        name: error.name,
-        message: `Failed to execute command: ${error.message}`,
-        exitCode: 1,
-        command,
-        stdout: stdout.trim(),
-        stderr: stderr.trim(),
-        cancelled: false,
-        killed: childProcess.killed,
-      };
-      reject(errResult);
-    });
+      const childProcess: ChildProcessWithoutNullStreams = spawn(command, args, { env, cwd });
 
-    childProcess.on('exit', exitCode => {
-      if (exitCode === 0) {
-        const result: RunResult = {
-          command,
-          stdout: stdout.trim(),
-          stderr: stderr.trim(),
-        };
-        resolve(result);
-      } else {
-        options?.logger?.error(`Command execution failed with exit code ${exitCode}`);
+      options?.token?.onCancellationRequested(() => {
+        if (!childProcess.killed) {
+          childProcess.kill();
+          options?.logger?.error('Execution cancelled');
+          const errResult: RunError = {
+            name: 'Execution cancelled',
+            message: 'Failed to execute command: Execution cancelled',
+            exitCode: 1,
+            command,
+            stdout: stdout.trim(),
+            stderr: stderr.trim(),
+            cancelled: true,
+            killed: childProcess.killed,
+          };
+          reject(errResult);
+        }
+        options?.logger?.error('Failed to execute cancel: Process has been already killed');
         const errResult: RunError = {
-          name: `Command execution failed with exit code ${exitCode}`,
-          message: `Command execution failed with exit code ${exitCode}`,
-          exitCode: exitCode || 1,
+          name: 'Failed to execute cancel: Process has been already killed',
+          message: 'Failed to execute cancel: Process has been already killed',
+          exitCode: 1,
           command,
           stdout: stdout.trim(),
           stderr: stderr.trim(),
@@ -140,9 +92,61 @@ export function exec(command: string, proxy: Proxy, args?: string[], options?: R
           killed: childProcess.killed,
         };
         reject(errResult);
-      }
+      });
+
+      childProcess.stdout.setEncoding('utf8');
+      childProcess.stderr.setEncoding('utf8');
+
+      childProcess.stdout.on('data', data => {
+        stdout += data.toString();
+        options?.logger?.log(data);
+      });
+
+      childProcess.stderr.on('data', data => {
+        stderr += data.toString();
+        options?.logger?.warn(data);
+      });
+
+      childProcess.on('error', error => {
+        options?.logger?.error(`Failed to execute command: ${error.message}`);
+        const errResult: RunError = {
+          name: error.name,
+          message: `Failed to execute command: ${error.message}`,
+          exitCode: 1,
+          command,
+          stdout: stdout.trim(),
+          stderr: stderr.trim(),
+          cancelled: false,
+          killed: childProcess.killed,
+        };
+        reject(errResult);
+      });
+
+      childProcess.on('exit', exitCode => {
+        if (exitCode === 0) {
+          const result: RunResult = {
+            command,
+            stdout: stdout.trim(),
+            stderr: stderr.trim(),
+          };
+          resolve(result);
+        } else {
+          options?.logger?.error(`Command execution failed with exit code ${exitCode}`);
+          const errResult: RunError = {
+            name: `Command execution failed with exit code ${exitCode}`,
+            message: `Command execution failed with exit code ${exitCode}`,
+            exitCode: exitCode || 1,
+            command,
+            stdout: stdout.trim(),
+            stderr: stderr.trim(),
+            cancelled: false,
+            killed: childProcess.killed,
+          };
+          reject(errResult);
+        }
+      });
     });
-  });
+  }
 }
 
 export function getInstallationPath(envPATH?: string): string {


### PR DESCRIPTION
Fixes #3768

### What does this PR do?

Set the proxy environment variables when launching process using the extension API

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

Fixes #3768 

### How to test this PR?

1. Create a proxy environment (install proxy, no network access outside proxy)
2. Configure proxy in Podman Desktop
3. Remove cached Podman machine images ($HOME/.local/share/containers/podman/machine/wsl on Windows)
4. Create a Podman machine, make sure image is downloaded through the proxy
