### PR TITLE
feat: show the k8s namespace

### DIFF
--- a/packages/main/src/plugin/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes-client.ts
@@ -296,6 +296,7 @@ export class KubernetesClient {
         name: context.name,
         cluster: context.cluster,
         user: context.user,
+        namespace: context.namespace,
         currentContext: context.name === this.currentContextName, // Set the current context to true if the name matches the current context name
         clusterInfo: cluster
           ? {

--- a/packages/main/src/plugin/kubernetes-context.ts
+++ b/packages/main/src/plugin/kubernetes-context.ts
@@ -30,6 +30,7 @@ export interface KubeContext {
   name: string;
   cluster: string;
   user: string;
+  namespace?: string;
   clusterInfo?: KubeCluster;
 
   // Is this the current context? Should be true for ONE context in the array list of contexts.

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.spec.ts
@@ -45,8 +45,19 @@ const mockContext2: KubeContext = {
   currentContext: true,
 };
 
+const mockContext3: KubeContext = {
+  name: 'context-name3',
+  cluster: 'cluster-name3',
+  user: 'user-name3',
+  namespace: 'namespace-name3',
+  clusterInfo: {
+    name: 'cluster-name3',
+    server: 'https://server-name3',
+  },
+};
+
 beforeEach(() => {
-  kubernetesContexts.set([mockContext1, mockContext2]);
+  kubernetesContexts.set([mockContext1, mockContext2, mockContext3]);
 });
 
 test('test that name, cluster and the server is displayed when rendering', async () => {
@@ -56,6 +67,11 @@ test('test that name, cluster and the server is displayed when rendering', async
   expect(await screen.findByText('cluster-name')).toBeInTheDocument();
   expect(await screen.findByText('user-name')).toBeInTheDocument();
   expect(await screen.findByText('https://server-name')).toBeInTheDocument();
+});
+
+test('Test that namespace is displayed when available in the context', async () => {
+  render(PreferencesKubernetesContextsRendering, {});
+  expect(await screen.findByText('namespace-name3')).toBeInTheDocument();
 });
 
 test('If nothing is returned for contexts, expect that the page shows a message', async () => {

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
@@ -113,6 +113,14 @@ async function handleDeleteContext(contextName: string) {
             <span class="my-auto font-bold col-span-1 text-right">USER</span>
             <span class="my-auto col-span-5 text-left pl-0.5 ml-3" aria-label="context-user">{context.user}</span>
           </div>
+
+          {#if context.namespace}
+            <div class="text-xs bg-charcoal-800 p-2 rounded-lg mt-1 grid grid-cols-6">
+              <span class="my-auto font-bold col-span-1 text-right">NAMESPACE</span>
+              <span class="my-auto col-span-5 text-left pl-0.5 ml-3" aria-label="context-namespace"
+                >{context.namespace}</span>
+            </div>
+          {/if}
         </div>
       </div>
     {/each}


### PR DESCRIPTION
### What does this PR do?

Show the namespace for the context, if any

```console
$ kubectl config get-contexts
CURRENT   NAME        CLUSTER     AUTHINFO    NAMESPACE
*         kind-kind   kind-kind   kind-kind   
$ kubectl config set-context --namespace kind-namespace kind-kind
Context "kind-kind" modified.
$ kubectl config get-contexts
CURRENT   NAME        CLUSTER     AUTHINFO    NAMESPACE
*         kind-kind   kind-kind   kind-kind   kind-namespace
```

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast 
explaining what is doing this PR -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop 
repository (or from another issue tracker). -->

* #4990

### How to test this PR?

<!-- Please explain steps to reproduce -->
