### PR TITLE
nit: no right margin in menus

### DIFF
--- a/packages/renderer/src/lib/ui/DropdownMenu.spec.ts
+++ b/packages/renderer/src/lib/ui/DropdownMenu.spec.ts
@@ -28,6 +28,7 @@ test('Expect the onBeforeToggle function to be called when the menu is clicked',
   });
 
   const toggleMenuButton = screen.getByRole('button', { name: 'kebab menu' });
+  expect(toggleMenuButton).not.toHaveClass('mr-2');
   expect(toggleMenuButton).toBeInTheDocument();
   await fireEvent.click(toggleMenuButton);
 

--- a/packages/renderer/src/lib/ui/DropdownMenu.svelte
+++ b/packages/renderer/src/lib/ui/DropdownMenu.svelte
@@ -54,7 +54,7 @@ function onWindowClick(e: any) {
       bind:this="{outsideWindow}"
       class="text-gray-400 {shownAsMenuActionItem
         ? 'bg-charcoal-800 px-3'
-        : 'hover:bg-charcoal-800 mr-2'} hover:text-purple-400 font-medium rounded-md inline-flex items-center px-2 py-2 text-center">
+        : 'hover:bg-charcoal-800'} hover:text-purple-400 font-medium rounded-md inline-flex items-center px-2 py-2 text-center">
       <Fa class="h-4 w-4" icon="{icon}" />
     </button>
 


### PR DESCRIPTION
### What does this PR do?

Our drop-down menus have a right margin, which means there is always a small unused/white-space to the right.

The margin was added in Nov 2022 when the hover behaviour was added and I can't find any reason for it. (maybe the main pages at the time needed the actions moved from the right edge of the window?) I've been through everywhere we use this component today, and removing the margin had the same minor layout improvement in all cases.

### Screenshot / video of UI

Before:

<img width="176" alt="Screenshot 2024-03-07 at 10 33 33 AM" src="https://github.com/containers/podman-desktop/assets/19958075/06b7bdb0-5beb-41f9-b039-f20447439524">

After:

<img width="176" alt="Screenshot 2024-03-07 at 10 34 00 AM" src="https://github.com/containers/podman-desktop/assets/19958075/0f859e40-ad21-4480-890d-7c51aa3d6eaa">

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Hover over right-most action in any of the Images/Pods/Containers pages to see the padding is now consistent top/right/bottom.

- [x] Tests are covering the bug fix or the new feature
