### PR TITLE
fix: report errors when analyzing extensions

### DIFF
--- a/packages/main/src/plugin/extension-loader.spec.ts
+++ b/packages/main/src/plugin/extension-loader.spec.ts
@@ -673,6 +673,7 @@ describe('analyze extension and main', async () => {
     const extension = await extensionLoader.analyzeExtension(path.resolve('/', 'fake', 'path'), false);
 
     expect(extension).toBeDefined();
+    expect(extension?.error).toBeDefined();
     expect(extension?.mainPath).toBe(path.resolve('/', 'fake', 'path', 'main-entry.js'));
     expect(extension?.id).toBe('fooPublisher.fooName');
   });
@@ -697,6 +698,7 @@ describe('analyze extension and main', async () => {
     const extension = await extensionLoader.analyzeExtension('/fake/path', false);
 
     expect(extension).toBeDefined();
+    expect(extension?.error).toBeDefined();
     // not set
     expect(extension?.mainPath).toBeUndefined();
     expect(extension?.id).toBe('fooPublisher.fooName');

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -325,7 +325,6 @@ export class ExtensionLoader {
   async analyzeExtension(extensionPath: string, removable: boolean): Promise<AnalyzedExtension> {
     // do nothing if there is no package.json file
     let error = undefined;
-    const disposables: Disposable[] = [];
     if (!fs.existsSync(path.resolve(extensionPath, 'package.json'))) {
       error = `Ignoring extension ${extensionPath} without package.json file`;
       console.warn(error);
@@ -336,10 +335,8 @@ export class ExtensionLoader {
         manifest: undefined,
         api: <typeof containerDesktopAPI>{},
         removable,
-        subscriptions: disposables,
-        dispose(): void {
-          disposables.forEach(disposable => disposable.dispose());
-        },
+        subscriptions: [],
+        dispose(): void {},
         error,
       };
       return analyzedExtension;
@@ -355,6 +352,7 @@ export class ExtensionLoader {
     // create api object
     const api = this.createApi(extensionPath, manifest);
 
+    const disposables: Disposable[] = [];
     const analyzedExtension: AnalyzedExtension = {
       id: `${manifest.publisher}.${manifest.name}`,
       name: manifest.name,

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -295,12 +295,12 @@ export class ExtensionLoader {
 
     const analyzedFoldersExtension = (
       await Promise.all(folders.map(folder => this.analyzeExtension(folder, false)))
-    ).filter(extension => !extension.error) as AnalyzedExtension[];
+    ).filter(extension => !extension.error);
     analyzedExtensions.push(...analyzedFoldersExtension);
 
     const analyzedExternalExtensions = (
       await Promise.all(externalExtensions.map(folder => this.analyzeExtension(folder, false)))
-    ).filter(extension => !extension.error) as AnalyzedExtension[];
+    ).filter(extension => !extension.error);
     analyzedExtensions.push(...analyzedExternalExtensions);
 
     // also load extensions from the plugins directory
@@ -314,7 +314,7 @@ export class ExtensionLoader {
       // collect all extensions from the pluginDirectory folders
       const analyzedPluginsDirectoryExtensions: AnalyzedExtension[] = (
         await Promise.all(pluginDirectories.map(folder => this.analyzeExtension(folder, true)))
-      ).filter(extension => !extension.error) as AnalyzedExtension[];
+      ).filter(extension => !extension.error);
       analyzedExtensions.push(...analyzedPluginsDirectoryExtensions);
     }
 

--- a/packages/main/src/plugin/install/extension-installer.ts
+++ b/packages/main/src/plugin/install/extension-installer.ts
@@ -166,6 +166,11 @@ export class ExtensionInstaller {
     } catch (error) {
       sendError('Error while analyzing extension: ' + error);
     }
+    if (analyzedExtension?.error) {
+      sendError('Could not load extension: ' + analyzedExtension?.error);
+      return;
+    }
+
     return analyzedExtension;
   }
 


### PR DESCRIPTION
### What does this PR do?

Since PR #2990 is very old I'm creating a new one.

Adds an error property to analyzed extensions, and analyzeExtension() sets it whenever there is a problem loading a folder instead of returning undefined. Added error for missing manifest entries.

Updated callers to check for error instead of undefined, and send an error when trying to install an extension that has an error.

Tests updated to confirm an error is being created.

### Screenshot/screencast of this PR

<img width="885" alt="Screenshot 2023-10-17 at 1 26 31 PM" src="https://github.com/containers/podman-desktop/assets/19958075/45fd8682-56ad-4c38-9a91-57c49942eff3">

### What issues does this PR fix or reference?

Fixes #2871.

### How to test this PR?

See issue https://github.com/containers/podman-desktop/issues/2871 - try installing this extension: quay.io/lstocchi/sample-podman-extension:v1