### PR TITLE
chore: env. CLOSE_DEVTOOLS can enforce devtools closed during test

### DIFF
--- a/packages/main/src/mainWindow.ts
+++ b/packages/main/src/mainWindow.ts
@@ -95,7 +95,9 @@ async function createWindow(): Promise<BrowserWindow> {
     }
 
     if (import.meta.env.DEV) {
-      browserWindow?.webContents.openDevTools();
+      if (!process.env.CLOSE_DEVTOOLS || process.env.CLOSE_DEVTOOLS !== 'true') {
+        browserWindow?.webContents.openDevTools();
+      }
     }
   });
 

--- a/packages/main/src/mainWindow.ts
+++ b/packages/main/src/mainWindow.ts
@@ -94,10 +94,11 @@ async function createWindow(): Promise<BrowserWindow> {
       browserWindow.show();
     }
 
-    if (import.meta.env.DEV) {
-      if (!process.env.CLOSE_DEVTOOLS || process.env.CLOSE_DEVTOOLS !== 'true') {
-        browserWindow?.webContents.openDevTools();
-      }
+    // Only in DEV mode, if OPEN_DEVTOOLS is not set or is true, we want to open Developer tools window
+    // When running the E2E tests, to avoid problems with small application window, we are settings
+    // OPEN_DEVTOOLS=false.
+    if (import.meta.env.DEV && (!process.env.OPEN_DEVTOOLS || process.env.OPEN_DEVTOOLS === 'true')) {
+      browserWindow?.webContents.openDevTools();
     }
   });
 


### PR DESCRIPTION
### What does this PR do?
Introduces an option how to enforce podman desktop not to open dev tools window. Especially during testing.
This bring only a condition in `packages/main/src/mainWindow.ts` that checks for env. var. CLOSE_DEVTOOLS, if it is defined and is `'true'`, then `browserWindow?.webContents.openDevTools();` is not called during application start up. This applies only in DEV mode which can be used mainly during `yarn watch` and during running the e2e tests. next pr will bring default setup of this env. var in `tests/src/runner/podman-desktop-runner.ts` during application start up. Resulting in a testing window without half of the space covered with dev tools.

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast 
explaining what is doing this PR -->

### What issues does this PR fix or reference?
#4983 #4968 
<!-- Include any related issues from Podman Desktop 
repository (or from another issue tracker). -->

### How to test this PR?
you can run tests without any change. `yarn test:e2e:smoke`. Check for the app during test run and verify that there is a dev tools opened. Then add `cross-env CLOSE_DEVTOOLS=true` at a beginning of a npm task `test:e2e:smoke:ruin` in `package.json`, task: `. If you then execute the tests, you should obeserve that dev tools were closed during testing.
<!-- Please explain steps to reproduce -->
