### PR TITLE
fix: try to search kubectl on the user path first

### DIFF
--- a/extensions/kubectl-cli/src/extension.spec.ts
+++ b/extensions/kubectl-cli/src/extension.spec.ts
@@ -318,7 +318,8 @@ test('findKubeCtl not global kubectl but in storage installed on macOS', async (
 
   const { version, path } = await KubectlExtension.findKubeCtl(extensionContext);
   expect(version).toBe('1.28.3');
-  expect(path).toContain(fakeStorageDirectory);
+  expect(path).toContain('fake');
+  expect(path).toContain('directory');
   expect(path).toContain('bin');
   expect(path).toContain('kubectl');
 

--- a/extensions/kubectl-cli/src/extension.spec.ts
+++ b/extensions/kubectl-cli/src/extension.spec.ts
@@ -22,6 +22,7 @@ import * as extensionApi from '@podman-desktop/api';
 import * as KubectlExtension from './extension';
 import { afterEach } from 'node:test';
 import type { Configuration } from '@podman-desktop/api';
+import * as path from 'node:path';
 
 const extensionContext = {
   subscriptions: [],
@@ -37,6 +38,9 @@ vi.mock('@podman-desktop/api', () => {
       exec: vi.fn(),
     },
     env: {
+      isMac: true,
+      isWindows: false,
+      isLinux: false,
       createTelemetryLogger: vi.fn(),
     },
     configuration: {
@@ -59,6 +63,7 @@ beforeEach(() => {
   vi.mocked(extensionApi.configuration.getConfiguration).mockReturnValue({
     update: vi.fn(),
   } as unknown as Configuration);
+  vi.mocked(extensionApi.process.exec).mockClear();
 });
 
 afterEach(() => {
@@ -112,7 +117,7 @@ test('kubectl CLI tool registered when detected and extension is activated', asy
 test('kubectl CLI tool not registered when not detected', async () => {
   vi.mocked(extensionApi.process.exec).mockRejectedValue(new Error('Error running version command'));
   const deferred = new Promise<void>(resolve => {
-    vi.spyOn(console, 'error').mockImplementation(() => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {
       resolve();
     });
   });
@@ -120,10 +125,8 @@ test('kubectl CLI tool not registered when not detected', async () => {
   await KubectlExtension.activate(extensionContext);
 
   return deferred.then(() => {
-    expect(console.error).toBeCalled();
-    expect(console.error).toBeCalledWith(
-      expect.stringContaining('Error getting kubectl version: Error: Error running version command'),
-    );
+    expect(console.warn).toBeCalled();
+    expect(console.warn).toBeCalledWith(expect.stringContaining('Error running version command'));
   });
 });
 
@@ -135,7 +138,7 @@ test('kubectl CLI tool not registered when version json stdout cannot be parsed'
   });
 
   const deferred = new Promise<void>(resolve => {
-    vi.spyOn(console, 'error').mockImplementation((message: string) => {
+    vi.spyOn(console, 'warn').mockImplementation((message: string) => {
       log(message);
       resolve();
     });
@@ -144,9 +147,11 @@ test('kubectl CLI tool not registered when version json stdout cannot be parsed'
   await KubectlExtension.activate(extensionContext);
 
   return deferred.then(() => {
-    expect(console.error).toBeCalled();
-    expect(console.error).toBeCalledWith(
-      expect.stringContaining('Error getting kubectl version: SyntaxError: Unexpected token { in JSON at position 1'),
+    expect(console.warn).toBeCalled();
+    expect(console.warn).toBeCalledWith(
+      expect.stringContaining(
+        'Error getting kubectl from user PATH: SyntaxError: Unexpected token { in JSON at position 1',
+      ),
     );
   });
 });
@@ -165,7 +170,7 @@ test('kubectl CLI tool not registered when version cannot be extracted from obje
   });
 
   const deferred = new Promise<void>(resolve => {
-    vi.spyOn(console, 'error').mockImplementation((message: string) => {
+    vi.spyOn(console, 'warn').mockImplementation((message: string) => {
       log(message);
       resolve();
     });
@@ -174,9 +179,149 @@ test('kubectl CLI tool not registered when version cannot be extracted from obje
   await KubectlExtension.activate(extensionContext);
 
   return deferred.then(() => {
-    expect(console.error).toBeCalled();
-    expect(console.error).toBeCalledWith(
-      expect.stringContaining('Error getting kubectl version: Error: Cannot extract version from stdout'),
-    );
+    expect(console.warn).toBeCalled();
+    expect(console.warn).toBeCalledWith(expect.stringContaining('Error: Cannot extract version from stdout'));
   });
+});
+
+test('kubectl CLI tool not registered when version cannot be extracted from object', async () => {
+  const wrongJsonStdout = {
+    clientVersion: {
+      ...jsonStdout.clientVersion,
+    },
+  };
+  delete (wrongJsonStdout.clientVersion as any).gitVersion;
+  vi.mocked(extensionApi.process.exec).mockResolvedValue({
+    stderr: '',
+    stdout: JSON.stringify(wrongJsonStdout),
+    command: 'kubectl version --client=true -o=json',
+  });
+
+  const deferred = new Promise<void>(resolve => {
+    vi.spyOn(console, 'warn').mockImplementation((message: string) => {
+      log(message);
+      resolve();
+    });
+  });
+
+  await KubectlExtension.activate(extensionContext);
+
+  return deferred.then(() => {
+    expect(console.warn).toBeCalled();
+    expect(console.warn).toBeCalledWith(expect.stringContaining('Error: Cannot extract version from stdout'));
+  });
+});
+
+test('getStorageKubectlPath', async () => {
+  // get current directory
+  const currentDirectory = process.cwd();
+
+  const extensionContext = {
+    storagePath: currentDirectory,
+  } as unknown as extensionApi.ExtensionContext;
+
+  const storagePath = KubectlExtension.getStorageKubectlPath(extensionContext);
+  expect(storagePath).toContain(path.resolve(currentDirectory, 'bin', 'kubectl'));
+});
+
+test('findKubeCtl with global kubectl being installed on macOS', async () => {
+  // get current directory
+  const currentDirectory = process.cwd();
+
+  const extensionContext = {
+    storagePath: currentDirectory,
+  } as unknown as extensionApi.ExtensionContext;
+
+  // first call is replying the kubectl version
+  vi.mocked(extensionApi.process.exec).mockResolvedValueOnce({
+    stderr: '',
+    stdout: JSON.stringify(jsonStdout),
+    command: 'kubectl version --client=true -o=json',
+  });
+
+  //
+  vi.mocked(extensionApi.env).isMac = true;
+
+  // second call is replying the path to kubectl
+  vi.mocked(extensionApi.process.exec).mockResolvedValueOnce({
+    stderr: '',
+    stdout: '/fake/directory/kubectl',
+    command: 'which kubectl',
+  });
+
+  const { version, path } = await KubectlExtension.findKubeCtl(extensionContext);
+  expect(version).toBe('1.28.3');
+  expect(path).toBe('/fake/directory/kubectl');
+
+  // expect we call with which
+  expect(extensionApi.process.exec).toBeCalledWith('which', expect.anything());
+});
+
+test('findKubeCtl with global kubectl being installed on Windows', async () => {
+  // get current directory
+  const currentDirectory = process.cwd();
+
+  const extensionContext = {
+    storagePath: currentDirectory,
+  } as unknown as extensionApi.ExtensionContext;
+
+  // first call is replying the kubectl version
+  vi.mocked(extensionApi.process.exec).mockResolvedValueOnce({
+    stderr: '',
+    stdout: JSON.stringify(jsonStdout),
+    command: 'kubectl version --client=true -o=json',
+  });
+
+  //
+  vi.mocked(extensionApi.env).isMac = false;
+  vi.mocked(extensionApi.env).isLinux = false;
+  vi.mocked(extensionApi.env).isWindows = true;
+
+  // second call is replying the path to kubectl
+  vi.mocked(extensionApi.process.exec).mockResolvedValueOnce({
+    stderr: '',
+    stdout: '/fake/directory/kubectl',
+    command: 'which kubectl',
+  });
+
+  const { version, path } = await KubectlExtension.findKubeCtl(extensionContext);
+  expect(version).toBe('1.28.3');
+  expect(path).toBe('/fake/directory/kubectl');
+
+  // expect we call with which
+  expect(extensionApi.process.exec).toBeCalledWith('where', expect.anything());
+});
+
+test('findKubeCtl not global kubectl but in storage installed on macOS', async () => {
+  // get current directory
+  const fakeStorageDirectory = '/fake/directory';
+
+  const extensionContext = {
+    storagePath: fakeStorageDirectory,
+  } as unknown as extensionApi.ExtensionContext;
+
+  // first call is replying the kubectl version
+  vi.mocked(extensionApi.process.exec).mockRejectedValueOnce(new Error('Error running kubectl command'));
+
+  //
+  vi.mocked(extensionApi.env).isMac = true;
+
+  // second call is replying the path to storage kubectl
+  vi.mocked(extensionApi.process.exec).mockResolvedValueOnce({
+    stderr: '',
+    stdout: JSON.stringify(jsonStdout),
+    command: 'kubectl version --client=true -o=json',
+  });
+
+  // mock extension storage path
+  vi.spyOn(KubectlExtension, 'getStorageKubectlPath').mockReturnValue('/fake/directory/kubectl');
+
+  const { version, path } = await KubectlExtension.findKubeCtl(extensionContext);
+  expect(version).toBe('1.28.3');
+  expect(path).toContain(fakeStorageDirectory);
+  expect(path).toContain('bin');
+  expect(path).toContain('kubectl');
+
+  // expect no call with which
+  expect(extensionApi.process.exec).not.toBeCalledWith('which', expect.anything());
 });


### PR DESCRIPTION
### What does this PR do?
register/set version/path from existing binary first

### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/5216

### How to test this PR?

unit test

check usecase from the issue

also check with an old binary, try to update it, without binary/cache from ~/.local/share/containers/podman-desktop/extensions-storage/
