### PR TITLE
fix: simplify Windows install doc nav

### DIFF
--- a/website/docs/Installation/windows-install/index.md
+++ b/website/docs/Installation/windows-install/index.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 1
-title: Installing Podman Desktop on Windows
+title: Windows
 description: How to install Podman on Windows.
 tags: [podman-desktop, installing, windows]
 keywords: [podman desktop, containers, podman, installing, installation, windows]

--- a/website/docs/Installation/windows-install/installing-podman-desktop-and-podman-in-a-restricted-environment.md
+++ b/website/docs/Installation/windows-install/installing-podman-desktop-and-podman-in-a-restricted-environment.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 5
-title: Installing Podman Desktop in a restricted environment
+title: Installing in a restricted environment
 description: Installing Podman Desktop on Windows in a restricted environment
 tags: [podman-desktop, installing, windows, restricted-environment]
 keywords: [podman desktop, containers, podman, installing, installation, windows, restricted-environment]

--- a/website/docs/Installation/windows-install/installing-podman-desktop-silently-with-the-windows-installer.md
+++ b/website/docs/Installation/windows-install/installing-podman-desktop-silently-with-the-windows-installer.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 2
-title: Installing Podman Desktop silently
+title: Installing silently
 description: Installing Podman Desktop silently on Windows with the installer
 tags: [podman-desktop, installing, windows]
 keywords: [podman desktop, containers, podman, installing, installation, windows]

--- a/website/docs/Installation/windows-install/installing-podman-desktop-with-chocolatey.md
+++ b/website/docs/Installation/windows-install/installing-podman-desktop-with-chocolatey.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 3
-title: Installing Podman Desktop with Chocolatey
+title: Installing with Chocolatey
 description: Installing Podman Desktop on Windows with Chocolatey
 tags: [podman-desktop, installing, windows, chocolatey]
 keywords: [podman desktop, containers, podman, installing, installation, windows, chocolatey]

--- a/website/docs/Installation/windows-install/installing-podman-desktop-with-scoop.md
+++ b/website/docs/Installation/windows-install/installing-podman-desktop-with-scoop.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 4
-title: Installing Podman Desktop with Scoop
+title: Installing with Scoop
 description: Installing Podman Desktop on Windows with Scoop
 tags: [podman-desktop, installing, windows, scoop]
 keywords: [podman desktop, containers, podman, installing, installation, windows, scoop]

--- a/website/docs/Installation/windows-install/installing-podman-desktop-with-winget.md
+++ b/website/docs/Installation/windows-install/installing-podman-desktop-with-winget.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 5
-title: Installing Podman Desktop with Winget
+title: Installing with Winget
 description: Installing Podman Desktop on Windows with Winget
 tags: [podman-desktop, installing, windows, winget]
 keywords: [podman desktop, containers, podman, installing, installation, windows, winget]


### PR DESCRIPTION
### What does this PR do?

I noticed when looking for the Windows install guide that the navigation on the first page "Installing Podman Desktop on Windows" was inconsistent with the other platforms (just "MacOS", "Linux"). Expanding it the child nav was also very verbose/repetitive compared to elsewhere and includes "Podman Desktop" in every title. This change make the first (index.md) consistent with the other platforms and simplifies the rest of the pages to match.

### Screenshot/screencast of this PR

Before:

<img width="498" alt="Screenshot 2023-09-11 at 12 06 48 PM" src="https://github.com/containers/podman-desktop/assets/19958075/71e741f6-e819-4cb1-8129-7400bf10e4f4">

After:

<img width="498" alt="Screenshot 2023-09-11 at 12 06 55 PM" src="https://github.com/containers/podman-desktop/assets/19958075/c777f4ee-cf09-4827-875d-d469292f0619">

### What issues does this PR fix or reference?

N/A

### How to test this PR?

`yarn website:dev`