### PR TITLE
feat: use https when deploying to kubernetes cluster

### DIFF
--- a/packages/renderer/src/lib/pod/DeployPodToKube.svelte
+++ b/packages/renderer/src/lib/pod/DeployPodToKube.svelte
@@ -145,7 +145,7 @@ function openPodDetails(): void {
 }
 
 function openRoute(route: V1Route) {
-  window.openExternal(`http://${route.spec.host}`);
+  window.openExternal(`https://${route.spec.host}`);
 }
 
 async function deployToKube() {
@@ -209,6 +209,9 @@ async function deployToKube() {
                 to: {
                   kind: 'Service',
                   name: `${bodyPod.metadata.name}-${port.hostPort}`,
+                },
+                tls: {
+                  termination: 'edge',
                 },
               },
             };


### PR DESCRIPTION

### What does this PR do?
Create routes being secured instead of unsecured http


### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/5767

### How to test this PR?

unit test provided

or deploy to DevSandbox for example