### PR TITLE
feat: deployment updates

### DIFF
--- a/packages/renderer/src/lib/deployments/DeploymentActions.spec.ts
+++ b/packages/renderer/src/lib/deployments/DeploymentActions.spec.ts
@@ -1,0 +1,58 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+import { test, expect, vi, beforeEach, afterEach } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import DeploymentActions from './DeploymentActions.svelte';
+import type { DeploymentUI } from './DeploymentUI';
+
+const updateMock = vi.fn();
+const deleteMock = vi.fn();
+
+const deployment: DeploymentUI = {
+  name: 'my-deployment',
+  status: 'RUNNING',
+  namespace: '',
+  replicas: 0,
+  ready: 0,
+  selected: false,
+  conditions: [],
+};
+
+beforeEach(() => {
+  (window as any).kubernetesDeleteDeployment = deleteMock;
+});
+
+afterEach(() => {
+  vi.resetAllMocks();
+  vi.clearAllMocks();
+});
+
+test('Expect no error and status deleting deployment', async () => {
+  const { component } = render(DeploymentActions, { deployment });
+  component.$on('update', updateMock);
+
+  // click on delete button
+  const deleteButton = screen.getByRole('button', { name: 'Delete Deployment' });
+  await fireEvent.click(deleteButton);
+
+  expect(deployment.status).toEqual('DELETING');
+  expect(updateMock).toHaveBeenCalled();
+  expect(deleteMock).toHaveBeenCalled();
+});

--- a/packages/renderer/src/lib/deployments/DeploymentActions.svelte
+++ b/packages/renderer/src/lib/deployments/DeploymentActions.svelte
@@ -2,11 +2,17 @@
 import { faTrash } from '@fortawesome/free-solid-svg-icons';
 import type { DeploymentUI } from './DeploymentUI';
 import ListItemButtonIcon from '../ui/ListItemButtonIcon.svelte';
+import { createEventDispatcher } from 'svelte';
 
 export let deployment: DeploymentUI;
 export let detailed = false;
 
+const dispatch = createEventDispatcher<{ update: DeploymentUI }>();
+
 async function deleteDeployment(): Promise<void> {
+  deployment.status = 'DELETING';
+  dispatch('update', deployment);
+
   await window.kubernetesDeleteDeployment(deployment.name);
 }
 </script>

--- a/packages/renderer/src/lib/deployments/DeploymentColumnActions.spec.ts
+++ b/packages/renderer/src/lib/deployments/DeploymentColumnActions.spec.ts
@@ -1,0 +1,41 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+import { test, expect } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+
+import type { DeploymentUI } from './DeploymentUI';
+import DeploymentColumnActions from './DeploymentColumnActions.svelte';
+
+test('Expect action buttons', async () => {
+  const deployment: DeploymentUI = {
+    name: 'my-deployment',
+    status: 'RUNNING',
+    namespace: '',
+    replicas: 0,
+    ready: 0,
+    selected: false,
+    conditions: [],
+  };
+
+  render(DeploymentColumnActions, { object: deployment });
+
+  const buttons = await screen.findAllByRole('button');
+  expect(buttons).toHaveLength(1);
+});

--- a/packages/renderer/src/lib/deployments/DeploymentColumnActions.svelte
+++ b/packages/renderer/src/lib/deployments/DeploymentColumnActions.svelte
@@ -5,4 +5,4 @@ import type { DeploymentUI } from './DeploymentUI';
 export let object: DeploymentUI;
 </script>
 
-<DeploymentActions deployment="{object}" />
+<DeploymentActions deployment="{object}" on:update />

--- a/packages/renderer/src/lib/deployments/DeploymentsList.svelte
+++ b/packages/renderer/src/lib/deployments/DeploymentsList.svelte
@@ -124,7 +124,8 @@ const row = new Row<DeploymentUI>({ selectable: _deployment => true });
       data="{deployments}"
       columns="{columns}"
       row="{row}"
-      defaultSortColumn="Name">
+      defaultSortColumn="Name"
+      on:update="{() => (deployments = deployments)}">
     </Table>
 
     {#if $filtered.length === 0}


### PR DESCRIPTION
### What does this PR do?

When adding pods we added the ability for actions to trigger update events that refresh table state. This uses the same thing so that when you delete a deployment the icon turns into a spinner. For most clusters the action is near instantaneous, but when you notice the effect is nice and it keeps things consistent.

### Screenshot / video of UI

Artificial 1s delay added to clearly show the change:

https://github.com/containers/podman-desktop/assets/19958075/4e903c15-9d8c-4357-a212-d44884127deb

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Start a cluster like kind, use `kubectl create deployment delete-me --image=gcr.io/google-samples/kubernetes-bootcamp:v1`, then delete it from the UI.