### PR TITLE
feat: allow to save images

### DIFF
--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -2469,7 +2469,10 @@ export class ContainerProviderRegistry {
         try {
           let targetPath = options.outputTarget;
           if (isMultiProvider) {
-            targetPath = path.join(options.outputTarget, `${imageGroup[0]}-images.tar`);
+            targetPath = path.join(
+              options.outputTarget,
+              `${imageGroup[0]}-images-${moment().format('YYYYMMDDHHmmss')}.tar`,
+            );
           }
           await pipeline(imagesStream, fs.createWriteStream(targetPath));
         } catch (e) {

--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -143,7 +143,7 @@ window.events?.receive('navigate', (navigationRequest: unknown) => {
         <Route path="/images/import" breadcrumb="Import Containers">
           <ImportContainersImages />
         </Route>
-        <Route path="/images/save/*" breadcrumb="Save Images">
+        <Route path="/images/save" breadcrumb="Save Images">
           <SaveImages />
         </Route>
         <Route path="/pods" breadcrumb="Pods" navigationHint="root">

--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -30,6 +30,7 @@ import ImagesList from './lib/image/ImagesList.svelte';
 import ImportContainersImages from './lib/image/ImportContainersImages.svelte';
 import PullImage from './lib/image/PullImage.svelte';
 import RunImage from './lib/image/RunImage.svelte';
+import SaveImages from './lib/image/SaveImages.svelte';
 import IngressDetails from './lib/ingresses-routes/IngressDetails.svelte';
 import IngressesRoutesList from './lib/ingresses-routes/IngressesRoutesList.svelte';
 import RouteDetails from './lib/ingresses-routes/RouteDetails.svelte';
@@ -141,6 +142,9 @@ window.events?.receive('navigate', (navigationRequest: unknown) => {
         </Route>
         <Route path="/images/import" breadcrumb="Import Containers">
           <ImportContainersImages />
+        </Route>
+        <Route path="/images/save/*" breadcrumb="Save Images">
+          <SaveImages />
         </Route>
         <Route path="/pods" breadcrumb="Pods" navigationHint="root">
           <PodsList />

--- a/packages/renderer/src/lib/image/ImageActions.spec.ts
+++ b/packages/renderer/src/lib/image/ImageActions.spec.ts
@@ -19,6 +19,8 @@
 import '@testing-library/jest-dom/vitest';
 
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { router } from 'tinro';
 import { beforeAll, expect, test, vi } from 'vitest';
 
 import ImageActions from '/@/lib/image/ImageActions.svelte';
@@ -175,4 +177,26 @@ test('Expect Push image to be there', async () => {
 
   const button = screen.getByTitle('Push Image');
   expect(button).toBeDefined();
+});
+
+test('Expect Save image to be there', async () => {
+  const goToMock = vi.spyOn(router, 'goto');
+
+  const image: ImageInfoUI = {
+    name: 'dummy',
+    status: 'UNUSED',
+  } as ImageInfoUI;
+
+  render(ImageActions, {
+    onPushImage: vi.fn(),
+    onRenameImage: vi.fn(),
+    image,
+  });
+
+  const button = screen.getByTitle('Save Image');
+  expect(button).toBeDefined();
+
+  await userEvent.click(button);
+
+  expect(goToMock).toBeCalledWith('/images/save');
 });

--- a/packages/renderer/src/lib/image/ImageActions.svelte
+++ b/packages/renderer/src/lib/image/ImageActions.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
-import { faArrowUp, faEdit, faLayerGroup, faPlay, faTrash } from '@fortawesome/free-solid-svg-icons';
+import { faArrowUp, faDownload, faEdit, faLayerGroup, faPlay, faTrash } from '@fortawesome/free-solid-svg-icons';
 import { createEventDispatcher, onDestroy, onMount } from 'svelte';
 import type { Unsubscriber } from 'svelte/motion';
 import { router } from 'tinro';
 
 import ContributionActions from '/@/lib/actions/ContributionActions.svelte';
 import { context } from '/@/stores/context';
+import { saveImagesInfo } from '/@/stores/save-images-store';
 
 import type { Menu } from '../../../../main/src/plugin/menu-registry';
 import { MenuContext } from '../../../../main/src/plugin/menu-registry';
@@ -90,6 +91,11 @@ function onError(error: string): void {
     type: 'error',
   });
 }
+
+async function saveImage() {
+  saveImagesInfo.set([image]);
+  router.goto('/images/save');
+}
 </script>
 
 <ListItemButtonIcon title="Run Image" onClick="{() => runImage(image)}" detailed="{detailed}" icon="{faPlay}" />
@@ -130,6 +136,13 @@ function onError(error: string): void {
       detailed="{detailed}"
       icon="{faLayerGroup}" />
   {/if}
+  <ListItemButtonIcon
+    title="Save Image"
+    tooltip="Save image to a local directory"
+    onClick="{() => saveImage()}"
+    menu="{dropdownMenu}"
+    detailed="{detailed}"
+    icon="{faDownload}" />
 
   <ActionsWrapper dropdownMenu="{groupingContributions}" dropdownMenuAsMenuActionItem="{groupingContributions}">
     <ContributionActions

--- a/packages/renderer/src/lib/image/ImageActions.svelte
+++ b/packages/renderer/src/lib/image/ImageActions.svelte
@@ -92,7 +92,7 @@ function onError(error: string): void {
   });
 }
 
-async function saveImage() {
+function saveImage() {
   saveImagesInfo.set([image]);
   router.goto('/images/save');
 }

--- a/packages/renderer/src/lib/image/ImagesList.svelte
+++ b/packages/renderer/src/lib/image/ImagesList.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
-import { faArrowCircleDown, faCube, faTrash } from '@fortawesome/free-solid-svg-icons';
+import { faArrowCircleDown, faCube, faDownload, faTrash } from '@fortawesome/free-solid-svg-icons';
 import moment from 'moment';
 import { onDestroy, onMount } from 'svelte';
 import type { Unsubscriber } from 'svelte/store';
 import { router } from 'tinro';
 
+import { saveImagesInfo } from '/@/stores/save-images-store';
 import { viewsContributions } from '/@/stores/views';
 
 import type { ContainerInfo } from '../../../../main/src/plugin/api/container-info';
@@ -182,6 +183,17 @@ async function deleteSelectedImages() {
   bulkDeleteInProgress = false;
 }
 
+// save the items selected in the list
+async function saveSelectedImages() {
+  const selectedImages = images.filter(image => image.selected);
+  if (selectedImages.length === 0) {
+    return;
+  }
+
+  saveImagesInfo.set(selectedImages);
+  router.goto('/images/save');
+}
+
 let refreshTimeouts: NodeJS.Timeout[] = [];
 const SECOND = 1000;
 function refreshAge() {
@@ -300,6 +312,11 @@ const row = new Row<ImageInfoUI>({
         title="Delete {selectedItemsNumber} selected items"
         bind:inProgress="{bulkDeleteInProgress}"
         icon="{faTrash}" />
+      <Button
+        on:click="{() => saveSelectedImages()}"
+        title="Save {selectedItemsNumber} selected items"
+        aria-label="Save images"
+        icon="{faDownload}" />
       <span>On {selectedItemsNumber} selected items.</span>
     {/if}
   </svelte:fragment>

--- a/packages/renderer/src/lib/image/SaveImages.spec.ts
+++ b/packages/renderer/src/lib/image/SaveImages.spec.ts
@@ -1,0 +1,170 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import '@testing-library/jest-dom/vitest';
+
+import type { Uri } from '@podman-desktop/api';
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { router } from 'tinro';
+import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
+
+import { saveImagesInfo } from '/@/stores/save-images-store';
+
+import type { ImageInfoUI } from './ImageInfoUI';
+import SaveImages from './SaveImages.svelte';
+
+const imageInfo: ImageInfoUI = {
+  id: 'id',
+  shortId: 'id',
+  name: 'image 1',
+  engineId: 'engine',
+} as ImageInfoUI;
+
+const imageInfo2: ImageInfoUI = {
+  id: 'id2',
+  shortId: 'id2',
+  name: 'image 2',
+  engineId: 'engine',
+} as ImageInfoUI;
+
+const saveDialogMock = vi.fn();
+const saveImagesMock = vi.fn();
+
+// fake the window.events object
+beforeAll(() => {
+  (window as any).saveDialog = saveDialogMock;
+  (window as any).saveImages = saveImagesMock;
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+async function waitRender(): Promise<void> {
+  const result = render(SaveImages);
+  // wait that result.component.$$.ctx[0] is set
+  while (result.component.$$.ctx[0] === undefined) {
+    await new Promise(resolve => setTimeout(resolve, 100));
+  }
+}
+
+test('Expect Save button is disabled if output path is not selected', async () => {
+  saveImagesInfo.set([imageInfo]);
+  await waitRender();
+
+  const saveButton = screen.getByRole('button', { name: 'Save images' });
+  expect(saveButton).toBeInTheDocument();
+  expect(saveButton).toBeDisabled();
+});
+
+test('Expect deleteImage is not visible if page has been opened with one item', async () => {
+  saveImagesInfo.set([imageInfo]);
+  await waitRender();
+
+  const deleteButton = screen.queryByRole('button', { name: 'Delete image' });
+  expect(deleteButton).not.toBeInTheDocument();
+});
+
+test('Expect deleteImage is visible if page has been opened with multiple item', async () => {
+  saveImagesInfo.set([imageInfo, imageInfo2]);
+  await waitRender();
+
+  const itemBeforeDelete = screen.getAllByLabelText('container image path');
+  expect(itemBeforeDelete.length).equal(2);
+
+  const deleteButtons = screen.getAllByLabelText('Delete image');
+
+  await userEvent.click(deleteButtons[0]);
+
+  const itemAfterDelete = screen.getAllByLabelText('container image path');
+  expect(itemAfterDelete.length).equal(1);
+  expect(itemAfterDelete.length).toBeLessThan(itemBeforeDelete.length);
+});
+
+test('Expect save button to be enabled if output target is selected and saveImages function called', async () => {
+  saveDialogMock.mockResolvedValue({ scheme: 'file', path: '/tmp/my/path' } as Uri);
+  saveImagesMock.mockResolvedValue('');
+  const goToMock = vi.spyOn(router, 'goto');
+
+  saveImagesInfo.set([imageInfo]);
+  await waitRender();
+
+  const saveButton = screen.getByRole('button', { name: 'Save images' });
+  expect(saveButton).toBeInTheDocument();
+  expect(saveButton).toBeDisabled();
+
+  const selectOutputPathButton = screen.getByRole('button', { name: 'Select output folder' });
+  expect(selectOutputPathButton).toBeInTheDocument();
+
+  await userEvent.click(selectOutputPathButton);
+
+  const saveButtonAfterSelection = screen.getByRole('button', { name: 'Save images' });
+  expect(saveButtonAfterSelection).toBeInTheDocument();
+  expect(saveButtonAfterSelection).toBeEnabled();
+
+  await userEvent.click(saveButtonAfterSelection);
+
+  expect(saveImagesMock).toBeCalledWith({
+    images: [
+      {
+        id: 'id',
+        engineId: 'engine',
+      },
+    ],
+    outputTarget: '/tmp/my/path',
+  });
+  expect(goToMock).toBeCalledWith('/images/');
+});
+
+test('Expect error message dispayed if saveImages fails', async () => {
+  saveDialogMock.mockResolvedValue({ scheme: 'file', path: '/tmp/my/path' } as Uri);
+  saveImagesMock.mockRejectedValue('error while saving');
+  const goToMock = vi.spyOn(router, 'goto');
+
+  saveImagesInfo.set([imageInfo]);
+  await waitRender();
+
+  const selectOutputPathButton = screen.getByRole('button', { name: 'Select output folder' });
+  expect(selectOutputPathButton).toBeInTheDocument();
+
+  await userEvent.click(selectOutputPathButton);
+
+  const saveButtonAfterSelection = screen.getByRole('button', { name: 'Save images' });
+  expect(saveButtonAfterSelection).toBeInTheDocument();
+  expect(saveButtonAfterSelection).toBeEnabled();
+
+  await userEvent.click(saveButtonAfterSelection);
+
+  const errorDiv = screen.getByLabelText('Error Message Content');
+
+  expect(saveImagesMock).toBeCalledWith({
+    images: [
+      {
+        id: 'id',
+        engineId: 'engine',
+      },
+    ],
+    outputTarget: '/tmp/my/path',
+  });
+  expect(goToMock).not.toBeCalled();
+  expect(errorDiv).toBeInTheDocument();
+  expect((errorDiv as HTMLDivElement).innerHTML).toContain('error while saving');
+});

--- a/packages/renderer/src/lib/image/SaveImages.svelte
+++ b/packages/renderer/src/lib/image/SaveImages.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-/* eslint-disable import/no-duplicates */
-// https://github.com/import-js/eslint-plugin-import/issues/1479
 import { faMinusCircle, faPlay } from '@fortawesome/free-solid-svg-icons';
 import { Input } from '@podman-desktop/ui-svelte';
 import { onMount } from 'svelte';

--- a/packages/renderer/src/lib/image/SaveImages.svelte
+++ b/packages/renderer/src/lib/image/SaveImages.svelte
@@ -53,7 +53,7 @@ async function selectTargetFilePath() {
     targetFile = `${imagesToSave[0].name.substring(lastSlashPos, lastColon)}.tar`;
   }
   const result = await window.saveDialog({
-    title: 'Select the directory where to export the container content',
+    title: 'Select the directory to export the container content',
     defaultUri: {
       fsPath: targetFile,
       path: targetFile,
@@ -73,7 +73,7 @@ async function selectTargetFilePath() {
 
 async function selectOutputDirectoryPath() {
   const result = await window.openDialog({
-    title: `Select the directory where to save the ${singleItemMode ? 'image' : 'images'}`,
+    title: `Select the directory to save the ${singleItemMode ? 'image' : 'images'}`,
     selectors: ['openDirectory'],
   });
   if (!result?.[0]) {

--- a/packages/renderer/src/stores/save-images-store.spec.ts
+++ b/packages/renderer/src/stores/save-images-store.spec.ts
@@ -1,0 +1,37 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { get } from 'svelte/store';
+import { expect, test } from 'vitest';
+
+import type { ImageInfoUI } from '../lib/image/ImageInfoUI';
+import { saveImagesInfo } from './save-images-store';
+
+const imageInfo: ImageInfoUI = {
+  id: 'id',
+} as ImageInfoUI;
+
+test('check that save image store is filled', async () => {
+  // initial images
+  saveImagesInfo.set([imageInfo]);
+  const imageInfoInStore = get(saveImagesInfo);
+  expect(imageInfoInStore.length).equal(1);
+  expect(imageInfoInStore[0]).equal(imageInfo);
+});

--- a/packages/renderer/src/stores/save-images-store.ts
+++ b/packages/renderer/src/stores/save-images-store.ts
@@ -1,0 +1,27 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { Writable } from 'svelte/store';
+import { writable } from 'svelte/store';
+
+import type { ImageInfoUI } from '../lib/image/ImageInfoUI';
+
+/**
+ * Defines the store used to define the images to save.
+ */
+export const saveImagesInfo: Writable<ImageInfoUI[]> = writable([]);

--- a/tests/playwright/src/model/pages/image-edit-page.ts
+++ b/tests/playwright/src/model/pages/image-edit-page.ts
@@ -32,7 +32,7 @@ export class ImageEditPage extends BasePage {
     super(page);
     this.imageName = page.getByLabel('imageName');
     this.cancelButton = page.getByRole('button', { name: 'Cancel' });
-    this.saveButton = page.getByRole('button', { name: 'Save' });
+    this.saveButton = page.getByRole('button', { name: 'Save', exact: true });
     this.name = name;
     this.imageTag = page.getByLabel('imageTag');
   }


### PR DESCRIPTION
### What does this PR do?

this allows to save images.
there are 3 possible scenarios.
1) only one item selected (or user clicks on the action on the right menu) -> it saves an archive containing one item, the user can customize the archive name
2) multiple items selected belonging to the same provider -> it saves one archive, the user can customize the archive name
3) multiple items belonging to different providers -> it saves N archives where N is the number of different providers, the user only select the final directory, then archives with name {providerName}-images-{randomstring}.tar are created.

### Screenshot / video of UI

1) save single item

![save_single_item](https://github.com/containers/podman-desktop/assets/49404737/0628aee1-1460-42e1-817e-39048197d559)

2) save multiple items of the same provider

![save_multiple_item](https://github.com/containers/podman-desktop/assets/49404737/d3df6fc4-6617-4be1-9185-701d990474b9)

3) save multiple items from multiple providers

![save_multiple_item_multiple_provs](https://github.com/containers/podman-desktop/assets/49404737/e342264a-1902-49af-a89f-73a3f126bb1d)

### What issues does this PR fix or reference?

it is part of #478 

### How to test this PR?

1) select images and save them, the load action will be available soon

- [X] Tests are covering the bug fix or the new feature
