### PR TITLE
docs: fix missing podman command in WSL example

### DIFF
--- a/website/docs/podman/accessing-podman-from-another-wsl-instance.md
+++ b/website/docs/podman/accessing-podman-from-another-wsl-instance.md
@@ -248,7 +248,7 @@ Verify that, on your WSL distribution, the Podman CLI communicates with your Pod
    On your WSL distribution, start a container such as `quay.io/podman/hello`, and list the name of the last running container:
 
    ```shell-session
-   $ podman quay.io/podman/hello
+   $ podman run quay.io/podman/hello
    $ podman ps -a --no-trunc --last 1
    ```
 


### PR DESCRIPTION
### What does this PR do?

Fix example of calling podman command in WSL documents

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Update #5706, so it relates to #5342

After I wrote this commit, I noticed that @glsee had already pointed out this problem 🙏 https://github.com/containers/podman-desktop/pull/5706/files#r1494603906

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

```console
$ podman --version
podman version 4.9.3
$ podman quay.io/podman/hello
Error: unrecognized command `podman quay.io/podman/hello`
Try 'podman --help' for more information
$ podman run quay.io/podman/hello
!... Hello Podman World ...!

         .--"--.
       / -     - \
      / (O)   (O) \
   ~~~| -=(,Y,)=- |
    .---. /`  \   |~~
 ~/  o  o \~~~~.----. ~~
  | =(X)= |~  / (O (O) \
   ~~~~~~~  ~| =(Y_)=-  |
  ~~~~    ~~~|   U      |~~

Project:   https://github.com/containers/podman
Website:   https://podman.io
Desktop:   https://podman-desktop.io
Documents: https://docs.podman.io
YouTube:   https://youtube.com/@Podman
X/Twitter: @Podman_io
Mastodon:  @Podman_io@fosstodon.org
```

- [x] Tests are covering the bug fix or the new feature
