### PR TITLE
fix: remove suggested registries on deactivation

### DIFF
--- a/extensions/registries/src/extension.ts
+++ b/extensions/registries/src/extension.ts
@@ -34,8 +34,9 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
       registry.icon = await base64EncodeFile(iconLocation);
     }
 
-    // Suggest it to the registry
-    extensionApi.registry.suggestRegistry(registry);
+    // Suggest it to the registry and add to subscriptions
+    const disposable = extensionApi.registry.suggestRegistry(registry);
+    extensionContext.subscriptions.push(disposable);
   }
 }
 


### PR DESCRIPTION
### What does this PR do?

The suggested registries extension adds registries but never adds the disposable subscription, so registries stay around even if you disable the extension. This just adds the subscription.

There's a good argument to be made that suggested registries should be registered more like commands or menu contributions, and since they'd be handled once by the extension loader this bug could never happen again. That would require a breaking API change and a much bigger PR though, so not sure it's worth it; either way I think it's best for this change to go ahead and fix the immediate bug.

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

Fixes #3909.

### How to test this PR?

Check that there are suggested registries in Settings > Registries, then disable the Registries extension in Settings > Extensions > Registries and go back to confirm they're gone.