### PR TITLE
chore: use proper proxy configuration

### DIFF
--- a/packages/main/src/plugin/extensions-catalog/extensions-catalog.ts
+++ b/packages/main/src/plugin/extensions-catalog/extensions-catalog.ts
@@ -16,7 +16,6 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type * as podmanDesktopAPI from '@podman-desktop/api';
 import type { HttpsOptions, OptionsOfTextResponseBody } from 'got';
 import got from 'got';
 import { HttpProxyAgent, HttpsProxyAgent } from 'hpagent';
@@ -37,9 +36,6 @@ import { ExtensionsCatalogSettings } from './extensions-catalog-settings.js';
 export class ExtensionsCatalog {
   public static readonly DEFAULT_EXTENSIONS_URL = 'https://registry.podman-desktop.io/api/extensions.json';
 
-  private proxySettings: podmanDesktopAPI.ProxySettings | undefined;
-  private proxyEnabled: boolean;
-
   private lastFetchTime = 0;
   private cachedCatalog: InternalCatalogJSON | undefined;
   static readonly CACHE_TIMEOUT = 1000 * 60 * 60 * 4; // 4 hours
@@ -48,17 +44,7 @@ export class ExtensionsCatalog {
     private certificates: Certificates,
     private proxy: Proxy,
     private configurationRegistry: ConfigurationRegistry,
-  ) {
-    this.proxy.onDidUpdateProxy(settings => {
-      this.proxySettings = settings;
-    });
-
-    this.proxy.onDidStateChange(state => {
-      this.proxyEnabled = state;
-    });
-
-    this.proxyEnabled = this.proxy.isEnabled();
-  }
+  ) {}
 
   init(): void {
     // register a configuration
@@ -190,9 +176,9 @@ export class ExtensionsCatalog {
       options.https.certificateAuthority = this.certificates.getAllCertificates();
     }
 
-    if (this.proxyEnabled) {
+    if (this.proxy.isEnabled()) {
       // use proxy when performing got request
-      const proxy = this.proxySettings;
+      const proxy = this.proxy.proxy;
       const httpProxyUrl = proxy?.httpProxy;
       const httpsProxyUrl = proxy?.httpsProxy;
 


### PR DESCRIPTION
### What does this PR do?

Current changes proposal fixes the problem with fetching extension list when proxy configuration is enabled.

### Screenshot / video of UI

When user provide the following proxy configuration like:

![Monosnap+Podman+Desktop+2024-04-10+16 00 30](https://github.com/containers/podman-desktop/assets/1968177/0f5aa417-4ca6-47a2-9cdd-9f5146f9a1c1)

Now the extension list fetches without any problems:

![Monosnap+Podman+Desktop+2024-04-10+16 00 10](https://github.com/containers/podman-desktop/assets/1968177/42477318-2ea9-483c-90c5-27c72c1ccfc9)

And how it looked like before:

![Monosnap+Podman+Desktop+2024-04-10+15 59 26](https://github.com/containers/podman-desktop/assets/1968177/1be98eef-04ca-4340-83f3-f51b83b3e094)


### What issues does this PR fix or reference?

#3449 

### How to test this PR?

You need to host machine, in my case I tested on macOS and Windows 11.

- On macOS you have to installed and configured squid server, open firewall for this test scenario.
- On router disable internet traffic for the Windows 11 host.
- Setup the proxy configuration with the IP address of squid server installed on macOS to pass all the traffic through the last ones
- Run Podman Desktop on Windows 11 and setup proxy configuration in Proxy settings page
- Navigate to extensions page
- Open developer tools and check that you have message: `main ↪️ Fetched https://registry.podman-desktop.io/api/extensions.json in 260.7532999962568ms`

- [x] Tests are covering the bug fix or the new feature
