### PR TITLE
feat: allow to use openDialog/saveDialog by extensions

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -1473,6 +1473,68 @@ declare module '@podman-desktop/api' {
   }
 
   /**
+   * Options to configure the behaviour of a file open dialog.
+   */
+  export interface OpenDialogOptions {
+    /**
+     * The resource the dialog shows when opened.
+     */
+    defaultUri?: Uri;
+
+    /**
+     * A human-readable string for the open button.
+     */
+    openLabel?: string;
+
+    /**
+     * Contains which features the dialog should use. The following values are
+     * supported:
+     */
+    selectors?: Array<'openFile' | 'openDirectory' | 'multiSelections' | 'showHiddenFiles'>;
+
+    /**
+     * A set of file filters that are used by the dialog.
+     */
+    filters?: {
+      extensions: string[];
+      name: string;
+    }[];
+
+    /**
+     * Dialog title.
+     */
+    title?: string;
+  }
+
+  /**
+   * Options to configure the behaviour of a file save dialog.
+   */
+  export interface SaveDialogOptions {
+    /**
+     * The resource the dialog shows when opened.
+     */
+    defaultUri?: Uri;
+
+    /**
+     * A human-readable string for the save button.
+     */
+    saveLabel?: string;
+
+    /**
+     * A set of file filters that are used by the dialog.
+     */
+    filters?: {
+      extensions: string[];
+      name: string;
+    }[];
+
+    /**
+     * Dialog title.
+     */
+    title?: string;
+  }
+
+  /**
    * Event fired when a webview panel's view state changes.
    */
   export interface WebviewPanelOnDidChangeViewStateEvent {
@@ -1604,6 +1666,24 @@ declare module '@podman-desktop/api' {
      * @return A promise that resolves to a string the user provided or to `undefined` in case of dismissal.
      */
     export function showInputBox(options?: InputBoxOptions, token?: CancellationToken): Promise<string | undefined>;
+
+    /**
+     * Shows a file open dialog to the user which allows to select a file
+     * for opening-purposes.
+     *
+     * @param options Options that control the dialog.
+     * @returns A promise that resolves to the selected resources or `undefined`.
+     */
+    export function showOpenDialog(options?: OpenDialogOptions): Promise<Uri[] | undefined>;
+
+    /**
+     * Shows a file save dialog to the user which allows to select a file
+     * for saving-purposes.
+     *
+     * @param options Options that control the dialog.
+     * @returns A promise that resolves to the selected resource or `undefined`.
+     */
+    export function showSaveDialog(options?: SaveDialogOptions): Promise<Uri | undefined>;
 
     /**
      * Shows a selection list allowing multiple selections.

--- a/packages/main/src/index.ts
+++ b/packages/main/src/index.ts
@@ -209,7 +209,7 @@ app.whenReady().then(
     const trayMenu = new TrayMenu(tray, animatedTray);
 
     // Start extensions
-    const pluginSystem = new PluginSystem(trayMenu);
+    const pluginSystem = new PluginSystem(trayMenu, mainWindowDeferred);
     extensionLoader = await pluginSystem.initExtensions();
 
     // Get the configuration registry (saves all our settings)

--- a/packages/main/src/plugin/dialog-registry.spec.ts
+++ b/packages/main/src/plugin/dialog-registry.spec.ts
@@ -1,0 +1,217 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { DialogRegistry } from './dialog-registry.js';
+import { dialog, type BrowserWindow } from 'electron';
+import { Deferred } from '/@/plugin/util/deferred.js';
+import type { Uri } from '@podman-desktop/api';
+
+let mainWindowDeferred: Deferred<BrowserWindow>;
+
+const fakeBrowserWindow: BrowserWindow = {
+  webContents: {
+    send: vi.fn(),
+  },
+} as unknown as BrowserWindow;
+
+vi.mock('electron', async () => {
+  return {
+    dialog: {
+      showOpenDialog: vi.fn(),
+      showSaveDialog: vi.fn(),
+    },
+  };
+});
+
+class TestDialogRegistry extends DialogRegistry {}
+
+let dialogRegistry: TestDialogRegistry;
+
+const originalConsoleError = console.error;
+
+const mockedConsoleError = vi.fn();
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  console.error = mockedConsoleError;
+  mainWindowDeferred = new Deferred<BrowserWindow>();
+  mainWindowDeferred.resolve(fakeBrowserWindow);
+  dialogRegistry = new TestDialogRegistry(mainWindowDeferred);
+  dialogRegistry.init();
+});
+
+afterEach(() => {
+  console.error = originalConsoleError;
+});
+
+// check a failure on init
+test('check failure on init method', async () => {
+  mainWindowDeferred = new Deferred<BrowserWindow>();
+  dialogRegistry = new TestDialogRegistry(mainWindowDeferred);
+  mainWindowDeferred.reject(new Error('test error'));
+
+  dialogRegistry.init();
+  await vi.waitFor(() => {
+    expect(mockedConsoleError).toHaveBeenCalledWith('Error getting main window', 'Error: test error');
+  });
+});
+
+describe('showOpenDialog', () => {
+  beforeEach(() => {
+    vi.mocked(dialog.showOpenDialog).mockResolvedValue({
+      filePaths: ['/tmp/my/path'],
+      canceled: false,
+    });
+  });
+
+  // check opendialog is failing without browserwindow
+  test('check failure on init method', async () => {
+    mainWindowDeferred = new Deferred<BrowserWindow>();
+    dialogRegistry = new TestDialogRegistry(mainWindowDeferred);
+    // we don't resolve the promise
+
+    await expect(dialogRegistry.openDialog()).rejects.toThrow('Browser window is not available');
+  });
+
+  test('check with no options should open a file', async () => {
+    const result = await dialogRegistry.openDialog();
+    expect(result).toStrictEqual(['/tmp/my/path']);
+
+    expect(dialog.showOpenDialog).toHaveBeenCalledWith(
+      fakeBrowserWindow,
+      expect.objectContaining({ properties: ['openFile'] }),
+    );
+
+    // no result sent to browserWindow
+    expect(fakeBrowserWindow.webContents.send).not.toHaveBeenCalled();
+  });
+
+  test('check with a dialog id should send value to browserWindow', async () => {
+    const result = await dialogRegistry.openDialog({}, 'my-dialog-id');
+    // no result as it should have been sent to the browserWindow
+    expect(result).toBeUndefined();
+
+    expect(fakeBrowserWindow.webContents.send).toHaveBeenCalledWith(
+      'dialog:open-save-dialog-response',
+      'my-dialog-id',
+      ['/tmp/my/path'],
+    );
+
+    expect(dialog.showOpenDialog).toHaveBeenCalledWith(
+      fakeBrowserWindow,
+      expect.objectContaining({ properties: ['openFile'] }),
+    );
+  });
+
+  test('check with all options with a folder', async () => {
+    const result = await dialogRegistry.openDialog({
+      selectors: ['openDirectory'],
+      filters: [{ name: 'All Files', extensions: ['*'] }],
+      defaultUri: { scheme: 'file', fsPath: '/tmp/my/path' } as Uri,
+      title: 'my title',
+      openLabel: 'my open label',
+    });
+
+    expect(result).toStrictEqual(['/tmp/my/path']);
+
+    expect(dialog.showOpenDialog).toHaveBeenCalledWith(
+      fakeBrowserWindow,
+      expect.objectContaining({
+        properties: ['openDirectory'],
+        filters: [{ name: 'All Files', extensions: ['*'] }],
+        defaultPath: '/tmp/my/path',
+        title: 'my title',
+        message: 'my title',
+        buttonLabel: 'my open label',
+      }),
+    );
+
+    // no result sent to browserWindow
+    expect(fakeBrowserWindow.webContents.send).not.toHaveBeenCalled();
+  });
+});
+
+describe('showSaveDialog', () => {
+  beforeEach(() => {
+    vi.mocked(dialog.showSaveDialog).mockResolvedValue({
+      filePath: '/tmp/my/path',
+      canceled: false,
+    });
+  });
+
+  // check showSaveDialog is failing without browserwindow
+  test('check failure on init method', async () => {
+    mainWindowDeferred = new Deferred<BrowserWindow>();
+    dialogRegistry = new TestDialogRegistry(mainWindowDeferred);
+    // we don't resolve the promise
+
+    await expect(dialogRegistry.saveDialog()).rejects.toThrow('Browser window is not available');
+  });
+
+  test('check with no options', async () => {
+    const result = await dialogRegistry.saveDialog();
+    expect(result).toStrictEqual('/tmp/my/path');
+
+    expect(dialog.showSaveDialog).toHaveBeenCalledWith(fakeBrowserWindow, expect.anything());
+
+    // no result sent to browserWindow
+    expect(fakeBrowserWindow.webContents.send).not.toHaveBeenCalled();
+  });
+
+  test('check with a dialog id should send value to browserWindow', async () => {
+    const result = await dialogRegistry.saveDialog({}, 'my-dialog-id');
+    // no result as it should have been sent to the browserWindow
+    expect(result).toBeUndefined();
+
+    expect(fakeBrowserWindow.webContents.send).toHaveBeenCalledWith(
+      'dialog:open-save-dialog-response',
+      'my-dialog-id',
+      '/tmp/my/path',
+    );
+
+    expect(dialog.showSaveDialog).toHaveBeenCalledWith(fakeBrowserWindow, expect.anything());
+  });
+
+  test('check with all options', async () => {
+    const result = await dialogRegistry.saveDialog({
+      filters: [{ name: 'All Files', extensions: ['*'] }],
+      defaultUri: { scheme: 'file', fsPath: '/tmp/my/path' } as Uri,
+      title: 'my title',
+      saveLabel: 'my save label',
+    });
+
+    expect(result).toStrictEqual('/tmp/my/path');
+
+    expect(dialog.showSaveDialog).toHaveBeenCalledWith(
+      fakeBrowserWindow,
+      expect.objectContaining({
+        filters: [{ name: 'All Files', extensions: ['*'] }],
+        defaultPath: '/tmp/my/path',
+        title: 'my title',
+        message: 'my title',
+        buttonLabel: 'my save label',
+      }),
+    );
+
+    // no result sent to browserWindow
+    expect(fakeBrowserWindow.webContents.send).not.toHaveBeenCalled();
+  });
+});

--- a/packages/main/src/plugin/dialog-registry.ts
+++ b/packages/main/src/plugin/dialog-registry.ts
@@ -57,7 +57,7 @@ export class DialogRegistry {
 
     const uri = options?.defaultUri;
     let defaultPath: string | undefined;
-    if (uri && uri.scheme === 'file') {
+    if (uri?.scheme === 'file') {
       // convert defaultUri into defaultPath if file
       defaultPath = uri.fsPath;
     }
@@ -95,7 +95,7 @@ export class DialogRegistry {
     // convert options into electron dialog options
     const uri = options?.defaultUri;
     let defaultPath: string | undefined;
-    if (uri && uri.scheme === 'file') {
+    if (uri?.scheme === 'file') {
       // convert defaultUri into defaultPath if file
       defaultPath = uri.fsPath;
     }

--- a/packages/main/src/plugin/dialog-registry.ts
+++ b/packages/main/src/plugin/dialog-registry.ts
@@ -1,0 +1,124 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { OpenDialogOptions, SaveDialogOptions } from '@podman-desktop/api';
+import type { BrowserWindow } from 'electron';
+import { dialog } from 'electron';
+import type { Deferred } from './util/deferred.js';
+
+/**
+ * Handle native open and save dialogs
+ */
+export class DialogRegistry {
+  #browserWindow: BrowserWindow | undefined;
+
+  #mainWindowDeferred: Deferred<BrowserWindow>;
+
+  constructor(readonly mainWindowDeferred: Deferred<BrowserWindow>) {
+    this.#mainWindowDeferred = mainWindowDeferred;
+  }
+
+  init(): void {
+    // browser window will be initialized when promise is resolved
+    this.#mainWindowDeferred.promise
+      .then(browserWindow => {
+        this.#browserWindow = browserWindow;
+      })
+      .catch((error: unknown) => {
+        console.error('Error getting main window', String(error));
+      });
+  }
+
+  async openDialog(options?: OpenDialogOptions, dialogId?: string): Promise<string[] | undefined> {
+    if (!this.#browserWindow) {
+      throw new Error('Browser window is not available');
+    }
+
+    // if no properties, use file
+    let selectors = options?.selectors;
+    if (!selectors || selectors.length === 0) {
+      selectors = ['openFile'];
+    }
+
+    const uri = options?.defaultUri;
+    let defaultPath: string | undefined;
+    if (uri && uri.scheme === 'file') {
+      // convert defaultUri into defaultPath if file
+      defaultPath = uri.fsPath;
+    }
+
+    // convert options into electron dialog options
+    const electronOpenDialogOptions: Electron.OpenDialogOptions = {
+      filters: options?.filters,
+      properties: selectors,
+      defaultPath,
+      title: options?.title,
+      message: options?.title,
+      buttonLabel: options?.openLabel,
+    };
+
+    let paths: string[] | undefined;
+
+    const response = await dialog.showOpenDialog(this.#browserWindow, electronOpenDialogOptions);
+    if (response.filePaths && !response.canceled) {
+      paths = response.filePaths;
+    }
+    // send the response to the renderer part if dialogId is provided
+    if (dialogId) {
+      this.#browserWindow.webContents.send('dialog:open-save-dialog-response', dialogId, paths);
+    } else {
+      // return the URIs if dialogId is not provided (call from main process)
+      return paths;
+    }
+  }
+
+  async saveDialog(options?: SaveDialogOptions, dialogId?: string): Promise<string | undefined> {
+    if (!this.#browserWindow) {
+      throw new Error('Browser window is not available');
+    }
+
+    // convert options into electron dialog options
+    const uri = options?.defaultUri;
+    let defaultPath: string | undefined;
+    if (uri && uri.scheme === 'file') {
+      // convert defaultUri into defaultPath if file
+      defaultPath = uri.fsPath;
+    }
+
+    // convert options into electron dialog options
+    const electronSaveDialogOptions: Electron.SaveDialogOptions = {
+      filters: options?.filters,
+      defaultPath,
+      title: options?.title,
+      message: options?.title,
+      buttonLabel: options?.saveLabel,
+    };
+
+    const response = await dialog.showSaveDialog(this.#browserWindow, electronSaveDialogOptions);
+    let filePath: string | undefined;
+    if (response.filePath && !response.canceled) {
+      filePath = response.filePath;
+    }
+    // send the response to the renderer part if dialogId is provided
+    if (dialogId) {
+      this.#browserWindow.webContents.send('dialog:open-save-dialog-response', dialogId, filePath);
+    } else {
+      return filePath;
+    }
+  }
+}

--- a/packages/main/src/plugin/extension-loader.spec.ts
+++ b/packages/main/src/plugin/extension-loader.spec.ts
@@ -62,6 +62,7 @@ import type { WebviewInfo } from './api/webview-info.js';
 import { getBase64Image } from '../util.js';
 import { Disposable } from './types/disposable.js';
 import type { ColorRegistry } from './color-registry.js';
+import type { DialogRegistry } from './dialog-registry.js';
 
 class TestExtensionLoader extends ExtensionLoader {
   public async setupScanningDirectory(): Promise<void> {
@@ -202,6 +203,13 @@ const navigationManager: NavigationManager = new NavigationManager(
 const colorRegistry = {
   registerExtensionThemes: vi.fn(),
 } as unknown as ColorRegistry;
+const openDialogMock = vi.fn();
+const saveDialogMock = vi.fn();
+
+const dialogRegistry: DialogRegistry = {
+  openDialog: openDialogMock,
+  saveDialog: saveDialogMock,
+} as unknown as DialogRegistry;
 
 vi.mock('electron', () => {
   return {
@@ -251,6 +259,7 @@ beforeAll(() => {
     navigationManager,
     webviewRegistry,
     colorRegistry,
+    dialogRegistry,
   );
 });
 
@@ -1603,4 +1612,35 @@ test('loadExtension with themes', async () => {
   await extensionLoader.loadExtension(fakeExtension);
 
   expect(colorRegistry.registerExtensionThemes).toBeCalledWith(fakeExtension, manifest.contributes.themes);
+});
+
+describe('window', async () => {
+  test('showOpenDialog ', async () => {
+    const api = extensionLoader.createApi('/path', {});
+    expect(api).toBeDefined();
+
+    const filePaths = ['/path-to-file1', '/path-to-file2'];
+    vi.mocked(dialogRegistry.openDialog).mockResolvedValue(filePaths);
+
+    const uris = await api.window.showOpenDialog();
+    expect(uris?.length).toBe(2);
+    const urisArray = uris as containerDesktopAPI.Uri[];
+
+    expect(dialogRegistry.openDialog).toBeCalled();
+    expect(urisArray[0].fsPath).toContain('path-to-file1');
+    expect(urisArray[1].fsPath).toContain('path-to-file2');
+  });
+
+  test('showSaveDialog ', async () => {
+    const api = extensionLoader.createApi('/path', {});
+    expect(api).toBeDefined();
+
+    const filePath = '/path-to-file1';
+    vi.mocked(dialogRegistry.saveDialog).mockResolvedValue(filePath);
+
+    const uri = await api.window.showSaveDialog();
+
+    expect(dialogRegistry.saveDialog).toBeCalled();
+    expect(uri?.fsPath).toContain('path-to-file1');
+  });
 });

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -75,6 +75,7 @@ import type { WebviewRegistry } from '/@/plugin/webview/webview-registry.js';
 import type { ImageInspectInfo } from '/@/plugin/api/image-inspect-info.js';
 import type { PodInfo } from './api/pod-info.js';
 import type { ColorRegistry } from '/@/plugin/color-registry.js';
+import type { DialogRegistry } from './dialog-registry.js';
 
 /**
  * Handle the loading of an extension
@@ -173,6 +174,7 @@ export class ExtensionLoader {
     private navigationManager: NavigationManager,
     private webviewRegistry: WebviewRegistry,
     private colorRegistry: ColorRegistry,
+    private dialogRegistry: DialogRegistry,
   ) {
     this.pluginsDirectory = directories.getPluginsDirectory();
     this.pluginsScanDirectory = directories.getPluginsScanDirectory();
@@ -805,6 +807,7 @@ export class ExtensionLoader {
     const inputQuickPickRegistry = this.inputQuickPickRegistry;
     const customPickRegistry = this.customPickRegistry;
     const webviewRegistry = this.webviewRegistry;
+    const dialogRegistry = this.dialogRegistry;
     const windowObj: typeof containerDesktopAPI.window = {
       showInformationMessage: (message: string, ...items: string[]) => {
         return messageBox.showDialog('info', extManifest.displayName, message, items);
@@ -881,6 +884,22 @@ export class ExtensionLoader {
       },
       listWebviews(): Promise<containerDesktopAPI.WebviewInfo[]> {
         return webviewRegistry.listSimpleWebviews();
+      },
+      showOpenDialog: async (
+        options?: containerDesktopAPI.OpenDialogOptions,
+      ): Promise<containerDesktopAPI.Uri[] | undefined> => {
+        const result = await dialogRegistry.openDialog(options);
+        if (result) {
+          return result.map(uri => Uri.file(uri));
+        }
+      },
+      showSaveDialog: async (
+        options?: containerDesktopAPI.SaveDialogOptions,
+      ): Promise<containerDesktopAPI.Uri | undefined> => {
+        const result = await dialogRegistry.saveDialog(options);
+        if (result) {
+          return Uri.file(result);
+        }
       },
     };
 

--- a/packages/main/src/plugin/index.spec.ts
+++ b/packages/main/src/plugin/index.spec.ts
@@ -21,11 +21,12 @@ import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
 import type { TrayMenu } from '../tray-menu.js';
 import { EventEmitter } from 'node:events';
 import { PluginSystem } from './index.js';
-import type { WebContents } from 'electron';
+import type { BrowserWindow, WebContents } from 'electron';
 import { shell, clipboard } from 'electron';
 import type { MessageBox } from './message-box.js';
 import { securityRestrictionCurrentHandler } from '../security-restrictions-handler.js';
 import { CancellationTokenRegistry } from './cancellation-token-registry.js';
+import { Deferred } from './util/deferred.js';
 
 let pluginSystem: PluginSystem;
 
@@ -34,6 +35,8 @@ const webContents = emitter as unknown as WebContents;
 
 // add send method
 webContents.send = vi.fn();
+
+const mainWindowDeferred = new Deferred<BrowserWindow>();
 
 beforeAll(() => {
   vi.mock('electron', () => {
@@ -50,7 +53,7 @@ beforeAll(() => {
     };
   });
   const trayMenuMock = {} as unknown as TrayMenu;
-  pluginSystem = new PluginSystem(trayMenuMock);
+  pluginSystem = new PluginSystem(trayMenuMock, mainWindowDeferred);
 });
 
 beforeEach(() => {

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -159,6 +159,8 @@ import { KubernetesUtils } from './kubernetes-util.js';
 import { downloadGuideList } from './learning-center/learning-center.js';
 import type { ColorInfo } from './api/color-info.js';
 import { ColorRegistry } from './color-registry.js';
+import { DialogRegistry } from './dialog-registry.js';
+import type { Deferred } from './util/deferred.js';
 
 type LogType = 'log' | 'warn' | 'trace' | 'debug' | 'error';
 
@@ -186,7 +188,10 @@ export class PluginSystem {
   private extensionLoader!: ExtensionLoader;
   private validExtList!: ExtensionInfo[];
 
-  constructor(private trayMenu: TrayMenu) {
+  constructor(
+    private trayMenu: TrayMenu,
+    private mainWindowDeferred: Deferred<BrowserWindow>,
+  ) {
     app.on('before-quit', () => {
       this.isQuitting = true;
     });
@@ -747,6 +752,9 @@ export class PluginSystem {
     const webviewRegistry = new WebviewRegistry(apiSender);
     await webviewRegistry.start();
 
+    const dialogRegistry = new DialogRegistry(this.mainWindowDeferred);
+    dialogRegistry.init();
+
     const navigationManager = new NavigationManager(
       apiSender,
       containerProviderRegistry,
@@ -790,6 +798,7 @@ export class PluginSystem {
       navigationManager,
       webviewRegistry,
       colorRegistry,
+      dialogRegistry,
     );
     await this.extensionLoader.init();
 
@@ -2231,6 +2240,23 @@ export class PluginSystem {
     this.ipcHandle('learning-center:listGuides', async () => {
       return downloadGuideList();
     });
+
+    this.ipcHandle(
+      'dialog:openDialog',
+      async (_listener, dialogId: string, options: containerDesktopAPI.OpenDialogOptions): Promise<void> => {
+        dialogRegistry.openDialog(options, dialogId).catch((error: unknown) => {
+          console.error('Error opening dialog', error);
+        });
+      },
+    );
+    this.ipcHandle(
+      'dialog:saveDialog',
+      async (_listener, dialogId: string, options: containerDesktopAPI.SaveDialogOptions): Promise<void> => {
+        dialogRegistry.saveDialog(options, dialogId).catch((error: unknown) => {
+          console.error('Error opening dialog', error);
+        });
+      },
+    );
 
     const dockerDesktopInstallation = new DockerDesktopInstallation(
       apiSender,

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -96,6 +96,7 @@ import type { ApiSenderType } from '../../main/src/plugin/api';
 import type { IDisposable } from '../../main/src/plugin/types/disposable';
 
 export type DialogResultCallback = (openDialogReturnValue: Electron.OpenDialogReturnValue) => void;
+export type OpenSaveDialogResultCallback = (result: string | string[] | undefined) => void;
 
 export type LogType = 'log' | 'warn' | 'trace' | 'debug' | 'error';
 const originalConsole = console;
@@ -135,7 +136,7 @@ export const buildApiSender = (): ApiSenderType => {
 };
 
 // initialize extension loader mechanism
-function initExposure(): void {
+export function initExposure(): void {
   const apiSender = buildApiSender();
 
   interface ErrorMessage {
@@ -1299,6 +1300,70 @@ function initExposure(): void {
       } else {
         console.error('Got response for an unknown dialog id', dialogId);
       }
+    },
+  );
+
+  // Handle callback on dialogs by calling the callback once we get the answer
+  ipcRenderer.on('dialog:open-save-dialog-response', (_, dialogId: string, result: string | string[] | undefined) => {
+    // grab from stored map
+    const callback = openSaveDialogResponses.get(dialogId);
+    if (callback) {
+      callback(result);
+
+      // remove callback
+      openSaveDialogResponses.delete(dialogId);
+    } else {
+      console.error('Got response for an unknown dialog id', dialogId);
+    }
+  });
+
+  let idOpenSaveDialog = 0;
+
+  const openSaveDialogResponses = new Map<string, OpenSaveDialogResultCallback>();
+
+  const deferedHandleDialog = (): { id: string; deferred: Deferred<string | string[] | undefined> } => {
+    // generate id
+    const dialogId = idOpenSaveDialog;
+    idOpenSaveDialog++;
+
+    // create defer object
+    const deferred = new Deferred<string | string[] | undefined>();
+
+    // store the dialogID
+    openSaveDialogResponses.set(`${dialogId}`, (result: string | string[] | undefined) => {
+      deferred.resolve(result);
+    });
+
+    return { deferred: deferred, id: `${dialogId}` };
+  };
+
+  contextBridge.exposeInMainWorld(
+    'openDialog',
+    async (options?: containerDesktopAPI.OpenDialogOptions): Promise<string[] | undefined> => {
+      const handle = deferedHandleDialog();
+
+      // ask to open file dialog
+      ipcInvoke('dialog:openDialog', handle.id, options).catch((error: unknown) => {
+        handle.deferred.reject(error);
+      });
+
+      // wait for response
+      return handle.deferred.promise as Promise<string[] | undefined>;
+    },
+  );
+
+  contextBridge.exposeInMainWorld(
+    'saveDialog',
+    async (options?: containerDesktopAPI.SaveDialogOptions): Promise<string | undefined> => {
+      const handle = deferedHandleDialog();
+
+      // ask to open file dialog
+      ipcInvoke('dialog:saveDialog', handle.id, options).catch((error: unknown) => {
+        handle.deferred.reject(error);
+      });
+
+      // wait for response
+      return handle.deferred.promise as Promise<string | undefined>;
     },
   );
 


### PR DESCRIPTION
### What does this PR do?
It is introducing a new 'dialog registry' to handle native dialogs current code was hooked in index.ts and not inside the extension system

It's providing API for extensions but renderer part is still hooked to the current system.
I'll provide other small PRs to switch renderer part to this new API and then remove all the 'old code'

### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fixes #5987

### How to test this PR?

Unit tests provided

you may try from extensions `window.showOpenDialog` or `window.showSaveDialog`