### PR TITLE
fix: check extension folder contains package.json

### DIFF
--- a/scripts/watch.mjs
+++ b/scripts/watch.mjs
@@ -6,7 +6,7 @@ import { spawn } from 'child_process';
 import { generateAsync } from 'dts-for-context-bridge';
 import { dirname, resolve } from 'path';
 import { fileURLToPath } from 'url';
-import { readdirSync } from 'node:fs';
+import { readdirSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -184,7 +184,7 @@ const setupExtensionApiWatcher = name => {
 
     // loop on all subfolders from the extensions folder
     readdirSync(extensionsFolder, { withFileTypes: true })
-      .filter(dirent => dirent.isDirectory())
+      .filter(dirent => dirent.isDirectory() && existsSync(join(extensionsFolder, dirent.name, 'package.json')))
       .forEach(dirent => setupExtensionApiWatcher(join(extensionsFolder, dirent.name)));
 
     for (const extension of extensions) {


### PR DESCRIPTION
### What does this PR do?

it adds a check for the folder to watch

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

it resolves #4963

### How to test this PR?

1. yarn watch with an empty extension folder
