### PR TITLE
feat: add podmanListImages API

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -1844,6 +1844,33 @@ declare module '@podman-desktop/api' {
     generate(kubernetesGeneratorArguments: KubernetesGeneratorArgument[]): Promise<GenerateKubeResult>;
   }
 
+  export interface PodmanListImagesOptions {
+    /**
+     * Show all images. By default all images from a final layer (no children) are shown.
+     * @defaultValue false
+     */
+    all?: boolean;
+
+    /**
+     * A JSON encoded value of the filters (a map[string][]string) to process on the images list. Available filters:
+     * - before=(<image-name>[:<tag>], <image id> or <image@digest>)
+     * - dangling=true
+     * - label=key or label="key=value" of an image label
+     * - reference=(<image-name>[:<tag>])
+     * - since=(<image-name>[:<tag>], <image id> or <image@digest>)
+     *
+     * @defaultValue undefined
+     */
+    filters?: string;
+
+    /**
+     * The provider we want to list the images. If not provided, will return all container images across all container engines.
+     *
+     * @defaultValue undefined
+     */
+    provider?: ContainerProviderConnection;
+  }
+
   export interface ImageInfo {
     engineId: string;
     engineName: string;
@@ -3267,6 +3294,30 @@ declare module '@podman-desktop/api' {
      * console.log(images);
      */
     export function listImages(options?: ListImagesOptions): Promise<ImageInfo[]>;
+
+    /**
+     * List podman container images from the Podman engine. This is a podman specific method that uses the libpod API and matches the API call
+     * including parameters and return values.
+     *
+     * @param options optional options for listing images
+     * @returns A promise resolving to an array of images information. This method returns a subset of the available information for images. To get the complete description of a specific image, you can use the {@link containerEngine.getImageInspect} method.
+     *
+     * @example
+     * // Example 1: List all podman container images
+     * const images = await podmanListImages();
+     * console.log(images);
+     *
+     * @example
+     * // Example 2: List podman container images using filters
+     * const images = await podmanListImages({ filters: { dangling: ['true'] } });
+     * console.log(images);
+     *
+     * @example
+     * // Example 3: List all images including children images
+     * const images = await podmanListImages({ all: true });
+     * console.log(images);
+     */
+    export function podmanListImages(options?: PodmanListImagesOptions): Promise<ImageInfo[]>;
 
     /**
      * Tag an image so that it becomes part of a repository

--- a/packages/main/src/plugin/api/image-info.ts
+++ b/packages/main/src/plugin/api/image-info.ts
@@ -188,3 +188,30 @@ export interface ListImagesOptions {
    */
   provider?: ContainerProviderConnection;
 }
+
+export interface PodmanListImagesOptions {
+  /**
+   * Show all images. By default all images from a final layer (no children) are shown.
+   * @defaultValue false
+   */
+  all?: boolean;
+
+  /**
+   * A JSON encoded value of the filters (a map[string][]string) to process on the images list. Available filters:
+   * - before=(<image-name>[:<tag>], <image id> or <image@digest>)
+   * - dangling=true
+   * - label=key or label="key=value" of an image label
+   * - reference=(<image-name>[:<tag>])
+   * - since=(<image-name>[:<tag>], <image id> or <image@digest>)
+   *
+   * @defaultValue undefined
+   */
+  filters?: string;
+
+  /**
+   * The provider we want to list the images. If not provided, will return all container images across all container engines.
+   *
+   * @defaultValue undefined
+   */
+  provider?: ContainerProviderConnection;
+}

--- a/packages/main/src/plugin/dockerode/libpod-dockerode.ts
+++ b/packages/main/src/plugin/dockerode/libpod-dockerode.ts
@@ -18,6 +18,8 @@
 
 import Dockerode from 'dockerode';
 
+import type { ImageInfo, PodmanListImagesOptions } from '../api/image-info.js';
+
 export interface PodContainerInfo {
   Id: string;
   Names: string;
@@ -347,6 +349,7 @@ export interface LibPod {
   pruneAllImages(dangling: boolean): Promise<void>;
   podmanInfo(): Promise<Info>;
   getImages(options: GetImagesOptions): Promise<NodeJS.ReadableStream>;
+  podmanListImages(options?: PodmanListImagesOptions): Promise<ImageInfo[]>;
 }
 
 // tweak Dockerode by adding the support of libpod API
@@ -396,6 +399,27 @@ export class LibpodDockerode {
         },
       };
 
+      return new Promise((resolve, reject) => {
+        this.modem.dial(optsf, (err: unknown, data: unknown) => {
+          if (err) {
+            return reject(err);
+          }
+          resolve(data);
+        });
+      });
+    };
+
+    // add listImages
+    prototypeOfDockerode.podmanListImages = function (options?: PodmanListImagesOptions): Promise<unknown> {
+      const optsf = {
+        path: '/v4.2.0/libpod/images/json',
+        method: 'GET',
+        options: options,
+        statusCodes: {
+          200: true,
+          500: 'server error',
+        },
+      };
       return new Promise((resolve, reject) => {
         this.modem.dial(optsf, (err: unknown, data: unknown) => {
           if (err) {

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -979,6 +979,11 @@ export class ExtensionLoader {
       listImages(options?: containerDesktopAPI.ListImagesOptions): Promise<containerDesktopAPI.ImageInfo[]> {
         return containerProviderRegistry.listImages(options);
       },
+      podmanListImages(
+        options?: containerDesktopAPI.PodmanListImagesOptions,
+      ): Promise<containerDesktopAPI.ImageInfo[]> {
+        return containerProviderRegistry.podmanListImages(options);
+      },
       saveImage(engineId: string, id: string, filename: string) {
         return containerProviderRegistry.saveImage(engineId, id, filename);
       },

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -80,7 +80,7 @@ import type { ExtensionInfo } from './api/extension-info.js';
 import type { HistoryInfo } from './api/history-info.js';
 import type { IconInfo } from './api/icon-info.js';
 import type { ImageCheckerInfo } from './api/image-checker-info.js';
-import type { ImageInfo } from './api/image-info.js';
+import type { ImageInfo, PodmanListImagesOptions } from './api/image-info.js';
 import type { ImageInspectInfo } from './api/image-inspect-info.js';
 import type { NetworkInspectInfo } from './api/network-info.js';
 import type { NotificationCard, NotificationCardOptions } from './api/notification.js';
@@ -652,6 +652,12 @@ export class PluginSystem {
     this.ipcHandle('container-provider-registry:listImages', async (): Promise<ImageInfo[]> => {
       return containerProviderRegistry.listImages();
     });
+    this.ipcHandle(
+      'container-provider-registry:podmanListImages',
+      async (_listener, options?: PodmanListImagesOptions): Promise<ImageInfo[]> => {
+        return containerProviderRegistry.podmanListImages(options);
+      },
+    );
     this.ipcHandle('container-provider-registry:listPods', async (): Promise<PodInfo[]> => {
       return containerProviderRegistry.listPods();
     });

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -59,7 +59,7 @@ import type { ExtensionInfo } from '../../main/src/plugin/api/extension-info';
 import type { HistoryInfo } from '../../main/src/plugin/api/history-info';
 import type { IconInfo } from '../../main/src/plugin/api/icon-info';
 import type { ImageCheckerInfo } from '../../main/src/plugin/api/image-checker-info';
-import type { ImageInfo } from '../../main/src/plugin/api/image-info';
+import type { ImageInfo, PodmanListImagesOptions } from '../../main/src/plugin/api/image-info';
 import type { ImageInspectInfo } from '../../main/src/plugin/api/image-inspect-info';
 import type { KubernetesGeneratorInfo } from '../../main/src/plugin/api/KubernetesGeneratorInfo';
 import type { NetworkInspectInfo } from '../../main/src/plugin/api/network-info';
@@ -233,6 +233,12 @@ export function initExposure(): void {
   contextBridge.exposeInMainWorld('listImages', async (): Promise<ImageInfo[]> => {
     return ipcInvoke('container-provider-registry:listImages');
   });
+  contextBridge.exposeInMainWorld(
+    'podmanListImages',
+    async (options?: PodmanListImagesOptions): Promise<ImageInfo[]> => {
+      return ipcInvoke('container-provider-registry:podmanListImages', options);
+    },
+  );
 
   contextBridge.exposeInMainWorld('listVolumes', async (fetchUsage = true): Promise<VolumeListInfo[]> => {
     return ipcInvoke('container-provider-registry:listVolumes', fetchUsage);


### PR DESCRIPTION
feat: add podmanListImages API

### What does this PR do?

* Adds the podmanListImages API that matches the libpod / podman API
  call
* Adds it to the extension / matches the parameters being called.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/A

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop/issues/6623

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature

Try as well with: `window.podmanListImages` within your svelte code /
API.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
