### PR TITLE
fix: deployment conditions overflow

### DIFF
--- a/packages/renderer/src/lib/deployments/DeploymentsList.spec.ts
+++ b/packages/renderer/src/lib/deployments/DeploymentsList.spec.ts
@@ -124,7 +124,7 @@ test('Expect correct column overflow', async () => {
 
   await waitRender({});
 
-  let rows = await screen.findAllByRole('row');
+  const rows = await screen.findAllByRole('row');
   expect(rows).toBeDefined();
   expect(rows.length).toBe(2);
 

--- a/packages/renderer/src/lib/deployments/DeploymentsList.svelte
+++ b/packages/renderer/src/lib/deployments/DeploymentsList.svelte
@@ -78,6 +78,7 @@ let namespaceColumn = new Column<DeploymentUI, string>('Namespace', {
 
 let conditionsColumn = new Column<DeploymentUI>('Conditions', {
   width: '2fr',
+  overflow: true,
   renderer: DeploymentColumnConditions,
 });
 


### PR DESCRIPTION
### What does this PR do?

While the deployments PR was up for review, we changed the default for columns to not allow overflow unless the column specifically requests it. This makes horizontal scaling avoid overlapping columns, but columns like conditions need to specifically request overflow for tooltips. This just adds the missing attribute.

### Screenshot / video of UI

See screen cap in #5463.

### What issues does this PR fix or reference?

Fixes #5463.

### How to test this PR?

View a deployment and make sure the tooltip is visible.