### PR TITLE
chore: allow to grab stdout and stderr when listing machines

### DIFF
--- a/extensions/podman/src/podman-install.ts
+++ b/extensions/podman/src/podman-install.ts
@@ -219,7 +219,7 @@ export class PodmanInstall {
     const machinesRunning: MachineJSON[] = [];
     try {
       const machineListOutput = await getJSONMachineList();
-      const machines = JSON.parse(machineListOutput) as MachineJSON[];
+      const machines = JSON.parse(machineListOutput.stdout) as MachineJSON[];
 
       machinesRunning.push(...machines.filter(machine => machine.Running || machine.Starting));
     } catch (error) {


### PR DESCRIPTION
### What does this PR do?
allow to return more data from the function that list machines (stderr to see if there are errors)

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

part of https://github.com/containers/podman-desktop/issues/6566

### How to test this PR?

should work as usual

tests are already using the function, it continue to work

- [x] Tests are covering the bug fix or the new feature
