### PR TITLE
feat: open terminal in the running container

### DIFF
--- a/packages/main/src/plugin/kubernetes-exec-transmitter.spec.ts
+++ b/packages/main/src/plugin/kubernetes-exec-transmitter.spec.ts
@@ -1,0 +1,65 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { expect, test } from 'vitest';
+
+import type { TerminalSize } from '/@/plugin/kubernetes-exec-transmitter.js';
+import {
+  BufferedStreamWriter,
+  DEFAULT_COLUMNS,
+  DEFAULT_ROWS,
+  ResizableTerminalWriter,
+  StringLineReader,
+} from '/@/plugin/kubernetes-exec-transmitter.js';
+
+test('Test should verify string line reader', () => {
+  const reader = new StringLineReader();
+
+  reader.on('data', chunk => {
+    expect(chunk.toString()).toEqual('foo');
+  });
+
+  reader.push('foo');
+});
+
+test('Test should verify buffered stream writer', () => {
+  const writer = new BufferedStreamWriter((data: Buffer) => {
+    expect(data.toString()).toEqual('foo');
+  });
+
+  writer.write(Buffer.from('foo'));
+});
+
+test('Test should verify resizable terminal writer', () => {
+  const writer = new ResizableTerminalWriter(
+    new BufferedStreamWriter((data: Buffer) => {
+      expect(data.toString()).toEqual('foo');
+    }),
+  );
+
+  writer.on('resize', () => {
+    const dimension = writer.getDimension();
+    expect(dimension).toEqual({ width: 1, height: 1 } as TerminalSize);
+  });
+
+  writer.write(Buffer.from('foo'));
+
+  expect(writer.getDimension()).toEqual({ width: DEFAULT_COLUMNS, height: DEFAULT_ROWS } as TerminalSize);
+  writer.resize({ width: 1, height: 1 } as TerminalSize);
+  expect(writer.getDimension()).toEqual({ width: 1, height: 1 } as TerminalSize);
+});

--- a/packages/main/src/plugin/kubernetes-exec-transmitter.ts
+++ b/packages/main/src/plugin/kubernetes-exec-transmitter.ts
@@ -1,0 +1,116 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { WritableOptions } from 'node:stream';
+import { Readable, Writable } from 'node:stream';
+
+export const DEFAULT_COLUMNS: number = 80;
+export const DEFAULT_ROWS: number = 60;
+
+export interface TerminalSize {
+  height: number;
+  width: number;
+}
+
+export class ExecStreamWriter extends Writable {
+  protected transmitter: Writable;
+
+  constructor(transmitter: Writable, options?: WritableOptions) {
+    super(options);
+    this.transmitter = transmitter;
+  }
+
+  _write(chunk: unknown, encoding: BufferEncoding, callback: (error?: Error | null) => void): void {
+    this.transmitter._write(chunk, encoding, callback);
+  }
+}
+
+export class ResizableTerminalWriter extends ExecStreamWriter {
+  protected columns: number;
+  protected rows: number;
+
+  constructor(
+    transmitter: Writable,
+    terminalSize: TerminalSize = { width: DEFAULT_COLUMNS, height: DEFAULT_ROWS },
+    options?: WritableOptions,
+  ) {
+    super(transmitter, options);
+    this.columns = terminalSize.width;
+    this.rows = terminalSize.height;
+  }
+
+  _write(chunk: unknown, encoding: BufferEncoding, callback: (error?: Error | null) => void): void {
+    super._write(chunk, encoding, callback);
+  }
+
+  resize(terminalSize: TerminalSize): void {
+    this.columns = terminalSize.width;
+    this.rows = terminalSize.height;
+
+    this.emit('resize');
+  }
+
+  getDimension(): TerminalSize {
+    return {
+      width: this.columns,
+      height: this.rows,
+    } as TerminalSize;
+  }
+}
+
+export class BufferedStreamWriter extends Writable {
+  private readonly transmitFn: (data: Buffer) => void;
+
+  constructor(transmitFn: (data: Buffer) => void, options?: WritableOptions) {
+    super(options);
+    this.transmitFn = transmitFn;
+  }
+
+  _write(chunk: Buffer, encoding: BufferEncoding, callback: (error?: Error | null) => void): void {
+    this.transmitFn(chunk);
+    callback();
+  }
+}
+
+export class StringLineReader extends Readable {
+  private dataQueue: string[] = [];
+  private isReading: boolean = false;
+
+  constructor() {
+    super();
+  }
+
+  readLine(data: string): void {
+    this.dataQueue.push(data);
+    if (!this.isReading) {
+      this.read();
+    }
+  }
+
+  _read(): void {
+    this.isReading = true;
+    const data = this.dataQueue.shift();
+
+    if (data) {
+      this.push(data);
+    } else {
+      this.isReading = false;
+      this.push(undefined);
+    }
+  }
+}

--- a/packages/renderer/src/lib/pod/KubernetesTerminal.spec.ts
+++ b/packages/renderer/src/lib/pod/KubernetesTerminal.spec.ts
@@ -1,0 +1,79 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, waitFor } from '@testing-library/svelte';
+import { get } from 'svelte/store';
+import { beforeAll, expect, test, vi } from 'vitest';
+
+import KubernetesTerminal from '/@/lib/pod/KubernetesTerminal.svelte';
+import { terminalStates } from '/@/stores/kubernetes-terminal-state-store';
+
+const getConfigurationValueMock = vi.fn();
+const kubernetesExecMock = vi.fn();
+const kubernetesExecResizeMock = vi.fn();
+
+beforeAll(() => {
+  (window as any).getConfigurationValue = getConfigurationValueMock;
+  (window as any).kubernetesExec = kubernetesExecMock;
+  (window as any).kubernetesExecResize = kubernetesExecResizeMock;
+
+  (window as any).matchMedia = vi.fn().mockReturnValue({
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+  });
+});
+
+test('Test should render the terminal and being able to reconnect', async () => {
+  let onStdOutCallback: (data: Buffer) => void = () => {};
+  const sendCallbackId = 1;
+  kubernetesExecMock.mockImplementation(
+    (
+      _podName: string,
+      _containerName: string,
+      onStdOut: (data: Buffer) => void,
+      _onStdErr: (data: Buffer) => void,
+      _onClose: () => void,
+    ) => {
+      onStdOutCallback = onStdOut;
+      return sendCallbackId;
+    },
+  );
+
+  const renderObject = render(KubernetesTerminal, { podName: 'podName', containerName: 'containerName' });
+  await waitFor(() => expect(kubernetesExecMock).toHaveBeenCalled());
+
+  onStdOutCallback(Buffer.from('hello\nworld'));
+
+  await new Promise(resolve => setTimeout(resolve, 1000));
+  const terminalLinesLiveRegion = renderObject.container.querySelector('div[aria-live="assertive"]');
+  expect(terminalLinesLiveRegion).toHaveTextContent('hello world');
+
+  const terminals = get(terminalStates);
+  expect(terminals.size).toBe(0);
+
+  renderObject.component.$destroy();
+  const terminalsAfterDestroy = get(terminalStates);
+  expect(terminalsAfterDestroy.size).toBe(1);
+
+  render(KubernetesTerminal, { podName: 'podName', containerName: 'containerName' });
+
+  await new Promise(resolve => setTimeout(resolve, 1000));
+  expect(kubernetesExecMock).toHaveBeenCalledTimes(1);
+});

--- a/packages/renderer/src/lib/pod/KubernetesTerminal.svelte
+++ b/packages/renderer/src/lib/pod/KubernetesTerminal.svelte
@@ -1,0 +1,156 @@
+<script lang="ts">
+import { onDestroy, onMount } from 'svelte';
+import { router } from 'tinro';
+import { type IDisposable, Terminal } from 'xterm';
+import { FitAddon } from 'xterm-addon-fit';
+
+import { getPanelDetailColor } from '/@/lib/color/color';
+import { terminalStates } from '/@/stores/kubernetes-terminal-state-store';
+
+import { TerminalSettings } from '../../../../main/src/plugin/terminal-settings';
+
+export let podName: string;
+export let containerName: string;
+
+export let terminalXtermDiv: HTMLElement = document.createElement('div');
+let curRouterPath: string;
+
+interface State {
+  terminal: Terminal;
+  id: number;
+}
+
+let shellTerminal: Terminal;
+let screenReaderMode = true;
+
+let id: number | undefined;
+let onDataDisposable: IDisposable | undefined;
+
+router.subscribe(route => {
+  curRouterPath = route.path;
+});
+
+onMount(async () => {
+  const savedState = getSavedTerminalState(podName, containerName);
+
+  if (savedState) {
+    shellTerminal = savedState.terminal;
+    id = savedState.id;
+    removeAllChildren(terminalXtermDiv);
+    shellTerminal.open(terminalXtermDiv);
+  } else {
+    await initializeNewTerminal(terminalXtermDiv);
+  }
+});
+
+onDestroy(() => {
+  saveTerminalState(podName, containerName, { terminal: shellTerminal, id: id } as State);
+});
+
+function removeAllChildren(element: HTMLElement): void {
+  while (element.firstChild) {
+    element.removeChild(element.firstChild);
+  }
+}
+
+function reconnect() {
+  window
+    .kubernetesExec(
+      podName,
+      containerName,
+      (data: Buffer) => {
+        shellTerminal.write(data);
+      },
+      (data: Buffer) => {
+        shellTerminal.write(data);
+      },
+      reconnect,
+    )
+    .then(execId => {
+      id = execId;
+
+      shellTerminal.clear();
+      onDataDisposable?.dispose();
+      onDataDisposable = shellTerminal.onData(data => {
+        window.kubernetesExecSend(id!, data);
+      });
+    });
+}
+
+async function initializeNewTerminal(container: HTMLElement) {
+  if (!terminalXtermDiv) {
+    return;
+  }
+
+  const fontSize = await window.getConfigurationValue<number>(
+    TerminalSettings.SectionName + '.' + TerminalSettings.FontSize,
+  );
+  const lineHeight = await window.getConfigurationValue<number>(
+    TerminalSettings.SectionName + '.' + TerminalSettings.LineHeight,
+  );
+
+  shellTerminal = new Terminal({
+    fontSize,
+    lineHeight,
+    screenReaderMode,
+    theme: {
+      background: getPanelDetailColor(),
+    },
+  });
+
+  id = await window.kubernetesExec(
+    podName,
+    containerName,
+    (data: Buffer) => {
+      shellTerminal.write(data);
+    },
+    (data: Buffer) => {
+      shellTerminal.write(data);
+    },
+    reconnect,
+  );
+
+  onDataDisposable?.dispose();
+  onDataDisposable = shellTerminal.onData(data => {
+    window.kubernetesExecSend(id!, data);
+  });
+
+  const fitAddon = new FitAddon();
+  shellTerminal.loadAddon(fitAddon);
+  removeAllChildren(container);
+  shellTerminal.open(container);
+  fitAddon.fit();
+
+  window.addEventListener('resize', () => {
+    const resizeAsync = async () => {
+      //resize all opened terminals
+      if (curRouterPath.endsWith('/k8s-terminal')) {
+        fitAddon.fit();
+        if (id) {
+          await window.kubernetesExecResize(id, shellTerminal.cols, shellTerminal.rows);
+        }
+      }
+    };
+    resizeAsync().catch(console.error);
+  });
+
+  await window.kubernetesExecResize(id, shellTerminal.cols, shellTerminal.rows);
+}
+
+function getSavedTerminalState(podName: string, containerName: string): State | undefined {
+  let state;
+  terminalStates.subscribe(states => {
+    state = states.get(`${podName}-${containerName}`);
+  })();
+  return state ? (state as unknown as State) : undefined;
+}
+
+function saveTerminalState(podName: string, containerName: string, state: State) {
+  terminalStates.update(states => {
+    states.set(`${podName}-${containerName}`, state);
+    return states;
+  });
+}
+</script>
+
+<div class="h-full" bind:this="{terminalXtermDiv}"></div>

--- a/packages/renderer/src/lib/pod/KubernetesTerminalBrowser.svelte
+++ b/packages/renderer/src/lib/pod/KubernetesTerminalBrowser.svelte
@@ -1,0 +1,86 @@
+<script lang="ts">
+import { onMount } from 'svelte';
+
+import EmptyScreen from '/@/lib/ui/EmptyScreen.svelte';
+import NoLogIcon from '/@/lib/ui/NoLogIcon.svelte';
+import { podsInfos } from '/@/stores/pods';
+
+import { terminalService } from './KubernetesTerminalService';
+import type { PodInfoUI } from './PodInfoUI';
+
+let key = 0;
+
+export let pod: PodInfoUI;
+
+$: currentContainerStatus =
+  $podsInfos
+    .find(p => p.Name === pod.name)
+    ?.Containers.reduce((acc, c) => {
+      acc.set(c.Names, c.Status);
+      return acc;
+    }, new Map<string, string>()) || new Map<string, string>();
+
+let currentContainerName = '';
+
+onMount(() => {
+  if (pod.containers.length > 0) {
+    currentContainerName = pod.containers[0].Names;
+    terminalService.ensureTerminalExists(pod.name, currentContainerName);
+  }
+  key++;
+});
+
+function handleSelectionChange(event: Event) {
+  const target = event.target as HTMLSelectElement;
+  currentContainerName = target.value;
+  terminalService.ensureTerminalExists(pod.name, currentContainerName);
+  key++;
+}
+</script>
+
+<div class="flex py-2">
+  <label
+    for="input-standard-{pod.name}"
+    class="block w-auto text-sm font-medium whitespace-nowrap leading-6 text-gray-900 pl-2 pr-2">
+    {#key key}
+      {#if terminalService.hasTerminal(pod.name, currentContainerName) && currentContainerStatus.get(currentContainerName) === 'running'}
+        Connected to:
+      {:else}
+        Connecting to:
+      {/if}
+    {/key}
+  </label>
+  <div class="w-full">
+    {#if pod.containers.length > 1}
+      <select
+        on:change="{handleSelectionChange}"
+        aria-labelledby="listbox-label"
+        class="block w-48 p-1 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700"
+        name="{pod.name}"
+        id="input-standard-{pod.name}">
+        {#each pod.containers as container}
+          <option value="{container.Names}">{container.Names}</option>
+        {/each}
+      </select>
+    {:else}
+      <span
+        id="input-standard-{pod.name}"
+        class="block text-sm font-bold leading-6 text-gray-900"
+        aria-labelledby="listbox-label">{currentContainerName}</span>
+    {/if}
+  </div>
+</div>
+
+{#key key}
+  {#if terminalService.hasTerminal(pod.name, currentContainerName) && currentContainerStatus.get(currentContainerName) === 'running'}
+    <svelte:component
+      this="{terminalService.getTerminal(pod.name, currentContainerName).component}"
+      {...terminalService.getTerminal(pod.name, currentContainerName).props} />
+  {/if}
+{/key}
+
+<EmptyScreen
+  hidden="{!currentContainerStatus.get(currentContainerName)}"
+  icon="{NoLogIcon}"
+  title="No Terminal"
+  message="Container is not running" />

--- a/packages/renderer/src/lib/pod/KubernetesTerminalService.spec.ts
+++ b/packages/renderer/src/lib/pod/KubernetesTerminalService.spec.ts
@@ -1,0 +1,92 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import type { PodContainerInfo, PodInfo } from '@podman-desktop/api';
+import { beforeEach, expect, test } from 'vitest';
+
+import { TerminalService } from '/@/lib/pod/KubernetesTerminalService';
+
+let terminalService: TestableKubernetesTerminalService;
+
+class TestableKubernetesTerminalService extends TerminalService {
+  public testInvalidateCacheRecordOnStatusUpdate(podsInfos: PodInfo[]) {
+    return this.invalidateCacheRecordOnStatusUpdate(podsInfos);
+  }
+
+  public testToKey(podName: string, containerName: string): string {
+    return super.toKey(podName, containerName);
+  }
+
+  public testInvalidateCacheRecordOnPodRemove(podsInfos: PodInfo[]) {
+    return this.invalidateCacheRecordOnPodRemove(podsInfos);
+  }
+
+  public testTerminalCache() {
+    return this.terminalCache;
+  }
+}
+
+beforeEach(() => {
+  terminalService = new TestableKubernetesTerminalService();
+});
+
+test('should create and cache a terminal if it does not exist', () => {
+  const podName = 'pod1';
+  const containerName = 'container1';
+
+  terminalService.ensureTerminalExists(podName, containerName);
+  const terminal = terminalService.getTerminal(podName, containerName);
+
+  expect(terminal).toBeDefined();
+  expect(terminal.props.podName).toBe(podName);
+  expect(terminal.props.containerName).toBe(containerName);
+});
+
+test('should check if the terminal exists in the cache', () => {
+  const podName = 'pod1';
+  const containerName = 'container1';
+
+  terminalService.ensureTerminalExists(podName, containerName);
+  expect(terminalService.hasTerminal(podName, containerName)).toBeTruthy();
+});
+
+test('should invalidate cache for non-running containers', () => {
+  terminalService.testTerminalCache().set('pod1-container1', {});
+  const podsInfosMock: PodInfo[] = [
+    {
+      Name: 'pod1',
+      Containers: [{ Names: 'container1', Status: 'exited' } as PodContainerInfo],
+    } as PodInfo,
+  ];
+
+  terminalService.testInvalidateCacheRecordOnStatusUpdate(podsInfosMock);
+  expect(terminalService.hasTerminal('pod1', 'container1')).toBe(false);
+});
+
+test('should invalidate cache when pod is removed', () => {
+  terminalService.testTerminalCache().set('pod1-container1', {});
+  terminalService.testInvalidateCacheRecordOnPodRemove([]);
+  expect(terminalService.hasTerminal('pod1', 'container1')).toBe(false);
+});
+
+test('should return correct key identifier', () => {
+  const key = terminalService.testToKey('pod1', 'container1');
+  expect(key).toBe('pod1-container1');
+});

--- a/packages/renderer/src/lib/pod/KubernetesTerminalService.ts
+++ b/packages/renderer/src/lib/pod/KubernetesTerminalService.ts
@@ -1,0 +1,88 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { PodContainerInfo, PodInfo } from '@podman-desktop/api';
+
+import KubernetesTerminal from '/@/lib/pod/KubernetesTerminal.svelte';
+import { terminalStates } from '/@/stores/kubernetes-terminal-state-store';
+import { podsInfos } from '/@/stores/pods';
+
+export class TerminalService {
+  protected terminalCache = new Map();
+
+  constructor() {
+    podsInfos.subscribe($podsInfos => {
+      this.invalidateCacheRecordOnStatusUpdate($podsInfos);
+      this.invalidateCacheRecordOnPodRemove($podsInfos);
+    });
+  }
+
+  protected invalidateCacheRecordOnStatusUpdate(podsInfos: PodInfo[]) {
+    podsInfos.forEach((pod: PodInfo) => {
+      pod.Containers.forEach((container: PodContainerInfo) => {
+        if (container.Status !== 'running') {
+          this.terminalCache.delete(this.toKey(pod.Name, container.Names));
+        }
+      });
+    });
+  }
+
+  protected invalidateCacheRecordOnPodRemove(podsInfos: PodInfo[]) {
+    const activePods = new Set(
+      podsInfos.flatMap((pod: PodInfo) =>
+        pod.Containers.map((container: PodContainerInfo) => this.toKey(pod.Name, container.Names)),
+      ),
+    );
+    for (const [key] of this.terminalCache) {
+      if (!activePods.has(key)) {
+        this.invalidateTerminalComponentState(key);
+        this.terminalCache.delete(key);
+      }
+    }
+  }
+
+  ensureTerminalExists(podName: string, containerName: string) {
+    if (!this.terminalCache.has(this.toKey(podName, containerName))) {
+      this.terminalCache.set(this.toKey(podName, containerName), {
+        component: KubernetesTerminal,
+        props: { podName: podName, containerName },
+      });
+    }
+  }
+
+  getTerminal(podName: string, containerName: string) {
+    return this.terminalCache.get(this.toKey(podName, containerName));
+  }
+
+  hasTerminal(podName: string, containerName: string) {
+    return this.terminalCache.has(this.toKey(podName, containerName));
+  }
+
+  protected invalidateTerminalComponentState(podAndContainerName: string) {
+    terminalStates.update(states => {
+      states.delete(podAndContainerName);
+      return states;
+    });
+  }
+
+  protected toKey(podName: string, containerName: string) {
+    return `${podName}-${containerName}`;
+  }
+}
+
+export const terminalService = new TerminalService();

--- a/packages/renderer/src/lib/pod/PodDetails.svelte
+++ b/packages/renderer/src/lib/pod/PodDetails.svelte
@@ -10,6 +10,7 @@ import DetailsPage from '../ui/DetailsPage.svelte';
 import ErrorMessage from '../ui/ErrorMessage.svelte';
 import StateChange from '../ui/StateChange.svelte';
 import Tab from '../ui/Tab.svelte';
+import KubernetesTerminalBrowser from './KubernetesTerminalBrowser.svelte';
 import { PodUtils } from './pod-utils';
 import PodActions from './PodActions.svelte';
 import PodDetailsInspect from './PodDetailsInspect.svelte';
@@ -79,6 +80,9 @@ onMount(() => {
       <Tab title="Logs" url="logs" />
       <Tab title="Inspect" url="inspect" />
       <Tab title="Kube" url="kube" />
+      {#if pod.kind === 'kubernetes'}
+        <Tab title="Terminal" url="k8s-terminal" />
+      {/if}
     </svelte:fragment>
     <svelte:fragment slot="content">
       <Route path="/summary" breadcrumb="Summary" navigationHint="tab">
@@ -92,6 +96,9 @@ onMount(() => {
       </Route>
       <Route path="/kube" breadcrumb="Kube" navigationHint="tab">
         <PodDetailsKube pod="{pod}" />
+      </Route>
+      <Route path="/k8s-terminal" breadcrumb="Terminal" navigationHint="tab">
+        <KubernetesTerminalBrowser pod="{pod}" />
       </Route>
     </svelte:fragment>
   </DetailsPage>

--- a/packages/renderer/src/stores/kubernetes-terminal-state-store.spec.ts
+++ b/packages/renderer/src/stores/kubernetes-terminal-state-store.spec.ts
@@ -1,0 +1,67 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { render, waitFor } from '@testing-library/svelte';
+import { get } from 'svelte/store';
+import { beforeAll, expect, test, vi } from 'vitest';
+
+import KubernetesTerminal from '/@/lib/pod/KubernetesTerminal.svelte';
+import { terminalStates } from '/@/stores/kubernetes-terminal-state-store';
+
+const kubernetesExecMock = vi.fn();
+
+beforeAll(() => {
+  (window as any).getConfigurationValue = vi.fn();
+  (window as any).kubernetesExec = kubernetesExecMock;
+  (window as any).kubernetesExecResize = vi.fn();
+
+  (window as any).matchMedia = vi.fn().mockReturnValue({
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+  });
+});
+
+test('Test should check saved terminal state after destroying terminal window', async () => {
+  const sendCallbackId = 1;
+  kubernetesExecMock.mockImplementation(
+    (
+      _podName: string,
+      _containerName: string,
+      _: (data: Buffer) => void,
+      _onStdErr: (data: Buffer) => void,
+      _onClose: () => void,
+    ) => {
+      return sendCallbackId;
+    },
+  );
+
+  const renderObject = render(KubernetesTerminal, { podName: 'podName', containerName: 'containerName' });
+  await waitFor(() => expect(kubernetesExecMock).toHaveBeenCalled());
+
+  const terminals = get(terminalStates);
+  expect(terminals.size).toBe(0);
+
+  renderObject.component.$destroy();
+  const terminalsAfterDestroy = get(terminalStates);
+  expect(terminalsAfterDestroy.size).toBe(1);
+
+  const state = terminalsAfterDestroy.get('podName-containerName');
+
+  expect(state.id).toBe(sendCallbackId);
+  expect(state.terminal).toBeDefined();
+});

--- a/packages/renderer/src/stores/kubernetes-terminal-state-store.ts
+++ b/packages/renderer/src/stores/kubernetes-terminal-state-store.ts
@@ -1,0 +1,21 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { writable } from 'svelte/store';
+
+export const terminalStates = writable(new Map());


### PR DESCRIPTION
### What does this PR do?

The following changes request adds the ability to open a terminal in a container located in a Kubernetes pod.

### Screenshot / video of UI

https://github.com/containers/podman-desktop/assets/1968177/eb5b498e-3e7b-4e85-bb38-e54b516849bf

### What issues does this PR fix or reference?

partially: #4402 

### How to test this PR?

Create the pod in kubernetes(in our case sample app was deployed in OpenShift Local cluster), navigate to the deployed pod and open Terminal tab.
