### PR TITLE
chore(tests): add playwright pom covering authentication providers

### DIFF
--- a/tests/playwright/src/model/pages/authentication-page.ts
+++ b/tests/playwright/src/model/pages/authentication-page.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/playwright/src/model/pages/authentication-page.ts
+++ b/tests/playwright/src/model/pages/authentication-page.ts
@@ -1,0 +1,42 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { Locator, Page } from '@playwright/test';
+
+import { SettingsPage } from './settings-page';
+
+export class AuthenticationPage extends SettingsPage {
+  readonly main: Locator;
+  readonly header: Locator;
+  readonly heading: Locator;
+  readonly content: Locator;
+  readonly providersList: Locator;
+
+  constructor(page: Page) {
+    super(page, 'Authentication');
+    this.main = page.getByRole('region', { name: 'Authentication' });
+    this.header = this.main.getByRole('region', { name: 'Header' });
+    this.heading = this.header.getByRole('heading', { name: 'Title', exact: true });
+    this.content = this.main.getByRole('region', { name: 'Content' });
+    this.providersList = this.content.getByRole('list');
+  }
+
+  public getProvider(providerName: string): Locator {
+    return this.providersList.getByRole('listitem', { name: providerName });
+  }
+}

--- a/tests/playwright/src/model/pages/extension-page.ts
+++ b/tests/playwright/src/model/pages/extension-page.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,6 +43,14 @@ export class ExtensionPage extends SettingsPage {
 
     await this.disableButton.click();
     await playExpect(this.status).toHaveText('DISABLED');
+    return this;
+  }
+
+  async enableExtension(): Promise<this> {
+    if ((await this.status.innerText()) === 'ACTIVE') return this;
+
+    await this.disableButton.click();
+    await playExpect(this.status).toHaveText('ACTIVE');
     return this;
   }
 

--- a/tests/playwright/src/model/pages/settings-extensions-page.ts
+++ b/tests/playwright/src/model/pages/settings-extensions-page.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,22 +23,24 @@ import { SettingsPage } from './settings-page';
 
 export class SettingsExtensionsPage extends SettingsPage {
   readonly heading: Locator;
+  readonly header: Locator;
+  readonly content: Locator;
   readonly featuredExtensions: Locator;
   readonly devSandboxBox: Locator;
   readonly openshiftLocalBox: Locator;
-  readonly extensionsTable: Locator;
   readonly imageInstallBox: Locator;
   readonly installedExtensions: Locator;
 
   constructor(page: Page) {
     super(page, 'Extensions');
-    this.heading = page.getByLabel('Title').getByText('Extensions');
-    this.featuredExtensions = page.getByLabel('FeaturedExtensions');
+    this.header = page.getByRole('region', { name: 'Header' });
+    this.content = page.getByRole('region', { name: 'Content' });
+    this.heading = this.header.getByLabel('Title').getByText('Extensions');
+    this.featuredExtensions = this.content.getByLabel('FeaturedExtensions');
     this.devSandboxBox = this.featuredExtensions.getByLabel('Developer Sandbox');
     this.openshiftLocalBox = this.featuredExtensions.getByLabel('OpenShift Local');
-    this.extensionsTable = page.getByRole('table');
-    this.imageInstallBox = page.getByRole('region', { name: 'OCI image installation box' });
-    this.installedExtensions = page.getByLabel('Installed Extensions');
+    this.imageInstallBox = this.content.getByRole('region', { name: 'OCI image installation box' });
+    this.installedExtensions = this.content.getByRole('table', { name: 'Installed Extensions' });
   }
 
   public async installExtensionFromOCIImage(extension: string): Promise<SettingsExtensionsPage> {
@@ -54,7 +56,7 @@ export class SettingsExtensionsPage extends SettingsPage {
   }
 
   public getExtensionRowFromTable(extensionName: string): Locator {
-    return this.extensionsTable.getByRole('row', { name: extensionName });
+    return this.installedExtensions.getByRole('row', { name: extensionName });
   }
 
   public getExtensionStopButton(extensionRow: Locator): Locator {

--- a/tests/playwright/src/model/pages/sso-extension-page.ts
+++ b/tests/playwright/src/model/pages/sso-extension-page.ts
@@ -1,0 +1,27 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { Page } from '@playwright/test';
+
+import { ExtensionPage } from './extension-page';
+
+export class SSOExtensionPage extends ExtensionPage {
+  constructor(page: Page) {
+    super(page, 'Red Hat Authentication', 'Red Hat Authentication Extension');
+  }
+}

--- a/tests/playwright/src/model/workbench/navigation.ts
+++ b/tests/playwright/src/model/workbench/navigation.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { Locator, Page } from '@playwright/test';
+import { expect, type Locator, type Page } from '@playwright/test';
 
 import { ContainersPage } from '../pages/containers-page';
 import { DashboardPage } from '../pages/dashboard-page';
@@ -72,7 +72,7 @@ export class NavigationBar {
   async openSettings(): Promise<SettingsBar> {
     const settingsBar = new SettingsBar(this.page);
     if (!(await settingsBar.settingsNavBar.isVisible())) {
-      await this.settingsLink.waitFor({ state: 'visible', timeout: 3000 });
+      await expect(this.settingsLink).toBeVisible();
       await this.settingsLink.click({ timeout: 5000 });
     }
     return settingsBar;

--- a/tests/playwright/src/model/workbench/navigation.ts
+++ b/tests/playwright/src/model/workbench/navigation.ts
@@ -70,8 +70,11 @@ export class NavigationBar {
   }
 
   async openSettings(): Promise<SettingsBar> {
-    await this.settingsLink.waitFor({ state: 'visible', timeout: 3000 });
-    await this.settingsLink.click({ timeout: 5000 });
-    return new SettingsBar(this.page);
+    const settingsBar = new SettingsBar(this.page);
+    if (!(await settingsBar.settingsNavBar.isVisible())) {
+      await this.settingsLink.waitFor({ state: 'visible', timeout: 3000 });
+      await this.settingsLink.click({ timeout: 5000 });
+    }
+    return settingsBar;
   }
 }


### PR DESCRIPTION
### What does this PR do?
It covers adding and updating some POM for e2e tests to cover authentication providers and extensions.
### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
#6727 
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?
Runnnig `yarn test:e2e` should still works without any failure.
<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- N/A Tests are covering the bug fix or the new feature
