### PR TITLE
fix: solid pod icon

### DIFF
--- a/packages/renderer/src/lib/ContainerList.svelte
+++ b/packages/renderer/src/lib/ContainerList.svelte
@@ -39,6 +39,7 @@ import type { ViewInfoUI } from '../../../main/src/plugin/api/view-info';
 import type { ContextUI } from './context/context';
 import Button from './ui/Button.svelte';
 import StateChange from './ui/StateChange.svelte';
+import SolidPodIcon from './images/SolidPodIcon.svelte';
 
 const containerUtils = new ContainerUtils();
 let openChoiceModal = false;
@@ -434,7 +435,7 @@ function errorCallback(container: ContainerInfoUI, errorMessage: string): void {
       <Button
         on:click="{() => createPodFromContainers()}"
         title="Create Pod with {selectedItemsNumber} selected items"
-        icon="{PodIcon}" />
+        icon="{SolidPodIcon}" />
       <span class="pl-2">On {selectedItemsNumber} selected items.</span>
     {/if}
   </div>

--- a/packages/renderer/src/lib/images/SolidPodIcon.svelte
+++ b/packages/renderer/src/lib/images/SolidPodIcon.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+import PodIcon from './PodIcon.svelte';
+
+export let size = '1em';
+</script>
+
+<PodIcon size="{size}" solid="{true}" />

--- a/packages/renderer/src/lib/pod/PodCreateFromContainers.svelte
+++ b/packages/renderer/src/lib/pod/PodCreateFromContainers.svelte
@@ -11,7 +11,7 @@ import StatusIcon from '../images/StatusIcon.svelte';
 import ContainerIcon from '../images/ContainerIcon.svelte';
 import { faTriangleExclamation } from '@fortawesome/free-solid-svg-icons';
 import Fa from 'svelte-fa/src/fa.svelte';
-import PodIcon from '../images/PodIcon.svelte';
+import SolidPodIcon from '../images/SolidPodIcon.svelte';
 import Button from '../ui/Button.svelte';
 import type { PodCreatePortOptions } from '../../../../main/src/plugin/dockerode/libpod-dockerode';
 
@@ -195,7 +195,7 @@ function updatePortExposure(port: number, checked: boolean) {
 </script>
 
 <FormPage title="Copy containers to a pod">
-  <PodIcon slot="icon" solid="{true}" />
+  <SolidPodIcon slot="icon" size="40" />
 
   <div class="min-w-full h-fit" slot="content">
     <div class="m-5 p-6 bg-charcoal-800 rounded-sm text-gray-700">
@@ -306,7 +306,7 @@ function updatePortExposure(port: number, checked: boolean) {
           <div>
             <Button type="link" on:click="{() => router.goto('/containers')}">Close</Button>
             <Button
-              icon="{PodIcon}"
+              icon="{SolidPodIcon}"
               bind:disabled="{createInProgress}"
               on:click="{() => {
                 createPodFromContainers();

--- a/packages/renderer/src/lib/ui/Button.svelte
+++ b/packages/renderer/src/lib/ui/Button.svelte
@@ -15,8 +15,6 @@ let iconType: string | undefined = undefined;
 onMount(() => {
   if (icon?.prefix === 'fas') {
     iconType = 'fa';
-  } else if (icon?.name.includes('PodIcon')) {
-    iconType = 'pd';
   } else {
     iconType = 'unknown';
   }
@@ -56,8 +54,6 @@ $: {
         <Spinner size="1em" />
       {:else if iconType === 'fa'}
         <Fa icon="{icon}" />
-      {:else if iconType === 'pd'}
-        <svelte:component this="{icon}" size="1em" solid="{true}" />
       {:else if iconType === 'unknown'}
         <svelte:component this="{icon}" />
       {/if}


### PR DESCRIPTION
### What does this PR do?

Fixes the 'large pod icon regression' when adopting the Button component and using PodIcon. Adds a SolidPodIcon with a more natural default size (1em) and removes the failing custom check in Button.

We may have to do the same with ContainerIcon, ImageIcon, and VolumeIcon at some point, but not doing it now since these components are not used. Likewise we may want to change the default size of all of them to 1em, but that's an independent change.

### Screenshot/screencast of this PR

<img width="171" alt="Screenshot 2023-09-27 at 9 01 43 AM" src="https://github.com/containers/podman-desktop/assets/19958075/7d583c9f-328e-4f8f-93ad-cbadfb5e4960">

### What issues does this PR fix or reference?

Fixes #4090.

### How to test this PR?

Open Container page and select one, then click the button to view the form.