### PR TITLE
fix: update authentication settings page after auth provider disposed

### DIFF
--- a/packages/main/src/plugin/authentication.spec.ts
+++ b/packages/main/src/plugin/authentication.spec.ts
@@ -23,11 +23,10 @@ import type {
   AuthenticationSessionAccountInformation,
   Event,
 } from '@podman-desktop/api';
-import { beforeEach, expect, test, vi } from 'vitest';
+import { beforeEach, afterEach, expect, test, vi } from 'vitest';
 import type { ApiSenderType } from './api.js';
 import { AuthenticationImpl } from './authentication.js';
 import { Emitter as EventEmitter } from './events/emitter.js';
-import { afterEach } from 'node:test';
 
 function randomNumber(n = 5): number {
   return Math.round(Math.random() * 10 * n);

--- a/packages/main/src/plugin/authentication.spec.ts
+++ b/packages/main/src/plugin/authentication.spec.ts
@@ -76,7 +76,7 @@ beforeEach(function () {
   authModule = new AuthenticationImpl(apiSender);
 });
 
-afterEach(function () {
+afterEach(() => {
   vi.resetAllMocks();
 });
 

--- a/packages/main/src/plugin/authentication.ts
+++ b/packages/main/src/plugin/authentication.ts
@@ -130,6 +130,7 @@ export class AuthenticationImpl {
       dispose: (): void => {
         onDidChangeSessionDisposable.dispose();
         this._authenticationProviders.delete(id);
+        this.apiSender.send('authentication-provider-update', { id });
       },
     };
   }


### PR DESCRIPTION
### What does this PR do?

It sends event to UI to update Authentication settings after authentication provider disposal.

### Screenshot / video of UI


https://github.com/containers/podman-desktop/assets/620330/c34546bb-acbc-4413-89f7-a4f0cbde5b97


### What issues does this PR fix or reference?

Fix #6273.
Fix https://github.com/redhat-developer/podman-desktop-redhat-account-ext/issues/67.

### How to test this PR?

See video of UI

- [x] Tests are covering the bug fix or the new feature
