### PR TITLE
chore: skip ui dist folder when checking svelte components

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "lint:clean": "rimraf .eslintcache",
     "lint:check": "node --max-old-space-size=4096 node_modules/eslint/bin/eslint.js --cache . --ext js,ts,tsx,svelte",
     "lint:fix": "node --max-old-space-size=4096 node_modules/eslint/bin/eslint.js --cache . --fix --ext js,ts,tsx,svelte",
-    "svelte:check": "svelte-check",
+    "svelte:check": "svelte-check --ignore \"packages/ui/dist\"",
     "typecheck:main": "tsc --noEmit -p packages/main/tsconfig.json",
     "typecheck:preload": "tsc --noEmit -p packages/preload/tsconfig.json",
     "typecheck:preload-dd-extension": "tsc --noEmit -p packages/preload-docker-extension/tsconfig.json",


### PR DESCRIPTION
### What does this PR do?
skip ui dist folder when checking svelte components
else it'll try to parse invalid files (in src folder this is correct)


### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

#5757 

### How to test this PR?

should be ✅ 

- [x] Tests are covering the bug fix or the new feature
