### PR TITLE
fix: check for self signed cert message and use insecure param when editing registry password

### DIFF
--- a/packages/main/src/plugin/image-registry.ts
+++ b/packages/main/src/plugin/image-registry.ts
@@ -278,7 +278,7 @@ export class ImageRegistry {
       throw new Error(`Registry ${registry.serverUrl} was not found`);
     }
     if (matchingRegistry.username !== registry.username || matchingRegistry.secret !== registry.secret) {
-      await this.checkCredentials(matchingRegistry.serverUrl, registry.username, registry.secret);
+      await this.checkCredentials(matchingRegistry.serverUrl, registry.username, registry.secret, registry.insecure);
     }
     matchingRegistry.username = registry.username;
     matchingRegistry.secret = registry.secret;

--- a/packages/renderer/src/lib/preferences/PreferencesRegistriesEditing.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRegistriesEditing.svelte
@@ -212,9 +212,9 @@ async function loginToRegistry(registry: containerDesktopAPI.Registry) {
 
   try {
     if (newRegistry) {
-      await window.createImageRegistry(registry.source, registry);
+      await window.createImageRegistry(registry.source, { ...registry });
     } else {
-      await window.updateImageRegistry(registry);
+      await window.updateImageRegistry({ ...registry });
     }
   } catch (error: any) {
     setErrorResponse(registry.serverUrl, error.message);

--- a/packages/renderer/src/lib/preferences/PreferencesRegistriesEditing.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRegistriesEditing.svelte
@@ -189,7 +189,11 @@ async function loginToRegistry(registry: containerDesktopAPI.Registry) {
   try {
     await window.checkImageCredentials(registry);
   } catch (error) {
-    if (error instanceof Error && error.message.includes('unable to verify the first certificate')) {
+    if (
+      error instanceof Error &&
+      (error.message.includes('unable to verify the first certificate') ||
+        error.message.includes('self signed certificate in certificate chain'))
+    ) {
       const result = await window.showMessageBox({
         title: 'Invalid Certificate',
         type: 'warning',


### PR DESCRIPTION
### What does this PR do?

Checking for another message related to self signed certificate when adding OpenShift Local image registry to trigger insecure registry confirmation request.

Use insecure parameter to verify new credentials when editing password for insecure registry.

### Screenshot/screencast of this PR


https://github.com/containers/podman-desktop/assets/620330/a6d13e9f-0048-4c8c-8c9c-223eda46e911


### What issues does this PR fix or reference?

fix #4522.
releated to testing of #3538.

### How to test this PR?

<!-- Please explain steps to reproduce -->
