### PR TITLE
feat: detect podman v4 machines not compliant with the new format of v5

### DIFF
--- a/extensions/podman/package.json
+++ b/extensions/podman/package.json
@@ -296,7 +296,7 @@
           "content": [
             [
               {
-                "value": "Podman Machines created with podman v4 are no longer supported by podman v5"
+                "value": "Podman Machines created by Podman v4 are no longer supported by v5"
               }
             ],
             [

--- a/extensions/podman/src/extension.spec.ts
+++ b/extensions/podman/src/extension.spec.ts
@@ -1308,6 +1308,7 @@ describe('initCheckAndRegisterUpdate', () => {
 
 describe('registerOnboardingMachineExistsCommand', () => {
   test('check with error when calling podman machine ls command', async () => {
+    vi.mocked(isMac).mockReturnValue(true);
     vi.mocked(extensionApi.commands.registerCommand).mockReturnValue({ dispose: vi.fn() });
 
     vi.mocked(extensionApi.process.exec).mockRejectedValue(new Error('error'));
@@ -1333,6 +1334,8 @@ describe('registerOnboardingMachineExistsCommand', () => {
   });
 
   test('check with 2 machines', async () => {
+    vi.mocked(isMac).mockReturnValue(true);
+
     vi.mocked(extensionApi.commands.registerCommand).mockReturnValue({ dispose: vi.fn() });
 
     // return 2 empty machines
@@ -1359,6 +1362,8 @@ describe('registerOnboardingMachineExistsCommand', () => {
   });
 
   test('check with 0 machine', async () => {
+    vi.mocked(isMac).mockReturnValue(true);
+
     vi.mocked(extensionApi.commands.registerCommand).mockReturnValue({ dispose: vi.fn() });
 
     // return empty machine array
@@ -1387,6 +1392,8 @@ describe('registerOnboardingMachineExistsCommand', () => {
 
 describe('registerOnboardingUnsupportedPodmanMachineCommand', () => {
   test('check with v5 and previous qemu folders', async () => {
+    vi.mocked(isMac).mockReturnValue(true);
+
     vi.mocked(fs.existsSync).mockReturnValue(true);
 
     vi.mocked(extensionApi.commands.registerCommand).mockReturnValue({ dispose: vi.fn() });
@@ -1421,6 +1428,8 @@ describe('registerOnboardingUnsupportedPodmanMachineCommand', () => {
   });
 
   test('check with v5 and no previous qemu folders', async () => {
+    vi.mocked(isMac).mockReturnValue(true);
+
     // no qemu folders
     vi.mocked(fs.existsSync).mockReturnValue(false);
 
@@ -1457,6 +1466,8 @@ describe('registerOnboardingUnsupportedPodmanMachineCommand', () => {
   });
 
   test('check with v4 and qemu folders', async () => {
+    vi.mocked(isMac).mockReturnValue(true);
+
     vi.mocked(fs.existsSync).mockReturnValue(true);
 
     vi.mocked(extensionApi.commands.registerCommand).mockReturnValue({ dispose: vi.fn() });
@@ -1491,6 +1502,8 @@ describe('registerOnboardingUnsupportedPodmanMachineCommand', () => {
   });
 
   test('check with v5 and error in JSON of machines', async () => {
+    vi.mocked(isMac).mockReturnValue(true);
+
     // no qemu folders
     vi.mocked(fs.existsSync).mockReturnValue(false);
 
@@ -1529,6 +1542,8 @@ describe('registerOnboardingUnsupportedPodmanMachineCommand', () => {
 
 describe('registerOnboardingRemoveUnsupportedMachinesCommand', () => {
   test('check with previous qemu folders', async () => {
+    vi.mocked(isMac).mockReturnValue(true);
+
     vi.mocked(fs.existsSync).mockReturnValue(true);
 
     // mock confirmation window message to true
@@ -1572,6 +1587,8 @@ describe('registerOnboardingRemoveUnsupportedMachinesCommand', () => {
   });
 
   test('check with previous podman v4 config files', async () => {
+    vi.mocked(isMac).mockReturnValue(true);
+
     // mock confirmation window message to true
     vi.mocked(extensionApi.window.showWarningMessage).mockResolvedValue('Yes');
 

--- a/extensions/podman/src/extension.spec.ts
+++ b/extensions/podman/src/extension.spec.ts
@@ -142,7 +142,8 @@ beforeEach(() => {
       VMType: 'wsl',
     },
   };
-
+  vi.resetAllMocks();
+  extension.resetShouldNotifySetup();
   (extensionApi.env.createTelemetryLogger as Mock).mockReturnValue(telemetryLogger);
 
   extension.initTelemetryLogger();
@@ -1527,10 +1528,6 @@ describe('registerOnboardingUnsupportedPodmanMachineCommand', () => {
 });
 
 describe('registerOnboardingRemoveUnsupportedMachinesCommand', () => {
-  beforeEach(() => {
-    vi.resetAllMocks();
-  });
-
   test('check with previous qemu folders', async () => {
     vi.mocked(fs.existsSync).mockReturnValue(true);
 

--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -154,7 +154,7 @@ export async function updateMachines(provider: extensionApi.Provider): Promise<v
 
     // Only on macOS and Windows should we show the setup notification
     // if for some reason doing getJSONMachineList fails..
-    if ((shouldNotifySetup || shouldCleanMachine) && !isLinux()) {
+    if (shouldNotifySetup && !isLinux()) {
       // push setup notification
       notificationDisposable = extensionApi.window.showNotification(setupPodmanNotification);
       shouldNotifySetup = false;
@@ -177,9 +177,10 @@ export async function updateMachines(provider: extensionApi.Provider): Promise<v
   }
 
   // invalid machines is not making the provider working properly so always notify
-  if (shouldCleanMachine && !isLinux()) {
+  if (shouldCleanMachine && shouldNotifySetup && !isLinux()) {
     // push setup notification
     notificationDisposable = extensionApi.window.showNotification(setupPodmanNotification);
+    shouldCleanMachine = false;
   }
 
   extensionApi.context.setValue(CLEANUP_REQUIRED_MACHINE_KEY, shouldCleanMachine);
@@ -1770,6 +1771,10 @@ export async function createMachine(
   shouldNotifySetup = true;
   // notification is no more required
   notificationDisposable?.dispose();
+}
+
+export function resetShouldNotifySetup(): void {
+  shouldNotifySetup = true;
 }
 
 function setupDisguisedPodmanSocketWatcher(

--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -125,6 +125,20 @@ export type MachineListOutput = {
   stderr: string;
 };
 
+export function isIncompatibleMachineOutput(output: string | undefined): boolean {
+  // apple HV v4 to v5 machine config error
+  const APPLE_HV_V4_V5_ERROR = 'incompatible machine config';
+
+  // wsl v4 to v5 machine config error
+  const WSL_V4_V5_ERROR = 'cannot unmarshal string';
+
+  if (output) {
+    return output.includes(APPLE_HV_V4_V5_ERROR) || output.includes(WSL_V4_V5_ERROR);
+  } else {
+    return false;
+  }
+}
+
 export async function updateMachines(provider: extensionApi.Provider): Promise<void> {
   // init machines available
   let machineListOutput: MachineListOutput;
@@ -150,6 +164,17 @@ export async function updateMachines(provider: extensionApi.Provider): Promise<v
   if (installedPodman) {
     shouldCleanMachine = shouldNotifyQemuMachinesWithV5(installedPodman);
   }
+  // check if the machine needs to be cleaned for v4 --> v5 format
+  if (!shouldCleanMachine) {
+    shouldCleanMachine = isIncompatibleMachineOutput(machineListOutput.stderr);
+  }
+
+  // invalid machines is not making the provider working properly so always notify
+  if (shouldCleanMachine && !isLinux()) {
+    // push setup notification
+    notificationDisposable = extensionApi.window.showNotification(setupPodmanNotification);
+  }
+
   extensionApi.context.setValue(CLEANUP_REQUIRED_MACHINE_KEY, shouldCleanMachine);
 
   // Only show the notification on macOS and Windows
@@ -920,40 +945,113 @@ export function registerOnboardingUnsupportedPodmanMachineCommand(): extensionAp
       isUnsupported = shouldNotifyQemuMachinesWithV5(installedPodman);
     }
 
+    // check if the machine needs to be cleaned for v4 --> v5 format
+    if (!isUnsupported) {
+      const machineListOutput = await getJSONMachineList();
+      isUnsupported = isIncompatibleMachineOutput(machineListOutput.stderr);
+    }
+
     extensionApi.context.setValue('unsupportedPodmanMachine', isUnsupported, 'onboarding');
   });
 }
 
 export function registerOnboardingRemoveUnsupportedMachinesCommand(): extensionApi.Disposable {
   return extensionApi.commands.registerCommand('podman.onboarding.removeUnsupportedMachines', async () => {
-    // only on macOS
-    // do not check if version is v5 as it is being checked by the command that triggers this one
-    if (extensionApi.env.isMac) {
+    const fileAndFoldersToRemove = [];
+    const installedPodman = await getPodmanInstallation();
+
+    if (extensionApi.env.isMac && installedPodman?.version.startsWith('5.')) {
       // remove the qemu machines folder
       const qemuSharePath = path.resolve(os.homedir(), appHomeDir(), 'machine', 'qemu');
       const qemuConfigPath = path.resolve(os.homedir(), appConfigDir(), 'machine', 'qemu');
 
       // remove folders if exists
-      const foldersToRemove = [];
       if (fs.existsSync(qemuSharePath)) {
-        foldersToRemove.push(qemuSharePath);
+        fileAndFoldersToRemove.push(qemuSharePath);
       }
       if (fs.existsSync(qemuConfigPath)) {
-        foldersToRemove.push(qemuConfigPath);
+        fileAndFoldersToRemove.push(qemuConfigPath);
       }
 
       // prompt the user to confirm
-      const result = await extensionApi.window.showWarningMessage(
-        'Removing old unsupported Podman machines will delete all of their data. Confirm approval?',
-        'Yes',
-        'No',
-      );
-      if (result === 'No') {
-        return;
+      if (fileAndFoldersToRemove.length > 0) {
+        const result = await extensionApi.window.showWarningMessage(
+          'Removing old unsupported provider Podman machines will delete all of their data. Confirm approval?',
+          'Yes',
+          'No',
+        );
+        if (result === 'No') {
+          return;
+        }
       }
+    }
 
+    // check if unmarshalling errors
+    const machineListOutput = await getJSONMachineList();
+
+    let machineFolderToCheck: string | undefined;
+    // check invalid config files only with v5
+    if (installedPodman?.version.startsWith('5.')) {
+      if (isMac) {
+        machineFolderToCheck = path.resolve(os.homedir(), appConfigDir(), 'machine', 'applehv');
+      } else if (isWindows) {
+        machineFolderToCheck = path.resolve(os.homedir(), appConfigDir(), 'machine', 'wsl');
+      }
+    }
+
+    if (
+      machineFolderToCheck &&
+      isIncompatibleMachineOutput(machineListOutput.stderr) &&
+      fs.existsSync(machineFolderToCheck)
+    ) {
+      // check for JSON files in the folder
+      const files = await fs.promises.readdir(machineFolderToCheck);
+      const machineFilesToAnalyze = files.filter(file => file.endsWith('.json'));
+      let machineConfigJson: { Version?: string } = {};
+      const allMachines = await Promise.all(
+        machineFilesToAnalyze.map(async file => {
+          // read content of the file
+          const absoluteFile = path.join(machineFolderToCheck, file);
+          try {
+            const machineConfigJsonRaw = await fs.promises.readFile(absoluteFile, 'utf-8');
+            machineConfigJson = JSON.parse(machineConfigJsonRaw);
+          } catch (error: unknown) {
+            console.error('Error reading machine file', file, error);
+          }
+          const machineName = file.replace('.json', '');
+          return {
+            file,
+            machineName,
+            machineFile: absoluteFile,
+            json: machineConfigJson,
+          };
+        }),
+      );
+
+      const invalidMachines = allMachines.filter(machine => {
+        // check if the machine has Version field, if it doesn't, it's an invalid machine
+        return !machine.json.Version;
+      });
+
+      // prompt to remove these invalid machines
+      if (invalidMachines.length > 0) {
+        const result = await extensionApi.window.showWarningMessage(
+          `Removing old unsupported Podman machines "${invalidMachines.map(m => m.machineName).join(', ')}" will delete all of their data. Confirm approval?`,
+          'Yes',
+          'No',
+        );
+        if (result === 'No') {
+          return;
+        }
+        for (const machine of invalidMachines) {
+          fileAndFoldersToRemove.push(machine.machineFile);
+        }
+      }
+    }
+
+    if (fileAndFoldersToRemove.length > 0) {
       const errors: string[] = [];
-      for (const folder of foldersToRemove) {
+      for (const folder of fileAndFoldersToRemove) {
         try {
           await fs.promises.rm(folder, { recursive: true, retryDelay: 1000, maxRetries: 3 });
         } catch (error) {
@@ -961,6 +1059,10 @@ export function registerOnboardingRemoveUnsupportedMachinesCommand(): extensionA
           errors.push(`Unable to remove the folder ${folder}: ${String(error)}`);
         }
       }
+      shouldNotifySetup = true;
+      // notification is no more required
+      notificationDisposable?.dispose();
+
       if (errors.length > 0) {
         await extensionApi.window.showErrorMessage(`Error removing unsupported Podman machines. ${errors.join('\n')}`);
       }


### PR DESCRIPTION
### What does this PR do?
Detect invalid applehv v4 on Podman v5 or wsl v4 machines on v5 and ask the user to remove these machines.



### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/6566

### How to test this PR?

keep Podman Desktop stopped
on macOS:
- install v4.9 edit `~/.config/containers/containers.conf` and add
```toml
[machine]
  provider = "applehv"
```
then create a podman machine using `podman machine init`

then download and install v5.0.0 installer from https://github.com/containers/podman/releases/tag/v5.0.0
(here you can create a new v5 machine like `podman machine init v5`

and start Podman Desktop. 

it should prompt you to delete v4 machines (so only `podman-machine-default` and not `v5`


on Windows:
assuming you have a fresh env (no v4 or v5 machines)
keep Podman Desktop stopped
install v4.9 and then create a podman machine using `podman machine init`
then download and install v5.0.0 installer from https://github.com/containers/podman/releases/tag/v5.0.0
(here you can create a new v5 machine like `podman machine init v5`
and start Podman Desktop. 

it should prompt you to delete v4 machines (so only `podman-machine-default` and not `v5`

- [x] Tests are covering the bug fix or the new feature
