### PR TITLE
fix(tests): add check for undefined window in TelemetryService

### DIFF
--- a/packages/renderer/src/lib/image/PullImage.spec.ts
+++ b/packages/renderer/src/lib/image/PullImage.spec.ts
@@ -37,8 +37,8 @@ beforeAll(() => {
       func();
     },
   };
-  (window as any).telemetryPage = vi.fn();
-  (window as any).getConfigurationValue = vi.fn();
+  (window as any).telemetryPage = vi.fn().mockResolvedValue(undefined);
+  (window as any).getConfigurationValue = vi.fn().mockResolvedValue(undefined);
   (window as any).matchMedia = vi.fn().mockReturnValue({
     addListener: vi.fn(),
   });

--- a/packages/renderer/src/lib/kube/KubePlayYAML.spec.ts
+++ b/packages/renderer/src/lib/kube/KubePlayYAML.spec.ts
@@ -73,15 +73,15 @@ beforeAll(() => {
       func();
     },
   };
-  (window as any).getConfigurationValue = vi.fn();
+  (window as any).getConfigurationValue = vi.fn().mockResolvedValue(undefined);
   (window as any).matchMedia = vi.fn().mockReturnValue({
     addListener: vi.fn(),
   });
   (window as any).openFileDialog = vi.fn().mockResolvedValue({ canceled: false, filePaths: ['Containerfile'] });
-  (window as any).telemetryPage = vi.fn();
-  (window as any).kubernetesGetCurrentContextName = vi.fn();
-  (window as any).kubernetesGetCurrentNamespace = vi.fn();
-  (window as any).kubernetesListNamespaces = vi.fn();
+  (window as any).telemetryPage = vi.fn().mockResolvedValue(undefined);
+  (window as any).kubernetesGetCurrentContextName = vi.fn().mockResolvedValue(undefined);
+  (window as any).kubernetesGetCurrentNamespace = vi.fn().mockResolvedValue(undefined);
+  (window as any).kubernetesListNamespaces = vi.fn().mockResolvedValue(undefined);
 });
 
 function setup() {

--- a/packages/renderer/src/lib/preferences/PreferencesRegistriesEditing.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesRegistriesEditing.spec.ts
@@ -28,8 +28,8 @@ import { registriesInfos } from '../../stores/registries';
 import type { Registry } from '@podman-desktop/api';
 
 beforeAll(() => {
-  (window as any).window.ddExtensionInstall = vi.fn();
-  (window as any).window.getImageRegistryProviderNames = vi.fn();
+  (window as any).window.ddExtensionInstall = vi.fn().mockResolvedValue(undefined);
+  (window as any).window.getImageRegistryProviderNames = vi.fn().mockResolvedValue(undefined);
 });
 
 describe('PreferencesRegistriesEditing', () => {

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.spec.ts
@@ -28,7 +28,7 @@ import PreferencesRenderingItemFormat from './PreferencesRenderingItemFormat.sve
 import userEvent from '@testing-library/user-event';
 
 beforeAll(() => {
-  (window as any).getConfigurationValue = vi.fn();
+  (window as any).getConfigurationValue = vi.fn().mockResolvedValue(undefined);
 });
 
 test('Expect to see checkbox enabled', async () => {

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.spec.ts
@@ -73,7 +73,7 @@ beforeEach(() => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     receive: vi.fn(),
   };
-  (window as any).telemetryTrack = vi.fn();
+  (window as any).telemetryTrack = vi.fn().mockResolvedValue(undefined);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (window as any).telemetryPage = vi.fn().mockResolvedValue(undefined);
 });


### PR DESCRIPTION
### What does this PR do?
Add check for window object in telemetry service which is occasionally undefined when there is a timeout in renderer unit tests.
### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast 
explaining what is doing this PR -->

### What issues does this PR fix or reference?
#3567 
<!-- Include any related issues from Podman Desktop 
repository (or from another issue tracker). -->

### How to test this PR?
`yarn test:renderer`
<!-- Please explain steps to reproduce -->
