### PR TITLE
feat: terminate wsl machines before removing conf files when fixing update

### DIFF
--- a/extensions/podman/src/extension.spec.ts
+++ b/extensions/podman/src/extension.spec.ts
@@ -36,7 +36,7 @@ import * as extension from './extension';
 import type { InstalledPodman } from './podman-cli';
 import { getPodmanCli } from './podman-cli';
 import { PodmanInstall } from './podman-install';
-import { isLinux, isMac, LoggerDelegator } from './util';
+import { isLinux, isMac, isWindows, LoggerDelegator } from './util';
 
 const config: Configuration = {
   get: () => {
@@ -1666,6 +1666,49 @@ describe('registerOnboardingRemoveUnsupportedMachinesCommand', () => {
     });
 
     // check called with true as there are qemu folders
+    expect(extensionApi.context.setValue).toBeCalledWith('unsupportedMachineRemoved', 'ok', 'onboarding');
+  });
+
+  test('check with previous podman v4 config files on Windows', async () => {
+    vi.mocked(isWindows).mockReturnValue(true);
+    vi.mocked(isMac).mockReturnValue(false);
+
+    // mock confirmation window message to true
+    vi.mocked(extensionApi.window.showWarningMessage).mockResolvedValue('Yes');
+
+    vi.mocked(extensionApi.commands.registerCommand).mockReturnValue({ dispose: vi.fn() });
+
+    vi.mocked(extensionApi.process.exec).mockResolvedValueOnce({
+      stdout: 'podman version 5.0.0',
+    } as unknown as extensionApi.RunResult);
+    // two times false (no qemu folders)
+    vi.mocked(fs.existsSync).mockReturnValueOnce(false);
+    vi.mocked(fs.existsSync).mockReturnValueOnce(false);
+
+    // return an error when trying to list output
+    vi.mocked(fs.existsSync).mockReturnValueOnce(true);
+    vi.mocked(extensionApi.process.exec).mockRejectedValueOnce({
+      stdout: '[]',
+      stderr: 'cannot unmarshal string',
+    } as unknown as extensionApi.RunResult);
+
+    vi.mocked(fs.promises.readdir).mockResolvedValue(['foo.json'] as unknown as fs.Dirent[]);
+
+    // mock readfile
+    vi.mocked(fs.promises.readFile).mockResolvedValueOnce('{"Driver": "podman"}');
+
+    // perform the call
+    extension.registerOnboardingRemoveUnsupportedMachinesCommand();
+
+    const func = vi.mocked(extensionApi.commands.registerCommand).mock.calls[0][1];
+    // call the function
+    await func();
+
+    // check that we called wsl --terminate and wsl --unregister
+    expect(extensionApi.process.exec).toBeCalledWith('wsl', ['--terminate', 'foo']);
+    expect(extensionApi.process.exec).toBeCalledWith('wsl', ['--unregister', 'foo']);
+
+    // check called with true
     expect(extensionApi.context.setValue).toBeCalledWith('unsupportedMachineRemoved', 'ok', 'onboarding');
   });
 });

--- a/extensions/podman/src/extension.spec.ts
+++ b/extensions/podman/src/extension.spec.ts
@@ -1692,7 +1692,10 @@ describe('registerOnboardingRemoveUnsupportedMachinesCommand', () => {
       stderr: 'cannot unmarshal string',
     } as unknown as extensionApi.RunResult);
 
-    vi.mocked(fs.promises.readdir).mockResolvedValue(['foo.json'] as unknown as fs.Dirent[]);
+    vi.mocked(fs.promises.readdir).mockResolvedValue([
+      'foo.json',
+      'podman-machine-default.json',
+    ] as unknown as fs.Dirent[]);
 
     // mock readfile
     vi.mocked(fs.promises.readFile).mockResolvedValueOnce('{"Driver": "podman"}');
@@ -1705,8 +1708,10 @@ describe('registerOnboardingRemoveUnsupportedMachinesCommand', () => {
     await func();
 
     // check that we called wsl --terminate and wsl --unregister
-    expect(extensionApi.process.exec).toBeCalledWith('wsl', ['--terminate', 'foo']);
-    expect(extensionApi.process.exec).toBeCalledWith('wsl', ['--unregister', 'foo']);
+    expect(extensionApi.process.exec).toBeCalledWith('wsl', ['--terminate', 'podman-foo']);
+    expect(extensionApi.process.exec).toBeCalledWith('wsl', ['--unregister', 'podman-foo']);
+    expect(extensionApi.process.exec).toBeCalledWith('wsl', ['--terminate', 'podman-machine-default']);
+    expect(extensionApi.process.exec).toBeCalledWith('wsl', ['--unregister', 'podman-machine-default']);
 
     // check called with true
     expect(extensionApi.context.setValue).toBeCalledWith('unsupportedMachineRemoved', 'ok', 'onboarding');

--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -1038,7 +1038,11 @@ export function registerOnboardingRemoveUnsupportedMachinesCommand(): extensionA
           } catch (error: unknown) {
             console.error('Error reading machine file', file, error);
           }
-          const machineName = file.replace('.json', '');
+          let machineName = file.replace('.json', '');
+          if (machineName !== 'podman-machine-default') {
+            machineName = `podman-${machineName}`;
+          }
+
           return {
             file,
             machineName,

--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -1053,7 +1053,6 @@ export function registerOnboardingRemoveUnsupportedMachinesCommand(): extensionA
         return !machine.json.GvProxy;
       });
 
-      console.log('invalid machines are', invalidMachines);
       // prompt to remove these invalid machines
       if (invalidMachines.length > 0) {
         const result = await extensionApi.window.showWarningMessage(

--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -1023,7 +1023,6 @@ export function registerOnboardingRemoveUnsupportedMachinesCommand(): extensionA
         machineFolderToCheck = path.resolve(os.homedir(), appConfigDir(), 'machine', 'wsl');
       }
     }
-
     if (machineFolderToCheck && isIncompatibleMachineOutput(machineListError) && fs.existsSync(machineFolderToCheck)) {
       // check for JSON files in the folder
       const files = await fs.promises.readdir(machineFolderToCheck);
@@ -1054,6 +1053,7 @@ export function registerOnboardingRemoveUnsupportedMachinesCommand(): extensionA
         return !machine.json.GvProxy;
       });
 
+      console.log('invalid machines are', invalidMachines);
       // prompt to remove these invalid machines
       if (invalidMachines.length > 0) {
         const result = await extensionApi.window.showWarningMessage(
@@ -1075,6 +1075,17 @@ export function registerOnboardingRemoveUnsupportedMachinesCommand(): extensionA
 
     const errors: string[] = [];
 
+    // stop and unregister old WSL machines
+    for (const wslMachineName of wslMachinesToUnregister) {
+      try {
+        await extensionApi.process.exec('wsl', ['--terminate', wslMachineName]);
+        await extensionApi.process.exec('wsl', ['--unregister', wslMachineName]);
+      } catch (error) {
+        console.error('Error removing WSL machine', wslMachineName, error);
+        errors.push(`Unable to remove the WSL machine ${wslMachineName}: ${String(error)}`);
+      }
+    }
+
     if (fileAndFoldersToRemove.length > 0) {
       for (const folder of fileAndFoldersToRemove) {
         try {
@@ -1090,14 +1101,6 @@ export function registerOnboardingRemoveUnsupportedMachinesCommand(): extensionA
       notificationDisposable?.dispose();
     }
 
-    for (const wslMachineName of wslMachinesToUnregister) {
-      try {
-        await extensionApi.process.exec('wsl', ['--unregister', wslMachineName]);
-      } catch (error) {
-        console.error('Error removing WSL machine', wslMachineName, error);
-        errors.push(`Unable to remove the WSL machine ${wslMachineName}: ${String(error)}`);
-      }
-    }
     if (errors.length > 0) {
       await extensionApi.window.showErrorMessage(`Error removing unsupported Podman machines. ${errors.join('\n')}`);
     }


### PR DESCRIPTION
### What does this PR do?
Before unregistering machines, terminate the machines as well

And we do that before deleting the files

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/pull/6570#issuecomment-2031332254


### How to test this PR?

use test case in https://github.com/containers/podman-desktop/pull/6570

provided unit test as well

- [x] Tests are covering the bug fix or the new feature
