### PR TITLE
fix(ui,tests): rewrite aria-label in various status fields in app

### DIFF
--- a/packages/renderer/src/lib/ui/ConnectionStatus.spec.ts
+++ b/packages/renderer/src/lib/ui/ConnectionStatus.spec.ts
@@ -24,10 +24,13 @@ import ConnectionStatus from './ConnectionStatus.svelte';
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-empty-function */
 
+const connectionStatusLabel = 'Connection Status Label';
+const connectionStatusIcon = 'Connection Status Icon';
+
 test('Expect green text and icon when connection is running', async () => {
   render(ConnectionStatus, { status: 'started' });
-  const icon = screen.getByLabelText('connection-status-icon');
-  const label = screen.getByLabelText('connection-status-label');
+  const icon = screen.getByLabelText(connectionStatusIcon);
+  const label = screen.getByLabelText(connectionStatusLabel);
   expect(icon).toBeInTheDocument();
   expect(icon).toHaveClass('bg-green-500');
   expect(label).toBeInTheDocument();
@@ -37,8 +40,8 @@ test('Expect green text and icon when connection is running', async () => {
 
 test('Expect green text and icon when connection is starting', async () => {
   render(ConnectionStatus, { status: 'starting' });
-  const icon = screen.getByLabelText('connection-status-icon');
-  const label = screen.getByLabelText('connection-status-label');
+  const icon = screen.getByLabelText(connectionStatusIcon);
+  const label = screen.getByLabelText(connectionStatusLabel);
   expect(icon).toBeInTheDocument();
   expect(icon).toHaveClass('bg-green-500');
   expect(label).toBeInTheDocument();
@@ -48,8 +51,8 @@ test('Expect green text and icon when connection is starting', async () => {
 
 test('Expect green text and icon when connection is stopped', async () => {
   render(ConnectionStatus, { status: 'stopped' });
-  const icon = screen.getByLabelText('connection-status-icon');
-  const label = screen.getByLabelText('connection-status-label');
+  const icon = screen.getByLabelText(connectionStatusIcon);
+  const label = screen.getByLabelText(connectionStatusLabel);
   expect(icon).toBeInTheDocument();
   expect(icon).toHaveClass('bg-gray-900');
   expect(label).toBeInTheDocument();
@@ -59,8 +62,8 @@ test('Expect green text and icon when connection is stopped', async () => {
 
 test('Expect green text and icon when connection is stopping', async () => {
   render(ConnectionStatus, { status: 'stopping' });
-  const icon = screen.getByLabelText('connection-status-icon');
-  const label = screen.getByLabelText('connection-status-label');
+  const icon = screen.getByLabelText(connectionStatusIcon);
+  const label = screen.getByLabelText(connectionStatusLabel);
   expect(icon).toBeInTheDocument();
   expect(icon).toHaveClass('bg-red-500');
   expect(label).toBeInTheDocument();
@@ -70,8 +73,8 @@ test('Expect green text and icon when connection is stopping', async () => {
 
 test('Expect green text and icon when connection is unknown', async () => {
   render(ConnectionStatus, { status: 'unknown' });
-  const icon = screen.getByLabelText('connection-status-icon');
-  const label = screen.getByLabelText('connection-status-label');
+  const icon = screen.getByLabelText(connectionStatusIcon);
+  const label = screen.getByLabelText(connectionStatusLabel);
   expect(icon).toBeInTheDocument();
   expect(icon).toHaveClass('bg-gray-900');
   expect(label).toBeInTheDocument();

--- a/packages/renderer/src/lib/ui/ConnectionStatus.svelte
+++ b/packages/renderer/src/lib/ui/ConnectionStatus.svelte
@@ -58,5 +58,5 @@ $: statusStyle = statusesStyle.get(status) || {
 };
 </script>
 
-<div aria-label="connection-status-icon" class="{roundIconStyle} {statusStyle.bgColor}"></div>
-<span aria-label="connection-status-label" class="{labelStyle} {statusStyle.txtColor}">{statusStyle.label}</span>
+<div aria-label="Connection Status Icon" class="{roundIconStyle} {statusStyle.bgColor}"></div>
+<span aria-label="Connection Status Label" class="{labelStyle} {statusStyle.txtColor}">{statusStyle.label}</span>

--- a/packages/renderer/src/lib/ui/ExtensionStatus.spec.ts
+++ b/packages/renderer/src/lib/ui/ExtensionStatus.spec.ts
@@ -24,10 +24,13 @@ import ExtensionStatus from './ExtensionStatus.svelte';
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-empty-function */
 
+const connectionStatusLabel = 'Connection Status Label';
+const connectionStatusIcon = 'Connection Status Icon';
+
 test('Expect green text and icon when connection is running', async () => {
   render(ExtensionStatus, { status: 'started' });
-  const icon = screen.getByLabelText('connection-status-icon');
-  const label = screen.getByLabelText('connection-status-label');
+  const icon = screen.getByLabelText(connectionStatusIcon);
+  const label = screen.getByLabelText(connectionStatusLabel);
   expect(icon).toBeInTheDocument();
   expect(icon).toHaveClass('bg-green-500');
   expect(label).toBeInTheDocument();
@@ -37,8 +40,8 @@ test('Expect green text and icon when connection is running', async () => {
 
 test('Expect green text and icon when connection is starting', async () => {
   render(ExtensionStatus, { status: 'starting' });
-  const icon = screen.getByLabelText('connection-status-icon');
-  const label = screen.getByLabelText('connection-status-label');
+  const icon = screen.getByLabelText(connectionStatusIcon);
+  const label = screen.getByLabelText(connectionStatusLabel);
   expect(icon).toBeInTheDocument();
   expect(icon).toHaveClass('bg-green-500');
   expect(label).toBeInTheDocument();
@@ -48,8 +51,8 @@ test('Expect green text and icon when connection is starting', async () => {
 
 test('Expect green text and icon when connection is stopped', async () => {
   render(ExtensionStatus, { status: 'stopped' });
-  const icon = screen.getByLabelText('connection-status-icon');
-  const label = screen.getByLabelText('connection-status-label');
+  const icon = screen.getByLabelText(connectionStatusIcon);
+  const label = screen.getByLabelText(connectionStatusLabel);
   expect(icon).toBeInTheDocument();
   expect(icon).toHaveClass('bg-gray-900');
   expect(label).toBeInTheDocument();
@@ -59,8 +62,8 @@ test('Expect green text and icon when connection is stopped', async () => {
 
 test('Expect green text and icon when connection is stopping', async () => {
   render(ExtensionStatus, { status: 'stopping' });
-  const icon = screen.getByLabelText('connection-status-icon');
-  const label = screen.getByLabelText('connection-status-label');
+  const icon = screen.getByLabelText(connectionStatusIcon);
+  const label = screen.getByLabelText(connectionStatusLabel);
   expect(icon).toBeInTheDocument();
   expect(icon).toHaveClass('bg-red-500');
   expect(label).toBeInTheDocument();
@@ -70,8 +73,8 @@ test('Expect green text and icon when connection is stopping', async () => {
 
 test('Expect green text and icon when connection is unknown', async () => {
   render(ExtensionStatus, { status: 'unknown' });
-  const icon = screen.getByLabelText('connection-status-icon');
-  const label = screen.getByLabelText('connection-status-label');
+  const icon = screen.getByLabelText(connectionStatusIcon);
+  const label = screen.getByLabelText(connectionStatusLabel);
   expect(icon).toBeInTheDocument();
   expect(icon).toHaveClass('bg-gray-900');
   expect(label).toBeInTheDocument();

--- a/packages/renderer/src/lib/ui/ExtensionStatus.svelte
+++ b/packages/renderer/src/lib/ui/ExtensionStatus.svelte
@@ -58,5 +58,5 @@ $: statusStyle = statusesStyle.get(status) || {
 };
 </script>
 
-<div aria-label="connection-status-icon" class="{roundIconStyle} {statusStyle.bgColor}"></div>
-<span aria-label="connection-status-label" class="{labelStyle} {statusStyle.txtColor}">{statusStyle.label}</span>
+<div aria-label="Connection Status Icon" class="{roundIconStyle} {statusStyle.bgColor}"></div>
+<span aria-label="Connection Status Label" class="{labelStyle} {statusStyle.txtColor}">{statusStyle.label}</span>

--- a/packages/renderer/src/lib/ui/ProviderStatus.spec.ts
+++ b/packages/renderer/src/lib/ui/ProviderStatus.spec.ts
@@ -24,10 +24,13 @@ import ExtensionStatus from './ExtensionStatus.svelte';
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-empty-function */
 
+const connectionStatusLabel = 'Connection Status Label';
+const connectionStatusIcon = 'Connection Status Icon';
+
 test('Expect green text and icon when connection is running', async () => {
   render(ExtensionStatus, { status: 'started' });
-  const icon = screen.getByLabelText('connection-status-icon');
-  const label = screen.getByLabelText('connection-status-label');
+  const icon = screen.getByLabelText(connectionStatusIcon);
+  const label = screen.getByLabelText(connectionStatusLabel);
   expect(icon).toBeInTheDocument();
   expect(icon).toHaveClass('bg-green-500');
   expect(label).toBeInTheDocument();
@@ -37,8 +40,8 @@ test('Expect green text and icon when connection is running', async () => {
 
 test('Expect green text and icon when connection is starting', async () => {
   render(ExtensionStatus, { status: 'starting' });
-  const icon = screen.getByLabelText('connection-status-icon');
-  const label = screen.getByLabelText('connection-status-label');
+  const icon = screen.getByLabelText(connectionStatusIcon);
+  const label = screen.getByLabelText(connectionStatusLabel);
   expect(icon).toBeInTheDocument();
   expect(icon).toHaveClass('bg-green-500');
   expect(label).toBeInTheDocument();
@@ -48,8 +51,8 @@ test('Expect green text and icon when connection is starting', async () => {
 
 test('Expect green text and icon when connection is stopped', async () => {
   render(ExtensionStatus, { status: 'stopped' });
-  const icon = screen.getByLabelText('connection-status-icon');
-  const label = screen.getByLabelText('connection-status-label');
+  const icon = screen.getByLabelText(connectionStatusIcon);
+  const label = screen.getByLabelText(connectionStatusLabel);
   expect(icon).toBeInTheDocument();
   expect(icon).toHaveClass('bg-gray-900');
   expect(label).toBeInTheDocument();
@@ -59,8 +62,8 @@ test('Expect green text and icon when connection is stopped', async () => {
 
 test('Expect green text and icon when connection is stopping', async () => {
   render(ExtensionStatus, { status: 'stopping' });
-  const icon = screen.getByLabelText('connection-status-icon');
-  const label = screen.getByLabelText('connection-status-label');
+  const icon = screen.getByLabelText(connectionStatusIcon);
+  const label = screen.getByLabelText(connectionStatusLabel);
   expect(icon).toBeInTheDocument();
   expect(icon).toHaveClass('bg-red-500');
   expect(label).toBeInTheDocument();
@@ -70,8 +73,8 @@ test('Expect green text and icon when connection is stopping', async () => {
 
 test('Expect green text and icon when connection is unknown', async () => {
   render(ExtensionStatus, { status: 'unknown' });
-  const icon = screen.getByLabelText('connection-status-icon');
-  const label = screen.getByLabelText('connection-status-label');
+  const icon = screen.getByLabelText(connectionStatusIcon);
+  const label = screen.getByLabelText(connectionStatusLabel);
   expect(icon).toBeInTheDocument();
   expect(icon).toHaveClass('bg-gray-900');
   expect(label).toBeInTheDocument();

--- a/packages/renderer/src/lib/ui/ProviderStatus.svelte
+++ b/packages/renderer/src/lib/ui/ProviderStatus.svelte
@@ -86,5 +86,5 @@ $: statusStyle = statusesStyle.get(status) || {
 };
 </script>
 
-<div aria-label="connection-status-icon" class="{roundIconStyle} {statusStyle.bgColor}"></div>
-<span aria-label="connection-status-label" class="{labelStyle} {statusStyle.txtColor}">{statusStyle.label}</span>
+<div aria-label="Connection Status Icon" class="{roundIconStyle} {statusStyle.bgColor}"></div>
+<span aria-label="Connection Status Label" class="{labelStyle} {statusStyle.txtColor}">{statusStyle.label}</span>

--- a/tests/src/model/pages/extension-page.ts
+++ b/tests/src/model/pages/extension-page.ts
@@ -32,6 +32,6 @@ export class ExtensionPage extends SettingsPage {
     this.enableButton = page.getByRole('button', { name: 'Enable' });
     this.disableButton = page.getByRole('button', { name: 'Disable' });
     this.removeExtensionButton = page.getByRole('button', { name: 'Remove' });
-    this.status = page.getByLabel('connection-status-label');
+    this.status = page.getByLabel('Connection Status Label');
   }
 }

--- a/tests/src/podman-extension-smoke.spec.ts
+++ b/tests/src/podman-extension-smoke.spec.ts
@@ -29,7 +29,7 @@ import { SettingsExtensionsPage } from './model/pages/settings-extensions-page';
 import { ExtensionPage } from './model/pages/extension-page';
 
 const SETTINGS_EXTENSIONS_TABLE_PODMAN_TITLE: string = 'podman';
-const SETTINGS_EXTENSIONS_TABLE_EXTENSION_STATUS_LABEL: string = 'connection-status-label';
+const SETTINGS_EXTENSIONS_TABLE_EXTENSION_STATUS_LABEL: string = 'Connection Status Label';
 const PODMAN_EXTENSION_STATUS_RUNNING: string = 'RUNNING';
 const PODMAN_EXTENSION_STATUS_OFF: string = 'OFF';
 const SETTINGS_NAVBAR_PREFERENCES_PODMAN_EXTENSION: string = 'Extension: Podman';


### PR DESCRIPTION
### What does this PR do?
Rewrite aria-label on multiple places showing status of connection, extension or provider, also updates the tests.
### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
#5566 
<!-- Include any related issues from Podman Desktop 
repository (or from another issue tracker). -->

### How to test this PR?
`yarn test`
<!-- Please explain steps to reproduce -->
