### PR TITLE
chore: update blog post link when creating PR to bump Podman Desktop

### DIFF
--- a/.github/workflows/publish-to-podman_io.yaml
+++ b/.github/workflows/publish-to-podman_io.yaml
@@ -59,9 +59,14 @@ jobs:
 
       - name: Replace the content of the file
         run: |
-          # Replace the version in static/data/global.ts file (replace the 1.0.1 value)
-          # export const LATEST_DESKTOP_VERSION = '1.0.1';
+          # Replace the version in static/data/global.ts file (replace the xxx value)
+          # export const LATEST_DESKTOP_VERSION = 'xxx';
           sed -i "s/export const LATEST_DESKTOP_VERSION = '.*';/export const LATEST_DESKTOP_VERSION = '${{ steps.VERSION.outputs.desktopVersion }}';/g" static/data/global.ts
+          # Replace the version of the blog post
+          # export const LATEST_DESKTOP_DOWNLOAD_URL = 'https://podman-desktop.io/blog/podman-desktop-release-xxx';
+          # need to strip out the last digit after the last . to get the blog post version (so for example 1.4.1 becomes 1.4)
+          blogPostVersion=$(echo ${{ steps.VERSION.outputs.desktopVersion }} | sed 's/\.[^.]*$//')
+          sed -i "s/export const LATEST_DESKTOP_DOWNLOAD_URL = '.*';/export const LATEST_DESKTOP_DOWNLOAD_URL = 'https:\/\/podman-desktop.io\/blog\/podman-desktop-release-$blogPostVersion';/g" static/data/global.ts
           echo "New content of the file:"
           cat static/data/global.ts
 


### PR DESCRIPTION
### What does this PR do?
 until now it was only updating the version of Podman Desktop, now it will also update the blog post article

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast 
explaining what is doing this PR -->

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/4051

### How to test this PR?

you can try the sed expression