### PR TITLE
fix: airgap mode and default for podman v5

### DIFF
--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -1730,8 +1730,11 @@ export async function createMachine(
       suffix = `-${process.arch}.qcow2.xz`;
     }
     const assetImagePath = path.resolve(getAssetsFolder(), `podman-image${suffix}`);
+
+    const podmanInstallation = await getPodmanInstallation();
+
     // check if the file exists and if it does, use it
-    if (fs.existsSync(assetImagePath)) {
+    if (fs.existsSync(assetImagePath) && podmanInstallation.version.startsWith('4.')) {
       parameters.push('--image-path');
       parameters.push(assetImagePath);
       telemetryRecords.imagePath = 'embedded';

--- a/extensions/podman/src/podman-install.ts
+++ b/extensions/podman/src/podman-install.ts
@@ -64,7 +64,20 @@ export function getBundledPodmanVersion(): string {
       !fs.existsSync(path.resolve(os.homedir(), '.config/containers/podman')) &&
       !fs.existsSync(path.resolve(os.homedir(), '.local/share/containers/podman'));
   }
-  if (podman5ExperimentalModeEnabled || noPreviousPodmanInstallation) {
+
+  // air gapped mode check.
+  const assetImagePath = path.resolve(getAssetsFolder());
+  let airGappedMode = false;
+  // check if we have some podman-image files
+  if (fs.existsSync(assetImagePath)) {
+    const podmanImageFiles = fs.readdirSync(assetImagePath).filter(file => file.startsWith('podman-image'));
+    if (podmanImageFiles.length > 0) {
+      airGappedMode = true;
+    }
+  }
+
+  // default to v5 if experimental mode is enabled or if there is no previous installation (and not using airgapped mode)
+  if (podman5ExperimentalModeEnabled || (noPreviousPodmanInstallation && !airGappedMode)) {
     return podman5JSON.version;
   }
 


### PR DESCRIPTION
### What does this PR do?
with airgap installer, podman v4 should be the default else it will install podman v5 but the image will be fetched remotely so it will fail in 'airgapped mode'

and if user manually toggle v5, it should not try to init the machine using the v4 image


### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/6617

### How to test this PR?

Use airgap installer on a fresh computer (no podman install)
it means no `~/.local/share/containers/podman` and `~/.config/containers/podman` folders

airgap installer = default to v4 (and not v5)

and if using v5, the embedded image is not used, it'll try to fetch from internet

- [x] Tests are covering the bug fix or the new feature
