### PR TITLE
fix(tests): fixed mac port issue in smoke tests

### DIFF
--- a/tests/src/model/pages/containers-page.ts
+++ b/tests/src/model/pages/containers-page.ts
@@ -81,7 +81,7 @@ export class ContainersPage extends MainPage {
       }
       await row.getByRole('cell').nth(1).click();
     }
-    await this.page.getByRole('button', { name: `Create Pod with ${names.length} selected items` }).click();
+    await this.page.getByRole('button', { name: `Create Pod` }).click();
     return new CreatePodsPage(this.page);
   }
 }

--- a/tests/src/pod-smoke.spec.ts
+++ b/tests/src/pod-smoke.spec.ts
@@ -26,6 +26,7 @@ import { NavigationBar } from './model/workbench/navigation';
 import { waitUntil, waitWhile } from './utility/wait';
 import { deleteContainer, deleteImage, deletePod } from './utility/operations';
 import { ContainerState, PodState } from './model/core/states';
+import * as os from 'node:os';
 
 let pdRunner: PodmanDesktopRunner;
 let page: Page;
@@ -36,6 +37,7 @@ const imagesTag = 'v1';
 const backendContainer = 'backend';
 const frontendContainer = 'frontend';
 const podToRun = 'frontend-app-pod';
+const isMac = os.platform() === 'darwin';
 
 beforeAll(async () => {
   pdRunner = new PodmanDesktopRunner();
@@ -111,6 +113,10 @@ describe.skipIf(process.env.GITHUB_ACTIONS && process.env.RUNNER_OS === 'Linux')
       images = await navigationBar.openImages();
       imageDetails = await images.openImageDetails(frontendImage);
       runImage = await imageDetails.openRunImage();
+      if (isMac) {
+        await runImage.setHostPortToExposedContainerPort('5000', '5101');
+      }
+      await pdRunner.screenshot('pods-run-frontend-image.png');
       await pdRunner.screenshot('pods-run-frontend-image.png');
       containers = await runImage.startContainer(frontendContainer, false);
       await waitUntil(async () => containers.containerExists(frontendContainer), 10000, 1000);


### PR DESCRIPTION
### What does this PR do?

This PR fixes mac issue, where the pod is not created, when port 5000 is already in use.
The port is instead set to 5101, which should not be used by default on mac.
I also fixed the pod test after button name change.

### Screenshot / video of UI

![image](https://github.com/containers/podman-desktop/assets/75624842/115c4fb0-5e7a-4027-ac35-261a64fa92af)

### What issues does this PR fix or reference?

This fixes [5279](https://github.com/containers/podman-desktop/issues/5279)

### How to test this PR?

`yarn test:e2e:smoke`