### PR TITLE
refactor(ui): split featured extensions svelte component

### DIFF
--- a/packages/renderer/src/lib/featured/FeaturedExtension.spec.ts
+++ b/packages/renderer/src/lib/featured/FeaturedExtension.spec.ts
@@ -1,0 +1,118 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/svelte';
+import { expect, test } from 'vitest';
+
+import FeaturedExtension from '/@/lib/featured/FeaturedExtension.svelte';
+
+import type { FeaturedExtension as IFeaturedExtension } from '../../../../main/src/plugin/featured/featured-api';
+
+const fetchableFeaturedExtension: IFeaturedExtension = {
+  builtin: true,
+  id: 'foo.bar',
+  displayName: 'FooBar',
+  description: 'This is FooBar description',
+  icon: 'data:image/png;base64,foobar',
+  categories: [],
+  fetchable: true,
+  fetchLink: 'oci-hello/world',
+  fetchVersion: '1.2.3',
+  installed: false,
+};
+
+const installedFeaturedExtension: IFeaturedExtension = {
+  builtin: true,
+  id: 'foo.baz',
+  displayName: 'FooBaz',
+  description: 'Foobaz description',
+  icon: 'data:image/png;base64,foobaz',
+  categories: [],
+  fetchable: false,
+  installed: true,
+};
+
+const notFetchableFeaturedExtension: IFeaturedExtension = {
+  builtin: true,
+  id: 'foo.bar',
+  displayName: 'Bar',
+  description: 'FooBar not fetchable description',
+  icon: 'data:image/png;base64,bar',
+  categories: [],
+  fetchable: false,
+  installed: false,
+};
+
+test('Expect featured extension to show install button', () => {
+  render(FeaturedExtension, {
+    featuredExtension: fetchableFeaturedExtension,
+  });
+
+  // get by title
+  const description = screen.getByTitle('This is FooBar description');
+  expect(description).toBeInTheDocument();
+
+  const image = screen.getByRole('img', { name: 'FooBar logo' });
+  // expect the image to be there
+  expect(image).toBeInTheDocument();
+  // expect image source is correct
+  expect(image).toHaveAttribute('src', 'data:image/png;base64,foobar');
+
+  // Not installed so it should have a button to install
+  const installButton = screen.getByRole('button', { name: 'Install foo.bar Extension' });
+  // expect the button to be there
+  expect(installButton).toBeInTheDocument();
+});
+
+test('Expect featured extension to show installed info', () => {
+  render(FeaturedExtension, {
+    featuredExtension: installedFeaturedExtension,
+  });
+
+  // get by title
+  const description = screen.getByTitle('Foobaz description');
+  expect(description).toBeInTheDocument();
+  // contains the text installed
+  expect(description).toHaveTextContent(/.*installed/);
+
+  const image = screen.getByRole('img', { name: 'FooBaz logo' });
+  // expect the image to be there
+  expect(image).toBeInTheDocument();
+  // expect image source is correct
+  expect(image).toHaveAttribute('src', 'data:image/png;base64,foobaz');
+});
+
+test('Expect featured extension to show NAN when not fetchable', () => {
+  render(FeaturedExtension, {
+    featuredExtension: notFetchableFeaturedExtension,
+  });
+
+  // get by title
+  const description = screen.getByTitle('FooBar not fetchable description');
+  expect(description).toBeInTheDocument();
+  // contains the text installed
+  expect(description).toHaveTextContent(/.*N\/A/);
+
+  const image = screen.getByRole('img', { name: 'Bar logo' });
+  // expect the image to be there
+  expect(image).toBeInTheDocument();
+  // expect image source is correct
+  expect(image).toHaveAttribute('src', 'data:image/png;base64,bar');
+});

--- a/packages/renderer/src/lib/featured/FeaturedExtension.svelte
+++ b/packages/renderer/src/lib/featured/FeaturedExtension.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+import { faCheckCircle, faCircleXmark } from '@fortawesome/free-solid-svg-icons';
+import Fa from 'svelte-fa';
+
+import type { FeaturedExtension } from '../../../../main/src/plugin/featured/featured-api';
+import FeaturedExtensionDownload from './FeaturedExtensionDownload.svelte';
+
+export let featuredExtension: FeaturedExtension;
+</script>
+
+<div
+  title="{featuredExtension.description}"
+  class="rounded-md
+               bg-charcoal-800 flex flex-row justify-center p-4 h-20 border-2 border-charcoal-800 hover:border-dustypurple-500"
+  aria-label="{featuredExtension.displayName}">
+  <div class=" flex flex-col flex-1">
+    <div class="flex flex-row place-items-center flex-1">
+      <div>
+        <img
+          class="w-12 h-12 object-contain"
+          alt="{featuredExtension.displayName} logo"
+          src="{featuredExtension.icon}" />
+      </div>
+      <div class="flex flex-1 mx-2 cursor-default font-bold justify-start">
+        {featuredExtension.displayName}
+      </div>
+      <div class="h-full w-18 flex flex-col items-end place-content-center">
+        {#if featuredExtension.installed}
+          <div class="text-dustypurple-700 p-1 text-center flex flex-row place-items-center">
+            <Fa class="ml-1.5 mr-2" size="1.1x" icon="{faCheckCircle}" />
+            <div class="uppercase font-bold text-xs cursor-default">installed</div>
+          </div>
+        {:else if featuredExtension.fetchable}
+          <FeaturedExtensionDownload featuredExtension="{featuredExtension}" />
+        {:else}
+          <div class="text-charcoal-300 p-1 text-center flex flex-row place-items-center">
+            <Fa class="ml-1.5 mr-1" size="1.1x" icon="{faCircleXmark}" />
+            <div class="uppercase text-xs cursor-default font-extralight">N/A</div>
+          </div>
+        {/if}
+      </div>
+    </div>
+  </div>
+</div>

--- a/packages/renderer/src/lib/featured/FeaturedExtensions.spec.ts
+++ b/packages/renderer/src/lib/featured/FeaturedExtensions.spec.ts
@@ -93,38 +93,12 @@ test('Expect that featured extensions are displayed', async () => {
   const firstExtension = screen.getByTitle('This is FooBar description');
   expect(firstExtension).toBeInTheDocument();
 
-  const imageExt1 = screen.getByRole('img', { name: 'FooBar logo' });
-  // expect the image to be there
-  expect(imageExt1).toBeInTheDocument();
-  // expect image source is correct
-  expect(imageExt1).toHaveAttribute('src', 'data:image/png;base64,foobar');
-
   // Not installed so it should have a button to install
   const installButton = screen.getByRole('button', { name: 'Install foo.bar Extension' });
   // expect the button to be there
   expect(installButton).toBeInTheDocument();
 
   // get by title
-  const secondExtension = screen.getByTitle('Foobaz description');
-  expect(secondExtension).toBeInTheDocument();
-  // contains the text installed
-  expect(secondExtension).toHaveTextContent(/.*installed/);
-
-  const imageExt2 = screen.getByRole('img', { name: 'FooBaz logo' });
-  // expect the image to be there
-  expect(imageExt2).toBeInTheDocument();
-  // expect image source is correct
-  expect(imageExt2).toHaveAttribute('src', 'data:image/png;base64,foobaz');
-
-  // get by title
   const thirdExtension = screen.getByTitle('FooBar not fetchable description');
   expect(thirdExtension).toBeInTheDocument();
-  // contains the text installed
-  expect(thirdExtension).toHaveTextContent(/.*N\/A/);
-
-  const imageExt3 = screen.getByRole('img', { name: 'Bar logo' });
-  // expect the image to be there
-  expect(imageExt3).toBeInTheDocument();
-  // expect image source is correct
-  expect(imageExt3).toHaveAttribute('src', 'data:image/png;base64,bar');
 });

--- a/packages/renderer/src/lib/featured/FeaturedExtensions.svelte
+++ b/packages/renderer/src/lib/featured/FeaturedExtensions.svelte
@@ -1,49 +1,12 @@
 <script lang="ts">
-import { faCheckCircle, faCircleXmark } from '@fortawesome/free-solid-svg-icons';
-import Fa from 'svelte-fa';
-
+import FeaturedExtension from '/@/lib/featured/FeaturedExtension.svelte';
 import { featuredExtensionInfos } from '/@/stores/featuredExtensions';
-
-import FeaturedExtensionDownload from './FeaturedExtensionDownload.svelte';
 </script>
 
 <!--Title-->
 <p class="text-lg first-letter:uppercase font-bold">featured extensions:</p>
 <div class="grid min-[920px]:grid-cols-2 min-[1180px]:grid-cols-3 gap-3" role="region" aria-label="FeaturedExtensions">
   {#each $featuredExtensionInfos as featuredExtension}
-    <div
-      title="{featuredExtension.description}"
-      class="rounded-md
-               bg-charcoal-800 flex flex-row justify-center p-4 h-20 border-2 border-charcoal-800 hover:border-dustypurple-500"
-      aria-label="{featuredExtension.displayName}">
-      <div class=" flex flex-col flex-1">
-        <div class="flex flex-row place-items-center flex-1">
-          <div>
-            <img
-              class="w-12 h-12 object-contain"
-              alt="{featuredExtension.displayName} logo"
-              src="{featuredExtension.icon}" />
-          </div>
-          <div class="flex flex-1 mx-2 cursor-default font-bold justify-start">
-            {featuredExtension.displayName}
-          </div>
-          <div class="h-full w-18 flex flex-col items-end place-content-center">
-            {#if featuredExtension.installed}
-              <div class="text-dustypurple-700 p-1 text-center flex flex-row place-items-center">
-                <Fa class="ml-1.5 mr-2" size="1.1x" icon="{faCheckCircle}" />
-                <div class="uppercase font-bold text-xs cursor-default">installed</div>
-              </div>
-            {:else if featuredExtension.fetchable}
-              <FeaturedExtensionDownload featuredExtension="{featuredExtension}" />
-            {:else}
-              <div class="text-charcoal-300 p-1 text-center flex flex-row place-items-center">
-                <Fa class="ml-1.5 mr-1" size="1.1x" icon="{faCircleXmark}" />
-                <div class="uppercase text-xs cursor-default font-extralight">N/A</div>
-              </div>
-            {/if}
-          </div>
-        </div>
-      </div>
-    </div>
+    <FeaturedExtension featuredExtension="{featuredExtension}" />
   {/each}
 </div>


### PR DESCRIPTION
### What does this PR do?

Move the content of the each block of the `FeaturedExtensions.svelte` component to a file, to make it standalone, and reusable.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop/issues/6669

### How to test this PR?

- [x] existing unit tests ensure no regression
