### PR TITLE
chore: download podman 5 binaries when building podman extension

### DIFF
--- a/extensions/podman/scripts/download.ts
+++ b/extensions/podman/scripts/download.ts
@@ -25,6 +25,6 @@ import * as podman5JSON from '../src/podman5.json';
 const podman4Download = new PodmanDownload(podman4JSON, true);
 podman4Download.downloadBinaries();
 
-// do not fetch for aigap mode now
+// do not fetch for airgap mode now
 const podman5Download = new PodmanDownload(podman5JSON, false);
 podman5Download.downloadBinaries();

--- a/extensions/podman/scripts/download.ts
+++ b/extensions/podman/scripts/download.ts
@@ -20,6 +20,11 @@
 import { PodmanDownload } from './podman-download';
 
 import * as podman4JSON from '../src/podman4.json';
+import * as podman5JSON from '../src/podman5.json';
 
 const podman4Download = new PodmanDownload(podman4JSON, true);
 podman4Download.downloadBinaries();
+
+// do not fetch for aigap mode now
+const podman5Download = new PodmanDownload(podman5JSON, false);
+podman5Download.downloadBinaries();

--- a/extensions/podman/src/podman5.json
+++ b/extensions/podman/src/podman5.json
@@ -1,0 +1,23 @@
+{
+  "version": "5.0.0",
+  "platform": {
+    "win32": {
+      "version": "v5.0.0",
+      "fileName": "podman-5.0.0-setup.exe"
+    },
+    "darwin": {
+      "version": "v5.0.0",
+      "arch": {
+        "x64": {
+          "fileName": "podman-installer-macos-amd64-v5.0.0.pkg"
+        },
+        "arm64": {
+          "fileName": "podman-installer-macos-aarch64-v5.0.0.pkg"
+        },
+        "universal": {
+          "fileName": "podman-installer-macos-universal-v5.0.0.pkg"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
### What does this PR do?
Download podman 5 binaries when building podman extension

note: they won't show up in the UI for now


### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

part of https://github.com/containers/podman-desktop/issues/6375

### How to test this PR?

manually, you can run `yarn build` in extensions/podman folder it'll fetch macOS or Windows installer depending on your platform


unit tests were provided before for testing download function
- [x] Tests are covering the bug fix or the new feature
