### PR TITLE
refactor: dialog box moving from 'no' to 'cancel'

### DIFF
--- a/packages/renderer/src/lib/engine/Prune.svelte
+++ b/packages/renderer/src/lib/engine/Prune.svelte
@@ -20,7 +20,7 @@ async function openPruneDialog(): Promise<void> {
   const result = await window.showMessageBox({
     title: 'Prune',
     message: message,
-    buttons: ['Yes', 'No'],
+    buttons: ['Yes', 'Cancel'],
   });
 
   if (result && result.response === 0) {

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
@@ -27,7 +27,7 @@ async function handleDeleteContext(contextName: string) {
       title: 'Delete Context',
       message:
         'You will delete the current context. If you delete it, you will need to switch to another context. Continue?',
-      buttons: ['Yes', 'No'],
+      buttons: ['Yes', 'Cancel'],
     });
     if (result.response !== 0) {
       return;

--- a/packages/renderer/src/lib/preferences/PreferencesRegistriesEditing.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRegistriesEditing.svelte
@@ -198,7 +198,7 @@ async function loginToRegistry(registry: containerDesktopAPI.Registry) {
         title: 'Invalid Certificate',
         type: 'warning',
         message: 'The certificate for this registry is not trusted / verifiable. Would you like to still add it?',
-        buttons: ['Yes', 'No'],
+        buttons: ['Yes', 'Cancel'],
       });
       if (result && result.response === 0) {
         registry.insecure = true;

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingRepairCleanup.spec.ts
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingRepairCleanup.spec.ts
@@ -65,7 +65,7 @@ test('Check cleanupProviders is called and button is in progress', async () => {
 
   // check that we asked for confirmation
   expect(showMessageBoxMock).toBeCalledWith({
-    buttons: ['Yes', 'No'],
+    buttons: ['Yes', 'Cancel'],
     message: 'This action may delete data. Proceed ?',
     title: 'Cleanup',
   });
@@ -95,7 +95,7 @@ test('Check errors are displayed with clipboard button', async () => {
 
   // check that we asked for confirmation
   expect(showMessageBoxMock).toBeCalledWith({
-    buttons: ['Yes', 'No'],
+    buttons: ['Yes', 'Cancel'],
     message: 'This action may delete data. Proceed ?',
     title: 'Cleanup',
   });

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingRepairCleanup.svelte
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingRepairCleanup.svelte
@@ -18,7 +18,7 @@ async function openCleanupDialog(): Promise<void> {
   const result = await window.showMessageBox({
     title: 'Cleanup',
     message: message,
-    buttons: ['Yes', 'No'],
+    buttons: ['Yes', 'Cancel'],
   });
 
   if (result?.response === 0) {


### PR DESCRIPTION
Move from No to Cancel to keep a standard approach when showing users a dialog

### What does this PR do?

The PR proposes using the word "cancel" instead of the word "no".

### Screenshot / video of UI

no screenshots

### What issues does this PR fix or reference?

Fixes #5446

### How to test this PR?

1) Check the dialogs boxes and verify if they contains "Cancel" instead of "No"