### PR TITLE
feat: ask to wipe all data when migrating from podman v4 to v5

### DIFF
--- a/extensions/podman/src/podman-install.ts
+++ b/extensions/podman/src/podman-install.ts
@@ -263,7 +263,7 @@ export class PodmanInstall {
     ) {
       // prompt if user wants to wipe all data
       const answer = await extensionApi.window.showInformationMessage(
-        `You are updating from Podman ${installedPodman.version} to ${updateInfo.bundledVersion}. It is recommended to delete all data (including containers, volumes, networks, podman machines, etc) for this update. DATA WILL BE DESTROYED. Do you want to proceed ?`,
+        `You are updating from Podman ${installedPodman.version} to ${updateInfo.bundledVersion}. It is recommended to delete all data (including containers, volumes, networks, podman machines, etc) for this update. DATA WILL BE DELETED PERMANENTLY. Do you want to proceed ?`,
         'Cancel',
         'Yes',
         'Skip',
@@ -316,7 +316,7 @@ export class PodmanInstall {
       const wipeAllDataCompleted = await this.wipeAllDataBeforeUpdatingToV5(installedPodman, updateInfo);
       if (!wipeAllDataCompleted) {
         await extensionApi.window.showWarningMessage(
-          'Podman update has been canceled. You can do some backups before restarting the update',
+          'Podman update has been canceled. It is recommended to backup OCI images or containers before resuming the update procedure',
           'OK',
         );
         return;


### PR DESCRIPTION
### What does this PR do?
Also bring a confirmation dialog
it is still an optional step

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/6522

### How to test this PR?

1. install v4.9.3
2. enable the experimental v5 upgrade flag
3. click on 'update to 5.0.0

then you should be prompted to wipe all data and confirm it

also unit tests are provided
- [x] Tests are covering the bug fix or the new feature
