### PR TITLE
chore: expose existing deleteImage and deleteContainer to extensions

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -1696,6 +1696,7 @@ declare module '@podman-desktop/api' {
       callback: (name: string, data: string) => void,
     ): Promise<void>;
     export function stopContainer(engineId: string, id: string): Promise<void>;
+    export function deleteContainer(engineId: string, id: string): Promise<void>;
     export function saveImage(engineId: string, id: string, filename: string): Promise<void>;
     export function tagImage(engineId: string, imageId: string, repo: string, tag?: string): Promise<void>;
     export function pushImage(
@@ -1710,7 +1711,7 @@ declare module '@podman-desktop/api' {
       imageName: string,
       callback: (event: PullEvent) => void,
     ): Promise<void>;
-
+    export function deleteImage(engineId: string, id: string): Promise<void>;
     export const onEvent: Event<ContainerJSONEvent>;
   }
 

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -854,6 +854,9 @@ export class ExtensionLoader {
       stopContainer(engineId: string, id: string) {
         return containerProviderRegistry.stopContainer(engineId, id);
       },
+      deleteContainer(engineId: string, id: string) {
+        return containerProviderRegistry.deleteContainer(engineId, id);
+      },
       saveImage(engineId: string, id: string, filename: string) {
         return containerProviderRegistry.saveImage(engineId, id, filename);
       },
@@ -874,6 +877,9 @@ export class ExtensionLoader {
       },
       tagImage(engineId: string, imageId: string, repo: string, tag: string | undefined): Promise<void> {
         return containerProviderRegistry.tagImage(engineId, imageId, repo, tag);
+      },
+      deleteImage(engineId: string, id: string) {
+        return containerProviderRegistry.deleteImage(engineId, id);
       },
       onEvent: (listener, thisArg, disposables) => {
         return containerProviderRegistry.onEvent(listener, thisArg, disposables);


### PR DESCRIPTION
### What does this PR do?
expose existing delete functions to extensions

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast 
explaining what is doing this PR -->

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/4169


### How to test this PR?

<!-- Please explain steps to reproduce -->
