### PR TITLE
fix: hide cpu, memory, size sliders on WSL

### DIFF
--- a/extensions/podman/package.json
+++ b/extensions/podman/package.json
@@ -113,7 +113,8 @@
           "minimum": 1,
           "maximum": "HOST_TOTAL_CPU",
           "scope": "ContainerProviderConnectionFactory",
-          "description": "CPU(s)"
+          "description": "CPU(s)",
+          "when": "!isWSL"
         },
         "podman.factory.machine.memory": {
           "type": "number",
@@ -123,7 +124,8 @@
           "maximum": "HOST_TOTAL_MEMORY",
           "scope": "ContainerProviderConnectionFactory",
           "step": 500000000,
-          "description": "Memory"
+          "description": "Memory",
+          "when": "!isWSL"
         },
         "podman.factory.machine.diskSize": {
           "type": "number",
@@ -133,7 +135,8 @@
           "maximum": "HOST_TOTAL_DISKSIZE",
           "step": 500000000,
           "scope": "ContainerProviderConnectionFactory",
-          "description": "Disk size"
+          "description": "Disk size",
+          "when": "!isWSL"
         },
         "podman.factory.machine.image-path": {
           "type": "string",

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -3715,6 +3715,16 @@ declare module '@podman-desktop/api' {
      * The system clipboard.
      */
     export const clipboard: Clipboard;
+
+    /**
+     * Indicates if the user is using WSL to run podman machines
+     */
+    export function isWSL(): Promise<boolean>;
+
+    /**
+     * Indicates if the user is using HyperV to run podman machines
+     */
+    export function isHyperV(): Promise<boolean>;
   }
 
   /**

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -32,7 +32,7 @@ import type { NavigationManager } from '/@/plugin/navigation/navigation-manager.
 import type { WebviewRegistry } from '/@/plugin/webview/webview-registry.js';
 
 import { securityRestrictionCurrentHandler } from '../security-restrictions-handler.js';
-import { getBase64Image, isLinux, isMac, isWindows } from '../util.js';
+import { getBase64Image, isHyperV, isLinux, isMac, isWindows, isWSL } from '../util.js';
 import type { ApiSenderType } from './api.js';
 import type { ExtensionError, ExtensionInfo, ExtensionUpdateInfo } from './api/extension-info.js';
 import type { PodInfo } from './api/pod-info.js';
@@ -1139,6 +1139,12 @@ export class ExtensionLoader {
             return electronClipboard.writeText(value);
           },
         };
+      },
+      isWSL: async (): Promise<boolean> => {
+        return isWSL();
+      },
+      isHyperV: async (): Promise<boolean> => {
+        return isHyperV();
       },
     };
 

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -58,7 +58,7 @@ import { Updater } from '/@/plugin/updater.js';
 
 import { securityRestrictionCurrentHandler } from '../security-restrictions-handler.js';
 import type { TrayMenu } from '../tray-menu.js';
-import { isMac } from '../util.js';
+import { isHyperV, isMac, isWSL } from '../util.js';
 import type { ApiSenderType } from './api.js';
 import type { CliToolInfo } from './api/cli-tool-info.js';
 import type { ColorInfo } from './api/color-info.js';
@@ -1607,6 +1607,12 @@ export class PluginSystem {
     });
     this.ipcHandle('os:getHostCpu', async (): Promise<number> => {
       return os.cpus().length;
+    });
+    this.ipcHandle('os:isWSL', async (): Promise<boolean> => {
+      return isWSL();
+    });
+    this.ipcHandle('os:isHyperV', async (): Promise<boolean> => {
+      return isHyperV();
     });
 
     this.ipcHandle(

--- a/packages/main/src/util.spec.ts
+++ b/packages/main/src/util.spec.ts
@@ -16,19 +16,28 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 import * as fs from 'node:fs';
+import * as os from 'node:os';
 
-import { beforeEach, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 
-import { getBase64Image } from './util.js';
+import * as util from './util.js';
+
+let originalProvider: string | undefined;
 
 beforeEach(() => {
   vi.resetAllMocks();
   vi.mock('node:fs');
+  vi.mock('node:os');
+  originalProvider = process.env.CONTAINERS_MACHINE_PROVIDER;
+});
+
+afterEach(() => {
+  process.env.CONTAINERS_MACHINE_PROVIDER = originalProvider;
 });
 
 test('getBase64Image - return undefined if path do not exists', () => {
   vi.spyOn(fs, 'existsSync').mockReturnValue(false);
-  const result = getBase64Image('unknown');
+  const result = util.getBase64Image('unknown');
   expect(result).toBe(undefined);
 });
 
@@ -37,7 +46,7 @@ test('getBase64Image - return undefined if erroring durin execution', () => {
   vi.spyOn(fs, 'readFileSync').mockImplementation(() => {
     throw new Error('error');
   });
-  const result = getBase64Image('path');
+  const result = util.getBase64Image('path');
   expect(result).toBe(undefined);
 });
 
@@ -48,6 +57,71 @@ test('getBase64Image - return base64 image', () => {
   vi.spyOn(Buffer, 'from').mockReturnValue(buffer);
   vi.spyOn(buffer, 'toString').mockReturnValue('image');
 
-  const result = getBase64Image('path');
+  const result = util.getBase64Image('path');
   expect(result).toBe('data:image/png;base64,image');
+});
+
+test('isWSL - return true is if os is Windows and it is not HyperV', async () => {
+  vi.mocked(os.platform).mockReturnValue('win32');
+  vi.mocked(os.homedir).mockReturnValue('home');
+  process.env.CONTAINERS_MACHINE_PROVIDER = 'wsl';
+  vi.mocked(fs.promises.readFile).mockResolvedValue('');
+
+  const wsl = await util.isWSL();
+  expect(wsl).toBeTruthy();
+});
+
+test('isWSL - return false is if os is NOT Windows', async () => {
+  vi.spyOn(os, 'platform').mockReturnValue('linux');
+
+  const wsl = await util.isWSL();
+  expect(wsl).toBeFalsy();
+});
+
+test('isWSL - return true is if os is Windows and it is HyperV', async () => {
+  vi.spyOn(os, 'platform').mockReturnValue('win32');
+  process.env.CONTAINERS_MACHINE_PROVIDER = 'hyperv';
+
+  const wsl = await util.isWSL();
+  expect(wsl).toBeFalsy();
+});
+
+test('isHyperV - return true is if os is Windows and it has env variable set', async () => {
+  vi.mocked(os.platform).mockReturnValue('win32');
+  process.env.CONTAINERS_MACHINE_PROVIDER = 'hyperv';
+
+  const hyperv = await util.isHyperV();
+  expect(hyperv).toBeTruthy();
+});
+
+test('isHyperV - return false if os is NOT windows', async () => {
+  vi.mocked(os.platform).mockReturnValue('linux');
+
+  const hyperv = await util.isHyperV();
+  expect(hyperv).toBeFalsy();
+});
+
+test('isHyperV - return false if os is windows but env variable is not hyperv and the containersConfig file does not set the provider to hyperv', async () => {
+  vi.mocked(os.platform).mockReturnValue('win32');
+  vi.mocked(os.homedir).mockReturnValue('home');
+  process.env.CONTAINERS_MACHINE_PROVIDER = '';
+  vi.mocked(fs.promises.readFile).mockResolvedValue('');
+
+  const hyperv = await util.isHyperV();
+  expect(hyperv).toBeFalsy();
+});
+
+test('isHyperV - return true if os is windows but env variable is not hyperv but the containersConfig file set the provider to hyperv', async () => {
+  vi.mocked(os.platform).mockReturnValue('win32');
+  vi.mocked(os.homedir).mockReturnValue('home');
+  process.env.CONTAINERS_MACHINE_PROVIDER = '';
+  vi.mocked(fs.promises.readFile).mockResolvedValue(`
+[machine]
+
+provider = "hyperv"
+memory = 4096
+    `);
+
+  const hyperv = await util.isHyperV();
+  expect(hyperv).toBeTruthy();
 });

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -1877,6 +1877,14 @@ export function initExposure(): void {
     return ipcInvoke('os:getHostname');
   });
 
+  contextBridge.exposeInMainWorld('isWSL', async (): Promise<boolean> => {
+    return ipcInvoke('os:isWSL');
+  });
+
+  contextBridge.exposeInMainWorld('isHyperV', async (): Promise<boolean> => {
+    return ipcInvoke('os:isHyperV');
+  });
+
   contextBridge.exposeInMainWorld('getCancellableTokenSource', async (): Promise<number> => {
     return ipcInvoke('cancellableTokenSource:create');
   });

--- a/packages/renderer/src/lib/context/contextKey.ts
+++ b/packages/renderer/src/lib/context/contextKey.ts
@@ -39,9 +39,13 @@ CONSTANT_VALUES.set('true', true);
 
 export async function initContextKeysPlatform(): Promise<void> {
   const platform = await window.getOsPlatform();
+  const isWSL = await window.isWSL();
+  const isHyperV = await window.isHyperV();
   CONSTANT_VALUES.set('isMac', platform === 'darwin');
   CONSTANT_VALUES.set('isLinux', platform === 'linux');
   CONSTANT_VALUES.set('isWindows', platform === 'win32');
+  CONSTANT_VALUES.set('isWSL', isWSL);
+  CONSTANT_VALUES.set('isHyperV', isHyperV);
 }
 
 /** allow register constant context keys that are known only after startup; requires running `substituteConstants` on the context key - https://github.com/microsoft/vscode/issues/174218#issuecomment-1437972127 */


### PR DESCRIPTION
### What does this PR do?

It hides the cpu, memory, size sliders on WSL as they are meaningless.
it is based on https://github.com/containers/podman-desktop/pull/6810

### Screenshot / video of UI

![image](https://github.com/containers/podman-desktop/assets/49404737/4bb7ca15-f31c-4677-a7c7-dd1bc37b9c0f)

### What issues does this PR fix or reference?

it resolves #2558 

### How to test this PR?

1. try to create a new machine on WSL, you should not see the cpu, memory, size sliders

- [ ] Tests are covering the bug fix or the new feature