### PR TITLE
fix: small input installing extension

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesExtensionList.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesExtensionList.svelte
@@ -95,13 +95,11 @@ async function updateExtension(extension: ExtensionInfo, ociUri: string) {
             aria-label="OCI Image Name"
             bind:value="{ociImage}"
             placeholder="Name of the Image"
-            class="w-1/2"
             required />
 
           <Button
             on:click="{() => installExtensionFromImage()}"
             disabled="{ociImage === undefined || ociImage.trim() === ''}"
-            class="w-full"
             inProgress="{installInProgress}"
             icon="{faArrowCircleDown}">
             Install extension from the OCI image


### PR DESCRIPTION
### What does this PR do?

When I removed w-full from Input in #6266, it caused a regression in the Settings > Extension page.

I think I was able to find all other Inputs, and confirmed none of them have this issue.

### Screenshot / video of UI

Before:

<img width="611" alt="Screenshot 2024-03-07 at 10 19 34 AM" src="https://github.com/containers/podman-desktop/assets/19958075/ee1d488b-a648-4316-beca-79181e8e57e3">

After:

<img width="611" alt="Screenshot 2024-03-07 at 10 18 59 AM" src="https://github.com/containers/podman-desktop/assets/19958075/cd92dc7b-0b15-4ced-b0c7-697067c1560d">

### What issues does this PR fix or reference?

Fixes #6311.

### How to test this PR?

Go to Settings > Extensions.