### PR TITLE
chore: kubeconfig topic

### DIFF
--- a/packages/main/src/plugin/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes-client.ts
@@ -156,12 +156,12 @@ export class KubernetesClient {
 
     // add configuration
     const kubeconfigConfigurationNode: IConfigurationNode = {
-      id: 'preferences.Kubernetes.Kubeconfig',
-      title: 'Path to the kubeconfig file',
+      id: 'preferences.kubernetes',
+      title: 'Kubernetes',
       type: 'object',
       properties: {
         ['kubernetes.Kubeconfig']: {
-          description: 'Kubeconfig path to use for accessing clusters. (Default is usually ~/.kube/config)',
+          description: 'Path to the Kubeconfig file for accessing clusters. (Default is usually ~/.kube/config)',
           type: 'string',
           default: defaultKubeconfigPath,
           format: 'file',


### PR DESCRIPTION
### What does this PR do?

After doing other PRs I noticed that the Kubeconfig preference has an odd path. This changes it to just 'Kubernetes' to fit in and be common enough to sit with other Kubernetes options.

This is a 'breaking change' since it will reset the preference for anyone who has changed it, but I don't think it is worth trying to migrate it and doing it now (before we start to release more Kubernetes UI support) is much better than holding off.

### Screenshot / video of UI

Before:

<img width="587" alt="Screenshot 2024-01-15 at 5 41 51 PM" src="https://github.com/containers/podman-desktop/assets/19958075/9e70b4e8-94d1-4eff-893a-25cae98bdac7">

After (shown with PR #5548):

<img width="587" alt="Screenshot 2024-01-15 at 5 33 14 PM" src="https://github.com/containers/podman-desktop/assets/19958075/6a76943e-003b-429c-9da1-8266f1e5145c">

### What issues does this PR fix or reference?

Fixes #5551.

### How to test this PR?

Go to Settings > Preferences > Kubernetes.