### PR TITLE
feat: add WSL version pre-flight check (#3659)

### DIFF
--- a/extensions/podman/src/podman-install.spec.ts
+++ b/extensions/podman/src/podman-install.spec.ts
@@ -319,7 +319,7 @@ test('expect WSLVersion preflight check return fail result if wsl --version comm
   const preflights = installer.getPreflightChecks();
   const winWSLCheck = preflights[4];
   const result = await winWSLCheck.execute();
-  expect(result.description).equal('WSL version should be >= 1.2.5.0.');
+  expect(result.description).equal('WSL version should be >= 1.2.5.');
   expect(result.docLinksDescription).equal(`Call 'wsl --version' in a terminal to check your wsl version.`);
 });
 
@@ -334,7 +334,7 @@ test('expect WSLVersion preflight check return fail result if first line output 
   const preflights = installer.getPreflightChecks();
   const winWSLCheck = preflights[4];
   const result = await winWSLCheck.execute();
-  expect(result.description).equal('WSL version should be >= 1.2.5.0.');
+  expect(result.description).equal('WSL version should be >= 1.2.5.');
   expect(result.docLinksDescription).equal(`Call 'wsl --version' in a terminal to check your wsl version.`);
 });
 
@@ -349,7 +349,7 @@ test('expect WSLVersion preflight check return fail result if first line output 
   const preflights = installer.getPreflightChecks();
   const winWSLCheck = preflights[4];
   const result = await winWSLCheck.execute();
-  expect(result.description).equal('WSL version should be >= 1.2.5.0.');
+  expect(result.description).equal('WSL version should be >= 1.2.5.');
   expect(result.docLinksDescription).equal(`Call 'wsl --version' in a terminal to check your wsl version.`);
 });
 
@@ -364,7 +364,7 @@ test('expect WSLVersion preflight check return fail result if first line output 
   const preflights = installer.getPreflightChecks();
   const winWSLCheck = preflights[4];
   const result = await winWSLCheck.execute();
-  expect(result.description).equal('Your WSL version is 1.1.3 but it should be >= 1.2.5.0.');
+  expect(result.description).equal('Your WSL version is 1.1.3 but it should be >= 1.2.5.');
   expect(result.docLinksDescription).equal(
     `Call 'wsl --update' to update your WSL installation. If you do not have access to the Windows store you can run 'wsl --update --web-download'. If you still receive an error please contact your IT administator as 'Windows Store Applications' may have been disabled.`,
   );

--- a/extensions/podman/src/podman-install.ts
+++ b/extensions/podman/src/podman-install.ts
@@ -571,7 +571,7 @@ class WSL2Check extends BaseCheck {
 class WSLVersionCheck extends BaseCheck {
   title = 'WSL Version';
 
-  minVersion = '1.2.5.0';
+  minVersion = '1.2.5';
 
   async execute(): Promise<extensionApi.CheckResult> {
     try {

--- a/extensions/podman/src/util.spec.ts
+++ b/extensions/podman/src/util.spec.ts
@@ -1,0 +1,47 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { expect, test } from 'vitest';
+import { normalizeWSLOutput } from './util';
+
+test('normalizeWSLOutput returns the same string if there is no need to normalize it', async () => {
+  const text = 'blabla';
+  const res = normalizeWSLOutput(text);
+  expect(res).toEqual(text);
+});
+
+test('normalizeWSLOutput returns a normalized output', async () => {
+  const text = 'WSL version: 1.2.5.0';
+  const textU16 = strEncodeUTF16(text);
+  const enc = new TextDecoder('utf-16');
+  const res = normalizeWSLOutput(enc.decode(textU16));
+  expect(textU16).not.toEqual(text);
+  expect(res).toEqual(text);
+});
+
+// create a string with invalid chars
+function strEncodeUTF16(str) {
+  const buf = new ArrayBuffer(str.length * 4);
+  const bufView = new Uint16Array(buf);
+  for (let i = 0; i < str.length; i++) {
+    bufView[i * 2] = str.charCodeAt(i);
+    // add an extra char to the string to simulate WSL output
+    bufView[i * 2 + 1] = 0;
+  }
+  return bufView;
+}

--- a/extensions/podman/src/util.ts
+++ b/extensions/podman/src/util.ts
@@ -107,3 +107,21 @@ export class LoggerDelegator implements Logger {
     this.loggers.forEach(logger => logger.warn(...data));
   }
 }
+
+// this is workaround, wsl2 some time send output in utf16le, but we treat that as utf8,
+// this code just eliminate every 'empty' character
+/**
+ * this function is a workaround to clean the output received by WSL2. Some time it sends output in utf16le, but we treat that as utf8,
+ * this code just eliminate every 'empty' character
+ * @param out the string to clean
+ * @returns the string cleaned
+ */
+export function normalizeWSLOutput(out: string): string {
+  let str = '';
+  for (let i = 0; i < out.length; i++) {
+    if (out.charCodeAt(i) !== 0) {
+      str += out.charAt(i);
+    }
+  }
+  return str;
+}

--- a/extensions/podman/src/wsl-helper.spec.ts
+++ b/extensions/podman/src/wsl-helper.spec.ts
@@ -61,3 +61,27 @@ Windows version: 10.0.22621.2134
   // expect called with wsl --version
   expect(extensionApi.process.exec).toHaveBeenCalledWith('wsl', ['--version']);
 });
+
+test('should grab correct versions even with an output with a language different from english', async () => {
+  const wslOutput = `Versione WSL: 1.2.5.0
+  Versione kernel: 5.15.90.1
+  Versione WSLg: 1.0.51
+  Versione MSRDC: 1.2.3770
+  Versione Direct3D: 1.608.2-61064218
+  Versione DXCore: 10.0.25131.1002-220531-1700.rs-onecore-base2-hyp
+  Versione di Windows: 10.0.22621.2283
+`;
+
+  (extensionApi.process.exec as Mock).mockReturnValue({
+    stdout: wslOutput,
+  } as extensionApi.RunResult);
+
+  const { wslVersion, kernelVersion, windowsVersion } = await wslHelper.getWSLVersionData();
+
+  expect(wslVersion).toBe('1.2.5.0');
+  expect(kernelVersion).toBe('5.15.90.1');
+  expect(windowsVersion).toBe('10.0.22621.2283');
+
+  // expect called with wsl --version
+  expect(extensionApi.process.exec).toHaveBeenCalledWith('wsl', ['--version']);
+});

--- a/extensions/podman/src/wsl-helper.ts
+++ b/extensions/podman/src/wsl-helper.ts
@@ -1,4 +1,5 @@
 import * as extensionApi from '@podman-desktop/api';
+import { normalizeWSLOutput } from './util';
 
 export interface WSLVersionInfo {
   wslVersion: string;
@@ -9,27 +10,52 @@ export interface WSLVersionInfo {
 export class WslHelper {
   async getWSLVersionData(): Promise<WSLVersionInfo> {
     const { stdout } = await extensionApi.process.exec('wsl', ['--version']);
-
-    // got something like
     /*
-WSL version: 1.2.5.0
-Kernel version: 5.15.90.1
-WSLg version: 1.0.51
-MSRDC version: 1.2.3770
-Direct3D version: 1.608.2-61064218
-DXCore version: 10.0.25131.1002-220531-1700.rs-onecore-base2-hyp
-Windows version: 10.0.22621.2134
- */
+      got something like
+      WSL version: 1.2.5.0
+      Kernel version: 5.15.90.1
+      WSLg version: 1.0.51
+      MSRDC version: 1.2.3770
+      Direct3D version: 1.608.2-61064218
+      DXCore version: 10.0.25131.1002-220531-1700.rs-onecore-base2-hyp
+      Windows version: 10.0.22621.2134
 
-    // match the string WSL version: 1.2.5.0
-    const wslVersion = stdout.match(/WSL version: ([0-9.]+)/)?.[1];
+      N.B: the label before the colon symbol changes based on the system language. In an italian system you would have
 
-    // kernel version match the string Kernel version: 5.15.90.1
-    const kernelVersion = stdout.match(/Kernel version: ([0-9.]+)/)?.[1];
+      Versione WSL: 1.2.5.0
+      Versione kernel: 5.15.90.1
+      ...
+    */
 
-    // Windows version match the string Windows version: 10.0.22621.2134
-    const windowsVersion = stdout.match(/Windows version: ([0-9.]+)/)?.[1];
+    // split the output in lines
+    const lines = normalizeWSLOutput(stdout).split('\n');
+
+    // the first line should display the version of the wsl - WSL version: 1.2.5.0
+    const wslVersion = getVersionFromWSLOutput(lines[0], 'wsl');
+
+    // the second line should display the kernel version - Kernel version: 5.15.90.1
+    const kernelVersion = getVersionFromWSLOutput(lines[1], 'kernel');
+
+    // the last line should display the Windows version - Windows version: 10.0.22621.2134
+    const windowsVersion = getVersionFromWSLOutput(lines[6], 'windows');
 
     return { wslVersion, kernelVersion, windowsVersion };
   }
+}
+
+/**
+ * it extract the content after the colon which should be the version of the tool/system
+ * @param line the content to analyze
+ * @param value the tool/system to find the version for
+ * @returns the content after the colon if the line belongs to the tool/system we are searching info for
+ */
+function getVersionFromWSLOutput(line: string, value: string): string {
+  if (!line) {
+    return undefined;
+  }
+  const colonPosition = line.indexOf(':');
+  if (colonPosition >= 0 && line.substring(0, colonPosition).toLowerCase().includes(value)) {
+    return line.substring(colonPosition + 1).trim();
+  }
+  return undefined;
 }


### PR DESCRIPTION
### What does this PR do?

This PR adds a new pre-flight check to verify is the WSL version is >= 1.2.5.0.

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

it resolves #3659 

### How to test this PR?

1. run tests
