### PR TITLE
chore: rework unit test to avoid dependency to extension loader

### DIFF
--- a/packages/main/src/plugin/cli-tool-registry.spec.ts
+++ b/packages/main/src/plugin/cli-tool-registry.spec.ts
@@ -17,115 +17,37 @@
  ***********************************************************************/
 
 import { beforeEach, test, expect, vi, suite } from 'vitest';
-import { ExtensionLoader } from './extension-loader.js';
 import type { Exec } from './util/exec.js';
 import type { ApiSenderType } from './api.js';
-import type { AuthenticationImpl } from './authentication.js';
 import { CliToolRegistry } from './cli-tool-registry.js';
-import type { CommandRegistry } from './command-registry.js';
-import type { ConfigurationRegistry } from './configuration-registry.js';
-import type { ContainerProviderRegistry } from './container-registry.js';
-import type { CustomPickRegistry } from './custompick/custompick-registry.js';
-import type { Directories } from './directories.js';
-import type { FilesystemMonitoring } from './filesystem-monitoring.js';
-import type { IconRegistry } from './icon-registry.js';
-import type { ImageRegistry } from './image-registry.js';
-import type { InputQuickPickRegistry } from './input-quickpick/input-quickpick-registry.js';
-import type { KubeGeneratorRegistry } from './kube-generator-registry.js';
-import type { KubernetesClient } from './kubernetes-client.js';
-import type { MenuRegistry } from './menu-registry.js';
-import type { MessageBox } from './message-box.js';
-import type { OnboardingRegistry } from './onboarding-registry.js';
-import type { ProgressImpl } from './progress-impl.js';
-import type { ProviderRegistry } from './provider-registry.js';
-import type { StatusBarRegistry } from './statusbar/statusbar-registry.js';
+
 import type { Telemetry } from './telemetry/telemetry.js';
-import type { TrayMenuRegistry } from './tray-menu-registry.js';
-import type { ViewRegistry } from './view-registry.js';
-import type { Context } from './context/context.js';
-import type { Proxy } from './proxy.js';
 import { afterEach } from 'node:test';
 import type { CliToolOptions, CliToolUpdate, Logger } from '@podman-desktop/api';
-import type { NotificationRegistry } from './notification-registry.js';
-import type { ImageCheckerImpl } from './image-checker.js';
 import type { CliToolImpl } from './cli-tool-impl.js';
-import type { NavigationManager } from '/@/plugin/navigation/navigation-manager.js';
-import type { WebviewRegistry } from '/@/plugin/webview/webview-registry.js';
-import { app } from 'electron';
+import type { CliToolExtensionInfo } from './api/cli-tool-info.js';
 
 const apiSender: ApiSenderType = {
   send: vi.fn(),
   receive: vi.fn(),
 };
 
-vi.mock('electron', () => {
-  return {
-    app: {
-      getVersion: vi.fn(),
-    },
-  };
-});
-
-const directories = {
-  getPluginsDirectory: () => '/fake-plugins-directory',
-  getPluginsScanDirectory: () => '/fake-plugins-scanning-directory',
-  getExtensionsStorageDirectory: () => '/fake-extensions-storage-directory',
-} as unknown as Directories;
-
 let cliToolRegistry: CliToolRegistry;
 suite('cli module', () => {
-  let extLoader: ExtensionLoader;
   beforeEach(() => {
     cliToolRegistry = new CliToolRegistry(apiSender, vi.fn() as unknown as Exec, vi.fn() as unknown as Telemetry);
-    extLoader = new ExtensionLoader(
-      vi.fn() as unknown as CommandRegistry,
-      vi.fn() as unknown as MenuRegistry,
-      vi.fn() as unknown as ProviderRegistry,
-      vi.fn() as unknown as ConfigurationRegistry,
-      vi.fn() as unknown as ImageRegistry,
-      vi.fn() as unknown as ApiSenderType,
-      vi.fn() as unknown as TrayMenuRegistry,
-      vi.fn() as unknown as MessageBox,
-      vi.fn() as unknown as ProgressImpl,
-      vi.fn() as unknown as StatusBarRegistry,
-      vi.fn() as unknown as KubernetesClient,
-      vi.fn() as unknown as FilesystemMonitoring,
-      vi.fn() as unknown as Proxy,
-      vi.fn() as unknown as ContainerProviderRegistry,
-      vi.fn() as unknown as InputQuickPickRegistry,
-      vi.fn() as unknown as CustomPickRegistry,
-      vi.fn() as unknown as AuthenticationImpl,
-      vi.fn() as unknown as IconRegistry,
-      vi.fn() as unknown as OnboardingRegistry,
-      vi.fn() as unknown as Telemetry,
-      vi.fn() as unknown as ViewRegistry,
-      vi.fn() as unknown as Context,
-      directories,
-      vi.fn() as unknown as Exec,
-      vi.fn() as unknown as KubeGeneratorRegistry,
-      cliToolRegistry,
-      vi.fn() as unknown as NotificationRegistry,
-      vi.fn() as unknown as ImageCheckerImpl,
-      vi.fn() as unknown as NavigationManager,
-      vi.fn() as unknown as WebviewRegistry,
-    );
-
-    // mock electron.app.getVersion
-    vi.mocked(app.getVersion).mockReturnValue('1.2.3');
   });
 
   afterEach(() => {
     vi.resetAllMocks();
   });
-  const extManifest = {
-    publisher: 'ext-publisher',
-    name: 'ext-name',
-    displayName: 'ext-display-name',
-    version: 'ext-version',
+  const extensionInfo: CliToolExtensionInfo = {
+    id: 'ext-publisher.ext-name',
+    label: 'my-label',
   };
+
   suite('create CliTool', () => {
     test('creates CliTool instance using CliToolsOptions properties', () => {
-      const api = extLoader.createApi('/path', extManifest);
       const options: CliToolOptions = {
         name: 'tool-name',
         displayName: 'tool-display-name',
@@ -134,8 +56,8 @@ suite('cli module', () => {
         version: '1.0.1',
         path: 'path/to/tool-name',
       };
-      const newCliTool = api.cli.createCliTool(options);
-      expect(newCliTool.id).equals(`${extManifest.publisher}.${extManifest.name}.${options.name}`);
+      const newCliTool = cliToolRegistry.createCliTool(extensionInfo, options);
+      expect(newCliTool.id).equals(`${extensionInfo.id}.${options.name}`);
       expect(newCliTool.name).equals(options.name);
       expect(newCliTool.displayName).equals(options.displayName);
       expect(newCliTool.markdownDescription).equals(options.markdownDescription);
@@ -144,7 +66,6 @@ suite('cli module', () => {
     });
 
     test('CLI Tool registry sends "cli-tool-create" event when new tool is created', () => {
-      const api = extLoader.createApi('/path', extManifest);
       const options: CliToolOptions = {
         name: 'tool-name',
         displayName: 'tool-display-name',
@@ -153,12 +74,12 @@ suite('cli module', () => {
         version: '1.0.1',
         path: 'path/to/tool-name',
       };
-      api.cli.createCliTool(options);
+      cliToolRegistry.createCliTool(extensionInfo, options);
+
       expect(apiSender.send).toBeCalledWith('cli-tool-create');
     });
 
     test('CLI Tool registry generates CliToolInfo array for created tools', () => {
-      const api = extLoader.createApi('/path', extManifest);
       const options: CliToolOptions = {
         name: 'tool-name',
         displayName: 'tool-display-name',
@@ -167,7 +88,7 @@ suite('cli module', () => {
         version: '1.0.1',
         path: 'path/to/tool-name',
       };
-      const newCliTool = api.cli.createCliTool(options);
+      const newCliTool = cliToolRegistry.createCliTool(extensionInfo, options);
       const infoList = cliToolRegistry.getCliToolInfos();
       expect(infoList.length).equals(1);
       expect(infoList[0]).toMatchObject({
@@ -184,7 +105,6 @@ suite('cli module', () => {
 
   suite('dispose CliTool', () => {
     test('sends "cli-tool-remove" event when cli tool is disposed', () => {
-      const api = extLoader.createApi('/path', extManifest);
       const options: CliToolOptions = {
         name: 'tool-name',
         displayName: 'tool-display-name',
@@ -193,13 +113,12 @@ suite('cli module', () => {
         version: '1.0.1',
         path: 'path/to/tool-name',
       };
-      const newCliTool = api.cli.createCliTool(options);
+      const newCliTool = cliToolRegistry.createCliTool(extensionInfo, options);
       newCliTool.dispose();
       expect(apiSender.send).toBeCalledWith('cli-tool-remove', newCliTool.id);
     });
 
     test('removes cli tool from the registry', () => {
-      const api = extLoader.createApi('/path', extManifest);
       const options: CliToolOptions = {
         name: 'tool-name',
         displayName: 'tool-display-name',
@@ -208,7 +127,7 @@ suite('cli module', () => {
         version: '1.0.1',
         path: 'path/to/tool-name',
       };
-      const newCliTool = api.cli.createCliTool(options);
+      const newCliTool = cliToolRegistry.createCliTool(extensionInfo, options);
       const infoListAfterCreate = cliToolRegistry.getCliToolInfos();
       expect(infoListAfterCreate.length).equals(1);
       newCliTool.dispose();
@@ -219,7 +138,6 @@ suite('cli module', () => {
 
   suite('update CliTool', () => {
     test('expect updater is registered and called', async () => {
-      const api = extLoader.createApi('/path', extManifest);
       const updateMock = vi.fn();
       const updater: CliToolUpdate = {
         doUpdate: updateMock,
@@ -233,7 +151,7 @@ suite('cli module', () => {
         version: '1.0.1',
         path: 'path/to/tool-name',
       };
-      const newCliTool = api.cli.createCliTool(options);
+      const newCliTool = cliToolRegistry.createCliTool(extensionInfo, options);
       // register the updater and call it
       const disposeUpdater = cliToolRegistry.registerUpdate(newCliTool as CliToolImpl, updater);
       await cliToolRegistry.updateCliTool(newCliTool.id, {} as unknown as Logger);

--- a/packages/main/src/plugin/extension-loader.spec.ts
+++ b/packages/main/src/plugin/extension-loader.spec.ts
@@ -161,7 +161,9 @@ const viewRegistry: ViewRegistry = {} as unknown as ViewRegistry;
 
 const context: Context = new Context(apiSender);
 
-const cliToolRegistry: CliToolRegistry = {} as unknown as CliToolRegistry;
+const cliToolRegistry: CliToolRegistry = {
+  createCliTool: vi.fn(),
+} as unknown as CliToolRegistry;
 
 const directories = {
   getPluginsDirectory: () => '/fake-plugins-directory',
@@ -1511,4 +1513,25 @@ describe('authentication Provider', async () => {
     expect(themeLogo?.light).equals(BASE64ENCODEDIMAGE);
     expect(themeLogo?.dark).equals(BASE64ENCODEDIMAGE);
   });
+});
+
+test('createCliTool ', async () => {
+  const api = extensionLoader.createApi('/path', {});
+  expect(api).toBeDefined();
+
+  const options: containerDesktopAPI.CliToolOptions = {
+    name: 'tool-name',
+    displayName: 'tool-display-name',
+    markdownDescription: 'markdown description',
+    images: {},
+    version: '1.0.1',
+    path: 'path/to/tool-name',
+  };
+
+  vi.mocked(cliToolRegistry.createCliTool).mockReturnValue({ id: 'created' } as containerDesktopAPI.CliTool);
+
+  const newCliTool = api.cli.createCliTool(options);
+
+  expect(cliToolRegistry.createCliTool).toBeCalledWith(expect.objectContaining({ extensionPath: '/path' }), options);
+  expect(newCliTool).toStrictEqual({ id: 'created' });
 });


### PR DESCRIPTION
### What does this PR do?
cut dependency to extension-loader as this class is changing lot of time and we need to mock tons of stuff while we should focus only on testing the dedicated class
move test related to extension loader to extension-loader.spec.ts

### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

related to https://github.com/containers/podman-desktop/issues/5733

### How to test this PR?

reworked unit tests