### PR TITLE
fix(tests,ci): skip cleaning up tests/output artifacts folder in before all hook on CI

### DIFF
--- a/tests/src/globalSetup/global-setup.ts
+++ b/tests/src/globalSetup/global-setup.ts
@@ -24,7 +24,15 @@ let teardownCalled = false;
 export async function setup() {
   if (!setupCalled) {
     // remove all previous testing output files
-    await removeFolderIfExists('tests/output');
+    // Junit reporter output file is created before we can clean up output folders
+    // It is not possible to remove junit output file because it is opened by the process already, at least on windows
+    if (!process.env.CI) {
+      await removeFolderIfExists('tests/output');
+    } else {
+      console.log(
+        `On CI, skipping before All tests/output cleanup, see https://github.com/containers/podman-desktop/issues/5460`,
+      );
+    }
     setupCalled = true;
   }
 }

--- a/tests/src/utility/cleanup.ts
+++ b/tests/src/utility/cleanup.ts
@@ -16,10 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { Stats } from 'node:fs';
-import { existsSync, readdirSync, rmSync, statSync } from 'node:fs';
-import path from 'node:path';
-import { userInfo } from 'os';
+import { existsSync, rmSync } from 'node:fs';
 
 /**
  * Force remove recursively folder, if exists
@@ -27,37 +24,9 @@ import { userInfo } from 'os';
  */
 export async function removeFolderIfExists(path: string) {
   console.log(`Cleaning up folder: ${path}`);
+
   if (existsSync(path)) {
     console.log(`Folder found, removing...`);
-    walkDir(path);
     rmSync(path, { recursive: true, force: true, maxRetries: 5 });
   }
-}
-
-function walkDir(dir: string): void {
-  const files = readdirSync(dir);
-  getUserInfo();
-
-  files.forEach(file => {
-    const filePath = path.join(dir, file);
-    const isDirectory = statSync(filePath).isDirectory();
-    const stats = statSync(filePath);
-
-    if (isDirectory) {
-      console.log(`[Folder]: ${filePath}`);
-      printStats(stats);
-      walkDir(filePath);
-    } else {
-      console.log(`[File]: ${filePath}`);
-      printStats(stats);
-    }
-  });
-}
-
-function getUserInfo(): void {
-  console.log(userInfo());
-}
-
-function printStats(stats: Stats) {
-  console.log(` - owner: ${stats.uid} + mode: ${stats.mode.toString(8)} + Last modified: ${stats.mtime}`);
 }

--- a/tests/src/utility/cleanup.ts
+++ b/tests/src/utility/cleanup.ts
@@ -27,6 +27,6 @@ export async function removeFolderIfExists(path: string) {
   console.log(`Cleaning up folder: ${path}`);
   if (existsSync(path)) {
     console.log(`Folder found, removing...`);
-    await rm(path, { recursive: true, force: true });
+    await rm(path, { recursive: true, force: true, maxRetries: 5 });
   }
 }

--- a/tests/src/utility/cleanup.ts
+++ b/tests/src/utility/cleanup.ts
@@ -16,8 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { existsSync } from 'node:fs';
-import { rm } from 'node:fs/promises';
+import { existsSync, rmSync } from 'node:fs';
 
 /**
  * Force remove recursively folder, if exists
@@ -27,6 +26,6 @@ export async function removeFolderIfExists(path: string) {
   console.log(`Cleaning up folder: ${path}`);
   if (existsSync(path)) {
     console.log(`Folder found, removing...`);
-    await rm(path, { recursive: true, force: true, maxRetries: 5 });
+    rmSync(path, { recursive: true, force: true, maxRetries: 5 });
   }
 }


### PR DESCRIPTION
### What does this PR do?
Fixes test/ci failure of test hook on windows e2e workflow.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
#5460 
<!-- Include any related issues from Podman Desktop 
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to reproduce -->
