### PR TITLE
feat: send telemetry for guide opened form learning center

### DIFF
--- a/packages/renderer/src/lib/learning-center/GuideCard.spec.ts
+++ b/packages/renderer/src/lib/learning-center/GuideCard.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/renderer/src/lib/learning-center/GuideCard.spec.ts
+++ b/packages/renderer/src/lib/learning-center/GuideCard.spec.ts
@@ -1,0 +1,66 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import '@testing-library/jest-dom/vitest';
+import { suite, test, expect, vi, beforeEach, afterEach } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import GuideCard from './GuideCard.svelte';
+
+suite('Guide card', () => {
+  beforeEach(() => {
+    render(GuideCard, {
+      guide: { id: 'id', url: 'url', title: 'title', description: 'description', categories: [], icon: 'icon' },
+      width: 300,
+      height: 300,
+    });
+    beforeEach(() => {
+      (window as any).openExternal = vi.fn();
+      (window as any).telemetryTrack = vi.fn();
+    });
+    afterEach(() => {
+      vi.resetAllMocks();
+    });
+  });
+
+  test('shows title', async () => {
+    const cardTitle = screen.getByText('title');
+    expect(cardTitle).toBeVisible();
+  });
+
+  test('shows description', async () => {
+    const cardDescription = screen.getByText('description');
+    screen.debug(cardDescription);
+    expect(cardDescription).toBeVisible();
+  });
+
+  test('shows button', async () => {
+    const cardButton = screen.getByRole('button', { name: 'Get started' });
+    expect(cardButton).toBeVisible();
+  });
+
+  test('opens guide and sends telemetry', async () => {
+    const cardButton = screen.getByRole('button', { name: 'Get started' });
+    await fireEvent.click(cardButton);
+    expect(vi.mocked(window.openExternal)).toHaveBeenCalledWith('url');
+    expect(vi.mocked(window.telemetryTrack)).toHaveBeenCalledWith('openLearningCenterGuide', {
+      guideId: 'id',
+    });
+  });
+});

--- a/packages/renderer/src/lib/learning-center/GuideCard.svelte
+++ b/packages/renderer/src/lib/learning-center/GuideCard.svelte
@@ -6,10 +6,10 @@ export let width = 300;
 export let height = 300;
 
 async function openGuide(guide: Guide): Promise<void> {
-  await window.openExternal(guide.url);
   window.telemetryTrack('openLearningCenterGuide', {
     guideId: guide.id,
   });
+  await window.openExternal(guide.url);
 }
 </script>
 

--- a/packages/renderer/src/lib/learning-center/GuideCard.svelte
+++ b/packages/renderer/src/lib/learning-center/GuideCard.svelte
@@ -15,15 +15,15 @@ async function openGuide(guide: Guide): Promise<void> {
 
 <div
   class="flex flex-col flex-1 bg-charcoal-600 pb-4 rounded-lg hover:bg-zinc-700 min-w-[{width}px] min-h-[{height}px]">
-  <dif class="pt-4 flex flex-col">
+  <div class="pt-4 flex flex-col">
     <div class="px-4">
       <img src="{`data:image/png;base64,${guide.icon}`}" class="h-[48px]" alt="{guide.id}" />
     </div>
     <div class="px-4 pt-4 text-nowrap text-gray-400">
       {guide.title}
     </div>
-    <p class="line-clamp-4 px-4 pt-4 text-base text-gray-700">{guide.description}</p>
-  </dif>
+    <div class="line-clamp-4 px-4 pt-4 text-base text-gray-700">{guide.description}</div>
+  </div>
   <div class="flex justify-center items-end flex-1 pt-4">
     <Button class="justify-self-center self-end text-md" on:click="{() => openGuide(guide)}" title="Get started"
       >Get started</Button>

--- a/packages/renderer/src/lib/learning-center/GuideCard.svelte
+++ b/packages/renderer/src/lib/learning-center/GuideCard.svelte
@@ -22,7 +22,7 @@ async function openGuide(guide: Guide): Promise<void> {
     <div class="px-4 pt-4 text-nowrap text-gray-400">
       {guide.title}
     </div>
-    <div class="line-clamp-4 px-4 pt-4 text-base text-gray-700">{guide.description}</div>
+    <p class="line-clamp-4 px-4 pt-4 text-base text-gray-700">{guide.description}</p>
   </div>
   <div class="flex justify-center items-end flex-1 pt-4">
     <Button class="justify-self-center self-end text-md" on:click="{() => openGuide(guide)}" title="Get started"

--- a/packages/renderer/src/lib/learning-center/GuideCard.svelte
+++ b/packages/renderer/src/lib/learning-center/GuideCard.svelte
@@ -4,6 +4,13 @@ import Button from '../ui/Button.svelte';
 export let guide: Guide;
 export let width = 300;
 export let height = 300;
+
+async function openGuide(guide: Guide): Promise<void> {
+  await window.openExternal(guide.url);
+  window.telemetryTrack('openLearningCenterGuide', {
+    guideId: guide.id,
+  });
+}
 </script>
 
 <div
@@ -18,9 +25,7 @@ export let height = 300;
     <p class="line-clamp-4 px-4 pt-4 text-base text-gray-700">{guide.description}</p>
   </dif>
   <div class="flex justify-center items-end flex-1 pt-4">
-    <Button
-      class="justify-self-center self-end text-md"
-      on:click="{() => window.openExternal(guide.url)}"
-      title="Get started">Get started</Button>
+    <Button class="justify-self-center self-end text-md" on:click="{() => openGuide(guide)}" title="Get started"
+      >Get started</Button>
   </div>
 </div>


### PR DESCRIPTION
### What does this PR do?

add window.telemetryTrack call for opened guide with `guideId`

### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop 
repository (or from another issue tracker). -->

Fix #5991

### How to test this PR?

<!-- Please explain steps to reproduce -->
