### PR TITLE
chore: notify frontend to refresh providers when a new update/install

### DIFF
--- a/packages/main/src/plugin/provider-registry.ts
+++ b/packages/main/src/plugin/provider-registry.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2022-2023 Red Hat, Inc.
+ * Copyright (C) 2022-2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -234,16 +234,24 @@ export class ProviderRegistry {
   registerInstallation(providerImpl: ProviderImpl, installation: ProviderInstallation): Disposable {
     this.providerInstallations.set(providerImpl.internalId, installation);
 
+    this.apiSender.send('provider-change', {});
     return Disposable.create(() => {
       this.providerInstallations.delete(providerImpl.internalId);
+      // need to refresh the provider
+      this.apiSender.send('provider-change', {});
     });
   }
 
   registerUpdate(providerImpl: ProviderImpl, update: ProviderUpdate): Disposable {
     this.providerUpdates.set(providerImpl.internalId, update);
 
+    // need to refresh the provider
+    this.apiSender.send('provider-change', {});
+
     return Disposable.create(() => {
       this.providerUpdates.delete(providerImpl.internalId);
+      // need to refresh the provider
+      this.apiSender.send('provider-change', {});
     });
   }
 


### PR DESCRIPTION
### What does this PR do?
when trying to add v4 -> v5 update or then hide the v5 update with experimental flag, etc
I noticed that the providers were not exposing the right data in the UI as it was not refreshed

add events to refresh

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

related to https://github.com/containers/podman-desktop/issues/6375

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
