### PR TITLE
extension installation checks architecture and os

### DIFF
--- a/packages/main/src/plugin/image-registry.spec.ts
+++ b/packages/main/src/plugin/image-registry.spec.ts
@@ -567,13 +567,13 @@ test('getBestManifest returns the expected manifest', () => {
   // Only one os by default
   expect(
     imageRegistry.getBestManifest([manifests['windows-arm64'], manifests['windows-amd64']], 'amd64', 'darwin'),
-  ).toHaveProperty('name', 'windows-amd64');
+  ).toBeUndefined();
   expect(
     imageRegistry.getBestManifest([manifests['windows-arm64'], manifests['windows-amd64']], 'arm64', 'darwin'),
-  ).toHaveProperty('name', 'windows-arm64');
+  ).toBeUndefined();
   expect(
     imageRegistry.getBestManifest([manifests['windows-arm64'], manifests['windows-amd64']], 'unknown-arch', 'darwin'),
-  ).toHaveProperty('name', 'windows-amd64');
+  ).toBeUndefined();
 
   // amd64 arch by default, linux os by default
   expect(

--- a/packages/main/src/plugin/image-registry.ts
+++ b/packages/main/src/plugin/image-registry.ts
@@ -37,6 +37,7 @@ import * as nodeTar from 'tar';
 
 import { pipeline } from 'node:stream/promises';
 import { createWriteStream } from 'node:fs';
+import { isMac, isWindows } from '../util.js';
 
 export interface RegistryAuthInfo {
   authUrl: string;
@@ -626,12 +627,18 @@ export class ImageRegistry {
         platformArch = 'arm64';
       }
 
+      let platformOs: 'linux' | 'windows' | 'darwin' = 'linux';
+      if (isMac()) {
+        platformOs = 'darwin';
+      } else if (isWindows()) {
+        platformOs = 'windows';
+      }
       // find the manifest corresponding to our platform
-      const matchedManifest = parsedManifest.manifests.find(
+      const matchedManifest = this.getBestManifest(
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (manifestIterator: any) =>
-          manifestIterator.mediaType === 'application/vnd.oci.image.manifest.v1+json' &&
-          manifestIterator.platform.architecture === platformArch,
+        parsedManifest.manifests.filter((m: any) => m.mediaType === 'application/vnd.oci.image.manifest.v1+json'),
+        platformArch,
+        platformOs,
       );
 
       // need to grab that manifest
@@ -641,9 +648,52 @@ export class ImageRegistry {
         const manifestURL = `${imageData.registryURL}/${imageData.name}/manifests/${matchedManifestDigest}`;
         return this.getManifestFromURL(manifestURL, imageData, token);
       }
-      throw new Error('Unable to find a manifest corresponding to the platform/architecture');
+      throw new Error(
+        `Unable to find a manifest corresponding to the platform os/architecture ${platformOs}/${platformArch}`,
+      );
     }
     return parsedManifest;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  getBestManifest(manifests: any[], wantedArch: string, wantedOs: string): any {
+    // eslint-disable-next-line etc/no-commented-out-code
+    // manifestsMap [os] [arch] = manifest
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const manifestsMap = new Map<string, Map<string, any>>();
+    manifests.forEach(manifest => {
+      const arch = manifest.platform.architecture;
+      const os = manifest.platform.os;
+      let manifestsForOs = manifestsMap.get(os);
+      if (!manifestsForOs) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        manifestsForOs = new Map<string, any>();
+      }
+      manifestsForOs.set(arch, manifest);
+      manifestsMap.set(os, manifestsForOs);
+    });
+
+    let wantedOses = manifestsMap.get(wantedOs);
+    if (!wantedOses) {
+      if (manifestsMap.size === 1) {
+        wantedOses = manifestsMap.get(manifestsMap.keys().next().value);
+      } else {
+        wantedOses = manifestsMap.get('linux');
+      }
+    }
+    if (!wantedOses) {
+      return;
+    }
+
+    let wanted = wantedOses.get(wantedArch);
+    if (!wanted) {
+      if (wantedOses.size === 1) {
+        wanted = wantedOses.get(wantedOses.keys().next().value);
+      } else {
+        wanted = wantedOses.get('amd64');
+      }
+    }
+    return wanted;
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/main/src/plugin/image-registry.ts
+++ b/packages/main/src/plugin/image-registry.ts
@@ -675,11 +675,7 @@ export class ImageRegistry {
 
     let wantedOses = manifestsMap.get(wantedOs);
     if (!wantedOses) {
-      if (manifestsMap.size === 1) {
-        wantedOses = manifestsMap.get(manifestsMap.keys().next().value);
-      } else {
-        wantedOses = manifestsMap.get('linux');
-      }
+      wantedOses = manifestsMap.get('linux');
     }
     if (!wantedOses) {
       return;


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

This PR makes the extension installation check for the OS in addition to the architecture of the platform, so binaries in the image can be used in the platform.


### Screenshot / video of UI


### What issues does this PR fix or reference?

fixes #5190 

### How to test this PR?

- Test with existing extensions that the extension is correctly installed
- Test with the extension image: quay.io/phmartin/openshift-image-checker:v0.0.32
