### PR TITLE
feat: use theme colors for secondary nav

### DIFF
--- a/packages/renderer/src/PreferencesNavigation.svelte
+++ b/packages/renderer/src/PreferencesNavigation.svelte
@@ -41,11 +41,11 @@ onMount(async () => {
 </script>
 
 <nav
-  class="z-1 w-leftsidebar min-w-leftsidebar shadow flex-col justify-between flex transition-all duration-500 ease-in-out bg-charcoal-700"
+  class="z-1 w-leftsidebar min-w-leftsidebar shadow flex-col justify-between flex transition-all duration-500 ease-in-out bg-[var(--pd-secondary-nav-bg)]"
   aria-label="PreferencesNavigation">
   <div class="flex items-center">
     <div class="pt-4 px-5 mb-10">
-      <p class="text-xl first-letter:uppercase">Settings</p>
+      <p class="text-xl first-letter:uppercase text-[color:var(--pd-secondary-nav-header-text)]">Settings</p>
     </div>
   </div>
   <div class="h-full overflow-hidden hover:overflow-y-auto" style="margin-bottom:auto">

--- a/packages/renderer/src/lib/preferences/SettingsNavItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/SettingsNavItem.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,7 +45,7 @@ test('Expect selection styling', async () => {
   const element = screen.getByLabelText(title);
   expect(element).toBeInTheDocument();
   expect(element.firstChild).toBeInTheDocument();
-  expect(element.firstChild).toHaveClass('border-purple-500');
+  expect(element.firstChild).toHaveClass('border-[var(--pd-secondary-nav-selected-highlight)]');
 });
 
 test('Expect not to have selection styling', async () => {
@@ -55,8 +55,8 @@ test('Expect not to have selection styling', async () => {
   const element = screen.getByLabelText(title);
   expect(element).toBeInTheDocument();
   expect(element.firstChild).toBeInTheDocument();
-  expect(element.firstChild).not.toHaveClass('border-purple-500');
-  expect(element.firstChild).toHaveClass('border-charcoal-600');
+  expect(element.firstChild).not.toHaveClass('border-[var(--pd-secondary-nav-selected-highlight)]');
+  expect(element.firstChild).toHaveClass('border-[var(--pd-secondary-nav-bg)]');
 });
 
 test('Expect child styling', async () => {

--- a/packages/renderer/src/lib/preferences/SettingsNavItem.svelte
+++ b/packages/renderer/src/lib/preferences/SettingsNavItem.svelte
@@ -26,7 +26,7 @@ function rotate(node: unknown, { clockwise = true }) {
 
 <a class="no-underline" href="{href}" aria-label="{title}" on:click="{() => (expanded = !expanded)}">
   <div
-    class="flex w-full pr-1 py-2 justify-between items-center cursor-pointer border-l-[4px] border-charcoal-600"
+    class="flex w-full pr-1 py-2 justify-between items-center cursor-pointer border-l-[4px]"
     class:text-white="{selected}"
     class:pl-3="{!child}"
     class:pl-4="{child}"
@@ -34,15 +34,17 @@ function rotate(node: unknown, { clockwise = true }) {
     class:text-sm="{child}"
     class:font-extralight="{child}"
     class:font-semibold="{!child}"
-    class:bg-charcoal-300="{selected}"
-    class:border-purple-500="{selected}"
-    class:text-gray-400="{!selected}"
-    class:hover:text-gray-300="{!selected}"
-    class:hover:bg-charcoal-500="{!selected}"
-    class:hover:border-charcoal-500="{!selected}">
+    class:bg-[var(--pd-secondary-nav-selected-bg)]="{selected}"
+    class:border-[var(--pd-secondary-nav-bg)]="{!selected}"
+    class:border-[var(--pd-secondary-nav-selected-highlight)]="{selected}"
+    class:text-[color:var(--pd-secondary-nav-text-selected)]="{selected}"
+    class:text-[color:var(--pd-secondary-nav-text)]="{!selected}"
+    class:hover:[color:var(--pd-secondary-nav-text-hover)]="{!selected}"
+    class:hover:bg-[var(--pd-secondary-nav-text-hover-bg)]="{!selected}"
+    class:hover:border-[var(--pd-secondary-nav-text-hover-bg)]="{!selected}">
     <span class="block group-hover:block" class:capitalize="{!child}">{title}</span>
     {#if section}
-      <div class="px-2 relative w-4 h-4">
+      <div class="px-2 relative w-4 h-4 [color:var(--pd-secondary-nav-expander)]">
         {#if expanded}
           <i
             class="fas fa-angle-down text-lg absolute left-0 top-0"


### PR DESCRIPTION
### What does this PR do?
apply theme colors for the secondary nav

### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

related to https://github.com/containers/podman-desktop/issues/5914

### How to test this PR?

check if you see some differences with before and after

now, ensure Podman Desktop is exited and change hidden preference to light
```
cat <<< $(jq '."preferences.appearance"="light"' $HOME/.local/share/containers/podman-desktop/configuration/settings.json ) > $HOME/.local/share/containers/podman-desktop/configuration/settings.json
```

restart Podman Desktop, you should have a secondary nav using 'light theme'

