### PR TITLE
fix: disable push to kind menu item if pushing is in progress (#4337)

### DIFF
--- a/extensions/kind/package.json
+++ b/extensions/kind/package.json
@@ -70,7 +70,8 @@
       "dashboard/image": [
         {
           "command": "kind.image.move",
-          "title": "Push image to Kind cluster"
+          "title": "Push image to Kind cluster",
+          "disabled": "selectedImageId in imagesPushInProgressToKind"
         }
       ]
     },

--- a/extensions/kind/src/image-handler.ts
+++ b/extensions/kind/src/image-handler.ts
@@ -21,7 +21,7 @@ import { tmpName } from 'tmp-promise';
 import { getKindPath } from './util';
 import * as fs from 'node:fs';
 
-type ImageInfo = { engineId: string; name?: string; tag?: string };
+export type ImageInfo = { engineId: string; name?: string; tag?: string };
 
 // Handle the image move command when moving from Podman or Docker to Kind
 export class ImageHandler {

--- a/packages/main/src/plugin/menu-registry.ts
+++ b/packages/main/src/plugin/menu-registry.ts
@@ -22,6 +22,7 @@ export interface Menu {
   command: string;
   title: string;
   when?: string;
+  disabled?: string;
 }
 
 export enum MenuContext {

--- a/packages/renderer/src/lib/actions/ContributionActions.svelte
+++ b/packages/renderer/src/lib/actions/ContributionActions.svelte
@@ -75,5 +75,6 @@ async function executeContribution(menu: Menu): Promise<void> {
     title="{menu.title}"
     onClick="{() => executeContribution(menu)}"
     menu="{dropdownMenu}"
-    icon="{faEllipsisVertical}" />
+    icon="{faEllipsisVertical}"
+    disabledWhen="{menu.disabled}" />
 {/each}

--- a/packages/renderer/src/lib/image/ActionsMenu.spec.ts
+++ b/packages/renderer/src/lib/image/ActionsMenu.spec.ts
@@ -1,0 +1,42 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import '@testing-library/jest-dom/vitest';
+import { test, expect } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import ActionsMenu from './ActionsMenu.svelte';
+
+test('Expect the dropdownmenu button is displayed if the dropdown variable is true', async () => {
+  render(ActionsMenu, {
+    dropdownMenu: true,
+  });
+
+  const buildButton = screen.getByRole('button', { name: 'kebab menu' });
+  expect(buildButton).toBeInTheDocument();
+});
+
+test('Expect the dropdownmenu button NOT to be displayed if the dropdown variable is false', async () => {
+  render(ActionsMenu, {
+    dropdownMenu: false,
+  });
+
+  const buildButton = screen.queryByRole('button', { name: 'kebab menu' });
+  expect(buildButton).not.toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/image/ActionsMenu.svelte
+++ b/packages/renderer/src/lib/image/ActionsMenu.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+import DropdownMenu from '../ui/DropdownMenu.svelte';
+import FlatMenu from '../ui/FlatMenu.svelte';
+
+export let dropdownMenu = false;
+export let onBeforeToggle = () => {};
+</script>
+
+{#if dropdownMenu}
+  <DropdownMenu onBeforeToggle="{onBeforeToggle}"><slot /></DropdownMenu>
+{:else}
+  <FlatMenu><slot /></FlatMenu>
+{/if}

--- a/packages/renderer/src/lib/ui/DropDownMenuItem.svelte
+++ b/packages/renderer/src/lib/ui/DropDownMenuItem.svelte
@@ -4,16 +4,17 @@ import Fa from 'svelte-fa';
 
 export let title: string;
 export let icon: IconDefinition;
+export let enabled = true;
 export let hidden = false;
 export let onClick: () => void = () => {};
+
+const enabledClasses = 'hover:bg-black hover:text-purple-500 hover:rounded-md text-gray-400 hover:cursor-pointer';
+const disabledClasses = 'text-gray-900 bg-charcoal-800';
 </script>
 
 {#if !hidden}
   <!-- Use a div + onclick so there's no "blind spots" for when clicking-->
-  <div
-    class="p-3 hover:bg-black hover:text-purple-500 hover:rounded-md text-gray-400 hover:cursor-pointer"
-    role="none"
-    on:click="{onClick}">
+  <div class="{`p-3 ${enabled ? enabledClasses : disabledClasses}`}" role="none" on:click="{onClick}">
     <span title="{title}" class="group flex items-center text-sm no-underline whitespace-nowrap" tabindex="-1">
       <Fa class="h-4 w-4 text-md mr-2" icon="{icon}" />
       {title}

--- a/packages/renderer/src/lib/ui/DropdownMenu.spec.ts
+++ b/packages/renderer/src/lib/ui/DropdownMenu.spec.ts
@@ -1,0 +1,35 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+import { test, expect, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import DropdownMenu from './DropdownMenu.svelte';
+
+test('Expect the onBeforeToggle function to be called when the menu is clicked', async () => {
+  const onBeforeToggleMock = vi.fn();
+  render(DropdownMenu, {
+    onBeforeToggle: onBeforeToggleMock,
+  });
+
+  const toggleMenuButton = screen.getByRole('button', { name: 'kebab menu' });
+  expect(toggleMenuButton).toBeInTheDocument();
+  await fireEvent.click(toggleMenuButton);
+
+  expect(onBeforeToggleMock).toHaveBeenCalled();
+});

--- a/packages/renderer/src/lib/ui/DropdownMenu.svelte
+++ b/packages/renderer/src/lib/ui/DropdownMenu.svelte
@@ -3,6 +3,7 @@ import { faEllipsisVertical } from '@fortawesome/free-solid-svg-icons';
 import Fa from 'svelte-fa';
 import DropDownMenuItems from './DropDownMenuItems.svelte';
 
+export let onBeforeToggle = () => {};
 // Show and hide the menu using clickOutside
 let showMenu = false;
 
@@ -19,6 +20,7 @@ function handleEscape({ key }: any) {
 let clientY: number;
 
 function toggleMenu() {
+  onBeforeToggle();
   showMenu = !showMenu;
 }
 

--- a/packages/renderer/src/lib/ui/DropdownMenu.svelte
+++ b/packages/renderer/src/lib/ui/DropdownMenu.svelte
@@ -37,6 +37,7 @@ function onWindowClick(e: any) {
 <div class="relative inline-block text-left">
   <!-- Button for the dropdown menu -->
   <button
+    aria-label="kebab menu"
     on:click="{e => {
       // keep track of the cursor position
       clientY = e.clientY;

--- a/packages/renderer/src/lib/ui/ListItemButtonIcon.spec.ts
+++ b/packages/renderer/src/lib/ui/ListItemButtonIcon.spec.ts
@@ -1,0 +1,108 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+import { test, expect } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import ListItemButtonIcon from './ListItemButtonIcon.svelte';
+import { faRocket } from '@fortawesome/free-solid-svg-icons';
+import { ContextUI } from '../context/context';
+import { context } from '/@/stores/context';
+
+test('Expect the dropDownMenuItem to have classes that display a disabled object if the disabled when clause is evaluated to true', async () => {
+  const title = 'title';
+
+  const contextUI = new ContextUI();
+  contextUI.setValue('values', ['test']);
+  context.set(contextUI);
+
+  render(ListItemButtonIcon, {
+    title,
+    icon: faRocket,
+    disabledWhen: 'test in values',
+    menu: true,
+  });
+
+  const listItemSpan = screen.getByTitle(title);
+  expect(listItemSpan).toBeInTheDocument();
+  expect(listItemSpan.parentElement!.outerHTML.indexOf('text-gray-900 bg-charcoal-800') > 0).toBeTruthy();
+});
+
+test('Expect the dropDownMenuItem to have classes that display a disabled object if the disabled when clause is true', async () => {
+  const title = 'title';
+
+  render(ListItemButtonIcon, {
+    title,
+    icon: faRocket,
+    disabledWhen: 'true',
+    menu: true,
+  });
+
+  const listItemSpan = screen.getByTitle(title);
+  expect(listItemSpan).toBeInTheDocument();
+  expect(listItemSpan.parentElement!.outerHTML.indexOf('text-gray-900 bg-charcoal-800') > 0).toBeTruthy();
+});
+
+test('Expect the dropDownMenuItem NOT to have classes that display a disabled object if the disabled when clause is evaluated to false', async () => {
+  const title = 'title';
+
+  const contextUI = new ContextUI();
+  contextUI.setValue('values', ['test']);
+  context.set(contextUI);
+
+  render(ListItemButtonIcon, {
+    title,
+    icon: faRocket,
+    disabledWhen: 'unknown in values',
+    menu: true,
+  });
+
+  const listItemSpan = screen.getByTitle(title);
+  expect(listItemSpan).toBeInTheDocument();
+  expect(listItemSpan.parentElement!.outerHTML.indexOf('text-gray-900 bg-charcoal-800') === -1).toBeTruthy();
+});
+
+test('Expect the dropDownMenuItem NOT to have classes that display a disabled object if the disabled when clause is false', async () => {
+  const title = 'title';
+
+  render(ListItemButtonIcon, {
+    title,
+    icon: faRocket,
+    disabledWhen: 'false',
+    menu: true,
+  });
+
+  const listItemSpan = screen.getByTitle(title);
+  expect(listItemSpan).toBeInTheDocument();
+  expect(listItemSpan.parentElement!.outerHTML.indexOf('text-gray-900 bg-charcoal-800') === -1).toBeTruthy();
+});
+
+test('Expect the dropDownMenuItem NOT to have classes that display a disabled object if the disabled when clause is empty', async () => {
+  const title = 'title';
+
+  render(ListItemButtonIcon, {
+    title,
+    icon: faRocket,
+    disabledWhen: '',
+    menu: true,
+  });
+
+  const listItemSpan = screen.getByTitle(title);
+  expect(listItemSpan).toBeInTheDocument();
+  expect(listItemSpan.parentElement!.outerHTML.indexOf('text-gray-900 bg-charcoal-800') === -1).toBeTruthy();
+});

--- a/website/docs/extensions/write/when-clause-context.md
+++ b/website/docs/extensions/write/when-clause-context.md
@@ -38,9 +38,10 @@ Podman Desktop has a set of context keys that are evaluated to Boolean true/fals
 
 Podman Desktop also provides context keys that return values that can be used to create meaningful expressions
 
-| Context key        | Value in it                                                                                       |
-| ------------------ | ------------------------------------------------------------------------------------------------- |
-| containerLabelKeys | A list of all labels belonging to the current container. Example: `"value in containerLabelKeys"` |
+| Context key        | Value in it                                                                                                             |
+| ------------------ | ----------------------------------------------------------------------------------------------------------------------- |
+| containerLabelKeys | A list of all labels belonging to the current container. Example: `"value in containerLabelKeys"`                       |
+| selectedImageId    | The image id which the dashboard/image menu opened belong to. Example `"selectedImageId in imagesPushInProgressToKind"` |
 
 ### Add a custom when clause context
 


### PR DESCRIPTION
### What does this PR do?

This PR adds a disable when clause to the push to kind menu item so that it can be disabled if another push for the same image is in progress

### Screenshot/screencast of this PR

![push_disabled](https://github.com/containers/podman-desktop/assets/49404737/2ab35f23-728e-4498-9c36-b2406a6b0464)

### What issues does this PR fix or reference?

it resolves #4337 

### How to test this PR?

1. push an image
2. open the menu to cpush again
3. you should see the action disabled
