### PR TITLE
feat: added a ; to the freedesktop entry

### DIFF
--- a/.flatpak.desktop
+++ b/.flatpak.desktop
@@ -5,5 +5,5 @@ Terminal=false
 Type=Application
 Icon=io.podman_desktop.PodmanDesktop
 StartupWMClass=Podman Desktop
-Categories=Development
+Categories=Development;
 X-Flatpak=io.podman_desktop.PodmanDesktop


### PR DESCRIPTION
Added a trailing `;` tp the Freedesktop `Categories` entry.

Because all examples in the specification have it; see: https://specifications.freedesktop.org/menu-spec/latest/ar01s03.html