### PR TITLE
docs: using standard OS tabs for registries docs

### DIFF
--- a/website/docs/working-with-containers/registries/_insecure-registry-linux.md
+++ b/website/docs/working-with-containers/registries/_insecure-registry-linux.md
@@ -1,6 +1,6 @@
 #### Prerequisites
 
-- Podman.
+- Podman is installed.
 
 #### Procedure
 

--- a/website/docs/working-with-containers/registries/_insecure-registry-linux.md
+++ b/website/docs/working-with-containers/registries/_insecure-registry-linux.md
@@ -1,0 +1,37 @@
+#### Prerequisites
+
+- Podman.
+
+#### Procedure
+
+1. Add your insecure registry within **<icon icon="fa-solid fa-cog" size="lg" /> Settings > Registries**.
+
+   ![Adding a custom registry](img/adding-a-custom-registry.png)
+
+1. Click "Yes" to the insecure registry warning.
+
+   ![Podman Desktop Registry Warning](img/registry-warning-insecure.png)
+
+1. Open `registries.conf`.
+
+   ```shell-session
+   $ sudo vi /etc/containers/registries.conf
+   ```
+
+1. Add the insecure registry: Add a new `[[registry]]` section for the URL of the insecure registry you want to use. For example, if your insecure registry is located at `http://registry.example.com`, add the following lines:
+
+   ```toml
+   [[registry]]
+   location = "registry.example.com"
+   insecure = true
+   ```
+
+   If you have multiple registries, you can add one `[[registry]]` block per registry:
+
+1. Save and exit the file.
+
+1. Restart Podman.
+
+   ```shell-session
+   $ sudo systemctl restart podman
+   ```

--- a/website/docs/working-with-containers/registries/_insecure-registry-windows-macos.md
+++ b/website/docs/working-with-containers/registries/_insecure-registry-windows-macos.md
@@ -1,0 +1,44 @@
+#### Prerequisites
+
+- [A running Podman machine](/docs/onboarding-for-containers/installing-podman).
+
+#### Procedure
+
+1. Add your insecure registry within **<icon icon="fa-solid fa-cog" size="lg" /> Settings > Registries**.
+
+   ![Adding a custom registry](img/adding-a-custom-registry.png)
+
+1. Click "Yes" to the insecure registry warning.
+
+   ![Podman Desktop Registry Warning](img/registry-warning-insecure.png)
+
+1. SSH into the Podman Machine to edit `registries.conf`.
+
+   ```shell-session
+   $ podman machine ssh [optional-machine-name]
+   ```
+
+1. Open `registries.conf`.
+
+   ```shell-session
+   $ sudo vi /etc/containers/registries.conf
+   ```
+
+1. Add the insecure registry: Add a new `[[registry]]` section for the URL of the insecure registry you want to use. For example, if your insecure registry is located at `http://registry.example.com`, add the following lines:
+
+   ```toml
+   [[registry]]
+   location = "registry.example.com"
+   insecure = true
+   ```
+
+   If you have multiple registries, you can add one `[[registry]]` block per registry.
+
+1. Save and exit the file.
+
+1. Restart Podman by the CLI or through Podman Desktop.
+
+   ```shell-session
+   $ podman machine stop
+   $ podman machine start
+   ```

--- a/website/docs/working-with-containers/registries/_verification-private-registry.md
+++ b/website/docs/working-with-containers/registries/_verification-private-registry.md
@@ -1,0 +1,8 @@
+#### Verification
+
+1. Go to **<icon icon="fa-solid fa-cloud" size="lg" /> Images**.
+1. You can pull a private image from the registry.
+1. You can push an image to the registry:
+   1. Build an image with the fully qualified name required for your registry, such as `quay.io/my-repository/my-image`, `ghcr.io/my-repository/my-image`, `docker.io/my-repository/my-image`, or `my-registry.tld/my-repository/my-image`.
+   1. On your image line, click **<icon icon="fa-solid fa-ellipsis-v" size="lg" />**.
+   1. The contextual menu has a **<icon icon="fa-solid fa-arrow-up" size="lg" />Push Image** entry.

--- a/website/docs/working-with-containers/registries/authenticating-to-a-preconfigured-registry.md
+++ b/website/docs/working-with-containers/registries/authenticating-to-a-preconfigured-registry.md
@@ -6,6 +6,8 @@ keywords: [podman desktop, podman, containers, registry, registries]
 tags: [images]
 ---
 
+import Verification from './\_verification-private-registry.md'
+
 # Authenticating to a pre-configured registry
 
 With Podman Desktop, you can authenticate to a set of pre-configured registries:
@@ -30,11 +32,4 @@ With Podman Desktop, you can authenticate to a set of pre-configured registries:
 
    ![Authenticating to a preconfigured registry](img/authenticating-to-a-preconfigured-registry.png)
 
-#### Verification
-
-1. Go to **<icon icon="fa-solid fa-cloud" size="lg" /> Images**.
-1. You can pull a private image from the registry.
-1. You can push an image to the registry:
-   1. Build an image the fully qualified name required for your registry, such as `quay.io/my-repository/my-image`, `ghcr.io/my-repository/my-image`, or `docker.io/my-repository/my-image`.
-   1. On your image line, click **<icon icon="fa-solid fa-ellipsis-v" size="lg" />**.
-   1. The contextual menu has a **<icon icon="fa-solid fa-arrow-up" size="lg" />Push Image** entry.
+<Verification />

--- a/website/docs/working-with-containers/registries/insecure-registry.md
+++ b/website/docs/working-with-containers/registries/insecure-registry.md
@@ -8,97 +8,30 @@ tags: [pods]
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import WindowsMacosProcedure from './\_insecure-registry-windows-macos.md'
+import LinuxProcedure from './\_insecure-registry-linux.md'
+import Verification from './\_verification-private-registry.md'
 
 # Adding an Insecure Registry to Podman Desktop
 
 In this guide, you will learn how to add an insecure registry to Podman Desktop. An insecure registry allows you to pull and push container images either over an unencrypted HTTP connection, or a HTTPS connection with a self-signed unverified certificate. Please note that using an insecure registry can expose your data to security risks, so it's recommended to use secure connections with a verifiable certificate whenever possible.
 
-#### Prerequisites
-
-- Podman installed and running (VM if on macOS or Windows).
-
-#### Procedure
-
 <Tabs groupId="operating-systems">
-<TabItem value="macwin" label="macOS & Windows">
+<TabItem value="win" label="Windows">
 
-1. Add your insecure registry within **<icon icon="fa-solid fa-cog" size="lg" /> Settings > Registries**.
+<WindowsMacosProcedure />
 
-   ![Adding a custom registry](img/adding-a-custom-registry.png)
+</TabItem>
+<TabItem value="mac" label="macOS">
 
-2. Click "Yes" to the insecure registry warning.
-
-   ![Podman Desktop Registry Warning](img/registry-warning-insecure.png)
-
-3. SSH into the Podman Machine to edit `registries.conf`.
-
-   ```shell-session
-   $ podman machine ssh [optional-machine-name]
-   ```
-
-4. Open `registries.conf`.
-
-   ```shell-session
-   $ sudo vi /etc/containers/registries.conf
-   ```
-
-5. Add the insecure registry: Add a new `[[registry]]` section for the URL of the insecure registry you want to use. For example, if your insecure registry is located at `http://registry.example.com`, add the following lines:
-
-   ```toml
-   [[registry]]
-   location = "registry.example.com"
-   insecure = true
-   ```
-
-   If you have multiple registries, you can add one `[[registry]]` block per registry.
-
-6. Save and exit the file.
-
-7. Restart Podman by the CLI or through Podman Desktop.
-
-   ```shell-session
-   $ podman machine stop
-   $ podman machine start
-   ```
-
-8. Pull or push container images: You can now use Podman Desktop to pull or push container images from/to the insecure registry you added.
+<WindowsMacosProcedure />
 
 </TabItem>
 <TabItem value="linux" label="Linux">
 
-1. Add your insecure registry within **<icon icon="fa-solid fa-cog" size="lg" /> Settings > Registries**.
-
-   ![Adding a custom registry](img/adding-a-custom-registry.png)
-
-2. Click "Yes" to the insecure registry warning.
-
-   ![Podman Desktop Registry Warning](img/registry-warning-insecure.png)
-
-3. Open `registries.conf`.
-
-   ```shell-session
-   $ sudo vi /etc/containers/registries.conf
-   ```
-
-4. Add the insecure registry: Add a new `[[registry]]` section for the URL of the insecure registry you want to use. For example, if your insecure registry is located at `http://registry.example.com`, add the following lines:
-
-   ```toml
-   [[registry]]
-   location = "registry.example.com"
-   insecure = true
-   ```
-
-   If you have multiple registries, you can add one `[[registry]]` block per registry:
-
-5. Save and exit the file.
-
-6. Restart Podman.
-
-   ```shell-session
-   $ sudo systemctl restart podman
-   ```
-
-7. Pull or push container images: You can now use Podman Desktop to pull or push container images from/to the insecure registry you added.
+<LinuxProcedure />
 
 </TabItem>
 </Tabs>
+
+<Verification />


### PR DESCRIPTION
### What does this PR do?

* Using standard "Windows, macOS, Linux" OS tabs to display options.
* Slight refactoring: using snippets for repeated content.
* Moved the content without rewriting it.
* Minimal content fixes.

### Screenshot/screencast of this PR


![Screenshot_20231025_140902](https://github.com/containers/podman-desktop/assets/243761/115fe90b-5802-43e4-bbd2-db8fb660ebf2)


### What issues does this PR fix or reference?

Standardize navigation.

<!-- Include any related issues from Podman Desktop 
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to reproduce -->

