### PR TITLE
nit: improve kubernetes http error reporting

### DIFF
--- a/packages/main/src/plugin/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes-client.ts
@@ -1166,9 +1166,19 @@ export class KubernetesClient {
       telemetryOptions.error = error;
       if (error instanceof HttpError) {
         const httpError = error as HttpError;
+
+        // If there is a "message" in the body of the http error, throw that
+        // as that's where Kubernetes tends to put the error message
+        if (httpError.body?.message) {
+          throw new Error(httpError.body.message);
+        }
+
+        // Otherwise, throw the "generic" HTTP error message
         if (httpError.message) {
           throw new Error(httpError.message);
         }
+
+        // If all else fails, throw the body of the error
         throw new Error(httpError.body);
       }
       throw error;


### PR DESCRIPTION
nit: improve kubernetes http error reporting

### What does this PR do?

* Check to see if there is a message in the "body" of the HTTP request
  and return that instead. This contains the actual "error" message of
  the Kubernetes API
* Added tests
* If there is no message in the body, return the standard message.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/A

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop/issues/6085

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
