### PR TITLE
feat: introduce a new section for extensions in the navbar

### DIFF
--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -22,6 +22,8 @@ import CustomPick from './lib/dialogs/CustomPick.svelte';
 import MessageBox from './lib/dialogs/MessageBox.svelte';
 import QuickPickInput from './lib/dialogs/QuickPickInput.svelte';
 import DockerExtension from './lib/docker-extension/DockerExtension.svelte';
+import ExtensionDetails from './lib/extensions/ExtensionDetails.svelte';
+import ExtensionList from './lib/extensions/ExtensionList.svelte';
 import SendFeedback from './lib/feedback/SendFeedback.svelte';
 import HelpPage from './lib/help/HelpPage.svelte';
 import BuildImageFromContainerfile from './lib/image/BuildImageFromContainerfile.svelte';
@@ -237,6 +239,12 @@ window.events?.receive('navigate', (navigationRequest: unknown) => {
         </Route>
         <Route path="/troubleshooting/*" breadcrumb="Troubleshooting">
           <TroubleshootingPage />
+        </Route>
+        <Route path="/extensions" breadcrumb="Extensions" navigationHint="root">
+          <ExtensionList />
+        </Route>
+        <Route path="/extensions/details/:id/*" breadcrumb="Extension Details" let:meta navigationHint="details">
+          <ExtensionDetails extensionId="{meta.params.id}" />
         </Route>
       </div>
     </div>

--- a/packages/renderer/src/AppNavigation.svelte
+++ b/packages/renderer/src/AppNavigation.svelte
@@ -15,6 +15,7 @@ import { ImageUtils } from './lib/image/image-utils';
 import ContainerIcon from './lib/images/ContainerIcon.svelte';
 import DashboardIcon from './lib/images/DashboardIcon.svelte';
 import DeploymentIcon from './lib/images/DeploymentIcon.svelte';
+import ExtensionIcon from './lib/images/ExtensionIcon.svelte';
 import ImageIcon from './lib/images/ImageIcon.svelte';
 import IngressRouteIcon from './lib/images/IngressRouteIcon.svelte';
 import KubeIcon from './lib/images/KubeIcon.svelte';
@@ -25,6 +26,7 @@ import SettingsIcon from './lib/images/SettingsIcon.svelte';
 import VolumeIcon from './lib/images/VolumeIcon.svelte';
 import NavItem from './lib/ui/NavItem.svelte';
 import NavSection from './lib/ui/NavSection.svelte';
+import { combinedInstalledExtensions } from './stores/all-installed-extensions';
 import { containersInfos } from './stores/containers';
 import { contributions } from './stores/contribs';
 import { imagesInfos } from './stores/images';
@@ -47,6 +49,7 @@ let deploymentsSubscribe: Unsubscriber;
 let servicesSubscribe: Unsubscriber;
 let ingressesSubscribe: Unsubscriber;
 let routesSubscribe: Unsubscriber;
+let combinedInstalledExtensionsSubscribe: Unsubscriber;
 
 let podCount = '';
 let containerCount = '';
@@ -58,6 +61,7 @@ let serviceCount = '';
 let ingressesCount = 0;
 let routesCount = 0;
 let ingressesRoutesCount = '';
+let extensionCount = '';
 
 const imageUtils = new ImageUtils();
 export let exitSettingsCallback: () => void;
@@ -122,6 +126,13 @@ onMount(async () => {
   contextsSubscribe = kubernetesContexts.subscribe(value => {
     contextCount = value.length;
   });
+  combinedInstalledExtensionsSubscribe = combinedInstalledExtensions.subscribe(value => {
+    if (value.length > 0) {
+      extensionCount = ` (${value.length})`;
+    } else {
+      extensionCount = '';
+    }
+  });
 });
 
 onDestroy(() => {
@@ -148,6 +159,7 @@ onDestroy(() => {
   }
   ingressesSubscribe?.();
   routesSubscribe?.();
+  combinedInstalledExtensionsSubscribe?.();
 });
 
 function updateIngressesRoutesCount(count: number) {
@@ -192,6 +204,9 @@ export let meta: TinroRouteMeta;
   </NavItem>
   <NavItem href="/volumes" tooltip="Volumes{volumeCount}" ariaLabel="Volumes" bind:meta="{meta}">
     <VolumeIcon size="{iconSize}" />
+  </NavItem>
+  <NavItem href="/extensions" tooltip="Extensions{extensionCount}" ariaLabel="Extensions" bind:meta="{meta}">
+    <ExtensionIcon size="24" />
   </NavItem>
   {#if contextCount > 0}
     <NavSection tooltip="Kubernetes">

--- a/packages/renderer/src/lib/extensions/CatalogExtension.spec.ts
+++ b/packages/renderer/src/lib/extensions/CatalogExtension.spec.ts
@@ -1,0 +1,114 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { router } from 'tinro';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import type { CatalogExtensionInfoUI } from './catalog-extension-info-ui';
+import CatalogExtension from './CatalogExtension.svelte';
+
+// mock the router
+vi.mock('tinro', () => {
+  return {
+    router: {
+      goto: vi.fn(),
+    },
+  };
+});
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  (window as any).extensionInstallFromImage = vi.fn();
+});
+
+test('Expect to have more details working', async () => {
+  const catalogExtensionUI: CatalogExtensionInfoUI = {
+    id: 'myId',
+    displayName: 'This is the display name',
+    isFeatured: false,
+    fetchable: false,
+    fetchLink: '',
+    fetchVersion: '',
+    publisherDisplayName: 'Foo publisher',
+    isInstalled: false,
+    shortDescription: 'my description',
+  };
+
+  render(CatalogExtension, { catalogExtensionUI });
+
+  // get div using aria-label 'This is the display name'
+  const extensionWidget = screen.getByRole('group', { name: 'This is the display name' });
+
+  expect(extensionWidget).toBeInTheDocument();
+
+  // check publisher display name is inside
+  const publisher = screen.getByText('Foo publisher');
+  expect(publisher).toBeInTheDocument();
+
+  // get more details button
+  const detailsButton = screen.getByRole('button', { name: 'More details' });
+  expect(detailsButton).toBeInTheDocument();
+
+  // click the button
+  await fireEvent.click(detailsButton);
+
+  // expect the router to be called
+  expect(vi.mocked(router.goto)).toHaveBeenCalledWith('/extensions/details/myId/');
+});
+
+test('Expect to see featured and fetch button', async () => {
+  const catalogExtensionUI: CatalogExtensionInfoUI = {
+    id: 'myId',
+    displayName: 'This is the display name',
+    isFeatured: true,
+    fetchable: true,
+    fetchLink: 'myLink',
+    fetchVersion: '',
+    publisherDisplayName: 'Foo publisher',
+    isInstalled: false,
+    shortDescription: 'my description',
+  };
+
+  render(CatalogExtension, { catalogExtensionUI });
+
+  // get div using aria-label 'This is the display name'
+  const extensionWidget = screen.getByRole('group', { name: 'This is the display name' });
+
+  expect(extensionWidget).toBeInTheDocument();
+
+  // check featured is inside
+  const featured = screen.getByText('Featured');
+  expect(featured).toBeInTheDocument();
+
+  // get install button
+  const installButton = screen.getByRole('button', { name: 'Install myId Extension' });
+  expect(installButton).toBeInTheDocument();
+
+  // click the button
+  await fireEvent.click(installButton);
+
+  // expect the router to be called
+  expect(vi.mocked(window.extensionInstallFromImage)).toHaveBeenCalledWith(
+    'myLink',
+    expect.any(Function),
+    expect.any(Function),
+  );
+});

--- a/packages/renderer/src/lib/extensions/CatalogExtension.svelte
+++ b/packages/renderer/src/lib/extensions/CatalogExtension.svelte
@@ -15,6 +15,7 @@ function openExtensionDetails() {
 
 <div
   class="rounded-lg border border-[var(--pd-card-bg)] flex flex-col bg-[var(--pd-card-bg)] hover:border-dustypurple-500 min-h-32 max-h-32"
+  role="group"
   aria-label="{catalogExtensionUI.displayName}">
   <!-- if featured need to display a top banner -->
 

--- a/packages/renderer/src/lib/extensions/CatalogExtension.svelte
+++ b/packages/renderer/src/lib/extensions/CatalogExtension.svelte
@@ -1,0 +1,69 @@
+<script lang="ts">
+import { faArrowUpRightFromSquare, faCheckCircle } from '@fortawesome/free-solid-svg-icons';
+import Fa from 'svelte-fa';
+import { router } from 'tinro';
+
+import FeaturedExtensionDownload from '../featured/FeaturedExtensionDownload.svelte';
+import type { CatalogExtensionInfoUI } from './catalog-extension-info-ui';
+
+export let catalogExtensionUI: CatalogExtensionInfoUI;
+
+function openExtensionDetails() {
+  router.goto(`/extensions/details/${catalogExtensionUI.id}/`);
+}
+</script>
+
+<div
+  class="rounded-lg border border-[var(--pd-card-bg)] flex flex-col bg-[var(--pd-card-bg)] hover:border-dustypurple-500 min-h-32 max-h-32"
+  aria-label="{catalogExtensionUI.displayName}">
+  <!-- if featured need to display a top banner -->
+
+  {#if catalogExtensionUI.isFeatured}
+    <div class="bg-dustypurple-500 rounded-t-md px-2 font-light text-xs min-h-6 flex flex-row items-center">
+      Featured
+    </div>
+  {/if}
+
+  <div class="p-3 h-full w-full flex flex-col justify-start">
+    <div class="flex flex-row w-full">
+      <div class="w-3/4 flex flex-col">
+        <div class="flex flex-col w-full">
+          <div class="flex-row flex items-center">
+            <img
+              src="{catalogExtensionUI.iconHref}"
+              alt="{catalogExtensionUI.displayName} logo"
+              class="mr-2 max-w-10 max-h-10 object-contain" />
+
+            <div>
+              <div class="line-clamp-2 leading-4 max-h-8">
+                {catalogExtensionUI.displayName}
+              </div>
+              <div class="pt-2 text-xs text-gray-700 line-clamp-1">{catalogExtensionUI.shortDescription}</div>
+            </div>
+          </div>
+          <div class="pt-1 text-gray-800 text-xs">{catalogExtensionUI.publisherDisplayName}</div>
+        </div>
+      </div>
+
+      {#if catalogExtensionUI.isInstalled}
+        <div class="flex flex-1 text-dustypurple-700 p-1 justify-items-end flex-row place-content-end items-center">
+          <Fa class="ml-1.5 mr-2" size="1.1x" icon="{faCheckCircle}" />
+          <div class="uppercase text-xs cursor-default">Already installed</div>
+        </div>
+      {:else if catalogExtensionUI.fetchable}
+        <div class="flex flex-1 justify-items-end w-18 flex-col items-end place-content-center">
+          <FeaturedExtensionDownload extension="{catalogExtensionUI}" />
+        </div>
+      {/if}
+    </div>
+    <div class="text-gray-200 items-end flex flex-1">
+      <div class="text-gray-700 text-xs">
+        v{catalogExtensionUI.fetchVersion}
+      </div>
+      <div class="flex flex-1 justify-end items-center">
+        <Fa icon="{faArrowUpRightFromSquare}" />
+        <button class="mx-2" on:click="{() => openExtensionDetails()}">More details</button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/packages/renderer/src/lib/extensions/CatalogExtension.svelte
+++ b/packages/renderer/src/lib/extensions/CatalogExtension.svelte
@@ -62,7 +62,7 @@ function openExtensionDetails() {
       </div>
       <div class="flex flex-1 justify-end items-center">
         <Fa icon="{faArrowUpRightFromSquare}" />
-        <button class="mx-2" on:click="{() => openExtensionDetails()}">More details</button>
+        <button class="ml-2" on:click="{() => openExtensionDetails()}">More details</button>
       </div>
     </div>
   </div>

--- a/packages/renderer/src/lib/extensions/CatalogExtensionList.spec.ts
+++ b/packages/renderer/src/lib/extensions/CatalogExtensionList.spec.ts
@@ -1,0 +1,80 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/svelte';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import type { CatalogExtensionInfoUI } from './catalog-extension-info-ui';
+import CatalogExtensionList from './CatalogExtensionList.svelte';
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  (window as any).extensionInstallFromImage = vi.fn();
+});
+
+const extensionA: CatalogExtensionInfoUI = {
+  id: 'myId1',
+  displayName: 'This is the display name1',
+  isFeatured: false,
+  fetchable: false,
+  fetchLink: '',
+  fetchVersion: '',
+  publisherDisplayName: 'Foo publisher',
+  isInstalled: false,
+  shortDescription: 'my description1',
+};
+
+const extensionB: CatalogExtensionInfoUI = {
+  id: 'myId2',
+  displayName: 'This is the display name2',
+  isFeatured: false,
+  fetchable: false,
+  fetchLink: '',
+  fetchVersion: '',
+  publisherDisplayName: 'Foo publisher',
+  isInstalled: false,
+  shortDescription: 'my description2',
+};
+test('Check with empty', async () => {
+  render(CatalogExtensionList, { catalogExtensions: [] });
+
+  // no 'Available extensions' text
+  const availableExtensions = screen.queryByText('Available extensions');
+  expect(availableExtensions).not.toBeInTheDocument();
+});
+
+test('Check with 2 extensions', async () => {
+  render(CatalogExtensionList, { catalogExtensions: [extensionA, extensionB] });
+
+  // 'Available extensions' text
+  const availableExtensions = screen.queryByText('Available extensions');
+  expect(availableExtensions).toBeInTheDocument();
+
+  // get region role with text 'Catalog Extensions'
+  const region = screen.getByRole('region', { name: 'Catalog Extensions' });
+  expect(region).toBeInTheDocument();
+
+  // get div using aria-label 'This is the display name1'
+  const extensionWidgetA = screen.getByRole('group', { name: 'This is the display name1' });
+  expect(extensionWidgetA).toBeInTheDocument();
+
+  const extensionWidgetB = screen.getByRole('group', { name: 'This is the display name2' });
+  expect(extensionWidgetB).toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/extensions/CatalogExtensionList.svelte
+++ b/packages/renderer/src/lib/extensions/CatalogExtensionList.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+import type { CatalogExtensionInfoUI } from './catalog-extension-info-ui';
+import CatalogExtension from './CatalogExtension.svelte';
+
+export let catalogExtensions: CatalogExtensionInfoUI[];
+</script>
+
+<div class="grow p-4">
+  <div class="pb-4">Available extensions</div>
+
+  <div class="flex flex-col w-full">
+    <div
+      class="grid min-[920px]:grid-cols-2 min-[1180px]:grid-cols-3 gap-3"
+      role="region"
+      aria-label="Catalog Extensions">
+      {#each catalogExtensions as catalogExtension}
+        <CatalogExtension catalogExtensionUI="{catalogExtension}" />
+      {/each}
+    </div>
+  </div>
+</div>

--- a/packages/renderer/src/lib/extensions/CatalogExtensionList.svelte
+++ b/packages/renderer/src/lib/extensions/CatalogExtensionList.svelte
@@ -6,7 +6,9 @@ export let catalogExtensions: CatalogExtensionInfoUI[];
 </script>
 
 <div class="flex flex-col grow p-4">
-  <div class="pb-4">Available extensions</div>
+  {#if catalogExtensions.length > 0}
+    <div class="pb-4">Available extensions</div>
+  {/if}
 
   <div class="flex flex-col w-full">
     <div

--- a/packages/renderer/src/lib/extensions/CatalogExtensionList.svelte
+++ b/packages/renderer/src/lib/extensions/CatalogExtensionList.svelte
@@ -5,7 +5,7 @@ import CatalogExtension from './CatalogExtension.svelte';
 export let catalogExtensions: CatalogExtensionInfoUI[];
 </script>
 
-<div class="grow p-4">
+<div class="flex flex-col grow p-4">
   <div class="pb-4">Available extensions</div>
 
   <div class="flex flex-col w-full">

--- a/packages/renderer/src/lib/extensions/ExtensionBadge.spec.ts
+++ b/packages/renderer/src/lib/extensions/ExtensionBadge.spec.ts
@@ -1,0 +1,56 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/svelte';
+import { beforeEach, expect, test } from 'vitest';
+
+import ExtensionBadge from './ExtensionBadge.svelte';
+
+beforeEach(() => {});
+
+test('Expect to have badge for dd Extension', async () => {
+  const extension: { type: 'dd' | 'pd'; removable: boolean } = {
+    type: 'dd',
+    removable: true,
+  };
+  render(ExtensionBadge, { extension });
+  // expect 'Docker Desktop extension' badge
+  const labels = screen.getAllByText('Docker Desktop extension');
+
+  // 2 items
+  expect(labels).toHaveLength(2);
+  expect(labels[0]).toBeInTheDocument();
+  expect(labels[1]).toBeInTheDocument();
+});
+
+test('Expect to have badge for pd  built-in Extension', async () => {
+  const extension: { type: 'dd' | 'pd'; removable: boolean } = {
+    type: 'pd',
+    removable: false,
+  };
+  render(ExtensionBadge, { extension });
+  // expect 'built-in' badge
+  const labels = screen.getAllByText('built-in Extension');
+
+  // 2 items
+  expect(labels).toHaveLength(2);
+  expect(labels[0]).toBeInTheDocument();
+  expect(labels[1]).toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/extensions/ExtensionBadge.svelte
+++ b/packages/renderer/src/lib/extensions/ExtensionBadge.svelte
@@ -11,8 +11,8 @@ export let extension: { type: 'dd' | 'pd'; removable: boolean };
       <Badge class="text-[8px] text-white" color="bg-sky-600" label="Docker Desktop extension" />
     </Tooltip>
   {:else if !extension.removable}
-    <Tooltip tip="Extension provided by default" right>
-      <Badge class="text-[8px] text-charcoal-800" color="bg-sky-200" label="built-in" />
+    <Tooltip tip="built-in Extension" right>
+      <Badge class="text-[8px] text-charcoal-800" color="bg-sky-200" label="built-in Extension" />
     </Tooltip>
   {/if}
 </div>

--- a/packages/renderer/src/lib/extensions/ExtensionBadge.svelte
+++ b/packages/renderer/src/lib/extensions/ExtensionBadge.svelte
@@ -5,7 +5,7 @@ import Tooltip from '/@/lib/ui/Tooltip.svelte';
 export let extension: { type: 'dd' | 'pd'; removable: boolean };
 </script>
 
-<div class="flex flex-row gap-1 items-center {$$props.class}">
+<div class="flex flex-row gap-1 items-center {$$props.class}" role="region" aria-label="Extension Badge">
   {#if extension.type === 'dd'}
     <Tooltip tip="Docker Desktop extension" right>
       <Badge class="text-[8px] text-white" color="bg-sky-600" label="Docker Desktop extension" />

--- a/packages/renderer/src/lib/extensions/ExtensionBadge.svelte
+++ b/packages/renderer/src/lib/extensions/ExtensionBadge.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+import Badge from '/@/lib/ui/Badge.svelte';
+import Tooltip from '/@/lib/ui/Tooltip.svelte';
+
+export let extension: { type: 'dd' | 'pd'; removable: boolean };
+</script>
+
+<div class="flex flex-row gap-1 items-center {$$props.class}">
+  {#if extension.type === 'dd'}
+    <Tooltip tip="Docker Desktop extension" right>
+      <Badge class="text-[8px] text-white" color="bg-sky-600" label="Docker Desktop extension" />
+    </Tooltip>
+  {:else if !extension.removable}
+    <Tooltip tip="Extension provided by default" right>
+      <Badge class="text-[8px] text-charcoal-800" color="bg-sky-200" label="built-in" />
+    </Tooltip>
+  {/if}
+</div>

--- a/packages/renderer/src/lib/extensions/ExtensionDetails.spec.ts
+++ b/packages/renderer/src/lib/extensions/ExtensionDetails.spec.ts
@@ -1,0 +1,98 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/svelte';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { type CombinedExtensionInfoUI } from '/@/stores/all-installed-extensions';
+import { catalogExtensionInfos } from '/@/stores/catalog-extensions';
+import { extensionInfos } from '/@/stores/extensions';
+
+import type { CatalogExtension } from '../../../../main/src/plugin/extensions-catalog/extensions-catalog-api';
+import ExtensionDetails from './ExtensionDetails.svelte';
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+async function waitRender(customProperties: object): Promise<void> {
+  const result = render(ExtensionDetails, { ...customProperties });
+  while (result.component.$$.ctx[0] === undefined) {
+    console.log(result.component.$$.ctx);
+    await new Promise(resolve => setTimeout(resolve, 100));
+  }
+}
+
+export const aFakeExtension: CatalogExtension = {
+  id: 'idAInstalled',
+  publisherName: 'FooPublisher',
+  shortDescription: 'this is short A',
+  publisherDisplayName: 'Foo Publisher',
+  extensionName: 'a-extension',
+  displayName: 'A Extension',
+  categories: [],
+  unlisted: false,
+  versions: [
+    {
+      version: '1.0.0A',
+      preview: false,
+      files: [
+        {
+          assetType: 'icon',
+          data: 'iconA',
+        },
+      ],
+      ociUri: 'linkA',
+      lastUpdated: new Date(),
+    },
+  ],
+};
+
+const combined: CombinedExtensionInfoUI[] = [
+  {
+    id: 'idAInstalled',
+    displayName: 'A installed Extension',
+    name: 'A extension',
+    removable: true,
+    state: 'started',
+  },
+  {
+    id: 'idYInstalled',
+    displayName: 'Y installed Extension',
+  },
+] as unknown[] as CombinedExtensionInfoUI[];
+
+test('Expect to have details page', async () => {
+  const extensionId = 'idAInstalled';
+
+  catalogExtensionInfos.set([aFakeExtension]);
+  extensionInfos.set(combined);
+
+  await waitRender({ extensionId });
+
+  const heading = screen.getByRole('heading', { name: 'A installed Extension extension' });
+  expect(heading).toBeInTheDocument();
+
+  const extensionActions = screen.getByRole('group', { name: 'Extension Actions' });
+  expect(extensionActions).toBeInTheDocument();
+
+  const extensionBadge = screen.getByRole('region', { name: 'Extension Badge' });
+  expect(extensionBadge).toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/extensions/ExtensionDetails.svelte
+++ b/packages/renderer/src/lib/extensions/ExtensionDetails.svelte
@@ -10,10 +10,10 @@ import FeaturedExtensionDownload from '../featured/FeaturedExtensionDownload.sve
 import DetailsPage from '../ui/DetailsPage.svelte';
 import ExtensionStatus from '../ui/ExtensionStatus.svelte';
 import type { ExtensionDetailsUI } from './extension-details-ui';
-import { ExtensionUtils } from './extension-utils';
 import ExtensionBadge from './ExtensionBadge.svelte';
 import ExtensionDetailsReadme from './ExtensionDetailsReadme.svelte';
 import ExtensionDetailsSummaryCard from './ExtensionDetailsSummaryCard.svelte';
+import { ExtensionsUtils } from './extensions-utils';
 import InstalledExtensionActions from './InstalledExtensionActions.svelte';
 
 export let extensionId: string;
@@ -21,12 +21,12 @@ export let extensionId: string;
 let extension: ExtensionDetailsUI;
 
 let detailsPage: DetailsPage;
-const extensionUtils = new ExtensionUtils();
+const extensionsUtils = new ExtensionsUtils();
 
 const extensionDetailStore: Readable<ExtensionDetailsUI | undefined> = derived(
   [catalogExtensionInfos, combinedInstalledExtensions],
   ([$catalogExtensionInfos, $combinedInstalledExtensions]) => {
-    return extensionUtils.extractExtensionDetail($catalogExtensionInfos, $combinedInstalledExtensions, extensionId);
+    return extensionsUtils.extractExtensionDetail($catalogExtensionInfos, $combinedInstalledExtensions, extensionId);
   },
 );
 

--- a/packages/renderer/src/lib/extensions/ExtensionDetails.svelte
+++ b/packages/renderer/src/lib/extensions/ExtensionDetails.svelte
@@ -1,0 +1,193 @@
+<script lang="ts">
+import { onMount } from 'svelte';
+import { derived, type Readable } from 'svelte/store';
+
+import ExtensionIcon from '/@/lib/preferences/ExtensionIcon.svelte';
+import { combinedInstalledExtensions } from '/@/stores/all-installed-extensions';
+import { catalogExtensionInfos } from '/@/stores/catalog-extensions';
+
+import FeaturedExtensionDownload from '../featured/FeaturedExtensionDownload.svelte';
+import DetailsPage from '../ui/DetailsPage.svelte';
+import ExtensionStatus from '../ui/ExtensionStatus.svelte';
+import type { ExtensionDetailsUI } from './extension-details-ui';
+import ExtensionBadge from './ExtensionBadge.svelte';
+import ExtensionDetailsReadme from './ExtensionDetailsReadme.svelte';
+import ExtensionDetailsSummaryCard from './ExtensionDetailsSummaryCard.svelte';
+import InstalledExtensionActions from './InstalledExtensionActions.svelte';
+
+export let extensionId: string;
+
+let extension: ExtensionDetailsUI;
+
+let detailsPage: DetailsPage;
+
+const extensionDetailStore: Readable<ExtensionDetailsUI | undefined> = derived(
+  [catalogExtensionInfos, combinedInstalledExtensions],
+  ([$catalogExtensionInfos, $combinedInstalledExtensions]) => {
+    const matchingInstalledExtension = $combinedInstalledExtensions.find(c => c.id === extensionId);
+    // is it in the catalog
+    const matchingCatalogExtension = $catalogExtensionInfos.find(c => c.id === extensionId);
+
+    // not installed and not in the catalog, return undefined as it is not matching
+    if (!matchingCatalogExtension && !matchingInstalledExtension) {
+      return undefined;
+    }
+
+    let displayName: string;
+
+    let description: string;
+
+    let type: 'dd' | 'pd';
+
+    let removable: boolean;
+    let state: string;
+    let icon: undefined | string | { light: string; dark: string };
+    let iconRef: undefined | string;
+    let name: string;
+    let readme: { content?: string; uri?: string } = {};
+
+    const nonPreviewVersions = matchingCatalogExtension?.versions.filter(v => v.preview === false) ?? [];
+    const latestVersion = nonPreviewVersions.length > 0 ? nonPreviewVersions[0] : undefined;
+    const latestVersionNumber = latestVersion ? `v${latestVersion.version}` : '';
+    const latestVersionOciLink = latestVersion ? latestVersion.ociUri : undefined;
+    const latestVersionIcon = latestVersion ? latestVersion.files.find(f => f.assetType === 'icon')?.data : undefined;
+    const latestVersionReadme = latestVersion
+      ? latestVersion.files.find(f => f.assetType.toLowerCase() === 'readme')?.data
+      : undefined;
+    const lastUpdated = latestVersion?.lastUpdated;
+
+    // grab first from installed extension
+    if (matchingInstalledExtension) {
+      displayName = matchingInstalledExtension.displayName;
+      description = matchingInstalledExtension.description;
+      type = matchingInstalledExtension.type;
+      removable = matchingInstalledExtension.removable;
+      state = matchingInstalledExtension.state;
+      icon = matchingInstalledExtension.icon;
+      name = matchingInstalledExtension.name;
+      readme.content = matchingInstalledExtension.readme;
+    } else if (matchingCatalogExtension) {
+      displayName = matchingCatalogExtension.displayName;
+      description = matchingCatalogExtension.shortDescription;
+      // catalog only includes Podman Desktop extensions
+      type = 'pd';
+      removable = true;
+      state = 'downloadable';
+      name = matchingCatalogExtension.extensionName;
+
+      if (latestVersionReadme) {
+        readme = { uri: latestVersionReadme };
+      }
+
+      if (latestVersionIcon) {
+        iconRef = latestVersionIcon;
+      }
+    } else {
+      displayName = 'Unknown';
+      description = '';
+      type = 'pd';
+      removable = false;
+      state = 'unknown';
+      name = 'unknown';
+    }
+
+    let releaseDate: string = 'N/A';
+    if (lastUpdated) {
+      releaseDate = lastUpdated.toISOString().split('T')[0];
+    }
+
+    let publisherDisplayName = matchingCatalogExtension?.publisherDisplayName ?? 'N/A';
+
+    if (matchingInstalledExtension && !matchingInstalledExtension.removable) {
+      publisherDisplayName = 'Podman Desktop (built-in)';
+    }
+
+    let categories: string[] = matchingCatalogExtension?.categories ?? [];
+    const matchingInstalledExtensionVersion = matchingInstalledExtension?.version
+      ? `v${matchingInstalledExtension.version}`
+      : undefined;
+    let version = matchingInstalledExtensionVersion ?? latestVersionNumber ?? 'N/A';
+
+    const installedExtension = matchingInstalledExtension;
+
+    const fetchLink = latestVersionOciLink ?? '';
+    const fetchVersion = latestVersion?.version ?? '';
+
+    const fetchable = fetchLink.length > 0;
+
+    const matchingExtension: ExtensionDetailsUI = {
+      id: extensionId,
+      displayName,
+      description,
+      type,
+      removable,
+      state,
+      icon,
+      iconRef,
+      name,
+      readme,
+      releaseDate,
+      categories,
+      publisherDisplayName,
+      version,
+      installedExtension,
+      fetchable,
+      fetchLink,
+      fetchVersion,
+    };
+
+    return matchingExtension;
+  },
+);
+
+onMount(() => {
+  // loading container info
+  return extensionDetailStore.subscribe(value => {
+    if (value) {
+      extension = value;
+    } else if (detailsPage) {
+      // the extension has been deleted
+      detailsPage.close();
+    }
+  });
+});
+</script>
+
+{#if extension}
+  <DetailsPage title="{extension.displayName} extension" subtitle="{extension.description}" bind:this="{detailsPage}">
+    <div class="flex flex-col w-14 min-h-14 items-baseline" slot="icon">
+      <!-- Display icon being installed using base64 -->
+      {#if extension.icon}
+        <ExtensionIcon extension="{extension}" />
+      {:else if extension.iconRef}
+        <img src="{extension.iconRef}" alt="{extension.displayName} icon" class="max-w-10 max-h-10" />
+      {/if}
+      <div class="flex flex-row mt-2">
+        <ExtensionStatus status="{extension.type === 'dd' ? 'started' : extension.state}" />
+      </div>
+    </div>
+    <svelte:fragment slot="actions">
+      <div class="flex items-center space-x-10 w-full">
+        {#if extension.installedExtension}
+          <InstalledExtensionActions class="w-48" extension="{extension.installedExtension}" />
+        {:else if extension.fetchable}
+          <div class="flex flex-1 justify-items-end w-18 flex-col items-end place-content-center">
+            <div class="italic text-xs text-gray-700 pb-3">Install this extension with a single click</div>
+            <FeaturedExtensionDownload extension="{extension}" />
+          </div>
+        {/if}
+      </div>
+    </svelte:fragment>
+
+    <div slot="detail" class="flex">
+      <ExtensionBadge class="mt-2" extension="{extension}" />
+    </div>
+
+    <svelte:fragment slot="content">
+      <div class="flex flex-row w-full h-full p-4">
+        <ExtensionDetailsReadme readme="{extension.readme}" />
+        <ExtensionDetailsSummaryCard extensionDetails="{extension}" />
+      </div>
+    </svelte:fragment>
+  </DetailsPage>
+{/if}

--- a/packages/renderer/src/lib/extensions/ExtensionDetails.svelte
+++ b/packages/renderer/src/lib/extensions/ExtensionDetails.svelte
@@ -45,14 +45,16 @@ onMount(() => {
 
 {#if extension}
   <DetailsPage title="{extension.displayName} extension" subtitle="{extension.description}" bind:this="{detailsPage}">
-    <div class="flex flex-col w-14 min-h-14 items-baseline" slot="icon">
-      <!-- Display icon being installed using base64 -->
-      {#if extension.icon}
-        <ExtensionIcon extension="{extension}" />
-      {:else if extension.iconRef}
-        <img src="{extension.iconRef}" alt="{extension.displayName} icon" class="max-w-10 max-h-10" />
-      {/if}
-      <div class="flex flex-row mt-2">
+    <div class="flex flex-col mt-1 items-baseline w-8" slot="icon">
+      <div class="w-8 min-h-8">
+        <!-- Display icon being installed using base64 -->
+        {#if extension.icon}
+          <ExtensionIcon extension="{extension}" />
+        {:else if extension.iconRef}
+          <img src="{extension.iconRef}" alt="{extension.displayName} icon" class="max-w-8 max-h-8" />
+        {/if}
+      </div>
+      <div class="flex flex-row mt-3">
         <ExtensionStatus status="{extension.type === 'dd' ? 'started' : extension.state}" />
       </div>
     </div>
@@ -72,11 +74,10 @@ onMount(() => {
     <div slot="detail" class="flex">
       <ExtensionBadge class="mt-2" extension="{extension}" />
     </div>
-
     <svelte:fragment slot="content">
-      <div class="flex flex-row w-full h-full p-4">
-        <ExtensionDetailsReadme readme="{extension.readme}" />
+      <div class="flex w-full h-full overflow-y-auto p-4 flex-col lg:flex-row">
         <ExtensionDetailsSummaryCard extensionDetails="{extension}" />
+        <ExtensionDetailsReadme readme="{extension.readme}" />
       </div>
     </svelte:fragment>
   </DetailsPage>

--- a/packages/renderer/src/lib/extensions/ExtensionDetails.svelte
+++ b/packages/renderer/src/lib/extensions/ExtensionDetails.svelte
@@ -19,7 +19,6 @@ import InstalledExtensionActions from './InstalledExtensionActions.svelte';
 export let extensionId: string;
 
 let extension: ExtensionDetailsUI;
-
 let detailsPage: DetailsPage;
 const extensionsUtils = new ExtensionsUtils();
 

--- a/packages/renderer/src/lib/extensions/ExtensionDetailsLink.spec.ts
+++ b/packages/renderer/src/lib/extensions/ExtensionDetailsLink.spec.ts
@@ -1,0 +1,71 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { router } from 'tinro';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import type { CombinedExtensionInfoUI } from '/@/stores/all-installed-extensions';
+
+import ExtensionDetailsLink from './ExtensionDetailsLink.svelte';
+
+// mock the router
+vi.mock('tinro', () => {
+  return {
+    router: {
+      goto: vi.fn(),
+    },
+  };
+});
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+test('Expect to have link with displayIcon', async () => {
+  const extension: CombinedExtensionInfoUI = {
+    type: 'pd',
+    id: 'myId',
+    name: 'foo',
+    description: 'my description',
+    displayName: 'This is the display name',
+    publisher: '',
+    removable: false,
+    version: 'v1.2.3',
+    state: 'started',
+    path: '',
+    readme: '',
+    icon: 'iconOfMyExtension.png',
+  };
+
+  render(ExtensionDetailsLink, { extension });
+
+  const detailsButton = screen.getByRole('button', { name: 'foo extension details' });
+  expect(detailsButton).toBeInTheDocument();
+
+  // check text of the button
+  expect(detailsButton).toHaveTextContent('This is the display name');
+
+  // click the button
+  await fireEvent.click(detailsButton);
+
+  // expect the router to be called
+  expect(vi.mocked(router.goto)).toHaveBeenCalledWith('/extensions/details/myId/');
+});

--- a/packages/renderer/src/lib/extensions/ExtensionDetailsLink.svelte
+++ b/packages/renderer/src/lib/extensions/ExtensionDetailsLink.svelte
@@ -17,7 +17,7 @@ function openDetailsExtension() {
 
 <Tooltip tip="{extension.name} extension details" top>
   <button aria-label="{extension.name} extension details" type="button" on:click="{() => openDetailsExtension()}">
-    <div class=" flex flex-row items-baseline">
+    <div class="flex flex-row items-center">
       {#if displayIcon}
         <Fa icon="{faArrowUpRightFromSquare}" />
       {/if}

--- a/packages/renderer/src/lib/extensions/ExtensionDetailsLink.svelte
+++ b/packages/renderer/src/lib/extensions/ExtensionDetailsLink.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+import { faArrowUpRightFromSquare } from '@fortawesome/free-solid-svg-icons';
+import Fa from 'svelte-fa';
+import { router } from 'tinro';
+
+import Tooltip from '/@/lib/ui/Tooltip.svelte';
+import type { CombinedExtensionInfoUI } from '/@/stores/all-installed-extensions';
+
+export let extension: CombinedExtensionInfoUI;
+
+export let displayIcon: boolean = true;
+
+function openDetailsExtension() {
+  router.goto(`/extensions/details/${extension.id}/`);
+}
+</script>
+
+<Tooltip tip="{extension.name} extension details" top>
+  <button aria-label="{extension.name} extension details" type="button" on:click="{() => openDetailsExtension()}">
+    <div class=" flex flex-row items-baseline">
+      {#if displayIcon}
+        <Fa icon="{faArrowUpRightFromSquare}" />
+      {/if}
+      <div class="text-left before:{$$props.class}">
+        {extension.displayName} extension
+      </div>
+    </div>
+  </button>
+</Tooltip>

--- a/packages/renderer/src/lib/extensions/ExtensionDetailsReadme.spec.ts
+++ b/packages/renderer/src/lib/extensions/ExtensionDetailsReadme.spec.ts
@@ -1,0 +1,80 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/svelte';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import ExtensionDetailsReadme from './ExtensionDetailsReadme.svelte';
+
+async function waitRender(customProperties: object): Promise<void> {
+  const result = render(ExtensionDetailsReadme, { ...customProperties });
+  while (result.component.$$.ctx[0] === undefined) {
+    await new Promise(resolve => setTimeout(resolve, 100));
+  }
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+test('Expect to have readme with URI', async () => {
+  const spyFetch = vi.spyOn(window, 'fetch');
+  const response = new Response('# This is my README');
+  spyFetch.mockResolvedValue(response);
+
+  await waitRender({ readme: { uri: 'http://my-fake-registry/readme-content' } });
+
+  // expect Markdown
+  const markdownContent = screen.queryByRole('region', { name: 'markdown-content' });
+  expect(markdownContent).toBeInTheDocument();
+
+  expect(markdownContent).toContainHTML('<h1>This is my README</h1>');
+});
+
+test('Expect to have readme with content', async () => {
+  const spyFetch = vi.spyOn(window, 'fetch');
+
+  await waitRender({ readme: { content: '# my README' } });
+
+  // expect not calling fetch
+  expect(spyFetch).not.toHaveBeenCalled();
+
+  // expect Markdown
+  const markdownContent = screen.getByRole('region', { name: 'markdown-content' });
+  expect(markdownContent).toBeInTheDocument();
+  expect(markdownContent).toContainHTML('<h1>my README</h1>');
+});
+
+test('Expect empty screen if no content', async () => {
+  const spyFetch = vi.spyOn(window, 'fetch');
+
+  await waitRender({ readme: { content: '' } });
+
+  // expect not calling fetch
+  expect(spyFetch).not.toHaveBeenCalled();
+
+  // expect no Markdown
+  const markdownContent = screen.queryByRole('region', { name: 'markdown-content' });
+  expect(markdownContent).not.toBeInTheDocument();
+
+  // but empty screen
+  const emptyScreen = screen.getByRole('heading', { name: 'No Readme' });
+  expect(emptyScreen).toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/extensions/ExtensionDetailsReadme.svelte
+++ b/packages/renderer/src/lib/extensions/ExtensionDetailsReadme.svelte
@@ -7,13 +7,12 @@ import EmptyScreen from '../ui/EmptyScreen.svelte';
 
 export let readme: { content?: string; uri?: string };
 
-let readmeContent: string = '';
+let readmeContent: string | undefined = undefined;
 
 onMount(async () => {
   if (readme.uri) {
     // fetch the readme file content
     const response = await fetch(readme.uri);
-
     if (response.ok) {
       const text = await response.text();
       readmeContent = text;
@@ -39,6 +38,6 @@ onMount(async () => {
   <EmptyScreen
     class="w-full h-full"
     icon="{faFileText}"
-    title="No readme"
+    title="No Readme"
     message="No readme file is available for this extension" />
 {/if}

--- a/packages/renderer/src/lib/extensions/ExtensionDetailsReadme.svelte
+++ b/packages/renderer/src/lib/extensions/ExtensionDetailsReadme.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+import { faFileText } from '@fortawesome/free-solid-svg-icons';
+import { onMount } from 'svelte';
+
+import Markdown from '../markdown/Markdown.svelte';
+import EmptyScreen from '../ui/EmptyScreen.svelte';
+
+export let readme: { content?: string; uri?: string };
+
+let readmeContent: string = '';
+
+onMount(async () => {
+  if (readme.uri) {
+    // fetch the readme file content
+    const response = await fetch(readme.uri);
+
+    if (response.ok) {
+      const text = await response.text();
+      readmeContent = text;
+    }
+  }
+
+  if (!readmeContent && readme.content) {
+    // try with extension readme
+    readmeContent = readme.content;
+  }
+
+  if (!readmeContent) {
+    readmeContent = '';
+  }
+});
+</script>
+
+{#if readmeContent}
+  <div class="overflow-y-scroll leading-6">
+    <Markdown markdown="{readmeContent}" />
+  </div>
+{:else}
+  <EmptyScreen
+    class="w-full h-full"
+    icon="{faFileText}"
+    title="No readme"
+    message="No readme file is available for this extension" />
+{/if}

--- a/packages/renderer/src/lib/extensions/ExtensionDetailsReadme.svelte
+++ b/packages/renderer/src/lib/extensions/ExtensionDetailsReadme.svelte
@@ -31,7 +31,7 @@ onMount(async () => {
 </script>
 
 {#if readmeContent}
-  <div class="overflow-y-scroll leading-6">
+  <div class="w-full min-h-full overflow-y-visible leading-6">
     <Markdown markdown="{readmeContent}" />
   </div>
 {:else}

--- a/packages/renderer/src/lib/extensions/ExtensionDetailsSummaryCard.spec.ts
+++ b/packages/renderer/src/lib/extensions/ExtensionDetailsSummaryCard.spec.ts
@@ -1,0 +1,68 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/svelte';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import type { ExtensionDetailsUI } from './extension-details-ui';
+import ExtensionDetailsSummaryCard from './ExtensionDetailsSummaryCard.svelte';
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+test('Expect to have text of the card including version, release date, publisher and categories', async () => {
+  const extensionDetails: ExtensionDetailsUI = {
+    displayName: 'my display name',
+    description: 'my description',
+    type: 'pd',
+    removable: false,
+    state: 'started',
+    name: 'foo',
+    icon: 'fooIcon',
+    readme: { content: '' },
+    releaseDate: '2024-01-01',
+    categories: ['cat1', 'cat2'],
+    publisherDisplayName: 'my publisher',
+    version: 'v1.2.3',
+    id: 'myId',
+    fetchable: true,
+    fetchLink: 'myLink',
+    fetchVersion: 'v3.4.5',
+  };
+
+  render(ExtensionDetailsSummaryCard, { extensionDetails });
+
+  // should contain the version v1.2.3
+  const version = screen.getByText('v1.2.3');
+  expect(version).toBeInTheDocument();
+
+  // should contain the publisher my publisher
+  const publisher = screen.getByText('my publisher');
+  expect(publisher).toBeInTheDocument();
+
+  // release date
+  const releaseDate = screen.getByText('2024-01-01');
+  expect(releaseDate).toBeInTheDocument();
+
+  // categories
+  const categories = screen.getByText('cat1, cat2');
+  expect(categories).toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/extensions/ExtensionDetailsSummaryCard.svelte
+++ b/packages/renderer/src/lib/extensions/ExtensionDetailsSummaryCard.svelte
@@ -5,8 +5,9 @@ import ExtensionDetailsSummaryCardEntry from './InstalledExtensionDetailsSummary
 export let extensionDetails: ExtensionDetailsUI;
 </script>
 
-<div class="w-48 flex flex-row grow justify-end">
-  <div class="bg-charcoal-600 w-40 h-fit mx-4 p-4 rounded-md flex flex-col">
+<div class="order-first lg:order-last w-full lg:w-48 flex flex-row grow justify-end pb-4 lg:pb-0">
+  <div
+    class="bg-charcoal-600 lg:w-40 h-fit lg:ml-4 p-4 rounded-md flex flex-row lg:flex-col w-full space-x-4 lg:space-x-0">
     <ExtensionDetailsSummaryCardEntry label="version" value="{extensionDetails.version}" />
 
     <ExtensionDetailsSummaryCardEntry label="released" value="{extensionDetails.releaseDate}" />

--- a/packages/renderer/src/lib/extensions/ExtensionDetailsSummaryCard.svelte
+++ b/packages/renderer/src/lib/extensions/ExtensionDetailsSummaryCard.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+import type { ExtensionDetailsUI } from './extension-details-ui';
+import ExtensionDetailsSummaryCardEntry from './InstalledExtensionDetailsSummaryCardEntry.svelte';
+
+export let extensionDetails: ExtensionDetailsUI;
+</script>
+
+<div class="w-48 flex flex-row grow justify-end">
+  <div class="bg-charcoal-600 w-40 h-fit mx-4 p-4 rounded-md flex flex-col">
+    <ExtensionDetailsSummaryCardEntry label="version" value="{extensionDetails.version}" />
+
+    <ExtensionDetailsSummaryCardEntry label="released" value="{extensionDetails.releaseDate}" />
+
+    <ExtensionDetailsSummaryCardEntry label="published by" value="{extensionDetails.publisherDisplayName}" />
+
+    {#if extensionDetails.categories.length > 0}
+      <ExtensionDetailsSummaryCardEntry label="categories" value="{extensionDetails.categories.join(', ')}" />
+    {/if}
+  </div>
+</div>

--- a/packages/renderer/src/lib/extensions/ExtensionList.spec.ts
+++ b/packages/renderer/src/lib/extensions/ExtensionList.spec.ts
@@ -1,0 +1,118 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { type CombinedExtensionInfoUI } from '/@/stores/all-installed-extensions';
+import { catalogExtensionInfos } from '/@/stores/catalog-extensions';
+import { extensionInfos } from '/@/stores/extensions';
+
+import type { CatalogExtension } from '../../../../main/src/plugin/extensions-catalog/extensions-catalog-api';
+import ExtensionList from './ExtensionList.svelte';
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+export const aFakeExtension: CatalogExtension = {
+  id: 'idAInstalled',
+  publisherName: 'FooPublisher',
+  shortDescription: 'this is short A',
+  publisherDisplayName: 'Foo Publisher',
+  extensionName: 'a-extension',
+  displayName: 'A Extension',
+  categories: [],
+  unlisted: false,
+  versions: [
+    {
+      version: '1.0.0A',
+      preview: false,
+      files: [
+        {
+          assetType: 'icon',
+          data: 'iconA',
+        },
+      ],
+      ociUri: 'linkA',
+      lastUpdated: new Date(),
+    },
+  ],
+};
+
+export const bFakeExtension: CatalogExtension = {
+  id: 'idB',
+  publisherName: 'FooPublisher',
+  shortDescription: 'this is short B',
+  publisherDisplayName: 'Foo Publisher',
+  extensionName: 'b-extension',
+  displayName: 'B Extension',
+  categories: [],
+  unlisted: false,
+  versions: [
+    {
+      version: '1.0.0B',
+      preview: false,
+      files: [
+        {
+          assetType: 'icon',
+          data: 'iconB',
+        },
+      ],
+      ociUri: 'linkB',
+      lastUpdated: new Date(),
+    },
+  ],
+};
+
+const combined: CombinedExtensionInfoUI[] = [
+  {
+    id: 'idAInstalled',
+    displayName: 'A installed Extension',
+    removable: true,
+    state: 'started',
+  },
+] as unknown[] as CombinedExtensionInfoUI[];
+
+test('Expect to see extensions', async () => {
+  catalogExtensionInfos.set([aFakeExtension, bFakeExtension]);
+  extensionInfos.set(combined);
+
+  render(ExtensionList);
+
+  const headingExtensions = screen.getByRole('heading', { name: 'extensions' });
+  expect(headingExtensions).toBeInTheDocument();
+
+  // get first extension
+  const myExtension1 = screen.getByRole('region', { name: 'idAInstalled' });
+  expect(myExtension1).toBeInTheDocument();
+
+  // second extension should not be there as only in catalog (not installed)
+  const extensionIdB = screen.queryByRole('group', { name: 'B Extension' });
+  expect(extensionIdB).not.toBeInTheDocument();
+
+  // click on the catalog
+  const catalogTab = screen.getByRole('button', { name: 'Catalog' });
+  await fireEvent.click(catalogTab);
+
+  // now the catalog extension should be there
+  const extensionIdBAfterSwitch = screen.getByRole('group', { name: 'B Extension' });
+  expect(extensionIdBAfterSwitch).toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/extensions/ExtensionList.svelte
+++ b/packages/renderer/src/lib/extensions/ExtensionList.svelte
@@ -1,0 +1,151 @@
+<script lang="ts">
+import { faCloudDownload } from '@fortawesome/free-solid-svg-icons';
+import { derived, type Readable, writable } from 'svelte/store';
+
+import InstalledExtensionList from '/@/lib/extensions/InstalledExtensionList.svelte';
+import ExtensionIcon from '/@/lib/images/ExtensionIcon.svelte';
+import Button from '/@/lib/ui/Button.svelte';
+import FilteredEmptyScreen from '/@/lib/ui/FilteredEmptyScreen.svelte';
+import NavPage from '/@/lib/ui/NavPage.svelte';
+import { type CombinedExtensionInfoUI, combinedInstalledExtensions } from '/@/stores/all-installed-extensions';
+import { catalogExtensionInfos } from '/@/stores/catalog-extensions';
+import { featuredExtensionInfos } from '/@/stores/featuredExtensions';
+
+import type { CatalogExtensionInfoUI } from './catalog-extension-info-ui';
+import CatalogExtensionList from './CatalogExtensionList.svelte';
+import InstallManuallyExtensionModal from './InstallManuallyExtensionModal.svelte';
+
+export let searchTerm = '';
+const combinedInstalledExtensionSearchPattern = writable('');
+$: combinedInstalledExtensionSearchPattern.set(searchTerm);
+
+let filteredItems: number = 0;
+$: filteredItems = $combinedInstalledExtensions.length - $filteredInstalledExtensions.length;
+const filteredInstalledExtensions: Readable<CombinedExtensionInfoUI[]> = derived(
+  [combinedInstalledExtensions, combinedInstalledExtensionSearchPattern],
+  ([$combinedInstalledExtensions, $combinedInstalledExtensionSearchPattern]) => {
+    return $combinedInstalledExtensions.filter(extension => {
+      return extension.displayName.toLowerCase().includes($combinedInstalledExtensionSearchPattern.toLowerCase());
+    });
+  },
+);
+
+// combine data from featured extensions and catalog extension
+// need to add in the catalog extension a flag to know if extension is featured or not
+// and featured extensions need to be displayed first
+const enhancedCatalogExtensions: Readable<CatalogExtensionInfoUI[]> = derived(
+  [catalogExtensionInfos, featuredExtensionInfos, combinedInstalledExtensions],
+  ([$catalogExtensionInfos, $featuredExtensionInfos, $combinedInstalledExtensions]) => {
+    const values: CatalogExtensionInfoUI[] = $catalogExtensionInfos.map(catalogExtension => {
+      // grab latest version
+      const nonPreviewVersions = catalogExtension.versions.filter(v => !v.preview);
+      const latestVersion = nonPreviewVersions[0];
+      const fetchLink = latestVersion.ociUri;
+      const fetchVersion = latestVersion.version;
+      const publisherDisplayName = catalogExtension.publisherDisplayName;
+
+      // grab icon
+      const icon = latestVersion.files.find(f => f.assetType === 'icon');
+      const isInstalled = $combinedInstalledExtensions.some(
+        installedExtension => installedExtension.id === catalogExtension.id,
+      );
+      const isFeatured = $featuredExtensionInfos.some(
+        featuredExtension => featuredExtension.id === catalogExtension.id,
+      );
+
+      const shortDescription = catalogExtension.shortDescription;
+
+      return {
+        id: catalogExtension.id,
+        displayName: catalogExtension.displayName,
+        isFeatured,
+        fetchLink,
+        fetchVersion,
+        fetchable: fetchLink !== '',
+        iconHref: icon?.data,
+        publisherDisplayName,
+        isInstalled,
+        shortDescription,
+      };
+    });
+
+    // sort by isFeatured and then by name
+    values.sort((a, b) => {
+      if (a.isFeatured && !b.isFeatured) {
+        return -1;
+      }
+      if (!a.isFeatured && b.isFeatured) {
+        return 1;
+      }
+      return a.displayName.localeCompare(b.displayName);
+    });
+    return values;
+  },
+);
+
+function closeModal() {
+  installManualImageModal = false;
+}
+
+let screen: 'installed' | 'catalog' = 'installed';
+
+let installManualImageModal: boolean = false;
+</script>
+
+<NavPage bind:searchTerm="{searchTerm}" title="extensions">
+  <svelte:fragment slot="additional-actions">
+    <Button
+      on:click="{() => {
+        installManualImageModal = true;
+      }}"
+      icon="{faCloudDownload}"
+      title="Install manually an extension">Install custom...</Button>
+  </svelte:fragment>
+
+  <svelte:fragment slot="bottom-additional-actions">
+    <!-- display filter out items-->
+    {#if filteredItems > 0 && screen === 'installed'}
+      <div class="text-sm text-gray-400">
+        Filtered out {filteredItems} items of {$combinedInstalledExtensions.length}
+      </div>
+    {/if}
+  </svelte:fragment>
+
+  <svelte:fragment slot="tabs">
+    <Button
+      type="tab"
+      on:click="{() => {
+        screen = 'installed';
+      }}"
+      selected="{screen === 'installed'}">Installed</Button>
+    <Button
+      type="tab"
+      on:click="{() => {
+        screen = 'catalog';
+      }}"
+      selected="{screen === 'catalog'}">Catalog</Button>
+  </svelte:fragment>
+
+  <div class="flex min-w-full h-full" slot="content">
+    {#if searchTerm && $filteredInstalledExtensions.length === 0}
+      <FilteredEmptyScreen
+        icon="{ExtensionIcon}"
+        kind="extensions"
+        searchTerm="{searchTerm}"
+        on:resetFilter="{() => (searchTerm = '')}" />
+    {/if}
+
+    {#if screen === 'installed'}
+      <InstalledExtensionList extensionInfos="{$filteredInstalledExtensions}" />
+    {:else}
+      <CatalogExtensionList catalogExtensions="{$enhancedCatalogExtensions}" />
+    {/if}
+  </div>
+</NavPage>
+
+{#if installManualImageModal}
+  <InstallManuallyExtensionModal
+    closeCallback="{() => {
+      closeModal();
+    }}" />
+{/if}

--- a/packages/renderer/src/lib/extensions/ExtensionList.svelte
+++ b/packages/renderer/src/lib/extensions/ExtensionList.svelte
@@ -13,14 +13,14 @@ import { featuredExtensionInfos } from '/@/stores/featuredExtensions';
 
 import type { CatalogExtensionInfoUI } from './catalog-extension-info-ui';
 import CatalogExtensionList from './CatalogExtensionList.svelte';
-import { ExtensionUtils } from './extension-utils';
+import { ExtensionsUtils } from './extensions-utils';
 import InstallManuallyExtensionModal from './InstallManuallyExtensionModal.svelte';
 
 export let searchTerm = '';
 const combinedInstalledExtensionSearchPattern = writable('');
 $: combinedInstalledExtensionSearchPattern.set(searchTerm);
 
-const extensionUtils = new ExtensionUtils();
+const extensionsUtils = new ExtensionsUtils();
 
 let filteredItems: number = 0;
 $: filteredItems = $combinedInstalledExtensions.length - $filteredInstalledExtensions.length;
@@ -39,7 +39,7 @@ const filteredInstalledExtensions: Readable<CombinedExtensionInfoUI[]> = derived
 const enhancedCatalogExtensions: Readable<CatalogExtensionInfoUI[]> = derived(
   [catalogExtensionInfos, featuredExtensionInfos, combinedInstalledExtensions],
   ([$catalogExtensionInfos, $featuredExtensionInfos, $combinedInstalledExtensions]) => {
-    return extensionUtils.extractCatalogExtensions(
+    return extensionsUtils.extractCatalogExtensions(
       $catalogExtensionInfos,
       $featuredExtensionInfos,
       $combinedInstalledExtensions,

--- a/packages/renderer/src/lib/extensions/InstallManuallyExtensionModal.spec.ts
+++ b/packages/renderer/src/lib/extensions/InstallManuallyExtensionModal.spec.ts
@@ -1,0 +1,78 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import InstallManuallyExtensionModal from './InstallManuallyExtensionModal.svelte';
+
+const closeCallback = vi.fn();
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  (window as any).extensionInstallFromImage = vi.fn();
+});
+
+test('expect invalid field', async () => {
+  render(InstallManuallyExtensionModal, { closeCallback });
+
+  // enter the name quay.io/foobar
+  const input = screen.getByRole('textbox', { name: 'Image name to install custom extension' });
+  expect(input).toBeInTheDocument();
+
+  const button = screen.getByRole('button', { name: 'Install' });
+  expect(button).toBeInTheDocument();
+
+  // disabled due to error
+  expect(button).toBeDisabled();
+});
+
+test('expect able to download an extension', async () => {
+  render(InstallManuallyExtensionModal, { closeCallback });
+
+  // enter the name quay.io/foobar
+  const input = screen.getByRole('textbox', { name: 'Image name to install custom extension' });
+  expect(input).toBeInTheDocument();
+  // now enter the text 'my-custom-image.io/foo'
+  await userEvent.type(input, 'my-custom-image.io/foo');
+
+  // click on the button
+  const button = screen.getByRole('button', { name: 'Install' });
+  expect(button).toBeInTheDocument();
+
+  await userEvent.click(button);
+
+  expect(window.extensionInstallFromImage).toBeCalledWith(
+    'my-custom-image.io/foo',
+    expect.anything(),
+    expect.anything(),
+  );
+
+  // expect button done is there now
+  const buttonDone = screen.getByRole('button', { name: 'Done' });
+  expect(buttonDone).toBeInTheDocument();
+
+  // click on the button
+  await userEvent.click(buttonDone);
+
+  // expect close callback to be called
+  expect(closeCallback).toBeCalled();
+});

--- a/packages/renderer/src/lib/extensions/InstallManuallyExtensionModal.svelte
+++ b/packages/renderer/src/lib/extensions/InstallManuallyExtensionModal.svelte
@@ -11,7 +11,7 @@ export let closeCallback: () => void;
 let imageName = '';
 
 let installInProgress = false;
-let inputfieldError: string | undefined = undefined;
+let inputfieldError: string | undefined = '';
 let progressPercent = 0;
 let logs: string[] = [];
 
@@ -40,7 +40,7 @@ function validateImageName(event: Event): void {
 }
 
 async function installExtension() {
-  inputfieldError = '';
+  inputfieldError = undefined;
   logs = [];
 
   installInProgress = true;
@@ -139,8 +139,11 @@ function handleKeydown(e: KeyboardEvent) {
               closeCallback();
             }}">Cancel</Button>
           {#if progressPercent !== 100}
-            <Button icon="{faCloudDownload}" on:click="{() => installExtension()}" inProgress="{installInProgress}"
-              >Install</Button>
+            <Button
+              icon="{faCloudDownload}"
+              disabled="{inputfieldError !== undefined}"
+              on:click="{() => installExtension()}"
+              inProgress="{installInProgress}">Install</Button>
           {/if}
           {#if progressPercent === 100}
             <Button on:click="{() => closeCallback()}">Done</Button>

--- a/packages/renderer/src/lib/extensions/InstallManuallyExtensionModal.svelte
+++ b/packages/renderer/src/lib/extensions/InstallManuallyExtensionModal.svelte
@@ -1,0 +1,152 @@
+<script lang="ts">
+import { faCloudDownload } from '@fortawesome/free-solid-svg-icons';
+import { Input } from '@podman-desktop/ui-svelte';
+import { onMount } from 'svelte';
+
+import Modal from '/@/lib/dialogs/Modal.svelte';
+import Button from '/@/lib/ui/Button.svelte';
+import CloseButton from '/@/lib/ui/CloseButton.svelte';
+
+export let closeCallback: () => void;
+let imageName = '';
+
+let installInProgress = false;
+let inputfieldError: string | undefined = undefined;
+let progressPercent = 0;
+let logs: string[] = [];
+
+const inputAriaLabel = 'Image name to install custom extension';
+
+onMount(async () => {
+  // search input field and make focus by aria-label Image name to install custom extension
+  const imageNameInputField = document.querySelector(`[aria-label="${inputAriaLabel}"]`);
+  if (imageNameInputField && imageNameInputField instanceof HTMLInputElement) {
+    imageNameInputField.focus();
+  }
+});
+
+function validateImageName(event: Event): void {
+  if (event.target instanceof HTMLInputElement) {
+    let name = event.target.value;
+    if (!name) {
+      inputfieldError = 'Missing name';
+      return;
+    } else {
+      inputfieldError = undefined;
+      return;
+    }
+  }
+  inputfieldError = 'Invalid input';
+}
+
+async function installExtension() {
+  inputfieldError = '';
+  logs = [];
+
+  installInProgress = true;
+
+  // do a trim on the image name
+  const ociImage = imageName?.trim();
+
+  try {
+    // download image
+    await window.extensionInstallFromImage(
+      ociImage,
+      (data: string) => {
+        logs = [...logs, data];
+        console.debug(`Installing ${ociImage}:`, data);
+
+        // try to extract percentage from string like
+        // data Downloading sha256:e8d2c9e5c69499c41ba39b7828c00e55087572884cac466b4d1b47243b085c7d.tar - 11% - (55132/521578)
+        const percentageMatch = data.match(/(\d+)%/);
+        if (percentageMatch) {
+          progressPercent = parseInt(percentageMatch[1]);
+        }
+      },
+      (error: string) => {
+        console.error(`got an error when installing ${ociImage}`, error);
+        installInProgress = false;
+        inputfieldError = error;
+      },
+    );
+    logs = [...logs, '☑️ installation finished !'];
+    progressPercent = 100;
+  } catch (error) {
+    console.error('error', error);
+  }
+  installInProgress = false;
+}
+
+function handleKeydown(e: KeyboardEvent) {
+  if (e.key === 'Enter') {
+    e.preventDefault();
+    if (progressPercent === 100) {
+      closeCallback();
+    } else {
+      installExtension();
+    }
+  }
+}
+</script>
+
+<svelte:window on:keydown="{handleKeydown}" />
+
+<Modal
+  name="Install Extension from OCI image"
+  on:close="{() => {
+    closeCallback();
+  }}">
+  <div class="modal flex flex-col place-self-center bg-charcoal-800 shadow-xl shadow-black">
+    <div class="flex items-center justify-between px-6 py-5 space-x-2">
+      <h1 class="grow text-lg font-bold capitalize">Install custom extension</h1>
+
+      <CloseButton on:click="{() => closeCallback()}" />
+    </div>
+    <div class="flex flex-col px-10 py-4 text-sm leading-5 space-y-5">
+      <div>
+        <label for="imageName" class="block text-sm pb-2 text-gray-400">OCI Image:</label>
+        <div class="min-h-14">
+          {#if progressPercent < 100}
+            <Input
+              bind:value="{imageName}"
+              name="imageName"
+              id="imageName"
+              placeholder="Enter OCI image name of the extension (e.g. quay.io/namespace/my-image)"
+              on:input="{event => validateImageName(event)}"
+              disabled="{installInProgress}"
+              error="{inputfieldError}"
+              aria-invalid="{inputfieldError !== ''}"
+              aria-label="{inputAriaLabel}"
+              required />
+          {:else}
+            <div class="text-gray-400">{imageName} successfully installed.</div>
+          {/if}
+        </div>
+        <div class="w-full min-h-9 h-9 py-2">
+          {#if installInProgress}
+            <div class="flex grow">
+              <div class="w-full h-4 mb-4 rounded-md bg-gray-600 progress-bar overflow-hidden">
+                <div class="h-4 bg-purple-500 rounded-md" role="progressbar" style="width: {progressPercent}%"></div>
+              </div>
+              <div class="ml-2 w-3 text-xs text-purple-500">{progressPercent}%</div>
+            </div>
+          {/if}
+        </div>
+        <div class="w-full grid grid-flow-col justify-items-center">
+          <Button
+            type="link"
+            on:click="{() => {
+              closeCallback();
+            }}">Cancel</Button>
+          {#if progressPercent !== 100}
+            <Button icon="{faCloudDownload}" on:click="{() => installExtension()}" inProgress="{installInProgress}"
+              >Install</Button>
+          {/if}
+          {#if progressPercent === 100}
+            <Button on:click="{() => closeCallback()}">Done</Button>
+          {/if}
+        </div>
+      </div>
+    </div>
+  </div>
+</Modal>

--- a/packages/renderer/src/lib/extensions/InstalledExtensionActions.spec.ts
+++ b/packages/renderer/src/lib/extensions/InstalledExtensionActions.spec.ts
@@ -1,0 +1,52 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/svelte';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import type { CombinedExtensionInfoUI } from '/@/stores/all-installed-extensions';
+
+import InstalledExtensionActions from './InstalledExtensionActions.svelte';
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+test('Expect to see icon, link, badge and actions', async () => {
+  const extension: CombinedExtensionInfoUI = {
+    type: 'pd',
+    id: '',
+    name: 'foo',
+    description: 'my description',
+    displayName: '',
+    publisher: '',
+    removable: false,
+    version: 'v1.2.3',
+    state: 'started',
+    path: '',
+    readme: '',
+    icon: 'iconOfMyExtension.png',
+  };
+  render(InstalledExtensionActions, { extension });
+
+  // get actions be there
+  const actions = screen.getByRole('group', { name: 'Extension Actions' });
+  expect(actions).toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/extensions/InstalledExtensionActions.svelte
+++ b/packages/renderer/src/lib/extensions/InstalledExtensionActions.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+import type { CombinedExtensionInfoUI } from '/@/stores/all-installed-extensions';
+
+import InstalledExtensionCardLeftLifecycle from './InstalledExtensionCardLeftLifecycle.svelte';
+import InstalledExtensionCardLeftOnboardingAndProperties from './InstalledExtensionCardLeftOnboardingAndProperties.svelte';
+
+export let extension: CombinedExtensionInfoUI;
+</script>
+
+<div class="text-center flex-row flex {$$props.class}">
+  <InstalledExtensionCardLeftLifecycle extension="{extension}" />
+  <InstalledExtensionCardLeftOnboardingAndProperties extension="{extension}" />
+</div>

--- a/packages/renderer/src/lib/extensions/InstalledExtensionCard.spec.ts
+++ b/packages/renderer/src/lib/extensions/InstalledExtensionCard.spec.ts
@@ -1,0 +1,54 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/svelte';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import type { CombinedExtensionInfoUI } from '/@/stores/all-installed-extensions';
+
+import InstalledExtensionCard from './InstalledExtensionCard.svelte';
+
+beforeEach(() => {
+  (window as any).ddExtensionDelete = vi.fn();
+  (window as any).removeExtension = vi.fn();
+});
+
+test('Expect to see a div with extension id title', async () => {
+  const extension: CombinedExtensionInfoUI = {
+    type: 'pd',
+    id: 'myExtensionId',
+    name: 'foo',
+    description: 'my description',
+    displayName: '',
+    publisher: '',
+    removable: false,
+    version: 'v1.2.3',
+    state: 'started',
+    path: '',
+    readme: '',
+    icon: 'iconOfMyExtension.png',
+  };
+  render(InstalledExtensionCard, { extension });
+
+  // get role Extension Badge
+  const badge = screen.getByRole('region', { name: 'myExtensionId' });
+  expect(badge).toBeInTheDocument();
+  expect(badge).toHaveTextContent('built-in');
+});

--- a/packages/renderer/src/lib/extensions/InstalledExtensionCard.svelte
+++ b/packages/renderer/src/lib/extensions/InstalledExtensionCard.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+import type { CombinedExtensionInfoUI } from '/@/stores/all-installed-extensions';
+
+import InstalledExtensionCardLeft from './InstalledExtensionCardLeft.svelte';
+import InstalledExtensionCardRight from './InstalledExtensionCardRight.svelte';
+
+export let extension: CombinedExtensionInfoUI;
+</script>
+
+<div
+  class="bg-[color:var(--pd-card-bg)] mb-5 rounded-md p-3 divide-x divide-charcoal-500 flex"
+  role="region"
+  aria-label="{extension.id}">
+  <!-- left col  -->
+  <InstalledExtensionCardLeft extension="{extension}" />
+
+  <div class="grow flex flex-wrap divide-gray-900 ml-2" role="region">
+    <InstalledExtensionCardRight extension="{extension}" />
+  </div>
+</div>

--- a/packages/renderer/src/lib/extensions/InstalledExtensionCardLeft.spec.ts
+++ b/packages/renderer/src/lib/extensions/InstalledExtensionCardLeft.spec.ts
@@ -1,0 +1,72 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/svelte';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import type { CombinedExtensionInfoUI } from '/@/stores/all-installed-extensions';
+
+import InstalledExtensionCardLeft from './InstalledExtensionCardLeft.svelte';
+
+beforeEach(() => {
+  (window as any).ddExtensionDelete = vi.fn();
+  (window as any).removeExtension = vi.fn();
+});
+
+test('Expect to see icon, link, badge and actions', async () => {
+  const extension: CombinedExtensionInfoUI = {
+    type: 'pd',
+    id: '',
+    name: 'foo',
+    description: 'my description',
+    displayName: '',
+    publisher: '',
+    removable: false,
+    version: 'v1.2.3',
+    state: 'started',
+    path: '',
+    readme: '',
+    icon: 'iconOfMyExtension.png',
+  };
+  render(InstalledExtensionCardLeft, { extension });
+
+  // get actions be there
+  const actions = screen.getByRole('group', { name: 'Extension Actions' });
+  expect(actions).toBeInTheDocument();
+
+  // check status
+  const statusLabel = screen.getByLabelText('Extension Status Label');
+  expect(statusLabel).toBeInTheDocument();
+  expect(statusLabel).toHaveTextContent('ACTIVE');
+
+  // get role Extension Badge
+  const badge = screen.getByRole('region', { name: 'Extension Badge' });
+  expect(badge).toBeInTheDocument();
+  expect(badge).toHaveTextContent('built-in');
+
+  // check icon
+  const icon = screen.getByRole('img');
+  expect(icon).toBeInTheDocument();
+  expect(icon).toHaveAttribute('src', 'iconOfMyExtension.png');
+
+  // and the link
+  const detailsButton = screen.getByRole('button', { name: 'foo extension details' });
+  expect(detailsButton).toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/extensions/InstalledExtensionCardLeft.svelte
+++ b/packages/renderer/src/lib/extensions/InstalledExtensionCardLeft.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+import ExtensionIcon from '/@/lib/preferences/ExtensionIcon.svelte';
+import ExtensionStatus from '/@/lib/ui/ExtensionStatus.svelte';
+import type { CombinedExtensionInfoUI } from '/@/stores/all-installed-extensions';
+
+import ExtensionBadge from './ExtensionBadge.svelte';
+import ExtensionDetailsLink from './ExtensionDetailsLink.svelte';
+import InstalledExtensionActions from './InstalledExtensionActions.svelte';
+
+export let extension: CombinedExtensionInfoUI;
+</script>
+
+<div role="region" aria-label="Extension {extension.name} left actions">
+  <div class="relative min-w-[200px] max-w-[200px]">
+    <div class="flex flex-row items-center grow">
+      <div><ExtensionIcon extension="{extension}" /></div>
+      <div class="flex flex-col ml-2">
+        <ExtensionDetailsLink
+          displayIcon="{false}"
+          class="my-auto text-xs text-[color:var(--pd-card-header-text)] break-words"
+          extension="{extension}" />
+        <div class="flex flex-row">
+          <ExtensionStatus status="{extension.type === 'dd' ? 'started' : extension.state}" />
+        </div>
+      </div>
+    </div>
+    <ExtensionBadge class="mt-4" extension="{extension}" />
+    <InstalledExtensionActions class="mt-4" extension="{extension}" />
+  </div>
+</div>

--- a/packages/renderer/src/lib/extensions/InstalledExtensionCardLeftLifecycle.spec.ts
+++ b/packages/renderer/src/lib/extensions/InstalledExtensionCardLeftLifecycle.spec.ts
@@ -1,0 +1,84 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/svelte';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import type { CombinedExtensionInfoUI } from '/@/stores/all-installed-extensions';
+
+import InstalledExtensionCardLeftLifecycle from './InstalledExtensionCardLeftLifecycle.svelte';
+
+beforeEach(() => {
+  (window as any).ddExtensionDelete = vi.fn();
+  (window as any).removeExtension = vi.fn();
+});
+
+test('Expect to see start and delete on stopped pd Extension', async () => {
+  const extension: CombinedExtensionInfoUI = {
+    type: 'pd',
+    id: '',
+    name: 'foo',
+    description: 'my description',
+    displayName: '',
+    publisher: '',
+    removable: true,
+    version: 'v1.2.3',
+    state: 'stopped',
+    path: '',
+    readme: '',
+  };
+  render(InstalledExtensionCardLeftLifecycle, { extension });
+
+  // get actions
+  const actions = screen.getByRole('group', { name: 'Extension Actions' });
+  expect(actions).toBeInTheDocument();
+
+  // should have start button and delete button
+  const start = screen.getByRole('button', { name: 'Start' });
+  expect(start).toBeInTheDocument();
+
+  const deleteButton = screen.getByRole('button', { name: 'Delete' });
+  expect(deleteButton).toBeInTheDocument();
+});
+
+test('Expect to see stop on started pd Extension', async () => {
+  const extension: CombinedExtensionInfoUI = {
+    type: 'pd',
+    id: '',
+    name: 'foo',
+    description: 'my description',
+    displayName: '',
+    publisher: '',
+    removable: true,
+    version: 'v1.2.3',
+    state: 'started',
+    path: '',
+    readme: '',
+  };
+  render(InstalledExtensionCardLeftLifecycle, { extension });
+
+  // get actions
+  const actions = screen.getByRole('group', { name: 'Extension Actions' });
+  expect(actions).toBeInTheDocument();
+
+  // should have stop button
+  const stop = screen.getByRole('button', { name: 'Stop' });
+  expect(stop).toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/extensions/InstalledExtensionCardLeftLifecycle.svelte
+++ b/packages/renderer/src/lib/extensions/InstalledExtensionCardLeftLifecycle.svelte
@@ -8,7 +8,7 @@ import InstalledExtensionCardLeftLifecycleStop from './InstalledExtensionCardLef
 export let extension: CombinedExtensionInfoUI;
 </script>
 
-<div class="flex bg-charcoal-900 w-fit rounded-lg m-auto" role="group" aria-label="Extension Actions">
+<div class="flex bg-charcoal-900 w-fit rounded-lg" role="group" aria-label="Extension Actions">
   <InstalledExtensionCardLeftLifecycleStart extension="{extension}" />
   <InstalledExtensionCardLeftLifecycleStop extension="{extension}" />
   <InstalledExtensionCardLeftLifecycleDelete extension="{extension}" />

--- a/packages/renderer/src/lib/extensions/InstalledExtensionCardLeftLifecycle.svelte
+++ b/packages/renderer/src/lib/extensions/InstalledExtensionCardLeftLifecycle.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+import type { CombinedExtensionInfoUI } from '/@/stores/all-installed-extensions';
+
+import InstalledExtensionCardLeftLifecycleDelete from './InstalledExtensionCardLeftLifecycleDelete.svelte';
+import InstalledExtensionCardLeftLifecycleStart from './InstalledExtensionCardLeftLifecycleStart.svelte';
+import InstalledExtensionCardLeftLifecycleStop from './InstalledExtensionCardLeftLifecycleStop.svelte';
+
+export let extension: CombinedExtensionInfoUI;
+</script>
+
+<div class="flex bg-charcoal-900 w-fit rounded-lg m-auto" role="group" aria-label="Connection Actions">
+  <InstalledExtensionCardLeftLifecycleStart extension="{extension}" />
+  <InstalledExtensionCardLeftLifecycleStop extension="{extension}" />
+  <InstalledExtensionCardLeftLifecycleDelete extension="{extension}" />
+</div>

--- a/packages/renderer/src/lib/extensions/InstalledExtensionCardLeftLifecycle.svelte
+++ b/packages/renderer/src/lib/extensions/InstalledExtensionCardLeftLifecycle.svelte
@@ -8,7 +8,7 @@ import InstalledExtensionCardLeftLifecycleStop from './InstalledExtensionCardLef
 export let extension: CombinedExtensionInfoUI;
 </script>
 
-<div class="flex bg-charcoal-900 w-fit rounded-lg m-auto" role="group" aria-label="Connection Actions">
+<div class="flex bg-charcoal-900 w-fit rounded-lg m-auto" role="group" aria-label="Extension Actions">
   <InstalledExtensionCardLeftLifecycleStart extension="{extension}" />
   <InstalledExtensionCardLeftLifecycleStop extension="{extension}" />
   <InstalledExtensionCardLeftLifecycleDelete extension="{extension}" />

--- a/packages/renderer/src/lib/extensions/InstalledExtensionCardLeftLifecycleDelete.spec.ts
+++ b/packages/renderer/src/lib/extensions/InstalledExtensionCardLeftLifecycleDelete.spec.ts
@@ -1,0 +1,135 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import type { CombinedExtensionInfoUI } from '/@/stores/all-installed-extensions';
+
+import InstalledExtensionCardLeftLifecycleDelete from './InstalledExtensionCardLeftLifecycleDelete.svelte';
+
+beforeEach(() => {
+  (window as any).ddExtensionDelete = vi.fn();
+  (window as any).removeExtension = vi.fn();
+});
+
+test('Expect to delete dd Extension', async () => {
+  const extension: CombinedExtensionInfoUI = {
+    type: 'dd',
+    id: '',
+    name: 'foo',
+    description: 'my description',
+    displayName: '',
+    publisher: '',
+    removable: true,
+    version: 'v1.2.3',
+    state: '',
+    path: '',
+    readme: '',
+  };
+  render(InstalledExtensionCardLeftLifecycleDelete, { extension });
+
+  // get button with label 'Delete Extension foo'
+  const button = screen.getByRole('button', { name: 'Delete' });
+  expect(button).toBeInTheDocument();
+
+  // click the button
+  await fireEvent.click(button);
+
+  // expect the delete function to be called
+  expect(vi.mocked(window.ddExtensionDelete)).toHaveBeenCalledWith('foo');
+  expect(vi.mocked(window.removeExtension)).not.toHaveBeenCalled();
+});
+
+test('Expect to delete pd Extension', async () => {
+  const extension: CombinedExtensionInfoUI = {
+    type: 'pd',
+    id: 'idExtension',
+    name: 'fooName',
+    description: 'my description',
+    displayName: '',
+    publisher: '',
+    removable: true,
+    version: 'v1.2.3',
+    state: '',
+    path: '',
+    readme: '',
+  };
+  render(InstalledExtensionCardLeftLifecycleDelete, { extension });
+
+  // get button with label 'Delete Extension foo'
+  const button = screen.getByRole('button', { name: 'Delete' });
+  expect(button).toBeInTheDocument();
+
+  // click the button
+  await fireEvent.click(button);
+
+  // expect the delete function to be called
+  expect(vi.mocked(window.ddExtensionDelete)).not.toHaveBeenCalled();
+  expect(vi.mocked(window.removeExtension)).toHaveBeenCalledWith('idExtension');
+});
+
+test('Expect unable to delete pd Extension if not removable', async () => {
+  const extension: CombinedExtensionInfoUI = {
+    type: 'pd',
+    id: 'idExtension',
+    name: 'fooName',
+    description: 'my description',
+    displayName: '',
+    publisher: '',
+    removable: false,
+    version: 'v1.2.3',
+    state: 'stopped',
+    path: '',
+    readme: '',
+  };
+  render(InstalledExtensionCardLeftLifecycleDelete, { extension });
+
+  // get button with label 'Delete Extension foo'
+  const button = screen.getByRole('button', { name: 'Delete' });
+  expect(button).toBeInTheDocument();
+
+  // expect to be disabled
+  expect(button).toBeDisabled();
+});
+
+test('Expect able to delete pd Extension if removable', async () => {
+  const extension: CombinedExtensionInfoUI = {
+    type: 'pd',
+    id: 'idExtension',
+    name: 'fooName',
+    description: 'my description',
+    displayName: '',
+    publisher: '',
+    removable: true,
+    version: 'v1.2.3',
+    state: 'stopped',
+    path: '',
+    readme: '',
+  };
+  render(InstalledExtensionCardLeftLifecycleDelete, { extension });
+
+  // get button with label 'Delete Extension foo'
+  const button = screen.getByRole('button', { name: 'Delete' });
+  expect(button).toBeInTheDocument();
+
+  // expect to be enabled
+  expect(button).toBeEnabled();
+});

--- a/packages/renderer/src/lib/extensions/InstalledExtensionCardLeftLifecycleDelete.svelte
+++ b/packages/renderer/src/lib/extensions/InstalledExtensionCardLeftLifecycleDelete.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+import { faTrashCan } from '@fortawesome/free-solid-svg-icons';
+
+import type { CombinedExtensionInfoUI } from '/@/stores/all-installed-extensions';
+
+import LoadingIconButton from '../ui/LoadingIconButton.svelte';
+
+export let extension: CombinedExtensionInfoUI;
+
+let inProgress = false;
+
+async function deleteExtension(): Promise<void> {
+  inProgress = true;
+  if (extension.type === 'dd') {
+    await window.ddExtensionDelete(extension.name);
+  } else {
+    await window.removeExtension(extension.id);
+  }
+  inProgress = false;
+}
+</script>
+
+<div class="text-sm">
+  <LoadingIconButton
+    clickAction="{() => deleteExtension()}"
+    action="delete"
+    icon="{faTrashCan}"
+    state="{{ status: extension.type === 'dd' ? 'stopped' : extension.removable ? extension.state : '', inProgress }}"
+    leftPosition="" />
+</div>

--- a/packages/renderer/src/lib/extensions/InstalledExtensionCardLeftLifecycleStart.spec.ts
+++ b/packages/renderer/src/lib/extensions/InstalledExtensionCardLeftLifecycleStart.spec.ts
@@ -1,0 +1,106 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import type { CombinedExtensionInfoUI } from '/@/stores/all-installed-extensions';
+
+import InstalledExtensionCardLeftLifecycleStart from './InstalledExtensionCardLeftLifecycleStart.svelte';
+
+beforeEach(() => {
+  (window as any).startExtension = vi.fn();
+});
+
+test('Expect to start dd Extension if stopped', async () => {
+  const extension: CombinedExtensionInfoUI = {
+    type: 'dd',
+    id: 'idExtension',
+    name: 'foo',
+    description: 'my description',
+    displayName: '',
+    publisher: '',
+    removable: true,
+    version: 'v1.2.3',
+    state: 'stopped',
+    path: '',
+    readme: '',
+  };
+  render(InstalledExtensionCardLeftLifecycleStart, { extension });
+
+  // get button with label 'Start'
+
+  const button = screen.getByRole('button', { name: 'Start' });
+  expect(button).toBeInTheDocument();
+
+  // click the button
+  await fireEvent.click(button);
+
+  // expect the start function to be called
+  expect(vi.mocked(window.startExtension)).toHaveBeenCalledWith('idExtension');
+});
+
+test('Expect to start pd Extension if stopped', async () => {
+  const extension: CombinedExtensionInfoUI = {
+    type: 'pd',
+    id: 'idExtension',
+    name: 'fooName',
+    description: 'my description',
+    displayName: '',
+    publisher: '',
+    removable: true,
+    version: 'v1.2.3',
+    state: 'stopped',
+    path: '',
+    readme: '',
+  };
+  render(InstalledExtensionCardLeftLifecycleStart, { extension });
+
+  // get button with label 'Start'
+  const button = screen.getByRole('button', { name: 'Start' });
+  expect(button).toBeInTheDocument();
+
+  // click the button
+  await fireEvent.click(button);
+
+  // expect the start function to be called
+  expect(vi.mocked(window.startExtension)).toHaveBeenCalledWith('idExtension');
+});
+
+test('Expect unable to start if already started', async () => {
+  const extension: CombinedExtensionInfoUI = {
+    type: 'pd',
+    id: 'idExtension',
+    name: 'fooName',
+    description: 'my description',
+    displayName: '',
+    publisher: '',
+    removable: true,
+    version: 'v1.2.3',
+    state: 'started',
+    path: '',
+    readme: '',
+  };
+  render(InstalledExtensionCardLeftLifecycleStart, { extension });
+
+  // get button with label 'Delete Extension foo'
+  const button = screen.queryByRole('button', { name: 'Start' });
+  expect(button).not.toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/extensions/InstalledExtensionCardLeftLifecycleStart.svelte
+++ b/packages/renderer/src/lib/extensions/InstalledExtensionCardLeftLifecycleStart.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+import { faPlay } from '@fortawesome/free-solid-svg-icons';
+
+import type { CombinedExtensionInfoUI } from '/@/stores/all-installed-extensions';
+
+import LoadingIconButton from '../ui/LoadingIconButton.svelte';
+
+export let extension: CombinedExtensionInfoUI;
+
+let inProgress = false;
+
+async function startExtension(): Promise<void> {
+  inProgress = true;
+  await window.startExtension(extension.id);
+  inProgress = false;
+}
+</script>
+
+{#if extension.state === 'stopped'}
+  <LoadingIconButton
+    clickAction="{() => startExtension()}"
+    action="start"
+    icon="{faPlay}"
+    state="{{ status: extension.state, inProgress }}"
+    leftPosition="" />
+{/if}

--- a/packages/renderer/src/lib/extensions/InstalledExtensionCardLeftLifecycleStop.spec.ts
+++ b/packages/renderer/src/lib/extensions/InstalledExtensionCardLeftLifecycleStop.spec.ts
@@ -1,0 +1,99 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import type { CombinedExtensionInfoUI } from '/@/stores/all-installed-extensions';
+
+import InstalledExtensionCardLeftLifecycleStop from './InstalledExtensionCardLeftLifecycleStop.svelte';
+
+beforeEach(() => {
+  (window as any).stopExtension = vi.fn();
+});
+
+test('Expect unable to stop dd Extension if started', async () => {
+  const extension: CombinedExtensionInfoUI = {
+    type: 'dd',
+    id: 'idExtension',
+    name: 'foo',
+    description: 'my description',
+    displayName: '',
+    publisher: '',
+    removable: true,
+    version: 'v1.2.3',
+    state: 'started',
+    path: '',
+    readme: '',
+  };
+  render(InstalledExtensionCardLeftLifecycleStop, { extension });
+
+  // get button with label 'Stop'
+  const button = screen.queryByRole('button', { name: 'Stop' });
+  expect(button).not.toBeInTheDocument();
+});
+
+test('Expect to stop pd Extension if started', async () => {
+  const extension: CombinedExtensionInfoUI = {
+    type: 'pd',
+    id: 'idExtension',
+    name: 'fooName',
+    description: 'my description',
+    displayName: '',
+    publisher: '',
+    removable: true,
+    version: 'v1.2.3',
+    state: 'started',
+    path: '',
+    readme: '',
+  };
+  render(InstalledExtensionCardLeftLifecycleStop, { extension });
+
+  // get button with label 'Stop'
+  const button = screen.getByRole('button', { name: 'Stop' });
+  expect(button).toBeInTheDocument();
+
+  // click the button
+  await fireEvent.click(button);
+
+  // expect the delete function to be called
+  expect(vi.mocked(window.stopExtension)).toHaveBeenCalledWith('idExtension');
+});
+
+test('Expect unable to stop if already stopped', async () => {
+  const extension: CombinedExtensionInfoUI = {
+    type: 'pd',
+    id: 'idExtension',
+    name: 'fooName',
+    description: 'my description',
+    displayName: '',
+    publisher: '',
+    removable: true,
+    version: 'v1.2.3',
+    state: 'stopped',
+    path: '',
+    readme: '',
+  };
+  render(InstalledExtensionCardLeftLifecycleStop, { extension });
+
+  // get button with label 'Stop'
+  const button = screen.queryByRole('button', { name: 'Stop' });
+  expect(button).not.toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/extensions/InstalledExtensionCardLeftLifecycleStop.svelte
+++ b/packages/renderer/src/lib/extensions/InstalledExtensionCardLeftLifecycleStop.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+import { faStop } from '@fortawesome/free-solid-svg-icons';
+
+import type { CombinedExtensionInfoUI } from '/@/stores/all-installed-extensions';
+
+import LoadingIconButton from '../ui/LoadingIconButton.svelte';
+
+export let extension: CombinedExtensionInfoUI;
+
+let inProgress = false;
+
+async function stopExtension(): Promise<void> {
+  inProgress = true;
+  await window.stopExtension(extension.id);
+  inProgress = false;
+}
+</script>
+
+{#if extension.state === 'started' && extension.type !== 'dd'}
+  <LoadingIconButton
+    clickAction="{() => stopExtension()}"
+    action="stop"
+    icon="{faStop}"
+    state="{{ status: extension.state, inProgress }}"
+    leftPosition="" />
+{/if}

--- a/packages/renderer/src/lib/extensions/InstalledExtensionCardLeftOnboardingAndProperties.spec.ts
+++ b/packages/renderer/src/lib/extensions/InstalledExtensionCardLeftOnboardingAndProperties.spec.ts
@@ -1,0 +1,126 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { router } from 'tinro';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import type { CombinedExtensionInfoUI } from '/@/stores/all-installed-extensions';
+import { configurationProperties } from '/@/stores/configurationProperties';
+import { onboardingList } from '/@/stores/onboarding';
+
+import type { OnboardingInfo } from '../../../../main/src/plugin/api/onboarding';
+import type { IConfigurationPropertyRecordedSchema } from '../../../../main/src/plugin/configuration-registry';
+import InstalledExtensionCardLeftOnboardingAndProperties from './InstalledExtensionCardLeftOnboardingAndProperties.svelte';
+
+// mock the router
+vi.mock('tinro', () => {
+  return {
+    router: {
+      goto: vi.fn(),
+    },
+  };
+});
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+test('Expect to have onboarding button for extension', async () => {
+  const onboardingInfo: OnboardingInfo = {
+    extension: 'myExtensionId',
+    name: '',
+    displayName: '',
+    icon: '',
+    title: '',
+    steps: [],
+    enablement: 'true',
+  };
+
+  onboardingList.set([onboardingInfo]);
+
+  const extension: CombinedExtensionInfoUI = {
+    type: 'pd',
+    id: 'myExtensionId',
+    name: 'foo',
+    description: 'my description',
+    displayName: '',
+    publisher: '',
+    removable: true,
+    version: 'v1.2.3',
+    state: '',
+    path: '',
+    readme: '',
+  };
+  render(InstalledExtensionCardLeftOnboardingAndProperties, { extension });
+
+  // expect button to be there 'Onboarding foo'
+  const onboardingButton = screen.getByRole('button', { name: 'Onboarding foo' });
+  expect(onboardingButton).toBeInTheDocument();
+
+  // expect button to be enabled
+  expect(onboardingButton).toBeEnabled();
+
+  // click on it
+  await fireEvent.click(onboardingButton);
+
+  // check method has been called
+  expect(router.goto).toHaveBeenCalledWith('/preferences/onboarding/myExtensionId');
+});
+
+test('expect edit properties button being enabled', async () => {
+  const configSchema: IConfigurationPropertyRecordedSchema = {
+    title: '',
+    parentId: 'preferences.myExtensionId.hello',
+    scope: 'DEFAULT',
+  };
+
+  // add onboarding properties
+  configurationProperties.set([configSchema]);
+
+  const extension: CombinedExtensionInfoUI = {
+    type: 'pd',
+    id: 'myExtensionId',
+    name: 'foo',
+    description: 'my description',
+    displayName: '',
+    publisher: '',
+    removable: true,
+    version: 'v1.2.3',
+    state: '',
+    path: '',
+    readme: '',
+  };
+
+  render(InstalledExtensionCardLeftOnboardingAndProperties, { extension });
+
+  // expect button to be there 'Edit Properties'
+  const editPropertiesButton = screen.getByRole('button', { name: 'Edit properties of foo extension' });
+  expect(editPropertiesButton).toBeInTheDocument();
+
+  // expect button to be enabled
+  expect(editPropertiesButton).toBeEnabled();
+
+  // click on it
+  await fireEvent.click(editPropertiesButton);
+
+  // check method has been called
+  expect(router.goto).toHaveBeenCalledWith('/preferences/default/preferences.myExtensionId');
+});

--- a/packages/renderer/src/lib/extensions/InstalledExtensionCardLeftOnboardingAndProperties.svelte
+++ b/packages/renderer/src/lib/extensions/InstalledExtensionCardLeftOnboardingAndProperties.svelte
@@ -1,0 +1,97 @@
+<script lang="ts">
+import { faFilePen, faGear } from '@fortawesome/free-solid-svg-icons';
+import { onDestroy, onMount } from 'svelte';
+import { derived, get, type Readable, type Unsubscriber } from 'svelte/store';
+import Fa from 'svelte-fa';
+import { router } from 'tinro';
+
+import Button from '/@/lib/ui/Button.svelte';
+import type { CombinedExtensionInfoUI } from '/@/stores/all-installed-extensions';
+import { configurationProperties } from '/@/stores/configurationProperties';
+import { context } from '/@/stores/context';
+import { onboardingList } from '/@/stores/onboarding';
+
+import { ContextKeyExpr } from '../context/contextKey';
+import { normalizeOnboardingWhenClause } from '../onboarding/onboarding-utils';
+import { isDefaultScope, isPropertyValidInContext } from '../preferences/Util';
+
+export let extension: CombinedExtensionInfoUI;
+
+let onboardingsUnsubscribe: Unsubscriber | undefined;
+let onboardingEnabledUnsubscribe: Unsubscriber | undefined;
+let configurationPropertiesUnsubscribe: Unsubscriber | undefined;
+let onboardingEnabledReadable: Readable<boolean>;
+let isOnboardingEnabled = false;
+
+let hasAnyConfiguration = false;
+
+onMount(() => {
+  configurationPropertiesUnsubscribe = configurationProperties.subscribe(properties => {
+    let globalContext = get(context);
+
+    hasAnyConfiguration =
+      properties
+        .filter(
+          property =>
+            property.parentId.startsWith(`preferences.${extension.id}`) &&
+            isDefaultScope(property.scope) &&
+            !property.hidden,
+        )
+        .filter(property => isPropertyValidInContext(property.when, globalContext)).length > 0;
+  });
+
+  onboardingEnabledReadable = derived([onboardingList, context], ([$onboardingList, $context]) => {
+    if (extension.type === 'dd') {
+      return false;
+    }
+
+    const matchingOnBoarding = $onboardingList.findLast(o => o.extension === extension.id && o.enablement);
+    if (!matchingOnBoarding) {
+      return false;
+    } else {
+      const enablement = normalizeOnboardingWhenClause(matchingOnBoarding.enablement, extension.id);
+      const whenDeserialized = ContextKeyExpr.deserialize(enablement);
+      const isEnabled = whenDeserialized?.evaluate($context);
+      return isEnabled || false;
+    }
+  });
+
+  onboardingEnabledUnsubscribe = onboardingEnabledReadable.subscribe(value => {
+    isOnboardingEnabled = value;
+  });
+});
+
+onDestroy(() => {
+  onboardingsUnsubscribe?.();
+  onboardingEnabledUnsubscribe?.();
+  configurationPropertiesUnsubscribe?.();
+});
+
+function handleOnboarding() {
+  router.goto(`/preferences/onboarding/${extension.id}`);
+}
+
+function handleProperties() {
+  router.goto(`/preferences/default/preferences.${extension.id}`);
+}
+</script>
+
+<Button
+  aria-label="Onboarding {extension.name}"
+  title="Onboarding {extension.name}"
+  type="primary"
+  class="m-auto {!isOnboardingEnabled ? 'cursor-not-allowed' : ''}"
+  disabled="{!isOnboardingEnabled}"
+  on:click="{() => handleOnboarding()}">
+  <Fa size="1x" icon="{faGear}" />
+</Button>
+
+<Button
+  aria-label="Edit properties of {extension.name} extension"
+  title="Edit properties of {extension.name} extension"
+  type="secondary"
+  class="m-auto {!hasAnyConfiguration ? 'cursor-not-allowed' : ''}"
+  disabled="{!hasAnyConfiguration}"
+  on:click="{() => handleProperties()}">
+  <Fa size="1x" icon="{faFilePen}" />
+</Button>

--- a/packages/renderer/src/lib/extensions/InstalledExtensionCardLeftOnboardingAndProperties.svelte
+++ b/packages/renderer/src/lib/extensions/InstalledExtensionCardLeftOnboardingAndProperties.svelte
@@ -46,6 +46,7 @@ onMount(() => {
     }
 
     const matchingOnBoarding = $onboardingList.findLast(o => o.extension === extension.id && o.enablement);
+
     if (!matchingOnBoarding) {
       return false;
     } else {

--- a/packages/renderer/src/lib/extensions/InstalledExtensionCardRight.spec.ts
+++ b/packages/renderer/src/lib/extensions/InstalledExtensionCardRight.spec.ts
@@ -52,7 +52,7 @@ test('Expect to have description and version', async () => {
   expect(region).toHaveTextContent('v1.2.3');
 
   // not removable
-  expect(region).not.toHaveTextContent('Podman Desktop default extension');
+  expect(region).not.toHaveTextContent('Podman Desktop built-in extension');
 });
 
 test('Expect to have podman desktop extension info (removable = false)', async () => {
@@ -76,5 +76,5 @@ test('Expect to have podman desktop extension info (removable = false)', async (
   expect(region).toBeInTheDocument();
 
   // region contains the details
-  expect(region).toHaveTextContent('Podman Desktop default extension');
+  expect(region).toHaveTextContent('Podman Desktop built-in extension');
 });

--- a/packages/renderer/src/lib/extensions/InstalledExtensionCardRight.spec.ts
+++ b/packages/renderer/src/lib/extensions/InstalledExtensionCardRight.spec.ts
@@ -1,0 +1,80 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/svelte';
+import { expect, test } from 'vitest';
+
+import type { CombinedExtensionInfoUI } from '/@/stores/all-installed-extensions';
+
+import InstalledExtensionCardRight from './InstalledExtensionCardRight.svelte';
+
+test('Expect to have description and version', async () => {
+  const extension: CombinedExtensionInfoUI = {
+    type: 'dd',
+    id: '',
+    name: 'foo',
+    description: 'my description',
+    displayName: '',
+    publisher: '',
+    removable: true,
+    version: 'v1.2.3',
+    state: '',
+    path: '',
+    readme: '',
+  };
+  render(InstalledExtensionCardRight, { extension });
+
+  // get region named Extension {extension.name} right actions
+  const region = screen.getByRole('region', { name: 'Extension foo right actions' });
+  expect(region).toBeInTheDocument();
+
+  // region contains the description
+  expect(region).toHaveTextContent('my description');
+
+  // region contains the version
+  expect(region).toHaveTextContent('v1.2.3');
+
+  // not removable
+  expect(region).not.toHaveTextContent('Podman Desktop default extension');
+});
+
+test('Expect to have podman desktop extension info (removable = false)', async () => {
+  const extension: CombinedExtensionInfoUI = {
+    type: 'dd',
+    id: '',
+    name: 'foo',
+    description: 'my description',
+    displayName: '',
+    publisher: '',
+    removable: false,
+    version: 'v1.2.3',
+    state: '',
+    path: '',
+    readme: '',
+  };
+  render(InstalledExtensionCardRight, { extension });
+
+  // get region named Extension {extension.name} right actions
+  const region = screen.getByRole('region', { name: 'Extension foo right actions' });
+  expect(region).toBeInTheDocument();
+
+  // region contains the details
+  expect(region).toHaveTextContent('Podman Desktop default extension');
+});

--- a/packages/renderer/src/lib/extensions/InstalledExtensionCardRight.svelte
+++ b/packages/renderer/src/lib/extensions/InstalledExtensionCardRight.svelte
@@ -16,7 +16,7 @@ export let extension: CombinedExtensionInfoUI;
   </div>
   <div class="absolute bottom-0 flex flex-col text-gray-700 text-xs" aria-label="">
     <div>
-      {extension.removable ? '' : 'Podman Desktop default extension'}
+      {extension.removable ? '' : 'Podman Desktop built-in extension'}
     </div>
     <div>
       {#if extension.version}

--- a/packages/renderer/src/lib/extensions/InstalledExtensionCardRight.svelte
+++ b/packages/renderer/src/lib/extensions/InstalledExtensionCardRight.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+import type { CombinedExtensionInfoUI } from '/@/stores/all-installed-extensions';
+
+import ExtensionDetailsLink from './ExtensionDetailsLink.svelte';
+
+export let extension: CombinedExtensionInfoUI;
+</script>
+
+<div class="relative px-5 py-2" role="region" aria-label="Extension {extension.name} right actions">
+  <ExtensionDetailsLink class="font-bold text-base ml-2" extension="{extension}" />
+
+  <div class="flex text-sm text-gray-700" aria-label="">
+    {#if extension.description}
+      {extension.description}
+    {/if}
+  </div>
+  <div class="absolute bottom-0 flex flex-col text-gray-700 text-xs" aria-label="">
+    <div>
+      {extension.removable ? '' : 'Podman Desktop default extension'}
+    </div>
+    <div>
+      {#if extension.version}
+        v{extension.version}
+      {/if}
+    </div>
+  </div>
+</div>

--- a/packages/renderer/src/lib/extensions/InstalledExtensionDetailsSummaryCardEntry.spec.ts
+++ b/packages/renderer/src/lib/extensions/InstalledExtensionDetailsSummaryCardEntry.spec.ts
@@ -1,0 +1,40 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/svelte';
+import { expect, test } from 'vitest';
+
+import InstalledExtensionDetailsSummaryCardEntry from './InstalledExtensionDetailsSummaryCardEntry.svelte';
+
+test('Expect to have label and value', async () => {
+  render(InstalledExtensionDetailsSummaryCardEntry, { label: 'my-label', value: 'my-value' });
+
+  // grab the label and value elements
+  const label = screen.getByText('my-label');
+  const value = screen.getByText('my-value');
+
+  // expect the label and value to be in the document
+  expect(label).toBeInTheDocument();
+  expect(value).toBeInTheDocument();
+
+  // expect classes to be applied
+  expect(label).toHaveClass('uppercase text-xs text-gray-700');
+  expect(value).toHaveClass('text-left font-thin text-xs');
+});

--- a/packages/renderer/src/lib/extensions/InstalledExtensionDetailsSummaryCardEntry.svelte
+++ b/packages/renderer/src/lib/extensions/InstalledExtensionDetailsSummaryCardEntry.svelte
@@ -3,7 +3,7 @@ export let label: string;
 export let value: string;
 </script>
 
-<div class="flex flex-col mb-4 items-start">
+<div class="flex flex-col lg:mb-4 items-start">
   <div class="uppercase text-xs text-gray-700">{label}</div>
   <div class="text-left font-thin text-xs">{value}</div>
 </div>

--- a/packages/renderer/src/lib/extensions/InstalledExtensionDetailsSummaryCardEntry.svelte
+++ b/packages/renderer/src/lib/extensions/InstalledExtensionDetailsSummaryCardEntry.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+export let label: string;
+export let value: string;
+</script>
+
+<div class="flex flex-col mb-4 items-start">
+  <div class="uppercase text-xs text-gray-700">{label}</div>
+  <div class="text-left font-thin text-xs">{value}</div>
+</div>

--- a/packages/renderer/src/lib/extensions/InstalledExtensionList.spec.ts
+++ b/packages/renderer/src/lib/extensions/InstalledExtensionList.spec.ts
@@ -1,0 +1,67 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/svelte';
+import { expect, test } from 'vitest';
+
+import type { CombinedExtensionInfoUI } from '/@/stores/all-installed-extensions';
+
+import InstalledExtensionList from './InstalledExtensionList.svelte';
+
+test('Expect to see each extension', async () => {
+  const extension1: CombinedExtensionInfoUI = {
+    type: 'pd',
+    id: 'myExtensionId1',
+    name: 'foo1',
+    description: 'my description1',
+    displayName: '',
+    publisher: '',
+    removable: false,
+    version: 'v1.2.3',
+    state: 'started',
+    path: '',
+    readme: '',
+    icon: 'iconOfMyExtension.png',
+  };
+
+  const extension2: CombinedExtensionInfoUI = {
+    type: 'pd',
+    id: 'myExtensionId2',
+    name: 'foo2',
+    description: 'my description2',
+    displayName: '',
+    publisher: '',
+    removable: false,
+    version: 'v1.2.3',
+    state: 'started',
+    path: '',
+    readme: '',
+    icon: 'iconOfMyExtension.png',
+  };
+  render(InstalledExtensionList, { extensionInfos: [extension1, extension2] });
+
+  // get first extension
+  const myExtension1 = screen.getByRole('region', { name: 'myExtensionId1' });
+  expect(myExtension1).toBeInTheDocument();
+
+  // get second extension
+  const myExtension2 = screen.getByRole('region', { name: 'myExtensionId2' });
+  expect(myExtension2).toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/extensions/InstalledExtensionList.svelte
+++ b/packages/renderer/src/lib/extensions/InstalledExtensionList.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+import type { CombinedExtensionInfoUI } from '/@/stores/all-installed-extensions';
+
+import InstalledExtensionCard from './InstalledExtensionCard.svelte';
+
+export let extensionInfos: CombinedExtensionInfoUI[] = [];
+</script>
+
+<div class="grow p-4">
+  {#each extensionInfos as extension}
+    <InstalledExtensionCard extension="{extension}" />
+  {/each}
+</div>

--- a/packages/renderer/src/lib/extensions/catalog-extension-info-ui.ts
+++ b/packages/renderer/src/lib/extensions/catalog-extension-info-ui.ts
@@ -1,0 +1,30 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+export interface CatalogExtensionInfoUI {
+  id: string;
+  displayName: string;
+  isFeatured: boolean;
+  fetchable: boolean;
+  fetchLink: string;
+  fetchVersion: string;
+  iconHref?: string;
+  publisherDisplayName: string;
+  isInstalled: boolean;
+  shortDescription: string;
+}

--- a/packages/renderer/src/lib/extensions/extension-details-ui.ts
+++ b/packages/renderer/src/lib/extensions/extension-details-ui.ts
@@ -1,0 +1,40 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { CombinedExtensionInfoUI } from '/@/stores/all-installed-extensions';
+
+export interface ExtensionDetailsUI {
+  displayName: string;
+  description: string;
+  type: 'dd' | 'pd';
+  removable: boolean;
+  state: string;
+  name: string;
+  icon: undefined | string | { light: string; dark: string };
+  iconRef?: string;
+  readme: { content?: string; uri?: string };
+  releaseDate: string;
+  categories: string[];
+  publisherDisplayName: string;
+  version: string;
+  installedExtension?: CombinedExtensionInfoUI;
+  id: string;
+  fetchable: boolean;
+  fetchLink: string;
+  fetchVersion: string;
+}

--- a/packages/renderer/src/lib/extensions/extension-utils.spec.ts
+++ b/packages/renderer/src/lib/extensions/extension-utils.spec.ts
@@ -1,0 +1,263 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import type { CombinedExtensionInfoUI } from '/@/stores/all-installed-extensions';
+
+import type { CatalogExtension } from '../../../../main/src/plugin/extensions-catalog/extensions-catalog-api';
+import type { FeaturedExtension } from '../../../../main/src/plugin/featured/featured-api';
+import { ExtensionUtils } from './extension-utils';
+
+let extensionUtils: ExtensionUtils;
+
+export const aFakeExtension: CatalogExtension = {
+  id: 'idAInstalled',
+  publisherName: 'FooPublisher',
+  shortDescription: 'this is short A',
+  publisherDisplayName: 'Foo Publisher',
+  extensionName: 'a-extension',
+  displayName: 'A Extension',
+  categories: [],
+  versions: [
+    {
+      version: '1.0.0A',
+      preview: false,
+      files: [
+        {
+          assetType: 'icon',
+          data: 'iconA',
+        },
+      ],
+      ociUri: 'linkA',
+      lastUpdated: new Date(),
+    },
+  ],
+};
+
+export const bFakeExtension: CatalogExtension = {
+  id: 'idBNotInstalled',
+  publisherName: 'FooPublisher',
+  shortDescription: 'this is short B',
+  publisherDisplayName: 'Foo Publisher',
+  extensionName: 'b-extension',
+  displayName: 'B Extension',
+  categories: [],
+  versions: [
+    {
+      version: '1.0.0B',
+      preview: false,
+      files: [
+        {
+          assetType: 'icon',
+          data: 'iconB',
+        },
+      ],
+      ociUri: 'linkB',
+      lastUpdated: new Date(),
+    },
+  ],
+};
+
+export const yFakeCatalogExtension: CatalogExtension = {
+  id: 'idYInstalled',
+  publisherName: 'FooPublisher',
+  shortDescription: 'this is short Y',
+  publisherDisplayName: 'Foo Publisher',
+  extensionName: 'y-extension',
+  displayName: 'Y Extension',
+  categories: [],
+  versions: [
+    {
+      version: '1.0.0Y',
+      preview: false,
+      files: [
+        {
+          assetType: 'icon',
+          data: 'iconY',
+        },
+      ],
+      ociUri: 'linkY',
+      lastUpdated: new Date(),
+    },
+  ],
+};
+
+export const zFakeCatalogExtension: CatalogExtension = {
+  id: 'idZNotInstalled',
+  publisherName: 'FooPublisher',
+  shortDescription: 'this is short Z',
+  publisherDisplayName: 'Foo Publisher',
+  extensionName: 'z-extension',
+  displayName: 'Z Extension',
+  categories: [],
+  versions: [
+    {
+      version: '1.0.0Z',
+      preview: false,
+      files: [
+        {
+          assetType: 'icon',
+          data: 'iconZ',
+        },
+      ],
+      ociUri: 'linkZ',
+      lastUpdated: new Date(),
+    },
+  ],
+};
+
+const catalogExtensions: CatalogExtension[] = [
+  aFakeExtension,
+  bFakeExtension,
+  yFakeCatalogExtension,
+  zFakeCatalogExtension,
+];
+
+// y and z are featured
+const featuredExtensions: FeaturedExtension[] = [
+  {
+    id: 'idYInstalled',
+    fetchable: true,
+  },
+  {
+    id: 'idZNotInstalled',
+    fetchable: true,
+  },
+] as unknown[] as FeaturedExtension[];
+
+// A and Y are installed
+const installedExtensions: CombinedExtensionInfoUI[] = [
+  {
+    id: 'idAInstalled',
+    displayName: 'A installed Extension',
+    removable: true,
+  },
+  {
+    id: 'idYInstalled',
+  },
+] as unknown[] as CombinedExtensionInfoUI[];
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  extensionUtils = new ExtensionUtils();
+});
+
+describe('extractCatalogExtensions', () => {
+  test('Expect first one should be featured even having a name starting with Y letter then Z extension, then A extension and then B extension', async () => {
+    // get UI objects
+    const catalogExtensionsUI = extensionUtils.extractCatalogExtensions(
+      catalogExtensions,
+      featuredExtensions,
+      installedExtensions,
+    );
+
+    // expect the first one to be featured named y
+    // then Z extension, then A extension and then B extension
+    expect(catalogExtensionsUI.length).toBe(4);
+    expect(catalogExtensionsUI[0].id).toBe('idYInstalled');
+    expect(catalogExtensionsUI[1].id).toBe('idZNotInstalled');
+    expect(catalogExtensionsUI[2].id).toBe('idAInstalled');
+    expect(catalogExtensionsUI[3].id).toBe('idBNotInstalled');
+
+    // check attributes of a featured extension being installed
+    const yExtensionUI = catalogExtensionsUI[0];
+    expect(yExtensionUI.displayName).toBe('Y Extension');
+    expect(yExtensionUI.isFeatured).toBe(true);
+    expect(yExtensionUI.fetchLink).toBe('linkY');
+    expect(yExtensionUI.fetchVersion).toBe('1.0.0Y');
+    expect(yExtensionUI.fetchable).toBe(true);
+    expect(yExtensionUI.iconHref).toBe('iconY');
+    expect(yExtensionUI.publisherDisplayName).toBe('Foo Publisher');
+    expect(yExtensionUI.isInstalled).toBe(true);
+    expect(yExtensionUI.shortDescription).toBe('this is short Y');
+
+    // check attributes of a featured extension not being installed
+    const zExtensionUI = catalogExtensionsUI[1];
+    expect(zExtensionUI.displayName).toBe('Z Extension');
+    expect(zExtensionUI.isFeatured).toBe(true);
+    expect(zExtensionUI.fetchLink).toBe('linkZ');
+    expect(zExtensionUI.fetchVersion).toBe('1.0.0Z');
+    expect(zExtensionUI.fetchable).toBe(true);
+    expect(zExtensionUI.iconHref).toBe('iconZ');
+    expect(zExtensionUI.publisherDisplayName).toBe('Foo Publisher');
+    expect(zExtensionUI.isInstalled).toBe(false);
+    expect(zExtensionUI.shortDescription).toBe('this is short Z');
+
+    // check attributes of a non featured extension being installed
+    const aExtensionUI = catalogExtensionsUI[2];
+    expect(aExtensionUI.displayName).toBe('A Extension');
+    expect(aExtensionUI.isFeatured).toBe(false);
+    expect(aExtensionUI.fetchLink).toBe('linkA');
+    expect(aExtensionUI.fetchVersion).toBe('1.0.0A');
+    expect(aExtensionUI.fetchable).toBe(true);
+    expect(aExtensionUI.iconHref).toBe('iconA');
+    expect(aExtensionUI.publisherDisplayName).toBe('Foo Publisher');
+    expect(aExtensionUI.isInstalled).toBe(true);
+    expect(aExtensionUI.shortDescription).toBe('this is short A');
+
+    // check attributes of a non featured extension not being installed
+    const bExtensionUI = catalogExtensionsUI[3];
+    expect(bExtensionUI.displayName).toBe('B Extension');
+    expect(bExtensionUI.isFeatured).toBe(false);
+    expect(bExtensionUI.fetchLink).toBe('linkB');
+    expect(bExtensionUI.fetchVersion).toBe('1.0.0B');
+    expect(bExtensionUI.fetchable).toBe(true);
+    expect(bExtensionUI.iconHref).toBe('iconB');
+    expect(bExtensionUI.publisherDisplayName).toBe('Foo Publisher');
+    expect(bExtensionUI.isInstalled).toBe(false);
+    expect(bExtensionUI.shortDescription).toBe('this is short B');
+  });
+});
+
+describe('extractExtensionDetail', () => {
+  test('Check with extension M not being installed or in the catalog', async () => {
+    const extensionDetail = extensionUtils.extractExtensionDetail(
+      catalogExtensions,
+      installedExtensions,
+      'idCNotKnown',
+    );
+    expect(extensionDetail).not.toBeDefined();
+  });
+
+  test('Check with extension A being installed (not featured)', async () => {
+    const extensionDetail = extensionUtils.extractExtensionDetail(
+      catalogExtensions,
+      installedExtensions,
+      'idAInstalled',
+    );
+    expect(extensionDetail).toBeDefined();
+    expect(extensionDetail?.id).toBe('idAInstalled');
+    expect(extensionDetail?.displayName).toBe('A installed Extension');
+    expect(extensionDetail?.publisherDisplayName).toBe('Foo Publisher');
+    expect(extensionDetail?.version).toBe('v1.0.0A');
+  });
+
+  test('Check with extension Z not being installed (but featured)', async () => {
+    const extensionDetail = extensionUtils.extractExtensionDetail(
+      catalogExtensions,
+      installedExtensions,
+      'idZNotInstalled',
+    );
+    expect(extensionDetail).toBeDefined();
+    expect(extensionDetail?.id).toBe('idZNotInstalled');
+    expect(extensionDetail?.displayName).toBe('Z Extension');
+    expect(extensionDetail?.publisherDisplayName).toBe('Foo Publisher');
+    expect(extensionDetail?.version).toBe('v1.0.0Z');
+  });
+});

--- a/packages/renderer/src/lib/extensions/extension-utils.ts
+++ b/packages/renderer/src/lib/extensions/extension-utils.ts
@@ -1,0 +1,193 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { CombinedExtensionInfoUI } from '/@/stores/all-installed-extensions';
+
+import type { CatalogExtension } from '../../../../main/src/plugin/extensions-catalog/extensions-catalog-api';
+import type { FeaturedExtension } from '../../../../main/src/plugin/featured/featured-api';
+import type { CatalogExtensionInfoUI } from './catalog-extension-info-ui';
+import type { ExtensionDetailsUI } from './extension-details-ui';
+
+export class ExtensionUtils {
+  extractExtensionDetail(
+    catalogExtensions: CatalogExtension[],
+    installedExtensions: CombinedExtensionInfoUI[],
+    extensionId: string,
+  ): ExtensionDetailsUI | undefined {
+    const matchingInstalledExtension = installedExtensions.find(c => c.id === extensionId);
+    // is it in the catalog
+    const matchingCatalogExtension = catalogExtensions.find(c => c.id === extensionId);
+
+    // not installed and not in the catalog, return undefined as it is not matching
+    if (!matchingCatalogExtension && !matchingInstalledExtension) {
+      return undefined;
+    }
+
+    let displayName: string;
+
+    let description: string;
+
+    let type: 'dd' | 'pd';
+
+    let removable: boolean;
+    let state: string;
+    let icon: undefined | string | { light: string; dark: string };
+    let iconRef: undefined | string;
+    let name: string;
+    let readme: { content?: string; uri?: string } = {};
+
+    const nonPreviewVersions = matchingCatalogExtension?.versions.filter(v => v.preview === false) ?? [];
+    const latestVersion = nonPreviewVersions.length > 0 ? nonPreviewVersions[0] : undefined;
+    const latestVersionNumber = latestVersion ? `v${latestVersion.version}` : '';
+    const latestVersionOciLink = latestVersion ? latestVersion.ociUri : undefined;
+    const latestVersionIcon = latestVersion ? latestVersion.files.find(f => f.assetType === 'icon')?.data : undefined;
+    const latestVersionReadme = latestVersion
+      ? latestVersion.files.find(f => f.assetType.toLowerCase() === 'readme')?.data
+      : undefined;
+    const lastUpdated = latestVersion?.lastUpdated;
+
+    // grab first from installed extension
+    if (matchingInstalledExtension) {
+      displayName = matchingInstalledExtension.displayName;
+      description = matchingInstalledExtension.description;
+      type = matchingInstalledExtension.type;
+      removable = matchingInstalledExtension.removable;
+      state = matchingInstalledExtension.state;
+      icon = matchingInstalledExtension.icon;
+      name = matchingInstalledExtension.name;
+      readme.content = matchingInstalledExtension.readme;
+    } else if (matchingCatalogExtension) {
+      displayName = matchingCatalogExtension.displayName;
+      description = matchingCatalogExtension.shortDescription;
+      // catalog only includes Podman Desktop extensions
+      type = 'pd';
+      removable = true;
+      state = 'downloadable';
+      name = matchingCatalogExtension.extensionName;
+
+      if (latestVersionReadme) {
+        readme = { uri: latestVersionReadme };
+      }
+
+      if (latestVersionIcon) {
+        iconRef = latestVersionIcon;
+      }
+    } else {
+      displayName = 'Unknown';
+      description = '';
+      type = 'pd';
+      removable = false;
+      state = 'unknown';
+      name = 'unknown';
+    }
+
+    let releaseDate: string = 'N/A';
+    if (lastUpdated) {
+      releaseDate = lastUpdated.toISOString().split('T')[0];
+    }
+
+    let publisherDisplayName = matchingCatalogExtension?.publisherDisplayName ?? 'N/A';
+
+    if (matchingInstalledExtension && !matchingInstalledExtension.removable) {
+      publisherDisplayName = 'Podman Desktop (built-in)';
+    }
+
+    const categories: string[] = matchingCatalogExtension?.categories ?? [];
+    const matchingInstalledExtensionVersion = matchingInstalledExtension?.version
+      ? `v${matchingInstalledExtension.version}`
+      : undefined;
+    const version = matchingInstalledExtensionVersion ?? latestVersionNumber ?? 'N/A';
+
+    const installedExtension = matchingInstalledExtension;
+
+    const fetchLink = latestVersionOciLink ?? '';
+    const fetchVersion = latestVersion?.version ?? '';
+
+    const fetchable = fetchLink.length > 0;
+
+    const matchingExtension: ExtensionDetailsUI = {
+      id: extensionId,
+      displayName,
+      description,
+      type,
+      removable,
+      state,
+      icon,
+      iconRef,
+      name,
+      readme,
+      releaseDate,
+      categories,
+      publisherDisplayName,
+      version,
+      installedExtension,
+      fetchable,
+      fetchLink,
+      fetchVersion,
+    };
+
+    return matchingExtension;
+  }
+
+  extractCatalogExtensions(
+    catalogExtensions: CatalogExtension[],
+    featuredExtensions: FeaturedExtension[],
+    installedExtensions: CombinedExtensionInfoUI[],
+  ): CatalogExtensionInfoUI[] {
+    const values: CatalogExtensionInfoUI[] = catalogExtensions.map(catalogExtension => {
+      // grab latest version
+      const nonPreviewVersions = catalogExtension.versions.filter(v => !v.preview);
+      const latestVersion = nonPreviewVersions[0];
+      const fetchLink = latestVersion?.ociUri;
+      const fetchVersion = latestVersion?.version;
+      const publisherDisplayName = catalogExtension.publisherDisplayName;
+
+      // grab icon
+      const icon = latestVersion?.files.find(f => f.assetType === 'icon');
+      const isInstalled = installedExtensions.some(installedExtension => installedExtension.id === catalogExtension.id);
+      const isFeatured = featuredExtensions.some(featuredExtension => featuredExtension.id === catalogExtension.id);
+
+      const shortDescription = catalogExtension.shortDescription;
+
+      return {
+        id: catalogExtension.id,
+        displayName: catalogExtension.displayName,
+        isFeatured,
+        fetchLink,
+        fetchVersion,
+        fetchable: fetchLink !== '',
+        iconHref: icon?.data,
+        publisherDisplayName,
+        isInstalled,
+        shortDescription,
+      };
+    });
+
+    // sort by isFeatured and then by name
+    values.sort((a, b) => {
+      if (a.isFeatured && !b.isFeatured) {
+        return -1;
+      }
+      if (!a.isFeatured && b.isFeatured) {
+        return 1;
+      }
+      return a.displayName.localeCompare(b.displayName);
+    });
+    return values;
+  }
+}

--- a/packages/renderer/src/lib/extensions/extensions-utils.spec.ts
+++ b/packages/renderer/src/lib/extensions/extensions-utils.spec.ts
@@ -22,9 +22,9 @@ import type { CombinedExtensionInfoUI } from '/@/stores/all-installed-extensions
 
 import type { CatalogExtension } from '../../../../main/src/plugin/extensions-catalog/extensions-catalog-api';
 import type { FeaturedExtension } from '../../../../main/src/plugin/featured/featured-api';
-import { ExtensionUtils } from './extension-utils';
+import { ExtensionsUtils } from './extensions-utils';
 
-let extensionUtils: ExtensionUtils;
+let extensionsUtils: ExtensionsUtils;
 
 export const aFakeExtension: CatalogExtension = {
   id: 'idAInstalled',
@@ -155,13 +155,13 @@ const installedExtensions: CombinedExtensionInfoUI[] = [
 
 beforeEach(() => {
   vi.resetAllMocks();
-  extensionUtils = new ExtensionUtils();
+  extensionsUtils = new ExtensionsUtils();
 });
 
 describe('extractCatalogExtensions', () => {
   test('Expect first one should be featured even having a name starting with Y letter then Z extension, then A extension and then B extension', async () => {
     // get UI objects
-    const catalogExtensionsUI = extensionUtils.extractCatalogExtensions(
+    const catalogExtensionsUI = extensionsUtils.extractCatalogExtensions(
       catalogExtensions,
       featuredExtensions,
       installedExtensions,
@@ -227,7 +227,7 @@ describe('extractCatalogExtensions', () => {
 
 describe('extractExtensionDetail', () => {
   test('Check with extension M not being installed or in the catalog', async () => {
-    const extensionDetail = extensionUtils.extractExtensionDetail(
+    const extensionDetail = extensionsUtils.extractExtensionDetail(
       catalogExtensions,
       installedExtensions,
       'idCNotKnown',
@@ -236,7 +236,7 @@ describe('extractExtensionDetail', () => {
   });
 
   test('Check with extension A being installed (not featured)', async () => {
-    const extensionDetail = extensionUtils.extractExtensionDetail(
+    const extensionDetail = extensionsUtils.extractExtensionDetail(
       catalogExtensions,
       installedExtensions,
       'idAInstalled',
@@ -249,7 +249,7 @@ describe('extractExtensionDetail', () => {
   });
 
   test('Check with extension Z not being installed (but featured)', async () => {
-    const extensionDetail = extensionUtils.extractExtensionDetail(
+    const extensionDetail = extensionsUtils.extractExtensionDetail(
       catalogExtensions,
       installedExtensions,
       'idZNotInstalled',

--- a/packages/renderer/src/lib/extensions/extensions-utils.spec.ts
+++ b/packages/renderer/src/lib/extensions/extensions-utils.spec.ts
@@ -34,6 +34,7 @@ export const aFakeExtension: CatalogExtension = {
   extensionName: 'a-extension',
   displayName: 'A Extension',
   categories: [],
+  unlisted: false,
   versions: [
     {
       version: '1.0.0A',
@@ -58,6 +59,7 @@ export const bFakeExtension: CatalogExtension = {
   extensionName: 'b-extension',
   displayName: 'B Extension',
   categories: [],
+  unlisted: false,
   versions: [
     {
       version: '1.0.0B',
@@ -74,6 +76,32 @@ export const bFakeExtension: CatalogExtension = {
   ],
 };
 
+export const unlistedFakeCatalogExtension: CatalogExtension = {
+  id: 'idUnlisted',
+  publisherName: 'FooPublisher',
+  shortDescription: 'this is short Unlisted',
+  publisherDisplayName: 'Foo Publisher',
+  extensionName: 'unlisted-extension',
+  displayName: 'Unlisted Extension',
+  categories: [],
+  unlisted: true,
+
+  versions: [
+    {
+      version: '1.0.0Unlisted',
+      preview: false,
+      files: [
+        {
+          assetType: 'icon',
+          data: 'iconUnlisted',
+        },
+      ],
+      ociUri: 'linkUnlisted',
+      lastUpdated: new Date(),
+    },
+  ],
+};
+
 export const yFakeCatalogExtension: CatalogExtension = {
   id: 'idYInstalled',
   publisherName: 'FooPublisher',
@@ -82,6 +110,8 @@ export const yFakeCatalogExtension: CatalogExtension = {
   extensionName: 'y-extension',
   displayName: 'Y Extension',
   categories: [],
+  unlisted: false,
+
   versions: [
     {
       version: '1.0.0Y',
@@ -106,6 +136,7 @@ export const zFakeCatalogExtension: CatalogExtension = {
   extensionName: 'z-extension',
   displayName: 'Z Extension',
   categories: [],
+  unlisted: false,
   versions: [
     {
       version: '1.0.0Z',
@@ -125,6 +156,7 @@ export const zFakeCatalogExtension: CatalogExtension = {
 const catalogExtensions: CatalogExtension[] = [
   aFakeExtension,
   bFakeExtension,
+  unlistedFakeCatalogExtension,
   yFakeCatalogExtension,
   zFakeCatalogExtension,
 ];

--- a/packages/renderer/src/lib/extensions/extensions-utils.ts
+++ b/packages/renderer/src/lib/extensions/extensions-utils.ts
@@ -60,7 +60,6 @@ export class ExtensionsUtils {
       ? latestVersion.files.find(f => f.assetType.toLowerCase() === 'readme')?.data
       : undefined;
     const lastUpdated = latestVersion?.lastUpdated;
-
     // grab first from installed extension
     if (matchingInstalledExtension) {
       displayName = matchingInstalledExtension.displayName;
@@ -140,7 +139,6 @@ export class ExtensionsUtils {
       fetchLink,
       fetchVersion,
     };
-
     return matchingExtension;
   }
 

--- a/packages/renderer/src/lib/extensions/extensions-utils.ts
+++ b/packages/renderer/src/lib/extensions/extensions-utils.ts
@@ -149,34 +149,39 @@ export class ExtensionsUtils {
     featuredExtensions: FeaturedExtension[],
     installedExtensions: CombinedExtensionInfoUI[],
   ): CatalogExtensionInfoUI[] {
-    const values: CatalogExtensionInfoUI[] = catalogExtensions.map(catalogExtension => {
-      // grab latest version
-      const nonPreviewVersions = catalogExtension.versions.filter(v => !v.preview);
-      const latestVersion = nonPreviewVersions[0];
-      const fetchLink = latestVersion?.ociUri;
-      const fetchVersion = latestVersion?.version;
-      const publisherDisplayName = catalogExtension.publisherDisplayName;
+    // filter out unlisted extensions
+    const values: CatalogExtensionInfoUI[] = catalogExtensions
+      .filter(e => !e.unlisted)
+      .map(catalogExtension => {
+        // grab latest version
+        const nonPreviewVersions = catalogExtension.versions.filter(v => !v.preview);
+        const latestVersion = nonPreviewVersions[0];
+        const fetchLink = latestVersion?.ociUri;
+        const fetchVersion = latestVersion?.version;
+        const publisherDisplayName = catalogExtension.publisherDisplayName;
 
-      // grab icon
-      const icon = latestVersion?.files.find(f => f.assetType === 'icon');
-      const isInstalled = installedExtensions.some(installedExtension => installedExtension.id === catalogExtension.id);
-      const isFeatured = featuredExtensions.some(featuredExtension => featuredExtension.id === catalogExtension.id);
+        // grab icon
+        const icon = latestVersion?.files.find(f => f.assetType === 'icon');
+        const isInstalled = installedExtensions.some(
+          installedExtension => installedExtension.id === catalogExtension.id,
+        );
+        const isFeatured = featuredExtensions.some(featuredExtension => featuredExtension.id === catalogExtension.id);
 
-      const shortDescription = catalogExtension.shortDescription;
+        const shortDescription = catalogExtension.shortDescription;
 
-      return {
-        id: catalogExtension.id,
-        displayName: catalogExtension.displayName,
-        isFeatured,
-        fetchLink,
-        fetchVersion,
-        fetchable: fetchLink !== '',
-        iconHref: icon?.data,
-        publisherDisplayName,
-        isInstalled,
-        shortDescription,
-      };
-    });
+        return {
+          id: catalogExtension.id,
+          displayName: catalogExtension.displayName,
+          isFeatured,
+          fetchLink,
+          fetchVersion,
+          fetchable: fetchLink !== '',
+          iconHref: icon?.data,
+          publisherDisplayName,
+          isInstalled,
+          shortDescription,
+        };
+      });
 
     // sort by isFeatured and then by name
     values.sort((a, b) => {

--- a/packages/renderer/src/lib/extensions/extensions-utils.ts
+++ b/packages/renderer/src/lib/extensions/extensions-utils.ts
@@ -23,7 +23,7 @@ import type { FeaturedExtension } from '../../../../main/src/plugin/featured/fea
 import type { CatalogExtensionInfoUI } from './catalog-extension-info-ui';
 import type { ExtensionDetailsUI } from './extension-details-ui';
 
-export class ExtensionUtils {
+export class ExtensionsUtils {
   extractExtensionDetail(
     catalogExtensions: CatalogExtension[],
     installedExtensions: CombinedExtensionInfoUI[],

--- a/packages/renderer/src/lib/preferences/ExtensionIcon.svelte
+++ b/packages/renderer/src/lib/preferences/ExtensionIcon.svelte
@@ -19,7 +19,7 @@ $: fade = extension.state !== 'started' ? ' brightness-50' : '';
 </script>
 
 {#if icon}
-  <img src="{icon}" alt="{extension.name}" class="max-w-10 max-h-10 {fade}" />
+  <img src="{icon}" alt="{extension.name}" class="max-w-8 max-h-8 {fade}" />
 {:else}
-  <Fa class="h-10 w-10 rounded-full text-violet-600 {fade}" size="1.6x" icon="{faPuzzlePiece}" />
+  <Fa class="h-8 w-8 rounded-full text-violet-600 {fade}" size="1.6x" icon="{faPuzzlePiece}" />
 {/if}


### PR DESCRIPTION
### What does this PR do?
Introduce a new page to manage extensions. Everything is centralized.

After that, pages settings/extensions,  dashboard/featured will be removed
current page of podman-desktop:extension/extId will be removed and user will get the extension details page



### Screenshot / video of UI



### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/6083
fixes https://github.com/containers/podman-desktop/issues/3720
fixes https://github.com/containers/podman-desktop/issues/4332
fixes https://github.com/containers/podman-desktop/issues/2677
fixes https://github.com/containers/podman-desktop/issues/6084

### How to test this PR?

Use puzzle icon in the left navbar
should be able to install both Podman Desktop and Docker Desktop extensions (using manual install in top right corner from extensions page)

not yet 100% of coverage but tests are being added

- [x] Tests are covering the bug fix or the new feature
