### PR TITLE
feat: pods table component

### DIFF
--- a/packages/renderer/src/lib/pod/PodColumnActions.spec.ts
+++ b/packages/renderer/src/lib/pod/PodColumnActions.spec.ts
@@ -1,0 +1,86 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+import { test, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+
+import type { PodInfoUI } from './PodInfoUI';
+import PodColumnActions from './PodColumnActions.svelte';
+import type { ContainerInfo, Port } from '@podman-desktop/api';
+
+const listContainersMock = vi.fn();
+const getContributedMenusMock = vi.fn();
+
+beforeEach(() => {
+  (window as any).listContainers = listContainersMock;
+  listContainersMock.mockResolvedValue([
+    { Id: 'pod', Ports: [{ PublicPort: 8080 } as Port] as Port[] } as ContainerInfo,
+  ]);
+
+  (window as any).getContributedMenus = getContributedMenusMock;
+  getContributedMenusMock.mockImplementation(() => Promise.resolve([]));
+});
+
+afterEach(() => {
+  vi.resetAllMocks();
+  vi.clearAllMocks();
+});
+
+test('Expect action buttons', async () => {
+  const pod: PodInfoUI = {
+    id: 'pod-id',
+    shortId: '',
+    name: '',
+    engineId: '',
+    engineName: '',
+    status: '',
+    age: '2 days',
+    created: '',
+    selected: false,
+    containers: [],
+    kind: 'podman',
+  };
+
+  render(PodColumnActions, { object: pod });
+
+  const buttons = await screen.findAllByRole('button');
+  expect(buttons).toHaveLength(4);
+});
+
+test('Expect error message', async () => {
+  const pod: PodInfoUI = {
+    id: 'pod-id',
+    shortId: '',
+    name: '',
+    engineId: '',
+    engineName: '',
+    status: '',
+    age: '2 days',
+    created: '',
+    selected: false,
+    containers: [],
+    kind: 'podman',
+    actionError: 'Pod failed',
+  };
+
+  render(PodColumnActions, { object: pod });
+
+  const error = screen.getByText('Pod failed');
+  expect(error).toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/pod/PodColumnActions.svelte
+++ b/packages/renderer/src/lib/pod/PodColumnActions.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+import type { PodInfoUI } from './PodInfoUI';
+import PodActions from './PodActions.svelte';
+import ErrorMessage from '../ui/ErrorMessage.svelte';
+
+export let object: PodInfoUI;
+</script>
+
+<div class="flex w-full">
+  <div class="flex items-center w-5">
+    {#if object.actionError}
+      <ErrorMessage error="{object.actionError}" icon />
+    {:else}
+      <div>&nbsp;</div>
+    {/if}
+  </div>
+  <div class="text-right w-full">
+    <PodActions pod="{object}" dropdownMenu="{true}" on:update />
+  </div>
+</div>

--- a/packages/renderer/src/lib/pod/PodColumnAge.spec.ts
+++ b/packages/renderer/src/lib/pod/PodColumnAge.spec.ts
@@ -1,0 +1,47 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+import { test, expect } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+
+import PodColumnAge from './PodColumnAge.svelte';
+import type { PodInfoUI } from './PodInfoUI';
+
+const pod: PodInfoUI = {
+  id: 'pod-id',
+  shortId: '',
+  name: '',
+  engineId: '',
+  engineName: '',
+  status: '',
+  age: '2 days',
+  created: '',
+  selected: false,
+  containers: [],
+  kind: 'podman',
+};
+
+test('Expect simple column styling', async () => {
+  render(PodColumnAge, { object: pod });
+
+  const text = screen.getByText(pod.age);
+  expect(text).toBeInTheDocument();
+  expect(text).toHaveClass('text-sm');
+  expect(text).toHaveClass('text-gray-700');
+});

--- a/packages/renderer/src/lib/pod/PodColumnAge.svelte
+++ b/packages/renderer/src/lib/pod/PodColumnAge.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+import type { PodInfoUI } from './PodInfoUI';
+import StateChange from '../ui/StateChange.svelte';
+
+export let object: PodInfoUI;
+</script>
+
+<div class="text-sm text-gray-700">
+  <StateChange state="{object.status}">{object.age}</StateChange>
+</div>

--- a/packages/renderer/src/lib/pod/PodColumnContainers.spec.ts
+++ b/packages/renderer/src/lib/pod/PodColumnContainers.spec.ts
@@ -1,0 +1,66 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+import { test, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+
+import PodColumnContainers from './PodColumnContainers.svelte';
+import type { PodInfoUI } from './PodInfoUI';
+import { fireEvent } from '@testing-library/dom';
+import { router } from 'tinro';
+
+const pod: PodInfoUI = {
+  id: 'pod-id',
+  shortId: 'short-id',
+  name: '',
+  engineId: '',
+  engineName: '',
+  status: '',
+  age: '',
+  created: '',
+  selected: false,
+  containers: [
+    {
+      Id: 'container1',
+      Names: 'container1',
+      Status: 'RUNNING',
+    },
+  ],
+  kind: 'podman',
+};
+
+test('Expect simple column styling', async () => {
+  render(PodColumnContainers, { object: pod });
+
+  const dot = screen.getByTestId('status-dot');
+  expect(dot).toBeInTheDocument();
+  expect(dot).toHaveClass('bg-status-running');
+});
+
+test('Expect clicking works', async () => {
+  render(PodColumnContainers, { object: pod });
+
+  const button = screen.getByRole('button');
+  expect(button).toBeInTheDocument();
+
+  const routerGotoSpy = vi.spyOn(router, 'goto');
+  fireEvent.click(button);
+
+  expect(routerGotoSpy).toBeCalledWith('/containers/?filter=short-id');
+});

--- a/packages/renderer/src/lib/pod/PodColumnContainers.svelte
+++ b/packages/renderer/src/lib/pod/PodColumnContainers.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+import type { PodInfoUI } from './PodInfoUI';
+import Dots from '../ui/Dots.svelte';
+import { router } from 'tinro';
+
+export let object: PodInfoUI;
+
+function openContainersFromPod(pod: PodInfoUI) {
+  router.goto(`/containers/?filter=${pod.shortId}`);
+}
+</script>
+
+<!-- If this is podman, make the dots clickable as it'll take us to the container menu 
+this does not work if you click on a kubernetes type pod -->
+{#if object.kind === 'podman'}
+  <button class:cursor-pointer="{object.containers.length > 0}" on:click="{() => openContainersFromPod(object)}">
+    <Dots containers="{object.containers}" />
+  </button>
+{:else}
+  <Dots containers="{object.containers}" />
+{/if}

--- a/packages/renderer/src/lib/pod/PodColumnEnvironment.spec.ts
+++ b/packages/renderer/src/lib/pod/PodColumnEnvironment.spec.ts
@@ -1,0 +1,47 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+import { test, expect } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+
+import PodColumnEnvironment from './PodColumnEnvironment.svelte';
+import type { PodInfoUI } from './PodInfoUI';
+
+const pod: PodInfoUI = {
+  id: 'pod-id',
+  shortId: 'short-id',
+  name: 'my-pod',
+  engineId: '',
+  engineName: '',
+  status: '',
+  age: '',
+  created: '',
+  selected: false,
+  containers: [],
+  kind: 'podman',
+};
+
+test('Expect simple column styling', async () => {
+  render(PodColumnEnvironment, { object: pod });
+
+  const text = screen.getByText(pod.kind);
+  expect(text).toBeInTheDocument();
+  expect(text).toHaveClass('text-xs');
+  expect(text).toHaveClass('capitalize');
+});

--- a/packages/renderer/src/lib/pod/PodColumnEnvironment.svelte
+++ b/packages/renderer/src/lib/pod/PodColumnEnvironment.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+import type { PodInfoUI } from './PodInfoUI';
+import ProviderInfo from '../ui/ProviderInfo.svelte';
+
+export let object: PodInfoUI;
+</script>
+
+<div class="text-xs rounded-md text-gray-500">
+  <ProviderInfo provider="{object.kind}" context="{object.engineId}" />
+</div>

--- a/packages/renderer/src/lib/pod/PodColumnName.spec.ts
+++ b/packages/renderer/src/lib/pod/PodColumnName.spec.ts
@@ -1,0 +1,68 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+import { test, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+
+import PodColumnName from './PodColumnName.svelte';
+import type { PodInfoUI } from './PodInfoUI';
+import { router } from 'tinro';
+import { fireEvent } from '@testing-library/dom';
+
+const pod: PodInfoUI = {
+  id: 'pod-id',
+  shortId: 'short-id',
+  name: 'my-pod',
+  engineId: 'podman',
+  engineName: '',
+  status: '',
+  age: '',
+  created: '',
+  selected: false,
+  containers: [],
+  kind: 'podman',
+};
+
+test('Expect simple column styling', async () => {
+  render(PodColumnName, { object: pod });
+
+  const text = screen.getByText(pod.name);
+  expect(text).toBeInTheDocument();
+  expect(text).toHaveClass('text-sm');
+  expect(text).toHaveClass('text-gray-300');
+
+  const id = screen.getByText(pod.shortId);
+  expect(id).toBeInTheDocument();
+  expect(id).toHaveClass('text-xs');
+  expect(id).toHaveClass('text-violet-400');
+});
+
+test('Expect clicking works', async () => {
+  render(PodColumnName, { object: pod });
+
+  const text = screen.getByText(pod.name);
+  expect(text).toBeInTheDocument();
+
+  // test click
+  const routerGotoSpy = vi.spyOn(router, 'goto');
+
+  fireEvent.click(text);
+
+  expect(routerGotoSpy).toBeCalledWith('/pods/podman/my-pod/podman/logs');
+});

--- a/packages/renderer/src/lib/pod/PodColumnName.svelte
+++ b/packages/renderer/src/lib/pod/PodColumnName.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+import { router } from 'tinro';
+import type { PodInfoUI } from './PodInfoUI';
+
+export let object: PodInfoUI;
+
+function openDetailsPod(pod: PodInfoUI) {
+  router.goto(`/pods/${encodeURI(pod.kind)}/${encodeURI(pod.name)}/${encodeURIComponent(pod.engineId)}/logs`);
+}
+</script>
+
+<button class="hover:cursor-pointer flex flex-col" on:click="{() => openDetailsPod(object)}">
+  <div class="text-sm text-gray-300">{object.name}</div>
+  <div class="text-xs text-violet-400">{object.shortId}</div>
+</button>

--- a/packages/renderer/src/lib/pod/PodColumnStatus.spec.ts
+++ b/packages/renderer/src/lib/pod/PodColumnStatus.spec.ts
@@ -1,0 +1,46 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+import { test, expect } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+
+import PodColumnStatus from './PodColumnStatus.svelte';
+import type { PodInfoUI } from './PodInfoUI';
+
+const pod: PodInfoUI = {
+  id: 'pod-id',
+  shortId: '',
+  name: '',
+  engineId: '',
+  engineName: '',
+  status: 'RUNNING',
+  age: '',
+  created: '',
+  selected: false,
+  containers: [],
+  kind: 'podman',
+};
+
+test('Expect simple column styling', async () => {
+  render(PodColumnStatus, { object: pod });
+
+  const status = screen.getByRole('status');
+  expect(status).toBeInTheDocument();
+  expect(status).toHaveClass('bg-green-400');
+});

--- a/packages/renderer/src/lib/pod/PodColumnStatus.svelte
+++ b/packages/renderer/src/lib/pod/PodColumnStatus.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+import type { PodInfoUI } from './PodInfoUI';
+import StatusIcon from '../images/StatusIcon.svelte';
+import PodIcon from '../images/PodIcon.svelte';
+
+export let object: PodInfoUI;
+</script>
+
+<StatusIcon icon="{PodIcon}" status="{object.status}" />

--- a/packages/renderer/src/lib/pod/PodsList.spec.ts
+++ b/packages/renderer/src/lib/pod/PodsList.spec.ts
@@ -402,7 +402,7 @@ test('Expect the route to a pod details page is correctly encoded with an engine
     { timeout: 5000 },
   );
   render(PodsList);
-  const podDetails = screen.getByRole('cell', { name: 'ocppod e8129c57' });
+  const podDetails = screen.getByText('ocppod');
   expect(podDetails).toBeInTheDocument();
 
   const podRow = screen.getByRole('row', {

--- a/tests/src/model/pages/pods-page.ts
+++ b/tests/src/model/pages/pods-page.ts
@@ -63,7 +63,13 @@ export class PodsPage extends BasePage {
     }
     const podsTable = await this.getTable();
     const rows = await podsTable.getByRole('row').all();
+    let first: boolean = true;
     for (const row of rows) {
+      if (first) {
+        // skip first row (header)
+        first = false;
+        continue;
+      }
       // test on empty row - contains on 0th position &nbsp; character (ISO 8859-1 character set: 160)
       const zeroCell = await row.getByRole('cell').nth(0).innerText();
       if (zeroCell.indexOf(String.fromCharCode(160)) === 0) {


### PR DESCRIPTION
### What does this PR do?

Switches the Pods page to the new table component. Columns and actions are extracted as expected. All the columns are sortable.

Table component allows update events to be passed through so that pod actions (or other future table actions) can trigger the UI to refresh.

### Screenshot / video of UI

Before:
<img width="973" alt="Screenshot 2023-12-18 at 1 59 06 PM" src="https://github.com/containers/podman-desktop/assets/19958075/d17bb192-ea9e-41fb-90f0-dd2f1f73b450">

After:
<img width="957" alt="Screenshot 2023-12-18 at 1 57 21 PM" src="https://github.com/containers/podman-desktop/assets/19958075/ffb2cd4d-36ba-41ae-847e-deb5952a24b2">

### What issues does this PR fix or reference?

Fixes #4842.

### How to test this PR?

Use pods list: start/stop/create pods, try container links and actions.