### PR TITLE
fix: validation rules for disk size and memory

### DIFF
--- a/packages/renderer/src/lib/preferences/item-formats/EditableConnectionResourceItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/EditableConnectionResourceItem.svelte
@@ -13,16 +13,20 @@ let recordValue: DisplayConfigurationValue | undefined;
 $: recordValue = getDisplayConfigurationValue(record, value);
 
 function onChangeInput(_recordId: string, _value: number) {
-  innerOnSave(_recordId, _value);
+  const displayConfigurationValue = getDisplayConfigurationValue(record, value);
+  if (displayConfigurationValue) {
+    onSave(_recordId, normalizeValue(_value));
+  }
 }
 
 function onCancel(_recordId: string, originalValue: number) {
-  innerOnSave(_recordId, originalValue);
+  onSave(_recordId, originalValue);
 }
 
 interface DisplayConfigurationValue {
   value: number;
   format?: string;
+  exponent?: number;
 }
 
 function getDisplayConfigurationValue(
@@ -31,13 +35,14 @@ function getDisplayConfigurationValue(
 ): DisplayConfigurationValue | undefined {
   if (configurationKey.format === 'memory' || configurationKey.format === 'diskSize') {
     const fileSizeItem = value
-      ? filesize(value as number)
-      : filesize(getNormalizedDefaultNumberValue(configurationKey));
-    const fileSizeItems = fileSizeItem.split(' ');
-    // the value returned consists of a number and its format (e.g 20 GB). We return the number as value and the format as description for the editableItem component
+      ? filesize(value as number, { output: 'object' })
+      : filesize(getNormalizedDefaultNumberValue(configurationKey), { output: 'object' });
+    // the value returned consists of a number and its format (e.g 20 GB) and its exponent(2 for MB, 3 for GB, etc).
+    // We return the number as value and the format as description for the editableItem component
     return {
-      value: Number(fileSizeItems[0]),
-      format: fileSizeItems[1],
+      value: Number(fileSizeItem.value),
+      format: fileSizeItem.symbol,
+      exponent: fileSizeItem.exponent,
     };
   } else if (configurationKey.format === 'cpu') {
     return {
@@ -48,56 +53,48 @@ function getDisplayConfigurationValue(
 }
 
 function getFileSizeValue(fileSizeItem: string): number {
-  return parseInt(fileSizeItem.split(' ')[0]);
+  return parseFloat(fileSizeItem.split(' ')[0]);
 }
 
 function normalizeDiskAndMemoryConfigurationKey(
   configurationKey: IConfigurationPropertyRecordedSchema,
+  recordValue?: DisplayConfigurationValue,
 ): IConfigurationPropertyRecordedSchema {
   const configurationKeyClone = Object.assign({}, configurationKey);
-  // if configurationKey is memory or diskSize let's convert the values in bytes to GB so, in case of errors, the message is displayed correctly to the user
-  // instad of having "the value must be less than 16000000000" will be ".... less than 16"
-  if (configurationKey.format === 'memory' || configurationKey.format === 'diskSize') {
+  // if configurationKey is memory or diskSize let's convert the values in bytes to the most appropriate unit so, in case of errors, the message is displayed correctly to the user
+  // instead of having "the value must be less than 16000000000" will be ".... less than 16"
+  if ((configurationKey.format === 'memory' || configurationKey.format === 'diskSize') && recordValue?.exponent) {
     configurationKeyClone.maximum =
       typeof configurationKey.maximum === 'number'
-        ? getFileSizeValue(filesize(configurationKey.maximum))
+        ? getFileSizeValue(filesize(configurationKey.maximum, { exponent: recordValue.exponent }))
         : configurationKey.maximum;
     configurationKeyClone.minimum = configurationKey.minimum
-      ? getFileSizeValue(filesize(configurationKey.minimum))
+      ? getFileSizeValue(filesize(configurationKey.minimum, { exponent: recordValue.exponent }))
       : configurationKey.minimum;
     configurationKeyClone.default =
       typeof configurationKey.maximum === 'number' && configurationKey.default
-        ? getFileSizeValue(filesize(configurationKey.default))
+        ? getFileSizeValue(filesize(configurationKey.default, { exponent: recordValue.exponent }))
         : configurationKey.default;
     return configurationKeyClone;
   }
   return configurationKey;
 }
 
-function innerOnSave(_recordId: string, _value: number) {
-  // convert value to byte to be saved
+function normalizeValue(originalValue: number): number {
   const displayConfigurationValue = getDisplayConfigurationValue(record, value);
-  if (displayConfigurationValue) {
-    switch (displayConfigurationValue.format) {
-      case 'GB': {
-        _value = _value * 1000 * 1000 * 1000;
-        break;
-      }
-      case 'MB': {
-        _value = _value * 1000 * 1000;
-        break;
-      }
-    }
-    onSave(_recordId, _value);
+  if (!displayConfigurationValue) {
+    return originalValue;
   }
+  return originalValue * Math.pow(1000, displayConfigurationValue.exponent || 0);
 }
 </script>
 
 {#if record && recordValue}
   <EditableItem
-    record="{normalizeDiskAndMemoryConfigurationKey(record)}"
+    record="{normalizeDiskAndMemoryConfigurationKey(record, recordValue)}"
     value="{recordValue.value}"
     description="{recordValue.format}"
     onCancel="{onCancel}"
-    onChange="{onChangeInput}" />
+    onChange="{onChangeInput}"
+    normalizeOriginalValue="{normalizeValue}" />
 {/if}


### PR DESCRIPTION
Signed-off-by: GLEF1X <glebgar567@gmail.com>

### What does this PR do?

Fixes and closes #6507 

### Screenshot / video of UI
#### Before

https://github.com/containers/podman-desktop/assets/71976818/04a3639d-298a-4010-a9a2-c53e70021d1a

#### After

https://github.com/containers/podman-desktop/assets/71976818/29c07858-4d98-4d92-a7ae-e123c95c6587



<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

#6507 - VM disk size validation rules are mutually exclusive on macOS 

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
