### PR TITLE
chore: add cleanup option on providers (plumbing)

### DIFF
--- a/extensions/podman/src/extension.spec.ts
+++ b/extensions/podman/src/extension.spec.ts
@@ -44,6 +44,7 @@ const provider: extensionApi.Provider = {
   registerInstallation: vi.fn(),
   registerUpdate: vi.fn(),
   registerAutostart: vi.fn(),
+  registerCleanup: vi.fn(),
   dispose: vi.fn(),
   name: '',
   id: '',

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -355,6 +355,26 @@ declare module '@podman-desktop/api' {
     start(logger: Logger): Promise<void>;
   }
 
+  /**
+   * Allow to clean some resources in case for example
+   */
+  export interface ProviderCleanup {
+    getActions(): Promise<ProviderCleanupAction[]>;
+  }
+
+  export interface ProviderCleanupExecuteOptions {
+    logger: Logger;
+    token?: CancellationToken;
+  }
+
+  // describe the action to perform
+  // for example, "remove a folder" or 'kill foo process'
+  export interface ProviderCleanupAction {
+    name: string;
+    // execute the action (can be canceled)
+    execute(options: ProviderCleanupExecuteOptions): Promise<void>;
+  }
+
   export type ProviderLinks = Link;
 
   export interface ProviderImages {
@@ -384,6 +404,8 @@ declare module '@podman-desktop/api' {
 
     // register autostart flow
     registerAutostart(autostart: ProviderAutostart): Disposable;
+
+    registerCleanup(cleanup: ProviderCleanup): Disposable;
 
     dispose(): void;
     readonly name: string;

--- a/packages/main/src/plugin/api/provider-info.ts
+++ b/packages/main/src/plugin/api/provider-info.ts
@@ -24,6 +24,7 @@ import type {
   ProviderStatus,
   Link,
   ProviderInformation,
+  ProviderCleanupAction,
 } from '@podman-desktop/api';
 
 export type LifecycleMethod = 'start' | 'stop' | 'delete' | 'edit';
@@ -93,6 +94,9 @@ export interface ProviderInfo {
   // can install a provider
   installationSupport: boolean;
 
+  // can perform cleanup operation
+  cleanupSupport: boolean;
+
   // can update a provider
   updateInfo?: {
     version: string;
@@ -114,4 +118,11 @@ export interface CheckStatus {
 export interface PreflightCheckEvent {
   type: 'start' | 'stop';
   status: CheckStatus;
+}
+
+export interface ProviderCleanupActionInfo {
+  providerId: string;
+  providerName: string;
+  actions: Promise<ProviderCleanupAction[]>;
+  instance: unknown;
 }

--- a/packages/main/src/plugin/api/provider-info.ts
+++ b/packages/main/src/plugin/api/provider-info.ts
@@ -24,7 +24,6 @@ import type {
   ProviderStatus,
   Link,
   ProviderInformation,
-  ProviderCleanupAction,
 } from '@podman-desktop/api';
 
 export type LifecycleMethod = 'start' | 'stop' | 'delete' | 'edit';
@@ -118,11 +117,4 @@ export interface CheckStatus {
 export interface PreflightCheckEvent {
   type: 'start' | 'stop';
   status: CheckStatus;
-}
-
-export interface ProviderCleanupActionInfo {
-  providerId: string;
-  providerName: string;
-  actions: Promise<ProviderCleanupAction[]>;
-  instance: unknown;
 }

--- a/packages/main/src/plugin/api/provider-info.ts
+++ b/packages/main/src/plugin/api/provider-info.ts
@@ -24,6 +24,7 @@ import type {
   ProviderStatus,
   Link,
   ProviderInformation,
+  ProviderCleanupAction,
 } from '@podman-desktop/api';
 
 export type LifecycleMethod = 'start' | 'stop' | 'delete' | 'edit';
@@ -117,4 +118,11 @@ export interface CheckStatus {
 export interface PreflightCheckEvent {
   type: 'start' | 'stop';
   status: CheckStatus;
+}
+
+export interface ProviderCleanupActionInfo {
+  providerId: string;
+  providerName: string;
+  actions: Promise<ProviderCleanupAction[]>;
+  instance: unknown;
 }

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1226,6 +1226,18 @@ export class PluginSystem {
       return providerRegistry.getProviderInfos();
     });
 
+    this.ipcHandle(
+      'provider-registry:cleanup',
+      async (_listener, providerIds: string[], loggerId: string, tokenId: number): Promise<void> => {
+        const logger = this.getLogHandler('provider-registry:cleanup-onData', loggerId);
+
+        const tokenSource = cancellationTokenRegistry.getCancellationTokenSource(tokenId);
+        const token = tokenSource?.token;
+
+        return providerRegistry.executeCleanupActions(logger, providerIds, token);
+      },
+    );
+
     this.ipcHandle('cli-tool-registry:getCliToolInfos', async (): Promise<CliToolInfo[]> => {
       return cliToolRegistry.getCliToolInfos();
     });

--- a/packages/main/src/plugin/provider-impl.ts
+++ b/packages/main/src/plugin/provider-impl.ts
@@ -39,6 +39,7 @@ import type {
   KubernetesProviderConnectionFactory,
   ProviderInformation,
   Auditor,
+  ProviderCleanup,
 } from '@podman-desktop/api';
 import type { ProviderRegistry } from './provider-registry.js';
 import { Emitter } from './events/emitter.js';
@@ -258,5 +259,9 @@ export class ProviderImpl implements Provider, IDisposable {
 
   registerAutostart(update: ProviderAutostart): Disposable {
     return this.providerRegistry.registerAutostart(this, update);
+  }
+
+  registerCleanup(cleanup: ProviderCleanup): Disposable {
+    return this.providerRegistry.registerCleanup(this, cleanup);
   }
 }

--- a/packages/main/src/tray-menu.ts
+++ b/packages/main/src/tray-menu.ts
@@ -87,6 +87,7 @@ export class TrayMenu {
             kubernetesProviderConnectionCreation: false,
             containerProviderConnectionInitialization: false,
             kubernetesProviderConnectionInitialization: false,
+            cleanupSupport: false,
             extensionId: '',
           });
         }

--- a/packages/renderer/src/lib/dashboard/ProviderInstalled.spec.ts
+++ b/packages/renderer/src/lib/dashboard/ProviderInstalled.spec.ts
@@ -64,6 +64,7 @@ test('Expect installed provider shows button', async () => {
     status: 'installed',
     warnings: [],
     extensionId: '',
+    cleanupSupport: false,
   };
 
   const initializationContext: InitializationContext = { mode: InitializeAndStartMode };
@@ -110,6 +111,7 @@ test('Expect to see the initialize context error if provider installation fails'
     status: 'installed',
     warnings: [],
     extensionId: '',
+    cleanupSupport: false,
   };
 
   const initializationContext: InitializationContext = { mode: InitializeAndStartMode };

--- a/packages/renderer/src/lib/dashboard/ProviderStatusTestHelper.spec.ts
+++ b/packages/renderer/src/lib/dashboard/ProviderStatusTestHelper.spec.ts
@@ -56,6 +56,7 @@ export function verifyStatus<C extends SvelteComponent>(
       version: sameVersions ? '1.0.0' : '1.0.1',
     },
     extensionId: '',
+    cleanupSupport: false,
   };
 
   const initializationContext = { mode: InitializeAndStartMode };

--- a/packages/renderer/src/lib/onboarding/OnboardingComponent.spec.ts
+++ b/packages/renderer/src/lib/onboarding/OnboardingComponent.spec.ts
@@ -53,6 +53,7 @@ const providerInfo: ProviderInfo = {
   containerProviderConnectionCreationDisplayName: 'Podman machine',
   kubernetesProviderConnectionInitialization: false,
   extensionId: 'id',
+  cleanupSupport: false,
 };
 
 async function waitRender(customProperties: any): Promise<void> {

--- a/packages/renderer/src/lib/pod/PodCreateFromContainers.spec.ts
+++ b/packages/renderer/src/lib/pod/PodCreateFromContainers.spec.ts
@@ -55,6 +55,7 @@ const providerInfo: ProviderInfo = {
   containerProviderConnectionCreationDisplayName: 'Podman machine',
   kubernetesProviderConnectionInitialization: false,
   extensionId: '',
+  cleanupSupport: false,
 };
 
 const podCreation: PodCreation = {

--- a/packages/renderer/src/lib/pod/PodsList.spec.ts
+++ b/packages/renderer/src/lib/pod/PodsList.spec.ts
@@ -60,6 +60,7 @@ const provider: ProviderInfo = {
   status: 'started',
   warnings: [],
   extensionId: '',
+  cleanupSupport: false,
 };
 
 const pod1: PodInfo = {

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionActions.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionActions.spec.ts
@@ -46,6 +46,7 @@ const containerProviderInfo: ProviderInfo = {
   containerProviderConnectionInitialization: false,
   kubernetesProviderConnectionInitialization: false,
   extensionId: '',
+  cleanupSupport: false,
 };
 
 const containerConnection: ProviderContainerConnectionInfo = {

--- a/packages/renderer/src/lib/preferences/PreferencesContainerConnectionRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesContainerConnectionRendering.spec.ts
@@ -331,6 +331,7 @@ test('Expect startContainerProvider to only be called once when restarting', asy
     containerProviderConnectionCreationDisplayName: 'Podman machine',
     kubernetesProviderConnectionInitialization: false,
     extensionId: '',
+    cleanupSupport: false,
   };
 
   providerInfos.set([providerInfo]);

--- a/packages/renderer/src/lib/preferences/PreferencesContainerConnectionRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesContainerConnectionRendering.spec.ts
@@ -81,6 +81,7 @@ test('Expect that the right machine is displayed', async () => {
     containerProviderConnectionCreationDisplayName: 'Podman machine',
     kubernetesProviderConnectionInitialization: false,
     extensionId: '',
+    cleanupSupport: false,
   };
 
   // 3 connections with the same socket path
@@ -159,6 +160,7 @@ test('Expect that removing the connection is going back to the previous page', a
     containerProviderConnectionCreationDisplayName: 'Podman machine',
     kubernetesProviderConnectionInitialization: false,
     extensionId: '',
+    cleanupSupport: false,
   };
 
   // 3 connections with the same socket path
@@ -250,6 +252,7 @@ test('Expect to see error message if action fails', async () => {
     containerProviderConnectionCreationDisplayName: 'Podman machine',
     kubernetesProviderConnectionInitialization: false,
     extensionId: '',
+    cleanupSupport: false,
   };
 
   providerInfos.set([providerInfo]);

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesConnectionRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesConnectionRendering.spec.ts
@@ -83,6 +83,7 @@ test('Expect that removing the connection is going back to the previous page', a
     containerProviderConnectionCreationDisplayName: 'Podman machine',
     kubernetesProviderConnectionInitialization: false,
     extensionId: '',
+    cleanupSupport: false,
   };
 
   // 3 connections with the same socket path
@@ -170,6 +171,7 @@ test('Expect to see error message if action fails', async () => {
     containerProviderConnectionCreationDisplayName: 'Podman machine',
     kubernetesProviderConnectionInitialization: false,
     extensionId: '',
+    cleanupSupport: false,
   };
 
   providerInfos.set([providerInfo]);

--- a/packages/renderer/src/lib/preferences/PreferencesProviderInstallationModal.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesProviderInstallationModal.spec.ts
@@ -53,6 +53,7 @@ const providerInfo: ProviderInfo = {
   containerProviderConnectionCreationDisplayName: 'Podman machine',
   kubernetesProviderConnectionInitialization: false,
   extensionId: '',
+  cleanupSupport: false,
 };
 
 const closeCallback = vi.fn();

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.spec.ts
@@ -59,6 +59,7 @@ const providerInfo: ProviderInfo = {
   containerProviderConnectionInitialization: false,
   containerProviderConnectionCreationDisplayName: 'Podman machine',
   kubernetesProviderConnectionInitialization: false,
+  cleanupSupport: false,
 };
 
 // mock the router


### PR DESCRIPTION
### What does this PR do?
extensions can register some cleanup methods

### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/5015

### How to test this PR?

you can call `registerCleanup` on a provider (but it won't be used)