### PR TITLE
chore: expose more data from the published catalog

### DIFF
--- a/packages/main/src/plugin/extensions-catalog/extensions-catalog-api.ts
+++ b/packages/main/src/plugin/extensions-catalog/extensions-catalog-api.ts
@@ -31,8 +31,11 @@ export interface CatalogFetchableExtension {
 export interface CatalogExtension {
   id: string;
   publisherName: string;
+  shortDescription: string;
+  publisherDisplayName: string;
   extensionName: string;
   displayName: string;
+  categories: string[];
   versions: CatalogExtensionVersion[];
 }
 
@@ -40,6 +43,7 @@ interface CatalogExtensionVersion {
   version: string;
   ociUri: string;
   preview: boolean;
+  lastUpdated: Date;
   files: CatalogExtensionVersionFile[];
 }
 

--- a/packages/main/src/plugin/extensions-catalog/extensions-catalog.spec.ts
+++ b/packages/main/src/plugin/extensions-catalog/extensions-catalog.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,6 +41,7 @@ const fakePublishedExtension1 = {
   displayName: 'Foo extension display name',
   shortDescription: 'Foo extension short description',
   license: 'Apache-2.0',
+  categories: ['Kubernetes'],
   versions: [
     {
       version: '1.0.0',
@@ -161,9 +162,13 @@ test('should get all extensions', async () => {
   expect(extension.id).toBe('foo.fooName');
   expect(extension.publisherName).toBe('foo');
   expect(extension.displayName).toBe(fakePublishedExtension1.displayName);
-  expect(extension.versions.length).toBe(1);
+  expect(extension.categories).toStrictEqual(['Kubernetes']);
+  expect(extension.publisherDisplayName).toBe('Foo publisher display name');
+  expect(extension.shortDescription).toBe('Foo extension short description');
+
   expect(extension.versions[0]).toStrictEqual({
     ociUri: 'oci-registry.foo/foo/bar',
+    lastUpdated: expect.any(Date),
     preview: false,
     version: '1.0.0',
     files: [fooAssetIcon],

--- a/packages/main/src/plugin/extensions-catalog/extensions-catalog.ts
+++ b/packages/main/src/plugin/extensions-catalog/extensions-catalog.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -98,7 +98,10 @@ export class ExtensionsCatalog {
         return {
           id: `${extension.publisher.publisherName}.${extension.extensionName}`,
           publisherName: extension.publisher.publisherName,
+          publisherDisplayName: extension.publisher.displayName,
+          categories: extension.categories,
           extensionName: extension.extensionName,
+          shortDescription: extension.shortDescription,
           displayName: extension.displayName,
           versions: extension.versions.map(version => {
             return {
@@ -106,6 +109,7 @@ export class ExtensionsCatalog {
               preview: version.preview,
               ociUri: version.ociUri,
               files: version.files,
+              lastUpdated: new Date(version.lastUpdated),
             };
           }),
         };
@@ -212,6 +216,8 @@ interface InternalCatalogExtensionJSON {
   publisher: InternalCatalogExtensionPublisherJSON;
   extensionName: string;
   displayName: string;
+  categories: string[];
+  shortDescription: string;
   versions: InternalCatalogExtensionVersionJSON[];
 }
 
@@ -219,6 +225,7 @@ interface InternalCatalogExtensionVersionJSON {
   version: string;
   ociUri: string;
   preview: boolean;
+  lastUpdated: string;
   files: InternalCatalogExtensionVersionFileJSON[];
 }
 

--- a/packages/main/src/plugin/extensions-updater/extensions-updater.spec.ts
+++ b/packages/main/src/plugin/extensions-updater/extensions-updater.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,12 +34,16 @@ const catalogExtension1: CatalogExtension = {
   publisherName: 'foo',
   extensionName: 'extension1',
   displayName: 'My Extension 1',
+  publisherDisplayName: 'Foo publisher display name',
+  shortDescription: 'Foo extension short description',
+  categories: ['Kubernetes'],
   versions: [
     {
       version: '2.0.0',
       preview: false,
       ociUri: 'oci-registry.foo/foo/bar1',
       files: [],
+      lastUpdated: new Date(),
     },
   ],
 };
@@ -49,12 +53,16 @@ const catalogExtension2: CatalogExtension = {
   publisherName: 'foo',
   extensionName: 'extension2',
   displayName: 'My Extension 2',
+  publisherDisplayName: 'Foo publisher display name',
+  shortDescription: 'Foo extension short description',
+  categories: [],
   versions: [
     {
       version: '4.0.0',
       preview: false,
       ociUri: 'oci-registry.foo/foo/bar2',
       files: [],
+      lastUpdated: new Date(),
     },
   ],
 };

--- a/packages/renderer/src/lib/preferences/PreferencesInstallExtensionFromId.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesInstallExtensionFromId.spec.ts
@@ -62,12 +62,16 @@ test('Expect that the install button is there and can click on it to install', a
       extensionName: 'FOOName',
       displayName: 'foo.bar Extension',
       publisherName: 'Foo',
+      publisherDisplayName: 'Foo Publisher',
+      shortDescription: 'foo.bar Extension',
+      categories: ['Kubernetes'],
       versions: [
         {
           version: '1.0.0',
           preview: false,
           ociUri: 'oci://foo/bar:1.0.0',
           files: [],
+          lastUpdated: new Date(),
         },
       ],
     },
@@ -128,12 +132,16 @@ test('Expect that the installed label is there if extension is already installed
       extensionName: 'FOOName',
       displayName: 'foo.bar Extension',
       publisherName: 'Foo',
+      publisherDisplayName: 'Foo Publisher',
+      shortDescription: 'foo.bar Extension',
+      categories: ['Kubernetes'],
       versions: [
         {
           version: '1.0.0',
           preview: false,
           ociUri: 'oci://foo/bar:1.0.0',
           files: [],
+          lastUpdated: new Date(),
         },
       ],
     },

--- a/packages/renderer/src/stores/catalog-extensions.spec.ts
+++ b/packages/renderer/src/stores/catalog-extensions.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -70,12 +70,16 @@ test('catalog extension should be updated in case of a container is removed', as
       displayName: 'test1',
       publisherName: 'Foo publisher',
       extensionName: 'extension',
+      shortDescription: 'short description',
+      publisherDisplayName: 'Foo publisher display name',
+      categories: [],
       versions: [
         {
           version: '1.0.0',
           ociUri: 'oci://test1',
           preview: false,
           files: [],
+          lastUpdated: new Date(),
         },
       ],
     },
@@ -84,12 +88,16 @@ test('catalog extension should be updated in case of a container is removed', as
       displayName: 'test2',
       publisherName: 'Foo publisher',
       extensionName: 'extension2',
+      shortDescription: 'short description',
+      publisherDisplayName: 'Foo publisher display name',
+      categories: [],
       versions: [
         {
           version: '2.0.0',
           ociUri: 'oci://test2',
           preview: false,
           files: [],
+          lastUpdated: new Date(),
         },
       ],
     },


### PR DESCRIPTION
### What does this PR do?
catalog is containing/publishing some fields but these fields were not exposed adding them

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

part of https://github.com/containers/podman-desktop/issues/6083

### How to test this PR?

- [x] Tests are covering the bug fix or the new feature
