### PR TITLE
chore: fix style of download button when we can't detect OS

### DIFF
--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -67,11 +67,13 @@ function DownloadClientLinks() {
     );
   } else {
     mainButton = (
-      <Link
-        className="no-underline hover:no-underline inline-flex text-white hover:text-white bg-indigo-500 border-0 py-2 px-6 focus:outline-none hover:bg-indigo-600 rounded text-lg"
-        to="/downloads">
-        Download Page
-      </Link>
+      <div>
+        <Link
+          className="no-underline hover:no-underline inline-flex text-white hover:text-white bg-purple-500 border-0 py-2 px-6 mt-6 mb-1 focus:outline-none hover:bg-purple-600 rounded text-lg"
+          to="/downloads">
+          Download Page
+        </Link>
+      </div>
     );
   }
 


### PR DESCRIPTION
### What does this PR do?

When we can determine the user's OS, we have a nice purple Download Now button on the front page.

When we can't determine the user's OS, it's a full-width blue button linking to the Download Page instead. This button doesn't match our current styling at all.

I copied from the Download Now button to make it match:
- Added outer div (makes it normal size and centered).
- Changed indigo to purple.
- Added 'mt-6 mb-1' to space it from above and below.

### Screenshot / video of UI

Before:
<img width="1033" alt="Screenshot 2024-01-30 at 2 34 32 PM" src="https://github.com/containers/podman-desktop/assets/19958075/4aebe543-dd31-4485-9b57-5b611e761451">

After:
<img width="1033" alt="Screenshot 2024-01-30 at 2 39 30 PM" src="https://github.com/containers/podman-desktop/assets/19958075/284bd58c-36a5-4ab6-943a-81c0204d3b75">

### What issues does this PR fix or reference?

N/A

### How to test this PR?

`yarn website:dev`, set `operatingSystem = ''` to undo OS detection.