### PR TITLE
fix: make the next button in onboarding fixed (#3656)

### DIFF
--- a/packages/renderer/src/lib/onboarding/Onboarding.spec.ts
+++ b/packages/renderer/src/lib/onboarding/Onboarding.spec.ts
@@ -31,6 +31,11 @@ async function waitRender(customProperties: object): Promise<void> {
   }
 }
 
+global.ResizeObserver = vi.fn().mockImplementation(() => ({
+  observe: vi.fn(),
+  unobserve: vi.fn(),
+}));
+
 test('Expect to have the "Try again" and Cancel buttons if the step represent a failed state', async () => {
   (window as any).resetOnboarding = vi.fn();
   (window as any).updateStepState = vi.fn();

--- a/packages/renderer/src/lib/onboarding/Onboarding.svelte
+++ b/packages/renderer/src/lib/onboarding/Onboarding.svelte
@@ -1,3 +1,22 @@
+<style>
+#stepBody::-webkit-scrollbar {
+  width: 1em;
+}
+#stepBody::-webkit-scrollbar-track {
+  -webkit-box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.3);
+}
+#stepBody::-webkit-scrollbar-thumb {
+  background-color: #5c5c5c;
+}
+#stepBody::-webkit-scrollbar-thumb:hover {
+  background-color: #707073;
+}
+.bodyWithBar::-webkit-scrollbar-track-piece:end {
+  background: transparent;
+  margin-bottom: 70px;
+}
+</style>
+
 <script lang="ts">
 import { onDestroy, onMount } from 'svelte';
 import type { OnboardingInfo, OnboardingStepItem } from '../../../../main/src/plugin/api/onboarding';
@@ -87,7 +106,7 @@ onMount(async () => {
   // Resize the bottom toolbar each time we change the div size
   resizeObserver = new ResizeObserver(() => {
     const parentWidth = activeStepDiv.getBoundingClientRect().width;
-    bottomToolbarDiv.style.width = parentWidth + 'px';
+    bottomToolbarDiv.style.width = parentWidth + 16 + 'px';
   });
 });
 
@@ -271,10 +290,11 @@ async function restartSetup() {
 
 {#if activeStep}
   <div
-    class="flex flex-col bg-[#36373a] h-full overflow-y-auto w-full overflow-x-hidden"
-    class:pb-20="{!activeStep.step.completionEvents || activeStep.step.completionEvents.length === 0}">
-    <div class="flex flex-col" bind:this="{activeStepDiv}">
-      <div class="flex flex-row justify-between mt-5 mx-5 mb-5">
+    id="stepBody"
+    class="flex flex-col bg-charcoal-500 h-full overflow-y-auto w-full overflow-x-hidden"
+    class:bodyWithBar="{!activeStep.step.completionEvents || activeStep.step.completionEvents.length === 0}">
+    <div class="flex flex-col h-full" bind:this="{activeStepDiv}">
+      <div class="flex flex-row justify-between m-5">
         <div class="flex flew-row">
           {#if activeStep.onboarding.media}
             <img
@@ -309,7 +329,7 @@ async function restartSetup() {
         </div>
       </div>
       {#if activeStep.step.component}
-        <div class="min-w-[700px] mx-auto overflow-y-auto" aria-label="onboarding component">
+        <div class="min-w-[700px] mx-auto" aria-label="onboarding component">
           <OnboardingComponent
             component="{activeStep.step.component}"
             extensionId="{activeStep.onboarding.extension}" />
@@ -378,11 +398,11 @@ async function restartSetup() {
       {#if !activeStep.step.completionEvents || activeStep.step.completionEvents.length === 0}
         <div class="grow"></div>
         {#if activeStep.step.state !== 'failed'}
-          <div class="mb-10 mx-auto text-sm" aria-label="next-info-message">
+          <div class="mt-10 mx-auto text-sm min-h-[120px]" aria-label="next-info-message">
             Press the <span class="bg-purple-700 p-0.5">Next</span> button below to proceed.
           </div>
         {:else}
-          <div class="mb-10 mx-auto text-sm" aria-label="exit-info-message">
+          <div class="mt-10 mx-auto text-sm min-h-[120px]" aria-label="exit-info-message">
             <Link on:click="{() => setDisplayCancelSetup(true)}">Exit</Link> the setup. You can try again later.
           </div>
         {/if}

--- a/packages/renderer/src/lib/onboarding/Onboarding.svelte
+++ b/packages/renderer/src/lib/onboarding/Onboarding.svelte
@@ -254,7 +254,9 @@ async function restartSetup() {
 </script>
 
 {#if activeStep}
-  <div class="flex flex-col bg-[#36373a] h-full">
+  <div
+    class="flex flex-col bg-[#36373a] h-full overflow-y-auto w-full overflow-x-hidden"
+    class:pb-20="{!activeStep.step.completionEvents || activeStep.step.completionEvents.length === 0}">
     <div class="flex flex-row justify-between mt-5 mx-5 mb-5">
       <div class="flex flew-row">
         {#if activeStep.onboarding.media}
@@ -357,7 +359,8 @@ async function restartSetup() {
           <Link on:click="{() => setDisplayCancelSetup(true)}">Exit</Link> the setup. You can try again later.
         </div>
       {/if}
-      <div class="flex flex-row-reverse p-6 bg-charcoal-700">
+      <div
+        class="flex flex-row-reverse p-6 bg-charcoal-700 fixed w-[calc(100%_-_17rem)] bottom-0 mb-5 pr-10 max-h-20 opacity-80">
         <Button type="primary" disabled="{activeStep.step.state === 'failed'}" on:click="{() => next()}">Next</Button>
         {#if activeStep.step.state !== 'completed'}
           <Button type="secondary" aria-label="Cancel setup" class="mr-2" on:click="{() => setDisplayCancelSetup(true)}"

--- a/packages/renderer/src/lib/onboarding/Onboarding.svelte
+++ b/packages/renderer/src/lib/onboarding/Onboarding.svelte
@@ -1,4 +1,4 @@
-<style>
+<style lang="postcss">
 #stepBody::-webkit-scrollbar {
   width: 1em;
 }
@@ -6,10 +6,13 @@
   -webkit-box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.3);
 }
 #stepBody::-webkit-scrollbar-thumb {
-  background-color: #5c5c5c;
+  background-color: theme(colors.charcoal.100);
 }
 #stepBody::-webkit-scrollbar-thumb:hover {
-  background-color: #707073;
+  background-color: theme(colors.charcoal.50);
+}
+#stepBody::-webkit-scrollbar-thumb:active {
+  background-color: theme(colors.gray.700);
 }
 .bodyWithBar::-webkit-scrollbar-track-piece:end {
   background: transparent;

--- a/packages/renderer/src/lib/onboarding/Onboarding.svelte
+++ b/packages/renderer/src/lib/onboarding/Onboarding.svelte
@@ -1,6 +1,7 @@
 <style lang="postcss">
 #stepBody::-webkit-scrollbar {
   width: 1em;
+  height: 50%;
 }
 #stepBody::-webkit-scrollbar-track {
   -webkit-box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.3);
@@ -399,6 +400,8 @@ async function restartSetup() {
       {/if}
 
       {#if !activeStep.step.completionEvents || activeStep.step.completionEvents.length === 0}
+        <!-- fake div used to hide scrollbar shadow  -->
+        <div class="fixed bg-charcoal-500 right-0 bottom-0 h-[70px] w-[30px] z-10 mb-6"></div>
         <div class="grow"></div>
         {#if activeStep.step.state !== 'failed'}
           <div class="mt-10 mx-auto text-sm min-h-[120px]" aria-label="next-info-message">
@@ -410,7 +413,7 @@ async function restartSetup() {
           </div>
         {/if}
         <div
-          class="flex flex-row-reverse p-6 bg-charcoal-700 fixed w-full bottom-0 mb-5 pr-10 max-h-20 bg-opacity-90"
+          class="flex flex-row-reverse p-6 bg-charcoal-700 fixed w-full bottom-0 mb-5 pr-10 max-h-20 bg-opacity-90 z-20"
           bind:this="{bottomToolbarDiv}">
           <Button type="primary" disabled="{activeStep.step.state === 'failed'}" on:click="{() => next()}">Next</Button>
           {#if activeStep.step.state !== 'completed'}

--- a/packages/renderer/svelte.config.js
+++ b/packages/renderer/svelte.config.js
@@ -1,12 +1,12 @@
 /**********************************************************************
  * Copyright (C) 2022 Red Hat, Inc.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,9 +17,18 @@
  ***********************************************************************/
 
 import sveltePreprocess from 'svelte-preprocess';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+console.log('dirname' + __dirname);
 
 export default {
   // Consult https://github.com/sveltejs/svelte-preprocess
   // for more information about preprocessors
-  preprocess: sveltePreprocess(),
+  preprocess: sveltePreprocess({
+    postcss: {
+      configFilePath: join(__dirname, 'postcss.config.cjs'),
+    },
+  }),
 };

--- a/packages/renderer/svelte.config.js
+++ b/packages/renderer/svelte.config.js
@@ -21,7 +21,6 @@ import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-console.log('dirname' + __dirname);
 
 export default {
   // Consult https://github.com/sveltejs/svelte-preprocess


### PR DESCRIPTION
### What does this PR do?

It makes the bar with the next/cancel buttons fixed to the bottom and 80% transparency.
Not a css expert so if someone has a better idea how to achieve it (i don't like the `calc(100%-17rem)` TBH), you're more than welcome to add a commit here or create a new PR.

### Screenshot/screencast of this PR

![fixed_next_onboarding](https://github.com/containers/podman-desktop/assets/49404737/a0f0d75d-f672-40a6-8d54-a02e9e06c26d)

### What issues does this PR fix or reference?

it resolves #3656 

### How to test this PR?

1. start the onboarding and resize the window when you see the next button
