### PR TITLE
feat(main): handle EnvFiles parameter when creating a container

### DIFF
--- a/packages/main/src/plugin/api/container-info.ts
+++ b/packages/main/src/plugin/api/container-info.ts
@@ -77,6 +77,10 @@ export interface ContainerCreateOptions {
   User?: string;
   // Env using ["MYVAR=value", ...]
   Env?: string[];
+
+  // environment files to use
+  EnvFiles?: string[];
+
   // eslint-disable-next-line @typescript-eslint/ban-types
   ExposedPorts?: { [port: string]: {} };
   HostConfig?: HostConfig;

--- a/packages/main/src/plugin/env-file-parser.spec.ts
+++ b/packages/main/src/plugin/env-file-parser.spec.ts
@@ -182,6 +182,20 @@ test('check parseEnvFiles', async () => {
   expect(result).toEqual(['HI=FOO', 'HELLO=WORLD', 'ANOTHER=', 'YETANOTHER=VALUE']);
 });
 
+test('check parseEnvFile with comments', async () => {
+  const content1 = 'HI=FOO\n# this is a commented line\nHELLO=WORLD';
+
+  const readFileMock = vi.spyOn(promises, 'readFile');
+  readFileMock.mockResolvedValue(content1);
+
+  const statsFileMock = vi.spyOn(promises, 'stat');
+  statsFileMock.mockResolvedValue({ size: 100 } as any);
+
+  const result = await envfileParser.parseEnvFile('foo1');
+
+  expect(result).toEqual(['HI=FOO', 'HELLO=WORLD']);
+});
+
 test('check parseEnvFile and expect error with a file too big', async () => {
   // big file
   const statsFileMock = vi.spyOn(promises, 'stat');

--- a/packages/main/src/plugin/env-file-parser.spec.ts
+++ b/packages/main/src/plugin/env-file-parser.spec.ts
@@ -1,0 +1,207 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable no-useless-escape */
+
+import { test, expect, describe, vi, beforeAll } from 'vitest';
+
+import { promises } from 'node:fs';
+import { EnvfileParser } from './env-file-parser.js';
+
+let envfileParser: TestEnvfileParser;
+
+beforeAll(() => {
+  envfileParser = new TestEnvfileParser();
+});
+
+class TestEnvfileParser extends EnvfileParser {
+  public async parseEnvFile(envFile: string): Promise<string[]> {
+    return super.parseEnvFile(envFile);
+  }
+
+  public envFileCleanEntry(entry: string): { key: string | undefined; value: string | undefined } {
+    return super.envFileCleanEntry(entry);
+  }
+}
+
+// using https://docs.docker.com/compose/environment-variables/env-file/ checks
+describe('check values', () => {
+  test('simple value', () => {
+    const item = 'VAR=VAL';
+
+    const result = envfileParser.envFileCleanEntry(item);
+
+    expect(result.key).toBe('VAR');
+    expect(result.value).toBe('VAL');
+  });
+
+  test('simple value with quotes', () => {
+    const item = `VAR="VAL"`;
+
+    const result = envfileParser.envFileCleanEntry(item);
+
+    expect(result.key).toBe('VAR');
+    expect(result.value).toBe('VAL');
+  });
+
+  test('simple value with simple quotes', () => {
+    const item = `VAR='VAL'`;
+
+    const result = envfileParser.envFileCleanEntry(item);
+
+    expect(result.key).toBe('VAR');
+    expect(result.value).toBe('VAL');
+  });
+
+  test('simple value with inline comments', () => {
+    const item = `VAR=VAL # comment`;
+
+    const result = envfileParser.envFileCleanEntry(item);
+
+    expect(result.key).toBe('VAR');
+    expect(result.value).toBe('VAL');
+  });
+
+  test('simple value with not an inline comment as missing space', () => {
+    const item = `VAR=VAL# not a comment`;
+
+    const result = envfileParser.envFileCleanEntry(item);
+
+    expect(result.key).toBe('VAR');
+    expect(result.value).toBe('VAL# not a comment');
+  });
+
+  test('simple value Inline comments for quoted values must follow the closing quote', () => {
+    const item = `VAR="VAL # not a comment"`;
+
+    const result = envfileParser.envFileCleanEntry(item);
+
+    expect(result.key).toBe('VAR');
+    expect(result.value).toBe('VAL # not a comment');
+  });
+
+  test('simple value Inline comments for quoted values without follow the closing quote', () => {
+    const item = `VAR="VAL" # comment`;
+
+    const result = envfileParser.envFileCleanEntry(item);
+
+    expect(result.key).toBe('VAR');
+    expect(result.value).toBe('VAL');
+  });
+
+  test('simple value Inline comments for quoted values must follow the closing simple quote', () => {
+    const item = `VAR='VAL # not a comment'`;
+
+    const result = envfileParser.envFileCleanEntry(item);
+
+    expect(result.key).toBe('VAR');
+    expect(result.value).toBe('VAL # not a comment');
+  });
+
+  test('simple value Inline comments for quoted values without follow the closing simple quote', () => {
+    const item = `VAR='VAL' # comment`;
+
+    const result = envfileParser.envFileCleanEntry(item);
+
+    expect(result.key).toBe('VAR');
+    expect(result.value).toBe('VAL');
+  });
+
+  test('simple value single quotes values are used literally', () => {
+    const item = `VAR='$OTHER'`;
+    const result = envfileParser.envFileCleanEntry(item);
+    expect(result.key).toBe('VAR');
+    expect(result.value).toBe('$OTHER');
+  });
+
+  test('simple value single quotes values are used literally bis', () => {
+    const item = `VAR='\${OTHER}'`;
+    const result = envfileParser.envFileCleanEntry(item);
+    expect(result.key).toBe('VAR');
+    expect(result.value).toBe('${OTHER}');
+  });
+
+  test('simple quotes can be escaped with \\', () => {
+    const item = `VAR='Let\'s go!'`;
+    const result = envfileParser.envFileCleanEntry(item);
+    expect(result.key).toBe('VAR');
+    expect(result.value).toBe(`Let's go!`);
+  });
+
+  test('simple quotes can be escaped with \\ json', () => {
+    const item = `VAR="{\"hello\": \"json\"}"`;
+    const result = envfileParser.envFileCleanEntry(item);
+    expect(result.key).toBe('VAR');
+    expect(result.value).toBe(`{"hello": "json"}`);
+  });
+});
+
+test('check parseEnvFile', async () => {
+  const content = 'HI=FOO\nHELLO=WORLD';
+
+  const readFileMock = vi.spyOn(promises, 'readFile');
+  readFileMock.mockResolvedValue(content);
+
+  const statsFileMock = vi.spyOn(promises, 'stat');
+  statsFileMock.mockResolvedValue({ size: 100 } as any);
+
+  const result = await envfileParser.parseEnvFile('foo');
+
+  expect(result).toEqual(['HI=FOO', 'HELLO=WORLD']);
+});
+
+test('check parseEnvFiles', async () => {
+  const content1 = 'HI=FOO\nHELLO=WORLD';
+  const content2 = 'ANOTHER=\nYETANOTHER=VALUE';
+
+  const readFileMock = vi.spyOn(promises, 'readFile');
+  readFileMock.mockResolvedValueOnce(content1);
+  readFileMock.mockResolvedValueOnce(content2);
+
+  const statsFileMock = vi.spyOn(promises, 'stat');
+  statsFileMock.mockResolvedValue({ size: 100 } as any);
+
+  const result = await envfileParser.parseEnvFiles(['foo1', 'foo2']);
+
+  expect(result).toEqual(['HI=FOO', 'HELLO=WORLD', 'ANOTHER=', 'YETANOTHER=VALUE']);
+});
+
+test('check parseEnvFile and expect error with a file too big', async () => {
+  // big file
+  const statsFileMock = vi.spyOn(promises, 'stat');
+  statsFileMock.mockResolvedValue({ size: 2048 * 1024 } as any);
+
+  await expect(envfileParser.parseEnvFile('foo')).rejects.toThrowError(
+    'Environment file foo is too big. Maximum size is 1MB.',
+  );
+});
+
+test('check parseEnvFile and expect error with invalid entries', async () => {
+  // big file
+  const statsFileMock = vi.spyOn(promises, 'stat');
+  statsFileMock.mockResolvedValue({ size: 1024 } as any);
+
+  const content = 'hello world';
+  const readFileMock = vi.spyOn(promises, 'readFile');
+  readFileMock.mockResolvedValueOnce(content);
+
+  await expect(envfileParser.parseEnvFile('foo')).rejects.toThrowError(
+    'Environment file foo is not a valid env file. Each line should have the format KEY=VALUE, value being optional.',
+  );
+});

--- a/packages/main/src/plugin/env-file-parser.ts
+++ b/packages/main/src/plugin/env-file-parser.ts
@@ -1,0 +1,116 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { promises } from 'node:fs';
+
+export class EnvfileParser {
+  async parseEnvFiles(envFiles: string[]): Promise<string[]> {
+    const envFileContent = await Promise.all(
+      envFiles.map(async envFile => {
+        return this.parseEnvFile(envFile);
+      }),
+    );
+    const envFileContentFlatten = envFileContent.flat();
+    return envFileContentFlatten.filter(line => line !== '');
+  }
+
+  protected async parseEnvFile(envFile: string): Promise<string[]> {
+    // check size of the file
+    const stats = await promises.stat(envFile);
+    if (stats.size > 1024 * 1024) {
+      throw new Error(`Environment file ${envFile} is too big. Maximum size is 1MB.`);
+    }
+
+    const content = await promises.readFile(envFile, 'utf-8');
+
+    // each lines should have the format KEY=VALUE or be empty
+    // but it can have comments, but comments are using a # character preceded by a space
+
+    const envVariables = [];
+    // parse all the lines, one by one
+    for (const line of content.split('\n')) {
+      if (line !== '') {
+        // clean up the value to remove comments
+        const clearLine = this.envFileCleanEntry(line);
+
+        if (!clearLine.key && !clearLine.value) {
+          throw new Error(
+            `Environment file ${envFile} is not a valid env file. Each line should have the format KEY=VALUE, value being optional. Found ${line}`,
+          );
+        }
+
+        envVariables.push(`${clearLine.key}=${clearLine.value}`);
+      }
+    }
+
+    return envVariables;
+  }
+
+  protected endOfChar(value: string, char: string): [boolean, number] {
+    let endsWithChar = false;
+    let index = 1;
+    while (!endsWithChar && index < value.length) {
+      if (value[index] === char && value[index - 1] !== '\\') {
+        endsWithChar = true;
+      } else {
+        index++;
+      }
+    }
+    return [endsWithChar, index];
+  }
+
+  protected envFileCleanEntry(entry: string): { key: string | undefined; value: string | undefined } {
+    // do we have a = in the entry ?
+    if (!entry.includes('=')) {
+      return { key: undefined, value: undefined };
+    }
+
+    const [key, value] = entry.split('=');
+
+    let updatedValue = value;
+
+    // do we have quotes around value ?
+    if ((value?.startsWith('"') && value?.endsWith('"')) || (value?.startsWith(`'`) && value?.endsWith(`'`))) {
+      // remove the quotes around
+      updatedValue = value.substring(1, value.length - 1);
+    } else if (value?.startsWith('"')) {
+      // we have starting quotes, try to see where it ends without being an escaped quote like \'
+      // iterate all the string to find the end of the quotes
+      const endOfQuotes = this.endOfChar(value, '"');
+
+      if (endOfQuotes[0]) {
+        updatedValue = value.substring(1, endOfQuotes[1]);
+      }
+    } else if (value?.startsWith(`'`)) {
+      const endOfSimpleQuotes = this.endOfChar(value, `'`);
+      if (endOfSimpleQuotes[0]) {
+        updatedValue = value.substring(1, endOfSimpleQuotes[1]);
+      }
+    } else {
+      // if there is a comment, and that it is preceded by a space, remove it
+      if (updatedValue?.includes(' #')) {
+        updatedValue = updatedValue.split(' #')[0];
+      }
+    }
+
+    return {
+      key: key.trim(),
+      value: updatedValue?.replace(/\\"/g, '"'),
+    };
+  }
+}

--- a/packages/main/src/plugin/env-file-parser.ts
+++ b/packages/main/src/plugin/env-file-parser.ts
@@ -44,7 +44,8 @@ export class EnvfileParser {
     const envVariables = [];
     // parse all the lines, one by one
     for (const line of content.split('\n')) {
-      if (line !== '') {
+      // skip empty lines and commented lines
+      if (line !== '' && !line.startsWith('#')) {
         // clean up the value to remove comments
         const clearLine = this.envFileCleanEntry(line);
 


### PR DESCRIPTION
### What does this PR do?
when receiving an EnvFile parameter when creating a container, read the file and add the properties to Env object

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast 
explaining what is doing this PR -->

### What issues does this PR fix or reference?

related to https://github.com/containers/podman-desktop/issues/3281

### How to test this PR?

unit tests added

use the PR https://github.com/containers/podman-desktop/pull/4026
