### PR TITLE
refactor: moving update logic to a separate file

### DIFF
--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -159,7 +159,7 @@ import { ColorRegistry } from './color-registry.js';
 import { DialogRegistry } from './dialog-registry.js';
 import type { Deferred } from './util/deferred.js';
 import type { ContextState } from './kubernetes-context-state.js';
-import { Updater } from '/@/plugin/Updater.js';
+import { Updater } from '/@/plugin/updater.js';
 
 type LogType = 'log' | 'warn' | 'trace' | 'debug' | 'error';
 

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -54,7 +54,7 @@ import type { ExtensionInfo } from './api/extension-info.js';
 import type { ImageInspectInfo } from './api/image-inspect-info.js';
 import type { TrayMenu } from '../tray-menu.js';
 import { getFreePort, getFreePortRange, isFreePort } from './util/port.js';
-import { isLinux, isMac } from '../util.js';
+import { isMac } from '../util.js';
 import type { MessageBoxOptions, MessageBoxReturnValue } from './message-box.js';
 import { MessageBox } from './message-box.js';
 import { ProgressImpl } from './progress-impl.js';
@@ -104,8 +104,6 @@ import { InputQuickPickRegistry } from './input-quickpick/input-quickpick-regist
 import type { Menu } from '/@/plugin/menu-registry.js';
 import { MenuRegistry } from '/@/plugin/menu-registry.js';
 import { CancellationTokenRegistry } from './cancellation-token-registry.js';
-import type { UpdateCheckResult } from 'electron-updater';
-import { autoUpdater } from 'electron-updater';
 import type { ApiSenderType } from './api.js';
 import type { AuthenticationProviderInfo } from './authentication.js';
 import { AuthenticationImpl } from './authentication.js';
@@ -161,6 +159,7 @@ import { ColorRegistry } from './color-registry.js';
 import { DialogRegistry } from './dialog-registry.js';
 import type { Deferred } from './util/deferred.js';
 import type { ContextState } from './kubernetes-context-state.js';
+import { Updater } from '/@/plugin/Updater.js';
 
 type LogType = 'log' | 'warn' | 'trace' | 'debug' | 'error';
 
@@ -454,6 +453,8 @@ export class PluginSystem {
     const closeBehaviorConfiguration = new CloseBehavior(configurationRegistry);
     await closeBehaviorConfiguration.init();
 
+    const messageBox = new MessageBox(apiSender);
+
     // Don't show the tray icon options on Mac
     if (!isMac()) {
       const trayIconColor = new TrayIconColor(configurationRegistry, providerRegistry);
@@ -521,188 +522,8 @@ export class PluginSystem {
       undefined,
     );
 
-    // Get the current version of our application
-    const currentVersion = `v${app.getVersion()}`;
-
-    // Add version entry to the status bar
-    const defaultVersionEntry = () => {
-      statusBarRegistry.setEntry(
-        'version',
-        false,
-        0,
-        currentVersion,
-        `Using version ${currentVersion}`,
-        undefined,
-        true,
-        'version',
-        undefined,
-      );
-    };
-    defaultVersionEntry();
-
-    // Show a "No update available" only for macOS and Windows users and on production builds
-    let detailMessage: string;
-    if (!isLinux() && import.meta.env.PROD) {
-      detailMessage = 'No update available';
-    }
-
-    // Register command 'version' that will display the current version and say that no update is available.
-    // Only show the "no update available" command for macOS and Windows users, not linux users.
-    commandRegistry.registerCommand('version', async () => {
-      await messageBox.showMessageBox({
-        type: 'info',
-        title: 'Version',
-        message: `Using version ${currentVersion}`,
-        detail: detailMessage,
-      });
-    });
-
-    // Only check on production builds for Windows and macOS users
-    if (import.meta.env.PROD && !isLinux()) {
-      // disable auto download
-      autoUpdater.autoDownload = false;
-
-      let updateInProgress = false;
-      let updateAlreadyDownloaded = false;
-
-      // setup the event listeners
-      autoUpdater.on('update-available', () => {
-        updateInProgress = false;
-        updateAlreadyDownloaded = false;
-
-        // Update the 'version' entry in the status bar to show that an update is available
-        // this uses setEntry to update the existing entry
-        statusBarRegistry.setEntry(
-          'version',
-          false,
-          0,
-          currentVersion,
-          'Update available',
-          UPDATER_UPDATE_AVAILABLE_ICON,
-          true,
-          'update',
-          undefined,
-          true,
-        );
-      });
-
-      autoUpdater.on('update-not-available', () => {
-        updateInProgress = false;
-        updateAlreadyDownloaded = false;
-
-        // Update the 'version' entry in the status bar to show that no update is available
-        defaultVersionEntry();
-      });
-
-      autoUpdater.on('update-downloaded', () => {
-        updateAlreadyDownloaded = true;
-        updateInProgress = false;
-        messageBox
-          .showMessageBox({
-            title: 'Update Downloaded',
-            message: 'Update downloaded, Do you want to restart Podman Desktop ?',
-            cancelId: 1,
-            type: 'info',
-            buttons: ['Restart', 'Cancel'],
-          })
-          .then(result => {
-            if (result.response === 0) {
-              setImmediate(() => autoUpdater.quitAndInstall());
-            }
-          })
-          .catch((error: unknown) => {
-            console.error('unable to show message box', error);
-          });
-      });
-
-      autoUpdater.on('error', error => {
-        updateInProgress = false;
-        // local build not pushed to GitHub so prevent any 'update'
-        if (error?.message?.includes('No published versions on GitHub')) {
-          console.log('Cannot check for updates, no published versions on GitHub');
-          defaultVersionEntry();
-          return;
-        }
-        console.error('unable to check for updates', error);
-      });
-
-      // check for updates now
-      let updateCheckResult: UpdateCheckResult | null;
-
-      try {
-        updateCheckResult = await autoUpdater.checkForUpdates();
-      } catch (error) {
-        console.error('unable to check for updates', error);
-      }
-
-      // Create an interval to check for updates every 12 hours
-      setInterval(
-        () => {
-          autoUpdater
-            .checkForUpdates()
-            .then(result => (updateCheckResult = result))
-            .catch((error: unknown) => {
-              console.log('unable to check for updates', error);
-            });
-        },
-        1000 * 60 * 60 * 12,
-      );
-
-      // Update will create a standard "autoUpdater" dialog / update process
-      commandRegistry.registerCommand('update', async () => {
-        if (updateAlreadyDownloaded) {
-          const result = await messageBox.showMessageBox({
-            type: 'info',
-            title: 'Update',
-            message: 'There is already an update downloaded. Please Restart Podman Desktop.',
-            cancelId: 1,
-            buttons: ['Restart', 'Cancel'],
-          });
-          if (result.response === 0) {
-            setImmediate(() => autoUpdater.quitAndInstall());
-          }
-          return;
-        }
-
-        if (updateInProgress) {
-          await messageBox.showMessageBox({
-            type: 'info',
-            title: 'Update',
-            message: 'There is already an update in progress. Please wait until it is downloaded',
-            buttons: ['OK'],
-          });
-          return;
-        }
-
-        // Get the version of the update
-        const updateVersion = updateCheckResult?.updateInfo.version ? `v${updateCheckResult?.updateInfo.version}` : '';
-
-        const result = await messageBox.showMessageBox({
-          type: 'info',
-          title: 'Update Available',
-          message: `A new version ${updateVersion} of Podman Desktop is available. Do you want to update your current version ${currentVersion}?`,
-          buttons: ['Update', 'Cancel'],
-          cancelId: 1,
-        });
-        if (result.response === 0) {
-          updateInProgress = true;
-          updateAlreadyDownloaded = false;
-
-          // Download update and try / catch it and create a dialog if it fails
-          try {
-            await autoUpdater.downloadUpdate();
-          } catch (error) {
-            console.error('Update error: ', error);
-            await messageBox.showMessageBox({
-              type: 'error',
-              title: 'Update Failed',
-              message: `An error occurred while trying to update to version ${updateVersion}. See the developer console for more information.`,
-              buttons: ['OK'],
-            });
-          }
-        }
-      });
-    }
+    // Init update logic
+    new Updater(messageBox, statusBarRegistry, commandRegistry).init();
 
     commandRegistry.registerCommand('feedback', () => {
       apiSender.send('display-feedback', '');
@@ -736,8 +557,6 @@ export class PluginSystem {
     // init welcome configuration
     const welcomeInit = new WelcomeInit(configurationRegistry);
     welcomeInit.init();
-
-    const messageBox = new MessageBox(apiSender);
 
     const authentication = new AuthenticationImpl(apiSender);
 

--- a/packages/main/src/plugin/updater.spec.ts
+++ b/packages/main/src/plugin/updater.spec.ts
@@ -68,12 +68,12 @@ beforeEach(() => {
   // Simulate PROD env
   vi.stubEnv('PROD', 'true');
 
-  vi.spyOn(app, 'getVersion').mockReturnValue('@debug');
+  vi.mocked(app.getVersion).mockReturnValue('@debug');
   // eslint-disable-next-line no-null/no-null
-  vi.spyOn(autoUpdater, 'checkForUpdates').mockResolvedValue(null);
+  vi.mocked(autoUpdater.checkForUpdates).mockResolvedValue(null);
 
-  vi.spyOn(commandRegistry, 'executeCommand').mockResolvedValue(undefined);
-  vi.spyOn(util, 'isLinux').mockReturnValue(false);
+  vi.mocked(commandRegistry.executeCommand).mockResolvedValue(undefined);
+  vi.mocked(util.isLinux).mockReturnValue(false);
 });
 
 test('expect env PROD to be truthy', () => {
@@ -88,9 +88,8 @@ test('expect init to provide a disposable', () => {
 });
 
 test('expect init to register commands', () => {
-  const registerCommandMock = vi.spyOn(commandRegistry, 'registerCommand');
   new Updater(messageBoxMock, statusBarRegistryMock, commandRegistry).init();
-  expect(registerCommandMock).toHaveBeenCalled();
+  expect(commandRegistry.registerCommand).toHaveBeenCalled();
 });
 
 test('expect update available entry to be displayed when expected', () => {

--- a/packages/main/src/plugin/updater.spec.ts
+++ b/packages/main/src/plugin/updater.spec.ts
@@ -101,7 +101,7 @@ test('expect update available entry to be displayed when expected', () => {
       expect(text).toBe('v@debug');
       expect(tooltip).toBe('Update available');
       expect(iconClass).toBe(UPDATER_UPDATE_AVAILABLE_ICON);
-      expect(enabled).toBe(true);
+      expect(enabled).toBeTruthy();
       expect(command).toBe('update');
       expect(highlight).toBe(true);
     },

--- a/packages/main/src/plugin/updater.spec.ts
+++ b/packages/main/src/plugin/updater.spec.ts
@@ -103,7 +103,7 @@ test('expect update available entry to be displayed when expected', () => {
       expect(iconClass).toBe(UPDATER_UPDATE_AVAILABLE_ICON);
       expect(enabled).toBeTruthy();
       expect(command).toBe('update');
-      expect(highlight).toBe(true);
+      expect(highlight).toBeTruthy();
     },
   );
 

--- a/packages/main/src/plugin/updater.spec.ts
+++ b/packages/main/src/plugin/updater.spec.ts
@@ -1,0 +1,165 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { beforeEach, expect, test, vi } from 'vitest';
+import type { MessageBox } from '/@/plugin/message-box.js';
+import type { StatusBarRegistry } from '/@/plugin/statusbar/statusbar-registry.js';
+import type { CommandRegistry } from '/@/plugin/command-registry.js';
+import { Disposable } from '/@/plugin/types/disposable.js';
+import { UPDATER_UPDATE_AVAILABLE_ICON } from '/@/plugin/index.js';
+import { Updater } from '/@/plugin/updater.js';
+
+const mocks = vi.hoisted(() => ({
+  // MessageBoxMock
+  showMessageBoxMock: vi.fn(),
+  // StatusBarRegistry
+  setEntryMock: vi.fn(),
+  // CommandRegistry
+  registerCommandMock: vi.fn(),
+  executeCommandMock: vi.fn(),
+  // Electron App
+  getVersionMock: vi.fn(),
+  // Electron Update
+  downloadUpdateMock: vi.fn(),
+  quitAndInstallMock: vi.fn(),
+  checkForUpdatesMock: vi.fn(),
+  onMock: vi.fn(),
+  // utils
+  isLinuxMock: vi.fn(),
+}));
+
+vi.mock('electron', () => ({
+  app: {
+    getVersion: mocks.getVersionMock,
+  },
+}));
+
+vi.mock('electron-updater', () => ({
+  autoUpdater: {
+    downloadUpdate: mocks.downloadUpdateMock,
+    quitAndInstall: mocks.quitAndInstallMock,
+    checkForUpdates: mocks.checkForUpdatesMock,
+    on: mocks.onMock,
+    autoDownload: true,
+  },
+}));
+
+vi.mock('/@/util.js', () => ({
+  isLinux: mocks.isLinuxMock,
+}));
+
+const messageBoxMock = {
+  showMessageBox: mocks.showMessageBoxMock,
+} as unknown as MessageBox;
+
+const statusBarRegistryMock = {
+  setEntry: mocks.setEntryMock,
+} as unknown as StatusBarRegistry;
+
+const commandRegistry = {
+  registerCommand: mocks.registerCommandMock,
+  executeCommand: mocks.executeCommandMock,
+} as unknown as CommandRegistry;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.resetAllMocks();
+
+  // Simulate PROD env
+  vi.stubEnv('PROD', 'true');
+
+  mocks.getVersionMock.mockReturnValue('@debug');
+  mocks.checkForUpdatesMock.mockResolvedValue(undefined);
+  mocks.executeCommandMock.mockResolvedValue(undefined);
+  mocks.isLinuxMock.mockReturnValue(false);
+});
+
+test('expect env PROD to be truthy', () => {
+  expect(import.meta.env.PROD).toBeTruthy();
+});
+
+test('expect init to provide a disposable', () => {
+  const updater = new Updater(messageBoxMock, statusBarRegistryMock, commandRegistry);
+  const disposable: unknown = updater.init();
+  expect(disposable).toBeDefined();
+  expect(disposable instanceof Disposable).toBe(true);
+});
+
+test('expect init to register commands', () => {
+  new Updater(messageBoxMock, statusBarRegistryMock, commandRegistry).init();
+
+  expect(mocks.registerCommandMock).toHaveBeenCalled();
+});
+
+test('expect update available entry to be displayed when expected', () => {
+  mocks.setEntryMock.mockImplementation(
+    (entryId, _alignLeft, _priority, text, tooltip, iconClass, enabled, command, _commandArgs, highlight) => {
+      expect(entryId).toBe('version');
+      expect(text).toBe('v@debug');
+      expect(tooltip).toBe('Update available');
+      expect(iconClass).toBe(UPDATER_UPDATE_AVAILABLE_ICON);
+      expect(enabled).toBe(true);
+      expect(command).toBe('update');
+      expect(highlight).toBe(true);
+    },
+  );
+
+  let mListener: (() => void) | undefined;
+  mocks.onMock.mockImplementation((channel: string, listener: () => void) => {
+    if (channel === 'update-available') mListener = listener;
+  });
+
+  new Updater(messageBoxMock, statusBarRegistryMock, commandRegistry).init();
+
+  // listener should exist
+  expect(mListener).toBeDefined();
+
+  // call the listener (which should be the private updateAvailableEntry method)
+  mListener?.();
+
+  expect(mocks.setEntryMock).toHaveBeenCalled();
+});
+
+test('expect default status entry to be displayed when no update available', () => {
+  mocks.setEntryMock.mockImplementation(
+    (entryId, _alignLeft, _priority, text, tooltip, iconClass, enabled, command, _commandArgs, highlight) => {
+      expect(entryId).toBe('version');
+      expect(text).toBe('v@debug');
+      expect(tooltip).toBe('Using version v@debug');
+      expect(iconClass).toBe(undefined);
+      expect(enabled).toBe(true);
+      expect(command).toBe('version');
+      expect(highlight).toBeFalsy();
+    },
+  );
+
+  let mListener: (() => void) | undefined;
+  mocks.onMock.mockImplementation((channel: string, listener: () => void) => {
+    if (channel === 'update-not-available') mListener = listener;
+  });
+
+  new Updater(messageBoxMock, statusBarRegistryMock, commandRegistry).init();
+
+  // listener should exist
+  expect(mListener).toBeDefined();
+
+  // call the listener (which should be the private onUpdateNotAvailable method)
+  mListener?.();
+
+  expect(mocks.setEntryMock).toHaveBeenCalled();
+});

--- a/packages/main/src/plugin/updater.spec.ts
+++ b/packages/main/src/plugin/updater.spec.ts
@@ -84,7 +84,7 @@ test('expect init to provide a disposable', () => {
   const updater = new Updater(messageBoxMock, statusBarRegistryMock, commandRegistry);
   const disposable: unknown = updater.init();
   expect(disposable).toBeDefined();
-  expect(disposable instanceof Disposable).toBe(true);
+  expect(disposable instanceof Disposable).toBeTruthy();
 });
 
 test('expect init to register commands', () => {

--- a/packages/main/src/plugin/updater.ts
+++ b/packages/main/src/plugin/updater.ts
@@ -1,0 +1,265 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { MessageBox } from '/@/plugin/message-box.js';
+import { autoUpdater, type UpdateCheckResult } from 'electron-updater';
+import { UPDATER_UPDATE_AVAILABLE_ICON } from '/@/plugin/index.js';
+import type { StatusBarRegistry } from '/@/plugin/statusbar/statusbar-registry.js';
+import { app } from 'electron';
+import type { CommandRegistry } from '/@/plugin/command-registry.js';
+import { isLinux } from '/@/util.js';
+import { Disposable } from '/@/plugin/types/disposable.js';
+
+/**
+ * Represents an updater utility for Podman Desktop.
+ */
+export class Updater {
+  #currentVersion: string;
+  #updateInProgress: boolean;
+  #updateAlreadyDownloaded: boolean;
+  #updateCheckResult: UpdateCheckResult | undefined;
+
+  constructor(
+    private messageBox: MessageBox,
+    private statusBarRegistry: StatusBarRegistry,
+    private commandRegistry: CommandRegistry,
+  ) {
+    this.#currentVersion = `v${app.getVersion()}`;
+    this.#updateInProgress = false;
+    this.#updateAlreadyDownloaded = false;
+    this.#updateCheckResult = undefined;
+  }
+
+  /**
+   * Sets the default version entry in the status bar.
+   */
+  private defaultVersionEntry() {
+    this.statusBarRegistry.setEntry(
+      'version',
+      false,
+      0,
+      this.#currentVersion,
+      `Using version ${this.#currentVersion}`,
+      undefined,
+      true,
+      'version',
+      undefined,
+    );
+  }
+
+  /**
+   * Sets the update available entry in the status bar.
+   */
+  private updateAvailableEntry() {
+    // Update the 'version' entry in the status bar to show that an update is available
+    // this uses setEntry to update the existing entry
+    this.statusBarRegistry.setEntry(
+      'version',
+      false,
+      0,
+      this.#currentVersion,
+      'Update available',
+      UPDATER_UPDATE_AVAILABLE_ICON,
+      true,
+      'update',
+      undefined,
+      true,
+    );
+  }
+
+  /**
+   * Registers commands related to version and update.
+   */
+  private registerCommands() {
+    // Show a "No update available" only for macOS and Windows users and on production builds
+    let detailMessage: string;
+    if (!isLinux() && import.meta.env.PROD) {
+      detailMessage = 'No update available';
+    }
+
+    // Register command 'version' that will display the current version and say that no update is available.
+    // Only show the "no update available" command for macOS and Windows users, not linux users.
+    this.commandRegistry.registerCommand('version', async () => {
+      await this.messageBox.showMessageBox({
+        type: 'info',
+        title: 'Version',
+        message: `Using version ${this.#currentVersion}`,
+        detail: detailMessage,
+      });
+    });
+
+    // Update will create a standard "autoUpdater" dialog / update process
+    this.commandRegistry.registerCommand('update', async () => {
+      if (this.#updateAlreadyDownloaded) {
+        const result = await this.messageBox.showMessageBox({
+          type: 'info',
+          title: 'Update',
+          message: 'There is already an update downloaded. Please Restart Podman Desktop.',
+          cancelId: 1,
+          buttons: ['Restart', 'Cancel'],
+        });
+        if (result.response === 0) {
+          setImmediate(() => autoUpdater.quitAndInstall());
+        }
+        return;
+      }
+
+      if (this.#updateInProgress) {
+        await this.messageBox.showMessageBox({
+          type: 'info',
+          title: 'Update',
+          message: 'There is already an update in progress. Please wait until it is downloaded',
+          buttons: ['OK'],
+        });
+        return;
+      }
+
+      // Get the version of the update
+      const updateVersion = this.#updateCheckResult?.updateInfo.version
+        ? `v${this.#updateCheckResult?.updateInfo.version}`
+        : '';
+
+      const result = await this.messageBox.showMessageBox({
+        type: 'info',
+        title: 'Update Available',
+        message: `A new version ${updateVersion} of Podman Desktop is available. Do you want to update your current version ${this.#currentVersion}?`,
+        buttons: ['Update', 'Cancel'],
+        cancelId: 1,
+      });
+      if (result.response === 0) {
+        this.#updateInProgress = true;
+        this.#updateAlreadyDownloaded = false;
+
+        // Download update and try / catch it and create a dialog if it fails
+        try {
+          await autoUpdater.downloadUpdate();
+        } catch (error) {
+          console.error('Update error: ', error);
+          await this.messageBox.showMessageBox({
+            type: 'error',
+            title: 'Update Failed',
+            message: `An error occurred while trying to update to version ${updateVersion}. See the developer console for more information.`,
+            buttons: ['OK'],
+          });
+        }
+      }
+    });
+  }
+
+  /**
+   * Handler for update available event.
+   */
+  private onUpdateAvailable(): void {
+    this.updateAvailableEntry();
+  }
+
+  /**
+   * Handler for update not available event.
+   */
+  private onUpdateNotAvailable(): void {
+    this.#updateInProgress = false;
+    this.#updateAlreadyDownloaded = false;
+
+    // Update the 'version' entry in the status bar to show that no update is available
+    this.defaultVersionEntry();
+  }
+
+  /**
+   * Handler for update downloaded event.
+   */
+  private onUpdateDownloaded(): void {
+    this.#updateInProgress = false;
+    this.#updateAlreadyDownloaded = true;
+
+    this.messageBox
+      .showMessageBox({
+        title: 'Update Downloaded',
+        message: 'Update downloaded, Do you want to restart Podman Desktop ?',
+        cancelId: 1,
+        type: 'info',
+        buttons: ['Restart', 'Cancel'],
+      })
+      .then(result => {
+        if (result.response === 0) {
+          setImmediate(() => autoUpdater.quitAndInstall());
+        }
+      })
+      .catch((error: unknown) => {
+        console.error('unable to show message box', error);
+      });
+  }
+
+  /**
+   * Handler for update error event.
+   * @param error - The error that occurred during update.
+   */
+  private onUpdateError(error: Error): void {
+    this.#updateInProgress = false;
+    // local build not pushed to GitHub so prevent any 'update'
+    if (error?.message?.includes('No published versions on GitHub')) {
+      console.log('Cannot check for updates, no published versions on GitHub');
+      this.defaultVersionEntry();
+      return;
+    }
+    console.error('unable to check for updates', error);
+  }
+
+  /**
+   * Checks for updates.
+   */
+  private checkForUpdates(): void {
+    autoUpdater
+      .checkForUpdates()
+      .then(result => (this.#updateCheckResult = result ?? undefined))
+      .catch((error: unknown) => {
+        console.log('unable to check for updates', error);
+      });
+  }
+
+  public init(): Disposable {
+    // disable auto download
+    autoUpdater.autoDownload = false;
+
+    // Only check on production builds for Windows and macOS users
+    if (!import.meta.env.PROD || isLinux()) {
+      this.defaultVersionEntry();
+      return Disposable.noop();
+    }
+
+    this.registerCommands();
+
+    // setup the event listeners
+    autoUpdater.on('update-available', this.onUpdateAvailable.bind(this));
+    autoUpdater.on('update-not-available', this.onUpdateNotAvailable.bind(this));
+    autoUpdater.on('update-downloaded', this.onUpdateDownloaded.bind(this));
+    autoUpdater.on('error', this.onUpdateError);
+
+    try {
+      this.checkForUpdates();
+    } catch (error: unknown) {
+      console.error('unable to check for updates', error);
+    }
+
+    // Create an interval to check for updates every 12 hours
+    const intervalId = setInterval(this.checkForUpdates.bind(this), 1000 * 60 * 60 * 12);
+
+    return Disposable.create(() => {
+      clearInterval(intervalId);
+    });
+  }
+}

--- a/packages/main/src/plugin/updater.ts
+++ b/packages/main/src/plugin/updater.ts
@@ -48,7 +48,7 @@ export class Updater {
   /**
    * Sets the default version entry in the status bar.
    */
-  private defaultVersionEntry() {
+  private defaultVersionEntry(): void {
     this.statusBarRegistry.setEntry(
       'version',
       false,
@@ -65,7 +65,7 @@ export class Updater {
   /**
    * Sets the update available entry in the status bar.
    */
-  private updateAvailableEntry() {
+  private updateAvailableEntry(): void {
     // Update the 'version' entry in the status bar to show that an update is available
     // this uses setEntry to update the existing entry
     this.statusBarRegistry.setEntry(
@@ -85,7 +85,7 @@ export class Updater {
   /**
    * Registers commands related to version and update.
    */
-  private registerCommands() {
+  private registerCommands(): void {
     // Show a "No update available" only for macOS and Windows users and on production builds
     let detailMessage: string;
     if (!isLinux() && import.meta.env.PROD) {

--- a/packages/main/src/plugin/updater.ts
+++ b/packages/main/src/plugin/updater.ts
@@ -247,7 +247,7 @@ export class Updater {
     autoUpdater.on('update-available', this.onUpdateAvailable.bind(this));
     autoUpdater.on('update-not-available', this.onUpdateNotAvailable.bind(this));
     autoUpdater.on('update-downloaded', this.onUpdateDownloaded.bind(this));
-    autoUpdater.on('error', this.onUpdateError);
+    autoUpdater.on('error', this.onUpdateError.bind(this));
 
     try {
       this.checkForUpdates();


### PR DESCRIPTION
### What does this PR do?

Moving the logic of the updater system (Status Bar Item, error handling etc.) from the index to a dedicated file.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Related to https://github.com/containers/podman-desktop/issues/5754

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
