### PR TITLE
feat: dispose old notifications (#4598)

### DIFF
--- a/packages/main/src/plugin/notification-registry.spec.ts
+++ b/packages/main/src/plugin/notification-registry.spec.ts
@@ -136,7 +136,7 @@ test('expect the queue to not have the notifications after they are removed by e
   });
   notificationRegistry.addNotification({
     extensionId,
-    title: 'title',
+    title: 'title1',
     body: 'description',
     type: 'info',
   });
@@ -146,7 +146,8 @@ test('expect the queue to not have the notifications after they are removed by e
 
   notificationRegistry.removeNotificationsByExtensionAndTitle(extensionId, 'title');
   queue = notificationRegistry.getNotifications();
-  expect(queue.length).toEqual(0);
+  expect(queue.length).toEqual(1);
+  expect(queue[0].title).equal('title1');
 });
 
 test('expect all notifications to be removed', async () => {
@@ -193,6 +194,35 @@ test('expect all notifications belonging to an extensions are removed after it i
   });
   let queue = notificationRegistry.getNotifications();
   expect(queue.length).toEqual(2);
+
+  registerNotificationDisposable.dispose();
+  queue = notificationRegistry.getNotifications();
+  expect(queue.length).toEqual(0);
+});
+
+test('expect same notification to only appear once if added multiple times', async () => {
+  notificationRegistry.addNotification({
+    extensionId,
+    title: '1',
+    body: '1',
+    type: 'info',
+  });
+  notificationRegistry.addNotification({
+    extensionId,
+    title: '2',
+    body: '2',
+    type: 'info',
+  });
+  notificationRegistry.addNotification({
+    extensionId,
+    title: '1',
+    body: '1',
+    type: 'info',
+  });
+  let queue = notificationRegistry.getNotifications();
+  expect(queue.length).toEqual(2);
+  expect(queue[0].title).equal('1');
+  expect(queue[1].title).equal('2');
 
   registerNotificationDisposable.dispose();
   queue = notificationRegistry.getNotifications();

--- a/packages/main/src/plugin/notification-registry.ts
+++ b/packages/main/src/plugin/notification-registry.ts
@@ -45,6 +45,11 @@ export class NotificationRegistry {
       ...notificationInfo,
       id: this.notificationId,
     };
+    // if there is the same notification already in the queue we remove it and put it at the head of the queue
+    this.notificationQueue = this.notificationQueue.filter(
+      notification =>
+        notification.extensionId !== notificationInfo.extensionId || notification.title !== notificationInfo.title,
+    );
     // we add the new notification to the beginning of the queue to display the queue head in the dashboard
     this.notificationQueue.unshift(notification);
     // send event
@@ -88,7 +93,7 @@ export class NotificationRegistry {
 
   removeNotificationsByExtensionAndTitle(extensionId: string, title: string): void {
     this.notificationQueue = this.notificationQueue.filter(
-      notification => notification.extensionId !== extensionId && notification.title !== title,
+      notification => notification.extensionId !== extensionId || notification.title !== title,
     );
     // send event
     this.apiSender.send('notifications-updated');


### PR DESCRIPTION
### What does this PR do?

this PR disposes old podman setup notifications and prevent to have the same notification displayed 2+ times.

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

it resolves #4598

### How to test this PR?

1. if you're on mac/win, delete all your podman machine
2. you should have the notification
3. create a new machine
4. the notification should not be there anymore
or run tests

