### PR TITLE
fix: stop provider card overflow

### DIFF
--- a/packages/renderer/src/lib/dashboard/ProviderCard.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderCard.svelte
@@ -10,7 +10,7 @@ export let provider: ProviderInfo;
 <div class="bg-charcoal-800 mb-5 rounded-md p-3 flex-nowrap" role="region" aria-label="{provider.name} Provider">
   <div class="flex flex-row">
     <div class="flex flex-row">
-      <IconImage image="{provider?.images?.icon}" class="mx-auto max-h-12" alt="{provider.name}"></IconImage>
+      <IconImage image="{provider?.images?.icon}" class="max-h-12" alt="{provider.name}"></IconImage>
       <div class="flex flex-col text-gray-400 ml-3 whitespace-nowrap" aria-label="context-name">
         <div class="flex flex-row items-center">
           {provider.name}
@@ -25,7 +25,7 @@ export let provider: ProviderInfo;
         </div>
       </div>
     </div>
-    <div class="flex flex-col items-center text-center flex-grow">
+    <div class="flex flex-col items-center text-center grow">
       <slot name="content" />
     </div>
   </div>

--- a/packages/renderer/src/lib/dashboard/ProviderConfigured.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderConfigured.svelte
@@ -48,11 +48,8 @@ onMount(() => {
 
 <ProviderCard provider="{provider}">
   <svelte:fragment slot="content">
-    <p class="text-base text-gray-700">
-      To start working with containers, {provider.name}
-      {#if provider.version}
-        v{provider.version}
-      {/if} needs to be started.
+    <p class="text-base text-gray-700 max-w-xs">
+      To start working with containers, {provider.name} needs to be started.
     </p>
 
     {#if !runAtStart && !runInProgress}

--- a/packages/renderer/src/lib/dashboard/ProviderInstalled.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderInstalled.svelte
@@ -135,7 +135,7 @@ function onInstallationClick() {
 
 <ProviderCard provider="{provider}">
   <svelte:fragment slot="content">
-    <p class="text-base text-gray-700" aria-label="Suggested Actions">
+    <p class="text-base text-gray-700 max-w-xs" aria-label="Suggested Actions">
       To start working with containers, {provider.name} needs to be initialized.
     </p>
 

--- a/packages/renderer/src/lib/dashboard/ProviderNotInstalled.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderNotInstalled.svelte
@@ -15,7 +15,7 @@ let preflightChecks: CheckStatus[] = [];
 
 <ProviderCard provider="{provider}">
   <svelte:fragment slot="content">
-    <p class="text-base text-gray-700" aria-label="Suggested Actions">
+    <p class="text-base text-gray-700 max-w-xs" aria-label="Suggested Actions">
       Could not find an installation. To start working with containers, {provider.name} needs to be detected/installed.
     </p>
     <div class="mt-5 mb-1 w-full flex justify-around">


### PR DESCRIPTION
### What does this PR do?

Small tweaks to ProviderCard to make sure the icon margin isn't growing and right column is growing correctly. Uses max-w-xs to limit the width of the right column wherever text was not wrapping correctly. Removes redundant provider version from the configured state.

Even with these changes it is still possible to get overlap when the window is between 640px (the minimum) and 690px wide. We're at the point where the required content does not fit the current design. If anyone else has a suggestion I'm willing to try it, but IMHO it may not be worth it as this is more of an extreme/edge case now, and we've been waiting for a couple sprints now on a design for moving some of the actions to other places like Resources.

Since this is visual overlap of elements not staying within their flex layout I can't think of any useful tests.

### Screenshot / video of UI

Before
<img width="638" alt="Screenshot 2023-12-19 at 10 42 23 PM" src="https://github.com/containers/podman-desktop/assets/19958075/56f56e7c-68ea-4bde-8fe1-045631753e3a">

After:
<img width="638" alt="Screenshot 2023-12-19 at 10 42 04 PM" src="https://github.com/containers/podman-desktop/assets/19958075/1a40bf72-2bc3-4a36-baab-410c8b68b640">

### What issues does this PR fix or reference?

Fixes #5316 (mostly).

### How to test this PR?

Just make the window narrow.