### PR TITLE
chore: add isManifest function to determine a manifest

### DIFF
--- a/packages/main/src/plugin/util/manifest.spec.ts
+++ b/packages/main/src/plugin/util/manifest.spec.ts
@@ -1,0 +1,120 @@
+/**********************************************************************
+ *
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { describe, expect, test } from 'vitest';
+
+import type { ImageInfo } from '../api/image-info.js';
+import { guessIsManifest } from './manifest.js';
+
+describe('guessIsManifest function', () => {
+  test('correctly identifies a manifest image', () => {
+    const manifestImage: ImageInfo = {
+      Id: 'manifestImage',
+      Labels: {},
+      engineId: 'engine1',
+      engineName: 'podman',
+      ParentId: '',
+      RepoTags: ['manifestTag'],
+      RepoDigests: ['manifestDigest'],
+      Created: 0,
+      Size: 0,
+      VirtualSize: 500000, // 500KB, less than the 1MB threshold
+      SharedSize: 0,
+      Containers: 0,
+    };
+
+    expect(guessIsManifest(manifestImage)).toBe(true);
+  });
+
+  test('returns false if VirtualSize is over 1MB', () => {
+    const largeImage: ImageInfo = {
+      Id: 'largeImage',
+      Labels: {},
+      engineId: 'engine2',
+      engineName: 'podman',
+      ParentId: '',
+      RepoTags: ['largeImageTag'],
+      RepoDigests: ['largeImageDigest'],
+      Created: 0,
+      Size: 0,
+      VirtualSize: 2000000, // 2MB
+      SharedSize: 0,
+      Containers: 0,
+    };
+
+    expect(guessIsManifest(largeImage)).toBe(false);
+  });
+
+  test('returns false if Labels is not empty', () => {
+    const labeledImage: ImageInfo = {
+      Id: 'labeledImage',
+      Labels: { key: 'value' },
+      engineId: 'engine3',
+      engineName: 'podman',
+      ParentId: '',
+      RepoTags: ['labeledImageTag'],
+      RepoDigests: ['labeledImageDigest'],
+      Created: 0,
+      Size: 0,
+      VirtualSize: 500000, // 500KB
+      SharedSize: 0,
+      Containers: 0,
+    };
+
+    expect(guessIsManifest(labeledImage)).toBe(false);
+  });
+
+  test('returns false if RepoTags is undefined or empty', () => {
+    const noTagImage: ImageInfo = {
+      Id: 'noTagImage',
+      Labels: {},
+      engineId: 'engine4',
+      engineName: 'podman',
+      ParentId: '',
+      RepoTags: [],
+      RepoDigests: ['noTagImageDigest'],
+      Created: 0,
+      Size: 0,
+      VirtualSize: 500000, // 500KB
+      SharedSize: 0,
+      Containers: 0,
+    };
+
+    expect(guessIsManifest(noTagImage)).toBe(false);
+  });
+
+  test('returns false if RepoDigests is undefined or empty', () => {
+    const noDigestImage: ImageInfo = {
+      Id: 'noDigestImage',
+      Labels: {},
+      engineId: 'engine5',
+      engineName: 'podman',
+      ParentId: '',
+      RepoTags: ['noDigestImageTag'],
+      RepoDigests: [],
+      Created: 0,
+      Size: 0,
+      VirtualSize: 500000, // 500KB
+      SharedSize: 0,
+      Containers: 0,
+    };
+
+    expect(guessIsManifest(noDigestImage)).toBe(false);
+  });
+});

--- a/packages/main/src/plugin/util/manifest.spec.ts
+++ b/packages/main/src/plugin/util/manifest.spec.ts
@@ -117,4 +117,28 @@ describe('guessIsManifest function', () => {
 
     expect(guessIsManifest(noDigestImage)).toBe(false);
   });
+
+  test('return false for a typical helloworld image example, that may be small enough to trigger guessIsManifest as true', () => {
+    const helloWorldImage: ImageInfo = {
+      Id: 'ee301c921b8aadc002973b2e0c3da17d701dcd994b606769a7e6eaa100b81d44',
+      Labels: {},
+      engineId: 'engine5', // Assuming 'engineId' and 'engineName' are part of your ImageInfo but not relevant here
+      engineName: 'podman',
+      ParentId: '',
+      RepoTags: ['testdomain.io/library/hello:latest'],
+      RepoDigests: [
+        'testdomain.io/library/hello@sha256:2d4e459f4ecb5329407ae3e47cbc107a2fbace221354ca75960af4c047b3cb13',
+        'testdomain.io/library/hello@sha256:53641cd209a4fecfc68e21a99871ce8c6920b2e7502df0a20671c6fccc73a7c6',
+      ],
+      Created: 1683046167,
+      Size: 23301,
+      VirtualSize: 23301, // Directly matches Size in this case
+      SharedSize: 0,
+      Containers: 0,
+      History: ['testdomain.io/library/hello:latest'],
+    };
+
+    // Should be false
+    expect(guessIsManifest(helloWorldImage)).toBe(false);
+  });
 });

--- a/packages/main/src/plugin/util/manifest.spec.ts
+++ b/packages/main/src/plugin/util/manifest.spec.ts
@@ -1,5 +1,4 @@
 /**********************************************************************
- *
  * Copyright (C) 2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/main/src/plugin/util/manifest.spec.ts
+++ b/packages/main/src/plugin/util/manifest.spec.ts
@@ -34,7 +34,7 @@ describe('guessIsManifest function', () => {
       RepoDigests: ['manifestDigest'],
       Created: 0,
       Size: 0,
-      VirtualSize: 500000, // 500KB, less than the 1MB threshold
+      VirtualSize: 40 * 1024, // 40KB (less than 50KB threshold)
       SharedSize: 0,
       Containers: 0,
     };

--- a/packages/main/src/plugin/util/manifest.ts
+++ b/packages/main/src/plugin/util/manifest.ts
@@ -22,7 +22,7 @@ import type { ImageInfo } from '../api/image-info.js';
 const GUESSED_MANIFEST_SIZE = 51200;
 
 // Function to safely "guess" if the image is actually a manifest
-// IMPORTANT NOTE: 
+// IMPORTANT NOTE:
 // This is because there is no clear way to now what a manifest
 // is in the Dockerode API / Podman API (yet). This is a workaround
 // until we have a better way to determine if an image is a manifest
@@ -45,7 +45,7 @@ export function guessIsManifest(image: ImageInfo): boolean {
       image.RepoTags.length > 0 &&
       image.RepoDigests.length > 0 &&
       (!image.Labels || Object.keys(image.Labels).length === 0) &&
-      (!image.History || image.History.length === 0) && 
+      (!image.History || image.History.length === 0) &&
       image.engineName === 'podman' &&
       image.VirtualSize < GUESSED_MANIFEST_SIZE,
   );

--- a/packages/main/src/plugin/util/manifest.ts
+++ b/packages/main/src/plugin/util/manifest.ts
@@ -18,8 +18,8 @@
 
 import type { ImageInfo } from '../api/image-info.js';
 
-// 50 KB
-const GUESSED_MANIFEST_SIZE = 51200;
+const KB = 1024;
+const GUESSED_MANIFEST_SIZE = 50 * KB; // 50 KB
 
 // Function to safely "guess" if the image is actually a manifest
 // IMPORTANT NOTE:

--- a/packages/main/src/plugin/util/manifest.ts
+++ b/packages/main/src/plugin/util/manifest.ts
@@ -18,7 +18,8 @@
 
 import type { ImageInfo } from '../api/image-info.js';
 
-const GUESSED_MANIFEST_SIZE = 1000000; // 1MB
+// 50 KB
+const GUESSED_MANIFEST_SIZE = 51200;
 
 // Function to safely "guess" if the image is actually a manifest
 // IMPORTANT NOTE: 
@@ -29,9 +30,11 @@ const GUESSED_MANIFEST_SIZE = 1000000; // 1MB
 //
 // We will "safely" determine if an image is a manifest by checking:
 // - VirtualSize is under 1MB, as the manifest is usually very small and only contains text
-// - Labels is empty, as the manifest usually doesn't have any labels
+// - Labels is null or empty, as the manifest usually doesn't have any labels
 // - RepoTags always exists, as the manifest has a tag associated
 // - RepoDigests always exists as well, as the manifest has a digest associated
+// - History is null or empty
+// - Engine type is "podman"
 // all of these conditions must be met to (safely) determine if the image is a manifest
 //
 // We will check this within ImageInfo
@@ -42,6 +45,8 @@ export function guessIsManifest(image: ImageInfo): boolean {
       image.RepoTags.length > 0 &&
       image.RepoDigests.length > 0 &&
       (!image.Labels || Object.keys(image.Labels).length === 0) &&
+      (!image.History || image.History.length === 0) && 
+      image.engineName === 'podman' &&
       image.VirtualSize < GUESSED_MANIFEST_SIZE,
   );
 }

--- a/packages/main/src/plugin/util/manifest.ts
+++ b/packages/main/src/plugin/util/manifest.ts
@@ -1,0 +1,47 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { ImageInfo } from '../api/image-info.js';
+
+const GUESSED_MANIFEST_SIZE = 1000000; // 1MB
+
+// Function to safely "guess" if the image is actually a manifest
+// IMPORTANT NOTE: 
+// This is because there is no clear way to now what a manifest
+// is in the Dockerode API / Podman API (yet). This is a workaround
+// until we have a better way to determine if an image is a manifest
+// See issue: https://github.com/containers/podman/issues/22184
+//
+// We will "safely" determine if an image is a manifest by checking:
+// - VirtualSize is under 1MB, as the manifest is usually very small and only contains text
+// - Labels is empty, as the manifest usually doesn't have any labels
+// - RepoTags always exists, as the manifest has a tag associated
+// - RepoDigests always exists as well, as the manifest has a digest associated
+// all of these conditions must be met to (safely) determine if the image is a manifest
+//
+// We will check this within ImageInfo
+export function guessIsManifest(image: ImageInfo): boolean {
+  return Boolean(
+    image.RepoTags &&
+      image.RepoDigests &&
+      image.RepoTags.length > 0 &&
+      image.RepoDigests.length > 0 &&
+      (!image.Labels || Object.keys(image.Labels).length === 0) &&
+      image.VirtualSize < GUESSED_MANIFEST_SIZE,
+  );
+}

--- a/packages/main/src/plugin/util/manifest.ts
+++ b/packages/main/src/plugin/util/manifest.ts
@@ -19,7 +19,7 @@
 import type { ImageInfo } from '../api/image-info.js';
 
 const KB = 1024;
-const GUESSED_MANIFEST_SIZE = 50 * KB; // 50 KB
+const GUESSED_MANIFEST_SIZE = 50 * KB;
 
 // Function to safely "guess" if the image is actually a manifest
 // IMPORTANT NOTE:


### PR DESCRIPTION
chore: add isManifest function to determine a manifest

### What does this PR do?

Adds a guessIsManifest function to try and determine if an image is a
manifest or not:

- By checking the repotags and digests
- Checking labels does not exist, as labels are not added when creating
  a manifest
- VirtualSize is under 1MB as a manifest list is just text that points
  to other images

We are unable to check the history (manifest commonly has no history) as
Dockerode API does not support getting the history of the image.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/A

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes  https://github.com/containers/podman-desktop/issues/6690

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
