### PR TITLE
feat: add a way to choose platform when building image

### DIFF
--- a/packages/renderer/src/lib/image/BuildImageFromContainerfile.spec.ts
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfile.spec.ts
@@ -42,6 +42,7 @@ beforeAll(() => {
   });
   (window as any).openFileDialog = vi.fn().mockResolvedValue({ canceled: false, filePaths: ['Containerfile'] });
   (window as any).telemetryPage = vi.fn().mockResolvedValue(undefined);
+  (window as any).getOsArch = vi.fn();
 });
 
 // the build image page expects to have a valid provider connection, so let's mock one

--- a/packages/renderer/src/lib/image/BuildImageFromContainerfile.svelte
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfile.svelte
@@ -22,6 +22,7 @@ import TerminalWindow from '../ui/TerminalWindow.svelte';
 import type { Terminal } from 'xterm';
 import Button from '../ui/Button.svelte';
 import { faCube } from '@fortawesome/free-solid-svg-icons';
+import BuildImageFromContainerfileCards from './BuildImageFromContainerfileCards.svelte';
 
 let buildFinished = false;
 let containerImageName = 'my-custom-image';
@@ -214,6 +215,11 @@ async function abortBuild() {
           {#if providerConnections.length === 1 && selectedProviderConnection}
             <input type="hidden" name="providerChoice" readonly bind:value="{selectedProviderConnection.name}" />
           {/if}
+        </div>
+
+        <div hidden="{buildImageInfo?.buildRunning}">
+          <label for="containerBuildPlatform" class="block mb-2 text-sm font-bold text-gray-400">Platform</label>
+          <BuildImageFromContainerfileCards bind:platforms="{containerBuildPlatform}" />
         </div>
 
         <div class="w-full flex flex-row space-x-4">

--- a/packages/renderer/src/lib/image/BuildImageFromContainerfileCard.spec.ts
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfileCard.spec.ts
@@ -1,0 +1,109 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import '@testing-library/jest-dom/vitest';
+import { test, expect } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import BuildImageFromContainerfileCard from '/@/lib/image/BuildImageFromContainerfileCard.svelte';
+
+test('check click', async () => {
+  const component = render(BuildImageFromContainerfileCard, {
+    title: 'ARM64',
+    badge: 'arm64',
+    isDefault: false,
+    checked: false,
+    value: 'arm64',
+    icon: undefined,
+  });
+
+  const events: { mode: string; value: string }[] = [];
+
+  component.component.$on('card', (e: any) => {
+    events.push(e.detail);
+  });
+
+  // expect checkbox is unchecked
+  expect(screen.getByRole('checkbox')).not.toBeChecked();
+
+  expect(events).toEqual([]);
+
+  // click on the card and expect to be checked
+  await userEvent.click(screen.getByRole('button'));
+
+  expect(events).toEqual([{ mode: 'add', value: 'arm64' }]);
+});
+
+test('Expect checked', async () => {
+  render(BuildImageFromContainerfileCard, {
+    title: 'ARM64',
+    badge: 'arm64',
+    isDefault: false,
+    checked: true,
+    value: 'arm64',
+    icon: undefined,
+  });
+
+  // expect checkbox is unchecked
+  expect(screen.getByRole('checkbox')).toBeChecked();
+});
+
+test('Expect default tooltip', async () => {
+  render(BuildImageFromContainerfileCard, {
+    title: 'ARM64',
+    badge: 'arm64',
+    isDefault: true,
+    checked: true,
+    value: 'arm64',
+    icon: undefined,
+  });
+
+  // check we have a div tooltip with aria-label tooltip
+  const tooltip = screen.getByText('Default platform of your computer');
+  expect(tooltip).toBeInTheDocument();
+});
+
+test('check we can add a new card', async () => {
+  const component = render(BuildImageFromContainerfileCard, {
+    title: '',
+    badge: '',
+    isDefault: false,
+    checked: false,
+    value: '',
+    icon: undefined,
+    additionalItem: true,
+  });
+
+  const addCards: { value: string }[] = [];
+
+  component.component.$on('addcard', (e: any) => {
+    addCards.push(e.detail);
+  });
+
+  expect(addCards).toEqual([]);
+
+  // click on the card and expect to be checked
+  await userEvent.click(screen.getByRole('button'));
+
+  // add new name on the input field
+  await userEvent.type(screen.getByRole('textbox'), 'my/platform{enter}');
+
+  expect(addCards).toEqual([{ value: 'my/platform' }]);
+});

--- a/packages/renderer/src/lib/image/BuildImageFromContainerfileCard.svelte
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfileCard.svelte
@@ -70,6 +70,7 @@ onMount(() => {
   class="rounded-md p-2 min-w-32 w-32 cursor-pointer hover:bg-charcoal-700 {checked
     ? 'border-dustypurple-700'
     : 'border-gray-700'} border-2 flex flex-row"
+  aria-label="{value}"
   on:click|preventDefault="{() => handleClick()}">
   <div>
     {#if !additionalItem}

--- a/packages/renderer/src/lib/image/BuildImageFromContainerfileCard.svelte
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfileCard.svelte
@@ -11,11 +11,10 @@ export let isDefault: boolean = false;
 export let checked: boolean = false;
 export let value: string = '';
 export let icon: any;
+let iconType: 'fontAwesome' | 'unknown' | undefined = undefined;
 
 export let additionalItem: boolean = false;
 let additionalValue: string = '';
-
-export let fontAwesomeIcon = false;
 
 let displayValueFieldInput = false;
 
@@ -55,6 +54,12 @@ function handleClick() {
 }
 
 onMount(() => {
+  if (icon?.prefix?.startsWith('fa')) {
+    iconType = 'fontAwesome';
+  } else {
+    iconType = 'unknown';
+  }
+
   if (isDefault) {
     dispatch('card', { mode: 'add', value: value });
   }
@@ -76,9 +81,9 @@ onMount(() => {
   <div class="mr-2 text-gray-700">
     <div class="flex flex-row">
       <div class="ml-1">
-        {#if fontAwesomeIcon}
+        {#if iconType === 'fontAwesome'}
           <Fa class="text-gray-700 cursor-pointer" icon="{icon}" size="24" />
-        {:else}
+        {:else if iconType === 'unknown'}
           <svelte:component this="{icon}" class="text-gray-700 cursor-pointer" size="24" />
         {/if}
       </div>

--- a/packages/renderer/src/lib/image/BuildImageFromContainerfileCard.svelte
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfileCard.svelte
@@ -1,0 +1,107 @@
+<script lang="ts">
+import { faSun } from '@fortawesome/free-solid-svg-icons';
+import Fa from 'svelte-fa';
+import Checkbox from '../ui/Checkbox.svelte';
+import Tooltip from '../ui/Tooltip.svelte';
+import { onMount, tick, createEventDispatcher } from 'svelte';
+
+export let title: string = '';
+export let badge: string = '';
+export let isDefault: boolean = false;
+export let checked: boolean = false;
+export let value: string = '';
+export let icon: any;
+
+export let additionalItem: boolean = false;
+let additionalValue: string = '';
+
+export let fontAwesomeIcon = false;
+
+let displayValueFieldInput = false;
+
+let inputHtmlElement: HTMLInputElement | undefined;
+
+const dispatch = createEventDispatcher();
+
+function handleKeydownAdditionalField(event: KeyboardEvent) {
+  if (event.key === 'Enter') {
+    dispatch('addcard', { value: additionalValue });
+    displayValueFieldInput = false;
+  }
+}
+
+function handleClick() {
+  if (additionalItem) {
+    // display the new field input
+    displayValueFieldInput = true;
+    additionalValue = '';
+
+    // make focus on the input field
+    tick().then(() => {
+      if (inputHtmlElement) {
+        inputHtmlElement.focus();
+      }
+    });
+    return;
+  }
+
+  checked = !checked;
+
+  if (checked) {
+    dispatch('card', { mode: 'add', value: value });
+  } else {
+    dispatch('card', { mode: 'remove', value: value });
+  }
+}
+
+onMount(() => {
+  if (isDefault) {
+    dispatch('card', { mode: 'add', value: value });
+  }
+});
+</script>
+
+<button
+  class="rounded-md p-2 min-w-32 w-32 cursor-pointer hover:bg-charcoal-700 {checked
+    ? 'border-dustypurple-700'
+    : 'border-gray-700'} border-2 flex flex-row"
+  on:click|preventDefault="{() => handleClick()}">
+  <div>
+    {#if !additionalItem}
+      <Checkbox bind:checked="{checked}" on:click="{() => handleClick()}" />
+    {:else}
+      <div>&nbsp;</div>
+    {/if}
+  </div>
+  <div class="mr-2 text-gray-700">
+    <div class="flex flex-row">
+      <div class="ml-1">
+        {#if fontAwesomeIcon}
+          <Fa class="text-gray-700 cursor-pointer" icon="{icon}" size="24" />
+        {:else}
+          <svelte:component this="{icon}" class="text-gray-700 cursor-pointer" size="24" />
+        {/if}
+      </div>
+
+      {#if isDefault}
+        <Tooltip tip="Default platform of your computer">
+          <Fa size="14" class="text-dustypurple-700 cursor-pointer" icon="{faSun}" />
+        </Tooltip>
+      {/if}
+    </div>
+    <div class="text-sm text-left truncate w-24">{title}</div>
+    <div class="flex">
+      {#if badge}
+        <div class="bg-dustypurple-700 text-white text-xs font-medium me-2 px-2.5 py-0.5 rounded">{badge}</div>
+      {/if}
+      {#if displayValueFieldInput}
+        <input
+          type="text"
+          class="w-24 outline-none text-sm bg-dustypurple-900 rounded-sm text-gray-700 placeholder-gray-700"
+          bind:value="{additionalValue}"
+          bind:this="{inputHtmlElement}"
+          on:keydown="{handleKeydownAdditionalField}" />
+      {/if}
+    </div>
+  </div>
+</button>

--- a/packages/renderer/src/lib/image/BuildImageFromContainerfileCards.spec.ts
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfileCards.spec.ts
@@ -1,0 +1,65 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import '@testing-library/jest-dom/vitest';
+import { test, expect, beforeAll, vi } from 'vitest';
+import { render } from '@testing-library/svelte';
+import BuildImageFromContainerfileCards from './BuildImageFromContainerfileCards.svelte';
+
+// fake the window.events object
+beforeAll(() => {
+  (window.events as unknown) = {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    receive: (_channel: string, func: any) => {
+      func();
+    },
+  };
+  (window as any).getOsArch = vi.fn();
+});
+
+test('check default on arm64', async () => {
+  vi.mocked(window.getOsArch).mockResolvedValue('arm64');
+
+  const platforms = '';
+  const rendered = render(BuildImageFromContainerfileCards, {
+    platforms,
+  });
+
+  // wait a little with setTimeout
+  await new Promise(resolve => setTimeout(resolve, 100));
+
+  // check we have a platform
+  expect(rendered.component.$$.ctx[5]).toEqual('linux/arm64');
+});
+
+test('check default on amd64', async () => {
+  vi.mocked(window.getOsArch).mockResolvedValue('x64');
+
+  const platforms = '';
+  const rendered = render(BuildImageFromContainerfileCards, {
+    platforms,
+  });
+
+  // wait a little with setTimeout
+  await new Promise(resolve => setTimeout(resolve, 100));
+
+  // check we have a platform
+  expect(rendered.component.$$.ctx[5]).toEqual('linux/amd64');
+});

--- a/packages/renderer/src/lib/image/BuildImageFromContainerfileCards.svelte
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfileCards.svelte
@@ -141,6 +141,7 @@ function addCard(item: { value: string }) {
 
   {#if !showMoreOptions}
     <button
+      aria-label="Show more options"
       class="pt-2 flex items-center text-sm cursor-pointer text-gray-700"
       on:click="{() => (showMoreOptions = !showMoreOptions)}">
       <Fa icon="{faChevronRight}" class=" mr-2 " />
@@ -171,6 +172,7 @@ function addCard(item: { value: string }) {
       </div>
     </div>
     <button
+      aria-label="Show less options"
       class="pt-2 flex items-center text-sm cursor-pointer text-gray-700"
       on:click="{() => (showMoreOptions = !showMoreOptions)}">
       <Fa icon="{faChevronCircleDown}" class=" mr-2 transform rotate-90" />

--- a/packages/renderer/src/lib/image/BuildImageFromContainerfileCards.svelte
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfileCards.svelte
@@ -16,7 +16,6 @@ interface CardInfo {
   checked: boolean;
   value: string;
   icon: unknown;
-  fontAwesomeIcon: boolean;
 }
 
 const DEFAULT_CARDS: CardInfo[] = [
@@ -27,7 +26,6 @@ const DEFAULT_CARDS: CardInfo[] = [
     checked: false,
     value: 'linux/amd64',
     icon: faLinux,
-    fontAwesomeIcon: true,
   },
   {
     title: 'Linux',
@@ -36,7 +34,6 @@ const DEFAULT_CARDS: CardInfo[] = [
     checked: false,
     value: 'linux/arm64',
     icon: faLinux,
-    fontAwesomeIcon: true,
   },
 ];
 
@@ -48,7 +45,6 @@ const ADVANCED_CARDS: CardInfo[] = [
     checked: false,
     value: 'linux/ppc64le',
     icon: faLinux,
-    fontAwesomeIcon: true,
   },
   {
     title: 'Linux',
@@ -57,7 +53,6 @@ const ADVANCED_CARDS: CardInfo[] = [
     checked: false,
     value: 'linux/s390x',
     icon: faLinux,
-    fontAwesomeIcon: true,
   },
   {
     title: 'WebAssembly',
@@ -66,7 +61,6 @@ const ADVANCED_CARDS: CardInfo[] = [
     checked: false,
     value: 'wasi/wasm',
     icon: WebAssemblyIcon,
-    fontAwesomeIcon: false,
   },
 ];
 
@@ -125,14 +119,13 @@ function addCard(item: { value: string }) {
     checked: true,
     value: item.value,
     icon: faLayerGroup,
-    fontAwesomeIcon: true,
   };
   advancedCards.push(card);
   advancedCards = advancedCards;
 }
 </script>
 
-<div class="flex flex-col">
+<div class="flex flex-col" role="region" aria-label="Build Platform Options">
   <div class="flex flex-row gap-x-4 gap-y-4 flex-wrap">
     {#each sortedCards as card}
       <BuildImageFromContainerfileCard
@@ -142,7 +135,6 @@ function addCard(item: { value: string }) {
         badge="{card.badge}"
         value="{card.value}"
         icon="{card.icon}"
-        fontAwesomeIcon="{card.fontAwesomeIcon}"
         on:card="{item => handleCard(item)}" />
     {/each}
   </div>
@@ -165,7 +157,6 @@ function addCard(item: { value: string }) {
             badge="{card.badge}"
             value="{card.value}"
             icon="{card.icon}"
-            fontAwesomeIcon="{card.fontAwesomeIcon}"
             on:card="{item => handleCard(item)}" />
         {/each}
         <BuildImageFromContainerfileCard
@@ -175,7 +166,6 @@ function addCard(item: { value: string }) {
           badge=""
           value=""
           icon="{faPlusCircle}"
-          fontAwesomeIcon="{true}"
           additionalItem="{true}"
           on:addcard="{item => addCard(item.detail)}" />
       </div>

--- a/packages/renderer/src/lib/image/BuildImageFromContainerfileCards.svelte
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfileCards.svelte
@@ -1,0 +1,190 @@
+<script lang="ts">
+import { faChevronCircleDown, faChevronRight, faLayerGroup, faPlusCircle } from '@fortawesome/free-solid-svg-icons';
+import { faLinux } from '@fortawesome/free-brands-svg-icons';
+import Fa from 'svelte-fa';
+import BuildImageFromContainerfileCard from './BuildImageFromContainerfileCard.svelte';
+import WebAssemblyIcon from '../images/WebAssemblyIcon.svelte';
+import { onMount } from 'svelte';
+
+export let platforms: string = '';
+let platformsArray: string[] = [];
+
+interface CardInfo {
+  title: string;
+  badge: string;
+  isDefault: boolean;
+  checked: boolean;
+  value: string;
+  icon: unknown;
+  fontAwesomeIcon: boolean;
+}
+
+const DEFAULT_CARDS: CardInfo[] = [
+  {
+    title: 'Linux',
+    badge: 'AMD64',
+    isDefault: false,
+    checked: false,
+    value: 'linux/amd64',
+    icon: faLinux,
+    fontAwesomeIcon: true,
+  },
+  {
+    title: 'Linux',
+    badge: 'ARM64',
+    isDefault: false,
+    checked: false,
+    value: 'linux/arm64',
+    icon: faLinux,
+    fontAwesomeIcon: true,
+  },
+];
+
+const ADVANCED_CARDS: CardInfo[] = [
+  {
+    title: 'Linux',
+    badge: 'PPC64LE',
+    isDefault: false,
+    checked: false,
+    value: 'linux/ppc64le',
+    icon: faLinux,
+    fontAwesomeIcon: true,
+  },
+  {
+    title: 'Linux',
+    badge: 'S390X',
+    isDefault: false,
+    checked: false,
+    value: 'linux/s390x',
+    icon: faLinux,
+    fontAwesomeIcon: true,
+  },
+  {
+    title: 'WebAssembly',
+    badge: 'WASI',
+    isDefault: false,
+    checked: false,
+    value: 'wasi/wasm',
+    icon: WebAssemblyIcon,
+    fontAwesomeIcon: false,
+  },
+];
+
+let showMoreOptions = false;
+
+let sortedCards: CardInfo[] = [];
+let advancedCards: CardInfo[] = [];
+
+onMount(async () => {
+  // need to sort the default cards by having the first card using the same arch than Podman Desktop
+
+  // get current arch
+  let arch = await window.getOsArch();
+  if (arch === 'x64') {
+    arch = 'amd64';
+  }
+
+  // sort the default cards using current arch as first
+  DEFAULT_CARDS.sort((a, b) => {
+    if (a.value.includes(arch)) {
+      return -1;
+    }
+    if (b.value.includes(arch)) {
+      return 1;
+    }
+    return 0;
+  });
+  sortedCards = DEFAULT_CARDS;
+
+  // first item should be the default
+  sortedCards[0].isDefault = true;
+  sortedCards[0].checked = true;
+
+  advancedCards = ADVANCED_CARDS;
+});
+
+function handleCard(card: { detail: { mode: 'add' | 'remove'; value: string } }) {
+  if (card.detail.mode === 'add') {
+    // add card.detail.value from the array platformsArray
+    platformsArray.push(card.detail.value);
+  } else if (card.detail.mode === 'remove') {
+    // remove card.detail.value from the array platformsArray
+    platformsArray = platformsArray.filter(item => item !== card.detail.value);
+  }
+
+  // platforms should be a comma separated string
+  platforms = platformsArray.join(',');
+}
+
+function addCard(item: { value: string }) {
+  // create a new card and make it checked
+  const card = {
+    title: item.value,
+    badge: 'custom',
+    isDefault: false,
+    checked: true,
+    value: item.value,
+    icon: faLayerGroup,
+    fontAwesomeIcon: true,
+  };
+  advancedCards.push(card);
+  advancedCards = advancedCards;
+}
+</script>
+
+<div class="flex flex-col">
+  <div class="flex flex-row gap-x-4 gap-y-4 flex-wrap">
+    {#each sortedCards as card}
+      <BuildImageFromContainerfileCard
+        title="{card.title}"
+        isDefault="{card.isDefault}"
+        checked="{card.checked}"
+        badge="{card.badge}"
+        value="{card.value}"
+        icon="{card.icon}"
+        fontAwesomeIcon="{card.fontAwesomeIcon}"
+        on:card="{item => handleCard(item)}" />
+    {/each}
+  </div>
+
+  {#if !showMoreOptions}
+    <button
+      class="pt-2 flex items-center text-sm cursor-pointer text-gray-700"
+      on:click="{() => (showMoreOptions = !showMoreOptions)}">
+      <Fa icon="{faChevronRight}" class=" mr-2 " />
+      More Options...
+    </button>
+  {:else}
+    <div class="flex flex-col pt-4">
+      <div class="flex flex-row gap-x-4 flex-wrap gap-y-4">
+        {#each advancedCards as card}
+          <BuildImageFromContainerfileCard
+            title="{card.title}"
+            isDefault="{card.isDefault}"
+            checked="{card.checked}"
+            badge="{card.badge}"
+            value="{card.value}"
+            icon="{card.icon}"
+            fontAwesomeIcon="{card.fontAwesomeIcon}"
+            on:card="{item => handleCard(item)}" />
+        {/each}
+        <BuildImageFromContainerfileCard
+          title="New platform"
+          isDefault="{false}"
+          checked="{false}"
+          badge=""
+          value=""
+          icon="{faPlusCircle}"
+          fontAwesomeIcon="{true}"
+          additionalItem="{true}"
+          on:addcard="{item => addCard(item.detail)}" />
+      </div>
+    </div>
+    <button
+      class="pt-2 flex items-center text-sm cursor-pointer text-gray-700"
+      on:click="{() => (showMoreOptions = !showMoreOptions)}">
+      <Fa icon="{faChevronCircleDown}" class=" mr-2 transform rotate-90" />
+      Less Options...
+    </button>
+  {/if}
+</div>


### PR DESCRIPTION
### What does this PR do?
Allow to build for a different platform when building image within Podman Desktop

### Screenshot / video of UI

![image](https://github.com/containers/podman-desktop/assets/436777/0b1ccbd7-5957-46d7-9efa-c833057ca2dd)


### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/5492

### How to test this PR?

unit tests added

you can also go to build panel and choose a platform
