### PR TITLE
:fix: typo in shell examples

### DIFF
--- a/website/docs/migrating-from-docker/verifying-your-tools-are-using-podman.md
+++ b/website/docs/migrating-from-docker/verifying-your-tools-are-using-podman.md
@@ -55,21 +55,21 @@ When you have configured your host to use Podman rather then Docker, consider ve
      <TabItem value="win" label="Windows">
 
    ```shell-session
-   $ CONTAINER_HOST=npipe:////./pipe/docker_engine podman ps
+   $ CONTAINER_HOST=npipe:////./pipe/docker_engine; podman ps
    ```
 
      </TabItem>
      <TabItem value="mac" label="macOS">
 
    ```shell-session
-   $ CONTAINER_HOST=/var/run/docker.sock podman ps
+   $ CONTAINER_HOST=/var/run/docker.sock; podman ps
    ```
 
      </TabItem>
      <TabItem value="linux" label="Linux">
 
    ```shell-session
-   $ CONTAINER_HOST=/var/run/docker.sock podman ps
+   $ CONTAINER_HOST=/var/run/docker.sock; podman ps
    ```
 
      </TabItem>


### PR DESCRIPTION
add missing semi colon between setting shell variables in podman verifying-your-tools-are-using-podman.

### What does this PR do?

fixes documentation guidance for those movinf from docker.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop 
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to reproduce -->
copy and execute the commands in macOS or unix shell environment, the previous examples were missing a ';' between the setting of the CONTAINER_HOST variable and the command to execute afterward. Without it a posix shell would interpret the entire command as a whole, producing no result from the 'podman ps' command, this might confuse users.