### PR TITLE
 feat: use tty for containers started with TTY/interactive mode

### DIFF
--- a/packages/renderer/src/lib/ContainerList.svelte
+++ b/packages/renderer/src/lib/ContainerList.svelte
@@ -326,7 +326,7 @@ onDestroy(() => {
 });
 
 function openDetailsContainer(container: ContainerInfoUI) {
-  router.goto(`/containers/${container.id}/logs`);
+  router.goto(`/containers/${container.id}/`);
 }
 
 function keydownChoice(e: KeyboardEvent) {

--- a/packages/renderer/src/lib/container/ContainerDetailsTtyTerminal.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerDetailsTtyTerminal.spec.ts
@@ -1,0 +1,82 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+import { test, expect, vi, beforeAll } from 'vitest';
+import { render, waitFor } from '@testing-library/svelte';
+import type { ContainerInfoUI } from './ContainerInfoUI';
+import ContainerDetailsTtyTerminal from './ContainerDetailsTtyTerminal.svelte';
+
+const getConfigurationValueMock = vi.fn();
+const attachContainerMock = vi.fn();
+
+beforeAll(() => {
+  (window as any).getConfigurationValue = getConfigurationValueMock;
+  (window as any).attachContainer = attachContainerMock;
+  (window as any).attachContainerSend = vi.fn();
+
+  (window as any).matchMedia = vi.fn().mockReturnValue({
+    addListener: vi.fn(),
+  });
+});
+
+test('expect being able to attach terminal ', async () => {
+  const container: ContainerInfoUI = {
+    id: 'myContainer',
+    state: 'RUNNING',
+    engineId: 'podman',
+  } as unknown as ContainerInfoUI;
+
+  let onDataCallback: (data: Buffer) => void = () => {};
+
+  const sendCallbackId = 12345;
+  attachContainerMock.mockImplementation(
+    (
+      _engineId: string,
+      _containerId: string,
+      onData: (data: Buffer) => void,
+      _onError: (error: string) => void,
+      _onEnd: () => void,
+    ) => {
+      onDataCallback = onData;
+      // return a callback id
+      return sendCallbackId;
+    },
+  );
+
+  // render the component with a terminal
+  const renderObject = render(ContainerDetailsTtyTerminal, { container, screenReaderMode: true });
+
+  // wait attachContainerMock is called
+  await waitFor(() => expect(attachContainerMock).toHaveBeenCalled());
+
+  // write some data on the terminal
+  onDataCallback(Buffer.from('hello\nworld'));
+
+  // wait 1s
+  await new Promise(resolve => setTimeout(resolve, 1000));
+
+  // search a div having aria-live="assertive" attribute
+  const terminalLinesLiveRegion = renderObject.container.querySelector('div[aria-live="assertive"]');
+
+  // check the content
+  expect(terminalLinesLiveRegion).toHaveTextContent('hello world');
+
+  // check we have called attachContainer
+  expect(attachContainerMock).toHaveBeenCalledTimes(1);
+});

--- a/packages/renderer/src/lib/container/ContainerDetailsTtyTerminal.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetailsTtyTerminal.svelte
@@ -1,0 +1,112 @@
+<script lang="ts">
+import type { ContainerInfoUI } from './ContainerInfoUI';
+import { TerminalSettings } from '../../../../main/src/plugin/terminal-settings';
+import { router } from 'tinro';
+import { onDestroy, onMount } from 'svelte';
+import { Terminal } from 'xterm';
+import { FitAddon } from 'xterm-addon-fit';
+import 'xterm/css/xterm.css';
+import { getPanelDetailColor } from '../color/color';
+import EmptyScreen from '../ui/EmptyScreen.svelte';
+import NoLogIcon from '../ui/NoLogIcon.svelte';
+
+export let container: ContainerInfoUI;
+export let screenReaderMode = false;
+let terminalXtermDiv: HTMLDivElement;
+let attachContainerTerminal: Terminal;
+let currentRouterPath: string;
+let closed = false;
+
+// update current route scheme
+router.subscribe(route => {
+  currentRouterPath = route.path;
+});
+
+// update terminal when receiving data
+function receiveDataCallback(data: Buffer) {
+  attachContainerTerminal.write(data.toString());
+}
+
+function receiveEndCallback() {
+  closed = true;
+}
+
+// call exec command
+async function attachToContainer() {
+  if (container.state !== 'RUNNING') {
+    return;
+  }
+
+  // attach to the container
+  const callbackId = await window.attachContainer(
+    container.engineId,
+    container.id,
+    receiveDataCallback,
+    () => {},
+    receiveEndCallback,
+  );
+
+  // pass data from xterm to container
+  attachContainerTerminal?.onData(data => {
+    window.attachContainerSend(callbackId, data);
+  });
+}
+
+// refresh
+async function refreshTerminal() {
+  // missing element, return
+  if (!terminalXtermDiv) {
+    return;
+  }
+
+  // grab font size
+  const fontSize = await window.getConfigurationValue<number>(
+    TerminalSettings.SectionName + '.' + TerminalSettings.FontSize,
+  );
+  const lineHeight = await window.getConfigurationValue<number>(
+    TerminalSettings.SectionName + '.' + TerminalSettings.LineHeight,
+  );
+
+  attachContainerTerminal = new Terminal({
+    fontSize,
+    lineHeight,
+    screenReaderMode,
+    theme: {
+      background: getPanelDetailColor(),
+    },
+  });
+
+  const fitAddon = new FitAddon();
+  attachContainerTerminal.loadAddon(fitAddon);
+
+  attachContainerTerminal.open(terminalXtermDiv);
+
+  // call fit addon each time we resize the window
+  window.addEventListener('resize', () => {
+    if (currentRouterPath === `/containers/${container.id}/tty-terminal`) {
+      fitAddon.fit();
+    }
+  });
+  fitAddon.fit();
+}
+onMount(async () => {
+  await refreshTerminal();
+  await attachToContainer();
+});
+
+onDestroy(() => {});
+</script>
+
+<div class="h-full" bind:this="{terminalXtermDiv}" class:hidden="{container.state !== 'RUNNING'}"></div>
+
+<EmptyScreen
+  hidden="{!closed && !(container.state === 'RUNNING')}"
+  icon="{NoLogIcon}"
+  title="No TTY"
+  message="Tty has stopped" />
+
+<EmptyScreen
+  hidden="{container.state === 'RUNNING'}"
+  icon="{NoLogIcon}"
+  title="No TTY"
+  message="Container is not running" />

--- a/tests/src/model/pages/run-image-page.ts
+++ b/tests/src/model/pages/run-image-page.ts
@@ -43,13 +43,21 @@ export class RunImagePage extends BasePage {
     await tabactive.click();
   }
 
-  async startContainer(customName = ''): Promise<ContainersPage> {
+  async startContainer(customName = '', interactive?: boolean): Promise<ContainersPage> {
     if (customName !== '') {
       await this.activateTab('Basic');
       // ToDo: improve UI side with aria-labels
       const textbox = this.page.locator(`input[type='text'][name='modalContainerName']`);
       await textbox.fill(customName);
     }
+
+    if (!interactive) {
+      // disable the checkbox in advanced tab
+      await this.activateTab('Advanced');
+      const checkbox = this.page.getByRole('checkbox', { name: 'Attach a pseudo terminal' });
+      await checkbox.uncheck();
+    }
+
     await this.startContainerButton.waitFor({ state: 'visible', timeout: 1000 });
     await this.startContainerButton.click();
     // wait for containers page to appear


### PR DESCRIPTION
### What does this PR do?

- [x]  depends on https://github.com/containers/podman-desktop/pull/3871

Allow to use the interactive terminal of a container (and not a new bash terminal)

note: if you start with interactive mode, if you start a container,
you are redirected to the tty tab of the container

if you click on the details of a container, you're redirected
to the tty tab if the container has been launched using tty/interactive
else you see the logs

In the details of a container, tty tab is only available if
container is started with tty/interactive mode else it's hidden.

### Screenshot/screencast of this PR



### What issues does this PR fix or reference?

Fixes #970 

### How to test this PR?

pull an image like `fedora` then run a new container from this image (in image list, click on the ▶️ icon)
then you should have a terminal

try also with `node` image. Here you've the interactive nodejs prompt while if you use the terminal tab you have sh/bash prompt.


unit tests added


