### PR TITLE
chore(palette): make command titles capitalization consistent

### DIFF
--- a/extensions/kube-context/package.json
+++ b/extensions/kube-context/package.json
@@ -14,11 +14,11 @@
     "commands": [
       {
         "command": "kubecontext.switch",
-        "title": "Kube Context: switch context"
+        "title": "Kube Context: Switch context"
       },
       {
         "command": "kubecontext.quickpick",
-        "title": "Kube Context: select a context"
+        "title": "Kube Context: Select a context"
       }
     ],
     "icons": {

--- a/extensions/kubectl-cli/package.json
+++ b/extensions/kubectl-cli/package.json
@@ -14,19 +14,19 @@
     "commands": [
       {
         "command": "kubectl.install",
-        "title": "kubectl: Install..."
+        "title": "Kubectl: Install..."
       },
       {
         "command": "kubectl.checks",
-        "title": "kubectl: Checks..."
+        "title": "Kubectl: Checks..."
       },
       {
         "command": "kubectl.onboarding.checkDownloadedCommand",
-        "title": "kubectl: Check kubectl Downloaded"
+        "title": "Kubectl: Check kubectl Downloaded"
       },
       {
         "command": "kubectl.onboarding.downloadCommand",
-        "title": "kubectl: Download kubectl"
+        "title": "Kubectl: Download kubectl"
       }
     ],
     "onboarding": {


### PR DESCRIPTION
Signed-off-by: GLEF1X <glebgar567@gmail.com>

### What does this PR do?

Closes #5890 by ensuring consistent capitalization throughout the command palette

### Screenshot / video of UI

![CleanShot 2024-03-31 at 15 09 25@2x](https://github.com/containers/podman-desktop/assets/71976818/5a03fffe-8441-4650-88cb-0aef939c17f2)


<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Closes #5890 

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
