### PR TITLE
chore: reduce extraneous test output

### DIFF
--- a/packages/renderer/src/lib/pod/DeployPodToKube.spec.ts
+++ b/packages/renderer/src/lib/pod/DeployPodToKube.spec.ts
@@ -121,7 +121,7 @@ afterEach(() => {
 });
 
 async function waitRender(customProperties: any): Promise<void> {
-  const result = render(DeployPodToKube, { resourceId: 'foo', engineId: 'bar', ...customProperties });
+  const result = render(DeployPodToKube, { resourceId: 'foo', engineId: 'bar', type: 'unknown', ...customProperties });
   // wait that result.component.$$.ctx[0] is set
   while (result.component.$$.ctx[0] === undefined) {
     await new Promise(resolve => setTimeout(resolve, 100));

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.spec.ts
@@ -303,7 +303,6 @@ describe.each([
       pageIsLoading: false,
       taskId,
       hideCloseButton: true,
-      hideProviderImage: true,
     });
 
     const closeButton = screen.queryByRole('button', { name: 'Close page' });

--- a/packages/renderer/src/lib/table/DurationColumn.spec.ts
+++ b/packages/renderer/src/lib/table/DurationColumn.spec.ts
@@ -20,13 +20,13 @@ import '@testing-library/jest-dom/vitest';
 import { test, expect } from 'vitest';
 import { render, screen } from '@testing-library/svelte';
 
-import SimpleDurationColumn from './DurationColumn.svelte';
+import DurationColumn from './DurationColumn.svelte';
 
 test('Expect simple column styling', async () => {
   // pick a date an hour ago
   const date = new Date();
   date.setTime(date.getTime() - 3600000);
-  render(SimpleDurationColumn, { object: date });
+  render(DurationColumn, { object: date });
 
   const text = screen.getByText('1 hour');
   expect(text).toBeInTheDocument();
@@ -35,57 +35,57 @@ test('Expect simple column styling', async () => {
 });
 
 test('Expect 2s refresh on values less than a minute', async () => {
-  const { component } = render(SimpleDurationColumn);
+  const { component } = render(DurationColumn, { object: undefined });
   expect(component.computeInterval(500)).toEqual(2000);
 });
 
 test('Expect 2s refresh on values less than a minute (2)', async () => {
-  const { component } = render(SimpleDurationColumn);
+  const { component } = render(DurationColumn, { object: undefined });
   expect(component.computeInterval(53400)).toEqual(2000);
 });
 
 test('Expect to refresh 59.9s on next minute', async () => {
-  const { component } = render(SimpleDurationColumn);
+  const { component } = render(DurationColumn, { object: undefined });
   // 59.999s = should refresh in 1ms
   expect(component.computeInterval(59999)).toEqual(1);
 });
 
 test('Expect to refresh 60s on next minute', async () => {
-  const { component } = render(SimpleDurationColumn);
+  const { component } = render(DurationColumn, { object: undefined });
   // 60s = 1m - should refresh in 1m
   expect(component.computeInterval(60000)).toEqual(60000);
 });
 
 test('Expect to refresh 61s on next minute', async () => {
-  const { component } = render(SimpleDurationColumn);
+  const { component } = render(DurationColumn, { object: undefined });
   // 61s = 1m1s - should refresh in 59s
   expect(component.computeInterval(61000)).toEqual(59000);
 });
 
 test('Expect to refresh 89s on next minute', async () => {
-  const { component } = render(SimpleDurationColumn);
+  const { component } = render(DurationColumn, { object: undefined });
   // 89s = 1m19s - should refresh in 31s (at 2m)
   expect(component.computeInterval(89000)).toEqual(31000);
 });
 
 test('Expect to refresh 1h on next hour', async () => {
-  const { component } = render(SimpleDurationColumn);
+  const { component } = render(DurationColumn, { object: undefined });
   // 362s = 1h2s - should refresh in 58m (at 2h)
   expect(component.computeInterval(3600000)).toEqual(60 * 60000);
 });
 
 test('Expect to refresh 3h25m on next hour', async () => {
-  const { component } = render(SimpleDurationColumn);
+  const { component } = render(DurationColumn, { object: undefined });
   // 3h25m - should refresh in 35m (at 4h)
   expect(component.computeInterval(12300000)).toEqual(2100000);
 });
 
 test('Expect to refresh 1d on next day', async () => {
-  const { component } = render(SimpleDurationColumn);
+  const { component } = render(DurationColumn, { object: undefined });
   expect(component.computeInterval(86400000)).toEqual(86400000);
 });
 
 test('Expect to refresh 1d1m on next day', async () => {
-  const { component } = render(SimpleDurationColumn);
+  const { component } = render(DurationColumn, { object: undefined });
   expect(component.computeInterval(86460000)).toEqual(86340000);
 });

--- a/packages/renderer/src/lib/ui/EmptyScreen.spec.ts
+++ b/packages/renderer/src/lib/ui/EmptyScreen.spec.ts
@@ -27,7 +27,7 @@ import EmptyScreen from './EmptyScreen.svelte';
 test('Expect copy in clipboard', async () => {
   const mock = vi.fn().mockImplementation(() => {});
   (window as any).clipboardWriteText = mock;
-  render(EmptyScreen, { commandline: 'podman run hello:world' });
+  render(EmptyScreen, { icon: '', commandline: 'podman run hello:world' });
   const button = screen.getByRole('button');
   expect(button).toBeInTheDocument();
   expect(button).toBeEnabled();


### PR DESCRIPTION
### What does this PR do?

I noticed several lines of unnecessary output during yarn test:renderer, just adding missing properties to Svelte component tests to reduce the output. Removes the following messages:

```
<DeployPodToKube> was created without expected prop 'type'
<DurationColumn> was created without expected prop 'object'
<EmptyScreen> was created without expected prop 'icon'
<PreferencesConnectionCreationOrEditRendering> was created with unknown prop 'hideProviderImage'
```

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Same results, less output from `yarn test:renderer`