### PR TITLE
fix: run image error spacing

### DIFF
--- a/packages/renderer/src/lib/image/RunImage.svelte
+++ b/packages/renderer/src/lib/image/RunImage.svelte
@@ -585,16 +585,19 @@ function checkContainerName(event: any) {
                   class="w-full p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700 border {containerNameError
                     ? 'border-red-500'
                     : 'border-charcoal-800'}" />
-                <ErrorMessage class="h-1 text-sm" error="{containerNameError}" />
-                <label for="modalEntrypoint" class="block mb-2 text-sm font-medium text-gray-400 dark:text-gray-400"
-                  >Entrypoint:</label>
+                {#if containerNameError}
+                  <ErrorMessage class="text-sm" error="{containerNameError}" />
+                {/if}
+                <label
+                  for="modalEntrypoint"
+                  class="pt-4 block mb-2 text-sm font-medium text-gray-400 dark:text-gray-400">Entrypoint:</label>
                 <input
                   type="text"
                   bind:value="{entrypoint}"
                   name="modalEntrypoint"
                   id="modalEntrypoint"
                   class="w-full p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700 border border-charcoal-800" />
-                <label for="modalCommand" class="block mb-2 text-sm font-medium text-gray-400 dark:text-gray-400"
+                <label for="modalCommand" class="pt-4 block mb-2 text-sm font-medium text-gray-400 dark:text-gray-400"
                   >Command:</label>
                 <input
                   type="text"


### PR DESCRIPTION
### What does this PR do?

Fixes error message over top of the field and label as shown in issue #3628. You can notice the Entrypoint field in the issue is also very close to the following Command label - both fields did not have the pt-4 padding that every other field in this form has. Adding this back leaves a blank line for the error, so I added an if statement as we do in many other uses of ErrorMessage.

### Screenshot/screencast of this PR

<img width="476" alt="Screenshot 2023-09-25 at 4 50 40 PM" src="https://github.com/containers/podman-desktop/assets/19958075/7cd10da4-8714-4edc-ac48-fc9a9b5a80ba">

### What issues does this PR fix or reference?

Fixes #3628.

### How to test this PR?

Run an image and type a container name that's already in use.