### PR TITLE
fix: add autoscroll to summary pages

### DIFF
--- a/packages/renderer/src/lib/compose/ComposeDetailsSummary.svelte
+++ b/packages/renderer/src/lib/compose/ComposeDetailsSummary.svelte
@@ -10,7 +10,7 @@ function openContainer(containerID: string) {
 }
 </script>
 
-<div class="flex px-5 py-4 flex-col">
+<div class="flex px-5 py-4 flex-col h-full overflow-auto">
   <div class="w-full">
     <table>
       <tr>

--- a/packages/renderer/src/lib/container/ContainerDetailsSummary.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetailsSummary.svelte
@@ -4,7 +4,7 @@ import type { ContainerInfoUI } from './ContainerInfoUI';
 export let container: ContainerInfoUI;
 </script>
 
-<div class="flex px-5 py-4 flex-col">
+<div class="flex px-5 py-4 flex-col h-full overflow-auto">
   <div class="w-full">
     <table class="h-2">
       <tr>

--- a/packages/renderer/src/lib/image/ImageDetailsSummary.svelte
+++ b/packages/renderer/src/lib/image/ImageDetailsSummary.svelte
@@ -4,7 +4,7 @@ import type { ImageInfoUI } from './ImageInfoUI';
 export let image: ImageInfoUI;
 </script>
 
-<div class="flex px-5 py-4 flex-col">
+<div class="flex px-5 py-4 flex-col h-full overflow-auto">
   <table>
     <tr>
       <td class="pt-2 pr-2">Id:</td>

--- a/packages/renderer/src/lib/kube/KubeDetailsSummary.svelte
+++ b/packages/renderer/src/lib/kube/KubeDetailsSummary.svelte
@@ -13,7 +13,7 @@ if (pod?.status?.startTime) {
 }
 </script>
 
-<div class="flex px-5 py-4 flex-col items-start hover:overflow-y-auto">
+<div class="flex px-5 py-4 flex-col items-start h-full overflow-auto">
   {#if pod}
     <table class="w-full">
       <tbody>

--- a/packages/renderer/src/lib/pod/PodDetailsSummary.svelte
+++ b/packages/renderer/src/lib/pod/PodDetailsSummary.svelte
@@ -41,7 +41,7 @@ ass KubeDetailsSummary will automatically add a 'Loading ... ' section -->
   <KubeDetailsSummary pod="{kubePod}" />
 {:else}
   <!-- Still show pod information in case the Kubernetes pod retrieval errors out -->
-  <div class="flex px-5 py-4 flex-col">
+  <div class="flex px-5 py-4 flex-col h-full overflow-auto">
     <div class="w-full">
       <table>
         <tr>
@@ -55,7 +55,7 @@ ass KubeDetailsSummary will automatically add a 'Loading ... ' section -->
       </table>
     </div>
     {#if pod.containers.length > 0}
-      <div class="w-full my-12">
+      <div class="w-full mt-12">
         <span>Containers using this pod:</span>
         <table>
           {#each pod.containers as container}

--- a/packages/renderer/src/lib/volume/VolumeDetailsSummary.svelte
+++ b/packages/renderer/src/lib/volume/VolumeDetailsSummary.svelte
@@ -10,7 +10,7 @@ function openContainer(containerID: string) {
 }
 </script>
 
-<div class="flex px-5 py-4 flex-col">
+<div class="flex px-5 py-4 flex-col h-full overflow-auto">
   <div class="w-full">
     <table>
       <tr>
@@ -28,7 +28,7 @@ function openContainer(containerID: string) {
     </table>
   </div>
   {#if volume.containersUsage.length > 0}
-    <div class="w-full my-12">
+    <div class="w-full mt-12">
       <span>Containers using this volume:</span>
       {#each volume.containersUsage as container}
         <table>


### PR DESCRIPTION
### What does this PR do?

None of the summary pages had overflow, so although most were small all would get cut-off if the window is small enough or (e.g.) a container id is long enough.

Also changes my- to mt- in pods and volumes since this was causing a large bottom gap instead of just between the sections.

### Screenshot/screencast of this PR

Just adds scrollbars when necessary.

### What issues does this PR fix or reference?

Fixes #4458.

### How to test this PR?

Make the window very small (yarn watch is better for this) and confirm scrollbars appear when you go to a bigger Summary tab.