### PR TITLE
chore: use same logic to restart the kube cluster as in resource list

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesConnectionRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesConnectionRendering.svelte
@@ -33,7 +33,7 @@ let connectionStatus: IConnectionStatus;
 let noLog = true;
 let connectionInfo: ProviderKubernetesConnectionInfo | undefined;
 let providerInfo: ProviderInfo | undefined;
-let loggerHandlerKey: symbol;
+let loggerHandlerKey: symbol | undefined;
 let configurationKeys: IConfigurationPropertyRecordedSchema[];
 $: configurationKeys = properties
   .filter(property => property.scope === 'KubernetesConnection')
@@ -68,6 +68,7 @@ onMount(async () => {
           status: connectionInfo.status,
         };
         startConnectionProvider(providerInfo, connectionInfo, loggerHandlerKey);
+        loggerHandlerKey = undefined;
       } else {
         connectionStatus = {
           inProgress: false,


### PR DESCRIPTION
### What does this PR do?

Fixes the bug, when restart minikube or kind cluster hangs on details page.

Synchronise the approach to restart minikube and kind cluster with the approach when they are displayed on Resource page. Now the is no any error that cluster has been already started. Problem was in reused loggerHandler, which should be undefined after first attempt or starting resource provider.

### Screenshot / video of UI

https://github.com/containers/podman-desktop/assets/1968177/72295b1a-c760-42c6-a5dc-9494cf2a4fc7

### What issues does this PR fix or reference?

#5666 

### How to test this PR?

Create the minikube or kind cluster from the Resource page. Then navigate to the Connection Details page and try to restart the cluster. In developer console previously appeared errors should no be visible anymore.

- [ ] Tests are covering the bug fix or the new feature
