### PR TITLE
fix: kind installer/Resource not present

### DIFF
--- a/extensions/podman/src/extension.spec.ts
+++ b/extensions/podman/src/extension.spec.ts
@@ -164,7 +164,6 @@ test('verify create command called with correct values', async () => {
     getPodmanCli(),
     ['machine', 'init', '--cpus', '2', '--memory', '999', '--disk-size', '232', '--image-path', 'path'],
     {
-      env: {},
       logger: undefined,
       token: undefined,
     },
@@ -201,7 +200,6 @@ test('verify create command called with correct values with user mode networking
     '--user-mode-networking',
   ];
   expect(spyExecPromise).toBeCalledWith(getPodmanCli(), parameters, {
-    env: {},
     logger: undefined,
   });
   expect(console.error).not.toBeCalled();

--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -1162,27 +1162,7 @@ export async function createMachine(
     parameters.push('--now');
   }
 
-  // Add proxy environment variables if proxy is enabled
-  const proxyEnabled = extensionApi.proxy.isEnabled();
-  const env = {};
-  if (proxyEnabled) {
-    const proxySettings = extensionApi.proxy.getProxySettings();
-    if (proxySettings?.httpProxy) {
-      if (isWindows()) {
-        env['env:http_proxy'] = proxySettings.httpProxy;
-      } else {
-        env['http_proxy'] = proxySettings.httpProxy;
-      }
-    }
-    if (proxySettings?.httpsProxy) {
-      if (isWindows()) {
-        env['env:https_proxy'] = proxySettings.httpsProxy;
-      } else {
-        env['https_proxy'] = proxySettings.httpsProxy;
-      }
-    }
-  }
-  await extensionApi.process.exec(getPodmanCli(), parameters, { logger, env, token });
+  await extensionApi.process.exec(getPodmanCli(), parameters, { logger, token });
   extensionApi.context.setValue('podmanMachineExists', true, 'onboarding');
 }
 

--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
     "postcss-import": "^15.1.0",
     "prettier": "^3.0.3",
     "prettier-plugin-svelte": "^3.0.3",
+    "proxy": "^2.1.1",
     "typescript": "5.2.2",
     "validator": "^13.11.0",
     "vite": "^4.4.9",
@@ -151,6 +152,7 @@
     "stream-json": "^1.8.0",
     "tar": "^6.2.0",
     "tar-fs": "^3.0.4",
+    "undici": "^5.25.1",
     "win-ca": "^3.5.0",
     "yaml": "^2.3.2",
     "zip-local": "^0.3.5"

--- a/packages/main/src/plugin/proxy-resolver.ts
+++ b/packages/main/src/plugin/proxy-resolver.ts
@@ -47,18 +47,18 @@ function createProxyAgent(secure: boolean, proxyUrl: string) {
     proxy: proxyUrl,
   };
   return secure
-    ? new HttpsProxyAgent(options as HttpProxyAgentOptions)
-    : new HttpProxyAgent(options as HttpsProxyAgentOptions);
+    ? new HttpsProxyAgent(options as HttpsProxyAgentOptions)
+    : new HttpProxyAgent(options as HttpProxyAgentOptions);
 }
 
-function getProxyUrl(proxy: Proxy): string | undefined {
+export function getProxyUrl(proxy: Proxy): string | undefined {
   if (proxy.isEnabled()) {
     // use HTTPS proxy if it is configured, because HTTPS proxy works for both HTTP/HTTPS
     // servers
     if (proxy.proxy?.httpsProxy) {
-      return proxy.proxy?.httpsProxy;
+      return `https://${proxy.proxy?.httpsProxy}`;
     }
-    return proxy.proxy?.httpProxy;
+    return `http://${proxy.proxy?.httpProxy}`;
   }
 }
 

--- a/packages/main/src/plugin/proxy.spec.ts
+++ b/packages/main/src/plugin/proxy.spec.ts
@@ -1,0 +1,78 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { expect, test, vi } from 'vitest';
+import { Proxy } from '/@/plugin/proxy.js';
+import type { ConfigurationRegistry } from '/@/plugin/configuration-registry.js';
+import * as http from 'http';
+import { createProxy, type ProxyServer } from 'proxy';
+import type { AddressInfo } from 'net';
+
+const URL = 'https://podman-desktop.io';
+
+function getConfigurationRegistry(
+  enabled: boolean,
+  http: string | undefined,
+  https: string | undefined,
+  no: string | undefined,
+): ConfigurationRegistry {
+  const get = vi.fn().mockImplementation(name => {
+    if (name === 'enabled') {
+      return enabled;
+    } else if (name === 'http') {
+      return http;
+    } else if (name === 'https') {
+      return https;
+    } else if (name === 'no') {
+      return no;
+    }
+  });
+  return {
+    registerConfigurations: vi.fn(),
+    onDidChangeConfiguration: vi.fn(),
+    getConfiguration: vi.fn().mockReturnValue({
+      get: get,
+    }),
+  } as unknown as ConfigurationRegistry;
+}
+
+async function buildProxy(): Promise<ProxyServer> {
+  return new Promise(resolve => {
+    const server = createProxy(http.createServer());
+    server.listen(0, () => resolve(server));
+  });
+}
+
+test('fetch without proxy', async () => {
+  const configurationRegistry = getConfigurationRegistry(false, undefined, undefined, undefined);
+  const proxy = new Proxy(configurationRegistry);
+  await proxy.init();
+  await fetch(URL);
+});
+
+test('fetch with http proxy', async () => {
+  const proxyServer = await buildProxy();
+  const address = proxyServer.address() as AddressInfo;
+  const configurationRegistry = getConfigurationRegistry(true, `127.0.0.1:${address.port}`, undefined, undefined);
+  const proxy = new Proxy(configurationRegistry);
+  await proxy.init();
+  let connectDone = false;
+  proxyServer.on('connect', () => (connectDone = true));
+  await fetch(URL);
+  expect(connectDone).toBeTruthy();
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -4320,6 +4320,16 @@ argparse@^2.0.1:
   resolved "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
 
+args@^5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/args/-/args-5.0.3.tgz#943256db85021a85684be2f0882f25d796278702"
+  integrity sha512-h6k/zfFgusnv3i5TU08KQkVKuCPBtL/PWQbWkHUxvJrZ2nAyeaUupneemcrgn1xmqxPQsPIzwkUhOpoqPDRZuA==
+  dependencies:
+    camelcase "5.0.0"
+    chalk "2.4.2"
+    leven "2.1.0"
+    mri "1.1.4"
+
 aria-query@5.1.3:
   version "5.1.3"
   resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-5.1.3.tgz#19db27cd101152773631396f7a95a3b58c22c35e"
@@ -4627,6 +4637,11 @@ base64-js@^1.3.1, base64-js@^1.5.1:
   resolved "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
 
+basic-auth-parser@0.0.2-1:
+  version "0.0.2-1"
+  resolved "https://registry.yarnpkg.com/basic-auth-parser/-/basic-auth-parser-0.0.2-1.tgz#f1ea575979b27af6a411921d6ff8793d9117347f"
+  integrity sha512-GFj8iVxo9onSU6BnnQvVwqvxh60UcSHJEDnIk3z4B6iOjsKSmqe+ibW0Rsz7YO7IE1HG3D3tqCNIidP46SZVdQ==
+
 batch@0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/batch/-/batch-0.6.1.tgz#dc34314f4e679318093fc760272525f94bf25c16"
@@ -4878,6 +4893,13 @@ builtin-modules@^3.3.0:
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-3.3.0.tgz#cae62812b89801e9656336e46223e030386be7b6"
   integrity sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==
 
+busboy@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/busboy/-/busboy-1.6.0.tgz#966ea36a9502e43cdb9146962523b92f531f6893"
+  integrity sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==
+  dependencies:
+    streamsearch "^1.1.0"
+
 byline@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/byline/-/byline-5.0.0.tgz#741c5216468eadc457b03410118ad77de8c1ddb1"
@@ -4982,6 +5004,11 @@ camelcase-keys@^6.2.2:
     map-obj "^4.0.0"
     quick-lru "^4.0.1"
 
+camelcase@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.0.0.tgz#03295527d58bd3cd4aa75363f35b2e8d97be2f42"
+  integrity sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA==
+
 camelcase@^5.3.1:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
@@ -5030,12 +5057,7 @@ chai@^4.3.7:
     pathval "^1.1.1"
     type-detect "^4.0.5"
 
-chalk@5.3.0:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-5.3.0.tgz#67c20a7ebef70e7f3970a01f90fa210cb6860385"
-  integrity sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==
-
-chalk@^2.0.0, chalk@^2.4.1:
+chalk@2.4.2, chalk@^2.0.0, chalk@^2.4.1:
   version "2.4.2"
   resolved "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -5043,6 +5065,11 @@ chalk@^2.0.0, chalk@^2.4.1:
     ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
+
+chalk@5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-5.3.0.tgz#67c20a7ebef70e7f3970a01f90fa210cb6860385"
+  integrity sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==
 
 chalk@^3.0.0:
   version "3.0.0"
@@ -9591,6 +9618,11 @@ lcid@^3.1.1:
   dependencies:
     invert-kv "^3.0.0"
 
+leven@2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/leven/-/leven-2.1.0.tgz#c2e7a9f772094dee9d34202ae8acce4687875580"
+  integrity sha512-nvVPLpIHUxCUoRLrFqTgSxXJ614d8AgQoWl7zPe/2VadE8+1dpU3LBhowRuBAcuwruWtOdD8oYC9jDNJjXDPyA==
+
 leven@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/leven/-/leven-3.1.0.tgz#77891de834064cccba82ae7842bb6b14a13ed7f2"
@@ -10531,6 +10563,11 @@ monaco-editor@^0.43.0:
   version "0.43.0"
   resolved "https://registry.yarnpkg.com/monaco-editor/-/monaco-editor-0.43.0.tgz#cb02a8d23d1249ad00b7cffe8bbecc2ac09d4baf"
   integrity sha512-cnoqwQi/9fml2Szamv1XbSJieGJ1Dc8tENVMD26Kcfl7xGQWp7OBKMjlwKVGYFJ3/AXJjSOGvcqK7Ry/j9BM1Q==
+
+mri@1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/mri/-/mri-1.1.4.tgz#7cb1dd1b9b40905f1fac053abe25b6720f44744a"
+  integrity sha512-6y7IjGPm8AzlvoUrwAaw1tLnUBudaS3752vcd8JtrpGGQn+rXIe63LFVHm/YMwtqAuh+LJPCFdlLYPWM1nYn6w==
 
 mri@^1.1.0:
   version "1.2.0"
@@ -11759,6 +11796,15 @@ proxy-addr@~2.0.7:
   dependencies:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
+
+proxy@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/proxy/-/proxy-2.1.1.tgz#45f9b307508ffcae12bdc71678d44a4ab79cbf8b"
+  integrity sha512-nLgd7zdUAOpB3ZO/xCkU8gy74UER7P0aihU8DkUsDS5ZoFwVCX7u8dy+cv5tVK8UaB/yminU1GiLWE26TKPYpg==
+  dependencies:
+    args "^5.0.3"
+    basic-auth-parser "0.0.2-1"
+    debug "^4.3.4"
 
 psl@^1.1.28, psl@^1.1.33:
   version "1.9.0"
@@ -13187,6 +13233,11 @@ stream-json@^1.8.0:
   dependencies:
     stream-chain "^2.2.5"
 
+streamsearch@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/streamsearch/-/streamsearch-1.1.0.tgz#404dd1e2247ca94af554e841a8ef0eaa238da764"
+  integrity sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==
+
 streamx@^2.15.0:
   version "2.15.0"
   resolved "https://registry.yarnpkg.com/streamx/-/streamx-2.15.0.tgz#f58c92e6f726b5390dcabd6dd9094d29a854d698"
@@ -14020,6 +14071,18 @@ unbox-primitive@^1.0.2:
     has-bigints "^1.0.2"
     has-symbols "^1.0.3"
     which-boxed-primitive "^1.0.2"
+
+underscore@^1.13.6:
+  version "1.13.6"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.13.6.tgz#04786a1f589dc6c09f761fc5f45b89e935136441"
+  integrity sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==
+
+undici@^5.25.1:
+  version "5.25.1"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-5.25.1.tgz#3fa537eb89a6a0bb576b395f0f7bcdedf7b8336a"
+  integrity sha512-nTw6b2G2OqP6btYPyghCgV4hSwjJlL/78FMJatVLCa3otj6PCOQSt6dVtYt82OtNqFz8XsnJ+vsXLADPXjPhqw==
+  dependencies:
+    busboy "^1.6.0"
 
 unherit@^1.0.4:
   version "1.1.3"


### PR DESCRIPTION
Fixes #2794

### What does this PR do?

Ensure libraries using NodeJS fetch implementation are proxy compatible. That would include the kind and compose extensions.

**WARNING** This part makes the assumption that the proxy configuration is either httpProxy if the proxy is using HTTP with the browser/Podman Desktop or httpsProxy if using HTTPS (ie configuring both makes no sense). Also this PR does not implement support for NO_PROXY, should be a follow up PR

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

Fixes #2794 

### How to test this PR?

1. Configure your workstation with proxy (no network access except for the proxy)
2. Remove kind or compose extensions
3. Launch Podman Desktop
4. Install kind or compose
