### PR TITLE
fix: dispose the wsl2 command when unregistering extension

### DIFF
--- a/extensions/podman/src/extension.spec.ts
+++ b/extensions/podman/src/extension.spec.ts
@@ -951,7 +951,8 @@ test('ensure showNotification is not called during update', async () => {
       }),
   );
 
-  const podmanInstall: PodmanInstall = new PodmanInstall('');
+  const extensionContext = { subscriptions: [], storagePath: '' } as extensionApi.ExtensionContext;
+  const podmanInstall: PodmanInstall = new PodmanInstall(extensionContext);
   vi.spyOn(podmanInstall, 'checkForUpdate').mockImplementation((_installedPodman: InstalledPodman) => {
     return Promise.resolve({
       hasUpdate: true,

--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -807,7 +807,7 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
 
   initTelemetryLogger();
 
-  const podmanInstall = new PodmanInstall(extensionContext.storagePath);
+  const podmanInstall = new PodmanInstall(extensionContext);
 
   const installedPodman = await getPodmanInstallation();
   const version: string | undefined = installedPodman?.version;


### PR DESCRIPTION
### What does this PR do?
register the command to be disposed when removing the extension (fix is at the very bottom of the PR)

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/4593
### How to test this PR?

unit test added

or check testcase from issue