### PR TITLE
chore: enable prefering nullish operator

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -80,6 +80,7 @@
     "@typescript-eslint/no-floating-promises": "error",
     "@typescript-eslint/no-misused-promises": "error",
     "@typescript-eslint/prefer-optional-chain": "error",
+    "@typescript-eslint/prefer-nullish-coalescing": "error",
     "no-null/no-null": "error",
 
     /**

--- a/extensions/compose/tsconfig.json
+++ b/extensions/compose/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "strictNullChecks": true,
     "target": "esnext",
     "module": "esnext",
     "moduleResolution": "Node",

--- a/extensions/docker/tsconfig.json
+++ b/extensions/docker/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "strictNullChecks": true,
     "lib": ["ES2017", "webworker"],
     "sourceMap": true,
     "rootDir": "src",

--- a/extensions/kind/tsconfig.json
+++ b/extensions/kind/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "strictNullChecks": true,
     "target": "esnext",
     "module": "esnext",
     "moduleResolution": "Node",

--- a/extensions/kube-context/tsconfig.json
+++ b/extensions/kube-context/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "strictNullChecks": true,
     "lib": ["ES2017", "webworker"],
     "sourceMap": true,
     "rootDir": "src",

--- a/extensions/kubectl-cli/tsconfig.json
+++ b/extensions/kubectl-cli/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "strictNullChecks": true,
     "target": "esnext",
     "module": "esnext",
     "moduleResolution": "Node",

--- a/extensions/lima/tsconfig.json
+++ b/extensions/lima/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "strictNullChecks": true,
     "lib": ["ES2017", "webworker"],
     "sourceMap": true,
     "rootDir": "src",

--- a/extensions/podman/tsconfig.json
+++ b/extensions/podman/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "strictNullChecks": true,
     "lib": ["ES2017"],
     "sourceMap": true,
     "rootDir": "src",

--- a/extensions/registries/tsconfig.json
+++ b/extensions/registries/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "strictNullChecks": true,
     "module": "esnext",
     "lib": ["ES2017"],
     "sourceMap": true,

--- a/packages/extension-api/tsconfig.json
+++ b/packages/extension-api/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "strictNullChecks": true,
     "target": "esnext",
     "module": "node16",
     "baseUrl": ".",

--- a/packages/main/tsconfig.json
+++ b/packages/main/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "strictNullChecks": true,
     "module": "node16",
     "target": "esnext",
     "sourceMap": false,

--- a/packages/preload-docker-extension/tsconfig.json
+++ b/packages/preload-docker-extension/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "strictNullChecks": true,
     "module": "esnext",
     "target": "esnext",
     "sourceMap": false,

--- a/packages/preload-webview/tsconfig.json
+++ b/packages/preload-webview/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "strictNullChecks": true,
     "module": "esnext",
     "target": "esnext",
     "sourceMap": false,

--- a/packages/preload/tsconfig.json
+++ b/packages/preload/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "strictNullChecks": true,
     "module": "esnext",
     "target": "esnext",
     "sourceMap": false,

--- a/packages/renderer/tsconfig.json
+++ b/packages/renderer/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@tsconfig/svelte/tsconfig.json",
   "compilerOptions": {
+    "strictNullChecks": true,
     "target": "esnext",
     "module": "esnext",
     "strict": true,

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@tsconfig/svelte/tsconfig.json",
   "compilerOptions": {
+    "strictNullChecks": true,
     "target": "esnext",
     "module": "esnext",
     "strict": true,


### PR DESCRIPTION
chore: enable prefering nullish operator

### What does this PR do?

Bad habit of using || when it should be ??

This enables erroring out for `yarn lint:fix` where it should be ?? instead of
||

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/A

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

N/A

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

N/A

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
