### PR TITLE
fix: try to listen on all ipv4 interfaces AND 0.0.0.0 before to declare a port free

### DIFF
--- a/packages/main/src/plugin/util/port.ts
+++ b/packages/main/src/plugin/util/port.ts
@@ -55,12 +55,16 @@ export async function getFreePortRange(rangeSize: number): Promise<string> {
   return `${startPort}-${port - 1}`;
 }
 
-export function isFreePort(port: number): Promise<boolean> {
+function isFreeAddressPort(address: string, port: number): Promise<boolean> {
   const server = net.createServer();
   return new Promise((resolve, reject) =>
     server
       .on('error', (error: NodeJS.ErrnoException) => (error.code === 'EADDRINUSE' ? resolve(false) : reject(error)))
       .on('listening', () => server.close(() => resolve(true)))
-      .listen(port, '127.0.0.1'),
+      .listen(port, address),
   );
+}
+
+export async function isFreePort(port: number): Promise<boolean> {
+  return (await isFreeAddressPort('127.0.0.1', port)) && (await isFreeAddressPort('0.0.0.0', port));
 }

--- a/packages/main/src/plugin/util/port.ts
+++ b/packages/main/src/plugin/util/port.ts
@@ -68,7 +68,10 @@ function isFreeAddressPort(address: string, port: number): Promise<boolean> {
 
 export async function isFreePort(port: number): Promise<boolean> {
   const intfs = getIPv4Interfaces();
-  intfs.push('0.0.0.0');
+  // Test this special interface separately, or it will interfere with other tests done in parallel
+  if (!(await isFreeAddressPort('0.0.0.0', port))) {
+    return false;
+  }
   const checkInterfaces = await Promise.all(intfs.map(intf => isFreeAddressPort(intf, port)));
   return checkInterfaces.every(element => element === true);
 }


### PR DESCRIPTION
### What does this PR do?

If an application binds to a port using the INADDR_ANY address (0.0.0.0) and setting the `SO_REUSEADDR` flag, another application can bind to the port on a local address without failure.

> Some folks don't like SO_REUSEADDR because it has a security stigma attached to it. On some operating systems it allows the same port to be used with a different address on the same machine by different processes at the same time. This is a problem because most servers bind to the port, but they don't bind to a specific address, instead they use INADDR_ANY (this is why things show up in netstat output as *.8080). So if the server is bound to *.8080, another malicious user on the local machine can bind to local-machine.8080, which will intercept all of your connections since it is more specific. (https://stackoverflow.com/questions/60217071/node-js-server-listens-to-the-same-port-on-0-0-0-0-and-localhost-without-error)

This PR duplicates the tests where a call to `listen` is done, to listen either in `127.0.0.1` or in `0.0.0.0`.

On Mac, the tests when listening on `0.0.0.0` fail without this patch.

The proposed patch is to try and listen on all local addresses AND 0.0.0.0 before to declare that a port is free.

### What issues does this PR fix or reference?

Fixes #5996 

### How to test this PR?

See Steps to reproduce in #5996 

- [x] Tests are covering the bug fix or the new feature
