### PR TITLE
feat: add cleanup UI

### DIFF
--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingContainerEngines.svelte
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingContainerEngines.svelte
@@ -9,7 +9,7 @@ $: containerEngines = providers.map(provider => provider.containerConnections).f
 $: containerEnginesRunning = containerEngines.filter(containerEngine => containerEngine.status === 'started');
 </script>
 
-<div class="flex flex-col w-full bg-charcoal-600 m-4 p-4 rounded-lg">
+<div class="flex flex-col w-full bg-charcoal-600 p-4 rounded-lg">
   <div class="flex flex-row align-middle items-center">
     <ContainerIcon size="40" solid="{true}" class="pr-3 text-gray-700" />
     <div role="status" aria-label="container connections" class="text-xl">

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingPageProviders.svelte
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingPageProviders.svelte
@@ -5,6 +5,7 @@ import { providerInfos } from '/@/stores/providers';
 import { type Unsubscriber } from 'svelte/store';
 import type { ProviderInfo } from '../../../../main/src/plugin/api/provider-info';
 import TroubleshootingContainerEngines from './TroubleshootingContainerEngines.svelte';
+import TroubleshootingRepair from './TroubleshootingRepair.svelte';
 
 let providers: ProviderInfo[] = [];
 
@@ -21,4 +22,8 @@ onDestroy(() => {
 });
 </script>
 
-<TroubleshootingContainerEngines providers="{providers}" />
+<div class="flex flex-col w-full m-4 space-y-4">
+  <TroubleshootingRepair providers="{providers}" />
+
+  <TroubleshootingContainerEngines providers="{providers}" />
+</div>

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingRepair.spec.ts
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingRepair.spec.ts
@@ -1,0 +1,34 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import '@testing-library/jest-dom/vitest';
+import { beforeAll, test, expect } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import TroubleshootingRepair from './TroubleshootingRepair.svelte';
+
+beforeAll(() => {});
+
+test('Check widget is there', async () => {
+  render(TroubleshootingRepair, {});
+
+  // check the repair title is there
+  const repairDiv = screen.getByText('Repair', { exact: true });
+  expect(repairDiv).toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingRepair.svelte
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingRepair.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+import { faWrench } from '@fortawesome/free-solid-svg-icons';
+import type { ProviderInfo } from '../../../../main/src/plugin/api/provider-info';
+import Fa from 'svelte-fa';
+import TroubleshootingRepairCleanup from './TroubleshootingRepairCleanup.svelte';
+
+export let providers: ProviderInfo[] = [];
+</script>
+
+<div class="flex flex-col w-full bg-charcoal-600 p-4 rounded-lg">
+  <div class="flex flex-row w-full pb-2 items-center">
+    <Fa size="24" class="pr-2 text-gray-700" icon="{faWrench}" />
+    <div class="text-xl" aria-label="Repair">Repair</div>
+  </div>
+
+  <TroubleshootingRepairCleanup providers="{providers}" />
+</div>

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingRepairCleanup.spec.ts
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingRepairCleanup.spec.ts
@@ -1,0 +1,110 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import '@testing-library/jest-dom/vitest';
+import { beforeAll, test, expect, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import TroubleshootingRepairCleanup from './TroubleshootingRepairCleanup.svelte';
+
+const showMessageBoxMock = vi.fn();
+const cleanupProvidersMock = vi.fn();
+
+// fake the window.events object
+beforeAll(() => {
+  (window as any).window.showMessageBox = showMessageBoxMock;
+  (window as any).window.cleanupProviders = cleanupProvidersMock;
+});
+
+test('Check cleanupProviders is called and button is in progress', async () => {
+  showMessageBoxMock.mockResolvedValue({ response: 0 });
+
+  render(TroubleshootingRepairCleanup);
+
+  // expect to have the cleanup button
+  const cleanupButton = screen.getByRole('button', { name: 'Cleanup' });
+  expect(cleanupButton).toBeInTheDocument();
+
+  // mock the cleanup as waiting for 2 seconds
+  cleanupProvidersMock.mockResolvedValue(new Promise(resolve => setTimeout(resolve, 2000)));
+
+  // click on the cleanup button
+  expect(cleanupButton).toBeEnabled();
+  await fireEvent.click(cleanupButton);
+
+  // wait next tick
+  await new Promise(resolve => setTimeout(resolve, 100));
+
+  // button should be in progress
+  expect(cleanupButton).toBeDisabled();
+  // svg should be inside the button
+  const svg = cleanupButton.querySelector('svg');
+  expect(svg).toBeInTheDocument();
+
+  // wait 2s for the cleanup to finish
+  await new Promise(resolve => setTimeout(resolve, 2000));
+
+  // button should not be in progress anymore
+  expect(cleanupButton).toBeEnabled();
+
+  // check that we asked for confirmation
+  expect(showMessageBoxMock).toBeCalledWith({
+    buttons: ['Yes', 'No'],
+    message: 'This action may delete data. Proceed ?',
+    title: 'Cleanup',
+  });
+
+  // check that we're calling the cleanupProvidersMock
+  expect(cleanupProvidersMock).toBeCalled();
+});
+
+test('Check errors are displayed with clipboard button', async () => {
+  showMessageBoxMock.mockResolvedValue({ response: 0 });
+
+  render(TroubleshootingRepairCleanup);
+
+  // expect to have the cleanup button
+  const cleanupButton = screen.getByRole('button', { name: 'Cleanup' });
+  expect(cleanupButton).toBeInTheDocument();
+
+  // mock the cleanup as waiting for 2 seconds
+  cleanupProvidersMock.mockRejectedValue(new Error('test error'));
+
+  // click on the cleanup button
+  expect(cleanupButton).toBeEnabled();
+  await fireEvent.click(cleanupButton);
+
+  // wait next tick
+  await new Promise(resolve => setTimeout(resolve, 100));
+
+  // check that we asked for confirmation
+  expect(showMessageBoxMock).toBeCalledWith({
+    buttons: ['Yes', 'No'],
+    message: 'This action may delete data. Proceed ?',
+    title: 'Cleanup',
+  });
+
+  // check that we're calling the cleanupProvidersMock
+  expect(cleanupProvidersMock).toBeCalled();
+
+  // check errors are displayed
+  const alterSection = screen.getByRole('alert');
+  expect(alterSection).toBeInTheDocument();
+  expect(alterSection).toHaveTextContent('1 failures');
+});

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingRepairCleanup.svelte
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingRepairCleanup.svelte
@@ -46,7 +46,7 @@ async function cleanup() {
 <div class="flex flex-row items-center">
   <div>
     <div class="text-gray-700 flex flex-row items-center">Clean / Purge data</div>
-    <div class="text-gray-900 text-xs flex flex-row items-center">
+    <div class="text-gray-900 text-sm flex flex-row items-center pt-1">
       <Fa class="pr-1" size="9" icon="{faWarning}" />Proceeding with this action may result in data loss, including
       existing volumes, containers, images, etc.
     </div>
@@ -56,10 +56,9 @@ async function cleanup() {
     <Button
       type="danger"
       on:click="{() => openCleanupDialog()}"
-      disabled="{cleanupInProgress}"
       inProgress="{cleanupInProgress}"
       aria-label="Cleanup"
-      icon="{faBroom}">Cleanup</Button>
+      icon="{faBroom}">Cleanup / Purge data</Button>
   </div>
 
   <div>

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingRepairCleanup.svelte
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingRepairCleanup.svelte
@@ -1,0 +1,72 @@
+<script lang="ts">
+import { faBroom, faWarning } from '@fortawesome/free-solid-svg-icons';
+import type { ProviderInfo } from '../../../../main/src/plugin/api/provider-info';
+import Button from '../ui/Button.svelte';
+import Fa from 'svelte-fa';
+
+export let providers: ProviderInfo[] = [];
+let providerIdsWithCleanup: string[] = [];
+$: providerIdsWithCleanup = providers.filter(provider => provider.cleanupSupport).map(provider => provider.internalId);
+
+let cleanupInProgress = false;
+
+let cleanupFailures: string[] = [];
+
+async function openCleanupDialog(): Promise<void> {
+  let message = 'This action may delete data. Proceed ?';
+
+  const result = await window.showMessageBox({
+    title: 'Cleanup',
+    message: message,
+    buttons: ['Yes', 'No'],
+  });
+
+  if (result?.response === 0) {
+    cleanup();
+  }
+}
+
+async function cleanup() {
+  try {
+    cleanupInProgress = true;
+    cleanupFailures = [];
+    await window.cleanupProviders(providerIdsWithCleanup, Symbol('cleanup-provider'), (_key, _eventName, args) => {
+      // log into the console as no UI is available to display logs
+      console.log('cleanup event', args);
+    });
+  } catch (e) {
+    console.error(e);
+    cleanupFailures.push(String(e));
+  } finally {
+    cleanupInProgress = false;
+  }
+}
+</script>
+
+<div class="flex flex-row items-center">
+  <div>
+    <div class="text-gray-700 flex flex-row items-center">Clean / Purge data</div>
+    <div class="text-gray-900 text-xs flex flex-row items-center">
+      <Fa class="pr-1" size="9" icon="{faWarning}" />Proceeding with this action may result in data loss, including
+      existing volumes, containers, images, etc.
+    </div>
+  </div>
+
+  <div class="flex flex-1 justify-end">
+    <Button
+      type="danger"
+      on:click="{() => openCleanupDialog()}"
+      disabled="{cleanupInProgress}"
+      inProgress="{cleanupInProgress}"
+      aria-label="Cleanup"
+      icon="{faBroom}">Cleanup</Button>
+  </div>
+
+  <div>
+    {#if cleanupFailures.length > 0}
+      <div class="text-red-500 text-xs flex flex-row items-center" role="alert" aria-label="error">
+        <Fa class="pr-1" size="9" icon="{faWarning}" />{cleanupFailures.length} failures
+      </div>
+    {/if}
+  </div>
+</div>


### PR DESCRIPTION
Signed-off-by: Florent Benoit <fbenoit@redhat.com>

### What does this PR do?
Add cleanup section in Troubleshooting page

depends on:
- [x] https://github.com/containers/podman-desktop/pull/5139
- [x] https://github.com/containers/podman-desktop/pull/5177

Note:  while UI is working, after UX meetup I'll need to include it as part of a tab but it allows to test the whole workflow for now

### Screenshot / video of UI

![image](https://github.com/containers/podman-desktop/assets/436777/da8f942a-e5e5-4beb-98ed-cb9f3d9def75)



### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/5022


### How to test this PR?

Go to troubleshooting page and click on 'cleanup'

all podman machine stuff should be gone, creating a fresh machine after this step should work
