### PR TITLE
feat: allow to retrieve connectionInfo

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -531,6 +531,18 @@ declare module '@podman-desktop/api' {
     connection: ContainerProviderConnection;
   }
 
+  export type LifecycleMethod = 'start' | 'stop' | 'delete' | 'edit';
+
+  export interface ProviderContainerConnectionInfo {
+    name: string;
+    status: ProviderConnectionStatus;
+    endpoint: {
+      socketPath: string;
+    };
+    lifecycleMethods?: LifecycleMethod[];
+    type: 'docker' | 'podman';
+  }
+
   export namespace provider {
     export function createProvider(provider: ProviderOptions): Provider;
     export const onDidUpdateProvider: Event<ProviderEvent>;
@@ -539,6 +551,9 @@ declare module '@podman-desktop/api' {
     export const onDidUnregisterContainerConnection: Event<UnregisterContainerConnectionEvent>;
     export const onDidRegisterContainerConnection: Event<RegisterContainerConnectionEvent>;
     export function getContainerConnections(): ProviderContainerConnection[];
+    export function getContainerConnectionInfo(
+      connection: ProviderContainerConnection,
+    ): ProviderContainerConnectionInfo | undefined;
     /**
      * It returns the lifecycle context for the provider connection.
      * If no context is found it throws an error

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -739,6 +739,9 @@ export class ExtensionLoader {
       getContainerConnections: () => {
         return providerRegistry.getContainerConnections();
       },
+      getContainerConnectionInfo: (connection: containerDesktopAPI.ProviderContainerConnection) => {
+        return providerRegistry.getContainerConnectionInfo(connection);
+      },
       getProviderLifecycleContext(
         providerId: string,
         providerConnectionInfo: containerDesktopAPI.ContainerProviderConnection,

--- a/packages/main/src/plugin/provider-registry.ts
+++ b/packages/main/src/plugin/provider-registry.ts
@@ -1217,6 +1217,19 @@ export class ProviderRegistry {
     return connections;
   }
 
+  getContainerConnectionInfo(connection: ProviderContainerConnection): ProviderContainerConnectionInfo | undefined {
+    for (const providerInfo of this.getProviderInfos()) {
+      if (providerInfo.id === connection.providerId) {
+        for (const containerConnection of providerInfo.containerConnections) {
+          if (containerConnection.endpoint.socketPath === connection.connection.endpoint.socketPath) {
+            return containerConnection;
+          }
+        }
+      }
+    }
+    return undefined;
+  }
+
   registerKubernetesConnection(
     provider: Provider,
     kubernetesProviderConnection: KubernetesProviderConnection,


### PR DESCRIPTION
### What does this PR do?

In ai labs i have the need to redirect the user to the edit podman machine page if the machine has few resources. However there is no way atm to know if the containerConnection supports the edit method. This new function allows to ask more info about a `ProviderContainerConnection`. So i can retrieve the running connection, asks for more info and see if it supports the edit action. 

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

N/A

### How to test this PR?

1. run test

- [x] Tests are covering the bug fix or the new feature
