### PR TITLE
fix: service type colors

### DIFF
--- a/packages/renderer/src/lib/service/ServiceColumnType.spec.ts
+++ b/packages/renderer/src/lib/service/ServiceColumnType.spec.ts
@@ -42,7 +42,7 @@ test('Expect basic column styling', async () => {
 
   const dot = text.parentElement?.children[0].children[0];
   expect(dot).toBeInTheDocument();
-  expect(dot).toHaveClass('bg-gray-900');
+  expect(dot).toHaveClass('bg-gray-600');
 });
 
 test('Expect column styling ClusterIP', async () => {
@@ -55,7 +55,7 @@ test('Expect column styling ClusterIP', async () => {
 
   const dot = text.parentElement?.children[0].children[0];
   expect(dot).toBeInTheDocument();
-  expect(dot).toHaveClass('bg-green-600');
+  expect(dot).toHaveClass('bg-sky-500');
 });
 
 test('Expect column styling LoadBalancer', async () => {
@@ -68,7 +68,7 @@ test('Expect column styling LoadBalancer', async () => {
 
   const dot = text.parentElement?.children[0].children[0];
   expect(dot).toBeInTheDocument();
-  expect(dot).toHaveClass('bg-sky-400');
+  expect(dot).toHaveClass('bg-purple-500');
 });
 
 test('Expect column styling NodePort', async () => {
@@ -81,5 +81,5 @@ test('Expect column styling NodePort', async () => {
 
   const dot = text.parentElement?.children[0].children[0];
   expect(dot).toBeInTheDocument();
-  expect(dot).toHaveClass('bg-amber-600');
+  expect(dot).toHaveClass('bg-fuschia-600');
 });

--- a/packages/renderer/src/lib/service/ServiceColumnType.svelte
+++ b/packages/renderer/src/lib/service/ServiceColumnType.svelte
@@ -4,20 +4,20 @@ import type { ServiceUI } from './ServiceUI';
 export let object: ServiceUI;
 
 // Each type has a colour associated to it within tailwind, this is a map of those colours.
-// bg-green-600 = ClusterIP
-// bg-sky-400 = LoadBalancer
-// bg-amber-600 = NodePort
+// bg-sky-500 = ClusterIP
+// bg-purple-500 = LoadBalancer
+// bg-fuschia-600 = NodePort
 // bg-gray-900 = unknown
 function getTypeColour(type: string): string {
   switch (type) {
     case 'ClusterIP':
-      return 'bg-green-600';
+      return 'bg-sky-500';
     case 'LoadBalancer':
-      return 'bg-sky-400';
+      return 'bg-purple-500';
     case 'NodePort':
-      return 'bg-amber-600';
+      return 'bg-fuschia-600';
     default:
-      return 'bg-gray-900';
+      return 'bg-gray-600';
   }
 }
 </script>


### PR DESCRIPTION
### What does this PR do?

The original design #4576 had a few different colors for port types, this switches to use the closest palette colors I could find. Green/amber are not used, so hopefully this is enough to show them as different types without a started/stopped association.

### Screenshot / video of UI

<img width="478" alt="Screenshot 2024-01-07 at 1 32 29 PM" src="https://github.com/containers/podman-desktop/assets/19958075/9226019f-7734-49d1-8538-df4195da8e24">

### What issues does this PR fix or reference?

Fixes #5443.

### How to test this PR?

`yarn test:renderer`, check if colors are distinct enough and avoid 