### PR TITLE
feat: refactor how warnings are displayed in onboarding

### DIFF
--- a/extensions/podman/package.json
+++ b/extensions/podman/package.json
@@ -158,8 +158,7 @@
           "content": [
             [
               {
-                "value": "${onboardingContext:warningsMarkdown}",
-                "highlight": true
+                "value": ":warnings[${onboardingContext:warningsMarkdown}]"
               }
             ],
             [

--- a/extensions/podman/src/base-check.ts
+++ b/extensions/podman/src/base-check.ts
@@ -21,11 +21,28 @@ export abstract class BaseCheck implements extensionApi.InstallCheck {
   abstract title: string;
   abstract execute(): Promise<extensionApi.CheckResult>;
 
-  protected createFailureResult(description?: string, title?: string, url?: string): extensionApi.CheckResult {
+  protected createFailureResult(
+    description?: string,
+    linksDescription?: string,
+    linkTitle?: string,
+    linkUrl?: string,
+    fixFailedCheckCommandId?: string,
+    fixFailedCheckCommandTitle?: string,
+  ): extensionApi.CheckResult {
     const result: extensionApi.CheckResult = { successful: false, description };
-    if (title && url) {
-      result.docLinks = [{ url, title }];
+    if (linkTitle && linkUrl) {
+      result.docLinks = [{ url: linkUrl, title: linkTitle }];
     }
+    if (linksDescription) {
+      result.docLinksDescription = linksDescription;
+    }
+    if (fixFailedCheckCommandId) {
+      result.fixFailedCheckCommand = {
+        id: fixFailedCheckCommandId,
+        title: fixFailedCheckCommandTitle,
+      };
+    }
+
     return result;
   }
 

--- a/extensions/podman/src/base-check.ts
+++ b/extensions/podman/src/base-check.ts
@@ -17,32 +17,31 @@
  ***********************************************************************/
 import type * as extensionApi from '@podman-desktop/api';
 
+export interface FailureObject {
+  description: string;
+  docLinksDescription?: string;
+  docLinks?: extensionApi.CheckResultLink;
+  fixCommand?: extensionApi.CheckResultFixCommand;
+}
+
 export abstract class BaseCheck implements extensionApi.InstallCheck {
   abstract title: string;
   abstract execute(): Promise<extensionApi.CheckResult>;
 
-  protected createFailureResult(
-    description?: string,
-    linksDescription?: string,
-    linkTitle?: string,
-    linkUrl?: string,
-    fixFailedCheckCommandId?: string,
-    fixFailedCheckCommandTitle?: string,
-  ): extensionApi.CheckResult {
-    const result: extensionApi.CheckResult = { successful: false, description };
-    if (linkTitle && linkUrl) {
-      result.docLinks = [{ url: linkUrl, title: linkTitle }];
+  protected createFailureResult(failureObject: FailureObject): extensionApi.CheckResult {
+    const result: extensionApi.CheckResult = { successful: false, description: failureObject.description };
+    if (failureObject.docLinksDescription) {
+      result.docLinksDescription = failureObject.docLinksDescription;
     }
-    if (linksDescription) {
-      result.docLinksDescription = linksDescription;
+    if (failureObject.docLinks) {
+      result.docLinks = [{ url: failureObject.docLinks.url, title: failureObject.docLinks.title }];
     }
-    if (fixFailedCheckCommandId) {
-      result.fixFailedCheckCommand = {
-        id: fixFailedCheckCommandId,
-        title: fixFailedCheckCommandTitle,
+    if (failureObject.fixCommand) {
+      result.fixCommand = {
+        id: failureObject.fixCommand.id,
+        title: failureObject.fixCommand.title,
       };
     }
-
     return result;
   }
 

--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -963,6 +963,8 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
             successful: checkResult.successful,
             description: checkResult.description,
             docLinks: checkResult.docLinks,
+            docLinksDescription: checkResult.docLinksDescription,
+            fixFailedCheckCommand: checkResult.fixFailedCheckCommand,
           });
 
           if (!checkResult.successful) {
@@ -979,24 +981,21 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
         }
       }
 
-      let warningsMarkdown = '';
+      const warnings = [];
 
       for (const res of result) {
-        warningsMarkdown += `* ${res.successful ? '✅' : '❌'} ${res.name} \n`;
-        if (res.description) {
-          warningsMarkdown += res.description;
-          if (res.docLinks) {
-            warningsMarkdown += ' See: ';
-            for (const link of res.docLinks) {
-              warningsMarkdown += `[${link.title}](${link.url}) `;
-            }
-            warningsMarkdown += '\n';
-          }
-        }
+        const warning = {
+          state: res.successful ? 'successful' : 'failed',
+          description: res.description ? res.description : res.name,
+          docDescription: res.docLinksDescription,
+          docLinks: res.docLinks,
+          command: res.fixFailedCheckCommand,
+        };
+        warnings.push(warning);
       }
 
       extensionApi.context.setValue('requirementsStatus', successful ? 'ok' : 'failed', 'onboarding');
-      extensionApi.context.setValue('warningsMarkdown', warningsMarkdown, 'onboarding');
+      extensionApi.context.setValue('warningsMarkdown', warnings, 'onboarding');
     },
   );
 

--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -964,7 +964,7 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
             description: checkResult.description,
             docLinks: checkResult.docLinks,
             docLinksDescription: checkResult.docLinksDescription,
-            fixFailedCheckCommand: checkResult.fixFailedCheckCommand,
+            fixCommand: checkResult.fixCommand,
           });
 
           if (!checkResult.successful) {
@@ -989,7 +989,7 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
           description: res.description ? res.description : res.name,
           docDescription: res.docLinksDescription,
           docLinks: res.docLinks,
-          command: res.fixFailedCheckCommand,
+          command: res.fixCommand,
         };
         warnings.push(warning);
       }

--- a/extensions/podman/src/macos-checks.ts
+++ b/extensions/podman/src/macos-checks.ts
@@ -27,7 +27,9 @@ export class MacCPUCheck extends BaseCheck {
   async execute(): Promise<extensionApi.CheckResult> {
     const cpus = os.cpus();
     if (cpus.length < this.MIN_CPU_NUMBER) {
-      return this.createFailureResult(`You need to have at least ${this.MIN_CPU_NUMBER} CPU cores to install podman.`);
+      return this.createFailureResult({
+        description: `You need to have at least ${this.MIN_CPU_NUMBER} CPU cores to install podman.`,
+      });
     }
 
     return this.createSuccessfulResult();
@@ -43,7 +45,9 @@ export class MacMemoryCheck extends BaseCheck {
     if (this.REQUIRED_MEM <= totalMem) {
       return this.createSuccessfulResult();
     } else {
-      return this.createFailureResult('You need at least 4GB to install Podman.');
+      return this.createFailureResult({
+        description: 'You need at least 4GB to install Podman.',
+      });
     }
   }
 }
@@ -57,8 +61,9 @@ export class MacVersionCheck extends BaseCheck {
     if (compare(darwinVersion, this.MINIMUM_VERSION, '>=')) {
       return this.createSuccessfulResult();
     }
-
-    return this.createFailureResult('To be able to install podman you need to update to macOS Catalina.');
+    return this.createFailureResult({
+      description: 'To be able to install podman you need to update to macOS Catalina.',
+    });
   }
 }
 
@@ -82,10 +87,13 @@ export class MacPodmanInstallCheck extends BaseCheck {
       return this.createSuccessfulResult();
     }
 
-    return this.createFailureResult(
-      'You have podman installed with "brew", run "brew update && brew upgrade podman" to install new version',
-      'Brew Documentation',
-      'https://docs.brew.sh/Manpage#upgrade-options-outdated_formulaoutdated_cask-',
-    );
+    return this.createFailureResult({
+      description:
+        'You have podman installed with "brew", run "brew update && brew upgrade podman" to install new version',
+      docLinks: {
+        url: 'https://docs.brew.sh/Manpage#upgrade-options-outdated_formulaoutdated_cask-',
+        title: 'Brew Documentation',
+      },
+    });
   }
 }

--- a/extensions/podman/src/podman-install.spec.ts
+++ b/extensions/podman/src/podman-install.spec.ts
@@ -20,9 +20,21 @@ import { WinInstaller } from './podman-install';
 import { beforeEach, expect, test, vi, afterEach } from 'vitest';
 import * as extensionApi from '@podman-desktop/api';
 import * as fs from 'node:fs';
+import * as os from 'node:os';
 
 const originalConsoleError = console.error;
 const consoleErrorMock = vi.fn();
+
+// mock release
+vi.mock('node:os', async () => {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-imports
+  const actual = await vi.importActual<typeof import('node:os')>('node:os');
+  return {
+    ...actual,
+    release: vi.fn(),
+    totalmem: vi.fn(),
+  };
+});
 
 vi.mock('@podman-desktop/api', async () => {
   return {
@@ -122,4 +134,300 @@ test('expect update on windows to throw error if non zero exit code', async () =
   const result = await installer.update();
   expect(result).toBeFalsy();
   expect(extensionApi.window.showErrorMessage).toHaveBeenCalled();
+});
+
+test('expect winbit preflight check return successful result if the arch is x64', async () => {
+  Object.defineProperty(process, 'arch', {
+    value: 'x64',
+  });
+
+  const installer = new WinInstaller();
+  const preflights = installer.getPreflightChecks();
+  const winBitCheck = preflights[0];
+  const result = await winBitCheck.execute();
+  expect(result.successful).toBeTruthy();
+});
+
+test('expect winbit preflight check return successful result if the arch is arm64', async () => {
+  Object.defineProperty(process, 'arch', {
+    value: 'arm64',
+  });
+
+  const installer = new WinInstaller();
+  const preflights = installer.getPreflightChecks();
+  const winBitCheck = preflights[0];
+  const result = await winBitCheck.execute();
+  expect(result.successful).toBeTruthy();
+});
+
+test('expect winbit preflight check return failure result if the arch is not supported', async () => {
+  Object.defineProperty(process, 'arch', {
+    value: 'x86',
+  });
+
+  const installer = new WinInstaller();
+  const preflights = installer.getPreflightChecks();
+  const winBitCheck = preflights[0];
+  const result = await winBitCheck.execute();
+  expect(result.description).equal('WSL2 works only on 64bit OS.');
+  expect(result.docLinksDescription).equal('Learn about WSL requirements:');
+  expect(result.docLinks[0].url).equal(
+    'https://docs.microsoft.com/en-us/windows/wsl/install-manual#step-2---check-requirements-for-running-wsl-2',
+  );
+  expect(result.docLinks[0].title).equal('WSL2 Manual Installation Steps');
+});
+
+test('expect winversion preflight check return successful result if the version is greater than min valid version', async () => {
+  vi.spyOn(os, 'release').mockReturnValue('10.0.19000');
+
+  const installer = new WinInstaller();
+  const preflights = installer.getPreflightChecks();
+  const winVersionCheck = preflights[1];
+  const result = await winVersionCheck.execute();
+  expect(result.successful).toBeTruthy();
+});
+
+test('expect winversion preflight check return failure result if the version is greater than 9. and less than min build version', async () => {
+  vi.spyOn(os, 'release').mockReturnValue('10.0.1000');
+
+  const installer = new WinInstaller();
+  const preflights = installer.getPreflightChecks();
+  const winVersionCheck = preflights[1];
+  const result = await winVersionCheck.execute();
+  expect(result.description).equal('To be able to run WSL2 you need Windows 10 Build 18362 or later.');
+  expect(result.docLinksDescription).equal('Learn about WSL requirements:');
+  expect(result.docLinks[0].url).equal(
+    'https://docs.microsoft.com/en-us/windows/wsl/install-manual#step-2---check-requirements-for-running-wsl-2',
+  );
+  expect(result.docLinks[0].title).equal('WSL2 Manual Installation Steps');
+});
+
+test('expect winversion preflight check return failure result if the version is less than 10.0.0', async () => {
+  vi.spyOn(os, 'release').mockReturnValue('9.0.19000');
+
+  const installer = new WinInstaller();
+  const preflights = installer.getPreflightChecks();
+  const winVersionCheck = preflights[1];
+  const result = await winVersionCheck.execute();
+  expect(result.description).equal('WSL2 works only on Windows 10 and newest OS');
+  expect(result.docLinksDescription).equal('Learn about WSL requirements:');
+  expect(result.docLinks[0].url).equal(
+    'https://docs.microsoft.com/en-us/windows/wsl/install-manual#step-2---check-requirements-for-running-wsl-2',
+  );
+  expect(result.docLinks[0].title).equal('WSL2 Manual Installation Steps');
+});
+
+test('expect winMemory preflight check return successful result if the machine has more than 6GB of memory', async () => {
+  const SYSTEM_MEM = 7 * 1024 * 1024 * 1024;
+  vi.spyOn(os, 'totalmem').mockReturnValue(SYSTEM_MEM);
+
+  const installer = new WinInstaller();
+  const preflights = installer.getPreflightChecks();
+  const winMemoryCheck = preflights[2];
+  const result = await winMemoryCheck.execute();
+  expect(result.successful).toBeTruthy();
+});
+
+test('expect winMemory preflight check return failure result if the machine has less than 6GB of memory', async () => {
+  const SYSTEM_MEM = 4 * 1024 * 1024 * 1024;
+  vi.spyOn(os, 'totalmem').mockReturnValue(SYSTEM_MEM);
+
+  const installer = new WinInstaller();
+  const preflights = installer.getPreflightChecks();
+  const winMemoryCheck = preflights[2];
+  const result = await winMemoryCheck.execute();
+  expect(result.description).equal('You need at least 6GB to run Podman.');
+  expect(result.docLinksDescription).toBeUndefined();
+  expect(result.docLinks).toBeUndefined();
+  expect(result.fixCommand).toBeUndefined();
+});
+
+test('expect winVirtualMachine preflight check return successful result if the virtual machine platform feature is enabled', async () => {
+  vi.spyOn(extensionApi.process, 'exec').mockImplementation(
+    () =>
+      new Promise<extensionApi.RunResult>((resolve, _) => {
+        // eslint-disable-next-line prefer-promise-reject-errors
+        resolve({
+          stdout: 'VirtualMachinePlatform',
+          stderr: '',
+          command: 'command',
+        });
+      }),
+  );
+
+  const installer = new WinInstaller();
+  const preflights = installer.getPreflightChecks();
+  const winVirtualMachinePlatformCheck = preflights[3];
+  const result = await winVirtualMachinePlatformCheck.execute();
+  expect(result.successful).toBeTruthy();
+});
+
+test('expect winVirtualMachine preflight check return successful result if the virtual machine platform feature is disabled', async () => {
+  vi.spyOn(extensionApi.process, 'exec').mockImplementation(
+    () =>
+      new Promise<extensionApi.RunResult>((resolve, _) => {
+        // eslint-disable-next-line prefer-promise-reject-errors
+        resolve({
+          stdout: 'some message',
+          stderr: '',
+          command: 'command',
+        });
+      }),
+  );
+
+  const installer = new WinInstaller();
+  const preflights = installer.getPreflightChecks();
+  const winVirtualMachinePlatformCheck = preflights[3];
+  const result = await winVirtualMachinePlatformCheck.execute();
+  expect(result.description).equal('Virtual Machine Platform should be enabled to be able to run Podman.');
+  expect(result.docLinksDescription).equal('Learn about how to enable the Virtual Machine Platform feature:');
+  expect(result.docLinks[0].url).equal(
+    'https://learn.microsoft.com/en-us/windows/wsl/install-manual#step-3---enable-virtual-machine-feature',
+  );
+  expect(result.docLinks[0].title).equal('Enable Virtual Machine Platform');
+});
+
+test('expect winVirtualMachine preflight check return successful result if there is an error when checking if virtual machine platform feature is enabled', async () => {
+  vi.spyOn(extensionApi.process, 'exec').mockImplementation(
+    () =>
+      new Promise<extensionApi.RunResult>((_, reject) => {
+        // eslint-disable-next-line prefer-promise-reject-errors
+        reject('');
+      }),
+  );
+
+  const installer = new WinInstaller();
+  const preflights = installer.getPreflightChecks();
+  const winVirtualMachinePlatformCheck = preflights[3];
+  const result = await winVirtualMachinePlatformCheck.execute();
+  expect(result.description).equal('Virtual Machine Platform should be enabled to be able to run Podman.');
+  expect(result.docLinksDescription).equal('Learn about how to enable the Virtual Machine Platform feature:');
+  expect(result.docLinks[0].url).equal(
+    'https://learn.microsoft.com/en-us/windows/wsl/install-manual#step-3---enable-virtual-machine-feature',
+  );
+  expect(result.docLinks[0].title).equal('Enable Virtual Machine Platform');
+});
+
+test('expect winWSL2 preflight check return successful result if the machine has WSL2 installed', async () => {
+  vi.spyOn(extensionApi.process, 'exec').mockImplementation(command => {
+    if (command === 'powershell.exe') {
+      return new Promise<extensionApi.RunResult>((resolve, _) => {
+        // eslint-disable-next-line prefer-promise-reject-errors
+        resolve({
+          stdout: 'True',
+          stderr: '',
+          command: 'command',
+        });
+      });
+    } else {
+      return new Promise<extensionApi.RunResult>((resolve, _) => {
+        // eslint-disable-next-line prefer-promise-reject-errors
+        resolve({
+          stdout: 'blabla',
+          stderr: '',
+          command: 'command',
+        });
+      });
+    }
+  });
+
+  const installer = new WinInstaller();
+  const preflights = installer.getPreflightChecks();
+  const winWSLCheck = preflights[4];
+  const result = await winWSLCheck.execute();
+  expect(result.successful).toBeTruthy();
+});
+
+test('expect winWSL2 preflight check return failure result if user do not have wsl but he is admin', async () => {
+  vi.spyOn(extensionApi.process, 'exec').mockImplementation(command => {
+    if (command === 'powershell.exe') {
+      return new Promise<extensionApi.RunResult>((resolve, _) => {
+        // eslint-disable-next-line prefer-promise-reject-errors
+        resolve({
+          stdout: 'True',
+          stderr: '',
+          command: 'command',
+        });
+      });
+    } else {
+      return new Promise<extensionApi.RunResult>((resolve, _) => {
+        // eslint-disable-next-line prefer-promise-reject-errors
+        resolve({
+          stdout: '',
+          stderr: '',
+          command: 'command',
+        });
+      });
+    }
+  });
+
+  const installer = new WinInstaller();
+  const preflights = installer.getPreflightChecks();
+  const winWSLCheck = preflights[4];
+  const result = await winWSLCheck.execute();
+  expect(result.description).equal('WSL2 is not installed.');
+  expect(result.docLinksDescription).equal(`Call 'wsl --install --no-distribution' in a terminal.`);
+  expect(result.docLinks[0].url).equal('https://learn.microsoft.com/en-us/windows/wsl/install');
+  expect(result.docLinks[0].title).equal('WSL2 Manual Installation Steps');
+});
+
+test('expect winWSL2 preflight check return failure result if user do not have wsl but he is not admin', async () => {
+  vi.spyOn(extensionApi.process, 'exec').mockImplementation(command => {
+    if (command === 'powershell.exe') {
+      return new Promise<extensionApi.RunResult>((resolve, _) => {
+        // eslint-disable-next-line prefer-promise-reject-errors
+        resolve({
+          stdout: 'False',
+          stderr: '',
+          command: 'command',
+        });
+      });
+    } else {
+      return new Promise<extensionApi.RunResult>((resolve, _) => {
+        // eslint-disable-next-line prefer-promise-reject-errors
+        resolve({
+          stdout: '',
+          stderr: '',
+          command: 'command',
+        });
+      });
+    }
+  });
+
+  const installer = new WinInstaller();
+  const preflights = installer.getPreflightChecks();
+  const winWSLCheck = preflights[4];
+  const result = await winWSLCheck.execute();
+  expect(result.description).equal('WSL2 is not installed or you do not have permissions to run WSL2.');
+  expect(result.docLinksDescription).equal('Contact your Administrator to setup WSL2.');
+  expect(result.docLinks[0].url).equal('https://learn.microsoft.com/en-us/windows/wsl/install');
+  expect(result.docLinks[0].title).equal('WSL2 Manual Installation Steps');
+});
+
+test('expect winWSL2 preflight check return failure result if it fails when checking if wsl is installed', async () => {
+  vi.spyOn(extensionApi.process, 'exec').mockImplementation(command => {
+    if (command === 'powershell.exe') {
+      return new Promise<extensionApi.RunResult>((_, reject) => {
+        // eslint-disable-next-line prefer-promise-reject-errors
+        reject('');
+      });
+    } else {
+      return new Promise<extensionApi.RunResult>((resolve, _) => {
+        // eslint-disable-next-line prefer-promise-reject-errors
+        resolve({
+          stdout: '',
+          stderr: '',
+          command: 'command',
+        });
+      });
+    }
+  });
+
+  const installer = new WinInstaller();
+  const preflights = installer.getPreflightChecks();
+  const winWSLCheck = preflights[4];
+  const result = await winWSLCheck.execute();
+  expect(result.description).equal('Could not detect WSL2');
+  expect(result.docLinks[0].url).equal('https://learn.microsoft.com/en-us/windows/wsl/install');
+  expect(result.docLinks[0].title).equal('WSL2 Manual Installation Steps');
 });

--- a/extensions/podman/src/podman-install.ts
+++ b/extensions/podman/src/podman-install.ts
@@ -390,12 +390,14 @@ class WinBitCheck extends BaseCheck {
     if (this.ARCH_X64 === currentArch || this.ARCH_ARM === currentArch) {
       return this.createSuccessfulResult();
     } else {
-      return this.createFailureResult(
-        'WSL2 works only on 64bit OS.',
-        'Learn about WSL requirements:',
-        'WSL2 Install Manual',
-        'https://docs.microsoft.com/en-us/windows/wsl/install-manual#step-2---check-requirements-for-running-wsl-2',
-      );
+      return this.createFailureResult({
+        description: 'WSL2 works only on 64bit OS.',
+        docLinksDescription: 'Learn about WSL requirements:',
+        docLinks: {
+          url: 'https://docs.microsoft.com/en-us/windows/wsl/install-manual#step-2---check-requirements-for-running-wsl-2',
+          title: 'WSL2 Install Manual',
+        },
+      });
     }
   }
 }
@@ -412,20 +414,24 @@ class WinVersionCheck extends BaseCheck {
       if (Number.parseInt(winBuild) >= this.MIN_BUILD) {
         return { successful: true };
       } else {
-        return this.createFailureResult(
-          'To be able to run WSL2 you need Windows 10 Build 18362 or later.',
-          'Learn about WSL requirements:',
-          'WSL2 Install Manual',
-          'https://docs.microsoft.com/en-us/windows/wsl/install-manual#step-2---check-requirements-for-running-wsl-2',
-        );
+        return this.createFailureResult({
+          description: 'To be able to run WSL2 you need Windows 10 Build 18362 or later.',
+          docLinksDescription: 'Learn about WSL requirements:',
+          docLinks: {
+            url: 'https://docs.microsoft.com/en-us/windows/wsl/install-manual#step-2---check-requirements-for-running-wsl-2',
+            title: 'WSL2 Install Manual',
+          },
+        });
       }
     } else {
-      return this.createFailureResult(
-        'WSL2 works only on Windows 10 and newest OS',
-        'Learn about WSL requirements:',
-        'WSL2 Install Manual',
-        'https://docs.microsoft.com/en-us/windows/wsl/install-manual#step-2---check-requirements-for-running-wsl-2',
-      );
+      return this.createFailureResult({
+        description: 'WSL2 works only on Windows 10 and newest OS',
+        docLinksDescription: 'Learn about WSL requirements:',
+        docLinks: {
+          url: 'https://docs.microsoft.com/en-us/windows/wsl/install-manual#step-2---check-requirements-for-running-wsl-2',
+          title: 'WSL2 Install Manual',
+        },
+      });
     }
   }
 }
@@ -439,7 +445,9 @@ class WinMemoryCheck extends BaseCheck {
     if (this.REQUIRED_MEM <= totalMem) {
       return this.createSuccessfulResult();
     } else {
-      return this.createFailureResult('You need at least 6GB to run Podman.');
+      return this.createFailureResult({
+        description: 'You need at least 6GB to run Podman.',
+      });
     }
   }
 }
@@ -459,12 +467,14 @@ class VirtualMachinePlatformCheck extends BaseCheck {
     } catch (err) {
       // ignore error, this means that VirtualMachinePlatform not enabled
     }
-    return this.createFailureResult(
-      'Virtual Machine Platform should be enabled to be able to run Podman.',
-      'Learn about how to enable the Virtual Machine Platform feature:',
-      'Enable Virtual Machine Platform',
-      'https://learn.microsoft.com/en-us/windows/wsl/install-manual#step-3---enable-virtual-machine-feature',
-    );
+    return this.createFailureResult({
+      description: 'Virtual Machine Platform should be enabled to be able to run Podman.',
+      docLinksDescription: 'Learn about how to enable the Virtual Machine Platform feature:',
+      docLinks: {
+        url: 'https://learn.microsoft.com/en-us/windows/wsl/install-manual#step-3---enable-virtual-machine-feature',
+        title: 'Enable Virtual Machine Platform',
+      },
+    });
   }
 }
 
@@ -478,28 +488,33 @@ class WSL2Check extends BaseCheck {
 
       if (!isWSL) {
         if (isAdmin) {
-          return this.createFailureResult(
-            'WSL2 is not installed.',
-            "Call 'wsl --install --no-distribution' in a terminal.",
-            'WSL2 Install Manual',
-            'https://learn.microsoft.com/en-us/windows/wsl/install',
-          );
+          return this.createFailureResult({
+            description: 'WSL2 is not installed.',
+            docLinksDescription: `Call 'wsl --install --no-distribution' in a terminal.`,
+            docLinks: {
+              url: 'https://learn.microsoft.com/en-us/windows/wsl/install',
+              title: 'WSL2 Install Manual',
+            },
+          });
         } else {
-          return this.createFailureResult(
-            'WSL2 is not installed or you do not have permissions to run WSL2.',
-            'Contact your Administrator to setup WSL2.',
-            'WSL2 Install Manual',
-            'https://learn.microsoft.com/en-us/windows/wsl/install',
-          );
+          return this.createFailureResult({
+            description: 'WSL2 is not installed or you do not have permissions to run WSL2.',
+            docLinksDescription: 'Contact your Administrator to setup WSL2.',
+            docLinks: {
+              url: 'https://learn.microsoft.com/en-us/windows/wsl/install',
+              title: 'WSL2 Install Manual',
+            },
+          });
         }
       }
     } catch (err) {
-      return this.createFailureResult(
-        'Could not detect WSL2',
-        '',
-        'WSL2 Install Manual',
-        'https://learn.microsoft.com/en-us/windows/wsl/install',
-      );
+      return this.createFailureResult({
+        description: 'Could not detect WSL2',
+        docLinks: {
+          url: 'https://learn.microsoft.com/en-us/windows/wsl/install',
+          title: 'WSL2 Install Manual',
+        },
+      });
     }
 
     return this.createSuccessfulResult();

--- a/extensions/podman/src/podman-install.ts
+++ b/extensions/podman/src/podman-install.ts
@@ -392,6 +392,8 @@ class WinBitCheck extends BaseCheck {
     } else {
       return this.createFailureResult(
         'WSL2 works only on 64bit OS.',
+        'Learn about WSL requirements:',
+        'WSL2 Install Manual',
         'https://docs.microsoft.com/en-us/windows/wsl/install-manual#step-2---check-requirements-for-running-wsl-2',
       );
     }
@@ -412,6 +414,7 @@ class WinVersionCheck extends BaseCheck {
       } else {
         return this.createFailureResult(
           'To be able to run WSL2 you need Windows 10 Build 18362 or later.',
+          'Learn about WSL requirements:',
           'WSL2 Install Manual',
           'https://docs.microsoft.com/en-us/windows/wsl/install-manual#step-2---check-requirements-for-running-wsl-2',
         );
@@ -419,6 +422,7 @@ class WinVersionCheck extends BaseCheck {
     } else {
       return this.createFailureResult(
         'WSL2 works only on Windows 10 and newest OS',
+        'Learn about WSL requirements:',
         'WSL2 Install Manual',
         'https://docs.microsoft.com/en-us/windows/wsl/install-manual#step-2---check-requirements-for-running-wsl-2',
       );
@@ -457,6 +461,7 @@ class VirtualMachinePlatformCheck extends BaseCheck {
     }
     return this.createFailureResult(
       'Virtual Machine Platform should be enabled to be able to run Podman.',
+      'Learn about how to enable the Virtual Machine Platform feature:',
       'Enable Virtual Machine Platform',
       'https://learn.microsoft.com/en-us/windows/wsl/install-manual#step-3---enable-virtual-machine-feature',
     );
@@ -474,14 +479,16 @@ class WSL2Check extends BaseCheck {
       if (!isWSL) {
         if (isAdmin) {
           return this.createFailureResult(
-            'WSL2 is not installed. Call "wsl --install --no-distribution" in a terminal.',
-            'Install WSL',
+            'WSL2 is not installed.',
+            "Call 'wsl --install --no-distribution' in a terminal.",
+            'WSL2 Install Manual',
             'https://learn.microsoft.com/en-us/windows/wsl/install',
           );
         } else {
           return this.createFailureResult(
-            'WSL2 is not installed or you do not have permissions to run WSL2. Contact your Administrator to setup WSL2.',
-            'More info',
+            'WSL2 is not installed or you do not have permissions to run WSL2.',
+            'Contact your Administrator to setup WSL2.',
+            'WSL2 Install Manual',
             'https://learn.microsoft.com/en-us/windows/wsl/install',
           );
         }
@@ -489,7 +496,8 @@ class WSL2Check extends BaseCheck {
     } catch (err) {
       return this.createFailureResult(
         'Could not detect WSL2',
-        'Install WSL',
+        '',
+        'WSL2 Install Manual',
         'https://learn.microsoft.com/en-us/windows/wsl/install',
       );
     }

--- a/extensions/podman/src/podman-install.ts
+++ b/extensions/podman/src/podman-install.ts
@@ -395,7 +395,7 @@ class WinBitCheck extends BaseCheck {
         docLinksDescription: 'Learn about WSL requirements:',
         docLinks: {
           url: 'https://docs.microsoft.com/en-us/windows/wsl/install-manual#step-2---check-requirements-for-running-wsl-2',
-          title: 'WSL2 Install Manual',
+          title: 'WSL2 Manual Installation Steps',
         },
       });
     }
@@ -419,7 +419,7 @@ class WinVersionCheck extends BaseCheck {
           docLinksDescription: 'Learn about WSL requirements:',
           docLinks: {
             url: 'https://docs.microsoft.com/en-us/windows/wsl/install-manual#step-2---check-requirements-for-running-wsl-2',
-            title: 'WSL2 Install Manual',
+            title: 'WSL2 Manual Installation Steps',
           },
         });
       }
@@ -429,7 +429,7 @@ class WinVersionCheck extends BaseCheck {
         docLinksDescription: 'Learn about WSL requirements:',
         docLinks: {
           url: 'https://docs.microsoft.com/en-us/windows/wsl/install-manual#step-2---check-requirements-for-running-wsl-2',
-          title: 'WSL2 Install Manual',
+          title: 'WSL2 Manual Installation Steps',
         },
       });
     }
@@ -493,7 +493,7 @@ class WSL2Check extends BaseCheck {
             docLinksDescription: `Call 'wsl --install --no-distribution' in a terminal.`,
             docLinks: {
               url: 'https://learn.microsoft.com/en-us/windows/wsl/install',
-              title: 'WSL2 Install Manual',
+              title: 'WSL2 Manual Installation Steps',
             },
           });
         } else {
@@ -502,7 +502,7 @@ class WSL2Check extends BaseCheck {
             docLinksDescription: 'Contact your Administrator to setup WSL2.',
             docLinks: {
               url: 'https://learn.microsoft.com/en-us/windows/wsl/install',
-              title: 'WSL2 Install Manual',
+              title: 'WSL2 Manual Installation Steps',
             },
           });
         }
@@ -512,7 +512,7 @@ class WSL2Check extends BaseCheck {
         description: 'Could not detect WSL2',
         docLinks: {
           url: 'https://learn.microsoft.com/en-us/windows/wsl/install',
-          title: 'WSL2 Install Manual',
+          title: 'WSL2 Manual Installation Steps',
         },
       });
     }

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -287,7 +287,7 @@ declare module '@podman-desktop/api' {
     description?: string;
     docLinksDescription?: string;
     docLinks?: CheckResultLink[];
-    fixFailedCheckCommand?: CheckResultFixCommand;
+    fixCommand?: CheckResultFixCommand;
   }
 
   export interface InstallCheck {

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -277,10 +277,17 @@ declare module '@podman-desktop/api' {
   }
   export type CheckResultLink = Link;
 
+  export interface CheckResultFixCommand {
+    id: string;
+    title: string;
+  }
+
   export interface CheckResult {
     successful: boolean;
     description?: string;
+    docLinksDescription?: string;
     docLinks?: CheckResultLink[];
+    fixFailedCheckCommand?: CheckResultFixCommand;
   }
 
   export interface InstallCheck {

--- a/packages/renderer/src/lib/markdown/Markdown.spec.ts
+++ b/packages/renderer/src/lib/markdown/Markdown.spec.ts
@@ -100,3 +100,64 @@ describe('Custom link', () => {
     );
   });
 });
+
+describe('Custom warnings', () => {
+  test('Expect warning failed status and description', async () => {
+    const warnings = [
+      {
+        state: 'failed',
+        description: 'description',
+      },
+    ];
+
+    await waitRender({ markdown: `:warnings[${JSON.stringify(warnings)}]` });
+    const markdownContent = screen.getByRole('region', { name: 'markdown-content' });
+    expect(markdownContent).toBeInTheDocument();
+    expect(markdownContent.textContent).toContain('description');
+    expect(markdownContent.textContent).toContain('❌');
+  });
+
+  test('Expect warning successful status and description', async () => {
+    const warnings = [
+      {
+        state: 'successful',
+        description: 'successful description',
+      },
+    ];
+
+    await waitRender({ markdown: `:warnings[${JSON.stringify(warnings)}]` });
+    const markdownContent = screen.getByRole('region', { name: 'markdown-content' });
+    expect(markdownContent).toBeInTheDocument();
+    expect(markdownContent.textContent).toContain('successful description');
+    expect(markdownContent.textContent).toContain('✅');
+  });
+
+  test('Expect command, docdescription and links to be rendered correctly', async () => {
+    const warnings = [
+      {
+        state: 'successful',
+        description: 'successful description',
+        command: {
+          id: 'command',
+          title: 'command title',
+        },
+        docDescription: 'this is the doc description',
+        docLinks: [
+          {
+            url: 'url',
+            title: 'first link',
+          },
+        ],
+      },
+    ];
+
+    await waitRender({ markdown: `:warnings[${JSON.stringify(warnings)}]` });
+    const markdownContent = screen.getByRole('region', { name: 'markdown-content' });
+    expect(markdownContent).toBeInTheDocument();
+    expect(markdownContent.textContent).toContain('this is the doc description');
+    const button = screen.getByRole('button', { name: 'command title' });
+    expect(button).toBeDefined();
+    const link = screen.getByRole('link', { name: 'first link' });
+    expect(link).toBeDefined();
+  });
+});

--- a/packages/renderer/src/lib/markdown/Markdown.svelte
+++ b/packages/renderer/src/lib/markdown/Markdown.svelte
@@ -33,6 +33,7 @@ import { micromark } from 'micromark';
 import { directive, directiveHtml } from 'micromark-extension-directive';
 import { button } from './micromark-button-directive';
 import { link } from './micromark-link-directive';
+import { warnings } from './micromark-warnings-directive';
 
 let text: string;
 let html: string;
@@ -57,7 +58,7 @@ const eventListeners: ((e: any) => void)[] = [];
 $: markdown
   ? (html = micromark(markdown, {
       extensions: [directive()],
-      htmlExtensions: [directiveHtml({ button, link })],
+      htmlExtensions: [directiveHtml({ button, link, warnings })],
     }))
   : undefined;
 
@@ -69,7 +70,7 @@ onMount(() => {
   // Provide micromark + extensions
   html = micromark(text, {
     extensions: [directive()],
-    htmlExtensions: [directiveHtml({ button, link })],
+    htmlExtensions: [directiveHtml({ button, link, warnings })],
   });
 
   // We create a click listener in order to execute any internal commands using:

--- a/packages/renderer/src/lib/markdown/micromark-warnings-directive.ts
+++ b/packages/renderer/src/lib/markdown/micromark-warnings-directive.ts
@@ -92,10 +92,56 @@ export function warnings(d: any) {
       );
 
       // Add the "progress" spinner
-      // TODO: Remove cloudfoundry to tailwind
       this.tag(
-        '<i class="pf-c-button__progress" style="position: relative; margin-right:5px; display: none;"><span class="pf-c-spinner pf-m-sm" role="progressbar"><span class="pf-c-spinner__clipper">' +
-          '</span><span class="pf-c-spinner__lead-ball"></span><span class="pf-c-spinner__tail-ball"></span></span></i>',
+        `<i class="flex justify-center items-center">
+          <svg width="2em" height="2em" viewBox="0 0 100 100">
+            <defs>
+              <linearGradient id="grad1" x1="0%" y1="0%" x2="0%" y2="100%">
+                <stop offset="0%" style="stop-color:rgb(0,0,0);stop-opacity:1"></stop>
+                <stop offset="60%" style="stop-color:rgb(0,0,0);stop-opacity:1"></stop>
+                <stop offset="100%" style="stop-color:rgb(255,255,255);stop-opacity:1"></stop>
+              </linearGradient>
+            </defs>
+            <mask id="myMask">
+              <rect x="0" y="0" width="100" height="100" fill="white"></rect>
+              <rect x="-25" y="-25" width="150" height="75" fill="black"></rect>
+              <g transform="translate(50,50)" style="width='2em'; height='2em'">
+                <g>
+                  <rect x="-75" y="-75" width="150" height="75" fill="url(#grad1)"></rect>
+                  <rect x="-75" y="-70" width="100" height="75" fill="black"></rect>
+                  <animateTransform
+                    attributeName="transform"
+                    type="rotate"
+                    dur="1.5s"
+                    from="0"
+                    to="180"
+                    values="0; 140;180; 140; 0"
+                    keyTimes="0; 0.25;0.5; 0.75;1"
+                    repeatCount="indefinite"></animateTransform>
+                </g>
+              </g>
+            </mask>
+            <circle
+              cx="50"
+              cy="50"
+              r="46"
+              stroke="currentColor"
+              opacity="0.8"
+              stroke-width="10"
+              fill="transparent"
+              mask="url(#myMask)"></circle>
+            <animateTransform
+              attributeName="transform"
+              type="rotate"
+              dur="3s"
+              from="0"
+              to="360"
+              repeatCount="indefinite"
+              values="0;90;180;270;360;450;540;630;720;810;900;990;1080;1170;1260;1350;1440;1530;1620;1710;1800"
+              keyTimes="0; 0.02;0.08;0.18;0.32;0.375;0.42;0.455;0.48;0.495;0.5;0.52;0.58;0.68;0.82;0.875;0.92;0.955;0.98;0.995;1"
+            ></animateTransform>
+          </svg>
+        </i>`,
       );
 
       // Add any labels and close the button

--- a/packages/renderer/src/lib/markdown/micromark-warnings-directive.ts
+++ b/packages/renderer/src/lib/markdown/micromark-warnings-directive.ts
@@ -1,0 +1,132 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+// @ts-nocheck
+// this is the opposite of what happens in the micromark encode function
+const characterReferences = { '&quot;': '"', '&amp;': '&', '&lt;': '<', '&gt;': '>' };
+
+export function decode(value) {
+  return value.replace(/(&quot;|&amp;|&gt;|&lt;)/g, replace);
+
+  /**
+   * @param {string} value
+   * @returns {string}
+   */
+  function replace(value) {
+    return characterReferences[value];
+  }
+}
+
+/**
+ * Allow to generate a link markdown directive that executes a command
+ * syntax is the following:
+ * :warnings[[{item}, {item}]]
+ * where item is 
+ * {
+    state: string;
+    description: string;
+    command?: {
+      id: string;
+      title: string;
+    }
+    docDescription?: string;
+    docLinks?: {
+      title: string;
+      url: string;
+      group?: string;
+    }[];
+  }
+ */
+/**
+ * @this {import('micromark-util-types').CompileContext}
+ * @type {import('micromark-extension-directive').Handle}
+ */
+export function warnings(d: any) {
+  // Make sure it's not part of a text directive
+  if (d.type !== 'textDirective') {
+    return false;
+  }
+
+  // Add the div tag which depicts the wrapper list containing all items
+  this.tag('<div class="flex flex-col space-y-3">');
+
+  const items = JSON.parse(decode(d.label) || '');
+  for (const item of items) {
+    // start the div representing one row
+    this.tag('<div class="flex flex-row space-x-3 bg-charcoal-600 p-4 rounded-md items-center">');
+    // add icon representing the warning status
+    this.tag('<div class="mr-2 flex justify-center">');
+    this.tag(item.state === 'successful' ? '✅' : '❌');
+    this.tag('</div>');
+    // add the warning description
+    if (item.description) {
+      // add title to the left
+      this.tag('<div class="flex-grow">');
+      this.raw(item.description);
+      this.tag('</div>');
+    }
+    // add the command
+    this.tag('<div class="w-[180px] pr-3 flex justify-center">');
+    if (item.command) {
+      // Make this a button
+      this.tag(
+        '<button class="px-4 py-[6px] rounded-[4px] text-white text-[13px] whitespace-nowrap bg-purple-600 hover:bg-purple-500 no-underline" data-command="' +
+          this.encode(item.command.id) +
+          '">',
+      );
+
+      // Add the "progress" spinner
+      // TODO: Remove cloudfoundry to tailwind
+      this.tag(
+        '<i class="pf-c-button__progress" style="position: relative; margin-right:5px; display: none;"><span class="pf-c-spinner pf-m-sm" role="progressbar"><span class="pf-c-spinner__clipper">' +
+          '</span><span class="pf-c-spinner__lead-ball"></span><span class="pf-c-spinner__tail-ball"></span></span></i>',
+      );
+
+      // Add any labels and close the button
+      this.raw(item.command.title);
+      this.tag('</button>');
+    }
+    this.tag('</div>');
+    // add the description to be shown above the links
+    this.tag('<div class="flex flex-col w-[250px] text-sm">');
+    if (item.docDescription) {
+      this.tag('<span>');
+      this.raw(item.docDescription);
+      this.tag('</span>');
+    }
+    // add links
+    if (item.docLinks) {
+      for (const link of item.docLinks) {
+        this.tag('<a ');
+        this.tag(' href="' + this.encode(link.url) + '"');
+        this.tag(' title="' + this.encode(link.title) + '"');
+        this.tag('>');
+        this.raw(link.title);
+        this.tag('</a>');
+      }
+    }
+    // close links + description div
+    this.tag('</div>');
+    // close whole row div
+    this.tag('</div>');
+  }
+
+  // close warnings component
+  this.tag('</div>');
+}

--- a/packages/renderer/src/lib/onboarding/onboarding-utils.ts
+++ b/packages/renderer/src/lib/onboarding/onboarding-utils.ts
@@ -188,12 +188,17 @@ function getStringWithContextKeyReplaced(
   replacement?: string,
 ) {
   if (matchArray.length > 1) {
+    let replacementUnknown: unknown = replacement;
     if (replacement === undefined && context) {
       const key = prefix ? `${prefix}.${matchArray[1]}` : matchArray[1];
-      replacement = context.getValue(key);
+      replacementUnknown = context.getValue(key);
     }
-    if (replacement !== undefined) {
-      return value.replace(matchArray[0], String(replacement));
+    if (replacementUnknown !== undefined) {
+      if (typeof replacementUnknown === 'string') {
+        return value.replace(matchArray[0], replacementUnknown);
+      } else {
+        return value.replace(matchArray[0], JSON.stringify(replacementUnknown));
+      }
     }
   }
   return value;


### PR DESCRIPTION
### What does this PR do?

This PR updates a bit how the warnings are displayed during the onboarding. 
This will be useful for follow-up PRs when we add buttons that automatically update/fix the system.

Following the new mockup that Mo made
![image](https://github.com/containers/podman-desktop/assets/49404737/30131499-31f2-46f0-8db3-d07da913d93e)

Let's say i miss 3 requirements, we can tell to Desktop that requirement 3 has a command that can fix it and 1,2 only have documentation and it's up to the user to fix them (e.g if you are on an older version of windows or you need more memory).

It can also happen that a warning has both (command + links)

### Screenshot/screencast of this PR

![image](https://github.com/containers/podman-desktop/assets/49404737/15637f08-4e41-49be-a94b-3692e2edfdf7)

### What issues does this PR fix or reference?

it resolves #4174 

### How to test this PR?

1. run tests (when i'll push them), open for discussion for the moment
