### PR TITLE
nit: fix width of telemetry prompt

### DIFF
--- a/packages/renderer/src/lib/welcome/WelcomePage.svelte
+++ b/packages/renderer/src/lib/welcome/WelcomePage.svelte
@@ -112,9 +112,9 @@ function closeWelcome() {
               class="w-4 h-4 rounded border-2 border-gray-700 peer peer-checked:bg-violet-500 peer-checked:border-violet-500">
             </div>
             <Fa class="w-4 h-4 absolute text-zinc-700" size="0.6x" icon="{faCheck}" />
-            <span class="font-medium font-bold px-2">Telemetry:</span>
+            <span class="font-bold px-2">Telemetry:</span>
           </label>
-          <div class="w-2/5 text-gray-400">
+          <div class="text-gray-400">
             Help Red Hat improve Podman Desktop by allowing anonymous usage data to be collected.
             <button
               class="text-violet-400 pl-1"


### PR DESCRIPTION
nit: fix width of telemetry prompt

### What does this PR do?

Has the text span the entire screen.

Removes "font-medium" as it's the same as "font-bold" (there was a
tailwind lint warning)

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

after:
![Screenshot 2024-03-04 at 2 59 05 PM](https://github.com/containers/podman-desktop/assets/6422176/d2b50146-e1ca-4fe9-a234-bf94ae62e162)

Before:
![Screenshot 2024-03-04 at 2 59 47 PM](https://github.com/containers/podman-desktop/assets/6422176/eb0110ec-0e10-4c92-a0d7-799cecdbf008)




### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop/issues/6267

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

1. Remove the telemetry and welcome options in  ~/.local/share/containers/podman-desktop/configuration/settings.json
2. `yarn watch`, and see it full width.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
