### PR TITLE
fix: ContainerList propagating containers in ComposeActions and PodActions

### DIFF
--- a/packages/renderer/src/lib/ContainerList.svelte
+++ b/packages/renderer/src/lib/ContainerList.svelte
@@ -540,7 +540,7 @@ function errorCallback(container: ContainerInfoUI, errorMessage: string): void {
                       name: containerGroup.name,
                       engineId: containerGroup.engineId,
                       engineType: containerGroup.engineType,
-                      containers: [],
+                      containers: containerGroup.containers,
                     }}"
                     dropdownMenu="{true}"
                     inProgressCallback="{(containers, flag, state) =>

--- a/packages/renderer/src/lib/ContainerList.svelte
+++ b/packages/renderer/src/lib/ContainerList.svelte
@@ -527,7 +527,11 @@ function errorCallback(container: ContainerInfoUI, errorMessage: string): void {
                       age: containerGroup.humanCreationDate,
                       created: containerGroup.created,
                       selected: false,
-                      containers: [],
+                      containers: containerGroup.containers.map(container => ({
+                        Id: container.id,
+                        Names: container.name,
+                        Status: container.state,
+                      })),
                       kind: 'podman',
                     }}"
                     dropdownMenu="{true}"


### PR DESCRIPTION
### What does this PR do?

As discussed in https://github.com/containers/podman-desktop/pull/3947 the ContainerList now support Contribution Menu (menus from extensions).

This PR is a small fix, on the current implementations, the ComposeList svelte component does not propagate the containers in ComposeActions.

Since an extension can add a command, it may be useful to give them the full context, with the contains associate with the compose group.

> This is also valid for PodActions