### PR TITLE
fix: createVolume is returning unexpected object

### DIFF
--- a/packages/main/src/plugin/dockerode/libpod-dockerode.spec.ts
+++ b/packages/main/src/plugin/dockerode/libpod-dockerode.spec.ts
@@ -259,3 +259,17 @@ test('Check using libpod/manifests/{name}/json endpoint', async () => {
   expect(manifest.manifests[0].size).toBe(0);
   expect(manifest.manifests[0].urls).toEqual([]);
 });
+
+test('Check create volume', async () => {
+  nock('http://localhost')
+    .post(`/volumes/create?Name=foo`)
+    .reply(200, { Name: 'foo', Driver: 'local', Scope: 'local' });
+
+  const api = new Dockerode({ protocol: 'http', host: 'localhost' });
+
+  const response = await api.createVolume({ Name: 'foo' });
+  expect(response).toBeDefined();
+  expect(response.Driver).toBe('local');
+  expect(response.Name).toBe('foo');
+  expect(response.Scope).toBe('local');
+});


### PR DESCRIPTION
### What does this PR do?
it turns out that Dockerode signature is saying that createVolume returns a `VolumeCreateResponse` object but in fact it returns a `Volume` object then it means that we have an object with modem field, etc and only the name of the volume, not all attributes of what is sent by the REST API

make the call returning the raw data from the REST API VolumeCreateResponse and not a dumb Volume object.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/6932

### How to test this PR?

test case of the issue or unit tests

- [x] Tests are covering the bug fix or the new feature
