### PR TITLE
chore: white tooltips

### DIFF
--- a/packages/renderer/src/lib/ui/Tooltip.spec.ts
+++ b/packages/renderer/src/lib/ui/Tooltip.spec.ts
@@ -1,0 +1,33 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import '@testing-library/jest-dom/vitest';
+import { test, expect } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import Tooltip from './Tooltip.svelte';
+
+test('Expect basic styling', async () => {
+  const tooltip = 'test';
+  render(Tooltip, { tip: tooltip });
+
+  const element = screen.getByLabelText('tooltip');
+  expect(element).toBeInTheDocument();
+  expect(element).toHaveClass('text-white');
+});

--- a/packages/renderer/src/lib/ui/Tooltip.svelte
+++ b/packages/renderer/src/lib/ui/Tooltip.svelte
@@ -60,7 +60,7 @@ export let left = false;
     class:top-left="{topLeft}"
     class:top-right="{topRight}">
     {#if tip}
-      <div class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs" aria-label="tooltip">{tip}</div>
+      <div class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs text-white" aria-label="tooltip">{tip}</div>
     {/if}
   </div>
 </div>


### PR DESCRIPTION
### What does this PR do?

Tooltip text currently picks up the current color of the parent, which means that if you have a green background, you get a green tooltip. I can't think of any case where we'd want this to be the case; tooltips should have white text and this should be consistent.

### Screenshot / video of UI

Before:

<img width="176" alt="Screenshot 2024-02-06 at 4 11 54 PM" src="https://github.com/containers/podman-desktop/assets/19958075/59f33f48-103f-4401-b04c-5cae47abe27c">

After:

<img width="176" alt="Screenshot 2024-02-06 at 4 07 32 PM" src="https://github.com/containers/podman-desktop/assets/19958075/6722fc9b-ddbe-43b1-a0c2-a21761a2b9e3">

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Try some tooltips for regression.