### PR TITLE
chore: align DD extension actions

### DIFF
--- a/packages/renderer/src/lib/extensions/InstalledExtensionCardLeftLifecycleStop.spec.ts
+++ b/packages/renderer/src/lib/extensions/InstalledExtensionCardLeftLifecycleStop.spec.ts
@@ -47,7 +47,8 @@ test('Expect unable to stop dd Extension if started', async () => {
 
   // get button with label 'Stop'
   const button = screen.queryByRole('button', { name: 'Stop' });
-  expect(button).not.toBeInTheDocument();
+  expect(button).toBeInTheDocument();
+  expect(button).toBeDisabled();
 });
 
 test('Expect to stop pd Extension if started', async () => {

--- a/packages/renderer/src/lib/extensions/InstalledExtensionCardLeftLifecycleStop.svelte
+++ b/packages/renderer/src/lib/extensions/InstalledExtensionCardLeftLifecycleStop.svelte
@@ -16,11 +16,11 @@ async function stopExtension(): Promise<void> {
 }
 </script>
 
-{#if extension.state === 'started' && extension.type !== 'dd'}
+{#if extension.state === 'started'}
   <LoadingIconButton
     clickAction="{() => stopExtension()}"
     action="stop"
     icon="{faStop}"
-    state="{{ status: extension.state, inProgress }}"
+    state="{{ status: extension.type === 'dd' ? 'no-stop' : extension.state, inProgress }}"
     leftPosition="" />
 {/if}

--- a/packages/renderer/src/lib/extensions/InstalledExtensionCardLeftLifecycleStop.svelte
+++ b/packages/renderer/src/lib/extensions/InstalledExtensionCardLeftLifecycleStop.svelte
@@ -21,6 +21,6 @@ async function stopExtension(): Promise<void> {
     clickAction="{() => stopExtension()}"
     action="stop"
     icon="{faStop}"
-    state="{{ status: extension.type === 'dd' ? 'unknown' : extension.state, inProgress }}"
+    state="{{ status: extension.type === 'dd' ? 'unsupported' : extension.state, inProgress }}"
     leftPosition="" />
 {/if}

--- a/packages/renderer/src/lib/extensions/InstalledExtensionCardLeftLifecycleStop.svelte
+++ b/packages/renderer/src/lib/extensions/InstalledExtensionCardLeftLifecycleStop.svelte
@@ -21,6 +21,6 @@ async function stopExtension(): Promise<void> {
     clickAction="{() => stopExtension()}"
     action="stop"
     icon="{faStop}"
-    state="{{ status: extension.type === 'dd' ? 'no-stop' : extension.state, inProgress }}"
+    state="{{ status: extension.type === 'dd' ? 'unknown' : extension.state, inProgress }}"
     leftPosition="" />
 {/if}

--- a/packages/renderer/src/lib/ui/LoadingIconButton.svelte
+++ b/packages/renderer/src/lib/ui/LoadingIconButton.svelte
@@ -16,6 +16,7 @@ export let clickAction: () => Promise<void> | void;
 
 $: disable =
   state?.inProgress ||
+  state?.status === 'unsupported' ||
   (action === 'start' && state?.status !== 'stopped') ||
   (action === 'restart' && state?.status !== 'started') ||
   (action === 'stop' && state?.status !== 'started') ||
@@ -29,7 +30,8 @@ function getStyleByState(state: ILoadingStatus | undefined, action: string): str
     (action === 'start' && (state?.inProgress || state?.status !== 'stopped')) ||
     ((action === 'stop' || action === 'restart') && (state?.inProgress || state?.status !== 'started')) ||
     (action === 'delete' && (state?.inProgress || (state?.status !== 'stopped' && state?.status !== 'unknown'))) ||
-    (action === 'update' && (state?.inProgress || state?.status === 'unknown'))
+    (action === 'update' && (state?.inProgress || state?.status === 'unknown')) ||
+    state?.status === 'unsupported'
   ) {
     return 'text-gray-900 cursor-not-allowed';
   } else {


### PR DESCRIPTION
### What does this PR do?

The action buttons for DD don't align with other extensions. This just adds a dummy Stop button that is never enabled so that the buttons visually match the other extensions.

There are other ways to solve this (changing the row layout, or adding a spacer that matches the width of the action buttons) but IMHO this keeps DD extensions as visually similar and consistent as possible to other extensions. From a user perspective I don't think this is a negative b/c it's clear 'this can't be stopped' vs potentially wondering 'why is there no stop button' before.

### Screenshot / video of UI

Before:
<img width="220" alt="Screenshot 2024-04-22 at 4 25 30 PM" src="https://github.com/containers/podman-desktop/assets/19958075/0cd1c320-228e-4dfd-bf2f-bfb0c51c59b8">

After:
<img width="220" alt="Screenshot 2024-04-22 at 4 18 54 PM" src="https://github.com/containers/podman-desktop/assets/19958075/8378f940-29e2-47e8-be3e-4bf1ad81b86d">

### What issues does this PR fix or reference?

One part of #6855.

### How to test this PR?

Look at extension page with a mix of DD and Podman Desktop extensions and confirm they look similar.