### PR TITLE
fix: copy volume mounted when copying container to pod (#5635)

### DIFF
--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -1191,10 +1191,11 @@ export class ContainerProviderRegistry {
         entrypoint: containerToReplicate.Config.Entrypoint,
         env: updatedEnv,
         image: containerToReplicate.Config.Image,
+        mounts: containerToReplicate.Mounts,
       };
 
       // add extra information
-      const configuration = {
+      const configuration: ContainerCreateOptions = {
         ...originalConfiguration,
         ...overrideParameters,
       };

--- a/packages/main/src/plugin/dockerode/libpod-dockerode.ts
+++ b/packages/main/src/plugin/dockerode/libpod-dockerode.ts
@@ -93,6 +93,16 @@ export interface ContainerCreateOptions {
   hostname?: string;
   image?: string;
   name?: string;
+  mounts?: Array<{
+    Name?: string;
+    Type: string;
+    Source: string;
+    Destination: string;
+    Driver?: string;
+    Mode: string;
+    RW: boolean;
+    Propagation: string;
+  }>;
 }
 
 export interface PodRemoveOptions {


### PR DESCRIPTION
### What does this PR do?

This PR copies the volume mounted to a container when this is copied to a pod.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

it resolves #5635 

### How to test this PR?

1. create a container with a volume
2. create a pod with it
3. check the volume is still there
