### PR TITLE
chore: use checkbox component in deploy to kube

### DIFF
--- a/packages/renderer/src/lib/pod/DeployPodToKube.spec.ts
+++ b/packages/renderer/src/lib/pod/DeployPodToKube.spec.ts
@@ -417,7 +417,7 @@ test('When deploying a pod, restricted security context is added', async () => {
   expect(createButton).toBeEnabled();
 
   // Click restricted
-  const useRestricted = screen.getByTestId('useRestricted');
+  const useRestricted = screen.getByRole('checkbox', { name: 'Use restricted security context' });
   await fireEvent.click(useRestricted);
 
   // Press the deploy button
@@ -464,7 +464,7 @@ test('Succeed to deploy ingress if service is selected', async () => {
   expect(createButton).toBeEnabled();
 
   // Checkmark the ingress
-  const checkbox = screen.getByLabelText('Expose Service Locally Using Kubernetes Ingress:');
+  const checkbox = screen.getByRole('checkbox', { name: 'Create Ingress' });
   await fireEvent.click(checkbox);
   expect(checkbox).toHaveProperty('checked', true);
 

--- a/packages/renderer/src/lib/pod/DeployPodToKube.svelte
+++ b/packages/renderer/src/lib/pod/DeployPodToKube.svelte
@@ -13,6 +13,7 @@ import { faExternalLink, faRocket } from '@fortawesome/free-solid-svg-icons';
 import Link from '../ui/Link.svelte';
 import { router } from 'tinro';
 import Input from '/@/lib/ui/Input.svelte';
+import Checkbox from '/@/lib/ui/Checkbox.svelte';
 
 export let resourceId: string;
 export let engineId: string;
@@ -400,34 +401,30 @@ function updateKubeResult() {
 
       <div class="pt-2 pb-4">
         <label for="services" class="block mb-1 text-sm font-medium text-gray-300">Kubernetes Services:</label>
-        <input
-          type="checkbox"
-          bind:checked="{deployUsingServices}"
-          name="useServices"
-          id="useServices"
-          class=""
-          required />
-        <span class="text-gray-400 text-sm ml-1"
-          >Replace .hostPort exposure on containers by Services. It is the recommended way to expose ports, as a cluster
-          policy may prevent to use hostPort.</span>
+        <div class="flex flex-row">
+          <Checkbox bind:checked="{deployUsingServices}" name="useServices" id="useServices" required />
+          <span class="text-gray-400 text-sm ml-1"
+            >Replace .hostPort exposure on containers by Services. It is the recommended way to expose ports, as a
+            cluster policy may prevent to use hostPort.</span>
+        </div>
       </div>
 
       <div class="pt-2 pb-4">
         <label for="useRestricted" class="block mb-1 text-sm font-medium text-gray-300"
           >Restricted Security Context:</label>
-        <input
-          type="checkbox"
-          bind:checked="{deployUsingRestrictedSecurityContext}"
-          name="useRestricted"
-          id="useRestricted"
-          data-testid="useRestricted"
-          class=""
-          required />
-        <span class="text-gray-400 text-sm ml-1">
-          Update Kubernetes manifest to respect the Pod security <Link
-            externalRef="https://kubernetes.io/docs/concepts/security/pod-security-standards#restricted"
-            >restricted profile</Link
-          >.</span>
+        <div class="flex flex-row">
+          <Checkbox
+            bind:checked="{deployUsingRestrictedSecurityContext}"
+            name="useRestricted"
+            id="useRestricted"
+            title="Use restricted security context"
+            required />
+          <span class="text-gray-400 text-sm ml-1">
+            Update Kubernetes manifest to respect the Pod security <Link
+              externalRef="https://kubernetes.io/docs/concepts/security/pod-security-standards#restricted"
+              >restricted profile</Link
+            >.</span>
+        </div>
       </div>
 
       <!-- Only show for non-OpenShift deployments (we use routes for OpenShift) -->
@@ -435,17 +432,18 @@ function updateKubeResult() {
         <div class="pt-2 pb-4">
           <label for="createIngress" class="block mb-1 text-sm font-medium text-gray-300"
             >Expose Service Locally Using Kubernetes Ingress:</label>
-          <input
-            type="checkbox"
-            bind:checked="{createIngress}"
-            name="createIngress"
-            id="createIngress"
-            class=""
-            required />
-          <span class="text-gray-300 text-sm ml-1">
-            Create an Ingress to get access to the local ports exposed, at the default Ingress Controller location.
-            Example: On default kind cluster created with Podman Desktop, it will be accessible at 'localhost:9090'.
-            Requirements: Your cluster must have an Ingress Controller.</span>
+          <div class="flex flex-row">
+            <Checkbox
+              bind:checked="{createIngress}"
+              name="createIngress"
+              id="createIngress"
+              title="Create Ingress"
+              required />
+            <span class="text-gray-300 text-sm ml-1">
+              Create an Ingress to get access to the local ports exposed, at the default Ingress Controller location.
+              Example: On default kind cluster created with Podman Desktop, it will be accessible at 'localhost:9090'.
+              Requirements: Your cluster must have an Ingress Controller.</span>
+          </div>
         </div>
       {/if}
 
@@ -473,7 +471,7 @@ function updateKubeResult() {
       {#if openshiftRouteGroupSupported}
         <div class="pt-2 m-2">
           <label for="routes" class="block mb-1 text-sm font-medium text-gray-400">Create OpenShift routes:</label>
-          <input type="checkbox" bind:checked="{deployUsingRoutes}" name="useRoutes" id="useRoutes" class="" required />
+          <Checkbox bind:checked="{deployUsingRoutes}" name="useRoutes" id="useRoutes" required />
           <span class="text-gray-400 text-sm ml-1"
             >Create OpenShift routes to get access to the exposed ports of this pod.</span>
         </div>

--- a/packages/renderer/src/lib/ui/Checkbox.svelte
+++ b/packages/renderer/src/lib/ui/Checkbox.svelte
@@ -11,6 +11,7 @@ export let disabledTooltip = '';
 export let title = '';
 export let id: string | undefined = undefined;
 export let name: string | undefined = undefined;
+export let required = false;
 
 const dispatch = createEventDispatcher<{ click: boolean }>();
 
@@ -27,6 +28,7 @@ function onClick(checked: boolean) {
     name="{name}"
     bind:checked="{checked}"
     disabled="{disabled}"
+    required="{required}"
     class="sr-only"
     on:click="{event => onClick(event.currentTarget.checked)}" />
   <div

--- a/packages/renderer/src/lib/ui/Checkbox.svelte
+++ b/packages/renderer/src/lib/ui/Checkbox.svelte
@@ -9,6 +9,7 @@ export let disabled = false;
 export let indeterminate = false;
 export let disabledTooltip = '';
 export let title = '';
+export let id: string | undefined = undefined;
 export let name: string | undefined = undefined;
 
 const dispatch = createEventDispatcher<{ click: boolean }>();
@@ -22,6 +23,7 @@ function onClick(checked: boolean) {
   <input
     aria-label="{title}"
     type="checkbox"
+    id="{id}"
     name="{name}"
     bind:checked="{checked}"
     disabled="{disabled}"

--- a/packages/renderer/src/lib/ui/Checkbox.svelte
+++ b/packages/renderer/src/lib/ui/Checkbox.svelte
@@ -9,6 +9,7 @@ export let disabled = false;
 export let indeterminate = false;
 export let disabledTooltip = '';
 export let title = '';
+export let name: string | undefined = undefined;
 
 const dispatch = createEventDispatcher<{ click: boolean }>();
 
@@ -21,6 +22,7 @@ function onClick(checked: boolean) {
   <input
     aria-label="{title}"
     type="checkbox"
+    name="{name}"
     bind:checked="{checked}"
     disabled="{disabled}"
     class="sr-only"


### PR DESCRIPTION
### What does this PR do?

We are using standard checkboxes in the Deploy to Kubernetes form instead of our styled Checkbox component. This just switches them and updates the test to be more consistent.

Wrapper <div>s added because Checkbox (a composite) doesn't work as well w/o a layout, but this also fixes the problem where text was wrapping below the checkbox when it shouldn't.

### Screenshot / video of UI

Before:

<img width="361" alt="Screenshot 2024-02-15 at 1 02 09 PM" src="https://github.com/containers/podman-desktop/assets/19958075/d5a59ffc-5ed8-42eb-bc38-d463fd77d4fd">

After:

<img width="361" alt="Screenshot 2024-02-15 at 1 03 08 PM" src="https://github.com/containers/podman-desktop/assets/19958075/67ef991b-0f23-45c7-b75f-1f8a937fe43a">

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Unit tests updated, just check UI.