### PR TITLE
feat: improve Podman-Desktop update alert

### DIFF
--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -158,8 +158,8 @@ import type { ColorInfo } from './api/color-info.js';
 import { ColorRegistry } from './color-registry.js';
 import { DialogRegistry } from './dialog-registry.js';
 import type { Deferred } from './util/deferred.js';
-import { Updater } from '/@/plugin/updater.js';
 import type { ContextGeneralState, ResourceName } from './kubernetes-context-state.js';
+import { Updater } from '/@/plugin/updater.js';
 
 type LogType = 'log' | 'warn' | 'trace' | 'debug' | 'error';
 
@@ -523,7 +523,7 @@ export class PluginSystem {
     );
 
     // Init update logic
-    new Updater(messageBox, statusBarRegistry, commandRegistry).init();
+    new Updater(messageBox, configurationRegistry, statusBarRegistry, commandRegistry).init();
 
     commandRegistry.registerCommand('feedback', () => {
       apiSender.send('display-feedback', '');

--- a/packages/main/src/plugin/updater.spec.ts
+++ b/packages/main/src/plugin/updater.spec.ts
@@ -222,7 +222,7 @@ test('expect command update to be called when configuration value on startup', (
   mListener?.();
 
   expect(configurationRegistryMock.getConfiguration).toHaveBeenCalled();
-  expect(commandRegistryMock.executeCommand).toHaveBeenCalledWith('update');
+  expect(commandRegistryMock.executeCommand).toHaveBeenCalledWith('update', 'startup');
 });
 
 test('expect command update not to be called when configuration value on never', () => {

--- a/packages/main/src/plugin/updater.spec.ts
+++ b/packages/main/src/plugin/updater.spec.ts
@@ -27,6 +27,8 @@ import { app } from 'electron';
 import { type AppUpdater, autoUpdater } from 'electron-updater';
 import * as util from '/@/util.js';
 import type { AppUpdaterEvents } from 'electron-updater/out/AppUpdater.js';
+import type { ConfigurationRegistry } from '/@/plugin/configuration-registry.js';
+import type { Configuration } from '@podman-desktop/api';
 
 vi.mock('electron', () => ({
   app: {
@@ -52,11 +54,22 @@ const messageBoxMock = {
   showMessageBox: vi.fn(),
 } as unknown as MessageBox;
 
+const configurationMock = {
+  get: vi.fn(),
+  has: vi.fn(),
+  update: vi.fn(),
+} as unknown as Configuration;
+
+const configurationRegistryMock = {
+  registerConfigurations: vi.fn(),
+  getConfiguration: vi.fn(),
+} as unknown as ConfigurationRegistry;
+
 const statusBarRegistryMock = {
   setEntry: vi.fn(),
 } as unknown as StatusBarRegistry;
 
-const commandRegistry = {
+const commandRegistryMock = {
   registerCommand: vi.fn(),
   executeCommand: vi.fn(),
 } as unknown as CommandRegistry;
@@ -72,8 +85,12 @@ beforeEach(() => {
   // eslint-disable-next-line no-null/no-null
   vi.mocked(autoUpdater.checkForUpdates).mockResolvedValue(null);
 
-  vi.mocked(commandRegistry.executeCommand).mockResolvedValue(undefined);
+  vi.mocked(commandRegistryMock.executeCommand).mockResolvedValue(undefined);
   vi.mocked(util.isLinux).mockReturnValue(false);
+
+  vi.mocked(configurationMock.get).mockReturnValue('never');
+  vi.mocked(configurationMock.update).mockResolvedValue(undefined);
+  vi.mocked(configurationRegistryMock.getConfiguration).mockReturnValue(configurationMock);
 });
 
 test('expect env PROD to be truthy', () => {
@@ -81,15 +98,20 @@ test('expect env PROD to be truthy', () => {
 });
 
 test('expect init to provide a disposable', () => {
-  const updater = new Updater(messageBoxMock, statusBarRegistryMock, commandRegistry);
+  const updater = new Updater(messageBoxMock, configurationRegistryMock, statusBarRegistryMock, commandRegistryMock);
   const disposable: unknown = updater.init();
   expect(disposable).toBeDefined();
   expect(disposable instanceof Disposable).toBeTruthy();
 });
 
 test('expect init to register commands', () => {
-  new Updater(messageBoxMock, statusBarRegistryMock, commandRegistry).init();
-  expect(commandRegistry.registerCommand).toHaveBeenCalled();
+  new Updater(messageBoxMock, configurationRegistryMock, statusBarRegistryMock, commandRegistryMock).init();
+  expect(commandRegistryMock.registerCommand).toHaveBeenCalled();
+});
+
+test('expect init to register configuration', () => {
+  new Updater(messageBoxMock, configurationRegistryMock, statusBarRegistryMock, commandRegistryMock).init();
+  expect(configurationRegistryMock.registerConfigurations).toHaveBeenCalled();
 });
 
 test('expect update available entry to be displayed when expected', () => {
@@ -112,7 +134,7 @@ test('expect update available entry to be displayed when expected', () => {
     return {} as unknown as AppUpdater;
   });
 
-  new Updater(messageBoxMock, statusBarRegistryMock, commandRegistry).init();
+  new Updater(messageBoxMock, configurationRegistryMock, statusBarRegistryMock, commandRegistryMock).init();
 
   // listener should exist
   expect(mListener).toBeDefined();
@@ -143,7 +165,7 @@ test('expect default status entry to be displayed when no update available', () 
     return {} as unknown as AppUpdater;
   });
 
-  new Updater(messageBoxMock, statusBarRegistryMock, commandRegistry).init();
+  new Updater(messageBoxMock, configurationRegistryMock, statusBarRegistryMock, commandRegistryMock).init();
 
   // listener should exist
   expect(mListener).toBeDefined();
@@ -174,7 +196,7 @@ test('expect default status entry when error No published versions on GitHub', (
     return {} as unknown as AppUpdater;
   });
 
-  new Updater(messageBoxMock, statusBarRegistryMock, commandRegistry).init();
+  new Updater(messageBoxMock, configurationRegistryMock, statusBarRegistryMock, commandRegistryMock).init();
 
   // listener should exist
   expect(mListener).toBeDefined();
@@ -183,4 +205,61 @@ test('expect default status entry when error No published versions on GitHub', (
   mListener?.(new Error('No published versions on GitHub'));
 
   expect(setEntryMock).toHaveBeenCalled();
+});
+
+test('expect command update to be called when configuration value on startup', () => {
+  let mListener: (() => void) | undefined;
+  vi.spyOn(autoUpdater, 'on').mockImplementation((channel: keyof AppUpdaterEvents, listener: unknown): AppUpdater => {
+    if (channel === 'update-available') mListener = listener as () => void;
+    return {} as unknown as AppUpdater;
+  });
+
+  vi.mocked(configurationMock.get).mockReturnValue('startup');
+
+  new Updater(messageBoxMock, configurationRegistryMock, statusBarRegistryMock, commandRegistryMock).init();
+
+  // call the listener (which should be the private updateAvailableEntry method)
+  mListener?.();
+
+  expect(configurationRegistryMock.getConfiguration).toHaveBeenCalled();
+  expect(commandRegistryMock.executeCommand).toHaveBeenCalledWith('update');
+});
+
+test('expect command update not to be called when configuration value on never', () => {
+  let mListener: (() => void) | undefined;
+  vi.spyOn(autoUpdater, 'on').mockImplementation((channel: keyof AppUpdaterEvents, listener: unknown): AppUpdater => {
+    if (channel === 'update-available') mListener = listener as () => void;
+    return {} as unknown as AppUpdater;
+  });
+
+  vi.mocked(configurationMock.get).mockReturnValue('never');
+
+  new Updater(messageBoxMock, configurationRegistryMock, statusBarRegistryMock, commandRegistryMock).init();
+
+  // call the listener (which should be the private updateAvailableEntry method)
+  mListener?.();
+
+  expect(configurationRegistryMock.getConfiguration).toHaveBeenCalled();
+  expect(commandRegistryMock.executeCommand).not.toHaveBeenCalled();
+});
+
+test('clicking on "Update Never" should set the configuration value to never', async () => {
+  vi.mocked(messageBoxMock.showMessageBox).mockResolvedValue({
+    response: 2, // Update never
+  });
+
+  let mListener: (() => Promise<void>) | undefined;
+  vi.mocked(commandRegistryMock.registerCommand).mockImplementation(
+    (channel: string, listener: () => Promise<void>) => {
+      if (channel === 'update') mListener = listener;
+      return Disposable.noop();
+    },
+  );
+
+  new Updater(messageBoxMock, configurationRegistryMock, statusBarRegistryMock, commandRegistryMock).init();
+  expect(mListener).toBeDefined();
+
+  await mListener?.();
+
+  expect(configurationMock.update).toHaveBeenCalledWith('update.reminder', 'never');
 });

--- a/packages/main/src/plugin/updater.ts
+++ b/packages/main/src/plugin/updater.ts
@@ -138,19 +138,20 @@ export class Updater {
 
       const result = await this.messageBox.showMessageBox({
         type: 'info',
-        title: 'Update Available',
+        title: 'Update Available now',
         message: `A new version ${updateVersion} of Podman Desktop is available. Do you want to update your current version ${this.#currentVersion}?`,
-        buttons: ['Update', 'Cancel'],
-        cancelId: 1,
+        buttons: ['Update now', 'Update later', 'Update never'],
       });
-      if (result.response === 0) {
+      if (result.response === 2) {
+        this.updateConfigurationValue('never');
+      } else if (result.response === 0) {
         this.#updateInProgress = true;
         this.#updateAlreadyDownloaded = false;
 
         // Download update and try / catch it and create a dialog if it fails
         try {
           await autoUpdater.downloadUpdate();
-        } catch (error) {
+        } catch (error: unknown) {
           console.error('Update error: ', error);
           await this.messageBox.showMessageBox({
             type: 'error',
@@ -176,7 +177,7 @@ export class Updater {
   }
 
   /**
-   * Handler for update not available event.
+   * Registers configuration settings for update preferences.
    */
   private registerConfiguration() {
     this.configurationRegistry.registerConfigurations([
@@ -196,6 +197,10 @@ export class Updater {
     ]);
   }
 
+  /**
+   * Retrieves the value of the update reminder configuration.
+   * @returns The value of the update reminder configuration.
+   */
   private getConfigurationValue(): 'startup' | 'never' {
     const value = this.configurationRegistry.getConfiguration('preferences').get('update.reminder');
     if (value !== 'startup' && value !== 'never')
@@ -203,6 +208,10 @@ export class Updater {
     return value;
   }
 
+  /**
+   * Updates the value of the update reminder configuration.
+   * @param value - The new value for the update reminder configuration.
+   */
   private updateConfigurationValue(value: 'startup' | 'never'): void {
     this.configurationRegistry
       .getConfiguration('preferences')
@@ -212,6 +221,9 @@ export class Updater {
       });
   }
 
+  /**
+   * Handler for update not available event.
+   */
   private onUpdateNotAvailable(): void {
     this.#updateInProgress = false;
     this.#updateAlreadyDownloaded = false;

--- a/packages/main/src/plugin/updater.ts
+++ b/packages/main/src/plugin/updater.ts
@@ -179,7 +179,7 @@ export class Updater {
   /**
    * Registers configuration settings for update preferences.
    */
-  private registerConfiguration() {
+  private registerConfiguration(): void {
     this.configurationRegistry.registerConfigurations([
       {
         id: 'preferences.update',


### PR DESCRIPTION
### What does this PR do?

According to https://github.com/containers/podman-desktop/issues/5754.

When an update is available
- [x] If user is just starting up Podman Desktop from fresh, have a pop up dialog
- [x] if an update occurs a popup is spawned

A new preference section called `Update` has a property `reminer` with two value `startup` or `never`.

### Screenshot / video of UI

#### starting `podman-desktop`

![image](https://github.com/containers/podman-desktop/assets/42176370/74927352-74e7-4ba2-9c54-be070e990b27)

#### Clicking on status bar item when update available (status bar item)

![image](https://github.com/containers/podman-desktop/assets/42176370/7b48c400-a5ce-42df-b11e-2653fc3562b7)



### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop/issues/5754

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature

**Testing manually**

(1) change the version to `1.6.5` in the `package.json` at the root
(2) run `yarn compile:current`
(3) go to `dist` folder and start the portable executable

(Thx to @benoitf for this method)