### PR TITLE
chore: forms & details should be closable by clicking escape

### DIFF
--- a/packages/renderer/src/lib/ui/DetailsPage.spec.ts
+++ b/packages/renderer/src/lib/ui/DetailsPage.spec.ts
@@ -17,12 +17,13 @@
  ***********************************************************************/
 
 import '@testing-library/jest-dom/vitest';
-import { test, expect, vi } from 'vitest';
+import { test, expect, vi, beforeEach } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/svelte';
 import DetailsPage from './DetailsPage.svelte';
 import { lastPage, currentPage } from '../../stores/breadcrumb';
 import type { TinroBreadcrumb } from 'tinro';
 import { router } from 'tinro';
+import userEvent from '@testing-library/user-event';
 
 // mock the router
 vi.mock('tinro', () => {
@@ -31,6 +32,10 @@ vi.mock('tinro', () => {
       goto: vi.fn(),
     },
   };
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
 });
 
 test('Expect title is defined', async () => {
@@ -68,9 +73,9 @@ test('Expect backlink is defined', async () => {
   expect(backElement).toBeInTheDocument();
   expect(backElement).toHaveTextContent(backName);
 
-  fireEvent.click(backElement);
+  await fireEvent.click(backElement);
 
-  expect(router.goto).toBeCalledWith('/back');
+  expect(router.goto).toHaveBeenCalledWith('/back');
 });
 
 test('Expect close link is defined', async () => {
@@ -83,4 +88,16 @@ test('Expect close link is defined', async () => {
   const closeElement = screen.getByTitle('Close Details');
   expect(closeElement).toBeInTheDocument();
   expect(closeElement).toHaveAttribute('href', backPath);
+});
+
+test('Expect Escape key closes', async () => {
+  const backPath = '/back';
+  lastPage.set({ name: 'Back', path: backPath } as TinroBreadcrumb);
+  render(DetailsPage, {
+    title: 'No Title',
+  });
+
+  await userEvent.keyboard('{Escape}');
+
+  expect(router.goto).toHaveBeenCalledWith('/back');
 });

--- a/packages/renderer/src/lib/ui/DetailsPage.svelte
+++ b/packages/renderer/src/lib/ui/DetailsPage.svelte
@@ -10,7 +10,16 @@ export let subtitle: string | undefined = undefined;
 export function close(): void {
   router.goto($lastPage.path);
 }
+
+function handleKeydown(e: KeyboardEvent) {
+  if (e.key === 'Escape') {
+    close();
+    e.preventDefault();
+  }
+}
 </script>
+
+<svelte:window on:keydown="{handleKeydown}" />
 
 <div class="w-full h-full">
   <div class="flex h-full flex-col">

--- a/packages/renderer/src/lib/ui/FormPage.spec.ts
+++ b/packages/renderer/src/lib/ui/FormPage.spec.ts
@@ -17,12 +17,13 @@
  ***********************************************************************/
 
 import '@testing-library/jest-dom/vitest';
-import { test, expect, vi } from 'vitest';
+import { test, expect, vi, beforeEach } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/svelte';
 import FormPage from './FormPage.svelte';
 import { lastPage, currentPage } from '../../stores/breadcrumb';
 import type { TinroBreadcrumb } from 'tinro';
 import { router } from 'tinro';
+import userEvent from '@testing-library/user-event';
 
 // mock the router
 vi.mock('tinro', () => {
@@ -31,6 +32,10 @@ vi.mock('tinro', () => {
       goto: vi.fn(),
     },
   };
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
 });
 
 test('Expect title is defined', async () => {
@@ -81,9 +86,9 @@ test('Expect backlink is defined', async () => {
   expect(backElement).toBeInTheDocument();
   expect(backElement).toHaveTextContent(backName);
 
-  fireEvent.click(backElement);
+  await fireEvent.click(backElement);
 
-  expect(router.goto).toBeCalledWith('/back');
+  expect(router.goto).toHaveBeenCalledWith('/back');
 });
 
 test('Expect close link is defined', async () => {
@@ -96,4 +101,16 @@ test('Expect close link is defined', async () => {
   const closeElement = screen.getByTitle('Close');
   expect(closeElement).toBeInTheDocument();
   expect(closeElement).toHaveAttribute('href', backPath);
+});
+
+test('Expect Escape key works', async () => {
+  const backPath = '/back';
+  lastPage.set({ name: 'Back', path: backPath } as TinroBreadcrumb);
+  render(FormPage, {
+    title: 'No Title',
+  });
+
+  await userEvent.keyboard('{Escape}');
+
+  expect(router.goto).toHaveBeenCalledWith('/back');
 });

--- a/packages/renderer/src/lib/ui/FormPage.svelte
+++ b/packages/renderer/src/lib/ui/FormPage.svelte
@@ -1,10 +1,24 @@
 <script lang="ts">
 import { lastPage, currentPage } from '../../stores/breadcrumb';
+import { router } from 'tinro';
 import Link from './Link.svelte';
 
 export let title: string;
 export let showBreadcrumb = true;
+
+export function close(): void {
+  router.goto($lastPage.path);
+}
+
+function handleKeydown(e: KeyboardEvent) {
+  if (e.key === 'Escape') {
+    close();
+    e.preventDefault();
+  }
+}
 </script>
+
+<svelte:window on:keydown="{handleKeydown}" />
 
 <div class="flex flex-col w-full h-full shadow-pageheader">
   <div class="flex flex-row w-full h-fit px-5 py-4">


### PR DESCRIPTION
### What does this PR do?

Inspired by issue #2853: if you click Escape on any Form or Details page we should close the page and return to the previous.

Exposed form close() method to match DetailsPage (in case consumers want to close for other reasons), and tests added.

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

Fixes #4086.

### How to test this PR?

Open a Details page (e.g. Image Details) and click Esc. Open a Form page (e.g. Pull Image) and click Esc.