### PR TITLE
chore: use input component in extension pages

### DIFF
--- a/packages/renderer/src/lib/docker-extension/PreferencesPageDockerExtensions.svelte
+++ b/packages/renderer/src/lib/docker-extension/PreferencesPageDockerExtensions.svelte
@@ -6,6 +6,7 @@ import ErrorMessage from '../ui/ErrorMessage.svelte';
 import SettingsPage from '../preferences/SettingsPage.svelte';
 import Button from '../ui/Button.svelte';
 import { faArrowCircleDown } from '@fortawesome/free-solid-svg-icons';
+import Input from '../ui/Input.svelte';
 
 export let ociImage: string | undefined = undefined;
 
@@ -69,14 +70,12 @@ function deleteContribution(extensionName: string) {
     <div class="container w-full mt-4 flex-col">
       <div class="flex flex-col mb-4">
         <label for="ociImage" class="block mb-2 text-sm font-medium text-gray-400">Image name:</label>
-        <input
+        <Input
           name="ociImage"
           id="ociImage"
           aria-label="OCI Image Name"
-          type="text"
           bind:value="{ociImage}"
           placeholder="Name of the Image"
-          class="text-sm rounded-sm focus:ring-purple-500 focus:border-purple-500 block p-2.5 bg-charcoal-800 border-gray-900 placeholder-gray-400 text-white"
           required />
       </div>
     </div>

--- a/packages/renderer/src/lib/preferences/PreferencesExtensionList.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesExtensionList.svelte
@@ -10,6 +10,7 @@ import ConnectionStatus from '../ui/ConnectionStatus.svelte';
 import FeaturedExtensions from '../featured/FeaturedExtensions.svelte';
 import Button from '../ui/Button.svelte';
 import ExtensionIcon from './ExtensionIcon.svelte';
+import Input from '../ui/Input.svelte';
 
 export let ociImage: string | undefined = undefined;
 
@@ -85,17 +86,16 @@ async function updateExtension(extension: ExtensionInfo, ociUri: string) {
 
       <div class="flex flex-col w-full">
         <div
-          class="flex flex-row mb-2 w-full space-x-8 items-center"
+          class="flex flex-row mb-2 w-full space-x-4 items-center"
           role="region"
           aria-label="Install Extension From OCI">
-          <input
+          <Input
             name="ociImage"
             id="ociImage"
             aria-label="OCI Image Name"
-            type="text"
             bind:value="{ociImage}"
             placeholder="Name of the Image"
-            class="w-1/2 p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700"
+            class="w-1/2"
             required />
 
           <Button


### PR DESCRIPTION
### What does this PR do?

Use the Input component when installing Podman or Docker extensions.

### Screenshot / video of UI

<img width="472" alt="Screenshot 2024-02-09 at 2 44 52 PM" src="https://github.com/containers/podman-desktop/assets/19958075/216fce42-625c-440e-876a-8e843d9b47b7">
<img width="310" alt="Screenshot 2024-02-09 at 2 45 16 PM" src="https://github.com/containers/podman-desktop/assets/19958075/2277ddc6-b273-4c91-a1c2-f97eef3ca489">

### What issues does this PR fix or reference?

Fixes another minor part of #3234.

### How to test this PR?

Check both extension pages.