### PR TITLE
chore: refactor deactivation: use disposable approach for unregister

### DIFF
--- a/packages/main/src/plugin/configuration-registry.ts
+++ b/packages/main/src/plugin/configuration-registry.ts
@@ -24,6 +24,7 @@ import type { Event } from './events/emitter.js';
 import { Emitter } from './events/emitter.js';
 import { CONFIGURATION_DEFAULT_SCOPE } from './configuration-registry-constants.js';
 import type { Directories } from './directories.js';
+import { Disposable } from './types/disposable.js';
 
 export type IConfigurationPropertySchemaType =
   | 'markdown'
@@ -140,8 +141,11 @@ export class ConfigurationRegistry implements IConfigurationRegistry {
     this.configurationValues.set(CONFIGURATION_DEFAULT_SCOPE, JSON.parse(settingsRawContent));
   }
 
-  public registerConfigurations(configurations: IConfigurationNode[]): void {
+  public registerConfigurations(configurations: IConfigurationNode[]): Disposable {
     this.doRegisterConfigurations(configurations, true);
+    return Disposable.create(() => {
+      this.deregisterConfigurations(configurations);
+    });
   }
 
   doRegisterConfigurations(configurations: IConfigurationNode[], notify?: boolean): string[] {

--- a/packages/main/src/plugin/extension-loader.spec.ts
+++ b/packages/main/src/plugin/extension-loader.spec.ts
@@ -22,7 +22,7 @@ import { beforeAll, beforeEach, test, expect, vi, describe } from 'vitest';
 import type { CommandRegistry } from './command-registry.js';
 import type { ConfigurationRegistry } from './configuration-registry.js';
 import type { ContainerProviderRegistry } from './container-registry.js';
-import type { AnalyzedExtension } from './extension-loader.js';
+import type { ActivatedExtension, AnalyzedExtension } from './extension-loader.js';
 import { ExtensionLoader } from './extension-loader.js';
 import type { FilesystemMonitoring } from './filesystem-monitoring.js';
 import type { ImageRegistry } from './image-registry.js';
@@ -73,6 +73,14 @@ class TestExtensionLoader extends ExtensionLoader {
 
   doRequire(module: string): NodeRequire {
     return super.doRequire(module);
+  }
+
+  setActivatedExtension(extensionId: string, activatedExtension: ActivatedExtension): void {
+    this.activatedExtensions.set(extensionId, activatedExtension);
+  }
+
+  setAnalyzedExtension(extensionId: string, analyzedExtension: AnalyzedExtension): void {
+    this.analyzedExtensions.set(extensionId, analyzedExtension);
   }
 }
 
@@ -293,6 +301,8 @@ test('Verify extension error leads to failed state', async () => {
       mainPath: '',
       removable: false,
       manifest: {},
+      subscriptions: [],
+      dispose: vi.fn(),
     },
     {
       activate: () => {
@@ -322,6 +332,8 @@ test('Verify extension activate with a long timeout is flagged as error', async 
       mainPath: '',
       removable: false,
       manifest: {},
+      subscriptions: [],
+      dispose: vi.fn(),
     },
     {
       activate: () => {
@@ -726,4 +738,25 @@ describe('Removing extension by user', async () => {
     expect(extensionLoader.removeExtension).toBeCalledWith(ExtID);
     expect(telemetry.track).toBeCalledWith('removeExtension', { extensionId: ExtID, error: RemoveError });
   });
+});
+
+test('check dispose when deactivating', async () => {
+  vi.mock('node:fs');
+
+  const extensionId = 'fooPublisher.fooName';
+  extensionLoader.setActivatedExtension(extensionId, {
+    id: extensionId,
+  } as ActivatedExtension);
+
+  const analyzedExtension: AnalyzedExtension = {
+    id: extensionId,
+    dispose: vi.fn(),
+  } as unknown as AnalyzedExtension;
+  extensionLoader.setAnalyzedExtension(extensionId, analyzedExtension);
+
+  // should have call the dispose method
+  await extensionLoader.deactivateExtension(extensionId);
+  expect(analyzedExtension.dispose).toBeCalled();
+
+  expect(telemetry.track).toBeCalledWith('deactivateExtension', { extensionId });
 });

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -90,6 +90,10 @@ export interface AnalyzedExtension {
 
   missingDependencies?: string[];
   circularDependencies?: string[];
+
+  readonly subscriptions: { dispose(): unknown }[];
+
+  dispose(): void;
 }
 
 export interface ActivatedExtension {
@@ -106,8 +110,8 @@ export class ExtensionLoader {
 
   private moduleLoader: ModuleLoader;
 
-  private activatedExtensions = new Map<string, ActivatedExtension>();
-  private analyzedExtensions = new Map<string, AnalyzedExtension>();
+  protected activatedExtensions = new Map<string, ActivatedExtension>();
+  protected analyzedExtensions = new Map<string, AnalyzedExtension>();
   private watcherExtensions = new Map<string, containerDesktopAPI.FileSystemWatcher>();
   private reloadInProgressExtensions = new Map<string, boolean>();
   protected extensionState = new Map<string, string>();
@@ -324,6 +328,7 @@ export class ExtensionLoader {
     // create api object
     const api = this.createApi(extensionPath, manifest);
 
+    const disposables: Disposable[] = [];
     const analyzedExtension: AnalyzedExtension = {
       id: `${manifest.publisher}.${manifest.name}`,
       name: manifest.name,
@@ -332,6 +337,10 @@ export class ExtensionLoader {
       mainPath: manifest.main ? path.resolve(extensionPath, manifest.main) : undefined,
       api,
       removable,
+      subscriptions: disposables,
+      dispose(): void {
+        disposables.forEach(disposable => disposable.dispose());
+      },
     };
 
     return analyzedExtension;
@@ -524,12 +533,12 @@ export class ExtensionLoader {
       extensionConfiguration.title = `Extension: ${extensionConfiguration.title}`;
       extensionConfiguration.id = 'preferences.' + extension.id;
 
-      this.configurationRegistry.registerConfigurations([extensionConfiguration]);
+      extension.subscriptions.push(this.configurationRegistry.registerConfigurations([extensionConfiguration]));
     }
 
     const menus = extension.manifest?.contributes?.menus;
     if (menus) {
-      this.menuRegistry.registerMenus(menus);
+      extension.subscriptions.push(this.menuRegistry.registerMenus(menus));
     }
 
     const icons = extension.manifest?.contributes?.icons;
@@ -539,12 +548,12 @@ export class ExtensionLoader {
 
     const views = extension.manifest?.contributes?.views;
     if (views) {
-      this.viewRegistry.registerViews(extension.id, views);
+      extension.subscriptions.push(this.viewRegistry.registerViews(extension.id, views));
     }
 
     const onboarding = extension.manifest?.contributes?.onboarding;
     if (onboarding) {
-      this.onboardingRegistry.registerOnboarding(extension, onboarding);
+      extension.subscriptions.push(this.onboardingRegistry.registerOnboarding(extension, onboarding));
     }
 
     this.analyzedExtensions.set(extension.id, extension);
@@ -1040,7 +1049,7 @@ export class ExtensionLoader {
     this.extensionStateErrors.delete(extension.id);
     this.apiSender.send('extension-starting', {});
 
-    const subscriptions: containerDesktopAPI.Disposable[] = [];
+    const subscriptions: containerDesktopAPI.Disposable[] = extension.subscriptions;
 
     const storagePath = path.resolve(this.extensionsStorageDirectory, extension.id);
     const oldStoragePath = path.resolve(this.extensionsStorageDirectory, extension.name);
@@ -1136,31 +1145,9 @@ export class ExtensionLoader {
     const watcher = this.watcherExtensions.get(extensionId);
     watcher?.dispose();
 
-    // dispose subscriptions
-    for (const subscription of extension.extensionContext.subscriptions) {
-      await subscription.dispose();
-    }
-
     const analyzedExtension = this.analyzedExtensions.get(extensionId);
-    if (analyzedExtension) {
-      const extensionConfiguration = analyzedExtension.manifest?.contributes?.configuration;
-      if (extensionConfiguration) {
-        this.configurationRegistry.deregisterConfigurations([extensionConfiguration]);
-      }
-      const menus = analyzedExtension.manifest?.contributes?.menus;
-      if (menus) {
-        this.menuRegistry.unregisterMenus(menus);
-      }
-      const views = analyzedExtension.manifest?.contributes?.views;
-      if (views) {
-        this.viewRegistry.unregisterViews(extensionId);
-      }
-
-      const onboarding = analyzedExtension.manifest?.contributes?.onboarding;
-      if (onboarding) {
-        this.onboardingRegistry.unregisterOnboarding(extensionId);
-      }
-    }
+    // dispose subscriptions if any
+    analyzedExtension?.dispose();
     this.activatedExtensions.delete(extensionId);
     this.extensionState.set(extension.id, 'stopped');
     this.apiSender.send('extension-stopped');

--- a/packages/main/src/plugin/menu-registry.spec.ts
+++ b/packages/main/src/plugin/menu-registry.spec.ts
@@ -16,16 +16,19 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { beforeAll, beforeEach, expect, expectTypeOf, test, vi } from 'vitest';
+import { beforeEach, expect, expectTypeOf, test, vi } from 'vitest';
 import { MenuRegistry } from './menu-registry.js';
 import { CommandRegistry } from './command-registry.js';
 import type { Telemetry } from '/@/plugin/telemetry/telemetry.js';
+import type { Disposable } from './types/disposable.js';
 
 let menuRegistry: MenuRegistry;
 let commandRegistry;
 
+let registerMenuDisposable: Disposable;
+
 /* eslint-disable @typescript-eslint/no-empty-function */
-beforeAll(() => {
+beforeEach(() => {
   commandRegistry = new CommandRegistry({} as Telemetry);
   menuRegistry = new MenuRegistry(commandRegistry);
   const manifest = {
@@ -56,7 +59,7 @@ beforeAll(() => {
       },
     },
   };
-  menuRegistry.registerMenus(manifest.contributes.menus);
+  registerMenuDisposable = menuRegistry.registerMenus(manifest.contributes.menus);
   commandRegistry.registerCommand('image.command1', () => {});
   commandRegistry.registerCommand('container.command1', () => {});
   commandRegistry.registerCommand('container.command2', () => {});
@@ -98,4 +101,10 @@ test('Menus with unregistered commands should not be returned', async () => {
   expect(menus).toBeDefined();
   expectTypeOf(menus).toBeArray();
   expect(menus.length).toBe(0);
+});
+
+test('Should not find menus after dispose', async () => {
+  registerMenuDisposable.dispose();
+  const menus = menuRegistry.getContributedMenus('dashboard/image');
+  expect(menus).toStrictEqual([]);
 });

--- a/packages/main/src/plugin/menu-registry.ts
+++ b/packages/main/src/plugin/menu-registry.ts
@@ -16,6 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 import type { CommandRegistry } from './command-registry.js';
+import { Disposable } from './types/disposable.js';
 
 export interface Menu {
   command: string;
@@ -31,11 +32,15 @@ export class MenuRegistry {
 
   constructor(private commandRegisty: CommandRegistry) {}
 
-  registerMenus(menus: { [key: string]: Menu[] }): void {
+  registerMenus(menus: { [key: string]: Menu[] }): Disposable {
     for (const name in menus) {
       const contextMenus = menus[name];
       contextMenus.forEach(menu => this.registerMenu(name, menu));
     }
+
+    return Disposable.create(() => {
+      this.unregisterMenus(menus);
+    });
   }
 
   unregisterMenus(menus: { [key: string]: Menu[] }): void {

--- a/packages/main/src/plugin/onboarding-registry.ts
+++ b/packages/main/src/plugin/onboarding-registry.ts
@@ -23,6 +23,7 @@ import type { AnalyzedExtension } from './extension-loader.js';
 import type { ConfigurationRegistry } from './configuration-registry.js';
 import { getBase64Image } from '../util.js';
 import type { Context } from './context/context.js';
+import { Disposable } from './types/disposable.js';
 
 export class OnboardingRegistry {
   private onboardingInfos: Map<string, OnboardingInfo> = new Map<string, OnboardingInfo>();
@@ -32,9 +33,13 @@ export class OnboardingRegistry {
     private context: Context,
   ) {}
 
-  registerOnboarding(extension: AnalyzedExtension, onboarding: Onboarding): void {
+  registerOnboarding(extension: AnalyzedExtension, onboarding: Onboarding): Disposable {
     const onInfo = this.createOnboardingInfo(extension, onboarding);
     this.onboardingInfos.set(extension.id, onInfo);
+
+    return Disposable.create(() => {
+      this.unregisterOnboarding(extension.id);
+    });
   }
 
   unregisterOnboarding(extension: string): void {

--- a/packages/main/src/plugin/view-registry.spec.ts
+++ b/packages/main/src/plugin/view-registry.spec.ts
@@ -16,13 +16,16 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { beforeAll, beforeEach, expect, expectTypeOf, test, vi } from 'vitest';
+import { beforeEach, expect, expectTypeOf, test, vi } from 'vitest';
 import { ViewRegistry } from './view-registry.js';
+import type { Disposable } from './types/disposable.js';
 
 let viewRegistry: ViewRegistry;
 
+let registerViewsDisposable: Disposable;
+
 /* eslint-disable @typescript-eslint/no-empty-function */
-beforeAll(() => {
+beforeEach(() => {
   viewRegistry = new ViewRegistry();
   const manifest = {
     contributes: {
@@ -36,7 +39,7 @@ beforeAll(() => {
       },
     },
   };
-  viewRegistry.registerViews('extension', manifest.contributes.views);
+  registerViewsDisposable = viewRegistry.registerViews('extension', manifest.contributes.views);
 });
 
 beforeEach(() => {
@@ -57,4 +60,10 @@ test('View context should have a single entry', async () => {
   expect(views.length).toBe(1);
   expect(views[0].when).toBe('io.x-k8s.kind.cluster in containerLabelKeys');
   expect(views[0].icon).toBe('${kind-icon}');
+});
+
+test('Should not find menus after dispose', async () => {
+  registerViewsDisposable.dispose();
+  const views = viewRegistry.fetchViewsContributions('extension');
+  expect(views).toStrictEqual([]);
 });

--- a/packages/main/src/plugin/view-registry.ts
+++ b/packages/main/src/plugin/view-registry.ts
@@ -16,6 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 import type { ViewContribution, ViewInfoUI } from './api/view-info.js';
+import { Disposable } from './types/disposable.js';
 
 export class ViewRegistry {
   private extViewContribution: Map<string, Map<string, ViewContribution[]>>;
@@ -32,7 +33,7 @@ export class ViewRegistry {
     this.extViewContribution.set(extensionId, view);
   }
 
-  registerViews(extensionId: string, views: { [key: string]: ViewContribution[] }): void {
+  registerViews(extensionId: string, views: { [key: string]: ViewContribution[] }): Disposable {
     // register each view contribution
     Object.entries(views).forEach(([viewId, viewContributions]) => {
       viewContributions.forEach(viewContribution => {
@@ -42,6 +43,10 @@ export class ViewRegistry {
         }
         this.registerView(extensionId, viewId, viewContribution);
       });
+    });
+
+    return Disposable.create(() => {
+      this.unregisterViews(extensionId);
     });
   }
 


### PR DESCRIPTION
### What does this PR do?
we were doing a lot of if in deactivate method but it's already done on the activation part. So only move to disposable pattern where all resources created during the register are cleaned up during deactivation

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

N/A

### How to test this PR?

unit tests added