### PR TITLE
fix: revert styling of disabled buttons

### DIFF
--- a/packages/renderer/src/lib/ui/Button.spec.ts
+++ b/packages/renderer/src/lib/ui/Button.spec.ts
@@ -26,16 +26,27 @@ import Button from './Button.svelte';
 test('Check primary button styling', async () => {
   render(Button, { type: 'primary' });
 
-  // check for one element of the styling
+  // check for a few elements of the styling
   const button = screen.getByRole('button');
   expect(button).toBeInTheDocument();
   expect(button).toHaveClass('bg-purple-600');
+  expect(button).toHaveClass('text-[13px]');
+});
+
+test('Check disabled/in-progress primary button styling', async () => {
+  render(Button, { type: 'primary', inProgress: true });
+
+  // check for a few elements of the styling
+  const button = screen.getByRole('button');
+  expect(button).toBeInTheDocument();
+  expect(button).toHaveClass('bg-charcoal-50');
+  expect(button).toHaveClass('text-[13px]');
 });
 
 test('Check primary button is the default', async () => {
   render(Button);
 
-  // check for one element of the styling
+  // check for a few elements of the styling
   const button = screen.getByRole('button');
   expect(button).toBeInTheDocument();
   expect(button).toHaveClass('bg-purple-600');
@@ -44,10 +55,21 @@ test('Check primary button is the default', async () => {
 test('Check secondary button styling', async () => {
   render(Button, { type: 'secondary' });
 
-  // check for one element of the styling
+  // check for a few elements of the styling
   const button = screen.getByRole('button');
   expect(button).toBeInTheDocument();
   expect(button).toHaveClass('border-gray-200');
+  expect(button).toHaveClass('text-[13px]');
+});
+
+test('Check disabled/in-progress secondary button styling', async () => {
+  render(Button, { type: 'secondary', inProgress: true });
+
+  // check for a few elements of the styling
+  const button = screen.getByRole('button');
+  expect(button).toBeInTheDocument();
+  expect(button).toHaveClass('bg-charcoal-50');
+  expect(button).toHaveClass('text-[13px]');
 });
 
 test('Check link button styling', async () => {
@@ -59,4 +81,28 @@ test('Check link button styling', async () => {
   expect(button).toHaveClass('border-none');
   expect(button).toHaveClass('hover:bg-white');
   expect(button).toHaveClass('hover:bg-opacity-10');
+  expect(button).toHaveClass('text-[13px]');
+});
+
+test('Check disabled/in-progress link button styling', async () => {
+  render(Button, { type: 'link', inProgress: true });
+
+  // check for a few elements of the styling
+  const button = screen.getByRole('button');
+  expect(button).toBeInTheDocument();
+  expect(button).toHaveClass('text-charcoal-50');
+  expect(button).toHaveClass('text-[13px]');
+});
+
+test('Check tab button styling', async () => {
+  render(Button, { type: 'tab' });
+
+  // check for a few elements of the styling
+  const button = screen.getByRole('button');
+  expect(button).toBeInTheDocument();
+  expect(button).toHaveClass('border-b-[3px]');
+  expect(button).toHaveClass('border-charcoal-700');
+  expect(button).toHaveClass('pb-2');
+  expect(button).toHaveClass('hover:cursor-pointer');
+  expect(button).not.toHaveClass('text-[13px]');
 });

--- a/packages/renderer/src/lib/ui/Button.svelte
+++ b/packages/renderer/src/lib/ui/Button.svelte
@@ -36,15 +36,18 @@ $: {
     }
   } else {
     if (type === 'primary') {
-      classes = 'bg-purple-600 border-none text-white hover:bg-purple-500 rounded-[4px] text-[13px]';
+      classes = 'bg-purple-600 border-none text-white hover:bg-purple-500';
     } else if (type === 'secondary') {
-      classes =
-        'border-[1px] border-gray-200 text-white hover:border-purple-500 hover:text-purple-500 rounded-[4px] text-[13px]';
+      classes = 'border-[1px] border-gray-200 text-white hover:border-purple-500 hover:text-purple-500';
     } else if (type === 'tab') {
       classes = 'pb-2 border-b-[3px] border-charcoal-700 hover:cursor-pointer py-2 text-gray-600 no-underline';
     } else {
-      classes = 'border-none text-purple-400 hover:bg-white hover:bg-opacity-10 rounded-[4px] text-[13px]';
+      classes = 'border-none text-purple-400 hover:bg-white hover:bg-opacity-10';
     }
+  }
+
+  if (type !== 'tab') {
+    classes += ' rounded-[4px] text-[13px]';
   }
 }
 </script>


### PR DESCRIPTION
### What does this PR do?

When tab button type was added for the All/Stopped/Started containers, it removed the rounded/text styling from disabled buttons. As a result, there was a visible difference between disabled/in-progress buttons and regular buttons.

This adds these two styles to all non-tab buttons, regardless of whether they are regular/disabled/in-progress.

### Screenshot/screencast of this PR

See issue #4882.

### What issues does this PR fix or reference?

Fixes #4882.

### How to test this PR?

See original issue, just click a button that will show the spinner/progress.