### PR TITLE
chore: allow to use index manifest without recommended mediaType field

### DIFF
--- a/packages/main/src/plugin/image-registry.ts
+++ b/packages/main/src/plugin/image-registry.ts
@@ -614,9 +614,13 @@ export class ImageRegistry {
       }
     }
 
-    // check mediaType of the manifest
-    // if it is application/vnd.oci.image.index.v1+json it is an index
-    if (parsedManifest.mediaType === 'application/vnd.oci.image.index.v1+json') {
+    // https://github.com/opencontainers/image-spec/blob/main/image-index.md
+    // check schemaVersion and (mediaType of the manifest or if it contains manifests field being an array)
+    if (
+      parsedManifest.schemaVersion === 2 &&
+      (parsedManifest.mediaType === 'application/vnd.oci.image.index.v1+json' ||
+        Array.isArray(parsedManifest.manifests))
+    ) {
       // need to grab correct manifest from the index corresponding to our platform
       let platformArch: 'amd64' | 'arm64' = 'amd64';
       const arch = os.arch();


### PR DESCRIPTION
### What does this PR do?
mediaType SHOULD be included but it's not mandatory (but it's not a REQUIRED one)
https://github.com/opencontainers/image-spec/blob/main/image-index.md

so we can't rely on the presence of this field as it may not be there

but add check on schemaVersion REQUIRED field as well

### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fixes https://github.com/redhat-developer/podman-desktop-demo/issues/33

### How to test this PR?

<!-- Please explain steps to reproduce -->
