### PR TITLE
nit: Change order of "Create" button on Volumes and Containers list

### DIFF
--- a/packages/renderer/src/lib/container/ContainerList.svelte
+++ b/packages/renderer/src/lib/container/ContainerList.svelte
@@ -440,10 +440,10 @@ function setStoppedFilter() {
     {#if $containersInfos.length > 0}
       <Prune type="containers" engines="{enginesList}" />
     {/if}
-    <Button on:click="{() => toggleCreateContainer()}" icon="{faPlusCircle}" title="Create a container">Create</Button>
     {#if providerPodmanConnections.length > 0}
       <KubePlayButton />
     {/if}
+    <Button on:click="{() => toggleCreateContainer()}" icon="{faPlusCircle}" title="Create a container">Create</Button>
   </svelte:fragment>
   <svelte:fragment slot="bottom-additional-actions">
     {#if selectedItemsNumber > 0}

--- a/packages/renderer/src/lib/volume/VolumesList.svelte
+++ b/packages/renderer/src/lib/volume/VolumesList.svelte
@@ -227,9 +227,6 @@ const row = new Row<VolumeInfoUI>({
 
 <NavPage bind:searchTerm="{searchTerm}" title="volumes">
   <svelte:fragment slot="additional-actions">
-    {#if providerConnections.length > 0}
-      <Button on:click="{() => gotoCreateVolume()}" icon="{faPlusCircle}" title="Create a volume">Create</Button>
-    {/if}
     {#if $volumeListInfos.map(volumeInfo => volumeInfo.Volumes).flat().length > 0}
       <Prune type="volumes" engines="{enginesList}" />
 
@@ -238,6 +235,9 @@ const row = new Row<VolumeInfoUI>({
         on:click="{() => fetchUsageData()}"
         title="Collect usage data for volumes. It can take a while..."
         icon="{faPieChart}">Collect usage data</Button>
+    {/if}
+    {#if providerConnections.length > 0}
+      <Button on:click="{() => gotoCreateVolume()}" icon="{faPlusCircle}" title="Create a volume">Create</Button>
     {/if}
   </svelte:fragment>
 


### PR DESCRIPTION
nit: Fix order of "Create" button on Volumes and Containers list

### What does this PR do?

Have the "Create" button always be the top right button.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

![Screenshot 2024-02-21 at 4 34 16 PM](https://github.com/containers/podman-desktop/assets/6422176/9550ce7d-e15a-4e9a-9faf-d5dfbe3111d3)
![Screenshot 2024-02-21 at 4 34 57 PM](https://github.com/containers/podman-desktop/assets/6422176/37d722c3-7ebb-4c14-b634-a0c8a47528e8)


### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop/issues/4397

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

View Containers / Volumes and see that it is the right-most button now.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
