### PR TITLE
feat: change layout of Troubleshooting page to use tabs

### DIFF
--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -58,7 +58,7 @@ window.events?.receive('display-help', () => {
 });
 
 window.events?.receive('display-troubleshooting', () => {
-  router.goto('/troubleshooting');
+  router.goto('/troubleshooting/repair-connections');
 });
 </script>
 
@@ -170,7 +170,7 @@ window.events?.receive('display-troubleshooting', () => {
         <Route path="/help" breadcrumb="Help">
           <HelpPage />
         </Route>
-        <Route path="/troubleshooting" breadcrumb="Troubleshooting">
+        <Route path="/troubleshooting/*" breadcrumb="Troubleshooting">
           <TroubleshootingPage />
         </Route>
       </div>

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingContainerEngines.svelte
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingContainerEngines.svelte
@@ -9,7 +9,7 @@ $: containerEngines = providers.map(provider => provider.containerConnections).f
 $: containerEnginesRunning = containerEngines.filter(containerEngine => containerEngine.status === 'started');
 </script>
 
-<div class="flex flex-col bg-charcoal-600 p-4 rounded-lg">
+<div class="flex flex-col w-full bg-charcoal-600 m-4 p-4 rounded-lg">
   <div class="flex flex-row align-middle items-center">
     <ContainerIcon size="40" solid="{true}" class="pr-3 text-gray-700" />
     <div role="status" aria-label="container connections" class="text-xl">

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingDevToolsConsoleLogs.svelte
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingDevToolsConsoleLogs.svelte
@@ -25,7 +25,7 @@ function copyLogsToClipboard() {
 </script>
 
 <div class="flex flex-col w-full m-4 bg-charcoal-600 p-4 rounded-lg">
-  <div class="flex flex-row align-middle items-center w-full">
+  <div class="flex flex-row align-middle items-center w-full mb-4">
     <Fa size="30" class="pr-3 text-gray-700" icon="{faFileLines}" />
     <div class="text-xl">Logs</div>
     <div class="flex flex-1 justify-end">
@@ -34,7 +34,7 @@ function copyLogsToClipboard() {
     </div>
   </div>
   {#if logs.length > 0}
-    <div class="h-full overflow-auto m-2 p-2 bg-charcoal-800">
+    <div class="h-full overflow-auto p-2 bg-charcoal-800">
       <ul aria-label="logs">
         {#each logs as log}
           <li>

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingDevToolsConsoleLogs.svelte
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingDevToolsConsoleLogs.svelte
@@ -24,7 +24,7 @@ function copyLogsToClipboard() {
 }
 </script>
 
-<div class="flex flex-col bg-charcoal-600 p-4 rounded-lg">
+<div class="flex flex-col w-full m-4 bg-charcoal-600 p-4 rounded-lg">
   <div class="flex flex-row align-middle items-center w-full">
     <Fa size="30" class="pr-3 text-gray-700" icon="{faFileLines}" />
     <div class="text-xl">Logs</div>
@@ -34,7 +34,7 @@ function copyLogsToClipboard() {
     </div>
   </div>
   {#if logs.length > 0}
-    <div class="h-40 overflow-auto m-2 p-2 bg-charcoal-800">
+    <div class="h-full overflow-auto m-2 p-2 bg-charcoal-800">
       <ul aria-label="logs">
         {#each logs as log}
           <li>

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingPage.spec.ts
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingPage.spec.ts
@@ -20,7 +20,7 @@
 
 import '@testing-library/jest-dom/vitest';
 import { beforeAll, test, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/svelte';
+import { fireEvent, render, screen } from '@testing-library/svelte';
 import TroubleshootingPage from './TroubleshootingPage.svelte';
 
 const getDevtoolsConsoleLogsMock = vi.fn();
@@ -33,7 +33,21 @@ test('Check Troubleshooting Page', async () => {
   getDevtoolsConsoleLogsMock.mockReturnValue([]);
   render(TroubleshootingPage, {});
 
+  // click on the first tab
+  const repairConnectionsLink = screen.getByRole('link', { name: 'Repair & Connections' });
+  expect(repairConnectionsLink).toBeInTheDocument();
+  await fireEvent.click(repairConnectionsLink);
+
   // check we have the container connections role
   const containerConnections = screen.getByRole('status', { name: 'container connections' });
   expect(containerConnections).toBeInTheDocument();
+
+  // click on the stores tab
+  const storesLink = screen.getByRole('link', { name: 'Stores' });
+  expect(storesLink).toBeInTheDocument();
+  await fireEvent.click(storesLink);
+
+  // check we have stores displayed
+  const stores = screen.getByRole('status', { name: 'stores' });
+  expect(stores).toBeInTheDocument();
 });

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingPage.svelte
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingPage.svelte
@@ -1,18 +1,31 @@
 <script>
 import FormPage from '../ui/FormPage.svelte';
+import Tab from '../ui/Tab.svelte';
 import TroubleshootingDevToolsConsoleLogs from './TroubleshootingDevToolsConsoleLogs.svelte';
 import TroubleshootingPageProviders from './TroubleshootingPageProviders.svelte';
 import TroubleshootingPageStores from './TroubleshootingPageStores.svelte';
+import Route from '/@/Route.svelte';
 </script>
 
 <FormPage title="Troubleshooting" showBreadcrumb="{false}">
   <i slot="icon" class="fas fa-lightbulb fa-2x" aria-hidden="true"></i>
 
-  <div slot="content" class="flex flex-col space-y-4 p-4">
-    <TroubleshootingPageProviders />
+  <svelte:fragment slot="tabs">
+    <Tab title="Repair & Connections" url="repair-connections" />
+    <Tab title="Logs" url="logs" />
+    <Tab title="Stores" url="stores" />
+  </svelte:fragment>
+  <svelte:fragment slot="content">
+    <Route path="/repair-connections" breadcrumb="Repair & Connections" navigationHint="tab">
+      <TroubleshootingPageProviders />
+    </Route>
 
-    <TroubleshootingDevToolsConsoleLogs />
+    <Route path="/logs" breadcrumb="Logs" navigationHint="tab">
+      <TroubleshootingDevToolsConsoleLogs />
+    </Route>
 
-    <TroubleshootingPageStores />
-  </div>
+    <Route path="/stores" breadcrumb="Stores" navigationHint="tab">
+      <TroubleshootingPageStores />
+    </Route>
+  </svelte:fragment>
 </FormPage>

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingPageStores.svelte
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingPageStores.svelte
@@ -25,7 +25,7 @@ onDestroy(() => {
 });
 </script>
 
-<div class="flex flex-col bg-charcoal-600 p-4 rounded-lg">
+<div class="flex w-full h-fit m-4 mr-8 flex-col bg-charcoal-600 p-4 rounded-lg">
   <div class="flex flex-row align-middle items-center w-full mb-4">
     <Fa size="30" class="pr-3 text-gray-700" icon="{faDatabase}" />
     <div role="status" aria-label="stores" class="text-xl">Stores</div>

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingPageStores.svelte
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingPageStores.svelte
@@ -25,7 +25,7 @@ onDestroy(() => {
 });
 </script>
 
-<div class="flex w-full h-fit m-4 mr-8 flex-col bg-charcoal-600 p-4 rounded-lg">
+<div class="flex w-full h-fit m-4 flex-col bg-charcoal-600 p-4 rounded-lg">
   <div class="flex flex-row align-middle items-center w-full mb-4">
     <Fa size="30" class="pr-3 text-gray-700" icon="{faDatabase}" />
     <div role="status" aria-label="stores" class="text-xl">Stores</div>


### PR DESCRIPTION
### What does this PR do?
move sections into tabs rather than using a single page

depends on:
- [x] https://github.com/containers/podman-desktop/pull/5185

### Screenshot / video of UI


https://github.com/containers/podman-desktop/assets/436777/b3c0266b-ac2b-494e-89ab-073a3245d7f4



### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/5183

### How to test this PR?

automatic testing: component test added
manual testing: Open troubleshooting page and see that it has now tabs