### PR TITLE
chore: add stores to kubernetes contexts

### DIFF
--- a/packages/main/src/plugin/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes-client.ts
@@ -185,6 +185,9 @@ export class KubernetesClient {
     });
   }
 
+  // The below methods (update, create, delete)
+  // help send information to the renderer process to notify any
+  // stores (in particular kube context store) as well as extensions (extensions/kube-context)
   setupWatcher(kubeconfigFile: string): void {
     // cancel the previous one (if any)
     this.kubeConfigWatcher?.dispose();
@@ -198,6 +201,7 @@ export class KubernetesClient {
     this.kubeConfigWatcher.onDidChange(async () => {
       this._onDidUpdateKubeconfig.fire({ type: 'UPDATE', location });
       await this.refresh();
+      this.apiSender.send('kubernetes-context-update');
     });
 
     this.kubeConfigWatcher.onDidCreate(async () => {

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.spec.ts
@@ -17,33 +17,34 @@
  ***********************************************************************/
 
 import '@testing-library/jest-dom/vitest';
-import { expect, test, vi } from 'vitest';
+import { beforeAll, expect, test, vi } from 'vitest';
 import { render, screen } from '@testing-library/svelte';
 import PreferencesKubernetesContextsRendering from './PreferencesKubernetesContextsRendering.svelte';
-import type { Cluster, Context } from '@kubernetes/client-node';
+import { kubernetesContexts } from '/@/stores/kubernetes-contexts';
+import type { KubeContextUI } from '../kube/KubeContextUI';
 
-// Create a fake Context
-const mockContext = {
+// Create a fake KubeContextUI
+const mockContext: KubeContextUI = {
   name: 'context-name',
   cluster: 'cluster-name',
   user: 'user-name',
-  namespace: 'namespace-name',
-} as Context;
+  clusterInfo: {
+    name: 'cluster-name',
+    server: 'https://server-name',
+  },
+};
 
-// Create a fake Cluster
-const mockCluster = {
-  name: 'cluster-name',
-  server: 'server-name',
-} as Cluster;
+beforeAll(() => {
+  kubernetesContexts.set([mockContext]);
+});
 
 test('test that name, cluster and the server is displayed when rendering', async () => {
-  (window as any).kubernetesGetContexts = vi.fn().mockResolvedValue([mockContext]);
-  (window as any).kubernetesGetClusters = vi.fn().mockResolvedValue([mockCluster]);
   (window as any).kubernetesGetCurrentContextName = vi.fn().mockResolvedValue('my-current-context');
   render(PreferencesKubernetesContextsRendering, {});
   expect(await screen.findByText('context-name')).toBeInTheDocument();
   expect(await screen.findByText('cluster-name')).toBeInTheDocument();
-  expect(await screen.findByText('server-name')).toBeInTheDocument();
+  expect(await screen.findByText('user-name')).toBeInTheDocument();
+  expect(await screen.findByText('https://server-name')).toBeInTheDocument();
 });
 
 test('If nothing is returned for contexts, expect that the page shows a message', async () => {

--- a/packages/renderer/src/stores/event-store.ts
+++ b/packages/renderer/src/stores/event-store.ts
@@ -76,11 +76,29 @@ export class EventStore<T> {
 
   constructor(
     private name: string,
+
+    // The store to actually update / return the data
     private store: Writable<T>,
+
+    // This is the "check" function that will be called to check if we need to update the store
+    // this is good for checking to see if all extensions have started or waiting for a specific event
+    // to occur before proceeding
     private checkForUpdate: (eventName: string, args?: unknown[]) => Promise<boolean>,
+
+    // The list of window events and listeners to listen for to trigger an update, for example:
+    // Window event: 'extension-started'
+    // Window listener: 'extensions-already-started''
     private windowEvents: string[],
     private windowListeners: string[],
+
+    // The main "updater" function that will be called to update the store.
+    // For example, you can pass in a custom function such as "grabAllPods"
+    // or a function with parameters such as "fetchPodsForNamespace(namespace: string)"
+    // or even a simple window call such as "window.listPods()"
+    // Whatever is returned from the "updater" function will be set to the writeable store above.
     private updater: (...args: unknown[]) => Promise<T>,
+
+    // Optional icon component to display in the UI
     private iconComponent?: ComponentType,
   ) {
     if (!iconComponent) {

--- a/packages/renderer/src/stores/kubernetes-contexts.ts
+++ b/packages/renderer/src/stores/kubernetes-contexts.ts
@@ -1,0 +1,56 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { writable, type Writable } from 'svelte/store';
+import { EventStore } from './event-store';
+import { getKubeUIContexts, type KubeContextUI } from '../lib/kube/KubeContextUI';
+
+const windowEvents: string[] = ['extensions-started', 'kubernetes-context-update'];
+const windowListeners = ['extensions-already-started'];
+
+// Do not update until all extensions are started (since we want to make sure kube-context has been loaded)
+let readyToUpdate = false;
+export async function checkForUpdate(eventName: string): Promise<boolean> {
+  if ('extensions-already-started' === eventName) {
+    readyToUpdate = true;
+  }
+
+  // do not fetch until extensions are all started
+  return readyToUpdate;
+}
+
+export const kubernetesContexts: Writable<KubeContextUI[]> = writable([]);
+
+const eventStore = new EventStore<KubeContextUI[]>(
+  'kubernetes contexts',
+  kubernetesContexts,
+  checkForUpdate,
+  windowEvents,
+  windowListeners,
+  grabKubernetesContexts,
+);
+eventStore.setup();
+
+export async function grabKubernetesContexts(): Promise<KubeContextUI[]> {
+  // Retrieve both the contexts and clusters
+  const k8sContexts = await window.kubernetesGetContexts();
+  const k8sClusters = await window.kubernetesGetClusters();
+
+  // Convert them to KubeContextUI so we can safely render them.
+  return getKubeUIContexts(k8sContexts, k8sClusters);
+}


### PR DESCRIPTION
chore: add stores to kubernetes contexts

### What does this PR do?
* Adds apiSender events for Kubernetes context changes
* Switches kubernetes contexts to a store
* Changes are reactive / reflective when changes have been made to the
  ~/.kube/config

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast
explaining what is doing this PR -->

https://github.com/containers/podman-desktop/assets/6422176/84e440d8-2d2d-4a41-88e5-8149cba4e2b6




### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes #4688

### How to test this PR?

<!-- Please explain steps to reproduce -->

1. View your Kubernetes context via Podman Desktop
2. Make changes to your .kube/config and you should see them change on
   PD.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
