### PR TITLE
docs: fix typos

### DIFF
--- a/.vale/fixtures/PodmanDesktop/Links/testvalid.md
+++ b/.vale/fixtures/PodmanDesktop/Links/testvalid.md
@@ -1,5 +1,5 @@
 [External link](https://podman-desktop.io)
-[Internal link statrting with /](/docs)
+[Internal link starting with /](/docs)
 [Good URL](/docs/onboarding)
 ![Image](/docs/onboarding/img/image.png)
 A sentence containing a (parenthesis block) inside.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -179,7 +179,7 @@ All files                     |    75.1 |    97.22 |   93.75 |    75.1 |
 For a detailed information about the code coverage you can search the mentioned folder and find `html` lcov report:
 `test-resources/coverage/extensions/compose/lcov-report/index.html`
 
-When contribuing the new code, you should consider not lowering overall code coverage.
+When contributing the new code, you should consider not lowering overall code coverage.
 
 ### Step 7. Code formatter / linter
 
@@ -229,7 +229,7 @@ Some tips for the PR process:
 - Make sure you include as much information as possible in your PR so maintainers can understand.
 - Try to break up larger PRs into smaller ones for easier reviewing
 - Any additional code changes should be in a new commit so we can see what has changed between reviews.
-- Squash your commits into logical pieces of work
+- Squash your commits into logical pieces of work.
 
 ### Use the correct commit message semantics
 
@@ -351,7 +351,7 @@ If you're unsure where to add code (renderer, UI, extensions, plugins) see the b
 
 ### Extensions
 
-Podman Desktop is moduralized into extensions for each 'Provider'. You can also create and add your own extension.
+Podman Desktop is modularized into extensions for each 'Provider'. You can also create and add your own extension.
 
 See our [EXTENSIONS.md](/EXTENSIONS.md) document for more details.
 

--- a/EXTENSIONS.md
+++ b/EXTENSIONS.md
@@ -82,7 +82,7 @@ This can be updated throughout your extension by calling for example: `provider.
 export type ProviderConnectionStatus = 'started' | 'stopped' | 'starting' | 'stopping' | 'unknown';
 ```
 
-> **_NOTE:_** The `unknown` status is unique as it will not show in the extension section of Podman Desktop, it will also not be accessible via API calls. Uknown statuses typically happen when Podman Desktop is unable to load the extension.
+> **_NOTE:_** The `unknown` status is unique as it will not show in the extension section of Podman Desktop, it will also not be accessible via API calls. Unknown statuses typically happen when Podman Desktop is unable to load the extension.
 
 `ProviderConnectionStatus` is the main "Lifecycle" of your extension. The status is updated by automatically by Podman Desktop and reflected within the provider.
 
@@ -90,7 +90,7 @@ Upon a successful start up via the `activate` function within your extension, `P
 
 `ProviderConnectionStatus` statuses are used in two areas, [extension-loader.ts](https://github.com/containers/podman-desktop/blob/main/packages/main/src/plugin/extension-loader.ts) and [tray-menu.ts](https://github.com/containers/podman-desktop/blob/main/packages/main/src/tray-menu.ts):
 
-- `extension-loader.ts`: Attempts to load the extension and sets the status accordingly (either `started`, `stopped`, `starting` or `stopping`). If an unknown error has occured, the status is set to `unknown`. `extension-loader.ts` also sends an API call to Podman Desktop to update the UI of the extension.
+- `extension-loader.ts`: Attempts to load the extension and sets the status accordingly (either `started`, `stopped`, `starting` or `stopping`). If an unknown error has occurred, the status is set to `unknown`. `extension-loader.ts` also sends an API call to Podman Desktop to update the UI of the extension.
 - `tray-menu.ts`: If `extensionApi.tray.registerMenuItem(item);` API call has been used, a tray menu of the extension will be created. When created, Podman Desktop will use the `ProviderConnectionStatus` to indicate the status within the tray menu.
 
 #### Expanding the `extension-api` API

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -25,8 +25,8 @@ Below is what a typical release week may look like:
 1. Enter the name of the release. Example: `0.12.0` (DO NOT use the v prefix like v0.12.0)
 1. Specify the branch to use for the new release. It's main for all major releases. For a bugfix release, you'll select a different branch.
 1. Click on the `Run workflow` button.
-1. Note: `Run workflow` takes approximatley 30-50 minutes. Brew a coffee, work on the release notes, and/or complete the next two steps while you wait.
-1. Close the milestone for the respective release, make sure that all tasks within the milesetone are completed / updated before closing. https://github.com/containers/podman-desktop/milestones
+1. Note: `Run workflow` takes approximately 30-50 minutes. Brew a coffee, work on the release notes, and/or complete the next two steps while you wait.
+1. Close the milestone for the respective release, make sure that all tasks within the milestone are completed / updated before closing. https://github.com/containers/podman-desktop/milestones
 1. If not already created, click on `New Milestone` and create a new milestone for the NEXT release.
 1. Check that https://github.com/containers/podman-desktop/actions/workflows/release.yaml has been completed. Sometimes it will flake, so you may need to re-run it.
 1. There should be an automated PR that has been created. Approve this and set to auto-merge. This will be automatically merged in after all tests have been ran (takes 10-30 minutes). The title looks like `chore: 📢 Bump version to 0.13.0`. Rerun workflow manually if some of e2e tests are failing.

--- a/website/blog/2022-11-17-develop-podman-using-codespaces.md
+++ b/website/blog/2022-11-17-develop-podman-using-codespaces.md
@@ -250,7 +250,7 @@ It starts VNC and noVNC, start precompiled Podman Desktop and start the document
 
 It is not launching the Watch mode/development mode of Podman Desktop as it requires a container having more than 8GB of memory.
 
-Picking up a larger instace with for example 16GB, it's possible to use development mode.
+Picking up a larger instance with for example 16GB, it's possible to use development mode.
 
 Of course, to make VNC happy, we need to specify the `DISPLAY` environment variable.
 
@@ -288,7 +288,7 @@ Go to <https://github.com/containers/podman-desktop> then click on the `< > Code
 
 Once you click on the button, the codespace is setting up:
 
-![Preparing Codepace](img/develop-podman-using-codespaces/codespaces-preparing-codespace.png)
+![Preparing Codespace](img/develop-podman-using-codespaces/codespaces-preparing-codespace.png)
 
 After few minutes, as there is not yet [prebuilt codespaces](https://docs.github.com/en/codespaces/prebuilding-your-codespaces/about-github-codespaces-prebuilds), the codespace is opening.
 

--- a/website/blog/2023-01-18-release-0.11.md
+++ b/website/blog/2023-01-18-release-0.11.md
@@ -139,7 +139,7 @@ The list of containers also displays pods, now clicking on the pod name directly
 
 #### Improved styles of buttons for actions [#984](https://github.com/containers/podman-desktop/pull/984)
 
-The style of the buttons for actions on item in the list of in details pages have been improved. The background has been removed, but to make the hover state more visible, the "hover" circle is visble and the icon's color is also changing.
+The style of the buttons for actions on item in the list of in details pages have been improved. The background has been removed, but to make the hover state more visible, the "hover" circle is visible and the icon's color is also changing.
 
 On lists:
 ![list-actions](https://user-images.githubusercontent.com/6422176/205979121-b49a0ddf-03bb-4a4d-8d12-bc8d0bd52387.png)

--- a/website/blog/2023-02-15-release-0.12.md
+++ b/website/blog/2023-02-15-release-0.12.md
@@ -39,7 +39,7 @@ With the latest update, users can now add multiple local-to-remote port mappings
 
 ![port-mapping](https://user-images.githubusercontent.com/49404737/215112797-86dcf3f0-121a-487e-a71f-ad41e91f93da.gif)
 
-### Installing Podman Dekstop on Windows Home Edition [#1268](https://github.com/containers/podman-desktop/pull/1268)
+### Installing Podman Desktop on Windows Home Edition [#1268](https://github.com/containers/podman-desktop/pull/1268)
 
 Podman Desktop 0.12 offers the ability to be installed on Windows Home Edition. The mechanism uses Virtual Machine Platform detection, instead of hyper-v. WSL2 is still requires but can be installed along with the installation process.
 
@@ -80,7 +80,7 @@ Icons in empty screens have been updated to use the same consistent SVG icon as 
 A placeholder is now displayed when logs are being fetched.
 ![placeholder-loading-logs](https://user-images.githubusercontent.com/49404737/216952505-899308ae-183e-487a-b6e5-28832a0b6452.gif)
 
-#### Fixed alignement in badges from the navigation sidebar [#1357](https://github.com/containers/podman-desktop/pull/1357)
+#### Fixed alignment in badges from the navigation sidebar [#1357](https://github.com/containers/podman-desktop/pull/1357)
 
 Badges in the sidebar are now aligned with the title of the section.
 
@@ -129,7 +129,7 @@ The documentation had many editorial reviews, and new content.
 - Website: fixed download links for Windows and macOS binaries [#1255](https://github.com/containers/podman-desktop/pull/1255)
 - Fixed prettier commands on Windows [#1266](https://github.com/containers/podman-desktop/pull/1267)
 - Fixed new xterm instance spawn when clicking the logs route [#1344](https://github.com/containers/podman-desktop/pull/1344)
-- Fixed need to wait that telemetry has been initilized before proceeding [#1373](https://github.com/containers/podman-desktop/pull/1373)
+- Fixed need to wait that telemetry has been initialized before proceeding [#1373](https://github.com/containers/podman-desktop/pull/1373)
 - Fixed new xterm instance spawn when clicking the logs route in pod details[#1393](https://github.com/containers/podman-desktop/pull/1393)
 - Fixed stop spinner if image cannot be retrieved [#1394](https://github.com/containers/podman-desktop/pull/1394)
 - Fixed escape command with quotes only for Windows [#1462](https://github.com/containers/podman-desktop/pull/1462)

--- a/website/blog/2023-04-14-release-0.14.md
+++ b/website/blog/2023-04-14-release-0.14.md
@@ -69,7 +69,7 @@ If you like terminals, you can always open one up and use the Kind CLI to
 [interact with your cluster](https://kind.sigs.k8s.io/docs/user/quick-start/#interacting-with-your-cluster).
 
 Within Podman Desktop we have started with two ways to interact with the cluster.
-The first is the ability to play local YAML files on your Kind (or any other Kubernetes!) cluster [1261](https://github.com/containers/podman-desktop/issues/1261). This allows you to take existing Kubernetes YAML definitons -
+The first is the ability to play local YAML files on your Kind (or any other Kubernetes!) cluster [1261](https://github.com/containers/podman-desktop/issues/1261). This allows you to take existing Kubernetes YAML definitions -
 your deployments, services, or other objects - and deploy it to the cluster.
 
 <ReactPlayer playing controls url="https://user-images.githubusercontent.com/436777/231812563-ece0a56a-b347-48f8-a3a7-400eb9449037.mp4" width='100%' height='100%' />

--- a/website/blog/2023-05-17-release-1.0.md
+++ b/website/blog/2023-05-17-release-1.0.md
@@ -37,7 +37,7 @@ Podman Desktop 1.0 is now available. [Click here to download it](/downloads)!
 
 ### Highlighting Featured Extensions
 
-A critical part of our vision for Podman Deskop is the ability to install extensions to
+A critical part of our vision for Podman Desktop is the ability to install extensions to
 support additional container engines, Kubernetes providers, or other tools. However, it
 has not been easy to discover new extensions.
 

--- a/website/docs/extensions/write/when-clause-context.md
+++ b/website/docs/extensions/write/when-clause-context.md
@@ -83,7 +83,7 @@ Logical operators allow combining simple context keys or when-clause expressions
 
 #### Equality operators
 
-Equality operators allow checking for equality of a context key's value againt a specified value.
+Equality operators allow checking for equality of a context key's value against a specified value.
 
 **Note:** the right side is a value and not considered as a context key, so no value is searched in the context. If it contains whitespaces, it must be wrapped in single-quotes (for example `'my tool.exe'`)
 

--- a/website/docs/kubernetes/deploying-a-pod-to-kubernetes.md
+++ b/website/docs/kubernetes/deploying-a-pod-to-kubernetes.md
@@ -32,6 +32,6 @@ With Podman Desktop, you can deploy a pod to your Kubernetes cluster.
 
 - On the **Deploy generated pod to Kubernetes** screen, the created pod status is _Phase: Running_
 
-  ![Deplying a pod](img/deploying-a-pod.png)
+  ![Deploying a pod](img/deploying-a-pod.png)
 
 - Go to **Pods**: your pod is in the list.

--- a/website/docs/kubernetes/index.md
+++ b/website/docs/kubernetes/index.md
@@ -18,4 +18,4 @@ Podman Desktop and Podman have many features allowing easy migration from contai
 
 1. [Select your Kubernetes context](/docs/kubernetes/viewing-and-selecting-current-kubernete-context-in-the-status-bar).
 2. [Deploy a container](/docs/kubernetes/deploying-a-container-to-kubernetes).
-3. [Deply a pod](/docs/kubernetes/deploying-a-pod-to-kubernetes).
+3. [Deploy a pod](/docs/kubernetes/deploying-a-pod-to-kubernetes).

--- a/website/docs/kubernetes/kind/pushing-an-image-to-kind.md
+++ b/website/docs/kubernetes/kind/pushing-an-image-to-kind.md
@@ -51,7 +51,7 @@ Therefore, create a Pod that uses the loaded image.
    1. **Kubernetes YAML file**: select your `verify_my_image.yaml` file.
    1. **Select Runtime**: **Using a Kubernetes cluster**.
    1. Click **Play**.
-   1. Clik **Done**
+   1. Click **Done**
 1. Open **<icon icon="fa-solid fa-cubes" size="lg" /> Pods**.
 1. **<icon icon="fa-solid fa-search" size="lg" /> Search pods**: `<verify-my-image>`.
 1. The pod **Status** is **Running**.

--- a/website/docs/onboarding-for-kubernetes/existing-kubernetes/index.md
+++ b/website/docs/onboarding-for-kubernetes/existing-kubernetes/index.md
@@ -32,6 +32,6 @@ You can also use the Kubernetes CLI to configure access to your Kubernetes clust
 
 - You can [view and select the Kubernetes cluster in Podman Desktop](/docs/kubernetes/viewing-and-selecting-current-kubernete-context)
 
-#### Additional resopurces
+#### Additional resources
 
 - [Kubernetes documentation: Configure access to multiple clusters](https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/)

--- a/website/docs/troubleshooting/troubleshooting-podman.md
+++ b/website/docs/troubleshooting/troubleshooting-podman.md
@@ -94,7 +94,7 @@ Podman Desktop might fail listing images or container.
    $ podman run quay.io/podman/hello
    ```
 
-## Podman Destkop fails listing containers
+## Podman Desktop fails listing containers
 
 #### Issue
 
@@ -232,4 +232,4 @@ This might appear when either:
 
 3. Restart the Podman machine to recreate and activate the default Docker socket path.
 
-_Note:_ If Docker Desktop is started again, it will automatically re-alias the default Docker socket location and the Podman compatibilty warning will re-appear.
+_Note:_ If Docker Desktop is started again, it will automatically re-alias the default Docker socket location and the Podman compatibility warning will re-appear.


### PR DESCRIPTION
### What does this PR do?
This PR is focused on improving the quality and correctness of the documentation by fixing some of the typos that may confuse users or hinder understanding.

### What issues does this PR fix or reference?
Fixes typos mainly from markdown files. 
One may create a similar pull request after encountering any other typos while going through the documentation.
