### PR TITLE
fix: nav item UI fixes

### DIFF
--- a/packages/renderer/src/lib/ui/NavItem.spec.ts
+++ b/packages/renderer/src/lib/ui/NavItem.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,6 +47,8 @@ test('Expect selection styling', async () => {
   expect(element).toBeInTheDocument();
   expect(element.firstChild).toBeInTheDocument();
   expect(element.firstChild).toHaveClass('border-l-purple-500');
+  expect(element.firstChild).not.toHaveClass('hover:bg-charcoal-700');
+  expect(element.firstChild).not.toHaveClass('hover:border-charcoal-700');
 });
 
 test('Expect selection styling for encoded URLs', async () => {
@@ -78,8 +80,11 @@ test('Expect not to have selection styling', async () => {
   const element = screen.getByLabelText(tooltip);
   expect(element).toBeInTheDocument();
   expect(element.firstChild).toBeInTheDocument();
-  expect(element.firstChild).not.toHaveClass('border-l-purple-500');
   expect(element.firstChild).toHaveClass('border-l-charcoal-800');
+  expect(element.firstChild).toHaveClass('hover:bg-charcoal-700');
+  expect(element.firstChild).toHaveClass('hover:border-charcoal-700');
+  expect(element.firstChild).not.toHaveClass('border-l-purple-500');
+  expect(element.firstChild).not.toHaveClass('px-2');
 });
 
 test('Expect in-section styling', async () => {
@@ -89,11 +94,15 @@ test('Expect in-section styling', async () => {
   const element = screen.getByLabelText(tooltip);
   expect(element).toBeInTheDocument();
   expect(element.firstChild).toBeInTheDocument();
-  expect(element.firstChild).toHaveClass('border-charcoal-600');
+  expect(element.firstChild).toHaveClass('px-2');
+  expect(element.firstChild).toHaveClass('hover:bg-charcoal-700');
+  expect(element.firstChild).not.toHaveClass('border-charcoal-600');
   expect(element.firstChild).not.toHaveClass('border-l-purple-500');
   expect(element.firstChild).not.toHaveClass('border-l-charcoal-800');
+  expect(element.firstChild).not.toHaveClass('hover:border-charcoal-700');
 });
-
+// class:hover:bg-charcoal-700="{!selected || inSection}"
+// class:hover:border-charcoal-700="{!selected && !inSection}"
 test('Expect in-section selection styling', async () => {
   const tooltip = 'Dashboard';
   render(NavItemTest);
@@ -102,7 +111,10 @@ test('Expect in-section selection styling', async () => {
   expect(element).toBeInTheDocument();
   expect(element.firstChild).toBeInTheDocument();
   expect(element.firstChild).toHaveClass('text-purple-500');
+  expect(element.firstChild).toHaveClass('px-2');
+  expect(element.firstChild).toHaveClass('hover:bg-charcoal-700');
   expect(element.firstChild).not.toHaveClass('border-l-purple-500');
+  expect(element.firstChild).not.toHaveClass('hover:border-charcoal-700');
 });
 
 test('Expect that having an onClick handler overrides href and works', async () => {

--- a/packages/renderer/src/lib/ui/NavItem.svelte
+++ b/packages/renderer/src/lib/ui/NavItem.svelte
@@ -35,17 +35,18 @@ onDestroy(() => {
   aria-label="{ariaLabel ? ariaLabel : tooltip}"
   on:click|preventDefault="{onClick}">
   <div
-    class="flex py-3 justify-center items-center border-x-[4px] cursor-pointer"
+    class="flex py-3 justify-center items-center cursor-pointer"
+    class:border-x-[4px]="{!inSection}"
+    class:px-2="{inSection}"
     class:border-charcoal-800="{!inSection}"
-    class:border-charcoal-600="{inSection}"
     class:text-white="{!selected || !inSection}"
     class:text-purple-500="{selected && inSection}"
     class:border-l-purple-500="{selected && !inSection}"
     class:bg-charcoal-500="{selected && !inSection}"
     class:border-r-charcoal-500="{selected && !inSection}"
     class:border-l-charcoal-800="{!selected && !inSection}"
-    class:hover:bg-charcoal-700="{!selected}"
-    class:hover:border-charcoal-700="{!selected}">
+    class:hover:bg-charcoal-700="{!selected || inSection}"
+    class:hover:border-charcoal-700="{!selected && !inSection}">
     <Tooltip tip="{tooltip}" right>
       <slot />
     </Tooltip>


### PR DESCRIPTION
### What does this PR do?

This fixes two minor UI issues for nav items inside sections:

- Makes the hover selection wider (was oddly narrow before).
- Hover now works over selected item in nav sections (before the selected item didn't have any hover).

### Screenshot / video of UI

Before:

No hover over selected
<img width="57" alt="Screenshot 2024-02-06 at 4 05 07 PM" src="https://github.com/containers/podman-desktop/assets/19958075/9195a2ca-17b5-4341-bbf2-d4e621a0f1dc">

Oddly shaped hover
<img width="57" alt="Screenshot 2024-02-06 at 4 04 56 PM" src="https://github.com/containers/podman-desktop/assets/19958075/dfca8e15-f12d-4a40-b13b-70a00986a7b8">

After:

<img width="57" alt="Screenshot 2024-02-06 at 4 04 11 PM" src="https://github.com/containers/podman-desktop/assets/19958075/f526a807-c03a-486a-9464-a88ed64edbdc">

### What issues does this PR fix or reference?

This started as a fix for #5671 (first issue), which @axel7083 has since closed but I still feel should be fixed.

### How to test this PR?

Check the main nav for any obvious hover/selection issues.