### PR TITLE
nit: Remove Kubernetes YAML button from Containers page

### DIFF
--- a/packages/renderer/src/lib/container/ContainerList.svelte
+++ b/packages/renderer/src/lib/container/ContainerList.svelte
@@ -25,7 +25,6 @@ import Fa from 'svelte-fa';
 import ErrorMessage from '../ui/ErrorMessage.svelte';
 import { podCreationHolder } from '../../stores/creation-from-containers-store';
 import { podsInfos } from '../../stores/pods';
-import KubePlayButton from '../kube/KubePlayButton.svelte';
 import Prune from '../engine/Prune.svelte';
 import type { EngineInfoUI } from '../engine/EngineInfoUI';
 import { containerGroupsInfo } from '../../stores/containerGroups';
@@ -62,13 +61,6 @@ function fromExistingImage(): void {
 $: providerConnections = $providerInfos
   .map(provider => provider.containerConnections)
   .flat()
-  .filter(providerContainerConnection => providerContainerConnection.status === 'started');
-
-$: providerPodmanConnections = $providerInfos
-  .map(provider => provider.containerConnections)
-  .flat()
-  // keep only podman providers as it is not supported by docker
-  .filter(providerContainerConnection => providerContainerConnection.type === 'podman')
   .filter(providerContainerConnection => providerContainerConnection.status === 'started');
 
 // number of selected items in the list
@@ -439,9 +431,6 @@ function setStoppedFilter() {
     <!-- Only show if there are containers-->
     {#if $containersInfos.length > 0}
       <Prune type="containers" engines="{enginesList}" />
-    {/if}
-    {#if providerPodmanConnections.length > 0}
-      <KubePlayButton />
     {/if}
     <Button on:click="{() => toggleCreateContainer()}" icon="{faPlusCircle}" title="Create a container">Create</Button>
   </svelte:fragment>


### PR DESCRIPTION
nit: Remove Kubernetes YAML button from Containers page

### What does this PR do?

Play Kubernetes YAML button within Containers does not make sense as the
button deploys **pods** only (on both Podman engine and Kubernetes).

With the upcoming Kubernetes features, it makes sense to have this only
on the Pods section.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->
![Screenshot 2024-02-21 at 4 21 53 PM](https://github.com/containers/podman-desktop/assets/6422176/8dd969d6-d0b4-4951-b648-1948530e0ff3)



### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop/issues/5802

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

Check the button is no longer there.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
