### PR TITLE
chore: include extension version in telemetry

### DIFF
--- a/packages/main/src/plugin/extension-loader.spec.ts
+++ b/packages/main/src/plugin/extension-loader.spec.ts
@@ -458,6 +458,30 @@ test('Verify extension activate with a long timeout is flagged as error', async 
   expect(extensionLoader.getExtensionState().get(id)).toBe('failed');
 });
 
+test('Verify extension load', async () => {
+  const id = 'extension.foo';
+
+  await extensionLoader.loadExtension({
+    id: id,
+    name: 'id',
+    path: 'dummy',
+    api: {} as typeof containerDesktopAPI,
+    mainPath: '',
+    removable: false,
+    manifest: {
+      version: '1.1',
+    },
+    subscriptions: [],
+    readme: '',
+    dispose: vi.fn(),
+  });
+
+  expect(telemetry.track).toBeCalledWith(
+    'loadExtension',
+    expect.objectContaining({ extensionId: id, extensionVersion: '1.1' }),
+  );
+});
+
 test('Verify setExtensionsUpdates', async () => {
   // set the private field analyzedExtensions of extensionLoader
   const analyzedExtensions = new Map<string, AnalyzedExtension>();
@@ -1780,6 +1804,9 @@ describe('extensionContext', async () => {
       subscriptions: [],
       id: 'fooPublisher.fooName',
       name: 'fooName',
+      manifest: {
+        version: '1.0',
+      },
     } as unknown as AnalyzedExtension;
 
     vi.mocked(configurationRegistry.getConfiguration).mockReturnValue({
@@ -1810,6 +1837,10 @@ describe('extensionContext', async () => {
 
     expect(extensionContext).toBeDefined();
     expect(extensionContext?.secrets).toBeDefined();
+    expect(telemetry.track).toBeCalledWith('activateExtension', {
+      extensionId: 'fooPublisher.fooName',
+      extensionVersion: '1.0',
+    });
 
     expect(safeStorageRegistry.getExtensionStorage).toBeCalledWith('fooPublisher.fooName');
 

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -634,7 +634,7 @@ export class ExtensionLoader {
     this.extensionState.delete(extension.id);
     this.extensionStateErrors.delete(extension.id);
 
-    const telemetryOptions = { extensionId: extension.id };
+    const telemetryOptions = { extensionId: extension.id, extensionVersion: extension.manifest?.version };
 
     if (extension.missingDependencies && extension.missingDependencies.length > 0) {
       this.extensionState.set(extension.id, 'failed');
@@ -1368,7 +1368,7 @@ export class ExtensionLoader {
       deactivateFunction = extensionMain['deactivate'];
     }
 
-    const telemetryOptions = { extensionId: extension.id };
+    const telemetryOptions = { extensionId: extension.id, extensionVersion: extension.manifest?.version };
     try {
       if (typeof extensionMain?.['activate'] === 'function') {
         // maximum time to wait for the extension to activate by reading from configuration


### PR DESCRIPTION
### What does this PR do?

The loadExtension and activateExtension telemetry events include the ids of extensions but not the versions. It would be handy if we have them here both for general debugging/fleet understanding, but also to stop each new extension from wanting to add a startup event.

Extensions should not get to either path without a valid manifest + version, just being slightly paranoid and consistent with prior code using ?.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes #6857.

### How to test this PR?

- [x] Tests are covering the bug fix or the new feature

There was no basic loadExtension test so I started one; also updated the activateExtension test to check for telemetry.