### PR TITLE
fix: align baselines of a title and a title detail on details page

### DIFF
--- a/packages/renderer/src/lib/ui/DetailsPage.svelte
+++ b/packages/renderer/src/lib/ui/DetailsPage.svelte
@@ -38,7 +38,7 @@ function handleKeydown(e: KeyboardEvent) {
           <slot name="icon" />
         </div>
         <div class="flex flex-col grow pr-2">
-          <div class="flex flex-row">
+          <div class="flex flex-row items-baseline">
             <h1 aria-label="{title}" class="text-xl leading-tight">{title}</h1>
             <div class="text-violet-400 ml-2 leading-normal" class:hidden="{!titleDetail}">{titleDetail}</div>
           </div>


### PR DESCRIPTION
### What does this PR do?

Fix title and title detail alignment to baseline, so for image details page `Image name` and 'image id' placed nicely at the same level.

### Screenshot / video of UI
Compare:
| before | after |
|-------|-------|
| ![Screenshot 2024-02-05 at 9 35 19 PM](https://github.com/containers/podman-desktop/assets/620330/3225339e-6e36-43b9-8786-322830104917) | ![image](https://github.com/containers/podman-desktop/assets/620330/0c6429de-5e95-4360-8aea-1a27a699359f) |

### What issues does this PR fix or reference?

Related to #4241.

### How to test this PR?

<!-- Please explain steps to reproduce -->
