### PR TITLE
docs: the main lima command is limactl

### DIFF
--- a/website/docs/lima/installing.md
+++ b/website/docs/lima/installing.md
@@ -19,8 +19,16 @@ tags: [migrating-to-kubernetes, lima]
 
 #### Verification
 
-1. You can run the `lima` CLI:
+1. You can run the `limactl` CLI:
 
    ```shell-session
+   $ limactl list
+   ```
+
+1. (Optionally) To open a shell:
+
+   ```shell-session
+   $ # requires a running instance
+   $ export LIMA_INSTANCE=<instance>
    $ lima
    ```


### PR DESCRIPTION
lima is an alias for "limactl shell $LIMA_INSTANCE".

Both of them are installed with "brew install lima".

### What does this PR do?

The default lima instance runs `nerdctl`, which is **not** supported by Podman Desktop.

So we should not (indirectly) prompt people to start it, which would be done by `lima`:

```
FATA[0000] instance "default" does not exist, run `limactl create default` to create a new instance 
```

The main Lima program, with the help text and all the commands, is called `limactl`:

* https://lima-vm.io/docs/reference/limactl/

The "lima" command, and also the *.lima commands, are just small shell wrappers...

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast 
explaining what is doing this PR -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop 
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to reproduce -->
