### PR TITLE
nit: add more details for deploy to kubernetes ambiguous error

### DIFF
--- a/packages/renderer/src/lib/pod/DeployPodToKube.svelte
+++ b/packages/renderer/src/lib/pod/DeployPodToKube.svelte
@@ -220,7 +220,7 @@ async function deployToKube() {
     // All services are always created with one port (the first one), so we can use that port to create the ingress.
     // Must be a number
     if (servicesToCreate.length === 0) {
-      deployWarning = 'You need to deploy using services to create an ingress.';
+      deployWarning = `In order to create an Ingress a Pod must have a Service associated to a port mapping. Check that your container(s) has a port exposed correctly in order to generate a Service.`;
       deployStarted = false;
       return;
     } else if (servicesToCreate.length === 1) {


### PR DESCRIPTION
nit: add more details for deploy to kubernetes ambiguous error

### What does this PR do?

Updates the ambiguous error that is associated with deploying a
container with no port.

### Screenshot/screencast of this PR



### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes #4653

### How to test this PR?

<!-- Please explain steps to reproduce -->

1. `podman run --name hello -d cdrage/helloworld`
2. Try to Deploy to Kubernetes
3. See updated warning

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
