### PR TITLE
fix: display correct usage of image in image details page

### DIFF
--- a/packages/renderer/src/lib/image/ImageDetails.svelte
+++ b/packages/renderer/src/lib/image/ImageDetails.svelte
@@ -14,6 +14,7 @@ import PushImageModal from './PushImageModal.svelte';
 import RenameImageModal from './RenameImageModal.svelte';
 import DetailsPage from '../ui/DetailsPage.svelte';
 import Tab from '../ui/Tab.svelte';
+import { containersInfos } from '/@/stores/containers';
 
 export let imageID: string;
 export let engineId: string;
@@ -44,7 +45,7 @@ onMount(() => {
     const matchingImage = images.find(c => c.Id === imageID && c.engineId === engineId);
     let tempImage;
     if (matchingImage) {
-      tempImage = imageUtils.getImageInfoUI(matchingImage, base64RepoTag);
+      tempImage = imageUtils.getImageInfoUI(matchingImage, base64RepoTag, $containersInfos);
     }
     if (tempImage) {
       image = tempImage;

--- a/packages/renderer/src/lib/image/image-utils.ts
+++ b/packages/renderer/src/lib/image/image-utils.ts
@@ -131,8 +131,12 @@ export class ImageUtils {
     return window.deleteImage(image.engineId, imageId);
   }
 
-  getImageInfoUI(imageInfo: ImageInfo, base64RepoTag: string): ImageInfoUI | undefined {
-    const images = this.getImagesInfoUI(imageInfo, []);
+  getImageInfoUI(
+    imageInfo: ImageInfo,
+    base64RepoTag: string,
+    containersInfo: ContainerInfo[],
+  ): ImageInfoUI | undefined {
+    const images = this.getImagesInfoUI(imageInfo, containersInfo);
     return images.find(image => image.base64RepoTag === base64RepoTag);
   }
 }

--- a/packages/renderer/src/lib/images/StatusIcon.svelte
+++ b/packages/renderer/src/lib/images/StatusIcon.svelte
@@ -18,6 +18,7 @@ $: solid = status === 'RUNNING' || status === 'STARTING' || status === 'USED' ||
     class:border-2="{!solid}"
     class:border-gray-700="{!solid}"
     class:text-gray-700="{!solid}"
+    role="status"
     title="{status}">
     {#if typeof icon === 'string'}
       <span class="{icon}" aria-hidden="true"></span>


### PR DESCRIPTION
### What does this PR do?
display correct usage of image in image details page
until now it was always 'not used' in the details

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast 
explaining what is doing this PR -->

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/1504

### How to test this PR?

Unit tests provided
but you can try use-case of the reported issue https://github.com/containers/podman-desktop/issues/1504
