### PR TITLE
feat: tabs in containers list to filter running/stopped

### DIFF
--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -94,7 +94,10 @@ window.events?.receive('display-troubleshooting', () => {
           <DashboardPage />
         </Route>
         <Route path="/containers/*" firstmatch>
-          <Route path="/list/*" breadcrumb="Containers" navigationHint="root">
+          <Route path="/">
+            <ContainerList searchTerm="{meta.query.filter || ''}" />
+          </Route>
+          <Route path="/list/:id" breadcrumb="Containers" navigationHint="root">
             <ContainerList searchTerm="{meta.query.filter || ''}" />
           </Route>
           <Route path="/:id/*" breadcrumb="Container Details" let:meta navigationHint="details">

--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -95,10 +95,10 @@ window.events?.receive('display-troubleshooting', () => {
         </Route>
         <Route path="/containers/*" firstmatch>
           <Route path="/">
-            <ContainerList searchTerm="{meta.query.filter || ''}" />
+            <ContainerList filter="{meta.query.filter || ''}" />
           </Route>
           <Route path="/list/:id" breadcrumb="Containers" navigationHint="root">
-            <ContainerList searchTerm="{meta.query.filter || ''}" />
+            <ContainerList filter="{meta.query.filter || ''}" />
           </Route>
           <Route path="/:id/*" breadcrumb="Container Details" let:meta navigationHint="details">
             <ContainerDetails containerID="{meta.params.id}" />

--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -93,7 +93,7 @@ window.events?.receive('display-troubleshooting', () => {
         <Route path="/" breadcrumb="Dashboard Page">
           <DashboardPage />
         </Route>
-        <Route path="/containers/*" breadcrumb="Containers" navigationHint="root">
+        <Route path="/containerslist/*" breadcrumb="Containers" navigationHint="root">
           <ContainerList searchTerm="{meta.query.filter || ''}" />
         </Route>
         <Route path="/containers/:id/*" breadcrumb="Container Details" let:meta navigationHint="details">

--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -93,7 +93,7 @@ window.events?.receive('display-troubleshooting', () => {
         <Route path="/" breadcrumb="Dashboard Page">
           <DashboardPage />
         </Route>
-        <Route path="/containers" breadcrumb="Containers" navigationHint="root">
+        <Route path="/containers/*" breadcrumb="Containers" navigationHint="root">
           <ContainerList searchTerm="{meta.query.filter || ''}" />
         </Route>
         <Route path="/containers/:id/*" breadcrumb="Container Details" let:meta navigationHint="details">

--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -93,13 +93,14 @@ window.events?.receive('display-troubleshooting', () => {
         <Route path="/" breadcrumb="Dashboard Page">
           <DashboardPage />
         </Route>
-        <Route path="/containerslist/*" breadcrumb="Containers" navigationHint="root">
-          <ContainerList searchTerm="{meta.query.filter || ''}" />
+        <Route path="/containers/*" firstmatch>
+          <Route path="/list/*" breadcrumb="Containers" navigationHint="root">
+            <ContainerList searchTerm="{meta.query.filter || ''}" />
+          </Route>
+          <Route path="/:id/*" breadcrumb="Container Details" let:meta navigationHint="details">
+            <ContainerDetails containerID="{meta.params.id}" />
+          </Route>
         </Route>
-        <Route path="/containers/:id/*" breadcrumb="Container Details" let:meta navigationHint="details">
-          <ContainerDetails containerID="{meta.params.id}" />
-        </Route>
-
         <Route path="/kube/play" breadcrumb="Play Kubernetes YAML">
           <KubePlayYAML />
         </Route>

--- a/packages/renderer/src/AppNavigation.svelte
+++ b/packages/renderer/src/AppNavigation.svelte
@@ -115,7 +115,7 @@ export let meta: TinroRouteMeta;
         ></svg>
     </div>
   </NavItem>
-  <NavItem href="/containers/list/all" tooltip="Containers{containerCount}" ariaLabel="Containers" bind:meta="{meta}">
+  <NavItem href="/containers" tooltip="Containers{containerCount}" ariaLabel="Containers" bind:meta="{meta}">
     <ContainerIcon size="24" />
   </NavItem>
   <NavItem href="/pods" tooltip="Pods{podCount}" ariaLabel="Pods" bind:meta="{meta}">

--- a/packages/renderer/src/AppNavigation.svelte
+++ b/packages/renderer/src/AppNavigation.svelte
@@ -115,7 +115,7 @@ export let meta: TinroRouteMeta;
         ></svg>
     </div>
   </NavItem>
-  <NavItem href="/containers" tooltip="Containers{containerCount}" ariaLabel="Containers" bind:meta="{meta}">
+  <NavItem href="/containers/all" tooltip="Containers{containerCount}" ariaLabel="Containers" bind:meta="{meta}">
     <ContainerIcon size="24" />
   </NavItem>
   <NavItem href="/pods" tooltip="Pods{podCount}" ariaLabel="Pods" bind:meta="{meta}">

--- a/packages/renderer/src/AppNavigation.svelte
+++ b/packages/renderer/src/AppNavigation.svelte
@@ -115,7 +115,7 @@ export let meta: TinroRouteMeta;
         ></svg>
     </div>
   </NavItem>
-  <NavItem href="/containers/all" tooltip="Containers{containerCount}" ariaLabel="Containers" bind:meta="{meta}">
+  <NavItem href="/containerslist/all" tooltip="Containers{containerCount}" ariaLabel="Containers" bind:meta="{meta}">
     <ContainerIcon size="24" />
   </NavItem>
   <NavItem href="/pods" tooltip="Pods{podCount}" ariaLabel="Pods" bind:meta="{meta}">

--- a/packages/renderer/src/AppNavigation.svelte
+++ b/packages/renderer/src/AppNavigation.svelte
@@ -115,7 +115,7 @@ export let meta: TinroRouteMeta;
         ></svg>
     </div>
   </NavItem>
-  <NavItem href="/containerslist/all" tooltip="Containers{containerCount}" ariaLabel="Containers" bind:meta="{meta}">
+  <NavItem href="/containers/list/all" tooltip="Containers{containerCount}" ariaLabel="Containers" bind:meta="{meta}">
     <ContainerIcon size="24" />
   </NavItem>
   <NavItem href="/pods" tooltip="Pods{podCount}" ariaLabel="Pods" bind:meta="{meta}">

--- a/packages/renderer/src/lib/ContainerList.spec.ts
+++ b/packages/renderer/src/lib/ContainerList.spec.ts
@@ -585,7 +585,7 @@ test('Expect to display running / stopped containers depending on tab', async ()
         'pod1 (pod) 2 containers',
         'container1-pod1 RUNNING',
         'container2-pod1 RUNNING',
-        'pod2 (pod) 1 container',
+        'pod2 (pod) 2 containers (1 filtered)',
         'container1-pod2 RUNNING',
       ],
       absentLabels: [/container2-pod2.*/, /pod3 \(pod\).*/, /container1-pod3.*/, /container2-pod3.*/],
@@ -593,7 +593,7 @@ test('Expect to display running / stopped containers depending on tab', async ()
     {
       tabLabel: 'Stopped containers',
       presentCells: [
-        'pod2 (pod) 1 container',
+        'pod2 (pod) 2 containers (1 filtered)',
         'container2-pod2 STOPPED',
         'pod3 (pod) 2 containers',
         'container1-pod3 STOPPED',

--- a/packages/renderer/src/lib/ContainerList.spec.ts
+++ b/packages/renderer/src/lib/ContainerList.spec.ts
@@ -100,6 +100,9 @@ test('Expect no containers being displayed', async () => {
   }
   await waitRender({});
 
+  const allTab = screen.getByRole('link', { name: 'All containers' });
+  await fireEvent.click(allTab);
+
   const noContainers = screen.getByRole('heading', { name: 'No containers' });
   expect(noContainers).toBeInTheDocument();
 
@@ -190,6 +193,9 @@ test('Try to delete a pod that has containers', async () => {
   }
   await waitRender({});
 
+  const allTab = screen.getByRole('link', { name: 'All containers' });
+  await fireEvent.click(allTab);
+
   // select the checkbox
   const checkbox = screen.getByRole('checkbox', { name: 'Toggle all' });
   expect(checkbox).toBeInTheDocument();
@@ -270,6 +276,9 @@ test('Try to delete a container without deleting pods', async () => {
   }
 
   await waitRender({});
+
+  const allTab = screen.getByRole('link', { name: 'All containers' });
+  await fireEvent.click(allTab);
 
   // select the standalone container checkbox
   const containerCheckbox = screen.getAllByRole('checkbox', { name: 'Toggle container' });
@@ -352,6 +361,9 @@ test('Try to delete a pod without deleting container', async () => {
 
   await waitRender({});
 
+  const allTab = screen.getByRole('link', { name: 'All containers' });
+  await fireEvent.click(allTab);
+
   // select the pod checkbox
   const podCheckbox = screen.getByRole('checkbox', { name: 'Toggle pod' });
   expect(podCheckbox).toBeInTheDocument();
@@ -418,6 +430,9 @@ test('Expect filter empty screen', async () => {
   }
   await waitRender({ searchTerm: 'No match' });
 
+  const allTab = screen.getByRole('link', { name: 'All containers' });
+  await fireEvent.click(allTab);
+
   const filterButton = screen.getByRole('button', { name: 'Clear filter' });
   expect(filterButton).toBeInTheDocument();
 });
@@ -442,10 +457,11 @@ test('Expect to display running / stopped containers depending on tab', async ()
   const pod3Id = 'pod3-id';
 
   // one single container and two containers part of a pod
+  const firstId = 'sha256:68347658374683476';
   const mockedContainers = [
     // 2 / 2 containers are running on this pod
     {
-      Id: 'sha256:456456456456456',
+      Id: firstId,
       Image: 'sha256:234',
       Names: ['container1-pod1'],
       RepoTags: ['veryold:image'],
@@ -538,7 +554,7 @@ test('Expect to display running / stopped containers depending on tab', async ()
   window.dispatchEvent(new CustomEvent('tray:update-provider'));
 
   // wait store are populated
-  while (get(containersInfos).length === 0) {
+  while (get(containersInfos).length === 0 || get(containersInfos)[0].Id !== firstId) {
     await new Promise(resolve => setTimeout(resolve, 500));
   }
 
@@ -549,7 +565,7 @@ test('Expect to display running / stopped containers depending on tab', async ()
 
   const tests = [
     {
-      tabLabel: undefined,
+      tabLabel: 'All containers',
       presentCells: [
         'pod1 (pod) 2 containers',
         'container1-pod1 RUNNING',

--- a/packages/renderer/src/lib/ContainerList.spec.ts
+++ b/packages/renderer/src/lib/ContainerList.spec.ts
@@ -428,7 +428,7 @@ test('Expect filter empty screen', async () => {
   while (get(providerInfos).length === 0) {
     await new Promise(resolve => setTimeout(resolve, 500));
   }
-  await waitRender({ searchTerm: 'No match' });
+  await waitRender({ filter: 'No match' });
 
   const allTab = screen.getByRole('link', { name: 'All containers' });
   await fireEvent.click(allTab);

--- a/packages/renderer/src/lib/ContainerList.svelte
+++ b/packages/renderer/src/lib/ContainerList.svelte
@@ -59,6 +59,18 @@ let stoppedFilter: boolean;
 
 $: filterObj = new Filter(decodeURI(filter));
 
+$: checkFilter(filterObj.rawFilter);
+
+function checkFilter(_: string): void {
+  if (filterObj.isRunning() && !runningFilter) {
+    router.goto(`/containers/list/running?filter=${filterObj.setState(true, false)}`);
+  } else if (filterObj.isStopped() && !stoppedFilter) {
+    router.goto(`/containers/list/stopped?filter=${filterObj.setState(false, true)}`);
+  } else if (!filterObj.isStopped() && !filterObj.isRunning() && (runningFilter || stoppedFilter)) {
+    router.goto(`/containers/list/all?filter=${filterObj.setState(false, false)}`);
+  }
+}
+
 interface FilterOptions {
   searchTerm: string;
   runningFilter: boolean;

--- a/packages/renderer/src/lib/ContainerList.svelte
+++ b/packages/renderer/src/lib/ContainerList.svelte
@@ -244,6 +244,10 @@ onMount(async () => {
 
   routeUnsubscribe = router.subscribe(route => {
     tab = route.path.substring(route.path.lastIndexOf('/') + 1);
+    if (tab === 'containers') {
+      router.goto('/containers/list/all');
+      return;
+    }
     runningFilter = tab === 'running';
     stoppedFilter = tab === 'stopped';
   });

--- a/packages/renderer/src/lib/ContainerList.svelte
+++ b/packages/renderer/src/lib/ContainerList.svelte
@@ -458,9 +458,9 @@ function errorCallback(container: ContainerInfoUI, errorMessage: string): void {
   </div>
 
   <div class="flex flex-row px-2 mb-2 border-b border-charcoal-400" slot="tabs">
-    <Tab title="All containers" url="all" />
-    <Tab title="Running containers" url="running" />
-    <Tab title="Stopped containers" url="stopped" />
+    <Tab title="All containers" url="{`all?filter=${searchTerm}`}" />
+    <Tab title="Running containers" url="{`running?filter=${searchTerm}`}" />
+    <Tab title="Stopped containers" url="{`stopped?filter=${searchTerm}`}" />
   </div>
 
   <div class="flex min-w-full h-full" slot="content">

--- a/packages/renderer/src/lib/ContainerList.svelte
+++ b/packages/renderer/src/lib/ContainerList.svelte
@@ -62,12 +62,16 @@ $: filterObj = new Filter(decodeURI(filter));
 $: checkFilter(filterObj.rawFilter);
 
 function checkFilter(_: string): void {
+  let url: string | undefined = undefined;
   if (filterObj.isRunning() && !runningFilter) {
-    router.goto(`/containers/list/running?filter=${filterObj.setState(true, false)}`);
+    url = filterObj.createRunningURL();
   } else if (filterObj.isStopped() && !stoppedFilter) {
-    router.goto(`/containers/list/stopped?filter=${filterObj.setState(false, true)}`);
+    url = filterObj.createStoppedURL();
   } else if (!filterObj.isStopped() && !filterObj.isRunning() && (runningFilter || stoppedFilter)) {
-    router.goto(`/containers/list/all?filter=${filterObj.setState(false, false)}`);
+    url = filterObj.createAllURL();
+  }
+  if (url !== undefined) {
+    router.goto('/containers/list/' + url);
   }
 }
 
@@ -489,9 +493,9 @@ function errorCallback(container: ContainerInfoUI, errorMessage: string): void {
   </div>
 
   <div class="flex flex-row px-2 mb-2 border-b border-charcoal-400" slot="tabs">
-    <Tab title="All containers" url="{`all?filter=${filterObj.setState(false, false)}`}" />
-    <Tab title="Running containers" url="{`running?filter=${filterObj.setState(true, false)}`}" />
-    <Tab title="Stopped containers" url="{`stopped?filter=${filterObj.setState(false, true)}`}" />
+    <Tab title="All containers" url="{filterObj.createAllURL()}" />
+    <Tab title="Running containers" url="{filterObj.createRunningURL()}" />
+    <Tab title="Stopped containers" url="{filterObj.createStoppedURL()}" />
   </div>
 
   <div class="flex min-w-full h-full" slot="content">

--- a/packages/renderer/src/lib/ContainerList.svelte
+++ b/packages/renderer/src/lib/ContainerList.svelte
@@ -453,7 +453,7 @@ function errorCallback(container: ContainerInfoUI, errorMessage: string): void {
     {/if}
   </div>
 
-  <div class="flex flex-row px-2 border-b border-charcoal-400" slot="tabs">
+  <div class="flex flex-row px-2 mb-2 border-b border-charcoal-400" slot="tabs">
     <Tab title="All containers" url="all" />
     <Tab title="Running containers" url="running" />
     <Tab title="Stopped containers" url="stopped" />

--- a/packages/renderer/src/lib/ContainerList.svelte
+++ b/packages/renderer/src/lib/ContainerList.svelte
@@ -49,6 +49,9 @@ let enginesList: EngineInfoUI[];
 
 // groups of containers that will be displayed
 let containerGroups: ContainerGroupInfoUI[] = [];
+
+let tab: string;
+
 export let searchTerm = '';
 let runningFilter: boolean;
 let stoppedFilter: boolean;
@@ -240,9 +243,9 @@ onMount(async () => {
   });
 
   routeUnsubscribe = router.subscribe(route => {
-    const f = route.path.substring(route.path.lastIndexOf('/') + 1);
-    runningFilter = f === 'running';
-    stoppedFilter = f === 'stopped';
+    tab = route.path.substring(route.path.lastIndexOf('/') + 1);
+    runningFilter = tab === 'running';
+    stoppedFilter = tab === 'stopped';
   });
 });
 
@@ -663,7 +666,7 @@ function errorCallback(container: ContainerInfoUI, errorMessage: string): void {
       {#if searchTerm}
         <FilteredEmptyScreen icon="{ContainerIcon}" kind="containers" bind:searchTerm="{searchTerm}" />
       {:else}
-        <ContainerEmptyScreen />
+        <ContainerEmptyScreen selected="{tab}" />
       {/if}
     {/if}
   </div>

--- a/packages/renderer/src/lib/ContainerList.svelte
+++ b/packages/renderer/src/lib/ContainerList.svelte
@@ -59,9 +59,9 @@ let stoppedFilter: boolean;
 
 $: filterObj = new Filter(decodeURI(filter));
 
-$: checkFilter(filterObj.rawFilter);
+$: filterObj.rawFilter && checkFilter();
 
-function checkFilter(_: string): void {
+function checkFilter(): void {
   let url: string | undefined = undefined;
   if (filterObj.isRunning() && !runningFilter) {
     url = filterObj.createRunningURL();

--- a/packages/renderer/src/lib/ContainerList.svelte
+++ b/packages/renderer/src/lib/ContainerList.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { onDestroy, onMount } from 'svelte';
-import { filtered, searchPattern, containersInfos } from '../stores/containers';
+import { filtered, searchPattern, containersInfos, runningFilter, stoppedFilter } from '../stores/containers';
 import { viewsContributions } from '../stores/views';
 import { context } from '../stores/context';
 
@@ -40,6 +40,7 @@ import type { ContextUI } from './context/context';
 import Button from './ui/Button.svelte';
 import StateChange from './ui/StateChange.svelte';
 import SolidPodIcon from './images/SolidPodIcon.svelte';
+import Tab from './ui/Tab.svelte';
 
 const containerUtils = new ContainerUtils();
 let openChoiceModal = false;
@@ -59,6 +60,12 @@ function fromExistingImage(): void {
 }
 
 let multipleEngines = false;
+
+router.subscribe(route => {
+  const f = route.path.substring(route.path.lastIndexOf('/') + 1);
+  runningFilter.set(f === 'running');
+  stoppedFilter.set(f === 'stopped');
+});
 
 $: providerConnections = $providerInfos
   .map(provider => provider.containerConnections)
@@ -438,6 +445,12 @@ function errorCallback(container: ContainerInfoUI, errorMessage: string): void {
         icon="{SolidPodIcon}" />
       <span class="pl-2">On {selectedItemsNumber} selected items.</span>
     {/if}
+  </div>
+
+  <div class="flex flex-row px-2 border-b border-charcoal-400" slot="tabs">
+    <Tab title="All containers" url="all" />
+    <Tab title="Running containers" url="running" />
+    <Tab title="Stopped containers" url="stopped" />
   </div>
 
   <div class="flex min-w-full h-full" slot="content">

--- a/packages/renderer/src/lib/container/ContainerEmptyScreen.svelte
+++ b/packages/renderer/src/lib/container/ContainerEmptyScreen.svelte
@@ -1,10 +1,41 @@
 <script lang="ts">
 import EmptyScreen from '../ui/EmptyScreen.svelte';
 import ContainerIcon from '../images/ContainerIcon.svelte';
+
+export let selected: string;
+
+$: title = getTitle(selected);
+$: message = getMessage(selected);
+$: commandLine = getCommandLine(selected);
+
+function getTitle(selected: string): string {
+  switch (selected) {
+    case 'running':
+      return 'No running containers';
+    case 'stopped':
+      return 'No stopped containers';
+    default:
+      return 'No containers';
+  }
+}
+
+function getMessage(selected: string): string {
+  switch (selected) {
+    case 'stopped':
+      return '';
+    default:
+      return 'Run a first container using the following command line:';
+  }
+}
+
+function getCommandLine(selected: string): string {
+  switch (selected) {
+    case 'stopped':
+      return '';
+    default:
+      return 'podman run quay.io/podman/hello';
+  }
+}
 </script>
 
-<EmptyScreen
-  icon="{ContainerIcon}"
-  title="No containers"
-  message="Run a first container using the following command line:"
-  commandline="podman run quay.io/podman/hello" />
+<EmptyScreen icon="{ContainerIcon}" title="{title}" message="{message}" commandline="{commandLine}" />

--- a/packages/renderer/src/lib/container/ContainerInfoUI.ts
+++ b/packages/renderer/src/lib/container/ContainerInfoUI.ts
@@ -75,6 +75,9 @@ export interface ContainerGroupInfoUI extends ContainerGroupPartInfoUI {
 
   selected: boolean;
 
+  // can be different from containers.length when a filter is applied on containers
+  allContainersCount: number;
+
   // list of containers in this group
   containers: ContainerInfoUI[];
 }

--- a/packages/renderer/src/lib/container/container-utils.ts
+++ b/packages/renderer/src/lib/container/container-utils.ts
@@ -193,7 +193,13 @@ export class ContainerUtils {
       const group = containerInfo.groupInfo;
       if (group.type === ContainerGroupInfoTypeUI.STANDALONE) {
         // standalone group, insert with id as key
-        groups.set(containerInfo.id, { ...group, containers: [containerInfo], expanded: true, selected: false });
+        groups.set(containerInfo.id, {
+          ...group,
+          containers: [containerInfo],
+          allContainersCount: 1,
+          expanded: true,
+          selected: false,
+        });
       } else {
         if (!groups.has(group.name)) {
           groups.set(group.name, {
@@ -206,11 +212,13 @@ export class ContainerUtils {
             engineId: group.engineId,
             engineType: group.engineType,
             containers: [],
+            allContainersCount: 0,
           });
         }
         groups.get(group.name)?.containers.push(containerInfo);
       }
     });
+    groups.forEach(group => (group.allContainersCount = group.containers.length));
 
     Array.from(groups.values())
       .filter(group => group.type === ContainerGroupInfoTypeUI.COMPOSE)

--- a/packages/renderer/src/lib/container/filter.ts
+++ b/packages/renderer/src/lib/container/filter.ts
@@ -29,4 +29,16 @@ export class Filter {
   isStopped(): boolean {
     return this.rawFilter.split(' ').includes('is:stopped');
   }
+
+  createRunningURL() {
+    return `running?filter=${this.setState(true, false)}`;
+  }
+
+  createStoppedURL() {
+    return `stopped?filter=${this.setState(false, true)}`;
+  }
+
+  createAllURL() {
+    return `all?filter=${this.setState(false, false)}`;
+  }
 }

--- a/packages/renderer/src/lib/container/filter.ts
+++ b/packages/renderer/src/lib/container/filter.ts
@@ -21,4 +21,12 @@ export class Filter {
     }
     return parts.join(' ');
   }
+
+  isRunning(): boolean {
+    return this.rawFilter.split(' ').includes('is:running');
+  }
+
+  isStopped(): boolean {
+    return this.rawFilter.split(' ').includes('is:stopped');
+  }
 }

--- a/packages/renderer/src/lib/container/filter.ts
+++ b/packages/renderer/src/lib/container/filter.ts
@@ -1,0 +1,24 @@
+export class Filter {
+  rawFilter: string;
+
+  constructor(filter: string) {
+    this.rawFilter = filter;
+  }
+
+  searchTerm(): string {
+    return this.rawFilter
+      .split(' ')
+      .filter(part => !part.startsWith('is:'))
+      .join(' ');
+  }
+
+  setState(isRunning: boolean, isStopped: boolean): string {
+    const parts = this.rawFilter.split(' ').filter(part => !part.startsWith('is:'));
+    if (isRunning) {
+      parts.push('is:running');
+    } else if (isStopped) {
+      parts.push('is:stopped');
+    }
+    return parts.join(' ');
+  }
+}

--- a/packages/renderer/src/lib/image/RunImage.spec.ts
+++ b/packages/renderer/src/lib/image/RunImage.spec.ts
@@ -46,6 +46,7 @@ beforeAll(() => {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  router.goto('/');
 });
 
 async function waitRender() {

--- a/packages/renderer/src/lib/image/RunImage.spec.ts
+++ b/packages/renderer/src/lib/image/RunImage.spec.ts
@@ -398,7 +398,7 @@ describe('RunImage', () => {
     await new Promise(resolve => setTimeout(resolve, 200));
 
     // expect to be redirected to containers page as there is no tty
-    expect(gotoSpy).toHaveBeenCalledWith('/containerslist/all');
+    expect(gotoSpy).toHaveBeenCalledWith('/containers/list/all');
   });
 
   test('Expect able to play with environment files', async () => {

--- a/packages/renderer/src/lib/image/RunImage.spec.ts
+++ b/packages/renderer/src/lib/image/RunImage.spec.ts
@@ -397,7 +397,7 @@ describe('RunImage', () => {
     await new Promise(resolve => setTimeout(resolve, 200));
 
     // expect to be redirected to containers page as there is no tty
-    expect(gotoSpy).toHaveBeenCalledWith('/containers');
+    expect(gotoSpy).toHaveBeenCalledWith('/containers/all');
   });
 
   test('Expect able to play with environment files', async () => {

--- a/packages/renderer/src/lib/image/RunImage.spec.ts
+++ b/packages/renderer/src/lib/image/RunImage.spec.ts
@@ -397,7 +397,7 @@ describe('RunImage', () => {
     await new Promise(resolve => setTimeout(resolve, 200));
 
     // expect to be redirected to containers page as there is no tty
-    expect(gotoSpy).toHaveBeenCalledWith('/containers/all');
+    expect(gotoSpy).toHaveBeenCalledWith('/containerslist/all');
   });
 
   test('Expect able to play with environment files', async () => {

--- a/packages/renderer/src/lib/image/RunImage.svelte
+++ b/packages/renderer/src/lib/image/RunImage.svelte
@@ -377,7 +377,7 @@ async function startContainer() {
     if (Tty && OpenStdin) {
       router.goto(`/containers/${data.id}/tty`);
     } else {
-      router.goto('/containers/all');
+      router.goto('/containerslist/all');
     }
   } catch (e) {
     createError = String(e);

--- a/packages/renderer/src/lib/image/RunImage.svelte
+++ b/packages/renderer/src/lib/image/RunImage.svelte
@@ -377,7 +377,7 @@ async function startContainer() {
     if (Tty && OpenStdin) {
       router.goto(`/containers/${data.id}/tty`);
     } else {
-      router.goto('/containers');
+      router.goto('/containers/all');
     }
   } catch (e) {
     createError = String(e);

--- a/packages/renderer/src/lib/image/RunImage.svelte
+++ b/packages/renderer/src/lib/image/RunImage.svelte
@@ -377,7 +377,7 @@ async function startContainer() {
     if (Tty && OpenStdin) {
       router.goto(`/containers/${data.id}/tty`);
     } else {
-      router.goto('/containerslist/all');
+      router.goto('/containers/list/all');
     }
   } catch (e) {
     createError = String(e);

--- a/packages/renderer/src/lib/pod/PodCreateFromContainers.svelte
+++ b/packages/renderer/src/lib/pod/PodCreateFromContainers.svelte
@@ -304,7 +304,7 @@ function updatePortExposure(port: number, checked: boolean) {
 
         <div class="w-full grid justify-items-end">
           <div>
-            <Button type="link" on:click="{() => router.goto('/containerslist/all')}">Close</Button>
+            <Button type="link" on:click="{() => router.goto('/containers/list/all')}">Close</Button>
             <Button
               icon="{SolidPodIcon}"
               bind:disabled="{createInProgress}"

--- a/packages/renderer/src/lib/pod/PodCreateFromContainers.svelte
+++ b/packages/renderer/src/lib/pod/PodCreateFromContainers.svelte
@@ -304,7 +304,7 @@ function updatePortExposure(port: number, checked: boolean) {
 
         <div class="w-full grid justify-items-end">
           <div>
-            <Button type="link" on:click="{() => router.goto('/containers')}">Close</Button>
+            <Button type="link" on:click="{() => router.goto('/containers/all')}">Close</Button>
             <Button
               icon="{SolidPodIcon}"
               bind:disabled="{createInProgress}"

--- a/packages/renderer/src/lib/pod/PodCreateFromContainers.svelte
+++ b/packages/renderer/src/lib/pod/PodCreateFromContainers.svelte
@@ -304,7 +304,7 @@ function updatePortExposure(port: number, checked: boolean) {
 
         <div class="w-full grid justify-items-end">
           <div>
-            <Button type="link" on:click="{() => router.goto('/containers/all')}">Close</Button>
+            <Button type="link" on:click="{() => router.goto('/containerslist/all')}">Close</Button>
             <Button
               icon="{SolidPodIcon}"
               bind:disabled="{createInProgress}"

--- a/packages/renderer/src/lib/pod/PodsList.svelte
+++ b/packages/renderer/src/lib/pod/PodsList.svelte
@@ -130,7 +130,7 @@ function openDetailsPod(pod: PodInfoUI) {
 }
 
 function openContainersFromPod(pod: PodInfoUI) {
-  router.goto(`/containers/?filter=${pod.shortId}`);
+  router.goto(`/containers/list/all?filter=${pod.shortId}`);
 }
 
 let refreshTimeouts: NodeJS.Timeout[] = [];

--- a/packages/renderer/src/lib/ui/NavPage.svelte
+++ b/packages/renderer/src/lib/ui/NavPage.svelte
@@ -16,6 +16,7 @@ export let searchEnabled = true;
         </div>
       </div>
     </div>
+    <slot name="tabs" />
     {#if searchEnabled}
       <div class="flex flex-row pb-4" role="region" aria-label="search">
         <div class="pl-5 lg:w-[35rem] w-[22rem]">

--- a/packages/renderer/src/lib/ui/NavPage.svelte
+++ b/packages/renderer/src/lib/ui/NavPage.svelte
@@ -16,7 +16,6 @@ export let searchEnabled = true;
         </div>
       </div>
     </div>
-    <slot name="tabs" />
     {#if searchEnabled}
       <div class="flex flex-row pb-4" role="region" aria-label="search">
         <div class="pl-5 lg:w-[35rem] w-[22rem]">
@@ -46,6 +45,8 @@ export let searchEnabled = true;
         </div>
       </div>
     {/if}
+
+    <slot name="tabs" />
 
     <div class="flex w-full h-full overflow-auto" role="region" aria-label="content">
       <slot name="content" />

--- a/packages/renderer/src/lib/ui/Tab.svelte
+++ b/packages/renderer/src/lib/ui/Tab.svelte
@@ -4,13 +4,15 @@ import { router } from 'tinro';
 export let url: string;
 export let title: string;
 
+$: urlWithoutParams = url.split('?')[0];
+
 let baseURL = $router.path.substring(0, $router.path.lastIndexOf('/'));
 </script>
 
 <div
   class="pb-2 border-b-[3px] border-charcoal-700 whitespace-nowrap hover:cursor-pointer"
-  class:border-purple-500="{$router.path === baseURL + '/' + url}"
-  class:hover:border-charcoal-100="{$router.path !== baseURL + '/' + url}">
+  class:border-purple-500="{$router.path === baseURL + '/' + urlWithoutParams}"
+  class:hover:border-charcoal-100="{$router.path !== baseURL + '/' + urlWithoutParams}">
   <a
     href="{baseURL}/{url}"
     class="px-4 py-2 text-gray-600 no-underline"

--- a/packages/renderer/src/stores/containers.ts
+++ b/packages/renderer/src/stores/containers.ts
@@ -16,9 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { writable, derived, type Writable } from 'svelte/store';
+import { writable, type Writable } from 'svelte/store';
 import type { ContainerInfo } from '../../../main/src/plugin/api/container-info';
-import { findMatchInLeaves } from './search-util';
 import { EventStore } from './event-store';
 import ContainerIcon from '../lib/images/ContainerIcon.svelte';
 
@@ -63,23 +62,3 @@ const containersEventStore = new EventStore<ContainerInfo[]>(
   ContainerIcon,
 );
 containersEventStore.setupWithDebounce();
-
-export const searchPattern = writable('');
-export const runningFilter = writable(false);
-export const stoppedFilter = writable(false);
-
-export const filtered = derived(
-  [searchPattern, runningFilter, stoppedFilter, containersInfos],
-  ([$searchPattern, $runningFilter, $stoppedFilter, $containersInfos]) =>
-    $containersInfos
-      .filter(containerInfo => findMatchInLeaves(containerInfo, $searchPattern.toLowerCase()))
-      .filter(containerInfo => {
-        if ($runningFilter) {
-          return containerInfo.State.toUpperCase() === 'RUNNING';
-        }
-        if ($stoppedFilter) {
-          return containerInfo.State.toUpperCase() !== 'RUNNING';
-        }
-        return true;
-      }),
-);

--- a/packages/renderer/src/stores/containers.ts
+++ b/packages/renderer/src/stores/containers.ts
@@ -65,7 +65,21 @@ const containersEventStore = new EventStore<ContainerInfo[]>(
 containersEventStore.setupWithDebounce();
 
 export const searchPattern = writable('');
+export const runningFilter = writable(false);
+export const stoppedFilter = writable(false);
 
-export const filtered = derived([searchPattern, containersInfos], ([$searchPattern, $containersInfos]) =>
-  $containersInfos.filter(containerInfo => findMatchInLeaves(containerInfo, $searchPattern.toLowerCase())),
+export const filtered = derived(
+  [searchPattern, runningFilter, stoppedFilter, containersInfos],
+  ([$searchPattern, $runningFilter, $stoppedFilter, $containersInfos]) =>
+    $containersInfos
+      .filter(containerInfo => findMatchInLeaves(containerInfo, $searchPattern.toLowerCase()))
+      .filter(containerInfo => {
+        if ($runningFilter) {
+          return containerInfo.State.toUpperCase() === 'RUNNING';
+        }
+        if ($stoppedFilter) {
+          return containerInfo.State.toUpperCase() !== 'RUNNING';
+        }
+        return true;
+      }),
 );

--- a/tests/src/model/workbench/navigation.ts
+++ b/tests/src/model/workbench/navigation.ts
@@ -17,7 +17,7 @@ export class NavigationBar {
     this.page = page;
     this.navigationLocator = this.page.getByRole('navigation', { name: 'AppNavigation' });
     this.imagesLink = this.page.getByRole('link', { name: 'Images' });
-    this.containersLink = this.page.getByRole('link', { name: 'Containers' });
+    this.containersLink = this.page.getByRole('link', { name: 'Containers', exact: true });
     this.podsLink = this.page.getByRole('link', { name: 'Pods' });
     this.volumesLink = this.page.getByRole('link', { name: 'Volumes' });
     this.dashboardLink = this.page.getByRole('link', { name: 'Dashboard' });


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

This PR adds tabs to the Containers List page, to filter on Running / Stopped containers.

When the user moves to a Running / Stopped tab, the filter "is:running" / "is:stopped" is added to the filter field.

When the user adds / removes the "is:running" / "is:stopped" text from the filter field, the UI changes the tab accordingly.

Tje filter field content is kept when the user swicthes from one tab to another (the filters is:running / is:stopped being modified, the rest of the filter being kept).

Groups of containers:
- After filtering containers, only groups with remaining containers are displayed
- The number of all containers (before filtering) for a group is displayed, and if some containers are filtered, the number of filtered containers is also displayed. For example `2 containers (1 filtered)` indicates that the group contains 2 containers, but only 1 is displayed because the other one is filtered.


### Screenshot/screencast of this PR

### What issues does this PR fix or reference?

Fixes #707 

### How to test this PR?

<!-- Please explain steps to reproduce -->
