### PR TITLE
chore(tests): improve Kube tab locator in container e2e tests

### DIFF
--- a/tests/src/model/pages/container-details-page.ts
+++ b/tests/src/model/pages/container-details-page.ts
@@ -45,7 +45,7 @@ export class ContainerDetailsPage extends BasePage {
   }
 
   async activateTab(tabName: string) {
-    const tabItem = this.page.getByRole('link', { name: tabName });
+    const tabItem = this.page.getByRole('link', { name: tabName, exact: true });
     await tabItem.waitFor({ state: 'visible', timeout: 2000 });
     await tabItem.click();
   }


### PR DESCRIPTION
### What does this PR do?
Makes the locator for `Kube` tab in container details more robust so it wont find any other element starting with `kube`, ie. `Kubernetes`.
### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast 
explaining what is doing this PR -->

### What issues does this PR fix or reference?
Fixes the test failure of #2792.
<!-- Include any related issues from Podman Desktop 
repository (or from another issue tracker). -->

### How to test this PR?
In mentioned PR, run `yarn test:e2e:smoke` -> should pass now.
<!-- Please explain steps to reproduce -->
