### PR TITLE
feat: adding kube state indicator

### DIFF
--- a/packages/renderer/src/lib/deployments/DeploymentsList.spec.ts
+++ b/packages/renderer/src/lib/deployments/DeploymentsList.spec.ts
@@ -46,7 +46,7 @@ Object.defineProperty(global, 'window', {
 beforeEach(() => {
   vi.resetAllMocks();
   vi.clearAllMocks();
-  (window as any).kubernetesGetContextsState = () => new Map();
+  (window as any).kubernetesGetContextsState = () => Promise.resolve(new Map());
 });
 
 async function waitRender(customProperties: object): Promise<void> {

--- a/packages/renderer/src/lib/deployments/DeploymentsList.spec.ts
+++ b/packages/renderer/src/lib/deployments/DeploymentsList.spec.ts
@@ -46,6 +46,7 @@ Object.defineProperty(global, 'window', {
 beforeEach(() => {
   vi.resetAllMocks();
   vi.clearAllMocks();
+  (window as any).kubernetesGetContextsState = () => new Map();
 });
 
 async function waitRender(customProperties: object): Promise<void> {

--- a/packages/renderer/src/lib/deployments/DeploymentsList.svelte
+++ b/packages/renderer/src/lib/deployments/DeploymentsList.svelte
@@ -20,6 +20,7 @@ import DeploymentEmptyScreen from './DeploymentEmptyScreen.svelte';
 import FilteredEmptyScreen from '../ui/FilteredEmptyScreen.svelte';
 import SimpleColumn from '../table/SimpleColumn.svelte';
 import DurationColumn from '../table/DurationColumn.svelte';
+import KubernetesCurrentContextConnectionBadge from '/@/lib/ui/KubernetesCurrentContextConnectionBadge.svelte';
 
 export let searchTerm = '';
 $: searchPattern.set(searchTerm);
@@ -120,6 +121,9 @@ const row = new Row<DeploymentUI>({ selectable: _deployment => true });
         icon="{faTrash}" />
       <span>On {selectedItemsNumber} selected items.</span>
     {/if}
+    <div class="flex min-w-full justify-end">
+      <KubernetesCurrentContextConnectionBadge />
+    </div>
   </svelte:fragment>
 
   <div class="flex min-w-full h-full" slot="content">

--- a/packages/renderer/src/lib/ingresses-routes/IngressesRoutesList.spec.ts
+++ b/packages/renderer/src/lib/ingresses-routes/IngressesRoutesList.spec.ts
@@ -48,6 +48,7 @@ Object.defineProperty(global, 'window', {
 beforeEach(() => {
   vi.resetAllMocks();
   vi.clearAllMocks();
+  (window as any).kubernetesGetContextsState = () => new Map();
 });
 
 async function waitRender(customProperties: object): Promise<void> {

--- a/packages/renderer/src/lib/ingresses-routes/IngressesRoutesList.spec.ts
+++ b/packages/renderer/src/lib/ingresses-routes/IngressesRoutesList.spec.ts
@@ -48,7 +48,7 @@ Object.defineProperty(global, 'window', {
 beforeEach(() => {
   vi.resetAllMocks();
   vi.clearAllMocks();
-  (window as any).kubernetesGetContextsState = () => new Map();
+  (window as any).kubernetesGetContextsState = () => Promise.resolve(new Map());
 });
 
 async function waitRender(customProperties: object): Promise<void> {

--- a/packages/renderer/src/lib/ingresses-routes/IngressesRoutesList.svelte
+++ b/packages/renderer/src/lib/ingresses-routes/IngressesRoutesList.svelte
@@ -21,6 +21,7 @@ import IngressRouteColumnHostPath from './IngressRouteColumnHostPath.svelte';
 import IngressRouteColumnBackend from './IngressRouteColumnBackend.svelte';
 import { filtered as filteredRoutes, searchPattern as searchPatternRoutes } from '/@/stores/routes';
 import IngressRouteColumnStatus from './IngressRouteColumnStatus.svelte';
+import KubernetesCurrentContextConnectionBadge from '/@/lib/ui/KubernetesCurrentContextConnectionBadge.svelte';
 
 export let searchTerm = '';
 $: searchPatternRoutes.set(searchTerm);
@@ -150,6 +151,9 @@ const row = new Row<IngressUI | RouteUI>({ selectable: _ingressRoute => true });
         icon="{faTrash}" />
       <span>On {selectedItemsNumber} selected items.</span>
     {/if}
+    <div class="flex min-w-full justify-end">
+      <KubernetesCurrentContextConnectionBadge />
+    </div>
   </svelte:fragment>
 
   <div class="flex min-w-full h-full" slot="content">

--- a/packages/renderer/src/lib/pod/PodsList.spec.ts
+++ b/packages/renderer/src/lib/pod/PodsList.spec.ts
@@ -262,6 +262,7 @@ const ocppod: PodInfo = {
 
 // fake the window.events object
 beforeAll(() => {
+  (window as any).kubernetesGetContextsState = () => new Map();
   (window as any).getProviderInfos = getProvidersInfoMock;
   (window as any).listPods = listPodsMock;
   (window as any).listContainers = listContainersMock.mockResolvedValue([]);

--- a/packages/renderer/src/lib/pod/PodsList.spec.ts
+++ b/packages/renderer/src/lib/pod/PodsList.spec.ts
@@ -262,7 +262,7 @@ const ocppod: PodInfo = {
 
 // fake the window.events object
 beforeAll(() => {
-  (window as any).kubernetesGetContextsState = () => new Map();
+  (window as any).kubernetesGetContextsState = () => Promise.resolve(new Map());
   (window as any).getProviderInfos = getProvidersInfoMock;
   (window as any).listPods = listPodsMock;
   (window as any).listContainers = listContainersMock.mockResolvedValue([]);

--- a/packages/renderer/src/lib/pod/PodsList.svelte
+++ b/packages/renderer/src/lib/pod/PodsList.svelte
@@ -26,6 +26,7 @@ import PodColumnEnvironment from './PodColumnEnvironment.svelte';
 import PodColumnContainers from './PodColumnContainers.svelte';
 import PodColumnAge from './PodColumnAge.svelte';
 import PodColumnActions from './PodColumnActions.svelte';
+import KubernetesCurrentContextConnectionBadge from '/@/lib/ui/KubernetesCurrentContextConnectionBadge.svelte';
 
 export let searchTerm = '';
 $: searchPattern.set(searchTerm);
@@ -229,6 +230,9 @@ const row = new Row<PodInfoUI>({ selectable: _pod => true });
         icon="{faTrash}" />
       <span>On {selectedItemsNumber} selected items.</span>
     {/if}
+    <div class="flex min-w-full justify-end">
+      <KubernetesCurrentContextConnectionBadge />
+    </div>
   </svelte:fragment>
 
   <svelte:fragment slot="tabs">

--- a/packages/renderer/src/lib/service/ServicesList.spec.ts
+++ b/packages/renderer/src/lib/service/ServicesList.spec.ts
@@ -46,7 +46,7 @@ Object.defineProperty(global, 'window', {
 beforeEach(() => {
   vi.resetAllMocks();
   vi.clearAllMocks();
-  (window as any).kubernetesGetContextsState = () => new Map();
+  (window as any).kubernetesGetContextsState = () => Promise.resolve(new Map());
 });
 
 async function waitRender(customProperties: object): Promise<void> {

--- a/packages/renderer/src/lib/service/ServicesList.spec.ts
+++ b/packages/renderer/src/lib/service/ServicesList.spec.ts
@@ -46,6 +46,7 @@ Object.defineProperty(global, 'window', {
 beforeEach(() => {
   vi.resetAllMocks();
   vi.clearAllMocks();
+  (window as any).kubernetesGetContextsState = () => new Map();
 });
 
 async function waitRender(customProperties: object): Promise<void> {

--- a/packages/renderer/src/lib/service/ServicesList.svelte
+++ b/packages/renderer/src/lib/service/ServicesList.svelte
@@ -18,6 +18,7 @@ import FilteredEmptyScreen from '../ui/FilteredEmptyScreen.svelte';
 import SimpleColumn from '../table/SimpleColumn.svelte';
 import DurationColumn from '../table/DurationColumn.svelte';
 import ServiceColumnType from './ServiceColumnType.svelte';
+import KubernetesCurrentContextConnectionBadge from '/@/lib/ui/KubernetesCurrentContextConnectionBadge.svelte';
 
 export let searchTerm = '';
 $: searchPattern.set(searchTerm);
@@ -126,6 +127,9 @@ const row = new Row<ServiceUI>({ selectable: _service => true });
         icon="{faTrash}" />
       <span>On {selectedItemsNumber} selected items.</span>
     {/if}
+    <div class="flex min-w-full justify-end">
+      <KubernetesCurrentContextConnectionBadge />
+    </div>
   </svelte:fragment>
 
   <div class="flex min-w-full h-full" slot="content">

--- a/packages/renderer/src/lib/ui/KubernetesCurrentContextConnectionBadge.spec.ts
+++ b/packages/renderer/src/lib/ui/KubernetesCurrentContextConnectionBadge.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/renderer/src/lib/ui/KubernetesCurrentContextConnectionBadge.spec.ts
+++ b/packages/renderer/src/lib/ui/KubernetesCurrentContextConnectionBadge.spec.ts
@@ -16,6 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
 import '@testing-library/jest-dom/vitest';
 import { test, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/svelte';

--- a/packages/renderer/src/lib/ui/KubernetesCurrentContextConnectionBadge.spec.ts
+++ b/packages/renderer/src/lib/ui/KubernetesCurrentContextConnectionBadge.spec.ts
@@ -1,0 +1,127 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+import { test, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import KubernetesCurrentContextConnectionBadge from '/@/lib/ui/KubernetesCurrentContextConnectionBadge.svelte';
+import type { ContextState } from '../../../../main/src/plugin/kubernetes-context-state';
+
+const mocks = vi.hoisted(() => ({
+  subscribeMock: vi.fn(),
+  getCurrentKubeContextState: vi.fn(),
+
+  // window mocks
+  eventsMocks: vi.fn(),
+}));
+
+vi.mock('../../stores/kubernetes-contexts-state', () => ({
+  kubernetesCurrentContextState: {
+    subscribe: mocks.subscribeMock,
+  },
+}));
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  mocks.subscribeMock.mockImplementation(listener => {
+    listener(mocks.getCurrentKubeContextState());
+    return { unsubscribe: () => {} };
+  });
+
+  (window as any).events = mocks.eventsMocks;
+  (window as any).kubernetesGetContextsState = mocks.getCurrentKubeContextState;
+});
+
+test('expect no badges shown as no context has been provided.', async () => {
+  mocks.getCurrentKubeContextState.mockReturnValue(undefined); // no current ContextState
+  render(KubernetesCurrentContextConnectionBadge);
+
+  expect(mocks.getCurrentKubeContextState).toHaveBeenCalled();
+  const status = screen.queryByRole('status');
+  expect(status).toBeNull();
+});
+
+test('expect badges to show as there is a context', async () => {
+  mocks.getCurrentKubeContextState.mockReturnValue({
+    error: undefined,
+    reachable: true,
+    deploymentsCount: 0,
+    podsCount: 0,
+  } as ContextState); // no current ContextState
+  render(KubernetesCurrentContextConnectionBadge);
+
+  expect(mocks.getCurrentKubeContextState).toHaveBeenCalled();
+  const status = screen.getByRole('status');
+  expect(status).toBeInTheDocument();
+});
+
+test('expect badges to be green when reachable', async () => {
+  mocks.getCurrentKubeContextState.mockReturnValue({
+    error: undefined,
+    reachable: true,
+    deploymentsCount: 0,
+    podsCount: 0,
+  } as ContextState); // no current ContextState
+  render(KubernetesCurrentContextConnectionBadge);
+
+  expect(mocks.getCurrentKubeContextState).toHaveBeenCalled();
+  const status = screen.getByRole('status');
+  expect(status.firstChild).toHaveClass('bg-green-600');
+});
+
+test('expect badges to be gray when not reachable', async () => {
+  mocks.getCurrentKubeContextState.mockReturnValue({
+    error: undefined,
+    reachable: false,
+    deploymentsCount: 0,
+    podsCount: 0,
+  } as ContextState); // no current ContextState
+  render(KubernetesCurrentContextConnectionBadge);
+
+  expect(mocks.getCurrentKubeContextState).toHaveBeenCalled();
+  const status = screen.getByRole('status');
+  expect(status.firstChild).toHaveClass('bg-gray-900');
+});
+
+test('expect no tooltip when no error', async () => {
+  mocks.getCurrentKubeContextState.mockReturnValue({
+    error: undefined,
+    reachable: false,
+    deploymentsCount: 0,
+    podsCount: 0,
+  } as ContextState); // no current ContextState
+  render(KubernetesCurrentContextConnectionBadge);
+
+  expect(mocks.getCurrentKubeContextState).toHaveBeenCalled();
+  const tooltip = screen.queryByLabelText('tooltip');
+  expect(tooltip).toBeNull();
+});
+
+test('expect tooltip when error', async () => {
+  mocks.getCurrentKubeContextState.mockReturnValue({
+    error: 'error message',
+    reachable: false,
+    deploymentsCount: 0,
+    podsCount: 0,
+  } as ContextState); // no current ContextState
+  render(KubernetesCurrentContextConnectionBadge);
+
+  expect(mocks.getCurrentKubeContextState).toHaveBeenCalled();
+  const tooltip = screen.getByLabelText('tooltip');
+  expect(tooltip).toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/ui/KubernetesCurrentContextConnectionBadge.svelte
+++ b/packages/renderer/src/lib/ui/KubernetesCurrentContextConnectionBadge.svelte
@@ -17,7 +17,7 @@ $: text = getText($kubernetesCurrentContextState);
 </script>
 
 {#if $kubernetesCurrentContextState}
-  <div class="flex items-center bg-charcoal-500 p-1 rounded-md">
+  <div role="status" class="flex items-center bg-charcoal-500 p-1 rounded-md">
     <div class="w-2 h-2 {getClassColor($kubernetesCurrentContextState)} rounded-full mx-1"></div>
     <span class="text-xs capitalize mr-1">
       {#if $kubernetesCurrentContextState.error !== undefined}

--- a/packages/renderer/src/lib/ui/KubernetesCurrentContextConnectionBadge.svelte
+++ b/packages/renderer/src/lib/ui/KubernetesCurrentContextConnectionBadge.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+import { kubernetesCurrentContextState } from '/@/stores/kubernetes-contexts-state';
+import type { ContextState } from '../../../../main/src/plugin/kubernetes-context-state';
+import Tooltip from '/@/lib/ui/Tooltip.svelte';
+
+function getText(state: ContextState | undefined): string {
+  if (state?.reachable) return 'Connected';
+  return 'Cluster not reachable';
+}
+
+function getClassColor(state: ContextState | undefined): string {
+  if (state?.reachable) return 'bg-green-600';
+  return 'bg-gray-900';
+}
+
+$: text = getText($kubernetesCurrentContextState);
+</script>
+
+{#if $kubernetesCurrentContextState}
+  <div class="flex items-center bg-charcoal-500 p-1 rounded-md">
+    <div class="w-2 h-2 {getClassColor($kubernetesCurrentContextState)} rounded-full mx-1"></div>
+    <span class="text-xs capitalize mr-1">
+      {#if $kubernetesCurrentContextState.error !== undefined}
+        <Tooltip tip="{$kubernetesCurrentContextState.error}" left>{text}</Tooltip>
+      {:else}
+        {text}
+      {/if}
+    </span>
+  </div>
+{/if}

--- a/packages/renderer/src/stores/kubernetes-contexts-state.ts
+++ b/packages/renderer/src/stores/kubernetes-contexts-state.ts
@@ -16,8 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { readable } from 'svelte/store';
+import { derived, type Readable, readable } from 'svelte/store';
 import type { ContextState } from '../../../main/src/plugin/kubernetes-context-state';
+import { kubernetesContexts } from '/@/stores/kubernetes-contexts';
 
 export const kubernetesContextsState = readable(new Map<string, ContextState>(), set => {
   window.kubernetesGetContextsState().then(value => set(value));
@@ -25,3 +26,12 @@ export const kubernetesContextsState = readable(new Map<string, ContextState>(),
     set(value as Map<string, ContextState>);
   });
 });
+
+export const kubernetesCurrentContextState: Readable<ContextState | undefined> = derived(
+  [kubernetesContextsState, kubernetesContexts],
+  ([$kubernetesContextsState, $kubernetesContexts]) => {
+    const currentContextName = $kubernetesContexts.find(c => c.currentContext)?.name;
+    if (currentContextName === undefined) return undefined;
+    return $kubernetesContextsState.get(currentContextName);
+  },
+);


### PR DESCRIPTION
### What does this PR do?

After a discussion with @deboer-tim and @cdrage we made the conclusion that for now, implementing the design thought by @mairin (see https://github.com/containers/podman-desktop/issues/5401#issuecomment-1949069361) could not be done in time for the next release.

Therefore we can for now simply show a badge with a color indicator in page where Kubernetes resources are shown.

### Screenshot / video of UI

https://github.com/containers/podman-desktop/assets/42176370/51b4c050-0e37-4c20-bc8f-7c1fa0af4c41

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop/issues/5401

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
