### PR TITLE
chore(ui,test): add aria functionality to SettingsPage

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesExtensionList.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesExtensionList.svelte
@@ -83,7 +83,10 @@ async function updateExtension(extension: ExtensionInfo, ociUri: string) {
       <h1 class="text-lg mb-2">Install a new extension from OCI Image</h1>
 
       <div class="flex flex-col w-full">
-        <div class="flex flex-row mb-2 w-full space-x-8 items-center">
+        <div
+          class="flex flex-row mb-2 w-full space-x-8 items-center"
+          role="region"
+          aria-label="Install Extension From OCI">
           <input
             name="ociImage"
             id="ociImage"
@@ -117,11 +120,11 @@ async function updateExtension(extension: ExtensionInfo, ociUri: string) {
       </div>
     </div>
     <div class="bg-charcoal-600 mt-5 rounded-md p-3">
-      <table class="min-w-full">
+      <table class="min-w-full" aria-label="Installed Extensions">
         <tbody>
           {#each $extensionInfos as extension}
-            <tr class="border-y border-gray-900">
-              <td class="px-6 py-2">
+            <tr class="border-y border-gray-900" aria-label="{extension.name}">
+              <td class="px-6 py-2" aria-label="Extension Details">
                 <div class="flex items-center">
                   <div class="flex-shrink-0 h-10 w-10 py-3" title="Extension {extension.name} is {extension.state}">
                     <Fa
@@ -132,7 +135,7 @@ async function updateExtension(extension: ExtensionInfo, ociUri: string) {
                       icon="{faPuzzlePiece}" />
                   </div>
                   <div class="ml-4">
-                    <div class="flex flex-row">
+                    <div class="flex flex-row" aria-label="Extension Details">
                       <div class="text-sm text-gray-300">
                         {extension.displayName}
                         {extension.removable ? '(user)' : '(default extension)'}
@@ -142,13 +145,16 @@ async function updateExtension(extension: ExtensionInfo, ociUri: string) {
                           <button
                             class="mx-2 px-2 text-xs font-medium text-center text-white bg-violet-600 rounded-sm hover:bg-dustypurple-800 focus:ring-2 focus:outline-none focus:ring-dustypurple-700"
                             title="Update to {extension.update.version}"
+                            aria-label="Extension Action Update"
                             on:click="{() => updateExtension(extension, extensionUpdate.ociUri)}">
                             Update</button>
                         {/if}
                       </div>
                     </div>
-                    <div class="flex flex-row">
-                      <div class="text-sm text-gray-700 italic">{extension.description}</div>
+                    <div class="flex flex-row" aria-label="Extension Description">
+                      <div class="text-sm text-gray-700 italic">
+                        {extension.description}
+                      </div>
                     </div>
                     <div class="flex">
                       <ConnectionStatus status="{extension.state}" />
@@ -156,15 +162,17 @@ async function updateExtension(extension: ExtensionInfo, ociUri: string) {
                   </div>
                 </div>
               </td>
-              <td class="px-2 py-2 whitespace-nowrap">
+              <td class="px-2 py-2 whitespace-nowrap" aria-label="Extension Actions">
                 <div class="flex flex-row justify-end">
                   <button
                     title="Start extension"
+                    aria-label="Extension Action Start"
                     on:click="{() => startExtension(extension)}"
                     class="{buttonClass}"
                     class:hidden="{extension.state !== 'stopped'}"><Fa class="h-4 w-4" icon="{faPlay}" /></button>
                   <button
                     title="Stop extension"
+                    aria-label="Extension Action Stop"
                     class="{buttonClass}"
                     on:click="{() => stopExtension(extension)}"
                     hidden
@@ -174,6 +182,7 @@ async function updateExtension(extension: ExtensionInfo, ociUri: string) {
                     {#if extension.state === 'stopped'}
                       <button
                         title="Remove extension"
+                        aria-label="Extension Action Remove"
                         class="{buttonClass}"
                         on:click="{() => removeExtension(extension)}"><Fa class="h-4 w-4" icon="{faTrash}" /></button>
                     {:else}

--- a/packages/renderer/src/lib/preferences/SettingsPage.svelte
+++ b/packages/renderer/src/lib/preferences/SettingsPage.svelte
@@ -3,18 +3,20 @@ export let title: string;
 </script>
 
 <div class="flex flex-col min-w-full h-full" role="region" aria-label="{title}">
-  <div class="min-w-full px-5 py-4" role="region" aria-label="header">
+  <div class="min-w-full px-5 py-4" role="region" aria-label="Header">
     <div class="flex flex-row">
       <div class="grow">
-        <p class="capitalize text-xl">{title}</p>
-        <p class="text-sm text-gray-700"><slot name="subtitle"><br /></slot></p>
+        <div class="capitalize text-xl" role="heading" aria-level="1" aria-label="Title">{title}</div>
+        <div class="text-sm text-gray-700" role="heading" aria-level="2" aria-label="Subtitle">
+          <slot name="subtitle"><br /></slot>
+        </div>
       </div>
       <slot name="actions" />
     </div>
 
     <slot name="header" />
   </div>
-  <div class="flex flex-row min-w-full h-full px-5 py-4 overflow-y-auto" role="region" aria-label="content">
+  <div class="flex flex-row min-w-full h-full px-5 py-4 overflow-y-auto" role="region" aria-label="Content">
     <div class="flex flex-col grow max-w-[905px] mx-auto">
       <slot />
     </div>

--- a/tests/src/model/pages/settings-extensions-page.ts
+++ b/tests/src/model/pages/settings-extensions-page.ts
@@ -36,15 +36,15 @@ export class SettingsExtensionsPage extends SettingsPage {
   }
 
   public getExtensionRowFromTable(extensionName: string): Locator {
-    return this.extensionsTable.getByRole('row').filter({ hasText: extensionName });
+    return this.extensionsTable.getByRole('row', { name: extensionName });
   }
 
   public getExtensionStopButton(extensionRow: Locator): Locator {
-    return extensionRow.getByRole('button', { name: 'Stop extension' });
+    return extensionRow.getByLabel('Extension Action Stop');
   }
 
   public getExtensionStartButton(extensionRow: Locator): Locator {
-    return extensionRow.getByRole('button', { name: 'Start extension' });
+    return extensionRow.getByLabel('Extension Action Start');
   }
 
   public getFeaturedExtension(extensionName: string): Locator {

--- a/tests/src/podman-extension-smoke.spec.ts
+++ b/tests/src/podman-extension-smoke.spec.ts
@@ -28,7 +28,7 @@ import type { SettingsBar } from './model/pages/settings-bar';
 import { SettingsExtensionsPage } from './model/pages/settings-extensions-page';
 import { ExtensionPage } from './model/pages/extension-page';
 
-const SETTINGS_EXTENSIONS_TABLE_PODMAN_TITLE: string = 'Podman (default extension)';
+const SETTINGS_EXTENSIONS_TABLE_PODMAN_TITLE: string = 'podman';
 const SETTINGS_EXTENSIONS_TABLE_EXTENSION_STATUS_LABEL: string = 'connection-status-label';
 const PODMAN_EXTENSION_STATUS_RUNNING: string = 'RUNNING';
 const PODMAN_EXTENSION_STATUS_OFF: string = 'OFF';


### PR DESCRIPTION
### What does this PR do?

* Adds ARIA functionality to SettingsPage and PreferencesExtensionList

### Screenshot/screencast of this PR
#### Left side is modified, right side is current main
![Screenshot_20231128_174533c](https://github.com/containers/podman-desktop/assets/16451875/fcfdd3d5-6302-4f02-9c85-f8a35cf37971)
![Screenshot_20231128_174508c](https://github.com/containers/podman-desktop/assets/16451875/2468dba6-e8c0-4209-8e97-fb85ec2c7517)


<!-- Please include a screenshot or a screencast 
explaining what is doing this PR -->

### What issues does this PR fix or reference?
#4760 

<!-- Include any related issues from Podman Desktop 
repository (or from another issue tracker). -->

### How to test this PR?
* run `yarn --frozen-lockfile`
* add `"test:e2e:smoke:podman": "xvfb-maybe --auto-servernum --server-args='-screen 0 1280x960x24' -- vitest run tests/src/podman-extension-smoke.spec.ts --threads false",` to package.json
* run `yarn run test:e2e:smoke:podman`

<!-- Please explain steps to reproduce -->
