### PR TITLE
fix: color of primary/secondary buttons should be white

### DIFF
--- a/packages/renderer/src/lib/ui/Button.spec.ts
+++ b/packages/renderer/src/lib/ui/Button.spec.ts
@@ -31,6 +31,7 @@ test('Check primary button styling', async () => {
   expect(button).toBeInTheDocument();
   expect(button).toHaveClass('bg-purple-600');
   expect(button).toHaveClass('text-[13px]');
+  expect(button).toHaveClass('text-white');
 });
 
 test('Check disabled/in-progress primary button styling', async () => {
@@ -50,6 +51,7 @@ test('Check primary button is the default', async () => {
   const button = screen.getByRole('button');
   expect(button).toBeInTheDocument();
   expect(button).toHaveClass('bg-purple-600');
+  expect(button).toHaveClass('text-white');
 });
 
 test('Check secondary button styling', async () => {
@@ -60,6 +62,7 @@ test('Check secondary button styling', async () => {
   expect(button).toBeInTheDocument();
   expect(button).toHaveClass('border-gray-200');
   expect(button).toHaveClass('text-[13px]');
+  expect(button).toHaveClass('text-white');
 });
 
 test('Check disabled/in-progress secondary button styling', async () => {
@@ -82,6 +85,7 @@ test('Check link button styling', async () => {
   expect(button).toHaveClass('hover:bg-white');
   expect(button).toHaveClass('hover:bg-opacity-10');
   expect(button).toHaveClass('text-[13px]');
+  expect(button).toHaveClass('text-purple-400');
 });
 
 test('Check disabled/in-progress link button styling', async () => {
@@ -103,6 +107,17 @@ test('Check tab button styling', async () => {
   expect(button).toHaveClass('border-b-[3px]');
   expect(button).toHaveClass('border-charcoal-700');
   expect(button).toHaveClass('pb-1');
+  expect(button).toHaveClass('text-gray-600');
   expect(button).toHaveClass('hover:cursor-pointer');
   expect(button).not.toHaveClass('text-[13px]');
+});
+
+test('Check selected tab button styling', async () => {
+  render(Button, { type: 'tab', selected: true });
+
+  // check for a few elements of the styling
+  const button = screen.getByRole('button');
+  expect(button).toBeInTheDocument();
+  expect(button).toHaveClass('text-white');
+  expect(button).toHaveClass('border-purple-500');
 });

--- a/packages/renderer/src/lib/ui/Button.svelte
+++ b/packages/renderer/src/lib/ui/Button.svelte
@@ -36,9 +36,9 @@ $: {
     }
   } else {
     if (type === 'primary') {
-      classes = 'bg-purple-600 border-none text-white hover:bg-purple-500';
+      classes = 'bg-purple-600 border-none hover:bg-purple-500';
     } else if (type === 'secondary') {
-      classes = 'border-[1px] border-gray-200 text-white hover:border-purple-500 hover:text-purple-500';
+      classes = 'border-[1px] border-gray-200 hover:border-purple-500 hover:text-purple-500';
     } else if (type === 'tab') {
       classes = 'border-b-[3px] border-charcoal-700 hover:cursor-pointer text-gray-600 no-underline';
     } else {
@@ -57,7 +57,7 @@ $: {
   class="relative {padding} box-border whitespace-nowrap select-none transition-all {classes} {$$props.class || ''}"
   class:border-purple-500="{type === 'tab' && selected}"
   class:hover:border-charcoal-100="{type === 'tab' && !selected}"
-  class:text-white="{type === 'tab' && selected}"
+  class:text-white="{(type === 'tab' && selected) || type === 'primary' || type === 'secondary'}"
   title="{title}"
   aria-label="{$$props['aria-label']}"
   on:click


### PR DESCRIPTION
### What does this PR do?
ensure color of button is valid

### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
fixes https://github.com/containers/podman-desktop/issues/5230
<!-- Include any related issues from Podman Desktop 
repository (or from another issue tracker). -->

### How to test this PR?

check colors of buttons (primary, secondary, links, tabs)

primary/secondary should have white text color

unit tests added