### PR TITLE
chore: skip video rendering when taking screenshots

### DIFF
--- a/website-argos/screenshot.css
+++ b/website-argos/screenshot.css
@@ -17,3 +17,10 @@ img[src$='.gif'],
 .docusaurus-mermaid-container {
   display: none;
 }
+
+/* Hide the video element that usually contains 'loading' spinner */
+video {
+  visibility: hidden;
+  height: 0px !important;
+  width: 0px !important;
+}


### PR DESCRIPTION
### What does this PR do?
when taking screenshots, some videos may still be in loading state and then there is a spinner displayed inside
as we compare screenshots, spinner can be at a different state, so it's better to not display them when comparing screenshots


### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast 
explaining what is doing this PR -->

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/4741

### How to test this PR?

look at the screenshot, videos should be hidden