### PR TITLE
fix: force breadcrumbs to be vertically aligned

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -158,3 +158,12 @@ li.footer__item a svg {
     font-size: 1.2em;
   }
 }
+
+.breadcrumbs {
+  display: flex;
+}
+
+.breadcrumbs__item {
+  display: flex;
+  align-items: center;
+}


### PR DESCRIPTION
### What does this PR do?

hotfix on the css

### Screenshot / video of UI

| Before | After |
| --- | --- |
| ![image](https://github.com/containers/podman-desktop/assets/42176370/b6458ca1-8cbe-4c0b-ba66-690d68c6cf80) | ![image](https://github.com/containers/podman-desktop/assets/42176370/e7cc7aee-20ba-47e9-a9e5-ce49a9e0ebd9) |


### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop/issues/5740

### How to test this PR?

<!-- Please explain steps to reproduce -->
