### PR TITLE
chore: switch script from commonjs to esmodule

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "test:renderer": "vitest -c packages/renderer/vite.config.js run packages/renderer --passWithNoTests --coverage",
     "test:tools": "vitest run tools --passWithNoTests --coverage",
     "test:watch": "vitest watch",
-    "watch": "node scripts/watch.cjs",
+    "watch": "node scripts/watch.mjs",
     "format:check": "prettier --cache --check \"{extensions,packages,tests,types,tools,website-argos}/**/*.{ts,svelte}\" \"extensions/*/scripts/build.js\" \"website/**/*.{md,js}\" \"website/src/**/*.{css,tsx}\"",
     "format:fix": "prettier --cache --write \"{extensions,packages,tests,types,tools,website-argos}/**/*.{ts,svelte}\" \"extensions/*/scripts/build.js\" \"website/**/*.{md,js}\" \"website/src/**/*.{css,tsx}\"",
     "markdownlint:check": "markdownlint-cli2 \"website/**/*.md\" \"#website/node_modules\"",

--- a/scripts/watch.mjs
+++ b/scripts/watch.mjs
@@ -1,10 +1,13 @@
 #!/usr/bin/env node
 
-const { createServer, build, createLogger } = require('vite');
-const electronPath = require('electron');
-const { spawn } = require('child_process');
-const { generateAsync } = require('dts-for-context-bridge');
-const path = require('path');
+import { createServer, build, createLogger } from 'vite';
+import electronPath from 'electron';
+import { spawn } from 'child_process';
+import { generateAsync } from 'dts-for-context-bridge';
+import { dirname, resolve } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 /** @type 'production' | 'development'' */
 const mode = (process.env.MODE = process.env.MODE || 'development');
@@ -142,7 +145,7 @@ const setupPreloadDockerExtensionPackageWatcher = ({ ws }) =>
  */
 const setupExtensionApiWatcher = name => {
   let spawnProcess;
-  const folderName = path.resolve(name);
+  const folderName = resolve(name);
 
   console.log('dirname is', folderName);
   spawnProcess = spawn('yarn', ['--cwd', folderName, 'watch'], { shell: process.platform === 'win32' });
@@ -159,7 +162,7 @@ const setupExtensionApiWatcher = name => {
 };
 
 const setupBuiltinExtensionApiWatcher = name => {
-  setupExtensionApiWatcher(path.resolve(__dirname, '../extensions/' + name));
+  setupExtensionApiWatcher(resolve(__dirname, '../extensions/' + name));
 }
 
 (async () => {
@@ -167,7 +170,7 @@ const setupBuiltinExtensionApiWatcher = name => {
     const extensions = []
     for(let index=0; index < process.argv.length;index++) {
       if (process.argv[index] === EXTENSION_OPTION && index < process.argv.length - 1) {
-        extensions.push(path.resolve(process.argv[++index]));
+        extensions.push(resolve(process.argv[++index]));
       }
     }
     const viteDevServer = await createServer({


### PR DESCRIPTION
### What does this PR do?
Vite 5 is out and it's now deprecating the commonjs API
https://vitejs.dev/guide/migration.html#deprecate-cjs-node-api

Migrate the script to ESM so we don't have a warning

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast 
explaining what is doing this PR -->

### What issues does this PR fix or reference?

https://github.com/containers/podman-desktop/issues/4924

Migration to vite 5
https://vitejs.dev/blog/announcing-vite5

### How to test this PR?

<!-- Please explain steps to reproduce -->
