### PR TITLE
nit: table column overlapping and aria roles

### DIFF
--- a/packages/renderer/src/lib/table/Table.spec.ts
+++ b/packages/renderer/src/lib/table/Table.spec.ts
@@ -18,7 +18,7 @@
 
 import '@testing-library/jest-dom/vitest';
 import { test, expect } from 'vitest';
-import { fireEvent, render, screen } from '@testing-library/svelte';
+import { fireEvent, render, screen, within } from '@testing-library/svelte';
 
 import TestTable from './TestTable.svelte';
 
@@ -49,13 +49,13 @@ test('Expect column headers with sort indicators', async () => {
 
   const headers = await screen.findAllByRole('columnheader');
   expect(headers).toBeDefined();
-  expect(headers.length).toBe(4);
-  expect(headers[1].textContent).toContain('Id');
-  expect(headers[1].innerHTML).toContain('fa-sort');
-  expect(headers[2].textContent).toContain('Name');
+  expect(headers.length).toBe(5);
+  expect(headers[2].textContent).toContain('Id');
   expect(headers[2].innerHTML).toContain('fa-sort');
-  expect(headers[3].textContent).toContain('Age');
+  expect(headers[3].textContent).toContain('Name');
   expect(headers[3].innerHTML).toContain('fa-sort');
+  expect(headers[4].textContent).toContain('Age');
+  expect(headers[4].innerHTML).toContain('fa-sort');
 });
 
 test('Expect default sort indicator', async () => {
@@ -63,9 +63,9 @@ test('Expect default sort indicator', async () => {
 
   const headers = await screen.findAllByRole('columnheader');
   expect(headers).toBeDefined();
-  expect(headers.length).toBe(4);
-  expect(headers[1].textContent).toContain('Id');
-  expect(headers[1].innerHTML).toContain('fa-sort-down');
+  expect(headers.length).toBe(5);
+  expect(headers[2].textContent).toContain('Id');
+  expect(headers[2].innerHTML).toContain('fa-sort-down');
 });
 
 test('Expect no default sort indicator on other columns', async () => {
@@ -73,11 +73,11 @@ test('Expect no default sort indicator on other columns', async () => {
 
   const headers = await screen.findAllByRole('columnheader');
   expect(headers).toBeDefined();
-  expect(headers.length).toBe(4);
-  expect(headers[2].innerHTML).not.toContain('fa-sort-up');
-  expect(headers[2].innerHTML).not.toContain('fa-sort-down');
+  expect(headers.length).toBe(5);
   expect(headers[3].innerHTML).not.toContain('fa-sort-up');
   expect(headers[3].innerHTML).not.toContain('fa-sort-down');
+  expect(headers[4].innerHTML).not.toContain('fa-sort-up');
+  expect(headers[4].innerHTML).not.toContain('fa-sort-down');
 });
 
 test('Expect sorting by name works', async () => {
@@ -120,4 +120,29 @@ test('Expect sorting by age works', async () => {
   expect(rows[1].textContent).toContain('Henry');
   expect(rows[2].textContent).toContain('Charlie');
   expect(rows[3].textContent).toContain('John');
+});
+
+test('Expect correct aria roles', async () => {
+  render(TestTable, {});
+
+  // table data is 3 objects with 3 properties, so
+  // there should be 5 column headers (expander, checkbox, 3 columns)
+  const headers = await screen.findAllByRole('columnheader');
+  expect(headers).toBeDefined();
+  expect(headers.length).toBe(5);
+  expect(headers[2].textContent).toContain('Id');
+  expect(headers[3].textContent).toContain('Name');
+  expect(headers[4].textContent).toContain('Age');
+
+  // and 4 rows (first is header)
+  const rows = await screen.findAllByRole('row');
+  expect(rows).toBeDefined();
+  expect(rows.length).toBe(4);
+
+  // and each non-header row should have 5 cells (expander, checkbox, 3 cells)
+  for (let i = 1; i < 4; i++) {
+    const cells = await within(rows[i]).findAllByRole('cell');
+    expect(cells).toBeDefined();
+    expect(cells.length).toBe(5);
+  }
 });

--- a/packages/renderer/src/lib/table/Table.svelte
+++ b/packages/renderer/src/lib/table/Table.svelte
@@ -105,7 +105,7 @@ function setGridColumns() {
   <div
     class="grid grid-table gap-x-0.5 mx-5 h-7 sticky top-0 bg-charcoal-700 text-xs text-gray-600 font-bold uppercase z-[2]"
     role="row">
-    <div class="whitespace-nowrap justify-self-start"></div>
+    <div class="whitespace-nowrap justify-self-start" role="columnheader"></div>
     {#if row.info.selectable}
       <div class="whitespace-nowrap place-self-center" role="columnheader">
         <Checkbox

--- a/packages/renderer/src/lib/table/Table.svelte
+++ b/packages/renderer/src/lib/table/Table.svelte
@@ -143,9 +143,9 @@ function setGridColumns() {
       class="grid grid-table gap-x-0.5 mx-5 h-12 bg-charcoal-800 hover:bg-zinc-700 rounded-lg mb-2"
       animate:flip="{{ duration: 300 }}"
       role="row">
-      <div class="whitespace-nowrap justify-self-start"></div>
+      <div class="whitespace-nowrap justify-self-start" role="cell"></div>
       {#if row.info.selectable}
-        <div class="whitespace-nowrap place-self-center">
+        <div class="whitespace-nowrap place-self-center" role="cell">
           <Checkbox
             title="Toggle {kind}"
             bind:checked="{object.selected}"
@@ -159,7 +159,7 @@ function setGridColumns() {
             ? 'justify-self-end'
             : column.info.align === 'center'
               ? 'justify-self-center'
-              : 'justify-self-start'} self-center overflow-hidden"
+              : 'justify-self-start'} self-center overflow-hidden max-w-full"
           role="cell">
           {#if column.info.renderer}
             <svelte:component this="{column.info.renderer}" object="{object}" />


### PR DESCRIPTION
### What does this PR do?

These changes are already proposed in PRs #4844 and #4841 respectively, but since those PRs are taking a while in review and these changes are common and required for other PRs I'm breaking them out here:
- Add missing aria roles to the first two cells in the column. (Not only is this correct, but some e2e tests are finding columns by counting aria cells).
- Add max-w-full to each cell, so that the overflow-hidden applies correctly and cells that are too narrow are cropped instead of overlapping.

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

Issues raised during reviews of the mentioned PRs.

### How to test this PR?

See issues in the PRs. e.g. to test overflow try #4841 with a long volume name and narrow columns, with or without this change.