### PR TITLE
nit: add comparator for status column for k8s services / ingress

### DIFF
--- a/packages/renderer/src/lib/ingresses-routes/IngressesRoutesList.spec.ts
+++ b/packages/renderer/src/lib/ingresses-routes/IngressesRoutesList.spec.ts
@@ -137,3 +137,13 @@ test('Expect filter empty screen if no match', async () => {
   const filterButton = screen.getByRole('button', { name: 'Clear filter' });
   expect(filterButton).toBeInTheDocument();
 });
+
+test('Expect status column name to be clickable / sortable', async () => {
+  await waitRender({});
+
+  const statusColumn = screen.getByRole('columnheader', { name: 'Status' });
+  expect(statusColumn).toBeInTheDocument();
+
+  // Expect it to have the 'cursor-pointer' class which means it's clickable / sortable
+  expect(statusColumn).toHaveClass('cursor-pointer');
+});

--- a/packages/renderer/src/lib/ingresses-routes/IngressesRoutesList.svelte
+++ b/packages/renderer/src/lib/ingresses-routes/IngressesRoutesList.svelte
@@ -100,6 +100,7 @@ let statusColumn = new Column<IngressUI>('Status', {
   align: 'center',
   width: '70px',
   renderer: IngressRouteColumnStatus,
+  comparator: (a, b) => a.status.localeCompare(b.status),
 });
 
 let nameColumn = new Column<IngressUI | RouteUI>('Name', {


### PR DESCRIPTION
nit: add comparator for status column for k8s services / ingress

### What does this PR do?

* Adds the comparator so to services / ingress to match all the other
  Kubernetes sections

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

https://github.com/containers/podman-desktop/assets/6422176/b4d5add1-c3d1-42a4-b14b-e43aabb24d34




### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop/issues/6735

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature

Check that the status column is clickable now

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
