### PR TITLE
draft: full kube informers integrated

### DIFF
--- a/packages/renderer/src/lib/deployments/DeploymentDetails.svelte
+++ b/packages/renderer/src/lib/deployments/DeploymentDetails.svelte
@@ -9,10 +9,10 @@ import Tab from '../ui/Tab.svelte';
 import DeploymentIcon from '../images/DeploymentIcon.svelte';
 import DeploymentActions from './DeploymentActions.svelte';
 import DeploymentDetailsSummary from './DeploymentDetailsSummary.svelte';
-import { deployments } from '/@/stores/deployments';
 import type { V1Deployment } from '@kubernetes/client-node';
 import { stringify } from 'yaml';
 import MonacoEditor from '../editor/MonacoEditor.svelte';
+import { kubernetesCurrentContextDeploymentState } from '/@/stores/kubernetes-contexts-state';
 
 export let name: string;
 export let namespace: string;
@@ -25,7 +25,7 @@ let kubeError: string;
 onMount(() => {
   const deploymentUtils = new DeploymentUtils();
   // loading deployment info
-  return deployments.subscribe(deployments => {
+  return kubernetesCurrentContextDeploymentState.subscribe(deployments => {
     const matchingDeployment = deployments.find(
       dep => dep.metadata?.name === name && dep.metadata?.namespace === namespace,
     );

--- a/packages/renderer/src/lib/deployments/DeploymentsList.svelte
+++ b/packages/renderer/src/lib/deployments/DeploymentsList.svelte
@@ -2,7 +2,6 @@
 import { onMount } from 'svelte';
 
 import type { DeploymentUI } from './DeploymentUI';
-import { filtered, searchPattern } from '../../stores/deployments';
 import NavPage from '../ui/NavPage.svelte';
 import Table from '../table/Table.svelte';
 import { Column, Row } from '../table/table';
@@ -21,16 +20,20 @@ import FilteredEmptyScreen from '../ui/FilteredEmptyScreen.svelte';
 import SimpleColumn from '../table/SimpleColumn.svelte';
 import DurationColumn from '../table/DurationColumn.svelte';
 import KubernetesCurrentContextConnectionBadge from '/@/lib/ui/KubernetesCurrentContextConnectionBadge.svelte';
+import {
+  deploymentSearchPattern,
+  kubernetesCurrentContextDeploymentStateFiltered,
+} from '/@/stores/kubernetes-contexts-state';
 
 export let searchTerm = '';
-$: searchPattern.set(searchTerm);
+$: deploymentSearchPattern.set(searchTerm);
 
 let deployments: DeploymentUI[] = [];
 
 const deploymentUtils = new DeploymentUtils();
 
 onMount(() => {
-  return filtered.subscribe(value => {
+  return kubernetesCurrentContextDeploymentStateFiltered.subscribe(value => {
     deployments = value.map(deployment => deploymentUtils.getDeploymentUI(deployment));
   });
 });
@@ -138,7 +141,7 @@ const row = new Row<DeploymentUI>({ selectable: _deployment => true });
       on:update="{() => (deployments = deployments)}">
     </Table>
 
-    {#if $filtered.length === 0}
+    {#if $kubernetesCurrentContextDeploymentStateFiltered.length === 0}
       {#if searchTerm}
         <FilteredEmptyScreen
           icon="{DeploymentIcon}"

--- a/packages/renderer/src/lib/ingresses-routes/IngressDetails.svelte
+++ b/packages/renderer/src/lib/ingresses-routes/IngressDetails.svelte
@@ -9,11 +9,11 @@ import { stringify } from 'yaml';
 import MonacoEditor from '../editor/MonacoEditor.svelte';
 import type { IngressUI } from './IngressUI';
 import { IngressRouteUtils } from './ingress-route-utils';
-import { ingresses } from '/@/stores/ingresses';
 import IngressRouteActions from './IngressRouteActions.svelte';
 import ServiceDetailsSummary from './IngressRouteDetailsSummary.svelte';
 import ServiceIcon from '../images/ServiceIcon.svelte';
 import Route from '../../Route.svelte';
+import { kubernetesCurrentContextIngressState } from '/@/stores/kubernetes-contexts-state';
 
 export let name: string;
 export let namespace: string;
@@ -26,7 +26,7 @@ let kubeError: string;
 onMount(() => {
   const ingressRouteUtils = new IngressRouteUtils();
 
-  return ingresses.subscribe(ingress => {
+  return kubernetesCurrentContextIngressState.subscribe(ingress => {
     const matchingIngress = ingress.find(srv => srv.metadata?.name === name && srv.metadata?.namespace === namespace);
     if (matchingIngress) {
       try {

--- a/packages/renderer/src/lib/ingresses-routes/IngressesRoutesList.svelte
+++ b/packages/renderer/src/lib/ingresses-routes/IngressesRoutesList.svelte
@@ -12,20 +12,25 @@ import FilteredEmptyScreen from '../ui/FilteredEmptyScreen.svelte';
 import SimpleColumn from '../table/SimpleColumn.svelte';
 import type { IngressUI } from './IngressUI';
 import { IngressRouteUtils } from './ingress-route-utils';
-import { filtered as filteredIngresses, searchPattern as searchPatternIngresses } from '/@/stores/ingresses';
 import IngressRouteIcon from '../images/IngressRouteIcon.svelte';
 import type { RouteUI } from './RouteUI';
 import IngressRouteColumnName from './IngressRouteColumnName.svelte';
 import IngressRouteEmptyScreen from './IngressRouteEmptyScreen.svelte';
 import IngressRouteColumnHostPath from './IngressRouteColumnHostPath.svelte';
 import IngressRouteColumnBackend from './IngressRouteColumnBackend.svelte';
-import { filtered as filteredRoutes, searchPattern as searchPatternRoutes } from '/@/stores/routes';
 import IngressRouteColumnStatus from './IngressRouteColumnStatus.svelte';
 import KubernetesCurrentContextConnectionBadge from '/@/lib/ui/KubernetesCurrentContextConnectionBadge.svelte';
+import {
+  ingressSearchPattern,
+  kubernetesCurrentContextIngressStateFiltered,
+  kubernetesCurrentContextRouteStateFiltered,
+  routeSearchPattern,
+} from '/@/stores/kubernetes-contexts-state';
+import type { V1Route } from '../../../../main/src/plugin/api/openshift-types';
 
 export let searchTerm = '';
-$: searchPatternRoutes.set(searchTerm);
-$: searchPatternIngresses.set(searchTerm);
+$: routeSearchPattern.set(searchTerm);
+$: ingressSearchPattern.set(searchTerm);
 
 let ingressesUI: IngressUI[] = [];
 let routesUI: RouteUI[] = [];
@@ -36,13 +41,13 @@ const ingressRouteUtils = new IngressRouteUtils();
 let ingressesUnsubscribe: Unsubscriber;
 let routesUnsubscribe: Unsubscriber;
 onMount(() => {
-  ingressesUnsubscribe = filteredIngresses.subscribe(value => {
+  ingressesUnsubscribe = kubernetesCurrentContextIngressStateFiltered.subscribe(value => {
     ingressesUI = value.map(ingress => ingressRouteUtils.getIngressUI(ingress));
     ingressesRoutesUI = [...ingressesUI, ...routesUI];
   });
 
-  routesUnsubscribe = filteredRoutes.subscribe(value => {
-    routesUI = value.map(route => ingressRouteUtils.getRouteUI(route));
+  routesUnsubscribe = kubernetesCurrentContextRouteStateFiltered.subscribe(value => {
+    routesUI = value.map(route => ingressRouteUtils.getRouteUI(route as V1Route));
     ingressesRoutesUI = [...ingressesUI, ...routesUI];
   });
 });
@@ -168,7 +173,7 @@ const row = new Row<IngressUI | RouteUI>({ selectable: _ingressRoute => true });
       on:update="{() => (ingressesRoutesUI = ingressesRoutesUI)}">
     </Table>
 
-    {#if $filteredIngresses.length === 0 && $filteredRoutes.length === 0}
+    {#if $kubernetesCurrentContextIngressStateFiltered.length === 0 && $kubernetesCurrentContextRouteStateFiltered.length === 0}
       {#if searchTerm}
         <FilteredEmptyScreen icon="{IngressRouteIcon}" kind="ingresses && routes" bind:searchTerm="{searchTerm}" />
       {:else}

--- a/packages/renderer/src/lib/ingresses-routes/RouteDetails.svelte
+++ b/packages/renderer/src/lib/ingresses-routes/RouteDetails.svelte
@@ -13,7 +13,7 @@ import IngressRouteActions from './IngressRouteActions.svelte';
 import ServiceDetailsSummary from './IngressRouteDetailsSummary.svelte';
 import ServiceIcon from '../images/ServiceIcon.svelte';
 import Route from '../../Route.svelte';
-import { routes } from '/@/stores/routes';
+import { kubernetesCurrentContextRouteState } from '/@/stores/kubernetes-contexts-state';
 
 export let name: string;
 export let namespace: string;
@@ -26,11 +26,11 @@ let kubeError: string;
 onMount(() => {
   const ingressRouteUtils = new IngressRouteUtils();
 
-  return routes.subscribe(route => {
+  return kubernetesCurrentContextRouteState.subscribe(route => {
     const matchingRoute = route.find(srv => srv.metadata?.name === name && srv.metadata?.namespace === namespace);
     if (matchingRoute) {
       try {
-        routeUI = ingressRouteUtils.getRouteUI(matchingRoute);
+        routeUI = ingressRouteUtils.getRouteUI(matchingRoute as V1Route);
         loadRouteDetails();
       } catch (err) {
         console.error(err);

--- a/packages/renderer/src/lib/service/ServiceDetails.svelte
+++ b/packages/renderer/src/lib/service/ServiceDetails.svelte
@@ -10,10 +10,10 @@ import { stringify } from 'yaml';
 import MonacoEditor from '../editor/MonacoEditor.svelte';
 import type { ServiceUI } from './ServiceUI';
 import { ServiceUtils } from './service-utils';
-import { services } from '/@/stores/services';
 import ServiceActions from './ServiceActions.svelte';
 import ServiceDetailsSummary from './ServiceDetailsSummary.svelte';
 import ServiceIcon from '../images/ServiceIcon.svelte';
+import { kubernetesCurrentContextServiceState } from '/@/stores/kubernetes-contexts-state';
 
 export let name: string;
 export let namespace: string;
@@ -26,7 +26,7 @@ let kubeError: string;
 onMount(() => {
   const serviceUtils = new ServiceUtils();
   // loading service info
-  return services.subscribe(services => {
+  return kubernetesCurrentContextServiceState.subscribe(services => {
     const matchingService = services.find(srv => srv.metadata?.name === name && srv.metadata?.namespace === namespace);
     if (matchingService) {
       try {

--- a/packages/renderer/src/lib/service/ServicesList.svelte
+++ b/packages/renderer/src/lib/service/ServicesList.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 import { onMount } from 'svelte';
-import { filtered, searchPattern } from '../../stores/services';
 import NavPage from '../ui/NavPage.svelte';
 import Table from '../table/Table.svelte';
 import { Column, Row } from '../table/table';
@@ -19,16 +18,20 @@ import SimpleColumn from '../table/SimpleColumn.svelte';
 import DurationColumn from '../table/DurationColumn.svelte';
 import ServiceColumnType from './ServiceColumnType.svelte';
 import KubernetesCurrentContextConnectionBadge from '/@/lib/ui/KubernetesCurrentContextConnectionBadge.svelte';
+import {
+  kubernetesCurrentContextServiceStateFiltered,
+  serviceSearchPattern,
+} from '/@/stores/kubernetes-contexts-state';
 
 export let searchTerm = '';
-$: searchPattern.set(searchTerm);
+$: serviceSearchPattern.set(searchTerm);
 
 let services: ServiceUI[] = [];
 
 const serviceUtils = new ServiceUtils();
 
 onMount(() => {
-  return filtered.subscribe(value => {
+  return kubernetesCurrentContextServiceStateFiltered.subscribe(value => {
     services = value.map(service => serviceUtils.getServiceUI(service));
   });
 });
@@ -143,7 +146,7 @@ const row = new Row<ServiceUI>({ selectable: _service => true });
       on:update="{() => (services = services)}">
     </Table>
 
-    {#if $filtered.length === 0}
+    {#if $kubernetesCurrentContextServiceStateFiltered.length === 0}
       {#if searchTerm}
         <FilteredEmptyScreen icon="{ServiceIcon}" kind="services" bind:searchTerm="{searchTerm}" />
       {:else}

--- a/packages/renderer/src/stores/kubernetes-contexts-state.ts
+++ b/packages/renderer/src/stores/kubernetes-contexts-state.ts
@@ -16,9 +16,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { derived, type Readable, readable } from 'svelte/store';
+import { derived, type Readable, readable, writable } from 'svelte/store';
 import type { ContextState } from '../../../main/src/plugin/kubernetes-context-state';
 import { kubernetesContexts } from '/@/stores/kubernetes-contexts';
+import { findMatchInLeaves } from './search-util';
 
 export const kubernetesContextsState = readable(new Map<string, ContextState>(), set => {
   window.kubernetesGetContextsState().then(value => set(value));
@@ -34,4 +35,68 @@ export const kubernetesCurrentContextState: Readable<ContextState | undefined> =
     if (currentContextName === undefined) return undefined;
     return $kubernetesContextsState.get(currentContextName);
   },
+);
+
+// All deployments in the current context
+export const kubernetesCurrentContextDeploymentState = derived(
+  [kubernetesCurrentContextState],
+  ([$kubernetesCurrentContextState]) => {
+    return $kubernetesCurrentContextState?.resources.deployments ?? [];
+  },
+);
+
+export const deploymentSearchPattern = writable('');
+
+// The deployments in the current context, filtered with `deploymentSearchPattern`
+export const kubernetesCurrentContextDeploymentStateFiltered = derived(
+  [deploymentSearchPattern, kubernetesCurrentContextDeploymentState],
+  ([$searchPattern, $deployments]) =>
+    $deployments.filter(deployment => findMatchInLeaves(deployment, $searchPattern.toLowerCase())),
+);
+
+// All services in the current context
+export const kubernetesCurrentContextServiceState = derived(
+  [kubernetesCurrentContextState],
+  ([$kubernetesCurrentContextState]) => {
+    return $kubernetesCurrentContextState?.resources.services ?? [];
+  },
+);
+export const serviceSearchPattern = writable('');
+
+// The services in the current context, filtered with `serviceSearchPattern`
+export const kubernetesCurrentContextServiceStateFiltered = derived(
+  [serviceSearchPattern, kubernetesCurrentContextServiceState],
+  ([$searchPattern, $services]) =>
+    $services.filter(service => findMatchInLeaves(service, $searchPattern.toLowerCase())),
+);
+
+// All ingresses in the current context
+export const kubernetesCurrentContextIngressState = derived(
+  [kubernetesCurrentContextState],
+  ([$kubernetesCurrentContextState]) => {
+    return $kubernetesCurrentContextState?.resources.ingresses ?? [];
+  },
+);
+export const ingressSearchPattern = writable('');
+
+// The ingresses in the current context, filtered with `ingressSearchPattern`
+export const kubernetesCurrentContextIngressStateFiltered = derived(
+  [ingressSearchPattern, kubernetesCurrentContextIngressState],
+  ([$searchPattern, $ingresses]) =>
+    $ingresses.filter(ingress => findMatchInLeaves(ingress, $searchPattern.toLowerCase())),
+);
+
+// All routes in the current context
+export const kubernetesCurrentContextRouteState = derived(
+  [kubernetesCurrentContextState],
+  ([$kubernetesCurrentContextState]) => {
+    return $kubernetesCurrentContextState?.resources.routes ?? [];
+  },
+);
+export const routeSearchPattern = writable('');
+
+// The routes in the current context, filtered with `routeSearchPattern`
+export const kubernetesCurrentContextRouteStateFiltered = derived(
+  [routeSearchPattern, kubernetesCurrentContextRouteState],
+  ([$searchPattern, $routes]) => $routes.filter(route => findMatchInLeaves(route, $searchPattern.toLowerCase())),
 );


### PR DESCRIPTION
### What does this PR do?

After seeing the filtered stores in #6101 I thought I'd see how hard it would be to do the same for ingress/routes/services. This is a quick pass at:
- Adding informers for the three missing types to main/kubernetes-context-state.ts. This is mostly copy/paste from kubernetes-client.ts, only missing one issue on line 331).
- Adding filtered stores to renderer/kubernetes-contexts-state.ts.
- Switching all the pages over to use these stores.

These changes would clearly have to be broken up into multiple PRs and tests updated, but we're not affecting existing UI until #3. After this, the other stores could be removed, as well as informers in kubernetes-client.ts.

Compared to the existing informers, this would fix the existing issues in #5311 with initial connection/reconnection, and would add backoff, but there are two issues we'd have to resolve:
- #6114 - reduce backoff for the current context, it's a bit slow.
- #6094 - we're probably creating too many informers; only loading these new ones for the current context would be enough for now.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes #5311. Fixes #6113.

### How to test this PR?

Draft, but works if anyone wants to try.