### PR TITLE
fix: allow to select files when importing tar files

### DIFF
--- a/packages/renderer/src/lib/image/LoadImages.spec.ts
+++ b/packages/renderer/src/lib/image/LoadImages.spec.ts
@@ -89,6 +89,11 @@ test('Expect loadImage button to be enabled when atleast one archive is selected
   const btnLoadImages = screen.getByRole('button', { name: 'Load images' });
   expect(btnLoadImages).toBeInTheDocument();
   expect(btnLoadImages).toBeEnabled();
+
+  expect(openDialogMock).toBeCalledWith({
+    selectors: ['multiSelections', 'openFile'],
+    title: 'Select Tar Archive(s) containing Image(s) to load',
+  });
 });
 
 test('Expect loadImage button to be disabled when atleast one archive is selected but there is no provider', async () => {

--- a/packages/renderer/src/lib/image/LoadImages.svelte
+++ b/packages/renderer/src/lib/image/LoadImages.svelte
@@ -39,7 +39,7 @@ onMount(async () => {
 async function addArchivesToLoad() {
   const archives = await window.openDialog({
     title: 'Select Tar Archive(s) containing Image(s) to load',
-    selectors: ['multiSelections'],
+    selectors: ['multiSelections', 'openFile'],
   });
 
   if (!archives) {


### PR DESCRIPTION
### What does this PR do?
The LoadImage screen is providing a selector 'multiSelections' then the selector is picking up only the options provided
The openFile is missing so we can't select any files

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes fixes https://github.com/containers/podman-desktop/issues/6581


### How to test this PR?

Select the import button from 'images' screen

- [x] Tests are covering the bug fix or the new feature
