### PR TITLE
chore: send bundled telemetry at the end of onboarding session

### DIFF
--- a/extensions/compose/src/extension.ts
+++ b/extensions/compose/src/extension.ts
@@ -95,6 +95,12 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
         downloaded: isDownloaded === '' ? false : true,
         version: composeVersionMetadata?.tag,
       });
+      return {
+        telemetry: {
+          downloaded: isDownloaded === '' ? false : true,
+          version: composeVersionMetadata?.tag,
+        },
+      };
     },
   );
 


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

This PR makes changes to the onboarding process, by collecting telemetry data from the commands executed during the onboarding (through the response of commands), and sending the bundled data at the end of the onboarding session.

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast 
explaining what is doing this PR -->

### What issues does this PR fix or reference?

Fixes #4590

### How to test this PR?

<!-- Please explain steps to reproduce -->
