### PR TITLE
chore: cleanup dark: prefix colors

### DIFF
--- a/packages/renderer/src/lib/docker-extension/PreferencesPageDockerExtensions.svelte
+++ b/packages/renderer/src/lib/docker-extension/PreferencesPageDockerExtensions.svelte
@@ -108,7 +108,7 @@ function deleteContribution(extensionName: string) {
           <div class="flex flex-col bg-purple-600 h-[100px]">
             <div class="flex justify-end flex-wrap">
               <button
-                class="inline-block text-gray-100 dark:text-gray-100 hover:text-gray-700 dark:hover:text-gray-700 focus:outline-none rounded-lg text-sm p-1.5"
+                class="inline-block text-gray-100 hover:text-gray-700 focus:outline-none rounded-lg text-sm p-1.5"
                 type="button">
                 <i
                   class="fas fa-times"

--- a/packages/renderer/src/lib/feedback/SendFeedback.svelte
+++ b/packages/renderer/src/lib/feedback/SendFeedback.svelte
@@ -67,7 +67,7 @@ async function sendFeedback(): Promise<void> {
       </div>
 
       <div class="overflow-y-auto p-4">
-        <label for="smiley" class="block mb-2 text-sm font-medium text-gray-400 dark:text-gray-400"
+        <label for="smiley" class="block mb-2 text-sm font-medium text-gray-400"
           >How was your experience with Podman Desktop ?</label>
         <div class="flex space-x-4">
           <button aria-label="very-sad-smiley" on:click="{() => selectSmiley(1)}">
@@ -96,7 +96,7 @@ async function sendFeedback(): Promise<void> {
           </button>
         </div>
 
-        <label for="tellUsWhyFeedback" class="block mt-4 mb-2 text-sm font-medium text-gray-400 dark:text-gray-400"
+        <label for="tellUsWhyFeedback" class="block mt-4 mb-2 text-sm font-medium text-gray-400"
           >Tell us why, or share any suggestion or issue to improve your experience: ({1000 - tellUsWhyFeedback.length} characters
           left)</label>
         <textarea
@@ -109,7 +109,7 @@ async function sendFeedback(): Promise<void> {
           class="w-full p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700"
           placeholder="Please enter your feedback here, we appreciate and review all comments"></textarea>
 
-        <label for="contactInformation" class="block mt-4 mb-2 text-sm font-medium text-gray-400 dark:text-gray-400"
+        <label for="contactInformation" class="block mt-4 mb-2 text-sm font-medium text-gray-400"
           >Share your contact information if you'd like us to answer you:</label>
         <input
           type="email"

--- a/packages/renderer/src/lib/image/BuildImageFromContainerfile.svelte
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfile.svelte
@@ -199,7 +199,7 @@ async function abortBuild() {
             class="w-full p-2 outline-none text-sm bg-charcoal-600 rounded-sm text-gray-700 placeholder-gray-700"
             required />
           {#if providerConnections.length > 1}
-            <label for="providerChoice" class="py-6 block mb-2 text-sm font-bold text-gray-400 dark:text-gray-400"
+            <label for="providerChoice" class="py-6 block mb-2 text-sm font-bold text-gray-400"
               >Container Engine
               <select
                 class="w-full p-2 outline-none text-sm bg-charcoal-600 rounded-sm text-gray-700 placeholder-gray-700"

--- a/packages/renderer/src/lib/image/PushImageModal.svelte
+++ b/packages/renderer/src/lib/image/PushImageModal.svelte
@@ -119,8 +119,7 @@ let pushLogsXtermDiv: HTMLDivElement;
 
     <div class="flex flex-col px-10 py-4 text-sm leading-5 space-y-5">
       <div>
-        <label for="modalImageTag" class="block mb-2 text-sm font-medium text-gray-400 dark:text-gray-400"
-          >Image Tag</label>
+        <label for="modalImageTag" class="block mb-2 text-sm font-medium text-gray-400">Image Tag</label>
         <select
           class="border text-sm rounded-lg focus:ring-purple-500 focus:border-purple-500 block w-full p-2.5 bg-charcoal-600 border-gray-900 placeholder-gray-700 text-white"
           name="imageChoice"

--- a/packages/renderer/src/lib/image/RunImage.svelte
+++ b/packages/renderer/src/lib/image/RunImage.svelte
@@ -655,7 +655,7 @@ async function assertAllPortAreValid(): Promise<void> {
           <div>
             <Route path="/basic" breadcrumb="Basic" navigationHint="tab">
               <div class="h-96 overflow-y-auto pr-4">
-                <label for="modalContainerName" class="block mb-2 text-sm font-medium text-gray-400 dark:text-gray-400"
+                <label for="modalContainerName" class="block mb-2 text-sm font-medium text-gray-400"
                   >Container name:</label>
                 <input
                   type="text"
@@ -670,25 +670,22 @@ async function assertAllPortAreValid(): Promise<void> {
                 {#if containerNameError}
                   <ErrorMessage class="text-sm" error="{containerNameError}" />
                 {/if}
-                <label
-                  for="modalEntrypoint"
-                  class="pt-4 block mb-2 text-sm font-medium text-gray-400 dark:text-gray-400">Entrypoint:</label>
+                <label for="modalEntrypoint" class="pt-4 block mb-2 text-sm font-medium text-gray-400"
+                  >Entrypoint:</label>
                 <input
                   type="text"
                   bind:value="{entrypoint}"
                   name="modalEntrypoint"
                   id="modalEntrypoint"
                   class="w-full p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700 border border-charcoal-800" />
-                <label for="modalCommand" class="pt-4 block mb-2 text-sm font-medium text-gray-400 dark:text-gray-400"
-                  >Command:</label>
+                <label for="modalCommand" class="pt-4 block mb-2 text-sm font-medium text-gray-400">Command:</label>
                 <input
                   type="text"
                   bind:value="{command}"
                   name="modalCommand"
                   id="modalCommand"
                   class="w-full p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700 border border-charcoal-800" />
-                <label for="volumes" class="pt-4 block mb-2 text-sm font-medium text-gray-400 dark:text-gray-400"
-                  >Volumes:</label>
+                <label for="volumes" class="pt-4 block mb-2 text-sm font-medium text-gray-400">Volumes:</label>
                 <!-- Display the list of volumes -->
                 {#each volumeMounts as volumeMount, index}
                   <div class="flex flex-row justify-center items-center w-full py-1">
@@ -727,9 +724,8 @@ async function assertAllPortAreValid(): Promise<void> {
                 {/each}
 
                 <!-- add a label for each port-->
-                <label
-                  for="modalContainerName"
-                  class="pt-4 block mb-2 text-sm font-medium text-gray-400 dark:text-gray-400">Port mapping:</label>
+                <label for="modalContainerName" class="pt-4 block mb-2 text-sm font-medium text-gray-400"
+                  >Port mapping:</label>
                 {#each exposedPorts as port, index}
                   <div class="flex flex-row justify-center items-center w-full">
                     <span class="text-sm flex-1 inline-block align-middle whitespace-nowrap text-gray-700"
@@ -773,9 +769,7 @@ async function assertAllPortAreValid(): Promise<void> {
                     </button>
                   </div>
                 {/each}
-                <label
-                  for="modalEnvironmentVariables"
-                  class="pt-4 block mb-2 text-sm font-medium text-gray-400 dark:text-gray-400"
+                <label for="modalEnvironmentVariables" class="pt-4 block mb-2 text-sm font-medium text-gray-400"
                   >Environment variables:</label>
                 <!-- Display the list of existing environment variables -->
                 {#each environmentVariables as environmentVariable, index}
@@ -807,9 +801,8 @@ async function assertAllPortAreValid(): Promise<void> {
                 {/each}
               </div>
 
-              <label
-                for="modalEnvironmentFiles"
-                class="pt-4 block mb-2 text-sm font-medium text-gray-400 dark:text-gray-400">Environment files:</label>
+              <label for="modalEnvironmentFiles" class="pt-4 block mb-2 text-sm font-medium text-gray-400"
+                >Environment files:</label>
               <!-- Display the list of existing environment files -->
               {#each environmentFiles as environmentFile, index}
                 <div class="flex flex-row justify-center items-center w-full py-1">
@@ -853,8 +846,7 @@ async function assertAllPortAreValid(): Promise<void> {
             <Route path="/advanced" breadcrumb="Advanced" navigationHint="tab">
               <div class="h-96 overflow-y-auto pr-4">
                 <!-- Use tty -->
-                <label for="containerTty" class="block mb-2 text-sm font-medium text-gray-400 dark:text-gray-400"
-                  >Use TTY:</label>
+                <label for="containerTty" class="block mb-2 text-sm font-medium text-gray-400">Use TTY:</label>
                 <div class="flex flex-row justify-start items-center align-middle w-full text-gray-700 text-sm">
                   <input
                     type="checkbox"
@@ -873,7 +865,7 @@ async function assertAllPortAreValid(): Promise<void> {
                 </div>
 
                 <!-- Specify user-->
-                <label for="containerUser" class="pt-4 block mb-2 text-sm font-medium text-gray-400 dark:text-gray-400"
+                <label for="containerUser" class="pt-4 block mb-2 text-sm font-medium text-gray-400"
                   >Specify user to run container as:</label>
                 <div class="flex flex-row justify-center items-center w-full">
                   <input
@@ -884,9 +876,7 @@ async function assertAllPortAreValid(): Promise<void> {
                 </div>
 
                 <!-- Autoremove-->
-                <label
-                  for="containerAutoRemove"
-                  class="pt-4 block mb-2 text-sm font-medium text-gray-400 dark:text-gray-400"
+                <label for="containerAutoRemove" class="pt-4 block mb-2 text-sm font-medium text-gray-400"
                   >Auto removal of container:</label>
                 <div class="flex flex-row justify-start items-center align-middle w-full text-gray-700 text-sm">
                   <input type="checkbox" bind:checked="{autoRemove}" class="mx-2 outline-none text-sm" />
@@ -894,9 +884,8 @@ async function assertAllPortAreValid(): Promise<void> {
                 </div>
 
                 <!-- RestartPolicy-->
-                <label
-                  for="containerRestartPolicy"
-                  class="pt-4 block mb-2 text-sm font-medium text-gray-400 dark:text-gray-400">Restart policy:</label>
+                <label for="containerRestartPolicy" class="pt-4 block mb-2 text-sm font-medium text-gray-400"
+                  >Restart policy:</label>
                 <div class="p-0 flex flex-row justify-start items-center align-middle w-full text-gray-700">
                   <span class="text-sm w-28 inline-block align-middle whitespace-nowrap text-gray-700"
                     >Policy name:</span>
@@ -934,7 +923,7 @@ async function assertAllPortAreValid(): Promise<void> {
             <Route path="/security" breadcrumb="Security" navigationHint="tab">
               <div class="h-96 overflow-y-auto pr-4">
                 <!-- Privileged-->
-                <label for="containerPrivileged" class="block mb-2 text-sm font-medium text-gray-400 dark:text-gray-400"
+                <label for="containerPrivileged" class="block mb-2 text-sm font-medium text-gray-400"
                   >Privileged:</label>
                 <div class="flex flex-row justify-start items-center align-middle w-full text-gray-700 text-sm">
                   <input type="checkbox" bind:checked="{privileged}" class="mx-2 outline-none text-sm" />
@@ -942,17 +931,14 @@ async function assertAllPortAreValid(): Promise<void> {
                 </div>
 
                 <!-- Read-Only -->
-                <label
-                  for="containerReadOnly"
-                  class="pt-4 block mb-2 text-sm font-medium text-gray-400 dark:text-gray-400">Read only:</label>
+                <label for="containerReadOnly" class="pt-4 block mb-2 text-sm font-medium text-gray-400"
+                  >Read only:</label>
                 <div class="flex flex-row justify-start items-center align-middle w-full text-gray-700 text-sm">
                   <input type="checkbox" bind:checked="{readOnly}" class="mx-2 outline-none text-sm" />
                   Make containers root filesystem read-only
                 </div>
 
-                <label
-                  for="ContainerSecurityOptions"
-                  class="pt-4 block mb-2 text-sm font-medium text-gray-400 dark:text-gray-400"
+                <label for="ContainerSecurityOptions" class="pt-4 block mb-2 text-sm font-medium text-gray-400"
                   >Security options (security-opt):</label>
                 <!-- Display the list of existing security options -->
                 {#each securityOpts as securityOpt, index}
@@ -978,14 +964,12 @@ async function assertAllPortAreValid(): Promise<void> {
                   </div>
                 {/each}
 
-                <label
-                  for="ContainerSecurityCapabilitiesAdd"
-                  class="pt-4 block mb-2 text-sm font-medium text-gray-400 dark:text-gray-400">Capabilities:</label>
+                <label for="ContainerSecurityCapabilitiesAdd" class="pt-4 block mb-2 text-sm font-medium text-gray-400"
+                  >Capabilities:</label>
 
                 <label
                   for="ContainerSecurityCapabilitiesAdd"
-                  class="pl-4 pt-2 block mb-2 text-sm font-medium text-gray-400 dark:text-gray-400"
-                  >Add to the container (CapAdd):</label>
+                  class="pl-4 pt-2 block mb-2 text-sm font-medium text-gray-400">Add to the container (CapAdd):</label>
                 <!-- Display the list of existing capAdd -->
                 {#each capAdds as capAdd, index}
                   <div class="flex flex-row justify-center items-center w-full py-1">
@@ -1011,7 +995,7 @@ async function assertAllPortAreValid(): Promise<void> {
                 {/each}
                 <label
                   for="ContainerSecurityCapabilitiesDrop"
-                  class="pl-4 pt-2 block mb-2 text-sm font-medium text-gray-400 dark:text-gray-400"
+                  class="pl-4 pt-2 block mb-2 text-sm font-medium text-gray-400"
                   >Drop from the container (CapDrop):</label>
                 <!-- Display the list of existing capDrop -->
                 {#each capDrops as capDrop, index}
@@ -1038,9 +1022,7 @@ async function assertAllPortAreValid(): Promise<void> {
                 {/each}
 
                 <!-- Specify user namespace-->
-                <label
-                  for="containerUserNamespace"
-                  class="pt-4 block mb-2 text-sm font-medium text-gray-400 dark:text-gray-400"
+                <label for="containerUserNamespace" class="pt-4 block mb-2 text-sm font-medium text-gray-400"
                   >Specify user namespace to use:</label>
                 <div class="flex flex-row justify-center items-center w-full">
                   <input
@@ -1055,7 +1037,7 @@ async function assertAllPortAreValid(): Promise<void> {
             <Route path="/networking" breadcrumb="Networking" navigationHint="tab">
               <div class="h-96 overflow-y-auto pr-4">
                 <!-- hostname-->
-                <label for="containerHostname" class="block mb-2 text-sm font-medium text-gray-400 dark:text-gray-400"
+                <label for="containerHostname" class="block mb-2 text-sm font-medium text-gray-400"
                   >Defines container hostname:</label>
                 <div class="flex flex-row justify-center items-center w-full">
                   <input
@@ -1066,7 +1048,7 @@ async function assertAllPortAreValid(): Promise<void> {
                 </div>
 
                 <!-- DNS -->
-                <label for="ContainerDns" class="pt-4 block mb-2 text-sm font-medium text-gray-400 dark:text-gray-400"
+                <label for="ContainerDns" class="pt-4 block mb-2 text-sm font-medium text-gray-400"
                   >Custom DNS server(s):</label>
 
                 {#each dnsServers as dnsServer, index}
@@ -1092,9 +1074,7 @@ async function assertAllPortAreValid(): Promise<void> {
                   </div>
                 {/each}
 
-                <label
-                  for="containerExtraHosts"
-                  class="pt-4 block mb-2 text-sm font-medium text-gray-400 dark:text-gray-400"
+                <label for="containerExtraHosts" class="pt-4 block mb-2 text-sm font-medium text-gray-400"
                   >Add extra hosts (appends to /etc/hosts file):</label>
                 <!-- Display the list of existing environment variables -->
                 {#each extraHosts as extraHost, index}
@@ -1126,9 +1106,7 @@ async function assertAllPortAreValid(): Promise<void> {
                 {/each}
 
                 <!-- Select network -->
-                <label
-                  for="containerNetwork"
-                  class="pt-4 block mb-2 text-sm font-medium text-gray-400 dark:text-gray-400"
+                <label for="containerNetwork" class="pt-4 block mb-2 text-sm font-medium text-gray-400"
                   >Select container networking:</label>
                 <div class="p-0 flex flex-row justify-start items-center align-middle w-full text-gray-700">
                   <span class="text-sm w-28 inline-block align-middle whitespace-nowrap text-gray-700">Mode:</span>

--- a/packages/renderer/src/lib/kube/KubePlayYAML.svelte
+++ b/packages/renderer/src/lib/kube/KubePlayYAML.svelte
@@ -201,9 +201,7 @@ async function getKubernetesfileLocation() {
                 </div>
                 <div hidden="{runStarted}">
                   {#if providerConnections.length > 1}
-                    <label
-                      for="providerConnectionName"
-                      class="py-6 block mb-2 text-sm font-medium text-gray-400 dark:text-gray-400"
+                    <label for="providerConnectionName" class="py-6 block mb-2 text-sm font-medium text-gray-400"
                       >Container Engine
                       <select
                         class="border text-sm rounded-lg focus:ring-purple-500 focus:border-purple-500 block w-full p-2.5 bg-gray-900 border-gray-900 placeholder-gray-700 text-white"

--- a/packages/renderer/src/lib/pod/PodCreateFromContainers.svelte
+++ b/packages/renderer/src/lib/pod/PodCreateFromContainers.svelte
@@ -230,7 +230,7 @@ function updatePortExposure(port: number, checked: boolean) {
             </div>
           {/if}
           <div class="mb-2">
-            <span class="block text-sm font-semibold rounded text-gray-400 dark:text-gray-400">Name of the pod:</span>
+            <span class="block text-sm font-semibold rounded text-gray-400">Name of the pod:</span>
           </div>
           <div class="mb-4">
             <Input
@@ -244,7 +244,7 @@ function updatePortExposure(port: number, checked: boolean) {
           </div>
 
           <div class="mb-2">
-            <span class="block text-sm font-semibold rounded text-gray-400 dark:text-gray-400" aria-label="Containers"
+            <span class="block text-sm font-semibold rounded text-gray-400" aria-label="Containers"
               >Containers to replicate to the pod:</span>
           </div>
           <div class="w-full bg-charcoal-900 mb-4 max-h-40 overflow-y-auto">
@@ -260,9 +260,8 @@ function updatePortExposure(port: number, checked: boolean) {
 
           {#if mapPortExposed.size > 0}
             <div class="mb-2">
-              <span
-                class="block text-sm font-semibold rounded text-gray-400 dark:text-gray-400"
-                aria-label="Exposed ports">All selected ports will be exposed:</span>
+              <span class="block text-sm font-semibold rounded text-gray-400" aria-label="Exposed ports"
+                >All selected ports will be exposed:</span>
             </div>
             <div class="bg-charcoal-900 mb-4 max-h-40 overflow-y-auto">
               {#each [...mapPortExposed] as [port, value]}
@@ -286,7 +285,7 @@ function updatePortExposure(port: number, checked: boolean) {
           {#if providerConnections.length > 1}
             <label
               for="providerConnectionName"
-              class="p-2 block mb-2 text-sm font-medium rounded bg-zinc-700 text-gray-300 dark:text-gray-300"
+              class="p-2 block mb-2 text-sm font-medium rounded bg-zinc-700 text-gray-300"
               >Container Engine
               <select
                 class="w-full p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-400 placeholder-gray-400"

--- a/packages/renderer/src/lib/preferences/PreferencesProxiesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesProxiesRendering.svelte
@@ -70,7 +70,7 @@ function validate(event: any) {
         id="toggle-proxy"
         class="sr-only peer" />
       <div
-        class="w-9 h-5 rounded-full peer bg-zinc-400 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-400 after:border after:rounded-full after:h-4 after:w-4 after:transition-all dark:border-gray-900 peer-checked:bg-violet-600">
+        class="w-9 h-5 rounded-full peer bg-zinc-400 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-400 after:border after:rounded-full after:h-4 after:w-4 after:transition-all border-gray-900 peer-checked:bg-violet-600">
       </div>
       <span class="ml-3 text-sm font-medium text-gray-400"
         >Proxy configuration {proxyState ? 'enabled' : 'disabled'}</span>
@@ -78,11 +78,8 @@ function validate(event: any) {
 
     {#if proxySettings}
       <div class="space-y-2">
-        <label
-          for="httpProxy"
-          class="mb-2 text-sm font-medium {proxyState
-            ? 'text-gray-400 dark:text-gray-400'
-            : 'text-gray-900 dark:text-gray-900'}">Web Proxy (HTTP):</label>
+        <label for="httpProxy" class="mb-2 text-sm font-medium {proxyState ? 'text-gray-400' : 'text-gray-900'}"
+          >Web Proxy (HTTP):</label>
         <input
           name="httpProxy"
           id="httpProxy"
@@ -97,11 +94,8 @@ function validate(event: any) {
         {/if}
       </div>
       <div class="space-y-2">
-        <label
-          for="httpsProxy"
-          class="pt-4 mb-2 text-sm font-medium {proxyState
-            ? 'text-gray-400 dark:text-gray-400'
-            : 'text-gray-900 dark:text-gray-900'}">Secure Web Proxy (HTTPS):</label>
+        <label for="httpsProxy" class="pt-4 mb-2 text-sm font-medium {proxyState ? 'text-gray-400' : 'text-gray-900'}"
+          >Secure Web Proxy (HTTPS):</label>
         <input
           name="httpsProxy"
           id="httpsProxy"
@@ -116,11 +110,8 @@ function validate(event: any) {
         {/if}
       </div>
       <div class="space-y-2">
-        <label
-          for="httpProxy"
-          class="pt-4 mb-2 text-sm font-medium {proxyState
-            ? 'text-gray-400 dark:text-gray-400'
-            : 'text-gray-900 dark:text-gray-900'}">Bypass proxy settings for these hosts and domains:</label>
+        <label for="httpProxy" class="pt-4 mb-2 text-sm font-medium {proxyState ? 'text-gray-400' : 'text-gray-900'}"
+          >Bypass proxy settings for these hosts and domains:</label>
         <input
           name="noProxy"
           id="noProxy"

--- a/packages/renderer/src/lib/volume/CreateVolume.svelte
+++ b/packages/renderer/src/lib/volume/CreateVolume.svelte
@@ -78,7 +78,7 @@ export let volumeName = '';
         </div>
         <div class:hidden="{providerConnections.length < 2}">
           {#if providerConnections.length > 1}
-            <label for="providerChoice" class="py-3 block mb-2 text-sm font-bold text-gray-400 dark:text-gray-400"
+            <label for="providerChoice" class="py-3 block mb-2 text-sm font-bold text-gray-400"
               >Container Engine
               <select
                 class="w-full p-2 outline-none text-sm bg-charcoal-600 rounded-sm text-gray-700 placeholder-gray-700"


### PR DESCRIPTION
### What does this PR do?
it is not necessary to have the `dark:` prefix colors as there is another
definition without `dark:` prefix and we won't be using tailwind
theming but color aliasing so we don't need these `dark:` colors


### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

related to https://github.com/containers/podman-desktop/issues/5914

### How to test this PR?

<!-- Please explain steps to reproduce -->
