### PR TITLE
feat(extension-api): enhance `listImages()` method with optional options

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -2985,7 +2985,7 @@ declare module '@podman-desktop/api' {
      * @example
      * // Example 2: List container images for a specific provider.
      * const provider = provider.getContainerConnections().find(connection => connection.connection.status() === 'started');
-     * const images = await listImages({provider: provider });
+     * const images = await listImages({provider});
      * console.log(images);
      */
     export function listImages(options?: ListImagesOptions): Promise<ImageInfo[]>;

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -2809,6 +2809,15 @@ declare module '@podman-desktop/api' {
     nocache?: boolean;
   }
 
+  export interface ListImagesOptions {
+    /**
+     * The provider we want to list the images. If not provided, will return all container images across all container engines.
+     *
+     * @defaultValue undefined
+     */
+    provider?: ContainerProviderConnection;
+  }
+
   export interface NetworkCreateOptions {
     Name: string;
   }
@@ -2965,7 +2974,7 @@ declare module '@podman-desktop/api' {
     /**
      * List the container images. Only images from a final layer (no children) are returned.
      *
-     * @param providerContainerConnection An optional parameter representing the container provider connection. If not provided, will return all container images across all container engines.
+     * @param options optional options for listing images
      * @returns A promise resolving to an array of images information. This method returns a subset of the available information for images. To get the complete description of a specific image, you can use the {@link containerEngine.getImageInspect} method.
      *
      * @example
@@ -2976,10 +2985,10 @@ declare module '@podman-desktop/api' {
      * @example
      * // Example 2: List container images for a specific provider.
      * const provider = provider.getContainerConnections().find(connection => connection.connection.status() === 'started');
-     * const images = await listImages(provider);
+     * const images = await listImages({provider: provider });
      * console.log(images);
      */
-    export function listImages(providerContainerConnection?: ContainerProviderConnection): Promise<ImageInfo[]>;
+    export function listImages(options?: ListImagesOptions): Promise<ImageInfo[]>;
 
     /**
      * Tag an image so that it becomes part of a repository

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -2963,11 +2963,23 @@ declare module '@podman-desktop/api' {
     export function saveImage(engineId: string, id: string, filename: string): Promise<void>;
 
     /**
-     * List the container images across all container engines. Only images from a final layer (no children) are returned.
+     * List the container images. Only images from a final layer (no children) are returned.
      *
-     * @return A promise resolving to an array of images information. This method returns a subset of the available information for images. To get the complete description of a specific image, you can use the {@link containerEngine.getImageInspect} method.
+     * @param providerContainerConnection An optional parameter representing the container provider connection. If not provided, will return all container images across all container engines.
+     * @returns A promise resolving to an array of images information. This method returns a subset of the available information for images. To get the complete description of a specific image, you can use the {@link containerEngine.getImageInspect} method.
+     *
+     * @example
+     * // Example 1: List all container images when no specific provider is provided.
+     * const images = await listImages();
+     * console.log(images);
+     *
+     * @example
+     * // Example 2: List container images for a specific provider.
+     * const provider = provider.getContainerConnections().find(connection => connection.connection.status() === 'started');
+     * const images = await listImages(provider);
+     * console.log(images);
      */
-    export function listImages(): Promise<ImageInfo[]>;
+    export function listImages(providerContainerConnection?: ContainerProviderConnection): Promise<ImageInfo[]>;
 
     /**
      * Tag an image so that it becomes part of a repository

--- a/packages/main/src/plugin/api/image-info.ts
+++ b/packages/main/src/plugin/api/image-info.ts
@@ -178,3 +178,12 @@ export interface BuildImageOptions {
    */
   nocache?: boolean;
 }
+
+export interface ListImagesOptions {
+  /**
+   * The provider we want to list the images. If not provided, will return all container images across all container engines.
+   *
+   * @defaultValue undefined
+   */
+  provider?: ContainerProviderConnection;
+}

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -544,10 +544,20 @@ export class ContainerProviderRegistry {
     return flatttenedContainers;
   }
 
-  async listImages(): Promise<ImageInfo[]> {
+  async listImages(
+    providerContainerConnection?: containerDesktopAPI.ContainerProviderConnection,
+  ): Promise<ImageInfo[]> {
     let telemetryOptions = {};
+
+    let providers: InternalContainerProvider[];
+    if (providerContainerConnection === undefined) {
+      providers = Array.from(this.internalProviders.values());
+    } else {
+      providers = [this.getMatchingContainerProvider(providerContainerConnection)];
+    }
+
     const images = await Promise.all(
-      Array.from(this.internalProviders.values()).map(async provider => {
+      Array.from(providers).map(async provider => {
         try {
           if (!provider.api) {
             return [];

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -31,7 +31,7 @@ import type {
   VolumeCreateOptions,
   VolumeCreateResponseInfo,
 } from './api/container-info.js';
-import type { BuildImageOptions, ImageInfo } from './api/image-info.js';
+import type { BuildImageOptions, ImageInfo, ListImagesOptions } from './api/image-info.js';
 import type { PodCreateOptions, PodInfo, PodInspectInfo } from './api/pod-info.js';
 import type { ImageInspectInfo } from './api/image-inspect-info.js';
 import type { ProviderContainerConnectionInfo } from './api/provider-info.js';
@@ -544,16 +544,14 @@ export class ContainerProviderRegistry {
     return flatttenedContainers;
   }
 
-  async listImages(
-    providerContainerConnection?: containerDesktopAPI.ContainerProviderConnection,
-  ): Promise<ImageInfo[]> {
+  async listImages(options?: ListImagesOptions): Promise<ImageInfo[]> {
     let telemetryOptions = {};
 
     let providers: InternalContainerProvider[];
-    if (providerContainerConnection === undefined) {
+    if (options?.provider === undefined) {
       providers = Array.from(this.internalProviders.values());
     } else {
-      providers = [this.getMatchingContainerProvider(providerContainerConnection)];
+      providers = [this.getMatchingContainerProvider(options?.provider)];
     }
 
     const images = await Promise.all(

--- a/packages/main/src/plugin/extension-loader.spec.ts
+++ b/packages/main/src/plugin/extension-loader.spec.ts
@@ -143,6 +143,7 @@ const containerProviderRegistry: ContainerProviderRegistry = {
   listPods: vi.fn(),
   stopPod: vi.fn(),
   removePod: vi.fn(),
+  listImages: vi.fn(),
 } as unknown as ContainerProviderRegistry;
 
 const inputQuickPickRegistry: InputQuickPickRegistry = {} as unknown as InputQuickPickRegistry;
@@ -1648,5 +1649,37 @@ describe('window', async () => {
 
     expect(dialogRegistry.saveDialog).toBeCalled();
     expect(uri?.fsPath).toContain('path-to-file1');
+  });
+});
+
+describe('containerEngine', async () => {
+  test('listImages without option ', async () => {
+    vi.mocked(containerProviderRegistry.listImages).mockResolvedValue([]);
+
+    const api = extensionLoader.createApi('/path', {});
+    expect(api).toBeDefined();
+
+    const images = await api.containerEngine.listImages();
+    expect(images.length).toBe(0);
+    expect(containerProviderRegistry.listImages).toHaveBeenCalledWith(undefined);
+  });
+
+  test('listImages with provider option', async () => {
+    vi.mocked(containerProviderRegistry.listImages).mockResolvedValue([]);
+
+    const api = extensionLoader.createApi('/path', {});
+    expect(api).toBeDefined();
+
+    const images = await api.containerEngine.listImages({
+      provider: {
+        name: 'dummyProvider',
+      } as unknown as containerDesktopAPI.ContainerProviderConnection,
+    });
+    expect(images.length).toBe(0);
+    expect(containerProviderRegistry.listImages).toHaveBeenCalledWith({
+      provider: {
+        name: 'dummyProvider',
+      },
+    });
   });
 });

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -962,10 +962,8 @@ export class ExtensionLoader {
       ) {
         return containerProviderRegistry.buildImage(context, eventCollect, options);
       },
-      listImages(
-        providerContainerConnection?: containerDesktopAPI.ContainerProviderConnection,
-      ): Promise<containerDesktopAPI.ImageInfo[]> {
-        return containerProviderRegistry.listImages(providerContainerConnection);
+      listImages(options?: containerDesktopAPI.ListImagesOptions): Promise<containerDesktopAPI.ImageInfo[]> {
+        return containerProviderRegistry.listImages(options);
       },
       saveImage(engineId: string, id: string, filename: string) {
         return containerProviderRegistry.saveImage(engineId, id, filename);

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -962,8 +962,10 @@ export class ExtensionLoader {
       ) {
         return containerProviderRegistry.buildImage(context, eventCollect, options);
       },
-      listImages(): Promise<containerDesktopAPI.ImageInfo[]> {
-        return containerProviderRegistry.listImages();
+      listImages(
+        providerContainerConnection?: containerDesktopAPI.ContainerProviderConnection,
+      ): Promise<containerDesktopAPI.ImageInfo[]> {
+        return containerProviderRegistry.listImages(providerContainerConnection);
       },
       saveImage(engineId: string, id: string, filename: string) {
         return containerProviderRegistry.saveImage(engineId, id, filename);


### PR DESCRIPTION
### What does this PR do?

Adding an optional argument to the `listImages` extension-api method. This PR is adding the option `provider` allowing to get list images for a specific provider.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop/issues/6256

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
