### PR TITLE
feat: add editable item for cpu/memory/disk (#2319)

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.spec.ts
@@ -38,7 +38,7 @@ async function awaitRender(record: IConfigurationPropertyRecordedSchema, customP
     initialValue: getInitialValue(record),
     ...customProperties,
   });
-  while (result.component.$$.ctx[3] === undefined) {
+  while (result.component.$$.ctx[4] === undefined) {
     await new Promise(resolve => setTimeout(resolve, 100));
   }
 }

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
@@ -22,6 +22,7 @@ export let enableSlider = false;
 export let record: IConfigurationPropertyRecordedSchema;
 
 export let initialValue: Promise<any>;
+export let givenValue: unknown = undefined;
 
 let currentRecord: IConfigurationPropertyRecordedSchema;
 let recordUpdateTimeout: NodeJS.Timeout;
@@ -111,36 +112,36 @@ async function onChange(recordId: string, value: boolean | string | number): Pro
 }
 </script>
 
-<div class="flex flex-row mb-1 pt-2">
-  <div class="flex flex-col text-start w-full justify-center items-end">
-    {#if record.type === 'boolean'}
-      <BooleanItem record="{record}" checked="{!!recordValue}" onChange="{onChange}" />
-    {:else if record.type === 'number'}
-      {#if enableSlider && typeof record.maximum === 'number'}
-        <SliderItem record="{record}" value="{getNormalizedDefaultNumberValue(record)}" onChange="{onChange}" />
-      {:else}
-        <NumberItem
-          record="{record}"
-          value="{typeof recordValue === 'number' ? recordValue : getNormalizedDefaultNumberValue(record)}"
-          onChange="{onChange}"
-          invalidRecord="{invalidRecord}" />
-      {/if}
-    {:else if record.type === 'string' && (typeof recordValue === 'string' || recordValue === undefined)}
-      {#if record.format === 'file'}
-        <FileItem record="{record}" value="{recordValue || ''}" onChange="{onChange}" />
-      {:else if record.enum && record.enum.length > 0}
-        <EnumItem record="{record}" value="{recordValue}" onChange="{onChange}" />
-      {:else}
-        <StringItem record="{record}" value="{recordValue}" onChange="{onChange}" />
-      {/if}
-    {:else if record.type === 'markdown'}
-      <div class="text-sm">
-        <Markdown>{record.markdownDescription}</Markdown>
-      </div>
+<div class="flex flex-row mb-1 pt-2 text-start items-center justify-start">
+  {#if invalidText}
+    <ErrorMessage error="{invalidText}." icon="{true}" class="mr-2" />
+  {/if}
+  {#if record.type === 'boolean'}
+    <BooleanItem record="{record}" checked="{!!recordValue}" onChange="{onChange}" />
+  {:else if record.type === 'number'}
+    {#if enableSlider && typeof record.maximum === 'number'}
+      <SliderItem
+        record="{record}"
+        value="{typeof givenValue === 'number' ? givenValue : getNormalizedDefaultNumberValue(record)}"
+        onChange="{onChange}" />
+    {:else}
+      <NumberItem
+        record="{record}"
+        value="{typeof recordValue === 'number' ? recordValue : getNormalizedDefaultNumberValue(record)}"
+        onChange="{onChange}"
+        invalidRecord="{invalidRecord}" />
     {/if}
-
-    {#if invalidText}
-      <ErrorMessage error="{invalidText}." />
+  {:else if record.type === 'string' && (typeof recordValue === 'string' || recordValue === undefined)}
+    {#if record.format === 'file'}
+      <FileItem record="{record}" value="{recordValue || ''}" onChange="{onChange}" />
+    {:else if record.enum && record.enum.length > 0}
+      <EnumItem record="{record}" value="{recordValue}" onChange="{onChange}" />
+    {:else}
+      <StringItem record="{record}" value="{recordValue}" onChange="{onChange}" />
     {/if}
-  </div>
+  {:else if record.type === 'markdown'}
+    <div class="text-sm">
+      <Markdown>{record.markdownDescription}</Markdown>
+    </div>
+  {/if}
 </div>

--- a/packages/renderer/src/lib/preferences/item-formats/EditableConnectionResourceItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/item-formats/EditableConnectionResourceItem.spec.ts
@@ -1,0 +1,102 @@
+import '@testing-library/jest-dom/vitest';
+import { test, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import type { IConfigurationPropertyRecordedSchema } from '../../../../../main/src/plugin/configuration-registry';
+import userEvent from '@testing-library/user-event';
+import EditableConnectionResourceItem from './EditableConnectionResourceItem.svelte';
+
+const onSave = vi.fn();
+
+test('Expect onSave is called with normalized value if record uses GB and input is updated', async () => {
+  const record: IConfigurationPropertyRecordedSchema = {
+    id: 'record',
+    title: 'record',
+    parentId: 'parent.record',
+    description: 'record-description',
+    type: 'number',
+    format: 'memory',
+    minimum: 1000000000,
+    maximum: 34000000000,
+  };
+  const value = 2000000000;
+  render(EditableConnectionResourceItem, { record, value, onSave });
+
+  const buttonEdit = screen.getByRole('button', { name: 'Edit' });
+  expect(buttonEdit).toBeInTheDocument();
+
+  await userEvent.click(buttonEdit);
+
+  const input = await screen.findByLabelText('record-description');
+  expect(input).toBeInTheDocument();
+
+  await userEvent.click(input);
+  await userEvent.clear(input);
+  await userEvent.keyboard('20');
+
+  expect(onSave).toBeCalledWith('record', 20000000000);
+});
+
+test('Expect onSave NOT to be called when an invalid input is typed', async () => {
+  const record: IConfigurationPropertyRecordedSchema = {
+    id: 'record',
+    title: 'record',
+    parentId: 'parent.record',
+    description: 'record-description',
+    type: 'number',
+    format: 'memory',
+    minimum: 1000000000,
+    maximum: 34000000000,
+  };
+  const value = 2000000000;
+  render(EditableConnectionResourceItem, { record, value, onSave });
+
+  const buttonEdit = screen.getByRole('button', { name: 'Edit' });
+  expect(buttonEdit).toBeInTheDocument();
+
+  await userEvent.click(buttonEdit);
+
+  const input = await screen.findByLabelText('record-description');
+  expect(input).toBeInTheDocument();
+
+  await userEvent.click(input);
+  await userEvent.clear(input);
+  await userEvent.keyboard('35');
+
+  expect(onSave).not.toBeCalledWith('record', 35000000000);
+});
+
+test('Expect onSave to be called with initial value if input is cancelled', async () => {
+  const record: IConfigurationPropertyRecordedSchema = {
+    id: 'record',
+    title: 'record',
+    parentId: 'parent.record',
+    description: 'record-description',
+    type: 'number',
+    format: 'memory',
+    minimum: 1000000000,
+    maximum: 34000000000,
+  };
+  const value = 2000000000;
+  render(EditableConnectionResourceItem, { record, value, onSave });
+
+  const buttonEdit = screen.getByRole('button', { name: 'Edit' });
+  expect(buttonEdit).toBeInTheDocument();
+
+  await userEvent.click(buttonEdit);
+
+  const input = await screen.findByLabelText('record-description');
+  expect(input).toBeInTheDocument();
+
+  await userEvent.click(input);
+  await userEvent.clear(input);
+  await userEvent.keyboard('10');
+
+  expect(onSave).toBeCalledWith('record', 10000000000);
+
+  const buttonCancel = await screen.findByRole('button', { name: 'Cancel' });
+  expect(buttonCancel).toBeInTheDocument();
+
+  await userEvent.click(buttonCancel);
+
+  expect(onSave).toBeCalledWith('record', 20000000000);
+});

--- a/packages/renderer/src/lib/preferences/item-formats/EditableConnectionResourceItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/EditableConnectionResourceItem.svelte
@@ -11,6 +11,14 @@ export let onSave = (_recordId: string, _value: number) => {};
 let recordValue: DisplayConfigurationValue | undefined;
 $: recordValue = getDisplayConfigurationValue(record, value);
 
+function onChangeInput(_recordId: string, _value: number) {
+  innerOnSave(_recordId, _value);
+}
+
+function onCancel(_recordId: string, originalValue: number) {
+  innerOnSave(_recordId, originalValue);
+}
+
 interface DisplayConfigurationValue {
   value: number;
   format?: string;
@@ -89,5 +97,6 @@ function innerOnSave(_recordId: string, _value: number) {
     record="{normalizeDiskAndMemoryConfigurationKey(record)}"
     value="{recordValue.value}"
     description="{recordValue.format}"
-    onSave="{innerOnSave}" />
+    onCancel="{onCancel}"
+    onChange="{onChangeInput}" />
 {/if}

--- a/packages/renderer/src/lib/preferences/item-formats/EditableConnectionResourceItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/EditableConnectionResourceItem.svelte
@@ -65,7 +65,7 @@ function normalizeDiskAndMemoryConfigurationKey(
       ? getFileSizeValue(filesize(configurationKey.minimum))
       : configurationKey.minimum;
     configurationKeyClone.default =
-      typeof configurationKey.maximum === 'number'
+      typeof configurationKey.maximum === 'number' && configurationKey.default
         ? getFileSizeValue(filesize(configurationKey.default))
         : configurationKey.default;
     return configurationKeyClone;

--- a/packages/renderer/src/lib/preferences/item-formats/EditableConnectionResourceItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/EditableConnectionResourceItem.svelte
@@ -1,0 +1,93 @@
+<script lang="ts">
+import type { IConfigurationPropertyRecordedSchema } from '../../../../../main/src/plugin/configuration-registry';
+import { getNormalizedDefaultNumberValue } from '../Util';
+import { filesize } from 'filesize';
+import EditableItem from './EditableItem.svelte';
+
+export let record: IConfigurationPropertyRecordedSchema;
+export let value: number | undefined = undefined;
+export let onSave = (_recordId: string, _value: number) => {};
+
+let recordValue: DisplayConfigurationValue | undefined;
+$: recordValue = getDisplayConfigurationValue(record, value);
+
+interface DisplayConfigurationValue {
+  value: number;
+  format?: string;
+}
+
+function getDisplayConfigurationValue(
+  configurationKey: IConfigurationPropertyRecordedSchema,
+  value?: unknown,
+): DisplayConfigurationValue | undefined {
+  if (configurationKey.format === 'memory' || configurationKey.format === 'diskSize') {
+    const fileSizeItem = value
+      ? filesize(value as number)
+      : filesize(getNormalizedDefaultNumberValue(configurationKey));
+    const fileSizeItems = fileSizeItem.split(' ');
+    // the value returned consists of a number and its format (e.g 20 GB). We return the number as value and the format as description for the editableItem component
+    return {
+      value: Number(fileSizeItems[0]),
+      format: fileSizeItems[1],
+    };
+  } else if (configurationKey.format === 'cpu') {
+    return {
+      value: value ? Number(value) : Number(getNormalizedDefaultNumberValue(configurationKey)),
+    };
+  }
+  return undefined;
+}
+
+function getFileSizeValue(fileSizeItem: string): number {
+  return parseInt(fileSizeItem.split(' ')[0]);
+}
+
+function normalizeDiskAndMemoryConfigurationKey(
+  configurationKey: IConfigurationPropertyRecordedSchema,
+): IConfigurationPropertyRecordedSchema {
+  const configurationKeyClone = Object.assign({}, configurationKey);
+  // if configurationKey is memory or diskSize let's convert the values in bytes to GB so, in case of errors, the message is displayed correctly to the user
+  // instad of having "the value must be less than 16000000000" will be ".... less than 16"
+  if (configurationKey.format === 'memory' || configurationKey.format === 'diskSize') {
+    configurationKeyClone.maximum =
+      typeof configurationKey.maximum === 'number'
+        ? getFileSizeValue(filesize(configurationKey.maximum))
+        : configurationKey.maximum;
+    configurationKeyClone.minimum = configurationKey.minimum
+      ? getFileSizeValue(filesize(configurationKey.minimum))
+      : configurationKey.minimum;
+    configurationKeyClone.default =
+      typeof configurationKey.maximum === 'number'
+        ? getFileSizeValue(filesize(configurationKey.default))
+        : configurationKey.default;
+    return configurationKeyClone;
+  }
+  return configurationKey;
+}
+
+function innerOnSave(_recordId: string, _value: number) {
+  // convert value to byte to be saved
+  const displayConfigurationValue = getDisplayConfigurationValue(record, value);
+  if (displayConfigurationValue) {
+    switch (displayConfigurationValue.format) {
+      case 'GB': {
+        _value = _value * 1000 * 1000 * 1000;
+        break;
+      }
+      case 'MB': {
+        _value = _value * 1000 * 1000;
+        break;
+      }
+    }
+    onSave(_recordId, _value);
+  }
+}
+</script>
+
+{#if record && recordValue}
+  <EditableItem
+    record="{normalizeDiskAndMemoryConfigurationKey(record)}"
+    value="{recordValue.value}"
+    description="{recordValue.format}"
+    onSave="{innerOnSave}" />
+{/if}

--- a/packages/renderer/src/lib/preferences/item-formats/EditableItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/item-formats/EditableItem.spec.ts
@@ -84,7 +84,7 @@ test('Expect description to be visible if defined', async () => {
   expect(descriptionDiv?.textContent).toEqual(description);
 });
 
-test('Expect save button is disabled if input value has not been updated', async () => {
+test('Expect save button is disabled if input value is invalid', async () => {
   const record: IConfigurationPropertyRecordedSchema = {
     id: 'record',
     title: 'record',
@@ -107,7 +107,7 @@ test('Expect save button is disabled if input value has not been updated', async
 
   await userEvent.click(input);
   await userEvent.clear(input);
-  await userEvent.keyboard(value.toString());
+  await userEvent.keyboard('');
 
   const buttonCancel = await screen.findByRole('button', { name: 'Cancel' });
   expect(buttonCancel).toBeInTheDocument();

--- a/packages/renderer/src/lib/preferences/item-formats/EditableItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/item-formats/EditableItem.spec.ts
@@ -107,7 +107,7 @@ test('Expect save button is disabled if input value is invalid', async () => {
 
   await userEvent.click(input);
   await userEvent.clear(input);
-  await userEvent.keyboard('');
+  await userEvent.keyboard('35');
 
   const buttonCancel = await screen.findByRole('button', { name: 'Cancel' });
   expect(buttonCancel).toBeInTheDocument();

--- a/packages/renderer/src/lib/preferences/item-formats/EditableItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/EditableItem.svelte
@@ -9,12 +9,15 @@ export let record: IConfigurationPropertyRecordedSchema;
 export let value: number;
 export let description: string | undefined = undefined;
 export let onSave = (_recordId: string, _value: number) => {};
+export let onChange = (_recordId: string, _value: number) => {};
+export let onCancel = (_recordId: string, _originalValue: number) => {};
 
 let editingInProgress = false;
 let editedValue: number;
 $: editedValue = value;
 let disableSaveButton: boolean;
-$: disableSaveButton = !editingInProgress || editedValue === value;
+$: disableSaveButton = !editingInProgress;
+let originalValue: number;
 
 function invalidRecord(_error: string) {
   if (_error) {
@@ -22,12 +25,18 @@ function invalidRecord(_error: string) {
   }
 }
 
-function onChange(_: string, _value: number) {
+function onChangeInput(_: string, _value: number) {
   editedValue = _value;
+  disableSaveButton = false;
+  // call onSave so other components that depends on this one will be updated as well (like the slider value if the input is updated manually)
+  if (record.id) {
+    onChange(record.id, editedValue);
+  }
 }
 
 function onSwitchToInProgress(e: MouseEvent) {
   e.preventDefault();
+  originalValue = value;
   editingInProgress = true;
 }
 
@@ -39,10 +48,13 @@ function onSaveClick(e: MouseEvent) {
   }
 }
 
-function onCancel(e: MouseEvent) {
+function onCancelClick(e: MouseEvent) {
   e.preventDefault();
-  editedValue = value;
+  editedValue = originalValue;
   editingInProgress = false;
+  if (record.id) {
+    onCancel(record.id, originalValue);
+  }
 }
 </script>
 
@@ -53,7 +65,7 @@ function onCancel(e: MouseEvent) {
     <FloatNumberItem
       record="{record}"
       value="{Number(editedValue)}"
-      onChange="{onChange}"
+      onChange="{onChangeInput}"
       invalidRecord="{invalidRecord}" />
   {/if}
   {#if description}
@@ -67,11 +79,11 @@ function onCancel(e: MouseEvent) {
       <Fa size="12" icon="{faPencil}" />
     </Button>
   {:else}
-    <Button on:click="{onCancel}" title="Cancel" class="ml-3" padding="p-2" type="link">
+    <Button on:click="{onCancelClick}" title="Cancel" class="ml-3" padding="p-2" type="link">
       <Fa size="14" class="text-red-500" icon="{faXmark}" />
     </Button>
     <Button on:click="{onSaveClick}" title="Save" padding="p-2" disabled="{disableSaveButton}" type="link">
-      <Fa size="14" class="text-green-500" icon="{faCheck}" />
+      <Fa size="14" class="{`${disableSaveButton ? 'text-gray-500' : 'text-green-500'}`}" icon="{faCheck}" />
     </Button>
   {/if}
 </div>

--- a/packages/renderer/src/lib/preferences/item-formats/EditableItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/EditableItem.svelte
@@ -28,7 +28,6 @@ function invalidRecord(_error: string) {
 function onChangeInput(_: string, _value: number) {
   editedValue = _value;
   disableSaveButton = false;
-  // call onSave so other components that depends on this one will be updated as well (like the slider value if the input is updated manually)
   if (record.id) {
     onChange(record.id, editedValue);
   }
@@ -36,6 +35,8 @@ function onChangeInput(_: string, _value: number) {
 
 function onSwitchToInProgress(e: MouseEvent) {
   e.preventDefault();
+  // we set the originalValue to keep a record of the initial value
+  // if the updating is cancelled, we can reset to it
   originalValue = value;
   editingInProgress = true;
 }
@@ -50,6 +51,7 @@ function onSaveClick(e: MouseEvent) {
 
 function onCancelClick(e: MouseEvent) {
   e.preventDefault();
+  // we set the value to the initial one - the value that was set when the edit mode was enabled
   editedValue = originalValue;
   editingInProgress = false;
   if (record.id) {

--- a/packages/renderer/src/lib/preferences/item-formats/FloatNumberItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/FloatNumberItem.svelte
@@ -10,8 +10,6 @@ export let value: number | undefined;
 export let onChange = (_id: string, _value: number) => {};
 export let invalidRecord = (_error: string) => {};
 
-let valueUpdateTimeout: NodeJS.Timeout;
-
 let recordValue: string;
 $: recordValue = value?.toString() || '0';
 
@@ -25,8 +23,6 @@ onMount(() => {
 });
 
 function onInput(event: Event) {
-  // clear the timeout so if there was an old call to onChange pending is deleted. We will create a new one soon
-  clearTimeout(valueUpdateTimeout);
   const target = event.currentTarget as HTMLInputElement;
   // if last char is a dot, user is probably adding a decimal point
   if (target.value.endsWith('.')) {
@@ -47,8 +43,8 @@ function onInput(event: Event) {
   }
   recordValue = _value.toString();
   // if the value is different from the original update
-  if (record.id && _value !== value) {
-    valueUpdateTimeout = setTimeout(() => onChange(record.id!, _value), 500);
+  if (record.id) {
+    onChange(record.id, _value);
   }
 }
 
@@ -74,7 +70,7 @@ function assertNumericValueIsValid(value: number): boolean {
   class="flex flex-row rounded-sm bg-zinc-700 text-sm divide-x divide-charcoal-800 w-24 border-b"
   class:border-violet-500="{!numberInputInvalid}"
   class:border-red-500="{numberInputInvalid}">
-  <Tooltip topLeft tip="{numberInputErrorMessage}">
+  <Tooltip topRight tip="{numberInputErrorMessage}">
     <input
       type="text"
       class="w-full px-2 outline-none focus:outline-none text-white text-sm py-0.5"

--- a/packages/renderer/src/lib/ui/ErrorMessage.svelte
+++ b/packages/renderer/src/lib/ui/ErrorMessage.svelte
@@ -10,7 +10,7 @@ export let icon = false;
 {#if icon}
   {#if error !== undefined && error !== ''}
     <Tooltip tip="{error}" top>
-      <Fa size="18" class="cursor-pointer text-red-500" icon="{faExclamationCircle}" />
+      <Fa size="18" class="cursor-pointer text-red-500 {$$props.class}" icon="{faExclamationCircle}" />
     </Tooltip>
   {/if}
 {:else}

--- a/packages/renderer/src/lib/ui/Tooltip.svelte
+++ b/packages/renderer/src/lib/ui/Tooltip.svelte
@@ -26,6 +26,11 @@
   transform: translate(-80%, -100%);
   margin-top: -8px;
 }
+.tooltip.top-right {
+  left: 0;
+  transform: translate(0%, -100%);
+  margin-top: -8px;
+}
 .tooltip-slot:hover + .tooltip {
   opacity: 1;
   visibility: initial;
@@ -36,6 +41,7 @@
 export let tip = '';
 export let top = false;
 export let topLeft = false;
+export let topRight = false;
 export let right = false;
 export let bottom = false;
 export let left = false;
@@ -51,7 +57,8 @@ export let left = false;
     class:right="{right}"
     class:bottom="{bottom}"
     class:top="{top}"
-    class:top-left="{topLeft}">
+    class:top-left="{topLeft}"
+    class:top-right="{topRight}">
     {#if tip}
       <div class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs" aria-label="tooltip">{tip}</div>
     {/if}


### PR DESCRIPTION
### What does this PR do?

This PR enhances the slider item. It increases the step value and allow to edit the value manually

### Screenshot/screencast of this PR

![editable_item_float](https://github.com/containers/podman-desktop/assets/49404737/cf4787a2-4d41-434b-93cb-f4112fb08338)

### What issues does this PR fix or reference?

it resolves #2319 

### How to test this PR?

1. create a podman machine and adds memory/cpu/disk by using the editable input
