### PR TITLE
chore: improve doc nav styling

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -149,6 +149,19 @@ li.footer__item a svg {
   display: none;
 }
 
+/* main nav items bold */
+.theme-doc-sidebar-item-link-level-1 {
+  font-weight: bold;
+}
+li.theme-doc-sidebar-item-category-level-1 > .menu__list-item-collapsible {
+  font-weight: bold;
+}
+
+/* child nav slightly smaller */
+li.theme-doc-sidebar-item-category-level-1 > .menu__list {
+  font-size: 0.85em;
+}
+
 @media (min-width: 1200px) {
   .navbar__title {
     font-size: 2em;


### PR DESCRIPTION
### What does this PR do?

Makes the main doc navigation elements (sections + root pages) bold, and reduces the size of child elements to make the main elements stand out better and child elements wrap less.

### Screenshot / video of UI

Before:

<img width="294" alt="Screenshot 2024-02-24 at 9 59 08 AM" src="https://github.com/containers/podman-desktop/assets/19958075/ed3f79c9-7f5e-45a0-b8c4-b533cd219b68">

After:

<img width="294" alt="Screenshot 2024-02-24 at 9 57 04 AM" src="https://github.com/containers/podman-desktop/assets/19958075/8187b7b5-ecd9-4a62-8edf-d304f4ddf9d5">

### What issues does this PR fix or reference?

Fixes styling part of #5338.

### How to test this PR?

`yarn website:dev`