### PR TITLE
fix: quick pick filter removes selection

### DIFF
--- a/packages/renderer/src/lib/dialogs/QuickPickInput.svelte
+++ b/packages/renderer/src/lib/dialogs/QuickPickInput.svelte
@@ -129,6 +129,11 @@ async function onInputChange(event: any) {
     quickPickSelectedFilteredIndex = 0;
     if (quickPickFilteredItems.length > 0) {
       quickPickSelectedIndex = quickPickItems.indexOf(quickPickFilteredItems[quickPickSelectedFilteredIndex]);
+    } else {
+      quickPickSelectedIndex = -1;
+    }
+    if (onSelectCallbackEnabled) {
+      window.sendShowQuickPickOnSelect(currentId, quickPickSelectedIndex);
     }
     return;
   }
@@ -176,7 +181,11 @@ function validateQuickPick() {
         selectedItems.map(item => quickPickItems.indexOf(item)),
       );
     } else {
-      window.sendShowQuickPickValues(currentId, [quickPickSelectedIndex]);
+      if (quickPickSelectedIndex >= 0) {
+        window.sendShowQuickPickValues(currentId, [quickPickSelectedIndex]);
+      } else {
+        window.sendShowQuickPickValues(currentId, []);
+      }
     }
   }
   cleanup();


### PR DESCRIPTION
### What does this PR do?

As you filter the quick pick would automatically select the first item that's left, but would never deselect, so (e.g.) if you type 'ddd' you're selecting whatever the last item that started with 'd' was (or the first item ever shown if there were none that started with d). This just adds the deselection if there are no items that match the filter.

I decided to use the 'onSelectCallback' to test and found a second problem: the callback is not called when the selection is changed due to filtering. That is fixed and tested as well.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes #5610.

### How to test this PR?

See issue for original problem; confirm tests catch this case.