### PR TITLE
Kube apply button

### DIFF
--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -2010,8 +2010,8 @@ export class PluginSystem {
 
     this.ipcHandle(
       'kubernetes-client:applyResourcesFromFile',
-      async (_listener, context: string, file: string): Promise<KubernetesObject[]> => {
-        return kubernetesClient.applyResourcesFromFile(context, file);
+      async (_listener, context: string, file: string, namespace?: string): Promise<KubernetesObject[]> => {
+        return kubernetesClient.applyResourcesFromFile(context, file, namespace);
       },
     );
 

--- a/packages/main/src/plugin/kubernetes-client.spec.ts
+++ b/packages/main/src/plugin/kubernetes-client.spec.ts
@@ -1218,22 +1218,27 @@ test('Expect ingress refreshInformer should stop and start the informer again', 
 
 test('Expect apply with invalid file should error', async () => {
   const client = createTestClient('default');
+  let expectedError: unknown;
   try {
     await client.applyResourcesFromFile('default', 'missing-file.yaml');
-    throw Error('should never get here');
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  } catch (err: any) {
-    expect(err).to.be.a('Error');
-    expect(err.message).equal('File missing-file.yaml does not exist');
+  } catch (err: unknown) {
+    expectedError = err;
   }
+  expect(expectedError).to.be.a('Error');
+  expect((expectedError as Error).message).equal('File missing-file.yaml does not exist');
 });
 
-test('Expect apply with empty yaml should return no objects', async () => {
+test('Expect apply with empty yaml should throw error', async () => {
   const client = createTestClient('default');
   vi.spyOn(client, 'loadManifestsFromFile').mockReturnValue(Promise.resolve([]));
-
-  const objects = await client.applyResourcesFromFile('default', 'missing-file.yaml');
-  expect(objects).toEqual([]);
+  let expectedError: unknown;
+  try {
+    await client.applyResourcesFromFile('default', 'missing-file.yaml');
+  } catch (err: unknown) {
+    expectedError = err;
+  }
+  expect(expectedError).to.be.a('Error');
+  expect((expectedError as Error).message).equal('No valid Kubernetes resources found in file');
 });
 
 test('Expect apply should create if object does not exist', async () => {

--- a/packages/main/src/plugin/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes-client.ts
@@ -1048,6 +1048,9 @@ export class KubernetesClient {
    */
   async createResourcesFromFile(context: string, filePath: string, namespace?: string): Promise<void> {
     const manifests = await this.loadManifestsFromFile(filePath);
+    if (manifests.filter(s => s?.kind).length === 0) {
+      throw new Error('No valid Kubernetes resources found in file');
+    }
     await this.syncResources(context, manifests, 'create', namespace);
   }
 
@@ -1074,6 +1077,9 @@ export class KubernetesClient {
    */
   async applyResourcesFromFile(context: string, filePath: string, namespace?: string): Promise<KubernetesObject[]> {
     const manifests = await this.loadManifestsFromFile(filePath);
+    if (manifests.filter(s => s?.kind).length === 0) {
+      throw new Error('No valid Kubernetes resources found in file');
+    }
     return this.syncResources(context, manifests, 'apply', namespace);
   }
 

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -1829,8 +1829,8 @@ export function initExposure(): void {
 
   contextBridge.exposeInMainWorld(
     'kubernetesApplyResourcesFromFile',
-    async (context: string, file: string): Promise<KubernetesObject[]> => {
-      return ipcInvoke('kubernetes-client:applyResourcesFromFile', context, file);
+    async (context: string, file: string, namespace?: string): Promise<KubernetesObject[]> => {
+      return ipcInvoke('kubernetes-client:applyResourcesFromFile', context, file, namespace);
     },
   );
 

--- a/packages/renderer/src/lib/deployments/DeploymentsList.svelte
+++ b/packages/renderer/src/lib/deployments/DeploymentsList.svelte
@@ -21,6 +21,7 @@ import FilteredEmptyScreen from '../ui/FilteredEmptyScreen.svelte';
 import SimpleColumn from '../table/SimpleColumn.svelte';
 import DurationColumn from '../table/DurationColumn.svelte';
 import KubernetesCurrentContextConnectionBadge from '/@/lib/ui/KubernetesCurrentContextConnectionBadge.svelte';
+import KubeApplyYamlButton from '../kube/KubeApplyYAMLButton.svelte';
 
 export let searchTerm = '';
 $: searchPattern.set(searchTerm);
@@ -112,6 +113,10 @@ const row = new Row<DeploymentUI>({ selectable: _deployment => true });
 </script>
 
 <NavPage bind:searchTerm="{searchTerm}" title="deployments">
+  <svelte:fragment slot="additional-actions">
+    <KubeApplyYamlButton />
+  </svelte:fragment>
+
   <svelte:fragment slot="bottom-additional-actions">
     {#if selectedItemsNumber > 0}
       <Button

--- a/packages/renderer/src/lib/images/SolidKubeIcon.svelte
+++ b/packages/renderer/src/lib/images/SolidKubeIcon.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+import KubeIcon from './KubeIcon.svelte';
+
+export let size = '1em';
+</script>
+
+<KubeIcon size="{size}" solid="{true}" />

--- a/packages/renderer/src/lib/ingresses-routes/IngressesRoutesList.svelte
+++ b/packages/renderer/src/lib/ingresses-routes/IngressesRoutesList.svelte
@@ -22,6 +22,7 @@ import IngressRouteColumnBackend from './IngressRouteColumnBackend.svelte';
 import { filtered as filteredRoutes, searchPattern as searchPatternRoutes } from '/@/stores/routes';
 import IngressRouteColumnStatus from './IngressRouteColumnStatus.svelte';
 import KubernetesCurrentContextConnectionBadge from '/@/lib/ui/KubernetesCurrentContextConnectionBadge.svelte';
+import KubeApplyYamlButton from '../kube/KubeApplyYAMLButton.svelte';
 
 export let searchTerm = '';
 $: searchPatternRoutes.set(searchTerm);
@@ -142,6 +143,10 @@ const row = new Row<IngressUI | RouteUI>({ selectable: _ingressRoute => true });
 </script>
 
 <NavPage bind:searchTerm="{searchTerm}" title="Ingresses & Routes">
+  <svelte:fragment slot="additional-actions">
+    <KubeApplyYamlButton />
+  </svelte:fragment>
+
   <svelte:fragment slot="bottom-additional-actions">
     {#if selectedItemsNumber > 0}
       <Button

--- a/packages/renderer/src/lib/kube/KubeApplyYAMLButton.spec.ts
+++ b/packages/renderer/src/lib/kube/KubeApplyYAMLButton.spec.ts
@@ -1,0 +1,119 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+import { test, expect, vi, beforeAll } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import KubeApplyYamlButton from './KubeApplyYAMLButton.svelte';
+
+const currentContext: string = 'test-context';
+const currentNamespace: string = 'test-namespace';
+const openFileDialogMock = vi.fn();
+const kubernetesApplyResourcesFromFileMock = vi.fn();
+const showMessageBoxMock = vi.fn();
+
+// fake the window object
+beforeAll(() => {
+  (window as any).openFileDialog = openFileDialogMock;
+  (window as any).kubernetesGetCurrentNamespace = vi.fn().mockResolvedValue(currentNamespace);
+  (window as any).kubernetesGetCurrentContextName = vi.fn().mockResolvedValue(currentContext);
+  (window as any).kubernetesApplyResourcesFromFile = kubernetesApplyResourcesFromFileMock;
+  (window as any).showMessageBox = showMessageBoxMock;
+});
+
+test('Verify clicking button will open file dialog and canceling will exit', async () => {
+  render(KubeApplyYamlButton);
+
+  openFileDialogMock.mockResolvedValue({ canceled: true });
+
+  const button = screen.getByRole('button', { name: 'Apply YAML' });
+  expect(button).toBeInTheDocument();
+  await userEvent.click(button);
+
+  expect(openFileDialogMock).toHaveBeenCalled();
+  expect(kubernetesApplyResourcesFromFileMock).not.toHaveBeenCalled();
+});
+
+test('Verify selected file will be applied', async () => {
+  render(KubeApplyYamlButton);
+
+  const filename = 'service.yaml';
+  openFileDialogMock.mockResolvedValue({ canceled: false, filePaths: [filename] });
+
+  const button = screen.getByRole('button', { name: 'Apply YAML' });
+  expect(button).toBeInTheDocument();
+  await userEvent.click(button);
+
+  expect(openFileDialogMock).toHaveBeenCalled();
+  expect(kubernetesApplyResourcesFromFileMock).toHaveBeenCalledWith(currentContext, filename, currentNamespace);
+});
+
+test('Verify success will open an info dialog', async () => {
+  render(KubeApplyYamlButton);
+
+  const filename = 'service.yaml';
+  openFileDialogMock.mockResolvedValue({ canceled: false, filePaths: [filename] });
+  kubernetesApplyResourcesFromFileMock.mockReturnValue([{}]);
+
+  const button = screen.getByRole('button', { name: 'Apply YAML' });
+  expect(button).toBeInTheDocument();
+  await userEvent.click(button);
+
+  expect(openFileDialogMock).toHaveBeenCalled();
+  expect(kubernetesApplyResourcesFromFileMock).toHaveBeenCalledWith(currentContext, filename, currentNamespace);
+
+  expect(showMessageBoxMock).toHaveBeenCalled();
+  expect(showMessageBoxMock).toHaveBeenCalledWith(expect.objectContaining({ type: 'info' }));
+});
+
+test('Verify no results will open a warning dialog', async () => {
+  render(KubeApplyYamlButton);
+
+  const filename = 'service.yaml';
+  openFileDialogMock.mockResolvedValue({ canceled: false, filePaths: [filename] });
+  kubernetesApplyResourcesFromFileMock.mockReturnValue([]);
+
+  const button = screen.getByRole('button', { name: 'Apply YAML' });
+  expect(button).toBeInTheDocument();
+  await userEvent.click(button);
+
+  expect(openFileDialogMock).toHaveBeenCalled();
+  expect(kubernetesApplyResourcesFromFileMock).toHaveBeenCalledWith(currentContext, filename, currentNamespace);
+
+  expect(showMessageBoxMock).toHaveBeenCalled();
+  expect(showMessageBoxMock).toHaveBeenCalledWith(expect.objectContaining({ type: 'warning' }));
+});
+
+test('Verify failure will open an error dialog', async () => {
+  render(KubeApplyYamlButton);
+
+  const filename = 'service.yaml';
+  openFileDialogMock.mockResolvedValue({ canceled: false, filePaths: [filename] });
+  kubernetesApplyResourcesFromFileMock.mockRejectedValue('error');
+
+  const button = screen.getByRole('button', { name: 'Apply YAML' });
+  expect(button).toBeInTheDocument();
+  await userEvent.click(button);
+
+  expect(openFileDialogMock).toHaveBeenCalled();
+  expect(kubernetesApplyResourcesFromFileMock).toHaveBeenCalledWith(currentContext, filename, currentNamespace);
+
+  expect(showMessageBoxMock).toHaveBeenCalled();
+  expect(showMessageBoxMock).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' }));
+});

--- a/packages/renderer/src/lib/kube/KubeApplyYAMLButton.svelte
+++ b/packages/renderer/src/lib/kube/KubeApplyYAMLButton.svelte
@@ -1,0 +1,59 @@
+<script lang="ts">
+import Button from '../ui/Button.svelte';
+import type { KubernetesObject } from '@kubernetes/client-node';
+import SolidKubeIcon from '../images/SolidKubeIcon.svelte';
+
+let inProgress = false;
+
+async function kubeApply(): Promise<void> {
+  let contextName = await window.kubernetesGetCurrentContextName();
+  if (!contextName) {
+    return;
+  }
+
+  const result = await window.openFileDialog('Select a .yaml file to apply', {
+    name: 'YAML files',
+    extensions: ['yaml', 'yml'],
+  });
+  if (result.canceled || result.filePaths.length !== 1) {
+    return;
+  }
+
+  let file = result.filePaths[0];
+  if (!file) {
+    return;
+  }
+
+  inProgress = true;
+  try {
+    const namespace = await window.kubernetesGetCurrentNamespace();
+    let objects: KubernetesObject[] = await window.kubernetesApplyResourcesFromFile(contextName, file, namespace);
+    if (objects.length === 0) {
+      await window.showMessageBox({
+        title: 'Kubernetes',
+        type: 'warning',
+        message: `No resource(s) were applied`,
+        buttons: ['OK'],
+      });
+    } else {
+      await window.showMessageBox({
+        title: 'Kubernetes',
+        type: 'info',
+        message: `Successfully applied ${objects.length} resource(s)`,
+        buttons: ['OK'],
+      });
+    }
+  } catch (error) {
+    await window.showMessageBox({
+      title: 'Kubernetes',
+      type: 'error',
+      message: 'Could not apply Kubernetes YAML: ' + error,
+      buttons: ['OK'],
+    });
+  }
+  inProgress = false;
+}
+</script>
+
+<Button on:click="{() => kubeApply()}" title="Apply YAML" icon="{SolidKubeIcon}" inProgress="{inProgress}"
+  >Apply YAML</Button>

--- a/packages/renderer/src/lib/service/ServicesList.svelte
+++ b/packages/renderer/src/lib/service/ServicesList.svelte
@@ -19,6 +19,7 @@ import SimpleColumn from '../table/SimpleColumn.svelte';
 import DurationColumn from '../table/DurationColumn.svelte';
 import ServiceColumnType from './ServiceColumnType.svelte';
 import KubernetesCurrentContextConnectionBadge from '/@/lib/ui/KubernetesCurrentContextConnectionBadge.svelte';
+import KubeApplyYamlButton from '../kube/KubeApplyYAMLButton.svelte';
 
 export let searchTerm = '';
 $: searchPattern.set(searchTerm);
@@ -118,6 +119,10 @@ const row = new Row<ServiceUI>({ selectable: _service => true });
 </script>
 
 <NavPage bind:searchTerm="{searchTerm}" title="services">
+  <svelte:fragment slot="additional-actions">
+    <KubeApplyYamlButton />
+  </svelte:fragment>
+
   <svelte:fragment slot="bottom-additional-actions">
     {#if selectedItemsNumber > 0}
       <Button


### PR DESCRIPTION
### What does this PR do?

Based on PR #5849, only /renderer files (latest commit) is changed here.

Creates an 'Apply YAML' button that prompts for a file, applies it to
the current context, and reports how many resources have been created.

I've added the button to the Deployments, Services, and Ingress/Routes
pages, as these are the most useful pages for a Kubernetes user. I
didn't add it to the Pods page b/c this is less likely used for a
Kube user and it might create confusion with the 'Play Kubernetes YAML'
button.

Created a SolidKubeIcon identical to how we created a SolidPodIcon
for the 'create pod from containers' action.

### Screenshot / video of UI

<img width="259" alt="Screenshot 2024-02-14 at 4 16 49 PM" src="https://github.com/containers/podman-desktop/assets/19958075/61296777-3878-4432-991e-d717c16afdb5">

### What issues does this PR fix or reference?

Fixes #5661.

### How to test this PR?

Unit tests included. Pick your favourite yaml and apply!