### PR TITLE
fix: check route tls to use either http or https

### DIFF
--- a/packages/renderer/src/lib/ingresses-routes/IngressRouteActions.spec.ts
+++ b/packages/renderer/src/lib/ingresses-routes/IngressRouteActions.spec.ts
@@ -69,6 +69,7 @@ test('Expect no error and status deleting route', async () => {
       name: 'service',
     },
     selected: false,
+    tlsEnabled: false,
   };
 
   const { component } = render(IngressRouteActions, { ingressRoute: routeUI });

--- a/packages/renderer/src/lib/ingresses-routes/IngressRouteColumnActions.spec.ts
+++ b/packages/renderer/src/lib/ingresses-routes/IngressRouteColumnActions.spec.ts
@@ -50,6 +50,7 @@ test('Expect action buttons with route object', async () => {
       name: 'service',
     },
     selected: false,
+    tlsEnabled: false,
   };
 
   render(IngressRouteColumnActions, { object: routeUI });

--- a/packages/renderer/src/lib/ingresses-routes/IngressRouteColumnBackend.spec.ts
+++ b/packages/renderer/src/lib/ingresses-routes/IngressRouteColumnBackend.spec.ts
@@ -128,6 +128,7 @@ test('Expect simple column styling with route', async () => {
       name: 'service',
     },
     selected: false,
+    tlsEnabled: false,
   };
   render(IngressRouteColumnBackend, { object: routeUI });
 

--- a/packages/renderer/src/lib/ingresses-routes/IngressRouteColumnHostPath.spec.ts
+++ b/packages/renderer/src/lib/ingresses-routes/IngressRouteColumnHostPath.spec.ts
@@ -124,6 +124,7 @@ test('Expect simple column styling with route', async () => {
       name: 'service',
     },
     selected: false,
+    tlsEnabled: false,
   };
   render(IngressRouteColumnHostPath, { object: routeUI });
 

--- a/packages/renderer/src/lib/ingresses-routes/IngressRouteColumnName.spec.ts
+++ b/packages/renderer/src/lib/ingresses-routes/IngressRouteColumnName.spec.ts
@@ -43,6 +43,7 @@ const routeUI: RouteUI = {
     name: 'service',
   },
   selected: false,
+  tlsEnabled: false,
 };
 
 test('Expect simple column styling with Ingress', async () => {

--- a/packages/renderer/src/lib/ingresses-routes/IngressRouteColumnStatus.spec.ts
+++ b/packages/renderer/src/lib/ingresses-routes/IngressRouteColumnStatus.spec.ts
@@ -50,6 +50,7 @@ test('Expect simple column styling with Route', async () => {
       name: 'service',
     },
     selected: false,
+    tlsEnabled: false,
   };
   render(IngressRouteColumnStatus, { object: routeUI });
 

--- a/packages/renderer/src/lib/ingresses-routes/IngressRouteDetailsSummary.spec.ts
+++ b/packages/renderer/src/lib/ingresses-routes/IngressRouteDetailsSummary.spec.ts
@@ -51,6 +51,7 @@ const routeUI: RouteUI = {
     name: 'service',
   },
   selected: false,
+  tlsEnabled: false,
 };
 
 const route: V1Route = {

--- a/packages/renderer/src/lib/ingresses-routes/RouteUI.ts
+++ b/packages/renderer/src/lib/ingresses-routes/RouteUI.ts
@@ -30,4 +30,5 @@ export interface RouteUI {
   path?: string;
   to: RouteToReference;
   selected: boolean;
+  tlsEnabled: boolean;
 }

--- a/packages/renderer/src/lib/ingresses-routes/ingress-route-utils.spec.ts
+++ b/packages/renderer/src/lib/ingresses-routes/ingress-route-utils.spec.ts
@@ -103,6 +103,7 @@ const routeUI: RouteUI = {
     kind: 'Service',
     name: 'service',
   },
+  tlsEnabled: true,
   selected: false,
 };
 
@@ -299,4 +300,49 @@ test('expect to return one hostPathObject with ingress that has multiple path', 
   expect(result.length).toBe(2);
   expect(result[0]).toEqual('StorageBucket bucket');
   expect(result[1]).toEqual('bucket-2:80');
+});
+
+test('expect tls on route', async () => {
+  const route = {
+    metadata: {
+      name: 'my-route',
+      namespace: 'test-namespace',
+    },
+    spec: {
+      host: 'foo.bar.com',
+      port: {
+        targetPort: '80',
+      },
+      tls: {
+        termination: 'edge',
+      },
+      to: {
+        kind: 'Service',
+        name: 'service',
+      },
+    },
+  } as V1Route;
+  const routeUI = ingressRouteUtils.getRouteUI(route);
+  expect(routeUI.tlsEnabled).toBeTruthy();
+});
+
+test('expect no tls on route', async () => {
+  const route = {
+    metadata: {
+      name: 'my-route',
+      namespace: 'test-namespace',
+    },
+    spec: {
+      host: 'foo.bar.com',
+      port: {
+        targetPort: '80',
+      },
+      to: {
+        kind: 'Service',
+        name: 'service',
+      },
+    },
+  } as V1Route;
+  const routeUI = ingressRouteUtils.getRouteUI(route);
+  expect(routeUI.tlsEnabled).toBeFalsy();
 });

--- a/packages/renderer/src/lib/ingresses-routes/ingress-route-utils.ts
+++ b/packages/renderer/src/lib/ingresses-routes/ingress-route-utils.ts
@@ -49,6 +49,8 @@ export class IngressRouteUtils {
         name: route.spec.to.name,
       },
       selected: false,
+      // true if tls part is defined
+      tlsEnabled: !!route.spec.tls,
     };
   }
   isIngress(object: IngressUI | RouteUI): object is IngressUI {
@@ -82,10 +84,11 @@ export class IngressRouteUtils {
     return hostPaths;
   }
   getRouteHostPaths(routeUI: RouteUI): HostPathObject[] {
+    const protocol = routeUI.tlsEnabled ? 'https' : 'http';
     return [
       {
         label: `${routeUI.host}${routeUI.path ?? ''}`,
-        url: `https://${routeUI.host}${routeUI.path ?? ''}`,
+        url: `${protocol}://${routeUI.host}${routeUI.path ?? ''}`,
       },
     ];
   }


### PR DESCRIPTION
### What does this PR do?
Ensure protocol http or https depends on the tls part of the route

### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/5766


### How to test this PR?

unit test

or deploy some routes without tls and check that it's either http or https