### PR TITLE
Provide ARIA functionality to Podman Machine onboarding

### DIFF
--- a/packages/renderer/src/lib/onboarding/Onboarding.spec.ts
+++ b/packages/renderer/src/lib/onboarding/Onboarding.spec.ts
@@ -62,7 +62,7 @@ test('Expect to have the "Try again" and Cancel buttons if the step represent a 
   });
   const button = screen.getByRole('button', { name: 'Try again' });
   expect(button).toBeInTheDocument();
-  const buttonCancel = screen.getByRole('button', { name: 'Cancel setup' });
+  const buttonCancel = screen.getByRole('button', { name: 'Cancel Setup' });
   expect(buttonCancel).toBeInTheDocument();
   const infoMessage = screen.queryByLabelText('Next Info Message');
   expect(infoMessage).not.toBeInTheDocument();
@@ -93,7 +93,7 @@ test('Expect not to have the "Try again" and "Cancel" buttons if the step repres
   });
   const buttonTryAgain = screen.queryByRole('button', { name: 'Try again' });
   expect(buttonTryAgain).not.toBeInTheDocument();
-  const buttonCancel = screen.queryByRole('button', { name: 'Cancel setup' });
+  const buttonCancel = screen.queryByRole('button', { name: 'Cancel Setup' });
   expect(buttonCancel).not.toBeInTheDocument();
   const infoMessage = screen.getByLabelText('Next Info Message');
   expect(infoMessage).toBeInTheDocument();
@@ -323,7 +323,7 @@ test('Expect Step Body to clean up if new step has no content to display.', asyn
   expect(helloExists[0]).toBeInTheDocument();
 
   // click on the next button
-  const nextButton = screen.getByRole('button', { name: 'Next' });
+  const nextButton = screen.getByLabelText('Next Step');
   expect(nextButton).toBeInTheDocument();
   await fireEvent.click(nextButton);
 

--- a/packages/renderer/src/lib/onboarding/Onboarding.svelte
+++ b/packages/renderer/src/lib/onboarding/Onboarding.svelte
@@ -423,11 +423,15 @@ function handleEscape({ key }: any) {
           class="flex flex-row-reverse p-6 bg-charcoal-700 fixed w-[calc(100%-theme(width.leftnavbar)-theme(width.leftsidebar))] bottom-0 mb-5 pr-10 max-h-20 bg-opacity-90 z-20"
           role="group"
           aria-label="Step Buttons">
-          <Button type="primary" disabled="{activeStep.step.state === 'failed'}" on:click="{() => next()}">Next</Button>
+          <Button
+            type="primary"
+            aria-label="Next Step"
+            disabled="{activeStep.step.state === 'failed'}"
+            on:click="{() => next()}">Next</Button>
           {#if activeStep.step.state !== 'completed'}
             <Button
               type="secondary"
-              aria-label="Cancel setup"
+              aria-label="Cancel Setup"
               class="mr-2 opacity-100"
               on:click="{() => setDisplayCancelSetup(true)}">Cancel</Button>
           {/if}


### PR DESCRIPTION
### What does this PR do?
* Provides ARIA label to Next button in Onboarding dialog
* Fixes naming convention for Cancel Setup aria-label
* Updates tests with said change

### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
#4709 

<!-- Include any related issues from Podman Desktop 
repository (or from another issue tracker). -->

### How to test this PR?
* yarn --frozen-lockfile
* yarn run test:e2e:smoke
<!-- Please explain steps to reproduce -->
