### PR TITLE
docs: adding a page explaining how to use .woff2 file as icons

### DIFF
--- a/website/docs/extensions/write/adding-icons.md
+++ b/website/docs/extensions/write/adding-icons.md
@@ -1,0 +1,39 @@
+---
+sidebar_position: 4
+title: Adding icons
+description: Podman Desktop and resources icons
+tags: [podman-desktop, extension, writing, icons]
+keywords: [podman desktop, extension, writing, icons]
+---
+
+# Adding icons
+
+Podman Desktop allows extensions to register custom icons that can be used for resources based on certain condition defined by a [when clause](when-clause-context.md).
+
+For example, the Kind extension register a custom icons by using the following instruction.
+
+```json
+"icons": {
+  "kind-icon": {
+    "description": "Kind icon",
+    "default": {
+      "fontPath": "kind-icon.woff2",
+      "fontCharacter": "\\EA01"
+    }
+  }
+}
+```
+
+We restrict the format to the [Web Open Font Format 2 (aka woff2)](https://www.w3.org/TR/WOFF2/) to use icons as text, to keep consistency across the UI, as the color and size is managed by Podman-Desktop.
+
+### Creating a .woff2 file
+
+You probably have an existing `.svg` file that you want to use, to make it possible you can use the tool [svgiconfont](https://nfroidure.github.io/svgiconfont/) made by [@nfroidure](https://twitter.com/nfroidure).
+
+To ensure the produced `.woff2` file contains the expected characters you created from your svg file(s). You can use the tool [fontforge.org](https://fontforge.org/) to visualize it.
+
+:::info
+
+To find the `fontCharacter` where your icons has been saved, you can search inside the FontForge tool by the name of the svg file you used.
+
+:::


### PR DESCRIPTION
### What does this PR do?

Adding a basic page giving some insights on how to build a .woff2 file that can be used as icon(s) source for extensions.

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop/issues/5633

### How to test this PR?

<!-- Please explain steps to reproduce -->
