### PR TITLE
fix: do not change color and underline of markdown buttons

### DIFF
--- a/packages/renderer/src/lib/markdown/Markdown.spec.ts
+++ b/packages/renderer/src/lib/markdown/Markdown.spec.ts
@@ -53,7 +53,7 @@ describe('Custom button', () => {
     const markdownContent = screen.getByRole('region', { name: 'markdown-content' });
     expect(markdownContent).toBeInTheDocument();
     expect(markdownContent).toContainHTML(
-      '<a class="px-4 py-[6px] rounded-[4px] text-white text-[13px] whitespace-nowrap bg-purple-600 hover:bg-purple-500 no-underline">Name of the button</a>',
+      '<a class="px-4 py-[6px] rounded-[4px] !text-white text-[13px] whitespace-nowrap bg-purple-600 hover:bg-purple-500 !no-underline">Name of the button</a>',
     );
   });
 

--- a/packages/renderer/src/lib/markdown/micromark-button-directive.ts
+++ b/packages/renderer/src/lib/markdown/micromark-button-directive.ts
@@ -59,7 +59,7 @@ export function button(d: any) {
   } else {
     // If href is passed in, make this an anchor tag but make it look like a button
     this.tag(
-      '<a class="px-4 py-[6px] rounded-[4px] text-white text-[13px] whitespace-nowrap bg-purple-600 hover:bg-purple-500 no-underline"',
+      '<a class="px-4 py-[6px] rounded-[4px] !text-white text-[13px] whitespace-nowrap bg-purple-600 hover:bg-purple-500 !no-underline"',
     );
 
     // Href & title


### PR DESCRIPTION
### What does this PR do?
do not change color and underline of markdown buttons (the one with href)

### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/5137

### How to test this PR?

Check the button has white color and not underlined on hover