### PR TITLE
chore(test): fix podman extension smoke test, caused by extension status being briefly 'STARTING'

### DIFF
--- a/tests/src/podman-extension-smoke.spec.ts
+++ b/tests/src/podman-extension-smoke.spec.ts
@@ -94,16 +94,17 @@ async function verifyPodmanExtensionStatus(enabled: boolean) {
     SETTINGS_EXTENSIONS_TABLE_PODMAN_TITLE,
   );
   await playExpect(podmanExtensionRowLocator).toBeVisible();
-  const connectionStatusLabel = podmanExtensionRowLocator.getByLabel(SETTINGS_EXTENSIONS_TABLE_EXTENSION_STATUS_LABEL);
-  await playExpect(connectionStatusLabel).toBeVisible();
-  await connectionStatusLabel.scrollIntoViewIfNeeded();
-  const connectionStatusLocatorText = await connectionStatusLabel.innerText({ timeout: 3000 });
-  // --------------------------
+  // -> await for the stop button to be visible to prevent state when the extension status is STARTING
   await playExpect(
     enabled
       ? settingsExtensionsPage.getExtensionStopButton(podmanExtensionRowLocator)
       : settingsExtensionsPage.getExtensionStartButton(podmanExtensionRowLocator),
   ).toBeVisible();
+  const connectionStatusLabel = podmanExtensionRowLocator.getByLabel(SETTINGS_EXTENSIONS_TABLE_EXTENSION_STATUS_LABEL);
+  await playExpect(connectionStatusLabel).toBeVisible();
+  await connectionStatusLabel.scrollIntoViewIfNeeded();
+  const connectionStatusLocatorText = await connectionStatusLabel.innerText({ timeout: 3000 });
+  // --------------------------
   playExpect(
     enabled
       ? connectionStatusLocatorText === PODMAN_EXTENSION_STATUS_RUNNING


### PR DESCRIPTION
### What does this PR do?
* Fixes podman-extension-smoke suite execution failures

### Screenshot / video of UI
N/A
<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
#5511 
<!-- Include any related issues from Podman Desktop 
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to reproduce -->
* yarn --frozen-lockfile
* yarn run test:e2e:smoke