### PR TITLE
wip feat: everything cancellable

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -272,6 +272,10 @@ declare module '@podman-desktop/api' {
     portmappings?: PodCreatePortOptions[];
     // Set the provider to use, if not we will try select the first one available (sorted in favor of Podman).
     provider?: ProviderContainerConnectionInfo | ContainerProviderConnection;
+    /**
+     * The cancellationToken to use for possibly cancelling the build image action.
+     */
+    token?: CancellationToken;
   }
 
   export interface KubernetesProviderConnectionEndpoint {
@@ -2176,6 +2180,10 @@ declare module '@podman-desktop/api' {
     StdinOnce?: boolean;
     Detach?: boolean;
     start?: boolean;
+    /**
+     * The cancellationToken to use for possibly cancelling the build image action.
+     */
+    token?: CancellationToken;
   }
 
   export interface ContainerCreateResult {
@@ -2205,6 +2213,10 @@ declare module '@podman-desktop/api' {
 
   export interface NetworkCreateOptions {
     Name: string;
+    /**
+     * The cancellationToken to use for possibly cancelling the build image action.
+     */
+    token?: CancellationToken;
   }
 
   export interface NetworkCreateResult {
@@ -2334,7 +2346,7 @@ declare module '@podman-desktop/api' {
       target: { engineId: string },
       overrideParameters: PodmanContainerCreateOptions,
     ): Promise<{ Id: string; Warnings: string[] }>;
-    export function startPod(engineId: string, podId: string): Promise<void>;
+    export function startPod(engineId: string, podId: string, token?: CancellationToken): Promise<void>;
   }
 
   /**

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -2280,7 +2280,7 @@ declare module '@podman-desktop/api' {
       callback: (name: string, data: string) => void,
       token?: CancellationToken,
     ): Promise<void>;
-    export function stopContainer(engineId: string, id: string): Promise<void>;
+    export function stopContainer(engineId: string, id: string, token?: CancellationToken): Promise<void>;
     export function deleteContainer(engineId: string, id: string): Promise<void>;
 
     /**

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -2293,7 +2293,7 @@ declare module '@podman-desktop/api' {
       token?: CancellationToken,
     ): Promise<void>;
     export function stopContainer(engineId: string, id: string, token?: CancellationToken): Promise<void>;
-    export function deleteContainer(engineId: string, id: string): Promise<void>;
+    export function deleteContainer(engineId: string, id: string, token?: CancellationToken): Promise<void>;
 
     /**
      *
@@ -2327,7 +2327,7 @@ declare module '@podman-desktop/api' {
     export function deleteImage(engineId: string, id: string): Promise<void>;
     export function getImageInspect(engineId: string, id: string): Promise<ImageInspectInfo>;
 
-    export function info(engineId: string): Promise<ContainerEngineInfo>;
+    export function info(engineId: string, token?: CancellationToken): Promise<ContainerEngineInfo>;
     export const onEvent: Event<ContainerJSONEvent>;
 
     export function listNetworks(): Promise<NetworkInspectInfo[]>;

--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -864,7 +864,7 @@ describe('listContainers', () => {
       },
     ];
 
-    nock('http://localhost').get('/containers/json?all=true').reply(200, containersWithDockerAPI);
+    nock('http://localhost').get('/containers/json?all=true&abortSignal=').reply(200, containersWithDockerAPI);
 
     // mock listPods
 
@@ -2543,7 +2543,7 @@ describe('attachToContainer', () => {
     //send some data
     stream.write(data);
 
-    expect(attachMock).toBeCalledWith(container.id);
+    expect(attachMock).toBeCalledWith(container.id, undefined);
 
     const streams = containerRegistry.getStreamsOutputPerContainerId().get(container.id);
     expect(streams).toBeDefined();
@@ -2655,7 +2655,7 @@ describe('attachToContainer', () => {
 });
 
 test('createNetwork', async () => {
-  nock('http://localhost').post('/networks/create?Name=myNetwork').reply(200, '');
+  nock('http://localhost').post('/networks/create?Name=myNetwork&abortSignal=').reply(200, '');
 
   const api = new Dockerode({ protocol: 'http', host: 'localhost' });
 

--- a/packages/main/src/plugin/extension-loader-utils.ts
+++ b/packages/main/src/plugin/extension-loader-utils.ts
@@ -1,0 +1,15 @@
+import type containerDesktopAPI from '@podman-desktop/api';
+
+export const createAbortControllerOnCancellationToken = (
+  token?: containerDesktopAPI.CancellationToken,
+): AbortController | undefined => {
+  if (token === undefined) {
+    return undefined;
+  }
+  const abortController = new AbortController();
+  token?.onCancellationRequested(() => {
+    // if the token is cancelled, we trigger the abort on the AbortController
+    abortController.abort();
+  });
+  return abortController;
+};

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -903,48 +903,49 @@ export class ExtensionLoader {
 
     const containerProviderRegistry = this.containerProviderRegistry;
     const containerEngine: typeof containerDesktopAPI.containerEngine = {
-      listContainers(
-        token: containerDesktopAPI.CancellationToken | undefined,
-      ): Promise<containerDesktopAPI.ContainerInfo[]> {
-        const abortController = createAbortControllerOnCancellationToken(token);
-        return containerProviderRegistry.listSimpleContainers(abortController);
+      listContainers(token?: containerDesktopAPI.CancellationToken): Promise<containerDesktopAPI.ContainerInfo[]> {
+        return containerProviderRegistry.listSimpleContainers(createAbortControllerOnCancellationToken(token));
       },
       createContainer(
         engineId: string,
         containerCreateOptions: containerDesktopAPI.ContainerCreateOptions,
       ): Promise<containerDesktopAPI.ContainerCreateResult> {
-        return containerProviderRegistry.createContainer(engineId, containerCreateOptions);
+        return containerProviderRegistry.createContainer(
+          engineId,
+          containerCreateOptions,
+          createAbortControllerOnCancellationToken(containerCreateOptions?.token),
+        );
       },
       inspectContainer(engineId: string, id: string): Promise<containerDesktopAPI.ContainerInspectInfo> {
         return containerProviderRegistry.getContainerInspect(engineId, id);
       },
-      startContainer(engineId: string, id: string, token: containerDesktopAPI.CancellationToken | undefined) {
-        const abortController = createAbortControllerOnCancellationToken(token);
-        return containerProviderRegistry.startContainer(engineId, id, abortController);
+      startContainer(engineId: string, id: string, token?: containerDesktopAPI.CancellationToken) {
+        return containerProviderRegistry.startContainer(engineId, id, createAbortControllerOnCancellationToken(token));
       },
       logsContainer(
         engineId: string,
         id: string,
         callback: (name: string, data: string) => void,
-        token: containerDesktopAPI.CancellationToken | undefined,
+        token?: containerDesktopAPI.CancellationToken,
       ) {
-        const abortController = createAbortControllerOnCancellationToken(token);
-        return containerProviderRegistry.logsContainer(engineId, id, callback, abortController);
+        return containerProviderRegistry.logsContainer(
+          engineId,
+          id,
+          callback,
+          createAbortControllerOnCancellationToken(token),
+        );
       },
       stopContainer(engineId: string, id: string, token: containerDesktopAPI.CancellationToken | undefined) {
-        const abortController = createAbortControllerOnCancellationToken(token);
-        return containerProviderRegistry.stopContainer(engineId, id, abortController);
+        return containerProviderRegistry.stopContainer(engineId, id, createAbortControllerOnCancellationToken(token));
       },
-      deleteContainer(engineId: string, id: string) {
-        return containerProviderRegistry.deleteContainer(engineId, id);
+      deleteContainer(engineId: string, id: string, token?: containerDesktopAPI.CancellationToken) {
+        return containerProviderRegistry.deleteContainer(engineId, id, createAbortControllerOnCancellationToken(token));
       },
       buildImage(
         context: string,
         eventCollect: (eventName: 'stream' | 'error' | 'finish', data: string) => void,
         options?: containerDesktopAPI.BuildImageOptions,
       ) {
-        const abortController = createAbortControllerOnCancellationToken(options?.token);
-
         return containerProviderRegistry.buildImage(
           context,
           eventCollect,
@@ -952,7 +953,7 @@ export class ExtensionLoader {
           options?.tag,
           options?.platform,
           options?.provider,
-          abortController,
+          createAbortControllerOnCancellationToken(options?.token),
         );
       },
       listImages(): Promise<containerDesktopAPI.ImageInfo[]> {
@@ -968,8 +969,13 @@ export class ExtensionLoader {
         authInfo: containerDesktopAPI.ContainerAuthInfo | undefined,
         token: containerDesktopAPI.CancellationToken | undefined,
       ): Promise<void> {
-        const abortController = createAbortControllerOnCancellationToken(token);
-        return containerProviderRegistry.pushImage(engineId, imageId, callback, authInfo, abortController);
+        return containerProviderRegistry.pushImage(
+          engineId,
+          imageId,
+          callback,
+          authInfo,
+          createAbortControllerOnCancellationToken(token),
+        );
       },
       pullImage(
         providerContainerConnection: containerDesktopAPI.ContainerProviderConnection,
@@ -977,8 +983,12 @@ export class ExtensionLoader {
         callback: (event: containerDesktopAPI.PullEvent) => void,
         token: containerDesktopAPI.CancellationToken | undefined,
       ): Promise<void> {
-        const abortController = createAbortControllerOnCancellationToken(token);
-        return containerProviderRegistry.pullImage(providerContainerConnection, imageName, callback, abortController);
+        return containerProviderRegistry.pullImage(
+          providerContainerConnection,
+          imageName,
+          callback,
+          createAbortControllerOnCancellationToken(token),
+        );
       },
       tagImage(engineId: string, imageId: string, repo: string, tag: string | undefined): Promise<void> {
         return containerProviderRegistry.tagImage(engineId, imageId, repo, tag);
@@ -989,8 +999,11 @@ export class ExtensionLoader {
       getImageInspect(engineId: string, id: string): Promise<ImageInspectInfo> {
         return containerProviderRegistry.getImageInspect(engineId, id);
       },
-      info(engineId: string): Promise<containerDesktopAPI.ContainerEngineInfo> {
-        return containerProviderRegistry.info(engineId);
+      info(
+        engineId: string,
+        token?: containerDesktopAPI.CancellationToken,
+      ): Promise<containerDesktopAPI.ContainerEngineInfo> {
+        return containerProviderRegistry.info(engineId, createAbortControllerOnCancellationToken(token));
       },
       onEvent: (listener, thisArg, disposables) => {
         return containerProviderRegistry.onEvent(listener, thisArg, disposables);
@@ -1002,7 +1015,11 @@ export class ExtensionLoader {
         providerContainerConnection: containerDesktopAPI.ContainerProviderConnection,
         networkCreateOptions: containerDesktopAPI.NetworkCreateOptions,
       ): Promise<containerDesktopAPI.NetworkCreateResult> {
-        return containerProviderRegistry.createNetwork(providerContainerConnection, networkCreateOptions);
+        return containerProviderRegistry.createNetwork(
+          providerContainerConnection,
+          networkCreateOptions,
+          createAbortControllerOnCancellationToken(networkCreateOptions?.token),
+        );
       },
       listVolumes(): Promise<containerDesktopAPI.VolumeListInfo[]> {
         return containerProviderRegistry.listVolumes();
@@ -1016,7 +1033,10 @@ export class ExtensionLoader {
         return containerProviderRegistry.deleteVolume(volumeName, options);
       },
       createPod(podOptions: containerDesktopAPI.PodCreateOptions): Promise<{ engineId: string; Id: string }> {
-        return containerProviderRegistry.createPod(podOptions);
+        return containerProviderRegistry.createPod(
+          podOptions,
+          createAbortControllerOnCancellationToken(podOptions?.token),
+        );
       },
       replicatePodmanContainer(
         source: { engineId: string; id: string },
@@ -1025,8 +1045,8 @@ export class ExtensionLoader {
       ): Promise<{ Id: string; Warnings: string[] }> {
         return containerProviderRegistry.replicatePodmanContainer(source, target, overrideParameters);
       },
-      startPod(engineId: string, podId: string): Promise<void> {
-        return containerProviderRegistry.startPod(engineId, podId);
+      startPod(engineId: string, podId: string, token?: containerDesktopAPI.CancellationToken): Promise<void> {
+        return containerProviderRegistry.startPod(engineId, podId, createAbortControllerOnCancellationToken(token));
       },
     };
 

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -931,8 +931,9 @@ export class ExtensionLoader {
         const abortController = createAbortControllerOnCancellationToken(token);
         return containerProviderRegistry.logsContainer(engineId, id, callback, abortController);
       },
-      stopContainer(engineId: string, id: string) {
-        return containerProviderRegistry.stopContainer(engineId, id);
+      stopContainer(engineId: string, id: string, token: containerDesktopAPI.CancellationToken | undefined) {
+        const abortController = createAbortControllerOnCancellationToken(token);
+        return containerProviderRegistry.stopContainer(engineId, id, abortController);
       },
       deleteContainer(engineId: string, id: string) {
         return containerProviderRegistry.deleteContainer(engineId, id);


### PR DESCRIPTION
## What does this PR do?

### Api changes

Fixes https://github.com/containers/podman-desktop/issues/5651

- `CancellationTokenSource` is now a `class` instantiable, instead of an `interface`

### `extension-api` changes

Continue the work started with https://github.com/containers/podman-desktop/pull/4364

List of methods supporting _cancellable_

- [x] listContainers
- [ ] inspectContainer (⚠️ issue with `Dockerode.Container.inspect` typing missing `signalAbort`) 
> It is supported see [dockerode/lib/container.js#L55](https://github.com/apocas/dockerode/blob/54b3fb43d7682f2a8091a6199126fb6b7ed715a4/lib/container.js#L55)
- [x] createContainer
- [x] startContainer
- [x] logsContainer
- [x] stopContainer
- [x] deleteContainer
- [x] buildImage
- [ ] saveImage (❌ cannot be made cancellable)
- [ ] listImages (⚠️ issue with `Dockerode.ListImagesOptions` typing missing `signalAbort`)
> It is supported see [dockerode/lib/docker.js#L450](https://github.com/apocas/dockerode/blob/54b3fb43d7682f2a8091a6199126fb6b7ed715a4/lib/docker.js#L450)
- [x] pushImage
- [x] pullImage
- [ ] tagImage (⚠️ issue with `Dockerode.Image.tag` typing missing `signalAbort`)
> It is supported see [dockerode/lib/image.js#L210](https://github.com/apocas/dockerode/blob/54b3fb43d7682f2a8091a6199126fb6b7ed715a4/lib/image.js#L210)
- [ ] deleteImage (⚠️ issue with `Dockerode.ImageRemoveOptions` typing missing `signalAbort`)
> It is supported see [dockerode/lib/image.js#L249](https://github.com/apocas/dockerode/blob/54b3fb43d7682f2a8091a6199126fb6b7ed715a4/lib/image.js#L249)
- [ ] getImageInspect (❌ not supported)
> not supported [dockerode/lib/image.js#L20](https://github.com/apocas/dockerode/blob/54b3fb43d7682f2a8091a6199126fb6b7ed715a4/lib/image.js#L20)
- [x] info
- [x] onEvent (already provide `disposable`)
- [ ] listNetworks (⚠️ issue with `Dockerode.listNetworks` typing missing `signalAbort`)
> It is supported see [dockerode/lib/docker.js#L1208](https://github.com/apocas/dockerode/blob/54b3fb43d7682f2a8091a6199126fb6b7ed715a4/lib/docker.js#L1208)
- [x] createNetwork 
- [ ] listVolumes (⚠️ issue with `Dockerode.listContainers` typing missing `signalAbort`)
> It is supported see [dockerode/lib/docker.js#L1132](https://github.com/apocas/dockerode/blob/54b3fb43d7682f2a8091a6199126fb6b7ed715a4/lib/docker.js#L1132)
- [ ] createVolume (⚠️ issue with `Dockerode.VolumeCreateOptions` typing missing `signalAbort`)
> It is supported see [dockerode/lib/docker.js#L1045](https://github.com/apocas/dockerode/blob/54b3fb43d7682f2a8091a6199126fb6b7ed715a4/lib/docker.js#L1045)
- [ ] deleteVolume (⚠️ issue with `Dockerode.Volume.remove` typing missing `signalAbort`)
> It is supported see [dockerode/lib/volume.js#L64](https://github.com/apocas/dockerode/blob/54b3fb43d7682f2a8091a6199126fb6b7ed715a4/lib/volume.js#L64)
- [x] createPod 
- [ ] replicatePodmanContainer (⚠️ depends on `getContainerInspect`)
- [x] startPod
