### PR TITLE
chore: replace zip-local by adm-zip 

### DIFF
--- a/extensions/compose/package.json
+++ b/extensions/compose/package.json
@@ -160,11 +160,10 @@
     "shell-path": "^3.0.0"
   },
   "devDependencies": {
-    "7zip-min": "^1.4.3",
+    "adm-zip": "^0.5.10",
     "@podman-desktop/api": "^0.0.1",
     "mkdirp": "^3.0.1",
     "vite": "^4.5.0",
-    "vitest": "^0.34.6",
-    "zip-local": "^0.3.5"
+    "vitest": "^0.34.6"
   }
 }

--- a/extensions/compose/scripts/build.js
+++ b/extensions/compose/scripts/build.js
@@ -17,7 +17,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-const zipper = require('zip-local');
+const AdmZip = require('adm-zip');
 const path = require('path');
 const packageJson = require('../package.json');
 const fs = require('fs');
@@ -35,9 +35,12 @@ if (fs.existsSync(builtinDirectory)) {
   fs.rmSync(builtinDirectory, { recursive: true, force: true });
 }
 
-zipper.sync.zip(path.resolve(__dirname, '../')).compress().save(destFile);
+const zip = new AdmZip();
+zip.addLocalFolder(path.resolve(__dirname, '../'));
+zip.writeZip(destFile);
 
 // create unzipped built-in
 mkdirp(unzippedDirectory).then(() => {
-  zipper.sync.unzip(destFile).save(unzippedDirectory);
+  const unzip = new AdmZip(destFile);
+  unzip.extractAllTo(unzippedDirectory);
 });

--- a/extensions/docker/package.json
+++ b/extensions/docker/package.json
@@ -20,8 +20,7 @@
     "@podman-desktop/api": "^0.0.1"
   },
   "devDependencies": {
-    "7zip-min": "^1.4.4",
-    "mkdirp": "^3.0.1",
-    "zip-local": "^0.3.5"
+    "adm-zip": "^0.5.10",
+    "mkdirp": "^3.0.1"
   }
 }

--- a/extensions/docker/scripts/build.js
+++ b/extensions/docker/scripts/build.js
@@ -17,7 +17,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-const zipper = require('zip-local');
+const AdmZip = require('adm-zip');
 const path = require('path');
 const packageJson = require('../package.json');
 const fs = require('fs');
@@ -35,9 +35,12 @@ if (fs.existsSync(builtinDirectory)) {
   fs.rmSync(builtinDirectory, { recursive: true, force: true });
 }
 
-zipper.sync.zip(path.resolve(__dirname, '../')).compress().save(destFile);
+const zip = new AdmZip();
+zip.addLocalFolder(path.resolve(__dirname, '../'));
+zip.writeZip(destFile);
 
 // create unzipped built-in
 mkdirp(unzippedDirectory).then(() => {
-  zipper.sync.unzip(destFile).save(unzippedDirectory);
+  const unzip = new AdmZip(destFile);
+  unzip.extractAllTo(unzippedDirectory);
 });

--- a/extensions/kind/package.json
+++ b/extensions/kind/package.json
@@ -108,11 +108,10 @@
     "yaml": "^2.3.4"
   },
   "devDependencies": {
-    "7zip-min": "^1.4.4",
+    "adm-zip": "^0.5.10",
     "mkdirp": "^3.0.1",
     "tmp-promise": "^3.0.3",
     "vite": "^4.5.0",
-    "vitest": "^0.34.6",
-    "zip-local": "^0.3.5"
+    "vitest": "^0.34.6"
   }
 }

--- a/extensions/kind/scripts/build.js
+++ b/extensions/kind/scripts/build.js
@@ -17,7 +17,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-const zipper = require('zip-local');
+const AdmZip = require('adm-zip');
 const path = require('path');
 const packageJson = require('../package.json');
 const fs = require('fs');
@@ -35,8 +35,12 @@ if (fs.existsSync(builtinDirectory)) {
   fs.rmSync(builtinDirectory, { recursive: true, force: true });
 }
 
-zipper.sync.zip(path.resolve(__dirname, '../')).compress().save(destFile);
+const zip = new AdmZip();
+zip.addLocalFolder(path.resolve(__dirname, '../'));
+zip.writeZip(destFile);
 
+// create unzipped built-in
 mkdirp(unzippedDirectory).then(() => {
-  zipper.sync.unzip(destFile).save(unzippedDirectory);
+  const unzip = new AdmZip(destFile);
+  unzip.extractAllTo(unzippedDirectory);
 });

--- a/extensions/kube-context/package.json
+++ b/extensions/kube-context/package.json
@@ -42,10 +42,9 @@
     "js-yaml": "^4.1.0"
   },
   "devDependencies": {
-    "7zip-min": "^1.4.4",
+    "adm-zip": "^0.5.10",
     "@types/js-yaml": "^4.0.9",
     "mkdirp": "^3.0.1",
-    "vitest": "^0.34.6",
-    "zip-local": "^0.3.5"
+    "vitest": "^0.34.6"
   }
 }

--- a/extensions/kube-context/scripts/build.js
+++ b/extensions/kube-context/scripts/build.js
@@ -17,7 +17,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-const zipper = require('zip-local');
+const AdmZip = require('adm-zip');
 const path = require('path');
 const packageJson = require('../package.json');
 const fs = require('fs');
@@ -35,9 +35,12 @@ if (fs.existsSync(builtinDirectory)) {
   fs.rmSync(builtinDirectory, { recursive: true, force: true });
 }
 
-zipper.sync.zip(path.resolve(__dirname, '../')).compress().save(destFile);
+const zip = new AdmZip();
+zip.addLocalFolder(path.resolve(__dirname, '../'));
+zip.writeZip(destFile);
 
 // create unzipped built-in
 mkdirp(unzippedDirectory).then(() => {
-  zipper.sync.unzip(destFile).save(unzippedDirectory);
+  const unzip = new AdmZip(destFile);
+  unzip.extractAllTo(unzippedDirectory);
 });

--- a/extensions/kubectl-cli/package.json
+++ b/extensions/kubectl-cli/package.json
@@ -21,10 +21,10 @@
     "@podman-desktop/api": "^0.0.1"
   },
   "devDependencies": {
+    "adm-zip": "^0.5.10",
     "byline": "^5.0.0",
     "copyfiles": "^2.4.1",
     "mkdirp": "^2.1.3",
-    "vitest": "^0.34.6",
-    "zip-local": "^0.3.5"
+    "vitest": "^0.34.6"
   }
 }

--- a/extensions/kubectl-cli/scripts/build.js
+++ b/extensions/kubectl-cli/scripts/build.js
@@ -17,7 +17,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-const zipper = require('zip-local');
+const AdmZip = require('adm-zip');
 const path = require('path');
 const package = require('../package.json');
 const { mkdirp } = require('mkdirp');
@@ -58,6 +58,8 @@ byline(fileStream)
         throw new Error('Error copying files', error);
       }
       console.log(`Zipping files to ${destFile}`);
-      zipper.sync.zip(zipDirectory).compress().save(destFile);
+      const zip = new AdmZip();
+      zip.addLocalFolder(zipDirectory);
+      zip.writeZip(destFile);
     });
   });

--- a/extensions/lima/package.json
+++ b/extensions/lima/package.json
@@ -42,8 +42,7 @@
     "@podman-desktop/api": "^0.0.1"
   },
   "devDependencies": {
-    "7zip-min": "^1.4.4",
-    "mkdirp": "^3.0.1",
-    "zip-local": "^0.3.5"
+    "adm-zip": "^0.5.10",
+    "mkdirp": "^3.0.1"
   }
 }

--- a/extensions/lima/scripts/build.js
+++ b/extensions/lima/scripts/build.js
@@ -17,7 +17,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-const zipper = require('zip-local');
+const AdmZip = require('adm-zip');
 const path = require('path');
 const packageJson = require('../package.json');
 const fs = require('fs');
@@ -35,9 +35,12 @@ if (fs.existsSync(builtinDirectory)) {
   fs.rmSync(builtinDirectory, { recursive: true, force: true });
 }
 
-zipper.sync.zip(path.resolve(__dirname, '../')).compress().save(destFile);
+const zip = new AdmZip();
+zip.addLocalFolder(path.resolve(__dirname, '../'));
+zip.writeZip(destFile);
 
 // create unzipped built-in
 mkdirp(unzippedDirectory).then(() => {
-  zipper.sync.unzip(destFile).save(unzippedDirectory);
+  const unzip = new AdmZip(destFile);
+  unzip.extractAllTo(unzippedDirectory);
 });

--- a/extensions/podman/package.json
+++ b/extensions/podman/package.json
@@ -287,13 +287,12 @@
     "compare-versions": "^6.1.0"
   },
   "devDependencies": {
-    "7zip-min": "^1.4.4",
+    "adm-zip": "^0.5.10",
     "hasha": "^5.2.2",
     "mkdirp": "^3.0.1",
     "nock": "^13.3.8",
     "octokit": "^3.1.2",
     "ts-node": "^10.9.1",
-    "vitest": "^0.34.6",
-    "zip-local": "^0.3.5"
+    "vitest": "^0.34.6"
   }
 }

--- a/extensions/podman/scripts/build.js
+++ b/extensions/podman/scripts/build.js
@@ -17,7 +17,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-const zipper = require('zip-local');
+const AdmZip = require('adm-zip');
 const path = require('path');
 const packageJson = require('../package.json');
 const fs = require('fs');
@@ -35,12 +35,14 @@ if (fs.existsSync(builtinDirectory)) {
   fs.rmSync(builtinDirectory, { recursive: true, force: true });
 }
 
-const zip = zipper.sync.zip(path.resolve(__dirname, '../'));
+const zip = new AdmZip();
+zip.addLocalFolder(path.resolve(__dirname, '../'));
 // delete assets from cdix file
-zip.lowLevel().remove('assets');
-zip.compress().save(destFile);
+zip.deleteFile('assets/');
+zip.writeZip(destFile);
 
 // create unzipped built-in
 mkdirp(unzippedDirectory).then(() => {
-  zipper.sync.unzip(destFile).save(unzippedDirectory);
+  const unzip = new AdmZip(destFile);
+  unzip.extractAllTo(unzippedDirectory);
 });

--- a/extensions/registries/package.json
+++ b/extensions/registries/package.json
@@ -20,9 +20,8 @@
     "@podman-desktop/api": "^0.0.1"
   },
   "devDependencies": {
-    "7zip-min": "^1.4.4",
+    "adm-zip": "^0.5.10",
     "mkdirp": "^3.0.1",
-    "rollup-plugin-copy": "^3.5.0",
-    "zip-local": "^0.3.5"
+    "rollup-plugin-copy": "^3.5.0"
   }
 }

--- a/extensions/registries/scripts/build.js
+++ b/extensions/registries/scripts/build.js
@@ -17,7 +17,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-const zipper = require('zip-local');
+const AdmZip = require('adm-zip');
 const path = require('path');
 const packageJson = require('../package.json');
 const fs = require('fs');
@@ -35,9 +35,12 @@ if (fs.existsSync(builtinDirectory)) {
   fs.rmSync(builtinDirectory, { recursive: true, force: true });
 }
 
-zipper.sync.zip(path.resolve(__dirname, '../')).compress().save(destFile);
+const zip = new AdmZip();
+zip.addLocalFolder(path.resolve(__dirname, '../'));
+zip.writeZip(destFile);
 
 // create unzipped built-in
 mkdirp(unzippedDirectory).then(() => {
-  zipper.sync.unzip(destFile).save(unzippedDirectory);
+  const unzip = new AdmZip(destFile);
+  unzip.extractAllTo(unzippedDirectory);
 });

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "@rollup/plugin-json": "^6.0.1",
     "@rollup/plugin-node-resolve": "^15.2.3",
     "@rollup/plugin-typescript": "^11.1.5",
+    "@types/adm-zip": "^0.5.5",
     "@types/analytics-node": "^3.1.14",
     "@types/dockerode": "^3.3.23",
     "@types/getos": "^3.0.4",
@@ -154,6 +155,7 @@
     "@kubernetes/client-node": "^0.20.0",
     "@segment/analytics-node": "^1.1.3",
     "@types/stream-json": "^1.7.7",
+    "adm-zip": "^0.5.10",
     "check-disk-space": "^3.4.0",
     "chokidar": "^3.5.3",
     "compare-versions": "^6.1.0",
@@ -173,8 +175,7 @@
     "tar-fs": "^3.0.4",
     "undici": "^5.27.2",
     "win-ca": "^3.5.1",
-    "yaml": "^2.3.4",
-    "zip-local": "^0.3.5"
+    "yaml": "^2.3.4"
   },
   "resolutions": {
     "trim": "0.0.3",

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -21,7 +21,8 @@ import * as path from 'path';
 import * as fs from 'fs';
 import type { CommandRegistry } from './command-registry.js';
 import type { ExtensionError, ExtensionInfo, ExtensionUpdateInfo } from './api/extension-info.js';
-import * as zipper from 'zip-local';
+import AdmZip from 'adm-zip';
+
 import type { TrayMenuRegistry } from './tray-menu-registry.js';
 import { Disposable } from './types/disposable.js';
 import type { ProviderRegistry } from './provider-registry.js';
@@ -203,7 +204,8 @@ export class ExtensionLoader {
     const unpackedDirectory = path.resolve(dirname, `../unpacked/${filename}`);
     fs.mkdirSync(unpackedDirectory, { recursive: true });
     // extract to an existing directory
-    zipper.sync.unzip(filePath).save(unpackedDirectory);
+    const admZip = new AdmZip(filePath);
+    admZip.extractAllTo(unpackedDirectory, true);
 
     const extension = await this.analyzeExtension(unpackedDirectory, true);
     if (!extension.error) {

--- a/types/additional.d.ts
+++ b/types/additional.d.ts
@@ -1,5 +1,4 @@
 declare module 'win-ca/api';
-declare module 'zip-local';
 declare module 'micromark-extension-directive';
 declare module 'date.js';
 declare module 'humanize-duration';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3350,6 +3350,13 @@
   dependencies:
     "@types/estree" "*"
 
+"@types/adm-zip@^0.5.5":
+  version "0.5.5"
+  resolved "https://registry.yarnpkg.com/@types/adm-zip/-/adm-zip-0.5.5.tgz#4588042726aa5f351d7ea88232e4a952f60e7c1a"
+  integrity sha512-YCGstVMjc4LTY5uK9/obvxBya93axZOVOyf2GSUulADzmLhYE45u2nAssCs/fWBs1Ifq5Vat75JTPwd5XZoPJw==
+  dependencies:
+    "@types/node" "*"
+
 "@types/analytics-node@^3.1.14":
   version "3.1.14"
   resolved "https://registry.yarnpkg.com/@types/analytics-node/-/analytics-node-3.1.14.tgz#aa4be9cddbb2b7901e67418fcaf155a599c1ffea"
@@ -4396,6 +4403,11 @@ address@^1.0.1, address@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/address/-/address-1.1.2.tgz#bf1116c9c758c51b7a933d296b72c221ed9428b6"
   integrity sha512-aT6camzM4xEA54YVJYSqxz1kv4IHnQZRtThJJHhUMRExaU5spC7jX5ugSwTaTgJliIgs4VhZOk7htClvQ/LmRA==
+
+adm-zip@^0.5.10:
+  version "0.5.10"
+  resolved "https://registry.yarnpkg.com/adm-zip/-/adm-zip-0.5.10.tgz#4a51d5ab544b1f5ce51e1b9043139b639afff45b"
+  integrity sha512-x0HvcHqVJNTPk/Bw8JbLWlWoo6Wwnsug0fnYYro1HBrjxZ3G7/AZk7Ahv8JwDe1uIcz8eBqvu86FuF1POiG7vQ==
 
 agent-base@6:
   version "6.0.2"


### PR DESCRIPTION
### What does this PR do?
replace zip-local broken with vite5 with another more popular library

2 commits:
one for main package
another one for the extensions

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast 
explaining what is doing this PR -->

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/4938

### How to test this PR?

build the cdix file of DevSandbox extension for example, copy it to podman desktop folder:

```bash
cp redhat-sandbox.cdix ~/.local/share/containers/podman-desktop/plugins-scanning
```

then see if sandbox extension has been unpacked in `~/.local/share/containers/podman-desktop/unpacked/` and is loaded

and for extensions:
check that in production mode or in development mode you're able to use/see the extensions