### PR TITLE
chore: cleanup API sender object

### DIFF
--- a/packages/main/src/plugin/api.ts
+++ b/packages/main/src/plugin/api.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2022 Red Hat, Inc.
+ * Copyright (C) 2022-2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
  ***********************************************************************/
 
 import type { ContainerInfo } from './api/container-info.js';
+import type { IDisposable } from './types/disposable.js';
 
 export interface RemoteAPI {
   // eslint-disable-next-line @typescript-eslint/ban-types
@@ -24,8 +25,6 @@ export interface RemoteAPI {
 }
 
 export type ApiSenderType = {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  send: (channel: string, data?: any) => void;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  receive: (channel: string, func: any) => void;
+  send: (channel: string, data?: unknown) => void;
+  receive: (channel: string, func: (...args: unknown[]) => void) => IDisposable;
 };

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2022-2023 Red Hat, Inc.
+ * Copyright (C) 2022-2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -200,24 +200,24 @@ export class ContainerProviderRegistry {
   }
 
   setupListeners() {
-    const cleanStreamMap = (containerId: string) => {
-      this.streamsPerContainerId.delete(containerId);
-      this.streamsOutputPerContainerId.delete(containerId);
+    const cleanStreamMap = (containerId: unknown) => {
+      this.streamsPerContainerId.delete(String(containerId));
+      this.streamsOutputPerContainerId.delete(String(containerId));
     };
 
-    this.apiSender.receive('container-stopped-event', (containerId: string) => {
+    this.apiSender.receive('container-stopped-event', (containerId: unknown) => {
       cleanStreamMap(containerId);
     });
 
-    this.apiSender.receive('container-die-event', (containerId: string) => {
+    this.apiSender.receive('container-die-event', (containerId: unknown) => {
       cleanStreamMap(containerId);
     });
 
-    this.apiSender.receive('container-kill-event', (containerId: string) => {
+    this.apiSender.receive('container-kill-event', (containerId: unknown) => {
       cleanStreamMap(containerId);
     });
 
-    this.apiSender.receive('container-removed-event', (containerId: string) => {
+    this.apiSender.receive('container-removed-event', (containerId: unknown) => {
       cleanStreamMap(containerId);
     });
   }

--- a/packages/main/src/plugin/contribution-manager.spec.ts
+++ b/packages/main/src/plugin/contribution-manager.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ import type { RunResult } from '@podman-desktop/api';
 import { EventEmitter } from 'stream-json/Assembler.js';
 import type { ContributionInfo } from './api/contribution-info.js';
 import type { Proxy } from './proxy.js';
+import type { IDisposable } from './types/disposable.js';
 let contributionManager: TestContributionManager;
 
 let composeFileExample: any;
@@ -42,14 +43,17 @@ const portNumber = 10000;
 
 const eventEmitter = new EventEmitter();
 
-const send = (channel: string, data?: any) => {
+const send = (channel: string, data?: unknown) => {
   eventEmitter.emit(channel, data);
 };
 
-const receive = (channel: string, func: any) => {
-  eventEmitter.on(channel, data => {
-    func(data);
-  });
+const receive = (channel: string, func: any): IDisposable => {
+  eventEmitter.on(channel, func);
+  return {
+    dispose: () => {
+      eventEmitter.off(channel, func);
+    },
+  } as unknown as IDisposable;
 };
 
 const apiSender: ApiSenderType = {

--- a/packages/main/src/plugin/contribution-manager.spec.ts
+++ b/packages/main/src/plugin/contribution-manager.spec.ts
@@ -47,7 +47,7 @@ const send = (channel: string, data?: unknown) => {
   eventEmitter.emit(channel, data);
 };
 
-const receive = (channel: string, func: any): IDisposable => {
+const receive = (channel: string, func: (...args: unknown[]) => void): IDisposable => {
   eventEmitter.on(channel, func);
   return {
     dispose: () => {

--- a/packages/main/src/plugin/kubernetes-client-kubeconfig.spec.ts
+++ b/packages/main/src/plugin/kubernetes-client-kubeconfig.spec.ts
@@ -1,3 +1,21 @@
+/**********************************************************************
+ * Copyright (C) 2023-2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
 import type { Cluster, Context, User, KubeConfig } from '@kubernetes/client-node';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import type { ConfigurationRegistry } from './configuration-registry.js';
@@ -52,7 +70,7 @@ describe('context tests', () => {
     } as unknown as Telemetry;
     const apiSender: ApiSenderType = {
       send: apiSendMock,
-      receive: () => {},
+      receive: vi.fn(),
     };
 
     const client = new TestKubernetesClient(

--- a/packages/preload/src/index.spec.ts
+++ b/packages/preload/src/index.spec.ts
@@ -1,0 +1,71 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import { beforeEach, expect, test, vi } from 'vitest';
+import { buildApiSender } from '.';
+
+vi.mock('electron', async () => {
+  return {
+    contextBridge: {
+      exposeInMainWorld: vi.fn(),
+    },
+    ipcRenderer: {
+      on: vi.fn(),
+      emit: vi.fn(),
+      handle: vi.fn(),
+    },
+    ipcMain: {
+      on: vi.fn(),
+      emit: vi.fn(),
+      handle: vi.fn(),
+    },
+  };
+});
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+test('build Api Sender', () => {
+  const apiSender = buildApiSender();
+
+  expect(apiSender).toBeDefined();
+
+  // add a receiver
+  const received: string[] = [];
+  const disposable = apiSender.receive('channel', (...val: unknown[]) => {
+    received.push(String(val));
+  });
+
+  // send a message
+  apiSender.send('channel', 'message');
+  expect(received.length).toBe(1);
+  expect(received[0]).toBe('message');
+
+  // send another message
+  apiSender.send('channel', 'message2');
+  expect(received.length).toBe(2);
+  expect(received[1]).toBe('message2');
+
+  // dispose the receiver
+  disposable.dispose();
+
+  // send another message
+  apiSender.send('channel', 'message3');
+  // should not be received anymore as we disposed the listener
+  expect(received.length).toBe(2);
+});

--- a/packages/renderer/src/Loader.svelte
+++ b/packages/renderer/src/Loader.svelte
@@ -72,7 +72,7 @@ window.events?.receive('install-extension:from-id', (extensionId: any) => {
 });
 
 // Wait that the server-side is ready
-window.events.receive('starting-extensions', (value: string) => {
+window.events.receive('starting-extensions', (value: unknown) => {
   systemReady = value === 'true';
   if (systemReady) {
     window.dispatchEvent(new CustomEvent('system-ready', {}));

--- a/packages/renderer/src/lib/dialogs/CustomPick.svelte
+++ b/packages/renderer/src/lib/dialogs/CustomPick.svelte
@@ -29,7 +29,8 @@ onMount(() => {
   window.events?.receive('showCustomPick:add', showCustomPickCallback);
 });
 
-async function showCustomPickCallback(options?: CustomPickOptions) {
+function showCustomPickCallback(customQuickPickParameter: unknown) {
+  const options: CustomPickOptions | undefined = customQuickPickParameter as CustomPickOptions;
   id = options?.id || 0;
   title = options?.title || '';
   description = options?.description || '';

--- a/packages/renderer/src/lib/dialogs/MessageBox.svelte
+++ b/packages/renderer/src/lib/dialogs/MessageBox.svelte
@@ -23,7 +23,8 @@ let display = false;
 let inputElement: HTMLInputElement | undefined = undefined;
 let messageBox: HTMLDivElement;
 
-const showMessageBoxCallback = async (options?: MessageBoxOptions) => {
+const showMessageBoxCallback = (messageBoxParameter: unknown) => {
+  const options: MessageBoxOptions | undefined = messageBoxParameter as MessageBoxOptions;
   currentId = options?.id || 0;
   title = options?.title || '';
   message = options?.message || '';
@@ -74,11 +75,15 @@ const showMessageBoxCallback = async (options?: MessageBoxOptions) => {
 
   display = true;
 
-  await tick();
-
-  if (display && inputElement) {
-    inputElement.focus();
-  }
+  tick()
+    .then(() => {
+      if (display && inputElement) {
+        inputElement.focus();
+      }
+    })
+    .catch((error: unknown) => {
+      console.error('Unable to focus on input element', error);
+    });
 };
 
 onMount(() => {

--- a/packages/renderer/src/lib/dialogs/QuickPickInput.svelte
+++ b/packages/renderer/src/lib/dialogs/QuickPickInput.svelte
@@ -32,7 +32,8 @@ let quickPickCanPickMany = false;
 let inputElement: HTMLInputElement | HTMLTextAreaElement | undefined = undefined;
 let outerDiv: HTMLDivElement | undefined = undefined;
 
-const showInputCallback = async (options?: InputBoxOptions) => {
+const showInputCallback = (inputCallpackParameter: unknown) => {
+  const options: InputBoxOptions | undefined = inputCallpackParameter as InputBoxOptions;
   mode = 'InputBox';
   inputValue = options?.value;
   placeHolder = options?.placeHolder;
@@ -48,17 +49,22 @@ const showInputCallback = async (options?: InputBoxOptions) => {
 
   validationEnabled = options?.validate || false;
   display = true;
-  await tick();
-
-  if (display && inputElement) {
-    inputElement.focus();
-    if (options?.valueSelection) {
-      inputElement.setSelectionRange(options.valueSelection[0], options.valueSelection[1]);
-    }
-  }
+  tick()
+    .then(() => {
+      if (display && inputElement) {
+        inputElement.focus();
+        if (options?.valueSelection) {
+          inputElement.setSelectionRange(options.valueSelection[0], options.valueSelection[1]);
+        }
+      }
+    })
+    .catch((error: unknown) => {
+      console.error('Unable to focus/select input box', error);
+    });
 };
 
-const showQuickPickCallback = async (options?: QuickPickOptions) => {
+const showQuickPickCallback = (quickpickParameter: unknown) => {
+  const options: QuickPickOptions | undefined = quickpickParameter as QuickPickOptions;
   mode = 'QuickPick';
   placeHolder = options?.placeHolder;
   title = options?.title;
@@ -96,11 +102,15 @@ const showQuickPickCallback = async (options?: QuickPickOptions) => {
 
   display = true;
 
-  await tick();
-
-  if (display && inputElement) {
-    inputElement.focus();
-  }
+  tick()
+    .then(() => {
+      if (display && inputElement) {
+        inputElement.focus();
+      }
+    })
+    .catch((error: unknown) => {
+      console.error('Unable to focus input box', error);
+    });
 };
 
 onMount(() => {

--- a/packages/renderer/src/lib/toast/ToastHandler.svelte
+++ b/packages/renderer/src/lib/toast/ToastHandler.svelte
@@ -43,8 +43,9 @@ onMount(() => {
     toast.push(object.message, { pausable: true, theme });
   };
 
-  window.events?.receive('toast:handler', (object: { type: string; message: string }) => {
-    callback(object);
+  window.events?.receive('toast:handler', (object: unknown) => {
+    const value = object as { type: string; message: string };
+    callback(value);
   });
 });
 

--- a/packages/renderer/src/stores/configurationProperties.ts
+++ b/packages/renderer/src/stores/configurationProperties.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2022-2023 Red Hat, Inc.
+ * Copyright (C) 2022-2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,8 +63,8 @@ class ConfigurationChangeEvent extends CustomEvent<IConfigurationChangeEvent> {
 
 export function setupConfigurationChange() {
   // be notified when a specific property is being changed
-  window.events?.receive('onDidChangeConfiguration', async (data: IConfigurationChangeEvent) => {
-    onDidChangeConfiguration.dispatchEvent(new ConfigurationChangeEvent(data));
+  window.events?.receive('onDidChangeConfiguration', (data: unknown) => {
+    onDidChangeConfiguration.dispatchEvent(new ConfigurationChangeEvent(data as IConfigurationChangeEvent));
   });
 }
 

--- a/packages/renderer/src/stores/context.ts
+++ b/packages/renderer/src/stores/context.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,16 +22,18 @@ import { ContextUI } from '../lib/context/context';
 
 export const context: Writable<ContextUI> = writable(new ContextUI());
 
-window.events?.receive('context-value-updated', async (value: { key: string; value: string }) => {
+window.events?.receive('context-value-updated', (value: unknown) => {
+  const typedValue = value as { key: string; value: string };
   context.update(ctx => {
-    ctx.setValue(value.key, value.value);
+    ctx.setValue(typedValue.key, typedValue.value);
     return ctx;
   });
 });
 
-window.events?.receive('context-key-removed', async (value: { key: string; value: string }) => {
+window.events?.receive('context-key-removed', (value: unknown) => {
+  const typedValue = value as { key: string; value: string };
   context.update(ctx => {
-    ctx.removeValue(value.key);
+    ctx.removeValue(typedValue.key);
     return ctx;
   });
 });

--- a/packages/renderer/src/stores/event-store.spec.ts
+++ b/packages/renderer/src/stores/event-store.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2022 Red Hat, Inc.
+ * Copyright (C) 2022-2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -89,6 +89,11 @@ test('should call fetch method using window event', async () => {
   updater.mockResolvedValue([myCustomTypeInfo]);
 
   await callback();
+
+  // wait updater method being called
+  while (updater.mock.calls.length === 0) {
+    await new Promise(resolve => setTimeout(resolve, 100));
+  }
 
   // check the updater is called
   expect(updater).toHaveBeenCalled();
@@ -227,6 +232,11 @@ test('should call fetch method using window event and object argument', async ()
   updater.mockResolvedValue([myCustomTypeInfo]);
 
   await callback({});
+
+  // wait updater method being called
+  while (updater.mock.calls.length === 0) {
+    await new Promise(resolve => setTimeout(resolve, 100));
+  }
 
   // check the updater is called
   expect(updater).toHaveBeenCalledWith({});

--- a/packages/renderer/src/stores/event-store.ts
+++ b/packages/renderer/src/stores/event-store.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -258,8 +258,10 @@ export class EventStore<T> {
     };
 
     this.windowEvents.forEach(eventName => {
-      window.events?.receive(eventName, async (args?: unknown[]) => {
-        await update(eventName, args);
+      window.events?.receive(eventName, (args?: unknown) => {
+        update(eventName, args as unknown[]).catch((error: unknown) => {
+          console.error(`Failed to update ${this.name}`, error);
+        });
       });
     });
 

--- a/packages/renderer/src/stores/kubernetes-informer-event-store.ts
+++ b/packages/renderer/src/stores/kubernetes-informer-event-store.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,13 +38,13 @@ export class EventStoreWithKubernetesInformer<T> {
 
   setup() {
     this.informerEvents.forEach(eventName => {
-      window.events?.receive(eventName, async (args?: unknown[]) => {
+      window.events?.receive(eventName, (args: unknown) => {
         this.informerListener(eventName, args);
       });
     });
 
     this.informerRefreshEvents.forEach(eventName => {
-      window.events?.receive(eventName, async (_args?: unknown[]) => {
+      window.events?.receive(eventName, (_: unknown) => {
         const informerId = this.store.getInformerId();
         if (informerId) {
           window.kubernetesRefreshInformer(informerId);
@@ -52,7 +52,7 @@ export class EventStoreWithKubernetesInformer<T> {
       });
     });
 
-    window.events?.receive(`kubernetes-informer-refresh`, async (id: number) => {
+    window.events?.receive(`kubernetes-informer-refresh`, (id: unknown) => {
       const informerId = this.store.getInformerId();
       // if informer has been refreshed we reset the store, most probably the kubeconfig changed and we're connected to a new namespace/cluster
       if (informerId === id) {

--- a/packages/renderer/src/stores/notifications.spec.ts
+++ b/packages/renderer/src/stores/notifications.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -82,6 +82,9 @@ test('notifications should be updated in case of an extension is stopped', async
   const extensionStoppedCallback = callbacks.get('notifications-updated');
   expect(extensionStoppedCallback).toBeDefined();
   await extensionStoppedCallback();
+
+  // wait a little
+  await new Promise(resolve => setTimeout(resolve, 100));
 
   // check if the notifications are updated
   const notificationQueue2 = get(notificationQueue);

--- a/packages/renderer/src/stores/onboarding.spec.ts
+++ b/packages/renderer/src/stores/onboarding.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -81,6 +81,9 @@ test('onboarding should be updated in case of an extension is stopped', async ()
   const extensionStoppedCallback = callbacks.get('extension-stopped');
   expect(extensionStoppedCallback).toBeDefined();
   await extensionStoppedCallback();
+
+  // wait a little
+  await new Promise(resolve => setTimeout(resolve, 100));
 
   // check if the onboardings are updated
   const onboardingList2 = get(onboardingList);

--- a/packages/renderer/src/stores/tasks.ts
+++ b/packages/renderer/src/stores/tasks.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -64,14 +64,14 @@ export function createTask(name: string): StatefulTask {
   return task;
 }
 
-window.events?.receive('task-created', (task: Task) => {
-  tasksInfo.update(tasks => [...tasks, task]);
+window.events?.receive('task-created', (task: unknown) => {
+  tasksInfo.update(tasks => [...tasks, task as Task]);
 });
-window.events?.receive('task-updated', (task: Task) => {
-  updateTask(task);
+window.events?.receive('task-updated', (task: unknown) => {
+  updateTask(task as Task);
 });
-window.events?.receive('task-removed', (task: Task) => {
-  removeTask(task.id);
+window.events?.receive('task-removed', (task: unknown) => {
+  removeTask((task as Task).id);
 });
 
 export function isStatefulTask(task: Task): task is StatefulTask {

--- a/packages/renderer/src/stores/view.spec.ts
+++ b/packages/renderer/src/stores/view.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -81,6 +81,9 @@ test('views should be updated in case of an extension is stopped', async () => {
   const extensionStoppedCallback = callbacks.get('extension-stopped');
   expect(extensionStoppedCallback).toBeDefined();
   await extensionStoppedCallback();
+
+  // wait a little
+  await new Promise(resolve => setTimeout(resolve, 100));
 
   // check if the volumes are updated
   const views2 = get(viewsContributions);

--- a/packages/renderer/src/stores/views.spec.ts
+++ b/packages/renderer/src/stores/views.spec.ts
@@ -82,6 +82,9 @@ test('views should be updated in case of an extension is stopped', async () => {
   expect(extensionStoppedCallback).toBeDefined();
   await extensionStoppedCallback();
 
+  // wait a little
+  await new Promise(resolve => setTimeout(resolve, 100));
+
   // check if the volumes are updated
   const views2 = get(viewsContributions);
   expect(views2.length).toBe(0);


### PR DESCRIPTION
### What does this PR do?
replace any type by unknown type
(and remove all eslint ignore/disable lines like @typescroipt-eslint/no-explicit-any)
also I had to fixes issues where we can't use async methods when sync methods are expected (before it was silently hidden due to the lack of signature/usage of any type)

make it consistent across all the packages and ensure it returns a disposable object for receiving events

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

consistency

### How to test this PR?

I've added a unit test on the implementation of Api Sender

But you could check that communication is working (UI is displaying correct objects ;-)