### PR TITLE
feat: add new contribution points for icon of image

### DIFF
--- a/packages/main/src/plugin/api/view-info.ts
+++ b/packages/main/src/plugin/api/view-info.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,12 +15,19 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
-export interface ViewContribution {
+export type ViewContribution = ViewContributionIcon;
+
+export interface ViewContributionIcon {
   when: string | undefined;
   icon: string;
 }
 
-export interface ViewInfoUI extends ViewContribution {
+export interface ViewInfoUI {
   extensionId: string;
   viewId: string;
+  value: ViewContributionIcon;
+}
+
+export function isViewContributionIcon(value: ViewContributionIcon): value is ViewContributionIcon {
+  return (value as ViewContributionIcon).icon !== undefined;
 }

--- a/packages/main/src/plugin/view-registry.spec.ts
+++ b/packages/main/src/plugin/view-registry.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@
 import { beforeEach, expect, expectTypeOf, test, vi } from 'vitest';
 import { ViewRegistry } from './view-registry.js';
 import type { Disposable } from './types/disposable.js';
+import type { ViewContributionIcon } from './api/view-info.js';
 
 let viewRegistry: ViewRegistry;
 
@@ -58,8 +59,8 @@ test('View context should have a single entry', async () => {
   expect(views).toBeDefined();
   expectTypeOf(views).toBeArray();
   expect(views.length).toBe(1);
-  expect(views[0].when).toBe('io.x-k8s.kind.cluster in containerLabelKeys');
-  expect(views[0].icon).toBe('${kind-icon}');
+  expect((views[0].value as ViewContributionIcon).when).toBe('io.x-k8s.kind.cluster in containerLabelKeys');
+  expect((views[0].value as ViewContributionIcon).icon).toBe('${kind-icon}');
 });
 
 test('Should not find menus after dispose', async () => {

--- a/packages/main/src/plugin/view-registry.ts
+++ b/packages/main/src/plugin/view-registry.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -60,7 +60,7 @@ export class ViewRegistry {
       value.forEach((contributions, view) => {
         contributions.forEach(contribution => {
           listViewInfoUI.push({
-            ...contribution,
+            value: contribution,
             extensionId: extension,
             viewId: view,
           });
@@ -79,7 +79,7 @@ export class ViewRegistry {
     viewContributions.forEach((contributions, view) => {
       contributions.forEach(contribution => {
         listViewInfoUI.push({
-          ...contribution,
+          value: contribution,
           extensionId: extensionId,
           viewId: view,
         });

--- a/packages/renderer/src/AppNavigation.svelte
+++ b/packages/renderer/src/AppNavigation.svelte
@@ -61,7 +61,7 @@ onMount(async () => {
     }
   });
   imageInfoSubscribe = imagesInfos.subscribe(value => {
-    let images = value.map((imageInfo: ImageInfo) => imageUtils.getImagesInfoUI(imageInfo, [])).flat();
+    let images = value.map((imageInfo: ImageInfo) => imageUtils.getImagesInfoUI(imageInfo, [], undefined, [])).flat();
     if (images.length > 0) {
       imageCount = ' (' + images.length + ')';
     } else {

--- a/packages/renderer/src/lib/actions/ContributionActions.svelte
+++ b/packages/renderer/src/lib/actions/ContributionActions.svelte
@@ -4,8 +4,8 @@ import { faPlug } from '@fortawesome/free-solid-svg-icons';
 import ListItemButtonIcon from '../ui/ListItemButtonIcon.svelte';
 import { removeNonSerializableProperties } from '/@/lib/actions/ActionUtils';
 import type { ContextUI } from '/@/lib/context/context';
-import { onDestroy, onMount } from 'svelte';
-import { context } from '/@/stores/context';
+import { onDestroy } from 'svelte';
+import { context as storeContext } from '/@/stores/context';
 import type { Unsubscriber } from 'svelte/store';
 import { ContextKeyExpr } from '/@/lib/context/contextKey';
 import { transformObjectToContext } from '/@/lib/context/ContextUtils';
@@ -17,6 +17,7 @@ export let contextPrefix: string | undefined = undefined;
 export let dropdownMenu = false;
 export let contributions: Menu[] = [];
 export let detailed = false;
+export let contextUI: ContextUI | undefined = undefined;
 
 let filteredContributions: Menu[] = [];
 $: {
@@ -48,11 +49,18 @@ $: {
 let globalContext: ContextUI;
 let contextsUnsubscribe: Unsubscriber;
 
-onMount(async () => {
-  contextsUnsubscribe = context.subscribe(value => {
-    globalContext = value;
-  });
-});
+$: {
+  if (contextUI) {
+    globalContext = contextUI;
+  } else {
+    if (contextsUnsubscribe) {
+      contextsUnsubscribe();
+    }
+    contextsUnsubscribe = storeContext.subscribe(value => {
+      globalContext = value;
+    });
+  }
+}
 
 onDestroy(() => {
   // unsubscribe from the store
@@ -78,5 +86,6 @@ async function executeContribution(menu: Menu): Promise<void> {
     menu="{dropdownMenu}"
     icon="{faPlug}"
     detailed="{detailed}"
-    disabledWhen="{menu.disabled}" />
+    disabledWhen="{menu.disabled}"
+    contextUI="{globalContext}" />
 {/each}

--- a/packages/renderer/src/lib/container/container-utils.spec.ts
+++ b/packages/renderer/src/lib/container/container-utils.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2022-2023 Red Hat, Inc.
+ * Copyright (C) 2022-2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -225,8 +225,10 @@ test('should expect icon to be valid value with context/view set', async () => {
   const view: ViewInfoUI = {
     extensionId: 'extension',
     viewId: 'id',
-    icon: '${kind-icon}',
-    when: 'io.x-k8s.kind.cluster in containerLabelKeys',
+    value: {
+      icon: '${kind-icon}',
+      when: 'io.x-k8s.kind.cluster in containerLabelKeys',
+    },
   };
   const containerInfo = {
     Image: 'docker.io/kindest/node:foobar',

--- a/packages/renderer/src/lib/container/container-utils.ts
+++ b/packages/renderer/src/lib/container/container-utils.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2022-2023 Red Hat, Inc.
+ * Copyright (C) 2022-2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import humanizeDuration from 'humanize-duration';
 import { filesize } from 'filesize';
 import type { Port } from '@podman-desktop/api';
 import type { ContextUI } from '../context/context';
-import type { ViewInfoUI } from '../../../../main/src/plugin/api/view-info';
+import { isViewContributionIcon, type ViewInfoUI } from '../../../../main/src/plugin/api/view-info';
 import { ContextKeyExpr } from '../context/contextKey';
 import ContainerIcon from '../images/ContainerIcon.svelte';
 
@@ -260,19 +260,21 @@ export class ContainerUtils {
     let icon;
     // loop over all contribution for this view
     for (const contribution of viewContributions) {
-      // adapt the context to work with containers (e.g save container labels into the context)
-      this.adaptContextOnContainer(context, container);
-      // deserialize the when clause
-      const whenDeserialized = ContextKeyExpr.deserialize(contribution.when);
-      // if the when clause has to be applied to this container
-      if (whenDeserialized?.evaluate(context)) {
-        // handle ${} in icon class
-        // and interpret the value and replace with the class-name
-        const match = contribution.icon.match(/\$\{(.*)\}/);
-        if (match && match.length === 2) {
-          const className = match[1];
-          icon = contribution.icon.replace(match[0], `podman-desktop-icon-${className}`);
-          return icon;
+      if (isViewContributionIcon(contribution.value)) {
+        // adapt the context to work with containers (e.g save container labels into the context)
+        this.adaptContextOnContainer(context, container);
+        // deserialize the when clause
+        const whenDeserialized = ContextKeyExpr.deserialize(contribution.value.when);
+        // if the when clause has to be applied to this container
+        if (whenDeserialized?.evaluate(context)) {
+          // handle ${} in icon class
+          // and interpret the value and replace with the class-name
+          const match = contribution.value.icon.match(/\$\{(.*)\}/);
+          if (match && match.length === 2) {
+            const className = match[1];
+            icon = contribution.value.icon.replace(match[0], `podman-desktop-icon-${className}`);
+            return icon;
+          }
         }
       }
     }

--- a/packages/renderer/src/lib/image/ImageActions.svelte
+++ b/packages/renderer/src/lib/image/ImageActions.svelte
@@ -11,7 +11,7 @@ import { onDestroy, onMount } from 'svelte';
 import { MenuContext } from '../../../../main/src/plugin/menu-registry';
 import ActionsWrapper from './ActionsMenu.svelte';
 import type { Unsubscriber } from 'svelte/motion';
-import type { ContextUI } from '../context/context';
+import { ContextUI } from '../context/context';
 import { context } from '/@/stores/context';
 
 export let onPushImage: (imageInfo: ImageInfoUI) => void;
@@ -33,7 +33,15 @@ onMount(async () => {
   contributions = await window.getContributedMenus(MenuContext.DASHBOARD_IMAGE);
   groupingContributions = groupContributions && !dropdownMenu && contributions.length > 1;
   contextsUnsubscribe = context.subscribe(value => {
-    globalContext = value;
+    // Copy context, do not use reference
+    globalContext = new ContextUI();
+    const allValues = value.collectAllValues();
+    for (const k in allValues) {
+      globalContext.setValue(k, allValues[k]);
+    }
+
+    const labels = image.labels ? Object.keys(image.labels) : [];
+    globalContext.setValue('imageLabelKeys', labels);
   });
 });
 
@@ -127,6 +135,7 @@ function onError(error: string): void {
       contributions="{contributions}"
       contextPrefix="imageItem"
       detailed="{detailed}"
-      onError="{onError}" />
+      onError="{onError}"
+      contextUI="{globalContext}" />
   </ActionsWrapper>
 </ActionsWrapper>

--- a/packages/renderer/src/lib/image/ImageColumnAge.spec.ts
+++ b/packages/renderer/src/lib/image/ImageColumnAge.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import { render, screen } from '@testing-library/svelte';
 
 import ImageColumnAge from './ImageColumnAge.svelte';
 import type { ImageInfoUI } from './ImageInfoUI';
+import ImageIcon from '../images/ImageIcon.svelte';
 
 test('Expect simple column styling', async () => {
   const image: ImageInfoUI = {
@@ -38,6 +39,7 @@ test('Expect simple column styling', async () => {
     base64RepoTag: '',
     selected: false,
     inUse: false,
+    icon: ImageIcon,
   };
   render(ImageColumnAge, { object: image });
 

--- a/packages/renderer/src/lib/image/ImageColumnEnvironment.spec.ts
+++ b/packages/renderer/src/lib/image/ImageColumnEnvironment.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import { render, screen } from '@testing-library/svelte';
 
 import ImageColumnEnvironment from './ImageColumnEnvironment.svelte';
 import type { ImageInfoUI } from './ImageInfoUI';
+import ImageIcon from '../images/ImageIcon.svelte';
 
 test('Expect simple column styling', async () => {
   const image: ImageInfoUI = {
@@ -38,6 +39,7 @@ test('Expect simple column styling', async () => {
     base64RepoTag: '',
     selected: false,
     inUse: false,
+    icon: ImageIcon,
   };
   render(ImageColumnEnvironment, { object: image });
 

--- a/packages/renderer/src/lib/image/ImageColumnName.spec.ts
+++ b/packages/renderer/src/lib/image/ImageColumnName.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import ImageColumnName from './ImageColumnName.svelte';
 import type { ImageInfoUI } from './ImageInfoUI';
 import { router } from 'tinro';
 import { fireEvent } from '@testing-library/dom';
+import ImageIcon from '../images/ImageIcon.svelte';
 
 const image: ImageInfoUI = {
   id: 'my-image',
@@ -39,6 +40,7 @@ const image: ImageInfoUI = {
   base64RepoTag: 'repoTag',
   selected: false,
   inUse: false,
+  icon: ImageIcon,
 };
 
 test('Expect simple column styling', async () => {

--- a/packages/renderer/src/lib/image/ImageColumnSize.spec.ts
+++ b/packages/renderer/src/lib/image/ImageColumnSize.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import { render, screen } from '@testing-library/svelte';
 
 import ImageColumnSize from './ImageColumnSize.svelte';
 import type { ImageInfoUI } from './ImageInfoUI';
+import ImageIcon from '../images/ImageIcon.svelte';
 
 test('Expect simple column styling', async () => {
   const image: ImageInfoUI = {
@@ -38,6 +39,7 @@ test('Expect simple column styling', async () => {
     base64RepoTag: '',
     selected: false,
     inUse: false,
+    icon: ImageIcon,
   };
   render(ImageColumnSize, { object: image });
 

--- a/packages/renderer/src/lib/image/ImageColumnStatus.spec.ts
+++ b/packages/renderer/src/lib/image/ImageColumnStatus.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import { render, screen } from '@testing-library/svelte';
 
 import ImageColumnStatus from './ImageColumnStatus.svelte';
 import type { ImageInfoUI } from './ImageInfoUI';
+import ImageIcon from '../images/ImageIcon.svelte';
 
 test('Expect simple column styling', async () => {
   const image: ImageInfoUI = {
@@ -38,6 +39,7 @@ test('Expect simple column styling', async () => {
     base64RepoTag: '',
     selected: false,
     inUse: true,
+    icon: ImageIcon,
   };
   render(ImageColumnStatus, { object: image });
 

--- a/packages/renderer/src/lib/image/ImageColumnStatus.svelte
+++ b/packages/renderer/src/lib/image/ImageColumnStatus.svelte
@@ -1,9 +1,8 @@
 <script lang="ts">
 import type { ImageInfoUI } from './ImageInfoUI';
-import ImageIcon from '../images/ImageIcon.svelte';
 import StatusIcon from '../images/StatusIcon.svelte';
 
 export let object: ImageInfoUI;
 </script>
 
-<StatusIcon icon="{ImageIcon}" status="{object.inUse ? 'USED' : 'UNUSED'}" />
+<StatusIcon icon="{object.icon}" status="{object.inUse ? 'USED' : 'UNUSED'}" />

--- a/packages/renderer/src/lib/image/ImageInfoUI.ts
+++ b/packages/renderer/src/lib/image/ImageInfoUI.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2022 Red Hat, Inc.
+ * Copyright (C) 2022-2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,4 +32,6 @@ export interface ImageInfoUI {
   base64RepoTag: string;
   selected: boolean;
   inUse: boolean;
+  icon: any;
+  labels?: { [label: string]: string };
 }

--- a/packages/renderer/src/lib/image/RunImage.spec.ts
+++ b/packages/renderer/src/lib/image/RunImage.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import type { ImageInspectInfo } from '../../../../main/src/plugin/api/image-ins
 import { mockBreadcrumb } from '../../stores/breadcrumb.spec';
 import userEvent from '@testing-library/user-event';
 import { router } from 'tinro';
+import ImageIcon from '../images/ImageIcon.svelte';
 
 const originalConsoleDebug = console.debug;
 
@@ -82,6 +83,7 @@ async function createRunImage(entrypoint?: string | string[], cmd?: string[]) {
     selected: false,
     shortId: '',
     tag: '',
+    icon: ImageIcon,
   });
   const imageInfo: ImageInspectInfo = {
     Architecture: '',

--- a/packages/renderer/src/lib/image/image-utils.spec.ts
+++ b/packages/renderer/src/lib/image/image-utils.spec.ts
@@ -18,6 +18,9 @@
 
 import { describe, beforeEach, expect, test, vi } from 'vitest';
 import { ImageUtils } from './image-utils';
+import type { ImageInfo } from '../../../../main/src/plugin/api/image-info';
+import { ContextUI } from '../context/context';
+import type { ViewInfoUI } from '../../../../main/src/plugin/api/view-info';
 
 let imageUtils: ImageUtils;
 
@@ -49,4 +52,52 @@ describe.each([
     expect(imageUtils.getName(repoTag)).toBe(expectedName);
     expect(imageUtils.getTag(repoTag)).toBe(expectedTag);
   });
+});
+
+test('should expect icon to be undefined if no context/view is passed', async () => {
+  const imageInfo = {
+    Id: '12345',
+    Labels: {},
+  } as unknown as ImageInfo;
+  const icon = imageUtils.iconClass(imageInfo);
+  expect(icon).toBe(undefined);
+});
+
+test('should expect icon to be valid value with context/view set', async () => {
+  const context = new ContextUI();
+  const view: ViewInfoUI = {
+    extensionId: 'extension',
+    viewId: 'id',
+    value: {
+      icon: '${kind-icon}',
+      when: 'io.x-k8s.kind.cluster in imageLabelKeys',
+    },
+  };
+  const imageInfo = {
+    Id: '12345',
+    Labels: {
+      'io.x-k8s.kind.cluster': 'ok',
+    },
+  } as unknown as ImageInfo;
+  const icon = imageUtils.iconClass(imageInfo, context, [view]);
+  expect(icon).toBe('podman-desktop-icon-kind-icon');
+});
+
+test('should expect icon to be ContainerIcon if no context/view is passed', async () => {
+  const imageInfo = {
+    Id: 'container1',
+    Size: 123,
+  } as unknown as ImageInfo;
+  const imageinfoUIs = imageUtils.getImagesInfoUI(imageInfo, []);
+  expect(imageinfoUIs[0].icon).toBeDefined();
+  expect(typeof imageinfoUIs[0].icon !== 'string').toBe(true);
+});
+
+test('check parsing of image info without labels', async () => {
+  const context = new ContextUI();
+  const imageInfo = {
+    Id: '1234',
+    Labels: '',
+  } as unknown as ImageInfo;
+  imageUtils.adaptContextOnImage(context, imageInfo);
 });

--- a/packages/renderer/src/lib/ui/ListItemButtonIcon.spec.ts
+++ b/packages/renderer/src/lib/ui/ListItemButtonIcon.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,6 +36,7 @@ test('Expect the dropDownMenuItem to have classes that display a disabled object
     icon: faRocket,
     disabledWhen: 'test in values',
     menu: true,
+    contextUI: contextUI,
   });
 
   const listItemSpan = screen.getByTitle(title);
@@ -70,6 +71,7 @@ test('Expect the dropDownMenuItem NOT to have classes that display a disabled ob
     icon: faRocket,
     disabledWhen: 'unknown in values',
     menu: true,
+    contextUI: contextUI,
   });
 
   const listItemSpan = screen.getByTitle(title);

--- a/packages/renderer/src/lib/view/views.ts
+++ b/packages/renderer/src/lib/view/views.ts
@@ -1,1 +1,22 @@
+/**********************************************************************
+ * Copyright (C) 2022-2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
 export const CONTAINER_LIST_VIEW = 'icons/containersList';
+export const IMAGE_LIST_VIEW_ICONS = 'icons/imagesList';
+export const IMAGE_DETAILS_VIEW_ICONS = 'icons/imageDetails';
+export const IMAGE_VIEW_ICONS = 'icons/image';


### PR DESCRIPTION
### What does this PR do?
contribution points are
`icons/imagesList` `icons/imageDetails` and `icons/image`

### Screenshot / video of UI
![image](https://github.com/containers/podman-desktop/assets/436777/784efc7d-9537-4351-88eb-e6a28fa6ae46)


![image](https://github.com/containers/podman-desktop/assets/436777/aa006e51-b598-492d-b654-485145bbcf4d)



### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/5542

### How to test this PR?

unit and component tests added

can be checked with like:

`icons/image` applies to both list and details

```
      "icons/imagesList": [
        {
          "when": "io.buildah.version in imageLabelKeys",
          "icon": "${kind-icon}"
        }
      ],
```

```
      "icons/imageDetails": [
        {
          "when": "io.buildah.version in imageLabelKeys",
          "icon": "${kind-icon}"
        }
      ],
```

or
```
      "icons/image": [
        {
          "when": "io.buildah.version in imageLabelKeys",
          "icon": "${kind-icon}"
        }
      ],
```
