### PR TITLE
fix: use vi.waitUtnil instead of cycles with awaiting promises

### DIFF
--- a/packages/renderer/src/lib/pod/PodsList.spec.ts
+++ b/packages/renderer/src/lib/pod/PodsList.spec.ts
@@ -275,18 +275,14 @@ beforeAll(() => {
 async function waitRender(customProperties: object): Promise<void> {
   const result = render(PodsList, { ...customProperties });
   // wait that result.component.$$.ctx[2] is set
-  while (result.component.$$.ctx[2] === undefined) {
-    await new Promise(resolve => setTimeout(resolve, 100));
-  }
+  await vi.waitUntil(() => result.component.$$.ctx[2] !== undefined, { timeout: 5000 });
 }
 
 test('Expect no pods being displayed', async () => {
   getProvidersInfoMock.mockResolvedValue([provider]);
   window.dispatchEvent(new CustomEvent('provider-lifecycle-change'));
 
-  while (get(providerInfos).length === 0) {
-    await new Promise(resolve => setTimeout(resolve, 500));
-  }
+  await vi.waitUntil(() => get(providerInfos).length !== 0);
 
   render(PodsList);
   const noPods = screen.getByText(/No pods/);
@@ -300,13 +296,7 @@ test('Expect single podman pod being displayed', async () => {
   window.dispatchEvent(new CustomEvent('provider-lifecycle-change'));
   window.dispatchEvent(new CustomEvent('extensions-already-started'));
 
-  while (get(providerInfos).length !== 1) {
-    await new Promise(resolve => setTimeout(resolve, 500));
-  }
-
-  while (get(podsInfos).length !== 1) {
-    await new Promise(resolve => setTimeout(resolve, 500));
-  }
+  await vi.waitUntil(() => get(providerInfos).length === 1 && get(podsInfos).length === 1, { timeout: 5000 });
 
   render(PodsList);
   const pod1Details = screen.getByRole('cell', { name: 'pod1 beab2512' });
@@ -326,13 +316,7 @@ test('Expect 2 podman pods being displayed', async () => {
   window.dispatchEvent(new CustomEvent('provider-lifecycle-change'));
   window.dispatchEvent(new CustomEvent('extensions-already-started'));
 
-  while (get(providerInfos).length !== 1) {
-    await new Promise(resolve => setTimeout(resolve, 500));
-  }
-
-  while (get(podsInfos).length !== 2) {
-    await new Promise(resolve => setTimeout(resolve, 500));
-  }
+  await vi.waitUntil(() => get(providerInfos).length === 1 && get(podsInfos).length === 2, { timeout: 5000 });
 
   render(PodsList);
   const pod1Details = screen.getByRole('cell', { name: 'pod1 beab2512' });
@@ -354,13 +338,7 @@ test('Expect single kubernetes pod being displayed', async () => {
   window.dispatchEvent(new CustomEvent('provider-lifecycle-change'));
   window.dispatchEvent(new CustomEvent('extensions-already-started'));
 
-  while (get(providerInfos).length !== 1) {
-    await new Promise(resolve => setTimeout(resolve, 500));
-  }
-
-  while (get(podsInfos).length !== 1) {
-    await new Promise(resolve => setTimeout(resolve, 500));
-  }
+  await vi.waitUntil(() => get(providerInfos).length === 1 && get(podsInfos).length === 1, { timeout: 5000 });
 
   render(PodsList);
   const pod1Details = screen.getByRole('row', {
@@ -376,13 +354,7 @@ test('Expect 2 kubernetes pods being displayed', async () => {
   window.dispatchEvent(new CustomEvent('provider-lifecycle-change'));
   window.dispatchEvent(new CustomEvent('extensions-already-started'));
 
-  while (get(providerInfos).length !== 1) {
-    await new Promise(resolve => setTimeout(resolve, 500));
-  }
-
-  while (get(podsInfos).length !== 2) {
-    await new Promise(resolve => setTimeout(resolve, 500));
-  }
+  await vi.waitUntil(() => get(providerInfos).length === 1 && get(podsInfos).length === 2, { timeout: 5000 });
 
   render(PodsList);
   const pod1Details = screen.getByRole('row', {
@@ -402,13 +374,7 @@ test('Expect filter empty screen', async () => {
   window.dispatchEvent(new CustomEvent('provider-lifecycle-change'));
   window.dispatchEvent(new CustomEvent('extensions-already-started'));
 
-  while (get(providerInfos).length !== 1) {
-    await new Promise(resolve => setTimeout(resolve, 500));
-  }
-
-  while (get(podsInfos).length !== 1) {
-    await new Promise(resolve => setTimeout(resolve, 500));
-  }
+  await vi.waitUntil(() => get(providerInfos).length === 1 && get(podsInfos).length === 1, { timeout: 5000 });
 
   render(PodsList, { searchTerm: 'No match' });
   const filterButton = screen.getByRole('button', { name: 'Clear filter' });
@@ -422,17 +388,15 @@ test('Expect the route to a pod details page is correctly encoded with an engine
   window.dispatchEvent(new CustomEvent('provider-lifecycle-change'));
   window.dispatchEvent(new CustomEvent('extensions-already-started'));
 
-  while (get(providerInfos).length !== 1) {
-    await new Promise(resolve => setTimeout(resolve, 500));
-  }
+  await vi.waitUntil(() => get(providerInfos).length === 1, { timeout: 5000 });
 
-  for (;;) {
-    const infos = get(podsInfos);
-    if (infos.length === 1 && infos[0].Name === ocppod.Name) {
-      break;
-    }
-    await new Promise(resolve => setTimeout(resolve, 500));
-  }
+  await vi.waitUntil(
+    () => {
+      const infos = get(podsInfos);
+      return infos.length === 1 && infos[0].Name === ocppod.Name;
+    },
+    { timeout: 5000 },
+  );
   render(PodsList);
   const podDetails = screen.getByRole('cell', { name: 'ocppod e8129c57' });
   expect(podDetails).toBeInTheDocument();
@@ -457,13 +421,7 @@ test('Expect the pod1 row to have 3 status dots with the correct colors and the 
   window.dispatchEvent(new CustomEvent('provider-lifecycle-change'));
   window.dispatchEvent(new CustomEvent('extensions-already-started'));
 
-  while (get(providerInfos).length !== 1) {
-    await new Promise(resolve => setTimeout(resolve, 500));
-  }
-
-  while (get(podsInfos).length !== 2) {
-    await new Promise(resolve => setTimeout(resolve, 500));
-  }
+  await vi.waitUntil(() => get(providerInfos).length === 1 && get(podsInfos).length === 2, { timeout: 5000 });
 
   waitRender(PodsList);
 
@@ -494,13 +452,7 @@ test('Expect the manyPod row to show 9 dots representing every status', async ()
   window.dispatchEvent(new CustomEvent('provider-lifecycle-change'));
   window.dispatchEvent(new CustomEvent('extensions-already-started'));
 
-  while (get(providerInfos).length !== 1) {
-    await new Promise(resolve => setTimeout(resolve, 500));
-  }
-
-  while (get(podsInfos).length !== 1) {
-    await new Promise(resolve => setTimeout(resolve, 500));
-  }
+  await vi.waitUntil(() => get(providerInfos).length === 1 && get(podsInfos).length === 1, { timeout: 5000 });
 
   waitRender(PodsList);
 


### PR DESCRIPTION
### What does this PR do?
this PR replaces:
* awaits for promises resolved by using timers
* cycles with awaits for promises

to `vi.waitUntil`

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast 
explaining what is doing this PR -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop 
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to reproduce -->
