### PR TITLE
chore: volume status

### DIFF
--- a/packages/renderer/src/lib/volume/VolumeActions.svelte
+++ b/packages/renderer/src/lib/volume/VolumeActions.svelte
@@ -11,6 +11,6 @@ async function removeVolume(): Promise<void> {
 }
 </script>
 
-{#if !volume.inUse}
+{#if volume.status === 'UNUSED'}
   <ListItemButtonIcon title="Delete Volume" onClick="{() => removeVolume()}" detailed="{detailed}" icon="{faTrash}" />
 {/if}

--- a/packages/renderer/src/lib/volume/VolumeColumnEnvironment.spec.ts
+++ b/packages/renderer/src/lib/volume/VolumeColumnEnvironment.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,7 +37,7 @@ test('Expect simple column styling', async () => {
     engineId: '',
     engineName: 'my-engine',
     selected: false,
-    inUse: false,
+    status: 'UNUSED',
     containersUsage: [],
   };
   render(VolumeColumnEnvironment, { object: volume });

--- a/packages/renderer/src/lib/volume/VolumeColumnName.spec.ts
+++ b/packages/renderer/src/lib/volume/VolumeColumnName.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,7 +38,7 @@ const volume: VolumeInfoUI = {
   engineId: 'engine-id',
   engineName: '',
   selected: false,
-  inUse: false,
+  status: 'UNUSED',
   containersUsage: [],
 };
 

--- a/packages/renderer/src/lib/volume/VolumeColumnStatus.spec.ts
+++ b/packages/renderer/src/lib/volume/VolumeColumnStatus.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,12 +37,12 @@ test('Expect simple column styling', async () => {
     engineId: '',
     engineName: '',
     selected: false,
-    inUse: true,
+    status: 'USED',
     containersUsage: [],
   };
   render(VolumeColumnStatus, { object: volume });
 
-  const text = screen.getByRole('status');
-  expect(text).toBeInTheDocument();
-  expect(text).toHaveClass('bg-green-400');
+  const status = screen.getByRole('status');
+  expect(status).toBeInTheDocument();
+  expect(status).toHaveClass('bg-green-400');
 });

--- a/packages/renderer/src/lib/volume/VolumeColumnStatus.svelte
+++ b/packages/renderer/src/lib/volume/VolumeColumnStatus.svelte
@@ -6,4 +6,4 @@ import type { VolumeInfoUI } from './VolumeInfoUI';
 export let object: VolumeInfoUI;
 </script>
 
-<StatusIcon icon="{VolumeIcon}" status="{object.inUse ? 'USED' : 'UNUSED'}" />
+<StatusIcon icon="{VolumeIcon}" status="{object.status}" />

--- a/packages/renderer/src/lib/volume/VolumeDetails.svelte
+++ b/packages/renderer/src/lib/volume/VolumeDetails.svelte
@@ -40,7 +40,7 @@ onMount(() => {
 
 {#if volume}
   <DetailsPage title="{volume.shortName}" subtitle="{volume.humanSize}" bind:this="{detailsPage}">
-    <StatusIcon slot="icon" icon="{VolumeIcon}" size="{24}" status="{volume.inUse ? 'USED' : 'UNUSED'}" />
+    <StatusIcon slot="icon" icon="{VolumeIcon}" size="{24}" status="{volume.status}" />
     <VolumeActions slot="actions" volume="{volume}" detailed="{true}" />
     <svelte:fragment slot="tabs">
       <Tab title="Summary" url="summary" />

--- a/packages/renderer/src/lib/volume/VolumeInfoUI.ts
+++ b/packages/renderer/src/lib/volume/VolumeInfoUI.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2022 Red Hat, Inc.
+ * Copyright (C) 2022-2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,6 @@ export interface VolumeInfoUI {
   engineId: string;
   engineName: string;
   selected: boolean;
-  inUse: boolean;
+  status: 'USED' | 'UNUSED';
   containersUsage: { id: string; names: string[] }[];
 }

--- a/packages/renderer/src/lib/volume/VolumesList.svelte
+++ b/packages/renderer/src/lib/volume/VolumesList.svelte
@@ -176,7 +176,7 @@ let statusColumn = new Column<VolumeInfoUI>('Status', {
   align: 'center',
   width: '70px',
   renderer: VolumeColumnStatus,
-  comparator: (a, b) => Number(b.inUse) - Number(a.inUse),
+  comparator: (a, b) => b.status.localeCompare(a.status),
 });
 
 let nameColumn = new Column<VolumeInfoUI>('Name', {
@@ -214,7 +214,7 @@ const columns: Column<VolumeInfoUI, VolumeInfoUI | string>[] = [
 ];
 
 const row = new Row<VolumeInfoUI>({
-  selectable: volume => !volume.inUse,
+  selectable: volume => volume.status === 'UNUSED',
   disabledText: 'Volume is used by a container',
 });
 </script>

--- a/packages/renderer/src/lib/volume/volume-utils.ts
+++ b/packages/renderer/src/lib/volume/volume-utils.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2022 Red Hat, Inc.
+ * Copyright (C) 2022-2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -75,7 +75,7 @@ export class VolumeUtils {
       engineId: volumeInfo.engineId,
       engineName: volumeInfo.engineName,
       selected: false,
-      inUse: (volumeInfo.UsageData?.RefCount || 0) > 0,
+      status: (volumeInfo.UsageData?.RefCount || 0) > 0 ? 'USED' : 'UNUSED',
       containersUsage: volumeInfo.containersUsage,
     };
   }


### PR DESCRIPTION
### What does this PR do?

Like #5528, volumes have an inUse flag that we use to determine which status icon to show or whether the image is deletable. However, that means we cannot have other states like deleting or new.

This changes images to have a status the same as most other types (e.g. pods, containers, deployments). This will allow future PRs to add additional states (e.g. deleting) and UI updates, e.g. so that you see a spinner if an image takes a second to delete.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Step toward #5614.

### How to test this PR?

Just PR checks, no regression to status icon or delete actions.