### PR TITLE
feat: add export container

### DIFF
--- a/packages/main/src/plugin/api/container-info.ts
+++ b/packages/main/src/plugin/api/container-info.ts
@@ -275,6 +275,5 @@ export interface VolumeCreateResponseInfo extends Dockerode.VolumeCreateResponse
 
 export interface ContainerExportOptions {
   id: string;
-  name: string;
-  outputDirectory: string;
+  outputTarget: string;
 }

--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -18,7 +18,6 @@
 
 import { EventEmitter } from 'node:events';
 import * as fs from 'node:fs';
-import path from 'node:path';
 import { PassThrough } from 'node:stream';
 
 import type * as podmanDesktopAPI from '@podman-desktop/api';
@@ -3803,8 +3802,7 @@ describe('exportContainer', () => {
     await expect(
       containerRegistry.exportContainer('engine', {
         id: 'id',
-        name: 'name',
-        outputDirectory: 'dir',
+        outputTarget: 'dir/name',
       }),
     ).rejects.toThrowError('no engine matching this container');
   });
@@ -3819,8 +3817,7 @@ describe('exportContainer', () => {
     await expect(
       containerRegistry.exportContainer('podman1', {
         id: 'id',
-        name: 'name',
-        outputDirectory: 'dir',
+        outputTarget: 'dir/name',
       }),
     ).rejects.toThrowError('no running provider for the matching container');
   });
@@ -3834,27 +3831,9 @@ describe('exportContainer', () => {
     } as unknown as fs.WriteStream);
     await containerRegistry.exportContainer('podman1', {
       id: 'id',
-      name: 'name',
-      outputDirectory: 'dir',
+      outputTarget: 'dir/name',
     });
-    expect(createWriteStreamMock).toBeCalledWith(path.join('dir', 'name'), {
-      flags: 'w',
-    });
-  });
-  test('should export container to customized location if given path already exists', async () => {
-    setExportContainerTestEnv();
-    vi.spyOn(fs.promises, 'readdir').mockResolvedValue([{ isFile: () => true, name: 'name' } as fs.Dirent]);
-
-    const createWriteStreamMock = vi.spyOn(fs, 'createWriteStream').mockReturnValue({
-      write: vi.fn(),
-      close: vi.fn(),
-    } as unknown as fs.WriteStream);
-    await containerRegistry.exportContainer('podman1', {
-      id: 'id',
-      name: 'name',
-      outputDirectory: 'dir',
-    });
-    expect(createWriteStreamMock).toBeCalledWith(path.join('dir', 'name (1)'), {
+    expect(createWriteStreamMock).toBeCalledWith('dir/name', {
       flags: 'w',
     });
   });

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -19,7 +19,6 @@
 import * as crypto from 'node:crypto';
 import { EventEmitter } from 'node:events';
 import * as fs from 'node:fs';
-import path from 'node:path';
 import { type Stream, Writable } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
 
@@ -2405,23 +2404,10 @@ export class ContainerProviderRegistry {
       throw new Error('no running provider for the matching container');
     }
 
-    // generate the name of the exported file
-    // if there are other entries with the same name, let's append (number of occurences)
-    let containerFile = options.name;
-    const regexFile = new RegExp(`${containerFile}\\s+\\(+\\d+\\)$`);
-    const entries = await fs.promises.readdir(options.outputDirectory, { withFileTypes: true });
-    const similarContainers = entries
-      .filter(entry => entry.isFile())
-      .filter(file => file.name === containerFile || regexFile.test(file.name));
-
-    if (similarContainers.length > 0) {
-      containerFile += ` (${similarContainers.length})`;
-    }
-
     // retrieve the container and export it by copying the content to the final destination
     const containerObject = engine.api.getContainer(options.id);
     const exportResult = await containerObject.export();
-    const fileWriteStream = fs.createWriteStream(path.join(options.outputDirectory, containerFile), {
+    const fileWriteStream = fs.createWriteStream(options.outputTarget, {
       flags: 'w',
     });
 

--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -11,6 +11,7 @@ import AppNavigation from './AppNavigation.svelte';
 import Appearance from './lib/appearance/Appearance.svelte';
 import ComposeDetails from './lib/compose/ComposeDetails.svelte';
 import ContainerDetails from './lib/container/ContainerDetails.svelte';
+import ContainerExport from './lib/container/ContainerExport.svelte';
 import ContainerList from './lib/container/ContainerList.svelte';
 import ContextKey from './lib/context/ContextKey.svelte';
 import DashboardPage from './lib/dashboard/DashboardPage.svelte';
@@ -106,6 +107,9 @@ window.events?.receive('navigate', (navigationRequest: unknown) => {
         </Route>
         <Route path="/containers/:id/*" breadcrumb="Container Details" let:meta navigationHint="details">
           <ContainerDetails containerID="{meta.params.id}" />
+        </Route>
+        <Route path="/containers/export/*" breadcrumb="Export Container">
+          <ContainerExport />
         </Route>
 
         <Route path="/kube/play" breadcrumb="Play Kubernetes YAML">

--- a/packages/renderer/src/lib/container/ContainerActions.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerActions.spec.ts
@@ -19,7 +19,10 @@
 import '@testing-library/jest-dom/vitest';
 
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
+import { router } from 'tinro';
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+
+import { exportContainerInfo } from '/@/stores/export-container-store';
 
 import ContainerActions from './ContainerActions.svelte';
 import type { ContainerInfoUI } from './ContainerInfoUI';
@@ -101,4 +104,16 @@ test('Expect no error and status deleting container', async () => {
   expect(container.state).toEqual('DELETING');
   expect(container.actionError).toEqual('');
   expect(updateMock).toHaveBeenCalled();
+});
+
+test('Expect exportContainerInfo is filled and user redirected to export container page', async () => {
+  const goToMock = vi.spyOn(router, 'goto');
+  const storeSetMock = vi.spyOn(exportContainerInfo, 'set');
+
+  render(ContainerActions, { container });
+  const exportButton = screen.getByRole('button', { name: 'Export Container' });
+  await fireEvent.click(exportButton);
+
+  expect(goToMock).toBeCalledWith('/containers/export');
+  expect(storeSetMock).toBeCalledWith(container);
 });

--- a/packages/renderer/src/lib/container/ContainerActions.svelte
+++ b/packages/renderer/src/lib/container/ContainerActions.svelte
@@ -211,6 +211,7 @@ if (dropdownMenu) {
     icon="{faArrowsRotate}" />
   <ListItemButtonIcon
     title="Export Container"
+    tooltip="Exports container's filesystem contents as a tar archive and saves it on the local machine"
     onClick="{() => exportContainer()}"
     menu="{dropdownMenu}"
     detailed="{detailed}"

--- a/packages/renderer/src/lib/container/ContainerActions.svelte
+++ b/packages/renderer/src/lib/container/ContainerActions.svelte
@@ -2,6 +2,7 @@
 import {
   faAlignLeft,
   faArrowsRotate,
+  faDownload,
   faExternalLinkSquareAlt,
   faFileCode,
   faPlay,
@@ -14,6 +15,7 @@ import { createEventDispatcher, onMount } from 'svelte';
 import { router } from 'tinro';
 
 import ContributionActions from '/@/lib/actions/ContributionActions.svelte';
+import { exportContainerInfo } from '/@/stores/export-container-store';
 
 import type { Menu } from '../../../../main/src/plugin/menu-registry';
 import { MenuContext } from '../../../../main/src/plugin/menu-registry';
@@ -104,6 +106,11 @@ async function deleteContainer(): Promise<void> {
   } finally {
     inProgress(false);
   }
+}
+
+async function exportContainer() {
+  exportContainerInfo.set(container);
+  router.goto('/containers/export');
 }
 
 function openTerminalContainer(): void {
@@ -202,6 +209,12 @@ if (dropdownMenu) {
     menu="{dropdownMenu}"
     detailed="{detailed}"
     icon="{faArrowsRotate}" />
+  <ListItemButtonIcon
+    title="Export Container"
+    onClick="{() => exportContainer()}"
+    menu="{dropdownMenu}"
+    detailed="{detailed}"
+    icon="{faDownload}" />
   <ContributionActions
     args="{[container]}"
     contextPrefix="containerItem"

--- a/packages/renderer/src/lib/container/ContainerExport.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerExport.spec.ts
@@ -1,0 +1,126 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import '@testing-library/jest-dom/vitest';
+
+import type { Uri } from '@podman-desktop/api';
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { router } from 'tinro';
+import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
+
+import { exportContainerInfo } from '/@/stores/export-container-store';
+
+import ContainerExport from './ContainerExport.svelte';
+import type { ContainerInfoUI } from './ContainerInfoUI';
+
+const container: ContainerInfoUI = {
+  engineId: 'engine',
+  id: 'id',
+  name: 'test',
+} as ContainerInfoUI;
+
+const saveDialogMock = vi.fn();
+const exportContainerMock = vi.fn();
+
+// fake the window.events object
+beforeAll(() => {
+  (window as any).saveDialog = saveDialogMock;
+  (window as any).exportContainer = exportContainerMock;
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+async function waitRender(): Promise<void> {
+  const result = render(ContainerExport);
+  // wait that result.component.$$.ctx[1] is set
+  while (result.component.$$.ctx[1] === undefined) {
+    await new Promise(resolve => setTimeout(resolve, 100));
+  }
+}
+
+test('Expect export button to be disabled', async () => {
+  exportContainerInfo.set(container);
+  await waitRender();
+  const btnExportcontainer = screen.getByRole('button', { name: 'Export container' });
+  expect(btnExportcontainer).toBeInTheDocument();
+  expect(btnExportcontainer).toBeDisabled();
+});
+
+test('Expect export button to be enabled when output target is selected', async () => {
+  exportContainerInfo.set(container);
+  saveDialogMock.mockResolvedValue({ scheme: 'file', path: '/tmp/my/path' } as Uri);
+  await waitRender();
+  const btnSelectOutputDir = screen.getByRole('button', { name: 'Select output file' });
+  expect(btnSelectOutputDir).toBeInTheDocument();
+  await userEvent.click(btnSelectOutputDir);
+
+  const btnExportcontainer = screen.getByRole('button', { name: 'Export container' });
+  expect(btnExportcontainer).toBeInTheDocument();
+  expect(btnExportcontainer).toBeEnabled();
+});
+
+test('Expect export function called when export button is clicked', async () => {
+  exportContainerInfo.set(container);
+  saveDialogMock.mockResolvedValue({ scheme: 'file', path: '/tmp/my/path' } as Uri);
+  exportContainerMock.mockResolvedValue('');
+  const goToMock = vi.spyOn(router, 'goto');
+  await waitRender();
+  const btnSelectOutputDir = screen.getByRole('button', { name: 'Select output file' });
+  expect(btnSelectOutputDir).toBeInTheDocument();
+  await userEvent.click(btnSelectOutputDir);
+
+  const btnExportcontainer = screen.getByRole('button', { name: 'Export container' });
+  expect(btnExportcontainer).toBeInTheDocument();
+  await userEvent.click(btnExportcontainer);
+
+  expect(exportContainerMock).toBeCalledWith(container.engineId, {
+    id: container.id,
+    outputTarget: '/tmp/my/path',
+  });
+  expect(goToMock).toBeCalledWith('/containers/');
+});
+
+test('Expect error shown if export function fails', async () => {
+  exportContainerInfo.set(container);
+  saveDialogMock.mockResolvedValue({ scheme: 'file', path: '/tmp/my/path' } as Uri);
+  exportContainerMock.mockRejectedValue('error while exporting');
+  const goToMock = vi.spyOn(router, 'goto');
+  await waitRender();
+  const btnSelectOutputDir = screen.getByRole('button', { name: 'Select output file' });
+  expect(btnSelectOutputDir).toBeInTheDocument();
+  await userEvent.click(btnSelectOutputDir);
+
+  const btnExportcontainer = screen.getByRole('button', { name: 'Export container' });
+  expect(btnExportcontainer).toBeInTheDocument();
+  await userEvent.click(btnExportcontainer);
+
+  const errorDiv = screen.getByLabelText('Error Message Content');
+
+  expect(exportContainerMock).toBeCalledWith(container.engineId, {
+    id: container.id,
+    outputTarget: '/tmp/my/path',
+  });
+  expect(goToMock).not.toBeCalled();
+  expect(errorDiv).toBeInTheDocument();
+  expect((errorDiv as HTMLDivElement).innerHTML).toContain('error while exporting');
+});

--- a/packages/renderer/src/lib/container/ContainerExport.svelte
+++ b/packages/renderer/src/lib/container/ContainerExport.svelte
@@ -1,0 +1,120 @@
+<script lang="ts">
+import { faDownload, faFolderOpen } from '@fortawesome/free-solid-svg-icons';
+import { Input } from '@podman-desktop/ui-svelte';
+import { onMount } from 'svelte';
+import { router } from 'tinro';
+
+import { exportContainerInfo } from '/@/stores/export-container-store';
+import { createTask } from '/@/stores/tasks';
+
+import Button from '../ui/Button.svelte';
+import ErrorMessage from '../ui/ErrorMessage.svelte';
+import FormPage from '../ui/FormPage.svelte';
+import { Uri } from '../uri/Uri';
+import type { ContainerInfoUI } from './ContainerInfoUI';
+
+let container: ContainerInfoUI;
+
+let invalidName = false;
+let invalidFolder = true;
+let outputTarget = '';
+let outputUri: Uri;
+let exportedError = '';
+$: invalidFields = invalidName || invalidFolder;
+
+onMount(async () => {
+  // grab current value
+  container = $exportContainerInfo;
+  if (!container) {
+    // go back to containers list
+    router.goto('/containers/');
+  }
+});
+
+async function selectFolderPath() {
+  const result = await window.saveDialog({
+    title: 'Select the directory where to export the container content',
+  });
+  if (!result) {
+    if (!outputTarget) {
+      invalidFolder = true;
+    }
+    return;
+  }
+  const uriAPI = Uri.revive(result);
+  outputUri = uriAPI;
+  outputTarget = uriAPI.fsPath;
+  invalidFolder = false;
+}
+
+async function exportContainer() {
+  exportedError = '';
+  const task = createTask(`Export container ${container.name}`);
+  task.action = {
+    name: 'Open folder >',
+    execute: () => {
+      window.openDialog({
+        defaultUri: outputUri,
+      });
+    },
+  };
+  try {
+    await window.exportContainer(container.engineId, {
+      id: container.id,
+      outputTarget: outputUri.fsPath,
+    });
+    task.status = 'success';
+    // go back to containers list
+    router.goto('/containers/');
+  } catch (error) {
+    task.status = 'failure';
+    task.error = String(error);
+    exportedError = String(error);
+  } finally {
+    task.state = 'completed';
+  }
+}
+</script>
+
+{#if container}
+  <FormPage title="Export container {container.name}">
+    <svelte:fragment slot="icon">
+      <i class="fas fa-download fa-2x" aria-hidden="true"></i>
+    </svelte:fragment>
+
+    <div slot="content" class="flex flex-col min-w-full h-fit p-5">
+      <div class="bg-charcoal-600 px-6 py-4 space-y-2 lg:px-8 sm:pb-6 xl:pb-8">
+        <div>
+          <label for="modalSelectTarget" class="block mb-2 text-sm font-medium text-gray-400">Export to:</label>
+          <div class="flex w-full">
+            <Input
+              class="grow mr-2"
+              name="{container.id}"
+              readonly
+              value="{outputTarget}"
+              id="input-export-container-name"
+              aria-invalid="{invalidFolder}" />
+            <Button
+              on:click="{() => selectFolderPath()}"
+              icon="{faFolderOpen}"
+              title="Open dialog to select the output file"
+              aria-label="Select output file">Browse ...</Button>
+          </div>
+          <div class="pt-5 border-zinc-600 border-t-2"></div>
+          <Button
+            on:click="{() => exportContainer()}"
+            class="w-full"
+            icon="{faDownload}"
+            bind:disabled="{invalidFields}"
+            aria-label="Export container">
+            Export Container
+          </Button>
+          <div aria-label="createError">
+            {#if exportedError}
+              <ErrorMessage class="py-2 text-sm" error="{exportedError}" />
+            {/if}
+          </div>
+        </div>
+      </div>
+    </div></FormPage>
+{/if}

--- a/packages/renderer/src/lib/container/ContainerExport.svelte
+++ b/packages/renderer/src/lib/container/ContainerExport.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { faDownload, faFolderOpen } from '@fortawesome/free-solid-svg-icons';
+import { faDownload } from '@fortawesome/free-solid-svg-icons';
 import { Input } from '@podman-desktop/ui-svelte';
 import { onMount } from 'svelte';
 import { router } from 'tinro';
@@ -20,6 +20,7 @@ let invalidFolder = true;
 let outputTarget = '';
 let outputUri: Uri;
 let exportedError = '';
+let inProgress = false;
 $: invalidFields = invalidName || invalidFolder;
 
 onMount(async () => {
@@ -34,6 +35,11 @@ onMount(async () => {
 async function selectFolderPath() {
   const result = await window.saveDialog({
     title: 'Select the directory where to export the container content',
+    defaultUri: {
+      fsPath: `${container.name}.tar`,
+      path: `${container.name}.tar`,
+      scheme: 'file',
+    } as Uri,
   });
   if (!result) {
     if (!outputTarget) {
@@ -49,6 +55,7 @@ async function selectFolderPath() {
 
 async function exportContainer() {
   exportedError = '';
+  inProgress = true;
   const task = createTask(`Export container ${container.name}`);
   task.action = {
     name: 'Open folder >',
@@ -72,6 +79,7 @@ async function exportContainer() {
     exportedError = String(error);
   } finally {
     task.state = 'completed';
+    inProgress = false;
   }
 }
 </script>
@@ -96,15 +104,14 @@ async function exportContainer() {
               aria-invalid="{invalidFolder}" />
             <Button
               on:click="{() => selectFolderPath()}"
-              icon="{faFolderOpen}"
               title="Open dialog to select the output file"
               aria-label="Select output file">Browse ...</Button>
           </div>
-          <div class="pt-5 border-zinc-600 border-t-2"></div>
           <Button
             on:click="{() => exportContainer()}"
-            class="w-full"
+            class="w-full mt-5"
             icon="{faDownload}"
+            inProgress="{inProgress}"
             bind:disabled="{invalidFields}"
             aria-label="Export container">
             Export Container

--- a/packages/renderer/src/lib/ui/DropDownMenuItem.spec.ts
+++ b/packages/renderer/src/lib/ui/DropDownMenuItem.spec.ts
@@ -49,3 +49,15 @@ test('Expect Font Awesome icon on the contributed action', async () => {
   // check it is a svelte-fa class
   expect(svgElement).toHaveClass('svelte-fa');
 });
+
+test('Expect tooltip is used if not empty', async () => {
+  render(DropDownMenuItem, {
+    title: 'dummy-title',
+    tooltip: 'tooltip',
+    icon: faCircleUp,
+  });
+
+  // grab the svg element
+  const span = screen.getByTitle('tooltip');
+  expect(span).toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/ui/DropDownMenuItem.svelte
+++ b/packages/renderer/src/lib/ui/DropDownMenuItem.svelte
@@ -3,6 +3,7 @@ import type { IconDefinition } from '@fortawesome/fontawesome-common-types';
 import Fa from 'svelte-fa';
 
 export let title: string;
+export let tooltip: string = '';
 export let icon: IconDefinition | string;
 export let enabled = true;
 export let hidden = false;
@@ -15,7 +16,10 @@ const disabledClasses = 'text-gray-900 bg-charcoal-800';
 {#if !hidden}
   <!-- Use a div + onclick so there's no "blind spots" for when clicking-->
   <div class="{`p-3 ${enabled ? enabledClasses : disabledClasses}`}" role="none" on:click="{onClick}">
-    <span title="{title}" class="group flex items-center text-sm no-underline whitespace-nowrap" tabindex="-1">
+    <span
+      title="{tooltip !== '' ? tooltip : title}"
+      class="group flex items-center text-sm no-underline whitespace-nowrap"
+      tabindex="-1">
       {#if typeof icon === 'string'}
         <span role="img" aria-label="{title}" class="{icon} h-4 w-4"></span>
       {:else}

--- a/packages/renderer/src/lib/ui/ListItemButtonIcon.svelte
+++ b/packages/renderer/src/lib/ui/ListItemButtonIcon.svelte
@@ -21,6 +21,7 @@ export let menu = false;
 export let detailed = false;
 export let inProgress = false;
 export let iconOffset = '';
+export let tooltip: string = '';
 
 // Pop up with a dialog before executing the action
 export let confirm = false;
@@ -114,7 +115,13 @@ $: styleClass = detailed
 <!-- If menu = true, use the menu, otherwise implement the button -->
 {#if menu}
   <!-- enabled menu -->
-  <DropdownMenuItem title="{title}" icon="{icon}" enabled="{enabled}" hidden="{hidden}" onClick="{handleClick}" />
+  <DropdownMenuItem
+    title="{title}"
+    tooltip="{tooltip}"
+    icon="{icon}"
+    enabled="{enabled}"
+    hidden="{hidden}"
+    onClick="{handleClick}" />
 {:else}
   <!-- enabled button -->
   <button

--- a/packages/renderer/src/stores/export-container-store.spec.ts
+++ b/packages/renderer/src/stores/export-container-store.spec.ts
@@ -1,0 +1,38 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { get } from 'svelte/store';
+import { expect, test } from 'vitest';
+
+import type { ContainerInfoUI } from '../lib/container/ContainerInfoUI';
+import { exportContainerInfo } from './export-container-store';
+
+const container: ContainerInfoUI = {
+  engineId: 'engine',
+  id: 'id',
+  name: 'test',
+} as ContainerInfoUI;
+
+test('check that export container store is filled', async () => {
+  // initial images
+  exportContainerInfo.set(container);
+  const containerInfo = get(exportContainerInfo);
+  expect(containerInfo).equal(container);
+});

--- a/packages/renderer/src/stores/export-container-store.ts
+++ b/packages/renderer/src/stores/export-container-store.ts
@@ -1,0 +1,27 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { Writable } from 'svelte/store';
+import { writable } from 'svelte/store';
+
+import type { ContainerInfoUI } from '../lib/container/ContainerInfoUI';
+
+/**
+ * Defines the store used to define the container to export.
+ */
+export const exportContainerInfo: Writable<ContainerInfoUI> = writable();


### PR DESCRIPTION
### What does this PR do?

It adds the export container action

### Screenshot / video of UI

![export_container](https://github.com/containers/podman-desktop/assets/49404737/f9aaf7bf-ee01-4844-9559-01b276fdddd8)

### What issues does this PR fix or reference?

it is part of #6355 

### How to test this PR?

1. try to export a container and see it is actually saved in the filesystem

- [x] Tests are covering the bug fix or the new feature
