### PR TITLE
chore: donut design and fixes

### DIFF
--- a/packages/renderer/src/lib/donut/Donut.svelte
+++ b/packages/renderer/src/lib/donut/Donut.svelte
@@ -1,50 +1,43 @@
 <script lang="ts">
+import Tooltip from '../ui/Tooltip.svelte';
+
 export let percent = 0;
-
 export let size = 64;
-
 export let title = '';
-
 export let value: unknown;
 
-function polarToCartesian(centerX: number, centerY: number, radius: number, angleInDegrees: number) {
+// describes an arc with the given radius, centered at an x,y position matching the radius
+function describeArc(radius: number, endAngle: number) {
+  const angleInDegrees = endAngle >= 360 ? 359.9 : endAngle;
   const angleInRadians = ((angleInDegrees - 90) * Math.PI) / 180.0;
 
-  return {
-    x: centerX + radius * Math.cos(angleInRadians),
-    y: centerY + radius * Math.sin(angleInRadians),
+  const start = {
+    x: radius + radius * Math.cos(angleInRadians),
+    y: radius + radius * Math.sin(angleInRadians),
   };
+
+  const largeArcFlag = endAngle <= 180 ? '0' : '1';
+
+  return ['M', start.x, start.y, 'A', radius, radius, 0, largeArcFlag, 0, radius, 0].join(' ');
 }
 
-function describeArc(x: number, y: number, radius: number, startAngle: number, endAngle: number) {
-  const start = polarToCartesian(x, y, radius, endAngle);
-  const end = polarToCartesian(x, y, radius, startAngle);
+$: stroke = percent < 0 ? '' : percent < 50 ? 'stroke-green-500' : percent < 75 ? 'stroke-amber-500' : 'stroke-red-500';
 
-  const largeArcFlag = endAngle - startAngle <= 180 ? '0' : '1';
-
-  return ['M', start.x, start.y, 'A', radius, radius, 0, largeArcFlag, 0, end.x, end.y].join(' ');
-}
-
-function getStoke() {
-  if (percent < 50) {
-    return 'green';
-  } else if (percent < 75) {
-    return 'orange';
-  }
-  return 'red';
-}
+$: tooltip = percent.toFixed(0) + '% ' + title + ' usage';
 </script>
 
-<svg viewBox="0 0 {size + 10} {size + 20}" height="{size}" width="{size}">
-  <circle fill="none" stroke="rgb(129, 129, 129)" stroke-width="5" r="{size / 2}" cx="{size / 2}" cy="{size / 2 + 5}"
-  ></circle>
-  <path
-    id="arc1"
-    fill="none"
-    stroke="{getStoke()}"
-    stroke-width="5"
-    d="{describeArc(size / 2, size / 2 + 5, size / 2, 0, (percent * 360) / 100)}"></path>
-  <text x="{size / 2}" y="37%" text-anchor="middle" class="text-xs stroke-gray-800">{title}</text>
-  <text x="{size / 2}" y="51%" dominant-baseline="central" text-anchor="middle" class="text-sm stroke-gray-500"
-    >{value}</text>
-</svg>
+<Tooltip tip="{tooltip}" right>
+  <svg viewBox="-4 -4 {size + 8} {size + 8}" height="{size}" width="{size}">
+    <circle fill="none" class="stroke-charcoal-300" stroke-width="1" r="{size / 2}" cx="{size / 2}" cy="{size / 2}"
+    ></circle>
+    <path fill="none" class="{stroke}" stroke-width="3.5" d="{describeArc(size / 2, (percent * 360) / 100)}"></path>
+    <text x="{size / 2}" y="38%" text-anchor="middle" font-size="{size / 5.5}" class="fill-gray-800">{title}</text>
+    <text
+      x="{size / 2}"
+      y="52%"
+      text-anchor="middle"
+      font-size="{size / 4.5}"
+      dominant-baseline="central"
+      class="fill-gray-400">{value}</text>
+  </svg>
+</Tooltip>


### PR DESCRIPTION
### What does this PR do?

Updates the Donut component to match the design better, and fixes a few minor bugs:

- Grey circle and arc are thinner (closer to the design).
- Switched to using colors from the palette.
- Since x,y=radius and starting angle=0 always I simplified the function a bit.
- Made the viewbox square, reduced padding, and made font sizes relative to reduce scaling issues.
- Added end limits (before if the client incorrectly requested 125% the arc would fail, now it looks like 100%).
- Colors weren't changing if the live value crossed thresholds (e.g. green to red), made it dynamic.
- Added tooltip.

There are still several issues compared to the design, e.g.:
- The titles doesn't match.
- Unit font should be smaller.
- Values should be rounded more (e.g. should be 99Gb not 99.25Gb).

Fixing the first is likely better done in the calling code, e.g.: changing the property names or some custom code to override 'Disk space' with 'DISK'. Unless we want the Donut to be really clever the second likely should be fixed in the caller too. Either way, it felt like there are more than enough changes in one PR and better to stop here for now.

### Screenshot/screencast of this PR

Design:

![251246170-37fe06e9-47ad-45de-b5cf-691536196176](https://github.com/containers/podman-desktop/assets/19958075/ed22c2c4-de9a-4018-98c1-78f4f22e2c13)

Before:

<img width="256" alt="Screenshot 2023-10-04 at 5 11 40 PM" src="https://github.com/containers/podman-desktop/assets/19958075/c697892f-d2bd-48e5-a722-497a96d4e413">

After:

<img width="256" alt="Screenshot 2023-10-04 at 5 11 10 PM" src="https://github.com/containers/podman-desktop/assets/19958075/c42fde50-5f2d-41ed-9154-cd5822688f0c">

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Go to Settings > Resources and look at a running Podman Machine.