### PR TITLE
Add complete object from contexts informers

### DIFF
--- a/packages/main/src/plugin/kubernetes-context-state.spec.ts
+++ b/packages/main/src/plugin/kubernetes-context-state.spec.ts
@@ -167,26 +167,34 @@ test('should send info of resources in all reachable contexts and nothing in non
   expectedMap.set('context1', {
     reachable: false,
     error: 'Error: connection error',
-    podsCount: 0,
-    deploymentsCount: 0,
+    resources: {
+      pods: 0,
+      deployments: 0,
+    },
   } as ContextState);
   expectedMap.set('context2', {
     reachable: true,
     error: undefined,
-    podsCount: 9,
-    deploymentsCount: 19,
+    resources: {
+      pods: 9,
+      deployments: 19,
+    },
   } as ContextState);
   expectedMap.set('context2-1', {
     reachable: true,
     error: undefined,
-    podsCount: 1,
-    deploymentsCount: 11,
+    resources: {
+      pods: 1,
+      deployments: 11,
+    },
   } as ContextState);
   expectedMap.set('context2-2', {
     reachable: true,
     error: undefined,
-    podsCount: 2,
-    deploymentsCount: 12,
+    resources: {
+      pods: 2,
+      deployments: 12,
+    },
   } as ContextState);
   await new Promise(resolve => setTimeout(resolve, 1200));
   expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-contexts-state-update', expectedMap);
@@ -232,13 +240,17 @@ test('should send info of resources in all reachable contexts and nothing in non
   expectedMap = new Map<string, ContextState>();
   expectedMap.set('context2', {
     reachable: true,
-    podsCount: 9,
-    deploymentsCount: 19,
+    resources: {
+      pods: 9,
+      deployments: 19,
+    },
   } as ContextState);
   expectedMap.set('context2-1', {
     reachable: true,
-    podsCount: 1,
-    deploymentsCount: 11,
+    resources: {
+      pods: 1,
+      deployments: 11,
+    },
   } as ContextState);
   await new Promise(resolve => setTimeout(resolve, 1200));
   expect(apiSenderSendMock).toHaveBeenLastCalledWith('kubernetes-contexts-state-update', expectedMap);

--- a/packages/main/src/plugin/kubernetes-context-state.spec.ts
+++ b/packages/main/src/plugin/kubernetes-context-state.spec.ts
@@ -88,14 +88,14 @@ function fakeMakeInformer(
     case '/api/v1/namespaces/ns2/pods':
       return new FakeInformer(2, connectResult);
     case '/api/v1/namespaces/default/pods':
-      return new FakeInformer(9, connectResult);
+      return new FakeInformer(3, connectResult);
 
     case '/apis/apps/v1/namespaces/ns1/deployments':
-      return new FakeInformer(11, connectResult);
+      return new FakeInformer(4, connectResult);
     case '/apis/apps/v1/namespaces/ns2/deployments':
-      return new FakeInformer(12, connectResult);
+      return new FakeInformer(5, connectResult);
     case '/apis/apps/v1/namespaces/default/deployments':
-      return new FakeInformer(19, connectResult);
+      return new FakeInformer(6, connectResult);
   }
   return new FakeInformer(0, connectResult);
 }
@@ -168,32 +168,32 @@ test('should send info of resources in all reachable contexts and nothing in non
     reachable: false,
     error: 'Error: connection error',
     resources: {
-      pods: 0,
-      deployments: 0,
+      pods: [],
+      deployments: [],
     },
   } as ContextState);
   expectedMap.set('context2', {
     reachable: true,
     error: undefined,
     resources: {
-      pods: 9,
-      deployments: 19,
+      pods: [{}, {}, {}],
+      deployments: [{}, {}, {}, {}, {}, {}],
     },
   } as ContextState);
   expectedMap.set('context2-1', {
     reachable: true,
     error: undefined,
     resources: {
-      pods: 1,
-      deployments: 11,
+      pods: [{}],
+      deployments: [{}, {}, {}, {}],
     },
   } as ContextState);
   expectedMap.set('context2-2', {
     reachable: true,
     error: undefined,
     resources: {
-      pods: 2,
-      deployments: 12,
+      pods: [{}, {}],
+      deployments: [{}, {}, {}, {}, {}],
     },
   } as ContextState);
   await new Promise(resolve => setTimeout(resolve, 1200));
@@ -241,15 +241,15 @@ test('should send info of resources in all reachable contexts and nothing in non
   expectedMap.set('context2', {
     reachable: true,
     resources: {
-      pods: 9,
-      deployments: 19,
+      pods: [{}, {}, {}],
+      deployments: [{}, {}, {}, {}, {}, {}],
     },
   } as ContextState);
   expectedMap.set('context2-1', {
     reachable: true,
     resources: {
-      pods: 1,
-      deployments: 11,
+      pods: [{}],
+      deployments: [{}, {}, {}, {}],
     },
   } as ContextState);
   await new Promise(resolve => setTimeout(resolve, 1200));

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.spec.ts
@@ -153,15 +153,15 @@ test('state and resources counts are displayed in contexts', () => {
   state.set('context-name', {
     reachable: true,
     resources: {
-      pods: 1,
-      deployments: 2,
+      pods: [{}],
+      deployments: [{}, {}],
     },
   });
   state.set('context-name2', {
     reachable: false,
     resources: {
-      pods: 0,
-      deployments: 0,
+      pods: [],
+      deployments: [],
     },
   });
   vi.mocked(kubernetesContextsState).kubernetesContextsState = readable<Map<string, ContextState>>(state);

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.spec.ts
@@ -152,13 +152,17 @@ test('state and resources counts are displayed in contexts', () => {
   const state: Map<string, ContextState> = new Map();
   state.set('context-name', {
     reachable: true,
-    podsCount: 1,
-    deploymentsCount: 2,
+    resources: {
+      pods: 1,
+      deployments: 2,
+    },
   });
   state.set('context-name2', {
     reachable: false,
-    podsCount: 0,
-    deploymentsCount: 0,
+    resources: {
+      pods: 0,
+      deployments: 0,
+    },
   });
   vi.mocked(kubernetesContextsState).kubernetesContextsState = readable<Map<string, ContextState>>(state);
   render(PreferencesKubernetesContextsRendering, {});

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
@@ -108,13 +108,13 @@ async function handleDeleteContext(contextName: string) {
                     <div class="text-center">
                       <div class="font-bold text-[9px] text-gray-800">PODS</div>
                       <div class="text-[16px] text-white" aria-label="context-pods-count">
-                        {$kubernetesContextsState.get(context.name)?.podsCount}
+                        {$kubernetesContextsState.get(context.name)?.resources.pods}
                       </div>
                     </div>
                     <div class="text-center">
                       <div class="font-bold text-[9px] text-gray-800">DEPLOYMENTS</div>
                       <div class="text-[16px] text-white" aria-label="context-deployments-count">
-                        {$kubernetesContextsState.get(context.name)?.deploymentsCount}
+                        {$kubernetesContextsState.get(context.name)?.resources.deployments}
                       </div>
                     </div>
                   </div>

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
@@ -108,13 +108,13 @@ async function handleDeleteContext(contextName: string) {
                     <div class="text-center">
                       <div class="font-bold text-[9px] text-gray-800">PODS</div>
                       <div class="text-[16px] text-white" aria-label="context-pods-count">
-                        {$kubernetesContextsState.get(context.name)?.resources.pods}
+                        {$kubernetesContextsState.get(context.name)?.resources.pods.length}
                       </div>
                     </div>
                     <div class="text-center">
                       <div class="font-bold text-[9px] text-gray-800">DEPLOYMENTS</div>
                       <div class="text-[16px] text-white" aria-label="context-deployments-count">
-                        {$kubernetesContextsState.get(context.name)?.resources.deployments}
+                        {$kubernetesContextsState.get(context.name)?.resources.deployments.length}
                       </div>
                     </div>
                   </div>

--- a/packages/renderer/src/lib/ui/KubernetesCurrentContextConnectionBadge.spec.ts
+++ b/packages/renderer/src/lib/ui/KubernetesCurrentContextConnectionBadge.spec.ts
@@ -62,8 +62,10 @@ test('expect badges to show as there is a context', async () => {
   mocks.getCurrentKubeContextState.mockReturnValue({
     error: undefined,
     reachable: true,
-    deploymentsCount: 0,
-    podsCount: 0,
+    resources: {
+      pods: [],
+      deployments: [],
+    },
   } as ContextState); // no current ContextState
   render(KubernetesCurrentContextConnectionBadge);
 
@@ -76,8 +78,10 @@ test('expect badges to be green when reachable', async () => {
   mocks.getCurrentKubeContextState.mockReturnValue({
     error: undefined,
     reachable: true,
-    deploymentsCount: 0,
-    podsCount: 0,
+    resources: {
+      pods: [],
+      deployments: [],
+    },
   } as ContextState); // no current ContextState
   render(KubernetesCurrentContextConnectionBadge);
 
@@ -90,8 +94,10 @@ test('expect badges to be gray when not reachable', async () => {
   mocks.getCurrentKubeContextState.mockReturnValue({
     error: undefined,
     reachable: false,
-    deploymentsCount: 0,
-    podsCount: 0,
+    resources: {
+      pods: [],
+      deployments: [],
+    },
   } as ContextState); // no current ContextState
   render(KubernetesCurrentContextConnectionBadge);
 
@@ -104,8 +110,10 @@ test('expect no tooltip when no error', async () => {
   mocks.getCurrentKubeContextState.mockReturnValue({
     error: undefined,
     reachable: false,
-    deploymentsCount: 0,
-    podsCount: 0,
+    resources: {
+      pods: [],
+      deployments: [],
+    },
   } as ContextState); // no current ContextState
   render(KubernetesCurrentContextConnectionBadge);
 
@@ -118,8 +126,10 @@ test('expect tooltip when error', async () => {
   mocks.getCurrentKubeContextState.mockReturnValue({
     error: 'error message',
     reachable: false,
-    deploymentsCount: 0,
-    podsCount: 0,
+    resources: {
+      pods: [],
+      deployments: [],
+    },
   } as ContextState); // no current ContextState
   render(KubernetesCurrentContextConnectionBadge);
 


### PR DESCRIPTION
### What does this PR do?

- use index signature for kubernetes context states, to be able to add more resources easily
- send complete objects data, not only count

### Screenshot / video of UI

### What issues does this PR fix or reference?

Part of #6100 

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
