### PR TITLE
feat: use theme colors for invert content

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesPage.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesPage.svelte
@@ -40,7 +40,7 @@ onMount(async () => {
 });
 </script>
 
-<div class="flex flex-col h-full">
+<div class="flex flex-col h-full bg-[var(--pd-invert-content-bg)]">
   <Route path="/*" breadcrumb="Preferences">
     {#if defaultPrefPageId !== undefined}
       <PreferencesRendering key="{defaultPrefPageId}" properties="{properties}" />

--- a/packages/renderer/src/lib/preferences/PreferencesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRendering.svelte
@@ -78,7 +78,7 @@ function updateSearchValue(event: any) {
             <div>
               <div class="first-letter:uppercase">{records.at(0)?.title}</div>
               {#each records as configItem}
-                <div class="bg-charcoal-600 rounded-md mt-2 ml-2">
+                <div class="bg-[var(--pd-invert-content-card-bg)] rounded-md mt-2 ml-2">
                   <PreferencesRenderingItem record="{configItem}" />
                 </div>
               {/each}

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItem.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItem.svelte
@@ -61,13 +61,13 @@ $: showResetButton = false;
 $: resetToDefault = false;
 </script>
 
-<div class="flex flex-row px-2 py-2 justify-between w-full">
+<div class="flex flex-row px-2 py-2 justify-between w-full text-[color:var(--pd-invert-content-card-text)]">
   <div
     class="flex flex-col {recordUI.original.type === 'string' &&
     (!recordUI.original.enum || recordUI.original.enum.length === 0)
       ? 'w-full'
       : ''}">
-    <div class="flex flex-row text-sm">
+    <div class="flex flex-row text-sm text-[color:var(--pd-invert-content-card-text)]">
       {recordUI.title}
       {#if showResetButton}
         <div class="ml-2">
@@ -78,11 +78,11 @@ $: resetToDefault = false;
       {/if}
     </div>
     {#if recordUI.markdownDescription}
-      <div class="pt-1 text-gray-700 text-xs pr-2">
+      <div class="pt-1 text-[color:var(--pd-invert-content-card-text)] text-xs pr-2">
         <Markdown>{recordUI.markdownDescription}</Markdown>
       </div>
     {:else}
-      <div class="pt-1 text-gray-700 text-xs pr-2">{recordUI.description}</div>
+      <div class="pt-1 text-[color:var(--pd-invert-content-card-text)] text-xs pr-2">{recordUI.description}</div>
     {/if}
     {#if recordUI.original.type === 'string' && (!recordUI.original.enum || recordUI.original.enum.length === 0)}
       <PreferencesRenderingItemFormat

--- a/packages/renderer/src/lib/preferences/SettingsPage.svelte
+++ b/packages/renderer/src/lib/preferences/SettingsPage.svelte
@@ -6,8 +6,18 @@ export let title: string;
   <div class="min-w-full px-5 py-4" role="region" aria-label="Header">
     <div class="flex flex-row">
       <div class="grow">
-        <div class="capitalize text-xl" role="heading" aria-level="1" aria-label="Title">{title}</div>
-        <div class="text-sm text-gray-700" role="heading" aria-level="2" aria-label="Subtitle">
+        <div
+          class="capitalize text-xl text-[color:var(--pd-invert-content-header-text)]"
+          role="heading"
+          aria-level="1"
+          aria-label="Title">
+          {title}
+        </div>
+        <div
+          class="text-sm text-[color:var(--pd-invert-content-header2-text)]"
+          role="heading"
+          aria-level="2"
+          aria-label="Subtitle">
           <slot name="subtitle"><br /></slot>
         </div>
       </div>


### PR DESCRIPTION
### What does this PR do?
apply theme colors for the invert content

### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

related to https://github.com/containers/podman-desktop/issues/5914

### How to test this PR?

Visually there should be no difference on the titlebar before or after the changes

now, ensure Podman Desktop is exited and change hidden preference to light
```
cat <<< $(jq '."preferences.appearance"="light"' $HOME/.local/share/containers/podman-desktop/configuration/settings.json ) > $HOME/.local/share/containers/podman-desktop/configuration/settings.json
```

restart Podman Desktop, you should have a some invert content using 'light theme'

