### PR TITLE
chore: SVG spinner

### DIFF
--- a/packages/renderer/src/lib/dashboard/ProviderConfigured.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderConfigured.svelte
@@ -78,7 +78,7 @@ onMount(() => {
         {/if}
         <div class="flex flex-col text-gray-700">
           <div>Starting</div>
-          <div class="my-2 pr-5 relative">
+          <div class="my-2">
             <Spinner />
           </div>
         </div>

--- a/packages/renderer/src/lib/dashboard/ProviderConfiguring.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderConfiguring.svelte
@@ -103,7 +103,7 @@ onDestroy(() => {
       {/if}
       <div class="flex flex-col text-gray-700">
         <div>Initializing</div>
-        <div class="my-2 pr-5 relative">
+        <div class="my-2">
           <Spinner />
         </div>
       </div>

--- a/packages/renderer/src/lib/dashboard/ProviderInstalled.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderInstalled.svelte
@@ -191,7 +191,7 @@ function onInstallationClick() {
       {/if}
       <div class="flex flex-col text-gray-700">
         <div>Initializing</div>
-        <div class="my-2 pr-5 relative">
+        <div class="my-2">
           <Spinner />
         </div>
       </div>

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationRendering.svelte
@@ -387,8 +387,8 @@ function closePage() {
     </h1>
     <div class="flex flex-col px-6 w-full h-full overflow-auto">
       {#if pageIsLoading}
-        <div class="text-center mt-16" role="status">
-          <Spinner size="lg" />
+        <div class="text-center mt-16 p-2" role="status">
+          <Spinner size="2em" />
         </div>
       {:else}
         {#if creationStarted}

--- a/packages/renderer/src/lib/ui/Button.svelte
+++ b/packages/renderer/src/lib/ui/Button.svelte
@@ -53,7 +53,7 @@ $: {
   {#if icon}
     <div class="flex flex-row p-0 m-0 bg-transparent justify-center space-x-[4px]">
       {#if inProgress}
-        <Spinner size="sm" relative="{true}" />
+        <Spinner size="1em" />
       {:else if iconType === 'fa'}
         <Fa icon="{icon}" />
       {:else if iconType === 'pd'}

--- a/packages/renderer/src/lib/ui/Spinner.svelte
+++ b/packages/renderer/src/lib/ui/Spinner.svelte
@@ -1,12 +1,53 @@
 <script lang="ts">
-export let size = 'md';
-export let relative = false;
+export let size = '2em';
 </script>
 
-<i class="pf-c-button__progress" style="{relative ? 'position: relative' : ''}">
-  <span class="pf-c-spinner pf-m-{size}" role="progressbar">
-    <span class="pf-c-spinner__clipper"></span>
-    <span class="pf-c-spinner__lead-ball"></span>
-    <span class="pf-c-spinner__tail-ball"></span>
-  </span>
+<i class="flex justify-center items-center">
+  <svg width="{size}" height="{size}" viewBox="0 0 100 100">
+    <defs>
+      <linearGradient id="grad1" x1="0%" y1="0%" x2="0%" y2="100%">
+        <stop offset="0%" style="stop-color:rgb(0,0,0);stop-opacity:1"></stop>
+        <stop offset="60%" style="stop-color:rgb(0,0,0);stop-opacity:1"></stop>
+        <stop offset="100%" style="stop-color:rgb(255,255,255);stop-opacity:1"></stop>
+      </linearGradient>
+    </defs>
+    <mask id="myMask">
+      <rect x="0" y="0" width="100" height="100" fill="white"></rect>
+      <rect x="-25" y="-25" width="150" height="75" fill="black"></rect>
+      <g transform="translate(50,50)" style="width={size}; height={size}">
+        <g>
+          <rect x="-75" y="-75" width="150" height="75" fill="url(#grad1)"></rect>
+          <rect x="-75" y="-70" width="100" height="75" fill="black"></rect>
+          <animateTransform
+            attributeName="transform"
+            type="rotate"
+            dur="1.5s"
+            from="0"
+            to="180"
+            values="0; 140;180; 140; 0"
+            keyTimes="0; 0.25;0.5; 0.75;1"
+            repeatCount="indefinite"></animateTransform>
+        </g>
+      </g>
+    </mask>
+    <circle
+      cx="50"
+      cy="50"
+      r="46"
+      stroke="currentColor"
+      opacity="0.8"
+      stroke-width="10"
+      fill="transparent"
+      mask="url(#myMask)"></circle>
+    <animateTransform
+      attributeName="transform"
+      type="rotate"
+      dur="3s"
+      from="0"
+      to="360"
+      repeatCount="indefinite"
+      values="0;90;180;270;360;450;540;630;720;810;900;990;1080;1170;1260;1350;1440;1530;1620;1710;1800"
+      keyTimes="0; 0.02;0.08;0.18;0.32;0.375;0.42;0.455;0.48;0.495;0.5;0.52;0.58;0.68;0.82;0.875;0.92;0.955;0.98;0.995;1"
+    ></animateTransform>
+  </svg>
 </i>


### PR DESCRIPTION
### What does this PR do?

I needed to use the Spinner inside of a StatusIcon and ran into layout/sizing issues that I couldn't fix without some contortions. Instead, I figured I would do issue #3797 first and replace the PF spinner with our own. This is my attempt at creating one with a similar design.

Yes, the code is much longer, but:
- It's now just a simple SVG with some transforms; it's now possible to see what it's doing and modify or replace later.
- There are fewer layout/relative issues.
- Sizing now uses regular units.

Updated use of the Spinner wherever it was overriding the default size, and removed some pr-s that were required before.


### Screenshot/screencast of this PR

Can you tell which is which? Top is the new Spinner, bottom is PF:

https://github.com/containers/podman-desktop/assets/19958075/bfd13605-04f5-49f8-848b-2a4e6fd15e48

### What issues does this PR fix or reference?

Fixes #3797.

### How to test this PR?

Try a few places with spinners (dashboard providers, buttons with progress, loading resource creation pages, onboarding) to confirm no UI regression. It may help to use watch mode to force indefinite progress (e.g. Button.svelte:58, make the condition always true).