### PR TITLE
feat: brings a simple command palette to invoke registered commands

### DIFF
--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -42,6 +42,7 @@ import IconsStyle from './lib/style/IconsStyle.svelte';
 import CustomPick from './lib/dialogs/CustomPick.svelte';
 import ContextKey from './lib/context/ContextKey.svelte';
 import CreateVolume from './lib/volume/CreateVolume.svelte';
+import CommandPalette from './lib/dialogs/CommandPalette.svelte';
 
 router.mode.hash();
 
@@ -76,6 +77,7 @@ window.events?.receive('display-troubleshooting', () => {
       <MessageBox />
       <QuickPickInput />
       <CustomPick />
+      <CommandPalette />
       <AppNavigation meta="{meta}" exitSettingsCallback="{() => router.goto(nonSettingsPage)}" />
       {#if meta.url.startsWith('/preferences')}
         <PreferencesNavigation meta="{meta}" />

--- a/packages/renderer/src/lib/dialogs/CommandPalette.spec.ts
+++ b/packages/renderer/src/lib/dialogs/CommandPalette.spec.ts
@@ -1,0 +1,321 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import '@testing-library/jest-dom/vitest';
+import { beforeAll, beforeEach, test, expect, vi, describe } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import CommandPalette from './CommandPalette.svelte';
+import { commandsInfos } from '/@/stores/commands';
+
+const receiveFunctionMock = vi.fn();
+
+const COMMAND_PALETTE_ARIA_LABEL = 'Command palette command input';
+
+const executeCommandMock = vi.fn();
+// mock some methods of the window object
+beforeAll(() => {
+  (window.events as unknown) = {
+    receive: receiveFunctionMock,
+  };
+
+  // mock missing scrollIntoView method
+  window.HTMLElement.prototype.scrollIntoView = vi.fn();
+
+  (window as any).executeCommand = executeCommandMock;
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('Command Palette', () => {
+  test('Expect that F1 key is displaying the widget', async () => {
+    render(CommandPalette);
+
+    // check we have the command palette input field
+    const inputBefore = screen.queryByRole('textbox', { name: COMMAND_PALETTE_ARIA_LABEL });
+    expect(inputBefore).not.toBeInTheDocument();
+
+    // now, press the F1 key
+    await userEvent.keyboard('{F1}');
+
+    // check it's displayed now
+    const input = screen.getByRole('textbox', { name: COMMAND_PALETTE_ARIA_LABEL });
+    expect(input).toBeInTheDocument();
+  });
+
+  test('Expect that esc key is hiding the widget', async () => {
+    render(CommandPalette, { display: true });
+
+    // check we have the command palette input field
+    const input = screen.getByRole('textbox', { name: COMMAND_PALETTE_ARIA_LABEL });
+    expect(input).toBeInTheDocument();
+
+    // now, press the ESC key
+    await userEvent.keyboard('{Escape}');
+
+    // check it's not displayed anymore
+    expect(input).not.toBeInTheDocument();
+  });
+
+  test('Check keydown ⬇️', async () => {
+    const commandTitle1 = 'My command 1';
+    const commandTitle2 = 'My command 2';
+
+    commandsInfos.set([
+      {
+        id: 'my-command-1',
+        title: commandTitle1,
+      },
+      {
+        id: 'my-command-2',
+        title: commandTitle2,
+      },
+    ]);
+
+    render(CommandPalette, { display: true });
+
+    // check we have the command palette input field
+    const input = screen.getByRole('textbox', { name: COMMAND_PALETTE_ARIA_LABEL });
+    expect(input).toBeInTheDocument();
+
+    // grab first item
+    const firstItem = screen.getByRole('button', { name: commandTitle1 });
+    // check the class selected is on this item
+    expect(firstItem).toHaveClass('selected');
+
+    // now, press the ⬇️ key
+    await userEvent.keyboard('{ArrowDown}');
+
+    // expect we've scrolled
+    expect(window.HTMLElement.prototype.scrollIntoView).toHaveBeenCalled();
+
+    // check the class selected is no longer on the first item
+    expect(firstItem).not.toHaveClass('selected');
+
+    // but on the second one
+    const secondItem = screen.getByRole('button', { name: commandTitle2 });
+    // check the class selected is on this item
+    expect(secondItem).toHaveClass('selected');
+
+    // click on the item
+    await userEvent.click(secondItem);
+
+    expect(executeCommandMock).toBeCalledWith('my-command-2');
+  });
+
+  test('Check tab key', async () => {
+    const commandTitle1 = 'My command 1';
+    const commandTitle2 = 'My command 2';
+
+    commandsInfos.set([
+      {
+        id: 'my-command-1',
+        title: commandTitle1,
+      },
+      {
+        id: 'my-command-2',
+        title: commandTitle2,
+      },
+    ]);
+
+    render(CommandPalette, { display: true });
+
+    // check we have the command palette input field
+    const input = screen.getByRole('textbox', { name: COMMAND_PALETTE_ARIA_LABEL });
+    expect(input).toBeInTheDocument();
+
+    // grab first item
+    const firstItem = screen.getByRole('button', { name: commandTitle1 });
+    // check the class selected is on this item
+    expect(firstItem).toHaveClass('selected');
+
+    // now, press the Tab key
+    await userEvent.keyboard('{Tab}');
+
+    // expect we've scrolled
+    expect(window.HTMLElement.prototype.scrollIntoView).toHaveBeenCalled();
+
+    // check the class selected is no longer on the first item
+    expect(firstItem).not.toHaveClass('selected');
+
+    // but on the second one
+    const secondItem = screen.getByRole('button', { name: commandTitle2 });
+    // check the class selected is on this item
+    expect(secondItem).toHaveClass('selected');
+
+    // click on the item
+    await userEvent.click(secondItem);
+
+    expect(executeCommandMock).toBeCalledWith('my-command-2');
+  });
+
+  test('Check keyup ⬆️', async () => {
+    const commandTitle1 = 'My command 1';
+    const commandTitle2 = 'My command 2';
+    const commandTitle3 = 'My command 3';
+
+    commandsInfos.set([
+      {
+        id: 'my-command-1',
+        title: commandTitle1,
+      },
+      {
+        id: 'my-command-2',
+        title: commandTitle2,
+      },
+      {
+        id: 'my-command-3',
+        title: commandTitle3,
+      },
+    ]);
+
+    render(CommandPalette, { display: true });
+
+    // check we have the command palette input field
+    const input = screen.getByRole('textbox', { name: COMMAND_PALETTE_ARIA_LABEL });
+    expect(input).toBeInTheDocument();
+
+    // grab first item
+    const firstItem = screen.getByRole('button', { name: commandTitle1 });
+    // check the class selected is on this item
+    expect(firstItem).toHaveClass('selected');
+
+    // now, press the ⬆️ key
+    await userEvent.keyboard('{ArrowUp}');
+
+    // expect we've scrolled
+    expect(window.HTMLElement.prototype.scrollIntoView).toHaveBeenCalled();
+
+    // check the class selected is no longer on the first item
+    expect(firstItem).not.toHaveClass('selected');
+
+    // but on the last one (as we were on top)
+    const lastItem = screen.getByRole('button', { name: commandTitle3 });
+    // check the class selected is on this item
+    expect(lastItem).toHaveClass('selected');
+
+    // now, press the ⬆️ key again
+    await userEvent.keyboard('{ArrowUp}');
+
+    // but on the second one
+    const secondItem = screen.getByRole('button', { name: commandTitle2 });
+    // check the class selected is on this item
+    expect(secondItem).toHaveClass('selected');
+
+    // click on the item
+    await userEvent.click(secondItem);
+
+    expect(executeCommandMock).toBeCalledWith('my-command-2');
+  });
+
+  test('Check Enter key', async () => {
+    const commandTitle1 = 'My command 1';
+    const commandTitle2 = 'My command 2';
+
+    commandsInfos.set([
+      {
+        id: 'my-command-1',
+        title: commandTitle1,
+      },
+      {
+        id: 'my-command-2',
+        title: commandTitle2,
+      },
+    ]);
+
+    render(CommandPalette, { display: true });
+
+    // check we have the command palette input field
+    const input = screen.getByRole('textbox', { name: COMMAND_PALETTE_ARIA_LABEL });
+    expect(input).toBeInTheDocument();
+
+    // grab first item
+    const firstItem = screen.getByRole('button', { name: commandTitle1 });
+    // check the class selected is on this item
+    expect(firstItem).toHaveClass('selected');
+
+    // now, press the Enter key
+    await userEvent.keyboard('{Enter}');
+
+    expect(executeCommandMock).toBeCalledWith('my-command-1');
+  });
+
+  test('Check filtering', async () => {
+    const commandTitle0 = 'Another Command';
+    const commandTitle1 = 'My command 1';
+    const commandTitle2 = 'My command 2';
+    const commandTitle3 = 'command 3';
+
+    commandsInfos.set([
+      {
+        id: 'my-command-0',
+        title: commandTitle0,
+      },
+      {
+        id: 'my-command-1',
+        title: commandTitle1,
+      },
+      {
+        id: 'my-command-2',
+        title: commandTitle2,
+      },
+      {
+        id: 'my-command-3',
+        title: commandTitle3,
+      },
+    ]);
+
+    render(CommandPalette, { display: true });
+
+    // check we have the command palette input field
+    const input = screen.getByRole('textbox', { name: COMMAND_PALETTE_ARIA_LABEL });
+    expect(input).toBeInTheDocument();
+
+    // Check items are displayed
+    const item0 = screen.getByRole('button', { name: commandTitle0 });
+    expect(item0).toBeInTheDocument();
+    const item1 = screen.getByRole('button', { name: commandTitle1 });
+    expect(item1).toBeInTheDocument();
+    const item2 = screen.getByRole('button', { name: commandTitle2 });
+    expect(item2).toBeInTheDocument();
+    const item3 = screen.getByRole('button', { name: commandTitle3 });
+    expect(item3).toBeInTheDocument();
+
+    // now enter the text 'My '
+    await userEvent.type(input, 'My ');
+
+    // check only command 1 and 2 are displayed
+    const searchingItem0 = screen.queryByRole('button', { name: commandTitle0 });
+    expect(searchingItem0).not.toBeInTheDocument();
+    const searchingItem1 = screen.queryByRole('button', { name: commandTitle1 });
+    expect(searchingItem1).toBeInTheDocument();
+    const searchingItem2 = screen.queryByRole('button', { name: commandTitle2 });
+    expect(searchingItem2).toBeInTheDocument();
+    const searchingItem3 = screen.queryByRole('button', { name: commandTitle3 });
+    expect(searchingItem3).not.toBeInTheDocument();
+
+    // now, press the Enter key
+    await userEvent.keyboard('{Enter}');
+
+    expect(executeCommandMock).toBeCalledWith('my-command-1');
+  });
+});

--- a/packages/renderer/src/lib/dialogs/CommandPalette.svelte
+++ b/packages/renderer/src/lib/dialogs/CommandPalette.svelte
@@ -1,0 +1,188 @@
+<script lang="ts">
+import { onMount, tick } from 'svelte';
+import { commandsInfos } from '/@/stores/commands';
+import type { CommandInfo } from '../../../../main/src/plugin/api/command-info';
+
+const ENTER_KEY = 'Enter';
+const ESCAPE_KEY = 'Escape';
+const ARROW_DOWN_KEY = 'ArrowDown';
+const ARROW_UP_KEY = 'ArrowUp';
+const TAB_KEY = 'Tab';
+
+export let display = false;
+let inputElement: HTMLInputElement | HTMLTextAreaElement | undefined = undefined;
+let outerDiv: HTMLDivElement | undefined = undefined;
+let inputValue: string | undefined = '';
+let scrollElements: HTMLLIElement[] = [];
+
+let commandInfoItems: CommandInfo[] = [];
+let filteredCommandInfoItems: CommandInfo[] = [];
+
+$: filteredCommandInfoItems = commandInfoItems.filter(item =>
+  inputValue ? item.title?.toLowerCase().includes(inputValue.toLowerCase()) : true,
+);
+
+onMount(() => {
+  // subscribe to the commands
+  return commandsInfos.subscribe(infos => {
+    commandInfoItems = infos;
+  });
+});
+
+let selectedFilteredIndex = 0;
+let selectedIndex = 0;
+
+function handleKeydown(e: KeyboardEvent) {
+  // toggle display using F1 or ESC keys
+  if (e.key === 'F1') {
+    // clear the input value
+    inputValue = '';
+    selectedFilteredIndex = 0;
+    selectedIndex = 0;
+    // toggle the display
+    display = true;
+    tick()
+      .then(() => {
+        inputElement?.focus();
+      })
+      .catch(() => {
+        // ignore
+      });
+
+    e.preventDefault();
+    return;
+  } else if (e.key === ESCAPE_KEY) {
+    // here we toggle the display
+    display = false;
+    e.preventDefault();
+    return;
+  }
+
+  // for other keys, only check if it's being displayed
+  if (!display) {
+    return;
+  }
+
+  // no items, abort
+  if (filteredCommandInfoItems.length === 0) {
+    return;
+  }
+
+  if (e.key === ARROW_DOWN_KEY || e.key === TAB_KEY) {
+    // if down key is pressed, move the index
+    selectedFilteredIndex++;
+    if (selectedFilteredIndex >= filteredCommandInfoItems.length) {
+      selectedFilteredIndex = 0;
+    }
+
+    selectedIndex = commandInfoItems.indexOf(filteredCommandInfoItems[selectedFilteredIndex]);
+
+    scrollElements[selectedFilteredIndex].scrollIntoView({
+      behavior: 'smooth',
+      block: 'nearest',
+      inline: 'start',
+    });
+    e.preventDefault();
+  } else if (e.key === ARROW_UP_KEY) {
+    // if up key is pressed, move the index
+    selectedFilteredIndex--;
+    if (selectedFilteredIndex < 0) {
+      selectedFilteredIndex = filteredCommandInfoItems.length - 1;
+    }
+    selectedIndex = commandInfoItems.indexOf(filteredCommandInfoItems[selectedFilteredIndex]);
+    scrollElements[selectedFilteredIndex].scrollIntoView({
+      behavior: 'smooth',
+      block: 'nearest',
+      inline: 'start',
+    });
+    e.preventDefault();
+  } else if (e.key === ENTER_KEY) {
+    // hide the command palette
+    display = false;
+
+    selectedIndex = commandInfoItems.indexOf(filteredCommandInfoItems[selectedFilteredIndex]);
+    executeCommand(selectedIndex);
+    e.preventDefault();
+  }
+}
+
+async function executeCommand(index: number) {
+  // get command id
+  const commandId = commandInfoItems[index].id;
+  // execute the command
+  try {
+    await window.executeCommand(commandId);
+  } catch (error) {
+    console.error('error executing command', error);
+  }
+}
+
+function handleMousedown(e: MouseEvent) {
+  if (!display) {
+    return;
+  }
+
+  if (outerDiv && !e.defaultPrevented && e.target instanceof Node && !outerDiv.contains(e.target)) {
+    display = false;
+  }
+}
+
+async function clickOnItem(item: any, index: number) {
+  // hide the command palette
+  display = false;
+
+  // select the index from the cursor
+  selectedIndex = commandInfoItems.indexOf(filteredCommandInfoItems[index]);
+  executeCommand(selectedIndex);
+}
+
+async function onInputChange() {
+  // in case of quick pick, filter the items
+
+  selectedFilteredIndex = 0;
+  if (filteredCommandInfoItems.length > 0) {
+    selectedIndex = commandInfoItems.indexOf(filteredCommandInfoItems[selectedFilteredIndex]);
+  }
+}
+</script>
+
+<svelte:window on:keydown="{handleKeydown}" on:mousedown="{handleMousedown}" />
+
+{#if display}
+  <div class="fixed top-0 left-0 right-0 bottom-0 bg-black bg-opacity-60 h-full z-50"></div>
+
+  <div class="absolute m-auto left-0 right-0 z-50">
+    <div class="flex justify-center items-center mt-1">
+      <div
+        bind:this="{outerDiv}"
+        class="bg-charcoal-800 w-[700px] max-h-fit shadow-sm p-2 rounded shadow-zinc-700 text-sm">
+        <div class="w-full flex flex-row">
+          <input
+            bind:this="{inputElement}"
+            aria-label="Command palette command input"
+            type="text"
+            bind:value="{inputValue}"
+            on:input="{() => onInputChange()}"
+            class="px-1 w-full text-gray-400 bg-zinc-700 border border-charcoal-600 focus:outline-none" />
+        </div>
+        <ul class="max-h-[50vh] overflow-y-auto flex flex-col">
+          {#each filteredCommandInfoItems as item, i}
+            <li class="flex w-full flex-row" bind:this="{scrollElements[i]}" aria-label="{item.id}">
+              <button
+                on:click="{() => clickOnItem(item, i)}"
+                class="text-gray-400 text-left relative my-0.5 mr-2 w-full {i === selectedFilteredIndex
+                  ? 'bg-violet-500 selected'
+                  : 'hover:bg-charcoal-600'}  px-1">
+                <div class="flex flex-col w-full">
+                  <div class="flex flex-row w-full max-w-[700px] truncate">
+                    <div class="text-xs">{item.title}</div>
+                  </div>
+                </div>
+              </button>
+            </li>
+          {/each}
+        </ul>
+      </div>
+    </div>
+  </div>
+{/if}

--- a/packages/renderer/src/stores/commands.spec.ts
+++ b/packages/renderer/src/stores/commands.spec.ts
@@ -1,0 +1,87 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { get } from 'svelte/store';
+import type { Mock } from 'vitest';
+import { beforeAll, expect, test, vi } from 'vitest';
+import type { CommandInfo } from '../../../main/src/plugin/api/command-info';
+import { commandsEventStore, commandsEventStoreInfo, commandsInfos } from './commands';
+
+// first, patch window object
+const callbacks = new Map<string, any>();
+const eventEmitter = {
+  receive: (message: string, callback: any) => {
+    callbacks.set(message, callback);
+  },
+};
+
+const getCommandPaletteCommandsMock: Mock<any, Promise<CommandInfo[]>> = vi.fn();
+
+Object.defineProperty(global, 'window', {
+  value: {
+    getCommandPaletteCommands: getCommandPaletteCommandsMock,
+    events: {
+      receive: eventEmitter.receive,
+    },
+    addEventListener: eventEmitter.receive,
+  },
+  writable: true,
+});
+
+beforeAll(() => {
+  vi.clearAllMocks();
+  commandsEventStore.setup();
+});
+
+test('commands should be updated', async () => {
+  // initial command is empty
+  getCommandPaletteCommandsMock.mockResolvedValue([]);
+
+  // get list and expect nothing there
+  const commands = get(commandsInfos);
+  expect(commands.length).toBe(0);
+
+  getCommandPaletteCommandsMock.mockReset();
+  getCommandPaletteCommandsMock.mockResolvedValue([
+    {
+      id: 'first.extension1',
+      title: 'test1',
+    },
+    {
+      id: 'second.extension2',
+      title: 'test2',
+    },
+  ]);
+
+  const callback = callbacks.get('system-ready');
+  // send 'system-ready' event
+  expect(callback).toBeDefined();
+  await callback();
+
+  // check that getCommandPaletteCommands is called
+  expect(getCommandPaletteCommandsMock).toBeCalled();
+
+  // fetch manually
+  await commandsEventStoreInfo.fetch();
+
+  // check if the commands has been updated
+  const afterCommands = get(commandsInfos);
+  expect(afterCommands.length).toBe(2);
+});

--- a/packages/renderer/src/stores/commands.ts
+++ b/packages/renderer/src/stores/commands.ts
@@ -1,0 +1,45 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { writable, type Writable } from 'svelte/store';
+import type { CommandInfo } from '../../../main/src/plugin/api/command-info';
+import { EventStore } from './event-store';
+
+const windowEvents: string[] = ['commands-added', 'commands-removed'];
+const windowListeners = ['system-ready'];
+
+export async function checkForUpdate(): Promise<boolean> {
+  return true;
+}
+
+export const commandsInfos: Writable<CommandInfo[]> = writable([]);
+
+// use helper here as window methods are initialized after the store in tests
+const getCommands = async (): Promise<CommandInfo[]> => {
+  return window.getCommandPaletteCommands();
+};
+
+export const commandsEventStore = new EventStore<CommandInfo[]>(
+  'catalog extensions',
+  commandsInfos,
+  checkForUpdate,
+  windowEvents,
+  windowListeners,
+  getCommands,
+);
+export const commandsEventStoreInfo = commandsEventStore.setup();


### PR DESCRIPTION
### What does this PR do?

Displays a command palette with registered commands
Lot of improvements can be done later like the shortcuts, the Fuzzy search, last recent command being called, etc

### Screenshot/screencast of this PR

https://github.com/containers/podman-desktop/assets/436777/5aaa6a1b-6df5-4b66-a811-cdd148d02ad6



### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/4011

### How to test this PR?

Invoke F1 key to bring the command palette