### PR TITLE
feat: volume deletion

### DIFF
--- a/packages/renderer/src/lib/volume/VolumeActions.spec.ts
+++ b/packages/renderer/src/lib/volume/VolumeActions.spec.ts
@@ -1,0 +1,55 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+import { test, expect, vi, beforeAll } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/svelte';
+import VolumeActions from './VolumeActions.svelte';
+import type { VolumeInfoUI } from './VolumeInfoUI';
+
+const showMessageBoxMock = vi.fn();
+const removeVolumeMock = vi.fn();
+
+beforeAll(() => {
+  (window as any).showMessageBox = showMessageBoxMock;
+  (window as any).removeVolume = removeVolumeMock;
+});
+
+test('Expect prompt dialog and deletion', async () => {
+  // Mock the showMessageBox to return 0 (yes)
+  showMessageBoxMock.mockResolvedValue({ response: 0 });
+
+  const volume: VolumeInfoUI = {
+    name: 'dummy',
+    status: 'UNUSED',
+  } as VolumeInfoUI;
+
+  render(VolumeActions, {
+    volume,
+  });
+  const button = screen.getByTitle('Delete Volume');
+  expect(button).toBeDefined();
+  await fireEvent.click(button);
+
+  await waitFor(() => {
+    expect(showMessageBoxMock).toHaveBeenCalledOnce();
+  });
+
+  expect(volume.status).toBe('DELETING');
+  expect(removeVolumeMock).toHaveBeenCalled();
+});

--- a/packages/renderer/src/lib/volume/VolumeActions.svelte
+++ b/packages/renderer/src/lib/volume/VolumeActions.svelte
@@ -2,11 +2,17 @@
 import { faTrash } from '@fortawesome/free-solid-svg-icons';
 import type { VolumeInfoUI } from './VolumeInfoUI';
 import ListItemButtonIcon from '../ui/ListItemButtonIcon.svelte';
+import { createEventDispatcher } from 'svelte';
 
 export let volume: VolumeInfoUI;
 export let detailed = false;
 
+const dispatch = createEventDispatcher<{ update: VolumeInfoUI }>();
+
 async function removeVolume(): Promise<void> {
+  volume.status = 'DELETING';
+  dispatch('update', volume);
+
   await window.removeVolume(volume.engineId, volume.name);
 }
 </script>

--- a/packages/renderer/src/lib/volume/VolumeColumnActions.svelte
+++ b/packages/renderer/src/lib/volume/VolumeColumnActions.svelte
@@ -5,4 +5,4 @@ import type { VolumeInfoUI } from './VolumeInfoUI';
 export let object: VolumeInfoUI;
 </script>
 
-<VolumeActions volume="{object}" />
+<VolumeActions volume="{object}" on:update />

--- a/packages/renderer/src/lib/volume/VolumeDetails.svelte
+++ b/packages/renderer/src/lib/volume/VolumeDetails.svelte
@@ -41,7 +41,7 @@ onMount(() => {
 {#if volume}
   <DetailsPage title="{volume.shortName}" subtitle="{volume.humanSize}" bind:this="{detailsPage}">
     <StatusIcon slot="icon" icon="{VolumeIcon}" size="{24}" status="{volume.status}" />
-    <VolumeActions slot="actions" volume="{volume}" detailed="{true}" />
+    <VolumeActions slot="actions" volume="{volume}" detailed="{true}" on:update="{() => (volume = volume)}" />
     <svelte:fragment slot="tabs">
       <Tab title="Summary" url="summary" />
       <Tab title="Inspect" url="inspect" />

--- a/packages/renderer/src/lib/volume/VolumeInfoUI.ts
+++ b/packages/renderer/src/lib/volume/VolumeInfoUI.ts
@@ -29,6 +29,6 @@ export interface VolumeInfoUI {
   engineId: string;
   engineName: string;
   selected: boolean;
-  status: 'USED' | 'UNUSED';
+  status: 'USED' | 'UNUSED' | 'DELETING';
   containersUsage: { id: string; names: string[] }[];
 }

--- a/packages/renderer/src/lib/volume/VolumesList.svelte
+++ b/packages/renderer/src/lib/volume/VolumesList.svelte
@@ -254,7 +254,8 @@ const row = new Row<VolumeInfoUI>({
       data="{volumes}"
       columns="{columns}"
       row="{row}"
-      defaultSortColumn="Name">
+      defaultSortColumn="Name"
+      on:update="{() => (volumes = volumes)}">
     </Table>
 
     {#if providerConnections.length === 0}


### PR DESCRIPTION
### What does this PR do?

Adds the 'DELETING' state to volumes so that a spinner appears while they are being deleted. Follows the identical pattern to pods, deployments, etc:
- Add new status.
- Set the status when deleting and fire an event.
- Propogate event through ColumnActions.
- List/Details trigger UI change.

Adds missing volume action test.

### Screenshot / video of UI

https://github.com/containers/podman-desktop/assets/19958075/bbc6dd32-76ff-42c8-b9b1-cffb2cf336e9

### What issues does this PR fix or reference?

Fixes #5614.

### How to test this PR?

Create a volume, then delete it.