### PR TITLE
fix: handle flatpak usecase for admin commands

### DIFF
--- a/packages/main/src/plugin/util/exec.ts
+++ b/packages/main/src/plugin/util/exec.ts
@@ -65,9 +65,6 @@ export class Exec {
 
     if (isMac() || isWindows()) {
       env.PATH = getInstallationPath(env.PATH);
-    } else if (env.FLATPAK_ID) {
-      args = ['--host', command, ...(args || [])];
-      command = 'flatpak-spawn';
     }
 
     // do we have an admin task ?
@@ -135,6 +132,11 @@ export class Exec {
         args = [command, ...(args || [])];
         command = 'pkexec';
       }
+    }
+
+    if (env.FLATPAK_ID) {
+      args = ['--host', command, ...(args || [])];
+      command = 'flatpak-spawn';
     }
 
     let cwd: string;


### PR DESCRIPTION
### What does this PR do?
we need to use flatpak-spawn only after command is set and not at the beginning

else we may try to execute commands with incorrect order of params

related to https://github.com/containers/podman-desktop/issues/4456

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast 
explaining what is doing this PR -->

### What issues does this PR fix or reference?

one error of #4456 

### How to test this PR?

unit test provided