### PR TITLE
chore: Add windows instructions for emulating docker cli

### DIFF
--- a/website/docs/migrating-from-docker/emulating-docker-cli-with-podman.md
+++ b/website/docs/migrating-from-docker/emulating-docker-cli-with-podman.md
@@ -18,6 +18,8 @@ Consider emulating Docker CLI with Podman to migrate transparently to Podman.
 
 - Podman
 
+### Linux
+
 #### Procedure
 
 1. Create a `/usr/local/bin/docker` script:
@@ -49,3 +51,27 @@ Consider emulating Docker CLI with Podman to migrate transparently to Podman.
   ```shell-session
   $ docker run -it docker.io/hello-world
   ```
+
+### Windows
+
+#### Procedure
+
+1. Create a `C:\Program Files\docker\bin\docker.bat` script:
+
+   ```batch
+   @echo off
+   echo Emulate Docker CLI using podman. <- remove this line to avoid the  `Emulate Docker CLI using podman.` message when running the script.
+   podman %*
+   ```
+2. Add C:\Program Files\docker\bin to the SYSTEM/USER environment variable PATH
+3. Close all cmd and powershell instances.
+
+#### Verification
+
+- Use the `docker` script to run commands.
+  Example:
+
+  ```PowerShell
+  $ docker run -it docker.io/hello-world
+  ```
+

--- a/website/docs/migrating-from-docker/emulating-docker-cli-with-podman.md
+++ b/website/docs/migrating-from-docker/emulating-docker-cli-with-podman.md
@@ -63,6 +63,7 @@ Consider emulating Docker CLI with Podman to migrate transparently to Podman.
    echo Emulate Docker CLI using podman. <- remove this line to avoid the  `Emulate Docker CLI using podman.` message when running the script.
    podman %*
    ```
+
 2. Add C:\Program Files\docker\bin to the SYSTEM/USER environment variable PATH
 3. Close all cmd and powershell instances.
 
@@ -74,4 +75,3 @@ Consider emulating Docker CLI with Podman to migrate transparently to Podman.
   ```PowerShell
   $ docker run -it docker.io/hello-world
   ```
-

--- a/website/docs/migrating-from-docker/emulating-docker-cli-with-podman.md
+++ b/website/docs/migrating-from-docker/emulating-docker-cli-with-podman.md
@@ -18,7 +18,7 @@ Consider emulating Docker CLI with Podman to migrate transparently to Podman.
 
 - Podman
 
-### Linux
+### Linux / macOS
 
 #### Procedure
 


### PR DESCRIPTION
### What does this PR do?
Add instructions for aliasing docker to podman in windows.
### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?
follow the instructions in windows after using Podman Desktop to install podman, then use docker ps or another docker command to see if the `Emulate Docker CLI using podman.` line shows up.
<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
