### PR TITLE
fix: disable create/start container if any port is busy

### DIFF
--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -52,7 +52,7 @@ import type { PullEvent } from './api/pull-event.js';
 import type { ExtensionInfo } from './api/extension-info.js';
 import type { ImageInspectInfo } from './api/image-inspect-info.js';
 import type { TrayMenu } from '../tray-menu.js';
-import { getFreePort, getFreePortRange } from './util/port.js';
+import { getFreePort, getFreePortRange, isFreePort } from './util/port.js';
 import { isLinux, isMac } from '../util.js';
 import type { MessageBoxOptions, MessageBoxReturnValue } from './message-box.js';
 import { MessageBox } from './message-box.js';
@@ -1315,6 +1315,10 @@ export class PluginSystem {
 
     this.ipcHandle('system:get-free-port-range', async (_, rangeSize: number): Promise<string> => {
       return getFreePortRange(rangeSize);
+    });
+
+    this.ipcHandle('system:is-port-free', async (_, port: number): Promise<boolean> => {
+      return isFreePort(port);
     });
 
     this.ipcHandle(

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -1219,6 +1219,10 @@ function initExposure(): void {
     return ipcInvoke('system:get-free-port-range', rangeSize);
   });
 
+  contextBridge.exposeInMainWorld('isFreePort', async (port: number): Promise<boolean> => {
+    return ipcInvoke('system:is-port-free', port);
+  });
+
   type LogFunction = (...data: unknown[]) => void;
 
   let onDataCallbacksStartReceiveLogsId = 0;


### PR DESCRIPTION
### What does this PR do?

This PR adds a check everytime a port is added/updated in the create/start container page so the button gets disabled if one of the ports is busy

### Screenshot/screencast of this PR

![show_used_ports](https://github.com/containers/podman-desktop/assets/49404737/2c1b1e5a-3835-4212-b9e0-2934ea3f12d2)

### What issues does this PR fix or reference?

it resolves #3907 

### How to test this PR?

1. go to the create a container from an image page
2. add a port that is already in use
3. you should not be able to start the container
