### PR TITLE
fix: check if updates are available after a new podman machine is added/removed

### DIFF
--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -850,6 +850,24 @@ export async function initCheckAndRegisterUpdate(
       await checkForUpdate();
     }
   });
+
+  extensionApi.provider.onDidRegisterContainerConnection(event => {
+    if (event.providerId === provider.id) {
+      // check for update
+      checkForUpdate().catch((error: unknown) => {
+        console.error('Error checking for update', error);
+      });
+    }
+  });
+
+  extensionApi.provider.onDidUnregisterContainerConnection(event => {
+    if (event.providerId === provider.id) {
+      // check for update
+      checkForUpdate().catch((error: unknown) => {
+        console.error('Error checking for update', error);
+      });
+    }
+  });
 }
 
 export function registerOnboardingMachineExistsCommand(): extensionApi.Disposable {


### PR DESCRIPTION
### What does this PR do?
if we start Podman Desktop with no machine and then create one, using v4.9, the upgrade should no longer be possible

but we were not tracking the creation of machine. Now it's done, so it'll unregister the update once machine is created

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/6552

### How to test this PR?

Try usecase of issue or unit tests

- [x] Tests are covering the bug fix or the new feature
