### PR TITLE
docs: message when the app terminates because another instance exists

### DIFF
--- a/packages/main/src/index.ts
+++ b/packages/main/src/index.ts
@@ -48,6 +48,7 @@ const additionalData: AdditionalData = {
 // provide additional data to the second instance
 const isSingleInstance = app.requestSingleInstanceLock(additionalData);
 if (!isSingleInstance) {
+  console.log('An instance of Podman Desktop is already running. Stopping');
   app.quit();
   process.exit(0);
 }

--- a/packages/main/src/index.ts
+++ b/packages/main/src/index.ts
@@ -48,7 +48,7 @@ const additionalData: AdditionalData = {
 // provide additional data to the second instance
 const isSingleInstance = app.requestSingleInstanceLock(additionalData);
 if (!isSingleInstance) {
-  console.log('An instance of Podman Desktop is already running. Stopping');
+  console.warn('An instance of Podman Desktop is already running. Stopping');
   app.quit();
   process.exit(0);
 }


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

This PR adds a message on the console before the app terminates when an instance already exists.

I needed a few hours to understand why my debug sessions were failing on Windows. I had installed a production version of Podman Desktop, and didn't realize it was running in the background, and prevented from starting other development sessions.

This message would help me or other people understand more easily the next time it happens.
