### PR TITLE
feat: allow to create container without starting it

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -2140,7 +2140,7 @@ declare module '@podman-desktop/api' {
     OpenStdin?: boolean;
     StdinOnce?: boolean;
     Detach?: boolean;
-    startOnCreation?: boolean;
+    start?: boolean;
   }
 
   export interface ContainerCreateResult {

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -2140,6 +2140,7 @@ declare module '@podman-desktop/api' {
     OpenStdin?: boolean;
     StdinOnce?: boolean;
     Detach?: boolean;
+    startOnCreation?: boolean;
   }
 
   export interface ContainerCreateResult {
@@ -2234,7 +2235,6 @@ declare module '@podman-desktop/api' {
     export function createContainer(
       engineId: string,
       containerCreateOptions: ContainerCreateOptions,
-      startOnCreation?: boolean,
     ): Promise<ContainerCreateResult>;
     export function startContainer(engineId: string, id: string): Promise<void>;
     export function logsContainer(

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -2234,6 +2234,7 @@ declare module '@podman-desktop/api' {
     export function createContainer(
       engineId: string,
       containerCreateOptions: ContainerCreateOptions,
+      startOnCreation?: boolean,
     ): Promise<ContainerCreateResult>;
     export function startContainer(engineId: string, id: string): Promise<void>;
     export function logsContainer(

--- a/packages/main/src/plugin/api/container-info.ts
+++ b/packages/main/src/plugin/api/container-info.ts
@@ -95,6 +95,7 @@ export interface ContainerCreateOptions {
   OpenStdin?: boolean;
   StdinOnce?: boolean;
   Detach?: boolean;
+  startOnCreation?: boolean;
 }
 
 export interface NetworkCreateOptions {

--- a/packages/main/src/plugin/api/container-info.ts
+++ b/packages/main/src/plugin/api/container-info.ts
@@ -95,7 +95,7 @@ export interface ContainerCreateOptions {
   OpenStdin?: boolean;
   StdinOnce?: boolean;
   Detach?: boolean;
-  startOnCreation?: boolean;
+  start?: boolean;
 }
 
 export interface NetworkCreateOptions {

--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -2117,8 +2117,8 @@ test('container logs callback notified when messages arrive', async () => {
   expect(telemetry.track).toHaveBeenCalled;
 });
 
-describe('createAndStartContainer', () => {
-  test('test createAndStartContainer', async () => {
+describe('createContainer', () => {
+  test('test create and start Container', async () => {
     const createdId = '1234';
 
     const startMock = vi.fn();
@@ -2147,14 +2147,14 @@ describe('createAndStartContainer', () => {
       api: fakeDockerode,
     } as InternalContainerProvider);
 
-    const container = await containerRegistry.createAndStartContainer('podman1', {}, true);
+    const container = await containerRegistry.createContainer('podman1', { startOnCreation: true });
 
     expect(container.id).toBe(createdId);
     expect(createContainerMock).toHaveBeenCalled();
     expect(startMock).toHaveBeenCalled();
   });
 
-  test('test createAndStartContainer with envfiles', async () => {
+  test('test create and start Container with envfiles', async () => {
     const createdId = '1234';
 
     const startMock = vi.fn();
@@ -2189,11 +2189,7 @@ describe('createAndStartContainer', () => {
 
     spyEnvParser.mockReturnValue({ parseEnvFiles: parseEnvFilesMock } as unknown as EnvfileParser);
 
-    const container = await containerRegistry.createAndStartContainer(
-      'podman1',
-      { EnvFiles: ['file1', 'file2'] },
-      true,
-    );
+    const container = await containerRegistry.createContainer('podman1', { EnvFiles: ['file1', 'file2'] });
 
     expect(container.id).toBe(createdId);
     expect(createContainerMock).toHaveBeenCalled();
@@ -2238,7 +2234,7 @@ describe('createAndStartContainer', () => {
       api: fakeDockerode,
     } as InternalContainerProvider);
 
-    const container = await containerRegistry.createAndStartContainer('podman1', {}, false);
+    const container = await containerRegistry.createContainer('podman1', { startOnCreation: false });
 
     expect(container.id).toBe(createdId);
     expect(createContainerMock).toHaveBeenCalled();

--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -2147,7 +2147,7 @@ describe('createContainer', () => {
       api: fakeDockerode,
     } as InternalContainerProvider);
 
-    const container = await containerRegistry.createContainer('podman1', { startOnCreation: true });
+    const container = await containerRegistry.createContainer('podman1', { start: true });
 
     expect(container.id).toBe(createdId);
     expect(createContainerMock).toHaveBeenCalled();
@@ -2234,7 +2234,7 @@ describe('createContainer', () => {
       api: fakeDockerode,
     } as InternalContainerProvider);
 
-    const container = await containerRegistry.createContainer('podman1', { startOnCreation: false });
+    const container = await containerRegistry.createContainer('podman1', { start: false });
 
     expect(container.id).toBe(createdId);
     expect(createContainerMock).toHaveBeenCalled();

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -1692,11 +1692,7 @@ export class ContainerProviderRegistry {
     }
   }
 
-  async createAndStartContainer(
-    engineId: string,
-    options: ContainerCreateOptions,
-    doStartContainer: boolean,
-  ): Promise<{ id: string }> {
+  async createContainer(engineId: string, options: ContainerCreateOptions): Promise<{ id: string }> {
     let telemetryOptions = {};
     try {
       // need to find the container engine of the container
@@ -1722,7 +1718,7 @@ export class ContainerProviderRegistry {
 
       const container = await engine.api.createContainer(options);
       await this.attachToContainer(engine, container, options.Tty, options.OpenStdin);
-      if (doStartContainer) {
+      if (options.startOnCreation === true || options.startOnCreation === undefined) {
         await container.start();
       }
       return { id: container.id };
@@ -1730,7 +1726,7 @@ export class ContainerProviderRegistry {
       telemetryOptions = { error: error };
       throw error;
     } finally {
-      this.telemetryService.track('createAndStartContainer', telemetryOptions);
+      this.telemetryService.track('createContainer', telemetryOptions);
     }
   }
 

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -1692,7 +1692,11 @@ export class ContainerProviderRegistry {
     }
   }
 
-  async createAndStartContainer(engineId: string, options: ContainerCreateOptions): Promise<{ id: string }> {
+  async createAndStartContainer(
+    engineId: string,
+    options: ContainerCreateOptions,
+    doStartContainer: boolean,
+  ): Promise<{ id: string }> {
     let telemetryOptions = {};
     try {
       // need to find the container engine of the container
@@ -1718,7 +1722,9 @@ export class ContainerProviderRegistry {
 
       const container = await engine.api.createContainer(options);
       await this.attachToContainer(engine, container, options.Tty, options.OpenStdin);
-      await container.start();
+      if (doStartContainer) {
+        await container.start();
+      }
       return { id: container.id };
     } catch (error) {
       telemetryOptions = { error: error };

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -1718,7 +1718,7 @@ export class ContainerProviderRegistry {
 
       const container = await engine.api.createContainer(options);
       await this.attachToContainer(engine, container, options.Tty, options.OpenStdin);
-      if (options.startOnCreation === true || options.startOnCreation === undefined) {
+      if (options.start === true || options.start === undefined) {
         await container.start();
       }
       return { id: container.id };

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -908,10 +908,8 @@ export class ExtensionLoader {
       createContainer(
         engineId: string,
         containerCreateOptions: containerDesktopAPI.ContainerCreateOptions,
-        startOnCreation?: boolean,
       ): Promise<containerDesktopAPI.ContainerCreateResult> {
-        const doStartContainer = startOnCreation === undefined ? true : startOnCreation;
-        return containerProviderRegistry.createAndStartContainer(engineId, containerCreateOptions, doStartContainer);
+        return containerProviderRegistry.createContainer(engineId, containerCreateOptions);
       },
       inspectContainer(engineId: string, id: string): Promise<containerDesktopAPI.ContainerInspectInfo> {
         return containerProviderRegistry.getContainerInspect(engineId, id);

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -908,8 +908,10 @@ export class ExtensionLoader {
       createContainer(
         engineId: string,
         containerCreateOptions: containerDesktopAPI.ContainerCreateOptions,
+        startOnCreation?: boolean,
       ): Promise<containerDesktopAPI.ContainerCreateResult> {
-        return containerProviderRegistry.createAndStartContainer(engineId, containerCreateOptions);
+        const doStartContainer = startOnCreation === undefined ? true : startOnCreation;
+        return containerProviderRegistry.createAndStartContainer(engineId, containerCreateOptions, doStartContainer);
       },
       inspectContainer(engineId: string, id: string): Promise<containerDesktopAPI.ContainerInspectInfo> {
         return containerProviderRegistry.getContainerInspect(engineId, id);

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1077,7 +1077,7 @@ export class PluginSystem {
     this.ipcHandle(
       'container-provider-registry:createAndStartContainer',
       async (_listener, engine: string, options: ContainerCreateOptions): Promise<{ id: string }> => {
-        options.startOnCreation = true;
+        options.start = true;
         return containerProviderRegistry.createContainer(engine, options);
       },
     );

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1077,7 +1077,7 @@ export class PluginSystem {
     this.ipcHandle(
       'container-provider-registry:createAndStartContainer',
       async (_listener, engine: string, options: ContainerCreateOptions): Promise<{ id: string }> => {
-        return containerProviderRegistry.createAndStartContainer(engine, options);
+        return containerProviderRegistry.createAndStartContainer(engine, options, true);
       },
     );
 

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1077,7 +1077,8 @@ export class PluginSystem {
     this.ipcHandle(
       'container-provider-registry:createAndStartContainer',
       async (_listener, engine: string, options: ContainerCreateOptions): Promise<{ id: string }> => {
-        return containerProviderRegistry.createAndStartContainer(engine, options, true);
+        options.startOnCreation = true;
+        return containerProviderRegistry.createContainer(engine, options);
       },
     );
 


### PR DESCRIPTION
### What does this PR do?

This PR just gives the chance to create a container without it is actually started. 
It is needed when we create containers that have to be added to a pod in ai-studio.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

it resolves #5475 

### How to test this PR?

1. run test
