### PR TITLE
feat: add open created pod details

### DIFF
--- a/packages/renderer/src/lib/pod/DeployPodToKube.svelte
+++ b/packages/renderer/src/lib/pod/DeployPodToKube.svelte
@@ -11,6 +11,7 @@ import { ensureRestrictedSecurityContext } from '/@/lib/pod/pod-utils';
 import Button from '../ui/Button.svelte';
 import { faExternalLink, faRocket } from '@fortawesome/free-solid-svg-icons';
 import Link from '../ui/Link.svelte';
+import { router } from 'tinro';
 
 export let resourceId: string;
 export let engineId: string;
@@ -134,6 +135,13 @@ onDestroy(() => {
 
 function goBackToHistory(): void {
   window.history.go(-1);
+}
+
+function openPodDetails(): void {
+  if (!createdPod?.metadata?.name || !defaultContextName) {
+    return;
+  }
+  router.goto(`/pods/kubernetes/${encodeURI(createdPod.metadata.name)}/${encodeURI(defaultContextName)}/logs`);
 }
 
 function openRoute(route: V1Route) {
@@ -585,8 +593,10 @@ function updateKubeResult() {
       {/if}
 
       {#if deployFinished}
-        <div class="pt-4">
-          <Button on:click="{() => goBackToHistory()}" class="w-full">Done</Button>
+        <div class="pt-4 flex flex-row space-x-2 justify-end">
+          <Button on:click="{() => goBackToHistory()}">Done</Button>
+          <Button on:click="{() => openPodDetails()}" disabled="{!createdPod?.metadata?.name || !defaultContextName}"
+            >Open Pod</Button>
         </div>
       {/if}
     </div>


### PR DESCRIPTION
### What does this PR do?

Adds "Open Pod" button after deploying generated pod to the Kubernetes.

### Screenshot/screencast of this PR

Additional button in the bottom right corner:
<img width="1162" src="https://github.com/containers/podman-desktop/assets/1968177/59910db7-592c-4c16-8c4d-6a9966a11ddd">

After clicking on "Open Pod" it navigates to the pod details:
<img width="1162" src="https://github.com/containers/podman-desktop/assets/1968177/59a3e7b8-d8b2-43a3-94cc-180456643595">

### What issues does this PR fix or reference?

fix #1470 

### How to test this PR?

Deploy existing container to the Kubernetes from the dropdown menu item "Deploy to Kubernetes", then when deployment is finished, an additional button should appear "Open Pod", which navigates to the newly deployed pod.
