### PR TITLE
fix: refresh list of kube contexts immediately after delete / change current

### DIFF
--- a/packages/main/src/plugin/kubernetes-client-kubeconfig.spec.ts
+++ b/packages/main/src/plugin/kubernetes-client-kubeconfig.spec.ts
@@ -40,6 +40,8 @@ describe('context tests', () => {
 
   let client: TestKubernetesClient;
 
+  const apiSendMock = vi.fn();
+
   function createClient(): TestKubernetesClient {
     const configurationRegistry: ConfigurationRegistry = {} as unknown as ConfigurationRegistry;
     const fileSystemMonitoring: FilesystemMonitoring = new FilesystemMonitoring();
@@ -47,7 +49,7 @@ describe('context tests', () => {
       track: vi.fn().mockImplementation(async () => {}),
     } as unknown as Telemetry;
     const apiSender: ApiSenderType = {
-      send: () => {},
+      send: apiSendMock,
       receive: () => {},
     };
 
@@ -76,6 +78,8 @@ describe('context tests', () => {
     expect(contexts[0]).toStrictEqual(originalContexts[0]);
     expect(client.getContexts().length).toBe(1);
     expect(client.getContexts()[0]).toStrictEqual(originalContexts[0]);
+    expect(apiSendMock).toHaveBeenCalledTimes(1);
+    expect(apiSendMock).toHaveBeenCalledWith('kubernetes-context-update');
   });
 
   test('should delete context from config and related user and cluster not referenced anymore', async () => {
@@ -134,5 +138,8 @@ describe('context tests', () => {
     expect(contexts[0].currentContext).toBe(false);
     // The second context should be true since it is the current context
     expect(contexts[1].currentContext).toBe(true);
+
+    expect(apiSendMock).toHaveBeenCalledTimes(1);
+    expect(apiSendMock).toHaveBeenCalledWith('kubernetes-context-update');
   });
 });

--- a/packages/main/src/plugin/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes-client.ts
@@ -332,6 +332,9 @@ export class KubernetesClient {
     await this.saveKubeConfig(newConfig);
     // the config is saved back only if saving the file succeeds
     this.kubeConfig = newConfig;
+    // We send an update event here, even if another one will be sent after the file change is detected,
+    // because that one can get some time to be sent (as cluster connectivity will be tested)
+    this.apiSender.send('kubernetes-context-update');
     return this.getContexts();
   }
 
@@ -354,6 +357,9 @@ export class KubernetesClient {
     // If saving the file succeeds then set the kubeConfig to the newConfig & set the current context name.
     this.kubeConfig = newConfig;
     this.currentContextName = contextName;
+    // We send an update event here, even if another one will be sent after the file change is detected,
+    // because that one can get some time to be sent (as cluster connectivity will be tested)
+    this.apiSender.send('kubernetes-context-update');
   }
 
   async saveKubeConfig(config: KubeConfig) {


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

This PR makes the kubrnetes client send an update event immediately after a context is deleted or the current context is changed.

Another event is sent later, after the .config file change is detected and the content is analyzed, but this event can come very late, because the network connectivity is tested for the current context, which can get some time.


### What issues does this PR fix or reference?

Fixes #5014 

### How to test this PR?

Have a .kube file referencing non accessible clusters, and set the current context for a context with a non accesisble cluster. Then try to delete another context. The deleted context should be deleted immediately from the list.
