### PR TITLE
feat: deployment store

### DIFF
--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -68,6 +68,7 @@ import type {
   Cluster,
   Context,
   V1ConfigMap,
+  V1Deployment,
   V1Ingress,
   V1NamespaceList,
   V1Pod,
@@ -1481,15 +1482,15 @@ function initExposure(): void {
     return ipcInvoke('kubernetes-client:listPods');
   });
 
-  contextBridge.exposeInMainWorld('kubernetesListDeployments', async (): Promise<PodInfo[]> => {
+  contextBridge.exposeInMainWorld('kubernetesListDeployments', async (): Promise<V1Deployment[]> => {
     return ipcInvoke('kubernetes-client:listDeployments');
   });
 
-  contextBridge.exposeInMainWorld('kubernetesListIngresses', async (): Promise<PodInfo[]> => {
+  contextBridge.exposeInMainWorld('kubernetesListIngresses', async (): Promise<V1Ingress[]> => {
     return ipcInvoke('kubernetes-client:listIngresses');
   });
 
-  contextBridge.exposeInMainWorld('kubernetesListRoutes', async (): Promise<PodInfo[]> => {
+  contextBridge.exposeInMainWorld('kubernetesListRoutes', async (): Promise<V1Route[]> => {
     return ipcInvoke('kubernetes-client:listRoutes');
   });
 

--- a/packages/renderer/src/lib/deployments/DeploymentUI.ts
+++ b/packages/renderer/src/lib/deployments/DeploymentUI.ts
@@ -1,0 +1,26 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+export interface DeploymentUI {
+  name: string;
+  namespace: string;
+  replicas: number;
+  ready: number;
+  age: string;
+  selected: boolean;
+}

--- a/packages/renderer/src/lib/deployments/deployment-utils.spec.ts
+++ b/packages/renderer/src/lib/deployments/deployment-utils.spec.ts
@@ -1,0 +1,46 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { beforeEach, expect, test, vi } from 'vitest';
+import { DeploymentUtils } from './deployment-utils';
+import type { V1Deployment } from '@kubernetes/client-node';
+
+let deploymentUtils: DeploymentUtils;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  deploymentUtils = new DeploymentUtils();
+});
+
+test('expect basic UI conversion', async () => {
+  const deployment = {
+    metadata: {
+      name: 'my-deployment',
+      namespace: 'test-namespace',
+    },
+    status: {
+      replicas : 4,
+      readyReplicas: 2,
+    }
+  } as V1Deployment;
+  const deploymentUI = deploymentUtils.getDeploymentUI(deployment);
+  expect(deploymentUI.name).toEqual('my-deployment');
+  expect(deploymentUI.namespace).toEqual('test-namespace');
+  expect(deploymentUI.replicas).toEqual(4);
+  expect(deploymentUI.ready).toEqual(2);
+});

--- a/packages/renderer/src/lib/deployments/deployment-utils.spec.ts
+++ b/packages/renderer/src/lib/deployments/deployment-utils.spec.ts
@@ -34,9 +34,9 @@ test('expect basic UI conversion', async () => {
       namespace: 'test-namespace',
     },
     status: {
-      replicas : 4,
+      replicas: 4,
       readyReplicas: 2,
-    }
+    },
   } as V1Deployment;
   const deploymentUI = deploymentUtils.getDeploymentUI(deployment);
   expect(deploymentUI.name).toEqual('my-deployment');

--- a/packages/renderer/src/lib/deployments/deployment-utils.ts
+++ b/packages/renderer/src/lib/deployments/deployment-utils.ts
@@ -1,0 +1,44 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import moment from 'moment';
+import humanizeDuration from 'humanize-duration';
+import type { DeploymentUI } from './DeploymentUI';
+import type { V1Deployment } from '@kubernetes/client-node';
+
+export class DeploymentUtils {
+  humanizeAge(started: string): string {
+    // get start time in ms
+    const uptimeInMs = moment().diff(started);
+    // make it human friendly
+    return humanizeDuration(uptimeInMs, { round: true, largest: 1 });
+  }
+
+  getDeploymentUI(deployment: V1Deployment): DeploymentUI {
+    return {
+      name: deployment.metadata?.name || '',
+      namespace: deployment.metadata?.namespace || '',
+      age: this.humanizeAge((deployment.metadata?.creationTimestamp || '').toString()),
+      // number of replicas
+      replicas: deployment.status?.replicas || 0,
+      // ready pods
+      ready: deployment.status?.readyReplicas || 0,
+      selected: false,
+    };
+  }
+}

--- a/packages/renderer/src/stores/deployments.ts
+++ b/packages/renderer/src/stores/deployments.ts
@@ -1,0 +1,61 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { writable, derived, type Writable } from 'svelte/store';
+import type { V1Deployment } from '@kubernetes/client-node';
+
+import { findMatchInLeaves } from './search-util';
+import { EventStore } from './event-store';
+import DeploymentIcon from '../lib/images/DeploymentIcon.svelte';
+
+const windowEvents = ['extension-started', 'extension-stopped', 'provider-change', 'extensions-started'];
+const windowListeners = ['extensions-already-started'];
+
+let readyToUpdate = false;
+
+export async function checkForUpdate(eventName: string): Promise<boolean> {
+  if ('extensions-already-started' === eventName) {
+    readyToUpdate = true;
+  }
+
+  // do not fetch until extensions are all started
+  return readyToUpdate;
+}
+
+export const deployments: Writable<V1Deployment[]> = writable([]);
+
+export const searchPattern = writable('');
+
+export const filtered = derived([searchPattern, deployments], ([$searchPattern, $deploymentInfos]) =>
+  $deploymentInfos.filter(deployment => findMatchInLeaves(deployment, $searchPattern.toLowerCase())),
+);
+
+const eventStore = new EventStore<V1Deployment[]>(
+  'deployments',
+  deployments,
+  checkForUpdate,
+  windowEvents,
+  windowListeners,
+  grabAllDeployments,
+  DeploymentIcon,
+);
+eventStore.setupWithDebounce();
+
+export async function grabAllDeployments(): Promise<V1Deployment[]> {
+  return window.kubernetesListDeployments();
+}


### PR DESCRIPTION
### What does this PR do?

Follows the same pattern as pods, images, volumes, etc to define a deployment store that's reactive to the expected events, a UI type, and a util class that maps to the UI type.

Re: index.ts - I copied from Luca, who likely copied from elsewhere, and we both missed updating one type. :)

We will definitely need additional properties mapped from V1Deployment to DeploymentUI when we add the UI, this PR is purely to get the store, UI object, and basic scaffolding in place.

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

Part of #4366.

### How to test this PR?

Run test.