### PR TITLE
feat: Deployments & Service details pages

### DIFF
--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -22,7 +22,9 @@ import AppNavigation from './AppNavigation.svelte';
 import VolumesList from './lib/volume/VolumesList.svelte';
 import VolumeDetails from './lib/volume/VolumeDetails.svelte';
 import DeploymentsList from './lib/deployments/DeploymentsList.svelte';
+import DeploymentDetails from './lib/deployments/DeploymentDetails.svelte';
 import ServicesList from './lib/service/ServicesList.svelte';
+import ServiceDetails from './lib/service/ServiceDetails.svelte';
 import KubePlayYAML from './lib/kube/KubePlayYAML.svelte';
 import PodDetails from './lib/pod/PodDetails.svelte';
 import ComposeDetails from './lib/compose/ComposeDetails.svelte';
@@ -164,8 +166,14 @@ window.events?.receive('navigate', (navigationRequest: unknown) => {
         <Route path="/deployments" breadcrumb="Deployments" navigationHint="root">
           <DeploymentsList />
         </Route>
+        <Route path="/deployments/:name/:namespace/*" breadcrumb="Deployment Details" let:meta navigationHint="details">
+          <DeploymentDetails name="{decodeURI(meta.params.name)}" namespace="{decodeURI(meta.params.namespace)}" />
+        </Route>
         <Route path="/services" breadcrumb="Services" navigationHint="root">
           <ServicesList />
+        </Route>
+        <Route path="/services/:name/:namespace/*" breadcrumb="Service Details" let:meta navigationHint="details">
+          <ServiceDetails name="{decodeURI(meta.params.name)}" namespace="{decodeURI(meta.params.namespace)}" />
         </Route>
         <Route path="/ingressesRoutes" breadcrumb="Ingresses & Routes" navigationHint="root">
           <IngressesRoutesList />

--- a/packages/renderer/src/lib/deployments/DeploymentColumnName.spec.ts
+++ b/packages/renderer/src/lib/deployments/DeploymentColumnName.spec.ts
@@ -17,26 +17,42 @@
  ***********************************************************************/
 
 import '@testing-library/jest-dom/vitest';
-import { test, expect } from 'vitest';
-import { render, screen } from '@testing-library/svelte';
+import { test, expect, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/svelte';
 
 import DeploymentColumnName from './DeploymentColumnName.svelte';
 import type { DeploymentUI } from './DeploymentUI';
+import { router } from 'tinro';
+
+const deployment: DeploymentUI = {
+  name: 'my-deployment',
+  status: '',
+  namespace: 'default',
+  replicas: 0,
+  ready: 0,
+  selected: false,
+  conditions: [],
+};
 
 test('Expect simple column styling', async () => {
-  const deployment: DeploymentUI = {
-    name: 'my-deployment',
-    status: '',
-    namespace: '',
-    replicas: 0,
-    ready: 0,
-    selected: false,
-    conditions: [],
-  };
   render(DeploymentColumnName, { object: deployment });
 
   const text = screen.getByText(deployment.name);
   expect(text).toBeInTheDocument();
   expect(text).toHaveClass('text-sm');
   expect(text).toHaveClass('text-gray-300');
+});
+
+test('Expect clicking works', async () => {
+  render(DeploymentColumnName, { object: deployment });
+
+  const text = screen.getByText(deployment.name);
+  expect(text).toBeInTheDocument();
+
+  // test click
+  const routerGotoSpy = vi.spyOn(router, 'goto');
+
+  fireEvent.click(text);
+
+  expect(routerGotoSpy).toBeCalledWith('/deployments/my-deployment/default/summary');
 });

--- a/packages/renderer/src/lib/deployments/DeploymentColumnName.svelte
+++ b/packages/renderer/src/lib/deployments/DeploymentColumnName.svelte
@@ -1,7 +1,14 @@
 <script lang="ts">
+import { router } from 'tinro';
 import type { DeploymentUI } from './DeploymentUI';
 
 export let object: DeploymentUI;
+
+function openDetails() {
+  router.goto(`/deployments/${encodeURI(object.name)}/${encodeURI(object.namespace)}/summary`);
+}
 </script>
 
-<div class="text-sm text-gray-300">{object.name}</div>
+<button class="hover:cursor-pointer flex flex-col" on:click="{() => openDetails()}">
+  <div class="text-sm text-gray-300">{object.name}</div>
+</button>

--- a/packages/renderer/src/lib/deployments/DeploymentDetails.spec.ts
+++ b/packages/renderer/src/lib/deployments/DeploymentDetails.spec.ts
@@ -1,0 +1,85 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+import { test, expect, vi, beforeAll } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/svelte';
+
+import DeploymentDetails from './DeploymentDetails.svelte';
+
+import { router } from 'tinro';
+import { lastPage } from '/@/stores/breadcrumb';
+import { deployments } from '/@/stores/deployments';
+import type { V1Deployment } from '@kubernetes/client-node';
+
+const kubernetesDeleteDeploymentMock = vi.fn();
+
+const deployment: V1Deployment = {
+  apiVersion: 'apps/v1',
+  kind: 'Deployment',
+  metadata: {
+    name: 'my-deployment',
+    namespace: 'default',
+  },
+  spec: {
+    replicas: 2,
+    selector: {},
+    template: {},
+  },
+};
+
+beforeAll(() => {
+  (window as any).kubernetesDeleteDeployment = kubernetesDeleteDeploymentMock;
+  (window as any).kubernetesReadNamespacedDeployment = vi.fn();
+});
+
+test('Expect redirect to previous page if deployment is deleted', async () => {
+  const routerGotoSpy = vi.spyOn(router, 'goto');
+  deployments.set([deployment]);
+
+  // remove deployment from the store when we call delete
+  kubernetesDeleteDeploymentMock.mockImplementation(() => {
+    deployments.set([]);
+  });
+
+  // define a fake lastPage so we can check where we will be redirected
+  lastPage.set({ name: 'Fake Previous', path: '/last' });
+
+  // render the component
+  render(DeploymentDetails, { name: 'my-deployment', namespace: 'default' });
+  expect(screen.getByText('my-deployment')).toBeInTheDocument();
+
+  // grab current route
+  const currentRoute = window.location;
+  expect(currentRoute.href).toBe('http://localhost:3000/');
+
+  // click on delete button
+  const deleteButton = screen.getByRole('button', { name: 'Delete Deployment' });
+  await fireEvent.click(deleteButton);
+
+  // check that delete method has been called
+  expect(kubernetesDeleteDeploymentMock).toHaveBeenCalled();
+
+  // expect that we have called the router when page has been removed
+  // to jump to the previous page
+  expect(routerGotoSpy).toBeCalledWith('/last');
+
+  // confirm updated route
+  const afterRoute = window.location;
+  expect(afterRoute.href).toBe('http://localhost:3000/last');
+});

--- a/packages/renderer/src/lib/deployments/DeploymentDetails.svelte
+++ b/packages/renderer/src/lib/deployments/DeploymentDetails.svelte
@@ -1,0 +1,79 @@
+<script lang="ts">
+import Route from '../../Route.svelte';
+import { onMount } from 'svelte';
+import type { DeploymentUI } from './DeploymentUI';
+import { DeploymentUtils } from './deployment-utils';
+import StatusIcon from '../images/StatusIcon.svelte';
+import DetailsPage from '../ui/DetailsPage.svelte';
+import Tab from '../ui/Tab.svelte';
+import DeploymentIcon from '../images/DeploymentIcon.svelte';
+import DeploymentActions from './DeploymentActions.svelte';
+import DeploymentDetailsSummary from './DeploymentDetailsSummary.svelte';
+import { deployments } from '/@/stores/deployments';
+import type { V1Deployment } from '@kubernetes/client-node';
+import { stringify } from 'yaml';
+import MonacoEditor from '../editor/MonacoEditor.svelte';
+
+export let name: string;
+export let namespace: string;
+
+let deployment: DeploymentUI;
+let detailsPage: DetailsPage;
+let kubeDeployment: V1Deployment | undefined;
+let kubeError: string;
+
+onMount(() => {
+  const deploymentUtils = new DeploymentUtils();
+  // loading deployment info
+  return deployments.subscribe(deployments => {
+    const matchingDeployment = deployments.find(
+      dep => dep.metadata?.name === name && dep.metadata?.namespace === namespace,
+    );
+    if (matchingDeployment) {
+      try {
+        deployment = deploymentUtils.getDeploymentUI(matchingDeployment);
+        loadDetails();
+      } catch (err) {
+        console.error(err);
+      }
+    } else if (detailsPage) {
+      // the deployment has been deleted
+      detailsPage.close();
+    }
+  });
+});
+
+async function loadDetails() {
+  const getKubeDeployment = await window.kubernetesReadNamespacedDeployment(name, namespace);
+  if (getKubeDeployment) {
+    kubeDeployment = getKubeDeployment;
+  } else {
+    kubeError = `Unable to retrieve Kubernetes details for ${deployment.name}`;
+  }
+}
+</script>
+
+{#if deployment}
+  <DetailsPage title="{deployment.name}" subtitle="{deployment.namespace}" bind:this="{detailsPage}">
+    <StatusIcon slot="icon" icon="{DeploymentIcon}" size="{24}" status="{deployment.status}" />
+    <svelte:fragment slot="actions">
+      <DeploymentActions deployment="{deployment}" detailed="{true}" on:update="{() => (deployment = deployment)}" />
+    </svelte:fragment>
+    <svelte:fragment slot="tabs">
+      <Tab title="Summary" url="summary" />
+      <Tab title="Inspect" url="inspect" />
+      <Tab title="Kube" url="kube" />
+    </svelte:fragment>
+    <svelte:fragment slot="content">
+      <Route path="/summary" breadcrumb="Summary" navigationHint="tab">
+        <DeploymentDetailsSummary deploymentUI="{deployment}" deployment="{kubeDeployment}" kubeError="{kubeError}" />
+      </Route>
+      <Route path="/inspect" breadcrumb="Inspect" navigationHint="tab">
+        <MonacoEditor content="{JSON.stringify(kubeDeployment, undefined, 2)}" language="json" />
+      </Route>
+      <Route path="/kube" breadcrumb="Kube" navigationHint="tab">
+        <MonacoEditor content="{stringify(kubeDeployment)}" language="yaml" />
+      </Route>
+    </svelte:fragment>
+  </DetailsPage>
+{/if}

--- a/packages/renderer/src/lib/deployments/DeploymentDetailsSummary.spec.ts
+++ b/packages/renderer/src/lib/deployments/DeploymentDetailsSummary.spec.ts
@@ -1,0 +1,76 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+import { test, vi, expect, beforeAll } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import DeploymentDetailsSummary from './DeploymentDetailsSummary.svelte';
+import type { DeploymentUI } from './DeploymentUI';
+import type { V1Deployment } from '@kubernetes/client-node';
+
+const deploymentUI: DeploymentUI = {
+  name: 'my-deployment',
+  status: 'RUNNING',
+  namespace: 'default',
+  replicas: 0,
+  ready: 0,
+  selected: false,
+  conditions: [],
+};
+
+const deployment: V1Deployment = {
+  apiVersion: 'apps/v1',
+  kind: 'Deployment',
+  metadata: {
+    name: 'my-deployment',
+    namespace: 'default',
+  },
+  spec: {
+    replicas: 2,
+    selector: {},
+    template: {},
+  },
+};
+
+const kubernetesGetCurrentNamespaceMock = vi.fn();
+const kubernetesReadNamespacedDeploymentMock = vi.fn();
+
+beforeAll(() => {
+  (window as any).kubernetesGetCurrentNamespace = kubernetesGetCurrentNamespaceMock;
+  (window as any).kubernetesReadNamespacedDeployment = kubernetesReadNamespacedDeploymentMock;
+});
+
+test('Expect basic rendering', async () => {
+  kubernetesGetCurrentNamespaceMock.mockResolvedValue('default');
+  kubernetesReadNamespacedDeploymentMock.mockResolvedValue(deployment);
+
+  render(DeploymentDetailsSummary, { deploymentUI: deploymentUI, deployment: deployment });
+
+  expect(screen.getByText(deploymentUI.name)).toBeInTheDocument();
+});
+
+test('Check more properties', async () => {
+  kubernetesGetCurrentNamespaceMock.mockResolvedValue('default');
+  kubernetesReadNamespacedDeploymentMock.mockResolvedValue(undefined);
+
+  render(DeploymentDetailsSummary, { deploymentUI: deploymentUI, deployment: deployment });
+
+  // Expect the name and namespace to show
+  expect(screen.getByText(deploymentUI.name)).toBeInTheDocument();
+  expect(screen.getByText(deploymentUI.namespace)).toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/deployments/DeploymentDetailsSummary.svelte
+++ b/packages/renderer/src/lib/deployments/DeploymentDetailsSummary.svelte
@@ -1,0 +1,48 @@
+<script lang="ts">
+import type { V1Deployment } from '@kubernetes/client-node';
+import ErrorMessage from '../ui/ErrorMessage.svelte';
+import DeploymentColumnConditions from './DeploymentColumnConditions.svelte';
+import type { DeploymentUI } from './DeploymentUI';
+import DeploymentColumnPods from './DeploymentColumnPods.svelte';
+
+export let deploymentUI: DeploymentUI;
+export let deployment: V1Deployment | undefined;
+export let kubeError: string | undefined = undefined;
+</script>
+
+<!-- Show the kube error if we're unable to retrieve the data correctly, but we still want to show the 
+basic information -->
+{#if kubeError}
+  <ErrorMessage error="{kubeError}" />
+{/if}
+
+<div class="flex px-5 py-4 flex-col h-full overflow-auto">
+  {#if deployment}
+    <table class="w-full">
+      <tbody>
+        <tr>
+          <td class="pr-2">Name</td>
+          <td>{deployment.metadata?.name}</td>
+        </tr>
+        <tr>
+          <td class="pr-2">Namespace</td>
+          <td>{deployment.metadata?.namespace}</td>
+        </tr>
+        <tr>
+          <td class="pr-2">Created</td>
+          <td>{deployment.metadata?.creationTimestamp}</td>
+        </tr>
+        <tr>
+          <td class="pr-2">Conditions</td>
+          <td><DeploymentColumnConditions object="{deploymentUI}" /></td>
+        </tr>
+        <tr>
+          <td class="pr-2">Pods</td>
+          <td><DeploymentColumnPods object="{deploymentUI}" /></td>
+        </tr>
+      </tbody>
+    </table>
+  {:else}
+    <p class="text-purple-500 font-medium">Loading ...</p>
+  {/if}
+</div>

--- a/packages/renderer/src/lib/service/ServiceColumnName.spec.ts
+++ b/packages/renderer/src/lib/service/ServiceColumnName.spec.ts
@@ -17,16 +17,18 @@
  ***********************************************************************/
 
 import '@testing-library/jest-dom/vitest';
-import { test, expect } from 'vitest';
+import { test, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/svelte';
 
 import ServiceColumnName from './ServiceColumnName.svelte';
 import type { ServiceUI } from './ServiceUI';
+import { router } from 'tinro';
+import { fireEvent } from '@testing-library/dom';
 
 const service: ServiceUI = {
   name: 'my-service',
   status: 'RUNNING',
-  namespace: '',
+  namespace: 'default',
   selected: false,
   type: '',
   clusterIP: '',
@@ -40,4 +42,18 @@ test('Expect simple column styling', async () => {
   expect(text).toBeInTheDocument();
   expect(text).toHaveClass('text-sm');
   expect(text).toHaveClass('text-gray-300');
+});
+
+test('Expect clicking works', async () => {
+  render(ServiceColumnName, { object: service });
+
+  const text = screen.getByText(service.name);
+  expect(text).toBeInTheDocument();
+
+  // test click
+  const routerGotoSpy = vi.spyOn(router, 'goto');
+
+  fireEvent.click(text);
+
+  expect(routerGotoSpy).toBeCalledWith('/services/my-service/default/summary');
 });

--- a/packages/renderer/src/lib/service/ServiceColumnName.svelte
+++ b/packages/renderer/src/lib/service/ServiceColumnName.svelte
@@ -1,7 +1,14 @@
 <script lang="ts">
+import { router } from 'tinro';
 import type { ServiceUI } from './ServiceUI';
 
 export let object: ServiceUI;
+
+function openDetails() {
+  router.goto(`/services/${encodeURI(object.name)}/${encodeURI(object.namespace)}/summary`);
+}
 </script>
 
-<div class="text-sm text-gray-300">{object.name}</div>
+<button class="hover:cursor-pointer flex flex-col" on:click="{() => openDetails()}">
+  <div class="text-sm text-gray-300">{object.name}</div>
+</button>

--- a/packages/renderer/src/lib/service/ServiceDetails.spec.ts
+++ b/packages/renderer/src/lib/service/ServiceDetails.spec.ts
@@ -1,0 +1,80 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+import { test, expect, vi, beforeAll } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/svelte';
+
+import ServiceDetails from './ServiceDetails.svelte';
+
+import { router } from 'tinro';
+import { lastPage } from '/@/stores/breadcrumb';
+import { services } from '/@/stores/services';
+import type { V1Service } from '@kubernetes/client-node';
+
+const kubernetesDeleteServiceMock = vi.fn();
+
+const service: V1Service = {
+  metadata: {
+    name: 'my-service',
+    namespace: 'default',
+  },
+  status: {},
+};
+
+beforeAll(() => {
+  (window as any).kubernetesDeleteService = kubernetesDeleteServiceMock;
+  (window as any).kubernetesReadNamespacedService = vi.fn();
+  //kubernetesGetCurrentNamespace
+});
+
+test('Expect redirect to previous page if service is deleted', async () => {
+  const routerGotoSpy = vi.spyOn(router, 'goto');
+  services.set([service]);
+
+  // remove service from the store when we call delete
+  kubernetesDeleteServiceMock.mockImplementation(() => {
+    services.set([]);
+  });
+
+  // define a fake lastPage so we can check where we will be redirected
+  lastPage.set({ name: 'Fake Previous', path: '/last' });
+
+  // render the component
+  render(ServiceDetails, { name: 'my-service', namespace: 'default' });
+  expect(screen.getByText('my-service')).toBeInTheDocument();
+
+  // grab current route
+  const currentRoute = window.location;
+  expect(currentRoute.href).toBe('http://localhost:3000/');
+
+  // click on delete button
+  const deleteButton = screen.getByRole('button', { name: 'Delete Service' });
+  await fireEvent.click(deleteButton);
+
+  // check that delete method has been called
+  expect(kubernetesDeleteServiceMock).toHaveBeenCalled();
+
+  // expect that we have called the router when page has been removed
+  // to jump to the previous page
+  expect(routerGotoSpy).toBeCalledWith('/last');
+
+  // confirm updated route
+  const afterRoute = window.location;
+  expect(afterRoute.href).toBe('http://localhost:3000/last');
+});

--- a/packages/renderer/src/lib/service/ServiceDetails.spec.ts
+++ b/packages/renderer/src/lib/service/ServiceDetails.spec.ts
@@ -40,7 +40,6 @@ const service: V1Service = {
 beforeAll(() => {
   (window as any).kubernetesDeleteService = kubernetesDeleteServiceMock;
   (window as any).kubernetesReadNamespacedService = vi.fn();
-  //kubernetesGetCurrentNamespace
 });
 
 test('Expect redirect to previous page if service is deleted', async () => {

--- a/packages/renderer/src/lib/service/ServiceDetails.svelte
+++ b/packages/renderer/src/lib/service/ServiceDetails.svelte
@@ -1,0 +1,81 @@
+<script lang="ts">
+import Route from '../../Route.svelte';
+import { onMount } from 'svelte';
+import StatusIcon from '../images/StatusIcon.svelte';
+import DetailsPage from '../ui/DetailsPage.svelte';
+import Tab from '../ui/Tab.svelte';
+import StateChange from '../ui/StateChange.svelte';
+import type { V1Service } from '@kubernetes/client-node';
+import { stringify } from 'yaml';
+import MonacoEditor from '../editor/MonacoEditor.svelte';
+import type { ServiceUI } from './ServiceUI';
+import { ServiceUtils } from './service-utils';
+import { services } from '/@/stores/services';
+import ServiceActions from './ServiceActions.svelte';
+import ServiceDetailsSummary from './ServiceDetailsSummary.svelte';
+import ServiceIcon from '../images/ServiceIcon.svelte';
+
+export let name: string;
+export let namespace: string;
+
+let service: ServiceUI;
+let detailsPage: DetailsPage;
+let kubeService: V1Service | undefined;
+let kubeError: string;
+
+onMount(() => {
+  const serviceUtils = new ServiceUtils();
+  // loading service info
+  return services.subscribe(services => {
+    const matchingService = services.find(srv => srv.metadata?.name === name && srv.metadata?.namespace === namespace);
+    if (matchingService) {
+      try {
+        service = serviceUtils.getServiceUI(matchingService);
+        loadDetails();
+      } catch (err) {
+        console.error(err);
+      }
+    } else if (detailsPage) {
+      // the service has been deleted
+      detailsPage.close();
+    }
+  });
+});
+
+async function loadDetails() {
+  const getKubeService = await window.kubernetesReadNamespacedService(service.name, namespace);
+  if (getKubeService) {
+    kubeService = getKubeService;
+  } else {
+    kubeError = `Unable to retrieve Kubernetes details for ${service.name}`;
+  }
+}
+</script>
+
+{#if service}
+  <DetailsPage title="{service.name}" subtitle="{service.namespace}" bind:this="{detailsPage}">
+    <StatusIcon slot="icon" icon="{ServiceIcon}" size="{24}" status="{service.status}" />
+    <svelte:fragment slot="actions">
+      <ServiceActions service="{service}" detailed="{true}" on:update="{() => (service = service)}" />
+    </svelte:fragment>
+    <div slot="detail" class="flex py-2 w-full justify-end text-sm text-gray-700">
+      <StateChange state="{service.status}" />
+    </div>
+    <svelte:fragment slot="tabs">
+      <Tab title="Summary" url="summary" />
+      <Tab title="Inspect" url="inspect" />
+      <Tab title="Kube" url="kube" />
+    </svelte:fragment>
+    <svelte:fragment slot="content">
+      <Route path="/summary" breadcrumb="Summary" navigationHint="tab">
+        <ServiceDetailsSummary serviceUI="{service}" service="{kubeService}" kubeError="{kubeError}" />
+      </Route>
+      <Route path="/inspect" breadcrumb="Inspect" navigationHint="tab">
+        <MonacoEditor content="{JSON.stringify(kubeService, undefined, 2)}" language="json" />
+      </Route>
+      <Route path="/kube" breadcrumb="Kube" navigationHint="tab">
+        <MonacoEditor content="{stringify(kubeService)}" language="yaml" />
+      </Route>
+    </svelte:fragment>
+  </DetailsPage>
+{/if}

--- a/packages/renderer/src/lib/service/ServiceDetailsSummary.spec.ts
+++ b/packages/renderer/src/lib/service/ServiceDetailsSummary.spec.ts
@@ -29,7 +29,7 @@ const serviceUI: ServiceUI = {
   namespace: 'default',
   selected: false,
   type: '',
-  clusterIP: '10.1.1.0',
+  clusterIP: 'the-cluster-ip',
   ports: '80/TCP',
 };
 

--- a/packages/renderer/src/lib/service/ServiceDetailsSummary.spec.ts
+++ b/packages/renderer/src/lib/service/ServiceDetailsSummary.spec.ts
@@ -1,0 +1,71 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+import { test, vi, expect, beforeAll } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import ServiceDetailsSummary from './ServiceDetailsSummary.svelte';
+import type { ServiceUI } from './ServiceUI';
+import type { V1Service } from '@kubernetes/client-node';
+
+const serviceUI: ServiceUI = {
+  name: 'my-service',
+  status: 'RUNNING',
+  namespace: 'default',
+  selected: false,
+  type: '',
+  clusterIP: '10.1.1.0',
+  ports: '80/TCP',
+};
+
+const service: V1Service = {
+  metadata: {
+    name: 'my-service',
+    namespace: 'default',
+  },
+  status: {},
+};
+
+const kubernetesGetCurrentNamespaceMock = vi.fn();
+const kubernetesReadNamespacedServiceMock = vi.fn();
+
+beforeAll(() => {
+  (window as any).kubernetesGetCurrentNamespace = kubernetesGetCurrentNamespaceMock;
+  (window as any).kubernetesReadNamespacedService = kubernetesReadNamespacedServiceMock;
+});
+
+test('Expect basic rendering', async () => {
+  kubernetesGetCurrentNamespaceMock.mockResolvedValue('default');
+  kubernetesReadNamespacedServiceMock.mockResolvedValue(service);
+
+  render(ServiceDetailsSummary, { serviceUI: serviceUI, service: service });
+
+  expect(screen.getByText(serviceUI.name)).toBeInTheDocument();
+});
+
+test('Check more properties', async () => {
+  kubernetesGetCurrentNamespaceMock.mockResolvedValue('default');
+  kubernetesReadNamespacedServiceMock.mockResolvedValue(undefined);
+
+  render(ServiceDetailsSummary, { serviceUI: serviceUI, service: service });
+
+  expect(screen.getByText(serviceUI.name)).toBeInTheDocument();
+  expect(screen.getByText(serviceUI.namespace)).toBeInTheDocument();
+  expect(screen.getByText(serviceUI.clusterIP)).toBeInTheDocument();
+  expect(screen.getByText(serviceUI.ports)).toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/service/ServiceDetailsSummary.svelte
+++ b/packages/renderer/src/lib/service/ServiceDetailsSummary.svelte
@@ -1,0 +1,51 @@
+<script lang="ts">
+import type { V1Service } from '@kubernetes/client-node';
+import ErrorMessage from '../ui/ErrorMessage.svelte';
+import type { ServiceUI } from './ServiceUI';
+import ServiceColumnType from './ServiceColumnType.svelte';
+
+export let serviceUI: ServiceUI;
+export let service: V1Service | undefined;
+export let kubeError: string | undefined = undefined;
+</script>
+
+<!-- Show the kube error if we're unable to retrieve the data correctly, but we still want to show the 
+basic information -->
+{#if kubeError}
+  <ErrorMessage error="{kubeError}" />
+{/if}
+
+<div class="flex px-5 py-4 flex-col h-full overflow-auto">
+  {#if service}
+    <table class="w-full">
+      <tbody>
+        <tr>
+          <td class="pr-2">Name</td>
+          <td>{service.metadata?.name}</td>
+        </tr>
+        <tr>
+          <td class="pr-2">Namespace</td>
+          <td>{service.metadata?.namespace}</td>
+        </tr>
+        <tr>
+          <td class="pr-2">Created</td>
+          <td>{service.metadata?.creationTimestamp}</td>
+        </tr>
+        <tr>
+          <td class="pr-2">Type</td>
+          <td><div class="flex flex-row"><ServiceColumnType object="{serviceUI}" /></div></td>
+        </tr>
+        <tr>
+          <td class="pr-2">Cluster IP</td>
+          <td>{serviceUI.clusterIP}</td>
+        </tr>
+        <tr>
+          <td class="pr-2">Ports</td>
+          <td>{serviceUI.ports}</td>
+        </tr>
+      </tbody>
+    </table>
+  {:else}
+    <p class="text-purple-500 font-medium">Loading ...</p>
+  {/if}
+</div>


### PR DESCRIPTION
### What does this PR do?

This is Details pages for both Deployments and Services. Name columns
are updated to buttons that link to details pages, just like in
other pages.

Compared to what we have for pods I did two things differently:
- kube objects are read once for all tabs, instead of each tab loading them independently.
- Due to this we can make Inspect and Kube tabs simple Monaco components (basically just JSON and YAML versions of the same thing) instead of having additional Svelte components.

For the Summary page I added a few fields to start, and tried reusing some of the table columns.

### Screenshot / video of UI

<img width="631" alt="Screenshot 2024-01-07 at 6 22 47 PM" src="https://github.com/containers/podman-desktop/assets/19958075/8718ecd6-7d7a-4241-bcca-6a924783c98e">
<img width="631" alt="Screenshot 2024-01-07 at 6 23 19 PM" src="https://github.com/containers/podman-desktop/assets/19958075/83ce2c5c-b552-4621-be0a-f4f04287ccb4">

### What issues does this PR fix or reference?

Fixes #5157.
Fixes #5159.

### How to test this PR?

Click on a deployment or service.