### PR TITLE
feat: publish colors to the style of the app

### DIFF
--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -50,6 +50,7 @@ import IngressesRoutesList from './lib/ingresses-routes/IngressesRoutesList.svel
 import Webview from './lib/webview/Webview.svelte';
 import IngressDetails from './lib/ingresses-routes/IngressDetails.svelte';
 import RouteDetails from './lib/ingresses-routes/RouteDetails.svelte';
+import ColorsStyle from './lib/style/ColorsStyle.svelte';
 
 router.mode.hash();
 
@@ -69,6 +70,7 @@ window.events?.receive('navigate', (navigationRequest: unknown) => {
 
 <Route path="/*" breadcrumb="Home" let:meta>
   <main class="flex flex-col w-screen h-screen overflow-hidden bg-charcoal-800">
+    <ColorsStyle />
     <IconsStyle />
     <Appearance />
     <TitleBar />

--- a/packages/renderer/src/lib/style/ColorsStyle.spec.ts
+++ b/packages/renderer/src/lib/style/ColorsStyle.spec.ts
@@ -1,0 +1,58 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import '@testing-library/jest-dom/vitest';
+import { beforeAll, test, expect, vi } from 'vitest';
+import { render } from '@testing-library/svelte';
+import ColorsStyle from './ColorsStyle.svelte';
+import { colorsInfos } from '/@/stores/colors';
+import type { ColorInfo } from '../../../../main/src/plugin/api/color-info';
+
+const listColorsMock = vi.fn();
+
+// fake the window object
+beforeAll(() => {
+  (window as any).listColors = listColorsMock;
+});
+
+test('Check colors are added in the css style', async () => {
+  const color: ColorInfo = {
+    id: 'my-custom-color',
+    value: '#123456',
+    cssVar: '--pd-my-custom-color',
+  };
+
+  // sets the colors
+  colorsInfos.set([color]);
+
+  render(ColorsStyle);
+
+  // expect to have the generated style for the colors
+  const style = document.querySelector('style');
+  expect(style).toBeInTheDocument();
+  // should have css type
+  expect(style).toHaveAttribute('type', 'text/css');
+
+  // check the id
+  expect(style).toHaveAttribute('id', 'podman-desktop-colors-styles');
+
+  // check content
+  expect(style).toHaveTextContent(':root { --pd-my-custom-color: #123456; }');
+});

--- a/packages/renderer/src/lib/style/ColorsStyle.svelte
+++ b/packages/renderer/src/lib/style/ColorsStyle.svelte
@@ -1,0 +1,51 @@
+<script lang="ts">
+import { onDestroy, onMount } from 'svelte';
+import { colorsInfos } from '/@/stores/colors';
+import type { ColorInfo } from '../../../../main/src/plugin/api/color-info';
+import type { Unsubscriber } from 'svelte/store';
+
+let style: HTMLStyleElement;
+
+let unsubscribe: Unsubscriber;
+
+function createStyleSheet(): HTMLStyleElement {
+  style = document.createElement('style');
+  style.type = 'text/css';
+  style.id = 'podman-desktop-colors-styles';
+  style.media = 'screen';
+
+  document.head.append(style);
+
+  style.textContent = '';
+
+  return style;
+}
+
+onMount(() => {
+  createStyleSheet();
+
+  // update icon rules
+  unsubscribe = colorsInfos.subscribe(infos => {
+    const styles: string[] = [];
+    infos.forEach((color: ColorInfo) => {
+      const cssVar = color.cssVar;
+      const colorValue = color.value;
+
+      styles.push(`${cssVar}: ${colorValue};`);
+    });
+
+    style.textContent = `
+  :root {
+    ${styles.join('\n')}
+  }
+`;
+  });
+});
+
+onDestroy(() => {
+  // remove old style tag from the head
+  style?.remove();
+
+  unsubscribe?.();
+});
+</script>


### PR DESCRIPTION
### What does this PR do?
it's publishing the colors in CSS with variables
so components can use the definition of these colors

register each color defined under the name `--pd-<name-of-the-color>`

depends on:
- [x] https://github.com/containers/podman-desktop/pull/5958
- [x] https://github.com/containers/podman-desktop/pull/5960

### Screenshot / video of UI
![image](https://github.com/containers/podman-desktop/assets/436777/155deaa0-5d6e-482e-b6fe-4a2afa3b8734)



### What issues does this PR fix or reference?

related to https://github.com/containers/podman-desktop/issues/5914

### How to test this PR?

unit tests provided