### PR TITLE
chore: button height

### DIFF
--- a/packages/renderer/src/lib/ui/Button.svelte
+++ b/packages/renderer/src/lib/ui/Button.svelte
@@ -14,7 +14,7 @@ export let selected: boolean | undefined = undefined;
 $: if (selected !== undefined && type !== 'tab') {
   console.error('property selected can be used with type=tab only');
 }
-export let padding: string = 'px-4 py-[6px]';
+export let padding: string = 'px-4 py-[5px]';
 
 let iconType: string | undefined = undefined;
 


### PR DESCRIPTION
### What does this PR do?

When we dropped PatternFly we 'lost' one style: "line-height: 0.9rem". This has made Buttons take up more vertical space, and caused some minor layout issues: e.g. at some font sizes, selecting a container/ pod/image/volume will make everything jump by a few pixels because the vertical button size is now bigger than the vertical height of the search bar.

Instead of setting the line height back, this just reduces the padding slightly which has the same effect.

### Screenshot/screencast of this PR

1.5.3 (58px):
<img width="448" alt="Screenshot 2023-11-28 at 11 26 11 PM" src="https://github.com/containers/podman-desktop/assets/19958075/ab06e6ea-97ed-4bbb-a32f-67b36abf1888">

Before (63px):

<img width="264" alt="Screenshot 2023-11-28 at 11 29 30 PM" src="https://github.com/containers/podman-desktop/assets/19958075/c3b19912-425f-4522-810f-5acfbc490885">

After (59px):

<img width="261" alt="Screenshot 2023-11-28 at 11 38 27 PM" src="https://github.com/containers/podman-desktop/assets/19958075/30cf3851-bcbb-4f86-898a-0bb7f690717a">

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Just check the look of buttons in various pages.