### PR TITLE
feat: allow to use touchid on macOS for admin tasks

### DIFF
--- a/extensions/compose/package.json
+++ b/extensions/compose/package.json
@@ -30,8 +30,7 @@
   "dependencies": {
     "@octokit/rest": "^20.0.1",
     "mustache": "^4.2.0",
-    "shell-path": "^3.0.0",
-    "sudo-prompt": "^9.2.1"
+    "shell-path": "^3.0.0"
   },
   "devDependencies": {
     "7zip-min": "^1.4.3",

--- a/extensions/compose/src/cli-run.ts
+++ b/extensions/compose/src/cli-run.ts
@@ -19,10 +19,9 @@
 import { spawn } from 'node:child_process';
 import { resolve } from 'node:path';
 import * as path from 'node:path';
-import * as sudo from 'sudo-prompt';
 import * as os from 'node:os';
 import * as fs from 'node:fs';
-import type * as extensionApi from '@podman-desktop/api';
+import * as extensionApi from '@podman-desktop/api';
 import type { OS } from './os';
 
 export interface SpawnResult {
@@ -126,10 +125,6 @@ export class CliRun {
   }
 
   // Takes a binary path (e.g. /tmp/docker-compose) and installs it to the system. Renames it based on binaryName
-  // supports Windows, Linux and macOS
-  // If using Windows or Mac, we will use sudo-prompt in order to elevate the privileges
-  // If using Linux, we'll use pkexec and polkit support to ask for privileges.
-  // When running in a flatpak, we'll use flatpak-spawn to execute the command on the host
   async installBinaryToSystem(binaryPath: string, binaryName: string): Promise<void> {
     const system = process.platform;
 
@@ -146,50 +141,31 @@ export class CliRun {
     // Create the appropriate destination path (Windows uses AppData/Local, Linux and Mac use /usr/local/bin)
     // and the appropriate command to move the binary to the destination path
     let destinationPath: string;
-    let command: string[];
+    let args: string[];
+    let command: string;
     if (system === 'win32') {
       destinationPath = path.join(os.homedir(), 'AppData', 'Local', 'Microsoft', 'WindowsApps', `${binaryName}.exe`);
-      command = ['copy', `"${binaryPath}"`, `"${destinationPath}"`];
+      command = 'copy';
+      args = [`"${binaryPath}"`, `"${destinationPath}"`];
     } else {
       destinationPath = path.join(localBinDir, binaryName);
-      command = ['cp', binaryPath, destinationPath];
+      command = 'exec';
+      args = ['cp', binaryPath, destinationPath];
     }
 
     // If on macOS or Linux, check to see if the /usr/local/bin directory exists,
     // if it does not, then add mkdir -p /usr/local/bin to the start of the command when moving the binary.
     if ((system === 'linux' || system === 'darwin') && !fs.existsSync(localBinDir)) {
-      command.unshift('mkdir', '-p', localBinDir, '&&');
+      args.unshift('mkdir', '-p', localBinDir, '&&');
     }
 
-    // If windows or mac, use sudo-prompt to elevate the privileges
-    // if Linux, use sudo and polkit support
-    if (system === 'win32' || system === 'darwin') {
-      return new Promise<void>((resolve, reject) => {
-        // Convert the command array to a string for sudo prompt
-        // the name is used for the prompt
-        const sudoOptions = {
-          name: 'Binary Installation',
-        };
-        const sudoCommand = command.join(' ');
-        sudo.exec(sudoCommand, sudoOptions, error => {
-          if (error) {
-            console.error(`Failed to install '${binaryName}' binary: ${error}`);
-            reject(error);
-          } else {
-            console.log(`Successfully installed '${binaryName}' binary.`);
-            resolve();
-          }
-        });
-      });
-    } else {
-      try {
-        // Use pkexec in order to elevate the prileges / ask for password for copying to /usr/local/bin
-        await this.runCommand('pkexec', command);
-        console.log(`Successfully installed '${binaryName}' binary.`);
-      } catch (error) {
-        console.error(`Failed to install '${binaryName}' binary: ${error}`);
-        throw error;
-      }
+    try {
+      // Use admin prileges / ask for password for copying to /usr/local/bin
+      await extensionApi.process.exec(command, args, { isAdmin: true });
+      console.log(`Successfully installed '${binaryName}' binary.`);
+    } catch (error) {
+      console.error(`Failed to install '${binaryName}' binary: ${error}`);
+      throw error;
     }
   }
 }

--- a/extensions/kind/package.json
+++ b/extensions/kind/package.json
@@ -104,7 +104,6 @@
     "@octokit/rest": "^20.0.1",
     "@podman-desktop/api": "^0.0.1",
     "mustache": "^4.2.0",
-    "sudo-prompt": "^9.2.1",
     "yaml": "^2.3.2"
   },
   "devDependencies": {

--- a/extensions/podman/package.json
+++ b/extensions/podman/package.json
@@ -227,8 +227,7 @@
   "dependencies": {
     "@ltd/j-toml": "^1.38.0",
     "@podman-desktop/api": "^0.0.1",
-    "compare-versions": "^6.1.0",
-    "sudo-prompt": "^9.2.1"
+    "compare-versions": "^6.1.0"
   },
   "devDependencies": {
     "7zip-min": "^1.4.4",

--- a/extensions/podman/src/compatibility-mode.spec.ts
+++ b/extensions/podman/src/compatibility-mode.spec.ts
@@ -35,11 +35,6 @@ vi.mock('@podman-desktop/api', () => {
   };
 });
 
-// macOS tests
-vi.mock('runSudoMacHelperCommand', () => {
-  return vi.fn();
-});
-
 afterEach(() => {
   vi.resetAllMocks();
   vi.restoreAllMocks();
@@ -61,7 +56,7 @@ test('darwin: compatibility mode binary not found failure', async () => {
   expect(extensionApi.window.showErrorMessage).toHaveBeenCalledWith('podman-mac-helper binary not found.', 'OK');
 });
 
-test('darwin: DarwinSocketCompatibility class, test runSudoMacHelperCommand ran within runCommand', async () => {
+test('darwin: DarwinSocketCompatibility class, test runMacHelperCommandWithAdminPriv ran within runCommand', async () => {
   // Mock platform to be darwin
   Object.defineProperty(process, 'platform', {
     value: 'darwin',
@@ -73,8 +68,8 @@ test('darwin: DarwinSocketCompatibility class, test runSudoMacHelperCommand ran 
   const spyFindPodmanHelper = vi.spyOn(socketCompatClass, 'findPodmanHelper');
   spyFindPodmanHelper.mockReturnValue('/opt/podman/bin/podman-mac-helper');
 
-  // Mock that sudo ran successfully (since we cannot test sudo-prompt in vitest / has to be integration tests)
-  const spyMacHelperCommand = vi.spyOn(socketCompatClass, 'runSudoMacHelperCommand');
+  // Mock that admin command ran successfully (since we cannot test interactive mode priv in vitest / has to be integration tests)
+  const spyMacHelperCommand = vi.spyOn(socketCompatClass, 'runMacHelperCommandWithAdminPriv');
   spyMacHelperCommand.mockImplementation(() => {
     return Promise.resolve();
   });


### PR DESCRIPTION
### What does this PR do?
replace adhoc calls of extensions to use the new param of exec allowing to execute admin/privileges tasks

and for macOS as it is using osascript we can use touchID key

* [x] : depends on https://github.com/containers/podman-desktop/pull/4049

### Screenshot/screencast of this PR

on macOS we can use touchID key now instead of entering the admin password

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/2998

### How to test this PR?

there are some unit tests, but

ensure you've applied https://github.com/containers/podman-desktop/pull/4049 PR

check you're able to turn on/off the mac-helper binary on macOS
check you're able to install kind and compose on Windows, Linux and macOS
