### PR TITLE
feat: service store

### DIFF
--- a/packages/renderer/src/lib/service/ServiceUI.ts
+++ b/packages/renderer/src/lib/service/ServiceUI.ts
@@ -20,7 +20,7 @@ export interface ServiceUI {
   name: string;
   status: string;
   namespace: string;
-  created: Date | undefined;
+  created?: Date;
   age: string;
   conditions: Condition[];
   selected: boolean;
@@ -28,5 +28,5 @@ export interface ServiceUI {
 
 export interface Condition {
   type: string;
-  message: string | undefined;
+  message?: string;
 }

--- a/packages/renderer/src/lib/service/ServiceUI.ts
+++ b/packages/renderer/src/lib/service/ServiceUI.ts
@@ -1,0 +1,32 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+export interface ServiceUI {
+  name: string;
+  status: string;
+  namespace: string;
+  created: Date | undefined;
+  age: string;
+  conditions: Condition[];
+  selected: boolean;
+}
+
+export interface Condition {
+  type: string;
+  message: string | undefined;
+}

--- a/packages/renderer/src/lib/service/service-utils.spec.ts
+++ b/packages/renderer/src/lib/service/service-utils.spec.ts
@@ -1,0 +1,41 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { beforeEach, expect, test, vi } from 'vitest';
+import { ServiceUtils } from './service-utils';
+import type { V1Service } from '@kubernetes/client-node';
+
+let serviceUtils: ServiceUtils;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  serviceUtils = new ServiceUtils();
+});
+
+test('expect basic UI conversion', async () => {
+  const service = {
+    metadata: {
+      name: 'my-service',
+      namespace: 'test-namespace',
+    },
+    status: {},
+  } as V1Service;
+  const serviceUI = serviceUtils.getServiceUI(service);
+  expect(serviceUI.name).toEqual('my-service');
+  expect(serviceUI.namespace).toEqual('test-namespace');
+});

--- a/packages/renderer/src/lib/service/service-utils.ts
+++ b/packages/renderer/src/lib/service/service-utils.ts
@@ -1,0 +1,62 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import moment from 'moment';
+import humanizeDuration from 'humanize-duration';
+import type { Condition, ServiceUI } from './ServiceUI';
+import type { V1Service } from '@kubernetes/client-node';
+
+export class ServiceUtils {
+  humanizeAge(started: string): string {
+    // get start time in ms
+    const uptimeInMs = moment().diff(started);
+    // make it human friendly
+    return humanizeDuration(uptimeInMs, { round: true, largest: 1 });
+  }
+
+  refreshAge(service: ServiceUI): string {
+    if (!service.created) {
+      return '';
+    }
+    // make it human friendly
+    return this.humanizeAge(service.created.toString());
+  }
+
+  getServiceUI(service: V1Service): ServiceUI {
+    const conditions = [];
+    if (service.status?.conditions) {
+      for (const con of service.status.conditions) {
+        const c: Condition = {
+          type: con.type,
+          message: con.message,
+        };
+        conditions.push(c);
+      }
+    }
+
+    return {
+      name: service.metadata?.name || '',
+      status: 'RUNNING',
+      namespace: service.metadata?.namespace || '',
+      created: service.metadata?.creationTimestamp,
+      age: service.metadata?.creationTimestamp ? this.humanizeAge(service.metadata.creationTimestamp.toString()) : '',
+      conditions: conditions,
+      selected: false,
+    };
+  }
+}

--- a/packages/renderer/src/lib/service/service-utils.ts
+++ b/packages/renderer/src/lib/service/service-utils.ts
@@ -50,9 +50,9 @@ export class ServiceUtils {
     }
 
     return {
-      name: service.metadata?.name || '',
+      name: service.metadata?.name ?? '',
       status: 'RUNNING',
-      namespace: service.metadata?.namespace || '',
+      namespace: service.metadata?.namespace ?? '',
       created: service.metadata?.creationTimestamp,
       age: service.metadata?.creationTimestamp ? this.humanizeAge(service.metadata.creationTimestamp.toString()) : '',
       conditions: conditions,

--- a/packages/renderer/src/lib/service/service-utils.ts
+++ b/packages/renderer/src/lib/service/service-utils.ts
@@ -18,7 +18,7 @@
 
 import moment from 'moment';
 import humanizeDuration from 'humanize-duration';
-import type { Condition, ServiceUI } from './ServiceUI';
+import type { ServiceUI } from './ServiceUI';
 import type { V1Service } from '@kubernetes/client-node';
 
 export class ServiceUtils {
@@ -38,16 +38,9 @@ export class ServiceUtils {
   }
 
   getServiceUI(service: V1Service): ServiceUI {
-    const conditions = [];
-    if (service.status?.conditions) {
-      for (const con of service.status.conditions) {
-        const c: Condition = {
-          type: con.type,
-          message: con.message,
-        };
-        conditions.push(c);
-      }
-    }
+    const conditions = (service.status?.conditions ?? []).map(c => {
+      return { type: c.type, message: c.message };
+    });
 
     return {
       name: service.metadata?.name ?? '',

--- a/packages/renderer/src/stores/services.spec.ts
+++ b/packages/renderer/src/stores/services.spec.ts
@@ -1,0 +1,92 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { get } from 'svelte/store';
+import type { Mock } from 'vitest';
+import { beforeAll, expect, test, vi } from 'vitest';
+import type { V1Service } from '@kubernetes/client-node';
+import { fetchServicesWithData, services, servicesEventStore } from './services';
+
+// first, path window object
+const callbacks = new Map<string, any>();
+const eventEmitter = {
+  receive: (message: string, callback: any) => {
+    callbacks.set(message, callback);
+  },
+};
+
+const listServicesMock: Mock<any, Promise<V1Service[]>> = vi.fn();
+
+Object.defineProperty(global, 'window', {
+  value: {
+    kubernetesListServices: listServicesMock,
+    events: {
+      receive: eventEmitter.receive,
+    },
+    addEventListener: eventEmitter.receive,
+  },
+  writable: true,
+});
+
+beforeAll(() => {
+  vi.clearAllMocks();
+});
+
+test('services should be updated in case of a extension is removed', async () => {
+  // initial services
+  listServicesMock.mockResolvedValue([
+    {
+      metadata: {
+        name: 'my-service',
+        namespace: 'test-namespace',
+      },
+      spec: {},
+    } as unknown as V1Service,
+  ]);
+  servicesEventStore.setup();
+
+  const callback = callbacks.get('extensions-already-started');
+  // send 'extensions-already-started' event
+  expect(callback).toBeDefined();
+  await callback();
+
+  // now ready to fetch services
+  await fetchServicesWithData();
+
+  // now get list
+  const listServices = get(services);
+  expect(listServices.length).toBe(1);
+  expect(listServices[0].metadata?.name).toBe('my-service');
+
+  // ok now mock the listServices function to return an empty list
+  listServicesMock.mockResolvedValue([]);
+
+  // call 'extension-stopped' event
+  const extensionStoppedCallback = callbacks.get('extension-stopped');
+  expect(extensionStoppedCallback).toBeDefined();
+  await extensionStoppedCallback();
+
+  // wait debounce
+  await new Promise(resolve => setTimeout(resolve, 2000));
+
+  // check if the services are updated
+  const services2 = get(services);
+  expect(services2.length).toBe(0);
+});

--- a/packages/renderer/src/stores/services.ts
+++ b/packages/renderer/src/stores/services.ts
@@ -1,0 +1,65 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { writable, derived, type Writable } from 'svelte/store';
+import type { V1Service } from '@kubernetes/client-node';
+
+import { findMatchInLeaves } from './search-util';
+import { EventStore } from './event-store';
+import ServiceIcon from '../lib/images/ServiceIcon.svelte';
+
+const windowEvents = ['extension-started', 'extension-stopped', 'provider-change', 'extensions-started'];
+const windowListeners = ['extensions-already-started'];
+
+let readyToUpdate = false;
+
+export async function checkForUpdate(eventName: string): Promise<boolean> {
+  if ('extensions-already-started' === eventName) {
+    readyToUpdate = true;
+  }
+
+  // do not fetch until extensions are all started
+  return readyToUpdate;
+}
+
+export const services: Writable<V1Service[]> = writable([]);
+
+export const searchPattern = writable('');
+
+export const filtered = derived([searchPattern, services], ([$searchPattern, $serviceInfos]) =>
+  $serviceInfos.filter(service => findMatchInLeaves(service, $searchPattern.toLowerCase())),
+);
+
+export const servicesEventStore = new EventStore<V1Service[]>(
+  'services',
+  services,
+  checkForUpdate,
+  windowEvents,
+  windowListeners,
+  grabAllServices,
+  ServiceIcon,
+);
+const servicesEventStoreInfo = servicesEventStore.setupWithDebounce();
+
+export async function grabAllServices(): Promise<V1Service[]> {
+  return window.kubernetesListServices();
+}
+
+export const fetchServicesWithData = async () => {
+  await servicesEventStoreInfo.fetch('fetchUsage');
+};


### PR DESCRIPTION
### What does this PR do?

Follows the same pattern as pods, images, volumes, etc to define a service store that's reactive to the expected events, a UI type, and a util class that maps to the UI type.

We will likely need additional properties mapped from V1Service to ServiceUI when we add the UI, this PR is to get the store, UI object, and basic scaffolding in place.

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

Part of #4368.

### How to test this PR?

`yarn test:renderer`