### PR TITLE
fix: update isLinux clause on podman onboarding (#3835)

### DIFF
--- a/extensions/podman/package.json
+++ b/extensions/podman/package.json
@@ -190,12 +190,12 @@
         {
           "id": "preCreatePodmanMachine",
           "title": "We could not find any Podman machine. Let's create one!",
-          "when": "onboardingContext:podmanMachineExists == false && onboardingContext:isLinux == false"
+          "when": "onboardingContext:podmanMachineExists == false && isLinux == false"
         },
         {
           "id": "createPodmanMachine",
           "title": "Create a Podman machine",
-          "when": "onboardingContext:podmanMachineExists == false && onboardingContext:isLinux == false",
+          "when": "onboardingContext:podmanMachineExists == false && isLinux == false",
           "completionEvents": [
             "onboardingContext:podmanMachineExists == true"
           ],


### PR DESCRIPTION
### What does this PR do?

It updates the isLinux clause used in Podman onboarding. IsLinux (as isWIndows and isMac) is a global context constant which do not belong to the specific onboardingContext, so they do not require any prefix. 

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

it fixes #3835 

### How to test this PR?

on linux there should no be any "create new machine" step
