### PR TITLE
fix: reject exec promises with custom RunErrorImpl derived from Error

### DIFF
--- a/packages/main/src/plugin/util/exec.spec.ts
+++ b/packages/main/src/plugin/util/exec.spec.ts
@@ -574,6 +574,4 @@ describe('getInstallationPath', () => {
 
     expect(path).toBe('/usr/other');
   });
-
-  test('should reject promises with instance of Error class', async () => {});
 });


### PR DESCRIPTION
### What does this PR do?

It changes exec API implementation to reject promises using RunExecImpl class derived form Error class and setting up correct prototype chain so instanceof statement recognize it as Error instance. This fix changes how error message rendered out of error thrown by exec API calls. 

Instead or `Error: [object:Object]` it shows actual error message

### Screenshot/screencast of this PR

![image](https://github.com/containers/podman-desktop/assets/620330/e8163c6b-74b8-4008-8881-c7804dfba2a3)

### What issues does this PR fix or reference?

#4230

### How to test this PR?

<!-- Please explain steps to reproduce -->
