### PR TITLE
fix(test): flake in telemetry

### DIFF
--- a/packages/renderer/src/Route.svelte
+++ b/packages/renderer/src/Route.svelte
@@ -4,6 +4,7 @@ import type { TinroBreadcrumb, TinroRouteMeta } from 'tinro';
 import { TelemetryService } from './TelemetryService';
 import { lastPage, currentPage, listPage, detailsPage } from './stores/breadcrumb';
 import type { NavigationHint } from './Route';
+import { onDestroy } from 'svelte';
 
 export let path = '/*';
 export let fallback = false;
@@ -70,6 +71,10 @@ $: route.update({
   redirect,
   firstmatch,
   breadcrumb,
+});
+
+onDestroy(() => {
+  TelemetryService.getService().handlePageClose();
 });
 </script>
 

--- a/packages/renderer/src/TelemetryService.ts
+++ b/packages/renderer/src/TelemetryService.ts
@@ -33,10 +33,7 @@ export class TelemetryService {
   private handlerFlusher: NodeJS.Timeout | undefined;
 
   public handlePageOpen(pagePath: string) {
-    if (this.handlerFlusher !== undefined) {
-      clearTimeout(this.handlerFlusher);
-      this.handlerFlusher = undefined;
-    }
+    this.handlePageClose();
 
     this.handlerFlusher = setTimeout(() => {
       if (window.telemetryPage) {
@@ -45,5 +42,13 @@ export class TelemetryService {
         });
       }
     }, 200);
+  }
+
+  // clear timeout
+  public handlePageClose() {
+    if (this.handlerFlusher) {
+      clearTimeout(this.handlerFlusher);
+      this.handlerFlusher = undefined;
+    }
   }
 }


### PR DESCRIPTION
### What does this PR do?
clear the timeout when the component is destroyed
else we may have code being executed once environment is gone

vitest, when it's tearing down the test, remove all global objects  like window, navigator, etc
we should remove any pending timeout when the component is removed so there is no late execution

(move the code to a separate method that was cleaning the timeout)

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast 
explaining what is doing this PR -->

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/3567

### How to test this PR?

<!-- Please explain steps to reproduce -->
