### PR TITLE
feat: import containers images

### DIFF
--- a/packages/main/src/plugin/api/container-info.ts
+++ b/packages/main/src/plugin/api/container-info.ts
@@ -18,6 +18,8 @@
 
 import type Dockerode from 'dockerode';
 
+import type { ProviderContainerConnectionInfo } from './provider-info.js';
+
 export interface ContainerPortInfo {
   IP: string;
   PrivatePort: number;
@@ -276,6 +278,12 @@ export interface VolumeCreateResponseInfo extends Dockerode.VolumeCreateResponse
 export interface ContainerExportOptions {
   id: string;
   outputTarget: string;
+}
+
+export interface ContainerImportOptions {
+  provider: ProviderContainerConnectionInfo;
+  archivePath: string;
+  imageTag: string;
 }
 
 export interface ImagesSaveOptions {

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -37,6 +37,7 @@ import type { ApiSenderType } from './api.js';
 import type {
   ContainerCreateOptions,
   ContainerExportOptions,
+  ContainerImportOptions,
   ContainerInfo,
   ContainerPortInfo,
   ImagesSaveOptions,
@@ -2426,6 +2427,19 @@ export class ContainerProviderRegistry {
       exportResult.on('error', error => {
         reject(error);
       });
+    });
+  }
+
+  async importContainer(options: ContainerImportOptions): Promise<void> {
+    const matchingEngine = this.getMatchingEngineFromConnection(options.provider);
+    if (!matchingEngine) {
+      throw new Error('no running engine for the matching provider');
+    }
+
+    const repoTag = options.imageTag.split(':');
+    await matchingEngine.importImage(options.archivePath, {
+      repo: repoTag[0],
+      tag: repoTag[1] ?? 'latest',
     });
   }
 

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -65,6 +65,7 @@ import type { CommandInfo } from './api/command-info.js';
 import type {
   ContainerCreateOptions,
   ContainerExportOptions,
+  ContainerImportOptions,
   ContainerInfo,
   ImagesSaveOptions,
   SimpleContainerInfo,
@@ -1085,6 +1086,13 @@ export class PluginSystem {
       'container-provider-registry:exportContainer',
       async (_listener, engine: string, options: ContainerExportOptions): Promise<void> => {
         return containerProviderRegistry.exportContainer(engine, options);
+      },
+    );
+
+    this.ipcHandle(
+    'container-provider-registry:importContainer',
+      async (_listener, options: ContainerImportOptions): Promise<void> => {
+        return containerProviderRegistry.importContainer(options);
       },
     );
 

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1090,7 +1090,7 @@ export class PluginSystem {
     );
 
     this.ipcHandle(
-    'container-provider-registry:importContainer',
+      'container-provider-registry:importContainer',
       async (_listener, options: ContainerImportOptions): Promise<void> => {
         return containerProviderRegistry.importContainer(options);
       },

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -44,6 +44,7 @@ import type { CommandInfo } from '../../main/src/plugin/api/command-info';
 import type {
   ContainerCreateOptions,
   ContainerExportOptions,
+  ContainerImportOptions,
   ContainerInfo,
   ImagesSaveOptions,
   SimpleContainerInfo,
@@ -448,6 +449,10 @@ export function initExposure(): void {
       return ipcInvoke('container-provider-registry:exportContainer', engine, options);
     },
   );
+
+  contextBridge.exposeInMainWorld('importContainer', async (options: ContainerImportOptions): Promise<void> => {
+    return ipcInvoke('container-provider-registry:importContainer', options);
+  });
 
   contextBridge.exposeInMainWorld('saveImages', async (options: ImagesSaveOptions): Promise<void> => {
     return ipcInvoke('container-provider-registry:saveImages', options);

--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -27,6 +27,7 @@ import HelpPage from './lib/help/HelpPage.svelte';
 import BuildImageFromContainerfile from './lib/image/BuildImageFromContainerfile.svelte';
 import ImageDetails from './lib/image/ImageDetails.svelte';
 import ImagesList from './lib/image/ImagesList.svelte';
+import ImportContainersImages from './lib/image/ImportContainersImages.svelte';
 import PullImage from './lib/image/PullImage.svelte';
 import RunImage from './lib/image/RunImage.svelte';
 import IngressDetails from './lib/ingresses-routes/IngressDetails.svelte';
@@ -137,6 +138,9 @@ window.events?.receive('navigate', (navigationRequest: unknown) => {
         </Route>
         <Route path="/images/pull" breadcrumb="Pull an Image">
           <PullImage />
+        </Route>
+        <Route path="/images/import" breadcrumb="Import Containers">
+          <ImportContainersImages />
         </Route>
         <Route path="/pods" breadcrumb="Pods" navigationHint="root">
           <PodsList />

--- a/packages/renderer/src/lib/image/ImagesList.spec.ts
+++ b/packages/renderer/src/lib/image/ImagesList.spec.ts
@@ -21,7 +21,9 @@
 import '@testing-library/jest-dom/vitest';
 
 import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
 import { get } from 'svelte/store';
+import { router } from 'tinro';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { viewsContributions } from '/@/stores/views';
@@ -350,4 +352,14 @@ describe('Contributions', () => {
       expect(fedoraOld.innerHTML).contain('background-color: #ff00ff');
     },
   );
+});
+
+test('Expect importImage button redirects to image import page', async () => {
+  const goToMock = vi.spyOn(router, 'goto');
+  render(ImagesList);
+  const btnImportImage = screen.getByRole('button', { name: 'Import Image' });
+  expect(btnImportImage).toBeInTheDocument();
+
+  await userEvent.click(btnImportImage);
+  expect(goToMock).toBeCalledWith('/images/import');
 });

--- a/packages/renderer/src/lib/image/ImagesList.svelte
+++ b/packages/renderer/src/lib/image/ImagesList.svelte
@@ -157,6 +157,10 @@ function gotoPullImage(): void {
   router.goto('/images/pull');
 }
 
+function importImage(): void {
+  router.goto('/images/import');
+}
+
 // delete the items selected in the list
 let bulkDeleteInProgress = false;
 async function deleteSelectedImages() {
@@ -276,6 +280,9 @@ const row = new Row<ImageInfoUI>({
     {#if $imagesInfos.length > 0}
       <Prune type="images" engines="{enginesList}" />
     {/if}
+    <Button on:click="{() => importImage()}" title="Import Image From Filesystem" icon="{faArrowCircleDown}">
+      Import
+    </Button>
     <Button on:click="{() => gotoPullImage()}" title="Pull Image From a Registry" icon="{faArrowCircleDown}">
       Pull
     </Button>

--- a/packages/renderer/src/lib/image/ImagesList.svelte
+++ b/packages/renderer/src/lib/image/ImagesList.svelte
@@ -280,7 +280,11 @@ const row = new Row<ImageInfoUI>({
     {#if $imagesInfos.length > 0}
       <Prune type="images" engines="{enginesList}" />
     {/if}
-    <Button on:click="{() => importImage()}" title="Import Image From Filesystem" icon="{faArrowCircleDown}">
+    <Button
+      on:click="{() => importImage()}"
+      title="Import Image From Filesystem"
+      icon="{faArrowCircleDown}"
+      aria-label="Import Image">
       Import
     </Button>
     <Button on:click="{() => gotoPullImage()}" title="Pull Image From a Registry" icon="{faArrowCircleDown}">

--- a/packages/renderer/src/lib/image/ImportContainersImages.spec.ts
+++ b/packages/renderer/src/lib/image/ImportContainersImages.spec.ts
@@ -65,7 +65,6 @@ const providerInfo = {
 beforeAll(() => {
   (window as any).openDialog = openDialogMock;
   (window as any).importContainer = importContainerMock;
-  (window as any).getOsPlatform = vi.fn().mockResolvedValue('linux');
 });
 
 beforeEach(() => {

--- a/packages/renderer/src/lib/image/ImportContainersImages.spec.ts
+++ b/packages/renderer/src/lib/image/ImportContainersImages.spec.ts
@@ -1,0 +1,154 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import '@testing-library/jest-dom/vitest';
+
+import type { ProviderStatus } from '@podman-desktop/api';
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { router } from 'tinro';
+import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
+
+import { providerInfos } from '/@/stores/providers';
+
+import type { ProviderContainerConnectionInfo, ProviderInfo } from '../../../../main/src/plugin/api/provider-info';
+import ImportContainersImages from './ImportContainersImages.svelte';
+
+const openDialogMock = vi.fn();
+const importContainerMock = vi.fn();
+
+const pStatus: ProviderStatus = 'started';
+const pInfo: ProviderContainerConnectionInfo = {
+  name: 'test',
+  status: 'started',
+  endpoint: {
+    socketPath: '',
+  },
+  type: 'podman',
+};
+const providerInfo = {
+  id: 'test',
+  internalId: 'id',
+  name: '',
+  containerConnections: [pInfo],
+  kubernetesConnections: undefined,
+  status: pStatus,
+  containerProviderConnectionCreation: false,
+  containerProviderConnectionInitialization: false,
+  kubernetesProviderConnectionCreation: false,
+  kubernetesProviderConnectionInitialization: false,
+  links: undefined,
+  detectionChecks: undefined,
+  warnings: undefined,
+  images: undefined,
+  installationSupport: undefined,
+} as unknown as ProviderInfo;
+
+// fake the window.events object
+beforeAll(() => {
+  (window as any).openDialog = openDialogMock;
+  (window as any).importContainer = importContainerMock;
+  (window as any).getOsPlatform = vi.fn().mockResolvedValue('linux');
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+test('Expect import button to be disabled', async () => {
+  render(ImportContainersImages);
+  const btnImportContainer = screen.getByRole('button', { name: 'Import containers' });
+  expect(btnImportContainer).toBeInTheDocument();
+  expect(btnImportContainer).toBeDisabled();
+});
+
+test('Expect import button to be enabled when atleast one container image is selected', async () => {
+  providerInfos.set([providerInfo]);
+  openDialogMock.mockResolvedValue(['path/file.tar']);
+  render(ImportContainersImages);
+  const btnAddImages = screen.getByRole('button', { name: 'Add images to import' });
+  expect(btnAddImages).toBeInTheDocument();
+  await userEvent.click(btnAddImages);
+
+  const btnImportContainer = screen.getByRole('button', { name: 'Import containers' });
+  expect(btnImportContainer).toBeInTheDocument();
+  expect(btnImportContainer).toBeEnabled();
+});
+
+test('Expect import button to be enabled when atleast one container image is selected but there is no provider', async () => {
+  providerInfos.set([]);
+  openDialogMock.mockResolvedValue(['path/file.tar']);
+  render(ImportContainersImages);
+  const btnAddImages = screen.getByRole('button', { name: 'Add images to import' });
+  expect(btnAddImages).toBeInTheDocument();
+  await userEvent.click(btnAddImages);
+
+  const btnImportContainer = screen.getByRole('button', { name: 'Import containers' });
+  expect(btnImportContainer).toBeInTheDocument();
+  expect(btnImportContainer).toBeDisabled();
+});
+
+test('Expect import call importContainer func', async () => {
+  providerInfos.set([providerInfo]);
+  openDialogMock.mockResolvedValue(['path/file.tar']);
+  importContainerMock.mockResolvedValue('');
+  const goToMock = vi.spyOn(router, 'goto');
+  render(ImportContainersImages);
+  const btnAddImages = screen.getByRole('button', { name: 'Add images to import' });
+  expect(btnAddImages).toBeInTheDocument();
+  await userEvent.click(btnAddImages);
+
+  const btnImportContainer = screen.getByRole('button', { name: 'Import containers' });
+  expect(btnImportContainer).toBeInTheDocument();
+  expect(btnImportContainer).toBeEnabled();
+  await userEvent.click(btnImportContainer);
+
+  expect(importContainerMock).toBeCalledWith({
+    provider: pInfo,
+    archivePath: 'path/file.tar',
+    imageTag: 'file',
+  });
+  expect(goToMock).toBeCalledWith('/images');
+});
+
+test('Expect error shown if import function fails', async () => {
+  providerInfos.set([providerInfo]);
+  openDialogMock.mockResolvedValue(['path/file.tar']);
+  importContainerMock.mockRejectedValue('import failed');
+  render(ImportContainersImages);
+  const btnAddImages = screen.getByRole('button', { name: 'Add images to import' });
+  expect(btnAddImages).toBeInTheDocument();
+  await userEvent.click(btnAddImages);
+
+  const btnImportContainer = screen.getByRole('button', { name: 'Import containers' });
+  expect(btnImportContainer).toBeInTheDocument();
+  expect(btnImportContainer).toBeEnabled();
+  await userEvent.click(btnImportContainer);
+
+  expect(importContainerMock).toBeCalledWith({
+    provider: pInfo,
+    archivePath: 'path/file.tar',
+    imageTag: 'file',
+  });
+
+  const errorDiv = screen.getByLabelText('Error Message Content');
+  expect(errorDiv).toBeInTheDocument();
+  expect((errorDiv as HTMLDivElement).innerHTML).toContain('import failed');
+});

--- a/packages/renderer/src/lib/image/ImportContainersImages.svelte
+++ b/packages/renderer/src/lib/image/ImportContainersImages.svelte
@@ -123,7 +123,7 @@ async function importContainers() {
         </label>
       {/if}
 
-      <label for="modalContainerName" class="pt-4 block mb-2 text-sm font-medium text-gray-400"
+      <label for="modalContainersImport" class="pt-4 block mb-2 text-sm font-medium text-gray-400"
         >Containers to import:</label>
       <Button on:click="{addContainersToImport}" icon="{faPlusCircle}" type="link">Add images to import</Button>
       <!-- Display the list of existing containersToImport -->
@@ -152,10 +152,11 @@ async function importContainers() {
         inProgress="{inProgress}"
         class="w-full"
         icon="{faPlay}"
+        aria-label="Import containers"
         bind:disabled="{importDisabled}">
         Import Containers
       </Button>
-      <div aria-label="createError">
+      <div aria-label="importError">
         {#if importError !== ''}
           <ErrorMessage class="py-2 text-sm" error="{importError}" />
         {/if}

--- a/packages/renderer/src/lib/image/ImportContainersImages.svelte
+++ b/packages/renderer/src/lib/image/ImportContainersImages.svelte
@@ -1,0 +1,165 @@
+<script lang="ts">
+import { faMinusCircle, faPlay, faPlusCircle } from '@fortawesome/free-solid-svg-icons';
+import { Input } from '@podman-desktop/ui-svelte';
+import { get, onMount } from 'svelte';
+import { router } from 'tinro';
+
+import { providerInfos } from '/@/stores/providers';
+
+import type { ProviderContainerConnectionInfo, ProviderInfo } from '../../../../main/src/plugin/api/provider-info';
+import Button from '../ui/Button.svelte';
+import ErrorMessage from '../ui/ErrorMessage.svelte';
+import FormPage from '../ui/FormPage.svelte';
+
+let containersToImport: { imagePath: string; nameWhenImporting: string }[] = [];
+let importError: string = '';
+
+let providers: ProviderInfo[] = [];
+let providerConnections: ProviderContainerConnectionInfo[] = [];
+let selectedProvider: ProviderContainerConnectionInfo | undefined = undefined;
+let inProgress = false;
+
+$: importDisabled = !selectedProvider || containersToImport.length === 0;
+let separator = '/';
+
+onMount(async () => {
+  providers = get(providerInfos);
+  providerConnections = providers
+    .map(provider => provider.containerConnections)
+    .flat()
+    .filter(providerContainerConnection => providerContainerConnection.status === 'started');
+
+  const selectedProviderConnection = providerConnections.length > 0 ? providerConnections[0] : undefined;
+  selectedProvider = !selectedProvider && selectedProviderConnection ? selectedProviderConnection : selectedProvider;
+
+  const platform = await window.getOsPlatform();
+  if (platform === 'win32') {
+    separator = '\\';
+  }
+});
+
+async function addContainersToImport() {
+  const images = await window.openDialog({
+    title: 'Select Containers Images to import',
+    selectors: ['multiSelections'],
+  });
+
+  if (!images) {
+    return;
+  }
+
+  const imagesInfo: { imagePath: string; nameWhenImporting: string }[] = [];
+  images.forEach(imgPath => {
+    let lastSlashPos = imgPath.lastIndexOf(separator) + 1;
+    let lastDot: number | undefined = imgPath.lastIndexOf('.');
+    if (lastDot === -1 || lastDot < lastSlashPos) {
+      lastDot = undefined;
+    }
+    imagesInfo.push({
+      imagePath: imgPath,
+      nameWhenImporting: imgPath.substring(lastSlashPos, lastDot),
+    });
+  });
+
+  containersToImport = [...containersToImport, ...imagesInfo];
+}
+
+function onHostContainerPortMappingInput(event: Event, index: number) {
+  const target = event.currentTarget as HTMLInputElement;
+  containersToImport[index].nameWhenImporting = target.value;
+  containersToImport = containersToImport;
+}
+
+function deleteContainerToImport(index: number) {
+  containersToImport = containersToImport.filter((_, i) => i !== index);
+}
+
+async function importContainers() {
+  importError = '';
+
+  if (!selectedProvider) {
+    throw new Error('Select a provider to import');
+  }
+
+  inProgress = true;
+
+  for (const containerImage of containersToImport) {
+    try {
+      await window.importContainer({
+        provider: selectedProvider,
+        archivePath: containerImage.imagePath,
+        imageTag: containerImage.nameWhenImporting,
+      });
+    } catch (e) {
+      importError += `Error while importing ${containerImage.imagePath}: ${String(e)}\n`;
+    }
+  }
+
+  inProgress = false;
+  if (importError === '') {
+    router.goto('/images');
+  }
+}
+</script>
+
+<FormPage title="Import Containers">
+  <svelte:fragment slot="icon">
+    <i class="fas fa-play fa-2x" aria-hidden="true"></i>
+  </svelte:fragment>
+  <div slot="content" class="p-5 min-w-full h-fit">
+    <div class="bg-charcoal-600 px-6 py-4 space-y-2 lg:px-8 sm:pb-6 xl:pb-8">
+      {#if providerConnections.length > 1}
+        <label for="providerChoice" class="py-6 block mb-2 text-sm font-bold text-gray-400"
+          >Container Engine
+          <select
+            class="w-full p-2 outline-none text-sm bg-charcoal-600 rounded-sm text-gray-700 placeholder-gray-700"
+            name="providerChoice"
+            id="providerChoice"
+            bind:value="{selectedProvider}">
+            {#each providerConnections as providerConnection}
+              <option value="{providerConnection}">{providerConnection.name}</option>
+            {/each}
+          </select>
+        </label>
+      {/if}
+
+      <label for="modalContainerName" class="pt-4 block mb-2 text-sm font-medium text-gray-400"
+        >Containers to import:</label>
+      <Button on:click="{addContainersToImport}" icon="{faPlusCircle}" type="link">Add images to import</Button>
+      <!-- Display the list of existing containersToImport -->
+      {#if containersToImport.length > 0}
+        <div class="flex flex-row justify-center w-full py-1 text-sm font-medium text-gray-400">
+          <div class="flex flex-col grow pl-2">Image Path</div>
+          <div class="flex flex-col w-2/4 mr-2.5">Image Name when importing (e.g quay.io/podman/hello)</div>
+        </div>
+      {/if}
+      {#each containersToImport as containerToImport, index}
+        <div class="flex flex-row justify-center w-full py-1">
+          <Input bind:value="{containerToImport.imagePath}" aria-label="container image path" readonly="{true}" />
+          <Input
+            bind:value="{containerToImport.nameWhenImporting}"
+            on:input="{event => onHostContainerPortMappingInput(event, index)}"
+            aria-label="container importing name"
+            placeholder="Image Name when Importing (e.g. quay.io/namespace/my-image-name)"
+            class="ml-2" />
+          <Button type="link" on:click="{() => deleteContainerToImport(index)}" icon="{faMinusCircle}" />
+        </div>
+      {/each}
+
+      <div class="pt-5 border-zinc-600 border-t-2"></div>
+      <Button
+        on:click="{() => importContainers()}"
+        inProgress="{inProgress}"
+        class="w-full"
+        icon="{faPlay}"
+        bind:disabled="{importDisabled}">
+        Import Containers
+      </Button>
+      <div aria-label="createError">
+        {#if importError !== ''}
+          <ErrorMessage class="py-2 text-sm" error="{importError}" />
+        {/if}
+      </div>
+    </div>
+  </div>
+</FormPage>


### PR DESCRIPTION
### What does this PR do?

It adds the import container action.

### Screenshot / video of UI

![import_containers](https://github.com/containers/podman-desktop/assets/49404737/37f3f4b8-7518-4e64-855f-1611dedbb732)

### What issues does this PR fix or reference?

it is part of #6355 

### How to test this PR?

1. images page -> click import -> try to import container image

- [x] Tests are covering the bug fix or the new feature
