### PR TITLE
chore: simplify container/compose actions & callbacks

### DIFF
--- a/packages/renderer/src/lib/compose/ComposeActions.spec.ts
+++ b/packages/renderer/src/lib/compose/ComposeActions.spec.ts
@@ -1,0 +1,118 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+import { test, expect, vi, beforeEach, afterEach } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import ComposeActions from './ComposeActions.svelte';
+import type { ComposeInfoUI } from './ComposeInfoUI';
+import type { ContainerInfoUI } from '../container/ContainerInfoUI';
+
+const compose: ComposeInfoUI = {
+  engineId: 'podman',
+  engineType: 'podman',
+  name: 'my-compose-group',
+  status: 'STOPPED',
+  actionInProgress: false,
+  actionError: undefined,
+  containers: [
+    {
+      actionInProgress: false,
+      actionError: undefined,
+      state: 'STOPPED',
+    } as ContainerInfoUI,
+  ],
+} as ComposeInfoUI;
+
+const getContributedMenusMock = vi.fn();
+const updateMock = vi.fn();
+
+beforeEach(() => {
+  (window as any).startContainersByLabel = vi.fn();
+  (window as any).stopContainersByLabel = vi.fn();
+  (window as any).restartContainersByLabel = vi.fn();
+  (window as any).deleteContainersByLabel = vi.fn();
+
+  (window as any).getContributedMenus = getContributedMenusMock;
+  getContributedMenusMock.mockImplementation(() => Promise.resolve([]));
+});
+
+afterEach(() => {
+  vi.resetAllMocks();
+  vi.clearAllMocks();
+});
+
+test('Expect no error and status starting compose', async () => {
+  const { component } = render(ComposeActions, { compose });
+  component.$on('update', updateMock);
+
+  // click on start button
+  const startButton = screen.getByRole('button', { name: 'Start Compose' });
+  await fireEvent.click(startButton);
+
+  expect(compose.status).toEqual('STARTING');
+  expect(compose.actionError).toEqual('');
+  expect(compose.containers[0].state).toEqual('STARTING');
+  expect(compose.containers[0].actionError).toEqual('');
+  expect(updateMock).toHaveBeenCalled();
+});
+
+test('Expect no error and status stopping compose', async () => {
+  const { component } = render(ComposeActions, { compose });
+  component.$on('update', updateMock);
+
+  // click on stop button
+  const stopButton = screen.getByRole('button', { name: 'Stop Compose' });
+  await fireEvent.click(stopButton);
+
+  expect(compose.status).toEqual('STOPPING');
+  expect(compose.actionError).toEqual('');
+  expect(compose.containers[0].state).toEqual('STOPPING');
+  expect(compose.containers[0].actionError).toEqual('');
+  expect(updateMock).toHaveBeenCalled();
+});
+
+test('Expect no error and status restarting compose', async () => {
+  const { component } = render(ComposeActions, { compose });
+  component.$on('update', updateMock);
+
+  // click on restart button
+  const restartButton = screen.getByRole('button', { name: 'Restart Compose' });
+  await fireEvent.click(restartButton);
+
+  expect(compose.status).toEqual('RESTARTING');
+  expect(compose.actionError).toEqual('');
+  expect(compose.containers[0].state).toEqual('RESTARTING');
+  expect(compose.containers[0].actionError).toEqual('');
+  expect(updateMock).toHaveBeenCalled();
+});
+
+test('Expect no error and status deleting compose', async () => {
+  const { component } = render(ComposeActions, { compose });
+  component.$on('update', updateMock);
+
+  // click on delete button
+  const deleteButton = screen.getByRole('button', { name: 'Delete Compose' });
+  await fireEvent.click(deleteButton);
+
+  expect(compose.status).toEqual('DELETING');
+  expect(compose.actionError).toEqual('');
+  expect(compose.containers[0].state).toEqual('DELETING');
+  expect(compose.containers[0].actionError).toEqual('');
+  expect(updateMock).toHaveBeenCalled();
+});

--- a/packages/renderer/src/lib/compose/ComposeActions.svelte
+++ b/packages/renderer/src/lib/compose/ComposeActions.svelte
@@ -33,7 +33,7 @@ function inProgress(inProgress: boolean, state?: string): void {
     compose.status = state;
   }
 
-  compose.containers.forEach(container => {
+  for (const container of compose.containers) {
     container.actionInProgress = inProgress;
     // reset error when starting task
     if (inProgress) {
@@ -42,7 +42,7 @@ function inProgress(inProgress: boolean, state?: string): void {
     if (state) {
       container.state = state;
     }
-  });
+  }
   dispatch('update', compose);
 }
 

--- a/packages/renderer/src/lib/compose/ComposeActions.svelte
+++ b/packages/renderer/src/lib/compose/ComposeActions.svelte
@@ -166,5 +166,6 @@ if (dropdownMenu) {
     contextPrefix="composeItem"
     dropdownMenu="{dropdownMenu}"
     contributions="{contributions}"
+    detailed="{detailed}"
     onError="{handleError}" />
 </svelte:component>

--- a/packages/renderer/src/lib/compose/ComposeDetails.svelte
+++ b/packages/renderer/src/lib/compose/ComposeDetails.svelte
@@ -91,7 +91,7 @@ onDestroy(() => {
       <div class="flex items-center w-5">
         <div>&nbsp;</div>
       </div>
-      <ComposeActions compose="{compose}" detailed="{true}" />
+      <ComposeActions compose="{compose}" detailed="{true}" on:update="{() => (compose = compose)}" />
     </svelte:fragment>
     <svelte:fragment slot="tabs">
       <Tab title="Summary" url="summary" />

--- a/packages/renderer/src/lib/container/ContainerActions.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerActions.spec.ts
@@ -1,0 +1,95 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+import { test, expect, vi, beforeEach, afterEach } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import ContainerActions from './ContainerActions.svelte';
+import type { ContainerInfoUI } from './ContainerInfoUI';
+
+const container: ContainerInfoUI = {} as ContainerInfoUI;
+
+const getContributedMenusMock = vi.fn();
+const updateMock = vi.fn();
+
+beforeEach(() => {
+  (window as any).startContainer = vi.fn();
+  (window as any).stopContainer = vi.fn();
+  (window as any).restartContainer = vi.fn();
+  (window as any).deleteContainer = vi.fn();
+
+  (window as any).getContributedMenus = getContributedMenusMock;
+  getContributedMenusMock.mockImplementation(() => Promise.resolve([]));
+});
+
+afterEach(() => {
+  vi.resetAllMocks();
+  vi.clearAllMocks();
+});
+
+test('Expect no error and status starting container', async () => {
+  const { component } = render(ContainerActions, { container });
+  component.$on('update', updateMock);
+
+  // click on start button
+  const startButton = screen.getByRole('button', { name: 'Start Container' });
+  await fireEvent.click(startButton);
+
+  expect(container.state).toEqual('STARTING');
+  expect(container.actionError).toEqual('');
+  expect(updateMock).toHaveBeenCalled();
+});
+
+test('Expect no error and status stopping container', async () => {
+  const { component } = render(ContainerActions, { container });
+  component.$on('update', updateMock);
+
+  // click on stop button
+  const stopButton = screen.getByRole('button', { name: 'Stop Container' });
+  await fireEvent.click(stopButton);
+
+  expect(container.state).toEqual('STOPPING');
+  expect(container.actionError).toEqual('');
+  expect(updateMock).toHaveBeenCalled();
+});
+
+test('Expect no error and status restarting container', async () => {
+  const { component } = render(ContainerActions, { container });
+  component.$on('update', updateMock);
+
+  // click on restart button
+  const restartButton = screen.getByRole('button', { name: 'Restart Container' });
+  await fireEvent.click(restartButton);
+
+  expect(container.state).toEqual('RESTARTING');
+  expect(container.actionError).toEqual('');
+  expect(updateMock).toHaveBeenCalled();
+});
+
+test('Expect no error and status deleting container', async () => {
+  const { component } = render(ContainerActions, { container });
+  component.$on('update', updateMock);
+
+  // click on delete button
+  const deleteButton = screen.getByRole('button', { name: 'Delete Container' });
+  await fireEvent.click(deleteButton);
+
+  expect(container.state).toEqual('DELETING');
+  expect(container.actionError).toEqual('');
+  expect(updateMock).toHaveBeenCalled();
+});

--- a/packages/renderer/src/lib/container/ContainerActions.svelte
+++ b/packages/renderer/src/lib/container/ContainerActions.svelte
@@ -19,49 +19,66 @@ import FlatMenu from '../ui/FlatMenu.svelte';
 import type { Menu } from '../../../../main/src/plugin/menu-registry';
 import ContributionActions from '/@/lib/actions/ContributionActions.svelte';
 import { MenuContext } from '../../../../main/src/plugin/menu-registry';
-import { onMount } from 'svelte';
+import { createEventDispatcher, onMount } from 'svelte';
 export let container: ContainerInfoUI;
 export let dropdownMenu = false;
 export let detailed = false;
 
-export let inProgressCallback: (inProgress: boolean, state?: string) => void = () => {};
-export let errorCallback: (erroMessage: string) => void = () => {};
+const dispatch = createEventDispatcher<{ update: ContainerInfoUI }>();
 
 let contributions: Menu[] = [];
 onMount(async () => {
   contributions = await window.getContributedMenus(MenuContext.DASHBOARD_CONTAINER);
 });
 
+function inProgress(inProgress: boolean, state?: string): void {
+  container.actionInProgress = inProgress;
+  // reset error when starting task
+  if (inProgress) {
+    container.actionError = '';
+  }
+  if (state) {
+    container.state = state;
+  }
+  dispatch('update', container);
+}
+
+function handleError(errorMessage: string): void {
+  container.actionError = errorMessage;
+  container.state = 'ERROR';
+  dispatch('update', container);
+}
+
 async function startContainer() {
-  inProgressCallback(true, 'STARTING');
+  inProgress(true, 'STARTING');
   try {
     await window.startContainer(container.engineId, container.id);
   } catch (error) {
-    errorCallback(String(error));
+    handleError(String(error));
   } finally {
-    inProgressCallback(false, 'RUNNING');
+    inProgress(false);
   }
 }
 
 async function restartContainer() {
-  inProgressCallback(true, 'RESTARTING');
+  inProgress(true, 'RESTARTING');
   try {
     await window.restartContainer(container.engineId, container.id);
   } catch (error) {
-    errorCallback(String(error));
+    handleError(String(error));
   } finally {
-    inProgressCallback(false);
+    inProgress(false);
   }
 }
 
 async function stopContainer() {
-  inProgressCallback(true, 'STOPPING');
+  inProgress(true, 'STOPPING');
   try {
     await window.stopContainer(container.engineId, container.id);
   } catch (error) {
-    errorCallback(String(error));
+    handleError(String(error));
   } finally {
-    inProgressCallback(false, 'STOPPED');
+    inProgress(false);
   }
 }
 
@@ -77,13 +94,13 @@ function openLogs(): void {
 }
 
 async function deleteContainer(): Promise<void> {
-  inProgressCallback(true, 'DELETING');
+  inProgress(true, 'DELETING');
   try {
     await window.deleteContainer(container.engineId, container.id);
   } catch (error) {
-    errorCallback(String(error));
+    handleError(String(error));
   } finally {
-    inProgressCallback(false);
+    inProgress(false);
   }
 }
 
@@ -187,6 +204,5 @@ if (dropdownMenu) {
     contextPrefix="containerItem"
     dropdownMenu="{dropdownMenu}"
     contributions="{contributions}"
-    detailed="{detailed}"
-    onError="{errorCallback}" />
+    onError="{handleError}" />
 </svelte:component>

--- a/packages/renderer/src/lib/container/ContainerActions.svelte
+++ b/packages/renderer/src/lib/container/ContainerActions.svelte
@@ -204,5 +204,6 @@ if (dropdownMenu) {
     contextPrefix="containerItem"
     dropdownMenu="{dropdownMenu}"
     contributions="{contributions}"
+    detailed="{detailed}"
     onError="{handleError}" />
 </svelte:component>

--- a/packages/renderer/src/lib/container/ContainerDetails.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetails.svelte
@@ -64,18 +64,6 @@ onMount(() => {
     }
   });
 });
-
-function inProgressCallback(inProgress: boolean, state: string | undefined): void {
-  container.actionInProgress = inProgress;
-  if (state && inProgress) {
-    container.state = state;
-  }
-}
-
-function errorCallback(errorMessage: string): void {
-  container.actionError = errorMessage;
-  container.state = 'ERROR';
-}
 </script>
 
 {#if container}
@@ -89,11 +77,7 @@ function errorCallback(errorMessage: string): void {
           <div>&nbsp;</div>
         {/if}
       </div>
-      <ContainerActions
-        inProgressCallback="{(flag, state) => inProgressCallback(flag, state)}"
-        errorCallback="{error => errorCallback(error)}"
-        container="{container}"
-        detailed="{true}" />
+      <ContainerActions container="{container}" detailed="{true}" on:update="{() => (container = container)}" />
     </svelte:fragment>
     <div slot="detail" class="flex py-2 w-full justify-end text-sm text-gray-700">
       <StateChange state="{container.state}" />


### PR DESCRIPTION
### What does this PR do?

The same change as #5141, but for containers & compose.

This change just makes the ContainerAction and ComposeAction update their UI objects directly, and then uses a standard dispatch event to notify parents that something changed. ContainerList, ContainerDetails, and ComposeDetails just need an on:update to trigger a Svelte update. Simpler/less code all around and less chance of the UI components having different behaviour.

Compared with pods I noticed and fixed a couple things:
- ComposeActions is updating the containers but not the compose group. Added this so now the group also goes into states like 'starting'.
- ComposeDetails was not listening for changes, so even after the change above there was no change in the UI. Fixed this.
- Both *Actions were frequently using the finally block to set the state after the action is completed. e.g. containers are set to RUNNING after start. In the best case this matches the state update we get from the container engine, so just setting twice. In the worst case the action fails, and we set the state anyway... Fixed.
- The ContainerList wasn't listening for changes to pods [*].

There is still one difference between pods and compose:
- When you start a compose group we set all containers (plus now the group) to STARTING, but for pods we only set the pod. I don't know if this is intentional, but I left it / unrelated for now.

and one unrelated gap [*]:
- The ContainerList passes newly created UI objects to PodActions and ComposeActions, so when those objects change the ContainerList doesn't update until the next notification through the respective store. This is the same problem listed in #5141 - if you start a container and then quickly go to Details it is still stopped. This problem is unrelated to / unaffected by this change.

Like #5141 this shouldn't merge until after 1.6.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Cleanup prior to #4843.

### How to test this PR?

yarn test:renderer or use ContainerList/ContainerDetails/ComposeDetails. As a code simplification chore, there should be no change to behaviour or tests. (although note some minor bugs fixed, e.g. compose groups will show 'starting' when started from compose details)