### PR TITLE
feat: register docker-compose cli for compose extension

### DIFF
--- a/extensions/compose/src/extension.ts
+++ b/extensions/compose/src/extension.ts
@@ -34,6 +34,11 @@ export function initTelemetryLogger(): void {
   telemetryLogger = extensionApi.env.createTelemetryLogger();
 }
 
+const composeCliName = 'docker-compose';
+const composeDisplayName = 'Compose';
+const composeDescription = `Compose is a specification for defining and running multi-container applications. We support both [podman compose](https://docs.podman.io/en/latest/markdown/podman-compose.1.html) and [docker compose](https://github.com/docker/compose) commands.\n\nMore information: [compose-spec.io](https://compose-spec.io/)`;
+const imageLocation = './icon.png';
+
 export async function activate(extensionContext: extensionApi.ExtensionContext): Promise<void> {
   initTelemetryLogger();
 
@@ -177,16 +182,26 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
   // Need to "ADD" a provider so we can actually press the button!
   // We set this to "unknown" so it does not appear on the dashboard (we only want it in preferences).
   const providerOptions: extensionApi.ProviderOptions = {
-    name: 'Compose',
-    id: 'Compose',
+    name: composeDisplayName,
+    id: composeDisplayName,
     status: 'unknown',
     images: {
-      icon: './icon.png',
+      icon: imageLocation,
     },
   };
 
-  providerOptions.emptyConnectionMarkdownDescription = `Compose is a specification for defining and running multi-container applications. We support both [podman compose](https://docs.podman.io/en/latest/markdown/podman-compose.1.html) and [docker compose](https://github.com/docker/compose) commands.\n\nMore information: [compose-spec.io](https://compose-spec.io/)`;
+  providerOptions.emptyConnectionMarkdownDescription = composeDescription;
 
   const provider = extensionApi.provider.createProvider(providerOptions);
   extensionContext.subscriptions.push(provider);
+
+  // Register the CLI extension, this will allow us to show the CLI version, update the CLI, installation, etc.
+  extensionApi.cli.createCliTool({
+    name: composeCliName,
+    displayName: composeDisplayName,
+    markdownDescription: composeDescription,
+    images: {
+      icon: imageLocation,
+    },
+  });
 }


### PR DESCRIPTION
feat: register docker-compose cli for compose extension

### What does this PR do?

Update to https://github.com/containers/podman-desktop/pull/4388

Adds the docker-compose CLI to the list of CLI's available in the CLI
page

![image](https://github.com/containers/podman-desktop/assets/620330/d7ab35a0-6cc4-4c2b-9cc8-4950a4f47184)

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast
explaining what is doing this PR -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Related to #3781
Depends on #4197

### How to test this PR?

Check the CLI section within settings and you'll see Compose

<!-- Please explain steps to reproduce -->

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
