### PR TITLE
chore(test): implementing podman machine creation through onboarding workflow e2e test

### DIFF
--- a/packages/renderer/src/lib/onboarding/Onboarding.svelte
+++ b/packages/renderer/src/lib/onboarding/Onboarding.svelte
@@ -298,6 +298,8 @@ function handleEscape({ key }: any) {
   <div class="fixed bg-charcoal-500 right-0 top-0 h-[100px] w-[30px] z-10 mt-8"></div>
   <div
     id="stepBody"
+    role="region"
+    aria-label="Onboarding Body"
     class="flex flex-col bg-charcoal-500 h-full overflow-y-auto w-full overflow-x-hidden"
     class:bodyWithBar="{!activeStep.step.completionEvents || activeStep.step.completionEvents.length === 0}">
     <div class="flex flex-col h-full">

--- a/tests/src/model/pages/dashboard-page.ts
+++ b/tests/src/model/pages/dashboard-page.ts
@@ -24,6 +24,7 @@ export class DashboardPage extends BasePage {
   readonly header: Locator;
   readonly content: Locator;
   readonly heading: Locator;
+  readonly notificationsBox: Locator;
   readonly featuredExtensions: Locator;
   readonly devSandboxProvider: Locator;
   readonly devSandboxBox: Locator;
@@ -37,8 +38,10 @@ export class DashboardPage extends BasePage {
     this.mainPage = page.getByRole('region', { name: 'Dashboard' });
     this.header = this.mainPage.getByRole('region', { name: 'header' });
     this.content = this.mainPage.getByRole('region', { name: 'content' });
-    this.featuredExtensions = page.getByLabel('FeaturedExtensions');
     this.heading = page.getByRole('heading', { name: 'Dashboard' });
+
+    this.notificationsBox = this.content.getByRole('region', { name: 'Notifications Box' });
+    this.featuredExtensions = page.getByLabel('FeaturedExtensions');
 
     this.devSandboxProvider = page.getByLabel('Developer Sandbox Provider');
     this.devSandboxBox = this.featuredExtensions.getByLabel('Developer Sandbox');

--- a/tests/src/model/pages/onboarding-page.ts
+++ b/tests/src/model/pages/onboarding-page.ts
@@ -1,0 +1,39 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { Locator, Page } from '@playwright/test';
+import { BasePage } from './base-page';
+
+export class OnboardingPage extends BasePage {
+  readonly mainPage: Locator;
+  readonly header: Locator;
+  readonly onboardingComponent: Locator;
+  readonly onboardingStatusMessage: Locator;
+  readonly nextStepButton: Locator;
+  readonly cancelSetupButtion: Locator;
+
+  constructor(page: Page) {
+    super(page);
+    this.mainPage = page.getByRole('region', { name: 'Onboarding Body' });
+    this.header = this.mainPage.getByRole('heading', { name: 'Header' });
+    this.onboardingComponent = this.mainPage.getByLabel('Onboarding Component');
+    this.onboardingStatusMessage = this.mainPage.getByLabel('Onboarding Status Message');
+    this.nextStepButton = this.mainPage.getByRole('button', { name: 'Next Step' });
+    this.cancelSetupButtion = this.mainPage.getByRole('button', { name: 'Cancel Setup' });
+  }
+}

--- a/tests/src/model/pages/podman-machine-details-page.ts
+++ b/tests/src/model/pages/podman-machine-details-page.ts
@@ -1,0 +1,44 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { Locator, Page } from '@playwright/test';
+import { ResourcesPage } from './resources-page';
+
+export class PodmanMachineDetails extends ResourcesPage {
+  readonly podmanMachineName: Locator;
+  readonly podmanMachineStatus: Locator;
+  readonly podmanMachineConnectionActions: Locator;
+  readonly podmanMachineStartButton: Locator;
+  readonly podmanMachineRestartButton: Locator;
+  readonly podmanMachineStopButton: Locator;
+  readonly podmanMachineDeleteButton: Locator;
+
+  constructor(page: Page) {
+    super(page);
+    this.podmanMachineName = this.getPage().getByRole('heading', { name: 'Podman Machine' });
+    this.podmanMachineStatus = this.getPage().getByLabel('Connection Status Label');
+    this.podmanMachineConnectionActions = this.getPage().getByRole('group', { name: 'Connection Actions' });
+    this.podmanMachineStartButton = this.podmanMachineConnectionActions.getByRole('button', {
+      name: 'Start',
+      exact: true,
+    });
+    this.podmanMachineRestartButton = this.podmanMachineConnectionActions.getByRole('button', { name: 'Restart' });
+    this.podmanMachineStopButton = this.podmanMachineConnectionActions.getByRole('button', { name: 'Stop' });
+    this.podmanMachineDeleteButton = this.podmanMachineConnectionActions.getByRole('button', { name: 'Delete' });
+  }
+}

--- a/tests/src/model/pages/podman-onboarding-page.ts
+++ b/tests/src/model/pages/podman-onboarding-page.ts
@@ -1,0 +1,62 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { Locator, Page } from '@playwright/test';
+import { OnboardingPage } from './onboarding-page';
+
+export class PodmanOnboardingPage extends OnboardingPage {
+  readonly podmanAutostartToggle: Locator;
+  readonly createMachinePageTitle: Locator;
+  readonly podmanMachineConfiguration: Locator;
+  readonly podmanMachineName: Locator;
+  readonly podmanMachineCPUs: Locator;
+  readonly podmanMachineMemory: Locator;
+  readonly podmanMachineDiskSize: Locator;
+  readonly podmanMachineImage: Locator;
+  readonly podmanMachineRootfulCheckbox: Locator;
+  readonly podmanMachineUserModeNetworkingCheckbox: Locator;
+  readonly podmanMachineStartAfterCreationCheckbox: Locator;
+  readonly podmanMachineCreateButton: Locator;
+  readonly podmanMachineShowLogsButton: Locator;
+
+  constructor(page: Page) {
+    super(page);
+    this.podmanAutostartToggle = this.mainPage.getByRole('checkbox', {
+      name: 'Autostart Podman engine when launching Podman Desktop',
+    });
+    this.createMachinePageTitle = this.onboardingComponent.getByLabel('title');
+    this.podmanMachineConfiguration = this.mainPage.getByRole('form', { name: 'Properties Information' });
+    this.podmanMachineName = this.podmanMachineConfiguration.getByRole('textbox', { name: 'Name' });
+    this.podmanMachineCPUs = this.podmanMachineConfiguration.getByRole('slider', { name: 'CPU(s)' });
+    this.podmanMachineMemory = this.podmanMachineConfiguration.getByRole('slider', { name: 'Memory' });
+    this.podmanMachineDiskSize = this.podmanMachineConfiguration.getByRole('slider', { name: 'Disk size' });
+    this.podmanMachineImage = this.podmanMachineConfiguration.getByRole('textbox', { name: 'Image Path (Optional)' });
+    this.podmanMachineRootfulCheckbox = this.podmanMachineConfiguration.getByRole('checkbox', {
+      name: 'Machine with root privileges',
+    });
+    this.podmanMachineUserModeNetworkingCheckbox = this.podmanMachineConfiguration.getByRole('checkbox', {
+      name: 'User mode networking',
+      exact: false,
+    });
+    this.podmanMachineStartAfterCreationCheckbox = this.podmanMachineConfiguration.getByRole('checkbox', {
+      name: 'Start the machine now',
+    });
+    this.podmanMachineCreateButton = this.podmanMachineConfiguration.getByRole('button', { name: 'Create' });
+    this.podmanMachineShowLogsButton = this.mainPage.getByRole('button', { name: 'Show Logs' });
+  }
+}

--- a/tests/src/model/pages/resources-page.ts
+++ b/tests/src/model/pages/resources-page.ts
@@ -22,10 +22,12 @@ import { SettingsPage } from './settings-page';
 export class ResourcesPage extends SettingsPage {
   readonly heading: Locator;
   readonly featuredProviderResources: Locator;
+  readonly podmanResources: Locator;
 
   constructor(page: Page) {
     super(page, 'Resources');
     this.heading = page.getByRole('heading', { name: 'Resources' });
     this.featuredProviderResources = page.getByRole('region', { name: 'Featured Provider Resources' });
+    this.podmanResources = this.featuredProviderResources.getByRole('region', { name: 'podman', exact: true });
   }
 }

--- a/tests/src/model/pages/resources-podman-connections-page.ts
+++ b/tests/src/model/pages/resources-podman-connections-page.ts
@@ -1,0 +1,45 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { Locator, Page } from '@playwright/test';
+import { ResourcesPage } from './resources-page';
+
+export class ResourcesPodmanConnections extends ResourcesPage {
+  readonly providerConnections: Locator;
+  readonly podmanMachineElement: Locator;
+  readonly machineConnectionStatus: Locator;
+  readonly machineDetailsButton: Locator;
+  readonly machineConnectionActions: Locator;
+  readonly machineStartButton: Locator;
+  readonly machineRestartButton: Locator;
+  readonly machineStopButton: Locator;
+  readonly machineDeleteButton: Locator;
+
+  constructor(page: Page, machineVisibleName: string) {
+    super(page);
+    this.providerConnections = this.podmanResources.getByRole('region', { name: 'Provider Connections' });
+    this.podmanMachineElement = this.providerConnections.getByRole('region', { name: machineVisibleName });
+    this.machineConnectionStatus = this.podmanMachineElement.getByLabel('Connection Status Label');
+    this.machineDetailsButton = this.podmanMachineElement.getByRole('button', { name: 'Podman details' });
+    this.machineConnectionActions = this.podmanMachineElement.getByRole('group', { name: 'Connection Actions' });
+    this.machineStartButton = this.machineConnectionActions.getByRole('button', { name: 'Start', exact: true });
+    this.machineRestartButton = this.machineConnectionActions.getByRole('button', { name: 'Restart' });
+    this.machineStopButton = this.machineConnectionActions.getByRole('button', { name: 'Stop' });
+    this.machineDeleteButton = this.machineConnectionActions.getByRole('button', { name: 'Delete' });
+  }
+}

--- a/tests/src/podman-machine-onboarding.spec.ts
+++ b/tests/src/podman-machine-onboarding.spec.ts
@@ -1,0 +1,244 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { Page } from 'playwright';
+import type { RunnerTestContext } from './testContext/runner-test-context';
+import { afterAll, beforeAll, test, describe, beforeEach } from 'vitest';
+import { PodmanDesktopRunner } from './runner/podman-desktop-runner';
+import { WelcomePage } from './model/pages/welcome-page';
+import type { DashboardPage } from './model/pages/dashboard-page';
+import type { Locator } from '@playwright/test';
+import { expect as playExpect } from '@playwright/test';
+import { NavigationBar } from './model/workbench/navigation';
+import type { SettingsBar } from './model/pages/settings-bar';
+import { ResourcesPage } from './model/pages/resources-page';
+
+const PODMAN_MACHINE_STARTUP_TIMEOUT: number = 360_000;
+
+let pdRunner: PodmanDesktopRunner;
+let page: Page;
+let dashboardPage: DashboardPage;
+let resourcesPage: ResourcesPage;
+let settingsBar: SettingsBar;
+let navigationBar: NavigationBar;
+
+let notificationPodmanSetup: Locator;
+let onboardingStepBody: Locator;
+let podmanMachineConfiguration: Locator;
+
+beforeAll(async () => {
+  pdRunner = new PodmanDesktopRunner();
+  page = await pdRunner.start();
+  pdRunner.setVideoAndTraceName('podman-machine-e2e');
+
+  const welcomePage = new WelcomePage(page);
+  await welcomePage.handleWelcomePage(true);
+  navigationBar = new NavigationBar(page);
+
+  // Delete machine if it already exists
+  await deletePodmanMachine('Podman Machine');
+});
+
+afterAll(async () => {
+  await pdRunner.close();
+}, 120000);
+
+beforeEach<RunnerTestContext>(async ctx => {
+  ctx.pdRunner = pdRunner;
+});
+
+describe('Podman Machine verification', async () => {
+  describe('Podman Machine onboarding workflow', async () => {
+    test('Setup Podman push notification is present', async () => {
+      dashboardPage = await navigationBar.openDashboard();
+      await playExpect(dashboardPage.mainPage).toBeVisible();
+      await playExpect(dashboardPage.notificationsBox).toBeVisible();
+      notificationPodmanSetup = dashboardPage.notificationsBox
+        .getByRole('region')
+        .filter({ hasText: 'Podman needs to be set up' });
+      await playExpect(notificationPodmanSetup).toBeVisible();
+    });
+    describe('Onboarding navigation', async () => {
+      test('Open Podman Machine Onboarding through Setup Notification', async () => {
+        await notificationPodmanSetup.getByTitle('Set up Podman').click();
+        await playExpect(page.getByRole('heading', { name: 'Podman Setup Header' })).toBeVisible();
+      });
+      test('Podman onboarding first page', async () => {
+        await playExpect(page.getByRole('heading', { name: 'Podman Setup Header' })).toBeVisible();
+      });
+      test('Return to Dashboard', async () => {
+        dashboardPage = await navigationBar.openDashboard();
+        await playExpect(dashboardPage.mainPage).toBeVisible();
+      });
+      test('Re-Open Podman Machine Onboarding through Settings Resources page', async () => {
+        settingsBar = await navigationBar.openSettings();
+        await settingsBar.resourcesTab.click();
+        resourcesPage = new ResourcesPage(page);
+        const podmanResourcesSectionLocator: Locator = resourcesPage.getPage().getByLabel('podman', { exact: true });
+        await playExpect(podmanResourcesSectionLocator).toBeVisible();
+        await podmanResourcesSectionLocator.getByLabel('Setup Podman').click();
+        await playExpect(page.getByRole('heading', { name: 'Podman Setup Header' })).toBeVisible();
+        onboardingStepBody = page.locator('//*[@id="stepBody"]');
+        await playExpect(onboardingStepBody).toBeVisible();
+      });
+    });
+    test('Verify Podman Autostart is enabled and proceed to next page', async () => {
+      const podmanAutostartToggle: Locator = onboardingStepBody.getByLabel(
+        'Autostart Podman engine when launching Podman Desktop',
+      );
+      await playExpect(podmanAutostartToggle).toBeChecked();
+      await onboardingStepBody.getByLabel('Next Step').click();
+    });
+    test('Expect no machine created message and proceed to next page', async () => {
+      await playExpect(onboardingStepBody.getByLabel('Onboarding Status Message')).toHaveText(
+        `We could not find any Podman machine. Let's create one!`,
+      );
+      await onboardingStepBody.getByLabel('Next Step').click();
+    });
+    test('Verify default podman machine settings', async () => {
+      await playExpect(onboardingStepBody.getByLabel('title')).toHaveText(`Create a Podman machine`);
+      podmanMachineConfiguration = onboardingStepBody.getByLabel('Properties Information');
+      await playExpect(podmanMachineConfiguration).toBeVisible();
+      const podmanMachineName: Locator = podmanMachineConfiguration.getByLabel('Name');
+      await playExpect(podmanMachineName).toHaveValue('podman-machine-default');
+      const podmanMachineCPUs: Locator = podmanMachineConfiguration.getByLabel('CPU(s)');
+      await playExpect(podmanMachineCPUs).toBeVisible();
+      const podmanMachineMemory: Locator = podmanMachineConfiguration.getByLabel('Memory');
+      await playExpect(podmanMachineMemory).toBeVisible();
+      const podmanMachineDiskSize: Locator = podmanMachineConfiguration.getByLabel('Disk size');
+      await playExpect(podmanMachineDiskSize).toBeVisible();
+      const podmanMachineImage: Locator = podmanMachineConfiguration.getByLabel('Image Path (Optional)', {
+        exact: true,
+      });
+      await playExpect(podmanMachineImage).toHaveValue('');
+      const podmanMachineRootful: Locator = podmanMachineConfiguration.getByLabel('Machine with root privileges');
+      await playExpect(podmanMachineRootful).toBeChecked();
+      const podmanMachineUserModeNetworking: Locator = podmanMachineConfiguration.getByLabel(
+        'User mode networking (traffic relayed by a user process)',
+        { exact: false },
+      );
+      playExpect(await podmanMachineUserModeNetworking.isChecked()).toBeFalsy();
+      const podmanMachineStartAfterCreation: Locator = podmanMachineConfiguration.getByLabel('Start the machine now');
+      playExpect(await podmanMachineStartAfterCreation.isChecked()).toBeTruthy();
+    });
+  });
+  describe('Podman Machine creation and operations', async () => {
+    test('Create a default Podman machine', async () => {
+      const createMachineButton: Locator = podmanMachineConfiguration.getByRole('button', { name: 'Create' });
+      await createMachineButton.click();
+      const expandLogsButton: Locator = onboardingStepBody.getByRole('button', { name: 'Show Logs' });
+      await playExpect(expandLogsButton).toBeVisible();
+      await expandLogsButton.click();
+      const machineCreationStatusMessage: Locator = onboardingStepBody.getByLabel('Onboarding Status Message');
+      await playExpect(machineCreationStatusMessage).toBeVisible({ timeout: PODMAN_MACHINE_STARTUP_TIMEOUT });
+      await playExpect(machineCreationStatusMessage).toHaveText('Podman successfully setup');
+      await onboardingStepBody.getByLabel('Next Step').click();
+    });
+    describe('Podman machine operations', async () => {
+      let podmanMachineStatus: Locator;
+      let podmanMachineStartButton: Locator;
+      let podmanMachineRestartButton: Locator;
+      let podmanMachineStopButton: Locator;
+      let podmanMachineDeleteButton: Locator;
+      test('Open podman machine details', async () => {
+        dashboardPage = await navigationBar.openDashboard();
+        await playExpect(dashboardPage.mainPage).toBeVisible();
+        settingsBar = await navigationBar.openSettings();
+        await settingsBar.resourcesTab.click();
+        resourcesPage = new ResourcesPage(page);
+        const podmanResourcesSectionLocator: Locator = resourcesPage.getPage().getByLabel('podman', { exact: true });
+        await playExpect(podmanResourcesSectionLocator).toBeVisible();
+        const podmanConnections: Locator = podmanResourcesSectionLocator.getByRole('region', {
+          name: 'Provider Connections',
+        });
+        await playExpect(podmanConnections).toBeVisible();
+        const podmanMachineDetails: Locator = podmanConnections.getByRole('button', { name: 'Podman details' });
+        await playExpect(podmanMachineDetails).toBeVisible();
+        await podmanMachineDetails.click();
+        podmanMachineStatus = page.getByLabel('Connection Status Label');
+        await playExpect(podmanMachineStatus).toBeVisible();
+        const podmanMachineControls: Locator = page.getByRole('group', { name: 'Connection Actions' });
+        await playExpect(podmanMachineControls).toBeVisible();
+        podmanMachineStartButton = podmanMachineControls.getByRole('button', { name: 'Start', exact: true });
+        await playExpect(podmanMachineStartButton).toBeVisible();
+        podmanMachineRestartButton = podmanMachineControls.getByRole('button', { name: 'Restart' });
+        await playExpect(podmanMachineRestartButton).toBeVisible();
+        podmanMachineStopButton = podmanMachineControls.getByRole('button', { name: 'Stop' });
+        await playExpect(podmanMachineStopButton).toBeVisible();
+        podmanMachineDeleteButton = podmanMachineControls.getByRole('button', { name: 'Delete' });
+        await playExpect(podmanMachineDeleteButton).toBeVisible();
+      });
+      test('Podman machine operations - STOP', async () => {
+        await playExpect(podmanMachineStatus).toHaveText('RUNNING', { timeout: 30_000 });
+        await podmanMachineStopButton.click();
+        await playExpect(podmanMachineStatus).toHaveText('OFF', { timeout: 30_000 });
+      });
+      test('Podman machine operations - START', async () => {
+        await podmanMachineStartButton.click();
+        await playExpect(podmanMachineStatus).toHaveText('RUNNING', { timeout: 30_000 });
+      });
+      test('Podman machine operations - RESTART', async () => {
+        await podmanMachineRestartButton.click();
+        await playExpect(podmanMachineStatus).toHaveText('OFF', { timeout: 30_000 });
+        await playExpect(podmanMachineStatus).toHaveText('RUNNING', { timeout: 30_000 });
+      });
+    });
+    test('Clean Up Podman Machine', async () => {
+      if (process.env.MACHINE_CLEANUP !== undefined && process.env.MACHINE_CLEANUP === 'true') {
+        await deletePodmanMachine('Podman Machine');
+      } else {
+        console.log('MACHINE_CLEANUP is undefined or false, Skipping machine cleanup');
+      }
+    });
+  });
+});
+
+async function deletePodmanMachine(machineVisibleName: string): Promise<void> {
+  dashboardPage = await navigationBar.openDashboard();
+  await playExpect(dashboardPage.mainPage).toBeVisible();
+  settingsBar = await navigationBar.openSettings();
+  await settingsBar.resourcesTab.click();
+  resourcesPage = new ResourcesPage(page);
+  const podmanResourcesSectionLocator: Locator = resourcesPage.getPage().getByLabel('podman', { exact: true });
+  await playExpect(podmanResourcesSectionLocator).toBeVisible();
+  const podmanConnections: Locator = podmanResourcesSectionLocator.getByRole('region', {
+    name: 'Provider Connections',
+  });
+  await playExpect(podmanConnections).toBeVisible();
+  const podmanMachineElement: Locator = podmanConnections.getByRole('region', { name: machineVisibleName });
+  if (await podmanMachineElement.isVisible()) {
+    await playExpect(podmanMachineElement).toBeVisible();
+    const podmanMachineControls: Locator = podmanConnections.getByRole('group', { name: 'Connection Actions' });
+    await playExpect(podmanMachineControls).toBeVisible();
+    const podmanMachineStatus: Locator = podmanResourcesSectionLocator.getByLabel('Connection Status Label');
+    await playExpect(podmanMachineStatus).toBeVisible();
+    if ((await podmanMachineStatus.innerText()) === 'RUNNING') {
+      const podmanMachineStopButton: Locator = podmanMachineControls.getByRole('button', { name: 'Stop' });
+      await playExpect(podmanMachineStopButton).toBeVisible();
+      await podmanMachineStopButton.click();
+      await playExpect(podmanMachineStatus).toHaveText('OFF', { timeout: 30_000 });
+    }
+    const podmanMachineDeleteButton: Locator = podmanMachineControls.getByRole('button', { name: 'Delete' });
+    await playExpect(podmanMachineDeleteButton).toBeVisible();
+    playExpect(await podmanMachineDeleteButton.isEnabled()).toBeTruthy();
+    await podmanMachineDeleteButton.click();
+    await playExpect(podmanMachineElement).not.toBeVisible({ timeout: 30_000 });
+  } else {
+    console.log(`Podman machine [${machineVisibleName}] not present, skipping deletion.`);
+  }
+}


### PR DESCRIPTION
### What does this PR do?
* Updates DashboardPage page object adding a locator for notifications
* Implements Podman Desktop Machine e2e test using Onboarding Workflow

### Screenshot / video of UI
N/A
<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
#4670 
<!-- Include any related issues from Podman Desktop 
repository (or from another issue tracker). -->

### How to test this PR? (Windows only!!!)
* Podman must be installed and configured (windows virtualization, WSL2 installed), there can be no podman machine present
* append `"test:e2e:machineonboarding": "xvfb-maybe --auto-servernum --server-args='-screen 0 1280x960x24' -- vitest run tests/src/podman-machine-onboarding.spec.ts --pool=threads --poolOptions.threads.singleThread --poolOptions.threads.isolate --no-file-parallelism",` into `package.json`
* run `yarn run test:e2e:build`
* run `yarn run test:e2e:machineonboarding`
<!-- Please explain steps to reproduce -->

### Additional context
Example test runs:
```
$ TEST_PODMAN_MACHINE=true MACHINE_CLEANUP=true yarn run test:e2e:machineonboarding:run

...

 ✓ tests/src/podman-machine-onboarding.spec.ts (13) 82640ms
   ❯ [ beforeAll ]
   ✓ Podman Machine verification (13) 66291ms
     ✓ Podman Machine onboarding workflow (7) 2598ms
       ✓ Setup Podman push notification is present
       ✓ Onboarding navigation (3) 791ms
         ✓ Open Podman Machine Onboarding through Setup Notification
         ✓ Return to Dashboard
         ✓ Re-Open Podman Machine Onboarding through Settings Resources page 394ms
       ✓ Verify Podman Autostart is enabled and proceed to next page 424ms
       ✓ Expect no machine created message and proceed to next page
       ✓ Verify default podman machine settings 1003ms
     ✓ Podman Machine creation and operations (5) 51658ms
       ✓ Create a default Podman machine 26505ms
       ✓ Podman machine operations (4) 25153ms
         ✓ Open podman machine details 1173ms
         ✓ Podman machine operations - STOP 6024ms
         ✓ Podman machine operations - START 5991ms
         ✓ Podman machine operations - RESTART 11965ms
     ✓ Clean Up Podman Machine 12035ms

 Test Files  1 passed (1)
      Tests  13 passed (13)
   Start at  10:01:06
   Duration  85.04s (transform 206ms, setup 18ms, collect 1.08s, tests 82.64s, environment 511ms, prepare 126ms)

Done in 85.76s.
```

```
$ TEST_PODMAN_MACHINE=true yarn run test:e2e:machineonboarding:run

...

 ✓ tests/src/podman-machine-onboarding.spec.ts (13) 70175ms
   ❯ [ beforeAll ]
   ✓ Podman Machine verification (13) 54029ms
     ✓ Podman Machine onboarding workflow (7) 2708ms
       ✓ Setup Podman push notification is present
       ✓ Onboarding navigation (3) 899ms
         ✓ Open Podman Machine Onboarding through Setup Notification
         ✓ Return to Dashboard
         ✓ Re-Open Podman Machine Onboarding through Settings Resources page 526ms
       ✓ Verify Podman Autostart is enabled and proceed to next page 418ms
       ✓ Expect no machine created message and proceed to next page
       ✓ Verify default podman machine settings 1022ms
     ✓ Podman Machine creation and operations (5) 51321ms
       ✓ Create a default Podman machine 26513ms
       ✓ Podman machine operations (4) 24807ms
         ✓ Open podman machine details 847ms
         ✓ Podman machine operations - STOP 4996ms
         ✓ Podman machine operations - START 7003ms
         ✓ Podman machine operations - RESTART 11961ms
     ↓ Clean Up Podman Machine [skipped]

 Test Files  1 passed (1)
      Tests  12 passed | 1 skipped (13)
   Start at  10:04:08
   Duration  72.72s (transform 206ms, setup 21ms, collect 1.07s, tests 70.17s, environment 521ms, prepare 121ms)

Done in 73.43s.
```