### PR TITLE
feat: command palette: add enablement property

### DIFF
--- a/EXTENSIONS.md
+++ b/EXTENSIONS.md
@@ -93,6 +93,37 @@ Upon a successful start up via the `activate` function within your extension, `P
 - `extension-loader.ts`: Attempts to load the extension and sets the status accordingly (either `started`, `stopped`, `starting` or `stopping`). If an unknown error has occurred, the status is set to `unknown`. `extension-loader.ts` also sends an API call to Podman Desktop to update the UI of the extension.
 - `tray-menu.ts`: If `extensionApi.tray.registerMenuItem(item);` API call has been used, a tray menu of the extension will be created. When created, Podman Desktop will use the `ProviderConnectionStatus` to indicate the status within the tray menu.
 
+#### Commands
+
+Declare commands using `contributes` section of package.json file.
+
+```json
+ "contributes": {
+    "commands": [
+      {
+        "command": "my.command",
+        "title": "This is my command",
+        "category": "Optional category to prefix title",
+        "enablement": "myProperty === myValue"
+      },
+    ],
+ }
+```
+
+If optional `enablement` property evaluates to false, command palette will not display this command.
+
+To register the callback of the command, use the following code:
+
+```ts
+import * as extensionApi from '@podman-desktop/api';
+
+extensionContext.subscriptions.push(extensionApi.commands.registerCommand('my.command', async () => {
+    // callback of your command
+    await extensionApi.window.showInformationMessage('Clicked on my command');
+});
+);
+```
+
 #### Expanding the `extension-api` API
 
 Sometimes you'll need to add new functionality to the API in order to make an internal change within Podman Desktop. An example would be a new UI/UX component that happens within the renderer, you'd need to expand the API in order to make that change to Podman Desktop's inner-workings.

--- a/packages/main/src/plugin/api/command-info.ts
+++ b/packages/main/src/plugin/api/command-info.ts
@@ -19,4 +19,5 @@
 export interface CommandInfo {
   id: string;
   title?: string;
+  enablement?: string;
 }

--- a/packages/main/src/plugin/command-registry.ts
+++ b/packages/main/src/plugin/command-registry.ts
@@ -28,6 +28,7 @@ export interface RawCommand {
   description?: string;
   icon?: string | { light: string; dark: string };
   keybinding?: string;
+  enablement?: string;
 }
 
 export interface CommandHandler {
@@ -104,6 +105,7 @@ export class CommandRegistry {
         commandInfos.push({
           id: command.command,
           title: command.category ? `${command.category}: ${command.title}` : command.title,
+          enablement: command.enablement,
         });
       });
     });


### PR DESCRIPTION
### What does this PR do?
as reported in comments https://github.com/containers/podman-desktop/pull/4081#pullrequestreview-1642374073
all commands should not appear in the command palette


### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

fixes #4107

### How to test this PR?

Unit test added

can add enablement in package.json and see if it's disabled based on the property

Signed-off-by: Florent Benoit <fbenoit@redhat.com>
