### PR TITLE
fix: clear local state for services when informer is stopped

### DIFF
--- a/packages/main/src/plugin/kubernetes-context-state.ts
+++ b/packages/main/src/plugin/kubernetes-context-state.ts
@@ -273,9 +273,13 @@ export class ContextsStates {
     if (informers) {
       for (const [resourceName, informer] of informers) {
         if (isSecondaryResourceName(resourceName)) {
-          console.debug(`stop watching ${resourceName} in context ${contextName}`);
           await informer?.stop();
+          // We clear the informer and the local state
           informers.delete(resourceName);
+          const state = this.state.get(contextName);
+          if (state) {
+            state.resources[resourceName] = [];
+          }
         }
       }
     }

--- a/packages/main/src/plugin/kubernetes-context-state.ts
+++ b/packages/main/src/plugin/kubernetes-context-state.ts
@@ -220,7 +220,7 @@ export class ContextsStates {
     };
   }
 
-  getCurrentContextResources(current: string, resourceName: ResourceName): KubernetesObject[] {
+  getContextResources(current: string, resourceName: ResourceName): KubernetesObject[] {
     if (current) {
       const state = this.state.get(current);
       if (!state?.reachable) {
@@ -667,7 +667,7 @@ export class ContextsManager {
   private dispatchCurrentContextResource(resourceName: ResourceName): void {
     this.apiSender.send(
       `kubernetes-current-context-${resourceName}-update`,
-      this.states.getCurrentContextResources(this.kubeConfig.currentContext, resourceName),
+      this.states.getContextResources(this.kubeConfig.currentContext, resourceName),
     );
   }
 
@@ -677,7 +677,7 @@ export class ContextsManager {
     }
     if (this.states.hasInformer(this.currentContext, resourceName)) {
       console.debug(`already watching ${resourceName} in context ${this.currentContext}`);
-      return this.states.getCurrentContextResources(this.kubeConfig.currentContext, resourceName);
+      return this.states.getContextResources(this.kubeConfig.currentContext, resourceName);
     }
     if (!this.states.isReachable(this.currentContext)) {
       console.debug(`skip watching ${resourceName} in context ${this.currentContext}, as the context is not reachable`);
@@ -686,5 +686,10 @@ export class ContextsManager {
     console.debug(`start watching ${resourceName} in context ${this.currentContext}`);
     this.startResourceInformer(this.currentContext, resourceName);
     return [];
+  }
+
+  // for tests
+  public getContextResources(contextName: string, resourceName: ResourceName): KubernetesObject[] {
+    return this.states.getContextResources(contextName, resourceName);
   }
 }


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Clears the local state when the service informer is stopped, because resources will be received again with the next informer.

Details: https://github.com/containers/podman-desktop/issues/6202#issuecomment-1976172159

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
