### PR TITLE
feat: add createManifest API

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -285,6 +285,16 @@ declare module '@podman-desktop/api' {
     provider?: ContainerProviderConnection;
   }
 
+  export interface ManifestCreateOptions {
+    images: string[];
+    name: string;
+    amend?: boolean;
+    all?: boolean;
+
+    // Provider to use for the manifest creation, if not, we will try to select the first one available (similar to podCreate)
+    provider?: ContainerProviderConnection;
+  }
+
   export interface KubernetesProviderConnectionEndpoint {
     apiURL: string;
   }
@@ -3367,6 +3377,9 @@ declare module '@podman-desktop/api' {
     export function listPods(): Promise<PodInfo[]>;
     export function stopPod(engineId: string, podId: string): Promise<void>;
     export function removePod(engineId: string, podId: string): Promise<void>;
+
+    // Manifest related methods
+    export function createManifest(options: ManifestCreateOptions): Promise<{ Id: string }>;
   }
 
   /**

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -3379,7 +3379,7 @@ declare module '@podman-desktop/api' {
     export function removePod(engineId: string, podId: string): Promise<void>;
 
     // Manifest related methods
-    export function createManifest(options: ManifestCreateOptions): Promise<{ Id: string }>;
+    export function createManifest(options: ManifestCreateOptions): Promise<{ engineId: string; Id: string }>;
   }
 
   /**

--- a/packages/main/src/plugin/api/manifest-info.ts
+++ b/packages/main/src/plugin/api/manifest-info.ts
@@ -1,0 +1,29 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { ContainerProviderConnection } from '@podman-desktop/api';
+
+export interface ManifestCreateOptions {
+  images: string[];
+  name: string;
+  amend?: boolean;
+  all?: boolean;
+
+  // Provider to use for the manifest creation, if not, we will try to select the first one available (similar to podCreate)
+  provider?: ContainerProviderConnection;
+}

--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -3131,6 +3131,71 @@ test('check volume mounted is replicated when executing replicatePodmanContainer
   });
 });
 
+test('check that createManifest returns an Id value after running podmanCreateManifest', async () => {
+  const createManifestMock = vi.fn().mockResolvedValue({
+    Id: 'testid1',
+  });
+
+  const fakeLibPod = {
+    podmanCreateManifest: createManifestMock,
+  } as unknown as LibPod;
+
+  containerRegistry.addInternalProvider('podman1', {
+    name: 'podman',
+    id: 'podman1',
+    libpodApi: fakeLibPod,
+    connection: {
+      type: 'podman',
+    },
+  } as unknown as InternalContainerProvider);
+
+  const result = await containerRegistry.createManifest({
+    name: 'manifest',
+    images: ['image1', 'image2'],
+  });
+
+  expect(result.Id).toBe('testid1');
+});
+
+test('check that createManifest errors with The matching provider does not support the Podman API if the provider has no libpodApi', async () => {
+  const fakeDockerode = {
+    createManifest: vi.fn(),
+  } as unknown as LibPod;
+
+  const internalProvider = {
+    name: 'podman1',
+    id: 'podman1',
+    connection: {
+      name: 'podman1',
+      type: 'podman',
+      endpoint: {
+        socketPath: 'podman.sock',
+      },
+    },
+    // Purposely NOT have libpodApi, but just have normal api
+    api: fakeDockerode,
+  } as unknown as InternalContainerProvider;
+
+  containerRegistry.addInternalProvider('podman1', internalProvider);
+
+  const containerProviderConnection: podmanDesktopAPI.ContainerProviderConnection = {
+    name: 'podman1',
+    endpoint: {
+      socketPath: 'podman.sock',
+    },
+    status: vi.fn(),
+    type: 'podman',
+  };
+
+  await expect(
+    containerRegistry.createManifest({
+      name: 'manifest',
+      images: ['image1', 'image2'],
+      provider: containerProviderConnection,
+    }),
+  ).rejects.toThrowError('The matching provider does not support the Podman API');
+});
+
 test('check createPod uses running podman connection if no selectedProvider is provided', async () => {
   const createPodMock = vi.fn().mockResolvedValue({
     Id: 'id',

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -1225,7 +1225,7 @@ export class ContainerProviderRegistry {
     }
   }
 
-  async createManifest(manifestOptions: ManifestCreateOptions): Promise<{ Id: string }> {
+  async createManifest(manifestOptions: ManifestCreateOptions): Promise<{ engineId: string; Id: string }> {
     let telemetryOptions = {};
     try {
       let internalContainerProvider: InternalContainerProvider;
@@ -1243,7 +1243,7 @@ export class ContainerProviderRegistry {
       }
 
       const result = await internalContainerProvider.libpodApi.podmanCreateManifest(manifestOptions);
-      return { Id: result.Id };
+      return { engineId: internalContainerProvider.id, Id: result.Id };
     } catch (error) {
       telemetryOptions = { error: error };
       throw error;

--- a/packages/main/src/plugin/dockerode/libpod-dockerode.spec.ts
+++ b/packages/main/src/plugin/dockerode/libpod-dockerode.spec.ts
@@ -183,3 +183,13 @@ test('Check labels are passed to the api when creating a pod', async () => {
     },
   });
 });
+
+test('Check using libpod/manifests/ endpoint', async () => {
+  nock('http://localhost').post('/v4.2.0/libpod/manifests/name1').reply(201, { Id: 'testId1' });
+  const api = new Dockerode({ protocol: 'http', host: 'localhost' });
+  const manifest = await (api as unknown as LibPod).podmanCreateManifest({
+    name: 'name1',
+    images: ['image1', 'image2'],
+  });
+  expect(manifest.Id).toBe('testId1');
+});

--- a/packages/main/src/plugin/dockerode/libpod-dockerode.ts
+++ b/packages/main/src/plugin/dockerode/libpod-dockerode.ts
@@ -348,7 +348,7 @@ export interface LibPod {
   pruneAllImages(dangling: boolean): Promise<void>;
   podmanInfo(): Promise<Info>;
   getImages(options: GetImagesOptions): Promise<NodeJS.ReadableStream>;
-  podmanCreateManifest(manifestOptions: ManifestCreateOptions): Promise<{ Id: string }>;
+  podmanCreateManifest(manifestOptions: ManifestCreateOptions): Promise<{ engineId: string; Id: string }>;
 }
 
 // tweak Dockerode by adding the support of libpod API

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -1047,7 +1047,9 @@ export class ExtensionLoader {
       removePod(engineId: string, podId: string): Promise<void> {
         return containerProviderRegistry.removePod(engineId, podId);
       },
-      createManifest(manifestOptions: containerDesktopAPI.ManifestCreateOptions): Promise<{ Id: string }> {
+      createManifest(
+        manifestOptions: containerDesktopAPI.ManifestCreateOptions,
+      ): Promise<{ engineId: string; Id: string }> {
         return containerProviderRegistry.createManifest(manifestOptions);
       },
       replicatePodmanContainer(

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -1047,6 +1047,9 @@ export class ExtensionLoader {
       removePod(engineId: string, podId: string): Promise<void> {
         return containerProviderRegistry.removePod(engineId, podId);
       },
+      createManifest(manifestOptions: containerDesktopAPI.ManifestCreateOptions): Promise<{ Id: string }> {
+        return containerProviderRegistry.createManifest(manifestOptions);
+      },
       replicatePodmanContainer(
         source: { engineId: string; id: string },
         target: { engineId: string },

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -82,6 +82,7 @@ import type { IconInfo } from './api/icon-info.js';
 import type { ImageCheckerInfo } from './api/image-checker-info.js';
 import type { ImageInfo } from './api/image-info.js';
 import type { ImageInspectInfo } from './api/image-inspect-info.js';
+import type { ManifestCreateOptions } from './api/manifest-info.js';
 import type { NetworkInspectInfo } from './api/network-info.js';
 import type { NotificationCard, NotificationCardOptions } from './api/notification.js';
 import type { OnboardingInfo, OnboardingStatus } from './api/onboarding.js';
@@ -750,6 +751,15 @@ export class PluginSystem {
         return containerProviderRegistry.removePod(engine, podId);
       },
     );
+
+    // manifest
+    this.ipcHandle(
+      'container-provider-registry:createManifest',
+      async (_listener, manifestOptions: ManifestCreateOptions): Promise<{ Id: string }> => {
+        return containerProviderRegistry.createManifest(manifestOptions);
+      },
+    );
+
     this.ipcHandle(
       'container-provider-registry:generatePodmanKube',
       async (_listener, engine: string, names: string[]): Promise<string> => {

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -755,7 +755,7 @@ export class PluginSystem {
     // manifest
     this.ipcHandle(
       'container-provider-registry:createManifest',
-      async (_listener, manifestOptions: ManifestCreateOptions): Promise<{ Id: string }> => {
+      async (_listener, manifestOptions: ManifestCreateOptions): Promise<{ engineId: string; Id: string }> => {
         return containerProviderRegistry.createManifest(manifestOptions);
       },
     );

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -286,7 +286,7 @@ export function initExposure(): void {
   // Manifest
   contextBridge.exposeInMainWorld(
     'createManifest',
-    async (createOptions: ManifestCreateOptions): Promise<{ Id: string }> => {
+    async (createOptions: ManifestCreateOptions): Promise<{ engineId: string; Id: string }> => {
       return ipcInvoke('container-provider-registry:createManifest', createOptions);
     },
   );

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -62,6 +62,7 @@ import type { ImageCheckerInfo } from '../../main/src/plugin/api/image-checker-i
 import type { ImageInfo } from '../../main/src/plugin/api/image-info';
 import type { ImageInspectInfo } from '../../main/src/plugin/api/image-inspect-info';
 import type { KubernetesGeneratorInfo } from '../../main/src/plugin/api/KubernetesGeneratorInfo';
+import type { ManifestCreateOptions } from '../../main/src/plugin/api/manifest-info';
 import type { NetworkInspectInfo } from '../../main/src/plugin/api/network-info';
 import type { NotificationCard, NotificationCardOptions } from '../../main/src/plugin/api/notification';
 import type { OnboardingInfo, OnboardingStatus } from '../../main/src/plugin/api/onboarding';
@@ -281,6 +282,14 @@ export function initExposure(): void {
   contextBridge.exposeInMainWorld('restartPod', async (engine: string, podId: string): Promise<void> => {
     return ipcInvoke('container-provider-registry:restartPod', engine, podId);
   });
+
+  // Manifest
+  contextBridge.exposeInMainWorld(
+    'createManifest',
+    async (createOptions: ManifestCreateOptions): Promise<{ Id: string }> => {
+      return ipcInvoke('container-provider-registry:createManifest', createOptions);
+    },
+  );
 
   /**
    * @deprecated This method is deprecated and will be removed in a future release.


### PR DESCRIPTION
feat: add createManifest API

### What does this PR do?

Adds the createManifest API modelled by https://docs.podman.io/en/latest/_static/api.html#tag/manifests/operation/ManifestCreateLibpod

You'll be able to pass in createManifestOptions with the name as well as
an array of image names and be able to create a manifest.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/A

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop/issues/6624

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature

Either through tests or you can also do the following in a svelte file:

```ts
    const options: ManifestCreateOptions = {
      name: containerImageName,
      images: [
        containerImageName],

    };
    await window.createManifest(options);
```

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
