### PR TITLE
fix: context update should trigger check on step completion (#3972)

### DIFF
--- a/packages/renderer/src/lib/onboarding/onboarding-utils.spec.ts
+++ b/packages/renderer/src/lib/onboarding/onboarding-utils.spec.ts
@@ -1,0 +1,500 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import '@testing-library/jest-dom/vitest';
+import { test, expect, vi, beforeAll } from 'vitest';
+import { ContextUI } from '../context/context';
+import {
+  cleanSetup,
+  isOnboardingCompleted,
+  isOnboardingsSetupCompleted,
+  normalizeOnboardingWhenClause,
+  type ActiveOnboardingStep,
+  isStepCompleted,
+  updateOnboardingStepStatus,
+} from './onboarding-utils';
+import type { OnboardingInfo, OnboardingStep } from '../../../../main/src/plugin/api/onboarding';
+import { ContextKeyExpr, type ContextKeyExpression } from '../context/contextKey';
+
+const deserialize = vi.fn();
+
+// fake the window.events object
+beforeAll(() => {
+  const resetOnboarding = vi.fn();
+  (window as any).resetOnboarding = resetOnboarding;
+  const updateStepState = vi.fn();
+  (window as any).updateStepState = updateStepState;
+  (ContextKeyExpr as any).deserialize = deserialize;
+});
+
+test('Expect to have the when clause normalized if contains an onboardingContext value', async () => {
+  const when = 'onboardingContext:engine.podmanMachineCreated';
+  const normalized = normalizeOnboardingWhenClause(when, 'podman');
+  expect(normalized).equal('podman.onboarding.engine.podmanMachineCreated');
+});
+
+test('Expect to have the when clause normalized if contains more than one onboardingContext value', async () => {
+  const when = 'onboardingContext:engine.podmanMachineCreated && onboardingContext:engine.podmanMachineStarted';
+  const normalized = normalizeOnboardingWhenClause(when, 'podman');
+  expect(normalized).equal(
+    'podman.onboarding.engine.podmanMachineCreated && podman.onboarding.engine.podmanMachineStarted',
+  );
+});
+
+test('Expect to have the when clause returned in its original form if it does not contain any onboardingContext value', async () => {
+  const when = '!isLinux';
+  const normalized = normalizeOnboardingWhenClause(when, 'podman');
+  expect(normalized).equal('!isLinux');
+});
+
+test('Expect cleanContext to remove onboarding values from context and reset the state of all steps', async () => {
+  const onboarding: OnboardingInfo = {
+    extension: 'id',
+    steps: [
+      {
+        id: 'id1',
+        title: 'title 1',
+        status: 'completed',
+      },
+      {
+        id: 'id2',
+        title: 'title 2',
+        status: 'completed',
+      },
+    ],
+    title: 'onboarding',
+    status: 'completed',
+  };
+  const context = new ContextUI();
+  context.setValue('id.onboarding.key1', 'value');
+  context.setValue('id.onboarding.key2', 'value');
+
+  await cleanSetup([onboarding], context);
+
+  expect(onboarding.status).toBeUndefined();
+  expect(onboarding.steps[0].status).toBeUndefined();
+  expect(onboarding.steps[1].status).toBeUndefined();
+  const contextValues = context.collectAllValues();
+  expect(Object.keys(contextValues).length).toBe(0);
+});
+
+test('Expect that the onboarding is not completed if atleast one step has not been completed', async () => {
+  const onboarding: OnboardingInfo = {
+    extension: 'id',
+    steps: [
+      {
+        id: 'id1',
+        title: 'title 1',
+        status: 'completed',
+      },
+      {
+        id: 'id2',
+        title: 'title 2',
+        status: undefined,
+      },
+    ],
+    title: 'onboarding',
+    status: 'skipped',
+  };
+  const complete = isOnboardingCompleted(onboarding);
+  expect(complete).toBeFalsy();
+});
+
+test('Expect that the onboarding is not completed if its status is not set', async () => {
+  const onboarding: OnboardingInfo = {
+    extension: 'id',
+    steps: [
+      {
+        id: 'id1',
+        title: 'title 1',
+        status: 'completed',
+      },
+      {
+        id: 'id2',
+        title: 'title 2',
+        status: 'skipped',
+      },
+    ],
+    title: 'onboarding',
+    status: undefined,
+  };
+  const complete = isOnboardingCompleted(onboarding);
+  expect(complete).toBeFalsy();
+});
+
+test('Expect that the onboarding is completed if all its steps are completed and its status is set', async () => {
+  const onboarding: OnboardingInfo = {
+    extension: 'id',
+    steps: [
+      {
+        id: 'id1',
+        title: 'title 1',
+        status: 'completed',
+      },
+      {
+        id: 'id2',
+        title: 'title 2',
+        status: 'completed',
+      },
+    ],
+    title: 'onboarding',
+    status: 'completed',
+  };
+  const complete = isOnboardingCompleted(onboarding);
+  expect(complete).toBeTruthy();
+});
+
+test('Expect the setup of multiple onboardings to be completed if all have been completed', async () => {
+  const onboarding1: OnboardingInfo = {
+    extension: 'id',
+    steps: [
+      {
+        id: 'id1',
+        title: 'title 1',
+        status: 'completed',
+      },
+      {
+        id: 'id2',
+        title: 'title 2',
+        status: 'completed',
+      },
+    ],
+    title: 'onboarding',
+    status: 'completed',
+  };
+  const onboarding2: OnboardingInfo = {
+    extension: 'id',
+    steps: [
+      {
+        id: 'id1',
+        title: 'title 1',
+        status: 'completed',
+      },
+      {
+        id: 'id2',
+        title: 'title 2',
+        status: 'completed',
+      },
+    ],
+    title: 'onboarding',
+    status: 'completed',
+  };
+  const complete = isOnboardingsSetupCompleted([onboarding1, onboarding2]);
+  expect(complete).toBeTruthy();
+});
+
+test('Expect the setup of multiple onboardings to be uncompleted if atleast one have not been completed', async () => {
+  const onboarding1: OnboardingInfo = {
+    extension: 'id',
+    steps: [
+      {
+        id: 'id1',
+        title: 'title 1',
+        status: 'completed',
+      },
+      {
+        id: 'id2',
+        title: 'title 2',
+        status: 'completed',
+      },
+    ],
+    title: 'onboarding',
+    status: 'completed',
+  };
+  const onboarding2: OnboardingInfo = {
+    extension: 'id',
+    steps: [
+      {
+        id: 'id1',
+        title: 'title 1',
+        status: 'completed',
+      },
+      {
+        id: 'id2',
+        title: 'title 2',
+        status: 'failed',
+      },
+    ],
+    title: 'onboarding',
+    status: undefined,
+  };
+  const complete = isOnboardingsSetupCompleted([onboarding1, onboarding2]);
+  expect(complete).toBeFalsy();
+});
+
+test('Expect the step to be completed if the active step have not completion events', async () => {
+  const step: OnboardingStep = {
+    id: 'id1',
+    title: 'title 1',
+    status: undefined,
+  };
+
+  const onboarding: OnboardingInfo = {
+    extension: 'id',
+    steps: [
+      step,
+      {
+        id: 'id2',
+        title: 'title 2',
+        status: undefined,
+      },
+    ],
+    title: 'onboarding',
+    status: undefined,
+  };
+  const activeStep: ActiveOnboardingStep = {
+    onboarding,
+    step,
+  };
+  const isCompleted = isStepCompleted(activeStep, []);
+  expect(isCompleted).toBeTruthy();
+});
+
+test('Expect the step to be completed if the step is considered completed if only a command has been executed and it has actually been executed', async () => {
+  const step: OnboardingStep = {
+    id: 'id1',
+    title: 'title 1',
+    status: undefined,
+    completionEvents: ['onCommand:mycommand'],
+  };
+
+  const onboarding: OnboardingInfo = {
+    extension: 'id',
+    steps: [
+      step,
+      {
+        id: 'id2',
+        title: 'title 2',
+        status: undefined,
+      },
+    ],
+    title: 'onboarding',
+    status: undefined,
+  };
+  const activeStep: ActiveOnboardingStep = {
+    onboarding,
+    step,
+  };
+  const isCompleted = isStepCompleted(activeStep, ['mycommand']);
+  expect(isCompleted).toBeTruthy();
+});
+
+test('Expect the step to NOT be completed if the step is considered completed if only a command has been executed and it has NOT been executed', async () => {
+  const step: OnboardingStep = {
+    id: 'id1',
+    title: 'title 1',
+    status: undefined,
+    completionEvents: ['onCommand:mycommand'],
+  };
+
+  const onboarding: OnboardingInfo = {
+    extension: 'id',
+    steps: [
+      step,
+      {
+        id: 'id2',
+        title: 'title 2',
+        status: undefined,
+      },
+    ],
+    title: 'onboarding',
+    status: undefined,
+  };
+  const activeStep: ActiveOnboardingStep = {
+    onboarding,
+    step,
+  };
+  const isCompleted = isStepCompleted(activeStep, []);
+  expect(isCompleted).toBeFalsy();
+});
+
+test('Expect the step to be completed if the step is considered completed if a context value is set and it is actually set and its evaluation returns true', async () => {
+  const step: OnboardingStep = {
+    id: 'id1',
+    title: 'title 1',
+    status: undefined,
+    completionEvents: ['onboardingContext:myvalue'],
+  };
+
+  const onboarding: OnboardingInfo = {
+    extension: 'id',
+    steps: [
+      step,
+      {
+        id: 'id2',
+        title: 'title 2',
+        status: undefined,
+      },
+    ],
+    title: 'onboarding',
+    status: undefined,
+  };
+  const activeStep: ActiveOnboardingStep = {
+    onboarding,
+    step,
+  };
+  const context = new ContextUI();
+  context.setValue('id.onboarding.myvalue', 'value');
+  deserialize.mockReturnValue({
+    evaluate: (_context: ContextUI) => true,
+  } as unknown as ContextKeyExpression);
+  const isCompleted = isStepCompleted(activeStep, [], context);
+  expect(isCompleted).toBeTruthy();
+});
+
+test('Expect the step to NOT be completed if the step is considered completed if a context value is set and its evaluation is true, but its evaluation returns false', async () => {
+  const step: OnboardingStep = {
+    id: 'id1',
+    title: 'title 1',
+    status: undefined,
+    completionEvents: ['onboardingContext:myvalue'],
+  };
+
+  const onboarding: OnboardingInfo = {
+    extension: 'id',
+    steps: [
+      step,
+      {
+        id: 'id2',
+        title: 'title 2',
+        status: undefined,
+      },
+    ],
+    title: 'onboarding',
+    status: undefined,
+  };
+  const activeStep: ActiveOnboardingStep = {
+    onboarding,
+    step,
+  };
+  const context = new ContextUI();
+  context.setValue('id.onboarding.myvalue', 'value');
+  deserialize.mockReturnValue({
+    evaluate: (_context: ContextUI) => false,
+  } as unknown as ContextKeyExpression);
+  const isCompleted = isStepCompleted(activeStep, [], context);
+  expect(isCompleted).toBeFalsy();
+});
+
+test('Expect the step to NOT be completed if the step is considered completed if a context value is set and it is NOT set', async () => {
+  const step: OnboardingStep = {
+    id: 'id1',
+    title: 'title 1',
+    status: undefined,
+    completionEvents: ['onboardingContext:myvalue'],
+  };
+
+  const onboarding: OnboardingInfo = {
+    extension: 'id',
+    steps: [
+      step,
+      {
+        id: 'id2',
+        title: 'title 2',
+        status: undefined,
+      },
+    ],
+    title: 'onboarding',
+    status: undefined,
+  };
+  const activeStep: ActiveOnboardingStep = {
+    onboarding,
+    step,
+  };
+  const context = new ContextUI();
+  deserialize.mockReturnValue({
+    evaluate: (_context: ContextUI) => false,
+  } as unknown as ContextKeyExpression);
+  const isCompleted = isStepCompleted(activeStep, [], context);
+  expect(isCompleted).toBeFalsy();
+});
+
+test('Expect the step to NOT be completed if the step is considered completed if a context value is set but there is no context available', async () => {
+  const step: OnboardingStep = {
+    id: 'id1',
+    title: 'title 1',
+    status: undefined,
+    completionEvents: ['onboardingContext:myvalue'],
+  };
+
+  const onboarding: OnboardingInfo = {
+    extension: 'id',
+    steps: [
+      step,
+      {
+        id: 'id2',
+        title: 'title 2',
+        status: undefined,
+      },
+    ],
+    title: 'onboarding',
+    status: undefined,
+  };
+  const activeStep: ActiveOnboardingStep = {
+    onboarding,
+    step,
+  };
+  const isCompleted = isStepCompleted(activeStep, []);
+  expect(isCompleted).toBeFalsy();
+});
+
+test('Expect the step status to be updated but not the onboarding as it is not the last step', async () => {
+  const step: OnboardingStep = {
+    id: 'id1',
+    title: 'title 1',
+    status: undefined,
+    completionEvents: ['onboardingContext:myvalue'],
+  };
+
+  const onboarding: OnboardingInfo = {
+    extension: 'id',
+    steps: [
+      step,
+      {
+        id: 'id2',
+        title: 'title 2',
+        status: undefined,
+        state: 'completed',
+      },
+    ],
+    title: 'onboarding',
+    status: undefined,
+  };
+  await updateOnboardingStepStatus(onboarding, step, 'completed');
+  expect(step.status).equal('completed');
+  expect(onboarding.status).toBeUndefined();
+});
+
+test('Expect the step and the onboarding status to be updated as it is the last step', async () => {
+  const step: OnboardingStep = {
+    id: 'id1',
+    title: 'title 1',
+    status: undefined,
+    state: 'completed',
+    completionEvents: ['onboardingContext:myvalue'],
+  };
+
+  const onboarding: OnboardingInfo = {
+    extension: 'id',
+    steps: [step],
+    title: 'onboarding',
+    status: undefined,
+  };
+  await updateOnboardingStepStatus(onboarding, step, 'completed');
+  expect(step.status).equal('completed');
+  expect(onboarding.status).equal('completed');
+});

--- a/packages/renderer/src/lib/onboarding/onboarding-utils.ts
+++ b/packages/renderer/src/lib/onboarding/onboarding-utils.ts
@@ -15,6 +15,11 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
+
+import type { OnboardingInfo, OnboardingStep, OnboardingStatus } from '../../../../main/src/plugin/api/onboarding';
+import type { ContextUI } from '../context/context';
+import { ContextKeyExpr } from '../context/contextKey';
+
 export const SCOPE_ONBOARDING = 'onboarding';
 
 export const STATUS_COMPLETED = 'completed';
@@ -22,3 +27,116 @@ export const STATUS_SKIPPED = 'skipped';
 
 export const ON_COMMAND_PREFIX = 'onCommand:';
 export const ONBOARDING_CONTEXT_PREFIX = 'onboardingContext:';
+
+export interface ActiveOnboardingStep {
+  onboarding: OnboardingInfo;
+  step: OnboardingStep;
+}
+
+/*
+ *   it update the step status and, if it is the last step with a completed state, the onboarding status in the backend.
+ */
+export async function updateOnboardingStepStatus(
+  onboarding: OnboardingInfo,
+  step: OnboardingStep,
+  status: OnboardingStatus,
+) {
+  step.status = status;
+  await window.updateStepState(status, onboarding.extension, step.id);
+  // if the completed step is the last one, we mark the onboarding as completed
+  // the last step should have a completed state by default
+  const lastCompletedStep = onboarding.steps.findLast(s => s.state === 'completed');
+  if (lastCompletedStep?.id === step.id) {
+    onboarding.status = STATUS_COMPLETED;
+    await window.updateStepState(STATUS_COMPLETED, onboarding.extension);
+  }
+}
+
+/**
+ * it verifies if a step must be marked as completed by checking that the step does not depend on any completion event or, if any, that that they have
+ * been satisfied.
+ */
+export function isStepCompleted(
+  activeStep: ActiveOnboardingStep,
+  executedCommands: string[],
+  globalContext?: ContextUI,
+): boolean {
+  return (
+    !activeStep.step.completionEvents ||
+    activeStep.step.completionEvents.length === 0 ||
+    activeStep.step.completionEvents.every(cmp => {
+      // check if command has been executed
+      if (cmp.startsWith(ON_COMMAND_PREFIX) && executedCommands.includes(cmp.replace(ON_COMMAND_PREFIX, ''))) {
+        return true;
+      }
+
+      // check if cmp string is an onContext event, check the value from context
+      if (cmp.startsWith(ONBOARDING_CONTEXT_PREFIX)) {
+        if (!globalContext) {
+          return false;
+        }
+        cmp = cmp.replace(ONBOARDING_CONTEXT_PREFIX, `${activeStep.onboarding.extension}.${SCOPE_ONBOARDING}.`);
+        const completionEventDeserialized = ContextKeyExpr.deserialize(cmp);
+        return completionEventDeserialized?.evaluate(globalContext);
+      }
+
+      return false;
+    })
+  );
+}
+
+/*
+ *   it checks if all onboardings i nthe list have been completed
+ */
+export function isOnboardingsSetupCompleted(onboardings: OnboardingInfo[]): boolean {
+  for (const onboarding of onboardings) {
+    if (!isOnboardingCompleted(onboarding)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/*
+ *   it checks if the setup of the onboarding is complete
+ */
+export function isOnboardingCompleted(onboarding: OnboardingInfo): boolean {
+  if (!onboarding.status) {
+    return false;
+  }
+  for (const step of onboarding.steps) {
+    if (!step.status) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/*
+ *   it normalizes the values containing the prefix "onboardingContext:". It is replaces with <extension>.onboarding
+ */
+export function normalizeOnboardingWhenClause(when: string, extension: string): string {
+  return when.replaceAll(ONBOARDING_CONTEXT_PREFIX, `${extension}.${SCOPE_ONBOARDING}.`);
+}
+
+/*
+ *   it clean the context of all onboardings in the list
+ */
+export async function cleanSetup(onboardings: OnboardingInfo[], globalContext: ContextUI) {
+  // reset onboarding on backend
+  await window.resetOnboarding(onboardings.map(onboarding => onboarding.extension));
+  // clean ui context
+  const contextValues = globalContext.collectAllValues();
+  onboardings.forEach(onboarding => {
+    // remove context key added during the onboarding
+    for (const key in contextValues) {
+      if (key.startsWith(`${onboarding.extension}.${SCOPE_ONBOARDING}`)) {
+        globalContext.removeValue(key);
+      }
+    }
+    onboarding.status = undefined;
+    onboarding.steps.forEach(step => {
+      step.status = undefined;
+    });
+  });
+}


### PR DESCRIPTION
### What does this PR do?

This PR changes how we verify if the step is completed.

Before: every time a command was executed, the function `assertStepCompleted` (which checks if we can progress to the next step) had to be called. The problem was that if you forgot to call this somewhere (like in the onboarding component) the onboarding could be blocked.

This PR: after a command at step activation is executed it calls a function which verifies if the step must be considered completed with just the execution of the command itself.
Furthermore, everytime the context updates we check if the active step is completed (a context value has been updated? we'll see if it was a requirement to mark the step as completed)

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

it closes #3972 

### How to test this PR?

1. when you create a new machine, after its completion, you should be redirected to the podman setup completed step.
