### PR TITLE
fix: center empty screens

### DIFF
--- a/packages/renderer/src/lib/image/BuildImageFromContainerfile.svelte
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfile.svelte
@@ -154,7 +154,7 @@ async function abortBuild() {
   <svelte:fragment slot="icon">
     <i class="fas fa-cube fa-2x" aria-hidden="true"></i>
   </svelte:fragment>
-  <div slot="content" class="p-5 min-w-full h-fit">
+  <div slot="content" class="p-5 min-w-full h-full">
     {#if providerConnections.length === 0}
       <NoContainerEngineEmptyScreen />
     {:else}

--- a/packages/renderer/src/lib/image/PullImage.svelte
+++ b/packages/renderer/src/lib/image/PullImage.svelte
@@ -142,7 +142,7 @@ function requestFocus(element: HTMLInputElement) {
     <Button on:click="{() => gotoManageRegistries()}" icon="{faCog}">Manage registries</Button>
   </svelte:fragment>
 
-  <div slot="content" class="p-5 min-w-full h-fit">
+  <div slot="content" class="p-5 min-w-full h-full">
     {#if providerConnections.length === 0}
       <NoContainerEngineEmptyScreen />
     {:else}

--- a/packages/renderer/src/lib/volume/CreateVolume.svelte
+++ b/packages/renderer/src/lib/volume/CreateVolume.svelte
@@ -60,7 +60,7 @@ export let volumeName = '';
   <svelte:fragment slot="icon">
     <VolumeIcon />
   </svelte:fragment>
-  <div slot="content" class="p-5 min-w-full h-fit">
+  <div slot="content" class="p-5 min-w-full h-full">
     {#if providerConnections.length === 0}
       <NoContainerEngineEmptyScreen />
     {:else}


### PR DESCRIPTION
### What does this PR do?

The pull/build image forms do not center the 'empty screen'. The difference between them and other forms is h-fit vs h-full, changing this fixes the issue and doesn't cause any regression when not showing the empty screen.

Create volume has the same issue - although it's not available when there is no container engine I thought we should keep the forms consistent.

### Screenshot / video of UI

<img width="637" alt="Screenshot 2024-02-20 at 11 15 03 AM" src="https://github.com/containers/podman-desktop/assets/19958075/895a6256-e288-4c58-8479-0e6d52e1ee76">

### What issues does this PR fix or reference?

Fixes #6059.

### How to test this PR?

Easiest way to test is to disable the Podman extension.