### PR TITLE
chore: fix Kubernetes status badge layout

### DIFF
--- a/packages/renderer/src/lib/deployments/DeploymentsList.svelte
+++ b/packages/renderer/src/lib/deployments/DeploymentsList.svelte
@@ -129,7 +129,7 @@ const row = new Row<DeploymentUI>({ selectable: _deployment => true });
         icon="{faTrash}" />
       <span>On {selectedItemsNumber} selected items.</span>
     {/if}
-    <div class="flex min-w-full justify-end">
+    <div class="flex grow justify-end">
       <KubernetesCurrentContextConnectionBadge />
     </div>
   </svelte:fragment>

--- a/packages/renderer/src/lib/ingresses-routes/IngressesRoutesList.svelte
+++ b/packages/renderer/src/lib/ingresses-routes/IngressesRoutesList.svelte
@@ -156,7 +156,7 @@ const row = new Row<IngressUI | RouteUI>({ selectable: _ingressRoute => true });
         icon="{faTrash}" />
       <span>On {selectedItemsNumber} selected items.</span>
     {/if}
-    <div class="flex min-w-full justify-end">
+    <div class="flex grow justify-end">
       <KubernetesCurrentContextConnectionBadge />
     </div>
   </svelte:fragment>

--- a/packages/renderer/src/lib/pod/PodsList.svelte
+++ b/packages/renderer/src/lib/pod/PodsList.svelte
@@ -230,7 +230,7 @@ const row = new Row<PodInfoUI>({ selectable: _pod => true });
         icon="{faTrash}" />
       <span>On {selectedItemsNumber} selected items.</span>
     {/if}
-    <div class="flex min-w-full justify-end">
+    <div class="flex grow justify-end">
       <KubernetesCurrentContextConnectionBadge />
     </div>
   </svelte:fragment>

--- a/packages/renderer/src/lib/service/ServicesList.svelte
+++ b/packages/renderer/src/lib/service/ServicesList.svelte
@@ -132,7 +132,7 @@ const row = new Row<ServiceUI>({ selectable: _service => true });
         icon="{faTrash}" />
       <span>On {selectedItemsNumber} selected items.</span>
     {/if}
-    <div class="flex min-w-full justify-end">
+    <div class="flex grow justify-end">
       <KubernetesCurrentContextConnectionBadge />
     </div>
   </svelte:fragment>


### PR DESCRIPTION
### What does this PR do?

min-w-full causes the Kubernetes status badge to require too much room, reduce to grow so that the badge doesn't cause layout issues.

### Screenshot / video of UI

Reverts issue shown in #6208.

### What issues does this PR fix or reference?

Fixes #6208.

### How to test this PR?

Check any of the Kubernetes object pages or Pods, the Kubernetes connection badge no longer causes layout problems when you select objects.