### PR TITLE
chore: adjust details heading and summary post-pf

### DIFF
--- a/packages/renderer/src/lib/compose/ComposeDetailsSummary.svelte
+++ b/packages/renderer/src/lib/compose/ComposeDetailsSummary.svelte
@@ -14,8 +14,8 @@ function openContainer(containerID: string) {
   <div class="w-full">
     <table>
       <tr>
-        <td class="pt-2 pr-2">Name:</td>
-        <td class="pt-2 pr-2">{compose.name}</td>
+        <td class="pr-2">Name:</td>
+        <td>{compose.name}</td>
       </tr>
     </table>
   </div>
@@ -25,8 +25,8 @@ function openContainer(containerID: string) {
       <table>
         {#each compose.containers as container}
           <tr class="cursor-pointer" on:click="{() => openContainer(container.id)}">
-            <td class="pt-2 pr-2">{container.name}</td>
-            <td class="pt-2 pr-2">{container.id}</td>
+            <td class="pr-2">{container.name}</td>
+            <td>{container.id}</td>
           </tr>
         {/each}
       </table>

--- a/packages/renderer/src/lib/container/ContainerDetailsSummary.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetailsSummary.svelte
@@ -8,21 +8,21 @@ export let container: ContainerInfoUI;
   <div class="w-full">
     <table class="h-2">
       <tr>
-        <td class="pt-2 pr-2">Id</td>
-        <td class="pt-2 pr-2">{container.shortId}</td>
+        <td class="pr-2">Id</td>
+        <td>{container.shortId}</td>
       </tr>
       <tr class:hidden="{!container.command}">
-        <td class="pt-2 pr-2">Command</td>
-        <td class="pt-2 pr-2">{container.command}</td>
+        <td class="pr-2">Command</td>
+        <td>{container.command}</td>
       </tr>
       <tr>
-        <td class="pt-2 pr-2">State</td>
-        <td class="pt-2 pr-2">{container.state}</td>
+        <td class="pr-2">State</td>
+        <td>{container.state}</td>
       </tr>
       <tr>
-        <td class="pt-2 pr-2">Ports</td>
-        <td class="pt-2 pr-2" class:hidden="{container.hasPublicPort}">N/A</td>
-        <td class="pt-2 pr-2" class:hidden="{!container.hasPublicPort}">{container.portsAsString}</td>
+        <td class="pr-2">Ports</td>
+        <td class:hidden="{container.hasPublicPort}">N/A</td>
+        <td class:hidden="{!container.hasPublicPort}">{container.portsAsString}</td>
       </tr>
     </table>
   </div>

--- a/packages/renderer/src/lib/image/ImageDetailsSummary.svelte
+++ b/packages/renderer/src/lib/image/ImageDetailsSummary.svelte
@@ -7,16 +7,16 @@ export let image: ImageInfoUI;
 <div class="flex px-5 py-4 flex-col h-full overflow-auto">
   <table>
     <tr>
-      <td class="pt-2 pr-2">Id:</td>
-      <td class="pt-2 pr-2">{image.id}</td>
+      <td class="pr-2">Id:</td>
+      <td>{image.id}</td>
     </tr>
     <tr>
-      <td class="pt-2 pr-2">Size:</td>
-      <td class="pt-2 pr-2">{image.humanSize}</td>
+      <td class="pr-2">Size:</td>
+      <td>{image.humanSize}</td>
     </tr>
     <tr>
-      <td class="pt-2 pr-2">Age</td>
-      <td class="pt-2 pr-2">{image.age}</td>
+      <td class="pr-2">Age</td>
+      <td>{image.age}</td>
     </tr>
   </table>
 </div>

--- a/packages/renderer/src/lib/pod/PodDetailsSummary.svelte
+++ b/packages/renderer/src/lib/pod/PodDetailsSummary.svelte
@@ -45,12 +45,12 @@ ass KubeDetailsSummary will automatically add a 'Loading ... ' section -->
     <div class="w-full">
       <table>
         <tr>
-          <td class="pt-2 pr-2">Name:</td>
-          <td class="pt-2 pr-2">{pod.name}</td>
+          <td class="pr-2">Name:</td>
+          <td>{pod.name}</td>
         </tr>
         <tr>
-          <td class="pt-2 pr-2">Id:</td>
-          <td class="pt-2 pr-2">{pod.id}</td>
+          <td class="pr-2">Id:</td>
+          <td>{pod.id}</td>
         </tr>
       </table>
     </div>
@@ -60,8 +60,8 @@ ass KubeDetailsSummary will automatically add a 'Loading ... ' section -->
         <table>
           {#each pod.containers as container}
             <tr class="cursor-pointer" on:click="{() => openContainer(container.Id)}">
-              <td class="pt-2 pr-2">{container.Names}</td>
-              <td class="pt-2 pr-2">{container.Id}</td>
+              <td class="pr-2">{container.Names}</td>
+              <td>{container.Id}</td>
             </tr>
           {/each}
         </table>

--- a/packages/renderer/src/lib/ui/DetailsPage.svelte
+++ b/packages/renderer/src/lib/ui/DetailsPage.svelte
@@ -22,7 +22,7 @@ function handleKeydown(e: KeyboardEvent) {
 <svelte:window on:keydown="{handleKeydown}" />
 
 <div class="flex flex-col w-full h-full shadow-pageheader">
-  <div class="flex flex-row w-full h-fit px-5 py-4">
+  <div class="flex flex-row w-full h-fit px-5 pt-4 pb-2">
     <div class="flex flex-col w-full h-fit">
       <div class="flex flew-row items-center text-sm text-gray-700">
         <Link class="text-sm" aria-label="back" internalRef="{$lastPage.path}" title="Go back to {$lastPage.name}"
@@ -42,7 +42,7 @@ function handleKeydown(e: KeyboardEvent) {
             <h1 aria-label="{title}" class="text-xl leading-tight">{title}</h1>
             <div class="text-violet-400 ml-2 leading-normal" class:hidden="{!titleDetail}">{titleDetail}</div>
           </div>
-          <div class="pt-1">
+          <div>
             <span class="text-sm leading-none text-gray-900" class:hidden="{!subtitle}">{subtitle}</span>
             <slot name="subtitle" />
           </div>
@@ -60,9 +60,11 @@ function handleKeydown(e: KeyboardEvent) {
       </div>
     </div>
   </div>
-  <div class="flex flex-row px-2 border-b border-charcoal-400">
-    <slot name="tabs" />
-  </div>
+  {#if $$slots.tabs}
+    <div class="flex flex-row px-2 border-b border-charcoal-400">
+      <slot name="tabs" />
+    </div>
+  {/if}
   <div class="h-full bg-charcoal-900 min-h-0">
     <slot name="content" />
   </div>

--- a/packages/renderer/src/lib/ui/DetailsPage.svelte
+++ b/packages/renderer/src/lib/ui/DetailsPage.svelte
@@ -60,11 +60,9 @@ function handleKeydown(e: KeyboardEvent) {
       </div>
     </div>
   </div>
-  {#if $$slots.tabs}
-    <div class="flex flex-row px-2 border-b border-charcoal-400">
-      <slot name="tabs" />
-    </div>
-  {/if}
+  <div class="flex flex-row px-2 border-b border-charcoal-400">
+    <slot name="tabs" />
+  </div>
   <div class="h-full bg-charcoal-900 min-h-0">
     <slot name="content" />
   </div>

--- a/packages/renderer/src/lib/ui/Tab.svelte
+++ b/packages/renderer/src/lib/ui/Tab.svelte
@@ -8,7 +8,7 @@ let baseURL = $router.path.substring(0, $router.path.lastIndexOf('/'));
 </script>
 
 <div
-  class="pb-2 border-b-[3px] border-charcoal-700 whitespace-nowrap hover:cursor-pointer"
+  class="pb-1 border-b-[3px] border-charcoal-700 whitespace-nowrap hover:cursor-pointer"
   class:border-purple-500="{$router.path === baseURL + '/' + url}"
   class:hover:border-charcoal-100="{$router.path !== baseURL + '/' + url}">
   <a

--- a/packages/renderer/src/lib/volume/VolumeDetailsSummary.svelte
+++ b/packages/renderer/src/lib/volume/VolumeDetailsSummary.svelte
@@ -14,16 +14,16 @@ function openContainer(containerID: string) {
   <div class="w-full">
     <table>
       <tr>
-        <td class="pt-2 pr-2">Name:</td>
-        <td class="pt-2 pr-2">{volume.name}</td>
+        <td class="pr-2">Name:</td>
+        <td>{volume.name}</td>
       </tr>
       <tr>
-        <td class="pt-2 pr-2">Size:</td>
-        <td class="pt-2 pr-2">{volume.humanSize}</td>
+        <td class="pr-2">Size:</td>
+        <td>{volume.humanSize}</td>
       </tr>
       <tr>
-        <td class="pt-2 pr-2">Age:</td>
-        <td class="pt-2 pr-2">{volume.age}</td>
+        <td class="pr-2">Age:</td>
+        <td>{volume.age}</td>
       </tr>
     </table>
   </div>
@@ -33,8 +33,8 @@ function openContainer(containerID: string) {
       {#each volume.containersUsage as container}
         <table>
           <tr class="cursor-pointer" on:click="{() => openContainer(container.id)}">
-            <td class="pt-2 pr-2">{container.names.join('')}</td>
-            <td class="pt-2 pr-2">{container.id}</td>
+            <td class="pr-2">{container.names.join('')}</td>
+            <td>{container.id}</td>
           </tr>
         </table>
       {/each}


### PR DESCRIPTION
### What does this PR do?

While testing another PR I noticed that the DetailsPage header was taking up a lot of vertical space. The Summary tabs are especially poor and the rows are really spaced out. I checked and sure enough, we were adding extra padding to compensate for PatternFly's narrow line-height, so when we removed PF these gaps became noticeable.

This PR removes all unnecessary padding from each of the Summary pages, and makes minor changes to padding in Tab and DetailsPage to return to the original design.

While I was there I added an if around the tabs, so if we ever have a details page without tabs there won't be an empty div adding padding and a line. <--- removed in second commit, needed for editing Podman machine.

### Screenshot / video of UI

1.5.3:
<img width="461" alt="Screenshot 2023-12-08 at 12 18 38 PM" src="https://github.com/containers/podman-desktop/assets/19958075/dc75749a-84a7-4c47-9116-f9fa18068479">

main:
<img width="461" alt="Screenshot 2023-12-08 at 12 34 43 PM" src="https://github.com/containers/podman-desktop/assets/19958075/0e05def7-5336-4d0e-b864-a051a0c58657">

After this PR:
<img width="461" alt="Screenshot 2023-12-08 at 12 52 34 PM" src="https://github.com/containers/podman-desktop/assets/19958075/c0026b8c-5b8f-460d-870b-9803c9242cc0">

### What issues does this PR fix or reference?

Fixes #5192.

### How to test this PR?

Go to Summary page for pods, containers, etc.