### PR TITLE
fix: reconnect to /events if disconnected

### DIFF
--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -16,6 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { Mock } from 'vitest';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import type { InternalContainerProvider } from '/@/plugin/container-registry.js';
 import { ContainerProviderRegistry } from '/@/plugin/container-registry.js';
@@ -143,6 +144,10 @@ class TestContainerProviderRegistry extends ContainerProviderRegistry {
 
   setStreamsPerContainerId(id: string, data: NodeJS.ReadWriteStream) {
     this.streamsPerContainerId.set(id, data);
+  }
+
+  setRetryDelayEvents(delay: number): void {
+    super.retryDelayEvents = delay;
   }
 }
 
@@ -2209,4 +2214,88 @@ test('createNetwork', async () => {
 
   // check that it's calling the right nock method
   await containerRegistry.createNetwork(providerConnectionInfo, { Name: 'myNetwork' });
+});
+
+test('setupConnectionAPI with errors', async () => {
+  // create a stream that we return to nock
+  const stream = new PassThrough();
+  // need to reply with a stream
+  nock('http://localhost').get('/events').reply(200, stream);
+
+  const internalContainerProvider: InternalContainerProvider = {
+    name: 'podman',
+    id: 'podman1',
+    connection: {
+      type: 'podman',
+      name: 'podman',
+      endpoint: {
+        socketPath: 'http://localhost',
+      },
+      status: () => 'started',
+    },
+  };
+
+  const providerConnectionInfo: podmanDesktopAPI.ContainerProviderConnection = {
+    name: 'podman',
+    type: 'podman',
+    endpoint: {
+      socketPath: '/endpoint1.sock',
+    },
+    status: () => 'started',
+  };
+
+  // check that api is being added
+  expect(internalContainerProvider.api).toBeUndefined();
+  expect(internalContainerProvider.libpodApi).toBeUndefined();
+  containerRegistry.setupConnectionAPI(internalContainerProvider, providerConnectionInfo);
+
+  // change delay of setRetryDelayEvents to be 200ms
+  containerRegistry.setRetryDelayEvents(200);
+
+  // wait 0.5s
+  await new Promise(resolve => setTimeout(resolve, 500));
+  expect(internalContainerProvider.api).toBeDefined();
+
+  // ok now send an error
+
+  // and send an error in the stream
+  stream.emit('error', new Error('my error'));
+  // close the stream
+  stream.end();
+
+  // we should not have the api anymore
+  expect(internalContainerProvider.api).toBeUndefined();
+
+  // and it should try to reconnect to the nock
+
+  // wait 0.5s
+  await new Promise(resolve => setTimeout(resolve, 500));
+
+  // mock again /events
+  const stream2 = new PassThrough();
+  nock('http://localhost').get('/events').reply(200, stream2);
+
+  // emit a container start event, we should proceed it as expected
+  const fakeId = '123456';
+  stream2.write(
+    JSON.stringify({
+      status: 'start',
+      Type: 'container',
+      id: fakeId,
+    }),
+  );
+  // check apiSender if we have a message 'container-started-event' with the right id
+  await new Promise(resolve => setTimeout(resolve, 1000));
+  expect(internalContainerProvider.api).toBeDefined();
+
+  // last call should be with the 'container-started-event' message
+  const allCalls = (apiSender.send as Mock).mock.calls;
+  expect(allCalls).toBeDefined();
+  const lastCall = allCalls[allCalls.length - 1];
+  expect(lastCall).toStrictEqual(['container-started-event', fakeId]);
+
+  stream2.end();
+
+  // it should have reconnect to the stream now and add again the api object
+  expect(internalContainerProvider.api).toBeDefined();
 });

--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -16,7 +16,6 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { Mock } from 'vitest';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import type { InternalContainerProvider } from '/@/plugin/container-registry.js';
 import { ContainerProviderRegistry } from '/@/plugin/container-registry.js';
@@ -2289,7 +2288,7 @@ test('setupConnectionAPI with errors', async () => {
   expect(internalContainerProvider.api).toBeDefined();
 
   // last call should be with the 'container-started-event' message
-  const allCalls = (apiSender.send as Mock).mock.calls;
+  const allCalls = vi.mocked(apiSender.send).mock.calls;
   expect(allCalls).toBeDefined();
   const lastCall = allCalls[allCalls.length - 1];
   expect(lastCall).toStrictEqual(['container-started-event', fakeId]);

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -90,6 +90,9 @@ export class ContainerProviderRegistry {
   private readonly _onEvent = new Emitter<JSONEvent>();
   readonly onEvent: Event<JSONEvent> = this._onEvent.event;
 
+  // delay in ms before retrying to connect to the provider when /events connection fails
+  protected retryDelayEvents: number = 5000;
+
   private envfileParser = new EnvfileParser();
 
   constructor(
@@ -111,7 +114,7 @@ export class ContainerProviderRegistry {
   protected streamsPerContainerId: Map<string, NodeJS.ReadWriteStream> = new Map();
   protected streamsOutputPerContainerId: Map<string, Buffer[]> = new Map();
 
-  handleEvents(api: Dockerode) {
+  handleEvents(api: Dockerode, errorCallback: (error: Error) => void) {
     const eventEmitter = new EventEmitter();
 
     eventEmitter.on('event', (jsonEvent: JSONEvent) => {
@@ -163,7 +166,15 @@ export class ContainerProviderRegistry {
     api.getEvents((err, stream) => {
       if (err) {
         console.log('error is', err);
+        errorCallback(new Error('Error in handling events', err));
       }
+
+      stream?.on('error', error => {
+        console.error('/event stream received an error.', error);
+        // notify the error (do not throw as we're inside handlers/callbacks)
+        errorCallback(new Error('Error in handling events', error));
+      });
+
       const pipeline = stream?.pipe(StreamValues.withParser());
       pipeline?.on('error', error => {
         console.error('Error while parsing events', error);
@@ -210,11 +221,33 @@ export class ContainerProviderRegistry {
     internalProvider: InternalContainerProvider,
     containerProviderConnection: containerDesktopAPI.ContainerProviderConnection,
   ) {
+    // abort if connection is stopped
+    if (containerProviderConnection.status() === 'stopped') {
+      console.log('Aborting reconnect due to error as connection is now stopped');
+      return;
+    }
+
     internalProvider.api = new Dockerode({ socketPath: containerProviderConnection.endpoint.socketPath });
     if (containerProviderConnection.type === 'podman') {
       internalProvider.libpodApi = internalProvider.api as unknown as LibPod;
     }
-    this.handleEvents(internalProvider.api);
+
+    // in case of errors reported during handling events like the connection is aborted, etc.
+    // we need to reconnect the provider
+    const errorHandler = (error: Error) => {
+      console.warn('Error when handling events', error, 'Will reconnect in 5s', error);
+      internalProvider.api = undefined;
+      internalProvider.libpodApi = undefined;
+
+      // ok we had some errors so we need to reconnect the provider
+      // delay the reconnection to avoid too many reconnections
+      // retry in 5 seconds
+      setTimeout(() => {
+        this.setupConnectionAPI(internalProvider, containerProviderConnection);
+      }, this.retryDelayEvents);
+    };
+
+    this.handleEvents(internalProvider.api, errorHandler);
     this.apiSender.send('provider-change', {});
   }
 


### PR DESCRIPTION
### What does this PR do?
When a provider is added, we establish a connection to `/events` REST API handler.
but if provider is not restarted and ping is still replying, we could have been disconnected from this stream.
It might happen if machine is restarting or some network issues.
In that case, re-establish the connection to the events so UI is properly refreshed. Because without events, we do not refresh the UI automatically

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/4712

### How to test this PR?

hard to test but I've added a unit test

you can for example to test, drop the update of the status in podman extension so you can do 'podman machine stop' wait and then 'podman machine start' and it'll reconnect
you should see mesages in the dev console that event connection has been dropped



Signed-off-by: Florent Benoit <fbenoit@redhat.com>
