### PR TITLE
chore: use donuts for container stats

### DIFF
--- a/packages/renderer/src/lib/container/ContainerStatistics.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerStatistics.spec.ts
@@ -1,0 +1,174 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+import { test, expect, vi, beforeAll } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+
+import ContainerStatistics from './ContainerStatistics.svelte';
+import type { ContainerStatsInfo } from '../../../../main/src/plugin/api/container-stats-info';
+import { ContainerGroupInfoTypeUI, type ContainerInfoUI } from './ContainerInfoUI';
+
+const myContainer: ContainerInfoUI = {
+  id: 'foobar',
+  shortId: 'foobar',
+  name: 'foobar',
+  image: 'foobar',
+  shortImage: 'foobar',
+  engineId: 'foobar',
+  engineName: 'foobar',
+  engineType: 'podman',
+  state: 'RUNNING',
+  uptime: 'foobar',
+  startedAt: 'foobar',
+  ports: [],
+  portsAsString: 'foobar',
+  displayPort: 'foobar',
+  command: 'foobar',
+  hasPublicPort: false,
+  groupInfo: {
+    name: 'foobar',
+    type: ContainerGroupInfoTypeUI.STANDALONE,
+  },
+  selected: false,
+  created: 0,
+  labels: {},
+};
+
+const stats: ContainerStatsInfo = {
+  memory_stats: {
+    usage: 256,
+    limit: 1024,
+    stats: {
+      total_pgmajfault: 0,
+      cache: 0,
+      mapped_file: 0,
+      total_inactive_file: 0,
+      pgpgout: 414,
+      rss: 6537216,
+      total_mapped_file: 0,
+      writeback: 0,
+      unevictable: 0,
+      pgpgin: 477,
+      total_unevictable: 0,
+      pgmajfault: 0,
+      total_rss: 6537216,
+      total_rss_huge: 6291456,
+      total_writeback: 0,
+      total_inactive_anon: 0,
+      rss_huge: 6291456,
+      hierarchical_memory_limit: 67108864,
+      total_pgfault: 964,
+      total_active_file: 0,
+      active_anon: 6537216,
+      total_active_anon: 6537216,
+      total_pgpgout: 414,
+      total_cache: 0,
+      inactive_anon: 0,
+      active_file: 0,
+      pgfault: 964,
+      inactive_file: 0,
+      total_pgpgin: 477,
+    },
+    max_usage: 1024,
+    failcnt: 0,
+  },
+  precpu_stats: {
+    cpu_usage: {
+      total_usage: 50,
+      percpu_usage: [50],
+      usage_in_usermode: 4,
+      usage_in_kernelmode: 4,
+    },
+    system_cpu_usage: 50,
+    online_cpus: 4,
+    throttling_data: {
+      periods: 0,
+      throttled_periods: 0,
+      throttled_time: 0,
+    },
+  },
+  cpu_stats: {
+    cpu_usage: {
+      total_usage: 60,
+      percpu_usage: [60],
+      usage_in_usermode: 4,
+      usage_in_kernelmode: 4,
+    },
+    system_cpu_usage: 95,
+    online_cpus: 4,
+    throttling_data: {
+      periods: 0,
+      throttled_periods: 0,
+      throttled_time: 0,
+    },
+  },
+  engineId: 'podman',
+  engineName: 'podman',
+  read: '',
+  preread: '',
+  num_procs: 1,
+  networks: {},
+};
+
+beforeAll(() => {
+  const containerStatsMock = vi.fn();
+  containerStatsMock.mockImplementation((engineId, id, stats) => {
+    return stats;
+  });
+  (window as any).getContainerStats = containerStatsMock;
+  (window as any).stopContainerStats = vi.fn();
+});
+
+test('Expect memory donut', async () => {
+  // render the component
+  const result = render(ContainerStatistics, { container: myContainer });
+
+  // update twice (needs two samples) and wait for update
+  result.component.updateStatistics(stats);
+  result.component.updateStatistics(stats);
+  await new Promise(resolve => setTimeout(resolve, 500));
+
+  const memValue = screen.getByText('256 B');
+  expect(memValue).toBeInTheDocument();
+
+  const memTooltip = screen.getByText('25% MEM usage');
+  expect(memTooltip).toBeInTheDocument();
+
+  const memArc = screen.getAllByTestId('arc')[1];
+  expect(memArc).toHaveClass('stroke-green-500');
+});
+
+test('Expect CPU donut', async () => {
+  // render the component
+  const result = render(ContainerStatistics, { container: myContainer });
+
+  // update twice (needs two samples) and wait for update
+  result.component.updateStatistics(stats);
+  result.component.updateStatistics(stats);
+  await new Promise(resolve => setTimeout(resolve, 500));
+
+  const cpuValue = screen.getByText('88.9%');
+  expect(cpuValue).toBeInTheDocument();
+
+  const cpuTooltip = screen.getByText('89% vCPUs usage');
+  expect(cpuTooltip).toBeInTheDocument();
+
+  const cpuArc = screen.getAllByTestId('arc')[0];
+  expect(cpuArc).toHaveClass('stroke-red-500');
+});

--- a/packages/renderer/src/lib/container/ContainerStatistics.svelte
+++ b/packages/renderer/src/lib/container/ContainerStatistics.svelte
@@ -23,7 +23,7 @@ let firstIteration = true;
 let cpuUsage: string;
 let memoryUsage: string;
 
-async function updateStatistics(containerStats: ContainerStatsInfo) {
+export async function updateStatistics(containerStats: ContainerStatsInfo) {
   // we need enough data to compute the CPU usage
   if (firstIteration) {
     firstIteration = false;

--- a/packages/renderer/src/lib/container/ContainerStatistics.svelte
+++ b/packages/renderer/src/lib/container/ContainerStatistics.svelte
@@ -3,35 +3,15 @@ import { onMount, onDestroy } from 'svelte';
 import type { ContainerStatsInfo } from '../../../../main/src/plugin/api/container-stats-info';
 import type { ContainerInfoUI } from './ContainerInfoUI';
 import { ContainerUtils } from './container-utils';
+import Donut from '../donut/Donut.svelte';
 
 export let container: ContainerInfoUI;
 
-const WARNING_PERCENTAGE = 70;
-const DANGER_PERCENTAGE = 90;
-
-const GREEN_COLOR = '#16a34a';
-const ORANGE_COLOR = '#F97316';
-const RED_COLOR = '#cb4d3e';
-
 const containerUtils = new ContainerUtils();
-
-$: cpuColor =
-  cpuUsagePercentage < WARNING_PERCENTAGE
-    ? GREEN_COLOR
-    : cpuUsagePercentage < DANGER_PERCENTAGE
-    ? ORANGE_COLOR
-    : RED_COLOR;
-$: memoryColor =
-  memoryUsagePercentage < WARNING_PERCENTAGE
-    ? GREEN_COLOR
-    : memoryUsagePercentage < DANGER_PERCENTAGE
-    ? ORANGE_COLOR
-    : RED_COLOR;
 
 // percentage
 let cpuUsagePercentage = -1;
 let memoryUsagePercentage = -1;
-let usedMemory;
 
 // id to cancel the streaming
 let fetchStatsId: number;
@@ -40,10 +20,8 @@ let fetchStatsId: number;
 let firstIteration = true;
 
 // title to use on
-let cpuUsagePercentageTitle: string;
-let cpuUsageTitle: string;
-let memoryUsagePercentageTitle: string;
-let memoryUsageTitle: string;
+let cpuUsage: string;
+let memoryUsage: string;
 
 async function updateStatistics(containerStats: ContainerStatsInfo) {
   // we need enough data to compute the CPU usage
@@ -52,12 +30,10 @@ async function updateStatistics(containerStats: ContainerStatsInfo) {
     return;
   }
 
-  //
-  usedMemory = containerStats.memory_stats.usage - (containerStats.memory_stats.stats?.cache || 0);
+  const usedMemory = containerStats.memory_stats.usage - (containerStats.memory_stats.stats?.cache || 0);
   const availableMemory = containerStats.memory_stats.limit;
   memoryUsagePercentage = (usedMemory / availableMemory) * 100.0;
-  memoryUsagePercentageTitle = containerUtils.getMemoryPercentageUsageTitle(memoryUsagePercentage, usedMemory);
-  memoryUsageTitle = containerUtils.getMemoryUsageTitle(usedMemory);
+  memoryUsage = containerUtils.getMemoryUsageTitle(usedMemory);
 
   const cpuDelta = containerStats.cpu_stats.cpu_usage.total_usage - containerStats.precpu_stats.cpu_usage.total_usage;
   const systemCpuDelta =
@@ -65,8 +41,7 @@ async function updateStatistics(containerStats: ContainerStatsInfo) {
   const numberCpus =
     containerStats.cpu_stats.online_cpus || containerStats.cpu_stats.cpu_usage?.percpu_usage?.length || 1.0;
   cpuUsagePercentage = (cpuDelta / systemCpuDelta) * numberCpus * 100.0;
-  cpuUsagePercentageTitle = `${cpuUsagePercentage.toFixed(2)}% of ${numberCpus}CPUs`;
-  cpuUsageTitle = `${cpuUsagePercentage.toFixed(2)}%`;
+  cpuUsage = cpuUsagePercentage.toFixed(1) + '%';
 }
 
 onMount(async () => {
@@ -88,44 +63,8 @@ onDestroy(async () => {
 </script>
 
 {#if container.state === 'RUNNING'}
-  <div class="mt-2 px-1 mx-2 border border-zinc-700 w-[240px] flex flex-row">
-    <svg class="mr-1 text-zinc-400" width="70px" height="40px">
-      <g class="bars">
-        <text text-anchor="end" x="63" y="16" font-size="12px" fill="currentColor">MEMORY </text>
-        <text text-anchor="end" x="63" y="34" font-size="12px" fill="currentColor">CPU</text>
-      </g>
-    </svg>
-    <svg width="100px" height="40px">
-      <g class="bars">
-        <rect fill="currentColor" width="100%" x="0" y="5" height="12"><title>{memoryUsagePercentageTitle}</title></rect
-        >;
-        {#if memoryUsagePercentage >= 0}
-          <rect fill="{memoryColor}" width="{memoryUsagePercentage}%" x="0" y="5" height="12"
-            ><title>{memoryUsagePercentageTitle}</title></rect>
-        {/if}
-        <rect fill="currentColor" width="100%" x="0" y="23" height="12"><title>{cpuUsagePercentageTitle}</title></rect>;
-
-        {#if cpuUsagePercentage >= 0}
-          <rect fill="{cpuColor}" width="{cpuUsagePercentage}%" x="0" y="23" height="12"
-            ><title>{cpuUsagePercentageTitle}</title></rect>
-        {/if}
-        {#if memoryUsagePercentage === -1}
-          <rect fill="#888" width="100%" x="0" y="5" height="12"></rect>;
-          <text text-anchor="end" x="90" y="14" font-size="8px" fill="#DDD">Initializing... </text>
-          <rect fill="#888" width="100%" x="0" y="23" height="12"></rect>;
-          <text text-anchor="end" x="90" y="32" font-size="8px" fill="#DDD">Initializing... </text>
-        {/if}
-      </g>
-    </svg>
-    <svg class="mr-1 text-zinc-400" width="80px" height="40px">
-      <g class="bars">
-        {#if memoryUsageTitle}
-          <text text-anchor="start" x="2" y="16" font-size="12px" fill="currentColor">{memoryUsageTitle} </text>
-        {/if}
-        {#if cpuUsageTitle}
-          <text text-anchor="start" x="2" y="34" font-size="12px" fill="currentColor">{cpuUsageTitle}</text>
-        {/if}
-      </g>
-    </svg>
+  <div class="flex flex-row gap-1">
+    <Donut title="vCPUs" size="{45}" value="{cpuUsage}" percent="{cpuUsagePercentage}" />
+    <Donut title="MEM" size="{45}" value="{memoryUsage}" percent="{memoryUsagePercentage}" />
   </div>
 {/if}

--- a/packages/renderer/src/lib/donut/Donut.svelte
+++ b/packages/renderer/src/lib/donut/Donut.svelte
@@ -30,7 +30,12 @@ $: tooltip = percent ? percent.toFixed(0) + '% ' + title + ' usage' : '';
   <svg viewBox="-4 -4 {size + 8} {size + 8}" height="{size}" width="{size}">
     <circle fill="none" class="stroke-charcoal-300" stroke-width="1" r="{size / 2}" cx="{size / 2}" cy="{size / 2}"
     ></circle>
-    <path fill="none" class="{stroke}" stroke-width="3.5" d="{describeArc(size / 2, (percent * 360) / 100)}"></path>
+    <path
+      fill="none"
+      class="{stroke}"
+      stroke-width="3.5"
+      d="{describeArc(size / 2, (percent * 360) / 100)}"
+      data-testid="arc"></path>
     <text x="{size / 2}" y="38%" text-anchor="middle" font-size="{size / 5.5}" class="fill-gray-800">{title}</text>
     <text
       x="{size / 2}"

--- a/packages/renderer/src/lib/donut/Donut.svelte
+++ b/packages/renderer/src/lib/donut/Donut.svelte
@@ -26,7 +26,7 @@ $: stroke = percent < 0 ? '' : percent < 50 ? 'stroke-green-500' : percent < 75 
 $: tooltip = percent ? percent.toFixed(0) + '% ' + title + ' usage' : '';
 </script>
 
-<Tooltip tip="{tooltip}" right>
+<Tooltip tip="{tooltip}" bottom>
   <svg viewBox="-4 -4 {size + 8} {size + 8}" height="{size}" width="{size}">
     <circle fill="none" class="stroke-charcoal-300" stroke-width="1" r="{size / 2}" cx="{size / 2}" cy="{size / 2}"
     ></circle>
@@ -38,6 +38,6 @@ $: tooltip = percent ? percent.toFixed(0) + '% ' + title + ' usage' : '';
       text-anchor="middle"
       font-size="{size / 4.5}"
       dominant-baseline="central"
-      class="fill-gray-400">{value}</text>
+      class="fill-gray-400">{value || ''}</text>
   </svg>
 </Tooltip>


### PR DESCRIPTION
### What does this PR do?

Switches the container statistics from bars to use the Donut component. This is more consistent, will match what we do in Settings > Resources, visually nice, and takes up far less horizontal space vs today (which is necessary for #4226 - details page consistency with design and other forms).

Minor benefit: the colors are now from the palette.

The donuts are taller than the previous component, but still visually look a little small. To me this is ok and still legible, and I can't go any bigger and solve #4226.

Two minor fixes for Donut: move the tooltip below instead of right (since container stats are shown near the right edge of the window) and do not show the value until it is set. This avoids showing 'undefined' before the container stats are available.

### Screenshot/screencast of this PR

Before:

<img width="315" alt="Screenshot 2023-10-04 at 11 22 37 PM" src="https://github.com/containers/podman-desktop/assets/19958075/8af15c44-3f94-4363-a184-4993c060ffb0">

After:

<img width="247" alt="Screenshot 2023-10-05 at 4 01 37 PM" src="https://github.com/containers/podman-desktop/assets/19958075/afa66e68-cfcb-4144-98c2-9eb9d06f4c06">

### What issues does this PR fix or reference?

Partial fix for #4226.

### How to test this PR?

Start a container and go to its details page.