### PR TITLE
docs: drop the word virtual from lima

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Check the downloads page on [podman-desktop.io/downloads](https://podman-desktop
 
 - [Podman container engine](https://github.com/containers/podman)
 - [crc](https://github.com/code-ready/crc)
-- [Lima virtual machines](https://github.com/lima-vm/lima)
+- [Lima: Linux Machines](https://github.com/lima-vm/lima)
 - [Docker container engine](https://github.com/docker/docker)
 
 #### Podman engine update support

--- a/extensions/lima/package.json
+++ b/extensions/lima/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lima",
   "displayName": "Lima",
-  "description": "Integration for Lima: Linux virtual machines (typically macOS)",
+  "description": "Integration for Lima: Linux Machines (typically macOS)",
   "version": "0.0.1",
   "icon": "icon.png",
   "publisher": "podman-desktop",

--- a/website/docs/lima/creating-a-kubernetes-instance.md
+++ b/website/docs/lima/creating-a-kubernetes-instance.md
@@ -8,7 +8,7 @@ keywords: [podman desktop, kubernetes, lima, onboarding, linux, macos]
 
 # Creating a Lima instance for Kubernetes workloads with Podman Desktop
 
-To use the Lima provider you need a Lima instance running a Linux virtual machine.
+To use the Lima provider you need a Lima instance running a Linux machine.
 
 In the future, Podman Desktop might be able to create Lima instances.
 

--- a/website/docs/lima/creating-a-lima-instance.md
+++ b/website/docs/lima/creating-a-lima-instance.md
@@ -8,7 +8,7 @@ keywords: [podman desktop, containers, lima, onboarding, linux, macos]
 
 # Creating a Lima instance for container workloads with Podman Desktop
 
-To use the Lima provider you need a Lima instance running a Linux virtual machine.
+To use the Lima provider you need a Lima instance running a Linux machine.
 
 In the future, Podman Desktop might be able to create Lima instances.
 


### PR DESCRIPTION
The linux machine can be both physical and virtual.

Each is referred to as a "Lima instance" (not VM).

### What does this PR do?

### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop 
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to reproduce -->
