### PR TITLE
fix: hide cpu, memory, size sliders on WSL

### DIFF
--- a/extensions/podman/package.json
+++ b/extensions/podman/package.json
@@ -113,7 +113,8 @@
           "minimum": 1,
           "maximum": "HOST_TOTAL_CPU",
           "scope": "ContainerProviderConnectionFactory",
-          "description": "CPU(s)"
+          "description": "CPU(s)",
+          "when": "!isWindows || !podman.isWSL"
         },
         "podman.factory.machine.memory": {
           "type": "number",
@@ -123,7 +124,8 @@
           "maximum": "HOST_TOTAL_MEMORY",
           "scope": "ContainerProviderConnectionFactory",
           "step": 500000000,
-          "description": "Memory"
+          "description": "Memory",
+          "when": "!isWindows || !podman.isWSL"
         },
         "podman.factory.machine.diskSize": {
           "type": "number",
@@ -133,7 +135,8 @@
           "maximum": "HOST_TOTAL_DISKSIZE",
           "step": 500000000,
           "scope": "ContainerProviderConnectionFactory",
-          "description": "Disk size"
+          "description": "Disk size",
+          "when": "!isWindows || !podman.isWSL"
         },
         "podman.factory.machine.image-path": {
           "type": "string",

--- a/extensions/podman/package.json
+++ b/extensions/podman/package.json
@@ -114,7 +114,7 @@
           "maximum": "HOST_TOTAL_CPU",
           "scope": "ContainerProviderConnectionFactory",
           "description": "CPU(s)",
-          "when": "!isWindows || !podman.isWSL"
+          "when": "podman.podmanMachineCpuSupported"
         },
         "podman.factory.machine.memory": {
           "type": "number",
@@ -125,7 +125,7 @@
           "scope": "ContainerProviderConnectionFactory",
           "step": 500000000,
           "description": "Memory",
-          "when": "!isWindows || !podman.isWSL"
+          "when": "podman.podmanMachineMemorySupported"
         },
         "podman.factory.machine.diskSize": {
           "type": "number",
@@ -136,7 +136,7 @@
           "step": 500000000,
           "scope": "ContainerProviderConnectionFactory",
           "description": "Disk size",
-          "when": "!isWindows || !podman.isWSL"
+          "when": "podman.podmanMachineDiskSupported"
         },
         "podman.factory.machine.image-path": {
           "type": "string",

--- a/extensions/podman/src/extension.spec.ts
+++ b/extensions/podman/src/extension.spec.ts
@@ -1818,6 +1818,15 @@ test('isIncompatibleMachineOutput', () => {
 
 describe('calcPodmanMachineSetting', () => {
   const podmanConfiguration = new PodmanConfiguration();
+  let originalProvider: string | undefined;
+  beforeEach(() => {
+    originalProvider = process.env.CONTAINERS_MACHINE_PROVIDER;
+  });
+
+  afterEach(() => {
+    process.env.CONTAINERS_MACHINE_PROVIDER = originalProvider;
+  });
+
   test('setValue to true if OS is MacOS', async () => {
     vi.mocked(isWindows).mockReturnValue(false);
     await extension.calcPodmanMachineSetting(podmanConfiguration);
@@ -1828,11 +1837,11 @@ describe('calcPodmanMachineSetting', () => {
   test('setValue to true if OS is Windows and uses HyperV - set env variable', async () => {
     vi.mocked(isWindows).mockReturnValue(true);
     process.env.CONTAINERS_MACHINE_PROVIDER = 'hyperv';
+    vi.spyOn(podmanConfiguration, 'matchRegexpInContainersConfig').mockResolvedValue(false);
     await extension.calcPodmanMachineSetting(podmanConfiguration);
     expect(extensionApi.context.setValue).toBeCalledWith(extension.PODMAN_MACHINE_CPU_SUPPORTED_KEY, true);
     expect(extensionApi.context.setValue).toBeCalledWith(extension.PODMAN_MACHINE_MEMORY_SUPPORTED_KEY, true);
     expect(extensionApi.context.setValue).toBeCalledWith(extension.PODMAN_MACHINE_DISK_SUPPORTED_KEY, true);
-    delete process.env.CONTAINERS_MACHINE_PROVIDER;
   });
   test('setValue to true if OS is Windows and uses HyperV - set by config file', async () => {
     vi.mocked(isWindows).mockReturnValue(true);
@@ -1850,6 +1859,5 @@ describe('calcPodmanMachineSetting', () => {
     expect(extensionApi.context.setValue).toBeCalledWith(extension.PODMAN_MACHINE_CPU_SUPPORTED_KEY, false);
     expect(extensionApi.context.setValue).toBeCalledWith(extension.PODMAN_MACHINE_MEMORY_SUPPORTED_KEY, false);
     expect(extensionApi.context.setValue).toBeCalledWith(extension.PODMAN_MACHINE_DISK_SUPPORTED_KEY, false);
-    delete process.env.CONTAINERS_MACHINE_PROVIDER;
   });
 });

--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -877,6 +877,7 @@ export const ROOTFUL_MACHINE_INIT_SUPPORTED_KEY = 'podman.isRootfulMachineInitSu
 export const USER_MODE_NETWORKING_SUPPORTED_KEY = 'podman.isUserModeNetworkingSupported';
 export const START_NOW_MACHINE_INIT_SUPPORTED_KEY = 'podman.isStartNowAtMachineInitSupported';
 export const CLEANUP_REQUIRED_MACHINE_KEY = 'podman.needPodmanMachineCleanup';
+export const PODMAN_WSL_KEY = 'podman.isWSL';
 
 export function initTelemetryLogger(): void {
   telemetryLogger = extensionApi.env.createTelemetryLogger();
@@ -1514,6 +1515,12 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
 
   const podmanConfiguration = new PodmanConfiguration();
   await podmanConfiguration.init();
+
+  if (isWindows()) {
+    const isPodmanHyperv_Env = process.env.CONTAINERS_MACHINE_PROVIDER === 'hyperv';
+    const isPodmanHyperv_Config = await podmanConfiguration.isValueInContainersConfig(/provider\s*=\s*"hyperv"/);
+    extensionApi.context.setValue(PODMAN_WSL_KEY, !(isPodmanHyperv_Env || isPodmanHyperv_Config));
+  }
 }
 
 // Function that checks to see if the default machine is running and return a string

--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -1518,7 +1518,7 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
 
   if (isWindows()) {
     const isPodmanHyperv_Env = process.env.CONTAINERS_MACHINE_PROVIDER === 'hyperv';
-    const isPodmanHyperv_Config = await podmanConfiguration.isValueInContainersConfig(/provider\s*=\s*"hyperv"/);
+    const isPodmanHyperv_Config = await podmanConfiguration.matchRegexpInContainersConfig(/provider\s*=\s*"hyperv"/);
     extensionApi.context.setValue(PODMAN_WSL_KEY, !(isPodmanHyperv_Env || isPodmanHyperv_Config));
   }
 }

--- a/extensions/podman/src/podman-configuration.spec.ts
+++ b/extensions/podman/src/podman-configuration.spec.ts
@@ -40,7 +40,7 @@ test('should return true if regex is satisfied', async () => {
 provider = "hyperv"
 memory = 4096
     `);
-  const found = await podmanConfiguration.isValueInContainersConfig(/provider\s*=\s*"hyperv"/);
+  const found = await podmanConfiguration.matchRegexpInContainersConfig(/provider\s*=\s*"hyperv"/);
   expect(found).toBeTruthy();
 });
 
@@ -50,6 +50,6 @@ test('should return false if regex is not satisfied', async () => {
 provider = "wsl"
 memory = 4096
     `);
-  const found = await podmanConfiguration.isValueInContainersConfig(/provider\s*=\s*"hyperv"/);
+  const found = await podmanConfiguration.matchRegexpInContainersConfig(/provider\s*=\s*"hyperv"/);
   expect(found).toBeFalsy();
 });

--- a/extensions/podman/src/podman-configuration.spec.ts
+++ b/extensions/podman/src/podman-configuration.spec.ts
@@ -1,0 +1,55 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { PodmanConfiguration } from './podman-configuration';
+
+// allows to call protected methods
+class TestPodmanConfiguration extends PodmanConfiguration {
+  readContainersConfigFile(): Promise<string> {
+    return super.readContainersConfigFile();
+  }
+}
+
+let podmanConfiguration: TestPodmanConfiguration;
+
+beforeEach(() => {
+  podmanConfiguration = new TestPodmanConfiguration();
+  vi.resetAllMocks();
+});
+
+test('should return true if regex is satisfied', async () => {
+  vi.spyOn(podmanConfiguration, 'readContainersConfigFile').mockResolvedValue(`
+[machine]
+provider = "hyperv"
+memory = 4096
+    `);
+  const found = await podmanConfiguration.isValueInContainersConfig(/provider\s*=\s*"hyperv"/);
+  expect(found).toBeTruthy();
+});
+
+test('should return false if regex is not satisfied', async () => {
+  vi.spyOn(podmanConfiguration, 'readContainersConfigFile').mockResolvedValue(`
+[machine]
+provider = "wsl"
+memory = 4096
+    `);
+  const found = await podmanConfiguration.isValueInContainersConfig(/provider\s*=\s*"hyperv"/);
+  expect(found).toBeFalsy();
+});

--- a/extensions/podman/src/podman-configuration.ts
+++ b/extensions/podman/src/podman-configuration.ts
@@ -203,12 +203,12 @@ export class PodmanConfiguration {
     }
   }
 
-  async isValueInContainersConfig(regex: RegExp): Promise<boolean> {
+  async matchRegexpInContainersConfig(regex: RegExp): Promise<boolean> {
     try {
       const containerConf = await this.readContainersConfigFile();
       return regex.test(containerConf);
     } catch (e) {
-      console.log(String(e));
+      console.warn(`Unable to run regex on containers.conf file. Reason: ${String(e)}`);
     }
     return false;
   }

--- a/extensions/podman/src/podman-configuration.ts
+++ b/extensions/podman/src/podman-configuration.ts
@@ -203,6 +203,16 @@ export class PodmanConfiguration {
     }
   }
 
+  async isValueInContainersConfig(regex: RegExp): Promise<boolean> {
+    try {
+      const containerConf = await this.readContainersConfigFile();
+      return regex.test(containerConf);
+    } catch (e) {
+      console.log(String(e));
+    }
+    return false;
+  }
+
   protected getContainersFileLocation(): string {
     let podmanConfigContainersPath;
 


### PR DESCRIPTION
### What does this PR do?

It hides the cpu, memory, size sliders on WSL as they are meaningless.

### Screenshot / video of UI

![image](https://github.com/containers/podman-desktop/assets/49404737/4bb7ca15-f31c-4677-a7c7-dd1bc37b9c0f)

### What issues does this PR fix or reference?

it resolves #2558 

### How to test this PR?

1. try to create a new machine on WSL, you should not see the cpu, memory, size sliders

- [x] Tests are covering the bug fix or the new feature