### PR TITLE
feat: making donut having a loading state

### DIFF
--- a/packages/renderer/src/lib/donut/Donut.spec.ts
+++ b/packages/renderer/src/lib/donut/Donut.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/renderer/src/lib/donut/Donut.spec.ts
+++ b/packages/renderer/src/lib/donut/Donut.spec.ts
@@ -30,11 +30,11 @@ test('Expect the tooltip to be in document', async () => {
 });
 
 test('Expect the tooltip to display loading', async () => {
-  render(Donut, { value: undefined, loading: true });
+  render(Donut, { value: undefined, title: 'potatoes', loading: true });
 
   const tooltip = screen.getByLabelText('tooltip');
   expect(tooltip).toBeInTheDocument();
-  expect(tooltip.textContent).toBe('Loading...');
+  expect(tooltip.textContent).toBe('Loading potatoes...');
 });
 
 test('Expect text being displayed when not loading', async () => {
@@ -44,9 +44,9 @@ test('Expect text being displayed when not loading', async () => {
   expect(text).toBeInTheDocument();
 });
 
-test('Expect text not being displayed when loading', async () => {
+test('Expect text being displayed when loading', async () => {
   render(Donut, { value: 'dummy-text', loading: true });
 
-  const text = screen.queryByText('dummy-text');
-  expect(text).toBeNull();
+  const text = screen.getByText('dummy-text');
+  expect(text).toBeInTheDocument();
 });

--- a/packages/renderer/src/lib/donut/Donut.spec.ts
+++ b/packages/renderer/src/lib/donut/Donut.spec.ts
@@ -1,0 +1,52 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+import { test, expect } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import Donut from '/@/lib/donut/Donut.svelte';
+
+test('Expect the tooltip to be in document', async () => {
+  render(Donut, { percent: 5, title: 'CPU', value: undefined });
+
+  const tooltip = screen.getByLabelText('tooltip');
+  expect(tooltip).toBeInTheDocument();
+  expect(tooltip.textContent).toBe('5% CPU usage');
+});
+
+test('Expect the tooltip to display loading', async () => {
+  render(Donut, { value: undefined, loading: true });
+
+  const tooltip = screen.getByLabelText('tooltip');
+  expect(tooltip).toBeInTheDocument();
+  expect(tooltip.textContent).toBe('Loading...');
+});
+
+test('Expect text being displayed when not loading', async () => {
+  render(Donut, { value: 'dummy-text', loading: false });
+
+  const text = screen.getByText('dummy-text');
+  expect(text).toBeInTheDocument();
+});
+
+test('Expect text not being displayed when loading', async () => {
+  render(Donut, { value: 'dummy-text', loading: true });
+
+  const text = screen.queryByText('dummy-text');
+  expect(text).toBeNull();
+});

--- a/packages/renderer/src/lib/donut/Donut.svelte
+++ b/packages/renderer/src/lib/donut/Donut.svelte
@@ -39,30 +39,30 @@ function getShape(): string {
   return describeArc(size / 2, (percent * 360) / 100);
 }
 
-function getTooltip(loading: boolean, percent: number): string {
-  if (loading) return 'Loading...';
+function getTooltip(loading: boolean, title: string, percent: number): string {
+  if (loading) return `Loading ${title}...`;
   return percent ? percent.toFixed(0) + '% ' + title + ' usage' : '';
 }
 
 $: stroke = getStroke(loading, percent);
 
-$: tooltip = getTooltip(loading, percent);
+$: tooltip = getTooltip(loading, title, percent);
 </script>
 
 <Tooltip tip="{tooltip}" bottom>
-  <svg viewBox="-4 -4 {size + 8} {size + 8}" height="{size}" width="{size}" class:animate-spin="{loading}">
-    <circle fill="none" class="stroke-charcoal-300" stroke-width="1" r="{size / 2}" cx="{size / 2}" cy="{size / 2}"
-    ></circle>
-    <path fill="none" class="{stroke}" stroke-width="3.5" d="{getShape()}" data-testid="arc"></path>
-    {#if !loading}
-      <text x="{size / 2}" y="38%" text-anchor="middle" font-size="{size / 5.5}" class="fill-gray-800">{title}</text>
-      <text
-        x="{size / 2}"
-        y="52%"
-        text-anchor="middle"
-        font-size="{size / 4.5}"
-        dominant-baseline="central"
-        class="fill-gray-400">{value !== undefined ? value : ''}</text>
-    {/if}
+  <svg viewBox="-4 -4 {size + 8} {size + 8}" height="{size}" width="{size}">
+    <g class:animate-spin="{loading}" class:origin-[50%_50%]="{loading}" style="transform-box: fill-box;">
+      <circle fill="none" class="stroke-charcoal-300" stroke-width="1" r="{size / 2}" cx="{size / 2}" cy="{size / 2}"
+      ></circle>
+      <path fill="none" class="{stroke}" stroke-width="3.5" d="{getShape()}" data-testid="arc"></path>
+    </g>
+    <text x="{size / 2}" y="38%" text-anchor="middle" font-size="{size / 5.5}" class="fill-gray-800">{title}</text>
+    <text
+      x="{size / 2}"
+      y="52%"
+      text-anchor="middle"
+      font-size="{size / 4.5}"
+      dominant-baseline="central"
+      class="fill-gray-400">{value !== undefined ? value : ''}</text>
   </svg>
 </Tooltip>


### PR DESCRIPTION
### What does this PR do?

Adding a loading state for the `Donut.svelte` component. This is backward compatible, as the loading state is `false` by default.

> This PR only add the support to the Donut, no component are using it for now, it will be in a follow up PR

### Screenshot / video of UI

See comments 

### What issues does this PR fix or reference?

Related to https://github.com/containers/podman-desktop/issues/5837

<!-- Include any related issues from Podman Desktop 
repository (or from another issue tracker). -->

### How to test this PR?

- [x] Unit tests has been added

<!-- Please explain steps to reproduce -->
