### PR TITLE
chore: remove usage of patternfly color

### DIFF
--- a/packages/renderer/src/lib/preferences/item-formats/SliderItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/SliderItem.svelte
@@ -23,4 +23,4 @@ function onInput(event: Event) {
   value="{value}"
   aria-label="{record.description}"
   on:input="{onInput}"
-  class="w-full h-1 bg-[var(--pf-global--primary-color--300)] rounded-lg appearance-none accent-[var(--pf-global--primary-color--300)] cursor-pointer range-xs mt-2" />
+  class="w-full h-1 bg-violet-600 rounded-lg appearance-none accent-violet-600 cursor-pointer range-xs mt-2" />


### PR DESCRIPTION
### What does this PR do?
use the same color than the toggle (violet-600) instead of using a patternfly color

toggle item definition: 
https://github.com/containers/podman-desktop/blob/9ca58e4d46875b2a2b07e97ce4d0f10171e59144/packages/renderer/src/lib/preferences/item-formats/BooleanItem.svelte#L32


### Screenshot/screencast of this PR

![image](https://github.com/containers/podman-desktop/assets/436777/a078dbd9-4626-427c-9d12-e72b49affb55)



<!-- Please include a screenshot or a screencast 
explaining what is doing this PR -->

### What issues does this PR fix or reference?
fixes https://github.com/containers/podman-desktop/issues/3800

### How to test this PR?

see if color is ok for you when going to create a new podman machine and looking at memory/cpu/etc sliders