### PR TITLE
feat: register docker-compose cli tool through podman-desktop/cli API

### DIFF
--- a/extensions/compose/src/compose-extension.spec.ts
+++ b/extensions/compose/src/compose-extension.spec.ts
@@ -114,6 +114,9 @@ vi.mock('@podman-desktop/api', () => {
         return telemetryLogger;
       },
     },
+    cli: {
+      createCliTool: vi.fn(),
+    },
   };
 });
 

--- a/extensions/compose/src/compose-extension.ts
+++ b/extensions/compose/src/compose-extension.ts
@@ -135,6 +135,20 @@ export class ComposeExtension {
       this.statusBarItem.show();
       this.extensionContext.subscriptions.push(this.statusBarItem);
     }
+    const description = `Compose is a tool for defining and running multi-container Docker applications. 
+    With Compose, you use a YAML file to configure your application's services. Then, with a single command, 
+    you create and start all the services from your configuration.
+    Compose works in all environments; production, staging, development, testing, as well as CI workflows. 
+    It also provides commands for managing the whole lifecycle of your application.`;
+
+    extensionApi.cli.createCliTool({
+      name: 'docker-compose',
+      displayName: 'Compose',
+      markdownDescription: description.replace('\n', ''),
+      images: {
+        icon: 'icon.png',
+      },
+    });
 
     // run init checks
     await this.runChecks(true);


### PR DESCRIPTION
### What does this PR do?

Uses cli API to register docker-compose CLI tool in podman-desktop

### Screenshot/screencast of this PR

<img width="1283" alt="Screenshot 2023-10-18 at 12 29 29 AM" src="https://github.com/containers/podman-desktop/assets/620330/7103d446-5955-48bb-ad31-bf5876a4335e">

### What issues does this PR fix or reference?

related to https://github.com/containers/podman-desktop/issues/3781
depends on https://github.com/containers/podman-desktop/pull/4197

### How to test this PR?

<!-- Please explain steps to reproduce -->
