### PR TITLE
[poc] Add layout components

### DIFF
--- a/packages/main/src/plugin/color-registry.ts
+++ b/packages/main/src/plugin/color-registry.ts
@@ -341,9 +341,24 @@ export class ColorRegistry {
       light: colorPalette.gray[300],
     });
 
+    this.registerColor(`${invCt}card-bg-highlighted`, {
+      dark: colorPalette.charcoal[700],
+      light: colorPalette.gray[200],
+    });
+
+    this.registerColor(`${invCt}card-divide`, {
+      dark: colorPalette.gray[900],
+      light: colorPalette.charcoal[50],
+    });
+
     this.registerColor(`${invCt}card-header-text`, {
       dark: colorPalette.white,
       light: colorPalette.charcoal[900],
+    });
+
+    this.registerColor(`${invCt}card-subtitle-text`, {
+      dark: colorPalette.gray[600],
+      light: colorPalette.charcoal[100],
     });
 
     this.registerColor(`${invCt}card-text`, {

--- a/packages/renderer/src/lib/dashboard/DashboardPage.svelte
+++ b/packages/renderer/src/lib/dashboard/DashboardPage.svelte
@@ -97,10 +97,14 @@ function getInitializationContext(id: string): InitializationContext {
             <ProviderStopped provider="{providerStopped}" />
           {/each}
         {/if}
-        <LearningCenter />
       </div>
-      <div class="px-2 space-y-5 h-full">
-        <Card title="Featured Extensions">
+      <div class="px-2 mt-5 h-full">
+        <Card title="Learning center">
+          <svelte:fragment slot="content">
+            <LearningCenter />
+          </svelte:fragment>
+        </Card>
+        <Card title="Featured extensions">
           <svelte:fragment slot="content">
             <FeaturedExtensions />
           </svelte:fragment>

--- a/packages/renderer/src/lib/dashboard/DashboardPage.svelte
+++ b/packages/renderer/src/lib/dashboard/DashboardPage.svelte
@@ -13,6 +13,7 @@ import FeaturedExtensions from '/@/lib/featured/FeaturedExtensions.svelte';
 import ProviderConfiguring from '/@/lib/dashboard/ProviderConfiguring.svelte';
 import NotificationsBox from './NotificationsBox.svelte';
 import LearningCenter from '../learning-center/LearningCenter.svelte';
+import Card from '../ui/Card.svelte';
 
 const providerInitContexts = new Map<string, InitializationContext>();
 
@@ -97,7 +98,13 @@ function getInitializationContext(id: string): InitializationContext {
           {/each}
         {/if}
         <LearningCenter />
-        <FeaturedExtensions />
+      </div>
+      <div class="px-2 space-y-5 h-full">
+        <Card title="Featured Extensions">
+          <svelte:fragment slot="content">
+            <FeaturedExtensions />
+          </svelte:fragment>
+        </Card>
       </div>
     </div>
   </div>

--- a/packages/renderer/src/lib/featured/FeaturedExtensions.svelte
+++ b/packages/renderer/src/lib/featured/FeaturedExtensions.svelte
@@ -5,8 +5,6 @@ import Fa from 'svelte-fa';
 import FeaturedExtensionDownload from './FeaturedExtensionDownload.svelte';
 </script>
 
-<!--Title-->
-<p class="text-lg first-letter:uppercase font-bold">featured extensions:</p>
 <div class="grid min-[920px]:grid-cols-2 min-[1180px]:grid-cols-3 gap-3" role="region" aria-label="FeaturedExtensions">
   {#each $featuredExtensionInfos as featuredExtension}
     <div

--- a/packages/renderer/src/lib/learning-center/LearningCenter.svelte
+++ b/packages/renderer/src/lib/learning-center/LearningCenter.svelte
@@ -11,11 +11,8 @@ onMount(async () => {
 });
 </script>
 
-<div class="flex flex-1 flex-col">
-  <p class="text-lg first-letter:uppercase font-bold pb-5">Learning center:</p>
-  <div class="flex flex-1 flex-col bg-charcoal-800 p-5 rounded-lg">
-    <Carousel cards="{guides}" let:card>
-      <GuideCard guide="{card}" />
-    </Carousel>
-  </div>
+<div class="flex flex-1 flex-col bg-charcoal-800 p-5 rounded-lg">
+  <Carousel cards="{guides}" let:card>
+    <GuideCard guide="{card}" />
+  </Carousel>
 </div>

--- a/packages/renderer/src/lib/preferences/PreferencesCliTool.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesCliTool.spec.ts
@@ -82,7 +82,7 @@ suite('CLI Tool item', () => {
     render(PreferencesCliTool, {
       cliTool: cliToolInfoItem1,
     });
-    const nameElement = screen.getByLabelText('cli-name');
+    const nameElement = screen.getByLabelText('title');
     expect(nameElement).toBeDefined();
     expect(nameElement.textContent).equal(cliToolInfoItem1.name);
     const registeredByElement = screen.getByLabelText('cli-registered-by');
@@ -101,7 +101,7 @@ suite('CLI Tool item', () => {
     render(PreferencesCliTool, {
       cliTool: cliToolInfoItem2,
     });
-    const nameElement = screen.getByLabelText('cli-name');
+    const nameElement = screen.getByLabelText('title');
     expect(nameElement).toBeDefined();
     expect(nameElement.textContent).equal(cliToolInfoItem2.name);
     const registeredByElement = screen.getByLabelText('cli-registered-by');
@@ -122,7 +122,7 @@ suite('CLI Tool item', () => {
     render(PreferencesCliTool, {
       cliTool: cliToolInfoItem3,
     });
-    const nameElement = screen.getByLabelText('cli-name');
+    const nameElement = screen.getByLabelText('title');
     expect(nameElement).toBeDefined();
     expect(nameElement.textContent).equal(cliToolInfoItem3.name);
     const registeredByElement = screen.getByLabelText('cli-registered-by');

--- a/packages/renderer/src/lib/preferences/PreferencesCliTool.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesCliTool.svelte
@@ -8,6 +8,7 @@ import LoadingIconButton from '../ui/LoadingIconButton.svelte';
 
 import Markdown from '../markdown/Markdown.svelte';
 import type { ILoadingStatus } from './Util';
+import HorizontalCard from '../ui/HorizontalCard.svelte';
 
 export let cliTool: CliToolInfo;
 let showError = false;
@@ -47,51 +48,37 @@ function getLoggerHandler(_cliToolId: string): ConnectionCallback {
     onEnd: () => {},
   };
 }
+
+/*
+Changes:
+ aria-label="cli-logo" -> aria-label="logo"
+*/
 </script>
 
-<div role="row" class="bg-charcoal-600 mb-5 rounded-md p-3 flex flex-col">
-  <div class="divide-x divide-gray-900 flex flex-row">
-    <div>
-      <!-- left col - cli-tool icon/name + "create new" button -->
-      <div class="min-w-[170px] max-w-[200px] h-full flex flex-col justify-between">
-        <div class="flex flex-row">
-          {#if cliTool?.images?.icon || cliTool?.extensionInfo.icon}
-            {#if typeof cliTool.images?.icon === 'string'}
-              <img
-                src="{cliTool.images.icon}"
-                aria-label="cli-logo"
-                alt="{cliTool.name} logo"
-                class="max-w-[40px] max-h-[40px] h-full" />
-            {:else if typeof cliTool.extensionInfo.icon === 'string'}
-              <img
-                src="{cliTool.extensionInfo.icon}"
-                aria-label="cli-logo"
-                alt="{cliTool.name} logo"
-                class="max-w-[40px] max-h-[40px] h-full" />
-            {/if}
-          {/if}
-          <span id="{cliTool.id}" class="my-auto ml-3 break-words" aria-label="cli-name">{cliTool.name}</span>
-        </div>
-        {#if cliTool.version && cliToolStatus}
-          <div class="p-0.5 rounded-lg bg-charcoal-900 w-fit">
-            <LoadingIconButton
-              action="update"
-              clickAction="{() => {
-                if (cliTool.newVersion) {
-                  update(cliTool);
-                }
-              }}"
-              icon="{faCircleArrowUp}"
-              leftPosition="left-[0.4rem]"
-              state="{cliToolStatus}"
-              color="primary"
-              tooltip="{!cliTool.newVersion ? 'No updates' : `Update to v${cliTool.newVersion}`}" />
-          </div>
-        {/if}
+<HorizontalCard
+  label="{cliTool?.id}"
+  title="{cliTool.name}"
+  icon="{cliTool?.images?.icon || cliTool?.extensionInfo.icon}">
+  <svelte:fragment slot="actions">
+    {#if cliTool.version && cliToolStatus}
+      <div class="p-0.5 rounded-lg bg-charcoal-900 w-fit">
+        <LoadingIconButton
+          action="update"
+          clickAction="{() => {
+            if (cliTool.newVersion) {
+              update(cliTool);
+            }
+          }}"
+          icon="{faCircleArrowUp}"
+          leftPosition="left-[0.4rem]"
+          state="{cliToolStatus}"
+          color="primary"
+          tooltip="{!cliTool.newVersion ? 'No updates' : `Update to v${cliTool.newVersion}`}" />
       </div>
-    </div>
-    <!-- cli-tools columns -->
-    <div class="grow flex-column divide-gray-900 ml-2">
+    {/if}
+  </svelte:fragment>
+  <svelte:fragment slot="content">
+    <div class="grow flex-column">
       <span class="my-auto ml-3 break-words" aria-label="cli-display-name">{cliTool.displayName}</span>
       <div role="region" class="float-right text-gray-900 px-2 text-sm" aria-label="cli-registered-by">
         Registered by {cliTool.extensionInfo.label}
@@ -125,17 +112,19 @@ function getLoggerHandler(_cliToolId: string): ConnectionCallback {
         {/if}
       </div>
     </div>
-  </div>
-  {#if showError}
-    <div class="flex flex-row items-center text-xs text-red-400 ml-[200px] mt-2">
-      <Fa icon="{faCircleXmark}" class="mr-1 text-red-500" />
-      <span>Unable to update {cliTool.displayName} to version {cliTool.newVersion}. </span>
-      <Button
-        type="link"
-        padding="p-0"
-        class="ml-1 text-xs"
-        aria-label="{cliTool.displayName} failed"
-        on:click="{() => window.events?.send('toggle-task-manager', '')}">Check why it failed</Button>
-    </div>
-  {/if}
-</div>
+  </svelte:fragment>
+  <svelte:fragment slot="footer">
+    {#if showError}
+      <div class="flex flex-row items-center text-xs text-red-400 ml-[200px] mt-2">
+        <Fa icon="{faCircleXmark}" class="mr-1 text-red-500" />
+        <span>Unable to update {cliTool.displayName} to version {cliTool.newVersion}. </span>
+        <Button
+          type="link"
+          padding="p-0"
+          class="ml-1 text-xs"
+          aria-label="{cliTool.displayName} failed"
+          on:click="{() => window.events?.send('toggle-task-manager', '')}">Check why it failed</Button>
+      </div>
+    {/if}
+  </svelte:fragment>
+</HorizontalCard>

--- a/packages/renderer/src/lib/preferences/PreferencesCliToolsRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesCliToolsRendering.spec.ts
@@ -20,7 +20,7 @@
 
 import '@testing-library/jest-dom/vitest';
 import { within } from '@testing-library/dom';
-import { afterEach, beforeAll, expect, suite, test, vi } from 'vitest';
+import { afterEach, beforeEach, expect, suite, test, vi } from 'vitest';
 import { render, screen } from '@testing-library/svelte';
 import { cliToolInfos } from '/@/stores/cli-tools';
 import type { CliToolInfo } from '../../../../main/src/plugin/api/cli-tool-info';
@@ -102,7 +102,7 @@ suite('CLI Tool Prefernces page shows', () => {
     });
   }
 
-  beforeAll(() => {
+  beforeEach(async () => {
     cliToolInfos.set(cliTools);
     render(PreferencesCliToolsRendering, {});
     const cliToolsTable = screen.getByRole('table', { name: 'cli-tools' });
@@ -114,7 +114,7 @@ suite('CLI Tool Prefernces page shows', () => {
   });
 
   test('tool`s name', () => {
-    validatePropertyPresentation('cli-name', toolInfo => toolInfo.name);
+    validatePropertyPresentation('title', toolInfo => toolInfo.name);
   });
 
   test('extension`s name that registered the tool', () => {
@@ -130,12 +130,12 @@ suite('CLI Tool Prefernces page shows', () => {
   });
 
   test('tool`s logo is not shown if images.icon property is not present or images property is empty', () => {
-    expect(within(cliToolRows[0]).queryAllByLabelText('cli-logo').length).equals(0);
-    expect(within(cliToolRows[1]).queryAllByLabelText('cli-logo').length).equals(0);
+    expect(within(cliToolRows[0]).queryAllByLabelText('logo').length).equals(0);
+    expect(within(cliToolRows[1]).queryAllByLabelText('logo').length).equals(0);
   });
 
   test('tool`s logo is shown when images.icon property is present', () => {
-    expect(within(cliToolRows[2]).getAllByLabelText('cli-logo').length).equals(1);
+    expect(within(cliToolRows[2]).getAllByLabelText('logo').length).equals(1);
   });
 
   test('test tools version is shown', () => {

--- a/packages/renderer/src/lib/preferences/PreferencesExtensionList.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesExtensionList.svelte
@@ -84,47 +84,48 @@ async function updateExtension(extension: ExtensionInfo, ociUri: string) {
       </svelte:fragment>
     </Card>
 
-    <div class="bg-charcoal-700 mt-5 rounded-md p-3" role="region" aria-label="OCI image installation box">
-      <h1 class="text-lg mb-2">Install a new extension from OCI Image</h1>
-
-      <div class="flex flex-col w-full">
-        <div
-          class="flex flex-row mb-2 w-full space-x-4 items-center"
-          role="region"
-          aria-label="Install Extension From OCI">
-          <Input
-            name="ociImage"
-            id="ociImage"
-            aria-label="OCI Image Name"
-            bind:value="{ociImage}"
-            placeholder="Name of the Image"
-            class="w-1/2"
-            required />
-
-          <Button
-            on:click="{() => installExtensionFromImage()}"
-            disabled="{ociImage === undefined || ociImage.trim() === ''}"
-            class="w-full"
-            inProgress="{installInProgress}"
-            icon="{faArrowCircleDown}">
-            Install extension from the OCI image
-          </Button>
-        </div>
-
-        <div class="container w-full flex-col">
+    <Card title="Install a new extension from OCI Image" label="OCI image installation box">
+      <svelte:fragment slot="content">
+        <div class="flex flex-col w-full">
           <div
-            class:opacity-0="{logs.length === 0}"
-            bind:this="{logElement}"
-            class="bg-zinc-700 text-gray-300 mt-4 mb-3 p-1 h-16 overflow-y-auto">
-            {#each logs as log}
-              <p class="font-light text-sm">{log}</p>
-            {/each}
+            class="flex flex-row mb-2 w-full space-x-4 items-center"
+            role="region"
+            aria-label="Install Extension From OCI">
+            <Input
+              name="ociImage"
+              id="ociImage"
+              aria-label="OCI Image Name"
+              bind:value="{ociImage}"
+              placeholder="Name of the Image"
+              class="w-1/2"
+              required />
+
+            <Button
+              on:click="{() => installExtensionFromImage()}"
+              disabled="{ociImage === undefined || ociImage.trim() === ''}"
+              class="w-full"
+              inProgress="{installInProgress}"
+              icon="{faArrowCircleDown}">
+              Install extension from the OCI image
+            </Button>
           </div>
 
-          <ErrorMessage error="{errorInstall}" />
+          <div class="container w-full flex-col">
+            <div
+              class:opacity-0="{logs.length === 0}"
+              bind:this="{logElement}"
+              class="bg-zinc-700 text-gray-300 mt-4 mb-3 p-1 h-16 overflow-y-auto">
+              {#each logs as log}
+                <p class="font-light text-sm">{log}</p>
+              {/each}
+            </div>
+
+            <ErrorMessage error="{errorInstall}" />
+          </div>
         </div>
-      </div>
-    </div>
+      </svelte:fragment>
+    </Card>
+
     <div class="bg-charcoal-600 mt-5 rounded-md p-3">
       <table class="min-w-full" aria-label="Installed Extensions">
         <tbody>

--- a/packages/renderer/src/lib/preferences/PreferencesExtensionList.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesExtensionList.svelte
@@ -11,6 +11,7 @@ import FeaturedExtensions from '../featured/FeaturedExtensions.svelte';
 import Button from '../ui/Button.svelte';
 import ExtensionIcon from './ExtensionIcon.svelte';
 import { Input } from '@podman-desktop/ui-svelte';
+import Card from '../ui/Card.svelte';
 
 export let ociImage: string | undefined = undefined;
 
@@ -77,9 +78,11 @@ async function updateExtension(extension: ExtensionInfo, ociUri: string) {
 
 <SettingsPage title="Extensions">
   <div class="bg-charcoal-600 rounded-md p-3">
-    <div class="bg-charcoal-700 mb-4 rounded-md p-3">
-      <FeaturedExtensions />
-    </div>
+    <Card title="Featured Extensions">
+      <svelte:fragment slot="content">
+        <FeaturedExtensions />
+      </svelte:fragment>
+    </Card>
 
     <div class="bg-charcoal-700 mt-5 rounded-md p-3" role="region" aria-label="OCI image installation box">
       <h1 class="text-lg mb-2">Install a new extension from OCI Image</h1>

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.spec.ts
@@ -101,7 +101,7 @@ test('Test that context-name2 is the current context', async () => {
   // Get current-context by aria label
   // find "context-name" which is located within the same parent div as current-context
   // make sure the content is context-name2
-  const currentContext = await screen.findByLabelText('current-context');
+  const currentContext = await screen.findByLabelText('subtitle');
   expect(currentContext).toBeInTheDocument();
 
   // Make sure that the span with the text "context-name2" is within the same parent div as current-context (to make sure that it is the current context)
@@ -120,7 +120,7 @@ test('when deleting the current context, a popup should ask confirmation', async
   const currentContext = screen.getAllByRole('row')[1];
   expect(currentContext).toBeInTheDocument();
 
-  const label = within(currentContext).queryByLabelText('current-context');
+  const label = within(currentContext).queryByLabelText('subtitle');
   expect(label).toBeInTheDocument();
 
   const deleteBtn = within(currentContext).getByRole('button', { name: 'Delete Context' });

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
@@ -8,6 +8,7 @@ import ErrorMessage from '../ui/ErrorMessage.svelte';
 import { kubernetesContexts } from '../../stores/kubernetes-contexts';
 import { clearKubeUIContextErrors, setKubeUIContextError } from '../kube/KubeContextUI';
 import { kubernetesContextsState } from '/@/stores/kubernetes-contexts-state';
+import Card from '../ui/Card.svelte';
 
 $: currentContextName = $kubernetesContexts.find(c => c.currentContext)?.name;
 
@@ -56,46 +57,30 @@ async function handleDeleteContext(contextName: string) {
       hidden="{$kubernetesContexts.length > 0}" />
     {#each $kubernetesContexts as context}
       <!-- If current context, use lighter background -->
-      <div
-        role="row"
-        class="{context.currentContext ? 'bg-charcoal-600' : 'bg-charcoal-700'} mb-5 rounded-md p-3 flex-nowrap">
-        <div class="pb-2">
-          <div class="flex">
-            {#if context?.icon}
-              {#if typeof context.icon === 'string'}
-                <img
-                  src="{context.icon}"
-                  aria-label="context-logo"
-                  alt="{context.name} logo"
-                  class="max-w-[40px] h-full" />
-              {/if}
-            {/if}
-            <!-- Centered items div -->
-            <div class="pl-3 flex-grow flex flex-col justify-center">
-              <div class="flex flex-col items-left">
-                {#if context.currentContext}
-                  <span class="text-xs text-gray-600" aria-label="current-context">Current Context</span>
-                {/if}
-                <span class="text-md" aria-label="context-name">{context.name}</span>
-              </div>
-            </div>
-            <!-- Only show the set context button if it is not the current context -->
-            {#if !context.currentContext}
-              <ListItemButtonIcon
-                title="Set as Current Context"
-                icon="{faRightToBracket}"
-                onClick="{() => handleSetContext(context.name)}"></ListItemButtonIcon>
-            {/if}
+      <Card
+        highlighted="{context.currentContext}"
+        title="{context.name}"
+        subtitle="{context.currentContext ? 'Current Context' : undefined}"
+        icon="{context?.icon}">
+        <svelte:fragment slot="actions">
+          <!-- Only show the set context button if it is not the current context -->
+          {#if !context.currentContext}
             <ListItemButtonIcon
-              title="Delete Context"
-              icon="{faTrash}"
-              onClick="{() => handleDeleteContext(context.name)}"></ListItemButtonIcon>
-          </div>
+              title="Set as Current Context"
+              icon="{faRightToBracket}"
+              onClick="{() => handleSetContext(context.name)}"></ListItemButtonIcon>
+          {/if}
+          <ListItemButtonIcon
+            title="Delete Context"
+            icon="{faTrash}"
+            onClick="{() => handleDeleteContext(context.name)}"></ListItemButtonIcon>
+        </svelte:fragment>
+        <svelte:fragment slot="subheader">
           {#if context.error}
             <ErrorMessage class="text-sm" error="{context.error}" />
           {/if}
-        </div>
-        <div class="grow flex-column divide-gray-900 text-gray-400">
+        </svelte:fragment>
+        <svelte:fragment slot="content">
           <div class="flex flex-row">
             {#if $kubernetesContextsState.get(context.name)}
               <div class="flex-none w-36">
@@ -160,8 +145,8 @@ async function handleDeleteContext(contextName: string) {
               {/if}
             </div>
           </div>
-        </div>
-      </div>
+        </svelte:fragment>
+      </Card>
     {/each}
   </div>
 </SettingsPage>

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
@@ -357,6 +357,7 @@ function hasAnyConfiguration(provider: ProviderInfo) {
 
 /*
 Changes:
+ role="region"                     -> region="row"
  aria-label="Provider Setup"       -> aria-label="Title"
  aria-label="Provider Connections" -> aria-label="Content"
 */

--- a/packages/renderer/src/lib/ui/Card.svelte
+++ b/packages/renderer/src/lib/ui/Card.svelte
@@ -1,11 +1,15 @@
 <script lang="ts">
 export let highlighted: boolean = false;
+export let label: string = '';
 export let icon: string | { light: string; dark: string } | undefined = undefined;
 export let title: string;
 export let subtitle: string | undefined = undefined;
 </script>
 
-<div role="row" class="{highlighted ? 'bg-charcoal-600' : 'bg-charcoal-700'} mb-5 rounded-md p-3 flex-nowrap">
+<div
+  role="row"
+  class="{highlighted ? 'bg-charcoal-600' : 'bg-charcoal-700'} mb-5 rounded-md p-3 flex-nowrap"
+  aria-label="{label}">
   <div class="pb-2">
     <div class="flex space-x-2">
       {#if icon}

--- a/packages/renderer/src/lib/ui/Card.svelte
+++ b/packages/renderer/src/lib/ui/Card.svelte
@@ -7,7 +7,7 @@ export let subtitle: string | undefined = undefined;
 
 <div role="row" class="{highlighted ? 'bg-charcoal-600' : 'bg-charcoal-700'} mb-5 rounded-md p-3 flex-nowrap">
   <div class="pb-2">
-    <div class="flex">
+    <div class="flex space-x-2">
       {#if icon}
         {#if typeof icon === 'string'}
           <img src="{icon}" alt="{title}" aria-label="logo" class="max-w-[40px] max-h-[40px] h-full" />
@@ -18,7 +18,7 @@ export let subtitle: string | undefined = undefined;
       {/if}
 
       <!-- Centered items div -->
-      <div class="pl-3 flex-grow flex flex-col justify-center">
+      <div class="flex-grow flex flex-col justify-center">
         <div class="flex flex-col items-left">
           <span class="text-md" aria-label="context-name">{title}</span>
           {#if subtitle}

--- a/packages/renderer/src/lib/ui/Card.svelte
+++ b/packages/renderer/src/lib/ui/Card.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+import CardTitle from './CardTitle.svelte';
+
 export let highlighted: boolean = false;
 export let label: string = '';
 export let icon: string | { light: string; dark: string } | undefined = undefined;
@@ -12,24 +14,7 @@ export let subtitle: string | undefined = undefined;
   aria-label="{label}">
   <div class="pb-2">
     <div class="flex space-x-2">
-      {#if icon}
-        {#if typeof icon === 'string'}
-          <img src="{icon}" alt="{title}" aria-label="logo" class="max-w-[40px] max-h-[40px] h-full" />
-          <!-- TODO check theme used for image, now use dark by default -->
-        {:else}
-          <img src="{icon.dark}" alt="{title}" aria-label="logo" class="max-w-[40px]" />
-        {/if}
-      {/if}
-
-      <!-- Centered items div -->
-      <div class="flex-grow flex flex-col justify-center">
-        <div class="flex flex-col items-left">
-          <span class="text-md" aria-label="context-name">{title}</span>
-          {#if subtitle}
-            <span class="text-xs text-gray-600" aria-label="subtitle">{subtitle}</span>
-          {/if}
-        </div>
-      </div>
+      <CardTitle title="{title}" subtitle="{subtitle}" icon="{icon}" />
       <slot name="actions" />
     </div>
     <slot name="subheader" />

--- a/packages/renderer/src/lib/ui/Card.svelte
+++ b/packages/renderer/src/lib/ui/Card.svelte
@@ -10,7 +10,9 @@ export let subtitle: string | undefined = undefined;
 
 <div
   role="row"
-  class="{highlighted ? 'bg-charcoal-600' : 'bg-charcoal-700'} mb-5 rounded-md p-3 flex-nowrap"
+  class="{highlighted
+    ? 'bg-[var(--pd-invert-content-card-bg)]'
+    : 'bg-[var(--pd-invert-content-card-bg-highlighted)]'} mb-5 rounded-md p-3 flex-nowrap"
   aria-label="{label}">
   <div class="pb-2">
     <div class="flex space-x-2">
@@ -19,7 +21,7 @@ export let subtitle: string | undefined = undefined;
     </div>
     <slot name="subheader" />
   </div>
-  <div class="grow flex-column divide-gray-900 text-gray-400">
+  <div class="grow flex-column divide-[var(--pd-invert-content-card-divide)] text-[var(--pd-invert-content-card-text)]">
     <slot name="content" />
   </div>
 </div>

--- a/packages/renderer/src/lib/ui/Card.svelte
+++ b/packages/renderer/src/lib/ui/Card.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+export let highlighted: boolean = false;
+export let icon: string | { light: string; dark: string } | undefined = undefined;
+export let title: string;
+export let subtitle: string | undefined = undefined;
+</script>
+
+<div role="row" class="{highlighted ? 'bg-charcoal-600' : 'bg-charcoal-700'} mb-5 rounded-md p-3 flex-nowrap">
+  <div class="pb-2">
+    <div class="flex">
+      {#if icon}
+        {#if typeof icon === 'string'}
+          <img src="{icon}" alt="{title}" aria-label="logo" class="max-w-[40px] max-h-[40px] h-full" />
+          <!-- TODO check theme used for image, now use dark by default -->
+        {:else}
+          <img src="{icon.dark}" alt="{title}" aria-label="logo" class="max-w-[40px]" />
+        {/if}
+      {/if}
+
+      <!-- Centered items div -->
+      <div class="pl-3 flex-grow flex flex-col justify-center">
+        <div class="flex flex-col items-left">
+          <span class="text-md" aria-label="context-name">{title}</span>
+          {#if subtitle}
+            <span class="text-xs text-gray-600" aria-label="subtitle">{subtitle}</span>
+          {/if}
+        </div>
+      </div>
+      <slot name="actions" />
+    </div>
+    <slot name="subheader" />
+  </div>
+  <div class="grow flex-column divide-gray-900 text-gray-400">
+    <slot name="content" />
+  </div>
+</div>

--- a/packages/renderer/src/lib/ui/CardTitle.svelte
+++ b/packages/renderer/src/lib/ui/CardTitle.svelte
@@ -16,9 +16,9 @@ export let icon: string | { light: string; dark: string } | undefined = undefine
 <!-- Centered items div -->
 <div class="flex-grow flex flex-col justify-center">
   <div class="flex flex-col items-left">
-    <span class="text-md" aria-label="title">{title}</span>
+    <span class="text-md text-[var(--pd-invert-content-card-header-text)]" aria-label="title">{title}</span>
     {#if subtitle}
-      <span class="text-xs text-gray-600" aria-label="subtitle">{subtitle}</span>
+      <span class="text-xs text-[var(--pd-invert-content-card-subtitle-text)]" aria-label="subtitle">{subtitle}</span>
     {/if}
   </div>
 </div>

--- a/packages/renderer/src/lib/ui/CardTitle.svelte
+++ b/packages/renderer/src/lib/ui/CardTitle.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+export let title: string;
+export let subtitle: string | undefined = undefined;
+export let icon: string | { light: string; dark: string } | undefined = undefined;
+</script>
+
+{#if icon}
+  {#if typeof icon === 'string'}
+    <img src="{icon}" alt="{title}" aria-label="logo" class="max-w-[40px] max-h-[40px] h-full" />
+    <!-- TODO check theme used for image, now use dark by default -->
+  {:else}
+    <img src="{icon.dark}" alt="{title}" aria-label="logo" class="max-w-[40px]" />
+  {/if}
+{/if}
+
+<!-- Centered items div -->
+<div class="flex-grow flex flex-col justify-center">
+  <div class="flex flex-col items-left">
+    <span class="text-md" aria-label="title">{title}</span>
+    {#if subtitle}
+      <span class="text-xs text-gray-600" aria-label="subtitle">{subtitle}</span>
+    {/if}
+  </div>
+</div>

--- a/packages/renderer/src/lib/ui/HorizontalCard.svelte
+++ b/packages/renderer/src/lib/ui/HorizontalCard.svelte
@@ -4,28 +4,31 @@ export let title: string;
 export let icon: string | { light: string; dark: string } | undefined = undefined;
 </script>
 
-<div class="bg-charcoal-600 mb-5 rounded-md p-3 divide-x divide-gray-900 flex" role="region" aria-label="{label}">
-  <div role="region" aria-label="Title">
-    <!-- left col: icon/name + actions -->
-    <div class="min-w-[170px] max-w-[200px]">
-      <div class="flex">
-        {#if icon}
-          {#if typeof icon === 'string'}
-            <img src="{icon}" alt="{title}" class="max-w-[40px] h-full" />
-            <!-- TODO check theme used for image, now use dark by default -->
-          {:else}
-            <img src="{icon.dark}" alt="{title}" class="max-w-[40px]" />
+<div role="row" class="bg-charcoal-600 mb-5 rounded-md p-3 flex flex-col" aria-label="{label}">
+  <div class="divide-x divide-gray-900 flex flex-row">
+    <div role="region" aria-label="Title">
+      <!-- left col: icon/name + actions -->
+      <div class="min-w-[170px] max-w-[200px]">
+        <div class="flex">
+          {#if icon}
+            {#if typeof icon === 'string'}
+              <img src="{icon}" alt="{title}" class="max-w-[40px] max-h-[40px] h-full" />
+              <!-- TODO check theme used for image, now use dark by default -->
+            {:else}
+              <img src="{icon.dark}" alt="{title}" aria-label="logo" class="max-w-[40px]" />
+            {/if}
           {/if}
-        {/if}
-        <span class="my-auto text-gray-400 ml-3 break-words">{title}</span>
-      </div>
-      <div class="text-center mt-10">
-        <slot name="actions" />
+          <span class="my-auto text-gray-400 ml-3 break-words">{title}</span>
+        </div>
+        <div class="text-center mt-10">
+          <slot name="actions" />
+        </div>
       </div>
     </div>
+    <!-- content -->
+    <div class="divide-gray-900 ml-2" role="region" aria-label="Content">
+      <slot name="content" />
+    </div>
   </div>
-  <!-- content -->
-  <div class="divide-gray-900 ml-2" role="region" aria-label="Content">
-    <slot name="content" />
-  </div>
+  <slot name="footer" />
 </div>

--- a/packages/renderer/src/lib/ui/HorizontalCard.svelte
+++ b/packages/renderer/src/lib/ui/HorizontalCard.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
+import CardTitle from './CardTitle.svelte';
+
 export let label: string;
 export let title: string;
+export let subtitle: string | undefined = undefined;
 export let icon: string | { light: string; dark: string } | undefined = undefined;
 </script>
 
@@ -10,15 +13,7 @@ export let icon: string | { light: string; dark: string } | undefined = undefine
       <!-- left col: icon/name + actions -->
       <div class="min-w-[170px] max-w-[200px]">
         <div class="flex space-x-2">
-          {#if icon}
-            {#if typeof icon === 'string'}
-              <img src="{icon}" alt="{title}" aria-label="logo" class="max-w-[40px] max-h-[40px] h-full" />
-              <!-- TODO check theme used for image, now use dark by default -->
-            {:else}
-              <img src="{icon.dark}" alt="{title}" aria-label="logo" class="max-w-[40px]" />
-            {/if}
-          {/if}
-          <span class="my-auto text-gray-400 break-words" aria-label="title">{title}</span>
+          <CardTitle title="{title}" subtitle="{subtitle}" icon="{icon}" />
         </div>
         <div class="text-center mt-10">
           <slot name="actions" />

--- a/packages/renderer/src/lib/ui/HorizontalCard.svelte
+++ b/packages/renderer/src/lib/ui/HorizontalCard.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+export let label: string;
+export let title: string;
+export let icon: string | { light: string; dark: string } | undefined = undefined;
+</script>
+
+<div class="bg-charcoal-600 mb-5 rounded-md p-3 divide-x divide-gray-900 flex" role="region" aria-label="{label}">
+  <div role="region" aria-label="Title">
+    <!-- left col: icon/name + actions -->
+    <div class="min-w-[170px] max-w-[200px]">
+      <div class="flex">
+        {#if icon}
+          {#if typeof icon === 'string'}
+            <img src="{icon}" alt="{title}" class="max-w-[40px] h-full" />
+            <!-- TODO check theme used for image, now use dark by default -->
+          {:else}
+            <img src="{icon.dark}" alt="{title}" class="max-w-[40px]" />
+          {/if}
+        {/if}
+        <span class="my-auto text-gray-400 ml-3 break-words">{title}</span>
+      </div>
+      <div class="text-center mt-10">
+        <slot name="actions" />
+      </div>
+    </div>
+  </div>
+  <!-- content -->
+  <div class="divide-gray-900 ml-2" role="region" aria-label="Content">
+    <slot name="content" />
+  </div>
+</div>

--- a/packages/renderer/src/lib/ui/HorizontalCard.svelte
+++ b/packages/renderer/src/lib/ui/HorizontalCard.svelte
@@ -6,19 +6,19 @@ export let icon: string | { light: string; dark: string } | undefined = undefine
 
 <div role="row" class="bg-charcoal-600 mb-5 rounded-md p-3 flex flex-col" aria-label="{label}">
   <div class="divide-x divide-gray-900 flex flex-row">
-    <div role="region" aria-label="Title">
+    <div role="region" aria-label="Title Region">
       <!-- left col: icon/name + actions -->
       <div class="min-w-[170px] max-w-[200px]">
         <div class="flex">
           {#if icon}
             {#if typeof icon === 'string'}
-              <img src="{icon}" alt="{title}" class="max-w-[40px] max-h-[40px] h-full" />
+              <img src="{icon}" alt="{title}" aria-label="logo" class="max-w-[40px] max-h-[40px] h-full" />
               <!-- TODO check theme used for image, now use dark by default -->
             {:else}
               <img src="{icon.dark}" alt="{title}" aria-label="logo" class="max-w-[40px]" />
             {/if}
           {/if}
-          <span class="my-auto text-gray-400 ml-3 break-words">{title}</span>
+          <span class="my-auto text-gray-400 ml-3 break-words" aria-label="title">{title}</span>
         </div>
         <div class="text-center mt-10">
           <slot name="actions" />

--- a/packages/renderer/src/lib/ui/HorizontalCard.svelte
+++ b/packages/renderer/src/lib/ui/HorizontalCard.svelte
@@ -9,7 +9,7 @@ export let icon: string | { light: string; dark: string } | undefined = undefine
     <div role="region" aria-label="Title Region">
       <!-- left col: icon/name + actions -->
       <div class="min-w-[170px] max-w-[200px]">
-        <div class="flex">
+        <div class="flex space-x-2">
           {#if icon}
             {#if typeof icon === 'string'}
               <img src="{icon}" alt="{title}" aria-label="logo" class="max-w-[40px] max-h-[40px] h-full" />
@@ -18,7 +18,7 @@ export let icon: string | { light: string; dark: string } | undefined = undefine
               <img src="{icon.dark}" alt="{title}" aria-label="logo" class="max-w-[40px]" />
             {/if}
           {/if}
-          <span class="my-auto text-gray-400 ml-3 break-words" aria-label="title">{title}</span>
+          <span class="my-auto text-gray-400 break-words" aria-label="title">{title}</span>
         </div>
         <div class="text-center mt-10">
           <slot name="actions" />

--- a/packages/renderer/src/lib/ui/HorizontalCard.svelte
+++ b/packages/renderer/src/lib/ui/HorizontalCard.svelte
@@ -7,8 +7,8 @@ export let subtitle: string | undefined = undefined;
 export let icon: string | { light: string; dark: string } | undefined = undefined;
 </script>
 
-<div role="row" class="bg-charcoal-600 mb-5 rounded-md p-3 flex flex-col" aria-label="{label}">
-  <div class="divide-x divide-gray-900 flex flex-row">
+<div role="row" class="bg-[var(--pd-invert-content-card-bg)] mb-5 rounded-md p-3 flex flex-col" aria-label="{label}">
+  <div class="divide-x divide-[var(--pd-invert-content-card-divide)] flex flex-row">
     <div role="region" aria-label="Title Region">
       <!-- left col: icon/name + actions -->
       <div class="min-w-[170px] max-w-[200px]">
@@ -21,7 +21,7 @@ export let icon: string | { light: string; dark: string } | undefined = undefine
       </div>
     </div>
     <!-- content -->
-    <div class="divide-gray-900 ml-2" role="region" aria-label="Content">
+    <div class="divide-[var(--pd-invert-content-card-divide)] ml-2" role="region" aria-label="Content">
       <slot name="content" />
     </div>
   </div>


### PR DESCRIPTION
### What does this PR do?

- Add a HorizontalCard component, and use it for  PreferencesCliTool and PreferencesResourcesRendering components
- Add a Card component, and use it in different places
- Add a CardTitle component, and use it in Card and HorizontalCard
- HorizontalCard, Card and CardTitle support dark/light mode (except icon)

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
