### PR TITLE
fix: services store register, to restart service informer when switching context

### DIFF
--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1918,6 +1918,13 @@ export class PluginSystem {
       },
     );
 
+    this.ipcHandle(
+      'kubernetes-client:unregisterGetCurrentContextResources',
+      async (_listener, resourceName: ResourceName): Promise<KubernetesObject[]> => {
+        return kubernetesClient.unregisterGetCurrentContextResources(resourceName);
+      },
+    );
+
     this.ipcHandle('feedback:send', async (_listener, feedbackProperties: unknown): Promise<void> => {
       return telemetry.sendFeedback(feedbackProperties);
     });

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1912,9 +1912,9 @@ export class PluginSystem {
     });
 
     this.ipcHandle(
-      'kubernetes-client:getCurrentContextResources',
+      'kubernetes-client:registerGetCurrentContextResources',
       async (_listener, resourceName: ResourceName): Promise<KubernetesObject[]> => {
-        return kubernetesClient.getCurrentContextResources(resourceName);
+        return kubernetesClient.registerGetCurrentContextResources(resourceName);
       },
     );
 

--- a/packages/main/src/plugin/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes-client.ts
@@ -1371,4 +1371,8 @@ export class KubernetesClient {
   public getCurrentContextResources(resourceName: ResourceName): KubernetesObject[] {
     return this.contextsState.getCurrentContextResources(resourceName);
   }
+
+  public unregisterGetCurrentContextResources(resourceName: ResourceName): KubernetesObject[] {
+    return this.contextsState.unregisterGetCurrentContextResources(resourceName);
+  }
 }

--- a/packages/main/src/plugin/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes-client.ts
@@ -1368,8 +1368,8 @@ export class KubernetesClient {
     return this.contextsState.getCurrentContextGeneralState();
   }
 
-  public getCurrentContextResources(resourceName: ResourceName): KubernetesObject[] {
-    return this.contextsState.getCurrentContextResources(resourceName);
+  public registerGetCurrentContextResources(resourceName: ResourceName): KubernetesObject[] {
+    return this.contextsState.registerGetCurrentContextResources(resourceName);
   }
 
   public unregisterGetCurrentContextResources(resourceName: ResourceName): KubernetesObject[] {

--- a/packages/main/src/plugin/kubernetes-context-state.spec.ts
+++ b/packages/main/src/plugin/kubernetes-context-state.spec.ts
@@ -1112,7 +1112,7 @@ describe.each(secondaryInformers)(`Secondary informer $resource`, ({ resource, i
     );
   });
 
-  test('calling getCurrentContextResources should start informer, the first time only', async () => {
+  test('calling registerGetCurrentContextResources should start informer, the first time only', async () => {
     vi.useFakeTimers();
     const makeInformerMock = vi.mocked(makeInformer);
     makeInformerMock.mockImplementation(
@@ -1153,12 +1153,12 @@ describe.each(secondaryInformers)(`Secondary informer $resource`, ({ resource, i
     vi.advanceTimersToNextTimer();
 
     makeInformerMock.mockClear();
-    client.getCurrentContextResources(resource as ResourceName);
+    client.registerGetCurrentContextResources(resource as ResourceName);
     expect(makeInformerMock).toHaveBeenCalledTimes(1);
     expect(makeInformerMock).toHaveBeenCalledWith(expect.any(KubeConfig), informerPath, expect.anything());
 
     makeInformerMock.mockClear();
-    client.getCurrentContextResources(resource as ResourceName);
+    client.registerGetCurrentContextResources(resource as ResourceName);
     expect(makeInformerMock).not.toHaveBeenCalled();
   });
 
@@ -1211,7 +1211,7 @@ describe.each(secondaryInformers)(`Secondary informer $resource`, ({ resource, i
     makeInformerMock.mockClear();
 
     // informer is started
-    client.getCurrentContextResources(resource as ResourceName);
+    client.registerGetCurrentContextResources(resource as ResourceName);
     expect(makeInformerMock).toHaveBeenCalledTimes(1);
     expect(makeInformerMock).toHaveBeenCalledWith(expect.any(KubeConfig), informerPath, expect.anything());
 
@@ -1282,7 +1282,7 @@ test('changing context should start service informer on current context if watch
   makeInformerMock.mockClear();
 
   // service informer is started
-  client.getCurrentContextResources('services');
+  client.registerGetCurrentContextResources('services');
   expect(makeInformerMock).toHaveBeenCalledTimes(1);
   expect(makeInformerMock).toHaveBeenCalledWith(
     expect.any(KubeConfig),
@@ -1359,7 +1359,7 @@ test('changing context should not start service informer on current context if n
   makeInformerMock.mockClear();
 
   // service informer is started
-  client.getCurrentContextResources('services');
+  client.registerGetCurrentContextResources('services');
   expect(makeInformerMock).toHaveBeenCalledTimes(1);
   expect(makeInformerMock).toHaveBeenCalledWith(
     expect.any(KubeConfig),

--- a/packages/main/src/plugin/kubernetes-context-state.spec.ts
+++ b/packages/main/src/plugin/kubernetes-context-state.spec.ts
@@ -1232,6 +1232,155 @@ describe.each(secondaryInformers)(`Secondary informer $resource`, ({ resource, i
   });
 });
 
+test('changing context should start service informer on current context if watchers have subscribed', async () => {
+  vi.useFakeTimers();
+  const makeInformerMock = vi.mocked(makeInformer);
+  makeInformerMock.mockImplementation(
+    (
+      kubeconfig: kubeclient.KubeConfig,
+      path: string,
+      _listPromiseFn: kubeclient.ListPromise<kubeclient.KubernetesObject>,
+    ) => {
+      return new FakeInformer(kubeconfig.currentContext, path, 0, undefined, [], []);
+    },
+  );
+  const client = new ContextsManager(apiSender);
+  const kubeConfig = new kubeclient.KubeConfig();
+  const config = {
+    clusters: [
+      {
+        name: 'cluster1',
+        server: 'server1',
+      },
+    ],
+    users: [
+      {
+        name: 'user1',
+      },
+    ],
+    contexts: [
+      {
+        name: 'context1',
+        cluster: 'cluster1',
+        user: 'user1',
+        namespace: 'ns1',
+      },
+      {
+        name: 'context2',
+        cluster: 'cluster1',
+        user: 'user1',
+        namespace: 'ns2',
+      },
+    ],
+    currentContext: 'context1',
+  };
+  kubeConfig.loadFromOptions(config);
+  await client.update(kubeConfig);
+  vi.advanceTimersToNextTimer();
+
+  makeInformerMock.mockClear();
+
+  // service informer is started
+  client.getCurrentContextResources('services');
+  expect(makeInformerMock).toHaveBeenCalledTimes(1);
+  expect(makeInformerMock).toHaveBeenCalledWith(
+    expect.any(KubeConfig),
+    '/api/v1/namespaces/ns1/services',
+    expect.anything(),
+  );
+
+  makeInformerMock.mockClear();
+
+  config.currentContext = 'context2';
+  kubeConfig.loadFromOptions(config);
+
+  expect(informerStopMock).not.toHaveBeenCalled();
+
+  await client.update(kubeConfig);
+
+  expect(informerStopMock).toHaveBeenCalledTimes(1);
+  expect(informerStopMock).toHaveBeenCalledWith('context1', '/api/v1/namespaces/ns1/services');
+  expect(makeInformerMock).toHaveBeenCalledTimes(1);
+  expect(makeInformerMock).toHaveBeenCalledWith(
+    expect.any(KubeConfig),
+    '/api/v1/namespaces/ns2/services',
+    expect.anything(),
+  );
+});
+
+test('changing context should not start service informer on current context if no watchers have subscribed', async () => {
+  vi.useFakeTimers();
+  const makeInformerMock = vi.mocked(makeInformer);
+  makeInformerMock.mockImplementation(
+    (
+      kubeconfig: kubeclient.KubeConfig,
+      path: string,
+      _listPromiseFn: kubeclient.ListPromise<kubeclient.KubernetesObject>,
+    ) => {
+      return new FakeInformer(kubeconfig.currentContext, path, 0, undefined, [], []);
+    },
+  );
+  const client = new ContextsManager(apiSender);
+  const kubeConfig = new kubeclient.KubeConfig();
+  const config = {
+    clusters: [
+      {
+        name: 'cluster1',
+        server: 'server1',
+      },
+    ],
+    users: [
+      {
+        name: 'user1',
+      },
+    ],
+    contexts: [
+      {
+        name: 'context1',
+        cluster: 'cluster1',
+        user: 'user1',
+        namespace: 'ns1',
+      },
+      {
+        name: 'context2',
+        cluster: 'cluster1',
+        user: 'user1',
+        namespace: 'ns2',
+      },
+    ],
+    currentContext: 'context1',
+  };
+  kubeConfig.loadFromOptions(config);
+  await client.update(kubeConfig);
+  vi.advanceTimersToNextTimer();
+
+  makeInformerMock.mockClear();
+
+  // service informer is started
+  client.getCurrentContextResources('services');
+  expect(makeInformerMock).toHaveBeenCalledTimes(1);
+  expect(makeInformerMock).toHaveBeenCalledWith(
+    expect.any(KubeConfig),
+    '/api/v1/namespaces/ns1/services',
+    expect.anything(),
+  );
+
+  makeInformerMock.mockClear();
+
+  config.currentContext = 'context2';
+  kubeConfig.loadFromOptions(config);
+
+  expect(informerStopMock).not.toHaveBeenCalled();
+
+  client.unregisterGetCurrentContextResources('services');
+
+  await client.update(kubeConfig);
+
+  expect(informerStopMock).toHaveBeenCalledTimes(1);
+  expect(informerStopMock).toHaveBeenCalledWith('context1', '/api/v1/namespaces/ns1/services');
+  expect(makeInformerMock).not.toHaveBeenCalled();
+});
+
 describe('ContextsStates tests', () => {
   test('hasInformer should check if informer exists for context', () => {
     const client = new ContextsStates();

--- a/packages/main/src/plugin/kubernetes-context-state.spec.ts
+++ b/packages/main/src/plugin/kubernetes-context-state.spec.ts
@@ -1277,6 +1277,7 @@ test('changing context should start service informer on current context if watch
   kubeConfig.loadFromOptions(config);
   await client.update(kubeConfig);
   vi.advanceTimersToNextTimer();
+  vi.advanceTimersToNextTimer();
 
   makeInformerMock.mockClear();
 
@@ -1352,6 +1353,7 @@ test('changing context should not start service informer on current context if n
   };
   kubeConfig.loadFromOptions(config);
   await client.update(kubeConfig);
+  vi.advanceTimersToNextTimer();
   vi.advanceTimersToNextTimer();
 
   makeInformerMock.mockClear();

--- a/packages/main/src/plugin/kubernetes-context-state.ts
+++ b/packages/main/src/plugin/kubernetes-context-state.ts
@@ -374,13 +374,13 @@ export class ContextsManager {
         const contextName = ctx.name;
         await this.states.disposeSecondaryInformers(contextName);
       }
-    }
 
-    // Restart informers for secondary resources if watchers are subscribing for this resource
-    for (const resourceName of secondaryResources) {
-      if (this.secondaryWatchers.hasSubscribers(resourceName)) {
-        console.debug(`start watching ${resourceName} in context ${this.currentContext}`);
-        this.startResourceInformer(this.currentContext, resourceName);
+      // Restart informers for secondary resources if watchers are subscribing for this resource
+      for (const resourceName of secondaryResources) {
+        if (this.secondaryWatchers.hasSubscribers(resourceName)) {
+          console.debug(`start watching ${resourceName} in context ${this.currentContext}`);
+          this.startResourceInformer(this.currentContext, resourceName);
+        }
       }
     }
 

--- a/packages/main/src/plugin/kubernetes-context-state.ts
+++ b/packages/main/src/plugin/kubernetes-context-state.ts
@@ -817,7 +817,7 @@ export class ContextsManager {
     );
   }
 
-  public getCurrentContextResources(resourceName: ResourceName): KubernetesObject[] {
+  public registerGetCurrentContextResources(resourceName: ResourceName): KubernetesObject[] {
     if (isSecondaryResourceName(resourceName)) {
       this.secondaryWatchers.subscribe(resourceName);
     }

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -1583,6 +1583,12 @@ export function initExposure(): void {
       return ipcInvoke('kubernetes-client:getCurrentContextResources', resourceName);
     },
   );
+  contextBridge.exposeInMainWorld(
+    'kubernetesUnregisterGetCurrentContextResources',
+    async (resourceName: ResourceName): Promise<KubernetesObject[]> => {
+      return ipcInvoke('kubernetes-client:unregisterGetCurrentContextResources', resourceName);
+    },
+  );
 
   contextBridge.exposeInMainWorld('kubernetesGetClusters', async (): Promise<Cluster[]> => {
     return ipcInvoke('kubernetes-client:getClusters');

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -1578,9 +1578,9 @@ export function initExposure(): void {
     return ipcInvoke('kubernetes-client:getCurrentContextGeneralState');
   });
   contextBridge.exposeInMainWorld(
-    'kubernetesGetCurrentContextResources',
+    'kubernetesRegisterGetCurrentContextResources',
     async (resourceName: ResourceName): Promise<KubernetesObject[]> => {
-      return ipcInvoke('kubernetes-client:getCurrentContextResources', resourceName);
+      return ipcInvoke('kubernetes-client:registerGetCurrentContextResources', resourceName);
     },
   );
   contextBridge.exposeInMainWorld(

--- a/packages/renderer/src/lib/deployments/DeploymentsList.spec.ts
+++ b/packages/renderer/src/lib/deployments/DeploymentsList.spec.ts
@@ -26,10 +26,10 @@ import { get } from 'svelte/store';
 import type { V1Deployment } from '@kubernetes/client-node';
 import { kubernetesCurrentContextDeployments } from '/@/stores/kubernetes-contexts-state';
 
-const kubernetesGetCurrentContextResourcesMock = vi.fn();
+const kubernetesRegisterGetCurrentContextResourcesMock = vi.fn();
 
 beforeAll(() => {
-  (window as any).kubernetesGetCurrentContextResources = kubernetesGetCurrentContextResourcesMock;
+  (window as any).kubernetesRegisterGetCurrentContextResources = kubernetesRegisterGetCurrentContextResourcesMock;
 });
 
 beforeEach(() => {
@@ -48,7 +48,7 @@ async function waitRender(customProperties: object): Promise<void> {
 }
 
 test('Expect deployment empty screen', async () => {
-  kubernetesGetCurrentContextResourcesMock.mockResolvedValue([]);
+  kubernetesRegisterGetCurrentContextResourcesMock.mockResolvedValue([]);
   render(DeploymentsList);
   const noDeployments = screen.getByRole('heading', { name: 'No deployments' });
   expect(noDeployments).toBeInTheDocument();
@@ -68,7 +68,7 @@ test('Expect deployments list', async () => {
       template: {},
     },
   };
-  kubernetesGetCurrentContextResourcesMock.mockResolvedValue([deployment]);
+  kubernetesRegisterGetCurrentContextResourcesMock.mockResolvedValue([deployment]);
 
   // wait while store is populated
   while (get(kubernetesCurrentContextDeployments).length === 0) {
@@ -97,7 +97,7 @@ test('Expect correct column overflow', async () => {
       template: {},
     },
   };
-  kubernetesGetCurrentContextResourcesMock.mockResolvedValue([deployment]);
+  kubernetesRegisterGetCurrentContextResourcesMock.mockResolvedValue([deployment]);
 
   // wait while store is populated
   while (get(kubernetesCurrentContextDeployments).length === 0) {
@@ -138,7 +138,7 @@ test('Expect filter empty screen', async () => {
     },
   };
 
-  kubernetesGetCurrentContextResourcesMock.mockResolvedValue([deployment]);
+  kubernetesRegisterGetCurrentContextResourcesMock.mockResolvedValue([deployment]);
 
   // wait while store is populated
   while (get(kubernetesCurrentContextDeployments).length === 0) {

--- a/packages/renderer/src/lib/service/ServicesList.spec.ts
+++ b/packages/renderer/src/lib/service/ServicesList.spec.ts
@@ -37,6 +37,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   (window as any).kubernetesGetContextsGeneralState = () => Promise.resolve(new Map());
   (window as any).kubernetesGetCurrentContextGeneralState = () => Promise.resolve({});
+  (window as any).window.kubernetesUnregisterGetCurrentContextResources = () => Promise.resolve(undefined);
 });
 
 async function waitRender(customProperties: object): Promise<void> {

--- a/packages/renderer/src/lib/service/ServicesList.spec.ts
+++ b/packages/renderer/src/lib/service/ServicesList.spec.ts
@@ -26,10 +26,10 @@ import { get } from 'svelte/store';
 import type { V1Service } from '@kubernetes/client-node';
 import { kubernetesCurrentContextServices } from '/@/stores/kubernetes-contexts-state';
 
-const kubernetesGetCurrentContextResourcesMock = vi.fn();
+const kubernetesRegisterGetCurrentContextResourcesMock = vi.fn();
 
 beforeAll(() => {
-  (window as any).kubernetesGetCurrentContextResources = kubernetesGetCurrentContextResourcesMock;
+  (window as any).kubernetesRegisterGetCurrentContextResources = kubernetesRegisterGetCurrentContextResourcesMock;
 });
 
 beforeEach(() => {
@@ -49,7 +49,7 @@ async function waitRender(customProperties: object): Promise<void> {
 }
 
 test('Expect service empty screen', async () => {
-  kubernetesGetCurrentContextResourcesMock.mockResolvedValue([]);
+  kubernetesRegisterGetCurrentContextResourcesMock.mockResolvedValue([]);
   render(ServicesList);
   const noServices = screen.getByRole('heading', { name: 'No services' });
   expect(noServices).toBeInTheDocument();
@@ -68,7 +68,7 @@ test('Expect services list', async () => {
       externalName: 'serve',
     },
   };
-  kubernetesGetCurrentContextResourcesMock.mockResolvedValue([service]);
+  kubernetesRegisterGetCurrentContextResourcesMock.mockResolvedValue([service]);
 
   // wait while store is populated
   while (get(kubernetesCurrentContextServices).length === 0) {
@@ -94,7 +94,7 @@ test('Expect filter empty screen', async () => {
       externalName: 'serve',
     },
   };
-  kubernetesGetCurrentContextResourcesMock.mockResolvedValue([service]);
+  kubernetesRegisterGetCurrentContextResourcesMock.mockResolvedValue([service]);
 
   // wait while store is populated
   while (get(kubernetesCurrentContextServices).length === 0) {

--- a/packages/renderer/src/stores/kubernetes-contexts-state.ts
+++ b/packages/renderer/src/stores/kubernetes-contexts-state.ts
@@ -65,6 +65,9 @@ export const kubernetesCurrentContextServices = readable<KubernetesObject[]>([],
   window.events?.receive('kubernetes-current-context-services-update', (value: unknown) => {
     set(value as KubernetesObject[]);
   });
+  return () => {
+    window.kubernetesUnregisterGetCurrentContextResources('services');
+  };
 });
 
 export const serviceSearchPattern = writable('');

--- a/packages/renderer/src/stores/kubernetes-contexts-state.ts
+++ b/packages/renderer/src/stores/kubernetes-contexts-state.ts
@@ -43,7 +43,7 @@ export const kubernetesCurrentContextState = readable(
 );
 
 export const kubernetesCurrentContextDeployments = readable<KubernetesObject[]>([], set => {
-  window.kubernetesGetCurrentContextResources('deployments').then(value => set(value));
+  window.kubernetesRegisterGetCurrentContextResources('deployments').then(value => set(value));
   window.events?.receive('kubernetes-current-context-deployments-update', (value: unknown) => {
     set(value as KubernetesObject[]);
   });
@@ -61,7 +61,7 @@ export const kubernetesCurrentContextDeploymentsFiltered = derived(
 // Services
 
 export const kubernetesCurrentContextServices = readable<KubernetesObject[]>([], set => {
-  window.kubernetesGetCurrentContextResources('services').then(value => set(value));
+  window.kubernetesRegisterGetCurrentContextResources('services').then(value => set(value));
   window.events?.receive('kubernetes-current-context-services-update', (value: unknown) => {
     set(value as KubernetesObject[]);
   });
@@ -82,7 +82,7 @@ export const kubernetesCurrentContextServicesFiltered = derived(
 // Ingresses
 
 export const kubernetesCurrentContextIngresses = readable<KubernetesObject[]>([], set => {
-  window.kubernetesGetCurrentContextResources('ingresses').then(value => set(value));
+  window.kubernetesRegisterGetCurrentContextResources('ingresses').then(value => set(value));
   window.events?.receive('kubernetes-current-context-ingresses-update', (value: unknown) => {
     set(value as KubernetesObject[]);
   });
@@ -103,7 +103,7 @@ export const kubernetesCurrentContextIngressesFiltered = derived(
 // Routes
 
 export const kubernetesCurrentContextRoutes = readable<KubernetesObject[]>([], set => {
-  window.kubernetesGetCurrentContextResources('routes').then(value => set(value));
+  window.kubernetesRegisterGetCurrentContextResources('routes').then(value => set(value));
   window.events?.receive('kubernetes-current-context-routes-update', (value: unknown) => {
     set(value as KubernetesObject[]);
   });

--- a/packages/renderer/src/stores/kubernetes-contexts-state.ts
+++ b/packages/renderer/src/stores/kubernetes-contexts-state.ts
@@ -86,6 +86,9 @@ export const kubernetesCurrentContextIngresses = readable<KubernetesObject[]>([]
   window.events?.receive('kubernetes-current-context-ingresses-update', (value: unknown) => {
     set(value as KubernetesObject[]);
   });
+  return () => {
+    window.kubernetesUnregisterGetCurrentContextResources('ingresses');
+  };
 });
 
 export const ingressSearchPattern = writable('');
@@ -104,6 +107,9 @@ export const kubernetesCurrentContextRoutes = readable<KubernetesObject[]>([], s
   window.events?.receive('kubernetes-current-context-routes-update', (value: unknown) => {
     set(value as KubernetesObject[]);
   });
+  return () => {
+    window.kubernetesUnregisterGetCurrentContextResources('routes');
+  };
 });
 
 export const routeSearchPattern = writable('');


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Add a registry to the ContextsManager to know if some clients have registered to the Services informers, so we can restart the informer automatically when the context is switched by the user. 

### What issues does this PR fix or reference?

Fixes #6254

### How to test this PR?

go to the Services List page, switch the context from the statusbar (without leaving the Service List page), then create a service using kubectl. The Service List should be updated.

- [x] Tests are covering the bug fix or the new feature
