### PR TITLE
refactor: updated compose onboarding installation

### DIFF
--- a/extensions/compose/package.json
+++ b/extensions/compose/package.json
@@ -21,12 +21,12 @@
         "title": "Compose: Checks..."
       },
       {
-        "command": "compose.onboarding.checkComposeInstalled",
-        "title": "Compose: Check Compose installation"
+        "command": "compose.onboarding.checkComposeDownloaded",
+        "title": "Compose: Check Compose Downloaded"
       },
       {
-        "command": "compose.onboarding.installCompose",
-        "title": "Compose: Install Compose"
+        "command": "compose.onboarding.downloadCompose",
+        "title": "Compose: Download Compose"
       }
     ],
     "onboarding": {
@@ -34,19 +34,19 @@
       "enablement": "!compose.isComposeInstalledSystemWide",
       "steps": [
         {
-          "id": "checkComposeInstalled",
+          "id": "checkComposeDownloaded",
           "label": "Check Compose",
           "title": "Checking for Compose installation",
-          "command": "compose.onboarding.checkComposeInstalled",
+          "command": "compose.onboarding.checkComposeDownloaded",
           "completionEvents": [
-            "onCommand:compose.onboarding.checkComposeInstalled"
+            "onCommand:compose.onboarding.checkComposeDownloaded"
           ]
         },
         {
-          "id": "startComposeInstallation",
-          "label": "Compose Installation",
-          "title": "Compose Installation",
-          "when": "onboardingContext:composeIsNotInstalled == true",
+          "id": "startComposeDownload",
+          "label": "Compose Download",
+          "title": "Compose Download",
+          "when": "onboardingContext:composeIsNotDownloaded == true",
           "content": [
             [
               {
@@ -55,55 +55,78 @@
             ],
             [
               {
-                "value": "#### How to use Compose\nRun `podman compose up` (podman CLI v4.7.0+) in a directory with a `compose.yaml` for Podman to deploy the containers. Podman Desktop will automatically detect the Compose deployment and show it in the container list. \n\n> ℹ️ Note: If you would like to use docker tools such as: `docker compose up` or `docker-compose` with podman. Enable **Docker Compatibility** within Preferences.",
+                "value": "> ℹ️ Note: Want to use docker CLI tools such as: `docker compose up` or `docker-compose` with podman? Enable **Docker Compatibility** within Preferences.",
                 "highlight": true
               }
             ],
             [
               {
-                "value": "Compose will be installed in the next step (Version ${onboardingContext:composeInstallVersion}). :link[Want to install a different version?]{command=compose.onboarding.promptUserForVersion}",
-                "when": "!onboardingContext:composeShowCustomInstallDialog"
+                "value": "Compose will be downloaded in the next step (Version ${onboardingContext:composeDownloadVersion}). :link[Want to download a different version?]{command=compose.onboarding.promptUserForVersion}",
+                "when": "!onboardingContext:composeShowCustomDownloadDialog"
               }
             ]
           ]
         },
         {
-          "id": "installComposeView",
-          "title": "Installing Compose ${onboardingContext:composeInstallVersion}",
-          "description": "Downloading and installing the binary.\n\nOnce installed, we will enable and configure the extension.",
-          "when": "onboardingContext:composeIsNotInstalled == true",
-          "command": "compose.onboarding.installCompose",
+          "id": "downloadComposeView",
+          "title": "Downloading Compose ${onboardingContext:composeDownloadVersion}",
+          "description": "Downloading the binary.\n\nOnce downloaded, the next step will install Compose system-wide.",
+          "when": "onboardingContext:composeIsNotDownloaded == true",
+          "command": "compose.onboarding.downloadCompose",
           "completionEvents": [
-            "onCommand:compose.onboarding.installCompose"
+            "onCommand:compose.onboarding.downloadCompose"
           ]
         },
         {
-          "id": "composeFailedInstallation",
-          "title": "Failed installing Compose",
-          "when": "onboardingContext:composeIsNotInstalled == true",
+          "id": "composeFailedDownload",
+          "title": "Failed Downloading Compose",
+          "when": "onboardingContext:composeIsNotDownloaded == true",
           "state": "failed"
         },
         {
-          "id": "composeInstalled",
-          "title": "Compose successfully installed",
-          "when": "onboardingContext:composeIsNotInstalled == false",
+          "id": "composeDownloaded",
+          "title": "Compose Successfully Downloaded",
+          "when": "onboardingContext:composeIsNotDownloaded == false",
           "state": "succeeded",
           "content": [
             [
               {
-                "value": "Compose has been successfully installed! However, in order for `podman compose` (podman CLI v4.7.0+) to work correctly, it is required for Compose to be installed system-wide for `podman` to access the binary.",
-                "when": "!compose.isComposeInstalledSystemWide"
+                "value": "Compose has been successfully downloaded! In order for `podman compose` (podman CLI v4.7.0+) to work correctly, it is required for Compose to be installed system-wide for `podman` to access the binary.\n\nThe next step will install Compose system-wide. **You will be prompted for system privileges when enabling this.**"
+              }
+            ]
+          ]
+        },
+        {
+          "id": "installComposeSystemWide",
+          "title": "Install Compose",
+          "description": "Installing the binary system-wide.\n\n You may be prompted for elevated system privileges.",
+          "when": "compose.isComposeInstalledSystemWide == false",
+          "command": "compose.onboarding.installSystemWide",
+          "completionEvents": [
+            "onCommand:compose.onboarding.installSystemWide"
+          ]
+        },
+        {
+          "id": "composeFailedInstalledSystemWide",
+          "title": "Failed Installing Compose",
+          "when": "compose.isComposeInstalledSystemWide == false",
+          "state": "failed"
+        },
+        {
+          "id": "composeInstalledSystemWide",
+          "title": "Compose Successfully Installed",
+          "when": "compose.isComposeInstalledSystemWide == true",
+          "state": "succeeded",
+          "content": [
+            [
+              {
+                "value": "Compose has been successfully installed system-wide!"
               }
             ],
             [
               {
-                "value": "${configuration:compose.binary.installComposeSystemWide}",
-                "when": "!compose.isComposeInstalledSystemWide"
-              }
-            ],
-            [
-              {
-                "value": "> ℹ️ Note on `docker`: If you are using docker CLI tools with a podman back-end you must enable **Docker Compatibility** within **Preferences -> Extension: Podman** or set the [DOCKER_HOST](https://podman-desktop.io/docs/migrating-from-docker/using-the-docker_host-environment-variable) environment variable before running `docker compose up` or `docker-compose up`."
+                "value": "#### How to use Compose\nRun `podman compose up` (podman CLI v4.7.0+) or `docker-compose` in a directory with a `compose.yaml`. Podman Desktop will automatically detect the Compose deployment and show it in the container list.'\n\n`$ podman compose up`",
+                "highlight": true
               }
             ]
           ]
@@ -118,7 +141,7 @@
           "default": false,
           "scope": ["DEFAULT", "Onboarding"],
           "hidden": true,
-          "description": "Install system-wide instead of just your user directory, so compose can be accessed on the command line. Note: You will be prompted for system privileges when enabling this. "
+          "description": "Install system-wide instead of just your user directory, so compose can be accessed on the command line. Note: You may be prompted for elevated system privileges when enabling this."
         }
       }
     }

--- a/extensions/compose/src/download.spec.ts
+++ b/extensions/compose/src/download.spec.ts
@@ -20,7 +20,7 @@ import { afterEach, expect, test, vi } from 'vitest';
 import type { ComposeGitHubReleases, ComposeGithubReleaseArtifactMetadata } from './compose-github-releases';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { ComposeInstallation } from './installation';
+import { ComposeDownload } from './download';
 import * as extensionApi from '@podman-desktop/api';
 import { OS } from './os';
 import * as utils from './utils';
@@ -87,8 +87,8 @@ test('expect getLatestVersionAsset to return the first release from a list of re
   });
 
   // Expect the test to return the first release from the list (as the function simply returns the first one)
-  const composeInstallation = new ComposeInstallation(extensionContext, composeGitHubReleasesMock, os);
-  const result = await composeInstallation.getLatestVersionAsset();
+  const composeDownload = new ComposeDownload(extensionContext, composeGitHubReleasesMock, os);
+  const result = await composeDownload.getLatestVersionAsset();
   expect(result).toBeDefined();
   expect(result).toEqual(releases[0]);
 });
@@ -103,13 +103,13 @@ test('pick the 4th option option in the quickpickmenu and expect it to return th
   showQuickPickMock.mockResolvedValue({ id: 86626999, label: 'v2.14.2', tag: 'v2.14.2' } as any);
 
   // Expect the test to return the first release from the list (as the function simply returns the first one)
-  const composeInstallation = new ComposeInstallation(extensionContext, composeGitHubReleasesMock, os);
-  const result = await composeInstallation.promptUserForVersion();
+  const composeDownload = new ComposeDownload(extensionContext, composeGitHubReleasesMock, os);
+  const result = await composeDownload.promptUserForVersion();
   expect(result).toBeDefined();
   expect(result).toEqual(releases[3]); // "4th" option was picked
 });
 
-test('test installation of compose passes and that mkdir and executable mocks are called', async () => {
+test('test download of compose passes and that mkdir and executable mocks are called', async () => {
   const makeExecutableMock = vi.spyOn(utils, 'makeExecutable');
   const mkdirMock = vi.spyOn(fs.promises, 'mkdir');
   const getReleaseAssetIdMock = vi.spyOn(composeGitHubReleasesMock, 'getReleaseAssetId');
@@ -128,9 +128,9 @@ test('test installation of compose passes and that mkdir and executable mocks ar
   getReleaseAssetIdMock.mockResolvedValue(123456789);
   downloadReleaseAssetMock.mockResolvedValue(undefined);
 
-  // Simply install the first release from the example json list
-  const composeInstallation = new ComposeInstallation(extensionContext, composeGitHubReleasesMock, os);
-  await composeInstallation.install(releases[0]);
+  // Simply download the first release from the example json list
+  const composeDownload = new ComposeDownload(extensionContext, composeGitHubReleasesMock, os);
+  await composeDownload.download(releases[0]);
 
   // Expect the mkdir and executables to have been called
   expect(mkdirMock).toHaveBeenCalled();

--- a/extensions/compose/src/download.ts
+++ b/extensions/compose/src/download.ts
@@ -24,7 +24,7 @@ import type { OS } from './os';
 import { platform, arch } from 'node:os';
 import { makeExecutable } from './utils';
 
-export class ComposeInstallation {
+export class ComposeDownload {
   constructor(
     private readonly extensionContext: extensionApi.ExtensionContext,
     private readonly composeGitHubReleases: ComposeGitHubReleases,
@@ -38,14 +38,14 @@ export class ComposeInstallation {
     return latestReleases[0];
   }
 
-  // Create a "quickpick" prompt to ask the user which version of Compose they want to install
+  // Create a "quickpick" prompt to ask the user which version of Compose they want to download
   async promptUserForVersion(): Promise<ComposeGithubReleaseArtifactMetadata> {
     // Get the latest releases
     const lastReleasesMetadata = await this.composeGitHubReleases.grabLatestsReleasesMetadata();
 
     // Show the quickpick
     const selectedRelease = await extensionApi.window.showQuickPick(lastReleasesMetadata, {
-      placeHolder: 'Select Compose version to install',
+      placeHolder: 'Select Compose version to download',
     });
 
     if (selectedRelease) {
@@ -55,12 +55,13 @@ export class ComposeInstallation {
     }
   }
 
-  // Install compose from the artifact metadata: ComposeGithubReleaseArtifactMetadata
-  async install(release: ComposeGithubReleaseArtifactMetadata): Promise<void> {
+  // Download compose from the artifact metadata: ComposeGithubReleaseArtifactMetadata
+  // this will download it to the storage bin folder as well as make it executeable
+  async download(release: ComposeGithubReleaseArtifactMetadata): Promise<void> {
     // Get asset id
     const assetId = await this.composeGitHubReleases.getReleaseAssetId(release.id, platform(), arch());
 
-    // Get the storage and check to see if it exists before we install Compose
+    // Get the storage and check to see if it exists before we download Compose
     const storageData = this.extensionContext.storagePath;
     const storageBinFolder = path.resolve(storageData, 'bin');
     if (!existsSync(storageBinFolder)) {

--- a/extensions/compose/src/handler.ts
+++ b/extensions/compose/src/handler.ts
@@ -66,14 +66,14 @@ async function handleComposeBinaryToggle(
 }
 
 // Install the compose binary to the system from the local storage path
-async function installComposeBinary(detect: Detect, extensionContext: extensionApi.ExtensionContext): Promise<void> {
+export async function installComposeBinary(
+  detect: Detect,
+  extensionContext: extensionApi.ExtensionContext,
+): Promise<void> {
   const storagePath = await detect.getStoragePath();
   if (storagePath) {
     try {
       await installBinaryToSystem(storagePath, 'docker-compose');
-      await extensionApi.window.showInformationMessage(
-        `Compose binary has been successfully installed system-wide. Try with 'docker-compose' or 'podman compose' commands.`,
-      );
     } catch (error) {
       console.error(error);
       await extensionApi.window.showErrorMessage(`Unable to install docker-compose binary: ${error}`);


### PR DESCRIPTION
refactor: updated compose onboarding installation

### What does this PR do?

* Installation is now Download which is more correct and files updated
  (installation.ts now download.ts)
* Onboarding compose process is more flowing and streamlined, the
  system-wide install is now it's own step as it's required for
  onboarding
* Updated documentation on how to use compose within the onboarding
  process

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast
explaining what is doing this PR -->

https://github.com/containers/podman-desktop/assets/6422176/e85fc64f-d133-4d32-b9cb-caf66398212f




### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop/issues/4475
Closes https://github.com/containers/podman-desktop/issues/4476

### How to test this PR?

Go through the onboarding process on a non-linux machine. If you are on
a linux machine, you should NOT see the setup button anymore.

<!-- Please explain steps to reproduce -->
