### PR TITLE
chore: declare missing commands

### DIFF
--- a/extensions/kind/package.json
+++ b/extensions/kind/package.json
@@ -81,7 +81,17 @@
           "icon": "${kind-icon}"
         }
       ]
-    }
+    },
+    "commands": [
+      {
+        "command": "kind.install",
+        "title": "Kind: Install..."
+      },
+      {
+        "command": "kind.image.move",
+        "title": "Kind: Move image to cluster..."
+      }
+    ]
   },
   "scripts": {
     "install:contour": "npx ts-node ./scripts/download.ts",


### PR DESCRIPTION
### What does this PR do?
some commands are registered but not declared

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast 
explaining what is doing this PR -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop 
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to reproduce -->

Signed-off-by: Florent Benoit <fbenoit@redhat.com>
