### PR TITLE
Initialize the context store

### DIFF
--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -2112,6 +2112,10 @@ export class PluginSystem {
         });
       },
     );
+    this.ipcHandle(
+      'context:collectAllValues',
+      async (): Promise<Record<string, unknown>> => context.collectAllValues(),
+    );
 
     const dockerDesktopInstallation = new DockerDesktopInstallation(
       apiSender,

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -1979,6 +1979,10 @@ export function initExposure(): void {
   contextBridge.exposeInMainWorld('listGuides', async (): Promise<Guide[]> => {
     return ipcInvoke('learning-center:listGuides');
   });
+
+  contextBridge.exposeInMainWorld('contextCollectAllValues', async (): Promise<Record<string, unknown>> => {
+    return ipcInvoke('context:collectAllValues');
+  });
 }
 
 // expose methods

--- a/packages/renderer/src/Loader.spec.ts
+++ b/packages/renderer/src/Loader.spec.ts
@@ -22,6 +22,9 @@ import { beforeAll, expect, test, vi } from 'vitest';
 import Loader from './Loader.svelte';
 import { render } from '@testing-library/svelte';
 import { router } from 'tinro';
+import * as contextStore from '/@/stores/context';
+import { writable } from 'svelte/store';
+import { ContextUI } from './lib/context/context';
 
 // first, patch window object
 const callbacks = new Map<string, any>();
@@ -43,6 +46,12 @@ vi.mock('tinro', () => {
   };
 });
 
+vi.mock('/@/stores/context', async () => {
+  return {
+    context: vi.fn(),
+  };
+});
+
 Object.defineProperty(global, 'window', {
   value: {
     events: {
@@ -59,6 +68,7 @@ Object.defineProperty(global, 'window', {
 beforeAll(() => {
   vi.resetAllMocks();
   vi.clearAllMocks();
+  vi.mocked(contextStore).context = writable(new ContextUI());
 });
 
 test('Loader should redirect to the installation page when receiving the event', async () => {

--- a/packages/renderer/src/lib/actions/ContributionActions.spec.ts
+++ b/packages/renderer/src/lib/actions/ContributionActions.spec.ts
@@ -20,8 +20,17 @@ import '@testing-library/jest-dom/vitest';
 import { beforeAll, test, expect, vi } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/svelte';
 import ContributionActions from '/@/lib/actions/ContributionActions.svelte';
+import * as contextStore from '/@/stores/context';
+import { writable } from 'svelte/store';
+import { ContextUI } from '../context/context';
 
 const executeCommand = vi.fn();
+
+vi.mock('/@/stores/context', async () => {
+  return {
+    context: vi.fn(),
+  };
+});
 
 beforeAll(() => {
   (window as any).executeCommand = executeCommand;
@@ -33,6 +42,7 @@ beforeAll(() => {
       func();
     },
   };
+  vi.mocked(contextStore).context = writable(new ContextUI());
 });
 
 test('Expect no ListItemButtonIcon', async () => {

--- a/packages/renderer/src/lib/compose/ComposeActions.spec.ts
+++ b/packages/renderer/src/lib/compose/ComposeActions.spec.ts
@@ -22,6 +22,9 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import ComposeActions from './ComposeActions.svelte';
 import type { ComposeInfoUI } from './ComposeInfoUI';
 import type { ContainerInfoUI } from '../container/ContainerInfoUI';
+import * as contextStore from '/@/stores/context';
+import { writable } from 'svelte/store';
+import { ContextUI } from '../context/context';
 
 const compose: ComposeInfoUI = {
   engineId: 'podman',
@@ -43,6 +46,12 @@ const getContributedMenusMock = vi.fn();
 const updateMock = vi.fn();
 const showMessageBoxMock = vi.fn();
 
+vi.mock('/@/stores/context', async () => {
+  return {
+    context: vi.fn(),
+  };
+});
+
 beforeEach(() => {
   (window as any).showMessageBox = showMessageBoxMock;
   (window as any).startContainersByLabel = vi.fn();
@@ -52,6 +61,7 @@ beforeEach(() => {
 
   (window as any).getContributedMenus = getContributedMenusMock;
   getContributedMenusMock.mockImplementation(() => Promise.resolve([]));
+  vi.mocked(contextStore).context = writable(new ContextUI());
 });
 
 afterEach(() => {

--- a/packages/renderer/src/lib/compose/ComposeDetails.spec.ts
+++ b/packages/renderer/src/lib/compose/ComposeDetails.spec.ts
@@ -6,7 +6,9 @@ import { mockBreadcrumb } from '../../stores/breadcrumb.spec';
 import type { ContainerInspectInfo } from '@podman-desktop/api';
 import { containersInfos } from '../../stores/containers';
 import { providerInfos } from '../../stores/providers';
-import { get } from 'svelte/store';
+import { get, writable } from 'svelte/store';
+import * as contextStore from '/@/stores/context';
+import { ContextUI } from '../context/context';
 
 const listContainersMock = vi.fn();
 const getProviderInfosMock = vi.fn();
@@ -15,6 +17,12 @@ const getContributedMenusMock = vi.fn();
 vi.mock('xterm', () => {
   return {
     Terminal: vi.fn().mockReturnValue({ loadAddon: vi.fn(), open: vi.fn(), write: vi.fn(), clear: vi.fn() }),
+  };
+});
+
+vi.mock('/@/stores/context', async () => {
+  return {
+    context: vi.fn(),
   };
 });
 
@@ -45,6 +53,7 @@ beforeAll(() => {
   (window as any).getContributedMenus = getContributedMenusMock;
   getContributedMenusMock.mockImplementation(() => Promise.resolve([]));
   mockBreadcrumb();
+  vi.mocked(contextStore).context = writable(new ContextUI());
 });
 
 async function waitRender(name: string, engineId: string): Promise<void> {

--- a/packages/renderer/src/lib/container/ContainerActions.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerActions.spec.ts
@@ -21,12 +21,21 @@ import { test, expect, vi, beforeEach, afterEach } from 'vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import ContainerActions from './ContainerActions.svelte';
 import type { ContainerInfoUI } from './ContainerInfoUI';
+import * as contextStore from '/@/stores/context';
+import { writable } from 'svelte/store';
+import { ContextUI } from '../context/context';
 
 const container: ContainerInfoUI = {} as ContainerInfoUI;
 
 const getContributedMenusMock = vi.fn();
 const updateMock = vi.fn();
 const showMessageBoxMock = vi.fn();
+
+vi.mock('/@/stores/context', async () => {
+  return {
+    context: vi.fn(),
+  };
+});
 
 beforeEach(() => {
   (window as any).showMessageBox = showMessageBoxMock;
@@ -37,6 +46,7 @@ beforeEach(() => {
 
   (window as any).getContributedMenus = getContributedMenusMock;
   getContributedMenusMock.mockImplementation(() => Promise.resolve([]));
+  vi.mocked(contextStore).context = writable(new ContextUI());
 });
 
 afterEach(() => {

--- a/packages/renderer/src/lib/container/ContainerDetails.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerDetails.spec.ts
@@ -21,12 +21,14 @@ import { test, expect, vi, beforeAll } from 'vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 
 import ContainerDetails from './ContainerDetails.svelte';
-import { get } from 'svelte/store';
+import { get, writable } from 'svelte/store';
 import { containersInfos } from '/@/stores/containers';
 import type { ContainerInfo } from '../../../../main/src/plugin/api/container-info';
 
 import { router } from 'tinro';
 import { lastPage } from '/@/stores/breadcrumb';
+import * as contextStore from '/@/stores/context';
+import { ContextUI } from '../context/context';
 
 const listContainersMock = vi.fn();
 
@@ -59,6 +61,12 @@ vi.mock('xterm', () => {
   };
 });
 
+vi.mock('/@/stores/context', async () => {
+  return {
+    context: vi.fn(),
+  };
+});
+
 beforeAll(() => {
   (window as any).showMessageBox = showMessageBoxMock;
   (window as any).listContainers = listContainersMock;
@@ -75,6 +83,7 @@ beforeAll(() => {
 
   (window as any).getContributedMenus = getContributedMenusMock;
   getContributedMenusMock.mockImplementation(() => Promise.resolve([]));
+  vi.mocked(contextStore).context = writable(new ContextUI());
 });
 
 test('Expect logs when tty is not enabled', async () => {

--- a/packages/renderer/src/lib/container/ContainerList.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerList.spec.ts
@@ -23,9 +23,11 @@ import { beforeAll, test, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/svelte';
 import ContainerList from './ContainerList.svelte';
 import { containersInfos } from '../../stores/containers';
-import { get } from 'svelte/store';
+import { get, writable } from 'svelte/store';
 import { providerInfos } from '../../stores/providers';
 import userEvent from '@testing-library/user-event';
+import * as contextStore from '/@/stores/context';
+import { ContextUI } from '../context/context';
 
 const listContainersMock = vi.fn();
 const getProviderInfosMock = vi.fn();
@@ -37,6 +39,12 @@ const removePodMock = vi.fn();
 const listPodsMock = vi.fn();
 
 const kubernetesListPodsMock = vi.fn();
+
+vi.mock('/@/stores/context', async () => {
+  return {
+    context: vi.fn(),
+  };
+});
 
 // fake the window.events object
 beforeAll(() => {
@@ -61,6 +69,7 @@ beforeAll(() => {
       func();
     },
   };
+  vi.mocked(contextStore).context = writable(new ContextUI());
 });
 
 async function waitRender(customProperties: object): Promise<void> {

--- a/packages/renderer/src/lib/container/ContainerListCompose.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerListCompose.spec.ts
@@ -23,8 +23,10 @@ import { beforeAll, test, expect, vi } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/svelte';
 import ContainerList from './ContainerList.svelte';
 import { containersInfos } from '../../stores/containers';
-import { get } from 'svelte/store';
+import { get, writable } from 'svelte/store';
 import { providerInfos } from '../../stores/providers';
+import * as contextStore from '/@/stores/context';
+import { ContextUI } from '../context/context';
 
 const listContainersMock = vi.fn();
 const getProviderInfosMock = vi.fn();
@@ -36,6 +38,12 @@ const listPodsMock = vi.fn();
 const kubernetesListPodsMock = vi.fn();
 
 const deleteContainersByLabelMock = vi.fn();
+
+vi.mock('/@/stores/context', async () => {
+  return {
+    context: vi.fn(),
+  };
+});
 
 // fake the window.events object
 beforeAll(() => {
@@ -62,6 +70,7 @@ beforeAll(() => {
       func();
     },
   };
+  vi.mocked(contextStore).context = writable(new ContextUI());
 });
 
 async function waitRender(customProperties: object): Promise<void> {

--- a/packages/renderer/src/lib/deployments/DeploymentActions.spec.ts
+++ b/packages/renderer/src/lib/deployments/DeploymentActions.spec.ts
@@ -21,6 +21,9 @@ import { test, expect, vi, beforeEach, afterEach } from 'vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import DeploymentActions from './DeploymentActions.svelte';
 import type { DeploymentUI } from './DeploymentUI';
+import * as contextStore from '/@/stores/context';
+import { writable } from 'svelte/store';
+import { ContextUI } from '../context/context';
 
 const updateMock = vi.fn();
 const deleteMock = vi.fn();
@@ -35,8 +38,15 @@ const deployment: DeploymentUI = {
   conditions: [],
 };
 
+vi.mock('/@/stores/context', async () => {
+  return {
+    context: vi.fn(),
+  };
+});
+
 beforeEach(() => {
   (window as any).kubernetesDeleteDeployment = deleteMock;
+  vi.mocked(contextStore).context = writable(new ContextUI());
 });
 
 afterEach(() => {

--- a/packages/renderer/src/lib/deployments/DeploymentColumnActions.spec.ts
+++ b/packages/renderer/src/lib/deployments/DeploymentColumnActions.spec.ts
@@ -17,11 +17,24 @@
  ***********************************************************************/
 
 import '@testing-library/jest-dom/vitest';
-import { test, expect } from 'vitest';
+import { test, expect, beforeAll, vi } from 'vitest';
 import { render, screen } from '@testing-library/svelte';
 
 import type { DeploymentUI } from './DeploymentUI';
 import DeploymentColumnActions from './DeploymentColumnActions.svelte';
+import * as contextStore from '/@/stores/context';
+import { writable } from 'svelte/store';
+import { ContextUI } from '../context/context';
+
+vi.mock('/@/stores/context', async () => {
+  return {
+    context: vi.fn(),
+  };
+});
+
+beforeAll(() => {
+  vi.mocked(contextStore).context = writable(new ContextUI());
+});
 
 test('Expect action buttons', async () => {
   const deployment: DeploymentUI = {

--- a/packages/renderer/src/lib/deployments/DeploymentDetails.spec.ts
+++ b/packages/renderer/src/lib/deployments/DeploymentDetails.spec.ts
@@ -27,6 +27,8 @@ import { lastPage } from '/@/stores/breadcrumb';
 import type { V1Deployment, KubernetesObject } from '@kubernetes/client-node';
 import * as kubeContextStore from '/@/stores/kubernetes-contexts-state';
 import { writable } from 'svelte/store';
+import * as contextStore from '/@/stores/context';
+import { ContextUI } from '../context/context';
 
 const kubernetesDeleteDeploymentMock = vi.fn();
 
@@ -50,9 +52,16 @@ vi.mock('/@/stores/kubernetes-contexts-state', async () => {
   };
 });
 
+vi.mock('/@/stores/context', async () => {
+  return {
+    context: vi.fn(),
+  };
+});
+
 beforeAll(() => {
   (window as any).kubernetesDeleteDeployment = kubernetesDeleteDeploymentMock;
   (window as any).kubernetesReadNamespacedDeployment = vi.fn();
+  vi.mocked(contextStore).context = writable(new ContextUI());
 });
 
 test('Expect redirect to previous page if deployment is deleted', async () => {

--- a/packages/renderer/src/lib/deployments/DeploymentsList.spec.ts
+++ b/packages/renderer/src/lib/deployments/DeploymentsList.spec.ts
@@ -22,14 +22,23 @@ import '@testing-library/jest-dom/vitest';
 import { test, expect, vi, beforeEach, beforeAll } from 'vitest';
 import { render, screen, within } from '@testing-library/svelte';
 import DeploymentsList from './DeploymentsList.svelte';
-import { get } from 'svelte/store';
+import { get, writable } from 'svelte/store';
 import type { V1Deployment } from '@kubernetes/client-node';
 import { kubernetesCurrentContextDeployments } from '/@/stores/kubernetes-contexts-state';
+import * as contextStore from '/@/stores/context';
+import { ContextUI } from '../context/context';
 
 const kubernetesRegisterGetCurrentContextResourcesMock = vi.fn();
 
+vi.mock('/@/stores/context', async () => {
+  return {
+    context: vi.fn(),
+  };
+});
+
 beforeAll(() => {
   (window as any).kubernetesRegisterGetCurrentContextResources = kubernetesRegisterGetCurrentContextResourcesMock;
+  vi.mocked(contextStore).context = writable(new ContextUI());
 });
 
 beforeEach(() => {

--- a/packages/renderer/src/lib/dialogs/CommandPalette.spec.ts
+++ b/packages/renderer/src/lib/dialogs/CommandPalette.spec.ts
@@ -24,11 +24,19 @@ import { render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import CommandPalette from './CommandPalette.svelte';
 import { commandsInfos } from '/@/stores/commands';
-import { context } from '/@/stores/context';
+import * as contextStore from '/@/stores/context';
+import { writable } from 'svelte/store';
+import { ContextUI } from '../context/context';
 
 const receiveFunctionMock = vi.fn();
 
 const COMMAND_PALETTE_ARIA_LABEL = 'Command palette command input';
+
+vi.mock('/@/stores/context', async () => {
+  return {
+    context: vi.fn(),
+  };
+});
 
 const executeCommandMock = vi.fn();
 // mock some methods of the window object
@@ -41,6 +49,7 @@ beforeAll(() => {
   window.HTMLElement.prototype.scrollIntoView = vi.fn();
 
   (window as any).executeCommand = executeCommandMock;
+  vi.mocked(contextStore).context = writable(new ContextUI());
 });
 
 beforeEach(() => {
@@ -348,7 +357,7 @@ describe('Command Palette', () => {
     ]);
 
     // set the context property
-    context.update(ctx => {
+    vi.mocked(contextStore).context.update(ctx => {
       ctx.setValue('myProperty', 'myValue');
       return ctx;
     });

--- a/packages/renderer/src/lib/image/ImageActions.spec.ts
+++ b/packages/renderer/src/lib/image/ImageActions.spec.ts
@@ -21,6 +21,9 @@ import { test, expect, vi, beforeAll } from 'vitest';
 import { render, screen, waitFor, fireEvent } from '@testing-library/svelte';
 import ImageActions from '/@/lib/image/ImageActions.svelte';
 import type { ImageInfoUI } from '/@/lib/image/ImageInfoUI';
+import * as contextStore from '/@/stores/context';
+import { writable } from 'svelte/store';
+import { ContextUI } from '../context/context';
 
 const showMessageBoxMock = vi.fn();
 const getContributedMenusMock = vi.fn();
@@ -33,12 +36,19 @@ vi.mock('./image-utils', () => {
   };
 });
 
+vi.mock('/@/stores/context', async () => {
+  return {
+    context: vi.fn(),
+  };
+});
+
 beforeAll(() => {
   (window as any).showMessageBox = showMessageBoxMock;
 
   (window as any).getContributedMenus = getContributedMenusMock;
   (window as any).hasAuthconfigForImage = vi.fn();
   (window as any).hasAuthconfigForImage.mockImplementation(() => Promise.resolve(false));
+  vi.mocked(contextStore).context = writable(new ContextUI());
 });
 
 const fakedImage: ImageInfoUI = {

--- a/packages/renderer/src/lib/image/ImageDetails.spec.ts
+++ b/packages/renderer/src/lib/image/ImageDetails.spec.ts
@@ -21,7 +21,7 @@ import { describe, test, expect, vi, afterEach, beforeEach } from 'vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 
 import ImageDetails from './ImageDetails.svelte';
-import { get } from 'svelte/store';
+import { get, writable } from 'svelte/store';
 import { imagesInfos } from '/@/stores/images';
 import type { ImageInfo } from '../../../../main/src/plugin/api/image-info';
 
@@ -39,6 +39,8 @@ import {
   IMAGE_VIEW_ICONS,
 } from '../view/views';
 import { viewsContributions } from '/@/stores/views';
+import * as contextStore from '/@/stores/context';
+import { ContextUI } from '../context/context';
 
 const listImagesMock = vi.fn();
 const getContributedMenusMock = vi.fn();
@@ -66,6 +68,12 @@ delete myNoneNameImage.RepoTags;
 const deleteImageMock = vi.fn();
 const hasAuthMock = vi.fn();
 
+vi.mock('/@/stores/context', async () => {
+  return {
+    context: vi.fn(),
+  };
+});
+
 beforeEach(() => {
   (window as any).showMessageBox = showMessageBoxMock;
   imagesInfos.set([]);
@@ -77,6 +85,7 @@ beforeEach(() => {
 
   (window as any).getContributedMenus = getContributedMenusMock;
   getContributedMenusMock.mockImplementation(() => Promise.resolve([]));
+  vi.mocked(contextStore).context = writable(new ContextUI());
 });
 
 afterEach(() => {

--- a/packages/renderer/src/lib/image/ImagesList.spec.ts
+++ b/packages/renderer/src/lib/image/ImagesList.spec.ts
@@ -23,14 +23,22 @@ import { test, expect, vi, beforeEach, describe } from 'vitest';
 import { render, screen } from '@testing-library/svelte';
 import ImagesList from './ImagesList.svelte';
 import { imagesInfos } from '../../stores/images';
-import { get } from 'svelte/store';
+import { get, writable } from 'svelte/store';
 import { providerInfos } from '../../stores/providers';
 import { viewsContributions } from '/@/stores/views';
 import { IMAGE_LIST_VIEW_BADGES, IMAGE_LIST_VIEW_ICONS, IMAGE_VIEW_BADGES, IMAGE_VIEW_ICONS } from '../view/views';
+import * as contextStore from '/@/stores/context';
+import { ContextUI } from '../context/context';
 
 const listImagesMock = vi.fn();
 const getProviderInfosMock = vi.fn();
 const listViewsContributionsMock = vi.fn();
+
+vi.mock('/@/stores/context', async () => {
+  return {
+    context: vi.fn(),
+  };
+});
 
 // fake the window.events object
 beforeEach(() => {
@@ -57,6 +65,7 @@ beforeEach(() => {
       func();
     },
   };
+  vi.mocked(contextStore).context = writable(new ContextUI());
 });
 
 async function waitRender(customProperties: object): Promise<void> {

--- a/packages/renderer/src/lib/ingresses-routes/IngressDetails.spec.ts
+++ b/packages/renderer/src/lib/ingresses-routes/IngressDetails.spec.ts
@@ -27,6 +27,8 @@ import { lastPage } from '/@/stores/breadcrumb';
 import type { V1Ingress, KubernetesObject } from '@kubernetes/client-node';
 import * as kubeContextStore from '/@/stores/kubernetes-contexts-state';
 import { writable } from 'svelte/store';
+import * as contextStore from '/@/stores/context';
+import { ContextUI } from '../context/context';
 
 const kubernetesDeleteIngressMock = vi.fn();
 
@@ -44,9 +46,16 @@ vi.mock('/@/stores/kubernetes-contexts-state', async () => {
   };
 });
 
+vi.mock('/@/stores/context', async () => {
+  return {
+    context: vi.fn(),
+  };
+});
+
 beforeAll(() => {
   (window as any).kubernetesDeleteIngress = kubernetesDeleteIngressMock;
   (window as any).kubernetesReadNamespacedIngress = vi.fn();
+  vi.mocked(contextStore).context = writable(new ContextUI());
 });
 
 test('Expect redirect to previous page if ingress is deleted', async () => {

--- a/packages/renderer/src/lib/ingresses-routes/IngressRouteActions.spec.ts
+++ b/packages/renderer/src/lib/ingresses-routes/IngressRouteActions.spec.ts
@@ -22,14 +22,24 @@ import { fireEvent, render, screen } from '@testing-library/svelte';
 import type { IngressUI } from './IngressUI';
 import IngressRouteActions from './IngressRouteActions.svelte';
 import type { RouteUI } from './RouteUI';
+import * as contextStore from '/@/stores/context';
+import { writable } from 'svelte/store';
+import { ContextUI } from '../context/context';
 
 const updateMock = vi.fn();
 const deleteIngressMock = vi.fn();
 const deleteRoutesMock = vi.fn();
 
+vi.mock('/@/stores/context', async () => {
+  return {
+    context: vi.fn(),
+  };
+});
+
 beforeEach(() => {
   (window as any).kubernetesDeleteIngress = deleteIngressMock;
   (window as any).kubernetesDeleteRoute = deleteRoutesMock;
+  vi.mocked(contextStore).context = writable(new ContextUI());
 });
 
 afterEach(() => {

--- a/packages/renderer/src/lib/ingresses-routes/IngressRouteColumnActions.spec.ts
+++ b/packages/renderer/src/lib/ingresses-routes/IngressRouteColumnActions.spec.ts
@@ -17,12 +17,25 @@
  ***********************************************************************/
 
 import '@testing-library/jest-dom/vitest';
-import { test, expect } from 'vitest';
+import { test, expect, beforeEach, vi } from 'vitest';
 import { render, screen } from '@testing-library/svelte';
 
 import IngressRouteColumnActions from './IngressRouteColumnActions.svelte';
 import type { IngressUI } from './IngressUI';
 import type { RouteUI } from './RouteUI';
+import * as contextStore from '/@/stores/context';
+import { writable } from 'svelte/store';
+import { ContextUI } from '../context/context';
+
+vi.mock('/@/stores/context', async () => {
+  return {
+    context: vi.fn(),
+  };
+});
+
+beforeEach(() => {
+  vi.mocked(contextStore).context = writable(new ContextUI());
+});
 
 test('Expect action buttons with ingress object', async () => {
   const ingressUI: IngressUI = {

--- a/packages/renderer/src/lib/ingresses-routes/IngressesRoutesList.spec.ts
+++ b/packages/renderer/src/lib/ingresses-routes/IngressesRoutesList.spec.ts
@@ -27,6 +27,8 @@ import IngressesRoutesList from './IngressesRoutesList.svelte';
 import type { V1Route } from '../../../../main/src/plugin/api/openshift-types';
 import * as kubeContextStore from '/@/stores/kubernetes-contexts-state';
 import type { ContextGeneralState } from '../../../../main/src/plugin/kubernetes-context-state';
+import * as contextStore from '/@/stores/context';
+import { ContextUI } from '../context/context';
 
 vi.mock('/@/stores/kubernetes-contexts-state', async () => {
   return {
@@ -44,11 +46,18 @@ vi.mock('/@/stores/kubernetes-contexts-state', async () => {
   };
 });
 
+vi.mock('/@/stores/context', async () => {
+  return {
+    context: vi.fn(),
+  };
+});
+
 beforeEach(() => {
   vi.resetAllMocks();
   vi.clearAllMocks();
   (window as any).kubernetesGetContextsGeneralState = () => Promise.resolve(new Map());
   (window as any).kubernetesGetCurrentContextGeneralState = () => Promise.resolve({});
+  vi.mocked(contextStore).context = writable(new ContextUI());
 });
 
 async function waitRender(customProperties: object): Promise<void> {

--- a/packages/renderer/src/lib/ingresses-routes/RouteDetails.spec.ts
+++ b/packages/renderer/src/lib/ingresses-routes/RouteDetails.spec.ts
@@ -28,6 +28,8 @@ import type { V1Route } from '../../../../main/src/plugin/api/openshift-types';
 import type { KubernetesObject } from '@kubernetes/client-node';
 import * as kubeContextStore from '/@/stores/kubernetes-contexts-state';
 import { writable } from 'svelte/store';
+import * as contextStore from '/@/stores/context';
+import { ContextUI } from '../context/context';
 
 const kubernetesDeleteRouteMock = vi.fn();
 
@@ -59,9 +61,16 @@ vi.mock('/@/stores/kubernetes-contexts-state', async () => {
   };
 });
 
+vi.mock('/@/stores/context', async () => {
+  return {
+    context: vi.fn(),
+  };
+});
+
 beforeAll(() => {
   (window as any).kubernetesDeleteRoute = kubernetesDeleteRouteMock;
   (window as any).kubernetesReadNamespacedRoute = vi.fn();
+  vi.mocked(contextStore).context = writable(new ContextUI());
 });
 
 test('Expect redirect to previous page if route is deleted', async () => {

--- a/packages/renderer/src/lib/onboarding/Onboarding.spec.ts
+++ b/packages/renderer/src/lib/onboarding/Onboarding.spec.ts
@@ -16,13 +16,14 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 import '@testing-library/jest-dom/vitest';
-import { test, expect, vi } from 'vitest';
+import { test, expect, vi, beforeAll } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/svelte';
 import Onboarding from './Onboarding.svelte';
 import { ContextUI } from '../context/context';
 import { onboardingList } from '/@/stores/onboarding';
-import { context } from '/@/stores/context';
 import userEvent from '@testing-library/user-event';
+import * as contextStore from '/@/stores/context';
+import { writable } from 'svelte/store';
 
 async function waitRender(customProperties: object): Promise<void> {
   const result = render(Onboarding, { ...customProperties });
@@ -36,6 +37,16 @@ global.ResizeObserver = vi.fn().mockImplementation(() => ({
   observe: vi.fn(),
   unobserve: vi.fn(),
 }));
+
+vi.mock('/@/stores/context', async () => {
+  return {
+    context: vi.fn(),
+  };
+});
+
+beforeAll(() => {
+  vi.mocked(contextStore).context = writable(new ContextUI());
+});
 
 test('Expect to have the "Try again" and Cancel buttons if the step represent a failed state', async () => {
   (window as any).resetOnboarding = vi.fn();
@@ -56,7 +67,7 @@ test('Expect to have the "Try again" and Cancel buttons if the step represent a 
       enablement: 'true',
     },
   ]);
-  context.set(new ContextUI());
+  vi.mocked(contextStore).context.set(new ContextUI());
   await waitRender({
     extensionIds: ['id'],
   });
@@ -87,7 +98,7 @@ test('Expect not to have the "Try again" and "Cancel" buttons if the step repres
       enablement: 'true',
     },
   ]);
-  context.set(new ContextUI());
+  vi.mocked(contextStore).context.set(new ContextUI());
   await waitRender({
     extensionIds: ['id'],
   });
@@ -118,7 +129,7 @@ test('Expect to have the "Step Body" div if the step does not include a componen
       enablement: 'true',
     },
   ]);
-  context.set(new ContextUI());
+  vi.mocked(contextStore).context.set(new ContextUI());
   await waitRender({
     extensionIds: ['id'],
   });
@@ -148,7 +159,7 @@ test('Expect to have the embedded component if the step includes a component', a
       enablement: 'true',
     },
   ]);
-  context.set(new ContextUI());
+  vi.mocked(contextStore).context.set(new ContextUI());
   await waitRender({
     extensionIds: ['id'],
   });
@@ -186,7 +197,7 @@ test('Expect content to show / render when when clause is true', async () => {
       enablement: 'true',
     },
   ]);
-  context.set(new ContextUI());
+  vi.mocked(contextStore).context.set(new ContextUI());
   await waitRender({
     extensionIds: ['id'],
   });
@@ -222,7 +233,7 @@ test('Expect content to NOT show / render when when clause is false', async () =
       enablement: 'true',
     },
   ]);
-  context.set(new ContextUI());
+  vi.mocked(contextStore).context.set(new ContextUI());
   await waitRender({
     extensionIds: ['id'],
   });
@@ -235,7 +246,7 @@ test('Expect content with "when" to change dynamically when setting has been upd
   (window as any).updateStepState = vi.fn();
 
   const contextConfig = new ContextUI();
-  context.set(contextConfig);
+  vi.mocked(contextStore).context.set(contextConfig);
   contextConfig.setValue('config.test', false);
 
   onboardingList.set([
@@ -285,7 +296,7 @@ test('Expect Step Body to clean up if new step has no content to display.', asyn
   (window as any).updateStepState = vi.fn();
 
   const contextConfig = new ContextUI();
-  context.set(contextConfig);
+  vi.mocked(contextStore).context.set(contextConfig);
   contextConfig.setValue('config.test', false);
 
   onboardingList.set([
@@ -342,7 +353,7 @@ test('Expect that Esc closes', async () => {
   (window as any).updateStepState = vi.fn();
 
   const contextConfig = new ContextUI();
-  context.set(contextConfig);
+  vi.mocked(contextStore).context.set(contextConfig);
   contextConfig.setValue('config.test', false);
 
   onboardingList.set([

--- a/packages/renderer/src/lib/onboarding/OnboardingComponent.spec.ts
+++ b/packages/renderer/src/lib/onboarding/OnboardingComponent.spec.ts
@@ -22,6 +22,9 @@ import OnboardingComponent from './OnboardingComponent.svelte';
 import { configurationProperties } from '/@/stores/configurationProperties';
 import { providerInfos } from '/@/stores/providers';
 import type { ProviderInfo } from '../../../../main/src/plugin/api/provider-info';
+import * as contextStore from '/@/stores/context';
+import { writable } from 'svelte/store';
+import { ContextUI } from '../context/context';
 
 const providerInfo: ProviderInfo = {
   id: 'podman',
@@ -64,6 +67,12 @@ async function waitRender(customProperties: any): Promise<void> {
   }
 }
 
+vi.mock('/@/stores/context', async () => {
+  return {
+    context: vi.fn(),
+  };
+});
+
 beforeAll(() => {
   (window as any).getConfigurationValue = vi.fn();
   (window as any).updateConfigurationValue = vi.fn();
@@ -83,6 +92,8 @@ beforeAll(() => {
       };
     },
   });
+
+  vi.mocked(contextStore).context = writable(new ContextUI());
 });
 
 test('Expect to find PreferencesConnectionCreationRendering component if step includes "create" component', async () => {

--- a/packages/renderer/src/lib/onboarding/OnboardingItem.spec.ts
+++ b/packages/renderer/src/lib/onboarding/OnboardingItem.spec.ts
@@ -16,14 +16,25 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 import '@testing-library/jest-dom/vitest';
-import { test, expect, vi } from 'vitest';
+import { test, expect, vi, beforeAll } from 'vitest';
 import { render, screen } from '@testing-library/svelte';
 import OnboardingItem from './OnboardingItem.svelte';
 import type { OnboardingStepItem } from '../../../../main/src/plugin/api/onboarding';
-import { context } from '/@/stores/context';
 import { configurationProperties } from '/@/stores/configurationProperties';
 import { CONFIGURATION_ONBOARDING_SCOPE } from '../../../../main/src/plugin/configuration-registry-constants';
 import { ContextUI } from '../context/context';
+import * as contextStore from '/@/stores/context';
+import { writable } from 'svelte/store';
+
+vi.mock('/@/stores/context', async () => {
+  return {
+    context: vi.fn(),
+  };
+});
+
+beforeAll(() => {
+  vi.mocked(contextStore).context = writable(new ContextUI());
+});
 
 test('Expect button html when passing a button tag in markdown', async () => {
   const textComponent: OnboardingStepItem = {
@@ -59,7 +70,7 @@ test('Expect placeholders are replaced when passing a text component with placeh
   };
   const globalContext = new ContextUI();
   globalContext.setValue('extension.onboarding.text', 'placeholder content');
-  context.set(globalContext);
+  vi.mocked(contextStore).context.set(globalContext);
   render(OnboardingItem, {
     extension: 'extension',
     item: textComponent,
@@ -205,7 +216,7 @@ test('Expect value rendered is updated if context value is updated', async () =>
   };
   const globalContext = new ContextUI();
   globalContext.setValue('extension.onboarding.text', 'first value');
-  context.set(globalContext);
+  vi.mocked(contextStore).context.set(globalContext);
   render(OnboardingItem, {
     extension: 'extension',
     item: textComponent,
@@ -217,7 +228,7 @@ test('Expect value rendered is updated if context value is updated', async () =>
 
   // simulate the value in context is updated
   globalContext.setValue('extension.onboarding.text', 'second value');
-  context.set(globalContext);
+  vi.mocked(contextStore).context.set(globalContext);
 
   await new Promise(resolve => setTimeout(resolve, 100));
   const markdownSection2 = screen.getByLabelText('markdown-content');

--- a/packages/renderer/src/lib/pod/PodActions.spec.ts
+++ b/packages/renderer/src/lib/pod/PodActions.spec.ts
@@ -22,6 +22,9 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import PodActions from './PodActions.svelte';
 import type { PodInfoUI } from './PodInfoUI';
 import type { ContainerInfo, Port } from '@podman-desktop/api';
+import * as contextStore from '/@/stores/context';
+import { writable } from 'svelte/store';
+import { ContextUI } from '../context/context';
 
 const podmanPod: PodInfoUI = {
   id: 'pod',
@@ -45,6 +48,12 @@ const showMessageBoxMock = vi.fn();
 const kubernetesGetCurrentNamespaceMock = vi.fn();
 const kubernetesReadNamespacedPodMock = vi.fn();
 
+vi.mock('/@/stores/context', async () => {
+  return {
+    context: vi.fn(),
+  };
+});
+
 beforeEach(() => {
   (window as any).showMessageBox = showMessageBoxMock;
   (window as any).kubernetesDeletePod = vi.fn();
@@ -65,6 +74,7 @@ beforeEach(() => {
 
   (window as any).getContributedMenus = getContributedMenusMock;
   getContributedMenusMock.mockResolvedValue([]);
+  vi.mocked(contextStore).context = writable(new ContextUI());
 });
 
 afterEach(() => {

--- a/packages/renderer/src/lib/pod/PodColumnActions.spec.ts
+++ b/packages/renderer/src/lib/pod/PodColumnActions.spec.ts
@@ -23,9 +23,18 @@ import { render, screen } from '@testing-library/svelte';
 import type { PodInfoUI } from './PodInfoUI';
 import PodColumnActions from './PodColumnActions.svelte';
 import type { ContainerInfo, Port } from '@podman-desktop/api';
+import * as contextStore from '/@/stores/context';
+import { writable } from 'svelte/store';
+import { ContextUI } from '../context/context';
 
 const listContainersMock = vi.fn();
 const getContributedMenusMock = vi.fn();
+
+vi.mock('/@/stores/context', async () => {
+  return {
+    context: vi.fn(),
+  };
+});
 
 beforeEach(() => {
   (window as any).listContainers = listContainersMock;
@@ -35,6 +44,7 @@ beforeEach(() => {
 
   (window as any).getContributedMenus = getContributedMenusMock;
   getContributedMenusMock.mockImplementation(() => Promise.resolve([]));
+  vi.mocked(contextStore).context = writable(new ContextUI());
 });
 
 afterEach(() => {

--- a/packages/renderer/src/lib/pod/PodDetails.spec.ts
+++ b/packages/renderer/src/lib/pod/PodDetails.spec.ts
@@ -21,12 +21,14 @@ import { test, expect, vi, beforeAll } from 'vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 
 import PodDetails from './PodDetails.svelte';
-import { get } from 'svelte/store';
+import { get, writable } from 'svelte/store';
 import { podsInfos } from '/@/stores/pods';
 import type { PodInfo } from '../../../../main/src/plugin/api/pod-info';
 
 import { router, type TinroRoute } from 'tinro';
 import { lastPage } from '/@/stores/breadcrumb';
+import * as contextStore from '/@/stores/context';
+import { ContextUI } from '../context/context';
 
 const mocks = vi.hoisted(() => ({
   TerminalMock: vi.fn(),
@@ -60,6 +62,12 @@ const myPod: PodInfo = {
 const removePodMock = vi.fn();
 const getContributedMenusMock = vi.fn();
 
+vi.mock('/@/stores/context', async () => {
+  return {
+    context: vi.fn(),
+  };
+});
+
 beforeAll(() => {
   (window as any).showMessageBox = showMessageBoxMock;
   (window as any).listPods = listPodsMock;
@@ -80,6 +88,7 @@ beforeAll(() => {
     unobserve: vi.fn(),
     disconnect: vi.fn(),
   });
+  vi.mocked(contextStore).context = writable(new ContextUI());
 });
 
 test('Expect redirect to previous page if pod is deleted', async () => {

--- a/packages/renderer/src/lib/pod/PodsList.spec.ts
+++ b/packages/renderer/src/lib/pod/PodsList.spec.ts
@@ -23,12 +23,14 @@ import { beforeAll, test, expect, vi } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/svelte';
 import PodsList from '/@/lib/pod/PodsList.svelte';
 import type { ProviderInfo } from '../../../../main/src/plugin/api/provider-info';
-import { get } from 'svelte/store';
+import { get, writable } from 'svelte/store';
 import { providerInfos } from '/@/stores/providers';
 import { filtered, podsInfos } from '/@/stores/pods';
 import type { PodInfo } from '../../../../main/src/plugin/api/pod-info';
 import { router } from 'tinro';
 import userEvent from '@testing-library/user-event';
+import * as contextStore from '/@/stores/context';
+import { ContextUI } from '../context/context';
 
 const getProvidersInfoMock = vi.fn();
 const listPodsMock = vi.fn();
@@ -260,6 +262,12 @@ const ocppod: PodInfo = {
   kind: 'kubernetes',
 };
 
+vi.mock('/@/stores/context', async () => {
+  return {
+    context: vi.fn(),
+  };
+});
+
 // fake the window.events object
 beforeAll(() => {
   (window as any).kubernetesGetContextsGeneralState = () => Promise.resolve(new Map());
@@ -278,6 +286,7 @@ beforeAll(() => {
 
   (window as any).getContributedMenus = getContributedMenusMock;
   getContributedMenusMock.mockImplementation(() => Promise.resolve([]));
+  vi.mocked(contextStore).context = writable(new ContextUI());
 });
 
 async function waitRender(customProperties: object): Promise<void> {

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.spec.ts
@@ -29,7 +29,9 @@ import type { IConfigurationPropertyRecordedSchema } from '../../../../main/src/
 import type { ProviderInfo, ProviderContainerConnectionInfo } from '../../../../main/src/plugin/api/provider-info';
 import { operationConnectionsInfo } from '/@/stores/operation-connections';
 import { eventCollect } from '/@/lib/preferences/preferences-connection-rendering-task';
-import { get } from 'svelte/store';
+import { get, writable } from 'svelte/store';
+import * as contextStore from '/@/stores/context';
+import { ContextUI } from '../context/context';
 
 type LoggerEventName = 'log' | 'warn' | 'error' | 'finish';
 
@@ -53,6 +55,12 @@ const connectionInfo = {
 } as unknown as ProviderContainerConnectionInfo;
 const propertyScope = 'ContainerProviderConnectionFactory';
 
+vi.mock('/@/stores/context', async () => {
+  return {
+    context: vi.fn(),
+  };
+});
+
 beforeAll(() => {
   (window as any).getConfigurationValue = vi.fn();
   (window as any).updateConfigurationValue = vi.fn();
@@ -72,6 +80,8 @@ beforeAll(() => {
       };
     },
   });
+
+  vi.mocked(contextStore).context = writable(new ContextUI());
 });
 
 function mockCallback(

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.spec.ts
@@ -24,11 +24,19 @@ import { kubernetesContexts } from '/@/stores/kubernetes-contexts';
 import type { KubeContext } from '../../../../main/src/plugin/kubernetes-context';
 import type { ContextGeneralState } from '../../../../main/src/plugin/kubernetes-context-state';
 import * as kubernetesContextsState from '/@/stores/kubernetes-contexts-state';
-import { readable } from 'svelte/store';
+import { readable, writable } from 'svelte/store';
+import * as contextStore from '/@/stores/context';
+import { ContextUI } from '../context/context';
 
 vi.mock('/@/stores/kubernetes-contexts-state', async () => {
   return {
     kubernetesContextsState: vi.fn(),
+  };
+});
+
+vi.mock('/@/stores/context', async () => {
+  return {
+    context: vi.fn(),
   };
 });
 
@@ -68,6 +76,7 @@ const mockContext3: KubeContext = {
 beforeEach(() => {
   kubernetesContexts.set([mockContext1, mockContext2, mockContext3]);
   (window as any).kubernetesGetContextsGeneralState = vi.fn().mockResolvedValue(new Map<string, ContextGeneralState>());
+  vi.mocked(contextStore).context = writable(new ContextUI());
 });
 
 test('test that name, cluster and the server is displayed when rendering', async () => {

--- a/packages/renderer/src/lib/preferences/PreferencesRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesRendering.spec.ts
@@ -26,8 +26,9 @@ import { render, screen } from '@testing-library/svelte';
 import type { IConfigurationPropertyRecordedSchema } from '../../../../main/src/plugin/configuration-registry';
 import PreferencesRendering from './PreferencesRendering.svelte';
 import { CONFIGURATION_DEFAULT_SCOPE } from '../../../../main/src/plugin/configuration-registry-constants';
+import * as contextStore from '/@/stores/context';
+import { writable } from 'svelte/store';
 import { ContextUI } from '../context/context';
-import { context } from '/@/stores/context';
 
 async function waitRender(customProperties: any): Promise<void> {
   const result = render(PreferencesRendering, { ...customProperties });
@@ -37,9 +38,16 @@ async function waitRender(customProperties: any): Promise<void> {
   }
 }
 
+vi.mock('/@/stores/context', async () => {
+  return {
+    context: vi.fn(),
+  };
+});
+
 beforeAll(() => {
   (window as any).getConfigurationValue = vi.fn().mockResolvedValue(true);
   (window as any).telemetryPage = vi.fn().mockResolvedValue(undefined);
+  vi.mocked(contextStore).context = writable(new ContextUI());
 });
 
 const record: IConfigurationPropertyRecordedSchema = {
@@ -90,7 +98,7 @@ test('Expect extension title used a section name', async () => {
 
 test('Expect example when property to be missing if when statement is not satisfied from context', async () => {
   const contextConfig = new ContextUI();
-  context.set(contextConfig);
+  vi.mocked(contextStore).context.set(contextConfig);
   contextConfig.setValue('config.test', true);
   expect(contextConfig.getValue('config.test')).toBe(true);
 
@@ -114,7 +122,7 @@ test('Expect example when property to be missing if when statement is not satisf
 
 test('Expect example when property to show if when statement is satisfied from context', async () => {
   const contextConfig = new ContextUI();
-  context.set(contextConfig);
+  vi.mocked(contextStore).context.set(contextConfig);
   contextConfig.setValue('config.test', true);
   expect(contextConfig.getValue('config.test')).toBe(true);
 

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.spec.ts
@@ -28,6 +28,9 @@ import { onboardingList } from '/@/stores/onboarding';
 import type { OnboardingInfo } from '../../../../main/src/plugin/api/onboarding';
 import { configurationProperties } from '/@/stores/configurationProperties';
 import { CONFIGURATION_DEFAULT_SCOPE } from '../../../../main/src/plugin/configuration-registry-constants';
+import * as contextStore from '/@/stores/context';
+import { writable } from 'svelte/store';
+import { ContextUI } from '../context/context';
 
 const providerInfo: ProviderInfo = {
   id: 'podman',
@@ -71,6 +74,12 @@ vi.mock('tinro', () => {
   };
 });
 
+vi.mock('/@/stores/context', async () => {
+  return {
+    context: vi.fn(),
+  };
+});
+
 // getOsPlatformMock is needed when using PreferencesResourcesRenderingCopyButton
 const getOsPlatformMock = vi.fn().mockResolvedValue('linux');
 
@@ -83,6 +92,7 @@ beforeEach(() => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (window as any).telemetryPage = vi.fn().mockResolvedValue(undefined);
   (window as any).getOsPlatform = getOsPlatformMock;
+  vi.mocked(contextStore).context = writable(new ContextUI());
 });
 
 test('Expect to see elements regarding default provider name', async () => {

--- a/packages/renderer/src/lib/service/ServiceActions.spec.ts
+++ b/packages/renderer/src/lib/service/ServiceActions.spec.ts
@@ -21,6 +21,9 @@ import { test, expect, vi, beforeEach, afterEach } from 'vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import ServiceActions from './ServiceActions.svelte';
 import type { ServiceUI } from './ServiceUI';
+import * as contextStore from '/@/stores/context';
+import { writable } from 'svelte/store';
+import { ContextUI } from '../context/context';
 
 const updateMock = vi.fn();
 const deleteMock = vi.fn();
@@ -36,9 +39,16 @@ const service: ServiceUI = {
   ports: '',
 };
 
+vi.mock('/@/stores/context', async () => {
+  return {
+    context: vi.fn(),
+  };
+});
+
 beforeEach(() => {
   (window as any).showMessageBox = showMessageBoxMock;
   (window as any).kubernetesDeleteService = deleteMock;
+  vi.mocked(contextStore).context = writable(new ContextUI());
 });
 
 afterEach(() => {

--- a/packages/renderer/src/lib/service/ServiceColumnActions.spec.ts
+++ b/packages/renderer/src/lib/service/ServiceColumnActions.spec.ts
@@ -17,11 +17,24 @@
  ***********************************************************************/
 
 import '@testing-library/jest-dom/vitest';
-import { test, expect } from 'vitest';
+import { test, expect, beforeEach, vi } from 'vitest';
 import { render, screen } from '@testing-library/svelte';
 
 import type { ServiceUI } from './ServiceUI';
 import ServiceColumnActions from './ServiceColumnActions.svelte';
+import * as contextStore from '/@/stores/context';
+import { writable } from 'svelte/store';
+import { ContextUI } from '../context/context';
+
+vi.mock('/@/stores/context', async () => {
+  return {
+    context: vi.fn(),
+  };
+});
+
+beforeEach(() => {
+  vi.mocked(contextStore).context = writable(new ContextUI());
+});
 
 test('Expect action buttons', async () => {
   const service: ServiceUI = {

--- a/packages/renderer/src/lib/service/ServiceDetails.spec.ts
+++ b/packages/renderer/src/lib/service/ServiceDetails.spec.ts
@@ -27,6 +27,8 @@ import { lastPage } from '/@/stores/breadcrumb';
 import type { V1Service, KubernetesObject } from '@kubernetes/client-node';
 import * as kubeContextStore from '/@/stores/kubernetes-contexts-state';
 import { writable } from 'svelte/store';
+import * as contextStore from '/@/stores/context';
+import { ContextUI } from '../context/context';
 
 const kubernetesDeleteServiceMock = vi.fn();
 
@@ -44,9 +46,16 @@ vi.mock('/@/stores/kubernetes-contexts-state', async () => {
   };
 });
 
+vi.mock('/@/stores/context', async () => {
+  return {
+    context: vi.fn(),
+  };
+});
+
 beforeAll(() => {
   (window as any).kubernetesDeleteService = kubernetesDeleteServiceMock;
   (window as any).kubernetesReadNamespacedService = vi.fn();
+  vi.mocked(contextStore).context = writable(new ContextUI());
 });
 
 test('Expect redirect to previous page if service is deleted', async () => {

--- a/packages/renderer/src/lib/service/ServicesList.spec.ts
+++ b/packages/renderer/src/lib/service/ServicesList.spec.ts
@@ -22,14 +22,23 @@ import '@testing-library/jest-dom/vitest';
 import { test, expect, vi, beforeEach, beforeAll } from 'vitest';
 import { render, screen } from '@testing-library/svelte';
 import ServicesList from './ServicesList.svelte';
-import { get } from 'svelte/store';
+import { get, writable } from 'svelte/store';
 import type { V1Service } from '@kubernetes/client-node';
 import { kubernetesCurrentContextServices } from '/@/stores/kubernetes-contexts-state';
+import * as contextStore from '/@/stores/context';
+import { ContextUI } from '../context/context';
 
 const kubernetesRegisterGetCurrentContextResourcesMock = vi.fn();
 
+vi.mock('/@/stores/context', async () => {
+  return {
+    context: vi.fn(),
+  };
+});
+
 beforeAll(() => {
   (window as any).kubernetesRegisterGetCurrentContextResources = kubernetesRegisterGetCurrentContextResourcesMock;
+  vi.mocked(contextStore).context = writable(new ContextUI());
 });
 
 beforeEach(() => {

--- a/packages/renderer/src/lib/ui/ListItemButtonIcon.spec.ts
+++ b/packages/renderer/src/lib/ui/ListItemButtonIcon.spec.ts
@@ -17,19 +17,30 @@
  ***********************************************************************/
 
 import '@testing-library/jest-dom/vitest';
-import { test, expect, vi } from 'vitest';
+import { test, expect, vi, beforeEach } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/svelte';
 import ListItemButtonIcon from './ListItemButtonIcon.svelte';
 import { faCircleCheck, faRocket } from '@fortawesome/free-solid-svg-icons';
 import { ContextUI } from '../context/context';
-import { context } from '/@/stores/context';
+import * as contextStore from '/@/stores/context';
+import { writable } from 'svelte/store';
+
+vi.mock('/@/stores/context', async () => {
+  return {
+    context: vi.fn(),
+  };
+});
+
+beforeEach(() => {
+  vi.mocked(contextStore).context = writable(new ContextUI());
+});
 
 test('Expect the dropDownMenuItem to have classes that display a disabled object if the disabled when clause is evaluated to true', async () => {
   const title = 'title';
 
   const contextUI = new ContextUI();
   contextUI.setValue('values', ['test']);
-  context.set(contextUI);
+  vi.mocked(contextStore).context.set(contextUI);
 
   render(ListItemButtonIcon, {
     title,
@@ -64,7 +75,7 @@ test('Expect the dropDownMenuItem NOT to have classes that display a disabled ob
 
   const contextUI = new ContextUI();
   contextUI.setValue('values', ['test']);
-  context.set(contextUI);
+  vi.mocked(contextStore).context.set(contextUI);
 
   render(ListItemButtonIcon, {
     title,
@@ -118,7 +129,7 @@ test('When you click on the button with confirm=yes, it will pop up with the dia
 
   const contextUI = new ContextUI();
   contextUI.setValue('values', ['test']);
-  context.set(contextUI);
+  vi.mocked(contextStore).context.set(contextUI);
 
   render(ListItemButtonIcon, {
     title,
@@ -143,7 +154,7 @@ test('With confirmation=no, there will be no confirmation when clicking the butt
 
   const contextUI = new ContextUI();
   contextUI.setValue('values', ['test']);
-  context.set(contextUI);
+  vi.mocked(contextStore).context.set(contextUI);
 
   render(ListItemButtonIcon, {
     title,

--- a/packages/renderer/src/lib/volume/VolumeActions.spec.ts
+++ b/packages/renderer/src/lib/volume/VolumeActions.spec.ts
@@ -21,13 +21,23 @@ import { test, expect, vi, beforeAll } from 'vitest';
 import { render, screen, waitFor, fireEvent } from '@testing-library/svelte';
 import VolumeActions from './VolumeActions.svelte';
 import type { VolumeInfoUI } from './VolumeInfoUI';
+import * as contextStore from '/@/stores/context';
+import { writable } from 'svelte/store';
+import { ContextUI } from '../context/context';
 
 const showMessageBoxMock = vi.fn();
 const removeVolumeMock = vi.fn();
 
+vi.mock('/@/stores/context', async () => {
+  return {
+    context: vi.fn(),
+  };
+});
+
 beforeAll(() => {
   (window as any).showMessageBox = showMessageBoxMock;
   (window as any).removeVolume = removeVolumeMock;
+  vi.mocked(contextStore).context = writable(new ContextUI());
 });
 
 test('Expect prompt dialog and deletion', async () => {

--- a/packages/renderer/src/lib/volume/VolumeDetails.spec.ts
+++ b/packages/renderer/src/lib/volume/VolumeDetails.spec.ts
@@ -21,12 +21,14 @@ import { test, expect, vi, beforeAll } from 'vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 
 import VolumeDetails from './VolumeDetails.svelte';
-import { get } from 'svelte/store';
+import { get, writable } from 'svelte/store';
 import { volumeListInfos } from '/@/stores/volumes';
 import type { VolumeListInfo } from '../../../../main/src/plugin/api/volume-info';
 
 import { router } from 'tinro';
 import { lastPage } from '/@/stores/breadcrumb';
+import * as contextStore from '/@/stores/context';
+import { ContextUI } from '../context/context';
 
 const listVolumesMock = vi.fn();
 const showMessageBoxMock = vi.fn();
@@ -53,10 +55,17 @@ const myVolume: VolumeListInfo = {
 
 const removeVolumeMock = vi.fn();
 
+vi.mock('/@/stores/context', async () => {
+  return {
+    context: vi.fn(),
+  };
+});
+
 beforeAll(() => {
   (window as any).showMessageBox = showMessageBoxMock;
   (window as any).listVolumes = listVolumesMock;
   (window as any).removeVolume = removeVolumeMock;
+  vi.mocked(contextStore).context = writable(new ContextUI());
 });
 
 test('Expect redirect to previous page if volume is deleted', async () => {

--- a/packages/renderer/src/lib/volume/VolumesList.spec.ts
+++ b/packages/renderer/src/lib/volume/VolumesList.spec.ts
@@ -22,15 +22,23 @@ import '@testing-library/jest-dom/vitest';
 import { beforeAll, test, expect, vi, beforeEach, describe } from 'vitest';
 import { render, screen } from '@testing-library/svelte';
 import VolumesList from './VolumesList.svelte';
-import { get } from 'svelte/store';
+import { get, writable } from 'svelte/store';
 import { providerInfos } from '/@/stores/providers';
 import { volumeListInfos, volumesEventStore } from '/@/stores/volumes';
 import type { ProviderInfo } from '../../../../main/src/plugin/api/provider-info';
 import userEvent from '@testing-library/user-event';
+import * as contextStore from '/@/stores/context';
+import { ContextUI } from '../context/context';
 
 const listVolumesMock = vi.fn();
 const getProviderInfosMock = vi.fn();
 const onDidUpdateProviderStatusMock = vi.fn();
+
+vi.mock('/@/stores/context', async () => {
+  return {
+    context: vi.fn(),
+  };
+});
 
 // fake the window.events object
 beforeAll(() => {
@@ -49,6 +57,7 @@ beforeAll(() => {
       func();
     },
   };
+  vi.mocked(contextStore).context = writable(new ContextUI());
 });
 
 beforeEach(() => {

--- a/packages/renderer/src/stores/context.spec.ts
+++ b/packages/renderer/src/stores/context.spec.ts
@@ -1,0 +1,57 @@
+import { beforeAll, expect, test, vi } from 'vitest';
+import { get } from 'svelte/store';
+import { ContextUI } from '../lib/context/context';
+import { context } from './context';
+import { waitFor } from '@testing-library/dom';
+
+const contextCollectAllValues = vi.fn();
+const receiveMock = vi.fn();
+
+beforeAll(() => {
+  (window as any).contextCollectAllValues = contextCollectAllValues;
+  (window as any).events = { receive: receiveMock };
+});
+
+test('context store', async () => {
+  contextCollectAllValues.mockResolvedValue({ a: 1, b: 'two' });
+  receiveMock.mockImplementation((msg: string, f: (value: unknown) => void) => {
+    if (msg === 'context-value-updated') {
+      setTimeout(() => f({ key: 'c', value: 'three' }), 5);
+      setTimeout(() => f({ key: 'b', value: 2 }), 15);
+    } else if (msg === 'context-key-removed') {
+      setTimeout(() => f({ key: 'a', value: 1 }), 10);
+    }
+  });
+
+  vi.useFakeTimers();
+  context.subscribe(() => {});
+
+  const expected = new ContextUI();
+  expected.setValue('a', 1);
+  expected.setValue('b', 'two');
+  // initial value comes from contextCollectAllValues
+  waitFor(() => {
+    expect(get(context)).toEqual(expected);
+  });
+
+  vi.advanceTimersByTime(5);
+  expected.setValue('c', 'three');
+  // context-value-updated has added the value to the store
+  waitFor(() => {
+    expect(get(context)).toEqual(expected);
+  });
+
+  vi.advanceTimersByTime(5);
+  expected.removeValue('a');
+  // context-key-removed has removed the value from the store
+  waitFor(() => {
+    expect(get(context)).toEqual(expected);
+  });
+
+  vi.advanceTimersByTime(5);
+  expected.setValue('b', 2);
+  // context-key-updated has updated the value in the store
+  waitFor(() => {
+    expect(get(context)).toEqual(expected);
+  });
+});


### PR DESCRIPTION
### What does this PR do?

When the user reloads the window, all the context values received before are not in the store anymore.

The store needs to get the current values of the context when some client subscribes to it again.

- Initialize the `context` store with the current values in the store
- test the `context` store
- mock the `context` store when testing components

### What issues does this PR fix or reference?

Fixes #4605

### How to test this PR?

See Steps to reproduce in #4605

- [x] Tests are covering the bug fix or the new feature
