### PR TITLE
nit: remove padding from link

### DIFF
--- a/packages/renderer/src/lib/ui/Link.svelte
+++ b/packages/renderer/src/lib/ui/Link.svelte
@@ -35,7 +35,7 @@ function click() {
 <!-- svelte-ignore a11y-no-redundant-roles -->
 <!-- svelte-ignore a11y-interactive-supports-focus -->
 <a
-  class="text-purple-400 hover:bg-white hover:bg-opacity-10 transition-all rounded-[4px] p-0.5 no-underline {$$props.class ||
+  class="text-purple-400 hover:bg-white hover:bg-opacity-10 transition-all rounded-[4px] no-underline {$$props.class ||
     ''}"
   on:click="{() => click()}"
   role="link"


### PR DESCRIPTION
nit: remove padding from link

### What does this PR do?

There is a little bit of padding in the link which makes it difficult to
implement columns / tables with lining up the imported link to other
elements.

It also fixes the very subtle spacing in sentences where link is being
used.

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast
explaining what is doing this PR -->


https://github.com/containers/podman-desktop/assets/6422176/be2594aa-221e-4d9c-bfa8-8016cbd4b271



### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Found it while implementing: https://github.com/containers/podman-desktop/pull/4560

### How to test this PR?

<!-- Please explain steps to reproduce -->

Go to "Deploy To Kube" page and see the link (it should be more inline
with the text)

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
