### PR TITLE
fix: update current context reactively

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
@@ -2,7 +2,6 @@
 import SettingsPage from './SettingsPage.svelte';
 import EngineIcon from '../ui/EngineIcon.svelte';
 import EmptyScreen from '../ui/EmptyScreen.svelte';
-import { onMount } from 'svelte';
 import Link from '../ui/Link.svelte';
 import { faTrash, faRightToBracket } from '@fortawesome/free-solid-svg-icons';
 import ListItemButtonIcon from '../ui/ListItemButtonIcon.svelte';
@@ -10,11 +9,7 @@ import ErrorMessage from '../ui/ErrorMessage.svelte';
 import { kubernetesContexts } from '../../stores/kubernetes-contexts';
 import { clearKubeUIContextErrors, setKubeUIContextError } from '../kube/KubeContextUI';
 
-let currentContextName: string | undefined;
-
-onMount(async () => {
-  currentContextName = await window.kubernetesGetCurrentContextName();
-});
+$: currentContextName = $kubernetesContexts.filter(c => c.currentContext).map(c => c.name)[0];
 
 async function handleSetContext(contextName: string) {
   $kubernetesContexts = clearKubeUIContextErrors($kubernetesContexts);

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
@@ -9,7 +9,7 @@ import ErrorMessage from '../ui/ErrorMessage.svelte';
 import { kubernetesContexts } from '../../stores/kubernetes-contexts';
 import { clearKubeUIContextErrors, setKubeUIContextError } from '../kube/KubeContextUI';
 
-$: currentContextName = $kubernetesContexts.filter(c => c.currentContext).map(c => c.name)[0];
+$: currentContextName = $kubernetesContexts.find(c => c.currentContext)?.name;
 
 async function handleSetContext(contextName: string) {
   $kubernetesContexts = clearKubeUIContextErrors($kubernetesContexts);


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

On the Kubernetes Context page, the current context is updated reactively, so it has the good value when the suer switches the current context.

### What issues does this PR fix or reference?

Fixes #5053 

### How to test this PR?

<!-- Please explain steps to reproduce -->
