### PR TITLE
chore: reduce navbar width

### DIFF
--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -38,11 +38,11 @@ module.exports = {
         width: 'width',
       },
       width: {
-        'leftnavbar': '54px',
+        'leftnavbar': '48px',
         'leftsidebar': '225px',
       },
       minWidth: {
-        'leftnavbar': '54px',
+        'leftnavbar': '48px',
         'leftsidebar': '225px',
       },
     },


### PR DESCRIPTION
### What does this PR do?

Now that we've reduced the height of the main navbar items and the icons themselves, the bar itself and item selection area look very wide to me. Making these rectangles a little narrower/more square would match our previous design better and be more visually appealing.

This just reduces the width by 6px, which IMHO is just enough to counteract the effect of the changes.

### Screenshot / video of UI

Before:
<img width="142" alt="Screenshot 2024-04-22 at 3 32 52 PM" src="https://github.com/containers/podman-desktop/assets/19958075/ccc5baa3-de6a-4748-bcd4-506cbf55ed82">

After:
<img width="142" alt="Screenshot 2024-04-22 at 3 31 51 PM" src="https://github.com/containers/podman-desktop/assets/19958075/63802efd-7f93-4aa6-9f8b-69bfcd196255">

### What issues does this PR fix or reference?

Related to #6774, from comment in #6777.

### How to test this PR?

Just look at left navbar.