### PR TITLE
docs: add compose troubleshooting doc related to authentication

### DIFF
--- a/website/docs/compose/troubleshooting.md
+++ b/website/docs/compose/troubleshooting.md
@@ -1,0 +1,32 @@
+---
+title: Troubleshooting Compose
+description: Troubleshooting compose issues
+sidebar_position: 3
+keywords: [compose]
+tags: [compose]
+---
+
+# Troubleshooting Compose
+
+## Registry authentication issues
+
+The Compose binary will prioritize the configuration file `~/.docker/config` over Podman credentials.
+
+### Issues encountered:
+
+`docker-credential-desktop` missing:
+
+```console
+docker.credentials.errors.InitializationError: docker-credential-desktop not installed or not available in PATH
+```
+
+Authentication access:
+
+```console
+Error response from daemon: {"message":"denied: requested access to the resource is denied"}
+Error: executing /usr/local/bin/docker-compose up: exit status 18
+```
+
+### Solution:
+
+Delete the `~/.docker/config` to clear any errors.


### PR DESCRIPTION
docs: add compose troubleshooting doc related to authentication

### What does this PR do?

Adds a troubleshooting document for Compose related to authentication.

### Screenshot / video of UI

N/A, see markdown / website.

### What issues does this PR fix or reference?

Part of https://github.com/containers/podman/issues/22682

### How to test this PR?

N/A, preview site.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
