### PR TITLE
fix: launch.json references wrong script (#5006)

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,24 +1,23 @@
 {
-    "version": "0.2.0",
-    "configurations": [
-        {
-            "type": "node",
-            "request": "launch",
-            "name": "Debug Main Process",
-            "skipFiles": ["<node_internals>/**"],
-            "program": "${workspaceFolder}/scripts/watch.cjs",
-            "autoAttachChildProcesses": true
-        },
-        {
-            // Needs to start "Debug Main Process" first
-            "name": "Attach Debugger Renderer Process",
-            "request": "attach",
-            "type": "chrome",
-            "port": 9223,
-            "sourceMaps": true,
-            "webRoot": "${workspaceRoot}/packages/",
-            "timeout": 30000
-          },
-    ],
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Debug Main Process",
+      "skipFiles": ["<node_internals>/**"],
+      "program": "${workspaceFolder}/scripts/watch.mjs",
+      "autoAttachChildProcesses": true
+    },
+    {
+      // Needs to start "Debug Main Process" first
+      "name": "Attach Debugger Renderer Process",
+      "request": "attach",
+      "type": "chrome",
+      "port": 9223,
+      "sourceMaps": true,
+      "webRoot": "${workspaceRoot}/packages/",
+      "timeout": 30000
+    }
+  ]
 }
-


### PR DESCRIPTION
### What does this PR do?

it updates the watch script file extension (from .cjs to .mjs)

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

it resolves #5006 

### How to test this PR?

1. try to debug
