### PR TITLE
feat: add All/Running/Stopped tabs to filter pods by status

### DIFF
--- a/packages/renderer/src/lib/pod/PodsList.svelte
+++ b/packages/renderer/src/lib/pod/PodsList.svelte
@@ -220,6 +220,42 @@ function errorCallback(pod: PodInfoUI, errorMessage: string): void {
     {/if}
   </div>
 
+  <div class="flex flex-row px-2 mb-2 border-b border-charcoal-400" slot="tabs">
+    <Button
+      type="tab"
+      on:click="{() => {
+        searchTerm = searchTerm
+          .split(' ')
+          .filter(pattern => pattern !== 'is:running' && pattern !== 'is:stopped')
+          .join(' ');
+      }}"
+      selected="{!searchTerm.includes('is:stopped') && !searchTerm.includes('is:running')}">All</Button>
+    <Button
+      type="tab"
+      on:click="{() => {
+        let temp = searchTerm
+          .trim()
+          .split(' ')
+          .filter(term => term !== 'is:stopped')
+          .join(' ')
+          .trim();
+        searchTerm = temp ? `${temp} is:running` : 'is:running';
+      }}"
+      selected="{searchTerm.includes('is:running')}">Running</Button>
+    <Button
+      type="tab"
+      on:click="{() => {
+        let temp = searchTerm
+          .trim()
+          .split(' ')
+          .filter(term => term !== 'is:running')
+          .join(' ')
+          .trim();
+        searchTerm = temp ? `${temp} is:stopped` : 'is:stopped';
+      }}"
+      selected="{searchTerm.includes('is:stopped')}">Stopped</Button>
+  </div>
+
   <div class="flex min-w-full h-full" slot="content">
     <table class="mx-5 w-full h-fit" class:hidden="{pods.length === 0}">
       <!-- title -->

--- a/packages/renderer/src/stores/pods.ts
+++ b/packages/renderer/src/stores/pods.ts
@@ -65,11 +65,9 @@ export const filtered = derived([searchPattern, podsInfos], ([$searchPattern, $i
     )
     .filter(pod => {
       if ($searchPattern.includes('is:running')) {
-        console.log(pod.Status);
         return pod.Status === 'Running';
       }
       if ($searchPattern.includes('is:stopped')) {
-        console.log(pod.Status);
         return pod.Status !== 'Running';
       }
       return true;

--- a/packages/renderer/src/stores/pods.ts
+++ b/packages/renderer/src/stores/pods.ts
@@ -52,7 +52,28 @@ export const podsInfos: Writable<PodInfo[]> = writable([]);
 export const searchPattern = writable('');
 
 export const filtered = derived([searchPattern, podsInfos], ([$searchPattern, $imagesInfos]) => {
-  return $imagesInfos.filter(podInfo => findMatchInLeaves(podInfo, $searchPattern.toLowerCase()));
+  return $imagesInfos
+    .filter(podInfo =>
+      findMatchInLeaves(
+        podInfo,
+        $searchPattern
+          .split(' ')
+          .filter(pattern => !pattern.startsWith('is:'))
+          .join(' ')
+          .toLowerCase(),
+      ),
+    )
+    .filter(pod => {
+      if ($searchPattern.includes('is:running')) {
+        console.log(pod.Status);
+        return pod.Status === 'Running';
+      }
+      if ($searchPattern.includes('is:stopped')) {
+        console.log(pod.Status);
+        return pod.Status !== 'Running';
+      }
+      return true;
+    });
 });
 
 const eventStore = new EventStore<PodInfo[]>(


### PR DESCRIPTION
### What does this PR do?

This PR adds tabs `All/Running/Stopped` to Pods page

### Screenshot/screencast of this PR

https://github.com/containers/podman-desktop/assets/620330/1dc54342-404a-4d90-9ca2-8e138be78f44

<!-- Please include a screenshot or a screencast 
explaining what is doing this PR -->

### What issues does this PR fix or reference?

Fix #4708. 

### How to test this PR?

1. Create pods using `podman pod create --label myFirstPod`
2. Stop/start some of them
3. Click on different tabs to filter by state or show them all
