### PR TITLE
chore: removing styling from text and adjusting alignments on provider card on dashboard

### DIFF
--- a/packages/renderer/src/lib/dashboard/ProviderCard.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderCard.svelte
@@ -7,28 +7,30 @@ import ProviderLinks from './ProviderLinks.svelte';
 export let provider: ProviderInfo;
 </script>
 
-<div class="bg-charcoal-800 mb-5 rounded-md p-3 flex-nowrap" role="region" aria-label="{provider.name} Provider">
-  <div class="flex flex-row">
-    <div class="flex flex-row">
-      <IconImage image="{provider?.images?.icon}" class="mx-auto max-h-12" alt="{provider.name}"></IconImage>
-      <div class="flex flex-col text-gray-400 text-lg font-bold ml-3 whitespace-nowrap" aria-label="context-name">
-        <div class="flex flex-row items-center">
+<div
+  class="flex bg-charcoal-800 rounded-md p-5 gap-3 flex-col flex-nowrap"
+  role="region"
+  aria-label="{provider.name} Provider">
+  <div class="flex flex-row gap-10">
+    <div class="flex gap-3 flex-row justify-start items-center">
+      <IconImage image="{provider?.images?.icon}" class="mx-0 max-h-12" alt="{provider.name}"></IconImage>
+      <div class="flex flex-col gap-0 text-gray-400 text-lg whitespace-nowrap" aria-label="context-name">
+        <div class="flex flex-row gap-1 items-center">
           {provider.name}
           {#if provider.version}
-            <div class="text-gray-800 text-base font-light pl-1" aria-label="Provider Version">
+            <div class="text-gray-800 text-base" aria-label="Provider Version">
               v{provider.version}
             </div>
           {/if}
         </div>
-        <div class="flex flex-row pt-1" aria-label="Actual State">
+        <div class="flex flex-row" aria-label="Actual State">
           <ProviderStatus status="{provider.status}" />
         </div>
       </div>
     </div>
-    <div class="flex flex-col items-center text-center flex-grow">
+    <div class="flex items-center flex-row space-x-10 grow flex-nowrap">
       <slot name="content" />
     </div>
   </div>
-
   <ProviderLinks provider="{provider}" />
 </div>

--- a/packages/renderer/src/lib/dashboard/ProviderLinks.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderLinks.svelte
@@ -6,7 +6,7 @@ export let provider: ProviderInfo;
 </script>
 
 {#if provider.links.length > 0}
-  <div class="mt-2 flex flex-row justify-around">
+  <div class="mt-2 flex relative w-full content-stretch items-center flex-row justify-around flex-grow flex-nowrap">
     {#each provider.links as link}
       {#if link.group === undefined}
         <Link class="text-base" externalRef="{link.url}">

--- a/packages/renderer/src/lib/dashboard/ProviderNotInstalled.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderNotInstalled.svelte
@@ -18,12 +18,12 @@ let preflightChecks: CheckStatus[] = [];
     <p class="text-sm text-gray-700" aria-label="Suggested Actions">
       Could not find an installation. To start working with containers, {provider.name} needs to be detected/installed.
     </p>
-    <div class="mt-5 mb-1 w-full flex justify-around">
+    <div class="mt-5 mb-1 flex">
       <ProviderDetectionChecksButton onDetectionChecks="{checks => (detectionChecks = checks)}" provider="{provider}" />
       <ProviderInstallationButton onPreflightChecks="{checks => (preflightChecks = checks)}" provider="{provider}" />
     </div>
     {#if detectionChecks.length > 0}
-      <div class="flex flex-col w-full mt-5 px-5 pt-5 pb-0 rounded-lg bg-zinc-600">
+      <div class="flex flex-col mt-5 px-5 pt-5 pb-0 rounded-lg bg-zinc-600">
         {#each detectionChecks as detectionCheck}
           <div class="flex flex-col">
             <p class="mb-4 items-center list-inside">{detectionCheck.status ? '✅' : '❌'} {detectionCheck.name}</p>

--- a/packages/renderer/src/lib/ui/ProviderStatus.svelte
+++ b/packages/renderer/src/lib/ui/ProviderStatus.svelte
@@ -12,7 +12,7 @@ interface connectionStatusStyle {
   | 'configured'
   | 'unknown';*/
 const roundIconStyle = 'my-auto w-3 h-3 rounded-full';
-const labelStyle = 'my-auto ml-1 text-base font-medium';
+const labelStyle = 'my-auto ml-1 text-sm';
 const statusesStyle = new Map<string, connectionStatusStyle>([
   [
     'ready',


### PR DESCRIPTION
### What does this PR do?
Fixes some of the styling issues that were brought up on #6547. I removed the styling of the font that I had previously added in as they can later be defined in the config file.

### Screenshot / video of UI
Before:
![image](https://github.com/containers/podman-desktop/assets/87311656/5b90688d-8594-4d5e-bef9-473906abb6aa)

After:
![Screenshot from 2024-04-12 11-45-26](https://github.com/containers/podman-desktop/assets/87311656/ad4d89f4-d9fe-4ea9-a513-5a0687ca30e9)

### What issues does this PR fix or reference?
This issue should contribute to #6547. Ideally the provider cards would look like the screenshot mentioned on [this comment](https://github.com/containers/podman-desktop/issues/6547#issuecomment-2048332477), but this will suffice until there's more time to adjust things. 

### How to test this PR?
Look at the provider cards on the dashboard 

