### PR TITLE
feat: form progress

### DIFF
--- a/packages/renderer/src/lib/image/BuildImageFromContainerfile.svelte
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfile.svelte
@@ -146,7 +146,7 @@ async function abortBuild() {
 }
 </script>
 
-<FormPage title="Build Image from Containerfile">
+<FormPage title="Build Image from Containerfile" inProgress="{buildImageInfo?.buildRunning}">
   <svelte:fragment slot="icon">
     <i class="fas fa-cube fa-2x" aria-hidden="true"></i>
   </svelte:fragment>

--- a/packages/renderer/src/lib/image/PullImage.svelte
+++ b/packages/renderer/src/lib/image/PullImage.svelte
@@ -133,7 +133,7 @@ function requestFocus(element: HTMLInputElement) {
 }
 </script>
 
-<FormPage title="Pull Image From a Registry">
+<FormPage title="Pull Image From a Registry" inProgress="{pullInProgress}">
   <svelte:fragment slot="icon">
     <i class="fas fa-arrow-circle-down fa-2x" aria-hidden="true"></i>
   </svelte:fragment>

--- a/packages/renderer/src/lib/kube/KubePlayYAML.svelte
+++ b/packages/renderer/src/lib/kube/KubePlayYAML.svelte
@@ -160,7 +160,7 @@ async function getKubernetesfileLocation() {
 {/if}
 
 {#if providerConnections.length > 0}
-  <FormPage title="Play Pods or Containers from a Kubernetes YAML File">
+  <FormPage title="Play Pods or Containers from a Kubernetes YAML File" inProgress="{runStarted && !runFinished}">
     <KubePlayIcon slot="icon" size="30px" />
 
     <div slot="content" class="p-5 min-w-full h-fit">

--- a/packages/renderer/src/lib/pod/DeployPodToKube.svelte
+++ b/packages/renderer/src/lib/pod/DeployPodToKube.svelte
@@ -365,7 +365,7 @@ function updateKubeResult() {
 }
 </script>
 
-<FormPage title="Deploy generated pod to Kubernetes">
+<FormPage title="Deploy generated pod to Kubernetes" inProgress="{deployStarted && !deployFinished}">
   <i class="fas fa-rocket fa-2x" slot="icon" aria-hidden="true"></i>
 
   <div slot="content" class="p-5 min-w-full h-fit">

--- a/packages/renderer/src/lib/pod/PodCreateFromContainers.svelte
+++ b/packages/renderer/src/lib/pod/PodCreateFromContainers.svelte
@@ -194,7 +194,7 @@ function updatePortExposure(port: number, checked: boolean) {
 }
 </script>
 
-<FormPage title="Copy containers to a pod">
+<FormPage title="Copy containers to a pod" inProgress="{createInProgress}">
   <SolidPodIcon slot="icon" size="40" />
 
   <div class="min-w-full h-fit" slot="content">

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.svelte
@@ -51,9 +51,9 @@ export let taskId: number | undefined = undefined;
 export let disableEmptyScreen = false;
 export let hideCloseButton = false;
 export let connectionInfo: ProviderContainerConnectionInfo | ProviderKubernetesConnectionInfo | undefined = undefined;
+export let inProgress = false;
 
 $: configurationValues = new Map<string, { modified: boolean; value: string | boolean | number }>();
-let operationInProgress = false;
 let operationStarted = false;
 let operationSuccessful = false;
 let operationCancelled = false;
@@ -119,7 +119,7 @@ onMount(async () => {
       propertyScope = value.propertyScope;
 
       // set the flag as before
-      operationInProgress = value.operationInProgress;
+      inProgress = value.operationInProgress;
       operationStarted = value.operationStarted;
       errorMessage = value.errorMessage;
       operationSuccessful = value.operationSuccessful;
@@ -267,7 +267,7 @@ function getLoggerHandler(): ConnectionCallback {
 }
 
 async function ended() {
-  operationInProgress = false;
+  inProgress = false;
   tokenId = undefined;
   if (!operationCancelled && !operationFailed) {
     window.dispatchEvent(new CustomEvent('provider-lifecycle-change'));
@@ -284,7 +284,7 @@ async function cleanup() {
   }
   errorMessage = undefined;
   showLogs = false;
-  operationInProgress = false;
+  inProgress = false;
   operationStarted = false;
   operationFailed = false;
   operationCancelled = false;
@@ -303,7 +303,7 @@ function updateStore() {
         connectionInfo,
         properties,
         propertyScope,
-        operationInProgress: operationInProgress,
+        operationInProgress: inProgress,
         operationSuccessful: operationSuccessful,
         operationStarted: operationStarted,
         errorMessage: errorMessage || '',
@@ -327,7 +327,7 @@ async function handleOnSubmit(e: any) {
   }
 
   // send the data to the right provider
-  operationInProgress = true;
+  inProgress = true;
   operationStarted = true;
   operationFailed = false;
   operationCancelled = false;
@@ -353,7 +353,7 @@ async function handleOnSubmit(e: any) {
     }
     errorMessage = error;
     operationStarted = false;
-    operationInProgress = false;
+    inProgress = false;
   }
 }
 
@@ -423,7 +423,7 @@ function getConnectionResourceConfigurationValue(
         {#if operationStarted}
           <div class="w-4/5">
             <div class="mt-2 mb-8">
-              {#if operationInProgress}
+              {#if inProgress}
                 <LinearProgress />
               {/if}
               <div class="mt-2 float-right">
@@ -439,7 +439,7 @@ function getConnectionResourceConfigurationValue(
                   disabled="{!tokenId}"
                   on:click="{cancelCreation}">Cancel</button>
                 <button
-                  class="text-xs hover:underline {operationInProgress ? 'hidden' : ''}"
+                  class="text-xs hover:underline {inProgress ? 'hidden' : ''}"
                   aria-label="Close panel"
                   on:click="{closePanel}">Close</button>
               </div>
@@ -457,7 +457,7 @@ function getConnectionResourceConfigurationValue(
           </div>
         {/if}
 
-        <div class="p-3 mt-2 w-4/5 h-fit {operationInProgress ? 'opacity-40 pointer-events-none' : ''}">
+        <div class="p-3 mt-2 w-4/5 h-fit {inProgress ? 'opacity-40 pointer-events-none' : ''}">
           {#if connectionAuditResult && (connectionAuditResult.records?.length || 0) > 0}
             <AuditMessageBox auditResult="{connectionAuditResult}" />
           {/if}
@@ -499,10 +499,8 @@ function getConnectionResourceConfigurationValue(
                 {#if !hideCloseButton}
                   <Button type="link" aria-label="Close page" on:click="{closePage}">Close</Button>
                 {/if}
-                <Button
-                  disabled="{!isValid}"
-                  inProgress="{operationInProgress}"
-                  on:click="{() => formEl.requestSubmit()}">{buttonLabel}</Button>
+                <Button disabled="{!isValid}" inProgress="{inProgress}" on:click="{() => formEl.requestSubmit()}"
+                  >{buttonLabel}</Button>
               </div>
             </div>
           </form>

--- a/packages/renderer/src/lib/preferences/PreferencesProviderRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesProviderRendering.svelte
@@ -24,6 +24,7 @@ import { operationConnectionsInfo } from '/@/stores/operation-connections';
 export let properties: IConfigurationPropertyRecordedSchema[] = [];
 export let providerInternalId: string | undefined = undefined;
 export let taskId: number | undefined = undefined;
+let inProgress: boolean = false;
 
 let showModalProviderInfo: ProviderInfo | undefined = undefined;
 
@@ -86,7 +87,7 @@ async function stopReceivingLogs(providerInternalId: string): Promise<void> {
 </script>
 
 <Route path="/*" breadcrumb="{providerInfo?.name}" navigationHint="details">
-  <FormPage title="{title}">
+  <FormPage title="{title}" inProgress="{inProgress}">
     <svelte:fragment slot="icon">
       {#if providerInfo?.images?.icon}
         {#if typeof providerInfo.images.icon === 'string'}
@@ -151,7 +152,8 @@ async function stopReceivingLogs(providerInternalId: string): Promise<void> {
             properties="{properties}"
             propertyScope="ContainerProviderConnectionFactory"
             callback="{window.createContainerProviderConnection}"
-            taskId="{taskId}" />
+            taskId="{taskId}"
+            bind:inProgress="{inProgress}" />
         {/if}
 
         <!-- Create connection panel-->
@@ -161,7 +163,8 @@ async function stopReceivingLogs(providerInternalId: string): Promise<void> {
             properties="{properties}"
             propertyScope="KubernetesProviderConnectionFactory"
             callback="{window.createKubernetesProviderConnection}"
-            taskId="{taskId}" />
+            taskId="{taskId}"
+            bind:inProgress="{inProgress}" />
         {/if}
       </div>
     </div>

--- a/packages/renderer/src/lib/ui/FormPage.spec.ts
+++ b/packages/renderer/src/lib/ui/FormPage.spec.ts
@@ -114,3 +114,25 @@ test('Expect Escape key works', async () => {
 
   expect(router.goto).toHaveBeenCalledWith('/back');
 });
+
+test('Expect no progress', async () => {
+  currentPage.set({ name: 'My name', path: '/' } as TinroBreadcrumb);
+  render(FormPage, {
+    title: 'No Title',
+    inProgress: false,
+  });
+
+  const progress = screen.queryByRole('progressbar');
+  expect(progress).toBeNull();
+});
+
+test('Expect progress', async () => {
+  currentPage.set({ name: 'My name', path: '/' } as TinroBreadcrumb);
+  render(FormPage, {
+    title: 'No Title',
+    inProgress: true,
+  });
+
+  const progress = screen.getByRole('progressbar');
+  expect(progress).toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/ui/FormPage.svelte
+++ b/packages/renderer/src/lib/ui/FormPage.svelte
@@ -2,9 +2,11 @@
 import { lastPage, currentPage } from '../../stores/breadcrumb';
 import { router } from 'tinro';
 import Link from './Link.svelte';
+import LinearProgress from './LinearProgress.svelte';
 
 export let title: string;
 export let showBreadcrumb = true;
+export let inProgress = false;
 
 export function close(): void {
   router.goto($lastPage.path);
@@ -21,7 +23,7 @@ function handleKeydown(e: KeyboardEvent) {
 <svelte:window on:keydown="{handleKeydown}" />
 
 <div class="flex flex-col w-full h-full shadow-pageheader">
-  <div class="flex flex-row w-full h-fit px-5 py-4">
+  <div class="flex flex-row w-full h-fit px-5 pt-4" class:pb-3.5="{inProgress}" class:pb-4="{!inProgress}">
     <div class="flex flex-col w-full h-fit">
       {#if showBreadcrumb}
         <div class="flex flew-row items-center text-sm text-gray-700">
@@ -56,6 +58,9 @@ function handleKeydown(e: KeyboardEvent) {
       </div>
     </div>
   </div>
+  {#if inProgress}
+    <LinearProgress />
+  {/if}
   {#if $$slots.tabs}
     <div class="flex flex-row px-2 border-b border-charcoal-400">
       <slot name="tabs" />

--- a/packages/renderer/src/lib/volume/CreateVolume.svelte
+++ b/packages/renderer/src/lib/volume/CreateVolume.svelte
@@ -55,7 +55,7 @@ let createVolumeFinished = false;
 export let volumeName = '';
 </script>
 
-<FormPage title="Create a volume">
+<FormPage title="Create a volume" inProgress="{createVolumeInProgress}">
   <svelte:fragment slot="icon">
     <VolumeIcon />
   </svelte:fragment>


### PR DESCRIPTION
### What does this PR do?

I'm pretty sure this was an idea from Mo. Adds a linear progress bar at the bottom of the FormPage header to indicate that something is 'in progress', and uses this when building and pulling images, playing kube, deploying pods, creating pods from containers, creating volumes, and creating resources (container or Kubernetes).

This helps to indicate that there's 'something happening', especially in cases like #4229 where you can't see another progress monitor in the view.

This 'duplicates' the progress monitor when creating a container/Kubernetes instance, but I don't want to remove that as these pages are also used during onboarding and the original/smaller one helps draw your eye to the Show Logs expander. IMHO having two here is still an improvement.

### Screenshot / video of UI

https://github.com/containers/podman-desktop/assets/19958075/7c9a5619-1137-45a7-a6d1-a3825feb7f7d

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Perform any of these actions.