### PR TITLE
chore: use Button for installing extension

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesInstallExtensionFromId.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesInstallExtensionFromId.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -110,7 +110,7 @@ test('Expect that the install button is there and can click on it to install', a
   await new Promise(r => setTimeout(r, 300));
 
   // and expect to have 'installed' label
-  const installedLabel = screen.getByText('Installed');
+  const installedLabel = screen.getByText('INSTALLED');
   expect(installedLabel).toBeInTheDocument();
 });
 
@@ -158,6 +158,6 @@ test('Expect that the installed label is there if extension is already installed
   expect(installButtonAfterClick).not.toBeInTheDocument();
 
   // and expect to have 'installed' label
-  const installedLabel = screen.getByText('Installed');
+  const installedLabel = screen.getByText('INSTALLED');
   expect(installedLabel).toBeInTheDocument();
 });

--- a/packages/renderer/src/lib/preferences/PreferencesInstallExtensionFromId.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesInstallExtensionFromId.svelte
@@ -17,10 +17,11 @@ import { onDestroy, onMount } from 'svelte';
 import SettingsPage from '/@/lib/preferences/SettingsPage.svelte';
 import { catalogExtensionInfos } from '/@/stores/catalog-extensions';
 import EmptyScreen from '/@/lib/ui/EmptyScreen.svelte';
-import { faPuzzlePiece } from '@fortawesome/free-solid-svg-icons';
+import { faArrowCircleDown, faPuzzlePiece } from '@fortawesome/free-solid-svg-icons';
 import Markdown from '/@/lib/markdown/Markdown.svelte';
 import { extensionInfos } from '/@/stores/extensions';
 import ErrorMessage from '/@/lib/ui/ErrorMessage.svelte';
+import Button from '../ui/Button.svelte';
 
 export let extensionId: string | undefined = undefined;
 
@@ -146,25 +147,21 @@ onDestroy(() => {
             <div class="text-sm text-gray-300">
               {extensionDetails.displayName}
             </div>
-            <div class="flex">
-              {#if installInProgress}
-                <div
-                  class="px-3 my-1 text-sm font-medium text-center text-white bg-violet-600 rounded-sm focus:outline-none cursor-default"
-                  title="Extension {extensionDetails.extensionName} is already installed.">
-                  Installing...
-                </div>
-              {:else if !isInstalled}
-                <button
-                  class="px-3 my-1 text-sm font-medium text-center text-white bg-violet-600 rounded-sm hover:bg-dustypurple-800 focus:ring-2 focus:outline-none focus:ring-dustypurple-700"
+            <div class="flex my-1">
+              {#if !isInstalled}
+                <Button
                   title="Install extension {extensionDetails.extensionName}"
+                  icon="{faArrowCircleDown}"
+                  inProgress="{installInProgress}"
                   on:click="{() => installExtension()}">
                   Install...
-                </button>
+                </Button>
               {:else}
+                <div aria-label="Installed" class="my-auto w-3 h-3 rounded-full bg-green-500"></div>
                 <div
-                  class="px-3 my-1 text-sm font-medium text-center text-white bg-violet-600 rounded-sm focus:outline-none cursor-default"
+                  class="my-1 text-xs text-green-500 ml-1 font-bold"
                   title="Extension {extensionDetails.extensionName} is already installed.">
-                  Installed
+                  INSTALLED
                 </div>
               {/if}
             </div>


### PR DESCRIPTION
### What does this PR do?

I noticed two minor issues when installing extensions from a link:
- it's using a regular button (not Button)
- once you've installed the extension the Installed div looks very similar to a button

This changes the Install button to a Button, including an icon and progress. For the Installed status we don't have a design, so I've basically copied the styling for a running extension.

### Screenshot / video of UI

<img width="255" alt="Screenshot 2024-02-05 at 4 05 42 PM" src="https://github.com/containers/podman-desktop/assets/19958075/bcbe0ebf-7845-49ef-9224-228da4d5c991">

<img width="255" alt="Screenshot 2024-02-05 at 4 26 28 PM" src="https://github.com/containers/podman-desktop/assets/19958075/7b3f8e5a-9471-4536-84b9-f7cdb157d247">

### What issues does this PR fix or reference?

Fixes #5854.

### How to test this PR?

Try an extension link like: `podman-desktop:extension/redhat.bootc`.