### PR TITLE
docs: update documentation highlights in the footer

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -171,12 +171,16 @@ const config = {
             title: 'Documentation',
             items: [
               {
-                label: 'Introduction',
-                to: '/docs/intro',
-              },
-              {
                 label: 'Installing Podman Desktop',
                 to: '/docs/Installation',
+              },
+              {
+                label: 'Onboarding for containers',
+                to: '/docs/onboarding/containers',
+              },
+              {
+                label: 'Onboarding for Kubernetes',
+                to: '/docs/onboarding/kubernetes',
               },
               {
                 label: 'Working with containers',
@@ -187,8 +191,12 @@ const config = {
                 to: '/docs/migrating-from-docker',
               },
               {
-                label: 'Using Compose',
+                label: 'Working with Compose',
                 to: '/docs/compose',
+              },
+              {
+                label: 'Working with Kubernetes',
+                to: '/docs/kubernetes',
               },
               {
                 label: 'Troubleshooting',


### PR DESCRIPTION
### What does this PR do?

docs: update documentation highlights in the footer

- Removed _Intro_.
- Added _Onboarding for containers_.
- Added _Onboarding for Kubernetes_.
- Added _Working with Kubernetes_.

### What issues does this PR fix or reference?

references #3790





