### PR TITLE
fix: add unit tests for container type and endpoint

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesContainerConnectionDetailsSummary.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesContainerConnectionDetailsSummary.spec.ts
@@ -26,7 +26,7 @@ import { render, screen } from '@testing-library/svelte';
 import type { ProviderContainerConnectionInfo } from '../../../../main/src/plugin/api/provider-info';
 import PreferencesContainerConnectionDetailsSummary from './PreferencesContainerConnectionDetailsSummary.svelte';
 
-const containerConnection: ProviderContainerConnectionInfo = {
+const podmanContainerConnection: ProviderContainerConnectionInfo = {
   name: 'connection',
   endpoint: {
     socketPath: 'socket',
@@ -35,12 +35,37 @@ const containerConnection: ProviderContainerConnectionInfo = {
   type: 'podman',
 };
 
-test('Expect that name and socket are displayed', async () => {
+const dockerContainerConnection: ProviderContainerConnectionInfo = {
+  name: 'connection',
+  endpoint: {
+    socketPath: 'socket',
+  },
+  status: 'started',
+  type: 'docker',
+};
+
+test('Expect that name, socket and type are displayed for Podman', async () => {
   render(PreferencesContainerConnectionDetailsSummary, {
-    containerConnectionInfo: containerConnection,
+    containerConnectionInfo: podmanContainerConnection,
   });
   const spanConnection = screen.getByLabelText('connection');
   expect(spanConnection).toBeInTheDocument();
   const spanSocket = screen.getByLabelText('socket');
   expect(spanSocket).toBeInTheDocument();
+  const spanType = screen.getByLabelText('podman');
+  expect(spanType).toBeInTheDocument();
+  expect(spanType.textContent).toBe('Podman');
+});
+
+test('Expect that name, socket and type are displayed for Docker', async () => {
+  render(PreferencesContainerConnectionDetailsSummary, {
+    containerConnectionInfo: dockerContainerConnection,
+  });
+  const spanConnection = screen.getByLabelText('connection');
+  expect(spanConnection).toBeInTheDocument();
+  const spanSocket = screen.getByLabelText('socket');
+  expect(spanSocket).toBeInTheDocument();
+  const spanType = screen.getByLabelText('docker');
+  expect(spanType).toBeInTheDocument();
+  expect(spanType.textContent).toBe('Docker');
 });

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesConnectionDetailsSummary.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesConnectionDetailsSummary.spec.ts
@@ -34,7 +34,7 @@ const kubernetesConnection: ProviderKubernetesConnectionInfo = {
   status: 'started',
 };
 
-test('Expect that name and url are displayed', async () => {
+test('Expect that name, url and kubernetes are displayed', async () => {
   render(PreferencesKubernetesConnectionDetailsSummary, {
     kubernetesConnectionInfo: kubernetesConnection,
   });
@@ -42,4 +42,7 @@ test('Expect that name and url are displayed', async () => {
   expect(spanConnection).toBeInTheDocument();
   const spanUrl = screen.getByLabelText('url');
   expect(spanUrl).toBeInTheDocument();
+  const kubernetes = screen.getByLabelText('kubernetes');
+  expect(kubernetes).toBeInTheDocument();
+  expect(kubernetes.textContent).toBe('Kubernetes');
 });

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.spec.ts
@@ -151,6 +151,25 @@ test('Expect to be start, delete actions disabled and stop, restart enabled when
   expect(deleteButton.classList.contains('cursor-not-allowed'));
 });
 
+test('Expect type to be reported for Podman engines', async () => {
+  providerInfos.set([providerInfo]);
+  render(PreferencesResourcesRendering, {});
+  const typeDiv = screen.getByLabelText('machine type');
+  expect(typeDiv.textContent).toBe('Podman endpoint');
+  const endpointSpan = screen.getByLabelText('machine endpoint');
+  expect(endpointSpan.textContent).toBe('socket');
+});
+
+test('Expect type to be reported for Docker engines', async () => {
+  providerInfo.containerConnections[0].type = 'docker';
+  providerInfos.set([providerInfo]);
+  render(PreferencesResourcesRendering, {});
+  const typeDiv = screen.getByLabelText('machine type');
+  expect(typeDiv.textContent).toBe('Docker endpoint');
+  const endpointSpan = screen.getByLabelText('machine endpoint');
+  expect(endpointSpan.textContent).toBe('socket');
+});
+
 test('Expect to see the no resource message when there is no providers', async () => {
   providerInfos.set([]);
   render(PreferencesResourcesRendering, {});

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
@@ -474,12 +474,14 @@ function hasAnyConfiguration(provider: ProviderInfo) {
                 {/if}
               </div>
               <div class="mt-2">
-                <div class="text-gray-700 text-xs">
+                <div class="text-gray-700 text-xs" aria-label="{container.name} type">
                   {#if container.type === 'docker'}Docker{:else if container.type === 'podman'}Podman{/if} endpoint
                 </div>
                 <div class="mt-1">
-                  <span class="my-auto text-xs" class:text-gray-900="{container.status !== 'started'}"
-                    >{container.endpoint.socketPath}</span>
+                  <span
+                    class="my-auto text-xs"
+                    class:text-gray-900="{container.status !== 'started'}"
+                    aria-label="{container.name} endpoint">{container.endpoint.socketPath}</span>
                 </div>
               </div>
 


### PR DESCRIPTION
Fixes #5169

### What does this PR do?

Add unit test for the new UI elements for container and Kubernetes engines

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes #5169 

### How to test this PR?

`yarn test:unit`
