### PR TITLE
feat: remember window position and size of Podman Desktop window

### DIFF
--- a/packages/main/src/index.ts
+++ b/packages/main/src/index.ts
@@ -28,6 +28,7 @@ import { StartupInstall } from './system/startup-install.js';
 import type { ExtensionLoader } from './plugin/extension-loader.js';
 import dns from 'node:dns';
 import { Deferred } from './plugin/util/deferred.js';
+import { WindowInit } from './system/window/window-init.js';
 
 let extensionLoader: ExtensionLoader | undefined;
 
@@ -214,6 +215,11 @@ app.whenReady().then(
 
     // Get the configuration registry (saves all our settings)
     const configurationRegistry = extensionLoader.getConfigurationRegistry();
+
+    // Register the window configuration
+    // This is used to save/restore the window size and position
+    const windowInit = new WindowInit(configurationRegistry);
+    windowInit.init();
 
     // If we've manually set the tray icon color, update the tray icon. This can only be done
     // after configurationRegistry is loaded. Windows or Linux support only for icon color change.

--- a/packages/main/src/system/window/window-handler.spec.ts
+++ b/packages/main/src/system/window/window-handler.spec.ts
@@ -1,0 +1,115 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import type { ConfigurationRegistry } from '/@/plugin/configuration-registry.js';
+import { WindowHandler } from './window-handler.js';
+import type { BrowserWindow } from 'electron';
+import type { Configuration } from '@podman-desktop/api';
+import { WindowSettings } from './window-settings.js';
+
+let windowHandler: WindowHandler;
+
+const configurationMock = {
+  get: vi.fn(),
+  update: vi.fn(),
+} as unknown as Configuration;
+
+const getConfigurationMock = vi.fn();
+
+const configurationRegistryMock = {
+  getConfiguration: getConfigurationMock,
+} as unknown as ConfigurationRegistry;
+
+const browserWindowMock = {
+  setSize: vi.fn(),
+  setPosition: vi.fn(),
+  getSize: vi.fn(),
+  getPosition: vi.fn(),
+} as unknown as BrowserWindow;
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  getConfigurationMock.mockReturnValue(configurationMock);
+  windowHandler = new WindowHandler(browserWindowMock, configurationRegistryMock);
+});
+
+describe('restore window', () => {
+  test('perform restore should be skipped if configuration is disabled', async () => {
+    vi.mocked(configurationMock.get).mockReturnValueOnce(false);
+
+    windowHandler.restore();
+
+    // should be the directory provided as env var
+    expect(configurationRegistryMock.getConfiguration).toBeCalledWith('window');
+
+    // first call should be false
+    expect(getConfigurationMock).toBeCalledWith('window');
+
+    // only one call to get the configuration
+    expect(vi.mocked(configurationMock.get)).toBeCalledTimes(1);
+
+    expect(vi.mocked(browserWindowMock).setSize).not.toBeCalled();
+    expect(vi.mocked(browserWindowMock).setPosition).not.toBeCalled();
+  });
+
+  test('perform restore if configuration is enabled', async () => {
+    vi.mocked(configurationMock.get).mockReturnValueOnce(true);
+    vi.mocked(configurationMock.get).mockReturnValueOnce(1024);
+    vi.mocked(configurationMock.get).mockReturnValueOnce(768);
+    vi.mocked(configurationMock.get).mockReturnValueOnce(100);
+    vi.mocked(configurationMock.get).mockReturnValueOnce(200);
+
+    windowHandler.restore();
+
+    // should be the directory provided as env var
+    expect(configurationRegistryMock.getConfiguration).toBeCalledWith('window');
+
+    // first call should be false
+    expect(getConfigurationMock).toBeCalledWith('window');
+
+    // 5 calls to get the configuration
+    expect(vi.mocked(configurationMock.get)).toBeCalledTimes(5);
+
+    expect(vi.mocked(browserWindowMock).setSize).toBeCalledWith(1024, 768);
+    expect(vi.mocked(browserWindowMock).setPosition).toBeCalledWith(100, 200);
+  });
+});
+
+describe('save window', () => {
+  test('perform save', async () => {
+    vi.mocked(browserWindowMock.getSize).mockReturnValue([1024, 768]);
+    vi.mocked(browserWindowMock.getPosition).mockReturnValue([100, 200]);
+    vi.mocked(configurationMock.get).mockReturnValueOnce(false);
+
+    // perform 5 save in a row
+    windowHandler.savePositionAndSize();
+    windowHandler.savePositionAndSize();
+    windowHandler.savePositionAndSize();
+    windowHandler.savePositionAndSize();
+    windowHandler.savePositionAndSize();
+
+    // wait that this.#browserWindow.getSize is called
+    await vi.waitFor(() => expect(vi.mocked(browserWindowMock.getSize)).toHaveBeenCalled());
+
+    expect(configurationMock.update).toBeCalledWith(WindowSettings.Width, 1024);
+    expect(configurationMock.update).toBeCalledWith(WindowSettings.Height, 768);
+    expect(configurationMock.update).toBeCalledWith(WindowSettings.XPosition, 100);
+    expect(configurationMock.update).toBeCalledWith(WindowSettings.YPosition, 200);
+  });
+});

--- a/packages/main/src/system/window/window-handler.ts
+++ b/packages/main/src/system/window/window-handler.ts
@@ -1,0 +1,79 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { BrowserWindow } from 'electron';
+import type { ConfigurationRegistry } from '/@/plugin/configuration-registry.js';
+import { WindowSettings } from './window-settings.js';
+
+/**
+ * Handle save and restore of the window position and size.
+ */
+export class WindowHandler {
+  readonly #browserWindow: BrowserWindow;
+  readonly #configurationRegistry: ConfigurationRegistry;
+
+  #debounceSaveTimeout: NodeJS.Timeout | undefined;
+
+  constructor(browserWindow: BrowserWindow, configurationRegistry: ConfigurationRegistry) {
+    this.#browserWindow = browserWindow;
+    this.#configurationRegistry = configurationRegistry;
+  }
+
+  // try to restore the window position and size
+  restore(): void {
+    // grab value of the width and height from the configuration
+    const windowPreferences = this.#configurationRegistry.getConfiguration(WindowSettings.SectionName);
+    const restore = windowPreferences.get<boolean>(WindowSettings.RestorePosition);
+    if (!restore) {
+      return;
+    }
+    const width = windowPreferences.get<number>(WindowSettings.Width);
+    const height = windowPreferences.get<number>(WindowSettings.Height);
+    if (width && height && typeof width === 'number' && typeof height === 'number' && width > 0 && height > 0) {
+      this.#browserWindow.setSize(width, height);
+    }
+    const xPosition = windowPreferences.get<number>(WindowSettings.XPosition);
+    const yPosition = windowPreferences.get<number>(WindowSettings.YPosition);
+    if (xPosition && yPosition && typeof xPosition === 'number' && typeof yPosition === 'number') {
+      this.#browserWindow.setPosition(xPosition, yPosition);
+    }
+  }
+
+  // save the window position but using debounce to avoid calling it too often
+  savePositionAndSize(): void {
+    if (this.#debounceSaveTimeout) {
+      clearTimeout(this.#debounceSaveTimeout);
+    }
+    // call the doSavePositionAndSize after 300ms if no other call to savePositionAndSize is made
+    this.#debounceSaveTimeout = setTimeout(() => {
+      this.doSavePositionAndSize().catch((e: unknown) => {
+        console.error('Error saving window position and size', e);
+      });
+    }, 300);
+  }
+
+  protected async doSavePositionAndSize(): Promise<void> {
+    const [width, height] = this.#browserWindow.getSize();
+    const [x, y] = this.#browserWindow.getPosition();
+    const windowPreferences = this.#configurationRegistry.getConfiguration(WindowSettings.SectionName);
+    await windowPreferences?.update(WindowSettings.Width, width);
+    await windowPreferences?.update(WindowSettings.Height, height);
+    await windowPreferences?.update(WindowSettings.XPosition, x);
+    await windowPreferences?.update(WindowSettings.YPosition, y);
+  }
+}

--- a/packages/main/src/system/window/window-init.spec.ts
+++ b/packages/main/src/system/window/window-init.spec.ts
@@ -1,0 +1,57 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { beforeEach, expect, test, vi } from 'vitest';
+import type { ConfigurationRegistry } from '/@/plugin/configuration-registry.js';
+import { WindowInit } from './window-init.js';
+
+let windowInit: WindowInit;
+
+const registerConfigurationsMock = vi.fn();
+
+const configurationRegistryMock = {
+  registerConfigurations: registerConfigurationsMock,
+} as unknown as ConfigurationRegistry;
+
+beforeEach(() => {
+  windowInit = new WindowInit(configurationRegistryMock);
+});
+test('should register a configuration', async () => {
+  // register configuration
+  windowInit.init();
+
+  // should be the directory provided as env var
+  expect(configurationRegistryMock.registerConfigurations).toBeCalled();
+
+  // take first argument of first call
+  const configurationNode = vi.mocked(configurationRegistryMock).registerConfigurations.mock.calls[0][0][0];
+  expect(configurationNode.id).toBe('preferences.window');
+  expect(configurationNode.title).toBe('Window');
+  expect(configurationNode.type).toBe('object');
+  expect(configurationNode.properties).toBeDefined();
+  expect(configurationNode.properties?.['window.height']).toBeDefined();
+  expect(configurationNode.properties?.['window.height'].description).toBe('Height of the window');
+  expect(configurationNode.properties?.['window.restorePosition'].type).toBe('boolean');
+  expect(configurationNode.properties?.['window.restorePosition'].description).toBe(
+    'Restore position and size of the window after a restart',
+  );
+  expect(configurationNode.properties?.['window.width']).toBeDefined();
+  expect(configurationNode.properties?.['window.xPosition']).toBeDefined();
+  expect(configurationNode.properties?.['window.yPosition']).toBeDefined();
+  expect(configurationNode.properties?.['window.restorePosition'].default).toBeTruthy();
+});

--- a/packages/main/src/system/window/window-init.ts
+++ b/packages/main/src/system/window/window-init.ts
@@ -1,0 +1,75 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { IConfigurationNode, IConfigurationRegistry } from '/@/plugin/configuration-registry.js';
+import { WindowSettings } from './window-settings.js';
+
+/**
+ * Save/Restore the window size and position.
+ */
+export class WindowInit {
+  readonly #configurationRegistry: IConfigurationRegistry;
+
+  constructor(configurationRegistry: IConfigurationRegistry) {
+    this.#configurationRegistry = configurationRegistry;
+  }
+
+  init(): void {
+    const heightKey = `${WindowSettings.SectionName}.${WindowSettings.Height}`;
+    const widthKey = `${WindowSettings.SectionName}.${WindowSettings.Width}`;
+    const xPositionKey = `${WindowSettings.SectionName}.${WindowSettings.XPosition}`;
+    const yPositionKey = `${WindowSettings.SectionName}.${WindowSettings.YPosition}`;
+    const restorePosition = `${WindowSettings.SectionName}.${WindowSettings.RestorePosition}`;
+
+    const windowConfiguration: IConfigurationNode = {
+      id: 'preferences.window',
+      title: 'Window',
+      type: 'object',
+      properties: {
+        [heightKey]: {
+          description: 'Height of the window',
+          type: 'number',
+          hidden: true,
+        },
+        [widthKey]: {
+          description: 'Width of the window',
+          type: 'number',
+          hidden: true,
+        },
+        [xPositionKey]: {
+          description: 'x position of the window',
+          type: 'number',
+          hidden: true,
+        },
+        [yPositionKey]: {
+          description: 'y position of the window',
+          type: 'number',
+          hidden: true,
+        },
+        [restorePosition]: {
+          description: 'Restore position and size of the window after a restart',
+          type: 'boolean',
+          default: true,
+          hidden: false,
+        },
+      },
+    };
+
+    this.#configurationRegistry.registerConfigurations([windowConfiguration]);
+  }
+}

--- a/packages/main/src/system/window/window-settings.ts
+++ b/packages/main/src/system/window/window-settings.ts
@@ -1,0 +1,26 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+export enum WindowSettings {
+  SectionName = 'window',
+  Height = 'height',
+  Width = 'width',
+  XPosition = 'xPosition',
+  YPosition = 'yPosition',
+  RestorePosition = 'restorePosition',
+}


### PR DESCRIPTION
### What does this PR do?
Save and restore the window position where it was before closing Podman Desktop

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/6115

### How to test this PR?

start podman desktop, move and resize the window. Then exit and restart
Check that it's at the same position than before

you can disable it through the settings/preferences (window)

- [x] Tests are covering the bug fix or the new feature
