### PR TITLE
feat: onboarding: adds dynamic refresh for content using "when" class

### DIFF
--- a/packages/main/src/plugin/api/onboarding.ts
+++ b/packages/main/src/plugin/api/onboarding.ts
@@ -25,6 +25,7 @@ export interface OnboardingCommandResponse {
 export interface OnboardingStepItem {
   value: string;
   highlight?: boolean;
+  when?: string;
 }
 
 export type OnboardingStatus = 'completed' | 'failed' | 'skipped';

--- a/packages/renderer/src/lib/onboarding/Onboarding.spec.ts
+++ b/packages/renderer/src/lib/onboarding/Onboarding.spec.ts
@@ -152,3 +152,124 @@ test('Expect to have the embedded component if the step includes a component', a
   const bodyDiv = screen.queryByLabelText('step body');
   expect(bodyDiv).not.toBeInTheDocument();
 });
+
+test('Expect content to show / render when when clause is true', async () => {
+  (window as any).resetOnboarding = vi.fn();
+  (window as any).updateStepState = vi.fn();
+
+  onboardingList.set([
+    {
+      extension: 'id',
+      title: 'onboarding',
+      steps: [
+        {
+          id: 'step',
+          title: 'step',
+          state: 'completed',
+          completionEvents: [],
+          content: [
+            [
+              {
+                value: 'helloworld',
+                when: 'true',
+              },
+            ],
+          ],
+        },
+      ],
+      enablement: 'true',
+    },
+  ]);
+  context.set(new ContextUI());
+  await waitRender({
+    extensionIds: ['id'],
+  });
+  // Get by specifically the paragraph element with the text helloworld
+  const paragraph = screen.getAllByText('helloworld');
+  expect(paragraph[0]).toBeInTheDocument();
+});
+
+test('Expect content to NOT show / render when when clause is false', async () => {
+  (window as any).resetOnboarding = vi.fn();
+  (window as any).updateStepState = vi.fn();
+
+  onboardingList.set([
+    {
+      extension: 'id',
+      title: 'onboarding',
+      steps: [
+        {
+          id: 'step',
+          title: 'step',
+          state: 'completed',
+          completionEvents: [],
+          content: [
+            [
+              {
+                value: 'helloworld',
+                when: 'false',
+              },
+            ],
+          ],
+        },
+      ],
+      enablement: 'true',
+    },
+  ]);
+  context.set(new ContextUI());
+  await waitRender({
+    extensionIds: ['id'],
+  });
+  const helloDoesntExist = screen.queryByText('helloworld');
+  expect(helloDoesntExist).not.toBeInTheDocument();
+});
+
+test('Expect content with "when" to change dynamically when setting has been updated via context.', async () => {
+  (window as any).resetOnboarding = vi.fn();
+  (window as any).updateStepState = vi.fn();
+
+  const contextConfig = new ContextUI();
+  context.set(contextConfig);
+  contextConfig.setValue('config.test', false);
+
+  onboardingList.set([
+    {
+      extension: 'id',
+      title: 'onboarding',
+      steps: [
+        {
+          id: 'step',
+          title: 'step',
+          state: 'completed',
+          completionEvents: [],
+          content: [
+            [
+              {
+                value: 'helloworld',
+                when: 'config.test',
+              },
+            ],
+          ],
+        },
+      ],
+      enablement: 'true',
+    },
+  ]);
+
+  await waitRender({
+    extensionIds: ['id'],
+  });
+
+  // Expect "helloworld" to not be in the document
+  const helloDoesntExist = screen.queryByText('helloworld');
+  expect(helloDoesntExist).not.toBeInTheDocument();
+
+  contextConfig.setValue('config.test', true);
+  await waitRender({
+    extensionIds: ['id'],
+  });
+
+  // Expect "helloworld" to exist
+  const helloExists = screen.getAllByText('helloworld');
+  expect(helloExists[0]).toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/onboarding/Onboarding.svelte
+++ b/packages/renderer/src/lib/onboarding/Onboarding.svelte
@@ -33,11 +33,7 @@ export let extensionIds: string[] = [];
 let onboardings: OnboardingInfo[];
 let activeStep: ActiveOnboardingStep;
 $: activeStep;
-
-// Content may be dynamically updated via "when" statements
-// this allows us to show warnings when clicking buttons, etc
 let activeStepContent: OnboardingStepItem[][];
-$: activeStepContent;
 
 $: executing = false;
 let globalContext: ContextUI;


### PR DESCRIPTION
feat: onboarding: adds dynamic refresh for content using "when" class

### What does this PR do?

* Be able to add `when` to content and have it dynamically update as
  part of the onboarding.
* For example: Remove content / add a warning depending on button
  presses / what's happening when updating.

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast
explaining what is doing this PR -->



https://github.com/containers/podman-desktop/assets/6422176/1098dcd3-5dbb-4aee-8d41-0cd675aebed0




### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop/issues/4048

### How to test this PR?

Run tests, or:

edit `package.json` and add:

`"when": "podman.test"`

To:

```
        {
          "id": "podmanInstalled",
          "title": "${onboardingContext:podmanInstalledTitle}",
          "when": "!onboardingContext:podmanIsNotInstalled",
          "content": [
            [
              {
                "value": "${configuration:preferences.podman-desktop.podman.engine.autostart}",
                "when": "podman.test"
              }
            ]
          ]
        },
```

Then edit `podman/extension.ts` and add the following code:

Outside the `activate() function`:

```
let test: boolean;
```

Within the `activate()` function:

```
  setInterval(() => {
    test = !test;
    extensionApi.context.setValue('podman.test', test);
    console.log('podman.test set to ', test);
  }, 5000);
```

This will update the value every 5 seconds within Podman Desktop.

Click on the onboarding sequence for podman and you'll see that the
content for autostart will now dissapear / reappear every 5 seconds as
`podman.test` is being set.

<!-- Please explain steps to reproduce -->

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
