### PR TITLE
chore: allow to install dd extensions from the common extension installer

### DIFF
--- a/packages/main/src/plugin/docker-extension/docker-desktop-installer.spec.ts
+++ b/packages/main/src/plugin/docker-extension/docker-desktop-installer.spec.ts
@@ -1,0 +1,228 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
+import type { ContributionManager } from '../contribution-manager.js';
+import { DockerDesktopInstaller } from './docker-desktop-installer.js';
+import { cp, readFile } from 'fs/promises';
+
+let dockerDesktopInstaller: TestDockerDesktopInstaller;
+
+const contributionManager = {
+  init: vi.fn(),
+  loadMetadata: vi.fn(),
+  saveMetadata: vi.fn(),
+  findComposeBinary: vi.fn(),
+  enhanceComposeFile: vi.fn(),
+  startVM: vi.fn(),
+} as unknown as ContributionManager;
+
+class TestDockerDesktopInstaller extends DockerDesktopInstaller {}
+
+beforeAll(async () => {
+  dockerDesktopInstaller = new TestDockerDesktopInstaller(contributionManager);
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+test('Check extractExtensionFiles', async () => {
+  vi.mock('node:fs/promises');
+
+  const metadataJson = {
+    name: 'My Extension',
+    icon: 'icon.png',
+    ui: {
+      myApp: {
+        title: 'myApp',
+        root: '/ui',
+        src: 'index.html',
+        backend: {
+          socket: 'plugin.sock',
+        },
+      },
+    },
+    vm: {
+      composefile: 'docker-compose.yaml',
+    },
+    host: {
+      binaries: [
+        {
+          darwin: [
+            {
+              path: '/host/darwin',
+            },
+          ],
+          linux: [
+            {
+              path: '/host/linux',
+            },
+          ],
+          windows: [
+            {
+              path: '/host/windows',
+            },
+          ],
+        },
+      ],
+    },
+  };
+
+  // mock readFile
+  vi.mocked(readFile).mockResolvedValueOnce(JSON.stringify(metadataJson));
+
+  // mock the cp of files
+  vi.mocked(cp).mockResolvedValue();
+
+  const reportLog: (message: string) => void = vi.fn();
+
+  await dockerDesktopInstaller.extractExtensionFiles('/tmp/source', '/tmp/dest', reportLog);
+
+  // expect cp to be called for each file
+  expect(vi.mocked(cp)).toHaveBeenCalledWith(
+    expect.stringContaining('metadata.json'),
+    expect.stringContaining('metadata.json'),
+    { recursive: true },
+  );
+  expect(vi.mocked(cp)).toHaveBeenCalledWith(expect.stringContaining('icon.png'), expect.stringContaining('icon.png'), {
+    recursive: true,
+  });
+  expect(vi.mocked(cp)).toHaveBeenCalledWith(expect.stringContaining('ui'), expect.stringContaining('ui'), {
+    recursive: true,
+  });
+  expect(vi.mocked(cp)).toHaveBeenCalledWith(
+    expect.stringContaining('docker-compose.yaml'),
+    expect.stringContaining('docker-compose.yaml'),
+    { recursive: true },
+  );
+
+  expect(reportLog).toHaveBeenCalledWith(expect.stringContaining('Copying host file'));
+});
+
+describe('Check setupContribution', async () => {
+  test('Check basic setupContribution', async () => {
+    const sendLog: (message: string) => void = vi.fn();
+    const sendError: (message: string) => void = vi.fn();
+
+    const metadata = {
+      name: 'My Extension',
+    };
+
+    // mock loadMetadata with a name
+    vi.mocked(contributionManager.loadMetadata).mockResolvedValueOnce(metadata);
+
+    const contrib = await dockerDesktopInstaller.setupContribution(
+      'My Extension',
+      'my-extension:latest',
+      'dest-folder',
+      sendLog,
+      sendError,
+    );
+
+    expect(contrib).toBeDefined();
+    expect(contrib?.title).toBe('My Extension');
+    expect(contrib?.extensionPath).toContain('dest-folder');
+    expect(contrib?.metadata).toBe(metadata);
+
+    // there is a title so saveMetadata
+    expect(vi.mocked(contributionManager.saveMetadata)).not.toHaveBeenCalled();
+
+    // expect init called
+    expect(vi.mocked(contributionManager.init)).toHaveBeenCalled();
+
+    // no vm  so not calling the enhance compose file
+    expect(vi.mocked(contributionManager).findComposeBinary).not.toHaveBeenCalled();
+    expect(vi.mocked(contributionManager).enhanceComposeFile).not.toHaveBeenCalled();
+
+    expect(sendError).not.toHaveBeenCalled();
+
+    expect(sendLog).toHaveBeenCalledWith(expect.stringContaining('Extension Successfully installed.'));
+  });
+
+  test('Check missing name', async () => {
+    const sendLog: (message: string) => void = vi.fn();
+    const sendError: (message: string) => void = vi.fn();
+
+    const metadata = {};
+
+    // mock loadMetadata with a name
+    vi.mocked(contributionManager.loadMetadata).mockResolvedValueOnce(metadata);
+
+    const contrib = await dockerDesktopInstaller.setupContribution(
+      'My Extension',
+      'my-extension:latest',
+      'dest-folder',
+      sendLog,
+      sendError,
+    );
+
+    expect(contrib).toBeDefined();
+    expect(contrib?.title).toBe('My Extension');
+    expect(contrib?.extensionPath).toContain('dest-folder');
+    expect(contrib?.metadata).toBe(metadata);
+
+    // there is a call to save  metadata
+    expect(vi.mocked(contributionManager.saveMetadata)).toHaveBeenCalledWith(
+      expect.stringContaining('dest-folder'),
+      expect.objectContaining({ name: 'My Extension' }),
+    );
+  });
+
+  test('Check with vm', async () => {
+    const sendLog: (message: string) => void = vi.fn();
+    const sendError: (message: string) => void = vi.fn();
+
+    const metadata = {
+      vm: {
+        composefile: 'docker-compose.yaml',
+      },
+    };
+
+    // mock loadMetadata with a name
+    vi.mocked(contributionManager.loadMetadata).mockResolvedValueOnce(metadata);
+
+    // say that we found the compose binary
+    vi.mocked(contributionManager.findComposeBinary).mockResolvedValue('found-docker-compose');
+
+    const contrib = await dockerDesktopInstaller.setupContribution(
+      'My Extension',
+      'my-extension:latest',
+      'dest-folder',
+      sendLog,
+      sendError,
+    );
+
+    expect(contrib).toBeDefined();
+    expect(contrib?.title).toBe('My Extension');
+    expect(contrib?.extensionPath).toContain('dest-folder');
+    expect(contrib?.metadata).toBe(metadata);
+
+    // there is a call to findComposeBinary
+    expect(vi.mocked(contributionManager.findComposeBinary)).toHaveBeenCalled();
+
+    // expect call to enhanceComposeFile
+    expect(vi.mocked(contributionManager.enhanceComposeFile)).toHaveBeenCalled();
+
+    // expect call to startVM
+    expect(vi.mocked(contributionManager.startVM)).toHaveBeenCalled();
+
+    // expect log with binary found
+    expect(sendLog).toHaveBeenCalledWith(expect.stringContaining('Compose binary found at'));
+  });
+});

--- a/packages/main/src/plugin/docker-extension/docker-desktop-installer.ts
+++ b/packages/main/src/plugin/docker-extension/docker-desktop-installer.ts
@@ -1,0 +1,173 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import * as path from 'node:path';
+import { readFile, cp } from 'node:fs/promises';
+import type { ContributionManager } from '/@/plugin/contribution-manager.js';
+
+export class DockerDesktopContribution {
+  readonly #title: string;
+  readonly #extensionPath: string;
+  readonly #metadata: unknown;
+
+  constructor(title: string, extensionPath: string, metadata: unknown) {
+    this.#title = title;
+    this.#extensionPath = extensionPath;
+    this.#metadata = metadata;
+  }
+
+  get title(): string {
+    return this.#title;
+  }
+
+  get extensionPath(): string {
+    return this.#extensionPath;
+  }
+
+  get metadata(): unknown {
+    return this.#metadata;
+  }
+}
+
+export class DockerDesktopInstaller {
+  readonly #contributionManager: ContributionManager;
+
+  constructor(contributionManager: ContributionManager) {
+    this.#contributionManager = contributionManager;
+  }
+
+  async extractExtensionFiles(
+    sourceFolderPath: string,
+    destFolderPath: string,
+    reportLog: (message: string) => void,
+  ): Promise<void> {
+    // ok now, we need to copy files that we're interested in by looking at the metadata.json file
+    const metadataFile = await readFile(`${sourceFolderPath}/metadata.json`, 'utf8');
+    const metadata = JSON.parse(metadataFile);
+
+    // files or folder to grab
+    const files: string[] = [];
+
+    // save metadata
+    files.push('metadata.json');
+
+    // save icon
+    if (metadata.icon) {
+      files.push(metadata.icon);
+    }
+
+    if (metadata.ui) {
+      Object.keys(metadata.ui).forEach(key => {
+        files.push(metadata.ui[key].root);
+      });
+    }
+
+    if (metadata.vm?.composefile) {
+      files.push(metadata.vm.composefile);
+    }
+
+    // host binaries
+    const hostFiles: string[] = [];
+    if (metadata?.host?.binaries) {
+      // grab current platform
+      let platform: string = process.platform;
+      if (platform === 'win32') {
+        platform = 'windows';
+      }
+      // do we have binaries ?
+      if (metadata.host.binaries) {
+        metadata.host.binaries.forEach((binary: { [key: string]: { path: string }[] }) => {
+          binary[platform].forEach(binaryPlatform => {
+            hostFiles.push(binaryPlatform.path);
+          });
+        });
+      }
+    }
+
+    // copy all files
+    await Promise.all(
+      files.map(async (file: string) => {
+        return cp(path.join(sourceFolderPath, file), path.join(destFolderPath, file), { recursive: true });
+      }),
+    );
+    // copy all host files
+    await Promise.all(
+      hostFiles.map(async (file: string) => {
+        const sourceFile = path.join(sourceFolderPath, file);
+        // get only the filename from the path
+        const destFile = path.basename(sourceFile);
+        reportLog(`Copying host file ${destFile}.`);
+        return cp(sourceFile, path.join(destFolderPath, 'host', destFile), { recursive: true });
+      }),
+    );
+  }
+
+  async setupContribution(
+    title: string,
+    imageName: string,
+    destFolderPath: string,
+    sendLog: (message: string) => void,
+    sendError: (message: string) => void,
+  ): Promise<DockerDesktopContribution | undefined> {
+    // check metadata. If name is missing, add the one from the image
+    const metadata = await this.#contributionManager.loadMetadata(destFolderPath);
+    if (!metadata.name) {
+      // need to add the title from the image
+      metadata.name = title;
+      await this.#contributionManager.saveMetadata(destFolderPath, metadata);
+    }
+
+    // if there is a VM, need to generate the updated compose file
+    let enhancedComposeFile;
+    if (metadata.vm) {
+      // check compose presence
+      sendLog('Check compose being setup...');
+      const foundPath = await this.#contributionManager.findComposeBinary();
+      if (!foundPath) {
+        sendError('Compose binary not found.');
+        return;
+      } else {
+        sendLog(`Compose binary found at ${foundPath}.`);
+      }
+
+      sendLog('Enhance compose file...');
+      // need to update the compose file
+      try {
+        enhancedComposeFile = await this.#contributionManager.enhanceComposeFile(destFolderPath, imageName, metadata);
+      } catch (error) {
+        sendError(String(error));
+        return;
+      }
+
+      // try to start the VM
+      sendLog('Starting compose project...');
+      await this.#contributionManager.startVM(metadata.name, enhancedComposeFile, true);
+    }
+
+    sendLog('Extension Successfully installed.');
+
+    // refresh contributions
+    try {
+      await this.#contributionManager.init();
+    } catch (error) {
+      sendError(String(error));
+      return;
+    }
+    return new DockerDesktopContribution(title, destFolderPath, metadata);
+  }
+}

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -2130,6 +2130,8 @@ export class PluginSystem {
       imageRegistry,
       extensionsCatalog,
       telemetry,
+      directories,
+      contributionManager,
     );
     await extensionInstaller.init();
 

--- a/packages/main/src/plugin/install/extension-installer.spec.ts
+++ b/packages/main/src/plugin/install/extension-installer.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
+import { beforeEach, expect, test, vi } from 'vitest';
 
 import { ExtensionInstaller } from './extension-installer.js';
 import type { ApiSenderType } from '../api.js';
@@ -28,6 +28,9 @@ import { ipcMain } from 'electron';
 import type { ExtensionsCatalog } from '../extensions-catalog/extensions-catalog.js';
 import type { CatalogFetchableExtension } from '../extensions-catalog/extensions-catalog-api.js';
 import type { Telemetry } from '../telemetry/telemetry.js';
+import type { Directories } from '../directories.js';
+import type { ContributionManager } from '../contribution-manager.js';
+import { rmSync } from 'node:fs';
 
 let extensionInstaller: ExtensionInstaller;
 
@@ -74,18 +77,43 @@ const telemetryMock = {
   track: vi.fn(),
 } as unknown as Telemetry;
 
-beforeAll(async () => {
+const directories = {
+  getPluginsDirectory: vi.fn(),
+  getContributionStorageDir: vi.fn(),
+} as unknown as Directories;
+
+const contributionManager = {} as unknown as ContributionManager;
+
+vi.mock('node:fs');
+
+vi.mock('./../docker-extension/docker-desktop-installer', async () => {
+  const ddInstallerReal = await vi.importActual('../docker-extension/docker-desktop-installer');
+
+  return {
+    DockerDesktopInstaller: vi.fn().mockImplementation(() => {
+      return {
+        extractExtensionFiles: vi.fn(),
+        setupContribution: vi.fn(),
+      };
+    }),
+    DockerDesktopContribution: ddInstallerReal.DockerDesktopContribution,
+  };
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(rmSync).mockReturnValue(undefined);
+  vi.mocked(directories.getPluginsDirectory).mockReturnValue('/fake/plugins/directory');
+  vi.mocked(directories.getContributionStorageDir).mockReturnValue('/fake/dd/directory');
   extensionInstaller = new ExtensionInstaller(
     apiSender,
     extensionLoader,
     imageRegistry,
     extensionsCatalog,
     telemetryMock,
+    directories,
+    contributionManager,
   );
-});
-
-beforeEach(() => {
-  vi.clearAllMocks();
 });
 
 test('should install an image if labels are correct', async () => {
@@ -121,6 +149,31 @@ test('should install an image if labels are correct', async () => {
 
   // extension started
   expect(apiSenderSendMock).toHaveBeenCalledWith('extension-started', {});
+});
+
+test('should install an image (dd extensions) if labels are correct', async () => {
+  const sendLog = vi.fn();
+  const sendError = vi.fn();
+  const sendEnd = vi.fn();
+
+  const imageToPull = 'fake.io/fake-image:fake-tag';
+
+  vi.mocked(imageRegistry.getImageConfigLabels).mockResolvedValueOnce({
+    'org.opencontainers.image.title': 'fake-title',
+    'org.opencontainers.image.description': 'fake-description',
+    'org.opencontainers.image.vendor': 'fake-vendor',
+    'com.docker.desktop.extension.api.version': '1.0.0',
+  });
+
+  const spyExtractExtensionFiles = vi.spyOn(extensionInstaller, 'extractExtensionFiles');
+
+  await extensionInstaller.installFromImage(sendLog, sendError, sendEnd, imageToPull);
+
+  expect(sendLog).toHaveBeenCalledWith(`Analyzing image ${imageToPull}...`);
+  // expect no error
+  expect(sendError).not.toHaveBeenCalled();
+
+  expect(spyExtractExtensionFiles).not.toHaveBeenCalled();
 });
 
 test('should fail if extension is already installed', async () => {

--- a/packages/main/src/plugin/install/extension-installer.ts
+++ b/packages/main/src/plugin/install/extension-installer.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,15 +28,24 @@ import type { ApiSenderType } from '../api.js';
 import type { ImageRegistry } from '../image-registry.js';
 import type { ExtensionsCatalog } from '../extensions-catalog/extensions-catalog.js';
 import type { Telemetry } from '../telemetry/telemetry.js';
+import type { Directories } from '/@/plugin/directories.js';
+import { DockerDesktopContribution, DockerDesktopInstaller } from '../docker-extension/docker-desktop-installer.js';
+import type { ContributionManager } from '../contribution-manager.js';
 
 export class ExtensionInstaller {
+  #dockerDesktopInstaller: DockerDesktopInstaller;
+
   constructor(
     private apiSender: ApiSenderType,
     private extensionLoader: ExtensionLoader,
     private imageRegistry: ImageRegistry,
     private extensionCatalog: ExtensionsCatalog,
     private telemetry: Telemetry,
-  ) {}
+    private directories: Directories,
+    private contributionManager: ContributionManager,
+  ) {
+    this.#dockerDesktopInstaller = new DockerDesktopInstaller(contributionManager);
+  }
 
   async extractExtensionFiles(
     tmpFolderPath: string,
@@ -79,9 +88,6 @@ export class ExtensionInstaller {
         return cp(sourceFile, path.join(finalFolderPath, 'host', destFile), { recursive: true });
       }),
     );
-
-    // delete the tmp folder
-    fs.rmSync(tmpFolderPath, { recursive: true });
   }
 
   async unpackTarFile(tarFilePath: string, destFolder: string): Promise<void> {
@@ -104,7 +110,7 @@ export class ExtensionInstaller {
     sendLog: (message: string) => void,
     sendError: (message: string) => void,
     imageName: string,
-  ): Promise<AnalyzedExtension | undefined> {
+  ): Promise<AnalyzedExtension | DockerDesktopContribution | undefined> {
     imageName = imageName.trim();
     sendLog(`Analyzing image ${imageName}...`);
     let imageConfigLabels;
@@ -120,14 +126,26 @@ export class ExtensionInstaller {
       return;
     }
 
-    const titleLabel = imageConfigLabels['org.opencontainers.image.title'];
+    const titleLabel = imageConfigLabels['org.opencontainers.image.title'] as string;
     const descriptionLabel = imageConfigLabels['org.opencontainers.image.description'];
     const vendorLabel = imageConfigLabels['org.opencontainers.image.vendor'];
     const apiVersion = imageConfigLabels['io.podman-desktop.api.version'];
+    const apiDDVersion = imageConfigLabels['com.docker.desktop.extension.api.version'];
 
-    if (!titleLabel || !descriptionLabel || !vendorLabel || !apiVersion) {
+    if (!titleLabel || !descriptionLabel || !vendorLabel || (!apiVersion && !apiDDVersion)) {
       sendError(`Image ${imageName} is not a Podman Desktop Extension`);
       return;
+    }
+
+    const isDDExtension = apiDDVersion ? true : false;
+    const isPDExtension = apiVersion ? true : false;
+
+    let unpackedFolder;
+    // where to unpack the extension
+    if (isPDExtension) {
+      unpackedFolder = this.directories.getPluginsDirectory();
+    } else {
+      unpackedFolder = this.directories.getContributionStorageDir();
     }
 
     // strip the tag (ending with :something) from the image name if any
@@ -145,37 +163,49 @@ export class ExtensionInstaller {
     const tmpFolderPath = path.join(os.tmpdir(), `/tmp/${imageNameWithoutSpecialChars}-tmp`);
 
     // final folder
-    const finalFolderPath = path.join(this.extensionLoader.getPluginsDirectory(), imageNameWithoutSpecialChars);
+    const finalFolderPath = path.join(unpackedFolder, imageNameWithoutSpecialChars);
 
     // grab all extensions
-    const extensions = await this.extensionLoader.listExtensions();
+    if (isPDExtension) {
+      const extensions = await this.extensionLoader.listExtensions();
 
-    // check if the extension is already installed for that path
-    const alreadyInstalledExtension = extensions.find(extension => extension.path === finalFolderPath);
+      // check if the extension is already installed for that path
+      const alreadyInstalledExtension = extensions.find(extension => extension.path === finalFolderPath);
 
-    if (alreadyInstalledExtension) {
-      sendError(`Extension ${alreadyInstalledExtension.name} is already installed`);
-      return;
+      if (alreadyInstalledExtension) {
+        sendError(`Extension ${alreadyInstalledExtension.name} is already installed`);
+        return;
+      }
     }
 
     sendLog('Downloading and extract layers...');
     await this.imageRegistry.downloadAndExtractImage(imageName, tmpFolderPath, sendLog);
 
     sendLog('Filtering image content...');
-    await this.extractExtensionFiles(tmpFolderPath, finalFolderPath, sendLog);
-
-    let analyzedExtension: AnalyzedExtension | undefined;
-    try {
-      analyzedExtension = await this.extensionLoader.analyzeExtension(finalFolderPath, true);
-    } catch (error) {
-      sendError('Error while analyzing extension: ' + error);
-    }
-    if (analyzedExtension?.error) {
-      sendError('Could not load extension: ' + analyzedExtension?.error);
-      return;
+    if (isPDExtension) {
+      await this.extractExtensionFiles(tmpFolderPath, finalFolderPath, sendLog);
+    } else if (isDDExtension) {
+      await this.#dockerDesktopInstaller.extractExtensionFiles(tmpFolderPath, finalFolderPath, sendLog);
     }
 
-    return analyzedExtension;
+    // delete the tmp folder
+    fs.rmSync(tmpFolderPath, { recursive: true });
+
+    if (isPDExtension) {
+      let analyzedExtension: AnalyzedExtension | undefined;
+      try {
+        analyzedExtension = await this.extensionLoader.analyzeExtension(finalFolderPath, true);
+      } catch (error) {
+        sendError('Error while analyzing extension: ' + error);
+      }
+      if (analyzedExtension?.error) {
+        sendError('Could not load extension: ' + analyzedExtension?.error);
+        return;
+      }
+      return analyzedExtension;
+    } else if (isDDExtension) {
+      return this.#dockerDesktopInstaller.setupContribution(titleLabel, imageName, finalFolderPath, sendLog, sendError);
+    }
   }
 
   async analyzeTransitiveDependencies(
@@ -238,7 +268,7 @@ export class ExtensionInstaller {
         try {
           const imageToAnalyze = await this.analyzeFromImage(sendLog, sendError, imageNameToAnalyze);
 
-          if (!imageToAnalyze) {
+          if (!imageToAnalyze || imageToAnalyze instanceof DockerDesktopContribution) {
             return false;
           }
           await this.analyzeTransitiveDependencies(imageToAnalyze, analyzedExtensions, errors, sendLog, sendError);
@@ -261,6 +291,10 @@ export class ExtensionInstaller {
     const analyzedExtensions: AnalyzedExtension[] = [];
     const errors: string[] = [];
     const analyzedExtension = await this.analyzeFromImage(sendLog, sendError, imageName);
+    if (analyzedExtension instanceof DockerDesktopContribution) {
+      sendEnd('Docker Desktop Extension Successfully installed.');
+      return;
+    }
 
     if (analyzedExtension) extensionAnalyzed?.(analyzedExtension);
 

--- a/packages/main/src/plugin/install/extension-installer.ts
+++ b/packages/main/src/plugin/install/extension-installer.ts
@@ -126,7 +126,7 @@ export class ExtensionInstaller {
       return;
     }
 
-    const titleLabel = imageConfigLabels['org.opencontainers.image.title'] as string;
+    const titleLabel = imageConfigLabels['org.opencontainers.image.title'] as string | undefined;
     const descriptionLabel = imageConfigLabels['org.opencontainers.image.description'];
     const vendorLabel = imageConfigLabels['org.opencontainers.image.vendor'];
     const apiVersion = imageConfigLabels['io.podman-desktop.api.version'];


### PR DESCRIPTION
### What does this PR do?
allow to call the install of DD extensions from the common installer workflow

it'll allow to remove the specific DD workflow later

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/6226

### How to test this PR?

Go to extension installer page (not DD extension page) and try to install trivy image `aquasec/trivy-docker-extension:latest`
you should see a new item in the navbar at the end

- [x] Tests are covering the bug fix or the new feature
