### PR TITLE
fix: refresh onboarding item when context value gets updated (#4597)

### DIFF
--- a/packages/renderer/src/lib/onboarding/Onboarding.svelte
+++ b/packages/renderer/src/lib/onboarding/Onboarding.svelte
@@ -397,7 +397,6 @@ function handleEscape({ key }: any) {
                   <OnboardingItem
                     extension="{activeStep.onboarding.extension}"
                     item="{item}"
-                    getContext="{() => globalContext}"
                     inProgressCommandExecution="{inProgressCommandExecution}" />
                 {/each}
               </div>

--- a/packages/renderer/src/lib/onboarding/OnboardingItem.svelte
+++ b/packages/renderer/src/lib/onboarding/OnboardingItem.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { onMount } from 'svelte';
+import { onDestroy, onMount } from 'svelte';
 import type { OnboardingStepItem } from '../../../../main/src/plugin/api/onboarding';
 import Markdown from '../markdown/Markdown.svelte';
 import type { ContextUI } from '../context/context';
@@ -9,9 +9,10 @@ import { configurationProperties } from '/@/stores/configurationProperties';
 import PreferencesRenderingItem from '../preferences/PreferencesRenderingItem.svelte';
 import { CONFIGURATION_ONBOARDING_SCOPE } from '../../../../main/src/plugin/configuration-registry-constants';
 import { isTargetScope } from '../preferences/Util';
+import { context } from '/@/stores/context';
+import type { Unsubscriber } from 'svelte/store';
 export let extension: string;
 export let item: OnboardingStepItem;
-export let getContext: () => ContextUI;
 export let inProgressCommandExecution: (
   command: string,
   state: 'starting' | 'failed' | 'successful',
@@ -24,6 +25,9 @@ $: html;
 let configurationItems: IConfigurationPropertyRecordedSchema[];
 let configurationItem: IConfigurationPropertyRecordedSchema | undefined;
 $: configurationItem;
+
+let globalContext: ContextUI;
+let contextsUnsubscribe: Unsubscriber;
 
 onMount(() => {
   configurationProperties.subscribe(value => {
@@ -39,14 +43,28 @@ onMount(() => {
     }
   });
 
-  const itemHtml = replacePlaceholders(item.value);
-  html = itemHtml;
+  contextsUnsubscribe = context.subscribe(value => {
+    globalContext = value;
+    updateHtml();
+  });
+
+  updateHtml();
 });
+
+onDestroy(() => {
+  contextsUnsubscribe?.();
+});
+
+function updateHtml() {
+  const itemHtml = replacePlaceholders(item.value);
+  if (html !== itemHtml) {
+    html = itemHtml;
+  }
+}
 
 function replacePlaceholders(label: string): string {
   let newLabel = label;
-  const context = getContext();
-  newLabel = replaceContextKeyPlaceholders(newLabel, extension, context);
+  newLabel = replaceContextKeyPlaceholders(newLabel, extension, globalContext);
   newLabel = replaceContextKeyPlaceHoldersByRegex(configurationRegex, newLabel, undefined, undefined, '');
   return newLabel;
 }
@@ -54,7 +72,7 @@ function replacePlaceholders(label: string): string {
 
 <div class="flex justify-center {item.highlight ? 'bg-charcoal-600' : ''} p-3 m-2 rounded-md min-w-[500px]">
   {#if html}
-    <Markdown inProgressMarkdownCommandExecutionCallback="{inProgressCommandExecution}">{html}</Markdown>
+    <Markdown inProgressMarkdownCommandExecutionCallback="{inProgressCommandExecution}" markdown="{html}" />
   {/if}
   {#if configurationItem}
     <div class="min-w-[500px] bg-charcoal-600 rounded-md">

--- a/packages/renderer/src/lib/onboarding/OnboardingItem.svelte
+++ b/packages/renderer/src/lib/onboarding/OnboardingItem.svelte
@@ -55,7 +55,7 @@ onDestroy(() => {
   contextsUnsubscribe?.();
 });
 
-function updateHtml() {
+function updateHtml(): void {
   const itemHtml = replacePlaceholders(item.value);
   if (html !== itemHtml) {
     html = itemHtml;


### PR DESCRIPTION
### What does this PR do?

it allows an onboarding item to be refreshed when the context value gets updated

### Screenshot / video of UI

![onboarding_refresh](https://github.com/containers/podman-desktop/assets/49404737/67db555d-0c50-4c73-8ef5-ce77cc9efe48)

### What issues does this PR fix or reference?

it resolves #4597 

### How to test this PR?

1) have the virtualization platform disabled
2) run podman onboarding and see the requirements step fails
3) enable virtualization platform
4) click on rerun requirements check
5) the virtual platform check should be successful 

- [x] Tests are covering the bug fix or the new feature
