### PR TITLE
fix: inconsistent tab filtering behavior

### DIFF
--- a/packages/renderer/src/lib/pod/PodsList.spec.ts
+++ b/packages/renderer/src/lib/pod/PodsList.spec.ts
@@ -605,3 +605,21 @@ test('Expect Stopped tab to show stopped (not running) pods only', async () => {
 
   expect(get(filtered)).toEqual(expect.arrayContaining([expect.objectContaining({ Status: 'Stopped' })]));
 });
+
+test('Expect tab filtering to not duplicate filter condition in the search bar', async () => {
+  getProvidersInfoMock.mockResolvedValue([provider]);
+  listPodsMock.mockResolvedValue([stoppedPod, runningPod]);
+  kubernetesListPodsMock.mockResolvedValue([]);
+  window.dispatchEvent(new CustomEvent('provider-lifecycle-change'));
+  window.dispatchEvent(new CustomEvent('extensions-already-started'));
+
+  render(PodsList);
+
+  const runningTab = screen.getByRole('button', { name: 'Running' });
+  await userEvent.click(runningTab);
+  await userEvent.click(runningTab);
+  await userEvent.click(runningTab);
+
+  const searchInput = screen.getByPlaceholderText('Search pods...') as HTMLInputElement;
+  expect(searchInput.value).toBe('is:running');
+});

--- a/packages/renderer/src/lib/pod/PodsList.svelte
+++ b/packages/renderer/src/lib/pod/PodsList.svelte
@@ -252,7 +252,7 @@ const row = new Row<PodInfoUI>({ selectable: _pod => true });
         let temp = searchTerm
           .trim()
           .split(' ')
-          .filter(term => term !== 'is:stopped')
+          .filter(term => term !== 'is:stopped' && term !== 'is:running')
           .join(' ')
           .trim();
         searchTerm = temp ? `${temp} is:running` : 'is:running';
@@ -264,7 +264,7 @@ const row = new Row<PodInfoUI>({ selectable: _pod => true });
         let temp = searchTerm
           .trim()
           .split(' ')
-          .filter(term => term !== 'is:running')
+          .filter(term => term !== 'is:stopped' && term !== 'is:running')
           .join(' ')
           .trim();
         searchTerm = temp ? `${temp} is:stopped` : 'is:stopped';


### PR DESCRIPTION
Signed-off-by: GLEF1X <glebgar567@gmail.com>

### What does this PR do?

Fixes and closes #6571 by making tab filtering logic consistent

### Screenshot / video of UI

#### Before


https://github.com/containers/podman-desktop/assets/71976818/7f5bcc42-055d-49c1-8a41-3311da627988


#### After


https://github.com/containers/podman-desktop/assets/71976818/22a59489-2a4e-4cb0-b573-1498cd9f7ced



<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
