### PR TITLE
feat: add support in command palette for category

### DIFF
--- a/packages/main/src/plugin/command-registry.spec.ts
+++ b/packages/main/src/plugin/command-registry.spec.ts
@@ -120,3 +120,39 @@ test('Should dispose global commands ', async () => {
   expectTypeOf(commandPaletteCommandsAfter2).toBeArray();
   expect(commandPaletteCommandsAfter2.length).toBe(0);
 });
+
+test('Should include category in the title', async () => {
+  const myCommandId1 = 'my-extension.command1';
+  const title1 = 'My dummy Command 1';
+
+  const myCommandId2 = 'my-extension.command2';
+  const title2 = 'My dummy Command 2';
+
+  const category = 'My Category';
+
+  commandRegistry.registerCommandsFromExtension('my-extension', [
+    {
+      command: myCommandId1,
+      title: title1,
+      category,
+    },
+    {
+      command: myCommandId2,
+      title: title2,
+      category,
+    },
+  ]);
+
+  // grab all commands
+  const commandPaletteCommands = commandRegistry.getCommandPaletteCommands();
+  expect(commandPaletteCommands).toBeDefined();
+  expectTypeOf(commandPaletteCommands).toBeArray();
+  expect(commandPaletteCommands.length).toBe(2);
+
+  // check we have our command
+  const myCommand = commandPaletteCommands.find(command => command.id === myCommandId1);
+  expect(myCommand).toBeDefined();
+
+  // should have category + title
+  expect(myCommand?.title).toBe(`${category}: ${title1}`);
+});

--- a/packages/main/src/plugin/command-registry.ts
+++ b/packages/main/src/plugin/command-registry.ts
@@ -103,7 +103,7 @@ export class CommandRegistry {
         }
         commandInfos.push({
           id: command.command,
-          title: command.title,
+          title: command.category ? `${command.category}: ${command.title}` : command.title,
         });
       });
     });


### PR DESCRIPTION
### What does this PR do?
Display category provided by commands in the command palette as a prefix of command's title

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast 
explaining what is doing this PR -->

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/4106

### How to test this PR?

unit test added

you can check the title when using podman desktop demo extension https://github.com/redhat-developer/podman-desktop-demo/tree/main/extension

bringing command palette should display these commands with `Podman Desktop demo:` prefix