### PR TITLE
feat(extension): allow to run admin tasks from extensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -149,6 +149,7 @@
     "moment": "^2.29.4",
     "os-locale": "^6.0.2",
     "stream-json": "^1.8.0",
+    "sudo-prompt": "^9.2.1",
     "tar": "^6.2.0",
     "tar-fs": "^3.0.4",
     "win-ca": "^3.5.0",

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -2014,6 +2014,11 @@ declare module '@podman-desktop/api' {
      * custom directory
      */
     cwd?: string;
+
+    /**
+     * admin privileges required
+     */
+    isAdmin?: boolean;
   }
 
   /**


### PR DESCRIPTION
### What does this PR do?
I noticed several extensions have some code to run admin tasks using like sudo-prompt, or pkexec

here it brings a new parameter isAdmin in the exec API so extensions can run admin tasks

it uses for macOS osascript allowing to use touch ID

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast 
explaining what is doing this PR -->

### What issues does this PR fix or reference?

pre-req for #2998 

### How to test this PR?

there are some unit tests but the clients of this API are in
https://github.com/containers/podman-desktop/pull/4050

