### PR TITLE
feat: adding secret store

### DIFF
--- a/packages/main/src/plugin/storage/encryption/encryptionMainService.ts
+++ b/packages/main/src/plugin/storage/encryption/encryptionMainService.ts
@@ -1,0 +1,97 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+// based on https://github.com/microsoft/vscode/blob/cff1e8e9a755d206fb33237bb6b6337d171471f2/src/vs/platform/encryption/electron-main/encryptionMainService.ts
+
+import { app, safeStorage } from 'electron';
+import { type IEncryptionMainService, KnownStorageProvider, PasswordStoreCLIOption } from './encryptionService.js';
+import { isMac, isWindows } from '/@/util.js';
+
+export class EncryptionMainService implements IEncryptionMainService {
+  constructor() {
+    // if this commandLine switch is set, the user has opted in to using basic text encryption
+    if (app.commandLine.getSwitchValue('password-store') === PasswordStoreCLIOption.basic) {
+      safeStorage.setUsePlainTextEncryption?.(true);
+    }
+  }
+
+  async encrypt(value: string): Promise<string> {
+    try {
+      return JSON.stringify(safeStorage.encryptString(value));
+    } catch (e) {
+      console.error(e);
+      throw e;
+    }
+  }
+
+  async decrypt(value: string): Promise<string> {
+    let parsedValue: { data: string };
+    try {
+      parsedValue = JSON.parse(value);
+      if (!parsedValue.data) {
+        throw new Error(`[EncryptionMainService] Invalid encrypted value: ${value}`);
+      }
+      const bufferToDecrypt = Buffer.from(parsedValue.data);
+      return safeStorage.decryptString(bufferToDecrypt);
+    } catch (e) {
+      console.error(e);
+      throw e;
+    }
+  }
+
+  isEncryptionAvailable(): Promise<boolean> {
+    return Promise.resolve(safeStorage.isEncryptionAvailable());
+  }
+
+  getKeyStorageProvider(): Promise<KnownStorageProvider> {
+    if (isWindows()) {
+      return Promise.resolve(KnownStorageProvider.dplib);
+    }
+    if (isMac()) {
+      return Promise.resolve(KnownStorageProvider.keychainAccess);
+    }
+    if (safeStorage.getSelectedStorageBackend) {
+      try {
+        const result = safeStorage.getSelectedStorageBackend() as KnownStorageProvider;
+        return Promise.resolve(result);
+      } catch (e) {
+        console.error(e);
+      }
+    }
+    return Promise.resolve(KnownStorageProvider.unknown);
+  }
+
+  async setUsePlainTextEncryption(): Promise<void> {
+    if (isWindows()) {
+      throw new Error('Setting plain text encryption is not supported on Windows.');
+    }
+
+    if (isMac()) {
+      throw new Error('Setting plain text encryption is not supported on macOS.');
+    }
+
+    if (!safeStorage.setUsePlainTextEncryption) {
+      throw new Error('Setting plain text encryption is not supported.');
+    }
+
+    safeStorage.setUsePlainTextEncryption(true);
+  }
+}

--- a/packages/main/src/plugin/storage/encryption/encryptionService.ts
+++ b/packages/main/src/plugin/storage/encryption/encryptionService.ts
@@ -1,0 +1,70 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+// based on https://github.com/microsoft/vscode/blob/cff1e8e9a755d206fb33237bb6b6337d171471f2/src/vs/platform/encryption/common/encryptionService.ts
+
+export interface IEncryptionService extends ICommonEncryptionService {
+  setUsePlainTextEncryption(): Promise<void>;
+  getKeyStorageProvider(): Promise<KnownStorageProvider>;
+}
+
+export interface IEncryptionMainService extends IEncryptionService {}
+
+export interface ICommonEncryptionService {
+  encrypt(value: string): Promise<string>;
+
+  decrypt(value: string): Promise<string>;
+
+  isEncryptionAvailable(): Promise<boolean>;
+}
+
+// The values provided to the `password-store` command line switch.
+// Notice that they are not the same as the values returned by
+// `getSelectedStorageBackend` in the `safeStorage` API.
+export const enum PasswordStoreCLIOption {
+  kwallet = 'kwallet',
+  kwallet5 = 'kwallet5',
+  gnomeLibsecret = 'gnome-libsecret',
+  basic = 'basic',
+}
+
+// The values returned by `getSelectedStorageBackend` in the `safeStorage` API.
+export const enum KnownStorageProvider {
+  unknown = 'unknown',
+  basicText = 'basic_text',
+
+  // Linux
+  gnomeAny = 'gnome_any',
+  gnomeLibsecret = 'gnome_libsecret',
+  gnomeKeyring = 'gnome_keyring',
+  kwallet = 'kwallet',
+  kwallet5 = 'kwallet5',
+  kwallet6 = 'kwallet6',
+
+  // The rest of these are not returned by `getSelectedStorageBackend`
+  // but these were added for platform completeness.
+
+  // Windows
+  dplib = 'dpapi',
+
+  // macOS
+  keychainAccess = 'keychain_access',
+}

--- a/packages/main/src/plugin/storage/secret/secret-registry.spec.ts
+++ b/packages/main/src/plugin/storage/secret/secret-registry.spec.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
-import { SecretStorage } from '/@/plugin/storage/secret/secret-registry.js';
+import { SecretRegistry } from '/@/plugin/storage/secret/secret-registry.js';
 import type { Directories } from '/@/plugin/directories.js';
 import type { IEncryptionService } from '/@/plugin/storage/encryption/encryptionService.js';
 
@@ -58,12 +58,12 @@ vi.mock('node:fs', async () => {
 });
 
 test('keys should be empty when init not called', () => {
-  const storage = new SecretStorage(directoriesMock, encryptionServiceMock);
+  const storage = new SecretRegistry(directoriesMock, encryptionServiceMock);
   expect(storage.keys().length).toBe(0);
 });
 
 test('init should load from disk the existing file', async () => {
-  const storage = new SecretStorage(directoriesMock, encryptionServiceMock);
+  const storage = new SecretRegistry(directoriesMock, encryptionServiceMock);
 
   // Mock config path
   mocks.getConfigurationDirectoryMock.mockReturnValue('dummy-path');
@@ -84,7 +84,7 @@ test('init should load from disk the existing file', async () => {
 });
 
 test('init should load from disk the existing secrets', async () => {
-  const storage = new SecretStorage(directoriesMock, encryptionServiceMock);
+  const storage = new SecretRegistry(directoriesMock, encryptionServiceMock);
 
   // Mock config path
   mocks.getConfigurationDirectoryMock.mockReturnValue('dummy-path');
@@ -116,7 +116,7 @@ test('init should load from disk the existing secrets', async () => {
 });
 
 test('save should save to disk the in-memory secrets', async () => {
-  const storage = new SecretStorage(directoriesMock, encryptionServiceMock);
+  const storage = new SecretRegistry(directoriesMock, encryptionServiceMock);
   // Mock decrypt service
   mocks.encryptMock.mockImplementation(value => {
     switch (value) {
@@ -137,25 +137,25 @@ test('save should save to disk the in-memory secrets', async () => {
 });
 
 test('getNumber on string should raise an error', async () => {
-  const storage = new SecretStorage(directoriesMock, encryptionServiceMock);
+  const storage = new SecretRegistry(directoriesMock, encryptionServiceMock);
   storage.store('dummy', 'string');
   expect(() => storage.getNumber('dummy')).toThrowError('wrong value type');
 });
 
 test('getBoolean on string should raise an error', async () => {
-  const storage = new SecretStorage(directoriesMock, encryptionServiceMock);
+  const storage = new SecretRegistry(directoriesMock, encryptionServiceMock);
   storage.store('dummy', 'string');
   expect(() => storage.getBoolean('dummy')).toThrowError('wrong value type');
 });
 
 test('getObject on string should raise an error', async () => {
-  const storage = new SecretStorage(directoriesMock, encryptionServiceMock);
+  const storage = new SecretRegistry(directoriesMock, encryptionServiceMock);
   storage.store('dummy', 'string');
   expect(() => storage.getObject('dummy')).toThrowError('wrong value type');
 });
 
 test('storeAll should store all the item provided', async () => {
-  const storage = new SecretStorage(directoriesMock, encryptionServiceMock);
+  const storage = new SecretRegistry(directoriesMock, encryptionServiceMock);
   storage.storeAll([
     {
       key: 'dummy-1',
@@ -177,7 +177,7 @@ test('storeAll should store all the item provided', async () => {
 });
 
 test('remove should remove the item', async () => {
-  const storage = new SecretStorage(directoriesMock, encryptionServiceMock);
+  const storage = new SecretRegistry(directoriesMock, encryptionServiceMock);
   storage.storeAll([
     {
       key: 'dummy-1',
@@ -195,7 +195,7 @@ test('remove should remove the item', async () => {
 });
 
 test('onDidChangeSecret should be fired when an item is inserted', async () => {
-  const storage = new SecretStorage(directoriesMock, encryptionServiceMock);
+  const storage = new SecretRegistry(directoriesMock, encryptionServiceMock);
 
   const listener = vi.fn();
   storage.onDidChangeSecret(listener);
@@ -206,7 +206,7 @@ test('onDidChangeSecret should be fired when an item is inserted', async () => {
 });
 
 test('onDidChangeSecret should be fired when an item is inserted', async () => {
-  const storage = new SecretStorage(directoriesMock, encryptionServiceMock);
+  const storage = new SecretRegistry(directoriesMock, encryptionServiceMock);
 
   const listener = vi.fn();
   storage.onDidChangeSecret(listener);
@@ -217,7 +217,7 @@ test('onDidChangeSecret should be fired when an item is inserted', async () => {
 });
 
 test('onDidChangeSecret should be fired when multiple items are inserted', async () => {
-  const storage = new SecretStorage(directoriesMock, encryptionServiceMock);
+  const storage = new SecretRegistry(directoriesMock, encryptionServiceMock);
 
   const listener = vi.fn();
   storage.onDidChangeSecret(listener);

--- a/packages/main/src/plugin/storage/secret/secret-registry.spec.ts
+++ b/packages/main/src/plugin/storage/secret/secret-registry.spec.ts
@@ -1,0 +1,237 @@
+/**********************************************************************
+ * Copyright (C) 2022-2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
+import { SecretStorage } from '/@/plugin/storage/secret/secret-registry.js';
+import type { Directories } from '/@/plugin/directories.js';
+import type { IEncryptionService } from '/@/plugin/storage/encryption/encryptionService.js';
+
+const mocks = vi.hoisted(() => ({
+  getConfigurationDirectoryMock: vi.fn(),
+  existsSyncMock: vi.fn(),
+  mkdirSyncMock: vi.fn(),
+  readFileSyncMock: vi.fn(),
+  encryptMock: vi.fn(),
+  decryptMock: vi.fn(),
+  writeFileSyncMock: vi.fn(),
+}));
+
+beforeAll(() => {
+  // mock the fs module
+  vi.mock('node:fs');
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+const directoriesMock = {
+  getConfigurationDirectory: mocks.getConfigurationDirectoryMock,
+} as unknown as Directories;
+
+const encryptionServiceMock = {
+  encrypt: mocks.encryptMock,
+  decrypt: mocks.decryptMock,
+} as unknown as IEncryptionService;
+
+vi.mock('node:fs', async () => {
+  return {
+    existsSync: mocks.existsSyncMock,
+    mkdirSync: mocks.mkdirSyncMock,
+    readFileSync: mocks.readFileSyncMock,
+    writeFileSync: mocks.writeFileSyncMock,
+  };
+});
+
+test('keys should be empty when init not called', () => {
+  const storage = new SecretStorage(directoriesMock, encryptionServiceMock);
+  expect(storage.keys().length).toBe(0);
+});
+
+test('init should load from disk the existing file', async () => {
+  const storage = new SecretStorage(directoriesMock, encryptionServiceMock);
+
+  // Mock config path
+  mocks.getConfigurationDirectoryMock.mockReturnValue('dummy-path');
+  // Simulate the file exists
+  mocks.existsSyncMock.mockReturnValue(true);
+  // Mock empty object
+  mocks.readFileSyncMock.mockReturnValue('{}');
+
+  await storage.init();
+
+  expect(mocks.getConfigurationDirectoryMock).toHaveBeenCalled();
+  expect(mocks.readFileSyncMock).toHaveBeenCalled();
+
+  // When file exist, we do not call mkdir
+  expect(mocks.mkdirSyncMock).not.toHaveBeenCalled();
+
+  expect(storage.keys().length).toBe(0);
+});
+
+test('init should load from disk the existing secrets', async () => {
+  const storage = new SecretStorage(directoriesMock, encryptionServiceMock);
+
+  // Mock config path
+  mocks.getConfigurationDirectoryMock.mockReturnValue('dummy-path');
+  // Simulate the file exists
+  mocks.existsSyncMock.mockReturnValue(true);
+  // Mock empty object
+  mocks.readFileSyncMock.mockReturnValue('{"crypt-dummy-key": "\\"crypt-dummy-value\\""}');
+  // Mock decrypt service
+  mocks.decryptMock.mockImplementation(value => {
+    switch (value) {
+      case 'crypt-dummy-key':
+        return 'dummy-key';
+      case '"crypt-dummy-value"':
+        return '"dummy-value"';
+    }
+  });
+
+  await storage.init();
+
+  expect(mocks.getConfigurationDirectoryMock).toHaveBeenCalled();
+  expect(mocks.readFileSyncMock).toHaveBeenCalled();
+  expect(mocks.decryptMock).toHaveBeenCalledTimes(2); // one for the key, one for the value
+
+  // When file exist, we do not call mkdir
+  expect(mocks.mkdirSyncMock).not.toHaveBeenCalled();
+
+  expect(storage.keys().length).toBe(1);
+  expect(storage.get('dummy-key')).toBe('dummy-value');
+});
+
+test('save should save to disk the in-memory secrets', async () => {
+  const storage = new SecretStorage(directoriesMock, encryptionServiceMock);
+  // Mock decrypt service
+  mocks.encryptMock.mockImplementation(value => {
+    switch (value) {
+      case 'dummy-number-key':
+        return 'crypt-dummy-key';
+      case '85':
+        return 'crypt-85';
+    }
+  });
+
+  // Mock config path
+  mocks.getConfigurationDirectoryMock.mockReturnValue('dummy-path');
+  storage.store('dummy-number-key', 85);
+
+  await storage.save();
+
+  expect(mocks.writeFileSyncMock).toHaveBeenCalledWith(expect.any(String), '{"crypt-dummy-key":"crypt-85"}');
+});
+
+test('getNumber on string should raise an error', async () => {
+  const storage = new SecretStorage(directoriesMock, encryptionServiceMock);
+  storage.store('dummy', 'string');
+  expect(() => storage.getNumber('dummy')).toThrowError('wrong value type');
+});
+
+test('getBoolean on string should raise an error', async () => {
+  const storage = new SecretStorage(directoriesMock, encryptionServiceMock);
+  storage.store('dummy', 'string');
+  expect(() => storage.getBoolean('dummy')).toThrowError('wrong value type');
+});
+
+test('getObject on string should raise an error', async () => {
+  const storage = new SecretStorage(directoriesMock, encryptionServiceMock);
+  storage.store('dummy', 'string');
+  expect(() => storage.getObject('dummy')).toThrowError('wrong value type');
+});
+
+test('storeAll should store all the item provided', async () => {
+  const storage = new SecretStorage(directoriesMock, encryptionServiceMock);
+  storage.storeAll([
+    {
+      key: 'dummy-1',
+      value: 5,
+    },
+    {
+      key: 'dummy-2',
+      value: true,
+    },
+    {
+      key: 'dummy-3',
+      value: 'dummy-str',
+    },
+  ]);
+
+  expect(storage.getNumber('dummy-1')).toBe(5);
+  expect(storage.getBoolean('dummy-2')).toBe(true);
+  expect(storage.get('dummy-3')).toBe('dummy-str');
+});
+
+test('remove should remove the item', async () => {
+  const storage = new SecretStorage(directoriesMock, encryptionServiceMock);
+  storage.storeAll([
+    {
+      key: 'dummy-1',
+      value: 5,
+    },
+    {
+      key: 'dummy-2',
+      value: true,
+    },
+  ]);
+
+  storage.remove('dummy-1');
+
+  expect(storage.keys()).toStrictEqual(['dummy-2']);
+});
+
+test('onDidChangeSecret should be fired when an item is inserted', async () => {
+  const storage = new SecretStorage(directoriesMock, encryptionServiceMock);
+
+  const listener = vi.fn();
+  storage.onDidChangeSecret(listener);
+
+  storage.store('dummy', 'dummy-value');
+
+  expect(listener).toHaveBeenCalledWith([{ key: 'dummy' }]);
+});
+
+test('onDidChangeSecret should be fired when an item is inserted', async () => {
+  const storage = new SecretStorage(directoriesMock, encryptionServiceMock);
+
+  const listener = vi.fn();
+  storage.onDidChangeSecret(listener);
+
+  storage.store('dummy', 'dummy-value');
+
+  expect(listener).toHaveBeenCalledWith([{ key: 'dummy' }]);
+});
+
+test('onDidChangeSecret should be fired when multiple items are inserted', async () => {
+  const storage = new SecretStorage(directoriesMock, encryptionServiceMock);
+
+  const listener = vi.fn();
+  storage.onDidChangeSecret(listener);
+
+  storage.storeAll([
+    {
+      key: 'dummy-1',
+      value: 5,
+    },
+    {
+      key: 'dummy-2',
+      value: true,
+    },
+  ]);
+
+  expect(listener).toHaveBeenCalledWith([{ key: 'dummy-1' }, { key: 'dummy-2' }]);
+});

--- a/packages/main/src/plugin/storage/secret/secret-registry.ts
+++ b/packages/main/src/plugin/storage/secret/secret-registry.ts
@@ -1,0 +1,168 @@
+/**********************************************************************
+ * Copyright (C) 2022-2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { Emitter, type Event } from '../../events/emitter.js';
+import type {
+  IStorageEntry,
+  IStorageService,
+  IStorageValueChangeEvent,
+  StorageValue,
+} from '/@/plugin/storage/storage.js';
+import type { Directories } from '/@/plugin/directories.js';
+import path from 'path';
+import * as fs from 'node:fs';
+import type { NotificationCardOptions } from '/@/plugin/api/notification.js';
+import type { IEncryptionService } from '/@/plugin/storage/encryption/encryptionService.js';
+
+// Type guard functions for commonly used types
+const isString = (value: unknown): value is string => typeof value === 'string';
+const isNumber = (value: unknown): value is number => typeof value === 'number';
+const isBoolean = (value: unknown): value is boolean => typeof value === 'boolean';
+const isObject = (value: unknown): value is object => typeof value === 'object';
+
+export class SecretStorage implements IStorageService {
+  private readonly _onDidChangeSecret = new Emitter<IStorageValueChangeEvent[]>();
+  readonly onDidChangeSecret: Event<IStorageValueChangeEvent[]> = this._onDidChangeSecret.event;
+
+  readonly #secretsValues: Map<string, StorageValue>;
+
+  constructor(
+    private directories: Directories,
+    private encryptionService: IEncryptionService,
+  ) {
+    this.#secretsValues = new Map();
+  }
+
+  protected getSecretsFile(): string {
+    return path.resolve(this.directories.getConfigurationDirectory(), 'secrets.json');
+  }
+
+  protected async load(content: unknown): Promise<void> {
+    if (!content || typeof content !== 'object') throw new Error(`${this.getSecretsFile()} is not formatted properly.`);
+
+    const entries = Object.entries(content);
+    for (const [key, value] of entries) {
+      if (typeof value !== 'string') throw new Error(`malformed value for property ${key}. Only string are supported`);
+
+      try {
+        const decryptedKey = await this.encryptionService.decrypt(key);
+        const decryptedValue = await this.encryptionService.decrypt(value);
+        this.#secretsValues.set(decryptedKey, JSON.parse(decryptedValue));
+      } catch (err: unknown) {
+        console.error(`something went wrong while trying to decrypt property ${key}`);
+        throw err;
+      }
+    }
+  }
+
+  async save(): Promise<void> {
+    const output: Record<string, string> = {};
+    const entries = Array.from(this.#secretsValues.entries());
+    for (const [key, value] of entries) {
+      const cryptedKey = await this.encryptionService.encrypt(key);
+      const cryptedValue = await this.encryptionService.encrypt(JSON.stringify(value));
+      output[cryptedKey] = cryptedValue;
+    }
+    fs.writeFileSync(this.getSecretsFile(), JSON.stringify(output));
+  }
+
+  public async init(): Promise<NotificationCardOptions[]> {
+    const notifications: NotificationCardOptions[] = [];
+
+    const secretsFile = this.getSecretsFile();
+    const parentDirectory = path.dirname(secretsFile);
+    if (!fs.existsSync(parentDirectory)) {
+      // create directory if it does not exist
+      fs.mkdirSync(parentDirectory, { recursive: true });
+    }
+    if (!fs.existsSync(secretsFile)) {
+      fs.writeFileSync(secretsFile, JSON.stringify({}));
+    }
+
+    const secretsRawContent = fs.readFileSync(secretsFile, 'utf-8');
+    let configData: unknown;
+    try {
+      configData = JSON.parse(secretsRawContent);
+      await this.load(configData);
+    } catch (error) {
+      console.error(`Unable to parse ${secretsFile} file`, error);
+
+      const backupFilename = `${secretsFile}.backup-${Date.now()}`;
+      // keep original file as a backup
+      fs.cpSync(secretsFile, backupFilename);
+
+      // append notification for the user
+      notifications.push({
+        title: 'Corrupted secret file',
+        body: `Secret file located at ${secretsFile} was invalid. Created a copy at '${backupFilename}' and started with default settings.`,
+        extensionId: 'core',
+        type: 'warn',
+        highlight: true,
+        silent: true,
+      });
+    }
+
+    return notifications;
+  }
+
+  protected getAs<T>(key: string, typeGuard: (value: unknown) => value is T, fallbackValue?: T): T | undefined {
+    const value = this.#secretsValues.get(key);
+    if (!value) return fallbackValue;
+    if (!typeGuard(value)) throw new Error(`wrong value type`);
+    return value;
+  }
+
+  get(key: string, fallbackValue: string): string;
+  get(key: string, fallbackValue?: string | undefined): string | undefined;
+
+  get(key: string, fallbackValue?: string): string | undefined {
+    return this.getAs<string>(key, isString, fallbackValue);
+  }
+
+  getBoolean(key: string, fallbackValue: boolean): boolean;
+  getBoolean(key: string, fallbackValue?: boolean | undefined): boolean | undefined;
+  getBoolean(key: string, fallbackValue?: boolean): boolean | undefined {
+    return this.getAs<boolean>(key, isBoolean, fallbackValue);
+  }
+
+  getNumber(key: string, fallbackValue: number): number;
+  getNumber(key: string, fallbackValue?: number | undefined): number | undefined;
+  getNumber(key: string, fallbackValue?: number): number | undefined {
+    return this.getAs<number>(key, isNumber, fallbackValue);
+  }
+
+  getObject<T extends object>(key: string, fallbackValue: T): T;
+  getObject<T extends object>(key: string, fallbackValue?: T | undefined): T | undefined;
+  getObject<T extends object>(key: string, fallbackValue?: T): T | undefined {
+    return this.getAs<object>(key, isObject, fallbackValue) as T;
+  }
+  store(key: string, value: StorageValue): void {
+    this.storeAll([{ key, value }]);
+  }
+  storeAll(entries: IStorageEntry[]): void {
+    entries.forEach(entry => this.#secretsValues.set(entry.key, entry.value));
+    this._onDidChangeSecret.fire(entries.map(entry => ({ key: entry.key })));
+  }
+  remove(key: string): void {
+    this.#secretsValues.delete(key);
+    this._onDidChangeSecret.fire([{ key: key }]);
+  }
+  keys(): string[] {
+    return Array.from(this.#secretsValues.keys());
+  }
+}

--- a/packages/main/src/plugin/storage/secret/secret-registry.ts
+++ b/packages/main/src/plugin/storage/secret/secret-registry.ts
@@ -17,12 +17,7 @@
  ***********************************************************************/
 
 import { Emitter, type Event } from '../../events/emitter.js';
-import type {
-  IStorageEntry,
-  IStorageService,
-  IStorageValueChangeEvent,
-  StorageValue,
-} from '/@/plugin/storage/storage.js';
+import type { IStorageEntry, IStorage, IStorageValueChangeEvent, StorageValue } from '/@/plugin/storage/storage.js';
 import type { Directories } from '/@/plugin/directories.js';
 import path from 'path';
 import * as fs from 'node:fs';
@@ -35,7 +30,7 @@ const isNumber = (value: unknown): value is number => typeof value === 'number';
 const isBoolean = (value: unknown): value is boolean => typeof value === 'boolean';
 const isObject = (value: unknown): value is object => typeof value === 'object';
 
-export class SecretStorage implements IStorageService {
+export class SecretRegistry implements IStorage {
   private readonly _onDidChangeSecret = new Emitter<IStorageValueChangeEvent[]>();
   readonly onDidChangeSecret: Event<IStorageValueChangeEvent[]> = this._onDidChangeSecret.event;
 

--- a/packages/main/src/plugin/storage/storage.ts
+++ b/packages/main/src/plugin/storage/storage.ts
@@ -1,0 +1,98 @@
+/**********************************************************************
+ * Copyright (C) 2022-2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+// based on https://github.com/microsoft/vscode/blob/cff1e8e9a755d206fb33237bb6b6337d171471f2/src/vs/platform/storage/common/storage.ts
+
+import type { Event } from '/@/plugin/events/emitter.js';
+
+export interface IStorageValueChangeEvent {
+  /**
+   * The `key` of the storage entry that was changed
+   * or was removed.
+   */
+  readonly key: string;
+}
+
+export type StorageValue = string | boolean | number | undefined | null | object;
+
+export interface IStorageEntry {
+  readonly key: string;
+  readonly value: StorageValue;
+}
+
+export interface IStorageService {
+  readonly onDidChangeSecret: Event<IStorageValueChangeEvent[]>;
+
+  /**
+   * Retrieve an element stored with the given key from storage. Use
+   * the provided `defaultValue` if the element is `null` or `undefined`.
+   */
+  get(key: string, fallbackValue: string): string;
+  get(key: string, fallbackValue?: string): string | undefined;
+
+  /**
+   * Retrieve an element stored with the given key from storage. Use
+   * the provided `defaultValue` if the element is `null` or `undefined`.
+   * The element will be converted to a `boolean`.
+   */
+  getBoolean(key: string, fallbackValue: boolean): boolean;
+  getBoolean(key: string, fallbackValue?: boolean): boolean | undefined;
+
+  /**
+   * Retrieve an element stored with the given key from storage. Use
+   * the provided `defaultValue` if the element is `null` or `undefined`.
+   * The element will be converted to a `number` using `parseInt` with a
+   * base of `10`.
+   */
+  getNumber(key: string, fallbackValue: number): number;
+  getNumber(key: string, fallbackValue?: number): number | undefined;
+
+  /**
+   * Retrieve an element stored with the given key from storage. Use
+   * the provided `defaultValue` if the element is `null` or `undefined`.
+   * The element will be converted to a `object` using `JSON.parse`.
+   */
+  getObject<T extends object>(key: string, fallbackValue: T): T;
+  getObject<T extends object>(key: string, fallbackValue?: T): T | undefined;
+
+  /**
+   * Store a value under the given key to storage. The value will be
+   * converted to a `string`. Storing either `undefined` or `null` will
+   * remove the entry under the key.
+   */
+  store(key: string, value: StorageValue): void;
+
+  /**
+   * Allows to store multiple values in a bulk operation. Events will only
+   * be emitted when all values have been stored.
+   */
+  storeAll(entries: Array<IStorageEntry>): void;
+
+  /**
+   * Delete an element stored under the provided key from storage.
+   */
+  remove(key: string): void;
+
+  /**
+   * Returns all the keys used in the storage
+   */
+  keys(): string[];
+}

--- a/packages/main/src/plugin/storage/storage.ts
+++ b/packages/main/src/plugin/storage/storage.ts
@@ -38,7 +38,7 @@ export interface IStorageEntry {
   readonly value: StorageValue;
 }
 
-export interface IStorageService {
+export interface IStorage {
   readonly onDidChangeSecret: Event<IStorageValueChangeEvent[]>;
 
   /**


### PR DESCRIPTION
### What does this PR do?

This PR is adding a secret store, which will add a `secrets.json` file next to the `settings.json` file in a similar format but with encrypted _key/value_.

> This PR is not adding the api support, nor usage on the added classes (trying to keep things clear)

Some references links 
- [safe-storage in Electron](https://www.electronjs.org/docs/latest/api/safe-storage)
- [storage interface in vscode](https://github.com/microsoft/vscode/blob/05e5d4bb073221eb49c4f161d55ea4f48ff88958/src/vs/base/parts/storage/common/storage.ts#L77)
- [vscode encryptionMainService](https://github.com/microsoft/vscode/blob/main/src/vs/platform/encryption/electron-main/encryptionMainService.ts)

### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Part of https://github.com/containers/podman-desktop/issues/6044

### How to test this PR?

- [x] Unit tests has been added
