### PR TITLE
feat: extension can register custom kube generator

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -1371,7 +1371,7 @@ declare module '@podman-desktop/api' {
   export interface KubernetesGeneratorProvider {
     name: string;
     types: KubernetesGeneratorSelector;
-    generate(kubernetesGeneratorArgument: KubernetesGeneratorArgument): Promise<GenerateKubeResult>;
+    generate(kubernetesGeneratorArguments: KubernetesGeneratorArgument[]): Promise<GenerateKubeResult>;
   }
 
   export interface ContainerInfo {

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -1333,7 +1333,7 @@ declare module '@podman-desktop/api' {
 
     /**
      * Add a KubernetesGenerator to KubernetesGeneratorRegistry
-     * @param KubernetesGeneratorProvider the generator to add
+     * @param provider the custom provider to add
      */
     export function registerKubernetesGeneratorProvider(provider: KubernetesGeneratorProvider): Disposable;
   }
@@ -1343,6 +1343,37 @@ declare module '@podman-desktop/api' {
   export interface KubeconfigUpdateEvent {
     readonly type: 'CREATE' | 'UPDATE' | 'DELETE';
     readonly location: Uri;
+  }
+
+  export enum KubernetesGeneratorType {
+    COMPOSE = 'Compose',
+    POD = 'Pod',
+    Container = 'Container',
+  }
+
+  /**
+   * The result containing a Kubernetes config files
+   */
+  export interface GenerateKubeResult {
+    yaml: string;
+  }
+
+  /**
+   * The KubernetesGeneratorProvider allows an extension to register a custom Kube Generator for a specific
+   * KubernetesGeneratorType.
+   */
+  export interface KubernetesGeneratorProvider {
+    /**
+     * A unique identifier for the provider.
+     */
+    id: string;
+
+    /**
+     * Optional accept function, if undefined we consider it accepts all types.
+     * @param type the type we want to know if the provider accept or not.
+     */
+    accept?(type: KubernetesGeneratorType): boolean;
+    generate(engineId: string, ids: string[]): GenerateKubeResult;
   }
 
   export interface ContainerInfo {

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -506,6 +506,20 @@ declare module '@podman-desktop/api' {
     export const onDidUnregisterRegistry: Event<Registry>;
   }
 
+  export namespace kubernetesGenerator {
+    /**
+     * Add a KubernetesGenerator to KubernetesGeneratorRegistry
+     * @param kubeGenerator the generator to add
+     */
+    export function registerKubernetesGeneratorProvider(kubeGenerator: KubeGenerator): Disposable;
+
+    /**
+     * Remove a provider from the KubernetesGeneratorRegistry
+     * @param kubeGenerator the generator to remove
+     */
+    export function unregisterKubernetesGeneratorProvider(kubeGenerator: KubeGenerator): void;
+  }
+
   export namespace tray {
     /**
      * Creates a menu not related to a Provider

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -1357,6 +1357,12 @@ declare module '@podman-desktop/api' {
     yaml: string;
   }
 
+  type KubernetesGeneratorArgument = {
+    containers?: string[];
+    pods?: string[];
+    compose?: string[];
+  };
+
   /**
    * The KubernetesGeneratorProvider allows an extension to register a custom Kube Generator for a specific
    * KubernetesGeneratorType.
@@ -1368,7 +1374,7 @@ declare module '@podman-desktop/api' {
     id: string;
     name: string;
     types: KubernetesGeneratorSelector;
-    generate(engineId: string, ids: string[]): GenerateKubeResult;
+    generate(kubernetesGeneratorArgument: KubernetesGeneratorArgument): GenerateKubeResult;
   }
 
   export interface ContainerInfo {

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -506,20 +506,6 @@ declare module '@podman-desktop/api' {
     export const onDidUnregisterRegistry: Event<Registry>;
   }
 
-  export namespace kubernetesGenerator {
-    /**
-     * Add a KubernetesGenerator to KubernetesGeneratorRegistry
-     * @param kubeGenerator the generator to add
-     */
-    export function registerKubernetesGeneratorProvider(kubeGenerator: KubeGenerator): Disposable;
-
-    /**
-     * Remove a provider from the KubernetesGeneratorRegistry
-     * @param kubeGenerator the generator to remove
-     */
-    export function unregisterKubernetesGeneratorProvider(kubeGenerator: KubeGenerator): void;
-  }
-
   export namespace tray {
     /**
      * Creates a menu not related to a Provider
@@ -1344,6 +1330,18 @@ declare module '@podman-desktop/api' {
      * @param manifests the manifests to create as JSON objects
      */
     export function createResources(context: string, manifests: unknown[]): Promise<void>;
+
+    /**
+     * Add a KubernetesGenerator to KubernetesGeneratorRegistry
+     * @param kubeGenerator the generator to add
+     */
+    export function registerKubernetesGeneratorProvider(kubeGenerator: KubeGenerator): Disposable;
+
+    /**
+     * Remove a provider from the KubernetesGeneratorRegistry
+     * @param kubeGenerator the generator to remove
+     */
+    export function unregisterKubernetesGeneratorProvider(kubeGenerator: KubeGenerator): void;
   }
   /**
    * An event describing the update in kubeconfig location

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -1333,15 +1333,9 @@ declare module '@podman-desktop/api' {
 
     /**
      * Add a KubernetesGenerator to KubernetesGeneratorRegistry
-     * @param kubeGenerator the generator to add
+     * @param KubernetesGeneratorProvider the generator to add
      */
-    export function registerKubernetesGeneratorProvider(kubeGenerator: KubeGenerator): Disposable;
-
-    /**
-     * Remove a provider from the KubernetesGeneratorRegistry
-     * @param kubeGenerator the generator to remove
-     */
-    export function unregisterKubernetesGeneratorProvider(kubeGenerator: KubeGenerator): void;
+    export function registerKubernetesGeneratorProvider(provider: KubernetesGeneratorProvider): Disposable;
   }
   /**
    * An event describing the update in kubeconfig location

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -1358,6 +1358,7 @@ declare module '@podman-desktop/api' {
   }
 
   type KubernetesGeneratorArgument = {
+    engineId: string;
     containers?: string[];
     pods?: string[];
     compose?: string[];
@@ -1370,7 +1371,7 @@ declare module '@podman-desktop/api' {
   export interface KubernetesGeneratorProvider {
     name: string;
     types: KubernetesGeneratorSelector;
-    generate(kubernetesGeneratorArgument: KubernetesGeneratorArgument): GenerateKubeResult;
+    generate(kubernetesGeneratorArgument: KubernetesGeneratorArgument): Promise<GenerateKubeResult>;
   }
 
   export interface ContainerInfo {

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -1336,10 +1336,7 @@ declare module '@podman-desktop/api' {
      * @param selector
      * @param provider the custom provider to add
      */
-    export function registerKubernetesGenerator(
-      selector: KubernetesGeneratorSelector,
-      provider: KubernetesGeneratorProvider,
-    ): Disposable;
+    export function registerKubernetesGenerator(provider: KubernetesGeneratorProvider): Disposable;
   }
   /**
    * An event describing the update in kubeconfig location
@@ -1349,7 +1346,7 @@ declare module '@podman-desktop/api' {
     readonly location: Uri;
   }
 
-  export type KubernetesGeneratorSelector = KubernetesGeneratorType | ReadonlyArray<KubernetesGeneratorType[]>;
+  export type KubernetesGeneratorSelector = KubernetesGeneratorType | ReadonlyArray<KubernetesGeneratorType>;
 
   export type KubernetesGeneratorType = 'Compose' | 'Pod' | 'Container';
 
@@ -1369,6 +1366,8 @@ declare module '@podman-desktop/api' {
      * A unique identifier for the provider.
      */
     id: string;
+    name: string;
+    types: KubernetesGeneratorSelector;
     generate(engineId: string, ids: string[]): GenerateKubeResult;
   }
 

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -1368,10 +1368,6 @@ declare module '@podman-desktop/api' {
    * KubernetesGeneratorType.
    */
   export interface KubernetesGeneratorProvider {
-    /**
-     * A unique identifier for the provider.
-     */
-    id: string;
     name: string;
     types: KubernetesGeneratorSelector;
     generate(kubernetesGeneratorArgument: KubernetesGeneratorArgument): GenerateKubeResult;

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -1333,9 +1333,13 @@ declare module '@podman-desktop/api' {
 
     /**
      * Add a KubernetesGenerator to KubernetesGeneratorRegistry
+     * @param selector
      * @param provider the custom provider to add
      */
-    export function registerKubernetesGeneratorProvider(provider: KubernetesGeneratorProvider): Disposable;
+    export function registerKubernetesGenerator(
+      selector: KubernetesGeneratorSelector,
+      provider: KubernetesGeneratorProvider,
+    ): Disposable;
   }
   /**
    * An event describing the update in kubeconfig location
@@ -1345,11 +1349,9 @@ declare module '@podman-desktop/api' {
     readonly location: Uri;
   }
 
-  export enum KubernetesGeneratorType {
-    COMPOSE = 'Compose',
-    POD = 'Pod',
-    Container = 'Container',
-  }
+  export type KubernetesGeneratorSelector = KubernetesGeneratorType | ReadonlyArray<KubernetesGeneratorType[]>;
+
+  export type KubernetesGeneratorType = 'Compose' | 'Pod' | 'Container';
 
   /**
    * The result containing a Kubernetes config files
@@ -1367,12 +1369,6 @@ declare module '@podman-desktop/api' {
      * A unique identifier for the provider.
      */
     id: string;
-
-    /**
-     * Optional accept function, if undefined we consider it accepts all types.
-     * @param type the type we want to know if the provider accept or not.
-     */
-    accept?(type: KubernetesGeneratorType): boolean;
     generate(engineId: string, ids: string[]): GenerateKubeResult;
   }
 

--- a/packages/main/src/plugin/api/KubernetesGeneratorInfo.ts
+++ b/packages/main/src/plugin/api/KubernetesGeneratorInfo.ts
@@ -15,7 +15,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
-import type { KubernetesGeneratorSelector } from '/@/plugin/kube-generator-registry.js';
+import type { KubernetesGeneratorSelector } from '../kube-generator-registry.js';
 
 export interface KubernetesGeneratorInfo {
   id: string;

--- a/packages/main/src/plugin/api/KubernetesGeneratorInfo.ts
+++ b/packages/main/src/plugin/api/KubernetesGeneratorInfo.ts
@@ -21,4 +21,5 @@ export interface KubernetesGeneratorInfo {
   id: string;
   name: string;
   types: KubernetesGeneratorSelector;
+  default: boolean;
 }

--- a/packages/main/src/plugin/api/KubernetesGeneratorInfo.ts
+++ b/packages/main/src/plugin/api/KubernetesGeneratorInfo.ts
@@ -1,0 +1,24 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import type { KubernetesGeneratorSelector } from '/@/plugin/kube-generator-registry.js';
+
+export interface KubernetesGeneratorInfo {
+  id: string;
+  name: string;
+  types: KubernetesGeneratorSelector;
+}

--- a/packages/main/src/plugin/authentication.spec.ts
+++ b/packages/main/src/plugin/authentication.spec.ts
@@ -53,6 +53,7 @@ import type { Context } from './context/context.js';
 import type { OnboardingRegistry } from './onboarding-registry.js';
 import { getBase64Image } from '../util.js';
 import type { Exec } from './util/exec.js';
+import type { KubeGeneratorRegistry } from '/@/plugin/kube-generator-registry.js';
 
 vi.mock('../util.js', async () => {
   return {
@@ -272,6 +273,7 @@ suite('Authentication', () => {
       vi.fn() as unknown as Context,
       directories,
       vi.fn() as unknown as Exec,
+      vi.fn() as unknown as KubeGeneratorRegistry,
     );
     providerMock = {
       onDidChangeSessions: vi.fn(),

--- a/packages/main/src/plugin/extension-loader.spec.ts
+++ b/packages/main/src/plugin/extension-loader.spec.ts
@@ -49,6 +49,7 @@ import type { ViewRegistry } from './view-registry.js';
 import { Context } from './context/context.js';
 import type { OnboardingRegistry } from './onboarding-registry.js';
 import { Exec } from './util/exec.js';
+import type { KubeGeneratorRegistry } from '/@/plugin/kube-generator-registry.js';
 
 class TestExtensionLoader extends ExtensionLoader {
   public async setupScanningDirectory(): Promise<void> {
@@ -89,6 +90,8 @@ let extensionLoader: TestExtensionLoader;
 const commandRegistry: CommandRegistry = {} as unknown as CommandRegistry;
 
 const menuRegistry: MenuRegistry = {} as unknown as MenuRegistry;
+
+const kubernetesGeneratorRegistry: KubeGeneratorRegistry = {} as unknown as KubeGeneratorRegistry;
 
 const providerRegistry: ProviderRegistry = {} as unknown as ProviderRegistry;
 
@@ -172,6 +175,7 @@ beforeAll(() => {
     context,
     directories,
     exec,
+    kubernetesGeneratorRegistry,
   );
 });
 

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -66,7 +66,8 @@ import type { OnboardingRegistry } from './onboarding-registry.js';
 import { createHttpPatchedModules } from './proxy-resolver.js';
 import { ModuleLoader } from './module-loader.js';
 import { ExtensionLoaderSettings } from './extension-loader-settings.js';
-import type { KubernetesGeneratorProvider, KubeGeneratorRegistry } from '/@/plugin/kube-generator-registry.js';
+import type { KubeGeneratorRegistry, KubernetesGeneratorProvider } from '/@/plugin/kube-generator-registry.js';
+import { KubernetesGeneratorType } from '/@/plugin/kube-generator-registry.js';
 
 /**
  * Handle the loading of an extension
@@ -992,6 +993,7 @@ export class ExtensionLoader {
       QuickPickItemKind,
       authentication,
       context: contextAPI,
+      KubernetesGeneratorType,
     };
   }
 

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -66,11 +66,7 @@ import type { OnboardingRegistry } from './onboarding-registry.js';
 import { createHttpPatchedModules } from './proxy-resolver.js';
 import { ModuleLoader } from './module-loader.js';
 import { ExtensionLoaderSettings } from './extension-loader-settings.js';
-import type {
-  KubeGeneratorRegistry,
-  KubernetesGeneratorProvider,
-  KubernetesGeneratorSelector,
-} from '/@/plugin/kube-generator-registry.js';
+import type { KubeGeneratorRegistry, KubernetesGeneratorProvider } from '/@/plugin/kube-generator-registry.js';
 
 /**
  * Handle the loading of an extension
@@ -836,11 +832,8 @@ export class ExtensionLoader {
       async createResources(context, manifests): Promise<void> {
         return kubernetesClient.createResources(context, manifests);
       },
-      registerKubernetesGenerator(
-        selector: KubernetesGeneratorSelector,
-        provider: KubernetesGeneratorProvider,
-      ): containerDesktopAPI.Disposable {
-        return kubernetesGeneratorRegistry.registerKubeGenerator(selector, provider);
+      registerKubernetesGenerator(provider: KubernetesGeneratorProvider): containerDesktopAPI.Disposable {
+        return kubernetesGeneratorRegistry.registerKubeGenerator(provider);
       },
     };
 

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -66,6 +66,7 @@ import type { OnboardingRegistry } from './onboarding-registry.js';
 import { createHttpPatchedModules } from './proxy-resolver.js';
 import { ModuleLoader } from './module-loader.js';
 import { ExtensionLoaderSettings } from './extension-loader-settings.js';
+import type { KubeGeneratorRegistry } from '/@/plugin/kube-generator-registry.js';
 
 /**
  * Handle the loading of an extension
@@ -152,6 +153,7 @@ export class ExtensionLoader {
     private context: Context,
     directories: Directories,
     private exec: Exec,
+    private kubeGeneratorRegistry: KubeGeneratorRegistry,
   ) {
     this.pluginsDirectory = directories.getPluginsDirectory();
     this.pluginsScanDirectory = directories.getPluginsScanDirectory();
@@ -559,6 +561,11 @@ export class ExtensionLoader {
     const onboarding = extension.manifest?.contributes?.onboarding;
     if (onboarding) {
       extension.subscriptions.push(this.onboardingRegistry.registerOnboarding(extension, onboarding));
+    }
+
+    const kubeGenerators = extension.manifest?.contributes?.kubeGenerators;
+    if (kubeGenerators) {
+      extension.subscriptions.push(this.kubeGeneratorRegistry.registerKubeGenerators(kubeGenerators));
     }
 
     this.analyzedExtensions.set(extension.id, extension);

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -66,7 +66,7 @@ import type { OnboardingRegistry } from './onboarding-registry.js';
 import { createHttpPatchedModules } from './proxy-resolver.js';
 import { ModuleLoader } from './module-loader.js';
 import { ExtensionLoaderSettings } from './extension-loader-settings.js';
-import type { Provider, KubeGeneratorRegistry } from '/@/plugin/kube-generator-registry.js';
+import type { KubernetesGeneratorProvider, KubeGeneratorRegistry } from '/@/plugin/kube-generator-registry.js';
 
 /**
  * Handle the loading of an extension
@@ -832,11 +832,8 @@ export class ExtensionLoader {
       async createResources(context, manifests): Promise<void> {
         return kubernetesClient.createResources(context, manifests);
       },
-      registerKubernetesGeneratorProvider(provider: Provider): containerDesktopAPI.Disposable {
+      registerKubernetesGeneratorProvider(provider: KubernetesGeneratorProvider): containerDesktopAPI.Disposable {
         return kubernetesGeneratorRegistry.registerKubeGenerator(provider);
-      },
-      unregisterKubernetesGeneratorProvider(provider: Provider) {
-        kubernetesGeneratorRegistry.unregisterKubeGenerator(provider);
       },
     };
 

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -66,8 +66,11 @@ import type { OnboardingRegistry } from './onboarding-registry.js';
 import { createHttpPatchedModules } from './proxy-resolver.js';
 import { ModuleLoader } from './module-loader.js';
 import { ExtensionLoaderSettings } from './extension-loader-settings.js';
-import type { KubeGeneratorRegistry, KubernetesGeneratorProvider } from '/@/plugin/kube-generator-registry.js';
-import { KubernetesGeneratorType } from '/@/plugin/kube-generator-registry.js';
+import type {
+  KubeGeneratorRegistry,
+  KubernetesGeneratorProvider,
+  KubernetesGeneratorSelector,
+} from '/@/plugin/kube-generator-registry.js';
 
 /**
  * Handle the loading of an extension
@@ -833,8 +836,11 @@ export class ExtensionLoader {
       async createResources(context, manifests): Promise<void> {
         return kubernetesClient.createResources(context, manifests);
       },
-      registerKubernetesGeneratorProvider(provider: KubernetesGeneratorProvider): containerDesktopAPI.Disposable {
-        return kubernetesGeneratorRegistry.registerKubeGenerator(provider);
+      registerKubernetesGenerator(
+        selector: KubernetesGeneratorSelector,
+        provider: KubernetesGeneratorProvider,
+      ): containerDesktopAPI.Disposable {
+        return kubernetesGeneratorRegistry.registerKubeGenerator(selector, provider);
       },
     };
 
@@ -993,7 +999,6 @@ export class ExtensionLoader {
       QuickPickItemKind,
       authentication,
       context: contextAPI,
-      KubernetesGeneratorType,
     };
   }
 

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -66,7 +66,7 @@ import type { OnboardingRegistry } from './onboarding-registry.js';
 import { createHttpPatchedModules } from './proxy-resolver.js';
 import { ModuleLoader } from './module-loader.js';
 import { ExtensionLoaderSettings } from './extension-loader-settings.js';
-import type { KubeGenerator, KubeGeneratorRegistry } from '/@/plugin/kube-generator-registry.js';
+import type { Provider, KubeGeneratorRegistry } from '/@/plugin/kube-generator-registry.js';
 
 /**
  * Handle the loading of an extension
@@ -627,16 +627,6 @@ export class ExtensionLoader {
       },
     };
 
-    const kubernetesGeneratorRegistry = this.kubeGeneratorRegistry;
-    const kubernetesGenerator: typeof containerDesktopAPI.kubernetesGenerator = {
-      registerKubernetesGeneratorProvider(kubeGenerator: KubeGenerator): containerDesktopAPI.Disposable {
-        return kubernetesGeneratorRegistry.registerKubeGenerator(kubeGenerator);
-      },
-      unregisterKubernetesGeneratorProvider(kubeGenerator: KubeGenerator) {
-        kubernetesGeneratorRegistry.unregisterKubeGenerator(kubeGenerator);
-      },
-    };
-
     //export function executeCommand<T = unknown>(command: string, ...rest: any[]): PromiseLike<T>;
 
     const providerRegistry = this.providerRegistry;
@@ -828,6 +818,7 @@ export class ExtensionLoader {
     };
 
     const kubernetesClient = this.kubernetesClient;
+    const kubernetesGeneratorRegistry = this.kubeGeneratorRegistry;
     const kubernetes: typeof containerDesktopAPI.kubernetes = {
       getKubeconfig(): containerDesktopAPI.Uri {
         return kubernetesClient.getKubeconfig();
@@ -840,6 +831,12 @@ export class ExtensionLoader {
       },
       async createResources(context, manifests): Promise<void> {
         return kubernetesClient.createResources(context, manifests);
+      },
+      registerKubernetesGeneratorProvider(provider: Provider): containerDesktopAPI.Disposable {
+        return kubernetesGeneratorRegistry.registerKubeGenerator(provider);
+      },
+      unregisterKubernetesGeneratorProvider(provider: Provider) {
+        kubernetesGeneratorRegistry.unregisterKubeGenerator(provider);
       },
     };
 
@@ -998,7 +995,6 @@ export class ExtensionLoader {
       QuickPickItemKind,
       authentication,
       context: contextAPI,
-      kubernetesGenerator,
     };
   }
 

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -834,7 +834,7 @@ export class PluginSystem {
         _listener,
         engine: string,
         names: string[],
-        kubeGeneratorId: string | undefined = undefined,
+        kubeGeneratorId?: string,
       ): Promise<string> => {
         if (!kubeGeneratorId) return containerProviderRegistry.generatePodmanKube(engine, names);
 

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -122,7 +122,8 @@ import { OnboardingRegistry } from './onboarding-registry.js';
 import type { OnboardingInfo, OnboardingStatus } from './api/onboarding.js';
 import { OnboardingUtils } from './onboarding/onboarding-utils.js';
 import { Exec } from './util/exec.js';
-import { KubeGeneratorRegistry, type KubernetesGeneratorType } from '/@/plugin/kube-generator-registry.js';
+import { KubeGeneratorRegistry } from '/@/plugin/kube-generator-registry.js';
+import type { KubeGeneratorsInfo, KubernetesGeneratorSelector } from '/@/plugin/kube-generator-registry.js';
 import type { CommandInfo } from './api/command-info.js';
 
 type LogType = 'log' | 'warn' | 'trace' | 'debug' | 'error';
@@ -1159,9 +1160,9 @@ export class PluginSystem {
     });
 
     this.ipcHandle(
-      'kube-generator-registry:getKubeGeneratorsIdsByType',
-      async (_, type: KubernetesGeneratorType): Promise<string[]> => {
-        return kubeGeneratorRegistry.getKubeGeneratorsIdsByType(type);
+      'kube-generator-registry:getKubeGeneratorsInfos',
+      async (_, selector: KubernetesGeneratorSelector): Promise<KubeGeneratorsInfo[]> => {
+        return kubeGeneratorRegistry.getKubeGeneratorsInfos(selector);
       },
     );
 

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1161,7 +1161,7 @@ export class PluginSystem {
 
     this.ipcHandle(
       'kube-generator-registry:getKubeGeneratorsInfos',
-      async (_, selector: KubernetesGeneratorSelector | undefined = undefined): Promise<KubeGeneratorsInfo[]> => {
+      async (_, selector?: KubernetesGeneratorSelector): Promise<KubeGeneratorsInfo[]> => {
         return kubeGeneratorRegistry.getKubeGeneratorsInfos(selector);
       },
     );

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1161,7 +1161,7 @@ export class PluginSystem {
 
     this.ipcHandle(
       'kube-generator-registry:getKubeGeneratorsInfos',
-      async (_, selector: KubernetesGeneratorSelector): Promise<KubeGeneratorsInfo[]> => {
+      async (_, selector: KubernetesGeneratorSelector | undefined = undefined): Promise<KubeGeneratorsInfo[]> => {
         return kubeGeneratorRegistry.getKubeGeneratorsInfos(selector);
       },
     );

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -840,7 +840,7 @@ export class PluginSystem {
         const kubeGenerator = kubeGeneratorRegistry.getKubeGenerator(kubeGeneratorId);
         if (!kubeGenerator) throw new Error(`kubeGenerator with id ${kubeGenerator} cannot be found.`);
 
-        return (await commandRegistry.executeCommand(kubeGenerator.command, engine, names)) as string;
+        return kubeGenerator.generate(engine, names).yaml;
       },
     );
 

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -122,7 +122,7 @@ import { OnboardingRegistry } from './onboarding-registry.js';
 import type { OnboardingInfo, OnboardingStatus } from './api/onboarding.js';
 import { OnboardingUtils } from './onboarding/onboarding-utils.js';
 import { Exec } from './util/exec.js';
-import { KubeGeneratorRegistry } from '/@/plugin/kube-generator-registry.js';
+import { KubeGeneratorRegistry, type KubernetesGeneratorType } from '/@/plugin/kube-generator-registry.js';
 import type { CommandInfo } from './api/command-info.js';
 
 type LogType = 'log' | 'warn' | 'trace' | 'debug' | 'error';
@@ -1157,6 +1157,13 @@ export class PluginSystem {
     this.ipcHandle('menu-registry:getContributedMenus', async (_, context: string): Promise<Menu[]> => {
       return menuRegistry.getContributedMenus(context);
     });
+
+    this.ipcHandle(
+      'kube-generator-registry:getKubeGeneratorsIdsByType',
+      async (_, type: KubernetesGeneratorType): Promise<string[]> => {
+        return kubeGeneratorRegistry.getKubeGeneratorsIdsByType(type);
+      },
+    );
 
     this.ipcHandle(
       'command-registry:executeCommand',

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -412,18 +412,21 @@ export class PluginSystem {
     kubeGeneratorRegistry.registerDefaultKubeGenerator({
       name: 'PodmanKube',
       types: ['Compose', 'Container', 'Pod'],
-      generate: async (argument: KubernetesGeneratorArgument) => {
-        let yaml: string;
-        if (argument.containers)
-          yaml = await containerProviderRegistry.generatePodmanKube(argument.engineId, argument.containers);
-        else if (argument.compose)
-          yaml = await containerProviderRegistry.generatePodmanKube(argument.engineId, argument.compose);
-        else if (argument.pods)
-          yaml = await containerProviderRegistry.generatePodmanKube(argument.engineId, argument.pods);
-        else throw new Error('Either containers, compose or pods property must be defined.');
+      generate: async (kubernetesGeneratorArguments: KubernetesGeneratorArgument[]) => {
+        const results: string[] = await Promise.all(
+          kubernetesGeneratorArguments.map(argument => {
+            if (argument.containers)
+              return containerProviderRegistry.generatePodmanKube(argument.engineId, argument.containers);
+            else if (argument.compose)
+              return containerProviderRegistry.generatePodmanKube(argument.engineId, argument.compose);
+            else if (argument.pods)
+              return containerProviderRegistry.generatePodmanKube(argument.engineId, argument.pods);
+            else throw new Error('Either containers, compose or pods property must be defined.');
+          }),
+        );
 
         return {
-          yaml,
+          yaml: results.join('\n---\n'),
         };
       },
     });
@@ -859,10 +862,12 @@ export class PluginSystem {
         if (!kubeGenerator) throw new Error(`Cannot find default KubeGenerator.`);
 
         return (
-          await kubeGenerator.generate({
-            engineId: engine,
-            containers: names,
-          })
+          await kubeGenerator.generate([
+            {
+              engineId: engine,
+              containers: names,
+            },
+          ])
         ).yaml;
       },
     );
@@ -871,13 +876,13 @@ export class PluginSystem {
       'kubernetes-generator-registry:generateKube',
       async (
         _listener,
-        kubernetesGeneratorArgument: KubernetesGeneratorArgument,
+        kubernetesGeneratorArguments: KubernetesGeneratorArgument[],
         kubeGeneratorId?: string,
       ): Promise<GenerateKubeResult> => {
         const kubeGenerator = kubeGeneratorRegistry.getKubeGenerator(kubeGeneratorId);
         if (!kubeGenerator) throw new Error(`kubeGenerator with id ${kubeGeneratorId} cannot be found.`);
 
-        return kubeGenerator.generate(kubernetesGeneratorArgument);
+        return kubeGenerator.generate(kubernetesGeneratorArguments);
       },
     );
 

--- a/packages/main/src/plugin/kube-generator-registry.spec.ts
+++ b/packages/main/src/plugin/kube-generator-registry.spec.ts
@@ -1,0 +1,97 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { expect, test, vi } from 'vitest';
+import type { KubernetesGeneratorSelector } from '/@/plugin/kube-generator-registry.js';
+import { KubeGeneratorRegistry } from '/@/plugin/kube-generator-registry.js';
+
+test('Creating KubeGeneratorRegistry and getting KubeGeneratorsInfos', async () => {
+  const result = new KubeGeneratorRegistry().getKubeGeneratorsInfos();
+  expect(result).lengthOf(0);
+});
+
+test('Registering a provider', async () => {
+  const kubeGeneratorRegistry = new KubeGeneratorRegistry();
+  kubeGeneratorRegistry.registerKubeGenerator({
+    id: 'dummy',
+    name: 'Dummy',
+    types: [],
+    generate: vi.fn(),
+  });
+
+  const kubeGeneratorsInfos = kubeGeneratorRegistry.getKubeGeneratorsInfos();
+  expect(kubeGeneratorsInfos).lengthOf(1);
+  expect(kubeGeneratorsInfos[0]).toStrictEqual({
+    id: 'dummy',
+    name: 'Dummy',
+    types: [],
+  });
+});
+
+test('Registering multiple providers', async () => {
+  const kubeGeneratorRegistry = new KubeGeneratorRegistry();
+
+  Array.from({ length: 5 }, (_, index) => ({
+    id: `${index}`,
+    name: 'dummy',
+    types: [],
+    generate: vi.fn(),
+  })).forEach(provider => {
+    kubeGeneratorRegistry.registerKubeGenerator(provider);
+  });
+
+  const kubeGeneratorsInfos = kubeGeneratorRegistry.getKubeGeneratorsInfos();
+  expect(kubeGeneratorsInfos).lengthOf(5);
+});
+
+test('Dispose multiple providers', async () => {
+  const kubeGeneratorRegistry = new KubeGeneratorRegistry();
+
+  const disposables = Array.from({ length: 5 }, (_, index) => ({
+    id: `${index}`,
+    name: 'dummy',
+    types: [],
+    generate: vi.fn(),
+  })).map(provider => kubeGeneratorRegistry.registerKubeGenerator(provider));
+
+  expect(kubeGeneratorRegistry.getKubeGeneratorsInfos()).lengthOf(5);
+
+  disposables.forEach(disposable => disposable.dispose());
+
+  expect(kubeGeneratorRegistry.getKubeGeneratorsInfos()).lengthOf(0);
+});
+
+test('getKubeGeneratorsInfos by types', async () => {
+  const kubeGeneratorRegistry = new KubeGeneratorRegistry();
+
+  const typesTests: KubernetesGeneratorSelector[] = [['Compose'], ['Compose', 'Pod'], ['Pod', 'Container']];
+
+  typesTests.forEach((typesTest, index) => {
+    kubeGeneratorRegistry.registerKubeGenerator({
+      id: `${index}`,
+      name: 'Dummy',
+      types: typesTest,
+      generate: vi.fn(),
+    });
+  });
+
+  expect(kubeGeneratorRegistry.getKubeGeneratorsInfos('Compose')).lengthOf(2);
+  expect(kubeGeneratorRegistry.getKubeGeneratorsInfos('Pod')).lengthOf(2);
+  expect(kubeGeneratorRegistry.getKubeGeneratorsInfos('Container')).lengthOf(1);
+  expect(kubeGeneratorRegistry.getKubeGeneratorsInfos(['Compose', 'Pod'])).lengthOf(1);
+});

--- a/packages/main/src/plugin/kube-generator-registry.spec.ts
+++ b/packages/main/src/plugin/kube-generator-registry.spec.ts
@@ -28,7 +28,6 @@ test('Creating KubeGeneratorRegistry and getting KubeGeneratorsInfos', async () 
 test('Registering a provider', async () => {
   const kubeGeneratorRegistry = new KubeGeneratorRegistry();
   kubeGeneratorRegistry.registerKubeGenerator({
-    id: 'dummy',
     name: 'Dummy',
     types: [],
     generate: vi.fn(),
@@ -36,8 +35,8 @@ test('Registering a provider', async () => {
 
   const kubeGeneratorsInfos = kubeGeneratorRegistry.getKubeGeneratorsInfos();
   expect(kubeGeneratorsInfos).lengthOf(1);
-  expect(kubeGeneratorsInfos[0]).toStrictEqual({
-    id: 'dummy',
+  expect(kubeGeneratorsInfos[0]).toMatchObject({
+    id: expect.any(String),
     name: 'Dummy',
     types: [],
   });
@@ -57,6 +56,10 @@ test('Registering multiple providers', async () => {
 
   const kubeGeneratorsInfos = kubeGeneratorRegistry.getKubeGeneratorsInfos();
   expect(kubeGeneratorsInfos).lengthOf(5);
+
+  // Ensuring only unique ids are provided.
+  const ids = kubeGeneratorsInfos.map(k => k.id);
+  expect(new Set(ids).size).toBe(ids.length);
 });
 
 test('Dispose multiple providers', async () => {
@@ -81,9 +84,8 @@ test('getKubeGeneratorsInfos by types', async () => {
 
   const typesTests: KubernetesGeneratorSelector[] = [['Compose'], ['Compose', 'Pod'], ['Pod', 'Container']];
 
-  typesTests.forEach((typesTest, index) => {
+  typesTests.forEach(typesTest => {
     kubeGeneratorRegistry.registerKubeGenerator({
-      id: `${index}`,
       name: 'Dummy',
       types: typesTest,
       generate: vi.fn(),

--- a/packages/main/src/plugin/kube-generator-registry.ts
+++ b/packages/main/src/plugin/kube-generator-registry.ts
@@ -65,11 +65,11 @@ export class KubeGeneratorRegistry {
     return this.kubeGenerators.get(kubeGeneratorId);
   }
 
-  getKubeGeneratorsInfos(selector: KubernetesGeneratorSelector): KubeGeneratorsInfo[] {
+  getKubeGeneratorsInfos(selector: KubernetesGeneratorSelector | undefined): KubeGeneratorsInfo[] {
     return Array.from(this.kubeGenerators.values()).reduce((filteredGenerators, generator) => {
-      const isMatchingGenerator = (Array.isArray(selector) ? selector : [selector]).every(type =>
-        generator.types.includes(type),
-      );
+      const isMatchingGenerator =
+        selector === undefined ||
+        (Array.isArray(selector) ? selector : [selector]).every(type => generator.types.includes(type));
 
       if (isMatchingGenerator) {
         // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/packages/main/src/plugin/kube-generator-registry.ts
+++ b/packages/main/src/plugin/kube-generator-registry.ts
@@ -36,26 +36,13 @@ export type KubeGeneratorsInfo = Omit<KubernetesGeneratorProvider, 'generate'>;
 
 export class KubeGeneratorRegistry {
   private kubeGenerators = new Map<string, KubernetesGeneratorProvider>();
-  private kubeGeneratorsSelectors = new Map<KubernetesGeneratorType, string[]>();
 
   unregisterKubeGenerator(kubeGenerator: KubernetesGeneratorProvider): void {
     this.kubeGenerators.delete(kubeGenerator.id);
-
-    for (const [key, value] of this.kubeGeneratorsSelectors) {
-      const updatedIds = value.filter(existingId => existingId !== kubeGenerator.id);
-      this.kubeGeneratorsSelectors.set(key, updatedIds);
-    }
   }
 
   registerKubeGenerator(kubeGenerator: KubernetesGeneratorProvider): Disposable {
     this.kubeGenerators.set(kubeGenerator.id, kubeGenerator);
-
-    const selectors = Array.isArray(kubeGenerator.types) ? kubeGenerator.types : [kubeGenerator.types];
-
-    for (const s of selectors) {
-      this.kubeGeneratorsSelectors.set(s, [...(this.kubeGeneratorsSelectors.get(s) ?? []), kubeGenerator.id]);
-    }
-
     return Disposable.create(() => {
       this.unregisterKubeGenerator(kubeGenerator);
     });
@@ -65,7 +52,7 @@ export class KubeGeneratorRegistry {
     return this.kubeGenerators.get(kubeGeneratorId);
   }
 
-  getKubeGeneratorsInfos(selector: KubernetesGeneratorSelector | undefined): KubeGeneratorsInfo[] {
+  getKubeGeneratorsInfos(selector: KubernetesGeneratorSelector | undefined = undefined): KubeGeneratorsInfo[] {
     return Array.from(this.kubeGenerators.values()).reduce((filteredGenerators, generator) => {
       const isMatchingGenerator =
         selector === undefined ||

--- a/packages/main/src/plugin/kube-generator-registry.ts
+++ b/packages/main/src/plugin/kube-generator-registry.ts
@@ -1,0 +1,55 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import { Disposable } from '/@/plugin/types/disposable.js';
+
+export interface KubeGenerator {
+  command: string;
+  id: string;
+}
+
+export class KubeGeneratorRegistry {
+  private kubeGenerators = new Map<string, KubeGenerator>();
+
+  registerKubeGenerators(kubeGenerators: KubeGenerator[]): Disposable {
+    for (const kubeGenerator of kubeGenerators) {
+      this.registerKubeGenerator(kubeGenerator);
+    }
+
+    return Disposable.create(() => {
+      this.unregisterKubeGenerators(kubeGenerators);
+    });
+  }
+
+  unregisterKubeGenerators(kubeGenerators: KubeGenerator[]): void {
+    for (const kubeGenerator of kubeGenerators) {
+      this.unregisterKubeGenerator(kubeGenerator);
+    }
+  }
+
+  unregisterKubeGenerator(kubeGenerator: KubeGenerator): void {
+    this.kubeGenerators.delete(kubeGenerator.id);
+  }
+
+  registerKubeGenerator(kubeGenerator: KubeGenerator): void {
+    this.kubeGenerators.set(kubeGenerator.id, kubeGenerator);
+  }
+
+  getKubeGenerator(kubeGeneratorId: string): KubeGenerator | undefined {
+    return this.kubeGenerators.get(kubeGeneratorId);
+  }
+}

--- a/packages/main/src/plugin/kube-generator-registry.ts
+++ b/packages/main/src/plugin/kube-generator-registry.ts
@@ -20,19 +20,19 @@ import { Disposable } from '/@/plugin/types/disposable.js';
 export interface GenerateKubeResult {
   yaml: string;
 }
-export interface Provider {
+export interface KubernetesGeneratorProvider {
   id: string;
   generate(engineId: string, ids: string[]): GenerateKubeResult;
 }
 
 export class KubeGeneratorRegistry {
-  private kubeGenerators = new Map<string, Provider>();
+  private kubeGenerators = new Map<string, KubernetesGeneratorProvider>();
 
-  unregisterKubeGenerator(kubeGenerator: Provider): void {
+  unregisterKubeGenerator(kubeGenerator: KubernetesGeneratorProvider): void {
     this.kubeGenerators.delete(kubeGenerator.id);
   }
 
-  registerKubeGenerator(kubeGenerator: Provider): Disposable {
+  registerKubeGenerator(kubeGenerator: KubernetesGeneratorProvider): Disposable {
     console.log('registerKubeGenerator');
     this.kubeGenerators.set(kubeGenerator.id, kubeGenerator);
 
@@ -41,7 +41,7 @@ export class KubeGeneratorRegistry {
     });
   }
 
-  getKubeGenerator(kubeGeneratorId: string): Provider | undefined {
+  getKubeGenerator(kubeGeneratorId: string): KubernetesGeneratorProvider | undefined {
     console.log('getKubeGenerator');
     return this.kubeGenerators.get(kubeGeneratorId);
   }

--- a/packages/main/src/plugin/kube-generator-registry.ts
+++ b/packages/main/src/plugin/kube-generator-registry.ts
@@ -17,19 +17,23 @@
  ***********************************************************************/
 import { Disposable } from '/@/plugin/types/disposable.js';
 
-export interface KubeGenerator {
-  command: string;
+export interface GenerateKubeResult {
+  yaml: string;
+}
+export interface Provider {
   id: string;
+  generate(engineId: string, ids: string[]): GenerateKubeResult;
 }
 
 export class KubeGeneratorRegistry {
-  private kubeGenerators = new Map<string, KubeGenerator>();
+  private kubeGenerators = new Map<string, Provider>();
 
-  unregisterKubeGenerator(kubeGenerator: KubeGenerator): void {
+  unregisterKubeGenerator(kubeGenerator: Provider): void {
     this.kubeGenerators.delete(kubeGenerator.id);
   }
 
-  registerKubeGenerator(kubeGenerator: KubeGenerator): Disposable {
+  registerKubeGenerator(kubeGenerator: Provider): Disposable {
+    console.log('registerKubeGenerator');
     this.kubeGenerators.set(kubeGenerator.id, kubeGenerator);
 
     return Disposable.create(() => {
@@ -37,7 +41,8 @@ export class KubeGeneratorRegistry {
     });
   }
 
-  getKubeGenerator(kubeGeneratorId: string): KubeGenerator | undefined {
+  getKubeGenerator(kubeGeneratorId: string): Provider | undefined {
+    console.log('getKubeGenerator');
     return this.kubeGenerators.get(kubeGeneratorId);
   }
 }

--- a/packages/main/src/plugin/kube-generator-registry.ts
+++ b/packages/main/src/plugin/kube-generator-registry.ts
@@ -17,11 +17,19 @@
  ***********************************************************************/
 import { Disposable } from '/@/plugin/types/disposable.js';
 
+export enum KubernetesGeneratorType {
+  COMPOSE = 'Compose',
+  POD = 'Pod',
+  Container = 'Container',
+}
+
 export interface GenerateKubeResult {
   yaml: string;
 }
+
 export interface KubernetesGeneratorProvider {
   id: string;
+  accept?(type: KubernetesGeneratorType): boolean;
   generate(engineId: string, ids: string[]): GenerateKubeResult;
 }
 

--- a/packages/main/src/plugin/kube-generator-registry.ts
+++ b/packages/main/src/plugin/kube-generator-registry.ts
@@ -36,7 +36,7 @@ export type KubernetesGeneratorArgument = {
 export interface KubernetesGeneratorProvider {
   readonly name: string;
   readonly types: KubernetesGeneratorSelector;
-  generate(argument: KubernetesGeneratorArgument): Promise<GenerateKubeResult>;
+  generate(kubernetesGeneratorArguments: KubernetesGeneratorArgument[]): Promise<GenerateKubeResult>;
 }
 
 export class KubeGeneratorRegistry {

--- a/packages/main/src/plugin/kube-generator-registry.ts
+++ b/packages/main/src/plugin/kube-generator-registry.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 import { Disposable } from './types/disposable.js';
-import type { KubernetesGeneratorInfo } from '/@/plugin/api/KubernetesGeneratorInfo.js';
+import type { KubernetesGeneratorInfo } from './api/KubernetesGeneratorInfo.js';
 
 export type KubernetesGeneratorType = 'Compose' | 'Pod' | 'Container';
 

--- a/packages/main/src/plugin/kube-generator-registry.ts
+++ b/packages/main/src/plugin/kube-generator-registry.ts
@@ -52,7 +52,7 @@ export class KubeGeneratorRegistry {
     return this.kubeGenerators.get(kubeGeneratorId);
   }
 
-  getKubeGeneratorsInfos(selector: KubernetesGeneratorSelector | undefined = undefined): KubeGeneratorsInfo[] {
+  getKubeGeneratorsInfos(selector?: KubernetesGeneratorSelector): KubeGeneratorsInfo[] {
     return Array.from(this.kubeGenerators.values()).reduce((filteredGenerators, generator) => {
       const isMatchingGenerator =
         selector === undefined ||

--- a/packages/main/src/plugin/kube-generator-registry.ts
+++ b/packages/main/src/plugin/kube-generator-registry.ts
@@ -25,28 +25,16 @@ export interface KubeGenerator {
 export class KubeGeneratorRegistry {
   private kubeGenerators = new Map<string, KubeGenerator>();
 
-  registerKubeGenerators(kubeGenerators: KubeGenerator[]): Disposable {
-    for (const kubeGenerator of kubeGenerators) {
-      this.registerKubeGenerator(kubeGenerator);
-    }
-
-    return Disposable.create(() => {
-      this.unregisterKubeGenerators(kubeGenerators);
-    });
-  }
-
-  unregisterKubeGenerators(kubeGenerators: KubeGenerator[]): void {
-    for (const kubeGenerator of kubeGenerators) {
-      this.unregisterKubeGenerator(kubeGenerator);
-    }
-  }
-
   unregisterKubeGenerator(kubeGenerator: KubeGenerator): void {
     this.kubeGenerators.delete(kubeGenerator.id);
   }
 
-  registerKubeGenerator(kubeGenerator: KubeGenerator): void {
+  registerKubeGenerator(kubeGenerator: KubeGenerator): Disposable {
     this.kubeGenerators.set(kubeGenerator.id, kubeGenerator);
+
+    return Disposable.create(() => {
+      this.unregisterKubeGenerator(kubeGenerator);
+    });
   }
 
   getKubeGenerator(kubeGeneratorId: string): KubeGenerator | undefined {

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -68,7 +68,13 @@ import type { MessageBoxOptions, MessageBoxReturnValue } from '../../main/src/pl
 import type { ViewInfoUI } from '../../main/src/plugin/api/view-info';
 import type { ContextInfo } from '../../main/src/plugin/api/context-info';
 import type { OnboardingInfo, OnboardingStatus } from '../../main/src/plugin/api/onboarding';
-import type { KubernetesGeneratorSelector } from '../../main/src/plugin/kube-generator-registry';
+import type {
+  KubernetesGeneratorSelector,
+  GenerateKubeResult,
+  KubernetesGeneratorArgument,
+} from '../../main/src/plugin/kube-generator-registry';
+
+import type { KubernetesGeneratorInfo } from '../../main/src/plugin/api/KubernetesGeneratorInfo';
 
 export type DialogResultCallback = (openDialogReturnValue: Electron.OpenDialogReturnValue) => void;
 
@@ -251,6 +257,16 @@ function initExposure(): void {
     'generatePodmanKube',
     async (engine: string, names: string[], kubeGeneratorId?: string): Promise<string> => {
       return ipcInvoke('container-provider-registry:generatePodmanKube', engine, names, kubeGeneratorId);
+    },
+  );
+
+  contextBridge.exposeInMainWorld(
+    'generateKube',
+    async (
+      kubeGeneratorId: string,
+      kubernetesGeneratorArgument: KubernetesGeneratorArgument,
+    ): Promise<GenerateKubeResult> => {
+      return ipcInvoke('kubernetes-generator-registry:generateKube', kubeGeneratorId, kubernetesGeneratorArgument);
     },
   );
 
@@ -934,7 +950,7 @@ function initExposure(): void {
 
   contextBridge.exposeInMainWorld(
     'getKubeGeneratorsInfos',
-    async (selector?: KubernetesGeneratorSelector): Promise<string[]> => {
+    async (selector?: KubernetesGeneratorSelector): Promise<KubernetesGeneratorInfo[]> => {
       return ipcInvoke('kube-generator-registry:getKubeGeneratorsInfos', selector);
     },
   );

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -249,7 +249,7 @@ function initExposure(): void {
   });
   contextBridge.exposeInMainWorld(
     'generatePodmanKube',
-    async (engine: string, names: string[], kubeGeneratorId: string | undefined = undefined): Promise<string> => {
+    async (engine: string, names: string[], kubeGeneratorId?: string): Promise<string> => {
       return ipcInvoke('container-provider-registry:generatePodmanKube', engine, names, kubeGeneratorId);
     },
   );

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -68,6 +68,7 @@ import type { MessageBoxOptions, MessageBoxReturnValue } from '../../main/src/pl
 import type { ViewInfoUI } from '../../main/src/plugin/api/view-info';
 import type { ContextInfo } from '../../main/src/plugin/api/context-info';
 import type { OnboardingInfo, OnboardingStatus } from '../../main/src/plugin/api/onboarding';
+import type { KubernetesGeneratorType } from '../../main/src/plugin/kube-generator-registry';
 
 export type DialogResultCallback = (openDialogReturnValue: Electron.OpenDialogReturnValue) => void;
 
@@ -930,6 +931,13 @@ function initExposure(): void {
   contextBridge.exposeInMainWorld('getContributedMenus', async (context: string): Promise<Menu[]> => {
     return ipcInvoke('menu-registry:getContributedMenus', context);
   });
+
+  contextBridge.exposeInMainWorld(
+    'getKubeGeneratorsIdsByType',
+    async (type: KubernetesGeneratorType): Promise<string[]> => {
+      return ipcInvoke('kube-generator-registry:getKubeGeneratorsIdsByType', type);
+    },
+  );
 
   contextBridge.exposeInMainWorld('executeCommand', async (command: string, ...args: unknown[]): Promise<unknown> => {
     return ipcInvoke('command-registry:executeCommand', command, ...args);

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -934,7 +934,7 @@ function initExposure(): void {
 
   contextBridge.exposeInMainWorld(
     'getKubeGeneratorsInfos',
-    async (selector: KubernetesGeneratorSelector | undefined = undefined): Promise<string[]> => {
+    async (selector?: KubernetesGeneratorSelector): Promise<string[]> => {
       return ipcInvoke('kube-generator-registry:getKubeGeneratorsInfos', selector);
     },
   );

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -253,20 +253,22 @@ function initExposure(): void {
   contextBridge.exposeInMainWorld('restartPod', async (engine: string, podId: string): Promise<void> => {
     return ipcInvoke('container-provider-registry:restartPod', engine, podId);
   });
-  contextBridge.exposeInMainWorld(
-    'generatePodmanKube',
-    async (engine: string, names: string[], kubeGeneratorId?: string): Promise<string> => {
-      return ipcInvoke('container-provider-registry:generatePodmanKube', engine, names, kubeGeneratorId);
-    },
-  );
+
+  /**
+   * @deprecated This method is deprecated and will be removed in a future release.
+   * Use generateKube instead.
+   */
+  contextBridge.exposeInMainWorld('generatePodmanKube', async (engine: string, names: string[]): Promise<string> => {
+    return ipcInvoke('container-provider-registry:generatePodmanKube', engine, names);
+  });
 
   contextBridge.exposeInMainWorld(
     'generateKube',
     async (
-      kubeGeneratorId: string,
       kubernetesGeneratorArgument: KubernetesGeneratorArgument,
+      kubeGeneratorId?: string,
     ): Promise<GenerateKubeResult> => {
-      return ipcInvoke('kubernetes-generator-registry:generateKube', kubeGeneratorId, kubernetesGeneratorArgument);
+      return ipcInvoke('kubernetes-generator-registry:generateKube', kubernetesGeneratorArgument, kubeGeneratorId);
     },
   );
 

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -934,7 +934,7 @@ function initExposure(): void {
 
   contextBridge.exposeInMainWorld(
     'getKubeGeneratorsInfos',
-    async (selector: KubernetesGeneratorSelector): Promise<string[]> => {
+    async (selector: KubernetesGeneratorSelector | undefined = undefined): Promise<string[]> => {
       return ipcInvoke('kube-generator-registry:getKubeGeneratorsInfos', selector);
     },
   );

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -68,7 +68,7 @@ import type { MessageBoxOptions, MessageBoxReturnValue } from '../../main/src/pl
 import type { ViewInfoUI } from '../../main/src/plugin/api/view-info';
 import type { ContextInfo } from '../../main/src/plugin/api/context-info';
 import type { OnboardingInfo, OnboardingStatus } from '../../main/src/plugin/api/onboarding';
-import type { KubernetesGeneratorType } from '../../main/src/plugin/kube-generator-registry';
+import type { KubernetesGeneratorSelector } from '../../main/src/plugin/kube-generator-registry';
 
 export type DialogResultCallback = (openDialogReturnValue: Electron.OpenDialogReturnValue) => void;
 
@@ -933,9 +933,9 @@ function initExposure(): void {
   });
 
   contextBridge.exposeInMainWorld(
-    'getKubeGeneratorsIdsByType',
-    async (type: KubernetesGeneratorType): Promise<string[]> => {
-      return ipcInvoke('kube-generator-registry:getKubeGeneratorsIdsByType', type);
+    'getKubeGeneratorsInfos',
+    async (selector: KubernetesGeneratorSelector): Promise<string[]> => {
+      return ipcInvoke('kube-generator-registry:getKubeGeneratorsInfos', selector);
     },
   );
 

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -265,10 +265,10 @@ function initExposure(): void {
   contextBridge.exposeInMainWorld(
     'generateKube',
     async (
-      kubernetesGeneratorArgument: KubernetesGeneratorArgument,
+      kubernetesGeneratorArguments: KubernetesGeneratorArgument[],
       kubeGeneratorId?: string,
     ): Promise<GenerateKubeResult> => {
-      return ipcInvoke('kubernetes-generator-registry:generateKube', kubernetesGeneratorArgument, kubeGeneratorId);
+      return ipcInvoke('kubernetes-generator-registry:generateKube', kubernetesGeneratorArguments, kubeGeneratorId);
     },
   );
 

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -246,9 +246,12 @@ function initExposure(): void {
   contextBridge.exposeInMainWorld('restartPod', async (engine: string, podId: string): Promise<void> => {
     return ipcInvoke('container-provider-registry:restartPod', engine, podId);
   });
-  contextBridge.exposeInMainWorld('generatePodmanKube', async (engine: string, names: string[]): Promise<string> => {
-    return ipcInvoke('container-provider-registry:generatePodmanKube', engine, names);
-  });
+  contextBridge.exposeInMainWorld(
+    'generatePodmanKube',
+    async (engine: string, names: string[], kubeGeneratorId: string | undefined = undefined): Promise<string> => {
+      return ipcInvoke('container-provider-registry:generatePodmanKube', engine, names, kubeGeneratorId);
+    },
+  );
 
   contextBridge.exposeInMainWorld(
     'playKube',

--- a/packages/renderer/src/lib/compose/ComposeDetailsKube.svelte
+++ b/packages/renderer/src/lib/compose/ComposeDetailsKube.svelte
@@ -11,13 +11,10 @@ onMount(async () => {
   // Grab all the container ID's from compose.containers
   const containerIds = compose.containers.map(container => container.id);
 
-  // Extracting the potential kubeGenerator from the query parameters
-  const urlParams = new URLSearchParams(window.location.search);
-  const kubeGenerator = urlParams.has('kubeGenerator') ? urlParams.get('kubeGenerator') : undefined;
-
   // Generate the kube yaml using the generatePodmanKube function which
   // only has to take in the engineID and an array of container ID's to generate from
-  kubeDetails = await window.generatePodmanKube(compose.engineId, containerIds, kubeGenerator);
+  const kubeResult = await window.generatePodmanKube(compose.engineId, containerIds);
+  kubeDetails = kubeResult;
 });
 </script>
 

--- a/packages/renderer/src/lib/compose/ComposeDetailsKube.svelte
+++ b/packages/renderer/src/lib/compose/ComposeDetailsKube.svelte
@@ -11,10 +11,13 @@ onMount(async () => {
   // Grab all the container ID's from compose.containers
   const containerIds = compose.containers.map(container => container.id);
 
+  // Extracting the potential kubeGenerator from the query parameters
+  const urlParams = new URLSearchParams(window.location.search);
+  const kubeGenerator = urlParams.has('kubeGenerator') ? urlParams.get('kubeGenerator') : undefined;
+
   // Generate the kube yaml using the generatePodmanKube function which
   // only has to take in the engineID and an array of container ID's to generate from
-  const kubeResult = await window.generatePodmanKube(compose.engineId, containerIds);
-  kubeDetails = kubeResult;
+  kubeDetails = await window.generatePodmanKube(compose.engineId, containerIds, kubeGenerator);
 });
 </script>
 


### PR DESCRIPTION
### What does this PR do?

The default way of generating kubernetes files from a container/group of containers is not use the `generatePodmanKube`.

This PR aims to add the possibility for extensions to add their own `KubeGenerator`, allowing to register a command, that will be called when we want to generate a Kubernetes Config.
### Example

See bellow in comment 

### Screenshot/screencast of this PR

![image](https://github.com/containers/podman-desktop/assets/42176370/ce482c1e-a9c9-4f19-984f-6ce205401e13)

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop 
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to reproduce -->
