### PR TITLE
fix: avoid to crash if configuration is invalid

### DIFF
--- a/packages/main/src/plugin/autostart-engine.spec.ts
+++ b/packages/main/src/plugin/autostart-engine.spec.ts
@@ -25,6 +25,7 @@ import { AutostartEngine } from './autostart-engine.js';
 import type { Configuration } from '@podman-desktop/api';
 import { CONFIGURATION_DEFAULT_SCOPE, CONFIGURATION_ONBOARDING_SCOPE } from './configuration-registry-constants.js';
 import type { ApiSenderType } from '/@/plugin/api.js';
+import type { NotificationRegistry } from './notification-registry.js';
 
 let configurationRegistry: ConfigurationRegistry;
 let providerRegistry: ProviderRegistry;
@@ -42,7 +43,7 @@ beforeEach(() => {
 
 /* eslint-disable @typescript-eslint/no-empty-function */
 beforeAll(() => {
-  configurationRegistry = new ConfigurationRegistry({} as ApiSenderType, {} as Directories);
+  configurationRegistry = new ConfigurationRegistry({} as ApiSenderType, {} as Directories, {} as NotificationRegistry);
   providerRegistry = {} as unknown as ProviderRegistry;
   autostartEngine = new AutostartEngine(configurationRegistry, providerRegistry);
   configurationRegistry.registerConfigurations = mockRegisterConfiguration;

--- a/packages/main/src/plugin/close-behavior.spec.ts
+++ b/packages/main/src/plugin/close-behavior.spec.ts
@@ -21,6 +21,7 @@ import { ConfigurationRegistry } from './configuration-registry.js';
 import * as util from '../util.js';
 import type { Directories } from './directories.js';
 import type { ApiSenderType } from '/@/plugin/api.js';
+import type { NotificationRegistry } from './notification-registry.js';
 
 vi.mock('./util', () => {
   return {
@@ -32,7 +33,7 @@ let closeBehavior: CloseBehavior;
 let configurationRegistry: ConfigurationRegistry;
 
 beforeEach(() => {
-  configurationRegistry = new ConfigurationRegistry({} as ApiSenderType, {} as Directories);
+  configurationRegistry = new ConfigurationRegistry({} as ApiSenderType, {} as Directories, {} as NotificationRegistry);
   closeBehavior = new CloseBehavior(configurationRegistry);
 });
 

--- a/packages/main/src/plugin/configuration-registry.spec.ts
+++ b/packages/main/src/plugin/configuration-registry.spec.ts
@@ -181,5 +181,5 @@ test('should work with an invalid configuration file', async () => {
   }
 
   expect(configurationRegistry.getConfigurationProperties()).toEqual({});
-  expect(mockedConsoleLog).toBeCalledWith('Unable to parse /my-config-dir/settings.json file', expect.anything());
+  expect(mockedConsoleLog).toBeCalledWith(expect.stringContaining('Unable to parse'), expect.anything());
 });

--- a/packages/main/src/plugin/configuration-registry.spec.ts
+++ b/packages/main/src/plugin/configuration-registry.spec.ts
@@ -159,3 +159,27 @@ test('Should not find configuration after dispose', async () => {
   const afterDisposeRecord = records['my.fake.property'];
   expect(afterDisposeRecord).toBeUndefined();
 });
+
+test('should work with an invalid configuration file', async () => {
+  vi.resetAllMocks();
+
+  getConfigurationDirectoryMock.mockReturnValue('/my-config-dir');
+
+  configurationRegistry = new ConfigurationRegistry(apiSender, directories);
+  readFileSync.mockReturnValue('invalid JSON content');
+
+  configurationRegistry = new ConfigurationRegistry(apiSender, directories);
+
+  // configuration is broken but it should not throw any error, just that config is empty
+  const originalConsoleError = console.error;
+  const mockedConsoleLog = vi.fn();
+  console.error = mockedConsoleLog;
+  try {
+    configurationRegistry.init();
+  } finally {
+    console.error = originalConsoleError;
+  }
+
+  expect(configurationRegistry.getConfigurationProperties()).toEqual({});
+  expect(mockedConsoleLog).toBeCalledWith('Unable to parse /my-config-dir/settings.json file', expect.anything());
+});

--- a/packages/main/src/plugin/configuration-registry.spec.ts
+++ b/packages/main/src/plugin/configuration-registry.spec.ts
@@ -23,6 +23,7 @@ import { ConfigurationRegistry } from './configuration-registry.js';
 import type { Directories } from './directories.js';
 import type { Disposable } from './types/disposable.js';
 import type { ApiSenderType } from '/@/plugin/api.js';
+import type { NotificationRegistry } from './notification-registry.js';
 
 let configurationRegistry: ConfigurationRegistry;
 
@@ -37,6 +38,10 @@ const apiSender = {
   send: vi.fn(),
 } as unknown as ApiSenderType;
 
+const notificationRegistry = {
+  addNotification: vi.fn(),
+} as unknown as NotificationRegistry;
+
 let registerConfigurationsDisposable: Disposable;
 
 beforeAll(() => {
@@ -49,7 +54,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   getConfigurationDirectoryMock.mockReturnValue('/my-config-dir');
 
-  configurationRegistry = new ConfigurationRegistry(apiSender, directories);
+  configurationRegistry = new ConfigurationRegistry(apiSender, directories, notificationRegistry);
   readFileSync.mockReturnValue(JSON.stringify({}));
 
   configurationRegistry.init();
@@ -165,10 +170,8 @@ test('should work with an invalid configuration file', async () => {
 
   getConfigurationDirectoryMock.mockReturnValue('/my-config-dir');
 
-  configurationRegistry = new ConfigurationRegistry(apiSender, directories);
+  configurationRegistry = new ConfigurationRegistry(apiSender, directories, notificationRegistry);
   readFileSync.mockReturnValue('invalid JSON content');
-
-  configurationRegistry = new ConfigurationRegistry(apiSender, directories);
 
   // configuration is broken but it should not throw any error, just that config is empty
   const originalConsoleError = console.error;

--- a/packages/main/src/plugin/configuration-registry.ts
+++ b/packages/main/src/plugin/configuration-registry.ts
@@ -145,7 +145,14 @@ export class ConfigurationRegistry implements IConfigurationRegistry {
     }
 
     const settingsRawContent = fs.readFileSync(settingsFile, 'utf-8');
-    this.configurationValues.set(CONFIGURATION_DEFAULT_SCOPE, JSON.parse(settingsRawContent));
+    let configData: unknown;
+    try {
+      configData = JSON.parse(settingsRawContent);
+    } catch (error) {
+      console.error(`Unable to parse ${settingsFile} file`, error);
+      configData = {};
+    }
+    this.configurationValues.set(CONFIGURATION_DEFAULT_SCOPE, configData);
   }
 
   public registerConfigurations(configurations: IConfigurationNode[]): Disposable {

--- a/packages/main/src/plugin/configuration-registry.ts
+++ b/packages/main/src/plugin/configuration-registry.ts
@@ -26,6 +26,7 @@ import { CONFIGURATION_DEFAULT_SCOPE } from './configuration-registry-constants.
 import type { Directories } from './directories.js';
 import { Disposable } from './types/disposable.js';
 import type { ApiSenderType } from './api.js';
+import type { NotificationRegistry } from './notification-registry.js';
 
 export type IConfigurationPropertySchemaType =
   | 'markdown'
@@ -122,6 +123,7 @@ export class ConfigurationRegistry implements IConfigurationRegistry {
   constructor(
     private apiSender: ApiSenderType,
     private directories: Directories,
+    private notificationRegistry: NotificationRegistry,
   ) {
     this.configurationProperties = {};
     this.configurationContributors = [];

--- a/packages/main/src/plugin/configuration-registry.ts
+++ b/packages/main/src/plugin/configuration-registry.ts
@@ -152,6 +152,20 @@ export class ConfigurationRegistry implements IConfigurationRegistry {
       configData = JSON.parse(settingsRawContent);
     } catch (error) {
       console.error(`Unable to parse ${settingsFile} file`, error);
+
+      const backupFilename = `${settingsFile}.backup-${Date.now()}`;
+      // keep original file as a backup
+      fs.cpSync(settingsFile, backupFilename);
+
+      // notify the user
+      this.notificationRegistry.addNotification({
+        title: 'Corrupted configuration file',
+        body: `Configuration file located at ${settingsFile} was invalid. Created a copy at '${backupFilename}' and started with default settings.`,
+        extensionId: 'core',
+        type: 'warn',
+        highlight: true,
+        silent: true,
+      });
       configData = {};
     }
     this.configurationValues.set(CONFIGURATION_DEFAULT_SCOPE, configData);

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -386,7 +386,10 @@ export class PluginSystem {
     const iconRegistry = new IconRegistry(apiSender);
     const directories = new Directories();
 
-    const configurationRegistry = new ConfigurationRegistry(apiSender, directories);
+    const taskManager = new TaskManager(apiSender);
+    const notificationRegistry = new NotificationRegistry(apiSender, taskManager);
+
+    const configurationRegistry = new ConfigurationRegistry(apiSender, directories, notificationRegistry);
     configurationRegistry.init();
 
     const proxy = new Proxy(configurationRegistry);
@@ -396,8 +399,6 @@ export class PluginSystem {
     await telemetry.init();
 
     const exec = new Exec(proxy);
-
-    const taskManager = new TaskManager(apiSender);
 
     const commandRegistry = new CommandRegistry(apiSender, telemetry);
     const menuRegistry = new MenuRegistry(commandRegistry);
@@ -416,7 +417,6 @@ export class PluginSystem {
     const fileSystemMonitoring = new FilesystemMonitoring();
     const customPickRegistry = new CustomPickRegistry(apiSender);
     const onboardingRegistry = new OnboardingRegistry(configurationRegistry, context);
-    const notificationRegistry = new NotificationRegistry(apiSender, taskManager);
     const kubernetesClient = new KubernetesClient(apiSender, configurationRegistry, fileSystemMonitoring, telemetry);
     await kubernetesClient.init();
     const closeBehaviorConfiguration = new CloseBehavior(configurationRegistry);

--- a/packages/main/src/plugin/task-manager.ts
+++ b/packages/main/src/plugin/task-manager.ts
@@ -18,7 +18,7 @@
 
 import type { ApiSenderType } from './api.js';
 import type { NotificationInfo } from './api/notification.js';
-import type { NotificationTask, StatefulTask, Task } from '/@/plugin/api/task.js';
+import type { NotificationTask, StatefulTask, Task } from './api/task.js';
 
 /**
  * Contribution manager to provide the list of external OCI contributions


### PR DESCRIPTION
### What does this PR do?
do not stop if config file is corrupted

### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

could be related to https://github.com/containers/podman-desktop/issues/4649

### How to test this PR?

unit test provided

manual testing:
Edit podman settings file and use invalid values ( ~/.local/share/containers/podman-desktop/configuration/settings.json)

before the patch: unable to start
after the patch: able to start