### PR TITLE
feat: image status & deletion

### DIFF
--- a/packages/renderer/src/lib/image/ImageActions.spec.ts
+++ b/packages/renderer/src/lib/image/ImageActions.spec.ts
@@ -54,6 +54,7 @@ test('Expect showMessageBox to be called when error occurs', async () => {
     onRenameImage: vi.fn(),
     image: {
       name: 'dummy',
+      status: 'UNUSED',
     } as unknown as ImageInfoUI,
   });
   const button = screen.getByTitle('Delete Image');

--- a/packages/renderer/src/lib/image/ImageActions.svelte
+++ b/packages/renderer/src/lib/image/ImageActions.svelte
@@ -7,7 +7,7 @@ import { runImageInfo } from '../../stores/run-image-store';
 import type { Menu } from '../../../../main/src/plugin/menu-registry';
 import ContributionActions from '/@/lib/actions/ContributionActions.svelte';
 import { ImageUtils } from './image-utils';
-import { onDestroy, onMount } from 'svelte';
+import { createEventDispatcher, onDestroy, onMount } from 'svelte';
 import { MenuContext } from '../../../../main/src/plugin/menu-registry';
 import ActionsWrapper from './ActionsMenu.svelte';
 import type { Unsubscriber } from 'svelte/motion';
@@ -28,6 +28,8 @@ let contributions: Menu[] = [];
 let globalContext: ContextUI;
 let contextsUnsubscribe: Unsubscriber;
 let groupingContributions = false;
+
+const dispatch = createEventDispatcher<{ update: ImageInfoUI }>();
 
 onMount(async () => {
   contributions = await window.getContributedMenus(MenuContext.DASHBOARD_IMAGE);
@@ -52,6 +54,8 @@ async function runImage(imageInfo: ImageInfoUI) {
 $: window.hasAuthconfigForImage(image.name).then(result => (isAuthenticatedForThisImage = result));
 
 async function deleteImage(): Promise<void> {
+  image.status = 'DELETING';
+  dispatch('update', image);
   try {
     await imageUtils.deleteImage(image);
   } catch (error) {
@@ -87,7 +91,7 @@ function onError(error: string): void {
   onClick="{() => deleteImage()}"
   detailed="{detailed}"
   icon="{faTrash}"
-  enabled="{!image.inUse}" />
+  enabled="{image.status === 'UNUSED'}" />
 
 <!-- If dropdownMenu is true, use it, otherwise just show the regular buttons -->
 <ActionsWrapper

--- a/packages/renderer/src/lib/image/ImageColumnActions.svelte
+++ b/packages/renderer/src/lib/image/ImageColumnActions.svelte
@@ -30,7 +30,8 @@ function closeModals() {
   image="{object}"
   onPushImage="{handlePushImageModal}"
   onRenameImage="{handleRenameImageModal}"
-  dropdownMenu="{true}" />
+  dropdownMenu="{true}"
+  on:update />
 
 {#if pushImageModal && pushImageModalImageInfo}
   <PushImageModal

--- a/packages/renderer/src/lib/image/ImageColumnAge.spec.ts
+++ b/packages/renderer/src/lib/image/ImageColumnAge.spec.ts
@@ -37,7 +37,7 @@ test('Expect simple column styling', async () => {
     humanSize: '',
     base64RepoTag: '',
     selected: false,
-    inUse: false,
+    status: 'USED',
   };
   render(ImageColumnAge, { object: image });
 

--- a/packages/renderer/src/lib/image/ImageColumnEnvironment.spec.ts
+++ b/packages/renderer/src/lib/image/ImageColumnEnvironment.spec.ts
@@ -37,7 +37,7 @@ test('Expect simple column styling', async () => {
     humanSize: '',
     base64RepoTag: '',
     selected: false,
-    inUse: false,
+    status: 'USED',
   };
   render(ImageColumnEnvironment, { object: image });
 

--- a/packages/renderer/src/lib/image/ImageColumnName.spec.ts
+++ b/packages/renderer/src/lib/image/ImageColumnName.spec.ts
@@ -38,7 +38,7 @@ const image: ImageInfoUI = {
   humanSize: '',
   base64RepoTag: 'repoTag',
   selected: false,
-  inUse: false,
+  status: 'USED',
 };
 
 test('Expect simple column styling', async () => {

--- a/packages/renderer/src/lib/image/ImageColumnSize.spec.ts
+++ b/packages/renderer/src/lib/image/ImageColumnSize.spec.ts
@@ -37,7 +37,7 @@ test('Expect simple column styling', async () => {
     humanSize: '3.2Mb',
     base64RepoTag: '',
     selected: false,
-    inUse: false,
+    status: 'USED',
   };
   render(ImageColumnSize, { object: image });
 

--- a/packages/renderer/src/lib/image/ImageColumnStatus.spec.ts
+++ b/packages/renderer/src/lib/image/ImageColumnStatus.spec.ts
@@ -37,7 +37,7 @@ test('Expect simple column styling', async () => {
     humanSize: '',
     base64RepoTag: '',
     selected: false,
-    inUse: true,
+    status: 'USED',
   };
   render(ImageColumnStatus, { object: image });
 

--- a/packages/renderer/src/lib/image/ImageColumnStatus.svelte
+++ b/packages/renderer/src/lib/image/ImageColumnStatus.svelte
@@ -6,4 +6,4 @@ import StatusIcon from '../images/StatusIcon.svelte';
 export let object: ImageInfoUI;
 </script>
 
-<StatusIcon icon="{ImageIcon}" status="{object.inUse ? 'USED' : 'UNUSED'}" />
+<StatusIcon icon="{ImageIcon}" status="{object.status}" />

--- a/packages/renderer/src/lib/image/ImageDetails.svelte
+++ b/packages/renderer/src/lib/image/ImageDetails.svelte
@@ -76,7 +76,7 @@ onDestroy(() => {
 
 {#if image}
   <DetailsPage title="{image.name}" titleDetail="{image.shortId}" subtitle="{image.tag}" bind:this="{detailsPage}">
-    <StatusIcon slot="icon" icon="{ImageIcon}" size="{24}" status="{image.inUse ? 'USED' : 'UNUSED'}" />
+    <StatusIcon slot="icon" icon="{ImageIcon}" size="{24}" status="{image.status}" />
     <ImageActions
       slot="actions"
       image="{image}"
@@ -84,7 +84,8 @@ onDestroy(() => {
       onRenameImage="{handleRenameImageModal}"
       detailed="{true}"
       dropdownMenu="{false}"
-      groupContributions="{true}" />
+      groupContributions="{true}"
+      on:update="{() => (image = image)}" />
     <svelte:fragment slot="tabs">
       <Tab title="Summary" url="summary" />
       <Tab title="History" url="history" />

--- a/packages/renderer/src/lib/image/ImageInfoUI.ts
+++ b/packages/renderer/src/lib/image/ImageInfoUI.ts
@@ -31,5 +31,5 @@ export interface ImageInfoUI {
   // no tag, we encode <none>
   base64RepoTag: string;
   selected: boolean;
-  inUse: boolean;
+  status: string;
 }

--- a/packages/renderer/src/lib/image/ImagesList.svelte
+++ b/packages/renderer/src/lib/image/ImagesList.svelte
@@ -183,7 +183,7 @@ let statusColumn = new Column<ImageInfoUI>('Status', {
   align: 'center',
   width: '70px',
   renderer: ImageColumnStatus,
-  comparator: (a, b) => Number(b.inUse) - Number(a.inUse),
+  comparator: (a, b) => b.status.localeCompare(a.status),
 });
 
 let nameColumn = new Column<ImageInfoUI>('Name', {
@@ -217,7 +217,10 @@ const columns: Column<ImageInfoUI>[] = [
   new Column<ImageInfoUI>('Actions', { align: 'right', width: '150px', renderer: ImageColumnActions, overflow: true }),
 ];
 
-const row = new Row<ImageInfoUI>({ selectable: image => !image.inUse, disabledText: 'Image is used by a container' });
+const row = new Row<ImageInfoUI>({
+  selectable: image => image.status === 'UNUSED',
+  disabledText: 'Image is used by a container',
+});
 </script>
 
 <NavPage bind:searchTerm="{searchTerm}" title="images">
@@ -250,7 +253,8 @@ const row = new Row<ImageInfoUI>({ selectable: image => !image.inUse, disabledTe
       data="{images}"
       columns="{columns}"
       row="{row}"
-      defaultSortColumn="Age">
+      defaultSortColumn="Age"
+      on:update="{() => (images = images)}">
     </Table>
 
     {#if providerConnections.length === 0}

--- a/packages/renderer/src/lib/image/RenameImageModal.spec.ts
+++ b/packages/renderer/src/lib/image/RenameImageModal.spec.ts
@@ -14,7 +14,7 @@ const imageInfo = {
   humanSize: '128kb',
   age: '2 hours',
   selected: false,
-  inUse: false,
+  status: 'UNUSED',
 };
 const closeCallback = () => {};
 

--- a/packages/renderer/src/lib/image/RunImage.spec.ts
+++ b/packages/renderer/src/lib/image/RunImage.spec.ts
@@ -77,7 +77,7 @@ async function createRunImage(entrypoint?: string | string[], cmd?: string[]) {
     size: 0,
     humanSize: '',
     id: '',
-    inUse: false,
+    status: 'USED',
     name: '',
     selected: false,
     shortId: '',

--- a/packages/renderer/src/lib/image/image-utils.ts
+++ b/packages/renderer/src/lib/image/image-utils.ts
@@ -104,7 +104,7 @@ export class ImageUtils {
           tag: '',
           base64RepoTag: this.getBase64EncodedName('<none>'),
           selected: false,
-          inUse: this.getInUse(imageInfo, containersInfo),
+          status: this.getInUse(imageInfo, containersInfo) ? 'USED' : 'UNUSED',
         },
       ];
     } else {
@@ -122,7 +122,7 @@ export class ImageUtils {
           tag: this.getTag(repoTag),
           base64RepoTag: this.getBase64EncodedName(repoTag),
           selected: false,
-          inUse: this.getInUse(imageInfo, containersInfo),
+          status: this.getInUse(imageInfo, containersInfo) ? 'USED' : 'UNUSED',
         };
       });
     }


### PR DESCRIPTION
### What does this PR do?

Images had an inUse flag that we used to determine which status icon to show or whether the image is delete-able. If you delete the image and there is any delay, there is no feedback in the UI and you can delete it again (or accidentally click on the next image delete if the first one disappears at the wrong time).

This changes images to have a status the same as most other types (e.g. pods, containers, deployments), so once the user clicks to delete it is marked for deletion (spinner in UI) and you can't delete again.

### Screenshot / video of UI

Self-explanatory, now same as other lists.

### What issues does this PR fix or reference?

Fixes #5474.

### How to test this PR?

Delete an image!