### PR TITLE
fix: onboarding should be available after reloading an extension

### DIFF
--- a/packages/renderer/src/stores/onboarding.ts
+++ b/packages/renderer/src/stores/onboarding.ts
@@ -22,7 +22,7 @@ import { writable } from 'svelte/store';
 import type { OnboardingInfo } from '../../../main/src/plugin/api/onboarding';
 import { EventStore } from './event-store';
 
-const windowEvents = ['extension-stopped', 'extensions-started'];
+const windowEvents = ['extension-stopped', 'extension-started', 'extensions-started'];
 const windowListeners = ['extensions-already-started'];
 
 let readyToUpdate = false;


### PR DESCRIPTION
### What does this PR do?
onboarding store was not listening to the event after an extension is started (only all of them being started) so after reloading a single extension, the onboarding was not visible.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/6509

### How to test this PR?

Look at the issue for manual steps, but I've provided unit tests.

- [x] Tests are covering the bug fix or the new feature
