### PR TITLE
feat: add sign in button for auth providers w/ the only auth session request

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesAuthenticationProvidersRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesAuthenticationProvidersRendering.spec.ts
@@ -43,7 +43,6 @@ test('Expect that page shows registered authentication providers without account
       id: 'test',
       displayName: 'Test Authentication Provider',
       accounts: [],
-      sessionRequests: [],
     },
   ]);
   render(PreferencesAuthenticationProvidersRendering, {});
@@ -89,7 +88,7 @@ test('Expect Sign Out button click calls window.requestAuthenticationProviderSig
   expect(requestSignOutMock).toBeCalledWith('test', 'test-account');
 });
 
-const testProividersInfoWithoutSessionRequests = [
+const testProvidersInfoWithoutSessionRequests = [
   {
     id: 'test',
     displayName: 'Test Authentication Provider',
@@ -98,14 +97,14 @@ const testProividersInfoWithoutSessionRequests = [
   },
 ];
 
-test('Expect Sign in menu item to be hidden when there are no session requests', async () => {
-  authenticationProviders.set(testProividersInfoWithoutSessionRequests);
+test('Expect Sign in button to be hidden when there are no session requests', async () => {
+  authenticationProviders.set(testProvidersInfoWithoutSessionRequests);
   render(PreferencesAuthenticationProvidersRendering, {});
   const menuButton = screen.queryAllByRole('button');
   expect(menuButton.length).equals(0); // no menu button
 });
 
-const testProividersInfoWithSessionRequests = [
+const testProvidersInfoWithSessionRequests = [
   {
     id: 'test',
     displayName: 'Test Authentication Provider',
@@ -122,26 +121,67 @@ const testProividersInfoWithSessionRequests = [
   },
 ];
 
-test('Expect Sign in menu item to be visible when there are session requests', async () => {
-  authenticationProviders.set(testProividersInfoWithSessionRequests);
-  render(PreferencesAuthenticationProvidersRendering, {});
-  const menuButton = screen.getAllByRole('button');
-  expect(menuButton.length).equals(1); // menu button
-  await fireEvent.click(menuButton[0]);
-  render(PreferencesAuthenticationProvidersRendering, {});
-  const menuItems = screen.getAllByText('Sign in to use Extension Label');
-  expect(menuItems.length).equals(1);
+test('Expect Sign In button to be visible when there is only one session request', async () => {
+  authenticationProviders.set(testProvidersInfoWithSessionRequests);
   const requestSignInMock = vi.fn();
   (window as any).requestAuthenticationProviderSignIn = requestSignInMock;
-  await fireEvent.click(menuItems[0]);
+  render(PreferencesAuthenticationProvidersRendering, {});
+  const menuButton = screen.getByRole('button');
+  const tooltip = screen.getByText('Sign in to use Extension Label');
+  expect(tooltip).toBeInTheDocument();
+  await fireEvent.click(menuButton);
   expect(requestSignInMock).toBeCalled();
 });
 
+const testProvidersInfoWithMultipleSessionRequests = [
+  {
+    id: 'test',
+    displayName: 'Test Authentication Provider',
+    accounts: [],
+    sessionRequests: [
+      {
+        id: 'ext:test1',
+        providerId: 'test',
+        extensionId: 'ext1',
+        extensionLabel: 'Extension1 Label',
+        scopes: ['scope1', 'scope2'],
+      },
+      {
+        id: 'ext:test2',
+        providerId: 'test',
+        extensionId: 'ext2',
+        extensionLabel: 'Extension2 Label',
+        scopes: ['scope1', 'scope2'],
+      },
+    ],
+  },
+];
+
+test('Expect Sign In popup menu to be visible when there is more than one session request', async () => {
+  authenticationProviders.set(testProvidersInfoWithMultipleSessionRequests);
+  (window as any).requestAuthenticationProviderSignIn = vi.fn();
+  render(PreferencesAuthenticationProvidersRendering, {});
+  const menuButton = screen.getByRole('button');
+  await fireEvent.click(menuButton);
+  // test sign in with extension1
+  const menuItem1 = screen.getByText('Sign in to use Extension1 Label');
+  const requestSignInMock = vi.fn();
+  (window as any).requestAuthenticationProviderSignIn = requestSignInMock;
+  await fireEvent.click(menuItem1);
+  expect(requestSignInMock).toBeCalledWith('ext:test1');
+  // test sign in with extension2
+  requestSignInMock.mockReset();
+  await fireEvent.click(menuButton);
+  const menuItem2 = screen.getByText('Sign in to use Extension2 Label');
+  await fireEvent.click(menuItem2);
+  expect(requestSignInMock).toBeCalledWith('ext:test2');
+});
+
 test('Expects default icon to be used when provider has no images option', async () => {
-  authenticationProviders.set(testProividersInfoWithSessionRequests);
+  authenticationProviders.set(testProvidersInfoWithSessionRequests);
   render(PreferencesAuthenticationProvidersRendering, {});
   screen.getByRole('img', {
-    name: `Default icon for ${testProividersInfoWithSessionRequests[0].displayName} provider`,
+    name: `Default icon for ${testProvidersInfoWithSessionRequests[0].displayName} provider`,
   });
 });
 
@@ -159,7 +199,7 @@ test('Expects images.icon option to be used when no themes are present', () => {
   ];
   authenticationProviders.set(providerWithImageIcon);
   render(PreferencesAuthenticationProvidersRendering, {});
-  screen.getByRole('img', { name: `Icon for ${testProividersInfoWithSessionRequests[0].displayName} provider` });
+  screen.getByRole('img', { name: `Icon for ${testProvidersInfoWithSessionRequests[0].displayName} provider` });
 });
 
 test('Expects images.icon.dark option to be used when themes are present', () => {
@@ -180,6 +220,6 @@ test('Expects images.icon.dark option to be used when themes are present', () =>
   authenticationProviders.set(providerWithImageIcon);
   render(PreferencesAuthenticationProvidersRendering, {});
   screen.getByRole('img', {
-    name: `Dark color theme icon for ${testProividersInfoWithSessionRequests[0].displayName} provider`,
+    name: `Dark color theme icon for ${testProvidersInfoWithSessionRequests[0].displayName} provider`,
   });
 });

--- a/packages/renderer/src/lib/preferences/PreferencesAuthenticationProvidersRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesAuthenticationProvidersRendering.svelte
@@ -27,7 +27,7 @@ import SettingsPage from './SettingsPage.svelte';
       message="Install an authentication provider extension to add an authentication provider here."
       hidden="{$authenticationProviders.length > 0}" />
     {#each $authenticationProviders as provider}
-      {@const sessionRequests = provider.sessionRequests || []}
+      {@const sessionRequests = provider.sessionRequests ?? []}
       <!-- Registered Authentication Provider row start -->
       <div class="flex flex-col w-full mb-5">
         <div

--- a/packages/renderer/src/lib/preferences/PreferencesAuthenticationProvidersRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesAuthenticationProvidersRendering.svelte
@@ -1,11 +1,17 @@
 <script lang="ts">
-import { faArrowRightToBracket, faCircle, faRightFromBracket } from '@fortawesome/free-solid-svg-icons';
+import {
+  faArrowRightToBracket,
+  faCircle,
+  faRightFromBracket,
+  faRightToBracket,
+} from '@fortawesome/free-solid-svg-icons';
 import Fa from 'svelte-fa';
 
 import Tooltip from '/@/lib/ui/Tooltip.svelte';
 
 import { authenticationProviders } from '../../stores/authenticationProviders';
 import KeyIcon from '../images/KeyIcon.svelte';
+import Button from '../ui/Button.svelte';
 import DropdownMenu from '../ui/DropdownMenu.svelte';
 import DropdownMenuItem from '../ui/DropDownMenuItem.svelte';
 import EmptyScreen from '../ui/EmptyScreen.svelte';
@@ -21,6 +27,7 @@ import SettingsPage from './SettingsPage.svelte';
       message="Install an authentication provider extension to add an authentication provider here."
       hidden="{$authenticationProviders.length > 0}" />
     {#each $authenticationProviders as provider}
+      {@const sessionRequests = provider.sessionRequests || []}
       <!-- Registered Authentication Provider row start -->
       <div class="flex flex-col w-full mb-5">
         <div
@@ -84,7 +91,7 @@ import SettingsPage from './SettingsPage.svelte';
                         <span class="my-auto font-bold col-span-1 text-ellipsis overflow-hidden max-w-64">
                           {account.label}
                         </span>
-                        <Tooltip tip="Sign out of {account.label}" left>
+                        <Tooltip tip="Sign out of {account.label}" bottomRight>
                           <button
                             aria-label="Sign out of {account.label}"
                             class="pl-2 hover:cursor-pointer hover:text-white text-white"
@@ -100,10 +107,9 @@ import SettingsPage from './SettingsPage.svelte';
             {/if}
           </div>
 
-          <!-- Authentication Provider Session label start -->
+          <!-- Authentication Provider Auth Requests DropDown start -->
           <div class="ml-4 flex items-center">
-            {#if (provider.sessionRequests || []).length > 0}
-              {@const sessionRequests = provider.sessionRequests || []}
+            {#if sessionRequests.length > 1}
               <DropdownMenu>
                 {#each sessionRequests as request}
                   <DropdownMenuItem
@@ -113,6 +119,23 @@ import SettingsPage from './SettingsPage.svelte';
                 {/each}
               </DropdownMenu>
             {/if}
+            <!-- Authentication Provider Auth Requests DropDown end -->
+
+            <!-- Authentication Provider Auth Request Sign In button start -->
+            {#if sessionRequests.length === 1}
+              {@const request = sessionRequests[0]}
+              <Tooltip tip="Sign in to use {request.extensionLabel}" bottomLeft>
+                <Button
+                  aria-label="Sign in"
+                  class="pl-2 mr-4 hover:cursor-pointer hover:text-white text-white"
+                  on:click="{() => window.requestAuthenticationProviderSignIn(request.id)}">
+                  <div class="flex flex-row items-center">
+                    <Fa class="h-3 w-3 text-md mr-2" icon="{faRightToBracket}" />Sign in
+                  </div>
+                </Button>
+              </Tooltip>
+            {/if}
+            <!-- Authentication Provider Auth Request Sign In button end -->
           </div>
         </div>
       </div>

--- a/packages/renderer/src/lib/preferences/PreferencesAuthenticationProvidersRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesAuthenticationProvidersRendering.svelte
@@ -107,23 +107,10 @@ import SettingsPage from './SettingsPage.svelte';
             {/if}
           </div>
 
-          <!-- Authentication Provider Auth Requests DropDown start -->
           <div class="ml-4 flex items-center">
-            {#if sessionRequests.length > 1}
-              <DropdownMenu>
-                {#each sessionRequests as request}
-                  <DropdownMenuItem
-                    title="Sign in to use {request.extensionLabel}"
-                    onClick="{() => window.requestAuthenticationProviderSignIn(request.id)}"
-                    icon="{faArrowRightToBracket}" />
-                {/each}
-              </DropdownMenu>
-            {/if}
-            <!-- Authentication Provider Auth Requests DropDown end -->
-
-            <!-- Authentication Provider Auth Request Sign In button start -->
             {#if sessionRequests.length === 1}
               {@const request = sessionRequests[0]}
+              <!-- Authentication Provider Auth Request Sign In button start -->
               <Tooltip tip="Sign in to use {request.extensionLabel}" bottomLeft>
                 <Button
                   aria-label="Sign in"
@@ -134,8 +121,19 @@ import SettingsPage from './SettingsPage.svelte';
                   </div>
                 </Button>
               </Tooltip>
+              <!-- Authentication Provider Auth Request Sign In button end -->
+            {:else if sessionRequests.length > 1}
+              <!-- Authentication Provider Auth Requests DropDown start -->
+              <DropdownMenu>
+                {#each sessionRequests as request}
+                  <DropdownMenuItem
+                    title="Sign in to use {request.extensionLabel}"
+                    onClick="{() => window.requestAuthenticationProviderSignIn(request.id)}"
+                    icon="{faArrowRightToBracket}" />
+                {/each}
+              </DropdownMenu>
+              <!-- Authentication Provider Auth Requests DropDown end -->
             {/if}
-            <!-- Authentication Provider Auth Request Sign In button end -->
           </div>
         </div>
       </div>


### PR DESCRIPTION
### What does this PR do?

PR adds logic to auth provider record on Authentication settings page to show `Sign in` button in case of only one none silent authentication request registered. If there are multiple requests then Drop down menu is component is used to list all request for user selection. 

### Screenshot / video of UI

![image](https://github.com/containers/podman-desktop/assets/620330/6b97833d-b622-4300-8d8b-75a283c05de6)


### What issues does this PR fix or reference?

* depends on #6445
* fix #5979

### How to test this PR?

1. pull the proposed changes
2. run PD with RedHat SSO provider extension installed 
3. open Authentication settings page and you should see the page above

- [ ] Tests are covering the bug fix or the new feature
