### PR TITLE
feat: extension icons

### DIFF
--- a/packages/main/src/plugin/api/extension-info.ts
+++ b/packages/main/src/plugin/api/extension-info.ts
@@ -38,6 +38,7 @@ export interface ExtensionInfo {
   state: string;
   error?: ExtensionError;
   path: string;
+  icon?: string | { light: string; dark: string };
   update?: {
     version: string;
     ociUri: string;

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -193,6 +193,7 @@ export class ExtensionLoader {
       path: extension.path,
       removable: extension.removable,
       update: extension.update,
+      icon: extension.manifest.icon ? this.updateImage(extension.manifest.icon, extension.path) : undefined,
     }));
   }
 

--- a/packages/renderer/src/lib/preferences/ExtensionIcon.spec.ts
+++ b/packages/renderer/src/lib/preferences/ExtensionIcon.spec.ts
@@ -1,0 +1,86 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+import { test, expect } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import ExtensionIcon from './ExtensionIcon.svelte';
+import type { ExtensionInfo } from '../../../../main/src/plugin/api/extension-info';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-empty-function */
+
+test('Expect started icon', async () => {
+  const extension: ExtensionInfo = {
+    id: '',
+    name: 'my-extension',
+    description: '',
+    displayName: '',
+    publisher: '',
+    removable: false,
+    version: '',
+    state: 'started',
+    path: '',
+    icon: 'my-icon',
+  };
+  render(ExtensionIcon, { extension: extension });
+  const icon = screen.getByRole('img');
+  expect(icon).toBeInTheDocument();
+  expect(icon).toHaveAttribute('src', extension.icon);
+  expect(icon).not.toHaveClass('brightness-50');
+});
+
+test('Expect faded icon for other states', async () => {
+  const extension: ExtensionInfo = {
+    id: '',
+    name: 'my-extension',
+    description: '',
+    displayName: '',
+    publisher: '',
+    removable: false,
+    version: '',
+    state: 'stopped',
+    path: '',
+    icon: 'my-icon',
+  };
+  render(ExtensionIcon, { extension: extension });
+  const icon = screen.getByRole('img');
+  expect(icon).toBeInTheDocument();
+  expect(icon).toHaveAttribute('src', extension.icon);
+  expect(icon).toHaveClass('brightness-50');
+});
+
+test('Expect puzzle for missing icon', async () => {
+  const extension: ExtensionInfo = {
+    id: '',
+    name: 'my-extension',
+    description: '',
+    displayName: '',
+    publisher: '',
+    removable: false,
+    version: '',
+    state: 'started',
+    path: '',
+    // no icon
+  };
+  render(ExtensionIcon, { extension: extension });
+  const icon = screen.getByRole('img', { hidden: true });
+  expect(icon).toBeInTheDocument();
+  expect(icon).not.toHaveAttribute('src', extension.icon);
+  expect(icon).toHaveClass('text-violet-600');
+});

--- a/packages/renderer/src/lib/preferences/ExtensionIcon.svelte
+++ b/packages/renderer/src/lib/preferences/ExtensionIcon.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+import Fa from 'svelte-fa';
+import type { ExtensionInfo } from '../../../../main/src/plugin/api/extension-info';
+import { faPuzzlePiece } from '@fortawesome/free-solid-svg-icons';
+
+export let extension: ExtensionInfo;
+
+let icon: string | undefined = undefined;
+$: {
+  if (extension.icon) {
+    if (typeof extension.icon === 'string') {
+      icon = extension.icon;
+    } else if (extension.icon.dark) {
+      // for now use dark theme
+      icon = extension.icon.dark;
+    }
+  }
+}
+$: fade = extension.state !== 'started' ? ' brightness-50' : '';
+</script>
+
+{#if icon}
+  <img src="{icon}" alt="{extension.name}" class="max-w-10 max-h-10 {fade}" />
+{:else}
+  <Fa alt="{extension.name}" class="h-10 w-10 rounded-full text-violet-600 {fade}" size="25" icon="{faPuzzlePiece}" />
+{/if}

--- a/packages/renderer/src/lib/preferences/PreferencesExtensionList.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesExtensionList.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 import Fa from 'svelte-fa';
-import { faPuzzlePiece, faTrash, faPlay, faStop, faArrowCircleDown } from '@fortawesome/free-solid-svg-icons';
+import { faTrash, faPlay, faStop, faArrowCircleDown } from '@fortawesome/free-solid-svg-icons';
 import { afterUpdate } from 'svelte';
 import { extensionInfos } from '../../stores/extensions';
 import type { ExtensionInfo } from '../../../../main/src/plugin/api/extension-info';
@@ -9,6 +9,7 @@ import SettingsPage from '../preferences/SettingsPage.svelte';
 import ConnectionStatus from '../ui/ConnectionStatus.svelte';
 import FeaturedExtensions from '../featured/FeaturedExtensions.svelte';
 import Button from '../ui/Button.svelte';
+import ExtensionIcon from './ExtensionIcon.svelte';
 
 export let ociImage: string | undefined = undefined;
 
@@ -123,13 +124,8 @@ async function updateExtension(extension: ExtensionInfo, ociUri: string) {
             <tr class="border-y border-gray-900">
               <td class="px-6 py-2">
                 <div class="flex items-center">
-                  <div class="flex-shrink-0 h-10 w-10 py-3" title="Extension {extension.name} is {extension.state}">
-                    <Fa
-                      class="h-10 w-10 rounded-full {extension.state === 'started'
-                        ? 'text-violet-600'
-                        : 'text-gray-900'}"
-                      size="25"
-                      icon="{faPuzzlePiece}" />
+                  <div class="flex items-center h-10 w-10">
+                    <ExtensionIcon extension="{extension}" />
                   </div>
                   <div class="ml-4">
                     <div class="flex flex-row">


### PR DESCRIPTION
### What does this PR do?

After seeing Luca's PR #5089 I felt like I had to do this. :) Uses the extension's icon in the Settings > Extensions page, using an almost identical component to ProviderLogo. If the extension has no icon, the puzzle piece is still used.

I've put the component in the /preferences folder since that's the only place it is being used for now.

The puzzle pieces used purple vs gray to show whether the extension is running, I've switched to using a brightness filter instead, since it is consistent between the two. Tests included.

### Screenshot/screencast of this PR

Before:

<img width="143" alt="Screenshot 2023-12-03 at 9 28 21 PM" src="https://github.com/containers/podman-desktop/assets/19958075/715421b8-a001-4bc8-8205-fe32c38726ca">

After:

<img width="143" alt="Screenshot 2023-12-03 at 8 56 47 PM" src="https://github.com/containers/podman-desktop/assets/19958075/71950327-d3bd-44ed-bba9-2059808589b8">

(I've stopped the Kube CLI extension in both for comparison)

### What issues does this PR fix or reference?

Fixes #5100.

### How to test this PR?

Go to Settings > Extensions and start/stop some extensions.