### PR TITLE
docs: Correct windows instructions for migrating from docker

### DIFF
--- a/website/docs/migrating-from-docker/using-the-docker_host-environment-variable.md
+++ b/website/docs/migrating-from-docker/using-the-docker_host-environment-variable.md
@@ -23,37 +23,53 @@ Consider using the `DOCKER_HOST` environment variable to migrate transparently f
 
 #### Procedure
 
-1. Identify the location of your Podman socket
+ <Tabs groupId="operating-systems">
+   <TabItem value="win" label="Windows">
+     
+  1. Identify the location of your Podman socket
+     
+   ```shell-session
+   $ podman machine inspect --format '{{.ConnectionInfo.PodmanPipe.Path}}'
+   ```
 
-   <Tabs groupId="operating-systems">
-     <TabItem value="win" label="Windows">
+  2. Set the `DOCKER_HOST` environment variable to your Podman socket location. Be sure to add the `npipe://` scheme to the path retrieved previously:
+  
+   ```shell-session
+   $ export DOCKER_HOST=npipe://<your_podman_socket_location>
+   ```
 
+  Note that setting the `DOCKER_HOST` environment variable isn't neccesary on windows since Podman also listens to the default `docker_engine` pipe.
+   </TabItem>
+   <TabItem value="mac" label="macOS">
+
+  1. Identify the location of your Podman socket
+  
    ```shell-session
    $ podman machine inspect --format '{{.ConnectionInfo.PodmanSocket.Path}}'
    ```
 
-     </TabItem>
-     <TabItem value="mac" label="macOS">
+  2. Set the `DOCKER_HOST` environment variable to your Podman socket location. Be sure to add the `unix://` scheme to the path retrieved previously:
 
    ```shell-session
-   $ podman machine inspect --format '{{.ConnectionInfo.PodmanSocket.Path}}'
+   $ export DOCKER_HOST=unix://<your_podman_socket_location>
    ```
+   </TabItem>
+   <TabItem value="linux" label="Linux">
 
-     </TabItem>
-     <TabItem value="linux" label="Linux">
+  1. Identify the location of your Podman socket
 
    ```shell-session
    $ podman info --format '{{.Host.RemoteSocket.Path}}'
    ```
 
-     </TabItem>
-   </Tabs>
-
-2. Set the `DOCKER_HOST` environment variable to your Podman socket location. Be sure to add the `unix://` scheme to the path retrieved previously:
-
+  2. Set the `DOCKER_HOST` environment variable to your Podman socket location. Be sure to add the `unix://` scheme to the path retrieved previously:
+  
    ```shell-session
    $ export DOCKER_HOST=unix://<your_podman_socket_location>
    ```
+   </TabItem>
+
+ </Tabs>
 
 #### Verification
 

--- a/website/docs/migrating-from-docker/using-the-docker_host-environment-variable.md
+++ b/website/docs/migrating-from-docker/using-the-docker_host-environment-variable.md
@@ -26,16 +26,16 @@ Consider using the `DOCKER_HOST` environment variable to migrate transparently f
  <Tabs groupId="operating-systems">
    <TabItem value="win" label="Windows">
 
-1. Identify the location of your Podman socket
+1. Identify the location of your Podman pipe
 
 ```shell-session
 $ podman machine inspect --format '{{.ConnectionInfo.PodmanPipe.Path}}'
 ```
 
-2. Set the `DOCKER_HOST` environment variable to your Podman socket location. You'll need to replace back slashes with forward slashes and add the `npipe://` scheme to the path retrieved previously:
+2. Set the `DOCKER_HOST` environment variable to your Podman pipe location. You'll need to replace back slashes with forward slashes and add the `npipe://` scheme to the path retrieved previously:
 
 ```shell-session
-$ export DOCKER_HOST=npipe://<your_podman_socket_location>
+$ export DOCKER_HOST=npipe://<your_podman_pipe_location>
 ```
 
 Note that setting the `DOCKER_HOST` environment variable isn't neccesary on windows since Podman also listens to the default `docker_engine` pipe.

--- a/website/docs/migrating-from-docker/using-the-docker_host-environment-variable.md
+++ b/website/docs/migrating-from-docker/using-the-docker_host-environment-variable.md
@@ -25,48 +25,50 @@ Consider using the `DOCKER_HOST` environment variable to migrate transparently f
 
  <Tabs groupId="operating-systems">
    <TabItem value="win" label="Windows">
-     
-  1. Identify the location of your Podman socket
-     
-   ```shell-session
-   $ podman machine inspect --format '{{.ConnectionInfo.PodmanPipe.Path}}'
-   ```
 
-  2. Set the `DOCKER_HOST` environment variable to your Podman socket location. You'll need to replace back slashes with forward slashes and add the `npipe://` scheme to the path retrieved previously:
-  
-   ```shell-session
-   $ export DOCKER_HOST=npipe://<your_podman_socket_location>
-   ```
+1. Identify the location of your Podman socket
 
-  Note that setting the `DOCKER_HOST` environment variable isn't neccesary on windows since Podman also listens to the default `docker_engine` pipe.
-   </TabItem>
-   <TabItem value="mac" label="macOS">
+```shell-session
+$ podman machine inspect --format '{{.ConnectionInfo.PodmanPipe.Path}}'
+```
 
-  1. Identify the location of your Podman socket
-  
-   ```shell-session
-   $ podman machine inspect --format '{{.ConnectionInfo.PodmanSocket.Path}}'
-   ```
+2. Set the `DOCKER_HOST` environment variable to your Podman socket location. You'll need to replace back slashes with forward slashes and add the `npipe://` scheme to the path retrieved previously:
 
-  2. Set the `DOCKER_HOST` environment variable to your Podman socket location. Be sure to add the `unix://` scheme to the path retrieved previously:
+```shell-session
+$ export DOCKER_HOST=npipe://<your_podman_socket_location>
+```
 
-   ```shell-session
-   $ export DOCKER_HOST=unix://<your_podman_socket_location>
-   ```
+Note that setting the `DOCKER_HOST` environment variable isn't neccesary on windows since Podman also listens to the default `docker_engine` pipe.
+</TabItem>
+<TabItem value="mac" label="macOS">
+
+1. Identify the location of your Podman socket
+
+```shell-session
+$ podman machine inspect --format '{{.ConnectionInfo.PodmanSocket.Path}}'
+```
+
+2. Set the `DOCKER_HOST` environment variable to your Podman socket location. Be sure to add the `unix://` scheme to the path retrieved previously:
+
+```shell-session
+$ export DOCKER_HOST=unix://<your_podman_socket_location>
+```
+
    </TabItem>
    <TabItem value="linux" label="Linux">
 
-  1. Identify the location of your Podman socket
+1. Identify the location of your Podman socket
 
-   ```shell-session
-   $ podman info --format '{{.Host.RemoteSocket.Path}}'
-   ```
+```shell-session
+$ podman info --format '{{.Host.RemoteSocket.Path}}'
+```
 
-  2. Set the `DOCKER_HOST` environment variable to your Podman socket location. Be sure to add the `unix://` scheme to the path retrieved previously:
-  
-   ```shell-session
-   $ export DOCKER_HOST=unix://<your_podman_socket_location>
-   ```
+2. Set the `DOCKER_HOST` environment variable to your Podman socket location. Be sure to add the `unix://` scheme to the path retrieved previously:
+
+```shell-session
+$ export DOCKER_HOST=unix://<your_podman_socket_location>
+```
+
    </TabItem>
 
  </Tabs>

--- a/website/docs/migrating-from-docker/using-the-docker_host-environment-variable.md
+++ b/website/docs/migrating-from-docker/using-the-docker_host-environment-variable.md
@@ -32,7 +32,7 @@ Consider using the `DOCKER_HOST` environment variable to migrate transparently f
    $ podman machine inspect --format '{{.ConnectionInfo.PodmanPipe.Path}}'
    ```
 
-  2. Set the `DOCKER_HOST` environment variable to your Podman socket location. Be sure to add the `npipe://` scheme to the path retrieved previously:
+  2. Set the `DOCKER_HOST` environment variable to your Podman socket location. You'll need to replace back slashes with forward slashes and add the `npipe://` scheme to the path retrieved previously:
   
    ```shell-session
    $ export DOCKER_HOST=npipe://<your_podman_socket_location>


### PR DESCRIPTION
### What does this PR do?

On windows, `DOCKER_HOST` is set to a named pipe instead of a socket, and podman has a seperate field for it, "PodmanPipe", the docs accidentally put "PodmanSocket" on windows. This also notes that you don't actually need to set `DOCKER_HOST` on windows, since podman already uses the default `docker_engine` named pipe.

### How to test this PR?

Run command on windows
