### PR TITLE
fix: initial action state in details pages

### DIFF
--- a/packages/renderer/src/lib/container/ContainerDetails.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetails.svelte
@@ -41,7 +41,7 @@ onMount(() => {
 function inProgressCallback(inProgress: boolean, state: string | undefined): void {
   container.actionInProgress = inProgress;
   if (state && inProgress) {
-    container.state = 'STARTING';
+    container.state = state;
   }
 }
 

--- a/packages/renderer/src/lib/pod/PodDetails.svelte
+++ b/packages/renderer/src/lib/pod/PodDetails.svelte
@@ -45,7 +45,7 @@ onMount(() => {
 function inProgressCallback(inProgress: boolean, state: string | undefined): void {
   pod.actionInProgress = inProgress;
   if (state && inProgress) {
-    pod.status = 'STARTING';
+    pod.status = state;
   }
 }
 


### PR DESCRIPTION
### What does this PR do?

While testing issue #3529 I noticed that when you're in the pod or container details page, all actions change the state to STARTING regardless of what the action says the state should be changed to. If you were actually deleting the object this means there's often a little blip where it looks like it's trying to start before the state is corrected.

Fixed, now matches the correct/identical code that's in the corresponding *List pages.

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

Fixes #3844.

### How to test this PR?

Start a container that takes >1s to stop or delete, go to Container Details, and stop or delete it. You'll notice the start button momentarily starts spinning.