### PR TITLE
feat: merge extension preferences

### DIFF
--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -231,7 +231,7 @@ export class ExtensionLoader {
     this.moduleLoader.overrideRequire();
     // register configuration for the max activation time
     const maxActivationTimeConfiguration: IConfigurationNode = {
-      id: 'preferences.extension',
+      id: 'preferences.extensions',
       title: 'Extensions',
       type: 'object',
       properties: {

--- a/packages/main/src/plugin/extensions-updater/extensions-updater.ts
+++ b/packages/main/src/plugin/extensions-updater/extensions-updater.ts
@@ -43,8 +43,8 @@ export class ExtensionsUpdater {
     const autoUpdateKey = `${ExtensionsUpdaterSettings.SectionName}.${ExtensionsUpdaterSettings.AutoUpdate}`;
 
     const extensionLoaderConfiguration: IConfigurationNode = {
-      id: 'preferences.extensions',
-      title: 'Extensions Updates',
+      id: 'preferences.extension',
+      title: 'Extensions',
       type: 'object',
       properties: {
         [autoCheckUpdatesKey]: {

--- a/packages/main/src/plugin/extensions-updater/extensions-updater.ts
+++ b/packages/main/src/plugin/extensions-updater/extensions-updater.ts
@@ -43,7 +43,7 @@ export class ExtensionsUpdater {
     const autoUpdateKey = `${ExtensionsUpdaterSettings.SectionName}.${ExtensionsUpdaterSettings.AutoUpdate}`;
 
     const extensionLoaderConfiguration: IConfigurationNode = {
-      id: 'preferences.extension',
+      id: 'preferences.extensions',
       title: 'Extensions',
       type: 'object',
       properties: {


### PR DESCRIPTION
### What does this PR do?

Sets the same id and title on the extension update preferences as the activation pref. We could merge the two, but having two contributions with the same id doesn't seem to have any side effects and this keeps each bit of code separate.

Yes, this means that anyone who has set these two properties will have them reset when they update to this PR, but that seems inevitable when we fix this (the sooner the better) and doesn't seem worth additional code to automatically migrate the setting.

### Screenshot / video of UI

Before:

<img width="750" alt="Screenshot 2024-01-15 at 1 50 40 PM" src="https://github.com/containers/podman-desktop/assets/19958075/39afa5e0-2821-46da-b557-88aa2aca3381">

After:

<img width="750" alt="Screenshot 2024-01-15 at 1 51 28 PM" src="https://github.com/containers/podman-desktop/assets/19958075/385fde10-06bb-4197-97f2-bb8db4a49cf5">

### What issues does this PR fix or reference?

Fixes #5549.

### How to test this PR?

Check Settings > Preferences.