### PR TITLE
fix: calc width of bottom toolbar in onboarding (#4418)

### DIFF
--- a/packages/renderer/src/AppNavigation.svelte
+++ b/packages/renderer/src/AppNavigation.svelte
@@ -91,7 +91,9 @@ export let meta: TinroRouteMeta;
 </script>
 
 <svelte:window />
-<nav class="group w-[54px] min-w-[54px] flex flex-col justify-between hover:overflow-y-none" aria-label="AppNavigation">
+<nav
+  class="group w-leftnavbar min-w-leftnavbar flex flex-col justify-between hover:overflow-y-none"
+  aria-label="AppNavigation">
   <NavItem href="/" tooltip="Dashboard" bind:meta="{meta}">
     <div class="flex items-center w-full h-full">
       <svg

--- a/packages/renderer/src/PreferencesNavigation.svelte
+++ b/packages/renderer/src/PreferencesNavigation.svelte
@@ -41,7 +41,7 @@ onMount(async () => {
 </script>
 
 <nav
-  class="z-1 w-[225px] min-w-[225px] shadow flex-col justify-between flex transition-all duration-500 ease-in-out bg-charcoal-700"
+  class="z-1 w-leftsidebar min-w-leftsidebar shadow flex-col justify-between flex transition-all duration-500 ease-in-out bg-charcoal-700"
   aria-label="PreferencesNavigation">
   <div class="flex items-center">
     <div class="pt-4 px-5 mb-10">

--- a/packages/renderer/src/lib/onboarding/Onboarding.svelte
+++ b/packages/renderer/src/lib/onboarding/Onboarding.svelte
@@ -403,7 +403,7 @@ async function restartSetup() {
           </div>
         {/if}
         <div
-          class="flex flex-row-reverse p-6 bg-charcoal-700 fixed w-[calc(100%-279px)] bottom-0 mb-5 pr-10 max-h-20 bg-opacity-90 z-20">
+          class="flex flex-row-reverse p-6 bg-charcoal-700 fixed w-[calc(100%-theme(width.leftnavbar)-theme(width.leftsidebar))] bottom-0 mb-5 pr-10 max-h-20 bg-opacity-90 z-20">
           <Button type="primary" disabled="{activeStep.step.state === 'failed'}" on:click="{() => next()}">Next</Button>
           {#if activeStep.step.state !== 'completed'}
             <Button

--- a/packages/renderer/src/lib/onboarding/Onboarding.svelte
+++ b/packages/renderer/src/lib/onboarding/Onboarding.svelte
@@ -68,10 +68,6 @@ let displayResetSetup = false;
 
 let executedCommands: string[] = [];
 
-let activeStepDiv: HTMLDivElement;
-let bottomToolbarDiv: HTMLDivElement;
-let resizeObserver: ResizeObserver;
-
 /*
 $: enableNextButton = false;*/
 let onboardingUnsubscribe: Unsubscriber;
@@ -110,12 +106,6 @@ onMount(async () => {
       startOnboarding().catch((err: unknown) => console.warn(String(err)));
     }
   });
-
-  // Resize the bottom toolbar each time we change the div size
-  resizeObserver = new ResizeObserver(() => {
-    const parentWidth = activeStepDiv.getBoundingClientRect().width;
-    bottomToolbarDiv.style.width = parentWidth + 16 + 'px';
-  });
 });
 
 async function startOnboarding(): Promise<void> {
@@ -126,8 +116,6 @@ async function startOnboarding(): Promise<void> {
       setDisplayResetSetup(true);
     } else {
       await restartSetup();
-      // Observe the terminal div
-      resizeObserver.observe(activeStepDiv);
     }
   }
 }
@@ -138,10 +126,6 @@ onDestroy(() => {
   }
   if (contextsUnsubscribe) {
     contextsUnsubscribe();
-  }
-  // Cleanup the observer on destroy
-  if (activeStepDiv) {
-    resizeObserver?.unobserve(activeStepDiv);
   }
 });
 
@@ -303,7 +287,7 @@ async function restartSetup() {
     id="stepBody"
     class="flex flex-col bg-charcoal-500 h-full overflow-y-auto w-full overflow-x-hidden"
     class:bodyWithBar="{!activeStep.step.completionEvents || activeStep.step.completionEvents.length === 0}">
-    <div class="flex flex-col h-full" bind:this="{activeStepDiv}">
+    <div class="flex flex-col h-full">
       <div class="flex flex-row justify-between h-[100px] p-5 z-20 fixed w-full bg-opacity-90 bg-charcoal-700">
         <div class="flex flew-row">
           {#if activeStep.onboarding.media}
@@ -419,8 +403,7 @@ async function restartSetup() {
           </div>
         {/if}
         <div
-          class="flex flex-row-reverse p-6 bg-charcoal-700 fixed w-full bottom-0 mb-5 pr-10 max-h-20 bg-opacity-90 z-20"
-          bind:this="{bottomToolbarDiv}">
+          class="flex flex-row-reverse p-6 bg-charcoal-700 fixed w-[calc(100%-279px)] bottom-0 mb-5 pr-10 max-h-20 bg-opacity-90 z-20">
           <Button type="primary" disabled="{activeStep.step.state === 'failed'}" on:click="{() => next()}">Next</Button>
           {#if activeStep.step.state !== 'completed'}
             <Button

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -33,6 +33,14 @@ module.exports = {
       transitionProperty: {
         width: 'width',
       },
+      width: {
+        'leftnavbar': '54px',
+        'leftsidebar': '225px',
+      },
+      minWidth: {
+        'leftnavbar': '54px',
+        'leftsidebar': '225px',
+      },
     },
     colors: {
       'charcoal': {


### PR DESCRIPTION
### What does this PR do?

this PR calculate the width of the bottom toolbar by subtract the width of the left nav (54px) and left sidebar (225px)

### Screenshot/screencast of this PR

As before

### What issues does this PR fix or reference?

it resolves #4418 

### How to test this PR?

1. run the onboarding on mac. after the podman installation wizard finishes and you are in the step where you can set the autostart setting you should see the next/cancel buttons correctly
