### PR TITLE
feat: show CLI versions

### DIFF
--- a/extensions/compose/src/extension.ts
+++ b/extensions/compose/src/extension.ts
@@ -31,6 +31,11 @@ import { ComposeInstallation } from './installation';
 let composeExtension: ComposeExtension | undefined;
 let composeVersionMetadata: ComposeGithubReleaseArtifactMetadata | undefined;
 
+const composeCliName = 'docker-compose';
+const composeDisplayName = 'Compose';
+const composeDescription = `Compose is a specification for defining and running multi-container applications. We support both [podman compose](https://docs.podman.io/en/latest/markdown/podman-compose.1.html) and [docker compose](https://github.com/docker/compose) commands.\n\nMore information: [compose-spec.io](https://compose-spec.io/)`;
+const imageLocation = './icon.png';
+
 export async function activate(extensionContext: extensionApi.ExtensionContext): Promise<void> {
   // Post activation
   setTimeout(() => {
@@ -138,18 +143,28 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
   // Need to "ADD" a provider so we can actually press the button!
   // We set this to "unknown" so it does not appear on the dashboard (we only want it in preferences).
   const providerOptions: extensionApi.ProviderOptions = {
-    name: 'Compose',
-    id: 'Compose',
+    name: composeDisplayName,
+    id: composeDisplayName,
     status: 'unknown',
     images: {
-      icon: './icon.png',
+      icon: imageLocation,
     },
   };
 
-  providerOptions.emptyConnectionMarkdownDescription = `Compose is a specification for defining and running multi-container applications. We support both [podman compose](https://docs.podman.io/en/latest/markdown/podman-compose.1.html) and [docker compose](https://github.com/docker/compose) commands.\n\nMore information: [compose-spec.io](https://compose-spec.io/)`;
+  providerOptions.emptyConnectionMarkdownDescription = composeDescription;
 
   const provider = extensionApi.provider.createProvider(providerOptions);
   extensionContext.subscriptions.push(provider);
+
+  // Register the CLI extension, this will allow us to show the CLI version, update the CLI, installation, etc.
+  extensionApi.cli.createCliTool({
+    name: composeCliName,
+    displayName: composeDisplayName,
+    markdownDescription: composeDescription,
+    images: {
+      icon: imageLocation,
+    },
+  });
 }
 
 async function postActivate(extensionContext: extensionApi.ExtensionContext): Promise<void> {

--- a/extensions/compose/src/extension.ts
+++ b/extensions/compose/src/extension.ts
@@ -164,6 +164,8 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
     images: {
       icon: imageLocation,
     },
+    storagePath: extensionContext.storagePath,
+    helpCommand: '--version',
   });
 }
 

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -2447,6 +2447,10 @@ declare module '@podman-desktop/api' {
     displayName: string;
     markdownDescription: string;
     images: ProviderImages;
+    storagePath: string;
+    // This is needed since every binary handles getting the version differently, for example some tools use
+    // --version, some use -v, some use -V, etc.
+    helpCommand: string;
   }
 
   export type CliToolState = 'registered';

--- a/packages/main/src/plugin/api/cli-tool-info.ts
+++ b/packages/main/src/plugin/api/cli-tool-info.ts
@@ -31,4 +31,5 @@ export interface CliToolInfo {
   state: CliToolState;
   images?: ProviderImages;
   extensionInfo: CliToolExtensionInfo;
+  version: string;
 }

--- a/packages/renderer/src/lib/preferences/PreferencesCliToolsRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesCliToolsRendering.spec.ts
@@ -40,6 +40,7 @@ const cliToolInfoItem1: CliToolInfo = {
     id: 'ext-id1',
     label: 'ext-label1',
   },
+  version: '1.0.1',
 };
 
 const cliToolInfoItem2: CliToolInfo = {
@@ -53,25 +54,41 @@ const cliToolInfoItem2: CliToolInfo = {
     label: 'ext-label2',
   },
   images: {},
+  version: '1.0.2',
 };
 
 const cliToolInfoItem3: CliToolInfo = {
-  id: 'ext-id.tool-name2',
-  name: 'tool-name2',
-  description: 'markdown description2',
-  displayName: 'tools-display-name2',
+  id: 'ext-id.tool-name3',
+  name: 'tool-name3',
+  description: 'markdown description3',
+  displayName: 'tools-display-name3',
   state: 'registered',
   extensionInfo: {
-    id: 'ext-id2',
-    label: 'ext-label2',
+    id: 'ext-id3',
+    label: 'ext-label3',
   },
   images: {
     icon: 'encoded-icon',
   },
+  version: '1.0.3',
+};
+
+const cliToolInfoItem4: CliToolInfo = {
+  id: 'ext-id.tool-name4',
+  name: 'tool-name4',
+  description: 'markdown description4',
+  displayName: 'tools-display-name4',
+  state: 'registered',
+  extensionInfo: {
+    id: 'ext-id4',
+    label: 'ext-label4',
+  },
+  images: {},
+  version: '', // version is empty, so it should be showing the error
 };
 
 suite('CLI Tool Prefernces page shows', () => {
-  const cliTools = [cliToolInfoItem1, cliToolInfoItem2, cliToolInfoItem3];
+  const cliTools = [cliToolInfoItem1, cliToolInfoItem2, cliToolInfoItem3, cliToolInfoItem4];
   let cliToolRows: HTMLElement[] = [];
 
   function validatePropertyPresentation(labelName: string, getExpectedContent: (info: CliToolInfo) => string) {
@@ -115,5 +132,15 @@ suite('CLI Tool Prefernces page shows', () => {
 
   test('tool`s logo is shown when images.icon property is present', () => {
     expect(within(cliToolRows[2]).getAllByLabelText('cli-logo').length).equals(1);
+  });
+
+  test('test tools version is shown', () => {
+    // First three tools have version, the last one has empty version and should show error
+    expect(within(cliToolRows[0]).queryAllByLabelText('cli-version')[0].textContent).toEqual('tool-name1 v1.0.1');
+    expect(within(cliToolRows[1]).queryAllByLabelText('cli-version')[0].textContent).toEqual('tool-name2 v1.0.2');
+    expect(within(cliToolRows[2]).queryAllByLabelText('cli-version')[0].textContent).toEqual('tool-name3 v1.0.3');
+    expect(within(cliToolRows[3]).queryAllByLabelText('cli-version')[0].textContent).toEqual(
+      'Unable to retrieve binary version, try running the setup again.',
+    );
   });
 });

--- a/packages/renderer/src/lib/preferences/PreferencesCliToolsRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesCliToolsRendering.svelte
@@ -44,6 +44,15 @@ import EmptyScreen from '../ui/EmptyScreen.svelte';
           </div>
           <div role="region" class="ml-3 mt-2 text-sm text-gray-300">
             <Markdown markdown="{cliTool.description}" />
+            {#if cliTool.version !== ''}
+              <span
+                class="text-white-400 font-bold font-mono text-xs bg-charcoal-900 p-2 rounded-lg"
+                aria-label="cli-version">{cliTool.name} v{cliTool.version}</span>
+            {:else}
+              <span
+                class="text-white-400 font-bold font-mono text-xs bg-charcoal-900 p-2 rounded-lg"
+                aria-label="cli-version">Unable to retrieve binary version, try running the setup again.</span>
+            {/if}
           </div>
         </div>
       </div>


### PR DESCRIPTION
feat: show CLI versions

### What does this PR do?

* Shows the CLI version number by executing the `--version` or `-v`,
  etc. command via the command line. This is done by adding the
  "helpCommand" parameter to createCliTool as well as the storage path
  of the binary from extensionContext.storagePath
* If it succeeds, it will show the version number, if it fails, it will
  not appear (but show the error via the console). This would only
  happen if the extension was registered but the binary removed from the
  extension folder.

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast
explaining what is doing this PR -->
![Screenshot 2023-10-24 at 8 17 42 PM](https://github.com/containers/podman-desktop/assets/6422176/838c7d00-3e1b-4f6d-a5bb-144725eba094)



### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop/issues/3707

### How to test this PR?

<!-- Please explain steps to reproduce -->

1. Install Compose / go through the onboarding
2. View the CLI Tools via preferences and you'll see the version number.
