### PR TITLE
fix: don't refresh image list when age updates

### DIFF
--- a/packages/renderer/src/lib/image/ImagesList.svelte
+++ b/packages/renderer/src/lib/image/ImagesList.svelte
@@ -133,9 +133,10 @@ async function deleteSelectedImages() {
 let refreshTimeouts: NodeJS.Timeout[] = [];
 const SECOND = 1000;
 function refreshAge() {
-  images = images.map(imageInfo => {
-    return { ...imageInfo, age: imageUtils.refreshAge(imageInfo) };
+  images.forEach(imageInfo => {
+    imageInfo.age = imageUtils.refreshAge(imageInfo);
   });
+  images = images;
 
   // compute new interval
   const newInterval = computeInterval();

--- a/packages/renderer/src/lib/image/ImagesList.svelte
+++ b/packages/renderer/src/lib/image/ImagesList.svelte
@@ -133,9 +133,9 @@ async function deleteSelectedImages() {
 let refreshTimeouts: NodeJS.Timeout[] = [];
 const SECOND = 1000;
 function refreshAge() {
-  images.forEach(imageInfo => {
+  for (const imageInfo of images) {
     imageInfo.age = imageUtils.refreshAge(imageInfo);
-  });
+  }
   images = images;
 
   // compute new interval


### PR DESCRIPTION
### What does this PR do?

We have been replacing the entire image list whenever the age is updated. This worked (?) for the <table> implementation, but for the new table component it is triggering a full refresh/reset of the table. Just updating the image age properties and then setting images to itself is enough to trigger Svelte to update the UI without a full replacement.

### Screenshot / video of UI

See #5263, this will still update age without the forced reset each 2s.

### What issues does this PR fix or reference?

Fixes #5263.

### How to test this PR?

Build an image and make sure the age increases on the list without causing everything to scroll.