### PR TITLE
docs: Shorter sidebar category names

### DIFF
--- a/website/docs/kind/configuring-podman-for-kind-on-windows.md
+++ b/website/docs/kind/configuring-podman-for-kind-on-windows.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 3
-title: Configuring Podman for Kind
+title: Configuring Podman
 description: Configuring Podman for Kind on Windows Subsystem for Linux (WSL).
 keywords: [podman desktop, podman, containers, migrating, kubernetes, kind]
 tags: [migrating-to-kubernetes, kind]

--- a/website/docs/kind/creating-a-kind-cluster.md
+++ b/website/docs/kind/creating-a-kind-cluster.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 4
-title: Creating a Kind cluster
+title: Creating a cluster
 description: Creating a local Kind-powered Kubernetes cluster.
 keywords: [podman desktop, podman, containers, migrating, kubernetes, kind]
 tags: [migrating-to-kubernetes, kind]

--- a/website/docs/kind/deleting-your-kind-cluster.md
+++ b/website/docs/kind/deleting-your-kind-cluster.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 6
-title: Deleting your Kind cluster
+title: Deleting a cluster
 description: Deleting your local Kind-powered Kubernetes cluster.
 keywords: [podman desktop, podman, containers, migrating, kubernetes, kind]
 tags: [migrating-to-kubernetes, kind]

--- a/website/docs/kind/installing.md
+++ b/website/docs/kind/installing.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 2
-title: Installing the `kind` CLI
+title: Installing the CLI
 description: Kind is one way to get Kubernetes running on your workstation.
 keywords: [podman desktop, podman, containers, migrating, kubernetes, kind]
 tags: [migrating-to-kubernetes, kind]

--- a/website/docs/kind/pushing-an-image-to-kind.md
+++ b/website/docs/kind/pushing-an-image-to-kind.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 10
-title: Push an image to Kind
+title: Pushing an image
 description: Pushing an image to your Kind cluster
 keywords: [podman desktop, podman, containers, images, migrating, kubernetes]
 tags: [migrating-to-kubernetes, images]

--- a/website/docs/kind/restarting-your-kind-cluster.md
+++ b/website/docs/kind/restarting-your-kind-cluster.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 5
-title: Restarting your Kind cluster
+title: Restarting a cluster
 description: Restarting your local Kind-powered Kubernetes cluster.
 keywords: [podman desktop, podman, containers, migrating, kubernetes, kind]
 tags: [migrating-to-kubernetes, kind]

--- a/website/docs/kind/working-with-your-local-kind-cluster.md
+++ b/website/docs/kind/working-with-your-local-kind-cluster.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 5
-title: Working with your Kind cluster
+title: Working with a cluster
 description: Working with your local Kind-powered Kubernetes cluster.
 keywords: [podman desktop, podman, containers, migrating, kubernetes, kind]
 tags: [migrating-to-kubernetes, kind]

--- a/website/docs/lima/installing.md
+++ b/website/docs/lima/installing.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 1
-title: Installing the `lima` CLI
+title: Installing the CLI
 description: Installing Lima
 keywords: [podman desktop, podman, containers, migrating, kubernetes, lima]
 tags: [migrating-to-kubernetes, lima]

--- a/website/docs/minikube/configuring-podman-for-minikube-on-windows.md
+++ b/website/docs/minikube/configuring-podman-for-minikube-on-windows.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 3
-title: Configuring Podman for Minikube
+title: Configuring Podman
 description: Configuring Podman for Minikube on Windows Subsystem for Linux (WSL).
 keywords: [podman desktop, podman, containers, migrating, kubernetes, minikube]
 tags: [migrating-to-kubernetes, minikube]

--- a/website/docs/minikube/creating-a-minikube-cluster.md
+++ b/website/docs/minikube/creating-a-minikube-cluster.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 4
-title: Creating a Minikube cluster
+title: Creating a cluster
 description: Creating a local Minikube-powered Kubernetes cluster.
 keywords: [podman desktop, podman, containers, migrating, kubernetes, minikube]
 tags: [migrating-to-kubernetes, minikube]

--- a/website/docs/minikube/deleting-your-minikube-cluster.md
+++ b/website/docs/minikube/deleting-your-minikube-cluster.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 7
-title: Deleting your Minikube cluster
+title: Deleting a cluster
 description: Deleting your local Minikube-powered Kubernetes cluster.
 keywords: [podman desktop, podman, containers, migrating, kubernetes, minikube]
 tags: [migrating-to-kubernetes, minikube]

--- a/website/docs/minikube/installing.md
+++ b/website/docs/minikube/installing.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 2
-title: Installing the `minikube` CLI
+title: Installing the CLI
 description: Minikube is one way to get Kubernetes running on your workstation.
 keywords: [podman desktop, podman, containers, migrating, kubernetes, minikube]
 tags: [migrating-to-kubernetes, minikube]

--- a/website/docs/minikube/pushing-an-image-to-minikube.md
+++ b/website/docs/minikube/pushing-an-image-to-minikube.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 10
-title: Push an image to Minikube
+title: Pushing an image
 description: Pushing an image to your Minikube cluster
 keywords: [podman desktop, podman, containers, images, migrating, kubernetes]
 tags: [migrating-to-kubernetes, images]

--- a/website/docs/minikube/restarting-your-minikube-cluster.md
+++ b/website/docs/minikube/restarting-your-minikube-cluster.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 6
-title: Restarting your Minikube cluster
+title: Restarting a cluster
 description: Restarting your local Minikube-powered Kubernetes cluster.
 keywords: [podman desktop, podman, containers, migrating, kubernetes, minikube]
 tags: [migrating-to-kubernetes, minikube]

--- a/website/docs/minikube/working-with-your-local-minikube-cluster.md
+++ b/website/docs/minikube/working-with-your-local-minikube-cluster.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 5
-title: Working with your Minikube cluster
+title: Working with a cluster
 description: Working with your local Minikube-powered Kubernetes cluster.
 keywords: [podman desktop, podman, containers, migrating, kubernetes, minikube]
 tags: [migrating-to-kubernetes, minikube]

--- a/website/docs/troubleshooting/index.md
+++ b/website/docs/troubleshooting/index.md
@@ -1,5 +1,7 @@
 ---
 sidebar_position: 120
+title: Troubleshooting
+description: How to investigate when it does not work as expected.
 ---
 
 # Troubleshooting

--- a/website/docs/troubleshooting/troubleshooting-openshift-local.md
+++ b/website/docs/troubleshooting/troubleshooting-openshift-local.md
@@ -1,5 +1,7 @@
 ---
 sidebar_position: 100
+title: Podman on OpenShift
+description: How to investigate when Podman does not work as expected.
 ---
 
 # Troubleshooting OpenShift Local

--- a/website/docs/troubleshooting/troubleshooting-podman-on-linux.md
+++ b/website/docs/troubleshooting/troubleshooting-podman-on-linux.md
@@ -1,5 +1,7 @@
 ---
 sidebar_position: 40
+title: Podman on Linux
+description: How to investigate when Podman does not work as expected.
 ---
 
 # Troubleshooting Podman on Linux

--- a/website/docs/troubleshooting/troubleshooting-podman-on-macos.md
+++ b/website/docs/troubleshooting/troubleshooting-podman-on-macos.md
@@ -1,5 +1,7 @@
 ---
 sidebar_position: 30
+title: Podman on MacOS
+description: How to investigate when Podman does not work as expected.
 ---
 
 # Troubleshooting Podman on macOS

--- a/website/docs/troubleshooting/troubleshooting-podman-on-windows.md
+++ b/website/docs/troubleshooting/troubleshooting-podman-on-windows.md
@@ -1,5 +1,7 @@
 ---
 sidebar_position: 20
+title: Podman on Windows
+description: How to investigate when Podman does not work as expected.
 ---
 
 # Troubleshooting Podman on Windows

--- a/website/docs/troubleshooting/troubleshooting-podman.md
+++ b/website/docs/troubleshooting/troubleshooting-podman.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 10
-title: Troubleshooting Podman
+title: Podman
 description: How to investigate when Podman does not work as expected.
 ---
 


### PR DESCRIPTION
### What does this PR do?

This PR is shortening some side menu items title

### Screenshot / video of UI

> Cluster sidebar before

![cluster_before](https://github.com/containers/podman-desktop/assets/16507629/c28acb1c-2b22-433d-8d9e-436edd25ad16)

> Cluster sidebar now

![cluster_now](https://github.com/containers/podman-desktop/assets/16507629/5faa0592-3280-4f88-9072-95e87b94e34b)

> Troubleshooting sidebar before

![troubleshooting_before](https://github.com/containers/podman-desktop/assets/16507629/93437f38-7705-40eb-8acb-d0b3d8c37c3b)

> Troubleshooting sidebar now

![troubleshooting_now](https://github.com/containers/podman-desktop/assets/16507629/94a821de-efb0-4556-85ab-90ed0addafd4)

### What issues does this PR fix or reference?

Fixes #5884 

### How to test this PR?

1) cd website
2) npx docusaurus start
3) check the side menu bar on docs