### PR TITLE
chore: switch details pages to new informers

### DIFF
--- a/packages/renderer/src/lib/deployments/DeploymentDetails.spec.ts
+++ b/packages/renderer/src/lib/deployments/DeploymentDetails.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023,2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,8 +24,9 @@ import DeploymentDetails from './DeploymentDetails.svelte';
 
 import { router } from 'tinro';
 import { lastPage } from '/@/stores/breadcrumb';
-import { deployments } from '/@/stores/deployments';
-import type { V1Deployment } from '@kubernetes/client-node';
+import type { V1Deployment, KubernetesObject } from '@kubernetes/client-node';
+import * as kubeContextStore from '/@/stores/kubernetes-contexts-state';
+import { writable } from 'svelte/store';
 
 const kubernetesDeleteDeploymentMock = vi.fn();
 
@@ -43,6 +44,12 @@ const deployment: V1Deployment = {
   },
 };
 
+vi.mock('/@/stores/kubernetes-contexts-state', async () => {
+  return {
+    kubernetesCurrentContextDeployments: vi.fn(),
+  };
+});
+
 beforeAll(() => {
   (window as any).kubernetesDeleteDeployment = kubernetesDeleteDeploymentMock;
   (window as any).kubernetesReadNamespacedDeployment = vi.fn();
@@ -54,7 +61,10 @@ test('Expect redirect to previous page if deployment is deleted', async () => {
   showMessageBoxMock.mockResolvedValue({ response: 0 });
 
   const routerGotoSpy = vi.spyOn(router, 'goto');
-  deployments.set([deployment]);
+
+  // mock object store
+  const deployments = writable<KubernetesObject[]>([deployment]);
+  vi.mocked(kubeContextStore).kubernetesCurrentContextDeployments = deployments;
 
   // remove deployment from the store when we call delete
   kubernetesDeleteDeploymentMock.mockImplementation(() => {

--- a/packages/renderer/src/lib/deployments/DeploymentDetails.svelte
+++ b/packages/renderer/src/lib/deployments/DeploymentDetails.svelte
@@ -9,11 +9,11 @@ import Tab from '../ui/Tab.svelte';
 import DeploymentIcon from '../images/DeploymentIcon.svelte';
 import DeploymentActions from './DeploymentActions.svelte';
 import DeploymentDetailsSummary from './DeploymentDetailsSummary.svelte';
-import { deployments } from '/@/stores/deployments';
 import type { V1Deployment } from '@kubernetes/client-node';
 import { stringify } from 'yaml';
 import MonacoEditor from '../editor/MonacoEditor.svelte';
 import KubeEditYAML from '../kube/KubeEditYAML.svelte';
+import { kubernetesCurrentContextDeployments } from '/@/stores/kubernetes-contexts-state';
 
 export let name: string;
 export let namespace: string;
@@ -26,7 +26,7 @@ let kubeError: string;
 onMount(() => {
   const deploymentUtils = new DeploymentUtils();
   // loading deployment info
-  return deployments.subscribe(deployments => {
+  return kubernetesCurrentContextDeployments.subscribe(deployments => {
     const matchingDeployment = deployments.find(
       dep => dep.metadata?.name === name && dep.metadata?.namespace === namespace,
     );

--- a/packages/renderer/src/lib/ingresses-routes/IngressDetails.svelte
+++ b/packages/renderer/src/lib/ingresses-routes/IngressDetails.svelte
@@ -9,12 +9,12 @@ import { stringify } from 'yaml';
 import MonacoEditor from '../editor/MonacoEditor.svelte';
 import type { IngressUI } from './IngressUI';
 import { IngressRouteUtils } from './ingress-route-utils';
-import { ingresses } from '/@/stores/ingresses';
 import IngressRouteActions from './IngressRouteActions.svelte';
 import ServiceDetailsSummary from './IngressRouteDetailsSummary.svelte';
 import ServiceIcon from '../images/ServiceIcon.svelte';
 import Route from '../../Route.svelte';
 import KubeEditYAML from '../kube/KubeEditYAML.svelte';
+import { kubernetesCurrentContextIngresses } from '/@/stores/kubernetes-contexts-state';
 
 export let name: string;
 export let namespace: string;
@@ -27,7 +27,7 @@ let kubeError: string;
 onMount(() => {
   const ingressRouteUtils = new IngressRouteUtils();
 
-  return ingresses.subscribe(ingress => {
+  return kubernetesCurrentContextIngresses.subscribe(ingress => {
     const matchingIngress = ingress.find(srv => srv.metadata?.name === name && srv.metadata?.namespace === namespace);
     if (matchingIngress) {
       try {

--- a/packages/renderer/src/lib/ingresses-routes/RouteDetails.svelte
+++ b/packages/renderer/src/lib/ingresses-routes/RouteDetails.svelte
@@ -13,8 +13,8 @@ import IngressRouteActions from './IngressRouteActions.svelte';
 import ServiceDetailsSummary from './IngressRouteDetailsSummary.svelte';
 import ServiceIcon from '../images/ServiceIcon.svelte';
 import Route from '../../Route.svelte';
-import { routes } from '/@/stores/routes';
 import KubeEditYAML from '../kube/KubeEditYAML.svelte';
+import { kubernetesCurrentContextRoutes } from '/@/stores/kubernetes-contexts-state';
 
 export let name: string;
 export let namespace: string;
@@ -27,11 +27,11 @@ let kubeError: string;
 onMount(() => {
   const ingressRouteUtils = new IngressRouteUtils();
 
-  return routes.subscribe(route => {
+  return kubernetesCurrentContextRoutes.subscribe(route => {
     const matchingRoute = route.find(srv => srv.metadata?.name === name && srv.metadata?.namespace === namespace);
     if (matchingRoute) {
       try {
-        routeUI = ingressRouteUtils.getRouteUI(matchingRoute);
+        routeUI = ingressRouteUtils.getRouteUI(matchingRoute as V1Route);
         loadRouteDetails();
       } catch (err) {
         console.error(err);

--- a/packages/renderer/src/lib/service/ServiceDetails.svelte
+++ b/packages/renderer/src/lib/service/ServiceDetails.svelte
@@ -10,11 +10,11 @@ import { stringify } from 'yaml';
 import MonacoEditor from '../editor/MonacoEditor.svelte';
 import type { ServiceUI } from './ServiceUI';
 import { ServiceUtils } from './service-utils';
-import { services } from '/@/stores/services';
 import ServiceActions from './ServiceActions.svelte';
 import ServiceDetailsSummary from './ServiceDetailsSummary.svelte';
 import ServiceIcon from '../images/ServiceIcon.svelte';
 import KubeEditYAML from '../kube/KubeEditYAML.svelte';
+import { kubernetesCurrentContextServices } from '/@/stores/kubernetes-contexts-state';
 
 export let name: string;
 export let namespace: string;
@@ -27,7 +27,7 @@ let kubeError: string;
 onMount(() => {
   const serviceUtils = new ServiceUtils();
   // loading service info
-  return services.subscribe(services => {
+  return kubernetesCurrentContextServices.subscribe(services => {
     const matchingService = services.find(srv => srv.metadata?.name === name && srv.metadata?.namespace === namespace);
     if (matchingService) {
       try {


### PR DESCRIPTION
### What does this PR do?

Switches our 4 Kubernetes details pages over to the newer informer stores. The changes to the pages themselves are very simple, but the old stores were (likely incorrectly) writable and the new stores aren't, so mocking was added to the tests to allow us to update the stores directly.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes another part of #6259.

### How to test this PR?

Go to details for each resource type, confirm no regression.

- [x] Tests are covering the bug fix or the new feature