### PR TITLE
chore: improve nav sections

### DIFF
--- a/packages/renderer/src/AppNavigation.svelte
+++ b/packages/renderer/src/AppNavigation.svelte
@@ -28,6 +28,7 @@ import IngressRouteIcon from './lib/images/IngressRouteIcon.svelte';
 import { ingresses } from './stores/ingresses';
 import { routes } from './stores/routes';
 import Webviews from '/@/lib/webview/Webviews.svelte';
+import { webviews } from '/@/stores/webviews';
 import PuzzleIcon from './lib/images/PuzzleIcon.svelte';
 import { onDidChangeConfiguration } from './stores/configurationProperties';
 
@@ -214,16 +215,18 @@ export let meta: TinroRouteMeta;
     </NavItem>
   {/if}
 
-  <NavSection tooltip="Desktop Extensions">
-    <PuzzleIcon size="24" slot="icon" />
-    {#each $contributions as contribution}
-      <NavItem href="/contribs/{contribution.name}" tooltip="{contribution.name}" bind:meta="{meta}" inSection="{true}">
-        <img src="{contribution.icon}" width="24" height="24" alt="{contribution.name}" />
-      </NavItem>
-    {/each}
-  </NavSection>
+  {#if $contributions.length + $webviews.length > 0}
+    <NavSection tooltip="Extensions">
+      <PuzzleIcon size="24" slot="icon" />
+      {#each $contributions as contribution}
+        <NavItem href="/contribs/{contribution.name}" tooltip="{contribution.name}" bind:meta="{meta}">
+          <img src="{contribution.icon}" width="24" height="24" alt="{contribution.name}" />
+        </NavItem>
+      {/each}
 
-  <Webviews bind:meta="{meta}" />
+      <Webviews bind:meta="{meta}" />
+    </NavSection>
+  {/if}
 
   <div class="grow"></div>
 

--- a/packages/renderer/src/lib/ui/NavItem.spec.ts
+++ b/packages/renderer/src/lib/ui/NavItem.spec.ts
@@ -22,9 +22,10 @@ import '@testing-library/jest-dom/vitest';
 import { test, expect } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/svelte';
 import NavItem from './NavItem.svelte';
+import NavItemTest from './NavItemTest.svelte';
 
-function renderIt(tooltip: string, href: string, meta: any, onClick?: any, inSection?: boolean): void {
-  render(NavItem, { tooltip: tooltip, href: href, meta: meta, onClick: onClick, inSection });
+function renderIt(tooltip: string, href: string, meta: any, onClick?: any): void {
+  render(NavItem, { tooltip: tooltip, href: href, meta: meta, onClick: onClick });
 }
 
 test('Expect correct role and href', async () => {
@@ -83,7 +84,7 @@ test('Expect not to have selection styling', async () => {
 
 test('Expect in-section styling', async () => {
   const tooltip = 'Dashboard';
-  renderIt(tooltip, '/test', { url: '/elsewhere' }, undefined, true);
+  render(NavItemTest);
 
   const element = screen.getByLabelText(tooltip);
   expect(element).toBeInTheDocument();
@@ -95,8 +96,7 @@ test('Expect in-section styling', async () => {
 
 test('Expect in-section selection styling', async () => {
   const tooltip = 'Dashboard';
-  const href = '/test';
-  renderIt(tooltip, href, { url: href }, undefined, true);
+  render(NavItemTest);
 
   const element = screen.getByLabelText(tooltip);
   expect(element).toBeInTheDocument();

--- a/packages/renderer/src/lib/ui/NavItem.svelte
+++ b/packages/renderer/src/lib/ui/NavItem.svelte
@@ -1,17 +1,29 @@
 <script lang="ts">
 import type { TinroRouteMeta } from 'tinro';
 import Tooltip from './Tooltip.svelte';
+import { getContext, onDestroy, onMount } from 'svelte';
+import type { Writable } from 'svelte/store';
 
 export let href: string;
 export let tooltip: string;
 export let ariaLabel: string | undefined = undefined;
 export let meta: TinroRouteMeta;
 export let onClick: any = undefined;
-export let inSection: boolean = false;
 
+let inSection: boolean = false;
 let uri = encodeURI(href);
 let selected: boolean;
 $: selected = meta.url === uri || (uri !== '/' && meta.url.startsWith(uri));
+
+const navItems: Writable<number> = getContext('nav-items');
+
+onMount(() => {
+  inSection = navItems !== undefined;
+  navItems?.update(i => i + 1);
+});
+onDestroy(() => {
+  navItems?.update(i => i - 1);
+});
 </script>
 
 <a

--- a/packages/renderer/src/lib/ui/NavItem.svelte
+++ b/packages/renderer/src/lib/ui/NavItem.svelte
@@ -1,8 +1,11 @@
 <script lang="ts">
+/* eslint-disable import/no-duplicates */
+// https://github.com/import-js/eslint-plugin-import/issues/1479
 import type { TinroRouteMeta } from 'tinro';
 import Tooltip from './Tooltip.svelte';
 import { getContext, onDestroy, onMount } from 'svelte';
 import type { Writable } from 'svelte/store';
+/* eslint-disable import/no-duplicates */
 
 export let href: string;
 export let tooltip: string;

--- a/packages/renderer/src/lib/ui/NavItemTest.svelte
+++ b/packages/renderer/src/lib/ui/NavItemTest.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+import type { TinroRouteMeta } from 'tinro';
+import NavItem from './NavItem.svelte';
+import { setContext } from 'svelte';
+import { writable } from 'svelte/store';
+
+let meta: TinroRouteMeta = { url: '/test' } as TinroRouteMeta;
+
+// define context so that item thinks we're in a section
+setContext('nav-items', writable(0));
+</script>
+
+<NavItem tooltip="Dashboard" href="/test" bind:meta="{meta}"></NavItem>

--- a/packages/renderer/src/lib/ui/NavItemTest.svelte
+++ b/packages/renderer/src/lib/ui/NavItemTest.svelte
@@ -1,8 +1,11 @@
 <script lang="ts">
+/* eslint-disable import/no-duplicates */
+// https://github.com/import-js/eslint-plugin-import/issues/1479
 import type { TinroRouteMeta } from 'tinro';
 import NavItem from './NavItem.svelte';
 import { setContext } from 'svelte';
 import { writable } from 'svelte/store';
+/* eslint-disable import/no-duplicates */
 
 let meta: TinroRouteMeta = { url: '/test' } as TinroRouteMeta;
 

--- a/packages/renderer/src/lib/ui/NavSection.spec.ts
+++ b/packages/renderer/src/lib/ui/NavSection.spec.ts
@@ -36,25 +36,29 @@ test('Expect correct button and tooltip', async () => {
   expect(within(button).queryByText(tooltip)).toBeInTheDocument();
 });
 
+test('Expect section is open by default', async () => {
+  render(NavSectionTest);
+
+  const content = screen.queryByLabelText('Item1');
+  expect(content).toBeInTheDocument();
+
+  const icon = screen.queryByTestId('icon');
+  expect(icon).not.toBeInTheDocument();
+});
+
 test('Expect button expands and contracts', async () => {
   render(NavSectionTest);
 
   const button = screen.getByRole('button');
   expect(button).toBeInTheDocument();
 
-  const content = screen.queryByTestId('content');
-  expect(content).not.toBeInTheDocument();
-
-  const icon = screen.queryByTestId('icon');
-  expect(icon).toBeInTheDocument();
-
   const expand = screen.getByTestId('expand');
   expect(expand).toBeInTheDocument();
-  expect(expand.textContent).toEqual('false');
-
-  await userEvent.click(button);
   expect(expand.textContent).toEqual('true');
 
   await userEvent.click(button);
   expect(expand.textContent).toEqual('false');
+
+  await userEvent.click(button);
+  expect(expand.textContent).toEqual('true');
 });

--- a/packages/renderer/src/lib/ui/NavSection.svelte
+++ b/packages/renderer/src/lib/ui/NavSection.svelte
@@ -1,10 +1,13 @@
 <script lang="ts">
+/* eslint-disable import/no-duplicates */
+// https://github.com/import-js/eslint-plugin-import/issues/1479
 import { faChevronDown, faChevronUp } from '@fortawesome/free-solid-svg-icons';
 import Tooltip from './Tooltip.svelte';
 import Fa from 'svelte-fa';
 import { onMount, setContext } from 'svelte';
 import { cubicOut } from 'svelte/easing';
 import { writable, type Writable } from 'svelte/store';
+/* eslint-disable import/no-duplicates */
 
 export let expanded: boolean = true;
 export let tooltip: string;

--- a/packages/renderer/src/lib/ui/NavSection.svelte
+++ b/packages/renderer/src/lib/ui/NavSection.svelte
@@ -2,10 +2,14 @@
 import { faChevronDown, faChevronUp } from '@fortawesome/free-solid-svg-icons';
 import Tooltip from './Tooltip.svelte';
 import Fa from 'svelte-fa';
+import { onMount, setContext } from 'svelte';
 import { cubicOut } from 'svelte/easing';
+import { writable, type Writable } from 'svelte/store';
 
-export let expanded: boolean = false;
+export let expanded: boolean = true;
 export let tooltip: string;
+
+const count: Writable<number> = setContext('nav-items', writable(0));
 
 function fadeSlide(node: any, { delay = 0, duration = 400, easing = cubicOut }) {
   const style = getComputedStyle(node);
@@ -26,6 +30,13 @@ function fadeSlide(node: any, { delay = 0, duration = 400, easing = cubicOut }) 
       `padding-bottom: ${t * paddingBottom}px;`,
   };
 }
+
+onMount(() => {
+  // collapse by default if > 3 items
+  if ($count > 3) {
+    expanded = false;
+  }
+});
 </script>
 
 <div class="flex flex-col justify-center items-center mx-1 bg-charcoal-600 rounded my-1">
@@ -37,14 +48,19 @@ function fadeSlide(node: any, { delay = 0, duration = 400, easing = cubicOut }) 
     </div>
   {/if}
 
-  <button class="inline-block flex flex-col justify-center items-center" on:click="{() => (expanded = !expanded)}">
+  <button
+    class="inline-block flex flex-col justify-center items-center"
+    on:click="{() => (expanded = !expanded)}"
+    disabled="{expanded && $count < 2}">
     <Tooltip class="flex flex-col justify-center items-center pb-1" tip="{tooltip}" right>
-      {#if !expanded}
-        <div class="pt-2 pb-2" transition:fadeSlide="{{ duration: 500 }}">
-          <slot name="icon" />
-        </div>
-      {/if}
-      <Fa size="12" icon="{expanded ? faChevronUp : faChevronDown}" />
+      <div class="flex flex-col justify-center items-center" class:text-charcoal-50="{expanded && $count < 2}">
+        {#if !expanded}
+          <div class="py-3" transition:fadeSlide="{{ duration: 500 }}">
+            <slot name="icon" />
+          </div>
+        {/if}
+        <Fa size="12" icon="{expanded ? faChevronUp : faChevronDown}" />
+      </div>
     </Tooltip>
   </button>
 </div>

--- a/packages/renderer/src/lib/ui/NavSectionTest.svelte
+++ b/packages/renderer/src/lib/ui/NavSectionTest.svelte
@@ -1,12 +1,18 @@
 <script lang="ts">
 import NavSection from './NavSection.svelte';
+import NavItem from './NavItem.svelte';
+import type { TinroRouteMeta } from 'tinro';
 
 let expanded: boolean;
+
+let meta: TinroRouteMeta = { url: '/test' } as TinroRouteMeta;
 </script>
 
 Is it expanded: <div data-testid="expand">{expanded}</div>
 
 <NavSection tooltip="Test Section" bind:expanded="{expanded}">
   <div data-testid="icon" slot="icon">The icon</div>
-  <div data-testid="content">Content</div>
+  <NavItem href="/item1" tooltip="Item1" bind:meta="{meta}">Item1</NavItem>
+  <NavItem href="/item2" tooltip="Item2" bind:meta="{meta}">Item2</NavItem>
+  <NavItem href="/item3" tooltip="Item3" bind:meta="{meta}">Item3</NavItem>
 </NavSection>


### PR DESCRIPTION
### What does this PR do?

Improving a number of issues with the new nav sections. Here are the changes in behaviour/UI:
- Webviews are added to the same section as the Docker extensions, and it is renamed to just Extensions. (This reduces the point of separating Webviews.svelte a bit - maybe future chore to have an an Extensions.svelte for both?)
- If there are no items, the section is not shown.
- Sections are now expanded by default, but collapsed by default if there are more than 3 items. (this is arbitrary, but 4+ felt like a lot to me)
- If there is only one item, the button to collapse is greyed out and disabled. I tried it without this, but even after you fix the height issue IMHO it was really confusing what it is doing ('why are you giving me a button to hide the nav item??') This felt like the right balance between showing that there is a section and what it is (you can still hover over the collapse button to see the tooltip) without confusing users.

Technical notes:
- The only way to count the number of items in a section is using the context. The nice side benefit of this is that we no longer need to tell NavItems that they are inSection - if the context exists, they are. It makes testing a little harder though.
- Why 'expanded && $count < 2'? Two reasons: 1) when you collapse the item count (correctly) goes to zero and you always want to be able to expand. 2) if there is one item and a second is added dynamically. the collapse button/styling will be removed.

### Screenshot / video of UI

Shown with a fake Kubernetes section that only has one item so you can see what it looks like:

https://github.com/containers/podman-desktop/assets/19958075/edafafee-89e7-455c-8887-60dbcb331f47

### What issues does this PR fix or reference?

Fixes #5618.

### How to test this PR?

Automated tests, plus try sections out with different number of extensions installed