### PR TITLE
feat: making task cancellable

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -708,12 +708,9 @@ declare module '@podman-desktop/api' {
     title?: string;
 
     /**
-     * Controls if a cancel button should show to allow the user to
-     * cancel the long running operation.  Note that currently only
-     * `ProgressLocation.Notification` is supporting to show a cancel
-     * button.
+     * Correspond to a cancel token that can be used to cancel the task
      */
-    cancellable?: boolean;
+    cancellableTokenId?: number;
   }
 
   /**

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -1494,7 +1494,7 @@ declare module '@podman-desktop/api' {
 
     export function withProgress<R>(
       options: ProgressOptions,
-      task: (progress: Progress<{ message?: string; increment?: number }>, token: CancellationToken) => Promise<R>,
+      task: (progress: Progress<{ message?: string; increment?: number }>, token?: CancellationToken) => Promise<R>,
     ): Promise<R>;
 
     /**

--- a/packages/main/src/plugin/api/task.ts
+++ b/packages/main/src/plugin/api/task.ts
@@ -23,6 +23,7 @@ export interface Task {
   id: string;
   name: string;
   started: number;
+  cancellationTokenCallbackId?: number;
 }
 
 export interface StatefulTask extends Task {
@@ -31,7 +32,6 @@ export interface StatefulTask extends Task {
   progress?: number;
   gotoTask?: () => void;
   error?: string;
-  cancellationTokenCallbackId?: number;
 }
 
 export interface NotificationTask extends Task {

--- a/packages/main/src/plugin/api/task.ts
+++ b/packages/main/src/plugin/api/task.ts
@@ -17,7 +17,7 @@
  ***********************************************************************/
 
 export type TaskState = 'running' | 'completed';
-type TaskStatus = 'in-progress' | 'success' | 'failure';
+type TaskStatus = 'in-progress' | 'success' | 'failure' | 'cancelled';
 
 export interface Task {
   id: string;
@@ -31,6 +31,7 @@ export interface StatefulTask extends Task {
   progress?: number;
   gotoTask?: () => void;
   error?: string;
+  cancellationTokenCallbackId?: number;
 }
 
 export interface NotificationTask extends Task {

--- a/packages/main/src/plugin/api/task.ts
+++ b/packages/main/src/plugin/api/task.ts
@@ -23,7 +23,7 @@ export interface Task {
   id: string;
   name: string;
   started: number;
-  cancellationTokenCallbackId?: number;
+  cancellableTokenId?: number;
 }
 
 export interface StatefulTask extends Task {

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -823,7 +823,7 @@ export class ExtensionLoader {
         options: containerDesktopAPI.ProgressOptions,
         task: (
           progress: containerDesktopAPI.Progress<{ message?: string; increment?: number }>,
-          token: containerDesktopAPI.CancellationToken,
+          token?: containerDesktopAPI.CancellationToken,
         ) => Promise<R>,
       ): Promise<R> => {
         return progress.withProgress(options, task);

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -761,7 +761,7 @@ export class PluginSystem {
       apiSender,
       trayMenuRegistry,
       messageBox,
-      new ProgressImpl(taskManager),
+      new ProgressImpl(taskManager, cancellationTokenRegistry),
       statusBarRegistry,
       kubernetesClient,
       fileSystemMonitoring,

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -2242,12 +2242,7 @@ export class PluginSystem {
         // We cancel it
         tokenSource.cancel();
         // Update the task accordinaly
-        if (taskManager.isStatefulTask(task)) {
-          task.state = 'completed';
-          task.status = 'cancelled';
-          task.error = 'task cancelled';
-        }
-        taskManager.updateTask(task);
+        this.cancelTask(taskManager, task);
       }
     });
 

--- a/packages/main/src/plugin/progress-impl.spec.ts
+++ b/packages/main/src/plugin/progress-impl.spec.ts
@@ -122,6 +122,25 @@ test('Should create a task and propagate the result', async () => {
 });
 
 
+test('The task should not be cancelable', async () => {
+  const apiSender = {
+    send: apiSenderSendMock,
+  } as unknown as ApiSenderType;
+
+  const progress = new ProgressImpl(
+    new TaskManager(apiSender),
+    cancellationTokenRegistryMock as unknown as CancellationTokenRegistry,
+  );
+
+  await progress.withProgress(
+    { location: ProgressLocation.TASK_WIDGET, title: 'My task', cancellable: false },
+    async (_progress, cancellationToken) => {
+      // Since cancellable is false
+      expect(cancellationToken).toBeUndefined();
+    },
+  );
+});
+
 test('The task should be cancelled', async () => {
   const apiSender = {
     send: apiSenderSendMock,
@@ -151,7 +170,7 @@ test('The task should be cancelled', async () => {
   // E.g. the external frontend should use `await window.cancelToken(tokenId)`
   await progress.withProgress(
     { location: ProgressLocation.TASK_WIDGET, title: 'My task', cancellable: true },
-    async (progress, cancellationToken) => {
+    async (_progress, cancellationToken) => {
       // Since cancellable is true
       expect(cancellationToken).toBeDefined();
 

--- a/packages/main/src/plugin/progress-impl.spec.ts
+++ b/packages/main/src/plugin/progress-impl.spec.ts
@@ -64,7 +64,6 @@ test('Should create a task and report 2 updates', async () => {
   expect(apiSenderSendMock).toHaveBeenNthCalledWith(3, 'task-updated', expect.objectContaining({ state: 'completed' }));
 });
 
-
 test('Should create a task and propagate the exception', async () => {
   const createTaskMock = vi.fn();
   const updateTaskMock = vi.fn();
@@ -120,7 +119,6 @@ test('Should create a task and propagate the result', async () => {
     status: 'success',
   });
 });
-
 
 test('The task should not be cancelable', async () => {
   const apiSender = {

--- a/packages/main/src/plugin/progress-impl.ts
+++ b/packages/main/src/plugin/progress-impl.ts
@@ -50,7 +50,7 @@ export class ProgressImpl {
     options: extensionApi.ProgressOptions,
     task: (
       progress: extensionApi.Progress<{ message?: string; increment?: number }>,
-      token: extensionApi.CancellationToken,
+      token?: extensionApi.CancellationToken,
     ) => Promise<R>,
   ): Promise<R> {
     if (options.location === ProgressLocation.APP_ICON) {
@@ -64,7 +64,7 @@ export class ProgressImpl {
     options: extensionApi.ProgressOptions,
     task: (
       progress: extensionApi.Progress<{ message?: string; increment?: number }>,
-      token: extensionApi.CancellationToken,
+      token?: extensionApi.CancellationToken,
     ) => Promise<R>,
   ): Promise<R> {
     return task(
@@ -84,7 +84,7 @@ export class ProgressImpl {
     options: extensionApi.ProgressOptions,
     task: (
       progress: extensionApi.Progress<{ message?: string; increment?: number }>,
-      token: extensionApi.CancellationToken,
+      token?: extensionApi.CancellationToken,
     ) => Promise<R>,
   ): Promise<R> {
     const t = this.taskManager.createTask(options.title, options.cancellableTokenId);

--- a/packages/main/src/plugin/progress-impl.ts
+++ b/packages/main/src/plugin/progress-impl.ts
@@ -87,12 +87,7 @@ export class ProgressImpl {
       token: extensionApi.CancellationToken,
     ) => Promise<R>,
   ): Promise<R> {
-    let cancellationTokenCallbackId: number | undefined = undefined;
-    if (options.cancellable) {
-      cancellationTokenCallbackId = this.cancellationTokenRegistry.createCancellationTokenSource();
-    }
-
-    const t = this.taskManager.createTask(options.title, cancellationTokenCallbackId);
+    const t = this.taskManager.createTask(options.title, options.cancellableTokenId);
 
     return task(
       {
@@ -106,8 +101,8 @@ export class ProgressImpl {
           this.taskManager.updateTask(t);
         },
       },
-      cancellationTokenCallbackId
-        ? this.cancellationTokenRegistry.getCancellationTokenSource(cancellationTokenCallbackId)?.token
+      options.cancellableTokenId
+        ? this.cancellationTokenRegistry.getCancellationTokenSource(options.cancellableTokenId)?.token
         : undefined,
     )
       .then(value => {

--- a/packages/main/src/plugin/task-manager.ts
+++ b/packages/main/src/plugin/task-manager.ts
@@ -30,7 +30,7 @@ export class TaskManager {
 
   constructor(private apiSender: ApiSenderType) {}
 
-  public createTask(title: string | undefined): StatefulTask {
+  public createTask(title: string | undefined, cancellationTokenCallbackId?: number): StatefulTask {
     this.taskId++;
     const task: StatefulTask = {
       id: `main-${this.taskId}`,
@@ -38,6 +38,7 @@ export class TaskManager {
       started: new Date().getTime(),
       state: 'running',
       status: 'in-progress',
+      cancellationTokenCallbackId: cancellationTokenCallbackId,
     };
     this.tasks.set(task.id, task);
     this.apiSender.send('task-created', task);

--- a/packages/main/src/plugin/task-manager.ts
+++ b/packages/main/src/plugin/task-manager.ts
@@ -45,6 +45,10 @@ export class TaskManager {
     return task;
   }
 
+  public getTask(taskId: string): Task | undefined {
+    return this.tasks.get(taskId);
+  }
+
   public createNotificationTask(notificationInfo: NotificationInfo): NotificationTask {
     this.taskId++;
     const task: NotificationTask = {

--- a/packages/main/src/plugin/task-manager.ts
+++ b/packages/main/src/plugin/task-manager.ts
@@ -70,6 +70,10 @@ export class TaskManager {
     }
   }
 
+  /**
+   * Retrieve tasks by a cancellable token
+   * @param cancellableTokenId The id of the cancellable token
+   */
   public findByCancellableToken(cancellableTokenId: number): Task[] {
     return Array.from(this.tasks.values()).filter(task => task.cancellableTokenId === cancellableTokenId);
   }

--- a/packages/main/src/plugin/task-manager.ts
+++ b/packages/main/src/plugin/task-manager.ts
@@ -38,7 +38,7 @@ export class TaskManager {
       started: new Date().getTime(),
       state: 'running',
       status: 'in-progress',
-      cancellationTokenCallbackId: cancellationTokenCallbackId,
+      cancellableTokenId: cancellationTokenCallbackId,
     };
     this.tasks.set(task.id, task);
     this.apiSender.send('task-created', task);
@@ -68,6 +68,10 @@ export class TaskManager {
     if (this.isStatefulTask(task) && task.state === 'completed') {
       this.tasks.delete(task.id);
     }
+  }
+
+  public findByCancellableToken(cancellableTokenId: number): Task[] {
+    return Array.from(this.tasks.values()).filter(task => task.cancellableTokenId === cancellableTokenId);
   }
 
   isStatefulTask(task: Task): task is StatefulTask {

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -1929,6 +1929,13 @@ function initExposure(): void {
       return ipcInvoke('image-checker:check', id, image, cancellationToken);
     },
   );
+
+  contextBridge.exposeInMainWorld(
+    'cancelTask',
+    async (taskId?: string): Promise<containerDesktopAPI.ImageChecks | undefined> => {
+      return ipcInvoke('task:cancel', taskId);
+    },
+  );
 }
 
 // expose methods

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -341,6 +341,7 @@ function initExposure(): void {
       providerContainerConnectionInfo: ProviderContainerConnectionInfo,
       imageName: string,
       callback: (event: PullEvent) => void,
+      cancellableTokenId?: number,
     ): Promise<void> => {
       onDataCallbacksPullImageId++;
       onDataCallbacksPullImage.set(onDataCallbacksPullImageId, callback);
@@ -349,6 +350,7 @@ function initExposure(): void {
         providerContainerConnectionInfo,
         imageName,
         onDataCallbacksPullImageId,
+        cancellableTokenId,
       );
     },
   );

--- a/packages/renderer/src/lib/image/PullImage.spec.ts
+++ b/packages/renderer/src/lib/image/PullImage.spec.ts
@@ -28,6 +28,7 @@ import type { ProviderContainerConnectionInfo, ProviderInfo } from '../../../../
 import userEvent from '@testing-library/user-event';
 
 const pullImageMock = vi.fn();
+const getCancellableTokenSourceMock = vi.fn();
 
 // fake the window.events object
 beforeAll(() => {
@@ -43,6 +44,7 @@ beforeAll(() => {
     addListener: vi.fn(),
   });
   (window as any).pullImage = pullImageMock;
+  (window as any).getCancellableTokenSource = getCancellableTokenSourceMock;
 
   Object.defineProperty(window, 'matchMedia', {
     value: () => {

--- a/packages/renderer/src/lib/task-manager/TaskManager.spec.ts
+++ b/packages/renderer/src/lib/task-manager/TaskManager.spec.ts
@@ -221,7 +221,7 @@ test('Expect cancel button to cancel task', async () => {
   const task = screen.queryByText(IN_PROGRESS_TASK.name);
   expect(task).toBeInTheDocument();
 
-  // click on the button "Clear notifications"
+  // click on the button "Cancel"
   const cancelButton = screen.getByRole('button', { name: 'Cancel' });
   expect(cancelButton).toBeInTheDocument();
   await fireEvent.click(cancelButton);

--- a/packages/renderer/src/lib/task-manager/TaskManagerItem.svelte
+++ b/packages/renderer/src/lib/task-manager/TaskManagerItem.svelte
@@ -26,19 +26,22 @@ let icon: IconDefinition;
 let iconColor: string;
 onMount(() => {
   if (isStatefulTask(task)) {
-    if (task.status === 'success') {
-      icon = faSquareCheck;
-      iconColor = 'text-green-600';
-      return;
-    } else if (task.status === 'failure') {
-      icon = faTriangleExclamation;
-      iconColor = 'text-red-500';
-      return;
+    switch (task.status) {
+      case 'success':
+        icon = faSquareCheck;
+        iconColor = 'text-green-600';
+        break;
+      case 'failure':
+      case 'cancelled':
+        icon = faTriangleExclamation;
+        iconColor = 'text-red-500';
+        break;
+      default:
+        icon = faInfoCircle;
+        iconColor = 'text-purple-500';
+        break;
     }
   }
-
-  icon = faInfoCircle;
-  iconColor = 'text-purple-500';
 });
 
 function closeCompleted(taskUI: StatefulTaskUI | NotificationTask) {
@@ -61,7 +64,7 @@ function cancelTask(taskUI: Task) {
 <!-- Display a task item-->
 <div class="flex flew-row w-full py-2">
   <!-- first column is the icon-->
-  <div class="flex w-3 {iconColor} justify-center">
+  <div class="flex w-3 {iconColor} mt-1 justify-center">
     <Fa size="14" icon="{icon}" />
   </div>
   <!-- second column is about the task-->

--- a/packages/renderer/src/lib/task-manager/TaskManagerItem.svelte
+++ b/packages/renderer/src/lib/task-manager/TaskManagerItem.svelte
@@ -54,7 +54,7 @@ function gotoTask(taskUI: StatefulTaskUI) {
 }
 
 function cancelTask(taskUI: Task) {
-  if (taskUI.cancellationTokenCallbackId) window.cancelTask(taskUI.id);
+  if (taskUI.cancellableTokenId) window.cancelTask(taskUI.id);
 }
 </script>
 
@@ -111,7 +111,7 @@ function cancelTask(taskUI: Task) {
           {/if}
         </div>
       </div>
-      {#if taskUI.cancellationTokenCallbackId}
+      {#if taskUI.cancellableTokenId}
         <div class="flex flex-col w-full items-end">
           <button
             on:click="{() => {

--- a/packages/renderer/src/lib/task-manager/TaskManagerItem.svelte
+++ b/packages/renderer/src/lib/task-manager/TaskManagerItem.svelte
@@ -52,6 +52,10 @@ function gotoTask(taskUI: StatefulTaskUI) {
   // and open the task
   taskUI?.gotoTask?.();
 }
+
+function cancelTask(taskUI: Task) {
+  if (taskUI.cancellationTokenCallbackId) window.cancelTask(taskUI.id);
+}
 </script>
 
 <!-- Display a task item-->
@@ -107,6 +111,15 @@ function gotoTask(taskUI: StatefulTaskUI) {
           {/if}
         </div>
       </div>
+      {#if taskUI.cancellationTokenCallbackId}
+        <div class="flex flex-col w-full items-end">
+          <button
+            on:click="{() => {
+              cancelTask(taskUI);
+            }}"
+            class="text-purple-500 cursor-pointer">Cancel</button>
+        </div>
+      {/if}
     {/if}
 
     <!-- if failed task, display the error-->

--- a/packages/renderer/src/lib/task-manager/task-manager.ts
+++ b/packages/renderer/src/lib/task-manager/task-manager.ts
@@ -25,7 +25,6 @@ export interface StatefulTaskUI extends StatefulTask {
   progress?: number;
   hasGotoTask: boolean;
   gotoTask?: () => void;
-  cancellationTokenCallbackId?: number;
 }
 
 export class TaskManager {

--- a/packages/renderer/src/lib/task-manager/task-manager.ts
+++ b/packages/renderer/src/lib/task-manager/task-manager.ts
@@ -39,7 +39,7 @@ export class TaskManager {
         hasGotoTask: false,
         age: `${humanizeDuration(new Date().getTime() - task.started, { round: true, largest: 1 })} ago`,
         error: task.error,
-        cancellationTokenCallbackId: task.cancellationTokenCallbackId,
+        cancellableTokenId: task.cancellableTokenId,
       };
 
       if (task.status === 'in-progress') {

--- a/packages/renderer/src/lib/task-manager/task-manager.ts
+++ b/packages/renderer/src/lib/task-manager/task-manager.ts
@@ -25,6 +25,7 @@ export interface StatefulTaskUI extends StatefulTask {
   progress?: number;
   hasGotoTask: boolean;
   gotoTask?: () => void;
+  cancellationTokenCallbackId?: number;
 }
 
 export class TaskManager {
@@ -39,6 +40,7 @@ export class TaskManager {
         hasGotoTask: false,
         age: `${humanizeDuration(new Date().getTime() - task.started, { round: true, largest: 1 })} ago`,
         error: task.error,
+        cancellationTokenCallbackId: task.cancellationTokenCallbackId,
       };
 
       if (task.status === 'in-progress') {


### PR DESCRIPTION
Related to https://github.com/containers/podman-desktop/issues/4363

### What does this PR do?

This PR adds a `cancellableTokenId` property to Task object. This PR only adds the backend logic and a test.

In this PR I am adding the cancelable action to the Pull Image as a demonstration of how to use the cancelable tasks logic.

### Screenshot/screencast of this PR

https://github.com/containers/podman-desktop/assets/42176370/de76aa80-d781-494e-b03c-6fd4a9c82771

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop 
repository (or from another issue tracker). -->

### How to test this PR?

- unit tests have been added
- Go to image page
- Pull an image
