### PR TITLE
fix: avoid errors with unexpected JSON input

### DIFF
--- a/packages/renderer/src/lib/container/container-utils.spec.ts
+++ b/packages/renderer/src/lib/container/container-utils.spec.ts
@@ -249,3 +249,29 @@ test('should expect icon to be ContainerIcon if no context/view is passed', asyn
   expect(containerUI.icon).toBeDefined();
   expect(typeof containerUI.icon !== 'string').toBe(true);
 });
+
+test('check parsing of container info without names', async () => {
+  const containerInfo = {
+    Id: 'container1',
+    Image: 'registry.k8s.io/pause:3.7',
+    Labels: {
+      'io.cri-containerd.kind': 'sandbox',
+    },
+    Names: '',
+    State: 'RUNNING',
+  } as unknown as ContainerInfo;
+  const name = containerUtils.getName(containerInfo);
+  expect(name).toBe('');
+});
+
+test('check parsing of container info without labels', async () => {
+  const context = new ContextUI();
+  const containerInfo = {
+    Id: 'container1',
+    Image: 'registry.k8s.io/pause:3.7',
+    Labels: '',
+    Names: ['container1'],
+    State: 'RUNNING',
+  } as unknown as ContainerInfo;
+  containerUtils.adaptContextOnContainer(context, containerInfo);
+});

--- a/packages/renderer/src/lib/container/container-utils.ts
+++ b/packages/renderer/src/lib/container/container-utils.ts
@@ -38,6 +38,9 @@ export class ContainerUtils {
         return `${composeService}-${composeContainerNumber}`;
       }
     }
+    if (containerInfo.Names.length === 0) {
+      return '';
+    }
     return containerInfo.Names[0].replace(/^\//, '');
   }
 
@@ -263,6 +266,6 @@ export class ContainerUtils {
   }
 
   adaptContextOnContainer(context: ContextUI, container: ContainerInfo): void {
-    context.setValue('containerLabelKeys', Object.keys(container.Labels));
+    context.setValue('containerLabelKeys', container.Labels ? Object.keys(container.Labels) : []);
   }
 }


### PR DESCRIPTION
If either Names or Labels of a container was empty (null), then there would just be a black screen and an error log.

### What does this PR do?

Ran into some docker compatibility errors / parsing assumptions, when dealing with showing `containerd`  containers.

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast 
explaining what is doing this PR -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop 
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to reproduce -->
