### PR TITLE
chore: send bundled onboarding telemetry

### DIFF
--- a/extensions/compose/src/handler.ts
+++ b/extensions/compose/src/handler.ts
@@ -77,6 +77,7 @@ export async function installComposeBinary(
     } catch (error) {
       console.error(error);
       await extensionApi.window.showErrorMessage(`Unable to install docker-compose binary: ${error}`);
+      throw error;
     } finally {
       // Regardless of what happens, always update the configuration setting and context
       // for example, if this fails when installing, the configuration setting will be set back to false

--- a/packages/renderer/src/lib/onboarding/Onboarding.svelte
+++ b/packages/renderer/src/lib/onboarding/Onboarding.svelte
@@ -54,6 +54,7 @@ import Button from '../ui/Button.svelte';
 import Link from '../ui/Link.svelte';
 import OnboardingComponent from './OnboardingComponent.svelte';
 import Spinner from '../ui/Spinner.svelte';
+import { TelemetrySession } from './telemetry';
 
 export let extensionIds: string[] = [];
 
@@ -66,6 +67,8 @@ let globalContext: ContextUI;
 let displayCancelSetup = false;
 
 let executedCommands: string[] = [];
+
+let telemetrySession = new TelemetrySession();
 
 /*
 $: enableNextButton = false;*/
@@ -111,6 +114,7 @@ async function startOnboarding(): Promise<void> {
   if (!started && globalContext && onboardings.length > 0) {
     started = true;
     if (!isOnboardingsSetupCompleted(onboardings)) {
+      telemetrySession.restart();
       await restartSetup();
     }
   }
@@ -141,6 +145,7 @@ async function setActiveStep() {
             whenDeserialized = ContextKeyExpr.deserialize(when);
           }
           if (!step.when || whenDeserialized?.evaluate(globalContext)) {
+            telemetrySession.startStep(i, step.id, step.title);
             activeStep = {
               onboarding,
               step,
@@ -154,7 +159,13 @@ async function setActiveStep() {
                 });
               }) || [];
             if (step.command) {
-              await doExecuteCommand(step.command);
+              try {
+                await doExecuteCommand(step.command);
+              } catch (error: unknown) {
+                if (error instanceof Error) {
+                  telemetrySession.setStepError(i, step.id, error);
+                }
+              }
               // after command has been executed, we check if the step must be marked as completed
               await assertStepCompletedAfterCommandExecution();
             }
@@ -167,6 +178,7 @@ async function setActiveStep() {
       }
     }
   }
+  telemetrySession.send(onboardings.map(o => o.extension).join(','), false);
   // if it reaches this point it means that the onboarding is fully completed and the user is redirected to the dashboard
   router.goto($lastPage.path);
 }
@@ -193,7 +205,7 @@ async function doExecuteCommand(command: string) {
     await window.executeCommand(command);
   } catch (e) {
     inProgressCommandExecution(command, 'failed', e);
-    return;
+    throw e;
   }
   inProgressCommandExecution(command, 'successful');
 }
@@ -262,9 +274,7 @@ async function cancelSetup() {
   // TODO: it cancels all running commands
   // it redirect the user to the dashboard
   await cleanSetup(onboardings, globalContext);
-  window.telemetryTrack('onboarding.cancelSetup', {
-    extensions: onboardings.map(o => o.extension).join(','),
-  });
+  telemetrySession.send(onboardings.map(o => o.extension).join(','), true);
   router.goto($lastPage.path);
 }
 

--- a/packages/renderer/src/lib/onboarding/Onboarding.svelte
+++ b/packages/renderer/src/lib/onboarding/Onboarding.svelte
@@ -54,7 +54,7 @@ import Button from '../ui/Button.svelte';
 import Link from '../ui/Link.svelte';
 import OnboardingComponent from './OnboardingComponent.svelte';
 import Spinner from '../ui/Spinner.svelte';
-import { TelemetrySession } from './telemetry';
+import { OnboardingTelemetrySession } from './telemetry';
 
 export let extensionIds: string[] = [];
 
@@ -68,7 +68,7 @@ let displayCancelSetup = false;
 
 let executedCommands: string[] = [];
 
-let telemetrySession = new TelemetrySession();
+let telemetrySession = new OnboardingTelemetrySession();
 
 /*
 $: enableNextButton = false;*/

--- a/packages/renderer/src/lib/onboarding/telemetry.ts
+++ b/packages/renderer/src/lib/onboarding/telemetry.ts
@@ -1,0 +1,133 @@
+export interface TelemetryStep {
+  id: string;
+  title: string;
+  durationMs: number;
+  error: undefined | string;
+}
+
+export interface TelemetryData {
+  extension: string;
+  skipped: boolean;
+  steps: TelemetryStep[];
+  stepsDetails?: any;
+  durationMs: number;
+  skipAtStep?: string;
+  errors?: string[];
+}
+
+export class TelemetrySession {
+  private data: TelemetryData;
+  private onboardingStartTime: number;
+  private stepStartTime: number;
+  private previousStepIndex: number;
+  private previousStepId: string;
+
+  constructor() {
+    this.data = {
+      extension: '',
+      skipped: false,
+      steps: [],
+      durationMs: 0,
+    };
+    this.onboardingStartTime = performance.now();
+    this.stepStartTime = performance.now();
+    this.previousStepIndex = -1;
+    this.previousStepId = '';
+  }
+
+  restart() {
+    this.onboardingStartTime = performance.now();
+    this.stepStartTime = performance.now();
+    this.previousStepIndex = -1;
+  }
+
+  startStep(i: number, id: string, title: string) {
+    if (this.previousStepIndex >= 0) {
+      this.savePreviousDuration();
+    }
+    this.previousStepIndex = i;
+    this.previousStepId = id;
+    this.data = telemetryAddStep(this.data, i, id, title);
+  }
+
+  setStepError(i: number, id: string, error: Error) {
+    this.data = telemetrySetStepError(this.data, i, id, error);
+  }
+
+  send(extensionName: string, skipped: boolean) {
+    this.savePreviousDuration();
+    this.data.extension = extensionName;
+    this.data.skipped = skipped;
+    this.data.durationMs = Math.round(performance.now() - this.onboardingStartTime);
+    window.telemetryTrack('onboarding', telemetryToSend(this.data));
+  }
+
+  private savePreviousDuration() {
+    const endTime = performance.now();
+    try {
+      const duration = Math.round(endTime - this.stepStartTime);
+      this.data = telemetrySetStepDuration(this.data, this.previousStepIndex, this.previousStepId, duration);
+    } catch {
+      // should not happen, as we should have added the step before
+      console.error('no step in telemetry');
+    }
+    this.stepStartTime = endTime;
+  }
+}
+
+function telemetryAddStep(data: TelemetryData, i: number, id: string, title: string): TelemetryData {
+  const completeId = getStepCompleteId(i, id);
+  data.steps.push({ id: completeId, title, durationMs: 0, error: undefined });
+  return data;
+}
+
+function telemetrySetStepDuration(data: TelemetryData, i: number, stepId: string, ms: number): TelemetryData {
+  const completeId = getStepCompleteId(i, stepId);
+  console.log('step duration', completeId, ms);
+  const stepIndex = data.steps.findLastIndex(step => step.id === completeId);
+  if (stepIndex < 0) {
+    return data;
+  }
+  data.steps[stepIndex].durationMs = ms;
+  return data;
+}
+
+function telemetrySetStepError(data: TelemetryData, i: number, stepId: string, error: Error): TelemetryData {
+  const completeId = getStepCompleteId(i, stepId);
+  const stepIndex = data.steps.findLastIndex(step => step.id === completeId);
+  if (stepIndex < 0) {
+    return data;
+  }
+  data.steps[stepIndex].error = String(error);
+  return data;
+}
+
+function telemetryToSend(data: TelemetryData) {
+  if (data.skipped) {
+    data.skipAtStep = data.steps[data.steps.length - 1].id;
+  }
+  data.stepsDetails = {};
+  data.errors = [];
+  for (let i = 0; i < data.steps.length; i++) {
+    const step = data.steps[i];
+    if (!data.stepsDetails[step.id]) {
+      data.stepsDetails[step.id] = {
+        count: 0,
+        durationMs: [],
+        errors: [],
+      };
+    }
+    data.stepsDetails[step.id].count++;
+    data.stepsDetails[step.id].durationMs.push(step.durationMs);
+    if (step.error) {
+      data.stepsDetails[step.id].errors.push(step.error);
+      data.errors.push(`${step.error} [${step.title}]`);
+    }
+  }
+  console.log('data', data);
+  return data;
+}
+
+function getStepCompleteId(i: number, stepId: string): string {
+  return String(i).padStart(2, '0') + '_' + stepId;
+}

--- a/packages/renderer/src/lib/onboarding/telemetry.ts
+++ b/packages/renderer/src/lib/onboarding/telemetry.ts
@@ -83,7 +83,6 @@ function telemetryAddStep(data: TelemetryData, i: number, id: string, title: str
 
 function telemetrySetStepDuration(data: TelemetryData, i: number, stepId: string, ms: number): TelemetryData {
   const completeId = getStepCompleteId(i, stepId);
-  console.log('step duration', completeId, ms);
   const stepIndex = data.steps.findLastIndex(step => step.id === completeId);
   if (stepIndex < 0) {
     return data;
@@ -124,7 +123,6 @@ function telemetryToSend(data: TelemetryData) {
       data.errors.push(`${step.error} [${step.title}]`);
     }
   }
-  console.log('data', data);
   return data;
 }
 

--- a/packages/renderer/src/lib/onboarding/telemetry.ts
+++ b/packages/renderer/src/lib/onboarding/telemetry.ts
@@ -1,22 +1,22 @@
-export interface TelemetryStep {
+export interface OnboardingTelemetryStep {
   id: string;
   title: string;
   durationMs: number;
   error: undefined | string;
 }
 
-export interface TelemetryData {
+export interface OnboardingTelemetryData {
   extension: string;
   skipped: boolean;
-  steps: TelemetryStep[];
+  steps: OnboardingTelemetryStep[];
   stepsDetails?: any;
   durationMs: number;
   skipAtStep?: string;
   errors?: string[];
 }
 
-export class TelemetrySession {
-  private data: TelemetryData;
+export class OnboardingTelemetrySession {
+  private data: OnboardingTelemetryData;
   private onboardingStartTime: number;
   private stepStartTime: number;
   private previousStepIndex: number;
@@ -78,13 +78,23 @@ export class TelemetrySession {
   }
 }
 
-function telemetryAddStep(data: TelemetryData, i: number, id: string, title: string): TelemetryData {
+function telemetryAddStep(
+  data: OnboardingTelemetryData,
+  i: number,
+  id: string,
+  title: string,
+): OnboardingTelemetryData {
   const completeId = getStepCompleteId(i, id);
   data.steps.push({ id: completeId, title, durationMs: 0, error: undefined });
   return data;
 }
 
-function telemetrySetStepDuration(data: TelemetryData, i: number, stepId: string, ms: number): TelemetryData {
+function telemetrySetStepDuration(
+  data: OnboardingTelemetryData,
+  i: number,
+  stepId: string,
+  ms: number,
+): OnboardingTelemetryData {
   const completeId = getStepCompleteId(i, stepId);
   const stepIndex = data.steps.findLastIndex(step => step.id === completeId);
   if (stepIndex < 0) {
@@ -94,7 +104,12 @@ function telemetrySetStepDuration(data: TelemetryData, i: number, stepId: string
   return data;
 }
 
-function telemetrySetStepError(data: TelemetryData, i: number, stepId: string, error: Error): TelemetryData {
+function telemetrySetStepError(
+  data: OnboardingTelemetryData,
+  i: number,
+  stepId: string,
+  error: Error,
+): OnboardingTelemetryData {
   const completeId = getStepCompleteId(i, stepId);
   const stepIndex = data.steps.findLastIndex(step => step.id === completeId);
   if (stepIndex < 0) {
@@ -104,7 +119,7 @@ function telemetrySetStepError(data: TelemetryData, i: number, stepId: string, e
   return data;
 }
 
-function telemetryToSend(data: TelemetryData) {
+function telemetryToSend(data: OnboardingTelemetryData) {
   if (data.skipped) {
     data.skipAtStep = data.steps[data.steps.length - 1].id;
   }

--- a/packages/renderer/src/lib/onboarding/telemetry.ts
+++ b/packages/renderer/src/lib/onboarding/telemetry.ts
@@ -42,6 +42,9 @@ export class TelemetrySession {
   }
 
   startStep(i: number, id: string, title: string) {
+    if (id === this.previousStepId) {
+      return;
+    }
     if (this.previousStepIndex >= 0) {
       this.savePreviousDuration();
     }


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

This PR makes Podman Desktop send bundled telemetry when an onboarding session terminates, either correctly or canceled.

The data sent to the telemetry is the list of steps done during the onboarding.

When an error occurs during a step, the Error is added to the step information.

The duration for each step and for the entire onboarding session is given.

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast 
explaining what is doing this PR -->

### What issues does this PR fix or reference?

Fixes #4590 

### How to test this PR?

Run any onboarding, and check the data sent to telemetry at the end of the onboarding session.