### PR TITLE
feat: register compose cli updater and update compose cli version

### DIFF
--- a/extensions/compose/src/extension.ts
+++ b/extensions/compose/src/extension.ts
@@ -167,9 +167,15 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
       try {
         await handler.installComposeBinary(detect, extensionContext);
         // update the cli version
+        const versionInstalled = composeVersionMetadata.tag.replace('v', '');
         composeCliTool.updateVersion({
-          version: composeVersionMetadata?.tag.replace('v', ''),
+          version: versionInstalled,
         });
+        // if installed version is the newest, dispose the updater
+        const lastReleaseMetadata = await composeDownload.getLatestVersionAsset();
+        if (lastReleaseMetadata.tag.replace('v', '').trim() === versionInstalled) {
+          composeCliToolUpdaterDisposable?.dispose();
+        }
         installed = true;
       } finally {
         telemetryLogger.logUsage('compose.onboarding.installSystemWideCommand', {

--- a/extensions/compose/src/extension.ts
+++ b/extensions/compose/src/extension.ts
@@ -29,6 +29,7 @@ import { installBinaryToSystem } from './cli-run';
 
 let composeVersionMetadata: ComposeGithubReleaseArtifactMetadata | undefined;
 let composeCliTool: extensionApi.CliTool | undefined;
+let composeCliToolUpdaterDisposable: extensionApi.Disposable | undefined;
 const os = new OS();
 
 // Telemetry
@@ -249,7 +250,7 @@ async function postActivate(
   const lastReleaseMetadata = await composeDownload.getLatestVersionAsset();
   const lastReleaseVersion = lastReleaseMetadata.tag.replace('v', '').trim();
   if (lastReleaseVersion !== binaryVersion) {
-    composeCliTool.registerUpdate({
+    composeCliToolUpdaterDisposable = composeCliTool.registerUpdate({
       version: lastReleaseVersion,
       doUpdate: async _logger => {
         // download, install system wide and update cli version
@@ -258,6 +259,7 @@ async function postActivate(
         composeCliTool.updateVersion({
           version: lastReleaseVersion,
         });
+        composeCliToolUpdaterDisposable.dispose();
       },
     });
   }

--- a/packages/main/src/plugin/cli-tool-registry.spec.ts
+++ b/packages/main/src/plugin/cli-tool-registry.spec.ts
@@ -227,6 +227,7 @@ suite('cli module', () => {
 
       // dispose the updater and check it is not called again
       disposeUpdater.dispose();
+      expect(apiSender.send).toBeCalledWith('cli-tool-change', 'ext-publisher.ext-name.tool-name');
       await cliToolRegistry.updateCliTool(newCliTool.id, {} as unknown as Logger);
 
       expect(updateMock).not.toBeCalled();

--- a/packages/main/src/plugin/cli-tool-registry.ts
+++ b/packages/main/src/plugin/cli-tool-registry.ts
@@ -47,6 +47,7 @@ export class CliToolRegistry {
 
     return Disposable.create(() => {
       this.cliToolsUpdater.delete(cliTool.id);
+      this.apiSender.send('cli-tool-change', cliTool.id);
     });
   }
 


### PR DESCRIPTION
### What does this PR do?

It adds the updater for the compose cli. 

### Screenshot/screencast of this PR

![update_composa](https://github.com/containers/podman-desktop/assets/49404737/155d13fe-148b-42c3-b364-1afd75ef19de)

### What issues does this PR fix or reference?

N/A

### How to test this PR?

1. remove compose from your machine
2. go through the onboarding and install an older version
3. go to the cli tools page
4. update compose
