### PR TITLE
fix: hide restart action for kubernetes pods

### DIFF
--- a/packages/renderer/src/lib/pod/PodActions.spec.ts
+++ b/packages/renderer/src/lib/pod/PodActions.spec.ts
@@ -20,7 +20,7 @@ import '@testing-library/jest-dom/vitest';
 
 import type { ContainerInfo, Port } from '@podman-desktop/api';
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
-import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import PodActions from './PodActions.svelte';
 import type { PodInfoUI } from './PodInfoUI';
@@ -193,4 +193,20 @@ test('Expect kubernetes routes kebab menu to be displayed', async () => {
 
   const routesDropDownMenu = await screen.findByTitle('Drop Down Menu Items');
   expect(routesDropDownMenu).toBeVisible();
+});
+
+describe('restart action', () => {
+  test('Expect podman pod to have restart action', async () => {
+    render(PodActions, { pod: podmanPod });
+
+    const restartPodButton = await screen.findByRole('button', { name: `Restart Pod` });
+    expect(restartPodButton).toBeVisible();
+  });
+
+  test('Expect kubernetes pod not to have restart action', async () => {
+    render(PodActions, { pod: kubernetesPod });
+
+    const restartPodButton = screen.queryByRole('button', { name: `Restart Pod` });
+    expect(restartPodButton).toBeNull();
+  });
 });

--- a/packages/renderer/src/lib/pod/PodActions.svelte
+++ b/packages/renderer/src/lib/pod/PodActions.svelte
@@ -233,6 +233,12 @@ if (dropdownMenu) {
         {/each}
       </DropdownMenu>
     {/if}
+    <ListItemButtonIcon
+      title="Restart Pod"
+      onClick="{() => restartPod()}"
+      menu="{dropdownMenu}"
+      detailed="{detailed}"
+      icon="{faArrowsRotate}" />
   {/if}
   {#if pod.kind === 'kubernetes'}
     {#if openingKubernetesUrls.size === 0}
@@ -271,12 +277,6 @@ if (dropdownMenu) {
       </DropdownMenu>
     {/if}
   {/if}
-  <ListItemButtonIcon
-    title="Restart Pod"
-    onClick="{() => restartPod()}"
-    menu="{dropdownMenu}"
-    detailed="{detailed}"
-    icon="{faArrowsRotate}" />
   <ContributionActions
     args="{[pod]}"
     contextPrefix="podItem"


### PR DESCRIPTION
### What does this PR do?

This PR is hidding the `Restart Pod` action. There is no api to restart a pod in kubectl, so it does not make sense to have restart abilities.

The issue https://github.com/containers/podman-desktop/issues/6381 was showing, that when the `Restart Pod` action is triggered on a Kubernetes pod, the code is calling the restart podman pod, which is not compatible.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop/issues/6381

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
