### PR TITLE
fix: removing dependency between ConfigurationRegistry and NotificationRegistry

### DIFF
--- a/packages/main/src/plugin/autostart-engine.spec.ts
+++ b/packages/main/src/plugin/autostart-engine.spec.ts
@@ -25,7 +25,6 @@ import { AutostartEngine } from './autostart-engine.js';
 import type { Configuration } from '@podman-desktop/api';
 import { CONFIGURATION_DEFAULT_SCOPE, CONFIGURATION_ONBOARDING_SCOPE } from './configuration-registry-constants.js';
 import type { ApiSenderType } from '/@/plugin/api.js';
-import type { NotificationRegistry } from './notification-registry.js';
 
 let configurationRegistry: ConfigurationRegistry;
 let providerRegistry: ProviderRegistry;
@@ -43,7 +42,7 @@ beforeEach(() => {
 
 /* eslint-disable @typescript-eslint/no-empty-function */
 beforeAll(() => {
-  configurationRegistry = new ConfigurationRegistry({} as ApiSenderType, {} as Directories, {} as NotificationRegistry);
+  configurationRegistry = new ConfigurationRegistry({} as ApiSenderType, {} as Directories);
   providerRegistry = {} as unknown as ProviderRegistry;
   autostartEngine = new AutostartEngine(configurationRegistry, providerRegistry);
   configurationRegistry.registerConfigurations = mockRegisterConfiguration;

--- a/packages/main/src/plugin/close-behavior.spec.ts
+++ b/packages/main/src/plugin/close-behavior.spec.ts
@@ -21,7 +21,6 @@ import { ConfigurationRegistry } from './configuration-registry.js';
 import * as util from '../util.js';
 import type { Directories } from './directories.js';
 import type { ApiSenderType } from '/@/plugin/api.js';
-import type { NotificationRegistry } from './notification-registry.js';
 
 vi.mock('./util', () => {
   return {
@@ -33,7 +32,7 @@ let closeBehavior: CloseBehavior;
 let configurationRegistry: ConfigurationRegistry;
 
 beforeEach(() => {
-  configurationRegistry = new ConfigurationRegistry({} as ApiSenderType, {} as Directories, {} as NotificationRegistry);
+  configurationRegistry = new ConfigurationRegistry({} as ApiSenderType, {} as Directories);
   closeBehavior = new CloseBehavior(configurationRegistry);
 });
 

--- a/packages/main/src/plugin/configuration-registry.spec.ts
+++ b/packages/main/src/plugin/configuration-registry.spec.ts
@@ -55,7 +55,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   getConfigurationDirectoryMock.mockReturnValue('/my-config-dir');
 
-  configurationRegistry = new ConfigurationRegistry(apiSender, directories, notificationRegistry);
+  configurationRegistry = new ConfigurationRegistry(apiSender, directories);
   readFileSync.mockReturnValue(JSON.stringify({}));
 
   cpSync.mockReturnValue(undefined);
@@ -172,7 +172,7 @@ test('should work with an invalid configuration file', async () => {
 
   getConfigurationDirectoryMock.mockReturnValue('/my-config-dir');
 
-  configurationRegistry = new ConfigurationRegistry(apiSender, directories, notificationRegistry);
+  configurationRegistry = new ConfigurationRegistry(apiSender, directories);
   readFileSync.mockReturnValue('invalid JSON content');
 
   // configuration is broken but it should not throw any error, just that config is empty
@@ -180,7 +180,7 @@ test('should work with an invalid configuration file', async () => {
   const mockedConsoleLog = vi.fn();
   console.error = mockedConsoleLog;
   try {
-    configurationRegistry.init();
+    configurationRegistry.init().forEach(notification => notificationRegistry.addNotification(notification));
   } finally {
     console.error = originalConsoleError;
   }

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -377,6 +377,8 @@ export class PluginSystem {
 
   // initialize extension loader mechanism
   async initExtensions(): Promise<ExtensionLoader> {
+    const notifications: NotificationCardOptions[] = [];
+
     this.isReady = false;
     this.uiReady = false;
     this.ipcHandle('extension-system:isReady', async (): Promise<boolean> => {
@@ -399,8 +401,8 @@ export class PluginSystem {
     const taskManager = new TaskManager(apiSender);
     const notificationRegistry = new NotificationRegistry(apiSender, taskManager);
 
-    const configurationRegistry = new ConfigurationRegistry(apiSender, directories, notificationRegistry);
-    configurationRegistry.init();
+    const configurationRegistry = new ConfigurationRegistry(apiSender, directories);
+    notifications.push(...configurationRegistry.init());
 
     const proxy = new Proxy(configurationRegistry);
     await proxy.init();
@@ -444,6 +446,9 @@ export class PluginSystem {
       const trayIconColor = new TrayIconColor(configurationRegistry, providerRegistry);
       await trayIconColor.init();
     }
+
+    // Add all notifications to notification registry
+    notifications.forEach(notification => notificationRegistry.addNotification(notification));
 
     kubeGeneratorRegistry.registerDefaultKubeGenerator({
       name: 'PodmanKube',

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -449,7 +449,8 @@ export class PluginSystem {
 
     // Add all notifications to notification registry
     notifications.forEach(notification => notificationRegistry.addNotification(notification));
-
+notifications.length = 0;
+Object.freeze(notifications);
     kubeGeneratorRegistry.registerDefaultKubeGenerator({
       name: 'PodmanKube',
       types: ['Compose', 'Container', 'Pod'],

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -449,8 +449,8 @@ export class PluginSystem {
 
     // Add all notifications to notification registry
     notifications.forEach(notification => notificationRegistry.addNotification(notification));
-notifications.length = 0;
-Object.freeze(notifications);
+    notifications.length = 0;
+    Object.freeze(notifications);
     kubeGeneratorRegistry.registerDefaultKubeGenerator({
       name: 'PodmanKube',
       types: ['Compose', 'Container', 'Pod'],


### PR DESCRIPTION
### What does this PR do?

Remove the direct dependencies between the ConfigurationRegistry and NotificationRegistry.

Reference: https://github.com/containers/podman-desktop/pull/5689#issuecomment-1910333126

### How to test this PR?

- [x] Unit tests have been adapted
