### PR TITLE
feat(ui): add danger button

### DIFF
--- a/packages/renderer/src/lib/ui/Button.spec.ts
+++ b/packages/renderer/src/lib/ui/Button.spec.ts
@@ -65,6 +65,18 @@ test('Check secondary button styling', async () => {
   expect(button).toHaveClass('text-white');
 });
 
+test('Check danger button styling', async () => {
+  render(Button, { type: 'danger' });
+
+  // check for a few elements of the styling
+  const button = screen.getByRole('button');
+  expect(button).toBeInTheDocument();
+  expect(button).toHaveClass('border-red-600');
+  expect(button).toHaveClass('bg-charcoal-700');
+  expect(button).toHaveClass('text-[13px]');
+  expect(button).toHaveClass('text-white');
+});
+
 test('Check disabled/in-progress secondary button styling', async () => {
   render(Button, { type: 'secondary', inProgress: true });
 

--- a/packages/renderer/src/lib/ui/Button.svelte
+++ b/packages/renderer/src/lib/ui/Button.svelte
@@ -31,6 +31,8 @@ $: {
   if (disabled || inProgress) {
     if (type === 'primary' || type === 'secondary') {
       classes = 'bg-charcoal-50';
+    } else if (type === 'danger') {
+      classes = 'border-2 border-gray-700 bg-charcoal-800';
     } else {
       classes = 'text-charcoal-50 no-underline';
     }
@@ -39,6 +41,8 @@ $: {
       classes = 'bg-purple-600 border-none hover:bg-purple-500';
     } else if (type === 'secondary') {
       classes = 'border-[1px] border-gray-200 hover:border-purple-500 hover:text-purple-500';
+    } else if (type === 'danger') {
+      classes = 'border-2 border-red-600 bg-charcoal-700 hover:bg-charcoal-400';
     } else if (type === 'tab') {
       classes = 'border-b-[3px] border-charcoal-700 hover:cursor-pointer text-gray-600 no-underline';
     } else {
@@ -57,7 +61,7 @@ $: {
   class="relative {padding} box-border whitespace-nowrap select-none transition-all {classes} {$$props.class || ''}"
   class:border-purple-500="{type === 'tab' && selected}"
   class:hover:border-charcoal-100="{type === 'tab' && !selected}"
-  class:text-white="{(type === 'tab' && selected) || type === 'primary' || type === 'secondary'}"
+  class:text-white="{(type === 'tab' && selected) || type === 'primary' || type === 'secondary' || type === 'danger'}"
   title="{title}"
   aria-label="{$$props['aria-label']}"
   on:click

--- a/packages/renderer/src/lib/ui/Button.ts
+++ b/packages/renderer/src/lib/ui/Button.ts
@@ -20,7 +20,8 @@
  * Type of button:
  *  primary   - a main action (the default)
  *  secondary - a secondary action
+ *  danger    - a danger action
  *  link      - close, cancel, or other non-default button
  *  tab       - displayed as tab
  */
-export type ButtonType = 'primary' | 'secondary' | 'link' | 'tab';
+export type ButtonType = 'primary' | 'secondary' | 'danger' | 'link' | 'tab';


### PR DESCRIPTION
### What does this PR do?
Add danger button

### Screenshot / video of UI

![image](https://github.com/containers/podman-desktop/assets/436777/674a4594-0ac6-413b-8ede-a1780ed453e6)


### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/5176

### How to test this PR?

try to create a `type='danger'` Button