### PR TITLE
chore: changing font sizes, weights and colours on the learning center card

### DIFF
--- a/packages/renderer/src/lib/learning-center/GuideCard.svelte
+++ b/packages/renderer/src/lib/learning-center/GuideCard.svelte
@@ -20,10 +20,10 @@ async function openGuide(guide: Guide): Promise<void> {
     <div class="px-4">
       <img src="{`data:image/png;base64,${guide.icon}`}" class="h-[48px]" alt="{guide.id}" />
     </div>
-    <div class="px-4 pt-4 text-nowrap text-sm text-gray-400">
+    <div class="px-4 pt-4 text-nowrap text-base text-gray-100 font-semibold">
       {guide.title}
     </div>
-    <p class="line-clamp-4 px-4 pt-4 text-sm text-gray-700">{guide.description}</p>
+    <p class="line-clamp-4 px-4 pt-4 text-sm text-gray-400">{guide.description}</p>
   </div>
   <div class="flex justify-center items-end flex-1 pt-4">
     <Button class="justify-self-center self-end" on:click="{() => openGuide(guide)}" title="Get started"

--- a/packages/renderer/src/lib/learning-center/LearningCenter.svelte
+++ b/packages/renderer/src/lib/learning-center/LearningCenter.svelte
@@ -23,7 +23,7 @@ onMount(async () => {
         {:else}
           <i class="fas fa-chevron-right"></i>
         {/if}
-        <span>Learning Center</span>
+        <p class="text-lg text-gray-100 font-semibold">Learning Center</p>
       </div>
     </button>
   </div>


### PR DESCRIPTION
### What does this PR do?

Edits the font sizes, weights and colours of text on the learning center card on the dashboard

### Screenshot / video of UI
Before:
![image](https://github.com/containers/podman-desktop/assets/87311656/0e721172-8a29-4290-8f62-eaa3068718cd)

After:
![Screenshot from 2024-04-08 11-52-37](https://github.com/containers/podman-desktop/assets/87311656/93744216-c812-4c9c-b18c-582b755bd116)

### What issues does this PR fix or reference?
This is in relation to https://github.com/containers/podman-desktop/issues/6547

### How to test this PR?
Look at Dashboard page
