### PR TITLE
feat: consistent close button

### DIFF
--- a/packages/renderer/src/lib/dialogs/MessageBox.svelte
+++ b/packages/renderer/src/lib/dialogs/MessageBox.svelte
@@ -7,6 +7,7 @@ import type { MessageBoxOptions } from './messagebox-input';
 import Button from '../ui/Button.svelte';
 import type { ButtonType } from '../ui/Button';
 import { tabWithinParent } from './dialog-utils';
+import CloseButton from '/@/lib/ui/CloseButton.svelte';
 
 let currentId = 0;
 let title: string;
@@ -158,11 +159,7 @@ function getButtonType(b: boolean): ButtonType {
         {/if}
         <h1 class="grow text-lg font-bold capitalize">{title}</h1>
 
-        <button
-          class="p-2 hover:text-gray-300 hover:bg-charcoal-500 rounded-full cursor-pointer"
-          on:click="{() => clickButton(cancelId >= 0 ? cancelId : undefined)}">
-          <i class="fas fa-times" aria-hidden="true"></i>
-        </button>
+        <CloseButton on:click="{() => clickButton(cancelId >= 0 ? cancelId : undefined)}" />
       </div>
 
       <div class="max-h-80 overflow-auto">

--- a/packages/renderer/src/lib/feedback/SendFeedback.svelte
+++ b/packages/renderer/src/lib/feedback/SendFeedback.svelte
@@ -6,6 +6,7 @@ import type { FeedbackProperties } from '../../../../preload/src/index';
 import ErrorMessage from '../ui/ErrorMessage.svelte';
 import Button from '../ui/Button.svelte';
 import WarningMessage from '../ui/WarningMessage.svelte';
+import CloseButton from '/@/lib/ui/CloseButton.svelte';
 let displayModal = false;
 
 // feedback of the user
@@ -61,9 +62,7 @@ async function sendFeedback(): Promise<void> {
       <div class="flex items-center justify-between bg-black px-5 py-4 border-b-2 border-violet-700">
         <h1 class="text-xl font-bold">Share your feedback</h1>
 
-        <button class="hover:text-gray-300 px-2 py-1" on:click="{() => hideModal()}">
-          <i class="fas fa-times" aria-hidden="true"></i>
-        </button>
+        <CloseButton on:click="{() => hideModal()}" />
       </div>
 
       <div class="overflow-y-auto p-4">

--- a/packages/renderer/src/lib/image/PushImageModal.svelte
+++ b/packages/renderer/src/lib/image/PushImageModal.svelte
@@ -10,6 +10,7 @@ import Button from '../ui/Button.svelte';
 import Link from '../ui/Link.svelte';
 import { faCheckCircle, faTriangleExclamation, faCircleArrowUp } from '@fortawesome/free-solid-svg-icons';
 import Fa from 'svelte-fa';
+import CloseButton from '/@/lib/ui/CloseButton.svelte';
 
 export let closeCallback: () => void;
 export let imageInfoToPush: ImageInfoUI;
@@ -117,9 +118,7 @@ $: window.hasAuthconfigForImage(imageInfoToPush.name).then(result => (isAuthenti
     <div class="flex items-center justify-between px-6 py-5 space-x-2">
       <h1 class="grow text-lg font-bold">Push image</h1>
 
-      <button class="hover:text-gray-300 py-1" on:click="{() => closeCallback()}">
-        <i class="fas fa-times" aria-hidden="true"></i>
-      </button>
+      <CloseButton on:click="{() => closeCallback()}" />
     </div>
 
     <div class="flex flex-col px-6 py-4 pt-0 text-sm leading-5 space-y-5">

--- a/packages/renderer/src/lib/image/RenameImageModal.svelte
+++ b/packages/renderer/src/lib/image/RenameImageModal.svelte
@@ -6,6 +6,7 @@ import type { ImageInfoUI } from './ImageInfoUI';
 import ErrorMessage from '../ui/ErrorMessage.svelte';
 import Button from '../ui/Button.svelte';
 import Input from '/@/lib/ui/Input.svelte';
+import CloseButton from '/@/lib/ui/CloseButton.svelte';
 
 export let closeCallback: () => void;
 export let detailed = false;
@@ -71,9 +72,7 @@ async function renameImage(imageName: string, imageTag: string) {
     <div class="flex items-center justify-between px-6 py-5 space-x-2">
       <h1 class="grow text-lg font-bold capitalize">Edit Image</h1>
 
-      <button class="hover:text-gray-300 py-1" on:click="{() => closeCallback()}">
-        <i class="fas fa-times" aria-hidden="true"></i>
-      </button>
+      <CloseButton on:click="{() => closeCallback()}" />
     </div>
     <div class="flex flex-col px-10 py-4 text-sm leading-5 space-y-5">
       <div>

--- a/packages/renderer/src/lib/preferences/PreferencesProviderInstallationModal.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesProviderInstallationModal.svelte
@@ -5,6 +5,7 @@ import Modal from '../dialogs/Modal.svelte';
 import ProviderLogo from '../dashboard/ProviderLogo.svelte';
 import type { ProviderInfo, CheckStatus } from '../../../../main/src/plugin/api/provider-info';
 import Button from '../ui/Button.svelte';
+import CloseButton from '/@/lib/ui/CloseButton.svelte';
 
 export let providerToBeInstalled: { provider: ProviderInfo; displayName: string };
 export let preflightChecks: CheckStatus[];
@@ -25,9 +26,7 @@ function openLink(e: MouseEvent, url: string): void {
       aria-label="install provider">
       <div class="flex items-center justify-between px-5 py-4 mb-4">
         <h1 class="text-md font-semibold">Create a new {providerToBeInstalled.displayName}</h1>
-        <button class="hover:text-gray-300 px-2 py-1" aria-label="Close" on:click="{() => closeCallback()}">
-          <i class="fas fa-times" aria-hidden="true"></i>
-        </button>
+        <CloseButton class="px-2 py-1" on:click="{() => closeCallback()}" />
       </div>
       <div class="overflow-y-auto px-4 pb-4">
         <div class="flex flex-col rounded-lg">

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingPageStoreDetails.svelte
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingPageStoreDetails.svelte
@@ -6,6 +6,7 @@ import moment from 'moment';
 import humanizeDuration from 'humanize-duration';
 import Button from '../ui/Button.svelte';
 import { faRefresh, faTrash } from '@fortawesome/free-solid-svg-icons';
+import CloseButton from '/@/lib/ui/CloseButton.svelte';
 
 export let closeCallback: () => void;
 
@@ -32,9 +33,7 @@ async function fetch(): Promise<void> {
           <div class="mx-2">Details of {eventStoreInfo.name} store</div>
         </div>
       </h1>
-      <button class="hover:text-gray-300 px-2 py-1" aria-label="Close" on:click="{() => closeCallback()}">
-        <i class="fas fa-times" aria-hidden="true"></i>
-      </button>
+      <CloseButton on:click="{() => closeCallback()}" />
     </div>
     <div class="overflow-y-auto px-4 pb-4">
       <div class="flex flex-col rounded-lg">

--- a/packages/renderer/src/lib/ui/CloseButton.spec.ts
+++ b/packages/renderer/src/lib/ui/CloseButton.spec.ts
@@ -1,0 +1,84 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import '@testing-library/jest-dom/vitest';
+import { test, expect, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import CloseButton from '/@/lib/ui/CloseButton.svelte';
+import { router } from 'tinro';
+
+// mock the router
+vi.mock('tinro', () => {
+  return {
+    router: {
+      goto: vi.fn(),
+    },
+  };
+});
+
+test('Check button styling', async () => {
+  render(CloseButton);
+
+  // check for one element of the styling
+  const button = screen.getByRole('button');
+  expect(button).toBeInTheDocument();
+  expect(button).toHaveClass('text-gray-800');
+  expect(button).toHaveClass('hover:bg-white');
+  expect(button).toHaveClass('hover:bg-opacity-10');
+  expect(button).toHaveClass('transition-all');
+  expect(button).toHaveClass('rounded-[4px]');
+  expect(button).toHaveClass('p-1');
+  expect(button).toHaveClass('no-underline');
+  expect(button).toHaveClass('cursor-pointer');
+
+  expect(button.firstChild).toBeInTheDocument();
+  expect(button.firstChild).toHaveClass('svelte-fa');
+});
+
+test('Check local href action', async () => {
+  const urlMock = vi.fn();
+  (window as any).openExternal = urlMock;
+  render(CloseButton, { href: '/Pods' });
+
+  // check href link
+  const button = screen.getByRole('button');
+  expect(button).toBeInTheDocument();
+
+  fireEvent.click(button);
+
+  expect(router.goto).toBeCalledTimes(1);
+  expect(urlMock).not.toHaveBeenCalled();
+});
+
+test('Check on:click action', async () => {
+  const comp = render(CloseButton);
+
+  const clickMock = vi.fn();
+  comp.component.$on('click', clickMock);
+
+  // check on:click
+  const button = screen.getByRole('button');
+  expect(button).toBeInTheDocument();
+  expect(clickMock).not.toHaveBeenCalled();
+
+  fireEvent.click(button);
+
+  expect(clickMock).toBeCalledTimes(1);
+});

--- a/packages/renderer/src/lib/ui/CloseButton.svelte
+++ b/packages/renderer/src/lib/ui/CloseButton.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+import { faTimes } from '@fortawesome/free-solid-svg-icons';
+import { createEventDispatcher } from 'svelte';
+import Fa from 'svelte-fa';
+import { router } from 'tinro';
+
+export let href: string | undefined = undefined;
+
+const dispatch = createEventDispatcher<{ click: undefined }>();
+
+function click() {
+  if (href) {
+    router.goto(href);
+  } else {
+    dispatch('click');
+  }
+}
+</script>
+
+<button
+  type="button"
+  class="text-gray-800 hover:bg-white hover:bg-opacity-10 transition-all rounded-[4px] p-1 no-underline cursor-pointer {$$props.class ||
+    ''}"
+  on:click="{() => click()}"
+  title="Close"
+  aria-label="Close">
+  <Fa icon="{faTimes}" />
+</button>

--- a/packages/renderer/src/lib/ui/DetailsPage.spec.ts
+++ b/packages/renderer/src/lib/ui/DetailsPage.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023, 2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -87,7 +87,9 @@ test('Expect close link is defined', async () => {
 
   const closeElement = screen.getByTitle('Close');
   expect(closeElement).toBeInTheDocument();
-  expect(closeElement).toHaveAttribute('href', backPath);
+  await fireEvent.click(closeElement);
+
+  expect(router.goto).toHaveBeenCalledWith(backPath);
 });
 
 test('Expect Escape key closes', async () => {

--- a/packages/renderer/src/lib/ui/DetailsPage.svelte
+++ b/packages/renderer/src/lib/ui/DetailsPage.svelte
@@ -2,6 +2,7 @@
 import { lastPage, currentPage } from '../../stores/breadcrumb';
 import { router } from 'tinro';
 import Link from './Link.svelte';
+import CloseButton from '/@/lib/ui/CloseButton.svelte';
 
 export let title: string;
 export let titleDetail: string | undefined = undefined;
@@ -29,9 +30,7 @@ function handleKeydown(e: KeyboardEvent) {
           >{$lastPage.name}</Link>
         <div class="mx-2">&gt;</div>
         <div class="grow font-extralight" aria-label="name">{$currentPage.name}</div>
-        <a href="{$lastPage.path}" title="Close" class="justify-self-end text-gray-900">
-          <i class="fas fa-times" aria-hidden="true"></i>
-        </a>
+        <CloseButton href="{$lastPage.path}" class="justify-self-end" />
       </div>
       <div class="flex flex-row items-start pt-1">
         <div class="pr-3">

--- a/packages/renderer/src/lib/ui/FormPage.spec.ts
+++ b/packages/renderer/src/lib/ui/FormPage.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023, 2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -100,7 +100,9 @@ test('Expect close link is defined', async () => {
 
   const closeElement = screen.getByTitle('Close');
   expect(closeElement).toBeInTheDocument();
-  expect(closeElement).toHaveAttribute('href', backPath);
+  await fireEvent.click(closeElement);
+
+  expect(router.goto).toHaveBeenCalledWith(backPath);
 });
 
 test('Expect Escape key works', async () => {

--- a/packages/renderer/src/lib/ui/FormPage.svelte
+++ b/packages/renderer/src/lib/ui/FormPage.svelte
@@ -3,6 +3,7 @@ import { lastPage, currentPage } from '../../stores/breadcrumb';
 import { router } from 'tinro';
 import Link from './Link.svelte';
 import LinearProgress from './LinearProgress.svelte';
+import CloseButton from '/@/lib/ui/CloseButton.svelte';
 
 export let title: string;
 export let showBreadcrumb = true;
@@ -31,9 +32,7 @@ function handleKeydown(e: KeyboardEvent) {
             >{$lastPage.name}</Link>
           <div class="mx-2">&gt;</div>
           <div class="grow font-extralight" aria-label="name">{$currentPage.name}</div>
-          <a href="{$lastPage.path}" title="Close" class="justify-self-end text-gray-900">
-            <i class="fas fa-times" aria-hidden="true"></i>
-          </a>
+          <CloseButton href="{$lastPage.path}" class="justify-self-end" />
         </div>
       {/if}
       <div class="flex flex-row items-center pt-1">
@@ -50,9 +49,7 @@ function handleKeydown(e: KeyboardEvent) {
             </div>
           {/if}
           {#if !showBreadcrumb}
-            <a href="{$lastPage.path}" title="Close" class="text-gray-900">
-              <i class="fas fa-times" aria-hidden="true"></i>
-            </a>
+            <CloseButton href="{$lastPage.path}" />
           {/if}
         </div>
       </div>


### PR DESCRIPTION
### What does this PR do?

We have 9 close buttons that I could find in Podman Desktop. They were at least 3 different colors, 6 of them changed color when you hover, and one hover changed the hover background too. Except for the one, the lack of/inconsistent hover indication was standing out to me compared with our Links and Buttons.

This provides a common CloseButton component in a medium-dark gray. On hover, it goes white and has the same bg as a Link (but slightly larger since the icon is small). The button accepts either an href or an on:click action to support our different uses.

I've made a call here that all close buttons look the same, instead of leaving those on dialogs/modals white. IMHO this consistency is better, allows the hover indication to be more clear, and we don't need to highlight the Close button in any of these places.

Although we might normally divide up the component + usage in two PRs, the amount of change here wasn't big and I thought it's important to see it in all of the contexts, so I've included both and can split up if requested.

### Screenshot / video of UI

Before:

https://github.com/containers/podman-desktop/assets/19958075/1371cdea-c40d-47f6-8d1f-f195604caeae

After:

https://github.com/containers/podman-desktop/assets/19958075/2904dcb4-5e92-4f0e-b3d8-a7c17591c13b

### What issues does this PR fix or reference?

Fixes #2352.

### How to test this PR?

Unit tests updated. Try modal dialogs, message boxes, and form/detail pages.