### PR TITLE
feat: ability to click enter in pull image name input

### DIFF
--- a/packages/renderer/src/lib/image/PullImage.spec.ts
+++ b/packages/renderer/src/lib/image/PullImage.spec.ts
@@ -164,6 +164,23 @@ describe('PullImage', () => {
     expect(errorMesssage).toHaveTextContent('Image does not exists');
   });
 
+  test('Expect that you can type an image name and hit Enter', async () => {
+    setup();
+    render(PullImage);
+
+    // first call to pull image throw an error
+    pullImageMock.mockRejectedValueOnce(new Error('Image does not exists'));
+
+    const pullImageInput = screen.getByRole('textbox', { name: 'imageName' });
+    await userEvent.click(pullImageInput);
+    await userEvent.keyboard('image-does-not-exist[Enter]');
+
+    // expect that the error message is displayed
+    const errorMesssage = screen.getByRole('alert', { name: 'Error Message Content' });
+    expect(errorMesssage).toBeInTheDocument();
+    expect(errorMesssage).toHaveTextContent('Image does not exists');
+  });
+
   // pull image with error and then pull image with success
   // error message should not be displayed anymore
   test('Expect that pull image is reporting an error only if invalid', async () => {

--- a/packages/renderer/src/lib/image/PullImage.svelte
+++ b/packages/renderer/src/lib/image/PullImage.svelte
@@ -149,9 +149,14 @@ function validateImageName(event: any): void {
             id="imageName"
             class="w-full p-2 outline-none text-sm bg-charcoal-600 rounded-sm text-gray-700 placeholder-gray-700"
             type="text"
-            name="serverUrl"
+            name="imageName"
             disabled="{pullFinished || pullInProgress}"
             on:input="{event => validateImageName(event)}"
+            on:keypress="{event => {
+              if (event.key === 'Enter') {
+                pullImage();
+              }
+            }}"
             bind:value="{imageToPull}"
             aria-invalid="{imageNameInvalid !== ''}"
             placeholder="Image name"


### PR DESCRIPTION
### What does this PR do?

Allows users to hit Enter after typing in an image name in the Pull Image form. Minor usability improvement, just saves grabbing the mouse to click the Pull Image button.

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

Fixes #3849.

### How to test this PR?

Go to pull an image and hit Enter after typing the name instead of clicking on the button.