### PR TITLE
chore: add `joinPath` + `with` methods on Uri extension point

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -1221,6 +1221,16 @@ declare module '@podman-desktop/api' {
     static file(path: string): Uri;
 
     /**
+     * Create a new uri which path is the result of joining
+     * the path of the base uri with the provided path segments.
+     *
+     * @param base An uri. Must have a path.
+     * @param pathSegments One more more path fragments
+     * @returns A new uri which path is joined with the given fragments
+     */
+    static joinPath(base: Uri, ...pathSegments: string[]): Uri;
+
+    /**
      * Use the `file` and `parse` factory functions to create new `Uri` objects.
      */
     private constructor(scheme: string, authority: string, path: string, query: string, fragment: string);

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -1267,6 +1267,43 @@ declare module '@podman-desktop/api' {
      */
     readonly fragment: string;
 
+    /**
+     * Derive a new Uri from this Uri.
+     *
+     * ```ts
+     * const foo = Uri.parse('http://foo');
+     * const httpsFoo = foo.with({ scheme: 'https' });
+     * // httpsFoo is now 'https://foo'
+     * ```
+     *
+     * @param change An object that describes a change to this Uri. To unset components use `undefined` or
+     *  the empty string.
+     * @returns A new Uri that reflects the given change. Will return `this` Uri if the change
+     *  is not changing anything.
+     */
+    with(change: {
+      /**
+       * The new scheme, defaults to this Uri's scheme.
+       */
+      scheme?: string;
+      /**
+       * The new authority, defaults to this Uri's authority.
+       */
+      authority?: string;
+      /**
+       * The new path, defaults to this Uri's path.
+       */
+      path?: string;
+      /**
+       * The new query, defaults to this Uri's query.
+       */
+      query?: string;
+      /**
+       * The new fragment, defaults to this Uri's fragment.
+       */
+      fragment?: string;
+    }): Uri;
+
     toString(): string;
   }
 

--- a/packages/main/src/plugin/types/uri.spec.ts
+++ b/packages/main/src/plugin/types/uri.spec.ts
@@ -49,3 +49,49 @@ test('toString', () => {
   const uri = Uri.parse('https://podman-desktop.io');
   expect(uri.toString()).toBe('https://podman-desktop.io/');
 });
+
+test('joinPath without path', () => {
+  const uri = Uri.parse('https://podman-desktop.io');
+
+  // delete path for the error
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  delete (uri as any)._path;
+
+  expect(() => Uri.joinPath(uri, 'foo')).toThrowError('cannot call joinPath on Uri without a path');
+});
+
+test.each([
+  ['file:///foo/', '../../bar', 'file:///bar'],
+  ['file:///foo', '../../bar', 'file:///bar'],
+  ['file:///foo/bar', './baz', 'file:///foo/bar/baz'],
+  ['http://foo', 'bar', 'http://foo/bar'],
+  ['https://foo', 'bar', 'https://foo/bar'],
+])('joinPath %s %s', (left, right, expected) => {
+  const leftUri = Uri.parse(left);
+  const joinPathUri = Uri.joinPath(leftUri, right);
+  expect(joinPathUri.toString()).toBe(expected);
+});
+
+test('Uri.with without any change should return same object', () => {
+  const uri = Uri.parse('https://podman-desktop.io');
+
+  const updatedUri = uri.with();
+
+  expect(updatedUri).toBe(uri);
+});
+
+test('Uri.with and undefined path', () => {
+  const uri = Uri.parse('https://podman-desktop.io');
+
+  const updatedUri = uri.with({ scheme: 'http' });
+
+  expect(updatedUri.scheme).toBe('http');
+});
+
+test('Uri.with and same change', () => {
+  const uri = Uri.parse('https://podman-desktop.io');
+
+  const updatedUri = uri.with({ scheme: 'https', authority: 'podman-desktop.io', path: '/', query: '', fragment: '' });
+
+  expect(updatedUri).toBe(uri);
+});


### PR DESCRIPTION
Signed-off-by: Florent Benoit <fbenoit@redhat.com>

### What does this PR do?
add/expose static `joinPath` and `with` methods

### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/5359

### How to test this PR?

unit tests provided