### PR TITLE
fix: log kind cluster creation failure with usage

### DIFF
--- a/extensions/kind/src/create-cluster.ts
+++ b/extensions/kind/src/create-cluster.ts
@@ -174,6 +174,7 @@ export async function createCluster(
       await setupIngressController(clusterName);
     }
   } catch (error) {
+    telemetryOptions.error = error;
     let errorMessage: string;
 
     if (typeof error === 'object' && 'message' in error) {
@@ -181,8 +182,6 @@ export async function createCluster(
     } else if (typeof error === 'string') {
       errorMessage = error;
     }
-
-    telemetryOptions.error = errorMessage;
 
     throw new Error(`Failed to create kind cluster. ${errorMessage}`);
   } finally {

--- a/extensions/kind/src/create-cluster.ts
+++ b/extensions/kind/src/create-cluster.ts
@@ -183,7 +183,6 @@ export async function createCluster(
     }
 
     telemetryOptions.error = errorMessage;
-    telemetryOptions.stdErr = errorMessage;
 
     throw new Error(`Failed to create kind cluster. ${errorMessage}`);
   } finally {


### PR DESCRIPTION
### What does this PR do?

Minimal change to send one event when we create a kind cluster instead of 1 event + different event on failure.

Added the duration while I was at it, but nothing else. There is likely more work to do here to classify failures or add more information to tell what is different about failure cases, but this will solve one core problem that it isn't easy to correlate failure with the usage.

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

Fixes part of #4214.

### How to test this PR?

Make a kind cluster, look for dev telemetry in Segment with duration (and maybe error).