### PR TITLE
fix: added Podman Desktop to the **Development** menu in the Flatpak package

### DIFF
--- a/.electron-builder.config.cjs
+++ b/.electron-builder.config.cjs
@@ -132,6 +132,7 @@ const config = {
     ],
   },
   linux: {
+    category: 'Development',
     icon: './buildResources/icon-512x512.png',
     target: ['flatpak', 'tar.gz'],
   },

--- a/.electron-builder.config.cjs
+++ b/.electron-builder.config.cjs
@@ -132,7 +132,7 @@ const config = {
     ],
   },
   linux: {
-    category: ['Development', 'Utility'],
+    category: 'Development',
     icon: './buildResources/icon-512x512.png',
     target: ['flatpak', 'tar.gz'],
   },

--- a/.electron-builder.config.cjs
+++ b/.electron-builder.config.cjs
@@ -132,7 +132,7 @@ const config = {
     ],
   },
   linux: {
-    category: 'Development',
+    category: ['Development', 'Utility'],
     icon: './buildResources/icon-512x512.png',
     target: ['flatpak', 'tar.gz'],
   },

--- a/.flatpak.desktop
+++ b/.flatpak.desktop
@@ -5,5 +5,5 @@ Terminal=false
 Type=Application
 Icon=io.podman_desktop.PodmanDesktop
 StartupWMClass=Podman Desktop
-Categories=Utility;Development;
+Categories=Development
 X-Flatpak=io.podman_desktop.PodmanDesktop


### PR DESCRIPTION
In the Flatpak package, added Podman Desktop to the **Development** category menu, rather then the default **Utilities** category.

fixes #3880 -

Fixes build error:

```
  • application Linux category is set to default "Utility"  reason=linux.category is not set and cannot map from macOS docs=https://www.electron.build/configuration/linux
```

To test (on Linux):

1. Build the flatpak

   ```
   $ MODE=production npm run build && ./node_modules/.bin/electron-builder build --config .electron-builder.config.cjs --linux flatpak
   ```

2. Install the flatpak

   ```
   $ flatpak install -u dist/podman-desktop-1.4.0-next.flatpak
   ```

4. Open the development menu:
 
   ![Screenshot_Plasma_20230915_071258](https://github.com/containers/podman-desktop/assets/243761/a71255e7-f248-4bc8-b625-7ec8fe20142a)
