### PR TITLE
chore: transparent background for input

### DIFF
--- a/packages/renderer/src/lib/ui/Input.spec.ts
+++ b/packages/renderer/src/lib/ui/Input.spec.ts
@@ -51,7 +51,7 @@ test('Expect basic styling', async () => {
   expect(element).toBeInTheDocument();
   expect(element).toHaveClass('px-1');
   expect(element).toHaveClass('outline-0');
-  expect(element).toHaveClass('bg-charcoal-500');
+  expect(element).toHaveClass('bg-transparent');
   expect(element).toHaveClass('text-sm');
   expect(element).toHaveClass('text-white');
 
@@ -60,9 +60,9 @@ test('Expect basic styling', async () => {
   expect(element).toHaveClass('group-hover-placeholder:text-gray-900');
 
   expect(element.parentElement).toBeInTheDocument();
-  expect(element.parentElement).toHaveClass('bg-charcoal-500');
+  expect(element.parentElement).toHaveClass('bg-transparent');
   expect(element.parentElement).toHaveClass('border-[1px]');
-  expect(element.parentElement).toHaveClass('border-charcoal-500');
+  expect(element.parentElement).toHaveClass('border-transparent');
 
   expect(element.parentElement).toHaveClass('hover:bg-charcoal-900');
   expect(element.parentElement).toHaveClass('hover:rounded-md');
@@ -77,7 +77,7 @@ test('Expect basic readonly styling', async () => {
   expect(element).toBeInTheDocument();
   expect(element).toHaveClass('px-1');
   expect(element).toHaveClass('outline-0');
-  expect(element).toHaveClass('bg-charcoal-500');
+  expect(element).toHaveClass('bg-transparent');
   expect(element).toHaveClass('text-sm');
   expect(element).toHaveClass('text-white');
 
@@ -86,9 +86,9 @@ test('Expect basic readonly styling', async () => {
   expect(element).not.toHaveClass('group-hover-placeholder:text-gray-900');
 
   expect(element.parentElement).toBeInTheDocument();
-  expect(element.parentElement).toHaveClass('bg-charcoal-500');
+  expect(element.parentElement).toHaveClass('bg-transparent');
   expect(element.parentElement).toHaveClass('border-[1px]');
-  expect(element.parentElement).toHaveClass('border-charcoal-500');
+  expect(element.parentElement).toHaveClass('border-transparent');
   expect(element.parentElement).toHaveClass('border-b-charcoal-100');
 
   expect(element.parentElement).not.toHaveClass('hover:bg-charcoal-900');
@@ -104,7 +104,7 @@ test('Expect basic disabled styling', async () => {
   expect(element).toBeInTheDocument();
   expect(element).toHaveClass('px-1');
   expect(element).toHaveClass('outline-0');
-  expect(element).toHaveClass('bg-charcoal-500');
+  expect(element).toHaveClass('bg-transparent');
   expect(element).toHaveClass('text-sm');
   expect(element).toHaveClass('text-gray-700');
 
@@ -113,9 +113,9 @@ test('Expect basic disabled styling', async () => {
   expect(element).not.toHaveClass('group-hover-placeholder:text-gray-900');
 
   expect(element.parentElement).toBeInTheDocument();
-  expect(element.parentElement).toHaveClass('bg-charcoal-500');
+  expect(element.parentElement).toHaveClass('bg-transparent');
   expect(element.parentElement).toHaveClass('border-[1px]');
-  expect(element.parentElement).toHaveClass('border-charcoal-500');
+  expect(element.parentElement).toHaveClass('border-transparent');
   expect(element.parentElement).toHaveClass('border-b-charcoal-100');
 
   expect(element.parentElement).not.toHaveClass('hover:bg-charcoal-900');

--- a/packages/renderer/src/lib/ui/Input.svelte
+++ b/packages/renderer/src/lib/ui/Input.svelte
@@ -15,6 +15,9 @@ export let error: string | undefined = undefined;
 
 export let element: HTMLInputElement | undefined = undefined;
 
+let enabled: boolean = true;
+$: enabled = !readonly && !disabled;
+
 const dispatch = createEventDispatcher();
 
 // clear the value if the parent doesn't override
@@ -32,29 +35,29 @@ async function onClear() {
 
 <div class="flex flex-col w-full">
   <div
-    class="flex flex-row w-full items-center px-1 py-1 group bg-charcoal-500 border-[1px] border-charcoal-500 {$$props.class ||
+    class="flex flex-row w-full items-center px-1 py-1 group bg-transparent border-[1px] border-transparent {$$props.class ||
       ''}"
-    class:hover:bg-charcoal-900="{!readonly && !disabled}"
-    class:focus-within:bg-charcoal-900="{!readonly && !disabled}"
-    class:hover:rounded-md="{!readonly && !disabled}"
-    class:focus-within:rounded-md="{!readonly && !disabled}"
-    class:border-b-purple-500="{!readonly && !disabled && !error}"
-    class:border-b-red-500="{!readonly && !disabled && error}"
-    class:hover:border-purple-400="{!readonly && !disabled && !error}"
-    class:hover:border-red-400="{!readonly && !disabled && error}"
-    class:focus-within:border-purple-500="{!readonly && !disabled && !error}"
-    class:focus-within:border-red-500="{!readonly && !disabled && error}"
+    class:hover:bg-charcoal-900="{enabled}"
+    class:focus-within:bg-charcoal-900="{enabled}"
+    class:hover:rounded-md="{enabled}"
+    class:focus-within:rounded-md="{enabled}"
+    class:border-b-purple-500="{enabled && !error}"
+    class:border-b-red-500="{enabled && error}"
+    class:hover:border-purple-400="{enabled && !error}"
+    class:hover:border-red-400="{enabled && error}"
+    class:focus-within:border-purple-500="{enabled && !error}"
+    class:focus-within:border-red-500="{enabled && error}"
     class:border-b-charcoal-100="{readonly || disabled}">
     <slot name="left" />
     <input
       bind:this="{element}"
       on:input
-      class="grow px-1 outline-0 bg-charcoal-500 text-sm placeholder:text-gray-700 overflow-hidden"
+      class="grow px-1 outline-0 text-sm bg-transparent placeholder:text-gray-700 overflow-hidden"
       class:text-white="{!disabled}"
       class:text-gray-700="{disabled}"
-      class:group-hover:bg-charcoal-900="{!readonly && !disabled}"
-      class:group-focus-within:bg-charcoal-900="{!readonly && !disabled}"
-      class:group-hover-placeholder:text-gray-900="{!readonly && !disabled}"
+      class:group-hover:bg-charcoal-900="{enabled}"
+      class:group-focus-within:bg-charcoal-900="{enabled}"
+      class:group-hover-placeholder:text-gray-900="{enabled}"
       name="{name}"
       type="text"
       disabled="{disabled}"


### PR DESCRIPTION
### What does this PR do?

The new Input component stands out a bit too much, especially when there are multiple Inputs in a form. After discussing the options, we decided to go with a transparent background, which gives a very clean look.

Added enabled flag to simplify readability of !readonly && !disabled.

### Screenshot / video of UI

https://github.com/containers/podman-desktop/assets/19958075/ba2c35e3-1c78-45b7-9dbb-b172b46b9795

### What issues does this PR fix or reference?

Fixes #5932.

### How to test this PR?

Tests updated, try search bar or any of the forms with inputs.