### PR TITLE
fix: custom container icon size

### DIFF
--- a/packages/renderer/src/lib/images/StatusIcon.svelte
+++ b/packages/renderer/src/lib/images/StatusIcon.svelte
@@ -13,7 +13,7 @@ $: solid = status === 'RUNNING' || status === 'STARTING' || status === 'USED' ||
 
 <div class="grid place-content-center" style="position:relative">
   <div
-    class="grid place-content-center rounded aspect-square"
+    class="grid place-content-center rounded aspect-square text-xs"
     class:bg-green-400="{status === 'RUNNING' || status === 'USED'}"
     class:bg-green-600="{status === 'STARTING'}"
     class:bg-amber-600="{status === 'DEGRADED'}"


### PR DESCRIPTION
### What does this PR do?

I would swear that the last change for scaling icons (PR #4167) had zero effect on the size of custom icons like Kind and that I have screenshots somewhere to prove it - and yet I see them different this morning. Since we can't easily set the size of the icons directly, the next easiest thing is to just set the font size.

### Screenshot/screencast of this PR

Before:
Regular icons: 20px square
Kind: 26.5px

<img width="137" alt="Screenshot 2023-10-23 at 10 42 22 AM" src="https://github.com/containers/podman-desktop/assets/19958075/eb664c5b-8c79-4971-a055-46e0741ecea3">

After:
Kind: 19.875px

<img width="137" alt="Screenshot 2023-10-23 at 10 42 10 AM" src="https://github.com/containers/podman-desktop/assets/19958075/356f03f4-45f1-48ca-b085-6fb8bf8a37df">

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Create a Kind cluster and go to Containers view.