### PR TITLE
feat(extension-api): adding stats container api

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -2655,19 +2655,19 @@ declare module '@podman-desktop/api' {
     title: string;
   }
 
-  interface PidsStats {
+  export interface PidsStats {
     current?: number;
     limit?: number;
   }
 
-  interface BlkioStatEntry {
+  export interface BlkioStatEntry {
     major: number;
     minor: number;
     op: string;
     value: number;
   }
 
-  interface BlkioStats {
+  export interface BlkioStats {
     io_service_bytes_recursive: BlkioStatEntry[];
     io_serviced_recursive: BlkioStatEntry[];
     io_queue_recursive: BlkioStatEntry[];
@@ -2678,21 +2678,21 @@ declare module '@podman-desktop/api' {
     sectors_recursive: BlkioStatEntry[];
   }
 
-  interface StorageStats {
+  export interface StorageStats {
     read_count_normalized?: number;
     read_size_bytes?: number;
     write_count_normalized?: number;
     write_size_bytes?: number;
   }
 
-  interface StorageStats {
+  export interface StorageStats {
     read_count_normalized?: number;
     read_size_bytes?: number;
     write_count_normalized?: number;
     write_size_bytes?: number;
   }
 
-  interface NetworkStats {
+  export interface NetworkStats {
     [name: string]: {
       rx_bytes: number;
       rx_dropped: number;
@@ -2707,7 +2707,7 @@ declare module '@podman-desktop/api' {
     };
   }
 
-  interface MemoryStats {
+  export interface MemoryStats {
     // Linux Memory Stats
     stats: {
       total_pgmajfault: number;
@@ -2751,20 +2751,20 @@ declare module '@podman-desktop/api' {
     privateworkingset?: number;
   }
 
-  interface CPUUsage {
+  export interface CPUUsage {
     percpu_usage: number[];
     usage_in_usermode: number;
     total_usage: number;
     usage_in_kernelmode: number;
   }
 
-  interface ThrottlingData {
+  export interface ThrottlingData {
     periods: number;
     throttled_periods: number;
     throttled_time: number;
   }
 
-  interface CPUStats {
+  export interface CPUStats {
     cpu_usage: CPUUsage;
     system_cpu_usage: number;
     online_cpus: number;

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -2456,17 +2456,6 @@ declare module '@podman-desktop/api' {
     }>;
   }
 
-  export interface StatsContainerOptions {
-    /**
-     * The engine where the container is deployed
-     */
-    engineId: string;
-    /**
-     * The identifier of the container
-     */
-    id: string;
-  }
-
   export interface ContainerCreateOptions {
     /**
      * Assign the specified name to the container. Must match the regular expression`/?[a-zA-Z0-9][a-zA-Z0-9_.-]+`. If not speficied, the platform assigns a unique name to the container
@@ -3078,7 +3067,8 @@ declare module '@podman-desktop/api' {
     /**
      * Get the streamed stats of a running container.
      *
-     * @param options the options to use {@link StatsContainerOptions}
+     * @param engineId the id of the engine managing the container, obtained from the result of {@link containerEngine.listContainers}
+     * @param id the id or name of the container on this engine, obtained from the result of {@link containerEngine.listContainers} or as the result of {@link containerEngine.createContainer}
      * @param callback the function called when container stats info are emitted.
      *
      * @return A Promise resolving a {@link Disposable} that unregister the callback when called.
@@ -3086,10 +3076,7 @@ declare module '@podman-desktop/api' {
      * @example
      * Here is a usage example
      * ```ts
-     * const disposable = await statsContainer({
-     *  engineId: 'engineId',
-     *  id: 'containerId',
-     * }, (stats: ContainerStatsInfo): void => {
+     * const disposable = await statsContainer('engineId', 'containerId', (stats: ContainerStatsInfo): void => {
      *  console.log('CPU Usage', stats.cpu_stats.cpu_usage.total_usage);
      * });
      *
@@ -3098,7 +3085,8 @@ declare module '@podman-desktop/api' {
      * ```
      */
     export function statsContainer(
-      options: StatsContainerOptions,
+      engineId: string,
+      id: string,
       callback: (stats: ContainerStatsInfo) => void,
     ): Promise<Disposable>;
 

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -2655,6 +2655,137 @@ declare module '@podman-desktop/api' {
     title: string;
   }
 
+  interface PidsStats {
+    current?: number;
+    limit?: number;
+  }
+
+  interface BlkioStatEntry {
+    major: number;
+    minor: number;
+    op: string;
+    value: number;
+  }
+
+  interface BlkioStats {
+    io_service_bytes_recursive: BlkioStatEntry[];
+    io_serviced_recursive: BlkioStatEntry[];
+    io_queue_recursive: BlkioStatEntry[];
+    io_service_time_recursive: BlkioStatEntry[];
+    io_wait_time_recursive: BlkioStatEntry[];
+    io_merged_recursive: BlkioStatEntry[];
+    io_time_recursive: BlkioStatEntry[];
+    sectors_recursive: BlkioStatEntry[];
+  }
+
+  interface StorageStats {
+    read_count_normalized?: number;
+    read_size_bytes?: number;
+    write_count_normalized?: number;
+    write_size_bytes?: number;
+  }
+
+  interface StorageStats {
+    read_count_normalized?: number;
+    read_size_bytes?: number;
+    write_count_normalized?: number;
+    write_size_bytes?: number;
+  }
+
+  interface NetworkStats {
+    [name: string]: {
+      rx_bytes: number;
+      rx_dropped: number;
+      rx_errors: number;
+      rx_packets: number;
+      tx_bytes: number;
+      tx_dropped: number;
+      tx_errors: number;
+      tx_packets: number;
+      endpoint_id?: string; // not used on linux
+      instance_id?: string; // not used on linux
+    };
+  }
+
+  interface MemoryStats {
+    // Linux Memory Stats
+    stats: {
+      total_pgmajfault: number;
+      cache: number;
+      mapped_file: number;
+      total_inactive_file: number;
+      pgpgout: number;
+      rss: number;
+      total_mapped_file: number;
+      writeback: number;
+      unevictable: number;
+      pgpgin: number;
+      total_unevictable: number;
+      pgmajfault: number;
+      total_rss: number;
+      total_rss_huge: number;
+      total_writeback: number;
+      total_inactive_anon: number;
+      rss_huge: number;
+      hierarchical_memory_limit: number;
+      total_pgfault: number;
+      total_active_file: number;
+      active_anon: number;
+      total_active_anon: number;
+      total_pgpgout: number;
+      total_cache: number;
+      inactive_anon: number;
+      active_file: number;
+      pgfault: number;
+      inactive_file: number;
+      total_pgpgin: number;
+    };
+    max_usage: number;
+    usage: number;
+    failcnt: number;
+    limit: number;
+
+    // Windows Memory Stats
+    commitbytes?: number;
+    commitpeakbytes?: number;
+    privateworkingset?: number;
+  }
+
+  interface CPUUsage {
+    percpu_usage: number[];
+    usage_in_usermode: number;
+    total_usage: number;
+    usage_in_kernelmode: number;
+  }
+
+  interface ThrottlingData {
+    periods: number;
+    throttled_periods: number;
+    throttled_time: number;
+  }
+
+  interface CPUStats {
+    cpu_usage: CPUUsage;
+    system_cpu_usage: number;
+    online_cpus: number;
+    throttling_data: ThrottlingData;
+  }
+
+  export interface ContainerStatsInfo {
+    engineId: string;
+    engineName: string;
+    read: string;
+    preread: string;
+    pids_stats?: PidsStats;
+    blkio_stats?: BlkioStats;
+    num_procs: number;
+    storage_stats?: StorageStats;
+    networks: NetworkStats;
+    memory_stats: MemoryStats;
+    cpu_stats: CPUStats;
+    precpu_stats: CPUStats;
+  }
+
   export interface BuildImageOptions {
     /**
      * Specifies a Containerfile which contains instructions for building the image
@@ -2932,6 +3063,32 @@ declare module '@podman-desktop/api' {
       id: string,
       callback: (name: string, data: string) => void,
     ): Promise<void>;
+
+    /**
+     * Get the streamed stats of a running container.
+     *
+     * @param engineId the id of the engine managing the container, obtained from the result of {@link containerEngine.listContainers}
+     * @param id the id or name of the container on this engine, obtained from the result of {@link containerEngine.listContainers} or as the result of {@link containerEngine.createContainer}
+     * @param callback the function called when container stats info are emitted.
+     *
+     * @return A Promise resolving a {@link Disposable} that unregister the callback when called.
+     *
+     * @example
+     * Here is a usage example
+     * ```ts
+     * const disposable = await statsContainer('engineId', 'containerId', (stats: ContainerStatsInfo): void => {
+     *  console.log('CPU Usage', stats.cpu_stats.cpu_usage.total_usage);
+     * });
+     *
+     * // When no longer needed
+     * disposable.dispose();
+     * ```
+     */
+    export function statsContainer(
+      engineId: string,
+      id: string,
+      callback: (stats: ContainerStatsInfo) => void,
+    ): Promise<Disposable>;
 
     /**
      * Stop an existing container

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -2456,6 +2456,17 @@ declare module '@podman-desktop/api' {
     }>;
   }
 
+  export interface StatsContainerOptions {
+    /**
+     * The engine where the container is deployed
+     */
+    engineId: string;
+    /**
+     * The identifier of the container
+     */
+    id: string;
+  }
+
   export interface ContainerCreateOptions {
     /**
      * Assign the specified name to the container. Must match the regular expression`/?[a-zA-Z0-9][a-zA-Z0-9_.-]+`. If not speficied, the platform assigns a unique name to the container
@@ -3067,8 +3078,7 @@ declare module '@podman-desktop/api' {
     /**
      * Get the streamed stats of a running container.
      *
-     * @param engineId the id of the engine managing the container, obtained from the result of {@link containerEngine.listContainers}
-     * @param id the id or name of the container on this engine, obtained from the result of {@link containerEngine.listContainers} or as the result of {@link containerEngine.createContainer}
+     * @param options the options to use {@link StatsContainerOptions}
      * @param callback the function called when container stats info are emitted.
      *
      * @return A Promise resolving a {@link Disposable} that unregister the callback when called.
@@ -3076,7 +3086,10 @@ declare module '@podman-desktop/api' {
      * @example
      * Here is a usage example
      * ```ts
-     * const disposable = await statsContainer('engineId', 'containerId', (stats: ContainerStatsInfo): void => {
+     * const disposable = await statsContainer({
+     *  engineId: 'engineId',
+     *  id: 'containerId',
+     * }, (stats: ContainerStatsInfo): void => {
      *  console.log('CPU Usage', stats.cpu_stats.cpu_usage.total_usage);
      * });
      *
@@ -3085,8 +3098,7 @@ declare module '@podman-desktop/api' {
      * ```
      */
     export function statsContainer(
-      engineId: string,
-      id: string,
+      options: StatsContainerOptions,
       callback: (stats: ContainerStatsInfo) => void,
     ): Promise<Disposable>;
 

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -2685,13 +2685,6 @@ declare module '@podman-desktop/api' {
     write_size_bytes?: number;
   }
 
-  export interface StorageStats {
-    read_count_normalized?: number;
-    read_size_bytes?: number;
-    write_count_normalized?: number;
-    write_size_bytes?: number;
-  }
-
   export interface NetworkStats {
     [name: string]: {
       rx_bytes: number;

--- a/packages/main/src/plugin/extension-loader.spec.ts
+++ b/packages/main/src/plugin/extension-loader.spec.ts
@@ -1662,7 +1662,13 @@ describe('containerEngine', async () => {
     const api = extensionLoader.createApi('/path', {});
     expect(api).toBeDefined();
 
-    const disposable = await api.containerEngine.statsContainer('dummyEngineId', 'dummyContainerId', () => {});
+    const disposable = await api.containerEngine.statsContainer(
+      {
+        engineId: 'dummyEngineId',
+        id: 'dummyContainerId',
+      },
+      () => {},
+    );
     expect(disposable).toBeDefined();
     expect(disposable instanceof Disposable).toBeTruthy();
     expect(containerProviderRegistry.getContainerStats).toHaveBeenCalledWith(

--- a/packages/main/src/plugin/extension-loader.spec.ts
+++ b/packages/main/src/plugin/extension-loader.spec.ts
@@ -1662,13 +1662,7 @@ describe('containerEngine', async () => {
     const api = extensionLoader.createApi('/path', {});
     expect(api).toBeDefined();
 
-    const disposable = await api.containerEngine.statsContainer(
-      {
-        engineId: 'dummyEngineId',
-        id: 'dummyContainerId',
-      },
-      () => {},
-    );
+    const disposable = await api.containerEngine.statsContainer('dummyEngineId', 'dummyContainerId', () => {});
     expect(disposable).toBeDefined();
     expect(disposable instanceof Disposable).toBeTruthy();
     expect(containerProviderRegistry.getContainerStats).toHaveBeenCalledWith(

--- a/packages/main/src/plugin/extension-loader.spec.ts
+++ b/packages/main/src/plugin/extension-loader.spec.ts
@@ -143,6 +143,8 @@ const containerProviderRegistry: ContainerProviderRegistry = {
   listPods: vi.fn(),
   stopPod: vi.fn(),
   removePod: vi.fn(),
+  getContainerStats: vi.fn(),
+  stopContainerStats: vi.fn(),
   listImages: vi.fn(),
 } as unknown as ContainerProviderRegistry;
 
@@ -1653,6 +1655,29 @@ describe('window', async () => {
 });
 
 describe('containerEngine', async () => {
+  test('statsContainer ', async () => {
+    vi.mocked(containerProviderRegistry.getContainerStats).mockResolvedValue(99);
+    vi.mocked(containerProviderRegistry.stopContainerStats).mockResolvedValue(undefined);
+
+    const api = extensionLoader.createApi('/path', {});
+    expect(api).toBeDefined();
+
+    const disposable = await api.containerEngine.statsContainer('dummyEngineId', 'dummyContainerId', () => {});
+    expect(disposable).toBeDefined();
+    expect(disposable instanceof Disposable).toBeTruthy();
+    expect(containerProviderRegistry.getContainerStats).toHaveBeenCalledWith(
+      'dummyEngineId',
+      'dummyContainerId',
+      expect.anything(),
+    );
+
+    disposable.dispose();
+    await vi.waitUntil(() => {
+      expect(containerProviderRegistry.stopContainerStats).toHaveBeenCalledWith(99);
+      return true;
+    });
+  });
+
   test('listImages without option ', async () => {
     vi.mocked(containerProviderRegistry.listImages).mockResolvedValue([]);
 

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -1041,11 +1041,10 @@ export class ExtensionLoader {
         return containerProviderRegistry.startPod(engineId, podId);
       },
       async statsContainer(
-        engineId: string,
-        containerId: string,
+        options: { engineId: string; id: string },
         callback: (stats: containerDesktopAPI.ContainerStatsInfo) => void,
       ): Promise<Disposable> {
-        const identifier = await containerProviderRegistry.getContainerStats(engineId, containerId, callback);
+        const identifier = await containerProviderRegistry.getContainerStats(options.engineId, options.id, callback);
         return Disposable.create(() => {
           containerProviderRegistry.stopContainerStats(identifier).catch((err: unknown): void => {
             console.error('Something went wrong while trying to stop container stats', err);

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -1041,10 +1041,11 @@ export class ExtensionLoader {
         return containerProviderRegistry.startPod(engineId, podId);
       },
       async statsContainer(
-        options: { engineId: string; id: string },
+        engineId: string,
+        containerId: string,
         callback: (stats: containerDesktopAPI.ContainerStatsInfo) => void,
       ): Promise<Disposable> {
-        const identifier = await containerProviderRegistry.getContainerStats(options.engineId, options.id, callback);
+        const identifier = await containerProviderRegistry.getContainerStats(engineId, containerId, callback);
         return Disposable.create(() => {
           containerProviderRegistry.stopContainerStats(identifier).catch((err: unknown): void => {
             console.error('Something went wrong while trying to stop container stats', err);

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -1040,6 +1040,18 @@ export class ExtensionLoader {
       startPod(engineId: string, podId: string): Promise<void> {
         return containerProviderRegistry.startPod(engineId, podId);
       },
+      async statsContainer(
+        engineId: string,
+        containerId: string,
+        callback: (stats: containerDesktopAPI.ContainerStatsInfo) => void,
+      ): Promise<Disposable> {
+        const identifier = await containerProviderRegistry.getContainerStats(engineId, containerId, callback);
+        return Disposable.create(() => {
+          containerProviderRegistry.stopContainerStats(identifier).catch((err: unknown): void => {
+            console.error('Something went wrong while trying to stop container stats', err);
+          });
+        });
+      },
     };
 
     const authenticationProviderRegistry = this.authenticationProviderRegistry;


### PR DESCRIPTION
### What does this PR do?

Adding support for `statsContainer` in the extension-api. Allowing extensions to get streams stats for a running container.

See for documentation preview [netlify.app](https://65e0a3985eac521501f9b295--podman-desktop-pr.netlify.app/api/namespaces/containerEngine/functions/statsContainer)

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop/issues/6211

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
