### PR TITLE
chore: use status colors

### DIFF
--- a/packages/renderer/src/lib/deployments/DeploymentColumnStatus.spec.ts
+++ b/packages/renderer/src/lib/deployments/DeploymentColumnStatus.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,5 +37,5 @@ test('Expect simple column styling', async () => {
 
   const text = screen.getByRole('status');
   expect(text).toBeInTheDocument();
-  expect(text).toHaveClass('bg-green-400');
+  expect(text).toHaveClass('bg-status-running');
 });

--- a/packages/renderer/src/lib/image/ImageColumnStatus.spec.ts
+++ b/packages/renderer/src/lib/image/ImageColumnStatus.spec.ts
@@ -46,5 +46,5 @@ test('Expect simple column styling', async () => {
 
   const text = screen.getByRole('status');
   expect(text).toBeInTheDocument();
-  expect(text).toHaveClass('bg-green-400');
+  expect(text).toHaveClass('bg-status-running');
 });

--- a/packages/renderer/src/lib/images/StatusIcon.spec.ts
+++ b/packages/renderer/src/lib/images/StatusIcon.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ test('Expect starting styling', async () => {
   expect(icon).toBeInTheDocument();
   expect(icon).toHaveAttribute('title', status);
 
-  expect(icon).toHaveClass('bg-green-600');
+  expect(icon).toHaveClass('bg-status-starting');
 });
 
 test('Expect running styling', async () => {
@@ -38,7 +38,7 @@ test('Expect running styling', async () => {
   expect(icon).toBeInTheDocument();
   expect(icon).toHaveAttribute('title', status);
 
-  expect(icon).toHaveClass('bg-green-400');
+  expect(icon).toHaveClass('bg-status-running');
 });
 
 test('Expect degraded styling', async () => {
@@ -48,7 +48,7 @@ test('Expect degraded styling', async () => {
   expect(icon).toBeInTheDocument();
   expect(icon).toHaveAttribute('title', status);
 
-  expect(icon).toHaveClass('bg-amber-600');
+  expect(icon).toHaveClass('bg-status-degraded');
 });
 
 test('Expect deleting styling', async () => {

--- a/packages/renderer/src/lib/images/StatusIcon.svelte
+++ b/packages/renderer/src/lib/images/StatusIcon.svelte
@@ -14,9 +14,9 @@ $: solid = status === 'RUNNING' || status === 'STARTING' || status === 'USED' ||
 <div class="grid place-content-center" style="position:relative">
   <div
     class="grid place-content-center rounded aspect-square text-xs"
-    class:bg-green-400="{status === 'RUNNING' || status === 'USED'}"
-    class:bg-green-600="{status === 'STARTING'}"
-    class:bg-amber-600="{status === 'DEGRADED'}"
+    class:bg-status-running="{status === 'RUNNING' || status === 'USED'}"
+    class:bg-status-starting="{status === 'STARTING'}"
+    class:bg-status-degraded="{status === 'DEGRADED'}"
     class:border-2="{!solid && status !== 'DELETING'}"
     class:p-0.5="{!solid}"
     class:p-1="{solid}"

--- a/packages/renderer/src/lib/ingresses-routes/IngressRouteColumnStatus.spec.ts
+++ b/packages/renderer/src/lib/ingresses-routes/IngressRouteColumnStatus.spec.ts
@@ -35,7 +35,7 @@ test('Expect simple column styling with Ingress', async () => {
 
   const text = screen.getByRole('status');
   expect(text).toBeInTheDocument();
-  expect(text).toHaveClass('bg-green-400');
+  expect(text).toHaveClass('bg-status-running');
 });
 
 test('Expect simple column styling with Route', async () => {
@@ -55,5 +55,5 @@ test('Expect simple column styling with Route', async () => {
 
   const text = screen.getByRole('status');
   expect(text).toBeInTheDocument();
-  expect(text).toHaveClass('bg-green-400');
+  expect(text).toHaveClass('bg-status-running');
 });

--- a/packages/renderer/src/lib/pod/PodColumnStatus.spec.ts
+++ b/packages/renderer/src/lib/pod/PodColumnStatus.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,5 +42,5 @@ test('Expect simple column styling', async () => {
 
   const status = screen.getByRole('status');
   expect(status).toBeInTheDocument();
-  expect(status).toHaveClass('bg-green-400');
+  expect(status).toHaveClass('bg-status-running');
 });

--- a/packages/renderer/src/lib/service/ServiceColumnStatus.spec.ts
+++ b/packages/renderer/src/lib/service/ServiceColumnStatus.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,5 +37,5 @@ test('Expect simple column styling', async () => {
 
   const text = screen.getByRole('status');
   expect(text).toBeInTheDocument();
-  expect(text).toHaveClass('bg-green-400');
+  expect(text).toHaveClass('bg-status-running');
 });

--- a/packages/renderer/src/lib/volume/VolumeColumnStatus.spec.ts
+++ b/packages/renderer/src/lib/volume/VolumeColumnStatus.spec.ts
@@ -44,5 +44,5 @@ test('Expect simple column styling', async () => {
 
   const status = screen.getByRole('status');
   expect(status).toBeInTheDocument();
-  expect(status).toHaveClass('bg-green-400');
+  expect(status).toHaveClass('bg-status-running');
 });

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2022-2023 Red Hat, Inc.
+ * Copyright (C) 2022-2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,6 +55,7 @@ module.exports = {
         'waiting': tailwindColors.amber[600],
 
         // Podman only
+        'starting': tailwindColors.green[600],
 
         // Stopped & Exited are the same color / same thing in the eyes of statuses
         'stopped': tailwindColors.gray[300],


### PR DESCRIPTION
### What does this PR do?

There are status colors in the palette, but prior code is referring to the color values directly. This is just cleanup to make everything use the status color.

Adds one 'missing' status color for starting, and there is one slight color change (degraded will go from amber-600 to the now official amber-700), but this is not a noticeable change. I did a scan for other references and didn't find any.

### Screenshot / video of UI

N/A, no visual change.

### What issues does this PR fix or reference?

Fixes #4740.

### How to test this PR?

PR tests; no visual regression in the normal status icons.