### PR TITLE
fix: container tabs should match pods

### DIFF
--- a/packages/renderer/src/lib/container/ContainerList.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerList.spec.ts
@@ -104,13 +104,13 @@ test('Expect no containers being displayed', async () => {
   const noContainers = screen.getByRole('heading', { name: 'No containers' });
   expect(noContainers).toBeInTheDocument();
 
-  const runningTab = screen.getByRole('button', { name: 'Running containers' });
+  const runningTab = screen.getByRole('button', { name: 'Running' });
   await fireEvent.click(runningTab);
 
   const noRunningContainers = screen.getByRole('heading', { name: 'No running containers' });
   expect(noRunningContainers).toBeInTheDocument();
 
-  const stoppedTab = screen.getByRole('button', { name: 'Stopped containers' });
+  const stoppedTab = screen.getByRole('button', { name: 'Stopped' });
   await fireEvent.click(stoppedTab);
 
   const noStoppedContainers = screen.getByRole('heading', { name: 'No stopped containers' });
@@ -146,13 +146,13 @@ test('Expect is:running / is:stopped is added to the filter field', async () => 
   expect(searchField).not.toHaveDisplayValue(/is:running/);
   expect(searchField).not.toHaveDisplayValue(/is:stopped/);
 
-  const runningTab = screen.getByRole('button', { name: 'Running containers' });
+  const runningTab = screen.getByRole('button', { name: 'Running' });
   await fireEvent.click(runningTab);
 
   expect(searchField).toHaveDisplayValue(/is:running/);
   expect(searchField).not.toHaveDisplayValue(/is:stopped/);
 
-  const stoppedTab = screen.getByRole('button', { name: 'Stopped containers' });
+  const stoppedTab = screen.getByRole('button', { name: 'Stopped' });
   await fireEvent.click(stoppedTab);
 
   expect(searchField).not.toHaveDisplayValue(/is:running/);
@@ -189,11 +189,11 @@ test('Expect filter is preserved between tabs', async () => {
   await user.type(searchField, 'foobar');
   expect(searchField).toHaveDisplayValue(/foobar/);
 
-  const runningTab = screen.getByRole('button', { name: 'Running containers' });
+  const runningTab = screen.getByRole('button', { name: 'Running' });
   await fireEvent.click(runningTab);
   expect(searchField).toHaveDisplayValue(/foobar/);
 
-  const stoppedTab = screen.getByRole('button', { name: 'Stopped containers' });
+  const stoppedTab = screen.getByRole('button', { name: 'Stopped' });
   await fireEvent.click(stoppedTab);
   expect(searchField).toHaveDisplayValue(/foobar/);
 });
@@ -553,7 +553,7 @@ test('Expect clear filter in empty screen to clear serach term, except is:...', 
   await user.type(searchField, 'foobar');
   expect(searchField).toHaveDisplayValue(/foobar/);
 
-  const runningTab = screen.getByRole('button', { name: 'Running containers' });
+  const runningTab = screen.getByRole('button', { name: 'Running' });
   await fireEvent.click(runningTab);
   expect(searchField).toHaveDisplayValue(/foobar/);
   expect(searchField).toHaveDisplayValue(/is:running/);
@@ -710,7 +710,7 @@ test('Expect to display running / stopped containers depending on tab', async ()
       absentLabels: [],
     },
     {
-      tabLabel: 'Running containers',
+      tabLabel: 'Running',
       presentCells: [
         'pod1 (pod) 2 containers',
         'container1-pod1 RUNNING',
@@ -721,7 +721,7 @@ test('Expect to display running / stopped containers depending on tab', async ()
       absentLabels: [/container2-pod2.*/, /pod3 \(pod\).*/, /container1-pod3.*/, /container2-pod3.*/],
     },
     {
-      tabLabel: 'Stopped containers',
+      tabLabel: 'Stopped',
       presentCells: [
         'pod2 (pod) 2 containers (1 filtered)',
         'container2-pod2 STOPPED',

--- a/packages/renderer/src/lib/container/ContainerList.svelte
+++ b/packages/renderer/src/lib/container/ContainerList.svelte
@@ -483,11 +483,11 @@ function setStoppedFilter() {
 
   <svelte:fragment slot="tabs">
     <Button type="tab" on:click="{() => resetRunningFilter()}" selected="{containerUtils.filterIsAll(searchTerm)}"
-      >All containers</Button>
+      >All</Button>
     <Button type="tab" on:click="{() => setRunningFilter()}" selected="{containerUtils.filterIsRunning(searchTerm)}"
-      >Running containers</Button>
+      >Running</Button>
     <Button type="tab" on:click="{() => setStoppedFilter()}" selected="{containerUtils.filterIsStopped(searchTerm)}"
-      >Stopped containers</Button>
+      >Stopped</Button>
   </svelte:fragment>
 
   <div class="flex min-w-full h-full" slot="content">


### PR DESCRIPTION
### What does this PR do?

When we made the container All/Running/Stopped tabs we used 'containers' in each tab title. By the time we did pods we just used All/Running/Stopped. This just cleans up the Containers page to be consistent with Pods and have less redundant tabs.

### Screenshot/screencast of this PR

See issue #4925.

### What issues does this PR fix or reference?

Fixes #4925.

### How to test this PR?

Page between Containers list and Pods list to see consistent tab filters.