### PR TITLE
feat: ability to apply kube yaml

### DIFF
--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -90,6 +90,7 @@ import type {
   Context as KubernetesContext,
   Cluster,
   V1Deployment,
+  KubernetesObject,
 } from '@kubernetes/client-node';
 import type { V1Route } from './api/openshift-types.js';
 import type { NetworkInspectInfo } from './api/network-info.js';
@@ -1988,6 +1989,13 @@ export class PluginSystem {
       'kubernetes-client:createResourcesFromFile',
       async (_listener, context: string, file: string, namespace: string): Promise<void> => {
         return kubernetesClient.createResourcesFromFile(context, file, namespace);
+      },
+    );
+
+    this.ipcHandle(
+      'kubernetes-client:applyResourcesFromFile',
+      async (_listener, context: string, file: string): Promise<KubernetesObject[]> => {
+        return kubernetesClient.applyResourcesFromFile(context, file);
       },
     );
 

--- a/packages/main/src/plugin/kubernetes-client.spec.ts
+++ b/packages/main/src/plugin/kubernetes-client.spec.ts
@@ -1229,7 +1229,7 @@ test('Expect apply with empty yaml should return no objects', async () => {
 
 test('Expect apply should create if object does not exist', async () => {
   const client = createTestClient('default');
-  const manifests = { kind: test, metadata: { annotations: test } };
+  const manifests = { kind: test, metadata: { annotations: test } } as unknown as KubernetesObject;
   const createdObj = { kind: 'created' };
   vi.spyOn(client, 'loadManifestsFromFile').mockReturnValue(Promise.resolve([manifests]));
   makeApiClientMock.mockReturnValue({
@@ -1244,7 +1244,7 @@ test('Expect apply should create if object does not exist', async () => {
 
 test('Expect apply should patch if object exists', async () => {
   const client = createTestClient('default');
-  const manifests = { kind: test, metadata: { annotations: test } };
+  const manifests = { kind: test, metadata: { annotations: test } } as unknown as KubernetesObject;
   const patchedObj = { kind: 'patched' };
   vi.spyOn(client, 'loadManifestsFromFile').mockReturnValue(Promise.resolve([manifests]));
   makeApiClientMock.mockReturnValue({

--- a/packages/main/src/plugin/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes-client.ts
@@ -1017,7 +1017,7 @@ export class KubernetesClient {
 
   // load yaml file and extract manifests
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  async loadManifestsFromFile(file: string): Promise<any[]> {
+  async loadManifestsFromFile(file: string): Promise<KubernetesObject[]> {
     // throw exception if file does not exist
     if (!fs.existsSync(file)) {
       throw new Error(`File ${file} does not exist`);
@@ -1123,8 +1123,7 @@ export class KubernetesClient {
       const client = ctx.makeApiClient(KubernetesObjectApi);
       const created: KubernetesObject[] = [];
       for (const spec of validSpecs) {
-        // this is to convince TypeScript that metadata exists even though we already filtered specs
-        // without metadata out
+        // this is to convince TypeScript that metadata exists
         spec.metadata = spec.metadata || {};
         spec.metadata.annotations = spec.metadata.annotations || {};
 

--- a/packages/main/src/plugin/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes-client.ts
@@ -1124,8 +1124,8 @@ export class KubernetesClient {
       const created: KubernetesObject[] = [];
       for (const spec of validSpecs) {
         // this is to convince TypeScript that metadata exists
-        spec.metadata = spec.metadata || {};
-        spec.metadata.annotations = spec.metadata.annotations || {};
+        spec.metadata = spec.metadata ?? {};
+        spec.metadata.annotations = spec.metadata.annotations ?? {};
 
         delete spec.metadata.annotations['kubectl.kubernetes.io/last-applied-configuration'];
         spec.metadata.annotations['kubectl.kubernetes.io/last-applied-configuration'] = JSON.stringify(spec);

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -68,6 +68,7 @@ import type {
 import type {
   Cluster,
   Context,
+  KubernetesObject,
   V1ConfigMap,
   V1Deployment,
   V1Ingress,
@@ -1746,6 +1747,13 @@ function initExposure(): void {
     'kubernetesCreateResourcesFromFile',
     async (context: string, file: string, namespace: string): Promise<void> => {
       return ipcInvoke('kubernetes-client:createResourcesFromFile', context, file, namespace);
+    },
+  );
+
+  contextBridge.exposeInMainWorld(
+    'kubernetesApplyResourcesFromFile',
+    async (context: string, file: string): Promise<KubernetesObject[]> => {
+      return ipcInvoke('kubernetes-client:applyResourcesFromFile', context, file);
     },
   );
 


### PR DESCRIPTION
### What does this PR do?

Adds a function to apply a Kubernetes yaml file, identical to how 'kubectl apply -f <file>' works. Based on the API's example but adapted to our codebase.

Exposes the new function to the renderer as window.kubernetesApply().

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

First step toward #5661.

### How to test this PR?

`yarn test:main` or hardcode a call to try window.kubernetesApply().