### PR TITLE
fix: reduce size of provider cards on the dashboard

### DIFF
--- a/packages/renderer/src/lib/dashboard/ProviderConfigured.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderConfigured.svelte
@@ -89,12 +89,12 @@ onMount(() => {
       <ErrorMessage class="flex flex-col mt-2 my-2 text-sm" error="{runError}" />
     {/if}
   </div>
-  {#if provider.version !== provider.updateInfo?.version}
-    <div class="mt-10 mb-1 w-full flex justify-around">
+  {#if provider.updateInfo?.version && provider.version !== provider.updateInfo?.version}
+    <div class="mt-5 mb-1 w-full flex justify-around">
       <ProviderUpdateButton onPreflightChecks="{checks => (preflightChecks = checks)}" provider="{provider}" />
     </div>
   {/if}
   <PreflightChecks preflightChecks="{preflightChecks}" />
-  <div class="mt-10 mb-1 w-full flex justify-around"></div>
+  <div class="mt-5 mb-1 w-full flex justify-around"></div>
   <ProviderLinks provider="{provider}" />
 </div>

--- a/packages/renderer/src/lib/dashboard/ProviderConfiguring.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderConfiguring.svelte
@@ -121,12 +121,12 @@ onDestroy(() => {
   </div>
 
   {#if provider.updateInfo}
-    <div class="mt-10 mb-1 w-full flex justify-around">
+    <div class="mt-5 mb-1 w-full flex justify-around">
       <ProviderUpdateButton onPreflightChecks="{checks => (preflightChecks = checks)}" provider="{provider}" />
     </div>
   {/if}
   <PreflightChecks preflightChecks="{preflightChecks}" />
 
-  <div class="mt-10 mb-1 w-full flex justify-around"></div>
+  <div class="mt-5 mb-1 w-full flex justify-around"></div>
   <ProviderLinks provider="{provider}" />
 </div>

--- a/packages/renderer/src/lib/dashboard/ProviderInstalled.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderInstalled.svelte
@@ -148,7 +148,7 @@ function onInstallationClick() {
       To start working with containers, {provider.name} needs to be initialized.
     </p>
 
-    <div class="m-5" class:hidden="{!initializationButtonVisible}">
+    <div class="mt-5" class:hidden="{!initializationButtonVisible}">
       <div class="bg-gray-300 text-white">
         <button
           class="float-left bg-purple-600 hover:bg-purple-500 pt-2 pr-3 pl-3 pb-2 text-[13px] text-white mr-px w-[180px]"
@@ -218,13 +218,12 @@ function onInstallationClick() {
     </div>
   </div>
 
-  {#if provider.version !== provider.updateInfo?.version}
-    <div class="mt-10 mb-1 w-full flex justify-around">
+  {#if provider.updateInfo?.version && provider.version !== provider.updateInfo?.version}
+    <div class="mt-5 mb-1 w-full flex justify-around">
       <ProviderUpdateButton onPreflightChecks="{checks => (preflightChecks = checks)}" provider="{provider}" />
     </div>
   {/if}
   <PreflightChecks preflightChecks="{preflightChecks}" />
 
-  <div class="mt-10 mb-1 w-full flex justify-around"></div>
   <ProviderLinks provider="{provider}" />
 </div>

--- a/packages/renderer/src/lib/dashboard/ProviderLinks.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderLinks.svelte
@@ -6,7 +6,7 @@ export let provider: ProviderInfo;
 </script>
 
 {#if provider.links.length > 0}
-  <div class="mt-10 flex flex-row justify-around">
+  <div class="mt-5 flex flex-row justify-around">
     {#each provider.links as link}
       {#if link.group === undefined}
         <Link class="text-sm" externalRef="{link.url}">

--- a/packages/renderer/src/lib/dashboard/ProviderLogo.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderLogo.svelte
@@ -18,7 +18,6 @@ $: {
 
 {#if logo}
   <div class="flex">
-    <!--w-3/4 lg:w-2/3 xl:w-1/2 -->
-    <img src="{logo}" alt="{provider.name}" class="mx-auto max-h-24 xl:max-h-36" />
+    <img src="{logo}" alt="{provider.name}" class="mx-auto max-h-12" />
   </div>
 {/if}

--- a/packages/renderer/src/lib/dashboard/ProviderNotInstalled.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderNotInstalled.svelte
@@ -24,7 +24,7 @@ let preflightChecks: CheckStatus[] = [];
       To start working with containers, {provider.name} needs to be detected/installed.
     </p>
   </div>
-  <div class="mt-10 mb-1 w-full flex justify-around">
+  <div class="mt-5 mb-1 w-full flex justify-around">
     <ProviderDetectionChecksButton onDetectionChecks="{checks => (detectionChecks = checks)}" provider="{provider}" />
     <ProviderInstallationButton onPreflightChecks="{checks => (preflightChecks = checks)}" provider="{provider}" />
   </div>

--- a/packages/renderer/src/lib/dashboard/ProviderReady.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderReady.svelte
@@ -30,8 +30,8 @@ let preflightChecks: CheckStatus[] = [];
       </div>
     {/if}
   </div>
-  {#if provider.version !== provider.updateInfo?.version}
-    <div class="mt-10 mb-1 w-full flex justify-around">
+  {#if provider.updateInfo?.version && provider.version !== provider.updateInfo?.version}
+    <div class="mt-5 mb-1 w-full flex justify-around">
       <ProviderUpdateButton onPreflightChecks="{checks => (preflightChecks = checks)}" provider="{provider}" />
     </div>
   {/if}

--- a/packages/renderer/src/lib/dashboard/ProviderWarnings.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderWarnings.svelte
@@ -11,9 +11,9 @@ $: {
 }
 </script>
 
-<div class="flex flex-col items-center text-center mt-3">
-  <!-- TODO: Add dismiss button / ignore warning? -->
-  {#if providerInfo && providerInfo.warnings?.length > 0}
+<!-- TODO: Add dismiss button / ignore warning? -->
+{#if providerInfo && providerInfo.warnings?.length > 0}
+  <div class="flex flex-col items-center text-center mt-3">
     {#each providerInfo.warnings as warn}
       <div class="flex-row items-center align-middle mt-0.5">
         <!-- Make line height center-->
@@ -22,5 +22,5 @@ $: {
         <span class="ml-1 text-sm text-gray-700">{warn.details}</span>
       </div>
     {/each}
-  {/if}
-</div>
+  </div>
+{/if}


### PR DESCRIPTION
### What does this PR do?

The current provider cards on the dashboard are massive, and it restricts us from adding other things to the dashboard, e.g. notifications or tutorials. There is a longer term redesign of these cards in the works, but in the meantime we can easily start by reducing their size.

Made the following changes:
- Reduce logo size from max-h-24 to max-h-12.
- mt-10 is excessive, reduce all to margins to mt-5.
- provider.updateInfo?.version can be undefined when there is no update available, so adding a check removes the section.
- ProviderWarnings section was always there. Change it to be like the other sections and only appear when there is content.
- Remove extraneous <div> in ProviderInstalled.

### Screenshot/screencast of this PR

Before:

<img width="781" alt="Screenshot 2023-11-02 at 12 26 24 PM" src="https://github.com/containers/podman-desktop/assets/19958075/7d29e6f6-b696-435f-ac2a-8db67fe07855">

After:

<img width="781" alt="Screenshot 2023-11-02 at 12 21 59 PM" src="https://github.com/containers/podman-desktop/assets/19958075/17b6070a-a6d9-40ab-8208-89c73a00783b">

### What issues does this PR fix or reference?

Fixes part of #4395.

### How to test this PR?

Install several providers, go to the dashboard and look for visual anomalies.