### PR TITLE
feat: create Docker context for Podman machines

### DIFF
--- a/extensions/podman/src/docker-cli.spec.ts
+++ b/extensions/podman/src/docker-cli.spec.ts
@@ -1,0 +1,126 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { expect, test, vi } from 'vitest';
+import type { RunResult } from '@podman-desktop/api';
+import * as extensionApi from '@podman-desktop/api';
+import { getDockerCli } from './docker-cli';
+
+vi.mock('@podman-desktop/api', async () => {
+  return {
+    process: {
+      exec: vi.fn(),
+    },
+  };
+});
+
+test('no client if no Docker installed', async () => {
+  const spyExecPromise = vi.spyOn(extensionApi.process, 'exec');
+  spyExecPromise.mockImplementation(() => {
+    return Promise.reject(new Error('No Docker client'));
+  });
+  const cli = await getDockerCli();
+  expect(cli).toBeUndefined();
+});
+
+test('no client if no Docker version returned', async () => {
+  const spyExecPromise = vi.spyOn(extensionApi.process, 'exec');
+  spyExecPromise.mockImplementation(() => {
+    return Promise.resolve({ stdout: '' } as RunResult);
+  });
+  const cli = await getDockerCli();
+  expect(cli).toBeUndefined();
+});
+
+test('client if Docker version returned', async () => {
+  const spyExecPromise = vi.spyOn(extensionApi.process, 'exec');
+  spyExecPromise.mockImplementation(() => {
+    return Promise.resolve({ stdout: 'Docker version 24.0.6, build ed223bc' } as RunResult);
+  });
+  const cli = await getDockerCli();
+  expect(cli).toBeDefined();
+});
+
+test('client does not support context', async () => {
+  const spyExecPromise = vi.spyOn(extensionApi.process, 'exec');
+  spyExecPromise.mockImplementation(() => {
+    return Promise.resolve({ stdout: 'Docker version 24.0.6, build ed223bc' } as RunResult);
+  });
+  const cli = await getDockerCli();
+  expect(cli).toBeDefined();
+  expect(cli.isContextSupported()).toBeTruthy();
+});
+
+test('create context if no context', async () => {
+  const spyExecPromise = vi.spyOn(extensionApi.process, 'exec');
+  spyExecPromise.mockImplementation((command: string, args?: string[]) => {
+    if (args?.length === 1 && args[0] === '-v') {
+      return Promise.resolve({ stdout: 'Docker version 24.0.6, build ed223bc' } as RunResult);
+    } else if (args?.length > 1 && args[0] === 'context' && args[1] === 'list') {
+      return Promise.resolve({ stdout: '[]' } as RunResult);
+    } else if (args?.length > 1 && args[0] === 'context' && args[1] === 'create') {
+      return Promise.resolve({ stdout: '' } as RunResult);
+    }
+    return Promise.reject(new Error('Unknown command'));
+  });
+  const cli = await getDockerCli();
+  expect(cli).toBeDefined();
+  expect(cli.isContextSupported()).toBeTruthy();
+  await cli.registerMachine('mymachine', '/var/run/podman.sock', false);
+  expect(spyExecPromise).toHaveBeenNthCalledWith(1, 'docker', ['-v']);
+  expect(spyExecPromise).toHaveBeenNthCalledWith(2, 'docker', ['context', 'list', '--format', 'json']);
+  expect(spyExecPromise).toHaveBeenNthCalledWith(3, 'docker', [
+    'context',
+    'create',
+    'mymachine',
+    '--docker',
+    expect.anything(),
+    '--description',
+    'Podman machine mymachine',
+  ]);
+});
+
+test('update context if context', async () => {
+  const spyExecPromise = vi.spyOn(extensionApi.process, 'exec');
+  spyExecPromise.mockImplementation((command: string, args?: string[]) => {
+    if (args?.length === 1 && args[0] === '-v') {
+      return Promise.resolve({ stdout: 'Docker version 24.0.6, build ed223bc' } as RunResult);
+    } else if (args?.length > 1 && args[0] === 'context' && args[1] === 'list') {
+      return Promise.resolve({ stdout: '[{"Name": "mymachine"}]' } as RunResult);
+    } else if (args?.length > 1 && args[0] === 'context' && args[1] === 'update') {
+      return Promise.resolve({ stdout: '' } as RunResult);
+    }
+    return Promise.reject(new Error('Unknown command'));
+  });
+  const cli = await getDockerCli();
+  expect(cli).toBeDefined();
+  expect(cli.isContextSupported()).toBeTruthy();
+  await cli.registerMachine('mymachine', '/var/run/podman.sock', false);
+  expect(spyExecPromise).toHaveBeenNthCalledWith(1, 'docker', ['-v']);
+  expect(spyExecPromise).toHaveBeenNthCalledWith(2, 'docker', ['context', 'list', '--format', 'json']);
+  expect(spyExecPromise).toHaveBeenNthCalledWith(3, 'docker', [
+    'context',
+    'update',
+    'mymachine',
+    '--docker',
+    expect.anything(),
+    '--description',
+    'Podman machine mymachine',
+  ]);
+});

--- a/extensions/podman/src/docker-cli.ts
+++ b/extensions/podman/src/docker-cli.ts
@@ -1,0 +1,114 @@
+/**********************************************************************
+ * Copyright (C) 2022 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import * as extensionApi from '@podman-desktop/api';
+import { compareVersions } from 'compare-versions';
+import { isWindows } from './util';
+
+const DOCKER_VERSION_PATTERN = /^Docker version (\d+\.\d+\.\d+), build (\w+)$/;
+
+const DOCKER_MINIMUM_VERSION_FOR_CONTEXT = '19.03.0';
+
+export async function getDockerCli(): Promise<DockerCli | undefined> {
+  try {
+    const result = await extensionApi.process.exec('docker', ['-v']);
+    const match = DOCKER_VERSION_PATTERN.exec(result.stdout);
+    if (match) {
+      return new DockerCli(match[1]);
+    }
+  } catch (err) {
+    return undefined;
+  }
+  return undefined;
+}
+
+export class DockerCli {
+  constructor(private version: string) {}
+
+  public isContextSupported(): boolean {
+    return compareVersions(this.version, DOCKER_MINIMUM_VERSION_FOR_CONTEXT) >= 0;
+  }
+
+  private async checkPodmanContext(name: string): Promise<boolean> {
+    const result = await extensionApi.process.exec('docker', ['context', 'list', '--format', 'json']);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const contexts = JSON.parse(result.stdout) as any[];
+    return contexts.find(c => c.Name === name);
+  }
+
+  public async registerMachine(name: string, socketPath: string, useAsDefault: boolean) {
+    const exists = await this.checkPodmanContext(name);
+    if (isWindows()) {
+      socketPath = `npipe://${socketPath.replace(/\\/g, '/')}`;
+    } else {
+      socketPath = `unix:/${socketPath}`;
+    }
+    if (exists) {
+      await extensionApi.process.exec('docker', [
+        'context',
+        'update',
+        name,
+        '--docker',
+        `host=${socketPath}`,
+        '--description',
+        `Podman machine ${name}`,
+      ]);
+    } else {
+      await extensionApi.process.exec('docker', [
+        'context',
+        'create',
+        name,
+        '--docker',
+        `host=${socketPath}`,
+        '--description',
+        `Podman machine ${name}`,
+      ]);
+    }
+    if (useAsDefault) {
+      await this.setAsDefaultContext(name);
+    }
+  }
+
+  public async unregisterMachine(name: string) {
+    await extensionApi.process.exec('docker', ['context', 'rm', '-f', name]);
+  }
+
+  public async setAsDefaultContext(name: string) {
+    await extensionApi.process.exec('docker', ['context', 'use', name]);
+  }
+
+  private extractSocketPath(endpoint: string): string {
+    endpoint = endpoint.substring(endpoint.lastIndexOf(':') + 1);
+    if (isWindows()) {
+      endpoint = endpoint.substring(2).replace(/\//g, '\\');
+    } else {
+      endpoint = endpoint.substring(1);
+    }
+    return endpoint;
+  }
+
+  public async getDefaultSocketPath(): Promise<string | undefined> {
+    const result = await extensionApi.process.exec('docker', ['context', 'list', '--format', 'json']);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const contexts = JSON.parse(result.stdout) as any[];
+    const defaultContext = contexts.find(c => c.Current);
+    if (defaultContext) {
+      return this.extractSocketPath(defaultContext.DockerEndpoint);
+    }
+    return undefined;
+  }
+}

--- a/extensions/podman/src/extension.spec.ts
+++ b/extensions/podman/src/extension.spec.ts
@@ -293,7 +293,7 @@ test('if a machine is successfully started it changes its state to started', asy
         resolve({} as extensionApi.RunResult);
       }),
   );
-  await extension.startMachine(provider, machineInfo);
+  await extension.startMachine(provider, machineInfo, undefined);
 
   expect(spyExecPromise).toBeCalledWith(getPodmanCli(), ['machine', 'start', 'name'], {
     logger: new LoggerDelegator(),
@@ -311,7 +311,7 @@ test('if a machine failed to start with a generic error, this is thrown', async 
       }),
   );
 
-  await expect(extension.startMachine(provider, machineInfo)).rejects.toThrow('generic error');
+  await expect(extension.startMachine(provider, machineInfo, undefined)).rejects.toThrow('generic error');
   expect(console.error).toBeCalled();
 });
 
@@ -324,7 +324,7 @@ test('if a machine failed to start with a wsl distro not found error, the user i
       }),
   );
 
-  await expect(extension.startMachine(provider, machineInfo)).rejects.toThrow(
+  await expect(extension.startMachine(provider, machineInfo, undefined)).rejects.toThrow(
     'wsl bootstrap script failed: exit status 0xffffffff',
   );
   expect(extensionApi.window.showInformationMessage).toBeCalledWith(
@@ -340,7 +340,7 @@ test('if a machine failed to start with a wsl distro not found error but the ski
   spyExecPromise.mockImplementation(() => {
     return Promise.reject(new Error('wsl bootstrap script failed: exit status 0xffffffff'));
   });
-  await expect(extension.startMachine(provider, machineInfo, undefined, undefined, true)).rejects.toThrow(
+  await expect(extension.startMachine(provider, machineInfo, undefined, undefined, undefined, true)).rejects.toThrow(
     'wsl bootstrap script failed: exit status 0xffffffff',
   );
   expect(extensionApi.window.showInformationMessage).not.toHaveBeenCalled();


### PR DESCRIPTION
Fixes #2630

### What does this PR do?

Create a Docker context if Docker is installed and supports context when creating a Podman machine.
If the default Docker context is not reachable, then this context become the default one.

### Screenshot/screencast of this PR

![docker-context](https://github.com/containers/podman-desktop/assets/695993/4325e443-55eb-4e94-b981-3cf35a97f92c)

### What issues does this PR fix or reference?

#2630 

### How to test this PR?

1. Create a Podman machine
2. Check the docker contexts: `docker context list`