### PR TITLE
fix: breadcrumb history

### DIFF
--- a/packages/renderer/src/Route.svelte
+++ b/packages/renderer/src/Route.svelte
@@ -2,7 +2,7 @@
 import { createRouteObject } from 'tinro/dist/tinro_lib';
 import type { TinroBreadcrumb, TinroRouteMeta } from 'tinro';
 import { TelemetryService } from './TelemetryService';
-import { lastPage, currentPage, listPage, detailsPage } from './stores/breadcrumb';
+import { lastPage, currentPage, history } from './stores/breadcrumb';
 import type { NavigationHint } from './Route';
 import { onDestroy } from 'svelte';
 
@@ -38,23 +38,23 @@ function processMetaBreadcrumbs(breadcrumbs?: Array<TinroBreadcrumb>) {
     if (!curPage) return;
 
     if (navigationHint === 'root') {
-      listPage.set(curPage);
-      detailsPage.set({ name: 'Home', path: '/' });
+      history.set([curPage]);
     } else if (navigationHint === 'details') {
-      detailsPage.set(curPage);
-      lastPage.set($listPage);
+      history.set([$history[0], curPage]);
+      lastPage.set($history[0]);
     } else if (navigationHint === 'tab') {
       // if we're on a details tab, fix the breadcrumb to come back to this tab
       const path = curPage.path.substring(0, curPage.path.lastIndexOf('/'));
-      if ($detailsPage?.path.startsWith(path)) {
-        $detailsPage.path = curPage.path;
+      const last = $history[$history.length - 1];
+      if (last?.path.startsWith(path)) {
+        last.path = curPage.path;
       } else {
         // otherwise, set the last page normally
-        lastPage.set($detailsPage ? $detailsPage : $listPage);
+        lastPage.set(last);
       }
     } else {
-      // set the last page to either details or list page
-      lastPage.set($detailsPage ? $detailsPage : $listPage);
+      // set the last page from the history
+      lastPage.set($history[$history.length - 1]);
     }
 
     // set the current page to this route, unless we're on a tab

--- a/packages/renderer/src/lib/compose/ComposeDetails.spec.ts
+++ b/packages/renderer/src/lib/compose/ComposeDetails.spec.ts
@@ -2,7 +2,7 @@ import '@testing-library/jest-dom/vitest';
 import { test, expect, vi, beforeAll } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/svelte';
 import ComposeDetails from './ComposeDetails.svelte';
-import { mockBreadcrumb } from '../../stores/breadcrumb';
+import { mockBreadcrumb } from '../../stores/breadcrumb.spec';
 import type { ContainerInspectInfo } from '@podman-desktop/api';
 import { containersInfos } from '../../stores/containers';
 import { providerInfos } from '../../stores/providers';

--- a/packages/renderer/src/lib/compose/ComposeDetailsLogs.spec.ts
+++ b/packages/renderer/src/lib/compose/ComposeDetailsLogs.spec.ts
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom/vitest';
 import { beforeAll, expect, test, vi } from 'vitest';
 import { render, screen } from '@testing-library/svelte';
-import { mockBreadcrumb } from '../../stores/breadcrumb';
+import { mockBreadcrumb } from '../../stores/breadcrumb.spec';
 import ComposeDetailsLogs from './ComposeDetailsLogs.svelte';
 import type { ComposeInfoUI } from './ComposeInfoUI';
 import { ContainerGroupInfoTypeUI, type ContainerInfoUI } from '../container/ContainerInfoUI';

--- a/packages/renderer/src/lib/image/RunImage.spec.ts
+++ b/packages/renderer/src/lib/image/RunImage.spec.ts
@@ -24,7 +24,7 @@ import { fireEvent, render, screen } from '@testing-library/svelte';
 import { runImageInfo } from '../../stores/run-image-store';
 import RunImage from '/@/lib/image/RunImage.svelte';
 import type { ImageInspectInfo } from '../../../../main/src/plugin/api/image-inspect-info';
-import { mockBreadcrumb } from '../../stores/breadcrumb';
+import { mockBreadcrumb } from '../../stores/breadcrumb.spec';
 import userEvent from '@testing-library/user-event';
 import { router } from 'tinro';
 

--- a/packages/renderer/src/stores/breadcrumb.spec.ts
+++ b/packages/renderer/src/stores/breadcrumb.spec.ts
@@ -1,0 +1,8 @@
+import type { TinroBreadcrumb } from 'tinro';
+import { lastPage, currentPage, history } from './breadcrumb';
+
+export function mockBreadcrumb() {
+  history.set([{ name: 'List', path: '/list' } as TinroBreadcrumb]);
+  lastPage.set({ name: 'Previous', path: '/last' } as TinroBreadcrumb);
+  currentPage.set({ name: 'Current', path: '/current' } as TinroBreadcrumb);
+}

--- a/packages/renderer/src/stores/breadcrumb.spec.ts
+++ b/packages/renderer/src/stores/breadcrumb.spec.ts
@@ -1,8 +1,41 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
 import type { TinroBreadcrumb } from 'tinro';
 import { lastPage, currentPage, history } from './breadcrumb';
+import { test, expect } from 'vitest';
+import { get } from 'svelte/store';
 
 export function mockBreadcrumb() {
   history.set([{ name: 'List', path: '/list' } as TinroBreadcrumb]);
   lastPage.set({ name: 'Previous', path: '/last' } as TinroBreadcrumb);
   currentPage.set({ name: 'Current', path: '/current' } as TinroBreadcrumb);
 }
+
+test('Confirm mock values', async () => {
+  mockBreadcrumb();
+
+  const cur = get(lastPage);
+  expect(cur.name, 'Current');
+
+  const last = get(lastPage);
+  expect(last.name, 'Previous');
+
+  const hist = get(history);
+  expect(hist[0].name, 'List');
+});

--- a/packages/renderer/src/stores/breadcrumb.ts
+++ b/packages/renderer/src/stores/breadcrumb.ts
@@ -24,11 +24,4 @@ const home = { name: 'Home', path: '/' } as TinroBreadcrumb;
 export const currentPage: Writable<TinroBreadcrumb> = writable(home);
 export const lastPage: Writable<TinroBreadcrumb> = writable(home);
 
-export const listPage: Writable<TinroBreadcrumb> = writable(home);
-export const detailsPage: Writable<TinroBreadcrumb> = writable(home);
-
-export function mockBreadcrumb() {
-  listPage.set({ name: 'List', path: '/list' } as TinroBreadcrumb);
-  lastPage.set({ name: 'Previous', path: '/last' } as TinroBreadcrumb);
-  currentPage.set({ name: 'Current', path: '/current' } as TinroBreadcrumb);
-}
+export const history: Writable<TinroBreadcrumb[]> = writable([home]);


### PR DESCRIPTION
### What does this PR do?

Breadcrumb history is going back to Home incorrectly in some cases because after PR #3679 the detailsPage does not get cleared.

Instead of just clearing the details page, I'm replacing list page + details page with a history array. This is more generic code, a more common pattern, more easily extendable if our needs change, and less likely to be broken by other changes. I probably should have done this originally, but at that point I was trying to keep it simple and didn't foresee us using history in Settings.

While I was at it I moved mockBreadcrumb() out of the .ts as promised a while ago in https://github.com/containers/podman-desktop/pull/3388#pullrequestreview-1558267032

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

Fixes #4288.

### How to test this PR?

Check that the breadcrumb correctly lists the previous page and works when going to the lists, details pages, forms from either, and in Settings > Resources for both machine creation and machine details.