### PR TITLE
chore(tests): adding application deployment check and some other checks

### DIFF
--- a/tests/src/model/pages/container-details-page.ts
+++ b/tests/src/model/pages/container-details-page.ts
@@ -87,13 +87,12 @@ export class ContainerDetailsPage extends BasePage {
     return new ContainersPage(this.page);
   }
 
-  async checkMappedPort(port: string): Promise<boolean> {
+  async getContainerPort(): Promise<string> {
     await this.activateTab(ContainerDetailsPage.SUMMARY_TAB);
     const summaryTable = this.getPage().getByRole('table');
     const portsRow = summaryTable.locator('tr:has-text("Ports")');
     const portsCell = portsRow.getByRole('cell').nth(1);
     await portsCell.waitFor({ state: 'visible', timeout: 500 });
-    const portsText = await portsCell.innerText();
-    return portsText.includes(port);
+    return await portsCell.innerText({ timeout: 5000 });
   }
 }

--- a/tests/src/model/pages/pods-page.ts
+++ b/tests/src/model/pages/pods-page.ts
@@ -89,4 +89,22 @@ export class PodsPage extends BasePage {
     await handleConfirmationDialog(this.page, 'Prune');
     return this;
   }
+
+  async selectPod(names: string[]): Promise<void> {
+    for await (const containerName of names) {
+      const row = await this.getPodRowByName(containerName);
+      if (row === undefined) {
+        throw Error('Pod cannot be selected');
+      }
+      await row.getByRole('cell').nth(1).click();
+    }
+  }
+
+  async getPodActionsMenu(name: string): Promise<Locator> {
+    const row = await this.getPodRowByName(name);
+    if (row === undefined) {
+      throw Error('Cannot select actions menu, pod does not exist');
+    }
+    return row.getByRole('button', { name: 'kebab menu', exact: true });
+  }
 }


### PR DESCRIPTION
### What does this PR do?

Updates the pod testing suite with application deployment check, check that containers, from which pod was created are stopped, check that start, restart, stop buttons in pods and pod details pages work. Also checking pop-up menu on pods page.
### Screenshot / video of UI

![image](https://github.com/containers/podman-desktop/assets/75624842/089f6bbb-5efc-47a3-94a0-41f7af3a2a0c)

### What issues does this PR fix or reference?

Closes [#4279](https://github.com/containers/podman-desktop/issues/4279)

### How to test this PR?

Run yarn test:e2e:smoke command
