### PR TITLE
nit: no need for reactive statement

### DIFF
--- a/packages/renderer/src/lib/onboarding/Onboarding.svelte
+++ b/packages/renderer/src/lib/onboarding/Onboarding.svelte
@@ -32,7 +32,6 @@ export let extensionIds: string[] = [];
 
 let onboardings: OnboardingInfo[];
 let activeStep: ActiveOnboardingStep;
-$: activeStep;
 let activeStepContent: OnboardingStepItem[][];
 
 $: executing = false;


### PR DESCRIPTION
nit: no need for reactive statement

### What does this PR do?

activeStep is updated via the assetStepCompleted function within the
context subscribe, so no need for reactive `$`.

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast
explaining what is doing this PR -->

N/A

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

References comment from https://github.com/containers/podman-desktop/pull/4108#discussion_r1338705625

### How to test this PR?

<!-- Please explain steps to reproduce -->

Click through onboarding, nothing should have changed.

Or run tests

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
