### PR TITLE
feat: adding extensionId optional property to Task interface

### DIFF
--- a/packages/main/src/plugin/api/task.ts
+++ b/packages/main/src/plugin/api/task.ts
@@ -23,6 +23,7 @@ export interface Task {
   id: string;
   name: string;
   started: number;
+  readonly extensionId?: string;
 }
 
 export interface StatefulTask extends Task {

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -826,7 +826,7 @@ export class ExtensionLoader {
           token: containerDesktopAPI.CancellationToken,
         ) => Promise<R>,
       ): Promise<R> => {
-        return progress.withProgress(options, task);
+        return progress.withProgress(options, task, extensionInfo.id);
       },
 
       showNotification: (notificationInfo: containerDesktopAPI.NotificationOptions): containerDesktopAPI.Disposable => {

--- a/packages/main/src/plugin/progress-impl.spec.ts
+++ b/packages/main/src/plugin/progress-impl.spec.ts
@@ -138,3 +138,23 @@ test('Should update the task name', async () => {
     status: 'success',
   });
 });
+
+test('Should propagate the extension id to the create task method', async () => {
+  const createTaskMock = vi.fn();
+  const updateTaskMock = vi.fn();
+  const taskManager = {
+    createTask: createTaskMock,
+    updateTask: updateTaskMock,
+  } as unknown as TaskManager;
+
+  createTaskMock.mockImplementation(() => ({}));
+  const progress = new ProgressImpl(taskManager);
+
+  await progress.withProgress<void>(
+    { location: ProgressLocation.TASK_WIDGET, title: 'My task' },
+    () => Promise.resolve(),
+    'random-extension-id',
+  );
+
+  expect(createTaskMock).toHaveBeenCalledWith('My task', 'random-extension-id');
+});

--- a/packages/main/src/plugin/progress-impl.ts
+++ b/packages/main/src/plugin/progress-impl.ts
@@ -40,6 +40,7 @@ export class ProgressImpl {
    * @template R - The type of the result of the task.
    * @param {extensionApi.ProgressOptions} options - The options for the progress.
    * @param {Function} task - The task function to be executed with progress.
+   * @param {string} extensionId - The extension id that own the task function provided.
    * @returns {Promise<R>} - A promise that resolves to the result of the task.
    */
   withProgress<R>(
@@ -48,11 +49,12 @@ export class ProgressImpl {
       progress: extensionApi.Progress<{ message?: string; increment?: number }>,
       token: extensionApi.CancellationToken,
     ) => Promise<R>,
+    extensionId?: string,
   ): Promise<R> {
     if (options.location === ProgressLocation.APP_ICON) {
       return this.withApplicationIcon(options, task);
     } else {
-      return this.withWidget(options, task);
+      return this.withWidget(options, task, extensionId);
     }
   }
 
@@ -82,8 +84,9 @@ export class ProgressImpl {
       progress: extensionApi.Progress<{ message?: string; increment?: number }>,
       token: extensionApi.CancellationToken,
     ) => Promise<R>,
+    extensionId?: string,
   ): Promise<R> {
-    const t = this.taskManager.createTask(options.title);
+    const t = this.taskManager.createTask(options.title, extensionId);
 
     return task(
       {

--- a/packages/main/src/plugin/task-manager.spec.ts
+++ b/packages/main/src/plugin/task-manager.spec.ts
@@ -48,6 +48,7 @@ test('create stateful task with title', async () => {
   expect(task.name).equal('title');
   expect(task.state).equal('running');
   expect(task.status).equal('in-progress');
+  expect(task.extensionId).toBeUndefined();
   expect(apiSenderSendMock).toBeCalledWith('task-created', task);
 });
 
@@ -58,6 +59,7 @@ test('create stateful task without title', async () => {
   expect(task.name).equal('Task 1');
   expect(task.state).equal('running');
   expect(task.status).equal('in-progress');
+  expect(task.extensionId).toBeUndefined();
   expect(apiSenderSendMock).toBeCalledWith('task-created', task);
 });
 
@@ -68,6 +70,7 @@ test('create multiple stateful tasks with title', async () => {
   expect(task.name).equal('title');
   expect(task.state).equal('running');
   expect(task.status).equal('in-progress');
+  expect(task.extensionId).toBeUndefined();
   expect(apiSenderSendMock).toBeCalledWith('task-created', task);
 
   const task2 = taskManager.createTask('another title');
@@ -75,6 +78,7 @@ test('create multiple stateful tasks with title', async () => {
   expect(task2.name).equal('another title');
   expect(task2.state).equal('running');
   expect(task2.status).equal('in-progress');
+  expect(task2.extensionId).toBeUndefined();
   expect(apiSenderSendMock).toBeCalledWith('task-created', task2);
 
   const task3 = taskManager.createTask('third title');
@@ -82,6 +86,7 @@ test('create multiple stateful tasks with title', async () => {
   expect(task3.name).equal('third title');
   expect(task3.state).equal('running');
   expect(task3.status).equal('in-progress');
+  expect(task3.extensionId).toBeUndefined();
   expect(apiSenderSendMock).toBeCalledWith('task-created', task3);
 });
 
@@ -191,4 +196,10 @@ test('Ensure init setup command and statusbar registry', async () => {
 
   expect(mocks.registerCommandMock).toHaveBeenCalledOnce();
   expect(mocks.setEntryMock).toHaveBeenCalledOnce();
+});
+
+test('create tasks with title and extensionId', async () => {
+  const taskManager = new TaskManager(apiSender, statusBarRegistry, commandRegistry);
+  const task = taskManager.createTask('title', 'random-extension-id');
+  expect(task.extensionId).equal('random-extension-id');
 });

--- a/packages/main/src/plugin/task-manager.ts
+++ b/packages/main/src/plugin/task-manager.ts
@@ -55,7 +55,7 @@ export class TaskManager {
     });
   }
 
-  public createTask(title: string | undefined): StatefulTask {
+  public createTask(title: string | undefined, extensionId?: string): StatefulTask {
     this.taskId++;
     const task: StatefulTask = {
       id: `main-${this.taskId}`,
@@ -63,13 +63,14 @@ export class TaskManager {
       started: new Date().getTime(),
       state: 'running',
       status: 'in-progress',
+      extensionId: extensionId,
     };
     this.tasks.set(task.id, task);
     this.apiSender.send('task-created', task);
     return task;
   }
 
-  public createNotificationTask(notificationInfo: NotificationInfo): NotificationTask {
+  public createNotificationTask(notificationInfo: NotificationInfo, extensionId?: string): NotificationTask {
     this.taskId++;
     const task: NotificationTask = {
       id: `main-${this.taskId}`,
@@ -77,6 +78,7 @@ export class TaskManager {
       started: new Date().getTime(),
       description: notificationInfo.body || '',
       markdownActions: notificationInfo.markdownActions,
+      extensionId: extensionId,
     };
     this.tasks.set(task.id, task);
     this.apiSender.send('task-created', task);


### PR DESCRIPTION
### What does this PR do?

This PR is adding a `extensionId` property to the Task interface.

> The `NotificationCardOptions` already have such property, as it makes sense to keep track of which extension created notifcations, this PR is expanding this idea to the Tasks.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Related to https://github.com/containers/podman-desktop/issues/5804

<!-- Include any related issues from Podman Desktop 
repository (or from another issue tracker). -->

### How to test this PR?

- [x] Unit tests has been added
<!-- Please explain steps to reproduce -->
