### PR TITLE
feat: add switching context button

### DIFF
--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1897,6 +1897,10 @@ export class PluginSystem {
       },
     );
 
+    this.ipcHandle('kubernetes-client:setContext', async (_listener, contextName: string): Promise<void> => {
+      return kubernetesClient.setContext(contextName);
+    });
+
     this.ipcHandle('feedback:send', async (_listener, feedbackProperties: unknown): Promise<void> => {
       return telemetry.sendFeedback(feedbackProperties);
     });

--- a/packages/main/src/plugin/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes-client.ts
@@ -325,6 +325,27 @@ export class KubernetesClient {
     return this.getContexts();
   }
 
+  // setContext takes a context name and sets it as the current context within the kubeconfig
+  async setContext(contextName: string): Promise<void> {
+    const newConfig = new KubeConfig();
+
+    // Load the configuration with all the standard contexts, clusters, users, etc.
+    // but change the currentContext to the provided contextName.
+    newConfig.loadFromOptions({
+      contexts: this.kubeConfig.contexts,
+      clusters: this.kubeConfig.clusters,
+      users: this.kubeConfig.users,
+      currentContext: contextName,
+    });
+
+    // Save the configuration to the kubeconfig file and set the current context to the context name.
+    await this.saveKubeConfig(newConfig);
+
+    // If saving the file succeeds then set the kubeConfig to the newConfig & set the current context name.
+    this.kubeConfig = newConfig;
+    this.currentContextName = contextName;
+  }
+
   async saveKubeConfig(config: KubeConfig) {
     const jsonString = config.exportConfig();
     const yamlString = jsYaml.dump(JSON.parse(jsonString));

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -1425,6 +1425,9 @@ function initExposure(): void {
   contextBridge.exposeInMainWorld('kubernetesDeleteContext', async (contextName: string): Promise<Context[]> => {
     return ipcInvoke('kubernetes-client:deleteContext', contextName);
   });
+  contextBridge.exposeInMainWorld('kubernetesSetContext', async (contextName: string): Promise<void> => {
+    return ipcInvoke('kubernetes-client:setContext', contextName);
+  });
 
   contextBridge.exposeInMainWorld('kubernetesGetClusters', async (): Promise<Cluster[]> => {
     return ipcInvoke('kubernetes-client:getClusters');

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
@@ -4,7 +4,7 @@ import EngineIcon from '../ui/EngineIcon.svelte';
 import EmptyScreen from '../ui/EmptyScreen.svelte';
 import { onMount } from 'svelte';
 import Link from '../ui/Link.svelte';
-import { faTrash } from '@fortawesome/free-solid-svg-icons';
+import { faTrash, faRightToBracket } from '@fortawesome/free-solid-svg-icons';
 import ListItemButtonIcon from '../ui/ListItemButtonIcon.svelte';
 import ErrorMessage from '../ui/ErrorMessage.svelte';
 import { kubernetesContexts } from '../../stores/kubernetes-contexts';
@@ -15,6 +15,17 @@ let currentContextName: string | undefined;
 onMount(async () => {
   currentContextName = await window.kubernetesGetCurrentContextName();
 });
+
+async function handleSetContext(contextName: string) {
+  $kubernetesContexts = clearKubeUIContextErrors($kubernetesContexts);
+  try {
+    await window.kubernetesSetContext(contextName);
+  } catch (e: unknown) {
+    if (e instanceof Error) {
+      $kubernetesContexts = setKubeUIContextError($kubernetesContexts, contextName, e);
+    }
+  }
+}
 
 async function handleDeleteContext(contextName: string) {
   if (currentContextName === contextName) {
@@ -73,6 +84,13 @@ async function handleDeleteContext(contextName: string) {
                 <span class="text-md" aria-label="context-name">{context.name}</span>
               </div>
             </div>
+            <!-- Only show the set context button if it is not the current context -->
+            {#if !context.currentContext}
+              <ListItemButtonIcon
+                title="Set as Current Context"
+                icon="{faRightToBracket}"
+                onClick="{() => handleSetContext(context.name)}"></ListItemButtonIcon>
+            {/if}
             <ListItemButtonIcon
               title="Delete Context"
               icon="{faTrash}"


### PR DESCRIPTION
feat: add switching context button

### What does this PR do?

* Adds the ability to switch contexts / save to file by clicking on a
  button.
* Changes also propagate to the status bar

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast
explaining what is doing this PR -->


https://github.com/containers/podman-desktop/assets/6422176/99303194-dceb-45af-a8d5-94312c505f85



### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop/issues/4920

### How to test this PR?

<!-- Please explain steps to reproduce -->

Go to the Kubernetes page and select another context, you should see
your file change (.kube/config) as well as the context change in the
status bar.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
