### PR TITLE
fix: provide correct return value for the method

### DIFF
--- a/packages/main/src/plugin/kubernetes-client.spec.ts
+++ b/packages/main/src/plugin/kubernetes-client.spec.ts
@@ -658,7 +658,7 @@ test('should return route list if connection to cluster is ok', async () => {
     getCode: () => Promise.resolve({ body: { gitVersion: 'v1.20.0' } }),
     listNamespacedCustomObject: () =>
       Promise.resolve({
-        body: [v1Route],
+        body: { items: [v1Route] },
       }),
   });
 

--- a/packages/main/src/plugin/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes-client.ts
@@ -25,6 +25,7 @@ import { PassThrough } from 'node:stream';
 import type {
   Cluster,
   Context,
+  KubernetesListObject,
   KubernetesObject,
   V1APIGroup,
   V1APIResource,
@@ -625,7 +626,8 @@ export class KubernetesClient {
         // Get the routes via the kubernetes api
         const customObjectsApi = this.kubeConfig.makeApiClient(CustomObjectsApi);
         const routes = await customObjectsApi.listNamespacedCustomObject('route.openshift.io', 'v1', ns, 'routes');
-        return routes.body as V1Route[];
+        const body = routes.body as KubernetesListObject<V1Route>;
+        return body.items;
       } catch (_) {
         // catch 404 error
         // do nothing

--- a/packages/renderer/src/lib/pod/PodActions.svelte
+++ b/packages/renderer/src/lib/pod/PodActions.svelte
@@ -13,7 +13,6 @@ import { router } from 'tinro';
 
 import ContributionActions from '/@/lib/actions/ContributionActions.svelte';
 
-import type { V1Route } from '../../../../main/src/plugin/api/openshift-types';
 import type { Menu } from '../../../../main/src/plugin/menu-registry';
 import { MenuContext } from '../../../../main/src/plugin/menu-registry';
 import { ContainerUtils } from '../container/container-utils';
@@ -62,10 +61,8 @@ onMount(async () => {
       if (kubepod?.metadata?.labels?.app) {
         const appName = kubepod.metadata.labels.app;
         const routes = await window.kubernetesListRoutes();
-        const appRoutes: V1Route[] = (routes as any).items.filter(
-          (r: V1Route) => r.metadata.labels && r.metadata.labels['app'] === appName,
-        );
-        appRoutes.forEach((route: V1Route) => {
+        const appRoutes = routes.filter(r => r.metadata.labels && r.metadata.labels['app'] === appName);
+        appRoutes.forEach(route => {
           openingKubernetesUrls = openingKubernetesUrls.set(
             route.metadata.name,
             route.spec.tls ? `https://${route.spec.host}` : `http://${route.spec.host}`,


### PR DESCRIPTION
### What does this PR do?
The method contract was invalid but then the client was changing the expected value to match the real value
so here just fix the returned value so the client does not need to change the return type

### Screenshot / video of UI


### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/6631

### How to test this PR?

go to pods details view with a non OpenShift cluster, you should no longer see errors in the console

- [x] Tests are covering the bug fix or the new feature
