### PR TITLE
fix: send kubernetes-context-update event when kubeconfig file created/deleted

### DIFF
--- a/packages/main/src/plugin/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes-client.ts
@@ -230,11 +230,13 @@ export class KubernetesClient {
     this.kubeConfigWatcher.onDidCreate(async () => {
       this._onDidUpdateKubeconfig.fire({ type: 'CREATE', location });
       await this.refresh();
+      this.apiSender.send('kubernetes-context-update');
     });
 
     this.kubeConfigWatcher.onDidDelete(() => {
       this._onDidUpdateKubeconfig.fire({ type: 'DELETE', location });
       this.kubeConfig = new KubeConfig();
+      this.apiSender.send('kubernetes-context-update');
     });
   }
 


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

send kubernetes-context-update event when kubeconfig file
is created or deleted.

### What issues does this PR fix or reference?

Fixes #6305 

### How to test this PR?

1. Rename your ~/.kube/config to another name
2. Start Podman Desktop, create a minikube or kind cluster
3. Go to the Kubernetes Contexts page, a new context should appear for the new cluster
4. Delete the created ~/.kube/config
5. Go to the Kubernetes Contexts page, the context should have disappeared
6. (Restore you original ~/.kube/config file)

- [x] Tests are covering the bug fix or the new feature
