### PR TITLE
fix: show error and stop spinner if podman initialization fail (#4304)

### DIFF
--- a/extensions/podman/src/extension.spec.ts
+++ b/extensions/podman/src/extension.spec.ts
@@ -334,6 +334,27 @@ test('verify create command called with now flag if start machine after creation
   expect(console.error).not.toBeCalled();
 });
 
+test('verify error contains name, message and stderr if creation fails', async () => {
+  vi.spyOn(extensionApi.process, 'exec').mockRejectedValue({
+    name: 'name',
+    message: 'description',
+    stderr: 'error',
+  });
+  await expect(
+    extension.createMachine(
+      {
+        'podman.factory.machine.cpus': '2',
+        'podman.factory.machine.image-path': 'path',
+        'podman.factory.machine.memory': '1048000000',
+        'podman.factory.machine.diskSize': '250000000000',
+        'podman.factory.machine.now': true,
+      },
+      undefined,
+      undefined,
+    ),
+  ).rejects.toThrowError('name\ndescription\nerror\n');
+});
+
 test('test checkDefaultMachine, if the machine running is not default, the function will prompt', async () => {
   await extension.checkDefaultMachine(fakeMachineJSON);
 

--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -1354,7 +1354,11 @@ export async function createMachine(
     } else if (error.stderr?.includes('only one VM can be active at a time')) {
       telemetryRecords.errorCode = 'ErrMultipleActiveVM';
     }
-    throw error;
+
+    let errorMessage = error.name ? `${error.name}\n` : '';
+    errorMessage += error.message ? `${error.message}\n` : '';
+    errorMessage += error.stderr ? `${error.stderr}\n` : '';
+    throw errorMessage || error;
   } finally {
     const endTime = performance.now();
     telemetryRecords.duration = endTime - startTime;

--- a/packages/renderer/src/lib/dashboard/ProviderInitUtils.ts
+++ b/packages/renderer/src/lib/dashboard/ProviderInitUtils.ts
@@ -28,6 +28,7 @@ export type InitializationMode = typeof DoNothingMode | typeof InitializeOnlyMod
 export interface InitializationContext {
   mode: InitializationMode;
   promise?: Promise<ProviderDetectionCheck[]>;
+  error?: string;
 }
 
 export const InitializationSteps = [

--- a/packages/renderer/src/lib/dashboard/ProviderInstalled.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderInstalled.svelte
@@ -45,13 +45,19 @@ let installationOptionSelected = InitializeAndStartMode;
 $: initializationButtonVisible =
   provider.containerProviderConnectionInitialization || provider.kubernetesProviderConnectionInitialization;
 
+function showLastExecutionError() {
+  initializeError = initializationContext.error;
+  logsTerminal?.write('Initialization failed. Please check the error below and try again' + '\r\n');
+  logsTerminal?.write(initializeError + '\r');
+}
+
 async function initializeProvider() {
   initializeError = undefined;
   logsTerminal.clear();
   initializeInProgress = true;
   initializationContext.promise = window.initializeProvider(provider.internalId);
   initializationContext.promise.catch((error: unknown) => {
-    initializeError = String(error);
+    initializationContext.error = String(error);
     initializationButtonVisible = true;
     logsTerminal.write(error + '\r');
     console.error('Error while initializing the provider', error);
@@ -98,7 +104,9 @@ async function refreshTerminal() {
 
 onMount(async () => {
   // Refresh the terminal on initial load
-  refreshTerminal();
+  await refreshTerminal();
+  // show error if last execution failed
+  showLastExecutionError();
 
   // Resize the terminal each time we change the div size
   resizeObserver = new ResizeObserver(() => {


### PR DESCRIPTION
### What does this PR do?

This PR fixes how the dashboard components are rendered during the initialization process.

Before: the provider is not installed -> ProviderInstalled.svelte -> user click on `Initialize` button -> provider status updated to 'configuring' -> ProviderConfiguring.svelte -> the user see the spinner -> if an error is thrown nothing is displayed and the spinner is still on

this PR: the provider is not installed -> ProviderInstalled.svelte -> user click on `Initialize` button -> provider status updated to 'configuring' -> ProviderConfiguring.svelte -> the user see the spinner -> if an error occurred the status is reset to 'installed' -> ProviderInstalled.svelte -> the user see the `Initialize` button again and the error of last execution 

### Screenshot/screencast of this PR

![initialize_podman](https://github.com/containers/podman-desktop/assets/49404737/72687b04-d20c-4ec6-8c1a-29ce8a3b3d05)

### What issues does this PR fix or reference?

it resolves #4304 

### How to test this PR?

1. have everything installed to make podman works but no podman machine
2. disable virtual machine platform feature
3. start Desktop, click on initializing
4. eventually you should see the 'Initialize' button again and the terminal with the error
