### PR TITLE
fix: add playsinline to avoid full screen

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -204,7 +204,7 @@ image: /blog/img/podman-desktop-release-1.X/X.png
 <!-- ADD IMPORT REACTPLAYER IF USING VIDEO -->
 <!-- import ReactPlayer from 'react-player' -->
 <!-- EXAMPLE -->
-<!-- <ReactPlayer playing controls url="https://user-images.githubusercontent.com/436777/241246481-305d215f-2a5c-46e8-9cc3-ecd90a6bd2bc.mp4" /> -->
+<!-- <ReactPlayer playing playsinline controls url="https://user-images.githubusercontent.com/436777/241246481-305d215f-2a5c-46e8-9cc3-ecd90a6bd2bc.mp4" /> -->
 
 Podman Desktop X.X Release! 🎉
 

--- a/website/blog/2023-01-18-release-0.11.md
+++ b/website/blog/2023-01-18-release-0.11.md
@@ -39,13 +39,13 @@ Please note, that those binaries are available only on releases and not the pre-
 
 There is also an optional way to provide a custom Podman machine image in the create machine form. By providing the path to the image you want, Podman Desktop will create a machine with that image. Leaving the field empty will use the default image (the one included in the binary).
 
-<ReactPlayer playing controls url='https://user-images.githubusercontent.com/436777/210508524-45005536-ac74-4074-92c1-2b3ca51d0073.mp4' width='100%' height='100%' />
+<ReactPlayer playing playsinline controls url='https://user-images.githubusercontent.com/436777/210508524-45005536-ac74-4074-92c1-2b3ca51d0073.mp4' width='100%' height='100%' />
 
 ### Feedback within Podman Desktop [#1078](https://github.com/containers/podman-desktop/pull/1078)
 
 Submitting feedback on Podman Desktop is getting easier as it is possible directly within the tool. This will help to get more information about the issues you are facing and will help us to improve the tool.
 
-<ReactPlayer playing controls url='https://user-images.githubusercontent.com/436777/208938878-948a2764-d73b-4584-a80d-497c052482c1.mp4' width='100%' height='100%' />
+<ReactPlayer playing playsinline controls url='https://user-images.githubusercontent.com/436777/208938878-948a2764-d73b-4584-a80d-497c052482c1.mp4' width='100%' height='100%' />
 
 Please feel free to submit any feedback you have, we are looking forward to hearing from you!
 
@@ -70,7 +70,7 @@ This is the warning for Mac users:
 
 In some context, users need the ability to disable and re-enable the proxy configuration very quickly, without having to entirely reconfigure it. This is now possible from the Podman Desktop settings page, where a toggle to enable/disable the proxy configuration has been added.
 
-<ReactPlayer playing controls url='https://user-images.githubusercontent.com/436777/205955418-670bc37c-a74f-40ef-bc60-8d9d013aa0dc.mp4' width='100%' height='100%' />
+<ReactPlayer playing playsinline controls url='https://user-images.githubusercontent.com/436777/205955418-670bc37c-a74f-40ef-bc60-8d9d013aa0dc.mp4' width='100%' height='100%' />
 
 Note: extensions can read this information and then update the proxy configuration.
 
@@ -99,7 +99,7 @@ The experience of configuring a registry is getting simplified for the most popu
 - IBM Container Registry
 - Google Container Registry
 
-<ReactPlayer playing controls url='https://user-images.githubusercontent.com/6422176/214332937-eb1d9050-0d32-4bc4-8393-49b4583b1390.mov' width='100%' height='100%' />
+<ReactPlayer playing playsinline controls url='https://user-images.githubusercontent.com/6422176/214332937-eb1d9050-0d32-4bc4-8393-49b4583b1390.mov' width='100%' height='100%' />
 
 ### UI/UX Improvements
 
@@ -113,29 +113,29 @@ The pods details view provides the ability to view the logs of each containers t
 
 When starting/stopping or deleting a container, a spinner is now displayed. In case of error, a message indicating that the action failed will also be better indicated.
 
-<ReactPlayer playing controls url='https://user-images.githubusercontent.com/436777/211531610-2347d302-4918-46ae-a5a2-c80fac0314f5.mp4' width='100%' height='100%' />
+<ReactPlayer playing playsinline controls url='https://user-images.githubusercontent.com/436777/211531610-2347d302-4918-46ae-a5a2-c80fac0314f5.mp4' width='100%' height='100%' />
 
 For containers that exit immediately or short-lived containers, the feedback is also improved and include report of error now provide a better feedback to the user [#1161](https://github.com/containers/podman-desktop/pull/1161).
 
-<ReactPlayer playing controls url='https://user-images.githubusercontent.com/436777/211831905-ebf596d5-efc8-4f55-8cb8-3f31655388b9.mp4' width='100%' height='100%' />
+<ReactPlayer playing playsinline controls url='https://user-images.githubusercontent.com/436777/211831905-ebf596d5-efc8-4f55-8cb8-3f31655388b9.mp4' width='100%' height='100%' />
 
 #### Allows to change the default font size for the editor [#1160](https://github.com/containers/podman-desktop/pull/1160)
 
 An editor is used in several screens of Podman Desktop, from the inspect screen to container's outputs and Kubernetes YAML. The default font size is 10 pixels. It's now possible to adjust the font size to the one the one you prefer. This setting is persisted and will be used for all the editors of Podman Desktop and available from the preferences page (Settings -> Preferences).
 
-<ReactPlayer playing controls url='https://user-images.githubusercontent.com/436777/211778161-130ff733-b2ca-4306-bea3-d031196c3b29.mp4' width='100%' height='100%' />
+<ReactPlayer playing playsinline controls url='https://user-images.githubusercontent.com/436777/211778161-130ff733-b2ca-4306-bea3-d031196c3b29.mp4' width='100%' height='100%' />
 
 #### Keep expanded state of pods when refreshing containers [#1042](https://github.com/containers/podman-desktop/pull/1042)
 
 When switching from different screens of the application or simply refreshing the list of containers, the expanded state of each item in the list is now persisted and will be properly restored.
 
-<ReactPlayer playing controls url='https://user-images.githubusercontent.com/436777/207864147-b68ea9bd-0ca9-42dc-882e-b8a705233749.mp4' width='100%' height='100%' />
+<ReactPlayer playing playsinline controls url='https://user-images.githubusercontent.com/436777/207864147-b68ea9bd-0ca9-42dc-882e-b8a705233749.mp4' width='100%' height='100%' />
 
 #### Click on the Pod name redirects to the Pod details page [#1159](https://github.com/containers/podman-desktop/pull/1159)
 
 The list of containers also displays pods, now clicking on the pod name directly redirects to the Pod details page.
 
-<ReactPlayer playing controls url='https://user-images.githubusercontent.com/436777/211770946-2255f39f-7e2e-48ad-9ead-bcbfe6a115a7.mp4' width='100%' height='100%' />
+<ReactPlayer playing playsinline controls url='https://user-images.githubusercontent.com/436777/211770946-2255f39f-7e2e-48ad-9ead-bcbfe6a115a7.mp4' width='100%' height='100%' />
 
 #### Improved styles of buttons for actions [#984](https://github.com/containers/podman-desktop/pull/984)
 

--- a/website/blog/2023-03-29-release-0.13.md
+++ b/website/blog/2023-03-29-release-0.13.md
@@ -74,7 +74,7 @@ The other settings pages have been updated for consistency with this new design.
 
 A new alert button will appear in the status bar when future updates are available.
 
-<ReactPlayer playing controls url='https://user-images.githubusercontent.com/436777/227596136-c6123d5c-d9ae-4fb3-a569-0cfaaeebf09c.mp4' width='100%' height='100%' />
+<ReactPlayer playing playsinline controls url='https://user-images.githubusercontent.com/436777/227596136-c6123d5c-d9ae-4fb3-a569-0cfaaeebf09c.mp4' width='100%' height='100%' />
 
 #### Prune buttons [#1481](https://github.com/containers/podman-desktop/pull/1481), [#1482](https://github.com/containers/podman-desktop/pull/1482), [#1484](https://github.com/containers/podman-desktop/pull/1484)
 

--- a/website/blog/2023-04-14-release-0.14.md
+++ b/website/blog/2023-04-14-release-0.14.md
@@ -72,7 +72,7 @@ Within Podman Desktop we have started with two ways to interact with the cluster
 The first is the ability to play local YAML files on your Kind (or any other Kubernetes!) cluster [1261](https://github.com/containers/podman-desktop/issues/1261). This allows you to take existing Kubernetes YAML definitions -
 your deployments, services, or other objects - and deploy it to the cluster.
 
-<ReactPlayer playing controls url="https://user-images.githubusercontent.com/436777/231812563-ece0a56a-b347-48f8-a3a7-400eb9449037.mp4" width='100%' height='100%' />
+<ReactPlayer playing playsinline controls url="https://user-images.githubusercontent.com/436777/231812563-ece0a56a-b347-48f8-a3a7-400eb9449037.mp4" width='100%' height='100%' />
 
 As you deploy pods, they will automatically appear in the list of **Pods** [1263](https://github.com/containers/podman-desktop/issues/1263), allowing you to start, stop, and interact them just like pods running on Podman.
 

--- a/website/blog/2023-05-02-release-0.15.md
+++ b/website/blog/2023-05-02-release-0.15.md
@@ -47,7 +47,7 @@ but you still couldn't access your containers without the corresponding ingress.
 This release adds a simple checkbox you can use when deploying to Kind to create an ingress and
 make your service accessible [#1322](https://github.com/containers/podman-desktop/issues/1322).
 
-<ReactPlayer playing controls url="https://user-images.githubusercontent.com/6422176/232894496-cbaea036-a14c-46c6-bfa3-bacca629a161.mov" width='100%' height='100%' />
+<ReactPlayer playing playsinline controls url="https://user-images.githubusercontent.com/6422176/232894496-cbaea036-a14c-46c6-bfa3-bacca629a161.mov" width='100%' height='100%' />
 
 ### Podliness: Ability to Choose External Ports when Podifying Containers
 

--- a/website/blog/2023-06-08-release-1.1.md
+++ b/website/blog/2023-06-08-release-1.1.md
@@ -45,7 +45,7 @@ Podman Desktop [#2655](https://github.com/containers/podman-desktop/pull/2655).
 We've also added options in **<Icon icon="fa-solid fa-cog" size="lg" />Settings > Preferences** to
 automatically check for and install extension updates.
 
-<ReactPlayer playing controls url="https://user-images.githubusercontent.com/436777/241246481-305d215f-2a5c-46e8-9cc3-ecd90a6bd2bc.mp4" width='100%' height='100%' />
+<ReactPlayer playing playsinline controls url="https://user-images.githubusercontent.com/436777/241246481-305d215f-2a5c-46e8-9cc3-ecd90a6bd2bc.mp4" width='100%' height='100%' />
 
 ![Update extensions](img/podman-desktop-release-1.1/update-extensions.png)
 
@@ -63,7 +63,7 @@ engine type Lima runs on and override the instance name [#2674](https://github.c
 
 We have a new loading screen, Podman Desktop style! [#2743](https://github.com/containers/podman-desktop/pull/2743).
 
-<ReactPlayer playing controls url="https://user-images.githubusercontent.com/436777/243706137-324b5870-f6a0-4bc1-ac91-e8b45c374c90.mp4" width='100%' height='100%' />
+<ReactPlayer playing playsinline controls url="https://user-images.githubusercontent.com/436777/243706137-324b5870-f6a0-4bc1-ac91-e8b45c374c90.mp4" width='100%' height='100%' />
 
 ---
 

--- a/website/blog/2023-07-12-release-1.2.md
+++ b/website/blog/2023-07-12-release-1.2.md
@@ -34,19 +34,19 @@ In the last month we've been addind support for more Compose features. Before yo
 
 Stay tuned as we add even more features to Compose! If you have any feedback or feature requests, feel free to open an issue or start a discussion on GitHub.
 
-<ReactPlayer playing controls url="https://user-images.githubusercontent.com/6422176/253331226-d80e7637-c223-4bb8-8675-1dcb8d48818f.mov" width='100%' height='100%' />
+<ReactPlayer playing playsinline controls url="https://user-images.githubusercontent.com/6422176/253331226-d80e7637-c223-4bb8-8675-1dcb8d48818f.mov" width='100%' height='100%' />
 
 ### Kubernetes context on the status bar
 
 With Kubernetes context on the status bar, you can switch from one context to another in just a couple of clicks. Easily switch to a different cluster all together. If there are multiple contexts available, you can now click and pick which one to use.
 
-<ReactPlayer playing controls url="https://user-images.githubusercontent.com/19958075/243804525-242b02b4-fc3c-415b-be08-24eb1933adc5.mov" width='100%' height='100%' />
+<ReactPlayer playing playsinline controls url="https://user-images.githubusercontent.com/19958075/243804525-242b02b4-fc3c-415b-be08-24eb1933adc5.mov" width='100%' height='100%' />
 
 ### Rename images
 
 Deployed an image but now you need to rename it / add a new tag? Podman Desktop allows you to edit an image now. Thanks to an awesome contributor [@tuckerrc](https://github.com/tuckerrc) who added the new feature.
 
-<ReactPlayer playing controls url="https://user-images.githubusercontent.com/436777/251759557-bd15a631-93ee-4383-a81c-8ef3934dfb59.mp4" width='100%' height='100%' />
+<ReactPlayer playing playsinline controls url="https://user-images.githubusercontent.com/436777/251759557-bd15a631-93ee-4383-a81c-8ef3934dfb59.mp4" width='100%' height='100%' />
 
 ### Troubleshooting page
 
@@ -54,13 +54,13 @@ Developing an extension for Podman Desktop? Want to view the logs of Podman Desk
 
 Click on the lightbulb button on the bottom right to access the page.
 
-<ReactPlayer playing controls url="https://user-images.githubusercontent.com/436777/248210601-e0a5deb0-44ad-4eea-9b24-134754fede80.mp4" width='100%' height='100%' />
+<ReactPlayer playing playsinline controls url="https://user-images.githubusercontent.com/436777/248210601-e0a5deb0-44ad-4eea-9b24-134754fede80.mp4" width='100%' height='100%' />
 
 ### Protocol handler support
 
 Podman Desktop now supports protocol handling when using the terminal! Want to access your favourite extension directly from a script or the terminal? If you type in `open podman-desktop:extension/redhat.openshift-local` in the terminal, Podman Desktop will automatically load up to the correct extension.
 
-<ReactPlayer playing controls url="https://user-images.githubusercontent.com/436777/243304511-b11ad1e4-4c2f-455c-957a-01653d2a93c8.mp4" width='100%' height='100%' />
+<ReactPlayer playing playsinline controls url="https://user-images.githubusercontent.com/436777/243304511-b11ad1e4-4c2f-455c-957a-01653d2a93c8.mp4" width='100%' height='100%' />
 
 ---
 

--- a/website/blog/2023-08-16-release-1.3.md
+++ b/website/blog/2023-08-16-release-1.3.md
@@ -48,31 +48,31 @@ Certain VPN setups or other specialized networking configs will block traffic fr
 
 Compose group Summary tab shows all containers in the group and let you navigate to Details page for specific container.
 
-<ReactPlayer playing controls url="https://github.com/containers/podman-desktop/assets/620330/6dd6dacd-a0d8-478d-b11e-2b414108bd20" width='100%' height='100%' />
+<ReactPlayer playing playsinline controls url="https://github.com/containers/podman-desktop/assets/620330/6dd6dacd-a0d8-478d-b11e-2b414108bd20" width='100%' height='100%' />
 
 ### Compose group Inspect tab [#3316](https://github.com/containers/podman-desktop/pull/3316)
 
 Compose group Inspect tab shows an array of "container inspect" from docker / podman.
 
-<ReactPlayer playing controls url="https://user-images.githubusercontent.com/6422176/255658081-4a2ce4ce-bdc7-435d-9114-1071ab1ec3c5.mov" width='100%' height='100%' />
+<ReactPlayer playing playsinline controls url="https://user-images.githubusercontent.com/6422176/255658081-4a2ce4ce-bdc7-435d-9114-1071ab1ec3c5.mov" width='100%' height='100%' />
 
 ### `Deploy to kubernetes` in compose actions [#3299](https://github.com/containers/podman-desktop/pull/3295)
 
 A button to deploy to kubernetes added to Compose group.
 
-<ReactPlayer playing controls url="https://user-images.githubusercontent.com/6422176/254973806-1ce57225-3422-4d36-8d09-b70a2825869f.mov" width='100%' height='100%' />
+<ReactPlayer playing playsinline controls url="https://user-images.githubusercontent.com/6422176/254973806-1ce57225-3422-4d36-8d09-b70a2825869f.mov" width='100%' height='100%' />
 
 ### `Generate Kube` in Compose actions and `Kube` tab in compose details [#3253](https://github.com/containers/podman-desktop/pull/3253)
 
 `Generate Kube` item added to Compose actions and "Kube" tab is now available in Compose details view.
 
-<ReactPlayer playing controls url="https://user-images.githubusercontent.com/6422176/254337805-98268722-4dde-4c0e-afdf-4873fa4f43fe.mov" width='100%' height='100%' />
+<ReactPlayer playing playsinline controls url="https://user-images.githubusercontent.com/6422176/254337805-98268722-4dde-4c0e-afdf-4873fa4f43fe.mov" width='100%' height='100%' />
 
 ### Install multiple extensions using extension pack [#3150](https://github.com/containers/podman-desktop/pull/3150)
 
 An Extension pack introduced in Extension engine is a way to declare set of extensions to install them all at once.
 
-<ReactPlayer playing controls url="https://user-images.githubusercontent.com/436777/251741571-0cd4a199-06f4-4890-8414-4e93ca9178bc.mp4" width='100%' height='100%' />
+<ReactPlayer playing playsinline controls url="https://user-images.githubusercontent.com/436777/251741571-0cd4a199-06f4-4890-8414-4e93ca9178bc.mp4" width='100%' height='100%' />
 
 ### Customize icons from extension [#3131](https://github.com/containers/podman-desktop/pull/3131)
 

--- a/website/blog/2023-11-03-release-1.5.md
+++ b/website/blog/2023-11-03-release-1.5.md
@@ -47,13 +47,13 @@ Visit **<Icon icon="fa-solid fa-cog" size="lg"/>Settings > Resources** screen an
 
 A new, search-driven command palette is now available to enable quick access to various commands available across 🦭 Podman Desktop. You can try this new tool out by hitting the F1 key. [#4081](https://github.com/containers/podman-desktop/pull/4081) &amp;&amp; [#3979](https://github.com/containers/podman-desktop/pull/3979)
 
-<ReactPlayer playing controls url="https://user-images.githubusercontent.com/436777/270362431-5aaa6a1b-6df5-4b66-a811-cdd148d02ad6.mp4" width='100%' height='100%' />
+<ReactPlayer playing playsinline controls url="https://user-images.githubusercontent.com/436777/270362431-5aaa6a1b-6df5-4b66-a811-cdd148d02ad6.mp4" width='100%' height='100%' />
 
 ### Expanded "Summary" tab for Kubernetes pods
 
 Kubernetes pods now offer a more comprehensive set of information under the "Summary" tab, including networking, volumes, environment variables, and other key metadata.
 
-<ReactPlayer playing controls url="https://user-images.githubusercontent.com/6422176/272972815-bed96f3a-6b13-45d3-a13b-74eacb27a4cd.mov" width='100%' height='100%' />
+<ReactPlayer playing playsinline controls url="https://user-images.githubusercontent.com/6422176/272972815-bed96f3a-6b13-45d3-a13b-74eacb27a4cd.mov" width='100%' height='100%' />
 
 ### Environment file support
 
@@ -63,15 +63,15 @@ When creating a container from the Images list, there's now an option to provide
 
 The user experience for enabling or disabling Docker compatibility is improved, with a new entry in the **<Icon icon="fa-solid fa-cog" size="lg" />Settings > Preferences** screen that includes contextual guidance. [#4093](https://github.com/containers/podman-desktop/pull/4093)
 
-<ReactPlayer playing controls url="https://user-images.githubusercontent.com/6422176/270497318-902b2566-62ad-4ee6-87af-6a9a2705de99.mov" width='100%' height='100%' />
+<ReactPlayer playing playsinline controls url="https://user-images.githubusercontent.com/6422176/270497318-902b2566-62ad-4ee6-87af-6a9a2705de99.mov" width='100%' height='100%' />
 
 ### Improved user experience for state changes
 
 The user experience around state changes for containers, pods, and other objects in the UI is improved, with clear status messages and improved animated visual indicator of state changes. [#4056](https://github.com/containers/podman-desktop/pull/4056)
 
-<ReactPlayer playing controls url="https://user-images.githubusercontent.com/19958075/270027524-f5176cf9-462f-4024-920a-b4a906c7d30d.mov" width='100%' height='100%' />
+<ReactPlayer playing playsinline controls url="https://user-images.githubusercontent.com/19958075/270027524-f5176cf9-462f-4024-920a-b4a906c7d30d.mov" width='100%' height='100%' />
 
-<ReactPlayer playing controls url="https://user-images.githubusercontent.com/19958075/270027533-70e152ec-5bbf-45ad-9f1d-563752464655.mov" width='100%' height='100%' />
+<ReactPlayer playing playsinline controls url="https://user-images.githubusercontent.com/19958075/270027533-70e152ec-5bbf-45ad-9f1d-563752464655.mov" width='100%' height='100%' />
 
 ### Extension API improvements
 
@@ -91,7 +91,7 @@ The 🦭 Podman Desktop extension API received many improvements, including:
 
 - Enhanced logic for displaying or hiding properties listed under the **<Icon icon="fa-solid fa-cog" size="lg" />Settings > Preferences** screens is now available. [#4159](https://github.com/containers/podman-desktop/pull/4159)
 
-<ReactPlayer playing controls url="https://user-images.githubusercontent.com/6422176/271650937-3991565c-12a4-4e6c-a315-9343bfa25f65.mov" width='100%' height='100%' />
+<ReactPlayer playing playsinline controls url="https://user-images.githubusercontent.com/6422176/271650937-3991565c-12a4-4e6c-a315-9343bfa25f65.mov" width='100%' height='100%' />
 
 ---
 
@@ -111,7 +111,7 @@ The 🦭 Podman Desktop extension API received many improvements, including:
 
 - The empty screen message shown when a search filter results in no matches now provides a message specific to filter matching, including the specific filter terms and an explicit button for clearing the filter. Previously, the screen displayed a generic message about how to create new objects of the type displayed on the screen, which led to some confusion about the status of the system. [#3988](https://github.com/containers/podman-desktop/pull/3988)
 
-<ReactPlayer playing controls url="https://user-images.githubusercontent.com/19958075/269291090-13e724f7-252f-4915-bb04-00665001d21d.mov" width='100%' height='100%' />
+<ReactPlayer playing playsinline controls url="https://user-images.githubusercontent.com/19958075/269291090-13e724f7-252f-4915-bb04-00665001d21d.mov" width='100%' height='100%' />
 
 - New support for adding spin animations to icons is now available. [#4188](https://github.com/containers/podman-desktop/pull/4188)
 
@@ -121,7 +121,7 @@ The 🦭 Podman Desktop extension API received many improvements, including:
 
 ![touchID-support](https://user-images.githubusercontent.com/436777/248588015-f08115bd-d211-43ad-bddd-286d7b3a7056.png)
 
-<ReactPlayer playing controls url="https://user-images.githubusercontent.com/436777/269859758-47581e2b-8469-4e9c-822c-f4fddf46684d.mp4" width='100%' height='100%' />
+<ReactPlayer playing playsinline controls url="https://user-images.githubusercontent.com/436777/269859758-47581e2b-8469-4e9c-822c-f4fddf46684d.mp4" width='100%' height='100%' />
 
 - Support for connecting to interactive terminals for containers via tty was added. [#3900](https://github.com/containers/podman-desktop/pull/3900)
 


### PR DESCRIPTION
### What does this PR do?

The 'playing' attribute sets the player to auto-start, but it is starting full screen. Adding 'playsinline' to every react player should ensure that it doesn't go full screen on phones.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes #6335.

### How to test this PR?

Browse blogs with videos (e.g. 1.5 release) on a phone and confirm the videos aren't full screen by default.