### PR TITLE
feat: duration column

### DIFF
--- a/packages/renderer/src/lib/deployments/DeploymentColumnConditions.spec.ts
+++ b/packages/renderer/src/lib/deployments/DeploymentColumnConditions.spec.ts
@@ -29,7 +29,6 @@ const deployment: DeploymentUI = {
   namespace: '',
   replicas: 0,
   ready: 0,
-  age: '',
   selected: false,
   conditions: [
     { type: 'Available', message: 'Running fine' },

--- a/packages/renderer/src/lib/deployments/DeploymentColumnName.spec.ts
+++ b/packages/renderer/src/lib/deployments/DeploymentColumnName.spec.ts
@@ -30,7 +30,6 @@ test('Expect simple column styling', async () => {
     namespace: '',
     replicas: 0,
     ready: 0,
-    age: '',
     selected: false,
     conditions: [],
   };

--- a/packages/renderer/src/lib/deployments/DeploymentColumnPods.spec.ts
+++ b/packages/renderer/src/lib/deployments/DeploymentColumnPods.spec.ts
@@ -30,7 +30,6 @@ test('Expect simple column styling', async () => {
     namespace: '',
     replicas: 0,
     ready: 0,
-    age: '',
     selected: false,
     conditions: [],
   };

--- a/packages/renderer/src/lib/deployments/DeploymentColumnStatus.spec.ts
+++ b/packages/renderer/src/lib/deployments/DeploymentColumnStatus.spec.ts
@@ -30,7 +30,6 @@ test('Expect simple column styling', async () => {
     namespace: '',
     replicas: 0,
     ready: 0,
-    age: '',
     selected: false,
     conditions: [],
   };

--- a/packages/renderer/src/lib/deployments/DeploymentUI.ts
+++ b/packages/renderer/src/lib/deployments/DeploymentUI.ts
@@ -23,7 +23,6 @@ export interface DeploymentUI {
   replicas: number;
   ready: number;
   created?: Date;
-  age: string;
   selected: boolean;
   conditions: DeploymentCondition[];
 }

--- a/packages/renderer/src/lib/deployments/deployment-utils.ts
+++ b/packages/renderer/src/lib/deployments/deployment-utils.ts
@@ -16,30 +16,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import moment from 'moment';
-import humanizeDuration from 'humanize-duration';
 import type { DeploymentUI } from './DeploymentUI';
 import type { V1Deployment } from '@kubernetes/client-node';
 
 export class DeploymentUtils {
-  humanizeAge(started: Date | undefined): string {
-    if (!started) {
-      return '';
-    }
-    // get start time in ms
-    const uptimeInMs = moment().diff(started);
-    // make it human friendly
-    return humanizeDuration(uptimeInMs, { round: true, largest: 1 });
-  }
-
-  refreshAge(deployment: DeploymentUI): string {
-    if (!deployment.created) {
-      return '';
-    }
-    // make it human friendly
-    return this.humanizeAge(deployment.created);
-  }
-
   getDeploymentUI(deployment: V1Deployment): DeploymentUI {
     const conditions = (deployment.status?.conditions ?? []).map(c => {
       return { type: c.type, message: c.message };
@@ -57,7 +37,6 @@ export class DeploymentUtils {
       status: status,
       namespace: deployment.metadata?.namespace || '',
       created: deployment.metadata?.creationTimestamp,
-      age: this.humanizeAge(deployment.metadata?.creationTimestamp),
       // number of replicas
       replicas: deployment.status?.replicas || 0,
       // ready pods

--- a/packages/renderer/src/lib/table/DurationColumn.spec.ts
+++ b/packages/renderer/src/lib/table/DurationColumn.spec.ts
@@ -23,10 +23,12 @@ import { render, screen } from '@testing-library/svelte';
 import SimpleDurationColumn from './DurationColumn.svelte';
 
 test('Expect simple column styling', async () => {
-  const obj = new Date();
-  render(SimpleDurationColumn, { object: obj });
+  // pick a date an hour ago
+  const date = new Date();
+  date.setTime(date.getTime() - 3600000);
+  render(SimpleDurationColumn, { object: date });
 
-  const text = screen.getByText('');
+  const text = screen.getByText('1 hour');
   expect(text).toBeInTheDocument();
   expect(text).toHaveClass('text-sm');
   expect(text).toHaveClass('text-gray-700');

--- a/packages/renderer/src/lib/table/DurationColumn.spec.ts
+++ b/packages/renderer/src/lib/table/DurationColumn.spec.ts
@@ -1,0 +1,89 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+import { test, expect } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+
+import SimpleDurationColumn from './DurationColumn.svelte';
+
+test('Expect simple column styling', async () => {
+  const obj = new Date();
+  render(SimpleDurationColumn, { object: obj });
+
+  const text = screen.getByText('');
+  expect(text).toBeInTheDocument();
+  expect(text).toHaveClass('text-sm');
+  expect(text).toHaveClass('text-gray-700');
+});
+
+test('Expect 2s refresh on values less than a minute', async () => {
+  const { component } = render(SimpleDurationColumn);
+  expect(component.computeInterval(500)).toEqual(2000);
+});
+
+test('Expect 2s refresh on values less than a minute (2)', async () => {
+  const { component } = render(SimpleDurationColumn);
+  expect(component.computeInterval(53400)).toEqual(2000);
+});
+
+test('Expect to refresh 59.9s on next minute', async () => {
+  const { component } = render(SimpleDurationColumn);
+  // 59.999s = should refresh in 1ms
+  expect(component.computeInterval(59999)).toEqual(1);
+});
+
+test('Expect to refresh 60s on next minute', async () => {
+  const { component } = render(SimpleDurationColumn);
+  // 60s = 1m - should refresh in 1m
+  expect(component.computeInterval(60000)).toEqual(60000);
+});
+
+test('Expect to refresh 61s on next minute', async () => {
+  const { component } = render(SimpleDurationColumn);
+  // 61s = 1m1s - should refresh in 59s
+  expect(component.computeInterval(61000)).toEqual(59000);
+});
+
+test('Expect to refresh 89s on next minute', async () => {
+  const { component } = render(SimpleDurationColumn);
+  // 89s = 1m19s - should refresh in 31s (at 2m)
+  expect(component.computeInterval(89000)).toEqual(31000);
+});
+
+test('Expect to refresh 1h on next hour', async () => {
+  const { component } = render(SimpleDurationColumn);
+  // 362s = 1h2s - should refresh in 58m (at 2h)
+  expect(component.computeInterval(3600000)).toEqual(60 * 60000);
+});
+
+test('Expect to refresh 3h25m on next hour', async () => {
+  const { component } = render(SimpleDurationColumn);
+  // 3h25m - should refresh in 35m (at 4h)
+  expect(component.computeInterval(12300000)).toEqual(2100000);
+});
+
+test('Expect to refresh 1d on next day', async () => {
+  const { component } = render(SimpleDurationColumn);
+  expect(component.computeInterval(86400000)).toEqual(86400000);
+});
+
+test('Expect to refresh 1d1m on next day', async () => {
+  const { component } = render(SimpleDurationColumn);
+  expect(component.computeInterval(86460000)).toEqual(86340000);
+});

--- a/packages/renderer/src/lib/table/DurationColumn.svelte
+++ b/packages/renderer/src/lib/table/DurationColumn.svelte
@@ -1,0 +1,66 @@
+<script lang="ts">
+import moment from 'moment';
+import humanizeDuration from 'humanize-duration';
+import { onDestroy, onMount } from 'svelte';
+
+export let object: Date | undefined;
+let duration: string = '';
+let refreshTimeouts: NodeJS.Timeout[] = [];
+
+export function computeInterval(uptimeInMs: number): number {
+  const SECOND = 1000;
+  const MINUTE = SECOND * 60;
+  const HOUR = MINUTE * 60;
+  const DAY = HOUR * 24;
+
+  // if less than a minute, refresh every 2s
+  if (uptimeInMs < MINUTE - 2 * SECOND) {
+    return 2 * SECOND;
+  }
+
+  // if less than an hour, refresh on the next minute
+  if (uptimeInMs < HOUR) {
+    return Math.ceil((uptimeInMs + 1) / MINUTE) * MINUTE - uptimeInMs;
+  }
+
+  // if less than a day, refresh on the next hour
+  if (uptimeInMs < DAY) {
+    return Math.ceil((uptimeInMs + 1) / HOUR) * HOUR - uptimeInMs;
+  }
+
+  // otherwise, refresh on the day
+  return Math.ceil((uptimeInMs + 1) / DAY) * DAY - uptimeInMs;
+}
+
+function refreshDuration() {
+  if (!object) {
+    duration = '';
+    return;
+  }
+
+  // get start time in ms
+  const uptimeInMs = moment().diff(object);
+
+  duration = humanizeDuration(uptimeInMs, { round: true, largest: 1 });
+
+  // compute next refresh
+  const interval = computeInterval(uptimeInMs);
+  refreshTimeouts.forEach(timeout => clearTimeout(timeout));
+  refreshTimeouts.length = 0;
+  refreshTimeouts.push(setTimeout(refreshDuration, interval));
+}
+
+onMount(async () => {
+  refreshDuration();
+});
+
+onDestroy(() => {
+  // kill timers
+  refreshTimeouts.forEach(timeout => clearTimeout(timeout));
+  refreshTimeouts.length = 0;
+});
+</script>
+
+<div class="text-sm text-gray-700">
+  {duration}
+</div>


### PR DESCRIPTION
### What does this PR do?

Creates a new duration column that takes a date and displays a humanized time, then automatically refreshes exactly when there should be an update.

Since the timeouts and UI are handled by the column itself there's no need for the UI object to store and update the age string, for the table to have timers or do anything related to the update. List components are much simpler, better encapsulation, and less overall code.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Core fix for #4972, would still need to be used by other tables.

### How to test this PR?

`yarn test:renderer`, or bring up Deployments page and see no difference.