### PR TITLE
feat: list/delete services

### DIFF
--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1801,6 +1801,10 @@ export class PluginSystem {
       return kubernetesClient.listRoutes();
     });
 
+    this.ipcHandle('kubernetes-client:listServices', async (): Promise<V1Service[]> => {
+      return kubernetesClient.listServices();
+    });
+
     this.ipcHandle(
       'kubernetes-client:readPodLog',
       async (_listener, name: string, container: string, onDataId: number): Promise<void> => {
@@ -1824,6 +1828,10 @@ export class PluginSystem {
 
     this.ipcHandle('kubernetes-client:deleteRoute', async (_listener, name: string): Promise<void> => {
       return kubernetesClient.deleteRoute(name);
+    });
+
+    this.ipcHandle('kubernetes-client:deleteService', async (_listener, name: string): Promise<void> => {
+      return kubernetesClient.deleteService(name);
     });
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -1494,6 +1494,10 @@ function initExposure(): void {
     return ipcInvoke('kubernetes-client:listRoutes');
   });
 
+  contextBridge.exposeInMainWorld('kubernetesListServices', async (): Promise<V1Service[]> => {
+    return ipcInvoke('kubernetes-client:listServices');
+  });
+
   let onDataCallbacksKubernetesPodLogId = 0;
   const onDataCallbacksKubernetesPodLog = new Map<number, (name: string, data: string) => void>();
   contextBridge.exposeInMainWorld(
@@ -1528,6 +1532,10 @@ function initExposure(): void {
 
   contextBridge.exposeInMainWorld('kubernetesDeleteRoute', async (name: string): Promise<void> => {
     return ipcInvoke('kubernetes-client:deleteRoute', name);
+  });
+
+  contextBridge.exposeInMainWorld('kubernetesDeleteService', async (name: string): Promise<void> => {
+    return ipcInvoke('kubernetes-client:deleteService', name);
   });
 
   contextBridge.exposeInMainWorld(


### PR DESCRIPTION
### What does this PR do?

Just like PR #4858 for deployments, we're going to need API for services following the same pattern.

API for listing and deleting Kubernetes Services, with tests. Needed for #4368.

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

Part of #4368.

### How to test this PR?

yarn tests