### PR TITLE
docs: added a validation check to use relative URLS for internal links

### DIFF
--- a/.vale/fixtures/PodmanDesktop/Links/.vale.ini
+++ b/.vale/fixtures/PodmanDesktop/Links/.vale.ini
@@ -1,0 +1,23 @@
+; .vale.ini
+; Vale configuration file. See https://vale.sh
+;
+; Copyright (C) 2023 Red Hat, Inc.
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+; http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+;
+; SPDX-License-Identifier: Apache-2.0
+;
+MinAlertLevel = suggestion
+StylesPath = ../../../styles
+
+[*.md]
+PodmanDesktop.Links = YES

--- a/.vale/fixtures/PodmanDesktop/Links/testinvalid.md
+++ b/.vale/fixtures/PodmanDesktop/Links/testinvalid.md
@@ -1,0 +1,4 @@
+[Relative link not starting with a /](link)
+[Relative link not starting with a /](httpslink)
+[Relative link not starting with a /](./link)
+![Image](img/image.png)

--- a/.vale/fixtures/PodmanDesktop/Links/testvalid.md
+++ b/.vale/fixtures/PodmanDesktop/Links/testvalid.md
@@ -1,0 +1,5 @@
+[External link](https://podman-desktop.io)
+[Internal link statrting with /](/docs)
+[Good URL](/docs/onboarding)
+![Image](/docs/onboarding/img/image.png)
+A sentence containing a (parenthesis block) inside.

--- a/.vale/styles/PodmanDesktop/Links.yml
+++ b/.vale/styles/PodmanDesktop/Links.yml
@@ -1,0 +1,9 @@
+---
+extends: existence
+message: 'Consider starting the link with https:// or /, rather than %s'
+level: warning
+nonword: true
+# To access link markup:
+scope: raw
+tokens:
+  - '\]\((?!(/)|(https://))[[:ascii:]]+?\)'


### PR DESCRIPTION
### What does this PR do?

Added a validation check to use relative URLS for internal link…

### Screenshot/screencast of this PR

### What issues does this PR fix or reference?

fixes #4010

### How to test this PR?

Test the the Vale rule with the fixtures:

```
cd .vale/fixtures/PodmanDesktop/Links/
vale .
```

Vale reports:
- one error per line in the `testinvalid.md` file.
- no error in the `testvalid.md` file.


```
 testinvalid.md
 1:37  warning  Consider starting the link      PodmanDesktop.Links 
                with https:// or /, rather                          
                than ](link)                                        
 2:37  warning  Consider starting the link      PodmanDesktop.Links 
                with https:// or /, rather                          
                than ](httpslink)                                   
 3:37  warning  Consider starting the link      PodmanDesktop.Links 
                with https:// or /, rather                          
                than ](./link)                                      
 4:8   warning  Consider starting the link      PodmanDesktop.Links 
                with https:// or /, rather                          
                than ](img/image.png)                               

✖ 0 errors, 4 warnings and 0 suggestions in 2 files.
```
