### PR TITLE
chore: delay screenshots on downloads page

### DIFF
--- a/.github/workflows/argos.yaml
+++ b/.github/workflows/argos.yaml
@@ -26,6 +26,7 @@ on:
       - 'package.json'
       - 'yarn.lock'
       - 'website/**'
+      - 'website-argos/**'
   pull_request:
     branches:
       - main
@@ -33,6 +34,7 @@ on:
       - 'package.json'
       - 'yarn.lock'
       - 'website/**'
+      - 'website-argos/**'
 
 jobs:
   take-screenshots:

--- a/website-argos/screenshot.spec.ts
+++ b/website-argos/screenshot.spec.ts
@@ -40,6 +40,13 @@ function screenshotPathname(pathname: string) {
     const url = siteUrl + pathname;
     await page.goto(url);
     await page.waitForFunction(waitForDocusaurusHydration);
+
+    // for downloads page, wait for the version being fetched
+    if (pathname.includes('/downloads')) {
+      // wait for the version being fetched during 5seconds using async setTimeout
+      await new Promise(resolve => setTimeout(resolve, 5000));
+    }
+
     await page.addStyleTag({ content: stylesheet });
     await argosScreenshot(page, pathnameToArgosName(pathname));
   });


### PR DESCRIPTION
### What does this PR do?
it takes time to refresh the UI to add version numbers
And if screenshot is made too soon, we have a delta in screenshots

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast 
explaining what is doing this PR -->

### What issues does this PR fix or reference?

False positive in changes on argos-ci.com
example: https://app.argos-ci.com/containers/podman-desktop/builds/16/64367957
### How to test this PR?

<!-- Please explain steps to reproduce -->
