### PR TITLE
chore(tests,ci): close the Dev Tools window when starting app. during…

### DIFF
--- a/tests/src/welcome-page-smoke.spec.ts
+++ b/tests/src/welcome-page-smoke.spec.ts
@@ -16,8 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { BrowserWindow } from 'electron';
-import type { JSHandle, Page } from '@playwright/test';
+import type { Page } from '@playwright/test';
 import type { RunnerTestContext } from './testContext/runner-test-context';
 import { afterAll, beforeAll, expect, test, describe, beforeEach } from 'vitest';
 import { expect as playExpect } from '@playwright/test';
@@ -46,29 +45,10 @@ beforeEach<RunnerTestContext>(async ctx => {
 describe('Basic e2e verification of podman desktop start', async () => {
   describe('Welcome page handling', async () => {
     test('Check the Welcome page is displayed', async () => {
-      const window: JSHandle<BrowserWindow> = await pdRunner.getBrowserWindow();
-
-      const windowState = await window.evaluate(
-        (mainWindow): Promise<{ isVisible: boolean; isDevToolsOpened: boolean; isCrashed: boolean }> => {
-          const getState = () => ({
-            isVisible: mainWindow.isVisible(),
-            isDevToolsOpened: mainWindow.webContents.isDevToolsOpened(),
-            isCrashed: mainWindow.webContents.isCrashed(),
-          });
-
-          return new Promise(resolve => {
-            /**
-             * The main window is created hidden, and is shown only when it is ready.
-             * See {@link ../packages/main/src/mainWindow.ts} function
-             */
-            if (mainWindow.isVisible()) {
-              resolve(getState());
-            } else mainWindow.once('ready-to-show', () => resolve(getState()));
-          });
-        },
-      );
+      const windowState = await pdRunner.getBrowserWindowState();
       expect(windowState.isCrashed, 'The app has crashed').toBeFalsy();
       expect(windowState.isVisible, 'The main window was not visible').toBeTruthy();
+      expect(windowState.isDevToolsOpened, 'The Dev Tools window is not closed').toBeFalsy();
 
       await pdRunner.screenshot('welcome-page-init.png');
 


### PR DESCRIPTION
… E2E tests

### What does this PR do?
It closes the dev tools that are opened during the e2e tests. Electron app is opened with dev tools on the side by default, I guess, because of the development mode the tests run in. It removes the redundancy in welcome-page tests file and add one more check for devtools window state.
### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast 
explaining what is doing this PR -->
![welcome-page-display](https://github.com/containers/podman-desktop/assets/19164299/d7ce21c8-09f6-4ac2-94cf-4b7a2db23d90)

### What issues does this PR fix or reference?
#4968 
<!-- Include any related issues from Podman Desktop 
repository (or from another issue tracker). -->

### How to test this PR?
Run the E2E tests (`yarn test:e2e:smoke`) and checks the `tests/output/screenshots` folder for `png` files
<!-- Please explain steps to reproduce -->
