### PR TITLE
fix: adjust import containers page

### DIFF
--- a/packages/renderer/src/lib/image/ImportContainersImages.svelte
+++ b/packages/renderer/src/lib/image/ImportContainersImages.svelte
@@ -153,20 +153,21 @@ async function importContainers() {
         </div>
       {/each}
 
-      <div class="pt-5 border-zinc-600 border-t-2"></div>
-      <Button
-        on:click="{() => importContainers()}"
-        inProgress="{inProgress}"
-        class="w-full"
-        icon="{faPlay}"
-        aria-label="Import containers"
-        bind:disabled="{importDisabled}">
-        Import Containers
-      </Button>
-      <div aria-label="importError">
-        {#if importError !== ''}
-          <ErrorMessage class="py-2 text-sm" error="{importError}" />
-        {/if}
+      <div class="pt-5">
+        <Button
+          on:click="{() => importContainers()}"
+          inProgress="{inProgress}"
+          class="w-full"
+          icon="{faPlay}"
+          aria-label="Import containers"
+          bind:disabled="{importDisabled}">
+          Import Containers
+        </Button>
+        <div aria-label="importError">
+          {#if importError !== ''}
+            <ErrorMessage class="py-2 text-sm" error="{importError}" />
+          {/if}
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
### What does this PR do?

This was a quick fix i forgot to add after the comment I received by Tim on the load images page -> https://github.com/containers/podman-desktop/pull/6540#discussion_r1539272375

the import containers PR was already merged so this patch updates the design by removing the divider to make it similar to the load images page.
Nothing else changes

### Screenshot / video of UI

![image](https://github.com/containers/podman-desktop/assets/49404737/57d35e56-c9aa-4995-8237-561c6de5aa96)

### What issues does this PR fix or reference?

N/A

### How to test this PR?

N/A

- [x] Tests are covering the bug fix or the new feature
