### PR TITLE
feat: kubernetes connection store

### DIFF
--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -155,6 +155,7 @@ import { WebviewRegistry } from './webview/webview-registry.js';
 import type { IDisposable } from './types/disposable.js';
 
 import { KubernetesUtils } from './kubernetes-util.js';
+import type { KubernetesConnection } from './kubernetes-connection.js';
 
 type LogType = 'log' | 'warn' | 'trace' | 'debug' | 'error';
 
@@ -2007,6 +2008,12 @@ export class PluginSystem {
 
     this.ipcHandle('kubernetes-client:getDetailedContexts', async (): Promise<KubeContext[]> => {
       return kubernetesClient.getDetailedContexts();
+    });
+
+    this.ipcHandle('kubernetes-client:getConnectionStatus', async (): Promise<KubernetesConnection | undefined> => {
+      const value = kubernetesClient.getConnectionStatus();
+      console.log('getConnectionStatus', value);
+      return value;
     });
 
     this.ipcHandle('kubernetes-client:getClusters', async (): Promise<Cluster[]> => {

--- a/packages/main/src/plugin/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes-client.ts
@@ -65,6 +65,9 @@ import type { KubeContext } from './kubernetes-context.js';
 import type { KubernetesInformerManager } from './kubernetes-informer-registry.js';
 import type { KubernetesInformerResourcesType } from './api/kubernetes-informer-info.js';
 import type { IncomingMessage } from 'node:http';
+import type { KubernetesConnection } from '/@/plugin/kubernetes-connection.js';
+import type http from 'http';
+import type { VersionInfo } from '@kubernetes/client-node/dist/gen/model/versionInfo.js';
 
 function toContainerStatus(state: V1ContainerState | undefined): string {
   if (state) {
@@ -113,7 +116,7 @@ const DEFAULT_NAMESPACE = 'default';
  * Handle calls to kubernetes API
  */
 export class KubernetesClient {
-  protected kubeConfig;
+  protected kubeConfig: KubeConfig;
 
   private static readonly DEFAULT_KUBECONFIG_PATH = resolve(homedir(), '.kube', 'config');
 
@@ -287,6 +290,24 @@ export class KubernetesClient {
 
   getCurrentNamespace(): string | undefined {
     return this.currentNamespace;
+  }
+
+  async getConnectionStatus(): Promise<KubernetesConnection | undefined> {
+    const currentContextName = this.getCurrentContextName();
+    if (currentContextName === undefined) return undefined;
+    try {
+      await this.getCode();
+      return {
+        context: currentContextName,
+        status: 'connected',
+      };
+    } catch (e) {
+      return {
+        context: currentContextName,
+        status: 'error',
+        error: `error: ${e}`,
+      };
+    }
   }
 
   getDetailedContexts(): KubeContext[] {
@@ -854,13 +875,18 @@ export class KubernetesClient {
   // We will check via trying to retrieve a list of API Versions from the server.
   async checkConnection(): Promise<boolean> {
     try {
-      const k8sApi = this.kubeConfig.makeApiClient(VersionApi);
       // getCode will error out if we're unable to connect to the cluster
-      await k8sApi.getCode();
+      await this.getCode();
       return true;
     } catch (error) {
       return false;
     }
+  }
+
+  // Thrown an error if the server cannot be contacted
+  private async getCode(): Promise<{ response: http.IncomingMessage; body: VersionInfo }> {
+    const k8sApi = this.kubeConfig.makeApiClient(VersionApi);
+    return k8sApi.getCode();
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/main/src/plugin/kubernetes-connection.ts
+++ b/packages/main/src/plugin/kubernetes-connection.ts
@@ -1,0 +1,26 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+// A simpler method of holding all the Kubernetes context information in one place
+// for the UI to use.
+
+export interface KubernetesConnection {
+  context: string;
+  status: 'connected' | 'error';
+  error?: string;
+}

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -92,6 +92,7 @@ import type { KubernetesGeneratorInfo } from '../../main/src/plugin/api/Kubernet
 import type { NotificationCard, NotificationCardOptions } from '../../main/src/plugin/api/notification';
 import type { ApiSenderType } from '../../main/src/plugin/api';
 import type { IDisposable } from '../../main/src/plugin/types/disposable';
+import type { KubernetesConnection } from '../../main/src/plugin/kubernetes-connection';
 
 export type DialogResultCallback = (openDialogReturnValue: Electron.OpenDialogReturnValue) => void;
 
@@ -1546,6 +1547,13 @@ function initExposure(): void {
   contextBridge.exposeInMainWorld('kubernetesGetDetailedContexts', async (): Promise<KubeContext[]> => {
     return ipcInvoke('kubernetes-client:getDetailedContexts');
   });
+
+  contextBridge.exposeInMainWorld(
+    'kubernetesGetConnectionStatus',
+    async (): Promise<KubernetesConnection | undefined> => {
+      return ipcInvoke('kubernetes-client:getConnectionStatus');
+    },
+  );
 
   contextBridge.exposeInMainWorld('kubernetesDeleteContext', async (contextName: string): Promise<Context[]> => {
     return ipcInvoke('kubernetes-client:deleteContext', contextName);

--- a/packages/renderer/src/stores/kubernetes-connection.ts
+++ b/packages/renderer/src/stores/kubernetes-connection.ts
@@ -1,0 +1,42 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { writable, type Writable } from 'svelte/store';
+import { EventStore } from './event-store';
+import { checkForUpdate } from './kubernetes-contexts';
+import type { KubernetesConnection } from '../../../main/src/plugin/kubernetes-connection';
+
+const windowEvents: string[] = ['kubernetes-context-update', 'kubernetes-connection-update'];
+const windowListeners = ['extensions-already-started'];
+
+export const kubernetesConnection: Writable<KubernetesConnection | undefined> = writable(undefined);
+
+const eventStore = new EventStore<KubernetesConnection | undefined>(
+  'kubernetes connection',
+  kubernetesConnection,
+  checkForUpdate,
+  windowEvents,
+  windowListeners,
+  grabKubernetesConnection,
+);
+eventStore.setup();
+
+export async function grabKubernetesConnection(): Promise<KubernetesConnection | undefined> {
+  // for now, we only fetch one, since we do not support multiple connection at the same time
+  return await window.kubernetesGetConnectionStatus();
+}


### PR DESCRIPTION
### What does this PR do?

The connection status of the current context must be accessible to the frontend. This PR is adding a `kubernetesConnection` store.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Related to https://github.com/containers/podman-desktop/issues/5401

### How to test this PR?

- [x] Unit tests has been added
