### PR TITLE
feat: allow to abort build image (#1655)

### DIFF
--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -906,6 +906,7 @@ function initExposure(): void {
       selectedProvider: ProviderContainerConnectionInfo,
       key: symbol,
       eventCollect: (key: symbol, eventName: 'finish' | 'stream' | 'error', data: string) => void,
+      cancellableTokenId?: number,
     ): Promise<unknown> => {
       onDataCallbacksBuildImageId++;
       onDataCallbacksBuildImage.set(onDataCallbacksBuildImageId, eventCollect);
@@ -917,6 +918,7 @@ function initExposure(): void {
         imageName,
         selectedProvider,
         onDataCallbacksBuildImageId,
+        cancellableTokenId,
       );
     },
   );

--- a/packages/renderer/src/lib/image/BuildImageFromContainerfile.spec.ts
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfile.spec.ts
@@ -26,6 +26,7 @@ import type { ProviderStatus } from '@podman-desktop/api';
 import type { ProviderContainerConnectionInfo, ProviderInfo } from '../../../../main/src/plugin/api/provider-info';
 import userEvent from '@testing-library/user-event';
 import BuildImageFromContainerfile from '/@/lib/image/BuildImageFromContainerfile.svelte';
+import { buildImagesInfo } from '/@/stores/build-images';
 
 // fake the window.events object
 beforeAll(() => {
@@ -120,4 +121,25 @@ test('Expect Done button is enabled once build is done', async () => {
   const doneButton = screen.getByRole('button', { name: 'Done' });
   expect(doneButton).toBeInTheDocument();
   expect(doneButton).toBeEnabled();
+});
+
+test('Expect Abort button to hidden when image build is not in progress', async () => {
+  setup();
+  render(BuildImageFromContainerfile);
+
+  const abortButton = screen.queryByRole('button', { name: 'Cancel' });
+  expect(abortButton).not.toBeInTheDocument();
+});
+
+test('Expect Abort button to being visible when image build is in progress', async () => {
+  setup();
+  buildImagesInfo.set({
+    buildImageKey: Symbol(),
+    buildRunning: true,
+  });
+  render(BuildImageFromContainerfile);
+
+  const abortButton = screen.getByRole('button', { name: 'Cancel' });
+  expect(abortButton).toBeInTheDocument();
+  expect(abortButton).toBeEnabled();
 });

--- a/packages/renderer/src/lib/image/BuildImageFromContainerfile.svelte
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfile.svelte
@@ -29,12 +29,12 @@ let containerFilePath: string;
 let containerBuildContextDirectory: string;
 
 let buildImageInfo: BuildImageInfo | undefined = undefined;
+let cancellableTokenId: number | undefined = undefined;
 let providers: ProviderInfo[] = [];
 let providerConnections: ProviderContainerConnectionInfo[] = [];
 let selectedProvider: ProviderContainerConnectionInfo | undefined = undefined;
 let selectedProviderConnection: ProviderContainerConnectionInfo | undefined = undefined;
 let logsTerminal: Terminal;
-let cancellableTokenId: number | undefined;
 
 $: hasInvalidFields = !containerFilePath || !containerBuildContextDirectory;
 
@@ -233,7 +233,7 @@ async function abortBuild() {
         <TerminalWindow bind:terminal="{logsTerminal}" />
         <div class="w-full">
           {#if buildImageInfo?.buildRunning}
-            <Button on:click="{() => abortBuild()}" class="w-full">Abort</Button>
+            <Button on:click="{() => abortBuild()}" class="w-full">Cancel</Button>
           {/if}
         </div>
       </div>


### PR DESCRIPTION
### What does this PR do?
This is built on https://github.com/containers/podman-desktop/pull/4364

It allows user to abort the build of an image

### Screenshot/screencast of this PR

![abort_build](https://github.com/containers/podman-desktop/assets/49404737/61ebc8f2-b705-4952-8aa4-7131abfac8f9)

### What issues does this PR fix or reference?

it closes #1655 

### How to test this PR?

1. build an image
2. abort
