### PR TITLE
chore: add podman is installed content screen for podman onboarding

### DIFF
--- a/extensions/podman/package.json
+++ b/extensions/podman/package.json
@@ -275,9 +275,22 @@
         },
         {
           "id": "onboardingSuccess",
-          "title": "Podman successfully setup",
+          "title": "Podman Installed",
           "when": "!onboardingContext:podmanIsNotInstalled",
-          "state": "completed"
+          "state": "completed",
+          "content": [
+            [
+              {
+                "value": "Podman is installed!"
+              }
+            ],
+            [
+              {
+                "value": "#### How to use podman \nRun `podman help` in the terminal for a list of commands to interact with Podman. For example, try the 'Create' button within the Containers tab of Podman Desktop and view your containers with `podman`:\n\n`$ podman ps`",
+                "highlight": true
+              }
+            ]
+          ]
         }
       ],
       "enablement": "(isLinux && onboardingContext:podmanIsNotInstalled) || (!isLinux && !onboardingContext:podmanMachineExists)"


### PR DESCRIPTION
chore: add podman is installed content screen for podman onboarding

### What does this PR do?

Adds "Podman is installed" onboarding content similar to how we have it
for both Compose and Kubectl.

This gives the user some more information on what to do with the
installed podman CLI.

This also provides more information in case the onboarding is "re-ran"
again.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

![Screenshot 2024-03-04 at 3 32 00 PM](https://github.com/containers/podman-desktop/assets/6422176/11b58aa5-eb6c-4f03-a51a-6d417ed8551c)


### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop/issues/6269

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

1. Go through the onboarding again
2. See the final screen has been updated

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
