### PR TITLE
feat: pressing esc exits onboarding

### DIFF
--- a/packages/renderer/src/lib/onboarding/Onboarding.svelte
+++ b/packages/renderer/src/lib/onboarding/Onboarding.svelte
@@ -282,7 +282,16 @@ async function restartSetup() {
   await cleanSetup(onboardings, globalContext);
   await setActiveStep();
 }
+
+// If the user hits escape, prompt them to exit the onboarding
+function handleEscape({ key }: any) {
+  if (key === 'Escape') {
+    setDisplayCancelSetup(true);
+  }
+}
 </script>
+
+<svelte:window on:keydown="{handleEscape}" />
 
 {#if activeStep}
   <!-- fake div used to hide scrollbar shadow behind the header as it's a bit transparent  -->


### PR DESCRIPTION
feat: pressing esc exits onboarding

### What does this PR do?

Very small PR, adds the ability to exist the setup if you press ESC.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

https://github.com/containers/podman-desktop/assets/6422176/defdfcf5-c56a-44d6-b146-9dd7a21678a5




### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop/issues/5163

### How to test this PR?

<!-- Please explain steps to reproduce -->

Open onboarding, press ESC.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
