### PR TITLE
fix: remove request for login after getting session programmatically

### DIFF
--- a/packages/main/src/plugin/authentication.spec.ts
+++ b/packages/main/src/plugin/authentication.spec.ts
@@ -208,6 +208,26 @@ test('Authentication provider creates session when session request is executed',
   expect(createSessionSpy).toBeCalledTimes(1);
 });
 
+test('Authentication removes session request when session requested programmatically', async () => {
+  const authProvidrer1 = new AuthenticationProviderSingleAccount();
+  const createSessionSpy = vi.spyOn(authProvidrer1, 'createSession');
+
+  authModule.registerAuthenticationProvider('company.auth-provider', 'Provider 1', authProvidrer1);
+  await authModule.getSession({ id: 'ext1', label: 'Ext 1' }, 'company.auth-provider', ['scope1', 'scope2'], {
+    silent: false,
+  });
+
+  expect(authModule.getSessionRequests()).length(1);
+
+  await authModule.getSession({ id: 'ext1', label: 'Ext 1' }, 'company.auth-provider', ['scope1', 'scope2'], {
+    createIfNone: true,
+    silent: false,
+  });
+
+  expect(createSessionSpy).toBeCalledTimes(1);
+  expect(authModule.getSessionRequests()).length(0);
+});
+
 test('getAuthenticationProvidersInfo', async () => {
   const authentication = new AuthenticationImpl(apiSender);
 

--- a/packages/main/src/plugin/authentication.ts
+++ b/packages/main/src/plugin/authentication.ts
@@ -249,7 +249,15 @@ export class AuthenticationImpl {
 
     if (options.createIfNone) {
       if (providerData) {
-        return providerData.provider.createSession(sortedScopes);
+        const newSession = await providerData.provider.createSession(sortedScopes);
+        const request = Array.from(this._signInRequestsData.values()).find(request => {
+          return request.extensionId === requestingExtension.id;
+        });
+        if (request) {
+          this._signInRequestsData.delete(request.id);
+          this._signInRequests.delete(providerId);
+        }
+        return newSession;
       } else {
         throw new Error(`Requested authentication provider ${providerId} is not installed.`);
       }


### PR DESCRIPTION
### What does this PR do?

PR adds cleanup for authentication request after session created programmatically by calling `auth.getSession()` 

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fix #6664.

### How to test this PR?

can be tested after https://github.com/redhat-developer/podman-desktop-redhat-account-ext/pull/91 merged.

- [x] Tests are covering the bug fix or the new feature
