### PR TITLE
Table column mapping and reuse

### DIFF
--- a/packages/renderer/src/lib/table/SimpleColumn.spec.ts
+++ b/packages/renderer/src/lib/table/SimpleColumn.spec.ts
@@ -1,0 +1,33 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+import { test, expect } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+
+import SimpleColumn from './SimpleColumn.svelte';
+
+test('Expect simple column styling', async () => {
+  const obj = 'Test';
+  render(SimpleColumn, { object: obj });
+
+  const text = screen.getByText(obj);
+  expect(text).toBeInTheDocument();
+  expect(text).toHaveClass('text-sm');
+  expect(text).toHaveClass('text-gray-700');
+});

--- a/packages/renderer/src/lib/table/SimpleColumn.svelte
+++ b/packages/renderer/src/lib/table/SimpleColumn.svelte
@@ -2,4 +2,6 @@
 export let object: any;
 </script>
 
-{object.name}
+<div class="text-sm text-gray-700">
+  {object}
+</div>

--- a/packages/renderer/src/lib/table/SimpleColumn.svelte
+++ b/packages/renderer/src/lib/table/SimpleColumn.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-export let object: any;
+export let object: string;
 </script>
 
 <div class="text-sm text-gray-700">

--- a/packages/renderer/src/lib/table/Table.svelte
+++ b/packages/renderer/src/lib/table/Table.svelte
@@ -186,7 +186,9 @@ function setGridColumns() {
                 : 'justify-self-start'} self-center overflow-hidden max-w-full"
             role="cell">
             {#if column.info.renderer}
-              <svelte:component this="{column.info.renderer}" object="{object}" />
+              <svelte:component
+                this="{column.info.renderer}"
+                object="{column.info.renderMapping ? column.info.renderMapping(object) : object}" />
             {/if}
           </div>
         {/each}

--- a/packages/renderer/src/lib/table/Table.svelte
+++ b/packages/renderer/src/lib/table/Table.svelte
@@ -188,7 +188,7 @@ function setGridColumns() {
             {#if column.info.renderer}
               <svelte:component
                 this="{column.info.renderer}"
-                object="{column.info.renderMapping ? column.info.renderMapping(object) : object}" />
+                object="{column.info.renderMapping?.(object) ?? object}" />
             {/if}
           </div>
         {/each}

--- a/packages/renderer/src/lib/table/TestColumnAge.svelte
+++ b/packages/renderer/src/lib/table/TestColumnAge.svelte
@@ -1,5 +1,0 @@
-<script lang="ts">
-export let object: any;
-</script>
-
-{object.age}

--- a/packages/renderer/src/lib/table/TestColumnId.svelte
+++ b/packages/renderer/src/lib/table/TestColumnId.svelte
@@ -1,5 +1,0 @@
-<script lang="ts">
-export let object: any;
-</script>
-
-{object.id}

--- a/packages/renderer/src/lib/table/TestTable.svelte
+++ b/packages/renderer/src/lib/table/TestTable.svelte
@@ -18,29 +18,29 @@ const people: Person[] = [
   { id: 3, name: 'Charlie', age: 43 },
 ];
 
-const idCol: Column<Person> = new Column('Id', {
+const idCol: Column<Person, string> = new Column('Id', {
   align: 'right',
-  renderMapping: obj => obj.id,
+  renderMapping: obj => obj.id.toString(),
   renderer: SimpleColumn,
   comparator: (a, b) => a.id - b.id,
 });
 
-const nameCol: Column<Person> = new Column('Name', {
+const nameCol: Column<Person, string> = new Column('Name', {
   width: '3fr',
   renderMapping: obj => obj.name,
   renderer: SimpleColumn,
   comparator: (a, b) => a.name.localeCompare(b.name),
 });
 
-const ageCol: Column<Person> = new Column('Age', {
+const ageCol: Column<Person, string> = new Column('Age', {
   align: 'right',
-  renderMapping: obj => obj.age,
+  renderMapping: obj => obj.age.toString(),
   renderer: SimpleColumn,
   comparator: (a, b) => a.age - b.age,
   initialOrder: 'descending',
 });
 
-const columns: Column<Person>[] = [idCol, nameCol, ageCol];
+const columns: Column<Person, string>[] = [idCol, nameCol, ageCol];
 
 const row = new Row<Person>({
   selectable: person => person.age < 50,

--- a/packages/renderer/src/lib/table/TestTable.svelte
+++ b/packages/renderer/src/lib/table/TestTable.svelte
@@ -1,9 +1,7 @@
 <script lang="ts">
 import Table from './Table.svelte';
-import TestColumnId from './TestColumnId.svelte';
-import TestColumnName from './TestColumnName.svelte';
-import TestColumnAge from './TestColumnAge.svelte';
 import { Column, Row } from './table';
+import SimpleColumn from './SimpleColumn.svelte';
 
 let table: Table;
 let selectedItemsNumber: number;
@@ -22,19 +20,22 @@ const people: Person[] = [
 
 const idCol: Column<Person> = new Column('Id', {
   align: 'right',
-  renderer: TestColumnId,
+  renderMapping: obj => obj.id,
+  renderer: SimpleColumn,
   comparator: (a, b) => a.id - b.id,
 });
 
 const nameCol: Column<Person> = new Column('Name', {
   width: '3fr',
-  renderer: TestColumnName,
+  renderMapping: obj => obj.name,
+  renderer: SimpleColumn,
   comparator: (a, b) => a.name.localeCompare(b.name),
 });
 
 const ageCol: Column<Person> = new Column('Age', {
   align: 'right',
-  renderer: TestColumnAge,
+  renderMapping: obj => obj.age,
+  renderer: SimpleColumn,
   comparator: (a, b) => a.age - b.age,
   initialOrder: 'descending',
 });

--- a/packages/renderer/src/lib/table/table.ts
+++ b/packages/renderer/src/lib/table/table.ts
@@ -35,6 +35,14 @@ export interface ColumnInformation<Type> {
   readonly width?: string;
 
   /**
+   * Map the source object to another type for rendering. Allows
+   * easier reuse and sharing of renderers by converting to simple
+   * types (e.g. rendering 'string' instead of 'type.name') or
+   * converting to a different type.
+   */
+  readonly renderMapping?: (object: Type) => any;
+
+  /**
    * Svelte component, renderer for each cell in the column.
    * The component must have a property 'object' that has the
    * same type as the Column.

--- a/packages/renderer/src/lib/table/table.ts
+++ b/packages/renderer/src/lib/table/table.ts
@@ -19,7 +19,7 @@
 /**
  * Options to be used when creating a Column.
  */
-export interface ColumnInformation<Type> {
+export interface ColumnInformation<Type, RenderType = Type> {
   /**
    * Column alignment, one of 'left', 'center', or 'right'.
    *
@@ -40,7 +40,7 @@ export interface ColumnInformation<Type> {
    * types (e.g. rendering 'string' instead of 'type.name') or
    * converting to a different type.
    */
-  readonly renderMapping?: (object: Type) => any;
+  readonly renderMapping?: (object: Type) => RenderType;
 
   /**
    * Svelte component, renderer for each cell in the column.
@@ -73,10 +73,10 @@ export interface ColumnInformation<Type> {
 /**
  * A table Column.
  */
-export class Column<Type> {
+export class Column<Type, RenderType = Type> {
   constructor(
     readonly title: string,
-    readonly info: ColumnInformation<Type>,
+    readonly info: ColumnInformation<Type, RenderType>,
   ) {}
 }
 

--- a/packages/renderer/src/lib/volume/VolumeColumnAge.svelte
+++ b/packages/renderer/src/lib/volume/VolumeColumnAge.svelte
@@ -1,9 +1,0 @@
-<script lang="ts">
-import type { VolumeInfoUI } from './VolumeInfoUI';
-
-export let object: VolumeInfoUI;
-</script>
-
-<div class="text-sm text-gray-700">
-  {object.age}
-</div>

--- a/packages/renderer/src/lib/volume/VolumeColumnSize.svelte
+++ b/packages/renderer/src/lib/volume/VolumeColumnSize.svelte
@@ -1,9 +1,0 @@
-<script lang="ts">
-import type { VolumeInfoUI } from './VolumeInfoUI';
-
-export let object: VolumeInfoUI;
-</script>
-
-<div class="text-sm text-gray-700">
-  {object.humanSize}
-</div>

--- a/packages/renderer/src/lib/volume/VolumesList.svelte
+++ b/packages/renderer/src/lib/volume/VolumesList.svelte
@@ -22,8 +22,7 @@ import { Column, Row } from '../table/table';
 import VolumeColumnStatus from './VolumeColumnStatus.svelte';
 import VolumeColumnName from './VolumeColumnName.svelte';
 import VolumeColumnEnvironment from './VolumeColumnEnvironment.svelte';
-import VolumeColumnSize from './VolumeColumnSize.svelte';
-import VolumeColumnAge from './VolumeColumnAge.svelte';
+import SimpleColumn from '../table/SimpleColumn.svelte';
 import VolumeColumnActions from './VolumeColumnActions.svelte';
 
 export let searchTerm = '';
@@ -191,13 +190,15 @@ let envColumn = new Column<VolumeInfoUI>('Environment', {
 });
 
 let ageColumn = new Column<VolumeInfoUI>('Age', {
-  renderer: VolumeColumnAge,
+  renderMapping: object => object.age,
+  renderer: SimpleColumn,
   comparator: (a, b) => moment().diff(a.created) - moment().diff(b.created),
 });
 
 let sizeColumn = new Column<VolumeInfoUI>('Size', {
   align: 'right',
-  renderer: VolumeColumnSize,
+  renderMapping: object => object.humanSize,
+  renderer: SimpleColumn,
   comparator: (a, b) => a.size - b.size,
   initialOrder: 'descending',
 });

--- a/packages/renderer/src/lib/volume/VolumesList.svelte
+++ b/packages/renderer/src/lib/volume/VolumesList.svelte
@@ -189,13 +189,13 @@ let envColumn = new Column<VolumeInfoUI>('Environment', {
   comparator: (a, b) => a.engineName.localeCompare(b.engineName),
 });
 
-let ageColumn = new Column<VolumeInfoUI>('Age', {
+let ageColumn = new Column<VolumeInfoUI, string>('Age', {
   renderMapping: object => object.age,
   renderer: SimpleColumn,
   comparator: (a, b) => moment().diff(a.created) - moment().diff(b.created),
 });
 
-let sizeColumn = new Column<VolumeInfoUI>('Size', {
+let sizeColumn = new Column<VolumeInfoUI, string>('Size', {
   align: 'right',
   renderMapping: object => object.humanSize,
   renderer: SimpleColumn,
@@ -203,7 +203,7 @@ let sizeColumn = new Column<VolumeInfoUI>('Size', {
   initialOrder: 'descending',
 });
 
-const columns: Column<VolumeInfoUI>[] = [
+const columns: Column<VolumeInfoUI, VolumeInfoUI | string>[] = [
   statusColumn,
   nameColumn,
   envColumn,


### PR DESCRIPTION
### What does this PR do?

It has come up a couple times so I thought I should make a proposal for how I think we should share column renderers between tables. IMHO we have three cases:
1. Type-specific column rendering like Image name. These should continue to be type-specific as today.
2. Generic columns that really just need to (e.g.) render a string in a certain way.
3. The middle ground where it's a little more complex, or maybe you need to render a couple properties.

This PR adds a simple type-mapping function to directly support #2, and applies it to VolumeList.

For the middle ground, I think we're going to have convenient cases where objects used in two tables have the same property types & names (e.g. { id: string, some-prop: number}) and we can just render those, and other cases where maybe the renderer should use another type (e.g. Condition) or one of the objects has a different property name. Again, this PR provides a simple way for tables to do whatever mapping is required.

Based on top of #5005 assuming that would merge soon.

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

Fixes #5002. We would share more columns as we add other tables that would use them.

### How to test this PR?

`yarn test:renderer`