### PR TITLE
fix: allow to select files when wanting to import container tar images

### DIFF
--- a/packages/renderer/src/lib/image/ImportContainersImages.spec.ts
+++ b/packages/renderer/src/lib/image/ImportContainersImages.spec.ts
@@ -89,6 +89,11 @@ test('Expect import button to be enabled when atleast one container image is sel
   const btnImportContainer = screen.getByRole('button', { name: 'Import containers' });
   expect(btnImportContainer).toBeInTheDocument();
   expect(btnImportContainer).toBeEnabled();
+
+  expect(openDialogMock).toBeCalledWith({
+    selectors: ['multiSelections', 'openFile'],
+    title: 'Select Containers Images to import',
+  });
 });
 
 test('Expect import button to be enabled when atleast one container image is selected but there is no provider', async () => {

--- a/packages/renderer/src/lib/image/ImportContainersImages.svelte
+++ b/packages/renderer/src/lib/image/ImportContainersImages.svelte
@@ -39,7 +39,7 @@ onMount(async () => {
 async function addContainersToImport() {
   const images = await window.openDialog({
     title: 'Select Containers Images to import',
-    selectors: ['multiSelections'],
+    selectors: ['multiSelections', 'openFile'],
   });
 
   if (!images) {


### PR DESCRIPTION
### What does this PR do?
same issue than for importing images, there is selector provided so it's not selecting files

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/6590

### How to test this PR?

Check steps from the linked issue or see unit tests

- [x] Tests are covering the bug fix or the new feature
