### PR TITLE
feat: allow extensions to contribute themes with set of colors

### DIFF
--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -74,6 +74,7 @@ import type { NavigationManager } from '/@/plugin/navigation/navigation-manager.
 import type { WebviewRegistry } from '/@/plugin/webview/webview-registry.js';
 import type { ImageInspectInfo } from '/@/plugin/api/image-inspect-info.js';
 import type { PodInfo } from './api/pod-info.js';
+import type { ColorRegistry } from '/@/plugin/color-registry.js';
 
 /**
  * Handle the loading of an extension
@@ -171,6 +172,7 @@ export class ExtensionLoader {
     private imageCheckerProvider: ImageCheckerImpl,
     private navigationManager: NavigationManager,
     private webviewRegistry: WebviewRegistry,
+    private colorRegistry: ColorRegistry,
   ) {
     this.pluginsDirectory = directories.getPluginsDirectory();
     this.pluginsScanDirectory = directories.getPluginsScanDirectory();
@@ -591,6 +593,12 @@ export class ExtensionLoader {
     const icons = extension.manifest?.contributes?.icons;
     if (icons) {
       this.iconRegistry.registerIconContribution(extension, icons);
+    }
+
+    const themes = extension.manifest?.contributes?.themes;
+    if (themes) {
+      const disposable = this.colorRegistry.registerExtensionThemes(extension, themes);
+      extension.subscriptions.push(disposable);
     }
 
     const views = extension.manifest?.contributes?.views;

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -789,6 +789,7 @@ export class PluginSystem {
       imageChecker,
       navigationManager,
       webviewRegistry,
+      colorRegistry,
     );
     await this.extensionLoader.init();
 


### PR DESCRIPTION
### What does this PR do?
an extension can contribute a theme of colors
it's based upon a parent theme
if color is missing in the contribution it's taking the color of the parent theme

- [x] depends on https://github.com/containers/podman-desktop/pull/5958

### Screenshot / video of UI


https://github.com/containers/podman-desktop/assets/436777/1623ec5b-3e31-4aad-85f1-9394965271fd




### What issues does this PR fix or reference?

related to https://github.com/containers/podman-desktop/issues/5914

### How to test this PR?

unit tests added
