### PR TITLE
chore: use input for registries

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesRegistriesEditing.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRegistriesEditing.svelte
@@ -7,6 +7,8 @@ import DropdownMenuItem from '../ui/DropDownMenuItem.svelte';
 import { faPlusCircle, faTrash, faUser, faUserPen } from '@fortawesome/free-solid-svg-icons';
 import SettingsPage from './SettingsPage.svelte';
 import Button from '../ui/Button.svelte';
+import Input from '/@/lib/ui/Input.svelte';
+import PasswordInput from '/@/lib/ui/PasswordInput.svelte';
 
 // contains the original instances of registries when user clicks on `Edit password` menu item
 // to be able to roll back changes when `Cancel` button is clicked
@@ -23,9 +25,6 @@ export let showNewRegistryForm = false;
 
 // at this moment it should be `podman`, but later can be any
 let defaultProviderSourceName: string;
-
-// store password input fields to handle password showing trigger
-let passwordElements: { serverUrl: string; element: HTMLInputElement }[] = [];
 
 // List of suggested registries to show
 let suggestedRegistries: containerDesktopAPI.RegistrySuggestedProvider[] = [];
@@ -101,18 +100,8 @@ function setPasswordForRegistryVisible(registry: containerDesktopAPI.Registry, v
 
   if (visible && index === -1) {
     showPasswordForServerUrls = [...showPasswordForServerUrls, serverUrl];
-
-    let passwordInputElement = passwordElements.find(el => el.serverUrl === serverUrl);
-    if (passwordInputElement) {
-      passwordInputElement.element.type = 'text';
-    }
   } else if (!visible && index > -1) {
     showPasswordForServerUrls = showPasswordForServerUrls.filter(r => r !== serverUrl);
-
-    let passwordInputElement = passwordElements.find(el => el.serverUrl === serverUrl);
-    if (passwordInputElement) {
-      passwordInputElement.element.type = 'password';
-    }
   }
 }
 
@@ -234,17 +223,6 @@ function removeExistingRegistry(registry: containerDesktopAPI.Registry) {
   window.unregisterImageRegistry(registry);
   setPasswordForRegistryVisible(registry, false);
 }
-
-const processPasswordElement = (node: HTMLInputElement, registry: containerDesktopAPI.Registry) => {
-  const serverUrl = registry === newRegistryRequest ? '' : registry.serverUrl;
-  passwordElements = [...passwordElements, { serverUrl: serverUrl, element: node }];
-
-  return {
-    destroy() {
-      passwordElements = passwordElements.filter(el => el.serverUrl !== serverUrl);
-    },
-  };
-};
 </script>
 
 <SettingsPage title="Registries">
@@ -298,12 +276,7 @@ const processPasswordElement = (node: HTMLInputElement, registry: containerDeskt
             <div class="text-sm w-1/4 m-auto text-ellipsis overflow-hidden max-x-32" role="cell">
               {#if originRegistries.some(r => r.serverUrl === registry.serverUrl)}
                 <div class="text-left h-7 pr-5 mt-1.5 mb-0.5 text-sm w-full">
-                  <input
-                    type="text"
-                    placeholder="Username"
-                    aria-label="Username"
-                    bind:value="{registry.username}"
-                    class="block px-3 block w-full h-full transition ease-in-out delay-50 bg-charcoal-800 text-gray-700 placeholder-gray-700 rounded-sm focus:outline-none" />
+                  <Input placeholder="Username" aria-label="Username" bind:value="{registry.username}" />
                 </div>
               {:else if !registry.username && !registry.secret}
                 <Button on:click="{() => markRegistryAsModified(registry)}">Login now</Button>
@@ -317,39 +290,14 @@ const processPasswordElement = (node: HTMLInputElement, registry: containerDeskt
               <div class="flex flex-row">
                 {#if originRegistries.some(r => r.serverUrl === registry.serverUrl)}
                   <div class="flex text-left h-7 pr-5 text-sm w-full">
-                    <div class="relative flex-1">
-                      <div class="absolute inset-y-0 right-0 flex px-1">
-                        <input
-                          id="password-toggle-{registry.serverUrl}"
-                          aria-label="Toggle password"
-                          class="hidden"
-                          type="checkbox"
-                          value="false"
-                          tabindex="-1"
-                          on:change="{() =>
-                            setPasswordForRegistryVisible(
-                              registry,
-                              !showPasswordForServerUrls.some(r => r === registry.serverUrl),
-                            )}" />
-                        <label
-                          class="px-2 py-1 text text-gray-900 cursor-pointer"
-                          for="password-toggle-{registry.serverUrl}">
-                          {#if showPasswordForServerUrls.some(r => r === registry.serverUrl)}
-                            <i class="fas fa-eye-slash"></i>
-                          {:else}
-                            <i class="fas fa-eye"></i>
-                          {/if}
-                        </label>
-                      </div>
-
-                      <input
-                        use:processPasswordElement="{registry}"
-                        type="password"
-                        placeholder="Password"
-                        aria-label="Password"
-                        bind:value="{registry.secret}"
-                        class="px-3 block w-full h-full transition ease-in-out delay-50 bg-charcoal-800 text-gray-700 placeholder-gray-700 rounded-sm focus:outline-none pr-10" />
-                    </div>
+                    <PasswordInput
+                      id="r.serverUrl"
+                      bind:password="{registry.secret}"
+                      on:action="{() =>
+                        setPasswordForRegistryVisible(
+                          registry,
+                          !showPasswordForServerUrls.some(r => r === registry.serverUrl),
+                        )}" />
                   </div>
                   <div class="h-7 text-sm">
                     <Button on:click="{() => loginToRegistry(registry)}" inProgress="{loggingIn}">Login</Button>
@@ -460,46 +408,21 @@ const processPasswordElement = (node: HTMLInputElement, registry: containerDeskt
             </div>
             <div class="flex pr-5 text-sm w-1/4" role="cell">
               {#if listedSuggestedRegistries[i]}
-                <input
-                  type="text"
-                  placeholder="Username"
-                  aria-label="Username"
-                  bind:value="{newRegistryRequest.username}"
-                  class="px-3 block w-full h-7 pr-5 transition ease-in-out delay-50 bg-charcoal-800 text-gray-700 placeholder-gray-700 rounded-sm focus:outline-none" />
+                <Input placeholder="Username" aria-label="Username" bind:value="{newRegistryRequest.username}" />
               {/if}
             </div>
             <div class="text-sm w-2/5" role="cell">
               <div class="flex flex-row items-center">
                 <div class="relative flex-1 mr-5">
                   {#if listedSuggestedRegistries[i]}
-                    <div class="absolute inset-y-0 right-0 flex">
-                      <input
-                        id="password-toggle-new-registry"
-                        aria-label="Toggle password"
-                        class="hidden"
-                        type="checkbox"
-                        value="false"
-                        tabindex="-1"
-                        on:change="{() =>
-                          setPasswordForRegistryVisible(
-                            newRegistryRequest,
-                            !showPasswordForServerUrls.some(r => r === ''),
-                          )}" />
-                      <label class="px-2 py-1 text text-gray-900 cursor-pointer" for="password-toggle-new-registry">
-                        {#if showPasswordForServerUrls.some(r => r === '')}
-                          <i class="fas fa-eye-slash"></i>
-                        {:else}
-                          <i class="fas fa-eye"></i>
-                        {/if}
-                      </label>
-                    </div>
-                    <input
-                      use:processPasswordElement="{newRegistryRequest}"
-                      type="password"
-                      placeholder="Password"
-                      aria-label="Password"
-                      bind:value="{newRegistryRequest.secret}"
-                      class="px-3 block w-full h-7 transition ease-in-out delay-50 bg-charcoal-800 text-gray-700 placeholder-gray-700 rounded-sm focus:outline-none pr-10" />
+                    <PasswordInput
+                      id="r.serverUrl"
+                      bind:password="{newRegistryRequest.secret}"
+                      on:action="{() =>
+                        setPasswordForRegistryVisible(
+                          newRegistryRequest,
+                          !showPasswordForServerUrls.some(r => r === ''),
+                        )}" />
                   {/if}
                 </div>
 
@@ -543,53 +466,24 @@ const processPasswordElement = (node: HTMLInputElement, registry: containerDeskt
         <div class="flex flex-col w-full border-t border-gray-900 space-x-2">
           <div class="flex flex-row items-center pt-4 pb-3">
             <div class="flex-1 pl-10 pr-5 text-sm w-auto m-auto">
-              <input
-                type="text"
+              <Input
                 placeholder="URL (HTTPS only)"
                 aria-label="Register URL"
-                bind:value="{newRegistryRequest.serverUrl}"
-                class="px-3 block w-full h-7 pr-5 transition ease-in-out delay-50 bg-charcoal-800 text-gray-700 placeholder-gray-700 rounded-sm focus:outline-none" />
+                bind:value="{newRegistryRequest.serverUrl}" />
             </div>
             <div class="flex pr-5 text-sm w-1/4">
-              <input
-                type="text"
-                placeholder="Username"
-                aria-label="Username"
-                bind:value="{newRegistryRequest.username}"
-                class="px-3 block w-full h-7 pr-5 transition ease-in-out delay-50 bg-charcoal-800 text-gray-700 placeholder-gray-700 rounded-sm focus:outline-none" />
+              <Input placeholder="Username" aria-label="Username" bind:value="{newRegistryRequest.username}" />
             </div>
             <div class="text-sm w-2/5">
               <div class="flex flex-row">
-                <div class="relative flex-1 mr-5">
-                  <div class="absolute inset-y-0 right-0 flex">
-                    <input
-                      id="password-toggle-new-registry"
-                      aria-label="Toggle password"
-                      class="hidden"
-                      type="checkbox"
-                      value="false"
-                      tabindex="-1"
-                      on:change="{() =>
-                        setPasswordForRegistryVisible(
-                          newRegistryRequest,
-                          !showPasswordForServerUrls.some(r => r === ''),
-                        )}" />
-                    <label class="px-2 py-1 text text-gray-900 cursor-pointer" for="password-toggle-new-registry">
-                      {#if showPasswordForServerUrls.some(r => r === '')}
-                        <i class="fas fa-eye-slash"></i>
-                      {:else}
-                        <i class="fas fa-eye"></i>
-                      {/if}
-                    </label>
-                  </div>
-                  <input
-                    use:processPasswordElement="{newRegistryRequest}"
-                    type="password"
-                    placeholder="Password"
-                    aria-label="Password"
-                    bind:value="{newRegistryRequest.secret}"
-                    class="px-3 block w-full h-7 transition ease-in-out delay-50 bg-charcoal-800 text-gray-700 placeholder-gray-700 rounded-sm focus:outline-none pr-10" />
-                </div>
+                <PasswordInput
+                  id="newRegistryRequest"
+                  bind:password="{newRegistryRequest.secret}"
+                  on:action="{() =>
+                    setPasswordForRegistryVisible(
+                      newRegistryRequest,
+                      !showPasswordForServerUrls.some(r => r === ''),
+                    )}" />
 
                 <div class="flex text-sm">
                   <Button

--- a/packages/renderer/src/lib/ui/Input.svelte
+++ b/packages/renderer/src/lib/ui/Input.svelte
@@ -43,7 +43,7 @@ async function onClear() {
   <input
     bind:this="{element}"
     on:input
-    class="grow px-1 outline-0 bg-charcoal-500 text-sm text-white placeholder:text-gray-700"
+    class="grow px-1 outline-0 bg-charcoal-500 text-sm text-white placeholder:text-gray-700 overflow-hidden"
     class:group-hover:bg-charcoal-900="{!readonly}"
     class:group-focus-within:bg-charcoal-900="{!readonly}"
     class:group-hover-placeholder:text-gray-900="{!readonly}"

--- a/packages/renderer/src/lib/ui/PasswordInput.svelte
+++ b/packages/renderer/src/lib/ui/PasswordInput.svelte
@@ -30,6 +30,7 @@ async function onShowHide() {
   class="{$$props.class || ''}"
   id="password-{id}"
   name="password-{id}"
+  placeholder="Password"
   bind:value="{password}"
   aria-label="password {id}"
   bind:readonly="{readonly}"


### PR DESCRIPTION
### What does this PR do?

Use the Input component when editing registries. Switching to use Input and PasswordInput I had to clean up some styling and 'use:' code.

Found two minor things needed for the components:
- Input needs to have overflow-hidden to work in narrow spaces.
- Password was missing a placeholder.

While testing I found *lots* of UI issues that are unrelated to this change. None of the columns/sections are aligned, have different spacing/styling/padding or none between user/password/button columns, sometimes controls touching each other, etc. I have another PR ready to go, but am keeping this one limited to just the input component change to keep things separate.

### Screenshot / video of UI

<img width="949" alt="Screenshot 2024-02-09 at 5 14 03 PM" src="https://github.com/containers/podman-desktop/assets/19958075/78a2215f-46b5-4dc4-ab77-c1dc03ea7e31">

### What issues does this PR fix or reference?

Another small part of #3234.

### How to test this PR?

Edit all three kinds of registries.