### PR TITLE
fix: long socket path

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
@@ -473,16 +473,15 @@ function hasAnyConfiguration(provider: ProviderInfo) {
                   <ConnectionErrorInfoButton status="{status}" />
                 {/if}
               </div>
-              <div class="mt-2">
-                <div class="text-gray-700 text-xs" aria-label="{container.name} type">
-                  {#if container.type === 'docker'}Docker{:else if container.type === 'podman'}Podman{/if} endpoint
-                </div>
-                <div class="mt-1">
-                  <span
-                    class="my-auto text-xs"
-                    class:text-gray-900="{container.status !== 'started'}"
-                    aria-label="{container.name} endpoint">{container.endpoint.socketPath}</span>
-                </div>
+              <div class="mt-2 text-gray-700 text-xs" aria-label="{container.name} type">
+                {#if container.type === 'docker'}Docker{:else if container.type === 'podman'}Podman{/if} endpoint
+              </div>
+              <div
+                class="mt-1 my-auto text-xs truncate"
+                class:text-gray-900="{container.status !== 'started'}"
+                aria-label="{container.name} endpoint"
+                title="{container.endpoint.socketPath}">
+                {container.endpoint.socketPath}
               </div>
 
               {#if providerContainerConfiguration.has(provider.internalId)}


### PR DESCRIPTION
### What does this PR do?

Fixes the long socket path by truncating, and then adding a tooltip.

Removed unnecessary parent div and changed span to div while I was editing, as that's what we'd normally do here.

### Screenshot / video of UI

Before:
<img width="759" alt="Screenshot 2023-12-11 at 11 17 00 AM" src="https://github.com/containers/podman-desktop/assets/19958075/d4f50897-2abc-4061-933f-ac969eab3107">

After:

<img width="759" alt="Screenshot 2023-12-11 at 11 54 34 AM" src="https://github.com/containers/podman-desktop/assets/19958075/75b912fd-582c-4634-8c45-1abf9818034e">

### What issues does this PR fix or reference?

Fixes #5218.

### How to test this PR?

Go to Settings > Resources on any platform with long socket paths.