### PR TITLE
feat: show container connection type and endpoint

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesContainerConnectionDetailsSummary.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesContainerConnectionDetailsSummary.svelte
@@ -63,6 +63,11 @@ $: providerContainerConfiguration = tmpProviderContainerConfiguration.filter(
         </div>
       {/each}
       <div class="flex flex-row mt-5">
+        <span class="font-semibold min-w-[150px]">Type</span>
+        <span aria-label="{containerConnectionInfo.type}"
+          >{#if containerConnectionInfo.type === 'docker'}Docker{:else if containerConnectionInfo.type === 'podman'}Podman{/if}</span>
+      </div>
+      <div class="flex flex-row mt-5">
         <span class="font-semibold min-w-[150px]">Endpoint</span>
         <span aria-label="{containerConnectionInfo.endpoint.socketPath}"
           >{containerConnectionInfo.endpoint.socketPath}</span>

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesConnectionDetailsSummary.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesConnectionDetailsSummary.svelte
@@ -44,6 +44,10 @@ $: providerConnectionConfiguration = tmpProviderContainerConfiguration.filter(
         </div>
       {/each}
       <div class="flex flex-row mt-5">
+        <span class="font-semibold min-w-[150px]">Type</span>
+        <span aria-label="kubernetes">Kubernetes</span>
+      </div>
+      <div class="flex flex-row mt-5">
         <span class="font-semibold min-w-[150px]">Endpoint</span>
         <span aria-label="{kubernetesConnectionInfo.endpoint.apiURL}">{kubernetesConnectionInfo.endpoint.apiURL}</span>
       </div>

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
@@ -473,6 +473,15 @@ function hasAnyConfiguration(provider: ProviderInfo) {
                   <ConnectionErrorInfoButton status="{status}" />
                 {/if}
               </div>
+              <div class="mt-2">
+                <div class="text-gray-700 text-xs">
+                  {#if container.type === 'docker'}Docker{:else if container.type === 'podman'}Podman{/if} endpoint
+                </div>
+                <div class="mt-1">
+                  <span class="my-auto text-xs" class:text-gray-900="{container.status !== 'started'}"
+                    >{container.endpoint.socketPath}</span>
+                </div>
+              </div>
 
               {#if providerContainerConfiguration.has(provider.internalId)}
                 {@const providerConfiguration = providerContainerConfiguration.get(provider.internalId) || []}


### PR DESCRIPTION
Make the container and the kubernetes endpoint look more similar.

Show the connection type, since it might not match the provider.

### What does this PR do?

### Screenshot/screencast of this PR

![pd-endpoints](https://github.com/containers/podman-desktop/assets/10364051/80dc0f1d-6c20-48f7-9287-a6725bac56ce)

### What issues does this PR fix or reference?

Fixes #4727

### How to test this PR?

<!-- Please explain steps to reproduce -->
