### PR TITLE
fix: retain autostart setting (#4647)

### DIFF
--- a/packages/main/src/plugin/autostart-engine.spec.ts
+++ b/packages/main/src/plugin/autostart-engine.spec.ts
@@ -50,17 +50,11 @@ beforeAll(() => {
   providerRegistry.runAutostart = mockRunAutostart;
 });
 
-test('Check that default value is false if provider autostart setting is undefined and old global setting is false', async () => {
-  vi.spyOn(configurationRegistry, 'getConfiguration').mockImplementation((section?: string) => {
-    if (section === `preferences.${extensionId}`) {
-      return {
-        get: (_section: string) => undefined,
-      } as Configuration;
-    } else {
-      return {
-        get: (_section: string) => false,
-      } as Configuration;
-    }
+test('Check that default value is false if provider autostart setting is false', async () => {
+  vi.spyOn(configurationRegistry, 'getConfiguration').mockImplementation(() => {
+    return {
+      get: (_section: string, _defaultValue: boolean) => false,
+    } as Configuration;
   });
 
   const autoStartConfigurationNode: IConfigurationNode = {
@@ -85,23 +79,10 @@ test('Check that default value is false if provider autostart setting is undefin
   expect(mockRegisterConfiguration).toBeCalledWith([autoStartConfigurationNode]);
 });
 
-test('Check that old global setting is not checked if provider autostart setting is already set', async () => {
-  const getConfigurationMock = vi.spyOn(configurationRegistry, 'getConfiguration').mockImplementation(() => {
-    return {
-      get: (_section: string) => false,
-    } as Configuration;
-  });
-
-  const disposable = autostartEngine.registerProvider(extensionId, extensionDisplayName, 'internalId');
-  disposable.dispose();
-  expect(getConfigurationMock).toBeCalledTimes(1);
-  expect(getConfigurationMock).toBeCalledWith(`preferences.${extensionId}`);
-});
-
-test('Check that default value is true if neither provider autostart setting nor old autostart setting are set', async () => {
+test('Check that default value is true if provider autostart setting is not set', async () => {
   vi.spyOn(configurationRegistry, 'getConfiguration').mockImplementation(() => {
     return {
-      get: (_section: string) => undefined,
+      get: (_section: string, defaultValue: boolean) => defaultValue,
     } as Configuration;
   });
 
@@ -131,7 +112,7 @@ test('Check that default value is true if neither provider autostart setting nor
 test('Check that runAutostart is called once if only one provider has registered autostart process', async () => {
   vi.spyOn(configurationRegistry, 'getConfiguration').mockImplementation(() => {
     return {
-      get: (_section: string) => true,
+      get: (_section: string, _defaultValue: boolean) => true,
     } as Configuration;
   });
 
@@ -146,7 +127,7 @@ test('Check that runAutostart is called once if only one provider has registered
 test('Check that runAutostart is never called if only one provider has registered autostart process but its setting is false', async () => {
   vi.spyOn(configurationRegistry, 'getConfiguration').mockImplementation(() => {
     return {
-      get: (_section: string) => false,
+      get: (_section: string, _defaultValue: boolean) => false,
     } as Configuration;
   });
 
@@ -161,7 +142,7 @@ test('Check that runAutostart is never called if only one provider has registere
 test('Check that runAutostart is called twice if only two providers has registered autostart process', async () => {
   vi.spyOn(configurationRegistry, 'getConfiguration').mockImplementation(() => {
     return {
-      get: (_section: string) => true,
+      get: (_section: string, _defaultValue: boolean) => true,
     } as Configuration;
   });
 

--- a/packages/main/src/plugin/configuration-impl.ts
+++ b/packages/main/src/plugin/configuration-impl.ts
@@ -55,12 +55,8 @@ export class ConfigurationImpl implements containerDesktopAPI.Configuration {
     const localView = this.getLocalView();
     if (localView[localKey] !== undefined) {
       return localView[localKey];
-    } else if (defaultValue) {
-      // not there but we have a default value, then return it
-      return defaultValue;
-    } else {
-      return undefined;
     }
+    return defaultValue;
   }
 
   has(section: string): boolean {

--- a/packages/main/src/plugin/configuration-registry.ts
+++ b/packages/main/src/plugin/configuration-registry.ts
@@ -173,7 +173,7 @@ export class ConfigurationRegistry implements IConfigurationRegistry {
         // register default if not yet set
         if (
           configProperty.default &&
-          !configProperty.scope &&
+          this.isDefaultScope(configProperty.scope) &&
           this.configurationValues.get(CONFIGURATION_DEFAULT_SCOPE)[key] === undefined
         ) {
           this.configurationValues.get(CONFIGURATION_DEFAULT_SCOPE)[key] = configProperty.default;
@@ -189,6 +189,16 @@ export class ConfigurationRegistry implements IConfigurationRegistry {
       this._onDidUpdateConfiguration.fire({ properties });
     }
     return properties;
+  }
+
+  private isDefaultScope(scope?: ConfigurationScope | ConfigurationScope[]): boolean {
+    if (!scope) {
+      return true;
+    }
+    if (Array.isArray(scope) && scope.find(s => s === CONFIGURATION_DEFAULT_SCOPE)) {
+      return true;
+    }
+    return scope === CONFIGURATION_DEFAULT_SCOPE;
   }
 
   public deregisterConfigurations(configurations: IConfigurationNode[]): void {


### PR DESCRIPTION
### What does this PR do?

This PR cleans the code that defines the autostart setting and fixes a problem when storing its value.

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

it fixes #4647 

### How to test this PR?

1. check that the autostart setting is actually saved
2. set autostart, stop machine, restart podman desktop, check that the autostart setting is true and the podman machine is started
3. set autostart to false, stop machine, restart desktop, check autostart setting is false and the podman machine is still stopped.
