### PR TITLE
chore: use new api for open/save dialog

### DIFF
--- a/packages/renderer/src/lib/preferences/item-formats/FileItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/item-formats/FileItem.spec.ts
@@ -5,10 +5,10 @@ import type { IConfigurationPropertyRecordedSchema } from '../../../../../main/s
 import FileItem from './FileItem.svelte';
 import userEvent from '@testing-library/user-event';
 
-const openFileDialogMock = vi.fn();
+const openDialogMock = vi.fn();
 beforeAll(() => {
   (window as any).getConfigurationValue = vi.fn();
-  (window as any).openFileDialog = openFileDialogMock;
+  (window as any).openDialog = openDialogMock;
 });
 
 test('Ensure HTMLInputElement', async () => {
@@ -28,12 +28,8 @@ test('Ensure HTMLInputElement', async () => {
   expect(input instanceof HTMLInputElement).toBe(true);
 });
 
-test('Ensure clicking on Browser invoke openFileDialog', async () => {
-  openFileDialogMock.mockResolvedValue({
-    id: undefined,
-    canceled: true,
-    filePaths: [],
-  });
+test('Ensure clicking on Browser invoke openDialog', async () => {
+  openDialogMock.mockResolvedValue([]);
   const record: IConfigurationPropertyRecordedSchema = {
     id: 'record',
     title: 'record',
@@ -48,5 +44,5 @@ test('Ensure clicking on Browser invoke openFileDialog', async () => {
   expect(input).toBeInTheDocument();
   await userEvent.click(input);
 
-  expect(openFileDialogMock).toBeCalled();
+  expect(openDialogMock).toBeCalled();
 });

--- a/packages/renderer/src/lib/preferences/item-formats/FileItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/FileItem.svelte
@@ -10,9 +10,9 @@ let invalidEntry = false;
 
 async function selectFilePath() {
   invalidEntry = false;
-  const result = await window.openFileDialog(`Select ${record.description}`);
-  if (record.id && !result.canceled && result.filePaths.length === 1) {
-    onChange(record.id, result.filePaths[0]).catch((_: unknown) => (invalidEntry = true));
+  const filePaths = await window.openDialog({ title: `Select ${record.description}` });
+  if (record.id && filePaths && filePaths.length === 1) {
+    onChange(record.id, filePaths[0]).catch((_: unknown) => (invalidEntry = true));
   }
 }
 


### PR DESCRIPTION
### What does this PR do?
we introduced a new dialog registry with better hooks and that is allowing exposure to extensions
switch current code to use this new API

### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

https://github.com/containers/podman-desktop/issues/5987

### How to test this PR?

<!-- Please explain steps to reproduce -->
