### PR TITLE
chore(tests): added tracing functionality from pw

### DIFF
--- a/tests/src/container-smoke.spec.ts
+++ b/tests/src/container-smoke.spec.ts
@@ -37,7 +37,7 @@ const containerToRun = 'alpine-container';
 beforeAll(async () => {
   pdRunner = new PodmanDesktopRunner();
   page = await pdRunner.start();
-  pdRunner.setVideoName('containers-e2e');
+  pdRunner.setVideoAndTraceName('containers-e2e');
   const welcomePage = new WelcomePage(page);
   await welcomePage.handleWelcomePage(true);
   // wait giving a time to podman desktop to load up

--- a/tests/src/image-smoke.spec.ts
+++ b/tests/src/image-smoke.spec.ts
@@ -33,7 +33,7 @@ let navBar: NavigationBar;
 beforeAll(async () => {
   pdRunner = new PodmanDesktopRunner();
   page = await pdRunner.start();
-  pdRunner.setVideoName('pull-image-e2e');
+  pdRunner.setVideoAndTraceName('pull-image-e2e');
 
   const welcomePage = new WelcomePage(page);
   await welcomePage.handleWelcomePage(true);

--- a/tests/src/pod-smoke.spec.ts
+++ b/tests/src/pod-smoke.spec.ts
@@ -42,7 +42,7 @@ const isMac = os.platform() === 'darwin';
 beforeAll(async () => {
   pdRunner = new PodmanDesktopRunner();
   page = await pdRunner.start();
-  pdRunner.setVideoName('pods-e2e');
+  pdRunner.setVideoAndTraceName('pods-e2e');
   const welcomePage = new WelcomePage(page);
   await welcomePage.handleWelcomePage(true);
   // wait giving a time to podman desktop to load up

--- a/tests/src/podman-extension-smoke.spec.ts
+++ b/tests/src/podman-extension-smoke.spec.ts
@@ -47,7 +47,7 @@ let navigationBar: NavigationBar;
 beforeAll(async () => {
   pdRunner = new PodmanDesktopRunner();
   page = await pdRunner.start();
-  pdRunner.setVideoName('settings-extensions-e2e');
+  pdRunner.setVideoAndTraceName('settings-extensions-e2e');
 
   const welcomePage = new WelcomePage(page);
   await welcomePage.handleWelcomePage(true);

--- a/tests/src/runner/podman-desktop-runner.ts
+++ b/tests/src/runner/podman-desktop-runner.ts
@@ -36,7 +36,7 @@ export class PodmanDesktopRunner {
   private readonly _profile: string;
   private readonly _customFolder;
   private readonly _testOutput: string;
-  private _videoName: string | undefined;
+  private _videoAndTraceName: string | undefined;
 
   constructor(profile = '', customFolder = 'podman-desktop') {
     this._running = false;
@@ -44,7 +44,7 @@ export class PodmanDesktopRunner {
     this._testOutput = join('tests', 'output', this._profile);
     this._customFolder = join(this._testOutput, customFolder);
     this._options = this.defaultOptions();
-    this._videoName = undefined;
+    this._videoAndTraceName = undefined;
   }
 
   public async start(): Promise<Page> {
@@ -108,7 +108,7 @@ export class PodmanDesktopRunner {
 
   public async stopTracing() {
     let name = '';
-    if (this._videoName) name = this._videoName;
+    if (this._videoAndTraceName) name = this._videoAndTraceName;
 
     name = name + '_trace.zip';
     await this.getPage()
@@ -165,8 +165,8 @@ export class PodmanDesktopRunner {
       console.log(`Elapsed time of closing the electron app: ${elapsed} ms`);
     }
 
-    if (this._videoName) {
-      const videoPath = join(this._testOutput, 'videos', `${this._videoName}.webm`);
+    if (this._videoAndTraceName) {
+      const videoPath = join(this._testOutput, 'videos', `${this._videoAndTraceName}.webm`);
       const elapsed = await this.trackTime(async () => await this.saveVideoAs(videoPath));
       console.log(`Saving a video file took: ${elapsed} ms`);
       console.log(`Video file saved as: ${videoPath}`);
@@ -246,7 +246,7 @@ export class PodmanDesktopRunner {
   }
 
   public setVideoAndTraceName(name: string) {
-    this._videoName = name;
+    this._videoAndTraceName = name;
   }
 
   public getTestOutput(): string {

--- a/tests/src/runner/podman-desktop-runner.ts
+++ b/tests/src/runner/podman-desktop-runner.ts
@@ -187,6 +187,7 @@ export class PodmanDesktopRunner {
 
   private defaultOptions() {
     const directory = join(this._testOutput, 'videos');
+    const tracesDir = join(this._testOutput, 'traces', 'raw');
     console.log(`video will be written to: ${directory}`);
     const env = this.setupPodmanDesktopCustomFolder();
     const recordVideo = {
@@ -208,6 +209,7 @@ export class PodmanDesktopRunner {
       executablePath,
       env,
       recordVideo,
+      tracesDir,
     };
   }
 

--- a/tests/src/welcome-page-smoke.spec.ts
+++ b/tests/src/welcome-page-smoke.spec.ts
@@ -31,7 +31,7 @@ let page: Page;
 beforeAll(async () => {
   pdRunner = new PodmanDesktopRunner('', 'welcome-podman-desktop');
   page = await pdRunner.start();
-  pdRunner.setVideoName('welcome-page-e2e');
+  pdRunner.setVideoAndTraceName('welcome-page-e2e');
 });
 
 afterAll(async () => {

--- a/tests/src/yaml-smoke.spec.ts
+++ b/tests/src/yaml-smoke.spec.ts
@@ -36,7 +36,7 @@ const backendImage = 'podify-demo-backend';
 beforeAll(async () => {
   pdRunner = new PodmanDesktopRunner();
   page = await pdRunner.start();
-  pdRunner.setVideoName('play-yaml-e2e');
+  pdRunner.setVideoAndTraceName('play-yaml-e2e');
 
   await new WelcomePage(page).handleWelcomePage(true);
 });


### PR DESCRIPTION
### What does this PR do?

Adds playwright tracing functionality to e2e tests.

### What issues does this PR fix or reference?

Closes https://github.com/containers/podman-desktop/issues/5518

### How to test this PR

After running e2e tests now there will be playwright generated trace files in tests/output/traces folder which can be viewed using playwright trace viewer

Traces can be view in the Playwright trace viewer by running the command: npx playwright show-trace path/to/trace.zip
