### PR TITLE
fix: table headers shouldn't allow text selection

### DIFF
--- a/packages/renderer/src/lib/table/Table.spec.ts
+++ b/packages/renderer/src/lib/table/Table.spec.ts
@@ -44,18 +44,36 @@ test('Expect basic table layout', async () => {
   expect(rows[3].textContent).toContain('43');
 });
 
-test('Expect column headers with sort indicators', async () => {
+test('Expect basic column headers', async () => {
   render(TestTable, {});
 
   const headers = await screen.findAllByRole('columnheader');
   expect(headers).toBeDefined();
-  expect(headers.length).toBe(5);
+  expect(headers.length).toBe(6);
   expect(headers[2].textContent).toContain('Id');
-  expect(headers[2].innerHTML).toContain('fa-sort');
+  expect(headers[2]).toHaveClass('select-none');
   expect(headers[3].textContent).toContain('Name');
-  expect(headers[3].innerHTML).toContain('fa-sort');
+  expect(headers[3]).toHaveClass('select-none');
   expect(headers[4].textContent).toContain('Age');
+  expect(headers[4]).toHaveClass('select-none');
+  expect(headers[5].textContent).toContain('Hobby');
+  expect(headers[5]).toHaveClass('select-none');
+});
+
+test('Expect column sort indicators', async () => {
+  render(TestTable, {});
+
+  const headers = await screen.findAllByRole('columnheader');
+  expect(headers).toBeDefined();
+  expect(headers.length).toBe(6);
+  expect(headers[2].innerHTML).toContain('fa-sort');
+  expect(headers[2]).toHaveClass('cursor-pointer');
+  expect(headers[3].innerHTML).toContain('fa-sort');
+  expect(headers[3]).toHaveClass('cursor-pointer');
   expect(headers[4].innerHTML).toContain('fa-sort');
+  expect(headers[4]).toHaveClass('cursor-pointer');
+  expect(headers[5].innerHTML).not.toContain('fa-sort');
+  expect(headers[5]).not.toHaveClass('cursor-pointer');
 });
 
 test('Expect default sort indicator', async () => {
@@ -63,7 +81,7 @@ test('Expect default sort indicator', async () => {
 
   const headers = await screen.findAllByRole('columnheader');
   expect(headers).toBeDefined();
-  expect(headers.length).toBe(5);
+  expect(headers.length).toBe(6);
   expect(headers[2].textContent).toContain('Id');
   expect(headers[2].innerHTML).toContain('fa-sort-up');
 });
@@ -73,7 +91,7 @@ test('Expect no default sort indicator on other columns', async () => {
 
   const headers = await screen.findAllByRole('columnheader');
   expect(headers).toBeDefined();
-  expect(headers.length).toBe(5);
+  expect(headers.length).toBe(6);
   expect(headers[3].innerHTML).not.toContain('fa-sort-up');
   expect(headers[3].innerHTML).not.toContain('fa-sort-down');
   expect(headers[4].innerHTML).not.toContain('fa-sort-up');
@@ -154,25 +172,22 @@ test('Expect sorting by age twice sorts ascending', async () => {
 test('Expect correct aria roles', async () => {
   render(TestTable, {});
 
-  // table data is 3 objects with 3 properties, so
-  // there should be 5 column headers (expander, checkbox, 3 columns)
+  // table data is 3 objects with 4 properties, so
+  // there should be 6 column headers (expander, checkbox, 4 columns)
   const headers = await screen.findAllByRole('columnheader');
   expect(headers).toBeDefined();
-  expect(headers.length).toBe(5);
-  expect(headers[2].textContent).toContain('Id');
-  expect(headers[3].textContent).toContain('Name');
-  expect(headers[4].textContent).toContain('Age');
+  expect(headers.length).toBe(6);
 
   // and 4 rows (first is header)
   const rows = await screen.findAllByRole('row');
   expect(rows).toBeDefined();
   expect(rows.length).toBe(4);
 
-  // and each non-header row should have 5 cells (expander, checkbox, 3 cells)
+  // and each non-header row should have 6 cells (expander, checkbox, 4 cells)
   for (let i = 1; i < 4; i++) {
     const cells = await within(rows[i]).findAllByRole('cell');
     expect(cells).toBeDefined();
-    expect(cells.length).toBe(5);
+    expect(cells.length).toBe(6);
   }
 });
 
@@ -187,7 +202,7 @@ test('Expect rowgroups', async () => {
   // one for the header row
   const headers = await within(rowgroups[0]).findAllByRole('columnheader');
   expect(headers).toBeDefined();
-  expect(headers.length).toBe(5);
+  expect(headers.length).toBe(6);
 
   // and one for the data rows
   const dataRows = await within(rowgroups[1]).findAllByRole('row');

--- a/packages/renderer/src/lib/table/Table.svelte
+++ b/packages/renderer/src/lib/table/Table.svelte
@@ -145,7 +145,8 @@ function setGridColumns() {
             ? 'justify-self-end'
             : column.info.align === 'center'
               ? 'justify-self-center'
-              : 'justify-self-start'} self-center"
+              : 'justify-self-start'} self-center select-none"
+          class:cursor-pointer="{column.info.comparator}"
           on:click="{() => sort(column)}"
           role="columnheader">
           {column.title}{#if column.info.comparator}<i

--- a/packages/renderer/src/lib/table/TestTable.svelte
+++ b/packages/renderer/src/lib/table/TestTable.svelte
@@ -10,12 +10,13 @@ type Person = {
   id: number;
   name: string;
   age: number;
+  hobby: string;
 };
 
 const people: Person[] = [
-  { id: 1, name: 'John', age: 57 },
-  { id: 2, name: 'Henry', age: 27 },
-  { id: 3, name: 'Charlie', age: 43 },
+  { id: 1, name: 'John', age: 57, hobby: 'Skydiving' },
+  { id: 2, name: 'Henry', age: 27, hobby: 'Cooking' },
+  { id: 3, name: 'Charlie', age: 43, hobby: 'Biking' },
 ];
 
 const idCol: Column<Person, string> = new Column('Id', {
@@ -40,7 +41,12 @@ const ageCol: Column<Person, string> = new Column('Age', {
   initialOrder: 'descending',
 });
 
-const columns: Column<Person, string>[] = [idCol, nameCol, ageCol];
+const hobbyCol: Column<Person, string> = new Column('Hobby', {
+  renderMapping: obj => obj.hobby,
+  renderer: SimpleColumn,
+});
+
+const columns: Column<Person, string>[] = [idCol, nameCol, ageCol, hobbyCol];
 
 const row = new Row<Person>({
   selectable: person => person.age < 50,


### PR DESCRIPTION
### What does this PR do?

Our column headers shouldn't allow you to select the text, and sortable columns should have a pointer cursor.

Added another unsortable column to test table to extend tests.

### Screenshot / video of UI

https://github.com/containers/podman-desktop/assets/19958075/1a3e1a37-bf91-4619-ac4e-4d43e68a3123

### What issues does this PR fix or reference?

Fixes #5114.

### How to test this PR?

Go to Volumes page.