### PR TITLE
fix: update podman installation message based if already or just installed (#3700)

### DIFF
--- a/extensions/podman/package.json
+++ b/extensions/podman/package.json
@@ -184,7 +184,7 @@
         },
         {
           "id": "podmanInstalled",
-          "title": "Podman successfully installed",
+          "title": "${onboardingContext:podmanInstalledTitle}",
           "when": "!onboardingContext:podmanIsNotInstalled",
           "content": [
             [

--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -942,6 +942,11 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
       const installation = await getPodmanInstallation();
       const installed = installation ? true : false;
       extensionApi.context.setValue('podmanIsNotInstalled', !installed, 'onboarding');
+      if (installed) {
+        extensionApi.context.setValue('podmanInstalledTitle', 'Podman already installed', 'onboarding');
+      } else {
+        extensionApi.context.setValue('podmanInstalledTitle', 'Podman successfully installed', 'onboarding');
+      }
     },
   );
 


### PR DESCRIPTION
### What does this PR do?

This is the second part of #3700 
Now the podman title is created based if the installation has been performed during the onboarding or it was already installed.

### Screenshot/screencast of this PR

![customize_title_onboarding](https://github.com/containers/podman-desktop/assets/49404737/edfcf6c6-2024-4cc7-b9b8-91e2a98a9b87)

### What issues does this PR fix or reference?

it resolves #3700 

### How to test this PR?

1. uninstall podman
2. run the onboarding, you should see "Podman successfully installed" after the installation completes.
3. exit from the onboarding without creating a podman machine
4. click the cog icon
5. you should see the title "Podman already installed"
