### PR TITLE
feat: default table sorting

### DIFF
--- a/packages/renderer/src/lib/table/Table.spec.ts
+++ b/packages/renderer/src/lib/table/Table.spec.ts
@@ -44,6 +44,42 @@ test('Expect basic table layout', async () => {
   expect(rows[3].textContent).toContain('43');
 });
 
+test('Expect column headers with sort indicators', async () => {
+  render(TestTable, {});
+
+  const headers = await screen.findAllByRole('columnheader');
+  expect(headers).toBeDefined();
+  expect(headers.length).toBe(4);
+  expect(headers[1].textContent).toContain('Id');
+  expect(headers[1].innerHTML).toContain('fa-sort');
+  expect(headers[2].textContent).toContain('Name');
+  expect(headers[2].innerHTML).toContain('fa-sort');
+  expect(headers[3].textContent).toContain('Age');
+  expect(headers[3].innerHTML).toContain('fa-sort');
+});
+
+test('Expect default sort indicator', async () => {
+  render(TestTable, {});
+
+  const headers = await screen.findAllByRole('columnheader');
+  expect(headers).toBeDefined();
+  expect(headers.length).toBe(4);
+  expect(headers[1].textContent).toContain('Id');
+  expect(headers[1].innerHTML).toContain('fa-sort-down');
+});
+
+test('Expect no default sort indicator on other columns', async () => {
+  render(TestTable, {});
+
+  const headers = await screen.findAllByRole('columnheader');
+  expect(headers).toBeDefined();
+  expect(headers.length).toBe(4);
+  expect(headers[2].innerHTML).not.toContain('fa-sort-up');
+  expect(headers[2].innerHTML).not.toContain('fa-sort-down');
+  expect(headers[3].innerHTML).not.toContain('fa-sort-up');
+  expect(headers[3].innerHTML).not.toContain('fa-sort-down');
+});
+
 test('Expect sorting by name works', async () => {
   render(TestTable, {});
 

--- a/packages/renderer/src/lib/table/Table.svelte
+++ b/packages/renderer/src/lib/table/Table.svelte
@@ -7,7 +7,7 @@
 <script lang="ts">
 /* eslint-disable import/no-duplicates */
 // https://github.com/import-js/eslint-plugin-import/issues/1479
-import { afterUpdate, tick } from 'svelte';
+import { afterUpdate, onMount, tick } from 'svelte';
 import Checkbox from '../ui/Checkbox.svelte';
 import type { Column, Row } from './table';
 import { flip } from 'svelte/animate';
@@ -17,11 +17,12 @@ export let kind: string;
 export let data: any[];
 export let columns: Column<any>[];
 export let row: Row<any>;
+export let defaultSortColumn: string | undefined = undefined;
 
 // number of selected items in the list
 export let selectedItemsNumber: number = 0;
 $: selectedItemsNumber = row.info.selectable
-  ? data.filter(object => row.info.selectable?.(object)).filter(object => object.selected).length
+  ? data.filter(object => row.info.selectable?.(object) && object.selected).length
   : 0;
 
 // do we need to unselect all checkboxes if we don't have all items being selected ?
@@ -65,6 +66,17 @@ function sort(column: Column<any>) {
   // eslint-disable-next-line etc/no-assign-mutated-array
   data = data.sort(comparator);
 }
+
+onMount(async () => {
+  if (defaultSortColumn) {
+    for (const column of columns) {
+      if (column.title === defaultSortColumn) {
+        sortCol = column;
+        sortAscending = true;
+      }
+    }
+  }
+});
 
 afterUpdate(async () => {
   await tick();
@@ -122,6 +134,7 @@ function setGridColumns() {
             class:fa-sort="{sortCol !== column}"
             class:fa-sort-up="{sortCol === column && !sortAscending}"
             class:fa-sort-down="{sortCol === column && sortAscending}"
+            class:text-charcoal-200="{sortCol !== column}"
             aria-hidden="true"></i
           >{/if}
       </div>

--- a/packages/renderer/src/lib/table/Table.svelte
+++ b/packages/renderer/src/lib/table/Table.svelte
@@ -68,12 +68,10 @@ function sort(column: Column<any>) {
 }
 
 onMount(async () => {
-  if (defaultSortColumn) {
-    const column: Column<any> | undefined = columns.find(column => column.title === defaultSortColumn);
-    if (column) {
-      sortCol = column;
-      sortAscending = true;
-    }
+  const column: Column<any> | undefined = columns.find(column => column.title === defaultSortColumn);
+  if (column) {
+    sortCol = column;
+    sortAscending = true;
   }
 });
 

--- a/packages/renderer/src/lib/table/Table.svelte
+++ b/packages/renderer/src/lib/table/Table.svelte
@@ -69,11 +69,10 @@ function sort(column: Column<any>) {
 
 onMount(async () => {
   if (defaultSortColumn) {
-    for (const column of columns) {
-      if (column.title === defaultSortColumn) {
-        sortCol = column;
-        sortAscending = true;
-      }
+    const column: Column<any> | undefined = columns.find(column => column.title === defaultSortColumn);
+    if (column) {
+      sortCol = column;
+      sortAscending = true;
     }
   }
 });

--- a/packages/renderer/src/lib/table/TestColumnId.svelte
+++ b/packages/renderer/src/lib/table/TestColumnId.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+export let object: any;
+</script>
+
+{object.id}

--- a/packages/renderer/src/lib/table/TestTable.svelte
+++ b/packages/renderer/src/lib/table/TestTable.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import Table from './Table.svelte';
+import TestColumnId from './TestColumnId.svelte';
 import TestColumnName from './TestColumnName.svelte';
 import TestColumnAge from './TestColumnAge.svelte';
 import { Column, Row } from './table';
@@ -8,15 +9,22 @@ let table: Table;
 let selectedItemsNumber: number;
 
 type Person = {
+  id: number;
   name: string;
   age: number;
 };
 
 const people: Person[] = [
-  { name: 'John', age: 57 },
-  { name: 'Henry', age: 27 },
-  { name: 'Charlie', age: 43 },
+  { id: 1, name: 'John', age: 57 },
+  { id: 2, name: 'Henry', age: 27 },
+  { id: 3, name: 'Charlie', age: 43 },
 ];
+
+const idCol: Column<Person> = new Column('Id', {
+  align: 'right',
+  renderer: TestColumnId,
+  comparator: (a, b) => a.id - b.id,
+});
 
 const nameCol: Column<Person> = new Column('Name', {
   width: '3fr',
@@ -30,7 +38,7 @@ const ageCol: Column<Person> = new Column('Age', {
   comparator: (a, b) => a.age - b.age,
 });
 
-const columns: Column<Person>[] = [nameCol, ageCol];
+const columns: Column<Person>[] = [idCol, nameCol, ageCol];
 
 const row = new Row<Person>({
   selectable: person => person.age < 50,
@@ -44,5 +52,6 @@ const row = new Row<Person>({
   bind:selectedItemsNumber="{selectedItemsNumber}"
   data="{people}"
   columns="{columns}"
-  row="{row}">
+  row="{row}"
+  defaultSortColumn="Id">
 </Table>


### PR DESCRIPTION
### What does this PR do?

Adds support for a 'default sort column' so that you can tell if the data was initially sorted by a particular column (and don't try to sort that column and have nothing change).

Dims the sort indicator on non-active columns so that you can still tell which columns are sortable, but they don't stand out as much.

Also includes a minor '&&' simplification suggested in previous PR review.

### Screenshot/screencast of this PR

![sort2](https://github.com/containers/podman-desktop/assets/19958075/62a3082c-5358-40da-a6c5-b81ff9ad2fab)

### What issues does this PR fix or reference?

Fixes #4838.

### How to test this PR?

It will change the column sort indicator if used in conjunction with the Image or Volume PRs; to set a default sort column you need to add something like `defaultSortColumn="Name"` to one of those tables.