### PR TITLE
feat: labels for createPod

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -275,6 +275,7 @@ declare module '@podman-desktop/api' {
   export interface PodCreateOptions {
     name: string;
     portmappings?: PodCreatePortOptions[];
+    labels?: { [key: string]: string };
     // Set the provider to use, if not we will try select the first one available (sorted in favor of Podman).
     provider?: ProviderContainerConnectionInfo | ContainerProviderConnection;
   }

--- a/packages/main/src/plugin/dockerode/libpod-dockerode.spec.ts
+++ b/packages/main/src/plugin/dockerode/libpod-dockerode.spec.ts
@@ -168,3 +168,16 @@ test('Check info', async () => {
   expect(info).toBeDefined();
   expect(info).toStrictEqual(podmanInfo);
 });
+
+test('Check labels are passed to the api when creating a pod', async () => {
+  nock('http://localhost')
+    .post('/v4.2.0/libpod/pods/create', { name: 'pod1', labels: { key1: 'value1' } })
+    .reply(201);
+  const api = new Dockerode({ protocol: 'http', host: 'localhost' });
+  await (api as unknown as LibPod).createPod({
+    name: 'pod1',
+    labels: {
+      key1: 'value1',
+    },
+  });
+});

--- a/packages/main/src/plugin/dockerode/libpod-dockerode.ts
+++ b/packages/main/src/plugin/dockerode/libpod-dockerode.ts
@@ -83,6 +83,7 @@ export interface PodCreatePortOptions {
 export interface PodCreateOptions {
   name: string;
   portmappings?: PodCreatePortOptions[];
+  labels?: { [key: string]: string };
 }
 
 export interface ContainerCreateOptions {


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Adds the possibility to define labels when using `createPod` from an extension

### Screenshot / video of UI

### What issues does this PR fix or reference?

Fixes #5861 

### How to test this PR?

<!-- Please explain steps to reproduce -->
