### PR TITLE
feat: ingress & route details pages

### DIFF
--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -48,6 +48,8 @@ import type { NavigationRequest } from '../../main/src/plugin/navigation/navigat
 import { navigationHandle } from '/@/Route';
 import IngressesRoutesList from './lib/ingresses-routes/IngressesRoutesList.svelte';
 import Webview from './lib/webview/Webview.svelte';
+import IngressDetails from './lib/ingresses-routes/IngressDetails.svelte';
+import RouteDetails from './lib/ingresses-routes/RouteDetails.svelte';
 
 router.mode.hash();
 
@@ -178,6 +180,20 @@ window.events?.receive('navigate', (navigationRequest: unknown) => {
         </Route>
         <Route path="/ingressesRoutes" breadcrumb="Ingresses & Routes" navigationHint="root">
           <IngressesRoutesList />
+        </Route>
+        <Route
+          path="/ingressesRoutes/ingress/:name/:namespace/*"
+          breadcrumb="Ingress Details"
+          let:meta
+          navigationHint="details">
+          <IngressDetails name="{decodeURI(meta.params.name)}" namespace="{decodeURI(meta.params.namespace)}" />
+        </Route>
+        <Route
+          path="/ingressesRoutes/route/:name/:namespace/*"
+          breadcrumb="Route Details"
+          let:meta
+          navigationHint="details">
+          <RouteDetails name="{decodeURI(meta.params.name)}" namespace="{decodeURI(meta.params.namespace)}" />
         </Route>
         <Route path="/preferences/*" breadcrumb="Settings">
           <PreferencesPage />

--- a/packages/renderer/src/lib/ingresses-routes/IngressDetails.spec.ts
+++ b/packages/renderer/src/lib/ingresses-routes/IngressDetails.spec.ts
@@ -1,0 +1,79 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+import { test, expect, vi, beforeAll } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/svelte';
+
+import IngressRouteDetails from './IngressDetails.svelte';
+
+import { router } from 'tinro';
+import { lastPage } from '/@/stores/breadcrumb';
+import type { V1Ingress } from '@kubernetes/client-node';
+import { ingresses } from '/@/stores/ingresses';
+
+const kubernetesDeleteIngressMock = vi.fn();
+
+const ingress: V1Ingress = {
+  metadata: {
+    name: 'my-ingress',
+    namespace: 'default',
+  },
+  status: {},
+};
+
+beforeAll(() => {
+  (window as any).kubernetesDeleteIngress = kubernetesDeleteIngressMock;
+  (window as any).kubernetesReadNamespacedIngress = vi.fn();
+});
+
+test('Expect redirect to previous page if ingress is deleted', async () => {
+  const routerGotoSpy = vi.spyOn(router, 'goto');
+  ingresses.set([ingress]);
+
+  // remove ingress from the store when we call delete
+  kubernetesDeleteIngressMock.mockImplementation(() => {
+    ingresses.set([]);
+  });
+
+  // define a fake lastPage so we can check where we will be redirected
+  lastPage.set({ name: 'Fake Previous', path: '/last' });
+
+  // render the component
+  render(IngressRouteDetails, { name: 'my-ingress', namespace: 'default' });
+  expect(screen.getByText('my-ingress')).toBeInTheDocument();
+
+  // grab current route
+  const currentRoute = window.location;
+  expect(currentRoute.href).toBe('http://localhost:3000/');
+
+  // click on delete button
+  const deleteButton = screen.getByRole('button', { name: 'Delete Ingress' });
+  await fireEvent.click(deleteButton);
+
+  // check that delete method has been called
+  expect(kubernetesDeleteIngressMock).toHaveBeenCalled();
+
+  // expect that we have called the router when page has been removed
+  // to jump to the previous page
+  expect(routerGotoSpy).toBeCalledWith('/last');
+
+  // confirm updated route
+  const afterRoute = window.location;
+  expect(afterRoute.href).toBe('http://localhost:3000/last');
+});

--- a/packages/renderer/src/lib/ingresses-routes/IngressDetails.svelte
+++ b/packages/renderer/src/lib/ingresses-routes/IngressDetails.svelte
@@ -1,0 +1,81 @@
+<script lang="ts">
+import { onMount } from 'svelte';
+import StatusIcon from '../images/StatusIcon.svelte';
+import DetailsPage from '../ui/DetailsPage.svelte';
+import Tab from '../ui/Tab.svelte';
+import StateChange from '../ui/StateChange.svelte';
+import type { V1Ingress } from '@kubernetes/client-node';
+import { stringify } from 'yaml';
+import MonacoEditor from '../editor/MonacoEditor.svelte';
+import type { IngressUI } from './IngressUI';
+import { IngressRouteUtils } from './ingress-route-utils';
+import { ingresses } from '/@/stores/ingresses';
+import IngressRouteActions from './IngressRouteActions.svelte';
+import ServiceDetailsSummary from './IngressRouteDetailsSummary.svelte';
+import ServiceIcon from '../images/ServiceIcon.svelte';
+import Route from '../../Route.svelte';
+
+export let name: string;
+export let namespace: string;
+
+let ingressUI: IngressUI;
+let detailsPage: DetailsPage;
+let kubeService: V1Ingress | undefined;
+let kubeError: string;
+
+onMount(() => {
+  const ingressRouteUtils = new IngressRouteUtils();
+
+  return ingresses.subscribe(ingress => {
+    const matchingIngress = ingress.find(srv => srv.metadata?.name === name && srv.metadata?.namespace === namespace);
+    if (matchingIngress) {
+      try {
+        ingressUI = ingressRouteUtils.getIngressUI(matchingIngress);
+        loadIngressDetails();
+      } catch (err) {
+        console.error(err);
+      }
+    } else if (detailsPage) {
+      // the ingress has been deleted
+      detailsPage.close();
+    }
+  });
+});
+
+async function loadIngressDetails() {
+  const getKubeService = await window.kubernetesReadNamespacedIngress(ingressUI.name, namespace);
+  if (getKubeService) {
+    kubeService = getKubeService;
+  } else {
+    kubeError = `Unable to retrieve Kubernetes details for ${ingressUI.name}`;
+  }
+}
+</script>
+
+{#if ingressUI}
+  <DetailsPage title="{ingressUI.name}" subtitle="{ingressUI.namespace}" bind:this="{detailsPage}">
+    <StatusIcon slot="icon" icon="{ServiceIcon}" size="{24}" status="{ingressUI.status}" />
+    <svelte:fragment slot="actions">
+      <IngressRouteActions ingressRoute="{ingressUI}" detailed="{true}" on:update="{() => (ingressUI = ingressUI)}" />
+    </svelte:fragment>
+    <div slot="detail" class="flex py-2 w-full justify-end text-sm text-gray-700">
+      <StateChange state="{ingressUI.status}" />
+    </div>
+    <svelte:fragment slot="tabs">
+      <Tab title="Summary" url="summary" />
+      <Tab title="Inspect" url="inspect" />
+      <Tab title="Kube" url="kube" />
+    </svelte:fragment>
+    <svelte:fragment slot="content">
+      <Route path="/summary" breadcrumb="Summary" navigationHint="tab">
+        <ServiceDetailsSummary ingressRouteUI="{ingressUI}" ingressRoute="{kubeService}" kubeError="{kubeError}" />
+      </Route>
+      <Route path="/inspect" breadcrumb="Inspect" navigationHint="tab">
+        <MonacoEditor content="{JSON.stringify(kubeService, undefined, 2)}" language="json" />
+      </Route>
+      <Route path="/kube" breadcrumb="Kube" navigationHint="tab">
+        <MonacoEditor content="{stringify(kubeService)}" language="yaml" />
+      </Route>
+    </svelte:fragment>
+  </DetailsPage>
+{/if}

--- a/packages/renderer/src/lib/ingresses-routes/IngressRouteColumnName.spec.ts
+++ b/packages/renderer/src/lib/ingresses-routes/IngressRouteColumnName.spec.ts
@@ -17,20 +17,35 @@
  ***********************************************************************/
 
 import '@testing-library/jest-dom/vitest';
-import { test, expect } from 'vitest';
-import { render, screen } from '@testing-library/svelte';
+import { test, expect, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/svelte';
 
 import type { IngressUI } from './IngressUI';
 import IngressRouteColumnName from './IngressRouteColumnName.svelte';
 import type { RouteUI } from './RouteUI';
+import { router } from 'tinro';
+
+const ingressUI: IngressUI = {
+  name: 'my-ingress',
+  namespace: 'test-namespace',
+  status: 'RUNNING',
+  selected: false,
+};
+
+const routeUI: RouteUI = {
+  name: 'my-route',
+  namespace: 'test-namespace',
+  status: 'RUNNING',
+  host: 'foo.bar.com',
+  port: '80',
+  to: {
+    kind: 'Service',
+    name: 'service',
+  },
+  selected: false,
+};
 
 test('Expect simple column styling with Ingress', async () => {
-  const ingressUI: IngressUI = {
-    name: 'my-ingress',
-    namespace: 'test-namespace',
-    status: 'RUNNING',
-    selected: false,
-  };
   render(IngressRouteColumnName, { object: ingressUI });
 
   const text = screen.getByText(ingressUI.name);
@@ -39,23 +54,39 @@ test('Expect simple column styling with Ingress', async () => {
   expect(text).toHaveClass('text-gray-300');
 });
 
+test('Expect clicking on Ingress works', async () => {
+  render(IngressRouteColumnName, { object: ingressUI });
+
+  const text = screen.getByText(ingressUI.name);
+  expect(text).toBeInTheDocument();
+
+  // test click
+  const routerGotoSpy = vi.spyOn(router, 'goto');
+
+  fireEvent.click(text);
+
+  expect(routerGotoSpy).toBeCalledWith('/ingressesRoutes/ingress/my-ingress/test-namespace/summary');
+});
+
 test('Expect simple column styling with Route', async () => {
-  const routeUI: RouteUI = {
-    name: 'my-route',
-    namespace: 'test-namespace',
-    status: 'RUNNING',
-    host: 'foo.bar.com',
-    port: '80',
-    to: {
-      kind: 'Service',
-      name: 'service',
-    },
-    selected: false,
-  };
   render(IngressRouteColumnName, { object: routeUI });
 
   const text = screen.getByText(routeUI.name);
   expect(text).toBeInTheDocument();
   expect(text).toHaveClass('text-sm');
   expect(text).toHaveClass('text-gray-300');
+});
+
+test('Expect clicking on Route works', async () => {
+  render(IngressRouteColumnName, { object: routeUI });
+
+  const text = screen.getByText(routeUI.name);
+  expect(text).toBeInTheDocument();
+
+  // test click
+  const routerGotoSpy = vi.spyOn(router, 'goto');
+
+  fireEvent.click(text);
+
+  expect(routerGotoSpy).toBeCalledWith('/ingressesRoutes/route/my-route/test-namespace/summary');
 });

--- a/packages/renderer/src/lib/ingresses-routes/IngressRouteColumnName.svelte
+++ b/packages/renderer/src/lib/ingresses-routes/IngressRouteColumnName.svelte
@@ -1,8 +1,21 @@
 <script lang="ts">
+import { router } from 'tinro';
 import type { IngressUI } from './IngressUI';
 import type { RouteUI } from './RouteUI';
+import { IngressRouteUtils } from './ingress-route-utils';
 
 export let object: IngressUI | RouteUI;
+
+function openDetails() {
+  const ingressRouteUtils = new IngressRouteUtils();
+  if (ingressRouteUtils.isIngress(object)) {
+    router.goto(`/ingressesRoutes/ingress/${encodeURI(object.name)}/${encodeURI(object.namespace)}/summary`);
+  } else {
+    router.goto(`/ingressesRoutes/route/${encodeURI(object.name)}/${encodeURI(object.namespace)}/summary`);
+  }
+}
 </script>
 
-<div class="text-sm text-gray-300">{object.name}</div>
+<button class="hover:cursor-pointer flex flex-col" on:click="{() => openDetails()}">
+  <div class="text-sm text-gray-300">{object.name}</div>
+</button>

--- a/packages/renderer/src/lib/ingresses-routes/IngressRouteDetailsSummary.spec.ts
+++ b/packages/renderer/src/lib/ingresses-routes/IngressRouteDetailsSummary.spec.ts
@@ -1,0 +1,122 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+import { test, vi, expect, beforeAll } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import IngressRouteDetailsSummary from './IngressRouteDetailsSummary.svelte';
+import type { IngressUI } from './IngressUI';
+import type { RouteUI } from './RouteUI';
+import type { V1Ingress } from '@kubernetes/client-node';
+import type { V1Route } from '../../../../main/src/plugin/api/openshift-types';
+
+const ingressUI: IngressUI = {
+  name: 'my-ingress',
+  namespace: 'default',
+  status: 'RUNNING',
+  selected: false,
+};
+
+const ingress: V1Ingress = {
+  metadata: {
+    name: 'my-ingress',
+    namespace: 'default',
+  },
+  status: {},
+};
+
+const routeUI: RouteUI = {
+  name: 'my-route',
+  namespace: 'default',
+  status: 'RUNNING',
+  host: 'foo.bar.com',
+  port: '80',
+  to: {
+    kind: 'Service',
+    name: 'service',
+  },
+  selected: false,
+};
+
+const route: V1Route = {
+  metadata: {
+    name: 'my-route',
+    namespace: 'default',
+  },
+  spec: {
+    host: '',
+    port: undefined,
+    path: undefined,
+    tls: {
+      insecureEdgeTerminationPolicy: '',
+      termination: '',
+    },
+    to: {
+      kind: '',
+      name: '',
+      weight: 0,
+    },
+    wildcardPolicy: '',
+  },
+};
+
+const kubernetesGetCurrentNamespaceMock = vi.fn();
+const kubernetesReadNamespacedServiceMock = vi.fn();
+
+beforeAll(() => {
+  (window as any).kubernetesGetCurrentNamespace = kubernetesGetCurrentNamespaceMock;
+  (window as any).kubernetesReadNamespacedService = kubernetesReadNamespacedServiceMock;
+});
+
+test('Expect basic ingress rendering', async () => {
+  kubernetesGetCurrentNamespaceMock.mockResolvedValue('default');
+  kubernetesReadNamespacedServiceMock.mockResolvedValue(ingress);
+
+  render(IngressRouteDetailsSummary, { ingressRouteUI: ingressUI, ingressRoute: ingress });
+
+  expect(screen.getByText(ingressUI.name)).toBeInTheDocument();
+});
+
+test('Expect basic route rendering', async () => {
+  kubernetesGetCurrentNamespaceMock.mockResolvedValue('default');
+  kubernetesReadNamespacedServiceMock.mockResolvedValue(route);
+
+  render(IngressRouteDetailsSummary, { ingressRouteUI: routeUI, ingressRoute: route });
+
+  expect(screen.getByText(routeUI.name)).toBeInTheDocument();
+});
+
+test('Check more ingress properties', async () => {
+  kubernetesGetCurrentNamespaceMock.mockResolvedValue('default');
+  kubernetesReadNamespacedServiceMock.mockResolvedValue(undefined);
+
+  render(IngressRouteDetailsSummary, { ingressRouteUI: ingressUI, ingressRoute: ingress });
+
+  expect(screen.getByText(ingressUI.name)).toBeInTheDocument();
+  expect(screen.getByText(ingressUI.namespace)).toBeInTheDocument();
+});
+
+test('Check more route properties', async () => {
+  kubernetesGetCurrentNamespaceMock.mockResolvedValue('default');
+  kubernetesReadNamespacedServiceMock.mockResolvedValue(undefined);
+
+  render(IngressRouteDetailsSummary, { ingressRouteUI: routeUI, ingressRoute: route });
+
+  expect(screen.getByText(routeUI.name)).toBeInTheDocument();
+  expect(screen.getByText(routeUI.namespace)).toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/ingresses-routes/IngressRouteDetailsSummary.svelte
+++ b/packages/renderer/src/lib/ingresses-routes/IngressRouteDetailsSummary.svelte
@@ -1,0 +1,46 @@
+<script lang="ts">
+import type { V1Ingress } from '@kubernetes/client-node';
+import type { V1Route } from '../../../../main/src/plugin/api/openshift-types';
+import ErrorMessage from '../ui/ErrorMessage.svelte';
+import type { IngressUI } from './IngressUI';
+import type { RouteUI } from './RouteUI';
+import IngressRouteColumnHostPath from './IngressRouteColumnHostPath.svelte';
+import IngressRouteColumnBackend from './IngressRouteColumnBackend.svelte';
+
+export let ingressRouteUI: IngressUI | RouteUI;
+export let ingressRoute: V1Ingress | V1Route | undefined;
+export let kubeError: string | undefined = undefined;
+</script>
+
+<!-- Show the kube error if we're unable to retrieve the data correctly, but we still want to show the 
+basic information -->
+{#if kubeError}
+  <ErrorMessage error="{kubeError}" />
+{/if}
+
+<div class="flex px-5 py-4 flex-col h-full overflow-auto">
+  {#if ingressRoute}
+    <table class="w-full">
+      <tbody>
+        <tr>
+          <td class="pr-2">Name</td>
+          <td>{ingressRoute.metadata?.name}</td>
+        </tr>
+        <tr>
+          <td class="pr-2">Namespace</td>
+          <td>{ingressRoute.metadata?.namespace}</td>
+        </tr>
+        <tr>
+          <td class="pr-2">Host/Path</td>
+          <td><IngressRouteColumnHostPath object="{ingressRouteUI}" /></td>
+        </tr>
+        <tr>
+          <td class="pr-2">Backend</td>
+          <td><IngressRouteColumnBackend object="{ingressRouteUI}" /></td>
+        </tr>
+      </tbody>
+    </table>
+  {:else}
+    <p class="text-purple-500 font-medium">Loading ...</p>
+  {/if}
+</div>

--- a/packages/renderer/src/lib/ingresses-routes/RouteDetails.spec.ts
+++ b/packages/renderer/src/lib/ingresses-routes/RouteDetails.spec.ts
@@ -1,0 +1,93 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+import { test, expect, vi, beforeAll } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/svelte';
+
+import RouteDetails from './RouteDetails.svelte';
+
+import { router } from 'tinro';
+import { lastPage } from '/@/stores/breadcrumb';
+import type { V1Route } from '../../../../main/src/plugin/api/openshift-types';
+import { routes } from '/@/stores/routes';
+
+const kubernetesDeleteRouteMock = vi.fn();
+
+const route: V1Route = {
+  metadata: {
+    name: 'my-route',
+    namespace: 'default',
+  },
+  spec: {
+    host: '',
+    port: undefined,
+    path: undefined,
+    tls: {
+      insecureEdgeTerminationPolicy: '',
+      termination: '',
+    },
+    to: {
+      kind: '',
+      name: '',
+      weight: 0,
+    },
+    wildcardPolicy: '',
+  },
+};
+
+beforeAll(() => {
+  (window as any).kubernetesDeleteRoute = kubernetesDeleteRouteMock;
+  (window as any).kubernetesReadNamespacedRoute = vi.fn();
+});
+
+test('Expect redirect to previous page if route is deleted', async () => {
+  const routerGotoSpy = vi.spyOn(router, 'goto');
+  routes.set([route]);
+
+  // remove route from the store when we call delete
+  kubernetesDeleteRouteMock.mockImplementation(() => {
+    routes.set([]);
+  });
+
+  // define a fake lastPage so we can check where we will be redirected
+  lastPage.set({ name: 'Fake Previous', path: '/last' });
+
+  // render the component
+  render(RouteDetails, { name: 'my-route', namespace: 'default' });
+  expect(screen.getByText('my-route')).toBeInTheDocument();
+
+  // grab current route
+  const currentRoute = window.location;
+  expect(currentRoute.href).toBe('http://localhost:3000/');
+
+  // click on delete button
+  const deleteButton = screen.getByRole('button', { name: 'Delete Route' });
+  await fireEvent.click(deleteButton);
+
+  // check that delete method has been called
+  expect(kubernetesDeleteRouteMock).toHaveBeenCalled();
+
+  // expect that we have called the router when page has been removed
+  // to jump to the previous page
+  expect(routerGotoSpy).toBeCalledWith('/last');
+
+  // confirm updated route
+  const afterRoute = window.location;
+  expect(afterRoute.href).toBe('http://localhost:3000/last');
+});

--- a/packages/renderer/src/lib/ingresses-routes/RouteDetails.svelte
+++ b/packages/renderer/src/lib/ingresses-routes/RouteDetails.svelte
@@ -1,0 +1,81 @@
+<script lang="ts">
+import { onMount } from 'svelte';
+import StatusIcon from '../images/StatusIcon.svelte';
+import DetailsPage from '../ui/DetailsPage.svelte';
+import Tab from '../ui/Tab.svelte';
+import StateChange from '../ui/StateChange.svelte';
+import type { V1Route } from '../../../../main/src/plugin/api/openshift-types';
+import { stringify } from 'yaml';
+import MonacoEditor from '../editor/MonacoEditor.svelte';
+import type { RouteUI } from './RouteUI';
+import { IngressRouteUtils } from './ingress-route-utils';
+import IngressRouteActions from './IngressRouteActions.svelte';
+import ServiceDetailsSummary from './IngressRouteDetailsSummary.svelte';
+import ServiceIcon from '../images/ServiceIcon.svelte';
+import Route from '../../Route.svelte';
+import { routes } from '/@/stores/routes';
+
+export let name: string;
+export let namespace: string;
+
+let routeUI: RouteUI;
+let detailsPage: DetailsPage;
+let kubeService: V1Route | undefined;
+let kubeError: string;
+
+onMount(() => {
+  const ingressRouteUtils = new IngressRouteUtils();
+
+  return routes.subscribe(route => {
+    const matchingRoute = route.find(srv => srv.metadata?.name === name && srv.metadata?.namespace === namespace);
+    if (matchingRoute) {
+      try {
+        routeUI = ingressRouteUtils.getRouteUI(matchingRoute);
+        loadRouteDetails();
+      } catch (err) {
+        console.error(err);
+      }
+    } else if (detailsPage) {
+      // the route has been deleted
+      detailsPage.close();
+    }
+  });
+});
+
+async function loadRouteDetails() {
+  const getKubeService = await window.kubernetesReadNamespacedRoute(routeUI.name, namespace);
+  if (getKubeService) {
+    kubeService = getKubeService;
+  } else {
+    kubeError = `Unable to retrieve Kubernetes details for ${routeUI.name}`;
+  }
+}
+</script>
+
+{#if routeUI}
+  <DetailsPage title="{routeUI.name}" subtitle="{routeUI.namespace}" bind:this="{detailsPage}">
+    <StatusIcon slot="icon" icon="{ServiceIcon}" size="{24}" status="{routeUI.status}" />
+    <svelte:fragment slot="actions">
+      <IngressRouteActions ingressRoute="{routeUI}" detailed="{true}" on:update="{() => (routeUI = routeUI)}" />
+    </svelte:fragment>
+    <div slot="detail" class="flex py-2 w-full justify-end text-sm text-gray-700">
+      <StateChange state="{routeUI.status}" />
+    </div>
+    <svelte:fragment slot="tabs">
+      <Tab title="Summary" url="summary" />
+      <Tab title="Inspect" url="inspect" />
+      <Tab title="Kube" url="kube" />
+    </svelte:fragment>
+    <svelte:fragment slot="content">
+      <Route path="/summary" breadcrumb="Summary" navigationHint="tab">
+        <ServiceDetailsSummary ingressRouteUI="{routeUI}" ingressRoute="{kubeService}" kubeError="{kubeError}" />
+      </Route>
+      <Route path="/inspect" breadcrumb="Inspect" navigationHint="tab">
+        <MonacoEditor content="{JSON.stringify(kubeService, undefined, 2)}" language="json" />
+      </Route>
+      <Route path="/kube" breadcrumb="Kube" navigationHint="tab">
+        <MonacoEditor content="{stringify(kubeService)}" language="yaml" />
+      </Route>
+    </svelte:fragment>
+  </DetailsPage>
+{/if}


### PR DESCRIPTION
### What does this PR do?

Basic details pages for ingress and routes. As with #5413 we'll need to add more details to the summary, but at least this provides the basic support so that you can click on an ingress or route and see the basic summary, Inspect, and view YAML.

I've gone with two separate detail pages instead of a combined page. Although the list was a merged page, this makes it easier for each page to follow the basic pattern (e.g. automatically closing the page if you're looking at something that is deleted) and have a title that says 'Ingress Details' instead of 'Ingress or Route Details'. The odd choice of '/ingressesRoutes/ingress' routes are so that the main nav keeps the ingress/route icon selected when you go to details, just like the other pages.

### Screenshot / video of UI

<img width="688" alt="Screenshot 2024-01-23 at 10 38 51 AM" src="https://github.com/containers/podman-desktop/assets/19958075/18427dfe-0c37-414f-ace0-a6205a09cec9">

### What issues does this PR fix or reference?

Fixes #5158.

### How to test this PR?

Point to a cluster that has an ingress and route), make sure you can click on the list and see details for them.