### PR TITLE
feat: provider creation form

### DIFF
--- a/packages/renderer/src/lib/onboarding/OnboardingComponent.spec.ts
+++ b/packages/renderer/src/lib/onboarding/OnboardingComponent.spec.ts
@@ -93,7 +93,7 @@ test('Expect to find PreferencesConnectionCreationRendering component if step in
   });
 
   const title = screen.getAllByRole('heading', { name: 'title' });
-  expect(title[0].textContent).equal('Create a Podman machine ');
+  expect(title[0].textContent).equal('Create a Podman machine');
 });
 
 test('Expect to find "not supported" message if step includes a component not supported by the provider', async () => {

--- a/packages/renderer/src/lib/onboarding/OnboardingComponent.svelte
+++ b/packages/renderer/src/lib/onboarding/OnboardingComponent.svelte
@@ -18,6 +18,14 @@ let providers: ProviderInfo[];
 let providerInfo: ProviderInfo | undefined;
 $: providerInfo;
 
+let providerDisplayName: string;
+$: providerDisplayName =
+  (providerInfo?.containerProviderConnectionCreation
+    ? providerInfo?.containerProviderConnectionCreationDisplayName || undefined
+    : providerInfo?.kubernetesProviderConnectionCreation
+    ? providerInfo?.kubernetesProviderConnectionCreationDisplayName
+    : undefined) || providerInfo?.name;
+
 onMount(() => {
   configurationProperties.subscribe(value => {
     configurationItems = value;
@@ -31,6 +39,9 @@ onMount(() => {
 </script>
 
 {#if providerInfo && configurationItems}
+  <h1 class="font-semibold px-6 pb-2" aria-label="title">
+    Create a {providerDisplayName}
+  </h1>
   {#if component === 'createContainerProviderConnection' && providerInfo?.containerProviderConnectionCreation === true}
     <PreferencesConnectionCreationRendering
       providerInfo="{providerInfo}"
@@ -38,7 +49,6 @@ onMount(() => {
       propertyScope="ContainerProviderConnectionFactory"
       callback="{window.createContainerProviderConnection}"
       disableEmptyScreen="{true}"
-      hideProviderImage="{true}"
       hideCloseButton="{true}" />
   {:else if component === 'createKubernetesProviderConnection' && providerInfo?.kubernetesProviderConnectionCreation === true}
     <PreferencesConnectionCreationRendering
@@ -47,7 +57,6 @@ onMount(() => {
       propertyScope="KubernetesProviderConnectionFactory"
       callback="{window.createKubernetesProviderConnection}"
       disableEmptyScreen="{true}"
-      hideProviderImage="{true}"
       hideCloseButton="{true}" />
   {:else}
     <div aria-label="not supported warning" class="flex flex-row min-h-[500px] items-center justify-center">

--- a/packages/renderer/src/lib/onboarding/OnboardingComponent.svelte
+++ b/packages/renderer/src/lib/onboarding/OnboardingComponent.svelte
@@ -18,7 +18,7 @@ let providers: ProviderInfo[];
 let providerInfo: ProviderInfo | undefined;
 $: providerInfo;
 
-let providerDisplayName: string;
+let providerDisplayName: string | undefined;
 $: providerDisplayName =
   (providerInfo?.containerProviderConnectionCreation
     ? providerInfo?.containerProviderConnectionCreationDisplayName || undefined

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationRendering.svelte
@@ -45,7 +45,6 @@ export let callback: (
 ) => Promise<void>;
 export let taskId: number | undefined = undefined;
 export let disableEmptyScreen = false;
-export let hideProviderImage = false;
 export let hideCloseButton = false;
 
 $: configurationValues = new Map<string, string>();
@@ -362,23 +361,6 @@ function closePage() {
       </Button>
     </EmptyScreen>
   {:else}
-    {#if !hideProviderImage}
-      <div class="my-2 px-6" aria-label="main image">
-        {#if providerInfo?.images?.icon}
-          {#if typeof providerInfo.images.icon === 'string'}
-            <img src="{providerInfo.images.icon}" alt="{providerInfo.name}" class="max-h-10" />
-            <!-- TODO check theme used for image, now use dark by default -->
-          {:else}
-            <img src="{providerInfo.images.icon.dark}" alt="{providerInfo.name}" class="max-h-10" />
-          {/if}
-        {/if}
-      </div>
-    {/if}
-    <h1 class="font-semibold px-6 pb-2" aria-label="title">
-      {creationInProgress ? 'Creating' : 'Create a'}
-      {providerDisplayName}
-      {creationInProgress ? '...' : ''}
-    </h1>
     <div class="flex flex-col px-6 w-full h-full overflow-auto">
       {#if pageIsLoading}
         <div class="text-center mt-16 p-2" role="status">

--- a/packages/renderer/src/lib/preferences/PreferencesPage.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesPage.svelte
@@ -54,7 +54,7 @@ onMount(async () => {
   <Route path="/extension/:extensionId/*" breadcrumb="Extensions" let:meta>
     <PreferencesExtensionRendering extensionId="{meta.params.extensionId}" />
   </Route>
-  <Route path="/provider/:providerInternalId/*" breadcrumb="Resources" let:meta>
+  <Route path="/provider/:providerInternalId/*" breadcrumb="Resources" let:meta navigationHint="details">
     <PreferencesProviderRendering providerInternalId="{meta.params.providerInternalId}" properties="{properties}" />
   </Route>
   <Route path="/provider-task/:providerInternalId/:taskId/*" breadcrumb="Resources" let:meta>


### PR DESCRIPTION
### What does this PR do?

Creating an instance of a Podman Machine or Kubernetes provider had a UI that didn't quite match other places. Switching it to be a FormPage aligns the look and feel with the rest of our UI (header, breadcrumbs, etc.) and fixes things that we've already solved once in all the form pages, e.g. clicking Esc to close (#2853).

Since this page was done a while ago there was some minor restructuring to make this happen:
- The Resources page has to be marked as a details navigation hint so that the backlink/close button goes back to the correct page.
- The code to find the provider display name and image (the header info) is moved up from the connection creation page to the provider rendering form.
- This makes the provider image 'always hidden' on the component, so the property could be removed.

### Screenshot/screencast of this PR

Before:

<img width="763" alt="Screenshot 2023-10-12 at 2 05 53 PM" src="https://github.com/containers/podman-desktop/assets/19958075/0c261a17-3edb-4f6b-aa3f-fdc614b1a825">

<img width="763" alt="Screenshot 2023-10-12 at 2 11 54 PM" src="https://github.com/containers/podman-desktop/assets/19958075/8cbe1521-21d7-4f37-b1be-bc7f407ee2eb">

After:

<img width="621" alt="Screenshot 2023-10-12 at 1 56 15 PM" src="https://github.com/containers/podman-desktop/assets/19958075/fe89f3bc-e5b8-4735-96e9-669fe52c7a41">

Onboarding unchanged.

### What issues does this PR fix or reference?

Fixes #2853.

### How to test this PR?

Create a Podman machine or Kubernetes provider.