### PR TITLE
chore: default volume sort

### DIFF
--- a/packages/renderer/src/lib/volume/VolumesList.svelte
+++ b/packages/renderer/src/lib/volume/VolumesList.svelte
@@ -250,7 +250,8 @@ const row = new Row<VolumeInfoUI>({
       bind:selectedItemsNumber="{selectedItemsNumber}"
       data="{volumes}"
       columns="{columns}"
-      row="{row}">
+      row="{row}"
+      defaultSortColumn="Name">
     </Table>
 
     {#if providerConnections.length === 0}


### PR DESCRIPTION
### What does this PR do?

Now that both #4841 (Volume table component) and #4860 (default sort column) have merged, we can follow up and mark the default sort column for volumes: name. This change has no effect other than setting the sort indicator for the Name column by default.

### Screenshot/screencast of this PR

<img width="249" alt="Screenshot 2023-11-23 at 3 55 54 PM" src="https://github.com/containers/podman-desktop/assets/19958075/34c84d27-cdc4-4047-b0e5-60d2834b4c2d">

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Open Volumes page, see Name sort indicator.