### PR TITLE
chore: use checkbox component

### DIFF
--- a/packages/renderer/src/lib/image/RunImage.svelte
+++ b/packages/renderer/src/lib/image/RunImage.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { faFolderOpen, faMinusCircle, faPlay, faPlusCircle } from '@fortawesome/free-solid-svg-icons';
-import { Button, Input } from '@podman-desktop/ui-svelte';
+import { Button, Checkbox, Input } from '@podman-desktop/ui-svelte';
 import { onMount } from 'svelte';
 import { router } from 'tinro';
 
@@ -787,19 +787,11 @@ async function assertAllPortAreValid(): Promise<void> {
                 <!-- Use tty -->
                 <label for="containerTty" class="block mb-2 text-sm font-medium text-gray-400">Use TTY:</label>
                 <div class="flex flex-row justify-start items-center align-middle w-full text-gray-700 text-sm">
-                  <input
-                    type="checkbox"
-                    bind:checked="{useTty}"
-                    class="mx-2 outline-none text-sm"
-                    aria-label="Attach a pseudo terminal" />
+                  <Checkbox bind:checked="{useTty}" class="mx-2" title="Attach a pseudo terminal" />
                   Attach a pseudo terminal
                 </div>
                 <div class="flex flex-row justify-start items-center align-middle w-full text-gray-700 text-sm">
-                  <input
-                    type="checkbox"
-                    bind:checked="{useInteractive}"
-                    class="mx-2 outline-none text-sm"
-                    aria-label="Use interactive" />
+                  <Checkbox bind:checked="{useInteractive}" class="mx-2" title="Use interactive" />
                   Interactive: Keep STDIN open even if not attached
                 </div>
 
@@ -817,7 +809,7 @@ async function assertAllPortAreValid(): Promise<void> {
                 <label for="containerAutoRemove" class="pt-4 block mb-2 text-sm font-medium text-gray-400"
                   >Auto removal of container:</label>
                 <div class="flex flex-row justify-start items-center align-middle w-full text-gray-700 text-sm">
-                  <input type="checkbox" bind:checked="{autoRemove}" class="mx-2 outline-none text-sm" />
+                  <Checkbox bind:checked="{autoRemove}" class="mx-2" />
                   Automatically remove the container when the process exits
                 </div>
 
@@ -864,7 +856,7 @@ async function assertAllPortAreValid(): Promise<void> {
                 <label for="containerPrivileged" class="block mb-2 text-sm font-medium text-gray-400"
                   >Privileged:</label>
                 <div class="flex flex-row justify-start items-center align-middle w-full text-gray-700 text-sm">
-                  <input type="checkbox" bind:checked="{privileged}" class="mx-2 outline-none text-sm" />
+                  <Checkbox bind:checked="{privileged}" class="mx-2" />
                   Turn off security<i class="pl-1 fas fa-exclamation-triangle"></i>
                 </div>
 
@@ -872,7 +864,7 @@ async function assertAllPortAreValid(): Promise<void> {
                 <label for="containerReadOnly" class="pt-4 block mb-2 text-sm font-medium text-gray-400"
                   >Read only:</label>
                 <div class="flex flex-row justify-start items-center align-middle w-full text-gray-700 text-sm">
-                  <input type="checkbox" bind:checked="{readOnly}" class="mx-2 outline-none text-sm" />
+                  <Checkbox bind:checked="{readOnly}" class="mx-2" />
                   Make containers root filesystem read-only
                 </div>
 

--- a/packages/ui/src/lib/checkbox/Checkbox.spec.ts
+++ b/packages/ui/src/lib/checkbox/Checkbox.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023, 2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ import { expect, test } from 'vitest';
 import Checkbox from './Checkbox.svelte';
 
 function getPeer(checkbox: HTMLElement): Element | undefined {
-  return checkbox.parentElement?.children[1];
+  return checkbox.parentElement?.children[0];
 }
 
 test('Basic check', async () => {

--- a/packages/ui/src/lib/checkbox/Checkbox.svelte
+++ b/packages/ui/src/lib/checkbox/Checkbox.svelte
@@ -25,19 +25,9 @@ function onClick(
 }
 </script>
 
-<label class="{$$props.class || ''}">
-  <input
-    aria-label="{title}"
-    type="checkbox"
-    id="{id}"
-    name="{name}"
-    bind:checked="{checked}"
-    disabled="{disabled}"
-    required="{required}"
-    class="sr-only"
-    on:click="{onClick}" />
+<label class="relative p-1 {$$props.class || ''}">
   <div
-    class="grid place-content-center"
+    class="grid place-content-center absolute inset-0"
     title="{disabled ? disabledTooltip : title}"
     class:cursor-pointer="{!disabled}"
     class:cursor-not-allowed="{disabled}">
@@ -51,4 +41,14 @@ function onClick(
       <Fa size="1.1x" icon="{faOutlineSquare}" class="text-gray-400" />
     {/if}
   </div>
+  <input
+    aria-label="{title}"
+    type="checkbox"
+    id="{id}"
+    name="{name}"
+    bind:checked="{checked}"
+    disabled="{disabled}"
+    required="{required}"
+    class="opacity-0 absolute"
+    on:click="{onClick}" />
 </label>


### PR DESCRIPTION
### What does this PR do?

I noticed several places where we're using a standard blue <input type="checkbox" /> instead of our styled Checkbox.

Run Image is the biggest one, just requires the ability to set a class on Checkbox for spacing.

### Screenshot / video of UI

Before:
<img width="408" alt="Screenshot 2024-02-15 at 10 12 43 AM" src="https://github.com/containers/podman-desktop/assets/19958075/e8cecdd1-0112-4dab-872e-9ca22ec8ae45">

After:
<img width="408" alt="Screenshot 2024-02-15 at 10 33 30 AM" src="https://github.com/containers/podman-desktop/assets/19958075/8fd7e433-fc1c-4323-aab5-f9ddf5b8cf61">

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Unit tests still work; page through Run Image form to confirm styling.