### PR TITLE
feat: add docker compatibility button in settings

### DIFF
--- a/extensions/podman/package.json
+++ b/extensions/podman/package.json
@@ -138,6 +138,12 @@
           "scope": "ContainerProviderConnectionFactory",
           "description": "Start the machine now",
           "when": "podman.isStartNowAtMachineInitSupported"
+        },
+        "podman.setting.dockerCompatibility": {
+          "type": "boolean",
+          "default": false,
+          "description": "Docker compatibility mode is a feature that allows you to use Podman as a drop-in replacement for Docker-compatible CLI tools. Podman will automatically emulate a Docker API socket connection (typically) to /var/run/docker.sock. NOTE: This requires administrative privileges.",
+          "when": "!isWindows"
         }
       }
     },

--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -63,6 +63,9 @@ const containerProviderConnections = new Map<string, extensionApi.ContainerProvi
 let isDisguisedPodmanSocket = true;
 let disguisedPodmanSocketWatcher: extensionApi.FileSystemWatcher | undefined;
 
+// Configuration buttons
+const configurationCompatibilityMode = 'setting.dockerCompatibility';
+
 export type MachineJSON = {
   Name: string;
   CPUs: number;
@@ -787,6 +790,13 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
   // Compatibility mode status bar item
   // only available for macOS or Linux (for now).
   if (isMac() || isLinux()) {
+    // Handle any configuration changes (for example, changing the boolean button for compatibility mode)
+    extensionApi.configuration.onDidChangeConfiguration(async e => {
+      if (e.affectsConfiguration(`podman.${configurationCompatibilityMode}`)) {
+        await handleCompatibilityModeSetting();
+      }
+    });
+
     // Get the socketCompatibilityClass for the current OS.
     const socketCompatibilityMode = getSocketCompatibility();
 
@@ -1256,9 +1266,30 @@ async function checkDisguisedPodmanSocket(provider: extensionApi.Provider) {
     isDisguisedPodmanSocket = disguisedCheck;
   }
 
+  // If it's disguised on startup, set the enable-docker-compatibility setting accordingly
+  await extensionApi.configuration.getConfiguration('podman').update(configurationCompatibilityMode, disguisedCheck);
+
   // If isDisguisedPodmanSocket is true, we'll push a warning up to the plugin library with getDisguisedPodmanWarning()
   // If isDisguisedPodmanSocket is false, we'll push an empty array up to the plugin library to clear the warning
   // as we have no other warnings to display (or implemented)
   const retrievedWarnings = isDisguisedPodmanSocket ? [] : [getDisguisedPodmanInformation()];
   provider.updateWarnings(retrievedWarnings);
+}
+
+// Shortform for getting the compatibility mode setting
+function getCompatibilityModeSetting(): boolean {
+  return extensionApi.configuration.getConfiguration('podman').get<boolean>(configurationCompatibilityMode);
+}
+
+// Handle the setting by checking the compatibility
+// and retrieving the correct socket compatibility class as well
+export async function handleCompatibilityModeSetting(): Promise<void> {
+  const compatibilityMode = getCompatibilityModeSetting();
+  const socketCompatibilityMode = getSocketCompatibility();
+
+  if (compatibilityMode) {
+    await socketCompatibilityMode.enable();
+  } else {
+    await socketCompatibilityMode.disable();
+  }
 }


### PR DESCRIPTION
feat: add docker compatibility button in settings

### What does this PR do?

This PR adds a "docker compatibility" enable and disable button within
the Podman extension settings rather than having to go through the
status bar in order to enable / disable the setting.

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast
explaining what is doing this PR -->


https://github.com/containers/podman-desktop/assets/6422176/902b2566-62ad-4ee6-87af-6a9a2705de99




### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop/issues/3851
Closes https://github.com/containers/podman-desktop/issues/3709

### How to test this PR?

<!-- Please explain steps to reproduce -->

Go into settings and click enable / disable on the button.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
