### PR TITLE
chore: fix tab button padding

### DIFF
--- a/packages/renderer/src/lib/ui/Button.spec.ts
+++ b/packages/renderer/src/lib/ui/Button.spec.ts
@@ -102,7 +102,7 @@ test('Check tab button styling', async () => {
   expect(button).toBeInTheDocument();
   expect(button).toHaveClass('border-b-[3px]');
   expect(button).toHaveClass('border-charcoal-700');
-  expect(button).toHaveClass('pb-2');
+  expect(button).toHaveClass('pb-1');
   expect(button).toHaveClass('hover:cursor-pointer');
   expect(button).not.toHaveClass('text-[13px]');
 });

--- a/packages/renderer/src/lib/ui/Button.svelte
+++ b/packages/renderer/src/lib/ui/Button.svelte
@@ -14,7 +14,7 @@ export let selected: boolean | undefined = undefined;
 $: if (selected !== undefined && type !== 'tab') {
   console.error('property selected can be used with type=tab only');
 }
-export let padding: string = 'px-4 py-[5px]';
+export let padding: string = type !== 'tab' ? 'px-4 py-[5px]' : 'px-4 pb-1';
 
 let iconType: string | undefined = undefined;
 
@@ -40,7 +40,7 @@ $: {
     } else if (type === 'secondary') {
       classes = 'border-[1px] border-gray-200 text-white hover:border-purple-500 hover:text-purple-500';
     } else if (type === 'tab') {
-      classes = 'pb-2 border-b-[3px] border-charcoal-700 hover:cursor-pointer py-2 text-gray-600 no-underline';
+      classes = 'border-b-[3px] border-charcoal-700 hover:cursor-pointer text-gray-600 no-underline';
     } else {
       classes = 'border-none text-purple-400 hover:bg-white hover:bg-opacity-10';
     }


### PR DESCRIPTION
### What does this PR do?

I noticed that tab buttons use a lot of vertical space. When I took a closer look I noticed that it uses the pre-PatternFly-removal spacing (we had extra py to compensate for a reduced line-height) and it specifies the y padding twice. Moved all padding to the property, removed duplication, and set to match Tabs:

Before: 'px-4 py-[5px] pb-2 py-2'

After: 'px-4 pb-1'

For comparison:
- Tab.svelte: 4px bottom padding.
- Button.svelte tab style before: 5px top + 8px bottom padding.
- Button.svelte tab style after: 4px bottom padding.

Regular button padding unchanged.

### Screenshot / video of UI

Before:
<img width="306" alt="Screenshot 2023-12-11 at 9 44 50 AM" src="https://github.com/containers/podman-desktop/assets/19958075/3540ec84-49b5-456e-831f-8723a8d24dd7">

After:

<img width="306" alt="Screenshot 2023-12-11 at 9 17 10 AM" src="https://github.com/containers/podman-desktop/assets/19958075/51703de5-ce99-4970-8ecd-a81954338d4a">

### What issues does this PR fix or reference?

Fixes #5213.

### How to test this PR?

`yarn test:renderer` or look at tabs on Pods/Containers pages.