### PR TITLE
chore: add History to podmanListImages / ImageInfo function

### DIFF
--- a/packages/main/src/plugin/api/image-info.ts
+++ b/packages/main/src/plugin/api/image-info.ts
@@ -24,6 +24,7 @@ import type { ProviderContainerConnectionInfo } from './provider-info.js';
 export interface ImageInfo extends Dockerode.ImageInfo {
   engineId: string;
   engineName: string;
+  History?: string[];
 }
 
 export interface BuildImageOptions {


### PR DESCRIPTION
chore: add History to podmanListImages / ImageInfo function

### What does this PR do?

* Adds `History` to ImageInfo which is returned by the podman list images
API.
* Adds tests

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/A

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop/issues/6709

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
