### PR TITLE
chore: increase size of status icon in details pages

### DIFF
--- a/packages/renderer/src/lib/compose/ComposeDetails.svelte
+++ b/packages/renderer/src/lib/compose/ComposeDetails.svelte
@@ -86,7 +86,7 @@ onDestroy(() => {
 
 {#if compose}
   <DetailsPage title="{composeName}" subtitle="">
-    <StatusIcon slot="icon" icon="{ComposeIcon}" status="{compose.status}" />
+    <StatusIcon slot="icon" icon="{ComposeIcon}" size="{24}" status="{compose.status}" />
     <svelte:fragment slot="actions">
       <div class="flex items-center w-5">
         <div>&nbsp;</div>

--- a/packages/renderer/src/lib/container/ContainerDetails.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetails.svelte
@@ -80,7 +80,7 @@ function errorCallback(errorMessage: string): void {
 
 {#if container}
   <DetailsPage title="{container.name}" subtitle="{container.shortImage}" bind:this="{detailsPage}">
-    <StatusIcon slot="icon" icon="{ContainerIcon}" status="{container.state}" />
+    <StatusIcon slot="icon" icon="{ContainerIcon}" size="{24}" status="{container.state}" />
     <svelte:fragment slot="actions">
       <div class="flex items-center w-5">
         {#if container.actionError}

--- a/packages/renderer/src/lib/image/ImageDetails.svelte
+++ b/packages/renderer/src/lib/image/ImageDetails.svelte
@@ -59,7 +59,7 @@ onMount(() => {
 
 {#if image}
   <DetailsPage title="{image.name}" titleDetail="{image.shortId}" subtitle="{image.tag}" bind:this="{detailsPage}">
-    <StatusIcon slot="icon" icon="{ImageIcon}" status="{image.inUse ? 'USED' : 'UNUSED'}" />
+    <StatusIcon slot="icon" icon="{ImageIcon}" size="{24}" status="{image.inUse ? 'USED' : 'UNUSED'}" />
     <ImageActions
       slot="actions"
       image="{image}"

--- a/packages/renderer/src/lib/images/StatusIcon.svelte
+++ b/packages/renderer/src/lib/images/StatusIcon.svelte
@@ -6,17 +6,20 @@ import Spinner from '../ui/Spinner.svelte';
 // any other status will result in a standard outlined box
 export let status = '';
 export let icon: any = undefined;
+export let size = 20;
 
 $: solid = status === 'RUNNING' || status === 'STARTING' || status === 'USED' || status === 'DEGRADED';
 </script>
 
 <div class="grid place-content-center" style="position:relative">
   <div
-    class="grid place-content-center w-7 h-7 rounded"
+    class="grid place-content-center rounded aspect-square"
     class:bg-green-400="{status === 'RUNNING' || status === 'USED'}"
     class:bg-green-600="{status === 'STARTING'}"
     class:bg-amber-600="{status === 'DEGRADED'}"
     class:border-2="{!solid && status !== 'DELETING'}"
+    class:p-0.5="{!solid}"
+    class:p-1="{solid}"
     class:border-gray-700="{!solid}"
     class:text-gray-700="{!solid}"
     role="status"
@@ -26,7 +29,7 @@ $: solid = status === 'RUNNING' || status === 'STARTING' || status === 'USED' ||
     {:else if typeof icon === 'string'}
       <span class="{icon}" aria-hidden="true"></span>
     {:else}
-      <svelte:component this="{icon}" size="20" solid="{solid}" />
+      <svelte:component this="{icon}" size="{size}" solid="{solid}" />
     {/if}
   </div>
   {#if status === 'CREATED'}

--- a/packages/renderer/src/lib/pod/PodDetails.svelte
+++ b/packages/renderer/src/lib/pod/PodDetails.svelte
@@ -58,7 +58,7 @@ function errorCallback(errorMessage: string): void {
 
 {#if pod}
   <DetailsPage title="{pod.name}" subtitle="{pod.shortId}" bind:this="{detailsPage}">
-    <StatusIcon slot="icon" icon="{PodIcon}" status="{pod.status}" />
+    <StatusIcon slot="icon" icon="{PodIcon}" size="{24}" status="{pod.status}" />
     <svelte:fragment slot="actions">
       <div class="flex items-center w-5">
         {#if pod.actionError}

--- a/packages/renderer/src/lib/volume/VolumeDetails.svelte
+++ b/packages/renderer/src/lib/volume/VolumeDetails.svelte
@@ -40,7 +40,7 @@ onMount(() => {
 
 {#if volume}
   <DetailsPage title="{volume.shortName}" subtitle="{volume.humanSize}" bind:this="{detailsPage}">
-    <StatusIcon slot="icon" icon="{VolumeIcon}" status="{volume.inUse ? 'USED' : 'UNUSED'}" />
+    <StatusIcon slot="icon" icon="{VolumeIcon}" size="{24}" status="{volume.inUse ? 'USED' : 'UNUSED'}" />
     <VolumeActions slot="actions" volume="{volume}" detailed="{true}" />
     <svelte:fragment slot="tabs">
       <Tab title="Summary" url="summary" />


### PR DESCRIPTION
### What does this PR do?

Status icons are fixed at 20x20px, but the design for the details pages had slightly larger icons, and they all look small compared to the icons used in all the form pages. This just allows status icons to be resized and bumps them up to 24px within *Details.

### Screenshot/screencast of this PR

Before:

<img width="174" alt="Screenshot 2023-10-02 at 8 16 26 AM" src="https://github.com/containers/podman-desktop/assets/19958075/ee94274a-c079-4cf3-bd60-9ea6e142a7ec">

After:

<img width="174" alt="Screenshot 2023-10-02 at 8 16 10 AM" src="https://github.com/containers/podman-desktop/assets/19958075/63dfb905-9ad6-4e65-8d56-f114f8ecda6f">

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Just open a list (to confirm no regression) and a Details page (to confirm behaviour).