### PR TITLE
feat: delete kube context

### DIFF
--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1866,6 +1866,13 @@ export class PluginSystem {
       return kubernetesClient.getCurrentNamespace();
     });
 
+    this.ipcHandle(
+      'kubernetes-client:deleteContext',
+      async (_listener, contextName: string): Promise<KubernetesContext[]> => {
+        return kubernetesClient.deleteContext(contextName);
+      },
+    );
+
     this.ipcHandle('feedback:send', async (_listener, feedbackProperties: unknown): Promise<void> => {
       return telemetry.sendFeedback(feedbackProperties);
     });

--- a/packages/main/src/plugin/kubernetes-client-kubeconfig.spec.ts
+++ b/packages/main/src/plugin/kubernetes-client-kubeconfig.spec.ts
@@ -1,0 +1,123 @@
+import type { Cluster, Context, User, KubeConfig } from '@kubernetes/client-node';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import type { ConfigurationRegistry } from './configuration-registry.js';
+import { FilesystemMonitoring } from './filesystem-monitoring.js';
+import type { Telemetry } from './telemetry/telemetry.js';
+import type { ApiSenderType } from './api.js';
+import { KubernetesClient } from './kubernetes-client.js';
+
+// WARNING: Do not import anything from kubernetes-client.spec.ts
+// or it will execute the modules mocks from there, incompatibles with tests in this file
+
+class TestKubernetesClient extends KubernetesClient {
+  public setClusters(clusters: Cluster[]) {
+    this.kubeConfig.clusters = clusters;
+  }
+  public setUsers(users: User[]) {
+    this.kubeConfig.users = users;
+  }
+  public setContexts(contexts: Context[]) {
+    this.kubeConfig.contexts = contexts;
+  }
+  public getUsers(): User[] {
+    return this.kubeConfig.users;
+  }
+  public setCurrentContext(name: string) {
+    this.currentContextName = name;
+  }
+}
+
+describe('delete context', () => {
+  const originalUsers = [{ name: 'user1' }, { name: 'user2' }];
+  const originalClusters = [
+    { name: 'cluster1', server: 'server1' },
+    { name: 'cluster2', server: 'server2' },
+  ];
+  const originalContexts = [
+    { name: 'ctx1', user: 'user1', cluster: 'cluster1' },
+    { name: 'ctx1bis', user: 'user1', cluster: 'cluster1' },
+  ];
+
+  let client: TestKubernetesClient;
+
+  function createClient(): TestKubernetesClient {
+    const configurationRegistry: ConfigurationRegistry = {} as unknown as ConfigurationRegistry;
+    const fileSystemMonitoring: FilesystemMonitoring = new FilesystemMonitoring();
+    const telemetry: Telemetry = {
+      track: vi.fn().mockImplementation(async () => {}),
+    } as unknown as Telemetry;
+    const apiSender: ApiSenderType = {
+      send: () => {},
+      receive: () => {},
+    };
+
+    const client = new TestKubernetesClient(apiSender, configurationRegistry, fileSystemMonitoring, telemetry);
+
+    client.setUsers(originalUsers);
+    client.setClusters(originalClusters);
+    client.setContexts(originalContexts);
+
+    return client;
+  }
+
+  beforeEach(() => {
+    client = createClient();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test('should delete context from config', async () => {
+    client.saveKubeConfig = vi.fn().mockImplementation((_config: KubeConfig) => {});
+
+    const contexts = await client.deleteContext(originalContexts[1].name);
+    expect(contexts.length).toBe(1);
+    expect(contexts[0]).toStrictEqual(originalContexts[0]);
+    expect(client.getContexts().length).toBe(1);
+    expect(client.getContexts()[0]).toStrictEqual(originalContexts[0]);
+  });
+
+  test('should delete context from config and related user and cluster not referenced anymore', async () => {
+    client.saveKubeConfig = vi.fn().mockImplementation((_config: KubeConfig) => {});
+
+    await client.deleteContext(originalContexts[0].name);
+    const contexts = await client.deleteContext(originalContexts[1].name);
+    expect(contexts.length).toBe(0);
+    expect(client.getContexts().length).toBe(0);
+    // user2 is not deleted, as it was already not referenced before
+    expect(client.getUsers().length).toBe(1);
+    expect(client.getUsers()[0]).toStrictEqual(originalUsers[1]);
+    // cluster2 is not deleted, as it was already not referenced before
+    expect(client.getClusters().length).toBe(1);
+    expect(client.getClusters()[0]).toStrictEqual(originalClusters[1]);
+  });
+
+  test('should not delete context if saving to file fails', async () => {
+    client.saveKubeConfig = vi.fn().mockImplementation((_config: KubeConfig) => {
+      throw 'an error';
+    });
+
+    await expect(async () => await client.deleteContext(originalContexts[0].name)).rejects.toThrow('an error');
+    expect(client.getContexts().length).toBe(2);
+    expect(client.getUsers().length).toBe(2);
+    expect(client.getClusters().length).toBe(2);
+  });
+
+  test('should be a no-op if the context name is not found', async () => {
+    client.saveKubeConfig = vi.fn().mockImplementation((_config: KubeConfig) => {});
+
+    await client.deleteContext('unknown-context');
+    expect(client.getContexts().length).toBe(2);
+    expect(client.getUsers().length).toBe(2);
+    expect(client.getClusters().length).toBe(2);
+  });
+
+  test('should keep the current context name when we delete the context', async () => {
+    client.saveKubeConfig = vi.fn().mockImplementation((_config: KubeConfig) => {});
+    client.setCurrentContext(originalContexts[0].name);
+
+    await client.deleteContext(originalContexts[0].name);
+    expect(client.getCurrentContextName()).toBe(originalContexts[0].name);
+  });
+});

--- a/packages/main/src/plugin/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes-client.ts
@@ -274,12 +274,9 @@ export class KubernetesClient {
       users: this.kubeConfig.users.filter(user => newContexts.some(ctx => ctx.user === user.name)),
       currentContext: this.kubeConfig.currentContext,
     });
-    try {
-      await this.saveKubeConfig(newConfig);
-      this.kubeConfig = newConfig;
-    } catch {
-      return this.getContexts();
-    }
+    await this.saveKubeConfig(newConfig);
+    // the config is saved back only if saving the file succeeds
+    this.kubeConfig = newConfig;
     return this.getContexts();
   }
 

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -1416,6 +1416,10 @@ function initExposure(): void {
     return ipcInvoke('kubernetes-client:getContexts');
   });
 
+  contextBridge.exposeInMainWorld('kubernetesDeleteContext', async (contextName: string): Promise<Context[]> => {
+    return ipcInvoke('kubernetes-client:deleteContext', contextName);
+  });
+
   contextBridge.exposeInMainWorld('kubernetesGetClusters', async (): Promise<Cluster[]> => {
     return ipcInvoke('kubernetes-client:getClusters');
   });

--- a/packages/renderer/src/lib/kube/KubeContextUI.ts
+++ b/packages/renderer/src/lib/kube/KubeContextUI.ts
@@ -36,6 +36,8 @@ export interface KubeContextUI {
   user: string;
   clusterInfo?: KubeContextClusterUI;
   icon?: string;
+  // error to display in case of deletion (or other operation) error
+  error?: string;
 }
 
 // Function that takes in the clusters and contexts and returns the KubeContextUI
@@ -68,4 +70,18 @@ export function getKubeUIContexts(contexts: Context[], clusters: Cluster[]): Kub
     });
   });
   return kubeContexts;
+}
+
+export function setKubeUIContextError(contexts: Context[], contextName: string, error: Error): Context[] {
+  return contexts.map(ctx => {
+    if (ctx.name === contextName) {
+      return { ...ctx, error: String(error) };
+    } else {
+      return ctx;
+    }
+  });
+}
+
+export function clearKubeUIContextErrors(contexts: Context[]): Context[] {
+  return contexts.map(ctx => ({ ...ctx, error: undefined }));
 }

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.spec.ts
@@ -39,6 +39,7 @@ const mockCluster = {
 test('test that name, cluster and the server is displayed when rendering', async () => {
   (window as any).kubernetesGetContexts = vi.fn().mockResolvedValue([mockContext]);
   (window as any).kubernetesGetClusters = vi.fn().mockResolvedValue([mockCluster]);
+  (window as any).kubernetesGetCurrentContextName = vi.fn().mockResolvedValue('my-current-context');
   render(PreferencesKubernetesContextsRendering, {});
   expect(await screen.findByText('context-name')).toBeInTheDocument();
   expect(await screen.findByText('cluster-name')).toBeInTheDocument();
@@ -48,6 +49,7 @@ test('test that name, cluster and the server is displayed when rendering', async
 test('If nothing is returned for contexts, expect that the page shows a message', async () => {
   (window as any).kubernetesGetContexts = vi.fn().mockResolvedValue([]);
   (window as any).kubernetesGetClusters = vi.fn().mockResolvedValue([]);
+  (window as any).kubernetesGetCurrentContextName = vi.fn().mockResolvedValue('my-current-context');
   render(PreferencesKubernetesContextsRendering, {});
   expect(await screen.findByText('No Kubernetes contexts found')).toBeInTheDocument();
 });

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
@@ -11,6 +11,7 @@ import { faTrash } from '@fortawesome/free-solid-svg-icons';
 import ListItemButtonIcon from '../ui/ListItemButtonIcon.svelte';
 import ErrorMessage from '../ui/ErrorMessage.svelte';
 
+let currentContextName: string | undefined;
 let contexts: KubeContextUI[] = [];
 let k8sClusters: Cluster[] = [];
 
@@ -18,6 +19,7 @@ $: contexts;
 
 onMount(async () => {
   // Retrieve both the contexts and clusters
+  currentContextName = await window.kubernetesGetCurrentContextName();
   let k8sContexts = await window.kubernetesGetContexts();
   k8sClusters = await window.kubernetesGetClusters();
 
@@ -26,6 +28,17 @@ onMount(async () => {
 });
 
 async function handleDeleteContext(contextName: string) {
+  if (currentContextName === contextName) {
+    const result = await window.showMessageBox({
+      title: 'Delete Context',
+      message:
+        'You will delete the current context. If you delete it, you will need to switch to another context. Continue?',
+      buttons: ['Yes', 'No'],
+    });
+    if (!result || result.response !== 0) {
+      return;
+    }
+  }
   contexts = clearKubeUIContextErrors(contexts);
   try {
     const newK8sContexts = await window.kubernetesDeleteContext(contextName);

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
@@ -6,19 +6,32 @@ import { onMount } from 'svelte';
 import type { KubeContextUI } from '../kube/KubeContextUI';
 import { getKubeUIContexts } from '../kube/KubeContextUI';
 import Link from '../ui/Link.svelte';
+import type { Cluster } from '@kubernetes/client-node';
+import { faTrash } from '@fortawesome/free-solid-svg-icons';
+import ListItemButtonIcon from '../ui/ListItemButtonIcon.svelte';
 
 let contexts: KubeContextUI[] = [];
+let k8sClusters: Cluster[] = [];
 
 $: contexts;
 
 onMount(async () => {
   // Retrieve both the contexts and clusters
   let k8sContexts = await window.kubernetesGetContexts();
-  let k8sClusters = await window.kubernetesGetClusters();
+  k8sClusters = await window.kubernetesGetClusters();
 
   // Convert them to KubeContextUI so we can safely render them.
   contexts = getKubeUIContexts(k8sContexts, k8sClusters);
 });
+
+async function handleDeleteContext(contextName: string) {
+  try {
+    const newK8sContexts = await window.kubernetesDeleteContext(contextName);
+    contexts = getKubeUIContexts(newK8sContexts, k8sClusters);
+  } catch (e) {
+    console.log(' ==> error', e);
+  }
+}
 </script>
 
 <SettingsPage title="Kubernetes Contexts">
@@ -43,8 +56,12 @@ onMount(async () => {
                   class="max-w-[40px] h-full" />
               {/if}
             {/if}
-            <span id="{context.name}" class="my-auto text-gray-400 ml-3 break-words" aria-label="context-name"
+            <span id="{context.name}" class="my-auto text-gray-400 ml-3 break-words flex-auto" aria-label="context-name"
               >{context.name}</span>
+            <ListItemButtonIcon
+              title="Delete Context"
+              icon="{faTrash}"
+              onClick="{() => handleDeleteContext(context.name)}"></ListItemButtonIcon>
           </div>
         </div>
         <div class="grow flex-column divide-gray-900 text-gray-400">

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
@@ -35,7 +35,7 @@ async function handleDeleteContext(contextName: string) {
         'You will delete the current context. If you delete it, you will need to switch to another context. Continue?',
       buttons: ['Yes', 'No'],
     });
-    if (!result || result.response !== 0) {
+    if (result.response !== 0) {
       return;
     }
   }


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

### Screenshot/screencast of this PR

#### Settings > Kubernetes

This PR adds a Trash button for each item in the list. 
Clicking the button deletes the context from the list and from the kubeconfig file.

/!\ Any user or cluster which were referenced by the context and not referenced anymore in the kubeconfig file is also removed from the file.

https://github.com/containers/podman-desktop/assets/9973512/7f90f800-2791-4d62-9732-6b0fe0e8ae5f



TODO
- [ ] do we want to ask for confirmation before to delete the context from the file?
- [ ] how do we want to display an error when one occurs (for example if the kubeconfig file is not writable)?
- [ ] do we want to update the current-context?
- [ ] unit tests

### What issues does this PR fix or reference?

Fixes #4417 

### How to test this PR?

First make a backup copy of your kubeconfig file, as it will be modified by the test.

Press the Trash button on any of the entries.

<!-- Please explain steps to reproduce -->
