### PR TITLE
fix: configuration hidden property should not affect visibility in onboarding (#3977)

### DIFF
--- a/packages/main/src/plugin/configuration-registry.ts
+++ b/packages/main/src/plugin/configuration-registry.ts
@@ -62,6 +62,7 @@ export interface IConfigurationPropertySchema {
   format?: string;
   scope?: ConfigurationScope | ConfigurationScope[];
   readonly?: boolean;
+  // if hidden is true, the property is not shown in the preferences page. It may still appear in other locations if it uses other scope (like onboarding)
   hidden?: boolean;
   enum?: string[];
   when?: string;

--- a/packages/renderer/src/lib/onboarding/OnboardingItem.spec.ts
+++ b/packages/renderer/src/lib/onboarding/OnboardingItem.spec.ts
@@ -170,3 +170,36 @@ test('Expect a type text configuration placeholder to be replaced by a text inpu
   expect((input as HTMLSelectElement).name).toBe('extension.text.prop');
   expect((input as HTMLInputElement).placeholder).toBe('Example: text');
 });
+
+test('Expect a configuration to be visible in the onboarding even if hidden property is set to true', async () => {
+  const textComponent: OnboardingStepItem = {
+    value: '${configuration:extension.text.prop}',
+  };
+  configurationProperties.set([
+    {
+      parentId: '',
+      title: 'record',
+      placeholder: 'Example: text',
+      description: 'record-description',
+      extension: {
+        id: 'extension',
+      },
+      hidden: true,
+      id: 'extension.text.prop',
+      type: 'string',
+      scope: CONFIGURATION_ONBOARDING_SCOPE,
+    },
+  ]);
+  render(OnboardingItem, {
+    extension: 'extension',
+    item: textComponent,
+    getContext: vi.fn(),
+    inProgressCommandExecution: vi.fn(),
+  });
+  const input = screen.getByLabelText('record-description');
+  expect(input).toBeInTheDocument();
+  expect(input instanceof HTMLInputElement).toBe(true);
+  expect((input as HTMLInputElement).type).toBe('text');
+  expect((input as HTMLSelectElement).name).toBe('extension.text.prop');
+  expect((input as HTMLInputElement).placeholder).toBe('Example: text');
+});

--- a/packages/renderer/src/lib/onboarding/OnboardingItem.svelte
+++ b/packages/renderer/src/lib/onboarding/OnboardingItem.svelte
@@ -34,7 +34,6 @@ onMount(() => {
     if (matches.length > 0 && matches[0].length > 1) {
       configurationItem = configurationItems.find(
         config =>
-          !config.hidden &&
           isTargetScope(CONFIGURATION_ONBOARDING_SCOPE, config.scope) &&
           config.extension?.id === extension &&
           config.id === matches[0][1],


### PR DESCRIPTION
### What does this PR do?

This PR removes the effect of the hidden property for the onboarding. 
The hidden property should only affect the DEFAULT scope. 

So if you have a configuration which should be visible in an onboarding step but not in the preferences page you should add something like

```
config: {
   .....
   scope: [onboarding, DEFAULT],
   hidden: true,
   .....
```

so that its value is persisted (only scope DEFAULT values are saved) but not visible other than the onboarding

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

it resolves #3977 

### How to test this PR?

1. run tests
2. it will be used by https://github.com/containers/podman-desktop/pull/3953

