### PR TITLE
fix: add style to link (#4880)

### DIFF
--- a/packages/renderer/src/lib/markdown/Markdown.svelte
+++ b/packages/renderer/src/lib/markdown/Markdown.svelte
@@ -1,6 +1,6 @@
 <!-- The markdown rendered has it's own style that you'll have to customize / check against podman desktop 
 UI guidelines -->
-<style>
+<style lang="postcss">
 .markdown > :global(p) {
   line-height: normal;
   padding-bottom: 8px;
@@ -33,6 +33,14 @@ UI guidelines -->
 .markdown > :global(blockquote) {
   opacity: 0.8;
   line-height: normal;
+}
+.markdown :global(a) {
+  color: theme(colors.purple.500);
+  text-decoration: none;
+}
+.markdown :global(a):hover {
+  color: theme(colors.purple.400);
+  text-decoration: underline;
 }
 </style>
 


### PR DESCRIPTION
### What does this PR do?

it adds style to links as it was before

### Screenshot/screencast of this PR

![purple_links_2](https://github.com/containers/podman-desktop/assets/49404737/10b3d339-d869-4397-a4c9-5f70f8b1a4e1)

### What issues does this PR fix or reference?

it closes 4880

### How to test this PR?

1. open the resources page or any other page with a link
