### PR TITLE
chore: kubectl is installed screen onboarding match other extensions

### DIFF
--- a/extensions/kubectl-cli/package.json
+++ b/extensions/kubectl-cli/package.json
@@ -107,13 +107,13 @@
         },
         {
           "id": "installSystemWideSuccess",
-          "title": "kubectl Successfully Installed",
+          "title": "kubectl Installed",
           "when": "kubectl.isKubectlInstalledSystemWide",
           "state": "completed",
           "content": [
             [
               {
-                "value": "kubectl has been successfully installed system-wide!"
+                "value": "kubectl is installed system-wide!"
               }
             ],
             [


### PR DESCRIPTION
chore: kubectl is installed screen onboarding match other extensions

### What does this PR do?

To match other extensions such as podman as well as compose, have the
last screen say "is installed".

This helps global onboarding when the onboarding has been "re-ran"
despite it not needing setup. So when you get to this screen after
checks, it will just say "Is installed".

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/A

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

References: https://github.com/containers/podman-desktop/pull/6270

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

See updated last page on onboarding for kubectl

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
