### PR TITLE
fix: improve feedback form

### DIFF
--- a/packages/renderer/src/lib/feedback/SendFeedback.spec.ts
+++ b/packages/renderer/src/lib/feedback/SendFeedback.spec.ts
@@ -20,6 +20,7 @@ import '@testing-library/jest-dom/vitest';
 import { beforeAll, test, expect } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/svelte';
 import SendFeedback from './SendFeedback.svelte';
+import userEvent from '@testing-library/user-event';
 
 // fake the window.events object
 beforeAll(() => {
@@ -54,4 +55,59 @@ test('Expect that the button is enabled after clicking on a smiley', async () =>
 
   // and the indication is gone
   expect(screen.queryByText('Please select an experience smiley')).not.toBeInTheDocument();
+});
+
+test('Expect very sad smiley errors without feedback', async () => {
+  render(SendFeedback, {});
+  const button = screen.getByRole('button', { name: 'Send feedback' });
+  expect(button).toBeDisabled();
+
+  // expect to have indication why the button is disabled
+  expect(screen.getByText('Please select an experience smiley')).toBeInTheDocument();
+
+  // click on very sad smiley
+  const smiley = screen.getByRole('button', { name: 'very-sad-smiley' });
+  await fireEvent.click(smiley);
+
+  // expect button is still disabled, but with different indication
+  expect(button).toBeDisabled();
+  const message = screen.getByText('Please share contact info or details on how we can improve');
+  expect(message).toBeInTheDocument();
+
+  // add some text
+  const feedback = screen.getByTestId('tellUsWhyFeedback');
+  expect(feedback).toBeInTheDocument();
+
+  await userEvent.type(feedback, 'PD is awesome');
+
+  // button is enabled and the indication is gone
+  expect(button).toBeEnabled();
+  expect(message).not.toBeInTheDocument();
+});
+
+test('Expect sad smiley warns without feedback', async () => {
+  render(SendFeedback, {});
+  const button = screen.getByRole('button', { name: 'Send feedback' });
+  expect(button).toBeDisabled();
+
+  // expect to have indication why the button is disabled
+  expect(screen.getByText('Please select an experience smiley')).toBeInTheDocument();
+
+  // click on very sad smiley
+  const smiley = screen.getByRole('button', { name: 'sad-smiley' });
+  await fireEvent.click(smiley);
+
+  // expect button is now enabled, but with different indication
+  expect(button).toBeEnabled();
+  const warn = screen.getByText('We would really appreciate knowing how we can improve');
+  expect(warn).toBeInTheDocument();
+
+  // add some text
+  const feedback = screen.getByTestId('tellUsWhyFeedback');
+  expect(feedback).toBeInTheDocument();
+
+  await userEvent.type(feedback, 'PD is awesome');
+
+  // and the indication is gone
+  expect(warn).not.toBeInTheDocument();
 });

--- a/packages/renderer/src/lib/feedback/SendFeedback.svelte
+++ b/packages/renderer/src/lib/feedback/SendFeedback.svelte
@@ -5,6 +5,7 @@ import Modal from '../dialogs/Modal.svelte';
 import type { FeedbackProperties } from '../../../../preload/src/index';
 import ErrorMessage from '../ui/ErrorMessage.svelte';
 import Button from '../ui/Button.svelte';
+import WarningMessage from '../ui/WarningMessage.svelte';
 let displayModal = false;
 
 // feedback of the user
@@ -99,9 +100,10 @@ async function sendFeedback(): Promise<void> {
           maxlength="1000"
           name="tellUsWhyFeedback"
           id="tellUsWhyFeedback"
+          data-testid="tellUsWhyFeedback"
           bind:value="{tellUsWhyFeedback}"
           class="w-full p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700"
-        ></textarea>
+          placeholder="Please enter your feedback here, we appreciate and review all comments"></textarea>
 
         <label for="contactInformation" class="block mt-4 mb-2 text-sm font-medium text-gray-400 dark:text-gray-400"
           >Share your contact information if you'd like us to answer you:</label>
@@ -110,17 +112,27 @@ async function sendFeedback(): Promise<void> {
           name="contactInformation"
           id="contactInformation"
           bind:value="{contactInformation}"
-          placeholder="Enter email address, phone number or leave blank for anonymous feedback"
+          placeholder="Enter email address, phone number, or leave blank for anonymous feedback"
           class="w-full p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700" />
 
-        <div class="pt-5 flex flex-row w-full">
-          {#if smileyRating === 0}
-            <ErrorMessage class="flex flex-row w-[350px] text-xs" error="Please select an experience smiley" />
-          {/if}
-
-          <div class="flex flex-row justify-end w-full">
-            <Button disabled="{smileyRating === 0}" on:click="{() => sendFeedback()}">Send feedback</Button>
+        <div class="pt-5 flex flex-row w-full justify-between">
+          <div>
+            {#if smileyRating === 0}
+              <ErrorMessage class="flex flex-row w-[350px] text-xs" error="Please select an experience smiley" />
+            {:else if smileyRating === 1 && !tellUsWhyFeedback && !contactInformation}
+              <ErrorMessage
+                class="flex flex-row w-[350px] text-xs"
+                error="Please share contact info or details on how we can improve" />
+            {:else if smileyRating === 2 && !tellUsWhyFeedback}
+              <WarningMessage
+                class="flex flex-row w-[350px] text-xs"
+                error="We would really appreciate knowing how we can improve" />
+            {/if}
           </div>
+
+          <Button
+            disabled="{smileyRating === 0 || (smileyRating === 1 && !tellUsWhyFeedback && !contactInformation)}"
+            on:click="{() => sendFeedback()}">Send feedback</Button>
         </div>
       </div>
     </div>

--- a/packages/renderer/src/lib/feedback/SendFeedback.svelte
+++ b/packages/renderer/src/lib/feedback/SendFeedback.svelte
@@ -13,6 +13,10 @@ let smileyRating = 0;
 let tellUsWhyFeedback = '';
 let contactInformation = '';
 
+$: hasFeedback =
+  (tellUsWhyFeedback && tellUsWhyFeedback.trim().length > 4) ||
+  (contactInformation && contactInformation.trim().length > 4);
+
 window.events?.receive('display-feedback', () => {
   displayModal = true;
 });
@@ -119,11 +123,11 @@ async function sendFeedback(): Promise<void> {
           <div>
             {#if smileyRating === 0}
               <ErrorMessage class="flex flex-row w-[350px] text-xs" error="Please select an experience smiley" />
-            {:else if smileyRating === 1 && !tellUsWhyFeedback && !contactInformation}
+            {:else if smileyRating === 1 && !hasFeedback}
               <ErrorMessage
                 class="flex flex-row w-[350px] text-xs"
                 error="Please share contact info or details on how we can improve" />
-            {:else if smileyRating === 2 && !tellUsWhyFeedback}
+            {:else if smileyRating === 2 && !hasFeedback}
               <WarningMessage
                 class="flex flex-row w-[350px] text-xs"
                 error="We would really appreciate knowing how we can improve" />
@@ -131,7 +135,7 @@ async function sendFeedback(): Promise<void> {
           </div>
 
           <Button
-            disabled="{smileyRating === 0 || (smileyRating === 1 && !tellUsWhyFeedback && !contactInformation)}"
+            disabled="{smileyRating === 0 || (smileyRating === 1 && !hasFeedback)}"
             on:click="{() => sendFeedback()}">Send feedback</Button>
         </div>
       </div>

--- a/packages/renderer/src/lib/feedback/SendFeedback.svelte
+++ b/packages/renderer/src/lib/feedback/SendFeedback.svelte
@@ -112,11 +112,11 @@ async function sendFeedback(): Promise<void> {
         <label for="contactInformation" class="block mt-4 mb-2 text-sm font-medium text-gray-400 dark:text-gray-400"
           >Share your contact information if you'd like us to answer you:</label>
         <input
-          type="text"
+          type="email"
           name="contactInformation"
           id="contactInformation"
           bind:value="{contactInformation}"
-          placeholder="Enter email address, phone number, or leave blank for anonymous feedback"
+          placeholder="Enter email address, or leave blank for anonymous feedback"
           class="w-full p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700" />
 
         <div class="pt-5 flex flex-row w-full justify-between">

--- a/packages/renderer/src/lib/ui/WarningMessage.svelte
+++ b/packages/renderer/src/lib/ui/WarningMessage.svelte
@@ -15,9 +15,9 @@ export let icon = false;
   {/if}
 {:else}
   <div
-    class="text-amber-500 p-1 flex flex-row items-top {$$props.class}"
+    class="text-amber-500 p-1 flex flex-row items-center {$$props.class}"
     class:opacity-0="{error === undefined || error === ''}">
-    <Fa size="18" class="cursor-pointer text-amber-500 mt-1" icon="{faTriangleExclamation}" />
-    <div class="ml-2">{error}</div>
+    <Fa size="18" class="cursor-pointer text-amber-500" icon="{faTriangleExclamation}" />
+    <div role="alert" aria-label="Warning Message Content" class="ml-2">{error}</div>
   </div>
 {/if}


### PR DESCRIPTION
### What does this PR do?

If you select the unhappy smiley and haven't added details or contact info, the feedback button stays disabled and there's a new error message: "Please share contact info or details on how we can improve".

If you select the 'meh' smiley and haven't entered details the feedback is not disabled, but there's a new warning message: "We would really appreciate knowing how we can improve".

The form also has a new placeholder in the details to say we appreciate and review all comments.

Suggestions on improving these feedback messages appreciated. :)

Two minor indirect fixes: had to fix the bottom layout to handle longer messages, and updated WarningMessage to match ErrorMessage (it was missing vertical alignment and aria fixes that ErrorMessage had).

### Screenshot/screencast of this PR

<img width="481" alt="Screenshot 2023-09-28 at 3 33 33 PM" src="https://github.com/containers/podman-desktop/assets/19958075/51045f5f-53c8-4531-b6a8-61436001f5e6">
<img width="481" alt="Screenshot 2023-09-28 at 3 33 44 PM" src="https://github.com/containers/podman-desktop/assets/19958075/c81e61a3-b36d-4582-a2c1-7a99d0fcd29d">

### What issues does this PR fix or reference?

Fixes #3974.

### How to test this PR?

Open feedback form and try different smileys.