### PR TITLE
feat: allow to load images

### DIFF
--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -28,6 +28,7 @@ import BuildImageFromContainerfile from './lib/image/BuildImageFromContainerfile
 import ImageDetails from './lib/image/ImageDetails.svelte';
 import ImagesList from './lib/image/ImagesList.svelte';
 import ImportContainersImages from './lib/image/ImportContainersImages.svelte';
+import LoadImages from './lib/image/LoadImages.svelte';
 import PullImage from './lib/image/PullImage.svelte';
 import RunImage from './lib/image/RunImage.svelte';
 import SaveImages from './lib/image/SaveImages.svelte';
@@ -145,6 +146,9 @@ window.events?.receive('navigate', (navigationRequest: unknown) => {
         </Route>
         <Route path="/images/save" breadcrumb="Save Images">
           <SaveImages />
+        </Route>
+        <Route path="/images/load" breadcrumb="Load Images">
+          <LoadImages />
         </Route>
         <Route path="/pods" breadcrumb="Pods" navigationHint="root">
           <PodsList />

--- a/packages/renderer/src/lib/image/ImagesList.spec.ts
+++ b/packages/renderer/src/lib/image/ImagesList.spec.ts
@@ -433,3 +433,13 @@ test('expect redirect to saveImage page when atleast one image is selected and t
 
   expect(goToMock).toBeCalledWith('/images/save');
 });
+
+test('Expect load images button redirects to images load page', async () => {
+  const goToMock = vi.spyOn(router, 'goto');
+  render(ImagesList);
+  const btnLoadImages = screen.getByRole('button', { name: 'Load Images' });
+  expect(btnLoadImages).toBeInTheDocument();
+
+  await userEvent.click(btnLoadImages);
+  expect(goToMock).toBeCalledWith('/images/load');
+});

--- a/packages/renderer/src/lib/image/ImagesList.svelte
+++ b/packages/renderer/src/lib/image/ImagesList.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { faArrowCircleDown, faCube, faDownload, faTrash } from '@fortawesome/free-solid-svg-icons';
+import { faArrowCircleDown, faCube, faDownload, faTrash, faUpload } from '@fortawesome/free-solid-svg-icons';
 import moment from 'moment';
 import { onDestroy, onMount } from 'svelte';
 import type { Unsubscriber } from 'svelte/store';
@@ -299,7 +299,7 @@ const row = new Row<ImageInfoUI>({
     <Button
       on:click="{() => loadImages()}"
       title="Load image(s) from tar archive(s)"
-      icon="{faArrowCircleDown}"
+      icon="{faUpload}"
       aria-label="Load Images">
       Load
     </Button>

--- a/packages/renderer/src/lib/image/ImagesList.svelte
+++ b/packages/renderer/src/lib/image/ImagesList.svelte
@@ -162,6 +162,10 @@ function importImage(): void {
   router.goto('/images/import');
 }
 
+function loadImages(): void {
+  router.goto('/images/load');
+}
+
 // delete the items selected in the list
 let bulkDeleteInProgress = false;
 async function deleteSelectedImages() {
@@ -292,6 +296,13 @@ const row = new Row<ImageInfoUI>({
     {#if $imagesInfos.length > 0}
       <Prune type="images" engines="{enginesList}" />
     {/if}
+    <Button
+      on:click="{() => loadImages()}"
+      title="Load image(s) from tar archive(s)"
+      icon="{faArrowCircleDown}"
+      aria-label="Load Images">
+      Load
+    </Button>
     <Button
       on:click="{() => importImage()}"
       title="Import Image From Filesystem"

--- a/packages/renderer/src/lib/image/LoadImages.spec.ts
+++ b/packages/renderer/src/lib/image/LoadImages.spec.ts
@@ -1,0 +1,151 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import '@testing-library/jest-dom/vitest';
+
+import type { ProviderStatus } from '@podman-desktop/api';
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { router } from 'tinro';
+import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
+
+import { providerInfos } from '/@/stores/providers';
+
+import type { ProviderContainerConnectionInfo, ProviderInfo } from '../../../../main/src/plugin/api/provider-info';
+import LoadImages from './LoadImages.svelte';
+
+const openDialogMock = vi.fn();
+const loadImagesMock = vi.fn();
+
+const pStatus: ProviderStatus = 'started';
+const pInfo: ProviderContainerConnectionInfo = {
+  name: 'test',
+  status: 'started',
+  endpoint: {
+    socketPath: '',
+  },
+  type: 'podman',
+};
+const providerInfo = {
+  id: 'test',
+  internalId: 'id',
+  name: '',
+  containerConnections: [pInfo],
+  kubernetesConnections: undefined,
+  status: pStatus,
+  containerProviderConnectionCreation: false,
+  containerProviderConnectionInitialization: false,
+  kubernetesProviderConnectionCreation: false,
+  kubernetesProviderConnectionInitialization: false,
+  links: undefined,
+  detectionChecks: undefined,
+  warnings: undefined,
+  images: undefined,
+  installationSupport: undefined,
+} as unknown as ProviderInfo;
+
+// fake the window.events object
+beforeAll(() => {
+  (window as any).openDialog = openDialogMock;
+  (window as any).loadImages = loadImagesMock;
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+test('Expect load button to be disabled', async () => {
+  render(LoadImages);
+  const btnLoadImages = screen.getByRole('button', { name: 'Load images' });
+  expect(btnLoadImages).toBeInTheDocument();
+  expect(btnLoadImages).toBeDisabled();
+});
+
+test('Expect loadImage button to be enabled when atleast one archive is selected', async () => {
+  providerInfos.set([providerInfo]);
+  openDialogMock.mockResolvedValue(['path/file.tar']);
+  render(LoadImages);
+  const btnAddArchive = screen.getByRole('button', { name: 'Add archive' });
+  expect(btnAddArchive).toBeInTheDocument();
+  await userEvent.click(btnAddArchive);
+
+  const btnLoadImages = screen.getByRole('button', { name: 'Load images' });
+  expect(btnLoadImages).toBeInTheDocument();
+  expect(btnLoadImages).toBeEnabled();
+});
+
+test('Expect loadImage button to be disabled when atleast one archive is selected but there is no provider', async () => {
+  providerInfos.set([]);
+  openDialogMock.mockResolvedValue(['path/file.tar']);
+  render(LoadImages);
+  const btnAddArchive = screen.getByRole('button', { name: 'Add archive' });
+  expect(btnAddArchive).toBeInTheDocument();
+  await userEvent.click(btnAddArchive);
+
+  const btnLoadImages = screen.getByRole('button', { name: 'Load images' });
+  expect(btnLoadImages).toBeInTheDocument();
+  expect(btnLoadImages).toBeDisabled();
+});
+
+test('Expect load button calls loadImages func', async () => {
+  providerInfos.set([providerInfo]);
+  openDialogMock.mockResolvedValue(['path/file.tar']);
+  loadImagesMock.mockResolvedValue('');
+  const goToMock = vi.spyOn(router, 'goto');
+  render(LoadImages);
+  const btnAddArchive = screen.getByRole('button', { name: 'Add archive' });
+  expect(btnAddArchive).toBeInTheDocument();
+  await userEvent.click(btnAddArchive);
+
+  const btnLoadImages = screen.getByRole('button', { name: 'Load images' });
+  expect(btnLoadImages).toBeInTheDocument();
+  expect(btnLoadImages).toBeEnabled();
+  await userEvent.click(btnLoadImages);
+
+  expect(loadImagesMock).toBeCalledWith({
+    provider: pInfo,
+    archives: ['path/file.tar'],
+  });
+  expect(goToMock).toBeCalledWith('/images');
+});
+
+test('Expect error shown if loadImages function fails', async () => {
+  providerInfos.set([providerInfo]);
+  openDialogMock.mockResolvedValue(['path/file.tar']);
+  loadImagesMock.mockRejectedValue('load failed');
+  render(LoadImages);
+  const btnAddArchive = screen.getByRole('button', { name: 'Add archive' });
+  expect(btnAddArchive).toBeInTheDocument();
+  await userEvent.click(btnAddArchive);
+
+  const btnLoadImages = screen.getByRole('button', { name: 'Load images' });
+  expect(btnLoadImages).toBeInTheDocument();
+  expect(btnLoadImages).toBeEnabled();
+  await userEvent.click(btnLoadImages);
+
+  expect(loadImagesMock).toBeCalledWith({
+    provider: pInfo,
+    archives: ['path/file.tar'],
+  });
+
+  const errorDiv = screen.getByLabelText('Error Message Content');
+  expect(errorDiv).toBeInTheDocument();
+  expect((errorDiv as HTMLDivElement).innerHTML).toContain('load failed');
+});

--- a/packages/renderer/src/lib/image/LoadImages.svelte
+++ b/packages/renderer/src/lib/image/LoadImages.svelte
@@ -109,13 +109,11 @@ async function loadImages() {
         </label>
       {/if}
 
-      <label for="modalImagesLoad" class="pt-4 block mb-2 text-sm font-medium text-gray-400"
-        >Images archive to load:</label>
       <Button on:click="{addArchivesToLoad}" icon="{faPlusCircle}" type="link">Add archive</Button>
       <!-- Display the list of existing imagesToLoad -->
       {#if archivesToLoad.length > 0}
         <div class="flex flex-row justify-center w-full py-1 text-sm font-medium text-gray-400">
-          <div class="flex flex-col grow pl-2">Archive</div>
+          <div class="flex flex-col grow pl-2">Image Archives</div>
         </div>
       {/if}
       {#each archivesToLoad as archiveToLoad, index}
@@ -125,20 +123,21 @@ async function loadImages() {
         </div>
       {/each}
 
-      <div class="pt-5 border-zinc-600 border-t-2"></div>
-      <Button
-        on:click="{() => loadImages()}"
-        inProgress="{inProgress}"
-        class="w-full"
-        icon="{faPlay}"
-        aria-label="Load images"
-        bind:disabled="{loadDisabled}">
-        Load Images
-      </Button>
-      <div aria-label="loadError">
-        {#if loadError !== ''}
-          <ErrorMessage class="py-2 text-sm" error="{loadError}" />
-        {/if}
+      <div class="pt-5">
+        <Button
+          on:click="{() => loadImages()}"
+          inProgress="{inProgress}"
+          class="w-full"
+          icon="{faPlay}"
+          aria-label="Load images"
+          bind:disabled="{loadDisabled}">
+          Load Images
+        </Button>
+        <div aria-label="loadError">
+          {#if loadError !== ''}
+            <ErrorMessage class="py-2 text-sm" error="{loadError}" />
+          {/if}
+        </div>
       </div>
     </div>
   </div>

--- a/packages/renderer/src/lib/image/LoadImages.svelte
+++ b/packages/renderer/src/lib/image/LoadImages.svelte
@@ -1,0 +1,145 @@
+<script lang="ts">
+/* eslint-disable import/no-duplicates */
+// https://github.com/import-js/eslint-plugin-import/issues/1479
+import { faMinusCircle, faPlay, faPlusCircle } from '@fortawesome/free-solid-svg-icons';
+import { Input } from '@podman-desktop/ui-svelte';
+import { onMount } from 'svelte';
+import { get } from 'svelte/store';
+import { router } from 'tinro';
+
+import Button from '/@/lib/ui//Button.svelte';
+import ErrorMessage from '/@/lib/ui//ErrorMessage.svelte';
+import FormPage from '/@/lib/ui//FormPage.svelte';
+import { providerInfos } from '/@/stores/providers';
+import { createTask } from '/@/stores/tasks';
+
+import type { ProviderContainerConnectionInfo, ProviderInfo } from '../../../../main/src/plugin/api/provider-info';
+
+let archivesToLoad: string[] = [];
+let loadError: string = '';
+
+let providers: ProviderInfo[] = [];
+let providerConnections: ProviderContainerConnectionInfo[] = [];
+let selectedProvider: ProviderContainerConnectionInfo | undefined = undefined;
+let inProgress = false;
+
+$: importDisabled = !selectedProvider || archivesToLoad.length === 0;
+
+onMount(async () => {
+  providers = get(providerInfos);
+  providerConnections = providers
+    .map(provider => provider.containerConnections)
+    .flat()
+    .filter(providerContainerConnection => providerContainerConnection.status === 'started');
+
+  const selectedProviderConnection = providerConnections.length > 0 ? providerConnections[0] : undefined;
+  selectedProvider = !selectedProvider && selectedProviderConnection ? selectedProviderConnection : selectedProvider;
+});
+
+async function addArchivesToLoad() {
+  const archives = await window.openDialog({
+    title: 'Select Tar Archive(s) containing Image(s) to load',
+    selectors: ['multiSelections'],
+  });
+
+  if (!archives) {
+    return;
+  }
+
+  archivesToLoad = [...archivesToLoad, ...archives];
+}
+
+function deleteImagesTarArchiveToLoad(index: number) {
+  archivesToLoad = archivesToLoad.filter((_, i) => i !== index);
+}
+
+async function loadImages() {
+  loadError = '';
+
+  if (!selectedProvider) {
+    throw new Error('Select a provider to import');
+  }
+
+  inProgress = true;
+
+  const task = createTask('Load images');
+
+  for (const archive of archivesToLoad) {
+    try {
+      await window.loadImages({
+        provider: selectedProvider,
+        archives: [archive],
+      });
+    } catch (e) {
+      loadError += `Error while loading ${archive}: ${String(e)}\n`;
+    }
+  }
+
+  inProgress = false;
+  if (loadError === '') {
+    task.status = 'success';
+    task.state = 'completed';
+    router.goto('/images');
+  } else {
+    task.status = 'failure';
+    task.error = loadError;
+    task.state = 'completed';
+  }
+}
+</script>
+
+<FormPage title="Load Images">
+  <svelte:fragment slot="icon">
+    <i class="fas fa-play fa-2x" aria-hidden="true"></i>
+  </svelte:fragment>
+  <div slot="content" class="p-5 min-w-full h-fit">
+    <div class="bg-charcoal-600 px-6 py-4 space-y-2 lg:px-8 sm:pb-6 xl:pb-8">
+      {#if providerConnections.length > 1}
+        <label for="providerChoice" class="pt-6 block text-sm font-bold text-gray-400"
+          >Container Engine
+          <select
+            class="w-full p-2 outline-none text-sm bg-charcoal-600 rounded-sm text-gray-700 placeholder-gray-700"
+            name="providerChoice"
+            id="providerChoice"
+            bind:value="{selectedProvider}">
+            {#each providerConnections as providerConnection}
+              <option value="{providerConnection}">{providerConnection.name}</option>
+            {/each}
+          </select>
+        </label>
+      {/if}
+
+      <label for="modalContainersImport" class="pt-4 block mb-2 text-sm font-medium text-gray-400"
+        >Images archive to load:</label>
+      <Button on:click="{addArchivesToLoad}" icon="{faPlusCircle}" type="link">Add archive</Button>
+      <!-- Display the list of existing containersToImport -->
+      {#if archivesToLoad.length > 0}
+        <div class="flex flex-row justify-center w-full py-1 text-sm font-medium text-gray-400">
+          <div class="flex flex-col grow pl-2">Archive</div>
+        </div>
+      {/if}
+      {#each archivesToLoad as archiveToLoad, index}
+        <div class="flex flex-row justify-center w-full py-1">
+          <Input bind:value="{archiveToLoad}" aria-label="archive path" readonly="{true}" />
+          <Button type="link" on:click="{() => deleteImagesTarArchiveToLoad(index)}" icon="{faMinusCircle}" />
+        </div>
+      {/each}
+
+      <div class="pt-5 border-zinc-600 border-t-2"></div>
+      <Button
+        on:click="{() => loadImages()}"
+        inProgress="{inProgress}"
+        class="w-full"
+        icon="{faPlay}"
+        aria-label="Import containers"
+        bind:disabled="{importDisabled}">
+        Load Images
+      </Button>
+      <div aria-label="importError">
+        {#if loadError !== ''}
+          <ErrorMessage class="py-2 text-sm" error="{loadError}" />
+        {/if}
+      </div>
+    </div>
+  </div>
+</FormPage>

--- a/packages/renderer/src/lib/image/LoadImages.svelte
+++ b/packages/renderer/src/lib/image/LoadImages.svelte
@@ -23,7 +23,7 @@ let providerConnections: ProviderContainerConnectionInfo[] = [];
 let selectedProvider: ProviderContainerConnectionInfo | undefined = undefined;
 let inProgress = false;
 
-$: importDisabled = !selectedProvider || archivesToLoad.length === 0;
+$: loadDisabled = !selectedProvider || archivesToLoad.length === 0;
 
 onMount(async () => {
   providers = get(providerInfos);
@@ -57,7 +57,7 @@ async function loadImages() {
   loadError = '';
 
   if (!selectedProvider) {
-    throw new Error('Select a provider to import');
+    throw new Error('Select a provider to load');
   }
 
   inProgress = true;
@@ -109,10 +109,10 @@ async function loadImages() {
         </label>
       {/if}
 
-      <label for="modalContainersImport" class="pt-4 block mb-2 text-sm font-medium text-gray-400"
+      <label for="modalImagesLoad" class="pt-4 block mb-2 text-sm font-medium text-gray-400"
         >Images archive to load:</label>
       <Button on:click="{addArchivesToLoad}" icon="{faPlusCircle}" type="link">Add archive</Button>
-      <!-- Display the list of existing containersToImport -->
+      <!-- Display the list of existing imagesToLoad -->
       {#if archivesToLoad.length > 0}
         <div class="flex flex-row justify-center w-full py-1 text-sm font-medium text-gray-400">
           <div class="flex flex-col grow pl-2">Archive</div>
@@ -131,11 +131,11 @@ async function loadImages() {
         inProgress="{inProgress}"
         class="w-full"
         icon="{faPlay}"
-        aria-label="Import containers"
-        bind:disabled="{importDisabled}">
+        aria-label="Load images"
+        bind:disabled="{loadDisabled}">
         Load Images
       </Button>
-      <div aria-label="importError">
+      <div aria-label="loadError">
         {#if loadError !== ''}
           <ErrorMessage class="py-2 text-sm" error="{loadError}" />
         {/if}


### PR DESCRIPTION
### What does this PR do?

it adds the loadImages to the UI. By going to the images page and click on the above Load button you can load archives containing images

### Screenshot / video of UI

![load_images](https://github.com/containers/podman-desktop/assets/49404737/47a96275-e6fd-4402-8a21-430f81e3f342)

### What issues does this PR fix or reference?

it is part of #478 

### How to test this PR?

1. try to load images

- [x] Tests are covering the bug fix or the new feature
