### PR TITLE
feat: introduce property for appearance but for now only dark is supported

### DIFF
--- a/packages/main/src/plugin/appearance-init.ts
+++ b/packages/main/src/plugin/appearance-init.ts
@@ -1,0 +1,43 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { IConfigurationNode, IConfigurationRegistry } from './configuration-registry.js';
+import { AppearanceSettings } from './appearance-settings.js';
+
+export class AppearanceInit {
+  constructor(private configurationRegistry: IConfigurationRegistry) {}
+
+  init() {
+    const appearanceConfiguration: IConfigurationNode = {
+      id: 'preferences.appearance',
+      title: 'Appearance',
+      type: 'object',
+      properties: {
+        [AppearanceSettings.SectionName + '.' + AppearanceSettings.Appearance]: {
+          description: 'Appearance',
+          type: 'string',
+          enum: ['system', 'dark', 'light'],
+          default: 'system',
+          hidden: true,
+        },
+      },
+    };
+
+    this.configurationRegistry.registerConfigurations([appearanceConfiguration]);
+  }
+}

--- a/packages/main/src/plugin/appearance-settings.ts
+++ b/packages/main/src/plugin/appearance-settings.ts
@@ -1,0 +1,25 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+export enum AppearanceSettings {
+  SectionName = 'preferences',
+  Appearance = 'appearance',
+  LightEnumValue = 'light',
+  DarkEnumValue = 'dark',
+  SystemEnumValue = 'system',
+}

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -143,6 +143,7 @@ import type { NotificationCard, NotificationCardOptions } from './api/notificati
 import { NotificationRegistry } from './notification-registry.js';
 import { ImageCheckerImpl } from './image-checker.js';
 import type { ImageCheckerInfo } from './api/image-checker-info.js';
+import { AppearanceInit } from './appearance-init.js';
 
 type LogType = 'log' | 'warn' | 'trace' | 'debug' | 'error';
 
@@ -689,6 +690,10 @@ export class PluginSystem {
     commandRegistry.registerCommand('troubleshooting', () => {
       apiSender.send('display-troubleshooting', '');
     });
+
+    // register appearance (light, dark, auto being system)
+    const appearanceConfiguration = new AppearanceInit(configurationRegistry);
+    appearanceConfiguration.init();
 
     const terminalInit = new TerminalInit(configurationRegistry);
     terminalInit.init();

--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -39,6 +39,7 @@ import CustomPick from './lib/dialogs/CustomPick.svelte';
 import ContextKey from './lib/context/ContextKey.svelte';
 import CreateVolume from './lib/volume/CreateVolume.svelte';
 import CommandPalette from './lib/dialogs/CommandPalette.svelte';
+import Appearance from './lib/appearance/Appearance.svelte';
 
 router.mode.hash();
 
@@ -64,6 +65,7 @@ window.events?.receive('display-troubleshooting', () => {
 <Route path="/*" breadcrumb="Home" let:meta>
   <main class="flex flex-col w-screen h-screen overflow-hidden bg-charcoal-800">
     <IconsStyle />
+    <Appearance />
     <TitleBar />
     <ContextKey />
 

--- a/packages/renderer/src/lib/appearance/Appearance.spec.ts
+++ b/packages/renderer/src/lib/appearance/Appearance.spec.ts
@@ -1,0 +1,106 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable no-null/no-null */
+import '@testing-library/jest-dom/vitest';
+import { test, vi, expect, beforeEach } from 'vitest';
+import { render, type RenderResult } from '@testing-library/svelte';
+import Appearance from './Appearance.svelte';
+import { AppearanceSettings } from '../../../../main/src/plugin/appearance-settings';
+
+const getConfigurationValueMock = vi.fn();
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  (window as any).getConfigurationValue = getConfigurationValueMock;
+  (window as any).matchMedia = vi.fn().mockReturnValue({
+    matches: false,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  });
+});
+
+function getRootElementClassesValue(container: HTMLElement): string | undefined {
+  // get root html element
+  let rootElement: HTMLElement | null = container;
+  while (rootElement?.parentElement) {
+    rootElement = container.parentElement;
+  }
+
+  return rootElement?.classList.value;
+}
+
+async function awaitRender(): Promise<RenderResult<Appearance>> {
+  const result = render(Appearance);
+  // wait end of asynchrounous onMount
+  // wait 200ms
+  await new Promise(resolve => setTimeout(resolve, 200));
+
+  return result;
+}
+
+// temporary as only dark mode is supported as rendering for now
+// it should return empty later
+test('Expect dark mode using system when OS is set to light', async () => {
+  (window as any).matchMedia = vi.fn().mockReturnValue({
+    matches: false,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  });
+
+  getConfigurationValueMock.mockResolvedValue(AppearanceSettings.SystemEnumValue);
+
+  const { container } = await awaitRender();
+
+  const val = getRootElementClassesValue(container);
+
+  // expect to have class being "dark" as for now we force dark mode in system mode
+  expect(val).toBe('dark');
+});
+
+test('Expect dark mode using system when OS is set to dark', async () => {
+  (window as any).matchMedia = vi.fn().mockReturnValue({
+    matches: true,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  });
+
+  getConfigurationValueMock.mockResolvedValue(AppearanceSettings.SystemEnumValue);
+
+  const { container } = await awaitRender();
+  // expect to have class being "dark" as OS is using dark
+  expect(getRootElementClassesValue(container)).toBe('dark');
+});
+
+test('Expect light mode using light configuration', async () => {
+  getConfigurationValueMock.mockResolvedValue(AppearanceSettings.LightEnumValue);
+
+  const { container } = await awaitRender();
+
+  // expect to have class being ""  as we should be in light mode
+  expect(getRootElementClassesValue(container)).toBe('');
+});
+
+test('Expect dark mode using dark configuration', async () => {
+  getConfigurationValueMock.mockResolvedValue(AppearanceSettings.DarkEnumValue);
+
+  const { container } = await awaitRender();
+
+  // expect to have class being "dark"  as we should be in light mode
+  expect(getRootElementClassesValue(container)).toBe('dark');
+});

--- a/packages/renderer/src/lib/appearance/Appearance.svelte
+++ b/packages/renderer/src/lib/appearance/Appearance.svelte
@@ -1,0 +1,57 @@
+<script lang="ts">
+import { onMount, onDestroy } from 'svelte';
+
+import { AppearanceSettings } from '../../../../main/src/plugin/appearance-settings';
+import { onDidChangeConfiguration } from '../../stores/configurationProperties';
+
+const APPEARANCE_CONFIGURATION_KEY = AppearanceSettings.SectionName + '.' + AppearanceSettings.Appearance;
+async function updateAppearance(): Promise<void> {
+  // get the configuration of the appearance
+  const appearance = await window.getConfigurationValue<string>(APPEARANCE_CONFIGURATION_KEY);
+
+  let isDark = false;
+
+  if (appearance === AppearanceSettings.SystemEnumValue) {
+    // need to read the system default theme using the window.matchMedia
+    isDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    //FIXME: for now we hardcode to the dark theme even if the Operatin System is using light theme
+    // as it renders correctly only in dark mode today
+    isDark = true;
+  } else if (appearance === AppearanceSettings.LightEnumValue) {
+    isDark = false;
+  } else if (appearance === AppearanceSettings.DarkEnumValue) {
+    isDark = true;
+  }
+
+  const html = document.documentElement;
+
+  // toggle the dark class on the html element
+  if (isDark) {
+    html.classList.add('dark');
+  } else {
+    html.classList.remove('dark');
+  }
+}
+
+let onDidChangeConfigurationCallback: EventListenerOrEventListenerObject = () => {
+  // we refresh the appearance
+  updateAppearance();
+};
+
+onMount(async () => {
+  await updateAppearance();
+
+  // add a listener for the appearance change in case user change setting on the Operating System
+  window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => {
+    updateAppearance();
+  });
+});
+
+// now, need to do the same for the appearance setting
+onDidChangeConfiguration.addEventListener(APPEARANCE_CONFIGURATION_KEY, onDidChangeConfigurationCallback);
+
+// remove callback when the component is destroyed
+onDestroy(() => {
+  onDidChangeConfiguration.removeEventListener(APPEARANCE_CONFIGURATION_KEY, onDidChangeConfigurationCallback);
+});
+</script>

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -23,6 +23,7 @@ module.exports = {
     'packages/renderer/index.html',
     'packages/renderer/src/**/*.{svelte,ts,css}',
   ],
+  darkMode: 'class',
   theme: {
     extend: {
       boxShadow: {


### PR DESCRIPTION
### What does this PR do?
add a new setting which is hidden to toggle between light or dark mode
it's hidden because if the user is asking for light mode it will be still displayed with dark colours.

It's set to `system` mode but even if all the logic is there, at the end we force 'dark' mode for the system mode to not break users having wrong display of items until the light mode is completed

But it toggles on or off the dark theme support then we can use dark: prefix in the codebase to make the style being specific for the dark theme

it's like the beginning of more upcoming PRs


### Screenshot/screencast of this PR

N/A as setting is hidden

### What issues does this PR fix or reference?

related to #576 

### How to test this PR?

you can replace `hidden: true` by `hidden:false` and then you'll see the preference in preferences page

default is system so it means it'll use mode of the underlying operating system
(but default will still be mapped now to dark to not let display something broken to the user as it's the default property)

then you can inspect with 'light' or 'dark' toggle the class of the html root element (it should add `dark` or remove `dark` if you change the property)

unit tests have been added