### PR TITLE
fix: handle event when loading images from archives

### DIFF
--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -163,6 +163,9 @@ export class ContainerProviderRegistry {
       } else if (jsonEvent.status === 'build' && jsonEvent?.Type === 'image') {
         // need to notify that image are being pulled
         this.apiSender.send('image-build-event', jsonEvent.id);
+      } else if (jsonEvent.status === 'loadfromarchive' && jsonEvent?.Type === 'image') {
+        // need to notify that image are being pulled
+        this.apiSender.send('image-loadfromarchive-event', jsonEvent.id);
       }
     });
 

--- a/packages/renderer/src/stores/images.spec.ts
+++ b/packages/renderer/src/stores/images.spec.ts
@@ -1,0 +1,88 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { get } from 'svelte/store';
+import type { Mock } from 'vitest';
+import { beforeAll, expect, test, vi } from 'vitest';
+import { imagesInfos, imagesEventStore } from './images';
+import type { ImageInfo } from '../../../main/src/plugin/api/image-info';
+
+// first, path window object
+const callbacks = new Map<string, any>();
+const eventEmitter = {
+  receive: (message: string, callback: any) => {
+    callbacks.set(message, callback);
+  },
+};
+
+const listImagesMock: Mock<any, Promise<ImageInfo[]>> = vi.fn();
+
+Object.defineProperty(global, 'window', {
+  value: {
+    listImages: listImagesMock,
+    events: {
+      receive: eventEmitter.receive,
+    },
+    addEventListener: eventEmitter.receive,
+  },
+  writable: true,
+});
+
+beforeAll(() => {
+  vi.clearAllMocks();
+});
+
+test('images should be updated in case of a image is loaded from an archive', async () => {
+  // initial images
+  listImagesMock.mockResolvedValue([
+    {
+      Id: 1,
+    } as unknown as ImageInfo,
+  ]);
+  const storeInfo = imagesEventStore.setup();
+
+  const callback = callbacks.get('extensions-already-started');
+  // send 'extensions-already-started' event
+  expect(callback).toBeDefined();
+  await callback();
+
+  // fetch
+  await storeInfo.fetch();
+
+  // now get list
+  const images = get(imagesInfos);
+  expect(images.length).toBe(1);
+  expect(images[0].Id).toBe(1);
+
+  // ok now mock the listImages function to return an empty list
+  listImagesMock.mockResolvedValue([]);
+
+  // call 'image-loadfromarchive-event' event
+  const imageLoadFromArchiveCallback = callbacks.get('image-loadfromarchive-event');
+  expect(imageLoadFromArchiveCallback).toBeDefined();
+  await imageLoadFromArchiveCallback();
+
+  // wait debounce
+  await new Promise(resolve => setTimeout(resolve, 2000));
+
+  // check if the images have been updated
+  const images2 = get(imagesInfos);
+  expect(images2.length).toBe(0);
+});

--- a/packages/renderer/src/stores/images.ts
+++ b/packages/renderer/src/stores/images.ts
@@ -35,6 +35,7 @@ const windowEvents = [
   'image-tag-event',
   'image-untag-event',
   'extensions-started',
+  'image-loadfromarchive-event',
 ];
 const windowListeners = ['image-build', 'extensions-already-started'];
 
@@ -56,7 +57,7 @@ const listImages = (): Promise<ImageInfo[]> => {
   return window.listImages();
 };
 
-const imagesEventStore = new EventStore<ImageInfo[]>(
+export const imagesEventStore = new EventStore<ImageInfo[]>(
   'images',
   imagesInfos,
   checkForUpdate,


### PR DESCRIPTION
### What does this PR do?
Refresh the UI when we load images from archive

### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/5221

### How to test this PR?

unit test or follow test case of the issue