### PR TITLE
fix: centering screen content for compose onboard

### DIFF
--- a/packages/renderer/src/lib/onboarding/Onboarding.svelte
+++ b/packages/renderer/src/lib/onboarding/Onboarding.svelte
@@ -366,7 +366,7 @@ async function restartSetup() {
           </div>
         {/if}
 
-        <div class="flex flex-col mx-auto">
+        <div class="max-w-[80%] flex flex-col mx-auto">
           {#if activeStepContent}
             {#each activeStepContent as row}
               <div class="flex flex-row mx-auto">


### PR DESCRIPTION
### What does this PR do?

This is truly an aesthetic margins/centering thing. It sets the margins to be wider, I tested in a bunch of different window sizes, it's purely aesthetic.

### Screenshot/screencast of this PR

![Screenshot from 2023-10-27 15-38-00](https://github.com/containers/podman-desktop/assets/799683/1a2b24e0-7d3e-443d-b866-5cbba974721c)

![Screenshot from 2023-10-27 15-40-06](https://github.com/containers/podman-desktop/assets/799683/a5452cfd-7cb3-44d5-86b6-c8c6de8a765b)
![Screenshot from 2023-10-27 15-39-54](https://github.com/containers/podman-desktop/assets/799683/06f2f34e-7d4e-46f3-9a5b-5fed56d58037)


### What issues does this PR fix or reference?

#4462

### How to test this PR?

Remove compose binaries from your system, run thru compose onboarding, check the screens to make sure there's clear padding on left and right of main content area as in screenshots above and that it doesn't break at diff window sizes.
