### PR TITLE
refactor: extract value retrieval from PreferencesRenderingItemFormat

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationRendering.svelte
@@ -3,7 +3,7 @@ import type { IConfigurationPropertyRecordedSchema } from '../../../../main/src/
 import type { ProviderInfo } from '../../../../main/src/plugin/api/provider-info';
 import PreferencesRenderingItemFormat from './PreferencesRenderingItemFormat.svelte';
 import TerminalWindow from '../ui/TerminalWindow.svelte';
-import { getNormalizedDefaultNumberValue, writeToTerminal, isPropertyValidInContext } from './Util';
+import { getNormalizedDefaultNumberValue, writeToTerminal, isPropertyValidInContext, getInitialValue } from './Util';
 import ErrorMessage from '../ui/ErrorMessage.svelte';
 import {
   clearCreateTask,
@@ -446,7 +446,8 @@ function closePage() {
                   validRecord="{handleValidComponent}"
                   record="{configurationKey}"
                   setRecordValue="{setConfigurationValue}"
-                  enableSlider="{true}" />
+                  enableSlider="{true}"
+                  initialValue="{getInitialValue(configurationKey)}" />
               </div>
             {/each}
             <div class="w-full">

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationRendering.svelte
@@ -447,7 +447,7 @@ function closePage() {
                   record="{configurationKey}"
                   setRecordValue="{setConfigurationValue}"
                   enableSlider="{true}"
-                  initialValue="{getInitialValue(configurationKey)}" />
+                  initialValue="{() => getInitialValue(configurationKey)}" />
               </div>
             {/each}
             <div class="w-full">

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationRendering.svelte
@@ -447,7 +447,7 @@ function closePage() {
                   record="{configurationKey}"
                   setRecordValue="{setConfigurationValue}"
                   enableSlider="{true}"
-                  initialValue="{() => getInitialValue(configurationKey)}" />
+                  initialValue="{getInitialValue(configurationKey)}" />
               </div>
             {/each}
             <div class="w-full">

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItem.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItem.svelte
@@ -90,7 +90,7 @@ $: resetToDefault = false;
         updateResetButtonVisibility="{updateResetButtonVisibility}"
         resetToDefault="{resetToDefault}"
         enableAutoSave="{true}"
-        initialValue="{() => getInitialValue(recordUI.original)}" />
+        initialValue="{getInitialValue(recordUI.original)}" />
     {/if}
   </div>
   {#if recordUI.original.type !== 'string' || (recordUI.original.enum && recordUI.original.enum.length > 0)}
@@ -99,6 +99,6 @@ $: resetToDefault = false;
       updateResetButtonVisibility="{updateResetButtonVisibility}"
       resetToDefault="{resetToDefault}"
       enableAutoSave="{true}"
-      initialValue="{() => getInitialValue(recordUI.original)}" />
+      initialValue="{getInitialValue(recordUI.original)}" />
   {/if}
 </div>

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItem.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItem.svelte
@@ -90,7 +90,7 @@ $: resetToDefault = false;
         updateResetButtonVisibility="{updateResetButtonVisibility}"
         resetToDefault="{resetToDefault}"
         enableAutoSave="{true}"
-        initialValue="{async () => await getInitialValue(recordUI.original)}" />
+        initialValue="{() => getInitialValue(recordUI.original)}" />
     {/if}
   </div>
   {#if recordUI.original.type !== 'string' || (recordUI.original.enum && recordUI.original.enum.length > 0)}
@@ -99,6 +99,6 @@ $: resetToDefault = false;
       updateResetButtonVisibility="{updateResetButtonVisibility}"
       resetToDefault="{resetToDefault}"
       enableAutoSave="{true}"
-      initialValue="{async () => await getInitialValue(recordUI.original)}" />
+      initialValue="{() => getInitialValue(recordUI.original)}" />
   {/if}
 </div>

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItem.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItem.svelte
@@ -4,6 +4,7 @@ import { afterUpdate } from 'svelte';
 import type { IConfigurationPropertyRecordedSchema } from '../../../../main/src/plugin/configuration-registry';
 import PreferencesRenderingItemFormat from './PreferencesRenderingItemFormat.svelte';
 import Markdown from '../markdown/Markdown.svelte';
+import { getInitialValue } from '/@/lib/preferences/Util';
 
 export let record: IConfigurationPropertyRecordedSchema;
 
@@ -88,7 +89,8 @@ $: resetToDefault = false;
         record="{recordUI.original}"
         updateResetButtonVisibility="{updateResetButtonVisibility}"
         resetToDefault="{resetToDefault}"
-        enableAutoSave="{true}" />
+        enableAutoSave="{true}"
+        initialValue="{async () => await getInitialValue(recordUI.original)}" />
     {/if}
   </div>
   {#if recordUI.original.type !== 'string' || (recordUI.original.enum && recordUI.original.enum.length > 0)}
@@ -96,6 +98,7 @@ $: resetToDefault = false;
       record="{recordUI.original}"
       updateResetButtonVisibility="{updateResetButtonVisibility}"
       resetToDefault="{resetToDefault}"
-      enableAutoSave="{true}" />
+      enableAutoSave="{true}"
+      initialValue="{async () => await getInitialValue(recordUI.original)}" />
   {/if}
 </div>

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.spec.ts
@@ -35,7 +35,7 @@ beforeAll(() => {
 async function awaitRender(record: IConfigurationPropertyRecordedSchema, customProperties: any) {
   const result = render(PreferencesRenderingItemFormat, {
     record,
-    initialValue: () => getInitialValue(record),
+    initialValue: getInitialValue(record),
     ...customProperties,
   });
   while (result.component.$$.ctx[2] === undefined) {

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.spec.ts
@@ -26,6 +26,7 @@ import { render, screen } from '@testing-library/svelte';
 import type { IConfigurationPropertyRecordedSchema } from '../../../../main/src/plugin/configuration-registry';
 import PreferencesRenderingItemFormat from './PreferencesRenderingItemFormat.svelte';
 import userEvent from '@testing-library/user-event';
+import { getInitialValue } from '/@/lib/preferences/Util';
 
 beforeAll(() => {
   (window as any).getConfigurationValue = vi.fn().mockResolvedValue(undefined);
@@ -40,7 +41,7 @@ test('Expect to see checkbox enabled', async () => {
     default: true,
   };
   // remove display name
-  render(PreferencesRenderingItemFormat, { record });
+  render(PreferencesRenderingItemFormat, { record, initialValue: await getInitialValue(record) });
   const button = screen.getByRole('checkbox');
   expect(button).toBeInTheDocument();
   expect(button).toBeChecked();
@@ -56,7 +57,7 @@ test('Expect to see the checkbox disabled / unable to press when readonly is pas
     readonly: true,
   };
   // remove display name
-  render(PreferencesRenderingItemFormat, { record });
+  render(PreferencesRenderingItemFormat, { record, initialValue: await getInitialValue(record) });
   const button = screen.getByRole('checkbox');
   expect(button).toBeInTheDocument();
   expect(button).toBeChecked();
@@ -72,7 +73,7 @@ test('Expect to see checkbox enabled', async () => {
     default: false,
   };
   // remove display name
-  render(PreferencesRenderingItemFormat, { record });
+  render(PreferencesRenderingItemFormat, { record, initialValue: await getInitialValue(record) });
   const button = screen.getByRole('checkbox');
   expect(button).toBeInTheDocument();
   expect(button).not.toBeChecked();
@@ -88,6 +89,7 @@ test('Expect a checkbox when record is type boolean', async () => {
   };
   render(PreferencesRenderingItemFormat, {
     record,
+    initialValue: await getInitialValue(record),
   });
   const input = screen.getByLabelText('record-description');
   expect(input).toBeInTheDocument();
@@ -109,6 +111,7 @@ test('Expect a slider when record and its maximum are type number and enableSlid
   render(PreferencesRenderingItemFormat, {
     record,
     enableSlider: true,
+    initialValue: await getInitialValue(record),
   });
   const input = screen.getByLabelText('record-description');
   expect(input).toBeInTheDocument();
@@ -129,6 +132,7 @@ test('Expect a text input when record is type number and enableSlider is false',
   };
   render(PreferencesRenderingItemFormat, {
     record,
+    initialValue: await getInitialValue(record),
   });
   const input = screen.getByLabelText('record-description');
   expect(input).toBeInTheDocument();
@@ -148,6 +152,7 @@ test('Expect an input button with Browse as placeholder when record is type stri
   };
   render(PreferencesRenderingItemFormat, {
     record,
+    initialValue: await getInitialValue(record),
   });
   const readOnlyInput = screen.getByLabelText('record-description');
   expect(readOnlyInput).toBeInTheDocument();
@@ -169,6 +174,7 @@ test('Expect a select when record is type string and has enum values', async () 
   };
   render(PreferencesRenderingItemFormat, {
     record,
+    initialValue: await getInitialValue(record),
   });
   const input = screen.getByLabelText('record-description');
   expect(input).toBeInTheDocument();
@@ -187,6 +193,7 @@ test('Expect a text input when record is type string', async () => {
   };
   render(PreferencesRenderingItemFormat, {
     record,
+    initialValue: await getInitialValue(record),
   });
   const input = screen.getByLabelText('record-description');
   expect(input).toBeInTheDocument();
@@ -208,6 +215,7 @@ test('Expect tooltip text shows info when input is less than minimum', async () 
   };
   render(PreferencesRenderingItemFormat, {
     record,
+    initialValue: await getInitialValue(record),
   });
   const input = screen.getByLabelText('record-description');
   await userEvent.click(input);
@@ -230,6 +238,7 @@ test('Expect tooltip text shows info when input is empty', async () => {
   };
   render(PreferencesRenderingItemFormat, {
     record,
+    initialValue: await getInitialValue(record),
   });
   const input = screen.getByLabelText('record-description');
   await userEvent.click(input);

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.spec.ts
@@ -41,7 +41,7 @@ test('Expect to see checkbox enabled', async () => {
     default: true,
   };
   // remove display name
-  render(PreferencesRenderingItemFormat, { record, initialValue: await getInitialValue(record) });
+  render(PreferencesRenderingItemFormat, { record, initialValue: () => getInitialValue(record) });
   const button = screen.getByRole('checkbox');
   expect(button).toBeInTheDocument();
   expect(button).toBeChecked();
@@ -57,7 +57,7 @@ test('Expect to see the checkbox disabled / unable to press when readonly is pas
     readonly: true,
   };
   // remove display name
-  render(PreferencesRenderingItemFormat, { record, initialValue: await getInitialValue(record) });
+  render(PreferencesRenderingItemFormat, { record, initialValue: () => getInitialValue(record) });
   const button = screen.getByRole('checkbox');
   expect(button).toBeInTheDocument();
   expect(button).toBeChecked();
@@ -73,7 +73,7 @@ test('Expect to see checkbox enabled', async () => {
     default: false,
   };
   // remove display name
-  render(PreferencesRenderingItemFormat, { record, initialValue: await getInitialValue(record) });
+  render(PreferencesRenderingItemFormat, { record, initialValue: () => getInitialValue(record) });
   const button = screen.getByRole('checkbox');
   expect(button).toBeInTheDocument();
   expect(button).not.toBeChecked();
@@ -111,7 +111,7 @@ test('Expect a slider when record and its maximum are type number and enableSlid
   render(PreferencesRenderingItemFormat, {
     record,
     enableSlider: true,
-    initialValue: await getInitialValue(record),
+    initialValue: () => getInitialValue(record),
   });
   const input = screen.getByLabelText('record-description');
   expect(input).toBeInTheDocument();
@@ -132,7 +132,7 @@ test('Expect a text input when record is type number and enableSlider is false',
   };
   render(PreferencesRenderingItemFormat, {
     record,
-    initialValue: await getInitialValue(record),
+    initialValue: () => getInitialValue(record),
   });
   const input = screen.getByLabelText('record-description');
   expect(input).toBeInTheDocument();
@@ -152,7 +152,7 @@ test('Expect an input button with Browse as placeholder when record is type stri
   };
   render(PreferencesRenderingItemFormat, {
     record,
-    initialValue: await getInitialValue(record),
+    initialValue: () => getInitialValue(record),
   });
   const readOnlyInput = screen.getByLabelText('record-description');
   expect(readOnlyInput).toBeInTheDocument();
@@ -174,7 +174,7 @@ test('Expect a select when record is type string and has enum values', async () 
   };
   render(PreferencesRenderingItemFormat, {
     record,
-    initialValue: await getInitialValue(record),
+    initialValue: () => getInitialValue(record),
   });
   const input = screen.getByLabelText('record-description');
   expect(input).toBeInTheDocument();
@@ -193,7 +193,7 @@ test('Expect a text input when record is type string', async () => {
   };
   render(PreferencesRenderingItemFormat, {
     record,
-    initialValue: await getInitialValue(record),
+    initialValue: () => getInitialValue(record),
   });
   const input = screen.getByLabelText('record-description');
   expect(input).toBeInTheDocument();
@@ -215,7 +215,7 @@ test('Expect tooltip text shows info when input is less than minimum', async () 
   };
   render(PreferencesRenderingItemFormat, {
     record,
-    initialValue: await getInitialValue(record),
+    initialValue: () => getInitialValue(record),
   });
   const input = screen.getByLabelText('record-description');
   await userEvent.click(input);
@@ -238,7 +238,7 @@ test('Expect tooltip text shows info when input is empty', async () => {
   };
   render(PreferencesRenderingItemFormat, {
     record,
-    initialValue: await getInitialValue(record),
+    initialValue: () => getInitialValue(record),
   });
   const input = screen.getByLabelText('record-description');
   await userEvent.click(input);

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.spec.ts
@@ -32,6 +32,17 @@ beforeAll(() => {
   (window as any).getConfigurationValue = vi.fn().mockResolvedValue(undefined);
 });
 
+async function awaitRender(record: IConfigurationPropertyRecordedSchema, customProperties: any) {
+  const result = render(PreferencesRenderingItemFormat, {
+    record,
+    initialValue: () => getInitialValue(record),
+    ...customProperties,
+  });
+  while (result.component.$$.ctx[2] === undefined) {
+    await new Promise(resolve => setTimeout(resolve, 100));
+  }
+}
+
 test('Expect to see checkbox enabled', async () => {
   const record: IConfigurationPropertyRecordedSchema = {
     title: 'my boolean property',
@@ -41,7 +52,7 @@ test('Expect to see checkbox enabled', async () => {
     default: true,
   };
   // remove display name
-  render(PreferencesRenderingItemFormat, { record, initialValue: () => getInitialValue(record) });
+  await awaitRender(record, {});
   const button = screen.getByRole('checkbox');
   expect(button).toBeInTheDocument();
   expect(button).toBeChecked();
@@ -57,7 +68,7 @@ test('Expect to see the checkbox disabled / unable to press when readonly is pas
     readonly: true,
   };
   // remove display name
-  render(PreferencesRenderingItemFormat, { record, initialValue: () => getInitialValue(record) });
+  await awaitRender(record, {});
   const button = screen.getByRole('checkbox');
   expect(button).toBeInTheDocument();
   expect(button).toBeChecked();
@@ -73,7 +84,7 @@ test('Expect to see checkbox enabled', async () => {
     default: false,
   };
   // remove display name
-  render(PreferencesRenderingItemFormat, { record, initialValue: () => getInitialValue(record) });
+  await awaitRender(record, {});
   const button = screen.getByRole('checkbox');
   expect(button).toBeInTheDocument();
   expect(button).not.toBeChecked();
@@ -87,10 +98,7 @@ test('Expect a checkbox when record is type boolean', async () => {
     description: 'record-description',
     type: 'boolean',
   };
-  render(PreferencesRenderingItemFormat, {
-    record,
-    initialValue: await getInitialValue(record),
-  });
+  await awaitRender(record, {});
   const input = screen.getByLabelText('record-description');
   expect(input).toBeInTheDocument();
   expect(input instanceof HTMLInputElement).toBe(true);
@@ -108,10 +116,8 @@ test('Expect a slider when record and its maximum are type number and enableSlid
     minimum: 1,
     maximum: 34,
   };
-  render(PreferencesRenderingItemFormat, {
-    record,
+  await awaitRender(record, {
     enableSlider: true,
-    initialValue: () => getInitialValue(record),
   });
   const input = screen.getByLabelText('record-description');
   expect(input).toBeInTheDocument();
@@ -130,10 +136,7 @@ test('Expect a text input when record is type number and enableSlider is false',
     minimum: 1,
     maximum: 34,
   };
-  render(PreferencesRenderingItemFormat, {
-    record,
-    initialValue: () => getInitialValue(record),
-  });
+  await awaitRender(record, {});
   const input = screen.getByLabelText('record-description');
   expect(input).toBeInTheDocument();
   expect(input instanceof HTMLInputElement).toBe(true);
@@ -150,10 +153,7 @@ test('Expect an input button with Browse as placeholder when record is type stri
     type: 'string',
     format: 'file',
   };
-  render(PreferencesRenderingItemFormat, {
-    record,
-    initialValue: () => getInitialValue(record),
-  });
+  await awaitRender(record, {});
   const readOnlyInput = screen.getByLabelText('record-description');
   expect(readOnlyInput).toBeInTheDocument();
   expect(readOnlyInput instanceof HTMLInputElement).toBe(true);
@@ -172,10 +172,7 @@ test('Expect a select when record is type string and has enum values', async () 
     type: 'string',
     enum: ['first', 'second'],
   };
-  render(PreferencesRenderingItemFormat, {
-    record,
-    initialValue: () => getInitialValue(record),
-  });
+  await awaitRender(record, {});
   const input = screen.getByLabelText('record-description');
   expect(input).toBeInTheDocument();
   expect(input instanceof HTMLSelectElement).toBe(true);
@@ -191,10 +188,7 @@ test('Expect a text input when record is type string', async () => {
     placeholder: 'Example: text',
     type: 'string',
   };
-  render(PreferencesRenderingItemFormat, {
-    record,
-    initialValue: () => getInitialValue(record),
-  });
+  await awaitRender(record, {});
   const input = screen.getByLabelText('record-description');
   expect(input).toBeInTheDocument();
   expect(input instanceof HTMLInputElement).toBe(true);
@@ -213,10 +207,7 @@ test('Expect tooltip text shows info when input is less than minimum', async () 
     minimum: 1,
     maximum: 34,
   };
-  render(PreferencesRenderingItemFormat, {
-    record,
-    initialValue: () => getInitialValue(record),
-  });
+  await awaitRender(record, {});
   const input = screen.getByLabelText('record-description');
   await userEvent.click(input);
   await userEvent.clear(input);
@@ -236,10 +227,7 @@ test('Expect tooltip text shows info when input is empty', async () => {
     minimum: 1,
     maximum: 34,
   };
-  render(PreferencesRenderingItemFormat, {
-    record,
-    initialValue: () => getInitialValue(record),
-  });
+  await awaitRender(record, {});
   const input = screen.getByLabelText('record-description');
   await userEvent.click(input);
   await userEvent.clear(input);

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
@@ -2,10 +2,9 @@
 import { faXmark } from '@fortawesome/free-solid-svg-icons';
 import Fa from 'svelte-fa';
 import type { IConfigurationPropertyRecordedSchema } from '../../../../main/src/plugin/configuration-registry';
-import { CONFIGURATION_DEFAULT_SCOPE } from '../../../../main/src/plugin/configuration-registry-constants';
 import ErrorMessage from '../ui/ErrorMessage.svelte';
 import Markdown from '../markdown/Markdown.svelte';
-import { getNormalizedDefaultNumberValue, isDefaultScope } from './Util';
+import { getNormalizedDefaultNumberValue } from './Util';
 import Tooltip from '../ui/Tooltip.svelte';
 import Button from '../ui/Button.svelte';
 
@@ -20,6 +19,8 @@ export let enableAutoSave = false;
 export let setRecordValue = (_id: string, _value: string) => {};
 export let enableSlider = false;
 export let record: IConfigurationPropertyRecordedSchema;
+
+export let initialValue: any;
 
 let currentRecord: IConfigurationPropertyRecordedSchema;
 let recordUpdateTimeout: NodeJS.Timeout;
@@ -38,21 +39,10 @@ $: if (resetToDefault) {
 }
 
 $: if (currentRecord !== record) {
-  if (isDefaultScope(record.scope)) {
-    if (record.id) {
-      window.getConfigurationValue(record.id, CONFIGURATION_DEFAULT_SCOPE).then(value => {
-        recordValue = value;
-        if (record.type === 'boolean') {
-          recordValue = !!value;
-          checkboxValue = recordValue;
-        }
-      });
-    }
-  } else if (record.default !== undefined) {
-    recordValue = record.type === 'number' ? getNormalizedDefaultNumberValue(record) : record.default;
-    if (record.type === 'boolean') {
-      checkboxValue = recordValue;
-    }
+  recordValue = initialValue;
+  if (record.type === 'boolean') {
+    recordValue = !!initialValue;
+    checkboxValue = recordValue;
   }
 
   currentRecord = record;

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
@@ -20,7 +20,7 @@ export let setRecordValue = (_id: string, _value: string) => {};
 export let enableSlider = false;
 export let record: IConfigurationPropertyRecordedSchema;
 
-export let initialValue: any;
+export let initialValue: () => Promise<any>;
 
 let currentRecord: IConfigurationPropertyRecordedSchema;
 let recordUpdateTimeout: NodeJS.Timeout;
@@ -39,11 +39,13 @@ $: if (resetToDefault) {
 }
 
 $: if (currentRecord !== record) {
-  recordValue = initialValue;
-  if (record.type === 'boolean') {
-    recordValue = !!initialValue;
-    checkboxValue = recordValue;
-  }
+  initialValue().then(value => {
+    recordValue = value;
+    if (record.type === 'boolean') {
+      recordValue = !!value;
+      checkboxValue = recordValue;
+    }
+  });
 
   currentRecord = record;
   invalidText = undefined;

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
@@ -20,7 +20,7 @@ export let setRecordValue = (_id: string, _value: string) => {};
 export let enableSlider = false;
 export let record: IConfigurationPropertyRecordedSchema;
 
-export let initialValue: () => Promise<any>;
+export let initialValue: Promise<any>;
 
 let currentRecord: IConfigurationPropertyRecordedSchema;
 let recordUpdateTimeout: NodeJS.Timeout;
@@ -39,7 +39,7 @@ $: if (resetToDefault) {
 }
 
 $: if (currentRecord !== record) {
-  initialValue().then(value => {
+  initialValue.then(value => {
     recordValue = value;
     if (record.type === 'boolean') {
       recordValue = !!value;

--- a/packages/renderer/src/lib/preferences/Util.ts
+++ b/packages/renderer/src/lib/preferences/Util.ts
@@ -100,6 +100,20 @@ export function isDefaultScope(scope?: ConfigurationScope | ConfigurationScope[]
   return isTargetScope(CONFIGURATION_DEFAULT_SCOPE, scope);
 }
 
+export async function getInitialValue(property: IConfigurationPropertyRecordedSchema): Promise<any> {
+  if (isDefaultScope(property.scope)) {
+    if (property.id) {
+      let value = await window.getConfigurationValue(property.id, CONFIGURATION_DEFAULT_SCOPE);
+      if (property.type === 'boolean') {
+        value = !!value;
+      }
+      return value;
+    }
+  } else if (property.default !== undefined) {
+    return property.type === 'number' ? getNormalizedDefaultNumberValue(property) : property.default;
+  }
+}
+
 export function isTargetScope(
   targetScope: ConfigurationScope,
   scope?: ConfigurationScope | ConfigurationScope[],

--- a/packages/renderer/src/lib/preferences/Util.ts
+++ b/packages/renderer/src/lib/preferences/Util.ts
@@ -111,6 +111,10 @@ export async function getInitialValue(property: IConfigurationPropertyRecordedSc
     }
   } else if (property.default !== undefined) {
     return property.type === 'number' ? getNormalizedDefaultNumberValue(property) : property.default;
+  } else if (property.type === 'string') {
+    return '';
+  } else if (property.type === 'number') {
+    return 0;
   }
 }
 


### PR DESCRIPTION
### What does this PR do?

While preparing #4113 I noticed there was already a form to edit machine properties (the one used when creating a machine) but as the scope is different a sub component (PreferencesRenderingItemFormat) was retrieving the value with code embedded into the component. This refactoring just extract value retrieval outside of the component

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Check tests
