### PR TITLE
feat: add slider step for memory/disk when creating a podman machine (#2319)

### DIFF
--- a/extensions/podman/package.json
+++ b/extensions/podman/package.json
@@ -101,6 +101,7 @@
           "default": 4000000000,
           "maximum": "HOST_TOTAL_MEMORY",
           "scope": "ContainerProviderConnectionFactory",
+          "step": 500000000,
           "description": "Memory"
         },
         "podman.factory.machine.diskSize": {
@@ -109,6 +110,7 @@
           "default": 100000000000,
           "minimum": 10000000000,
           "maximum": "HOST_TOTAL_DISKSIZE",
+          "step": 500000000,
           "scope": "ContainerProviderConnectionFactory",
           "description": "Disk size"
         },

--- a/packages/main/src/plugin/configuration-registry.ts
+++ b/packages/main/src/plugin/configuration-registry.ts
@@ -61,6 +61,7 @@ export interface IConfigurationPropertySchema {
   minimum?: number;
   maximum?: number | string;
   format?: string;
+  step?: number;
   scope?: ConfigurationScope | ConfigurationScope[];
   readonly?: boolean;
   // if hidden is true, the property is not shown in the preferences page. It may still appear in other locations if it uses other scope (like onboarding)

--- a/packages/renderer/src/lib/preferences/item-formats/SliderItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/SliderItem.svelte
@@ -19,6 +19,7 @@ function onInput(event: Event) {
   name="{record.id}"
   min="{record.minimum}"
   max="{record.maximum}"
+  step="{record.step}"
   value="{value}"
   aria-label="{record.description}"
   on:input="{onInput}"


### PR DESCRIPTION
### What does this PR do?

This PR adds a step to the podman machine memory/disk sliders.
The code has been extracted from https://github.com/containers/podman-desktop/pull/4683 to simplify the review.

### Screenshot/screencast of this PR

![slider_step](https://github.com/containers/podman-desktop/assets/49404737/046eaf92-9450-406c-aae8-f2d074d8f9fd)

### What issues does this PR fix or reference?

it is part of #2319 

### How to test this PR?

1. create a new podman machine and check the sliders value change at a 0.5 step
