### PR TITLE
chore(test): add some aria labels to volumes page

### DIFF
--- a/packages/renderer/src/lib/volume/VolumesList.svelte
+++ b/packages/renderer/src/lib/volume/VolumesList.svelte
@@ -234,10 +234,15 @@ const row = new Row<VolumeInfoUI>({
         inProgress="{fetchDataInProgress}"
         on:click="{() => fetchUsageData()}"
         title="Collect usage data for volumes. It can take a while..."
-        icon="{faPieChart}">Collect usage data</Button>
+        icon="{faPieChart}"
+        aria-label="Collect usage data">Collect usage data</Button>
     {/if}
     {#if providerConnections.length > 0}
-      <Button on:click="{() => gotoCreateVolume()}" icon="{faPlusCircle}" title="Create a volume">Create</Button>
+      <Button
+        on:click="{() => gotoCreateVolume()}"
+        icon="{faPlusCircle}"
+        title="Create a volume"
+        aria-label="Create volume">Create</Button>
     {/if}
   </svelte:fragment>
 

--- a/packages/renderer/src/lib/volume/VolumesList.svelte
+++ b/packages/renderer/src/lib/volume/VolumesList.svelte
@@ -238,11 +238,8 @@ const row = new Row<VolumeInfoUI>({
         aria-label="Collect usage data">Collect usage data</Button>
     {/if}
     {#if providerConnections.length > 0}
-      <Button
-        on:click="{() => gotoCreateVolume()}"
-        icon="{faPlusCircle}"
-        title="Create a volume"
-        aria-label="Create volume">Create</Button>
+      <Button on:click="{() => gotoCreateVolume()}" icon="{faPlusCircle}" title="Create a volume" aria-label="Create"
+        >Create</Button>
     {/if}
   </svelte:fragment>
 


### PR DESCRIPTION
### What does this PR do?
Adds some missing area labels to the volumes page

### What issues does this PR fix or reference?
https://github.com/containers/podman-desktop/issues/5625

