### PR TITLE
Don't log console errors when activating lima extension

### DIFF
--- a/extensions/lima/src/extension.ts
+++ b/extensions/lima/src/extension.ts
@@ -85,15 +85,22 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
     extensionContext.subscriptions.push(provider);
   }
 
-  if (fs.existsSync(socketPath)) {
-    registerProvider(extensionContext, provider, socketPath);
-  } else {
-    console.debug(`Could not find socket at ${socketPath}`);
-  }
-  if (fs.existsSync(configPath)) {
-    registerProvider(extensionContext, provider, configPath);
-  } else {
-    console.debug(`Could not find config at ${configPath}`);
+  switch (engineType) {
+    case 'podman':
+    case 'docker':
+      if (fs.existsSync(socketPath)) {
+        registerProvider(extensionContext, provider, socketPath);
+      } else {
+        console.debug(`Could not find socket at ${socketPath}`);
+      }
+      break;
+    case 'kubernetes':
+      if (fs.existsSync(configPath)) {
+        registerProvider(extensionContext, provider, configPath);
+      } else {
+        console.debug(`Could not find config at ${configPath}`);
+      }
+      break;
   }
 }
 

--- a/extensions/lima/src/extension.ts
+++ b/extensions/lima/src/extension.ts
@@ -88,12 +88,12 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
   if (fs.existsSync(socketPath)) {
     registerProvider(extensionContext, provider, socketPath);
   } else {
-    console.error(`Could not find socket at ${socketPath}`);
+    console.debug(`Could not find socket at ${socketPath}`);
   }
   if (fs.existsSync(configPath)) {
     registerProvider(extensionContext, provider, configPath);
   } else {
-    console.error(`Could not find config at ${configPath}`);
+    console.debug(`Could not find config at ${configPath}`);
   }
 }
 


### PR DESCRIPTION
### What does this PR do?

Avoid logging errors for the lima extension.

Only check files in use, and use "debug" log.

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast 
explaining what is doing this PR -->

### What issues does this PR fix or reference?

Closes #3780

### How to test this PR?

When not using the lima extension, log should be empty.

When using template://podman, no "kubernetes.sock" errors.