### PR TITLE
fix(kubectl-cli): update error

### DIFF
--- a/extensions/kubectl-cli/src/download.ts
+++ b/extensions/kubectl-cli/src/download.ts
@@ -59,7 +59,8 @@ export class KubectlDownload {
 
   // Download kubectl from the artifact metadata: KubectlGithubReleaseArtifactMetadata
   // this will download it to the storage bin folder as well as make it executable
-  async download(release: KubectlGithubReleaseArtifactMetadata): Promise<void> {
+  // return the path where the file has been downloaded
+  async download(release: KubectlGithubReleaseArtifactMetadata): Promise<string> {
     // Get asset id
     const url = await this.kubectlGitHubReleases.getReleaseAssetURL(release.tag, platform(), arch());
 
@@ -80,5 +81,7 @@ export class KubectlDownload {
     // Download the asset and make it executable
     await this.kubectlGitHubReleases.downloadReleaseAsset(url, kubectlDownloadLocation);
     await makeExecutable(kubectlDownloadLocation);
+
+    return kubectlDownloadLocation;
   }
 }

--- a/extensions/kubectl-cli/src/extension.spec.ts
+++ b/extensions/kubectl-cli/src/extension.spec.ts
@@ -20,16 +20,26 @@
 import * as path from 'node:path';
 import { afterEach } from 'node:test';
 
-import type { Configuration } from '@podman-desktop/api';
+import type { CliToolUpdate, Configuration, Logger } from '@podman-desktop/api';
 import * as extensionApi from '@podman-desktop/api';
-import { beforeEach, expect, test, vi } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 
+import { installBinaryToSystem } from './cli-run';
 import * as KubectlExtension from './extension';
+import { KubectlGitHubReleases } from './kubectl-github-releases';
 
 const extensionContext = {
   subscriptions: [],
   storagePath: '/tmp/kubectl-cli',
 } as extensionApi.ExtensionContext;
+
+vi.mock('./cli-run', () => ({
+  installBinaryToSystem: vi.fn(),
+}));
+
+vi.mock('./kubectl-github-releases', () => ({
+  KubectlGitHubReleases: vi.fn(),
+}));
 
 vi.mock('@podman-desktop/api', () => {
   return {
@@ -61,11 +71,25 @@ vi.mock('@podman-desktop/api', () => {
   };
 });
 
+const downloadReleaseAssetMock = vi.fn();
+
 beforeEach(() => {
   vi.mocked(extensionApi.configuration.getConfiguration).mockReturnValue({
     update: vi.fn(),
   } as unknown as Configuration);
   vi.mocked(extensionApi.process.exec).mockClear();
+
+  vi.mocked(KubectlGitHubReleases).mockReturnValue({
+    grabLatestsReleasesMetadata: vi.fn().mockResolvedValue([
+      {
+        label: 'dummy label',
+        tag: 'dummy tag',
+        id: 'dummy id',
+      },
+    ]),
+    getReleaseAssetURL: vi.fn().mockResolvedValue('dummy download url'),
+    downloadReleaseAsset: downloadReleaseAssetMock,
+  } as unknown as KubectlGitHubReleases);
 });
 
 afterEach(() => {
@@ -327,4 +351,76 @@ test('findKubeCtl not global kubectl but in storage installed on macOS', async (
 
   // expect no call with which
   expect(extensionApi.process.exec).not.toBeCalledWith('which', expect.anything());
+});
+
+describe('postActivate', () => {
+  test('postActivate should registerUpdate', async () => {
+    const deferredCliUpdate: Promise<CliToolUpdate> = new Promise<CliToolUpdate>(resolve => {
+      vi.mocked(extensionApi.cli.createCliTool).mockImplementation(() => {
+        return {
+          registerUpdate: listener => {
+            resolve(listener);
+            return {
+              dispose: vi.fn(),
+            };
+          },
+          updateVersion: vi.fn(),
+        } as unknown as extensionApi.CliTool;
+      });
+    });
+
+    await KubectlExtension.activate(extensionContext);
+
+    return deferredCliUpdate;
+  });
+
+  test('onUpdate should dispose itself', async () => {
+    const disposeMock = vi.fn();
+    const deferredCliUpdate: Promise<CliToolUpdate> = new Promise<CliToolUpdate>(resolve => {
+      vi.mocked(extensionApi.cli.createCliTool).mockImplementation(() => {
+        return {
+          registerUpdate: listener => {
+            resolve(listener);
+            return {
+              dispose: disposeMock,
+            };
+          },
+          updateVersion: vi.fn(),
+        } as unknown as extensionApi.CliTool;
+      });
+    });
+
+    await KubectlExtension.activate(extensionContext);
+
+    const cliUpdate = await deferredCliUpdate;
+    await cliUpdate.doUpdate({} as unknown as Logger);
+    expect(disposeMock).toHaveBeenCalled();
+  });
+
+  test('onUpdate should download and install binary', async () => {
+    const deferredCliUpdate: Promise<CliToolUpdate> = new Promise<CliToolUpdate>(resolve => {
+      vi.mocked(extensionApi.cli.createCliTool).mockImplementation(() => {
+        return {
+          registerUpdate: listener => {
+            resolve(listener);
+            return {
+              dispose: vi.fn(),
+            };
+          },
+          updateVersion: vi.fn(),
+        } as unknown as extensionApi.CliTool;
+      });
+    });
+
+    await KubectlExtension.activate(extensionContext);
+
+    const cliUpdate = await deferredCliUpdate;
+    await cliUpdate.doUpdate({} as unknown as Logger);
+
+    expect(downloadReleaseAssetMock).toHaveBeenCalledWith('dummy download url', expect.anything());
+    expect(installBinaryToSystem).toHaveBeenCalledWith(expect.anything(), 'kubectl');
+    expect(vi.mocked(installBinaryToSystem).mock.calls[0][0]).toContain(
+      path.resolve(extensionContext.storagePath, 'bin', 'kubectl'),
+    );
+  });
 });

--- a/extensions/kubectl-cli/src/extension.spec.ts
+++ b/extensions/kubectl-cli/src/extension.spec.ts
@@ -41,6 +41,14 @@ vi.mock('./kubectl-github-releases', () => ({
   KubectlGitHubReleases: vi.fn(),
 }));
 
+vi.mock('node:fs', () => ({
+  promises: {
+    chmod: vi.fn(),
+    mkdir: vi.fn(),
+  },
+  existsSync: vi.fn(),
+}));
+
 vi.mock('@podman-desktop/api', () => {
   return {
     cli: {

--- a/extensions/kubectl-cli/src/extension.ts
+++ b/extensions/kubectl-cli/src/extension.ts
@@ -332,8 +332,8 @@ async function postActivate(
       version: lastReleaseVersion,
       doUpdate: async _logger => {
         // download, install system wide and update cli version
-        await kubectlDownload.download(lastReleaseMetadata);
-        await installBinaryToSystem(path, 'kubectl');
+        const binaryPath = await kubectlDownload.download(lastReleaseMetadata);
+        await installBinaryToSystem(binaryPath, 'kubectl');
         kubectlCliTool.updateVersion({
           version: lastReleaseVersion,
         });


### PR DESCRIPTION
### What does this PR do?

The problem was that when the update mecanism is triggered, the extension was trying to install system wide, the system wide kubectl executable, leading to an error, as it was trying to replace itself.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop/issues/5760

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature

**Testing manually**

On windows replace the `kubectl.exe` available in `C:\Users\<USER>\AppData\Local\Microsoft\WindowsApps\kubectl.exe` with an old version such as [kubectl.exe#1.25.0](https://cdn.dl.k8s.io/release/v1.25.0/bin/windows/amd64/kubectl.exe).

Start podman desktop, go to settings -> CLI tools and run the update. Enjoy