### PR TITLE
feat: compose installation onboarding

### DIFF
--- a/extensions/compose/package.json
+++ b/extensions/compose/package.json
@@ -55,13 +55,13 @@
             ],
             [
               {
-                "value": "#### How to use Compose\nRun `podman compose up` (podman CLI v4.7.0+) in a directory with a `compose.yaml` for Podman to deploy the containers. Podman Desktop will automatically detect the Compose deployment and show it in the container list. \n\n> ℹ️ Note: If you would like to use docker tools such as: `docker compose up`. Enable **Docker Compatibility** within Preferences.",
+                "value": "#### How to use Compose\nRun `podman compose up` (podman CLI v4.7.0+) in a directory with a `compose.yaml` for Podman to deploy the containers. Podman Desktop will automatically detect the Compose deployment and show it in the container list. \n\n> ℹ️ Note: If you would like to use docker tools such as: `docker compose up` or `docker-compose` with podman. Enable **Docker Compatibility** within Preferences.",
                 "highlight": true
               }
             ],
             [
               {
-                "value": "Podman Desktop will install the latest Compose binary (${onboardingContext:composeInstallVersion}). :link[Want to install a different version?]{command=compose.onboarding.promptUserForVersion}",
+                "value": "Compose will be installed in the next step (Version ${onboardingContext:composeInstallVersion}). :link[Want to install a different version?]{command=compose.onboarding.promptUserForVersion}",
                 "when": "!onboardingContext:composeShowCustomInstallDialog"
               }
             ]
@@ -91,19 +91,19 @@
           "content": [
             [
               {
+                "value": "Compose has been successfully installed! However, in order for `podman compose` (podman CLI v4.7.0+) to work correctly, it is required for Compose to be installed system-wide for `podman` to access the binary.",
+                "when": "!compose.isComposeInstalledSystemWide"
+              }
+            ],
+            [
+              {
                 "value": "${configuration:compose.binary.installComposeSystemWide}",
                 "when": "!compose.isComposeInstalledSystemWide"
               }
             ],
             [
               {
-                "value": "> ℹ️ Note on `podman`: In order for `podman compose` (podman CLI v4.7.0+) to work correctly, it is required for Compose to be installed system-wide for podman to access the binary.",
-                "when": "!compose.isComposeInstalledSystemWide"
-              }
-            ],
-            [
-              {
-                "value": "> ℹ️ Note on `docker`: If you are using docker CLI tools with a podman back-end you must enable **Docker Compatibility** within **Preferences -> Extension: Podman** or set the [DOCKER_HOST](https://podman-desktop.io/docs/migrating-from-docker/using-the-docker_host-environment-variable) environment variable before running `docker compose up`."
+                "value": "> ℹ️ Note on `docker`: If you are using docker CLI tools with a podman back-end you must enable **Docker Compatibility** within **Preferences -> Extension: Podman** or set the [DOCKER_HOST](https://podman-desktop.io/docs/migrating-from-docker/using-the-docker_host-environment-variable) environment variable before running `docker compose up` or `docker-compose up`."
               }
             ]
           ]

--- a/extensions/compose/package.json
+++ b/extensions/compose/package.json
@@ -19,6 +19,14 @@
       {
         "command": "compose.checks",
         "title": "Compose: Checks..."
+      },
+      {
+        "command": "compose.onboarding.checkComposeInstalled",
+        "title": "Compose: Check Compose installation"
+      },
+      {
+        "command": "compose.onboarding.installCompose",
+        "title": "Compose: Install Compose"
       }
     ],
     "onboarding": {
@@ -26,14 +34,76 @@
       "enablement": "!compose.isComposeInstalledSystemWide",
       "steps": [
         {
-          "id": "composeSettings",
-          "label": "Compose Settings",
-          "title": "Compose Settings",
+          "id": "checkComposeInstalled",
+          "label": "Check Compose",
+          "title": "Checking for Compose installation",
+          "command": "compose.onboarding.checkComposeInstalled",
+          "completionEvents": [
+            "onCommand:compose.onboarding.checkComposeInstalled"
+          ]
+        },
+        {
+          "id": "startComposeInstallation",
+          "label": "Compose Installation",
+          "title": "Compose Installation",
+          "when": "onboardingContext:composeIsNotInstalled == true",
+          "content": [
+            [
+              {
+                "value": "Compose support in Podman Desktop enables you to use Compose specification CLI implementations such as `podman compose` and `docker compose` with supported container engines."
+              }
+            ],
+            [
+              {
+                "value": "#### How to use Compose\nRun `podman compose up` (podman CLI v4.7.0+) in a directory with a `compose.yaml` for Podman to deploy the containers. Podman Desktop will automatically detect the Compose deployment and show it in the container list. \n\n> ℹ️ Note: If you would like to use docker tools such as: `docker compose up`. Enable **Docker Compatibility** within Preferences.",
+                "highlight": true
+              }
+            ],
+            [
+              {
+                "value": "Podman Desktop will install the latest Compose binary (${onboardingContext:composeInstallVersion}). :link[Want to install a different version?]{command=compose.onboarding.promptUserForVersion}",
+                "when": "!onboardingContext:composeShowCustomInstallDialog"
+              }
+            ]
+          ]
+        },
+        {
+          "id": "installComposeView",
+          "title": "Installing Compose ${onboardingContext:composeInstallVersion}",
+          "description": "Downloading and installing the binary.\n\nOnce installed, we will enable and configure the extension.",
+          "when": "onboardingContext:composeIsNotInstalled == true",
+          "command": "compose.onboarding.installCompose",
+          "completionEvents": [
+            "onCommand:compose.onboarding.installCompose"
+          ]
+        },
+        {
+          "id": "composeFailedInstallation",
+          "title": "Failed installing Compose",
+          "when": "onboardingContext:composeIsNotInstalled == true",
+          "state": "failed"
+        },
+        {
+          "id": "composeInstalled",
+          "title": "Compose successfully installed",
+          "when": "onboardingContext:composeIsNotInstalled == false",
+          "state": "succeeded",
           "content": [
             [
               {
                 "value": "${configuration:compose.binary.installComposeSystemWide}",
                 "when": "!compose.isComposeInstalledSystemWide"
+              }
+            ],
+            [
+              {
+                "value": "> ℹ️ Note on `podman`: In order for `podman compose` (podman CLI v4.7.0+) to work correctly, it is required for Compose to be installed system-wide for podman to access the binary.",
+                "when": "!compose.isComposeInstalledSystemWide"
+              }
+            ],
+            [
+              {
+                "value": "> ℹ️ Note on `docker`: If you are using docker CLI tools with a podman back-end you must enable **Docker Compatibility** within **Preferences -> Extension: Podman** or set the [DOCKER_HOST](https://podman-desktop.io/docs/migrating-from-docker/using-the-docker_host-environment-variable) environment variable before running `docker compose up`."
               }
             ]
           ]

--- a/extensions/compose/src/extension.ts
+++ b/extensions/compose/src/extension.ts
@@ -58,12 +58,15 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
   const onboardingCheckInstallationCommand = extensionApi.commands.registerCommand(
     'compose.onboarding.checkComposeInstalled',
     async () => {
-      // Check to see if docker compose is installed. This will check via doing
-      // 'docker-compose --version'.
-      // NOTE: This will return true if it ONLY exists in the storage/bin folder, it doesn't
-      // have to be installed system-wide.
-      const isInstalled = await detect.checkForDockerCompose();
-      extensionApi.context.setValue('composeIsNotInstalled', !isInstalled, 'onboarding');
+      // Check that docker-compose binary has been installed to the storage folder.
+      // instead of checking for `docker-compose` on the command line, the most reliable way is to see
+      // if we can get the pathname to the binary from the configuration
+      const isInstalled = await detect.getStoragePath();
+      if (isInstalled === '') {
+        extensionApi.context.setValue('composeIsNotInstalled', true, 'onboarding');
+      } else {
+        extensionApi.context.setValue('composeIsNotInstalled', false, 'onboarding');
+      }
 
       // EDGE CASE: Update system-wide installation context in case the user has removed
       // the binary from the system path while podman-desktop is running (we only check on startup)

--- a/extensions/compose/src/installation.spec.ts
+++ b/extensions/compose/src/installation.spec.ts
@@ -1,0 +1,138 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { afterEach, expect, test, vi } from 'vitest';
+import type { ComposeGitHubReleases, ComposeGithubReleaseArtifactMetadata } from './compose-github-releases';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { ComposeInstallation } from './installation';
+import * as extensionApi from '@podman-desktop/api';
+import { OS } from './os';
+import * as utils from './utils';
+import { beforeEach } from 'node:test';
+
+// Create the OS class as well as fake extensionContext
+const os = new OS();
+const extensionContext: extensionApi.ExtensionContext = {
+  storagePath: '/fake/path',
+  subscriptions: [],
+} as unknown as extensionApi.ExtensionContext;
+
+// Mock the "github release"
+const grabLatestsReleasesMetadataMock = vi.fn();
+const getLatestVersionAssetMock = vi.fn();
+const getReleaseAssetIdMock = vi.fn();
+const downloadReleaseAssetMock = vi.fn();
+const composeGitHubReleasesMock = {
+  grabLatestsReleasesMetadata: grabLatestsReleasesMetadataMock,
+  getLatestVersionAsset: getLatestVersionAssetMock,
+  getReleaseAssetId: getReleaseAssetIdMock,
+  downloadReleaseAsset: downloadReleaseAssetMock,
+} as unknown as ComposeGitHubReleases;
+
+// We are also testing fs, but we need fs for reading the JSON file, so we will use "vi.importActual"
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports
+const fsActual = await vi.importActual<typeof import('node:fs')>('node:fs');
+
+// Create a mock ComposeGithubReleaseArtifactMetadata[] with 5 release from the test json file
+// this file we'll use for all the tests
+const resultREST = JSON.parse(
+  fsActual.readFileSync(path.resolve(__dirname, '../tests/resources/compose-github-release-all.json'), 'utf8'),
+);
+const releases: ComposeGithubReleaseArtifactMetadata[] = resultREST.map(release => {
+  return {
+    label: release.name || release.tag_name,
+    tag: release.tag_name,
+    id: release.id,
+  };
+});
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+afterEach(() => {
+  vi.resetAllMocks();
+  vi.restoreAllMocks();
+});
+
+vi.mock('@podman-desktop/api', () => {
+  return {
+    window: {
+      showQuickPick: vi.fn(),
+      createStatusBarItem: vi.fn(),
+      showInformationMessage: vi.fn(),
+    },
+  };
+});
+
+test('expect getLatestVersionAsset to return the first release from a list of releases', async () => {
+  grabLatestsReleasesMetadataMock.mockImplementation(() => {
+    return releases;
+  });
+
+  // Expect the test to return the first release from the list (as the function simply returns the first one)
+  const composeInstallation = new ComposeInstallation(extensionContext, composeGitHubReleasesMock, os);
+  const result = await composeInstallation.getLatestVersionAsset();
+  expect(result).toBeDefined();
+  expect(result).toEqual(releases[0]);
+});
+
+test('pick the 4th option option in the quickpickmenu and expect it to return the github release information', async () => {
+  grabLatestsReleasesMetadataMock.mockImplementation(() => {
+    return releases;
+  });
+  const showQuickPickMock = vi.spyOn(extensionApi.window, 'showQuickPick');
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  showQuickPickMock.mockResolvedValue({ id: 86626999, label: 'v2.14.2', tag: 'v2.14.2' } as any);
+
+  // Expect the test to return the first release from the list (as the function simply returns the first one)
+  const composeInstallation = new ComposeInstallation(extensionContext, composeGitHubReleasesMock, os);
+  const result = await composeInstallation.promptUserForVersion();
+  expect(result).toBeDefined();
+  expect(result).toEqual(releases[3]); // "4th" option was picked
+});
+
+test('test installation of compose passes and that mkdir and executable mocks are called', async () => {
+  const makeExecutableMock = vi.spyOn(utils, 'makeExecutable');
+  const mkdirMock = vi.spyOn(fs.promises, 'mkdir');
+  const getReleaseAssetIdMock = vi.spyOn(composeGitHubReleasesMock, 'getReleaseAssetId');
+  const downloadReleaseAssetMock = vi.spyOn(composeGitHubReleasesMock, 'downloadReleaseAsset');
+
+  // Mock that the storage path does not exist
+  vi.mock('node:fs');
+  vi.spyOn(fs, 'existsSync').mockImplementation(() => {
+    return false;
+  });
+
+  // Mock the mkdir to return "success"
+  mkdirMock.mockResolvedValue(undefined);
+
+  // Mock the getting and downloading the release
+  getReleaseAssetIdMock.mockResolvedValue(123456789);
+  downloadReleaseAssetMock.mockResolvedValue(undefined);
+
+  // Simply install the first release from the example json list
+  const composeInstallation = new ComposeInstallation(extensionContext, composeGitHubReleasesMock, os);
+  await composeInstallation.install(releases[0]);
+
+  // Expect the mkdir and executables to have been called
+  expect(mkdirMock).toHaveBeenCalled();
+  expect(makeExecutableMock).toHaveBeenCalled();
+});

--- a/extensions/compose/src/installation.ts
+++ b/extensions/compose/src/installation.ts
@@ -1,0 +1,81 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import * as path from 'node:path';
+import { existsSync, promises } from 'node:fs';
+import * as extensionApi from '@podman-desktop/api';
+import type { ComposeGitHubReleases, ComposeGithubReleaseArtifactMetadata } from './compose-github-releases';
+import type { OS } from './os';
+import { platform, arch } from 'node:os';
+import { makeExecutable } from './utils';
+
+export class ComposeInstallation {
+  constructor(
+    private readonly extensionContext: extensionApi.ExtensionContext,
+    private readonly composeGitHubReleases: ComposeGitHubReleases,
+    private readonly os: OS,
+  ) {}
+
+  // Get the latest version of Compose from GitHub Releases
+  // and return the artifact metadata
+  async getLatestVersionAsset(): Promise<ComposeGithubReleaseArtifactMetadata> {
+    const latestReleases = await this.composeGitHubReleases.grabLatestsReleasesMetadata();
+    return latestReleases[0];
+  }
+
+  // Create a "quickpick" prompt to ask the user which version of Compose they want to install
+  async promptUserForVersion(): Promise<ComposeGithubReleaseArtifactMetadata> {
+    // Get the latest releases
+    const lastReleasesMetadata = await this.composeGitHubReleases.grabLatestsReleasesMetadata();
+
+    // Show the quickpick
+    const selectedRelease = await extensionApi.window.showQuickPick(lastReleasesMetadata, {
+      placeHolder: 'Select Compose version to install',
+    });
+
+    if (selectedRelease) {
+      return selectedRelease;
+    } else {
+      throw new Error('No version selected');
+    }
+  }
+
+  // Install compose from the artifact metadata: ComposeGithubReleaseArtifactMetadata
+  async install(release: ComposeGithubReleaseArtifactMetadata): Promise<void> {
+    // Get asset id
+    const assetId = await this.composeGitHubReleases.getReleaseAssetId(release.id, platform(), arch());
+
+    // Get the storage and check to see if it exists before we install Compose
+    const storageData = this.extensionContext.storagePath;
+    const storageBinFolder = path.resolve(storageData, 'bin');
+    if (!existsSync(storageBinFolder)) {
+      await promises.mkdir(storageBinFolder, { recursive: true });
+    }
+
+    // Correct the file extension and path resolution
+    let fileExtension = '';
+    if (this.os.isWindows()) {
+      fileExtension = '.exe';
+    }
+    const dockerComposeDownloadLocation = path.resolve(storageBinFolder, `docker-compose${fileExtension}`);
+
+    // Download the asset and make it executable
+    await this.composeGitHubReleases.downloadReleaseAsset(assetId, dockerComposeDownloadLocation);
+    await makeExecutable(dockerComposeDownloadLocation);
+  }
+}

--- a/extensions/compose/src/utils.spec.ts
+++ b/extensions/compose/src/utils.spec.ts
@@ -1,0 +1,57 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { expect, test, vi, vitest, describe } from 'vitest';
+import { makeExecutable } from './utils';
+import { promises } from 'fs';
+
+describe('makeExecutable', async () => {
+  const fakePath = '/fake/path';
+  test('mac', async () => {
+    vitest.spyOn(process, 'platform', 'get').mockReturnValue('darwin');
+
+    // fake chmod
+    const chmodMock = vi.spyOn(promises, 'chmod');
+    chmodMock.mockImplementation(() => Promise.resolve());
+    await makeExecutable(fakePath);
+    // check it has been called
+    expect(chmodMock).toHaveBeenCalledWith(fakePath, 0o755);
+  });
+
+  test('linux', async () => {
+    vitest.spyOn(process, 'platform', 'get').mockReturnValue('linux');
+
+    // fake chmod
+    const chmodMock = vi.spyOn(promises, 'chmod');
+    chmodMock.mockImplementation(() => Promise.resolve());
+    await makeExecutable(fakePath);
+    // check it has been called
+    expect(chmodMock).toHaveBeenCalledWith(fakePath, 0o755);
+  });
+
+  test('windows', async () => {
+    vitest.spyOn(process, 'platform', 'get').mockReturnValue('win32');
+
+    // fake chmod
+    const chmodMock = vi.spyOn(promises, 'chmod');
+    chmodMock.mockImplementation(() => Promise.resolve());
+    await makeExecutable(fakePath);
+    // check it has not been called on Windows
+    expect(chmodMock).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/compose/src/utils.ts
+++ b/extensions/compose/src/utils.ts
@@ -1,0 +1,29 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { promises } from 'fs';
+import { OS } from './os';
+
+export async function makeExecutable(filePath: string): Promise<void> {
+  // New OS class
+  const os = new OS();
+
+  if (os.isLinux() || os.isMac()) {
+    await promises.chmod(filePath, 0o755);
+  }
+}

--- a/packages/renderer/src/lib/markdown/Markdown.svelte
+++ b/packages/renderer/src/lib/markdown/Markdown.svelte
@@ -2,7 +2,7 @@
 UI guidelines -->
 <style>
 .markdown > :global(p) {
-  line-height: revert;
+  line-height: normal;
   padding-bottom: 8px;
   margin-bottom: 8px;
 }
@@ -24,6 +24,15 @@ UI guidelines -->
   list-style: revert;
   margin: revert;
   padding: revert;
+}
+
+.markdown > :global(b),
+:global(strong) {
+  font-weight: 600;
+}
+.markdown > :global(blockquote) {
+  opacity: 0.8;
+  line-height: normal;
 }
 </style>
 


### PR DESCRIPTION
feat: compose installation onboarding

### What does this PR do?

* Adds compose installation onboarding, being able to check if you have
  compose installed, install compose as well as continue to the settings
  page.
* Ability to pick and choose your compose installation version from a
  quickpick prompt

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast
explaining what is doing this PR -->



https://github.com/containers/podman-desktop/assets/6422176/035e3b27-6a8b-4dfc-9e73-c1aa0dd98349





### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop/issues/2411
Closes https://github.com/containers/podman-desktop/issues/4181
Closes https://github.com/containers/podman-desktop/issues/4180

### How to test this PR?

<!-- Please explain steps to reproduce -->

Two scenarios:

Installed but not systemwide:
1. Remove docker-compose system-wide (whereis docker-compose)
2. Go through onboarding process, it will skip the installation section
   and just show you the system-wide install button

Not installed:
1. Remove docker-compose from the
   ~/.local/share/containers/podman-desktop/extensions-storage/compose
   folder as well as system-wide
2. Go through the onboarding process

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
