### PR TITLE
feat: use directory name as default container image name

### DIFF
--- a/packages/renderer/src/lib/image/BuildImageFromContainerfile.spec.ts
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfile.spec.ts
@@ -40,7 +40,9 @@ beforeAll(() => {
   (window as any).matchMedia = vi.fn().mockReturnValue({
     addListener: vi.fn(),
   });
-  (window as any).openFileDialog = vi.fn().mockResolvedValue({ canceled: false, filePaths: ['Containerfile'] });
+  (window as any).openFileDialog = vi
+    .fn()
+    .mockResolvedValue({ canceled: false, filePaths: ['path/to/mock-image/Containerfile'] });
   (window as any).telemetryPage = vi.fn().mockResolvedValue(undefined);
 });
 
@@ -121,6 +123,20 @@ test('Expect Done button is enabled once build is done', async () => {
   const doneButton = screen.getByRole('button', { name: 'Done' });
   expect(doneButton).toBeInTheDocument();
   expect(doneButton).toBeEnabled();
+});
+
+test('Expect image name to match container directory name', async () => {
+  setup();
+  render(BuildImageFromContainerfile, {});
+
+  const containerImageName = screen.getByRole('textbox', { name: 'Image Name' });
+  expect(containerImageName).toBeInTheDocument();
+  expect(containerImageName).toHaveValue('my-custom-image');
+
+  const containerFilePathBrowse = screen.getByRole('button', { name: 'containerFilePathBrowse' });
+  await userEvent.click(containerFilePathBrowse);
+
+  expect(containerImageName).toHaveValue('mock-image');
 });
 
 test('Expect Abort button to hidden when image build is not in progress', async () => {

--- a/packages/renderer/src/lib/image/BuildImageFromContainerfile.svelte
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfile.svelte
@@ -122,10 +122,20 @@ async function getContainerfileLocation() {
   const result = await window.openFileDialog('Select Containerfile to build');
   if (!result.canceled && result.filePaths.length === 1) {
     containerFilePath = result.filePaths[0];
+    hasInvalidFields = false;
+
+    // normalize the file path to posix style
+    // eslint-disable-next-line no-useless-escape
+    const posixContainerDirPath = containerFilePath.replace(/\\/g, '/').replace(/\/[^\/]*$/, '');
+    const containerDirName = posixContainerDirPath.split('/').slice(-1)[0];
+    if (containerDirName) {
+      // use the directory as default image name
+      containerImageName = containerDirName;
+    }
+
     if (!containerBuildContextDirectory) {
       // select the parent directory of the file as default
-      // eslint-disable-next-line no-useless-escape
-      containerBuildContextDirectory = containerFilePath.replace(/\\/g, '/').replace(/\/[^\/]*$/, '');
+      containerBuildContextDirectory = posixContainerDirPath;
     }
   }
 }
@@ -166,7 +176,8 @@ async function abortBuild() {
               class="w-full p-2 mr-3 outline-none text-sm bg-charcoal-600 rounded-sm text-gray-700 placeholder-gray-700"
               required />
 
-            <Button on:click="{() => getContainerfileLocation()}">Browse...</Button>
+            <Button aria-label="containerFilePathBrowse" on:click="{() => getContainerfileLocation()}"
+              >Browse...</Button>
           </div>
         </div>
 


### PR DESCRIPTION
### What does this PR do?

When creating a new container, the container image name currently defaults to `my-custom-image`. 
With this PR, the container image defaults to the directory name of the chose container file.

### Screenshot/screencast of this PR

<img width="752" alt="image" src="https://github.com/containers/podman-desktop/assets/17082165/2a02aa5b-c4e3-463c-bdee-d236d488cd70">

### What issues does this PR fix or reference?

Fix for https://github.com/containers/podman-desktop/issues/2713

Inspired by https://github.com/containers/podman-desktop/pull/2897 (added support for Windows style paths)

### How to test this PR?

Create a custom container, choose a file and observe the image name
