### PR TITLE
Make informers used for kubernetes contexts send resources data

### DIFF
--- a/packages/main/src/plugin/kubernetes-context-state.spec.ts
+++ b/packages/main/src/plugin/kubernetes-context-state.spec.ts
@@ -167,26 +167,34 @@ test('should send info of resources in all reachable contexts and nothing in non
   expectedMap.set('context1', {
     reachable: false,
     error: 'Error: connection error',
-    podsCount: 0,
-    deploymentsCount: 0,
+    resources: {
+      pods: 0,
+      deployments: 0,
+    },
   } as ContextState);
   expectedMap.set('context2', {
     reachable: true,
     error: undefined,
-    podsCount: 9,
-    deploymentsCount: 19,
+    resources: {
+      pods: 9,
+      deployments: 19,
+    },
   } as ContextState);
   expectedMap.set('context2-1', {
     reachable: true,
     error: undefined,
-    podsCount: 1,
-    deploymentsCount: 11,
+    resources: {
+      pods: 1,
+      deployments: 11,
+    },
   } as ContextState);
   expectedMap.set('context2-2', {
     reachable: true,
     error: undefined,
-    podsCount: 2,
-    deploymentsCount: 12,
+    resources: {
+      pods: 2,
+      deployments: 12,
+    },
   } as ContextState);
   await new Promise(resolve => setTimeout(resolve, 1200));
   expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-contexts-state-update', expectedMap);
@@ -232,13 +240,17 @@ test('should send info of resources in all reachable contexts and nothing in non
   expectedMap = new Map<string, ContextState>();
   expectedMap.set('context2', {
     reachable: true,
-    podsCount: 9,
-    deploymentsCount: 19,
+    resources: {
+      pods: 9,
+      deployments: 19,
+    },
   } as ContextState);
   expectedMap.set('context2-1', {
     reachable: true,
-    podsCount: 1,
-    deploymentsCount: 11,
+    resources: {
+      pods: 1,
+      deployments: 11,
+    },
   } as ContextState);
   await new Promise(resolve => setTimeout(resolve, 1200));
   expect(apiSenderSendMock).toHaveBeenLastCalledWith('kubernetes-contexts-state-update', expectedMap);

--- a/packages/main/src/plugin/kubernetes-context-state.spec.ts
+++ b/packages/main/src/plugin/kubernetes-context-state.spec.ts
@@ -88,14 +88,14 @@ function fakeMakeInformer(
     case '/api/v1/namespaces/ns2/pods':
       return new FakeInformer(2, connectResult);
     case '/api/v1/namespaces/default/pods':
-      return new FakeInformer(9, connectResult);
+      return new FakeInformer(3, connectResult);
 
     case '/apis/apps/v1/namespaces/ns1/deployments':
-      return new FakeInformer(11, connectResult);
+      return new FakeInformer(4, connectResult);
     case '/apis/apps/v1/namespaces/ns2/deployments':
-      return new FakeInformer(12, connectResult);
+      return new FakeInformer(5, connectResult);
     case '/apis/apps/v1/namespaces/default/deployments':
-      return new FakeInformer(19, connectResult);
+      return new FakeInformer(6, connectResult);
   }
   return new FakeInformer(0, connectResult);
 }
@@ -168,32 +168,32 @@ test('should send info of resources in all reachable contexts and nothing in non
     reachable: false,
     error: 'Error: connection error',
     resources: {
-      pods: 0,
-      deployments: 0,
+      pods: [],
+      deployments: [],
     },
   } as ContextState);
   expectedMap.set('context2', {
     reachable: true,
     error: undefined,
     resources: {
-      pods: 9,
-      deployments: 19,
+      pods: [{}, {}, {}],
+      deployments: [{}, {}, {}, {}, {}, {}],
     },
   } as ContextState);
   expectedMap.set('context2-1', {
     reachable: true,
     error: undefined,
     resources: {
-      pods: 1,
-      deployments: 11,
+      pods: [{}],
+      deployments: [{}, {}, {}, {}],
     },
   } as ContextState);
   expectedMap.set('context2-2', {
     reachable: true,
     error: undefined,
     resources: {
-      pods: 2,
-      deployments: 12,
+      pods: [{}, {}],
+      deployments: [{}, {}, {}, {}, {}],
     },
   } as ContextState);
   await new Promise(resolve => setTimeout(resolve, 1200));
@@ -241,15 +241,15 @@ test('should send info of resources in all reachable contexts and nothing in non
   expectedMap.set('context2', {
     reachable: true,
     resources: {
-      pods: 9,
-      deployments: 19,
+      pods: [{}, {}, {}],
+      deployments: [{}, {}, {}, {}, {}, {}],
     },
   } as ContextState);
   expectedMap.set('context2-1', {
     reachable: true,
     resources: {
-      pods: 1,
-      deployments: 11,
+      pods: [{}],
+      deployments: [{}, {}, {}, {}],
     },
   } as ContextState);
   await new Promise(resolve => setTimeout(resolve, 1200));

--- a/packages/renderer/src/lib/deployments/DeploymentsList.svelte
+++ b/packages/renderer/src/lib/deployments/DeploymentsList.svelte
@@ -2,7 +2,10 @@
 import { onMount } from 'svelte';
 
 import type { DeploymentUI } from './DeploymentUI';
-import { filtered, searchPattern } from '../../stores/deployments';
+import {
+  kubernetesCurrentContextDeploymentStateFiltered as filtered,
+  deploymentSearchPattern as searchPattern,
+} from '../../stores/kubernetes-contexts-state';
 import NavPage from '../ui/NavPage.svelte';
 import Table from '../table/Table.svelte';
 import { Column, Row } from '../table/table';

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.spec.ts
@@ -153,15 +153,15 @@ test('state and resources counts are displayed in contexts', () => {
   state.set('context-name', {
     reachable: true,
     resources: {
-      pods: 1,
-      deployments: 2,
+      pods: [{}],
+      deployments: [{}, {}],
     },
   });
   state.set('context-name2', {
     reachable: false,
     resources: {
-      pods: 0,
-      deployments: 0,
+      pods: [],
+      deployments: [],
     },
   });
   vi.mocked(kubernetesContextsState).kubernetesContextsState = readable<Map<string, ContextState>>(state);

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.spec.ts
@@ -152,13 +152,17 @@ test('state and resources counts are displayed in contexts', () => {
   const state: Map<string, ContextState> = new Map();
   state.set('context-name', {
     reachable: true,
-    podsCount: 1,
-    deploymentsCount: 2,
+    resources: {
+      pods: 1,
+      deployments: 2,
+    },
   });
   state.set('context-name2', {
     reachable: false,
-    podsCount: 0,
-    deploymentsCount: 0,
+    resources: {
+      pods: 0,
+      deployments: 0,
+    },
   });
   vi.mocked(kubernetesContextsState).kubernetesContextsState = readable<Map<string, ContextState>>(state);
   render(PreferencesKubernetesContextsRendering, {});

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
@@ -108,13 +108,13 @@ async function handleDeleteContext(contextName: string) {
                     <div class="text-center">
                       <div class="font-bold text-[9px] text-gray-800">PODS</div>
                       <div class="text-[16px] text-white" aria-label="context-pods-count">
-                        {$kubernetesContextsState.get(context.name)?.podsCount}
+                        {$kubernetesContextsState.get(context.name)?.resources.pods}
                       </div>
                     </div>
                     <div class="text-center">
                       <div class="font-bold text-[9px] text-gray-800">DEPLOYMENTS</div>
                       <div class="text-[16px] text-white" aria-label="context-deployments-count">
-                        {$kubernetesContextsState.get(context.name)?.deploymentsCount}
+                        {$kubernetesContextsState.get(context.name)?.resources.deployments}
                       </div>
                     </div>
                   </div>

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
@@ -108,13 +108,13 @@ async function handleDeleteContext(contextName: string) {
                     <div class="text-center">
                       <div class="font-bold text-[9px] text-gray-800">PODS</div>
                       <div class="text-[16px] text-white" aria-label="context-pods-count">
-                        {$kubernetesContextsState.get(context.name)?.resources.pods}
+                        {$kubernetesContextsState.get(context.name)?.resources.pods.length}
                       </div>
                     </div>
                     <div class="text-center">
                       <div class="font-bold text-[9px] text-gray-800">DEPLOYMENTS</div>
                       <div class="text-[16px] text-white" aria-label="context-deployments-count">
-                        {$kubernetesContextsState.get(context.name)?.resources.deployments}
+                        {$kubernetesContextsState.get(context.name)?.resources.deployments.length}
                       </div>
                     </div>
                   </div>

--- a/packages/renderer/src/stores/kubernetes-contexts-state.ts
+++ b/packages/renderer/src/stores/kubernetes-contexts-state.ts
@@ -16,10 +16,12 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { derived, type Readable, readable } from 'svelte/store';
+import { derived, type Readable, readable, writable } from 'svelte/store';
 import type { ContextState } from '../../../main/src/plugin/kubernetes-context-state';
 import { kubernetesContexts } from '/@/stores/kubernetes-contexts';
+import { findMatchInLeaves } from './search-util';
 
+// Map of resources and statuses for all contexts
 export const kubernetesContextsState = readable(new Map<string, ContextState>(), set => {
   window.kubernetesGetContextsState().then(value => set(value));
   window.events?.receive('kubernetes-contexts-state-update', (value: unknown) => {
@@ -27,6 +29,7 @@ export const kubernetesContextsState = readable(new Map<string, ContextState>(),
   });
 });
 
+// Resources and status of the current context
 export const kubernetesCurrentContextState: Readable<ContextState | undefined> = derived(
   [kubernetesContextsState, kubernetesContexts],
   ([$kubernetesContextsState, $kubernetesContexts]) => {
@@ -34,4 +37,21 @@ export const kubernetesCurrentContextState: Readable<ContextState | undefined> =
     if (currentContextName === undefined) return undefined;
     return $kubernetesContextsState.get(currentContextName);
   },
+);
+
+// All deployments in the current context
+export const kubernetesCurrentContextDeploymentState = derived(
+  [kubernetesCurrentContextState],
+  ([$kubernetesCurrentContextState]) => {
+    return $kubernetesCurrentContextState?.resources.deployments ?? [];
+  },
+);
+
+export const deploymentSearchPattern = writable('');
+
+// The deployments in the current context, filtered with `deploymentSearchPattern`
+export const kubernetesCurrentContextDeploymentStateFiltered = derived(
+  [deploymentSearchPattern, kubernetesCurrentContextDeploymentState],
+  ([$searchPattern, $deployments]) =>
+    $deployments.filter(deployment => findMatchInLeaves(deployment, $searchPattern.toLowerCase())),
 );


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

- use index signature for kubernetes context states, to be able to add more resources easily
- send complete objects data, not only count
- add a new store, giving the state of the current context (updated as soon as the current context is changed) (also done as part of #6102)
- add new stores to get filtered deployments in the current context (the code will need to be more generic to create stores for different resources)
- use of these new stores in Deployments page

Fixes a bug where resources are still visible in the Deployments list when the context is not reachable:
When an informer is disconnected then reconnected, is does not get new 'add' events for the resources it is watching (bug or feature?), so we cannot reset the resources in our cache, as it won't be populated again after reconnection.
Instead, the resources are not sent anymore to the frontend when the context is not reachable (but not cleared from the cache). Another possibility would be to send the resources in any case, so the frontend could display the resources as 'latest seen', or filter itself, based on the `reachable` state. @deboer-tim WDYT?


### Screenshot / video of UI

https://github.com/containers/podman-desktop/assets/9973512/5c88838b-73a0-46c1-a23c-2d7cd2ef0c97

### What issues does this PR fix or reference?

Fixes #6100 

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
