### PR TITLE
fix: report error if container engine action fails in details page (#3796)

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesConnectionActions.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionActions.spec.ts
@@ -25,7 +25,6 @@ import type {
   ProviderKubernetesConnectionInfo,
 } from '../../../../main/src/plugin/api/provider-info';
 import type { IConnectionStatus } from './Util';
-import { getProviderConnectionName } from './Util';
 import PreferencesConnectionActions from './PreferencesConnectionActions.svelte';
 
 const containerProviderInfo: ProviderInfo = {
@@ -76,8 +75,6 @@ const addConnectionToRestartingQueue = () => {
   //nothing
 };
 
-const connectionStatuses = new Map<string, IConnectionStatus>();
-
 const connectionStatus: IConnectionStatus = {
   status: 'started',
   inProgress: false,
@@ -85,11 +82,9 @@ const connectionStatus: IConnectionStatus = {
 
 test('if container connection has start lifecycle method, start button has to be visible', () => {
   const customProviderInfo: ProviderInfo = { ...containerProviderInfo, name: 'podman' };
-  const connectionName = getProviderConnectionName(customProviderInfo, containerConnection);
-  connectionStatuses.set(connectionName, connectionStatus);
 
   render(PreferencesConnectionActions, {
-    connectionStatuses,
+    connectionStatus,
     provider: customProviderInfo,
     connection: containerConnection,
     updateConnectionStatus,
@@ -101,11 +96,9 @@ test('if container connection has start lifecycle method, start button has to be
 
 test('if container connection has stop lifecycle method, stop button has to be visible', () => {
   const customProviderInfo: ProviderInfo = { ...containerProviderInfo, name: 'podman' };
-  const connectionName = getProviderConnectionName(customProviderInfo, containerConnection);
-  connectionStatuses.set(connectionName, connectionStatus);
 
   render(PreferencesConnectionActions, {
-    connectionStatuses,
+    connectionStatus,
     provider: customProviderInfo,
     connection: containerConnection,
     updateConnectionStatus,
@@ -117,11 +110,9 @@ test('if container connection has stop lifecycle method, stop button has to be v
 
 test('if container connection has start and stop lifecycle methods, restart button has to be visible', () => {
   const customProviderInfo: ProviderInfo = { ...containerProviderInfo, name: 'podman' };
-  const connectionName = getProviderConnectionName(customProviderInfo, containerConnection);
-  connectionStatuses.set(connectionName, connectionStatus);
 
   render(PreferencesConnectionActions, {
-    connectionStatuses,
+    connectionStatus,
     provider: customProviderInfo,
     connection: containerConnection,
     updateConnectionStatus,
@@ -137,11 +128,9 @@ test('if container connection has start and stop lifecycle methods, restart butt
 
 test('if container connection has delete lifecycle method, delete button has to be visible', () => {
   const customProviderInfo: ProviderInfo = { ...containerProviderInfo, name: 'podman' };
-  const connectionName = getProviderConnectionName(customProviderInfo, containerConnection);
-  connectionStatuses.set(connectionName, connectionStatus);
 
   render(PreferencesConnectionActions, {
-    connectionStatuses,
+    connectionStatus,
     provider: customProviderInfo,
     connection: containerConnection,
     updateConnectionStatus,
@@ -153,11 +142,9 @@ test('if container connection has delete lifecycle method, delete button has to 
 
 test('if kubernetes connection has start lifecycle method, start button has to be visible', () => {
   const customProviderInfo: ProviderInfo = { ...containerProviderInfo, name: 'kube' };
-  const connectionName = getProviderConnectionName(customProviderInfo, kubernetesConnection);
-  connectionStatuses.set(connectionName, connectionStatus);
 
   render(PreferencesConnectionActions, {
-    connectionStatuses,
+    connectionStatus,
     provider: customProviderInfo,
     connection: kubernetesConnection,
     updateConnectionStatus,
@@ -169,11 +156,9 @@ test('if kubernetes connection has start lifecycle method, start button has to b
 
 test('if kubernetes connection has stop lifecycle method, stop button has to be visible', () => {
   const customProviderInfo: ProviderInfo = { ...containerProviderInfo, name: 'kube' };
-  const connectionName = getProviderConnectionName(customProviderInfo, kubernetesConnection);
-  connectionStatuses.set(connectionName, connectionStatus);
 
   render(PreferencesConnectionActions, {
-    connectionStatuses,
+    connectionStatus,
     provider: customProviderInfo,
     connection: kubernetesConnection,
     updateConnectionStatus,
@@ -185,11 +170,9 @@ test('if kubernetes connection has stop lifecycle method, stop button has to be 
 
 test('if kubernetes connection has start and stop lifecycle methods, restart button has to be visible', () => {
   const customProviderInfo: ProviderInfo = { ...containerProviderInfo, name: 'kube' };
-  const connectionName = getProviderConnectionName(customProviderInfo, kubernetesConnection);
-  connectionStatuses.set(connectionName, connectionStatus);
 
   render(PreferencesConnectionActions, {
-    connectionStatuses,
+    connectionStatus,
     provider: customProviderInfo,
     connection: kubernetesConnection,
     updateConnectionStatus,
@@ -205,11 +188,9 @@ test('if kubernetes connection has start and stop lifecycle methods, restart but
 
 test('if kubernetes connection has delete lifecycle method, delete button has to be visible', () => {
   const customProviderInfo: ProviderInfo = { ...containerProviderInfo, name: 'kube' };
-  const connectionName = getProviderConnectionName(customProviderInfo, kubernetesConnection);
-  connectionStatuses.set(connectionName, connectionStatus);
 
   render(PreferencesConnectionActions, {
-    connectionStatuses,
+    connectionStatus,
     provider: customProviderInfo,
     connection: kubernetesConnection,
     updateConnectionStatus,

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionActions.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionActions.svelte
@@ -7,9 +7,9 @@ import type {
 } from '../../../../main/src/plugin/api/provider-info';
 import LoadingIconButton from '../ui/LoadingIconButton.svelte';
 import { type ConnectionCallback, eventCollect, startTask } from './preferences-connection-rendering-task';
-import { getProviderConnectionName, type IConnectionRestart, type IConnectionStatus } from './Util';
+import { type IConnectionRestart, type IConnectionStatus } from './Util';
 
-export let connectionStatuses: Map<string, IConnectionStatus>;
+export let connectionStatus: IConnectionStatus | undefined;
 export let provider: ProviderInfo;
 export let connection: ProviderContainerConnectionInfo | ProviderKubernetesConnectionInfo;
 export let updateConnectionStatus: (
@@ -20,7 +20,6 @@ export let updateConnectionStatus: (
   inProgress?: boolean,
 ) => void;
 export let addConnectionToRestartingQueue: (connection: IConnectionRestart) => void;
-$: connectionStatus = connectionStatuses;
 
 async function startConnectionProvider(
   provider: ProviderInfo,
@@ -139,8 +138,7 @@ function getLoggerHandler(
 }
 </script>
 
-{#if connectionStatus.has(getProviderConnectionName(provider, connection))}
-  {@const state = connectionStatus.get(getProviderConnectionName(provider, connection))}
+{#if connectionStatus}
   {#if connection.lifecycleMethods && connection.lifecycleMethods.length > 0}
     <div class="mt-2 relative">
       <!-- TODO: see action available like machine infos -->
@@ -151,7 +149,7 @@ function getLoggerHandler(
               clickAction="{() => startConnectionProvider(provider, connection)}"
               action="start"
               icon="{faPlay}"
-              state="{state}"
+              state="{connectionStatus}"
               leftPosition="left-[0.15rem]" />
           </div>
         {/if}
@@ -160,7 +158,7 @@ function getLoggerHandler(
             clickAction="{() => restartConnectionProvider(provider, connection)}"
             action="restart"
             icon="{faRotateRight}"
-            state="{state}"
+            state="{connectionStatus}"
             leftPosition="left-1.5" />
         {/if}
         {#if connection.lifecycleMethods.includes('stop')}
@@ -168,7 +166,7 @@ function getLoggerHandler(
             clickAction="{() => stopConnectionProvider(provider, connection)}"
             action="stop"
             icon="{faStop}"
-            state="{state}"
+            state="{connectionStatus}"
             leftPosition="left-[0.22rem]" />
         {/if}
         {#if connection.lifecycleMethods.includes('delete')}
@@ -177,7 +175,7 @@ function getLoggerHandler(
               clickAction="{() => deleteConnectionProvider(provider, connection)}"
               action="delete"
               icon="{faTrash}"
-              state="{state}"
+              state="{connectionStatus}"
               leftPosition="left-1" />
           </div>
         {/if}

--- a/packages/renderer/src/lib/preferences/PreferencesContainerConnectionRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesContainerConnectionRendering.svelte
@@ -21,6 +21,7 @@ import PreferencesConnectionDetailsLogs from './PreferencesConnectionDetailsLogs
 import Tab from '../ui/Tab.svelte';
 import DetailsPage from '../ui/DetailsPage.svelte';
 import CustomIcon from '../images/CustomIcon.svelte';
+import ConnectionErrorInfoButton from '../ui/ConnectionErrorInfoButton.svelte';
 
 export let properties: IConfigurationPropertyRecordedSchema[] = [];
 export let providerInternalId: string | undefined = undefined;
@@ -136,6 +137,7 @@ function setNoLogs() {
       <svelte:fragment slot="subtitle">
         <div class="flex flex-row">
           <ConnectionStatus status="{connectionInfo.status}" />
+          <ConnectionErrorInfoButton status="{connectionStatus}" />
         </div>
       </svelte:fragment>
       <svelte:fragment slot="actions">

--- a/packages/renderer/src/lib/preferences/PreferencesContainerConnectionRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesContainerConnectionRendering.svelte
@@ -31,7 +31,7 @@ let detailsPage: DetailsPage;
 
 const connectionName = Buffer.from(name || '', 'base64').toString();
 const socketPath: string = Buffer.from(connection || '', 'base64').toString();
-$: connectionStatus = new Map<string, IConnectionStatus>();
+let connectionStatus: IConnectionStatus;
 let noLog = true;
 let connectionInfo: ProviderContainerConnectionInfo | undefined;
 let providerInfo: ProviderInfo | undefined;
@@ -59,24 +59,20 @@ onMount(async () => {
       return;
     }
     const containerConnectionName = getProviderConnectionName(providerInfo, connectionInfo);
-    if (
-      containerConnectionName &&
-      (!connectionStatus.has(containerConnectionName) ||
-        connectionStatus.get(containerConnectionName)?.status !== connectionInfo.status)
-    ) {
+    if (containerConnectionName && (!connectionStatus || connectionStatus.status !== connectionInfo.status)) {
       if (loggerHandlerKey !== undefined) {
-        connectionStatus.set(containerConnectionName, {
+        connectionStatus = {
           inProgress: true,
           action: 'restart',
           status: connectionInfo.status,
-        });
+        };
         startContainerProvider(providerInfo, connectionInfo, loggerHandlerKey);
       } else {
-        connectionStatus.set(containerConnectionName, {
+        connectionStatus = {
           inProgress: false,
           action: undefined,
           status: connectionInfo.status,
-        });
+        };
       }
     }
     connectionStatus = connectionStatus;
@@ -101,28 +97,26 @@ async function startContainerProvider(
     eventCollect,
   );
 }
-function updateConectionStatus(
+function updateConnectionStatus(
   provider: ProviderInfo,
   containerConnectionInfo: ProviderContainerConnectionInfo | ProviderKubernetesConnectionInfo,
   action?: string,
   error?: string,
 ): void {
-  const containerConnectionName = getProviderConnectionName(provider, containerConnectionInfo);
   if (error) {
-    const currentStatus = connectionStatus.get(containerConnectionName);
-    if (currentStatus) {
-      connectionStatus.set(containerConnectionName, {
-        ...currentStatus,
+    if (connectionStatus) {
+      connectionStatus = {
+        ...connectionStatus,
         inProgress: false,
         error,
-      });
+      };
     }
   } else if (action) {
-    connectionStatus.set(containerConnectionName, {
+    connectionStatus = {
       inProgress: true,
       action: action,
       status: containerConnectionInfo.status,
-    });
+    };
   }
   connectionStatus = connectionStatus;
 }
@@ -150,8 +144,8 @@ function setNoLogs() {
             <PreferencesConnectionActions
               provider="{providerInfo}"
               connection="{connectionInfo}"
-              connectionStatuses="{connectionStatus}"
-              updateConnectionStatus="{updateConectionStatus}"
+              connectionStatus="{connectionStatus}"
+              updateConnectionStatus="{updateConnectionStatus}"
               addConnectionToRestartingQueue="{addConnectionToRestartingQueue}" />
           </div>
         {/if}

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesConnectionRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesConnectionRendering.svelte
@@ -21,6 +21,7 @@ import PreferencesKubernetesConnectionDetailsSummary from './PreferencesKubernet
 import PreferencesConnectionDetailsLogs from './PreferencesConnectionDetailsLogs.svelte';
 import DetailsPage from '../ui/DetailsPage.svelte';
 import CustomIcon from '../images/CustomIcon.svelte';
+import ConnectionErrorInfoButton from '../ui/ConnectionErrorInfoButton.svelte';
 
 export let properties: IConfigurationPropertyRecordedSchema[] = [];
 export let providerInternalId: string | undefined = undefined;
@@ -132,6 +133,7 @@ function setNoLogs() {
       <svelte:fragment slot="subtitle">
         <div class="flex flex-row">
           <ConnectionStatus status="{connectionInfo.status}" />
+          <ConnectionErrorInfoButton status="{connectionStatus}" />
         </div>
       </svelte:fragment>
       <svelte:fragment slot="actions">

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
@@ -519,7 +519,7 @@ function hasAnyConfiguration(provider: ProviderInfo) {
               <PreferencesConnectionActions
                 provider="{provider}"
                 connection="{container}"
-                connectionStatuses="{containerConnectionStatus}"
+                connectionStatus="{containerConnectionStatus.get(getProviderConnectionName(provider, container))}"
                 updateConnectionStatus="{updateContainerStatus}"
                 addConnectionToRestartingQueue="{addConnectionToRestartingQueue}" />
               <div class="mt-1.5 text-gray-900 text-[9px]">
@@ -560,7 +560,7 @@ function hasAnyConfiguration(provider: ProviderInfo) {
               <PreferencesConnectionActions
                 provider="{provider}"
                 connection="{kubeConnection}"
-                connectionStatuses="{containerConnectionStatus}"
+                connectionStatus="{containerConnectionStatus.get(getProviderConnectionName(provider, kubeConnection))}"
                 updateConnectionStatus="{updateContainerStatus}"
                 addConnectionToRestartingQueue="{addConnectionToRestartingQueue}" />
             </div>

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
@@ -41,6 +41,7 @@ import { ContextKeyExpr } from '../context/contextKey';
 import { normalizeOnboardingWhenClause } from '../onboarding/onboarding-utils';
 import Donut from '/@/lib/donut/Donut.svelte';
 import { PeerProperties } from './PeerProperties';
+import ConnectionErrorInfoButton from '../ui/ConnectionErrorInfoButton.svelte';
 export let properties: IConfigurationPropertyRecordedSchema[] = [];
 let providers: ProviderInfo[] = [];
 $: containerConnectionStatus = new Map<string, IConnectionStatus>();
@@ -469,11 +470,7 @@ function hasAnyConfiguration(provider: ProviderInfo) {
                 <ConnectionStatus status="{container.status}" />
                 {#if containerConnectionStatus.has(getProviderConnectionName(provider, container))}
                   {@const status = containerConnectionStatus.get(getProviderConnectionName(provider, container))}
-                  {#if status?.error}
-                    <button
-                      class="ml-3 text-[9px] text-red-500 underline"
-                      on:click="{() => window.events?.send('toggle-task-manager', '')}">{status.action} failed</button>
-                  {/if}
+                  <ConnectionErrorInfoButton status="{status}" />
                 {/if}
               </div>
 

--- a/packages/renderer/src/lib/ui/ConnectionErrorInfoButton.spec.ts
+++ b/packages/renderer/src/lib/ui/ConnectionErrorInfoButton.spec.ts
@@ -1,0 +1,77 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import '@testing-library/jest-dom/vitest';
+import { test, expect } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import ConnectionErrorInfoButton from './ConnectionErrorInfoButton.svelte';
+
+test('Expect nothing if status is undefined', async () => {
+  render(ConnectionErrorInfoButton, {
+    status: undefined,
+  });
+
+  // check element does not exists
+  const button = screen.queryByRole('button', { name: 'action failed' });
+  expect(button).not.toBeInTheDocument();
+});
+
+test('Expect error button if status action and error are defined', async () => {
+  render(ConnectionErrorInfoButton, {
+    status: {
+      action: 'action',
+      error: 'error',
+      inProgress: false,
+      status: 'failed',
+    },
+  });
+
+  // check element does exist
+  const button = screen.getByRole('button', { name: 'action failed' });
+  expect(button).toBeInTheDocument();
+});
+
+test('Expect nothing if status action is not defined', async () => {
+  render(ConnectionErrorInfoButton, {
+    status: {
+      error: 'error',
+      inProgress: false,
+      status: 'failed',
+    },
+  });
+
+  // check element does not exists
+  const button = screen.queryByRole('button', { name: 'action failed' });
+  expect(button).not.toBeInTheDocument();
+});
+
+test('Expect nothing if status error is not defined', async () => {
+  render(ConnectionErrorInfoButton, {
+    status: {
+      action: 'action',
+      inProgress: false,
+      status: 'failed',
+    },
+  });
+
+  // check element does not exists
+  const button = screen.queryByRole('button', { name: 'action failed' });
+  expect(button).not.toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/ui/ConnectionErrorInfoButton.svelte
+++ b/packages/renderer/src/lib/ui/ConnectionErrorInfoButton.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+import type { IConnectionStatus } from '../preferences/Util';
+
+export let status: IConnectionStatus | undefined;
+</script>
+
+{#if status?.action && status?.error}
+  <button
+    aria-label="{status.action} failed"
+    class="ml-3 text-[9px] text-red-500 underline"
+    on:click="{() => window.events?.send('toggle-task-manager', '')}">{status.action} failed</button>
+{/if}


### PR DESCRIPTION
### What does this PR do?

This PR adds the error button that get shown if a container action fails

### Screenshot/screencast of this PR

![error_container-action](https://github.com/containers/podman-desktop/assets/49404737/8dd8c62b-7913-4ae4-827c-be044411dc54)

### What issues does this PR fix or reference?

it resolves #3796

### How to test this PR?

1. execute any action that you know it will fail from the details page of a container engine
2. you should see the error button
