### PR TITLE
chore: use entire height when creating container

### DIFF
--- a/packages/renderer/src/lib/image/RunImage.svelte
+++ b/packages/renderer/src/lib/image/RunImage.svelte
@@ -654,7 +654,7 @@ async function assertAllPortAreValid(): Promise<void> {
           </div>
           <div>
             <Route path="/basic" breadcrumb="Basic" navigationHint="tab">
-              <div class="h-96 overflow-y-auto pr-4">
+              <div class="overflow-y-auto pr-4">
                 <label for="modalContainerName" class="block mb-2 text-sm font-medium text-gray-400 dark:text-gray-400"
                   >Container name:</label>
                 <input


### PR DESCRIPTION
chore: use entire height when creating container

### What does this PR do?

Uses the entire height instead of limiting it.

Small change, so only visual / no tests.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

Before:
![Screenshot 2024-02-08 at 4 28 33 PM](https://github.com/containers/podman-desktop/assets/6422176/48995460-8b5b-43c0-a892-394169d754e6)

After:
![Screenshot 2024-02-08 at 4 30 33 PM](https://github.com/containers/podman-desktop/assets/6422176/559cfd74-bfc9-4cac-b241-881135b88da9)




### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

N/A

### How to test this PR?

<!-- Please explain steps to reproduce -->

Go to create a container, you should see the height be the entire
window.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
