### PR TITLE
Refactor List UI components

### DIFF
--- a/packages/renderer/src/lib/container/ContainerList.svelte
+++ b/packages/renderer/src/lib/container/ContainerList.svelte
@@ -473,12 +473,11 @@ function setStoppedFilter() {
         title="Delete {selectedItemsNumber} selected items"
         bind:inProgress="{bulkDeleteInProgress}"
         icon="{faTrash}" />
-      <div class="px-1"></div>
       <Button
         on:click="{() => createPodFromContainers()}"
         title="Create Pod with {selectedItemsNumber} selected items"
         icon="{SolidPodIcon}" />
-      <span class="pl-2">On {selectedItemsNumber} selected items.</span>
+      <span>On {selectedItemsNumber} selected items.</span>
     {/if}
   </svelte:fragment>
 

--- a/packages/renderer/src/lib/container/ContainerList.svelte
+++ b/packages/renderer/src/lib/container/ContainerList.svelte
@@ -482,14 +482,14 @@ function setStoppedFilter() {
     {/if}
   </div>
 
-  <div class="flex flex-row px-2 mb-2 border-b border-charcoal-400" slot="tabs">
+  <svelte:fragment slot="tabs">
     <Button type="tab" on:click="{() => resetRunningFilter()}" selected="{containerUtils.filterIsAll(searchTerm)}"
       >All containers</Button>
     <Button type="tab" on:click="{() => setRunningFilter()}" selected="{containerUtils.filterIsRunning(searchTerm)}"
       >Running containers</Button>
     <Button type="tab" on:click="{() => setStoppedFilter()}" selected="{containerUtils.filterIsStopped(searchTerm)}"
       >Stopped containers</Button>
-  </div>
+  </svelte:fragment>
 
   <div class="flex min-w-full h-full" slot="content">
     <table class="mx-5 w-full h-fit" class:hidden="{containerGroups.length === 0}">

--- a/packages/renderer/src/lib/container/ContainerList.svelte
+++ b/packages/renderer/src/lib/container/ContainerList.svelte
@@ -455,7 +455,7 @@ function setStoppedFilter() {
 </script>
 
 <NavPage bind:searchTerm="{searchTerm}" title="containers">
-  <div slot="additional-actions" class="space-x-2 flex flex-nowrap">
+  <svelte:fragment slot="additional-actions">
     <!-- Only show if there are containers-->
     {#if $containersInfos.length > 0}
       <Prune type="containers" engines="{enginesList}" />
@@ -464,7 +464,7 @@ function setStoppedFilter() {
     {#if providerPodmanConnections.length > 0}
       <KubePlayButton />
     {/if}
-  </div>
+  </svelte:fragment>
   <div slot="bottom-additional-actions" class="flex flex-row justify-start items-center w-full">
     {#if selectedItemsNumber > 0}
       <Button

--- a/packages/renderer/src/lib/container/ContainerList.svelte
+++ b/packages/renderer/src/lib/container/ContainerList.svelte
@@ -465,7 +465,7 @@ function setStoppedFilter() {
       <KubePlayButton />
     {/if}
   </svelte:fragment>
-  <div slot="bottom-additional-actions" class="flex flex-row justify-start items-center w-full">
+  <svelte:fragment slot="bottom-additional-actions">
     {#if selectedItemsNumber > 0}
       <Button
         on:click="{() => deleteSelectedContainers()}"
@@ -480,7 +480,7 @@ function setStoppedFilter() {
         icon="{SolidPodIcon}" />
       <span class="pl-2">On {selectedItemsNumber} selected items.</span>
     {/if}
-  </div>
+  </svelte:fragment>
 
   <svelte:fragment slot="tabs">
     <Button type="tab" on:click="{() => resetRunningFilter()}" selected="{containerUtils.filterIsAll(searchTerm)}"

--- a/packages/renderer/src/lib/image/ImagesList.svelte
+++ b/packages/renderer/src/lib/image/ImagesList.svelte
@@ -227,7 +227,7 @@ function computeInterval(): number {
     <Button on:click="{() => gotoBuildImage()}" title="Build Image from Containerfile" icon="{faCube}">Build</Button>
   </svelte:fragment>
 
-  <div slot="bottom-additional-actions" class="flex flex-row justify-start items-center w-full">
+  <svelte:fragment slot="bottom-additional-actions">
     {#if selectedItemsNumber > 0}
       <Button
         on:click="{() => deleteSelectedImages()}"
@@ -236,7 +236,7 @@ function computeInterval(): number {
         icon="{faTrash}" />
       <span class="pl-2">On {selectedItemsNumber} selected items.</span>
     {/if}
-  </div>
+  </svelte:fragment>
 
   <div class="flex min-w-full h-full" slot="content">
     <table class="mx-5 w-full h-fit" class:hidden="{images.length === 0}">

--- a/packages/renderer/src/lib/image/ImagesList.svelte
+++ b/packages/renderer/src/lib/image/ImagesList.svelte
@@ -234,7 +234,7 @@ function computeInterval(): number {
         title="Delete {selectedItemsNumber} selected items"
         bind:inProgress="{bulkDeleteInProgress}"
         icon="{faTrash}" />
-      <span class="pl-2">On {selectedItemsNumber} selected items.</span>
+      <span>On {selectedItemsNumber} selected items.</span>
     {/if}
   </svelte:fragment>
 

--- a/packages/renderer/src/lib/image/ImagesList.svelte
+++ b/packages/renderer/src/lib/image/ImagesList.svelte
@@ -217,7 +217,7 @@ function computeInterval(): number {
 </script>
 
 <NavPage bind:searchTerm="{searchTerm}" title="images">
-  <div slot="additional-actions" class="space-x-2 flex flex-nowrap">
+  <svelte:fragment slot="additional-actions">
     {#if $imagesInfos.length > 0}
       <Prune type="images" engines="{enginesList}" />
     {/if}
@@ -225,7 +225,7 @@ function computeInterval(): number {
       Pull
     </Button>
     <Button on:click="{() => gotoBuildImage()}" title="Build Image from Containerfile" icon="{faCube}">Build</Button>
-  </div>
+  </svelte:fragment>
 
   <div slot="bottom-additional-actions" class="flex flex-row justify-start items-center w-full">
     {#if selectedItemsNumber > 0}

--- a/packages/renderer/src/lib/pod/PodsList.svelte
+++ b/packages/renderer/src/lib/pod/PodsList.svelte
@@ -220,7 +220,7 @@ function errorCallback(pod: PodInfoUI, errorMessage: string): void {
     {/if}
   </div>
 
-  <div class="flex flex-row px-2 mb-2 border-b border-charcoal-400" slot="tabs">
+  <svelte:fragment slot="tabs">
     <Button
       type="tab"
       on:click="{() => {
@@ -254,7 +254,7 @@ function errorCallback(pod: PodInfoUI, errorMessage: string): void {
         searchTerm = temp ? `${temp} is:stopped` : 'is:stopped';
       }}"
       selected="{searchTerm.includes('is:stopped')}">Stopped</Button>
-  </div>
+  </svelte:fragment>
 
   <div class="flex min-w-full h-full" slot="content">
     <table class="mx-5 w-full h-fit" class:hidden="{pods.length === 0}">

--- a/packages/renderer/src/lib/pod/PodsList.svelte
+++ b/packages/renderer/src/lib/pod/PodsList.svelte
@@ -200,14 +200,14 @@ function errorCallback(pod: PodInfoUI, errorMessage: string): void {
 </script>
 
 <NavPage bind:searchTerm="{searchTerm}" title="pods">
-  <div slot="additional-actions" class="space-x-2 flex flex-nowrap">
+  <svelte:fragment slot="additional-actions">
     {#if $podsInfos.length > 0}
       <Prune type="pods" engines="{enginesList}" />
     {/if}
     {#if providerPodmanConnections.length > 0}
       <KubePlayButton />
     {/if}
-  </div>
+  </svelte:fragment>
 
   <div slot="bottom-additional-actions" class="flex flex-row justify-start items-center w-full">
     {#if selectedItemsNumber > 0}

--- a/packages/renderer/src/lib/pod/PodsList.svelte
+++ b/packages/renderer/src/lib/pod/PodsList.svelte
@@ -216,7 +216,7 @@ function errorCallback(pod: PodInfoUI, errorMessage: string): void {
         title="Delete {selectedItemsNumber} selected items"
         inProgress="{bulkDeleteInProgress}"
         icon="{faTrash}" />
-      <span class="pl-2">On {selectedItemsNumber} selected items.</span>
+      <span>On {selectedItemsNumber} selected items.</span>
     {/if}
   </svelte:fragment>
 

--- a/packages/renderer/src/lib/pod/PodsList.svelte
+++ b/packages/renderer/src/lib/pod/PodsList.svelte
@@ -209,7 +209,7 @@ function errorCallback(pod: PodInfoUI, errorMessage: string): void {
     {/if}
   </svelte:fragment>
 
-  <div slot="bottom-additional-actions" class="flex flex-row justify-start items-center w-full">
+  <svelte:fragment slot="bottom-additional-actions">
     {#if selectedItemsNumber > 0}
       <Button
         on:click="{() => deleteSelectedPods()}"
@@ -218,7 +218,7 @@ function errorCallback(pod: PodInfoUI, errorMessage: string): void {
         icon="{faTrash}" />
       <span class="pl-2">On {selectedItemsNumber} selected items.</span>
     {/if}
-  </div>
+  </svelte:fragment>
 
   <svelte:fragment slot="tabs">
     <Button

--- a/packages/renderer/src/lib/ui/NavPage.svelte
+++ b/packages/renderer/src/lib/ui/NavPage.svelte
@@ -46,7 +46,11 @@ export let searchEnabled = true;
       </div>
     {/if}
 
-    <slot name="tabs" />
+    {#if $$slots.tabs}
+      <div class="flex flex-row px-2 mb-2 border-b border-charcoal-400">
+        <slot name="tabs" />
+      </div>
+    {/if}
 
     <div class="flex w-full h-full overflow-auto" role="region" aria-label="content">
       <slot name="content" />

--- a/packages/renderer/src/lib/ui/NavPage.svelte
+++ b/packages/renderer/src/lib/ui/NavPage.svelte
@@ -43,7 +43,11 @@ export let searchEnabled = true;
           </div>
         </div>
         <div class="flex flex-1 px-5" role="group" aria-label="bottomAdditionalActions">
-          <slot name="bottom-additional-actions">&nbsp;</slot>
+          {#if $$slots['bottom-additional-actions']}
+            <div class="flex flex-row justify-start items-center w-full">
+              <slot name="bottom-additional-actions" />
+            </div>
+          {:else}&nbsp;#{/if}
         </div>
       </div>
     {/if}

--- a/packages/renderer/src/lib/ui/NavPage.svelte
+++ b/packages/renderer/src/lib/ui/NavPage.svelte
@@ -12,7 +12,9 @@ export let searchEnabled = true;
       </div>
       <div class="flex flex-1 justify-end">
         <div class="px-5" role="group" aria-label="additionalActions">
-          <slot name="additional-actions">&nbsp;</slot>
+          {#if $$slots['additional-actions']}
+            <div class="space-x-2 flex flex-nowrap"><slot name="additional-actions" /></div>
+          {:else}&nbsp;{/if}
         </div>
       </div>
     </div>

--- a/packages/renderer/src/lib/ui/NavPage.svelte
+++ b/packages/renderer/src/lib/ui/NavPage.svelte
@@ -44,7 +44,7 @@ export let searchEnabled = true;
         </div>
         <div class="flex flex-1 px-5" role="group" aria-label="bottomAdditionalActions">
           {#if $$slots['bottom-additional-actions']}
-            <div class="flex flex-row justify-start items-center w-full">
+            <div class="space-x-2 flex flex-row justify-start items-center w-full">
               <slot name="bottom-additional-actions" />
             </div>
           {:else}&nbsp;#{/if}

--- a/packages/renderer/src/lib/volume/VolumesList.svelte
+++ b/packages/renderer/src/lib/volume/VolumesList.svelte
@@ -210,7 +210,7 @@ function gotoCreateVolume(): void {
         title="Delete {selectedItemsNumber} selected items"
         inProgress="{bulkDeleteInProgress}"
         icon="{faTrash}" />
-      <span class="pl-2">On {selectedItemsNumber} selected items.</span>
+      <span>On {selectedItemsNumber} selected items.</span>
     {/if}
   </svelte:fragment>
 

--- a/packages/renderer/src/lib/volume/VolumesList.svelte
+++ b/packages/renderer/src/lib/volume/VolumesList.svelte
@@ -203,7 +203,7 @@ function gotoCreateVolume(): void {
     {/if}
   </svelte:fragment>
 
-  <div slot="bottom-additional-actions" class="flex flex-row justify-start items-center w-full">
+  <svelte:fragment slot="bottom-additional-actions">
     {#if selectedItemsNumber > 0}
       <Button
         on:click="{() => deleteSelectedVolumes()}"
@@ -212,7 +212,7 @@ function gotoCreateVolume(): void {
         icon="{faTrash}" />
       <span class="pl-2">On {selectedItemsNumber} selected items.</span>
     {/if}
-  </div>
+  </svelte:fragment>
 
   <div class="flex min-w-full h-full" slot="content">
     <table class="mx-5 w-full h-fit" class:hidden="{volumes.length === 0}">

--- a/packages/renderer/src/lib/volume/VolumesList.svelte
+++ b/packages/renderer/src/lib/volume/VolumesList.svelte
@@ -188,7 +188,7 @@ function gotoCreateVolume(): void {
 </script>
 
 <NavPage bind:searchTerm="{searchTerm}" title="volumes">
-  <div slot="additional-actions" class="space-x-2 flex flex-nowrap">
+  <svelte:fragment slot="additional-actions">
     {#if providerConnections.length > 0}
       <Button on:click="{() => gotoCreateVolume()}" icon="{faPlusCircle}" title="Create a volume">Create</Button>
     {/if}
@@ -201,7 +201,7 @@ function gotoCreateVolume(): void {
         title="Collect usage data for volumes. It can take a while..."
         icon="{faPieChart}">Collect usage data</Button>
     {/if}
-  </div>
+  </svelte:fragment>
 
   <div slot="bottom-additional-actions" class="flex flex-row justify-start items-center w-full">
     {#if selectedItemsNumber > 0}


### PR DESCRIPTION
### What does this PR do?

- moves layout information into NavPage, instead of having to duplicate the TailWind classes in places where the NavPage component is used.

It takes advantage of `$$slots` (https://github.com/sveltejs/svelte/pull/4602) to move layout into component when the content is optional.
