### PR TITLE
chore: remove the limit of featured extensions

### DIFF
--- a/packages/main/src/plugin/featured/featured.spec.ts
+++ b/packages/main/src/plugin/featured/featured.spec.ts
@@ -121,12 +121,12 @@ test('getFeaturedExtensions should check installable extensions', async () => {
   expect(crcExtension?.fetchLink).toBe(ociLink);
 });
 
-test('getFeaturedExtensions should shuffle and limit to 6 extensions by default', async () => {
+test('getFeaturedExtensions', async () => {
   // mock the set of featured JSON extensions
   const spyReadJson = vi.spyOn(featured, 'readFeaturedJson');
 
   const jsonValues = [];
-  for (let i = 1; i < 10; i++) {
+  for (let i = 1; i <= 10; i++) {
     jsonValues.push({
       extensionId: `podman-desktop.${i}`,
       displayName: `Podman${i}`,
@@ -144,71 +144,6 @@ test('getFeaturedExtensions should shuffle and limit to 6 extensions by default'
 
   expect(featuredExtensions1).toBeDefined();
 
-  // should be limited to 6
-  expect(featuredExtensions1.length).toBe(6);
-
-  // call again to check the shuffle
-  const featuredExtensions2 = await featured.getFeaturedExtensions();
-
-  // compare id from the 2 lists
-  // they should be in a different order
-  const idsList1 = featuredExtensions1.map(e => e.id);
-  const idsList2 = featuredExtensions2.map(e => e.id);
-
-  // check that the 2 lists are not the same
-  expect(idsList1).not.toStrictEqual(idsList2);
-});
-
-test('getFeaturedExtensions have no limit when calling with -1', async () => {
-  // mock the set of featured JSON extensions
-  const spyReadJson = vi.spyOn(featured, 'readFeaturedJson');
-
-  const jsonValues = [];
-  for (let i = 1; i <= 10; i++) {
-    jsonValues.push({
-      extensionId: `podman-desktop.${i}`,
-      displayName: `Podman${i}`,
-      shortDescription: `test${i}`,
-      categories: ['Container Engine'],
-      builtIn: true,
-      icon: `data:image/png;base64,${i}`,
-    });
-  }
-  spyReadJson.mockReturnValue(jsonValues);
-
-  // init fetchable extensions
-  await featured.init();
-  const featuredExtensions1 = await featured.getFeaturedExtensions(-1);
-
-  expect(featuredExtensions1).toBeDefined();
-
   // should not be limited
   expect(featuredExtensions1.length).toBe(10);
-});
-
-test('getFeaturedExtensions should limit the number of item returned with the provided value', async () => {
-  // mock the set of featured JSON extensions
-  const spyReadJson = vi.spyOn(featured, 'readFeaturedJson');
-
-  const jsonValues = [];
-  for (let i = 1; i <= 10; i++) {
-    jsonValues.push({
-      extensionId: `podman-desktop.${i}`,
-      displayName: `Podman${i}`,
-      shortDescription: `test${i}`,
-      categories: ['Container Engine'],
-      builtIn: true,
-      icon: `data:image/png;base64,${i}`,
-    });
-  }
-  spyReadJson.mockReturnValue(jsonValues);
-
-  // init fetchable extensions
-  await featured.init();
-  const featuredExtensions1 = await featured.getFeaturedExtensions(3);
-
-  expect(featuredExtensions1).toBeDefined();
-
-  // should be limited to 3
-  expect(featuredExtensions1.length).toBe(3);
 });

--- a/packages/main/src/plugin/featured/featured.ts
+++ b/packages/main/src/plugin/featured/featured.ts
@@ -46,9 +46,8 @@ export class Featured {
   /**
    * Return the list of featured extensions
    * and check if they are installed/available/etc
-   * @param limit the maximum number of feature extension returned. Default 6, use -1 for no limit
    */
-  async getFeaturedExtensions(limit: number = 6): Promise<FeaturedExtension[]> {
+  async getFeaturedExtensions(): Promise<FeaturedExtension[]> {
     const extensionsToCheck = this.readFeaturedJson();
 
     // get the list of all the installed extensions
@@ -94,11 +93,6 @@ export class Featured {
     // now, randomize the list to have only 6 items and list first the non installed extensions and then the installed one
     // shuffle the list of featured extensions
     featuredExtensions.sort(() => Math.random() - 0.5);
-
-    // take only a portion of them
-    if (limit >= 0 && featuredExtensions.length > limit) {
-      featuredExtensions.splice(limit);
-    }
 
     // and then by non installed first
     featuredExtensions.sort((b, a) => Number(b.installed) - Number(a.installed));

--- a/packages/main/src/plugin/recommendations/recommendations-registry.ts
+++ b/packages/main/src/plugin/recommendations/recommendations-registry.ts
@@ -45,7 +45,7 @@ export class RecommendationsRegistry {
     if (!this.isRecommendationEnabled()) return [];
 
     const featuredExtensions: Record<string, FeaturedExtension> = Object.fromEntries(
-      (await this.featured.getFeaturedExtensions(-1)).map(featured => [featured.id, featured]),
+      (await this.featured.getFeaturedExtensions()).map(featured => [featured.id, featured]),
     );
 
     // Filter and shuffle the extensions


### PR DESCRIPTION
### What does this PR do?
Widget is not displayed in the UI for now (but extension catalog displays the featured extensions) so we can remove the limit of 6

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
