### PR TITLE
style: do not hide terminal when there are errors

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.spec.ts
@@ -27,9 +27,9 @@ import { router } from 'tinro';
 import PreferencesConnectionCreationOrEditRendering from './PreferencesConnectionCreationOrEditRendering.svelte';
 import type { IConfigurationPropertyRecordedSchema } from '../../../../main/src/plugin/configuration-registry';
 import type { ProviderInfo, ProviderContainerConnectionInfo } from '../../../../main/src/plugin/api/provider-info';
-import { get } from 'svelte/store';
 import { operationConnectionsInfo } from '/@/stores/operation-connections';
 import { eventCollect } from '/@/lib/preferences/preferences-connection-rendering-task';
+import { get } from 'svelte/store';
 
 type LoggerEventName = 'log' | 'warn' | 'error' | 'finish';
 
@@ -309,5 +309,27 @@ describe.each([
     expect(closeButton).not.toBeInTheDocument();
     const mainImage = screen.queryByLabelText('main image');
     expect(mainImage).not.toBeInTheDocument();
+  });
+
+  test('Expect Terminal Component to be acessible after error being thrown', async () => {
+    const callback = vi.fn();
+    callback.mockRejectedValue(new Error('error'));
+
+    // eslint-disable-next-line @typescript-eslint/await-thenable
+    const result = render(PreferencesConnectionCreationOrEditRendering, {
+      properties,
+      providerInfo,
+      connectionInfo,
+      propertyScope,
+      callback,
+      pageIsLoading: false,
+      taskId,
+    });
+    await vi.waitUntil(() => screen.queryByRole('textbox', { name: 'test.factoryProperty' }));
+    const createButton = screen.getByRole('button', { name: `${label}` });
+    expect(createButton).toBeInTheDocument();
+    await fireEvent.click(createButton);
+    const showLogsButton = screen.getByRole('button', { name: 'Show Logs' });
+    expect(showLogsButton).toBeInTheDocument();
   });
 });

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.svelte
@@ -420,7 +420,7 @@ function getConnectionResourceConfigurationValue(
           <Spinner size="2em" />
         </div>
       {:else}
-        {#if operationStarted}
+        {#if operationStarted || errorMessage}
           <div class="w-4/5">
             <div class="mt-2 mb-8">
               {#if inProgress}
@@ -452,7 +452,7 @@ function getConnectionResourceConfigurationValue(
           </div>
         {/if}
         {#if errorMessage}
-          <div class="w-4/5 mt-2">
+          <div class="pt-3 mt-2 w-4/5 h-fit">
             <ErrorMessage error="{errorMessage}" />
           </div>
         {/if}


### PR DESCRIPTION
### What does this PR do?

Keep the terminal component when errors occur

### Screenshot / video of UI

<img width="1031" alt="Screenshot 2024-01-26 at 15 22 51" src="https://github.com/containers/podman-desktop/assets/16507629/d1ee6ce9-eec8-4fb3-8eff-add5612ad250">

### What issues does this PR fix or reference?

Fixes #5688 

### How to test this PR?

1) Go to settings
2) Go to Resources
3) Find "Kind" and click on "Create new ..." button
4) Find the field "Node’s container image" and type anything there
5) Click Create