### PR TITLE
feat: add icon to extensionInfo

### DIFF
--- a/packages/main/src/plugin/authentication.ts
+++ b/packages/main/src/plugin/authentication.ts
@@ -52,6 +52,7 @@ export interface AuthenticationProviderInfo {
 export interface ExtensionInfo {
   id: string;
   label: string;
+  icon?: string | { light: string; dark: string };
 }
 
 export interface AllowedExtension {

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -946,6 +946,7 @@ export class ExtensionLoader {
       version: extManifest.version,
       publisher: extManifest.publisher,
       name: extManifest.name,
+      icon: extManifest.icon ? instance.updateImage(extManifest.icon, extensionPath) : undefined,
     };
     const authentication: typeof containerDesktopAPI.authentication = {
       getSession: (providerId, scopes, options) => {


### PR DESCRIPTION
### What does this PR do?

This PR adds the icon to the extensionInfo object so that it can be reused by some components as a default icon if nothing is provided by the extension. 
E.g. if the clitool extension is not provided we can display the default extension icon -> https://github.com/containers/podman-desktop/pull/5054 

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

N/A

### How to test this PR?

N/A
