### PR TITLE
fix: skip existing installed extensions when installing a pack

### DIFF
--- a/packages/main/src/plugin/install/extension-installer.ts
+++ b/packages/main/src/plugin/install/extension-installer.ts
@@ -242,7 +242,7 @@ export class ExtensionInstaller {
       // need to analyze extensions that are in dependency minus the one installed or already analyzed
       const extensionsToAnalyze = dependencyExtensionIds.filter(
         dependency =>
-          !alreadyInstalledExtensionIds.includes(dependency) ||
+          !alreadyInstalledExtensionIds.includes(dependency) &&
           !analyzedExtensions.find(extension => extension.id === dependency),
       );
 


### PR DESCRIPTION
### What does this PR do?
the condition was invalid, then installed extensions were not skipped as expected

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/6913

### How to test this PR?

Use test case of the issue
- [x] Tests are covering the bug fix or the new feature
