### PR TITLE
fix: don't check default machine on Linux

### DIFF
--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -54,7 +54,7 @@ let autoMachineStarted = false;
 let autoMachineName;
 
 // System default notifier
-let defaultMachineNotify = true;
+let defaultMachineNotify = !isLinux();
 let defaultMachineMonitor = true;
 
 // current status of machines

--- a/extensions/podman/src/podman-install.spec.ts
+++ b/extensions/podman/src/podman-install.spec.ts
@@ -70,6 +70,7 @@ vi.mock('./util', async () => {
     runCliCommand: vi.fn(),
     appHomeDir: vi.fn().mockReturnValue(''),
     normalizeWSLOutput: vi.fn().mockImplementation((s: string) => s),
+    isLinux: vi.fn(),
   };
 });
 


### PR DESCRIPTION
### What does this PR do?

Avoids setting a default system connection on Linux.

![](https://github.com/containers/podman-desktop/assets/10364051/86783df0-0dbe-4f54-b9d2-55bc7c4d37cc)

Chances are, user wants to decide this themselves...

`podman-remote version`

`podman-remote-static --connection podman-machine-default version`

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
