### PR TITLE
fix: ensure machine list is up-to-date when running onboarding

### DIFF
--- a/extensions/podman/package.json
+++ b/extensions/podman/package.json
@@ -26,6 +26,10 @@
         "title": "Podman: Check system requirements to install podman"
       },
       {
+        "command": "podman.onboarding.checkPodmanMachineExistsCommand",
+        "title": "Podman: Check if a podman machine exists"
+      },
+      {
         "command": "podman.onboarding.installPodman",
         "title": "Podman: Install podman"
       }
@@ -263,6 +267,15 @@
                 "value": "${configuration:preferences.podman-desktop.podman.engine.autostart}"
               }
             ]
+          ]
+        },
+        {
+          "id": "checkPodmanMachineExistsCommand",
+          "title": "Checking if a Podman machine exists",
+          "when": "!isLinux",
+          "command": "podman.onboarding.checkPodmanMachineExistsCommand",
+          "completionEvents": [
+            "onCommand:podman.onboarding.checkPodmanMachineExistsCommand"
           ]
         },
         {

--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -852,6 +852,20 @@ export async function initCheckAndRegisterUpdate(
   });
 }
 
+export function registerOnboardingMachineExistsCommand(): extensionApi.Disposable {
+  return extensionApi.commands.registerCommand('podman.onboarding.checkPodmanMachineExistsCommand', async () => {
+    let machineLength;
+    try {
+      const machineListOutput = await getJSONMachineList();
+      const machines = JSON.parse(machineListOutput) as MachineJSON[];
+      machineLength = machines.length;
+    } catch (error) {
+      machineLength = 0;
+    }
+    extensionApi.context.setValue('podmanMachineExists', machineLength > 0, 'onboarding');
+  });
+}
+
 export async function activate(extensionContext: extensionApi.ExtensionContext): Promise<void> {
   initExtensionContext(extensionContext);
 
@@ -1157,6 +1171,8 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
     },
   );
 
+  const onboardingCheckPodmanMachineExistsCommand = registerOnboardingMachineExistsCommand();
+
   const onboardingCheckReqsCommand = extensionApi.commands.registerCommand(
     'podman.onboarding.checkRequirementsCommand',
     async () => {
@@ -1239,6 +1255,7 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
 
   extensionContext.subscriptions.push(
     onboardingCheckInstallationCommand,
+    onboardingCheckPodmanMachineExistsCommand,
     onboardingCheckReqsCommand,
     onboardingInstallPodmanCommand,
   );


### PR DESCRIPTION
### What does this PR do?
Ensure that we have up-to-date information about the number of podman machines.
also what happens is that when restarting an onboarding workflow, all values are removed, so it might say that there is no machine in the workflow and display the wizard to create a machine while we may have one.

Here we enforce that a command is executed before checking the result which should be the 'recommended workflow' when checking values.


### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/6511

### How to test this PR?

really hard to reproduce manually at it's only within a 5s delay window after restarting onboarding workflow

- [x] Tests are covering the bug fix or the new feature
