### PR TITLE
nit: adds temporary fix for rendering bug for podman global onboarding

### DIFF
--- a/extensions/podman/package.json
+++ b/extensions/podman/package.json
@@ -279,6 +279,8 @@
           "when": "!onboardingContext:podmanIsNotInstalled",
           "state": "completed",
           "content": [
+            [],
+            [],
             [
               {
                 "value": "#### How to use podman \nRun `podman help` in the terminal for a list of commands to interact with Podman. For example, try the 'Create' button within the Containers tab of Podman Desktop and view your containers with `podman`:\n\n`$ podman ps`",


### PR DESCRIPTION
nit: adds temporary fix for rendering bug for podman global onboarding

### What does this PR do?

This adds a temporary fix for global onboarding that adds two extra
"contents" to forcefully re-render / override the "cache" content that
still lingers despite going to a different screen.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

https://github.com/containers/podman-desktop/assets/6422176/97ca850f-75b4-4a46-93a8-fbd1e7b6270a



### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Reference: https://github.com/containers/podman-desktop/issues/6313

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature

Do global onboarding:
1. Delete ` ~/.local/share/containers/podman-desktop/configuration/settings.json`, or remote 'welcome: initial' part.
2. Go through onboarding and you should no longer see the configuration
   "autostart" appearing on the last screen.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
