### PR TITLE
fix: location of roots.exe in devmode

### DIFF
--- a/packages/main/src/plugin/certificates.ts
+++ b/packages/main/src/plugin/certificates.ts
@@ -81,6 +81,8 @@ export class Certificates {
       if (import.meta.env.PROD) {
         const rootExePath = path.join(process.resourcesPath, 'win-ca', 'roots.exe');
         wincaAPI.exe(rootExePath);
+      } else {
+        wincaAPI.exe(path.resolve(__dirname, '..', '..', '..', 'node_modules', 'win-ca', 'lib', 'roots.exe'));
       }
 
       wincaAPI({

--- a/packages/main/src/plugin/certificates.ts
+++ b/packages/main/src/plugin/certificates.ts
@@ -82,7 +82,7 @@ export class Certificates {
         const rootExePath = path.join(process.resourcesPath, 'win-ca', 'roots.exe');
         wincaAPI.exe(rootExePath);
       } else {
-        wincaAPI.exe(path.resolve(__dirname, '..', '..', '..', 'node_modules', 'win-ca', 'lib', 'roots.exe'));
+        wincaAPI.exe(require.resolve('win-ca/lib/roots.exe'));
       }
 
       wincaAPI({


### PR DESCRIPTION
### What does this PR do?

fixes exception when retrieving CA on windows.

### Screenshot/screencast of this PR

![image](https://github.com/containers/podman-desktop/assets/620330/35620fe7-566d-4f80-8695-34e4fb84c1f2)

### What issues does this PR fix or reference?

fix #4653.

### How to test this PR?

<!-- Please explain steps to reproduce -->
