### PR TITLE
fix: provides the tag names rather than id when saving images

### DIFF
--- a/packages/renderer/src/lib/image/SaveImages.svelte
+++ b/packages/renderer/src/lib/image/SaveImages.svelte
@@ -104,8 +104,13 @@ async function saveImages() {
   try {
     await window.saveImages({
       images: imagesToSave.map(img => {
+        // do we have a valid name for the image?
+        let imageId = `${img.name}:${img.tag}`;
+        if (imageId.startsWith('<none>')) {
+          imageId = img.shortId;
+        }
         return {
-          id: img.shortId,
+          id: imageId,
           engineId: img.engineId,
         };
       }),


### PR DESCRIPTION
### What does this PR do?
it allows to restore images under their proper names and not pure ids

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/6582

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
