### PR TITLE
docs: clear up lima column on containers page

### DIFF
--- a/website/docs/onboarding-for-containers/index.md
+++ b/website/docs/onboarding-for-containers/index.md
@@ -29,7 +29,7 @@ Podman Desktop does not automatically set up container engine resources that you
 
    - Select a Podman execution environment:
 
-     | Host operating system | Native containers |        Podman machine         |  Lima instance  |
+     | Host operating system | Native containers |        Podman Machine         |  Lima instance  |
      | :-------------------- | :---------------: | :---------------------------: | :-------------: |
      | Windows               |       ❌ no       |            ✅ yes             | ❌ experimental |
      | macOS                 |       ❌ no       |            ✅ yes             |     ✅ yes      |
@@ -37,11 +37,11 @@ Podman Desktop does not automatically set up container engine resources that you
 
    - Select a Docker execution environment:
 
-     | Host operating system | Native containers | Lima instance | Docker Desktop |
-     | :-------------------- | :---------------: | :-----------: | :------------: |
-     | Windows               |       ❌ no       |     ❌ no     |     ✅ yes     |
-     | macOS                 |       ❌ no       |    ✅ yes     |     ✅ yes     |
-     | Linux                 |      ✅ yes       |     ❌ no     |     ✅ yes     |
+     | Host operating system | Native containers | Docker Desktop |  Lima instance  |
+     | :-------------------- | :---------------: | :------------: | :-------------: |
+     | Windows               |       ❌ no       |     ✅ yes     | ❌ experimental |
+     | macOS                 |       ❌ no       |     ✅ yes     |     ✅ yes      |
+     | Linux                 |      ✅ yes       |     ✅ yes     |     ✅ yes      |
 
 3. Setup your container engine.
 


### PR DESCRIPTION
The OS support is the same for the Linux machine, no matter what distribution and what container engine is getting installed on it.

### What does this PR do?

Changes the Lima column for Linux, from "no" to "yes"

Rearrange the columns to have the same order for both.

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast 
explaining what is doing this PR -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop 
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to reproduce -->
