### PR TITLE
feat: icon image component

### DIFF
--- a/packages/renderer/src/lib/appearance/Appearance.svelte
+++ b/packages/renderer/src/lib/appearance/Appearance.svelte
@@ -3,29 +3,15 @@ import { onMount, onDestroy } from 'svelte';
 
 import { AppearanceSettings } from '../../../../main/src/plugin/appearance-settings';
 import { onDidChangeConfiguration } from '../../stores/configurationProperties';
+import { AppearanceUtil } from './appearance-util';
 
 const APPEARANCE_CONFIGURATION_KEY = AppearanceSettings.SectionName + '.' + AppearanceSettings.Appearance;
 async function updateAppearance(): Promise<void> {
-  // get the configuration of the appearance
-  const appearance = await window.getConfigurationValue<string>(APPEARANCE_CONFIGURATION_KEY);
-
-  let isDark = false;
-
-  if (appearance === AppearanceSettings.SystemEnumValue) {
-    // need to read the system default theme using the window.matchMedia
-    isDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-    //FIXME: for now we hardcode to the dark theme even if the Operatin System is using light theme
-    // as it renders correctly only in dark mode today
-    isDark = true;
-  } else if (appearance === AppearanceSettings.LightEnumValue) {
-    isDark = false;
-  } else if (appearance === AppearanceSettings.DarkEnumValue) {
-    isDark = true;
-  }
-
   const html = document.documentElement;
 
   // toggle the dark class on the html element
+  const appearanceUtil = new AppearanceUtil();
+  let isDark = await appearanceUtil.isDarkMode();
   if (isDark) {
     html.classList.add('dark');
     html.setAttribute('style', 'color-scheme: dark;');

--- a/packages/renderer/src/lib/appearance/IconImage.spec.ts
+++ b/packages/renderer/src/lib/appearance/IconImage.spec.ts
@@ -1,0 +1,115 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable no-null/no-null */
+import '@testing-library/jest-dom/vitest';
+import { test, vi, expect, beforeEach } from 'vitest';
+import { render, type RenderResult } from '@testing-library/svelte';
+import Appearance from './Appearance.svelte';
+import { AppearanceSettings } from '../../../../main/src/plugin/appearance-settings';
+
+const getConfigurationValueMock = vi.fn();
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  (window as any).getConfigurationValue = getConfigurationValueMock;
+  (window as any).matchMedia = vi.fn().mockReturnValue({
+    matches: false,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  });
+});
+
+function getRootElement(container: HTMLElement): HTMLElement {
+  // get root html element
+  let rootElement: HTMLElement | null = container;
+  while (rootElement?.parentElement) {
+    rootElement = container.parentElement;
+  }
+  return rootElement as HTMLElement;
+}
+
+function getRootElementClassesValue(container: HTMLElement): string | undefined {
+  return getRootElement(container).classList.value;
+}
+
+async function awaitRender(): Promise<RenderResult<Appearance>> {
+  const result = render(Appearance);
+  // wait end of asynchrounous onMount
+  // wait 200ms
+  await new Promise(resolve => setTimeout(resolve, 200));
+
+  return result;
+}
+
+// temporary as only dark mode is supported as rendering for now
+// it should return empty later
+test('Expect dark mode using system when OS is set to light', async () => {
+  (window as any).matchMedia = vi.fn().mockReturnValue({
+    matches: false,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  });
+
+  getConfigurationValueMock.mockResolvedValue(AppearanceSettings.SystemEnumValue);
+
+  const { container } = await awaitRender();
+
+  const val = getRootElementClassesValue(container);
+
+  // expect to have class being "dark" as for now we force dark mode in system mode
+  expect(val).toBe('dark');
+});
+
+test('Expect dark mode using system when OS is set to dark', async () => {
+  (window as any).matchMedia = vi.fn().mockReturnValue({
+    matches: true,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  });
+
+  getConfigurationValueMock.mockResolvedValue(AppearanceSettings.SystemEnumValue);
+
+  const { container } = await awaitRender();
+  // expect to have class being "dark" as OS is using dark
+  expect(getRootElementClassesValue(container)).toBe('dark');
+});
+
+test('Expect light mode using light configuration', async () => {
+  getConfigurationValueMock.mockResolvedValue(AppearanceSettings.LightEnumValue);
+
+  const { container } = await awaitRender();
+
+  // expect to have class being ""  as we should be in light mode
+  expect(getRootElementClassesValue(container)).toBe('');
+
+  // expect to have color-scheme: light
+  expect(getRootElement(container)).toHaveStyle('color-scheme: light');
+});
+
+test('Expect dark mode using dark configuration', async () => {
+  getConfigurationValueMock.mockResolvedValue(AppearanceSettings.DarkEnumValue);
+
+  const { container } = await awaitRender();
+
+  // expect to have class being "dark" as we should be in light mode
+  expect(getRootElementClassesValue(container)).toBe('dark');
+
+  // expect to have color-scheme: dark
+  expect(getRootElement(container)).toHaveStyle('color-scheme: dark');
+});

--- a/packages/renderer/src/lib/appearance/IconImage.svelte
+++ b/packages/renderer/src/lib/appearance/IconImage.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+import { onMount } from 'svelte';
+import { AppearanceUtil } from './appearance-util';
+
+export let image: string | { light: string; dark: string } | undefined = undefined;
+export let alt: string;
+
+let imgSrc: string | undefined = undefined;
+
+onMount(async () => {
+  const appearanceUtil = new AppearanceUtil();
+  imgSrc = await appearanceUtil.getImage(image);
+});
+</script>
+
+{#if imgSrc}
+  <img src="{imgSrc}" alt="{alt}" class="{$$props.class}" />
+{:else}
+  <slot />
+{/if}

--- a/packages/renderer/src/lib/appearance/appearance-util.ts
+++ b/packages/renderer/src/lib/appearance/appearance-util.ts
@@ -1,0 +1,64 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { AppearanceSettings } from '../../../../main/src/plugin/appearance-settings';
+
+export class AppearanceUtil {
+  async isDarkMode(): Promise<boolean> {
+    // get the configuration of the appearance
+    const appearance = await window.getConfigurationValue<string>(
+      AppearanceSettings.SectionName + '.' + AppearanceSettings.Appearance,
+    );
+
+    let isDark = false;
+
+    if (appearance === AppearanceSettings.SystemEnumValue) {
+      // need to read the system default theme using the window.matchMedia
+      isDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+      //FIXME: for now we hardcode to the dark theme even if the Operatin System is using light theme
+      // as it renders correctly only in dark mode today
+      isDark = true;
+    } else if (appearance === AppearanceSettings.LightEnumValue) {
+      isDark = false;
+    } else if (appearance === AppearanceSettings.DarkEnumValue) {
+      isDark = true;
+    }
+    return isDark;
+  }
+
+  /**
+   * Helper function that returns the correct image to use based on icon and current light vs dark setting.
+   */
+  async getImage(icon: string | { light: string; dark: string } | undefined): Promise<string | undefined> {
+    if (!icon) {
+      return undefined;
+    }
+
+    if (typeof icon === 'string') {
+      return icon;
+    }
+
+    const isDark: boolean = await this.isDarkMode();
+    if (isDark && icon.dark) {
+      return icon.dark;
+    } else if (!isDark && icon.light) {
+      return icon.light;
+    }
+    return undefined;
+  }
+}

--- a/packages/renderer/src/lib/appearance/appearance-utils.spec.ts
+++ b/packages/renderer/src/lib/appearance/appearance-utils.spec.ts
@@ -1,0 +1,107 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { beforeEach, expect, test, vi } from 'vitest';
+import { AppearanceUtil } from './appearance-util';
+import { AppearanceSettings } from '../../../../main/src/plugin/appearance-settings';
+
+const appearanceUtil: AppearanceUtil = new AppearanceUtil();
+
+// mock window.getConfigurationValue
+const getConfigurationValueMock = vi.fn();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  (window as any).getConfigurationValue = getConfigurationValueMock;
+});
+
+// temporary as only dark mode is supported as rendering for now
+// it should return empty later
+test('Expect dark mode using system when OS is set to light', async () => {
+  (window as any).matchMedia = vi.fn().mockReturnValue({
+    matches: false,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  });
+
+  getConfigurationValueMock.mockResolvedValue(AppearanceSettings.SystemEnumValue);
+
+  // expect to have class being "dark" as for now we force dark mode in system mode
+  expect(await appearanceUtil.isDarkMode()).toBe(true);
+});
+
+test('Expect dark mode using system when OS is set to dark', async () => {
+  (window as any).matchMedia = vi.fn().mockReturnValue({
+    matches: true,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  });
+
+  getConfigurationValueMock.mockResolvedValue(AppearanceSettings.SystemEnumValue);
+
+  // expect to have class being "dark" as OS is using dark
+  expect(await appearanceUtil.isDarkMode()).toBe(true);
+});
+
+test('Expect light mode using light configuration', async () => {
+  getConfigurationValueMock.mockResolvedValue(AppearanceSettings.LightEnumValue);
+
+  expect(await appearanceUtil.isDarkMode()).toBe(false);
+});
+
+test('Expect dark mode using dark configuration', async () => {
+  getConfigurationValueMock.mockResolvedValue(AppearanceSettings.DarkEnumValue);
+
+  expect(await appearanceUtil.isDarkMode()).toBe(true);
+});
+
+test('Expect light mode using light configuration', async () => {
+  getConfigurationValueMock.mockResolvedValue(AppearanceSettings.LightEnumValue);
+
+  expect(await appearanceUtil.isDarkMode()).toBe(false);
+});
+
+test('Expect standard icon using dark configuration', async () => {
+  const img = 'icon.png';
+  getConfigurationValueMock.mockResolvedValue(AppearanceSettings.DarkEnumValue);
+
+  expect(await appearanceUtil.getImage(img)).toBe(img);
+});
+
+test('Expect standard icon using light configuration', async () => {
+  const img = 'icon.png';
+  getConfigurationValueMock.mockResolvedValue(AppearanceSettings.LightEnumValue);
+
+  expect(await appearanceUtil.getImage(img)).toBe(img);
+});
+
+test('Expect dark icon using dark configuration', async () => {
+  const img = { light: 'light.png', dark: 'dark.png' };
+  getConfigurationValueMock.mockResolvedValue(AppearanceSettings.DarkEnumValue);
+
+  expect(await appearanceUtil.getImage(img)).toBe(img.dark);
+});
+
+test('Expect light icon using light configuration', async () => {
+  const img = { light: 'light.png', dark: 'dark.png' };
+  getConfigurationValueMock.mockResolvedValue(AppearanceSettings.LightEnumValue);
+
+  expect(await appearanceUtil.getImage(img)).toBe(img.light);
+});


### PR DESCRIPTION
### What does this PR do?

Creates a new IconImage component (couldn't think of a better name) that can display our normal icon/logo pattern of "string | { light: string; dark: string } | undefined" as an image, with the default slot as a fallback.

The logic for which image to use could have been directly in the component, but in order to start sharing code with Appearance.svelte (and in case we have other places that will need to know which theme we're using) I extracted the basic function to appearance-utils.js.

This component would allows us to basically delete components like ProviderLogo and ExtensionIcon and replace with single lines like: <IconImage image="{provider?.images?.logo}" class=".." alt="{provider.name}"/>

### Screenshot / video of UI

N/A, unused so far.

### What issues does this PR fix or reference?

First half of #5116.

### How to test this PR?

`yarn test:renderer`