### PR TITLE
feat: show canceled analyzers + filter on analyzers

### DIFF
--- a/packages/renderer/src/lib/ui/ProviderResultPage.ts
+++ b/packages/renderer/src/lib/ui/ProviderResultPage.ts
@@ -3,8 +3,9 @@ import type { ImageCheckerInfo } from '../../../../main/src/plugin/api/image-che
 
 export interface ProviderUI {
   info: ImageCheckerInfo;
-  state: 'running' | 'success' | 'failed';
+  state: 'running' | 'success' | 'failed' | 'canceled';
   error?: Error;
+  checked?: boolean;
 }
 
 export interface CheckUI {

--- a/packages/renderer/src/lib/ui/SlideToggle.svelte
+++ b/packages/renderer/src/lib/ui/SlideToggle.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+import { createEventDispatcher } from 'svelte';
+
+export let checked = false;
+
+const dispatch = createEventDispatcher();
+
+function onInput() {
+  dispatch('checked', !checked);
+}
+</script>
+
+<label class="h-[20px] relative inline-flex cursor-pointer">
+  <span class="text-xs {checked ? 'text-white' : 'text-gray-700'} mr-3"></span>
+  <input on:input="{onInput}" class="sr-only peer" bind:checked="{checked}" type="checkbox" />
+  <div
+    class="w-8 h-[20px] bg-gray-900 rounded-full peer peer-checked:after:translate-x-full after:bg-charcoal-600 after:content-[''] after:absolute after:top-[4px] after:left-[16px] after:rounded-full after:h-3 after:w-3 after:transition-all peer-checked:bg-violet-600">
+  </div>
+</label>


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

This PR adds information on the Image Checker page, to display which provider has been canceled when the user clicks the Cancel button before the providers finish.

The PR also adds toggle button to Providers, to filter the results on providers.

### Screenshot/screencast of this PR

https://github.com/containers/podman-desktop/assets/9973512/ab2d2096-9d35-4c1c-84f3-d792934ddbe9

### What issues does this PR fix or reference?

References #4707

### How to test this PR?

You can install a fake image checker from the image at quay.io/phmartin/fake-image-checker:v0.0.3 (sources: https://github.com/feloy/podman-desktop-extension-fake-image-checker)

