### PR TITLE
fix: update min windows build version needed for podman (#3659)

### DIFF
--- a/extensions/podman/src/podman-install.spec.ts
+++ b/extensions/podman/src/podman-install.spec.ts
@@ -178,7 +178,7 @@ test('expect winbit preflight check return failure result if the arch is not sup
 });
 
 test('expect winversion preflight check return successful result if the version is greater than min valid version', async () => {
-  vi.spyOn(os, 'release').mockReturnValue('10.0.19000');
+  vi.spyOn(os, 'release').mockReturnValue('10.0.19043');
 
   const installer = new WinInstaller();
   const preflights = installer.getPreflightChecks();
@@ -188,13 +188,13 @@ test('expect winversion preflight check return successful result if the version 
 });
 
 test('expect winversion preflight check return failure result if the version is greater than 9. and less than min build version', async () => {
-  vi.spyOn(os, 'release').mockReturnValue('10.0.1000');
+  vi.spyOn(os, 'release').mockReturnValue('10.0.19042');
 
   const installer = new WinInstaller();
   const preflights = installer.getPreflightChecks();
   const winVersionCheck = preflights[1];
   const result = await winVersionCheck.execute();
-  expect(result.description).equal('To be able to run WSL2 you need Windows 10 Build 18362 or later.');
+  expect(result.description).equal('To be able to run WSL2 you need Windows 10 Build 19043 or later.');
   expect(result.docLinksDescription).equal('Learn about WSL requirements:');
   expect(result.docLinks[0].url).equal(
     'https://docs.microsoft.com/en-us/windows/wsl/install-manual#step-2---check-requirements-for-running-wsl-2',

--- a/extensions/podman/src/podman-install.ts
+++ b/extensions/podman/src/podman-install.ts
@@ -405,7 +405,7 @@ class WinBitCheck extends BaseCheck {
 class WinVersionCheck extends BaseCheck {
   title = 'Windows Version';
 
-  private MIN_BUILD = 18362;
+  private MIN_BUILD = 19043; //it represents version 21H1 windows 10
   async execute(): Promise<extensionApi.CheckResult> {
     const winRelease = os.release();
     if (winRelease.startsWith('10.0.')) {
@@ -415,7 +415,7 @@ class WinVersionCheck extends BaseCheck {
         return { successful: true };
       } else {
         return this.createFailureResult({
-          description: 'To be able to run WSL2 you need Windows 10 Build 18362 or later.',
+          description: `To be able to run WSL2 you need Windows 10 Build ${this.MIN_BUILD} or later.`,
           docLinksDescription: 'Learn about WSL requirements:',
           docLinks: {
             url: 'https://docs.microsoft.com/en-us/windows/wsl/install-manual#step-2---check-requirements-for-running-wsl-2',


### PR DESCRIPTION
### What does this PR do?

This PR updates the min windows build version that is checked by the pre-flights.
By following https://github.com/containers/podman-desktop/discussions/3151#discussioncomment-6754515 the min version supported should be Windows 10 21H1 which starts with the build number `19043.985` https://learn.microsoft.com/en-us/windows/release-health/release-information#windows-10-release-history

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

it is part of #3659 

### How to test this PR?

1. run tests
