### PR TITLE
feat: display Kubernetes connection status in relevant pages

### DIFF
--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -149,6 +149,7 @@ import type { KubeContext } from './kubernetes-context.js';
 import { KubernetesInformerManager } from './kubernetes-informer-registry.js';
 import type { KubernetesInformerResourcesType } from './api/kubernetes-informer-info.js';
 import { OpenDevToolsInit } from './open-devtools-init.js';
+import type { KubernetesConnection } from '/@/plugin/kubernetes-connection.js';
 
 type LogType = 'log' | 'warn' | 'trace' | 'debug' | 'error';
 
@@ -1996,6 +1997,12 @@ export class PluginSystem {
 
     this.ipcHandle('kubernetes-client:getDetailedContexts', async (): Promise<KubeContext[]> => {
       return kubernetesClient.getDetailedContexts();
+    });
+
+    this.ipcHandle('kubernetes-client:getConnectionStatus', async (): Promise<KubernetesConnection | undefined> => {
+      const value = kubernetesClient.getConnectionStatus();
+      console.log('getConnectionStatus', value);
+      return value;
     });
 
     this.ipcHandle('kubernetes-client:getClusters', async (): Promise<Cluster[]> => {

--- a/packages/main/src/plugin/kubernetes-connection.ts
+++ b/packages/main/src/plugin/kubernetes-connection.ts
@@ -1,0 +1,26 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+// A simpler method of holding all the Kubernetes context information in one place
+// for the UI to use.
+
+export interface KubernetesConnection {
+  context: string;
+  status: 'connected' | 'error';
+  error?: string;
+}

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -90,6 +90,7 @@ import type { KubeContext } from '../../main/src/plugin/kubernetes-context';
 
 import type { KubernetesGeneratorInfo } from '../../main/src/plugin/api/KubernetesGeneratorInfo';
 import type { NotificationCard, NotificationCardOptions } from '../../main/src/plugin/api/notification';
+import type { KubernetesConnection } from '../../main/src/plugin/kubernetes-connection';
 
 export type DialogResultCallback = (openDialogReturnValue: Electron.OpenDialogReturnValue) => void;
 
@@ -1525,6 +1526,13 @@ function initExposure(): void {
   contextBridge.exposeInMainWorld('kubernetesGetDetailedContexts', async (): Promise<KubeContext[]> => {
     return ipcInvoke('kubernetes-client:getDetailedContexts');
   });
+
+  contextBridge.exposeInMainWorld(
+    'kubernetesGetConnectionStatus',
+    async (): Promise<KubernetesConnection | undefined> => {
+      return ipcInvoke('kubernetes-client:getConnectionStatus');
+    },
+  );
 
   contextBridge.exposeInMainWorld('kubernetesDeleteContext', async (contextName: string): Promise<Context[]> => {
     return ipcInvoke('kubernetes-client:deleteContext', contextName);

--- a/packages/renderer/src/lib/deployments/DeploymentsList.svelte
+++ b/packages/renderer/src/lib/deployments/DeploymentsList.svelte
@@ -20,6 +20,7 @@ import DeploymentEmptyScreen from './DeploymentEmptyScreen.svelte';
 import FilteredEmptyScreen from '../ui/FilteredEmptyScreen.svelte';
 import SimpleColumn from '../table/SimpleColumn.svelte';
 import DurationColumn from '../table/DurationColumn.svelte';
+import ConnectionStatusBadge from '/@/lib/ui/ConnectionStatusBadge.svelte';
 
 export let searchTerm = '';
 $: searchPattern.set(searchTerm);
@@ -114,6 +115,9 @@ const row = new Row<DeploymentUI>({ selectable: _deployment => true });
         icon="{faTrash}" />
       <span>On {selectedItemsNumber} selected items.</span>
     {/if}
+    <div class="flex min-w-full justify-end">
+      <ConnectionStatusBadge />
+    </div>
   </svelte:fragment>
 
   <div class="flex min-w-full h-full" slot="content">

--- a/packages/renderer/src/lib/service/ServicesList.svelte
+++ b/packages/renderer/src/lib/service/ServicesList.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import { onMount } from 'svelte';
 import { filtered, searchPattern } from '../../stores/services';
+import { kubernetesConnection } from '../../stores/kubernetes-connection';
 import NavPage from '../ui/NavPage.svelte';
 import Table from '../table/Table.svelte';
 import { Column, Row } from '../table/table';
@@ -18,18 +19,33 @@ import FilteredEmptyScreen from '../ui/FilteredEmptyScreen.svelte';
 import SimpleColumn from '../table/SimpleColumn.svelte';
 import DurationColumn from '../table/DurationColumn.svelte';
 import ServiceColumnType from './ServiceColumnType.svelte';
+import type { KubernetesConnection } from '../../../../main/src/plugin/kubernetes-connection';
+import type { Unsubscriber } from 'svelte/store';
+import Badge from '/@/lib/ui/Badge.svelte';
 
 export let searchTerm = '';
 $: searchPattern.set(searchTerm);
 
 let services: ServiceUI[] = [];
+let connection: KubernetesConnection | undefined = undefined;
 
 const serviceUtils = new ServiceUtils();
 
 onMount(() => {
-  return filtered.subscribe(value => {
-    services = value.map(service => serviceUtils.getServiceUI(service));
-  });
+  let unsubscribers: Unsubscriber[] = [];
+
+  unsubscribers.push(
+    kubernetesConnection.subscribe(value => {
+      connection = value;
+    }),
+  );
+
+  unsubscribers.push(
+    filtered.subscribe(value => {
+      services = value.map(service => serviceUtils.getServiceUI(service));
+    }),
+  );
+  return () => unsubscribers.forEach(unsubscribe => unsubscribe());
 });
 
 // delete the items selected in the list
@@ -109,6 +125,12 @@ const columns: Column<ServiceUI, ServiceUI | string | Date | undefined>[] = [
 ];
 
 const row = new Row<ServiceUI>({ selectable: _service => true });
+
+function getConnectionBadgeColor() {
+  if (connection === undefined || connection.status === 'error') return 'bg-gray-900';
+
+  return 'bg-green-900';
+}
 </script>
 
 <NavPage bind:searchTerm="{searchTerm}" title="services">
@@ -121,6 +143,11 @@ const row = new Row<ServiceUI>({ selectable: _service => true });
         icon="{faTrash}" />
       <span>On {selectedItemsNumber} selected items.</span>
     {/if}
+    <div class="flex min-w-full justify-end">
+      {#if connection !== undefined}
+        <Badge text="{connection.status}" classColor="{getConnectionBadgeColor()}" tooltip="{connection.error}" />
+      {/if}
+    </div>
   </svelte:fragment>
 
   <div class="flex min-w-full h-full" slot="content">

--- a/packages/renderer/src/lib/ui/Badge.svelte
+++ b/packages/renderer/src/lib/ui/Badge.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+import Tooltip from './Tooltip.svelte';
+
+export let text = '';
+
+export let tooltip: string | undefined = undefined;
+
+export let classColor = '';
+</script>
+
+<div class="flex items-center bg-charcoal-500 p-1 rounded-md">
+  <div class="w-2 h-2 {classColor} rounded-full mr-2"></div>
+  <span class="text-xs capitalize mr-1">
+    {#if tooltip !== undefined}
+      <Tooltip tip="{tooltip}" left>{text}</Tooltip>
+    {:else}
+      {text}
+    {/if}
+  </span>
+</div>

--- a/packages/renderer/src/lib/ui/ConnectionStatusBadge.spec.ts
+++ b/packages/renderer/src/lib/ui/ConnectionStatusBadge.spec.ts
@@ -1,0 +1,66 @@
+import '@testing-library/jest-dom/vitest';
+import { test, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import ConnectionStatusBadge from './ConnectionStatusBadge.svelte';
+
+const mock = vi.hoisted(() => {
+  return {
+    subscribe: vi.fn(),
+  };
+});
+
+vi.mock('../../stores/kubernetes-connection', () => {
+  return {
+    kubernetesConnection: {
+      subscribe: mock.subscribe,
+    },
+  };
+});
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+test('Expect connected to be green', async () => {
+  mock.subscribe.mockImplementation(callable => {
+    callable({
+      context: 'mocked-context',
+      status: 'connected',
+    });
+  });
+
+  render(ConnectionStatusBadge);
+  const label = screen.getByText('connected');
+  expect(label).toBeInTheDocument();
+  expect(label.parentElement?.firstChild).toBeInTheDocument();
+  expect(label.parentElement?.firstChild).toHaveClass('bg-green-600');
+});
+
+test('Expect unknown to be gray', async () => {
+  mock.subscribe.mockImplementation(callable => {
+    callable(undefined);
+  });
+
+  render(ConnectionStatusBadge);
+  const label = screen.getByText('unknown');
+  expect(label).toBeInTheDocument();
+  expect(label.parentElement?.firstChild).toBeInTheDocument();
+  expect(label.parentElement?.firstChild).toHaveClass('bg-gray-900');
+});
+
+test('Expect error to have tooltip', async () => {
+  mock.subscribe.mockImplementation(callable => {
+    callable({
+      status: 'error',
+      context: 'mocked-context',
+      error: 'error-msg',
+    });
+  });
+
+  render(ConnectionStatusBadge);
+  const label = screen.getByText('error');
+  expect(label).toBeInTheDocument();
+  expect(label.parentElement?.firstChild).toBeInTheDocument();
+  expect(label.parentElement?.firstChild).toHaveClass('tooltip-slot');
+  expect(label.parentElement?.parentElement?.parentElement?.firstChild).toHaveClass('bg-gray-900');
+});

--- a/packages/renderer/src/lib/ui/ConnectionStatusBadge.svelte
+++ b/packages/renderer/src/lib/ui/ConnectionStatusBadge.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+import { kubernetesConnection } from '../../stores/kubernetes-connection';
+import { onMount } from 'svelte';
+import type { KubernetesConnection } from '../../../../main/src/plugin/kubernetes-connection';
+import Badge from '/@/lib/ui/Badge.svelte';
+
+let connection: KubernetesConnection | undefined = undefined;
+
+onMount(() => {
+  return kubernetesConnection.subscribe(value => {
+    connection = value;
+  });
+});
+
+function getConnectionBadgeColor(status: string | undefined) {
+  if (status === undefined || status === 'error') return 'bg-gray-900';
+
+  return 'bg-green-600';
+}
+</script>
+
+<Badge
+  text="{connection?.status || 'unknown'}"
+  classColor="{getConnectionBadgeColor(connection?.status)}"
+  tooltip="{connection?.error}" />

--- a/packages/renderer/src/lib/ui/ConnectionStatusBadge.svelte
+++ b/packages/renderer/src/lib/ui/ConnectionStatusBadge.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { kubernetesConnection } from '../../stores/kubernetes-connection';
+import { kubernetesConnection } from '/@/stores/kubernetes-connection';
 import { onMount } from 'svelte';
 import type { KubernetesConnection } from '../../../../main/src/plugin/kubernetes-connection';
 import Badge from '/@/lib/ui/Badge.svelte';

--- a/packages/renderer/src/stores/kubernetes-connection.ts
+++ b/packages/renderer/src/stores/kubernetes-connection.ts
@@ -1,0 +1,42 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { writable, type Writable } from 'svelte/store';
+import { EventStore } from './event-store';
+import { checkForUpdate } from '/@/stores/kubernetes-contexts';
+import type { KubernetesConnection } from '../../../main/src/plugin/kubernetes-connection';
+
+const windowEvents: string[] = ['kubernetes-context-update', 'kubernetes-connection-update'];
+const windowListeners = ['extensions-already-started'];
+
+export const kubernetesConnection: Writable<KubernetesConnection | undefined> = writable(undefined);
+
+const eventStore = new EventStore<KubernetesConnection | undefined>(
+  'kubernetes connection',
+  kubernetesConnection,
+  checkForUpdate,
+  windowEvents,
+  windowListeners,
+  grabKubernetesConnection,
+);
+eventStore.setup();
+
+export async function grabKubernetesConnection(): Promise<KubernetesConnection | undefined> {
+  // for now, we only fetch one, since we do not support multiple connection at the same time
+  return await window.kubernetesGetConnectionStatus();
+}


### PR DESCRIPTION
### What does this PR do?

This PR is adding a badge to the Service and Deployment page indicating the status ('connected' | 'error') to the current context (when exist).

### Screenshot / video of UI

**error display**
<img width="788" alt="image" src="https://github.com/containers/podman-desktop/assets/42176370/56a79e1f-ede3-4796-98e2-9605ec5f34bf">

**on hover**
![image](https://github.com/containers/podman-desktop/assets/42176370/fca5970e-f3fc-4b89-9c59-33d70257bdbb)

**connected**
![image](https://github.com/containers/podman-desktop/assets/42176370/0158d644-107a-470f-b4f6-a02a3252b552)

### What issues does this PR fix or reference?

https://github.com/containers/podman-desktop/issues/5401

### How to test this PR?

- Create / delete kind cluster
- Switch between contexts 
