### PR TITLE
chore: remove widget from dashboard as it'll be in the catalog extension section

### DIFF
--- a/packages/renderer/src/lib/dashboard/DashboardPage.svelte
+++ b/packages/renderer/src/lib/dashboard/DashboardPage.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 import ProviderConfiguring from '/@/lib/dashboard/ProviderConfiguring.svelte';
-import FeaturedExtensions from '/@/lib/featured/FeaturedExtensions.svelte';
 import ExtensionBanners from '/@/lib/recommendation/ExtensionBanners.svelte';
 
 import { providerInfos } from '../../stores/providers';
@@ -99,7 +98,6 @@ function getInitializationContext(id: string): InitializationContext {
           {/each}
         {/if}
         <LearningCenter />
-        <FeaturedExtensions />
         <ExtensionBanners />
       </div>
     </div>


### PR DESCRIPTION
### What does this PR do?
A new section visible from the main navbar will include catalog extensions (and the promoted featured extensions)

Also the recommended extensions are now displayed on the welcome page

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
related to https://github.com/containers/podman-desktop/pull/6775

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
