### PR TITLE
Extension installation through OCI image

### DIFF
--- a/packages/renderer/src/lib/docker-extension/PreferencesPageDockerExtensions.spec.ts
+++ b/packages/renderer/src/lib/docker-extension/PreferencesPageDockerExtensions.spec.ts
@@ -39,7 +39,7 @@ describe('PreferencesPageDockerExtensions', () => {
   test('Expect that textbox is available and button is displayed', async () => {
     render(PreferencesPageDockerExtensions, {});
 
-    const input = screen.getByRole('textbox', { name: 'Image name:' });
+    const input = screen.getByRole('textbox', { name: 'OCI Image Name' });
     expect(input).toBeInTheDocument();
     const button = screen.getByRole('button', { name: buttonText });
     expect(button).toBeInTheDocument();

--- a/packages/renderer/src/lib/docker-extension/PreferencesPageDockerExtensions.svelte
+++ b/packages/renderer/src/lib/docker-extension/PreferencesPageDockerExtensions.svelte
@@ -72,7 +72,8 @@ function deleteContribution(extensionName: string) {
         <input
           name="ociImage"
           id="ociImage"
-          aria-label="ociImage"
+          aria-label="OCI Image Name"
+          type="text"
           bind:value="{ociImage}"
           placeholder="Name of the Image"
           class="text-sm rounded-sm focus:ring-purple-500 focus:border-purple-500 block p-2.5 bg-charcoal-800 border-gray-900 placeholder-gray-400 text-white"

--- a/packages/renderer/src/lib/docker-extension/PreferencesPageDockerExtensions.svelte
+++ b/packages/renderer/src/lib/docker-extension/PreferencesPageDockerExtensions.svelte
@@ -72,6 +72,7 @@ function deleteContribution(extensionName: string) {
         <input
           name="ociImage"
           id="ociImage"
+          aria-label="ociImage"
           bind:value="{ociImage}"
           placeholder="Name of the Image"
           class="text-sm rounded-sm focus:ring-purple-500 focus:border-purple-500 block p-2.5 bg-charcoal-800 border-gray-900 placeholder-gray-400 text-white"

--- a/packages/renderer/src/lib/preferences/PreferencesExtensionList.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesExtensionList.svelte
@@ -91,7 +91,8 @@ async function updateExtension(extension: ExtensionInfo, ociUri: string) {
           <input
             name="ociImage"
             id="ociImage"
-            aria-label="ociImage"
+            aria-label="OCI Image Name"
+            type="text"
             bind:value="{ociImage}"
             placeholder="Name of the Image"
             class="w-1/2 p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700"

--- a/packages/renderer/src/lib/preferences/PreferencesExtensionList.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesExtensionList.svelte
@@ -80,7 +80,7 @@ async function updateExtension(extension: ExtensionInfo, ociUri: string) {
       <FeaturedExtensions />
     </div>
 
-    <div class="bg-charcoal-700 mt-5 rounded-md p-3">
+    <div class="bg-charcoal-700 mt-5 rounded-md p-3" role="region" aria-label="OCI image installation box">
       <h1 class="text-lg mb-2">Install a new extension from OCI Image</h1>
 
       <div class="flex flex-col w-full">
@@ -91,6 +91,7 @@ async function updateExtension(extension: ExtensionInfo, ociUri: string) {
           <input
             name="ociImage"
             id="ociImage"
+            aria-label="ociImage"
             bind:value="{ociImage}"
             placeholder="Name of the Image"
             class="w-1/2 p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700"

--- a/tests/src/extension-installation.spec.ts
+++ b/tests/src/extension-installation.spec.ts
@@ -39,6 +39,7 @@ let extensionSettingsBox: Locator;
 let installButtonLabel: string;
 let settingsLink: string;
 let resourceLabel: string;
+let imageLink: string;
 
 const _startup = async function () {
   console.log('running before all');
@@ -93,7 +94,17 @@ describe.each([
   });
 
   test('Install extension through Settings', async () => {
-    const installButton = extensionSettingsBox.getByRole('button', { name: installButtonLabel });
+    let installButton = extensionSettingsBox.getByRole('button', { name: installButtonLabel });
+    if (await installButton.isHidden()) {
+      const settingsPage = new SettingsExtensionsPage(page);
+      const imageInstallBox = settingsPage.imageInstallBox;
+      const imageInput = imageInstallBox.getByLabel('ociImage');
+      await imageInput.fill(imageLink);
+
+      installButton = imageInstallBox.getByRole('button', { name: 'Install extension from the OCI image' });
+      await installButton.isEnabled();
+    }
+
     await installButton.click();
     const installedLabel = extensionSettingsBox.getByText('installed');
     await playExpect(installedLabel).toBeVisible({ timeout: 180000 });
@@ -193,6 +204,7 @@ function initializeLocators(extensionType: string) {
       installButtonLabel = 'Install redhat.redhat-sandbox Extension';
       settingsLink = 'Red Hat OpenShift Sandbox';
       resourceLabel = 'redhat.sandbox';
+      imageLink = 'ghcr.io/redhat-developer/podman-desktop-sandbox-ext:0.0.2';
       break;
     }
     case 'Openshift Local': {
@@ -203,6 +215,7 @@ function initializeLocators(extensionType: string) {
       installButtonLabel = 'Install redhat.openshift-local Extension';
       settingsLink = 'Red Hat OpenShift Local';
       resourceLabel = 'crc';
+      imageLink = 'quay.io/redhat-developer/openshift-local-extension:v1.3.0';
       break;
     }
   }

--- a/tests/src/model/pages/dashboard-page.ts
+++ b/tests/src/model/pages/dashboard-page.ts
@@ -18,7 +18,6 @@
 
 import type { Locator, Page } from '@playwright/test';
 import { BasePage } from './base-page';
-import * as os from 'os';
 
 export class DashboardPage extends BasePage {
   readonly mainPage: Locator;
@@ -43,20 +42,11 @@ export class DashboardPage extends BasePage {
 
     this.devSandboxProvider = page.getByLabel('Developer Sandbox Provider');
     this.devSandboxBox = this.featuredExtensions.getByLabel('Developer Sandbox');
-    this.devSandboxEnabledStatus = page.getByText('Developer Sandbox is running');
+    this.devSandboxEnabledStatus = this.devSandboxProvider.getByText('RUNNING');
 
     this.openshiftLocalProvider = page.getByLabel('OpenShift Local Provider');
     this.openshiftLocalBox = this.featuredExtensions.getByLabel('OpenShift Local');
-    this.openshiftLocalEnabledStatus = this.getOpenShiftStatusLocator();
-  }
-
-  getOpenShiftStatusLocator(): Locator {
-    const currentOS = os.platform();
-    if (currentOS === 'linux') {
-      return this.content.getByText('Podman Desktop was not able to find an installation of OpenShift Local.');
-    }
-    const pattern = new RegExp('OpenShift Local v([0-9.]*) is installed but not ready');
-    return this.content.getByText(pattern);
+    this.openshiftLocalEnabledStatus = this.openshiftLocalProvider.getByText('NOT-INSTALLED');
   }
 
   public getPodmanStatusLocator(): Locator {

--- a/tests/src/model/pages/settings-extensions-page.ts
+++ b/tests/src/model/pages/settings-extensions-page.ts
@@ -25,6 +25,7 @@ export class SettingsExtensionsPage extends SettingsPage {
   readonly devSandboxBox: Locator;
   readonly openshiftLocalBox: Locator;
   readonly extensionsTable: Locator;
+  readonly imageInstallBox: Locator;
 
   constructor(page: Page) {
     super(page, 'Extensions');
@@ -33,6 +34,7 @@ export class SettingsExtensionsPage extends SettingsPage {
     this.devSandboxBox = this.featuredExtensions.getByLabel('Developer Sandbox');
     this.openshiftLocalBox = this.featuredExtensions.getByLabel('OpenShift Local');
     this.extensionsTable = page.getByRole('table');
+    this.imageInstallBox = page.getByRole('region', { name: 'OCI image installation box' });
   }
 
   public getExtensionRowFromTable(extensionName: string): Locator {

--- a/tests/src/model/pages/settings-extensions-page.ts
+++ b/tests/src/model/pages/settings-extensions-page.ts
@@ -26,6 +26,7 @@ export class SettingsExtensionsPage extends SettingsPage {
   readonly openshiftLocalBox: Locator;
   readonly extensionsTable: Locator;
   readonly imageInstallBox: Locator;
+  readonly installedExtensions: Locator;
 
   constructor(page: Page) {
     super(page, 'Extensions');
@@ -35,6 +36,7 @@ export class SettingsExtensionsPage extends SettingsPage {
     this.openshiftLocalBox = this.featuredExtensions.getByLabel('OpenShift Local');
     this.extensionsTable = page.getByRole('table');
     this.imageInstallBox = page.getByRole('region', { name: 'OCI image installation box' });
+    this.installedExtensions = page.getByLabel('Installed Extensions');
   }
 
   public getExtensionRowFromTable(extensionName: string): Locator {


### PR DESCRIPTION
### What does this PR do?
Adds the option of installation through OCI image in case the original installation button is not available.

### Screenshot / video of UI

### What issues does this PR fix or reference?
https://github.com/containers/podman-desktop/issues/5067

### How to test this PR?
yarn test:e2e:extension
