### PR TITLE
feat: allow to revive a Uri object when passing it frontend - backend

### DIFF
--- a/packages/main/src/plugin/types/uri.spec.ts
+++ b/packages/main/src/plugin/types/uri.spec.ts
@@ -16,6 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { Uri as APIUri } from '@podman-desktop/api';
 import { afterEach, expect, test, vi } from 'vitest';
 
 import { Uri } from './uri.js';
@@ -94,4 +95,22 @@ test('Uri.with and same change', () => {
   const updatedUri = uri.with({ scheme: 'https', authority: 'podman-desktop.io', path: '/', query: '', fragment: '' });
 
   expect(updatedUri).toBe(uri);
+});
+
+test('Expect revive to return revived Uri object', () => {
+  const uriSerialized = {
+    _scheme: 'scheme',
+    _authority: 'authority',
+    _path: 'path',
+    _query: 'query',
+    _fragment: 'fragment',
+  } as unknown as APIUri;
+
+  const revived = Uri.revive(uriSerialized);
+  expect(revived.authority).equals('authority');
+  expect(revived.scheme).equals('scheme');
+  expect(revived.path).equals('path');
+  expect(revived.fsPath).equals('path');
+  expect(revived.query).equals('query');
+  expect(revived.fragment).equals('fragment');
 });

--- a/packages/main/src/plugin/types/uri.ts
+++ b/packages/main/src/plugin/types/uri.ts
@@ -18,6 +18,8 @@
 
 import path, { join } from 'node:path';
 
+import type { Uri as APIUri } from '@podman-desktop/api';
+
 import { isWindows } from '/@/util.js';
 
 /**
@@ -136,5 +138,24 @@ export class Uri {
       link = `${link}#${this._fragment}`;
     }
     return link;
+  }
+
+  static revive(serialized: APIUri): Uri {
+    if (serialized instanceof Uri) {
+      return serialized;
+    }
+    const serializedProps: Map<string, string> = Object.entries(serialized)
+      .map(([key, value]) => [key.startsWith('_') ? key.substring(1) : key, value])
+      .reduce((map, [key, value]) => {
+        map.set(key, value);
+        return map;
+      }, new Map());
+    return new Uri(
+      serializedProps.get('scheme') ?? '',
+      serializedProps.get('authority') ?? '',
+      serializedProps.get('path') ?? '',
+      serializedProps.get('query') ?? '',
+      serializedProps.get('fragment') ?? '',
+    );
   }
 }

--- a/packages/renderer/src/lib/uri/Uri.spec.ts
+++ b/packages/renderer/src/lib/uri/Uri.spec.ts
@@ -1,0 +1,45 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { Uri as APIUri } from '@podman-desktop/api';
+import { afterEach, expect, test, vi } from 'vitest';
+
+import { Uri } from './Uri.js';
+
+afterEach(() => {
+  vi.resetAllMocks();
+  vi.clearAllMocks();
+});
+
+test('Expect revive to return revived Uri object', () => {
+  const uriSerialized = {
+    _scheme: 'scheme',
+    _authority: 'authority',
+    _path: 'path',
+    _query: 'query',
+    _fragment: 'fragment',
+  } as unknown as APIUri;
+
+  const revived = Uri.revive(uriSerialized);
+  expect(revived.authority).equals('authority');
+  expect(revived.scheme).equals('scheme');
+  expect(revived.path).equals('path');
+  expect(revived.fsPath).equals('path');
+  expect(revived.query).equals('query');
+  expect(revived.fragment).equals('fragment');
+});

--- a/packages/renderer/src/lib/uri/Uri.ts
+++ b/packages/renderer/src/lib/uri/Uri.ts
@@ -1,0 +1,78 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import type { Uri as APIUri } from '@podman-desktop/api';
+
+export class Uri {
+  private constructor(
+    private _scheme: string,
+    private _authority: string,
+    private _path: string,
+    private _query: string,
+    private _fragment: string,
+  ) {}
+
+  get fsPath(): string {
+    return this._path;
+  }
+  get scheme(): string {
+    return this._scheme;
+  }
+
+  get authority(): string {
+    return this._authority;
+  }
+
+  get path(): string {
+    return this._path;
+  }
+
+  get query(): string {
+    return this._query;
+  }
+
+  get fragment(): string {
+    return this._fragment;
+  }
+
+  with(_change?: { scheme?: string; authority?: string; path?: string; query?: string; fragment?: string }): Uri {
+    throw new Error('unsupported');
+  }
+
+  toString(): string {
+    throw new Error('unsupported');
+  }
+
+  static revive(serialized: APIUri): Uri {
+    if (serialized instanceof Uri) {
+      return serialized;
+    }
+    const serializedProps: Map<string, string> = Object.entries(serialized)
+      .map(([key, value]) => [key.startsWith('_') ? key.substring(1) : key, value])
+      .reduce((map, [key, value]) => {
+        map.set(key, value);
+        return map;
+      }, new Map());
+    return new Uri(
+      serializedProps.get('scheme') ?? '',
+      serializedProps.get('authority') ?? '',
+      serializedProps.get('path') ?? '',
+      serializedProps.get('query') ?? '',
+      serializedProps.get('fragment') ?? '',
+    );
+  }
+}


### PR DESCRIPTION
### What does this PR do?

It allows to return/send a URI object between frontend/backend and retrieve the property by calling the `URI.revive` function

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

N/A

### How to test this PR?

run tests

- [x] Tests are covering the bug fix or the new feature
