### PR TITLE
feat: always on buddy widget to manage identities

### DIFF
--- a/packages/main/src/plugin/authentication-menu.spec.ts
+++ b/packages/main/src/plugin/authentication-menu.spec.ts
@@ -24,6 +24,7 @@ import type { ApiSenderType } from './api.js';
 import { AuthenticationImpl } from './authentication.js';
 import { AuthenticationProviderSingleAccount } from './authentication.spec.js';
 import { showAccountsMenu } from './authentication-menu.js';
+import type { NavigationManager } from './navigation/navigation-manager.js';
 
 const menu = {
   popup: vi.fn(),
@@ -42,6 +43,10 @@ vi.mock('electron', () => ({
       }) as unknown as BrowserWindow,
   },
 }));
+
+const navigationManager = {
+  navigateToAuthentication: vi.fn(),
+} as unknown as NavigationManager;
 
 let authModule: AuthenticationImpl;
 
@@ -92,7 +97,7 @@ test('showAccountsMenu creates menu with authentication requests and current ses
 
   const buildFromTemplateSpy = vi.spyOn(Menu, 'buildFromTemplate');
 
-  await showAccountsMenu(10, 10, authModule, apiSender);
+  await showAccountsMenu(10, 10, authModule, navigationManager);
 
   expect(menu.popup).toBeCalledWith({ x: 13, y: 13 });
   expect(buildFromTemplateSpy).toBeCalledWith(

--- a/packages/main/src/plugin/authentication-menu.spec.ts
+++ b/packages/main/src/plugin/authentication-menu.spec.ts
@@ -1,0 +1,122 @@
+/**********************************************************************
+ * Copyright (C) 2023-2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { BrowserWindow } from 'electron';
+import { Menu } from 'electron';
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+
+import type { ApiSenderType } from './api.js';
+import { AuthenticationImpl } from './authentication.js';
+import { AuthenticationProviderSingleAccount } from './authentication.spec.js';
+import { showAccountsMenu } from './authentication-menu.js';
+
+const menu = {
+  popup: vi.fn(),
+} as unknown as Menu;
+
+vi.mock('electron', () => ({
+  Menu: {
+    buildFromTemplate: (): Menu => menu,
+  },
+  BrowserWindow: {
+    getFocusedWindow: (): BrowserWindow =>
+      ({
+        webContents: {
+          getZoomFactor: (): number => 1.3,
+        },
+      }) as unknown as BrowserWindow,
+  },
+}));
+
+let authModule: AuthenticationImpl;
+
+const apiSender: ApiSenderType = {
+  send: vi.fn(),
+  receive: vi.fn(),
+};
+
+beforeEach(function () {
+  authModule = new AuthenticationImpl(apiSender);
+});
+
+afterEach(() => {
+  vi.resetAllMocks();
+});
+
+test('showAccountsMenu creates menu with authentication requests and current sessions', async () => {
+  const authProvidrer1 = new AuthenticationProviderSingleAccount();
+  const authProvidrer2 = new AuthenticationProviderSingleAccount();
+  authModule.registerAuthenticationProvider('company.auth-provider1', 'Provider 1', authProvidrer1);
+  authModule.registerAuthenticationProvider('company.auth-provider2', 'Provider 2', authProvidrer2);
+
+  const session1 = await authModule.getSession(
+    { id: 'ext1', label: 'Ext 1' },
+    'company.auth-provider2',
+    ['scope1', 'scope2'],
+    { createIfNone: true },
+  );
+  expect(session1).toBeDefined();
+
+  const session2 = await authModule.getSession(
+    { id: 'ext2', label: 'Ext 2' },
+    'company.auth-provider1',
+    ['scope1', 'scope2'],
+    { silent: false },
+  );
+  expect(session2).toBeUndefined();
+
+  const session3 = await authModule.getSession(
+    { id: 'ext3', label: 'Ext 3' },
+    'company.auth-provider1',
+    ['scope1', 'scope2'],
+    { silent: false },
+  );
+  expect(session3).toBeUndefined();
+
+  expect(authModule.getSessionRequests()).length(2);
+
+  const buildFromTemplateSpy = vi.spyOn(Menu, 'buildFromTemplate');
+
+  await showAccountsMenu(10, 10, authModule, apiSender);
+
+  expect(menu.popup).toBeCalledWith({ x: 13, y: 13 });
+  expect(buildFromTemplateSpy).toBeCalledWith(
+    expect.arrayContaining([
+      expect.objectContaining({
+        label: 'Manage authentication',
+      }),
+      expect.objectContaining({
+        type: 'separator',
+      }),
+      expect.objectContaining({
+        label: 'Sign in with Provider 1 to use Ext 2',
+      }),
+      expect.objectContaining({
+        label: 'Sign in with Provider 1 to use Ext 3',
+      }),
+      expect.objectContaining({
+        label: `${session1?.account.label} (Provider 2)`,
+        submenu: expect.arrayContaining([
+          expect.objectContaining({
+            label: 'Sign out',
+          }),
+        ]),
+      }),
+    ]),
+  );
+});

--- a/packages/main/src/plugin/authentication-menu.ts
+++ b/packages/main/src/plugin/authentication-menu.ts
@@ -1,0 +1,74 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { MenuItem, MenuItemConstructorOptions } from 'electron';
+import { BrowserWindow, Menu } from 'electron';
+
+import type { ApiSenderType } from './api.js';
+import type { AuthenticationImpl } from './authentication.js';
+
+export async function showAccountsMenu(
+  x: number,
+  y: number,
+  auth: AuthenticationImpl,
+  apiSender: ApiSenderType,
+): Promise<void> {
+  const template: (MenuItemConstructorOptions | MenuItem)[] = [
+    {
+      label: 'Manage authentication',
+      click: (): void => {
+        apiSender.send('navigate', {
+          page: 'authentication-providers',
+        });
+      },
+    },
+    {
+      type: 'separator',
+    } as MenuItem,
+  ];
+  const menuInfo = await auth.getAccountsMenuInfo();
+  menuInfo.forEach(item => {
+    if ('requestId' in item) {
+      template.push({
+        label: item.label,
+        click: (): void => {
+          auth.executeSessionRequest(item.requestId).catch(console.error);
+        },
+      });
+    } else {
+      template.push({
+        label: item.label,
+        submenu: [
+          {
+            label: 'Sign out',
+            click: (): void => {
+              auth.signOut(item.providerId, item.sessionId).catch(console.error);
+            },
+          },
+        ],
+      });
+    }
+  });
+  const menu = Menu.buildFromTemplate(template);
+  const zf = BrowserWindow.getFocusedWindow()?.webContents.getZoomFactor();
+  const zoomFactor = zf ? zf : 1;
+  menu.popup({
+    x: Math.round(x * zoomFactor),
+    y: Math.round(y * zoomFactor),
+  });
+}

--- a/packages/main/src/plugin/authentication-menu.ts
+++ b/packages/main/src/plugin/authentication-menu.ts
@@ -19,22 +19,20 @@
 import type { MenuItem, MenuItemConstructorOptions } from 'electron';
 import { BrowserWindow, Menu } from 'electron';
 
-import type { ApiSenderType } from './api.js';
 import type { AuthenticationImpl } from './authentication.js';
+import type { NavigationManager } from './navigation/navigation-manager.js';
 
 export async function showAccountsMenu(
   x: number,
   y: number,
   auth: AuthenticationImpl,
-  apiSender: ApiSenderType,
+  navigation: NavigationManager,
 ): Promise<void> {
   const template: (MenuItemConstructorOptions | MenuItem)[] = [
     {
       label: 'Manage authentication',
       click: (): void => {
-        apiSender.send('navigate', {
-          page: 'authentication-providers',
-        });
+        navigation.navigateToAuthentication().catch(console.error);
       },
     },
     {

--- a/packages/main/src/plugin/authentication.spec.ts
+++ b/packages/main/src/plugin/authentication.spec.ts
@@ -23,11 +23,31 @@ import type {
   AuthenticationSessionAccountInformation,
   Event,
 } from '@podman-desktop/api';
+import type { BrowserWindow } from 'electron';
+import { Menu } from 'electron';
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 
 import type { ApiSenderType } from './api.js';
 import { AuthenticationImpl } from './authentication.js';
 import { Emitter as EventEmitter } from './events/emitter.js';
+
+const menu = {
+  popup: vi.fn(),
+} as unknown as Menu;
+
+vi.mock('electron', () => ({
+  Menu: {
+    buildFromTemplate: (): Menu => menu,
+  },
+  BrowserWindow: {
+    getFocusedWindow: (): BrowserWindow =>
+      ({
+        webContents: {
+          getZoomFactor: (): number => 1.3,
+        },
+      }) as unknown as BrowserWindow,
+  },
+}));
 
 function randomNumber(n = 5): number {
   return Math.round(Math.random() * 10 * n);
@@ -254,4 +274,67 @@ test('authentication provider send event to update settings page', async () => {
   disposable.dispose();
 
   expect(apiSender.send).lastCalledWith('authentication-provider-update', { id: 'provider1.id' });
+});
+
+test('showAccountsMenu creates menu with authentication requests and current sessions', async () => {
+  const authProvidrer1 = new AuthenticationProviderSingleAccount();
+  const authProvidrer2 = new AuthenticationProviderSingleAccount();
+  authModule.registerAuthenticationProvider('company.auth-provider1', 'Provider 1', authProvidrer1);
+  authModule.registerAuthenticationProvider('company.auth-provider2', 'Provider 2', authProvidrer2);
+
+  const session1 = await authModule.getSession(
+    { id: 'ext1', label: 'Ext 1' },
+    'company.auth-provider2',
+    ['scope1', 'scope2'],
+    { createIfNone: true },
+  );
+  expect(session1).toBeDefined();
+
+  const session2 = await authModule.getSession(
+    { id: 'ext2', label: 'Ext 2' },
+    'company.auth-provider1',
+    ['scope1', 'scope2'],
+    { silent: false },
+  );
+  expect(session2).toBeUndefined();
+
+  const session3 = await authModule.getSession(
+    { id: 'ext3', label: 'Ext 3' },
+    'company.auth-provider1',
+    ['scope1', 'scope2'],
+    { silent: false },
+  );
+  expect(session3).toBeUndefined();
+
+  expect(authModule.getSessionRequests()).length(2);
+
+  const buildFromTemplateSpy = vi.spyOn(Menu, 'buildFromTemplate');
+
+  await authModule.showAccountsMenu(10, 10);
+
+  expect(menu.popup).toBeCalledWith({ x: 13, y: 13 });
+  expect(buildFromTemplateSpy).toBeCalledWith(
+    expect.arrayContaining([
+      expect.objectContaining({
+        label: 'Manage authentication',
+      }),
+      expect.objectContaining({
+        type: 'separator',
+      }),
+      expect.objectContaining({
+        label: 'Sign in with Provider 1 to use Ext 2',
+      }),
+      expect.objectContaining({
+        label: 'Sign in with Provider 1 to use Ext 3',
+      }),
+      expect.objectContaining({
+        label: `${session1?.account.label} (Provider 2)`,
+        submenu: expect.arrayContaining([
+          expect.objectContaining({
+            label: 'Sign out',
+          }),
+        ]),
+      }),
+    ]),
+  );
 });

--- a/packages/main/src/plugin/authentication.spec.ts
+++ b/packages/main/src/plugin/authentication.spec.ts
@@ -23,37 +23,17 @@ import type {
   AuthenticationSessionAccountInformation,
   Event,
 } from '@podman-desktop/api';
-import type { BrowserWindow } from 'electron';
-import { Menu } from 'electron';
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 
 import type { ApiSenderType } from './api.js';
 import { AuthenticationImpl } from './authentication.js';
 import { Emitter as EventEmitter } from './events/emitter.js';
 
-const menu = {
-  popup: vi.fn(),
-} as unknown as Menu;
-
-vi.mock('electron', () => ({
-  Menu: {
-    buildFromTemplate: (): Menu => menu,
-  },
-  BrowserWindow: {
-    getFocusedWindow: (): BrowserWindow =>
-      ({
-        webContents: {
-          getZoomFactor: (): number => 1.3,
-        },
-      }) as unknown as BrowserWindow,
-  },
-}));
-
 function randomNumber(n = 5): number {
   return Math.round(Math.random() * 10 * n);
 }
 
-class RandomAuthenticationSession implements AuthenticationSession {
+export class RandomAuthenticationSession implements AuthenticationSession {
   id: string;
   accessToken: string;
   account: AuthenticationSessionAccountInformation;
@@ -67,10 +47,11 @@ class RandomAuthenticationSession implements AuthenticationSession {
   }
 }
 
-class AuthenticationProviderSingleAccount implements AuthenticationProvider {
+export class AuthenticationProviderSingleAccount implements AuthenticationProvider {
   private _onDidChangeSession = new EventEmitter<AuthenticationProviderAuthenticationSessionsChangeEvent>();
   private session: AuthenticationSession | undefined;
   onDidChangeSessions: Event<AuthenticationProviderAuthenticationSessionsChangeEvent> = this._onDidChangeSession.event;
+  constructor() {}
   async getSessions(scopes?: string[]): Promise<readonly AuthenticationSession[]> {
     if (scopes) {
       return this.session ? [this.session] : [];
@@ -274,67 +255,4 @@ test('authentication provider send event to update settings page', async () => {
   disposable.dispose();
 
   expect(apiSender.send).lastCalledWith('authentication-provider-update', { id: 'provider1.id' });
-});
-
-test('showAccountsMenu creates menu with authentication requests and current sessions', async () => {
-  const authProvidrer1 = new AuthenticationProviderSingleAccount();
-  const authProvidrer2 = new AuthenticationProviderSingleAccount();
-  authModule.registerAuthenticationProvider('company.auth-provider1', 'Provider 1', authProvidrer1);
-  authModule.registerAuthenticationProvider('company.auth-provider2', 'Provider 2', authProvidrer2);
-
-  const session1 = await authModule.getSession(
-    { id: 'ext1', label: 'Ext 1' },
-    'company.auth-provider2',
-    ['scope1', 'scope2'],
-    { createIfNone: true },
-  );
-  expect(session1).toBeDefined();
-
-  const session2 = await authModule.getSession(
-    { id: 'ext2', label: 'Ext 2' },
-    'company.auth-provider1',
-    ['scope1', 'scope2'],
-    { silent: false },
-  );
-  expect(session2).toBeUndefined();
-
-  const session3 = await authModule.getSession(
-    { id: 'ext3', label: 'Ext 3' },
-    'company.auth-provider1',
-    ['scope1', 'scope2'],
-    { silent: false },
-  );
-  expect(session3).toBeUndefined();
-
-  expect(authModule.getSessionRequests()).length(2);
-
-  const buildFromTemplateSpy = vi.spyOn(Menu, 'buildFromTemplate');
-
-  await authModule.showAccountsMenu(10, 10);
-
-  expect(menu.popup).toBeCalledWith({ x: 13, y: 13 });
-  expect(buildFromTemplateSpy).toBeCalledWith(
-    expect.arrayContaining([
-      expect.objectContaining({
-        label: 'Manage authentication',
-      }),
-      expect.objectContaining({
-        type: 'separator',
-      }),
-      expect.objectContaining({
-        label: 'Sign in with Provider 1 to use Ext 2',
-      }),
-      expect.objectContaining({
-        label: 'Sign in with Provider 1 to use Ext 3',
-      }),
-      expect.objectContaining({
-        label: `${session1?.account.label} (Provider 2)`,
-        submenu: expect.arrayContaining([
-          expect.objectContaining({
-            label: 'Sign out',
-          }),
-        ]),
-      }),
-    ]),
-  );
 });

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1470,7 +1470,7 @@ export class PluginSystem {
     );
 
     this.ipcHandle('authentication:showAccountsMenu', async (_listener, x: number, y: number): Promise<void> => {
-      return showAccountsMenu(x, y, authentication, apiSender);
+      return showAccountsMenu(x, y, authentication, navigationManager);
     });
 
     this.ipcHandle(

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1464,9 +1464,13 @@ export class PluginSystem {
     this.ipcHandle(
       'authentication-provider-registry:requestAuthenticationProviderSignIn',
       async (_listener, requestId: string): Promise<void> => {
-        return authentication.executeSessionRequest(requestId);
+        await authentication.executeSessionRequest(requestId);
       },
     );
+
+    this.ipcHandle('authentication:showAccountsMenu', async (_listener, x: number, y: number): Promise<void> => {
+      return authentication.showAccountsMenu(x, y);
+    });
 
     this.ipcHandle(
       'configuration-registry:getConfigurationProperties',

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -101,6 +101,7 @@ import type { WebviewInfo } from './api/webview-info.js';
 import { AppearanceInit } from './appearance-init.js';
 import type { AuthenticationProviderInfo } from './authentication.js';
 import { AuthenticationImpl } from './authentication.js';
+import { showAccountsMenu } from './authentication-menu.js';
 import { AutostartEngine } from './autostart-engine.js';
 import { CancellationTokenRegistry } from './cancellation-token-registry.js';
 import { Certificates } from './certificates.js';
@@ -1469,7 +1470,7 @@ export class PluginSystem {
     );
 
     this.ipcHandle('authentication:showAccountsMenu', async (_listener, x: number, y: number): Promise<void> => {
-      return authentication.showAccountsMenu(x, y);
+      return showAccountsMenu(x, y, authentication, apiSender);
     });
 
     this.ipcHandle(

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -1225,6 +1225,10 @@ export function initExposure(): void {
     return ipcInvoke('authentication-provider-registry:requestAuthenticationProviderSignIn', requestId);
   });
 
+  contextBridge.exposeInMainWorld('showAccountsMenu', async (x: number, y: number) => {
+    return ipcInvoke('authentication:showAccountsMenu', x, y);
+  });
+
   contextBridge.exposeInMainWorld(
     'getConfigurationProperties',
     async (): Promise<Record<string, IConfigurationPropertyRecordedSchema>> => {

--- a/packages/renderer/src/AppNavigation.svelte
+++ b/packages/renderer/src/AppNavigation.svelte
@@ -229,10 +229,7 @@ export let meta: TinroRouteMeta;
     href="/accounts"
     tooltip="Accounts"
     bind:meta="{meta}"
-    onClick="{event => {
-      console.log(event.currentTarget);
-      window.showAccountsMenu(event.x, event.y);
-    }}">
+    onClick="{event => window.showAccountsMenu(event.x, event.y)}">
     <Fa class="ml-[-3px] h-8 w-8 fa-light" icon="{faCircleUser}" size="lg" style="fa-light" />
   </NavItem>
 

--- a/packages/renderer/src/AppNavigation.svelte
+++ b/packages/renderer/src/AppNavigation.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
+import { faCircleUser } from '@fortawesome/free-regular-svg-icons';
 import { onDestroy, onMount } from 'svelte';
 import type { Unsubscriber } from 'svelte/store';
+import Fa from 'svelte-fa';
 import type { TinroRouteMeta } from 'tinro';
 
 import Webviews from '/@/lib/webview/Webviews.svelte';
@@ -222,6 +224,17 @@ export let meta: TinroRouteMeta;
   {/if}
 
   <div class="grow"></div>
+
+  <NavItem
+    href="/accounts"
+    tooltip="Accounts"
+    bind:meta="{meta}"
+    onClick="{event => {
+      console.log(event.currentTarget);
+      window.showAccountsMenu(event.x, event.y);
+    }}">
+    <Fa class="ml-[-3px] h-8 w-8 fa-light" icon="{faCircleUser}" size="lg" style="fa-light" />
+  </NavItem>
 
   <NavItem
     href="/preferences"

--- a/packages/renderer/src/lib/ui/NavItem.svelte
+++ b/packages/renderer/src/lib/ui/NavItem.svelte
@@ -2,6 +2,7 @@
 /* eslint-disable import/no-duplicates */
 // https://github.com/import-js/eslint-plugin-import/issues/1479
 import { getContext, onDestroy, onMount } from 'svelte';
+import type { MouseEventHandler } from 'svelte/elements';
 import type { Writable } from 'svelte/store';
 import type { TinroRouteMeta } from 'tinro';
 
@@ -12,7 +13,7 @@ export let href: string;
 export let tooltip: string;
 export let ariaLabel: string | undefined = undefined;
 export let meta: TinroRouteMeta;
-export let onClick: any = undefined;
+export let onClick: MouseEventHandler<HTMLAnchorElement> | undefined;
 
 let inSection: boolean = false;
 let uri = encodeURI(href);

--- a/packages/renderer/src/lib/ui/NavItem.svelte
+++ b/packages/renderer/src/lib/ui/NavItem.svelte
@@ -13,7 +13,7 @@ export let href: string;
 export let tooltip: string;
 export let ariaLabel: string | undefined = undefined;
 export let meta: TinroRouteMeta;
-export let onClick: MouseEventHandler<HTMLAnchorElement> | undefined;
+export let onClick: MouseEventHandler<HTMLAnchorElement> | undefined = undefined;
 
 let inSection: boolean = false;
 let uri = encodeURI(href);


### PR DESCRIPTION
### What does this PR do?

Adds buddy always on widget to manage identities

### Screenshot / video of UI

https://github.com/containers/podman-desktop/assets/620330/45ab96b6-1313-485b-9eb0-fb730a45c7ca

### What issues does this PR fix or reference?

Fix #6297

### How to test this PR?

Install auth extension and use steps from demo above.

- [ ] Tests are covering the bug fix or the new feature
