### PR TITLE
fix: adding flatpak to 'development' app category

### DIFF
--- a/.flatpak.desktop
+++ b/.flatpak.desktop
@@ -5,5 +5,5 @@ Terminal=false
 Type=Application
 Icon=io.podman_desktop.PodmanDesktop
 StartupWMClass=Podman Desktop
-Categories=Utility;
+Categories=Utility;Development;
 X-Flatpak=io.podman_desktop.PodmanDesktop


### PR DESCRIPTION
Addresses issue #3880 - this should add Podman Desktop to the "Development" category of Linux desktops that the flatpak is installed on in addition to the "Utilities" category which it is already in.

### What does this PR do?

Places Podman Desktop in the "Development" applications category on Linux desktops for Flatpak installs.

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast 
explaining what is doing this PR -->

### What issues does this PR fix or reference?

https://github.com/containers/podman-desktop/issues/3880

### How to test this PR?

install the flatpak on a KDE or GNOME desktop, go to the application menu (in GNOME, you might have to turn on the classic GNOME setting on the GNOME login screen), check if Podman Desktop shows up under the "Development" submenu.
