### PR TITLE
feat(extension): adds spinning if icon contains ~spin suffix

### DIFF
--- a/packages/renderer/src/lib/statusbar/StatusBarItem.spec.ts
+++ b/packages/renderer/src/lib/statusbar/StatusBarItem.spec.ts
@@ -39,3 +39,13 @@ test('check iconClass with custom icon name', () => {
   const icon = iconClass(statusBarEntry);
   expect(icon).toBe('podman-desktop-icon-podman');
 });
+
+test('check iconClass with font awesome icons and spinning', () => {
+  const statusBarEntry: StatusBarEntry = {
+    enabled: true,
+    activeIconClass: 'fas fa-sync~spin',
+  };
+
+  const icon = iconClass(statusBarEntry);
+  expect(icon).toBe('fas fa-sync animate-spin');
+});

--- a/packages/renderer/src/lib/statusbar/StatusBarItem.ts
+++ b/packages/renderer/src/lib/statusbar/StatusBarItem.ts
@@ -32,6 +32,10 @@ export function iconClass(entry: StatusBarEntry): string | undefined {
     if (match?.length === 2) {
       const className = match[1];
       iconClass = iconClass.replace(match[0], `podman-desktop-icon-${className}`);
+    } else if (iconClass.endsWith('~spin')) {
+      // check if the iconClass ends with ~spin
+      // and then remove the ~spin suffix and use animate-spin
+      iconClass = iconClass.replace('~spin', ' animate-spin');
     }
   }
   return iconClass;


### PR DESCRIPTION
### What does this PR do?
adds spinning animation on `~spin` icons

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast 
explaining what is doing this PR -->

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/4186

### How to test this PR?

unit test provided
