### PR TITLE
fix: remove flex class from markdown button rendering

### DIFF
--- a/packages/renderer/src/lib/markdown/Markdown.spec.ts
+++ b/packages/renderer/src/lib/markdown/Markdown.spec.ts
@@ -71,7 +71,7 @@ describe('Custom button', () => {
     const markdownContent = screen.getByRole('region', { name: 'markdown-content' });
     expect(markdownContent).toBeInTheDocument();
     expect(markdownContent).toContainHTML(
-      '<button class="px-4 py-[6px] rounded-[4px] flex text-white text-[13px] whitespace-nowrap bg-purple-600 hover:bg-purple-500 no-underline"',
+      '<button class="px-4 py-[6px] rounded-[4px] text-white text-[13px] whitespace-nowrap bg-purple-600 hover:bg-purple-500 no-underline"',
     );
     expect(markdownContent).toContainHTML('data-command="command"');
     expect(markdownContent).toContainHTML('Name of the button</button>');

--- a/packages/renderer/src/lib/markdown/micromark-button-directive.ts
+++ b/packages/renderer/src/lib/markdown/micromark-button-directive.ts
@@ -43,7 +43,7 @@ export function button(d: any) {
   if (d.attributes && 'command' in d.attributes) {
     // Make this a button if it's a command
     this.tag(
-      '<button class="px-4 py-[6px] rounded-[4px] flex text-white text-[13px] whitespace-nowrap bg-purple-600 hover:bg-purple-500 no-underline" data-command="' +
+      '<button class="px-4 py-[6px] rounded-[4px] text-white text-[13px] whitespace-nowrap bg-purple-600 hover:bg-purple-500 no-underline" data-command="' +
         this.encode(d.attributes.command) +
         '">',
     );


### PR DESCRIPTION
### What does this PR do?

Removes flex class form markdown <button> tag generated to render :button so buttons can be rendered inline

```:button[Sign Up]{command=sandbox.open.login.url href=\"https://developers.redhat.com/developer-sandbox/?sc_cid=7013a000003SUmgAAG\"} :button[Login]{command=sandbox.login}']```

### Screenshot/screencast of this PR

![image](https://github.com/containers/podman-desktop/assets/620330/fe606ff0-054c-430f-a3d4-a0f8a0c1458c)

### What issues does this PR fix or reference?

Fix #4933 

### How to test this PR?

<!-- Please explain steps to reproduce -->
