### PR TITLE
chore: button hidden and icon-only spacing

### DIFF
--- a/packages/renderer/src/lib/ui/Button.spec.ts
+++ b/packages/renderer/src/lib/ui/Button.spec.ts
@@ -133,3 +133,13 @@ test('Check selected tab button styling', async () => {
   expect(button).toHaveClass('text-white');
   expect(button).toHaveClass('border-purple-500');
 });
+
+test('Check hidden button', async () => {
+  render(Button, { hidden: true });
+
+  // check that the button is in fact hidden
+  const button = screen.getByRole('button', { hidden: true });
+  expect(button).toBeInTheDocument();
+  expect(button).toHaveAttribute('hidden');
+  expect(button).not.toBeVisible();
+});

--- a/packages/renderer/src/lib/ui/Button.svelte
+++ b/packages/renderer/src/lib/ui/Button.svelte
@@ -7,6 +7,7 @@ import Spinner from './Spinner.svelte';
 export let title: string | undefined = undefined;
 export let inProgress = false;
 export let disabled = false;
+export let hidden = false;
 export let type: ButtonType = 'primary';
 export let icon: any = undefined;
 export let selected: boolean | undefined = undefined;
@@ -65,9 +66,12 @@ $: {
   title="{title}"
   aria-label="{$$props['aria-label']}"
   on:click
-  disabled="{disabled || inProgress}">
+  disabled="{disabled || inProgress}"
+  hidden="{hidden}">
   {#if icon}
-    <div class="flex flex-row p-0 m-0 bg-transparent justify-center items-center space-x-[4px]">
+    <div
+      class="flex flex-row p-0 m-0 bg-transparent justify-center items-center space-x-[4px]"
+      class:py-[3px]="{!$$slots.default}">
       {#if inProgress}
         <Spinner size="1em" />
       {:else if iconType === 'fa'}


### PR DESCRIPTION
### What does this PR do?

Yes, two things shouldn't be in the same PR, but they are both very minor:
- The Button does not have a hidden state, which will be required for the Run Image form.
- When a Button has no text, it is noticeably smaller vertically than other buttons. This adds some minor padding to bring the button to within 0.5px.

### Screenshot / video of UI

Before:

<img width="302" alt="Screenshot 2024-03-02 at 7 42 36 AM" src="https://github.com/containers/podman-desktop/assets/19958075/5e5cabd7-d2c0-480e-a803-64a5843d74b3">

After:

<img width="302" alt="Screenshot 2024-03-02 at 7 42 10 AM" src="https://github.com/containers/podman-desktop/assets/19958075/76bf84f1-130d-4389-b3fc-856da5130f4c">

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Use checkboxes on one of the list pages to show the delete button.