### PR TITLE
feat: add multi-arch building / manifest creation

### DIFF
--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1086,7 +1086,6 @@ export class PluginSystem {
           cancellationTokenRegistry,
           cancellableTokenId,
         );
-
         return containerProviderRegistry.buildImage(
           containerBuildContextDirectory,
           (eventName: string, data: string) => {

--- a/packages/renderer/src/lib/image/BuildImageFromContainerfileCard.svelte
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfileCard.svelte
@@ -87,7 +87,7 @@ onMount(() => {
   <div class="flex flex-row">
     <div class="flex flex-col">
       {#if !additionalItem}
-        <Checkbox bind:checked="{checked}" on:click="{() => handleClick()}" />
+        <Checkbox bind:checked="{checked}" title="{title}" on:click="{() => handleClick()}" />
       {:else}
         <Fa class="text-dustypurple-700 cursor-pointer" icon="{faPlusCircle}" size="1.5x" />
       {/if}


### PR DESCRIPTION
feat: add multi-arch building / manifest creation

### What does this PR do?

* When doing a multi-arch / platform selection on the build image page,
  it will now create a singular manifest
* Tells the user that they are creating a manifest
* Tests cover new feature

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->


https://github.com/containers/podman-desktop/assets/6422176/73759545-62cb-4441-8cd5-5f547d74f44b



### What issues does this PR fix or reference?

Closes https://github.com/containers/podman-desktop/issues/6626

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature

1. Select multiple platforms when building a test image (any image will
   do)
2. Do `podman image ls` afterwards and you should see your image (it's a
   manifest)
3. Examine the confirm it is a manifest by doing `podman manifest
   inspect <image-name>

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
