### PR TITLE
feat: allow to register badges by extensions for image list/details

### DIFF
--- a/packages/main/src/plugin/api/view-info.ts
+++ b/packages/main/src/plugin/api/view-info.ts
@@ -15,19 +15,37 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
-export type ViewContribution = ViewContributionIcon;
+export type ViewContribution = ViewContributionIcon | ViewContributionBadge;
 
 export interface ViewContributionIcon {
   when: string | undefined;
   icon: string;
 }
 
+export interface ViewContributionBadge {
+  when: string | undefined;
+  badge: ViewContributionBadgeValue;
+}
+
+export interface ViewContributionBadgeValue {
+  label: string;
+  color?: string | { light: string; dark: string };
+}
+
 export interface ViewInfoUI {
   extensionId: string;
   viewId: string;
-  value: ViewContributionIcon;
+  value: ViewContributionIcon | ViewContributionBadge;
 }
 
-export function isViewContributionIcon(value: ViewContributionIcon): value is ViewContributionIcon {
+export function isViewContributionIcon(
+  value: ViewContributionIcon | ViewContributionBadge,
+): value is ViewContributionIcon {
   return (value as ViewContributionIcon).icon !== undefined;
+}
+
+export function isViewContributionBadge(
+  value: ViewContributionIcon | ViewContributionBadge,
+): value is ViewContributionBadge {
+  return (value as ViewContributionBadge).badge !== undefined;
 }

--- a/packages/renderer/src/lib/image/ImageColumnAge.spec.ts
+++ b/packages/renderer/src/lib/image/ImageColumnAge.spec.ts
@@ -40,6 +40,7 @@ test('Expect simple column styling', async () => {
     selected: false,
     inUse: false,
     icon: ImageIcon,
+    badges: [],
   };
   render(ImageColumnAge, { object: image });
 

--- a/packages/renderer/src/lib/image/ImageColumnEnvironment.spec.ts
+++ b/packages/renderer/src/lib/image/ImageColumnEnvironment.spec.ts
@@ -40,6 +40,7 @@ test('Expect simple column styling', async () => {
     selected: false,
     inUse: false,
     icon: ImageIcon,
+    badges: [],
   };
   render(ImageColumnEnvironment, { object: image });
 

--- a/packages/renderer/src/lib/image/ImageColumnName.spec.ts
+++ b/packages/renderer/src/lib/image/ImageColumnName.spec.ts
@@ -25,6 +25,7 @@ import type { ImageInfoUI } from './ImageInfoUI';
 import { router } from 'tinro';
 import { fireEvent } from '@testing-library/dom';
 import ImageIcon from '../images/ImageIcon.svelte';
+import { AppearanceSettings } from '../../../../main/src/plugin/appearance-settings';
 
 const image: ImageInfoUI = {
   id: 'my-image',
@@ -41,6 +42,7 @@ const image: ImageInfoUI = {
   selected: false,
   inUse: false,
   icon: ImageIcon,
+  badges: [],
 };
 
 test('Expect simple column styling', async () => {
@@ -73,4 +75,90 @@ test('Expect clicking works', async () => {
   fireEvent.click(text);
 
   expect(routerGotoSpy).toBeCalledWith('/images/my-image/podman/repoTag/summary');
+});
+
+test('Expect badge with simple color', async () => {
+  const imageWithBadges: ImageInfoUI = {
+    ...image,
+    badges: [
+      {
+        label: 'my-badge',
+        color: '#ff0000',
+      },
+    ],
+  };
+  render(ImageColumnName, { object: imageWithBadges });
+
+  // wait for image to be rendered using timeout
+  await new Promise(resolve => setTimeout(resolve, 100));
+
+  const text = screen.getByText(image.name);
+  expect(text).toBeInTheDocument();
+
+  // get label 'my-badge'
+  const badge = screen.getByText('my-badge');
+  expect(badge).toBeInTheDocument();
+
+  // check background color
+  expect(badge).toHaveStyle('background-color: #ff0000');
+});
+
+test('Expect badge with dark color', async () => {
+  (window as any).getConfigurationValue = vi.fn().mockResolvedValue(AppearanceSettings.DarkEnumValue);
+  const imageWithBadges: ImageInfoUI = {
+    ...image,
+    badges: [
+      {
+        label: 'my-dark-badge',
+        color: {
+          dark: '#0000ff',
+          light: '#00ff00',
+        },
+      },
+    ],
+  };
+  render(ImageColumnName, { object: imageWithBadges });
+
+  // wait for image to be rendered using timeout
+  await new Promise(resolve => setTimeout(resolve, 100));
+
+  const text = screen.getByText(image.name);
+  expect(text).toBeInTheDocument();
+
+  // get label 'my-badge'
+  const badge = screen.getByText('my-dark-badge');
+  expect(badge).toBeInTheDocument();
+
+  // check background color
+  expect(badge).toHaveStyle('background-color: #0000ff');
+});
+
+test('Expect badge with light color', async () => {
+  (window as any).getConfigurationValue = vi.fn().mockResolvedValue(AppearanceSettings.LightEnumValue);
+  const imageWithBadges: ImageInfoUI = {
+    ...image,
+    badges: [
+      {
+        label: 'my-light-badge',
+        color: {
+          dark: '#0000ff',
+          light: '#00ff00',
+        },
+      },
+    ],
+  };
+  render(ImageColumnName, { object: imageWithBadges });
+
+  // wait for image to be rendered using timeout
+  await new Promise(resolve => setTimeout(resolve, 100));
+
+  const text = screen.getByText(image.name);
+  expect(text).toBeInTheDocument();
+
+  // get label 'my-badge'
+  const badge = screen.getByText('my-light-badge');
+  expect(badge).toBeInTheDocument();
+
+  // check background color
+  expect(badge).toHaveStyle('background-color: #00ff00');
 });

--- a/packages/renderer/src/lib/image/ImageColumnName.svelte
+++ b/packages/renderer/src/lib/image/ImageColumnName.svelte
@@ -2,6 +2,7 @@
 import { router } from 'tinro';
 import type { ImageInfoUI } from './ImageInfoUI';
 
+import Badge from '../ui/Badge.svelte';
 export let object: ImageInfoUI;
 
 function openDetailsImage(image: ImageInfoUI) {
@@ -10,7 +11,14 @@ function openDetailsImage(image: ImageInfoUI) {
 </script>
 
 <button class="flex flex-col" on:click="{() => openDetailsImage(object)}">
-  <div class="text-sm text-gray-300">{object.name}</div>
+  <div class="flex flex-row text-xs gap-1 items-center">
+    <div class="text-sm text-gray-300">{object.name}</div>
+    {#if object.badges.length}
+      {#each object.badges as badge}
+        <Badge color="{badge.color}" label="{badge.label}" />
+      {/each}
+    {/if}
+  </div>
   <div class="flex flex-row text-xs gap-1">
     <div class="text-violet-400">{object.shortId}</div>
     <div class="font-extra-light text-gray-400">{object.tag}</div>

--- a/packages/renderer/src/lib/image/ImageColumnSize.spec.ts
+++ b/packages/renderer/src/lib/image/ImageColumnSize.spec.ts
@@ -40,6 +40,7 @@ test('Expect simple column styling', async () => {
     selected: false,
     inUse: false,
     icon: ImageIcon,
+    badges: [],
   };
   render(ImageColumnSize, { object: image });
 

--- a/packages/renderer/src/lib/image/ImageColumnStatus.spec.ts
+++ b/packages/renderer/src/lib/image/ImageColumnStatus.spec.ts
@@ -40,6 +40,7 @@ test('Expect simple column styling', async () => {
     selected: false,
     inUse: true,
     icon: ImageIcon,
+    badges: [],
   };
   render(ImageColumnStatus, { object: image });
 

--- a/packages/renderer/src/lib/image/ImageDetails.svelte
+++ b/packages/renderer/src/lib/image/ImageDetails.svelte
@@ -20,9 +20,15 @@ import type { Unsubscriber } from 'svelte/motion';
 import type { ImageInfo } from '@podman-desktop/api';
 import { viewsContributions } from '/@/stores/views';
 import type { ViewInfoUI } from '../../../../main/src/plugin/api/view-info';
-import { IMAGE_DETAILS_VIEW_ICONS, IMAGE_VIEW_ICONS } from '../view/views';
+import {
+  IMAGE_DETAILS_VIEW_BADGES,
+  IMAGE_DETAILS_VIEW_ICONS,
+  IMAGE_VIEW_BADGES,
+  IMAGE_VIEW_ICONS,
+} from '../view/views';
 import { context } from '/@/stores/context';
 import type { ContextUI } from '../context/context';
+import Badge from '../ui/Badge.svelte';
 
 export let imageID: string;
 export let engineId: string;
@@ -82,7 +88,13 @@ onMount(() => {
 
   viewsUnsubscribe = viewsContributions.subscribe(value => {
     viewContributions =
-      value.filter(view => view.viewId === IMAGE_DETAILS_VIEW_ICONS || view.viewId === IMAGE_VIEW_ICONS) || [];
+      value.filter(
+        view =>
+          view.viewId === IMAGE_DETAILS_VIEW_ICONS ||
+          view.viewId === IMAGE_VIEW_ICONS ||
+          view.viewId === IMAGE_VIEW_BADGES ||
+          view.viewId === IMAGE_DETAILS_VIEW_BADGES,
+      ) || [];
     updateImage();
   });
 
@@ -109,6 +121,15 @@ onDestroy(() => {
 {#if image}
   <DetailsPage title="{image.name}" titleDetail="{image.shortId}" subtitle="{image.tag}" bind:this="{detailsPage}">
     <StatusIcon slot="icon" icon="{image.icon}" size="{24}" status="{image.inUse ? 'USED' : 'UNUSED'}" />
+    <svelte:fragment slot="subtitle">
+      {#if image.badges.length}
+        <div class="flex flex-row">
+          {#each image.badges as badge}
+            <Badge color="{badge.color}" label="{badge.label}" />
+          {/each}
+        </div>
+      {/if}
+    </svelte:fragment>
     <ImageActions
       slot="actions"
       image="{image}"

--- a/packages/renderer/src/lib/image/ImageInfoUI.ts
+++ b/packages/renderer/src/lib/image/ImageInfoUI.ts
@@ -16,6 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { ViewContributionBadgeValue } from '../../../../main/src/plugin/api/view-info';
+
 export interface ImageInfoUI {
   id: string;
   shortId: string;
@@ -34,4 +36,5 @@ export interface ImageInfoUI {
   inUse: boolean;
   icon: any;
   labels?: { [label: string]: string };
+  badges: ViewContributionBadgeValue[];
 }

--- a/packages/renderer/src/lib/image/ImagesList.svelte
+++ b/packages/renderer/src/lib/image/ImagesList.svelte
@@ -30,7 +30,7 @@ import ImageColumnSize from './ImageColumnSize.svelte';
 import ImageColumnActions from './ImageColumnActions.svelte';
 import type { ViewInfoUI } from '../../../../main/src/plugin/api/view-info';
 import { viewsContributions } from '/@/stores/views';
-import { IMAGE_VIEW_ICONS, IMAGE_LIST_VIEW_ICONS } from '../view/views';
+import { IMAGE_VIEW_ICONS, IMAGE_LIST_VIEW_ICONS, IMAGE_VIEW_BADGES, IMAGE_LIST_VIEW_BADGES } from '../view/views';
 import type { ContextUI } from '../context/context';
 import { context } from '../../stores/context';
 
@@ -115,7 +115,13 @@ onMount(async () => {
 
   viewsUnsubscribe = viewsContributions.subscribe(value => {
     viewContributions =
-      value.filter(view => view.viewId === IMAGE_LIST_VIEW_ICONS || view.viewId === IMAGE_VIEW_ICONS) || [];
+      value.filter(
+        view =>
+          view.viewId === IMAGE_LIST_VIEW_ICONS ||
+          view.viewId === IMAGE_VIEW_ICONS ||
+          view.viewId === IMAGE_LIST_VIEW_BADGES ||
+          view.viewId === IMAGE_VIEW_BADGES,
+      ) || [];
     if (images.length > 0) {
       updateImages(globalContext);
     }

--- a/packages/renderer/src/lib/image/RunImage.spec.ts
+++ b/packages/renderer/src/lib/image/RunImage.spec.ts
@@ -84,6 +84,7 @@ async function createRunImage(entrypoint?: string | string[], cmd?: string[]) {
     shortId: '',
     tag: '',
     icon: ImageIcon,
+    badges: [],
   });
   const imageInfo: ImageInspectInfo = {
     Architecture: '',

--- a/packages/renderer/src/lib/image/image-utils.spec.ts
+++ b/packages/renderer/src/lib/image/image-utils.spec.ts
@@ -101,3 +101,39 @@ test('check parsing of image info without labels', async () => {
   } as unknown as ImageInfo;
   imageUtils.adaptContextOnImage(context, imageInfo);
 });
+
+test('should expect badge to be undefined if no context/view is passed', async () => {
+  const imageInfo = {
+    Id: '12345',
+    Labels: {},
+  } as unknown as ImageInfo;
+  const badges = imageUtils.computeBagdes(imageInfo);
+  expect(badges).toStrictEqual([]);
+});
+
+test('should expect badge to be valid value with context/view set', async () => {
+  const context = new ContextUI();
+  const view: ViewInfoUI = {
+    extensionId: 'extension',
+    viewId: 'id',
+    value: {
+      badge: {
+        label: 'my-custom-badge',
+        color: '#ff0000',
+      },
+      when: 'io.x-k8s.kind.cluster in imageLabelKeys',
+    },
+  };
+  const imageInfo = {
+    Id: '12345',
+    Labels: {
+      'io.x-k8s.kind.cluster': 'ok',
+    },
+  } as unknown as ImageInfo;
+  const badges = imageUtils.computeBagdes(imageInfo, context, [view]);
+  // size should be one
+  expect(badges.length).toBe(1);
+
+  expect(badges[0].label).toBe('my-custom-badge');
+  expect(badges[0].color).toBe('#ff0000');
+});

--- a/packages/renderer/src/lib/view/views.ts
+++ b/packages/renderer/src/lib/view/views.ts
@@ -20,3 +20,6 @@ export const CONTAINER_LIST_VIEW = 'icons/containersList';
 export const IMAGE_LIST_VIEW_ICONS = 'icons/imagesList';
 export const IMAGE_DETAILS_VIEW_ICONS = 'icons/imageDetails';
 export const IMAGE_VIEW_ICONS = 'icons/image';
+export const IMAGE_VIEW_BADGES = 'badges/image';
+export const IMAGE_DETAILS_VIEW_BADGES = 'badges/imageDetails';
+export const IMAGE_LIST_VIEW_BADGES = 'badges/imagesList';


### PR DESCRIPTION
### What does this PR do?
- [x] depends on https://github.com/containers/podman-desktop/pull/5543

allow to register badges by extensions for image list/details

### Screenshot / video of UI

![image](https://github.com/containers/podman-desktop/assets/436777/2774ff97-50b1-4fb9-9200-14699dc3459c)

![image](https://github.com/containers/podman-desktop/assets/436777/ecef06fe-d642-4ab0-87e7-d1c6ac68c4d2)


### What issues does this PR fix or reference?

fixes #5330 

### How to test this PR?

unit/component tests added

can test using for example
```
      "badges/image": [
        {
          "when": "io.buildah.version in imageLabelKeys",
          "badge": {
            "label": "buildah",
            "color": {
              "dark": "#32CD32",
              "light": "#FF0000"
            }
          }
        },
```