### PR TITLE
fix: fix margin between icon and registry url

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesRegistriesEditing.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRegistriesEditing.svelte
@@ -265,7 +265,7 @@ function removeExistingRegistry(registry: containerDesktopAPI.Registry) {
                       {registry.name}
                     </span>
                   {:else}
-                    <span class="ml-0">
+                    <span class="ml-2">
                       {registry.serverUrl.replace('https://', '')}
                     </span>
                   {/if}


### PR DESCRIPTION
### What does this PR do?

This PR fixes space between registry icon and url in case registry added with image and url, but without name

### Screenshot / video of UI

Before the fix

![image](https://github.com/containers/podman-desktop/assets/620330/29fd85b2-0347-475e-ac2b-78669d9e03fc)

After the fix

![image](https://github.com/containers/podman-desktop/assets/620330/ff297fe9-e23e-49c7-b337-557e4fdb2a96)

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
