### PR TITLE
feat: add alias for registry entries

### DIFF
--- a/extensions/podman/src/registry-setup.spec.ts
+++ b/extensions/podman/src/registry-setup.spec.ts
@@ -123,7 +123,7 @@ test('should work with JSON auth file', async () => {
   // expect the file to have a single entry
   expect(authFile.auths['myregistry.io']).toBeDefined();
   expect(authFile.auths['myregistry.io'].auth).toBe(auth);
-  expect(authFile.auths['myregistry.io']['podman_desktop.alias']).not.toBeDefined();
+  expect(authFile.auths['myregistry.io']['podmanDesktopAlias']).not.toBeDefined();
 
   // expect read with the correct file
   expect(readFileSpy).toHaveBeenCalledWith(authJsonLocation, 'utf-8', expect.anything());
@@ -142,10 +142,7 @@ test('should work with JSON auth file and alias', async () => {
     (_path: string, _encoding: string, callback: (err: Error | null, data: string) => void) => {
       // mock the error
 
-      callback(
-        undefined,
-        JSON.stringify({ auths: { 'myregistry.io': { auth: auth, 'podman_desktop.alias': 'alias' } } }),
-      );
+      callback(undefined, JSON.stringify({ auths: { 'myregistry.io': { auth: auth, podmanDesktopAlias: 'alias' } } }));
     },
   );
 
@@ -160,7 +157,7 @@ test('should work with JSON auth file and alias', async () => {
   // expect the file to have a single entry
   expect(authFile.auths['myregistry.io']).toBeDefined();
   expect(authFile.auths['myregistry.io'].auth).toBe(auth);
-  expect(authFile.auths['myregistry.io']['podman_desktop.alias']).toBe('alias');
+  expect(authFile.auths['myregistry.io']['podmanDesktopAlias']).toBe('alias');
 
   // expect read with the correct file
   expect(readFileSpy).toHaveBeenCalledWith(authJsonLocation, 'utf-8', expect.anything());

--- a/extensions/podman/src/registry-setup.spec.ts
+++ b/extensions/podman/src/registry-setup.spec.ts
@@ -56,16 +56,16 @@ afterEach(() => {
   console.error = originalConsoleError;
 });
 
+type ReadFileType = (
+  path: string,
+  options: string,
+  callback: (err: NodeJS.ErrnoException | undefined, data: string | Buffer) => void,
+) => void;
+
 test('should work with invalid JSON auth file', async () => {
   // mock the existSync
   const existSyncSpy = vi.spyOn(fs, 'existsSync');
   existSyncSpy.mockReturnValue(true);
-
-  type ReadFileType = (
-    path: string,
-    options: string,
-    callback: (err: NodeJS.ErrnoException | undefined, data: string | Buffer) => void,
-  ) => void;
 
   // mock the readFile
   const readFileSpy = vi.spyOn(fs, 'readFile') as unknown as MockedFunction<ReadFileType>;
@@ -93,4 +93,75 @@ test('should work with invalid JSON auth file', async () => {
 
   // expect error was logged
   expect(consoleErroMock).toHaveBeenCalledWith('Error parsing auth file', expect.anything());
+});
+
+test('should work with JSON auth file', async () => {
+  // mock the existSync
+  const existSyncSpy = vi.spyOn(fs, 'existsSync');
+  existSyncSpy.mockReturnValue(true);
+
+  // mock the readFile
+  const readFileSpy = vi.spyOn(fs, 'readFile') as unknown as MockedFunction<ReadFileType>;
+  const auth = Buffer.from('user:password').toString('base64');
+
+  readFileSpy.mockImplementation(
+    (_path: string, _encoding: string, callback: (err: Error | null, data: string) => void) => {
+      // mock the error
+
+      callback(undefined, JSON.stringify({ auths: { 'myregistry.io': { auth: auth } } }));
+    },
+  );
+
+  // mock the location
+  const authJsonLocation = '/tmp/containers/auth.json';
+  const mockGetAuthFileLocation = vi.spyOn(registrySetup, 'getAuthFileLocation');
+  mockGetAuthFileLocation.mockReturnValue(authJsonLocation);
+
+  // expect an error
+  const authFile = await registrySetup.publicReadAuthFile();
+
+  // expect the file to have a single entry
+  expect(authFile.auths['myregistry.io']).toBeDefined();
+  expect(authFile.auths['myregistry.io'].auth).toBe(auth);
+  expect(authFile.auths['myregistry.io']['podman_desktop.alias']).not.toBeDefined();
+
+  // expect read with the correct file
+  expect(readFileSpy).toHaveBeenCalledWith(authJsonLocation, 'utf-8', expect.anything());
+});
+
+test('should work with JSON auth file and alias', async () => {
+  // mock the existSync
+  const existSyncSpy = vi.spyOn(fs, 'existsSync');
+  existSyncSpy.mockReturnValue(true);
+
+  // mock the readFile
+  const readFileSpy = vi.spyOn(fs, 'readFile') as unknown as MockedFunction<ReadFileType>;
+  const auth = Buffer.from('user:password').toString('base64');
+
+  readFileSpy.mockImplementation(
+    (_path: string, _encoding: string, callback: (err: Error | null, data: string) => void) => {
+      // mock the error
+
+      callback(
+        undefined,
+        JSON.stringify({ auths: { 'myregistry.io': { auth: auth, 'podman_desktop.alias': 'alias' } } }),
+      );
+    },
+  );
+
+  // mock the location
+  const authJsonLocation = '/tmp/containers/auth.json';
+  const mockGetAuthFileLocation = vi.spyOn(registrySetup, 'getAuthFileLocation');
+  mockGetAuthFileLocation.mockReturnValue(authJsonLocation);
+
+  // expect an error
+  const authFile = await registrySetup.publicReadAuthFile();
+
+  // expect the file to have a single entry
+  expect(authFile.auths['myregistry.io']).toBeDefined();
+  expect(authFile.auths['myregistry.io'].auth).toBe(auth);
+  expect(authFile.auths['myregistry.io']['podman_desktop.alias']).toBe('alias');
+
+  // expect read with the correct file
+  expect(readFileSpy).toHaveBeenCalledWith(authJsonLocation, 'utf-8', expect.anything());
 });

--- a/extensions/podman/src/registry-setup.ts
+++ b/extensions/podman/src/registry-setup.ts
@@ -27,7 +27,7 @@ import { isLinux, isMac, isWindows } from './util';
 export type ContainerAuthConfigEntry = {
   [key: string]: {
     auth: string;
-    'podman_desktop.alias': string | undefined;
+    podmanDesktopAlias: string | undefined;
   };
 };
 
@@ -71,7 +71,7 @@ export class RegistrySetup {
           serverUrl,
           username,
           secret,
-          alias: value['podman_desktop.alias'],
+          alias: value['podmanDesktopAlias'],
         };
         inFileRegistries.push(registry);
       }
@@ -119,7 +119,7 @@ export class RegistrySetup {
         }
         authFile.auths[registry.serverUrl] = {
           auth: Buffer.from(`${registry.username}:${registry.secret}`).toString('base64'),
-          'podman_desktop.alias': registry.alias,
+          podmanDesktopAlias: registry.alias,
         };
 
         await this.writeAuthFile(JSON.stringify(authFile, undefined, 8));
@@ -152,7 +152,7 @@ export class RegistrySetup {
         }
         authFile.auths[registry.serverUrl] = {
           auth: Buffer.from(`${registry.username}:${registry.secret}`).toString('base64'),
-          'podman_desktop.alias': registry.alias,
+          podmanDesktopAlias: registry.alias,
         };
 
         await this.writeAuthFile(JSON.stringify(authFile, undefined, 8));

--- a/extensions/podman/src/registry-setup.ts
+++ b/extensions/podman/src/registry-setup.ts
@@ -27,6 +27,7 @@ import { isLinux, isMac, isWindows } from './util';
 export type ContainerAuthConfigEntry = {
   [key: string]: {
     auth: string;
+    'podman_desktop.alias': string | undefined;
   };
 };
 
@@ -70,6 +71,7 @@ export class RegistrySetup {
           serverUrl,
           username,
           secret,
+          alias: value['podman_desktop.alias'],
         };
         inFileRegistries.push(registry);
       }
@@ -117,6 +119,7 @@ export class RegistrySetup {
         }
         authFile.auths[registry.serverUrl] = {
           auth: Buffer.from(`${registry.username}:${registry.secret}`).toString('base64'),
+          'podman_desktop.alias': registry.alias,
         };
 
         await this.writeAuthFile(JSON.stringify(authFile, undefined, 8));
@@ -149,6 +152,7 @@ export class RegistrySetup {
         }
         authFile.auths[registry.serverUrl] = {
           auth: Buffer.from(`${registry.username}:${registry.secret}`).toString('base64'),
+          'podman_desktop.alias': registry.alias,
         };
 
         await this.writeAuthFile(JSON.stringify(authFile, undefined, 8));

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -623,6 +623,7 @@ declare module '@podman-desktop/api' {
     username: string;
     secret: string;
     insecure?: boolean;
+    alias?: string;
   }
 
   export interface RegistryProvider {

--- a/packages/renderer/src/lib/preferences/PreferencesRegistriesEditing.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRegistriesEditing.svelte
@@ -65,6 +65,7 @@ function markRegistryAsModified(registry: containerDesktopAPI.Registry) {
     serverUrl: registry.serverUrl,
     username: registry.username,
     secret: registry.secret,
+    alias: registry.alias,
   } as containerDesktopAPI.Registry;
 
   originRegistries = [...originRegistries, originRegistry];
@@ -282,7 +283,7 @@ function removeExistingRegistry(registry: containerDesktopAPI.Registry) {
               {:else if !registry.username && !registry.secret}
                 <Button on:click="{() => markRegistryAsModified(registry)}">Login now</Button>
               {:else}
-                {registry.username}
+                {registry.alias ?? registry.username}
               {/if}
             </div>
 


### PR DESCRIPTION
Fixes #6298

### What does this PR do?

Extend Podman Desktop API to allow to register a registry user with an alias and display that alias in the registries page. Field is serialized in auth.json as an additional `podman_desktop.alias` field 

### Screenshot / video of UI

![registries](https://github.com/containers/podman-desktop/assets/695993/1897c2fc-014d-4351-b4a8-47fe406e3b12)

### What issues does this PR fix or reference?

#6298

### How to test this PR?

- Edit your $HOME/.config/containers/auth.json -> add podman_desktop.alias field next to the auth field
- Start Podman Desktop and go the registries field

- [x] Tests are covering the bug fix or the new feature
