### PR TITLE
feat: multi-delete animation

### DIFF
--- a/packages/renderer/src/lib/deployments/DeploymentsList.svelte
+++ b/packages/renderer/src/lib/deployments/DeploymentsList.svelte
@@ -52,7 +52,7 @@ async function deleteSelectedDeployments() {
       try {
         await window.kubernetesDeleteDeployment(deployment.name);
       } catch (e) {
-        console.log('error while deleting deployment', e);
+        console.error('error while deleting deployment', e);
       }
     }),
   );

--- a/packages/renderer/src/lib/deployments/DeploymentsList.svelte
+++ b/packages/renderer/src/lib/deployments/DeploymentsList.svelte
@@ -38,20 +38,25 @@ onMount(() => {
 let bulkDeleteInProgress = false;
 async function deleteSelectedDeployments() {
   const selectedDeployments = deployments.filter(deployment => deployment.selected);
-
-  if (selectedDeployments.length > 0) {
-    bulkDeleteInProgress = true;
-    await Promise.all(
-      selectedDeployments.map(async deployment => {
-        try {
-          await window.kubernetesDeleteDeployment(deployment.name);
-        } catch (e) {
-          console.log('error while deleting deployment', e);
-        }
-      }),
-    );
-    bulkDeleteInProgress = false;
+  if (selectedDeployments.length === 0) {
+    return;
   }
+
+  // mark deployments for deletion
+  bulkDeleteInProgress = true;
+  selectedDeployments.forEach(image => (image.status = 'DELETING'));
+  deployments = deployments;
+
+  await Promise.all(
+    selectedDeployments.map(async deployment => {
+      try {
+        await window.kubernetesDeleteDeployment(deployment.name);
+      } catch (e) {
+        console.log('error while deleting deployment', e);
+      }
+    }),
+  );
+  bulkDeleteInProgress = false;
 }
 
 let selectedItemsNumber: number;

--- a/packages/renderer/src/lib/image/ImagesList.svelte
+++ b/packages/renderer/src/lib/image/ImagesList.svelte
@@ -172,7 +172,7 @@ async function deleteSelectedImages() {
   await selectedImages.reduce((prev: Promise<void>, image) => {
     return prev
       .then(() => imageUtils.deleteImage(image))
-      .catch((e: unknown) => console.log('error while removing image', e));
+      .catch((e: unknown) => console.error('error while removing image', e));
   }, Promise.resolve());
   bulkDeleteInProgress = false;
 }

--- a/packages/renderer/src/lib/image/ImagesList.svelte
+++ b/packages/renderer/src/lib/image/ImagesList.svelte
@@ -159,8 +159,16 @@ function gotoPullImage(): void {
 // delete the items selected in the list
 let bulkDeleteInProgress = false;
 async function deleteSelectedImages() {
-  bulkDeleteInProgress = true;
   const selectedImages = images.filter(image => image.selected);
+  if (selectedImages.length === 0) {
+    return;
+  }
+
+  // mark images for deletion
+  bulkDeleteInProgress = true;
+  selectedImages.forEach(image => (image.status = 'DELETING'));
+  images = images;
+
   await selectedImages.reduce((prev: Promise<void>, image) => {
     return prev
       .then(() => imageUtils.deleteImage(image))

--- a/packages/renderer/src/lib/ingresses-routes/IngressesRoutesList.svelte
+++ b/packages/renderer/src/lib/ingresses-routes/IngressesRoutesList.svelte
@@ -56,6 +56,14 @@ onDestroy(() => {
 let bulkDeleteInProgress = false;
 async function deleteSelectedIngressesRoutes() {
   const selectedIngressesRoutes = ingressesRoutesUI.filter(ingressesRoutesUI => ingressesRoutesUI.selected);
+  if (selectedIngressesRoutes.length === 0) {
+    return;
+  }
+
+  // mark ingress or route for deletion
+  bulkDeleteInProgress = true;
+  selectedIngressesRoutes.forEach(ingressRoute => (ingressRoute.status = 'DELETING'));
+  ingressesRoutesUI = ingressesRoutesUI;
 
   if (selectedIngressesRoutes.length > 0) {
     bulkDeleteInProgress = true;

--- a/packages/renderer/src/lib/ingresses-routes/IngressesRoutesList.svelte
+++ b/packages/renderer/src/lib/ingresses-routes/IngressesRoutesList.svelte
@@ -77,7 +77,7 @@ async function deleteSelectedIngressesRoutes() {
             await window.kubernetesDeleteRoute(ingressRoute.name);
           }
         } catch (e) {
-          console.log(`error while deleting ${isIngress ? 'ingress' : 'route'}`, e);
+          console.error(`error while deleting ${isIngress ? 'ingress' : 'route'}`, e);
         }
       }),
     );

--- a/packages/renderer/src/lib/pod/PodsList.svelte
+++ b/packages/renderer/src/lib/pod/PodsList.svelte
@@ -94,24 +94,29 @@ onDestroy(() => {
 let bulkDeleteInProgress = false;
 async function deleteSelectedPods() {
   const selectedPods = pods.filter(pod => pod.selected);
-
-  if (selectedPods.length > 0) {
-    bulkDeleteInProgress = true;
-    await Promise.all(
-      selectedPods.map(async pod => {
-        try {
-          if (pod.kind === 'podman') {
-            await window.removePod(pod.engineId, pod.id);
-          } else {
-            await window.kubernetesDeletePod(pod.name);
-          }
-        } catch (e) {
-          console.log('error while removing pod', e);
-        }
-      }),
-    );
-    bulkDeleteInProgress = false;
+  if (selectedPods.length === 0) {
+    return;
   }
+
+  // mark pods for deletion
+  bulkDeleteInProgress = true;
+  selectedPods.forEach(pod => (pod.status = 'DELETING'));
+  pods = pods;
+
+  await Promise.all(
+    selectedPods.map(async pod => {
+      try {
+        if (pod.kind === 'podman') {
+          await window.removePod(pod.engineId, pod.id);
+        } else {
+          await window.kubernetesDeletePod(pod.name);
+        }
+      } catch (e) {
+        console.log('error while removing pod', e);
+      }
+    }),
+  );
+  bulkDeleteInProgress = false;
 }
 
 let refreshTimeouts: NodeJS.Timeout[] = [];

--- a/packages/renderer/src/lib/pod/PodsList.svelte
+++ b/packages/renderer/src/lib/pod/PodsList.svelte
@@ -112,7 +112,7 @@ async function deleteSelectedPods() {
           await window.kubernetesDeletePod(pod.name);
         }
       } catch (e) {
-        console.log('error while removing pod', e);
+        console.error('error while removing pod', e);
       }
     }),
   );

--- a/packages/renderer/src/lib/service/ServicesList.svelte
+++ b/packages/renderer/src/lib/service/ServicesList.svelte
@@ -36,20 +36,25 @@ onMount(() => {
 let bulkDeleteInProgress = false;
 async function deleteSelectedServices() {
   const selectedServices = services.filter(service => service.selected);
-
-  if (selectedServices.length > 0) {
-    bulkDeleteInProgress = true;
-    await Promise.all(
-      selectedServices.map(async service => {
-        try {
-          await window.kubernetesDeleteService(service.name);
-        } catch (e) {
-          console.log('error while deleting service', e);
-        }
-      }),
-    );
-    bulkDeleteInProgress = false;
+  if (selectedServices.length === 0) {
+    return;
   }
+
+  // mark services for deletion
+  bulkDeleteInProgress = true;
+  selectedServices.forEach(service => (service.status = 'DELETING'));
+  services = services;
+
+  await Promise.all(
+    selectedServices.map(async service => {
+      try {
+        await window.kubernetesDeleteService(service.name);
+      } catch (e) {
+        console.log('error while deleting service', e);
+      }
+    }),
+  );
+  bulkDeleteInProgress = false;
 }
 
 let selectedItemsNumber: number;

--- a/packages/renderer/src/lib/service/ServicesList.svelte
+++ b/packages/renderer/src/lib/service/ServicesList.svelte
@@ -50,7 +50,7 @@ async function deleteSelectedServices() {
       try {
         await window.kubernetesDeleteService(service.name);
       } catch (e) {
-        console.log('error while deleting service', e);
+        console.error('error while deleting service', e);
       }
     }),
   );

--- a/packages/renderer/src/lib/volume/VolumesList.svelte
+++ b/packages/renderer/src/lib/volume/VolumesList.svelte
@@ -94,19 +94,25 @@ let bulkDeleteInProgress = false;
 async function deleteSelectedVolumes() {
   const selectedVolumes = volumes.filter(volume => volume.selected);
 
-  if (selectedVolumes.length > 0) {
-    bulkDeleteInProgress = true;
-    await Promise.all(
-      selectedVolumes.map(async volume => {
-        try {
-          await window.removeVolume(volume.engineId, volume.name);
-        } catch (e) {
-          console.log('error while removing volume', e);
-        }
-      }),
-    );
-    bulkDeleteInProgress = false;
+  if (selectedVolumes.length === 0) {
+    return;
   }
+
+  // mark volumes for deletion
+  bulkDeleteInProgress = true;
+  selectedVolumes.forEach(volume => (volume.status = 'DELETING'));
+  volumes = volumes;
+
+  await Promise.all(
+    selectedVolumes.map(async volume => {
+      try {
+        await window.removeVolume(volume.engineId, volume.name);
+      } catch (e) {
+        console.log('error while removing volume', e);
+      }
+    }),
+  );
+  bulkDeleteInProgress = false;
 }
 
 let refreshTimeouts: NodeJS.Timeout[] = [];

--- a/packages/renderer/src/lib/volume/VolumesList.svelte
+++ b/packages/renderer/src/lib/volume/VolumesList.svelte
@@ -108,7 +108,7 @@ async function deleteSelectedVolumes() {
       try {
         await window.removeVolume(volume.engineId, volume.name);
       } catch (e) {
-        console.log('error while removing volume', e);
+        console.error('error while removing volume', e);
       }
     }),
   );


### PR DESCRIPTION
### What does this PR do?

When you delete multiple objects at once, the delete button would show as in progress, but each object you're deleting didn't have any spinner like it does when you click the object's delete button (except the containers list, which marked containers for deletion but not pods).

This makes the bulk delete actions a little more consistent:
- exit if there's nothing being deleted
- mark everything as being deleted
- do the deletion

Also fixes a case in container list where the bulk delete wouldn't start (so the button wouldn't go in-progress) until after deleting pods.

### Screenshot / video of UI

Before:

https://github.com/containers/podman-desktop/assets/19958075/9c25d78c-6ed3-483d-8613-a6da4a2c7ce4

After:

https://github.com/containers/podman-desktop/assets/19958075/fc476482-bb19-432a-9d45-30f3336d92e3

### What issues does this PR fix or reference?

Fixes #5615.

### How to test this PR?

Create and delete lots of objects.