### PR TITLE
chore: details & form breadcrumb consistency

### DIFF
--- a/packages/renderer/src/lib/ui/DetailsPage.spec.ts
+++ b/packages/renderer/src/lib/ui/DetailsPage.spec.ts
@@ -85,7 +85,7 @@ test('Expect close link is defined', async () => {
     title: 'No Title',
   });
 
-  const closeElement = screen.getByTitle('Close Details');
+  const closeElement = screen.getByTitle('Close');
   expect(closeElement).toBeInTheDocument();
   expect(closeElement).toHaveAttribute('href', backPath);
 });

--- a/packages/renderer/src/lib/ui/DetailsPage.svelte
+++ b/packages/renderer/src/lib/ui/DetailsPage.svelte
@@ -25,11 +25,11 @@ function handleKeydown(e: KeyboardEvent) {
   <div class="flex h-full flex-col">
     <div class="flex w-full flex-row">
       <div class="w-full pl-5 pt-4">
-        <div class="flex flew-row items-center">
+        <div class="flex flew-row items-center text-sm text-gray-700">
           <Link aria-label="back" internalRef="{$lastPage.path}" title="Go back to {$lastPage.name}"
             >{$lastPage.name}</Link>
-          <div class="text-xl mx-2 text-gray-700">></div>
-          <div class="text-sm font-extralight text-gray-700" aria-label="name">{$currentPage.name}</div>
+          <div class="mx-2">&gt;</div>
+          <div class="font-extralight" aria-label="name">{$currentPage.name}</div>
         </div>
         <div class="text-lg flex flex-row items-start pt-1">
           <div class="pr-3 pt-1">
@@ -53,7 +53,7 @@ function handleKeydown(e: KeyboardEvent) {
         </div>
         <slot name="detail" />
       </div>
-      <a href="{$lastPage.path}" title="Close Details" class="mt-2 mr-2 text-gray-900"
+      <a href="{$lastPage.path}" title="Close" class="mt-2 mr-2 text-gray-900"
         ><i class="fas fa-times" aria-hidden="true"></i></a>
     </div>
     <div class="flex flex-row px-2 border-b border-charcoal-400">

--- a/packages/renderer/src/lib/ui/FormPage.svelte
+++ b/packages/renderer/src/lib/ui/FormPage.svelte
@@ -24,11 +24,11 @@ function handleKeydown(e: KeyboardEvent) {
   <div class="flex flex-row w-full h-fit px-5 py-4">
     <div class="flex flex-col w-full h-fit">
       {#if showBreadcrumb}
-        <div class="flex flew-row items-center">
+        <div class="flex flew-row items-center text-sm text-gray-700">
           <Link aria-label="back" internalRef="{$lastPage.path}" title="Go back to {$lastPage.name}"
             >{$lastPage.name}</Link>
-          <div class="text-xl mx-2 text-gray-700">></div>
-          <div class="grow text-sm font-extralight text-gray-700" aria-label="name">{$currentPage.name}</div>
+          <div class="mx-2">&gt;</div>
+          <div class="grow font-extralight" aria-label="name">{$currentPage.name}</div>
           <a href="{$lastPage.path}" title="Close" class="justify-self-end text-gray-900">
             <i class="fas fa-times" aria-hidden="true"></i>
           </a>


### PR DESCRIPTION
### What does this PR do?

This PR covers some really minor cleanup:
- The details and form pages had breadcrumb headers with three different font sizes (sm, md, and xl), this makes them consistent (text-sm) and sets the color once.
- Uses '&gt;' for breadcrumb so the '>' doesn't stand out as red in editors.
- Removes ' Details' from the details close button tooltip so that the pages are consistent.

### Screenshot/screencast of this PR

<img width="285" alt="Screenshot 2023-10-02 at 5 29 07 PM" src="https://github.com/containers/podman-desktop/assets/19958075/f334c566-6959-4d9c-ac44-b727d75c023a">

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Just open up a details page and a form.