### PR TITLE
chore: clamp line if too long for subtitles

### DIFF
--- a/packages/renderer/src/lib/ui/DetailsPage.spec.ts
+++ b/packages/renderer/src/lib/ui/DetailsPage.spec.ts
@@ -105,3 +105,18 @@ test('Expect Escape key closes', async () => {
 
   expect(router.goto).toHaveBeenCalledWith('/back');
 });
+
+test('Expect subtitle is defined and cut', async () => {
+  const subtitle = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit';
+  render(DetailsPage, {
+    title: '',
+    subtitle,
+  });
+
+  // get the element having the 'Lorem ipsum' text
+  const subtitleElement = screen.getByText(subtitle);
+  expect(subtitleElement).toBeInTheDocument();
+
+  // expect class has the clamp
+  expect(subtitleElement).toHaveClass('line-clamp-1');
+});

--- a/packages/renderer/src/lib/ui/DetailsPage.svelte
+++ b/packages/renderer/src/lib/ui/DetailsPage.svelte
@@ -44,7 +44,7 @@ function handleKeydown(e: KeyboardEvent) {
             <div class="text-violet-400 ml-2 leading-normal" class:hidden="{!titleDetail}">{titleDetail}</div>
           </div>
           <div>
-            <span class="text-sm leading-none text-gray-900" class:hidden="{!subtitle}">{subtitle}</span>
+            <span class="text-sm leading-none text-gray-900 line-clamp-1" class:hidden="{!subtitle}">{subtitle}</span>
             <slot name="subtitle" />
           </div>
         </div>


### PR DESCRIPTION
### What does this PR do?
make sure subtitle on details page is always one line

Despite https://github.com/containers/podman-desktop/issues/6771 I got reviews on https://github.com/containers/podman-desktop/pull/6775 that the text was too long and not displayed correctly.

### Screenshot / video of UI

![image](https://github.com/containers/podman-desktop/assets/436777/e90e9afb-09fe-43a1-844b-478db0c0f3c7)
![image](https://github.com/containers/podman-desktop/assets/436777/f81a572f-f740-42e5-8ea5-0156dda6a76c)



### What issues does this PR fix or reference?

Commented there
https://github.com/containers/podman-desktop/pull/6775


### How to test this PR?

- [x] Tests are covering the bug fix or the new feature
