### PR TITLE
feat: add confirmation dialog when deleting objects

### DIFF
--- a/packages/renderer/src/lib/compose/ComposeActions.svelte
+++ b/packages/renderer/src/lib/compose/ComposeActions.svelte
@@ -133,6 +133,7 @@ if (dropdownMenu) {
 
 <ListItemButtonIcon
   title="Delete Compose"
+  confirm="{true}"
   onClick="{() => deleteCompose()}"
   icon="{faTrash}"
   detailed="{detailed}"

--- a/packages/renderer/src/lib/container/ContainerActions.svelte
+++ b/packages/renderer/src/lib/container/ContainerActions.svelte
@@ -145,6 +145,7 @@ if (dropdownMenu) {
 
 <ListItemButtonIcon
   title="Delete Container"
+  confirm="{true}"
   onClick="{() => deleteContainer()}"
   icon="{faTrash}"
   detailed="{detailed}"

--- a/packages/renderer/src/lib/deployments/DeploymentActions.svelte
+++ b/packages/renderer/src/lib/deployments/DeploymentActions.svelte
@@ -19,6 +19,7 @@ async function deleteDeployment(): Promise<void> {
 
 <ListItemButtonIcon
   title="Delete Deployment"
+  confirm="{true}"
   onClick="{() => deleteDeployment()}"
   detailed="{detailed}"
   icon="{faTrash}" />

--- a/packages/renderer/src/lib/dialogs/MessageBox.svelte
+++ b/packages/renderer/src/lib/dialogs/MessageBox.svelte
@@ -139,6 +139,8 @@ function getButtonType(b: boolean): ButtonType {
   <div class="fixed top-0 left-0 right-0 bottom-0 bg-black bg-opacity-60 bg-blend-multiply h-full grid z-50">
     <div
       class="flex flex-col place-self-center w-[550px] rounded-xl bg-charcoal-800 shadow-xl shadow-black"
+      role="dialog"
+      aria-labelledby="{title}"
       bind:this="{messageBox}">
       <div class="flex items-center justify-between pl-4 pr-3 py-3 space-x-2 text-gray-400">
         {#if type === 'error'}
@@ -153,7 +155,7 @@ function getButtonType(b: boolean): ButtonType {
         {:else if type === 'question'}
           <Fa class="h-4 w-4" icon="{faCircleQuestion}" />
         {/if}
-        <h1 class="grow text-lg font-bold capitalize">{title}</h1>
+        <h1 aria-label="{title}" class="grow text-lg font-bold capitalize">{title}</h1>
 
         <button
           class="p-2 hover:text-gray-300 hover:bg-charcoal-500 rounded-full cursor-pointer"
@@ -163,10 +165,10 @@ function getButtonType(b: boolean): ButtonType {
       </div>
 
       <div class="max-h-80 overflow-auto">
-        <div class="px-10 py-4 text-sm text-gray-500 leading-5">{message}</div>
+        <div class="px-10 py-4 text-sm text-gray-500 leading-5" aria-label="Dialog Message">{message}</div>
 
         {#if detail}
-          <div class="px-10 pb-4 text-sm text-gray-500 leading-5">{detail}</div>
+          <div class="px-10 pb-4 text-sm text-gray-500 leading-5" aria-label="Dialog Details">{detail}</div>
         {/if}
       </div>
 

--- a/packages/renderer/src/lib/dialogs/MessageBox.svelte
+++ b/packages/renderer/src/lib/dialogs/MessageBox.svelte
@@ -141,6 +141,7 @@ function getButtonType(b: boolean): ButtonType {
       class="flex flex-col place-self-center w-[550px] rounded-xl bg-charcoal-800 shadow-xl shadow-black"
       role="dialog"
       aria-labelledby="{title}"
+      aria-label="{title}"
       bind:this="{messageBox}">
       <div class="flex items-center justify-between pl-4 pr-3 py-3 space-x-2 text-gray-400">
         {#if type === 'error'}
@@ -155,7 +156,7 @@ function getButtonType(b: boolean): ButtonType {
         {:else if type === 'question'}
           <Fa class="h-4 w-4" icon="{faCircleQuestion}" />
         {/if}
-        <h1 aria-label="{title}" class="grow text-lg font-bold capitalize">{title}</h1>
+        <h1 class="grow text-lg font-bold capitalize">{title}</h1>
 
         <button
           class="p-2 hover:text-gray-300 hover:bg-charcoal-500 rounded-full cursor-pointer"

--- a/packages/renderer/src/lib/image/ImageActions.spec.ts
+++ b/packages/renderer/src/lib/image/ImageActions.spec.ts
@@ -47,6 +47,8 @@ const fakedImage: ImageInfoUI = {
 } as unknown as ImageInfoUI;
 
 test('Expect showMessageBox to be called when error occurs', async () => {
+  // Mock the showMessageBox to return 0 (yes)
+  showMessageBoxMock.mockResolvedValue({ response: 0 });
   getContributedMenusMock.mockImplementation(() => Promise.resolve([]));
 
   render(ImageActions, {

--- a/packages/renderer/src/lib/image/ImageActions.svelte
+++ b/packages/renderer/src/lib/image/ImageActions.svelte
@@ -92,6 +92,7 @@ function onError(error: string): void {
 
 <ListItemButtonIcon
   title="Delete Image"
+  confirm="{true}"
   onClick="{() => deleteImage()}"
   detailed="{detailed}"
   icon="{faTrash}"

--- a/packages/renderer/src/lib/pod/PodActions.svelte
+++ b/packages/renderer/src/lib/pod/PodActions.svelte
@@ -178,6 +178,7 @@ if (dropdownMenu) {
 <ListItemButtonIcon
   title="Delete Pod"
   onClick="{() => deletePod()}"
+  confirm="{true}"
   icon="{faTrash}"
   detailed="{detailed}"
   inProgress="{pod.actionInProgress && pod.status === 'DELETING'}" />

--- a/packages/renderer/src/lib/service/ServiceActions.svelte
+++ b/packages/renderer/src/lib/service/ServiceActions.svelte
@@ -17,4 +17,9 @@ async function deleteService(): Promise<void> {
 }
 </script>
 
-<ListItemButtonIcon title="Delete Service" onClick="{() => deleteService()}" detailed="{detailed}" icon="{faTrash}" />
+<ListItemButtonIcon
+  title="Delete Service"
+  confirm="{true}"
+  onClick="{() => deleteService()}"
+  detailed="{detailed}"
+  icon="{faTrash}" />

--- a/packages/renderer/src/lib/ui/ListItemButtonIcon.spec.ts
+++ b/packages/renderer/src/lib/ui/ListItemButtonIcon.spec.ts
@@ -17,8 +17,8 @@
  ***********************************************************************/
 
 import '@testing-library/jest-dom/vitest';
-import { test, expect } from 'vitest';
-import { render, screen } from '@testing-library/svelte';
+import { test, expect, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/svelte';
 import ListItemButtonIcon from './ListItemButtonIcon.svelte';
 import { faRocket } from '@fortawesome/free-solid-svg-icons';
 import { ContextUI } from '../context/context';
@@ -107,4 +107,54 @@ test('Expect the dropDownMenuItem NOT to have classes that display a disabled ob
   const listItemSpan = screen.getByTitle(title);
   expect(listItemSpan).toBeInTheDocument();
   expect(listItemSpan.parentElement!.outerHTML.indexOf('text-gray-900 bg-charcoal-800') === -1).toBeTruthy();
+});
+
+test('When you click on the button with confirm=yes, it will pop up with the dialog', async () => {
+  const showMessageBoxMock = vi.fn();
+  (window as any).showMessageBox = showMessageBoxMock;
+  showMessageBoxMock.mockResolvedValue({ result: 1 });
+
+  const title = 'Delete Pod';
+
+  const contextUI = new ContextUI();
+  contextUI.setValue('values', ['test']);
+  context.set(contextUI);
+
+  render(ListItemButtonIcon, {
+    title,
+    icon: faRocket,
+    menu: false,
+    confirm: true,
+    enabled: true,
+    inProgress: false,
+  });
+
+  const button = screen.getByRole('button', { name: title });
+  await fireEvent.click(button);
+  expect(showMessageBoxMock).toHaveBeenCalledOnce();
+});
+
+test('With confirmation=no, there will be no confirmation when clicking the button', async () => {
+  const showMessageBoxMock = vi.fn();
+  (window as any).showMessageBox = showMessageBoxMock;
+  showMessageBoxMock.mockResolvedValue({ result: 1 });
+
+  const title = 'Delete Pod';
+
+  const contextUI = new ContextUI();
+  contextUI.setValue('values', ['test']);
+  context.set(contextUI);
+
+  render(ListItemButtonIcon, {
+    title,
+    icon: faRocket,
+    menu: false,
+    confirm: false,
+    enabled: true,
+    inProgress: false,
+  });
+
+  const button = screen.getByRole('button', { name: title });
+  await fireEvent.click(button);
+  expect(showMessageBoxMock).not.toHaveBeenCalled();
 });

--- a/packages/renderer/src/lib/ui/ListItemButtonIcon.svelte
+++ b/packages/renderer/src/lib/ui/ListItemButtonIcon.svelte
@@ -18,6 +18,10 @@ export let menu = false;
 export let detailed = false;
 export let inProgress = false;
 export let iconOffset = '';
+
+// Pop up with a dialog before executing the action
+export let confirm = false;
+
 export let contextUI: ContextUI | undefined = undefined;
 
 let positionLeftClass = 'left-1';
@@ -69,7 +73,26 @@ const buttonClass =
 const buttonDisabledClass =
   'm-0.5 text-gray-900 font-medium rounded-full inline-flex items-center px-2 py-2 text-center';
 
-$: handleClick = enabled && !inProgress ? onClick : () => {};
+// $: handleClick = enabled && !inProgress ? onClick : () => {};
+$: handleClick = () => {
+  if (enabled && !inProgress) {
+    if (confirm) {
+      window
+        .showMessageBox({
+          title: 'Confirmation',
+          message: 'Are you sure you want to ' + title.toLowerCase() + '?',
+          buttons: ['Yes', 'Cancel'],
+        })
+        .then(result => {
+          if (result && result.response === 0) {
+            onClick();
+          }
+        });
+    } else {
+      onClick();
+    }
+  }
+};
 $: styleClass = detailed
   ? enabled && !inProgress
     ? buttonDetailedClass

--- a/packages/renderer/src/lib/volume/VolumeActions.svelte
+++ b/packages/renderer/src/lib/volume/VolumeActions.svelte
@@ -12,5 +12,10 @@ async function removeVolume(): Promise<void> {
 </script>
 
 {#if volume.status === 'UNUSED'}
-  <ListItemButtonIcon title="Delete Volume" onClick="{() => removeVolume()}" detailed="{detailed}" icon="{faTrash}" />
+  <ListItemButtonIcon
+    title="Delete Volume"
+    confirm="{true}"
+    onClick="{() => removeVolume()}"
+    detailed="{detailed}"
+    icon="{faTrash}" />
 {/if}

--- a/tests/src/container-smoke.spec.ts
+++ b/tests/src/container-smoke.spec.ts
@@ -24,7 +24,7 @@ import { PodmanDesktopRunner } from './runner/podman-desktop-runner';
 import { WelcomePage } from './model/pages/welcome-page';
 import { NavigationBar } from './model/workbench/navigation';
 import { waitUntil, waitWhile } from './utility/wait';
-import { deleteContainer, deleteImage, pressConfirmationButton } from './utility/operations';
+import { deleteContainer, deleteImage } from './utility/operations';
 import { ContainerState } from './model/core/states';
 import type { ImagesPage } from './model/pages/images-page';
 
@@ -154,7 +154,6 @@ describe('Verification of container creation workflow', async () => {
     const containersDetails = await containers.openContainersDetails(containerToRun);
     await playExpect(containersDetails.heading).toContainText(containerToRun);
     const containersPage = await containersDetails.deleteContainer(10000);
-    await pressConfirmationButton(page, true);
     playExpect(containersPage).toBeDefined();
     playExpect(await containersPage.containerExists(containerToRun)).toBeFalsy();
     await pdRunner.screenshot('containers-container-deleted.png');

--- a/tests/src/container-smoke.spec.ts
+++ b/tests/src/container-smoke.spec.ts
@@ -24,7 +24,7 @@ import { PodmanDesktopRunner } from './runner/podman-desktop-runner';
 import { WelcomePage } from './model/pages/welcome-page';
 import { NavigationBar } from './model/workbench/navigation';
 import { waitUntil, waitWhile } from './utility/wait';
-import { deleteContainer, deleteImage } from './utility/operations';
+import { deleteContainer, deleteImage, pressConfirmationButton } from './utility/operations';
 import { ContainerState } from './model/core/states';
 import type { ImagesPage } from './model/pages/images-page';
 
@@ -154,6 +154,7 @@ describe('Verification of container creation workflow', async () => {
     const containersDetails = await containers.openContainersDetails(containerToRun);
     await playExpect(containersDetails.heading).toContainText(containerToRun);
     const containersPage = await containersDetails.deleteContainer(10000);
+    await pressConfirmationButton(page, true);
     playExpect(containersPage).toBeDefined();
     playExpect(await containersPage.containerExists(containerToRun)).toBeFalsy();
     await pdRunner.screenshot('containers-container-deleted.png');

--- a/tests/src/image-smoke.spec.ts
+++ b/tests/src/image-smoke.spec.ts
@@ -25,6 +25,7 @@ import { WelcomePage } from './model/pages/welcome-page';
 import { NavigationBar } from './model/workbench/navigation';
 import { ImageDetailsPage } from './model/pages/image-details-page';
 import path from 'path';
+import { handleConfirmationDialog } from './utility/operations';
 
 let pdRunner: PodmanDesktopRunner;
 let page: Page;
@@ -97,6 +98,7 @@ describe('Image workflow verification', async () => {
     const imageDetailPage = await imagesPage.openImageDetails('quay.io/podman/hello');
     await playExpect(imageDetailPage.deleteButton).toBeVisible();
     await imageDetailPage.deleteButton.click();
+    await handleConfirmationDialog(page);
 
     const imageDeleted = await imagesPage.waitForImageDelete('quay.io/podman/hello');
     expect(imageDeleted).equals(true);

--- a/tests/src/model/pages/container-details-page.ts
+++ b/tests/src/model/pages/container-details-page.ts
@@ -21,6 +21,7 @@ import { BasePage } from './base-page';
 import { ContainersPage } from './containers-page';
 import { waitUntil, waitWhile } from '../../utility/wait';
 import { ContainerState } from '../core/states';
+import { handleConfirmationDialog } from '../../utility/operations';
 
 export class ContainerDetailsPage extends BasePage {
   readonly labelName: Locator;
@@ -82,6 +83,7 @@ export class ContainerDetailsPage extends BasePage {
   async deleteContainer(timeout: number): Promise<ContainersPage> {
     const deleteButton = this.page.getByRole('button').and(this.page.getByLabel('Delete Container'));
     await deleteButton.click();
+    await handleConfirmationDialog(this.page);
     await waitWhile(
       async () => await this.heading.isVisible(),
       timeout,

--- a/tests/src/model/pages/pods-details-page.ts
+++ b/tests/src/model/pages/pods-details-page.ts
@@ -21,6 +21,7 @@ import { BasePage } from './base-page';
 import { PodsPage } from './pods-page';
 import { waitUntil, waitWhile } from '../../utility/wait';
 import { PodState } from '../core/states';
+import { handleConfirmationDialog } from '../../utility/operations';
 
 export class PodDetailsPage extends BasePage {
   readonly labelName: Locator;
@@ -78,6 +79,7 @@ export class PodDetailsPage extends BasePage {
   async deletePod(timeout: number): Promise<PodsPage> {
     const deleteButton = this.page.getByRole('button').and(this.page.getByLabel('Delete Pod'));
     await deleteButton.click();
+    await handleConfirmationDialog(this.page);
     await waitWhile(
       async () => await this.heading.isVisible(),
       timeout,

--- a/tests/src/utility/operations.ts
+++ b/tests/src/utility/operations.ts
@@ -122,3 +122,14 @@ export async function deletePod(page: Page, name: string) {
     }
   }
 }
+
+export async function pressConfirmationButton(page: Page, boolean: boolean) {
+  // wait for dialog to appear using waitFor
+  await waitWhile(async () => {
+    const dialog = page.locator('dialog');
+    return (await dialog.count()) > 0 ? true : false;
+  });
+
+  const button = boolean ? page.getByRole('button', { name: 'Yes' }) : page.getByRole('button', { name: 'No' });
+  await button.click();
+}

--- a/tests/src/utility/operations.ts
+++ b/tests/src/utility/operations.ts
@@ -130,8 +130,8 @@ export async function deletePod(page: Page, name: string) {
 // Handles dialog that has accessible name `dialogTitle` and either confirms or rejects it.
 export async function handleConfirmationDialog(page: Page, dialogTitle = 'Confirmation', confirm = true) {
   // wait for dialog to appear using waitFor
-  const dialog = page.getByRole('heading', { name: dialogTitle, exact: true });
+  const dialog = page.getByRole('dialog', { name: dialogTitle, exact: true });
   await dialog.waitFor({ state: 'visible', timeout: 3000 });
-  const button = confirm ? dialog.getByRole('button', { name: 'Yes' }) : dialog.getByRole('button', { name: 'No' });
+  const button = confirm ? dialog.getByRole('button', { name: 'Yes' }) : dialog.getByRole('button', { name: 'Cancel' });
   await button.click();
 }

--- a/tests/src/utility/operations.ts
+++ b/tests/src/utility/operations.ts
@@ -44,6 +44,7 @@ export async function deleteContainer(page: Page, name: string) {
     // delete the container
     const deleteButton = container.getByRole('button').and(container.getByLabel('Delete Container'));
     await deleteButton.click();
+    await handleConfirmationDialog(page);
     // wait for container to disappear
     try {
       console.log('Waiting for container to get deleted ...');
@@ -74,6 +75,7 @@ export async function deleteImage(page: Page, name: string) {
     const deleteButton = row.getByRole('button', { name: 'Delete Image' });
     if (await deleteButton.isEnabled({ timeout: 2000 })) {
       await deleteButton.click();
+      await handleConfirmationDialog(page);
     } else {
       throw Error(`Cannot delete image ${name}, because it is in use`);
     }
@@ -109,6 +111,8 @@ export async function deletePod(page: Page, name: string) {
     // delete the pod
     const deleteButton = pod.getByRole('button').and(pod.getByLabel('Delete Pod'));
     await deleteButton.click();
+    // config delete dialog
+    await handleConfirmationDialog(page);
     // wait for pod to disappear
     try {
       console.log('Waiting for pod to get deleted ...');
@@ -123,13 +127,11 @@ export async function deletePod(page: Page, name: string) {
   }
 }
 
-export async function pressConfirmationButton(page: Page, boolean: boolean) {
+// Handles dialog that has accessible name `dialogTitle` and either confirms or rejects it.
+export async function handleConfirmationDialog(page: Page, dialogTitle = 'Confirmation', confirm = true) {
   // wait for dialog to appear using waitFor
-  await waitWhile(async () => {
-    const dialog = page.locator('dialog');
-    return (await dialog.count()) > 0 ? true : false;
-  });
-
-  const button = boolean ? page.getByRole('button', { name: 'Yes' }) : page.getByRole('button', { name: 'No' });
+  const dialog = page.getByRole('heading', { name: dialogTitle, exact: true });
+  await dialog.waitFor({ state: 'visible', timeout: 3000 });
+  const button = confirm ? dialog.getByRole('button', { name: 'Yes' }) : dialog.getByRole('button', { name: 'No' });
   await button.click();
 }


### PR DESCRIPTION
feat: add confirmation dialog when deleting objects

### What does this PR do?

Adds confirmation dialogs to all critical components of Podman Desktop
where you are deleting a container, pod, deployment, service, etc.

This makes sure you do not accidently delete something (such as a
deployment) that could be critical infrastructure.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->


https://github.com/containers/podman-desktop/assets/6422176/b094db26-d9d6-4d8d-8891-16a05c39b4a8



### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop/issues/5444

### How to test this PR?

Try to delete anything (volume, pod, container, etc.) and you will now
see a dialog.

<!-- Please explain steps to reproduce -->

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
