### PR TITLE
chore: show onboarding for unknown status providers

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.spec.ts
@@ -252,6 +252,28 @@ test('Expect to redirect to onboarding page if setup button is clicked', async (
   expect(router.goto).toHaveBeenCalledWith(`/preferences/onboarding/id`);
 });
 
+test('Expect setup button to appear even if provider status is set to unknown and enablement is true', async () => {
+  const customProviderInfo: ProviderInfo = { ...providerInfo };
+  customProviderInfo.containerProviderConnectionCreationDisplayName = undefined;
+  customProviderInfo.status = 'unknown';
+  customProviderInfo.name = 'foobar';
+  providerInfos.set([customProviderInfo]);
+
+  // Onboarding is enabled
+  const onboarding: OnboardingInfo = {
+    extension: 'id',
+    steps: [],
+    title: 'onboarding',
+    enablement: 'true',
+  };
+  onboardingList.set([onboarding]);
+  render(PreferencesResourcesRendering, {});
+
+  // Expect the setup button to appear
+  const button = screen.getByRole('button', { name: 'Setup foobar' });
+  expect(button).toBeInTheDocument();
+});
+
 test('Expect to redirect to extension preferences page if onboarding is disabled and the cog button is clicked', async () => {
   // clone providerInfo and change id and status
   const customProviderInfo: ProviderInfo = { ...providerInfo };

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
@@ -369,7 +369,8 @@ function isOnboardingEnabled(provider: ProviderInfo, globalContext: ContextUI): 
               <span class="my-auto text-gray-400 ml-3 break-words">{provider.name}</span>
             </div>
             <div class="text-center mt-10">
-              {#if isOnboardingEnabled(provider, globalContext) && provider.status === 'not-installed'}
+              <!-- Some providers have a status of 'unknown' so that they do not appear in the dashboard, this allows onboarding to still show. -->
+              {#if isOnboardingEnabled(provider, globalContext) && (provider.status === 'not-installed' || provider.status === 'unknown')}
                 <Button
                   aria-label="Setup {provider.name}"
                   title="Setup {provider.name}"


### PR DESCRIPTION
chore: show onboarding for unknown status providers

### What does this PR do?

Some providers are using 'unknown' such as compose and kind in order for
them NOT to appear in the dashboard.

This allows the new compose onboarding to be able to still show
enablement / onboarding process.

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast
explaining what is doing this PR -->

N/A

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop/issues/4207

### How to test this PR?

<!-- Please explain steps to reproduce -->

Run the tests, or patch the PR against
https://github.com/containers/podman-desktop/pull/3953 it will not show
the "Setup..." button.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
