### PR TITLE
feat: create informers for kube contexts

### DIFF
--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -79,6 +79,7 @@ import type Dockerode from 'dockerode';
 import { AutostartEngine } from './autostart-engine.js';
 import { CloseBehavior } from './close-behavior.js';
 import { TrayIconColor } from './tray-icon-color.js';
+import type { ContextState } from './kubernetes-client.js';
 import { KubernetesClient } from './kubernetes-client.js';
 import type {
   V1Pod,
@@ -2029,6 +2030,10 @@ export class PluginSystem {
 
     this.ipcHandle('kubernetes-client:setContext', async (_listener, contextName: string): Promise<void> => {
       return kubernetesClient.setContext(contextName);
+    });
+
+    this.ipcHandle('kubernetes-client:getContextsState', async (): Promise<Map<string, ContextState>> => {
+      return kubernetesClient.getContextsState();
     });
 
     this.ipcHandle('feedback:send', async (_listener, feedbackProperties: unknown): Promise<void> => {

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -79,7 +79,6 @@ import type Dockerode from 'dockerode';
 import { AutostartEngine } from './autostart-engine.js';
 import { CloseBehavior } from './close-behavior.js';
 import { TrayIconColor } from './tray-icon-color.js';
-import type { ContextState } from './kubernetes-client.js';
 import { KubernetesClient } from './kubernetes-client.js';
 import type {
   V1Pod,
@@ -154,6 +153,7 @@ import { OpenDevToolsInit } from './open-devtools-init.js';
 import { NavigationManager } from '/@/plugin/navigation/navigation-manager.js';
 import { WebviewRegistry } from './webview/webview-registry.js';
 import type { IDisposable } from './types/disposable.js';
+import type { ContextState } from './kubernetes-context-state.js';
 
 import { KubernetesUtils } from './kubernetes-util.js';
 

--- a/packages/main/src/plugin/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes-client.ts
@@ -33,9 +33,6 @@ import type {
   KubernetesObject,
   ListPromise,
   KubernetesListObject,
-  Informer,
-  ObjectCache,
-  V1ReplicaSet,
 } from '@kubernetes/client-node';
 import {
   ApisApi,
@@ -67,8 +64,9 @@ import * as jsYaml from 'js-yaml';
 import type { KubeContext } from './kubernetes-context.js';
 import type { KubernetesInformerManager } from './kubernetes-informer-registry.js';
 import type { KubernetesInformerResourcesType } from './api/kubernetes-informer-info.js';
-import type { ContextInternalState, ContextState } from './kubernetes-context-state.js';
 import type { IncomingMessage } from 'node:http';
+import type { ContextState } from './kubernetes-context-state.js';
+import { ContextsState } from './kubernetes-context-state.js';
 
 function toContainerStatus(state: V1ContainerState | undefined): string {
   if (state) {
@@ -140,8 +138,7 @@ export class KubernetesClient {
    */
   private apiResources = new Map<string, Array<V1APIResource>>();
 
-  private contextsState = new Map<string, ContextState>();
-  private contextsInternalState = new Map<string, ContextInternalState>();
+  private contextsState: ContextsState;
 
   private readonly _onDidUpdateKubeconfig = new Emitter<containerDesktopAPI.KubeconfigUpdateEvent>();
   readonly onDidUpdateKubeconfig: containerDesktopAPI.Event<containerDesktopAPI.KubeconfigUpdateEvent> =
@@ -155,6 +152,7 @@ export class KubernetesClient {
     private readonly telemetry: Telemetry,
   ) {
     this.kubeConfig = new KubeConfig();
+    this.contextsState = new ContextsState(this.configurationRegistry, this.apiSender);
   }
 
   async init(): Promise<void> {
@@ -469,44 +467,7 @@ export class KubernetesClient {
     const kubernetesConfiguration = this.configurationRegistry.getConfiguration('kubernetes');
     const liveContextsInfo = kubernetesConfiguration.get<boolean>('LiveContextsInfo');
 
-    if (liveContextsInfo) {
-      // Add informers for new contexts
-      for (const context of this.kubeConfig.contexts) {
-        if (this.contextsInternalState.get(context.name) === undefined) {
-          this.contextsState.set(context.name, {
-            reachable: false,
-            podsCount: 0,
-            deploymentsCount: 0,
-            replicasetsCount: 0,
-          });
-          const informers = this.createKubeContextInformers(context);
-          if (informers) {
-            this.contextsInternalState.set(context.name, informers);
-          }
-        }
-      }
-      // Delete informers for removed contexts
-      for (const [name, state] of this.contextsInternalState) {
-        if (!this.kubeConfig.contexts.find(c => c.name === name)) {
-          await state.podInformer?.stop();
-          await state.deploymentInformer?.stop();
-          await state.replicasetInformer?.stop();
-          this.contextsInternalState.delete(name);
-          this.contextsState.delete(name);
-        }
-      }
-    } else {
-      for (const state of this.contextsInternalState.values()) {
-        await state.podInformer?.stop();
-        await state.deploymentInformer?.stop();
-        await state.replicasetInformer?.stop();
-      }
-      this.contextsInternalState.clear();
-      this.contextsState.clear();
-      this.dispatchContextsState();
-    }
-
-    console.log('==> # informers', this.contextsInternalState.size, this.contextsState.size);
+    await this.contextsState.update(liveContextsInfo, this.kubeConfig);
   }
 
   newError(message: string, cause: Error): Error {
@@ -1303,169 +1264,7 @@ export class KubernetesClient {
     }
   }
 
-  createKubeContextInformers(context: KubeContext): ContextInternalState | undefined {
-    const kc = new KubeConfig();
-    const cluster = this.kubeConfig.clusters.find(c => c.name === context.cluster);
-    const user = this.kubeConfig.users.find(u => u.name === context.user);
-    if (!cluster || !user) {
-      return;
-    }
-    kc.loadFromOptions({
-      clusters: [cluster],
-      users: [user],
-      contexts: [context],
-      currentContext: context.name,
-    });
-
-    const ns = context.namespace ?? 'default';
-    return {
-      podInformer: this.createPodInformer(kc, ns, context),
-      deploymentInformer: this.createDeploymentInformer(kc, ns, context),
-      replicasetInformer: this.createReplicasetInformer(kc, ns, context),
-    };
-  }
-
-  createPodInformer(kc: KubeConfig, ns: string, context: KubeContext): Informer<V1Pod> & ObjectCache<V1Pod> {
-    const k8sApi = kc.makeApiClient(CoreV1Api);
-    const listFn = () => k8sApi.listNamespacedPod(ns);
-    const informer = makeInformer(kc, `/api/v1/namespaces/${ns}/pods`, listFn);
-
-    informer.on('add', (_obj: V1Pod) => {
-      const previous = this.contextsState.get(context.name);
-      if (previous) {
-        previous.podsCount++;
-      }
-      this.dispatchContextsState();
-    });
-
-    informer.on('delete', (_obj: V1Pod) => {
-      const previous = this.contextsState.get(context.name);
-      if (previous) {
-        previous.podsCount--;
-      }
-      this.dispatchContextsState();
-    });
-    informer.on('error', (err: unknown) => {
-      console.error(`==> ${context.name}: error`, err);
-      const previous = this.contextsState.get(context.name);
-      if (previous) {
-        previous.reachable = err === undefined;
-      }
-      this.dispatchContextsState();
-      // Restart informer after 5sec
-      setTimeout(() => {
-        this.restartInformer(informer, context);
-      }, 5000);
-    });
-    informer.on('connect', (err: unknown) => {
-      console.error(`==> ${context.name}: connect`, err);
-      const previous = this.contextsState.get(context.name);
-      if (previous) {
-        previous.reachable = err === undefined;
-      }
-      this.dispatchContextsState();
-    });
-    this.restartInformer(informer, context);
-    return informer;
-  }
-
-  createDeploymentInformer(
-    kc: KubeConfig,
-    ns: string,
-    context: KubeContext,
-  ): Informer<V1Deployment> & ObjectCache<V1Deployment> {
-    const k8sApi = kc.makeApiClient(AppsV1Api);
-    const listFn = () => k8sApi.listNamespacedDeployment(ns);
-    const informer = makeInformer(kc, `/apis/apps/v1/namespaces/${ns}/deployments`, listFn);
-
-    informer.on('add', (_obj: V1Deployment) => {
-      const previous = this.contextsState.get(context.name);
-      if (previous) {
-        previous.deploymentsCount++;
-      }
-      this.dispatchContextsState();
-    });
-
-    informer.on('delete', (_obj: V1Deployment) => {
-      const previous = this.contextsState.get(context.name);
-      if (previous) {
-        previous.deploymentsCount--;
-      }
-      this.dispatchContextsState();
-    });
-    informer.on('error', (_err: unknown) => {
-      // Restart informer after 5sec
-      setTimeout(() => {
-        this.restartInformer(informer, context);
-      }, 5000);
-    });
-    this.restartInformer(informer, context);
-    return informer;
-  }
-
-  createReplicasetInformer(
-    kc: KubeConfig,
-    ns: string,
-    context: KubeContext,
-  ): Informer<V1ReplicaSet> & ObjectCache<V1ReplicaSet> {
-    const k8sApi = kc.makeApiClient(AppsV1Api);
-    const listFn = () => k8sApi.listNamespacedReplicaSet(ns);
-    const informer = makeInformer(kc, `/apis/apps/v1/namespaces/${ns}/replicasets`, listFn);
-
-    informer.on('add', (_obj: V1ReplicaSet) => {
-      const previous = this.contextsState.get(context.name);
-      if (previous) {
-        previous.replicasetsCount++;
-      }
-      this.dispatchContextsState();
-    });
-
-    informer.on('delete', (_obj: V1ReplicaSet) => {
-      const previous = this.contextsState.get(context.name);
-      if (previous) {
-        previous.replicasetsCount--;
-      }
-      this.dispatchContextsState();
-    });
-    informer.on('error', (_err: unknown) => {
-      // Restart informer after 5sec
-      setTimeout(() => {
-        this.restartInformer(informer, context);
-      }, 5000);
-    });
-    this.restartInformer(informer, context);
-    return informer;
-  }
-
-  restartInformer(informer: Informer<KubernetesObject> & ObjectCache<KubernetesObject>, context: KubeContext) {
-    const kubernetesConfiguration = this.configurationRegistry.getConfiguration('kubernetes');
-    const liveContextsInfo = kubernetesConfiguration.get<boolean>('LiveContextsInfo');
-    if (!liveContextsInfo) {
-      return;
-    }
-
-    informer
-      .start()
-      .then(() => {})
-      .catch((err: unknown) => {
-        console.log('==> catched err', err);
-        const previous = this.contextsState.get(context.name);
-        if (previous) {
-          previous.reachable = err === undefined;
-        }
-        this.dispatchContextsState();
-        // Restart informer after 5sec
-        setTimeout(() => {
-          this.restartInformer(informer, context);
-        }, 5000);
-      });
-  }
-
-  dispatchContextsState() {
-    this.apiSender.send(`kubernetes-contexts-state-update`, this.contextsState);
-  }
-
-  getContextsState(): Map<string, ContextState> {
-    return this.contextsState;
+  public getContextsState(): Map<string, ContextState> {
+    return this.contextsState.getContextsState();
   }
 }

--- a/packages/main/src/plugin/kubernetes-context-state.spec.ts
+++ b/packages/main/src/plugin/kubernetes-context-state.spec.ts
@@ -146,6 +146,7 @@ test('should send info of resources in all reachable contexts and nothing in non
     deploymentsCount: 12,
     replicasetsCount: 22,
   } as ContextState);
+  await new Promise(resolve => setTimeout(resolve, 200));
   expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-contexts-state-update', expectedMap);
 
   // => removing contexts, should remving clusters from sent info
@@ -199,11 +200,13 @@ test('should send info of resources in all reachable contexts and nothing in non
     deploymentsCount: 11,
     replicasetsCount: 21,
   } as ContextState);
+  await new Promise(resolve => setTimeout(resolve, 200));
   expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-contexts-state-update', expectedMap);
 
   // => disabling feature, should send empty map
   vi.clearAllMocks();
   await client.update(false, kubeConfig);
   expectedMap = new Map<string, ContextState>();
+  await new Promise(resolve => setTimeout(resolve, 200));
   expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-contexts-state-update', expectedMap);
 });

--- a/packages/main/src/plugin/kubernetes-context-state.spec.ts
+++ b/packages/main/src/plugin/kubernetes-context-state.spec.ts
@@ -1,0 +1,209 @@
+import { expect, test, vi } from 'vitest';
+import type { ContextState } from './kubernetes-context-state.js';
+import { ContextsState } from './kubernetes-context-state.js';
+import type { ConfigurationRegistry } from './configuration-registry.js';
+import type { ApiSenderType } from './api.js';
+import type { Configuration } from '@podman-desktop/api';
+import { FakeInformer } from './testutils/fake-informer.js';
+import * as kubeclient from '@kubernetes/client-node';
+
+const kubernetesConfigurationGetMock = vi.fn();
+const kubernetesConfiguration: Configuration = {
+  get: kubernetesConfigurationGetMock,
+} as unknown as Configuration;
+
+const configurationRegistryGetConfigurationMock = vi.fn();
+const configurationRegistry: ConfigurationRegistry = {
+  getConfiguration: configurationRegistryGetConfigurationMock,
+} as unknown as ConfigurationRegistry;
+
+const apiSenderSendMock = vi.fn();
+const apiSender: ApiSenderType = {
+  send: apiSenderSendMock,
+  receive: vi.fn(),
+};
+
+// fakeMakeInformer describes how many resources are in the different namespaces and if cluster is reachable
+function fakeMakeInformer(
+  kubeconfig: kubeclient.KubeConfig,
+  path: string,
+  _listPromiseFn: kubeclient.ListPromise<kubeclient.KubernetesObject>,
+) {
+  let connectResult: Error | undefined;
+  switch (kubeconfig.currentContext) {
+    case 'context1':
+      connectResult = new Error('connection error');
+      break;
+    default:
+      connectResult = undefined;
+  }
+  switch (path) {
+    case '/api/v1/namespaces/ns1/pods':
+      return new FakeInformer(1, connectResult);
+    case '/api/v1/namespaces/ns2/pods':
+      return new FakeInformer(2, connectResult);
+    case '/api/v1/namespaces/default/pods':
+      return new FakeInformer(9, connectResult);
+
+    case '/apis/apps/v1/namespaces/ns1/deployments':
+      return new FakeInformer(11, connectResult);
+    case '/apis/apps/v1/namespaces/ns2/deployments':
+      return new FakeInformer(12, connectResult);
+    case '/apis/apps/v1/namespaces/default/deployments':
+      return new FakeInformer(19, connectResult);
+
+    case '/apis/apps/v1/namespaces/ns1/replicasets':
+      return new FakeInformer(21, connectResult);
+    case '/apis/apps/v1/namespaces/ns2/replicasets':
+      return new FakeInformer(22, connectResult);
+    case '/apis/apps/v1/namespaces/default/replicasets':
+      return new FakeInformer(29, connectResult);
+  }
+  return new FakeInformer(0, connectResult);
+}
+
+vi.mock('@kubernetes/client-node', async importOriginal => {
+  const actual = await importOriginal<typeof kubeclient>();
+  return {
+    ...actual,
+    makeInformer: fakeMakeInformer,
+  };
+});
+
+test('should send info of resources in all reachable contexts and nothing in non reachable', async () => {
+  const client = new ContextsState(configurationRegistry, apiSender);
+  const kubeConfig = new kubeclient.KubeConfig();
+  kubeConfig.loadFromOptions({
+    clusters: [
+      {
+        name: 'cluster1',
+        server: 'server1',
+      },
+      {
+        name: 'cluster2',
+        server: 'server2',
+      },
+    ],
+    users: [
+      {
+        name: 'user1',
+      },
+      {
+        name: 'user2',
+      },
+    ],
+    contexts: [
+      {
+        name: 'context1',
+        cluster: 'cluster1',
+        user: 'user1',
+      },
+      {
+        name: 'context2',
+        cluster: 'cluster2',
+        user: 'user2',
+      },
+      {
+        name: 'context2-1',
+        cluster: 'cluster2',
+        user: 'user2',
+        namespace: 'ns1',
+      },
+      {
+        name: 'context2-2',
+        cluster: 'cluster2',
+        user: 'user2',
+        namespace: 'ns2',
+      },
+    ],
+    currentContext: 'context2-1',
+  });
+  kubernetesConfigurationGetMock.mockReturnValue(true);
+  configurationRegistryGetConfigurationMock.mockReturnValue(kubernetesConfiguration);
+  await client.update(true, kubeConfig);
+  let expectedMap = new Map<string, ContextState>();
+  expectedMap.set('context1', {
+    reachable: false,
+    podsCount: 0,
+    deploymentsCount: 0,
+    replicasetsCount: 0,
+  } as ContextState);
+  expectedMap.set('context2', {
+    reachable: true,
+    podsCount: 9,
+    deploymentsCount: 19,
+    replicasetsCount: 29,
+  } as ContextState);
+  expectedMap.set('context2-1', {
+    reachable: true,
+    podsCount: 1,
+    deploymentsCount: 11,
+    replicasetsCount: 21,
+  } as ContextState);
+  expectedMap.set('context2-2', {
+    reachable: true,
+    podsCount: 2,
+    deploymentsCount: 12,
+    replicasetsCount: 22,
+  } as ContextState);
+  expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-contexts-state-update', expectedMap);
+
+  // => removing contexts, should remving clusters from sent info
+  kubeConfig.loadFromOptions({
+    clusters: [
+      {
+        name: 'cluster1',
+        server: 'server1',
+      },
+      {
+        name: 'cluster2',
+        server: 'server2',
+      },
+    ],
+    users: [
+      {
+        name: 'user1',
+      },
+      {
+        name: 'user2',
+      },
+    ],
+    contexts: [
+      {
+        name: 'context2',
+        cluster: 'cluster2',
+        user: 'user2',
+      },
+      {
+        name: 'context2-1',
+        cluster: 'cluster2',
+        user: 'user2',
+        namespace: 'ns1',
+      },
+    ],
+    currentContext: 'context2-1',
+  });
+
+  vi.clearAllMocks();
+  await client.update(true, kubeConfig);
+  expectedMap = new Map<string, ContextState>();
+  expectedMap.set('context2', {
+    reachable: true,
+    podsCount: 9,
+    deploymentsCount: 19,
+    replicasetsCount: 29,
+  } as ContextState);
+  expectedMap.set('context2-1', {
+    reachable: true,
+    podsCount: 1,
+    deploymentsCount: 11,
+    replicasetsCount: 21,
+  } as ContextState);
+  expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-contexts-state-update', expectedMap);
+
+  // => disabling feature, should send empty map
+  vi.clearAllMocks();
+  await client.update(false, kubeConfig);
+  expectedMap = new Map<string, ContextState>();
+  expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-contexts-state-update', expectedMap);
+});

--- a/packages/main/src/plugin/kubernetes-context-state.spec.ts
+++ b/packages/main/src/plugin/kubernetes-context-state.spec.ts
@@ -51,13 +51,6 @@ function fakeMakeInformer(
       return new FakeInformer(12, connectResult);
     case '/apis/apps/v1/namespaces/default/deployments':
       return new FakeInformer(19, connectResult);
-
-    case '/apis/apps/v1/namespaces/ns1/replicasets':
-      return new FakeInformer(21, connectResult);
-    case '/apis/apps/v1/namespaces/ns2/replicasets':
-      return new FakeInformer(22, connectResult);
-    case '/apis/apps/v1/namespaces/default/replicasets':
-      return new FakeInformer(29, connectResult);
   }
   return new FakeInformer(0, connectResult);
 }
@@ -126,25 +119,21 @@ test('should send info of resources in all reachable contexts and nothing in non
     reachable: false,
     podsCount: 0,
     deploymentsCount: 0,
-    replicasetsCount: 0,
   } as ContextState);
   expectedMap.set('context2', {
     reachable: true,
     podsCount: 9,
     deploymentsCount: 19,
-    replicasetsCount: 29,
   } as ContextState);
   expectedMap.set('context2-1', {
     reachable: true,
     podsCount: 1,
     deploymentsCount: 11,
-    replicasetsCount: 21,
   } as ContextState);
   expectedMap.set('context2-2', {
     reachable: true,
     podsCount: 2,
     deploymentsCount: 12,
-    replicasetsCount: 22,
   } as ContextState);
   await new Promise(resolve => setTimeout(resolve, 200));
   expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-contexts-state-update', expectedMap);
@@ -192,13 +181,11 @@ test('should send info of resources in all reachable contexts and nothing in non
     reachable: true,
     podsCount: 9,
     deploymentsCount: 19,
-    replicasetsCount: 29,
   } as ContextState);
   expectedMap.set('context2-1', {
     reachable: true,
     podsCount: 1,
     deploymentsCount: 11,
-    replicasetsCount: 21,
   } as ContextState);
   await new Promise(resolve => setTimeout(resolve, 200));
   expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-contexts-state-update', expectedMap);

--- a/packages/main/src/plugin/kubernetes-context-state.ts
+++ b/packages/main/src/plugin/kubernetes-context-state.ts
@@ -219,21 +219,18 @@ export class ContextsState {
       return;
     }
 
-    informer
-      .start()
-      .then(() => {})
-      .catch((err: unknown) => {
-        console.log('==> catched err', err);
-        const previous = this.contextsState.get(context.name);
-        if (previous) {
-          previous.reachable = err === undefined;
-        }
-        this.dispatchContextsState();
-        // Restart informer after 5sec
-        setTimeout(() => {
-          this.restartInformer(informer, context);
-        }, 5000);
-      });
+    informer.start().catch((err: unknown) => {
+      console.log('==> catched err', err);
+      const previous = this.contextsState.get(context.name);
+      if (previous) {
+        previous.reachable = err === undefined;
+      }
+      this.dispatchContextsState();
+      // Restart informer after 5sec
+      setTimeout(() => {
+        this.restartInformer(informer, context);
+      }, 5000);
+    });
   }
 
   private dispatchContextsState() {

--- a/packages/main/src/plugin/kubernetes-context-state.ts
+++ b/packages/main/src/plugin/kubernetes-context-state.ts
@@ -1,6 +1,17 @@
-﻿import type { Informer, ObjectCache, V1Deployment, V1Pod, V1ReplicaSet } from '@kubernetes/client-node';
+﻿import type {
+  Informer,
+  KubernetesObject,
+  ObjectCache,
+  V1Deployment,
+  V1Pod,
+  V1ReplicaSet,
+} from '@kubernetes/client-node';
+import { AppsV1Api, CoreV1Api, KubeConfig, makeInformer } from '@kubernetes/client-node';
+import type { KubeContext } from './kubernetes-context.js';
+import type { ConfigurationRegistry } from './configuration-registry.js';
+import type { ApiSenderType } from './api.js';
 
-export interface ContextInternalState {
+interface ContextInternalState {
   podInformer?: Informer<V1Pod> & ObjectCache<V1Pod>;
   deploymentInformer?: Informer<V1Deployment> & ObjectCache<V1Deployment>;
   replicasetInformer?: Informer<V1ReplicaSet> & ObjectCache<V1ReplicaSet>;
@@ -11,4 +22,222 @@ export interface ContextState {
   podsCount: number;
   deploymentsCount: number;
   replicasetsCount: number;
+}
+
+export class ContextsState {
+  private kubeConfig = new KubeConfig();
+  private contextsState = new Map<string, ContextState>();
+  private contextsInternalState = new Map<string, ContextInternalState>();
+
+  constructor(
+    private readonly configurationRegistry: ConfigurationRegistry,
+    private readonly apiSender: ApiSenderType,
+  ) {}
+
+  async update(enabled: boolean | undefined, kubeconfig: KubeConfig) {
+    this.kubeConfig = kubeconfig;
+    if (enabled) {
+      // Add informers for new contexts
+      for (const context of this.kubeConfig.contexts) {
+        if (this.contextsInternalState.get(context.name) === undefined) {
+          this.contextsState.set(context.name, {
+            reachable: false,
+            podsCount: 0,
+            deploymentsCount: 0,
+            replicasetsCount: 0,
+          });
+          const informers = this.createKubeContextInformers(context);
+          if (informers) {
+            this.contextsInternalState.set(context.name, informers);
+          }
+        }
+      }
+      // Delete informers for removed contexts
+      for (const [name, state] of this.contextsInternalState) {
+        if (!this.kubeConfig.contexts.find(c => c.name === name)) {
+          await state.podInformer?.stop();
+          await state.deploymentInformer?.stop();
+          await state.replicasetInformer?.stop();
+          this.contextsInternalState.delete(name);
+          this.contextsState.delete(name);
+        }
+      }
+    } else {
+      for (const state of this.contextsInternalState.values()) {
+        await state.podInformer?.stop();
+        await state.deploymentInformer?.stop();
+        await state.replicasetInformer?.stop();
+      }
+      this.contextsInternalState.clear();
+      this.contextsState.clear();
+      this.dispatchContextsState();
+    }
+    console.log('==> # informers', this.contextsInternalState.size, this.contextsState.size);
+  }
+
+  private createKubeContextInformers(context: KubeContext): ContextInternalState | undefined {
+    const kc = new KubeConfig();
+    const cluster = this.kubeConfig.clusters.find(c => c.name === context.cluster);
+    const user = this.kubeConfig.users.find(u => u.name === context.user);
+    if (!cluster || !user) {
+      return;
+    }
+    kc.loadFromOptions({
+      clusters: [cluster],
+      users: [user],
+      contexts: [context],
+      currentContext: context.name,
+    });
+
+    const ns = context.namespace ?? 'default';
+    return {
+      podInformer: this.createPodInformer(kc, ns, context),
+      deploymentInformer: this.createDeploymentInformer(kc, ns, context),
+      replicasetInformer: this.createReplicasetInformer(kc, ns, context),
+    };
+  }
+
+  private createPodInformer(kc: KubeConfig, ns: string, context: KubeContext): Informer<V1Pod> & ObjectCache<V1Pod> {
+    const k8sApi = kc.makeApiClient(CoreV1Api);
+    const listFn = () => k8sApi.listNamespacedPod(ns);
+    const informer = makeInformer(kc, `/api/v1/namespaces/${ns}/pods`, listFn);
+
+    informer.on('add', (_obj: V1Pod) => {
+      const previous = this.contextsState.get(context.name);
+      if (previous) {
+        previous.podsCount++;
+      }
+      this.dispatchContextsState();
+    });
+
+    informer.on('delete', (_obj: V1Pod) => {
+      const previous = this.contextsState.get(context.name);
+      if (previous) {
+        previous.podsCount--;
+      }
+      this.dispatchContextsState();
+    });
+    informer.on('error', (err: unknown) => {
+      console.error(`==> ${context.name}: error`, err);
+      const previous = this.contextsState.get(context.name);
+      if (previous) {
+        previous.reachable = err === undefined;
+      }
+      this.dispatchContextsState();
+      // Restart informer after 5sec
+      setTimeout(() => {
+        this.restartInformer(informer, context);
+      }, 5000);
+    });
+    informer.on('connect', (err: unknown) => {
+      console.error(`==> ${context.name}: connect`, err);
+      const previous = this.contextsState.get(context.name);
+      if (previous) {
+        previous.reachable = err === undefined;
+      }
+      this.dispatchContextsState();
+    });
+    this.restartInformer(informer, context);
+    return informer;
+  }
+
+  private createDeploymentInformer(
+    kc: KubeConfig,
+    ns: string,
+    context: KubeContext,
+  ): Informer<V1Deployment> & ObjectCache<V1Deployment> {
+    const k8sApi = kc.makeApiClient(AppsV1Api);
+    const listFn = () => k8sApi.listNamespacedDeployment(ns);
+    const informer = makeInformer(kc, `/apis/apps/v1/namespaces/${ns}/deployments`, listFn);
+
+    informer.on('add', (_obj: V1Deployment) => {
+      const previous = this.contextsState.get(context.name);
+      if (previous) {
+        previous.deploymentsCount++;
+      }
+      this.dispatchContextsState();
+    });
+
+    informer.on('delete', (_obj: V1Deployment) => {
+      const previous = this.contextsState.get(context.name);
+      if (previous) {
+        previous.deploymentsCount--;
+      }
+      this.dispatchContextsState();
+    });
+    informer.on('error', (_err: unknown) => {
+      // Restart informer after 5sec
+      setTimeout(() => {
+        this.restartInformer(informer, context);
+      }, 5000);
+    });
+    this.restartInformer(informer, context);
+    return informer;
+  }
+
+  private createReplicasetInformer(
+    kc: KubeConfig,
+    ns: string,
+    context: KubeContext,
+  ): Informer<V1ReplicaSet> & ObjectCache<V1ReplicaSet> {
+    const k8sApi = kc.makeApiClient(AppsV1Api);
+    const listFn = () => k8sApi.listNamespacedReplicaSet(ns);
+    const informer = makeInformer(kc, `/apis/apps/v1/namespaces/${ns}/replicasets`, listFn);
+
+    informer.on('add', (_obj: V1ReplicaSet) => {
+      const previous = this.contextsState.get(context.name);
+      if (previous) {
+        previous.replicasetsCount++;
+      }
+      this.dispatchContextsState();
+    });
+
+    informer.on('delete', (_obj: V1ReplicaSet) => {
+      const previous = this.contextsState.get(context.name);
+      if (previous) {
+        previous.replicasetsCount--;
+      }
+      this.dispatchContextsState();
+    });
+    informer.on('error', (_err: unknown) => {
+      // Restart informer after 5sec
+      setTimeout(() => {
+        this.restartInformer(informer, context);
+      }, 5000);
+    });
+    this.restartInformer(informer, context);
+    return informer;
+  }
+
+  private restartInformer(informer: Informer<KubernetesObject> & ObjectCache<KubernetesObject>, context: KubeContext) {
+    const kubernetesConfiguration = this.configurationRegistry.getConfiguration('kubernetes');
+    const liveContextsInfo = kubernetesConfiguration.get<boolean>('LiveContextsInfo');
+    if (!liveContextsInfo) {
+      return;
+    }
+
+    informer
+      .start()
+      .then(() => {})
+      .catch((err: unknown) => {
+        console.log('==> catched err', err);
+        const previous = this.contextsState.get(context.name);
+        if (previous) {
+          previous.reachable = err === undefined;
+        }
+        this.dispatchContextsState();
+        // Restart informer after 5sec
+        setTimeout(() => {
+          this.restartInformer(informer, context);
+        }, 5000);
+      });
+  }
+
+  private dispatchContextsState() {
+    this.apiSender.send(`kubernetes-contexts-state-update`, this.contextsState);
+  }
+
+  public getContextsState(): Map<string, ContextState> {
+    return this.contextsState;
+  }
 }

--- a/packages/main/src/plugin/kubernetes-context-state.ts
+++ b/packages/main/src/plugin/kubernetes-context-state.ts
@@ -1,0 +1,14 @@
+﻿import type { Informer, ObjectCache, V1Deployment, V1Pod, V1ReplicaSet } from '@kubernetes/client-node';
+
+export interface ContextInternalState {
+  podInformer?: Informer<V1Pod> & ObjectCache<V1Pod>;
+  deploymentInformer?: Informer<V1Deployment> & ObjectCache<V1Deployment>;
+  replicasetInformer?: Informer<V1ReplicaSet> & ObjectCache<V1ReplicaSet>;
+}
+
+export interface ContextState {
+  reachable: boolean;
+  podsCount: number;
+  deploymentsCount: number;
+  replicasetsCount: number;
+}

--- a/packages/main/src/plugin/testutils/fake-informer.ts
+++ b/packages/main/src/plugin/testutils/fake-informer.ts
@@ -1,0 +1,46 @@
+import type { ErrorCallback, KubernetesObject, ObjectCallback } from '@kubernetes/client-node';
+
+export class FakeInformer {
+  private onCb: Map<string, ObjectCallback<KubernetesObject>>;
+  private offCb: Map<string, ObjectCallback<KubernetesObject>>;
+  private onErrorCb: Map<string, ErrorCallback>;
+
+  constructor(
+    private resourcesCount: number,
+    private connectResponse: Error | undefined,
+  ) {
+    this.onCb = new Map<string, ObjectCallback<KubernetesObject>>();
+    this.offCb = new Map<string, ObjectCallback<KubernetesObject>>();
+    this.onErrorCb = new Map<string, ErrorCallback>();
+  }
+  async start(): Promise<void> {
+    this.onErrorCb.get('connect')?.(this.connectResponse);
+    if (this.connectResponse === undefined) {
+      for (let i = 0; i < this.resourcesCount; i++) {
+        this.onCb.get('add')?.({});
+      }
+    }
+  }
+  stop() {}
+  on(
+    verb: 'change' | 'add' | 'update' | 'delete' | 'error' | 'connect',
+    cb: ErrorCallback | ObjectCallback<KubernetesObject>,
+  ) {
+    switch (verb) {
+      case 'error':
+      case 'connect':
+        this.onErrorCb.set(verb, cb as ErrorCallback);
+        break;
+      default:
+        this.onCb.set(verb, cb as ObjectCallback<KubernetesObject>);
+    }
+  }
+  off(
+    verb: 'change' | 'add' | 'update' | 'delete' | 'error' | 'connect',
+    cb: ErrorCallback | ObjectCallback<KubernetesObject>,
+  ) {
+    this.offCb.set(verb, cb);
+  }
+  get() {}
+  list() {}
+}

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -45,7 +45,7 @@ import type { FeaturedExtension } from '../../main/src/plugin/featured/featured-
 import type { CatalogExtension } from '../../main/src/plugin/extensions-catalog/extensions-catalog-api';
 import type { CommandInfo } from '../../main/src/plugin/api/command-info';
 import type { KubernetesInformerResourcesType } from '../../main/src/plugin/api/kubernetes-informer-info';
-
+import type { ContextState } from '../../main/src/plugin/kubernetes-client';
 import type { V1Route } from '../../main/src/plugin/api/openshift-types';
 import type { AuthenticationProviderInfo } from '../../main/src/plugin/authentication';
 import type {
@@ -1552,6 +1552,9 @@ function initExposure(): void {
   });
   contextBridge.exposeInMainWorld('kubernetesSetContext', async (contextName: string): Promise<void> => {
     return ipcInvoke('kubernetes-client:setContext', contextName);
+  });
+  contextBridge.exposeInMainWorld('kubernetesGetContextsState', async (): Promise<Map<string, ContextState>> => {
+    return ipcInvoke('kubernetes-client:getContextsState');
   });
 
   contextBridge.exposeInMainWorld('kubernetesGetClusters', async (): Promise<Cluster[]> => {

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -45,7 +45,6 @@ import type { FeaturedExtension } from '../../main/src/plugin/featured/featured-
 import type { CatalogExtension } from '../../main/src/plugin/extensions-catalog/extensions-catalog-api';
 import type { CommandInfo } from '../../main/src/plugin/api/command-info';
 import type { KubernetesInformerResourcesType } from '../../main/src/plugin/api/kubernetes-informer-info';
-import type { ContextState } from '../../main/src/plugin/kubernetes-client';
 import type { V1Route } from '../../main/src/plugin/api/openshift-types';
 import type { AuthenticationProviderInfo } from '../../main/src/plugin/authentication';
 import type {
@@ -92,6 +91,7 @@ import type { KubernetesGeneratorInfo } from '../../main/src/plugin/api/Kubernet
 import type { NotificationCard, NotificationCardOptions } from '../../main/src/plugin/api/notification';
 import type { ApiSenderType } from '../../main/src/plugin/api';
 import type { IDisposable } from '../../main/src/plugin/types/disposable';
+import type { ContextState } from '../../main/src/plugin/kubernetes-context-state.js';
 
 export type DialogResultCallback = (openDialogReturnValue: Electron.OpenDialogReturnValue) => void;
 

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.spec.ts
@@ -22,7 +22,7 @@ import { fireEvent, render, screen, within } from '@testing-library/svelte';
 import PreferencesKubernetesContextsRendering from './PreferencesKubernetesContextsRendering.svelte';
 import { kubernetesContexts } from '/@/stores/kubernetes-contexts';
 import type { KubeContext } from '../../../../main/src/plugin/kubernetes-context';
-import type { ContextState } from '../../../../main/src/plugin/kubernetes-client';
+import type { ContextState } from '../../../../main/src/plugin/kubernetes-context-state';
 
 // Create a fake KubeContextUI
 const mockContext1: KubeContext = {

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.spec.ts
@@ -22,6 +22,7 @@ import { fireEvent, render, screen, within } from '@testing-library/svelte';
 import PreferencesKubernetesContextsRendering from './PreferencesKubernetesContextsRendering.svelte';
 import { kubernetesContexts } from '/@/stores/kubernetes-contexts';
 import type { KubeContext } from '../../../../main/src/plugin/kubernetes-context';
+import type { ContextState } from '../../../../main/src/plugin/kubernetes-client';
 
 // Create a fake KubeContextUI
 const mockContext1: KubeContext = {
@@ -58,6 +59,7 @@ const mockContext3: KubeContext = {
 
 beforeEach(() => {
   kubernetesContexts.set([mockContext1, mockContext2, mockContext3]);
+  (window as any).kubernetesGetContextsState = vi.fn().mockResolvedValue(new Map<string, ContextState>());
 });
 
 test('test that name, cluster and the server is displayed when rendering', async () => {

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
@@ -7,6 +7,7 @@ import ListItemButtonIcon from '../ui/ListItemButtonIcon.svelte';
 import ErrorMessage from '../ui/ErrorMessage.svelte';
 import { kubernetesContexts } from '../../stores/kubernetes-contexts';
 import { clearKubeUIContextErrors, setKubeUIContextError } from '../kube/KubeContextUI';
+import { kubernetesContextsState } from '/@/stores/kubernetes-contexts-state';
 
 $: currentContextName = $kubernetesContexts.find(c => c.currentContext)?.name;
 
@@ -119,6 +120,18 @@ async function handleDeleteContext(contextName: string) {
               <span class="my-auto font-bold col-span-1 text-right">NAMESPACE</span>
               <span class="my-auto col-span-5 text-left pl-0.5 ml-3" aria-label="context-namespace"
                 >{context.namespace}</span>
+            </div>
+          {/if}
+          <div class="text-xs bg-charcoal-800 p-2 rounded-lg mt-1 grid grid-cols-6">
+            <span class="my-auto font-bold col-span-1 text-right">Reachable</span>
+            <span class="my-auto col-span-5 text-left pl-0.5 ml-3" aria-label="context-namespace"
+              >{$kubernetesContextsState.get(context.name)?.reachable}</span>
+          </div>
+          {#if $kubernetesContextsState.get(context.name)?.reachable}
+            <div class="text-xs bg-charcoal-800 p-2 rounded-lg mt-1 grid grid-cols-6">
+              <span class="my-auto font-bold col-span-1 text-right">Pods</span>
+              <span class="my-auto col-span-5 text-left pl-0.5 ml-3" aria-label="context-namespace"
+                >{$kubernetesContextsState.get(context.name)?.podsCount}</span>
             </div>
           {/if}
         </div>

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
@@ -114,13 +114,13 @@ async function handleDeleteContext(contextName: string) {
                     <div class="text-center">
                       <div class="font-bold text-[9px] text-gray-800">DEPLOYMENTS</div>
                       <div class="text-[16px] text-white">
-                        {$kubernetesContextsState.get(context.name)?.podsCount}
+                        {$kubernetesContextsState.get(context.name)?.deploymentsCount}
                       </div>
                     </div>
                     <div class="text-center">
                       <div class="font-bold text-[9px] text-gray-800">REPLICASETS</div>
                       <div class="text-[16px] text-white">
-                        {$kubernetesContextsState.get(context.name)?.podsCount}
+                        {$kubernetesContextsState.get(context.name)?.replicasetsCount}
                       </div>
                     </div>
                   </div>

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
@@ -122,17 +122,19 @@ async function handleDeleteContext(contextName: string) {
                 >{context.namespace}</span>
             </div>
           {/if}
-          <div class="text-xs bg-charcoal-800 p-2 rounded-lg mt-1 grid grid-cols-6">
-            <span class="my-auto font-bold col-span-1 text-right">Reachable</span>
-            <span class="my-auto col-span-5 text-left pl-0.5 ml-3" aria-label="context-namespace"
-              >{$kubernetesContextsState.get(context.name)?.reachable}</span>
-          </div>
-          {#if $kubernetesContextsState.get(context.name)?.reachable}
+          {#if $kubernetesContextsState.get(context.name)}
             <div class="text-xs bg-charcoal-800 p-2 rounded-lg mt-1 grid grid-cols-6">
-              <span class="my-auto font-bold col-span-1 text-right">Pods</span>
+              <span class="my-auto font-bold col-span-1 text-right">Reachable</span>
               <span class="my-auto col-span-5 text-left pl-0.5 ml-3" aria-label="context-namespace"
-                >{$kubernetesContextsState.get(context.name)?.podsCount}</span>
+                >{$kubernetesContextsState.get(context.name)?.reachable}</span>
             </div>
+            {#if $kubernetesContextsState.get(context.name)?.reachable}
+              <div class="text-xs bg-charcoal-800 p-2 rounded-lg mt-1 grid grid-cols-6">
+                <span class="my-auto font-bold col-span-1 text-right">Pods</span>
+                <span class="my-auto col-span-5 text-left pl-0.5 ml-3" aria-label="context-namespace"
+                  >{$kubernetesContextsState.get(context.name)?.podsCount}</span>
+              </div>
+            {/if}
           {/if}
         </div>
       </div>

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
@@ -98,7 +98,7 @@ async function handleDeleteContext(contextName: string) {
         <div class="grow flex-column divide-gray-900 text-gray-400">
           <div class="flex flex-row">
             {#if $kubernetesContextsState.get(context.name)}
-              <div class="flex-none w-48">
+              <div class="flex-none w-36">
                 {#if $kubernetesContextsState.get(context.name)?.reachable}
                   <div class="flex flex-row pt-2">
                     <div class="w-3 h-3 rounded-full bg-green-500"></div>
@@ -115,12 +115,6 @@ async function handleDeleteContext(contextName: string) {
                       <div class="font-bold text-[9px] text-gray-800">DEPLOYMENTS</div>
                       <div class="text-[16px] text-white">
                         {$kubernetesContextsState.get(context.name)?.deploymentsCount}
-                      </div>
-                    </div>
-                    <div class="text-center">
-                      <div class="font-bold text-[9px] text-gray-800">REPLICASETS</div>
-                      <div class="text-[16px] text-white">
-                        {$kubernetesContextsState.get(context.name)?.replicasetsCount}
                       </div>
                     </div>
                   </div>

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
@@ -96,46 +96,72 @@ async function handleDeleteContext(contextName: string) {
           {/if}
         </div>
         <div class="grow flex-column divide-gray-900 text-gray-400">
-          <div class="text-xs bg-charcoal-800 p-2 rounded-lg mt-1 grid grid-cols-6">
-            <span class="my-auto font-bold col-span-1 text-right">CLUSTER</span>
-            <span class="my-auto col-span-5 text-left pl-0.5 ml-3" aria-label="context-cluster">{context.cluster}</span>
-          </div>
-
-          {#if context.clusterInfo !== undefined}
-            <div class="text-xs bg-charcoal-800 p-2 rounded-lg mt-1 grid grid-cols-6">
-              <span class="my-auto font-bold col-span-1 text-right">SERVER</span>
-              <span class="my-auto col-span-5 text-left ml-3">
-                {context.clusterInfo.server}
-              </span>
-            </div>
-          {/if}
-
-          <div class="text-xs bg-charcoal-800 p-2 rounded-lg mt-1 grid grid-cols-6">
-            <span class="my-auto font-bold col-span-1 text-right">USER</span>
-            <span class="my-auto col-span-5 text-left pl-0.5 ml-3" aria-label="context-user">{context.user}</span>
-          </div>
-
-          {#if context.namespace}
-            <div class="text-xs bg-charcoal-800 p-2 rounded-lg mt-1 grid grid-cols-6">
-              <span class="my-auto font-bold col-span-1 text-right">NAMESPACE</span>
-              <span class="my-auto col-span-5 text-left pl-0.5 ml-3" aria-label="context-namespace"
-                >{context.namespace}</span>
-            </div>
-          {/if}
-          {#if $kubernetesContextsState.get(context.name)}
-            <div class="text-xs bg-charcoal-800 p-2 rounded-lg mt-1 grid grid-cols-6">
-              <span class="my-auto font-bold col-span-1 text-right">Reachable</span>
-              <span class="my-auto col-span-5 text-left pl-0.5 ml-3" aria-label="context-namespace"
-                >{$kubernetesContextsState.get(context.name)?.reachable}</span>
-            </div>
-            {#if $kubernetesContextsState.get(context.name)?.reachable}
-              <div class="text-xs bg-charcoal-800 p-2 rounded-lg mt-1 grid grid-cols-6">
-                <span class="my-auto font-bold col-span-1 text-right">Pods</span>
-                <span class="my-auto col-span-5 text-left pl-0.5 ml-3" aria-label="context-namespace"
-                  >{$kubernetesContextsState.get(context.name)?.podsCount}</span>
+          <div class="flex flex-row">
+            {#if $kubernetesContextsState.get(context.name)}
+              <div class="flex-none w-48">
+                {#if $kubernetesContextsState.get(context.name)?.reachable}
+                  <div class="flex flex-row pt-2">
+                    <div class="w-3 h-3 rounded-full bg-green-500"></div>
+                    <div class="ml-1 font-bold text-[9px] text-green-500">REACHABLE</div>
+                  </div>
+                  <div class="flex flex-row gap-4 mt-4">
+                    <div class="text-center">
+                      <div class="font-bold text-[9px] text-gray-800">PODS</div>
+                      <div class="text-[16px] text-white">
+                        {$kubernetesContextsState.get(context.name)?.podsCount}
+                      </div>
+                    </div>
+                    <div class="text-center">
+                      <div class="font-bold text-[9px] text-gray-800">DEPLOYMENTS</div>
+                      <div class="text-[16px] text-white">
+                        {$kubernetesContextsState.get(context.name)?.podsCount}
+                      </div>
+                    </div>
+                    <div class="text-center">
+                      <div class="font-bold text-[9px] text-gray-800">REPLICASETS</div>
+                      <div class="text-[16px] text-white">
+                        {$kubernetesContextsState.get(context.name)?.podsCount}
+                      </div>
+                    </div>
+                  </div>
+                {:else}
+                  <div class="flex flex-row pt-2">
+                    <div class="w-3 h-3 rounded-full bg-gray-900"></div>
+                    <div class="ml-1 font-bold text-[9px] text-gray-900">UNREACHABLE</div>
+                  </div>
+                {/if}
               </div>
             {/if}
-          {/if}
+            <div class="grow">
+              <div class="text-xs bg-charcoal-800 p-2 rounded-lg mt-1 grid grid-cols-6">
+                <span class="my-auto font-bold col-span-1 text-right">CLUSTER</span>
+                <span class="my-auto col-span-5 text-left pl-0.5 ml-3" aria-label="context-cluster"
+                  >{context.cluster}</span>
+              </div>
+
+              {#if context.clusterInfo !== undefined}
+                <div class="text-xs bg-charcoal-800 p-2 rounded-lg mt-1 grid grid-cols-6">
+                  <span class="my-auto font-bold col-span-1 text-right">SERVER</span>
+                  <span class="my-auto col-span-5 text-left ml-3">
+                    {context.clusterInfo.server}
+                  </span>
+                </div>
+              {/if}
+
+              <div class="text-xs bg-charcoal-800 p-2 rounded-lg mt-1 grid grid-cols-6">
+                <span class="my-auto font-bold col-span-1 text-right">USER</span>
+                <span class="my-auto col-span-5 text-left pl-0.5 ml-3" aria-label="context-user">{context.user}</span>
+              </div>
+
+              {#if context.namespace}
+                <div class="text-xs bg-charcoal-800 p-2 rounded-lg mt-1 grid grid-cols-6">
+                  <span class="my-auto font-bold col-span-1 text-right">NAMESPACE</span>
+                  <span class="my-auto col-span-5 text-left pl-0.5 ml-3" aria-label="context-namespace"
+                    >{context.namespace}</span>
+                </div>
+              {/if}
+            </div>
+          </div>
         </div>
       </div>
     {/each}

--- a/packages/renderer/src/stores/kubernetes-contexts-state.ts
+++ b/packages/renderer/src/stores/kubernetes-contexts-state.ts
@@ -17,7 +17,7 @@
  ***********************************************************************/
 
 import { readable } from 'svelte/store';
-import type { ContextState } from '../../../main/src/plugin/kubernetes-client';
+import type { ContextState } from '../../../main/src/plugin/kubernetes-context-state';
 
 export const kubernetesContextsState = readable(new Map<string, ContextState>(), set => {
   window.kubernetesGetContextsState().then(value => set(value));

--- a/packages/renderer/src/stores/kubernetes-contexts-state.ts
+++ b/packages/renderer/src/stores/kubernetes-contexts-state.ts
@@ -1,0 +1,27 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { readable } from 'svelte/store';
+import type { ContextState } from '../../../main/src/plugin/kubernetes-client';
+
+export const kubernetesContextsState = readable(new Map<string, ContextState>(), set => {
+  window.kubernetesGetContextsState().then(value => set(value));
+  window.events?.receive('kubernetes-contexts-state-update', (value: Map<string, ContextState>) => {
+    set(value);
+  });
+});

--- a/packages/renderer/src/stores/kubernetes-contexts-state.ts
+++ b/packages/renderer/src/stores/kubernetes-contexts-state.ts
@@ -21,7 +21,7 @@ import type { ContextState } from '../../../main/src/plugin/kubernetes-context-s
 
 export const kubernetesContextsState = readable(new Map<string, ContextState>(), set => {
   window.kubernetesGetContextsState().then(value => set(value));
-  window.events?.receive('kubernetes-contexts-state-update', (value: Map<string, ContextState>) => {
-    set(value);
+  window.events?.receive('kubernetes-contexts-state-update', (value: unknown) => {
+    set(value as Map<string, ContextState>);
   });
 });


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

- adds a new boolean Preference entry `Get information about clusters declared in Kubeconfig`, to enable / disable the running of informers watching pods/deployments/replicasets for different kube contexts
- if enabled, the kubernetes client singleton manages a state of informers for the different contexts (stops informers of delete contexts, starts new informers for new contexts)
- if enabled, displays in the list of kube contexts if the cluster is reachable, and the number of current pods/deployemnts/replicasets for each kube context

### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

#4562

<!-- Include any related issues from Podman Desktop 
repository (or from another issue tracker). -->

### How to test this PR?

- Enable the feature in the Preferences
- Switch contexts and check information is updated
- add/remove resources (pods, deployments) from context and check information is updated
- 
<!-- Please explain steps to reproduce -->
