### PR TITLE
feat: add navigateTo resources and edit container connection

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -4175,6 +4175,15 @@ declare module '@podman-desktop/api' {
      * Navigate to Authentication settings page
      */
     export function navigateToAuthentication(): Promise<void>;
+
+    /**
+     * Navigate to Preferences page
+     */
+    export function navigateToResources(): Promise<void>;
+    /**
+     * Navigate to Preferences page
+     */
+    export function navigateToEditProviderContainerConnection(connection: ProviderContainerConnection): Promise<void>;
   }
 
   /**

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -4177,11 +4177,11 @@ declare module '@podman-desktop/api' {
     export function navigateToAuthentication(): Promise<void>;
 
     /**
-     * Navigate to Preferences page
+     * Navigate to Resources page
      */
     export function navigateToResources(): Promise<void>;
     /**
-     * Navigate to Preferences page
+     * Navigate to the Edit Provider Container Connection page
      */
     export function navigateToEditProviderContainerConnection(connection: ProviderContainerConnection): Promise<void>;
   }

--- a/packages/main/src/plugin/extension-loader.spec.ts
+++ b/packages/main/src/plugin/extension-loader.spec.ts
@@ -212,6 +212,7 @@ const navigationManager: NavigationManager = new NavigationManager(
   apiSender,
   containerProviderRegistry,
   contributionManager,
+  providerRegistry,
   webviewRegistry,
 );
 

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -1224,6 +1224,14 @@ export class ExtensionLoader {
       navigateToAuthentication: async (): Promise<void> => {
         await this.navigationManager.navigateToAuthentication();
       },
+      navigateToResources: async (): Promise<void> => {
+        await this.navigationManager.navigateToResources();
+      },
+      navigateToEditProviderContainerConnection: async (
+        connection: containerDesktopAPI.ProviderContainerConnection,
+      ): Promise<void> => {
+        await this.navigationManager.navigateToEditProviderContainerConnection(connection);
+      },
     };
 
     const version = app.getVersion();

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -584,6 +584,7 @@ export class PluginSystem {
       apiSender,
       containerProviderRegistry,
       contributionManager,
+      providerRegistry,
       webviewRegistry,
     );
 

--- a/packages/main/src/plugin/navigation/navigation-manager.ts
+++ b/packages/main/src/plugin/navigation/navigation-manager.ts
@@ -16,12 +16,15 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { ProviderContainerConnection } from '@podman-desktop/api';
+
 import type { ApiSenderType } from '/@/plugin/api.js';
 import type { ContainerProviderRegistry } from '/@/plugin/container-registry.js';
 import type { ContributionManager } from '/@/plugin/contribution-manager.js';
 import { NavigationPage } from '/@/plugin/navigation/navigation-page.js';
 import type { NavigationRequest } from '/@/plugin/navigation/navigation-request.js';
 
+import type { ProviderRegistry } from '../provider-registry.js';
 import type { WebviewRegistry } from '../webview/webview-registry.js';
 
 export class NavigationManager {
@@ -29,6 +32,7 @@ export class NavigationManager {
     private apiSender: ApiSenderType,
     private containerRegistry: ContainerProviderRegistry,
     private contributionManager: ContributionManager,
+    private providerRegistry: ProviderRegistry,
     private webviewRegistry: WebviewRegistry,
   ) {}
 
@@ -211,6 +215,23 @@ export class NavigationManager {
   async navigateToAuthentication(): Promise<void> {
     this.navigateTo({
       page: NavigationPage.AUTHENTICATION,
+    });
+  }
+
+  async navigateToResources(): Promise<void> {
+    this.navigateTo({
+      page: NavigationPage.RESOURCES,
+    });
+  }
+
+  async navigateToEditProviderContainerConnection(connection: ProviderContainerConnection): Promise<void> {
+    const internalId = this.providerRegistry.getMatchingProviderInternalId(connection.providerId);
+    this.navigateTo({
+      page: NavigationPage.EDIT_CONTAINER_CONNECTION,
+      parameters: {
+        provider: internalId,
+        name: Buffer.from(connection.connection.name).toString('base64'),
+      },
     });
   }
 }

--- a/packages/main/src/plugin/navigation/navigation-page.ts
+++ b/packages/main/src/plugin/navigation/navigation-page.ts
@@ -33,4 +33,6 @@ export enum NavigationPage {
   HELP = 'help',
   WEBVIEW = 'webview',
   AUTHENTICATION = 'authentication',
+  RESOURCES = 'resources',
+  EDIT_CONTAINER_CONNECTION = 'edit-container-connection',
 }

--- a/packages/renderer/src/navigation.spec.ts
+++ b/packages/renderer/src/navigation.spec.ts
@@ -42,3 +42,15 @@ test('Test navigationHandle to a specific webview', () => {
 
   expect(vi.mocked(router.goto)).toHaveBeenCalledWith('/webviews/123');
 });
+
+test('Test navigationHandle to resources page', () => {
+  handleNavigation(NavigationPage.RESOURCES);
+
+  expect(vi.mocked(router.goto)).toHaveBeenCalledWith('/preferences/resources');
+});
+
+test('Test navigationHandle to a specific edit page', () => {
+  handleNavigation(NavigationPage.EDIT_CONTAINER_CONNECTION, { provider: '123', name: 'test' });
+
+  expect(vi.mocked(router.goto)).toHaveBeenCalledWith('/preferences/container-connection/edit/123/test');
+});

--- a/packages/renderer/src/navigation.ts
+++ b/packages/renderer/src/navigation.ts
@@ -82,5 +82,11 @@ export const handleNavigation = (page: NavigationPage, parameters?: { [key: stri
     case NavigationPage.AUTHENTICATION:
       router.goto('/preferences/authentication-providers');
       break;
+    case NavigationPage.RESOURCES:
+      router.goto('/preferences/resources');
+      break;
+    case NavigationPage.EDIT_CONTAINER_CONNECTION:
+      router.goto(`/preferences/container-connection/edit/${parameters?.['provider']}/${parameters?.['name']}`);
+      break;
   }
 };


### PR DESCRIPTION
### What does this PR do?

This PR allows to navigate to the resources page and the edit container connection page.
It will be used by AI Lab to help the user when its env is not properly set.
E.g.
You don't have a podman machine running -> go to resources
Your podman machine has not enough resources -> edit it

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

N/A

### How to test this PR?

run tests

- [x] Tests are covering the bug fix or the new feature
