### PR TITLE
feat: add local version retrieval for cli API

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -2481,16 +2481,25 @@ declare module '@podman-desktop/api' {
     displayName: string;
     markdownDescription: string;
     images: ProviderImages;
+    path: string;
 
     /**
-     * Within your extension, it is reccommended to implement your own functionality to check the current
+     * Within your extension, it is recommended to implement your own functionality to check the current
      * version number of the CLI tool. For example, parsing the information from the CLI tool's `--version` flag.
      * Passing in path will also help to show where the CLI tool is expected to be installed.
-     * This is usually the ~/.local/share/containers/podman-desktop/extensions-storage directory.
+     *
+     * You can either pass in the current version in the `version` field or implement `getLocalVersion` function to
+     * return the current version of the CLI tool.
+     *
      * Note: The expected value should not include 'v'.
      */
-    version: string;
-    path: string;
+    version?: string;
+
+    /**
+     * Since it's difficult to determine how to retrieve the exact version of the local binary, we recommend the
+     * extension use the getLocalVersion function to retrieve the version of the CLI tool.
+     */
+    getLocalVersion: () => Promise<string>;
   }
 
   export type CliToolState = 'registered';
@@ -2506,6 +2515,7 @@ declare module '@podman-desktop/api' {
       id: string;
       label: string;
     };
+    getLocalVersion: () => Promise<string>;
   }
 
   /**

--- a/packages/main/src/plugin/cli-tool-registry.spec.ts
+++ b/packages/main/src/plugin/cli-tool-registry.spec.ts
@@ -114,8 +114,8 @@ suite('cli module', () => {
         displayName: 'tool-display-name',
         markdownDescription: 'markdown description',
         images: {},
-        version: '1.0.1',
         path: 'path/to/tool-name',
+        getLocalVersion: async () => '1.0.1',
       };
       const newCliTool = api.cli.createCliTool(options);
       expect(newCliTool.id).equals(`${extManifest.publisher}.${extManifest.name}.${options.name}`);
@@ -133,25 +133,25 @@ suite('cli module', () => {
         displayName: 'tool-display-name',
         markdownDescription: 'markdown description',
         images: {},
-        version: '1.0.1',
+        getLocalVersion: async () => '1.0.1',
         path: 'path/to/tool-name',
       };
       api.cli.createCliTool(options);
       expect(apiSender.send).toBeCalledWith('cli-tool-create');
     });
 
-    test('CLI Tool registry generates CliToolInfo array for created tools', () => {
+    test('CLI Tool registry generates CliToolInfo array for created tools', async () => {
       const api = extLoader.createApi('/path', extManifest);
       const options: CliToolOptions = {
         name: 'tool-name',
         displayName: 'tool-display-name',
         markdownDescription: 'markdown description',
         images: {},
-        version: '1.0.1',
+        getLocalVersion: async () => '1.0.1',
         path: 'path/to/tool-name',
       };
       const newCliTool = api.cli.createCliTool(options);
-      const infoList = cliToolRegistry.getCliToolInfos();
+      const infoList = await cliToolRegistry.getCliToolInfos();
       expect(infoList.length).equals(1);
       expect(infoList[0]).toMatchObject({
         id: newCliTool.id,
@@ -173,7 +173,7 @@ suite('cli module', () => {
         displayName: 'tool-display-name',
         markdownDescription: 'markdown description',
         images: {},
-        version: '1.0.1',
+        getLocalVersion: async () => '1.0.1',
         path: 'path/to/tool-name',
       };
       const newCliTool = api.cli.createCliTool(options);
@@ -181,21 +181,21 @@ suite('cli module', () => {
       expect(apiSender.send).toBeCalledWith('cli-tool-remove', newCliTool.id);
     });
 
-    test('removes cli tool from the registry', () => {
+    test('removes cli tool from the registry', async () => {
       const api = extLoader.createApi('/path', extManifest);
       const options: CliToolOptions = {
         name: 'tool-name',
         displayName: 'tool-display-name',
         markdownDescription: 'markdown description',
         images: {},
-        version: '1.0.1',
+        getLocalVersion: async () => '1.0.1',
         path: 'path/to/tool-name',
       };
       const newCliTool = api.cli.createCliTool(options);
-      const infoListAfterCreate = cliToolRegistry.getCliToolInfos();
+      const infoListAfterCreate = await cliToolRegistry.getCliToolInfos();
       expect(infoListAfterCreate.length).equals(1);
       newCliTool.dispose();
-      const infoListAfterDispose = cliToolRegistry.getCliToolInfos();
+      const infoListAfterDispose = await cliToolRegistry.getCliToolInfos();
       expect(infoListAfterDispose.length).equals(0);
     });
   });

--- a/packages/main/src/plugin/cli-tool-registry.ts
+++ b/packages/main/src/plugin/cli-tool-registry.ts
@@ -36,6 +36,17 @@ export class CliToolImpl implements CliTool, Disposable {
     this.id = `${extensionInfo.id}.${_options.name}`;
   }
 
+  // Use the getLocalVersion function from _options
+  async getLocalVersion(): Promise<string> {
+    try {
+      // The path is already known to this class instance
+      return await this._options.getLocalVersion();
+    } catch (error) {
+      console.error(`Error getting local version for CLI tool at path ${this.path}:`, error);
+      throw error;
+    }
+  }
+
   get state() {
     return this._state;
   }
@@ -90,8 +101,11 @@ export class CliToolRegistry {
     this.apiSender.send('cli-tool-remove', cliTool.id);
   }
 
-  getCliToolInfos(): CliToolInfo[] {
-    return Array.from(this.cliTools.values()).map(cliTool => {
+  async getCliToolInfos(): Promise<CliToolInfo[]> {
+    const cliToolsArray = Array.from(this.cliTools.values());
+
+    // Map each cliTool to a promise that resolves to its info
+    const cliToolInfoPromises = cliToolsArray.map(async cliTool => {
       return {
         id: cliTool.id,
         name: cliTool.name,
@@ -100,9 +114,12 @@ export class CliToolRegistry {
         state: cliTool.state,
         images: cliTool.images,
         extensionInfo: cliTool.extensionInfo,
-        version: cliTool.version,
+        version: await cliTool.getLocalVersion(),
         path: cliTool.path,
       };
     });
+
+    // Wait for all promises to resolve
+    return Promise.all(cliToolInfoPromises);
   }
 }


### PR DESCRIPTION
feat: add local version retrieval for cli API

### What does this PR do?

* Adds the ability for the Podman Desktop API to retrieve the local
  binary for the extension via a defined function.
* Fixes the problem with Compose extension only showing the local
  storage binary version rather than the system-wide installed one.
  
This is required so that we can update the version reactively / see the changes locally so that when we update the binary, it's reactively updated within Podman Desktop.

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast
explaining what is doing this PR -->

N/A

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Part of https://github.com/containers/podman-desktop/issues/4689

Closes https://github.com/containers/podman-desktop/issues/5008

### How to test this PR?

Go to CLI screen in settings and you should see the appropriate CLI
version.

You can confirm it is the correct version shown by typing `podman
compose version` into the CLI, or `kubectl version`.

<!-- Please explain steps to reproduce -->

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
