### PR TITLE
feat: send contexts status on different channels

### DIFF
--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -159,7 +159,7 @@ import { ColorRegistry } from './color-registry.js';
 import { DialogRegistry } from './dialog-registry.js';
 import type { Deferred } from './util/deferred.js';
 import { Updater } from '/@/plugin/updater.js';
-import type { ContextGeneralState } from './kubernetes-context-state.js';
+import type { ContextGeneralState, ResourceName } from './kubernetes-context-state.js';
 
 type LogType = 'log' | 'warn' | 'trace' | 'debug' | 'error';
 
@@ -1910,6 +1910,13 @@ export class PluginSystem {
     this.ipcHandle('kubernetes-client:getCurrentContextGeneralState', async (): Promise<ContextGeneralState> => {
       return kubernetesClient.getCurrentContextGeneralState();
     });
+
+    this.ipcHandle(
+      'kubernetes-client:getCurrentContextResources',
+      async (_listener, resourceName: ResourceName): Promise<KubernetesObject[]> => {
+        return kubernetesClient.getCurrentContextResources(resourceName);
+      },
+    );
 
     this.ipcHandle('feedback:send', async (_listener, feedbackProperties: unknown): Promise<void> => {
       return telemetry.sendFeedback(feedbackProperties);

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -158,8 +158,8 @@ import type { ColorInfo } from './api/color-info.js';
 import { ColorRegistry } from './color-registry.js';
 import { DialogRegistry } from './dialog-registry.js';
 import type { Deferred } from './util/deferred.js';
-import type { ContextState } from './kubernetes-context-state.js';
 import { Updater } from '/@/plugin/updater.js';
+import type { ContextGeneralState } from './kubernetes-context-state.js';
 
 type LogType = 'log' | 'warn' | 'trace' | 'debug' | 'error';
 
@@ -1903,8 +1903,8 @@ export class PluginSystem {
       return kubernetesClient.setContext(contextName);
     });
 
-    this.ipcHandle('kubernetes-client:getContextsState', async (): Promise<Map<string, ContextState>> => {
-      return kubernetesClient.getContextsState();
+    this.ipcHandle('kubernetes-client:getContextsGeneralState', async (): Promise<Map<string, ContextGeneralState>> => {
+      return kubernetesClient.getContextsGeneralState();
     });
 
     this.ipcHandle('feedback:send', async (_listener, feedbackProperties: unknown): Promise<void> => {

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1907,6 +1907,10 @@ export class PluginSystem {
       return kubernetesClient.getContextsGeneralState();
     });
 
+    this.ipcHandle('kubernetes-client:getCurrentContextGeneralState', async (): Promise<ContextGeneralState> => {
+      return kubernetesClient.getCurrentContextGeneralState();
+    });
+
     this.ipcHandle('feedback:send', async (_listener, feedbackProperties: unknown): Promise<void> => {
       return telemetry.sendFeedback(feedbackProperties);
     });

--- a/packages/main/src/plugin/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes-client.ts
@@ -1356,4 +1356,8 @@ export class KubernetesClient {
   public getContextsGeneralState(): Map<string, ContextGeneralState> {
     return this.contextsState.getContextsGeneralState();
   }
+
+  public getCurrentContextGeneralState(): ContextGeneralState {
+    return this.contextsState.getCurrentContextGeneralState();
+  }
 }

--- a/packages/main/src/plugin/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes-client.ts
@@ -68,7 +68,7 @@ import type { KubernetesInformerManager } from './kubernetes-informer-registry.j
 import type { KubernetesInformerResourcesType } from './api/kubernetes-informer-info.js';
 import type { IncomingMessage } from 'node:http';
 import { ContextsManager } from './kubernetes-context-state.js';
-import type { ContextState } from './kubernetes-context-state.js';
+import type { ContextGeneralState } from './kubernetes-context-state.js';
 
 interface KubernetesObjectWithKind extends KubernetesObject {
   kind: string;
@@ -1353,7 +1353,7 @@ export class KubernetesClient {
     }
   }
 
-  public getContextsState(): Map<string, ContextState> {
-    return this.contextsState.getContextsState();
+  public getContextsGeneralState(): Map<string, ContextGeneralState> {
+    return this.contextsState.getContextsGeneralState();
   }
 }

--- a/packages/main/src/plugin/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes-client.ts
@@ -68,7 +68,7 @@ import type { KubernetesInformerManager } from './kubernetes-informer-registry.j
 import type { KubernetesInformerResourcesType } from './api/kubernetes-informer-info.js';
 import type { IncomingMessage } from 'node:http';
 import { ContextsManager } from './kubernetes-context-state.js';
-import type { ContextGeneralState } from './kubernetes-context-state.js';
+import type { ContextGeneralState, ResourceName } from './kubernetes-context-state.js';
 
 interface KubernetesObjectWithKind extends KubernetesObject {
   kind: string;
@@ -1359,5 +1359,9 @@ export class KubernetesClient {
 
   public getCurrentContextGeneralState(): ContextGeneralState {
     return this.contextsState.getCurrentContextGeneralState();
+  }
+
+  public getCurrentContextResources(resourceName: ResourceName): KubernetesObject[] {
+    return this.contextsState.getCurrentContextResources(resourceName);
   }
 }

--- a/packages/main/src/plugin/kubernetes-context-state.spec.ts
+++ b/packages/main/src/plugin/kubernetes-context-state.spec.ts
@@ -222,7 +222,14 @@ test('should send info of resources in all reachable contexts and nothing in non
   } as ContextGeneralState);
   await new Promise(resolve => setTimeout(resolve, 2));
   expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-contexts-general-state-update', expectedMap);
-
+  expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-current-context-general-state-update', {
+    reachable: true,
+    error: undefined,
+    resources: {
+      pods: 1,
+      deployments: 4,
+    },
+  });
   // => removing contexts, should remving clusters from sent info
   kubeConfig.loadFromOptions({
     clusters: [
@@ -292,7 +299,15 @@ test('should send info of resources in all reachable contexts and nothing in non
     },
   } as ContextGeneralState);
   await new Promise(resolve => setTimeout(resolve, 2));
-  expect(apiSenderSendMock).toHaveBeenLastCalledWith('kubernetes-contexts-general-state-update', expectedMap);
+  expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-contexts-general-state-update', expectedMap);
+  expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-current-context-general-state-update', {
+    reachable: true,
+    error: undefined,
+    resources: {
+      pods: 1,
+      deployments: 4,
+    },
+  });
 });
 
 test('should write logs when connection fails', async () => {

--- a/packages/main/src/plugin/kubernetes-context-state.spec.ts
+++ b/packages/main/src/plugin/kubernetes-context-state.spec.ts
@@ -23,6 +23,18 @@ import type { ApiSenderType } from './api.js';
 import * as kubeclient from '@kubernetes/client-node';
 import type { ErrorCallback, KubernetesObject, ObjectCallback } from '@kubernetes/client-node';
 
+interface InformerEvent {
+  delayMs: number;
+  verb: string;
+  object: KubernetesObject;
+}
+
+interface InformerErrorEvent {
+  delayMs: number;
+  verb: string;
+  error: string;
+}
+
 export class FakeInformer {
   private onCb: Map<string, ObjectCallback<KubernetesObject>>;
   private offCb: Map<string, ObjectCallback<KubernetesObject>>;
@@ -31,6 +43,8 @@ export class FakeInformer {
   constructor(
     private resourcesCount: number,
     private connectResponse: Error | undefined,
+    private events: InformerEvent[],
+    private errorEvents: InformerErrorEvent[],
   ) {
     this.onCb = new Map<string, ObjectCallback<KubernetesObject>>();
     this.offCb = new Map<string, ObjectCallback<KubernetesObject>>();
@@ -45,6 +59,16 @@ export class FakeInformer {
       for (let i = 0; i < this.resourcesCount; i++) {
         this.onCb.get('add')?.({});
       }
+      this.events.forEach(event => {
+        setTimeout(() => {
+          this.onCb.get(event.verb)?.(event.object);
+        }, event.delayMs);
+      });
+      this.errorEvents.forEach(event => {
+        setTimeout(() => {
+          this.onErrorCb.get(event.verb)?.(event.error);
+        }, event.delayMs);
+      });
     }
   }
   stop(): void {}
@@ -87,20 +111,20 @@ function fakeMakeInformer(
   }
   switch (path) {
     case '/api/v1/namespaces/ns1/pods':
-      return new FakeInformer(1, connectResult);
+      return new FakeInformer(1, connectResult, [], []);
     case '/api/v1/namespaces/ns2/pods':
-      return new FakeInformer(2, connectResult);
+      return new FakeInformer(2, connectResult, [], []);
     case '/api/v1/namespaces/default/pods':
-      return new FakeInformer(3, connectResult);
+      return new FakeInformer(3, connectResult, [], []);
 
     case '/apis/apps/v1/namespaces/ns1/deployments':
-      return new FakeInformer(4, connectResult);
+      return new FakeInformer(4, connectResult, [], []);
     case '/apis/apps/v1/namespaces/ns2/deployments':
-      return new FakeInformer(5, connectResult);
+      return new FakeInformer(5, connectResult, [], []);
     case '/apis/apps/v1/namespaces/default/deployments':
-      return new FakeInformer(6, connectResult);
+      return new FakeInformer(6, connectResult, [], []);
   }
-  return new FakeInformer(0, connectResult);
+  return new FakeInformer(0, connectResult, [], []);
 }
 
 const apiSenderSendMock = vi.fn();
@@ -109,20 +133,27 @@ const apiSender: ApiSenderType = {
   receive: vi.fn(),
 };
 
+const mocks = vi.hoisted(() => {
+  return {
+    makeInformerMock: vi.fn(),
+  };
+});
+
 vi.mock('@kubernetes/client-node', async importOriginal => {
   const actual = await importOriginal<typeof kubeclient>();
   return {
     ...actual,
-    makeInformer: fakeMakeInformer,
+    makeInformer: mocks.makeInformerMock,
   };
 });
 
+// Needs to mock these values to make the backoff much longer than other timeouts, so connection are never retried during the tests
 vi.mock('./kubernetes-context-state-constants.js', () => {
   return {
     connectTimeout: 1,
     backoffInitialValue: 1000,
     backoffLimit: 1000,
-    backoffJitter: 1,
+    backoffJitter: 0,
   };
 });
 
@@ -130,15 +161,17 @@ const originalConsoleDebug = console.debug;
 const consoleDebugMock = vi.fn();
 
 beforeEach(() => {
-  vi.resetAllMocks();
   console.debug = consoleDebugMock;
+  vi.useFakeTimers();
 });
 
 afterEach(() => {
   console.debug = originalConsoleDebug;
+  vi.resetAllMocks();
 });
 
 test('should send info of resources in all reachable contexts and nothing in non reachable', async () => {
+  mocks.makeInformerMock.mockImplementation(fakeMakeInformer);
   const client = new ContextsManager(apiSender);
   const kubeConfig = new kubeclient.KubeConfig();
   const config = {
@@ -221,7 +254,8 @@ test('should send info of resources in all reachable contexts and nothing in non
       deployments: 5,
     },
   } as ContextGeneralState);
-  await new Promise(resolve => setTimeout(resolve, 2));
+  vi.advanceTimersToNextTimer();
+  expect(apiSenderSendMock).toHaveBeenCalledTimes(4);
   expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-contexts-general-state-update', expectedMap);
   expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-current-context-general-state-update', {
     reachable: true,
@@ -242,10 +276,10 @@ test('should send info of resources in all reachable contexts and nothing in non
     currentContext: 'context1',
   });
 
-  vi.clearAllMocks();
+  apiSenderSendMock.mockReset();
   await client.update(kubeConfig);
 
-  await new Promise(resolve => setTimeout(resolve, 1200));
+  vi.advanceTimersToNextTimer();
   expect(apiSenderSendMock).toHaveBeenCalledTimes(4);
   expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-contexts-general-state-update', expectedMap);
   expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-current-context-general-state-update', {
@@ -268,7 +302,7 @@ test('should send info of resources in all reachable contexts and nothing in non
     currentContext: 'context2-1',
   });
 
-  vi.clearAllMocks();
+  apiSenderSendMock.mockReset();
   await client.update(kubeConfig);
   expectedMap = new Map<string, ContextGeneralState>();
   expectedMap.set('context1', {
@@ -295,7 +329,9 @@ test('should send info of resources in all reachable contexts and nothing in non
       deployments: 4,
     },
   } as ContextGeneralState);
-  await new Promise(resolve => setTimeout(resolve, 2));
+
+  vi.advanceTimersToNextTimer();
+  expect(apiSenderSendMock).toHaveBeenCalledTimes(4);
   expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-contexts-general-state-update', expectedMap);
   expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-current-context-general-state-update', {
     reachable: true,
@@ -310,6 +346,7 @@ test('should send info of resources in all reachable contexts and nothing in non
 });
 
 test('should write logs when connection fails', async () => {
+  mocks.makeInformerMock.mockImplementation(fakeMakeInformer);
   const client = new ContextsManager(apiSender);
   const kubeConfig = new kubeclient.KubeConfig();
   kubeConfig.loadFromOptions({
@@ -339,4 +376,442 @@ test('should write logs when connection fails', async () => {
       /Trying to watch pods on the kubernetes context named "context1" but got a connection refused, retrying the connection in [0-9]*s. Error: connection error/,
     ),
   );
+});
+
+test('should send new deployment when a new one is created', async () => {
+  mocks.makeInformerMock.mockImplementation(
+    (
+      _kubeconfig: kubeclient.KubeConfig,
+      path: string,
+      _listPromiseFn: kubeclient.ListPromise<kubeclient.KubernetesObject>,
+    ) => {
+      const connectResult = undefined;
+      switch (path) {
+        case '/api/v1/namespaces/ns1/pods':
+          return new FakeInformer(0, connectResult, [], []);
+        case '/apis/apps/v1/namespaces/ns1/deployments':
+          return new FakeInformer(
+            0,
+            connectResult,
+            [
+              {
+                delayMs: 5,
+                verb: 'add',
+                object: { metadata: { name: 'deploy1' } },
+              },
+            ],
+            [],
+          );
+      }
+      return new FakeInformer(0, connectResult, [], []);
+    },
+  );
+  const client = new ContextsManager(apiSender);
+  const kubeConfig = new kubeclient.KubeConfig();
+  const config = {
+    clusters: [
+      {
+        name: 'cluster1',
+        server: 'server1',
+      },
+    ],
+    users: [
+      {
+        name: 'user1',
+      },
+    ],
+    contexts: [
+      {
+        name: 'context1',
+        cluster: 'cluster1',
+        user: 'user1',
+        namespace: 'ns1',
+      },
+    ],
+    currentContext: 'context1',
+  };
+  kubeConfig.loadFromOptions(config);
+  await client.update(kubeConfig);
+  vi.advanceTimersToNextTimer(); // dispatches
+  const expectedMap = new Map<string, ContextGeneralState>();
+  expectedMap.set('context1', {
+    reachable: true,
+    error: undefined,
+    resources: {
+      pods: 0,
+      deployments: 0,
+    },
+  });
+  expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-contexts-general-state-update', expectedMap);
+  expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-current-context-general-state-update', {
+    reachable: true,
+    error: undefined,
+    resources: {
+      pods: 0,
+      deployments: 0,
+    },
+  });
+  expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-current-context-pods-update', []);
+  expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-current-context-deployments-update', []);
+
+  apiSenderSendMock.mockReset();
+  vi.advanceTimersToNextTimer(); // add event
+  vi.advanceTimersToNextTimer(); // dispatches
+  expectedMap.set('context1', {
+    reachable: true,
+    error: undefined,
+    resources: {
+      pods: 0,
+      deployments: 1,
+    },
+  });
+  expect(apiSenderSendMock).toHaveBeenCalledTimes(3);
+  expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-contexts-general-state-update', expectedMap);
+  expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-current-context-general-state-update', {
+    reachable: true,
+    error: undefined,
+    resources: {
+      pods: 0,
+      deployments: 1,
+    },
+  });
+  expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-current-context-deployments-update', [
+    { metadata: { name: 'deploy1' } },
+  ]);
+});
+
+test('should delete deployment when deleted from context', async () => {
+  mocks.makeInformerMock.mockImplementation(
+    (
+      _kubeconfig: kubeclient.KubeConfig,
+      path: string,
+      _listPromiseFn: kubeclient.ListPromise<kubeclient.KubernetesObject>,
+    ) => {
+      const connectResult = undefined;
+      switch (path) {
+        case '/api/v1/namespaces/ns1/pods':
+          return new FakeInformer(0, connectResult, [], []);
+        case '/apis/apps/v1/namespaces/ns1/deployments':
+          return new FakeInformer(
+            0,
+            connectResult,
+            [
+              {
+                delayMs: 0,
+                verb: 'add',
+                object: { metadata: { uid: 'deploy1' } },
+              },
+              {
+                delayMs: 0,
+                verb: 'add',
+                object: { metadata: { uid: 'deploy2' } },
+              },
+              {
+                delayMs: 5,
+                verb: 'delete',
+                object: { metadata: { uid: 'deploy1' } },
+              },
+            ],
+            [],
+          );
+      }
+      return new FakeInformer(0, connectResult, [], []);
+    },
+  );
+  const client = new ContextsManager(apiSender);
+  const kubeConfig = new kubeclient.KubeConfig();
+  const config = {
+    clusters: [
+      {
+        name: 'cluster1',
+        server: 'server1',
+      },
+    ],
+    users: [
+      {
+        name: 'user1',
+      },
+    ],
+    contexts: [
+      {
+        name: 'context1',
+        cluster: 'cluster1',
+        user: 'user1',
+        namespace: 'ns1',
+      },
+    ],
+    currentContext: 'context1',
+  };
+  kubeConfig.loadFromOptions(config);
+  await client.update(kubeConfig);
+  vi.advanceTimersToNextTimer(); // add events
+  vi.advanceTimersToNextTimer(); // dispatches
+  const expectedMap = new Map<string, ContextGeneralState>();
+  expectedMap.set('context1', {
+    reachable: true,
+    error: undefined,
+    resources: {
+      pods: 0,
+      deployments: 2,
+    },
+  });
+  expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-contexts-general-state-update', expectedMap);
+  expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-current-context-general-state-update', {
+    reachable: true,
+    error: undefined,
+    resources: {
+      pods: 0,
+      deployments: 2,
+    },
+  });
+  expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-current-context-pods-update', []);
+  expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-current-context-deployments-update', [
+    { metadata: { uid: 'deploy1' } },
+    { metadata: { uid: 'deploy2' } },
+  ]);
+
+  apiSenderSendMock.mockReset();
+  vi.advanceTimersToNextTimer(); // 'delete' event
+  vi.advanceTimersToNextTimer(); // dispatches
+
+  expectedMap.set('context1', {
+    reachable: true,
+    error: undefined,
+    resources: {
+      pods: 0,
+      deployments: 1,
+    },
+  });
+  expect(apiSenderSendMock).toHaveBeenCalledTimes(3);
+  expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-contexts-general-state-update', expectedMap);
+  expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-current-context-general-state-update', {
+    reachable: true,
+    error: undefined,
+    resources: {
+      pods: 0,
+      deployments: 1,
+    },
+  });
+  expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-current-context-deployments-update', [
+    { metadata: { uid: 'deploy2' } },
+  ]);
+});
+
+test('should update deployment when updated on context', async () => {
+  mocks.makeInformerMock.mockImplementation(
+    (
+      _kubeconfig: kubeclient.KubeConfig,
+      path: string,
+      _listPromiseFn: kubeclient.ListPromise<kubeclient.KubernetesObject>,
+    ) => {
+      const connectResult = undefined;
+      switch (path) {
+        case '/api/v1/namespaces/ns1/pods':
+          return new FakeInformer(0, connectResult, [], []);
+        case '/apis/apps/v1/namespaces/ns1/deployments':
+          return new FakeInformer(
+            0,
+            connectResult,
+            [
+              {
+                delayMs: 0,
+                verb: 'add',
+                object: { metadata: { uid: 'deploy1', name: 'name1' } },
+              },
+              {
+                delayMs: 0,
+                verb: 'add',
+                object: { metadata: { uid: 'deploy2', name: 'name2' } },
+              },
+              {
+                delayMs: 5,
+                verb: 'update',
+                object: { metadata: { uid: 'deploy1', name: 'name1new' } },
+              },
+            ],
+            [],
+          );
+      }
+      return new FakeInformer(0, connectResult, [], []);
+    },
+  );
+  const client = new ContextsManager(apiSender);
+  const kubeConfig = new kubeclient.KubeConfig();
+  const config = {
+    clusters: [
+      {
+        name: 'cluster1',
+        server: 'server1',
+      },
+    ],
+    users: [
+      {
+        name: 'user1',
+      },
+    ],
+    contexts: [
+      {
+        name: 'context1',
+        cluster: 'cluster1',
+        user: 'user1',
+        namespace: 'ns1',
+      },
+    ],
+    currentContext: 'context1',
+  };
+  kubeConfig.loadFromOptions(config);
+  await client.update(kubeConfig);
+  vi.advanceTimersToNextTimer(); // add events
+  vi.advanceTimersToNextTimer(); // dispatches
+  const expectedMap = new Map<string, ContextGeneralState>();
+  expectedMap.set('context1', {
+    reachable: true,
+    error: undefined,
+    resources: {
+      pods: 0,
+      deployments: 2,
+    },
+  });
+  expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-contexts-general-state-update', expectedMap);
+  expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-current-context-general-state-update', {
+    reachable: true,
+    error: undefined,
+    resources: {
+      pods: 0,
+      deployments: 2,
+    },
+  });
+  expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-current-context-pods-update', []);
+  expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-current-context-deployments-update', [
+    { metadata: { uid: 'deploy1', name: 'name1' } },
+    { metadata: { uid: 'deploy2', name: 'name2' } },
+  ]);
+
+  apiSenderSendMock.mockReset();
+  vi.advanceTimersToNextTimer(); // update event
+  vi.advanceTimersToNextTimer(); // dispatches
+  expectedMap.set('context1', {
+    reachable: true,
+    error: undefined,
+    resources: {
+      pods: 0,
+      deployments: 2,
+    },
+  });
+  expect(apiSenderSendMock).toHaveBeenCalledTimes(3);
+  expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-contexts-general-state-update', expectedMap);
+  expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-current-context-general-state-update', {
+    reachable: true,
+    error: undefined,
+    resources: {
+      pods: 0,
+      deployments: 2,
+    },
+  });
+  expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-current-context-deployments-update', [
+    { metadata: { uid: 'deploy2', name: 'name2' } },
+    { metadata: { uid: 'deploy1', name: 'name1new' } },
+  ]);
+});
+
+test('should send appropriate data when context becomes unreachable', async () => {
+  mocks.makeInformerMock.mockImplementation(
+    (
+      _kubeconfig: kubeclient.KubeConfig,
+      path: string,
+      _listPromiseFn: kubeclient.ListPromise<kubeclient.KubernetesObject>,
+    ) => {
+      const connectResult = undefined;
+      switch (path) {
+        case '/api/v1/namespaces/ns1/pods':
+          return new FakeInformer(
+            0,
+            connectResult,
+            [],
+            [
+              {
+                delayMs: 5,
+                verb: 'error',
+                error: 'connection error',
+              },
+            ],
+          );
+        case '/apis/apps/v1/namespaces/ns1/deployments':
+          return new FakeInformer(2, connectResult, [], []);
+      }
+      return new FakeInformer(0, connectResult, [], []);
+    },
+  );
+  const client = new ContextsManager(apiSender);
+  const kubeConfig = new kubeclient.KubeConfig();
+  const config = {
+    clusters: [
+      {
+        name: 'cluster1',
+        server: 'server1',
+      },
+    ],
+    users: [
+      {
+        name: 'user1',
+      },
+    ],
+    contexts: [
+      {
+        name: 'context1',
+        cluster: 'cluster1',
+        user: 'user1',
+        namespace: 'ns1',
+      },
+    ],
+    currentContext: 'context1',
+  };
+  kubeConfig.loadFromOptions(config);
+  await client.update(kubeConfig);
+  vi.advanceTimersToNextTimer(); // dispatches
+  const expectedMap = new Map<string, ContextGeneralState>();
+  expectedMap.set('context1', {
+    reachable: true,
+    error: undefined,
+    resources: {
+      pods: 0,
+      deployments: 2,
+    },
+  });
+  expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-contexts-general-state-update', expectedMap);
+  expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-current-context-general-state-update', {
+    reachable: true,
+    error: undefined,
+    resources: {
+      pods: 0,
+      deployments: 2,
+    },
+  });
+  expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-current-context-pods-update', []);
+  expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-current-context-deployments-update', [{}, {}]);
+
+  apiSenderSendMock.mockReset();
+  vi.advanceTimersToNextTimer(); // error event
+  vi.advanceTimersToNextTimer(); // dispatches
+  // This time, we do not check the number of calls, as the connection will be retried, and calls will be done after each retry
+  expectedMap.set('context1', {
+    reachable: false,
+    error: 'connection error',
+    resources: {
+      pods: 0,
+      deployments: 0,
+    },
+  });
+  expect(apiSenderSendMock).toHaveBeenCalledTimes(4);
+  expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-contexts-general-state-update', expectedMap);
+  expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-current-context-general-state-update', {
+    reachable: false,
+    error: 'connection error',
+    resources: {
+      pods: 0,
+      deployments: 0,
+    },
+  });
+  expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-current-context-pods-update', []);
+  expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-current-context-deployments-update', []);
 });

--- a/packages/main/src/plugin/kubernetes-context-state.spec.ts
+++ b/packages/main/src/plugin/kubernetes-context-state.spec.ts
@@ -230,6 +230,8 @@ test('should send info of resources in all reachable contexts and nothing in non
       deployments: 4,
     },
   });
+  expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-current-context-pods-update', [{}]);
+  expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-current-context-deployments-update', [{}, {}, {}, {}]);
   // => removing contexts, should remving clusters from sent info
   kubeConfig.loadFromOptions({
     clusters: [
@@ -308,6 +310,8 @@ test('should send info of resources in all reachable contexts and nothing in non
       deployments: 4,
     },
   });
+  expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-current-context-pods-update', [{}]);
+  expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-current-context-deployments-update', [{}, {}, {}, {}]);
 });
 
 test('should write logs when connection fails', async () => {

--- a/packages/main/src/plugin/kubernetes-context-state.spec.ts
+++ b/packages/main/src/plugin/kubernetes-context-state.spec.ts
@@ -17,7 +17,7 @@
  ***********************************************************************/
 
 import { beforeEach, afterEach, expect, test, vi } from 'vitest';
-import type { ContextState } from './kubernetes-context-state.js';
+import type { ContextGeneralState } from './kubernetes-context-state.js';
 import { ContextsManager } from './kubernetes-context-state.js';
 import type { ApiSenderType } from './api.js';
 import * as kubeclient from '@kubernetes/client-node';
@@ -187,41 +187,41 @@ test('should send info of resources in all reachable contexts and nothing in non
     currentContext: 'context2-1',
   });
   await client.update(kubeConfig);
-  let expectedMap = new Map<string, ContextState>();
+  let expectedMap = new Map<string, ContextGeneralState>();
   expectedMap.set('context1', {
     reachable: false,
     error: 'Error: connection error',
     resources: {
-      pods: [],
-      deployments: [],
+      pods: 0,
+      deployments: 0,
     },
-  } as ContextState);
+  } as ContextGeneralState);
   expectedMap.set('context2', {
     reachable: true,
     error: undefined,
     resources: {
-      pods: [{}, {}, {}],
-      deployments: [{}, {}, {}, {}, {}, {}],
+      pods: 3,
+      deployments: 6,
     },
-  } as ContextState);
+  } as ContextGeneralState);
   expectedMap.set('context2-1', {
     reachable: true,
     error: undefined,
     resources: {
-      pods: [{}],
-      deployments: [{}, {}, {}, {}],
+      pods: 1,
+      deployments: 4,
     },
-  } as ContextState);
+  } as ContextGeneralState);
   expectedMap.set('context2-2', {
     reachable: true,
     error: undefined,
     resources: {
-      pods: [{}, {}],
-      deployments: [{}, {}, {}, {}, {}],
+      pods: 2,
+      deployments: 5,
     },
-  } as ContextState);
+  } as ContextGeneralState);
   await new Promise(resolve => setTimeout(resolve, 2));
-  expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-contexts-state-update', expectedMap);
+  expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-contexts-general-state-update', expectedMap);
 
   // => removing contexts, should remving clusters from sent info
   kubeConfig.loadFromOptions({
@@ -266,33 +266,33 @@ test('should send info of resources in all reachable contexts and nothing in non
 
   vi.clearAllMocks();
   await client.update(kubeConfig);
-  expectedMap = new Map<string, ContextState>();
+  expectedMap = new Map<string, ContextGeneralState>();
   expectedMap.set('context1', {
     reachable: false,
     error: 'Error: connection error',
     resources: {
-      pods: [],
-      deployments: [],
+      pods: 0,
+      deployments: 0,
     },
-  } as ContextState);
+  } as ContextGeneralState);
   expectedMap.set('context2', {
     reachable: true,
     error: undefined,
     resources: {
-      pods: [{}, {}, {}],
-      deployments: [{}, {}, {}, {}, {}, {}],
+      pods: 3,
+      deployments: 6,
     },
-  } as ContextState);
+  } as ContextGeneralState);
   expectedMap.set('context2-1', {
     reachable: true,
     error: undefined,
     resources: {
-      pods: [{}],
-      deployments: [{}, {}, {}, {}],
+      pods: 1,
+      deployments: 4,
     },
-  } as ContextState);
+  } as ContextGeneralState);
   await new Promise(resolve => setTimeout(resolve, 2));
-  expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-contexts-state-update', expectedMap);
+  expect(apiSenderSendMock).toHaveBeenLastCalledWith('kubernetes-contexts-general-state-update', expectedMap);
 });
 
 test('should write logs when connection fails', async () => {

--- a/packages/main/src/plugin/kubernetes-context-state.ts
+++ b/packages/main/src/plugin/kubernetes-context-state.ts
@@ -96,7 +96,7 @@ class Backoff {
 }
 
 class ContextsStates {
-  private published = new Map<string, ContextState>();
+  private state = new Map<string, ContextState>();
   private informers = new Map<string, ContextInternalState>();
 
   has(name: string): boolean {
@@ -114,12 +114,12 @@ class ContextsStates {
   }
 
   getPublished(): Map<string, ContextState> {
-    return this.published;
+    return this.state;
   }
 
   safeSetState(name: string, update: (previous: ContextState) => void): void {
-    if (!this.published.has(name)) {
-      this.published.set(name, {
+    if (!this.state.has(name)) {
+      this.state.set(name, {
         error: undefined,
         reachable: false,
         resources: {
@@ -128,7 +128,7 @@ class ContextsStates {
         },
       });
     }
-    const val = this.published.get(name);
+    const val = this.state.get(name);
     if (!val) {
       throw new Error('value not correctly set in map');
     }
@@ -139,7 +139,7 @@ class ContextsStates {
     await this.informers.get(name)?.podInformer?.stop();
     await this.informers.get(name)?.deploymentInformer?.stop();
     this.informers.delete(name);
-    this.published.delete(name);
+    this.state.delete(name);
   }
 }
 

--- a/packages/main/src/plugin/kubernetes-context-state.ts
+++ b/packages/main/src/plugin/kubernetes-context-state.ts
@@ -148,8 +148,8 @@ class ContextsStates {
       result.set(key, {
         ...val,
         resources: {
-          pods: val.resources.pods.length,
-          deployments: val.resources.deployments.length,
+          pods: val.reachable ? val.resources.pods.length : 0,
+          deployments: val.reachable ? val.resources.deployments.length : 0,
         },
       });
     });
@@ -163,8 +163,8 @@ class ContextsStates {
         return {
           ...state,
           resources: {
-            pods: state.resources.pods.length,
-            deployments: state.resources.deployments.length,
+            pods: state.reachable ? state.resources.pods.length : 0,
+            deployments: state.reachable ? state.resources.deployments.length : 0,
           },
         };
       }
@@ -484,7 +484,7 @@ export class ContextsManager {
         `kubernetes-current-context-general-state-update`,
         this.states.getCurrentContextGeneralState(this.kubeConfig.currentContext),
       );
-    }, 1000);
+    }, connectTimeout);
   }
 
   public getCurrentContextGeneralState(): ContextGeneralState {
@@ -502,7 +502,7 @@ export class ContextsManager {
           `kubernetes-current-context-${resourceName}-update`,
           this.states.getCurrentContextResources(this.kubeConfig.currentContext, resourceName),
         );
-      }, 1000),
+      }, connectTimeout),
     );
   }
 

--- a/packages/main/src/plugin/kubernetes-context-state.ts
+++ b/packages/main/src/plugin/kubernetes-context-state.ts
@@ -93,7 +93,7 @@ interface DispatchOptions {
   contextsGeneralState: boolean;
   // do we send general context for current context?
   currentContextGeneralState: boolean;
-  // do we end resources data for each resource kind? default false for all resources
+  // do we send resources data for each resource kind? default false for all resources
   resources: ResourcesDispatchOptions;
 }
 

--- a/packages/main/src/plugin/kubernetes-context-state.ts
+++ b/packages/main/src/plugin/kubernetes-context-state.ts
@@ -476,7 +476,7 @@ export class ContextsManager {
   }
 
   private currentStateTimeoutId: NodeJS.Timeout | undefined;
-  private dispatchCurrentContextGeneralState() {
+  private dispatchCurrentContextGeneralState(): void {
     // Debounce: send only the latest value if several values are sent in a short period
     clearTimeout(this.currentStateTimeoutId);
     this.currentStateTimeoutId = setTimeout(() => {
@@ -492,7 +492,7 @@ export class ContextsManager {
   }
 
   private resourceTimeoutId = new Map<ResourceName, NodeJS.Timeout>();
-  private dispatchCurrentContextResource(resourceName: ResourceName) {
+  private dispatchCurrentContextResource(resourceName: ResourceName): void {
     // Debounce: send only the latest value if several values are sent in a short period
     clearTimeout(this.resourceTimeoutId.get(resourceName));
     this.resourceTimeoutId.set(

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -95,7 +95,7 @@ import type { KubernetesGeneratorInfo } from '../../main/src/plugin/api/Kubernet
 import type { NotificationCard, NotificationCardOptions } from '../../main/src/plugin/api/notification';
 import type { ApiSenderType } from '../../main/src/plugin/api';
 import type { IDisposable } from '../../main/src/plugin/types/disposable';
-import type { ContextGeneralState } from '../../main/src/plugin/kubernetes-context-state.js';
+import type { ContextGeneralState, ResourceName } from '../../main/src/plugin/kubernetes-context-state.js';
 
 export type DialogResultCallback = (openDialogReturnValue: Electron.OpenDialogReturnValue) => void;
 export type OpenSaveDialogResultCallback = (result: string | string[] | undefined) => void;
@@ -1577,6 +1577,12 @@ export function initExposure(): void {
   contextBridge.exposeInMainWorld('kubernetesGetCurrentContextGeneralState', async (): Promise<ContextGeneralState> => {
     return ipcInvoke('kubernetes-client:getCurrentContextGeneralState');
   });
+  contextBridge.exposeInMainWorld(
+    'kubernetesGetCurrentContextResources',
+    async (resourceName: ResourceName): Promise<KubernetesObject[]> => {
+      return ipcInvoke('kubernetes-client:getCurrentContextResources', resourceName);
+    },
+  );
 
   contextBridge.exposeInMainWorld('kubernetesGetClusters', async (): Promise<Cluster[]> => {
     return ipcInvoke('kubernetes-client:getClusters');

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -1574,6 +1574,9 @@ export function initExposure(): void {
       return ipcInvoke('kubernetes-client:getContextsGeneralState');
     },
   );
+  contextBridge.exposeInMainWorld('kubernetesGetCurrentContextGeneralState', async (): Promise<ContextGeneralState> => {
+    return ipcInvoke('kubernetes-client:getCurrentContextGeneralState');
+  });
 
   contextBridge.exposeInMainWorld('kubernetesGetClusters', async (): Promise<Cluster[]> => {
     return ipcInvoke('kubernetes-client:getClusters');

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -95,7 +95,7 @@ import type { KubernetesGeneratorInfo } from '../../main/src/plugin/api/Kubernet
 import type { NotificationCard, NotificationCardOptions } from '../../main/src/plugin/api/notification';
 import type { ApiSenderType } from '../../main/src/plugin/api';
 import type { IDisposable } from '../../main/src/plugin/types/disposable';
-import type { ContextState } from '../../main/src/plugin/kubernetes-context-state.js';
+import type { ContextGeneralState } from '../../main/src/plugin/kubernetes-context-state.js';
 
 export type DialogResultCallback = (openDialogReturnValue: Electron.OpenDialogReturnValue) => void;
 export type OpenSaveDialogResultCallback = (result: string | string[] | undefined) => void;
@@ -1568,9 +1568,12 @@ export function initExposure(): void {
   contextBridge.exposeInMainWorld('kubernetesSetContext', async (contextName: string): Promise<void> => {
     return ipcInvoke('kubernetes-client:setContext', contextName);
   });
-  contextBridge.exposeInMainWorld('kubernetesGetContextsState', async (): Promise<Map<string, ContextState>> => {
-    return ipcInvoke('kubernetes-client:getContextsState');
-  });
+  contextBridge.exposeInMainWorld(
+    'kubernetesGetContextsGeneralState',
+    async (): Promise<Map<string, ContextGeneralState>> => {
+      return ipcInvoke('kubernetes-client:getContextsGeneralState');
+    },
+  );
 
   contextBridge.exposeInMainWorld('kubernetesGetClusters', async (): Promise<Cluster[]> => {
     return ipcInvoke('kubernetes-client:getClusters');

--- a/packages/renderer/src/lib/deployments/DeploymentsList.spec.ts
+++ b/packages/renderer/src/lib/deployments/DeploymentsList.spec.ts
@@ -19,28 +19,17 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import '@testing-library/jest-dom/vitest';
-import { test, expect, vi, beforeEach } from 'vitest';
+import { test, expect, vi, beforeEach, beforeAll } from 'vitest';
 import { render, screen, within } from '@testing-library/svelte';
 import DeploymentsList from './DeploymentsList.svelte';
 import { get } from 'svelte/store';
-import { deployments, deploymentsEventStore } from '/@/stores/deployments';
 import type { V1Deployment } from '@kubernetes/client-node';
+import { kubernetesCurrentContextDeployments } from '/@/stores/kubernetes-contexts-state';
 
-const callbacks = new Map<string, any>();
-const eventEmitter = {
-  receive: (message: string, callback: any) => {
-    callbacks.set(message, callback);
-  },
-};
+const kubernetesGetCurrentContextResourcesMock = vi.fn();
 
-Object.defineProperty(global, 'window', {
-  value: {
-    events: {
-      receive: eventEmitter.receive,
-    },
-    addEventListener: eventEmitter.receive,
-  },
-  writable: true,
+beforeAll(() => {
+  (window as any).kubernetesGetCurrentContextResources = kubernetesGetCurrentContextResourcesMock;
 });
 
 beforeEach(() => {
@@ -59,6 +48,7 @@ async function waitRender(customProperties: object): Promise<void> {
 }
 
 test('Expect deployment empty screen', async () => {
+  kubernetesGetCurrentContextResourcesMock.mockResolvedValue([]);
   render(DeploymentsList);
   const noDeployments = screen.getByRole('heading', { name: 'No deployments' });
   expect(noDeployments).toBeInTheDocument();
@@ -78,15 +68,10 @@ test('Expect deployments list', async () => {
       template: {},
     },
   };
-
-  deploymentsEventStore.setup();
-
-  const DeploymentAddCallback = callbacks.get('kubernetes-deployment-add');
-  expect(DeploymentAddCallback).toBeDefined();
-  await DeploymentAddCallback(deployment);
+  kubernetesGetCurrentContextResourcesMock.mockResolvedValue([deployment]);
 
   // wait while store is populated
-  while (get(deployments).length === 0) {
+  while (get(kubernetesCurrentContextDeployments).length === 0) {
     await new Promise(resolve => setTimeout(resolve, 500));
   }
 
@@ -112,15 +97,10 @@ test('Expect correct column overflow', async () => {
       template: {},
     },
   };
-
-  deploymentsEventStore.setup();
-
-  const DeploymentAddCallback = callbacks.get('kubernetes-deployment-add');
-  expect(DeploymentAddCallback).toBeDefined();
-  await DeploymentAddCallback(deployment);
+  kubernetesGetCurrentContextResourcesMock.mockResolvedValue([deployment]);
 
   // wait while store is populated
-  while (get(deployments).length === 0) {
+  while (get(kubernetesCurrentContextDeployments).length === 0) {
     await new Promise(resolve => setTimeout(resolve, 500));
   }
 
@@ -158,14 +138,10 @@ test('Expect filter empty screen', async () => {
     },
   };
 
-  deploymentsEventStore.setup();
-
-  const DeploymentAddCallback = callbacks.get('kubernetes-deployment-add');
-  expect(DeploymentAddCallback).toBeDefined();
-  await DeploymentAddCallback(deployment);
+  kubernetesGetCurrentContextResourcesMock.mockResolvedValue([deployment]);
 
   // wait while store is populated
-  while (get(deployments).length === 0) {
+  while (get(kubernetesCurrentContextDeployments).length === 0) {
     await new Promise(resolve => setTimeout(resolve, 500));
   }
 

--- a/packages/renderer/src/lib/deployments/DeploymentsList.spec.ts
+++ b/packages/renderer/src/lib/deployments/DeploymentsList.spec.ts
@@ -47,6 +47,7 @@ beforeEach(() => {
   vi.resetAllMocks();
   vi.clearAllMocks();
   (window as any).kubernetesGetContextsGeneralState = () => Promise.resolve(new Map());
+  (window as any).kubernetesGetCurrentContextGeneralState = () => Promise.resolve({});
 });
 
 async function waitRender(customProperties: object): Promise<void> {

--- a/packages/renderer/src/lib/deployments/DeploymentsList.spec.ts
+++ b/packages/renderer/src/lib/deployments/DeploymentsList.spec.ts
@@ -46,7 +46,7 @@ Object.defineProperty(global, 'window', {
 beforeEach(() => {
   vi.resetAllMocks();
   vi.clearAllMocks();
-  (window as any).kubernetesGetContextsState = () => Promise.resolve(new Map());
+  (window as any).kubernetesGetContextsGeneralState = () => Promise.resolve(new Map());
 });
 
 async function waitRender(customProperties: object): Promise<void> {

--- a/packages/renderer/src/lib/deployments/DeploymentsList.svelte
+++ b/packages/renderer/src/lib/deployments/DeploymentsList.svelte
@@ -2,7 +2,6 @@
 import { onMount } from 'svelte';
 
 import type { DeploymentUI } from './DeploymentUI';
-import { filtered, searchPattern } from '../../stores/deployments';
 import NavPage from '../ui/NavPage.svelte';
 import Table from '../table/Table.svelte';
 import { Column, Row } from '../table/table';
@@ -22,16 +21,20 @@ import SimpleColumn from '../table/SimpleColumn.svelte';
 import DurationColumn from '../table/DurationColumn.svelte';
 import KubernetesCurrentContextConnectionBadge from '/@/lib/ui/KubernetesCurrentContextConnectionBadge.svelte';
 import KubeApplyYamlButton from '../kube/KubeApplyYAMLButton.svelte';
+import {
+  deploymentSearchPattern,
+  kubernetesCurrentContextDeploymentsFiltered,
+} from '/@/stores/kubernetes-contexts-state';
 
 export let searchTerm = '';
-$: searchPattern.set(searchTerm);
+$: deploymentSearchPattern.set(searchTerm);
 
 let deployments: DeploymentUI[] = [];
 
 const deploymentUtils = new DeploymentUtils();
 
 onMount(() => {
-  return filtered.subscribe(value => {
+  return kubernetesCurrentContextDeploymentsFiltered.subscribe(value => {
     deployments = value.map(deployment => deploymentUtils.getDeploymentUI(deployment));
   });
 });
@@ -143,7 +146,7 @@ const row = new Row<DeploymentUI>({ selectable: _deployment => true });
       on:update="{() => (deployments = deployments)}">
     </Table>
 
-    {#if $filtered.length === 0}
+    {#if $kubernetesCurrentContextDeploymentsFiltered.length === 0}
       {#if searchTerm}
         <FilteredEmptyScreen
           icon="{DeploymentIcon}"

--- a/packages/renderer/src/lib/ingresses-routes/IngressesRoutesList.spec.ts
+++ b/packages/renderer/src/lib/ingresses-routes/IngressesRoutesList.spec.ts
@@ -48,7 +48,7 @@ Object.defineProperty(global, 'window', {
 beforeEach(() => {
   vi.resetAllMocks();
   vi.clearAllMocks();
-  (window as any).kubernetesGetContextsState = () => Promise.resolve(new Map());
+  (window as any).kubernetesGetContextsGeneralState = () => Promise.resolve(new Map());
 });
 
 async function waitRender(customProperties: object): Promise<void> {

--- a/packages/renderer/src/lib/ingresses-routes/IngressesRoutesList.spec.ts
+++ b/packages/renderer/src/lib/ingresses-routes/IngressesRoutesList.spec.ts
@@ -49,6 +49,7 @@ beforeEach(() => {
   vi.resetAllMocks();
   vi.clearAllMocks();
   (window as any).kubernetesGetContextsGeneralState = () => Promise.resolve(new Map());
+  (window as any).kubernetesGetCurrentContextGeneralState = () => Promise.resolve({});
 });
 
 async function waitRender(customProperties: object): Promise<void> {

--- a/packages/renderer/src/lib/pod/PodsList.spec.ts
+++ b/packages/renderer/src/lib/pod/PodsList.spec.ts
@@ -262,7 +262,7 @@ const ocppod: PodInfo = {
 
 // fake the window.events object
 beforeAll(() => {
-  (window as any).kubernetesGetContextsState = () => Promise.resolve(new Map());
+  (window as any).kubernetesGetContextsGeneralState = () => Promise.resolve(new Map());
   (window as any).getProviderInfos = getProvidersInfoMock;
   (window as any).listPods = listPodsMock;
   (window as any).listContainers = listContainersMock.mockResolvedValue([]);

--- a/packages/renderer/src/lib/pod/PodsList.spec.ts
+++ b/packages/renderer/src/lib/pod/PodsList.spec.ts
@@ -263,6 +263,7 @@ const ocppod: PodInfo = {
 // fake the window.events object
 beforeAll(() => {
   (window as any).kubernetesGetContextsGeneralState = () => Promise.resolve(new Map());
+  (window as any).kubernetesGetCurrentContextGeneralState = () => Promise.resolve({});
   (window as any).getProviderInfos = getProvidersInfoMock;
   (window as any).listPods = listPodsMock;
   (window as any).listContainers = listContainersMock.mockResolvedValue([]);

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.spec.ts
@@ -22,7 +22,7 @@ import { fireEvent, render, screen, within } from '@testing-library/svelte';
 import PreferencesKubernetesContextsRendering from './PreferencesKubernetesContextsRendering.svelte';
 import { kubernetesContexts } from '/@/stores/kubernetes-contexts';
 import type { KubeContext } from '../../../../main/src/plugin/kubernetes-context';
-import type { ContextState } from '../../../../main/src/plugin/kubernetes-context-state';
+import type { ContextGeneralState } from '../../../../main/src/plugin/kubernetes-context-state';
 import * as kubernetesContextsState from '/@/stores/kubernetes-contexts-state';
 import { readable } from 'svelte/store';
 
@@ -67,11 +67,11 @@ const mockContext3: KubeContext = {
 
 beforeEach(() => {
   kubernetesContexts.set([mockContext1, mockContext2, mockContext3]);
-  (window as any).kubernetesGetContextsState = vi.fn().mockResolvedValue(new Map<string, ContextState>());
+  (window as any).kubernetesGetContextsGeneralState = vi.fn().mockResolvedValue(new Map<string, ContextGeneralState>());
 });
 
 test('test that name, cluster and the server is displayed when rendering', async () => {
-  vi.mocked(kubernetesContextsState).kubernetesContextsState = readable<Map<string, ContextState>>(new Map());
+  vi.mocked(kubernetesContextsState).kubernetesContextsState = readable<Map<string, ContextGeneralState>>(new Map());
   (window as any).kubernetesGetCurrentContextName = vi.fn().mockResolvedValue('my-current-context');
   render(PreferencesKubernetesContextsRendering, {});
   expect(await screen.findByText('context-name')).toBeInTheDocument();
@@ -81,20 +81,20 @@ test('test that name, cluster and the server is displayed when rendering', async
 });
 
 test('Test that namespace is displayed when available in the context', async () => {
-  vi.mocked(kubernetesContextsState).kubernetesContextsState = readable<Map<string, ContextState>>(new Map());
+  vi.mocked(kubernetesContextsState).kubernetesContextsState = readable<Map<string, ContextGeneralState>>(new Map());
   render(PreferencesKubernetesContextsRendering, {});
   expect(await screen.findByText('namespace-name3')).toBeInTheDocument();
 });
 
 test('If nothing is returned for contexts, expect that the page shows a message', async () => {
-  vi.mocked(kubernetesContextsState).kubernetesContextsState = readable<Map<string, ContextState>>(new Map());
+  vi.mocked(kubernetesContextsState).kubernetesContextsState = readable<Map<string, ContextGeneralState>>(new Map());
   kubernetesContexts.set([]);
   render(PreferencesKubernetesContextsRendering, {});
   expect(await screen.findByText('No Kubernetes contexts found')).toBeInTheDocument();
 });
 
 test('Test that context-name2 is the current context', async () => {
-  vi.mocked(kubernetesContextsState).kubernetesContextsState = readable<Map<string, ContextState>>(new Map());
+  vi.mocked(kubernetesContextsState).kubernetesContextsState = readable<Map<string, ContextGeneralState>>(new Map());
   (window as any).kubernetesGetCurrentContextName = vi.fn().mockResolvedValue('context-name2');
   render(PreferencesKubernetesContextsRendering, {});
 
@@ -111,7 +111,7 @@ test('Test that context-name2 is the current context', async () => {
 });
 
 test('when deleting the current context, a popup should ask confirmation', async () => {
-  vi.mocked(kubernetesContextsState).kubernetesContextsState = readable<Map<string, ContextState>>(new Map());
+  vi.mocked(kubernetesContextsState).kubernetesContextsState = readable<Map<string, ContextGeneralState>>(new Map());
   const showMessageBoxMock = vi.fn();
   (window as any).showMessageBox = showMessageBoxMock;
   showMessageBoxMock.mockResolvedValue({ result: 1 });
@@ -130,7 +130,7 @@ test('when deleting the current context, a popup should ask confirmation', async
 });
 
 test('when deleting the non current context, no popup should ask confirmation', async () => {
-  vi.mocked(kubernetesContextsState).kubernetesContextsState = readable<Map<string, ContextState>>(new Map());
+  vi.mocked(kubernetesContextsState).kubernetesContextsState = readable<Map<string, ContextGeneralState>>(new Map());
   const showMessageBoxMock = vi.fn();
   (window as any).showMessageBox = showMessageBoxMock;
   showMessageBoxMock.mockResolvedValue({ result: 1 });
@@ -149,22 +149,22 @@ test('when deleting the non current context, no popup should ask confirmation', 
 });
 
 test('state and resources counts are displayed in contexts', () => {
-  const state: Map<string, ContextState> = new Map();
+  const state: Map<string, ContextGeneralState> = new Map();
   state.set('context-name', {
     reachable: true,
     resources: {
-      pods: [{}],
-      deployments: [{}, {}],
+      pods: 1,
+      deployments: 2,
     },
   });
   state.set('context-name2', {
     reachable: false,
     resources: {
-      pods: [],
-      deployments: [],
+      pods: 0,
+      deployments: 0,
     },
   });
-  vi.mocked(kubernetesContextsState).kubernetesContextsState = readable<Map<string, ContextState>>(state);
+  vi.mocked(kubernetesContextsState).kubernetesContextsState = readable<Map<string, ContextGeneralState>>(state);
   render(PreferencesKubernetesContextsRendering, {});
   const context1 = screen.getAllByRole('row')[0];
   const context2 = screen.getAllByRole('row')[1];

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
@@ -108,13 +108,13 @@ async function handleDeleteContext(contextName: string) {
                     <div class="text-center">
                       <div class="font-bold text-[9px] text-gray-800">PODS</div>
                       <div class="text-[16px] text-white" aria-label="context-pods-count">
-                        {$kubernetesContextsState.get(context.name)?.resources.pods.length}
+                        {$kubernetesContextsState.get(context.name)?.resources.pods}
                       </div>
                     </div>
                     <div class="text-center">
                       <div class="font-bold text-[9px] text-gray-800">DEPLOYMENTS</div>
                       <div class="text-[16px] text-white" aria-label="context-deployments-count">
-                        {$kubernetesContextsState.get(context.name)?.resources.deployments.length}
+                        {$kubernetesContextsState.get(context.name)?.resources.deployments}
                       </div>
                     </div>
                   </div>

--- a/packages/renderer/src/lib/service/ServicesList.spec.ts
+++ b/packages/renderer/src/lib/service/ServicesList.spec.ts
@@ -47,6 +47,7 @@ beforeEach(() => {
   vi.resetAllMocks();
   vi.clearAllMocks();
   (window as any).kubernetesGetContextsGeneralState = () => Promise.resolve(new Map());
+  (window as any).kubernetesGetCurrentContextGeneralState = () => Promise.resolve({});
 });
 
 async function waitRender(customProperties: object): Promise<void> {

--- a/packages/renderer/src/lib/service/ServicesList.spec.ts
+++ b/packages/renderer/src/lib/service/ServicesList.spec.ts
@@ -46,7 +46,7 @@ Object.defineProperty(global, 'window', {
 beforeEach(() => {
   vi.resetAllMocks();
   vi.clearAllMocks();
-  (window as any).kubernetesGetContextsState = () => Promise.resolve(new Map());
+  (window as any).kubernetesGetContextsGeneralState = () => Promise.resolve(new Map());
 });
 
 async function waitRender(customProperties: object): Promise<void> {

--- a/packages/renderer/src/lib/ui/KubernetesCurrentContextConnectionBadge.spec.ts
+++ b/packages/renderer/src/lib/ui/KubernetesCurrentContextConnectionBadge.spec.ts
@@ -22,7 +22,7 @@ import '@testing-library/jest-dom/vitest';
 import { test, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/svelte';
 import KubernetesCurrentContextConnectionBadge from '/@/lib/ui/KubernetesCurrentContextConnectionBadge.svelte';
-import type { ContextState } from '../../../../main/src/plugin/kubernetes-context-state';
+import type { ContextGeneralState } from '../../../../main/src/plugin/kubernetes-context-state';
 
 const mocks = vi.hoisted(() => ({
   subscribeMock: vi.fn(),
@@ -46,7 +46,7 @@ beforeEach(() => {
   });
 
   (window as any).events = mocks.eventsMocks;
-  (window as any).kubernetesGetContextsState = mocks.getCurrentKubeContextState;
+  (window as any).kubernetesGetContextsGeneralState = mocks.getCurrentKubeContextState;
 });
 
 test('expect no badges shown as no context has been provided.', async () => {
@@ -63,10 +63,10 @@ test('expect badges to show as there is a context', async () => {
     error: undefined,
     reachable: true,
     resources: {
-      pods: [],
-      deployments: [],
+      pods: 0,
+      deployments: 0,
     },
-  } as ContextState); // no current ContextState
+  } as ContextGeneralState); // no current ContextState
   render(KubernetesCurrentContextConnectionBadge);
 
   expect(mocks.getCurrentKubeContextState).toHaveBeenCalled();
@@ -79,10 +79,10 @@ test('expect badges to be green when reachable', async () => {
     error: undefined,
     reachable: true,
     resources: {
-      pods: [],
-      deployments: [],
+      pods: 0,
+      deployments: 0,
     },
-  } as ContextState); // no current ContextState
+  } as ContextGeneralState); // no current ContextState
   render(KubernetesCurrentContextConnectionBadge);
 
   expect(mocks.getCurrentKubeContextState).toHaveBeenCalled();
@@ -95,10 +95,10 @@ test('expect badges to be gray when not reachable', async () => {
     error: undefined,
     reachable: false,
     resources: {
-      pods: [],
-      deployments: [],
+      pods: 0,
+      deployments: 0,
     },
-  } as ContextState); // no current ContextState
+  } as ContextGeneralState); // no current ContextState
   render(KubernetesCurrentContextConnectionBadge);
 
   expect(mocks.getCurrentKubeContextState).toHaveBeenCalled();
@@ -111,10 +111,10 @@ test('expect no tooltip when no error', async () => {
     error: undefined,
     reachable: false,
     resources: {
-      pods: [],
-      deployments: [],
+      pods: 0,
+      deployments: 0,
     },
-  } as ContextState); // no current ContextState
+  } as ContextGeneralState); // no current ContextState
   render(KubernetesCurrentContextConnectionBadge);
 
   expect(mocks.getCurrentKubeContextState).toHaveBeenCalled();
@@ -127,10 +127,10 @@ test('expect tooltip when error', async () => {
     error: 'error message',
     reachable: false,
     resources: {
-      pods: [],
-      deployments: [],
+      pods: 0,
+      deployments: 0,
     },
-  } as ContextState); // no current ContextState
+  } as ContextGeneralState); // no current ContextState
   render(KubernetesCurrentContextConnectionBadge);
 
   expect(mocks.getCurrentKubeContextState).toHaveBeenCalled();

--- a/packages/renderer/src/lib/ui/KubernetesCurrentContextConnectionBadge.svelte
+++ b/packages/renderer/src/lib/ui/KubernetesCurrentContextConnectionBadge.svelte
@@ -3,12 +3,12 @@ import { kubernetesCurrentContextState } from '/@/stores/kubernetes-contexts-sta
 import type { ContextGeneralState } from '../../../../main/src/plugin/kubernetes-context-state';
 import Tooltip from '/@/lib/ui/Tooltip.svelte';
 
-function getText(state: ContextGeneralState | undefined): string {
+function getText(state?: ContextGeneralState): string {
   if (state?.reachable) return 'Connected';
   return 'Cluster not reachable';
 }
 
-function getClassColor(state: ContextGeneralState | undefined): string {
+function getClassColor(state?: ContextGeneralState): string {
   if (state?.reachable) return 'bg-green-600';
   return 'bg-gray-900';
 }

--- a/packages/renderer/src/lib/ui/KubernetesCurrentContextConnectionBadge.svelte
+++ b/packages/renderer/src/lib/ui/KubernetesCurrentContextConnectionBadge.svelte
@@ -1,14 +1,14 @@
 <script lang="ts">
 import { kubernetesCurrentContextState } from '/@/stores/kubernetes-contexts-state';
-import type { ContextState } from '../../../../main/src/plugin/kubernetes-context-state';
+import type { ContextGeneralState } from '../../../../main/src/plugin/kubernetes-context-state';
 import Tooltip from '/@/lib/ui/Tooltip.svelte';
 
-function getText(state: ContextState | undefined): string {
+function getText(state: ContextGeneralState | undefined): string {
   if (state?.reachable) return 'Connected';
   return 'Cluster not reachable';
 }
 
-function getClassColor(state: ContextState | undefined): string {
+function getClassColor(state: ContextGeneralState | undefined): string {
   if (state?.reachable) return 'bg-green-600';
   return 'bg-gray-900';
 }

--- a/packages/renderer/src/stores/kubernetes-contexts-state.ts
+++ b/packages/renderer/src/stores/kubernetes-contexts-state.ts
@@ -17,17 +17,17 @@
  ***********************************************************************/
 
 import { derived, type Readable, readable } from 'svelte/store';
-import type { ContextState } from '../../../main/src/plugin/kubernetes-context-state';
+import type { ContextGeneralState } from '../../../main/src/plugin/kubernetes-context-state';
 import { kubernetesContexts } from '/@/stores/kubernetes-contexts';
 
-export const kubernetesContextsState = readable(new Map<string, ContextState>(), set => {
-  window.kubernetesGetContextsState().then(value => set(value));
-  window.events?.receive('kubernetes-contexts-state-update', (value: unknown) => {
-    set(value as Map<string, ContextState>);
+export const kubernetesContextsState = readable(new Map<string, ContextGeneralState>(), set => {
+  window.kubernetesGetContextsGeneralState().then(value => set(value));
+  window.events?.receive('kubernetes-contexts-general-state-update', (value: unknown) => {
+    set(value as Map<string, ContextGeneralState>);
   });
 });
 
-export const kubernetesCurrentContextState: Readable<ContextState | undefined> = derived(
+export const kubernetesCurrentContextState: Readable<ContextGeneralState | undefined> = derived(
   [kubernetesContextsState, kubernetesContexts],
   ([$kubernetesContextsState, $kubernetesContexts]) => {
     const currentContextName = $kubernetesContexts.find(c => c.currentContext)?.name;


### PR DESCRIPTION
### What does this PR do?

Use 4 different channels to send information to the frontend:

- status and number of a selected list of resources (pods, deployments) for all contexts (including the current one)
- Status and number of a selected list of resources (pods, deployments) for current context
- Pods in the current context
- Deploymenets in the current context

New state is sent or not into channels depending on the event (for example, the "Pods in current context" is not sent when a new Deployment is added to a context)

More unit tests 

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes #6171

### How to test this PR?

Enable Kubernetes on Podman Desktop, start/stop deployments, start/stop clusters, and check data is always valid on Deployments List page and in Kubernetes Contexts page



- [x] Tests are covering the bug fix or the new feature
