### PR TITLE
feat: allow to use context syntax in onboarding titles and descriptions (#3820)

### DIFF
--- a/packages/main/src/plugin/context/context.ts
+++ b/packages/main/src/plugin/context/context.ts
@@ -62,7 +62,11 @@ export class Context implements IContext {
   }
 
   getValue<T>(key: string): T | undefined {
-    return this._value[key] || this.getDottedKeyValue(key);
+    const contextValue = this._value[key];
+    if (contextValue !== undefined) {
+      return contextValue;
+    }
+    return this.getDottedKeyValue(key);
   }
 
   /**

--- a/packages/renderer/src/lib/context/context.spec.ts
+++ b/packages/renderer/src/lib/context/context.spec.ts
@@ -19,6 +19,14 @@
 import { expect, test } from 'vitest';
 import { ContextUI } from './context';
 
+test('check that a false value is correctly returned', async () => {
+  const context = new ContextUI();
+  context.setValue('key', 'false');
+
+  const value = context.getValue('key');
+  expect(value).toBe('false');
+});
+
 test('check that value is correctly returned', async () => {
   const context = new ContextUI();
   context.setValue('key', 'value');

--- a/packages/renderer/src/lib/context/context.ts
+++ b/packages/renderer/src/lib/context/context.ts
@@ -51,7 +51,11 @@ export class ContextUI implements IContext {
   }
 
   getValue<T>(key: string): T | undefined {
-    return this._value[key] || this.getDottedKeyValue(key);
+    const contextValue = this._value[key];
+    if (contextValue !== undefined) {
+      return contextValue;
+    }
+    return this.getDottedKeyValue(key);
   }
 
   /**

--- a/packages/renderer/src/lib/onboarding/Onboarding.svelte
+++ b/packages/renderer/src/lib/onboarding/Onboarding.svelte
@@ -20,6 +20,7 @@ import {
   isOnboardingsSetupCompleted,
   normalizeOnboardingWhenClause,
   cleanSetup,
+  replaceContextKeyPlaceholders,
 } from './onboarding-utils';
 import { lastPage } from '/@/stores/breadcrumb';
 import Button from '../ui/Button.svelte';
@@ -229,9 +230,17 @@ async function restartSetup() {
             src="{activeStep.onboarding.media.path}" />
         {/if}
         <div class="flex flex-col ml-8 my-2">
-          <div class="text-lg font-bold text-white">{activeStep.onboarding.title}</div>
+          <div class="text-lg font-bold text-white">
+            {replaceContextKeyPlaceholders(activeStep.onboarding.title, activeStep.onboarding.extension, globalContext)}
+          </div>
           {#if activeStep.onboarding.description}
-            <div class="text-sm text-white">{activeStep.onboarding.description}</div>
+            <div class="text-sm text-white">
+              {replaceContextKeyPlaceholders(
+                activeStep.onboarding.description,
+                activeStep.onboarding.extension,
+                globalContext,
+              )}
+            </div>
           {/if}
           <button
             class="flex flex-row text-xs items-center hover:underline"
@@ -269,10 +278,14 @@ async function restartSetup() {
               <Spinner />
             </div>
           {/if}
-          <div class="text-lg text-white">{activeStep.step.title}</div>
+          <div class="text-lg text-white">
+            {replaceContextKeyPlaceholders(activeStep.step.title, activeStep.onboarding.extension, globalContext)}
+          </div>
         </div>
         {#if activeStep.step.description}
-          <div class="text-sm text-white mx-auto">{activeStep.step.description}</div>
+          <div class="text-sm text-white mx-auto">
+            {replaceContextKeyPlaceholders(activeStep.step.description, activeStep.onboarding.extension, globalContext)}
+          </div>
         {/if}
       </div>
 


### PR DESCRIPTION
### What does this PR do?

This PR moves the already existing functions that replace context key placeholders (like `onboardingContext:contextKey`) into the onboarding-utils.ts so that they can be called from other location (onboarding title/description, onboarding step title/description)

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

it resolves #3820 

### How to test this PR?

1. run tests or edit one step title in the podman onboarding to display a context value like `${onboardingContext:podmanIsNotInstalled}`
