### PR TITLE
chore: fix GitHub template for versions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -49,9 +49,9 @@ body:
       label: Version
       description: What version of the software are you running?
       options:
-        - "1.6.0"
+        - "1.6.2"
         - "next (development version)"
-        - "1.5.0"
+        - "1.5.3"
         - "1.4.0"
         - "1.3.1"
         - "1.2.1"


### PR DESCRIPTION
### What does this PR do?
1.5.3 was the published release
1.6.0 is not published, 1.6.2 will probably

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Drop down when reporting issues

### How to test this PR?

