### PR TITLE
refactor: human readable podman onboarding ids

### DIFF
--- a/extensions/podman/package.json
+++ b/extensions/podman/package.json
@@ -17,11 +17,11 @@
         "title": "Podman: Socket Compatibility Mode"
       },
       {
-        "command": "podman.onboarding.checkPodmanInstalled",
+        "command": "podman.onboarding.checkInstalledCommand",
         "title": "Podman: Check podman installation"
       },
       {
-        "command": "podman.onboarding.checkPodmanRequirements",
+        "command": "podman.onboarding.checkRequirementsCommand",
         "title": "Podman: Check system requirements to install podman"
       },
       {
@@ -162,29 +162,29 @@
       "title": "Podman Setup",
       "steps": [
         {
-          "id": "checkPodmanInstalled",
+          "id": "checkInstalledCommand",
           "title": "Checking for Podman installation",
-          "command": "podman.onboarding.checkPodmanInstalled",
+          "command": "podman.onboarding.checkInstalledCommand",
           "completionEvents": [
-            "onCommand:podman.onboarding.checkPodmanInstalled"
+            "onCommand:podman.onboarding.checkInstalledCommand"
           ]
         },
         {
-          "id": "startPodmanInstallation",
+          "id": "welcomeInstallationView",
           "title": "We could not find Podman. Let's install it!",
           "when": "onboardingContext:podmanIsNotInstalled"
         },
         {
-          "id": "checkPodmanRequirements",
+          "id": "checkRequirementsCommand",
           "title": "Checking for system requirements to install Podman",
           "when": "onboardingContext:podmanIsNotInstalled",
-          "command": "podman.onboarding.checkPodmanRequirements",
+          "command": "podman.onboarding.checkRequirementsCommand",
           "completionEvents": [
-            "onCommand:podman.onboarding.checkPodmanRequirements"
+            "onCommand:podman.onboarding.checkRequirementsCommand"
           ]
         },
         {
-          "id": "missingRequirementView",
+          "id": "missingRequirementsView",
           "title": "Some system requirements are missing",
           "when": "onboardingContext:requirementsStatus == failed && onboardingContext:podmanIsNotInstalled",
           "completionEvents": [
@@ -203,13 +203,13 @@
             ],
             [
               {
-                "value": ":button[Check requirements again]{command=podman.onboarding.checkPodmanRequirements}"
+                "value": ":button[Check requirements again]{command=podman.onboarding.checkRequirementsCommand}"
               }
             ]
           ]
         },
         {
-          "id": "installPodmanView",
+          "id": "installOnLinuxInstructionsView",
           "title": "Installing Podman",
           "when": "onboardingContext:podmanIsNotInstalled && isLinux",
           "completionEvents": [
@@ -224,7 +224,7 @@
           ]
         },
         {
-          "id": "installPodmanView",
+          "id": "autoInstallCommand",
           "title": "Installing Podman",
           "description": "Once installed, we will enable and configure the extension",
           "when": "onboardingContext:podmanIsNotInstalled && !isLinux",
@@ -234,14 +234,14 @@
           ]
         },
         {
-          "id": "podmanFailedInstallation",
+          "id": "installationFailure",
           "title": "Failed installing Podman",
           "when": "onboardingContext:podmanIsNotInstalled",
           "state": "failed"
         },
         {
-          "id": "podmanInstalled",
-          "title": "${onboardingContext:podmanInstalledTitle}",
+          "id": "installationSuccessView",
+          "title": "${onboardingContext:installationSuccessViewTitle}",
           "when": "!onboardingContext:podmanIsNotInstalled",
           "content": [
             [
@@ -252,12 +252,12 @@
           ]
         },
         {
-          "id": "preCreatePodmanMachine",
+          "id": "welcomeCreatePodmanMachineView",
           "title": "We could not find any Podman machine. Let's create one!",
           "when": "!onboardingContext:podmanMachineExists && !isLinux"
         },
         {
-          "id": "createPodmanMachine",
+          "id": "createPodmanMachineCommand",
           "title": "Create a Podman machine",
           "when": "!onboardingContext:podmanMachineExists && !isLinux",
           "completionEvents": [
@@ -266,7 +266,7 @@
           "component": "createContainerProviderConnection"
         },
         {
-          "id": "podmanSuccessfullySetup",
+          "id": "onboardingSuccess",
           "title": "Podman successfully setup",
           "when": "!onboardingContext:podmanIsNotInstalled",
           "state": "completed"

--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -1044,17 +1044,17 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
   });
 
   const onboardingCheckInstallationCommand = extensionApi.commands.registerCommand(
-    'podman.onboarding.checkPodmanInstalled',
+    'podman.onboarding.checkInstalledCommand',
     async () => {
       const installation = await getPodmanInstallation();
       const installed = installation ? true : false;
       extensionApi.context.setValue('podmanIsNotInstalled', !installed, 'onboarding');
       if (installed) {
-        extensionApi.context.setValue('podmanInstalledTitle', 'Podman already installed', 'onboarding');
+        extensionApi.context.setValue('installationSuccessViewTitle', 'Podman already installed', 'onboarding');
       } else {
-        extensionApi.context.setValue('podmanInstalledTitle', 'Podman successfully installed', 'onboarding');
+        extensionApi.context.setValue('installationSuccessViewTitle', 'Podman successfully installed', 'onboarding');
       }
-      telemetryLogger.logUsage('podman.onboarding.checkPodmanInstalled', {
+      telemetryLogger.logUsage('podman.onboarding.checkInstalledCommand', {
         status: installed,
         version: installation?.version || '',
       });
@@ -1062,7 +1062,7 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
   );
 
   const onboardingCheckReqsCommand = extensionApi.commands.registerCommand(
-    'podman.onboarding.checkPodmanRequirements',
+    'podman.onboarding.checkRequirementsCommand',
     async () => {
       const checks = podmanInstall.getInstallChecks() || [];
       const result = [];
@@ -1114,7 +1114,7 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
 
       extensionApi.context.setValue('requirementsStatus', successful ? 'ok' : 'failed', 'onboarding');
       extensionApi.context.setValue('warningsMarkdown', warnings, 'onboarding');
-      telemetryLogger.logUsage('podman.onboarding.checkPodmanRequirements', telemetryRecords);
+      telemetryLogger.logUsage('podman.onboarding.checkRequirementsCommand', telemetryRecords);
     },
   );
 

--- a/extensions/podman/src/podman-install.ts
+++ b/extensions/podman/src/podman-install.ts
@@ -489,7 +489,7 @@ class WSL2Check extends BaseCheck {
       const installSucceeded = await this.installWSL();
       if (installSucceeded) {
         // if action succeeded, do a re-check of all podman requirements so user can be moved forward if all missing pieces have been installed
-        await extensionApi.commands.executeCommand('podman.onboarding.checkPodmanRequirements');
+        await extensionApi.commands.executeCommand('podman.onboarding.checkRequirementsCommand');
       }
     });
   }


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

This PR changes the ids on the Podman Onboarding steps (and the ids of their associated commands and context values), so they are easily readable in the telemetry tool when they are sent to the telemetry.

- steps displaying information are suffixed with `View`
- steps executing a command are suffixed with `Command`
- steps with a state='failed' are suffixed with `Failure`
- steps with a state='completed' are suffixed with `Success`


### What issues does this PR fix or reference?

Fixes partially #4911 

### How to test this PR?

Play the onboarding for Podman extension.
