### PR TITLE
chore: check for install on every step of compose onboarding

### DIFF
--- a/extensions/compose/package.json
+++ b/extensions/compose/package.json
@@ -46,7 +46,7 @@
           "id": "welcomeDownloadView",
           "label": "Compose Download",
           "title": "Compose Download",
-          "when": "onboardingContext:composeIsNotDownloaded == true",
+          "when": "!compose.isComposeInstalledSystemWide && onboardingContext:composeIsNotDownloaded",
           "content": [
             [
               {
@@ -71,7 +71,7 @@
           "id": "downloadCommand",
           "title": "Downloading Compose ${onboardingContext:composeDownloadVersion}",
           "description": "Downloading the binary.\n\nOnce downloaded, the next step will install Compose system-wide.",
-          "when": "onboardingContext:composeIsNotDownloaded == true",
+          "when": "!compose.isComposeInstalledSystemWide && onboardingContext:composeIsNotDownloaded",
           "command": "compose.onboarding.downloadCommand",
           "completionEvents": [
             "onCommand:compose.onboarding.downloadCommand"
@@ -80,13 +80,13 @@
         {
           "id": "downloadFailure",
           "title": "Failed Downloading Compose",
-          "when": "onboardingContext:composeIsNotDownloaded == true",
+          "when": "!compose.isComposeInstalledSystemWide && onboardingContext:composeIsNotDownloaded",
           "state": "failed"
         },
         {
           "id": "downloadSuccessfulView",
           "title": "Compose Successfully Downloaded",
-          "when": "onboardingContext:composeIsNotDownloaded == false",
+          "when": "!compose.isComposeInstalledSystemWide && !onboardingContext:composeIsNotDownloaded",
           "content": [
             [
               {
@@ -99,7 +99,7 @@
           "id": "installSystemWideCommand",
           "title": "Install Compose",
           "description": "Installing the binary system-wide.\n\n You may be prompted for elevated system privileges.",
-          "when": "compose.isComposeInstalledSystemWide == false",
+          "when": "!compose.isComposeInstalledSystemWide && !compose.isComposeInstalledSystemWide",
           "command": "compose.onboarding.installSystemWideCommand",
           "completionEvents": [
             "onCommand:compose.onboarding.installSystemWideCommand"
@@ -108,18 +108,18 @@
         {
           "id": "installSystemWideFailure",
           "title": "Failed Installing Compose",
-          "when": "compose.isComposeInstalledSystemWide == false",
+          "when": "!compose.isComposeInstalledSystemWide && !compose.isComposeInstalledSystemWide",
           "state": "failed"
         },
         {
           "id": "installSystemWideSuccess",
-          "title": "Compose Successfully Installed",
-          "when": "compose.isComposeInstalledSystemWide == true",
+          "title": "Compose Installed",
+          "when": "compose.isComposeInstalledSystemWide",
           "state": "completed",
           "content": [
             [
               {
-                "value": "Compose has been successfully installed system-wide!"
+                "value": "Compose is installed system-wide!"
               }
             ],
             [


### PR DESCRIPTION
chore: check for install on every step of compose onboarding

### What does this PR do?

* When going through the onboarding sequence, similar to the Podman
  onboarding, we should be checking to see if compose has already been
  installed.
* Allows you to re-run the setup and get to the "compose installed"
  page.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

https://github.com/containers/podman-desktop/assets/6422176/0aaf44aa-bb4c-48ab-969d-877a219d2c26




### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop/issues/5346

### How to test this PR?

1. Edit compose/package.json to `enablement: "true"` so you can see it
   in the Resources page
2. Click on `Setup ...` it should take you to the last page (Compose is
   installed).

<!-- Please explain steps to reproduce -->

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
