### PR TITLE
fix: increase hook timeout for e2e tests

### DIFF
--- a/vitest.config.js
+++ b/vitest.config.js
@@ -47,7 +47,7 @@ const config = {
      * A default timeout of 5000ms is sometimes not enough for playwright.
      */
     testTimeout: 60_000,
-    hookTimeout: 60_000,
+    hookTimeout: 120_000,
     // test reporters - default for all and junit for CI
     reporters: process.env.CI ? ['default', 'junit'] : ['default'],
     outputFile: process.env.CI ? { junit: 'tests/output/junit-results.xml' } : {},


### PR DESCRIPTION
### What does this PR do?
I am seeing multiple test hook timeout in smoke e2e testing suite. It seems that closing the electron app takes longer than 60 second. So this is a fix for this flakiness. 

### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
#5325 

<!-- Include any related issues from Podman Desktop 
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to reproduce -->
