### PR TITLE
feat: add experimental flag to install podman v5

### DIFF
--- a/extensions/podman/package.json
+++ b/extensions/podman/package.json
@@ -39,6 +39,11 @@
           "default": "",
           "description": "Custom path to Podman binary (Default is blank)"
         },
+        "podman.experimental.install.v5": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enable podman v5 installation support (experimental)"
+        },
         "podman.machine.cpus": {
           "type": "number",
           "format": "cpu",


### PR DESCRIPTION
### What does this PR do?
if toggling the flag in preferences, it'll register the 'update to v5.0.0'

depends on this PR
- [x] https://github.com/containers/podman-desktop/pull/6475
for better result

### Screenshot / video of UI

![image](https://github.com/containers/podman-desktop/assets/436777/8241fb85-46a8-4a95-82fd-e3af1681cd2b)

![image](https://github.com/containers/podman-desktop/assets/436777/643b2023-1594-4e6e-b119-7a97f8935999)


### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/6375

### How to test this PR?

you can run Podman Desktop and toggle the flag then you should see "Update to 5.0.0" flag
if you don't see it immediately, refresh the UI of the client or apply https://github.com/containers/podman-desktop/pull/6475 before

- [x] Tests are covering the bug fix or the new feature
