### PR TITLE
chore(deps): bump @segment/analytics-node from 1.3.0 to 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
   "dependencies": {
     "@docker/extension-api-client-types": "0.3.4",
     "@kubernetes/client-node": "^0.20.0",
-    "@segment/analytics-node": "^1.3.0",
+    "@segment/analytics-node": "^2.0.0",
     "@types/stream-json": "^1.7.7",
     "adm-zip": "^0.5.10",
     "check-disk-space": "^3.4.0",

--- a/packages/main/vite.config.js
+++ b/packages/main/vite.config.js
@@ -53,7 +53,7 @@ const config = {
         '@kubernetes/client-node',
         'tar-fs',
         'ssh2',
-        'analytics-node',
+        '@segment/analytics-node',
         'express',
         'electron-devtools-installer',
         ...builtinModules.flatMap(p => [p, `node:${p}`]),

--- a/yarn.lock
+++ b/yarn.lock
@@ -3090,15 +3090,16 @@
   dependencies:
     tslib "^2.4.1"
 
-"@segment/analytics-node@^1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@segment/analytics-node/-/analytics-node-1.3.0.tgz#4129ea2c5e2bc9d5795cbf5d5ad1e3071a221783"
-  integrity sha512-lRLz1WZaDokMoUe299yP5JkInc3OgJuqNNlxb6j0q22umCiq6b5iDo2gRmFn93reirIvJxWIicQsGrHd93q8GQ==
+"@segment/analytics-node@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@segment/analytics-node/-/analytics-node-2.0.0.tgz#297acf76dc787e373d4236fceb38a67f110e1a7c"
+  integrity sha512-DU25dmsTsMEQ/A1OxVr2vHpGUyUZ2wukH3dH9bYRgvQOlhnnRHBP9hB3smNLfygC0IU2CKhT1rP6CGtVfdf4Sg==
   dependencies:
     "@lukeed/uuid" "^2.0.0"
     "@segment/analytics-core" "1.4.1"
     "@segment/analytics-generic-utils" "1.1.1"
     buffer "^6.0.3"
+    jose "^5.1.0"
     node-fetch "^2.6.7"
     tslib "^2.4.1"
 
@@ -10012,6 +10013,11 @@ jose@^4.10.0:
   version "4.11.1"
   resolved "https://registry.yarnpkg.com/jose/-/jose-4.11.1.tgz#8f7443549befe5bddcf4bae664a9cbc1a62da4fa"
   integrity sha512-YRv4Tk/Wlug8qicwqFNFVEZSdbROCHRAC6qu/i0dyNKr5JQdoa2pIGoS04lLO/jXQX7Z9omoNewYIVIxqZBd9Q==
+
+jose@^5.1.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/jose/-/jose-5.2.0.tgz#d0ffd7f7e31253f633eefb190a930cd14a916995"
+  integrity sha512-oW3PCnvyrcm1HMvGTzqjxxfnEs9EoFOFWi2HsEGhlFVOXxTE3K9GKWVMFoFw06yPUqwpvEWic1BmtUZBI/tIjw==
 
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION

### What does this PR do?
update the vite config file to not touch the library library had an old name before
but when switching to the new lib as part
of https://github.com/containers/podman-desktop/pull/4149 we didn't update the vite config file


### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/pull/5750

### How to test this PR?

<!-- Please explain steps to reproduce -->
