### PR TITLE
feat: add option to select how to open devtools in dev mode

### DIFF
--- a/packages/main/src/mainWindow.ts
+++ b/packages/main/src/mainWindow.ts
@@ -24,6 +24,9 @@ import { join } from 'path';
 import { URL } from 'url';
 import type { ConfigurationRegistry } from './plugin/configuration-registry.js';
 import { isLinux, isMac, stoppedExtensions } from './util.js';
+import { OpenDevTools } from './open-dev-tools.js';
+
+const openDevTools = new OpenDevTools();
 
 async function createWindow(): Promise<BrowserWindow> {
   const INITIAL_APP_WIDTH = 1050;
@@ -93,10 +96,6 @@ async function createWindow(): Promise<BrowserWindow> {
     } else {
       browserWindow.show();
     }
-
-    if (import.meta.env.DEV) {
-      browserWindow?.webContents.openDevTools();
-    }
   });
 
   // select a file using native widget
@@ -135,6 +134,9 @@ async function createWindow(): Promise<BrowserWindow> {
   let configurationRegistry: ConfigurationRegistry;
   ipcMain.on('configuration-registry', (_, data) => {
     configurationRegistry = data;
+
+    // open dev tools (if required)
+    openDevTools.open(browserWindow, configurationRegistry);
   });
 
   // receive the message because an update is in progress and we need to quit the app

--- a/packages/main/src/open-dev-tools.spec.ts
+++ b/packages/main/src/open-dev-tools.spec.ts
@@ -1,0 +1,92 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { beforeEach, expect, test, vi } from 'vitest';
+import type { BrowserWindow } from 'electron';
+import type { ConfigurationRegistry } from './plugin/configuration-registry.js';
+import { OpenDevTools } from './open-dev-tools.js';
+
+let openDevTools: OpenDevTools;
+
+const getConfigurationMock = vi.fn();
+const configurationRegistryMock = {
+  getConfiguration: getConfigurationMock,
+} as unknown as ConfigurationRegistry;
+
+const openDevToolsMock = vi.fn();
+const browserWindowMock = {
+  webContents: {
+    openDevTools: openDevToolsMock,
+  },
+} as unknown as BrowserWindow;
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  openDevTools = new OpenDevTools();
+});
+
+test('should open devtools with undocked mode if no configuration', async () => {
+  openDevTools.open(browserWindowMock, configurationRegistryMock);
+
+  expect(browserWindowMock.webContents.openDevTools).toBeCalledWith({ mode: 'undocked' });
+});
+
+test('should not open devtools if none', async () => {
+  getConfigurationMock.mockReturnValue({
+    get: () => 'none',
+  });
+  openDevTools.open(browserWindowMock, configurationRegistryMock);
+
+  expect(browserWindowMock.webContents.openDevTools).not.toBeCalled();
+});
+
+test('should open devtools on left if left config', async () => {
+  getConfigurationMock.mockReturnValue({
+    get: () => 'left',
+  });
+  openDevTools.open(browserWindowMock, configurationRegistryMock);
+
+  expect(browserWindowMock.webContents.openDevTools).toBeCalledWith({ mode: 'left' });
+});
+
+test('should open devtools on right if right config', async () => {
+  getConfigurationMock.mockReturnValue({
+    get: () => 'right',
+  });
+  openDevTools.open(browserWindowMock, configurationRegistryMock);
+
+  expect(browserWindowMock.webContents.openDevTools).toBeCalledWith({ mode: 'right' });
+});
+
+test('should open devtools on left if bottom config', async () => {
+  getConfigurationMock.mockReturnValue({
+    get: () => 'bottom',
+  });
+  openDevTools.open(browserWindowMock, configurationRegistryMock);
+
+  expect(browserWindowMock.webContents.openDevTools).toBeCalledWith({ mode: 'bottom' });
+});
+
+test('should open devtools on left if detach config', async () => {
+  getConfigurationMock.mockReturnValue({
+    get: () => 'detach',
+  });
+  openDevTools.open(browserWindowMock, configurationRegistryMock);
+
+  expect(browserWindowMock.webContents.openDevTools).toBeCalledWith({ mode: 'detach' });
+});

--- a/packages/main/src/open-dev-tools.ts
+++ b/packages/main/src/open-dev-tools.ts
@@ -1,0 +1,42 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { BrowserWindow } from 'electron';
+import type { ConfigurationRegistry } from './plugin/configuration-registry.js';
+
+export class OpenDevTools {
+  open(browserWindow: BrowserWindow, configurationRegistry?: ConfigurationRegistry) {
+    if (import.meta.env.DEV) {
+      // grab configuration option
+      const preferencesConfiguration = configurationRegistry?.getConfiguration('preferences');
+      let openDevToolsConfiguration = preferencesConfiguration?.get<
+        'left' | 'right' | 'bottom' | 'undocked' | 'detach' | 'none'
+      >('OpenDevTools');
+
+      // undocked mode by default
+      if (!openDevToolsConfiguration) {
+        openDevToolsConfiguration = 'undocked';
+      }
+
+      // open dev tools if not none
+      if (openDevToolsConfiguration !== 'none') {
+        browserWindow?.webContents.openDevTools({ mode: openDevToolsConfiguration });
+      }
+    }
+  }
+}

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -148,6 +148,7 @@ import { AppearanceInit } from './appearance-init.js';
 import type { KubeContext } from './kubernetes-context.js';
 import { KubernetesInformerManager } from './kubernetes-informer-registry.js';
 import type { KubernetesInformerResourcesType } from './api/kubernetes-informer-info.js';
+import { OpenDevToolsInit } from './open-devtools-init.js';
 
 type LogType = 'log' | 'warn' | 'trace' | 'debug' | 'error';
 
@@ -710,6 +711,12 @@ export class PluginSystem {
 
     const terminalInit = new TerminalInit(configurationRegistry);
     terminalInit.init();
+
+    // only in development mode
+    if (import.meta.env.DEV) {
+      const openDevToolsInit = new OpenDevToolsInit(configurationRegistry);
+      openDevToolsInit.init();
+    }
 
     // init editor configuration
     const editorInit = new EditorInit(configurationRegistry);

--- a/packages/main/src/plugin/open-devtools-init.spec.ts
+++ b/packages/main/src/plugin/open-devtools-init.spec.ts
@@ -1,0 +1,61 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { beforeEach, expect, test, vi } from 'vitest';
+import { OpenDevToolsInit } from './open-devtools-init.js';
+import type { ConfigurationRegistry } from './configuration-registry.js';
+
+let openDevToolsInit: OpenDevToolsInit;
+
+const registerConfigurationsMock = vi.fn();
+
+const configurationRegistryMock = {
+  registerConfigurations: registerConfigurationsMock,
+} as unknown as ConfigurationRegistry;
+
+beforeEach(() => {
+  openDevToolsInit = new OpenDevToolsInit(configurationRegistryMock);
+});
+test('should register a configuration', async () => {
+  // register configuration
+  openDevToolsInit.init();
+
+  // should be the directory provided as env var
+  expect(configurationRegistryMock.registerConfigurations).toBeCalled();
+
+  // take first argument of first call
+  const configurationNode = vi.mocked(configurationRegistryMock).registerConfigurations.mock.calls[0][0][0];
+  expect(configurationNode.id).toBe('preferences.OpenDevTools');
+  expect(configurationNode.title).toBe('Open Dev Tools');
+  expect(configurationNode.type).toBe('object');
+  expect(configurationNode.properties).toBeDefined();
+  expect(configurationNode.properties?.['preferences.OpenDevTools']).toBeDefined();
+  expect(configurationNode.properties?.['preferences.OpenDevTools'].description).toBe(
+    'Open DevTools when launching Podman Desktop in development mode.',
+  );
+  expect(configurationNode.properties?.['preferences.OpenDevTools'].type).toBe('string');
+  expect(configurationNode.properties?.['preferences.OpenDevTools'].enum).toEqual([
+    'left',
+    'right',
+    'bottom',
+    'undocked',
+    'detach',
+    'none',
+  ]);
+  expect(configurationNode.properties?.['preferences.OpenDevTools'].default).toBe('undocked');
+});

--- a/packages/main/src/plugin/open-devtools-init.ts
+++ b/packages/main/src/plugin/open-devtools-init.ts
@@ -1,0 +1,42 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { ConfigurationRegistry, IConfigurationNode } from './configuration-registry.js';
+
+export class OpenDevToolsInit {
+  constructor(private configurationRegistry: ConfigurationRegistry) {}
+
+  init(): void {
+    // add configuration
+    const openDevToolsConfigurationNode: IConfigurationNode = {
+      id: 'preferences.OpenDevTools',
+      title: 'Open Dev Tools',
+      type: 'object',
+      properties: {
+        ['preferences.OpenDevTools']: {
+          description: 'Open DevTools when launching Podman Desktop in development mode.',
+          type: 'string',
+          enum: ['left', 'right', 'bottom', 'undocked', 'detach', 'none'],
+          default: 'undocked',
+        },
+      },
+    };
+
+    this.configurationRegistry.registerConfigurations([openDevToolsConfigurationNode]);
+  }
+}

--- a/packages/main/src/plugin/open-devtools-settings.ts
+++ b/packages/main/src/plugin/open-devtools-settings.ts
@@ -1,0 +1,22 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+export enum OpenDevToolsSettings {
+  SectionName = 'preferences',
+  OpenDevTools = 'OpenDevTools',
+}


### PR DESCRIPTION
### What does this PR do?
allow to select how to open dev tools at startup in dev mode

### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/5031

### How to test this PR?

use development mode, and change options (settings/preferences)

unit tests provided