### PR TITLE
chore: return the container's id when creating a container

### DIFF
--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -1553,3 +1553,31 @@ test('container logs callback notified when messages arrive', async () => {
   expect(callback).toHaveBeenCalledWith('end', '');
   expect(telemetry.track).toHaveBeenCalled;
 });
+
+test('test createAndStartContainer', async () => {
+  const createdId = '1234';
+
+  const startMock = vi.fn();
+  const createContainerMock = vi
+    .fn()
+    .mockResolvedValue({ id: createdId, start: startMock } as unknown as Dockerode.Container);
+
+  const fakeDockerode = {
+    createContainer: createContainerMock,
+  } as unknown as Dockerode;
+
+  containerRegistry.addInternalProvider('podman1', {
+    name: 'podman1',
+    id: 'podman1',
+    connection: {
+      type: 'podman',
+    },
+    api: fakeDockerode,
+  } as InternalContainerProvider);
+
+  const container = await containerRegistry.createAndStartContainer('podman1', {});
+
+  expect(container.id).toBe(createdId);
+  expect(createContainerMock).toHaveBeenCalled();
+  expect(startMock).toHaveBeenCalled();
+});

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -1347,7 +1347,7 @@ export class ContainerProviderRegistry {
     }
   }
 
-  async createAndStartContainer(engineId: string, options: ContainerCreateOptions): Promise<void> {
+  async createAndStartContainer(engineId: string, options: ContainerCreateOptions): Promise<{ id: string }> {
     let telemetryOptions = {};
     try {
       // need to find the container engine of the container
@@ -1359,7 +1359,8 @@ export class ContainerProviderRegistry {
         throw new Error('no running provider for the matching container');
       }
       const container = await engine.api.createContainer(options);
-      return container.start();
+      await container.start();
+      return { id: container.id };
     } catch (error) {
       telemetryOptions = { error: error };
       throw error;

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -962,7 +962,7 @@ export class PluginSystem {
 
     this.ipcHandle(
       'container-provider-registry:createAndStartContainer',
-      async (_listener, engine: string, options: ContainerCreateOptions): Promise<void> => {
+      async (_listener, engine: string, options: ContainerCreateOptions): Promise<{ id: string }> => {
         return containerProviderRegistry.createAndStartContainer(engine, options);
       },
     );

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -371,7 +371,7 @@ function initExposure(): void {
 
   contextBridge.exposeInMainWorld(
     'createAndStartContainer',
-    async (engine: string, options: ContainerCreateOptions): Promise<void> => {
+    async (engine: string, options: ContainerCreateOptions): Promise<{ id: string }> => {
       return ipcInvoke('container-provider-registry:createAndStartContainer', engine, options);
     },
   );


### PR DESCRIPTION
### What does this PR do?
return the id of the container so client can reuse the value of this new container for other calls

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast 
explaining what is doing this PR -->

### What issues does this PR fix or reference?

related to https://github.com/containers/podman-desktop/issues/970

### How to test this PR?

should work as before

unit test added