### PR TITLE
chore: unused palette entries

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesProxiesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesProxiesRendering.svelte
@@ -70,7 +70,7 @@ function validate(event: any) {
         id="toggle-proxy"
         class="sr-only peer" />
       <div
-        class="w-9 h-5 peer-focus:ring-violet-800 rounded-full peer bg-zinc-400 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-400 after:border after:rounded-full after:h-4 after:w-4 after:transition-all dark:border-gray-900 peer-checked:bg-violet-600">
+        class="w-9 h-5 rounded-full peer bg-zinc-400 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-400 after:border after:rounded-full after:h-4 after:w-4 after:transition-all dark:border-gray-900 peer-checked:bg-violet-600">
       </div>
       <span class="ml-3 text-sm font-medium text-gray-400"
         >Proxy configuration {proxyState ? 'enabled' : 'disabled'}</span>

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -184,10 +184,6 @@ module.exports = {
       white: '#fff',
       // The remaining colors below are not part of our palette and are only here
       // to maintain existing code. No new use.
-      'slate': {
-        400: tailwindColors.slate[400],
-        800: tailwindColors.slate[800],
-      },
       'zinc': {
         100: tailwindColors.zinc[100],
         200: tailwindColors.zinc[200],
@@ -206,7 +202,6 @@ module.exports = {
         500: tailwindColors.violet[500],
         600: tailwindColors.violet[600],
         700: tailwindColors.violet[700],
-        800: tailwindColors.violet[800],
       },
     },
   },


### PR DESCRIPTION
### What does this PR do?

I had to look at the palette for another PR and noticed that three of the old legacy colors are no longer in use just due to natural evolution. Removing these so they don't accidentally get used again.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Confirm no test failures or grep to confirm no use of these colors.