### PR TITLE
chore: align registry actions right

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesRegistriesEditing.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRegistriesEditing.svelte
@@ -314,7 +314,7 @@ function removeExistingRegistry(registry: containerDesktopAPI.Registry) {
                 </div>
                 <!-- Password field end -->
               </div>
-              <div class="text-sm w-1/5 flex flex-row space-x-2" role="cell">
+              <div class="text-sm w-1/5 flex flex-row space-x-2 justify-end" role="cell">
                 <!-- Show/hide password start -->
                 {#if registry.username && registry.secret}
                   {#if showPasswordForServerUrls.some(r => r === registry.serverUrl)}
@@ -419,7 +419,7 @@ function removeExistingRegistry(registry: containerDesktopAPI.Registry) {
                     )}" />
               {/if}
             </div>
-            <div class="text-sm w-1/5" role="cell">
+            <div class="text-sm w-1/5 flex space-x-2 justify-end" role="cell">
               {#if listedSuggestedRegistries[i]}
                 <Button
                   on:click="{() => loginToRegistry(newRegistryRequest)}"
@@ -469,7 +469,7 @@ function removeExistingRegistry(registry: containerDesktopAPI.Registry) {
                 on:action="{() =>
                   setPasswordForRegistryVisible(newRegistryRequest, !showPasswordForServerUrls.some(r => r === ''))}" />
             </div>
-            <div class="text-sm w-1/5" role="cell">
+            <div class="text-sm w-1/5 flex space-x-2 justify-end" role="cell">
               <Button
                 on:click="{() => loginToRegistry(newRegistryRequest)}"
                 disabled="{!newRegistryRequest.serverUrl || !newRegistryRequest.username || !newRegistryRequest.secret}"


### PR DESCRIPTION
### What does this PR do?

When we merged #5965 there was a comment that some of the actions used to be right-aligned (it wasn't totally consistent) but our design language always has actions in the last 'column' aligned to the right. I said I'd follow up, this just changes all of the actions to be right for consistency, and added some missing space-x-2s.

### Screenshot / video of UI

Before:

<img width="272" alt="Screenshot 2024-03-07 at 10 47 45 AM" src="https://github.com/containers/podman-desktop/assets/19958075/c85740de-bf3a-46fa-8943-9b4c72b242e7">

After:

<img width="272" alt="Screenshot 2024-03-07 at 10 48 10 AM" src="https://github.com/containers/podman-desktop/assets/19958075/0a03edf4-cc60-473a-8c39-7ed5649e6607">

The first row isn't perfectly aligned on the right (more obvious when you hover over the action), but that's fixed by #6314.

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Go to Settings > Registries.