### PR TITLE
fix: make all rows being selectable for image list

### DIFF
--- a/packages/renderer/src/lib/image/ImagesList.svelte
+++ b/packages/renderer/src/lib/image/ImagesList.svelte
@@ -286,8 +286,7 @@ const columns: Column<ImageInfoUI>[] = [
 ];
 
 const row = new Row<ImageInfoUI>({
-  selectable: image => image.status === 'UNUSED',
-  disabledText: 'Image is used by a container',
+  selectable: () => true,
 });
 </script>
 


### PR DESCRIPTION
### What does this PR do?
Until now we were restricting the selection to images without having a running container
but then we can't apply other bulk operations like 'save'

Fixes it allows to select all images to save/export them to a tarball

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/6592


### How to test this PR?

See that now all lines can be selected

- [ ] Tests are covering the bug fix or the new feature
