### PR TITLE
chore: use new informers in main nav

### DIFF
--- a/packages/renderer/src/AppNavigation.spec.ts
+++ b/packages/renderer/src/AppNavigation.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023,2024 Red Hat, Inc.
+ * Copyright (C) 2023-2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/renderer/src/AppNavigation.spec.ts
+++ b/packages/renderer/src/AppNavigation.spec.ts
@@ -21,19 +21,31 @@ import { beforeAll, test, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/svelte';
 import AppNavigation from './AppNavigation.svelte';
 import type { TinroRouteMeta } from 'tinro';
+import { readable } from 'svelte/store';
+import type { KubernetesObject } from '@kubernetes/client-node';
+import * as kubeContextStore from '/@/stores/kubernetes-contexts-state';
 
 const eventsMock = vi.fn();
+
+vi.mock('/@/stores/kubernetes-contexts-state', async () => {
+  return {};
+});
 
 // fake the window object
 beforeAll(() => {
   (window as any).events = eventsMock;
-  (window as any).kubernetesGetCurrentContextResources = vi.fn().mockImplementation(() => []);
 });
 
 test('Test rendering of the navigation bar with empty items', () => {
   const meta = {
     url: '/',
   } as unknown as TinroRouteMeta;
+
+  // mock no kubernetes resources
+  vi.mocked(kubeContextStore).kubernetesCurrentContextDeployments = readable<KubernetesObject[]>([]);
+  vi.mocked(kubeContextStore).kubernetesCurrentContextServices = readable<KubernetesObject[]>([]);
+  vi.mocked(kubeContextStore).kubernetesCurrentContextIngresses = readable<KubernetesObject[]>([]);
+  vi.mocked(kubeContextStore).kubernetesCurrentContextRoutes = readable<KubernetesObject[]>([]);
 
   render(AppNavigation, {
     meta,

--- a/packages/renderer/src/AppNavigation.spec.ts
+++ b/packages/renderer/src/AppNavigation.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023,2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ const eventsMock = vi.fn();
 // fake the window object
 beforeAll(() => {
   (window as any).events = eventsMock;
+  (window as any).kubernetesGetCurrentContextResources = vi.fn().mockImplementation(() => []);
 });
 
 test('Test rendering of the navigation bar with empty items', () => {

--- a/packages/renderer/src/AppNavigation.svelte
+++ b/packages/renderer/src/AppNavigation.svelte
@@ -7,8 +7,6 @@ import { containersInfos } from './stores/containers';
 import { imagesInfos } from './stores/images';
 import { volumeListInfos } from './stores/volumes';
 import { kubernetesContexts } from './stores/kubernetes-contexts';
-import { deployments } from './stores/deployments';
-import { services } from './stores/services';
 import { ImageUtils } from './lib/image/image-utils';
 import type { ImageInfo } from '../../main/src/plugin/api/image-info';
 import ContainerIcon from './lib/images/ContainerIcon.svelte';
@@ -25,12 +23,16 @@ import DashboardIcon from './lib/images/DashboardIcon.svelte';
 import NavSection from './lib/ui/NavSection.svelte';
 import ServiceIcon from './lib/images/ServiceIcon.svelte';
 import IngressRouteIcon from './lib/images/IngressRouteIcon.svelte';
-import { ingresses } from './stores/ingresses';
-import { routes } from './stores/routes';
 import Webviews from '/@/lib/webview/Webviews.svelte';
 import { webviews } from '/@/stores/webviews';
 import PuzzleIcon from './lib/images/PuzzleIcon.svelte';
 import KubeIcon from './lib/images/KubeIcon.svelte';
+import {
+  kubernetesCurrentContextDeployments,
+  kubernetesCurrentContextIngresses,
+  kubernetesCurrentContextRoutes,
+  kubernetesCurrentContextServices,
+} from './stores/kubernetes-contexts-state';
 
 let podInfoSubscribe: Unsubscriber;
 let containerInfoSubscribe: Unsubscriber;
@@ -89,25 +91,25 @@ onMount(async () => {
       volumeCount = '';
     }
   });
-  deploymentsSubscribe = deployments.subscribe(value => {
+  deploymentsSubscribe = kubernetesCurrentContextDeployments.subscribe(value => {
     if (value.length > 0) {
       deploymentCount = ' (' + value.length + ')';
     } else {
       deploymentCount = '';
     }
   });
-  servicesSubscribe = services.subscribe(value => {
+  servicesSubscribe = kubernetesCurrentContextServices.subscribe(value => {
     if (value.length > 0) {
       serviceCount = ' (' + value.length + ')';
     } else {
       serviceCount = '';
     }
   });
-  ingressesSubscribe = ingresses.subscribe(value => {
+  ingressesSubscribe = kubernetesCurrentContextIngresses.subscribe(value => {
     ingressesCount = value.length;
     updateIngressesRoutesCount(ingressesCount + routesCount);
   });
-  routesSubscribe = routes.subscribe(value => {
+  routesSubscribe = kubernetesCurrentContextRoutes.subscribe(value => {
     routesCount = value.length;
     updateIngressesRoutesCount(ingressesCount + routesCount);
   });


### PR DESCRIPTION
### What does this PR do?

Uses the newer informers in the main navigation so that the count in the tooltips match what is on the pages.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes a part of #6259.

### How to test this PR?

Confirm tooltip counts in the main navigator match the number of items on each page.

- [x] Tests are covering the bug fix or the new feature