### PR TITLE
fix: use expected component in the tests

### DIFF
--- a/packages/renderer/src/lib/ui/ProviderStatus.spec.ts
+++ b/packages/renderer/src/lib/ui/ProviderStatus.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,60 +19,57 @@
 import '@testing-library/jest-dom/vitest';
 import { test, expect } from 'vitest';
 import { render, screen } from '@testing-library/svelte';
-import ExtensionStatus from './ExtensionStatus.svelte';
-
-/* eslint-disable @typescript-eslint/no-explicit-any */
-/* eslint-disable @typescript-eslint/no-empty-function */
+import ProviderStatus from './ProviderStatus.svelte';
 
 const connectionStatusLabel = 'Connection Status Label';
 const connectionStatusIcon = 'Connection Status Icon';
 
 test('Expect green text and icon when connection is running', async () => {
-  render(ExtensionStatus, { status: 'started' });
+  render(ProviderStatus, { status: 'started' });
   const icon = screen.getByLabelText(connectionStatusIcon);
   const label = screen.getByLabelText(connectionStatusLabel);
   expect(icon).toBeInTheDocument();
   expect(icon).toHaveClass('bg-green-500');
   expect(label).toBeInTheDocument();
   expect(label).toHaveClass('text-green-500');
-  expect(label).toHaveTextContent('ENABLED');
+  expect(label).toHaveTextContent('RUNNING');
 });
 
 test('Expect green text and icon when connection is starting', async () => {
-  render(ExtensionStatus, { status: 'starting' });
+  render(ProviderStatus, { status: 'starting' });
   const icon = screen.getByLabelText(connectionStatusIcon);
   const label = screen.getByLabelText(connectionStatusLabel);
   expect(icon).toBeInTheDocument();
   expect(icon).toHaveClass('bg-green-500');
   expect(label).toBeInTheDocument();
   expect(label).toHaveClass('text-green-500');
-  expect(label).toHaveTextContent('ENABLING');
+  expect(label).toHaveTextContent('STARTING');
 });
 
 test('Expect green text and icon when connection is stopped', async () => {
-  render(ExtensionStatus, { status: 'stopped' });
+  render(ProviderStatus, { status: 'stopped' });
   const icon = screen.getByLabelText(connectionStatusIcon);
   const label = screen.getByLabelText(connectionStatusLabel);
   expect(icon).toBeInTheDocument();
   expect(icon).toHaveClass('bg-gray-900');
   expect(label).toBeInTheDocument();
   expect(label).toHaveClass('text-gray-900');
-  expect(label).toHaveTextContent('DISABLED');
+  expect(label).toHaveTextContent('STOPPED');
 });
 
 test('Expect green text and icon when connection is stopping', async () => {
-  render(ExtensionStatus, { status: 'stopping' });
+  render(ProviderStatus, { status: 'stopping' });
   const icon = screen.getByLabelText(connectionStatusIcon);
   const label = screen.getByLabelText(connectionStatusLabel);
   expect(icon).toBeInTheDocument();
   expect(icon).toHaveClass('bg-red-500');
   expect(label).toBeInTheDocument();
   expect(label).toHaveClass('text-red-500');
-  expect(label).toHaveTextContent('DISABLING');
+  expect(label).toHaveTextContent('STOPPING');
 });
 
 test('Expect green text and icon when connection is unknown', async () => {
-  render(ExtensionStatus, { status: 'unknown' });
+  render(ProviderStatus, { status: 'unknown' });
   const icon = screen.getByLabelText(connectionStatusIcon);
   const label = screen.getByLabelText(connectionStatusLabel);
   expect(icon).toBeInTheDocument();


### PR DESCRIPTION
### What does this PR do?
when working on a change in ExtensionStatus I noticed that some unrelated tests were breaking
it turns out that the test file is not testing the expected component
it is testing ExtensionStatus instead of ProviderStatus
fixing the test to match the component that we need to test

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

https://github.com/containers/podman-desktop/pull/6410

### How to test this PR?

unit test provided

- [x] Tests are covering the bug fix or the new feature
