### PR TITLE
feat: add action to install wsl if missing during onboarding (#4193)

### DIFF
--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -876,9 +876,14 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
 
   // provide an installation path ?
   if (podmanInstall.isAbleToInstall()) {
+    // init all install checks
+    const installChecks = podmanInstall.getInstallChecks();
+    for (const check of installChecks) {
+      await check.init?.();
+    }
     provider.registerInstallation({
       install: () => podmanInstall.doInstallPodman(provider),
-      preflightChecks: () => podmanInstall.getInstallChecks(),
+      preflightChecks: () => installChecks,
     });
   }
 

--- a/extensions/podman/src/podman-install.spec.ts
+++ b/extensions/podman/src/podman-install.spec.ts
@@ -38,6 +38,9 @@ vi.mock('node:os', async () => {
 
 vi.mock('@podman-desktop/api', async () => {
   return {
+    commands: {
+      registerCommand: vi.fn(),
+    },
     window: {
       withProgress: vi.fn(),
       showNotification: vi.fn(),
@@ -430,4 +433,13 @@ test('expect winWSL2 preflight check return failure result if it fails when chec
   expect(result.description).equal('Could not detect WSL2');
   expect(result.docLinks[0].url).equal('https://learn.microsoft.com/en-us/windows/wsl/install');
   expect(result.docLinks[0].title).equal('WSL2 Manual Installation Steps');
+});
+
+test('expect winWSL2 init to rgister WSLInstall command', async () => {
+  const registerCommandMock = vi.spyOn(extensionApi.commands, 'registerCommand');
+  const installer = new WinInstaller();
+  const preflights = installer.getPreflightChecks();
+  const winWSLCheck = preflights[4];
+  await winWSLCheck.init();
+  expect(registerCommandMock).toBeCalledWith('podman.onboarding.installWSL', expect.any(Function));
 });

--- a/extensions/podman/src/podman-install.ts
+++ b/extensions/podman/src/podman-install.ts
@@ -480,6 +480,13 @@ class VirtualMachinePlatformCheck extends BaseCheck {
 
 class WSL2Check extends BaseCheck {
   title = 'WSL2 Installed';
+  installWSLCommandId = 'podman.onboarding.installWSL';
+
+  async init(): Promise<void> {
+    extensionApi.commands.registerCommand(this.installWSLCommandId, async () => {
+      return await this.installWSL();
+    });
+  }
 
   async execute(): Promise<extensionApi.CheckResult> {
     try {
@@ -494,6 +501,10 @@ class WSL2Check extends BaseCheck {
             docLinks: {
               url: 'https://learn.microsoft.com/en-us/windows/wsl/install',
               title: 'WSL2 Manual Installation Steps',
+            },
+            fixCommand: {
+              id: this.installWSLCommandId,
+              title: 'Install WSL2',
             },
           });
         } else {
@@ -548,6 +559,19 @@ class WSL2Check extends BaseCheck {
       return !!output;
     } catch (error) {
       return false;
+    }
+  }
+
+  private async installWSL(): Promise<string> {
+    try {
+      const { stdout: res } = await extensionApi.process.exec('wsl', ['--install', '--no-distribution'], {
+        env: { WSL_UTF8: '1' },
+      });
+      return this.normalizeOutput(res);
+    } catch (error) {
+      let message = error.message ? `${error.message}\n` : '';
+      message += error.stdout || '';
+      return message;
     }
   }
 }

--- a/extensions/podman/src/podman-install.ts
+++ b/extensions/podman/src/podman-install.ts
@@ -571,6 +571,7 @@ class WSL2Check extends BaseCheck {
     } catch (error) {
       let message = error.message ? `${error.message}\n` : '';
       message += error.stdout || '';
+      message += error.stderr || '';
       throw new Error(message);
     }
   }

--- a/extensions/podman/src/podman-install.ts
+++ b/extensions/podman/src/podman-install.ts
@@ -571,7 +571,7 @@ class WSL2Check extends BaseCheck {
     } catch (error) {
       let message = error.message ? `${error.message}\n` : '';
       message += error.stdout || '';
-      return message;
+      throw new Error(message);
     }
   }
 }

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -293,6 +293,7 @@ declare module '@podman-desktop/api' {
   export interface InstallCheck {
     title: string;
     execute(): Promise<CheckResult>;
+    init?(): Promise<void>;
   }
 
   export interface ProviderInstallation {

--- a/packages/renderer/src/lib/markdown/component/micromark-button.spec.ts
+++ b/packages/renderer/src/lib/markdown/component/micromark-button.spec.ts
@@ -1,0 +1,51 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { CompileContext } from 'micromark-util-types';
+import '@testing-library/jest-dom/vitest';
+import { test, expect, vi } from 'vitest';
+import { createUIButton } from './micromark-button';
+
+test('Expect createUIButton to return a button with a spinner and an error icon', async () => {
+  let html = '';
+  const context: CompileContext = {
+    options: {},
+    setData: vi.fn(),
+    getData: vi.fn(),
+    lineEndingIfNeeded: vi.fn(),
+    encode: vi.fn(),
+    buffer: vi.fn(),
+    resume: vi.fn(),
+    raw: function (value: string): undefined {
+      html += value;
+    },
+    tag: function (value: string): undefined {
+      html += value;
+    },
+    sliceSerialize: vi.fn(),
+  };
+  createUIButton.bind(context)({
+    id: 'id',
+    title: 'command',
+  });
+
+  const htmlSanitized = html.replace('\n', '').replaceAll(/\s+/g, ' ');
+  expect(htmlSanitized).toContain("<button id='micromark-button-1'");
+  expect(htmlSanitized).toContain("<i id='micromark-spinner-1'");
+  expect(htmlSanitized).toContain("<i id='micromark-button-1-failed-icon'");
+});

--- a/packages/renderer/src/lib/markdown/component/micromark-button.spec.ts
+++ b/packages/renderer/src/lib/markdown/component/micromark-button.spec.ts
@@ -44,8 +44,8 @@ test('Expect createUIButton to return a button with a spinner and an error icon'
     title: 'command',
   });
 
-  const htmlSanitized = html.replace('\n', '').replaceAll(/\s+/g, ' ');
-  expect(htmlSanitized).toContain("<button id='micromark-button-1'");
-  expect(htmlSanitized).toContain("<i id='micromark-spinner-1'");
-  expect(htmlSanitized).toContain("<i id='micromark-button-1-failed-icon'");
+  const htmlSanitized: string = html.replace('\n', '').replace(/\s+/g, ' ');
+  expect(htmlSanitized).toContain(`<button id='micromark-button-1'`);
+  expect(htmlSanitized).toContain(`<i id='micromark-spinner-1'`);
+  expect(htmlSanitized).toContain(`<i id='micromark-button-1-failed-icon'`);
 });

--- a/packages/renderer/src/lib/markdown/component/micromark-button.ts
+++ b/packages/renderer/src/lib/markdown/component/micromark-button.ts
@@ -39,8 +39,8 @@ interface ButtonElement {
 
 const BASE_BUTTON_CSS =
   'flex flex-row items-center justify-center px-4 py-[6px] max-w-[200px] rounded-[4px] text-white text-[13px] whitespace-nowrap no-underline';
-const NORMAL_MODE_CSS = `${BASE_BUTTON_CSS} bg-purple-600 hover:bg-purple-500`;
-const ERROR_MODE_CSS = `${BASE_BUTTON_CSS} text-gray-400 bg-red-900 hover:bg-red-700`;
+export const NORMAL_MODE_CSS = `${BASE_BUTTON_CSS} bg-purple-600 hover:bg-purple-500`;
+export const ERROR_MODE_CSS = `${BASE_BUTTON_CSS} text-gray-400 bg-red-900 hover:bg-red-700`;
 
 /**
  * it creates a new button by associating the command to it and returns its new generated button id
@@ -77,7 +77,6 @@ function newButtonId(): string {
  * if the command execution succeed the button state is reset to its normal mode
  * if the command execution fails the button goes in error mode - its color becomes red and a toggle to see all logs is displayed
  * @param buttonId button id
- * @returns n/a
  */
 export async function executeButtonCommand(buttonId: string) {
   const button = buttons.get(buttonId);
@@ -108,7 +107,7 @@ export async function executeButtonCommand(buttonId: string) {
 function createHtmlErrorContent(reason: string): string {
   // it uses inline style to constraint the height as tailwind max-height classes do not work with html injected
   return `
-    <div class="bg-black text-sm overflow-y-auto overflow-x-auto p-3" style="height: 150px">
+    <div class='bg-black text-sm overflow-y-auto overflow-x-auto p-3' style='height: 150px'>
     ${reason}
     </div>
     `;
@@ -200,17 +199,17 @@ export function createUIButton(this: CompileContext, command: Command) {
   const buttonId = createButton(command);
   this.tag(
     `<button 
-            id='${buttonId}' 
-            class='${NORMAL_MODE_CSS}'
-            title='${command.title}'
-        >`,
+      id='${buttonId}' 
+      class='${NORMAL_MODE_CSS}'
+      title='${command.title}'
+    >`,
   );
 
-  // Add the "progress" spinner
+  // Add the 'progress' spinner
   this.tag(createSpinner(buttonId));
 
   // add the failed icon which gets visible in error mode
-  this.tag(`<i id="${buttonId}-failed-icon" class="fas fa-times text-gray-100 mr-1" style="display: none"></i>`);
+  this.tag(`<i id='${buttonId}-failed-icon' class='fas fa-times text-gray-100 mr-1' style='display: none'></i>`);
 
   // Add the command title
   this.raw(command.title);

--- a/packages/renderer/src/lib/markdown/component/micromark-button.ts
+++ b/packages/renderer/src/lib/markdown/component/micromark-button.ts
@@ -1,0 +1,235 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+/**
+ * It allows to create a button which has a spinner and an error log expandable section which gets visible if the command execution fails
+ */
+import type { CompileContext } from 'micromark-util-types';
+import type { Command, ExpandableSectionProps } from '../micromark-utils';
+import { createSpinner, disableSpinner, enableSpinner } from './micromark-spinner';
+import {
+  createExpandableSection,
+  hideExpandableToggleByRef,
+  showExpandableToggleByRef,
+  updateExpandableSectionHtmlContentByRef,
+} from './micromark-expandable-section';
+
+let buttonCount = 0;
+const buttons = new Map<string, ButtonElement>();
+
+interface ButtonElement {
+  id: string;
+  command: Command;
+  disabled: boolean;
+}
+
+const BASE_BUTTON_CSS =
+  'flex flex-row items-center justify-center px-4 py-[6px] max-w-[200px] rounded-[4px] text-white text-[13px] whitespace-nowrap no-underline';
+const NORMAL_MODE_CSS = `${BASE_BUTTON_CSS} bg-purple-600 hover:bg-purple-500`;
+const ERROR_MODE_CSS = `${BASE_BUTTON_CSS} text-gray-400 bg-red-900 hover:bg-red-700`;
+
+/**
+ * it creates a new button by associating the command to it and returns its new generated button id
+ * @param command command to execute when the button is clicked
+ * @returns new button id
+ */
+function createButton(command: Command): string {
+  // returns new id
+  const id = newButtonId();
+  const button: ButtonElement = {
+    id,
+    command,
+    disabled: false,
+  };
+  // associate command to id
+  buttons.set(id, button);
+  return id;
+}
+
+/**
+ * generate a new button id
+ * @returns button id
+ */
+function newButtonId(): string {
+  // update button number and create a new id
+  ++buttonCount;
+  return `micromark-button-${buttonCount}`;
+}
+
+/**
+ * execute the command when the button is clicked
+ *
+ * when this function is invoked the button is disabled to prevent multiple click. The spinner is enabled and the command execution is invoked
+ * if the command execution succeed the button state is reset to its normal mode
+ * if the command execution fails the button goes in error mode - its color becomes red and a toggle to see all logs is displayed
+ * @param buttonId button id
+ * @returns n/a
+ */
+export async function executeButtonCommand(buttonId: string) {
+  const button = buttons.get(buttonId);
+  if (button && !button.disabled) {
+    // hide its expandable error log section if visible and reset button css
+    disableErrorMode(button.id);
+    // disable button
+    disableButton(buttonId);
+    // show spinner
+    enableSpinner(buttonId);
+    // execute command
+    await window.executeCommand(button.command.id).catch((reason: unknown) => {
+      // enable error mode (button style is updated, the log error content is updated with the error text and it is made visible)
+      enableErrorMode(button.id, String(reason));
+    });
+    // hide spinner
+    disableSpinner(buttonId);
+    // re-enable button
+    enableButton(buttonId);
+  }
+}
+
+/**
+ * create a panel with the error data received from the server
+ * @param reason the reason why the command execution failed
+ * @returns the html panel
+ */
+function createHtmlErrorContent(reason: string): string {
+  // it uses inline style to constraint the height as tailwind max-height classes do not work with html injected
+  return `
+    <div class="bg-black text-sm overflow-y-auto overflow-x-auto p-3" style="height: 150px">
+    ${reason}
+    </div>
+    `;
+}
+
+/**
+ * enable the button
+ * @param id button id
+ */
+function enableButton(id: string) {
+  updateButtonState(id, false);
+}
+
+/**
+ * disable the button
+ * @param id button id
+ */
+function disableButton(id: string) {
+  updateButtonState(id, true);
+}
+
+/**
+ * enable/disable the button based on the disabled param
+ * @param id button id
+ * @param disabled if the button has to be disabled
+ */
+function updateButtonState(id: string, disabled: boolean) {
+  const button = buttons.get(id);
+  if (button) {
+    button.disabled = disabled;
+    const buttonElement = document.getElementById(id);
+    if (buttonElement) {
+      (buttonElement as HTMLButtonElement).disabled = button.disabled;
+    }
+  }
+}
+
+/**
+ * it enables the error mode. The button is colored in red, the expandable section which contains the log error is made visible
+ * @param id button id
+ * @param error the error log data to show in the expandable section
+ */
+function enableErrorMode(id: string, error: string) {
+  //updates the style applied to the button
+  toggleButtonMode(id, true);
+  // update its content with the error received
+  updateExpandableSectionHtmlContentByRef(id, createHtmlErrorContent(error));
+  // show the error log section
+  showExpandableToggleByRef(id);
+}
+
+/**
+ * it disable the error mode so the button is reset to its normal state (purple color, hide expandable section)
+ * @param id button id
+ */
+function disableErrorMode(id: string) {
+  //updates the style applied to the button
+  toggleButtonMode(id, false);
+  // hide the error log section
+  hideExpandableToggleByRef(id);
+}
+
+function toggleButtonMode(id: string, isErrorMode: boolean) {
+  const button = buttons.get(id);
+  if (button) {
+    const buttonElement = document.getElementById(id);
+    if (buttonElement) {
+      // we retrieve all children of the button to update them (spinnericon, error icon, text)
+      const buttonChildren = buttonElement.childNodes;
+      // last child is the text
+      buttonChildren[buttonChildren.length - 1].textContent = `${button.command.title}${isErrorMode ? ' failed' : ''}`;
+      // update the css of the button
+      const classes = isErrorMode
+        ? buttonElement.className.replace(NORMAL_MODE_CSS, ERROR_MODE_CSS)
+        : buttonElement.className.replace(ERROR_MODE_CSS, NORMAL_MODE_CSS);
+      buttonElement.className = classes;
+      // change visibility of error icon
+      (buttonChildren[buttonChildren.length - 2] as HTMLElement).style.display = isErrorMode ? 'flex' : 'none';
+    }
+  }
+}
+
+/**
+ * it adds a button and all its feature in the micromark directive context
+ * @param this compile context used by the micromark directive
+ * @param command the command to be associated to the new button, so when its clicked it start the command execution
+ */
+export function createUIButton(this: CompileContext, command: Command) {
+  const buttonId = createButton(command);
+  this.tag(
+    `<button 
+            id='${buttonId}' 
+            class='${NORMAL_MODE_CSS}'
+            title='${command.title}'
+        >`,
+  );
+
+  // Add the "progress" spinner
+  this.tag(createSpinner(buttonId));
+
+  // add the failed icon which gets visible in error mode
+  this.tag(`<i id="${buttonId}-failed-icon" class="fas fa-times text-gray-100 mr-1" style="display: none"></i>`);
+
+  // Add the command title
+  this.raw(command.title);
+  this.tag('</button>');
+
+  // add the expandable section which will contains the error logs if the command execution fails
+  const expandable: ExpandableSectionProps = {
+    toggleExpandedState: {
+      label: 'Error Log',
+    },
+    toggleCollapsedState: {
+      label: 'Error Log',
+    },
+    content: {
+      html: 'error',
+      expanded: false,
+    },
+    ref: buttonId,
+    showToggle: false,
+  };
+  createExpandableSection.bind(this)(expandable);
+}

--- a/packages/renderer/src/lib/markdown/component/micromark-expandable-section.spec.ts
+++ b/packages/renderer/src/lib/markdown/component/micromark-expandable-section.spec.ts
@@ -60,12 +60,12 @@ test('Expect createExpandableSection to return a button with an expandable secti
   };
   createExpandableSection.bind(context)(expandable);
 
-  const htmlSanitized = html.replace('\n', '').replaceAll(/\s+/g, ' ');
+  const htmlSanitized = html.replace('\n', '').replace(/\s+/g, ' ');
   expect(htmlSanitized).toContain(
-    "<button class='flex space-x-2 text-purple-400 w-fit hover:bg-white hover:bg-opacity-10 text-xs items-center' data-expandable='micromark-expandable-1'",
+    `<button class='flex space-x-2 text-purple-400 w-fit hover:bg-white hover:bg-opacity-10 text-xs items-center' data-expandable='micromark-expandable-1'`,
   );
   expect(htmlSanitized).toContain(
-    "<div class='flex-col w-[250px] text-sm micromark-expandable-1' style='display: none;'",
+    `<div class='flex-col w-[250px] text-sm micromark-expandable-1' style='display: none;'`,
   );
 });
 
@@ -85,12 +85,12 @@ test('Expect createExpandableSection to return a button and a visible expandable
   };
   createExpandableSection.bind(context)(expandable);
 
-  const htmlSanitized = html.replace('\n', '').replaceAll(/\s+/g, ' ');
+  const htmlSanitized = html.replace('\n', '').replace(/\s+/g, ' ');
   expect(htmlSanitized).toContain(
-    "<button class='flex space-x-2 text-purple-400 w-fit hover:bg-white hover:bg-opacity-10 text-xs items-center' data-expandable='micromark-expandable-2'",
+    `<button class='flex space-x-2 text-purple-400 w-fit hover:bg-white hover:bg-opacity-10 text-xs items-center' data-expandable='micromark-expandable-2'`,
   );
   expect(htmlSanitized).toContain(
-    "<div class='flex-col w-[250px] text-sm micromark-expandable-2' style='display: flex;'",
+    `<div class='flex-col w-[250px] text-sm micromark-expandable-2' style='display: flex;'`,
   );
 });
 
@@ -110,11 +110,11 @@ test('Expect createExpandableSection to return a hidden button and expandable se
   };
   createExpandableSection.bind(context)(expandable);
 
-  const htmlSanitized = html.replace('\n', '').replaceAll(/\s+/g, ' ');
+  const htmlSanitized = html.replace('\n', '').replace(/\s+/g, ' ');
   expect(htmlSanitized).toContain(
-    "<button class='flex space-x-2 text-purple-400 w-fit hover:bg-white hover:bg-opacity-10 text-xs items-center' data-expandable='micromark-expandable-3' style='display: none;'",
+    `<button class='flex space-x-2 text-purple-400 w-fit hover:bg-white hover:bg-opacity-10 text-xs items-center' data-expandable='micromark-expandable-3' style='display: none;'`,
   );
   expect(htmlSanitized).toContain(
-    "<div class='flex-col w-[250px] text-sm micromark-expandable-3' style='display: none;'",
+    `<div class='flex-col w-[250px] text-sm micromark-expandable-3' style='display: none;'`,
   );
 });

--- a/packages/renderer/src/lib/markdown/component/micromark-expandable-section.spec.ts
+++ b/packages/renderer/src/lib/markdown/component/micromark-expandable-section.spec.ts
@@ -1,0 +1,120 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { CompileContext } from 'micromark-util-types';
+import '@testing-library/jest-dom/vitest';
+import { test, expect, vi, beforeEach } from 'vitest';
+import type { ExpandableSectionProps } from '../micromark-utils';
+import { createExpandableSection } from './micromark-expandable-section';
+
+let html = '';
+const context: CompileContext = {
+  options: {},
+  setData: vi.fn(),
+  getData: vi.fn(),
+  lineEndingIfNeeded: vi.fn(),
+  encode: vi.fn(),
+  buffer: vi.fn(),
+  resume: vi.fn(),
+  raw: function (value: string): undefined {
+    html += value;
+  },
+  tag: function (value: string): undefined {
+    html += value;
+  },
+  sliceSerialize: vi.fn(),
+};
+
+beforeEach(() => {
+  html = '';
+});
+
+test('Expect createExpandableSection to return a button with an expandable section', async () => {
+  const expandable: ExpandableSectionProps = {
+    showToggle: true,
+    toggleExpandedState: {
+      label: 'Less information',
+    },
+    toggleCollapsedState: {
+      label: 'More information',
+    },
+    content: {
+      html: 'content',
+      expanded: false,
+    },
+  };
+  createExpandableSection.bind(context)(expandable);
+
+  const htmlSanitized = html.replace('\n', '').replaceAll(/\s+/g, ' ');
+  expect(htmlSanitized).toContain(
+    "<button class='flex space-x-2 text-purple-400 w-fit hover:bg-white hover:bg-opacity-10 text-xs items-center' data-expandable='micromark-expandable-1'",
+  );
+  expect(htmlSanitized).toContain(
+    "<div class='flex-col w-[250px] text-sm micromark-expandable-1' style='display: none;'",
+  );
+});
+
+test('Expect createExpandableSection to return a button and a visible expandable section', async () => {
+  const expandable: ExpandableSectionProps = {
+    showToggle: true,
+    toggleExpandedState: {
+      label: 'Less information',
+    },
+    toggleCollapsedState: {
+      label: 'More information',
+    },
+    content: {
+      html: 'content',
+      expanded: true,
+    },
+  };
+  createExpandableSection.bind(context)(expandable);
+
+  const htmlSanitized = html.replace('\n', '').replaceAll(/\s+/g, ' ');
+  expect(htmlSanitized).toContain(
+    "<button class='flex space-x-2 text-purple-400 w-fit hover:bg-white hover:bg-opacity-10 text-xs items-center' data-expandable='micromark-expandable-2'",
+  );
+  expect(htmlSanitized).toContain(
+    "<div class='flex-col w-[250px] text-sm micromark-expandable-2' style='display: flex;'",
+  );
+});
+
+test('Expect createExpandableSection to return a hidden button and expandable section', async () => {
+  const expandable: ExpandableSectionProps = {
+    showToggle: false,
+    toggleExpandedState: {
+      label: 'Less information',
+    },
+    toggleCollapsedState: {
+      label: 'More information',
+    },
+    content: {
+      html: 'content',
+      expanded: false,
+    },
+  };
+  createExpandableSection.bind(context)(expandable);
+
+  const htmlSanitized = html.replace('\n', '').replaceAll(/\s+/g, ' ');
+  expect(htmlSanitized).toContain(
+    "<button class='flex space-x-2 text-purple-400 w-fit hover:bg-white hover:bg-opacity-10 text-xs items-center' data-expandable='micromark-expandable-3' style='display: none;'",
+  );
+  expect(htmlSanitized).toContain(
+    "<div class='flex-col w-[250px] text-sm micromark-expandable-3' style='display: none;'",
+  );
+});

--- a/packages/renderer/src/lib/markdown/component/micromark-expandable-section.ts
+++ b/packages/renderer/src/lib/markdown/component/micromark-expandable-section.ts
@@ -1,0 +1,186 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+/**
+ * It allows to create an expandable section which consists of a toggle and a section which can be visible/hidden based on the toggle state
+ */
+import type { CompileContext } from 'micromark-util-types';
+import type { ExpandableSectionProps, ExpandableSection } from '../micromark-utils';
+
+let expandableCount = 0;
+const expandables = new Map<string, ExpandableSection>();
+
+const OPENED_STATE_TOGGLE_ICON = '<i class="fas fa-chevron-up text-gray-100 mr-1"></i>';
+const CLOSED_STATE_TOGGLE_ICON = '<i class="fas fa-chevron-down text-gray-100 mr-1"></i>';
+
+/**
+ * it creates a new expandable section object
+ * @param expandable property of the new expandable section
+ * @returns the expandable section
+ */
+function createExpandableSectionElement(expandable: ExpandableSectionProps): ExpandableSection {
+  const id = newExpandableId();
+  const expandableElement = {
+    ...expandable,
+    id,
+    toggleExpandedState: {
+      icon: OPENED_STATE_TOGGLE_ICON,
+      ...expandable.toggleExpandedState,
+    },
+    toggleCollapsedState: {
+      icon: CLOSED_STATE_TOGGLE_ICON,
+      ...expandable.toggleCollapsedState,
+    },
+  };
+  expandables.set(id, expandableElement);
+  return expandableElement;
+}
+
+/**
+ * generate an id for an expandable section
+ * @returns new id
+ */
+function newExpandableId(): string {
+  // update toggle number and create a new id
+  ++expandableCount;
+  return `micromark-expandable-${expandableCount}`;
+}
+
+/**
+ * it adds an expandable section (toggle + expandable/collapsable section) in the micromark directive context
+ * @param this compile context used by the micromark directive
+ * @param expandable the expandable section property to create the new expandable section ui element
+ */
+export function createExpandableSection(this: CompileContext, expandable: ExpandableSectionProps) {
+  // create the expandable element from the data received
+  const expandableElement = createExpandableSectionElement(expandable);
+
+  // if the expandable is created expanded, the button needs to be in open state, otherwise it's closed
+  const toggleState = expandableElement.content.expanded
+    ? expandableElement.toggleExpandedState
+    : expandableElement.toggleCollapsedState;
+
+  // create button (icon + label)
+  this.tag(
+    `<button class="flex space-x-2 text-purple-400 w-fit hover:bg-white hover:bg-opacity-10 text-xs items-center" data-expandable="${
+      expandableElement.id
+    }" style="display: ${expandable.showToggle ? 'flex' : 'none'};">`,
+  );
+  this.tag(toggleState.icon);
+  this.raw(toggleState.label);
+  this.tag('</button>');
+
+  // create expandable section
+  this.tag(
+    `<div class="flex-col w-[250px] text-sm ${expandableElement.id}" style="display: ${
+      expandable.content.expanded ? 'flex' : 'none'
+    };">`,
+  );
+  this.tag(expandable.content.html);
+  this.tag('</div>');
+}
+
+/**
+ * it gets triggered when the toggle is clicked and the expandable section needs to be expanded/collapsed
+ * @param id expandable section id
+ */
+export function executeExpandableToggle(id: string) {
+  const expandable = expandables.get(id);
+  if (expandable) {
+    // update expanded state
+    expandable.content.expanded = !expandable.content.expanded;
+    // invoke the actual toggle expandable function
+    toggleExpandableSection(expandable);
+  }
+}
+
+/**
+ * it updates the UI with the new expandable section state
+ * @param expandable expandable section
+ */
+function toggleExpandableSection(expandable: ExpandableSection) {
+  // retrieve info about the toggle (open/close icon + text) by looking at its expanded state
+  const toggleState = expandable.content.expanded ? expandable.toggleExpandedState : expandable.toggleCollapsedState;
+
+  // find toggle button
+  const toggleHTMLElement = document.querySelector(`[data-expandable="${expandable.id}"]`);
+  // update the inner icon + text based on its expanded state
+  if (toggleHTMLElement) {
+    toggleHTMLElement.innerHTML = `${toggleState.icon}${toggleState.label}`;
+  }
+  // find the expanded panel and expand/collapse it based on the expanded state
+  const expandedPanels = document.getElementsByClassName(expandable.id);
+  if (expandedPanels?.length > 0) {
+    const panel = expandedPanels[0] as HTMLElement;
+    panel.style.display = expandable.content.expanded ? 'flex' : 'none';
+  }
+}
+
+/**
+ * show the expandable section toggle
+ * @param ref id of the element that created the expandable section
+ */
+export function showExpandableToggleByRef(ref: string) {
+  updateExpandableToggleVisibility(ref, true);
+}
+
+/**
+ * hide the expandable section toggle
+ * @param ref id of the element that created the expandable section
+ */
+export function hideExpandableToggleByRef(ref: string) {
+  updateExpandableToggleVisibility(ref, false);
+}
+
+/**
+ * update the visibility of the expandable section toggle
+ * @param ref id of the element that created the expandable section
+ * @param show if the toggle must be visible or hidden
+ */
+function updateExpandableToggleVisibility(ref: string, show: boolean) {
+  for (const expandable of expandables.values()) {
+    if (expandable.ref === ref) {
+      expandable.showToggle = show;
+      // find toggle button
+      const toggleHTMLElement = document.querySelector(`[data-expandable="${expandable.id}"]`);
+      if (toggleHTMLElement) {
+        // update the visibility
+        (toggleHTMLElement as HTMLButtonElement).style.display = expandable.showToggle ? 'flex' : 'none';
+      }
+    }
+  }
+}
+
+/**
+ * update the content of the expandable section by using the ref property
+ * @param ref id of the element that created the expandable section
+ * @param html html to render inside the expandable section
+ */
+export function updateExpandableSectionHtmlContentByRef(ref: string, html: string) {
+  for (const expandable of expandables.values()) {
+    if (expandable.ref === ref) {
+      expandable.content.html = html;
+      // find toggle button
+      // find the toggle panel and show/hide it based on the expanded state
+      const expandableDivs = document.getElementsByClassName(expandable.id);
+      if (expandableDivs?.length > 0) {
+        const expandableDiv = expandableDivs[0] as HTMLElement;
+        expandableDiv.innerHTML = expandable.content.html;
+      }
+    }
+  }
+}

--- a/packages/renderer/src/lib/markdown/component/micromark-expandable-section.ts
+++ b/packages/renderer/src/lib/markdown/component/micromark-expandable-section.ts
@@ -24,8 +24,8 @@ import type { ExpandableSectionProps, ExpandableSection } from '../micromark-uti
 let expandableCount = 0;
 const expandables = new Map<string, ExpandableSection>();
 
-const OPENED_STATE_TOGGLE_ICON = '<i class="fas fa-chevron-up text-gray-100 mr-1"></i>';
-const CLOSED_STATE_TOGGLE_ICON = '<i class="fas fa-chevron-down text-gray-100 mr-1"></i>';
+const OPENED_STATE_TOGGLE_ICON = `<i class='fas fa-chevron-up text-gray-100 mr-1'></i>`;
+const CLOSED_STATE_TOGGLE_ICON = `<i class='fas fa-chevron-down text-gray-100 mr-1'></i>`;
 
 /**
  * it creates a new expandable section object
@@ -76,9 +76,9 @@ export function createExpandableSection(this: CompileContext, expandable: Expand
 
   // create button (icon + label)
   this.tag(
-    `<button class="flex space-x-2 text-purple-400 w-fit hover:bg-white hover:bg-opacity-10 text-xs items-center" data-expandable="${
+    `<button class='flex space-x-2 text-purple-400 w-fit hover:bg-white hover:bg-opacity-10 text-xs items-center' data-expandable='${
       expandableElement.id
-    }" style="display: ${expandable.showToggle ? 'flex' : 'none'};">`,
+    }' style='display: ${expandable.showToggle ? 'flex' : 'none'};' aria-label='${expandableElement.id}'>`,
   );
   this.tag(toggleState.icon);
   this.raw(toggleState.label);
@@ -86,9 +86,9 @@ export function createExpandableSection(this: CompileContext, expandable: Expand
 
   // create expandable section
   this.tag(
-    `<div class="flex-col w-[250px] text-sm ${expandableElement.id}" style="display: ${
+    `<div class='flex-col w-[250px] text-sm ${expandableElement.id}' style='display: ${
       expandable.content.expanded ? 'flex' : 'none'
-    };">`,
+    };'>`,
   );
   this.tag(expandable.content.html);
   this.tag('</div>');
@@ -117,7 +117,7 @@ function toggleExpandableSection(expandable: ExpandableSection) {
   const toggleState = expandable.content.expanded ? expandable.toggleExpandedState : expandable.toggleCollapsedState;
 
   // find toggle button
-  const toggleHTMLElement = document.querySelector(`[data-expandable="${expandable.id}"]`);
+  const toggleHTMLElement = document.querySelector(`[data-expandable='${expandable.id}']`);
   // update the inner icon + text based on its expanded state
   if (toggleHTMLElement) {
     toggleHTMLElement.innerHTML = `${toggleState.icon}${toggleState.label}`;
@@ -156,7 +156,7 @@ function updateExpandableToggleVisibility(ref: string, show: boolean) {
     if (expandable.ref === ref) {
       expandable.showToggle = show;
       // find toggle button
-      const toggleHTMLElement = document.querySelector(`[data-expandable="${expandable.id}"]`);
+      const toggleHTMLElement = document.querySelector(`[data-expandable='${expandable.id}']`);
       if (toggleHTMLElement) {
         // update the visibility
         (toggleHTMLElement as HTMLButtonElement).style.display = expandable.showToggle ? 'flex' : 'none';

--- a/packages/renderer/src/lib/markdown/component/micromark-spinner.spec.ts
+++ b/packages/renderer/src/lib/markdown/component/micromark-spinner.spec.ts
@@ -23,6 +23,6 @@ import { createSpinner } from './micromark-spinner';
 test('Expect createSoinner to return an icon with spinner id', async () => {
   const html = createSpinner('owner');
 
-  const htmlSanitized = html.replace('\n', '').replaceAll(/\s+/g, ' ');
-  expect(htmlSanitized).toContain("<i id='micromark-spinner-1'");
+  const htmlSanitized = html.replace('\n', '').replace(/\s+/g, ' ');
+  expect(htmlSanitized).toContain(`<i id='micromark-spinner-1'`);
 });

--- a/packages/renderer/src/lib/markdown/component/micromark-spinner.spec.ts
+++ b/packages/renderer/src/lib/markdown/component/micromark-spinner.spec.ts
@@ -1,0 +1,28 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+import { test, expect } from 'vitest';
+import { createSpinner } from './micromark-spinner';
+
+test('Expect createSoinner to return an icon with spinner id', async () => {
+  const html = createSpinner('owner');
+
+  const htmlSanitized = html.replace('\n', '').replaceAll(/\s+/g, ' ');
+  expect(htmlSanitized).toContain("<i id='micromark-spinner-1'");
+});

--- a/packages/renderer/src/lib/markdown/component/micromark-spinner.ts
+++ b/packages/renderer/src/lib/markdown/component/micromark-spinner.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 /**
- * It allows to create a spinner to be associated to another object ("owner") so the spinner state is changed based on its owner behavior
+ * It allows to create a spinner to be associated to another object ('owner') so the spinner state is changed based on its owner behavior
  * E.g if a button (owner) is clicked and the action start executing we can enabled the spinner
  */
 import { type MicromarkSpinner } from '../micromark-utils';
@@ -93,52 +93,52 @@ function toggleElementSpinner(ownerId: string, enabled: boolean) {
  */
 function generateSpinnerIcon(id: string) {
   return `
-        <i id=${id} class="flex justify-center items-center mr-2" style="display: none;">
-            <svg width="1em" height="1em" viewBox="0 0 100 100">
+        <i id='${id}' class='flex justify-center items-center mr-2' style='display: none;'>
+            <svg width='1em' height='1em' viewBox='0 0 100 100'>
             <defs>
-                <linearGradient id="grad1" x1="0%" y1="0%" x2="0%" y2="100%">
-                <stop offset="0%" style="stop-color:rgb(0,0,0);stop-opacity:1"></stop>
-                <stop offset="60%" style="stop-color:rgb(0,0,0);stop-opacity:1"></stop>
-                <stop offset="100%" style="stop-color:rgb(255,255,255);stop-opacity:1"></stop>
+                <linearGradient id='grad1' x1='0%' y1='0%' x2='0%' y2='100%'>
+                <stop offset='0%' style='stop-color:rgb(0,0,0);stop-opacity:1'></stop>
+                <stop offset='60%' style='stop-color:rgb(0,0,0);stop-opacity:1'></stop>
+                <stop offset='100%' style='stop-color:rgb(255,255,255);stop-opacity:1'></stop>
                 </linearGradient>
             </defs>
-            <mask id="myMask">
-                <rect x="0" y="0" width="100" height="100" fill="white"></rect>
-                <rect x="-25" y="-25" width="150" height="75" fill="black"></rect>
-                <g transform="translate(50,50)" style="width='1em'; height='1em'">
+            <mask id='myMask'>
+                <rect x='0' y='0' width='100' height='100' fill='white'></rect>
+                <rect x='-25' y='-25' width='150' height='75' fill='black'></rect>
+                <g transform='translate(50,50)' style='width='1em'; height='1em''>
                 <g>
-                    <rect x="-75" y="-75" width="150" height="75" fill="url(#grad1)"></rect>
-                    <rect x="-75" y="-70" width="100" height="75" fill="black"></rect>
+                    <rect x='-75' y='-75' width='150' height='75' fill='url(#grad1)'></rect>
+                    <rect x='-75' y='-70' width='100' height='75' fill='black'></rect>
                     <animateTransform
-                    attributeName="transform"
-                    type="rotate"
-                    dur="1.5s"
-                    from="0"
-                    to="180"
-                    values="0; 140;180; 140; 0"
-                    keyTimes="0; 0.25;0.5; 0.75;1"
-                    repeatCount="indefinite"></animateTransform>
+                    attributeName='transform'
+                    type='rotate'
+                    dur='1.5s'
+                    from='0'
+                    to='180'
+                    values='0; 140;180; 140; 0'
+                    keyTimes='0; 0.25;0.5; 0.75;1'
+                    repeatCount='indefinite'></animateTransform>
                 </g>
                 </g>
             </mask>
             <circle
-                cx="50"
-                cy="50"
-                r="46"
-                stroke="currentColor"
-                opacity="0.8"
-                stroke-width="10"
-                fill="transparent"
-                mask="url(#myMask)"></circle>
+                cx='50'
+                cy='50'
+                r='46'
+                stroke='currentColor'
+                opacity='0.8'
+                stroke-width='10'
+                fill='transparent'
+                mask='url(#myMask)'></circle>
             <animateTransform
-                attributeName="transform"
-                type="rotate"
-                dur="3s"
-                from="0"
-                to="360"
-                repeatCount="indefinite"
-                values="0;90;180;270;360;450;540;630;720;810;900;990;1080;1170;1260;1350;1440;1530;1620;1710;1800"
-                keyTimes="0; 0.02;0.08;0.18;0.32;0.375;0.42;0.455;0.48;0.495;0.5;0.52;0.58;0.68;0.82;0.875;0.92;0.955;0.98;0.995;1"
+                attributeName='transform'
+                type='rotate'
+                dur='3s'
+                from='0'
+                to='360'
+                repeatCount='indefinite'
+                values='0;90;180;270;360;450;540;630;720;810;900;990;1080;1170;1260;1350;1440;1530;1620;1710;1800'
+                keyTimes='0; 0.02;0.08;0.18;0.32;0.375;0.42;0.455;0.48;0.495;0.5;0.52;0.58;0.68;0.82;0.875;0.92;0.955;0.98;0.995;1'
             ></animateTransform>
             </svg>
         </i>`;

--- a/packages/renderer/src/lib/markdown/component/micromark-spinner.ts
+++ b/packages/renderer/src/lib/markdown/component/micromark-spinner.ts
@@ -1,0 +1,145 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+/**
+ * It allows to create a spinner to be associated to another object ("owner") so the spinner state is changed based on its owner behavior
+ * E.g if a button (owner) is clicked and the action start executing we can enabled the spinner
+ */
+import { type MicromarkSpinner } from '../micromark-utils';
+
+let spinnerCount = 0;
+const spinners = new Map<string, MicromarkSpinner>();
+
+/**
+ * it creates a new spinner id, associate the command to it and returns the spinner icon
+ * @param ownerId id of the element which the spinner belong to
+ * @returns spinner icon
+ */
+export function createSpinner(ownerId: string): string {
+  // create new id
+  const spinnerId = newSpinnerId();
+  // generate new spinner icon
+  const icon = generateSpinnerIcon(spinnerId);
+  // save spinner and associate it to the owner element
+  // e.g a button, when this will be clicked, by using its id we can retrieve the spinner and toggle its state
+  spinners.set(ownerId, {
+    id: spinnerId,
+    icon,
+    enabled: false,
+  });
+  return icon;
+}
+
+/**
+ * generate the new spinner id
+ * @returns spinner id
+ */
+function newSpinnerId() {
+  // update spinner number and create a new id
+  ++spinnerCount;
+  return `micromark-spinner-${spinnerCount}`;
+}
+
+/**
+ * make the spinner visible
+ * @param ownerId id of the element which the spinner belong to
+ */
+export function enableSpinner(ownerId: string) {
+  toggleElementSpinner(ownerId, true);
+}
+
+/**
+ * hide the spinner
+ * @param ownerId id of the element which the spinner belong to
+ */
+export function disableSpinner(ownerId: string) {
+  toggleElementSpinner(ownerId, false);
+}
+
+/**
+ * it changes the visibility of the spinner based on its owner id
+ * @param ownerId id of the element which the spinner belong to
+ * @param enabled if must be visible
+ */
+function toggleElementSpinner(ownerId: string, enabled: boolean) {
+  const spinner = spinners.get(ownerId);
+  if (spinner) {
+    const spinnerElement = document.getElementById(spinner.id);
+    if (spinnerElement) {
+      spinnerElement.style.display = enabled ? 'inline-block' : 'none';
+    }
+    spinner.enabled = !spinner.enabled;
+  }
+}
+
+/**
+ * generate a new spinner icon with a custom id
+ * @param id id of the new spinner
+ * @returns the spinner icon
+ */
+function generateSpinnerIcon(id: string) {
+  return `
+        <i id=${id} class="flex justify-center items-center mr-2" style="display: none;">
+            <svg width="1em" height="1em" viewBox="0 0 100 100">
+            <defs>
+                <linearGradient id="grad1" x1="0%" y1="0%" x2="0%" y2="100%">
+                <stop offset="0%" style="stop-color:rgb(0,0,0);stop-opacity:1"></stop>
+                <stop offset="60%" style="stop-color:rgb(0,0,0);stop-opacity:1"></stop>
+                <stop offset="100%" style="stop-color:rgb(255,255,255);stop-opacity:1"></stop>
+                </linearGradient>
+            </defs>
+            <mask id="myMask">
+                <rect x="0" y="0" width="100" height="100" fill="white"></rect>
+                <rect x="-25" y="-25" width="150" height="75" fill="black"></rect>
+                <g transform="translate(50,50)" style="width='1em'; height='1em'">
+                <g>
+                    <rect x="-75" y="-75" width="150" height="75" fill="url(#grad1)"></rect>
+                    <rect x="-75" y="-70" width="100" height="75" fill="black"></rect>
+                    <animateTransform
+                    attributeName="transform"
+                    type="rotate"
+                    dur="1.5s"
+                    from="0"
+                    to="180"
+                    values="0; 140;180; 140; 0"
+                    keyTimes="0; 0.25;0.5; 0.75;1"
+                    repeatCount="indefinite"></animateTransform>
+                </g>
+                </g>
+            </mask>
+            <circle
+                cx="50"
+                cy="50"
+                r="46"
+                stroke="currentColor"
+                opacity="0.8"
+                stroke-width="10"
+                fill="transparent"
+                mask="url(#myMask)"></circle>
+            <animateTransform
+                attributeName="transform"
+                type="rotate"
+                dur="3s"
+                from="0"
+                to="360"
+                repeatCount="indefinite"
+                values="0;90;180;270;360;450;540;630;720;810;900;990;1080;1170;1260;1350;1440;1530;1620;1710;1800"
+                keyTimes="0; 0.02;0.08;0.18;0.32;0.375;0.42;0.455;0.48;0.495;0.5;0.52;0.58;0.68;0.82;0.875;0.92;0.955;0.98;0.995;1"
+            ></animateTransform>
+            </svg>
+        </i>`;
+}

--- a/packages/renderer/src/lib/markdown/micromark-listener-handler.ts
+++ b/packages/renderer/src/lib/markdown/micromark-listener-handler.ts
@@ -1,0 +1,72 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { executeButtonCommand } from './component/micromark-button';
+import { executeExpandableToggle } from './component/micromark-expandable-section';
+
+export function createListener(
+  inProgressMarkdownCommandExecutionCallback: (
+    command: string,
+    state: 'starting' | 'failed' | 'successful',
+    value?: unknown,
+  ) => void,
+) {
+  return (e: any) => {
+    // Retrieve the command and expandable within the dataset
+    const command = e.target.dataset.command;
+    const expandable = e.target.dataset.expandable;
+
+    // if the user clicked on the toggle of an expandable section
+    if (expandable) {
+      executeExpandableToggle(expandable);
+      return;
+    }
+
+    // if the user clicked on a button (new way)
+    if (!command && e.target instanceof HTMLButtonElement) {
+      executeButtonCommand(e.target.id);
+      return;
+    }
+
+    // Only check if the command exists and the target is not disabled
+    if (command && !e.target.disabled) {
+      // If the target is an instance of a button element, we know that we are going to execute either
+      // a command or hyperlink
+      if (e.target instanceof HTMLButtonElement) {
+        // If the command exists and the button is not disabled, we execute the command
+        // we'll also be updating the inProgressMarkdownCommandExecutionCallback so we have
+        // real-time updates on the button
+        inProgressMarkdownCommandExecutionCallback(command, 'starting');
+        e.target.disabled = true;
+        e.target.firstChild.style.display = 'inline-block';
+        window
+          .executeCommand(command)
+          .then(value => inProgressMarkdownCommandExecutionCallback(command, 'successful', value))
+          .catch((reason: unknown) => inProgressMarkdownCommandExecutionCallback(command, 'failed', reason))
+          .finally(() => {
+            e.target.disabled = false;
+            e.target.firstChild.style.display = 'none';
+          });
+      } else if (e.target instanceof HTMLAnchorElement) {
+        // Execute the command since it's a simple "link" to it
+        // usually associated with a dialog / quickpick action.
+        window.executeCommand(command).catch((reason: unknown) => console.error(String(reason)));
+      }
+    }
+  };
+}

--- a/packages/renderer/src/lib/markdown/micromark-utils.ts
+++ b/packages/renderer/src/lib/markdown/micromark-utils.ts
@@ -1,0 +1,65 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+export interface ExpandableSectionToggle {
+  readonly label: string;
+}
+
+export interface ExpandedExpandableSectionToggle extends ExpandableSectionToggle {
+  readonly icon: string;
+}
+
+export interface CollapsedExpandableSectionToggle extends ExpandableSectionToggle {
+  readonly icon: string;
+}
+
+export interface ExpandableSectionContent {
+  html: string;
+  // it defines if the section containing the html must be visible
+  expanded: boolean;
+}
+
+export interface ExpandableSectionProps {
+  toggleExpandedState: ExpandableSectionToggle;
+  toggleCollapsedState: ExpandableSectionToggle;
+  content: ExpandableSectionContent;
+  // it defines if the toggle must be visible or not
+  showToggle: boolean;
+  /*
+     it lets you reference an element id that's not needed for rendering, but it can be used to identify a relationship 
+     (e.g a button with an expandable section that display command error)
+    */
+  ref?: string;
+}
+
+export interface ExpandableSection extends ExpandableSectionProps {
+  id: string;
+  toggleExpandedState: ExpandedExpandableSectionToggle;
+  toggleCollapsedState: CollapsedExpandableSectionToggle;
+}
+
+export interface Command {
+  id: string;
+  title: string;
+}
+
+export interface MicromarkSpinner {
+  id: string;
+  icon: string;
+  enabled: boolean;
+}

--- a/packages/renderer/src/lib/markdown/micromark-warnings-directive.ts
+++ b/packages/renderer/src/lib/markdown/micromark-warnings-directive.ts
@@ -86,15 +86,15 @@ export function warnings(d: any) {
     if (item.command) {
       // Make this a button
       this.tag(
-        '<button class="px-4 py-[6px] rounded-[4px] text-white text-[13px] whitespace-nowrap bg-purple-600 hover:bg-purple-500 no-underline" data-command="' +
+        '<button class="flex flex-row items-center justify-center px-4 py-[6px] rounded-[4px] text-white text-[13px] whitespace-nowrap bg-purple-600 hover:bg-purple-500 no-underline" data-command="' +
           this.encode(item.command.id) +
           '">',
       );
 
       // Add the "progress" spinner
       this.tag(
-        `<i class="flex justify-center items-center">
-          <svg width="2em" height="2em" viewBox="0 0 100 100">
+        `<i class="flex justify-center items-center mr-2" style="display: none;">
+          <svg width="1em" height="1em" viewBox="0 0 100 100">
             <defs>
               <linearGradient id="grad1" x1="0%" y1="0%" x2="0%" y2="100%">
                 <stop offset="0%" style="stop-color:rgb(0,0,0);stop-opacity:1"></stop>
@@ -105,7 +105,7 @@ export function warnings(d: any) {
             <mask id="myMask">
               <rect x="0" y="0" width="100" height="100" fill="white"></rect>
               <rect x="-25" y="-25" width="150" height="75" fill="black"></rect>
-              <g transform="translate(50,50)" style="width='2em'; height='2em'">
+              <g transform="translate(50,50)" style="width='1em'; height='1em'">
                 <g>
                   <rect x="-75" y="-75" width="150" height="75" fill="url(#grad1)"></rect>
                   <rect x="-75" y="-70" width="100" height="75" fill="black"></rect>

--- a/packages/renderer/src/lib/markdown/micromark-warnings-directive.ts
+++ b/packages/renderer/src/lib/markdown/micromark-warnings-directive.ts
@@ -16,20 +16,30 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { CompileContext } from 'micromark-util-types';
+import { createUIButton } from './component/micromark-button';
+import { createExpandableSection } from './component/micromark-expandable-section';
+import type { ExpandableSectionProps } from './micromark-utils';
+
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 // @ts-nocheck
 // this is the opposite of what happens in the micromark encode function
-const characterReferences = { '&quot;': '"', '&amp;': '&', '&lt;': '<', '&gt;': '>' };
+const characterReferences = new Map([
+  ['&quot;', '"'],
+  ['&amp;', '&'],
+  ['&lt;', '<'],
+  ['&gt;', '>'],
+]);
 
-export function decode(value) {
+export function decode(value: string) {
   return value.replace(/(&quot;|&amp;|&gt;|&lt;)/g, replace);
 
   /**
    * @param {string} value
    * @returns {string}
    */
-  function replace(value) {
-    return characterReferences[value];
+  function replace(value: string) {
+    return characterReferences.get(value) || '';
   }
 }
 
@@ -54,10 +64,9 @@ export function decode(value) {
   }
  */
 /**
- * @this {import('micromark-util-types').CompileContext}
  * @type {import('micromark-extension-directive').Handle}
  */
-export function warnings(d: any) {
+export function warnings(this: CompileContext, d: any) {
   // Make sure it's not part of a text directive
   if (d.type !== 'textDirective') {
     return false;
@@ -69,7 +78,7 @@ export function warnings(d: any) {
   const items = JSON.parse(decode(d.label) || '');
   for (const item of items) {
     // start the div representing one row
-    this.tag('<div class="flex flex-row space-x-3 bg-charcoal-600 p-4 rounded-md items-center">');
+    this.tag('<div class="flex flex-row space-x-3 bg-charcoal-600 p-4 rounded-md items-start">');
     // add icon representing the warning status
     this.tag('<div class="mr-2 flex justify-center">');
     this.tag(item.state === 'successful' ? '✅' : '❌');
@@ -81,94 +90,61 @@ export function warnings(d: any) {
       this.raw(item.description);
       this.tag('</div>');
     }
-    // add the command
-    this.tag('<div class="w-[180px] pr-3 flex justify-center">');
-    if (item.command) {
-      // Make this a button
-      this.tag(
-        '<button class="flex flex-row items-center justify-center px-4 py-[6px] rounded-[4px] text-white text-[13px] whitespace-nowrap bg-purple-600 hover:bg-purple-500 no-underline" data-command="' +
-          this.encode(item.command.id) +
-          '">',
-      );
 
-      // Add the "progress" spinner
-      this.tag(
-        `<i class="flex justify-center items-center mr-2" style="display: none;">
-          <svg width="1em" height="1em" viewBox="0 0 100 100">
-            <defs>
-              <linearGradient id="grad1" x1="0%" y1="0%" x2="0%" y2="100%">
-                <stop offset="0%" style="stop-color:rgb(0,0,0);stop-opacity:1"></stop>
-                <stop offset="60%" style="stop-color:rgb(0,0,0);stop-opacity:1"></stop>
-                <stop offset="100%" style="stop-color:rgb(255,255,255);stop-opacity:1"></stop>
-              </linearGradient>
-            </defs>
-            <mask id="myMask">
-              <rect x="0" y="0" width="100" height="100" fill="white"></rect>
-              <rect x="-25" y="-25" width="150" height="75" fill="black"></rect>
-              <g transform="translate(50,50)" style="width='1em'; height='1em'">
-                <g>
-                  <rect x="-75" y="-75" width="150" height="75" fill="url(#grad1)"></rect>
-                  <rect x="-75" y="-70" width="100" height="75" fill="black"></rect>
-                  <animateTransform
-                    attributeName="transform"
-                    type="rotate"
-                    dur="1.5s"
-                    from="0"
-                    to="180"
-                    values="0; 140;180; 140; 0"
-                    keyTimes="0; 0.25;0.5; 0.75;1"
-                    repeatCount="indefinite"></animateTransform>
-                </g>
-              </g>
-            </mask>
-            <circle
-              cx="50"
-              cy="50"
-              r="46"
-              stroke="currentColor"
-              opacity="0.8"
-              stroke-width="10"
-              fill="transparent"
-              mask="url(#myMask)"></circle>
-            <animateTransform
-              attributeName="transform"
-              type="rotate"
-              dur="3s"
-              from="0"
-              to="360"
-              repeatCount="indefinite"
-              values="0;90;180;270;360;450;540;630;720;810;900;990;1080;1170;1260;1350;1440;1530;1620;1710;1800"
-              keyTimes="0; 0.02;0.08;0.18;0.32;0.375;0.42;0.455;0.48;0.495;0.5;0.52;0.58;0.68;0.82;0.875;0.92;0.955;0.98;0.995;1"
-            ></animateTransform>
-          </svg>
-        </i>`,
-      );
-
-      // Add any labels and close the button
-      this.raw(item.command.title);
-      this.tag('</button>');
-    }
-    this.tag('</div>');
-    // add the description to be shown above the links
-    this.tag('<div class="flex flex-col w-[250px] text-sm">');
+    // create the documentation content (text + links), if any
+    let docContent = '';
     if (item.docDescription) {
-      this.tag('<span>');
-      this.raw(item.docDescription);
-      this.tag('</span>');
+      docContent += `
+        <span>
+        ${item.docDescription}
+        </span>
+      `;
     }
     // add links
     if (item.docLinks) {
       for (const link of item.docLinks) {
-        this.tag('<a ');
-        this.tag(' href="' + this.encode(link.url) + '"');
-        this.tag(' title="' + this.encode(link.title) + '"');
-        this.tag('>');
-        this.raw(link.title);
-        this.tag('</a>');
+        docContent += `
+          <a href="${this.encode(link.url)}" title="${this.encode(link.title)}">
+          ${link.title}
+          </a>
+        `;
       }
     }
-    // close links + description div
+
+    // add the right column containing the command and the description + links
+    this.tag('<div class="flex flex-col space-y-2 w-[250px] pr-3 flex">');
+    if (item.command) {
+      // Make this a button
+      createUIButton.bind(this)({
+        id: item.command.id,
+        title: item.command.title,
+      });
+
+      // if there is additional content to show, we create an expandable section
+      if (docContent !== '') {
+        const expandable: ExpandableSectionProps = {
+          showToggle: true,
+          toggleExpandedState: {
+            label: 'Less information',
+          },
+          toggleCollapsedState: {
+            label: 'More information',
+          },
+          content: {
+            html: docContent,
+            expanded: false,
+          },
+        };
+        createExpandableSection.bind(this)(expandable);
+      }
+    } else if (docContent !== '') {
+      // there is no command, so the doc content has full visibility
+      this.tag(docContent);
+    }
+
+    // close right column
     this.tag('</div>');
+
     // close whole row div
     this.tag('</div>');
   }

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -21,7 +21,7 @@ const tailwindColors = require('tailwindcss/colors')
 module.exports = {
   content: [
     'packages/renderer/index.html',
-    'packages/renderer/src/**/*.{svelte,ts,css}',    
+    'packages/renderer/src/**/*.{svelte,ts,css}',
   ],
   theme: {
     extend: {

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -21,7 +21,7 @@ const tailwindColors = require('tailwindcss/colors')
 module.exports = {
   content: [
     'packages/renderer/index.html',
-    'packages/renderer/src/**/*.{svelte,css}',
+    'packages/renderer/src/**/*.{svelte,ts,css}',    
   ],
   theme: {
     extend: {


### PR DESCRIPTION
### What does this PR do?

This PR adds the action/button to install wsl in modern Windows OS and show it during the onboarding if wsl2 is not installed.

The button has like two modes. The first is the normal one (purple with the spinner on the left when executing) and the "error" mode if the command fails its execution.
As there is no much space in the onboarding view if the command fail somehow, the button gets red and an expandable section is displayed that allow to see the error logs.

### Screenshot/screencast of this PR

![action_onboarding_error](https://github.com/containers/podman-desktop/assets/49404737/2ecbb2fd-532a-4987-8184-4064c62c4fe3)

### What issues does this PR fix or reference?

it is part of #4193 

### How to test this PR?

1. uninstall wsl from your machine and run the onboarding
2. install it by using the new button
