### PR TITLE
fix(ci,tests): improve test failure screenshot files naming

### DIFF
--- a/tests/src/podman-extension-smoke.spec.ts
+++ b/tests/src/podman-extension-smoke.spec.ts
@@ -90,10 +90,6 @@ async function verifyPodmanExtensionStatus(enabled: boolean) {
     : await playExpect(podmanProviderLocator).not.toBeVisible();
   // always present and visible
   const settingsExtensionsPage = await openSettingsExtensionsPage();
-  const settingsExtensionsPodmanLocator = settingsExtensionsPage.getFeaturedExtension(
-    SETTINGS_NAVBAR_EXTENSIONS_PODMAN,
-  );
-  await playExpect(settingsExtensionsPodmanLocator).toBeVisible();
   const podmanExtensionRowLocator = settingsExtensionsPage.getExtensionRowFromTable(
     SETTINGS_EXTENSIONS_TABLE_PODMAN_TITLE,
   );

--- a/tests/src/setupFiles/extended-hooks.ts
+++ b/tests/src/setupFiles/extended-hooks.ts
@@ -23,11 +23,7 @@ import * as path from 'node:path';
 
 afterEach(async (context: RunnerTestContext) => {
   context.onTestFailed(async () => {
-    const normalizedFilePath = context.task.name
-      .replace(/'/g, '')
-      .replace(/\//g, '_')
-      .replace(/:/g, '_')
-      .replace(/ /g, '_');
+    const normalizedFilePath = context.task.name.replace(/([/: ])/g, '_').replace(/(['"><|*?\r\n])/g, '');
     let fileName = `${normalizedFilePath}_failure`;
     let counter = 0;
     while (fs.existsSync(path.resolve(context.pdRunner.getTestOutput(), 'screenshots', `${fileName}.png`))) {

--- a/tests/src/setupFiles/extended-hooks.ts
+++ b/tests/src/setupFiles/extended-hooks.ts
@@ -23,7 +23,10 @@ import * as path from 'node:path';
 
 afterEach(async (context: RunnerTestContext) => {
   context.onTestFailed(async () => {
-    const normalizedFilePath = context.task.name.replace(/([/: ])/g, '_').replace(/(['"><|*?\r\n])/g, '');
+    const normalizedFilePath = context.task.name
+      .replace(/([/: ])/g, '_')
+      .replace(/[^_a-zA-Z0-9]/g, '')
+      .replace(/[_]{2,}/g, '_');
     let fileName = `${normalizedFilePath}_failure`;
     let counter = 0;
     while (fs.existsSync(path.resolve(context.pdRunner.getTestOutput(), 'screenshots', `${fileName}.png`))) {


### PR DESCRIPTION
### What does this PR do?

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast 
explaining what is doing this PR -->

### What issues does this PR fix or reference?
#4905
<!-- Include any related issues from Podman Desktop 
repository (or from another issue tracker). -->

### How to test this PR?
Include some invalid character (as defined by filesystem or third party program) into test method name, make the test fail and check failure screenshot file name in `tests/output/screenshots` folder.
<!-- Please explain steps to reproduce -->
