### PR TITLE
feat: reading deployments, ingress, routes, and services

### DIFF
--- a/packages/main/src/plugin/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes-client.ts
@@ -741,11 +741,7 @@ export class KubernetesClient {
     const k8sApi = this.kubeConfig.makeApiClient(CoreV1Api);
     try {
       const res = await k8sApi.readNamespacedPod(name, namespace);
-      if (res?.body) {
-        return res.body;
-      } else {
-        return undefined;
-      }
+      return res?.body;
     } catch (error) {
       telemetryOptions = { error: error };
       throw this.wrapK8sClientError(error);
@@ -754,16 +750,73 @@ export class KubernetesClient {
     }
   }
 
+  async readNamespacedDeployment(name: string, namespace: string): Promise<V1Deployment | undefined> {
+    let telemetryOptions = {};
+    const k8sAppsApi = this.kubeConfig.makeApiClient(AppsV1Api);
+    try {
+      const res = await k8sAppsApi.readNamespacedDeployment(name, namespace);
+      return res?.body;
+    } catch (error) {
+      telemetryOptions = { error: error };
+      throw this.wrapK8sClientError(error);
+    } finally {
+      this.telemetry.track('kubernetesReadNamespacedDeployment', telemetryOptions);
+    }
+  }
+  async readNamespacedIngress(name: string, namespace: string): Promise<V1Ingress | undefined> {
+    let telemetryOptions = {};
+    const k8sNetworkingApi = this.kubeConfig.makeApiClient(NetworkingV1Api);
+    try {
+      const res = await k8sNetworkingApi.readNamespacedIngress(name, namespace);
+      return res?.body;
+    } catch (error) {
+      telemetryOptions = { error: error };
+      throw this.wrapK8sClientError(error);
+    } finally {
+      this.telemetry.track('kubernetesReadNamespacedIngress', telemetryOptions);
+    }
+  }
+
+  async readNamespacedRoute(name: string, namespace: string): Promise<V1Route | undefined> {
+    let telemetryOptions = {};
+    const k8sCustomObjectsApi = this.kubeConfig.makeApiClient(CustomObjectsApi);
+    try {
+      const res = await k8sCustomObjectsApi.getNamespacedCustomObject(
+        'route.openshift.io',
+        'v1',
+        namespace,
+        'routes',
+        name,
+      );
+      return res?.body as V1Route;
+    } catch (error) {
+      telemetryOptions = { error: error };
+      throw this.wrapK8sClientError(error);
+    } finally {
+      this.telemetry.track('kubernetesReadNamespacedRoute', telemetryOptions);
+    }
+  }
+
+  async readNamespacedService(name: string, namespace: string): Promise<V1Service | undefined> {
+    let telemetryOptions = {};
+    const k8sApi = this.kubeConfig.makeApiClient(CoreV1Api);
+    try {
+      const res = await k8sApi.readNamespacedService(name, namespace);
+      return res?.body;
+    } catch (error) {
+      telemetryOptions = { error: error };
+      throw this.wrapK8sClientError(error);
+    } finally {
+      this.telemetry.track('kubernetesReadNamespacedService', telemetryOptions);
+    }
+  }
+
   async readNamespacedConfigMap(name: string, namespace: string): Promise<V1ConfigMap | undefined> {
     let telemetryOptions = {};
     const k8sApi = this.kubeConfig.makeApiClient(CoreV1Api);
     try {
       const res = await k8sApi.readNamespacedConfigMap(name, namespace);
-      if (res?.body) {
-        return res.body;
-      } else {
-        return undefined;
-      }
+      return res?.body;
     } catch (error) {
       telemetryOptions = { error: error };
       throw this.wrapK8sClientError(error);

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -1513,6 +1513,33 @@ function initExposure(): void {
   );
 
   contextBridge.exposeInMainWorld(
+    'kubernetesReadNamespacedDeployment',
+    async (name: string, namespace: string): Promise<V1Deployment | undefined> => {
+      return ipcInvoke('kubernetes-client:readNamespacedDeployment', name, namespace);
+    },
+  );
+
+  contextBridge.exposeInMainWorld(
+    'kubernetesReadNamespacedIngress',
+    async (name: string, namespace: string): Promise<V1Ingress | undefined> => {
+      return ipcInvoke('kubernetes-client:readNamespacedIngress', name, namespace);
+    },
+  );
+
+  contextBridge.exposeInMainWorld(
+    'kubernetesReadNamespacedRoute',
+    async (name: string, namespace: string): Promise<V1Route | undefined> => {
+      return ipcInvoke('kubernetes-client:readNamespacedRoute', name, namespace);
+    },
+  );
+
+  contextBridge.exposeInMainWorld(
+    'kubernetesReadNamespacedService',
+    async (name: string, namespace: string): Promise<V1Service | undefined> => {
+      return ipcInvoke('kubernetes-client:readNamespacedService', name, namespace);
+    },
+  );
+  contextBridge.exposeInMainWorld(
     'kubernetesReadNamespacedConfigMap',
     async (name: string, namespace: string): Promise<V1ConfigMap | undefined> => {
       return ipcInvoke('kubernetes-client:readNamespacedConfigMap', name, namespace);


### PR DESCRIPTION
### What does this PR do?

When we do DetailPages for the four Kubernetes objects that we're building nav pages for, we'll need the ability to read each of the objects the same way we do for pods today.

These are fairly boilerplate, so I'm just doing them all at once. Extracted createTestClient() since we're calling that a lot.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Part of #5157/#5158/#5159.

### How to test this PR?

`yarn test:main`