### PR TITLE
chore: store combining PD and DD extensions

### DIFF
--- a/packages/renderer/src/stores/all-installed-extensions.spec.ts
+++ b/packages/renderer/src/stores/all-installed-extensions.spec.ts
@@ -1,0 +1,173 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { get } from 'svelte/store';
+import { beforeEach, expect, test, vi } from 'vitest';
+import { combinedInstalledExtensions } from './all-installed-extensions';
+import { contributions } from './contribs';
+import { extensionInfos } from './extensions';
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  contributions.set([]);
+  extensionInfos.set([]);
+});
+
+test('combined extensions from DD', async () => {
+  let allExtensons = get(combinedInstalledExtensions);
+
+  expect(allExtensons.length).toBe(0);
+
+  // now, add some contributions
+  contributions.set([
+    {
+      id: 'first.extension1',
+      extensionId: 'first.extension1',
+      description: 'test1',
+      type: 'hello',
+      uiUri: 'http://test1',
+      icon: 'icon1',
+      hostEnvPath: 'path1',
+      storagePath: 'storage1',
+      displayName: 'test1',
+      publisher: 'Foo publisher',
+      name: 'extension',
+      version: '1.0.0',
+    },
+    {
+      id: 'second.extension2',
+      extensionId: 'second.extension2',
+      description: 'test2',
+      type: 'hello',
+      uiUri: 'http://test2',
+      icon: 'icon2',
+      hostEnvPath: 'path2',
+      storagePath: 'storage2',
+      displayName: 'test2',
+      publisher: 'Foo publisher',
+      name: 'extension2',
+      version: '2.0.0',
+    },
+  ]);
+
+  // refresh the extensions
+  allExtensons = get(combinedInstalledExtensions);
+  expect(allExtensons.length).toBe(2);
+
+  const extension1 = allExtensons.find(ext => ext.id === 'first.extension1');
+  expect(extension1).toBeDefined();
+
+  expect(extension1?.type).toBe('dd');
+  expect(extension1?.displayName).toBe('test1');
+});
+
+test('combined extensions from PD', async () => {
+  let allExtensons = get(combinedInstalledExtensions);
+
+  expect(allExtensons.length).toBe(0);
+
+  extensionInfos.set([
+    {
+      id: 'first.extension1',
+      name: 'first.extension1',
+      description: 'test1',
+      displayName: 'test1',
+      publisher: 'Foo publisher',
+      removable: true,
+      version: '1.0.0',
+      state: 'started',
+      path: 'path1',
+      readme: 'readme1',
+    },
+    {
+      id: 'second.extension2',
+      name: 'second.extension2',
+      description: 'test2',
+      displayName: 'test2',
+      publisher: 'Foo publisher',
+      removable: true,
+      version: '2.0.0',
+      state: 'started',
+      path: 'path2',
+      readme: 'readme2',
+    },
+  ]);
+
+  // refresh the extensions
+  allExtensons = get(combinedInstalledExtensions);
+  expect(allExtensons.length).toBe(2);
+
+  const extension1 = allExtensons.find(ext => ext.id === 'first.extension1');
+  expect(extension1).toBeDefined();
+
+  expect(extension1?.type).toBe('pd');
+  expect(extension1?.displayName).toBe('test1');
+});
+
+test('combined extensions from all', async () => {
+  let allExtensons = get(combinedInstalledExtensions);
+
+  expect(allExtensons.length).toBe(0);
+
+  extensionInfos.set([
+    {
+      id: 'first.extension1',
+      name: 'first.extension1',
+      description: 'test1',
+      displayName: 'test1',
+      publisher: 'Foo publisher',
+      removable: true,
+      version: '1.0.0',
+      state: 'started',
+      path: 'path1',
+      readme: 'readme1',
+    },
+  ]);
+
+  contributions.set([
+    {
+      id: 'second.extension2',
+      extensionId: 'second.extension2',
+      description: 'test2',
+      type: 'hello',
+      uiUri: 'http://test2',
+      icon: 'icon2',
+      hostEnvPath: 'path2',
+      storagePath: 'storage2',
+      displayName: 'test2',
+      publisher: 'Foo publisher',
+      name: 'extension2',
+      version: '2.0.0',
+    },
+  ]);
+
+  // refresh the extensions
+  allExtensons = get(combinedInstalledExtensions);
+  expect(allExtensons.length).toBe(2);
+
+  const extension1 = allExtensons.find(ext => ext.id === 'first.extension1');
+  expect(extension1).toBeDefined();
+  expect(extension1?.type).toBe('pd');
+  expect(extension1?.displayName).toBe('test1');
+
+  const extension2 = allExtensons.find(ext => ext.id === 'second.extension2');
+  expect(extension2).toBeDefined();
+
+  expect(extension2?.type).toBe('dd');
+  expect(extension2?.displayName).toBe('test2');
+});

--- a/packages/renderer/src/stores/all-installed-extensions.ts
+++ b/packages/renderer/src/stores/all-installed-extensions.ts
@@ -23,6 +23,7 @@ import { contributions } from './contribs';
 import type { ExtensionInfo } from '../../../main/src/plugin/api/extension-info';
 
 export interface CombinedExtensionInfoUI extends ExtensionInfo {
+  // type is either 'pd' for Podman Desktop or 'dd' for 'Docker Desktop'
   type: 'dd' | 'pd';
 }
 

--- a/packages/renderer/src/stores/all-installed-extensions.ts
+++ b/packages/renderer/src/stores/all-installed-extensions.ts
@@ -1,0 +1,60 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+// Combine PD and DD extensions being installed
+import { derived, type Readable } from 'svelte/store';
+import { extensionInfos } from './extensions';
+import { contributions } from './contribs';
+import type { ExtensionInfo } from '../../../main/src/plugin/api/extension-info';
+
+export interface CombinedExtensionInfoUI extends ExtensionInfo {
+  type: 'dd' | 'pd';
+}
+
+export const combinedInstalledExtensions: Readable<CombinedExtensionInfoUI[]> = derived(
+  [contributions, extensionInfos],
+  ([$contributions, $extensionInfos]) => {
+    // Combine PD and DD extensions being installed
+
+    // add type to each extension
+    const pdExtensions: CombinedExtensionInfoUI[] = $extensionInfos.map(ext => ({ ...ext, type: 'pd' }));
+
+    // now convert the contributions to the same type
+    const ddExtensions: CombinedExtensionInfoUI[] = $contributions.map(ext => {
+      let displayName = ext.displayName;
+      if (!displayName) {
+        displayName = ext.name;
+      }
+      return {
+        ...ext,
+        displayName,
+        type: 'dd',
+        state: 'started',
+        removable: true,
+        path: ext.storagePath,
+        readme: ext.readme ?? '',
+      };
+    });
+
+    const allExtensions = [...pdExtensions, ...ddExtensions];
+
+    // sort by display name
+    allExtensions.sort((a, b) => a.displayName.localeCompare(b.displayName));
+    return allExtensions;
+  },
+);


### PR DESCRIPTION
### What does this PR do?
In UI we need to display PD and DD in a common way, use this derived store that is aggregating both sources

it adds a `type` attribute being either `pd` or `dd`

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/6341


### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
