### PR TITLE
fix(tests): take afterhook screenshot only for failed tests

### DIFF
--- a/tests/playwright/src/setupFiles/extended-hooks.ts
+++ b/tests/playwright/src/setupFiles/extended-hooks.ts
@@ -22,5 +22,5 @@ import type { RunnerTestContext } from '../testContext/runner-test-context';
 import { takeScreenshotHook } from './extended-hooks-utils';
 
 afterEach(async (context: RunnerTestContext) => {
-  await takeScreenshotHook(context.pdRunner, context.task.name);
+  context.onTestFailed(async () => await takeScreenshotHook(context.pdRunner, context.task.name));
 });


### PR DESCRIPTION
### What does this PR do?
Add a hook condition to create screenshot only for failed tests.
### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
#6796 
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?
before running `yarn test:e2e` produced screenshots in `tests/output/screenshots` with `failure` suffix even though there were not test failures.
after: no screenshots with `failure` suffix unless there are actual failures.
<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
