### PR TITLE
nit: Fix description of Kubernetes Play YAML

### DIFF
--- a/packages/renderer/src/lib/kube/KubePlayYAML.svelte
+++ b/packages/renderer/src/lib/kube/KubePlayYAML.svelte
@@ -166,7 +166,7 @@ async function getKubernetesfileLocation() {
 {/if}
 
 {#if providerConnections.length > 0}
-  <FormPage title="Play Pods or Containers from a Kubernetes YAML File" inProgress="{runStarted && !runFinished}">
+  <FormPage title="Create pods from a Kubernetes YAML file" inProgress="{runStarted && !runFinished}">
     <KubePlayIcon slot="icon" size="30px" />
 
     <div slot="content" class="p-5 min-w-full h-fit">
@@ -188,7 +188,7 @@ async function getKubernetesfileLocation() {
         </div>
 
         <div>
-          <div class="text-sm font-bold text-gray-400 pb-2">Select Runtime:</div>
+          <div class="text-sm font-bold text-gray-400 pb-2">Select runtime:</div>
 
           <div class="px-5">
             <div class="flex flex-col space-y-3">


### PR DESCRIPTION
nit: Fix description of Kubernetes Play YAML

### What does this PR do?

Fixes the description. We do not create standalone containers, but pods
instead.

Also fixes the capitalization of the title (form page titles don't use
"heading" capitalization)

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/A, minor change

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Ref https://github.com/containers/podman-desktop/issues/5802

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

Press "Play Kubernetes YAML" button and see the page.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
