### PR TITLE
feat: improve Authentication Providers page

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesAuthenticationProvidersRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesAuthenticationProvidersRendering.svelte
@@ -7,6 +7,7 @@ import KeyIcon from '../images/KeyIcon.svelte';
 import EmptyScreen from '../ui/EmptyScreen.svelte';
 import DropdownMenu from '../ui/DropdownMenu.svelte';
 import DropdownMenuItem from '../ui/DropDownMenuItem.svelte';
+import Tooltip from '/@/lib/ui/Tooltip.svelte';
 </script>
 
 <SettingsPage title="Authentication">
@@ -19,9 +20,13 @@ import DropdownMenuItem from '../ui/DropDownMenuItem.svelte';
       hidden="{$authenticationProviders.length > 0}" />
     {#each $authenticationProviders as provider}
       <!-- Registered Authentication Provider row start -->
-      <div class="flex flex-col w-full">
-        <div class="flex rounded-md border-0" style="background-color: rgb(39 39 42 / var(--tw-bg-opacity))">
+      <div class="flex flex-col w-full mb-5">
+        <div
+          class="flex rounded-md border-0 justify-between"
+          style="background-color: rgb(39 39 42 / var(--tw-bg-opacity))">
+          <!-- Icon + status -->
           <div class="ml-4 flex items-center">
+            <!-- Icon -->
             <div class="flex">
               {#if provider?.images?.icon}
                 {#if typeof provider.images.icon === 'string'}
@@ -45,61 +50,70 @@ import DropdownMenuItem from '../ui/DropDownMenuItem.svelte';
                   aria-label="Default icon for {provider.displayName} provider" />
               {/if}
             </div>
-          </div>
-          <!-- Authentication Provider name and status item start -->
-          <div class="px-5 py-2 text-sm w-1/3 m-auto">
-            <div class="flex flex-col">
-              <div class="flex items-center text-lg w-full h-full">
-                {provider.displayName}
-              </div>
-              <div class="flex flex-row items-center w-full h-full">
-                <dif>
-                  <Fa
-                    class="h-3 w-3 text-md mr-2 text-{provider.accounts.length > 0 ? 'green' : 'gray'}-500"
-                    icon="{faCircle}" />
-                </dif>
-                <div class="uppercase text-xs text-{provider.accounts.length > 0 ? 'green' : 'gray'}-500">
-                  <span>
-                    {provider.accounts.length > 0 ? 'Logged in' : 'Logged out'}
-                  </span>
+
+            <!-- Authentication Provider name and status item start -->
+            <div class="px-5 py-2 text-sm m-auto">
+              <div class="flex flex-col">
+                <div class="flex items-center text-lg w-full h-full">
+                  {provider.displayName}
                 </div>
-                {#if provider.accounts.length > 0}
-                  <button
-                    aria-label="Sign out of {provider.accounts[0].label}"
-                    class="pl-2 hover:cursor-pointer hover:text-white text-white"
-                    on:click="{() =>
-                      window.requestAuthenticationProviderSignOut(provider.id, provider.accounts[0].id)}">
-                    <Fa class="h-3 w-3 text-md mr-2" icon="{faRightFromBracket}" />
-                  </button>
-                {/if}
+                <div class="flex flex-row items-center w-full h-full">
+                  <dif>
+                    <Fa
+                      class="h-3 w-3 text-md mr-2 text-{provider.accounts.length > 0 ? 'green' : 'gray'}-500"
+                      icon="{faCircle}" />
+                  </dif>
+                  <div class="uppercase text-xs text-{provider.accounts.length > 0 ? 'green' : 'gray'}-500">
+                    <span>
+                      {provider.accounts.length > 0 ? 'Logged in' : 'Logged out'}
+                    </span>
+                  </div>
+                </div>
               </div>
             </div>
           </div>
+
           <!-- Authentication Provider name and status item end -->
 
-          <!-- Authentication Provider Session label start -->
-          <div class="pt-3 pb-3 text-sm w-2/3 m-auto">
-            <div class="flex flex-row">
-              <div class="flex items-center w-full">
-                <span>
-                  {provider.accounts.length > 0 ? provider.accounts[0].label : ''}
-                </span>
-              </div>
-            </div>
-          </div>
-          <!-- Authentication Provider Session label start -->
-          <div class="ml-4 flex items-center">
-            {#if (provider.sessionRequests || []).length > 0}
-              {@const sessionRequests = provider.sessionRequests || []}
-              <DropdownMenu>
-                {#each sessionRequests as request}
-                  <DropdownMenuItem
-                    title="Sign in to use {request.extensionLabel}"
-                    onClick="{() => window.requestAuthenticationProviderSignIn(request.id)}"
-                    icon="{faArrowRightToBracket}" />
+          <div class="flex">
+            {#if provider?.accounts?.length > 0}
+              <!-- Authentication Provider Session label start -->
+              <div class="pt-3 pb-3 text-sm">
+                {#each provider.accounts as account}
+                  <div class="flex flex-row">
+                    <div class="flex items-center w-full">
+                      <div class="text-xs bg-charcoal-800 p-2 rounded-lg mt-1">
+                        <span class="my-auto font-bold col-span-1 text-right">
+                          {account.label}
+                        </span>
+                        <Tooltip tip="Sign out of {account.label}" left>
+                          <button
+                            aria-label="Sign out of {account.label}"
+                            class="pl-2 hover:cursor-pointer hover:text-white text-white"
+                            on:click="{() => window.requestAuthenticationProviderSignOut(provider.id, account.id)}">
+                            <Fa class="h-3 w-3 text-md mr-2" icon="{faRightFromBracket}" />
+                          </button>
+                        </Tooltip>
+                      </div>
+                    </div>
+                  </div>
                 {/each}
-              </DropdownMenu>
+              </div>
             {/if}
+            <!-- Authentication Provider Session label start -->
+            <div class="ml-4 flex items-center">
+              {#if (provider.sessionRequests || []).length > 0}
+                {@const sessionRequests = provider.sessionRequests || []}
+                <DropdownMenu>
+                  {#each sessionRequests as request}
+                    <DropdownMenuItem
+                      title="Sign in to use {request.extensionLabel}"
+                      onClick="{() => window.requestAuthenticationProviderSignIn(request.id)}"
+                      icon="{faArrowRightToBracket}" />
+                  {/each}
+                </DropdownMenu>
+              {/if}
+            </div>
           </div>
         </div>
       </div>

--- a/packages/renderer/src/lib/preferences/PreferencesAuthenticationProvidersRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesAuthenticationProvidersRendering.svelte
@@ -71,11 +71,7 @@ import Tooltip from '/@/lib/ui/Tooltip.svelte';
                 </div>
               </div>
             </div>
-          </div>
 
-          <!-- Authentication Provider name and status item end -->
-
-          <div class="flex">
             {#if provider?.accounts?.length > 0}
               <!-- Authentication Provider Session label start -->
               <div class="pt-3 pb-3 text-sm">
@@ -100,20 +96,21 @@ import Tooltip from '/@/lib/ui/Tooltip.svelte';
                 {/each}
               </div>
             {/if}
-            <!-- Authentication Provider Session label start -->
-            <div class="ml-4 flex items-center">
-              {#if (provider.sessionRequests || []).length > 0}
-                {@const sessionRequests = provider.sessionRequests || []}
-                <DropdownMenu>
-                  {#each sessionRequests as request}
-                    <DropdownMenuItem
-                      title="Sign in to use {request.extensionLabel}"
-                      onClick="{() => window.requestAuthenticationProviderSignIn(request.id)}"
-                      icon="{faArrowRightToBracket}" />
-                  {/each}
-                </DropdownMenu>
-              {/if}
-            </div>
+          </div>
+
+          <!-- Authentication Provider Session label start -->
+          <div class="ml-4 flex items-center">
+            {#if (provider.sessionRequests || []).length > 0}
+              {@const sessionRequests = provider.sessionRequests || []}
+              <DropdownMenu>
+                {#each sessionRequests as request}
+                  <DropdownMenuItem
+                    title="Sign in to use {request.extensionLabel}"
+                    onClick="{() => window.requestAuthenticationProviderSignIn(request.id)}"
+                    icon="{faArrowRightToBracket}" />
+                {/each}
+              </DropdownMenu>
+            {/if}
           </div>
         </div>
       </div>


### PR DESCRIPTION
### What does this PR do?

This PR introduce small change to the Authentification Providers page

### Screenshot / video of UI

| Before | After |
| --- | --- |
| <img width="577" alt="image" src="https://github.com/containers/podman-desktop/assets/42176370/ccbfd57f-8735-4c1a-a751-3fc5f764780f"> | <img width="575" alt="image" src="https://github.com/containers/podman-desktop/assets/42176370/8a3d78f5-9519-4cfb-900e-6ff81c017906"> | 
| <img width="578" alt="image" src="https://github.com/containers/podman-desktop/assets/42176370/92a91043-5572-4e2a-87d0-579d21bb3ef5"> | <img width="573" alt="image" src="https://github.com/containers/podman-desktop/assets/42176370/d71854ff-2db6-4324-a655-fd9c631ec7cb"> | 
| <img width="577" alt="image" src="https://github.com/containers/podman-desktop/assets/42176370/ccbfd57f-8735-4c1a-a751-3fc5f764780f"> | <img width="574" alt="image" src="https://github.com/containers/podman-desktop/assets/42176370/0c3b6bb3-8ee1-4c94-83ef-4e1b79bc3d46"> | 

### What issues does this PR fix or reference?

Related to https://github.com/containers/podman-desktop/issues/2274

- [x] Display all accounts instead of only one
- [x] Allow to sign out of individual account instead of only the first one
- [x] Add tooltip for sign out  

<!-- Include any related issues from Podman Desktop 
repository (or from another issue tracker). -->

### How to test this PR?

You can use the https://github.com/containers/podman-desktop/pull/5400 to test an authentification provider

CC @mairin :) 
