### PR TITLE
fix: invalid if clause for !isLinux

### DIFF
--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -315,9 +315,11 @@ export async function updateMachines(provider: extensionApi.Provider): Promise<v
   // we will update the provider as being 'installed', or ready / starting / configured if there is a machine
   // if we are on Linux, ignore this as podman machine is OPTIONAL and the provider status in Linux is based upon
   // the native podman installation / not machine.
-  if (!isLinux() && machines.length === 0) {
-    if (provider.status !== 'configuring') {
-      provider.updateStatus('installed');
+  if (!isLinux()) {
+    if (machines.length === 0) {
+      if (provider.status !== 'configuring') {
+        provider.updateStatus('installed');
+      }
     } else {
       const atLeastOneMachineRunning = machines.some(machine => machine.Running);
       const atLeastOneMachineStarting = machines.some(machine => machine.Starting);
@@ -332,13 +334,13 @@ export async function updateMachines(provider: extensionApi.Provider): Promise<v
         provider.updateStatus('configured');
       }
     }
-  }
 
-  // Finally, we check to see if the machine that is running is set by default or not on the CLI
-  // this will create a dialog that will ask the user if they wish to set the running machine as default.
-  // this should only run if we have multiple machines
-  if (machines.length > 1) {
-    await checkDefaultMachine(machines);
+    // Finally, we check to see if the machine that is running is set by default or not on the CLI
+    // this will create a dialog that will ask the user if they wish to set the running machine as default.
+    // this should only run if we have multiple machines
+    if (machines.length > 1) {
+      await checkDefaultMachine(machines);
+    }
   }
 }
 


### PR DESCRIPTION
### What does this PR do?
After https://github.com/containers/podman-desktop/commit/287c15d429c1dd104c3451012ccce9e37d50da45 there is a regression, the state of the provider is not checked based on the number of machines running or being stopped
on Windows or macOS due to the if condition

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/6595

### How to test this PR?

Check usecase

- [ ] Tests are covering the bug fix or the new feature
