### PR TITLE
chore: remove PF vars

### DIFF
--- a/packages/renderer/src/lib/dashboard/ProviderInstalled.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderInstalled.svelte
@@ -141,25 +141,27 @@ function onInstallationClick() {
     </p>
 
     <div class="m-5" class:hidden="{!initializationButtonVisible}">
-      <div class="bg-[#e5e7eb]">
+      <div class="bg-gray-300 text-white">
         <button
-          class="float-left bg-[var(--pf-global--primary-color--300)] hover:bg-[var(--pf-global--primary-color--200)] pt-2 pr-3 pl-3 pb-2 text-[13px] mr-px w-[180px]"
+          class="float-left bg-purple-600 hover:bg-purple-500 pt-2 pr-3 pl-3 pb-2 text-[13px] text-white mr-px w-[180px]"
           on:click="{onInstallationClick}">
           {installationOptionSelected}
         </button>
         <button
-          class="inline-block bg-[var(--pf-global--primary-color--300)] hover:bg-[var(--pf-global--primary-color--200)] text-[13px] pt-2 pr-3 pl-3 pb-2 w-[32px]"
+          class="inline-block bg-purple-600 hover:bg-purple-500 text-[13px] text-white pt-2 pr-3 pl-3 pb-2 w-[32px]"
           on:click="{() => updateOptionsMenu(!installationOptionsMenuVisible)}">
           <i class="fas fa-caret-down"></i>
         </button>
       </div>
-      <div class="-z-1 min-w-[130px] m-auto bg-primary text-[13px]" class:hidden="{!installationOptionsMenuVisible}">
-        <ul class="w-full outline-none bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700">
+      <div
+        class="-z-1 min-w-[130px] m-auto bg-primary text-[13px] text-white"
+        class:hidden="{!installationOptionsMenuVisible}">
+        <ul class="w-full outline-none bg-charcoal-800 rounded-sm placeholder-gray-700">
           <li>
             <button
               class="w-full p-2 {installationOptionSelected === InitializeOnlyMode
-                ? 'bg-[#ffffff33]'
-                : ''} hover:text-gray-400 hover:bg-[var(--pf-global--BackgroundColor--300)] cursor-pointer"
+                ? 'bg-purple-600 text-white'
+                : 'bg-purple-700 text-gray-700'} hover:bg-purple-500 cursor-pointer"
               on:click="{() => {
                 installationOptionSelected = InitializeOnlyMode;
                 installationOptionsMenuVisible = false;
@@ -171,8 +173,8 @@ function onInstallationClick() {
           <li>
             <button
               class="w-full p-2 {installationOptionSelected === InitializeAndStartMode
-                ? 'bg-[#ffffff33]'
-                : ''} hover:text-gray-400 hover:bg-[var(--pf-global--BackgroundColor--300)] cursor-pointer"
+                ? 'bg-purple-600 text-white'
+                : 'bg-purple-700 text-gray-700'} hover:bg-purple-500 cursor-pointer"
               on:click="{() => {
                 installationOptionSelected = InitializeAndStartMode;
                 installationOptionsMenuVisible = false;

--- a/packages/renderer/src/lib/ui/LinearProgress.svelte
+++ b/packages/renderer/src/lib/ui/LinearProgress.svelte
@@ -52,6 +52,5 @@
 }
 </style>
 
-<progress
-  class="w-full appearance-none border-none h-0.5 text-[var(--pf-global--primary-color--100)] text-base pure-material-progress-linear"
+<progress class="w-full appearance-none border-none h-0.5 text-purple-500 text-base pure-material-progress-linear"
 ></progress>


### PR DESCRIPTION
### What does this PR do?

Replaces -pf variables and a few hardcoded rgb values with colors directly from our palette. Looks slightly more consistent with other UI elements since I matched colors as much as possible with Buttons.

I did not replace Initialize button with the Button component since it is a compound/drop-down button and there would be issues with rounded corners. There's probably a bigger change that could be done, but this is much simpler/safer/less code.

### Screenshot/screencast of this PR

Before:

<img width="247" alt="Screenshot 2023-10-05 at 5 00 58 PM" src="https://github.com/containers/podman-desktop/assets/19958075/581c0013-8e84-4327-8a8f-2fcfcc487ec1">

After:

<img width="247" alt="Screenshot 2023-10-05 at 4 59 44 PM" src="https://github.com/containers/podman-desktop/assets/19958075/58eb24d4-425d-448a-9277-0eea3b6118d6">

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Go to Dashboard with a provider in initialize state; create a new podman machine or other action to see the linear progress bar.