### PR TITLE
feat: add fieldManager when patching Kubernetes resource

### DIFF
--- a/packages/main/src/plugin/kubernetes-client.spec.ts
+++ b/packages/main/src/plugin/kubernetes-client.spec.ts
@@ -1288,15 +1288,32 @@ test('Expect apply should patch if object exists', async () => {
   const manifests = { kind: test, metadata: { annotations: test } } as unknown as KubernetesObject;
   const patchedObj = { kind: 'patched' };
   vi.spyOn(client, 'loadManifestsFromFile').mockReturnValue(Promise.resolve([manifests]));
+  const patchMock = vi.fn();
   makeApiClientMock.mockReturnValue({
     read: vi.fn(),
-    patch: vi.fn().mockReturnValue({ body: patchedObj }),
+    patch: patchMock.mockReturnValue({ body: patchedObj }),
   });
 
   const objects = await client.applyResourcesFromFile('default', 'some-file.yaml');
 
   expect(objects).toHaveLength(1);
   expect(objects[0]).toEqual(patchedObj);
+  expect(patchMock).toHaveBeenCalledWith(expect.any(Object), undefined, undefined, 'podman-desktop');
+});
+
+test('Expect apply should patch with specific field manager', async () => {
+  const client = createTestClient('default');
+  const manifests = { kind: test, metadata: { annotations: test } } as unknown as KubernetesObject;
+  const patchedObj = { kind: 'patched' };
+  vi.spyOn(client, 'loadManifestsFromFile').mockReturnValue(Promise.resolve([manifests]));
+  const patchMock = vi.fn();
+  makeApiClientMock.mockReturnValue({
+    read: vi.fn(),
+    patch: patchMock.mockReturnValue({ body: patchedObj }),
+  });
+
+  await client.applyResourcesFromFile('default', 'some-file.yaml');
+  expect(patchMock).toHaveBeenCalledWith(expect.any(Object), undefined, undefined, 'podman-desktop');
 });
 
 test('If Kubernetes returns a http error, output the http body message error.', async () => {

--- a/packages/main/src/plugin/kubernetes-client.spec.ts
+++ b/packages/main/src/plugin/kubernetes-client.spec.ts
@@ -343,7 +343,7 @@ test('Create custom Kubernetes resources in error should return error', async ()
 
 test('Create unknown custom Kubernetes resources should return error', async () => {
   const client = createTestClient();
-  const createSpy = vi.spyOn(client, 'createCustomResource').mockReturnValue(Promise.resolve());
+  const createSpy = vi.spyOn(client, 'createCustomResource').mockResolvedValue(undefined);
   const pluralSpy = vi.spyOn(client, 'getAPIResource').mockRejectedValue(new Error('CustomError'));
   try {
     await client.createResources('dummy', [{ apiVersion: 'group/v1', kind: 'Namespace' }]);
@@ -1257,7 +1257,7 @@ test('Expect apply with invalid file should error', async () => {
 
 test('Expect apply with empty yaml should throw error', async () => {
   const client = createTestClient('default');
-  vi.spyOn(client, 'loadManifestsFromFile').mockReturnValue(Promise.resolve([]));
+  vi.spyOn(client, 'loadManifestsFromFile').mockResolvedValue([]);
   let expectedError: unknown;
   try {
     await client.applyResourcesFromFile('default', 'missing-file.yaml');
@@ -1272,7 +1272,7 @@ test('Expect apply should create if object does not exist', async () => {
   const client = createTestClient('default');
   const manifests = { kind: test, metadata: { annotations: test } } as unknown as KubernetesObject;
   const createdObj = { kind: 'created' };
-  vi.spyOn(client, 'loadManifestsFromFile').mockReturnValue(Promise.resolve([manifests]));
+  vi.spyOn(client, 'loadManifestsFromFile').mockResolvedValue([manifests]);
   makeApiClientMock.mockReturnValue({
     create: vi.fn().mockReturnValue({ body: createdObj }),
   });
@@ -1287,7 +1287,7 @@ test('Expect apply should patch if object exists', async () => {
   const client = createTestClient('default');
   const manifests = { kind: test, metadata: { annotations: test } } as unknown as KubernetesObject;
   const patchedObj = { kind: 'patched' };
-  vi.spyOn(client, 'loadManifestsFromFile').mockReturnValue(Promise.resolve([manifests]));
+  vi.spyOn(client, 'loadManifestsFromFile').mockResolvedValue([manifests]);
   const patchMock = vi.fn();
   makeApiClientMock.mockReturnValue({
     read: vi.fn(),
@@ -1305,7 +1305,7 @@ test('Expect apply should patch with specific field manager', async () => {
   const client = createTestClient('default');
   const manifests = { kind: test, metadata: { annotations: test } } as unknown as KubernetesObject;
   const patchedObj = { kind: 'patched' };
-  vi.spyOn(client, 'loadManifestsFromFile').mockReturnValue(Promise.resolve([manifests]));
+  vi.spyOn(client, 'loadManifestsFromFile').mockResolvedValue([manifests]);
   const patchMock = vi.fn();
   makeApiClientMock.mockReturnValue({
     read: vi.fn(),
@@ -1439,7 +1439,7 @@ test('Expect applyResourcesFromYAML to correctly call applyResources after loadi
       },
     },
   ];
-  const applyResourcesSpy = vi.spyOn(client, 'applyResources').mockReturnValue(Promise.resolve(expectedObjects));
+  const applyResourcesSpy = vi.spyOn(client, 'applyResources').mockResolvedValue(expectedObjects);
   const objects = await client.applyResourcesFromYAML('default', podAndDeploymentTestYAML);
   expect(objects).toEqual(expectedObjects);
   expect(applyResourcesSpy).toHaveBeenCalledWith('default', expectedObjects, 'apply');

--- a/packages/main/src/plugin/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes-client.ts
@@ -117,6 +117,8 @@ const OPENSHIFT_PROJECT_API_GROUP = 'project.openshift.io';
 
 const DEFAULT_NAMESPACE = 'default';
 
+const FIELD_MANAGER = 'podman-desktop';
+
 /**
  * Handle calls to kubernetes API
  */
@@ -1181,7 +1183,12 @@ export class KubernetesClient {
           //
           // See: https://github.com/kubernetes/kubernetes/issues/97423
           if (action === 'apply') {
-            const response = await client.patch(spec);
+            const response = await client.patch(
+              spec,
+              undefined /* pretty */,
+              undefined /* dryRun */,
+              FIELD_MANAGER /* fieldManager */,
+            );
             created.push(response.body);
           }
         } catch (error) {


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Declare a field manager name when doing PATCH operation on a Kubernetes resource.

### Screenshot / video of UI

In the screenshot:
- the first Update is done by a `kubectl create deployment ...` command (manager = kubectl-create)
- the second is made by Podman Desktop before this PR (manager = unknown)
- the third is made by Podman Desktop with this PR (manager = podman-desktop)


![fieldManager](https://github.com/containers/podman-desktop/assets/9973512/f5ccee5a-4f01-4448-b68b-92df1620ef4e)

### What issues does this PR fix or reference?

Fixes #6186 

### How to test this PR?

Create a deployment, then open this deployment in Podman Desktop and edit it from the Kube tab. 

In the resulting yaml, the `managedFields` section should indicate 'podman-desktop' as menager for the matching entry.


- [x] Tests are covering the bug fix or the new feature
