### PR TITLE
chore: remove patternfly dependency

### DIFF
--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -14,7 +14,6 @@
     "@fortawesome/free-brands-svg-icons": "^6.4.2",
     "@fortawesome/free-solid-svg-icons": "^6.4.2",
     "@fortawesome/free-regular-svg-icons": "^6.4.2",
-    "@patternfly/patternfly": "^4.224.5",
     "@sveltejs/vite-plugin-svelte": "^3.0.0",
     "@testing-library/dom": "^9.3.3",
     "@testing-library/jest-dom": "^6.1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2906,11 +2906,6 @@
     "@octokit/webhooks-types" "7.1.0"
     aggregate-error "^3.1.0"
 
-"@patternfly/patternfly@^4.224.5":
-  version "4.224.5"
-  resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-4.224.5.tgz#ad704848ce7754fcd6ffc5dc349f17beb84168ce"
-  integrity sha512-io0huj+LCP5FgDZJDaLv1snxktTYs8iCFz/W1VDRneYoebNHLmGfQdF7Yn8bS6PF7qmN6oJKEBlq3AjmmE8vdA==
-
 "@phenomnomnominal/tsquery@^5.0.0":
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/@phenomnomnominal/tsquery/-/tsquery-5.0.1.tgz#a2a5abc89f92c01562a32806655817516653a388"


### PR DESCRIPTION
### What does this PR do?
remove the patternfly library

usage was removed but somehow the dependency was still there

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

https://github.com/containers/podman-desktop/issues/1617

### How to test this PR?

check that everything is still working
(as we're not importing the library anymore it should be easy)