### PR TITLE
fix: do not reconnect when connection is removed

### DIFF
--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -236,6 +236,12 @@ export class ContainerProviderRegistry {
       return;
     }
 
+    // abort if connection has been removed
+    if (containerProviderConnection.status() === undefined) {
+      console.log('Aborting reconnect due to error as connection has been removed (probably machine has been removed)');
+      return;
+    }
+
     internalProvider.api = new Dockerode({ socketPath: containerProviderConnection.endpoint.socketPath });
     if (containerProviderConnection.type === 'podman') {
       internalProvider.libpodApi = internalProvider.api as unknown as LibPod;


### PR DESCRIPTION
Signed-off-by: Florent Benoit <fbenoit@redhat.com>

### What does this PR do?
do not reconnect to /events endpoint when connection is removed

### Screenshot / video of UI
N/A

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/5130

### How to test this PR?

unit test added

manual testing: delete a podman machine, you should now see that it does not try to reconnect
