### PR TITLE
feat: make it possible for lima to provide both

### DIFF
--- a/extensions/lima/package.json
+++ b/extensions/lima/package.json
@@ -34,6 +34,11 @@
           "type": "string",
           "default": "",
           "description": "Instance name (default is same name as type)"
+        },
+        "lima.socket": {
+          "type": "string",
+          "default": "",
+          "description": "Socket name (default is equal to type.sock)"
         }
       }
     },


### PR DESCRIPTION
Allow installing a container engine on your kubernetes node, and use the same lima instance for **both** containers and kubernetes.

For instance by installing "nerdctld" for containerd, or by running with Podman/CRI-O or Docker/CRI-Docker custom setup.

### What does this PR do?

### Screenshot/screencast of this PR

The same VM, running both "containers" and "kubernetes":

![lima-provider-both](https://github.com/containers/podman-desktop/assets/10364051/c769399d-139e-4eac-adfc-36886ef8c786)

You configure what Docker socket filename you want to use:

![lima-extension-sock](https://github.com/containers/podman-desktop/assets/10364051/4d37b20c-2e3e-4cdb-8a95-e464af40717e)

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop 
repository (or from another issue tracker). -->

Closes #5206

### How to test this PR?

<!-- Please explain steps to reproduce -->

The default templates don't have any such socket (only containerd), so it would require a custom installation.

Podman: `lima sudo apt install -y podman`. This will install podman version 3.4.4 (or [updates](https://packages.ubuntu.com/jammy-updates/podman))

<details>
<pre>
$ lima sudo podman --remote version
Client:
Version:      3.4.4
API Version:  3.4.4
Go Version:   go1.18.1
Built:        Thu Jan  1 00:00:00 1970
OS/Arch:      linux/amd64
Server:
Version:      3.4.4
API Version:  3.4.4
Go Version:   go1.18.1
Built:        Thu Jan  1 00:00:00 1970
OS/Arch:      linux/amd64
</pre>
</details>

Docker: `lima sudo apt install -y docker.io`. This will install docker version 20.10 (or [updates](https://packages.ubuntu.com/jammy-updates/docker.io))

<details>
<pre>
$ lima sudo docker version
Client:
 Version:           24.0.5
 API version:       1.43
 Go version:        go1.20.3
 Git commit:        24.0.5-0ubuntu1~22.04.1
 Built:             Mon Aug 21 19:50:14 2023
 OS/Arch:           linux/amd64
 Context:           default
Server:
 Engine:
  Version:          24.0.5
  API version:      1.43 (minimum version 1.12)
  Go version:       go1.20.3
  Git commit:       24.0.5-0ubuntu1~22.04.1
  Built:            Mon Aug 21 19:50:14 2023
  OS/Arch:          linux/amd64
  Experimental:     false
 containerd:
  Version:          v1.7.7
  GitCommit:        8c087663b0233f6e6e2f4515cee61d49f14746a8
 runc:
  Version:          1.1.9
  GitCommit:        v1.1.9-0-gccaecfcb
 docker-init:
  Version:          0.19.0
  GitCommit:        
</pre>
</details>

Then the unix socket for the container engine needs to be forwarded (see "podman" or "docker" templates).

The VM would run both the containers and the Kubernetes cluster, but they would **not** be sharing images.

So you would have to download the images (from podman/docker), and upload them again (to k3s or k8s)...

### (Advanced) To share image storage:

You would install either Podman + CRI-O or Docker + CRI-Docker, and then set up both the socket and the config.

But the default container runtime is containerd, and it does not _have_ a Docker API socket - only the `nerdctl` CLI.

The support for nerdctld is experimental, it can be found here: https://github.com/afbjorklund/nerdctld

You will need to install nerdctl and buildkit, in addition to the already running containerd (for k3s or k8s).

```
Client:
 Version:           24.0.5
 API version:       1.42 (downgraded from 1.43)
 Go version:        go1.20.3
 Git commit:        24.0.5-0ubuntu1~20.04.1
 Built:             Mon Aug 21 19:50:14 2023
 OS/Arch:           linux/amd64
 Context:           default

Server: 🤓
 nerdctl:
  Version:          1.6.2
 containerd:
  Version:          1.7.6-k3s1.27
 Engine:
  Version:          1.6.2
  API version:      1.42 (minimum version 1.24)
  Go version:       go1.21.1
  Git commit:       e3dc23be348efded17d2cd244397b4f7018e0794
  Built:            
  OS/Arch:          linux/amd64
  Experimental:     true

```

You could also start with the container runtime, and add the Kubernetes installation (complete with CRI/CNI).

For podman you would need to add cri-o, and for docker you would need to add cri-dockerd. And Kubernetes.

* https://docs.k3s.io/installation

* https://kubernetes.io/docs/setup/