### PR TITLE
feat: make Kubernetes support experimental

### DIFF
--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -155,6 +155,8 @@ import { NavigationManager } from '/@/plugin/navigation/navigation-manager.js';
 import { WebviewRegistry } from './webview/webview-registry.js';
 import type { IDisposable } from './types/disposable.js';
 
+import { KubernetesUtils } from './kubernetes-util.js';
+
 type LogType = 'log' | 'warn' | 'trace' | 'debug' | 'error';
 
 export const UPDATER_UPDATE_AVAILABLE_ICON = 'fa fa-exclamation-triangle';
@@ -745,6 +747,10 @@ export class PluginSystem {
     const navigationManager = new NavigationManager(apiSender, containerProviderRegistry, contributionManager);
     const webviewRegistry = new WebviewRegistry(apiSender);
     await webviewRegistry.start();
+
+    // init kubernetes configuration
+    const kubernetesUtils = new KubernetesUtils(configurationRegistry);
+    kubernetesUtils.init();
 
     this.extensionLoader = new ExtensionLoader(
       commandRegistry,

--- a/packages/main/src/plugin/kubernetes-util.ts
+++ b/packages/main/src/plugin/kubernetes-util.ts
@@ -1,0 +1,41 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { IConfigurationNode, IConfigurationRegistry } from './configuration-registry.js';
+
+export class KubernetesUtils {
+  constructor(private configurationRegistry: IConfigurationRegistry) {}
+
+  init() {
+    const kubernetesConfiguration: IConfigurationNode = {
+      id: 'preferences.kubernetes',
+      title: 'Kubernetes',
+      type: 'object',
+      properties: {
+        ['kubernetes.experimental']: {
+          description: 'Experimental extended Kubernetes support.',
+          type: 'boolean',
+          default: false,
+          hidden: false,
+        },
+      },
+    };
+
+    this.configurationRegistry.registerConfigurations([kubernetesConfiguration]);
+  }
+}


### PR DESCRIPTION
### What does this PR do?

Adds a new experimental flag (off by default) that hides the Kubernetes options on the left navbar. When you enable it, the options automatically appear.

Tests added to make sure that the Kubernetes options don't appear if the preference is not set, and do appear if it is (and have at least one context).

### Screenshot / video of UI

<img width="725" alt="Screenshot 2024-01-15 at 1 35 25 PM" src="https://github.com/containers/podman-desktop/assets/19958075/f4897f4e-67d4-4d0a-8ef4-7fa11c8981de">

### What issues does this PR fix or reference?

Fixes #5525.

### How to test this PR?

Make sure you have at least one Kubernetes context and the options aren't visible. Go to Preferences and turn it on and they should appear.