### PR TITLE
feat: add environment column to pods / containers

### DIFF
--- a/packages/main/src/plugin/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes-client.ts
@@ -89,7 +89,7 @@ function toPodInfo(pod: V1Pod, contextName?: string): PodInfo {
     Networks: [],
     Status: pod.metadata?.deletionTimestamp ? 'DELETING' : pod.status?.phase || '',
     engineId: contextName ?? 'kubernetes',
-    engineName: 'k8s',
+    engineName: 'Kubernetes',
     kind: 'kubernetes',
   };
 }

--- a/packages/renderer/src/lib/compose/ComposeDetailsLogs.spec.ts
+++ b/packages/renderer/src/lib/compose/ComposeDetailsLogs.spec.ts
@@ -29,7 +29,7 @@ const containerInfoUIMock: ContainerInfoUI = {
   shortImage: 'foobar',
   engineId: 'foobar',
   engineName: 'foobar',
-  engineType: 'podman',
+  engineType: ContainerGroupInfoTypeUI.PODMAN,
   state: 'running',
   uptime: 'foobar',
   startedAt: 'foobar',
@@ -49,7 +49,7 @@ const containerInfoUIMock: ContainerInfoUI = {
 
 const composeInfoUIMock: ComposeInfoUI = {
   engineId: 'foobar',
-  engineType: 'podman',
+  engineType: ContainerGroupInfoTypeUI.PODMAN,
   name: 'foobar',
   status: 'running',
   containers: [containerInfoUIMock],

--- a/packages/renderer/src/lib/container/ContainerInfoUI.ts
+++ b/packages/renderer/src/lib/container/ContainerInfoUI.ts
@@ -23,6 +23,8 @@ export enum ContainerGroupInfoTypeUI {
   STANDALONE = 'standalone',
   COMPOSE = 'compose',
   POD = 'pod',
+  DOCKER = 'docker',
+  PODMAN = 'podman',
 }
 
 export interface ContainerGroupPartInfoUI {

--- a/packages/renderer/src/lib/container/ContainerList.svelte
+++ b/packages/renderer/src/lib/container/ContainerList.svelte
@@ -583,7 +583,7 @@ function errorCallback(container: ContainerInfoUI, errorMessage: string): void {
                 </td>
                 <td class="pl-3 whitespace-nowrap hover:cursor-pointer group">
                   <div class="flex items-center text-xs p-1 rounded-md text-gray-500">
-                    <ProviderInfo provider="{container.engineName}" context="{container.engineId}" />
+                    <ProviderInfo provider="{container.engineType}" context="{container.engineId}" />
                   </div>
                 </td>
                 <!-- Open the container details, TODO: open image details instead? -->

--- a/packages/renderer/src/lib/container/ContainerList.svelte
+++ b/packages/renderer/src/lib/container/ContainerList.svelte
@@ -3,7 +3,6 @@ import { onDestroy, onMount } from 'svelte';
 import { filtered, searchPattern, containersInfos } from '../../stores/containers';
 import { viewsContributions } from '../../stores/views';
 import { context } from '../../stores/context';
-
 import type { ContainerInfo } from '../../../../main/src/plugin/api/container-info';
 import PodIcon from '../images/PodIcon.svelte';
 import StatusIcon from '../images/StatusIcon.svelte';
@@ -40,6 +39,7 @@ import type { ContextUI } from '../context/context';
 import Button from '../ui/Button.svelte';
 import StateChange from '../ui/StateChange.svelte';
 import SolidPodIcon from '../images/SolidPodIcon.svelte';
+import ProviderInfo from '../ui/ProviderInfo.svelte';
 
 const containerUtils = new ContainerUtils();
 let openChoiceModal = false;
@@ -57,8 +57,6 @@ function fromExistingImage(): void {
   openChoiceModal = false;
   window.location.href = '#/images';
 }
-
-let multipleEngines = false;
 
 $: providerConnections = $providerInfos
   .map(provider => provider.containerConnections)
@@ -269,12 +267,6 @@ function updateContainers(containers: ContainerInfo[], globalContext: ContextUI,
   // Remove duplicates from engines by name
   const uniqueEngines = engines.filter((engine, index, self) => index === self.findIndex(t => t.name === engine.name));
 
-  if (uniqueEngines.length > 1) {
-    multipleEngines = true;
-  } else {
-    multipleEngines = false;
-  }
-
   // Set the engines to the global variable for the Prune functionality button
   enginesList = uniqueEngines;
 
@@ -454,10 +446,11 @@ function errorCallback(container: ContainerInfoUI, errorMessage: string): void {
               on:click="{event => toggleAllContainerGroups(event.detail)}" />
           </th>
           <th class="text-center font-extrabold w-10 px-2">Status</th>
-          <th class="w-10">Name</th>
-          <th>Image</th>
-          <th class="pl-4">Age</th>
-          <th class="text-right pr-2">actions</th>
+          <th>Name</th>
+          <th class="pl-3">Environment</th>
+          <th class="pl-3">Image</th>
+          <th class="pl-3">Age</th>
+          <th class="text-right pr-2">Actions</th>
         </tr>
       </thead>
 
@@ -488,7 +481,7 @@ function errorCallback(container: ContainerInfoUI, errorMessage: string): void {
               </td>
               <td class="whitespace-nowrap hover:cursor-pointer">
                 <div class="flex items-center text-sm text-gray-300 overflow-hidden text-ellipsis">
-                  <div class="flex flex-col flex-nowrap">
+                  <div>
                     <button
                       class="text-sm text-gray-300 overflow-hidden text-ellipsis"
                       title="{containerGroup.type}"
@@ -501,11 +494,10 @@ function errorCallback(container: ContainerInfoUI, errorMessage: string): void {
                   </div>
                 </div>
               </td>
-              <td class="px-6 py-2 whitespace-nowrap w-10">
-                <div class="flex items-center">
-                  <div class="ml-2 text-sm text-gray-700"></div>
-                </div>
+              <td class="pl-3 whitespace-nowrap hover:cursor-pointer group">
+                <div class="flex items-center text-xs p-1 rounded-md text-gray-500"></div>
               </td>
+              <td class="px-6 py-2 whitespace-nowrap w-10"> </td>
               <td class="whitespace-nowrap pl-4">
                 <div class="flex items-center">
                   <div class="text-sm text-gray-700"></div>
@@ -582,23 +574,21 @@ function errorCallback(container: ContainerInfoUI, errorMessage: string): void {
                           {container.name}
                         </div>
                       </div>
-                      <div class="flex flex-row text-xs font-extra-light text-gray-900">
+                      <div class="flex flex-nowrap text-xs font-extra-light text-gray-900 items-center">
                         <div>{container.state}</div>
-                        <!-- Hide in case of single engines-->
-                        {#if multipleEngines}
-                          <div
-                            class="mx-2 px-2 inline-flex text-xs font-extralight rounded-sm bg-zinc-700 text-slate-400">
-                            {container.engineName}
-                          </div>
-                        {/if}
-                        <div class="pl-2 pr-2">{container.displayPort}</div>
+                        <div class="pl-2 pr-2 inline-flex">{container.displayPort}</div>
                       </div>
                     </div>
                   </div>
                 </td>
+                <td class="pl-3 whitespace-nowrap hover:cursor-pointer group">
+                  <div class="flex items-center text-xs p-1 rounded-md text-gray-500">
+                    <ProviderInfo provider="{container.engineName}" context="{container.engineId}" />
+                  </div>
+                </td>
                 <!-- Open the container details, TODO: open image details instead? -->
                 <td
-                  class="whitespace-nowrap hover:cursor-pointer group"
+                  class="pl-3 whitespace-nowrap hover:cursor-pointer group"
                   on:click="{() => openDetailsContainer(container)}">
                   <div class="flex items-center">
                     <div class="text-sm text-gray-700 overflow-hidden text-ellipsis" title="{container.image}">

--- a/packages/renderer/src/lib/pod/PodInfoUI.ts
+++ b/packages/renderer/src/lib/pod/PodInfoUI.ts
@@ -16,6 +16,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+export enum PodGroupInfoTypeUI {
+  KUBERNETES = 'kubernetes',
+  PODMAN = 'podman',
+}
 export interface PodInfoContainerUI {
   Id: string;
   Names: string;

--- a/packages/renderer/src/lib/pod/PodsList.spec.ts
+++ b/packages/renderer/src/lib/pod/PodsList.spec.ts
@@ -241,7 +241,7 @@ test('Expect single kubernetes pod being displayed', async () => {
 
   render(PodsList);
   const pod1Details = screen.getByRole('row', {
-    name: 'Toggle pod kubepod1 beab2512 0 container Kubernetes tooltip 0 seconds spinner',
+    name: 'Toggle pod kubepod1 beab2512 0 container kubernetes 0 seconds spinner',
   });
   expect(pod1Details).toBeInTheDocument();
 });
@@ -263,11 +263,11 @@ test('Expect 2 kubernetes pods being displayed', async () => {
 
   render(PodsList);
   const pod1Details = screen.getByRole('row', {
-    name: 'Toggle pod kubepod1 beab2512 0 container Kubernetes tooltip 0 seconds spinner',
+    name: 'Toggle pod kubepod1 beab2512 0 container kubernetes 0 seconds spinner',
   });
   expect(pod1Details).toBeInTheDocument();
   const pod2Details = screen.getByRole('row', {
-    name: 'Toggle pod kubepod2 e8129c57 0 container Kubernetes tooltip 0 seconds spinner',
+    name: 'Toggle pod kubepod2 e8129c57 0 container kubernetes 0 seconds spinner',
   });
   expect(pod2Details).toBeInTheDocument();
 });
@@ -315,7 +315,7 @@ test('Expect the route to a pod details page is correctly encoded with an engine
   expect(podDetails).toBeInTheDocument();
 
   const podRow = screen.getByRole('row', {
-    name: 'Toggle pod ocppod e8129c57 0 container Kubernetes tooltip 0 seconds spinner',
+    name: 'Toggle pod ocppod e8129c57 0 container kubernetes 0 seconds spinner',
   });
   expect(podRow).toBeInTheDocument();
 

--- a/packages/renderer/src/lib/pod/PodsList.spec.ts
+++ b/packages/renderer/src/lib/pod/PodsList.spec.ts
@@ -104,7 +104,7 @@ const kubepod1: PodInfo = {
   Networks: [],
   Status: 'running',
   engineId: 'context1',
-  engineName: 'k8s',
+  engineName: 'Kubernetes',
   kind: 'kubernetes',
 };
 
@@ -120,7 +120,7 @@ const kubepod2: PodInfo = {
   Networks: [],
   Status: 'running',
   engineId: 'context2',
-  engineName: 'k8s',
+  engineName: 'Kubernetes',
   kind: 'kubernetes',
 };
 
@@ -136,7 +136,7 @@ const ocppod: PodInfo = {
   Networks: [],
   Status: 'running',
   engineId: 'userid-dev/api-sandbox-123-openshiftapps-com:6443/userId',
-  engineName: 'k8s',
+  engineName: 'Kubernetes',
   kind: 'kubernetes',
 };
 
@@ -185,8 +185,12 @@ test('Expect single podman pod being displayed', async () => {
   }
 
   render(PodsList);
-  const pod1Details = screen.getByRole('cell', { name: 'pod1 beab2512 0 container podman' });
+  const pod1Details = screen.getByRole('cell', { name: 'pod1 beab2512 0 container' });
   expect(pod1Details).toBeInTheDocument();
+  const pod1Row = screen.getByRole('row', {
+    name: 'Toggle pod pod1 beab2512 0 container podman 0 seconds spinner spinner spinner',
+  });
+  expect(pod1Row).toBeInTheDocument();
 });
 
 test('Expect 2 podman pods being displayed', async () => {
@@ -205,10 +209,19 @@ test('Expect 2 podman pods being displayed', async () => {
   }
 
   render(PodsList);
-  const pod1Details = screen.getByRole('cell', { name: 'pod1 beab2512 0 container podman' });
+  const pod1Details = screen.getByRole('cell', { name: 'pod1 beab2512 0 container' });
   expect(pod1Details).toBeInTheDocument();
-  const pod2Details = screen.getByRole('cell', { name: 'pod2 e8129c57 0 container podman' });
+  const pod1Row = screen.getByRole('row', {
+    name: 'Toggle pod pod1 beab2512 0 container podman 0 seconds spinner spinner spinner',
+  });
+  expect(pod1Row).toBeInTheDocument();
+
+  const pod2Details = screen.getByRole('cell', { name: 'pod2 e8129c57 0 container' });
   expect(pod2Details).toBeInTheDocument();
+  const pod2Row = screen.getByRole('row', {
+    name: 'Toggle pod pod2 e8129c57 0 container podman 0 seconds spinner spinner spinner',
+  });
+  expect(pod2Row).toBeInTheDocument();
 });
 
 test('Expect single kubernetes pod being displayed', async () => {
@@ -227,7 +240,9 @@ test('Expect single kubernetes pod being displayed', async () => {
   }
 
   render(PodsList);
-  const pod1Details = screen.getByRole('cell', { name: 'kubepod1 beab2512 0 container k8s context1 tooltip' });
+  const pod1Details = screen.getByRole('row', {
+    name: 'Toggle pod kubepod1 beab2512 0 container Kubernetes tooltip 0 seconds spinner',
+  });
   expect(pod1Details).toBeInTheDocument();
 });
 
@@ -247,9 +262,13 @@ test('Expect 2 kubernetes pods being displayed', async () => {
   }
 
   render(PodsList);
-  const pod1Details = screen.getByRole('cell', { name: 'kubepod1 beab2512 0 container k8s context1 tooltip' });
+  const pod1Details = screen.getByRole('row', {
+    name: 'Toggle pod kubepod1 beab2512 0 container Kubernetes tooltip 0 seconds spinner',
+  });
   expect(pod1Details).toBeInTheDocument();
-  const pod2Details = screen.getByRole('cell', { name: 'kubepod2 e8129c57 0 container k8s context2 tooltip' });
+  const pod2Details = screen.getByRole('row', {
+    name: 'Toggle pod kubepod2 e8129c57 0 container Kubernetes tooltip 0 seconds spinner',
+  });
   expect(pod2Details).toBeInTheDocument();
 });
 
@@ -292,8 +311,13 @@ test('Expect the route to a pod details page is correctly encoded with an engine
     await new Promise(resolve => setTimeout(resolve, 500));
   }
   render(PodsList);
-  const podDetails = screen.getByRole('cell', { name: 'ocppod e8129c57 0 container k8s userid-dev/api-s tooltip' });
+  const podDetails = screen.getByRole('cell', { name: 'ocppod e8129c57 0 container' });
   expect(podDetails).toBeInTheDocument();
+
+  const podRow = screen.getByRole('row', {
+    name: 'Toggle pod ocppod e8129c57 0 container Kubernetes tooltip 0 seconds spinner',
+  });
+  expect(podRow).toBeInTheDocument();
 
   const routerGotoMock = vi.fn();
   router.goto = routerGotoMock;

--- a/packages/renderer/src/lib/pod/PodsList.svelte
+++ b/packages/renderer/src/lib/pod/PodsList.svelte
@@ -17,7 +17,6 @@ import PodIcon from '../images/PodIcon.svelte';
 import PodActions from './PodActions.svelte';
 import KubePlayButton from '../kube/KubePlayButton.svelte';
 import moment from 'moment';
-import Tooltip from '../ui/Tooltip.svelte';
 import Prune from '../engine/Prune.svelte';
 import type { EngineInfoUI } from '../engine/EngineInfoUI';
 import ErrorMessage from '../ui/ErrorMessage.svelte';
@@ -25,6 +24,7 @@ import Checkbox from '../ui/Checkbox.svelte';
 import Button from '../ui/Button.svelte';
 import { faTrash } from '@fortawesome/free-solid-svg-icons';
 import StateChange from '../ui/StateChange.svelte';
+import ProviderInfo from '../ui/ProviderInfo.svelte';
 
 export let searchTerm = '';
 $: searchPattern.set(searchTerm);
@@ -234,7 +234,8 @@ function errorCallback(pod: PodInfoUI, errorMessage: string): void {
           </th>
           <th class="text-center font-extrabold w-10 px-2">Status</th>
           <th>Name</th>
-          <th class="whitespace-nowrap px-6">age</th>
+          <th class="pl-3">Environment</th>
+          <th class="whitespace-nowrap px-6">Age</th>
           <th class="text-right pr-2">Actions</th>
         </tr>
       </thead>
@@ -265,16 +266,15 @@ function errorCallback(pod: PodInfoUI, errorMessage: string): void {
                       {pod.containers.length} container{pod.containers.length > 1 ? 's' : ''}
                     </button>
                   </div>
-                  <div class="flex flex-row text-xs font-extra-light text-gray-900">
-                    <div class="px-2 inline-flex text-xs font-extralight rounded-full bg-slate-800 text-slate-400">
-                      {pod.engineName}{#if pod.kind === 'kubernetes'}<div class="ml-1">
-                          <Tooltip tip="{pod.engineId}" top>{pod.engineId.substring(0, 16)}</Tooltip>
-                        </div>{/if}
-                    </div>
-                  </div>
                 </div>
               </div>
             </td>
+            <td class="pl-3 whitespace-nowrap hover:cursor-pointer group">
+              <div class="flex items-center text-xs p-1 rounded-md text-gray-500">
+                <ProviderInfo provider="{pod.engineName}" context="{pod.engineId}" />
+              </div>
+            </td>
+
             <td class="px-6 py-2 whitespace-nowrap w-10">
               <div class="flex items-center">
                 <div class="text-sm text-gray-700">

--- a/packages/renderer/src/lib/pod/PodsList.svelte
+++ b/packages/renderer/src/lib/pod/PodsList.svelte
@@ -271,7 +271,7 @@ function errorCallback(pod: PodInfoUI, errorMessage: string): void {
             </td>
             <td class="pl-3 whitespace-nowrap hover:cursor-pointer group">
               <div class="flex items-center text-xs p-1 rounded-md text-gray-500">
-                <ProviderInfo provider="{pod.engineName}" context="{pod.engineId}" />
+                <ProviderInfo provider="{pod.kind}" context="{pod.engineId}" />
               </div>
             </td>
 

--- a/packages/renderer/src/lib/ui/ProviderInfo.svelte
+++ b/packages/renderer/src/lib/ui/ProviderInfo.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+import Tooltip from './Tooltip.svelte';
+
+// Name of the provider (e.g. podman, docker, kubernetes)
+export let provider = '';
+
+// Only used for Kubernetes-like distros
+export let context = '';
+
+// Each provider has a colour associated to it within tailwind, this is a map of those colours.
+// bg-purple-600 = podman
+// bg-sky-300 = docker
+// bg-sky-600 = kubernetes
+// bg-gray-900 = unknown
+function getProviderColour(providerName: string): string {
+  switch (providerName) {
+    case 'Podman':
+      return 'bg-purple-600';
+    case 'Docker':
+      return 'bg-sky-400';
+    case 'Kubernetes':
+      return 'bg-sky-600';
+    default:
+      return 'bg-gray-900';
+  }
+}
+</script>
+
+<div class="flex items-center bg-charcoal-500 p-1 rounded-md">
+  <div class="w-2 h-2 {getProviderColour(provider)} rounded-full mr-1"></div>
+  <span class="text-xs capitalize">
+    <!-- If Kubernetes, show the context via the tooltip / hover, else just provider the name.-->
+    {#if provider === 'Kubernetes'}
+      <Tooltip tip="{context}" top>{provider}</Tooltip>
+    {:else}
+      {provider}
+    {/if}
+  </span>
+</div>

--- a/packages/renderer/src/lib/ui/ProviderInfo.svelte
+++ b/packages/renderer/src/lib/ui/ProviderInfo.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
 import Tooltip from './Tooltip.svelte';
+import { ContainerGroupInfoTypeUI } from '../container/ContainerInfoUI';
+import { PodGroupInfoTypeUI } from '../pod/PodInfoUI';
 
 // Name of the provider (e.g. podman, docker, kubernetes)
 export let provider = '';
@@ -14,11 +16,11 @@ export let context = '';
 // bg-gray-900 = unknown
 function getProviderColour(providerName: string): string {
   switch (providerName) {
-    case 'Podman':
+    case ContainerGroupInfoTypeUI.PODMAN:
       return 'bg-purple-600';
-    case 'Docker':
+    case ContainerGroupInfoTypeUI.DOCKER:
       return 'bg-sky-400';
-    case 'Kubernetes':
+    case PodGroupInfoTypeUI.KUBERNETES:
       return 'bg-sky-600';
     default:
       return 'bg-gray-900';


### PR DESCRIPTION
feat: add environment column to pods / containers

### What does this PR do?

* Adds environment column for pods / containers
* Changes the engine from k8s to Kubernetes to match Podman and Docker
  engine type names
* Reworks the columns a bit
* Moves (Pod) and (Compose) to Environment when displaying a group

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast
explaining what is doing this PR -->

![Screenshot 2023-10-31 at 10 38 06 PM](https://github.com/containers/podman-desktop/assets/6422176/6c8de4a7-4521-4ec5-b44e-213257f7b743)
![Screenshot 2023-10-31 at 10 38 11 PM](https://github.com/containers/podman-desktop/assets/6422176/dcd5bb46-46f0-4eb1-9a5e-e6803605448b)



### What issues does this PR fix or reference?

Closes https://github.com/containers/podman-desktop/issues/4401
Closes https://github.com/containers/podman-desktop/issues/4579

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

View Pods / Containers section with multiple engines

<!-- Please explain steps to reproduce -->

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
