### PR TITLE
nit: fix alignment of age on containers page

### DIFF
--- a/packages/renderer/src/lib/container/ContainerList.svelte
+++ b/packages/renderer/src/lib/container/ContainerList.svelte
@@ -557,7 +557,7 @@ function setStoppedFilter() {
                 <div class="flex items-center text-xs p-1 rounded-md text-gray-500"></div>
               </td>
               <td class="px-6 py-2 whitespace-nowrap w-10"> </td>
-              <td class="whitespace-nowrap pl-4">
+              <td class="whitespace-nowrap pl-3">
                 <div class="flex items-center">
                   <div class="text-sm text-gray-700"></div>
                 </div>
@@ -654,7 +654,7 @@ function setStoppedFilter() {
                       {container.shortImage}
                     </div>
                   </div></td>
-                <td class="whitespace-nowrap pl-4">
+                <td class="whitespace-nowrap pl-3">
                   <div class="flex items-center">
                     <div class="text-sm text-gray-700">
                       <StateChange state="{container.state}">{container.uptime}</StateChange>


### PR DESCRIPTION
nit: fix alignment of age on containers page

### What does this PR do?

Fixes the slight misalignment of age. It should be `pl-3` to it aligns
to "Age" table header, similar to the other columns.

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast
explaining what is doing this PR -->

See aligned one (top) vs unaligned (bottom)

![Screenshot 2023-11-09 at 10 54 58 PM](https://github.com/containers/podman-desktop/assets/6422176/59af14d4-671c-45a3-a4e4-506b47a191ed)



### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

N/A

### How to test this PR?

<!-- Please explain steps to reproduce -->

`yarn watch`

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
