### PR TITLE
fix: change redirection based on onboarding state (#3700)

### DIFF
--- a/extensions/podman/package.json
+++ b/extensions/podman/package.json
@@ -214,7 +214,8 @@
           "when": "!onboardingContext:podmanIsNotInstalled",
           "state": "completed"
         }
-      ]
+      ],
+      "enablement": "(isLinux && onboardingContext:podmanIsNotInstalled) || !onboardingContext:podmanMachineExists"
     }
   },
   "scripts": {

--- a/packages/main/src/plugin/api/onboarding.ts
+++ b/packages/main/src/plugin/api/onboarding.ts
@@ -54,6 +54,7 @@ export interface Onboarding {
   description?: string;
   media?: { path: string; altText: string };
   steps: OnboardingStep[];
+  enablement: string;
 }
 
 export interface OnboardingInfo extends Onboarding {

--- a/packages/main/src/plugin/onboarding-registry.spec.ts
+++ b/packages/main/src/plugin/onboarding-registry.spec.ts
@@ -64,6 +64,7 @@ beforeEach(() => {
             completionEvents: ['onCommand:podman.onboarding.checkPodmanInstalled'],
           },
         ],
+        enablement: 'true',
       },
     },
   };

--- a/packages/renderer/src/lib/onboarding/Onboarding.spec.ts
+++ b/packages/renderer/src/lib/onboarding/Onboarding.spec.ts
@@ -47,6 +47,7 @@ test('Expect to have the "Try again" and Cancel buttons if the step represent a 
           completionEvents: [],
         },
       ],
+      enablement: 'true',
     },
   ]);
   context.set(new ContextUI());
@@ -77,6 +78,7 @@ test('Expect not to have the "Try again" and "Cancel" buttons if the step repres
           completionEvents: [],
         },
       ],
+      enablement: 'true',
     },
   ]);
   context.set(new ContextUI());
@@ -107,6 +109,7 @@ test('Expect to have the "step body" div if the step does not include a componen
           completionEvents: [],
         },
       ],
+      enablement: 'true',
     },
   ]);
   context.set(new ContextUI());
@@ -136,6 +139,7 @@ test('Expect to have the embedded component if the step includes a component', a
           completionEvents: [],
         },
       ],
+      enablement: 'true',
     },
   ]);
   context.set(new ContextUI());

--- a/packages/renderer/src/lib/onboarding/onboarding-utils.spec.ts
+++ b/packages/renderer/src/lib/onboarding/onboarding-utils.spec.ts
@@ -78,6 +78,7 @@ test('Expect cleanContext to remove onboarding values from context and reset the
     ],
     title: 'onboarding',
     status: 'completed',
+    enablement: 'true',
   };
   const context = new ContextUI();
   context.setValue('id.onboarding.key1', 'value');
@@ -109,6 +110,7 @@ test('Expect that the onboarding is not completed if atleast one step has not be
     ],
     title: 'onboarding',
     status: 'skipped',
+    enablement: 'true',
   };
   const complete = isOnboardingCompleted(onboarding);
   expect(complete).toBeFalsy();
@@ -131,6 +133,7 @@ test('Expect that the onboarding is not completed if its status is not set', asy
     ],
     title: 'onboarding',
     status: undefined,
+    enablement: 'true',
   };
   const complete = isOnboardingCompleted(onboarding);
   expect(complete).toBeFalsy();
@@ -153,6 +156,7 @@ test('Expect that the onboarding is completed if all its steps are completed and
     ],
     title: 'onboarding',
     status: 'completed',
+    enablement: 'true',
   };
   const complete = isOnboardingCompleted(onboarding);
   expect(complete).toBeTruthy();
@@ -175,6 +179,7 @@ test('Expect the setup of multiple onboardings to be completed if all have been 
     ],
     title: 'onboarding',
     status: 'completed',
+    enablement: 'true',
   };
   const onboarding2: OnboardingInfo = {
     extension: 'id',
@@ -192,6 +197,7 @@ test('Expect the setup of multiple onboardings to be completed if all have been 
     ],
     title: 'onboarding',
     status: 'completed',
+    enablement: 'true',
   };
   const complete = isOnboardingsSetupCompleted([onboarding1, onboarding2]);
   expect(complete).toBeTruthy();
@@ -214,6 +220,7 @@ test('Expect the setup of multiple onboardings to be uncompleted if atleast one 
     ],
     title: 'onboarding',
     status: 'completed',
+    enablement: 'true',
   };
   const onboarding2: OnboardingInfo = {
     extension: 'id',
@@ -231,6 +238,7 @@ test('Expect the setup of multiple onboardings to be uncompleted if atleast one 
     ],
     title: 'onboarding',
     status: undefined,
+    enablement: 'true',
   };
   const complete = isOnboardingsSetupCompleted([onboarding1, onboarding2]);
   expect(complete).toBeFalsy();
@@ -255,6 +263,7 @@ test('Expect the step to be completed if the active step have not completion eve
     ],
     title: 'onboarding',
     status: undefined,
+    enablement: 'true',
   };
   const activeStep: ActiveOnboardingStep = {
     onboarding,
@@ -284,6 +293,7 @@ test('Expect the step to be completed if the step is considered completed if onl
     ],
     title: 'onboarding',
     status: undefined,
+    enablement: 'true',
   };
   const activeStep: ActiveOnboardingStep = {
     onboarding,
@@ -313,6 +323,7 @@ test('Expect the step to NOT be completed if the step is considered completed if
     ],
     title: 'onboarding',
     status: undefined,
+    enablement: 'true',
   };
   const activeStep: ActiveOnboardingStep = {
     onboarding,
@@ -342,6 +353,7 @@ test('Expect the step to be completed if the step is considered completed if a c
     ],
     title: 'onboarding',
     status: undefined,
+    enablement: 'true',
   };
   const activeStep: ActiveOnboardingStep = {
     onboarding,
@@ -376,6 +388,7 @@ test('Expect the step to NOT be completed if the step is considered completed if
     ],
     title: 'onboarding',
     status: undefined,
+    enablement: 'true',
   };
   const activeStep: ActiveOnboardingStep = {
     onboarding,
@@ -410,6 +423,7 @@ test('Expect the step to NOT be completed if the step is considered completed if
     ],
     title: 'onboarding',
     status: undefined,
+    enablement: 'true',
   };
   const activeStep: ActiveOnboardingStep = {
     onboarding,
@@ -443,6 +457,7 @@ test('Expect the step to NOT be completed if the step is considered completed if
     ],
     title: 'onboarding',
     status: undefined,
+    enablement: 'true',
   };
   const activeStep: ActiveOnboardingStep = {
     onboarding,
@@ -473,6 +488,7 @@ test('Expect the step status to be updated but not the onboarding as it is not t
     ],
     title: 'onboarding',
     status: undefined,
+    enablement: 'true',
   };
   await updateOnboardingStepStatus(onboarding, step, 'completed');
   expect(step.status).equal('completed');
@@ -493,6 +509,7 @@ test('Expect the step and the onboarding status to be updated as it is the last 
     steps: [step],
     title: 'onboarding',
     status: undefined,
+    enablement: 'true',
   };
   await updateOnboardingStepStatus(onboarding, step, 'completed');
   expect(step.status).equal('completed');

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.spec.ts
@@ -241,6 +241,7 @@ test('Expect to redirect to onboarding page if setup button is clicked', async (
     extension: 'id',
     steps: [],
     title: 'onboarding',
+    enablement: 'true',
   };
   onboardingList.set([onboarding]);
   render(PreferencesResourcesRendering, {});
@@ -249,4 +250,54 @@ test('Expect to redirect to onboarding page if setup button is clicked', async (
   await userEvent.click(button);
   // redirect to create new page
   expect(router.goto).toHaveBeenCalledWith(`/preferences/onboarding/id`);
+});
+
+test('Expect to redirect to extension preferences page if onboarding is disabled and the cog button is clicked', async () => {
+  // clone providerInfo and change id and status
+  const customProviderInfo: ProviderInfo = { ...providerInfo };
+  // remove display name
+  customProviderInfo.containerProviderConnectionCreationDisplayName = undefined;
+  customProviderInfo.status = 'installed';
+  // change name of the provider
+  customProviderInfo.name = 'foo-provider';
+  providerInfos.set([customProviderInfo]);
+
+  const onboarding: OnboardingInfo = {
+    extension: 'id',
+    steps: [],
+    title: 'onboarding',
+    enablement: 'false',
+  };
+  onboardingList.set([onboarding]);
+  render(PreferencesResourcesRendering, {});
+  const button = screen.getByRole('button', { name: 'Setup foo-provider' });
+  expect(button).toBeInTheDocument();
+  await userEvent.click(button);
+  // redirect to create new page
+  expect(router.goto).toHaveBeenCalledWith('/preferences/default/preferences.id');
+});
+
+test('Expect to redirect to extension onboarding page if onboarding is enabled and the cog button is clicked', async () => {
+  // clone providerInfo and change id and status
+  const customProviderInfo: ProviderInfo = { ...providerInfo };
+  // remove display name
+  customProviderInfo.containerProviderConnectionCreationDisplayName = undefined;
+  customProviderInfo.status = 'installed';
+  // change name of the provider
+  customProviderInfo.name = 'foo-provider';
+  providerInfos.set([customProviderInfo]);
+
+  const onboarding: OnboardingInfo = {
+    extension: 'id',
+    steps: [],
+    title: 'onboarding',
+    enablement: 'true',
+  };
+  onboardingList.set([onboarding]);
+  render(PreferencesResourcesRendering, {});
+  const button = screen.getByRole('button', { name: 'Setup foo-provider' });
+  expect(button).toBeInTheDocument();
+  await userEvent.click(button);
+  // redirect to create new page
+  expect(router.goto).toHaveBeenCalledWith('/preferences/onboarding/id');
 });


### PR DESCRIPTION
### What does this PR do?

This PR adds a new state to the onboarding (enabled an disabled) which allows Podman Desktop to know if it needs to redirect the user to the onboarding or not when clicking on the cog icon. 

By following the different use cases from https://github.com/containers/podman-desktop/issues/3700#issuecomment-1725823239 , the podman extension enable/disable its own onboarding.

This will also come in handy when we need to show the different onboarding workflows when Podman Desktop is opened first time. Maybe you already have podman and a podman machine so it does not make sense for you to start it and we make it unclickable or hide it

### Screenshot/screencast of this PR

This is an example of different redirection. 
At start i have podman installed and a podman machine so i'm redirected to the extension setting page, then i remove the machine and i see the onboarding.

![cog_icon_redirect](https://github.com/containers/podman-desktop/assets/49404737/dfb5fb48-90ae-45de-98b3-f3481339b775)

### What issues does this PR fix or reference?

This is a part of #3700 
I'll update the page title in a follow-up PR

### How to test this PR?

1. have  podman and a podman machine and click on the cog icon, see you'reredirected to the settings page
2. delete the podman machine (wait a couple of seconds as the UI needs to receive the event that the onboarding state has been update), click the cog icon again. You should see the onboarding step
