### PR TITLE
fix: tooltip z order

### DIFF
--- a/packages/renderer/src/lib/ui/Tooltip.svelte
+++ b/packages/renderer/src/lib/ui/Tooltip.svelte
@@ -41,12 +41,12 @@ export let bottom = false;
 export let left = false;
 </script>
 
-<div class="relative inline-block z-[10]">
+<div class="relative inline-block">
   <span class="group tooltip-slot">
     <slot />
   </span>
   <div
-    class="whitespace-nowrap absolute tooltip opacity-0 inline-block transition-opacity duration-150 ease-in-out pointer-events-none"
+    class="whitespace-nowrap absolute tooltip opacity-0 inline-block transition-opacity duration-150 ease-in-out pointer-events-none z-[10]"
     class:left="{left}"
     class:right="{right}"
     class:bottom="{bottom}"


### PR DESCRIPTION
### What does this PR do?

I have no idea how we didn't notice this before now, but since we fixed some other z-ordering issues in May, the tooltip has put a higher z-order not just on the tooltip itself but _also on the component that is getting the tooltip_.

This means that if you have two objects that both have tooltips close enough to each other, depending on the positioning of the tooltip one of the objects will always be over top of the other's tooltip. In my case I'm adding tooltips to two Donuts and the tooltip remains behind the following Donut.

The fix just moves the z-order to only be on the tooltip div.

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Using `yarn watch`, change the NavItem.svelte tooltip location to `bottom`. Before this change the nav tooltips will be partially behind the next nav item, afterward they'll be on top.