### PR TITLE
chore: add isManifest to podmanListImages

### DIFF
--- a/packages/main/src/plugin/api/image-info.ts
+++ b/packages/main/src/plugin/api/image-info.ts
@@ -25,6 +25,7 @@ export interface ImageInfo extends Dockerode.ImageInfo {
   engineId: string;
   engineName: string;
   History?: string[];
+  isManifest?: boolean;
 }
 
 export interface BuildImageOptions {

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -75,6 +75,7 @@ import { Emitter } from './events/emitter.js';
 import type { ImageRegistry } from './image-registry.js';
 import type { Telemetry } from './telemetry/telemetry.js';
 import { Disposable } from './types/disposable.js';
+import { guessIsManifest } from './util/manifest.js';
 
 const tar: { pack: (dir: string) => NodeJS.ReadableStream } = require('tar-fs');
 
@@ -626,6 +627,10 @@ export class ContainerProviderRegistry {
           ...image,
           engineName: provider.name,
           engineId: provider.id,
+          // Using guessIsManifest, determine if the image is a manifest and set isManifest accordingly
+          // NOTE: This is a workaround until we have a better way to determine if an image is a manifest
+          // and may result in false positives until issue: https://github.com/containers/podman/issues/22184 is resolved
+          isManifest: guessIsManifest(image),
         }));
       }),
     );


### PR DESCRIPTION
chore: add isManifest to podmanListImages

### What does this PR do?

* Adds the ability to see what is and isn't a manifest based upon
  guessIsManifest function for podmanListImages, allowing you to use the
  internal function call to determine what's a manifest or not
* Added tests to cover the functionality

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/A

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop/issues/6691

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
