### PR TITLE
feat: adding optional abort controller to dockerode api

### DIFF
--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -1003,7 +1003,6 @@ export class ContainerProviderRegistry {
       if (engine) {
         await this.attachToContainer(engine, container);
       }
-      // see https://github.com/containers/podman-desktop/issues/4363
       return container.start({ abortSignal: abortController?.signal } as unknown as Dockerode.ContainerStartOptions);
     } catch (error) {
       telemetryOptions = { error: error };

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -272,7 +272,7 @@ export class ContainerProviderRegistry {
   }
 
   // do not use inspect information
-  async listSimpleContainers(): Promise<SimpleContainerInfo[]> {
+  async listSimpleContainers(abortController?: AbortController): Promise<SimpleContainerInfo[]> {
     let telemetryOptions = {};
     const containers = await Promise.all(
       Array.from(this.internalProviders.values()).map(async provider => {
@@ -282,7 +282,7 @@ export class ContainerProviderRegistry {
             return [];
           }
 
-          const containers = await providerApi.listContainers({ all: true });
+          const containers = await providerApi.listContainers({ all: true, abortSignal: abortController?.signal });
           return Promise.all(
             containers.map(async container => {
               const containerInfo: SimpleContainerInfo = {
@@ -311,9 +311,13 @@ export class ContainerProviderRegistry {
   }
 
   // listSimpleContainers by matching label and key
-  async listSimpleContainersByLabel(label: string, key: string): Promise<SimpleContainerInfo[]> {
+  async listSimpleContainersByLabel(
+    label: string,
+    key: string,
+    abortController?: AbortController,
+  ): Promise<SimpleContainerInfo[]> {
     // Get all the containers using listSimpleContainers
-    const containers = await this.listSimpleContainers();
+    const containers = await this.listSimpleContainers(abortController);
 
     // Find all the containers that match the label + key
     return containers.filter(container => {
@@ -800,10 +804,10 @@ export class ContainerProviderRegistry {
     return this.getMatchingEngine(engineId).getImage(imageId);
   }
 
-  async stopContainer(engineId: string, id: string): Promise<void> {
+  async stopContainer(engineId: string, id: string, abortController?: AbortController): Promise<void> {
     let telemetryOptions = {};
     try {
-      return this.getMatchingContainer(engineId, id).stop();
+      return this.getMatchingContainer(engineId, id).stop({ abortSignal: abortController?.signal });
     } catch (error) {
       telemetryOptions = { error: error };
       throw error;
@@ -856,13 +860,17 @@ export class ContainerProviderRegistry {
     imageTag: string,
     callback: (name: string, data: string) => void,
     authInfo?: containerDesktopAPI.ContainerAuthInfo,
+    abortController?: AbortController,
   ): Promise<void> {
     let telemetryOptions = {};
     try {
       const engine = this.getMatchingEngine(engineId);
       const image = engine.getImage(imageTag);
       const authconfig = authInfo || this.imageRegistry.getAuthconfigForImage(imageTag);
-      const pushStream = await image.push({ authconfig });
+      const pushStream = await image.push({
+        authconfig,
+        abortSignal: abortController?.signal,
+      });
       pushStream.on('end', () => {
         callback('end', '');
       });
@@ -890,6 +898,7 @@ export class ContainerProviderRegistry {
     providerContainerConnectionInfo: ProviderContainerConnectionInfo | containerDesktopAPI.ContainerProviderConnection,
     imageName: string,
     callback: (event: PullEvent) => void,
+    abortController?: AbortController,
   ): Promise<void> {
     let telemetryOptions = {};
     try {
@@ -897,6 +906,7 @@ export class ContainerProviderRegistry {
       const matchingEngine = this.getMatchingEngineFromConnection(providerContainerConnectionInfo);
       const pullStream = await matchingEngine.pull(imageName, {
         authconfig,
+        abortSignal: abortController?.signal,
       });
       // eslint-disable-next-line @typescript-eslint/ban-types
       let resolve: () => void;
@@ -971,11 +981,11 @@ export class ContainerProviderRegistry {
     }
   }
 
-  async deleteContainer(engineId: string, id: string): Promise<void> {
+  async deleteContainer(engineId: string, id: string, abortController?: AbortController): Promise<void> {
     let telemetryOptions = {};
     try {
       // use force to delete it even it is running
-      return this.getMatchingContainer(engineId, id).remove({ force: true });
+      return this.getMatchingContainer(engineId, id).remove({ force: true, abortSignal: abortController?.signal });
     } catch (error) {
       telemetryOptions = { error: error };
       throw error;
@@ -984,7 +994,7 @@ export class ContainerProviderRegistry {
     }
   }
 
-  async startContainer(engineId: string, id: string): Promise<void> {
+  async startContainer(engineId: string, id: string, abortController?: AbortController): Promise<void> {
     let telemetryOptions = {};
     try {
       const engine = this.internalProviders.get(engineId);
@@ -993,8 +1003,8 @@ export class ContainerProviderRegistry {
       if (engine) {
         await this.attachToContainer(engine, container);
       }
-
-      return container.start();
+      // see https://github.com/containers/podman-desktop/issues/4363
+      return container.start({ abortSignal: abortController?.signal } as unknown as Dockerode.ContainerStartOptions);
     } catch (error) {
       telemetryOptions = { error: error };
       throw error;
@@ -1166,7 +1176,7 @@ export class ContainerProviderRegistry {
     }
   }
 
-  async restartContainer(engineId: string, id: string): Promise<void> {
+  async restartContainer(engineId: string, id: string, abortController?: AbortController): Promise<void> {
     let telemetryOptions = {};
     try {
       const engine = this.internalProviders.get(engineId);
@@ -1176,7 +1186,7 @@ export class ContainerProviderRegistry {
         await this.attachToContainer(engine, container);
       }
 
-      return container.restart();
+      return container.restart({ abortSignal: abortController?.signal });
     } catch (error) {
       telemetryOptions = { error: error };
       throw error;
@@ -1188,11 +1198,16 @@ export class ContainerProviderRegistry {
   // Find all containers that match the against the given project name to
   // the label com.docker.compose.project (for example)
   // and then restart all the containers that have the following label AND key
-  async restartContainersByLabel(engineId: string, label: string, key: string): Promise<void> {
+  async restartContainersByLabel(
+    engineId: string,
+    label: string,
+    key: string,
+    abortController?: AbortController,
+  ): Promise<void> {
     let telemetryOptions = {};
     try {
       // Get all the containers using listSimpleContainers
-      const containers = await this.listSimpleContainers();
+      const containers = await this.listSimpleContainers(abortController);
 
       // Find all the containers that are using projectLabel and match the projectName
       const containersMatchingProject = containers.filter(container => {
@@ -1239,7 +1254,12 @@ export class ContainerProviderRegistry {
   }
 
   // Stop containers that match a label + key
-  async stopContainersByLabel(engineId: string, label: string, key: string): Promise<void> {
+  async stopContainersByLabel(
+    engineId: string,
+    label: string,
+    key: string,
+    abortController?: AbortController,
+  ): Promise<void> {
     let telemetryOptions = {};
     try {
       // Get all the containers using listSimpleContainers
@@ -1254,7 +1274,7 @@ export class ContainerProviderRegistry {
       const containerIds = containersMatchingProject.map(container => container.Id);
 
       // Stop all the containers
-      await Promise.all(containerIds.map(containerId => this.stopContainer(engineId, containerId)));
+      await Promise.all(containerIds.map(containerId => this.stopContainer(engineId, containerId, abortController)));
     } catch (error) {
       telemetryOptions = { error: error };
       throw error;
@@ -1264,7 +1284,12 @@ export class ContainerProviderRegistry {
   }
 
   // Delete all containers that match a certain label and key
-  async deleteContainersByLabel(engineId: string, label: string, key: string): Promise<void> {
+  async deleteContainersByLabel(
+    engineId: string,
+    label: string,
+    key: string,
+    abortController?: AbortController,
+  ): Promise<void> {
     let telemetryOptions = {};
     try {
       // Get all the containers using listSimpleContainers
@@ -1277,7 +1302,7 @@ export class ContainerProviderRegistry {
       const containerIds = containersMatchingProject.map(container => container.Id);
 
       // Delete all the containers in containerIds
-      await Promise.all(containerIds.map(containerId => this.deleteContainer(engineId, containerId)));
+      await Promise.all(containerIds.map(containerId => this.deleteContainer(engineId, containerId, abortController)));
     } catch (error) {
       telemetryOptions = { error: error };
       throw error;
@@ -1286,7 +1311,12 @@ export class ContainerProviderRegistry {
     }
   }
 
-  async logsContainer(engineId: string, id: string, callback: (name: string, data: string) => void): Promise<void> {
+  async logsContainer(
+    engineId: string,
+    id: string,
+    callback: (name: string, data: string) => void,
+    abortController?: AbortController,
+  ): Promise<void> {
     let telemetryOptions = {};
     let firstMessage = true;
     const container = this.getMatchingContainer(engineId, id);
@@ -1295,6 +1325,7 @@ export class ContainerProviderRegistry {
         follow: true,
         stdout: true,
         stderr: true,
+        abortSignal: abortController?.signal,
       })
       .then(containerStream => {
         containerStream.on('end', () => {
@@ -1321,6 +1352,7 @@ export class ContainerProviderRegistry {
     command: string[],
     onStdout: (data: Buffer) => void,
     onStderr: (data: Buffer) => void,
+    abortController?: AbortController,
   ): Promise<void> {
     const container = this.getMatchingContainer(engineId, id);
 
@@ -1332,7 +1364,7 @@ export class ContainerProviderRegistry {
       Tty: false,
     });
 
-    const execStream = await exec.start({ hijack: true, stdin: false });
+    const execStream = await exec.start({ hijack: true, stdin: false, abortSignal: abortController?.signal });
 
     const wrappedAsStream = (redirect: (data: Buffer) => void): Writable => {
       return new Writable({
@@ -1851,6 +1883,7 @@ export class ContainerProviderRegistry {
     imageName: string,
     selectedProvider: ProviderContainerConnectionInfo,
     eventCollect: (eventName: 'stream' | 'error' | 'finish', data: string) => void,
+    abortController?: AbortController,
   ): Promise<unknown> {
     let telemetryOptions = {};
     try {
@@ -1882,6 +1915,7 @@ export class ContainerProviderRegistry {
           registryconfig,
           dockerfile: relativeContainerfilePath,
           t: imageName,
+          abortSignal: abortController?.signal,
         })) as unknown as Stream;
       } catch (error: unknown) {
         console.log('error in buildImage', error);


### PR DESCRIPTION
Related: https://github.com/containers/podman-desktop/issues/4363

### What does this PR do?

Adding optional AbortController argument to functions with potentially long duration 
