### PR TITLE
fix: log compose error with usage

### DIFF
--- a/extensions/compose/src/compose-extension.ts
+++ b/extensions/compose/src/compose-extension.ts
@@ -152,6 +152,7 @@ export class ComposeExtension {
     const telemetryLogger = extensionApi.env.createTelemetryLogger();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const telemetryOptions: Record<string, any> = {};
+    const startTime = performance.now();
     try {
       // grab latest assets metadata
       const lastReleasesMetadata = await this.composeGitHubReleases.grabLatestsReleasesMetadata();
@@ -211,9 +212,12 @@ export class ComposeExtension {
       } else {
         telemetryOptions.skip = true;
       }
-      telemetryLogger.logUsage('install', telemetryOptions);
     } catch (err) {
-      telemetryLogger.logError('install', { error: err });
+      telemetryOptions.error = err;
+    } finally {
+      const endTime = performance.now();
+      telemetryOptions.duration = endTime - startTime;
+      telemetryLogger.logUsage('install', telemetryOptions);
     }
   }
 


### PR DESCRIPTION
### What does this PR do?

Minimal change to send one event when we install compose instead of 1 event + different event on failure.

Added the duration while I was at it, but nothing else. There is likely more work to do here to classify failures or add more information to tell what is different about failure cases, but this will solve one core problem that it isn't easy to correlate failure with the usage.

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

Fixes part of #4214.

### How to test this PR?

Fail compose installation. :)