### PR TITLE
feat: add secrets handling to extensionContext in extension api

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -144,6 +144,11 @@ declare module '@podman-desktop/api' {
      * The uri of the directory containing the extension.
      */
     readonly extensionUri: Uri;
+
+    /**
+     * A storage utility for secrets. Secrets are persisted across reloads.
+     */
+    readonly secrets: SecretStorage;
   }
 
   /**
@@ -4152,5 +4157,47 @@ declare module '@podman-desktop/api' {
      * @see {@link window.createWebviewPanel createWebviewPanel} for creating a Webview
      */
     export function navigateToWebview(webviewId: string): Promise<void>;
+  }
+
+  /**
+   * The event data that is fired when a secret is added or removed.
+   */
+  export interface SecretStorageChangeEvent {
+    /**
+     * The key of the secret that has changed.
+     */
+    readonly key: string;
+  }
+
+  /**
+   * Represents a storage utility for secrets, information that is
+   * sensitive.
+   */
+  export interface SecretStorage {
+    /**
+     * Retrieve a secret that was stored with key. Returns undefined if there
+     * is no secret matching that key.
+     * @param key The key the secret was stored under.
+     * @returns The stored value or `undefined`.
+     */
+    get(key: string): Promise<string | undefined>;
+
+    /**
+     * Store a secret under a given key.
+     * @param key The key to store the secret under.
+     * @param value The secret.
+     */
+    store(key: string, value: string): Promise<void>;
+
+    /**
+     * Remove a secret from storage.
+     * @param key The key the secret was stored under.
+     */
+    delete(key: string): Promise<void>;
+
+    /**
+     * Fires when a secret is stored or deleted.
+     */
+    onDidChange: Event<SecretStorageChangeEvent>;
   }
 }

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -64,6 +64,7 @@ import { ProgressLocation } from './progress-impl.js';
 import type { ProviderRegistry } from './provider-registry.js';
 import type { Proxy } from './proxy.js';
 import { createHttpPatchedModules } from './proxy-resolver.js';
+import { type SafeStorageRegistry } from './safe-storage/safe-storage-registry.js';
 import {
   StatusBarAlignLeft,
   StatusBarAlignRight,
@@ -179,6 +180,7 @@ export class ExtensionLoader {
     private webviewRegistry: WebviewRegistry,
     private colorRegistry: ColorRegistry,
     private dialogRegistry: DialogRegistry,
+    private safeStorageRegistry: SafeStorageRegistry,
   ) {
     this.pluginsDirectory = directories.getPluginsDirectory();
     this.pluginsScanDirectory = directories.getPluginsScanDirectory();
@@ -1337,10 +1339,13 @@ export class ExtensionLoader {
       await fs.promises.rename(oldStoragePath, storagePath);
     }
 
+    const secrets = this.safeStorageRegistry.getExtensionStorage(extension.id);
+
     const extensionContext: containerDesktopAPI.ExtensionContext = {
       subscriptions,
       storagePath,
       extensionUri,
+      secrets,
     };
     let deactivateFunction = undefined;
     if (typeof extensionMain?.['deactivate'] === 'function') {

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -625,6 +625,7 @@ export class PluginSystem {
       webviewRegistry,
       colorRegistry,
       dialogRegistry,
+      safeStorageRegistry,
     );
     await this.extensionLoader.init();
 


### PR DESCRIPTION
### What does this PR do?

expose to extensions secrets storage

- [x] depends on https://github.com/containers/podman-desktop/pull/6422

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/6044

### How to test this PR?

unit tests added

- [x] Tests are covering the bug fix or the new feature
