### PR TITLE
feat: creating interface for subviews

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -2651,4 +2651,19 @@ declare module '@podman-desktop/api' {
       metadata?: ImageCheckerProviderMetadata,
     ): Disposable;
   }
+
+  export interface SubviewOption {
+    // unique identifier
+    id: string;
+    // name to display
+    name: string;
+    // the path to index.html or url
+    source: string;
+    // base64 icon
+    icon: string;
+  }
+
+  export namespace subview {
+    export function registerSubview(option: SubviewOption): Disposable;
+  }
 }

--- a/packages/main/src/mainWindow.ts
+++ b/packages/main/src/mainWindow.ts
@@ -195,15 +195,15 @@ async function createWindow(): Promise<BrowserWindow> {
       // In development mode, show the "Open DevTools of Extension" menu item
       if (import.meta.env.DEV) {
         let extensionId = '';
-        if (parameters?.linkURL?.includes('/contribs')) {
-          extensionId = parameters.linkURL.split('/contribs/')[1];
+        if (parameters?.linkURL?.includes('/subviews')) {
+          extensionId = parameters.linkURL.split('/subviews/')[1];
         }
         return [
           {
             label: `Open DevTools of ${decodeURI(extensionId)} Extension`,
             // make it visible when link contains contribs and we're inside the extension
             visible:
-              parameters.linkURL.includes('/contribs/') && parameters.pageURL.includes(`/contribs/${extensionId}`),
+              parameters.linkURL.includes('/subviews/') && parameters.pageURL.includes(`/subviews/${extensionId}`),
             click: () => {
               browserWindow.webContents.send('dev-tools:open-extension', extensionId.replaceAll('%20', '-'));
             },

--- a/packages/main/src/plugin/api/subviewInfo.ts
+++ b/packages/main/src/plugin/api/subviewInfo.ts
@@ -26,7 +26,7 @@ export interface SubviewInfo {
   // base64 encoded icon in format: 'data:image/svg+xml;base64,<content>'
   icon: string;
   // extension id related to the subview
-  extensionId: string;
+  extensionId?: string;
   // port use for the exposure and to allow the extension to connect to the service
   vmServicePort?: number;
 }

--- a/packages/main/src/plugin/api/subviewInfo.ts
+++ b/packages/main/src/plugin/api/subviewInfo.ts
@@ -1,0 +1,32 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+export interface SubviewInfo {
+  // unique identifier
+  id: string;
+  // the source (aka path to index.html)
+  source: string;
+  // name to display
+  name: string;
+  // base64 encoded icon in format: 'data:image/svg+xml;base64,<content>'
+  icon: string;
+  // extension id related to the subview
+  extensionId: string;
+  // port use for the exposure and to allow the extension to connect to the service
+  vmServicePort?: number;
+}

--- a/packages/main/src/plugin/contribution-manager.ts
+++ b/packages/main/src/plugin/contribution-manager.ts
@@ -27,6 +27,7 @@ import * as jsYaml from 'js-yaml';
 import type { RunResult } from '@podman-desktop/api';
 import type { ContainerProviderRegistry } from './container-registry.js';
 import { isLinux, isMac, isWindows } from '../util.js';
+import type { SubviewRegistry } from '/@/plugin/subview-registry.js';
 
 export interface DockerExtensionMetadata {
   name: string;
@@ -74,6 +75,7 @@ export class ContributionManager {
     private directories: Directories,
     private containerRegistry: ContainerProviderRegistry,
     private exec: Exec,
+    private subviewRegistry: SubviewRegistry,
   ) {}
 
   // load the existing contributions
@@ -141,6 +143,17 @@ export class ContributionManager {
     // flatten
     this.contributions = allContribs.flat();
     this.apiSender.send('contribution-register', this.contributions);
+
+    this.contributions.forEach(contribution => {
+      this.subviewRegistry.register({
+        id: contribution.id,
+        source: contribution.uiUri,
+        name: contribution.name,
+        icon: contribution.icon,
+        extensionId: contribution.extensionId,
+        vmServicePort: contribution.vmServicePort,
+      });
+    });
 
     // start vm engine but do not hold before returning
     this.startVMs().catch((error: unknown) => {

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -70,6 +70,7 @@ import type { KubeGeneratorRegistry, KubernetesGeneratorProvider } from '/@/plug
 import type { CliToolRegistry } from './cli-tool-registry.js';
 import type { NotificationRegistry } from './notification-registry.js';
 import type { ImageCheckerImpl } from './image-checker.js';
+import type { SubviewRegistry } from '/@/plugin/subview-registry.js';
 
 /**
  * Handle the loading of an extension
@@ -161,6 +162,7 @@ export class ExtensionLoader {
     private cliToolRegistry: CliToolRegistry,
     private notificationRegistry: NotificationRegistry,
     private imageCheckerProvider: ImageCheckerImpl,
+    private subviewRegistry: SubviewRegistry,
   ) {
     this.pluginsDirectory = directories.getPluginsDirectory();
     this.pluginsScanDirectory = directories.getPluginsScanDirectory();
@@ -1055,6 +1057,14 @@ export class ExtensionLoader {
       },
     };
 
+    const subviewRegistry = this.subviewRegistry;
+    const subview: typeof containerDesktopAPI.subview = {
+      registerSubview(option: containerDesktopAPI.SubviewOption): containerDesktopAPI.Disposable {
+        return subviewRegistry.register({
+          ...option,
+        });
+      },
+    };
     return <typeof containerDesktopAPI>{
       // Types
       Disposable: Disposable,
@@ -1084,6 +1094,7 @@ export class ExtensionLoader {
       context: contextAPI,
       cli,
       imageChecker,
+      subview,
     };
   }
 

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -767,6 +767,7 @@ export class PluginSystem {
       cliToolRegistry,
       notificationRegistry,
       imageChecker,
+      subviewRegistry,
     );
     await this.extensionLoader.init();
 

--- a/packages/main/src/plugin/registry.ts
+++ b/packages/main/src/plugin/registry.ts
@@ -1,0 +1,43 @@
+import type { Disposable } from './types/disposable.js';
+
+/**
+ * Registry is an abstract class representing a registry pattern for managing
+ * items with unique identifiers.
+ *
+ * @typeparam T - The type of items to be registered, must have a partial
+ * property `id` of type `E`.
+ * @typeparam E - The type of unique identifiers used to register and unregister
+ * items.
+ *
+ * @remarks
+ * This class serves as a foundation for creating registries that can be used
+ * to manage collections of items with unique identifiers. Subclasses should
+ * implement the `register` and `unregister` methods to define how items are
+ * added to and removed from the registry.
+ */
+export abstract class Registry<T extends Partial<{ id: E }>, E> {
+  /**
+   * Registers an item into the registry.
+   *
+   * @param item - The item to be registered. It must have a partial property
+   * `id` of type `E` to uniquely identify the item.
+   * @returns A Disposable object that can be used to unregister the item
+   * from the registry and dispose of associated resources.
+   *
+   * @remarks
+   * Subclasses must implement this method to define how items are added to the
+   * registry.
+   */
+  abstract register(item: T): Disposable;
+
+  /**
+   * Unregisters an item from the registry based on its unique identifier.
+   *
+   * @param id - The unique identifier of the item to be unregistered.
+   *
+   * @remarks
+   * Subclasses must implement this method to define how items are removed
+   * from the registry.
+   */
+  abstract unregister(id: E): void;
+}

--- a/packages/main/src/plugin/subview-registry.ts
+++ b/packages/main/src/plugin/subview-registry.ts
@@ -1,0 +1,29 @@
+import type { ApiSenderType } from '/@/plugin/api.js';
+import { Registry } from '/@/plugin/registry.js';
+import { Disposable } from './types/disposable.js';
+import type { SubviewInfo } from '/@/plugin/api/subviewInfo.js';
+
+export class SubviewRegistry extends Registry<SubviewInfo, string> {
+  protected subviews: Map<string, SubviewInfo> = new Map();
+
+  constructor(private apiSender: ApiSenderType) {
+    super();
+  }
+
+  listSubviews(): SubviewInfo[] {
+    return Array.from(this.subviews.values());
+  }
+
+  register(item: SubviewInfo): Disposable {
+    this.subviews.set(item.id, item);
+    this.apiSender.send('subview-register');
+    return new Disposable(() => {
+      this.unregister(item.id);
+    });
+  }
+
+  unregister(id: string): void {
+    this.subviews.delete(id);
+    this.apiSender.send('subview-unregister');
+  }
+}

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -90,6 +90,7 @@ import type { KubeContext } from '../../main/src/plugin/kubernetes-context';
 
 import type { KubernetesGeneratorInfo } from '../../main/src/plugin/api/KubernetesGeneratorInfo';
 import type { NotificationCard, NotificationCardOptions } from '../../main/src/plugin/api/notification';
+import type { SubviewInfo } from '../../main/src/plugin/api/subviewInfo';
 
 export type DialogResultCallback = (openDialogReturnValue: Electron.OpenDialogReturnValue) => void;
 
@@ -1243,6 +1244,10 @@ function initExposure(): void {
 
   contextBridge.exposeInMainWorld('listContributions', async (): Promise<ContributionInfo[]> => {
     return ipcInvoke('contributions:listContributions');
+  });
+
+  contextBridge.exposeInMainWorld('listSubviews', async (): Promise<SubviewInfo[]> => {
+    return ipcInvoke('subviews:listSubviews');
   });
 
   contextBridge.exposeInMainWorld('listIcons', async (): Promise<IconInfo[]> => {

--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -9,7 +9,7 @@ import ImagesList from './lib/image/ImagesList.svelte';
 import PreferencesPage from './lib/preferences/PreferencesPage.svelte';
 import BuildImageFromContainerfile from './lib/image/BuildImageFromContainerfile.svelte';
 import PullImage from './lib/image/PullImage.svelte';
-import DockerExtension from './lib/docker-extension/DockerExtension.svelte';
+import Subview from './lib/subview/Subview.svelte';
 import ContainerDetails from './lib/container/ContainerDetails.svelte';
 import WelcomePage from './lib/welcome/WelcomePage.svelte';
 import DashboardPage from './lib/dashboard/DashboardPage.svelte';
@@ -172,8 +172,8 @@ window.events?.receive('display-troubleshooting', () => {
         <Route path="/preferences/*" breadcrumb="Settings">
           <PreferencesPage />
         </Route>
-        <Route path="/contribs/:name/*" breadcrumb="Extension" let:meta>
-          <DockerExtension name="{decodeURI(meta.params.name)}" />
+        <Route path="/subviews/:name/*" breadcrumb="Extension" let:meta>
+          <Subview id="{decodeURI(meta.params.name)}" />
         </Route>
         <Route path="/help" breadcrumb="Help">
           <HelpPage />

--- a/packages/renderer/src/AppNavigation.svelte
+++ b/packages/renderer/src/AppNavigation.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { contributions } from './stores/contribs';
+import { subviews } from './stores/subviews';
 import { onDestroy, onMount } from 'svelte';
 import { CommandRegistry } from './lib/CommandRegistry';
 import { podsInfos } from './stores/pods';
@@ -163,12 +163,12 @@ export let meta: TinroRouteMeta;
     </NavItem>
   {/if}
 
-  {#if $contributions.length > 0}
+  {#if $subviews.length > 0}
     <div class="mx-3 my-2 h-[1px] bg-zinc-600"></div>
   {/if}
-  {#each $contributions as contribution}
-    <NavItem href="/contribs/{contribution.name}" tooltip="{contribution.name}" bind:meta="{meta}">
-      <img src="{contribution.icon}" width="24" height="24" alt="{contribution.name}" />
+  {#each $subviews as subview}
+    <NavItem href="/subviews/{subview.id}" tooltip="{subview.name}" bind:meta="{meta}">
+      <img src="{subview.icon}" width="24" height="24" alt="{subview.name}" />
     </NavItem>
   {/each}
 

--- a/packages/renderer/src/Loader.svelte
+++ b/packages/renderer/src/Loader.svelte
@@ -72,7 +72,7 @@ window.events?.receive('install-extension:from-id', (extensionId: any) => {
 });
 
 // Wait that the server-side is ready
-window.events.receive('starting-extensions', (value: string) => {
+window.events?.receive('starting-extensions', (value: string) => {
   systemReady = value === 'true';
   if (systemReady) {
     window.dispatchEvent(new CustomEvent('system-ready', {}));

--- a/packages/renderer/src/lib/subview/Subview.svelte
+++ b/packages/renderer/src/lib/subview/Subview.svelte
@@ -1,22 +1,22 @@
 <script lang="ts">
 import { afterUpdate, onMount } from 'svelte';
-import { contributions } from '../../stores/contribs';
+import { subviews } from '../../stores/subviews';
 import Route from '../../Route.svelte';
 
-export let name: string;
+export let id: string;
 let source: string | undefined;
 let arch: string;
 let hostname: string;
 let platform: string;
 
 let preloadPath: string;
-$: currentContrib = $contributions.find(contrib => contrib.name === name);
+$: currentSubview = $subviews.find(subview => subview.id === id);
 
-$: webviewId = name.replaceAll(' ', '-');
+$: webviewId = id.replaceAll(' ', '-');
 
 afterUpdate(() => {
-  console.log('contribution', currentContrib);
-  source = currentContrib?.uiUri;
+  console.log('contribution', currentSubview);
+  source = currentSubview?.source;
 });
 
 onMount(async () => {
@@ -25,7 +25,7 @@ onMount(async () => {
   hostname = await window.getOsHostname();
   platform = await window.getOsPlatform();
   preloadPath = await window.getDDPreloadPath();
-  source = currentContrib?.uiUri;
+  source = currentSubview?.source;
 });
 
 window.events?.receive('dev-tools:open-extension', (extensionId: any) => {
@@ -38,10 +38,10 @@ window.events?.receive('dev-tools:open-extension', (extensionId: any) => {
 </script>
 
 {#if source && preloadPath}
-  <Route path="/*" breadcrumb="{name}">
+  <Route path="/*" breadcrumb="{id}">
     <webview
       id="dd-webview-{webviewId}"
-      src="{source}?extensionName={currentContrib?.extensionId}&arch={arch}&hostname={hostname}&platform={platform}&vmServicePort={currentContrib?.vmServicePort}"
+      src="{source}?extensionName={currentSubview?.extensionId}&arch={arch}&hostname={hostname}&platform={platform}&vmServicePort={currentSubview?.vmServicePort}"
       preload="{preloadPath}"
       style="height: 100%; width: 100%"></webview>
   </Route>


### PR DESCRIPTION
### What does this PR do?

Related to #5140

This PR is trying to abstract and reuse the existing implementation used for Docker Extension UI.

> The word `subview` is used instead of `webview` (we can change it, it was ), but it was to emphasis with the relation with the parent page.
- Creating a SubviewRegistry 
- The ContributionManager will register each contribution having an UI to the SubviewRegistry
- A Subviews store is created and used by the AppNavigation (instead of Contributions)
- Rename and abstract the DockerExtension.svelte component to Subview.svelte
- Introducing `extensionApi.subview.registerSubview` method 

**warning:** The docker-extension-preload script will be used. Meaning, extension loading a custom page will have access to Docker client through `window.ddClient`.

## Future consideration

Should we allow the extension to register they own preload script ?
> Me personal thought on the subject is **not** to allow extension to register their own preload as it is runned with full node capabilities, therefore leading to potential security issue.

How subview should interact with podman apis ? Does the `extensionApi` should be available, therefore requiring to load it in the extension preload (more complex that it seems) ?

Should the Podman extension have access to the Docker Client adapter provided by the `package/docker-extension-preload` ?