### PR TITLE
fix: add website target for running vale

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -17,6 +17,7 @@
     "format:fix": "prettier --cache --write '**/*.{md,js}' 'src/**/*.{css,ts,tsx}'",
     "markdownlint:check": "markdownlint-cli2 --config ../.markdownlint.yaml \"**/*.md\" \"#node_modules\"",
     "markdownlint:fix": "markdownlint-cli2-fix --config ../.markdownlint.yaml \"**/*.md\" \"#node_modules\"",
+    "vale": "vale sync && vale --config ../.vale.ini .",
     "lint:check": "cd .. && eslint --cache --cache-location website/.eslintcache website --ext js,ts,tsx",
     "lint:fix": "cd .. && eslint --cache --cache-location website/.eslintcache website --fix --ext js,ts,tsx",
     "lint:clean": "rimraf .eslintcache"


### PR DESCRIPTION
### What does this PR do?

Enables to check the "vale" output, before GitHub Actions does.

https://redhat-documentation.github.io/vale-at-red-hat/docs/main/user-guide/installing-vale-cli/

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast 
explaining what is doing this PR -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop 
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to reproduce -->

`cd website`
`yarn vale`