### PR TITLE
nit: remove "is installed" repeating in onboarding

### DIFF
--- a/extensions/compose/package.json
+++ b/extensions/compose/package.json
@@ -119,11 +119,6 @@
           "content": [
             [
               {
-                "value": "Compose is installed system-wide!"
-              }
-            ],
-            [
-              {
                 "value": "#### How to use Compose\nRun `podman compose up` (podman CLI v4.7.0+) or `docker-compose` in a directory with a `compose.yaml`. Podman Desktop will automatically detect the Compose deployment and show it in the container list.'\n\n`$ podman compose up`",
                 "highlight": true
               }

--- a/extensions/kubectl-cli/package.json
+++ b/extensions/kubectl-cli/package.json
@@ -113,11 +113,6 @@
           "content": [
             [
               {
-                "value": "kubectl is installed system-wide!"
-              }
-            ],
-            [
-              {
                 "value": "#### How to use kubectl \nRun `kubectl help` in the terminal for a list of commands to interact with your Kubernetes cluster. For example, try the 'Deploy to Kubernetes' button within Podman Desktop and view your pods with `kubectl`:\n\n`$ kubectl get pods`",
                 "highlight": true
               }

--- a/extensions/podman/package.json
+++ b/extensions/podman/package.json
@@ -281,11 +281,6 @@
           "content": [
             [
               {
-                "value": "Podman is installed!"
-              }
-            ],
-            [
-              {
                 "value": "#### How to use podman \nRun `podman help` in the terminal for a list of commands to interact with Podman. For example, try the 'Create' button within the Containers tab of Podman Desktop and view your containers with `podman`:\n\n`$ podman ps`",
                 "highlight": true
               }


### PR DESCRIPTION
nit: remove "is installed" repeating in onboarding

### What does this PR do?

Removes the "is installed" repeating message in onboarding. The title is
already shown (ex. Podman installed!) so no need to re-repeat it.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

![Screenshot 2024-03-07 at 9 44 33 AM](https://github.com/containers/podman-desktop/assets/6422176/40d15786-f405-48e8-b037-5de45ac3ab50)


### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

References: https://github.com/containers/podman-desktop/pull/5271

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

N/A

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
