### PR TITLE
chore: use input when creating pod from containers

### DIFF
--- a/packages/renderer/src/lib/pod/PodCreateFromContainers.svelte
+++ b/packages/renderer/src/lib/pod/PodCreateFromContainers.svelte
@@ -14,6 +14,7 @@ import Fa from 'svelte-fa';
 import SolidPodIcon from '../images/SolidPodIcon.svelte';
 import Button from '../ui/Button.svelte';
 import type { PodCreatePortOptions } from '../../../../main/src/plugin/dockerode/libpod-dockerode';
+import Input from '../ui/Input.svelte';
 
 let podCreation: PodCreation;
 let createInProgress = false;
@@ -232,13 +233,13 @@ function updatePortExposure(port: number, checked: boolean) {
             <span class="block text-sm font-semibold rounded text-gray-400 dark:text-gray-400">Name of the pod:</span>
           </div>
           <div class="mb-4">
-            <input
+            <Input
               name="podName"
               id="podName"
               bind:value="{podCreation.name}"
               placeholder="Select name of the pod..."
               aria-label="Pod name"
-              class="w-full mt-1 p-2 outline-0 text-sm bg-charcoal-500 focus:bg-charcoal-900 border-violet-700 border-b focus:border-violet-700 focus:border rounded-sm text-gray-500 focus:text-gray-700 placeholder-gray-700"
+              class="w-full mt-1"
               required />
           </div>
 

--- a/packages/renderer/src/lib/pod/PodCreateFromContainers.svelte
+++ b/packages/renderer/src/lib/pod/PodCreateFromContainers.svelte
@@ -14,7 +14,7 @@ import Fa from 'svelte-fa';
 import SolidPodIcon from '../images/SolidPodIcon.svelte';
 import Button from '../ui/Button.svelte';
 import type { PodCreatePortOptions } from '../../../../main/src/plugin/dockerode/libpod-dockerode';
-import Input from '../ui/Input.svelte';
+import Input from '/@/lib/ui/Input.svelte';
 
 let podCreation: PodCreation;
 let createInProgress = false;


### PR DESCRIPTION
### What does this PR do?

Use the Input component when creating a pod from containers.

### Screenshot / video of UI

<img width="564" alt="Screenshot 2024-02-09 at 2 52 26 PM" src="https://github.com/containers/podman-desktop/assets/19958075/386f0056-005d-4714-b744-675b77420854">

### What issues does this PR fix or reference?

Fixes another minor part of #3234.

### How to test this PR?

Select a container and click the Create Pod button.