### PR TITLE
chore: fix yarn watch

### DIFF
--- a/scripts/watch.mjs
+++ b/scripts/watch.mjs
@@ -7,6 +7,7 @@ import { generateAsync } from 'dts-for-context-bridge';
 import { dirname, resolve } from 'path';
 import { fileURLToPath } from 'url';
 import { readdirSync } from 'node:fs';
+import { join } from 'node:path';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 


### PR DESCRIPTION
chore: fix yarn watch

### What does this PR do?

`yarn watch` now works, looks like we did not explicitly say to use join
from `node:path`.

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast
explaining what is doing this PR -->

N/A

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop/issues/4956

### How to test this PR?

<!-- Please explain steps to reproduce -->

`yarn watch` should now work

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
