### PR TITLE
chore: add 'when' to content during onboarding

### DIFF
--- a/packages/main/src/plugin/api/onboarding.ts
+++ b/packages/main/src/plugin/api/onboarding.ts
@@ -25,6 +25,7 @@ export interface OnboardingCommandResponse {
 export interface OnboardingStepItem {
   value: string;
   highlight?: boolean;
+  when?: string;
 }
 
 export type OnboardingStatus = 'completed' | 'failed' | 'skipped';

--- a/packages/renderer/src/lib/onboarding/OnboardingItem.spec.ts
+++ b/packages/renderer/src/lib/onboarding/OnboardingItem.spec.ts
@@ -71,6 +71,23 @@ test('Expect placeholders are replaced when passing a text component with placeh
   expect(markdownSection.innerHTML.includes('placeholder content')).toBe(true);
 });
 
+test('Expect when in content to not show up when validation is false', async () => {
+  const textComponent: OnboardingStepItem = {
+    value: '${onboardingContext:text}',
+    when: 'extension.onboarding.test',
+  };
+  const context = new ContextUI();
+  context.setValue('extension.onboarding.text', false);
+  render(OnboardingItem, {
+    extension: 'extension',
+    item: textComponent,
+    getContext: () => context,
+    inProgressCommandExecution: vi.fn(),
+  });
+  // Expect that the content does not show up (markdown-content wont show)
+  expect(screen.queryByLabelText('markdown-content')).not.toBeInTheDocument();
+});
+
 test('Expect boolean configuration placeholder to be replaced with a checkbox', async () => {
   const textComponent: OnboardingStepItem = {
     value: '${configuration:extension.boolean.prop}',


### PR DESCRIPTION
chore: add 'when' to content during onboarding

### What does this PR do?

When showing content in onboarding, we should be able to add 'when' of
when to show certain content.

In an example case, is showing a button to install a binary system wide
if it has not been detected.

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast
explaining what is doing this PR -->

N/A

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Fixes https://github.com/containers/podman-desktop/issues/4048

### How to test this PR?

Edit `podman/package.json` to the following and test out "when".

Replace enablement to:

```
"enablement": true
```

So it will always show.

Replace the "podmanInstalled" section with content that includes "when":

```
{
  "id": "podmanInstalled",
  "title": "${onboardingContext:podmanInstalledTitle}",
  "when": "!onboardingContext:podmanIsNotInstalled",
  "content": [
    [
      {
        "value": "${configuration:preferences.podman-desktop.podman.engine.autostart}",
        "when": "true"
      }
    ]
  ]
},
```

Test out by using true/false or even "podman.test.variable == true" /
when statements.

<!-- Please explain steps to reproduce -->

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
