### PR TITLE
docs: lima provider cleanup after the merge

### DIFF
--- a/website/docs/lima/creating-a-kubernetes-instance.md
+++ b/website/docs/lima/creating-a-kubernetes-instance.md
@@ -1,5 +1,6 @@
 ---
-title: Lima
+sidebar_position: 3
+title: Lima instance for Kubernetes
 description: Podman Desktop can assist you to create a custom Lima instance on Linux and macOS.
 tags: [podman-desktop, kubernetes, onboarding, linux, macOS]
 keywords: [podman desktop, kubernetes, lima, onboarding, linux, macos]

--- a/website/docs/lima/creating-a-lima-instance.md
+++ b/website/docs/lima/creating-a-lima-instance.md
@@ -1,8 +1,8 @@
 ---
-sidebar_position: 30
-title: Custom Lima instance
+sidebar_position: 2
+title: Lima instance for containers
 description: Podman Desktop can assist you to create a custom Lima instance on Linux and macOS.
-tags: [podman-desktop, podman, onboarding, containers, linux, macOS]
+tags: [podman-desktop, podman, docker, containers, onboarding, linux, macOS]
 keywords: [podman desktop, containers, lima, onboarding, linux, macos]
 ---
 

--- a/website/docs/lima/index.md
+++ b/website/docs/lima/index.md
@@ -2,8 +2,8 @@
 sidebar_position: 90
 title: Lima
 description: Podman Desktop can assist you to create a custom Lima instance on Linux and macOS.
-tags: [podman-desktop, kubernetes, onboarding, linux, macOS]
-keywords: [podman desktop, kubernetes, lima, onboarding, linux, macos]
+tags: [podman-desktop, containers, kubernetes, onboarding, linux, macOS]
+keywords: [podman desktop, containers, kubernetes, lima, onboarding, linux, macos]
 ---
 
 # Lima
@@ -15,5 +15,5 @@ With Podman Desktop, you can work on [Lima-powered](https://lima-vm.io/) custom 
 #### Next steps
 
 1. [Installing Lima](/docs/lima/installing).
-1. [Create a custom instance for Podman](/docs/lima/creating-a-lima-instance).
+1. [Create a Lima instance for container workloads](/docs/lima/creating-a-lima-instance).
 1. [Create a Lima instance for Kubernetes workloads](/docs/lima/creating-a-kubernetes-instance).

--- a/website/docs/lima/installing.md
+++ b/website/docs/lima/installing.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 2
+sidebar_position: 1
 title: Installing the `lima` CLI
 description: Installing Lima
 keywords: [podman desktop, podman, containers, migrating, kubernetes, lima]


### PR DESCRIPTION
### What does this PR do?

Cleanup after:

* #4558

Documentation for containers and Kubernetes was merged, for each provider.

The menus got a bit weird, when they were pulled out of the previous context.

### Screenshot/screencast of this PR

![lima-menu](https://github.com/containers/podman-desktop/assets/10364051/32bd8ba8-cea7-43ce-bd26-2c1e59822ae3)

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop 
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to reproduce -->
