### PR TITLE
chore: handle unlisted field of catalog

### DIFF
--- a/packages/main/src/plugin/extensions-catalog/extensions-catalog-api.ts
+++ b/packages/main/src/plugin/extensions-catalog/extensions-catalog-api.ts
@@ -36,6 +36,7 @@ export interface CatalogExtension {
   extensionName: string;
   displayName: string;
   categories: string[];
+  unlisted: boolean;
   versions: CatalogExtensionVersion[];
 }
 

--- a/packages/main/src/plugin/extensions-catalog/extensions-catalog.spec.ts
+++ b/packages/main/src/plugin/extensions-catalog/extensions-catalog.spec.ts
@@ -32,6 +32,7 @@ const fooAssetIcon = {
   data: 'fooIcon',
 };
 
+// unlisted field is not present (assuming it should be listed then)
 const fakePublishedExtension1 = {
   publisher: {
     publisherName: 'foo',
@@ -41,6 +42,52 @@ const fakePublishedExtension1 = {
   displayName: 'Foo extension display name',
   shortDescription: 'Foo extension short description',
   license: 'Apache-2.0',
+  categories: ['Kubernetes'],
+  versions: [
+    {
+      version: '1.0.0',
+      preview: false,
+      lastUpdated: '2021-01-01T00:00:00.000Z',
+      ociUri: 'oci-registry.foo/foo/bar',
+      files: [fooAssetIcon],
+    },
+  ],
+};
+
+// this one is unlisted with field unlisted being true
+const fakePublishedExtension2 = {
+  publisher: {
+    publisherName: 'foo2',
+    displayName: 'Foo publisher display name',
+  },
+  extensionName: 'fooName2',
+  displayName: 'Foo2 extension display name',
+  shortDescription: 'Foo2 extension short description',
+  license: 'Apache-2.0',
+  unlisted: true,
+  categories: ['Kubernetes'],
+  versions: [
+    {
+      version: '1.0.0',
+      preview: false,
+      lastUpdated: '2021-01-01T00:00:00.000Z',
+      ociUri: 'oci-registry.foo/foo/bar',
+      files: [fooAssetIcon],
+    },
+  ],
+};
+
+// this one is unlisted with field unlisted being false
+const fakePublishedExtension3 = {
+  publisher: {
+    publisherName: 'foo3',
+    displayName: 'Foo publisher display name',
+  },
+  extensionName: 'fooName3',
+  displayName: 'Foo3 extension display name',
+  shortDescription: 'Foo3 extension short description',
+  license: 'Apache-2.0',
+  unlisted: false,
   categories: ['Kubernetes'],
   versions: [
     {
@@ -173,6 +220,37 @@ test('should get all extensions', async () => {
     version: '1.0.0',
     files: [fooAssetIcon],
   });
+  // no error
+  expect(console.error).not.toBeCalled();
+});
+
+test('should get proper unlisted fields', async () => {
+  const url = new URL(ExtensionsCatalog.ALL_EXTENSIONS_URL);
+  const host = url.origin;
+  const pathname = url.pathname;
+  nock(host)
+    .get(pathname)
+    .reply(200, {
+      extensions: [fakePublishedExtension1, fakePublishedExtension2, fakePublishedExtension3],
+    });
+
+  const allExtensions = await extensionsCatalog.getExtensions();
+  expect(allExtensions).toBeDefined();
+  expect(allExtensions.length).toBe(3);
+
+  // check data
+  const missingUnlistedExtension = allExtensions.find(e => e.id === 'foo.fooName');
+  expect(missingUnlistedExtension).toBeDefined();
+  expect(missingUnlistedExtension?.unlisted).toBeFalsy();
+
+  const unlistedTrueExtension = allExtensions.find(e => e.id === 'foo2.fooName2');
+  expect(unlistedTrueExtension).toBeDefined();
+  expect(unlistedTrueExtension?.unlisted).toBeTruthy();
+
+  const unlistedFalseExtension = allExtensions.find(e => e.id === 'foo3.fooName3');
+  expect(unlistedFalseExtension).toBeDefined();
+  expect(unlistedFalseExtension?.unlisted).toBeFalsy();
+
   // no error
   expect(console.error).not.toBeCalled();
 });

--- a/packages/main/src/plugin/extensions-catalog/extensions-catalog.ts
+++ b/packages/main/src/plugin/extensions-catalog/extensions-catalog.ts
@@ -100,6 +100,7 @@ export class ExtensionsCatalog {
           publisherName: extension.publisher.publisherName,
           publisherDisplayName: extension.publisher.displayName,
           categories: extension.categories,
+          unlisted: extension.unlisted ?? false,
           extensionName: extension.extensionName,
           shortDescription: extension.shortDescription,
           displayName: extension.displayName,
@@ -217,6 +218,7 @@ interface InternalCatalogExtensionJSON {
   extensionName: string;
   displayName: string;
   categories: string[];
+  unlisted?: boolean;
   shortDescription: string;
   versions: InternalCatalogExtensionVersionJSON[];
 }

--- a/packages/main/src/plugin/extensions-updater/extensions-updater.spec.ts
+++ b/packages/main/src/plugin/extensions-updater/extensions-updater.spec.ts
@@ -37,6 +37,7 @@ const catalogExtension1: CatalogExtension = {
   publisherDisplayName: 'Foo publisher display name',
   shortDescription: 'Foo extension short description',
   categories: ['Kubernetes'],
+  unlisted: false,
   versions: [
     {
       version: '2.0.0',
@@ -56,6 +57,7 @@ const catalogExtension2: CatalogExtension = {
   publisherDisplayName: 'Foo publisher display name',
   shortDescription: 'Foo extension short description',
   categories: [],
+  unlisted: false,
   versions: [
     {
       version: '4.0.0',

--- a/packages/renderer/src/lib/preferences/PreferencesInstallExtensionFromId.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesInstallExtensionFromId.spec.ts
@@ -65,6 +65,7 @@ test('Expect that the install button is there and can click on it to install', a
       publisherDisplayName: 'Foo Publisher',
       shortDescription: 'foo.bar Extension',
       categories: ['Kubernetes'],
+      unlisted: false,
       versions: [
         {
           version: '1.0.0',
@@ -135,6 +136,7 @@ test('Expect that the installed label is there if extension is already installed
       publisherDisplayName: 'Foo Publisher',
       shortDescription: 'foo.bar Extension',
       categories: ['Kubernetes'],
+      unlisted: false,
       versions: [
         {
           version: '1.0.0',

--- a/packages/renderer/src/stores/catalog-extensions.spec.ts
+++ b/packages/renderer/src/stores/catalog-extensions.spec.ts
@@ -72,6 +72,7 @@ test('catalog extension should be updated in case of a container is removed', as
       extensionName: 'extension',
       shortDescription: 'short description',
       publisherDisplayName: 'Foo publisher display name',
+      unlisted: false,
       categories: [],
       versions: [
         {
@@ -91,6 +92,7 @@ test('catalog extension should be updated in case of a container is removed', as
       shortDescription: 'short description',
       publisherDisplayName: 'Foo publisher display name',
       categories: [],
+      unlisted: true,
       versions: [
         {
           version: '2.0.0',
@@ -117,4 +119,14 @@ test('catalog extension should be updated in case of a container is removed', as
   // check if the catalog has been updated
   const afterCatalogExtensions = get(catalogExtensionInfos);
   expect(afterCatalogExtensions.length).toBe(2);
+
+  // get first extension
+  const firstExtension = afterCatalogExtensions.find(ext => ext.id === 'first.extension1');
+  expect(firstExtension).toBeDefined();
+  expect(firstExtension?.unlisted).toBeFalsy();
+
+  // get second extension
+  const secondExtension = afterCatalogExtensions.find(ext => ext.id === 'second.extension2');
+  expect(secondExtension).toBeDefined();
+  expect(secondExtension?.unlisted).toBeTruthy();
 });


### PR DESCRIPTION
### What does this PR do?
handle new field of catalog registry (and expose them in the store)

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

follow up of https://github.com/containers/podman-desktop-catalog/pull/36

### How to test this PR?


- [x] Tests are covering the bug fix or the new feature
