### PR TITLE
nit: make guide buttons smaller

### DIFF
--- a/packages/renderer/src/lib/learning-center/GuideCard.svelte
+++ b/packages/renderer/src/lib/learning-center/GuideCard.svelte
@@ -19,7 +19,7 @@ export let height = 300;
   </dif>
   <div class="flex justify-center items-end flex-1 pt-4">
     <Button
-      class="justify-self-center self-end text-lg"
+      class="justify-self-center self-end text-md"
       on:click="{() => window.openExternal(guide.url)}"
       title="Get started">Get started</Button>
   </div>


### PR DESCRIPTION
nit: make guide buttons smaller

### What does this PR do?

I find that the buttons are massive compared to the other parts of the
dashboard.

PR to make the buttons a tad smaller (medium) which matches the rest of
the dashboard.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

Before:
![Screenshot 2024-02-13 at 1 54 31 PM](https://github.com/containers/podman-desktop/assets/6422176/63a39d4e-fca3-4df2-b3f8-006ea7b99b39)

After:
![Screenshot 2024-02-13 at 1 54 58 PM](https://github.com/containers/podman-desktop/assets/6422176/06ea40f4-3cdc-40e1-a32f-5f81379df604)


### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

N/A

### How to test this PR?

`yarn watch` and look at the dashboard.

<!-- Please explain steps to reproduce -->

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
