### PR TITLE
fix(featured-extension): make limit configurable

### DIFF
--- a/packages/main/src/plugin/featured/featured.spec.ts
+++ b/packages/main/src/plugin/featured/featured.spec.ts
@@ -121,7 +121,7 @@ test('getFeaturedExtensions should check installable extensions', async () => {
   expect(crcExtension?.fetchLink).toBe(ociLink);
 });
 
-test('getFeaturedExtensions should shuffle and limit to 6 extensions', async () => {
+test('getFeaturedExtensions should shuffle and limit to 6 extensions by default', async () => {
   // mock the set of featured JSON extensions
   const spyReadJson = vi.spyOn(featured, 'readFeaturedJson');
 
@@ -157,4 +157,58 @@ test('getFeaturedExtensions should shuffle and limit to 6 extensions', async () 
 
   // check that the 2 lists are not the same
   expect(idsList1).not.toStrictEqual(idsList2);
+});
+
+test('getFeaturedExtensions have no limit when calling with -1', async () => {
+  // mock the set of featured JSON extensions
+  const spyReadJson = vi.spyOn(featured, 'readFeaturedJson');
+
+  const jsonValues = [];
+  for (let i = 1; i <= 10; i++) {
+    jsonValues.push({
+      extensionId: `podman-desktop.${i}`,
+      displayName: `Podman${i}`,
+      shortDescription: `test${i}`,
+      categories: ['Container Engine'],
+      builtIn: true,
+      icon: `data:image/png;base64,${i}`,
+    });
+  }
+  spyReadJson.mockReturnValue(jsonValues);
+
+  // init fetchable extensions
+  await featured.init();
+  const featuredExtensions1 = await featured.getFeaturedExtensions(-1);
+
+  expect(featuredExtensions1).toBeDefined();
+
+  // should not be limited
+  expect(featuredExtensions1.length).toBe(10);
+});
+
+test('getFeaturedExtensions should limit the number of item returned with the provided value', async () => {
+  // mock the set of featured JSON extensions
+  const spyReadJson = vi.spyOn(featured, 'readFeaturedJson');
+
+  const jsonValues = [];
+  for (let i = 1; i <= 10; i++) {
+    jsonValues.push({
+      extensionId: `podman-desktop.${i}`,
+      displayName: `Podman${i}`,
+      shortDescription: `test${i}`,
+      categories: ['Container Engine'],
+      builtIn: true,
+      icon: `data:image/png;base64,${i}`,
+    });
+  }
+  spyReadJson.mockReturnValue(jsonValues);
+
+  // init fetchable extensions
+  await featured.init();
+  const featuredExtensions1 = await featured.getFeaturedExtensions(3);
+
+  expect(featuredExtensions1).toBeDefined();
+
+  // should be limited to 3
+  expect(featuredExtensions1.length).toBe(3);
 });

--- a/packages/main/src/plugin/featured/featured.ts
+++ b/packages/main/src/plugin/featured/featured.ts
@@ -46,8 +46,9 @@ export class Featured {
   /**
    * Return the list of featured extensions
    * and check if they are installed/available/etc
+   * @param limit the maximum number of feature extension returned. Default 6, use -1 for no limit
    */
-  async getFeaturedExtensions(): Promise<FeaturedExtension[]> {
+  async getFeaturedExtensions(limit: number = 6): Promise<FeaturedExtension[]> {
     const extensionsToCheck = this.readFeaturedJson();
 
     // get the list of all the installed extensions
@@ -94,9 +95,9 @@ export class Featured {
     // shuffle the list of featured extensions
     featuredExtensions.sort(() => Math.random() - 0.5);
 
-    // take only 6 of them
-    if (featuredExtensions.length > 6) {
-      featuredExtensions.splice(6);
+    // take only a portion of them
+    if (limit > 0 && featuredExtensions.length > limit) {
+      featuredExtensions.splice(limit);
     }
 
     // and then by non installed first

--- a/packages/main/src/plugin/featured/featured.ts
+++ b/packages/main/src/plugin/featured/featured.ts
@@ -96,7 +96,7 @@ export class Featured {
     featuredExtensions.sort(() => Math.random() - 0.5);
 
     // take only a portion of them
-    if (limit > 0 && featuredExtensions.length > limit) {
+    if (limit >= 0 && featuredExtensions.length > limit) {
       featuredExtensions.splice(limit);
     }
 


### PR DESCRIPTION
### What does this PR do?

This PR is required to make https://github.com/containers/podman-desktop/issues/6215 possible. As we need to have a way, to get all featured extension, and not only the first 6.

This PR is moving out the hardcoded value from the core of the method, to a `limit` argument with a default value. This makes is compatible with any existing usage, while keeping existing behaviour, but allowing new caller to get all by changing this value to `-1`

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop/issues/6656

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
