### PR TITLE
chore: make saveDialog function returns Uri

### DIFF
--- a/packages/main/src/plugin/dialog-registry.spec.ts
+++ b/packages/main/src/plugin/dialog-registry.spec.ts
@@ -18,13 +18,13 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import type { Uri } from '@podman-desktop/api';
 import { type BrowserWindow, dialog } from 'electron';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { Deferred } from '/@/plugin/util/deferred.js';
 
 import { DialogRegistry } from './dialog-registry.js';
+import { Uri } from './types/uri.js';
 
 let mainWindowDeferred: Deferred<BrowserWindow>;
 
@@ -170,7 +170,7 @@ describe('showSaveDialog', () => {
 
   test('check with no options', async () => {
     const result = await dialogRegistry.saveDialog();
-    expect(result).toStrictEqual('/tmp/my/path');
+    expect(result).toStrictEqual(Uri.file('/tmp/my/path'));
 
     expect(dialog.showSaveDialog).toHaveBeenCalledWith(fakeBrowserWindow, expect.anything());
 
@@ -186,7 +186,7 @@ describe('showSaveDialog', () => {
     expect(fakeBrowserWindow.webContents.send).toHaveBeenCalledWith(
       'dialog:open-save-dialog-response',
       'my-dialog-id',
-      '/tmp/my/path',
+      Uri.file('/tmp/my/path'),
     );
 
     expect(dialog.showSaveDialog).toHaveBeenCalledWith(fakeBrowserWindow, expect.anything());
@@ -200,7 +200,7 @@ describe('showSaveDialog', () => {
       saveLabel: 'my save label',
     });
 
-    expect(result).toStrictEqual('/tmp/my/path');
+    expect(result).toStrictEqual(Uri.file('/tmp/my/path'));
 
     expect(dialog.showSaveDialog).toHaveBeenCalledWith(
       fakeBrowserWindow,

--- a/packages/main/src/plugin/dialog-registry.ts
+++ b/packages/main/src/plugin/dialog-registry.ts
@@ -20,6 +20,7 @@ import type { OpenDialogOptions, SaveDialogOptions } from '@podman-desktop/api';
 import type { BrowserWindow } from 'electron';
 import { dialog } from 'electron';
 
+import { Uri } from './types/uri.js';
 import type { Deferred } from './util/deferred.js';
 
 /**
@@ -88,7 +89,7 @@ export class DialogRegistry {
     }
   }
 
-  async saveDialog(options?: SaveDialogOptions, dialogId?: string): Promise<string | undefined> {
+  async saveDialog(options?: SaveDialogOptions, dialogId?: string): Promise<Uri | undefined> {
     if (!this.#browserWindow) {
       throw new Error('Browser window is not available');
     }
@@ -115,11 +116,12 @@ export class DialogRegistry {
     if (response.filePath && !response.canceled) {
       filePath = response.filePath;
     }
+    const fileUri = filePath ? Uri.file(filePath) : undefined;
     // send the response to the renderer part if dialogId is provided
     if (dialogId) {
-      this.#browserWindow.webContents.send('dialog:open-save-dialog-response', dialogId, filePath);
+      this.#browserWindow.webContents.send('dialog:open-save-dialog-response', dialogId, fileUri);
     } else {
-      return filePath;
+      return fileUri;
     }
   }
 }

--- a/packages/main/src/plugin/dialog-registry.ts
+++ b/packages/main/src/plugin/dialog-registry.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { OpenDialogOptions, SaveDialogOptions } from '@podman-desktop/api';
+import type { OpenDialogOptions, SaveDialogOptions, Uri as APIUri } from '@podman-desktop/api';
 import type { BrowserWindow } from 'electron';
 import { dialog } from 'electron';
 
@@ -89,7 +89,7 @@ export class DialogRegistry {
     }
   }
 
-  async saveDialog(options?: SaveDialogOptions, dialogId?: string): Promise<Uri | undefined> {
+  async saveDialog(options?: SaveDialogOptions, dialogId?: string): Promise<APIUri | undefined> {
     if (!this.#browserWindow) {
       throw new Error('Browser window is not available');
     }

--- a/packages/main/src/plugin/extension-loader.spec.ts
+++ b/packages/main/src/plugin/extension-loader.spec.ts
@@ -65,6 +65,7 @@ import type { StatusBarRegistry } from './statusbar/statusbar-registry.js';
 import type { Telemetry } from './telemetry/telemetry.js';
 import type { TrayMenuRegistry } from './tray-menu-registry.js';
 import { Disposable } from './types/disposable.js';
+import { Uri } from './types/uri.js';
 import { Exec } from './util/exec.js';
 import type { ViewRegistry } from './view-registry.js';
 
@@ -1666,7 +1667,7 @@ describe('window', async () => {
     expect(api).toBeDefined();
 
     const filePath = '/path-to-file1';
-    vi.mocked(dialogRegistry.saveDialog).mockResolvedValue(filePath);
+    vi.mocked(dialogRegistry.saveDialog).mockResolvedValue(Uri.file(filePath));
 
     const uri = await api.window.showSaveDialog();
 

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -910,10 +910,7 @@ export class ExtensionLoader {
       showSaveDialog: async (
         options?: containerDesktopAPI.SaveDialogOptions,
       ): Promise<containerDesktopAPI.Uri | undefined> => {
-        const result = await dialogRegistry.saveDialog(options);
-        if (result) {
-          return Uri.file(result);
-        }
+        return dialogRegistry.saveDialog(options);
       },
     };
 

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -156,6 +156,7 @@ import { TrayIconColor } from './tray-icon-color.js';
 import { TrayMenuRegistry } from './tray-menu-registry.js';
 import { Troubleshooting } from './troubleshooting.js';
 import type { IDisposable } from './types/disposable.js';
+import { Uri } from './types/uri.js';
 import type { Deferred } from './util/deferred.js';
 import { Exec } from './util/exec.js';
 import { getFreePort, getFreePortRange, isFreePort } from './util/port.js';
@@ -2131,6 +2132,9 @@ export class PluginSystem {
       'context:collectAllValues',
       async (): Promise<Record<string, unknown>> => context.collectAllValues(),
     );
+    this.ipcHandle('uri:parseFile', async (_listener, path: string): Promise<containerDesktopAPI.Uri> => {
+      return Uri.file(path);
+    });
 
     const dockerDesktopInstallation = new DockerDesktopInstallation(
       apiSender,

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -156,7 +156,6 @@ import { TrayIconColor } from './tray-icon-color.js';
 import { TrayMenuRegistry } from './tray-menu-registry.js';
 import { Troubleshooting } from './troubleshooting.js';
 import type { IDisposable } from './types/disposable.js';
-import { Uri } from './types/uri.js';
 import type { Deferred } from './util/deferred.js';
 import { Exec } from './util/exec.js';
 import { getFreePort, getFreePortRange, isFreePort } from './util/port.js';
@@ -2122,19 +2121,18 @@ export class PluginSystem {
     );
     this.ipcHandle(
       'dialog:saveDialog',
-      async (_listener, dialogId: string, options: containerDesktopAPI.SaveDialogOptions): Promise<void> => {
-        dialogRegistry.saveDialog(options, dialogId).catch((error: unknown) => {
-          console.error('Error opening dialog', error);
-        });
+      async (
+        _listener,
+        dialogId: string,
+        options: containerDesktopAPI.SaveDialogOptions,
+      ): Promise<containerDesktopAPI.Uri | undefined> => {
+        return dialogRegistry.saveDialog(options, dialogId);
       },
     );
     this.ipcHandle(
       'context:collectAllValues',
       async (): Promise<Record<string, unknown>> => context.collectAllValues(),
     );
-    this.ipcHandle('uri:parseFile', async (_listener, path: string): Promise<containerDesktopAPI.Uri> => {
-      return Uri.file(path);
-    });
 
     const dockerDesktopInstallation = new DockerDesktopInstallation(
       apiSender,

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -1991,6 +1991,10 @@ export function initExposure(): void {
   contextBridge.exposeInMainWorld('contextCollectAllValues', async (): Promise<Record<string, unknown>> => {
     return ipcInvoke('context:collectAllValues');
   });
+
+  contextBridge.exposeInMainWorld('uriFile', async (path: string): Promise<containerDesktopAPI.Uri> => {
+    return ipcInvoke('uri:parseFile', path);
+  });
 }
 
 // expose methods

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -1316,16 +1316,19 @@ export function initExposure(): void {
 
   const openSaveDialogResponses = new Map<string, OpenSaveDialogResultCallback>();
 
-  const deferedHandleDialog = (): { id: string; deferred: Deferred<string | string[] | undefined> } => {
+  const deferedHandleDialog = (): {
+    id: string;
+    deferred: Deferred<containerDesktopAPI.Uri | string | string[] | undefined>;
+  } => {
     // generate id
     const dialogId = idOpenSaveDialog;
     idOpenSaveDialog++;
 
     // create defer object
-    const deferred = new Deferred<string | string[] | undefined>();
+    const deferred = new Deferred<containerDesktopAPI.Uri | string | string[] | undefined>();
 
     // store the dialogID
-    openSaveDialogResponses.set(`${dialogId}`, (result: string | string[] | undefined) => {
+    openSaveDialogResponses.set(`${dialogId}`, (result: containerDesktopAPI.Uri | string | string[] | undefined) => {
       deferred.resolve(result);
     });
 
@@ -1349,7 +1352,7 @@ export function initExposure(): void {
 
   contextBridge.exposeInMainWorld(
     'saveDialog',
-    async (options?: containerDesktopAPI.SaveDialogOptions): Promise<string | undefined> => {
+    async (options?: containerDesktopAPI.SaveDialogOptions): Promise<containerDesktopAPI.Uri | undefined> => {
       const handle = deferedHandleDialog();
 
       // ask to open file dialog
@@ -1358,7 +1361,7 @@ export function initExposure(): void {
       });
 
       // wait for response
-      return handle.deferred.promise as Promise<string | undefined>;
+      return handle.deferred.promise as Promise<containerDesktopAPI.Uri | undefined>;
     },
   );
 
@@ -1990,10 +1993,6 @@ export function initExposure(): void {
 
   contextBridge.exposeInMainWorld('contextCollectAllValues', async (): Promise<Record<string, unknown>> => {
     return ipcInvoke('context:collectAllValues');
-  });
-
-  contextBridge.exposeInMainWorld('uriFile', async (path: string): Promise<containerDesktopAPI.Uri> => {
-    return ipcInvoke('uri:parseFile', path);
   });
 }
 

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingGatherLogs.svelte
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingGatherLogs.svelte
@@ -4,6 +4,8 @@ import Fa from 'svelte-fa';
 
 import Button from '/@/lib/ui/Button.svelte';
 
+import { Uri } from '../uri/Uri';
+
 let logs: string[] = [];
 
 // Save files as a zip file (we first ask the user for the dialog, and then save the files to the filepath)
@@ -11,7 +13,8 @@ async function saveLogsAsZip() {
   const defaultUri = await window.troubleshootingGenerateLogFileUri('podman-desktop', 'zip');
   const filePath = await window.saveDialog({ title: 'Save Logs as .zip', defaultUri });
   if (filePath) {
-    logs = await window.troubleshootingSaveLogs(filePath);
+    const filePathUri = Uri.revive(filePath);
+    logs = await window.troubleshootingSaveLogs(filePathUri.fsPath);
   }
 }
 </script>


### PR DESCRIPTION
### What does this PR do?

it makes the saveDialog function returns the Uri instead of a string so that it can be re-used if we need to call the openDialog function from a task -> https://github.com/containers/podman-desktop/pull/6453

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

N/A

### How to test this PR?

N/A

- [x] Tests are covering the bug fix or the new feature
