### PR TITLE
feat(UI): adding optional title property to featured extension

### DIFF
--- a/packages/renderer/src/lib/featured/FeaturedExtension.spec.ts
+++ b/packages/renderer/src/lib/featured/FeaturedExtension.spec.ts
@@ -107,14 +107,25 @@ describe('variants', () => {
   });
 });
 
-test('title should be visible when provided', () => {
-  render(FeaturedExtension, {
-    featuredExtension: fetchableFeaturedExtension,
-    title: 'dummy title',
+describe('title', () => {
+  test('title should not be visible by default', async () => {
+    render(FeaturedExtension, {
+      featuredExtension: fetchableFeaturedExtension,
+    });
+
+    const title = screen.queryByText('EXTENSION');
+    expect(title).toBeNull();
   });
 
-  const title = screen.getByText('dummy title');
-  expect(title).toBeDefined();
+  test('title should not be visible by default', async () => {
+    render(FeaturedExtension, {
+      featuredExtension: fetchableFeaturedExtension,
+      displayTitle: true,
+    });
+
+    const title = screen.getByText('EXTENSION');
+    expect(title).toBeDefined();
+  });
 });
 
 test('Expect featured extension to show install button', () => {

--- a/packages/renderer/src/lib/featured/FeaturedExtension.spec.ts
+++ b/packages/renderer/src/lib/featured/FeaturedExtension.spec.ts
@@ -107,6 +107,16 @@ describe('variants', () => {
   });
 });
 
+test('title should be visible when provided', () => {
+  render(FeaturedExtension, {
+    featuredExtension: fetchableFeaturedExtension,
+    title: 'dummy title',
+  });
+
+  const title = screen.getByText('dummy title');
+  expect(title).toBeDefined();
+});
+
 test('Expect featured extension to show install button', () => {
   render(FeaturedExtension, {
     featuredExtension: fetchableFeaturedExtension,

--- a/packages/renderer/src/lib/featured/FeaturedExtension.svelte
+++ b/packages/renderer/src/lib/featured/FeaturedExtension.svelte
@@ -7,6 +7,7 @@ import FeaturedExtensionDownload from './FeaturedExtensionDownload.svelte';
 
 export let featuredExtension: FeaturedExtension;
 export let variant: 'primary' | 'secondary' = 'primary';
+export let title: string | undefined = undefined;
 </script>
 
 <div
@@ -15,9 +16,12 @@ export let variant: 'primary' | 'secondary' = 'primary';
   class:border-[var(--pd-card-bg)]="{variant === 'primary'}"
   class:bg-[var(--pd-invert-content-card-bg)]="{variant === 'secondary'}"
   class:border-[var(--pd-invert-content-card-bg)]="{variant === 'secondary'}"
-  class="rounded-md flex flex-row justify-center p-4 h-20 border-2 hover:border-dustypurple-500"
+  class="rounded-md flex flex-row justify-center p-4 border-2 hover:border-dustypurple-500"
   aria-label="{featuredExtension.displayName}">
-  <div class=" flex flex-col flex-1">
+  <div class="flex flex-col flex-1">
+    {#if title}
+      <span class="text-xs font-bold mb-1.5">{title}</span>
+    {/if}
     <div class="flex flex-row place-items-center flex-1">
       <div>
         <img

--- a/packages/renderer/src/lib/featured/FeaturedExtension.svelte
+++ b/packages/renderer/src/lib/featured/FeaturedExtension.svelte
@@ -7,7 +7,7 @@ import FeaturedExtensionDownload from './FeaturedExtensionDownload.svelte';
 
 export let featuredExtension: FeaturedExtension;
 export let variant: 'primary' | 'secondary' = 'primary';
-export let title: string | undefined = undefined;
+export let displayTitle: boolean = false;
 </script>
 
 <div
@@ -19,8 +19,8 @@ export let title: string | undefined = undefined;
   class="rounded-md flex flex-row justify-center p-4 border-2 hover:border-dustypurple-500"
   aria-label="{featuredExtension.displayName}">
   <div class="flex flex-col flex-1">
-    {#if title}
-      <span class="text-xs font-bold mb-1.5">{title}</span>
+    {#if displayTitle}
+      <span class="text-xs font-bold mb-1.5">EXTENSION</span>
     {/if}
     <div class="flex flex-row place-items-center flex-1">
       <div>


### PR DESCRIPTION
### What does this PR do?

Required for https://github.com/containers/podman-desktop/issues/6215

### Screenshot / video of UI

(E.g. defining the title property to `EXTENSION`).

![image](https://github.com/containers/podman-desktop/assets/42176370/123a0842-4e35-4298-a70e-6e4d85de29e0)

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop/issues/6729

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
