### PR TITLE
chore: add internal podman list images API call

### DIFF
--- a/packages/main/src/plugin/api/image-info.ts
+++ b/packages/main/src/plugin/api/image-info.ts
@@ -188,3 +188,30 @@ export interface ListImagesOptions {
    */
   provider?: ContainerProviderConnection;
 }
+
+export interface PodmanListImagesOptions {
+  /**
+   * Show all images. By default all images from a final layer (no children) are shown.
+   * @defaultValue false
+   */
+  all?: boolean;
+
+  /**
+   * A JSON encoded value of the filters (a map[string][]string) to process on the images list. Available filters:
+   * - before=(<image-name>[:<tag>], <image id> or <image@digest>)
+   * - dangling=true
+   * - label=key or label="key=value" of an image label
+   * - reference=(<image-name>[:<tag>])
+   * - since=(<image-name>[:<tag>], <image id> or <image@digest>)
+   *
+   * @defaultValue undefined
+   */
+  filters?: string;
+
+  /**
+   * The provider we want to list the images. If not provided, will return all container images across all container engines.
+   *
+   * @defaultValue undefined
+   */
+  provider?: ContainerProviderConnection;
+}

--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -3785,14 +3785,21 @@ test('list images with podmanListImages correctly', async () => {
   expect(image.Id).toBe('dummyImageId');
 });
 
-test('expect to get no images returned if podman provider does not have libpodApi', async () => {
+test('expect to fall back to compat api images if podman provider does not have libpodApi', async () => {
   const imagesList = [
     {
       Id: 'dummyImageId',
     },
   ];
 
+  const imagesList2 = [
+    {
+      Id: 'dummyImageId2',
+    },
+  ];
+
   nock('http://localhost').get('/v4.2.0/libpod/images/json').reply(200, imagesList);
+  nock('http://localhost').get('/images/json?all=false').reply(200, imagesList2);
 
   const api = new Dockerode({ protocol: 'http', host: 'localhost' });
 
@@ -3805,6 +3812,23 @@ test('expect to get no images returned if podman provider does not have libpodAp
       type: 'podman',
     },
     // purposely NOT have libpodApi
+  } as unknown as InternalContainerProvider);
+
+  const images = await containerRegistry.podmanListImages();
+  // ensure the field are correct
+  expect(images).toBeDefined();
+  expect(images).toHaveLength(1);
+  expect(images[0].Id).toBe('dummyImageId2');
+});
+
+test('expect to get get zero images if podman provider has neither libpodApi nor compat api', async () => {
+  containerRegistry.addInternalProvider('podman', {
+    name: 'podman',
+    id: 'podman1',
+    connection: {
+      type: 'podman',
+    },
+    // purposely NOT have libpodApi or compat api
   } as unknown as InternalContainerProvider);
 
   const images = await containerRegistry.podmanListImages();

--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -3821,6 +3821,22 @@ test('expect to fall back to compat api images if podman provider does not have 
   expect(images[0].Id).toBe('dummyImageId2');
 });
 
+test('expect a blank array if there is no api or libpodapi when doing podmanListImages', async () => {
+  containerRegistry.addInternalProvider('podman', {
+    name: 'podman',
+    id: 'podman1',
+    connection: {
+      type: 'podman',
+    },
+    // purposely NOT have api or libpodApi
+  } as unknown as InternalContainerProvider);
+
+  const images = await containerRegistry.podmanListImages();
+  // ensure the field are correct
+  expect(images).toBeDefined();
+  expect(images).toHaveLength(0);
+});
+
 test('expect to get get zero images if podman provider has neither libpodApi nor compat api', async () => {
   containerRegistry.addInternalProvider('podman', {
     name: 'podman',

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -606,6 +606,7 @@ export class ContainerProviderRegistry {
           // is that we are using the libpod API to list images, so we only retrieve the images
           // from providers that have implemented libpod API.
           if (!provider.libpodApi) {
+            console.log('podman engine is missing libpod API, cannot list images, check your provider configuration');
             return [];
           }
 

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -617,7 +617,8 @@ export class ContainerProviderRegistry {
         } else if (provider.api) {
           fetchedImages = await provider.api.listImages({ all: false });
         } else {
-          console.log('Engine does not have an API or a libpod API', provider.name);
+          console.log('Engine does not have an API or a libpod API, returning empty array', provider.name);
+          return fetchedImages;
         }
 
         // Transform fetched images to include engine name and ID

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -51,7 +51,7 @@ import type {
 import type { ContainerInspectInfo } from './api/container-inspect-info.js';
 import type { ContainerStatsInfo } from './api/container-stats-info.js';
 import type { HistoryInfo } from './api/history-info.js';
-import type { BuildImageOptions, ImageInfo, ListImagesOptions } from './api/image-info.js';
+import type { BuildImageOptions, ImageInfo, ListImagesOptions, PodmanListImagesOptions } from './api/image-info.js';
 import type { ImageInspectInfo } from './api/image-inspect-info.js';
 import type { ManifestCreateOptions } from './api/manifest-info.js';
 import type { NetworkInspectInfo } from './api/network-info.js';
@@ -584,6 +584,48 @@ export class ContainerProviderRegistry {
     );
     const flattenedImages = images.flat();
     this.telemetryService.track('listImages', Object.assign({ total: flattenedImages.length }, telemetryOptions));
+
+    return flattenedImages;
+  }
+
+  async podmanListImages(options?: PodmanListImagesOptions): Promise<ImageInfo[]> {
+    let telemetryOptions = {};
+
+    // This gets all the available providers if no provider has been specified
+    let providers: InternalContainerProvider[];
+    if (options?.provider === undefined) {
+      providers = Array.from(this.internalProviders.values());
+    } else {
+      providers = [this.getMatchingContainerProvider(options?.provider)];
+    }
+
+    const images = await Promise.all(
+      Array.from(providers).map(async provider => {
+        try {
+          // This is important and very similar to the 'listImages' function with the difference
+          // is that we are using the libpod API to list images, so we only retrieve the images
+          // from providers that have implemented libpod API.
+          if (!provider.libpodApi) {
+            return [];
+          }
+
+          // List the images
+          const images = await provider.libpodApi.podmanListImages(options);
+
+          // Add the additional information such as engineName and engineId to the ImageInfo
+          return images.map(image => {
+            const imageInfo: ImageInfo = { ...image, engineName: provider.name, engineId: provider.id };
+            return imageInfo;
+          });
+        } catch (error) {
+          console.log('error in engine', provider.name, error);
+          telemetryOptions = { error: error };
+          return [];
+        }
+      }),
+    );
+    const flattenedImages = images.flat();
+    this.telemetryService.track('podmanListImages', Object.assign({ total: flattenedImages.length }, telemetryOptions));
 
     return flattenedImages;
   }

--- a/packages/main/src/plugin/dockerode/libpod-dockerode.ts
+++ b/packages/main/src/plugin/dockerode/libpod-dockerode.ts
@@ -19,6 +19,8 @@
 import type { ManifestCreateOptions } from '@podman-desktop/api';
 import Dockerode from 'dockerode';
 
+import type { ImageInfo, PodmanListImagesOptions } from '../api/image-info.js';
+
 export interface PodContainerInfo {
   Id: string;
   Names: string;
@@ -348,6 +350,7 @@ export interface LibPod {
   pruneAllImages(dangling: boolean): Promise<void>;
   podmanInfo(): Promise<Info>;
   getImages(options: GetImagesOptions): Promise<NodeJS.ReadableStream>;
+  podmanListImages(options?: PodmanListImagesOptions): Promise<ImageInfo[]>;
   podmanCreateManifest(manifestOptions: ManifestCreateOptions): Promise<{ engineId: string; Id: string }>;
 }
 
@@ -398,6 +401,27 @@ export class LibpodDockerode {
         },
       };
 
+      return new Promise((resolve, reject) => {
+        this.modem.dial(optsf, (err: unknown, data: unknown) => {
+          if (err) {
+            return reject(err);
+          }
+          resolve(data);
+        });
+      });
+    };
+
+    // add listImages
+    prototypeOfDockerode.podmanListImages = function (options?: PodmanListImagesOptions): Promise<unknown> {
+      const optsf = {
+        path: '/v4.2.0/libpod/images/json',
+        method: 'GET',
+        options: options,
+        statusCodes: {
+          200: true,
+          500: 'server error',
+        },
+      };
       return new Promise((resolve, reject) => {
         this.modem.dial(optsf, (err: unknown, data: unknown) => {
           if (err) {


### PR DESCRIPTION
chore: add internal podman list images API call

### What does this PR do?

* Adds the internal podman list images API call similar to list
  containers functionality
* Follows same parameters / convention as the HTTP api library

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/A

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop/issues/6623

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
