### PR TITLE
fix(UI): adding margin right for container actions in container list

### DIFF
--- a/packages/renderer/src/lib/container/ContainerList.svelte
+++ b/packages/renderer/src/lib/container/ContainerList.svelte
@@ -650,7 +650,7 @@ function setStoppedFilter() {
                         <div>&nbsp;</div>
                       {/if}
                     </div>
-                    <div class="text-right w-full">
+                    <div class="text-right w-full mr-[5px]">
                       <ContainerActions
                         container="{container}"
                         dropdownMenu="{true}"


### PR DESCRIPTION
### What does this PR do?

The container list is not using the `<Table/>` component, therefore does not get the left/right 5px hardcoded margin the other listing have.

https://github.com/containers/podman-desktop/blob/0698e4d2fd1f3fcb64bfc8d66a96003545b6ee89/packages/renderer/src/lib/table/Table.svelte#L115

Therefore adding a margin-right of `5px` fixes the missing spaces.

> We would probably need at some point to use the table component for the container list, but it would probably require a lot of refactoring, this is a quick fix 

### Screenshot / video of UI

Before
![image](https://github.com/containers/podman-desktop/assets/42176370/01b4ba90-9042-41ee-8971-93fa1cfc3a36)

After
![image](https://github.com/containers/podman-desktop/assets/42176370/dd1aa08f-1348-4c5a-9508-4be5c9d33110)


### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop/issues/6719

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature

