### PR TITLE
feat: prompt user to stop any running podman machine before updating

### DIFF
--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -1307,7 +1307,7 @@ async function stopAutoStartedMachine(): Promise<void> {
   await extensionApi.process.exec(getPodmanCli(), ['machine', 'stop', autoMachineName]);
 }
 
-async function getJSONMachineList(): Promise<string> {
+export async function getJSONMachineList(): Promise<string> {
   const { stdout } = await extensionApi.process.exec(getPodmanCli(), ['machine', 'list', '--format', 'json']);
   return stdout;
 }


### PR DESCRIPTION
### What does this PR do?

Before updating podman by running the installer, check if there is no active podman machine running.
if it's the case, prompt the user to stop the machines before proceeding

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/6518

### How to test this PR?

1. Use for example podman v4.9.3 and enable the experimental flag to update to v5
1. run a podman machine
1. click on update to 5.0.0 in Podman Desktop
1. It should prompt to stop all podman machines before continuing

unit tests provided

- [x] Tests are covering the bug fix or the new feature
