### PR TITLE
chore: rename release notes

### DIFF
--- a/website/blog/2023-05-17-release-1.0.md
+++ b/website/blog/2023-05-17-release-1.0.md
@@ -1,5 +1,5 @@
 ---
-title: Release Notes - Podman Desktop 1.0
+title: Podman Desktop 1.0 Release
 description: Podman Desktop 1.0 has been released!
 slug: podman-desktop-release-1.0
 authors: [deboer]

--- a/website/blog/2023-06-08-release-1.1.md
+++ b/website/blog/2023-06-08-release-1.1.md
@@ -1,5 +1,5 @@
 ---
-title: Release Notes - Podman Desktop 1.1
+title: Podman Desktop 1.1 Release
 description: Podman Desktop 1.1 has been released!
 slug: podman-desktop-release-1.1
 authors: [deboer]

--- a/website/blog/2023-07-12-release-1.2.md
+++ b/website/blog/2023-07-12-release-1.2.md
@@ -1,5 +1,5 @@
 ---
-title: Release Notes - Podman Desktop 1.2
+title: Podman Desktop 1.2 Release
 description: Podman Desktop 1.2 has been released!
 slug: podman-desktop-release-1.2
 authors: [cdrage]

--- a/website/blog/2023-08-16-release-1.3.md
+++ b/website/blog/2023-08-16-release-1.3.md
@@ -1,5 +1,5 @@
 ---
-title: Release Notes - Podman Desktop 1.3
+title: Podman Desktop 1.3 Release
 description: Podman Desktop 1.3 has been released!
 slug: podman-desktop-release-1.3
 authors: [dgolovin]

--- a/website/blog/2023-09-18-release-1.4.md
+++ b/website/blog/2023-09-18-release-1.4.md
@@ -1,5 +1,5 @@
 ---
-title: Release Notes - Podman Desktop 1.4
+title: Podman Desktop 1.4 Release
 description: Podman Desktop 1.4 has been released!
 slug: podman-desktop-release-1.4
 authors: [jeffmaury]

--- a/website/blog/2023-11-03-release-1.5.md
+++ b/website/blog/2023-11-03-release-1.5.md
@@ -1,5 +1,5 @@
 ---
-title: Release Notes - Podman Desktop 1.5
+title: Podman Desktop 1.5 Release
 description: Podman Desktop 1.5 has been released!
 slug: podman-desktop-release-1.5
 authors: duffy

--- a/website/blog/2023-12-18-release-1.6.md
+++ b/website/blog/2023-12-18-release-1.6.md
@@ -1,5 +1,5 @@
 ---
-title: Release Notes - Podman Desktop 1.6
+title: Podman Desktop 1.6 Release
 description: Podman Desktop 1.6 has been released!
 slug: podman-desktop-release-1.6
 authors: slemeur

--- a/website/blog/2024-01-24-release-1.7.md
+++ b/website/blog/2024-01-24-release-1.7.md
@@ -1,5 +1,5 @@
 ---
-title: Release Notes - Podman Desktop 1.7
+title: Podman Desktop 1.7 Release
 description: Podman Desktop 1.7 has been released!
 slug: podman-desktop-release-1.7
 authors: deboer


### PR DESCRIPTION
### What does this PR do?

The release was only out for 15 minutes but something was already nagging. ;-)

Yes, these are release notes, but 'Release Notes - Podman Desktop X' is long and we're mostly using these blogs posts as announcements. Isn't 'Podman Desktop X Release' shorter and easier to read?

The slug/url doesn't change, so shouldn't be a breaking change, and I went back as far as 1.0 to keep things consistent.

### Screenshot / video of UI

Before:

<img width="1069" alt="Screenshot 2024-01-25 at 4 11 18 PM" src="https://github.com/containers/podman-desktop/assets/19958075/684c8395-bb86-4f0c-8caa-d86f46230b3b">

After:

<img width="1069" alt="Screenshot 2024-01-25 at 4 09 54 PM" src="https://github.com/containers/podman-desktop/assets/19958075/4efcd4e6-fb2e-4793-8fde-91a67a9eb93b">

### What issues does this PR fix or reference?

N/A

### How to test this PR?

PR checks or `yarn website:dev`