### PR TITLE
Compose download screen text rewording

### DIFF
--- a/extensions/compose/package.json
+++ b/extensions/compose/package.json
@@ -50,12 +50,12 @@
           "content": [
             [
               {
-                "value": "Compose support in Podman Desktop enables you to use Compose specification CLI implementations such as `podman compose` and `docker compose` with supported container engines."
+                "value": "Podman Desktop provides optional command line support for compose files with Podman."
               }
             ],
             [
               {
-                "value": "> ℹ️ Note: Want to use docker CLI tools such as: `docker compose up` or `docker-compose` with podman? Enable **Docker Compatibility** within Preferences.",
+                "value": "> ℹ️ **Note:** If you would like to use `docker compose up` or `docker-compose` with Podman, [enable Docker Compatibility](/preferences/default/preferences.podman-desktop.podman).",
                 "highlight": true
               }
             ],
@@ -139,7 +139,10 @@
         "compose.binary.installComposeSystemWide": {
           "type": "boolean",
           "default": false,
-          "scope": ["DEFAULT", "Onboarding"],
+          "scope": [
+            "DEFAULT",
+            "Onboarding"
+          ],
           "hidden": true,
           "description": "Install system-wide instead of just your user directory, so compose can be accessed on the command line. Note: You may be prompted for elevated system privileges when enabling this."
         }


### PR DESCRIPTION
### What does this PR do?

Edits down some of the text on the compose download screen to be more succinct.

### Screenshot/screencast of this PR

#### AFTER
![Screenshot from 2023-10-26 20-43-51](https://github.com/containers/podman-desktop/assets/799683/b15ddb65-c1cf-4e6f-b397-c330cc4254d7)

#### BEFORE
![Screenshot from 2023-10-26 20-46-12](https://github.com/containers/podman-desktop/assets/799683/e2ed9d1d-d801-4e0e-8ac9-73b050010fba)

### What issues does this PR fix or reference?

Helps address #4462

### How to test this PR?

Run Podman Desktop on a system with no compose installed. This is the first set up screen. Make sure it looks like the before text and not the after.
