### PR TITLE
fix: add path prop for route object

### DIFF
--- a/packages/main/src/plugin/api/openshift-types.ts
+++ b/packages/main/src/plugin/api/openshift-types.ts
@@ -26,9 +26,10 @@ export type V1Route = {
   };
   spec: {
     host: string;
-    port: {
+    port?: {
       targetPort: string;
     };
+    path?: string;
     tls: {
       insecureEdgeTerminationPolicy: string;
       termination: string;

--- a/packages/renderer/src/lib/ingresses-routes/RouteUI.ts
+++ b/packages/renderer/src/lib/ingresses-routes/RouteUI.ts
@@ -25,7 +25,8 @@ export interface RouteUI {
   name: string;
   namespace: string;
   host: string;
-  port: string;
+  port?: string;
+  path?: string;
   to: RouteToReference;
   selected: boolean;
 }

--- a/packages/renderer/src/lib/ingresses-routes/ingress-route-utils.spec.ts
+++ b/packages/renderer/src/lib/ingresses-routes/ingress-route-utils.spec.ts
@@ -90,7 +90,7 @@ test('expect basic UI conversion for route with port', async () => {
   expect(routeUI.to.name).toEqual(route.spec.to.name);
 });
 
-test('expect basic UI conversion for route with port', async () => {
+test('expect basic UI conversion for route with path', async () => {
   const route = {
     metadata: {
       name: 'my-route',

--- a/packages/renderer/src/lib/ingresses-routes/ingress-route-utils.spec.ts
+++ b/packages/renderer/src/lib/ingresses-routes/ingress-route-utils.spec.ts
@@ -63,7 +63,7 @@ test('expect basic UI conversion for ingress', async () => {
   expect(ingressUI.rules).equal(ingress.spec?.rules);
 });
 
-test('expect basic UI conversion for route', async () => {
+test('expect basic UI conversion for route with port', async () => {
   const route = {
     metadata: {
       name: 'my-route',
@@ -84,7 +84,33 @@ test('expect basic UI conversion for route', async () => {
   expect(routeUI.name).toEqual('my-route');
   expect(routeUI.namespace).toEqual('test-namespace');
   expect(routeUI.host).toEqual(route.spec.host);
-  expect(routeUI.port).toEqual(route.spec.port.targetPort);
+  expect(routeUI.port).toEqual(route.spec.port?.targetPort);
+  expect(routeUI.path).toBeUndefined();
+  expect(routeUI.to.kind).toEqual(route.spec.to.kind);
+  expect(routeUI.to.name).toEqual(route.spec.to.name);
+});
+
+test('expect basic UI conversion for route with port', async () => {
+  const route = {
+    metadata: {
+      name: 'my-route',
+      namespace: 'test-namespace',
+    },
+    spec: {
+      host: 'foo.bar.com',
+      path: '/test',
+      to: {
+        kind: 'Service',
+        name: 'service',
+      },
+    },
+  } as V1Route;
+  const routeUI = ingressRouteUtils.getRouteUI(route);
+  expect(routeUI.name).toEqual('my-route');
+  expect(routeUI.namespace).toEqual('test-namespace');
+  expect(routeUI.host).toEqual(route.spec.host);
+  expect(routeUI.port).toBeUndefined();
+  expect(routeUI.path).toEqual(route.spec.path);
   expect(routeUI.to.kind).toEqual(route.spec.to.kind);
   expect(routeUI.to.name).toEqual(route.spec.to.name);
 });

--- a/packages/renderer/src/lib/ingresses-routes/ingress-route-utils.ts
+++ b/packages/renderer/src/lib/ingresses-routes/ingress-route-utils.ts
@@ -35,7 +35,8 @@ export class IngressRouteUtils {
       name: route.metadata?.name || '',
       namespace: route.metadata?.namespace || '',
       host: route.spec.host,
-      port: route.spec.port.targetPort,
+      port: route.spec.port?.targetPort,
+      path: route.spec.path,
       to: {
         kind: route.spec.to.kind,
         name: route.spec.to.name,

--- a/packages/renderer/src/lib/pod/DeployPodToKube.svelte
+++ b/packages/renderer/src/lib/pod/DeployPodToKube.svelte
@@ -569,7 +569,7 @@ function updateKubeResult() {
               <ul class="list-disc list-inside">
                 {#each createdRoutes as createdRoute}
                   <li class="pt-2">
-                    Port {createdRoute.spec.port.targetPort} is reachable with route
+                    Port {createdRoute.spec.port?.targetPort} is reachable with route
                     <Link on:click="{() => openRoute(createdRoute)}">{createdRoute.metadata.name}</Link>
                   </li>
                 {/each}


### PR DESCRIPTION
### What does this PR do?

a route can use a port but also a path https://docs.openshift.com/container-platform/4.14/networking/routes/route-configuration.html#nw-path-based-routes_route-configuration
this PR adds support for the path property

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

it is part of #4367 

### How to test this PR?

1. run tests
