### PR TITLE
chore: leftover change from window.openFolderDialog

### DIFF
--- a/packages/renderer/src/lib/image/RunImage.svelte
+++ b/packages/renderer/src/lib/image/RunImage.svelte
@@ -512,10 +512,13 @@ function deleteHostContainerPorts(index: number) {
 
 async function browseFolders(index: number) {
   // need to show the dialog to open a folder and then we update the source of the given index
-  const result = await window.openFolderDialog('Select a directory to mount in the container');
+  const result = await window.openDialog({
+    title: 'Select a directory to mount in the container',
+    selectors: ['openDirectory'],
+  });
 
-  if (!result.canceled && result.filePaths.length === 1) {
-    volumeMounts[index].source = result.filePaths[0];
+  if (result?.length === 1) {
+    volumeMounts[index].source = result[0];
   }
 }
 


### PR DESCRIPTION
### What does this PR do?
use the new generic API instead openDialog

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

https://github.com/containers/podman-desktop/issues/5987

### How to test this PR?

try to select a volume when running a container from an image