### PR TITLE
feat: show registered CLI versions

### DIFF
--- a/extensions/compose/src/utils.spec.ts
+++ b/extensions/compose/src/utils.spec.ts
@@ -20,6 +20,14 @@ import { expect, test, vi, vitest, describe } from 'vitest';
 import { makeExecutable } from './utils';
 import { promises } from 'fs';
 
+vi.mock('@podman-desktop/api', async () => {
+  return {
+    process: {
+      exec: vi.fn(),
+    },
+  };
+});
+
 describe('makeExecutable', async () => {
   const fakePath = '/fake/path';
   test('mac', async () => {

--- a/extensions/compose/src/utils.ts
+++ b/extensions/compose/src/utils.ts
@@ -22,7 +22,6 @@ import { OS } from './os';
 export async function makeExecutable(filePath: string): Promise<void> {
   // New OS class
   const os = new OS();
-
   if (os.isLinux() || os.isMac()) {
     await promises.chmod(filePath, 0o755);
   }

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -2447,6 +2447,16 @@ declare module '@podman-desktop/api' {
     displayName: string;
     markdownDescription: string;
     images: ProviderImages;
+
+    /**
+     * Within your extension, it is reccommended to implement your own functionality to check the current
+     * version number of the CLI tool. For example, parsing the information from the CLI tool's `--version` flag.
+     * Passing in path will also help to show where the CLI tool is expected to be installed.
+     * This is usually the ~/.local/share/containers/podman-desktop/extensions-storage directory.
+     * Note: The expected value should not include 'v'.
+     */
+    version: string;
+    path: string;
   }
 
   export type CliToolState = 'registered';

--- a/packages/main/src/plugin/api/cli-tool-info.ts
+++ b/packages/main/src/plugin/api/cli-tool-info.ts
@@ -31,4 +31,6 @@ export interface CliToolInfo {
   state: CliToolState;
   images?: ProviderImages;
   extensionInfo: CliToolExtensionInfo;
+  version?: string;
+  path?: string;
 }

--- a/packages/main/src/plugin/cli-tool-registry.spec.ts
+++ b/packages/main/src/plugin/cli-tool-registry.spec.ts
@@ -112,6 +112,8 @@ suite('cli module', () => {
         displayName: 'tool-display-name',
         markdownDescription: 'markdown description',
         images: {},
+        version: '1.0.1',
+        path: 'path/to/tool-name',
       };
       const newCliTool = api.cli.createCliTool(options);
       expect(newCliTool.id).equals(`${extManifest.publisher}.${extManifest.name}.${options.name}`);
@@ -129,6 +131,8 @@ suite('cli module', () => {
         displayName: 'tool-display-name',
         markdownDescription: 'markdown description',
         images: {},
+        version: '1.0.1',
+        path: 'path/to/tool-name',
       };
       api.cli.createCliTool(options);
       expect(apiSender.send).toBeCalledWith('cli-tool-create');
@@ -141,6 +145,8 @@ suite('cli module', () => {
         displayName: 'tool-display-name',
         markdownDescription: 'markdown description',
         images: {},
+        version: '1.0.1',
+        path: 'path/to/tool-name',
       };
       const newCliTool = api.cli.createCliTool(options);
       const infoList = cliToolRegistry.getCliToolInfos();
@@ -165,6 +171,8 @@ suite('cli module', () => {
         displayName: 'tool-display-name',
         markdownDescription: 'markdown description',
         images: {},
+        version: '1.0.1',
+        path: 'path/to/tool-name',
       };
       const newCliTool = api.cli.createCliTool(options);
       newCliTool.dispose();
@@ -178,6 +186,8 @@ suite('cli module', () => {
         displayName: 'tool-display-name',
         markdownDescription: 'markdown description',
         images: {},
+        version: '1.0.1',
+        path: 'path/to/tool-name',
       };
       const newCliTool = api.cli.createCliTool(options);
       const infoListAfterCreate = cliToolRegistry.getCliToolInfos();

--- a/packages/main/src/plugin/cli-tool-registry.ts
+++ b/packages/main/src/plugin/cli-tool-registry.ts
@@ -52,6 +52,14 @@ export class CliToolImpl implements CliTool, Disposable {
     return this._options.markdownDescription;
   }
 
+  get version() {
+    return this._options.version;
+  }
+
+  get path() {
+    return this._options.path;
+  }
+
   get images() {
     return Object.freeze(this._options.images);
   }
@@ -92,6 +100,8 @@ export class CliToolRegistry {
         state: cliTool.state,
         images: cliTool.images,
         extensionInfo: cliTool.extensionInfo,
+        version: cliTool.version,
+        path: cliTool.path,
       };
     });
   }

--- a/packages/renderer/src/lib/preferences/PreferencesCliToolsRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesCliToolsRendering.spec.ts
@@ -40,6 +40,8 @@ const cliToolInfoItem1: CliToolInfo = {
     id: 'ext-id1',
     label: 'ext-label1',
   },
+  version: '1.0.1',
+  path: 'path/to/tool-name-1',
 };
 
 const cliToolInfoItem2: CliToolInfo = {
@@ -53,25 +55,44 @@ const cliToolInfoItem2: CliToolInfo = {
     label: 'ext-label2',
   },
   images: {},
+  version: '1.0.2',
+  path: 'path/to/tool-name-2',
 };
 
 const cliToolInfoItem3: CliToolInfo = {
-  id: 'ext-id.tool-name2',
-  name: 'tool-name2',
-  description: 'markdown description2',
-  displayName: 'tools-display-name2',
+  id: 'ext-id.tool-name3',
+  name: 'tool-name3',
+  description: 'markdown description3',
+  displayName: 'tools-display-name3',
   state: 'registered',
   extensionInfo: {
-    id: 'ext-id2',
-    label: 'ext-label2',
+    id: 'ext-id3',
+    label: 'ext-label3',
   },
   images: {
     icon: 'encoded-icon',
   },
+  version: '1.0.3',
+  path: 'path/to/tool-name-3',
+};
+
+const cliToolInfoItem4: CliToolInfo = {
+  id: 'ext-id.tool-name4',
+  name: 'tool-name4',
+  description: 'markdown description4',
+  displayName: 'tools-display-name4',
+  state: 'registered',
+  extensionInfo: {
+    id: 'ext-id4',
+    label: 'ext-label4',
+  },
+  images: {},
+  version: '', // version is empty, so it should be showing the error
+  path: '',
 };
 
 suite('CLI Tool Prefernces page shows', () => {
-  const cliTools = [cliToolInfoItem1, cliToolInfoItem2, cliToolInfoItem3];
+  const cliTools = [cliToolInfoItem1, cliToolInfoItem2, cliToolInfoItem3, cliToolInfoItem4];
   let cliToolRows: HTMLElement[] = [];
 
   function validatePropertyPresentation(labelName: string, getExpectedContent: (info: CliToolInfo) => string) {
@@ -115,5 +136,15 @@ suite('CLI Tool Prefernces page shows', () => {
 
   test('tool`s logo is shown when images.icon property is present', () => {
     expect(within(cliToolRows[2]).getAllByLabelText('cli-logo').length).equals(1);
+  });
+
+  test('test tools version is shown', () => {
+    // First three tools have version, the last one has empty version and should show error
+    expect(within(cliToolRows[0]).queryAllByLabelText('cli-version')[0].textContent).toEqual('tool-name1 v1.0.1');
+    expect(within(cliToolRows[1]).queryAllByLabelText('cli-version')[0].textContent).toEqual('tool-name2 v1.0.2');
+    expect(within(cliToolRows[2]).queryAllByLabelText('cli-version')[0].textContent).toEqual('tool-name3 v1.0.3');
+
+    // Expect cliToolRows[3] cli-version to not exist since we do not provide version
+    expect(within(cliToolRows[3]).queryAllByLabelText('cli-version').length).toEqual(0);
   });
 });

--- a/packages/renderer/src/lib/preferences/PreferencesCliToolsRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesCliToolsRendering.svelte
@@ -44,6 +44,11 @@ import EmptyScreen from '../ui/EmptyScreen.svelte';
           </div>
           <div role="region" class="ml-3 mt-2 text-sm text-gray-300">
             <Markdown markdown="{cliTool.description}" />
+            {#if cliTool.version !== ''}
+              <span
+                class="text-white-400 font-bold font-mono text-xs bg-charcoal-900 p-2 rounded-lg"
+                aria-label="cli-version">{cliTool.name} v{cliTool.version}</span>
+            {/if}
           </div>
         </div>
       </div>


### PR DESCRIPTION
feat: show registered CLI versions

### What does this PR do?

* Shows the CLI version within the CLI Tools section of preferences
* The extension handles the updating / checking of the version and
  updates the CLI page accordingly.

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast
explaining what is doing this PR -->

![Screenshot 2023-10-27 at 11 45 07 AM](https://github.com/containers/podman-desktop/assets/6422176/09b0aadf-3cf1-4521-bbab-d69e273c7cb7)



### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes #3707

### How to test this PR?

1. Install Compose through onboarding
2. Open the CLI Tools section and you should now see the version number
   of the tool.

<!-- Please explain steps to reproduce -->

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
