### PR TITLE
fix: using window.showMessageBox instead of custom modal

### DIFF
--- a/packages/renderer/src/lib/image/ImageActions.spec.ts
+++ b/packages/renderer/src/lib/image/ImageActions.spec.ts
@@ -1,14 +1,42 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
 import '@testing-library/jest-dom/vitest';
 import { test, expect, vi, beforeAll } from 'vitest';
 import { render, screen, waitFor, fireEvent } from '@testing-library/svelte';
 import ImageActions from '/@/lib/image/ImageActions.svelte';
 import type { ImageInfoUI } from '/@/lib/image/ImageInfoUI';
 
+const showMessageBoxMock = vi.fn();
 const getContributedMenusMock = vi.fn();
 
-beforeAll(() => {
-  (window as any).getContributedMenus = getContributedMenusMock;
+vi.mock('./image-utils', () => {
+  return {
+    ImageUtils: vi.fn().mockImplementation(() => ({
+      deleteImage: vi.fn().mockImplementation(() => Promise.reject(new Error('Cannot delete image in test'))),
+    })),
+  };
+});
 
+beforeAll(() => {
+  (window as any).showMessageBox = showMessageBoxMock;
+
+  (window as any).getContributedMenus = getContributedMenusMock;
   (window as any).hasAuthconfigForImage = vi.fn();
   (window as any).hasAuthconfigForImage.mockImplementation(() => Promise.resolve(false));
 });
@@ -17,6 +45,24 @@ const fakedImage: ImageInfoUI = {
   id: 'dummy',
   name: 'dummy',
 } as unknown as ImageInfoUI;
+
+
+test('Expect showMessageBox to be called when error occurs', async () => {
+  render(ImageActions, {
+    onPushImage: vi.fn(),
+    onRenameImage: vi.fn(),
+    image: {
+      name: 'dummy',
+    } as unknown as ImageInfoUI,
+  });
+  const button = screen.getByTitle('Delete Image');
+  expect(button).toBeDefined();
+  await fireEvent.click(button);
+
+  await waitFor(() => {
+    expect(showMessageBoxMock).toHaveBeenCalledOnce();
+  });
+});
 
 test('Expect no dropdown when one contribution and dropdownMenu off', async () => {
   // Since we only have one contribution, we do not use a dropdown

--- a/packages/renderer/src/lib/image/ImageActions.spec.ts
+++ b/packages/renderer/src/lib/image/ImageActions.spec.ts
@@ -46,8 +46,9 @@ const fakedImage: ImageInfoUI = {
   name: 'dummy',
 } as unknown as ImageInfoUI;
 
-
 test('Expect showMessageBox to be called when error occurs', async () => {
+  getContributedMenusMock.mockImplementation(() => Promise.resolve([]));
+
   render(ImageActions, {
     onPushImage: vi.fn(),
     onRenameImage: vi.fn(),

--- a/packages/renderer/src/lib/image/ImageActions.svelte
+++ b/packages/renderer/src/lib/image/ImageActions.svelte
@@ -55,7 +55,7 @@ async function deleteImage(): Promise<void> {
   try {
     await imageUtils.deleteImage(image);
   } catch (error) {
-    onError(`Error while deleting image: ${error}`);
+    onError(`Error while deleting image: ${String(error)}`);
   }
 }
 

--- a/packages/renderer/src/lib/image/ImageActions.svelte
+++ b/packages/renderer/src/lib/image/ImageActions.svelte
@@ -1,13 +1,5 @@
 <script lang="ts">
-import {
-  faArrowUp,
-  faLayerGroup,
-  faPlay,
-  faTrash,
-  faEdit,
-  faExclamationCircle,
-  faTimes,
-} from '@fortawesome/free-solid-svg-icons';
+import { faArrowUp, faLayerGroup, faPlay, faTrash, faEdit } from '@fortawesome/free-solid-svg-icons';
 import type { ImageInfoUI } from './ImageInfoUI';
 import { router } from 'tinro';
 import ListItemButtonIcon from '../ui/ListItemButtonIcon.svelte';
@@ -21,8 +13,6 @@ import ActionsWrapper from './ActionsMenu.svelte';
 import type { Unsubscriber } from 'svelte/motion';
 import type { ContextUI } from '../context/context';
 import { context } from '/@/stores/context';
-import Fa from 'svelte-fa';
-import Button from '../ui/Button.svelte';
 
 export let onPushImage: (imageInfo: ImageInfoUI) => void;
 export let onRenameImage: (imageInfo: ImageInfoUI) => void;
@@ -31,8 +21,6 @@ export let dropdownMenu = false;
 export let detailed = false;
 export let groupContributions = false;
 
-let errorTitle: string | undefined = undefined;
-let errorMessage: string | undefined = undefined;
 let isAuthenticatedForThisImage = false;
 const imageUtils = new ImageUtils();
 
@@ -67,8 +55,7 @@ async function deleteImage(): Promise<void> {
   try {
     await imageUtils.deleteImage(image);
   } catch (error) {
-    errorTitle = 'Error while deleting image';
-    errorMessage = String(error);
+    onError(`Error while deleting image: ${error}`);
   }
 }
 
@@ -85,8 +72,11 @@ async function showLayersImage(): Promise<void> {
 }
 
 function onError(error: string): void {
-  errorTitle = 'Something went wrong.';
-  errorMessage = error;
+  window.showMessageBox({
+    title: 'Something went wrong.',
+    message: error,
+    type: 'error',
+  });
 }
 </script>
 
@@ -139,34 +129,4 @@ function onError(error: string): void {
       detailed="{detailed}"
       onError="{onError}" />
   </ActionsWrapper>
-
-  {#if errorMessage}
-    <div class="modal fixed w-full h-full top-0 left-0 flex items-center justify-center p-8 lg:p-0 z-50" tabindex="-1">
-      <div class="border-t-red-600 border-t-2 p-4 bg-charcoal-600" aria-label="Success alert">
-        <div class="flex flex-row justify-center items-center pb-2">
-          <Fa icon="{faExclamationCircle}" class="text-red-500 mr-2" />
-          <div class="text-red-500 font-bold text-sm">
-            {errorTitle}
-          </div>
-          <Fa
-            icon="{faTimes}"
-            class="text-gray-900 pl-2 cursor-pointer"
-            on:click="{() => {
-              errorMessage = undefined;
-            }}" />
-        </div>
-        <div class="flex justify-center break-words whitespace-normal text-xs pb-2">
-          {errorMessage}
-        </div>
-
-        <div class="flex flex-row justify-center">
-          <Button
-            type="link"
-            on:click="{() => {
-              errorMessage = undefined;
-            }}">Ignore</Button>
-        </div>
-      </div>
-    </div>
-  {/if}
 </ActionsWrapper>


### PR DESCRIPTION
### What does this PR do?

Replace the existing error modal implemented in the ImageAction svelte component by the `window.showMessageBox`.
- Improve consistency in application
- Avoid to maintain individual implementation of error message

### Screenshot / video of UI

| Before | After |
| --- | --- |
| ![image](https://github.com/containers/podman-desktop/assets/42176370/693c0a56-799d-480d-8856-d61b856b8343)  | <img width="788" alt="image" src="https://github.com/containers/podman-desktop/assets/42176370/5caa913f-da37-42f4-bda9-12f03eaf49e6"> | 

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop/issues/5290 https://github.com/containers/podman-desktop/issues/5420

<!-- Include any related issues from Podman Desktop 
repository (or from another issue tracker). -->

CC @lstocchi  :)