### PR TITLE
feat: table update event passthrough

### DIFF
--- a/packages/renderer/src/lib/table/Table.spec.ts
+++ b/packages/renderer/src/lib/table/Table.spec.ts
@@ -17,7 +17,7 @@
  ***********************************************************************/
 
 import '@testing-library/jest-dom/vitest';
-import { test, expect } from 'vitest';
+import { test, expect, vi } from 'vitest';
 import { fireEvent, render, screen, within } from '@testing-library/svelte';
 
 import TestTable from './TestTable.svelte';
@@ -231,4 +231,17 @@ test('Expect overflow-hidden', async () => {
     expect(cells[4]).not.toHaveClass('overflow-hidden');
     expect(cells[5]).toHaveClass('overflow-hidden');
   }
+});
+
+test('Expect update callback', async () => {
+  const callback = vi.fn();
+  const result = render(TestTable);
+  result.component.$on('update', callback);
+
+  const ageCol = await screen.findByRole('columnheader', { name: 'Age' });
+  expect(ageCol).toBeDefined();
+
+  await fireEvent.click(ageCol);
+
+  expect(callback).toHaveBeenCalled();
 });

--- a/packages/renderer/src/lib/table/Table.svelte
+++ b/packages/renderer/src/lib/table/Table.svelte
@@ -189,7 +189,8 @@ function setGridColumns() {
             {#if column.info.renderer}
               <svelte:component
                 this="{column.info.renderer}"
-                object="{column.info.renderMapping?.(object) ?? object}" />
+                object="{column.info.renderMapping?.(object) ?? object}"
+                on:update />
             {/if}
           </div>
         {/each}

--- a/packages/renderer/src/lib/table/TestTable.svelte
+++ b/packages/renderer/src/lib/table/TestTable.svelte
@@ -2,9 +2,12 @@
 import Table from './Table.svelte';
 import { Column, Row } from './table';
 import SimpleColumn from './SimpleColumn.svelte';
+import { createEventDispatcher } from 'svelte';
 
 let table: Table;
 let selectedItemsNumber: number;
+
+const dispatch = createEventDispatcher<{ update: string }>();
 
 type Person = {
   id: number;
@@ -37,7 +40,10 @@ const ageCol: Column<Person, string> = new Column('Age', {
   align: 'right',
   renderMapping: obj => obj.age.toString(),
   renderer: SimpleColumn,
-  comparator: (a, b) => a.age - b.age,
+  comparator: (a, b) => {
+    dispatch('update', 'sorting');
+    return a.age - b.age;
+  },
   initialOrder: 'descending',
   overflow: true,
 });
@@ -62,5 +68,6 @@ const row = new Row<Person>({
   data="{people}"
   columns="{columns}"
   row="{row}"
-  defaultSortColumn="Id">
+  defaultSortColumn="Id"
+  on:update>
 </Table>


### PR DESCRIPTION
### What does this PR do?

The pods and containers list use an update event (previously callbacks) to let the parent page know that one column has triggered a change that requires a UI refresh in other columns. As we move to the table component there is an additional level of components, so we just need this event to pass through the table component.

This change just allows the table to pass through update events. To test the age column was changed to trigger a callback whenever it is sorted.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

N/A, required by #4842.

### How to test this PR?

`yarn test:renderer`