### PR TITLE
fix: avoid leakage of internal interface in the extension API for pods

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -277,7 +277,7 @@ declare module '@podman-desktop/api' {
     portmappings?: PodCreatePortOptions[];
     labels?: { [key: string]: string };
     // Set the provider to use, if not we will try select the first one available (sorted in favor of Podman).
-    provider?: ProviderContainerConnectionInfo | ContainerProviderConnection;
+    provider?: ContainerProviderConnection;
   }
 
   export interface KubernetesProviderConnectionEndpoint {

--- a/packages/main/src/plugin/api/pod-info.ts
+++ b/packages/main/src/plugin/api/pod-info.ts
@@ -16,10 +16,12 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { ContainerProviderConnection, PodCreatePortOptions } from '@podman-desktop/api';
 import type {
   PodInfo as LibPodPodInfo,
   PodInspectInfo as LibPodPodInspectInfo,
 } from '../dockerode/libpod-dockerode.js';
+import type { ProviderContainerConnectionInfo } from './provider-info.js';
 
 export interface PodInfo extends LibPodPodInfo {
   engineId: string;
@@ -30,4 +32,12 @@ export interface PodInfo extends LibPodPodInfo {
 export interface PodInspectInfo extends LibPodPodInspectInfo {
   engineId: string;
   engineName: string;
+}
+
+export interface PodCreateOptions {
+  name: string;
+  portmappings?: PodCreatePortOptions[];
+  labels?: { [key: string]: string };
+  // Set the provider to use, if not we will try select the first one available (sorted in favor of Podman).
+  provider?: ProviderContainerConnectionInfo | ContainerProviderConnection;
 }

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -32,7 +32,7 @@ import type {
   VolumeCreateResponseInfo,
 } from './api/container-info.js';
 import type { ImageInfo } from './api/image-info.js';
-import type { PodInfo, PodInspectInfo } from './api/pod-info.js';
+import type { PodCreateOptions, PodInfo, PodInspectInfo } from './api/pod-info.js';
 import type { ImageInspectInfo } from './api/image-inspect-info.js';
 import type { ProviderContainerConnectionInfo } from './api/provider-info.js';
 import type { ImageRegistry } from './image-registry.js';
@@ -1168,7 +1168,7 @@ export class ContainerProviderRegistry {
     }
   }
 
-  async createPod(podOptions: containerDesktopAPI.PodCreateOptions): Promise<{ engineId: string; Id: string }> {
+  async createPod(podOptions: PodCreateOptions): Promise<{ engineId: string; Id: string }> {
     let telemetryOptions = {};
     try {
       let internalContainerProvider: InternalContainerProvider;

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -32,7 +32,7 @@ import type {
 import type { ContributionInfo } from '../../main/src/plugin/api/contribution-info';
 import type { ImageInfo } from '../../main/src/plugin/api/image-info';
 import type { VolumeInspectInfo, VolumeListInfo } from '../../main/src/plugin/api/volume-info';
-import type { PodInfo, PodInspectInfo } from '../../main/src/plugin/api/pod-info';
+import type { PodCreateOptions, PodInfo, PodInspectInfo } from '../../main/src/plugin/api/pod-info';
 import type { NetworkInspectInfo } from '../../main/src/plugin/api/network-info';
 import type { ImageInspectInfo } from '../../main/src/plugin/api/image-inspect-info';
 import type { HistoryInfo } from '../../main/src/plugin/api/history-info';
@@ -268,7 +268,7 @@ export function initExposure(): void {
   );
   contextBridge.exposeInMainWorld(
     'createPod',
-    async (podCreateOptions: containerDesktopAPI.PodCreateOptions): Promise<{ engineId: string; Id: string }> => {
+    async (podCreateOptions: PodCreateOptions): Promise<{ engineId: string; Id: string }> => {
       return ipcInvoke('container-provider-registry:createPod', podCreateOptions);
     },
   );


### PR DESCRIPTION
### What does this PR do?
internal API object ProviderContainerConnectionInfo should stay in the internal API and not leaked to extension API for creating pods.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

related to https://github.com/containers/podman-desktop/pull/5880
and https://github.com/containers/podman-desktop/issues/5879

### How to test this PR?

Current tests should continue to work

- [x] Tests are covering the bug fix or the new feature
