### PR TITLE
chore: switch provider cards to icon

### DIFF
--- a/packages/renderer/src/lib/dashboard/ProviderCard.spec.ts
+++ b/packages/renderer/src/lib/dashboard/ProviderCard.spec.ts
@@ -24,6 +24,7 @@ import ProviderCard from './ProviderCard.svelte';
 import { screen, render } from '@testing-library/svelte';
 import type { ProviderInfo } from '../../../../main/src/plugin/api/provider-info';
 import type { ProviderImages } from '@podman-desktop/api';
+import { tick } from 'svelte';
 
 test('Expect provider region', async () => {
   const provider: ProviderInfo = {
@@ -74,6 +75,36 @@ test('Expect provider name', async () => {
   const name = screen.getByLabelText('context-name');
   expect(name).toBeInTheDocument();
   expect(name.textContent).toContain(provider.name);
+});
+
+test('Expect provider icon', async () => {
+  const provider: ProviderInfo = {
+    internalId: 'internal-id',
+    id: 'my-provider',
+    extensionId: '',
+    name: 'Podman',
+    containerConnections: [],
+    kubernetesConnections: [],
+    status: 'not-installed',
+    containerProviderConnectionCreation: false,
+    containerProviderConnectionInitialization: false,
+    kubernetesProviderConnectionCreation: false,
+    kubernetesProviderConnectionInitialization: false,
+    links: [],
+    detectionChecks: [],
+    warnings: [],
+    images: { icon: 'test.png' } as ProviderImages,
+    installationSupport: false,
+  };
+
+  render(ProviderCard, { provider });
+
+  // allow IconImage to render
+  await tick();
+
+  const logo = screen.getByRole('img');
+  expect(logo).toBeInTheDocument();
+  expect(logo).toHaveAttribute('src', provider.images.icon);
 });
 
 test('Expect no provider version', async () => {

--- a/packages/renderer/src/lib/dashboard/ProviderCard.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderCard.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
 import type { ProviderInfo } from '../../../../main/src/plugin/api/provider-info';
+import IconImage from '../appearance/IconImage.svelte';
 import ProviderStatus from '../ui/ProviderStatus.svelte';
 import ProviderLinks from './ProviderLinks.svelte';
-import ProviderLogo from './ProviderLogo.svelte';
 
 export let provider: ProviderInfo;
 </script>
@@ -10,7 +10,7 @@ export let provider: ProviderInfo;
 <div class="bg-charcoal-800 mb-5 rounded-md p-3 flex-nowrap" role="region" aria-label="{provider.name} Provider">
   <div class="flex flex-row">
     <div class="flex flex-row">
-      <ProviderLogo provider="{provider}" />
+      <IconImage image="{provider?.images?.icon}" class="mx-auto max-h-12" alt="{provider.name}"></IconImage>
       <div class="flex flex-col text-gray-400 ml-3 whitespace-nowrap" aria-label="context-name">
         <div class="flex flex-row items-center">
           {provider.name}


### PR DESCRIPTION
### What does this PR do?

The updated dashboard design in #4395 uses provider icons (square) and not logos (could be wider or taller). This changes switches from using .logo to .icon, and from using ProviderLogo to IconImage, since we don't need ProviderLogo anymore and IconImage also supports light mode. Tests added.

I would like to delete ProviderLogo but it is still used by PreferencesProviderInstallationModel - so that will be a different PR once I have a chance to do the same change there.

### Screenshot / video of UI

Before:
<img width="346" alt="Screenshot 2023-12-14 at 8 46 12 PM" src="https://github.com/containers/podman-desktop/assets/19958075/a9c7d2a0-75b5-4301-8458-3837beecac5d">

After:
<img width="346" alt="Screenshot 2023-12-14 at 8 46 21 PM" src="https://github.com/containers/podman-desktop/assets/19958075/7c6a9546-c8c8-41b9-a1b2-cd4e6cb8b814">

### What issues does this PR fix or reference?

Part of #4395.

### How to test this PR?

Just open the dashboard.