### PR TITLE
fix: rename kubectl extension

### DIFF
--- a/extensions/extensions.spec.ts
+++ b/extensions/extensions.spec.ts
@@ -1,0 +1,43 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { expect, test } from 'vitest';
+import { promises, existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+test('expect extension name match extension folder', async () => {
+  // grab all folders in extensions folder
+  const extensionsDir = __dirname;
+  const allFiles = await promises.readdir(extensionsDir, { withFileTypes: true });
+  const folders = allFiles.filter(dirent => dirent.isDirectory());
+
+  // keep only folders with a package.json file inside
+  const extensionsWithPackageJsonFile = folders.filter(folder => {
+    // check if package.json exists
+    const packageJsonPath = resolve(extensionsDir, folder.name, 'package.json');
+    return existsSync(packageJsonPath);
+  });
+
+  // now check for each extension with a json file if the extension name match the folder name
+  for (const extensionFolder of extensionsWithPackageJsonFile) {
+    const packageJsonPath = resolve(extensionsDir, extensionFolder.name, 'package.json');
+    const packageJson = await promises.readFile(packageJsonPath, 'utf8');
+    const packageJsonObj = JSON.parse(packageJson);
+    expect(packageJsonObj.name).toBe(extensionFolder.name);
+  }
+});

--- a/extensions/kubectl-cli/package.json
+++ b/extensions/kubectl-cli/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "kubectl-cli-tool",
+  "name": "kubectl-cli",
   "displayName": "kubectl CLI",
   "description": "Install and update kubectl CLI Tools without leaving Podman Desktop",
   "version": "0.0.1",

--- a/extensions/util.spec.ts
+++ b/extensions/util.spec.ts
@@ -1,5 +1,0 @@
-import { expect, test } from 'vitest';
-
-test('expect showNotification to be called', async () => {
-  expect(1).to.toBeTruthy();
-});

--- a/extensions/vitest.config.js
+++ b/extensions/vitest.config.js
@@ -1,0 +1,33 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/**
+ * Config for extensions tests
+ * placed in project root tests folder
+ * @type {import('vite').UserConfig}
+ * @see https://vitest.dev/config/
+ */
+const config = {
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    include: ['*.{test,spec}.ts'],
+  },
+};
+
+export default config;

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "test:main": "vitest run -r packages/main --passWithNoTests --coverage",
     "test:preload": "vitest run -r packages/preload --passWithNoTests --coverage",
     "test:preload-docker-extension": "vitest run -r packages/preload-docker-extension --passWithNoTests --coverage",
-    "test:extensions": "npm run test:extensions:compose && npm run test:extensions:kind && npm run test:extensions:docker && npm run test:extensions:lima && npm run test:extensions:kube && npm run test:extensions:podman && npm run test:extensions:registries && npm run test:extensions:kubectl-cli",
+    "test:extensions": "vitest run -r extensions --passWithNoTests --coverage && npm run test:extensions:compose && npm run test:extensions:kind && npm run test:extensions:docker && npm run test:extensions:lima && npm run test:extensions:kube && npm run test:extensions:podman && npm run test:extensions:registries && npm run test:extensions:kubectl-cli",
     "test:extensions:kind": "vitest run -r extensions/kind --passWithNoTests --coverage ",
     "test:extensions:compose": "vitest run -r extensions/compose --passWithNoTests --coverage",
     "test:extensions:docker": "vitest run -r extensions/docker --passWithNoTests --coverage ",


### PR DESCRIPTION
### What does this PR do?

I'll be honest and admit that I haven't spent the time to figure out exactly _why_ this works, but I assume it is due to the build script or elsewhere assuming that the extension name matches the folder name. Either way, it is a better/shorter name for this extension, suggested by Florent during the initial review, and causes the extension to correctly be included in the production build.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes #5254.

### How to test this PR?

yarn compile:current and run the binary. Go to Settings > Extensions or CLI Tools. The kubectl CLI extension is not there before and is there afterward.