### PR TITLE
fix: Removed fullstop from summary

### DIFF
--- a/.flatpak-appdata.xml
+++ b/.flatpak-appdata.xml
@@ -4,7 +4,7 @@
   <name>Podman Desktop</name>
   <project_license>Apache-2.0</project_license>
   <developer_name>Red Hat, Inc.</developer_name>
-  <summary>Manage Podman and other container engines from a single UI and tray.</summary>
+  <summary>Manage Podman and other container engines from a single UI and tray</summary>
   <metadata_license>CC0-1.0</metadata_license>
   <url type="homepage">https://podman-desktop.io/</url>
   <url type="bugtracker">https://github.com/containers/podman-desktop/issues</url>


### PR DESCRIPTION
### What does this PR do?
This PR removes the fullstop from the summary.

### Screenshot/screencast of this PR
![fix](https://github.com/containers/podman-desktop/assets/52111635/8e6c59a8-6adc-473c-83af-d27bd72576ad)

### What issues does this PR fix or reference?
fixes #3077
