### PR TITLE
chore: add basic colors for cards

### DIFF
--- a/packages/main/src/plugin/color-registry.spec.ts
+++ b/packages/main/src/plugin/color-registry.spec.ts
@@ -52,6 +52,10 @@ class TestColorRegistry extends ColorRegistry {
   initTitlebar(): void {
     super.initTitlebar();
   }
+
+  initCardContent(): void {
+    super.initCardContent();
+  }
 }
 
 const _onDidChangeConfiguration = new Emitter<IConfigurationChangeEvent>();
@@ -187,6 +191,24 @@ test('initTitlebar', async () => {
   expect(spyOnRegisterColor.mock.calls[0][0]).toStrictEqual('titlebar-bg');
   expect(spyOnRegisterColor.mock.calls[0][1].light).toBe('#f9fafb');
   expect(spyOnRegisterColor.mock.calls[0][1].dark).toBe('#0f0f11');
+});
+
+test('initCardContent', async () => {
+  // mock the registerColor
+  const spyOnRegisterColor = vi.spyOn(colorRegistry, 'registerColor');
+  spyOnRegisterColor.mockReturnValue(undefined);
+
+  colorRegistry.initCardContent();
+
+  expect(spyOnRegisterColor).toHaveBeenCalled();
+
+  // at least 3 times
+  expect(spyOnRegisterColor.mock.calls.length).toBeGreaterThanOrEqual(3);
+
+  // check the first call
+  expect(spyOnRegisterColor.mock.calls[0][0]).toStrictEqual('card-bg');
+  expect(spyOnRegisterColor.mock.calls[0][1].light).toBe('#e4e4e4');
+  expect(spyOnRegisterColor.mock.calls[0][1].dark).toBe('#18181b');
 });
 
 describe('registerColor', () => {

--- a/packages/main/src/plugin/color-registry.spec.ts
+++ b/packages/main/src/plugin/color-registry.spec.ts
@@ -28,6 +28,7 @@ import type { AnalyzedExtension } from '/@/plugin/extension-loader.js';
 import { Disposable } from '/@/plugin/types/disposable.js';
 import type { RawThemeContribution } from '/@/plugin/api/theme-info.js';
 import { ColorRegistry } from './color-registry.js';
+import colorPalette from '../../../../tailwind-color-palette.json';
 
 class TestColorRegistry extends ColorRegistry {
   notifyUpdate(): void {
@@ -207,8 +208,8 @@ test('initCardContent', async () => {
 
   // check the first call
   expect(spyOnRegisterColor.mock.calls[0][0]).toStrictEqual('card-bg');
-  expect(spyOnRegisterColor.mock.calls[0][1].light).toBe('#e4e4e4');
-  expect(spyOnRegisterColor.mock.calls[0][1].dark).toBe('#18181b');
+  expect(spyOnRegisterColor.mock.calls[0][1].light).toBe(colorPalette.gray[300]);
+  expect(spyOnRegisterColor.mock.calls[0][1].dark).toBe(colorPalette.charcoal[800]);
 });
 
 describe('registerColor', () => {

--- a/packages/main/src/plugin/color-registry.ts
+++ b/packages/main/src/plugin/color-registry.ts
@@ -202,6 +202,7 @@ export class ColorRegistry {
     this.initSecondaryNav();
     this.initTitlebar();
     this.initInvertContent();
+    this.initCardContent();
     this.initInputBox();
   }
 
@@ -315,6 +316,23 @@ export class ColorRegistry {
 
     this.registerColor(`${sNav}expander`, {
       dark: colorPalette.white,
+      light: colorPalette.charcoal[700],
+    });
+  }
+
+  protected initCardContent(): void {
+    this.registerColor(`card-bg`, {
+      dark: colorPalette.charcoal[800],
+      light: colorPalette.gray[300],
+    });
+
+    this.registerColor(`card-header-text`, {
+      dark: colorPalette.white,
+      light: colorPalette.charcoal[900],
+    });
+
+    this.registerColor(`card-text`, {
+      dark: colorPalette.gray[300],
       light: colorPalette.charcoal[700],
     });
   }


### PR DESCRIPTION
### What does this PR do?

There was only the inverted cards colors

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
https://github.com/containers/podman-desktop/issues/4907

### How to test this PR?

- [x] Tests are covering the bug fix or the new feature
