### PR TITLE
chore: for Windows users, make correct line ending

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
### What does this PR do?
it looks like formatter is not happy without that setting on Windows

so apply correct line ending in this project (to avoid people configuring something globally)

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast 
explaining what is doing this PR -->

### What issues does this PR fix or reference?

https://github.com/containers/podman-desktop/issues/1850

### How to test this PR?

1. Ensure you don't have any git settings (like in your $HOME/.git folder)
2. Clone the repository with this branch
3. run formatter

(with this .gitattributes file, formatter should work. Without you should have warnings on all files)