### PR TITLE
feat: ability to edit kube yaml

### DIFF
--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -2016,6 +2016,13 @@ export class PluginSystem {
     );
 
     this.ipcHandle(
+      'kubernetes-client:applyResourcesFromYAML',
+      async (_listener, context: string, yaml: string): Promise<KubernetesObject[]> => {
+        return kubernetesClient.applyResourcesFromYAML(context, yaml);
+      },
+    );
+
+    this.ipcHandle(
       'openshift-client:createRoute',
       async (_listener, namespace: string, route: V1Route): Promise<V1Route> => {
         return kubernetesClient.createOpenShiftRoute(namespace, route);

--- a/packages/main/src/plugin/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes-client.ts
@@ -1078,6 +1078,29 @@ export class KubernetesClient {
   }
 
   /**
+   * Load manifests from a YAML string.
+   * @param yaml the YAML string
+   * @return an array of Kubernetes resources
+   */
+  async loadManifestsFromYAML(yaml: string): Promise<KubernetesObject[]> {
+    const manifests = parseAllDocuments(yaml, { customTags: this.getTags });
+    // filter out any null manifests
+    return manifests.map(manifest => manifest.toJSON()).filter(manifest => !!manifest);
+  }
+
+  /**
+   * Similar to applyResourcesFromFile, but instead you can pass in a string that contains the YAML
+   *
+   * @param context a context
+   * @param yaml content consisting of a stringified YAML
+   * @return an array of resources created
+   */
+  async applyResourcesFromYAML(context: string, yaml: string): Promise<KubernetesObject[]> {
+    const manifests = await this.loadManifestsFromYAML(yaml);
+    return this.applyResources(context, manifests, 'apply');
+  }
+
+  /**
    * Apply a given yaml file to a context, i.e. 'kubectl apply -f'. Resources that exist
    * on the context are patched, and any new resources are created.
    *

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -1835,6 +1835,13 @@ export function initExposure(): void {
   );
 
   contextBridge.exposeInMainWorld(
+    'kubernetesApplyResourcesFromYAML',
+    async (context: string, yaml: string): Promise<KubernetesObject[]> => {
+      return ipcInvoke('kubernetes-client:applyResourcesFromYAML', context, yaml);
+    },
+  );
+
+  contextBridge.exposeInMainWorld(
     'openshiftCreateRoute',
     async (namespace: string, route: V1Route): Promise<V1Route> => {
       return ipcInvoke('openshift-client:createRoute', namespace, route);

--- a/packages/renderer/src/lib/deployments/DeploymentDetails.svelte
+++ b/packages/renderer/src/lib/deployments/DeploymentDetails.svelte
@@ -13,6 +13,7 @@ import { deployments } from '/@/stores/deployments';
 import type { V1Deployment } from '@kubernetes/client-node';
 import { stringify } from 'yaml';
 import MonacoEditor from '../editor/MonacoEditor.svelte';
+import KubeEditYAML from '../kube/KubeEditYAML.svelte';
 
 export let name: string;
 export let namespace: string;
@@ -62,7 +63,7 @@ async function loadDetails() {
     <svelte:fragment slot="tabs">
       <Tab title="Summary" url="summary" />
       <Tab title="Inspect" url="inspect" />
-      <Tab title="Kube" url="kube" />
+      <Tab title="Edit" url="edit" />
     </svelte:fragment>
     <svelte:fragment slot="content">
       <Route path="/summary" breadcrumb="Summary" navigationHint="tab">
@@ -71,8 +72,8 @@ async function loadDetails() {
       <Route path="/inspect" breadcrumb="Inspect" navigationHint="tab">
         <MonacoEditor content="{JSON.stringify(kubeDeployment, undefined, 2)}" language="json" />
       </Route>
-      <Route path="/kube" breadcrumb="Kube" navigationHint="tab">
-        <MonacoEditor content="{stringify(kubeDeployment)}" language="yaml" />
+      <Route path="/edit" breadcrumb="Edit" navigationHint="tab">
+        <KubeEditYAML content="{stringify(kubeDeployment)}" />
       </Route>
     </svelte:fragment>
   </DetailsPage>

--- a/packages/renderer/src/lib/deployments/DeploymentDetails.svelte
+++ b/packages/renderer/src/lib/deployments/DeploymentDetails.svelte
@@ -63,7 +63,7 @@ async function loadDetails() {
     <svelte:fragment slot="tabs">
       <Tab title="Summary" url="summary" />
       <Tab title="Inspect" url="inspect" />
-      <Tab title="Edit" url="edit" />
+      <Tab title="Kube" url="kube" />
     </svelte:fragment>
     <svelte:fragment slot="content">
       <Route path="/summary" breadcrumb="Summary" navigationHint="tab">
@@ -72,7 +72,7 @@ async function loadDetails() {
       <Route path="/inspect" breadcrumb="Inspect" navigationHint="tab">
         <MonacoEditor content="{JSON.stringify(kubeDeployment, undefined, 2)}" language="json" />
       </Route>
-      <Route path="/edit" breadcrumb="Edit" navigationHint="tab">
+      <Route path="/kube" breadcrumb="Kube" navigationHint="tab">
         <KubeEditYAML content="{stringify(kubeDeployment)}" />
       </Route>
     </svelte:fragment>

--- a/packages/renderer/src/lib/editor/MonacoEditor.svelte
+++ b/packages/renderer/src/lib/editor/MonacoEditor.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { onDestroy, onMount } from 'svelte';
+import { onDestroy, onMount, createEventDispatcher } from 'svelte';
 import editorWorker from 'monaco-editor/esm/vs/editor/editor.worker?worker';
 import jsonWorker from 'monaco-editor/esm/vs/language/json/json.worker?worker';
 import { EditorSettings } from '../../../../main/src/plugin/editor-settings';
@@ -13,6 +13,9 @@ let Monaco;
 
 export let content = '';
 export let language = 'json';
+export let readOnly = true;
+
+const dispatch = createEventDispatcher<{ contentChange: string }>();
 
 onMount(async () => {
   self.MonacoEnvironment = {
@@ -45,10 +48,15 @@ onMount(async () => {
     value: content,
     fontSize,
     language,
-    readOnly: true,
+    readOnly: readOnly,
     theme: 'podmanDesktopTheme',
     automaticLayout: true,
     scrollBeyondLastLine: false,
+  });
+
+  editor.onDidChangeModelContent(() => {
+    // Emit the content change so we can use it in the parent component
+    dispatch('contentChange', editor.getValue());
   });
 });
 

--- a/packages/renderer/src/lib/ingresses-routes/IngressDetails.svelte
+++ b/packages/renderer/src/lib/ingresses-routes/IngressDetails.svelte
@@ -14,6 +14,7 @@ import IngressRouteActions from './IngressRouteActions.svelte';
 import ServiceDetailsSummary from './IngressRouteDetailsSummary.svelte';
 import ServiceIcon from '../images/ServiceIcon.svelte';
 import Route from '../../Route.svelte';
+import KubeEditYAML from '../kube/KubeEditYAML.svelte';
 
 export let name: string;
 export let namespace: string;
@@ -64,7 +65,7 @@ async function loadIngressDetails() {
     <svelte:fragment slot="tabs">
       <Tab title="Summary" url="summary" />
       <Tab title="Inspect" url="inspect" />
-      <Tab title="Kube" url="kube" />
+      <Tab title="Edit" url="edit" />
     </svelte:fragment>
     <svelte:fragment slot="content">
       <Route path="/summary" breadcrumb="Summary" navigationHint="tab">
@@ -73,8 +74,8 @@ async function loadIngressDetails() {
       <Route path="/inspect" breadcrumb="Inspect" navigationHint="tab">
         <MonacoEditor content="{JSON.stringify(kubeService, undefined, 2)}" language="json" />
       </Route>
-      <Route path="/kube" breadcrumb="Kube" navigationHint="tab">
-        <MonacoEditor content="{stringify(kubeService)}" language="yaml" />
+      <Route path="/edit" breadcrumb="Edit" navigationHint="tab">
+        <KubeEditYAML content="{stringify(kubeService)}" />
       </Route>
     </svelte:fragment>
   </DetailsPage>

--- a/packages/renderer/src/lib/ingresses-routes/IngressDetails.svelte
+++ b/packages/renderer/src/lib/ingresses-routes/IngressDetails.svelte
@@ -65,7 +65,7 @@ async function loadIngressDetails() {
     <svelte:fragment slot="tabs">
       <Tab title="Summary" url="summary" />
       <Tab title="Inspect" url="inspect" />
-      <Tab title="Edit" url="edit" />
+      <Tab title="Kube" url="kube" />
     </svelte:fragment>
     <svelte:fragment slot="content">
       <Route path="/summary" breadcrumb="Summary" navigationHint="tab">
@@ -74,7 +74,7 @@ async function loadIngressDetails() {
       <Route path="/inspect" breadcrumb="Inspect" navigationHint="tab">
         <MonacoEditor content="{JSON.stringify(kubeService, undefined, 2)}" language="json" />
       </Route>
-      <Route path="/edit" breadcrumb="Edit" navigationHint="tab">
+      <Route path="/kube" breadcrumb="Kube" navigationHint="tab">
         <KubeEditYAML content="{stringify(kubeService)}" />
       </Route>
     </svelte:fragment>

--- a/packages/renderer/src/lib/ingresses-routes/RouteDetails.svelte
+++ b/packages/renderer/src/lib/ingresses-routes/RouteDetails.svelte
@@ -65,7 +65,7 @@ async function loadRouteDetails() {
     <svelte:fragment slot="tabs">
       <Tab title="Summary" url="summary" />
       <Tab title="Inspect" url="inspect" />
-      <Tab title="Edit" url="edit" />
+      <Tab title="Kube" url="kube" />
     </svelte:fragment>
     <svelte:fragment slot="content">
       <Route path="/summary" breadcrumb="Summary" navigationHint="tab">
@@ -74,7 +74,7 @@ async function loadRouteDetails() {
       <Route path="/inspect" breadcrumb="Inspect" navigationHint="tab">
         <MonacoEditor content="{JSON.stringify(kubeService, undefined, 2)}" language="json" />
       </Route>
-      <Route path="/edit" breadcrumb="Edit" navigationHint="tab">
+      <Route path="/kube" breadcrumb="Kube" navigationHint="tab">
         <KubeEditYAML content="{stringify(kubeService)}" />
       </Route>
     </svelte:fragment>

--- a/packages/renderer/src/lib/ingresses-routes/RouteDetails.svelte
+++ b/packages/renderer/src/lib/ingresses-routes/RouteDetails.svelte
@@ -14,6 +14,7 @@ import ServiceDetailsSummary from './IngressRouteDetailsSummary.svelte';
 import ServiceIcon from '../images/ServiceIcon.svelte';
 import Route from '../../Route.svelte';
 import { routes } from '/@/stores/routes';
+import KubeEditYAML from '../kube/KubeEditYAML.svelte';
 
 export let name: string;
 export let namespace: string;
@@ -64,7 +65,7 @@ async function loadRouteDetails() {
     <svelte:fragment slot="tabs">
       <Tab title="Summary" url="summary" />
       <Tab title="Inspect" url="inspect" />
-      <Tab title="Kube" url="kube" />
+      <Tab title="Edit" url="edit" />
     </svelte:fragment>
     <svelte:fragment slot="content">
       <Route path="/summary" breadcrumb="Summary" navigationHint="tab">
@@ -73,8 +74,8 @@ async function loadRouteDetails() {
       <Route path="/inspect" breadcrumb="Inspect" navigationHint="tab">
         <MonacoEditor content="{JSON.stringify(kubeService, undefined, 2)}" language="json" />
       </Route>
-      <Route path="/kube" breadcrumb="Kube" navigationHint="tab">
-        <MonacoEditor content="{stringify(kubeService)}" language="yaml" />
+      <Route path="/edit" breadcrumb="Edit" navigationHint="tab">
+        <KubeEditYAML content="{stringify(kubeService)}" />
       </Route>
     </svelte:fragment>
   </DetailsPage>

--- a/packages/renderer/src/lib/kube/KubeEditYAML.svelte
+++ b/packages/renderer/src/lib/kube/KubeEditYAML.svelte
@@ -1,0 +1,87 @@
+<script lang="ts">
+import MonacoEditor from '../editor/MonacoEditor.svelte';
+import Button from '../ui/Button.svelte';
+import Tooltip from '../ui/Tooltip.svelte';
+
+// Make sure that when using the MonacoEditor, the content is "stringified" before
+// being passed into this component. ex. stringify(kubeDeploymentYAML)
+// this is the 'initial' content.
+export let content = '';
+let key = 0; // Initial key
+let originalContent = '';
+let editorContent: string;
+let inProgress = false;
+
+// Reactive statement to update originalContent only if it's blank and content is not
+// as sometimes content is blank until it's "loaded". This does not work with onMount,
+// so we use the reactive statement
+$: if (originalContent === '' && content !== '') {
+  originalContent = content;
+}
+
+// Handle the content change from the MonacoEditor / store it for us to use for applying to the cluster.
+function handleContentChange(event: CustomEvent<string>) {
+  editorContent = event.detail;
+}
+
+/////////////
+// Buttons //
+/////////////
+
+// Function that will update content with originalContent
+// when 'revertChanges' button is pressed.
+async function revertChanges() {
+  content = originalContent;
+  key++; // Increment the key to force re-render
+}
+
+async function applyToCluster() {
+  // Get the current context name
+  let contextName = await window.kubernetesGetCurrentContextName();
+  if (!contextName) {
+    return;
+  }
+
+  try {
+    inProgress = true;
+    await window.kubernetesApplyResourcesFromYAML(contextName, editorContent);
+    await window.showMessageBox({
+      title: 'Kubernetes',
+      type: 'info',
+      message: 'Succesfully applied Kubernetes YAML',
+      buttons: ['OK'],
+    });
+  } catch (error) {
+    console.error('error playing kube file', error);
+    await window.showMessageBox({
+      title: 'Kubernetes',
+      type: 'error',
+      message: 'Could not apply Kubernetes YAML: ' + error,
+      buttons: ['OK'],
+    });
+  } finally {
+    inProgress = false;
+  }
+}
+</script>
+
+<div
+  class="flex flex-row-reverse p-6 bg-transparent fixed bottom-0 right-0 mb-5 pr-10 max-h-20 bg-opacity-90 z-50"
+  role="group"
+  aria-label="Edit Buttons">
+  <Tooltip tip="Apply the changes to the cluster, similar to 'kubectl apply'" topLeft="{true}">
+    <Button type="primary" aria-label="Apply to cluster" on:click="{applyToCluster}" inProgress="{inProgress}"
+      >Apply to cluster</Button>
+  </Tooltip>
+  <Tooltip tip="Revert the changes to the original content" topLeft="{true}">
+    <Button type="secondary" aria-label="Revert changes" class="mr-2 opacity-100" on:click="{revertChanges}"
+      >Revert edits</Button>
+  </Tooltip>
+</div>
+
+<!-- We use key to force a re-render of the MonacoEditor component
+    The reasoning is that MonacoEditor is complex and uses it's own rendering components
+    and does not allow a way to reactively update the content externally. So we just re-render with the original content -->
+{#key key}
+  <MonacoEditor content="{content}" language="yaml" readOnly="{false}" on:contentChange="{handleContentChange}" />
+{/key}

--- a/packages/renderer/src/lib/pod/PodDetails.svelte
+++ b/packages/renderer/src/lib/pod/PodDetails.svelte
@@ -64,7 +64,8 @@ onMount(() => {
       <Tab title="Summary" url="summary" />
       <Tab title="Logs" url="logs" />
       <Tab title="Inspect" url="inspect" />
-      <Tab title="Kube" url="kube" />
+      <!-- Different title depending on if the pod is k8s or podman as we want to emphasize the "Edit" feature of Kubernetes -->
+      <Tab title="{pod.kind === 'podman' ? 'Kube' : 'Edit'}" url="kube" />
     </svelte:fragment>
     <svelte:fragment slot="content">
       <Route path="/summary" breadcrumb="Summary" navigationHint="tab">

--- a/packages/renderer/src/lib/pod/PodDetails.svelte
+++ b/packages/renderer/src/lib/pod/PodDetails.svelte
@@ -64,8 +64,7 @@ onMount(() => {
       <Tab title="Summary" url="summary" />
       <Tab title="Logs" url="logs" />
       <Tab title="Inspect" url="inspect" />
-      <!-- Different title depending on if the pod is k8s or podman as we want to emphasize the "Edit" feature of Kubernetes -->
-      <Tab title="{pod.kind === 'podman' ? 'Kube' : 'Edit'}" url="kube" />
+      <Tab title="Kube" url="kube" />
     </svelte:fragment>
     <svelte:fragment slot="content">
       <Route path="/summary" breadcrumb="Summary" navigationHint="tab">

--- a/packages/renderer/src/lib/pod/PodDetailsKube.svelte
+++ b/packages/renderer/src/lib/pod/PodDetailsKube.svelte
@@ -3,6 +3,7 @@ import { onMount } from 'svelte';
 import MonacoEditor from '../editor/MonacoEditor.svelte';
 import type { PodInfoUI } from './PodInfoUI';
 import { stringify } from 'yaml';
+import KubeEditYAML from '../kube/KubeEditYAML.svelte';
 export let pod: PodInfoUI;
 
 let kubeDetails: string;
@@ -25,5 +26,9 @@ onMount(async () => {
 </script>
 
 {#if kubeDetails}
-  <MonacoEditor content="{kubeDetails}" language="yaml" />
+  {#if pod.kind === 'podman'}
+    <MonacoEditor content="{kubeDetails}" language="yaml" />
+  {:else}
+    <KubeEditYAML content="{kubeDetails}" />
+  {/if}
 {/if}

--- a/packages/renderer/src/lib/service/ServiceDetails.svelte
+++ b/packages/renderer/src/lib/service/ServiceDetails.svelte
@@ -14,6 +14,7 @@ import { services } from '/@/stores/services';
 import ServiceActions from './ServiceActions.svelte';
 import ServiceDetailsSummary from './ServiceDetailsSummary.svelte';
 import ServiceIcon from '../images/ServiceIcon.svelte';
+import KubeEditYAML from '../kube/KubeEditYAML.svelte';
 
 export let name: string;
 export let namespace: string;
@@ -64,7 +65,7 @@ async function loadDetails() {
     <svelte:fragment slot="tabs">
       <Tab title="Summary" url="summary" />
       <Tab title="Inspect" url="inspect" />
-      <Tab title="Kube" url="kube" />
+      <Tab title="Edit" url="edit" />
     </svelte:fragment>
     <svelte:fragment slot="content">
       <Route path="/summary" breadcrumb="Summary" navigationHint="tab">
@@ -73,8 +74,8 @@ async function loadDetails() {
       <Route path="/inspect" breadcrumb="Inspect" navigationHint="tab">
         <MonacoEditor content="{JSON.stringify(kubeService, undefined, 2)}" language="json" />
       </Route>
-      <Route path="/kube" breadcrumb="Kube" navigationHint="tab">
-        <MonacoEditor content="{stringify(kubeService)}" language="yaml" />
+      <Route path="/edit" breadcrumb="Edit" navigationHint="tab">
+        <KubeEditYAML content="{stringify(kubeService)}" />
       </Route>
     </svelte:fragment>
   </DetailsPage>

--- a/packages/renderer/src/lib/service/ServiceDetails.svelte
+++ b/packages/renderer/src/lib/service/ServiceDetails.svelte
@@ -65,7 +65,7 @@ async function loadDetails() {
     <svelte:fragment slot="tabs">
       <Tab title="Summary" url="summary" />
       <Tab title="Inspect" url="inspect" />
-      <Tab title="Edit" url="edit" />
+      <Tab title="Kube" url="kube" />
     </svelte:fragment>
     <svelte:fragment slot="content">
       <Route path="/summary" breadcrumb="Summary" navigationHint="tab">
@@ -74,7 +74,7 @@ async function loadDetails() {
       <Route path="/inspect" breadcrumb="Inspect" navigationHint="tab">
         <MonacoEditor content="{JSON.stringify(kubeService, undefined, 2)}" language="json" />
       </Route>
-      <Route path="/edit" breadcrumb="Edit" navigationHint="tab">
+      <Route path="/kube" breadcrumb="Kube" navigationHint="tab">
         <KubeEditYAML content="{stringify(kubeService)}" />
       </Route>
     </svelte:fragment>


### PR DESCRIPTION
feat: ability to edit kube yaml

### What does this PR do?

* Adds the ability to edit kube yaml with two buttons, "revert" and
  "apply"
* Renames Kube section to "Edit"

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

https://github.com/containers/podman-desktop/assets/6422176/4d159c14-3a50-4a84-aa8d-4469a92b531e




### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop/issues/5662

### How to test this PR?

1. Go to Kube tab
2. Edit a YAML (Deployment only right now)
3. Click on apply / revert buttons.

<!-- Please explain steps to reproduce -->

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
