### PR TITLE
feat: add statusbar item highlight property

### DIFF
--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -570,6 +570,7 @@ export class PluginSystem {
           true,
           'update',
           undefined,
+          true,
         );
       });
 

--- a/packages/main/src/plugin/statusbar/statusbar-item.ts
+++ b/packages/main/src/plugin/statusbar/statusbar-item.ts
@@ -34,6 +34,7 @@ export class StatusBarItemImpl implements StatusBarItem {
   private isVisible = false;
   private _iconClass: string | { active: string; inactive: string } | undefined;
   private _enabled = true;
+  private _important = false;
 
   private _command: string | undefined;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -46,6 +47,15 @@ export class StatusBarItemImpl implements StatusBarItem {
     this._alignment = alignment;
     this._priority = priority;
     this._id = StatusBarItemImpl.nextId();
+  }
+
+  public get important(): boolean {
+    return this._important;
+  }
+
+  public set important(important: boolean) {
+    this._important = important;
+    this.update();
   }
 
   public get alignment(): StatusBarAlignment {

--- a/packages/main/src/plugin/statusbar/statusbar-item.ts
+++ b/packages/main/src/plugin/statusbar/statusbar-item.ts
@@ -34,7 +34,7 @@ export class StatusBarItemImpl implements StatusBarItem {
   private isVisible = false;
   private _iconClass: string | { active: string; inactive: string } | undefined;
   private _enabled = true;
-  private _important = false;
+  private _highlight = false;
 
   private _command: string | undefined;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -49,12 +49,12 @@ export class StatusBarItemImpl implements StatusBarItem {
     this._id = StatusBarItemImpl.nextId();
   }
 
-  public get important(): boolean {
-    return this._important;
+  public get highlight(): boolean {
+    return this._highlight;
   }
 
-  public set important(important: boolean) {
-    this._important = important;
+  public set highlight(highlight: boolean) {
+    this._highlight = highlight;
     this.update();
   }
 

--- a/packages/main/src/plugin/statusbar/statusbar-registry.ts
+++ b/packages/main/src/plugin/statusbar/statusbar-registry.ts
@@ -30,6 +30,7 @@ export interface StatusBarEntry {
   command?: string;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   commandArgs?: any[];
+  important?: boolean;
 }
 
 export interface StatusBarEntryDescriptor {
@@ -62,6 +63,7 @@ export class StatusBarRegistry implements IDisposable {
     command: string | undefined,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     commandArgs: any[] | undefined,
+    important?: boolean,
   ) {
     const existingEntry = this.entries.get(entryId);
     if (existingEntry && (existingEntry.alignLeft !== alignLeft || existingEntry.priority !== priority)) {
@@ -80,6 +82,7 @@ export class StatusBarRegistry implements IDisposable {
         enabled: enabled,
         command: command,
         commandArgs: commandArgs,
+        important: important,
       };
 
       const entryDescriptor: StatusBarEntryDescriptor = {
@@ -97,6 +100,7 @@ export class StatusBarRegistry implements IDisposable {
       entryToUpdate.enabled = enabled;
       entryToUpdate.command = command;
       entryToUpdate.commandArgs = commandArgs;
+      entryToUpdate.important = important;
     }
 
     this.apiSender.send(STATUS_BAR_UPDATED_EVENT_NAME, undefined);

--- a/packages/main/src/plugin/statusbar/statusbar-registry.ts
+++ b/packages/main/src/plugin/statusbar/statusbar-registry.ts
@@ -30,7 +30,7 @@ export interface StatusBarEntry {
   command?: string;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   commandArgs?: any[];
-  important?: boolean;
+  highlight?: boolean;
 }
 
 export interface StatusBarEntryDescriptor {
@@ -63,7 +63,7 @@ export class StatusBarRegistry implements IDisposable {
     command: string | undefined,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     commandArgs: any[] | undefined,
-    important?: boolean,
+    highlight?: boolean,
   ) {
     const existingEntry = this.entries.get(entryId);
     if (existingEntry && (existingEntry.alignLeft !== alignLeft || existingEntry.priority !== priority)) {
@@ -82,7 +82,7 @@ export class StatusBarRegistry implements IDisposable {
         enabled: enabled,
         command: command,
         commandArgs: commandArgs,
-        important: important,
+        highlight: highlight,
       };
 
       const entryDescriptor: StatusBarEntryDescriptor = {
@@ -100,7 +100,7 @@ export class StatusBarRegistry implements IDisposable {
       entryToUpdate.enabled = enabled;
       entryToUpdate.command = command;
       entryToUpdate.commandArgs = commandArgs;
-      entryToUpdate.important = important;
+      entryToUpdate.highlight = highlight;
     }
 
     this.apiSender.send(STATUS_BAR_UPDATED_EVENT_NAME, undefined);

--- a/packages/renderer/src/lib/statusbar/StatusBarItem.spec.ts
+++ b/packages/renderer/src/lib/statusbar/StatusBarItem.spec.ts
@@ -19,6 +19,8 @@
 import { test, expect } from 'vitest';
 import type { StatusBarEntry } from '../../../../main/src/plugin/statusbar/statusbar-registry';
 import { iconClass } from './StatusBarItem';
+import { render, screen } from '@testing-library/svelte';
+import StatusBarItem from './StatusBarItem.svelte';
 
 test('check iconClass with font awesome icons', () => {
   const statusBarEntry: StatusBarEntry = {
@@ -48,4 +50,30 @@ test('check iconClass with font awesome icons and spinning', () => {
 
   const icon = iconClass(statusBarEntry);
   expect(icon).toBe('fas fa-sync animate-spin');
+});
+
+test('expect dot not rendered', async () => {
+  const statusBarEntry: StatusBarEntry = {
+    enabled: true,
+    activeIconClass: '${podman}',
+    important: false,
+  };
+
+  render(StatusBarItem, { entry: statusBarEntry });
+
+  const dot = screen.queryByRole('status');
+  expect(dot).toBeNull();
+});
+
+test('expect dot rendered', () => {
+  const statusBarEntry: StatusBarEntry = {
+    enabled: true,
+    activeIconClass: '${podman}',
+    important: true,
+  };
+
+  render(StatusBarItem, { entry: statusBarEntry });
+
+  const dot = screen.getByRole('status');
+  expect(dot).toBeDefined();
 });

--- a/packages/renderer/src/lib/statusbar/StatusBarItem.spec.ts
+++ b/packages/renderer/src/lib/statusbar/StatusBarItem.spec.ts
@@ -56,7 +56,7 @@ test('expect dot not rendered', async () => {
   const statusBarEntry: StatusBarEntry = {
     enabled: true,
     activeIconClass: '${podman}',
-    important: false,
+    highlight: false,
   };
 
   render(StatusBarItem, { entry: statusBarEntry });
@@ -69,7 +69,7 @@ test('expect dot rendered', () => {
   const statusBarEntry: StatusBarEntry = {
     enabled: true,
     activeIconClass: '${podman}',
-    important: true,
+    highlight: true,
   };
 
   render(StatusBarItem, { entry: statusBarEntry });

--- a/packages/renderer/src/lib/statusbar/StatusBarItem.svelte
+++ b/packages/renderer/src/lib/statusbar/StatusBarItem.svelte
@@ -44,6 +44,6 @@ async function executeCommand(entry: StatusBarEntry) {
     <span class="ml-1">{entry.text}</span>
   {/if}
   {#if entry.important}
-    <span role="status" class="absolute bg-purple-500 rounded-full p-1 top-[-4px] right-[-2px]"></span>
+    <span role="status" class="absolute bg-purple-500 rounded-full p-1 top-[-2px] right-[-2px]"></span>
   {/if}
 </button>

--- a/packages/renderer/src/lib/statusbar/StatusBarItem.svelte
+++ b/packages/renderer/src/lib/statusbar/StatusBarItem.svelte
@@ -35,12 +35,15 @@ async function executeCommand(entry: StatusBarEntry) {
   on:click="{() => {
     executeCommand(entry);
   }}"
-  class="{opacity(entry)} px-1 flex items-center {hoverBackground(entry)} {hoverCursor(entry)}"
+  class="{opacity(entry)} px-1 flex items-center {hoverBackground(entry)} {hoverCursor(entry)} relative inline-block"
   title="{tooltipText(entry)}">
   {#if iconClass(entry)}
     <span class="{iconClass(entry)}" aria-hidden="true"></span>
   {/if}
   {#if entry.text}
     <span class="ml-1">{entry.text}</span>
+  {/if}
+  {#if entry.important}
+    <span role="status" class="absolute bg-purple-500 rounded-full p-1 top-[-4px] right-[-2px]"></span>
   {/if}
 </button>

--- a/packages/renderer/src/lib/statusbar/StatusBarItem.svelte
+++ b/packages/renderer/src/lib/statusbar/StatusBarItem.svelte
@@ -43,7 +43,7 @@ async function executeCommand(entry: StatusBarEntry) {
   {#if entry.text}
     <span class="ml-1">{entry.text}</span>
   {/if}
-  {#if entry.important}
+  {#if entry.highlight}
     <span role="status" class="absolute bg-purple-500 rounded-full p-1 top-[-2px] right-[-2px]"></span>
   {/if}
 </button>


### PR DESCRIPTION
### What does this PR do?

This PR is adding an `important` property to the StatusBarItem. This can be useful to bring attention to the user to a specific item. For example here the `Update available` StatusBar item.

### Screenshot / video of UI

<img width="112" alt="image" src="https://github.com/containers/podman-desktop/assets/42176370/aebbd126-e50d-475f-8056-eba3527c4140">

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop/issues/5814

### How to test this PR?

- [x] Unit tests have been added
