### PR TITLE
feat: settings page for CLI Tools

### DIFF
--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -53,6 +53,7 @@ import type {
   ProviderInfo,
   ProviderKubernetesConnectionInfo,
 } from '../../main/src/plugin/api/provider-info';
+import type { CliToolInfo } from '../../main/src/plugin/api/cli-tool-info';
 import type { IConfigurationPropertyRecordedSchema } from '../../main/src/plugin/configuration-registry';
 import type { PullEvent } from '../../main/src/plugin/api/pull-event';
 import { Deferred } from './util/deferred';
@@ -945,6 +946,10 @@ function initExposure(): void {
 
   contextBridge.exposeInMainWorld('getProviderInfos', async (): Promise<ProviderInfo[]> => {
     return ipcInvoke('provider-registry:getProviderInfos');
+  });
+
+  contextBridge.exposeInMainWorld('getCliToolInfos', async (): Promise<CliToolInfo[]> => {
+    return ipcInvoke('cli-tool-registry:getCliToolInfos');
   });
 
   contextBridge.exposeInMainWorld('getContributedMenus', async (context: string): Promise<Menu[]> => {

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -15,6 +15,7 @@
     "@fortawesome/free-regular-svg-icons": "^6.4.2",
     "@patternfly/patternfly": "^4.224.5",
     "@sveltejs/vite-plugin-svelte": "^2.4.6",
+    "@testing-library/dom": "^9.3.1",
     "@testing-library/jest-dom": "^6.1.4",
     "@testing-library/svelte": "^4.0.4",
     "@testing-library/user-event": "^14.5.1",

--- a/packages/renderer/src/PreferencesNavigation.svelte
+++ b/packages/renderer/src/PreferencesNavigation.svelte
@@ -57,6 +57,8 @@ onMount(async () => {
 
     <SettingsNavItem title="Authentication" href="/preferences/authentication-providers" bind:meta="{meta}" />
 
+    <SettingsNavItem title="CLI Tools" href="/preferences/cli-tools" bind:meta="{meta}" />
+
     <SettingsNavItem
       title="Extensions"
       href="/preferences/extensions"

--- a/packages/renderer/src/lib/preferences/PreferencesCliToolsRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesCliToolsRendering.spec.ts
@@ -1,0 +1,25 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { test } from 'vitest';
+
+test('CLI Tool info presented correctly in UI', () => {
+  // TBD
+});

--- a/packages/renderer/src/lib/preferences/PreferencesCliToolsRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesCliToolsRendering.spec.ts
@@ -1,14 +1,14 @@
 /**********************************************************************
  * Copyright (C) 2023 Red Hat, Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
+ * distributed under the License is distributed on an 'AS IS' BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
@@ -74,13 +74,6 @@ suite('CLI Tool Prefernces page shows', () => {
   const cliTools = [cliToolInfoItem1, cliToolInfoItem2, cliToolInfoItem3];
   let cliToolRows: HTMLElement[] = [];
 
-  function validatePropertyPresentation(labelName: string, getExpectedContent: (info: CliToolInfo) => string) {
-    cliTools.forEach((tool, index) => {
-      const nameElement = within(cliToolRows[index]).getByLabelText(labelName);
-      expect(nameElement.textContent?.trim()).equals(getExpectedContent(tool));
-    });
-  }
-
   beforeAll(() => {
     cliToolInfos.set(cliTools);
     render(PreferencesCliToolsRendering, {});
@@ -90,30 +83,5 @@ suite('CLI Tool Prefernces page shows', () => {
 
   test('all registered tools', () => {
     expect(cliToolRows.length).equals(cliTools.length);
-  });
-
-  test("tool's name", () => {
-    validatePropertyPresentation('cli-name', toolInfo => toolInfo.name);
-  });
-
-  test("extension's name that registered the tool", () => {
-    validatePropertyPresentation('cli-registered-by', toolInfo => `Registered by ${toolInfo.extensionInfo.label}`);
-  });
-
-  test("tool's display name", () => {
-    validatePropertyPresentation('cli-display-name', toolInfo => toolInfo.displayName);
-  });
-
-  test("tool's description", () => {
-    validatePropertyPresentation('markdown-content', toolInfo => toolInfo.description);
-  });
-
-  test("tool's logo is not shown if images.icon property is not present or images property is empty", () => {
-    expect(within(cliToolRows[0]).queryAllByLabelText('cli-logo').length).equals(0);
-    expect(within(cliToolRows[1]).queryAllByLabelText('cli-logo').length).equals(0);
-  });
-
-  test("tool's logo is shown when images.icon property is present", () => {
-    expect(within(cliToolRows[2]).getAllByLabelText('cli-logo').length).equals(1);
   });
 });

--- a/packages/renderer/src/lib/preferences/PreferencesCliToolsRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesCliToolsRendering.spec.ts
@@ -92,28 +92,28 @@ suite('CLI Tool Prefernces page shows', () => {
     expect(cliToolRows.length).equals(cliTools.length);
   });
 
-  test("tool's name", () => {
+  test('tool`s name', () => {
     validatePropertyPresentation('cli-name', toolInfo => toolInfo.name);
   });
 
-  test("extension's name that registered the tool", () => {
+  test('extension`s name that registered the tool', () => {
     validatePropertyPresentation('cli-registered-by', toolInfo => `Registered by ${toolInfo.extensionInfo.label}`);
   });
 
-  test("tool's display name", () => {
+  test('tool`s display name', () => {
     validatePropertyPresentation('cli-display-name', toolInfo => toolInfo.displayName);
   });
 
-  test("tool's description", () => {
+  test('tool`s description', () => {
     validatePropertyPresentation('markdown-content', toolInfo => toolInfo.description);
   });
 
-  test("tool's logo is not shown if images.icon property is not present or images property is empty", () => {
+  test('tool`s logo is not shown if images.icon property is not present or images property is empty', () => {
     expect(within(cliToolRows[0]).queryAllByLabelText('cli-logo').length).equals(0);
     expect(within(cliToolRows[1]).queryAllByLabelText('cli-logo').length).equals(0);
   });
 
-  test("tool's logo is shown when images.icon property is present", () => {
+  test('tool`s logo is shown when images.icon property is present', () => {
     expect(within(cliToolRows[2]).getAllByLabelText('cli-logo').length).equals(1);
   });
 });

--- a/packages/renderer/src/lib/preferences/PreferencesCliToolsRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesCliToolsRendering.spec.ts
@@ -113,7 +113,7 @@ suite('CLI Tool Prefernces page shows', () => {
     expect(within(cliToolRows[1]).queryAllByLabelText('cli-logo').length).equals(0);
   });
 
-  test("tool's logo is shown if images.icon property is present", () => {
+  test("tool's logo is shown when images.icon property is present", () => {
     expect(within(cliToolRows[2]).getAllByLabelText('cli-logo').length).equals(1);
   });
 });

--- a/packages/renderer/src/lib/preferences/PreferencesCliToolsRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesCliToolsRendering.spec.ts
@@ -74,6 +74,13 @@ suite('CLI Tool Prefernces page shows', () => {
   const cliTools = [cliToolInfoItem1, cliToolInfoItem2, cliToolInfoItem3];
   let cliToolRows: HTMLElement[] = [];
 
+  function validatePropertyPresentation(labelName: string, getExpectedContent: (info: CliToolInfo) => string) {
+    cliTools.forEach((tool, index) => {
+      const nameElement = within(cliToolRows[index]).getByLabelText(labelName);
+      expect(nameElement.textContent?.trim()).equals(getExpectedContent(tool));
+    });
+  }
+
   beforeAll(() => {
     cliToolInfos.set(cliTools);
     render(PreferencesCliToolsRendering, {});
@@ -83,5 +90,30 @@ suite('CLI Tool Prefernces page shows', () => {
 
   test('all registered tools', () => {
     expect(cliToolRows.length).equals(cliTools.length);
+  });
+
+  test("tool's name", () => {
+    validatePropertyPresentation('cli-name', toolInfo => toolInfo.name);
+  });
+
+  test("extension's name that registered the tool", () => {
+    validatePropertyPresentation('cli-registered-by', toolInfo => `Registered by ${toolInfo.extensionInfo.label}`);
+  });
+
+  test("tool's display name", () => {
+    validatePropertyPresentation('cli-display-name', toolInfo => toolInfo.displayName);
+  });
+
+  test("tool's description", () => {
+    validatePropertyPresentation('markdown-content', toolInfo => toolInfo.description);
+  });
+
+  test("tool's logo is not shown if images.icon property is not present or images property is empty", () => {
+    expect(within(cliToolRows[0]).queryAllByLabelText('cli-logo').length).equals(0);
+    expect(within(cliToolRows[1]).queryAllByLabelText('cli-logo').length).equals(0);
+  });
+
+  test("tool's logo is shown when images.icon property is present", () => {
+    expect(within(cliToolRows[2]).getAllByLabelText('cli-logo').length).equals(1);
   });
 });

--- a/packages/renderer/src/lib/preferences/PreferencesCliToolsRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesCliToolsRendering.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+import { cliToolInfos } from '../../stores/cli-tools';
+import Markdown from '../markdown/Markdown.svelte';
+import SettingsPage from './SettingsPage.svelte';
+import EngineIcon from '../ui/EngineIcon.svelte';
+import EmptyScreen from '../ui/EmptyScreen.svelte';
+</script>
+
+<SettingsPage title="CLI Tools">
+  <div class="h-full">
+    <EmptyScreen
+      aria-label="no-resource-panel"
+      icon="{EngineIcon}"
+      title="No CLI tool has been registered"
+      message="Start an extension that registers a CLI"
+      hidden="{$cliToolInfos.length > 0}" />
+
+    {#each $cliToolInfos as cliTool}
+      <div class="bg-charcoal-600 mb-5 rounded-md p-3 divide-x divide-gray-900 flex">
+        <div>
+          <!-- left col - cli-tool icon/name + "create new" button -->
+          <div class="min-w-[170px] max-w-[200px]">
+            <div class="flex">
+              {#if cliTool?.images?.icon}
+                {#if typeof cliTool.images.icon === 'string'}
+                  <img src="{cliTool.images.icon}" alt="{cliTool.name}" class="max-w-[40px] h-full" />
+                {/if}
+              {/if}
+              <span class="my-auto text-gray-400 ml-3 break-words">{cliTool.name}</span>
+            </div>
+          </div>
+        </div>
+        <!-- cli-tools columns -->
+        <div class="grow flex-column divide-gray-900 ml-2">
+          <span class="my-auto text-gray-400 ml-3 break-words">{cliTool.displayName}</span>
+          <div class="float-right text-gray-900 px-2 text-sm">Registered by {cliTool.extensionInfo.label}</div>
+          <div class="ml-3 mt-2 text-sm text-gray-300">
+            <Markdown markdown="{cliTool.description}" />
+          </div>
+        </div>
+      </div>
+    {/each}
+  </div>
+</SettingsPage>

--- a/packages/renderer/src/lib/preferences/PreferencesCliToolsRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesCliToolsRendering.svelte
@@ -7,7 +7,7 @@ import EmptyScreen from '../ui/EmptyScreen.svelte';
 </script>
 
 <SettingsPage title="CLI Tools">
-  <div class="h-full">
+  <div class="h-full" role="table" aria-label="cli-tools">
     <EmptyScreen
       aria-label="no-resource-panel"
       icon="{EngineIcon}"
@@ -16,25 +16,33 @@ import EmptyScreen from '../ui/EmptyScreen.svelte';
       hidden="{$cliToolInfos.length > 0}" />
 
     {#each $cliToolInfos as cliTool}
-      <div class="bg-charcoal-600 mb-5 rounded-md p-3 divide-x divide-gray-900 flex">
+      <div role="row" class="bg-charcoal-600 mb-5 rounded-md p-3 divide-x divide-gray-900 flex">
         <div>
           <!-- left col - cli-tool icon/name + "create new" button -->
           <div class="min-w-[170px] max-w-[200px]">
             <div class="flex">
               {#if cliTool?.images?.icon}
                 {#if typeof cliTool.images.icon === 'string'}
-                  <img src="{cliTool.images.icon}" alt="{cliTool.name}" class="max-w-[40px] h-full" />
+                  <img
+                    src="{cliTool.images.icon}"
+                    aria-label="cli-logo"
+                    alt="{cliTool.name} logo"
+                    class="max-w-[40px] h-full" />
                 {/if}
               {/if}
-              <span class="my-auto text-gray-400 ml-3 break-words">{cliTool.name}</span>
+              <span id="{cliTool.id}" class="my-auto text-gray-400 ml-3 break-words" aria-label="cli-name"
+                >{cliTool.name}</span>
             </div>
           </div>
         </div>
         <!-- cli-tools columns -->
         <div class="grow flex-column divide-gray-900 ml-2">
-          <span class="my-auto text-gray-400 ml-3 break-words">{cliTool.displayName}</span>
-          <div class="float-right text-gray-900 px-2 text-sm">Registered by {cliTool.extensionInfo.label}</div>
-          <div class="ml-3 mt-2 text-sm text-gray-300">
+          <span class="my-auto text-gray-400 ml-3 break-words" aria-label="cli-display-name"
+            >{cliTool.displayName}</span>
+          <div role="region" class="float-right text-gray-900 px-2 text-sm" aria-label="cli-registered-by">
+            Registered by {cliTool.extensionInfo.label}
+          </div>
+          <div role="region" class="ml-3 mt-2 text-sm text-gray-300">
             <Markdown markdown="{cliTool.description}" />
           </div>
         </div>

--- a/packages/renderer/src/lib/preferences/PreferencesPage.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesPage.svelte
@@ -15,6 +15,7 @@ import PreferencesExtensionList from './PreferencesExtensionList.svelte';
 import PreferencesResourcesRendering from './PreferencesResourcesRendering.svelte';
 import PreferencesAuthenticationProvidersRendering from './PreferencesAuthenticationProvidersRendering.svelte';
 import PreferencesInstallExtensionFromId from './PreferencesInstallExtensionFromId.svelte';
+import PreferencesCliToolsRendering from './PreferencesCliToolsRendering.svelte';
 import Onboarding from '../onboarding/Onboarding.svelte';
 import { isDefaultScope } from './Util';
 
@@ -71,6 +72,9 @@ onMount(async () => {
   </Route>
   <Route path="/authentication-providers" breadcrumb="Authentication">
     <PreferencesAuthenticationProvidersRendering />
+  </Route>
+  <Route path="/cli-tools" breadcrumb="Authentication">
+    <PreferencesCliToolsRendering />
   </Route>
   <Route path="/proxies" breadcrumb="Proxy">
     <PreferencesProxiesRendering />

--- a/packages/renderer/src/lib/preferences/PreferencesPage.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesPage.svelte
@@ -73,7 +73,7 @@ onMount(async () => {
   <Route path="/authentication-providers" breadcrumb="Authentication">
     <PreferencesAuthenticationProvidersRendering />
   </Route>
-  <Route path="/cli-tools" breadcrumb="Authentication">
+  <Route path="/cli-tools" breadcrumb="CLI Tools">
     <PreferencesCliToolsRendering />
   </Route>
   <Route path="/proxies" breadcrumb="Proxy">

--- a/packages/renderer/src/stores/cli-tools.ts
+++ b/packages/renderer/src/stores/cli-tools.ts
@@ -1,0 +1,52 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { writable, type Writable } from 'svelte/store';
+import { EventStore } from './event-store';
+import type { CliToolInfo } from '../../../main/src/plugin/api/cli-tool-info';
+
+const windowEvents: string[] = ['extensions-started', 'cli-tool-create', 'cli-tool-remove', 'cli-tool-change'];
+const windowListeners = ['system-ready', 'extensions-already-started'];
+
+let extensionsStarted = false;
+
+export async function checkForUpdate(eventName: string): Promise<boolean> {
+  // trigger update after all extensions started
+  if (eventName === 'extensions-started' || eventName === 'extensions-already-started') {
+    return (extensionsStarted = true);
+  }
+
+  // ignore individual tools created from extension activation methods until
+  // all extensions are activated and they can be requested all in one call
+  return (
+    extensionsStarted &&
+    (eventName === 'cli-tool-create' || eventName === 'cli-tool-remove' || eventName === 'cli-tool-change')
+  );
+}
+
+export const cliToolInfos: Writable<CliToolInfo[]> = writable([]);
+
+const eventStore = new EventStore<CliToolInfo[]>(
+  'cli tools',
+  cliToolInfos,
+  checkForUpdate,
+  windowEvents,
+  windowListeners,
+  window.getCliToolInfos,
+);
+eventStore.setup();

--- a/packages/renderer/src/stores/cli-tools.ts
+++ b/packages/renderer/src/stores/cli-tools.ts
@@ -27,7 +27,7 @@ let extensionsStarted = false;
 
 export async function checkForUpdate(eventName: string): Promise<boolean> {
   // trigger update after all extensions started
-  if (eventName === 'extensions-started' || eventName === 'extensions-already-started') {
+  if (eventName === 'extensions-already-started') {
     return (extensionsStarted = true);
   }
 


### PR DESCRIPTION
### What does this PR do?

Adds `Settings/CLI Tools` page to show cli tools registered by extensions using cli API

### Screenshot/screencast of this PR

![image](https://github.com/containers/podman-desktop/assets/620330/c47baba9-09c5-42fc-a32d-b62575e3d36a)

### What issues does this PR fix or reference?

related to #3781
depends on #4197

### How to test this PR?

