### PR TITLE
fix: properly disable boolean input when set to readonly

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.spec.ts
@@ -46,6 +46,23 @@ test('Expect to see checkbox enabled', async () => {
   expect(button).toBeChecked();
 });
 
+test('Expect to see the checkbox disabled / unable to press when readonly is passed into record', async () => {
+  const record: IConfigurationPropertyRecordedSchema = {
+    title: 'my boolean property',
+    id: 'myid',
+    parentId: '',
+    type: 'boolean',
+    default: true,
+    readonly: true,
+  };
+  // remove display name
+  render(PreferencesRenderingItemFormat, { record });
+  const button = screen.getByRole('checkbox');
+  expect(button).toBeInTheDocument();
+  expect(button).toBeChecked();
+  expect(button).toBeDisabled();
+});
+
 test('Expect to see checkbox enabled', async () => {
   const record: IConfigurationPropertyRecordedSchema = {
     title: 'my boolean property',

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
@@ -272,7 +272,7 @@ function assertNumericValueIsValid(value: number) {
           bind:checked="{checkboxValue}"
           name="{record.id}"
           type="checkbox"
-          readonly="{!!record.readonly}"
+          disabled="{!!record.readonly}"
           id="input-standard-{record.id}"
           aria-invalid="{invalidEntry}"
           aria-label="{record.description || record.markdownDescription}" />


### PR DESCRIPTION
fix: properly disable boolean input when set to readonly

### What does this PR do?

When setting readonly: true with a boolean configuration setting, you
can still toggle it true / false. This is because boolean is using
onclick for toggle.

This changes it to "disable" similar to other inputs.

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast
explaining what is doing this PR -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Fixes https://github.com/containers/podman-desktop/issues/4017

### How to test this PR?

<!-- Please explain steps to reproduce -->

Run tests, or modify a boolean configuration setting in
`package.json` by adding `"readonly": true`.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
