### PR TITLE
fix: providerinfo badge

### DIFF
--- a/packages/renderer/src/lib/ui/ProviderInfo.spec.ts
+++ b/packages/renderer/src/lib/ui/ProviderInfo.spec.ts
@@ -1,0 +1,55 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+import { test, expect } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import ProviderInfo from './ProviderInfo.svelte';
+
+test('Expect podman is purple', async () => {
+  const provider = 'podman';
+  render(ProviderInfo, {
+    provider,
+  });
+  const label = screen.getByText(provider);
+  expect(label).toBeInTheDocument();
+  expect(label.parentElement?.firstChild).toBeInTheDocument();
+  expect(label.parentElement?.firstChild).toHaveClass('bg-purple-600');
+});
+
+test('Expect Podman (different case) is purple', async () => {
+  const provider = 'Podman';
+  render(ProviderInfo, {
+    provider,
+  });
+  const label = screen.getByText(provider);
+  expect(label).toBeInTheDocument();
+  expect(label.parentElement?.firstChild).toBeInTheDocument();
+  expect(label.parentElement?.firstChild).toHaveClass('bg-purple-600');
+});
+
+test('Expect docker is blue', async () => {
+  const provider = 'docker';
+  render(ProviderInfo, {
+    provider,
+  });
+  const label = screen.getByText(provider);
+  expect(label).toBeInTheDocument();
+  expect(label.parentElement?.firstChild).toBeInTheDocument();
+  expect(label.parentElement?.firstChild).toHaveClass('bg-sky-400');
+});

--- a/packages/renderer/src/lib/ui/ProviderInfo.svelte
+++ b/packages/renderer/src/lib/ui/ProviderInfo.svelte
@@ -15,7 +15,7 @@ export let context = '';
 // bg-sky-600 = kubernetes
 // bg-gray-900 = unknown
 function getProviderColour(providerName: string): string {
-  switch (providerName) {
+  switch (providerName?.toLowerCase()) {
     case ContainerGroupInfoTypeUI.PODMAN:
       return 'bg-purple-600';
     case ContainerGroupInfoTypeUI.DOCKER:


### PR DESCRIPTION
### What does this PR do?

ProviderInfo was built for pods, where the .kind is 'podman' or 'kubernetes'. For images, .engineName is 'Podman'. Simple fix to base color on lowercased provider name.

Tests added. Some unrelated tests aren't passing a provider, so that's why the '?'.

### Screenshot / video of UI

The dot changes color, see #5264.

### What issues does this PR fix or reference?

Fixes #5264.

### How to test this PR?

Go to Images page, Podman environment badges now purple.