### PR TITLE
feat: toggle button group to select severity results to display

### DIFF
--- a/packages/renderer/src/lib/image/ImageDetailsCheck.spec.ts
+++ b/packages/renderer/src/lib/image/ImageDetailsCheck.spec.ts
@@ -52,7 +52,7 @@ test('expect to display wait message before to receive results', async () => {
     },
   });
 
-  vi.waitFor(() => {
+  await vi.waitFor(() => {
     const msg = screen.getByText(content => content.includes('Image analysis in progress'));
     expect(msg).toBeInTheDocument();
   });
@@ -93,7 +93,7 @@ test('expect to cancel when clicking the Cancel button', async () => {
     await fireEvent.click(abortBtn);
   });
 
-  vi.waitFor(() => {
+  await vi.waitFor(() => {
     const msg = screen.getByText(content => content.includes('Image analysis canceled'));
     expect(msg).toBeInTheDocument();
   });
@@ -175,7 +175,7 @@ test('expect to not cancel again when destroying the component after manual canc
     await fireEvent.click(abortBtn);
   });
 
-  vi.waitFor(() => {
+  await vi.waitFor(() => {
     const msg = screen.getByText(content => content.includes('Image analysis canceled'));
     expect(msg).toBeInTheDocument();
   });
@@ -223,12 +223,12 @@ test('expect to display results from image checker provider', async () => {
     },
   });
 
-  vi.waitFor(() => {
+  await vi.waitFor(() => {
     const msg = screen.getByText(content => content.includes('Image analysis complete'));
     expect(msg).toBeInTheDocument();
   });
 
-  vi.waitFor(() => {
+  await vi.waitFor(() => {
     const cell = screen.getByText('check1');
     expect(cell).toBeInTheDocument();
   });
@@ -270,7 +270,7 @@ test('expect to not cancel when destroying the component after displaying result
     },
   });
 
-  vi.waitFor(() => {
+  await vi.waitFor(() => {
     const cell = screen.getByText('check1');
     expect(cell).toBeInTheDocument();
   });

--- a/packages/renderer/src/lib/image/ImageDetailsCheck.svelte
+++ b/packages/renderer/src/lib/image/ImageDetailsCheck.svelte
@@ -123,10 +123,10 @@ function handleAbort() {
   <div class="flex flex-row" slot="header-info">
     <div class="w-full flex mb-4 space-x-4">
       <Fa size="24" icon="{faStethoscope}" />
-      {#if remainingProviders > 0}
-        <span>Image analysis in progress...</span>
-      {:else if aborted}
+      {#if aborted}
         <span>Image analysis canceled</span>
+      {:else if remainingProviders > 0}
+        <span>Image analysis in progress...</span>
       {:else}
         <span>Image analysis complete</span>
       {/if}

--- a/packages/renderer/src/lib/ui/ProviderResultPage.spec.ts
+++ b/packages/renderer/src/lib/ui/ProviderResultPage.spec.ts
@@ -1,0 +1,198 @@
+import '@testing-library/jest-dom/vitest';
+import { fireEvent, render, screen, within, cleanup } from '@testing-library/svelte';
+import { afterEach, describe, expect, test } from 'vitest';
+import ProviderResultPage from './ProviderResultPage.svelte';
+import type { CheckUI, ProviderUI } from './ProviderResultPage';
+
+function checkResultDisplayed(result: CheckUI) {
+  const res = screen.getByRole('row', { name: result.check.name + ' Reported by ' + result.provider.label });
+  expect(res).toBeInTheDocument();
+}
+
+function checkResultNotDisplayed(result: CheckUI) {
+  const res = screen.queryByRole('row', { name: result.check.name + ' Reported by ' + result.provider.label });
+  expect(res).not.toBeInTheDocument();
+}
+
+describe('test ProviderResultPage', async () => {
+  const providers: ProviderUI[] = [
+    {
+      info: {
+        id: 'provider1',
+        label: 'Provider 1',
+      },
+      state: 'running',
+    },
+    {
+      info: {
+        id: 'provider2',
+        label: 'Provider 2',
+      },
+      state: 'running',
+    },
+  ];
+
+  const results: CheckUI[] = [
+    {
+      provider: providers[0].info,
+      check: {
+        name: 'Check A1',
+        status: 'failed',
+        severity: 'critical',
+      },
+    },
+    {
+      provider: providers[0].info,
+      check: {
+        name: 'Check A2',
+        status: 'failed',
+        severity: 'high',
+      },
+    },
+    {
+      provider: providers[0].info,
+      check: {
+        name: 'Check A3',
+        status: 'failed',
+        severity: 'medium',
+      },
+    },
+    {
+      provider: providers[0].info,
+      check: {
+        name: 'Check A4',
+        status: 'failed',
+        severity: 'low',
+      },
+    },
+    {
+      provider: providers[0].info,
+      check: {
+        name: 'Check A5',
+        status: 'success',
+      },
+    },
+    {
+      provider: providers[1].info,
+      check: {
+        name: 'Check B1',
+        status: 'success',
+      },
+    },
+    {
+      provider: providers[1].info,
+      check: {
+        name: 'Check B2',
+        status: 'failed',
+        severity: 'critical',
+      },
+    },
+  ];
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  test('all providers are displayed as running', () => {
+    const checkProviderRunning = (text: string) => {
+      const providerEntry = screen.getByRole('row', { name: text });
+      expect(providerEntry).toBeInTheDocument();
+      const cb = within(providerEntry).queryByRole('checkbox');
+      expect(cb).not.toBeInTheDocument();
+      const spinner = within(providerEntry).queryByRole('img');
+      expect(spinner).toBeInTheDocument();
+    };
+
+    render(ProviderResultPage, {
+      providers: providers,
+    });
+
+    checkProviderRunning('Provider 1');
+    checkProviderRunning('Provider 2');
+  });
+
+  test('all providers are displayed as successful', () => {
+    const checkProviderSuccess = (text: string) => {
+      const providerEntry = screen.getByRole('row', { name: text });
+      expect(providerEntry).toBeInTheDocument();
+      const cb = within(providerEntry).queryByRole('checkbox');
+      expect(cb).toBeInTheDocument();
+      const spinner = within(providerEntry).queryByRole('img');
+      expect(spinner).not.toBeInTheDocument();
+    };
+
+    providers[0].state = 'success';
+    providers[1].state = 'success';
+    render(ProviderResultPage, {
+      providers: providers,
+    });
+
+    checkProviderSuccess('Provider 1');
+    checkProviderSuccess('Provider 2');
+  });
+
+  test('all results are displayed', () => {
+    providers[0].state = 'success';
+    providers[1].state = 'success';
+    render(ProviderResultPage, {
+      providers: providers,
+      results: results,
+    });
+    results.forEach(result => checkResultDisplayed(result));
+  });
+
+  test('results from selected providers -2nd- only are displayed', async () => {
+    providers[0].state = 'success';
+    providers[1].state = 'success';
+    render(ProviderResultPage, {
+      providers: providers,
+      results: results,
+    });
+
+    const providerEntry = screen.getByRole('row', { name: 'Provider 1' });
+    const cb = within(providerEntry).getByRole('checkbox');
+    await fireEvent.click(cb);
+    results.filter(r => r.provider.id === 'provider1').forEach(result => checkResultNotDisplayed(result));
+    results.filter(r => r.provider.id === 'provider2').forEach(result => checkResultDisplayed(result));
+    // TODO(feloy) This should not be necessary, as component is unmounted between tests
+    // but it fails to work correctly without it
+    await fireEvent.click(cb);
+    results.filter(r => r.provider.id === 'provider1').forEach(result => checkResultDisplayed(result));
+    results.filter(r => r.provider.id === 'provider2').forEach(result => checkResultDisplayed(result));
+  });
+
+  test('results from selected providers -1st- only are displayed', async () => {
+    providers[0].state = 'success';
+    providers[1].state = 'success';
+    render(ProviderResultPage, {
+      providers: providers,
+      results: results,
+    });
+
+    const providerEntry = screen.getByRole('row', { name: 'Provider 2' });
+    const cb = within(providerEntry).getByRole('checkbox');
+    await fireEvent.click(cb);
+    results.filter(r => r.provider.id === 'provider1').forEach(result => checkResultDisplayed(result));
+    results.filter(r => r.provider.id === 'provider2').forEach(result => checkResultNotDisplayed(result));
+    await fireEvent.click(cb);
+    results.filter(r => r.provider.id === 'provider1').forEach(result => checkResultDisplayed(result));
+    results.filter(r => r.provider.id === 'provider2').forEach(result => checkResultDisplayed(result));
+  });
+
+  test('results from selected severities only are displayed', async () => {
+    providers[0].state = 'success';
+    providers[1].state = 'success';
+    render(ProviderResultPage, {
+      providers: providers,
+      results: results,
+    });
+
+    const criticalButton = screen.getByRole('button', { name: 'Critical (2)' });
+    await fireEvent.click(criticalButton);
+    results.filter(r => r.check.severity === 'critical').forEach(result => checkResultNotDisplayed(result));
+    results.filter(r => r.check.severity !== 'critical').forEach(result => checkResultDisplayed(result));
+    await fireEvent.click(criticalButton);
+    results.filter(r => r.check.severity === 'critical').forEach(result => checkResultDisplayed(result));
+    results.filter(r => r.check.severity !== 'critical').forEach(result => checkResultDisplayed(result));
+  });
+});

--- a/packages/renderer/src/lib/ui/ProviderResultPage.svelte
+++ b/packages/renderer/src/lib/ui/ProviderResultPage.svelte
@@ -156,7 +156,7 @@ function onSeverityClicked(severity: 'critical' | 'high' | 'medium' | 'low' | 's
   <div class="h-full flex flex-row space-x-8">
     <div class="h-full overflow-y-auto w-1/3">
       {#each providers as provider}
-        <div class="rounded-lg bg-charcoal-700 mb-4 p-4 flex flex-col">
+        <div role="row" class="rounded-lg bg-charcoal-700 mb-4 p-4 flex flex-col">
           <div class="flex flex-row items-center">
             <span class="grow">{provider.info.label}</span>
             {#if provider.state === 'running'}
@@ -190,6 +190,7 @@ function onSeverityClicked(severity: 'critical' | 'high' | 'medium' | 'low' | 's
     <div class="h-full w-full pr-4 overflow-y-scroll pb-16">
       {#each filtered as result}
         <div
+          role="row"
           class="rounded-r-lg bg-charcoal-700 mb-4 mr-4 p-4 border-l-2"
           class:border-l-red-600="{result.check.severity === 'critical'}"
           class:border-l-amber-500="{result.check.severity === 'high'}"

--- a/packages/renderer/src/lib/ui/ProviderResultPage.svelte
+++ b/packages/renderer/src/lib/ui/ProviderResultPage.svelte
@@ -121,28 +121,33 @@ function onSeverityClicked(severity: 'critical' | 'high' | 'medium' | 'low' | 's
           selected="{true}"
           disabled="{countBySeverity.critical === 0}"
           icon="{faExclamationCircle}"
+          iconClass="text-red-600"
           on:click="{event => onSeverityClicked('critical', event.detail)}"
           >Critical ({countBySeverity.critical})</ToggleButton>
         <ToggleButton
           selected="{true}"
           disabled="{countBySeverity.high === 0}"
           icon="{faExclamationTriangle}"
+          iconClass="text-amber-500"
           on:click="{event => onSeverityClicked('high', event.detail)}">High ({countBySeverity.high})</ToggleButton>
         <ToggleButton
           selected="{true}"
           disabled="{countBySeverity.medium === 0}"
           icon="{faExclamationTriangle}"
+          iconClass="text-gray-800"
           on:click="{event => onSeverityClicked('medium', event.detail)}"
           >Medium ({countBySeverity.medium})</ToggleButton>
         <ToggleButton
           selected="{true}"
           disabled="{countBySeverity.low === 0}"
           icon="{faCircleMinus}"
+          iconClass="text-gray-500"
           on:click="{event => onSeverityClicked('low', event.detail)}">Low ({countBySeverity.low})</ToggleButton>
         <ToggleButton
           selected="{true}"
           disabled="{countBySeverity.success === 0}"
           icon="{faCheckSquare}"
+          iconClass="text-green-500"
           on:click="{event => onSeverityClicked('success', event.detail)}"
           >Passed ({countBySeverity.success})</ToggleButton>
       </ToggleButtonGroup>

--- a/packages/renderer/src/lib/ui/ToggleButton.svelte
+++ b/packages/renderer/src/lib/ui/ToggleButton.svelte
@@ -6,6 +6,9 @@ import Fa from 'svelte-fa';
 export let icon: IconDefinition;
 export let selected: boolean = false;
 export let disabled: boolean = false;
+export let iconClass: string = '';
+
+$: displayedIconClass = disabled ? '' : iconClass;
 
 const dispatch = createEventDispatcher();
 
@@ -22,14 +25,14 @@ function onclick() {
   class:hover:bg-charcoal-300="{!disabled && !selected}"
   class:bg-charcoal-200="{!disabled && selected}"
   class:hover:bg-charcoal-100="{!disabled && selected}"
-  class:bg-charcoal-600="{disabled}"
-  class:hover:bg-charcoal-600="{disabled}"
-  class:text-gray-400="{disabled}"
+  class:bg-charcoal-700="{disabled}"
+  class:hover:bg-charcoal-700="{disabled}"
+  class:text-gray-900="{disabled}"
   class:cursor-not-allowed="{disabled}"
   on:click="{onclick}">
   <div class="flex flex-row items-center space-x-2 px-2 py-1 text-xs">
     {#if icon}
-      <Fa icon="{icon}" />
+      <Fa icon="{icon}" class="{displayedIconClass}" />
     {/if}
     <span><slot /></span>
   </div>

--- a/packages/renderer/src/lib/ui/ToggleButton.svelte
+++ b/packages/renderer/src/lib/ui/ToggleButton.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+import type { IconDefinition } from '@fortawesome/free-solid-svg-icons';
+import { createEventDispatcher } from 'svelte';
+import Fa from 'svelte-fa';
+
+export let icon: IconDefinition;
+export let selected: boolean = false;
+export let disabled: boolean = false;
+
+const dispatch = createEventDispatcher();
+
+function onclick() {
+  selected = !selected;
+  dispatch('click', selected);
+}
+</script>
+
+<button
+  disabled="{disabled}"
+  class="first:rounded-l last:rounded-r"
+  class:bg-charcoal-500="{!disabled && !selected}"
+  class:hover:bg-charcoal-300="{!disabled && !selected}"
+  class:bg-charcoal-200="{!disabled && selected}"
+  class:hover:bg-charcoal-100="{!disabled && selected}"
+  class:bg-charcoal-600="{disabled}"
+  class:hover:bg-charcoal-600="{disabled}"
+  class:text-gray-400="{disabled}"
+  class:cursor-not-allowed="{disabled}"
+  on:click="{onclick}">
+  <div class="flex flex-row items-center space-x-2 px-2 py-1 text-xs">
+    {#if icon}
+      <Fa icon="{icon}" />
+    {/if}
+    <span><slot /></span>
+  </div>
+</button>

--- a/packages/renderer/src/lib/ui/ToggleButtonGroup.svelte
+++ b/packages/renderer/src/lib/ui/ToggleButtonGroup.svelte
@@ -1,0 +1,3 @@
+<div class="flex flex-row space-x-[1px]">
+  <slot />
+</div>


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

On the Image Checker screen, adds toggle buttons to filter results by severity.

TODO
- [x] add unit tests


### Screenshot/screencast of this PR

https://github.com/containers/podman-desktop/assets/9973512/33c17817-11cb-4816-bb56-df41535a5688

### What issues does this PR fix or reference?

#4985

### How to test this PR?

You can install a fake image checker from the image at quay.io/phmartin/fake-image-checker:v0.0.3 (sources: https://github.com/feloy/podman-desktop-extension-fake-image-checker)