### PR TITLE
fix: use URL for proxy specification and add validation

### DIFF
--- a/packages/main/src/plugin/proxy-resolver.ts
+++ b/packages/main/src/plugin/proxy-resolver.ts
@@ -51,14 +51,9 @@ function createProxyAgent(secure: boolean, proxyUrl: string) {
     : new HttpProxyAgent(options as HttpProxyAgentOptions);
 }
 
-export function getProxyUrl(proxy: Proxy): string | undefined {
+export function getProxyUrl(proxy: Proxy, secure: boolean): string | undefined {
   if (proxy.isEnabled()) {
-    // use HTTPS proxy if it is configured, because HTTPS proxy works for both HTTP/HTTPS
-    // servers
-    if (proxy.proxy?.httpsProxy) {
-      return `https://${proxy.proxy?.httpsProxy}`;
-    }
-    return `http://${proxy.proxy?.httpProxy}`;
+    return secure ? proxy.proxy?.httpsProxy : proxy.proxy?.httpProxy;
   }
 }
 
@@ -66,7 +61,7 @@ type ProxyOptions = { agent?: http.Agent | https.Agent };
 
 export function getOptions(proxy: Proxy, secure: boolean): ProxyOptions {
   const options: ProxyOptions = {};
-  const proxyUrl = getProxyUrl(proxy);
+  const proxyUrl = getProxyUrl(proxy, secure);
   if (proxyUrl) {
     options.agent = createProxyAgent(secure, proxyUrl);
   }

--- a/packages/main/src/plugin/proxy.spec.ts
+++ b/packages/main/src/plugin/proxy.spec.ts
@@ -16,8 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { expect, test, vi } from 'vitest';
-import { Proxy } from '/@/plugin/proxy.js';
+import { describe, expect, test, vi } from 'vitest';
+import { ensureURL, Proxy } from '/@/plugin/proxy.js';
 import type { ConfigurationRegistry } from '/@/plugin/configuration-registry.js';
 import * as http from 'http';
 import { createProxy, type ProxyServer } from 'proxy';
@@ -75,4 +75,27 @@ test('fetch with http proxy', async () => {
   proxyServer.on('connect', () => (connectDone = true));
   await fetch(URL);
   expect(connectDone).toBeTruthy();
+});
+
+describe.each([
+  { original: '127.0.0.1', converted: 'http://127.0.0.1' },
+  { original: '127.0.0.1:8080', converted: 'http://127.0.0.1:8080' },
+  { original: '192.168.1.1', converted: 'http://192.168.1.1' },
+  { original: '192.168.1.1:8080', converted: 'http://192.168.1.1:8080' },
+  { original: 'myhostname', converted: 'http://myhostname' },
+  { original: 'myhostname:8080', converted: 'http://myhostname:8080' },
+  { original: 'myhostname.domain.com', converted: 'http://myhostname.domain.com' },
+  { original: 'myhostname.domain.com:8080', converted: 'http://myhostname.domain.com:8080' },
+  { original: 'http://127.0.0.1', converted: 'http://127.0.0.1' },
+  { original: 'http://127.0.0.1:8080', converted: 'http://127.0.0.1:8080' },
+  { original: 'http://192.168.1.1', converted: 'http://192.168.1.1' },
+  { original: 'http://192.168.1.1:8080', converted: 'http://192.168.1.1:8080' },
+  { original: 'http://myhostname', converted: 'http://myhostname' },
+  { original: 'http://myhostname:8080', converted: 'http://myhostname:8080' },
+  { original: 'http://myhostname.domain.com', converted: 'http://myhostname.domain.com' },
+  { original: 'http://myhostname.domain.com:8080', converted: 'http://myhostname.domain.com:8080' },
+])('Ensure URL returns corrected value', ({ original, converted }) => {
+  test(`Ensure ${original} is converted to ${converted}`, () => {
+    expect(ensureURL(original)).toBe(converted);
+  });
 });

--- a/packages/main/src/plugin/proxy.ts
+++ b/packages/main/src/plugin/proxy.ts
@@ -22,7 +22,7 @@ import { Emitter } from './events/emitter.js';
 import { getProxyUrl } from './proxy-resolver.js';
 import { ProxyAgent } from 'undici';
 
-function ensureURL(urlstring: string | undefined): string | undefined {
+export function ensureURL(urlstring: string | undefined): string | undefined {
   if (urlstring) {
     try {
       const url = new URL(urlstring);

--- a/packages/main/src/plugin/proxy.ts
+++ b/packages/main/src/plugin/proxy.ts
@@ -22,6 +22,30 @@ import { Emitter } from './events/emitter.js';
 import { getProxyUrl } from './proxy-resolver.js';
 import { ProxyAgent } from 'undici';
 
+function ensureURL(urlstring: string | undefined): string | undefined {
+  if (urlstring) {
+    try {
+      const url = new URL(urlstring);
+      if (url.hostname) {
+        return urlstring;
+      }
+    } catch (err) {
+      /* empty */
+    }
+    return `http://${urlstring}`;
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function asURL(url: any): URL {
+  if (url instanceof URL) {
+    return url;
+  } else if (typeof url === 'string') {
+    return new URL(url);
+  }
+  return new URL((url as Request).url);
+}
+
 /**
  * Handle proxy settings for Podman Desktop
  */
@@ -93,14 +117,16 @@ export class Proxy {
     const isEnabled = proxyConfiguration.get<boolean>('enabled') || false;
 
     this.proxySettings = {
-      httpProxy,
-      httpsProxy,
+      httpProxy: ensureURL(httpProxy),
+      httpsProxy: ensureURL(httpsProxy),
       noProxy,
     };
     this.proxyState = isEnabled;
   }
 
   async setProxy(proxy: ProxySettings): Promise<void> {
+    proxy.httpProxy = ensureURL(proxy.httpProxy);
+    proxy.httpsProxy = ensureURL(proxy.httpsProxy);
     // notify
     this._onDidUpdateProxy.fire(proxy);
 
@@ -141,7 +167,7 @@ export class Proxy {
     const _me = this;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     globalThis.fetch = function (url: any, opts?: any) {
-      const proxyurl = getProxyUrl(_me);
+      const proxyurl = getProxyUrl(_me, asURL(url).protocol === 'https');
       if (proxyurl) {
         opts = Object.assign({}, opts, { dispatcher: new ProxyAgent(proxyurl) });
       }

--- a/packages/renderer/src/lib/preferences/PreferencesProxiesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesProxiesRendering.svelte
@@ -4,9 +4,13 @@ import { onMount } from 'svelte';
 import SettingsPage from './SettingsPage.svelte';
 import Button from '../ui/Button.svelte';
 import { faPen } from '@fortawesome/free-solid-svg-icons';
+import { validateProxyAddress } from './Util';
+import ErrorMessage from '/@/lib/ui/ErrorMessage.svelte';
 
 let proxySettings: ProxySettings;
 let proxyState: boolean;
+let httpProxyError: string | undefined;
+let httpsProxyError: string | undefined;
 
 onMount(async () => {
   proxySettings = await window.getProxySettings();
@@ -41,6 +45,17 @@ async function updateProxySettings() {
 async function updateProxyState() {
   await window.setProxyState(proxyState);
 }
+
+function validate(event: any) {
+  if (event.target.id === 'httpProxy' || event.target.id === 'httpsProxy') {
+    const error = validateProxyAddress(event.target.value);
+    if (event.target.id === 'httpProxy') {
+      httpProxyError = error;
+    } else {
+      httpsProxyError = error;
+    }
+  }
+}
 </script>
 
 <SettingsPage title="Proxy Settings">
@@ -74,7 +89,12 @@ async function updateProxyState() {
           disabled="{!proxyState}"
           bind:value="{proxySettings.httpProxy}"
           class="w-full p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700"
-          required />
+          placeholder="URL of the proxy for http: URLs (eg http://myproxy.domain.com:8080)"
+          required
+          on:input="{event => validate(event)}" />
+        {#if httpProxyError}
+          <ErrorMessage error="{httpProxyError}" />
+        {/if}
       </div>
       <div class="space-y-2">
         <label
@@ -88,7 +108,12 @@ async function updateProxyState() {
           disabled="{!proxyState}"
           bind:value="{proxySettings.httpsProxy}"
           class="w-full p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700"
-          required />
+          placeholder="URL of the proxy for https: URLs (eg http://myproxy.domain.com:8080)"
+          required
+          on:input="{event => validate(event)}" />
+        {#if httpsProxyError}
+          <ErrorMessage error="{httpsProxyError}" />
+        {/if}
       </div>
       <div class="space-y-2">
         <label

--- a/packages/renderer/src/lib/preferences/Util.spec.ts
+++ b/packages/renderer/src/lib/preferences/Util.spec.ts
@@ -16,12 +16,13 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { test, expect, vi, afterEach } from 'vitest';
+import { test, expect, vi, afterEach, describe } from 'vitest';
 import {
   getNormalizedDefaultNumberValue,
   isPropertyValidInContext,
   isTargetScope,
   uncertainStringToNumber,
+  validateProxyAddress,
   writeToTerminal,
 } from './Util';
 import type { IConfigurationPropertyRecordedSchema } from '../../../../main/src/plugin/configuration-registry';
@@ -194,4 +195,21 @@ test('Expect to receive a number if a number as string is passed as arg', async 
 test('Expect to receive a NaN if a not number string is passed as arg', async () => {
   const valueAsString = 'unknown';
   expect(uncertainStringToNumber(valueAsString)).toBe(NaN);
+});
+
+describe.each([
+  'http://127.0.1',
+  'http://127.0.0.1:8080',
+  'http://hostname',
+  'http://hostname:8080',
+  'http://hostname-suffix',
+  'http://hostname-suffix:8080',
+  'http://hostname.domain.com',
+  'http://hostname.domain.com:8080',
+  'http://hostname-suffix.domain.com',
+  'http://hostname-suffix.domain.com:8080',
+])('Test proxy addresses', address => {
+  test(`Test address ${address}`, () => {
+    expect(validateProxyAddress(address)).toBeUndefined();
+  });
 });

--- a/packages/renderer/src/lib/preferences/Util.spec.ts
+++ b/packages/renderer/src/lib/preferences/Util.spec.ts
@@ -208,8 +208,25 @@ describe.each([
   'http://hostname.domain.com:8080',
   'http://hostname-suffix.domain.com',
   'http://hostname-suffix.domain.com:8080',
-])('Test proxy addresses', address => {
+])('Test accepted proxy addresses', address => {
   test(`Test address ${address}`, () => {
     expect(validateProxyAddress(address)).toBeUndefined();
+  });
+});
+
+describe.each([
+  '127.0.1',
+  '127.0.0.1:8080',
+  'hostname',
+  'hostname:8080',
+  'hostname-suffix',
+  'hostname-suffix:8080',
+  'hostname.domain.com',
+  'hostname.domain.com:8080',
+  'hostname-suffix.domain.com',
+  'hostname-suffix.domain.com:8080',
+])('Test rejected proxy addresses', address => {
+  test(`Test address ${address}`, () => {
+    expect(validateProxyAddress(address)).toBeDefined();
   });
 });

--- a/packages/renderer/src/lib/preferences/Util.ts
+++ b/packages/renderer/src/lib/preferences/Util.ts
@@ -145,3 +145,16 @@ export function uncertainStringToNumber(value: string | number): number {
   if (typeof value === 'number') return value;
   return parseFloat(value);
 }
+
+export function validateProxyAddress(value: string): string | undefined {
+  if (value) {
+    try {
+      const u = new URL(value);
+      if (!u.hostname) {
+        return `Hostname missing from ${value}`;
+      }
+    } catch (err) {
+      return `Value ${value} should be an URL`;
+    }
+  }
+}


### PR DESCRIPTION
Fixes #4810

### What does this PR do?

Ensure proxy addresses are now URLs; convert previous values and add validation in the settings screen

### Screenshot/screencast of this PR



### What issues does this PR fix or reference?

Fixes #4810

### How to test this PR?

Go to the proxy settings page
