### PR TITLE
fix: check if machine init rootful flag supported

### DIFF
--- a/extensions/podman/package.json
+++ b/extensions/podman/package.json
@@ -104,7 +104,8 @@
           "type": "boolean",
           "default": true,
           "scope": "ContainerProviderConnectionFactory",
-          "description": "Machine with root privileges"
+          "description": "Machine with root privileges",
+          "when": "podman.isRootfulMachineInitSupported == true"
         },
         "podman.factory.machine.user-mode-networking": {
           "type": "boolean",

--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -664,6 +664,7 @@ async function registerUpdatesIfAny(
   }
 }
 
+export const ROOTFUL_MACHINE_INIT_SUPPORTED_KEY = 'podman.isRootfulMachineInitSupported';
 export const USER_MODE_NETWORKING_SUPPORTED_KEY = 'podman.isUserModeNetworkingSupported';
 
 export async function activate(extensionContext: extensionApi.ExtensionContext): Promise<void> {
@@ -674,6 +675,7 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
   const version: string | undefined = installedPodman?.version;
 
   if (version) {
+    extensionApi.context.setValue(ROOTFUL_MACHINE_INIT_SUPPORTED_KEY, isRootfulMachineInitSupported(version));
     extensionApi.context.setValue(USER_MODE_NETWORKING_SUPPORTED_KEY, isUserModeNetworkingSupported(version));
     isMovedPodmanSocket = isPodmanSocketLocationMoved(version);
   }
@@ -1078,6 +1080,13 @@ export async function deactivate(): Promise<void> {
       console.log('stopped autostarted machine', autoMachineName);
     }
   });
+}
+
+const PODMAN_MINIMUM_VERSION_FOR_ROOTFUL_MACHINE_INIT = '4.1.0';
+
+// Checks if rootful machine init is supported.
+export function isRootfulMachineInitSupported(podmanVersion: string) {
+  return compareVersions(podmanVersion, PODMAN_MINIMUM_VERSION_FOR_ROOTFUL_MACHINE_INIT) >= 0;
 }
 
 const PODMAN_MINIMUM_VERSION_FOR_NEW_SOCKET_LOCATION = '4.5.0';

--- a/extensions/podman/src/podman-install.ts
+++ b/extensions/podman/src/podman-install.ts
@@ -29,7 +29,12 @@ import { getAssetsFolder } from './util';
 import { getDetectionChecks } from './detection-checks';
 import { BaseCheck } from './base-check';
 import { MacCPUCheck, MacMemoryCheck, MacPodmanInstallCheck, MacVersionCheck } from './macos-checks';
-import { isUserModeNetworkingSupported, USER_MODE_NETWORKING_SUPPORTED_KEY } from './extension';
+import {
+  isRootfulMachineInitSupported,
+  ROOTFUL_MACHINE_INIT_SUPPORTED_KEY,
+  isUserModeNetworkingSupported,
+  USER_MODE_NETWORKING_SUPPORTED_KEY,
+} from './extension';
 
 const readFile = promisify(fs.readFile);
 const writeFile = promisify(fs.writeFile);
@@ -133,6 +138,10 @@ export class PodmanInstall {
       if (newInstalledPodman) {
         this.podmanInfo.podmanVersion = newInstalledPodman.version;
         extensionApi.context.setValue(
+          ROOTFUL_MACHINE_INIT_SUPPORTED_KEY,
+          isRootfulMachineInitSupported(newInstalledPodman.version),
+        );
+        extensionApi.context.setValue(
           USER_MODE_NETWORKING_SUPPORTED_KEY,
           isUserModeNetworkingSupported(newInstalledPodman.version),
         );
@@ -181,6 +190,10 @@ export class PodmanInstall {
         provider.updateDetectionChecks(getDetectionChecks(installedPodman));
         provider.updateVersion(updateInfo.bundledVersion);
         this.podmanInfo.ignoreVersionUpdate = undefined;
+        extensionApi.context.setValue(
+          ROOTFUL_MACHINE_INIT_SUPPORTED_KEY,
+          isRootfulMachineInitSupported(updateInfo.bundledVersion),
+        );
         extensionApi.context.setValue(
           USER_MODE_NETWORKING_SUPPORTED_KEY,
           isUserModeNetworkingSupported(updateInfo.bundledVersion),


### PR DESCRIPTION
### What does this PR do?

`Error: unknown flag: --rootful`

`Command execution failed with exit code 125`

### Screenshot/screencast of this PR

![pd-create-machine-error](https://github.com/containers/podman-desktop/assets/10364051/c25e5b70-723a-4524-ab8a-5968d8ffd2e5)

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop 
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to reproduce -->

Run with Podman 3.4 or Podman 4.0 legacy versions.
