### PR TITLE
fix: podman onboarding enablement not working on linux

### DIFF
--- a/extensions/podman/package.json
+++ b/extensions/podman/package.json
@@ -270,7 +270,7 @@
           "state": "completed"
         }
       ],
-      "enablement": "(isLinux && onboardingContext:podmanIsNotInstalled) || !onboardingContext:podmanMachineExists"
+      "enablement": "(isLinux && onboardingContext:podmanIsNotInstalled) || (!isLinux && !onboardingContext:podmanMachineExists)"
     }
   },
   "scripts": {

--- a/packages/renderer/src/lib/onboarding/onboarding-utils.spec.ts
+++ b/packages/renderer/src/lib/onboarding/onboarding-utils.spec.ts
@@ -469,6 +469,40 @@ test('Expect the step to NOT be completed if the step is considered completed if
   expect(isCompleted).toBeFalsy();
 });
 
+test('Expect the step to be completed if the negated context value is true', async () => {
+  const step: OnboardingStep = {
+    id: 'id1',
+    title: 'title 1',
+    status: undefined,
+    completionEvents: ['!onboardingContext:myvalue'],
+  };
+
+  const onboarding: OnboardingInfo = {
+    extension: 'id',
+    steps: [
+      step,
+      {
+        id: 'id2',
+        title: 'title 2',
+        status: undefined,
+      },
+    ],
+    title: 'onboarding',
+    status: undefined,
+    enablement: 'true',
+  };
+  const activeStep: ActiveOnboardingStep = {
+    onboarding,
+    step,
+  };
+  const context = new ContextUI();
+  deserialize.mockReturnValue({
+    evaluate: (_context: ContextUI) => true,
+  } as unknown as ContextKeyExpression);
+  const isCompleted = isStepCompleted(activeStep, [], context);
+  expect(isCompleted).toBeTruthy();
+});
+
 test('Expect the step status to be updated but not the onboarding as it is not the last step', async () => {
   const step: OnboardingStep = {
     id: 'id1',

--- a/packages/renderer/src/lib/onboarding/onboarding-utils.ts
+++ b/packages/renderer/src/lib/onboarding/onboarding-utils.ts
@@ -28,6 +28,8 @@ export const STATUS_SKIPPED = 'skipped';
 export const ON_COMMAND_PREFIX = 'onCommand:';
 export const ONBOARDING_CONTEXT_PREFIX = 'onboardingContext:';
 
+const ONBOARDING_CONTEXT_PREFIX_REGEX = new RegExp(/^!*onboardingContext:/);
+
 const ONBOARDING_CONTEXT_REGEX = new RegExp(/\${onboardingContext:(.+?)}/g);
 const GLOBAL_CONTEXT_REGEX = new RegExp(/\${onContext:(.+?)}/g);
 
@@ -71,7 +73,8 @@ export function isStepCompleted(
       }
 
       // check if cmp string is an onContext event, check the value from context
-      if (cmp.startsWith(ONBOARDING_CONTEXT_PREFIX)) {
+      const matchesOnboardingPrefix = cmp.match(ONBOARDING_CONTEXT_PREFIX_REGEX);
+      if (matchesOnboardingPrefix) {
         if (!globalContext) {
           return false;
         }


### PR DESCRIPTION
### What does this PR do?

This PR refines the enablement clause for podman onboarding to work on linux.
It also replace a `startWith` with a regex match as `onboardingContext` could also be preceded by `!` and it was not detected before

### Screenshot/screencast of this PR

![onboarding_linux](https://github.com/containers/podman-desktop/assets/49404737/5f920a9e-e4d1-4db1-a0c2-3ed22e38d694)

### What issues does this PR fix or reference?

it is part of #4428 

### How to test this PR?

1. run onboarding on linux
