### PR TITLE
chore: fix color of server-side download button

### DIFF
--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -89,7 +89,7 @@ function DownloadGenericLinks() {
   return (
     <div className="flex justify-center">
       <Link
-        className="no-underline hover:no-underline inline-flex text-white hover:text-white bg-indigo-500 border-0 py-2 px-6 focus:outline-none hover:bg-indigo-600 rounded text-lg"
+        className="no-underline hover:no-underline inline-flex text-white hover:text-white bg-purple-500 border-0 py-2 px-6 mt-6 mb-1 focus:outline-none hover:bg-purple-600 rounded text-lg"
         to="/downloads">
         Download Page
       </Link>


### PR DESCRIPTION
### What does this PR do?

The download button on the front page of the website is generated client-side, and has a fallback in case we can't detect the user's browser.

Before any of this happens, docusaurus generates the button on the server-side, which is essentially a fallback that should never be seen. This button is the last thing in our codebase using indigo (blue) and is missing the mt-6 mb-1 spacing from the client-side version.

This change just fixes the color and mt/mb so that the button is identical to the client-side one on line 72. (matches current style)

### Screenshot / video of UI

<img width="604" alt="Screenshot 2024-01-31 at 4 29 47 PM" src="https://github.com/containers/podman-desktop/assets/19958075/9e7c06a2-bb06-4276-bb51-2c73c2b9a9e0">

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Easiest way is to change DownloadClientLinks to DownloadGenericLinks on line 117.