### PR TITLE
feat: quick pick case-insensitive filtering

### DIFF
--- a/packages/renderer/src/lib/dialogs/QuickPickInput.spec.ts
+++ b/packages/renderer/src/lib/dialogs/QuickPickInput.spec.ts
@@ -207,4 +207,78 @@ describe('QuickPickInput', () => {
     const area = await screen.findByRole('textbox');
     expect(area).toBeInTheDocument();
   });
+
+  test('Expect that filtering works', async () => {
+    const idRequest = 123;
+
+    const quickPickOptions: QuickPickOptions = {
+      items: ['itemA', 'itemB'],
+      title: 'My custom title',
+      canPickMany: false,
+      placeHolder: 'placeHolder',
+      prompt: '',
+      id: idRequest,
+      onSelectCallback: false,
+    };
+
+    receiveFunctionMock.mockImplementation((message: string, callback: (options: QuickPickOptions) => void) => {
+      if (message === 'showQuickPick:add') {
+        callback(quickPickOptions);
+      }
+    });
+
+    render(QuickPickInput, {});
+
+    const input = screen.getByRole('textbox');
+    expect(input).toBeInTheDocument();
+
+    const itemA1 = await screen.findByText('itemA');
+    expect(itemA1).toBeInTheDocument();
+    const itemB1 = await screen.findByText('itemB');
+    expect(itemB1).toBeInTheDocument();
+
+    await userEvent.type(input, 'B');
+
+    const itemA2 = screen.queryByText('itemA');
+    expect(itemA2).not.toBeInTheDocument();
+    const itemB2 = await screen.findByText('itemB');
+    expect(itemB2).toBeInTheDocument();
+  });
+
+  test('Expect that filtering is case insensitive', async () => {
+    const idRequest = 123;
+
+    const quickPickOptions: QuickPickOptions = {
+      items: ['itemA', 'itemB'],
+      title: 'My custom title',
+      canPickMany: false,
+      placeHolder: 'placeHolder',
+      prompt: '',
+      id: idRequest,
+      onSelectCallback: false,
+    };
+
+    receiveFunctionMock.mockImplementation((message: string, callback: (options: QuickPickOptions) => void) => {
+      if (message === 'showQuickPick:add') {
+        callback(quickPickOptions);
+      }
+    });
+
+    render(QuickPickInput, {});
+
+    const input = screen.getByRole('textbox');
+    expect(input).toBeInTheDocument();
+
+    const itemA1 = await screen.findByText('itemA');
+    expect(itemA1).toBeInTheDocument();
+    const itemB1 = await screen.findByText('itemB');
+    expect(itemB1).toBeInTheDocument();
+
+    await userEvent.type(input, 'a');
+
+    const itemA2 = await screen.findByText('itemA');
+    expect(itemA2).toBeInTheDocument();
+    const itemB2 = screen.queryByText('itemB');
+    expect(itemB2).not.toBeInTheDocument();
+  });
 });

--- a/packages/renderer/src/lib/dialogs/QuickPickInput.svelte
+++ b/packages/renderer/src/lib/dialogs/QuickPickInput.svelte
@@ -114,7 +114,8 @@ onMount(() => {
 async function onInputChange(event: any) {
   // in case of quick pick, filter the items
   if (mode === 'QuickPick') {
-    quickPickFilteredItems = quickPickItems.filter(item => item.value.includes(event.target.value));
+    let val = event.target.value.toLowerCase();
+    quickPickFilteredItems = quickPickItems.filter(item => item.value.toLowerCase().includes(val));
     quickPickSelectedFilteredIndex = 0;
     if (quickPickFilteredItems.length > 0) {
       quickPickSelectedIndex = quickPickItems.indexOf(quickPickFilteredItems[quickPickSelectedFilteredIndex]);


### PR DESCRIPTION
### What does this PR do?

Makes the quick pick filtering case-insensitive, and adds tests for both same and 'wrong' case.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes #5581.

### How to test this PR?

Try any quick pick and type a letter in the wrong case.