### PR TITLE
fix: reduce website footer

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -351,18 +351,6 @@ const config = {
                 to: '/docs/installation',
               },
               {
-                label: 'Onboarding for containers',
-                to: '/docs/onboarding/containers',
-              },
-              {
-                label: 'Onboarding for Kubernetes',
-                to: '/docs/onboarding-for-kubernetes',
-              },
-              {
-                label: 'Working with containers',
-                to: '/docs/working-with-containers',
-              },
-              {
                 label: 'Migrating from Docker',
                 to: '/docs/migrating-from-docker',
               },
@@ -384,10 +372,6 @@ const config = {
             title: 'Links',
             items: [
               {
-                label: 'Blog',
-                to: '/blog',
-              },
-              {
                 label: 'GitHub',
                 href: 'https://github.com/containers/podman-desktop',
               },
@@ -404,17 +388,13 @@ const config = {
                 href: 'https://fedora.im',
               },
               {
-                label: 'Kubernetes chat: Join #podman-desktop on the Kubernetes Slack',
+                label: 'Kubernetes chat: #podman-desktop on the Kubernetes Slack',
                 href: 'https://slack.k8s.io/',
-              },
-              {
-                label: 'Podman Desktop Planning & Roadmap',
-                href: 'https://github.com/containers/podman-desktop/projects?type=beta',
               },
             ],
           },
         ],
-        copyright: `Copyright © ${new Date().getFullYear()} ${title}<br/>Apache License 2.0 License`,
+        copyright: `Copyright © ${new Date().getFullYear()} ${title} - Apache License 2.0 License`,
       },
       prism: {
         theme: lightCodeTheme,

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -355,10 +355,6 @@ const config = {
                 to: '/docs/migrating-from-docker',
               },
               {
-                label: 'Working with Compose',
-                to: '/docs/compose',
-              },
-              {
                 label: 'Working with Kubernetes',
                 to: '/docs/kubernetes',
               },
@@ -376,20 +372,16 @@ const config = {
                 href: 'https://github.com/containers/podman-desktop',
               },
               {
-                label: 'General chat (bridged): #podman-desktop on Discord',
+                label: 'Chat (bridged): #podman-desktop on Discord',
                 href: 'https://discord.com/invite/x5GzFF6QH4',
               },
               {
-                label: 'General chat (bridged): #podman-desktop@libera.chat on IRC',
-                href: 'https://libera.chat',
+                label: 'Other ways to Communicate',
+                href: 'https://github.com/containers/podman-desktop#communication',
               },
               {
-                label: 'General chat (bridged): #podman-desktop@fedora.im on Matrix',
-                href: 'https://fedora.im',
-              },
-              {
-                label: 'Kubernetes chat: #podman-desktop on the Kubernetes Slack',
-                href: 'https://slack.k8s.io/',
+                label: 'Current Sprint',
+                href: 'https://github.com/orgs/containers/projects/4/views/8',
               },
             ],
           },


### PR DESCRIPTION
### What does this PR do?

Ok, here's my pass at reducing the vertical height of the footer. Long term I think we can and should do more, this is just a quick initial cleanup pass:
- Left: removed three links (so both columns are down to 5). These are a judgement call, e.g. I felt like 'Docker migration' is a bit of marketing we'd want to leave for now.
- Right: remove Blog (it's already at the top of the page).
- Right: remove planning and roadmap, both not really useful link and accessible from the Github link above.
- Put copyright and license on one line.

Overall, this reduces the footer height from 11 lines of text to 7.

### Screenshot/screencast of this PR

Before:

<img width="1257" alt="Screenshot 2023-10-27 at 4 30 37 PM" src="https://github.com/containers/podman-desktop/assets/19958075/02efe459-6ead-4bfc-986a-27916a3a3abf">

After (updated to latest commit):

<img width="1056" alt="Screenshot 2023-10-30 at 2 43 53 PM" src="https://github.com/containers/podman-desktop/assets/19958075/3249576a-3162-4de2-a427-2cf9d56536c7">

### What issues does this PR fix or reference?

Fixes #4299.

### How to test this PR?

`yarn website:dev`