### PR TITLE
chore: rename <icon component to <Icon

### DIFF
--- a/website/blog/2022-12-01-release-0.10-blog.md
+++ b/website/blog/2022-12-01-release-0.10-blog.md
@@ -33,7 +33,7 @@ Until now, we could only specify port binding when building images to start cont
 
 **Custom Kubeconfig file path ([#780](https://github.com/containers/podman-desktop/pull/780))**
 
-Kubeconfig path location is now configurable from **<icon icon="fa-solid fa-cog" size="lg" /> Settings > Preferences > Kubernetes: Kubeconfig** and can be set to a custom path. By default, Podman Desktop use the path `$HOME/.kube/config` for the Kubeconfig file.
+Kubeconfig path location is now configurable from **<Icon icon="fa-solid fa-cog" size="lg" /> Settings > Preferences > Kubernetes: Kubeconfig** and can be set to a custom path. By default, Podman Desktop use the path `$HOME/.kube/config` for the Kubeconfig file.
 
 ![custom kubeconfig file path](img/podman-desktop-release-0.10/custom-kubeconfig.png)
 

--- a/website/blog/2023-02-15-release-0.12.md
+++ b/website/blog/2023-02-15-release-0.12.md
@@ -49,7 +49,7 @@ Podman Desktop 0.12 offers the ability to be installed on Windows Home Edition. 
 
 Podman Desktop now provides a "start minimized" option when users log in onto the laptop. This option, available from the application's settings, can be useful if users want to automatically launch Podman Desktop at log in, but prefer not to have the window visible on the screen. With this feature, you can ensure that Podman Desktop is up and running in the background without any interruption to your workflows.
 
-- Go to **<icon icon="fa-solid fa-cog" size="lg" /> Settings > Preferences > Login: Minimize** to activate the option.
+- Go to **<Icon icon="fa-solid fa-cog" size="lg" /> Settings > Preferences > Login: Minimize** to activate the option.
 
 ![minimize-on-login](https://user-images.githubusercontent.com/6422176/216651424-bcf756fd-7554-4b24-a838-e3e2f798fe6e.png)
 

--- a/website/blog/2023-03-29-release-0.13.md
+++ b/website/blog/2023-03-29-release-0.13.md
@@ -64,7 +64,7 @@ A new Task Manager has been added to the status bar to see the progress (or retu
 
 #### Updated Resources Settings [#1582](https://github.com/containers/podman-desktop/pull/1582)
 
-The **<icon icon="fa-solid fa-cog" size="lg" /> Settings > Resources** page has been updated with a new design, making it easier to see and control your providers from a single place.
+The **<Icon icon="fa-solid fa-cog" size="lg" /> Settings > Resources** page has been updated with a new design, making it easier to see and control your providers from a single place.
 
 ![resources](https://user-images.githubusercontent.com/49404737/221908815-595715fe-4c95-4087-89e0-45e5544ed5c9.gif)
 

--- a/website/blog/2023-04-14-release-0.14.md
+++ b/website/blog/2023-04-14-release-0.14.md
@@ -25,7 +25,7 @@ all the Kind features.
 <!--Main Features-->
 
 - **Kind Installation**: Install Kind from the status bar
-- **Manage Kind Clusters**: Create and manage Kind clusters from **<icon icon="fa-solid fa-cog" size="lg" /> Settings > Resources**
+- **Manage Kind Clusters**: Create and manage Kind clusters from **<Icon icon="fa-solid fa-cog" size="lg" /> Settings > Resources**
 - **Using Kind**: Deploying YAML and sharing images to a cluster
 - **Kind Ingress**: Install a Contour ingress controller
 - **UX and UI Improvements**: Updated preferences and telemetry prompt
@@ -52,7 +52,7 @@ allowing you to open a terminal window to `kind get clusters` or work with other
 
 ### Manage Kind Clusters
 
-Once Kind is installed (or if you already had it), you can manage your clusters in **<icon icon="fa-solid fa-cog" size="lg" /> Settings > Resources**.
+Once Kind is installed (or if you already had it), you can manage your clusters in **<Icon icon="fa-solid fa-cog" size="lg" /> Settings > Resources**.
 From here you can [create Kind clusters](/docs/kind/creating-a-kind-cluster),
 start/stop [1953](https://github.com/containers/podman-desktop/issues/1953)
 or delete [1977](https://github.com/containers/podman-desktop/issues/1977) them.
@@ -98,7 +98,7 @@ makes it easy to get started with Kind and shows where we're headed. As always, 
 
 #### Updated Preferences
 
-The **<icon icon="fa-solid fa-cog" size="lg" /> Settings > Preferences** page has been updated with a new design [1913](https://github.com/containers/podman-desktop/pull/1913),
+The **<Icon icon="fa-solid fa-cog" size="lg" /> Settings > Preferences** page has been updated with a new design [1913](https://github.com/containers/podman-desktop/pull/1913),
 making it easier to see and change preferences. Changes are live, no more Update button.
 
 ![preferences](https://user-images.githubusercontent.com/49404737/229498507-e754b55c-dcbd-486d-9ee3-a1fe3bed7271.gif)

--- a/website/blog/2023-04-19-running-a-local-kubernetes-cluster-with-podman-desktop.md
+++ b/website/blog/2023-04-19-running-a-local-kubernetes-cluster-with-podman-desktop.md
@@ -91,8 +91,8 @@ Podman Desktop helps you [installing the `kind` CLI](/docs/kind/installing):
    $ podman system connection default podman-machine-default-root
    ```
 
-1. Go to **<icon icon="fa-solid fa-cog" size="lg" /> Settings > Resources**
-1. In the **<img src="/img/podman-icon.png" alt="Podman icon" style={{height: '1.5em', display: 'inline'}} /> Podman** tile, click on the **<icon icon="fa-solid fa-repeat" size="lg" />** icon to restart the Podman container engine.
+1. Go to **<Icon icon="fa-solid fa-cog" size="lg" /> Settings > Resources**
+1. In the **<img src="/img/podman-icon.png" alt="Podman icon" style={{height: '1.5em', display: 'inline'}} /> Podman** tile, click on the **<Icon icon="fa-solid fa-repeat" size="lg" />** icon to restart the Podman container engine.
 1. In the **<img src="/img/kind-icon.png" alt="Kind icon" style={{height: '1.5em', display: 'inline'}} /> Kind** tile, click on the **Create new** button.
    1. **Name**: enter `kind-cluster`.
    1. **Provider Type**: select `podman`.
@@ -105,7 +105,7 @@ Podman Desktop helps you [installing the `kind` CLI](/docs/kind/installing):
 
 #### Verification
 
-1. In **<icon icon="fa-solid fa-cog" size="lg" /> Settings > Resources** your Kind cluster is running/
+1. In **<Icon icon="fa-solid fa-cog" size="lg" /> Settings > Resources** your Kind cluster is running/
 
    ![Kind cluster is running](img/running-a-local-kubernetes-cluster-with-podman-desktop/kind-cluster-is-running.png)
 
@@ -128,32 +128,32 @@ This is functionally equal to the `redis-leader` deployment that the Kubernetes 
 
 #### Procedure
 
-1. Open **<icon icon="fa-solid fa-cloud" size="lg" /> Images > <icon icon="fa-solid fa-arrow-circle-down" size="lg" /> Pull an image**.
+1. Open **<Icon icon="fa-solid fa-cloud" size="lg" /> Images > <Icon icon="fa-solid fa-arrow-circle-down" size="lg" /> Pull an image**.
    1. **Image to Pull**: enter `docker.io/redis:6.0.5`
    1. Click **Pull image** to pull the image to your container engine local image registry.
    1. Click **Done** to get back to the images list.
-1. **<icon icon="fa-solid fa-cloud" size="lg" /> Search images**: enter `redis:6.0.5` to find the image.
-1. Click **<icon icon="fa-solid fa-play" size="lg" />** to open the **Create a container from image** dialog.
+1. **<Icon icon="fa-solid fa-cloud" size="lg" /> Search images**: enter `redis:6.0.5` to find the image.
+1. Click **<Icon icon="fa-solid fa-play" size="lg" />** to open the **Create a container from image** dialog.
    1. **Container name**: enter `leader`,
    1. **Local port for `6379/tcp`**: `6379`.
-   1. Click **<icon icon="fa-solid fa-play" size="lg" /> Start Container** to start the container in your container engine.
-1. **<icon icon="fa-solid fa-cloud" size="lg" /> Search containers**: enter `leader` to find the running container.
-1. Click **<icon icon="fa-solid fa-stop" size="lg" />** to stop the container, and leave the `6379` port available for the Redis follower container.
+   1. Click **<Icon icon="fa-solid fa-play" size="lg" /> Start Container** to start the container in your container engine.
+1. **<Icon icon="fa-solid fa-cloud" size="lg" /> Search containers**: enter `leader` to find the running container.
+1. Click **<Icon icon="fa-solid fa-stop" size="lg" />** to stop the container, and leave the `6379` port available for the Redis follower container.
 
-1. Click **<icon icon="fa-solid fa-ellipsis-v" size="lg" /> > <icon icon="fa-solid fa-rocket" size="lg" /> Deploy to Kubernetes** to open the **Deploy generated pod to Kubernetes** screen.
+1. Click **<Icon icon="fa-solid fa-ellipsis-v" size="lg" /> > <Icon icon="fa-solid fa-rocket" size="lg" /> Deploy to Kubernetes** to open the **Deploy generated pod to Kubernetes** screen.
 
    1. **Pod Name**: enter `redis-leader`.
    1. **Use Kubernetes Services**: select **Replace `hostPort` exposure on containers by Services. It is the recommended way to expose ports, as a cluster policy might prevent to use `hostPort`.**
    1. **Expose service locally using Kubernetes Ingress**: deselect **Create a Kubernetes ingress to get access to the ports that this pod exposes, at the default ingress controller location. Example: on a default Kind cluster created with Podman Desktop: `http://localhost:9090`. Requirements: your cluster has an ingress controller`**.
    1. **Kubernetes namespaces**: select `default`.
-   1. Click **<icon icon="fa-solid fa-rocket" size="lg" /> Deploy**.
+   1. Click **<Icon icon="fa-solid fa-rocket" size="lg" /> Deploy**.
       ![Deploy generated leader pod to Kubernetes screen](img/running-a-local-kubernetes-cluster-with-podman-desktop/deploy-generated-leader-pod-to-kubernetes.png)
    1. Wait for the pod to reach the state: **Phase: Running**.
    1. Click **Done**.
 
 #### Verification
 
-- The **<icon icon="fa-solid fa-cubes" size="lg" /> Pods** screen lists the running `redis-leader` pod.
+- The **<Icon icon="fa-solid fa-cubes" size="lg" /> Pods** screen lists the running `redis-leader` pod.
 
   ![leader pod is running](img/running-a-local-kubernetes-cluster-with-podman-desktop/leader-pod-is-running.png)
 
@@ -166,23 +166,23 @@ This is functionally equal to the `redis-follower` deployment that the Kubernete
 
 #### Procedure
 
-1. Open **<icon icon="fa-solid fa-cloud" size="lg" /> Images > <icon icon="fa-solid fa-arrow-circle-down" size="lg" /> Pull an image**.
+1. Open **<Icon icon="fa-solid fa-cloud" size="lg" /> Images > <Icon icon="fa-solid fa-arrow-circle-down" size="lg" /> Pull an image**.
    1. **Image to Pull**: enter `gcr.io/google_samples/gb-redis-follower:v2`
    1. Click **Pull image** to pull the image to your container engine local image registry.
    1. Click **Done** to get back to the images list.
-1. **<icon icon="fa-solid fa-cloud" size="lg" /> Search images**: enter `gb-redis-follower:v2` to find the image.
-1. Click **<icon icon="fa-solid fa-play" size="lg" />** to open the **Create a container from image** dialog.
+1. **<Icon icon="fa-solid fa-cloud" size="lg" /> Search images**: enter `gb-redis-follower:v2` to find the image.
+1. Click **<Icon icon="fa-solid fa-play" size="lg" />** to open the **Create a container from image** dialog.
    1. **Container name**: enter `follower`,
    1. **Local port for `6379/tcp`**: `6379`.
-   1. Click **<icon icon="fa-solid fa-play" size="lg" /> Start Container** to start the container in your container engine.
-1. **<icon icon="fa-solid fa-cloud" size="lg" /> Search containers**: enter `follower` to find the running container.
-1. Click **<icon icon="fa-solid fa-stop" size="lg" />** to stop the container: you do not need it to run in the container engine.
-1. Click **<icon icon="fa-solid fa-ellipsis-v" size="lg" /> > <icon icon="fa-solid fa-rocket" size="lg" /> Deploy to Kubernetes** to open the **Deploy generated pod to Kubernetes** screen.
+   1. Click **<Icon icon="fa-solid fa-play" size="lg" /> Start Container** to start the container in your container engine.
+1. **<Icon icon="fa-solid fa-cloud" size="lg" /> Search containers**: enter `follower` to find the running container.
+1. Click **<Icon icon="fa-solid fa-stop" size="lg" />** to stop the container: you do not need it to run in the container engine.
+1. Click **<Icon icon="fa-solid fa-ellipsis-v" size="lg" /> > <Icon icon="fa-solid fa-rocket" size="lg" /> Deploy to Kubernetes** to open the **Deploy generated pod to Kubernetes** screen.
    1. **Pod Name**: enter `redis-follower`.
    1. **Use Kubernetes Services**: select **Replace `hostPort` exposure on containers by Services. It is the recommended way to expose ports, as a cluster policy might prevent to use `hostPort`.**
    1. **Expose service locally using Kubernetes Ingress**: deselect **Create a Kubernetes ingress to get access to the ports that this pod exposes, at the default ingress controller location. Example: on a default Kind cluster created with Podman Desktop: `http://localhost:9090`. Requirements: your cluster has an ingress controller`**.
    1. **Kubernetes namespaces**: select `default`.
-   1. Click **<icon icon="fa-solid fa-rocket" size="lg" /> Deploy**.
+   1. Click **<Icon icon="fa-solid fa-rocket" size="lg" /> Deploy**.
       ![Deploy generated follower pod to Kubernetes screen](img/running-a-local-kubernetes-cluster-with-podman-desktop/deploy-generated-follower-pod-to-kubernetes.png)
    1. Wait for the pod to reach the state: **Phase: Running**.
    1. Click **Done**.
@@ -190,7 +190,7 @@ This is functionally equal to the `redis-follower` deployment that the Kubernete
 
 #### Verification
 
-- The **<icon icon="fa-solid fa-cubes" size="lg" /> Pods** screen lists the running `redis-follower` pods.
+- The **<Icon icon="fa-solid fa-cubes" size="lg" /> Pods** screen lists the running `redis-follower` pods.
 
   ![follower pods are running](img/running-a-local-kubernetes-cluster-with-podman-desktop/follower-pods-are-running.png)
 
@@ -208,31 +208,31 @@ This is functionally equal to the `frontend` deployment that the Kubernetes exam
 
 #### Procedure
 
-1. Open **<icon icon="fa-solid fa-cloud" size="lg" /> Images > <icon icon="fa-solid fa-arrow-circle-down" size="lg" /> Pull an image**.
+1. Open **<Icon icon="fa-solid fa-cloud" size="lg" /> Images > <Icon icon="fa-solid fa-arrow-circle-down" size="lg" /> Pull an image**.
    1. **Image to Pull**: enter `gcr.io/google_samples/gb-frontend:v5`
    1. Click **Pull image** to pull the image to your container engine local image registry.
    1. Wait for the pull to complete.
    1. Click **Done** to get back to the images list.
-1. **<icon icon="fa-solid fa-cloud" size="lg" /> Search images**: enter `gb-frontend:v5` to find the image.
-1. Click **<icon icon="fa-solid fa-play" size="lg" />** to open the **Create a container from image** dialog.
+1. **<Icon icon="fa-solid fa-cloud" size="lg" /> Search images**: enter `gb-frontend:v5` to find the image.
+1. Click **<Icon icon="fa-solid fa-play" size="lg" />** to open the **Create a container from image** dialog.
    1. **Container name**: enter `frontend`,
    1. **Local port for `80/tcp`**: `9000`.
-   1. Click **<icon icon="fa-solid fa-play" size="lg" /> Start Container** to start the container in your container engine.
-1. **<icon icon="fa-solid fa-cloud" size="lg" /> Search containers**: enter `frontend` to find the running container.
-1. Click **<icon icon="fa-solid fa-stop" size="lg" />** to stop the container: you do not need it to run in the container engine.
-1. Click **<icon icon="fa-solid fa-ellipsis-v" size="lg" /> > <icon icon="fa-solid fa-rocket" size="lg" /> Deploy to Kubernetes** to open the **Deploy generated pod to Kubernetes** screen.
+   1. Click **<Icon icon="fa-solid fa-play" size="lg" /> Start Container** to start the container in your container engine.
+1. **<Icon icon="fa-solid fa-cloud" size="lg" /> Search containers**: enter `frontend` to find the running container.
+1. Click **<Icon icon="fa-solid fa-stop" size="lg" />** to stop the container: you do not need it to run in the container engine.
+1. Click **<Icon icon="fa-solid fa-ellipsis-v" size="lg" /> > <Icon icon="fa-solid fa-rocket" size="lg" /> Deploy to Kubernetes** to open the **Deploy generated pod to Kubernetes** screen.
    1. **Pod Name**: enter `frontend`.
    1. **Use Kubernetes Services**: select **Replace `hostPort` exposure on containers by Services. It is the recommended way to expose ports, as a cluster policy might prevent to use `hostPort`.**
    1. **Expose service locally using Kubernetes Ingress**: select **Create a Kubernetes ingress to get access to the ports that this pod exposes, at the default ingress controller location. Example: on a default Kind cluster created with Podman Desktop: `http://localhost:9090`. Requirements: your cluster has an ingress controller`**.
    1. **Kubernetes namespaces**: select `default`.
-   1. Click **<icon icon="fa-solid fa-rocket" size="lg" /> Deploy**.
+   1. Click **<Icon icon="fa-solid fa-rocket" size="lg" /> Deploy**.
       ![Deploy generated frontend pod to Kubernetes screen](img/running-a-local-kubernetes-cluster-with-podman-desktop/deploy-generated-frontend-pod-to-kubernetes.png)
    1. Wait for the pod to reach the state: **Phase: Running**.
    1. Click **Done**.
 
 #### Verification
 
-1. The **<icon icon="fa-solid fa-cubes" size="lg" /> Pods** screen lists the running `frontend` pod.
+1. The **<Icon icon="fa-solid fa-cubes" size="lg" /> Pods** screen lists the running `frontend` pod.
 
    ![`frontend` pod is running](img/running-a-local-kubernetes-cluster-with-podman-desktop/frontend-pod-is-running.png)
 

--- a/website/blog/2023-05-02-release-0.15.md
+++ b/website/blog/2023-05-02-release-0.15.md
@@ -65,7 +65,7 @@ It was time to catch up on some design ideas and do some UI cleanup!
 #### New Navgation Bar
 
 The navigation bar is now always fixed on the left size, without labels. This opens up more space
-for the content on each page, and is easier to jump in and out of **<icon icon="fa-solid fa-cog" size="lg" /> Settings**.
+for the content on each page, and is easier to jump in and out of **<Icon icon="fa-solid fa-cog" size="lg" /> Settings**.
 [#2167](https://github.com/containers/podman-desktop/issues/2167)
 
 ![Navigation bar](img/podman-desktop-release-0.15/navigation.png)
@@ -104,7 +104,7 @@ We can now embed links and other formatting in preferences, and extensions can u
 
 ## Other Notable Enhancements
 
-- We know which **Settings** page is used the most often, so now it's the default: **<icon icon="fa-solid fa-cog" size="lg" /> Settings > Resources** [#2105](https://github.com/containers/podman-desktop/issues/2105).
+- We know which **Settings** page is used the most often, so now it's the default: **<Icon icon="fa-solid fa-cog" size="lg" /> Settings > Resources** [#2105](https://github.com/containers/podman-desktop/issues/2105).
 
 - Extensions can now use the Tasks API to let long running tasks continue in the background [#2019](https://github.com/containers/podman-desktop/issues/2019) and the existing withProgress API also uses the task manager now
   [#2187](https://github.com/containers/podman-desktop/pull/2187).
@@ -116,7 +116,7 @@ We can now embed links and other formatting in preferences, and extensions can u
 - When you start/stop a container or pod, the button is now animated instead of having an separate spinner
   [#2101](https://github.com/containers/podman-desktop/issues/2101).
 
-- The **<icon icon="fa-solid fa-cog" size="lg" /> Settings > Preferences** page now has a search bar [#2128](https://github.com/containers/podman-desktop/pull/2128).
+- The **<Icon icon="fa-solid fa-cog" size="lg" /> Settings > Preferences** page now has a search bar [#2128](https://github.com/containers/podman-desktop/pull/2128).
 
 ![Search preferences](img/podman-desktop-release-0.15/prefs.png)
 
@@ -130,7 +130,7 @@ We can now embed links and other formatting in preferences, and extensions can u
 
 - There was no way to see log or outcome if you leave the Kind cluster creation page [#2079](https://github.com/containers/podman-desktop/issues/2079).
 - Kind image load doesn't show a notification [#2225](https://github.com/containers/podman-desktop/issues/2225).
-- Fix odd selection in **<icon icon="fa-solid fa-cog" size="lg" /> Settings > Extensions** [#2130](https://github.com/containers/podman-desktop/issues/2130).
+- Fix odd selection in **<Icon icon="fa-solid fa-cog" size="lg" /> Settings > Extensions** [#2130](https://github.com/containers/podman-desktop/issues/2130).
 - Menus are now cleaned up properly when extensions are stopped [#2188](https://github.com/containers/podman-desktop/pull/2188).
 - Kind clusters are now cleaned up when Podman machine is stopped [#2306](https://github.com/containers/podman-desktop/pull/2306).
 

--- a/website/blog/2023-05-17-release-1.0.md
+++ b/website/blog/2023-05-17-release-1.0.md
@@ -43,7 +43,7 @@ has not been easy to discover new extensions.
 
 With 1.0 we show a list of featured extensions in the **Welcome**
 [#2354](https://github.com/containers/podman-desktop/pull/2354), the **Dashboard** and in
-**<icon icon="fa-solid fa-cog" size="lg" /> Settings > Extensions**
+**<Icon icon="fa-solid fa-cog" size="lg" /> Settings > Extensions**
 [#2355](https://github.com/containers/podman-desktop/pull/2355). Check out the new
 extensions for **Red Hat OpenShift Local** and the **Developer Sandbox for Red Hat OpenShift**!
 

--- a/website/blog/2023-06-08-release-1.1.md
+++ b/website/blog/2023-06-08-release-1.1.md
@@ -42,7 +42,7 @@ Optional extensions will follow their own lifecycle and update independently fro
 this release you'll be able to see when there is an update available and install from within
 Podman Desktop [#2655](https://github.com/containers/podman-desktop/pull/2655).
 
-We've also added options in **<icon icon="fa-solid fa-cog" size="lg" />Settings > Preferences** to
+We've also added options in **<Icon icon="fa-solid fa-cog" size="lg" />Settings > Preferences** to
 automatically check for and install extension updates.
 
 <ReactPlayer playing controls url="https://user-images.githubusercontent.com/436777/241246481-305d215f-2a5c-46e8-9cc3-ecd90a6bd2bc.mp4" width='100%' height='100%' />
@@ -52,7 +52,7 @@ automatically check for and install extension updates.
 ### Lima Support
 
 Thanks to contributor [Anders Björklund](https://github.com/afbjorklund), we have some improvements to the
-Lima extension! In **<icon icon="fa-solid fa-cog" size="lg" />Settings > Preferences** you can select which
+Lima extension! In **<Icon icon="fa-solid fa-cog" size="lg" />Settings > Preferences** you can select which
 engine type Lima runs on and override the instance name [#2674](https://github.com/containers/podman-desktop/pull/2674).
 
 ![Lima preferences](https://user-images.githubusercontent.com/10364051/241755966-0a6a293b-b18e-4222-9c40-abd6c114d464.png)

--- a/website/blog/2023-11-03-release-1.5.md
+++ b/website/blog/2023-11-03-release-1.5.md
@@ -39,7 +39,7 @@ To start the Podman onboarding flow, you can start from the dashboard notificati
 ![podman-onboarding-start](https://user-images.githubusercontent.com/799683/280362279-598cc052-5ea4-4c31-849c-da9bbbcc3e42.png)
 ![podman-onboarding](https://user-images.githubusercontent.com/799683/280363859-f35b85f8-1dd4-4b7f-a995-25fe5d1ccced.png)
 
-Visit **<icon icon="fa-solid fa-cog" size="lg"/>Settings > Resources** screen and click the Compose "Setup ..." button in order to start Compose onboarding:
+Visit **<Icon icon="fa-solid fa-cog" size="lg"/>Settings > Resources** screen and click the Compose "Setup ..." button in order to start Compose onboarding:
 ![compose-onboarding-start](https://user-images.githubusercontent.com/799683/280276847-ca0558ab-70ad-48cc-8dd5-67e3eb465a62.png)
 ![compose-onboarding](https://user-images.githubusercontent.com/799683/280277936-77ba0fb2-5cb0-41de-a7cf-1a3d6400fd89.png)
 
@@ -61,7 +61,7 @@ When creating a container from the Images list, there's now an option to provide
 
 ### Enhancements to the Settings area
 
-The user experience for enabling or disabling Docker compatibility is improved, with a new entry in the **<icon icon="fa-solid fa-cog" size="lg" />Settings > Preferences** screen that includes contextual guidance. [#4093](https://github.com/containers/podman-desktop/pull/4093)
+The user experience for enabling or disabling Docker compatibility is improved, with a new entry in the **<Icon icon="fa-solid fa-cog" size="lg" />Settings > Preferences** screen that includes contextual guidance. [#4093](https://github.com/containers/podman-desktop/pull/4093)
 
 <ReactPlayer playing controls url="https://user-images.githubusercontent.com/6422176/270497318-902b2566-62ad-4ee6-87af-6a9a2705de99.mov" width='100%' height='100%' />
 
@@ -89,7 +89,7 @@ The 🦭 Podman Desktop extension API received many improvements, including:
 
 - Extensions have gained the ability to contribute menu items in the UI based on specific conditions. [#3959](https://github.com/containers/podman-desktop/pull/3959)
 
-- Enhanced logic for displaying or hiding properties listed under the **<icon icon="fa-solid fa-cog" size="lg" />Settings > Preferences** screens is now available. [#4159](https://github.com/containers/podman-desktop/pull/4159)
+- Enhanced logic for displaying or hiding properties listed under the **<Icon icon="fa-solid fa-cog" size="lg" />Settings > Preferences** screens is now available. [#4159](https://github.com/containers/podman-desktop/pull/4159)
 
 <ReactPlayer playing controls url="https://user-images.githubusercontent.com/6422176/271650937-3991565c-12a4-4e6c-a315-9343bfa25f65.mov" width='100%' height='100%' />
 

--- a/website/docs/compose/running-compose.md
+++ b/website/docs/compose/running-compose.md
@@ -60,6 +60,6 @@ With Podman Desktop, you can manage multi-container applications defined in a Co
 
 1. Podman Desktop detects the Compose labels, and displays the container group as a group of containers.
 
-   The Podman Desktop **<icon icon="fa-solid fa-cube" size="lg" /> Containers** list displays the containers created by Compose grouped in a container group with a `(compose)` suffix, such as `flask-redis (compose)`.
+   The Podman Desktop **<Icon icon="fa-solid fa-cube" size="lg" /> Containers** list displays the containers created by Compose grouped in a container group with a `(compose)` suffix, such as `flask-redis (compose)`.
 
 ![img2](img/compose-in-containers-view.png)

--- a/website/docs/compose/setting-up-compose.md
+++ b/website/docs/compose/setting-up-compose.md
@@ -12,7 +12,7 @@ Podman Desktop can install the Compose engine.
 
 #### Procedure
 
-1. Go to **<icon icon="fa-solid fa-cog" size="lg" /> Settings > Resources**.
+1. Go to **<Icon icon="fa-solid fa-cog" size="lg" /> Settings > Resources**.
 1. In the **Compose** tile, click **Setup**, and follow the prompts.
 
 #### Verification

--- a/website/docs/containers/creating-a-pod.md
+++ b/website/docs/containers/creating-a-pod.md
@@ -23,23 +23,23 @@ Consider running containers in a pod to:
 
 #### Procedure
 
-1. Go to **<icon icon="fa-solid fa-cube" size="lg" /> Containers**.
+1. Go to **<Icon icon="fa-solid fa-cube" size="lg" /> Containers**.
 1. Click the checkbox in the container line for your containers, such as `database` and `frontend`.
-1. Click **<icon icon="fa-solid fa-cubes" size="lg" />**.
+1. Click **<Icon icon="fa-solid fa-cubes" size="lg" />**.
 1. In the **Copy containers to a pod** screen:
    1. **Name of the pod**: enter your pod name, such as `my-pod`.
    1. **All selected ports will be exposed**:
       1. Select `frontend`.
       1. Clear `database`.
-1. Click **<icon icon="fa-solid fa-cube" size="lg" /> Create Pod**.
+1. Click **<Icon icon="fa-solid fa-cube" size="lg" /> Create Pod**.
 
 #### Verification
 
-1. Go to **<icon icon="fa-solid fa-cubes" size="lg" /> Pods**.
+1. Go to **<Icon icon="fa-solid fa-cubes" size="lg" /> Pods**.
 1. Click your pod, such as `my-pod`.
 1. Go to **Logs**: see the combined logs from the two containers.
 1. Go to **Summary**: see the containers.
 1. Click `frontend-podified`.
-1. Click **<icon icon="fa-solid fa-external-link" size="lg" />**.
+1. Click **<Icon icon="fa-solid fa-external-link" size="lg" />**.
 1. Your browser opens the service exposed by your `frontend-podified` container.
-1. Go to **<icon icon="fa-solid fa-cube" size="lg" /> Containers**: see the running containers.
+1. Go to **<Icon icon="fa-solid fa-cube" size="lg" /> Containers**: see the running containers.

--- a/website/docs/containers/images/building-an-image.md
+++ b/website/docs/containers/images/building-an-image.md
@@ -16,18 +16,18 @@ With Podman Desktop, you can build an image from a Containerfile on your contain
 
 #### Procedure
 
-1. Go to **<icon icon="fa-solid fa-cloud" size="lg" /> Images**.
-1. Click **<icon icon="fa-solid fa-cube" size="lg" /> Build an image**.
+1. Go to **<Icon icon="fa-solid fa-cloud" size="lg" /> Images**.
+1. Click **<Icon icon="fa-solid fa-cube" size="lg" /> Build an image**.
 1. On the **Build Image from Containerfile** screen
    1. **Containerfile path**: select the `Containerfile` or `Dockerfile` to build.
    1. **Image Name**: enter your image name, such as `my-image`. If you want to push the image to a registry, use the fully qualified image name that your registry requires, such as `quay.io/my-repository/my-image`, `ghcr.io/my-repository/my-image`, or `docker.io/my-repository/my-image`.
-   1. Click **<icon icon="fa-solid fa-cubes" size="lg" /> Build**.
+   1. Click **<Icon icon="fa-solid fa-cubes" size="lg" /> Build**.
    1. Click **Done**.
 
 #### Verification
 
-1. Go to **<icon icon="fa-solid fa-cloud" size="lg" /> Images**.
-1. **<icon icon="fa-solid fa-search" size="lg" />**: Enter your image name, such as `quay.io/my-repository/my-image`, `ghcr.io/my-repository/my-image`, or `docker.io/my-repository/my-image`.
+1. Go to **<Icon icon="fa-solid fa-cloud" size="lg" /> Images**.
+1. **<Icon icon="fa-solid fa-search" size="lg" />**: Enter your image name, such as `quay.io/my-repository/my-image`, `ghcr.io/my-repository/my-image`, or `docker.io/my-repository/my-image`.
 1. Click the line with your image name.
 1. Go to **History**.
    1. Click the content area to activate it.
@@ -35,5 +35,5 @@ With Podman Desktop, you can build an image from a Containerfile on your contain
 1. Go to **Inspect**.
    1. Click the content area to activate it.
    1. Enter <kbd>Ctrl</kbd> + <kbd>F</kbd> on Windows and Linux, or <kbd>⌘</kbd> + <kbd>F</kbd> on macOS to start searching in the content.
-1. Click **<icon icon="fa-solid fa-play" size="lg" />**..
+1. Click **<Icon icon="fa-solid fa-play" size="lg" />**..
    1. You see the **Create a container** screen.

--- a/website/docs/containers/images/pulling-an-image.md
+++ b/website/docs/containers/images/pulling-an-image.md
@@ -13,12 +13,12 @@ With Podman Desktop, you can pull an image from a registry, to your container en
 #### Prerequisites
 
 - The image is available in a registry.
-- If the registry or the image are not publicly available, you configured access to the registry on Podman Desktop in **<icon icon="fa-solid fa-cog" size="lg" /> Settings > Registries**.
+- If the registry or the image are not publicly available, you configured access to the registry on Podman Desktop in **<Icon icon="fa-solid fa-cog" size="lg" /> Settings > Registries**.
 
 #### Procedure
 
-1. Go to **<icon icon="fa-solid fa-cloud" size="lg" /> Images**.
-1. Click **<icon icon="fa-solid fa-arrow-circle-down" size="lg" /> Pull an image**.
+1. Go to **<Icon icon="fa-solid fa-cloud" size="lg" /> Images**.
+1. Click **<Icon icon="fa-solid fa-arrow-circle-down" size="lg" /> Pull an image**.
 1. On the **Image to Pull** screen:
    1. **Image to pull**: enter the image name, such as `quay.io/podman/hello`. Prefer the fully qualified image name that specifies the registry, to the short name that might lead to registry resolution mistakes.
    2. Click **Pull image**.
@@ -26,7 +26,7 @@ With Podman Desktop, you can pull an image from a registry, to your container en
 
 #### Verification
 
-1. Go to **<icon icon="fa-solid fa-cloud" size="lg" /> Images**.
+1. Go to **<Icon icon="fa-solid fa-cloud" size="lg" /> Images**.
 1. Click the image name you pulled, such as `quay.io/podman/hello`. Podman Desktop always displays the fully qualified image name.
 1. Go to **Summary**.
 1. Go to **History**.

--- a/website/docs/containers/images/pushing-an-image-to-a-registry.md
+++ b/website/docs/containers/images/pushing-an-image-to-a-registry.md
@@ -12,16 +12,16 @@ With Podman Desktop, you can push an image to registries.
 
 #### Prerequisites
 
-- You have configured your registry **<icon icon="fa-solid fa-cog" size="lg" /> Settings > Registries**.
+- You have configured your registry **<Icon icon="fa-solid fa-cog" size="lg" /> Settings > Registries**.
 - You have built an image, which name is the fully qualified name required for your registry, such as `quay.io/my-repository/my-image`, `ghcr.io/my-repository/my-image`, or `docker.io/my-repository/my-image`.
   Ensure that the image name includes the registry where to publish the image. To publish on `quay.io/repository` the image `my-image`, the FQN image name should be `quay.io/repository/my-image`.
 
 #### Procedure
 
-1. Go to **<icon icon="fa-solid fa-cloud" size="lg" /> Images**.
-1. On your image line, click **<icon icon="fa-solid fa-ellipsis-v" size="lg" /> > <icon icon="fa-solid fa-arrow-up" size="lg" />Push Image**.
+1. Go to **<Icon icon="fa-solid fa-cloud" size="lg" /> Images**.
+1. On your image line, click **<Icon icon="fa-solid fa-ellipsis-v" size="lg" /> > <Icon icon="fa-solid fa-arrow-up" size="lg" />Push Image**.
 1. Select the Image tag for your registry.
-1. Click **<icon icon="fa-solid fa-arrow-up" size="lg" />Push Image**.
+1. Click **<Icon icon="fa-solid fa-arrow-up" size="lg" />Push Image**.
 1. Click **Done**.
 
 #### Verification

--- a/website/docs/containers/registries/_insecure-registry-linux.md
+++ b/website/docs/containers/registries/_insecure-registry-linux.md
@@ -4,7 +4,7 @@
 
 #### Procedure
 
-1. Add your insecure registry within **<icon icon="fa-solid fa-cog" size="lg" /> Settings > Registries**.
+1. Add your insecure registry within **<Icon icon="fa-solid fa-cog" size="lg" /> Settings > Registries**.
 
    ![Adding a custom registry](img/adding-a-custom-registry.png)
 

--- a/website/docs/containers/registries/_insecure-registry-windows-macos.md
+++ b/website/docs/containers/registries/_insecure-registry-windows-macos.md
@@ -4,7 +4,7 @@
 
 #### Procedure
 
-1. Add your insecure registry within **<icon icon="fa-solid fa-cog" size="lg" /> Settings > Registries**.
+1. Add your insecure registry within **<Icon icon="fa-solid fa-cog" size="lg" /> Settings > Registries**.
 
    ![Adding a custom registry](img/adding-a-custom-registry.png)
 

--- a/website/docs/containers/registries/_verification-private-registry.md
+++ b/website/docs/containers/registries/_verification-private-registry.md
@@ -1,8 +1,8 @@
 #### Verification
 
-1. Go to **<icon icon="fa-solid fa-cloud" size="lg" /> Images**.
+1. Go to **<Icon icon="fa-solid fa-cloud" size="lg" /> Images**.
 1. You can pull a private image from the registry.
 1. You can push an image to the registry:
    1. Build an image with the fully qualified name required for your registry, such as `quay.io/my-repository/my-image`, `ghcr.io/my-repository/my-image`, `docker.io/my-repository/my-image`, or `my-registry.tld/my-repository/my-image`.
-   1. On your image line, click **<icon icon="fa-solid fa-ellipsis-v" size="lg" />**.
-   1. The contextual menu has a **<icon icon="fa-solid fa-arrow-up" size="lg" />Push Image** entry.
+   1. On your image line, click **<Icon icon="fa-solid fa-ellipsis-v" size="lg" />**.
+   1. The contextual menu has a **<Icon icon="fa-solid fa-arrow-up" size="lg" />Push Image** entry.

--- a/website/docs/containers/registries/authenticating-to-a-preconfigured-registry.md
+++ b/website/docs/containers/registries/authenticating-to-a-preconfigured-registry.md
@@ -23,7 +23,7 @@ With Podman Desktop, you can authenticate to a set of pre-configured registries:
 
 #### Procedure
 
-1. Go to **<icon icon="fa-solid fa-cog" size="lg" /> Settings > Registries**.
+1. Go to **<Icon icon="fa-solid fa-cog" size="lg" /> Settings > Registries**.
 1. On your registry line, click **Configure**.
 
    1. **User name**: Enter your user name.

--- a/website/docs/containers/starting-a-container.md
+++ b/website/docs/containers/starting-a-container.md
@@ -13,19 +13,19 @@ You can interact with the running container by using the terminal in Podman Desk
 
 #### Prerequisites
 
-- The **<icon icon="fa-solid fa-cloud" size="lg" /> Images** list has your image, such as `quay.io/podman/hello`.
+- The **<Icon icon="fa-solid fa-cloud" size="lg" /> Images** list has your image, such as `quay.io/podman/hello`.
 
 #### Procedure
 
-1. Go to **<icon icon="fa-solid fa-cloud" size="lg" /> Images**.
-1. On the line with your image name, such as `quay.io/podman/hello`, click **<icon icon="fa-solid fa-play" size="lg" />**.
+1. Go to **<Icon icon="fa-solid fa-cloud" size="lg" /> Images**.
+1. On the line with your image name, such as `quay.io/podman/hello`, click **<Icon icon="fa-solid fa-play" size="lg" />**.
 1. On the **Create a container** screen, review the configuration.
-1. Click **<icon icon="fa-solid fa-play" size="lg" /> Start Container**.
+1. Click **<Icon icon="fa-solid fa-play" size="lg" /> Start Container**.
 
 #### Verification
 
-1. Go to **<icon icon="fa-solid fa-cubes" size="lg" /> Containers**.
-1. **<icon icon="fa-solid fa-search" size="lg" />**: Enter your image name, such as `quay.io/podman/hello`, to find your running container.
+1. Go to **<Icon icon="fa-solid fa-cubes" size="lg" /> Containers**.
+1. **<Icon icon="fa-solid fa-search" size="lg" />**: Enter your image name, such as `quay.io/podman/hello`, to find your running container.
 1. Click your running container name.
 1. To view logs:
    1. Go to **Logs**.
@@ -45,13 +45,13 @@ You can interact with the running container by using the terminal in Podman Desk
    1. Click the content area to activate the terminal.
    1. Enter your commands.
 1. To interact with the exposed ports:
-   1. Click **<icon icon="fa-solid fa-external-link" size="lg" />**.
+   1. Click **<Icon icon="fa-solid fa-external-link" size="lg" />**.
    1. Your browser opens a page to the first exposed port on `localhost`.
 1. To deploy to your current Kubernetes context, when you container engine is Podman:
-   1. Click **<icon icon="fa-solid fa-rocket" size="lg" />**.
+   1. Click **<Icon icon="fa-solid fa-rocket" size="lg" />**.
    1. Review the **Deploy generated pod to Kubernetes** screen.
-   1. Click **<icon icon="fa-solid fa-rocket" size="lg" />**.
+   1. Click **<Icon icon="fa-solid fa-rocket" size="lg" />**.
 1. To stop the container:
-1. Click **<icon icon="fa-solid fa-stop" size="lg" />**.
+1. Click **<Icon icon="fa-solid fa-stop" size="lg" />**.
 1. To delete the container:
-1. Click **<icon icon="fa-solid fa-trash" size="lg" />**.
+1. Click **<Icon icon="fa-solid fa-trash" size="lg" />**.

--- a/website/docs/extensions/install/index.md
+++ b/website/docs/extensions/install/index.md
@@ -18,7 +18,7 @@ Consider installing Podman Desktop extensions to enrich the default capabilities
 
 #### Procedure
 
-1. Go to the **<icon icon="fa-solid fa-cog" size="lg" /> Settings > Extensions**.
+1. Go to the **<Icon icon="fa-solid fa-cog" size="lg" /> Settings > Extensions**.
 
 1. In the **Name of the Image** field, write the extension OCI image name.
 

--- a/website/docs/kind/building-an-image-and-testing-it-in-kind.md
+++ b/website/docs/kind/building-an-image-and-testing-it-in-kind.md
@@ -21,41 +21,41 @@ With Podman Desktop, you can build an image with your container engine, and test
 
 1. Build your image:
 
-   1. Open **<icon icon="fa-solid fa-cloud" size="lg" /> Images > <icon icon="fa-solid fa-cube" size="lg" /> Build an image**.
+   1. Open **<Icon icon="fa-solid fa-cloud" size="lg" /> Images > <Icon icon="fa-solid fa-cube" size="lg" /> Build an image**.
    1. **Containerfile path**: select your `Containerfile` or `Dockerfile`.
    1. **Build context directory**: optionally, select a directory different from the directory containing your `Containerfile` or `Dockerfile`.
    1. **Image Name**: enter your image name `my-custom-image`.
-   1. Click **<icon icon="fa-solid fa-cube" size="lg" /> Build**.
+   1. Click **<Icon icon="fa-solid fa-cube" size="lg" /> Build**.
    1. Wait for the image build to finish.
    1. Click **Done** to get back to the images list.
 
 1. Push your image to your Kind cluster:
 
-   1. **<icon icon="fa-solid fa-cloud" size="lg" /> Search images**: enter your image name `my-custom-image` to find the image.
-   1. Click **<icon icon="fa-solid fa-ellipsis-v" size="lg" /> > <icon icon="fa-solid fa-ellipsis-v" size="lg" /> Push image to Kind cluster**.
+   1. **<Icon icon="fa-solid fa-cloud" size="lg" /> Search images**: enter your image name `my-custom-image` to find the image.
+   1. Click **<Icon icon="fa-solid fa-ellipsis-v" size="lg" /> > <Icon icon="fa-solid fa-ellipsis-v" size="lg" /> Push image to Kind cluster**.
 
 1. Test your image by creating a container:
 
-   1. Click **<icon icon="fa-solid fa-play" size="lg" />** to open the **Create a container from image** dialog.
+   1. Click **<Icon icon="fa-solid fa-play" size="lg" />** to open the **Create a container from image** dialog.
    1. **Container name**: enter `my-custom-image-container`.
    1. Review the parameters that Podman Desktop has detected from your image definition.
-   1. Click **<icon icon="fa-solid fa-play" size="lg" /> Start Container** to start the container in your container engine.
+   1. Click **<Icon icon="fa-solid fa-play" size="lg" /> Start Container** to start the container in your container engine.
 
 1. Test your image and container on your Kind cluster:
 
-   1. **<icon icon="fa-solid fa-cloud" size="lg" /> Search containers**: enter `my-custom-image-container` to find the running container.
-   1. Click **<icon icon="fa-solid fa-ellipsis-v" size="lg" /> > <icon icon="fa-solid fa-rocket" size="lg" /> Deploy to Kubernetes** to open the **Deploy generated pod to Kubernetes** screen.
+   1. **<Icon icon="fa-solid fa-cloud" size="lg" /> Search containers**: enter `my-custom-image-container` to find the running container.
+   1. Click **<Icon icon="fa-solid fa-ellipsis-v" size="lg" /> > <Icon icon="fa-solid fa-rocket" size="lg" /> Deploy to Kubernetes** to open the **Deploy generated pod to Kubernetes** screen.
    1. **Pod Name**: keep the proposed value `my-custom-image-container-pod`.
    1. **Use Kubernetes Services**: select **Replace `hostPort` exposure on containers by Services. It is the recommended way to expose ports, as a cluster policy might prevent to use `hostPort`.**
    1. **Expose service locally using Kubernetes Ingress**: if your container is exposing at a port, select **Create a Kubernetes ingress to get access to the ports that this pod exposes, at the default ingress controller location. Example: on a default Kind cluster created with Podman Desktop: `http://localhost:9090`. Requirements: your cluster has an ingress controller`**.
    1. Optionally, if your container is exposing more than one port, select the port to expose.
    1. **Kubernetes namespaces**: select `default`.
-   1. Click **<icon icon="fa-solid fa-rocket" size="lg" /> Deploy**.
+   1. Click **<Icon icon="fa-solid fa-rocket" size="lg" /> Deploy**.
    1. Wait for the pod to reach the state: **Phase: Running**.
    1. Click **Done**.
 
 #### Verification
 
-1. The **<icon icon="fa-solid fa-cubes" size="lg" /> Pods** screen lists the running `my-image-container-pod` pod.
+1. The **<Icon icon="fa-solid fa-cubes" size="lg" /> Pods** screen lists the running `my-image-container-pod` pod.
 1. Click on the pod name to view details and logs.
 1. Optionally, if your container is exposing a port, go to `http://localhost:9090`: your application is running.

--- a/website/docs/kind/creating-a-kind-cluster.md
+++ b/website/docs/kind/creating-a-kind-cluster.md
@@ -17,7 +17,7 @@ You can create multiple local Kind-powered Kubernetes clusters.
 
 #### Procedure
 
-1. Go to **<icon icon="fa-solid fa-cog" size="lg" /> Settings > Resources**
+1. Go to **<Icon icon="fa-solid fa-cog" size="lg" /> Settings > Resources**
 1. In the Kind tile, click on the **Create new ...** button.
 1. Choose your options, and click the **Create** button.
 
@@ -35,5 +35,5 @@ You can create multiple local Kind-powered Kubernetes clusters.
 
 #### Verification
 
-1. In **<icon icon="fa-solid fa-cog" size="lg" /> Settings > Resources**, in the **Kind** tile, your `<kind-cluster>` instance is running.
+1. In **<Icon icon="fa-solid fa-cog" size="lg" /> Settings > Resources**, in the **Kind** tile, your `<kind-cluster>` instance is running.
 1. In the Podman Desktop tray, open the **Kubernetes** menu, you can set the context to your Kind cluster: `kind-<kind-cluster>`.

--- a/website/docs/kind/deleting-your-kind-cluster.md
+++ b/website/docs/kind/deleting-your-kind-cluster.md
@@ -15,11 +15,11 @@ tags: [migrating-to-kubernetes, kind]
 
 #### Procedure
 
-1. Open **<icon icon="fa-solid fa-cog" size="lg" /> Settings > Resources**.
+1. Open **<Icon icon="fa-solid fa-cog" size="lg" /> Settings > Resources**.
 1. Find the Kind cluster to delete.
-1. Click <icon icon="fa-solid fa-stop" size="lg" /> to stop the cluster.
-1. Once the cluster is stopped, click <icon icon="fa-solid fa-trash" size="lg" /> to delete it.
+1. Click <Icon icon="fa-solid fa-stop" size="lg" /> to stop the cluster.
+1. Once the cluster is stopped, click <Icon icon="fa-solid fa-trash" size="lg" /> to delete it.
 
 #### Verification
 
-1. In **<icon icon="fa-solid fa-cog" size="lg" /> Settings > Resources**, the deleted Kind cluster is not visible.
+1. In **<Icon icon="fa-solid fa-cog" size="lg" /> Settings > Resources**, the deleted Kind cluster is not visible.

--- a/website/docs/kind/installing.md
+++ b/website/docs/kind/installing.md
@@ -16,7 +16,7 @@ tags: [migrating-to-kubernetes, kind]
 #### Verification
 
 1. The status bar does not display **Kind**.
-1. **<icon icon="fa-solid fa-cog" size="lg" /> Settings > Resources** contain a **Kind** tile.
+1. **<Icon icon="fa-solid fa-cog" size="lg" /> Settings > Resources** contain a **Kind** tile.
    ![Kind resource tile](img/kind-resource.png)
 1. You can run the `kind` CLI:
 

--- a/website/docs/kind/pushing-an-image-to-kind.md
+++ b/website/docs/kind/pushing-an-image-to-kind.md
@@ -19,9 +19,9 @@ With Podman Desktop, you can push an image to your local Kind-powered Kubernetes
 
 #### Procedure
 
-1. Open **Podman Desktop dashboard > <icon icon="fa-solid fa-cloud" size="lg" /> Images**.
-1. **<icon icon="fa-solid fa-search" size="lg" /> Search images**: `<your_image>:<your_tag>`.
-1. Click **<icon icon="fa-solid fa-ellipsis-v" size="lg" /> > <icon icon="fa-solid fa-ellipsis-v" size="lg" /> Push image to Kind cluster**.
+1. Open **Podman Desktop dashboard > <Icon icon="fa-solid fa-cloud" size="lg" /> Images**.
+1. **<Icon icon="fa-solid fa-search" size="lg" /> Search images**: `<your_image>:<your_tag>`.
+1. Click **<Icon icon="fa-solid fa-ellipsis-v" size="lg" /> > <Icon icon="fa-solid fa-ellipsis-v" size="lg" /> Push image to Kind cluster**.
 1. If you created many Kind clusters, select your Kind cluster from the list.
 
 #### Verification
@@ -47,11 +47,11 @@ Therefore, create a Pod that uses the loaded image.
          imagePullPolicy: Never
    ```
 
-1. Open **<icon icon="fa-solid fa-cubes" size="lg" /> Pods > Play Kubernetes YAML**.
+1. Open **<Icon icon="fa-solid fa-cubes" size="lg" /> Pods > Play Kubernetes YAML**.
    1. **Kubernetes YAML file**: select your `verify_my_image.yaml` file.
    1. **Select Runtime**: **Using a Kubernetes cluster**.
    1. Click **Play**.
    1. Clik **Done**
-1. Open **<icon icon="fa-solid fa-cubes" size="lg" /> Pods**.
-1. **<icon icon="fa-solid fa-search" size="lg" /> Search pods**: `<verify-my-image>`.
+1. Open **<Icon icon="fa-solid fa-cubes" size="lg" /> Pods**.
+1. **<Icon icon="fa-solid fa-search" size="lg" /> Search pods**: `<verify-my-image>`.
 1. The pod **Status** is **Running**.

--- a/website/docs/kind/restarting-your-kind-cluster.md
+++ b/website/docs/kind/restarting-your-kind-cluster.md
@@ -12,9 +12,9 @@ With Podman Desktop, you can restart your local Kind-powered Kubernetes cluster.
 
 #### Procedure
 
-1. Open **<icon icon="fa-solid fa-cog" size="lg" /> Settings > Resources**.
+1. Open **<Icon icon="fa-solid fa-cog" size="lg" /> Settings > Resources**.
 1. Find the Kind cluster to restart.
-1. Click <icon icon="fa-solid fa-repeat" size="lg" />.
+1. Click <Icon icon="fa-solid fa-repeat" size="lg" />.
 
 #### Verification
 

--- a/website/docs/kubernetes/deploying-a-container-to-kubernetes.md
+++ b/website/docs/kubernetes/deploying-a-container-to-kubernetes.md
@@ -20,13 +20,13 @@ With Podman Desktop, you can deploy a container to your Kubernetes cluster.
 #### Procedure
 
 1. Click **Podman Desktop tray &gt; Kubernetes &gt; Context &gt; _&lt;your_kubernetes_cluster&gt;_** to set your Kubernetes context.
-1. Open **Podman Desktop dashboard > <icon icon="fa-solid fa-cubes" size="lg" /> Containers > _&lt;your_container&gt;_** to see the **Container Details** page.
-1. Click <icon icon="fa-solid fa-rocket" size="lg" /> to generate a Kubernetes pod.
+1. Open **Podman Desktop dashboard > <Icon icon="fa-solid fa-cubes" size="lg" /> Containers > _&lt;your_container&gt;_** to see the **Container Details** page.
+1. Click <Icon icon="fa-solid fa-rocket" size="lg" /> to generate a Kubernetes pod.
 1. On the **Deploy generated pod to Kubernetes** screen, choose your options:
    1. **Pod Name**: edit the proposed name.
    1. **Use Kubernetes Services**: enable or disable **Replace `hostPort` exposure on containers by Services. It is the recommended way to expose ports, as a cluster policy might prevent to use `hostPort`.**
    1. **Kubernetes namespace**: select in the list the namespace to deploy the pod to.
-1. Click the **<icon icon="fa-solid fa-rocket" size="lg" /> Deploy** button.
+1. Click the **<Icon icon="fa-solid fa-rocket" size="lg" /> Deploy** button.
 
 #### Verification
 

--- a/website/docs/kubernetes/deploying-a-pod-to-kubernetes.md
+++ b/website/docs/kubernetes/deploying-a-pod-to-kubernetes.md
@@ -20,13 +20,13 @@ With Podman Desktop, you can deploy a pod to your Kubernetes cluster.
 #### Procedure
 
 1. Click **Podman Desktop tray > Kubernetes > Context > _&lt;your_kubernetes_cluster&gt;_** to set your Kubernetes context.
-1. Open **Podman Desktop dashboard > <icon icon="fa-solid fa-cubes" size="lg" /> Pods > _&lt;your_pod&gt;_** to see the **Pod Details** page.
-1. Click <icon icon="fa-solid fa-rocket" size="lg" /> to generate a Kubernetes pod.
+1. Open **Podman Desktop dashboard > <Icon icon="fa-solid fa-cubes" size="lg" /> Pods > _&lt;your_pod&gt;_** to see the **Pod Details** page.
+1. Click <Icon icon="fa-solid fa-rocket" size="lg" /> to generate a Kubernetes pod.
 1. On the **Deploy generated pod to Kubernetes** screen, choose your options:
    1. **Pod Name**: edit the proposed name.
    1. **Use Kubernetes Services**: enable or disable **Replace `hostPort` exposure on containers by Services. It is the recommended way to expose ports, as a cluster policy might prevent to use `hostPort`.**
    1. **Kubernetes namespace**: select in the list the namespace to deploy the pod to.
-1. Click the **<icon icon="fa-solid fa-rocket" size="lg" /> Deploy** button.
+1. Click the **<Icon icon="fa-solid fa-rocket" size="lg" /> Deploy** button.
 
 #### Verification
 

--- a/website/docs/kubernetes/existing-kubernetes/index.md
+++ b/website/docs/kubernetes/existing-kubernetes/index.md
@@ -21,7 +21,7 @@ You can also use the Kubernetes CLI to configure access to your Kubernetes clust
 
 #### Procedure
 
-1. (Optionally) Go to **<icon icon="fa-solid fa-cog" size="lg" /> Settings > Preferences > Path to the kubeconfig file** to adapt your kubeconfig file location, when different from the default `$HOME/.kube/config`.
+1. (Optionally) Go to **<Icon icon="fa-solid fa-cog" size="lg" /> Settings > Preferences > Path to the kubeconfig file** to adapt your kubeconfig file location, when different from the default `$HOME/.kube/config`.
 1. Register your _`<my_kubernetes>`_ Kubernetes cluster:
 
    ```shell-session

--- a/website/docs/kubernetes/kind/pushing-an-image-to-kind.md
+++ b/website/docs/kubernetes/kind/pushing-an-image-to-kind.md
@@ -19,9 +19,9 @@ With Podman Desktop, you can push an image to your local Kind-powered Kubernetes
 
 #### Procedure
 
-1. Open **Podman Desktop dashboard > <icon icon="fa-solid fa-cloud" size="lg" /> Images**.
-1. **<icon icon="fa-solid fa-search" size="lg" /> Search images**: `<your_image>:<your_tag>`.
-1. Click **<icon icon="fa-solid fa-ellipsis-v" size="lg" /> > <icon icon="fa-solid fa-ellipsis-v" size="lg" /> Push image to Kind cluster**.
+1. Open **Podman Desktop dashboard > <Icon icon="fa-solid fa-cloud" size="lg" /> Images**.
+1. **<Icon icon="fa-solid fa-search" size="lg" /> Search images**: `<your_image>:<your_tag>`.
+1. Click **<Icon icon="fa-solid fa-ellipsis-v" size="lg" /> > <Icon icon="fa-solid fa-ellipsis-v" size="lg" /> Push image to Kind cluster**.
 1. If you created many Kind clusters, select your Kind cluster from the list.
 
 #### Verification
@@ -47,11 +47,11 @@ Therefore, create a Pod that uses the loaded image.
          imagePullPolicy: Never
    ```
 
-1. Open **<icon icon="fa-solid fa-cubes" size="lg" /> Pods > Play Kubernetes YAML**.
+1. Open **<Icon icon="fa-solid fa-cubes" size="lg" /> Pods > Play Kubernetes YAML**.
    1. **Kubernetes YAML file**: select your `verify_my_image.yaml` file.
    1. **Select Runtime**: **Using a Kubernetes cluster**.
    1. Click **Play**.
    1. Click **Done**
-1. Open **<icon icon="fa-solid fa-cubes" size="lg" /> Pods**.
-1. **<icon icon="fa-solid fa-search" size="lg" /> Search pods**: `<verify-my-image>`.
+1. Open **<Icon icon="fa-solid fa-cubes" size="lg" /> Pods**.
+1. **<Icon icon="fa-solid fa-search" size="lg" /> Search pods**: `<verify-my-image>`.
 1. The pod **Status** is **Running**.

--- a/website/docs/kubernetes/viewing-and-selecting-current-kubernete-context-in-the-status-bar.md
+++ b/website/docs/kubernetes/viewing-and-selecting-current-kubernete-context-in-the-status-bar.md
@@ -17,8 +17,8 @@ With Podman Desktop, you can view and select your current Kubernetes context in 
 
 #### Procedure
 
-1. To view your current Kubernetes context, in the **Podman Desktop** main window status bar, see the name next to the <icon icon="fa-solid fa-server" size="lg" /> icon.
+1. To view your current Kubernetes context, in the **Podman Desktop** main window status bar, see the name next to the <Icon icon="fa-solid fa-server" size="lg" /> icon.
 
 1. (Optionally) To change your Kubernetes context:
-   1. Click <icon icon="fa-solid fa-server" size="lg" />.
+   1. Click <Icon icon="fa-solid fa-server" size="lg" />.
    2. In the drop-down menu, click the context name to activate.

--- a/website/docs/lima/creating-a-kubernetes-instance.md
+++ b/website/docs/lima/creating-a-kubernetes-instance.md
@@ -45,7 +45,7 @@ Consider creating a custom Lima instance to:
 
 2. Wait for the instance to start, and restart the Lima extension.
 
-   - Go to **<icon icon="fa-solid fa-cog" size="lg" /> Settings > Preferences > Extension: Lima**, to change the instance name and type.
+   - Go to **<Icon icon="fa-solid fa-cog" size="lg" /> Settings > Preferences > Extension: Lima**, to change the instance name and type.
 
      - k3s
 
@@ -59,13 +59,13 @@ Consider creating a custom Lima instance to:
        - Name: k8s
          ![Lima preferences k8s](img/lima-preferences-k8s.png)
 
-   - Go to **<icon icon="fa-solid fa-cog" size="lg" /> Settings > Extensions > Lima**, to disable and enable the extension after changes.
+   - Go to **<Icon icon="fa-solid fa-cog" size="lg" /> Settings > Extensions > Lima**, to disable and enable the extension after changes.
 
 #### Verification
 
 1. When the installation is done, the location of the KUBECONFIG file is printed. See [Configuring access to a Kubernetes cluster](/docs/kubernetes/existing-kubernetes).
 
-   - Go to **<icon icon="fa-solid fa-cog" size="lg" /> Settings > Preferences > Path to the kubeconfig file**, to set the path of the file.
+   - Go to **<Icon icon="fa-solid fa-cog" size="lg" /> Settings > Preferences > Path to the kubeconfig file**, to set the path of the file.
 
 1. Use the `kubectl.lima` wrapper script to connect to the cluster:
 

--- a/website/docs/lima/creating-a-lima-instance.md
+++ b/website/docs/lima/creating-a-lima-instance.md
@@ -57,7 +57,7 @@ Consider creating a custom Lima instance to:
 
 2. Wait for the instance to start, and restart the Lima extension.
 
-   - Go to **<icon icon="fa-solid fa-cog" size="lg" /> Settings > Preferences > Extension: Lima**, to change the instance name and type.
+   - Go to **<Icon icon="fa-solid fa-cog" size="lg" /> Settings > Preferences > Extension: Lima**, to change the instance name and type.
 
      - Podman (default)
 
@@ -71,7 +71,7 @@ Consider creating a custom Lima instance to:
        - Name: docker
          ![Lima preferences Docker](img/lima-preferences-docker.png)
 
-   - Go to **<icon icon="fa-solid fa-cog" size="lg" /> Settings > Extensions > Lima**, to disable and enable the extension after changes.
+   - Go to **<Icon icon="fa-solid fa-cog" size="lg" /> Settings > Extensions > Lima**, to disable and enable the extension after changes.
 
 #### Verification
 

--- a/website/docs/migrating-from-docker/using-podman-mac-helper.md
+++ b/website/docs/migrating-from-docker/using-podman-mac-helper.md
@@ -31,7 +31,7 @@ The service redirects `/var/run/docker` to the fixed user-assigned UNIX socket l
    sudo podman-mac-helper install
    ```
 
-1. Restart your Podman machine: go to **<icon icon="fa-solid fa-cog" size="lg" /> Settings > Resources**, and in the Podman tile, click <icon icon="fa-solid fa-repeat" size="lg" />.
+1. Restart your Podman machine: go to **<Icon icon="fa-solid fa-cog" size="lg" /> Settings > Resources**, and in the Podman tile, click <Icon icon="fa-solid fa-repeat" size="lg" />.
 
 #### Verification
 

--- a/website/docs/minikube/building-an-image-and-testing-it-in-minikube.md
+++ b/website/docs/minikube/building-an-image-and-testing-it-in-minikube.md
@@ -21,41 +21,41 @@ With Podman Desktop, you can build an image with your container engine, and test
 
 1. Build your image:
 
-   1. Open **<icon icon="fa-solid fa-cloud" size="lg" /> Images > <icon icon="fa-solid fa-cube" size="lg" /> Build an image**.
+   1. Open **<Icon icon="fa-solid fa-cloud" size="lg" /> Images > <Icon icon="fa-solid fa-cube" size="lg" /> Build an image**.
    1. **Containerfile path**: select your `Containerfile` or `Dockerfile`.
    1. **Build context directory**: optionally, select a directory different from the directory containing your `Containerfile` or `Dockerfile`.
    1. **Image Name**: enter your image name `my-custom-image`.
-   1. Click **<icon icon="fa-solid fa-cube" size="lg" /> Build**.
+   1. Click **<Icon icon="fa-solid fa-cube" size="lg" /> Build**.
    1. Wait for the image build to finish.
    1. Click **Done** to get back to the images list.
 
 1. Push your image to your Minikube cluster:
 
-   1. **<icon icon="fa-solid fa-cloud" size="lg" /> Search images**: enter your image name `my-custom-image` to find the image.
-   1. Click **<icon icon="fa-solid fa-ellipsis-v" size="lg" /> > <icon icon="fa-solid fa-ellipsis-v" size="lg" /> Push image to Minikube cluster**.
+   1. **<Icon icon="fa-solid fa-cloud" size="lg" /> Search images**: enter your image name `my-custom-image` to find the image.
+   1. Click **<Icon icon="fa-solid fa-ellipsis-v" size="lg" /> > <Icon icon="fa-solid fa-ellipsis-v" size="lg" /> Push image to Minikube cluster**.
 
 1. Test your image by creating a container:
 
-   1. Click **<icon icon="fa-solid fa-play" size="lg" />** to open the **Create a container from image** dialog.
+   1. Click **<Icon icon="fa-solid fa-play" size="lg" />** to open the **Create a container from image** dialog.
    1. **Container name**: enter `my-custom-image-container`.
    1. Review the parameters that Podman Desktop has detected from your image definition.
-   1. Click **<icon icon="fa-solid fa-play" size="lg" /> Start Container** to start the container in your container engine.
+   1. Click **<Icon icon="fa-solid fa-play" size="lg" /> Start Container** to start the container in your container engine.
 
 1. Test your image and container on your Minikube cluster:
 
-   1. **<icon icon="fa-solid fa-cloud" size="lg" /> Search containers**: enter `my-custom-image-container` to find the running container.
-   1. Click **<icon icon="fa-solid fa-ellipsis-v" size="lg" /> > <icon icon="fa-solid fa-rocket" size="lg" /> Deploy to Kubernetes** to open the **Deploy generated pod to Kubernetes** screen.
+   1. **<Icon icon="fa-solid fa-cloud" size="lg" /> Search containers**: enter `my-custom-image-container` to find the running container.
+   1. Click **<Icon icon="fa-solid fa-ellipsis-v" size="lg" /> > <Icon icon="fa-solid fa-rocket" size="lg" /> Deploy to Kubernetes** to open the **Deploy generated pod to Kubernetes** screen.
    1. **Pod Name**: keep the proposed value `my-custom-image-container-pod`.
    1. **Use Kubernetes Services**: select **Replace `hostPort` exposure on containers by Services. It is the recommended way to expose ports, as a cluster policy might prevent to use `hostPort`.**
    1. **Expose service locally using Kubernetes LoadBalancer**: if your container is exposing a service, you can use `minikube service` to get a web browser or an URL to use.
    1. Optionally, if your container is exposing more than one port, select the port to expose.
    1. **Kubernetes namespaces**: select `default`.
-   1. Click **<icon icon="fa-solid fa-rocket" size="lg" /> Deploy**.
+   1. Click **<Icon icon="fa-solid fa-rocket" size="lg" /> Deploy**.
    1. Wait for the pod to reach the state: **Phase: Running**.
    1. Click **Done**.
 
 #### Verification
 
-1. The **<icon icon="fa-solid fa-cubes" size="lg" /> Pods** screen lists the running `my-image-container-pod` pod.
+1. The **<Icon icon="fa-solid fa-cubes" size="lg" /> Pods** screen lists the running `my-image-container-pod` pod.
 1. Click on the pod name to view details and logs.
 1. Optionally, if your container is exposing a service, go to the server URL: your application is running.

--- a/website/docs/minikube/creating-a-minikube-cluster.md
+++ b/website/docs/minikube/creating-a-minikube-cluster.md
@@ -17,7 +17,7 @@ You can create multiple local Minikube-powered Kubernetes clusters.
 
 #### Procedure
 
-1. Go to **<icon icon="fa-solid fa-cog" size="lg" /> Settings > Resources**
+1. Go to **<Icon icon="fa-solid fa-cog" size="lg" /> Settings > Resources**
 1. In the Minikube tile, click on the **Create new ...** button.
 1. Choose your options, and click the **Create** button.
 
@@ -32,5 +32,5 @@ You can create multiple local Minikube-powered Kubernetes clusters.
 
 #### Verification
 
-1. In **<icon icon="fa-solid fa-cog" size="lg" /> Settings > Resources**, in the **Minikube** tile, your `<minikube>` instance is running.
+1. In **<Icon icon="fa-solid fa-cog" size="lg" /> Settings > Resources**, in the **Minikube** tile, your `<minikube>` instance is running.
 1. In the Podman Desktop tray, open the **Kubernetes** menu, you can set the context to your Minikube cluster: `minikube`.

--- a/website/docs/minikube/deleting-your-minikube-cluster.md
+++ b/website/docs/minikube/deleting-your-minikube-cluster.md
@@ -15,11 +15,11 @@ tags: [migrating-to-kubernetes, minikube]
 
 #### Procedure
 
-1. Open **<icon icon="fa-solid fa-cog" size="lg" /> Settings > Resources**.
+1. Open **<Icon icon="fa-solid fa-cog" size="lg" /> Settings > Resources**.
 1. Find the Minikube cluster to delete.
-1. Click <icon icon="fa-solid fa-stop" size="lg" /> to stop the cluster.
-1. Once the cluster is stopped, click <icon icon="fa-solid fa-trash" size="lg" /> to delete it.
+1. Click <Icon icon="fa-solid fa-stop" size="lg" /> to stop the cluster.
+1. Once the cluster is stopped, click <Icon icon="fa-solid fa-trash" size="lg" /> to delete it.
 
 #### Verification
 
-1. In **<icon icon="fa-solid fa-cog" size="lg" /> Settings > Resources**, the deleted Minikube cluster is not visible.
+1. In **<Icon icon="fa-solid fa-cog" size="lg" /> Settings > Resources**, the deleted Minikube cluster is not visible.

--- a/website/docs/minikube/index.md
+++ b/website/docs/minikube/index.md
@@ -12,11 +12,11 @@ Podman Desktop can help you run [Minikube-powered](https://minikube.sigs.k8s.io/
 
 #### Procedure
 
-1. Go to **<icon icon="fa-solid fa-cog" size="lg" /> Settings > Extensions**.
+1. Go to **<Icon icon="fa-solid fa-cog" size="lg" /> Settings > Extensions**.
 1. Install the _Minikube_ extension:
    1. Go to **Install a new extension from OCI Image**
    1. Enter the **Name of the Image**: `ghcr.io/containers/podman-desktop-extension-minikube`
-   1. Click **<icon icon="fa-solid fa-download" size="lg" /> Install extension from the OCI image**
+   1. Click **<Icon icon="fa-solid fa-download" size="lg" /> Install extension from the OCI image**
 1. [Install the `minikube` CLI](/docs/minikube/installing).
 1. [On Windows, configure Podman in rootful mode](/docs/minikube/configuring-podman-for-minikube-on-windows).
 1. [Create a Minikube cluster](/docs/minikube/creating-a-minikube-cluster).

--- a/website/docs/minikube/installing.md
+++ b/website/docs/minikube/installing.md
@@ -16,7 +16,7 @@ tags: [migrating-to-kubernetes, minikube]
 #### Verification
 
 1. The status bar doesn't display **Minikube**.
-1. **<icon icon="fa-solid fa-cog" size="lg" /> Settings > Resources** contain a **Minikube** tile.
+1. **<Icon icon="fa-solid fa-cog" size="lg" /> Settings > Resources** contain a **Minikube** tile.
    ![Minikube resource tile](img/minikube-resource.png)
 1. You can run the `minikube` CLI:
 

--- a/website/docs/minikube/pushing-an-image-to-minikube.md
+++ b/website/docs/minikube/pushing-an-image-to-minikube.md
@@ -19,9 +19,9 @@ With Podman Desktop, you can push an image to your local Minikube-powered Kubern
 
 #### Procedure
 
-1. Open **Podman Desktop dashboard > <icon icon="fa-solid fa-cloud" size="lg" /> Images**.
-1. **<icon icon="fa-solid fa-search" size="lg" /> Search images**: `<your_image>:<your_tag>`.
-1. Click **<icon icon="fa-solid fa-ellipsis-v" size="lg" /> > <icon icon="fa-solid fa-ellipsis-v" size="lg" /> Push image to Minikube cluster**.
+1. Open **Podman Desktop dashboard > <Icon icon="fa-solid fa-cloud" size="lg" /> Images**.
+1. **<Icon icon="fa-solid fa-search" size="lg" /> Search images**: `<your_image>:<your_tag>`.
+1. Click **<Icon icon="fa-solid fa-ellipsis-v" size="lg" /> > <Icon icon="fa-solid fa-ellipsis-v" size="lg" /> Push image to Minikube cluster**.
 1. If you created many Minikube clusters, select your Minikube cluster from the list.
 
 #### Verification
@@ -52,11 +52,11 @@ You can also create a Pod that uses the loaded image:
          imagePullPolicy: Never
    ```
 
-1. Open **<icon icon="fa-solid fa-cubes" size="lg" /> Pods > Play Kubernetes YAML**.
+1. Open **<Icon icon="fa-solid fa-cubes" size="lg" /> Pods > Play Kubernetes YAML**.
    1. **Kubernetes YAML file**: select your `verify_my_image.yaml` file.
    1. **Select Runtime**: **Using a Kubernetes cluster**.
    1. Click **Play**.
    1. Clik **Done**
-1. Open **<icon icon="fa-solid fa-cubes" size="lg" /> Pods**.
-1. **<icon icon="fa-solid fa-search" size="lg" /> Search pods**: `<verify-my-image>`.
+1. Open **<Icon icon="fa-solid fa-cubes" size="lg" /> Pods**.
+1. **<Icon icon="fa-solid fa-search" size="lg" /> Search pods**: `<verify-my-image>`.
 1. The pod **Status** is **Running**.

--- a/website/docs/minikube/restarting-your-minikube-cluster.md
+++ b/website/docs/minikube/restarting-your-minikube-cluster.md
@@ -12,9 +12,9 @@ With Podman Desktop, you can restart your local Minikube-powered Kubernetes clus
 
 #### Procedure
 
-1. Open **<icon icon="fa-solid fa-cog" size="lg" /> Settings > Resources**.
+1. Open **<Icon icon="fa-solid fa-cog" size="lg" /> Settings > Resources**.
 1. Find the Minikube cluster to restart.
-1. Click <icon icon="fa-solid fa-repeat" size="lg" />.
+1. Click <Icon icon="fa-solid fa-repeat" size="lg" />.
 
 #### Verification
 

--- a/website/docs/openshift/developer-sandbox/index.md
+++ b/website/docs/openshift/developer-sandbox/index.md
@@ -18,8 +18,8 @@ With Podman Desktop, you can configure access to your Developer Sandbox instance
 
 #### Procedure
 
-1. Install the _Developer Sandbox_ extension: go to **Dashboard**, and click **Developer Sandbox <icon icon="fa-solid fa-download" size="lg" />**.
-1. Go to **<icon icon="fa-solid fa-cog" size="lg" /> Settings > Resources**.
+1. Install the _Developer Sandbox_ extension: go to **Dashboard**, and click **Developer Sandbox <Icon icon="fa-solid fa-download" size="lg" />**.
+1. Go to **<Icon icon="fa-solid fa-cog" size="lg" /> Settings > Resources**.
 1. In the **Developer Sandbox** tile, click **Create new**.
 1. In the **Create a Developer Sandbox** screen, click **Log into Developer Sandbox**.
 1. In the **Open external website** dialog, click **Yes**.
@@ -38,7 +38,7 @@ With Podman Desktop, you can configure access to your Developer Sandbox instance
 
 #### Verification
 
-1. On the **<icon icon="fa-solid fa-cog" size="lg" /> Settings > Resources** screen, your Developer Sandbox is running.
+1. On the **<Icon icon="fa-solid fa-cog" size="lg" /> Settings > Resources** screen, your Developer Sandbox is running.
 
    ![Developer Sandbox is running](img/resources-developer-sandbox-running.png)
 

--- a/website/docs/openshift/openshift-local/index.md
+++ b/website/docs/openshift/openshift-local/index.md
@@ -20,13 +20,13 @@ With Podman Desktop and the OpenShift Local extension, you can manage your OpenS
 
 #### Procedure
 
-1. Install the _OpenShift Local_ extension: on to **Dashboard**, click **OpenShift Local <icon icon="fa-solid fa-download" size="lg" />**.
+1. Install the _OpenShift Local_ extension: on to **Dashboard**, click **OpenShift Local <Icon icon="fa-solid fa-download" size="lg" />**.
 1. Install the OpenShift Local binaries, when on the **Dashboard**, you see _Podman Desktop was not able to find an installation of OpenShift Local_.
 
    <Tabs groupId="operating-systems">
    <TabItem value="win" label="Windows">
 
-   1. In the **OpenShift Local** tile, click **<icon icon="fa-solid fa-rocket" size="lg" /> Install**.
+   1. In the **OpenShift Local** tile, click **<Icon icon="fa-solid fa-rocket" size="lg" /> Install**.
    1. When prerequisites are missing, follow the instructions.
    1. In the **Red Hat OpenShift Local** screen, click **Yes** to start the installation.
    1. Follow the installation program instructions.
@@ -35,7 +35,7 @@ With Podman Desktop and the OpenShift Local extension, you can manage your OpenS
    </TabItem>
    <TabItem value="mac" label="macOS">
 
-   1. In the **OpenShift Local** tile, click **<icon icon="fa-solid fa-rocket" size="lg" /> Install**.
+   1. In the **OpenShift Local** tile, click **<Icon icon="fa-solid fa-rocket" size="lg" /> Install**.
    1. When prerequisites are missing, follow the instructions.
    1. In the **Red Hat OpenShift Local** screen, click **Yes** to start the installation.
    1. Follow the installation program instructions.
@@ -60,10 +60,10 @@ With Podman Desktop and the OpenShift Local extension, you can manage your OpenS
    </TabItem>
    </Tabs>
 
-1. (Optionally) Review the extension settings in **<icon icon="fa-solid fa-cog" size="lg" /> Settings > Preferences > Extension: Red Hat OpenShift Local**.
+1. (Optionally) Review the extension settings in **<Icon icon="fa-solid fa-cog" size="lg" /> Settings > Preferences > Extension: Red Hat OpenShift Local**.
 1. On the **Dashboard**, click **Initialize and start**.
 
-   1. Select your OpenShift Local Virtual machine preset, if not set in **<icon icon="fa-solid fa-cog" size="lg" /> Settings > Preferences > Extension: Red Hat OpenShift Local > Preset**.
+   1. Select your OpenShift Local Virtual machine preset, if not set in **<Icon icon="fa-solid fa-cog" size="lg" /> Settings > Preferences > Extension: Red Hat OpenShift Local > Preset**.
       - _MicroShift_ (experimental): provides a lightweight and optimized environment with a limited set of services.
       - _OpenShift_: provides a single node OpenShift cluster with a fuller set of services, including a web console (requires more resources).
    2. Provide a pull secret, required to pull container images from the registry:
@@ -76,7 +76,7 @@ With Podman Desktop and the OpenShift Local extension, you can manage your OpenS
 #### Verification
 
 1. On the **Dashboard** screen, _OpenShift Local is running_.
-1. On the **<icon icon="fa-solid fa-cog" size="lg" />Settings > Resources** screen, your OpenShift Local instance is running.
+1. On the **<Icon icon="fa-solid fa-cog" size="lg" />Settings > Resources** screen, your OpenShift Local instance is running.
 
    ![Developer Sandbox is running](img/resources-openshift-local-running.png)
 

--- a/website/docs/podman/setting-podman-machine-default-connection.md
+++ b/website/docs/podman/setting-podman-machine-default-connection.md
@@ -44,7 +44,7 @@ After an event that might have changed the default Podman machine connection, su
    $ podman machine start
    ```
 
-1. Refresh Podman Desktop connection to Podman: click the **<icon icon="fa-solid fa-lightbulb" size="lg" />** icon to open the **Troubleshooting** page, and click the **Reconnect providers** button.
+1. Refresh Podman Desktop connection to Podman: click the **<Icon icon="fa-solid fa-lightbulb" size="lg" />** icon to open the **Troubleshooting** page, and click the **Reconnect providers** button.
 
 #### Verification
 

--- a/website/docs/troubleshooting/index.md
+++ b/website/docs/troubleshooting/index.md
@@ -12,7 +12,7 @@ Podman Desktop has a **Troubleshooting** page to help identify and fix most comm
 
 #### Procedure
 
-1. To open the **Troubleshooting** page, click the **<icon icon="fa-solid fa-lightbulb" size="lg" />** icon.
+1. To open the **Troubleshooting** page, click the **<Icon icon="fa-solid fa-lightbulb" size="lg" />** icon.
 1. To test the connection to the container engine, click the **Ping** button.
 
    Expect a reply such as: _Responded: 79,75 (9.10ms)_.

--- a/website/src/theme/MDXComponents.js
+++ b/website/src/theme/MDXComponents.js
@@ -10,5 +10,5 @@ library.add(fab, fas); // Add all icons to the library so you can use them witho
 export default {
   // Re-use the default mapping
   ...MDXComponents,
-  icon: FontAwesomeIcon, // Make the FontAwesomeIcon component available in MDX as <icon />.
+  Icon: FontAwesomeIcon, // Make the FontAwesomeIcon component available in MDX as <icon />.
 };


### PR DESCRIPTION
### What does this PR do?
React components should start with an uppercase else it is considered as a default HTML component

fixed issue with docusaurus v3 enforcing that rule (React 18 vs 17)


### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast 
explaining what is doing this PR -->

### What issues does this PR fix or reference?
https://github.com/containers/podman-desktop/pull/4764

### How to test this PR?
should not have any visual change
