### PR TITLE
fix: report metrics for stopped machines

### DIFF
--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -169,15 +169,19 @@ export async function updateMachines(provider: extensionApi.Provider): Promise<v
     const userModeNetworking = isWindows() ? machine.UserModeNetworking : true;
     podmanMachinesInfo.set(machine.Name, {
       name: machine.Name,
-      memory: machineInfo ? machineInfo?.memory : Number(machine.Memory),
-      cpus: machineInfo ? machineInfo?.cpus : machine.CPUs,
-      diskSize: machineInfo ? machineInfo?.diskSize : Number(machine.DiskSize),
+      memory: machineInfo ? machineInfo.memory : Number(machine.Memory),
+      cpus: machineInfo ? machineInfo.cpus : machine.CPUs,
+      diskSize: machineInfo ? machineInfo.diskSize : Number(machine.DiskSize),
       userModeNetworking: userModeNetworking,
-      cpuUsage: machineInfo?.cpuIdle ? 100 - machineInfo?.cpuIdle : 0,
+      cpuUsage: machineInfo?.cpuIdle !== undefined ? 100 - machineInfo?.cpuIdle : 0,
       diskUsage:
-        machineInfo?.diskUsed && machineInfo?.diskSize ? (machineInfo?.diskUsed * 100) / machineInfo?.diskSize : 0,
+        machineInfo?.diskUsed !== undefined && machineInfo?.diskSize > 0
+          ? (machineInfo?.diskUsed * 100) / machineInfo?.diskSize
+          : 0,
       memoryUsage:
-        machineInfo?.memory && machineInfo?.memoryUsed ? (machineInfo?.memoryUsed * 100) / machineInfo?.memory : 0,
+        machineInfo?.memory !== undefined && machineInfo?.memoryUsed > 0
+          ? (machineInfo?.memoryUsed * 100) / machineInfo?.memory
+          : 0,
     });
 
     if (!podmanMachinesStatuses.has(machine.Name)) {

--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -116,7 +116,7 @@ export type MachineInfo = {
   memoryUsage: number;
 };
 
-async function updateMachines(provider: extensionApi.Provider): Promise<void> {
+export async function updateMachines(provider: extensionApi.Provider): Promise<void> {
   // init machines available
   let machineListOutput: string;
   try {
@@ -169,9 +169,9 @@ async function updateMachines(provider: extensionApi.Provider): Promise<void> {
     const userModeNetworking = isWindows() ? machine.UserModeNetworking : true;
     podmanMachinesInfo.set(machine.Name, {
       name: machine.Name,
-      memory: machineInfo?.memory,
-      cpus: machineInfo?.cpus,
-      diskSize: machineInfo?.diskSize,
+      memory: machineInfo ? machineInfo?.memory : Number(machine.Memory),
+      cpus: machineInfo ? machineInfo?.cpus : machine.CPUs,
+      diskSize: machineInfo ? machineInfo?.diskSize : Number(machine.DiskSize),
       userModeNetworking: userModeNetworking,
       cpuUsage: machineInfo?.cpuIdle ? 100 - machineInfo?.cpuIdle : 0,
       diskUsage:
@@ -626,7 +626,9 @@ async function registerProviderFor(provider: extensionApi.Provider, machineInfo:
   await containerConfiguration.update('machine.cpus', machineInfo.cpus);
   await containerConfiguration.update('machine.memory', machineInfo.memory);
   await containerConfiguration.update('machine.diskSize', machineInfo.diskSize);
-  await containerConfiguration.update('machine.cpuUsage', machineInfo.cpuUsage);
+  await containerConfiguration.update('machine.cpusUsage', machineInfo.cpuUsage);
+  await containerConfiguration.update('machine.memoryUsage', machineInfo.memoryUsage);
+  await containerConfiguration.update('machine.diskSizeUsage', machineInfo.diskUsage);
 
   currentConnections.set(machineInfo.name, disposable);
   storedExtensionContext.subscriptions.push(disposable);
@@ -754,8 +756,12 @@ export function initTelemetryLogger(): void {
   telemetryLogger = extensionApi.env.createTelemetryLogger();
 }
 
-export async function activate(extensionContext: extensionApi.ExtensionContext): Promise<void> {
+export function initExtensionContext(extensionContext: extensionApi.ExtensionContext) {
   storedExtensionContext = extensionContext;
+}
+
+export async function activate(extensionContext: extensionApi.ExtensionContext): Promise<void> {
+  initExtensionContext(extensionContext);
 
   initTelemetryLogger();
 

--- a/packages/main/src/plugin/configuration-impl.ts
+++ b/packages/main/src/plugin/configuration-impl.ts
@@ -53,7 +53,7 @@ export class ConfigurationImpl implements containerDesktopAPI.Configuration {
 
     // now look if we have this value
     const localView = this.getLocalView();
-    if (localView[localKey]) {
+    if (localView[localKey] !== undefined) {
       return localView[localKey];
     } else if (defaultValue) {
       // not there but we have a default value, then return it

--- a/packages/renderer/src/lib/donut/Donut.svelte
+++ b/packages/renderer/src/lib/donut/Donut.svelte
@@ -43,6 +43,6 @@ $: tooltip = percent ? percent.toFixed(0) + '% ' + title + ' usage' : '';
       text-anchor="middle"
       font-size="{size / 4.5}"
       dominant-baseline="central"
-      class="fill-gray-400">{value || ''}</text>
+      class="fill-gray-400">{value !== undefined ? value : ''}</text>
   </svg>
 </Tooltip>


### PR DESCRIPTION
Fixes #4224

### What does this PR do?

Reports machine info in donuts when machine is stopped

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast 
explaining what is doing this PR -->

### What issues does this PR fix or reference?

Fixes #4224

<!-- Include any related issues from Podman Desktop 
repository (or from another issue tracker). -->

### How to test this PR?

1. Create a machine (do not ask to start it)
2. Go to the resources pages
3. There should be donuts for cpu, memory and disk

<!-- Please explain steps to reproduce -->
