### PR TITLE
feat: show lima instance name in connection name

### DIFF
--- a/extensions/lima/src/extension.ts
+++ b/extensions/lima/src/extension.ts
@@ -31,17 +31,27 @@ const LIMA_MOVE_IMAGE_COMMAND = 'lima.image.move';
 
 const imageHandler = new ImageHandler();
 
+function prettyInstanceName(instanceName: string): string {
+  let name;
+  if (instanceName === 'default') {
+    name = 'Lima';
+  } else {
+    name = `Lima ${instanceName}`;
+  }
+  return name;
+}
+
 function registerProvider(
   extensionContext: extensionApi.ExtensionContext,
   provider: extensionApi.Provider,
   providerType: limaProviderType,
   providerPath: string,
+  instanceName: string,
 ): void {
   let providerState: extensionApi.ProviderConnectionStatus = 'unknown';
-  const instanceName: string = configuration.getConfiguration('lima').get('name') || providerType;
   if (providerType === 'podman' || providerType === 'docker') {
     const connection: extensionApi.ContainerProviderConnection = {
-      name: 'Lima',
+      name: prettyInstanceName(instanceName),
       type: providerType,
       status: () => providerState,
       endpoint: {
@@ -54,7 +64,7 @@ function registerProvider(
     extensionContext.subscriptions.push(disposable);
   } else if (providerType === 'kubernetes') {
     const connection: extensionApi.KubernetesProviderConnection = {
-      name: 'Lima',
+      name: prettyInstanceName(instanceName),
       status: () => providerState,
       endpoint: {
         apiURL: 'https://localhost:6443',
@@ -109,7 +119,7 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
   if (socketName !== 'kubernetes.sock') {
     const providerType = engineType === 'kubernetes' ? 'docker' : (engineType as limaProviderType);
     if (fs.existsSync(socketPath)) {
-      registerProvider(extensionContext, provider, providerType, socketPath);
+      registerProvider(extensionContext, provider, providerType, socketPath, instanceName);
     } else {
       console.debug(`Could not find socket at ${socketPath}`);
     }
@@ -118,7 +128,7 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
   if (engineType === 'kubernetes') {
     const providerType = engineType as limaProviderType;
     if (fs.existsSync(configPath)) {
-      registerProvider(extensionContext, provider, providerType, configPath);
+      registerProvider(extensionContext, provider, providerType, configPath, instanceName);
     } else {
       console.debug(`Could not find config at ${configPath}`);
     }

--- a/extensions/lima/src/extension.ts
+++ b/extensions/lima/src/extension.ts
@@ -91,9 +91,10 @@ function registerProvider(
 }
 
 export async function activate(extensionContext: extensionApi.ExtensionContext): Promise<void> {
-  const engineType = configuration.getConfiguration('lima').get('type') || 'podman';
-  const instanceName = configuration.getConfiguration('lima').get('name') || engineType;
-  const socketName = configuration.getConfiguration('lima').get('socket') || engineType + '.sock';
+  const engineType: string = configuration.getConfiguration('lima').get('type') || 'podman';
+  const instanceName: string = configuration.getConfiguration('lima').get('name') || engineType;
+  const socketName: string = configuration.getConfiguration('lima').get('socket') || engineType + '.sock';
+
   const limaHome = 'LIMA_HOME' in process.env ? process.env['LIMA_HOME'] : os.homedir() + '/.lima';
   const socketPath = path.resolve(limaHome, instanceName + '/sock/' + socketName);
   const configPath = path.resolve(limaHome, instanceName + '/copied-from-guest/kubeconfig.yaml');


### PR DESCRIPTION
### What does this PR do?

Shows the name of the preferred instance

`Lima ${LIMA_INSTANCE}`

### Screenshot / video of UI

![pd-lima-name-u7s](https://github.com/containers/podman-desktop/assets/10364051/07b74e64-1425-47cc-b19a-0d4b933b1f19)

### What issues does this PR fix or reference?

Closes: #5207

### How to test this PR?

<!-- Please explain steps to reproduce -->
