### PR TITLE
docs: fix minor typos in docker host environment variable doc

### DIFF
--- a/website/docs/migrating-from-docker/using-the-docker_host-environment-variable.md
+++ b/website/docs/migrating-from-docker/using-the-docker_host-environment-variable.md
@@ -38,7 +38,7 @@ $ podman machine inspect --format '{{.ConnectionInfo.PodmanPipe.Path}}'
 $ export DOCKER_HOST=npipe://<your_podman_pipe_location>
 ```
 
-Note that setting the `DOCKER_HOST` environment variable isn't neccesary on windows since Podman also listens to the default `docker_engine` pipe.
+Note: Setting the `DOCKER_HOST` environment variable isn't necessary on Windows since Podman also listens to the default `docker_engine` pipe.
 </TabItem>
 <TabItem value="mac" label="macOS">
 


### PR DESCRIPTION
docs: fix minor typos in docker host environment variable doc

### What does this PR do?

Fixes the small typos noticed after merging the PR for migrating from
docker documentation

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast
explaining what is doing this PR -->

N/A

### What issues does this PR fix or reference?

N/A

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

N/A

<!-- Please explain steps to reproduce -->

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
