### PR TITLE
chore(test): add destructed object for params

### DIFF
--- a/tests/playwright/src/runner/podman-desktop-runner.ts
+++ b/tests/playwright/src/runner/podman-desktop-runner.ts
@@ -40,14 +40,20 @@ export class PodmanDesktopRunner {
   private _videoAndTraceName: string | undefined;
   private _autoupdate: boolean;
 
-  constructor(profile = '', customFolder = 'podman-desktop', autoupdate = true) {
+  constructor({
+    profile = '',
+    customFolder = 'podman-desktop',
+    autoupdate = true,
+  }: { profile?: string; customFolder?: string; autoupdate?: boolean } = {}) {
     this._running = false;
     this._profile = profile;
     this._testOutput = join('tests', 'output', this._profile);
     this._customFolder = join(this._testOutput, customFolder);
-    this._options = this.defaultOptions();
     this._videoAndTraceName = undefined;
     this._autoupdate = autoupdate;
+
+    // Options setting always needs to be last action in constructor in order to apply settings correctly
+    this._options = this.defaultOptions();
   }
 
   public async start(): Promise<Page> {

--- a/tests/playwright/src/specs/welcome-page-smoke.spec.ts
+++ b/tests/playwright/src/specs/welcome-page-smoke.spec.ts
@@ -30,7 +30,7 @@ let pdRunner: PodmanDesktopRunner;
 let page: Page;
 
 beforeAll(async () => {
-  pdRunner = new PodmanDesktopRunner('', 'welcome-podman-desktop');
+  pdRunner = new PodmanDesktopRunner({ customFolder: 'welcome-podman-desktop' });
   page = await pdRunner.start();
   pdRunner.setVideoAndTraceName('welcome-page-e2e');
 });


### PR DESCRIPTION
### What does this PR do?
Create a destructed object for runner params and ensures custom params are applied correctly

### What issues does this PR fix or reference?
https://github.com/containers/podman-desktop/issues/6524
