### PR TITLE
fix: minor issues with CLI tool UI

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesCliTool.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesCliTool.svelte
@@ -72,24 +72,22 @@ function getLoggerHandler(_cliToolId: string): ConnectionCallback {
           {/if}
           <span id="{cliTool.id}" class="my-auto ml-3 break-words" aria-label="cli-name">{cliTool.name}</span>
         </div>
-        <div class="">
+        {#if cliTool.version && cliToolStatus}
           <div class="p-0.5 rounded-lg bg-charcoal-900 w-fit">
-            {#if cliTool.version && cliToolStatus}
-              <LoadingIconButton
-                action="update"
-                clickAction="{() => {
-                  if (cliTool.newVersion) {
-                    update(cliTool);
-                  }
-                }}"
-                icon="{faCircleArrowUp}"
-                leftPosition="left-[0.4rem]"
-                state="{cliToolStatus}"
-                color="primary"
-                tooltip="{!cliTool.newVersion ? 'No updates' : `Update to v.${cliTool.newVersion}`}" />
-            {/if}
+            <LoadingIconButton
+              action="update"
+              clickAction="{() => {
+                if (cliTool.newVersion) {
+                  update(cliTool);
+                }
+              }}"
+              icon="{faCircleArrowUp}"
+              leftPosition="left-[0.4rem]"
+              state="{cliToolStatus}"
+              color="primary"
+              tooltip="{!cliTool.newVersion ? 'No updates' : `Update to v${cliTool.newVersion}`}" />
           </div>
-        </div>
+        {/if}
       </div>
     </div>
     <!-- cli-tools columns -->
@@ -103,9 +101,10 @@ function getLoggerHandler(_cliToolId: string): ConnectionCallback {
           <Markdown markdown="{cliTool.description}" />
         </div>
         {#if cliTool.version}
-          <div class="flex flex-row justify-between bg-charcoal-900 p-2 rounded-lg min-w-[320px] w-fit">
-            <span class="text-white-400 font-bold text-xs" aria-label="cli-version"
-              >{cliTool.name} v{cliTool.version}</span>
+          <div class="flex flex-row justify-between align-center bg-charcoal-900 p-2 rounded-lg min-w-[320px] w-fit">
+            <div class="flex text-white-400 font-bold text-xs items-center" aria-label="cli-version">
+              {cliTool.name} v{cliTool.version}
+            </div>
             {#if cliTool.newVersion}
               <Button
                 type="link"
@@ -116,7 +115,7 @@ function getLoggerHandler(_cliToolId: string): ConnectionCallback {
                     update(cliTool);
                   }
                 }}"
-                title="{`Update ${cliTool.displayName} to v.${cliTool.newVersion}?`}"
+                title="{`${cliTool.displayName} will be updated to v${cliTool.newVersion}`}"
                 disabled="{!cliTool.newVersion}"
                 aria-label="Update available">
                 Update available


### PR DESCRIPTION
### What does this PR do?

Fixes some small issues I noticed while testing the CLI tools settings:
- Remove 'dot' if there is no version or status - removed unused parent div and moved the other inside of the if statement.
- Removed '.' from version in both tooltips.
- Fixed vertical alignment of version and update button.
- Rephrased the tooltip question to telling you what it'll do.

### Screenshot / video of UI

Before:
<img width="610" alt="Screenshot 2023-12-13 at 12 10 29 PM" src="https://github.com/containers/podman-desktop/assets/19958075/6e909ce3-0cfe-461a-97c5-bd4b201cdfcc">

After:
<img width="610" alt="Screenshot 2023-12-13 at 2 17 39 PM" src="https://github.com/containers/podman-desktop/assets/19958075/f9aece28-85e5-4a5e-b805-369a1f9b6014">

### What issues does this PR fix or reference?

Fixes #5251.

### How to test this PR?

Go to Settings > CLI Tools.