### PR TITLE
chore: add breadcrumb to Extensions when opening link podman-desktop:extension/id link

### DIFF
--- a/packages/renderer/src/Loader.spec.ts
+++ b/packages/renderer/src/Loader.spec.ts
@@ -19,10 +19,12 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import { render } from '@testing-library/svelte';
+import { get } from 'svelte/store';
 import { router } from 'tinro';
 import { beforeAll, expect, test, vi } from 'vitest';
 
 import Loader from './Loader.svelte';
+import { lastPage } from './stores/breadcrumb';
 
 // first, patch window object
 const callbacks = new Map<string, any>();
@@ -85,6 +87,12 @@ test('Loader should redirect to the installation page when receiving the event',
 
   // check that we have been redirected
   expect(router.goto).toHaveBeenCalledWith(`/extensions/details/${dummyExtensionId}`);
+
+  // check that breadcrumb is correct
+  expect(get(lastPage)).toStrictEqual({
+    name: 'Extensions',
+    path: '/extensions',
+  });
 });
 
 test('Loader should send the event if extensions take time to start', async () => {

--- a/packages/renderer/src/Loader.svelte
+++ b/packages/renderer/src/Loader.svelte
@@ -4,6 +4,7 @@ import { router } from 'tinro';
 
 import App from './App.svelte';
 import SealRocket from './lib/images/SealRocket.svelte';
+import { lastPage } from './stores/breadcrumb';
 
 let systemReady = false;
 
@@ -60,6 +61,8 @@ window.events?.receive('install-extension:from-id', (extensionId: any) => {
     // need to open the extension page
     await tick();
     router.goto(redirectPage);
+    // make sure the last page is set to the extensions page so breadcrumb will be correct
+    lastPage.set({ name: 'Extensions', path: '/extensions' });
   };
 
   if (!systemReady) {


### PR DESCRIPTION
### What does this PR do?
it was displaying the current path to the page
for example if user was in a volume page, it was displaying `Volumes` while user might expect `Extensions`

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

https://github.com/containers/podman-desktop/pull/6850#pullrequestreview-2015776049

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
