### PR TITLE
fix: make min-height=0px for tabs on container details page

### DIFF
--- a/packages/renderer/src/lib/ui/DetailsPage.svelte
+++ b/packages/renderer/src/lib/ui/DetailsPage.svelte
@@ -50,7 +50,7 @@ export function close(): void {
     <div class="flex flex-row px-2 border-b border-charcoal-400">
       <slot name="tabs" />
     </div>
-    <div class="h-full bg-charcoal-900">
+    <div class="h-full bg-charcoal-900" style="min-height:0px">
       <slot name="content" />
     </div>
   </div>

--- a/packages/renderer/src/lib/ui/DetailsPage.svelte
+++ b/packages/renderer/src/lib/ui/DetailsPage.svelte
@@ -50,7 +50,7 @@ export function close(): void {
     <div class="flex flex-row px-2 border-b border-charcoal-400">
       <slot name="tabs" />
     </div>
-    <div class="h-full bg-charcoal-900" style="min-height:0px">
+    <div class="h-full bg-charcoal-900 min-h-0">
       <slot name="content" />
     </div>
   </div>


### PR DESCRIPTION
### What does this PR do?

Fix #3992.

### Screenshot/screencast of this PR

https://github.com/containers/podman-desktop/assets/620330/22ac6eb0-eb4d-4daf-bfcc-0473cad40577

### What issues does this PR fix or reference?

Fix #3992.

### How to test this PR?

See #3992 screen recording to replicate.
