### PR TITLE
feat: detect podman v4 qemu machines after update and delete them

### DIFF
--- a/extensions/podman/package.json
+++ b/extensions/podman/package.json
@@ -306,7 +306,7 @@
             ],
             [
               {
-                "value": "Interupt the process by clicking on `skip` or `skip the entire setup`"
+                "value": "Interrupt the process by clicking on `skip` or `skip the entire setup`"
               }
             ]
           ],

--- a/extensions/podman/package.json
+++ b/extensions/podman/package.json
@@ -32,6 +32,14 @@
       {
         "command": "podman.onboarding.installPodman",
         "title": "Podman: Install podman"
+      },
+      {
+        "command": "podman.onboarding.checkUnsupportedPodmanMachine",
+        "title": "Podman: Check if an old unsupported podman machine exists"
+      },
+      {
+        "command": "podman.onboarding.removeUnsupportedMachines",
+        "title": "Podman: Remove unsupported podman machines"
       }
     ],
     "configuration": {
@@ -260,7 +268,7 @@
         {
           "id": "installationSuccessView",
           "title": "Podman settings",
-          "when": "!onboardingContext:podmanIsNotInstalled",
+          "when": "!onboardingContext:podmanIsNotInstalled && !podman.needPodmanMachineCleanup",
           "content": [
             [
               {
@@ -268,6 +276,41 @@
               }
             ]
           ]
+        },
+        {
+          "id": "checkUnsupportedPodmanMachineCommand",
+          "title": "Checking if an old unsupported Podman machine exists",
+          "when": "!isLinux",
+          "command": "podman.onboarding.checkUnsupportedPodmanMachine",
+          "completionEvents": [
+            "onCommand:podman.onboarding.checkUnsupportedPodmanMachine"
+          ]
+        },
+        {
+          "id": "welcomeFixUnsupportedPodmanMachineView",
+          "title": "Unsupported podman machines detected",
+          "description": "Podman Desktop will remove the unsupported machines",
+          "completionEvents": [
+            "onboardingContext:unsupportedMachineRemoved == ok"
+          ],
+          "content": [
+            [
+              {
+                "value": "Machines created with podman v4 are no longer supported by podman v5"
+              }
+            ],
+            [
+              {
+                "value": ":button[Remove unsupported podman machines]{command=podman.onboarding.removeUnsupportedMachines}"
+              }
+            ],
+            [
+              {
+                "value": "Interupt the process by clicking on `skip` or `skip the entire setup`"
+              }
+            ]
+          ],
+          "when": "onboardingContext:unsupportedPodmanMachine && !isLinux"
         },
         {
           "id": "checkPodmanMachineExistsCommand",
@@ -309,7 +352,7 @@
           ]
         }
       ],
-      "enablement": "(isLinux && onboardingContext:podmanIsNotInstalled) || (!isLinux && !onboardingContext:podmanMachineExists)"
+      "enablement": "(isLinux && onboardingContext:podmanIsNotInstalled) || (!isLinux && !onboardingContext:podmanMachineExists) || podman.needPodmanMachineCleanup"
     }
   },
   "scripts": {

--- a/extensions/podman/package.json
+++ b/extensions/podman/package.json
@@ -288,7 +288,7 @@
         },
         {
           "id": "welcomeFixUnsupportedPodmanMachineView",
-          "title": "Unsupported podman machines detected",
+          "title": "Unsupported Podman machine detected",
           "description": "Podman Desktop will remove the unsupported machines",
           "completionEvents": [
             "onboardingContext:unsupportedMachineRemoved == ok"
@@ -296,12 +296,12 @@
           "content": [
             [
               {
-                "value": "Machines created with podman v4 are no longer supported by podman v5"
+                "value": "Podman Machines created with podman v4 are no longer supported by podman v5"
               }
             ],
             [
               {
-                "value": ":button[Remove unsupported podman machines]{command=podman.onboarding.removeUnsupportedMachines}"
+                "value": ":button[Remove unsupported Podman machine(s)]{command=podman.onboarding.removeUnsupportedMachines}"
               }
             ],
             [

--- a/extensions/podman/src/extension.spec.ts
+++ b/extensions/podman/src/extension.spec.ts
@@ -905,6 +905,8 @@ test('ensure started machine reports default configuration', async () => {
           resolve({
             stdout: JSON.stringify([{ Name: fakeMachineJSON[0].Name, Default: true }]),
           } as extensionApi.RunResult);
+        } else if (args[0] === '--version') {
+          resolve({ stdout: 'podman version 4.9.0' } as extensionApi.RunResult);
         }
       }),
   );
@@ -931,6 +933,8 @@ test('ensure started machine reports configuration', async () => {
           resolve({
             stdout: JSON.stringify([{ Name: fakeMachineJSON[0].Name, Default: true }]),
           } as extensionApi.RunResult);
+        } else if (args[0] === '--version') {
+          resolve({ stdout: 'podman version 4.9.0' } as extensionApi.RunResult);
         }
       }),
   );
@@ -966,6 +970,8 @@ test('ensure stopped machine reports configuration', async () => {
           resolve({
             stdout: JSON.stringify([{ Name: fakeMachineJSON[1].Name, Default: true }]),
           } as extensionApi.RunResult);
+        } else if (args[0] === '--version') {
+          resolve({ stdout: 'podman version 4.9.0' } as extensionApi.RunResult);
         }
       }),
   );

--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -940,7 +940,7 @@ export function registerOnboardingRemoveUnsupportedMachinesCommand(): extensionA
 
       // prompt the user to confirm
       const result = await extensionApi.window.showWarningMessage(
-        'Confirm removal of the unsupported qemu podman machines',
+        'Removing old unsupported Podman machines will delete all of their data. Confirm approval?',
         'Yes',
         'No',
       );

--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -146,7 +146,10 @@ export async function updateMachines(provider: extensionApi.Provider): Promise<v
   extensionApi.context.setValue('podmanMachineExists', machines.length > 0, 'onboarding');
 
   const installedPodman = await getPodmanInstallation();
-  const shouldCleanMachine = shouldNotifyQemuMachinesWithV5(installedPodman);
+  let shouldCleanMachine = false;
+  if (installedPodman) {
+    shouldCleanMachine = shouldNotifyQemuMachinesWithV5(installedPodman);
+  }
   extensionApi.context.setValue(CLEANUP_REQUIRED_MACHINE_KEY, shouldCleanMachine);
 
   // Only show the notification on macOS and Windows

--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -38,7 +38,7 @@ import { PodmanInfoHelper } from './podman-info-helper';
 import { PODMAN5_EXPERIMENTAL_MODE_CONFIG_FULLKEY, PodmanInstall } from './podman-install';
 import { QemuHelper } from './qemu-helper';
 import { RegistrySetup } from './registry-setup';
-import { appHomeDir, getAssetsFolder, isLinux, isMac, isWindows, LoggerDelegator } from './util';
+import { appConfigDir, appHomeDir, getAssetsFolder, isLinux, isMac, isWindows, LoggerDelegator } from './util';
 import { getDisguisedPodmanInformation, getSocketPath, isDisguisedPodman } from './warnings';
 import { WslHelper } from './wsl-helper';
 
@@ -555,6 +555,20 @@ async function monitorMachines(provider: extensionApi.Provider): Promise<void> {
   }
 }
 
+async function shouldNotifyQemuMachinesWithV5(installedPodman: InstalledPodman): Promise<boolean> {
+  // if on macOS we have some files from qemu it needs to be removed/cleaned
+  // check if the qemu files are present in  ~/.config/containers/podman/machine/qemu or ~/.local/share/containers/podman/machine/qemu
+  // get current podman version
+  if (extensionApi.env.isMac && installedPodman.version.startsWith('5.')) {
+    const qemuSharePath = path.resolve(os.homedir(), appHomeDir(), 'machine', 'qemu');
+    const qemuConfigPath = path.resolve(os.homedir(), appConfigDir(), 'machine', 'qemu');
+    if (fs.existsSync(qemuSharePath) || fs.existsSync(qemuConfigPath)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 async function monitorProvider(provider: extensionApi.Provider): Promise<void> {
   // call us again
   if (!stopLoop) {
@@ -580,6 +594,10 @@ async function monitorProvider(provider: extensionApi.Provider): Promise<void> {
         if (provider.status === 'not-installed') {
           provider.updateStatus('installed');
         }
+
+        const shouldCleanMachine = await shouldNotifyQemuMachinesWithV5(installedPodman);
+        extensionApi.context.setValue(CLEANUP_REQUIRED_MACHINE_KEY, shouldCleanMachine);
+
         extensionApi.context.setValue('podmanIsNotInstalled', false, 'onboarding');
         // if podman has been installed, we reset the notification flag so if podman is uninstalled in future we can show the notification again
         if (isLinux()) {
@@ -819,6 +837,7 @@ export async function registerUpdatesIfAny(
 export const ROOTFUL_MACHINE_INIT_SUPPORTED_KEY = 'podman.isRootfulMachineInitSupported';
 export const USER_MODE_NETWORKING_SUPPORTED_KEY = 'podman.isUserModeNetworkingSupported';
 export const START_NOW_MACHINE_INIT_SUPPORTED_KEY = 'podman.isStartNowAtMachineInitSupported';
+export const CLEANUP_REQUIRED_MACHINE_KEY = 'podman.needPodmanMachineCleanup';
 
 export function initTelemetryLogger(): void {
   telemetryLogger = extensionApi.env.createTelemetryLogger();
@@ -886,6 +905,58 @@ export function registerOnboardingMachineExistsCommand(): extensionApi.Disposabl
       machineLength = 0;
     }
     extensionApi.context.setValue('podmanMachineExists', machineLength > 0, 'onboarding');
+  });
+}
+
+export function registerOnboardingUnsupportedPodmanMachineCommand(): extensionApi.Disposable {
+  return extensionApi.commands.registerCommand('podman.onboarding.checkUnsupportedPodmanMachine', async () => {
+    let isUnsupported = false;
+    const installedPodman = await getPodmanInstallation();
+    if (installedPodman) {
+      isUnsupported = await shouldNotifyQemuMachinesWithV5(installedPodman);
+    }
+
+    extensionApi.context.setValue('unsupportedPodmanMachine', isUnsupported, 'onboarding');
+  });
+}
+
+export function registerOnboardingRemoveUnsupportedMachinesCommand(): extensionApi.Disposable {
+  return extensionApi.commands.registerCommand('podman.onboarding.removeUnsupportedMachines', async () => {
+    // only on macOS
+    // do not check if version is v5 as it is being checked by the command that triggers this one
+    if (extensionApi.env.isMac) {
+      // remove the qemu machines folder
+      const qemuSharePath = path.resolve(os.homedir(), appHomeDir(), 'machine', 'qemu');
+      const qemuConfigPath = path.resolve(os.homedir(), appConfigDir(), 'machine', 'qemu');
+
+      // remove folders if exists
+      const foldersToRemove = [];
+      if (fs.existsSync(qemuSharePath)) {
+        foldersToRemove.push(qemuSharePath);
+      }
+      if (fs.existsSync(qemuConfigPath)) {
+        foldersToRemove.push(qemuConfigPath);
+      }
+
+      // prompt the user to confirm
+      const result = await extensionApi.window.showWarningMessage(
+        'Confirm removal of the unsupported qemu podman machines',
+        'Yes',
+        'No',
+      );
+      if (result === 'No') {
+        return;
+      }
+
+      for (const folder of foldersToRemove) {
+        try {
+          await fs.promises.rm(folder, { recursive: true, retryDelay: 1000, maxRetries: 3 });
+        } catch (error) {
+          console.error('Error removing folder', folder, error);
+        }
+      }
+    }
+    extensionApi.context.setValue('unsupportedMachineRemoved', 'ok', 'onboarding');
   });
 }
 
@@ -1193,6 +1264,8 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
       });
     },
   );
+  const onboardingUnsupportedPodmanMachineCommand = registerOnboardingUnsupportedPodmanMachineCommand();
+  const onboardingRemoveUnsupportedMachinesCommand = registerOnboardingRemoveUnsupportedMachinesCommand();
 
   const onboardingCheckPodmanMachineExistsCommand = registerOnboardingMachineExistsCommand();
 
@@ -1281,6 +1354,8 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
     onboardingCheckPodmanMachineExistsCommand,
     onboardingCheckReqsCommand,
     onboardingInstallPodmanCommand,
+    onboardingUnsupportedPodmanMachineCommand,
+    onboardingRemoveUnsupportedMachinesCommand,
   );
 
   // register the registries

--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -949,14 +949,20 @@ export function registerOnboardingRemoveUnsupportedMachinesCommand(): extensionA
         return;
       }
 
+      const errors: string[] = [];
       for (const folder of foldersToRemove) {
         try {
           await fs.promises.rm(folder, { recursive: true, retryDelay: 1000, maxRetries: 3 });
         } catch (error) {
           console.error('Error removing folder', folder, error);
+          errors.push(`Unable to remove the folder ${folder}: ${String(error)}`);
         }
       }
+      if (errors.length > 0) {
+        await extensionApi.window.showErrorMessage(`Error removing unsupported Podman machines. ${errors.join('\n')}`);
+      }
     }
+
     extensionApi.context.setValue('unsupportedMachineRemoved', 'ok', 'onboarding');
   });
 }

--- a/extensions/podman/src/util.ts
+++ b/extensions/podman/src/util.ts
@@ -38,6 +38,11 @@ export function appHomeDir(): string {
   return xdgDataDirectory + '/podman';
 }
 
+const configDirectory = '.config/containers';
+export function appConfigDir(): string {
+  return `${configDirectory}/podman`;
+}
+
 /**
  * @returns true if app running in dev mode
  */


### PR DESCRIPTION
### What does this PR do?
It is part of the onboarding workflow

Podman Desktop detects that problem and register a notification
Then you can run the onboarding workflow and fix the issue

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/6559

### How to test this PR?

Install podman v4 and create machines

then install podman v5 using the installer (and not using Podman Desktop to do the install)

Start Podman Desktop. It should add a notification about Podman onboarding and you'll be able to remove qemu machines from there

note: It's for macOS only

- [x] Tests are covering the bug fix or the new feature
