### PR TITLE
chore: volume updates

### DIFF
--- a/packages/renderer/src/lib/volume/VolumeColumnEnvironment.spec.ts
+++ b/packages/renderer/src/lib/volume/VolumeColumnEnvironment.spec.ts
@@ -1,0 +1,49 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+import { test, expect } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+
+import VolumeColumnEnvironment from './VolumeColumnEnvironment.svelte';
+import type { VolumeInfoUI } from './VolumeInfoUI';
+
+test('Expect simple column styling', async () => {
+  const volume: VolumeInfoUI = {
+    name: '',
+    shortName: '',
+    mountPoint: '',
+    scope: '',
+    driver: '',
+    created: '',
+    age: '',
+    size: 0,
+    humanSize: '',
+    engineId: '',
+    engineName: 'my-engine',
+    selected: false,
+    inUse: false,
+    containersUsage: [],
+  };
+  render(VolumeColumnEnvironment, { object: volume });
+
+  const text = screen.getByText(volume.engineName);
+  expect(text).toBeInTheDocument();
+  expect(text).toHaveClass('text-xs');
+  expect(text).toHaveClass('capitalize');
+});

--- a/packages/renderer/src/lib/volume/VolumeColumnName.spec.ts
+++ b/packages/renderer/src/lib/volume/VolumeColumnName.spec.ts
@@ -1,0 +1,65 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+import { test, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+
+import VolumeColumnName from './VolumeColumnName.svelte';
+import type { VolumeInfoUI } from './VolumeInfoUI';
+import { router } from 'tinro';
+import { fireEvent } from '@testing-library/dom';
+
+const volume: VolumeInfoUI = {
+  name: 'my-name',
+  shortName: 'short-name',
+  mountPoint: '',
+  scope: '',
+  driver: '',
+  created: '',
+  age: '',
+  size: 0,
+  humanSize: '',
+  engineId: 'engine-id',
+  engineName: '',
+  selected: false,
+  inUse: false,
+  containersUsage: [],
+};
+
+test('Expect simple column styling', async () => {
+  render(VolumeColumnName, { object: volume });
+
+  const text = screen.getByText(volume.shortName);
+  expect(text).toBeInTheDocument();
+  expect(text).toHaveClass('text-sm');
+  expect(text).toHaveClass('text-gray-300');
+});
+
+test('Expect clicking works', async () => {
+  render(VolumeColumnName, { object: volume });
+
+  const text = screen.getByText(volume.shortName);
+  expect(text).toBeInTheDocument();
+
+  // test click
+  const routerGotoSpy = vi.spyOn(router, 'goto');
+  fireEvent.click(text);
+
+  expect(routerGotoSpy).toBeCalledWith('/volumes/my-name/engine-id/summary');
+});

--- a/packages/renderer/src/lib/volume/VolumeColumnName.svelte
+++ b/packages/renderer/src/lib/volume/VolumeColumnName.svelte
@@ -9,8 +9,6 @@ function openDetailsVolume(volume: VolumeInfoUI) {
 }
 </script>
 
-<!-- svelte-ignore a11y-no-static-element-interactions -->
-<!-- svelte-ignore a11y-click-events-have-key-events -->
-<div class="hover:cursor-pointer flex text-sm text-gray-300" on:click="{() => openDetailsVolume(object)}">
+<button class="hover:cursor-pointer flex text-sm text-gray-300" on:click="{() => openDetailsVolume(object)}">
   {object.shortName}
-</div>
+</button>

--- a/packages/renderer/src/lib/volume/VolumeColumnStatus.spec.ts
+++ b/packages/renderer/src/lib/volume/VolumeColumnStatus.spec.ts
@@ -1,0 +1,48 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+import { test, expect } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+
+import VolumeColumnStatus from './VolumeColumnStatus.svelte';
+import type { VolumeInfoUI } from './VolumeInfoUI';
+
+test('Expect simple column styling', async () => {
+  const volume: VolumeInfoUI = {
+    name: '',
+    shortName: '',
+    mountPoint: '',
+    scope: '',
+    driver: '',
+    created: '',
+    age: '',
+    size: 0,
+    humanSize: '',
+    engineId: '',
+    engineName: '',
+    selected: false,
+    inUse: true,
+    containersUsage: [],
+  };
+  render(VolumeColumnStatus, { object: volume });
+
+  const text = screen.getByRole('status');
+  expect(text).toBeInTheDocument();
+  expect(text).toHaveClass('bg-green-400');
+});

--- a/packages/renderer/src/lib/volume/VolumesList.svelte
+++ b/packages/renderer/src/lib/volume/VolumesList.svelte
@@ -113,7 +113,7 @@ let refreshTimeouts: NodeJS.Timeout[] = [];
 const SECOND = 1000;
 function refreshAge() {
   for (const volumeInfo of volumes) {
-    volumeInfo.age = volumeUtils.refreshAge(volumeInfo)
+    volumeInfo.age = volumeUtils.refreshAge(volumeInfo);
   }
   volumes = volumes;
 

--- a/packages/renderer/src/lib/volume/VolumesList.svelte
+++ b/packages/renderer/src/lib/volume/VolumesList.svelte
@@ -112,9 +112,10 @@ async function deleteSelectedVolumes() {
 let refreshTimeouts: NodeJS.Timeout[] = [];
 const SECOND = 1000;
 function refreshAge() {
-  volumes = volumes.map(volumeInfo => {
-    return { ...volumeInfo, age: volumeUtils.refreshAge(volumeInfo) };
-  });
+  for (const volumeInfo of volumes) {
+    volumeInfo.age = volumeUtils.refreshAge(volumeInfo)
+  }
+  volumes = volumes;
 
   // compute new interval
   const newInterval = computeInterval();


### PR DESCRIPTION
### What does this PR do?

Since the volume table component PR there have been a few changes in other table columns/PRs:
- adding tests per column
- changing the clickable column from div to button
- ImagesList had a fix to refreshing when the age changes

This just applies the same changes to volumes.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

N/A

### How to test this PR?

`yarn test:renderer`, or create enough volumes that they don't fit on the page and check age updates.