### PR TITLE
feat: display notification on task manager (#4406)

### DIFF
--- a/packages/main/src/plugin/api/notification.ts
+++ b/packages/main/src/plugin/api/notification.ts
@@ -18,15 +18,18 @@
 
 type NotificationType = 'info' | 'warn' | 'error';
 
-export interface NotificationCardOptions {
-  extensionId: string;
+export interface NotificationInfo {
   // title displayed on the top of the notification card
   title: string;
   // description displayed just below the title, it should explain what the notification is about
   body?: string;
-  type: NotificationType;
   // displayed below the description, centered in the notification card. It may contains actions (like commands/buttons and links)
   markdownActions?: string;
+}
+
+export interface NotificationCardOptions extends NotificationInfo {
+  extensionId: string;
+  type: NotificationType;
   // the notification will be added to the dashboard queue
   highlight?: boolean;
   // whether or not to emit an OS notification noise when showing the notification.

--- a/packages/main/src/plugin/api/task.ts
+++ b/packages/main/src/plugin/api/task.ts
@@ -23,9 +23,17 @@ export interface Task {
   id: string;
   name: string;
   started: number;
+}
+
+export interface StatefulTask extends Task {
   state: TaskState;
   status: TaskStatus;
   progress?: number;
   gotoTask?: () => void;
   error?: string;
+}
+
+export interface NotificationTask extends Task {
+  description: string;
+  markdownActions?: string;
 }

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -397,6 +397,8 @@ export class PluginSystem {
 
     const exec = new Exec(proxy);
 
+    const taskManager = new TaskManager(apiSender);
+
     const commandRegistry = new CommandRegistry(apiSender, telemetry);
     const menuRegistry = new MenuRegistry(commandRegistry);
     const kubeGeneratorRegistry = new KubeGeneratorRegistry();
@@ -414,7 +416,7 @@ export class PluginSystem {
     const fileSystemMonitoring = new FilesystemMonitoring();
     const customPickRegistry = new CustomPickRegistry(apiSender);
     const onboardingRegistry = new OnboardingRegistry(configurationRegistry, context);
-    const notificationRegistry = new NotificationRegistry(apiSender);
+    const notificationRegistry = new NotificationRegistry(apiSender, taskManager);
     const kubernetesClient = new KubernetesClient(apiSender, configurationRegistry, fileSystemMonitoring, telemetry);
     await kubernetesClient.init();
     const closeBehaviorConfiguration = new CloseBehavior(configurationRegistry);
@@ -711,8 +713,6 @@ export class PluginSystem {
     const messageBox = new MessageBox(apiSender);
 
     const authentication = new AuthenticationImpl(apiSender);
-
-    const taskManager = new TaskManager(apiSender);
 
     const cliToolRegistry = new CliToolRegistry(apiSender, exec, telemetry);
 

--- a/packages/main/src/plugin/notification-registry.spec.ts
+++ b/packages/main/src/plugin/notification-registry.spec.ts
@@ -20,16 +20,19 @@ import { beforeEach, expect, test, vi } from 'vitest';
 import type { ApiSenderType } from './api.js';
 import type { Disposable } from './types/disposable.js';
 import { NotificationRegistry } from './notification-registry.js';
+import type { TaskManager } from './task-manager.js';
 
 let notificationRegistry: NotificationRegistry;
 const extensionId = 'myextension.id';
 const apiSender: ApiSenderType = { send: vi.fn() } as unknown as ApiSenderType;
+const createNotificationtaskMock = vi.fn();
+const taskManager: TaskManager = { createNotificationTask: createNotificationtaskMock } as unknown as TaskManager;
 
 let registerNotificationDisposable: Disposable;
 
 /* eslint-disable @typescript-eslint/no-empty-function */
 beforeEach(() => {
-  notificationRegistry = new NotificationRegistry(apiSender);
+  notificationRegistry = new NotificationRegistry(apiSender, taskManager);
   registerNotificationDisposable = notificationRegistry.registerExtension(extensionId);
 });
 
@@ -61,6 +64,10 @@ test('expect notification added to the queue', async () => {
   expect(queue[0].extensionId).toEqual(extensionId);
   expect(queue[0].title).toEqual('title');
   expect(queue[0].type).toEqual('info');
+  expect(createNotificationtaskMock).toBeCalledWith({
+    title: 'title',
+    body: 'description',
+  });
 });
 
 test('expect latest added notification is in top of the queue', async () => {

--- a/packages/main/src/plugin/notification-registry.ts
+++ b/packages/main/src/plugin/notification-registry.ts
@@ -22,12 +22,16 @@ import { Notification } from 'electron';
 import type { ApiSenderType } from './api.js';
 import { Disposable } from './types/disposable.js';
 import type * as containerDesktopAPI from '@podman-desktop/api';
+import type { TaskManager } from './task-manager.js';
 
 export class NotificationRegistry {
   private notificationId = 0;
   private notificationQueue: NotificationCard[] = [];
 
-  constructor(private apiSender: ApiSenderType) {}
+  constructor(
+    private apiSender: ApiSenderType,
+    private taskManager: TaskManager,
+  ) {}
 
   registerExtension(extensionId: string): Disposable {
     return Disposable.create(() => {
@@ -45,6 +49,8 @@ export class NotificationRegistry {
     this.notificationQueue.unshift(notification);
     // send event
     this.apiSender.send('notifications-updated');
+    // create task
+    this.taskManager.createNotificationTask(notification.title, notification.body, notification.markdownActions);
     // we show the notification
     const disposeShowNotification = this.showNotification({
       title: notification.title,

--- a/packages/main/src/plugin/notification-registry.ts
+++ b/packages/main/src/plugin/notification-registry.ts
@@ -50,7 +50,11 @@ export class NotificationRegistry {
     // send event
     this.apiSender.send('notifications-updated');
     // create task
-    this.taskManager.createNotificationTask(notification.title, notification.body, notification.markdownActions);
+    this.taskManager.createNotificationTask({
+      title: notification.title,
+      body: notification.body,
+      markdownActions: notification.markdownActions,
+    });
     // we show the notification
     const disposeShowNotification = this.showNotification({
       title: notification.title,

--- a/packages/main/src/plugin/task-manager.spec.ts
+++ b/packages/main/src/plugin/task-manager.spec.ts
@@ -1,0 +1,171 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { expect, test, vi } from 'vitest';
+import { TaskManager } from './task-manager.js';
+import type { ApiSenderType } from './api.js';
+
+const apiSenderSendMock = vi.fn();
+
+const apiSender = {
+  send: apiSenderSendMock,
+} as unknown as ApiSenderType;
+
+test('create stateful task with title', async () => {
+  const taskManager = new TaskManager(apiSender);
+  const task = taskManager.createTask('title');
+  expect(task.id).equal('main-1');
+  expect(task.name).equal('title');
+  expect(task.state).equal('running');
+  expect(task.status).equal('in-progress');
+  expect(apiSenderSendMock).toBeCalledWith('task-created', task);
+});
+
+test('create stateful task without title', async () => {
+  const taskManager = new TaskManager(apiSender);
+  const task = taskManager.createTask(undefined);
+  expect(task.id).equal('main-1');
+  expect(task.name).equal('Task 1');
+  expect(task.state).equal('running');
+  expect(task.status).equal('in-progress');
+  expect(apiSenderSendMock).toBeCalledWith('task-created', task);
+});
+
+test('create multiple stateful tasks with title', async () => {
+  const taskManager = new TaskManager(apiSender);
+  const task = taskManager.createTask('title');
+  expect(task.id).equal('main-1');
+  expect(task.name).equal('title');
+  expect(task.state).equal('running');
+  expect(task.status).equal('in-progress');
+  expect(apiSenderSendMock).toBeCalledWith('task-created', task);
+
+  const task2 = taskManager.createTask('another title');
+  expect(task2.id).equal('main-2');
+  expect(task2.name).equal('another title');
+  expect(task2.state).equal('running');
+  expect(task2.status).equal('in-progress');
+  expect(apiSenderSendMock).toBeCalledWith('task-created', task2);
+
+  const task3 = taskManager.createTask('third title');
+  expect(task3.id).equal('main-3');
+  expect(task3.name).equal('third title');
+  expect(task3.state).equal('running');
+  expect(task3.status).equal('in-progress');
+  expect(apiSenderSendMock).toBeCalledWith('task-created', task3);
+});
+
+test('create notification task with body', async () => {
+  const taskManager = new TaskManager(apiSender);
+  const task = taskManager.createNotificationTask({
+    title: 'title',
+    body: 'body',
+  });
+  expect(task.id).equal('main-1');
+  expect(task.name).equal('title');
+  expect(task.description).equal('body');
+  expect(task.markdownActions).toBeUndefined();
+  expect(apiSenderSendMock).toBeCalledWith('task-created', task);
+});
+
+test('create stateful task without body', async () => {
+  const taskManager = new TaskManager(apiSender);
+  const task = taskManager.createNotificationTask({
+    title: 'title',
+  });
+  expect(task.id).equal('main-1');
+  expect(task.name).equal('title');
+  expect(task.description).equal('');
+  expect(task.markdownActions).toBeUndefined();
+  expect(apiSenderSendMock).toBeCalledWith('task-created', task);
+});
+
+test('create stateful task with markdown actions', async () => {
+  const taskManager = new TaskManager(apiSender);
+  const task = taskManager.createNotificationTask({
+    title: 'title',
+    markdownActions: 'action',
+  });
+  expect(task.id).equal('main-1');
+  expect(task.name).equal('title');
+  expect(task.description).equal('');
+  expect(task.markdownActions).equal('action');
+  expect(apiSenderSendMock).toBeCalledWith('task-created', task);
+});
+
+test('create multiple stateful tasks with title', async () => {
+  const taskManager = new TaskManager(apiSender);
+  const task = taskManager.createNotificationTask({
+    title: 'title',
+  });
+  expect(task.id).equal('main-1');
+  expect(task.name).equal('title');
+  expect(task.description).equal('');
+  expect(task.markdownActions).toBeUndefined();
+  expect(apiSenderSendMock).toBeCalledWith('task-created', task);
+
+  const task2 = taskManager.createNotificationTask({
+    title: 'second title',
+  });
+  expect(task2.id).equal('main-2');
+  expect(task2.name).equal('second title');
+  expect(task2.description).equal('');
+  expect(task2.markdownActions).toBeUndefined();
+  expect(apiSenderSendMock).toBeCalledWith('task-created', task2);
+
+  const task3 = taskManager.createNotificationTask({
+    title: 'third title',
+  });
+  expect(task3.id).equal('main-3');
+  expect(task3.name).equal('third title');
+  expect(task3.description).equal('');
+  expect(task3.markdownActions).toBeUndefined();
+  expect(apiSenderSendMock).toBeCalledWith('task-created', task3);
+});
+
+test('return true if statefulTask', async () => {
+  const taskManager = new TaskManager(apiSender);
+  const task = taskManager.createTask('title');
+  const result = taskManager.isStatefulTask(task);
+  expect(result).toBeTruthy();
+});
+
+test('return false if it is not a statefulTask', async () => {
+  const taskManager = new TaskManager(apiSender);
+  const task = taskManager.createNotificationTask({
+    title: 'title',
+  });
+  const result = taskManager.isStatefulTask(task);
+  expect(result).toBeFalsy();
+});
+
+test('return true if notificationTask', async () => {
+  const taskManager = new TaskManager(apiSender);
+  const task = taskManager.createNotificationTask({
+    title: 'title',
+  });
+  const result = taskManager.isNotificationTask(task);
+  expect(result).toBeTruthy();
+});
+
+test('return false if it is not a notificationTask', async () => {
+  const taskManager = new TaskManager(apiSender);
+  const task = taskManager.createTask('title');
+  const result = taskManager.isNotificationTask(task);
+  expect(result).toBeFalsy();
+});

--- a/packages/main/src/plugin/task-manager.ts
+++ b/packages/main/src/plugin/task-manager.ts
@@ -44,7 +44,7 @@ export class TaskManager {
     return task;
   }
 
-  public createNotificationTask(notificationInfo: NotificationInfo): Task {
+  public createNotificationTask(notificationInfo: NotificationInfo): NotificationTask {
     this.taskId++;
     const task: NotificationTask = {
       id: `main-${this.taskId}`,

--- a/packages/main/src/plugin/task-manager.ts
+++ b/packages/main/src/plugin/task-manager.ts
@@ -17,6 +17,7 @@
  ***********************************************************************/
 
 import type { ApiSenderType } from './api.js';
+import type { NotificationInfo } from './api/notification.js';
 import type { NotificationTask, StatefulTask, Task } from '/@/plugin/api/task.js';
 
 /**
@@ -43,18 +44,14 @@ export class TaskManager {
     return task;
   }
 
-  public createNotificationTask(
-    title: string | undefined,
-    description: string | undefined,
-    markdownActions: string | undefined,
-  ): Task {
+  public createNotificationTask(notificationInfo: NotificationInfo): Task {
     this.taskId++;
     const task: NotificationTask = {
       id: `main-${this.taskId}`,
-      name: title ? title : `Task ${this.taskId}`,
+      name: notificationInfo.title,
       started: new Date().getTime(),
-      description: description || '',
-      markdownActions: markdownActions,
+      description: notificationInfo.body || '',
+      markdownActions: notificationInfo.markdownActions,
     };
     this.tasks.set(task.id, task);
     this.apiSender.send('task-created', task);

--- a/packages/renderer/src/lib/image/build-image-task.ts
+++ b/packages/renderer/src/lib/image/build-image-task.ts
@@ -18,7 +18,7 @@
 
 import { router } from 'tinro';
 import { type BuildImageInfo, buildImagesInfo } from '/@/stores/build-images';
-import { createTask, removeTask } from '/@/stores/tasks';
+import { createTask, isStatefulTask, removeTask } from '/@/stores/tasks';
 import type { Task } from '../../../../main/src/plugin/api/task';
 
 export interface BuildImageCallback {
@@ -156,7 +156,7 @@ function getKey(): symbol {
 // anonymous function to collect events
 export function eventCollect(key: symbol, eventName: 'finish' | 'stream' | 'error', data: string): void {
   const task = allTasks.get(key);
-  if (task) {
+  if (task && isStatefulTask(task)) {
     if (eventName === 'error') {
       // If we errored out, we should store the error message in the task so it is correctly displayed
       task.error = data;

--- a/packages/renderer/src/lib/preferences/preferences-connection-rendering-task.ts
+++ b/packages/renderer/src/lib/preferences/preferences-connection-rendering-task.ts
@@ -20,7 +20,7 @@ import { createConnectionsInfo } from '/@/stores/create-connections';
 import { router } from 'tinro';
 
 import type { Logger as LoggerType } from '@podman-desktop/api';
-import { createTask, removeTask } from '/@/stores/tasks';
+import { createTask, isStatefulTask, removeTask } from '/@/stores/tasks';
 import type { Task } from '../../../../main/src/plugin/api/task';
 
 export interface ConnectionCallback extends LoggerType {
@@ -163,7 +163,7 @@ function getKey(): symbol {
 
 export function eventCollect(key: symbol, eventName: 'log' | 'warn' | 'error' | 'finish', args: string[]): void {
   const task = allTasks.get(key);
-  if (task) {
+  if (task && isStatefulTask(task)) {
     if (eventName === 'error') {
       task.status = 'failure';
       task.error = args.join('\n');

--- a/packages/renderer/src/lib/task-manager/TaskManager.spec.ts
+++ b/packages/renderer/src/lib/task-manager/TaskManager.spec.ts
@@ -22,7 +22,7 @@ import { fireEvent, render, screen } from '@testing-library/svelte';
 import TaskManager from './TaskManager.svelte';
 import userEvent from '@testing-library/user-event';
 import { tasksInfo } from '/@/stores/tasks';
-import type { StatefulTask } from '../../../../main/src/plugin/api/task';
+import type { NotificationTask, StatefulTask } from '../../../../main/src/plugin/api/task';
 
 // fake the window.events object
 beforeAll(() => {
@@ -42,6 +42,12 @@ const IN_PROGRESS_TASK: StatefulTask = {
   status: 'in-progress',
 };
 const SUCCEED_TASK: StatefulTask = { id: '1', name: 'Running Task 1', state: 'completed', started, status: 'success' };
+const NOTIFICATION_TASK: NotificationTask = {
+  id: '1',
+  name: 'Notification Task 1',
+  description: ' description',
+  started,
+};
 
 test('Expect that the tasks manager is hidden by default', async () => {
   render(TaskManager, {});
@@ -148,4 +154,45 @@ test('Expect click on faClose icon remove the task', async () => {
   // expect the task name is not visible
   const afterTask = screen.queryByText(SUCCEED_TASK.name);
   expect(afterTask).not.toBeInTheDocument();
+});
+
+test('Expect to have tasks when only having notification task', async () => {
+  tasksInfo.set([NOTIFICATION_TASK]);
+  render(TaskManager, { showTaskManager: true });
+
+  // expect the "You Have no Tasks" is not visible
+  const noTaskField = screen.queryByText('You have no tasks.');
+  expect(noTaskField).not.toBeInTheDocument();
+
+  // expect the task is visible
+  const task = screen.queryByText(NOTIFICATION_TASK.name);
+  expect(task).toBeInTheDocument();
+});
+
+test('Expect clear notifications remove completed tasks and notifications', async () => {
+  tasksInfo.set([SUCCEED_TASK, NOTIFICATION_TASK]);
+  render(TaskManager, { showTaskManager: true });
+
+  // expect the task name is visible
+  const task = screen.queryByText(SUCCEED_TASK.name);
+  expect(task).toBeInTheDocument();
+
+  // expect the notification name is visible
+  const notification = screen.queryByText(NOTIFICATION_TASK.name);
+  expect(notification).toBeInTheDocument();
+
+  // click on the button "Clear notifications"
+  const clearNotificationsButton = screen.getByRole('button', { name: 'Clear notifications' });
+  expect(clearNotificationsButton).toBeInTheDocument();
+  await fireEvent.click(clearNotificationsButton);
+
+  // expect the task name and notification name are not visible
+  const afterTask = screen.queryByText(SUCCEED_TASK.name);
+  expect(afterTask).not.toBeInTheDocument();
+  const afterNotification = screen.queryByText(NOTIFICATION_TASK.name);
+  expect(afterNotification).not.toBeInTheDocument();
+
+  // button is also gone
+  const afterClearNotificationsButton = screen.queryByRole('button', { name: 'Clear notifications' });
+  expect(afterClearNotificationsButton).not.toBeInTheDocument();
 });

--- a/packages/renderer/src/lib/task-manager/TaskManager.spec.ts
+++ b/packages/renderer/src/lib/task-manager/TaskManager.spec.ts
@@ -22,7 +22,7 @@ import { fireEvent, render, screen } from '@testing-library/svelte';
 import TaskManager from './TaskManager.svelte';
 import userEvent from '@testing-library/user-event';
 import { tasksInfo } from '/@/stores/tasks';
-import type { Task } from '../../../../main/src/plugin/api/task';
+import type { StatefulTask } from '../../../../main/src/plugin/api/task';
 
 // fake the window.events object
 beforeAll(() => {
@@ -34,8 +34,14 @@ beforeAll(() => {
 });
 
 const started = new Date().getTime();
-const IN_PROGRESS_TASK: Task = { id: '1', name: 'Running Task 1', state: 'running', started, status: 'in-progress' };
-const SUCCEED_TASK: Task = { id: '1', name: 'Running Task 1', state: 'completed', started, status: 'success' };
+const IN_PROGRESS_TASK: StatefulTask = {
+  id: '1',
+  name: 'Running Task 1',
+  state: 'running',
+  started,
+  status: 'in-progress',
+};
+const SUCCEED_TASK: StatefulTask = { id: '1', name: 'Running Task 1', state: 'completed', started, status: 'success' };
 
 test('Expect that the tasks manager is hidden by default', async () => {
   render(TaskManager, {});
@@ -112,18 +118,18 @@ test('Expect delete completed tasks remove tasks', async () => {
   const task = screen.queryByText(SUCCEED_TASK.name);
   expect(task).toBeInTheDocument();
 
-  // click on the button "Clear completed"
-  const clearCompletedButton = screen.getByRole('button', { name: 'Clear completed' });
-  expect(clearCompletedButton).toBeInTheDocument();
-  await fireEvent.click(clearCompletedButton);
+  // click on the button "Clear notifications"
+  const clearNotificationsButton = screen.getByRole('button', { name: 'Clear notifications' });
+  expect(clearNotificationsButton).toBeInTheDocument();
+  await fireEvent.click(clearNotificationsButton);
 
   // expect the task name is not visible
   const afterTask = screen.queryByText(SUCCEED_TASK.name);
   expect(afterTask).not.toBeInTheDocument();
 
   // button is also gone
-  const afterClearCompletedButton = screen.queryByRole('button', { name: 'Clear completed' });
-  expect(afterClearCompletedButton).not.toBeInTheDocument();
+  const afterClearNotificationsButton = screen.queryByRole('button', { name: 'Clear notifications' });
+  expect(afterClearNotificationsButton).not.toBeInTheDocument();
 });
 
 test('Expect click on faClose icon remove the task', async () => {

--- a/packages/renderer/src/lib/task-manager/TaskManager.spec.ts
+++ b/packages/renderer/src/lib/task-manager/TaskManager.spec.ts
@@ -125,7 +125,7 @@ test('Expect delete completed tasks remove tasks', async () => {
   expect(task).toBeInTheDocument();
 
   // click on the button "Clear notifications"
-  const clearNotificationsButton = screen.getByRole('button', { name: 'Clear notifications' });
+  const clearNotificationsButton = screen.getByRole('button', { name: 'Clear' });
   expect(clearNotificationsButton).toBeInTheDocument();
   await fireEvent.click(clearNotificationsButton);
 
@@ -134,7 +134,7 @@ test('Expect delete completed tasks remove tasks', async () => {
   expect(afterTask).not.toBeInTheDocument();
 
   // button is also gone
-  const afterClearNotificationsButton = screen.queryByRole('button', { name: 'Clear notifications' });
+  const afterClearNotificationsButton = screen.queryByRole('button', { name: 'Clear' });
   expect(afterClearNotificationsButton).not.toBeInTheDocument();
 });
 
@@ -147,7 +147,7 @@ test('Expect click on faClose icon remove the task', async () => {
   expect(task).toBeInTheDocument();
 
   // click on the button with title "Clear notification"
-  const clearCompletedButton = screen.getByRole('button', { name: 'Clear notification' });
+  const clearCompletedButton = screen.getByRole('button', { name: 'Clear' });
   expect(clearCompletedButton).toBeInTheDocument();
   await fireEvent.click(clearCompletedButton);
 
@@ -182,7 +182,7 @@ test('Expect clear notifications remove completed tasks and notifications', asyn
   expect(notification).toBeInTheDocument();
 
   // click on the button "Clear notifications"
-  const clearNotificationsButton = screen.getByRole('button', { name: 'Clear notifications' });
+  const clearNotificationsButton = screen.getByRole('button', { name: 'Clear' });
   expect(clearNotificationsButton).toBeInTheDocument();
   await fireEvent.click(clearNotificationsButton);
 
@@ -193,6 +193,6 @@ test('Expect clear notifications remove completed tasks and notifications', asyn
   expect(afterNotification).not.toBeInTheDocument();
 
   // button is also gone
-  const afterClearNotificationsButton = screen.queryByRole('button', { name: 'Clear notifications' });
+  const afterClearNotificationsButton = screen.queryByRole('button', { name: 'Clear' });
   expect(afterClearNotificationsButton).not.toBeInTheDocument();
 });

--- a/packages/renderer/src/lib/task-manager/TaskManager.svelte
+++ b/packages/renderer/src/lib/task-manager/TaskManager.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { faCheck, faChevronDown, faCircle } from '@fortawesome/free-solid-svg-icons';
-import { clearCompletedTasks, tasksInfo } from '/@/stores/tasks';
+import { clearNotifications, isStatefulTask, tasksInfo } from '/@/stores/tasks';
 
 import Fa from 'svelte-fa';
 import TaskIcon from '../images/TaskIcon.svelte';
@@ -11,8 +11,18 @@ import Button from '../ui/Button.svelte';
 // display or not the tasks manager (defaut is false)
 export let showTaskManager = false;
 
-$: runningTasks = $tasksInfo.filter(task => task.state === 'running');
-$: completedTasks = $tasksInfo.filter(task => task.state === 'completed');
+$: runningTasks = $tasksInfo.filter(task => {
+  if (isStatefulTask(task)) {
+    return task.state === 'running';
+  }
+  return false;
+});
+$: notificationsTasks = $tasksInfo.filter(task => {
+  if (isStatefulTask(task)) {
+    return task.state === 'completed';
+  }
+  return true;
+});
 
 // hide the task manager
 function hide() {
@@ -21,7 +31,7 @@ function hide() {
 
 function clearCompleted() {
   // needs to delete the task from the svelte store
-  clearCompletedTasks();
+  clearNotifications();
 }
 
 // If we hit ESC while the menu is open, close it
@@ -87,13 +97,13 @@ window.events?.receive('toggle-task-manager', () => {
           {/if}
 
           <!-- completed tasks-->
-          {#if completedTasks.length > 0}
+          {#if notificationsTasks.length > 0}
             <div class="flex bg-charcoal-600 pt-1 px-4">
               <TaskManagerGroup
                 lineColor="bg-zinc-400"
                 icon="{faCheck}"
-                tasks="{completedTasks}"
-                title="completed tasks" />
+                tasks="{notificationsTasks}"
+                title="notifications" />
             </div>
           {/if}
         </div>
@@ -101,10 +111,10 @@ window.events?.receive('toggle-task-manager', () => {
 
       <!-- footer of the task manager -->
       <!-- only if there are tasks-->
-      {#if completedTasks.length > 0}
+      {#if notificationsTasks.length > 0}
         <div class="flex flex-row w-full">
           <div class="p-2 flex flex-row space-x-2 w-full">
-            <Button on:click="{() => clearCompleted()}">Clear completed</Button>
+            <Button on:click="{() => clearCompleted()}">Clear notifications</Button>
             <!--<Button>View task history</Button>-->
           </div>
         </div>

--- a/packages/renderer/src/lib/task-manager/TaskManager.svelte
+++ b/packages/renderer/src/lib/task-manager/TaskManager.svelte
@@ -29,11 +29,6 @@ function hide() {
   showTaskManager = false;
 }
 
-function clearCompleted() {
-  // needs to delete the task from the svelte store
-  clearNotifications();
-}
-
 // If we hit ESC while the menu is open, close it
 function handleEscape({ key }: any) {
   // if the task manager is not open, do not check any keys
@@ -114,7 +109,7 @@ window.events?.receive('toggle-task-manager', () => {
       {#if notificationsTasks.length > 0}
         <div class="flex flex-row w-full">
           <div class="p-2 flex flex-row space-x-2 w-full">
-            <Button on:click="{() => clearCompleted()}">Clear notifications</Button>
+            <Button on:click="{() => clearNotifications()}">Clear</Button>
             <!--<Button>View task history</Button>-->
           </div>
         </div>

--- a/packages/renderer/src/lib/task-manager/TaskManagerItem.svelte
+++ b/packages/renderer/src/lib/task-manager/TaskManagerItem.svelte
@@ -67,7 +67,7 @@ function gotoTask(taskUI: StatefulTaskUI) {
 
       <div class="flex flex-col flex-grow items-end">
         <!-- if completed task, display a close icon-->
-        {#if isNotificationTask(task) || (isStatefulTask(taskUI) && taskUI.state === 'completed')}
+        {#if isNotificationTask(taskUI) || (isStatefulTask(taskUI) && taskUI.state === 'completed')}
           <button
             title="Clear notification"
             class="hover:bg-charcoal-800 hover:text-purple-500"
@@ -75,11 +75,11 @@ function gotoTask(taskUI: StatefulTaskUI) {
         {/if}
       </div>
     </div>
-    {#if isNotificationTask(task)}
-      <div class="text-gray-700 text-xs my-2">{task.description}</div>
-      {#if task.markdownActions}
+    {#if isNotificationTask(taskUI)}
+      <div class="text-gray-700 text-xs my-2">{taskUI.description}</div>
+      {#if taskUI.markdownActions}
         <div class="flex justify-end">
-          <Markdown>{task.markdownActions}</Markdown>
+          <Markdown>{taskUI.markdownActions}</Markdown>
         </div>
       {/if}
     {/if}

--- a/packages/renderer/src/lib/task-manager/TaskManagerItem.svelte
+++ b/packages/renderer/src/lib/task-manager/TaskManagerItem.svelte
@@ -67,7 +67,7 @@ function gotoTask(taskUI: StatefulTaskUI) {
 
       <div class="flex flex-col flex-grow items-end">
         <!-- if completed task, display a close icon-->
-        {#if isNotificationTask(task) || (taskManager.isStatefulTaskUI(taskUI) && taskUI.state === 'completed')}
+        {#if isNotificationTask(task) || (isStatefulTask(taskUI) && taskUI.state === 'completed')}
           <button
             title="Clear notification"
             class="hover:bg-charcoal-800 hover:text-purple-500"
@@ -83,7 +83,7 @@ function gotoTask(taskUI: StatefulTaskUI) {
         </div>
       {/if}
     {/if}
-    {#if taskManager.isStatefulTaskUI(taskUI)}
+    {#if isStatefulTask(taskUI)}
       {#if taskUI.error}
         <div class:hidden="{!showError}" class="text-xs my-2 break-words">{taskUI.error}</div>
       {/if}
@@ -92,7 +92,7 @@ function gotoTask(taskUI: StatefulTaskUI) {
     {/if}
 
     <!-- if in-progress task, display a link to resume-->
-    {#if taskManager.isStatefulTaskUI(taskUI) && taskUI.status === 'in-progress'}
+    {#if isStatefulTask(taskUI) && taskUI.status === 'in-progress'}
       <div class="flex flex-row w-full">
         {#if (taskUI.progress || 0) >= 0}
           <ProgressBar progress="{taskUI.progress}" />
@@ -102,7 +102,7 @@ function gotoTask(taskUI: StatefulTaskUI) {
             <button
               class="text-purple-500 cursor-pointer"
               on:click="{() => {
-                if (taskManager.isStatefulTaskUI(taskUI)) gotoTask(taskUI);
+                if (isStatefulTask(taskUI)) gotoTask(taskUI);
               }}">Go to task ></button>
           {/if}
         </div>
@@ -110,7 +110,7 @@ function gotoTask(taskUI: StatefulTaskUI) {
     {/if}
 
     <!-- if failed task, display the error-->
-    {#if taskManager.isStatefulTaskUI(taskUI) && taskUI.status === 'failure'}
+    {#if isStatefulTask(taskUI) && taskUI.status === 'failure'}
       <div class="flex flex-col w-full items-end">
         <button on:click="{() => (showError = !showError)}" class="text-purple-200 text-xs">
           View Error

--- a/packages/renderer/src/lib/task-manager/TaskManagerItem.svelte
+++ b/packages/renderer/src/lib/task-manager/TaskManagerItem.svelte
@@ -8,40 +8,45 @@ import {
 } from '@fortawesome/free-solid-svg-icons';
 import { onMount } from 'svelte';
 import Fa from 'svelte-fa';
-import { TaskManager, type TaskUI } from './task-manager';
-import { removeTask } from '/@/stores/tasks';
-import type { Task } from '../../../../main/src/plugin/api/task';
+import { TaskManager, type StatefulTaskUI } from './task-manager';
+import { isNotificationTask, isStatefulTask, removeTask } from '/@/stores/tasks';
+import type { NotificationTask, Task } from '../../../../main/src/plugin/api/task';
 import ProgressBar from '/@/lib/task-manager/ProgressBar.svelte';
+import Markdown from '../markdown/Markdown.svelte';
 
 export let task: Task;
 
 const taskManager = new TaskManager();
 
-let taskUI: TaskUI;
+let taskUI: StatefulTaskUI | NotificationTask;
 $: taskUI = taskManager.toTaskUi(task);
 
 let showError = false;
 let icon: IconDefinition;
 let iconColor: string;
 onMount(() => {
-  if (task.status === 'success') {
-    icon = faSquareCheck;
-    iconColor = 'text-green-600';
-  } else if (task.status === 'failure') {
-    icon = faTriangleExclamation;
-    iconColor = 'text-red-500';
-  } else {
-    icon = faInfoCircle;
-    iconColor = 'text-purple-500';
+  if (isStatefulTask(task)) {
+    if (task.status === 'success') {
+      icon = faSquareCheck;
+      iconColor = 'text-green-600';
+      return;
+    } else if (task.status === 'failure') {
+      icon = faTriangleExclamation;
+      iconColor = 'text-red-500';
+      return;
+    }
   }
+
+  icon = faInfoCircle;
+  iconColor = 'text-purple-500';
 });
 
-function closeCompleted(taskUI: TaskUI) {
+function closeCompleted(taskUI: StatefulTaskUI | NotificationTask) {
   // needs to delete the task from the svelte store
   removeTask(taskUI.id);
 }
 
-function gotoTask(taskUI: TaskUI) {
+function gotoTask(taskUI: StatefulTaskUI) {
   // hide the task manager
   window.events?.send('toggle-task-manager', '');
   // and open the task
@@ -62,7 +67,7 @@ function gotoTask(taskUI: TaskUI) {
 
       <div class="flex flex-col flex-grow items-end">
         <!-- if completed task, display a close icon-->
-        {#if taskUI.state === 'completed'}
+        {#if isNotificationTask(task) || (taskManager.isStatefulTaskUI(taskUI) && taskUI.state === 'completed')}
           <button
             title="Clear notification"
             class="hover:bg-charcoal-800 hover:text-purple-500"
@@ -70,28 +75,42 @@ function gotoTask(taskUI: TaskUI) {
         {/if}
       </div>
     </div>
-    {#if taskUI.error}
-      <div class:hidden="{!showError}" class="text-xs my-2 break-words">{taskUI.error}</div>
+    {#if isNotificationTask(task)}
+      <div class="text-gray-700 text-xs my-2">{task.description}</div>
+      {#if task.markdownActions}
+        <div class="flex justify-end">
+          <Markdown>{task.markdownActions}</Markdown>
+        </div>
+      {/if}
     {/if}
-    <!-- age -->
-    <div class="text-gray-700 text-xs">{taskUI.age}</div>
+    {#if taskManager.isStatefulTaskUI(taskUI)}
+      {#if taskUI.error}
+        <div class:hidden="{!showError}" class="text-xs my-2 break-words">{taskUI.error}</div>
+      {/if}
+      <!-- age -->
+      <div class="text-gray-700 text-xs">{taskUI.age}</div>
+    {/if}
 
     <!-- if in-progress task, display a link to resume-->
-    {#if taskUI.status === 'in-progress'}
+    {#if taskManager.isStatefulTaskUI(taskUI) && taskUI.status === 'in-progress'}
       <div class="flex flex-row w-full">
         {#if (taskUI.progress || 0) >= 0}
           <ProgressBar progress="{taskUI.progress}" />
         {/if}
         <div class="flex flex-1 flex-col w-full items-end text-purple-500 text-xs">
           {#if taskUI.hasGotoTask}
-            <button class="text-purple-500 cursor-pointer" on:click="{() => gotoTask(taskUI)}">Go to task ></button>
+            <button
+              class="text-purple-500 cursor-pointer"
+              on:click="{() => {
+                if (taskManager.isStatefulTaskUI(taskUI)) gotoTask(taskUI);
+              }}">Go to task ></button>
           {/if}
         </div>
       </div>
     {/if}
 
     <!-- if failed task, display the error-->
-    {#if taskUI.status === 'failure'}
+    {#if taskManager.isStatefulTaskUI(taskUI) && taskUI.status === 'failure'}
       <div class="flex flex-col w-full items-end">
         <button on:click="{() => (showError = !showError)}" class="text-purple-200 text-xs">
           View Error

--- a/packages/renderer/src/lib/task-manager/task-manager.spec.ts
+++ b/packages/renderer/src/lib/task-manager/task-manager.spec.ts
@@ -1,0 +1,60 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+import { beforeAll, test, expect, vi } from 'vitest';
+import { isNotificationTask, tasksInfo } from '/@/stores/tasks';
+import type { NotificationTask, StatefulTask } from '../../../../main/src/plugin/api/task';
+import { TaskManager } from './task-manager';
+
+// fake the window.events object
+beforeAll(() => {
+  (window.events as unknown) = {
+    receive: vi.fn(),
+  };
+  // reset store
+  tasksInfo.set([]);
+});
+
+const started = new Date().getTime();
+const IN_PROGRESS_TASK: StatefulTask = {
+  id: '1',
+  name: 'Running Task 1',
+  state: 'running',
+  started,
+  status: 'in-progress',
+};
+const NOTIFICATION_TASK: NotificationTask = {
+  id: '1',
+  name: 'Notification Task 1',
+  description: ' description',
+  started,
+};
+
+test('Expect totaskUI returns original NotificationTask', async () => {
+  const taskManager = new TaskManager();
+  const task = taskManager.toTaskUi(NOTIFICATION_TASK);
+  expect(task.id).equal(NOTIFICATION_TASK.id);
+  expect(isNotificationTask(task)).toBeTruthy();
+});
+
+test('Expect toTaskUI returns StatefulTaskUi for StatefulTask', async () => {
+  const taskManager = new TaskManager();
+  const task = taskManager.toTaskUi(IN_PROGRESS_TASK);
+  expect('age' in task).toBeTruthy();
+});

--- a/packages/renderer/src/lib/task-manager/task-manager.ts
+++ b/packages/renderer/src/lib/task-manager/task-manager.ts
@@ -55,8 +55,4 @@ export class TaskManager {
 
     return task as NotificationTask;
   }
-
-  isStatefulTaskUI(task: StatefulTaskUI | NotificationTask): task is StatefulTaskUI {
-    return 'state' in task;
-  }
 }

--- a/packages/renderer/src/lib/task-manager/task-manager.ts
+++ b/packages/renderer/src/lib/task-manager/task-manager.ts
@@ -17,9 +17,10 @@
  ***********************************************************************/
 
 import humanizeDuration from 'humanize-duration';
-import type { Task } from '../../../../main/src/plugin/api/task';
+import type { NotificationTask, StatefulTask, Task } from '../../../../main/src/plugin/api/task';
+import { isStatefulTask } from '/@/stores/tasks';
 
-export interface TaskUI extends Task {
+export interface StatefulTaskUI extends StatefulTask {
   age: string;
   progress?: number;
   hasGotoTask: boolean;
@@ -27,27 +28,35 @@ export interface TaskUI extends Task {
 }
 
 export class TaskManager {
-  toTaskUi(task: Task): TaskUI {
-    const taskUI: TaskUI = {
-      id: task.id,
-      name: task.name,
-      started: task.started,
-      state: task.state,
-      status: task.status,
-      hasGotoTask: false,
-      age: `${humanizeDuration(new Date().getTime() - task.started, { round: true, largest: 1 })} ago`,
-      error: task.error,
-    };
+  toTaskUi(task: Task): StatefulTaskUI | NotificationTask {
+    if (isStatefulTask(task)) {
+      const taskUI: StatefulTaskUI = {
+        id: task.id,
+        name: task.name,
+        started: task.started,
+        state: task.state,
+        status: task.status,
+        hasGotoTask: false,
+        age: `${humanizeDuration(new Date().getTime() - task.started, { round: true, largest: 1 })} ago`,
+        error: task.error,
+      };
 
-    if (task.status === 'in-progress') {
-      taskUI.progress = task.progress;
-      if (task.gotoTask) {
-        taskUI.hasGotoTask = true;
-        taskUI.gotoTask = task.gotoTask;
-      } else {
-        taskUI.hasGotoTask = false;
+      if (task.status === 'in-progress') {
+        taskUI.progress = task.progress;
+        if (task.gotoTask) {
+          taskUI.hasGotoTask = true;
+          taskUI.gotoTask = task.gotoTask;
+        } else {
+          taskUI.hasGotoTask = false;
+        }
       }
+      return taskUI;
     }
-    return taskUI;
+
+    return task as NotificationTask;
+  }
+
+  isStatefulTaskUI(task: StatefulTaskUI | NotificationTask): task is StatefulTaskUI {
+    return 'state' in task;
   }
 }

--- a/packages/renderer/src/stores/tasks.spec.ts
+++ b/packages/renderer/src/stores/tasks.spec.ts
@@ -1,0 +1,70 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { get } from 'svelte/store';
+import { expect, test } from 'vitest';
+import type { NotificationTask, StatefulTask } from '../../../main/src/plugin/api/task';
+import { clearNotifications, isNotificationTask, isStatefulTask, tasksInfo } from './tasks';
+
+const started = new Date().getTime();
+const IN_PROGRESS_TASK: StatefulTask = {
+  id: '1',
+  name: 'Running Task 1',
+  state: 'running',
+  started,
+  status: 'in-progress',
+};
+const SUCCEED_TASK: StatefulTask = { id: '1', name: 'Running Task 1', state: 'completed', started, status: 'success' };
+const NOTIFICATION_TASK: NotificationTask = {
+  id: '1',
+  name: 'Notification Task 1',
+  description: ' description',
+  started,
+};
+
+test('Expect clearNotification removes all completed tasks and notifications', async () => {
+  tasksInfo.set([SUCCEED_TASK, NOTIFICATION_TASK, IN_PROGRESS_TASK]);
+
+  clearNotifications();
+
+  const tasks = get(tasksInfo);
+  expect(tasks.length).equal(1);
+  expect(tasks[0].name).equal(IN_PROGRESS_TASK.name);
+});
+
+test('return true if statefulTask', async () => {
+  const result = isStatefulTask(SUCCEED_TASK);
+  expect(result).toBeTruthy();
+});
+
+test('return false if it is not a statefulTask', async () => {
+  const result = isStatefulTask(NOTIFICATION_TASK);
+  expect(result).toBeFalsy();
+});
+
+test('return true if notificationTask', async () => {
+  const result = isNotificationTask(NOTIFICATION_TASK);
+  expect(result).toBeTruthy();
+});
+
+test('return false if it is not a notificationTask', async () => {
+  const result = isNotificationTask(SUCCEED_TASK);
+  expect(result).toBeFalsy();
+});

--- a/packages/renderer/src/stores/tasks.ts
+++ b/packages/renderer/src/stores/tasks.ts
@@ -18,7 +18,7 @@
 
 import type { Writable } from 'svelte/store';
 import { writable } from 'svelte/store';
-import type { Task } from '../../../main/src/plugin/api/task';
+import type { NotificationTask, StatefulTask, Task } from '../../../main/src/plugin/api/task';
 
 /**
  * Defines the store used to define the tasks.
@@ -44,16 +44,16 @@ function updateTask(task: Task) {
 }
 
 // remove element from the store that are completed
-export function clearCompletedTasks() {
-  tasksInfo.update(tasks => tasks.filter(task => task.state !== 'completed'));
+export function clearNotifications() {
+  tasksInfo.update(tasks => tasks.filter(task => isStatefulTask(task) && task.state !== 'completed'));
 }
 
 let taskId = 0;
 
 // create a new task
-export function createTask(name: string): Task {
+export function createTask(name: string): StatefulTask {
   taskId++;
-  const task: Task = {
+  const task: StatefulTask = {
     id: `ui-${taskId}`,
     name,
     started: new Date().getTime(),
@@ -73,3 +73,11 @@ window.events?.receive('task-updated', (task: Task) => {
 window.events?.receive('task-removed', (task: Task) => {
   removeTask(task.id);
 });
+
+export function isStatefulTask(task: Task): task is StatefulTask {
+  return 'state' in task;
+}
+
+export function isNotificationTask(task: Task): task is NotificationTask {
+  return 'description' in task;
+}


### PR DESCRIPTION
### What does this PR do?

This PR allow to display notifications using the bell icon on the bottom toolbar.

The idea is this one.
As a completed (successfully or not) task can be considered like a notification, we merge the actual notifications with the completed tasks in the bottom of the task manager and keep the running task on the top.
If you click on the `clear notifications` button everything gets deleted except the running tasks.

### Screenshot/screencast of this PR

![notifications_bell](https://github.com/containers/podman-desktop/assets/49404737/ed25737f-f0b6-4415-9104-01855c13609f)

### What issues does this PR fix or reference?

it resolves #4406 

### How to test this PR?

1. be sure to not have any podman machine to see the onboarding notification, then create a new machine or build an image or do something else to display an old task and see it works as before, and notifications + completed task are grouped in the bottom
