### PR TITLE
chore: use input in create volume

### DIFF
--- a/packages/renderer/src/lib/volume/CreateVolume.svelte
+++ b/packages/renderer/src/lib/volume/CreateVolume.svelte
@@ -15,6 +15,7 @@ import Button from '/@/lib/ui/Button.svelte';
 import VolumeIcon from '/@/lib/images/VolumeIcon.svelte';
 import { router } from 'tinro';
 import { faPlusCircle } from '@fortawesome/free-solid-svg-icons';
+import Input from '../ui/Input.svelte';
 
 let providers: ProviderInfo[] = [];
 let providerConnections: ProviderContainerConnectionInfo[] = [];
@@ -67,11 +68,12 @@ export let volumeName = '';
         <div>
           <label for="containerBuildContextDirectory" class="block mb-2 text-sm font-bold text-gray-400"
             >Volume name:</label>
-          <input
+          <Input
+            clearable
             aria-label="Volume Name"
             disabled="{createVolumeFinished}"
             bind:value="{volumeName}"
-            class="w-full p-2 outline-none text-sm bg-charcoal-600 rounded-sm text-gray-700 placeholder-gray-700"
+            class="w-full"
             required />
         </div>
         <div class:hidden="{providerConnections.length < 2}">


### PR DESCRIPTION
### What does this PR do?

Use the Input component when creating a volume.

Bonus fix: button should be disabled until the volume has a name (if I don't pick a name, UI hung).

### Screenshot / video of UI

<img width="592" alt="Screenshot 2024-02-09 at 2 49 14 PM" src="https://github.com/containers/podman-desktop/assets/19958075/8593483d-f0f9-468c-9ad6-b147ba750ea6">

### What issues does this PR fix or reference?

Fixes another minor part of #3234.

### How to test this PR?

Create a volume.