### PR TITLE
fix: don't prefix all podman machine names

### DIFF
--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -503,7 +503,7 @@ function prettyMachineName(machineName: string): string {
     const sub = machineName.substring('podman-machine-'.length);
     name = `Podman Machine ${sub}`;
   } else {
-    name = `Podman Machine ${machineName}`;
+    name = machineName;
   }
   return name;
 }


### PR DESCRIPTION
### What does this PR do?

My initial position was that we shouldn't prefix any Podman machine names, but I've softened a bit: if someone appends to the default name and calls their machine "podman-machine-3", then I think it's nice we pretty-print that to "Podman Machine 3". But if I call my machine "My Machine", and that's the name I see on the command line, then I still believe we should use "My Machine" and not "Podman Machine My Machine".

I have been using this change for a few days, and I prefer it. The only place I've found where there isn't the obvious context of My Machine being a Podman machine is in the system tray, and IMHO that's not a problem because I named it and recognize what it is in that context.

### Screenshot/screencast of this PR

<img width="224" alt="Screenshot 2023-09-12 at 11 15 49 AM" src="https://github.com/containers/podman-desktop/assets/19958075/aafdfbd7-f005-4b94-8626-9e11eec61b95">

### What issues does this PR fix or reference?

Fixes #3424.

### How to test this PR?

Create a new Podman machine without the prefix.