### PR TITLE
fix: details page consistency

### DIFF
--- a/packages/renderer/src/lib/ui/DetailsPage.svelte
+++ b/packages/renderer/src/lib/ui/DetailsPage.svelte
@@ -24,11 +24,11 @@ function handleKeydown(e: KeyboardEvent) {
 <div class="flex flex-col w-full h-full shadow-pageheader">
   <div class="flex flex-row w-full h-fit px-5 py-4">
     <div class="flex flex-col w-full h-fit">
-      <div class="flex flew-row items-center">
+      <div class="flex flew-row items-center text-sm text-gray-700">
         <Link class="text-sm" aria-label="back" internalRef="{$lastPage.path}" title="Go back to {$lastPage.name}"
           >{$lastPage.name}</Link>
-        <div class="text-md mx-2 text-gray-700">></div>
-        <div class="grow text-sm font-extralight text-gray-700" aria-label="name">{$currentPage.name}</div>
+        <div class="mx-2">&gt;</div>
+        <div class="grow font-extralight" aria-label="name">{$currentPage.name}</div>
         <a href="{$lastPage.path}" title="Close" class="justify-self-end text-gray-900">
           <i class="fas fa-times" aria-hidden="true"></i>
         </a>

--- a/packages/renderer/src/lib/ui/DetailsPage.svelte
+++ b/packages/renderer/src/lib/ui/DetailsPage.svelte
@@ -21,46 +21,49 @@ function handleKeydown(e: KeyboardEvent) {
 
 <svelte:window on:keydown="{handleKeydown}" />
 
-<div class="w-full h-full">
-  <div class="flex h-full flex-col">
-    <div class="flex w-full flex-row">
-      <div class="w-full pl-5 pt-4">
-        <div class="flex flew-row items-center text-sm text-gray-700">
-          <Link aria-label="back" internalRef="{$lastPage.path}" title="Go back to {$lastPage.name}"
-            >{$lastPage.name}</Link>
-          <div class="mx-2">&gt;</div>
-          <div class="font-extralight" aria-label="name">{$currentPage.name}</div>
+<div class="flex flex-col w-full h-full shadow-pageheader">
+  <div class="flex flex-row w-full h-fit px-5 py-4">
+    <div class="flex flex-col w-full h-fit">
+      <div class="flex flew-row items-center">
+        <Link class="text-sm" aria-label="back" internalRef="{$lastPage.path}" title="Go back to {$lastPage.name}"
+          >{$lastPage.name}</Link>
+        <div class="text-md mx-2 text-gray-700">></div>
+        <div class="grow text-sm font-extralight text-gray-700" aria-label="name">{$currentPage.name}</div>
+        <a href="{$lastPage.path}" title="Close" class="justify-self-end text-gray-900">
+          <i class="fas fa-times" aria-hidden="true"></i>
+        </a>
+      </div>
+      <div class="flex flex-row items-start pt-1">
+        <div class="pr-3">
+          <slot name="icon" />
         </div>
-        <div class="text-lg flex flex-row items-start pt-1">
-          <div class="pr-3 pt-1">
-            <slot name="icon" />
+        <div class="flex flex-col grow pr-2">
+          <div class="flex flex-row">
+            <h1 aria-label="{title}" class="text-xl leading-tight">{title}</h1>
+            <div class="text-violet-400 ml-2 leading-normal" class:hidden="{!titleDetail}">{titleDetail}</div>
           </div>
-          <div class="text-lg flex flex-col">
-            <div class="flex flex-row items-baseline">
-              <h1>{title}</h1>
-              <div class="text-base text-violet-400 ml-2" class:hidden="{!titleDetail}">{titleDetail}</div>
-            </div>
-            <div class="mr-2 pb-4">
-              <span class="text-small text-gray-900" class:hidden="{!subtitle}">{subtitle}</span>
-              <slot name="subtitle" />
+          <div class="pt-1">
+            <span class="text-sm leading-none text-gray-900" class:hidden="{!subtitle}">{subtitle}</span>
+            <slot name="subtitle" />
+          </div>
+        </div>
+        <div class="flex flex-col">
+          <div class="flex flex-nowrap justify-self-end pl-3 space-x-2">
+            <slot name="actions" />
+          </div>
+          <div class="relative">
+            <div class="absolute top-0 right-0">
+              <slot name="detail" />
             </div>
           </div>
         </div>
       </div>
-      <div class="flex flex-col pr-2 pt-5">
-        <div class="flex justify-end space-x-2">
-          <slot name="actions" />
-        </div>
-        <slot name="detail" />
-      </div>
-      <a href="{$lastPage.path}" title="Close" class="mt-2 mr-2 text-gray-900"
-        ><i class="fas fa-times" aria-hidden="true"></i></a>
     </div>
-    <div class="flex flex-row px-2 border-b border-charcoal-400">
-      <slot name="tabs" />
-    </div>
-    <div class="h-full bg-charcoal-900 min-h-0 overflow-y-auto">
-      <slot name="content" />
-    </div>
+  </div>
+  <div class="flex flex-row px-2 border-b border-charcoal-400">
+    <slot name="tabs" />
+  </div>
+  <div class="h-full bg-charcoal-900 min-h-0">
+    <slot name="content" />
   </div>
 </div>


### PR DESCRIPTION
### What does this PR do?

Moves the close button and actions of the details page to be consistent with form pages. It also makes the subtitle font a little smaller, and adds a missing shadow-pageheader that was in the design.

The overall page structure & layout is much closer to form pages after this. I didn't go full shared-component because there are still a few differences between the two, but this is a step towards a common page component or breadcrumb + close header.

Shouldn't really be released before PR #4227. It's not awful, but one of the reasons for switching to donuts is that it takes up less horizontal space and won't go over the tab titles.

### Screenshot/screencast of this PR

Before:

<img width="740" alt="Screenshot 2023-10-16 at 4 25 28 PM" src="https://github.com/containers/podman-desktop/assets/19958075/74c98bff-9f19-4d61-ae1b-79b8611fd8fb">

After:

<img width="740" alt="Screenshot 2023-10-16 at 4 23 48 PM" src="https://github.com/containers/podman-desktop/assets/19958075/35c750ac-1f29-44ab-a53f-a90b5e46ff8b">

### What issues does this PR fix or reference?

Fixes #4226.

### How to test this PR?

Just go to details pages.