### PR TITLE
chore: fix scrollbar colors to match light/dark mode

### DIFF
--- a/packages/renderer/src/lib/appearance/Appearance.spec.ts
+++ b/packages/renderer/src/lib/appearance/Appearance.spec.ts
@@ -98,7 +98,7 @@ test('Expect light mode using light configuration', async () => {
   // expect to have class being ""  as we should be in light mode
   expect(getRootElementClassesValue(container)).toBe('');
 
-  // expect to have color-scheme: dark
+  // expect to have color-scheme: light
   expect(getRootElement(container)).toHaveStyle('color-scheme: light');
 });
 

--- a/packages/renderer/src/lib/appearance/Appearance.spec.ts
+++ b/packages/renderer/src/lib/appearance/Appearance.spec.ts
@@ -35,14 +35,17 @@ beforeEach(() => {
   });
 });
 
-function getRootElementClassesValue(container: HTMLElement): string | undefined {
+function getRootElement(container: HTMLElement): HTMLElement {
   // get root html element
   let rootElement: HTMLElement | null = container;
   while (rootElement?.parentElement) {
     rootElement = container.parentElement;
   }
+  return rootElement as HTMLElement;
+}
 
-  return rootElement?.classList.value;
+function getRootElementClassesValue(container: HTMLElement): string | undefined {
+  return getRootElement(container).classList.value;
 }
 
 async function awaitRender(): Promise<RenderResult<Appearance>> {
@@ -94,6 +97,9 @@ test('Expect light mode using light configuration', async () => {
 
   // expect to have class being ""  as we should be in light mode
   expect(getRootElementClassesValue(container)).toBe('');
+
+  // expect to have color-scheme: dark
+  expect(getRootElement(container)).toHaveStyle('color-scheme: light');
 });
 
 test('Expect dark mode using dark configuration', async () => {
@@ -101,6 +107,9 @@ test('Expect dark mode using dark configuration', async () => {
 
   const { container } = await awaitRender();
 
-  // expect to have class being "dark"  as we should be in light mode
+  // expect to have class being "dark" as we should be in light mode
   expect(getRootElementClassesValue(container)).toBe('dark');
+
+  // expect to have color-scheme: dark
+  expect(getRootElement(container)).toHaveStyle('color-scheme: dark');
 });

--- a/packages/renderer/src/lib/appearance/Appearance.svelte
+++ b/packages/renderer/src/lib/appearance/Appearance.svelte
@@ -28,8 +28,10 @@ async function updateAppearance(): Promise<void> {
   // toggle the dark class on the html element
   if (isDark) {
     html.classList.add('dark');
+    html.setAttribute('style', 'color-scheme: dark;');
   } else {
     html.classList.remove('dark');
+    html.setAttribute('style', 'color-scheme: light;');
   }
 }
 


### PR DESCRIPTION
### What does this PR do?
apply color scheme conditionally

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast 
explaining what is doing this PR -->

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/4888

### How to test this PR?

unit test

but let's go to a big page, reduce the height and look at scrollbars it should look like grey with Dark mode and not dark
