### PR TITLE
feat: add a safe storage registry

### DIFF
--- a/packages/main/src/plugin/directories.ts
+++ b/packages/main/src/plugin/directories.ts
@@ -31,6 +31,7 @@ export class Directories {
   private pluginsScanDirectory: string;
   private extensionsStorageDirectory: string;
   private contributionStorageDirectory: string;
+  private safeStorageDirectory: string;
   protected desktopAppHomeDir: string;
 
   constructor() {
@@ -47,6 +48,7 @@ export class Directories {
     this.pluginsScanDirectory = path.resolve(this.desktopAppHomeDir, 'plugins-scanning');
     this.extensionsStorageDirectory = path.resolve(this.desktopAppHomeDir, 'extensions-storage');
     this.contributionStorageDirectory = path.resolve(this.desktopAppHomeDir, 'contributions');
+    this.safeStorageDirectory = path.resolve(this.desktopAppHomeDir, 'safe-storage');
   }
 
   getConfigurationDirectory(): string {
@@ -67,5 +69,9 @@ export class Directories {
 
   public getContributionStorageDir(): string {
     return this.contributionStorageDirectory;
+  }
+
+  public getSafeStorageDirectory(): string {
+    return this.safeStorageDirectory;
   }
 }

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -146,6 +146,7 @@ import { ProgressImpl } from './progress-impl.js';
 import { ProviderRegistry } from './provider-registry.js';
 import { Proxy } from './proxy.js';
 import { RecommendationsRegistry } from './recommendations/recommendations-registry.js';
+import { SafeStorageRegistry } from './safe-storage/safe-storage-registry.js';
 import type { StatusBarEntryDescriptor } from './statusbar/statusbar-registry.js';
 import { StatusBarRegistry } from './statusbar/statusbar-registry.js';
 import { PAGE_EVENT_TYPE, Telemetry } from './telemetry/telemetry.js';
@@ -410,6 +411,9 @@ export class PluginSystem {
     const iconRegistry = new IconRegistry(apiSender);
     const directories = new Directories();
     const statusBarRegistry = new StatusBarRegistry(apiSender);
+
+    const safeStorageRegistry = new SafeStorageRegistry(directories);
+    await safeStorageRegistry.init();
 
     const configurationRegistry = new ConfigurationRegistry(apiSender, directories);
     notifications.push(...configurationRegistry.init());

--- a/packages/main/src/plugin/safe-storage/safe-storage-registry.spec.ts
+++ b/packages/main/src/plugin/safe-storage/safe-storage-registry.spec.ts
@@ -1,0 +1,115 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { existsSync } from 'node:fs';
+import { readFile, writeFile } from 'node:fs/promises';
+
+import { safeStorage } from 'electron';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { type Directories } from '/@/plugin/directories.js';
+
+import type { SecretStorageChangeEvent } from './safe-storage-registry.js';
+import { SafeStorageRegistry } from './safe-storage-registry.js';
+
+vi.mock('electron', () => ({
+  safeStorage: {
+    encryptString: vi.fn(),
+    decryptString: vi.fn(),
+  },
+}));
+
+let safeStorageRegistry: SafeStorageRegistry;
+
+const directories = {
+  getSafeStorageDirectory: () => '/fake-safe-storage-directory',
+} as unknown as Directories;
+
+beforeEach(() => {
+  safeStorageRegistry = new SafeStorageRegistry(directories);
+});
+
+test('should init safe storage', async () => {
+  vi.mock('node:fs');
+  vi.mock('node:fs/promises');
+
+  // mock existsSync
+  vi.mocked(existsSync).mockReturnValue(false);
+
+  vi.mocked(readFile).mockResolvedValue('{}');
+
+  const encryptedValue = Buffer.from('encryptedValue');
+  vi.mocked(safeStorage.encryptString).mockReturnValue(encryptedValue);
+  vi.mocked(safeStorage.decryptString).mockReturnValue('originalValue');
+
+  // register configuration
+  await safeStorageRegistry.init();
+
+  // get getExtensionStorage
+  const extensionSpecificStorage = safeStorageRegistry.getExtensionStorage('id1');
+
+  // reset the writeFile
+  vi.mocked(writeFile).mockClear();
+
+  let key = await extensionSpecificStorage.get('key1');
+  expect(key).toBeUndefined();
+
+  const onDidChangeEvent = extensionSpecificStorage.onDidChange;
+  const events: SecretStorageChangeEvent[] = [];
+  onDidChangeEvent(event => {
+    events.push(event);
+  });
+  await extensionSpecificStorage.store('key1', 'value1');
+  expect(events).toEqual([{ key: 'key1' }]);
+
+  // expect file is being written
+  expect(safeStorage.encryptString).toHaveBeenCalledWith('value1');
+
+  // full key should be extension Id and key
+  const fullKey = 'id1.key1';
+  const base64Encrypted = encryptedValue.toString('base64');
+
+  const expectedData = {
+    [fullKey]: base64Encrypted,
+  };
+
+  expect(vi.mocked(writeFile)).toHaveBeenCalledWith(
+    expect.stringContaining('data.json'),
+    JSON.stringify(expectedData),
+    'utf-8',
+  );
+
+  // read again the value
+  key = await extensionSpecificStorage.get('key1');
+  expect(key).toBe('originalValue');
+
+  // check delete
+  events.length = 0;
+  await extensionSpecificStorage.delete('key1');
+  expect(vi.mocked(writeFile)).toHaveBeenCalledWith(expect.stringContaining('data.json'), JSON.stringify({}), 'utf-8');
+
+  // check change event
+  expect(events).toEqual([{ key: 'key1' }]);
+});
+
+test('should throw error if not initialized', async () => {
+  vi.mock('node:fs');
+  vi.mock('node:fs/promises');
+
+  expect(() => safeStorageRegistry.getExtensionStorage('foo')).toThrow('Safe storage not initialized');
+});

--- a/packages/main/src/plugin/safe-storage/safe-storage-registry.ts
+++ b/packages/main/src/plugin/safe-storage/safe-storage-registry.ts
@@ -39,14 +39,14 @@ export class SafeStorageRegistry {
     this.#directories = directories;
   }
 
-  protected getSafeStoragePath(): string {
+  protected getSafeStorageDataPath(): string {
     // create directory if it does not exist
     return path.resolve(this.#directories.getSafeStorageDirectory(), 'data.json');
   }
 
   // initialize the safe storage
   public async init(): Promise<void> {
-    const safeStoragePath = this.getSafeStoragePath();
+    const safeStoragePath = this.getSafeStorageDataPath();
 
     const parentDirectory = path.dirname(safeStoragePath);
     if (!existsSync(parentDirectory)) {

--- a/packages/main/src/plugin/safe-storage/safe-storage-registry.ts
+++ b/packages/main/src/plugin/safe-storage/safe-storage-registry.ts
@@ -1,0 +1,146 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { existsSync } from 'node:fs';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import { safeStorage } from 'electron';
+
+import { type Directories } from '/@/plugin/directories.js';
+import type { Event } from '/@/plugin/events/emitter.js';
+import { Emitter } from '/@/plugin/events/emitter.js';
+
+/**
+ * Manage the storage of string being encrypted on disk
+ * It's only converted to readable content when getting the value
+ */
+export class SafeStorageRegistry {
+  readonly #directories: Directories;
+
+  #extensionStorage: SafeStorage | undefined;
+
+  constructor(directories: Directories) {
+    this.#directories = directories;
+  }
+
+  protected getSafeStoragePath(): string {
+    // create directory if it does not exist
+    return path.resolve(this.#directories.getSafeStorageDirectory(), 'data.json');
+  }
+
+  // initialize the safe storage
+  public async init(): Promise<void> {
+    const safeStoragePath = this.getSafeStoragePath();
+
+    const parentDirectory = path.dirname(safeStoragePath);
+    if (!existsSync(parentDirectory)) {
+      await mkdir(parentDirectory, { recursive: true });
+    }
+    if (!existsSync(safeStoragePath)) {
+      await writeFile(safeStoragePath, JSON.stringify({}), 'utf-8');
+    }
+
+    // read the file and create a SafeStorage object
+    const content = await readFile(safeStoragePath, 'utf-8');
+    const data = JSON.parse(content);
+    this.#extensionStorage = new SafeStorage(data);
+
+    // in case of an update, persists the new data to the file
+    this.#extensionStorage.onDidChange(async () => {
+      await writeFile(safeStoragePath, JSON.stringify(data), 'utf-8');
+    });
+  }
+
+  getExtensionStorage(extensionId: string): ExtensionSecretStorage {
+    if (!this.#extensionStorage) {
+      throw new Error('Safe storage not initialized');
+    }
+    return new ExtensionSecretStorage(this.#extensionStorage, extensionId);
+  }
+}
+
+export interface SecretStorageChangeEvent {
+  readonly key: string;
+}
+
+export class SafeStorage {
+  readonly #onDidChange = new Emitter<SecretStorageChangeEvent>();
+  readonly onDidChange: Event<SecretStorageChangeEvent> = this.#onDidChange.event;
+
+  encrypt(value: string): string {
+    return safeStorage.encryptString(value).toString('base64');
+  }
+
+  decrypt(value: string): string {
+    return safeStorage.decryptString(Buffer.from(value, 'base64'));
+  }
+
+  // create Map of key value pairs
+  // key is the secret name
+  // value is the secret value
+  readonly #data: { [key: string]: string };
+
+  constructor(data: { [key: string]: string }) {
+    this.#data = data;
+  }
+
+  getDecrypted(key: string): string | undefined {
+    const value = this.#data[key];
+    if (value) {
+      return this.decrypt(value);
+    }
+  }
+
+  set(key: string, value: string): void {
+    this.#data[key] = this.encrypt(value);
+    this.#onDidChange.fire({ key });
+  }
+
+  delete(key: string): void {
+    delete this.#data[key];
+    this.#onDidChange.fire({ key });
+  }
+}
+
+export class ExtensionSecretStorage {
+  readonly #onDidChange = new Emitter<SecretStorageChangeEvent>();
+  readonly onDidChange: Event<SecretStorageChangeEvent> = this.#onDidChange.event;
+
+  readonly #storage: SafeStorage;
+  readonly #extensionId: string;
+
+  constructor(storage: SafeStorage, extensionId: string) {
+    this.#storage = storage;
+    this.#extensionId = extensionId;
+  }
+
+  async get(key: string): Promise<string | undefined> {
+    return this.#storage.getDecrypted(`${this.#extensionId}.${key}`);
+  }
+
+  async store(key: string, value: string): Promise<void> {
+    this.#storage.set(`${this.#extensionId}.${key}`, value);
+    this.#onDidChange.fire({ key });
+  }
+
+  async delete(key: string): Promise<void> {
+    this.#storage.delete(`${this.#extensionId}.${key}`);
+    this.#onDidChange.fire({ key });
+  }
+}


### PR DESCRIPTION
### What does this PR do?

introduce a registry storing key/values in encrypted and then encoded in base64 values

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

part 1 of https://github.com/containers/podman-desktop/issues/6044


### How to test this PR?

unit tests added

- [x] Tests are covering the bug fix or the new feature
