### PR TITLE
fix(navigation): adding pod details default tab

### DIFF
--- a/packages/renderer/src/lib/container/ContainerList.svelte
+++ b/packages/renderer/src/lib/container/ContainerList.svelte
@@ -40,8 +40,6 @@ import StateChange from '../ui/StateChange.svelte';
 import SolidPodIcon from '../images/SolidPodIcon.svelte';
 import ProviderInfo from '../ui/ProviderInfo.svelte';
 import { findMatchInLeaves } from '../../stores/search-util';
-import { handleNavigation } from '/@/navigation';
-import { NavigationPage } from '../../../../main/src/plugin/navigation/navigation-page';
 
 const containerUtils = new ContainerUtils();
 let openChoiceModal = false;

--- a/packages/renderer/src/lib/container/ContainerList.svelte
+++ b/packages/renderer/src/lib/container/ContainerList.svelte
@@ -40,6 +40,8 @@ import StateChange from '../ui/StateChange.svelte';
 import SolidPodIcon from '../images/SolidPodIcon.svelte';
 import ProviderInfo from '../ui/ProviderInfo.svelte';
 import { findMatchInLeaves } from '../../stores/search-util';
+import { handleNavigation } from '/@/navigation';
+import { NavigationPage } from '../../../../main/src/plugin/navigation/navigation-page';
 
 const containerUtils = new ContainerUtils();
 let openChoiceModal = false;
@@ -368,7 +370,9 @@ onDestroy(() => {
 });
 
 function openDetailsContainer(container: ContainerInfoUI) {
-  router.goto(`/containers/${container.id}/`);
+  handleNavigation(NavigationPage.CONTAINER, {
+    id: container.id,
+  });
 }
 
 function keydownChoice(e: KeyboardEvent) {

--- a/packages/renderer/src/lib/container/ContainerList.svelte
+++ b/packages/renderer/src/lib/container/ContainerList.svelte
@@ -368,9 +368,7 @@ onDestroy(() => {
 });
 
 function openDetailsContainer(container: ContainerInfoUI) {
-  handleNavigation(NavigationPage.CONTAINER, {
-    id: container.id,
-  });
+  router.goto(`/containers/${container.id}/`);
 }
 
 function keydownChoice(e: KeyboardEvent) {

--- a/packages/renderer/src/lib/pod/PodColumnName.spec.ts
+++ b/packages/renderer/src/lib/pod/PodColumnName.spec.ts
@@ -64,5 +64,5 @@ test('Expect clicking works', async () => {
 
   fireEvent.click(text);
 
-  expect(routerGotoSpy).toBeCalledWith('/pods/podman/my-pod/podman/logs');
+  expect(routerGotoSpy).toBeCalledWith('/pods/podman/my-pod/podman/');
 });

--- a/packages/renderer/src/lib/pod/PodColumnName.svelte
+++ b/packages/renderer/src/lib/pod/PodColumnName.svelte
@@ -1,11 +1,16 @@
 <script lang="ts">
-import { router } from 'tinro';
 import type { PodInfoUI } from './PodInfoUI';
+import { handleNavigation } from '/@/navigation';
+import { NavigationPage } from '../../../../main/src/plugin/navigation/navigation-page';
 
 export let object: PodInfoUI;
 
 function openDetailsPod(pod: PodInfoUI) {
-  router.goto(`/pods/${encodeURI(pod.kind)}/${encodeURI(pod.name)}/${encodeURIComponent(pod.engineId)}/logs`);
+  handleNavigation(NavigationPage.POD, {
+    kind: encodeURI(pod.kind),
+    name: encodeURI(pod.name),
+    engineId: encodeURIComponent(pod.engineId),
+  });
 }
 </script>
 

--- a/packages/renderer/src/lib/pod/PodDetails.svelte
+++ b/packages/renderer/src/lib/pod/PodDetails.svelte
@@ -15,6 +15,7 @@ import DetailsPage from '../ui/DetailsPage.svelte';
 import Tab from '../ui/Tab.svelte';
 import ErrorMessage from '../ui/ErrorMessage.svelte';
 import StateChange from '../ui/StateChange.svelte';
+import { router } from 'tinro';
 
 export let podName: string;
 export let engineId: string;
@@ -23,8 +24,16 @@ export let kind: string;
 let pod: PodInfoUI;
 let detailsPage: DetailsPage;
 
+// update current route scheme
+let currentRouterPath: string;
+
 onMount(() => {
   const podUtils = new PodUtils();
+
+  router.subscribe(route => {
+    currentRouterPath = route.path;
+  });
+
   // loading pod info
   return podsInfos.subscribe(pods => {
     const matchingPod = pods.find(
@@ -33,6 +42,10 @@ onMount(() => {
     if (matchingPod) {
       try {
         pod = podUtils.getPodInfoUI(matchingPod);
+
+        if (currentRouterPath.endsWith('/')) {
+          router.goto(`${currentRouterPath}logs`);
+        }
       } catch (err) {
         console.error(err);
       }

--- a/packages/renderer/src/lib/pod/PodsList.spec.ts
+++ b/packages/renderer/src/lib/pod/PodsList.spec.ts
@@ -417,7 +417,7 @@ test('Expect the route to a pod details page is correctly encoded with an engine
   router.goto = routerGotoMock;
   await fireEvent.click(podDetails);
   expect(routerGotoMock).toHaveBeenCalledWith(
-    '/pods/kubernetes/ocppod/userid-dev%2Fapi-sandbox-123-openshiftapps-com%3A6443%2FuserId/logs',
+    '/pods/kubernetes/ocppod/userid-dev%2Fapi-sandbox-123-openshiftapps-com%3A6443%2FuserId/',
   );
 });
 


### PR DESCRIPTION
### What does this PR do?

This PR is adding a default route to the Pod Details page. When no path is provided, it will redirect to `/logs` in a similar manner than the ContainerDetails is doing (see issue for details)

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop/issues/6071

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
