### PR TITLE
chore: ensure we use node: prefix on imports

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -48,7 +48,8 @@
     {
       "files": ["*.svelte", "*.tsx"],
       "rules": {
-        "header/header": "off"
+        "header/header": "off",
+        "unicorn/prefer-node-protocol": "off"
       }
     }
   ],
@@ -66,7 +67,16 @@
       }
     }
   },
-  "plugins": ["@typescript-eslint", "sonarjs", "etc", "redundant-undefined", "no-null", "header", "simple-import-sort"],
+  "plugins": [
+    "@typescript-eslint",
+    "sonarjs",
+    "etc",
+    "redundant-undefined",
+    "no-null",
+    "header",
+    "simple-import-sort",
+    "unicorn"
+  ],
   "ignorePatterns": [
     "packages/preload/exposedInMainWorld.d.ts",
     "packages/preload-docker-extension/exposedInDockerExtension.d.ts",
@@ -119,6 +129,7 @@
     "import/no-extraneous-dependencies": "error",
     "header/header": [2, "block", [{ "pattern": "SPDX-License-Identifier: Apache-2\\.0" }]],
     "simple-import-sort/imports": "error",
-    "simple-import-sort/exports": "error"
+    "simple-import-sort/exports": "error",
+    "unicorn/prefer-node-protocol": "error"
   }
 }

--- a/extensions/compose/src/cli-run.spec.ts
+++ b/extensions/compose/src/cli-run.spec.ts
@@ -17,9 +17,9 @@
  ***********************************************************************/
 
 import * as fs from 'node:fs';
+import * as path from 'node:path';
 
 import * as extensionApi from '@podman-desktop/api';
-import * as path from 'path';
 import { beforeEach, expect, test, vi } from 'vitest';
 
 import { installBinaryToSystem } from './cli-run';

--- a/extensions/compose/src/compose-extension.spec.ts
+++ b/extensions/compose/src/compose-extension.spec.ts
@@ -21,9 +21,9 @@
 import * as fs from 'node:fs';
 import { promises } from 'node:fs';
 import { resolve } from 'node:path';
+import * as path from 'node:path';
 
 import * as extensionApi from '@podman-desktop/api';
-import * as path from 'path';
 import type { Mock } from 'vitest';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 

--- a/extensions/compose/src/detect.ts
+++ b/extensions/compose/src/detect.ts
@@ -18,9 +18,9 @@
 
 import * as fs from 'node:fs';
 import * as http from 'node:http';
+import { resolve } from 'node:path';
 
 import * as extensionApi from '@podman-desktop/api';
-import { resolve } from 'path';
 import { shellPath } from 'shell-path';
 
 import type { OS } from './os';

--- a/extensions/compose/src/extension.ts
+++ b/extensions/compose/src/extension.ts
@@ -16,9 +16,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import * as path from 'node:path';
+
 import { Octokit } from '@octokit/rest';
 import * as extensionApi from '@podman-desktop/api';
-import * as path from 'path';
 
 import { installBinaryToSystem } from './cli-run';
 import type { ComposeGithubReleaseArtifactMetadata } from './compose-github-releases';

--- a/extensions/compose/src/utils.spec.ts
+++ b/extensions/compose/src/utils.spec.ts
@@ -16,7 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { promises } from 'fs';
+import { promises } from 'node:fs';
+
 import { describe, expect, test, vi, vitest } from 'vitest';
 
 import { makeExecutable } from './utils';

--- a/extensions/compose/src/utils.ts
+++ b/extensions/compose/src/utils.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { promises } from 'fs';
+import { promises } from 'node:fs';
 
 import { OS } from './os';
 

--- a/extensions/kubectl-cli/src/cli-run.spec.ts
+++ b/extensions/kubectl-cli/src/cli-run.spec.ts
@@ -17,9 +17,9 @@
  ***********************************************************************/
 
 import * as fs from 'node:fs';
+import * as path from 'node:path';
 
 import * as extensionApi from '@podman-desktop/api';
-import * as path from 'path';
 import { beforeEach, expect, test, vi } from 'vitest';
 
 import { installBinaryToSystem } from './cli-run';

--- a/extensions/kubectl-cli/src/detect.ts
+++ b/extensions/kubectl-cli/src/detect.ts
@@ -17,9 +17,9 @@
  ***********************************************************************/
 
 import * as fs from 'node:fs';
+import { resolve } from 'node:path';
 
 import * as extensionApi from '@podman-desktop/api';
-import { resolve } from 'path';
 import { shellPath } from 'shell-path';
 
 import type { OS } from './os';

--- a/extensions/kubectl-cli/src/extension.ts
+++ b/extensions/kubectl-cli/src/extension.ts
@@ -16,10 +16,11 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import * as path from 'node:path';
+
 import { Octokit } from '@octokit/rest';
 import type { CliTool } from '@podman-desktop/api';
 import * as extensionApi from '@podman-desktop/api';
-import * as path from 'path';
 
 import { installBinaryToSystem } from './cli-run';
 import { Detect } from './detect';

--- a/extensions/kubectl-cli/src/utils.spec.ts
+++ b/extensions/kubectl-cli/src/utils.spec.ts
@@ -16,7 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { promises } from 'fs';
+import { promises } from 'node:fs';
+
 import { describe, expect, test, vi, vitest } from 'vitest';
 
 import { makeExecutable } from './utils';

--- a/extensions/kubectl-cli/src/utils.ts
+++ b/extensions/kubectl-cli/src/utils.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { promises } from 'fs';
+import { promises } from 'node:fs';
 
 import { OS } from './os';
 

--- a/extensions/lima/src/extension.ts
+++ b/extensions/lima/src/extension.ts
@@ -16,11 +16,12 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
 import * as extensionApi from '@podman-desktop/api';
 import { configuration, ProgressLocation } from '@podman-desktop/api';
-import * as fs from 'fs';
-import * as os from 'os';
-import * as path from 'path';
 
 import { ImageHandler } from './image-handler';
 import { getLimactl } from './limactl';

--- a/package.json
+++ b/package.json
@@ -149,6 +149,7 @@
     "eslint-plugin-redundant-undefined": "^1.0.0",
     "eslint-plugin-simple-import-sort": "^12.0.0",
     "eslint-plugin-sonarjs": "^0.24.0",
+    "eslint-plugin-unicorn": "^51.0.1",
     "husky": "^9.0.11",
     "js-yaml": "^4.1.0",
     "lint-staged": "^15.2.2",

--- a/packages/main/src/mainWindow.ts
+++ b/packages/main/src/mainWindow.ts
@@ -16,12 +16,13 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import { join } from 'node:path';
+import { URL } from 'node:url';
+
 import type { BrowserWindowConstructorOptions } from 'electron';
 import { app, autoUpdater, BrowserWindow, ipcMain, Menu, nativeTheme, screen } from 'electron';
 import contextMenu from 'electron-context-menu';
 import { aboutMenuItem } from 'electron-util/main';
-import { join } from 'path';
-import { URL } from 'url';
 
 import { OpenDevTools } from './open-dev-tools.js';
 import type { ConfigurationRegistry } from './plugin/configuration-registry.js';

--- a/packages/main/src/plugin/configuration-registry.ts
+++ b/packages/main/src/plugin/configuration-registry.ts
@@ -16,9 +16,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
 import type * as containerDesktopAPI from '@podman-desktop/api';
-import * as fs from 'fs';
-import * as path from 'path';
 
 import type { ApiSenderType } from './api.js';
 import type { NotificationCardOptions } from './api/notification.js';

--- a/packages/main/src/plugin/docker-extension/docker-desktop-installation.spec.ts
+++ b/packages/main/src/plugin/docker-extension/docker-desktop-installation.spec.ts
@@ -18,10 +18,11 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+import * as fs from 'node:fs';
+
 import type { RequestConfig } from '@docker/extension-api-client-types/dist/v1/http-service.js';
 import type Dockerode from 'dockerode';
 import type { IpcMainEvent } from 'electron';
-import * as fs from 'fs';
 import type { Method } from 'got';
 import nock from 'nock';
 import { beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';

--- a/packages/main/src/plugin/docker-extension/docker-desktop-installer.spec.ts
+++ b/packages/main/src/plugin/docker-extension/docker-desktop-installer.spec.ts
@@ -16,7 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { cp, readFile } from 'fs/promises';
+import { cp, readFile } from 'node:fs/promises';
+
 import { beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import type { ContributionManager } from '../contribution-manager.js';

--- a/packages/main/src/plugin/docker-extension/docker-plugin-adapter.ts
+++ b/packages/main/src/plugin/docker-extension/docker-plugin-adapter.ts
@@ -16,9 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import { spawn } from 'node:child_process';
 import * as os from 'node:os';
 
-import { spawn } from 'child_process';
 import type { IpcMainEvent, IpcMainInvokeEvent } from 'electron';
 import { ipcMain } from 'electron';
 

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -17,12 +17,12 @@
  ***********************************************************************/
 
 import * as fs from 'node:fs';
+import { readFile } from 'node:fs/promises';
+import * as path from 'node:path';
 
 import type * as containerDesktopAPI from '@podman-desktop/api';
 import AdmZip from 'adm-zip';
 import { app, clipboard as electronClipboard } from 'electron';
-import { readFile } from 'fs/promises';
-import * as path from 'path';
 
 import type { ImageInspectInfo } from '/@/plugin/api/image-inspect-info.js';
 import type { ColorRegistry } from '/@/plugin/color-registry.js';
@@ -183,7 +183,7 @@ export class ExtensionLoader {
     this.pluginsDirectory = directories.getPluginsDirectory();
     this.pluginsScanDirectory = directories.getPluginsScanDirectory();
     this.extensionsStorageDirectory = directories.getExtensionsStorageDirectory();
-    this.moduleLoader = new ModuleLoader(require('module'), this.analyzedExtensions);
+    this.moduleLoader = new ModuleLoader(require('node:module'), this.analyzedExtensions);
   }
 
   mapError(err: unknown): ExtensionError | undefined {

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -21,6 +21,7 @@
  */
 import { EventEmitter } from 'node:events';
 import * as os from 'node:os';
+import * as path from 'node:path';
 
 import type {
   Cluster,
@@ -40,7 +41,6 @@ import type Dockerode from 'dockerode';
 import type { WebContents } from 'electron';
 import { app, BrowserWindow, clipboard, ipcMain, shell } from 'electron';
 import type { IpcMainInvokeEvent } from 'electron/main';
-import * as path from 'path';
 
 import type { KubernetesGeneratorInfo } from '/@/plugin/api/KubernetesGeneratorInfo.js';
 import type {

--- a/packages/main/src/plugin/module-loader.ts
+++ b/packages/main/src/plugin/module-loader.ts
@@ -16,8 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import * as path from 'node:path';
+
 import type * as api from '@podman-desktop/api';
-import * as path from 'path';
 
 export interface ExtensionModule {
   path: string;

--- a/packages/main/src/plugin/onboarding-registry.ts
+++ b/packages/main/src/plugin/onboarding-registry.ts
@@ -17,7 +17,7 @@
  ***********************************************************************/
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import * as path from 'path';
+import * as path from 'node:path';
 
 import { getBase64Image } from '../util.js';
 import type { Onboarding, OnboardingInfo, OnboardingStatus } from './api/onboarding.js';

--- a/packages/main/src/plugin/proxy-resolver.spec.ts
+++ b/packages/main/src/plugin/proxy-resolver.spec.ts
@@ -20,10 +20,11 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+import { get } from 'node:http';
+import * as nodeurl from 'node:url';
+
 import type { HttpsProxyAgentOptions } from 'hpagent';
 import { HttpsProxyAgent } from 'hpagent';
-import { get } from 'http';
-import * as nodeurl from 'url';
 import { beforeEach, expect, test, vi } from 'vitest';
 
 import type { Proxy } from './proxy.js';

--- a/packages/main/src/plugin/proxy-resolver.ts
+++ b/packages/main/src/plugin/proxy-resolver.ts
@@ -16,11 +16,12 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import * as http from 'node:http';
+import * as https from 'node:https';
+import * as nodeurl from 'node:url';
+
 import type { HttpProxyAgentOptions, HttpsProxyAgentOptions } from 'hpagent';
 import { HttpProxyAgent, HttpsProxyAgent } from 'hpagent';
-import * as http from 'http';
-import * as https from 'https';
-import * as nodeurl from 'url';
 
 import type { Proxy } from './proxy.js';
 

--- a/packages/main/src/plugin/proxy.spec.ts
+++ b/packages/main/src/plugin/proxy.spec.ts
@@ -16,8 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import * as http from 'http';
-import type { AddressInfo } from 'net';
+import * as http from 'node:http';
+import type { AddressInfo } from 'node:net';
+
 import { createProxy, type ProxyServer } from 'proxy';
 import { describe, expect, test, vi } from 'vitest';
 

--- a/packages/main/src/plugin/types/uri.ts
+++ b/packages/main/src/plugin/types/uri.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import path, { join } from 'path';
+import path, { join } from 'node:path';
 
 import { isWindows } from '/@/util.js';
 

--- a/packages/main/src/plugin/util/exec.spec.ts
+++ b/packages/main/src/plugin/util/exec.spec.ts
@@ -16,10 +16,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { ChildProcessWithoutNullStreams } from 'node:child_process';
+import { spawn } from 'node:child_process';
 import type { Readable } from 'node:stream';
 
-import type { ChildProcessWithoutNullStreams } from 'child_process';
-import { spawn } from 'child_process';
 import * as sudo from 'sudo-prompt';
 import type { Mock } from 'vitest';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';

--- a/packages/main/src/plugin/util/exec.ts
+++ b/packages/main/src/plugin/util/exec.ts
@@ -16,9 +16,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { ChildProcessWithoutNullStreams } from 'node:child_process';
+import { spawn } from 'node:child_process';
+
 import type { RunError, RunOptions, RunResult } from '@podman-desktop/api';
-import type { ChildProcessWithoutNullStreams } from 'child_process';
-import { spawn } from 'child_process';
 import * as sudo from 'sudo-prompt';
 
 import { isLinux, isMac, isWindows } from '../../util.js';

--- a/packages/main/src/plugin/util/port.spec.ts
+++ b/packages/main/src/plugin/util/port.spec.ts
@@ -16,7 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import * as net from 'net';
+import * as net from 'node:net';
+
 import { expect, test } from 'vitest';
 
 import * as port from './port.js';

--- a/packages/main/src/plugin/util/port.ts
+++ b/packages/main/src/plugin/util/port.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import * as net from 'net';
+import * as net from 'node:net';
 
 /**
  * Find a free port starting from the given port

--- a/packages/main/src/security-restrictions.ts
+++ b/packages/main/src/security-restrictions.ts
@@ -16,8 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import { URL } from 'node:url';
+
 import { app, shell } from 'electron';
-import { URL } from 'url';
 
 import { securityRestrictionCurrentHandler } from './security-restrictions-handler.js';
 

--- a/packages/main/src/tray-animate-icon.spec.ts
+++ b/packages/main/src/tray-animate-icon.spec.ts
@@ -16,8 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import * as path from 'node:path';
+
 import { app } from 'electron';
-import * as path from 'path';
 import { beforeEach, expect, test, vi } from 'vitest';
 
 import { AnimatedTray } from './tray-animate-icon.js';

--- a/packages/main/src/tray-animate-icon.ts
+++ b/packages/main/src/tray-animate-icon.ts
@@ -16,9 +16,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import * as path from 'node:path';
+
 import type { Tray } from 'electron';
 import { app, nativeTheme } from 'electron';
-import * as path from 'path';
 
 import { isLinux, isMac } from './util.js';
 

--- a/packages/main/src/util.ts
+++ b/packages/main/src/util.ts
@@ -16,9 +16,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+
 import { BrowserWindow } from 'electron';
-import * as fs from 'fs';
-import * as os from 'os';
 
 const windows = os.platform() === 'win32';
 export function isWindows(): boolean {

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -20,6 +20,8 @@
  * @module preload
  */
 
+import EventEmitter from 'node:events';
+
 import type {
   Cluster,
   Context,
@@ -34,7 +36,6 @@ import type {
 } from '@kubernetes/client-node';
 import type * as containerDesktopAPI from '@podman-desktop/api';
 import { contextBridge, ipcRenderer } from 'electron';
-import EventEmitter from 'events';
 
 import type { ApiSenderType } from '../../main/src/plugin/api';
 import type { CliToolInfo } from '../../main/src/plugin/api/cli-tool-info';

--- a/packages/renderer/src/lib/context/contextKey.spec.ts
+++ b/packages/renderer/src/lib/context/contextKey.spec.ts
@@ -22,7 +22,8 @@
 // based on https://github.com/microsoft/vscode/blob/76415ef0b1f60e0479bdfee173c1a4f97e785b52/src/vs/platform/contextkey/test/common/contextkey.test.ts
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import assert from 'assert';
+import assert from 'node:assert';
+
 import { suite, test, vi } from 'vitest';
 
 import { ContextKeyExpr, type ContextKeyExpression, implies, initContextKeysPlatform } from './contextKey.js';

--- a/packages/renderer/src/lib/context/scanner.spec.ts
+++ b/packages/renderer/src/lib/context/scanner.spec.ts
@@ -22,7 +22,8 @@
 // based on https://github.com/microsoft/vscode/blob/76415ef0b1f60e0479bdfee173c1a4f97e785b52/src/vs/platform/contextkey/test/common/scanner.test.ts
 /* eslint-disable no-useless-escape */
 
-import * as assert from 'assert';
+import * as assert from 'node:assert';
+
 import { test } from 'vitest';
 
 import { Scanner, type Token, TokenType } from './scanner';

--- a/packages/renderer/src/lib/image/image-utils.ts
+++ b/packages/renderer/src/lib/image/image-utils.ts
@@ -16,6 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+// eslint-disable-next-line unicorn/prefer-node-protocol
 import { Buffer } from 'buffer';
 import { filesize } from 'filesize';
 import humanizeDuration from 'humanize-duration';

--- a/packages/renderer/src/lib/stream/stream-utils.ts
+++ b/packages/renderer/src/lib/stream/stream-utils.ts
@@ -16,6 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+// eslint-disable-next-line unicorn/prefer-node-protocol
 import { Buffer } from 'buffer';
 
 // if multiplexed, we have:

--- a/tests/playwright/src/specs/image-smoke.spec.ts
+++ b/tests/playwright/src/specs/image-smoke.spec.ts
@@ -16,9 +16,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import path from 'node:path';
+
 import type { Page } from '@playwright/test';
 import { expect as playExpect } from '@playwright/test';
-import path from 'path';
 import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest';
 
 import { ImageDetailsPage } from '../model/pages/image-details-page';

--- a/tests/playwright/src/specs/yaml-smoke.spec.ts
+++ b/tests/playwright/src/specs/yaml-smoke.spec.ts
@@ -16,9 +16,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import path from 'node:path';
+
 import type { Page } from '@playwright/test';
 import { expect as playExpect } from '@playwright/test';
-import path from 'path';
 import { afterAll, beforeAll, beforeEach, describe, test } from 'vitest';
 
 import { WelcomePage } from '../model/pages/welcome-page';

--- a/website-argos/screenshot.spec.ts
+++ b/website-argos/screenshot.spec.ts
@@ -16,9 +16,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import * as fs from 'node:fs';
+
 import { argosScreenshot } from '@argos-ci/playwright';
 import { test } from '@playwright/test';
-import * as fs from 'fs';
 
 import { extractSitemapPathnames, pathnameToArgosName } from './utils';
 

--- a/website-argos/utils.ts
+++ b/website-argos/utils.ts
@@ -16,8 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import * as fs from 'node:fs';
+
 import * as cheerio from 'cheerio';
-import * as fs from 'fs';
 
 const allowed: string[] = [
   '/api/namespaces/commands',

--- a/yarn.lock
+++ b/yarn.lock
@@ -5267,7 +5267,7 @@ braces@^3.0.2, braces@~3.0.2:
   dependencies:
     fill-range "^7.0.1"
 
-browserslist@^4.0.0, browserslist@^4.14.5, browserslist@^4.16.6, browserslist@^4.18.1, browserslist@^4.20.3, browserslist@^4.21.4, browserslist@^4.21.9, browserslist@^4.22.1, browserslist@^4.22.2, browserslist@^4.23.0:
+browserslist@^4.0.0, browserslist@^4.14.5, browserslist@^4.16.6, browserslist@^4.18.1, browserslist@^4.20.3, browserslist@^4.21.4, browserslist@^4.21.9, browserslist@^4.22.1, browserslist@^4.22.2, browserslist@^4.22.3, browserslist@^4.23.0:
   version "4.23.0"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.23.0.tgz#8f3acc2bbe73af7213399430890f86c63a5674ab"
   integrity sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==
@@ -5661,6 +5661,11 @@ ci-info@^3.2.0:
   resolved "https://registry.npmjs.org/ci-info/-/ci-info-3.3.0.tgz"
   integrity sha512-riT/3vI5YpVH6/qomlDnJow6TBee2PBKSEpx3O32EGPYbWGIRsIlGRms3Sm74wYE1JMo8RnO04Hb12+v1J5ICw==
 
+ci-info@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-4.0.0.tgz#65466f8b280fc019b9f50a5388115d17a63a44f2"
+  integrity sha512-TdHqgGf9odd8SXNuxtUBVx8Nv+qZOejE6qyqiy5NtbYYQOeFa6zmHkxlPzmaLxWWHsU6nJmB7AETdVPi+2NBUg==
+
 clean-css@^5.2.2:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-5.3.1.tgz#d0610b0b90d125196a2894d35366f734e5d7aa32"
@@ -5674,6 +5679,13 @@ clean-css@^5.3.2, clean-css@~5.3.2:
   integrity sha512-JVJbM+f3d3Q704rF4bqQ5UUyTtuJ0JRKNbTKVEeujCCBoMdkEi+V+e8oktO9qGQNSvHrFTM6JZRXrUvGR1czww==
   dependencies:
     source-map "~0.6.0"
+
+clean-regexp@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/clean-regexp/-/clean-regexp-1.0.0.tgz#8df7c7aae51fd36874e8f8d05b9180bc11a3fed7"
+  integrity sha512-GfisEZEJvzKrmGWkvfhgzcz/BllN1USeqD2V6tg14OAOgaCD2Z/PUEuxnAZ/nPvmaHRG7a8y77p1T/IRQ4D1Hw==
+  dependencies:
+    escape-string-regexp "^1.0.5"
 
 clean-stack@^2.0.0:
   version "2.2.0"
@@ -6089,6 +6101,13 @@ core-js-compat@^3.31.0, core-js-compat@^3.33.1:
   integrity sha512-cNzGqFsh3Ot+529GIXacjTJ7kegdt5fPXxCBVS1G0iaZpuo/tBz399ymceLJveQhFFZ8qThHiP3fzuoQjKN2ow==
   dependencies:
     browserslist "^4.22.1"
+
+core-js-compat@^3.34.0:
+  version "3.36.0"
+  resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.36.0.tgz#087679119bc2fdbdefad0d45d8e5d307d45ba190"
+  integrity sha512-iV9Pd/PsgjNWBXeq8XRtWVSgz2tKAfhfvBs7qxYty+RlRd+OCksaWmOnc4JKrTc1cToXL1N0s3l/vwlxPtdElw==
+  dependencies:
+    browserslist "^4.22.3"
 
 core-js-pure@^3.30.2:
   version "3.33.3"
@@ -7812,6 +7831,28 @@ eslint-plugin-svelte@^2.35.1:
     semver "^7.5.3"
     svelte-eslint-parser ">=0.33.0 <1.0.0"
 
+eslint-plugin-unicorn@^51.0.1:
+  version "51.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-unicorn/-/eslint-plugin-unicorn-51.0.1.tgz#3641c5e110324c3739d6cb98fc1b99ada39f477b"
+  integrity sha512-MuR/+9VuB0fydoI0nIn2RDA5WISRn4AsJyNSaNKLVwie9/ONvQhxOBbkfSICBPnzKrB77Fh6CZZXjgTt/4Latw==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.22.20"
+    "@eslint-community/eslint-utils" "^4.4.0"
+    "@eslint/eslintrc" "^2.1.4"
+    ci-info "^4.0.0"
+    clean-regexp "^1.0.0"
+    core-js-compat "^3.34.0"
+    esquery "^1.5.0"
+    indent-string "^4.0.0"
+    is-builtin-module "^3.2.1"
+    jsesc "^3.0.2"
+    pluralize "^8.0.0"
+    read-pkg-up "^7.0.1"
+    regexp-tree "^0.1.27"
+    regjsparser "^0.10.0"
+    semver "^7.5.4"
+    strip-indent "^3.0.0"
+
 eslint-scope@5.1.1, eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz"
@@ -7891,7 +7932,7 @@ esprima@^4.0.0:
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
 
-esquery@^1.4.0, esquery@^1.4.2:
+esquery@^1.4.0, esquery@^1.4.2, esquery@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.5.0.tgz#6ce17738de8577694edd7361c57182ac8cb0db0b"
   integrity sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==
@@ -10133,6 +10174,11 @@ jsesc@^2.5.1:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4"
   integrity sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==
+
+jsesc@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-3.0.2.tgz#bb8b09a6597ba426425f2e4a07245c3d00b9343e"
+  integrity sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==
 
 jsesc@~0.5.0:
   version "0.5.0"
@@ -12656,6 +12702,11 @@ plist@^3.0.1, plist@^3.0.4:
     base64-js "^1.5.1"
     xmlbuilder "^15.1.1"
 
+pluralize@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-8.0.0.tgz#1a6fa16a38d12a1901e0320fa017051c539ce3b1"
+  integrity sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==
+
 postcss-calc@^8.2.3:
   version "8.2.4"
   resolved "https://registry.yarnpkg.com/postcss-calc/-/postcss-calc-8.2.4.tgz#77b9c29bfcbe8a07ff6693dc87050828889739a5"
@@ -13504,7 +13555,7 @@ read-config-file@6.2.0:
     json5 "^2.2.0"
     lazy-val "^1.0.4"
 
-read-pkg-up@^7.0.0:
+read-pkg-up@^7.0.0, read-pkg-up@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-7.0.1.tgz#f3a6135758459733ae2b95638056e1854e7ef507"
   integrity sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==
@@ -13620,6 +13671,11 @@ regenerator-transform@^0.15.2:
   dependencies:
     "@babel/runtime" "^7.8.4"
 
+regexp-tree@^0.1.27:
+  version "0.1.27"
+  resolved "https://registry.yarnpkg.com/regexp-tree/-/regexp-tree-0.1.27.tgz#2198f0ef54518ffa743fe74d983b56ffd631b6cd"
+  integrity sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==
+
 regexp.prototype.flags@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.5.0.tgz#fe7ce25e7e4cca8db37b6634c8a2c7009199b9cb"
@@ -13680,6 +13736,13 @@ regjsgen@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/regjsgen/-/regjsgen-0.6.0.tgz#83414c5354afd7d6627b16af5f10f41c4e71808d"
   integrity sha512-ozE883Uigtqj3bx7OhL1KNbCzGyW2NQZPl6Hs09WTvCuZD5sTI4JY58bkbQWa/Y9hxIsvJ3M8Nbf7j54IqeZbA==
+
+regjsparser@^0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/regjsparser/-/regjsparser-0.10.0.tgz#b1ed26051736b436f22fdec1c8f72635f9f44892"
+  integrity sha512-qx+xQGZVsy55CH0a1hiVwHmqjLryfh7wQyF5HO07XJ9f7dQMY/gPQHhlyDkIzJKC+x2fUCpCcUODUUUFrm7SHA==
+  dependencies:
+    jsesc "~0.5.0"
 
 regjsparser@^0.8.2:
   version "0.8.4"


### PR DESCRIPTION
### What does this PR do?
ensure we import stuff from 'node:fs', 'node:path' and not 'fs' or 'path', etc

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?


### How to test this PR?

PR check should be ✅ 

- [x] Tests are covering the bug fix or the new feature
