### PR TITLE
feat(recommendation): make recommendation have publishDate property

### DIFF
--- a/packages/main/src/plugin/recommendations/recommendations-api.ts
+++ b/packages/main/src/plugin/recommendations/recommendations-api.ts
@@ -24,7 +24,7 @@ export interface ExtensionBanner {
   description: string;
   icon: string;
   thumbnail: string;
-  published?: string;
+  publishDate?: string;
   background?: {
     image?: string;
     gradient?: {

--- a/packages/main/src/plugin/recommendations/recommendations-api.ts
+++ b/packages/main/src/plugin/recommendations/recommendations-api.ts
@@ -24,6 +24,7 @@ export interface ExtensionBanner {
   description: string;
   icon: string;
   thumbnail: string;
+  published?: string;
   background?: {
     image?: string;
     gradient?: {

--- a/packages/main/src/plugin/recommendations/recommendations-registry.spec.ts
+++ b/packages/main/src/plugin/recommendations/recommendations-registry.spec.ts
@@ -37,7 +37,7 @@ vi.mock('../../../../../recommendations.json', () => ({
       description: 'dummy description',
       icon: 'data:image/png;base64-icon',
       thumbnail: 'data:image/png;base64-thumbnail',
-      published: '2020-01-01',
+      publishDate: '2020-01-01',
     })),
   },
 }));
@@ -202,7 +202,7 @@ describe('getExtensionBanners', () => {
     expect(featuredMock.getFeaturedExtensions).toHaveBeenCalled();
   });
 
-  test('published value anterior', async () => {
+  test('publishDate value anterior', async () => {
     vi.setSystemTime(new Date(2019, 1, 1));
 
     getRecommendationIgnored.mockReturnValue(false);

--- a/packages/main/src/plugin/recommendations/recommendations-registry.spec.ts
+++ b/packages/main/src/plugin/recommendations/recommendations-registry.spec.ts
@@ -37,7 +37,7 @@ vi.mock('../../../../../recommendations.json', () => ({
       description: 'dummy description',
       icon: 'data:image/png;base64-icon',
       thumbnail: 'data:image/png;base64-thumbnail',
-      published: '2021-01-01',
+      published: '2020-01-01',
     })),
   },
 }));
@@ -203,7 +203,7 @@ describe('getExtensionBanners', () => {
   });
 
   test('published value anterior', async () => {
-    vi.setSystemTime(new Date(2022, 1, 1));
+    vi.setSystemTime(new Date(2019, 1, 1));
 
     getRecommendationIgnored.mockReturnValue(false);
     const featured: FeaturedExtension = {

--- a/packages/main/src/plugin/recommendations/recommendations-registry.ts
+++ b/packages/main/src/plugin/recommendations/recommendations-registry.ts
@@ -50,15 +50,28 @@ export class RecommendationsRegistry {
 
     // Filter and shuffle the extensions
     const extensionBanners: ExtensionBanner[] = recommendations.extensions
-      .filter(
-        extension =>
-          extension.extensionId in featuredExtensions && !featuredExtensions[extension.extensionId].installed,
-      )
-      .map(extension => ({
-        ...extension,
-        featured: featuredExtensions[extension.extensionId],
-      }))
-      .sort(() => Math.random() - 0.5);
+      .reduce((prev, extension) => {
+        // ensure the extension is in the featured extensions and is not install
+        if (!(extension.extensionId in featuredExtensions) || featuredExtensions[extension.extensionId].installed) {
+          return prev;
+        }
+
+        // Check for published property
+        if ('published' in extension && typeof extension.published === 'string') {
+          const published = new Date(extension.published).getTime();
+          if (isNaN(published) || published < Date.now()) {
+            return prev;
+          }
+        }
+
+        prev.push({
+          ...extension,
+          featured: featuredExtensions[extension.extensionId],
+        });
+
+        return prev;
+      }, [] as ExtensionBanner[])
+      .toSorted(() => Math.random() - 0.5);
 
     // Limit the number of
     if (limit >= 0 && extensionBanners.length > limit) {

--- a/packages/main/src/plugin/recommendations/recommendations-registry.ts
+++ b/packages/main/src/plugin/recommendations/recommendations-registry.ts
@@ -59,7 +59,7 @@ export class RecommendationsRegistry {
         // Check for published property
         if ('published' in extension && typeof extension.published === 'string') {
           const published = new Date(extension.published).getTime();
-          if (isNaN(published) || published < Date.now()) {
+          if (isNaN(published) || published > Date.now()) {
             return prev;
           }
         }

--- a/packages/main/src/plugin/recommendations/recommendations-registry.ts
+++ b/packages/main/src/plugin/recommendations/recommendations-registry.ts
@@ -57,9 +57,9 @@ export class RecommendationsRegistry {
         }
 
         // Check for published property
-        if ('published' in extension && typeof extension.published === 'string') {
-          const published = new Date(extension.published).getTime();
-          if (isNaN(published) || published > Date.now()) {
+        if ('publishDate' in extension && typeof extension.publishDate === 'string') {
+          const publishDate = new Date(extension.publishDate).getTime();
+          if (isNaN(publishDate) || publishDate > Date.now()) {
             return prev;
           }
         }

--- a/packages/main/src/plugin/recommendations/recommendations-registry.ts
+++ b/packages/main/src/plugin/recommendations/recommendations-registry.ts
@@ -56,7 +56,7 @@ export class RecommendationsRegistry {
           return prev;
         }
 
-        // Check for published property
+        // Check for publishDate property
         if ('publishDate' in extension && typeof extension.publishDate === 'string') {
           const publishDate = new Date(extension.publishDate).getTime();
           if (isNaN(publishDate) || publishDate > Date.now()) {


### PR DESCRIPTION
### What does this PR do?

Adding a `published` property on extension recommended, to only display them past the date.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop-internal/issues/242

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
