### PR TITLE
chore(test): add aria labels for rows

### DIFF
--- a/packages/renderer/src/lib/container/ContainerList.svelte
+++ b/packages/renderer/src/lib/container/ContainerList.svelte
@@ -583,7 +583,7 @@ function setStoppedFilter() {
           <!-- Display each container of this group -->
           {#if containerGroup.expanded}
             {#each containerGroup.containers as container, index}
-              <tr class="group h-12 bg-charcoal-800 hover:bg-zinc-700">
+              <tr class="group h-12 bg-charcoal-800 hover:bg-zinc-700" aria-label="{container.name}">
                 <td
                   class="{containerGroup.type === ContainerGroupInfoTypeUI.STANDALONE ? 'rounded-tl-lg' : ''} {index ===
                   containerGroup.containers.length - 1

--- a/packages/renderer/src/lib/pod/PodsList.spec.ts
+++ b/packages/renderer/src/lib/pod/PodsList.spec.ts
@@ -315,7 +315,7 @@ test('Expect single podman pod being displayed', async () => {
 
   // Expect to have three "tooltips" which are the "dots".
   const pod1Row = screen.getByRole('row', {
-    name: 'Toggle pod pod1 beab2512 podman tooltip tooltip tooltip 0 seconds spinner spinner spinner',
+    name: `${pod1.Name}`,
   });
   expect(pod1Row).toBeInTheDocument();
 });
@@ -333,11 +333,11 @@ test('Expect 2 podman pods being displayed', async () => {
   const pod1Details = screen.getByRole('cell', { name: 'pod1 beab2512' });
   expect(pod1Details).toBeInTheDocument();
   const pod1Row = screen.getByRole('row', {
-    name: 'Toggle pod pod1 beab2512 podman tooltip tooltip tooltip 0 seconds spinner spinner spinner',
+    name: `${pod1.Name}`,
   });
   expect(pod1Row).toBeInTheDocument();
   const pod2Row = screen.getByRole('row', {
-    name: 'Toggle pod pod2 e8129c57 podman tooltip 0 seconds spinner spinner spinner',
+    name: `${pod2.Name}`,
   });
   expect(pod2Row).toBeInTheDocument();
 });
@@ -353,7 +353,7 @@ test('Expect single kubernetes pod being displayed', async () => {
 
   render(PodsList);
   const pod1Details = screen.getByRole('row', {
-    name: 'Toggle pod kubepod1 beab2512 kubernetes tooltip 0 seconds spinner',
+    name: `${kubepod1.Name}`,
   });
   expect(pod1Details).toBeInTheDocument();
 });
@@ -369,11 +369,11 @@ test('Expect 2 kubernetes pods being displayed', async () => {
 
   render(PodsList);
   const pod1Details = screen.getByRole('row', {
-    name: 'Toggle pod kubepod1 beab2512 kubernetes tooltip 0 seconds spinner',
+    name: `${kubepod1.Name}`,
   });
   expect(pod1Details).toBeInTheDocument();
   const pod2Details = screen.getByRole('row', {
-    name: 'Toggle pod kubepod2 e8129c57 kubernetes tooltip 0 seconds spinner',
+    name: `${kubepod2.Name}`,
   });
   expect(pod2Details).toBeInTheDocument();
 });
@@ -413,7 +413,7 @@ test('Expect the route to a pod details page is correctly encoded with an engine
   expect(podDetails).toBeInTheDocument();
 
   const podRow = screen.getByRole('row', {
-    name: 'Toggle pod ocppod e8129c57 kubernetes tooltip 0 seconds spinner',
+    name: `${ocppod.Name}`,
   });
   expect(podRow).toBeInTheDocument();
 

--- a/packages/renderer/src/lib/table/Table.svelte
+++ b/packages/renderer/src/lib/table/Table.svelte
@@ -168,7 +168,8 @@ function setGridColumns() {
       <div
         class="grid grid-table gap-x-0.5 mx-5 min-h-[48px] h-fit bg-charcoal-800 hover:bg-zinc-700 rounded-lg mb-2"
         animate:flip="{{ duration: 300 }}"
-        role="row">
+        role="row"
+        aria-label="{object.name}">
         <div class="whitespace-nowrap justify-self-start" role="cell"></div>
         {#if row.info.selectable}
           <div class="whitespace-nowrap place-self-center" role="cell">


### PR DESCRIPTION
### What does this PR do?
Add aria-labels for images and container page rows

### What issues does this PR fix or reference?
https://github.com/containers/podman-desktop/issues/5639

### How to test this PR?
Check image and container rows to have aria-label property with the corresponding values.
