### PR TITLE
feat: allow image push to lima kubernetes cluster

### DIFF
--- a/extensions/lima/package.json
+++ b/extensions/lima/package.json
@@ -36,7 +36,21 @@
           "description": "Instance name (default is same name as type)"
         }
       }
-    }
+    },
+    "menus": {
+      "dashboard/image": [
+        {
+          "command": "lima.image.move",
+          "title": "Push image to Lima cluster"
+        }
+      ]
+    },
+    "commands": [
+      {
+        "command": "lima.image.move",
+        "title": "Lima: Move image to cluster..."
+      }
+    ]
   },
   "scripts": {
     "build": "vite build && node ./scripts/build.js",
@@ -51,6 +65,7 @@
     "adm-zip": "^0.5.10",
     "mkdirp": "^3.0.1",
     "vite": "^5.0.10",
-    "vitest": "^1.1.0"
+    "vitest": "^1.1.0",
+    "tmp-promise": "^3.0.3"
   }
 }

--- a/extensions/lima/package.json
+++ b/extensions/lima/package.json
@@ -14,6 +14,12 @@
     "configuration": {
       "title": "Lima",
       "properties": {
+        "lima.binary.path": {
+          "type": "string",
+          "format": "file",
+          "default": "",
+          "description": "Custom path to limactl binary (Default is blank)"
+        },
         "lima.type": {
           "type": "string",
           "default": "podman",

--- a/extensions/lima/src/image-handler.ts
+++ b/extensions/lima/src/image-handler.ts
@@ -1,0 +1,83 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import * as extensionApi from '@podman-desktop/api';
+import { tmpName } from 'tmp-promise';
+import { getInstallationPath } from './limactl';
+import * as fs from 'node:fs';
+
+type ImageInfo = { engineId: string; name?: string; tag?: string };
+
+// Handle the image move command when moving from Podman or Docker to Lima
+export class ImageHandler {
+  // Move image from Podman or Docker to Lima
+  async moveImage(image: ImageInfo, instanceName: string, limactl: string): Promise<void> {
+    // If there's no image name passed in, we can't do anything
+    if (!image.name) {
+      throw new Error('Image selection not supported yet');
+    }
+
+    // Only proceed if instance was given
+    if (instanceName) {
+      let name = image.name;
+      let filename: string;
+      const env = Object.assign({}, process.env);
+
+      // Create a name:tag string for the image
+      if (image.tag) {
+        name = name + ':' + image.tag;
+      }
+
+      env.PATH = getInstallationPath();
+      try {
+        // Create a temporary file to store the image
+        filename = await tmpName();
+
+        // Save the image to the temporary file
+        await extensionApi.containerEngine.saveImage(image.engineId, name, filename);
+
+        // Run the Lima commands to push the image to the cluster
+        const { stdout: tempname } = await extensionApi.process.exec(limactl, ['shell', instanceName, 'mktemp'], {
+          env: env,
+        });
+        await extensionApi.process.exec(limactl, ['copy', filename, instanceName + ':' + tempname], { env: env });
+        const loadCommand = ['sudo', 'ctr', '-n=k8s.io', 'images', 'import']; // or "sudo nerdctl -n k8s.io load -i"
+        await extensionApi.process.exec(limactl, ['shell', instanceName, ...loadCommand, tempname], { env: env });
+        await extensionApi.process.exec(limactl, ['shell', instanceName, 'rm', tempname], { env: env });
+
+        // Show a dialog to the user that the image was pushed
+        // TODO: Change this to taskbar notification when implemented
+        await extensionApi.window.showInformationMessage(
+          `Image ${image.name} pushed to Lima instance: ${instanceName}`,
+        );
+      } catch (err) {
+        // Show a dialog error to the user that the image was not pushed
+        await extensionApi.window.showErrorMessage(
+          `Unable to push image ${image.name} to Lima instance: ${instanceName}. Error: ${err}`,
+        );
+
+        // Throw the errors to the console aswell
+        throw new Error(`Unable to push image to Lima instance: ${err}`);
+      } finally {
+        // Remove the temporary file if one was created
+        if (filename !== undefined) {
+          await fs.promises.rm(filename);
+        }
+      }
+    }
+  }
+}

--- a/extensions/lima/src/limactl.ts
+++ b/extensions/lima/src/limactl.ts
@@ -1,0 +1,52 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import * as extensionApi from '@podman-desktop/api';
+
+const macosExtraPath = '/usr/local/bin:/opt/homebrew/bin:/opt/local/bin';
+
+export function getInstallationPath(): string {
+  const env = process.env;
+  if (extensionApi.env.isMac) {
+    if (!env.PATH) {
+      return macosExtraPath;
+    } else {
+      return env.PATH.concat(':').concat(macosExtraPath);
+    }
+  } else {
+    return env.PATH;
+  }
+}
+
+export function getLimactl(): string {
+  // If we have a custom binary path regardless if we are running Windows or not
+  const customBinaryPath = getCustomBinaryPath();
+  if (customBinaryPath) {
+    return customBinaryPath;
+  }
+
+  if (extensionApi.env.isWindows) {
+    return 'limactl.exe';
+  }
+  return 'limactl';
+}
+
+// Get the limactl binary path from configuration lima.binary.path
+// return string or undefined
+export function getCustomBinaryPath(): string | undefined {
+  return extensionApi.configuration.getConfiguration('lima').get('binary.path');
+}


### PR DESCRIPTION
### What does this PR do?

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast 
explaining what is doing this PR -->

### What issues does this PR fix or reference?

* #4486

Closes #4486

### How to test this PR?

<!-- Please explain steps to reproduce -->

This assumes that the cluster is using containerd...

If running cri-o, it would have to use `podman load` instead:

`sudo nerdctl -n k8s.io load -i` => `sudo podman load -i`

But it is hardcoded the same way, in `kind load image-archive`