### PR TITLE
chore: add scripts to download podman 5 machines

### DIFF
--- a/extensions/podman/scripts/download.ts
+++ b/extensions/podman/scripts/download.ts
@@ -23,8 +23,7 @@ import * as podman4JSON from '../src/podman4.json';
 import * as podman5JSON from '../src/podman5.json';
 
 const podman4Download = new PodmanDownload(podman4JSON, true);
-podman4Download.downloadBinaries();
+await podman4Download.downloadBinaries();
 
-// do not fetch for airgap mode now
-const podman5Download = new PodmanDownload(podman5JSON, false);
-podman5Download.downloadBinaries();
+const podman5Download = new PodmanDownload(podman5JSON, true);
+await podman5Download.downloadBinaries();


### PR DESCRIPTION
### What does this PR do?
Update images for AirGapped mode

For Windows download from another repository on GitHub containers/podman-machine-wsl-os
and for macOS, fetch OCI images from quay.io/v2/podman/machine-os

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

related to https://github.com/containers/podman-desktop/issues/6360

### How to test this PR?

run `yarn build` in podman extensions folder (can use `AIRGAP_DOWNLOAD=true` as env variable)

- [x] Tests are covering the bug fix or the new feature
