### PR TITLE
feat: add navigateToAuthentication method to navigation API

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -4159,7 +4159,7 @@ declare module '@podman-desktop/api' {
     export function navigateToWebview(webviewId: string): Promise<void>;
 
     /**
-     * Navigate ot Authentication settings page
+     * Navigate to Authentication settings page
      */
     export function navigateToAuthentication(): Promise<void>;
   }

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -4157,6 +4157,11 @@ declare module '@podman-desktop/api' {
      * @see {@link window.createWebviewPanel createWebviewPanel} for creating a Webview
      */
     export function navigateToWebview(webviewId: string): Promise<void>;
+
+    /**
+     * Navigate ot Authentication settings page
+     */
+    export function navigateToAuthentication(): Promise<void>;
   }
 
   /**

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -1216,6 +1216,9 @@ export class ExtensionLoader {
       navigateToWebview: async (webviewId: string): Promise<void> => {
         await this.navigationManager.navigateToWebview(webviewId);
       },
+      navigateToAuthentication: async (): Promise<void> => {
+        await this.navigationManager.navigateToAuthentication();
+      },
     };
 
     const version = app.getVersion();

--- a/packages/main/src/plugin/navigation/navigation-manager.ts
+++ b/packages/main/src/plugin/navigation/navigation-manager.ts
@@ -207,4 +207,10 @@ export class NavigationManager {
       },
     });
   }
+
+  async navigateToAuthentication(): Promise<void> {
+    this.navigateTo({
+      page: NavigationPage.AUTHENTICATION,
+    });
+  }
 }

--- a/packages/main/src/plugin/navigation/navigation-page.ts
+++ b/packages/main/src/plugin/navigation/navigation-page.ts
@@ -32,4 +32,5 @@ export enum NavigationPage {
   TROUBLESHOOTING = 'troubleshooting',
   HELP = 'help',
   WEBVIEW = 'webview',
+  AUTHENTICATION = 'authentication',
 }

--- a/packages/renderer/src/navigation.ts
+++ b/packages/renderer/src/navigation.ts
@@ -79,5 +79,8 @@ export const handleNavigation = (page: NavigationPage, parameters?: { [key: stri
     case NavigationPage.WEBVIEW:
       router.goto(`/webviews/${parameters?.['id']}`);
       break;
+    case NavigationPage.AUTHENTICATION:
+      router.goto('/preferences/authentication-providers');
+      break;
   }
 };


### PR DESCRIPTION
### What does this PR do?

PR adds `async navigateToAuthentication(): Promise<void>` to API 'navigation' module to let extensions to navigate user to Authentication Settings page

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Going to be used in Red Hat SSO status item implementation (see https://github.com/redhat-developer/podman-desktop-redhat-account-ext/pull/91)

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
