### PR TITLE
feat: check if reboot is needed after wsl install (#4193)

### DIFF
--- a/extensions/podman/src/podman-install.ts
+++ b/extensions/podman/src/podman-install.ts
@@ -576,7 +576,7 @@ class WSL2Check extends BaseCheck {
       throw new Error(message);
     }
   }
-  
+
   private async isRebootNeeded(): Promise<boolean> {
     try {
       await extensionApi.process.exec('wsl', ['-l'], {

--- a/extensions/podman/src/podman-install.ts
+++ b/extensions/podman/src/podman-install.ts
@@ -583,12 +583,16 @@ class WSL2Check extends BaseCheck {
         env: { WSL_UTF8: '1' },
       });
     } catch (error) {
-      console.log(error);
       // we only return true for the WSL_E_WSL_OPTIONAL_COMPONENT_REQUIRED error code
       // as other errors may not be connected to a reboot, like
       // WSL_E_DEFAULT_DISTRO_NOT_FOUND = wsl was installed without the default distro
       if (error.stdout.includes('Wsl/WSL_E_WSL_OPTIONAL_COMPONENT_REQUIRED')) {
         return true;
+      } else if (error.stdout.includes('Wsl/WSL_E_DEFAULT_DISTRO_NOT_FOUND')) {
+        // treating this log differently as we install wsl without any distro
+        console.log('WSL has been installed without the default distribution');
+      } else {
+        console.error(error);
       }
     }
     return false;

--- a/extensions/podman/src/podman-install.ts
+++ b/extensions/podman/src/podman-install.ts
@@ -498,6 +498,7 @@ class WSL2Check extends BaseCheck {
     try {
       const isAdmin = await this.isUserAdmin();
       const isWSL = await this.isWSLPresent();
+      const isRebootNeeded = await this.isRebootNeeded();
 
       if (!isWSL) {
         if (isAdmin) {
@@ -523,6 +524,11 @@ class WSL2Check extends BaseCheck {
             },
           });
         }
+      } else if (isRebootNeeded) {
+        return this.createFailureResult({
+          description:
+            'WSL2 seems to be installed but the system needs to be restarted so the changes can take effect.',
+        });
       }
     } catch (err) {
       return this.createFailureResult({
@@ -569,6 +575,23 @@ class WSL2Check extends BaseCheck {
       message += error.stderr || '';
       throw new Error(message);
     }
+  }
+  
+  private async isRebootNeeded(): Promise<boolean> {
+    try {
+      await extensionApi.process.exec('wsl', ['-l'], {
+        env: { WSL_UTF8: '1' },
+      });
+    } catch (error) {
+      console.log(error);
+      // we only return true for the WSL_E_WSL_OPTIONAL_COMPONENT_REQUIRED error code
+      // as other errors may not be connected to a reboot, like
+      // WSL_E_DEFAULT_DISTRO_NOT_FOUND = wsl was installed without the default distro
+      if (error.stdout.includes('Wsl/WSL_E_WSL_OPTIONAL_COMPONENT_REQUIRED')) {
+        return true;
+      }
+    }
+    return false;
   }
 }
 


### PR DESCRIPTION
### What does this PR do?

This PR adds a check to see if the system must be restarted when WSL is installed.
In older version of Windows it is mandatory. 

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

it is part of #4193 

### How to test this PR?

1. you need to be on win 10
2. uninstall wsl
3. restart the machine
4. install wsl and do not reboot
5. launch Desktop
6. start the onboarding, you should see the warning telling you to restart the system
