### PR TITLE
chore: some styling cleanup on carousel

### DIFF
--- a/packages/renderer/src/lib/carousel/Carousel.svelte
+++ b/packages/renderer/src/lib/carousel/Carousel.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { faGreaterThan, faLessThan } from '@fortawesome/free-solid-svg-icons';
+import { faChevronRight, faChevronLeft } from '@fortawesome/free-solid-svg-icons';
 import Fa from 'svelte-fa';
 import { onDestroy, onMount } from 'svelte';
 
@@ -49,9 +49,9 @@ function rotateRight() {
     id="left"
     on:click="{rotateLeft}"
     aria-label="Rotate left"
-    class="h-8 w-8 mr-3 bg-gray-800 rounded-full disabled:bg-zinc-700"
+    class="h-8 w-8 mr-3 bg-gray-800 rounded-full disabled:bg-charcoal-700"
     disabled="{visibleCards.length === cards.length}">
-    <Fa class="w-8 h-8" icon="{faLessThan}" color="black" />
+    <Fa class="w-8 h-8" icon="{faChevronLeft}" color="black" />
   </button>
 
   <div id="carousel-cards-{containerId}" class="flex flex-grow gap-3 overflow-hidden">
@@ -64,8 +64,8 @@ function rotateRight() {
     id="right"
     on:click="{rotateRight}"
     aria-label="Rotate right"
-    class="h-8 w-8 ml-3 bg-gray-800 rounded-full disabled:bg-zinc-700"
+    class="h-8 w-8 ml-3 bg-gray-800 rounded-full disabled:bg-charcoal-700"
     disabled="{visibleCards.length === cards.length}">
-    <Fa class="h-8 w-8" icon="{faGreaterThan}" color="black" />
+    <Fa class="h-8 w-8" icon="{faChevronRight}" color="black" />
   </button>
 </div>


### PR DESCRIPTION
### What does this PR do?

super-minor tweaks on carousel... changing to the chevron left / right icons instead of the lessthan / greaterthan, and tweaking color values from zinc (which we don't use anymore) to charcoal values.

### Screenshot / video of UI

Yeh yeh, hard to tell the difference, but check out the arrows, see?

#### BEFORE
![image](https://github.com/containers/podman-desktop/assets/799683/61b1bcc8-cbbf-42ca-b145-50c1d512c47b)


#### AFTER
![image](https://github.com/containers/podman-desktop/assets/799683/d60dc6a7-82e8-4f5d-a7be-797f3d8140c1)


### What issues does this PR fix or reference?

none, i just like to tweak, sorry

### How to test this PR?

Screen should look like the after and not the before above :)