### PR TITLE
feat: show what the current context is

### DIFF
--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -145,6 +145,7 @@ import { NotificationRegistry } from './notification-registry.js';
 import { ImageCheckerImpl } from './image-checker.js';
 import type { ImageCheckerInfo } from './api/image-checker-info.js';
 import { AppearanceInit } from './appearance-init.js';
+import type { KubeContext } from './kubernetes-context.js';
 
 type LogType = 'log' | 'warn' | 'trace' | 'debug' | 'error';
 
@@ -1875,6 +1876,10 @@ export class PluginSystem {
 
     this.ipcHandle('kubernetes-client:getContexts', async (): Promise<KubernetesContext[]> => {
       return kubernetesClient.getContexts();
+    });
+
+    this.ipcHandle('kubernetes-client:getDetailedContexts', async (): Promise<KubeContext[]> => {
+      return kubernetesClient.getDetailedContexts();
     });
 
     this.ipcHandle('kubernetes-client:getClusters', async (): Promise<Cluster[]> => {

--- a/packages/main/src/plugin/kubernetes-context.ts
+++ b/packages/main/src/plugin/kubernetes-context.ts
@@ -1,0 +1,42 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+// A simpler method of holding all the Kubernetes context information in one place
+// for the UI to use.
+
+export interface KubeCluster {
+  name: string;
+  server: string;
+  skipTLSVerify?: boolean;
+  tlsServerName?: string;
+}
+
+export interface KubeContext {
+  name: string;
+  cluster: string;
+  user: string;
+  clusterInfo?: KubeCluster;
+
+  // Is this the current context? Should be true for ONE context in the array list of contexts.
+  currentContext?: boolean;
+
+  // Optional BASE64 encoded icon to be used in the UI.
+  icon?: string;
+  // error to display in case of deletion (or other operation) error
+  error?: string;
+}

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -84,6 +84,7 @@ import type {
   GenerateKubeResult,
   KubernetesGeneratorArgument,
 } from '../../main/src/plugin/kube-generator-registry';
+import type { KubeContext } from '../../main/src/plugin/kubernetes-context';
 
 import type { KubernetesGeneratorInfo } from '../../main/src/plugin/api/KubernetesGeneratorInfo';
 import type { NotificationCard, NotificationCardOptions } from '../../main/src/plugin/api/notification';
@@ -1415,6 +1416,10 @@ function initExposure(): void {
 
   contextBridge.exposeInMainWorld('kubernetesGetContexts', async (): Promise<Context[]> => {
     return ipcInvoke('kubernetes-client:getContexts');
+  });
+
+  contextBridge.exposeInMainWorld('kubernetesGetDetailedContexts', async (): Promise<KubeContext[]> => {
+    return ipcInvoke('kubernetes-client:getDetailedContexts');
   });
 
   contextBridge.exposeInMainWorld('kubernetesDeleteContext', async (contextName: string): Promise<Context[]> => {

--- a/packages/renderer/src/lib/kube/KubeContextUI.ts
+++ b/packages/renderer/src/lib/kube/KubeContextUI.ts
@@ -16,60 +16,17 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { Cluster, Context } from '@kubernetes/client-node';
+import type { Context } from '@kubernetes/client-node';
 import { kubernetesIconBase64 } from './KubeIcon';
+import type { KubeContext } from '../../../../main/src/plugin/kubernetes-context';
 
-export interface KubeContextClusterUI {
-  name: string;
-  server: string;
-  skipTLSVerify?: boolean;
-  tlsServerName?: string;
-}
-
-export interface KubeConnectionInfo {
-  online: boolean; // Checks if the cluster is online via checkConnection
-}
-
-export interface KubeContextUI {
-  name: string;
-  cluster: string;
-  user: string;
-  clusterInfo?: KubeContextClusterUI;
-  icon?: string;
-  // error to display in case of deletion (or other operation) error
-  error?: string;
-}
-
-// Function that takes in the clusters and contexts and returns the KubeContextUI
-// for the UI to use.
-// If the cluster is not found, the clusterInfo will be undefined.
-export function getKubeUIContexts(contexts: Context[], clusters: Cluster[]): KubeContextUI[] {
-  const kubeContexts: KubeContextUI[] = [];
-
-  // Go through each context
-  contexts.forEach(context => {
-    // Try and find the cluster
-    const cluster = clusters.find(c => c.name === context.cluster);
-
-    // If the cluster is not found, just return undefined for clusterInfo
-    // as sometimes in the context we have information, but nothing about
-    // the cluster.
-    kubeContexts.push({
-      name: context.name,
-      cluster: context.cluster,
-      user: context.user,
-      icon: kubernetesIconBase64,
-      clusterInfo: cluster
-        ? {
-            name: cluster.name,
-            server: cluster.server,
-            skipTLSVerify: cluster.skipTLSVerify,
-            tlsServerName: cluster.tlsServerName,
-          }
-        : undefined,
-    });
+// Function that goes through KubeContext and adds kubernetesIconBase64 icon to each context
+// TODO: In the future we will analyze which icon to use based on the cluster name and cluster information
+// We have this in here rather than /plugin because this is UI related.
+export function addIconToContexts(contexts: KubeContext[]): KubeContext[] {
+  return contexts.map(ctx => {
+    return { ...ctx, icon: kubernetesIconBase64 };
   });
-  return kubeContexts;
 }
 
 export function setKubeUIContextError(contexts: Context[], contextName: string, error: Error): Context[] {

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
@@ -49,7 +49,10 @@ async function handleDeleteContext(contextName: string) {
       message="Check that $HOME/.kube/config exists or KUBECONFIG environment variable has been set correctly."
       hidden="{$kubernetesContexts.length > 0}" />
     {#each $kubernetesContexts as context}
-      <div role="row" class="bg-charcoal-600 mb-5 rounded-md p-3 flex-nowrap">
+      <!-- If current context, use lighter background -->
+      <div
+        role="row"
+        class="{context.currentContext ? 'bg-charcoal-600' : 'bg-charcoal-700'} mb-5 rounded-md p-3 flex-nowrap">
         <div class="pb-2">
           <div class="flex">
             {#if context?.icon}
@@ -61,8 +64,15 @@ async function handleDeleteContext(contextName: string) {
                   class="max-w-[40px] h-full" />
               {/if}
             {/if}
-            <span id="{context.name}" class="my-auto text-gray-400 ml-3 break-words flex-auto" aria-label="context-name"
-              >{context.name}</span>
+            <!-- Centered items div -->
+            <div class="pl-3 flex-grow flex flex-col justify-center">
+              <div class="flex flex-col items-left">
+                {#if context.currentContext}
+                  <span class="text-xs text-gray-600" aria-label="current-context">Current Context</span>
+                {/if}
+                <span class="text-md" aria-label="context-name">{context.name}</span>
+              </div>
+            </div>
             <ListItemButtonIcon
               title="Delete Context"
               icon="{faTrash}"

--- a/packages/renderer/src/stores/kubernetes-contexts.ts
+++ b/packages/renderer/src/stores/kubernetes-contexts.ts
@@ -18,7 +18,8 @@
 
 import { writable, type Writable } from 'svelte/store';
 import { EventStore } from './event-store';
-import { getKubeUIContexts, type KubeContextUI } from '../lib/kube/KubeContextUI';
+import type { KubeContext } from '../../../main/src/plugin/kubernetes-context';
+import { addIconToContexts } from '../lib/kube/KubeContextUI';
 
 const windowEvents: string[] = ['extensions-started', 'kubernetes-context-update'];
 const windowListeners = ['extensions-already-started'];
@@ -34,9 +35,9 @@ export async function checkForUpdate(eventName: string): Promise<boolean> {
   return readyToUpdate;
 }
 
-export const kubernetesContexts: Writable<KubeContextUI[]> = writable([]);
+export const kubernetesContexts: Writable<KubeContext[]> = writable([]);
 
-const eventStore = new EventStore<KubeContextUI[]>(
+const eventStore = new EventStore<KubeContext[]>(
   'kubernetes contexts',
   kubernetesContexts,
   checkForUpdate,
@@ -46,11 +47,10 @@ const eventStore = new EventStore<KubeContextUI[]>(
 );
 eventStore.setup();
 
-export async function grabKubernetesContexts(): Promise<KubeContextUI[]> {
-  // Retrieve both the contexts and clusters
-  const k8sContexts = await window.kubernetesGetContexts();
-  const k8sClusters = await window.kubernetesGetClusters();
+export async function grabKubernetesContexts(): Promise<KubeContext[]> {
+  // Retrieve the detailed contexts which includes cluster information, current context, etc.
+  const contexts = await window.kubernetesGetDetailedContexts();
 
-  // Convert them to KubeContextUI so we can safely render them.
-  return getKubeUIContexts(k8sContexts, k8sClusters);
+  // Add the icon to each context and return it
+  return addIconToContexts(contexts);
 }


### PR DESCRIPTION
feat: show what the current context is

### What does this PR do?

* Refactors the Kubernetes window calls a bit so we can do it in one
  call that returns the current context, cluster information, etc.
* Now shows what the current context is / slight shade / different
  background

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast
explaining what is doing this PR -->


https://github.com/containers/podman-desktop/assets/6422176/e061fdbd-c512-40c9-b4eb-92aed3558bfb





### What issues does this PR fix or reference?

Closes https://github.com/containers/podman-desktop/issues/4618

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to reproduce -->

1. Have a .kube/config
2. Go to Kubernetes view in settings
3. Edit the current context to a different value and you will see the
   current context change

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
