### PR TITLE
chore: check kubectl installation on each onboarding step

### DIFF
--- a/extensions/kubectl-cli/package.json
+++ b/extensions/kubectl-cli/package.json
@@ -46,7 +46,7 @@
           "id": "welcomeDownloadView",
           "label": "kubectl Download",
           "title": "kubectl Download",
-          "when": "onboardingContext:kubectlIsNotDownloaded == true",
+          "when": "!kubectl.isKubectlInstalledSystemWide && onboardingContext:kubectlIsNotDownloaded",
           "content": [
             [
               {
@@ -65,7 +65,7 @@
           "id": "downloadCommand",
           "title": "Downloading kubectl ${onboardingContext:kubectlDownloadVersion}",
           "description": "Downloading the binary.\n\nOnce downloaded, the next step will install kubectl system-wide.",
-          "when": "onboardingContext:kubectlIsNotDownloaded == true",
+          "when": "!kubectl.isKubectlInstalledSystemWide && onboardingContext:kubectlIsNotDownloaded",
           "command": "kubectl.onboarding.downloadCommand",
           "completionEvents": [
             "onCommand:kubectl.onboarding.downloadCommand"
@@ -74,17 +74,17 @@
         {
           "id": "downloadFailure",
           "title": "Failed Downloading kubectl",
-          "when": "onboardingContext:kubectlIsNotDownloaded == true",
+          "when": "!kubectl.isKubectlInstalledSystemWide && onboardingContext:kubectlIsNotDownloaded",
           "state": "failed"
         },
         {
           "id": "downloadSuccessfulView",
           "title": "kubectl Successfully Downloaded",
-          "when": "onboardingContext:kubectlIsNotDownloaded == false",
+          "when": "!kubectl.isKubectlInstalledSystemWide && !onboardingContext:kubectlIsNotDownloaded",
           "content": [
             [
               {
-                "value": "kubectl has been successfully downloaded! In order to use kubectl from a shell, it is required for kubectl to be installed system-wide.\n\nThe next step will install kubectl system-wide. **You will be prompted for system privileges when enabling this.**"
+                "value": "kubectl has been successfully downloaded! In order to use kubectl from the terminal, it is required for kubectl to be installed system-wide.\n\nThe next step will install kubectl system-wide. **You will be prompted for system privileges when enabling this.**"
               }
             ]
           ]
@@ -93,7 +93,7 @@
           "id": "installSystemWideCommand",
           "title": "Install kubectl",
           "description": "Installing the binary system-wide.\n\n You may be prompted for elevated system privileges.",
-          "when": "kubectl.isKubectlInstalledSystemWide == false",
+          "when": "!kubectl.isKubectlInstalledSystemWide && !kubectl.isKubectlInstalledSystemWide",
           "command": "kubectl.onboarding.installSystemWideCommand",
           "completionEvents": [
             "onCommand:kubectl.onboarding.installSystemWideCommand"
@@ -102,18 +102,24 @@
         {
           "id": "installSystemWideFailure",
           "title": "Failed Installing kubectl",
-          "when": "kubectl.isKubectlInstalledSystemWide == false",
+          "when": "!kubectl.isKubectlInstalledSystemWide && !kubectl.isKubectlInstalledSystemWide",
           "state": "failed"
         },
         {
           "id": "installSystemWideSuccess",
           "title": "kubectl Successfully Installed",
-          "when": "kubectl.isKubectlInstalledSystemWide == true",
+          "when": "kubectl.isKubectlInstalledSystemWide",
           "state": "completed",
           "content": [
             [
               {
                 "value": "kubectl has been successfully installed system-wide!"
+              }
+            ],
+            [
+              {
+                "value": "#### How to use kubectl \nRun `kubectl help` in the terminal for a list of commands to interact with your Kubernetes cluster. For example, try the 'Deploy to Kubernetes' button within Podman Desktop and view your pods with `kubectl`:\n\n`$ kubectl get pods`",
+                "highlight": true
               }
             ]
           ]


### PR DESCRIPTION
chore: check kubectl installation on each onboarding step

### What does this PR do?

* Similar to Podman onboarding, check that it has been installed on
  every step. This allows you to reach the last page if you happen to
  have accidently pressed the onboarding sequence again.
* Update the last page to give a small tutorial on how to use `kubectl`
  similar to compose

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

https://github.com/containers/podman-desktop/assets/6422176/f0cb0995-8b3f-4797-8c43-8a1695bfd80c




### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes  https://github.com/containers/podman-desktop/issues/5347

### How to test this PR?

<!-- Please explain steps to reproduce -->

1. Edit kubectl-cli/package.json enablement to: `enablement: "true"` so
   it shows it in resources
2. Click on the onboarding sequence

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
