### PR TITLE
fix: image usage by containers

### DIFF
--- a/packages/renderer/src/lib/image/image-utils.ts
+++ b/packages/renderer/src/lib/image/image-utils.ts
@@ -90,11 +90,19 @@ export class ImageUtils {
 
   // is that this image is used by a container or not
   // search if there is a container matching this image
-  getInUse(imageInfo: ImageInfo, containersInfo?: ContainerInfo[]): boolean {
+  getInUse(imageInfo: ImageInfo, repositoryTag?: string, containersInfo?: ContainerInfo[]): boolean {
     if (!containersInfo) {
       return false;
     }
-    return containersInfo.some(container => container.ImageID === imageInfo.Id);
+
+    // if there is a container with the same image id and the same repository tag, it's in use
+    // else check if we have an untagged ilmage and in that case we check that container is matching the image id
+    return containersInfo.some(container => {
+      return (
+        (container.ImageID === imageInfo.Id && container.Image === repositoryTag) ||
+        (!!repositoryTag === false && imageInfo.Id.includes(container.Image) && (imageInfo.RepoTags ?? []).length === 0)
+      );
+    });
   }
 
   computeBagdes(
@@ -176,7 +184,7 @@ export class ImageUtils {
           tag: '',
           base64RepoTag: this.getBase64EncodedName('<none>'),
           selected: false,
-          inUse: this.getInUse(imageInfo, containersInfo),
+          inUse: this.getInUse(imageInfo, undefined, containersInfo),
           badges,
           icon,
           labels: imageInfo.Labels,
@@ -197,7 +205,7 @@ export class ImageUtils {
           tag: this.getTag(repoTag),
           base64RepoTag: this.getBase64EncodedName(repoTag),
           selected: false,
-          inUse: this.getInUse(imageInfo, containersInfo),
+          inUse: this.getInUse(imageInfo, repoTag, containersInfo),
           badges,
           icon,
           labels: imageInfo.Labels,


### PR DESCRIPTION
### What does this PR do?
Image usage should only match if the image tag is matching as well

### Screenshot / video of UI

![image](https://github.com/containers/podman-desktop/assets/436777/e8fdf46d-b916-488f-8418-19b50b9d6d38)


### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/5583

### How to test this PR?

Unit tests

try the case reported by the issue (or another usage)