### PR TITLE
Start other informers lazily

### DIFF
--- a/packages/main/src/plugin/kubernetes-context-state.spec.ts
+++ b/packages/main/src/plugin/kubernetes-context-state.spec.ts
@@ -1204,9 +1204,10 @@ test('changing context should stop service informer on previous current context'
 describe('ContextsStates tests', () => {
   test('hasInformer should check if informer exists for context', () => {
     const client = new ContextsStates();
-    client.setInformers('context1', {
-      pods: new FakeInformer('context1', '/path/to/resource', 0, undefined, [], []),
-    });
+    client.setInformers(
+      'context1',
+      new Map([['pods', new FakeInformer('context1', '/path/to/resource', 0, undefined, [], [])]]),
+    );
     expect(client.hasInformer('context1', 'pods')).toBeTruthy();
     expect(client.hasInformer('context1', 'deployments')).toBeFalsy();
     expect(client.hasInformer('context2', 'pods')).toBeFalsy();
@@ -1215,23 +1216,27 @@ describe('ContextsStates tests', () => {
 
   test('getContextsNames should return the names of contexts as array', () => {
     const client = new ContextsStates();
-    client.setInformers('context1', {
-      pods: new FakeInformer('context1', '/path/to/resource', 0, undefined, [], []),
-    });
-    client.setInformers('context2', {
-      pods: new FakeInformer('context2', '/path/to/resource', 0, undefined, [], []),
-    });
+    client.setInformers(
+      'context1',
+      new Map([['pods', new FakeInformer('context1', '/path/to/resource', 0, undefined, [], [])]]),
+    );
+    client.setInformers(
+      'context2',
+      new Map([['pods', new FakeInformer('context2', '/path/to/resource', 0, undefined, [], [])]]),
+    );
     expect(Array.from(client.getContextsNames())).toEqual(['context1', 'context2']);
   });
 
   test('isReachable', () => {
     const client = new ContextsStates();
-    client.setInformers('context1', {
-      pods: new FakeInformer('context1', '/path/to/resource', 0, undefined, [], []),
-    });
-    client.setInformers('context2', {
-      pods: new FakeInformer('context2', '/path/to/resource', 0, undefined, [], []),
-    });
+    client.setInformers(
+      'context1',
+      new Map([['pods', new FakeInformer('context1', '/path/to/resource', 0, undefined, [], [])]]),
+    );
+    client.setInformers(
+      'context2',
+      new Map([['pods', new FakeInformer('context2', '/path/to/resource', 0, undefined, [], [])]]),
+    );
     client.safeSetState('context1', state => (state.reachable = true));
 
     expect(client.isReachable('context1')).toBeTruthy();

--- a/packages/main/src/plugin/kubernetes-context-state.ts
+++ b/packages/main/src/plugin/kubernetes-context-state.ts
@@ -153,7 +153,7 @@ class Backoff {
   }
 }
 
-class ContextsStates {
+export class ContextsStates {
   private state = new Map<string, ContextState>();
   private informers = new Map<string, ContextInternalState>();
 
@@ -163,10 +163,7 @@ class ContextsStates {
 
   hasInformer(context: string, resourceName: ResourceName): boolean {
     const informers = this.informers.get(context);
-    if (!informers) {
-      return false;
-    }
-    return !!informers[resourceName];
+    return !!informers?.[resourceName];
   }
 
   setInformers(name: string, informers: ContextInternalState | undefined): void {
@@ -239,8 +236,7 @@ class ContextsStates {
   }
 
   isReachable(contextName: string): boolean {
-    const state = this.state.get(contextName);
-    return state?.reachable ?? false;
+    return this.state.get(contextName)?.reachable ?? false;
   }
 
   safeSetState(name: string, update: (previous: ContextState) => void): void {

--- a/packages/renderer/src/lib/service/ServicesList.spec.ts
+++ b/packages/renderer/src/lib/service/ServicesList.spec.ts
@@ -19,28 +19,17 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import '@testing-library/jest-dom/vitest';
-import { test, expect, vi, beforeEach } from 'vitest';
+import { test, expect, vi, beforeEach, beforeAll } from 'vitest';
 import { render, screen } from '@testing-library/svelte';
 import ServicesList from './ServicesList.svelte';
 import { get } from 'svelte/store';
 import type { V1Service } from '@kubernetes/client-node';
-import { services, servicesEventStore } from '/@/stores/services';
+import { kubernetesCurrentContextServices } from '/@/stores/kubernetes-contexts-state';
 
-const callbacks = new Map<string, any>();
-const eventEmitter = {
-  receive: (message: string, callback: any) => {
-    callbacks.set(message, callback);
-  },
-};
+const kubernetesGetCurrentContextResourcesMock = vi.fn();
 
-Object.defineProperty(global, 'window', {
-  value: {
-    events: {
-      receive: eventEmitter.receive,
-    },
-    addEventListener: eventEmitter.receive,
-  },
-  writable: true,
+beforeAll(() => {
+  (window as any).kubernetesGetCurrentContextResources = kubernetesGetCurrentContextResourcesMock;
 });
 
 beforeEach(() => {
@@ -59,6 +48,7 @@ async function waitRender(customProperties: object): Promise<void> {
 }
 
 test('Expect service empty screen', async () => {
+  kubernetesGetCurrentContextResourcesMock.mockResolvedValue([]);
   render(ServicesList);
   const noServices = screen.getByRole('heading', { name: 'No services' });
   expect(noServices).toBeInTheDocument();
@@ -77,15 +67,10 @@ test('Expect services list', async () => {
       externalName: 'serve',
     },
   };
-
-  servicesEventStore.setup();
-
-  const ServiceAddCallback = callbacks.get('kubernetes-service-add');
-  expect(ServiceAddCallback).toBeDefined();
-  await ServiceAddCallback(service);
+  kubernetesGetCurrentContextResourcesMock.mockResolvedValue([service]);
 
   // wait while store is populated
-  while (get(services).length === 0) {
+  while (get(kubernetesCurrentContextServices).length === 0) {
     await new Promise(resolve => setTimeout(resolve, 500));
   }
 
@@ -108,15 +93,10 @@ test('Expect filter empty screen', async () => {
       externalName: 'serve',
     },
   };
-
-  servicesEventStore.setup();
-
-  const ServiceAddCallback = callbacks.get('kubernetes-service-add');
-  expect(ServiceAddCallback).toBeDefined();
-  await ServiceAddCallback(service);
+  kubernetesGetCurrentContextResourcesMock.mockResolvedValue([service]);
 
   // wait while store is populated
-  while (get(services).length === 0) {
+  while (get(kubernetesCurrentContextServices).length === 0) {
     await new Promise(resolve => setTimeout(resolve, 500));
   }
 

--- a/packages/renderer/src/lib/service/ServicesList.svelte
+++ b/packages/renderer/src/lib/service/ServicesList.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 import { onMount } from 'svelte';
-import { filtered, searchPattern } from '../../stores/services';
 import NavPage from '../ui/NavPage.svelte';
 import Table from '../table/Table.svelte';
 import { Column, Row } from '../table/table';
@@ -20,16 +19,17 @@ import DurationColumn from '../table/DurationColumn.svelte';
 import ServiceColumnType from './ServiceColumnType.svelte';
 import KubernetesCurrentContextConnectionBadge from '/@/lib/ui/KubernetesCurrentContextConnectionBadge.svelte';
 import KubeApplyYamlButton from '../kube/KubeApplyYAMLButton.svelte';
+import { kubernetesCurrentContextServicesFiltered, serviceSearchPattern } from '/@/stores/kubernetes-contexts-state';
 
 export let searchTerm = '';
-$: searchPattern.set(searchTerm);
+$: serviceSearchPattern.set(searchTerm);
 
 let services: ServiceUI[] = [];
 
 const serviceUtils = new ServiceUtils();
 
 onMount(() => {
-  return filtered.subscribe(value => {
+  return kubernetesCurrentContextServicesFiltered.subscribe(value => {
     services = value.map(service => serviceUtils.getServiceUI(service));
   });
 });
@@ -148,7 +148,7 @@ const row = new Row<ServiceUI>({ selectable: _service => true });
       on:update="{() => (services = services)}">
     </Table>
 
-    {#if $filtered.length === 0}
+    {#if $kubernetesCurrentContextServicesFiltered.length === 0}
       {#if searchTerm}
         <FilteredEmptyScreen icon="{ServiceIcon}" kind="services" bind:searchTerm="{searchTerm}" />
       {:else}

--- a/packages/renderer/src/stores/kubernetes-contexts-state.ts
+++ b/packages/renderer/src/stores/kubernetes-contexts-state.ts
@@ -57,3 +57,21 @@ export const kubernetesCurrentContextDeploymentsFiltered = derived(
   ([$searchPattern, $deployments]) =>
     $deployments.filter(deployment => findMatchInLeaves(deployment, $searchPattern.toLowerCase())),
 );
+
+// Services
+
+export const kubernetesCurrentContextServices = readable<KubernetesObject[]>([], set => {
+  window.kubernetesGetCurrentContextResources('services').then(value => set(value));
+  window.events?.receive('kubernetes-current-context-services-update', (value: unknown) => {
+    set(value as KubernetesObject[]);
+  });
+});
+
+export const serviceSearchPattern = writable('');
+
+// The services in the current context, filtered with `serviceSearchPattern`
+export const kubernetesCurrentContextServicesFiltered = derived(
+  [serviceSearchPattern, kubernetesCurrentContextServices],
+  ([$searchPattern, $services]) =>
+    $services.filter(service => findMatchInLeaves(service, $searchPattern.toLowerCase())),
+);


### PR DESCRIPTION
### What does this PR do?

- start service informer when service store asks the first time the list of services
- stop the service informer on previous context when the current context changes

### What issues does this PR fix or reference?

Fixes partially #6202 

### How to test this PR?

Switch to the services list page and check that the services are visible
Debug logs indicate when the informer is started or not
Check by changing context 

- [x] Tests are covering the bug fix or the new feature
