### PR TITLE
chore: enforce dark theme for system setting for now

### DIFF
--- a/packages/renderer/src/lib/appearance/appearance-util.ts
+++ b/packages/renderer/src/lib/appearance/appearance-util.ts
@@ -49,7 +49,9 @@ export class AppearanceUtil {
     const systemTheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
 
     if (themeName === AppearanceSettings.SystemEnumValue) {
-      return systemTheme;
+      //FIXME: for now we hardcode to the dark theme even if the Operating System is using light theme
+      // return systemTheme;
+      return 'dark';
     }
 
     return themeName ?? systemTheme;

--- a/packages/renderer/src/lib/appearance/appearance-utils.spec.ts
+++ b/packages/renderer/src/lib/appearance/appearance-utils.spec.ts
@@ -128,7 +128,10 @@ describe('getTheme', () => {
     getConfigurationValueMock.mockResolvedValue(AppearanceSettings.SystemEnumValue);
 
     const theme = await appearanceUtil.getTheme();
-    expect(theme).toBe('light');
+
+    // FIXME: for now we hardcode to the dark theme even if the Operating System is using light theme
+    // expect(theme).toBe('light');
+    expect(theme).toBe('dark');
   });
 
   test('should return dark if value is dark even if os is light', async () => {


### PR DESCRIPTION
### What does this PR do?
it will be removed once light theme will be completed

### Screenshot / video of UI

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

switch your OS to light theme and start Podman Desktop it should use dark colors

manually forcing 'light' should work

```json
"preferences.appearance": "light"
```
in the config file

- [x] Tests are covering the bug fix or the new feature
