### PR TITLE
chore: rename Route.ts to navigation.ts

### DIFF
--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -45,7 +45,7 @@ import CreateVolume from './lib/volume/CreateVolume.svelte';
 import CommandPalette from './lib/dialogs/CommandPalette.svelte';
 import Appearance from './lib/appearance/Appearance.svelte';
 import type { NavigationRequest } from '../../main/src/plugin/navigation/navigation-request';
-import { navigationHandle } from '/@/Route';
+import { handleNavigation } from '/@/navigation';
 import IngressesRoutesList from './lib/ingresses-routes/IngressesRoutesList.svelte';
 import Webview from './lib/webview/Webview.svelte';
 import IngressDetails from './lib/ingresses-routes/IngressDetails.svelte';
@@ -63,7 +63,7 @@ router.subscribe(function (navigation) {
 
 window.events?.receive('navigate', (navigationRequest: unknown) => {
   const navRequest = navigationRequest as NavigationRequest;
-  navigationHandle(navRequest.page, navRequest.parameters);
+  handleNavigation(navRequest.page, navRequest.parameters);
 });
 </script>
 

--- a/packages/renderer/src/Route.svelte
+++ b/packages/renderer/src/Route.svelte
@@ -3,7 +3,7 @@ import { createRouteObject } from 'tinro/dist/tinro_lib';
 import type { TinroBreadcrumb, TinroRouteMeta } from 'tinro';
 import { TelemetryService } from './TelemetryService';
 import { lastPage, currentPage, history } from './stores/breadcrumb';
-import type { NavigationHint } from './Route';
+import type { NavigationHint } from './navigation';
 import { onDestroy } from 'svelte';
 
 export let path = '/*';

--- a/packages/renderer/src/navigation.spec.ts
+++ b/packages/renderer/src/navigation.spec.ts
@@ -1,0 +1,37 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { test, expect, vi } from 'vitest';
+import { NavigationPage } from '../../main/src/plugin/navigation/navigation-page';
+import { handleNavigation } from './navigation';
+import { router } from 'tinro';
+
+// mock the router
+vi.mock('tinro', () => {
+  return {
+    router: {
+      goto: vi.fn(),
+    },
+  };
+});
+
+test('Test navigationHandle to a specific container', () => {
+  handleNavigation(NavigationPage.CONTAINER, { id: '123' });
+
+  expect(vi.mocked(router.goto)).toHaveBeenCalledWith('/containers/123/');
+});

--- a/packages/renderer/src/navigation.ts
+++ b/packages/renderer/src/navigation.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ import { router } from 'tinro';
  */
 export type NavigationHint = 'root' | 'details' | 'tab';
 
-export const navigationHandle = (page: NavigationPage, parameters?: { [key: string]: string }) => {
+export const handleNavigation = (page: NavigationPage, parameters?: { [key: string]: string }) => {
   switch (page) {
     case NavigationPage.CONTAINERS:
       router.goto('/containers');


### PR DESCRIPTION
### What does this PR do?
it was confusing as there is a Route.svelte object as well
use all lowercase (not a Svelte component)
rename navigationHandle to handleNavigation method
add unit test

### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

consistency

### How to test this PR?

unit test provided