### PR TITLE
chore: replace ENABLED by ACTIVE in extension status

### DIFF
--- a/packages/renderer/src/lib/ui/ExtensionStatus.spec.ts
+++ b/packages/renderer/src/lib/ui/ExtensionStatus.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,9 +21,6 @@ import { test, expect } from 'vitest';
 import { render, screen } from '@testing-library/svelte';
 import ExtensionStatus from './ExtensionStatus.svelte';
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
-/* eslint-disable @typescript-eslint/no-empty-function */
-
 const connectionStatusLabel = 'Connection Status Label';
 const connectionStatusIcon = 'Connection Status Icon';
 
@@ -35,7 +32,7 @@ test('Expect green text and icon when connection is running', async () => {
   expect(icon).toHaveClass('bg-green-500');
   expect(label).toBeInTheDocument();
   expect(label).toHaveClass('text-green-500');
-  expect(label).toHaveTextContent('ENABLED');
+  expect(label).toHaveTextContent('ACTIVE');
 });
 
 test('Expect green text and icon when connection is starting', async () => {

--- a/packages/renderer/src/lib/ui/ExtensionStatus.spec.ts
+++ b/packages/renderer/src/lib/ui/ExtensionStatus.spec.ts
@@ -43,7 +43,7 @@ test('Expect green text and icon when connection is starting', async () => {
   expect(icon).toHaveClass('bg-green-500');
   expect(label).toBeInTheDocument();
   expect(label).toHaveClass('text-green-500');
-  expect(label).toHaveTextContent('ENABLING');
+  expect(label).toHaveTextContent('ACTIVATING');
 });
 
 test('Expect green text and icon when connection is stopped', async () => {

--- a/packages/renderer/src/lib/ui/ExtensionStatus.svelte
+++ b/packages/renderer/src/lib/ui/ExtensionStatus.svelte
@@ -15,7 +15,7 @@ const statusesStyle = new Map<string, connectionStatusStyle>([
     {
       bgColor: 'bg-green-500',
       txtColor: 'text-green-500',
-      label: 'ENABLED',
+      label: 'ACTIVE',
     },
   ],
   [

--- a/packages/renderer/src/lib/ui/ExtensionStatus.svelte
+++ b/packages/renderer/src/lib/ui/ExtensionStatus.svelte
@@ -23,7 +23,7 @@ const statusesStyle = new Map<string, connectionStatusStyle>([
     {
       bgColor: 'bg-green-500',
       txtColor: 'text-green-500',
-      label: 'ENABLING',
+      label: 'ACTIVATING',
     },
   ],
   [

--- a/tests/playwright/src/specs/podman-extension-smoke.spec.ts
+++ b/tests/playwright/src/specs/podman-extension-smoke.spec.ts
@@ -35,7 +35,7 @@ const PODMAN_EXTENSION_STATUS_OFF: string = 'OFF';
 const SETTINGS_NAVBAR_PREFERENCES_PODMAN_EXTENSION: string = 'Extension: Podman';
 const SETTINGS_NAVBAR_EXTENSIONS_PODMAN: string = 'Podman';
 const PODMAN_EXTENSION_PAGE_HEADING: string = 'Podman Extension';
-const PODMAN_EXTENSION_PAGE_STATUS_ENABLED: string = 'ENABLED';
+const PODMAN_EXTENSION_PAGE_STATUS_ACTIVE: string = 'ACTIVE';
 const PODMAN_EXTENSION_PAGE_STATUS_DISABLED: string = 'DISABLED';
 
 let pdRunner: PodmanDesktopRunner;
@@ -117,7 +117,7 @@ async function verifyPodmanExtensionStatus(enabled: boolean): Promise<void> {
   if (enabled) {
     await playExpect(podmanExtensionPage.enableButton).toBeDisabled({ timeout: 10000 });
     await playExpect(podmanExtensionPage.disableButton).toBeEnabled({ timeout: 10000 });
-    await playExpect(podmanExtensionPage.status.getByText(PODMAN_EXTENSION_PAGE_STATUS_ENABLED)).toBeVisible();
+    await playExpect(podmanExtensionPage.status.getByText(PODMAN_EXTENSION_PAGE_STATUS_ACTIVE)).toBeVisible();
   } else {
     await playExpect(podmanExtensionPage.enableButton).toBeEnabled({ timeout: 10000 });
     await playExpect(podmanExtensionPage.disableButton).toBeDisabled({ timeout: 10000 });


### PR DESCRIPTION
### What does this PR do?
- [x] depends on https://github.com/containers/podman-desktop/pull/6424

replace `ENABLED` by `ACTIVE` in extension status

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/6409

### How to test this PR?

- [x] Tests are covering the bug fix or the new feature
