### PR TITLE
fix: make create component visible with new header (#4312)

### DIFF
--- a/packages/renderer/src/lib/onboarding/Onboarding.svelte
+++ b/packages/renderer/src/lib/onboarding/Onboarding.svelte
@@ -339,7 +339,7 @@ async function restartSetup() {
         </div>
       </div>
       {#if activeStep.step.component}
-        <div class="min-w-[700px] mx-auto mt-5" aria-label="onboarding component">
+        <div class="min-w-[700px] mx-auto mt-32" aria-label="onboarding component">
           <OnboardingComponent
             component="{activeStep.step.component}"
             extensionId="{activeStep.onboarding.extension}" />


### PR DESCRIPTION
### What does this PR do?

This PR just adds a margin to the embedded component to work with the new fixed header

### Screenshot/screencast of this PR

![image](https://github.com/containers/podman-desktop/assets/49404737/dc635fbf-72ce-4975-83a9-7cc80f652d2a)

### What issues does this PR fix or reference?

it resolves #4312 

### How to test this PR?

1. go through the onboarding
