### PR TITLE
feat: request focus for image name when pull image form opened

### DIFF
--- a/packages/renderer/src/lib/image/PullImage.spec.ts
+++ b/packages/renderer/src/lib/image/PullImage.spec.ts
@@ -164,6 +164,14 @@ describe('PullImage', () => {
     expect(errorMesssage).toHaveTextContent('Image does not exists');
   });
 
+  test('Expect that focus is in `Image to Pull` field after page is opened', async () => {
+    setup();
+    render(PullImage);
+
+    const pullImageInput = screen.getByRole('textbox', { name: 'imageName' });
+    expect(pullImageInput.matches(':focus')).toBe(true);
+  });
+
   test('Expect that you can type an image name and hit Enter', async () => {
     setup();
     render(PullImage);
@@ -171,8 +179,6 @@ describe('PullImage', () => {
     // first call to pull image throw an error
     pullImageMock.mockRejectedValueOnce(new Error('Image does not exists'));
 
-    const pullImageInput = screen.getByRole('textbox', { name: 'imageName' });
-    await userEvent.click(pullImageInput);
     await userEvent.keyboard('image-does-not-exist[Enter]');
 
     // expect that the error message is displayed

--- a/packages/renderer/src/lib/image/PullImage.svelte
+++ b/packages/renderer/src/lib/image/PullImage.svelte
@@ -127,6 +127,10 @@ function validateImageName(event: any): void {
     imageNameInvalid = undefined;
   }
 }
+
+function requestFocus(element: HTMLInputElement) {
+  element.focus();
+}
 </script>
 
 <FormPage title="Pull Image From a Registry">
@@ -161,7 +165,8 @@ function validateImageName(event: any): void {
             aria-invalid="{imageNameInvalid !== ''}"
             placeholder="Image name"
             aria-label="imageName"
-            required />
+            required
+            use:requestFocus />
           {#if imageNameInvalid}
             <ErrorMessage error="{imageNameInvalid}" />
           {/if}


### PR DESCRIPTION
### What does this PR do?

It adds focus request for image name input field when pull image form is opened.  In connection with other PR it gives nice and smooth forkflow for pulling images.

### Screenshot/screencast of this [PR #3850](https://github.com/containers/podman-desktop/pull/3850)

https://github.com/containers/podman-desktop/assets/620330/c2230259-b84a-40fd-ada1-0f27332a2027

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop 
repository (or from another issue tracker). -->

N/A

### How to test this PR?

<!-- Please explain steps to reproduce -->

1. Open pull image form 
2.  Cursor should be in Image name input, so you can start typing image name right away.
