### PR TITLE
chore: settings nav height

### DIFF
--- a/packages/renderer/src/lib/preferences/SettingsNavItem.svelte
+++ b/packages/renderer/src/lib/preferences/SettingsNavItem.svelte
@@ -26,11 +26,9 @@ function rotate(node: unknown, { clockwise = true }) {
 
 <a class="no-underline" href="{href}" aria-label="{title}" on:click="{() => (expanded = !expanded)}">
   <div
-    class="flex w-full pr-1 justify-between items-center cursor-pointer border-l-[4px] border-charcoal-600"
+    class="flex w-full pr-1 py-2 justify-between items-center cursor-pointer border-l-[4px] border-charcoal-600"
     class:text-white="{selected}"
-    class:py-3="{!child}"
     class:pl-3="{!child}"
-    class:py-2="{child}"
     class:pl-4="{child}"
     class:leading-none="{child}"
     class:text-sm="{child}"


### PR DESCRIPTION
### What does this PR do?

When we dropped PatternFly we 'lost' one style: "line-height: 0.9rem". Among other things, this has made the Settings navigation take up a lot of vertical space. Instead of setting the line height back, this just makes the padding consistent between parent and child elements, which simplifies the code slightly and has the same effect.

### Screenshot/screencast of this PR

1.5.3:

<img width="308" alt="Screenshot 2023-11-28 at 11 25 41 PM" src="https://github.com/containers/podman-desktop/assets/19958075/1f9573f4-6350-4e2a-b0cd-fc916868283e">

Before:

<img width="283" alt="Screenshot 2023-11-28 at 11 28 55 PM" src="https://github.com/containers/podman-desktop/assets/19958075/abc71f9e-4a77-401c-9adb-d305678de696">

After:

<img width="284" alt="Screenshot 2023-11-28 at 11 31 50 PM" src="https://github.com/containers/podman-desktop/assets/19958075/533909ff-69fd-43c4-84e3-8fb40dce75b0">

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Just look at Settings nav.