### PR TITLE
feat: add inspectManifest API endpoint

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -302,14 +302,12 @@ declare module '@podman-desktop/api' {
       mediaType: string;
       platform: {
         architecture: string;
-        features: string[];
+        features?: string[];
         os: string;
-        osFeatures: string[];
-        osVersion: string;
-        variant: string;
+        variant?: string;
       };
       size: number;
-      urls: string[];
+      urls?: string[];
     }[];
     mediaType: string;
     schemaVersion: number;

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -294,6 +294,26 @@ declare module '@podman-desktop/api' {
     // Provider to use for the manifest creation, if not, we will try to select the first one available (similar to podCreate)
     provider?: ContainerProviderConnection;
   }
+  export interface ManifestInspectInfo {
+    engineId: string;
+    engineName: string;
+    manifests: {
+      digest: string;
+      mediaType: string;
+      platform: {
+        architecture: string;
+        features: string[];
+        os: string;
+        osFeatures: string[];
+        osVersion: string;
+        variant: string;
+      };
+      size: number;
+      urls: string[];
+    }[];
+    mediaType: string;
+    schemaVersion: number;
+  }
 
   export interface KubernetesProviderConnectionEndpoint {
     apiURL: string;
@@ -3385,6 +3405,7 @@ declare module '@podman-desktop/api' {
 
     // Manifest related methods
     export function createManifest(options: ManifestCreateOptions): Promise<{ engineId: string; Id: string }>;
+    export function inspectManifest(engineId: string, id: string): Promise<ManifestInspectInfo>;
   }
 
   /**

--- a/packages/main/src/plugin/api/manifest-info.ts
+++ b/packages/main/src/plugin/api/manifest-info.ts
@@ -27,3 +27,24 @@ export interface ManifestCreateOptions {
   // Provider to use for the manifest creation, if not, we will try to select the first one available (similar to podCreate)
   provider?: ContainerProviderConnection;
 }
+
+export interface ManifestInspectInfo {
+  engineId: string;
+  engineName: string;
+  manifests: {
+    digest: string;
+    mediaType: string;
+    platform: {
+      architecture: string;
+      features: string[];
+      os: string;
+      osFeatures: string[];
+      osVersion: string;
+      variant: string;
+    };
+    size: number;
+    urls: string[];
+  }[];
+  mediaType: string;
+  schemaVersion: number;
+}

--- a/packages/main/src/plugin/api/manifest-info.ts
+++ b/packages/main/src/plugin/api/manifest-info.ts
@@ -36,14 +36,12 @@ export interface ManifestInspectInfo {
     mediaType: string;
     platform: {
       architecture: string;
-      features: string[];
+      features?: string[];
       os: string;
-      osFeatures: string[];
-      osVersion: string;
-      variant: string;
+      variant?: string;
     };
     size: number;
-    urls: string[];
+    urls?: string[];
   }[];
   mediaType: string;
   schemaVersion: number;

--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -4587,8 +4587,6 @@ test('check that inspectManifest returns information from libPod.podmanInspectMa
           architecture: 'architecture',
           features: [],
           os: 'os',
-          osFeatures: [],
-          osVersion: 'osVersion',
           variant: 'variant',
         },
         size: 100,

--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -4574,3 +4574,72 @@ test('if configuration setting is disabled for using libpodApi, it should fall b
   expect(image.engineId).toBe('podman1');
   expect(image.engineName).toBe('podman');
 });
+
+test('check that inspectManifest returns information from libPod.podmanInspectManifest', async () => {
+  const inspectManifestMock = vi.fn().mockResolvedValue({
+    engineId: 'podman1',
+    engineName: 'podman',
+    manifests: [
+      {
+        digest: 'digest',
+        mediaType: 'mediaType',
+        platform: {
+          architecture: 'architecture',
+          features: [],
+          os: 'os',
+          osFeatures: [],
+          osVersion: 'osVersion',
+          variant: 'variant',
+        },
+        size: 100,
+        urls: ['url1', 'url2'],
+      },
+    ],
+    mediaType: 'mediaType',
+    schemaVersion: 1,
+  });
+
+  const fakeLibPod = {
+    podmanInspectManifest: inspectManifestMock,
+  } as unknown as LibPod;
+
+  const api = new Dockerode({ protocol: 'http', host: 'localhost' });
+
+  containerRegistry.addInternalProvider('podman1', {
+    name: 'podman',
+    id: 'podman1',
+    api,
+    libpodApi: fakeLibPod,
+    connection: {
+      type: 'podman',
+    },
+  } as unknown as InternalContainerProvider);
+
+  const result = await containerRegistry.inspectManifest('podman1', 'manifestId');
+
+  // Expect that inspectManifest was called with manifestId
+  expect(inspectManifestMock).toBeCalledWith('manifestId');
+
+  // Check the results are as expected
+  expect(result).toBeDefined();
+  expect(result.engineId).toBe('podman1');
+  expect(result.engineName).toBe('podman');
+  expect(result.manifests).toBeDefined();
+});
+
+test('inspectManifest should fail if libpod is missing from the provider', async () => {
+  const api = new Dockerode({ protocol: 'http', host: 'localhost' });
+
+  containerRegistry.addInternalProvider('podman1', {
+    name: 'podman',
+    id: 'podman1',
+    api,
+    connection: {
+      type: 'podman',
+    },
+  } as unknown as InternalContainerProvider);
+
+  await expect(() => containerRegistry.inspectManifest('podman1', 'manifestId')).rejects.toThrowError(
+    'LibPod is not supported by this engine',
+  );
+});

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -53,7 +53,7 @@ import type { ContainerStatsInfo } from './api/container-stats-info.js';
 import type { HistoryInfo } from './api/history-info.js';
 import type { BuildImageOptions, ImageInfo, ListImagesOptions, PodmanListImagesOptions } from './api/image-info.js';
 import type { ImageInspectInfo } from './api/image-inspect-info.js';
-import type { ManifestCreateOptions } from './api/manifest-info.js';
+import type { ManifestCreateOptions, ManifestInspectInfo } from './api/manifest-info.js';
 import type { NetworkInspectInfo } from './api/network-info.js';
 import type { PodCreateOptions, PodInfo, PodInspectInfo } from './api/pod-info.js';
 import type { ProviderContainerConnectionInfo } from './api/provider-info.js';
@@ -1321,6 +1321,22 @@ export class ContainerProviderRegistry {
       throw error;
     } finally {
       this.telemetryService.track('createManifest', telemetryOptions);
+    }
+  }
+
+  async inspectManifest(engineId: string, manifestId: string): Promise<ManifestInspectInfo> {
+    let telemetryOptions = {};
+    try {
+      const libPod = this.getMatchingPodmanEngineLibPod(engineId);
+      if (!libPod) {
+        throw new Error('No podman provider with a running engine');
+      }
+      return await libPod.podmanInspectManifest(manifestId);
+    } catch (error) {
+      telemetryOptions = { error: error };
+      throw error;
+    } finally {
+      this.telemetryService.track('inspectManifest', telemetryOptions);
     }
   }
 

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -1052,6 +1052,9 @@ export class ExtensionLoader {
       ): Promise<{ engineId: string; Id: string }> {
         return containerProviderRegistry.createManifest(manifestOptions);
       },
+      inspectManifest(engineId: string, id: string): Promise<containerDesktopAPI.ManifestInspectInfo> {
+        return containerProviderRegistry.inspectManifest(engineId, id);
+      },
       replicatePodmanContainer(
         source: { engineId: string; id: string },
         target: { engineId: string },

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -83,7 +83,7 @@ import type { IconInfo } from './api/icon-info.js';
 import type { ImageCheckerInfo } from './api/image-checker-info.js';
 import type { ImageInfo } from './api/image-info.js';
 import type { ImageInspectInfo } from './api/image-inspect-info.js';
-import type { ManifestCreateOptions } from './api/manifest-info.js';
+import type { ManifestCreateOptions, ManifestInspectInfo } from './api/manifest-info.js';
 import type { NetworkInspectInfo } from './api/network-info.js';
 import type { NotificationCard, NotificationCardOptions } from './api/notification.js';
 import type { OnboardingInfo, OnboardingStatus } from './api/onboarding.js';
@@ -772,6 +772,13 @@ export class PluginSystem {
       'container-provider-registry:createManifest',
       async (_listener, manifestOptions: ManifestCreateOptions): Promise<{ engineId: string; Id: string }> => {
         return containerProviderRegistry.createManifest(manifestOptions);
+      },
+    );
+
+    this.ipcHandle(
+      'container-provider-registry:inspectManifest',
+      async (_listener, engine: string, manifestId: string): Promise<ManifestInspectInfo> => {
+        return containerProviderRegistry.inspectManifest(engine, manifestId);
       },
     );
 

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -62,7 +62,7 @@ import type { ImageCheckerInfo } from '../../main/src/plugin/api/image-checker-i
 import type { ImageInfo } from '../../main/src/plugin/api/image-info';
 import type { ImageInspectInfo } from '../../main/src/plugin/api/image-inspect-info';
 import type { KubernetesGeneratorInfo } from '../../main/src/plugin/api/KubernetesGeneratorInfo';
-import type { ManifestCreateOptions } from '../../main/src/plugin/api/manifest-info';
+import type { ManifestCreateOptions, ManifestInspectInfo } from '../../main/src/plugin/api/manifest-info';
 import type { NetworkInspectInfo } from '../../main/src/plugin/api/network-info';
 import type { NotificationCard, NotificationCardOptions } from '../../main/src/plugin/api/notification';
 import type { OnboardingInfo, OnboardingStatus } from '../../main/src/plugin/api/onboarding';
@@ -289,6 +289,12 @@ export function initExposure(): void {
     'createManifest',
     async (createOptions: ManifestCreateOptions): Promise<{ engineId: string; Id: string }> => {
       return ipcInvoke('container-provider-registry:createManifest', createOptions);
+    },
+  );
+  contextBridge.exposeInMainWorld(
+    'inspectManifest',
+    async (engine: string, manifestId: string): Promise<ManifestInspectInfo> => {
+      return ipcInvoke('container-provider-registry:inspectManifest', engine, manifestId);
     },
   );
 


### PR DESCRIPTION
feat: add inspectManifest API endpoint

### What does this PR do?

* Adds the inspectManifest API endpoint so we can retrieve information
  regarding a manifest from the podman libpodApi endpoint

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/A, it's an API call.

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop/issues/6793

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature

Tests cover, otherwise you could also put the following (after creating
ANY manifest, in a svelte file:)

```ts
  // List all the images
  const images = await window.listImages();

  // Get all the ones that have isManifest set to true
  const manifestImages = images.filter(image => image.isManifest);

  // For each manifestImages use inspectManifest to get the information (passing in engineId as well)
  const imageInfoPromises = manifestImages.map(image => window.inspectManifest(image.engineId, image.Id));

  // Wait for all the promises to resolve
  const imageInfos = await Promise.all(imageInfoPromises);

  // Consoel log each one
  imageInfos.forEach(imageInfo => {
    console.log(imageInfo);
  });
```

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
