### PR TITLE
chore: shuffle and keep only 6 items for featured extensions

### DIFF
--- a/packages/main/src/plugin/featured/featured.spec.ts
+++ b/packages/main/src/plugin/featured/featured.spec.ts
@@ -120,3 +120,41 @@ test('getFeaturedExtensions should check installable extensions', async () => {
   expect(crcExtension?.icon).toBe('data:image/png;base64,456');
   expect(crcExtension?.fetchLink).toBe(ociLink);
 });
+
+test('getFeaturedExtensions should shuffle and limit to 6 extensions', async () => {
+  // mock the set of featured JSON extensions
+  const spyReadJson = vi.spyOn(featured, 'readFeaturedJson');
+
+  const jsonValues = [];
+  for (let i = 1; i < 10; i++) {
+    jsonValues.push({
+      extensionId: `podman-desktop.${i}`,
+      displayName: `Podman${i}`,
+      shortDescription: `test${i}`,
+      categories: ['Container Engine'],
+      builtIn: true,
+      icon: `data:image/png;base64,${i}`,
+    });
+  }
+  spyReadJson.mockReturnValue(jsonValues);
+
+  // init fetchable extensions
+  await featured.init();
+  const featuredExtensions1 = await featured.getFeaturedExtensions();
+
+  expect(featuredExtensions1).toBeDefined();
+
+  // should be limited to 6
+  expect(featuredExtensions1.length).toBe(6);
+
+  // call again to check the shuffle
+  const featuredExtensions2 = await featured.getFeaturedExtensions();
+
+  // compare id from the 2 lists
+  // they should be in a different order
+  const idsList1 = featuredExtensions1.map(e => e.id);
+  const idsList2 = featuredExtensions2.map(e => e.id);
+
+  // check that the 2 lists are not the same
+  expect(idsList1).not.toStrictEqual(idsList2);
+});

--- a/packages/main/src/plugin/featured/featured.ts
+++ b/packages/main/src/plugin/featured/featured.ts
@@ -89,6 +89,18 @@ export class Featured {
       return featuredExtension;
     });
 
+    // now, randomize the list to have only 6 items and list first the non installed extensions and then the installed one
+    // shuffle the list of featured extensions
+    featuredExtensions.sort(() => Math.random() - 0.5);
+
+    // take only 6 of them
+    if (featuredExtensions.length > 6) {
+      featuredExtensions.splice(6);
+    }
+
+    // and then by non installed first
+    featuredExtensions.sort((b, a) => Number(b.installed) - Number(a.installed));
+
     return featuredExtensions;
   }
 }


### PR DESCRIPTION
### What does this PR do?
shuffle and keep only 6 items for featured extensions

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast 
explaining what is doing this PR -->

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/4833

### How to test this PR?

unit test
else, go to the dashboard and see that  each time you refresh you got a different order of featured extensions
