### PR TITLE
Copy button - Details page

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
@@ -478,7 +478,7 @@ function hasAnyConfiguration(provider: ProviderInfo) {
                 {#if container.type === 'docker'}Docker{:else if container.type === 'podman'}Podman{/if} endpoint
               </div>
               <PreferencesResourcesRenderingCopyButton
-                class="{container.status !== 'started' ? 'text-gray-900' : ''}"
+                class="text-xs {container.status !== 'started' ? 'text-gray-900' : ''}"
                 path="{container.endpoint.socketPath}" />
               {#if providerContainerConfiguration.has(provider.internalId)}
                 {@const providerConfiguration = providerContainerConfiguration.get(provider.internalId) || []}

--- a/packages/renderer/src/lib/ui/CopyToClipboard.svelte
+++ b/packages/renderer/src/lib/ui/CopyToClipboard.svelte
@@ -12,16 +12,16 @@ function copyTextToClipboard() {
 </script>
 
 <div class="float-right">
-  <Tooltip tip="Copy to Clipboard" bottom>
+  <Tooltip tip="Copy to Clipboard" bottom class="{$$props.class || ''}">
     <button
       title="Copy To Clipboard"
-      class="ml-5 {$$props.class || ''}"
+      class="ml-3 {$$props.class || ''}"
       aria-label="Copy To Clipboard"
       on:click="{() => copyTextToClipboard()}">
       <Fa icon="{faPaste}" />
     </button>
   </Tooltip>
 </div>
-<div class="mt-1 my-auto text-xs truncate {$$props.class || ''}" aria-label="{title} copy to clipboard" title="{title}">
+<div class="mt-1 my-auto truncate {$$props.class || ''}" aria-label="{title} copy to clipboard" title="{title}">
   {title}
 </div>

--- a/packages/renderer/src/lib/ui/DetailsPage.spec.ts
+++ b/packages/renderer/src/lib/ui/DetailsPage.spec.ts
@@ -44,9 +44,10 @@ test('Expect title is defined', async () => {
     title,
   });
 
-  const titleElement = screen.getByRole('heading', { level: 1, name: title });
+  const titleElement = screen.getByTitle(title);
   expect(titleElement).toBeInTheDocument();
   expect(titleElement).toHaveTextContent(title);
+  expect(titleElement.ariaLabel).toBe(`${title} copy to clipboard`);
 });
 
 test('Expect name is defined', async () => {

--- a/packages/renderer/src/lib/ui/DetailsPage.svelte
+++ b/packages/renderer/src/lib/ui/DetailsPage.svelte
@@ -2,6 +2,7 @@
 import { lastPage, currentPage } from '../../stores/breadcrumb';
 import { router } from 'tinro';
 import Link from './Link.svelte';
+import CopyToClipboard from './CopyToClipboard.svelte';
 
 export let title: string;
 export let titleDetail: string | undefined = undefined;
@@ -39,8 +40,8 @@ function handleKeydown(e: KeyboardEvent) {
         </div>
         <div class="flex flex-col grow pr-2">
           <div class="flex flex-row">
-            <h1 aria-label="{title}" class="text-xl leading-tight">{title}</h1>
-            <div class="text-violet-400 ml-2 leading-normal" class:hidden="{!titleDetail}">{titleDetail}</div>
+            <div><CopyToClipboard title="{title}" clipboardData="{title}" class="text-xl inline-block mt-1" /></div>
+            <div class="text-violet-400 ml-2 leading-normal mt-2" class:hidden="{!titleDetail}">{titleDetail}</div>
           </div>
           <div>
             <span class="text-sm leading-none text-gray-900" class:hidden="{!subtitle}">{subtitle}</span>


### PR DESCRIPTION
### What does this PR do?

It makes usage of the “Copy To Clipboard” component, so the users can copy the title of the details page to the clipboard.

### Screenshot / video of UI
![copy_button_details](https://github.com/containers/podman-desktop/assets/16507629/509627ce-72f2-4d7c-8326-3adebb5ff7f2)

### What issues does this PR fix or reference?

Fixes #4241

### How to test this PR?

1) Open the detail page
2) Click on the copy button
3) Check if the title is present on your clipboard as expected