### PR TITLE
fix: do not register the same registry twice

### DIFF
--- a/packages/main/src/plugin/image-registry.ts
+++ b/packages/main/src/plugin/image-registry.ts
@@ -142,6 +142,15 @@ export class ImageRegistry {
   }
 
   registerRegistry(registry: containerDesktopAPI.Registry): Disposable {
+    const found = this.registries.find(
+      reg =>
+        reg.source === registry.source && reg.serverUrl === registry.serverUrl && reg.username === registry.username,
+    );
+    if (found) {
+      // Ignore and don't register - extension may register registries every time it is restarted
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      return Disposable.create(() => {});
+    }
     this.registries = [...this.registries, registry];
     this.telemetryService.track('registerRegistry', {
       serverUrl: this.getRegistryHash(registry),

--- a/packages/main/src/plugin/image-registry.ts
+++ b/packages/main/src/plugin/image-registry.ts
@@ -148,8 +148,8 @@ export class ImageRegistry {
     );
     if (found) {
       // Ignore and don't register - extension may register registries every time it is restarted
-      // eslint-disable-next-line @typescript-eslint/no-empty-function
-      return Disposable.create(() => {});
+      console.log('Registry already registered, skipping registration');
+      return Disposable.noop();
     }
     this.registries = [...this.registries, registry];
     this.telemetryService.track('registerRegistry', {
@@ -169,9 +169,7 @@ export class ImageRegistry {
     if (this.suggestedRegistries.find(reg => reg.url === registry.url && reg.name === registry.name)) {
       // Ignore and don't register
       console.log(`Registry already registered: ${registry.url}`);
-
-      // eslint-disable-next-line @typescript-eslint/no-empty-function
-      return Disposable.create(() => {});
+      return Disposable.noop();
     }
 
     this.suggestedRegistries.push(registry);

--- a/packages/main/src/plugin/types/disposable.ts
+++ b/packages/main/src/plugin/types/disposable.ts
@@ -52,4 +52,8 @@ export class Disposable implements IDisposable {
   static create(func: () => void): Disposable {
     return new Disposable(func);
   }
+
+  static noop(): Disposable {
+    return Disposable.from();
+  }
 }


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

This PR checks that a Registry is not already registered by a source before to register it.

This is useful as the podman extension (at least) re-registers registries every time it is enabled again.

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast 
explaining what is doing this PR -->

### What issues does this PR fix or reference?

Fixes #3908 

### How to test this PR?

- Have podman installed (might not be necessary)
- Insert new registry
- Extensions -> Podman - disable, enable
- Check registries: they should not be duplicated

<!-- Please explain steps to reproduce -->
