### PR TITLE
docs: fix broken links and add lima onboarding

### DIFF
--- a/website/docs/kubernetes/lima/index.md
+++ b/website/docs/kubernetes/lima/index.md
@@ -10,8 +10,10 @@ tags: [migrating-to-kubernetes, lima]
 
 With Podman Desktop, you can work on [Lima-powered](https://lima-vm.io/) local Kubernetes clusters.
 
+#### Prerequisites
+
+- [You onboarded a Lima cluster](/docs/onboarding-for-kubernetes/lima).
+
 #### Procedure
 
-1. [Start a Lima instance running Kubernetes](/docs/onboarding-for-containers/creating-a-lima-instance-with-podman-desktop)
-1. [Configure the path to the kubeconfig file](/docs/kubernetes/configuring-access-to-a-kubernetes-cluster)
-1. Set the Kubernetes context to the Lima cluster
+1. Set your Kubernetes context to your local Lima-powered Kubernetes cluster

--- a/website/docs/onboarding-for-kubernetes/lima/index.md
+++ b/website/docs/onboarding-for-kubernetes/lima/index.md
@@ -67,7 +67,7 @@ Consider creating a custom Lima instance to:
 
 #### Verification
 
-1. When the installation is done, the location of the KUBECONFIG file is printed. See [Configuring access to a Kubernetes cluster](/docs/kubernetes/configuring-access-to-a-kubernetes-cluster).
+1. When the installation is done, the location of the KUBECONFIG file is printed. See [Configuring access to a Kubernetes cluster](/docs/onboarding-for-kubernetes/existing-kubernetes).
 
    - Go to **<icon icon="fa-solid fa-cog" size="lg" /> Settings > Preferences > Path to the kubeconfig file**, to set the path of the file.
 


### PR DESCRIPTION
Since we currently have to change the location of the KUBECONFIG, there is only one context (until Podman Desktop supports files).

### What does this PR do?

Fix some broken links, after the latest/greatest "onboarding".

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast 
explaining what is doing this PR -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop 
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to reproduce -->
