### PR TITLE
fix: remove fixed height after patternfly removal

### DIFF
--- a/packages/renderer/src/lib/container/ContainerList.svelte
+++ b/packages/renderer/src/lib/container/ContainerList.svelte
@@ -714,7 +714,7 @@ function setStoppedFilter() {
       openChoiceModal = false;
     }}">
     <button
-      class="inline-block w-full overflow-hidden text-left transition-all transform bg-charcoal-600 z-50 h-[200px] rounded-xl shadow-xl shadow-charcoal-900"
+      class="inline-block w-full overflow-hidden text-left transition-all transform bg-charcoal-600 z-50 rounded-xl shadow-xl shadow-charcoal-900"
       on:keydown="{keydownChoice}">
       <div class="flex items-center justify-between bg-black px-5 py-4 border-b-2 border-violet-700">
         <h1 class="text-xl font-bold">Create a new container</h1>


### PR DESCRIPTION

### What does this PR do?
let the height being computed automatically

some modal have a height being hardcoded, while in some other locations we don't specify it

### Screenshot/screencast of this PR
before
![image](https://github.com/containers/podman-desktop/assets/436777/d0f28843-353d-48d5-b59e-baebd94e08d4)


after:
![image](https://github.com/containers/podman-desktop/assets/436777/59d12bda-05a3-4ec3-8b51-cc19b01f362b)



### What issues does this PR fix or reference?

https://github.com/containers/podman-desktop/pull/4762

### How to test this PR?

<!-- Please explain steps to reproduce -->
