### PR TITLE
feat: add specific provider autostart setting and remove global one (#3839)

### DIFF
--- a/packages/main/src/plugin/autostart-engine.spec.ts
+++ b/packages/main/src/plugin/autostart-engine.spec.ts
@@ -1,0 +1,174 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
+import type { IConfigurationNode } from './configuration-registry.js';
+import { ConfigurationRegistry } from './configuration-registry.js';
+import type { Directories } from './directories.js';
+import type { ProviderRegistry } from './provider-registry.js';
+import { AutostartEngine } from './autostart-engine.js';
+import type { Configuration } from '@podman-desktop/api';
+
+let configurationRegistry: ConfigurationRegistry;
+let providerRegistry: ProviderRegistry;
+let autostartEngine: AutostartEngine;
+
+const extensionId = 'id';
+const extensionDisplayName = 'name';
+
+const mockRegisterConfiguration = vi.fn();
+const mockRunAutostart = vi.fn().mockResolvedValue('');
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+/* eslint-disable @typescript-eslint/no-empty-function */
+beforeAll(() => {
+  configurationRegistry = new ConfigurationRegistry({} as Directories);
+  providerRegistry = {} as unknown as ProviderRegistry;
+  autostartEngine = new AutostartEngine(configurationRegistry, providerRegistry);
+  configurationRegistry.registerConfigurations = mockRegisterConfiguration;
+  configurationRegistry.deregisterConfigurations = vi.fn();
+  providerRegistry.runAutostart = mockRunAutostart;
+});
+
+test('Check that default value is false if provider autostart setting is undefined and old global setting is false', async () => {
+  vi.spyOn(configurationRegistry, 'getConfiguration').mockImplementation((section?: string) => {
+    if (section === `preferences.${extensionId}`) {
+      return {
+        get: (_section: string) => undefined,
+      } as Configuration;
+    } else {
+      return {
+        get: (_section: string) => false,
+      } as Configuration;
+    }
+  });
+
+  const autoStartConfigurationNode: IConfigurationNode = {
+    id: `preferences.${extensionId}.engine.autostart`,
+    title: `Autostart ${extensionDisplayName} engine`,
+    type: 'object',
+    extension: {
+      id: extensionId,
+    },
+    properties: {
+      [`preferences.${extensionId}.engine.autostart`]: {
+        description: `Autostart ${extensionDisplayName} engine when launching Podman Desktop`,
+        type: 'boolean',
+        default: false,
+      },
+    },
+  };
+
+  const disposable = autostartEngine.registerProvider(extensionId, extensionDisplayName, 'internalId');
+  disposable.dispose();
+  expect(mockRegisterConfiguration).toBeCalledWith([autoStartConfigurationNode]);
+});
+
+test('Check that old global setting is not checked if provider autostart setting is already set', async () => {
+  const getConfigurationMock = vi.spyOn(configurationRegistry, 'getConfiguration').mockImplementation(() => {
+    return {
+      get: (_section: string) => false,
+    } as Configuration;
+  });
+
+  const disposable = autostartEngine.registerProvider(extensionId, extensionDisplayName, 'internalId');
+  disposable.dispose();
+  expect(getConfigurationMock).toBeCalledTimes(1);
+  expect(getConfigurationMock).toBeCalledWith(`preferences.${extensionId}`);
+});
+
+test('Check that default value is true if neither provider autostart setting nor old autostart setting are set', async () => {
+  vi.spyOn(configurationRegistry, 'getConfiguration').mockImplementation(() => {
+    return {
+      get: (_section: string) => undefined,
+    } as Configuration;
+  });
+
+  const autoStartConfigurationNode: IConfigurationNode = {
+    id: `preferences.${extensionId}.engine.autostart`,
+    title: `Autostart ${extensionDisplayName} engine`,
+    type: 'object',
+    extension: {
+      id: extensionId,
+    },
+    properties: {
+      [`preferences.${extensionId}.engine.autostart`]: {
+        description: `Autostart ${extensionDisplayName} engine when launching Podman Desktop`,
+        type: 'boolean',
+        default: true,
+      },
+    },
+  };
+
+  const disposable = autostartEngine.registerProvider(extensionId, extensionDisplayName, 'internalId');
+  disposable.dispose();
+
+  expect(mockRegisterConfiguration).toBeCalledWith([autoStartConfigurationNode]);
+});
+
+test('Check that runAutostart is called once if only one provider has registered autostart process', async () => {
+  vi.spyOn(configurationRegistry, 'getConfiguration').mockImplementation(() => {
+    return {
+      get: (_section: string) => true,
+    } as Configuration;
+  });
+
+  const disposable = autostartEngine.registerProvider(extensionId, extensionDisplayName, 'internalId');
+  await autostartEngine.start();
+
+  disposable.dispose();
+  expect(mockRunAutostart).toBeCalledTimes(1);
+  expect(mockRunAutostart).toBeCalledWith('internalId');
+});
+
+test('Check that runAutostart is never called if only one provider has registered autostart process but its setting is false', async () => {
+  vi.spyOn(configurationRegistry, 'getConfiguration').mockImplementation(() => {
+    return {
+      get: (_section: string) => false,
+    } as Configuration;
+  });
+
+  const disposable = autostartEngine.registerProvider(extensionId, extensionDisplayName, 'internalId');
+
+  await autostartEngine.start();
+
+  disposable.dispose();
+  expect(mockRunAutostart).toBeCalledTimes(0);
+});
+
+test('Check that runAutostart is called twice if only two providers has registered autostart process', async () => {
+  vi.spyOn(configurationRegistry, 'getConfiguration').mockImplementation(() => {
+    return {
+      get: (_section: string) => true,
+    } as Configuration;
+  });
+
+  const disposable1 = autostartEngine.registerProvider(extensionId, extensionDisplayName, 'internalId1');
+  const disposable2 = autostartEngine.registerProvider(extensionId, extensionDisplayName, 'internalId2');
+
+  await autostartEngine.start();
+
+  disposable1.dispose();
+  disposable2.dispose();
+  expect(mockRunAutostart).toBeCalledTimes(2);
+  expect(mockRunAutostart).toHaveBeenNthCalledWith(1, 'internalId1');
+  expect(mockRunAutostart).toHaveBeenLastCalledWith('internalId2');
+});

--- a/packages/main/src/plugin/autostart-engine.ts
+++ b/packages/main/src/plugin/autostart-engine.ts
@@ -16,50 +16,73 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import { Disposable } from './types/disposable.js';
 import type { ConfigurationRegistry, IConfigurationNode } from './configuration-registry.js';
 import type { ProviderRegistry } from './provider-registry.js';
 
 export class AutostartEngine {
-  constructor(
-    private configurationRegistry: ConfigurationRegistry,
-    private providerRegistry: ProviderRegistry,
-  ) {}
+  private providerExtension = new Map<string, string>();
 
-  async init(): Promise<void> {
-    // add configuration
+  constructor(private configurationRegistry: ConfigurationRegistry, private providerRegistry: ProviderRegistry) {}
+
+  registerProvider(extensionId: string, extensionDisplayName: string, providerInternalId: string): Disposable {
+    this.providerExtension.set(providerInternalId, extensionId);
+    const autostartConfiguration = this.registerProviderConfiguration(extensionId, extensionDisplayName);
+
+    return Disposable.create(() => {
+      this.providerExtension.delete(providerInternalId);
+      this.configurationRegistry.deregisterConfigurations([autostartConfiguration]);
+    });
+  }
+
+  registerProviderConfiguration(extensionId: string, extensionDisplayName: string): IConfigurationNode {
+    const extensionConfiguration = this.configurationRegistry.getConfiguration(`preferences.${extensionId}`);
+    let autostart = extensionConfiguration.get<boolean>('engine.autostart');
+    // if there is no configuration set, we try to retrieve the value of the old deprecated preferences.engine.autostart setting
+    if (!autostart) {
+      const autoStartConfigurationGlobal = this.configurationRegistry.getConfiguration('preferences.engine');
+      autostart = autoStartConfigurationGlobal.get<boolean>('autostart');
+    }
+
     const autoStartConfigurationNode: IConfigurationNode = {
-      id: 'preferences.engine.autostart',
-      title: 'Autostart container engine',
+      id: `preferences.${extensionId}.engine.autostart`,
+      title: `Autostart ${extensionDisplayName} engine`,
       type: 'object',
+      extension: {
+        id: extensionId,
+      },
       properties: {
-        ['preferences.engine.autostart']: {
-          description: 'Autostart container engine when launching Podman Desktop',
+        [`preferences.${extensionId}.engine.autostart`]: {
+          description: `Autostart ${extensionDisplayName} engine when launching Podman Desktop`,
           type: 'boolean',
-          default: true,
+          default: autostart || true,
         },
       },
     };
 
     this.configurationRegistry.registerConfigurations([autoStartConfigurationNode]);
+    return autoStartConfigurationNode;
   }
 
   async start(): Promise<void> {
-    // grab value
-    const autoStartConfiguration = this.configurationRegistry.getConfiguration('preferences.engine');
-    const autostart = autoStartConfiguration.get<boolean>('autostart');
-    if (autostart) {
-      console.log('Autostarting container engine');
-      // send autostart
-      this.providerRegistry.runAutostart().catch((e: unknown) => {
-        console.error('Failed to autostart container engine', e);
-      });
-    }
-
-    // start the engine if we toggle the property
-    this.configurationRegistry.onDidChangeConfiguration(async e => {
-      if (e.key === 'preferences.engine.autostart' && e.value === true) {
-        await this.providerRegistry.runAutostart();
+    this.providerExtension.forEach((extensionId, providerInternalId) => {
+      // grab value
+      const autoStartConfiguration = this.configurationRegistry.getConfiguration(`preferences.${extensionId}`);
+      const autostart = autoStartConfiguration.get<boolean>('engine.autostart');
+      if (autostart) {
+        console.log(`Autostarting ${extensionId} container engine`);
+        // send autostart
+        this.providerRegistry.runAutostart(providerInternalId).catch((e: unknown) => {
+          console.error(`Failed to autostart ${extensionId} container engine`, e);
+        });
       }
+
+      // start the engine if we toggle the property
+      this.configurationRegistry.onDidChangeConfiguration(async e => {
+        if (e.key === `${extensionId}.engine.autostart` && e.value === true) {
+          await this.providerRegistry.runAutostart(providerInternalId);
+        }
+      });
     });
   }
 }

--- a/packages/main/src/plugin/autostart-engine.ts
+++ b/packages/main/src/plugin/autostart-engine.ts
@@ -35,11 +35,11 @@ export class AutostartEngine {
     });
   }
 
-  registerProviderConfiguration(extensionId: string, extensionDisplayName: string): IConfigurationNode {
+  private registerProviderConfiguration(extensionId: string, extensionDisplayName: string): IConfigurationNode {
     const extensionConfiguration = this.configurationRegistry.getConfiguration(`preferences.${extensionId}`);
     let autostart = extensionConfiguration.get<boolean>('engine.autostart');
     // if there is no configuration set, we try to retrieve the value of the old deprecated preferences.engine.autostart setting
-    if (!autostart) {
+    if (autostart === undefined) {
       const autoStartConfigurationGlobal = this.configurationRegistry.getConfiguration('preferences.engine');
       autostart = autoStartConfigurationGlobal.get<boolean>('autostart');
     }
@@ -55,7 +55,7 @@ export class AutostartEngine {
         [`preferences.${extensionId}.engine.autostart`]: {
           description: `Autostart ${extensionDisplayName} engine when launching Podman Desktop`,
           type: 'boolean',
-          default: autostart || true,
+          default: autostart !== undefined ? autostart : true,
         },
       },
     };

--- a/packages/main/src/plugin/autostart-engine.ts
+++ b/packages/main/src/plugin/autostart-engine.ts
@@ -23,12 +23,14 @@ import type { ProviderRegistry } from './provider-registry.js';
 export class AutostartEngine {
   private providerExtension = new Map<string, string>();
 
-  constructor(private configurationRegistry: ConfigurationRegistry, private providerRegistry: ProviderRegistry) {}
+  constructor(
+    private configurationRegistry: ConfigurationRegistry,
+    private providerRegistry: ProviderRegistry,
+  ) {}
 
   registerProvider(extensionId: string, extensionDisplayName: string, providerInternalId: string): Disposable {
     this.providerExtension.set(providerInternalId, extensionId);
     const autostartConfiguration = this.registerProviderConfiguration(extensionId, extensionDisplayName);
-
     return Disposable.create(() => {
       this.providerExtension.delete(providerInternalId);
       this.configurationRegistry.deregisterConfigurations([autostartConfiguration]);

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -626,7 +626,7 @@ export class ExtensionLoader {
           images.icon = instance.updateImage(images.icon, extensionPath);
           images.logo = instance.updateImage(images.logo, extensionPath);
         }
-        return providerRegistry.createProvider(extensionInfo.id, providerOptions);
+        return providerRegistry.createProvider(extensionInfo.id, extensionInfo.label, providerOptions);
       },
       onDidUpdateProvider: (listener, thisArg, disposables) => {
         return providerRegistry.onDidUpdateProvider(listener, thisArg, disposables);

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -400,8 +400,8 @@ export class PluginSystem {
       await trayIconColor.init();
     }
 
-    const autoStartConfiguration = new AutostartEngine(configurationRegistry, providerRegistry);
-    await autoStartConfiguration.init();
+    const autoStartEngine = new AutostartEngine(configurationRegistry, providerRegistry);
+    providerRegistry.registerAutostartEngine(autoStartEngine);
 
     providerRegistry.addProviderListener((name: string, providerInfo: ProviderInfo) => {
       if (name === 'provider:update-status') {
@@ -1837,7 +1837,7 @@ export class PluginSystem {
       this.markAsExtensionsStarted();
     }
     extensionsUpdater.init().catch((err: unknown) => console.error('Unable to perform extension updates', err));
-    autoStartConfiguration.start().catch((err: unknown) => console.error('Unable to perform autostart', err));
+    autoStartEngine.start().catch((err: unknown) => console.error('Unable to perform autostart', err));
     return this.extensionLoader;
   }
 

--- a/packages/main/src/plugin/provider-impl.ts
+++ b/packages/main/src/plugin/provider-impl.ts
@@ -76,6 +76,7 @@ export class ProviderImpl implements Provider, IDisposable {
   constructor(
     private _internalId: string,
     readonly extensionId: string,
+    readonly extensionDisplayName: string,
     private providerOptions: ProviderOptions,
     private providerRegistry: ProviderRegistry,
     private containerRegistry: ContainerProviderRegistry,


### PR DESCRIPTION
### What does this PR do?

This PR gets rid of the global autostart setting and add a specific one per provider that registers its autostart process.

If the old global setting was set, its value is used to initialize the provider autostart setting.

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

it resolves #3839 

### How to test this PR?

1. check the new autostart podman setting it's in the preferences and try it
2. if set to true the podman machine should autostart as before
