### PR TITLE
feat: apply theme colors for global nav

### DIFF
--- a/packages/renderer/src/AppNavigation.svelte
+++ b/packages/renderer/src/AppNavigation.svelte
@@ -179,7 +179,9 @@ export let meta: TinroRouteMeta;
 </script>
 
 <svelte:window />
-<nav class="group w-leftnavbar min-w-leftnavbar flex flex-col hover:overflow-y-none" aria-label="AppNavigation">
+<nav
+  class="group w-leftnavbar min-w-leftnavbar flex flex-col hover:overflow-y-none bg-[var(--pd-global-nav-bg)]"
+  aria-label="AppNavigation">
   <NavItem href="/" tooltip="Dashboard" bind:meta="{meta}">
     <div class="relative w-full">
       <div class="flex items-center w-full h-full">

--- a/packages/renderer/src/lib/ui/NavItem.spec.ts
+++ b/packages/renderer/src/lib/ui/NavItem.spec.ts
@@ -46,9 +46,9 @@ test('Expect selection styling', async () => {
   const element = screen.getByLabelText(tooltip);
   expect(element).toBeInTheDocument();
   expect(element.firstChild).toBeInTheDocument();
-  expect(element.firstChild).toHaveClass('border-l-purple-500');
-  expect(element.firstChild).not.toHaveClass('hover:bg-charcoal-700');
-  expect(element.firstChild).not.toHaveClass('hover:border-charcoal-700');
+  expect(element.firstChild).toHaveClass('border-l-[var(--pd-global-nav-icon-selected-highlight)]');
+  expect(element.firstChild).not.toHaveClass('hover:bg-[var(--pd-global-nav-icon-hover-bg)]');
+  expect(element.firstChild).not.toHaveClass('hover:border-[var(--pd-global-nav-icon-hover-bg)]');
 });
 
 test('Expect selection styling for encoded URLs', async () => {
@@ -59,7 +59,7 @@ test('Expect selection styling for encoded URLs', async () => {
   const element = screen.getByLabelText(tooltip);
   expect(element).toBeInTheDocument();
   expect(element.firstChild).toBeInTheDocument();
-  expect(element.firstChild).toHaveClass('border-l-purple-500');
+  expect(element.firstChild).toHaveClass('border-l-[var(--pd-global-nav-icon-selected-highlight)]');
 });
 
 test('Expect selection styling for sub-pages', async () => {
@@ -70,7 +70,7 @@ test('Expect selection styling for sub-pages', async () => {
   const element = screen.getByLabelText(tooltip);
   expect(element).toBeInTheDocument();
   expect(element.firstChild).toBeInTheDocument();
-  expect(element.firstChild).toHaveClass('border-l-purple-500');
+  expect(element.firstChild).toHaveClass('border-l-[var(--pd-global-nav-icon-selected-highlight)]');
 });
 
 test('Expect not to have selection styling', async () => {
@@ -80,10 +80,10 @@ test('Expect not to have selection styling', async () => {
   const element = screen.getByLabelText(tooltip);
   expect(element).toBeInTheDocument();
   expect(element.firstChild).toBeInTheDocument();
-  expect(element.firstChild).toHaveClass('border-l-charcoal-800');
-  expect(element.firstChild).toHaveClass('hover:bg-charcoal-700');
-  expect(element.firstChild).toHaveClass('hover:border-charcoal-700');
-  expect(element.firstChild).not.toHaveClass('border-l-purple-500');
+  expect(element.firstChild).toHaveClass('border-l-[var(--pd-global-nav-bg)]');
+  expect(element.firstChild).toHaveClass('hover:bg-[var(--pd-global-nav-icon-hover-bg)]');
+  expect(element.firstChild).toHaveClass('hover:border-[var(--pd-global-nav-icon-hover-bg)]');
+  expect(element.firstChild).not.toHaveClass('border-l-[var(--pd-global-nav-icon-selected-highlight)]');
   expect(element.firstChild).not.toHaveClass('px-2');
 });
 
@@ -95,14 +95,16 @@ test('Expect in-section styling', async () => {
   expect(element).toBeInTheDocument();
   expect(element.firstChild).toBeInTheDocument();
   expect(element.firstChild).toHaveClass('px-2');
-  expect(element.firstChild).toHaveClass('hover:bg-charcoal-700');
-  expect(element.firstChild).not.toHaveClass('border-charcoal-600');
-  expect(element.firstChild).not.toHaveClass('border-l-purple-500');
-  expect(element.firstChild).not.toHaveClass('border-l-charcoal-800');
-  expect(element.firstChild).not.toHaveClass('hover:border-charcoal-700');
+  expect(element.firstChild).toHaveClass('hover:bg-[var(--pd-global-nav-icon-hover-bg)]');
+  expect(element.firstChild).not.toHaveClass('border-[var(--pd-global-nav-bg)]');
+  expect(element.firstChild).not.toHaveClass('border-l-[var(--pd-global-nav-bg)]');
+  expect(element.firstChild).not.toHaveClass('border-l-[var(--pd-global-nav-icon-selected-highlight)]');
+  expect(element.firstChild).not.toHaveClass('hover:border-[var(--pd-global-nav-icon-hover-bg)]');
 });
-// class:hover:bg-charcoal-700="{!selected || inSection}"
-// class:hover:border-charcoal-700="{!selected && !inSection}"
+
+// class:hover:text-[color:var(--pd-global-nav-icon-hover)]="{!selected || inSection}"
+// class:hover:bg-[var(--pd-global-nav-icon-hover-bg)]="{!selected || inSection}"
+// class:hover:border-[var(--pd-global-nav-icon-hover-bg)]="{!selected && !inSection}">
 test('Expect in-section selection styling', async () => {
   const tooltip = 'Dashboard';
   render(NavItemTest);
@@ -110,11 +112,12 @@ test('Expect in-section selection styling', async () => {
   const element = screen.getByLabelText(tooltip);
   expect(element).toBeInTheDocument();
   expect(element.firstChild).toBeInTheDocument();
-  expect(element.firstChild).toHaveClass('text-purple-500');
+  expect(element.firstChild).toHaveClass('text-[color:var(--pd-global-nav-icon-selected)]');
   expect(element.firstChild).toHaveClass('px-2');
-  expect(element.firstChild).toHaveClass('hover:bg-charcoal-700');
-  expect(element.firstChild).not.toHaveClass('border-l-purple-500');
-  expect(element.firstChild).not.toHaveClass('hover:border-charcoal-700');
+  expect(element.firstChild).toHaveClass('hover:text-[color:var(--pd-global-nav-icon-hover)]');
+  expect(element.firstChild).toHaveClass('hover:bg-[var(--pd-global-nav-icon-hover-bg)]');
+  expect(element.firstChild).not.toHaveClass('border-l-[var(--pd-global-nav-bg)]');
+  expect(element.firstChild).not.toHaveClass('hover:border-[var(--pd-global-nav-icon-hover-bg)]');
 });
 
 test('Expect that having an onClick handler overrides href and works', async () => {

--- a/packages/renderer/src/lib/ui/NavItem.svelte
+++ b/packages/renderer/src/lib/ui/NavItem.svelte
@@ -38,15 +38,16 @@ onDestroy(() => {
     class="flex py-3 justify-center items-center cursor-pointer"
     class:border-x-[4px]="{!inSection}"
     class:px-2="{inSection}"
-    class:border-charcoal-800="{!inSection}"
-    class:text-white="{!selected || !inSection}"
-    class:text-purple-500="{selected && inSection}"
-    class:border-l-purple-500="{selected && !inSection}"
-    class:bg-charcoal-500="{selected && !inSection}"
-    class:border-r-charcoal-500="{selected && !inSection}"
-    class:border-l-charcoal-800="{!selected && !inSection}"
-    class:hover:bg-charcoal-700="{!selected || inSection}"
-    class:hover:border-charcoal-700="{!selected && !inSection}">
+    class:border-[var(--pd-global-nav-bg)]="{!inSection}"
+    class:text-[color:var(--pd-global-nav-icon)]="{!selected || !inSection}"
+    class:text-[color:var(--pd-global-nav-icon-selected)]="{selected && inSection}"
+    class:border-l-[var(--pd-global-nav-icon-selected-highlight)]="{selected && !inSection}"
+    class:bg-[var(--pd-global-nav-icon-selected-bg)]="{selected && !inSection}"
+    class:border-r-[var(--pd-global-nav-icon-selected-bg)]="{selected && !inSection}"
+    class:border-l-[var(--pd-global-nav-bg)]="{!selected && !inSection}"
+    class:hover:text-[color:var(--pd-global-nav-icon-hover)]="{!selected || inSection}"
+    class:hover:bg-[var(--pd-global-nav-icon-hover-bg)]="{!selected || inSection}"
+    class:hover:border-[var(--pd-global-nav-icon-hover-bg)]="{!selected && !inSection}">
     <Tooltip tip="{tooltip}" right>
       <slot />
     </Tooltip>

--- a/packages/renderer/src/lib/ui/NavSection.svelte
+++ b/packages/renderer/src/lib/ui/NavSection.svelte
@@ -42,7 +42,7 @@ onMount(() => {
 });
 </script>
 
-<div class="flex flex-col justify-center items-center mx-1 bg-charcoal-600 rounded my-1">
+<div class="flex flex-col justify-center items-center mx-1 bg-[var(--pd-global-nav-icon-inset-bg)] rounded my-1">
   {#if expanded}
     <div class="inline-block pt-0.5">
       <div transition:fadeSlide="{{ duration: 500 }}">


### PR DESCRIPTION
### What does this PR do?
apply theme colors for the global nav

it's changing background color and hovering of the left navbar and inset background to match UX mockups

### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

related to https://github.com/containers/podman-desktop/issues/5914

### How to test this PR?

Visually there should be a difference on the hovering and background of the navbar
purple hover and different colors for background



now, ensure Podman Desktop is exited and change hidden preference to light
```
cat <<< $(jq '."preferences.appearance"="light"' $HOME/.local/share/containers/podman-desktop/configuration/settings.json ) > $HOME/.local/share/containers/podman-desktop/configuration/settings.json
```

restart Podman Desktop, you should have a left navbar using 'light theme'

