### PR TITLE
Fix podman machine onboarding test in CI

### DIFF
--- a/.github/workflows/e2e-main.yaml
+++ b/.github/workflows/e2e-main.yaml
@@ -91,6 +91,7 @@ jobs:
       - name: Run All E2E tests
         env:
           PODMANDESKTOP_CI_BOT_TOKEN: ${{ secrets.PODMANDESKTOP_CI_BOT_TOKEN }}
+          TEST_PODMAN_MACHINE: 'true'
         run: yarn test:e2e
 
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
A machine was already present in podman at the moment of podman-machine-onboarding test execution

Adding this variable will enable machine cleanup in the `beforeAll` step and prevent cleanup after the test is done executing

### What does this PR do?
* Updates workflow to fix the test failure https://github.com/containers/podman-desktop/actions/runs/8187311750/job/22387817204

### Screenshot / video of UI
[podman-machine-e2e.webm](https://github.com/containers/podman-desktop/assets/16451875/8ef4a766-b01b-49ad-951a-c369962607ed)
![ApplicationFrameHost_vcLy8PQV4d](https://github.com/containers/podman-desktop/assets/16451875/e88956b3-bc1b-4a67-896c-fb89d8d52074)

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
N/A - hotfix
Follow-up of #4670 
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?
N/A
<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
