### PR TITLE
nit: remove my-custom-image default value from image build

### DIFF
--- a/packages/renderer/src/lib/image/BuildImageFromContainerfile.spec.ts
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfile.spec.ts
@@ -151,3 +151,13 @@ test('Expect Abort button to being visible when image build is in progress', asy
   expect(abortButton).toBeInTheDocument();
   expect(abortButton).toBeEnabled();
 });
+
+test('Expect no value for containerImageName input field (no my-custom-image value), just show the placeholder.', async () => {
+  setup();
+  render(BuildImageFromContainerfile);
+
+  const containerImageName = screen.getByRole('textbox', { name: 'Image Name' });
+  expect(containerImageName).toBeInTheDocument();
+  expect(containerImageName).toHaveValue('');
+  expect(containerImageName).toHaveAttribute('placeholder', 'Image name (e.g. quay.io/namespace/my-custom-image)');
+});

--- a/packages/renderer/src/lib/image/BuildImageFromContainerfile.svelte
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfile.svelte
@@ -27,7 +27,7 @@ import BuildImageFromContainerfileCards from './BuildImageFromContainerfileCards
 import NoContainerEngineEmptyScreen from './NoContainerEngineEmptyScreen.svelte';
 
 let buildFinished = false;
-let containerImageName = 'my-custom-image';
+let containerImageName: string;
 let containerFilePath: string;
 let containerBuildContextDirectory: string;
 let containerBuildPlatform: string;
@@ -194,7 +194,7 @@ async function abortBuild() {
             bind:value="{containerImageName}"
             name="containerImageName"
             id="containerImageName"
-            placeholder="image name (e.g. quay.io/namespace/my-custom-image)"
+            placeholder="Image name (e.g. quay.io/namespace/my-custom-image)"
             class="w-full"
             required />
           {#if providerConnections.length > 1}


### PR DESCRIPTION
nit: remove my-custom-image default value from image build

### What does this PR do?

Removes the default name which instead should be the placeholder that
shows you what information you can enter

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->
![Screenshot 2024-04-10 at 4 16 18 PM](https://github.com/containers/podman-desktop/assets/6422176/573f4a1e-c4d5-439c-8386-577400ab479d)



### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop/issues/6748

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature

Also view the Build Page

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
