### PR TITLE
Revert "chore: do not collapse categories on sidebar"

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -339,7 +339,6 @@ const config = {
       /** @type {import('@docusaurus/preset-classic').Options} */
       ({
         docs: {
-          sidebarCollapsed: false,
           sidebarPath: require.resolve('./sidebars.js'),
           editUrl: 'https://github.com/containers/podman-desktop/tree/main/website',
         },
@@ -371,6 +370,7 @@ const config = {
       },
       docs: {
         sidebar: {
+          autoCollapseCategories: true,
           hideable: true,
         },
       },


### PR DESCRIPTION
Reverts containers/podman-desktop#5727

The original issue was to have only 2-levels deep for documentation, as of right now the sidebar is super-expanded:

![Screenshot 2024-02-06 at 9 02 36 AM](https://github.com/containers/podman-desktop/assets/6422176/e9cc25dc-4c53-47ec-96f1-e054f2a90267)

This was merged in by mistake and does not solve the original issue: https://github.com/containers/podman-desktop/issues/5338

We should create a solution (plugin / javascript, etc.) to solve the original #5338 issue