### PR TITLE
fix: context store gets current context on extensions-already-started event

### DIFF
--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -2112,6 +2112,10 @@ export class PluginSystem {
         });
       },
     );
+    this.ipcHandle(
+      'context:collectAllValues',
+      async (): Promise<Record<string, unknown>> => context.collectAllValues(),
+    );
 
     const dockerDesktopInstallation = new DockerDesktopInstallation(
       apiSender,

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -1979,6 +1979,10 @@ export function initExposure(): void {
   contextBridge.exposeInMainWorld('listGuides', async (): Promise<Guide[]> => {
     return ipcInvoke('learning-center:listGuides');
   });
+
+  contextBridge.exposeInMainWorld('contextCollectAllValues', async (): Promise<Record<string, unknown>> => {
+    return ipcInvoke('context:collectAllValues');
+  });
 }
 
 // expose methods

--- a/packages/renderer/src/stores/context.spec.ts
+++ b/packages/renderer/src/stores/context.spec.ts
@@ -1,0 +1,88 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
+import { setup } from './context';
+import { ContextUI } from '../lib/context/context';
+import { get } from 'svelte/store';
+
+const contextCollectAllValues = vi.fn();
+const receiveMock = vi.fn();
+const addEventListenerMock = vi.fn();
+
+beforeAll(() => {
+  (window as any).contextCollectAllValues = contextCollectAllValues;
+  (window as any).events = { receive: receiveMock };
+  (window as any).window.addEventListener = addEventListenerMock;
+});
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.useRealTimers();
+});
+
+test('context store values updated on context-value-updated/context-key-removed events', async () => {
+  receiveMock.mockImplementation((msg: string, f: (value: unknown) => void) => {
+    if (msg === 'context-value-updated') {
+      setTimeout(() => f({ key: 'c', value: 'three' }), 5);
+      setTimeout(() => f({ key: 'b', value: 2 }), 15);
+    } else if (msg === 'context-key-removed') {
+      setTimeout(() => f({ key: 'a', value: 1 }), 10);
+    }
+  });
+
+  vi.useFakeTimers();
+  const context = setup();
+  const initial = new ContextUI();
+  initial.setValue('a', 1);
+  initial.setValue('b', 'two');
+  context.set(initial);
+
+  vi.advanceTimersByTime(6);
+  initial.setValue('c', 'three');
+  // context-value-updated has added the value to the store
+  expect(get(context)).toEqual(initial);
+
+  vi.advanceTimersByTime(5);
+  initial.removeValue('a');
+  // context-key-removed has removed the value from the store
+  expect(get(context)).toEqual(initial);
+
+  vi.advanceTimersByTime(5);
+  initial.setValue('b', 2);
+  // context-key-updated has updated the value in the store
+  expect(get(context)).toEqual(initial);
+});
+
+test('context store values set on extensions-already-started', async () => {
+  contextCollectAllValues.mockResolvedValue({ a: 1, b: 'two' });
+  addEventListenerMock.mockImplementation((msg: string, f: () => void) => {
+    if (msg === 'extensions-already-started') {
+      f();
+    }
+  });
+
+  const context = setup();
+
+  const expected = new ContextUI();
+  expected.setValue('a', 1);
+  expected.setValue('b', 'two');
+
+  await new Promise(resolve => setTimeout(resolve, 0));
+  expect(get(context)).toEqual(expected);
+});

--- a/packages/renderer/src/stores/context.ts
+++ b/packages/renderer/src/stores/context.ts
@@ -20,6 +20,13 @@ import type { Writable } from 'svelte/store';
 import { writable } from 'svelte/store';
 import { ContextUI } from '../lib/context/context';
 
+async function getCurrentContext(): Promise<ContextUI> {
+  return Object.entries(await window.contextCollectAllValues()).reduce((result, [key, value]) => {
+    result.setValue(key, value);
+    return result;
+  }, new ContextUI());
+}
+
 export const context: Writable<ContextUI> = writable(new ContextUI());
 
 window.events?.receive('context-value-updated', (value: unknown) => {
@@ -36,4 +43,10 @@ window.events?.receive('context-key-removed', (value: unknown) => {
     ctx.removeValue(typedValue.key);
     return ctx;
   });
+});
+
+window.addEventListener('extensions-already-started', () => {
+  getCurrentContext()
+    .then(values => context.set(values))
+    .catch((err: unknown) => console.error('error getting current context', err));
 });

--- a/packages/renderer/src/stores/context.ts
+++ b/packages/renderer/src/stores/context.ts
@@ -20,34 +20,39 @@ import type { Writable } from 'svelte/store';
 import { writable } from 'svelte/store';
 import { ContextUI } from '../lib/context/context';
 
-export const context: Writable<ContextUI> = writable(new ContextUI());
+export const context: Writable<ContextUI> = setup();
 
-window.events?.receive('context-value-updated', (value: unknown) => {
-  const typedValue = value as { key: string; value: string };
-  context.update(ctx => {
-    ctx.setValue(typedValue.key, typedValue.value);
-    return ctx;
+export function setup(): Writable<ContextUI> {
+  const store = writable(new ContextUI());
+
+  window.events?.receive('context-value-updated', (value: unknown) => {
+    const typedValue = value as { key: string; value: string };
+    store.update(ctx => {
+      ctx.setValue(typedValue.key, typedValue.value);
+      return ctx;
+    });
   });
-});
 
-window.events?.receive('context-key-removed', (value: unknown) => {
-  const typedValue = value as { key: string; value: string };
-  context.update(ctx => {
-    ctx.removeValue(typedValue.key);
-    return ctx;
+  window.events?.receive('context-key-removed', (value: unknown) => {
+    const typedValue = value as { key: string; value: string };
+    store.update(ctx => {
+      ctx.removeValue(typedValue.key);
+      return ctx;
+    });
   });
-});
 
-window.addEventListener('extensions-already-started', () => {
-  // this function can be undefined during tests
-  window
-    .contextCollectAllValues?.()
-    .then(values => {
-      const currentContext = Object.entries(values).reduce((result, [key, value]) => {
-        result.setValue(key, value);
-        return result;
-      }, new ContextUI());
-      context.set(currentContext);
-    })
-    .catch((err: unknown) => console.error('error getting current context', err));
-});
+  window.addEventListener('extensions-already-started', () => {
+    // this function can be undefined during tests
+    window
+      .contextCollectAllValues?.()
+      .then(values => {
+        const currentContext = Object.entries(values).reduce((result, [key, value]) => {
+          result.setValue(key, value);
+          return result;
+        }, new ContextUI());
+        store.set(currentContext);
+      })
+      .catch((err: unknown) => console.error('error getting current context', err));
+  });
+  return store;
+}


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

The current `context` store is initialized with an empty context and receives updates when the context changes.

But if the user reloads the window, the store is reset, but never receives again the previous values.
 
This PR gets the current values of the context to set the new value of the context store when the event `extensions-already-started` is received, event happening when the window is reloaded.


### What issues does this PR fix or reference?

Fixes #4605 

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
