### PR TITLE
feat: support for webview reveal

### DIFF
--- a/packages/main/src/plugin/webview/webview-panel-impl.spec.ts
+++ b/packages/main/src/plugin/webview/webview-panel-impl.spec.ts
@@ -243,7 +243,7 @@ test('check reveal with true', async () => {
   webviewPanelImpl.reveal(true);
 
   // check apiSender called
-  expect(apiSender.send).toHaveBeenCalledWith('webview-panel-reveal', { id: 'internalId0', preserveFocus: true });
+  expect(apiSender.send).toHaveBeenCalledWith('navigate', { page: 'webview', parameters: { id: 'internalId0' } });
 });
 
 test('check dispose', async () => {

--- a/packages/main/src/plugin/webview/webview-panel-impl.ts
+++ b/packages/main/src/plugin/webview/webview-panel-impl.ts
@@ -27,6 +27,8 @@ import type {
 import type { ApiSenderType } from '/@/plugin/api.js';
 import { Emitter } from '/@/plugin/events/emitter.js';
 
+import { NavigationPage } from '../navigation/navigation-page.js';
+import type { NavigationRequest } from '../navigation/navigation-request.js';
 import type { WebviewImpl } from './webview-impl.js';
 import type { WebviewRegistry } from './webview-registry.js';
 
@@ -146,11 +148,16 @@ export class WebviewPanelImpl implements WebviewPanel {
     }
   }
 
-  reveal(preserveFocus?: boolean): void {
+  reveal(_preserveFocus?: boolean): void {
     this.assertNotDisposed();
 
     // notify the renderer to reveal the webview
-    this.#apiSender.send('webview-panel-reveal', { id: this.#internalId, preserveFocus });
+    this.#apiSender.send('navigate', {
+      page: NavigationPage.WEBVIEW,
+      parameters: {
+        id: this.#internalId,
+      },
+    } as NavigationRequest);
   }
 
   dispose(): void {

--- a/packages/main/src/plugin/webview/webview-panel-impl.ts
+++ b/packages/main/src/plugin/webview/webview-panel-impl.ts
@@ -152,12 +152,13 @@ export class WebviewPanelImpl implements WebviewPanel {
     this.assertNotDisposed();
 
     // notify the renderer to reveal the webview
-    this.#apiSender.send('navigate', {
+    const navigationRequest: NavigationRequest = {
       page: NavigationPage.WEBVIEW,
       parameters: {
         id: this.#internalId,
       },
-    } as NavigationRequest);
+    };
+    this.#apiSender.send('navigate', navigationRequest);
   }
 
   dispose(): void {


### PR DESCRIPTION
### What does this PR do?

When you call a Webview panel's reveal() function today, it fires a webview-panel-reveal event that nothing listens to, so the panel is never opened. There are a few possible ways we could solve this:
- Webview panel could call the navigation manager directly.
- Webview panel could fire a navigation event itself.
- Renderer can listen to the reveal event and navigate.

The first requires the navigation manager to be passed into the Webview, which involves a decent amount of change and a somewhat circular dependency because the navigation manager already depends on the webview registry. The third is really simple and works, but this is essentially a second, custom webview navigation event.

So this is the middle option: just trigger a webview navigation event instead. Although it's not necessary the code uses NavigationPage and casts to NavigationRequest to ensure type safety, and being caught if there are ever changes to the navigation code.

The optional preserveFocus is (still) not respected, since webview navigation doesn't support an option like this; we could add that separately, whether or not we expose it via the navigation API.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes #5925.

### How to test this PR?

Test updated; you need a webview to call panel.reveal() on itself to test in dev.

- [x] Tests are covering the bug fix or the new feature