### PR TITLE
chore: add stale bot

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -47,7 +47,7 @@ jobs:
             This issue has been automatically marked as stale because it has not had
             activity in the last year. It will be closed in 30 days if no further activity occurs. Please
             feel free to leave a comment if you believe the issue is still relevant.
-            Thank you for your contributions!'
+            Thank you for your contributions!
         close-issue-message: >
             This issue has been automatically closed because it has not had any further
             activity in the last 30 days. Thank you for your contributions!            

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,0 +1,66 @@
+#
+# Copyright (C) 2022 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: stale
+
+on:
+  schedule:
+    - cron: "5 0 * * *"
+  workflow_dispatch:
+  
+permissions:
+  contents: read
+
+jobs:
+  stale:
+    permissions:
+      issues: write  # for actions/stale to close stale issues
+      pull-requests: write  # for actions/stale to close stale PRs
+
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/stale@v9
+      with:
+        repo-token: ${{ secrets.PODMAN_DESKTOP_BOT_TOKEN }}
+       # Please refer to https://github.com/actions/stale/
+        # limit to 10 operations per run (to see how it works)
+        operations-per-run: 10
+        days-before-issue-stale: 500
+        days-before-issue-close: 30
+        stale-issue-label: lifecycle/stale
+        exempt-issue-labels: lifecycle/frozen
+        stale-issue-message: >
+            This issue has been automatically marked as stale because it has not had
+            activity in the last year. It will be closed in 30 days if no further activity occurs. Please
+            feel free to leave a comment if you believe the issue is still relevant.
+            Thank you for your contributions!'
+        close-issue-message: >
+            This issue has been automatically closed because it has not had any further
+            activity in the last 30 days. Thank you for your contributions!            
+        days-before-pr-stale: 200
+        days-before-pr-close: 14
+        stale-pr-label: lifecycle/stale
+        exempt-pr-labels: lifecycle/frozen
+        stale-pr-message: >
+          This pull request has been automatically marked as stale because it has not had
+          activity in the last 6 months. It will be closed in 2 weeks if no further activity occurs. Please
+          feel free to give a status update or ping for review. Thank you for your contributions!
+        close-pr-message: >
+          This pull request has been automatically closed because it has not had any further
+          activity in the last 2 weeks. Thank you for your contributions!
+        remove-stale-when-updated: true
+        debug-only: true

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022 Red Hat, Inc.
+# Copyright (C) 2024 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -35,7 +35,7 @@ jobs:
     steps:
     - uses: actions/stale@v9
       with:
-        repo-token: ${{ secrets.PODMAN_DESKTOP_BOT_TOKEN }}
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
        # Please refer to https://github.com/actions/stale/
         # limit to 10 operations per run (to see how it works)
         operations-per-run: 10


### PR DESCRIPTION
### What does this PR do?

I enabled `debug-only` flag  + a low `operations-per-run` for now with very old stale range to limit the impact on first run

so it should just do traces for now :-)

### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

related https://github.com/containers/podman-desktop/issues/6032

it won't fix as it will just log the actions (debug)

### How to test this PR?

<!-- Please explain steps to reproduce -->
