### PR TITLE
fix: use bash -c because when using with flatpak-spawn it does not work

### DIFF
--- a/extensions/compose/src/cli-run.spec.ts
+++ b/extensions/compose/src/cli-run.spec.ts
@@ -117,15 +117,10 @@ test('success: installBinaryToSystem on linux with /usr/local/bin NOT created ye
 
   // check called with admin being true
   expect(extensionApi.process.exec).toBeCalledWith(
-    'exec',
+    '/bin/sh',
     expect.arrayContaining([
-      'mkdir',
-      '-p',
-      '/usr/local/bin',
-      '&&',
-      'cp',
-      'test',
-      `${path.sep}usr${path.sep}local${path.sep}bin${path.sep}tmpBinary`,
+      '-c',
+      `mkdir -p /usr/local/bin && cp test ${path.sep}usr${path.sep}local${path.sep}bin${path.sep}tmpBinary`,
     ]),
     expect.objectContaining({ isAdmin: true }),
   );


### PR DESCRIPTION
### What does this PR do?
try to use a command working in conjunction to flatpak-spawn command

to have 100% of the linked issue, it also depends on
- [x] https://github.com/containers/podman-desktop/pull/4501

but merge can occurs in parallel

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast 
explaining what is doing this PR -->

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/4456

### How to test this PR?

unit test + try to install compose using the flatpak version (test case of the reported issue)