### PR TITLE
fix: point user to official installation guide during podman onboarding on linux (#4077)

### DIFF
--- a/extensions/podman/package.json
+++ b/extensions/podman/package.json
@@ -169,8 +169,23 @@
         {
           "id": "installPodmanView",
           "title": "Installing Podman",
+          "when": "onboardingContext:podmanIsNotInstalled && isLinux",
+          "completionEvents": [
+            "!onboardingContext:podmanIsNotInstalled"
+          ],
+          "content": [
+            [
+              {
+                "value": "To install Podman please follow these :link[installation instructions]{href=https://podman.io/docs/installation#installing-on-linux}"
+              }
+            ]
+          ]
+        },
+        {
+          "id": "installPodmanView",
+          "title": "Installing Podman",
           "description": "Once installed, we will enable and configure the extension",
-          "when": "onboardingContext:podmanIsNotInstalled",
+          "when": "onboardingContext:podmanIsNotInstalled && !isLinux",
           "command": "podman.onboarding.installPodman",
           "completionEvents": [
             "onCommand:podman.onboarding.installPodman"

--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -483,12 +483,14 @@ async function monitorProvider(provider: extensionApi.Provider) {
       // update version
       if (!installedPodman) {
         provider.updateStatus('not-installed');
+        extensionApi.context.setValue('podmanIsNotInstalled', true, 'onboarding');
       } else if (installedPodman.version) {
         provider.updateVersion(installedPodman.version);
         // update provider status if someone has installed podman externally
         if (provider.status === 'not-installed') {
           provider.updateStatus('installed');
         }
+        extensionApi.context.setValue('podmanIsNotInstalled', false, 'onboarding');
       }
     } catch (error) {
       // ignore the update
@@ -953,7 +955,7 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
   const onboardingCheckReqsCommand = extensionApi.commands.registerCommand(
     'podman.onboarding.checkPodmanRequirements',
     async () => {
-      const checks = podmanInstall.getInstallChecks();
+      const checks = podmanInstall.getInstallChecks() || [];
       const result = [];
       let successful = true;
       for (const check of checks) {


### PR DESCRIPTION
### What does this PR do?

This PR adds a custom step for linux. As we do not have any installer, we just point the user to the official installation web page.

### Screenshot/screencast of this PR

![install_podman_linux](https://github.com/containers/podman-desktop/assets/49404737/4626abb4-6aab-497f-884c-aa0d9e65abee)

### What issues does this PR fix or reference?

it resolves #4077 

### How to test this PR?

1. launch the onboarding on linux without having podman installed
