### PR TITLE
feat: default to podman v5 for new users

### DIFF
--- a/extensions/podman/src/podman-install.spec.ts
+++ b/extensions/podman/src/podman-install.spec.ts
@@ -688,6 +688,33 @@ describe('getBundledPodmanVersion', () => {
     // should have called the get with the property for experimental install
     expect(getMock).toHaveBeenCalledWith('experimental.install.v5');
   });
+
+  test('should return the podman 5 version if experimental podman 5 flag is not enabled but first install', async () => {
+    vi.mocked(extensionApi.configuration.getConfiguration).mockReset();
+    const getMock = vi.fn();
+    getMock.mockReturnValue(false);
+
+    // exist sync is false
+    vi.mock('node:fs');
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+
+    vi.mocked(extensionApi.configuration.getConfiguration).mockReturnValue({
+      get: getMock,
+      has: vi.fn(),
+      update: vi.fn(),
+    });
+    const version = getBundledPodmanVersion();
+    expect(version.startsWith('4')).toBeFalsy();
+    expect(version.startsWith('5')).toBeTruthy();
+
+    // check existSync has been called
+    expect(vi.mocked(fs.existsSync)).toHaveBeenCalled();
+
+    // check first argument of the call to getMock
+    expect(getMock).toHaveBeenCalled();
+    // should have called the get with the property for experimental install
+    expect(getMock).toHaveBeenCalledWith('experimental.install.v5');
+  });
 });
 
 class TestPodmanInstall extends PodmanInstall {

--- a/extensions/podman/src/podman-install.ts
+++ b/extensions/podman/src/podman-install.ts
@@ -56,7 +56,15 @@ export function getBundledPodmanVersion(): string {
     .getConfiguration('podman')
     .get<boolean>(PODMAN5_EXPERIMENTAL_MODE_CONFIG_KEY);
 
-  if (podman5ExperimentalModeEnabled) {
+  // also check if the user has never installed podman (for example there is no configuration folder for Podman)
+  // no ~/.config/containers/podman and ~/.local/share/containers/podman folders on Windows or macOS
+  let noPreviousPodmanInstallation = false;
+  if (extensionApi.env.isWindows || extensionApi.env.isMac) {
+    noPreviousPodmanInstallation =
+      !fs.existsSync(path.resolve(os.homedir(), '.config/containers/podman')) &&
+      !fs.existsSync(path.resolve(os.homedir(), '.local/share/containers/podman'));
+  }
+  if (podman5ExperimentalModeEnabled || noPreviousPodmanInstallation) {
     return podman5JSON.version;
   }
 


### PR DESCRIPTION
### What does this PR do?
if you have an existing podman installation, you need to enable a flag but without a previous podman installation you can install v5


### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/6523

### How to test this PR?

remove all `$HOME/.config/containers/podman` and `$HOME/.local/share/containers/podman` it should install v5
with something there it should install/update only to v4 without v5 experimental flag

Added unit tests

- [x] Tests are covering the bug fix or the new feature
