### PR TITLE
fix: shorter doc nav section titles

### DIFF
--- a/website/docs/compose/index.md
+++ b/website/docs/compose/index.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 35
-title: Working with Compose
+title: Compose
 description: With Podman Desktop, you can install a Compose engine and manage multi-container applications defined in Compose files.
 keywords: [compose]
 tags: [compose]

--- a/website/docs/containers/index.md
+++ b/website/docs/containers/index.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 30
-title: Working with containers
+title: Containers
 description: Working with container workloads
 tags: [podman-desktop, containers]
 keywords: [podman desktop, podman, containers]

--- a/website/docs/installation/index.md
+++ b/website/docs/installation/index.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 2
-title: Installing Podman Desktop
+title: Installation
 description: You can install Podman Desktop on Windows, macOS, and Linux.
 tags: [podman-desktop, installing]
 keywords: [podman desktop, containers, podman, installing, installation]

--- a/website/docs/kubernetes/index.md
+++ b/website/docs/kubernetes/index.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 60
-title: Working with Kubernetes
+title: Kubernetes
 description: Migrate transparently from Podman to Kubernetes, and continue using familiar workflows.
 keywords: [podman desktop, podman, containers, migrating, kubernetes]
 tags: [migrating-to-kubernetes]

--- a/website/docs/proxy/index.md
+++ b/website/docs/proxy/index.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 2
-title: In a restricted environment
+title: Restricted environments
 description: Using Podman Desktop behind a proxy requiring custom Certificate Authorities (CA).
 tags: [podman-desktop, installing, windows, macos, linux]
 keywords: [podman desktop, containers, podman, installing, installation, windows, macos, linux]


### PR DESCRIPTION
### What does this PR do?

A few of the section titles in the doc nav are long, which makes it harder to scan for a topic. Worse, some of these wrap to two lines making the layout not flow very well.

### Screenshot/screencast of this PR

Before:

<img width="285" alt="Screenshot 2023-11-02 at 8 52 18 AM" src="https://github.com/containers/podman-desktop/assets/19958075/40ff3643-6137-4bb9-8094-dea0b649f9c8">

After:

<img width="285" alt="Screenshot 2023-11-02 at 8 56 01 AM" src="https://github.com/containers/podman-desktop/assets/19958075/6357f2cc-21b0-4689-a8ae-2cddeeb335e3">

### What issues does this PR fix or reference?

N/A

### How to test this PR?

`yarn website:dev`