### PR TITLE
feat: deployments watch

### DIFF
--- a/packages/main/src/plugin/kubernetes-client.spec.ts
+++ b/packages/main/src/plugin/kubernetes-client.spec.ts
@@ -257,13 +257,13 @@ test('Check update with empty kubeconfig file', async () => {
 test('kube watcher', () => {
   const client = new TestKubernetesClient({} as ApiSenderType, configurationRegistry, fileSystemMonitoring, telemetry);
   client.setCurrentNamespace('fooNS');
-  let path;
+  const path: string[] = [];
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let errorHandler: any;
 
   // mock TestKubernetesClient.createWatchObject
   const watchMethodMock = vi.fn().mockImplementation((pathMethod, _ignore1, _ignore2, c) => {
-    path = pathMethod;
+    path.push(pathMethod);
     errorHandler = c;
     return Promise.resolve();
   });
@@ -274,7 +274,8 @@ test('kube watcher', () => {
 
   client.setupKubeWatcher();
 
-  expect(path).toBe('/api/v1/namespaces/fooNS/pods');
+  expect(path).toContain('/api/v1/namespaces/fooNS/pods');
+  expect(path).toContain('/apis/apps/v1/namespaces/fooNS/deployments');
   expect(errorHandler).toBeDefined();
 
   // call the error Handler with undefined

--- a/packages/main/src/plugin/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes-client.ts
@@ -232,10 +232,20 @@ export class KubernetesClient {
           '/api/v1/namespaces/' + ns + '/pods',
           {},
           () => this.apiSender.send('pod-event'),
-          err => console.warn('Kube watch ended', String(err)),
+          err => console.warn('Kube pod watch ended', String(err)),
         )
         .then(req => (this.kubeWatcher = req))
-        .catch((err: unknown) => console.error('Kube event error', err));
+        .catch((err: unknown) => console.error('Kube pod event error', err));
+
+      watch
+        .watch(
+          '/apis/apps/v1/namespaces/' + ns + '/deployments',
+          {},
+          () => this.apiSender.send('deployment-event'),
+          err => console.warn('Kube deployment watch ended', String(err)),
+        )
+        .then(req => (this.kubeWatcher = req))
+        .catch((err: unknown) => console.error('Kube deployment event error', err));
     }
   }
 

--- a/packages/renderer/src/stores/deployments.ts
+++ b/packages/renderer/src/stores/deployments.ts
@@ -23,7 +23,13 @@ import { findMatchInLeaves } from './search-util';
 import { EventStore } from './event-store';
 import DeploymentIcon from '../lib/images/DeploymentIcon.svelte';
 
-const windowEvents = ['extension-started', 'extension-stopped', 'provider-change', 'extensions-started'];
+const windowEvents = [
+  'extension-started',
+  'extension-stopped',
+  'provider-change',
+  'extensions-started',
+  'deployment-event',
+];
 const windowListeners = ['extensions-already-started'];
 
 let readyToUpdate = false;


### PR DESCRIPTION
### What does this PR do?

Adds a watch to deployments, identical to what we're doing for pods. This is not a long-term solution for #4974, but for now it is simple and responds to changes in deployments, allowing PR #4931 to proceed.

We clearly need to do #4974 at some point, but I think we should be able to do this for ingress/routes/services without issue? I could do all of these in this PR.

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

Part of #4366.

### How to test this PR?

`yarn test:main`