### PR TITLE
fix: refresh provider preferences if onboarding has changed

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.spec.ts
@@ -402,3 +402,34 @@ test('Expect to redirect to extension onboarding page if onboarding is enabled a
   // redirect to create new page
   expect(router.goto).toHaveBeenCalledWith('/preferences/onboarding/id');
 });
+
+test('Expect providers to refresh if extensionOnboardingEnablement has changed', async () => {
+  // clone providerInfo and change id and status
+  const customProviderInfo: ProviderInfo = { ...providerInfo };
+  customProviderInfo.containerProviderConnectionCreationDisplayName = undefined;
+  customProviderInfo.status = 'installed';
+  customProviderInfo.name = 'foo-provider';
+  providerInfos.set([customProviderInfo]);
+
+  const onboarding: OnboardingInfo = {
+    extension: 'id',
+    steps: [],
+    title: 'onboarding',
+    enablement: 'true',
+  };
+  onboardingList.set([onboarding]);
+  render(PreferencesResourcesRendering, {});
+  const button = screen.queryByRole('button', { name: 'Setup foo-provider' });
+  expect(button).toBeInTheDocument();
+
+  // change onboarding enablement
+  onboarding.enablement = 'false';
+  onboardingList.set([onboarding]);
+
+  // Using await findByRole to wait for the DOM to update
+  await screen.findByRole('button', { name: 'Setup foo-provider' });
+
+  // Expect it to be gone since onboarding.enablement is now false
+  const buttonAfterChange = screen.queryByRole('button', { name: 'Setup foo-provider' });
+  expect(buttonAfterChange).not.toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
@@ -46,7 +46,13 @@ export let properties: IConfigurationPropertyRecordedSchema[] = [];
 let providers: ProviderInfo[] = [];
 $: containerConnectionStatus = new Map<string, IConnectionStatus>();
 $: providerInstallationInProgress = new Map<string, boolean>();
+
+// If the onboarding is updated, we should force an update of the providers
+// rendering as the "Setup ..." button may have been changed based on extension contexts.
 $: extensionOnboardingEnablement = new Map<string, string>();
+$: if (extensionOnboardingEnablement) {
+  providers = providers;
+}
 
 let isStatusUpdated = false;
 let displayInstallModal = false;


### PR DESCRIPTION
fix: refresh provider preferences if onboarding has changed

### What does this PR do?

* If any of the values in onboarding has changed (status updated,
  context, etc). Force a refresh of the providers list so that the Setup
  button will appear / not appear.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

If you "force refresh" (using ctrl+r, or via drop down), the same Setup
buttons should appear.

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop/issues/5249

### How to test this PR?

<!-- Please explain steps to reproduce -->

View preferences / providers and do a forceful refresh (ctrl+r).

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
