### PR TITLE
[POC, no review yet, do not merge] feat: listImages API now lists manifests in API and UI

### DIFF
--- a/packages/main/src/plugin/api/image-info.ts
+++ b/packages/main/src/plugin/api/image-info.ts
@@ -188,3 +188,30 @@ export interface ListImagesOptions {
    */
   provider?: ContainerProviderConnection;
 }
+
+export interface PodmanListImagesOptions {
+  /**
+   * Show all images. By default all images from a final layer (no children) are shown.
+   * @defaultValue false
+   */
+  all?: boolean;
+
+  /**
+   * A JSON encoded value of the filters (a map[string][]string) to process on the images list. Available filters:
+   * - before=(<image-name>[:<tag>], <image id> or <image@digest>)
+   * - dangling=true
+   * - label=key or label="key=value" of an image label
+   * - reference=(<image-name>[:<tag>])
+   * - since=(<image-name>[:<tag>], <image id> or <image@digest>)
+   *
+   * @defaultValue undefined
+   */
+  filters?: string;
+
+  /**
+   * The provider we want to list the images. If not provided, will return all container images across all container engines.
+   *
+   * @defaultValue undefined
+   */
+  provider?: ContainerProviderConnection;
+}

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -606,6 +606,7 @@ export class ContainerProviderRegistry {
           // is that we are using the libpod API to list images, so we only retrieve the images
           // from providers that have implemented libpod API.
           if (!provider.libpodApi) {
+            console.log('podman engine is missing libpod API, cannot list images, check your provider configuration');
             return [];
           }
 

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -51,7 +51,7 @@ import type {
 import type { ContainerInspectInfo } from './api/container-inspect-info.js';
 import type { ContainerStatsInfo } from './api/container-stats-info.js';
 import type { HistoryInfo } from './api/history-info.js';
-import type { BuildImageOptions, ImageInfo, ListImagesOptions } from './api/image-info.js';
+import type { BuildImageOptions, ImageInfo, ListImagesOptions, PodmanListImagesOptions } from './api/image-info.js';
 import type { ImageInspectInfo } from './api/image-inspect-info.js';
 import type { ManifestCreateOptions } from './api/manifest-info.js';
 import type { NetworkInspectInfo } from './api/network-info.js';
@@ -584,6 +584,48 @@ export class ContainerProviderRegistry {
     );
     const flattenedImages = images.flat();
     this.telemetryService.track('listImages', Object.assign({ total: flattenedImages.length }, telemetryOptions));
+
+    return flattenedImages;
+  }
+
+  async podmanListImages(options?: PodmanListImagesOptions): Promise<ImageInfo[]> {
+    let telemetryOptions = {};
+
+    // This gets all the available providers if no provider has been specified
+    let providers: InternalContainerProvider[];
+    if (options?.provider === undefined) {
+      providers = Array.from(this.internalProviders.values());
+    } else {
+      providers = [this.getMatchingContainerProvider(options?.provider)];
+    }
+
+    const images = await Promise.all(
+      Array.from(providers).map(async provider => {
+        try {
+          // This is important and very similar to the 'listImages' function with the difference
+          // is that we are using the libpod API to list images, so we only retrieve the images
+          // from providers that have implemented libpod API.
+          if (!provider.libpodApi) {
+            return [];
+          }
+
+          // List the images
+          const images = await provider.libpodApi.podmanListImages(options);
+
+          // Add the additional information such as engineName and engineId to the ImageInfo
+          return images.map(image => {
+            const imageInfo: ImageInfo = { ...image, engineName: provider.name, engineId: provider.id };
+            return imageInfo;
+          });
+        } catch (error) {
+          console.log('error in engine', provider.name, error);
+          telemetryOptions = { error: error };
+          return [];
+        }
+      }),
+    );
+    const flattenedImages = images.flat();
+    this.telemetryService.track('podmanListImages', Object.assign({ total: flattenedImages.length }, telemetryOptions));
 
     return flattenedImages;
   }

--- a/packages/main/src/plugin/dockerode/libpod-dockerode.ts
+++ b/packages/main/src/plugin/dockerode/libpod-dockerode.ts
@@ -19,6 +19,8 @@
 import type { ManifestCreateOptions } from '@podman-desktop/api';
 import Dockerode from 'dockerode';
 
+import type { ImageInfo, PodmanListImagesOptions } from '../api/image-info.js';
+
 export interface PodContainerInfo {
   Id: string;
   Names: string;
@@ -348,6 +350,7 @@ export interface LibPod {
   pruneAllImages(dangling: boolean): Promise<void>;
   podmanInfo(): Promise<Info>;
   getImages(options: GetImagesOptions): Promise<NodeJS.ReadableStream>;
+  podmanListImages(options?: PodmanListImagesOptions): Promise<ImageInfo[]>;
   podmanCreateManifest(manifestOptions: ManifestCreateOptions): Promise<{ engineId: string; Id: string }>;
 }
 
@@ -398,6 +401,27 @@ export class LibpodDockerode {
         },
       };
 
+      return new Promise((resolve, reject) => {
+        this.modem.dial(optsf, (err: unknown, data: unknown) => {
+          if (err) {
+            return reject(err);
+          }
+          resolve(data);
+        });
+      });
+    };
+
+    // add listImages
+    prototypeOfDockerode.podmanListImages = function (options?: PodmanListImagesOptions): Promise<unknown> {
+      const optsf = {
+        path: '/v4.2.0/libpod/images/json',
+        method: 'GET',
+        options: options,
+        statusCodes: {
+          200: true,
+          500: 'server error',
+        },
+      };
       return new Promise((resolve, reject) => {
         this.modem.dial(optsf, (err: unknown, data: unknown) => {
           if (err) {

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -651,7 +651,7 @@ export class PluginSystem {
       return containerProviderRegistry.listSimpleContainers();
     });
     this.ipcHandle('container-provider-registry:listImages', async (): Promise<ImageInfo[]> => {
-      return containerProviderRegistry.listImages();
+      return containerProviderRegistry.unifiedListImages();
     });
     this.ipcHandle('container-provider-registry:listPods', async (): Promise<PodInfo[]> => {
       return containerProviderRegistry.listPods();


### PR DESCRIPTION
feat: listImages API now lists manifests in API and UI

### What does this PR do?

This PR now shows manifests in the UI / API call.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop/issues/6676

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature

Create a manifest:
1. `podman build --platform linux/arm64,linux/amd64 --manifest
   testmanifest .`
2. View it in the UI.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
