### PR TITLE
nit: podman is installed onboarding, have screen for settings say settings

### DIFF
--- a/extensions/podman/package.json
+++ b/extensions/podman/package.json
@@ -249,7 +249,7 @@
         },
         {
           "id": "installationSuccessView",
-          "title": "${onboardingContext:installationSuccessViewTitle}",
+          "title": "Podman settings",
           "when": "!onboardingContext:podmanIsNotInstalled",
           "content": [
             [

--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -1122,11 +1122,6 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
       const installation = await getPodmanInstallation();
       const installed = installation ? true : false;
       extensionApi.context.setValue('podmanIsNotInstalled', !installed, 'onboarding');
-      if (installed) {
-        extensionApi.context.setValue('installationSuccessViewTitle', 'Podman already installed', 'onboarding');
-      } else {
-        extensionApi.context.setValue('installationSuccessViewTitle', 'Podman successfully installed', 'onboarding');
-      }
       telemetryLogger.logUsage('podman.onboarding.checkInstalledCommand', {
         status: installed,
         version: installation?.version || '',


### PR DESCRIPTION
nit: podman is installed onboarding, have screen for settings say settings

### What does this PR do?

When going through onboarding, when it reaches the page full of
settings, it should say "Podman Settings", not "podman installed /
succesfully installed".

As the next screen will show "Podman Installed" anyways.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

![Screenshot 2024-03-07 at 9 34 13 AM](https://github.com/containers/podman-desktop/assets/6422176/ca5013c9-be94-49ca-9b18-20ce89efb206)


### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop/issues/6306

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

1. Go through onboarding again, see that it now says settings.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
