### PR TITLE
chore(deps-dev): bump @commitlint/config-conventional to 18.6.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
   },
   "devDependencies": {
     "@commitlint/cli": "^18.6.1",
-    "@commitlint/config-conventional": "^18.6.1",
+    "@commitlint/config-conventional": "^18.6.2",
     "@electron/fuses": "^1.7.0",
     "@playwright/test": "1.41.2",
     "@rollup/plugin-commonjs": "^25.0.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1561,10 +1561,10 @@
     resolve-global "1.0.0"
     yargs "^17.0.0"
 
-"@commitlint/config-conventional@^18.6.1":
-  version "18.6.1"
-  resolved "https://registry.yarnpkg.com/@commitlint/config-conventional/-/config-conventional-18.6.1.tgz#febb4bed074413162da989640a42d4d72383a618"
-  integrity sha512-ftpfAOQyI+IHvut0cRF4EFM39PWCqde+uOXCjH9NpK6FpqfhncAbEvP0E7OIpFsrDX0aS7k81tzH5Yz7prcNxA==
+"@commitlint/config-conventional@^18.6.2":
+  version "18.6.2"
+  resolved "https://registry.yarnpkg.com/@commitlint/config-conventional/-/config-conventional-18.6.2.tgz#617f3ee761578040cade530631058699642cbd78"
+  integrity sha512-PcgSYg1AKGQIwDQKbaHtJsfqYy4uJTC7crLVZ83lfjcPaec4Pry2vLeaWej7ao2KsT20l9dWoMPpEGg8LWdUuA==
   dependencies:
     "@commitlint/types" "^18.6.1"
     conventional-changelog-conventionalcommits "^7.0.2"


### PR DESCRIPTION
### What does this PR do?
fix bug in 18.6.1 where it was throwing an error on commit

Bug Fixes
fix(config-conventional): use default export by @dargmuesli https://github.com/conventional-changelog/commitlint/pull/3911


### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

unable to commit

### How to test this PR?

should be able to commit with checks
