### PR TITLE
chore: handle empty state and make it reactive in extension details

### DIFF
--- a/packages/renderer/src/lib/extensions/ExtensionDetails.spec.ts
+++ b/packages/renderer/src/lib/extensions/ExtensionDetails.spec.ts
@@ -96,3 +96,16 @@ test('Expect to have details page', async () => {
   const extensionBadge = screen.getByRole('region', { name: 'Extension Badge' });
   expect(extensionBadge).toBeInTheDocument();
 });
+
+test('Expect empty screen', async () => {
+  const extensionId = 'idUnknown';
+
+  catalogExtensionInfos.set([aFakeExtension]);
+  extensionInfos.set(combined);
+
+  await waitRender({ extensionId });
+
+  // should have the text "Extension not found"
+  const extensionNotFound = screen.getByText('Extension not found');
+  expect(extensionNotFound).toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/extensions/ExtensionDetails.svelte
+++ b/packages/renderer/src/lib/extensions/ExtensionDetails.svelte
@@ -1,13 +1,14 @@
 <script lang="ts">
-import { onMount } from 'svelte';
 import { derived, type Readable } from 'svelte/store';
 
+import extensionIcon from '/@/lib/images/ExtensionIcon.svelte';
 import ExtensionIcon from '/@/lib/preferences/ExtensionIcon.svelte';
 import { combinedInstalledExtensions } from '/@/stores/all-installed-extensions';
 import { catalogExtensionInfos } from '/@/stores/catalog-extensions';
 
 import FeaturedExtensionDownload from '../featured/FeaturedExtensionDownload.svelte';
 import DetailsPage from '../ui/DetailsPage.svelte';
+import EmptyScreen from '../ui/EmptyScreen.svelte';
 import ExtensionStatus from '../ui/ExtensionStatus.svelte';
 import type { ExtensionDetailsUI } from './extension-details-ui';
 import ExtensionBadge from './ExtensionBadge.svelte';
@@ -18,65 +19,65 @@ import InstalledExtensionActions from './InstalledExtensionActions.svelte';
 
 export let extensionId: string;
 
-let extension: ExtensionDetailsUI;
 let detailsPage: DetailsPage;
 const extensionsUtils = new ExtensionsUtils();
 
-const extensionDetailStore: Readable<ExtensionDetailsUI | undefined> = derived(
+let extension: Readable<ExtensionDetailsUI | undefined>;
+
+$: extension = derived(
   [catalogExtensionInfos, combinedInstalledExtensions],
   ([$catalogExtensionInfos, $combinedInstalledExtensions]) => {
     return extensionsUtils.extractExtensionDetail($catalogExtensionInfos, $combinedInstalledExtensions, extensionId);
   },
 );
-
-onMount(() => {
-  // loading container info
-  return extensionDetailStore.subscribe(value => {
-    if (value) {
-      extension = value;
-    } else if (detailsPage) {
-      // the extension has been deleted
-      detailsPage.close();
-    }
-  });
-});
 </script>
 
-{#if extension}
-  <DetailsPage title="{extension.displayName} extension" subtitle="{extension.description}" bind:this="{detailsPage}">
+{#if $extension}
+  <DetailsPage title="{$extension.displayName} extension" subtitle="{$extension.description}" bind:this="{detailsPage}">
     <div class="flex flex-col mt-1 items-baseline w-8" slot="icon">
       <div class="w-8 min-h-8">
         <!-- Display icon being installed using base64 -->
-        {#if extension.icon}
-          <ExtensionIcon extension="{extension}" />
-        {:else if extension.iconRef}
-          <img src="{extension.iconRef}" alt="{extension.displayName} icon" class="max-w-8 max-h-8" />
+        {#if $extension.icon}
+          <ExtensionIcon extension="{$extension}" />
+        {:else if $extension.iconRef}
+          <img src="{$extension.iconRef}" alt="{$extension.displayName} icon" class="max-w-8 max-h-8" />
         {/if}
       </div>
       <div class="flex flex-row mt-3">
-        <ExtensionStatus status="{extension.type === 'dd' ? 'started' : extension.state}" />
+        <ExtensionStatus status="{$extension.type === 'dd' ? 'started' : $extension.state}" />
       </div>
     </div>
     <svelte:fragment slot="actions">
       <div class="flex items-center space-x-10 w-full">
-        {#if extension.installedExtension}
-          <InstalledExtensionActions class="w-48" extension="{extension.installedExtension}" />
-        {:else if extension.fetchable}
+        {#if $extension.installedExtension}
+          <InstalledExtensionActions class="w-48" extension="{$extension.installedExtension}" />
+        {:else if $extension.fetchable}
           <div class="flex flex-1 justify-items-end w-18 flex-col items-end place-content-center">
             <div class="italic text-xs text-gray-700 pb-3">Install this extension with a single click</div>
-            <FeaturedExtensionDownload extension="{extension}" />
+            <FeaturedExtensionDownload extension="{$extension}" />
           </div>
         {/if}
       </div>
     </svelte:fragment>
 
     <div slot="detail" class="flex">
-      <ExtensionBadge class="mt-2" extension="{extension}" />
+      <ExtensionBadge class="mt-2" extension="{$extension}" />
     </div>
     <svelte:fragment slot="content">
       <div class="flex w-full h-full overflow-y-auto p-4 flex-col lg:flex-row">
-        <ExtensionDetailsSummaryCard extensionDetails="{extension}" />
-        <ExtensionDetailsReadme readme="{extension.readme}" />
+        <ExtensionDetailsSummaryCard extensionDetails="{$extension}" />
+        <ExtensionDetailsReadme readme="{$extension.readme}" />
+      </div>
+    </svelte:fragment>
+  </DetailsPage>
+{:else}
+  <DetailsPage title="{extensionId} extension" bind:this="{detailsPage}">
+    <svelte:fragment slot="content">
+      <div class="flex w-full h-full">
+        <EmptyScreen
+          title="Extension not found"
+          message="Extension with id '{extensionId}' is not available in the catalog"
+          icon="{extensionIcon}" />
       </div>
     </svelte:fragment>
   </DetailsPage>

--- a/packages/renderer/src/lib/extensions/ExtensionDetailsReadme.spec.ts
+++ b/packages/renderer/src/lib/extensions/ExtensionDetailsReadme.spec.ts
@@ -36,8 +36,8 @@ beforeEach(() => {
 
 test('Expect to have readme with URI', async () => {
   const spyFetch = vi.spyOn(window, 'fetch');
-  const response = new Response('# This is my README');
-  spyFetch.mockResolvedValue(response);
+  spyFetch.mockResolvedValueOnce(new Response('#'));
+  spyFetch.mockResolvedValueOnce(new Response('# This is my README'));
 
   await waitRender({ readme: { uri: 'http://my-fake-registry/readme-content' } });
 

--- a/packages/renderer/src/lib/extensions/ExtensionDetailsReadme.svelte
+++ b/packages/renderer/src/lib/extensions/ExtensionDetailsReadme.svelte
@@ -9,7 +9,10 @@ export let readme: { content?: string; uri?: string };
 
 let readmeContent: string | undefined = undefined;
 
-onMount(async () => {
+$: readme && refreshReadme();
+
+async function refreshReadme(): Promise<void> {
+  readmeContent = undefined;
   if (readme.uri) {
     // fetch the readme file content
     const response = await fetch(readme.uri);
@@ -27,6 +30,10 @@ onMount(async () => {
   if (!readmeContent) {
     readmeContent = '';
   }
+}
+
+onMount(async () => {
+  await refreshReadme();
 });
 </script>
 


### PR DESCRIPTION
### What does this PR do?
extension may not be found so we should display an empty screen in that case for extension details 
### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

- [x] Tests are covering the bug fix or the new feature
