### PR TITLE
fix: adding 'Development' category for flathub

### DIFF
--- a/.flatpak-appdata.xml
+++ b/.flatpak-appdata.xml
@@ -30,6 +30,9 @@
     </ul>
     <p>You can also bring new features with Podman Desktop plug-ins or Docker Desktop extensions.</p>
   </description>
+  <categories>
+    <category>Development</category>
+  </categories>
   <screenshots>
     <screenshot>
       <caption>Podman Desktop UI</caption>


### PR DESCRIPTION
Should address issue #3879 - placing the Podman Desktop listing on flathub.org under the "Developer Tools" category

### What does this PR do?

It *should* put Podman Desktop in the "Developer Tools" category of Flathub

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast 
explaining what is doing this PR -->

### What issues does this PR fix or reference?

https://github.com/containers/podman-desktop/issues/3879

### How to test this PR?

So this is the tricky bit, I'm not sure. Ultimately after a release, we could go to flathub.org, scroll down to "Developer Tools", click "More" and see it listed there in that category. But I don't know how to test that before "prod" so to speak.
