### PR TITLE
feat: open dashboard with left click on tray icon on Windows

### DIFF
--- a/packages/main/src/tray-menu.spec.ts
+++ b/packages/main/src/tray-menu.spec.ts
@@ -24,6 +24,7 @@ import statusStopped from './assets/status-stopped.png';
 import type { ProviderInfo } from './plugin/api/provider-info.js';
 import type { AnimatedTray } from './tray-animate-icon.js';
 import { TrayMenu } from './tray-menu.js';
+import * as util from './util.js';
 
 let trayMenu: TrayMenu;
 let tray: Tray;
@@ -147,4 +148,17 @@ test('Tray provider start enabled when configured state', () => {
   );
   expect(startItem).to.be.not.undefined;
   expect(startItem?.enabled).to.be.true;
+});
+
+test('Tray click trigger is only added on Windows devices', () => {
+  const onSpy = vi.spyOn(tray, 'on');
+
+  vi.spyOn(util, 'isWindows').mockReturnValue(true);
+  trayMenu = new TrayMenu(tray, animatedTray);
+  expect(onSpy).toHaveBeenCalledWith('click', expect.any(Function));
+  onSpy.mockClear();
+
+  vi.spyOn(util, 'isWindows').mockReturnValue(false);
+  trayMenu = new TrayMenu(tray, animatedTray);
+  expect(onSpy).not.toHaveBeenCalledWith('click', expect.any(Function));
 });

--- a/packages/main/src/tray-menu.spec.ts
+++ b/packages/main/src/tray-menu.spec.ts
@@ -47,6 +47,7 @@ vi.mock('electron', async () => {
 beforeAll(() => {
   tray = {
     setContextMenu: vi.fn(),
+    on: vi.fn(),
   } as unknown as Tray;
   animatedTray = {
     setStatus: vi.fn(),

--- a/packages/main/src/tray-menu.ts
+++ b/packages/main/src/tray-menu.ts
@@ -26,7 +26,7 @@ import statusStopped from './assets/status-stopped.png';
 import statusUnknown from './assets/status-unknown.png';
 import type { ProviderContainerConnectionInfo, ProviderInfo } from './plugin/api/provider-info.js';
 import type { AnimatedTray, TrayIconStatus } from './tray-animate-icon.js';
-import { findWindow, isMac } from './util.js';
+import { findWindow, isMac, isWindows } from './util.js';
 
 // extends type from the plugin
 interface ProviderMenuItem extends ProviderInfo {
@@ -120,7 +120,9 @@ export class TrayMenu {
       this.updateMenu();
     });
 
-    tray.on('double-click', this.showMainWindow.bind(this));
+    if (isWindows()) {
+      tray.on('click', this.showMainWindow.bind(this));
+    }
 
     // create menu first time
     this.updateMenu();

--- a/packages/main/src/tray-menu.ts
+++ b/packages/main/src/tray-menu.ts
@@ -120,6 +120,8 @@ export class TrayMenu {
       this.updateMenu();
     });
 
+    tray.on('double-click', this.showMainWindow.bind(this));
+
     // create menu first time
     this.updateMenu();
   }


### PR DESCRIPTION
### What does this PR do?

* Add the ability to open the dashboard when clicking the tray menu icon on Windows
* If the dashboard is already open, but not visible, it will be brought into focus / to the foreground instead

### What issues does this PR fix or reference?

Closes #4500.

### How to test this PR?

- Run Podman Desktop on Windows
- Close or hide dashboard window
- Click tray menu icon
