### PR TITLE
fix: pass the complete imageInfo to the check function

### DIFF
--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -1747,7 +1747,7 @@ function initExposure(): void {
     'imageCheck',
     async (
       id: string,
-      image: string,
+      image: containerDesktopAPI.ImageInfo,
       cancellationToken?: number,
     ): Promise<containerDesktopAPI.ImageChecks | undefined> => {
       return ipcInvoke('image-checker:check', id, image, cancellationToken);

--- a/packages/renderer/src/lib/image/ImageDetails.svelte
+++ b/packages/renderer/src/lib/image/ImageDetails.svelte
@@ -18,6 +18,7 @@ import { containersInfos } from '/@/stores/containers';
 import ImageDetailsCheck from './ImageDetailsCheck.svelte';
 import { imageCheckerProviders } from '/@/stores/image-checker-providers';
 import type { Unsubscriber } from 'svelte/motion';
+import type { ImageInfo } from '@podman-desktop/api';
 
 export let imageID: string;
 export let engineId: string;
@@ -38,6 +39,7 @@ function closeModals() {
   renameImageModal = false;
 }
 
+let imageInfo: ImageInfo | undefined;
 let image: ImageInfoUI;
 let detailsPage: DetailsPage;
 
@@ -52,10 +54,10 @@ onMount(() => {
   const imageUtils = new ImageUtils();
   // loading image info
   return imagesInfos.subscribe(images => {
-    const matchingImage = images.find(c => c.Id === imageID && c.engineId === engineId);
+    imageInfo = images.find(c => c.Id === imageID && c.engineId === engineId);
     let tempImage;
-    if (matchingImage) {
-      tempImage = imageUtils.getImageInfoUI(matchingImage, base64RepoTag, $containersInfos);
+    if (imageInfo) {
+      tempImage = imageUtils.getImageInfoUI(imageInfo, base64RepoTag, $containersInfos);
     }
     if (tempImage) {
       image = tempImage;
@@ -101,7 +103,7 @@ onDestroy(() => {
         <ImageDetailsInspect image="{image}" />
       </Route>
       <Route path="/check" breadcrumb="Check" navigationHint="tab">
-        <ImageDetailsCheck image="{image}" />
+        <ImageDetailsCheck imageInfo="{imageInfo}" />
       </Route>
     </svelte:fragment>
   </DetailsPage>

--- a/packages/renderer/src/lib/image/ImageDetailsCheck.spec.ts
+++ b/packages/renderer/src/lib/image/ImageDetailsCheck.spec.ts
@@ -36,19 +36,18 @@ test('expect to display wait message before to receive results', async () => {
   });
 
   render(ImageDetailsCheck, {
-    image: {
-      id: '123456',
-      shortId: '123',
-      name: 'an-image',
-      engineId: 'podman',
+    imageInfo: {
+      engineId: 'podman.Podman',
       engineName: 'Podman',
-      tag: 'a-tag',
-      createdAt: 123,
-      age: '1 day',
-      humanSize: '1Mb',
-      base64RepoTag: Buffer.from('<none>', 'binary').toString('base64'),
-      selected: false,
-      inUse: false,
+      Id: 'sha256:3696f18be9a51a60395a7c2667e2fcebd2d913af0ad6da287e03810fda566833',
+      ParentId: '7f8297e79d497136a7d75d506781b545b20ea599041f02ab14aa092e24f110b7',
+      RepoTags: ['quay.io/user/image-name:v0.0.1'],
+      Created: 1701338214,
+      Size: 34134140,
+      VirtualSize: 34134140,
+      SharedSize: 0,
+      Labels: {},
+      Containers: 0,
     },
   });
 
@@ -72,19 +71,18 @@ test('expect to cancel when clicking the Cancel button', async () => {
   });
 
   render(ImageDetailsCheck, {
-    image: {
-      id: '123456',
-      shortId: '123',
-      name: 'an-image',
-      engineId: 'podman',
+    imageInfo: {
+      engineId: 'podman.Podman',
       engineName: 'Podman',
-      tag: 'a-tag',
-      createdAt: 123,
-      age: '1 day',
-      humanSize: '1Mb',
-      base64RepoTag: Buffer.from('<none>', 'binary').toString('base64'),
-      selected: false,
-      inUse: false,
+      Id: 'sha256:3696f18be9a51a60395a7c2667e2fcebd2d913af0ad6da287e03810fda566833',
+      ParentId: '7f8297e79d497136a7d75d506781b545b20ea599041f02ab14aa092e24f110b7',
+      RepoTags: ['quay.io/user/image-name:v0.0.1'],
+      Created: 1701338214,
+      Size: 34134140,
+      VirtualSize: 34134140,
+      SharedSize: 0,
+      Labels: {},
+      Containers: 0,
     },
   });
 
@@ -115,19 +113,18 @@ test('expect to cancel when destroying the component', async () => {
   });
 
   const result = render(ImageDetailsCheck, {
-    image: {
-      id: '123456',
-      shortId: '123',
-      name: 'an-image',
-      engineId: 'podman',
+    imageInfo: {
+      engineId: 'podman.Podman',
       engineName: 'Podman',
-      tag: 'a-tag',
-      createdAt: 123,
-      age: '1 day',
-      humanSize: '1Mb',
-      base64RepoTag: Buffer.from('<none>', 'binary').toString('base64'),
-      selected: false,
-      inUse: false,
+      Id: 'sha256:3696f18be9a51a60395a7c2667e2fcebd2d913af0ad6da287e03810fda566833',
+      ParentId: '7f8297e79d497136a7d75d506781b545b20ea599041f02ab14aa092e24f110b7',
+      RepoTags: ['quay.io/user/image-name:v0.0.1'],
+      Created: 1701338214,
+      Size: 34134140,
+      VirtualSize: 34134140,
+      SharedSize: 0,
+      Labels: {},
+      Containers: 0,
     },
   });
 
@@ -154,19 +151,18 @@ test('expect to not cancel again when destroying the component after manual canc
   });
 
   const result = render(ImageDetailsCheck, {
-    image: {
-      id: '123456',
-      shortId: '123',
-      name: 'an-image',
-      engineId: 'podman',
+    imageInfo: {
+      engineId: 'podman.Podman',
       engineName: 'Podman',
-      tag: 'a-tag',
-      createdAt: 123,
-      age: '1 day',
-      humanSize: '1Mb',
-      base64RepoTag: Buffer.from('<none>', 'binary').toString('base64'),
-      selected: false,
-      inUse: false,
+      Id: 'sha256:3696f18be9a51a60395a7c2667e2fcebd2d913af0ad6da287e03810fda566833',
+      ParentId: '7f8297e79d497136a7d75d506781b545b20ea599041f02ab14aa092e24f110b7',
+      RepoTags: ['quay.io/user/image-name:v0.0.1'],
+      Created: 1701338214,
+      Size: 34134140,
+      VirtualSize: 34134140,
+      SharedSize: 0,
+      Labels: {},
+      Containers: 0,
     },
   });
 
@@ -207,19 +203,18 @@ test('expect to display results from image checker provider', async () => {
   } as ImageChecks);
 
   render(ImageDetailsCheck, {
-    image: {
-      id: '123456',
-      shortId: '123',
-      name: 'an-image',
-      engineId: 'podman',
+    imageInfo: {
+      engineId: 'podman.Podman',
       engineName: 'Podman',
-      tag: 'a-tag',
-      createdAt: 123,
-      age: '1 day',
-      humanSize: '1Mb',
-      base64RepoTag: Buffer.from('<none>', 'binary').toString('base64'),
-      selected: false,
-      inUse: false,
+      Id: 'sha256:3696f18be9a51a60395a7c2667e2fcebd2d913af0ad6da287e03810fda566833',
+      ParentId: '7f8297e79d497136a7d75d506781b545b20ea599041f02ab14aa092e24f110b7',
+      RepoTags: ['quay.io/user/image-name:v0.0.1'],
+      Created: 1701338214,
+      Size: 34134140,
+      VirtualSize: 34134140,
+      SharedSize: 0,
+      Labels: {},
+      Containers: 0,
     },
   });
 
@@ -254,19 +249,18 @@ test('expect to not cancel when destroying the component after displaying result
   } as ImageChecks);
 
   const result = render(ImageDetailsCheck, {
-    image: {
-      id: '123456',
-      shortId: '123',
-      name: 'an-image',
-      engineId: 'podman',
+    imageInfo: {
+      engineId: 'podman.Podman',
       engineName: 'Podman',
-      tag: 'a-tag',
-      createdAt: 123,
-      age: '1 day',
-      humanSize: '1Mb',
-      base64RepoTag: Buffer.from('<none>', 'binary').toString('base64'),
-      selected: false,
-      inUse: false,
+      Id: 'sha256:3696f18be9a51a60395a7c2667e2fcebd2d913af0ad6da287e03810fda566833',
+      ParentId: '7f8297e79d497136a7d75d506781b545b20ea599041f02ab14aa092e24f110b7',
+      RepoTags: ['quay.io/user/image-name:v0.0.1'],
+      Created: 1701338214,
+      Size: 34134140,
+      VirtualSize: 34134140,
+      SharedSize: 0,
+      Labels: {},
+      Containers: 0,
     },
   });
 

--- a/packages/renderer/src/lib/image/ImageDetailsCheck.svelte
+++ b/packages/renderer/src/lib/image/ImageDetailsCheck.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 import type { ImageCheckerInfo } from '../../../../main/src/plugin/api/image-checker-info';
-import type { ImageInfoUI } from './ImageInfoUI';
 import Fa from 'svelte-fa';
 import { faStethoscope } from '@fortawesome/free-solid-svg-icons';
 import Button from '../ui/Button.svelte';
@@ -9,11 +8,12 @@ import { onDestroy, onMount } from 'svelte';
 import { imageCheckerProviders } from '/@/stores/image-checker-providers';
 import ProviderResultPage from '../ui/ProviderResultPage.svelte';
 import { type CheckUI, type ProviderUI } from '../ui/ProviderResultPage';
+import type { ImageInfo } from '@podman-desktop/api';
 
 const orderStatus = ['failed', 'success'];
 const orderSeverity = ['critical', 'high', 'medium', 'low', undefined];
 
-export let image: ImageInfoUI;
+export let imageInfo: ImageInfo | undefined;
 
 let providers: ProviderUI[];
 let results: CheckUI[] = [];
@@ -47,12 +47,15 @@ async function callProviders(_providers: readonly ImageCheckerInfo[]) {
   remainingProviders = providers.length;
 
   providers.forEach(provider => {
+    if (imageInfo === undefined) {
+      return;
+    }
     let telemetryOptions = {
       provider: provider.info.label,
       error: '',
     };
     window
-      .imageCheck(provider.info.id, image.name, cancellableTokenId)
+      .imageCheck(provider.info.id, imageInfo, cancellableTokenId)
       .then(_result => {
         // we test if it is still running, as it could have been marked as 'canceled'
         if (provider.state === 'running') {

--- a/packages/renderer/src/lib/image/ImageDetailsCheck.svelte
+++ b/packages/renderer/src/lib/image/ImageDetailsCheck.svelte
@@ -47,7 +47,7 @@ async function callProviders(_providers: readonly ImageCheckerInfo[]) {
   remainingProviders = providers.length;
 
   providers.forEach(provider => {
-    if (imageInfo === undefined) {
+    if (!imageInfo) {
       return;
     }
     let telemetryOptions = {


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Passes the complete ImageInfo to the Image Checker's `check` function, instead of the `name` only, as expected by the API

### What issues does this PR fix or reference?

Fixes #5065 

### How to test this PR?

<!-- Please explain steps to reproduce -->
