### PR TITLE
chore: add simple README files for internal extensions

### DIFF
--- a/extensions/compose/README.md
+++ b/extensions/compose/README.md
@@ -1,0 +1,3 @@
+# Compose Extension
+
+The Compose Extension allows to setup compose binary so `podman compose` commands can work.

--- a/extensions/docker/README.md
+++ b/extensions/docker/README.md
@@ -1,0 +1,5 @@
+# Docker extension
+
+Docker extension detects if docker engine is running and if running, it'll register the socket to Podman Desktop.
+
+Then, you can monitor containers, images, volumes, etc. from Podman Desktop.

--- a/extensions/kind/README.md
+++ b/extensions/kind/README.md
@@ -1,0 +1,8 @@
+# kind extension
+
+This extension adds the support of https://kind.sigs.k8s.io/
+
+By using this extension, it is possible to create kubernetes clusters
+running on top of the container engine.
+
+You can initialize a kind cluster using Settings/Resources.

--- a/extensions/kube-context/README.md
+++ b/extensions/kube-context/README.md
@@ -1,0 +1,5 @@
+# kube-context extension
+
+This extensions allows to list and switch the current kubernetes context.
+
+It displays the contexts in the tray icon or in the status bar.

--- a/extensions/lima/README.md
+++ b/extensions/lima/README.md
@@ -1,0 +1,5 @@
+# Lima extension
+
+This extension allows to create Lima VM used to have a podman or docker engine.
+
+More information on Lima: https://github.com/lima-vm/lima

--- a/extensions/podman/README.md
+++ b/extensions/podman/README.md
@@ -1,0 +1,7 @@
+# Podman extension
+
+This extension handles:
+
+- monitor the podman machines on Linux, macOS and Windows
+- creation of podman machines on macOS and Windows
+- connect to the podman socket so you can see the containers, images, volumes, etc. from podman

--- a/extensions/registries/README.md
+++ b/extensions/registries/README.md
@@ -1,0 +1,8 @@
+# Registries extension
+
+This extension registers some default registries so users don't have to
+enter the full URL.
+
+example: There is a quay.io with the icon, no need to enter `quay.io`
+
+Only need to provide login and password when you want to connect.


### PR DESCRIPTION
### What does this PR do?
As we want to show README files of extensions, we should have some to be displayed.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

related to https://github.com/containers/podman-desktop/issues/6084

### How to test this PR?

- [ ] Tests are covering the bug fix or the new feature
