### PR TITLE
chore: default machine CPU to Cores/2

### DIFF
--- a/extensions/podman/package.json
+++ b/extensions/podman/package.json
@@ -55,7 +55,7 @@
           "type": "number",
           "format": "cpu",
           "minimum": 1,
-          "default": 2,
+          "default": "HOST_HALF_CPU_CORES",
           "maximum": "HOST_TOTAL_CPU",
           "scope": "ContainerConnection",
           "description": "CPU(s)"
@@ -109,7 +109,7 @@
         "podman.factory.machine.cpus": {
           "type": "number",
           "format": "cpu",
-          "default": 2,
+          "default": "HOST_HALF_CPU_CORES",
           "minimum": 1,
           "maximum": "HOST_TOTAL_CPU",
           "scope": "ContainerProviderConnectionFactory",

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.svelte
@@ -37,7 +37,7 @@ import {
   startTask,
 } from './preferences-connection-rendering-task';
 import PreferencesRenderingItemFormat from './PreferencesRenderingItemFormat.svelte';
-import { getInitialValue, isPropertyValidInContext, writeToTerminal } from './Util';
+import { calcHalfCpuCores, getInitialValue, isPropertyValidInContext, writeToTerminal } from './Util';
 
 export let properties: IConfigurationPropertyRecordedSchema[] = [];
 export let providerInfo: ProviderInfo;
@@ -134,6 +134,17 @@ onMount(async () => {
     .filter(property => property.id?.startsWith(providerInfo.id))
     .filter(property => isPropertyValidInContext(property.when, globalContext))
     .map(property => {
+      switch (property.default) {
+        case 'HOST_HALF_CPU_CORES': {
+          if (osCpu) {
+            property.default = calcHalfCpuCores(osCpu);
+          }
+          break;
+        }
+        default: {
+          break;
+        }
+      }
       switch (property.maximum) {
         case 'HOST_TOTAL_DISKSIZE': {
           if (osFreeDisk) {

--- a/packages/renderer/src/lib/preferences/Util.spec.ts
+++ b/packages/renderer/src/lib/preferences/Util.spec.ts
@@ -21,6 +21,7 @@ import { afterEach, describe, expect, test, vi } from 'vitest';
 import type { IConfigurationPropertyRecordedSchema } from '../../../../main/src/plugin/configuration-registry';
 import { ContextUI } from '../context/context';
 import {
+  calcHalfCpuCores,
   getNormalizedDefaultNumberValue,
   isPropertyValidInContext,
   isTargetScope,
@@ -229,5 +230,28 @@ describe.each([
 ])('Test rejected proxy addresses', address => {
   test(`Test address ${address}`, () => {
     expect(validateProxyAddress(address)).toBeDefined();
+  });
+});
+
+describe('calcHalfCpuCores', () => {
+  test('should return half of the provided CPU cores as a number', () => {
+    expect(calcHalfCpuCores('4')).toBe(2);
+    expect(calcHalfCpuCores('10')).toBe(5);
+  });
+
+  test('should return 1 if provided CPU cores are 0', () => {
+    expect(calcHalfCpuCores('0')).toBe(1);
+  });
+
+  test('should handle same integer value if CPU has one core', () => {
+    expect(calcHalfCpuCores('1')).toBe(1);
+  });
+
+  test('should return 1 for non-numeric strings', () => {
+    expect(calcHalfCpuCores('not-a-number')).toBe(1);
+  });
+
+  test('should return 1 for negative numbers', () => {
+    expect(calcHalfCpuCores('-4')).toBe(1);
   });
 });

--- a/packages/renderer/src/lib/preferences/Util.ts
+++ b/packages/renderer/src/lib/preferences/Util.ts
@@ -168,3 +168,13 @@ export function isContainerConnection(
 ): connection is ProviderContainerConnectionInfo {
   return (connection as ProviderContainerConnectionInfo).endpoint.socketPath !== undefined;
 }
+
+export function calcHalfCpuCores(osCpu: string): number {
+  const cores = parseInt(osCpu, 10);
+  if (isNaN(cores) || cores <= 0) {
+    return 1;
+  }
+
+  const hCores = Math.floor(cores / 2);
+  return hCores === 0 ? 1 : hCores;
+}


### PR DESCRIPTION
### What does this PR do?

Adoption of upstream https://github.com/containers/common/pull/1659

When user wants to create the new podman machine, CPU size calculates the same way as it done in upstream, Cores/2.

### Screenshot / video of UI

<img width="1162" alt="Снимок экрана 2024-04-11 в 15 05 53" src="https://github.com/containers/podman-desktop/assets/1968177/96c31bd0-22ad-4afa-a8d3-3cdd6e5131dc">


### What issues does this PR fix or reference?

#6386 

### How to test this PR?

When creating the new Podman machine, CPU size should conform Cores/2

- [x] Tests are covering the bug fix or the new feature
