### PR TITLE
fix: use ui terminal cols/rows to set container exec instance size

### DIFF
--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -1341,8 +1341,13 @@ export class ContainerProviderRegistry {
           execStream.write(param);
         },
         resize: (w: number, h: number) => {
-          exec.resize({ w, h }).catch(() => {
-            return; /*ignore error*/
+          exec.resize({ w, h }).catch((err: unknown) => {
+            // resize sets the size correctly and returns status code 201, but dockerode
+            // interprets it as an error
+            if (err.statusCode !== 201) {
+              // ignore status code 201
+              throw err;
+            }
           });
         },
       };

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -1344,7 +1344,7 @@ export class ContainerProviderRegistry {
           exec.resize({ w, h }).catch((err: unknown) => {
             // the resize call sets the size correctly and returns status code 201, but dockerode
             // interprets it as an error
-            if (err.statusCode !== 201) {
+            if ((err as { statusCode: number }).statusCode !== 201) {
               // ignore status code 201
               throw err;
             }

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -1307,7 +1307,7 @@ export class ContainerProviderRegistry {
     onData: (data: Buffer) => void,
     onError: (error: string) => void,
     onEnd: () => void,
-  ): Promise<(param: string) => void> {
+  ): Promise<{ write: (param: string) => void; resize: (w: number, h: number) => void }> {
     let telemetryOptions = {};
     try {
       const exec = await this.getMatchingContainer(engineId, id).exec({
@@ -1336,8 +1336,15 @@ export class ContainerProviderRegistry {
         onEnd();
       });
 
-      return (param: string) => {
-        execStream.write(param);
+      return {
+        write: (param: string) => {
+          execStream.write(param);
+        },
+        resize: (w: number, h: number) => {
+          exec.resize({ w, h }).catch(() => {
+            return; /*ignore error*/
+          });
+        },
       };
     } catch (error) {
       telemetryOptions = { error: error };

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -1342,7 +1342,7 @@ export class ContainerProviderRegistry {
         },
         resize: (w: number, h: number) => {
           exec.resize({ w, h }).catch((err: unknown) => {
-            // resize sets the size correctly and returns status code 201, but dockerode
+            // the resize call sets the size correctly and returns status code 201, but dockerode
             // interprets it as an error
             if (err.statusCode !== 201) {
               // ignore status code 201

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1008,7 +1008,10 @@ export class PluginSystem {
       },
     );
 
-    const containerProviderRegistryShellInContainerSendCallback = new Map<number, (param: string) => void>();
+    const containerProviderRegistryShellInContainerSendCallback = new Map<
+      number,
+      { write: (param: string) => void; resize: (w: number, h: number) => void }
+    >();
     this.ipcHandle(
       'container-provider-registry:shellInContainer',
       async (_listener, engine: string, containerId: string, onDataId: number): Promise<number> => {
@@ -1039,7 +1042,17 @@ export class PluginSystem {
       async (_listener, onDataId: number, content: string): Promise<void> => {
         const callback = containerProviderRegistryShellInContainerSendCallback.get(onDataId);
         if (callback) {
-          callback(content);
+          callback.write(content);
+        }
+      },
+    );
+
+    this.ipcHandle(
+      'container-provider-registry:shellInContainerResize',
+      async (_listener, onDataId: number, width: number, height: number): Promise<void> => {
+        const callback = containerProviderRegistryShellInContainerSendCallback.get(onDataId);
+        if (callback) {
+          callback.resize(width, height);
         }
       },
     );

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -450,6 +450,10 @@ function initExposure(): void {
     return ipcInvoke('container-provider-registry:shellInContainerSend', dataId, content);
   });
 
+  contextBridge.exposeInMainWorld('shellInContainerResize', async (dataId: number, width: number, height: number) => {
+    return ipcInvoke('container-provider-registry:shellInContainerResize', dataId, width, height);
+  });
+
   ipcRenderer.on(
     'container-provider-registry:shellInContainer-onData',
     (_, onDataCallbacksShellInContainerId: number, data: Buffer) => {

--- a/packages/renderer/src/lib/container/ContainerDetailsTerminal.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerDetailsTerminal.spec.ts
@@ -26,10 +26,12 @@ import { containerTerminals } from '/@/stores/container-terminal-store';
 
 const getConfigurationValueMock = vi.fn();
 const shellInContainerMock = vi.fn();
+const shellInContainerResizeMock = vi.fn();
 
 beforeAll(() => {
   (window as any).getConfigurationValue = getConfigurationValueMock;
   (window as any).shellInContainer = shellInContainerMock;
+  (window as any).shellInContainerResize = shellInContainerResizeMock;
 
   (window as any).matchMedia = vi.fn().mockReturnValue({
     addListener: vi.fn(),

--- a/packages/renderer/src/lib/container/ContainerDetailsTerminal.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetailsTerminal.svelte
@@ -56,6 +56,7 @@ async function executeShellIntoContainer() {
       () => {},
       receiveEndCallback,
     );
+    await window.shellInContainerResize(callbackId, shellTerminal.cols, shellTerminal.rows);
     // pass data from xterm to container
     shellTerminal?.onData(data => {
       window.shellInContainerSend(callbackId, data);
@@ -107,6 +108,9 @@ async function refreshTerminal() {
   window.addEventListener('resize', () => {
     if (currentRouterPath === `/containers/${container.id}/terminal`) {
       fitAddon.fit();
+      if (sendCallbackId) {
+        window.shellInContainerResize(sendCallbackId, shellTerminal.cols, shellTerminal.rows);
+      }
     }
   });
   fitAddon.fit();


### PR DESCRIPTION
### What does this PR do?

Pass terminal size in UI to container exec instance to ensure correct terminal behavior with long lines

### Screenshot/screencast of this PR

https://github.com/containers/podman-desktop/assets/620330/c12be4ec-bc83-41e6-bed7-8658b32e5348

### What issues does this PR fix or reference?

Fix #3767.

### How to test this PR?

see #3767