### PR TITLE
fix: fix setup in build image tests

### DIFF
--- a/packages/renderer/src/lib/image/BuildImageFromContainerfile.spec.ts
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfile.spec.ts
@@ -73,6 +73,10 @@ function setup() {
     installationSupport: undefined,
   } as unknown as ProviderInfo;
   providerInfos.set([providerInfo]);
+  buildImagesInfo.set({
+    buildImageKey: Symbol(),
+    buildRunning: false,
+  });
 }
 
 test('Expect Build button is disabled', async () => {


### PR DESCRIPTION
### What does this PR do?

This PR just reset the `buildImagesInfo` object when running tests for BuilImage.
Thanks to @jannikbertram for reporting it 🙏 -> https://github.com/containers/podman-desktop/pull/4538#issuecomment-1791645263

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

N/A

### How to test this PR?

1. run test
