### PR TITLE
feat: update run image screen buttons

### DIFF
--- a/packages/renderer/src/lib/image/RunImage.svelte
+++ b/packages/renderer/src/lib/image/RunImage.svelte
@@ -5,8 +5,7 @@ import type { ContainerCreateOptions, HostConfig } from '../../../../main/src/pl
 import type { ImageInspectInfo } from '../../../../main/src/plugin/api/image-inspect-info';
 import FormPage from '../ui/FormPage.svelte';
 import type { ImageInfoUI } from './ImageInfoUI';
-import { faFolderOpen, faMinusCircle, faPlay, faPlusCircle, faXmark } from '@fortawesome/free-solid-svg-icons';
-import Fa from 'svelte-fa';
+import { faFolderOpen, faMinusCircle, faPlay, faPlusCircle } from '@fortawesome/free-solid-svg-icons';
 import { router } from 'tinro';
 import Route from '../../Route.svelte';
 import type { NetworkInspectInfo } from '../../../../main/src/plugin/api/network-info';
@@ -17,7 +16,7 @@ import ErrorMessage from '../ui/ErrorMessage.svelte';
 import { splitSpacesHandlingDoubleQuotes } from '../string/string';
 import { array2String } from '/@/lib/string/string.js';
 import Tab from '../ui/Tab.svelte';
-import Button from '../ui/Button.svelte';
+import Button from '/@/lib/ui/Button.svelte';
 import { Input } from '@podman-desktop/ui-svelte';
 
 interface PortInfo {
@@ -483,16 +482,6 @@ function deleteEnvFile(index: number) {
   environmentFiles = environmentFiles.filter((_, i) => i !== index);
 }
 
-function handleCleanValueEnvFile(
-  event: MouseEvent & {
-    currentTarget: EventTarget & HTMLButtonElement;
-  },
-  index: number,
-) {
-  environmentFiles[index] = '';
-  event.preventDefault();
-}
-
 function addHostContainerPorts() {
   hostContainerPortMappings = [
     ...hostContainerPortMappings,
@@ -678,28 +667,22 @@ async function assertAllPortAreValid(): Promise<void> {
                 {#each volumeMounts as volumeMount, index}
                   <div class="flex flex-row justify-center items-center w-full py-1">
                     <Input bind:value="{volumeMount.source}" placeholder="Path on the host" class="ml-2" />
-                    <button
+                    <Button
+                      type="link"
                       title="Open dialog to select a directory"
-                      class="ml-2 p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700"
-                      on:click="{() => browseFolders(index)}">
-                      <Fa class="h-4 w-4 text-xl" icon="{faFolderOpen}" />
-                    </button>
-                    <Input
-                      bind:value="{volumeMount.target}"
-                      placeholder="Path inside the container"
-                      class="ml-2 w-full" />
-                    <button
-                      class="ml-2 p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700"
+                      icon="{faFolderOpen}"
+                      on:click="{() => browseFolders(index)}" />
+                    <Input bind:value="{volumeMount.target}" placeholder="Path inside the container" class="ml-2" />
+                    <Button
+                      type="link"
                       hidden="{index === volumeMounts.length - 1}"
-                      on:click="{() => deleteVolumeMount(index)}">
-                      <Fa class="h-4 w-4 text-xl" icon="{faMinusCircle}" />
-                    </button>
-                    <button
-                      class="ml-2 p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700"
+                      on:click="{() => deleteVolumeMount(index)}"
+                      icon="{faMinusCircle}" />
+                    <Button
+                      type="link"
                       hidden="{index < volumeMounts.length - 1}"
-                      on:click="{addVolumeMount}">
-                      <Fa class="h-4 w-4 text-xl" icon="{faPlusCircle}" />
-                    </button>
+                      on:click="{addVolumeMount}"
+                      icon="{faPlusCircle}" />
                   </div>
                 {/each}
 
@@ -720,7 +703,7 @@ async function assertAllPortAreValid(): Promise<void> {
                   </div>
                 {/each}
 
-                <Button class="pt-3 pb-2" on:click="{addHostContainerPorts}" icon="{faPlusCircle}" type="link">
+                <Button on:click="{addHostContainerPorts}" icon="{faPlusCircle}" type="link">
                   Add custom port mapping
                 </Button>
                 <!-- Display the list of existing hostContainerPortMappings -->
@@ -732,18 +715,13 @@ async function assertAllPortAreValid(): Promise<void> {
                       aria-label="host port"
                       placeholder="Host Port"
                       error="{hostContainerPortMapping.hostPort.error}"
-                      class="w-full"
                       title="{hostContainerPortMapping.hostPort.error}" />
                     <Input
                       bind:value="{hostContainerPortMapping.containerPort}"
                       aria-label="container port"
                       placeholder="Container Port"
-                      class="ml-2 w-full" />
-                    <button
-                      class="ml-2 p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700"
-                      on:click="{() => deleteHostContainerPorts(index)}">
-                      <Fa class="h-4 w-4 text-xl" icon="{faMinusCircle}" />
-                    </button>
+                      class="ml-2" />
+                    <Button type="link" on:click="{() => deleteHostContainerPorts(index)}" icon="{faMinusCircle}" />
                   </div>
                 {/each}
                 <label for="modalEnvironmentVariables" class="pt-4 block mb-2 text-sm font-medium text-gray-400"
@@ -756,19 +734,17 @@ async function assertAllPortAreValid(): Promise<void> {
                     <Input
                       bind:value="{environmentVariable.value}"
                       placeholder="Value (leave blank for empty)"
-                      class="ml-2 w-full" />
-                    <button
-                      class="ml-2 p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700"
+                      class="ml-2" />
+                    <Button
+                      type="link"
                       hidden="{index === environmentVariables.length - 1}"
-                      on:click="{() => deleteEnvVariable(index)}">
-                      <Fa class="h-4 w-4 text-xl" icon="{faMinusCircle}" />
-                    </button>
-                    <button
-                      class="ml-2 p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700"
+                      on:click="{() => deleteEnvVariable(index)}"
+                      icon="{faMinusCircle}" />
+                    <Button
+                      type="link"
                       hidden="{index < environmentVariables.length - 1}"
-                      on:click="{addEnvVariable}">
-                      <Fa class="h-4 w-4 text-xl" icon="{faPlusCircle}" />
-                    </button>
+                      on:click="{addEnvVariable}"
+                      icon="{faPlusCircle}" />
                   </div>
                 {/each}
               </div>
@@ -780,37 +756,28 @@ async function assertAllPortAreValid(): Promise<void> {
                 <div class="flex flex-row justify-center items-center w-full py-1">
                   <div class="w-full flex">
                     <Input
-                      class="grow"
                       readonly
+                      clearable
                       placeholder="Environment file containing KEY=VALUE items"
                       bind:value="{environmentFile}"
                       aria-label="environmentFile.{index}" />
-                    <button
-                      class="relative cursor-pointer right-5"
-                      class:hidden="{!environmentFile}"
-                      aria-label="clear"
-                      on:click="{event => handleCleanValueEnvFile(event, index)}">
-                      <Fa icon="{faXmark}" />
-                    </button>
                     <Button
                       on:click="{() => selectEnvironmentFile(index)}"
                       id="filePath.{index}"
                       aria-label="button-select-env-file-{index}">Browse ...</Button>
                   </div>
-                  <button
-                    class="ml-2 p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700"
+                  <Button
+                    type="link"
                     hidden="{index === environmentFiles.length - 1}"
                     aria-label="Delete env file at index {index}"
-                    on:click="{() => deleteEnvFile(index)}">
-                    <Fa class="h-4 w-4 text-xl" icon="{faMinusCircle}" />
-                  </button>
-                  <button
-                    class="ml-2 p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700"
+                    on:click="{() => deleteEnvFile(index)}"
+                    icon="{faMinusCircle}" />
+                  <Button
+                    type="link"
                     hidden="{index < environmentFiles.length - 1}"
                     aria-label="Add env file after index {index}"
-                    on:click="{addEnvFile}">
-                    <Fa class="h-4 w-4 text-xl" icon="{faPlusCircle}" />
-                  </button>
+                    on:click="{addEnvFile}"
+                    icon="{faPlusCircle}" />
                 </div>
               {/each}
             </Route>
@@ -918,18 +885,16 @@ async function assertAllPortAreValid(): Promise<void> {
                       placeholder="Enter a security option (Ex. seccomp=/path/to/profile.json)"
                       class="ml-2" />
 
-                    <button
-                      class="ml-2 p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700"
+                    <Button
+                      type="link"
                       hidden="{index === securityOpts.length - 1}"
-                      on:click="{() => deleteSecurityOpt(index)}">
-                      <Fa class="h-4 w-4 text-xl" icon="{faMinusCircle}" />
-                    </button>
-                    <button
-                      class="ml-2 p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700"
+                      on:click="{() => deleteSecurityOpt(index)}"
+                      icon="{faMinusCircle}" />
+                    <Button
+                      type="link"
                       hidden="{index < securityOpts.length - 1}"
-                      on:click="{addSecurityOpt}">
-                      <Fa class="h-4 w-4 text-xl" icon="{faPlusCircle}" />
-                    </button>
+                      on:click="{addSecurityOpt}"
+                      icon="{faPlusCircle}" />
                   </div>
                 {/each}
 
@@ -944,18 +909,16 @@ async function assertAllPortAreValid(): Promise<void> {
                   <div class="flex flex-row justify-center items-center w-full py-1">
                     <Input bind:value="{capAdd}" placeholder="Enter a kernel capability (Ex. SYS_ADMIN)" class="ml-4" />
 
-                    <button
-                      class="ml-2 p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700"
+                    <Button
+                      type="link"
                       hidden="{index === capAdds.length - 1}"
-                      on:click="{() => deleteCapAdd(index)}">
-                      <Fa class="h-4 w-4 text-xl" icon="{faMinusCircle}" />
-                    </button>
-                    <button
-                      class="ml-2 p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700"
+                      on:click="{() => deleteCapAdd(index)}"
+                      icon="{faMinusCircle}" />
+                    <Button
+                      type="link"
                       hidden="{index < capAdds.length - 1}"
-                      on:click="{addCapAdd}">
-                      <Fa class="h-4 w-4 text-xl" icon="{faPlusCircle}" />
-                    </button>
+                      on:click="{addCapAdd}"
+                      icon="{faPlusCircle}" />
                   </div>
                 {/each}
                 <label
@@ -970,18 +933,16 @@ async function assertAllPortAreValid(): Promise<void> {
                       placeholder="Enter a kernel capability (Ex. SYS_ADMIN)"
                       class="ml-4" />
 
-                    <button
-                      class="ml-2 p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700"
+                    <Button
+                      type="link"
                       hidden="{index === capDrops.length - 1}"
-                      on:click="{() => deleteCappDrop(index)}">
-                      <Fa class="h-4 w-4 text-xl" icon="{faMinusCircle}" />
-                    </button>
-                    <button
-                      class="ml-2 p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700"
+                      on:click="{() => deleteCappDrop(index)}"
+                      icon="{faMinusCircle}" />
+                    <Button
+                      type="link"
                       hidden="{index < capDrops.length - 1}"
-                      on:click="{addCapDrop}">
-                      <Fa class="h-4 w-4 text-xl" icon="{faPlusCircle}" />
-                    </button>
+                      on:click="{addCapDrop}"
+                      icon="{faPlusCircle}" />
                   </div>
                 {/each}
 
@@ -1011,41 +972,37 @@ async function assertAllPortAreValid(): Promise<void> {
                   <div class="flex flex-row justify-center items-center w-full py-1">
                     <Input bind:value="{dnsServer}" placeholder="IP Address" class="ml-2" />
 
-                    <button
-                      class="ml-2 p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700"
+                    <Button
+                      type="link"
                       hidden="{index === dnsServers.length - 1}"
-                      on:click="{() => deleteDnsServer(index)}">
-                      <Fa class="h-4 w-4 text-xl" icon="{faMinusCircle}" />
-                    </button>
-                    <button
-                      class="ml-2 p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700"
+                      on:click="{() => deleteDnsServer(index)}"
+                      icon="{faMinusCircle}" />
+                    <Button
+                      type="link"
                       hidden="{index < dnsServers.length - 1}"
-                      on:click="{addDnsServer}">
-                      <Fa class="h-4 w-4 text-xl" icon="{faPlusCircle}" />
-                    </button>
+                      on:click="{addDnsServer}"
+                      icon="{faPlusCircle}" />
                   </div>
                 {/each}
 
                 <label for="containerExtraHosts" class="pt-4 block mb-2 text-sm font-medium text-gray-400"
                   >Add extra hosts (appends to /etc/hosts file):</label>
-                <!-- Display the list of existing environment variables -->
+                <!-- Display the list of extra hosts -->
                 {#each extraHosts as extraHost, index}
                   <div class="flex flex-row justify-center items-center w-full py-1">
-                    <Input bind:value="{extraHost.host}" placeholder="Hostname" class="ml-2 w-full" />
+                    <Input bind:value="{extraHost.host}" placeholder="Hostname" class="ml-2" />
 
-                    <Input bind:value="{extraHost.ip}" placeholder="IP Address" class="ml-2 w-full" />
-                    <button
-                      class="ml-2 p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700"
+                    <Input bind:value="{extraHost.ip}" placeholder="IP Address" class="ml-2" />
+                    <Button
+                      type="link"
                       hidden="{index === extraHosts.length - 1}"
-                      on:click="{() => deleteExtraHost(index)}">
-                      <Fa class="h-4 w-4 text-xl" icon="{faMinusCircle}" />
-                    </button>
-                    <button
-                      class="ml-2 p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700"
+                      on:click="{() => deleteExtraHost(index)}"
+                      icon="{faMinusCircle}" />
+                    <Button
+                      type="link"
                       hidden="{index < extraHosts.length - 1}"
-                      on:click="{addExtraHost}">
-                      <Fa class="h-4 w-4 text-xl" icon="{faPlusCircle}" />
-                    </button>
+                      on:click="{addExtraHost}"
+                      icon="{faPlusCircle}" />
                   </div>
                 {/each}
 

--- a/packages/ui/src/lib/input/Input.spec.ts
+++ b/packages/ui/src/lib/input/Input.spec.ts
@@ -49,6 +49,7 @@ test('Expect basic styling', async () => {
 
   const element = screen.getByPlaceholderText(value);
   expect(element).toBeInTheDocument();
+  expect(element).toHaveClass('grow');
   expect(element).toHaveClass('px-1');
   expect(element).toHaveClass('outline-0');
   expect(element).toHaveClass('bg-transparent');
@@ -75,6 +76,7 @@ test('Expect basic readonly styling', async () => {
 
   const element = screen.getByPlaceholderText(value);
   expect(element).toBeInTheDocument();
+  expect(element).toHaveClass('grow');
   expect(element).toHaveClass('px-1');
   expect(element).toHaveClass('outline-0');
   expect(element).toHaveClass('bg-transparent');
@@ -102,6 +104,7 @@ test('Expect basic disabled styling', async () => {
 
   const element = screen.getByPlaceholderText(value);
   expect(element).toBeInTheDocument();
+  expect(element).toHaveClass('grow');
   expect(element).toHaveClass('px-1');
   expect(element).toHaveClass('outline-0');
   expect(element).toHaveClass('bg-transparent');

--- a/packages/ui/src/lib/input/Input.svelte
+++ b/packages/ui/src/lib/input/Input.svelte
@@ -33,9 +33,9 @@ async function onClear(): Promise<void> {
 }
 </script>
 
-<div class="flex flex-col w-full">
+<div class="flex flex-col grow">
   <div
-    class="flex flex-row w-full items-center px-1 py-1 group bg-transparent border-[1px] border-transparent {$$props.class ||
+    class="flex flex-row grow items-center px-1 py-1 group bg-transparent border-[1px] border-transparent {$$props.class ||
       ''}"
     class:hover:bg-[var(--pd-input-field-hover-bg)]="{enabled}"
     class:focus-within:bg-[var(--pd-input-field-focused-bg)]="{enabled}"


### PR DESCRIPTION
### What does this PR do?

Switches all the buttons in the Run Images form to the Button
component. The normal button type is way too bold and stands out, and
the secondary button type has an outline and also stands out a lot,
so I've gone with 'link' since that matches the original look the most.

The Input component was using w-full where it should have been using
grow, which was causing it to overlap with buttons. Fixed and updated
test.

### Screenshot / video of UI

Before:

<img width="984" alt="Screenshot 2024-03-04 at 2 38 48 PM" src="https://github.com/containers/podman-desktop/assets/19958075/16660ab4-f16c-4d4c-890f-d14c9cb7b665">

After:

<img width="984" alt="Screenshot 2024-03-04 at 2 38 14 PM" src="https://github.com/containers/podman-desktop/assets/19958075/a68bf6b0-d5df-4de5-9276-73b16b355ef2">

### What issues does this PR fix or reference?

Fixes one part of [#6220](https://github.com/deboer-tim/desktop/issues/6220).

### How to test this PR?

Open the Run

- [x] Tests are covering the bug fix or the new feature