### PR TITLE
chore(tests): changing test images to those used in demo

### DIFF
--- a/tests/src/model/pages/container-details-page.ts
+++ b/tests/src/model/pages/container-details-page.ts
@@ -92,4 +92,14 @@ export class ContainerDetailsPage extends BasePage {
     // after delete is successful we expect to see containers page
     return new ContainersPage(this.page);
   }
+
+  async checkMappedPort(port: string): Promise<boolean> {
+    await this.activateTab(ContainerDetailsPage.SUMMARY_TAB);
+    const summaryTable = this.getPage().getByRole('table');
+    const portsRow = summaryTable.locator('tr:has-text("Ports")');
+    const portsCell = portsRow.getByRole('cell').nth(1);
+    await portsCell.waitFor({ state: 'visible', timeout: 500 });
+    const portsText = await portsCell.innerText();
+    return portsText.includes(port);
+  }
 }

--- a/tests/src/model/pages/containers-page.ts
+++ b/tests/src/model/pages/containers-page.ts
@@ -73,13 +73,15 @@ export class ContainersPage extends MainPage {
     return (await this.getContainerRowByName(name)) !== undefined ? true : false;
   }
 
-  async openCreatePodPage(name: string): Promise<CreatePodsPage> {
-    const row = await this.getContainerRowByName(name);
-    if (row === undefined) {
-      throw Error('Container cannot be podified');
+  async openCreatePodPage(names: string[]): Promise<CreatePodsPage> {
+    for await (const containerName of names) {
+      const row = await this.getContainerRowByName(containerName);
+      if (row === undefined) {
+        throw Error('Container cannot be podified');
+      }
+      await row.getByRole('cell').nth(1).click();
     }
-    await row.getByRole('cell').nth(1).click();
-    await this.page.getByRole('button', { name: 'Create Pod with 1 selected items' }).click();
+    await this.page.getByRole('button', { name: `Create Pod with ${names.length} selected items` }).click();
     return new CreatePodsPage(this.page);
   }
 }

--- a/tests/src/model/pages/create-pod-page.ts
+++ b/tests/src/model/pages/create-pod-page.ts
@@ -41,7 +41,7 @@ export class CreatePodsPage extends BasePage {
     await this.podNameBox.fill(podName);
     await this.createPodButton.click();
     try {
-      await waitWhile(async () => await this.createPodButton.isVisible(), 10000, 700);
+      await waitWhile(async () => await this.createPodButton.isVisible(), 20000, 700);
     } catch (err) {
       const errLocator = this.page.getByRole('alert', { name: 'Error Message Content' });
       await errLocator.waitFor({ state: 'visible', timeout: 5000 });

--- a/tests/src/model/pages/run-image-page.ts
+++ b/tests/src/model/pages/run-image-page.ts
@@ -70,4 +70,15 @@ export class RunImagePage extends BasePage {
     }
     return containers;
   }
+
+  async setCustomPortMapping(customPortMapping: string): Promise<void> {
+    // add port mapping
+    await this.activateTab('Basic');
+    const addPortMappingButton = this.page.getByRole('button', { name: 'Add custom port mapping' });
+    await addPortMappingButton.click();
+    const hostPort = this.page.getByLabel('host port');
+    const containerPort = this.page.getByLabel('container port');
+    await hostPort.fill(customPortMapping.split(':')[0]);
+    await containerPort.fill(customPortMapping.split(':')[1]);
+  }
 }


### PR DESCRIPTION
### What does this PR do?
Updates the pod testing suite with images from the podman desktop demo application.
This application consists of [backend](https://quay.io/repository/podman-desktop-demo/podify-demo-backend) and [frontend](https://quay.io/repository/podman-desktop-demo/podify-demo-frontend) containers.

### Screenshot/screencast of this PR

![pods-frontend-container-exists](https://github.com/containers/podman-desktop/assets/75624842/2a609900-ad98-4756-ad67-d8f3a57bc99e)

![pods-pod-containers-exist](https://github.com/containers/podman-desktop/assets/75624842/1cbf29d9-d3f2-4224-8a24-3ff349dcb192)



### What issues does this PR fix or reference?

Closes [#4279](https://github.com/containers/podman-desktop/issues/4279)

### How to test this PR?

Run `yarn test:e2e:smoke` command.
