### PR TITLE
fix: handle compose format json that is no longer a JSON array object

### DIFF
--- a/packages/main/src/plugin/contribution-manager.spec.ts
+++ b/packages/main/src/plugin/contribution-manager.spec.ts
@@ -483,7 +483,7 @@ describe('isPodmanDesktopServiceAlive', () => {
     contributionManager = new TestContributionManager(apiSender, directories, containerProviderRegistry, exec);
   });
 
-  test('is Alive', async () => {
+  test('is Alive with JSON array', async () => {
     const items = [
       {
         Service: 'podman-desktop-socket',
@@ -498,6 +498,27 @@ describe('isPodmanDesktopServiceAlive', () => {
     const execSpy = vi
       .spyOn(contributionManager, 'execComposeCommand')
       .mockResolvedValue({ stdout: JSON.stringify(items) } as any);
+
+    const isAlive = await contributionManager.isPodmanDesktopServiceAlive('/fake/directory', 'my-project');
+    expect(execSpy).toBeCalledWith('/fake/directory', ['-p', 'my-project', 'ps', '--format', 'json']);
+    expect(isAlive).toBeTruthy();
+  });
+
+  test('is Alive with JSON newline object (docker compose v2.21+)', async () => {
+    const item1 = {
+      Service: 'podman-desktop-socket',
+      State: 'running',
+    };
+    const item2 = {
+      Service: 'my-app',
+      State: 'running',
+    };
+
+    const fullString = JSON.stringify(item1) + '\n' + JSON.stringify(item2);
+
+    const execSpy = vi
+      .spyOn(contributionManager, 'execComposeCommand')
+      .mockResolvedValue({ stdout: fullString } as any);
 
     const isAlive = await contributionManager.isPodmanDesktopServiceAlive('/fake/directory', 'my-project');
     expect(execSpy).toBeCalledWith('/fake/directory', ['-p', 'my-project', 'ps', '--format', 'json']);

--- a/packages/main/src/plugin/contribution-manager.ts
+++ b/packages/main/src/plugin/contribution-manager.ts
@@ -272,7 +272,18 @@ export class ContributionManager {
     try {
       jsonResultPs = JSON.parse(result.stdout);
     } catch (error) {
-      throw new Error(`unable to parse the result of the ps command ${result.stdout}`);
+      if (error instanceof SyntaxError) {
+        // handle syntax of docker-compose v2.21+ format
+        // https://github.com/docker/compose/pull/10918
+        try {
+          const arrayResult = result.stdout.trim().split('\n');
+          jsonResultPs = arrayResult.map(entry => JSON.parse(entry));
+        } catch (error) {
+          throw new Error(`unable to parse the result of the ps command ${result.stdout}. Error is ${error}`);
+        }
+      } else {
+        throw new Error(`unable to parse the result of the ps command ${result.stdout}`);
+      }
     }
 
     // check jsonResultPs is an array


### PR DESCRIPTION
### What does this PR do?
handle new JSON output of docker-compose v2.21.+ which is in fact no longer JSON compliant
it's a set of JSON objects separated by newlines
related entry: https://github.com/docker/compose/pull/10918

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast 
explaining what is doing this PR -->

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/4357

### How to test this PR?

unit test
