### PR TITLE
chore: handle docker manifests in addition to the OCI manifests

### DIFF
--- a/packages/main/src/plugin/image-registry.ts
+++ b/packages/main/src/plugin/image-registry.ts
@@ -622,6 +622,7 @@ export class ImageRegistry {
     if (
       parsedManifest.schemaVersion === 2 &&
       (parsedManifest.mediaType === 'application/vnd.oci.image.index.v1+json' ||
+        parsedManifest.mediaType === 'application/vnd.docker.distribution.manifest.list.v2+json' ||
         Array.isArray(parsedManifest.manifests))
     ) {
       // need to grab correct manifest from the index corresponding to our platform
@@ -642,8 +643,12 @@ export class ImageRegistry {
       }
       // find the manifest corresponding to our platform
       const matchedManifest = this.getBestManifest(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        parsedManifest.manifests.filter((m: any) => m.mediaType === 'application/vnd.oci.image.manifest.v1+json'),
+        parsedManifest.manifests.filter(
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (m: any) =>
+            m.mediaType === 'application/vnd.oci.image.manifest.v1+json' ||
+            m.mediaType === 'application/vnd.docker.distribution.manifest.v2+json',
+        ),
         platformArch,
         platformOs,
       );


### PR DESCRIPTION
### What does this PR do?
some registries/tooling might use old metadata

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

related to https://github.com/containers/podman-desktop/issues/6226

### How to test this PR?

- [x] Tests are covering the bug fix or the new feature
