### PR TITLE
chore: watch all extensions from extension folder

### DIFF
--- a/scripts/watch.mjs
+++ b/scripts/watch.mjs
@@ -182,14 +182,10 @@ const setupExtensionApiWatcher = name => {
     const extensionsFolder = resolve(__dirname, '../extensions/');
 
     // loop on all subfolders from the extensions folder
-    const extensionsFolders = readdirSync(extensionsFolder, { withFileTypes: true })
+    // loop on all subfolders from the extensions folder
+    readdirSync(extensionsFolder, { withFileTypes: true })
       .filter(dirent => dirent.isDirectory())
-      .map(dirent => resolve(__dirname, '../extensions/' + dirent.name));
-
-    // for each subfolder, start a watcher
-    for (const extensionFolder of extensionsFolders) {
-      setupExtensionApiWatcher(extensionFolder);
-    }
+      .forEach(dirent => setupExtensionApiWatcher(join(extensionsFolder, dirent.name)));
 
     for (const extension of extensions) {
       setupExtensionApiWatcher(extension);

--- a/scripts/watch.mjs
+++ b/scripts/watch.mjs
@@ -182,7 +182,6 @@ const setupExtensionApiWatcher = name => {
     const extensionsFolder = resolve(__dirname, '../extensions/');
 
     // loop on all subfolders from the extensions folder
-    // loop on all subfolders from the extensions folder
     readdirSync(extensionsFolder, { withFileTypes: true })
       .filter(dirent => dirent.isDirectory())
       .forEach(dirent => setupExtensionApiWatcher(join(extensionsFolder, dirent.name)));


### PR DESCRIPTION

### What does this PR do?
for now we were listing explicitly all extension one by one but for example kubectl-cli was missing

now, loop on the folder so we won't miss a new extension

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast 
explaining what is doing this PR -->

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/4944


### How to test this PR?

`yarn watch` should work (dev mode)