### PR TITLE
fix: remove prev/next bar

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -145,6 +145,10 @@ li.footer__item a svg {
   font-size: 1em;
 }
 
+.pagination-nav {
+  display: none;
+}
+
 @media (min-width: 1200px) {
   .navbar__title {
     font-size: 2em;


### PR DESCRIPTION
### What does this PR do?

Users don't read documentation like a book anymore, and when there is an obvious next step we're already putting this in a Next Steps section. To avoid the duplication and spending any time trying to make the prev/next bar consistent, we should just remove this bar entirely.

As per [1] the Docusaurus feature to allow you to disable prev/next may be coming in a future release, so the only current options are to add
```
  pagination_next: null
  pagination_prev: null
```
in every page, or use custom css to hide the bar. This does the latter.

[1] https://github.com/facebook/docusaurus/discussions/6525

### Screenshot/screencast of this PR

Before:

<img width="811" alt="Screenshot 2023-10-29 at 8 40 38 AM" src="https://github.com/containers/podman-desktop/assets/19958075/2743813a-617d-43a7-b01a-bea79f3b915d">

After:

<img width="811" alt="Screenshot 2023-10-29 at 8 40 13 AM" src="https://github.com/containers/podman-desktop/assets/19958075/fb0649fa-3784-47fe-916c-7f0df7b759f8">

### What issues does this PR fix or reference?

Fixes #4311.

### How to test this PR?

`yarn website:dev`