### PR TITLE
feat: add ability to edit / add placeholder widget to editor

### DIFF
--- a/packages/renderer/src/lib/editor/MonacoEditor.spec.ts
+++ b/packages/renderer/src/lib/editor/MonacoEditor.spec.ts
@@ -1,0 +1,31 @@
+import '@testing-library/jest-dom/vitest';
+import { test, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitForElementToBeRemoved } from '@testing-library/svelte';
+import MonacoEditor from './MonacoEditor.svelte';
+
+async function waitRender(customProperties: object): Promise<void> {
+  const result = render(MonacoEditor, { ...customProperties });
+  // wait that result.component.$$.ctx[0] is set
+  while (result.component.$$.ctx[0] === undefined) {
+    await new Promise(resolve => setTimeout(resolve, 100));
+  }
+}
+
+vi.mock('monaco-editor');
+vi.mock('@monaco-editor/react');
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+test('Render monaco editor with json content and expect to have the correct content', async () => {
+    const content = '{"key": "value"}';
+    await waitRender({
+        content: content,
+        language: 'json',
+        readOnly: true,
+    });
+
+    const editor = screen.getByTestId('monaco');
+    expect(editor).toHaveTextContent(content);
+});

--- a/packages/renderer/src/lib/editor/MonacoEditor.svelte
+++ b/packages/renderer/src/lib/editor/MonacoEditor.svelte
@@ -13,6 +13,10 @@ let Monaco;
 
 export let content = '';
 export let language = 'json';
+export let readOnly = true;
+// Add "default" text that will show if the content is blank
+// once typing occurs it'll clear.
+export let defaultText = '';
 
 onMount(async () => {
   self.MonacoEnvironment = {
@@ -45,11 +49,12 @@ onMount(async () => {
     value: content,
     fontSize,
     language,
-    readOnly: true,
+    readOnly: readOnly,
     theme: 'podmanDesktopTheme',
     automaticLayout: true,
     scrollBeyondLastLine: false,
   });
+
 });
 
 onDestroy(() => {
@@ -59,4 +64,4 @@ onDestroy(() => {
 $: content, editor?.getModel()?.setValue(content);
 </script>
 
-<div bind:this="{divEl}" class="h-full"></div>
+<div bind:this="{divEl}" class="h-full" data-testid="monaco"></div>

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -60,3 +60,7 @@ const config = {
 };
 
 export default config;
+
+// Due to importing 'monaco-editor' which uses JSDOM, we require this to be set as
+// it uses the clipboard API which is not supported by JSDOM.
+global.document.queryCommandSupported = () => {};


### PR DESCRIPTION
feat: add ability to edit / add placeholder widget to editor

### What does this PR do?

* Adds the ability to pass in values to Monaco editor in order to add a
"placeholder" message if the editor is blank
* Add ability to toggle readOnly on/off

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Work towards https://github.com/containers/podman-desktop/issues/725

### How to test this PR?

<!-- Please explain steps to reproduce -->

1. Edit ContainerDetailsKube.svelte code to the following:

```ts

  <div class="h-[100px] pt-2">
    <MonacoEditor readOnly="{false}" defaultText="foobar" language="json" />
  </div>
```

2. Click on Play Kubernetes YAML in PD.

3. See that the placeholder shows as well as you are able to edit the
   YAML.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
