### PR TITLE
feat: input component in play kube

### DIFF
--- a/packages/renderer/src/lib/kube/KubePlayYAML.spec.ts
+++ b/packages/renderer/src/lib/kube/KubePlayYAML.spec.ts
@@ -124,7 +124,10 @@ test('error: When pressing the Play button, expect us to show the errors to the 
   // Simulate selecting a file
   const fileInput = screen.getByRole('textbox', { name: 'Kubernetes YAML file' });
   expect(fileInput).toBeInTheDocument();
-  await userEvent.click(fileInput);
+
+  const browseButton = screen.getByRole('button', { name: 'Browse ...' });
+  expect(browseButton).toBeInTheDocument();
+  await userEvent.click(browseButton);
 
   // Simulate selecting a runtime
   const runtimeOption = screen.getByText('Using a Podman container engine');
@@ -153,7 +156,10 @@ test('expect done button is there at the end', async () => {
   // Simulate selecting a file
   const fileInput = screen.getByRole('textbox', { name: 'Kubernetes YAML file' });
   expect(fileInput).toBeInTheDocument();
-  await userEvent.click(fileInput);
+
+  const browseButton = screen.getByRole('button', { name: 'Browse ...' });
+  expect(browseButton).toBeInTheDocument();
+  await userEvent.click(browseButton);
 
   // Simulate selecting a runtime
   const runtimeOption = screen.getByText('Using a Podman container engine');

--- a/packages/renderer/src/lib/kube/KubePlayYAML.svelte
+++ b/packages/renderer/src/lib/kube/KubePlayYAML.svelte
@@ -15,6 +15,7 @@ import type { V1NamespaceList } from '@kubernetes/client-node/dist/api';
 import { faCircleCheck } from '@fortawesome/free-solid-svg-icons';
 import Fa from 'svelte-fa';
 import Button from '../ui/Button.svelte';
+import Input from '/@/lib/ui/Input.svelte';
 
 let runStarted = false;
 let runFinished = false;
@@ -168,15 +169,17 @@ async function getKubernetesfileLocation() {
         <div class="text-xl font-medium">Select file:</div>
         <div hidden="{runStarted}">
           <label for="containerFilePath" class="block mb-2 text-sm font-bold text-gray-400">Kubernetes YAML file</label>
-          <input
-            on:click="{() => getKubernetesfileLocation()}"
-            name="containerFilePath"
-            id="containerFilePath"
-            bind:value="{kubernetesYamlFilePath}"
-            readonly
-            placeholder="Select a .yaml file to play"
-            class="w-full p-2 outline-none text-sm bg-charcoal-600 rounded-sm text-gray-700 placeholder-gray-700"
-            required />
+          <div class="flex flex-row space-x-2">
+            <Input
+              name="containerFilePath"
+              id="containerFilePath"
+              bind:value="{kubernetesYamlFilePath}"
+              readonly
+              placeholder="Select a .yaml file to play"
+              class="w-full p-2"
+              required />
+            <Button on:click="{() => getKubernetesfileLocation()}">Browse ...</Button>
+          </div>
         </div>
 
         <div>
@@ -243,14 +246,13 @@ async function getKubernetesfileLocation() {
                       for="contextToUse"
                       class="block mb-1 text-sm font-bold text-gray-400"
                       class:text-gray-900="{userChoice !== 'kubernetes'}">Kubernetes Context:</label>
-                    <input
-                      type="text"
+                    <Input
                       disabled="{userChoice === 'podman'}"
                       bind:value="{defaultContextName}"
                       name="defaultContextName"
                       id="defaultContextName"
                       readonly
-                      class="cursor-default w-full p-2 outline-none text-sm bg-charcoal-600 rounded-sm text-gray-700 placeholder-gray-700"
+                      class="w-full"
                       required />
                   </div>
                 {/if}


### PR DESCRIPTION
### What does this PR do?

Use the Input component when playing a Kube YAML.

When I went to test this I was so confused how to select a file I had to look at the code, and realized you're supposed to click on the readonly text input.

This wasn't a great pattern before, but it's less obvious now that we have disabled styling on Input, so I switched this to the more common pattern of having a Browse button to open the file dialog.

### Screenshot / video of UI

<img width="701" alt="Screenshot 2024-02-15 at 7 55 25 AM" src="https://github.com/containers/podman-desktop/assets/19958075/a0f9325e-fbfa-4f0b-b09e-9dff6ff4e592">

### What issues does this PR fix or reference?

Another part of #3234.

### How to test this PR?

Unit tests updated. Go to container or pods page and Play Kubernetes yaml.