### PR TITLE
chore: remove docker compatibility warning & button on Linux

### DIFF
--- a/extensions/podman/package.json
+++ b/extensions/podman/package.json
@@ -153,7 +153,7 @@
           "type": "boolean",
           "default": false,
           "description": "Docker compatibility mode is a feature that allows you to use Podman as a drop-in replacement for Docker-compatible CLI tools. Podman will automatically emulate a Docker API socket connection (typically) to /var/run/docker.sock. NOTE: This requires administrative privileges.",
-          "when": "!isWindows"
+          "when": "isMac"
         }
       }
     },

--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -1532,7 +1532,7 @@ function setupDisguisedPodmanSocketWatcher(
   return socketWatcher;
 }
 
-async function checkDisguisedPodmanSocket(provider: extensionApi.Provider) {
+export async function checkDisguisedPodmanSocket(provider: extensionApi.Provider) {
   // Check to see if the socket is disguised or not. If it is, we'll push a warning up
   // to the plugin library to the let the provider know that there is a warning
   const disguisedCheck = await isDisguisedPodman();

--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -908,8 +908,8 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
   }
 
   // Compatibility mode status bar item
-  // only available for macOS or Linux (for now).
-  if (isMac() || isLinux()) {
+  // only available for macOS
+  if (isMac()) {
     // Handle any configuration changes (for example, changing the boolean button for compatibility mode)
     extensionApi.configuration.onDidChangeConfiguration(async e => {
       if (e.affectsConfiguration(`podman.${configurationCompatibilityMode}`)) {
@@ -1546,8 +1546,13 @@ async function checkDisguisedPodmanSocket(provider: extensionApi.Provider) {
   // If isDisguisedPodmanSocket is true, we'll push a warning up to the plugin library with getDisguisedPodmanWarning()
   // If isDisguisedPodmanSocket is false, we'll push an empty array up to the plugin library to clear the warning
   // as we have no other warnings to display (or implemented)
-  const retrievedWarnings = isDisguisedPodmanSocket ? [] : [getDisguisedPodmanInformation()];
-  provider.updateWarnings(retrievedWarnings);
+
+  // NOTE: LINUX SUPPORT
+  // Linux does not support compatibility mode button, so do not sending the warning
+  if (!isLinux()) {
+    const retrievedWarnings = isDisguisedPodmanSocket ? [] : [getDisguisedPodmanInformation()];
+    provider.updateWarnings(retrievedWarnings);
+  }
 }
 
 // Shortform for getting the compatibility mode setting


### PR DESCRIPTION
chore: remove docker compatibility warning & button on Linux

### What does this PR do?

Due to limitations of using PD via flatpak, we are disabling / removing
the docker compatibility button.

The reason being is that PD requires manipulation of the host system
(creating symlinks).

Another reasoning is the enablement of docker compatibility was for docker compose support. This is now supported with `podman compose`.

This PR:
* Removes the button for docker compatibility
* Ignores the warning
* Removes the configuration setting for Linux for docker compatibility

### Screenshot / video of UI

![Screenshot from 2024-02-07 17-53-09](https://github.com/containers/podman-desktop/assets/6422176/ba05c9ec-5796-4110-98b3-727884d0a844)


<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes #5789

### How to test this PR?

<!-- Please explain steps to reproduce -->

1. Use `yarn watch` or `yarn compile` and execute the Flatpak
2. See there is no longer a docker compatibility on the status bar, or a
   warning.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
