### PR TITLE
fix: handle undefined percent in donut

### DIFF
--- a/packages/renderer/src/lib/donut/Donut.svelte
+++ b/packages/renderer/src/lib/donut/Donut.svelte
@@ -23,7 +23,7 @@ function describeArc(radius: number, endAngle: number) {
 
 $: stroke = percent < 0 ? '' : percent < 50 ? 'stroke-green-500' : percent < 75 ? 'stroke-amber-500' : 'stroke-red-500';
 
-$: tooltip = percent.toFixed(0) + '% ' + title + ' usage';
+$: tooltip = percent ? percent.toFixed(0) + '% ' + title + ' usage' : '';
 </script>
 
 <Tooltip tip="{tooltip}" right>


### PR DESCRIPTION
### What does this PR do?

Just adds an undefined check to avoid failure when percent isn't a valid number in Donut.

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

Fixes #4232.

### How to test this PR?

Restart a Podman machine and confirm it doesn't hang.