### PR TITLE
chore: simplify pod actions & callbacks

### DIFF
--- a/packages/renderer/src/lib/pod/PodActions.spec.ts
+++ b/packages/renderer/src/lib/pod/PodActions.spec.ts
@@ -30,13 +30,16 @@ const pod: PodInfoUI = {
   kind: 'podman',
 } as PodInfoUI;
 
-const errorCallback = vi.fn();
 const listContainersMock = vi.fn();
 const getContributedMenusMock = vi.fn();
+const updateMock = vi.fn();
 
 beforeEach(() => {
   (window as any).kubernetesDeletePod = vi.fn();
   (window as any).listContainers = listContainersMock;
+  (window as any).startPod = vi.fn();
+  (window as any).stopPod = vi.fn();
+  (window as any).restartPod = vi.fn();
   (window as any).removePod = vi.fn();
 
   listContainersMock.mockResolvedValue([
@@ -52,14 +55,62 @@ afterEach(() => {
   vi.clearAllMocks();
 });
 
-test('Expect no error deleting pod', async () => {
+test('Expect no error and status starting pod', async () => {
   listContainersMock.mockResolvedValue([]);
 
-  render(PodActions, { pod, errorCallback });
+  const { component } = render(PodActions, {pod});
+	component.$on("update", updateMock);
+
+  // click on start button
+  const startButton = screen.getByRole('button', { name: 'Start Pod' });
+  await fireEvent.click(startButton);
+
+  expect(pod.status).toEqual('STARTING');
+  expect(pod.actionError).toEqual('');
+  expect(updateMock).toHaveBeenCalled();
+});
+
+test('Expect no error and status stopping pod', async () => {
+  listContainersMock.mockResolvedValue([]);
+
+  const { component } = render(PodActions, {pod});
+	component.$on("update", updateMock);
+
+  // click on stop button
+  const stopButton = screen.getByRole('button', { name: 'Stop Pod' });
+  await fireEvent.click(stopButton);
+
+  expect(pod.status).toEqual('STOPPING');
+  expect(pod.actionError).toEqual('');
+  expect(updateMock).toHaveBeenCalled();
+});
+
+test('Expect no error and status restarting pod', async () => {
+  listContainersMock.mockResolvedValue([]);
+
+  const { component } = render(PodActions, {pod});
+	component.$on("update", updateMock);
+
+  // click on restart button
+  const restartButton = screen.getByRole('button', { name: 'Restart Pod' });
+  await fireEvent.click(restartButton);
+
+  expect(pod.status).toEqual('RESTARTING');
+  expect(pod.actionError).toEqual('');
+  expect(updateMock).toHaveBeenCalled();
+});
+
+test('Expect no error and status deleting pod', async () => {
+  listContainersMock.mockResolvedValue([]);
+
+  const { component } = render(PodActions, {pod});
+	component.$on("update", updateMock);
 
   // click on delete button
   const deleteButton = screen.getByRole('button', { name: 'Delete Pod' });
   await fireEvent.click(deleteButton);
 
-  expect(errorCallback).not.toHaveBeenCalled();
+  expect(pod.status).toEqual('DELETING');
+  expect(pod.actionError).toEqual('');
+  expect(updateMock).toHaveBeenCalled();
 });

--- a/packages/renderer/src/lib/pod/PodActions.spec.ts
+++ b/packages/renderer/src/lib/pod/PodActions.spec.ts
@@ -58,8 +58,8 @@ afterEach(() => {
 test('Expect no error and status starting pod', async () => {
   listContainersMock.mockResolvedValue([]);
 
-  const { component } = render(PodActions, {pod});
-	component.$on("update", updateMock);
+  const { component } = render(PodActions, { pod });
+  component.$on('update', updateMock);
 
   // click on start button
   const startButton = screen.getByRole('button', { name: 'Start Pod' });
@@ -73,8 +73,8 @@ test('Expect no error and status starting pod', async () => {
 test('Expect no error and status stopping pod', async () => {
   listContainersMock.mockResolvedValue([]);
 
-  const { component } = render(PodActions, {pod});
-	component.$on("update", updateMock);
+  const { component } = render(PodActions, { pod });
+  component.$on('update', updateMock);
 
   // click on stop button
   const stopButton = screen.getByRole('button', { name: 'Stop Pod' });
@@ -88,8 +88,8 @@ test('Expect no error and status stopping pod', async () => {
 test('Expect no error and status restarting pod', async () => {
   listContainersMock.mockResolvedValue([]);
 
-  const { component } = render(PodActions, {pod});
-	component.$on("update", updateMock);
+  const { component } = render(PodActions, { pod });
+  component.$on('update', updateMock);
 
   // click on restart button
   const restartButton = screen.getByRole('button', { name: 'Restart Pod' });
@@ -103,8 +103,8 @@ test('Expect no error and status restarting pod', async () => {
 test('Expect no error and status deleting pod', async () => {
   listContainersMock.mockResolvedValue([]);
 
-  const { component } = render(PodActions, {pod});
-	component.$on("update", updateMock);
+  const { component } = render(PodActions, { pod });
+  component.$on('update', updateMock);
 
   // click on delete button
   const deleteButton = screen.getByRole('button', { name: 'Delete Pod' });

--- a/packages/renderer/src/lib/pod/PodActions.svelte
+++ b/packages/renderer/src/lib/pod/PodActions.svelte
@@ -220,5 +220,6 @@ if (dropdownMenu) {
     contextPrefix="podItem"
     dropdownMenu="{dropdownMenu}"
     contributions="{contributions}"
+    detailed="{detailed}"
     onError="{handleError}" />
 </svelte:component>

--- a/packages/renderer/src/lib/pod/PodActions.svelte
+++ b/packages/renderer/src/lib/pod/PodActions.svelte
@@ -78,7 +78,7 @@ async function startPod() {
   } catch (error) {
     handleError(String(error));
   } finally {
-    inProgress(false, 'RUNNING');
+    inProgress(false);
   }
 }
 
@@ -100,7 +100,7 @@ async function stopPod() {
   } catch (error) {
     handleError(String(error));
   } finally {
-    inProgress(false, 'STOPPED');
+    inProgress(false);
   }
 }
 

--- a/packages/renderer/src/lib/pod/PodActions.svelte
+++ b/packages/renderer/src/lib/pod/PodActions.svelte
@@ -15,7 +15,7 @@ import DropdownMenu from '../ui/DropdownMenu.svelte';
 import FlatMenu from '../ui/FlatMenu.svelte';
 import type { Menu } from '../../../../main/src/plugin/menu-registry';
 import ContributionActions from '/@/lib/actions/ContributionActions.svelte';
-import { onMount } from 'svelte';
+import { createEventDispatcher, onMount } from 'svelte';
 import { MenuContext } from '../../../../main/src/plugin/menu-registry';
 import { ContainerUtils } from '../container/container-utils';
 
@@ -23,8 +23,7 @@ export let pod: PodInfoUI;
 export let dropdownMenu = false;
 export let detailed = false;
 
-export let inProgressCallback: (inProgress: boolean, state?: string) => void = () => {};
-export let errorCallback: (erroMessage: string) => void = () => {};
+const dispatch = createEventDispatcher<{ update: PodInfoUI }>();
 
 let contributions: Menu[] = [];
 onMount(async () => {
@@ -53,51 +52,70 @@ onMount(async () => {
   });
 });
 
-async function startPod(podInfoUI: PodInfoUI) {
-  inProgressCallback(true, 'STARTING');
+function inProgress(inProgress: boolean, state?: string): void {
+  pod.actionInProgress = inProgress;
+  // reset error when starting task
+  if (inProgress) {
+    pod.actionError = '';
+  }
+  if (state) {
+    pod.status = state;
+  }
+
+  dispatch('update', pod);
+}
+
+function handleError(errorMessage: string): void {
+  pod.actionError = errorMessage;
+  pod.status = 'ERROR';
+  dispatch('update', pod);
+}
+
+async function startPod() {
+  inProgress(true, 'STARTING');
   try {
-    await window.startPod(podInfoUI.engineId, podInfoUI.id);
+    await window.startPod(pod.engineId, pod.id);
   } catch (error) {
-    errorCallback(String(error));
+    handleError(String(error));
   } finally {
-    inProgressCallback(false, 'RUNNING');
+    inProgress(false, 'RUNNING');
   }
 }
 
-async function restartPod(podInfoUI: PodInfoUI) {
-  inProgressCallback(true, 'RESTARTING');
+async function restartPod() {
+  inProgress(false, 'RESTARTING');
   try {
-    await window.restartPod(podInfoUI.engineId, podInfoUI.id);
+    await window.restartPod(pod.engineId, pod.id);
   } catch (error) {
-    errorCallback(String(error));
+    handleError(String(error));
   } finally {
-    inProgressCallback(false);
+    inProgress(false);
   }
 }
 
-async function stopPod(podInfoUI: PodInfoUI) {
-  inProgressCallback(true, 'STOPPING');
+async function stopPod() {
+  inProgress(false, 'STOPPING');
   try {
-    await window.stopPod(podInfoUI.engineId, podInfoUI.id);
+    await window.stopPod(pod.engineId, pod.id);
   } catch (error) {
-    errorCallback(String(error));
+    handleError(String(error));
   } finally {
-    inProgressCallback(false, 'STOPPED');
+    inProgress(false, 'STOPPED');
   }
 }
 
-async function deletePod(podInfoUI: PodInfoUI): Promise<void> {
-  inProgressCallback(true, 'DELETING');
+async function deletePod(): Promise<void> {
+  inProgress(false, 'DELETING');
   try {
     if (pod.kind === 'podman') {
-      await window.removePod(podInfoUI.engineId, podInfoUI.id);
+      await window.removePod(pod.engineId, pod.id);
     } else {
-      await window.kubernetesDeletePod(podInfoUI.name);
+      await window.kubernetesDeletePod(pod.name);
     }
   } catch (error) {
-    errorCallback(String(error));
+    handleError(String(error));
   } finally {
-    inProgressCallback(false);
+    inProgress(false);
   }
 }
 
@@ -121,7 +139,7 @@ if (dropdownMenu) {
 {#if pod.kind === 'podman'}
   <ListItemButtonIcon
     title="Start Pod"
-    onClick="{() => startPod(pod)}"
+    onClick="{() => startPod()}"
     hidden="{pod.status === 'RUNNING' || pod.status === 'STOPPING'}"
     detailed="{detailed}"
     inProgress="{pod.actionInProgress && pod.status === 'STARTING'}"
@@ -129,7 +147,7 @@ if (dropdownMenu) {
     iconOffset="pl-[0.15rem]" />
   <ListItemButtonIcon
     title="Stop Pod"
-    onClick="{() => stopPod(pod)}"
+    onClick="{() => stopPod()}"
     hidden="{!(pod.status === 'RUNNING' || pod.status === 'STOPPING')}"
     detailed="{detailed}"
     inProgress="{pod.actionInProgress && pod.status === 'STOPPING'}"
@@ -137,7 +155,7 @@ if (dropdownMenu) {
 {/if}
 <ListItemButtonIcon
   title="Delete Pod"
-  onClick="{() => deletePod(pod)}"
+  onClick="{() => deletePod()}"
   icon="{faTrash}"
   detailed="{detailed}"
   inProgress="{pod.actionInProgress && pod.status === 'DELETING'}" />
@@ -192,7 +210,7 @@ if (dropdownMenu) {
     {/if}
     <ListItemButtonIcon
       title="Restart Pod"
-      onClick="{() => restartPod(pod)}"
+      onClick="{() => restartPod()}"
       menu="{dropdownMenu}"
       detailed="{detailed}"
       icon="{faArrowsRotate}" />
@@ -202,6 +220,5 @@ if (dropdownMenu) {
     contextPrefix="podItem"
     dropdownMenu="{dropdownMenu}"
     contributions="{contributions}"
-    detailed="{detailed}"
-    onError="{errorCallback}" />
+    onError="{handleError}" />
 </svelte:component>

--- a/packages/renderer/src/lib/pod/PodDetails.svelte
+++ b/packages/renderer/src/lib/pod/PodDetails.svelte
@@ -42,18 +42,6 @@ onMount(() => {
     }
   });
 });
-
-function inProgressCallback(inProgress: boolean, state: string | undefined): void {
-  pod.actionInProgress = inProgress;
-  if (state && inProgress) {
-    pod.status = state;
-  }
-}
-
-function errorCallback(errorMessage: string): void {
-  pod.actionError = errorMessage;
-  pod.status = 'ERROR';
-}
 </script>
 
 {#if pod}
@@ -67,11 +55,7 @@ function errorCallback(errorMessage: string): void {
           <div>&nbsp;</div>
         {/if}
       </div>
-      <PodActions
-        pod="{pod}"
-        inProgressCallback="{(flag, state) => inProgressCallback(flag, state)}"
-        errorCallback="{error => errorCallback(error)}"
-        detailed="{true}" />
+      <PodActions pod="{pod}" detailed="{true}" on:update="{() => (pod = pod)}" />
     </svelte:fragment>
     <div slot="detail" class="flex py-2 w-full justify-end text-sm text-gray-700">
       <StateChange state="{pod.status}" />

--- a/packages/renderer/src/lib/pod/PodsList.svelte
+++ b/packages/renderer/src/lib/pod/PodsList.svelte
@@ -178,25 +178,6 @@ function computeInterval(): number {
   // every day
   return 60 * 60 * 24 * SECOND;
 }
-
-function inProgressCallback(pod: PodInfoUI, inProgress: boolean, state?: string): void {
-  pod.actionInProgress = inProgress;
-  // reset error when starting task
-  if (inProgress) {
-    pod.actionError = '';
-  }
-  if (state) {
-    pod.status = state;
-  }
-
-  pods = [...pods];
-}
-
-function errorCallback(pod: PodInfoUI, errorMessage: string): void {
-  pod.actionError = errorMessage;
-  pod.status = 'ERROR';
-  pods = [...pods];
-}
 </script>
 
 <NavPage bind:searchTerm="{searchTerm}" title="pods">
@@ -340,11 +321,7 @@ function errorCallback(pod: PodInfoUI, errorMessage: string): void {
                   {/if}
                 </div>
                 <div class="text-right w-full">
-                  <PodActions
-                    pod="{pod}"
-                    errorCallback="{error => errorCallback(pod, error)}"
-                    inProgressCallback="{(flag, state) => inProgressCallback(pod, flag, state)}"
-                    dropdownMenu="{true}" />
+                  <PodActions pod="{pod}" dropdownMenu="{true}" on:update="{() => (pods = [...pods])}" />
                 </div>
               </div>
             </td>


### PR DESCRIPTION
### What does this PR do?

It has been bugging me for a while that PodActions has a callback when an action affects a pod, and both PodList and PodDetails have essentially the same response of updating the pod UI object, and then PodList needs to trigger the UI to update. PodActions also passes a podInfoUI to functions when it already has the pod as a property.

When trying to extract columns to use the Table component this gets uglier because there is an intermediate component that needs to pass the callbacks through as well, so I figure it's a good time to simplify this a bit first.

This change just makes the PodAction update the pod UI object itself, and then uses a standard dispatch event to notify parents that something changed. Both PodList and PodDetails just need an on:update to trigger a Svelte update. Simpler/less code all around and less chance of PodList and PodDetails having different behaviour.

Note that there's one thing that still bothers me but is not fixed in this change: PodList and PodDetails use their own copies of PodInfoUI objects, so if you click Start in one view and then switch quickly, the pod is still stopped for a couple seconds in the other view. That is a separate problem but at least this change might make it marginally easier to fix in the future.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Cleanup prior to #4842.

### How to test this PR?

`yarn test:renderer` or use PodList/PodDetails. As a code simplification chore, there should be no change to behaviour or tests.