### PR TITLE
chore(api): creating api package

### DIFF
--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -4,7 +4,6 @@
     "target": "esnext",
     "sourceMap": false,
     "moduleResolution": "Node",
-    "skipLibCheck": true,
     "strict": true,
     "allowSyntheticDefaultImports": true,
     "isolatedModules": true,

--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -16,5 +16,5 @@
       "/@/*": ["./src/*"]
     }
   },
-  "include": ["src/**/*.ts", "exposedInDockerExtension.d.ts", "../../types/**/*.d.ts", "../api/src/**/*.ts"]
+  "include": ["src/**/*.ts", "../../types/**/*.d.ts"]
 }

--- a/packages/api/vite.config.js
+++ b/packages/api/vite.config.js
@@ -22,7 +22,7 @@ import { builtinModules } from 'module';
 import { coverageConfig } from '../../vitest-shared-extensions.config';
 
 const PACKAGE_ROOT = __dirname;
-const PACKAGE_NAME = 'preload-docker-extension';
+const PACKAGE_NAME = 'api';
 
 /**
  * @type {import('vite').UserConfig}
@@ -35,17 +35,8 @@ const config = {
   resolve: {
     alias: {
       '/@/': join(PACKAGE_ROOT, 'src') + '/',
-      '/@api/': join(PACKAGE_ROOT, '../api/src') + '/',
     },
   },
-  /*plugins: [
-     commonjs({
-       dynamicRequireTargets: [
-         // include using a glob pattern (either a string or an array of strings)
-         'node_modules/ssh2/lib/protocol/crypto/poly1305.js',
-       ]
-       }),
-   ],*/
   build: {
     sourcemap: 'inline',
     target: `chrome${chrome}`,

--- a/packages/main/tsconfig.json
+++ b/packages/main/tsconfig.json
@@ -15,7 +15,7 @@
     "baseUrl": ".",
     "paths": {
       "/@/*": ["./src/*"],
-      "/@api/*": ["../api/src"]
+      "/@api/*": ["../api/src/*"]
     }
   },
   "include": ["src/**/*.ts", "../../types/**/*.d.ts", "../api/src/**/*.ts"]

--- a/packages/main/tsconfig.json
+++ b/packages/main/tsconfig.json
@@ -14,8 +14,9 @@
 
     "baseUrl": ".",
     "paths": {
-      "/@/*": ["./src/*"]
+      "/@/*": ["./src/*"],
+      "/@api/*": ["../api/src"]
     }
   },
-  "include": ["src/**/*.ts", "../../types/**/*.d.ts"]
+  "include": ["src/**/*.ts", "../../types/**/*.d.ts", "../api/src/**/*.ts"]
 }

--- a/packages/main/vite.config.js
+++ b/packages/main/vite.config.js
@@ -34,6 +34,7 @@ const config = {
   resolve: {
     alias: {
       '/@/': join(PACKAGE_ROOT, 'src') + '/',
+      '/@api/': join(PACKAGE_ROOT, '../api/src') + '/',
     },
   },
   build: {

--- a/packages/preload-docker-extension/tsconfig.json
+++ b/packages/preload-docker-extension/tsconfig.json
@@ -13,7 +13,8 @@
 
     "baseUrl": ".",
     "paths": {
-      "/@/*": ["./src/*"]
+      "/@/*": ["./src/*"],
+      "/@api/*": ["../api/src/*"]
     }
   },
   "include": ["src/**/*.ts", "exposedInDockerExtension.d.ts", "../../types/**/*.d.ts", "../api/src/**/*.ts"]

--- a/packages/preload-webview/tsconfig.json
+++ b/packages/preload-webview/tsconfig.json
@@ -13,8 +13,9 @@
 
     "baseUrl": ".",
     "paths": {
-      "/@/*": ["./src/*"]
+      "/@/*": ["./src/*"],
+      "/@api/*": ["../api/src"]
     }
   },
-  "include": ["src/**/*.ts", "exposedInWebview.d.ts", "../../types/**/*.d.ts"]
+  "include": ["src/**/*.ts", "exposedInWebview.d.ts", "../../types/**/*.d.ts", "../api/src/**/*.ts"]
 }

--- a/packages/preload-webview/tsconfig.json
+++ b/packages/preload-webview/tsconfig.json
@@ -14,7 +14,7 @@
     "baseUrl": ".",
     "paths": {
       "/@/*": ["./src/*"],
-      "/@api/*": ["../api/src"]
+      "/@api/*": ["../api/src/*"]
     }
   },
   "include": ["src/**/*.ts", "exposedInWebview.d.ts", "../../types/**/*.d.ts", "../api/src/**/*.ts"]

--- a/packages/preload-webview/vite.config.js
+++ b/packages/preload-webview/vite.config.js
@@ -35,6 +35,7 @@ const config = {
   resolve: {
     alias: {
       '/@/': join(PACKAGE_ROOT, 'src') + '/',
+      '/@api/': join(PACKAGE_ROOT, '../api/src') + '/',
     },
   },
   build: {

--- a/packages/preload/tsconfig.json
+++ b/packages/preload/tsconfig.json
@@ -14,7 +14,7 @@
     "baseUrl": ".",
     "paths": {
       "/@/*": ["./src/*"],
-      "/@api/*": ["../api/src"]
+      "/@api/*": ["../api/src/*"]
     }
   },
   "include": ["src/**/*.ts", "exposedInMainWorld.d.ts", "../../types/**/*.d.ts", "../api/src/**/*.ts"]

--- a/packages/preload/tsconfig.json
+++ b/packages/preload/tsconfig.json
@@ -13,8 +13,9 @@
 
     "baseUrl": ".",
     "paths": {
-      "/@/*": ["./src/*"]
+      "/@/*": ["./src/*"],
+      "/@api/*": ["../api/src"]
     }
   },
-  "include": ["src/**/*.ts", "exposedInMainWorld.d.ts", "../../types/**/*.d.ts"]
+  "include": ["src/**/*.ts", "exposedInMainWorld.d.ts", "../../types/**/*.d.ts", "../api/src/**/*.ts"]
 }

--- a/packages/preload/vite.config.js
+++ b/packages/preload/vite.config.js
@@ -1,12 +1,12 @@
 /**********************************************************************
  * Copyright (C) 2023 Red Hat, Inc.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,9 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import {chrome} from '../../.electron-vendors.cache.json';
-import {join} from 'path';
-import {builtinModules} from 'module';
+import { chrome } from '../../.electron-vendors.cache.json';
+import { join } from 'path';
+import { builtinModules } from 'module';
 import { coverageConfig } from '../../vitest-shared-extensions.config';
 
 const PACKAGE_ROOT = __dirname;
@@ -35,6 +35,7 @@ const config = {
   resolve: {
     alias: {
       '/@/': join(PACKAGE_ROOT, 'src') + '/',
+      '/@api/': join(PACKAGE_ROOT, '../api/src') + '/',
     },
   },
   /*plugins: [
@@ -56,10 +57,7 @@ const config = {
       formats: ['cjs'],
     },
     rollupOptions: {
-      external: [
-        'electron',
-        ...builtinModules.flatMap(p => [p, `node:${p}`]),
-      ],
+      external: ['electron', ...builtinModules.flatMap(p => [p, `node:${p}`])],
       output: {
         entryFileNames: '[name].cjs',
       },

--- a/packages/renderer/tsconfig.json
+++ b/packages/renderer/tsconfig.json
@@ -9,7 +9,7 @@
     "baseUrl": ".",
     "paths": {
       "/@/*": ["./src/*"],
-      "/@api/*": ["../api/src"]
+      "/@api/*": ["../api/src/*"]
     },
     /**
      * Typecheck JS in `.svelte` and `.js` files by default.

--- a/packages/renderer/tsconfig.json
+++ b/packages/renderer/tsconfig.json
@@ -8,7 +8,8 @@
     "preserveValueImports": false,
     "baseUrl": ".",
     "paths": {
-      "/@/*": ["./src/*"]
+      "/@/*": ["./src/*"],
+      "/@api/*": ["../api/src"]
     },
     /**
      * Typecheck JS in `.svelte` and `.js` files by default.
@@ -26,6 +27,7 @@
     "src/**/*.svelte",
     "types/**/*.d.ts",
     "../../types/**/*.d.ts",
-    "../preload/exposedInMainWorld.d.ts"
+    "../preload/exposedInMainWorld.d.ts",
+    "../api/src/**/*.ts"
   ]
 }

--- a/packages/renderer/vite.config.js
+++ b/packages/renderer/vite.config.js
@@ -35,6 +35,7 @@ export default defineConfig({
   resolve: {
     alias: {
       '/@/': join(PACKAGE_ROOT, 'src') + '/',
+      '/@api/': join(PACKAGE_ROOT, '../api/src') + '/',
     },
   },
   plugins: [svelte({ hot: !process.env.VITEST })],
@@ -50,11 +51,9 @@ export default defineConfig({
       { find: /^svelte$/, replacement: 'svelte/internal' },
     ],
     deps: {
-      inline: [
-        'moment',
-      ],
+      inline: ['moment'],
     },
-      ...coverageConfig(PACKAGE_ROOT, PACKAGE_NAME),
+    ...coverageConfig(PACKAGE_ROOT, PACKAGE_NAME),
   },
   base: '',
   server: {


### PR DESCRIPTION
### What does this PR do?

Moving directly all `packages/main/src/plugin/api` in one PR would make it hard to review due to the numbers of import that would be impacted. This first PR create the `packages/api` folder, and set the required configuration in the packages that will use the `/@api/*`.

⚠️ Packages that will not use the api are: `packages/ui` and `packages/extension-api`.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Related to https://github.com/containers/podman-desktop/issues/6300

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
