### PR TITLE
fix: display back the icons of registries

### DIFF
--- a/extensions/registries/package.json
+++ b/extensions/registries/package.json
@@ -13,8 +13,8 @@
   "source": "./src/extension.ts",
   "scripts": {
     "build": "vite build && node ./scripts/build.js",
-    "test": "vitest run --coverage --passWithNoTests",
-    "test:watch": "vitest watch --coverage --passWithNoTests",
+    "test": "vitest run --coverage",
+    "test:watch": "vitest watch --coverage",
     "watch": "vite build --watch"
   },
   "dependencies": {

--- a/extensions/registries/src/extension.spec.ts
+++ b/extensions/registries/src/extension.spec.ts
@@ -1,0 +1,61 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
+import { activate, stripImagePrefix } from './extension';
+import * as extensionApi from '@podman-desktop/api';
+
+vi.mock('@podman-desktop/api', async () => {
+  return {
+    registry: {
+      suggestRegistry: vi.fn(),
+    },
+  };
+});
+
+beforeAll(() => {});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+test('check remove prefix', async () => {
+  const base64Content = stripImagePrefix('data:image/png;base64,content');
+  expect(base64Content).toBe('content');
+});
+
+test('activate is registering 4 registries', async () => {
+  const extensionContext = { subscriptions: [] } as unknown as extensionApi.ExtensionContext;
+
+  await activate(extensionContext);
+
+  // should be called 4 times
+  expect(vi.mocked(extensionApi.registry.suggestRegistry)).toHaveBeenCalledTimes(4);
+
+  // should be called with the right parameters
+  expect(vi.mocked(extensionApi.registry.suggestRegistry)).toHaveBeenCalledWith({
+    name: 'Docker Hub',
+    url: 'docker.io',
+    icon: '/src/images/docker.io.png',
+  });
+
+  // 4 subscriptions/disposables should be added
+  expect(extensionContext.subscriptions.length).toBe(4);
+});

--- a/extensions/registries/tsconfig.json
+++ b/extensions/registries/tsconfig.json
@@ -7,11 +7,12 @@
     "outDir": "dist",
     "target": "esnext",
     "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "types": ["node"]
   },
-  "include": ["src"],
+  "include": ["src", "types/*.d.ts"],
   "ts-node": {
     "compilerOptions": {
       "module": "CommonJS",

--- a/extensions/registries/types/template.d.ts
+++ b/extensions/registries/types/template.d.ts
@@ -1,0 +1,22 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+declare module '*.png' {
+  const contents: string;
+  export = contents;
+}


### PR DESCRIPTION
### What does this PR do?

instead of resolving images as files, embed them as resources using vite


### Screenshot / video of UI

![image](https://github.com/containers/podman-desktop/assets/436777/6525a8f0-9a3c-4720-b910-a9b123cd647c)


### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/5742


### How to test this PR?

Add unit tests