### PR TITLE
fix: empty screen reset filter by default

### DIFF
--- a/packages/renderer/src/lib/container/ContainerList.svelte
+++ b/packages/renderer/src/lib/container/ContainerList.svelte
@@ -674,7 +674,10 @@ function setStoppedFilter() {
         <FilteredEmptyScreen
           icon="{ContainerIcon}"
           kind="containers"
-          on:resetFilter="{() => (searchTerm = containerUtils.filterResetSearchTerm(searchTerm))}"
+          on:resetFilter="{e => {
+            searchTerm = containerUtils.filterResetSearchTerm(searchTerm);
+            e.preventDefault();
+          }}"
           searchTerm="{containerUtils.filterSearchTerm(searchTerm)}" />
       {:else}
         <ContainerEmptyScreen

--- a/packages/renderer/src/lib/pod/PodsList.svelte
+++ b/packages/renderer/src/lib/pod/PodsList.svelte
@@ -277,7 +277,14 @@ const row = new Row<PodInfoUI>({ selectable: _pod => true });
       <NoContainerEngineEmptyScreen />
     {:else if $filtered.length === 0}
       {#if searchTerm}
-        <FilteredEmptyScreen icon="{PodIcon}" kind="pods" bind:searchTerm="{searchTerm}" />
+        <FilteredEmptyScreen
+          icon="{PodIcon}"
+          kind="pods"
+          bind:searchTerm="{searchTerm}"
+          on:resetFilter="{e => {
+            searchTerm = podUtils.filterResetSearchTerm(searchTerm);
+            e.preventDefault();
+          }}" />
       {:else}
         <PodEmptyScreen />
       {/if}

--- a/packages/renderer/src/lib/pod/pod-utils.ts
+++ b/packages/renderer/src/lib/pod/pod-utils.ts
@@ -86,6 +86,13 @@ export class PodUtils {
       return uniqueName;
     }
   }
+
+  filterResetSearchTerm(f: string): string {
+    return f
+      .split(' ')
+      .filter(part => part.startsWith('is:'))
+      .join(' ');
+  }
 }
 
 // eslint-disable-next-line  @typescript-eslint/no-explicit-any

--- a/packages/renderer/src/lib/ui/FilteredEmptyScreen.spec.ts
+++ b/packages/renderer/src/lib/ui/FilteredEmptyScreen.spec.ts
@@ -24,6 +24,7 @@ import DesktopIcon from '../images/DesktopIcon.svelte';
 
 test('Expect basic styling', async () => {
   render(FilteredEmptyScreen, { icon: DesktopIcon, kind: 'object', searchTerm: 'test' });
+  // eslint-disable-next-line quotes
   const title = screen.getByText("No object matching 'test' found");
   expect(title).toBeInTheDocument();
   expect(title).toHaveClass('text-xl');
@@ -54,6 +55,7 @@ test('Expect button to fire event and clear search term', async () => {
 
   // confirm search term has changed
   expect(resetMock).toHaveBeenCalledOnce();
+  // eslint-disable-next-line quotes
   const title = screen.getByText("No object matching '' found");
   expect(title).toBeInTheDocument();
 });
@@ -76,6 +78,7 @@ test('Expect button to fire event and respect event listener', async () => {
 
   // confirm search term has not changed
   expect(resetMock).toHaveBeenCalledOnce();
+  // eslint-disable-next-line quotes
   const title = screen.getByText("No object matching 'test' found");
   expect(title).toBeInTheDocument();
 });

--- a/packages/renderer/src/lib/ui/FilteredEmptyScreen.spec.ts
+++ b/packages/renderer/src/lib/ui/FilteredEmptyScreen.spec.ts
@@ -1,0 +1,81 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+import { test, expect, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import FilteredEmptyScreen from './FilteredEmptyScreen.svelte';
+import DesktopIcon from '../images/DesktopIcon.svelte';
+
+test('Expect basic styling', async () => {
+  render(FilteredEmptyScreen, { icon: DesktopIcon, kind: 'object', searchTerm: 'test' });
+  const title = screen.getByText("No object matching 'test' found");
+  expect(title).toBeInTheDocument();
+  expect(title).toHaveClass('text-xl');
+});
+
+test('Expect long search term to not display', async () => {
+  render(FilteredEmptyScreen, {
+    icon: DesktopIcon,
+    kind: 'object',
+    searchTerm: 'a really long search term that will not fit in the UI',
+  });
+  const title = screen.getByText('No object matching filter found');
+  expect(title).toBeInTheDocument();
+  expect(title).toHaveClass('text-xl');
+});
+
+test('Expect button to fire event and clear search term', async () => {
+  const config = { icon: DesktopIcon, kind: 'object', searchTerm: 'test' };
+  const result = render(FilteredEmptyScreen, config);
+
+  const resetMock = vi.fn();
+  result.component.$on('resetFilter', resetMock);
+
+  const button = screen.getByRole('button', { name: 'Clear filter' });
+  expect(button).toBeInTheDocument();
+
+  await fireEvent.click(button);
+
+  // confirm search term has changed
+  expect(resetMock).toHaveBeenCalledOnce();
+  const title = screen.getByText("No object matching '' found");
+  expect(title).toBeInTheDocument();
+});
+
+test('Expect button to fire event and respect event listener', async () => {
+  const config = { icon: DesktopIcon, kind: 'object', searchTerm: 'test' };
+  const result = render(FilteredEmptyScreen, config);
+
+  // setup mock event listener that just prevents default action
+  const resetMock = vi.fn();
+  resetMock.mockImplementation(e => {
+    e.preventDefault();
+  });
+  result.component.$on('resetFilter', resetMock);
+
+  const button = screen.getByRole('button', { name: 'Clear filter' });
+  expect(button).toBeInTheDocument();
+
+  await fireEvent.click(button);
+
+  // confirm search term has not changed
+  expect(resetMock).toHaveBeenCalledOnce();
+  const title = screen.getByText("No object matching 'test' found");
+  expect(title).toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/ui/FilteredEmptyScreen.svelte
+++ b/packages/renderer/src/lib/ui/FilteredEmptyScreen.svelte
@@ -8,7 +8,9 @@ export let searchTerm: string;
 
 const dispatch = createEventDispatcher();
 function onResetFilter() {
-  dispatch('resetFilter');
+  if (dispatch('resetFilter', searchTerm, { cancelable: true })) {
+    searchTerm = '';
+  }
 }
 
 $: filter = searchTerm && searchTerm.length > 20 ? 'filter' : `'${searchTerm}'`;


### PR DESCRIPTION
### What does this PR do?

Fixes the regression caused by #4600. Prior to this the FilteredEmptyScreen would reset all filters to ''. The container list needed special processing to not remove the filters like 'is:running' so it was changed to an event, but none of the other lists respond to this event so none of the filters get cleared.

This sets a default behaviour of clearing the list so that none of the other lists need to respond to the event if they are fine just clearing the filter. If you do your own special processing, you just call e.preventDefault(). The search term is included as an event property because we need to set cancelable in the third argument.

The pods list has the tabs/is:running so I added the event handling there as well. Without this change clearing the filter would always return you to the first tab.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes #5288.

### How to test this PR?

Enter random text in container, pods, and volumes/images view, and confirm that clearing the filter works (and leaves the is:running/stopped for containers/pods list).