### PR TITLE
fix: enhance 401/500 error status message when pulling image (#3845)

### DIFF
--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -862,7 +862,7 @@ describe('listContainers', () => {
   });
 });
 
-test('pull unknown image ', async () => {
+test('pull unknown image fails with error 403', async () => {
   const getMatchingEngineFromConnectionSpy = vi.spyOn(containerRegistry, 'getMatchingEngineFromConnection');
 
   const pullMock = vi.fn();
@@ -888,6 +888,64 @@ test('pull unknown image ', async () => {
   // check that we have a nice error message
   await expect(containerRegistry.pullImage(containerConnectionInfo, 'unknown-image', callback)).rejects.toThrow(
     'access to image "unknown-image" is denied (403 error). Can also be that image does not exist',
+  );
+});
+
+test('pull unknown image fails with error 401', async () => {
+  const getMatchingEngineFromConnectionSpy = vi.spyOn(containerRegistry, 'getMatchingEngineFromConnection');
+
+  const pullMock = vi.fn();
+
+  const fakeDockerode = {
+    pull: pullMock,
+    modem: {
+      followProgress: vi.fn(),
+    },
+  } as unknown as Dockerode;
+
+  getMatchingEngineFromConnectionSpy.mockReturnValue(fakeDockerode);
+
+  const containerConnectionInfo = {} as ProviderContainerConnectionInfo;
+
+  // add statusCode on the error
+  const error = new Error('access denied');
+  (error as any).statusCode = 401;
+
+  pullMock.mockRejectedValue(error);
+
+  const callback = vi.fn();
+  // check that we have a nice error message
+  await expect(containerRegistry.pullImage(containerConnectionInfo, 'unknown-image', callback)).rejects.toThrow(
+    'access to image "unknown-image" is denied (401 error). Can also be that the registry requires authentication.',
+  );
+});
+
+test('pull unknown image fails with error 500', async () => {
+  const getMatchingEngineFromConnectionSpy = vi.spyOn(containerRegistry, 'getMatchingEngineFromConnection');
+
+  const pullMock = vi.fn();
+
+  const fakeDockerode = {
+    pull: pullMock,
+    modem: {
+      followProgress: vi.fn(),
+    },
+  } as unknown as Dockerode;
+
+  getMatchingEngineFromConnectionSpy.mockReturnValue(fakeDockerode);
+
+  const containerConnectionInfo = {} as ProviderContainerConnectionInfo;
+
+  // add statusCode on the error
+  const error = new Error('access denied');
+  (error as any).statusCode = 500;
+
+  pullMock.mockRejectedValue(error);
+
+  const callback = vi.fn();
+  // check that we have a nice error message
+  await expect(containerRegistry.pullImage(containerConnectionInfo, 'unknown-image', callback)).rejects.toThrow(
+    'access to image "unknown-image" is denied (500 error). Can also be that the registry requires authentication.',
   );
 });
 

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -921,10 +921,15 @@ export class ContainerProviderRegistry {
 
       return promise;
     } catch (error) {
-      // Provides a better error message for 403 errors
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      if (error instanceof Error && (error as any)?.statusCode === 403) {
-        error.message = `access to image "${imageName}" is denied (403 error). Can also be that image does not exist.`;
+      // Provides a better error message for 401, 403 and 500 errors
+      if (error instanceof Error) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const statusCode = (error as any)?.statusCode;
+        if (statusCode === 403) {
+          error.message = `access to image "${imageName}" is denied (403 error). Can also be that image does not exist.`;
+        } else if (statusCode === 500 || statusCode === 401) {
+          error.message = `access to image "${imageName}" is denied (${statusCode} error). Can also be that the registry requires authentication.`;
+        }
       }
       telemetryOptions = { error: error };
       throw error;


### PR DESCRIPTION
### What does this PR do?

It replaces [Object object] with a message saying that the registry may requires authentication

### Screenshot/screencast of this PR

![image](https://github.com/containers/podman-desktop/assets/49404737/1abbbfef-4626-49d4-8203-5520348b104f)

### What issues does this PR fix or reference?

it resolves #3845 

### How to test this PR?

1. Do not have particular registry added to the available registries.
Try to pull an image from registry that requires authentication, ie: registry.redhat.io/rhel9/cups
