### PR TITLE
feat: add bottomLeft and bottomRight options for Tooltip component

### DIFF
--- a/packages/renderer/src/lib/ui/Tooltip.spec.ts
+++ b/packages/renderer/src/lib/ui/Tooltip.spec.ts
@@ -25,11 +25,30 @@ import { expect, test } from 'vitest';
 
 import Tooltip from './Tooltip.svelte';
 
+const tip = 'test';
+
 test('Expect basic styling', async () => {
-  const tooltip = 'test';
-  render(Tooltip, { tip: tooltip });
+  render(Tooltip, { tip });
 
   const element = screen.getByLabelText('tooltip');
   expect(element).toBeInTheDocument();
   expect(element).toHaveClass('text-white');
 });
+
+function createTest(props: Record<string, boolean>, locationName: string, expectedStyle = locationName) {
+  test(`Expect property ${locationName} to add ${expectedStyle} class to parent element`, () => {
+    render(Tooltip, { tip, ...props });
+    const element = screen.getByLabelText('tooltip');
+    expect(element).toBeInTheDocument();
+    expect(element.parentElement).toHaveClass(expectedStyle);
+  });
+}
+
+createTest({ left: true }, 'left');
+createTest({ right: true }, 'right');
+createTest({ bottom: true }, 'bottom');
+createTest({ top: true }, 'top');
+createTest({ topLeft: true }, 'topLeft', 'top-left');
+createTest({ topRight: true }, 'topRight', 'top-right');
+createTest({ bottomLeft: true }, 'bottomLeft', 'bottom-left');
+createTest({ bottomRight: true }, 'bottomRight', 'bottom-right');

--- a/packages/renderer/src/lib/ui/Tooltip.svelte
+++ b/packages/renderer/src/lib/ui/Tooltip.svelte
@@ -26,6 +26,18 @@
   transform: translate(-80%, -100%);
   margin-top: -8px;
 }
+.tooltip.bottom-left {
+  left: 0;
+  bottom: 0;
+  transform: translate(-80%, 100%);
+  margin-top: -8px;
+}
+.tooltip.bottom-right {
+  left: 0;
+  bottom: 0;
+  transform: translate(0%, 100%);
+  margin-top: -8px;
+}
 .tooltip.top-right {
   left: 0;
   transform: translate(0%, -100%);
@@ -44,6 +56,8 @@ export let topLeft = false;
 export let topRight = false;
 export let right = false;
 export let bottom = false;
+export let bottomLeft = false;
+export let bottomRight = false;
 export let left = false;
 </script>
 
@@ -58,7 +72,9 @@ export let left = false;
     class:bottom="{bottom}"
     class:top="{top}"
     class:top-left="{topLeft}"
-    class:top-right="{topRight}">
+    class:top-right="{topRight}"
+    class:bottom-left="{bottomLeft}"
+    class:bottom-right="{bottomRight}">
     {#if tip}
       <div class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs text-white" aria-label="tooltip">{tip}</div>
     {/if}


### PR DESCRIPTION
### What does this PR do?

It adds two new options for Tooltip component:
- bottomLeft
- bottomRight

### Screenshot / video of UI

Bottom left usecase

![image](https://github.com/containers/podman-desktop/assets/620330/6f104d45-c1b7-4ef3-88d8-7d602e92fa9b)

Bottom right usecase

![image](https://github.com/containers/podman-desktop/assets/620330/3635b3ab-2f94-44cb-a599-bd93edabbc93)


### What issues does this PR fix or reference?

For tooltips on Authentication settings page

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature

No clue how to test appearance of tooltip in correct place, so there is no tests
