### PR TITLE
feat: adds downloadable state for extension status widget

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesExtensionList.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesExtensionList.svelte
@@ -9,8 +9,8 @@ import { extensionInfos } from '../../stores/extensions';
 import FeaturedExtensions from '../featured/FeaturedExtensions.svelte';
 import SettingsPage from '../preferences/SettingsPage.svelte';
 import Button from '../ui/Button.svelte';
-import ConnectionStatus from '../ui/ConnectionStatus.svelte';
 import ErrorMessage from '../ui/ErrorMessage.svelte';
+import ExtensionStatus from '../ui/ExtensionStatus.svelte';
 import ExtensionIcon from './ExtensionIcon.svelte';
 
 export let ociImage: string | undefined = undefined;
@@ -154,7 +154,7 @@ async function updateExtension(extension: ExtensionInfo, ociUri: string) {
                       </div>
                     </div>
                     <div class="flex">
-                      <ConnectionStatus status="{extension.state}" />
+                      <ExtensionStatus status="{extension.state}" />
                     </div>
                   </div>
                 </div>

--- a/packages/renderer/src/lib/ui/ExtensionStatus.spec.ts
+++ b/packages/renderer/src/lib/ui/ExtensionStatus.spec.ts
@@ -23,13 +23,13 @@ import { expect, test } from 'vitest';
 
 import ExtensionStatus from './ExtensionStatus.svelte';
 
-const connectionStatusLabel = 'Connection Status Label';
-const connectionStatusIcon = 'Connection Status Icon';
+const extensionStatusLabel = 'Extension Status Label';
+const extensionStatusIcon = 'Extension Status Icon';
 
-test('Expect green text and icon when connection is running', async () => {
+test('Expect green text and icon when extension is running', async () => {
   render(ExtensionStatus, { status: 'started' });
-  const icon = screen.getByLabelText(connectionStatusIcon);
-  const label = screen.getByLabelText(connectionStatusLabel);
+  const icon = screen.getByLabelText(extensionStatusIcon);
+  const label = screen.getByLabelText(extensionStatusLabel);
   expect(icon).toBeInTheDocument();
   expect(icon).toHaveClass('bg-green-500');
   expect(label).toBeInTheDocument();
@@ -37,10 +37,10 @@ test('Expect green text and icon when connection is running', async () => {
   expect(label).toHaveTextContent('ACTIVE');
 });
 
-test('Expect green text and icon when connection is starting', async () => {
+test('Expect green text and icon when extension is starting', async () => {
   render(ExtensionStatus, { status: 'starting' });
-  const icon = screen.getByLabelText(connectionStatusIcon);
-  const label = screen.getByLabelText(connectionStatusLabel);
+  const icon = screen.getByLabelText(extensionStatusIcon);
+  const label = screen.getByLabelText(extensionStatusLabel);
   expect(icon).toBeInTheDocument();
   expect(icon).toHaveClass('bg-green-500');
   expect(label).toBeInTheDocument();
@@ -48,10 +48,10 @@ test('Expect green text and icon when connection is starting', async () => {
   expect(label).toHaveTextContent('ACTIVATING');
 });
 
-test('Expect green text and icon when connection is stopped', async () => {
+test('Expect green text and icon when extension is stopped', async () => {
   render(ExtensionStatus, { status: 'stopped' });
-  const icon = screen.getByLabelText(connectionStatusIcon);
-  const label = screen.getByLabelText(connectionStatusLabel);
+  const icon = screen.getByLabelText(extensionStatusIcon);
+  const label = screen.getByLabelText(extensionStatusLabel);
   expect(icon).toBeInTheDocument();
   expect(icon).toHaveClass('bg-gray-900');
   expect(label).toBeInTheDocument();
@@ -59,21 +59,20 @@ test('Expect green text and icon when connection is stopped', async () => {
   expect(label).toHaveTextContent('DISABLED');
 });
 
-test('Expect green text and icon when connection is stopping', async () => {
+test('Expect green text and icon when extension is stopping', async () => {
   render(ExtensionStatus, { status: 'stopping' });
-  const icon = screen.getByLabelText(connectionStatusIcon);
-  const label = screen.getByLabelText(connectionStatusLabel);
+  const icon = screen.getByLabelText(extensionStatusIcon);
+  const label = screen.getByLabelText(extensionStatusLabel);
   expect(icon).toBeInTheDocument();
   expect(icon).toHaveClass('bg-red-500');
   expect(label).toBeInTheDocument();
   expect(label).toHaveClass('text-red-500');
   expect(label).toHaveTextContent('DISABLING');
 });
-
-test('Expect green text and icon when connection is unknown', async () => {
+test('Expect green text and icon when extension is unknown', async () => {
   render(ExtensionStatus, { status: 'unknown' });
-  const icon = screen.getByLabelText(connectionStatusIcon);
-  const label = screen.getByLabelText(connectionStatusLabel);
+  const icon = screen.getByLabelText(extensionStatusIcon);
+  const label = screen.getByLabelText(extensionStatusLabel);
   expect(icon).toBeInTheDocument();
   expect(icon).toHaveClass('bg-gray-900');
   expect(label).toBeInTheDocument();

--- a/packages/renderer/src/lib/ui/ExtensionStatus.spec.ts
+++ b/packages/renderer/src/lib/ui/ExtensionStatus.spec.ts
@@ -79,3 +79,14 @@ test('Expect green text and icon when extension is unknown', async () => {
   expect(label).toHaveClass('text-gray-900');
   expect(label).toHaveTextContent('UNKNOWN');
 });
+
+test('Expect purple text and icon when extension is downloadable', async () => {
+  render(ExtensionStatus, { status: 'downloadable' });
+  const icon = screen.getByLabelText(extensionStatusIcon);
+  const label = screen.getByLabelText(extensionStatusLabel);
+  expect(icon).toBeInTheDocument();
+  expect(icon).toHaveClass('bg-purple-600');
+  expect(label).toBeInTheDocument();
+  expect(label).toHaveClass('text-gray-700');
+  expect(label).toHaveTextContent('DOWNLOADABLE');
+});

--- a/packages/renderer/src/lib/ui/ExtensionStatus.svelte
+++ b/packages/renderer/src/lib/ui/ExtensionStatus.svelte
@@ -6,7 +6,6 @@ interface connectionStatusStyle {
   txtColor: string;
   label: string;
 }
-
 const roundIconStyle = 'my-auto w-3 h-3 rounded-full';
 const labelStyle = 'my-auto ml-1 font-bold text-[9px]';
 const statusesStyle = new Map<string, connectionStatusStyle>([
@@ -58,5 +57,5 @@ $: statusStyle = statusesStyle.get(status) || {
 };
 </script>
 
-<div aria-label="Connection Status Icon" class="{roundIconStyle} {statusStyle.bgColor}"></div>
-<span aria-label="Connection Status Label" class="{labelStyle} {statusStyle.txtColor}">{statusStyle.label}</span>
+<div aria-label="Extension Status Icon" class="bg-{roundIconStyle} {statusStyle.bgColor}"></div>
+<span aria-label="Extension Status Label" class="{labelStyle} {statusStyle.txtColor}">{statusStyle.label}</span>

--- a/packages/renderer/src/lib/ui/ExtensionStatus.svelte
+++ b/packages/renderer/src/lib/ui/ExtensionStatus.svelte
@@ -49,6 +49,14 @@ const statusesStyle = new Map<string, connectionStatusStyle>([
       label: 'FAILED',
     },
   ],
+  [
+    'downloadable',
+    {
+      bgColor: 'bg-purple-600',
+      txtColor: 'text-gray-700',
+      label: 'DOWNLOADABLE',
+    },
+  ],
 ]);
 $: statusStyle = statusesStyle.get(status) || {
   bgColor: 'bg-gray-900',

--- a/tests/playwright/src/model/pages/extension-page.ts
+++ b/tests/playwright/src/model/pages/extension-page.ts
@@ -35,7 +35,7 @@ export class ExtensionPage extends SettingsPage {
     this.enableButton = page.getByRole('button', { name: 'Enable' });
     this.disableButton = page.getByRole('button', { name: 'Disable' });
     this.removeExtensionButton = page.getByRole('button', { name: 'Remove' });
-    this.status = page.getByLabel('Connection Status Label');
+    this.status = page.getByLabel('Extension Status Label');
   }
 
   async disableExtension(): Promise<this> {

--- a/tests/playwright/src/specs/podman-extension-smoke.spec.ts
+++ b/tests/playwright/src/specs/podman-extension-smoke.spec.ts
@@ -30,14 +30,12 @@ import { PodmanDesktopRunner } from '../runner/podman-desktop-runner';
 import type { RunnerTestContext } from '../testContext/runner-test-context';
 
 const SETTINGS_EXTENSIONS_TABLE_PODMAN_TITLE: string = 'podman';
-const SETTINGS_EXTENSIONS_TABLE_EXTENSION_STATUS_LABEL: string = 'Connection Status Label';
-const PODMAN_EXTENSION_STATUS_RUNNING: string = 'RUNNING';
-const PODMAN_EXTENSION_STATUS_OFF: string = 'OFF';
+const SETTINGS_EXTENSIONS_TABLE_EXTENSION_STATUS_LABEL: string = 'Extension Status Label';
+const PODMAN_EXTENSION_STATUS_ACTIVE: string = 'ACTIVE';
+const PODMAN_EXTENSION_STATUS_DISABLED: string = 'DISABLED';
 const SETTINGS_NAVBAR_PREFERENCES_PODMAN_EXTENSION: string = 'Extension: Podman';
 const SETTINGS_NAVBAR_EXTENSIONS_PODMAN: string = 'Podman';
 const PODMAN_EXTENSION_PAGE_HEADING: string = 'Podman Extension';
-const PODMAN_EXTENSION_PAGE_STATUS_ACTIVE: string = 'ACTIVE';
-const PODMAN_EXTENSION_PAGE_STATUS_DISABLED: string = 'DISABLED';
 
 let pdRunner: PodmanDesktopRunner;
 let page: Page;
@@ -101,15 +99,15 @@ async function verifyPodmanExtensionStatus(enabled: boolean): Promise<void> {
       ? settingsExtensionsPage.getExtensionStopButton(podmanExtensionRowLocator)
       : settingsExtensionsPage.getExtensionStartButton(podmanExtensionRowLocator),
   ).toBeVisible();
-  const connectionStatusLabel = podmanExtensionRowLocator.getByLabel(SETTINGS_EXTENSIONS_TABLE_EXTENSION_STATUS_LABEL);
-  await playExpect(connectionStatusLabel).toBeVisible();
-  await connectionStatusLabel.scrollIntoViewIfNeeded();
-  const connectionStatusLocatorText = await connectionStatusLabel.innerText({ timeout: 3000 });
+  const extensionStatusLabel = podmanExtensionRowLocator.getByLabel(SETTINGS_EXTENSIONS_TABLE_EXTENSION_STATUS_LABEL);
+  await playExpect(extensionStatusLabel).toBeVisible();
+  await extensionStatusLabel.scrollIntoViewIfNeeded();
+  const extensionStatusLocatorText = await extensionStatusLabel.innerText({ timeout: 3000 });
   // --------------------------
   playExpect(
     enabled
-      ? connectionStatusLocatorText === PODMAN_EXTENSION_STATUS_RUNNING
-      : connectionStatusLocatorText === PODMAN_EXTENSION_STATUS_OFF,
+      ? extensionStatusLocatorText === PODMAN_EXTENSION_STATUS_ACTIVE
+      : extensionStatusLocatorText === PODMAN_EXTENSION_STATUS_DISABLED,
   ).toBeTruthy();
   // always present and visible
   const podmanExtensionPage = await openSettingsExtensionsPodmanPage();
@@ -118,11 +116,11 @@ async function verifyPodmanExtensionStatus(enabled: boolean): Promise<void> {
   if (enabled) {
     await playExpect(podmanExtensionPage.enableButton).toBeDisabled({ timeout: 10000 });
     await playExpect(podmanExtensionPage.disableButton).toBeEnabled({ timeout: 10000 });
-    await playExpect(podmanExtensionPage.status.getByText(PODMAN_EXTENSION_PAGE_STATUS_ACTIVE)).toBeVisible();
+    await playExpect(podmanExtensionPage.status.getByText(PODMAN_EXTENSION_STATUS_ACTIVE)).toBeVisible();
   } else {
     await playExpect(podmanExtensionPage.enableButton).toBeEnabled({ timeout: 10000 });
     await playExpect(podmanExtensionPage.disableButton).toBeDisabled({ timeout: 10000 });
-    await playExpect(podmanExtensionPage.status.getByText(PODMAN_EXTENSION_PAGE_STATUS_DISABLED)).toBeVisible();
+    await playExpect(podmanExtensionPage.status.getByText(PODMAN_EXTENSION_STATUS_DISABLED)).toBeVisible();
   }
   // expand Settings -> Preferences menu
   await settingsBar.preferencesTab.click();


### PR DESCRIPTION
### What does this PR do?
2 commits:

1. the first one is to fix a copy/paste typo of `connection` that should be `extension`
1. the second one adds `downloadable` state

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

related to https://github.com/containers/podman-desktop/issues/6083

### How to test this PR?


- [x] Tests are covering the bug fix or the new feature
