### PR TITLE
chore: remove indigo from palette

### DIFF
--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -192,10 +192,6 @@ module.exports = {
         600: tailwindColors.zinc[600],
         700: tailwindColors.zinc[700],
       },
-      'indigo': { // website only
-        500: tailwindColors.indigo[500],
-        600: tailwindColors.indigo[600],
-      },
       'violet': {
          50: tailwindColors.violet[50],
         400: tailwindColors.violet[400],


### PR DESCRIPTION
### What does this PR do?

Indigo is one of the historic colors in our palette that we're not supposed to use, and it is finally out of the codebase. Removing from the palette so that it doesn't get accidentally used.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Confirm there are no instances of `indigo` anywhere else in the codebase.