### PR TITLE
feat: allow to show new/update cli version

### DIFF
--- a/packages/main/src/plugin/api/cli-tool-info.ts
+++ b/packages/main/src/plugin/api/cli-tool-info.ts
@@ -21,6 +21,7 @@ import type { CliToolState, ProviderImages } from '@podman-desktop/api';
 export type CliToolExtensionInfo = {
   id: string;
   label: string;
+  icon?: string | { light: string; dark: string };
 };
 
 export interface CliToolInfo {

--- a/packages/renderer/src/lib/preferences/PreferencesCliTool.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesCliTool.spec.ts
@@ -1,0 +1,163 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import '@testing-library/jest-dom/vitest';
+import { afterEach, expect, suite, test, vi } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import type { CliToolInfo } from '../../../../main/src/plugin/api/cli-tool-info';
+import userEvent from '@testing-library/user-event';
+import PreferencesCliTool from './PreferencesCliTool.svelte';
+import { beforeEach } from 'node:test';
+
+const cliToolInfoItem1: CliToolInfo = {
+  id: 'ext-id.tool-name1',
+  name: 'tool-name1',
+  description: 'markdown description1',
+  displayName: 'tools-display-name1',
+  state: 'registered',
+  extensionInfo: {
+    id: 'ext-id1',
+    label: 'ext-label1',
+  },
+  path: 'path/to/tool-name-1',
+};
+
+const cliToolInfoItem2: CliToolInfo = {
+  id: 'ext-id.tool-name2',
+  name: 'tool-name2',
+  description: 'markdown description2',
+  displayName: 'tools-display-name2',
+  state: 'registered',
+  extensionInfo: {
+    id: 'ext-id2',
+    label: 'ext-label2',
+  },
+  version: '1.0.1',
+  path: 'path/to/tool-name-2',
+};
+
+const cliToolInfoItem3: CliToolInfo = {
+  id: 'ext-id.tool-name3',
+  name: 'tool-name3',
+  description: 'markdown description3',
+  displayName: 'tools-display-name3',
+  state: 'registered',
+  extensionInfo: {
+    id: 'ext-id3',
+    label: 'ext-label3',
+  },
+  version: '1.0.1',
+  path: 'path/to/tool-name-3',
+  newVersion: '2.0.1',
+};
+
+const updateCliToolMock = vi.fn();
+beforeEach(() => {
+  (window as any).updateCliTool = updateCliToolMock;
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+suite('CLI Tool item', () => {
+  test('check tool infos are displayed as expected if version is not specified', () => {
+    render(PreferencesCliTool, {
+      cliTool: cliToolInfoItem1,
+    });
+    const nameElement = screen.getByLabelText('cli-name');
+    expect(nameElement).toBeDefined();
+    expect(nameElement.textContent).equal(cliToolInfoItem1.name);
+    const registeredByElement = screen.getByLabelText('cli-registered-by');
+    expect(registeredByElement).toBeDefined();
+    expect(registeredByElement.textContent).equal(`Registered by ${cliToolInfoItem1.extensionInfo.label}`);
+    const displayNameElement = screen.getByLabelText('cli-display-name');
+    expect(displayNameElement).toBeDefined();
+    expect(displayNameElement.textContent).equal(cliToolInfoItem1.displayName);
+    const versionElement = screen.queryByLabelText('cli-version');
+    expect(versionElement).not.toBeInTheDocument();
+    const updateLoadingButton = screen.getByRole('button', { name: 'Update' });
+    expect(updateLoadingButton).toBeDefined();
+    expect(updateLoadingButton).toBeDisabled();
+  });
+
+  test('check tool infos are displayed as expected and version is specified but there is no new version available', () => {
+    render(PreferencesCliTool, {
+      cliTool: cliToolInfoItem2,
+    });
+    const nameElement = screen.getByLabelText('cli-name');
+    expect(nameElement).toBeDefined();
+    expect(nameElement.textContent).equal(cliToolInfoItem2.name);
+    const registeredByElement = screen.getByLabelText('cli-registered-by');
+    expect(registeredByElement).toBeDefined();
+    expect(registeredByElement.textContent).equal(`Registered by ${cliToolInfoItem2.extensionInfo.label}`);
+    const displayNameElement = screen.getByLabelText('cli-display-name');
+    expect(displayNameElement).toBeDefined();
+    expect(displayNameElement.textContent).equal(cliToolInfoItem2.displayName);
+    const versionElement = screen.getByLabelText('cli-version');
+    expect(versionElement).toBeDefined();
+    expect(versionElement.textContent).equal(`${cliToolInfoItem2.name} v${cliToolInfoItem2.version}`);
+    const updateLoadingButton = screen.getByRole('button', { name: 'Update' });
+    expect(updateLoadingButton).toBeDefined();
+    expect(updateLoadingButton).toBeDisabled();
+  });
+
+  test('check tool infos are displayed as expected and there is a new version available', () => {
+    render(PreferencesCliTool, {
+      cliTool: cliToolInfoItem3,
+    });
+    const nameElement = screen.getByLabelText('cli-name');
+    expect(nameElement).toBeDefined();
+    expect(nameElement.textContent).equal(cliToolInfoItem3.name);
+    const registeredByElement = screen.getByLabelText('cli-registered-by');
+    expect(registeredByElement).toBeDefined();
+    expect(registeredByElement.textContent).equal(`Registered by ${cliToolInfoItem3.extensionInfo.label}`);
+    const displayNameElement = screen.getByLabelText('cli-display-name');
+    expect(displayNameElement).toBeDefined();
+    expect(displayNameElement.textContent).equal(cliToolInfoItem3.displayName);
+    const versionElement = screen.getByLabelText('cli-version');
+    expect(versionElement).toBeDefined();
+    expect(versionElement.textContent).equal(`${cliToolInfoItem3.name} v${cliToolInfoItem3.version}`);
+    const updateAvailableElement = screen.getByRole('button', { name: 'Update available' });
+    expect(updateAvailableElement).toBeDefined();
+    expect(updateAvailableElement.textContent).toBe('Update available');
+    const updateLoadingButton = screen.getByRole('button', { name: 'Update' });
+    expect(updateLoadingButton).toBeDefined();
+    expect(updateLoadingButton).toBeEnabled();
+  });
+
+  test('if update fails the error message is shown', async () => {
+    updateCliToolMock.mockRejectedValue('');
+    render(PreferencesCliTool, {
+      cliTool: cliToolInfoItem3,
+    });
+    const updateAvailableElement = screen.getByRole('button', { name: 'Update available' });
+    expect(updateAvailableElement).toBeDefined();
+    expect(updateAvailableElement.textContent).toBe('Update available');
+
+    const failedErrorButton = screen.queryByRole('button', { name: `${cliToolInfoItem3.displayName} failed` });
+    expect(failedErrorButton).not.toBeInTheDocument();
+
+    await userEvent.click(updateAvailableElement);
+
+    const failedErrorButton2 = screen.getByRole('button', { name: `${cliToolInfoItem3.displayName} failed` });
+    expect(failedErrorButton2).toBeInTheDocument();
+  });
+});

--- a/packages/renderer/src/lib/preferences/PreferencesCliTool.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesCliTool.spec.ts
@@ -93,9 +93,8 @@ suite('CLI Tool item', () => {
     expect(displayNameElement.textContent).equal(cliToolInfoItem1.displayName);
     const versionElement = screen.queryByLabelText('cli-version');
     expect(versionElement).not.toBeInTheDocument();
-    const updateLoadingButton = screen.getByRole('button', { name: 'Update' });
-    expect(updateLoadingButton).toBeDefined();
-    expect(updateLoadingButton).toBeDisabled();
+    const updateLoadingButton = screen.queryByRole('button', { name: 'Update' });
+    expect(updateLoadingButton).not.toBeInTheDocument();
   });
 
   test('check tool infos are displayed as expected and version is specified but there is no new version available', () => {
@@ -115,7 +114,7 @@ suite('CLI Tool item', () => {
     expect(versionElement).toBeDefined();
     expect(versionElement.textContent).equal(`${cliToolInfoItem2.name} v${cliToolInfoItem2.version}`);
     const updateLoadingButton = screen.getByRole('button', { name: 'Update' });
-    expect(updateLoadingButton).toBeDefined();
+    expect(updateLoadingButton).toBeInTheDocument();
     expect(updateLoadingButton).toBeDisabled();
   });
 
@@ -139,7 +138,7 @@ suite('CLI Tool item', () => {
     expect(updateAvailableElement).toBeDefined();
     expect(updateAvailableElement.textContent).toBe('Update available');
     const updateLoadingButton = screen.getByRole('button', { name: 'Update' });
-    expect(updateLoadingButton).toBeDefined();
+    expect(updateLoadingButton).toBeInTheDocument();
     expect(updateLoadingButton).toBeEnabled();
   });
 

--- a/packages/renderer/src/lib/preferences/PreferencesCliTool.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesCliTool.svelte
@@ -74,7 +74,7 @@ function getLoggerHandler(_cliToolId: string): ConnectionCallback {
         </div>
         <div class="">
           <div class="p-0.5 rounded-lg bg-charcoal-900 w-fit">
-            {#if cliToolStatus}
+            {#if cliTool.version && cliToolStatus}
               <LoadingIconButton
                 action="update"
                 clickAction="{() => {
@@ -85,7 +85,8 @@ function getLoggerHandler(_cliToolId: string): ConnectionCallback {
                 icon="{faCircleArrowUp}"
                 leftPosition="left-[0.4rem]"
                 state="{cliToolStatus}"
-                color="primary" />
+                color="primary"
+                tooltip="{!cliTool.newVersion ? 'No updates' : `Update to v.${cliTool.newVersion}`}" />
             {/if}
           </div>
         </div>

--- a/packages/renderer/src/lib/preferences/PreferencesCliTool.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesCliTool.svelte
@@ -1,0 +1,135 @@
+<script lang="ts">
+import { faCircleArrowUp, faCircleXmark } from '@fortawesome/free-solid-svg-icons';
+import Button from '../ui/Button.svelte';
+import Fa from 'svelte-fa';
+import { startTask, type ConnectionCallback, eventCollect } from './preferences-connection-rendering-task';
+import type { CliToolInfo } from '../../../../main/src/plugin/api/cli-tool-info';
+import LoadingIconButton from '../ui/LoadingIconButton.svelte';
+
+import Markdown from '../markdown/Markdown.svelte';
+import type { ILoadingStatus } from './Util';
+
+export let cliTool: CliToolInfo;
+let showError = false;
+let cliToolStatus: ILoadingStatus = {
+  inProgress: false,
+  status: cliTool.newVersion ? 'toUpdate' : 'unknown',
+  action: 'update',
+};
+
+async function update(cliTool: CliToolInfo) {
+  try {
+    cliToolStatus.inProgress = true;
+    cliToolStatus = cliToolStatus;
+    const loggerHandlerKey = startTask(
+      `Update ${cliTool.name} to v${cliTool.newVersion}`,
+      '/preferences/cli-tools',
+      getLoggerHandler(cliTool.id),
+    );
+    await window.updateCliTool(cliTool.id, loggerHandlerKey, eventCollect);
+    showError = false;
+    cliToolStatus.status = 'unknown';
+  } catch (e) {
+    showError = true;
+  } finally {
+    cliToolStatus.inProgress = false;
+    cliToolStatus = cliToolStatus;
+  }
+}
+
+function getLoggerHandler(_cliToolId: string): ConnectionCallback {
+  return {
+    log: () => {},
+    warn: () => {},
+    error: _args => {
+      showError = true;
+    },
+    onEnd: () => {},
+  };
+}
+</script>
+
+<div role="row" class="bg-charcoal-600 mb-5 rounded-md p-3 flex flex-col">
+  <div class="divide-x divide-gray-900 flex flex-row">
+    <div>
+      <!-- left col - cli-tool icon/name + "create new" button -->
+      <div class="min-w-[170px] max-w-[200px] h-full flex flex-col justify-between">
+        <div class="flex flex-row">
+          {#if cliTool?.images?.icon}
+            {#if typeof cliTool.images.icon === 'string'}
+              <img
+                src="{cliTool.images.icon}"
+                aria-label="cli-logo"
+                alt="{cliTool.name} logo"
+                class="max-w-[40px] max-h-[40px] h-full" />
+            {/if}
+          {/if}
+          <span id="{cliTool.id}" class="my-auto ml-3 break-words" aria-label="cli-name">{cliTool.name}</span>
+        </div>
+        <div class="">
+          <div class="p-0.5 rounded-lg bg-charcoal-900 w-fit">
+            {#if cliToolStatus}
+              <LoadingIconButton
+                action="update"
+                clickAction="{() => {
+                  if (cliTool.newVersion) {
+                    update(cliTool);
+                  }
+                }}"
+                icon="{faCircleArrowUp}"
+                leftPosition="left-[0.4rem]"
+                state="{cliToolStatus}"
+                color="primary" />
+            {/if}
+          </div>
+        </div>
+      </div>
+    </div>
+    <!-- cli-tools columns -->
+    <div class="grow flex-column divide-gray-900 ml-2">
+      <span class="my-auto ml-3 break-words" aria-label="cli-display-name">{cliTool.displayName}</span>
+      <div role="region" class="float-right text-gray-900 px-2 text-sm" aria-label="cli-registered-by">
+        Registered by {cliTool.extensionInfo.label}
+      </div>
+      <div role="region" class="ml-3 mt-2 text-sm text-gray-300">
+        <div class="text-gray-700">
+          <Markdown markdown="{cliTool.description}" />
+        </div>
+        {#if cliTool.version}
+          <div class="flex flex-row justify-between bg-charcoal-900 p-2 rounded-lg min-w-[320px] w-fit">
+            <span class="text-white-400 font-bold text-xs" aria-label="cli-version"
+              >{cliTool.name} v{cliTool.version}</span>
+            {#if cliTool.newVersion}
+              <Button
+                type="link"
+                class="underline"
+                padding="p-0"
+                on:click="{() => {
+                  if (cliTool.newVersion) {
+                    update(cliTool);
+                  }
+                }}"
+                title="{`Update ${cliTool.displayName} to v.${cliTool.newVersion}?`}"
+                disabled="{!cliTool.newVersion}"
+                aria-label="Update available">
+                Update available
+              </Button>
+            {/if}
+          </div>
+        {/if}
+      </div>
+    </div>
+  </div>
+  {#if showError}
+    <div class="flex flex-row items-center text-xs text-red-400 ml-[200px] mt-2">
+      <Fa icon="{faCircleXmark}" class="mr-1 text-red-500" />
+      <span>Unable to update {cliTool.displayName} to version {cliTool.newVersion}. </span>
+      <Button
+        type="link"
+        padding="p-0"
+        class="ml-1 text-xs"
+        aria-label="{cliTool.displayName} failed"
+        on:click="{() => window.events?.send('toggle-task-manager', '')}">Check why it failed</Button>
+    </div>
+  {/if}
+</div>

--- a/packages/renderer/src/lib/preferences/PreferencesCliTool.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesCliTool.svelte
@@ -55,10 +55,16 @@ function getLoggerHandler(_cliToolId: string): ConnectionCallback {
       <!-- left col - cli-tool icon/name + "create new" button -->
       <div class="min-w-[170px] max-w-[200px] h-full flex flex-col justify-between">
         <div class="flex flex-row">
-          {#if cliTool?.images?.icon}
-            {#if typeof cliTool.images.icon === 'string'}
+          {#if cliTool?.images?.icon || cliTool?.extensionInfo.icon}
+            {#if typeof cliTool.images?.icon === 'string'}
               <img
                 src="{cliTool.images.icon}"
+                aria-label="cli-logo"
+                alt="{cliTool.name} logo"
+                class="max-w-[40px] max-h-[40px] h-full" />
+            {:else if typeof cliTool.extensionInfo.icon === 'string'}
+              <img
+                src="{cliTool.extensionInfo.icon}"
                 aria-label="cli-logo"
                 alt="{cliTool.name} logo"
                 class="max-w-[40px] max-h-[40px] h-full" />

--- a/packages/renderer/src/lib/preferences/PreferencesCliToolsRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesCliToolsRendering.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
 import { cliToolInfos } from '../../stores/cli-tools';
-import Markdown from '../markdown/Markdown.svelte';
 import SettingsPage from './SettingsPage.svelte';
 import EngineIcon from '../ui/EngineIcon.svelte';
 import EmptyScreen from '../ui/EmptyScreen.svelte';
+import PreferencesCliTool from './PreferencesCliTool.svelte';
 </script>
 
 <SettingsPage title="CLI Tools">
@@ -16,42 +16,7 @@ import EmptyScreen from '../ui/EmptyScreen.svelte';
       hidden="{$cliToolInfos.length > 0}" />
 
     {#each $cliToolInfos as cliTool}
-      <div role="row" class="bg-charcoal-600 mb-5 rounded-md p-3 divide-x divide-gray-900 flex">
-        <div>
-          <!-- left col - cli-tool icon/name + "create new" button -->
-          <div class="min-w-[170px] max-w-[200px]">
-            <div class="flex">
-              {#if cliTool?.images?.icon}
-                {#if typeof cliTool.images.icon === 'string'}
-                  <img
-                    src="{cliTool.images.icon}"
-                    aria-label="cli-logo"
-                    alt="{cliTool.name} logo"
-                    class="max-w-[40px] h-full" />
-                {/if}
-              {/if}
-              <span id="{cliTool.id}" class="my-auto text-gray-400 ml-3 break-words" aria-label="cli-name"
-                >{cliTool.name}</span>
-            </div>
-          </div>
-        </div>
-        <!-- cli-tools columns -->
-        <div class="grow flex-column divide-gray-900 ml-2">
-          <span class="my-auto text-gray-400 ml-3 break-words" aria-label="cli-display-name"
-            >{cliTool.displayName}</span>
-          <div role="region" class="float-right text-gray-900 px-2 text-sm" aria-label="cli-registered-by">
-            Registered by {cliTool.extensionInfo.label}
-          </div>
-          <div role="region" class="ml-3 mt-2 text-sm text-gray-300">
-            <Markdown markdown="{cliTool.description}" />
-            {#if cliTool.version !== ''}
-              <span
-                class="text-white-400 font-bold font-mono text-xs bg-charcoal-900 p-2 rounded-lg"
-                aria-label="cli-version">{cliTool.name} v{cliTool.version}</span>
-            {/if}
-          </div>
-        </div>
-      </div>
+      <PreferencesCliTool cliTool="{cliTool}" />
     {/each}
   </div>
 </SettingsPage>

--- a/packages/renderer/src/lib/preferences/Util.ts
+++ b/packages/renderer/src/lib/preferences/Util.ts
@@ -34,10 +34,13 @@ export interface IProviderConnectionConfigurationPropertyRecorded extends IConfi
   providerId: string;
 }
 
-export interface IConnectionStatus {
+export interface ILoadingStatus {
   status: string;
   action?: string;
   inProgress: boolean;
+}
+
+export interface IConnectionStatus extends ILoadingStatus {
   error?: string;
 }
 

--- a/packages/renderer/src/lib/ui/LoadingIconButton.svelte
+++ b/packages/renderer/src/lib/ui/LoadingIconButton.svelte
@@ -10,6 +10,7 @@ export let icon: IconDefinition;
 export let state: ILoadingStatus | undefined;
 export let leftPosition: string;
 export let color: 'primary' | 'secondary' = 'secondary';
+export let tooltip: string = capitalize(action);
 export let clickAction: () => Promise<void> | void;
 
 $: disable =
@@ -36,7 +37,7 @@ function getStyleByState(state: ILoadingStatus | undefined, action: string) {
 }
 </script>
 
-<Tooltip tip="{capitalize(action)}" bottom>
+<Tooltip tip="{tooltip}" bottom>
   <button
     aria-label="{capitalize(action)}"
     class="mx-2.5 my-2 {getStyleByState(state, action)}"

--- a/packages/renderer/src/lib/ui/LoadingIconButton.svelte
+++ b/packages/renderer/src/lib/ui/LoadingIconButton.svelte
@@ -1,14 +1,15 @@
 <script lang="ts">
 import type { IconDefinition } from '@fortawesome/free-solid-svg-icons';
-import type { IConnectionStatus } from '../preferences/Util';
+import type { ILoadingStatus } from '../preferences/Util';
 import LoadingIcon from './LoadingIcon.svelte';
 import Tooltip from './Tooltip.svelte';
 import { capitalize } from './Util';
 
 export let action: string;
 export let icon: IconDefinition;
-export let state: IConnectionStatus | undefined;
+export let state: ILoadingStatus | undefined;
 export let leftPosition: string;
+export let color: 'primary' | 'secondary' = 'secondary';
 export let clickAction: () => Promise<void> | void;
 
 $: disable =
@@ -16,19 +17,21 @@ $: disable =
   (action === 'start' && state?.status !== 'stopped') ||
   (action === 'restart' && state?.status !== 'started') ||
   (action === 'stop' && state?.status !== 'started') ||
-  (action === 'delete' && state?.status !== 'stopped' && state?.status !== 'unknown');
+  (action === 'delete' && state?.status !== 'stopped' && state?.status !== 'unknown') ||
+  (action === 'update' && state?.status === 'unknown');
 
 $: loading = state?.inProgress && action === state?.action;
 
-function getStyleByState(state: IConnectionStatus | undefined, action: string) {
+function getStyleByState(state: ILoadingStatus | undefined, action: string) {
   if (
     (action === 'start' && (state?.inProgress || state?.status !== 'stopped')) ||
     ((action === 'stop' || action === 'restart') && (state?.inProgress || state?.status !== 'started')) ||
-    (action === 'delete' && (state?.inProgress || (state?.status !== 'stopped' && state?.status !== 'unknown')))
+    (action === 'delete' && (state?.inProgress || (state?.status !== 'stopped' && state?.status !== 'unknown'))) ||
+    (action === 'update' && (state?.inProgress || state?.status === 'unknown'))
   ) {
     return 'text-gray-900 cursor-not-allowed';
   } else {
-    return 'hover:text-gray-700';
+    return color === 'secondary' ? 'text-white hover:text-gray-700' : 'text-purple-600 hover:text-purple-500';
   }
 }
 </script>


### PR DESCRIPTION
### What does this PR do?

This PR adds the logic to show new/update cli version. Probably to be splitted in multiple parts.

### Screenshot/screencast of this PR

if succeed

![update_version_succeed](https://github.com/containers/podman-desktop/assets/49404737/25d4ad36-ee4e-481e-bff8-acd34d9301d6)

if fails

![update_version_error](https://github.com/containers/podman-desktop/assets/49404737/6a4bfbe2-0069-4892-bae2-045e85a85a84)

### What issues does this PR fix or reference?

it resolves #4690 

### How to test this PR?


