### PR TITLE
fix: find a free port

### DIFF
--- a/packages/main/src/plugin/util/port.spec.ts
+++ b/packages/main/src/plugin/util/port.spec.ts
@@ -120,3 +120,15 @@ test('return first empty port, port and next one are used so it returns the seco
   expect(freePort).toBe(port20002);
   expect(await port.isFreePort(freePort)).toBe(true);
 });
+
+test('fails with range error if trying to get a port which is over upper range', async () => {
+  await expect(port.getFreePort(200000)).rejects.toThrowError(/options.port should be >= 0 and < 65536/);
+});
+
+test('fails with range error if value is over upper range', async () => {
+  await expect(port.isFreePort(200000)).rejects.toThrowError(/options.port should be >= 0 and < 65536/);
+});
+
+test('fails with range error if value is less lower range', async () => {
+  await expect(port.isFreePort(-1)).rejects.toThrowError(/options.port should be >= 0 and < 65536/);
+});

--- a/packages/main/src/plugin/util/port.spec.ts
+++ b/packages/main/src/plugin/util/port.spec.ts
@@ -20,6 +20,8 @@ import { expect, test } from 'vitest';
 import * as port from './port.js';
 import * as net from 'net';
 
+const host = '127.0.0.1';
+
 test('return valid port range', async () => {
   const range = await port.getFreePortRange(3);
 
@@ -52,7 +54,7 @@ test('check that the range returns new free ports if the one in previous call ar
   expect(endRange + 1 - startRange).toBe(3);
 
   const server = net.createServer();
-  server.listen(endRange);
+  server.listen(endRange, host);
 
   const newRange = await port.getFreePortRange(3);
 
@@ -71,4 +73,50 @@ test('check that the range returns new free ports if the one in previous call ar
   expect(endNewRange + 1 - startNewRange).toBe(3);
   expect(await port.isFreePort(startNewRange)).toBe(true);
   expect(await port.isFreePort(endNewRange)).toBe(true);
+});
+
+test('return first empty port, no port is used', async () => {
+  const freePort = await port.getFreePort(20000);
+
+  expect(freePort).toBe(20000);
+  expect(await port.isFreePort(freePort)).toBe(true);
+});
+
+test('return first empty port, port is used so it returns the next one', async () => {
+  const port20000 = 20000;
+  const port20001 = 20001;
+
+  // create a server to make port 20000 busy
+  const server = net.createServer();
+  server.listen(port20000, host);
+
+  // as 20000 is busy it should increment it and return 20001
+  const freePort = await port.getFreePort(port20000);
+
+  server.close();
+
+  expect(freePort).toBe(port20001);
+  expect(await port.isFreePort(freePort)).toBe(true);
+});
+
+test('return first empty port, port and next one are used so it returns the second from the starting one', async () => {
+  const port20000 = 20000;
+  const port20001 = 20001;
+  const port20002 = 20002;
+
+  // create a server to make port 20000 busy
+  const server = net.createServer();
+  server.listen(port20000, host);
+
+  const server2 = net.createServer();
+  server2.listen(port20001, host);
+
+  // as 20000 is busy it should increment it and return 20001
+  const freePort = await port.getFreePort(port20000);
+
+  server.close();
+  server2.close();
+
+  expect(freePort).toBe(port20002);
+  expect(await port.isFreePort(freePort)).toBe(true);
 });

--- a/packages/main/src/plugin/util/port.ts
+++ b/packages/main/src/plugin/util/port.ts
@@ -21,19 +21,19 @@ import * as net from 'net';
 /**
  * Find a free port starting from the given port
  */
-export function getFreePort(port = 0): Promise<number> {
+export async function getFreePort(port = 0): Promise<number> {
   if (port < 1024) {
     port = 9000;
   }
-  const server = net.createServer();
-  return new Promise((resolve, reject) =>
-    server
-      .on('error', (error: NodeJS.ErrnoException) =>
-        error.code === 'EADDRINUSE' ? server.listen(++port) : reject(error),
-      )
-      .on('listening', () => server.close(() => resolve(port)))
-      .listen(port),
-  );
+  let isFree = false;
+  while (!isFree) {
+    isFree = await isFreePort(port);
+    if (!isFree) {
+      port++;
+    }
+  }
+
+  return port;
 }
 
 /**
@@ -61,6 +61,6 @@ export function isFreePort(port: number): Promise<boolean> {
     server
       .on('error', (error: NodeJS.ErrnoException) => (error.code === 'EADDRINUSE' ? resolve(false) : reject(error)))
       .on('listening', () => server.close(() => resolve(true)))
-      .listen(port),
+      .listen(port, '127.0.0.1'),
   );
 }


### PR DESCRIPTION
### What does this PR do?

I found out that, atleast on my machine, the `getFreePort` function was not actually returning a free port, so when trying to create/start a container the form was always pre-filled with port 9000 even if it was busy.

I saw that we didn't add any hostname to specify to the "fake" net.server where to listen to and that was my problem. By adding the localhost ip, it worked as expected.

Now the question is, there was any reason why we never added a hostname? I was expecting that localhost was the default but that is not true apparently. 
Without specifying the hostname it tried to connect to
`6::::9000`
by adding the localhost
`4:127.0.0.1:9001`

### Screenshot/screencast of this PR

![get_free_port](https://github.com/containers/podman-desktop/assets/49404737/c46ae0ef-05c7-4625-acd8-df0a14f9635a)

### What issues does this PR fix or reference?

This PR is part of #3907

### How to test this PR?

1. create and start a container
2. repeat to see if the port number has been updated
