### PR TITLE
nit: status bar should have z-40 to go above onboarding button area

### DIFF
--- a/packages/renderer/src/lib/statusbar/StatusBar.svelte
+++ b/packages/renderer/src/lib/statusbar/StatusBar.svelte
@@ -46,7 +46,7 @@ onMount(async () => {
 });
 </script>
 
-<div class="flex items-center justify-between px-1 bg-[#302251] text-sm py-0.5 space-x-2">
+<div class="flex items-center justify-between px-1 bg-[#302251] text-sm py-0.5 space-x-2 z-40">
   <div>
     <ul class="flex flex-wrap gap-x-2 list-none items-center">
       {#each leftEntries as entry}


### PR DESCRIPTION
nit: status bar should have z-40 to go above onboarding button area

### What does this PR do?

Small nitpick, there is an overlap from the onboarding buttons which are
z-20 to z-30.

The status bar should be z-40 so it'll always appear above the buttons /
not overlap.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->


Before:

![Screenshot 2024-02-09 at 9 55 13 AM](https://github.com/containers/podman-desktop/assets/6422176/f0312496-86cf-4689-a017-faa8507f62cf)

After:

![Screenshot 2024-02-09 at 10 07 07 AM](https://github.com/containers/podman-desktop/assets/6422176/40490340-430d-4819-9126-4d8e47327927)



### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

N/A

### How to test this PR?

<!-- Please explain steps to reproduce -->

Go to onboarding sequence and see that there is no more "overlapping".

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
