### PR TITLE
nit: fix capitalizations in onboarding titles

### DIFF
--- a/extensions/compose/package.json
+++ b/extensions/compose/package.json
@@ -45,7 +45,7 @@
         {
           "id": "welcomeDownloadView",
           "label": "Compose Download",
-          "title": "Compose Download",
+          "title": "Compose download",
           "when": "!compose.isComposeInstalledSystemWide && onboardingContext:composeIsNotDownloaded",
           "content": [
             [
@@ -79,13 +79,13 @@
         },
         {
           "id": "downloadFailure",
-          "title": "Failed Downloading Compose",
+          "title": "Failed downloading Compose",
           "when": "!compose.isComposeInstalledSystemWide && onboardingContext:composeIsNotDownloaded",
           "state": "failed"
         },
         {
           "id": "downloadSuccessfulView",
-          "title": "Compose Successfully Downloaded",
+          "title": "Compose successfully Downloaded",
           "when": "!compose.isComposeInstalledSystemWide && !onboardingContext:composeIsNotDownloaded",
           "content": [
             [
@@ -107,13 +107,13 @@
         },
         {
           "id": "installSystemWideFailure",
-          "title": "Failed Installing Compose",
+          "title": "Failed installing Compose",
           "when": "!compose.isComposeInstalledSystemWide && !compose.isComposeInstalledSystemWide",
           "state": "failed"
         },
         {
           "id": "installSystemWideSuccess",
-          "title": "Compose Installed",
+          "title": "Compose installed",
           "when": "compose.isComposeInstalledSystemWide",
           "state": "completed",
           "content": [

--- a/extensions/kubectl-cli/package.json
+++ b/extensions/kubectl-cli/package.json
@@ -45,7 +45,7 @@
         {
           "id": "welcomeDownloadView",
           "label": "kubectl Download",
-          "title": "kubectl Download",
+          "title": "kubectl download",
           "when": "!kubectl.isKubectlInstalledSystemWide && onboardingContext:kubectlIsNotDownloaded",
           "content": [
             [
@@ -73,13 +73,13 @@
         },
         {
           "id": "downloadFailure",
-          "title": "Failed Downloading kubectl",
+          "title": "Failed downloading kubectl",
           "when": "!kubectl.isKubectlInstalledSystemWide && onboardingContext:kubectlIsNotDownloaded",
           "state": "failed"
         },
         {
           "id": "downloadSuccessfulView",
-          "title": "kubectl Successfully Downloaded",
+          "title": "kubectl successfully downloaded",
           "when": "!kubectl.isKubectlInstalledSystemWide && !onboardingContext:kubectlIsNotDownloaded",
           "content": [
             [
@@ -101,13 +101,13 @@
         },
         {
           "id": "installSystemWideFailure",
-          "title": "Failed Installing kubectl",
+          "title": "Failed installing kubectl",
           "when": "!kubectl.isKubectlInstalledSystemWide && !kubectl.isKubectlInstalledSystemWide",
           "state": "failed"
         },
         {
           "id": "installSystemWideSuccess",
-          "title": "kubectl Installed",
+          "title": "kubectl installed",
           "when": "kubectl.isKubectlInstalledSystemWide",
           "state": "completed",
           "content": [

--- a/extensions/podman/package.json
+++ b/extensions/podman/package.json
@@ -275,7 +275,7 @@
         },
         {
           "id": "onboardingSuccess",
-          "title": "Podman Installed",
+          "title": "Podman installed",
           "when": "!onboardingContext:podmanIsNotInstalled",
           "state": "completed",
           "content": [


### PR DESCRIPTION
nit: fix capitalizations in onboarding titles

### What does this PR do?

Fixes all the capitalization in the "titles" within extensions.

I noticed that capitalization is inconsistent between the steps.

Words like Podman should be capitalized which is the extension name
(with the exception of `kubectl`), while other words should not be
capitalized.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/A really, just see code.

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Noticed in https://github.com/containers/podman-desktop/pull/5271

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

Go through onboarding

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
