### PR TITLE
chore: fix invalid URL when trying a registry using basic auth

### DIFF
--- a/packages/main/src/plugin/image-registry.ts
+++ b/packages/main/src/plugin/image-registry.ts
@@ -735,12 +735,12 @@ export class ImageRegistry {
         if (wwwAuthenticate) {
           const authInfo = this.extractAuthData(wwwAuthenticate);
           if (authInfo) {
-            const url = new URL(authInfo.authUrl);
             scheme = authInfo.scheme?.toLowerCase();
             // in case of basic auth, we use directly the registry URL
             if (scheme === 'basic') {
               return { authUrl: registryUrl, scheme };
             }
+            const url = new URL(authInfo.authUrl);
             if (authInfo.service) {
               url.searchParams.set('service', authInfo.service);
             }


### PR DESCRIPTION
### What does this PR do?
url was initialized using `url = new URL(authInfo.authUrl);` but in case of basic, authUrl is undefined and we return a different a different url (the registry URL)

initialize later that url object once basic case has been handled.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/6344

### How to test this PR?

Look at a manual test in the linked issue else unit tests are provided

- [x] Tests are covering the bug fix or the new feature
