### PR TITLE
feat: adding task progress for kind `kind.image.move`

### DIFF
--- a/extensions/kind/src/extension.spec.ts
+++ b/extensions/kind/src/extension.spec.ts
@@ -78,7 +78,7 @@ test('check we received notifications ', async () => {
   expect(listContainersMock).toBeCalledTimes(1);
 });
 
-test('', async () => {
+test('Ensuring a progress task is created when calling kind.image.move command', async () => {
   const commandRegistry: { [id: string]: (image: { image: string }) => Promise<void> } = {};
 
   const registerCommandMock = vi.fn();

--- a/extensions/kind/src/extension.ts
+++ b/extensions/kind/src/extension.ts
@@ -257,7 +257,7 @@ async function createProvider(
         async progress => {
           await imageHandler.moveImage(image, kindClusters, kindCli);
           // Mark the task as completed
-          progress.report({ increment: -1, message: `Image ${image.name} loaded to kind.` });
+          progress.report({ increment: -1 });
         },
       );
     }),

--- a/extensions/kind/src/extension.ts
+++ b/extensions/kind/src/extension.ts
@@ -223,7 +223,7 @@ export function refreshKindClustersOnProviderConnectionUpdate(provider: extensio
   });
 }
 
-async function createProvider(
+export async function createProvider(
   extensionContext: extensionApi.ExtensionContext,
   telemetryLogger: extensionApi.TelemetryLogger,
 ): Promise<void> {


### PR DESCRIPTION
### What does this PR do?

Adding a progress task to the TASKS for loading an image to kind.

### Screenshot/screencast of this PR

#### When loading

![image](https://github.com/containers/podman-desktop/assets/42176370/eb7007b4-fd0e-4287-be9e-40ffc412de35)

> This will look way better when https://github.com/containers/podman-desktop/pull/4016 will be merged.

#### Finish loading

![image](https://github.com/containers/podman-desktop/assets/42176370/d9e861f6-0b37-4567-99ef-ca2017b0d907)

<!-- Please include a screenshot or a screencast 
explaining what is doing this PR -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop 
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to reproduce -->
