### PR TITLE
feat: table sorting II

### DIFF
--- a/packages/renderer/src/lib/table/Table.spec.ts
+++ b/packages/renderer/src/lib/table/Table.spec.ts
@@ -65,7 +65,7 @@ test('Expect default sort indicator', async () => {
   expect(headers).toBeDefined();
   expect(headers.length).toBe(5);
   expect(headers[2].textContent).toContain('Id');
-  expect(headers[2].innerHTML).toContain('fa-sort-down');
+  expect(headers[2].innerHTML).toContain('fa-sort-up');
 });
 
 test('Expect no default sort indicator on other columns', async () => {

--- a/packages/renderer/src/lib/table/Table.spec.ts
+++ b/packages/renderer/src/lib/table/Table.spec.ts
@@ -101,11 +101,11 @@ test('Expect sorting by name works', async () => {
   expect(rows[3].textContent).toContain('John');
 });
 
-test('Expect sorting by age works', async () => {
+test('Expect sorting by age sorts descending initially', async () => {
   render(TestTable, {});
 
-  const ageCol = screen.getByText('Age');
-  expect(ageCol).toBeInTheDocument();
+  const ageCol = await screen.findByRole('columnheader', { name: 'Age' });
+  expect(ageCol).toBeDefined();
 
   let rows = await screen.findAllByRole('row');
   expect(rows).toBeDefined();
@@ -115,6 +115,35 @@ test('Expect sorting by age works', async () => {
   expect(rows[3].textContent).toContain('Charlie');
 
   await fireEvent.click(ageCol);
+
+  expect(ageCol.innerHTML).toContain('fa-sort-down');
+
+  rows = await screen.findAllByRole('row');
+  expect(rows[1].textContent).toContain('John');
+  expect(rows[2].textContent).toContain('Charlie');
+  expect(rows[3].textContent).toContain('Henry');
+});
+
+test('Expect sorting by age twice sorts ascending', async () => {
+  render(TestTable, {});
+
+  const ageCol = await screen.findByRole('columnheader', { name: 'Age' });
+  expect(ageCol).toBeDefined();
+
+  let rows = await screen.findAllByRole('row');
+  expect(rows).toBeDefined();
+  expect(rows.length).toBe(4);
+  expect(rows[1].textContent).toContain('John');
+  expect(rows[2].textContent).toContain('Henry');
+  expect(rows[3].textContent).toContain('Charlie');
+
+  await fireEvent.click(ageCol);
+
+  expect(ageCol.innerHTML).toContain('fa-sort-down');
+
+  await fireEvent.click(ageCol);
+
+  expect(ageCol.innerHTML).toContain('fa-sort-up');
 
   rows = await screen.findAllByRole('row');
   expect(rows[1].textContent).toContain('Henry');

--- a/packages/renderer/src/lib/table/Table.svelte
+++ b/packages/renderer/src/lib/table/Table.svelte
@@ -40,6 +40,10 @@ function toggleAll(checked: boolean) {
 let sortCol: Column<any>;
 let sortAscending: boolean;
 
+if (data) {
+  sortImpl();
+}
+
 function sort(column: Column<any>) {
   if (!column) {
     return;
@@ -55,8 +59,23 @@ function sort(column: Column<any>) {
     sortAscending = !sortAscending;
   } else {
     sortCol = column;
-    sortAscending = true;
+    sortAscending = column.info.initialOrder ? column.info.initialOrder !== 'descending' : true;
   }
+  sortImpl();
+}
+
+function sortImpl() {
+  // confirm we're sorting
+  if (!sortCol) {
+    return;
+  }
+
+  let comparator = sortCol.info.comparator;
+  if (!comparator) {
+    // column is not sortable
+    return;
+  }
+
   if (!sortAscending) {
     // we're already sorted, switch to reverse order
     let comparatorTemp = comparator;
@@ -69,9 +88,9 @@ function sort(column: Column<any>) {
 
 onMount(async () => {
   const column: Column<any> | undefined = columns.find(column => column.title === defaultSortColumn);
-  if (column) {
+  if (column?.info.comparator) {
     sortCol = column;
-    sortAscending = true;
+    sortAscending = column.info.initialOrder ? column.info.initialOrder !== 'descending' : true;
   }
 });
 
@@ -84,7 +103,9 @@ function setGridColumns() {
   // section and checkbox columns
   let columnWidths: string[] = ['20px'];
 
-  if (row.info.selectable) columnWidths.push('32px');
+  if (row.info.selectable) {
+    columnWidths.push('32px');
+  }
 
   // custom columns
   columns.map(c => c.info.width ?? '1fr').forEach(w => columnWidths.push(w));
@@ -129,8 +150,8 @@ function setGridColumns() {
         {column.title}{#if column.info.comparator}<i
             class="fas pl-0.5"
             class:fa-sort="{sortCol !== column}"
-            class:fa-sort-up="{sortCol === column && !sortAscending}"
-            class:fa-sort-down="{sortCol === column && sortAscending}"
+            class:fa-sort-up="{sortCol === column && sortAscending}"
+            class:fa-sort-down="{sortCol === column && !sortAscending}"
             class:text-charcoal-200="{sortCol !== column}"
             aria-hidden="true"></i
           >{/if}

--- a/packages/renderer/src/lib/table/TestTable.svelte
+++ b/packages/renderer/src/lib/table/TestTable.svelte
@@ -36,6 +36,7 @@ const ageCol: Column<Person> = new Column('Age', {
   align: 'right',
   renderer: TestColumnAge,
   comparator: (a, b) => a.age - b.age,
+  initialOrder: 'descending',
 });
 
 const columns: Column<Person>[] = [idCol, nameCol, ageCol];

--- a/packages/renderer/src/lib/table/table.ts
+++ b/packages/renderer/src/lib/table/table.ts
@@ -47,6 +47,19 @@ export interface ColumnInformation<Type> {
    * @param comparator
    */
   readonly comparator?: (object1: Type, object2: Type) => number;
+
+  /**
+   * The 'natural' or initial sort direction. Most columns are
+   * naturally sorted in ascending order and do not need to
+   * specify this value - e.g. names are sorted alphabetically.
+   *
+   * Columns that are naturally sorted in descending order -
+   * e.g. file sizes or 'number of children' by biggest first -
+   * can set this value to change the initial sort direction.
+   *
+   * Defaults to 'ascending'.
+   */
+  readonly initialOrder?: 'ascending' | 'descending';
 }
 
 /**

--- a/packages/renderer/src/lib/volume/VolumesList.svelte
+++ b/packages/renderer/src/lib/volume/VolumesList.svelte
@@ -198,7 +198,8 @@ let ageColumn = new Column<VolumeInfoUI>('Age', {
 let sizeColumn = new Column<VolumeInfoUI>('Size', {
   align: 'right',
   renderer: VolumeColumnSize,
-  comparator: (a, b) => b.size - a.size,
+  comparator: (a, b) => a.size - b.size,
+  initialOrder: 'descending',
 });
 
 const columns: Column<VolumeInfoUI>[] = [


### PR DESCRIPTION
### What does this PR do?

Fixes the sort issues raised in issue #4881:

- Fixed sort direction: ascending sort should be 'up', descending 'down'.
- Added a new 'initialSortDir' for Columns like Size to specify that they should be sorted in descending order by default. This could have been a boolean flag, but seeing "initialSortDir: 'descending'" in Column definitions seems more natural and obvious to me.

This also fixes the sorting gap raised in #4860: constant sorting by any column.

Prior to this change sorting only happens once, when the user clicks on the column header. If the data changes it becomes unsorted again, and the column header is then wrong/out of sync. e.g. if you're in the Containers view, sort by Status, and then start a new container, data will revert back to the initial order and the new container will appear where it would have, even though the Status column still says it is sorted.

Now, sorting is also applied _whenever the data changes_. This means that if you sort by Status and start a container it would move to the top, or if you've sorted Age by descending it would move to the bottom. i.e. the sorting is always applied. This also means that any view can set the Table defaultSortColumn to any arbitrary column.

### Screenshot/screencast of this PR

Note changed sort indicators (ascending is 'up'), Containers sort descending the first time you click on it (initialSortDir), and once sorted by Status the started pod moves to the top: 
https://github.com/containers/podman-desktop/assets/19958075/bc3c69ee-150b-44a5-b1eb-d48575a64d47

### What issues does this PR fix or reference?

Fixes #4881.

### How to test this PR?

Use along with the Images or Volumes PR.