### PR TITLE
fix: merged compose deploy to kube page in UI

### DIFF
--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -132,13 +132,13 @@ window.events?.receive('display-troubleshooting', () => {
             type="container" />
         </Route>
         <!-- Same DeployPodToKube route, but instead we pass in the compose group name, then redirect to DeployPodToKube -->
-        <Route path="/compose-deploy-to-kube/:composeGroupName/:engineId/*" breadcrumb="Deploy to Kubernetes" let:meta>
+        <Route path="/compose/deploy-to-kube/:composeGroupName/:engineId/*" breadcrumb="Deploy to Kubernetes" let:meta>
           <DeployPodToKube
             resourceId="{decodeURI(meta.params.composeGroupName)}"
             engineId="{decodeURI(meta.params.engineId)}"
             type="compose" />
         </Route>
-        <Route path="/compose/:name/:engineId/*" breadcrumb="Compose Details" let:meta navigationHint="details">
+        <Route path="/compose/details/:name/:engineId/*" breadcrumb="Compose Details" let:meta navigationHint="details">
           <ComposeDetails composeName="{decodeURI(meta.params.name)}" engineId="{decodeURI(meta.params.engineId)}" />
         </Route>
         <Route path="/pods/:kind/:name/:engineId/*" breadcrumb="Pod Details" let:meta navigationHint="details">

--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -132,7 +132,7 @@ window.events?.receive('display-troubleshooting', () => {
             type="container" />
         </Route>
         <!-- Same DeployPodToKube route, but instead we pass in the compose group name, then redirect to DeployPodToKube -->
-        <Route path="/compose/deploy-to-kube/:composeGroupName/:engineId/*" breadcrumb="Deploy to Kubernetes" let:meta>
+        <Route path="/compose-deploy-to-kube/:composeGroupName/:engineId/*" breadcrumb="Deploy to Kubernetes" let:meta>
           <DeployPodToKube
             resourceId="{decodeURI(meta.params.composeGroupName)}"
             engineId="{decodeURI(meta.params.engineId)}"

--- a/packages/renderer/src/lib/compose/ComposeActions.svelte
+++ b/packages/renderer/src/lib/compose/ComposeActions.svelte
@@ -69,7 +69,7 @@ async function restartCompose(composeInfoUI: ComposeInfoUI) {
 }
 
 function deployToKubernetes(): void {
-  router.goto(`/compose/deploy-to-kube/${compose.name}/${compose.engineId}`);
+  router.goto(`/compose-deploy-to-kube/${compose.name}/${compose.engineId}`);
 }
 
 function openGenerateKube(): void {

--- a/packages/renderer/src/lib/compose/ComposeActions.svelte
+++ b/packages/renderer/src/lib/compose/ComposeActions.svelte
@@ -69,11 +69,11 @@ async function restartCompose(composeInfoUI: ComposeInfoUI) {
 }
 
 function deployToKubernetes(): void {
-  router.goto(`/compose-deploy-to-kube/${compose.name}/${compose.engineId}`);
+  router.goto(`/compose/deploy-to-kube/${compose.name}/${compose.engineId}`);
 }
 
 function openGenerateKube(): void {
-  router.goto(`/compose/${encodeURI(compose.name)}/${encodeURI(compose.engineId)}/kube`);
+  router.goto(`/compose/details/${encodeURI(compose.name)}/${encodeURI(compose.engineId)}/kube`);
 }
 
 // If dropdownMenu = true, we'll change style to the imported dropdownMenu style

--- a/packages/renderer/src/lib/compose/ComposeDetailsLogs.svelte
+++ b/packages/renderer/src/lib/compose/ComposeDetailsLogs.svelte
@@ -35,7 +35,7 @@ let termFit: FitAddon;
 let currentRouterPath: string;
 
 // Router path for the logging
-let logsRouterPath = `/compose/${encodeURI(compose.name)}/${encodeURI(compose.engineId)}/logs`;
+let logsRouterPath = `/compose/details/${encodeURI(compose.name)}/${encodeURI(compose.engineId)}/logs`;
 
 // Create a map that will store the ANSI 256 colour for each container name
 // if we run out of colours, we'll start from the beginning.

--- a/packages/renderer/src/lib/container/ContainerList.svelte
+++ b/packages/renderer/src/lib/container/ContainerList.svelte
@@ -378,7 +378,7 @@ function openGroupDetails(containerGroup: ContainerGroupInfoUI): void {
   if (containerGroup.type === ContainerGroupInfoTypeUI.POD) {
     router.goto(`/pods/podman/${encodeURI(containerGroup.name)}/${encodeURIComponent(containerGroup.engineId)}/logs`);
   } else if (containerGroup.type === ContainerGroupInfoTypeUI.COMPOSE) {
-    router.goto(`/compose/${encodeURI(containerGroup.name)}/${encodeURI(containerGroup.engineId)}/logs`);
+    router.goto(`/compose/details/${encodeURI(containerGroup.name)}/${encodeURI(containerGroup.engineId)}/logs`);
   }
 }
 


### PR DESCRIPTION
### What does this PR do?

When used on a compose app, the Deploy to Kube form incorrectly shows the compose details at the bottom of the page. You can also see it in the breadcrumb that says 'Container > Compose Details' when it should say 'Container > Deploy to Kubernetes'.

The problem is the route path of these two pages can overlap:
 - /compose/deploy-to-kube/:composeGroupName/:engineId/*
 - /compose/:name/:engineId/* i.e. deploy to kube path also resolves to compose details page with name 'deploy-to-kube' and engineId of the compose group name.

Simple fix to just rename the path so they don't overlap.

### Screenshot/screencast of this PR

Same as before, but with correct breadcrumb and no details page at the bottom!

### What issues does this PR fix or reference?

Fixes #4723.

### How to test this PR?

Create a compose app and use the Deploy to Kubernetes action on the Containers page.