### PR TITLE
fix: unable to read wsl version when using chinese as syslang on Windows (#4863)

### DIFF
--- a/extensions/podman/src/wsl-helper.spec.ts
+++ b/extensions/podman/src/wsl-helper.spec.ts
@@ -59,7 +59,7 @@ Windows version: 10.0.22621.2134
   expect(windowsVersion).toBe('10.0.22621.2134');
 
   // expect called with wsl --version
-  expect(extensionApi.process.exec).toHaveBeenCalledWith('wsl', ['--version']);
+  expect(extensionApi.process.exec).toHaveBeenCalledWith('wsl', ['--version'], { encoding: 'utf16le' });
 });
 
 test('should grab correct versions even with an output with a language different from english', async () => {
@@ -83,5 +83,28 @@ test('should grab correct versions even with an output with a language different
   expect(windowsVersion).toBe('10.0.22621.2283');
 
   // expect called with wsl --version
-  expect(extensionApi.process.exec).toHaveBeenCalledWith('wsl', ['--version']);
+  expect(extensionApi.process.exec).toHaveBeenCalledWith('wsl', ['--version'], { encoding: 'utf16le' });
+});
+
+test('should grab correct versions even with an output in chinese', async () => {
+  const wslOutput = `WSL 版本： 2.0.4.0
+  内核版本： 5.15.123.1-1
+  WSLg 版本： 1.0.58
+  MSRDC 版本： 1.2.4485
+  Direct3D 版本： 1.608.2-61064218
+  DXCore 版本： 10.0.25880.1000-230602-1350.main
+  Windows 版本： 10.0.22621.2715
+`;
+
+  (extensionApi.process.exec as Mock).mockReturnValue({
+    stdout: wslOutput,
+  } as extensionApi.RunResult);
+
+  const wslVersionInfo = await wslHelper.getWSLVersionData();
+
+  expect(wslVersionInfo.wslVersion).toBe('2.0.4.0');
+  expect(wslVersionInfo.windowsVersion).toBe('10.0.22621.2715');
+
+  // expect called with wsl --version
+  expect(extensionApi.process.exec).toHaveBeenCalledWith('wsl', ['--version'], { encoding: 'utf16le' });
 });

--- a/extensions/podman/src/wsl-helper.spec.ts
+++ b/extensions/podman/src/wsl-helper.spec.ts
@@ -86,7 +86,7 @@ test('should grab correct versions even with an output with a language different
   expect(extensionApi.process.exec).toHaveBeenCalledWith('wsl', ['--version'], { encoding: 'utf16le' });
 });
 
-test('should grab correct versions even with an output in chinese', async () => {
+test('should grab correct versions even with an output in chinese and fullwidth colon symbol', async () => {
   const wslOutput = `WSL 版本： 2.0.4.0
   内核版本： 5.15.123.1-1
   WSLg 版本： 1.0.58
@@ -104,6 +104,30 @@ test('should grab correct versions even with an output in chinese', async () => 
 
   expect(wslVersionInfo.wslVersion).toBe('2.0.4.0');
   expect(wslVersionInfo.windowsVersion).toBe('10.0.22621.2715');
+
+  // expect called with wsl --version
+  expect(extensionApi.process.exec).toHaveBeenCalledWith('wsl', ['--version'], { encoding: 'utf16le' });
+});
+
+test('should grab correct versions when output contains small colon symbol', async () => {
+  const wslOutput = `WSL version﹕1.2.5.0
+Kernel version﹕5.15.90.1
+WSLg version﹕1.0.51
+MSRDC version﹕1.2.3770
+Direct3D version﹕1.608.2-61064218
+DXCore version﹕10.0.25131.1002-220531-1700.rs-onecore-base2-hyp
+Windows version﹕10.0.22621.2134
+`;
+
+  (extensionApi.process.exec as Mock).mockReturnValue({
+    stdout: wslOutput,
+  } as extensionApi.RunResult);
+
+  const { wslVersion, kernelVersion, windowsVersion } = await wslHelper.getWSLVersionData();
+
+  expect(wslVersion).toBe('1.2.5.0');
+  expect(kernelVersion).toBe('5.15.90.1');
+  expect(windowsVersion).toBe('10.0.22621.2134');
 
   // expect called with wsl --version
   expect(extensionApi.process.exec).toHaveBeenCalledWith('wsl', ['--version'], { encoding: 'utf16le' });

--- a/extensions/podman/src/wsl-helper.ts
+++ b/extensions/podman/src/wsl-helper.ts
@@ -9,7 +9,7 @@ export interface WSLVersionInfo {
 
 export class WslHelper {
   async getWSLVersionData(): Promise<WSLVersionInfo> {
-    const { stdout } = await extensionApi.process.exec('wsl', ['--version']);
+    const { stdout } = await extensionApi.process.exec('wsl', ['--version'], { encoding: 'utf16le' });
     /*
       got something like
       WSL version: 1.2.5.0
@@ -53,9 +53,29 @@ function getVersionFromWSLOutput(line: string, value: string): string {
   if (!line) {
     return undefined;
   }
-  const colonPosition = line.indexOf(':');
+  const colonPosition = indexOfColons(line);
   if (colonPosition >= 0 && line.substring(0, colonPosition).toLowerCase().includes(value)) {
     return line.substring(colonPosition + 1).trim();
   }
   return undefined;
+}
+
+/**
+ * WSL uses a different encoding based on the default system language (utf-8 for english, utf-16 for chinese)
+ * when using a non-latin language like chinese, WSL also uses a different value for the colon symbol
+ * There are three colons:
+ * symbol | name            | number
+ * :      | vertical colon  | 58
+ * ：     | fullwidth colon | 65306
+ * ﹕     | small colon     | 65109
+ * This function returns the position of the first colon symbol found in the string
+ */
+function indexOfColons(value: string): number {
+  for (let i = 0; i < value.length; i++) {
+    const codeChar = value.charCodeAt(i);
+    if (codeChar === 58 || codeChar === 65306 || codeChar === 65109) {
+      return i;
+    }
+  }
+  return -1;
 }

--- a/extensions/podman/src/wsl-helper.ts
+++ b/extensions/podman/src/wsl-helper.ts
@@ -61,8 +61,7 @@ function getVersionFromWSLOutput(line: string, value: string): string {
 }
 
 /**
- * WSL uses a different encoding based on the default system language (utf-8 for english, utf-16 for chinese)
- * when using a non-latin language like chinese, WSL also uses a different value for the colon symbol
+ * When using a non-latin language like chinese, WSL also uses a different value for the colon symbol
  * There are three colons:
  * symbol | name            | number
  * :      | vertical colon  | 58


### PR DESCRIPTION
### What does this PR do?

This PR fixes an issue when detecting wsl version on a chinese lang system.
There were 2 problems, the first we encoded using utf8 when wsl returns an output encoded utf16, and then the output contains a fullwidth colon which is different from the one we use in ASCII.

### Screenshot/screencast of this PR

N/A 

### What issues does this PR fix or reference?

it fixes #4863

### How to test this PR?

1. switch to chinese on windows or just run on your usual syste mto see if it works as before
