### PR TITLE
refactor: human readable compose onboarding ids

### DIFF
--- a/extensions/compose/package.json
+++ b/extensions/compose/package.json
@@ -21,11 +21,11 @@
         "title": "Compose: Checks..."
       },
       {
-        "command": "compose.onboarding.checkComposeDownloaded",
+        "command": "compose.onboarding.checkDownloadedCommand",
         "title": "Compose: Check Compose Downloaded"
       },
       {
-        "command": "compose.onboarding.downloadCompose",
+        "command": "compose.onboarding.downloadCommand",
         "title": "Compose: Download Compose"
       }
     ],
@@ -34,16 +34,16 @@
       "enablement": "!compose.isComposeInstalledSystemWide",
       "steps": [
         {
-          "id": "checkComposeDownloaded",
+          "id": "checkDownloadedCommand",
           "label": "Check Compose",
           "title": "Checking for Compose installation",
-          "command": "compose.onboarding.checkComposeDownloaded",
+          "command": "compose.onboarding.checkDownloadedCommand",
           "completionEvents": [
-            "onCommand:compose.onboarding.checkComposeDownloaded"
+            "onCommand:compose.onboarding.checkDownloadedCommand"
           ]
         },
         {
-          "id": "startComposeDownload",
+          "id": "welcomeDownloadView",
           "label": "Compose Download",
           "title": "Compose Download",
           "when": "onboardingContext:composeIsNotDownloaded == true",
@@ -68,23 +68,23 @@
           ]
         },
         {
-          "id": "downloadComposeView",
+          "id": "downloadCommand",
           "title": "Downloading Compose ${onboardingContext:composeDownloadVersion}",
           "description": "Downloading the binary.\n\nOnce downloaded, the next step will install Compose system-wide.",
           "when": "onboardingContext:composeIsNotDownloaded == true",
-          "command": "compose.onboarding.downloadCompose",
+          "command": "compose.onboarding.downloadCommand",
           "completionEvents": [
-            "onCommand:compose.onboarding.downloadCompose"
+            "onCommand:compose.onboarding.downloadCommand"
           ]
         },
         {
-          "id": "composeFailedDownload",
+          "id": "downloadFailure",
           "title": "Failed Downloading Compose",
           "when": "onboardingContext:composeIsNotDownloaded == true",
           "state": "failed"
         },
         {
-          "id": "composeDownloaded",
+          "id": "downloadSuccessfulView",
           "title": "Compose Successfully Downloaded",
           "when": "onboardingContext:composeIsNotDownloaded == false",
           "content": [
@@ -96,23 +96,23 @@
           ]
         },
         {
-          "id": "installComposeSystemWide",
+          "id": "installSystemWideCommand",
           "title": "Install Compose",
           "description": "Installing the binary system-wide.\n\n You may be prompted for elevated system privileges.",
           "when": "compose.isComposeInstalledSystemWide == false",
-          "command": "compose.onboarding.installSystemWide",
+          "command": "compose.onboarding.installSystemWideCommand",
           "completionEvents": [
-            "onCommand:compose.onboarding.installSystemWide"
+            "onCommand:compose.onboarding.installSystemWideCommand"
           ]
         },
         {
-          "id": "composeFailedInstalledSystemWide",
+          "id": "installSystemWideFailure",
           "title": "Failed Installing Compose",
           "when": "compose.isComposeInstalledSystemWide == false",
           "state": "failed"
         },
         {
-          "id": "composeInstalledSystemWide",
+          "id": "installSystemWideSuccess",
           "title": "Compose Successfully Installed",
           "when": "compose.isComposeInstalledSystemWide == true",
           "state": "completed",

--- a/extensions/compose/src/extension.ts
+++ b/extensions/compose/src/extension.ts
@@ -61,7 +61,7 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
 
   // ONBOARDING: Command to check compose is downloaded
   const onboardingCheckDownloadCommand = extensionApi.commands.registerCommand(
-    'compose.onboarding.checkComposeDownloaded',
+    'compose.onboarding.checkDownloadedCommand',
     async () => {
       // Check that docker-compose binary has been downloaded to the storage folder.
       // instead of checking for `docker-compose` on the command line, the most reliable way is to see
@@ -91,7 +91,7 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
       }
 
       // Log if it's downloaded and what version is being selected for download (can be either latest, or chosen by user)
-      telemetryLogger.logUsage('compose.onboarding.checkComposeDownloaded', {
+      telemetryLogger.logUsage('compose.onboarding.checkDownloadedCommand', {
         downloaded: isDownloaded === '' ? false : true,
         version: composeVersionMetadata?.tag,
       });
@@ -101,7 +101,7 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
   // ONBOARDING; Command to download the compose binary. We will get the value that the user has "picked"
   // from the context value. This is because we have the option to either "select a version" or "download the latest"
   const onboardingDownloadComposeCommand = extensionApi.commands.registerCommand(
-    'compose.onboarding.downloadCompose',
+    'compose.onboarding.downloadCommand',
     async () => {
       // If the version is undefined (checks weren't run, or the user didn't select a version)
       // we will just download the latest version
@@ -120,7 +120,7 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
       } finally {
         // Make sure we log the telemetry even if we encounter an error
         // If we have downloaded the binary, we can log it as being succcessfully downloaded
-        telemetryLogger.logUsage('compose.onboarding.downloadCompose', {
+        telemetryLogger.logUsage('compose.onboarding.downloadCommand', {
           successful: downloaded,
           version: composeVersionMetadata?.tag,
         });
@@ -157,7 +157,7 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
 
   // ONBOARDING: Install compose system wide step
   const onboardingInstallSystemWideCommand = extensionApi.commands.registerCommand(
-    'compose.onboarding.installSystemWide',
+    'compose.onboarding.installSystemWideCommand',
     async () => {
       // This is TEMPORARY until we re-add the "Installing compose system wide" toggle again
       // We will just call the handler function directly
@@ -166,7 +166,7 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
         await handler.installComposeBinary(detect, extensionContext);
         installed = true;
       } finally {
-        telemetryLogger.logUsage('compose.onboarding.installSystemWide', {
+        telemetryLogger.logUsage('compose.onboarding.installSystemWideCommand', {
           successful: installed,
         });
       }


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

This PR changes the ids on the Compose Onboarding steps (and the ids of their associated commands), so they are easily readable in the telemetry tool when they are sent to the telemetry.

### What issues does this PR fix or reference?

Partially #4911

### How to test this PR?

Play the onboarding for Compose extension.