### PR TITLE
fix: when the next button is visible, the step is completed only when next is clicked

### DIFF
--- a/packages/renderer/src/lib/onboarding/onboarding-utils.spec.ts
+++ b/packages/renderer/src/lib/onboarding/onboarding-utils.spec.ts
@@ -236,7 +236,7 @@ test('Expect the setup of multiple onboardings to be uncompleted if atleast one 
   expect(complete).toBeFalsy();
 });
 
-test('Expect the step to be completed if the active step have not completion events', async () => {
+test('Expect the step to be considered NOT completed if the active step have not completion events', async () => {
   const step: OnboardingStep = {
     id: 'id1',
     title: 'title 1',
@@ -261,7 +261,7 @@ test('Expect the step to be completed if the active step have not completion eve
     step,
   };
   const isCompleted = isStepCompleted(activeStep, []);
-  expect(isCompleted).toBeTruthy();
+  expect(isCompleted).toBeFalsy();
 });
 
 test('Expect the step to be completed if the step is considered completed if only a command has been executed and it has actually been executed', async () => {

--- a/packages/renderer/src/lib/onboarding/onboarding-utils.ts
+++ b/packages/renderer/src/lib/onboarding/onboarding-utils.ts
@@ -53,8 +53,7 @@ export async function updateOnboardingStepStatus(
 }
 
 /**
- * it verifies if a step must be marked as completed by checking that the step does not depend on any completion event or, if any, that that they have
- * been satisfied.
+ * it verifies if a step must be marked as completed by checking that all completion events have been satisied.
  */
 export function isStepCompleted(
   activeStep: ActiveOnboardingStep,
@@ -62,9 +61,7 @@ export function isStepCompleted(
   globalContext?: ContextUI,
 ): boolean {
   return (
-    !activeStep.step.completionEvents ||
-    activeStep.step.completionEvents.length === 0 ||
-    activeStep.step.completionEvents.every(cmp => {
+    activeStep.step?.completionEvents?.every(cmp => {
       // check if command has been executed
       if (cmp.startsWith(ON_COMMAND_PREFIX) && executedCommands.includes(cmp.replace(ON_COMMAND_PREFIX, ''))) {
         return true;
@@ -81,7 +78,7 @@ export function isStepCompleted(
       }
 
       return false;
-    })
+    }) || false
   );
 }
 


### PR DESCRIPTION
### What does this PR do?

When the step have an empty completion events array we show the `Next` button, which is the only way the user have to move forward in the onboarding.

I just noticed that the `isStepCompleted`, which is called when the `context` is updated or a command has been executed, evaluates an empty completion events array as a truthy result, which is wrong.

If the completion events is empty and we show the Next button, the user has to click on it

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

N/A

### How to test this PR?

1. not sure how to test it, it happened twice while i was testing another PR. The active step is one that has an empty completion events, the context is updated and triggers a check on the active step to see if it's completed (bc the events is empty it is marked as completed) and move the user to the next one, without that the user clicked on anything.
