### PR TITLE
feat: add generic action to task

### DIFF
--- a/packages/main/src/plugin/api/task.ts
+++ b/packages/main/src/plugin/api/task.ts
@@ -30,6 +30,7 @@ export interface StatefulTask extends Task {
   status: TaskStatus;
   progress?: number;
   gotoTask?: () => void;
+  openFolder?: () => void;
   error?: string;
 }
 

--- a/packages/main/src/plugin/api/task.ts
+++ b/packages/main/src/plugin/api/task.ts
@@ -30,7 +30,10 @@ export interface StatefulTask extends Task {
   status: TaskStatus;
   progress?: number;
   gotoTask?: () => void;
-  openFolder?: () => void;
+  action?: {
+    name: string;
+    execute: () => void;
+  };
   error?: string;
 }
 

--- a/packages/renderer/src/lib/task-manager/TaskManagerItem.spec.ts
+++ b/packages/renderer/src/lib/task-manager/TaskManagerItem.spec.ts
@@ -31,7 +31,10 @@ const IN_PROGRESS_TASK: StatefulTask = {
   state: 'running',
   started,
   status: 'in-progress',
-  openFolder: () => {},
+  action: {
+    name: 'action',
+    execute: () => {},
+  },
 };
 
 const IN_PROGRESS_TASK_2: StatefulTask = {
@@ -42,20 +45,21 @@ const IN_PROGRESS_TASK_2: StatefulTask = {
   status: 'in-progress',
 };
 
-test('Expect that the open folder button is visible', async () => {
+test('Expect that the action button is visible', async () => {
   render(TaskManagerItem, {
     task: IN_PROGRESS_TASK,
   });
   // expect the tasks manager is not visible by default
-  const openFolderBtn = screen.getByRole('button', { name: 'open folder' });
-  expect(openFolderBtn).toBeInTheDocument();
+  const actionBtn = screen.getByRole('button', { name: 'action button' });
+  expect(actionBtn).toBeInTheDocument();
+  expect(actionBtn.textContent).equal('action');
 });
 
-test('Expect that the open folder button is hidden', async () => {
+test('Expect that the action button is hidden', async () => {
   render(TaskManagerItem, {
     task: IN_PROGRESS_TASK_2,
   });
   // expect the tasks manager is not visible by default
-  const openFolderBtn = screen.queryByRole('button', { name: 'open folder' });
-  expect(openFolderBtn).not.toBeInTheDocument();
+  const actionBtn = screen.queryByRole('button', { name: 'action button' });
+  expect(actionBtn).not.toBeInTheDocument();
 });

--- a/packages/renderer/src/lib/task-manager/TaskManagerItem.spec.ts
+++ b/packages/renderer/src/lib/task-manager/TaskManagerItem.spec.ts
@@ -1,0 +1,61 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/svelte';
+import { expect, test } from 'vitest';
+
+import type { StatefulTask } from '../../../../main/src/plugin/api/task';
+import TaskManagerItem from './TaskManagerItem.svelte';
+
+const started = new Date().getTime();
+const IN_PROGRESS_TASK: StatefulTask = {
+  id: '1',
+  name: 'Running Task 1',
+  state: 'running',
+  started,
+  status: 'in-progress',
+  openFolder: () => {},
+};
+
+const IN_PROGRESS_TASK_2: StatefulTask = {
+  id: '1',
+  name: 'Running Task 1',
+  state: 'running',
+  started,
+  status: 'in-progress',
+};
+
+test('Expect that the open folder button is visible', async () => {
+  render(TaskManagerItem, {
+    task: IN_PROGRESS_TASK,
+  });
+  // expect the tasks manager is not visible by default
+  const openFolderBtn = screen.getByRole('button', { name: 'open folder' });
+  expect(openFolderBtn).toBeInTheDocument();
+});
+
+test('Expect that the open folder button is hidden', async () => {
+  render(TaskManagerItem, {
+    task: IN_PROGRESS_TASK_2,
+  });
+  // expect the tasks manager is not visible by default
+  const openFolderBtn = screen.queryByRole('button', { name: 'open folder' });
+  expect(openFolderBtn).not.toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/task-manager/TaskManagerItem.svelte
+++ b/packages/renderer/src/lib/task-manager/TaskManagerItem.svelte
@@ -55,8 +55,8 @@ function gotoTask(taskUI: StatefulTaskUI) {
   taskUI?.gotoTask?.();
 }
 
-function openFolder(taskUI: StatefulTaskUI) {
-  taskUI?.openFolder?.();
+function doExecuteAction(taskUI: StatefulTaskUI) {
+  taskUI?.action?.execute();
 }
 </script>
 
@@ -118,13 +118,13 @@ function openFolder(taskUI: StatefulTaskUI) {
     {#if isStatefulTask(taskUI) && taskUI.status !== 'failure'}
       <div class="flex flex-row w-full">
         <div class="flex flex-1 flex-col w-full items-end text-purple-500 text-xs">
-          {#if taskUI.openFolder}
+          {#if taskUI.action}
             <button
               class="text-purple-500 cursor-pointer"
               on:click="{() => {
-                if (isStatefulTask(taskUI)) openFolder(taskUI);
+                if (isStatefulTask(taskUI)) doExecuteAction(taskUI);
               }}"
-              aria-label="open folder">Open folder &gt;</button>
+              aria-label="action button">{taskUI.action.name}</button>
           {/if}
         </div>
       </div>

--- a/packages/renderer/src/lib/task-manager/TaskManagerItem.svelte
+++ b/packages/renderer/src/lib/task-manager/TaskManagerItem.svelte
@@ -124,7 +124,7 @@ function openFolder(taskUI: StatefulTaskUI) {
               on:click="{() => {
                 if (isStatefulTask(taskUI)) openFolder(taskUI);
               }}"
-              aria-label="open folder">Open folder ></button>
+              aria-label="open folder">Open folder &gt;</button>
           {/if}
         </div>
       </div>

--- a/packages/renderer/src/lib/task-manager/TaskManagerItem.svelte
+++ b/packages/renderer/src/lib/task-manager/TaskManagerItem.svelte
@@ -54,6 +54,10 @@ function gotoTask(taskUI: StatefulTaskUI) {
   // and open the task
   taskUI?.gotoTask?.();
 }
+
+function openFolder(taskUI: StatefulTaskUI) {
+  taskUI?.openFolder?.();
+}
 </script>
 
 <!-- Display a task item-->
@@ -106,6 +110,21 @@ function gotoTask(taskUI: StatefulTaskUI) {
               on:click="{() => {
                 if (isStatefulTask(taskUI)) gotoTask(taskUI);
               }}">Go to task ></button>
+          {/if}
+        </div>
+      </div>
+    {/if}
+
+    {#if isStatefulTask(taskUI) && taskUI.status !== 'failure'}
+      <div class="flex flex-row w-full">
+        <div class="flex flex-1 flex-col w-full items-end text-purple-500 text-xs">
+          {#if taskUI.openFolder}
+            <button
+              class="text-purple-500 cursor-pointer"
+              on:click="{() => {
+                if (isStatefulTask(taskUI)) openFolder(taskUI);
+              }}"
+              aria-label="open folder">Open folder ></button>
           {/if}
         </div>
       </div>

--- a/packages/renderer/src/lib/task-manager/task-manager.spec.ts
+++ b/packages/renderer/src/lib/task-manager/task-manager.spec.ts
@@ -54,7 +54,10 @@ const OPEN_FOLDER_TASK: StatefulTask = {
   state: 'running',
   started,
   status: 'in-progress',
-  openFolder: () => {},
+  action: {
+    name: 'action',
+    execute: () => {},
+  },
 };
 
 test('Expect totaskUI returns original NotificationTask', async () => {
@@ -70,9 +73,9 @@ test('Expect toTaskUI returns StatefulTaskUi for StatefulTask', async () => {
   expect('age' in task).toBeTruthy();
 });
 
-test('Expect totaskUI returns StatefulTaskUi with openFolder prop', async () => {
+test('Expect totaskUI returns StatefulTaskUi with action prop', async () => {
   const taskManager = new TaskManager();
   const task = taskManager.toTaskUi(OPEN_FOLDER_TASK);
   expect(task.id).equal(OPEN_FOLDER_TASK.id);
-  expect('openFolder' in task).not.toBeUndefined();
+  expect('action' in task).not.toBeUndefined();
 });

--- a/packages/renderer/src/lib/task-manager/task-manager.spec.ts
+++ b/packages/renderer/src/lib/task-manager/task-manager.spec.ts
@@ -48,6 +48,14 @@ const NOTIFICATION_TASK: NotificationTask = {
   description: ' description',
   started,
 };
+const OPEN_FOLDER_TASK: StatefulTask = {
+  id: '1',
+  name: 'Running Task 1',
+  state: 'running',
+  started,
+  status: 'in-progress',
+  openFolder: () => {},
+};
 
 test('Expect totaskUI returns original NotificationTask', async () => {
   const taskManager = new TaskManager();
@@ -60,4 +68,11 @@ test('Expect toTaskUI returns StatefulTaskUi for StatefulTask', async () => {
   const taskManager = new TaskManager();
   const task = taskManager.toTaskUi(IN_PROGRESS_TASK);
   expect('age' in task).toBeTruthy();
+});
+
+test('Expect totaskUI returns StatefulTaskUi with openFolder prop', async () => {
+  const taskManager = new TaskManager();
+  const task = taskManager.toTaskUi(OPEN_FOLDER_TASK);
+  expect(task.id).equal(OPEN_FOLDER_TASK.id);
+  expect('openFolder' in task).not.toBeUndefined();
 });

--- a/packages/renderer/src/lib/task-manager/task-manager.ts
+++ b/packages/renderer/src/lib/task-manager/task-manager.ts
@@ -40,7 +40,7 @@ export class TaskManager {
         status: task.status,
         hasGotoTask: false,
         age: `${humanizeDuration(new Date().getTime() - task.started, { round: true, largest: 1 })} ago`,
-        openFolder: task.openFolder,
+        action: task.action,
         error: task.error,
       };
 

--- a/packages/renderer/src/lib/task-manager/task-manager.ts
+++ b/packages/renderer/src/lib/task-manager/task-manager.ts
@@ -40,6 +40,7 @@ export class TaskManager {
         status: task.status,
         hasGotoTask: false,
         age: `${humanizeDuration(new Date().getTime() - task.started, { round: true, largest: 1 })} ago`,
+        openFolder: task.openFolder,
         error: task.error,
       };
 


### PR DESCRIPTION
### What does this PR do?

It adds a new property to a task to implement a custom behavior like show an 'open folder' action.
This will be used with the export container action. When the export is executing/has been executed the user could open the taskmanager, click on the open folder link to open the directory where the container content will be saved

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

it is part of #6355 

### How to test this PR?

1. run test

- [x] Tests are covering the bug fix or the new feature
