### PR TITLE
chore(ui,tests): add ARIA functionality elements into SettingsPage

### DIFF
--- a/packages/renderer/src/lib/preferences/SettingsPage.svelte
+++ b/packages/renderer/src/lib/preferences/SettingsPage.svelte
@@ -2,8 +2,8 @@
 export let title: string;
 </script>
 
-<div class="flex flex-col min-w-full h-full">
-  <div class="min-w-full px-5 py-4">
+<div class="flex flex-col min-w-full h-full" role="region" aria-label="{title}">
+  <div class="min-w-full px-5 py-4" role="region" aria-label="header">
     <div class="flex flex-row">
       <div class="grow">
         <p class="capitalize text-xl">{title}</p>
@@ -14,7 +14,7 @@ export let title: string;
 
     <slot name="header" />
   </div>
-  <div class="flex flex-row min-w-full h-full px-5 py-4 overflow-y-auto">
+  <div class="flex flex-row min-w-full h-full px-5 py-4 overflow-y-auto" role="region" aria-label="content">
     <div class="flex flex-col grow max-w-[905px] mx-auto">
       <slot />
     </div>


### PR DESCRIPTION
### What does this PR do?
Add basic division of a whole settings page, its header and main content with ARIA functionality.

### Screenshot/screencast of this PR
```
<div class="flex flex-col min-w-full h-full" role="region" aria-label="CLI Tools">
  <div class="min-w-full px-5 py-4" role="region" aria-label="header">
    ...
  </div>
  <div class="flex flex-row min-w-full h-full px-5 py-4 overflow-y-auto" role="region" aria-label="content">
    ...
  </div>
  ...
</div>
```

<!-- Please include a screenshot or a screencast 
explaining what is doing this PR -->



### What issues does this PR fix or reference?
#4715.
<!-- Include any related issues from Podman Desktop 
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to reproduce -->
