### PR TITLE
chore: allow to handle svelte v5

### DIFF
--- a/packages/renderer/src/main.ts
+++ b/packages/renderer/src/main.ts
@@ -1,10 +1,17 @@
+import * as svelte from 'svelte';
 import Loader from './Loader.svelte';
 
 const target = document.getElementById('app');
 let app;
 if (target) {
-  app = new Loader({
-    target,
-  });
+  // handle svelte v5
+  if ((svelte as any).createRoot) {
+    app = (svelte as any).createRoot(Loader, { target });
+  } else {
+    // v4 usage
+    app = new Loader({
+      target,
+    });
+  }
 }
 export default app;


### PR DESCRIPTION
### What does this PR do?
svelte v5 is no longer instantiating classes
https://svelte-5-preview.vercel.app/docs/breaking-changes#components-are-no-longer-classes

use code to be compliant with both v4 and v5

### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

usage of svelte v5

### How to test this PR?

should be ✅ as before
