### PR TITLE
chore: long usernames in auth page

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesAuthenticationProvidersRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesAuthenticationProvidersRendering.svelte
@@ -78,8 +78,8 @@ import Tooltip from '/@/lib/ui/Tooltip.svelte';
                 {#each provider.accounts as account}
                   <div class="flex flex-row">
                     <div class="flex items-center w-full">
-                      <div class="text-xs bg-charcoal-800 p-2 rounded-lg mt-1">
-                        <span class="my-auto font-bold col-span-1 text-right">
+                      <div class="flex flex-row text-xs bg-charcoal-800 p-2 rounded-lg mt-1">
+                        <span class="my-auto font-bold col-span-1 text-ellipsis overflow-hidden max-w-64">
                           {account.label}
                         </span>
                         <Tooltip tip="Sign out of {account.label}" left>


### PR DESCRIPTION
### What does this PR do?

While testing #5670 I noticed that the auth page has an identical issue with long usernames. This just uses a flex row and the same 'text-ellipsis overflow-hidden max-w-64' to ensure long usernames don't cause UI issues.

### Screenshot / video of UI

Before:

<img width="753" alt="Screenshot 2024-01-29 at 10 19 32 AM" src="https://github.com/containers/podman-desktop/assets/19958075/2c7afdbd-8db4-47ea-ac5d-697e81059150">

After:

<img width="753" alt="Screenshot 2024-01-29 at 10 10 59 AM" src="https://github.com/containers/podman-desktop/assets/19958075/1c7a10dd-db87-4f99-82cc-1f1be92cf662">

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Have a very long username, or edit line 83 with junk to simulate one.