### PR TITLE
fix: remove errant hash mark

### DIFF
--- a/packages/renderer/src/lib/ui/NavPage.svelte
+++ b/packages/renderer/src/lib/ui/NavPage.svelte
@@ -47,7 +47,7 @@ export let searchEnabled = true;
             <div class="space-x-2 flex flex-row justify-start items-center w-full">
               <slot name="bottom-additional-actions" />
             </div>
-          {:else}&nbsp;#{/if}
+          {:else}&nbsp;{/if}
         </div>
       </div>
     {/if}


### PR DESCRIPTION
### What does this PR do?

I noticed an errant hash appearing on a nav page to the right of the filter bar, tracked it back to #4953. Will appear on any nav page that doesn't have actions on selected objects.

### Screenshot/screencast of this PR

Mocked for volumes page - I was building the deployments page at the time and didn't have actions yet.

<img width="619" alt="Screenshot 2023-11-23 at 3 25 51 PM" src="https://github.com/containers/podman-desktop/assets/19958075/0069fad8-9b91-4a10-8bb7-a2309a78ec2a">

### What issues does this PR fix or reference?

Forgive me for not opening a bug first, but it's just one character...

### How to test this PR?

Find a nav page without selected object actions, or remove the bottom-additional-actions from one.