### PR TITLE
fix: light scrollbars and line height

### DIFF
--- a/packages/renderer/index.html
+++ b/packages/renderer/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1.0" />
     <title>Podman Desktop</title>
   </head>
-  <body class="overflow-hidden text-white">
+  <body class="overflow-hidden">
     <div id="app"></div>
     <script type="module" src="/src/main.ts"></script>
   </body>

--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -1,3 +1,10 @@
+<style>
+:root {
+  color-scheme: dark;
+  line-height: 0.95rem;
+}
+</style>
+
 <script lang="ts">
 import './app.css';
 import '@fortawesome/fontawesome-free/css/all.min.css';


### PR DESCRIPTION
### What does this PR do?

After the PatternFly removal I noticed that the scrollbars on Mac are in light-mode. PF-dark was setting the color-scheme before, setting it again fixes the problem and means we can also remove the explicit text-white. (maybe some of the changes in #4803 too?)

PF was also setting the line height to 0.9. I'm not tied to it, but it makes buttons, multi-line text, and preferences nav items all less tall. Maybe I'm just used to it, but I prefer a smaller window and 0.95 gets most of the way there & uses less space.

### Screenshot/screencast of this PR

1.5.3:
<img width="638" alt="Screenshot 2023-11-15 at 6 55 43 PM" src="https://github.com/containers/podman-desktop/assets/19958075/be46daa5-db9c-4ab4-9f54-68bcd4bc137a">

Post PatternFly:
<img width="638" alt="Screenshot 2023-11-15 at 4 15 15 PM" src="https://github.com/containers/podman-desktop/assets/19958075/ed9c64e7-38ea-43ab-83b0-0ff07c20da61">

This PR:
<img width="638" alt="Screenshot 2023-11-15 at 4 14 40 PM" src="https://github.com/containers/podman-desktop/assets/19958075/2ca3df16-6b43-4442-ba4e-770ce1f74e2b">

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Open dashboard, preferences.