### PR TITLE
fix: remove check on podman machine sockets directory when activating podman (#4080)

### DIFF
--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -879,15 +879,7 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
     });
   }
 
-  // no podman for now, skip
-  if (isMac()) {
-    if (!fs.existsSync(podmanMachineSocketsDirectory)) {
-      return;
-    }
-    monitorMachines(provider).catch((error: unknown) => {
-      console.error('Error while monitoring machines', error);
-    });
-  } else if (isLinux()) {
+  if (isLinux()) {
     // on Linux, need to run the system service for unlimited time
     let command = 'podman';
     let args = ['system', 'service', '--time=0'];
@@ -928,7 +920,7 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
     initDefaultLinux(provider).catch((error: unknown) => {
       console.error('Error while initializing default linux', error);
     });
-  } else if (isWindows()) {
+  } else if (isWindows() || isMac()) {
     monitorMachines(provider).catch((error: unknown) => {
       console.error('Error while monitoring machines', error);
     });


### PR DESCRIPTION
### What does this PR do?

It just unifies the `isWindows` and `isMac` branches when it starts checking the machines at the extension activation as they do the same thing.

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

it resolves #4080 

### How to test this PR?

1. start podman desktop, it should work as before
