### PR TITLE
fix: clean step body if new step has no content

### DIFF
--- a/packages/renderer/src/lib/onboarding/Onboarding.svelte
+++ b/packages/renderer/src/lib/onboarding/Onboarding.svelte
@@ -62,13 +62,12 @@ onMount(async () => {
 
     // When the context is updated while on the content page,
     // update the step content to show / hide rows based on the "when" clause
-    if (activeStep?.step.content) {
-      activeStepContent = activeStep.step.content.map(row => {
+    activeStepContent =
+      activeStep?.step.content?.map(row => {
         return row.filter(item => {
           return evaluateWhen(item.when, activeStep.onboarding.extension);
         });
-      });
-    }
+      }) || [];
 
     // when the context is updated it checks if the onboarding already started
     if (started) {
@@ -125,13 +124,12 @@ async function setActiveStep() {
             };
             // When the context is updated while on the content page,
             // update the step content to show / hide rows based on the "when" clause
-            if (step.content) {
-              activeStepContent = step.content.map(row => {
+            activeStepContent =
+              step.content?.map(row => {
                 return row.filter(item => {
                   return evaluateWhen(item.when, onboarding.extension);
                 });
-              });
-            }
+              }) || [];
             if (step.command) {
               await doExecuteCommand(step.command);
               // after command has been executed, we check if the step must be marked as completed


### PR DESCRIPTION
### What does this PR do?

This PR cleans the body of the active onboarding step if the current step has no content to show.

The problem was that if you had two steps (step 1 with content and step 2 empty) when moving from 1 to 2, the old content was still shown because the activeStepContent was not refreshed.
The if prevented to recalculate the stepcontent if the current step content was undefined.

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

N/A

### How to test this PR?

1. should work as before
