### PR TITLE
Kubernetes Services Page

### DIFF
--- a/packages/main/src/plugin/api/kubernetes-informer-info.ts
+++ b/packages/main/src/plugin/api/kubernetes-informer-info.ts
@@ -17,7 +17,7 @@
  ***********************************************************************/
 import type { Context, Informer, KubernetesObject } from '@kubernetes/client-node';
 
-export type KubernetesInformerResourcesType = 'INGRESS';
+export type KubernetesInformerResourcesType = 'DEPLOYMENT' | 'INGRESS' | 'ROUTE' | 'SERVICE';
 
 export interface KubernetesInformerInfo {
   informer: Informer<KubernetesObject>;

--- a/packages/main/src/plugin/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes-client.ts
@@ -32,6 +32,7 @@ import type {
   V1Deployment,
   KubernetesObject,
   ListPromise,
+  KubernetesListObject,
 } from '@kubernetes/client-node';
 import {
   ApisApi,
@@ -63,6 +64,7 @@ import * as jsYaml from 'js-yaml';
 import type { KubeContext } from './kubernetes-context.js';
 import type { KubernetesInformerManager } from './kubernetes-informer-registry.js';
 import type { KubernetesInformerResourcesType } from './api/kubernetes-informer-info.js';
+import type { IncomingMessage } from 'node:http';
 
 function toContainerStatus(state: V1ContainerState | undefined): string {
   if (state) {
@@ -1134,19 +1136,20 @@ export class KubernetesClient {
   }
 
   async createRoutesInformer(_id?: number): Promise<number> {
-    // : Promise<{ response: http.IncomingMessage; body: V1IngressList;  }> {
-    // : Promise<{ response: http.IncomingMessage; body: object;  }> {
-    /*const ns = this.getCurrentNamespace();
+    const ns = this.getCurrentNamespace();
     if (ns) {
       const customObjectsApi = this.kubeConfig.makeApiClient(CustomObjectsApi);
       return this.makeKubernetesInformer<V1Route>(
         'ROUTE',
         '/apis/route.openshift.io/v1/namespaces/' + ns + '/routes',
-        //() => new Promise<{ response: {} as IncomingMessage, body: {KubernetesListObject<V1Route>} }>,
-        //customObjectsApi.listNamespacedCustomObject('route.openshift.io', 'v1', ns, 'routes').body as V1Route[],
-        id,
+        () =>
+          customObjectsApi.listNamespacedCustomObject('route.openshift.io', 'v1', ns, 'routes') as Promise<{
+            response: IncomingMessage;
+            body: KubernetesListObject<V1Route>;
+          }>,
+        _id,
       );
-    }*/
+    }
     throw new Error('no active namespace');
   }
 

--- a/packages/main/src/plugin/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes-client.ts
@@ -1135,7 +1135,7 @@ export class KubernetesClient {
     throw new Error('no active namespace');
   }
 
-  async createRoutesInformer(_id?: number): Promise<number> {
+  async createRoutesInformer(id?: number): Promise<number> {
     const ns = this.getCurrentNamespace();
     if (ns) {
       const customObjectsApi = this.kubeConfig.makeApiClient(CustomObjectsApi);
@@ -1147,7 +1147,7 @@ export class KubernetesClient {
             response: IncomingMessage;
             body: KubernetesListObject<V1Route>;
           }>,
-        _id,
+        id,
       );
     }
     throw new Error('no active namespace');

--- a/packages/main/src/plugin/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes-client.ts
@@ -1105,6 +1105,20 @@ export class KubernetesClient {
     }
   }
 
+  async createDeploymentsInformer(id?: number): Promise<number> {
+    const ns = this.getCurrentNamespace();
+    if (ns) {
+      const k8sAppsApi = this.kubeConfig.makeApiClient(AppsV1Api);
+      return this.makeKubernetesInformer<V1Deployment>(
+        'DEPLOYMENT',
+        '/apis/apps/v1/namespaces/' + ns + '/deployments',
+        () => k8sAppsApi.listNamespacedDeployment(ns),
+        id,
+      );
+    }
+    throw new Error('no active namespace');
+  }
+
   async createIngressesInformer(id?: number): Promise<number> {
     const ns = this.getCurrentNamespace();
     if (ns) {
@@ -1119,10 +1133,50 @@ export class KubernetesClient {
     throw new Error('no active namespace');
   }
 
+  async createRoutesInformer(_id?: number): Promise<number> {
+    // : Promise<{ response: http.IncomingMessage; body: V1IngressList;  }> {
+    // : Promise<{ response: http.IncomingMessage; body: object;  }> {
+    /*const ns = this.getCurrentNamespace();
+    if (ns) {
+      const customObjectsApi = this.kubeConfig.makeApiClient(CustomObjectsApi);
+      return this.makeKubernetesInformer<V1Route>(
+        'ROUTE',
+        '/apis/route.openshift.io/v1/namespaces/' + ns + '/routes',
+        //() => new Promise<{ response: {} as IncomingMessage, body: {KubernetesListObject<V1Route>} }>,
+        //customObjectsApi.listNamespacedCustomObject('route.openshift.io', 'v1', ns, 'routes').body as V1Route[],
+        id,
+      );
+    }*/
+    throw new Error('no active namespace');
+  }
+
+  async createServicesInformer(id?: number): Promise<number> {
+    const ns = this.getCurrentNamespace();
+    if (ns) {
+      const k8sApi = this.kubeConfig.makeApiClient(CoreV1Api);
+      return this.makeKubernetesInformer<V1Service>(
+        'SERVICE',
+        '/api/v1/namespaces/' + ns + '/services',
+        () => k8sApi.listNamespacedService(ns),
+        id,
+      );
+    }
+    throw new Error('no active namespace');
+  }
+
   async startInformer(resourcesType: KubernetesInformerResourcesType, id?: number): Promise<number> {
     switch (resourcesType) {
+      case 'DEPLOYMENT': {
+        return this.createDeploymentsInformer(id);
+      }
       case 'INGRESS': {
         return this.createIngressesInformer(id);
+      }
+      case 'ROUTE': {
+        return this.createRoutesInformer(id);
+      }
+      case 'SERVICE': {
+        return this.createServicesInformer(id);
       }
     }
   }

--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -22,6 +22,7 @@ import AppNavigation from './AppNavigation.svelte';
 import VolumesList from './lib/volume/VolumesList.svelte';
 import VolumeDetails from './lib/volume/VolumeDetails.svelte';
 import DeploymentsList from './lib/deployments/DeploymentsList.svelte';
+import ServicesList from './lib/service/ServicesList.svelte';
 import KubePlayYAML from './lib/kube/KubePlayYAML.svelte';
 import PodDetails from './lib/pod/PodDetails.svelte';
 import ComposeDetails from './lib/compose/ComposeDetails.svelte';
@@ -164,6 +165,9 @@ window.events?.receive('display-troubleshooting', () => {
         </Route>
         <Route path="/deployments" breadcrumb="Deployments" navigationHint="root">
           <DeploymentsList />
+        </Route>
+        <Route path="/services" breadcrumb="Services" navigationHint="root">
+          <ServicesList />
         </Route>
         <Route path="/preferences/*" breadcrumb="Settings">
           <PreferencesPage />

--- a/packages/renderer/src/AppNavigation.svelte
+++ b/packages/renderer/src/AppNavigation.svelte
@@ -8,6 +8,7 @@ import { imagesInfos } from './stores/images';
 import { volumeListInfos } from './stores/volumes';
 import { kubernetesContexts } from './stores/kubernetes-contexts';
 import { deployments } from './stores/deployments';
+import { services } from './stores/services';
 import { ImageUtils } from './lib/image/image-utils';
 import type { ImageInfo } from '../../main/src/plugin/api/image-info';
 import ContainerIcon from './lib/images/ContainerIcon.svelte';
@@ -21,6 +22,7 @@ import type { Unsubscriber } from 'svelte/store';
 import NewContentOnDashboardBadge from './lib/dashboard/NewContentOnDashboardBadge.svelte';
 import SettingsIcon from './lib/images/SettingsIcon.svelte';
 import DashboardIcon from './lib/images/DashboardIcon.svelte';
+import ServiceIcon from './lib/images/ServiceIcon.svelte';
 
 let podInfoSubscribe: Unsubscriber;
 let containerInfoSubscribe: Unsubscriber;
@@ -28,6 +30,7 @@ let imageInfoSubscribe: Unsubscriber;
 let volumeInfoSubscribe: Unsubscriber;
 let contextsSubscribe: Unsubscriber;
 let deploymentsSubscribe: Unsubscriber;
+let servicesSubscribe: Unsubscriber;
 
 let podCount = '';
 let containerCount = '';
@@ -35,6 +38,7 @@ let imageCount = '';
 let volumeCount = '';
 let contextCount = 0;
 let deploymentCount = '';
+let serviceCount = '';
 
 const imageUtils = new ImageUtils();
 export let exitSettingsCallback: () => void;
@@ -79,6 +83,13 @@ onMount(async () => {
       deploymentCount = '';
     }
   });
+  servicesSubscribe = services.subscribe(value => {
+    if (value.length > 0) {
+      serviceCount = ' (' + value.length + ')';
+    } else {
+      serviceCount = '';
+    }
+  });
   contextsSubscribe = kubernetesContexts.subscribe(value => {
     contextCount = value.length;
   });
@@ -102,6 +113,9 @@ onDestroy(() => {
   }
   if (deploymentsSubscribe) {
     deploymentsSubscribe();
+  }
+  if (servicesSubscribe) {
+    servicesSubscribe();
   }
 });
 
@@ -143,6 +157,9 @@ export let meta: TinroRouteMeta;
   {#if contextCount > 0}
     <NavItem href="/deployments" tooltip="Deployments{deploymentCount}" ariaLabel="Deployments" bind:meta="{meta}">
       <DeploymentIcon size="24" />
+    </NavItem>
+    <NavItem href="/services" tooltip="Services{serviceCount}" ariaLabel="Services" bind:meta="{meta}">
+      <ServiceIcon size="24" />
     </NavItem>
   {/if}
 

--- a/packages/renderer/src/lib/service/ServiceActions.spec.ts
+++ b/packages/renderer/src/lib/service/ServiceActions.spec.ts
@@ -1,0 +1,58 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+import { test, expect, vi, beforeEach, afterEach } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import ServiceActions from './ServiceActions.svelte';
+import type { ServiceUI } from './ServiceUI';
+
+const updateMock = vi.fn();
+const deleteMock = vi.fn();
+
+const service: ServiceUI = {
+  name: 'my-service',
+  status: 'RUNNING',
+  namespace: '',
+  selected: false,
+  type: '',
+  clusterIP: '',
+  ports: '',
+};
+
+beforeEach(() => {
+  (window as any).kubernetesDeleteService = deleteMock;
+});
+
+afterEach(() => {
+  vi.resetAllMocks();
+  vi.clearAllMocks();
+});
+
+test('Expect no error and status deleting service', async () => {
+  const { component } = render(ServiceActions, { service });
+  component.$on('update', updateMock);
+
+  // click on delete button
+  const deleteButton = screen.getByRole('button', { name: 'Delete Service' });
+  await fireEvent.click(deleteButton);
+
+  expect(service.status).toEqual('DELETING');
+  expect(updateMock).toHaveBeenCalled();
+  expect(deleteMock).toHaveBeenCalled();
+});

--- a/packages/renderer/src/lib/service/ServiceActions.svelte
+++ b/packages/renderer/src/lib/service/ServiceActions.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+import { faTrash } from '@fortawesome/free-solid-svg-icons';
+import type { ServiceUI } from './ServiceUI';
+import ListItemButtonIcon from '../ui/ListItemButtonIcon.svelte';
+import { createEventDispatcher } from 'svelte';
+
+export let service: ServiceUI;
+export let detailed = false;
+
+const dispatch = createEventDispatcher<{ update: ServiceUI }>();
+
+async function deleteService(): Promise<void> {
+  service.status = 'DELETING';
+  dispatch('update', service);
+
+  await window.kubernetesDeleteService(service.name);
+}
+</script>
+
+<ListItemButtonIcon title="Delete Service" onClick="{() => deleteService()}" detailed="{detailed}" icon="{faTrash}" />

--- a/packages/renderer/src/lib/service/ServiceColumnActions.spec.ts
+++ b/packages/renderer/src/lib/service/ServiceColumnActions.spec.ts
@@ -1,0 +1,41 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+import { test, expect } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+
+import type { ServiceUI } from './ServiceUI';
+import ServiceColumnActions from './ServiceColumnActions.svelte';
+
+test('Expect action buttons', async () => {
+  const service: ServiceUI = {
+    name: 'my-service',
+    status: 'RUNNING',
+    namespace: '',
+    selected: false,
+    type: '',
+    clusterIP: '',
+    ports: '',
+  };
+
+  render(ServiceColumnActions, { object: service });
+
+  const buttons = await screen.findAllByRole('button');
+  expect(buttons).toHaveLength(1);
+});

--- a/packages/renderer/src/lib/service/ServiceColumnActions.svelte
+++ b/packages/renderer/src/lib/service/ServiceColumnActions.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+import ServiceActions from './ServiceActions.svelte';
+import type { ServiceUI } from './ServiceUI';
+
+export let object: ServiceUI;
+</script>
+
+<ServiceActions service="{object}" on:update />

--- a/packages/renderer/src/lib/service/ServiceColumnName.spec.ts
+++ b/packages/renderer/src/lib/service/ServiceColumnName.spec.ts
@@ -1,0 +1,43 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+import { test, expect } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+
+import ServiceColumnName from './ServiceColumnName.svelte';
+import type { ServiceUI } from './ServiceUI';
+
+const service: ServiceUI = {
+  name: 'my-service',
+  status: 'RUNNING',
+  namespace: '',
+  selected: false,
+  type: '',
+  clusterIP: '',
+  ports: '',
+};
+
+test('Expect simple column styling', async () => {
+  render(ServiceColumnName, { object: service });
+
+  const text = screen.getByText(service.name);
+  expect(text).toBeInTheDocument();
+  expect(text).toHaveClass('text-sm');
+  expect(text).toHaveClass('text-gray-300');
+});

--- a/packages/renderer/src/lib/service/ServiceColumnName.svelte
+++ b/packages/renderer/src/lib/service/ServiceColumnName.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+import type { ServiceUI } from './ServiceUI';
+
+export let object: ServiceUI;
+</script>
+
+<div class="text-sm text-gray-300">{object.name}</div>

--- a/packages/renderer/src/lib/service/ServiceColumnStatus.spec.ts
+++ b/packages/renderer/src/lib/service/ServiceColumnStatus.spec.ts
@@ -1,0 +1,41 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+import { test, expect } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+
+import ServiceColumnStatus from './ServiceColumnStatus.svelte';
+import type { ServiceUI } from './ServiceUI';
+
+test('Expect simple column styling', async () => {
+  const service: ServiceUI = {
+    name: 'my-service',
+    status: 'RUNNING',
+    namespace: '',
+    selected: false,
+    type: '',
+    clusterIP: '',
+    ports: '',
+  };
+  render(ServiceColumnStatus, { object: service });
+
+  const text = screen.getByRole('status');
+  expect(text).toBeInTheDocument();
+  expect(text).toHaveClass('bg-green-400');
+});

--- a/packages/renderer/src/lib/service/ServiceColumnStatus.svelte
+++ b/packages/renderer/src/lib/service/ServiceColumnStatus.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+import StatusIcon from '../images/StatusIcon.svelte';
+import ServiceIcon from '../images/ServiceIcon.svelte';
+import type { ServiceUI } from './ServiceUI';
+
+export let object: ServiceUI;
+</script>
+
+<StatusIcon icon="{ServiceIcon}" status="{object.status}" />

--- a/packages/renderer/src/lib/service/ServiceColumnType.spec.ts
+++ b/packages/renderer/src/lib/service/ServiceColumnType.spec.ts
@@ -1,0 +1,85 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+import { test, expect } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+
+import ServiceColumnType from './ServiceColumnType.svelte';
+import type { ServiceUI } from './ServiceUI';
+
+const service: ServiceUI = {
+  name: 'my-service',
+  status: '',
+  namespace: '',
+  selected: false,
+  type: 'unknown',
+  clusterIP: '',
+  ports: '',
+};
+
+test('Expect basic column styling', async () => {
+  render(ServiceColumnType, { object: service });
+
+  const text = screen.getByText(service.type);
+  expect(text).toBeInTheDocument();
+  expect(text).toHaveClass('text-gray-500');
+
+  const dot = text.parentElement?.children[0].children[0];
+  expect(dot).toBeInTheDocument();
+  expect(dot).toHaveClass('bg-gray-900');
+});
+
+test('Expect column styling ClusterIP', async () => {
+  service.type = 'ClusterIP';
+  render(ServiceColumnType, { object: service });
+
+  const text = screen.getByText(service.type);
+  expect(text).toBeInTheDocument();
+  expect(text).toHaveClass('text-gray-500');
+
+  const dot = text.parentElement?.children[0].children[0];
+  expect(dot).toBeInTheDocument();
+  expect(dot).toHaveClass('bg-green-600');
+});
+
+test('Expect column styling LoadBalancer', async () => {
+  service.type = 'LoadBalancer';
+  render(ServiceColumnType, { object: service });
+
+  const text = screen.getByText(service.type);
+  expect(text).toBeInTheDocument();
+  expect(text).toHaveClass('text-gray-500');
+
+  const dot = text.parentElement?.children[0].children[0];
+  expect(dot).toBeInTheDocument();
+  expect(dot).toHaveClass('bg-sky-400');
+});
+
+test('Expect column styling NodePort', async () => {
+  service.type = 'NodePort';
+  render(ServiceColumnType, { object: service });
+
+  const text = screen.getByText(service.type);
+  expect(text).toBeInTheDocument();
+  expect(text).toHaveClass('text-gray-500');
+
+  const dot = text.parentElement?.children[0].children[0];
+  expect(dot).toBeInTheDocument();
+  expect(dot).toHaveClass('bg-amber-600');
+});

--- a/packages/renderer/src/lib/service/ServiceColumnType.svelte
+++ b/packages/renderer/src/lib/service/ServiceColumnType.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+import type { ServiceUI } from './ServiceUI';
+
+export let object: ServiceUI;
+
+// Each type has a colour associated to it within tailwind, this is a map of those colours.
+// bg-green-600 = ClusterIP
+// bg-sky-400 = LoadBalancer
+// bg-amber-600 = NodePort
+// bg-gray-900 = unknown
+function getTypeColour(type: string): string {
+  switch (type) {
+    case 'ClusterIP':
+      return 'bg-green-600';
+    case 'LoadBalancer':
+      return 'bg-sky-400';
+    case 'NodePort':
+      return 'bg-amber-600';
+    default:
+      return 'bg-gray-900';
+  }
+}
+</script>
+
+<div class="flex flex-row bg-charcoal-500 items-center p-1 rounded-md text-xs text-gray-500">
+  <div class="w-2 h-2 {getTypeColour(object.type)} rounded-full mr-1"></div>
+  {object.type}
+</div>

--- a/packages/renderer/src/lib/service/ServiceEmptyScreen.svelte
+++ b/packages/renderer/src/lib/service/ServiceEmptyScreen.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+import EmptyScreen from '../ui/EmptyScreen.svelte';
+import ServiceIcon from '../images/ServiceIcon.svelte';
+</script>
+
+<EmptyScreen icon="{ServiceIcon}" title="No services" message="Try switching to a different context or namespace" />

--- a/packages/renderer/src/lib/service/ServiceUI.ts
+++ b/packages/renderer/src/lib/service/ServiceUI.ts
@@ -1,0 +1,28 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+export interface ServiceUI {
+  name: string;
+  status: string;
+  namespace: string;
+  created?: Date;
+  selected: boolean;
+  type: string;
+  clusterIP: string;
+  ports: string;
+}

--- a/packages/renderer/src/lib/service/ServicesList.spec.ts
+++ b/packages/renderer/src/lib/service/ServicesList.spec.ts
@@ -1,0 +1,125 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import '@testing-library/jest-dom/vitest';
+import { test, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import ServicesList from './ServicesList.svelte';
+import { get } from 'svelte/store';
+import type { V1Service } from '@kubernetes/client-node';
+import { services, servicesEventStore } from '/@/stores/services';
+
+const callbacks = new Map<string, any>();
+const eventEmitter = {
+  receive: (message: string, callback: any) => {
+    callbacks.set(message, callback);
+  },
+};
+
+Object.defineProperty(global, 'window', {
+  value: {
+    events: {
+      receive: eventEmitter.receive,
+    },
+    addEventListener: eventEmitter.receive,
+  },
+  writable: true,
+});
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.clearAllMocks();
+});
+
+async function waitRender(customProperties: object): Promise<void> {
+  const result = render(ServicesList, { ...customProperties });
+  // wait that result.component.$$.ctx[2] is set
+  while (result.component.$$.ctx[2] === undefined) {
+    await new Promise(resolve => setTimeout(resolve, 100));
+  }
+}
+
+test('Expect service empty screen', async () => {
+  render(ServicesList);
+  const noServices = screen.getByRole('heading', { name: 'No services' });
+  expect(noServices).toBeInTheDocument();
+});
+
+test('Expect services list', async () => {
+  const service: V1Service = {
+    apiVersion: 'v1',
+    kind: 'Service',
+    metadata: {
+      name: 'my-service',
+    },
+    spec: {
+      selector: {},
+      ports: [],
+      externalName: 'serve',
+    },
+  };
+
+  servicesEventStore.setup();
+
+  const ServiceAddCallback = callbacks.get('kubernetes-service-add');
+  expect(ServiceAddCallback).toBeDefined();
+  await ServiceAddCallback(service);
+
+  // wait while store is populated
+  while (get(services).length === 0) {
+    await new Promise(resolve => setTimeout(resolve, 500));
+  }
+
+  await waitRender({});
+
+  const serviceName = screen.getByRole('cell', { name: 'my-service' });
+  expect(serviceName).toBeInTheDocument();
+});
+
+test('Expect filter empty screen', async () => {
+  const service: V1Service = {
+    apiVersion: 'v1',
+    kind: 'Service',
+    metadata: {
+      name: 'my-service',
+    },
+    spec: {
+      selector: {},
+      ports: [],
+      externalName: 'serve',
+    },
+  };
+
+  servicesEventStore.setup();
+
+  const ServiceAddCallback = callbacks.get('kubernetes-service-add');
+  expect(ServiceAddCallback).toBeDefined();
+  await ServiceAddCallback(service);
+
+  // wait while store is populated
+  while (get(services).length === 0) {
+    await new Promise(resolve => setTimeout(resolve, 500));
+  }
+
+  await waitRender({ searchTerm: 'No match' });
+
+  const filterButton = screen.getByRole('button', { name: 'Clear filter' });
+  expect(filterButton).toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/service/ServicesList.svelte
+++ b/packages/renderer/src/lib/service/ServicesList.svelte
@@ -1,0 +1,145 @@
+<script lang="ts">
+import { onMount } from 'svelte';
+import { filtered, searchPattern } from '../../stores/services';
+import NavPage from '../ui/NavPage.svelte';
+import Table from '../table/Table.svelte';
+import { Column, Row } from '../table/table';
+import ServiceColumnStatus from './ServiceColumnStatus.svelte';
+import ServiceColumnName from './ServiceColumnName.svelte';
+import { ServiceUtils } from './service-utils';
+import ServiceColumnActions from './ServiceColumnActions.svelte';
+import moment from 'moment';
+import Button from '../ui/Button.svelte';
+import { faTrash } from '@fortawesome/free-solid-svg-icons';
+import type { ServiceUI } from './ServiceUI';
+import ServiceIcon from '../images/ServiceIcon.svelte';
+import ServiceEmptyScreen from './ServiceEmptyScreen.svelte';
+import FilteredEmptyScreen from '../ui/FilteredEmptyScreen.svelte';
+import SimpleColumn from '../table/SimpleColumn.svelte';
+import DurationColumn from '../table/DurationColumn.svelte';
+import ServiceColumnType from './ServiceColumnType.svelte';
+
+export let searchTerm = '';
+$: searchPattern.set(searchTerm);
+
+let services: ServiceUI[] = [];
+
+const serviceUtils = new ServiceUtils();
+
+onMount(() => {
+  return filtered.subscribe(value => {
+    services = value.map(service => serviceUtils.getServiceUI(service));
+  });
+});
+
+// delete the items selected in the list
+let bulkDeleteInProgress = false;
+async function deleteSelectedServices() {
+  const selectedServices = services.filter(service => service.selected);
+
+  if (selectedServices.length > 0) {
+    bulkDeleteInProgress = true;
+    await Promise.all(
+      selectedServices.map(async service => {
+        try {
+          await window.kubernetesDeleteService(service.name);
+        } catch (e) {
+          console.log('error while deleting service', e);
+        }
+      }),
+    );
+    bulkDeleteInProgress = false;
+  }
+}
+
+let selectedItemsNumber: number;
+let table: Table;
+
+let statusColumn = new Column<ServiceUI>('Status', {
+  align: 'center',
+  width: '70px',
+  renderer: ServiceColumnStatus,
+  comparator: (a, b) => a.status.localeCompare(b.status),
+});
+
+let nameColumn = new Column<ServiceUI>('Name', {
+  width: '1fr',
+  renderer: ServiceColumnName,
+  comparator: (a, b) => a.name.localeCompare(b.name),
+});
+
+let namespaceColumn = new Column<ServiceUI, string>('Namespace', {
+  renderMapping: service => service.namespace,
+  renderer: SimpleColumn,
+  comparator: (a, b) => a.namespace.localeCompare(b.namespace),
+});
+
+let typeColumn = new Column<ServiceUI>('Type', {
+  renderer: ServiceColumnType,
+  comparator: (a, b) => a.type.localeCompare(b.type),
+});
+
+let clusterIPColumn = new Column<ServiceUI, string>('Cluster IP', {
+  renderMapping: service => service.clusterIP,
+  renderer: SimpleColumn,
+  comparator: (a, b) => a.clusterIP.localeCompare(b.clusterIP),
+});
+
+let portsColumn = new Column<ServiceUI, string>('Ports', {
+  renderMapping: service => service.ports,
+  renderer: SimpleColumn,
+  comparator: (a, b) => a.ports.localeCompare(b.ports),
+});
+
+let ageColumn = new Column<ServiceUI, Date | undefined>('Age', {
+  renderMapping: service => service.created,
+  renderer: DurationColumn,
+  comparator: (a, b) => moment(b.created).diff(moment(a.created)),
+});
+
+const columns: Column<ServiceUI, ServiceUI | string | Date | undefined>[] = [
+  statusColumn,
+  nameColumn,
+  namespaceColumn,
+  typeColumn,
+  clusterIPColumn,
+  portsColumn,
+  ageColumn,
+  new Column<ServiceUI>('Actions', { align: 'right', renderer: ServiceColumnActions }),
+];
+
+const row = new Row<ServiceUI>({ selectable: _service => true });
+</script>
+
+<NavPage bind:searchTerm="{searchTerm}" title="services">
+  <svelte:fragment slot="bottom-additional-actions">
+    {#if selectedItemsNumber > 0}
+      <Button
+        on:click="{() => deleteSelectedServices()}"
+        title="Delete {selectedItemsNumber} selected items"
+        inProgress="{bulkDeleteInProgress}"
+        icon="{faTrash}" />
+      <span>On {selectedItemsNumber} selected items.</span>
+    {/if}
+  </svelte:fragment>
+
+  <div class="flex min-w-full h-full" slot="content">
+    <Table
+      kind="service"
+      bind:this="{table}"
+      bind:selectedItemsNumber="{selectedItemsNumber}"
+      data="{services}"
+      columns="{columns}"
+      row="{row}"
+      on:update="{() => (services = services)}">
+    </Table>
+
+    {#if $filtered.length === 0}
+      {#if searchTerm}
+        <FilteredEmptyScreen icon="{ServiceIcon}" kind="services" bind:searchTerm="{searchTerm}" />
+      {:else}
+        <ServiceEmptyScreen />
+      {/if}
+    {/if}
+  </div>
+</NavPage>

--- a/packages/renderer/src/lib/service/service-utils.spec.ts
+++ b/packages/renderer/src/lib/service/service-utils.spec.ts
@@ -1,0 +1,41 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { beforeEach, expect, test, vi } from 'vitest';
+import { ServiceUtils } from './service-utils';
+import type { V1Service } from '@kubernetes/client-node';
+
+let serviceUtils: ServiceUtils;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  serviceUtils = new ServiceUtils();
+});
+
+test('expect basic UI conversion', async () => {
+  const service = {
+    metadata: {
+      name: 'my-service',
+      namespace: 'test-namespace',
+    },
+    status: {},
+  } as V1Service;
+  const serviceUI = serviceUtils.getServiceUI(service);
+  expect(serviceUI.name).toEqual('my-service');
+  expect(serviceUI.namespace).toEqual('test-namespace');
+});

--- a/packages/renderer/src/lib/service/service-utils.ts
+++ b/packages/renderer/src/lib/service/service-utils.ts
@@ -1,0 +1,35 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { ServiceUI } from './ServiceUI';
+import type { V1Service } from '@kubernetes/client-node';
+
+export class ServiceUtils {
+  getServiceUI(service: V1Service): ServiceUI {
+    return {
+      name: service.metadata?.name ?? '',
+      status: 'RUNNING',
+      namespace: service.metadata?.namespace ?? '',
+      created: service.metadata?.creationTimestamp,
+      selected: false,
+      type: service.spec?.type ?? '',
+      clusterIP: service.spec?.clusterIP ?? '',
+      ports: (service.spec?.ports ?? []).map(port => port.port + '/' + port.protocol).join(', '),
+    };
+  }
+}

--- a/packages/renderer/src/stores/deployments.spec.ts
+++ b/packages/renderer/src/stores/deployments.spec.ts
@@ -1,0 +1,117 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { get } from 'svelte/store';
+import { beforeAll, expect, test, vi } from 'vitest';
+import type { V1Deployment } from '@kubernetes/client-node';
+import { deployments, deploymentsEventStore } from './deployments';
+
+// first, path window object
+const callbacks = new Map<string, any>();
+const eventEmitter = {
+  receive: (message: string, callback: any) => {
+    callbacks.set(message, callback);
+  },
+};
+
+Object.defineProperty(global, 'window', {
+  value: {
+    events: {
+      receive: eventEmitter.receive,
+    },
+    addEventListener: eventEmitter.receive,
+  },
+  writable: true,
+});
+
+beforeAll(() => {
+  vi.clearAllMocks();
+});
+
+const v1Deployment: V1Deployment = {
+  apiVersion: 'apps/v1',
+  kind: 'Deployment',
+  metadata: {
+    name: 'deployment',
+  },
+  spec: {
+    replicas: 2,
+    selector: {},
+    template: {},
+  },
+};
+
+const v2Deployment: V1Deployment = {
+  apiVersion: 'apps/v1',
+  kind: 'Deployment',
+  metadata: {
+    name: 'deployment',
+  },
+  spec: {
+    replicas: 3,
+    selector: {},
+    template: {},
+  },
+};
+
+test('deployments should be updated when informer sends signals', async () => {
+  deploymentsEventStore.setup();
+
+  // get list
+  const listDeploymentes = get(deployments);
+  expect(listDeploymentes.length).toBe(0);
+
+  // call 'kubernetes-deployment-add' event
+  const DeploymentAddCallback = callbacks.get('kubernetes-deployment-add');
+  expect(DeploymentAddCallback).toBeDefined();
+  await DeploymentAddCallback(v1Deployment);
+
+  // wait
+  await new Promise(resolve => setTimeout(resolve, 2000));
+
+  // check if the deployments are updated
+  const deployments2 = get(deployments);
+  expect(deployments2.length).toBe(1);
+  expect(deployments2[0].metadata?.name).equal('deployment');
+  expect(deployments2[0].spec?.replicas).equal(2);
+
+  // call 'kubernetes-deployment-update' event - update the deployment
+  const DeploymentUpdateCallback = callbacks.get('kubernetes-deployment-update');
+  expect(DeploymentUpdateCallback).toBeDefined();
+  await DeploymentUpdateCallback(v2Deployment);
+
+  // check if the deployments are updated
+  const deployments3 = get(deployments);
+  expect(deployments3.length).toBe(1);
+  expect(deployments3[0].metadata?.name).equal('deployment');
+  expect(deployments3[0].spec?.replicas).equal(3);
+
+  // call 'kubernetes-deployment-deleted' event
+  const DeploymentDeleteCallback = callbacks.get('kubernetes-deployment-deleted');
+  expect(DeploymentDeleteCallback).toBeDefined();
+  await DeploymentDeleteCallback(v1Deployment);
+
+  // wait
+  await new Promise(resolve => setTimeout(resolve, 2000));
+
+  // check if the deployments are updated
+  const deployments4 = get(deployments);
+  expect(deployments4.length).toBe(0);
+});

--- a/packages/renderer/src/stores/deployments.ts
+++ b/packages/renderer/src/stores/deployments.ts
@@ -49,24 +49,24 @@ function informerListener(...args: unknown[]) {
     if (event === 'kubernetes-deployment-add') {
       if (
         !deploymentsList.find(
-          ing =>
-            ing.metadata?.name === deployment.metadata?.name &&
-            ing.metadata?.namespace === deployment.metadata?.namespace,
+          dep =>
+            dep.metadata?.name === deployment.metadata?.name &&
+            dep.metadata?.namespace === deployment.metadata?.namespace,
         )
       ) {
         deploymentsList.push(deployment);
       }
     } else if (event === 'kubernetes-deployment-deleted') {
       deploymentsList = deploymentsList.filter(
-        ing =>
-          ing.metadata?.name !== deployment.metadata?.name ||
-          ing.metadata?.namespace !== deployment.metadata?.namespace,
+        dep =>
+          dep.metadata?.name !== deployment.metadata?.name ||
+          dep.metadata?.namespace !== deployment.metadata?.namespace,
       );
     } else if (event === 'kubernetes-deployment-update') {
       const index = deploymentsList.findIndex(
-        ing =>
-          ing.metadata?.name === deployment.metadata?.name &&
-          ing.metadata?.namespace === deployment.metadata?.namespace,
+        dep =>
+          dep.metadata?.name === deployment.metadata?.name &&
+          dep.metadata?.namespace === deployment.metadata?.namespace,
       );
       if (index > -1) {
         deploymentsList[index] = deployment;

--- a/packages/renderer/src/stores/ingresses.ts
+++ b/packages/renderer/src/stores/ingresses.ts
@@ -19,6 +19,8 @@
 import type { V1Ingress } from '@kubernetes/client-node';
 import { customWritable, type KubernetesInformerWritable } from './kubernetesInformerWritable';
 import { EventStoreWithKubernetesInformer } from './kubernetes-informer-event-store';
+import { writable, derived } from 'svelte/store';
+import { findMatchInLeaves } from './search-util';
 
 const informerEvents = ['kubernetes-ingress-add', 'kubernetes-ingress-update', 'kubernetes-ingress-deleted'];
 const informerRefreshEvents = ['provider-change', 'kubeconfig-update'];
@@ -33,6 +35,12 @@ export const ingressesEventStore = new EventStoreWithKubernetesInformer<V1Ingres
 );
 
 ingressesEventStore.setup();
+
+export const searchPattern = writable('');
+
+export const filtered = derived([searchPattern, ingresses], ([$searchPattern, $ingresses]) =>
+  $ingresses.filter(deployment => findMatchInLeaves(deployment, $searchPattern.toLowerCase())),
+);
 
 function informerListener(...args: unknown[]) {
   const event = args[0];

--- a/packages/renderer/src/stores/routes.ts
+++ b/packages/renderer/src/stores/routes.ts
@@ -49,18 +49,18 @@ function informerListener(...args: unknown[]) {
     if (event === 'kubernetes-route-add') {
       if (
         !routesList.find(
-          ing => ing.metadata?.name === route.metadata?.name && ing.metadata?.namespace === route.metadata?.namespace,
+          rte => rte.metadata?.name === route.metadata?.name && rte.metadata?.namespace === route.metadata?.namespace,
         )
       ) {
         routesList.push(route);
       }
     } else if (event === 'kubernetes-route-deleted') {
       routesList = routesList.filter(
-        ing => ing.metadata?.name !== route.metadata?.name || ing.metadata?.namespace !== route.metadata?.namespace,
+        rte => rte.metadata?.name !== route.metadata?.name || rte.metadata?.namespace !== route.metadata?.namespace,
       );
     } else if (event === 'kubernetes-route-update') {
       const index = routesList.findIndex(
-        ing => ing.metadata?.name === route.metadata?.name && ing.metadata?.namespace === route.metadata?.namespace,
+        rte => rte.metadata?.name === route.metadata?.name && rte.metadata?.namespace === route.metadata?.namespace,
       );
       if (index > -1) {
         routesList[index] = route;

--- a/packages/renderer/src/stores/services.spec.ts
+++ b/packages/renderer/src/stores/services.spec.ts
@@ -1,0 +1,117 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { get } from 'svelte/store';
+import { beforeAll, expect, test, vi } from 'vitest';
+import type { V1Service } from '@kubernetes/client-node';
+import { services, servicesEventStore } from './services';
+
+// first, path window object
+const callbacks = new Map<string, any>();
+const eventEmitter = {
+  receive: (message: string, callback: any) => {
+    callbacks.set(message, callback);
+  },
+};
+
+Object.defineProperty(global, 'window', {
+  value: {
+    events: {
+      receive: eventEmitter.receive,
+    },
+    addEventListener: eventEmitter.receive,
+  },
+  writable: true,
+});
+
+beforeAll(() => {
+  vi.clearAllMocks();
+});
+
+const v1Service: V1Service = {
+  apiVersion: 'v1',
+  kind: 'Service',
+  metadata: {
+    name: 'service',
+  },
+  spec: {
+    selector: {},
+    ports: [],
+    externalName: 'serve',
+  },
+};
+
+const v2Ingress: V1Service = {
+  apiVersion: 'v1',
+  kind: 'Service',
+  metadata: {
+    name: 'service',
+  },
+  spec: {
+    selector: {},
+    ports: [],
+    externalName: 'protect',
+  },
+};
+
+test('services should be updated when informer sends signals', async () => {
+  servicesEventStore.setup();
+
+  // get list
+  const listServices = get(services);
+  expect(listServices.length).toBe(0);
+
+  // call 'kubernetes-service-add' event
+  const serviceAddCallback = callbacks.get('kubernetes-service-add');
+  expect(serviceAddCallback).toBeDefined();
+  await serviceAddCallback(v1Service);
+
+  // wait
+  await new Promise(resolve => setTimeout(resolve, 2000));
+
+  // check if the services are updated
+  const services2 = get(services);
+  expect(services2.length).toBe(1);
+  expect(services2[0].metadata?.name).equal('service');
+  expect(services2[0].spec?.externalName).equal('serve');
+
+  // call 'kubernetes-service-update' event - update the service
+  const serviceUpdateCallback = callbacks.get('kubernetes-service-update');
+  expect(serviceUpdateCallback).toBeDefined();
+  await serviceUpdateCallback(v2Ingress);
+
+  // check if the services are updated
+  const services3 = get(services);
+  expect(services3.length).toBe(1);
+  expect(services3[0].metadata?.name).equal('service');
+  expect(services3[0].spec?.externalName).equal('protect');
+
+  // call 'kubernetes-service-deleted' event
+  const servicsDeleteCallback = callbacks.get('kubernetes-service-deleted');
+  expect(servicsDeleteCallback).toBeDefined();
+  await servicsDeleteCallback(v1Service);
+
+  // wait
+  await new Promise(resolve => setTimeout(resolve, 2000));
+
+  // check if the services are updated
+  const services4 = get(services);
+  expect(services4.length).toBe(0);
+});

--- a/packages/renderer/src/stores/services.ts
+++ b/packages/renderer/src/stores/services.ts
@@ -49,19 +49,19 @@ function informerListener(...args: unknown[]) {
     if (event === 'kubernetes-service-add') {
       if (
         !servicesList.find(
-          ing =>
-            ing.metadata?.name === service.metadata?.name && ing.metadata?.namespace === service.metadata?.namespace,
+          svc =>
+            svc.metadata?.name === service.metadata?.name && svc.metadata?.namespace === service.metadata?.namespace,
         )
       ) {
         servicesList.push(service);
       }
     } else if (event === 'kubernetes-service-deleted') {
       servicesList = servicesList.filter(
-        ing => ing.metadata?.name !== service.metadata?.name || ing.metadata?.namespace !== service.metadata?.namespace,
+        svc => svc.metadata?.name !== service.metadata?.name || svc.metadata?.namespace !== service.metadata?.namespace,
       );
     } else if (event === 'kubernetes-service-update') {
       const index = servicesList.findIndex(
-        ing => ing.metadata?.name === service.metadata?.name && ing.metadata?.namespace === service.metadata?.namespace,
+        svc => svc.metadata?.name === service.metadata?.name && svc.metadata?.namespace === service.metadata?.namespace,
       );
       if (index > -1) {
         servicesList[index] = service;


### PR DESCRIPTION
### What does this PR do?

Adds a UI for Kubernetes Services, similar to the Deployments page. All
design elements are included, columns are sortable, and there is a
delete action.

Depends on service store (PR #5295), so ignore everything except the
last commit (i.e. only review /service folder and App/AppNavigation).
Do not merge before #5295.

### Screenshot / video of UI

<img width="1033" alt="Screenshot 2023-12-21 at 5 00 23 PM" src="https://github.com/containers/podman-desktop/assets/19958075/f7269559-d778-4815-bb86-338a46cfb407">

### What issues does this PR fix or reference?

Fixes #4368.

### How to test this PR?

Like the Deployments page, the Services page will appear whenever you have a kube context.