### PR TITLE
fix: stop informer not more valid and handle similar contexts

### DIFF
--- a/packages/main/src/plugin/kubernetes-context-state.spec.ts
+++ b/packages/main/src/plugin/kubernetes-context-state.spec.ts
@@ -19,9 +19,10 @@
 import type { ErrorCallback, KubernetesObject, ObjectCallback } from '@kubernetes/client-node';
 import * as kubeclient from '@kubernetes/client-node';
 import { KubeConfig, makeInformer } from '@kubernetes/client-node';
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import type { ApiSenderType } from './api.js';
+import type { KubeContext } from './kubernetes-context.js';
 import type { ContextGeneralState, ResourceName } from './kubernetes-context-state.js';
 import { ContextsManager, ContextsStates } from './kubernetes-context-state.js';
 
@@ -305,8 +306,10 @@ describe('update', async () => {
     });
 
     apiSenderSendMock.mockReset();
+    console.log('DA QUI');
     await client.update(kubeConfig);
 
+    vi.advanceTimersToNextTimer();
     vi.advanceTimersToNextTimer();
     expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-contexts-general-state-update', expectedMap);
     expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-current-context-general-state-update', {
@@ -330,6 +333,7 @@ describe('update', async () => {
     });
 
     apiSenderSendMock.mockReset();
+    console.log('DA QUI 2');
     await client.update(kubeConfig);
     expectedMap = new Map<string, ContextGeneralState>();
     expectedMap.set('context1', {
@@ -357,6 +361,7 @@ describe('update', async () => {
       },
     } as ContextGeneralState);
 
+    vi.advanceTimersToNextTimer();
     vi.advanceTimersToNextTimer();
     expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-contexts-general-state-update', expectedMap);
     expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-current-context-general-state-update', {
@@ -1233,8 +1238,10 @@ describe('update', async () => {
 
       await client.update(kubeConfig);
 
-      expect(informerStopMock).toHaveBeenCalledTimes(1);
-      expect(informerStopMock).toHaveBeenCalledWith('context1', informerPath);
+      expect(informerStopMock).toHaveBeenCalledTimes(3);
+      expect(informerStopMock).toHaveBeenNthCalledWith(1, 'context2', '/api/v1/namespaces/ns2/pods');
+      expect(informerStopMock).toHaveBeenNthCalledWith(2, 'context2', '/apis/apps/v1/namespaces/ns2/deployments');
+      expect(informerStopMock).toHaveBeenNthCalledWith(3, 'context1', informerPath);
       expect(client.getContextResources('context1', resource as ResourceName).length).toBe(0);
     });
   });
@@ -1306,10 +1313,25 @@ describe('update', async () => {
 
     await client.update(kubeConfig);
 
-    expect(informerStopMock).toHaveBeenCalledTimes(1);
-    expect(informerStopMock).toHaveBeenCalledWith('context1', '/api/v1/namespaces/ns1/services');
-    expect(makeInformerMock).toHaveBeenCalledTimes(1);
-    expect(makeInformerMock).toHaveBeenCalledWith(
+    expect(informerStopMock).toHaveBeenCalledTimes(3);
+    expect(informerStopMock).toHaveBeenNthCalledWith(1, 'context2', '/api/v1/namespaces/ns2/pods');
+    expect(informerStopMock).toHaveBeenNthCalledWith(2, 'context2', '/apis/apps/v1/namespaces/ns2/deployments');
+    expect(informerStopMock).toHaveBeenNthCalledWith(3, 'context1', '/api/v1/namespaces/ns1/services');
+    expect(makeInformerMock).toHaveBeenCalledTimes(3);
+    expect(makeInformerMock).toHaveBeenNthCalledWith(
+      1,
+      expect.any(KubeConfig),
+      '/api/v1/namespaces/ns2/pods',
+      expect.anything(),
+    );
+    expect(makeInformerMock).toHaveBeenNthCalledWith(
+      2,
+      expect.any(KubeConfig),
+      '/apis/apps/v1/namespaces/ns2/deployments',
+      expect.anything(),
+    );
+    expect(makeInformerMock).toHaveBeenNthCalledWith(
+      3,
       expect.any(KubeConfig),
       '/api/v1/namespaces/ns2/services',
       expect.anything(),
@@ -1385,9 +1407,23 @@ describe('update', async () => {
 
     await client.update(kubeConfig);
 
-    expect(informerStopMock).toHaveBeenCalledTimes(1);
-    expect(informerStopMock).toHaveBeenCalledWith('context1', '/api/v1/namespaces/ns1/services');
-    expect(makeInformerMock).not.toHaveBeenCalled();
+    expect(informerStopMock).toHaveBeenCalledTimes(3);
+    expect(informerStopMock).toHaveBeenNthCalledWith(1, 'context2', '/api/v1/namespaces/ns2/pods');
+    expect(informerStopMock).toHaveBeenNthCalledWith(2, 'context2', '/apis/apps/v1/namespaces/ns2/deployments');
+    expect(informerStopMock).toHaveBeenNthCalledWith(3, 'context1', '/api/v1/namespaces/ns1/services');
+    expect(makeInformerMock).toHaveBeenCalledTimes(2);
+    expect(makeInformerMock).toHaveBeenNthCalledWith(
+      1,
+      expect.any(KubeConfig),
+      '/api/v1/namespaces/ns2/pods',
+      expect.anything(),
+    );
+    expect(makeInformerMock).toHaveBeenNthCalledWith(
+      2,
+      expect.any(KubeConfig),
+      '/apis/apps/v1/namespaces/ns2/deployments',
+      expect.anything(),
+    );
   });
 
   test('should not ignore events sent a short time before', async () => {
@@ -1481,6 +1517,103 @@ describe('update', async () => {
     expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-current-context-routes-update', []);
   });
 
+  test('changing context that have same name as the old one should start service informer again', async () => {
+    vi.useFakeTimers();
+    const makeInformerMock = vi.mocked(makeInformer);
+    makeInformerMock.mockImplementation(
+      (
+        kubeconfig: kubeclient.KubeConfig,
+        path: string,
+        _listPromiseFn: kubeclient.ListPromise<kubeclient.KubernetesObject>,
+      ) => {
+        return new FakeInformer(kubeconfig.currentContext, path, 0, undefined, [], []);
+      },
+    );
+    client = new ContextsManager(apiSender);
+    const kubeConfig = new kubeclient.KubeConfig();
+    const config = {
+      clusters: [
+        {
+          name: 'cluster1',
+          server: 'server1',
+        },
+      ],
+      users: [
+        {
+          name: 'user1',
+        },
+      ],
+      contexts: [
+        {
+          name: 'context1',
+          cluster: 'cluster1',
+          user: 'user1',
+          namespace: 'ns1',
+        },
+        {
+          name: 'context2',
+          cluster: 'cluster1',
+          user: 'user1',
+          namespace: 'ns2',
+        },
+      ],
+      currentContext: 'context1',
+    };
+    kubeConfig.loadFromOptions(config);
+    await client.update(kubeConfig);
+    vi.advanceTimersToNextTimer();
+    vi.advanceTimersToNextTimer();
+
+    makeInformerMock.mockClear();
+
+    // service informer is started
+    client.registerGetCurrentContextResources('services');
+    expect(makeInformerMock).toHaveBeenCalledTimes(1);
+    expect(makeInformerMock).toHaveBeenCalledWith(
+      expect.any(KubeConfig),
+      '/api/v1/namespaces/ns1/services',
+      expect.anything(),
+    );
+
+    makeInformerMock.mockClear();
+
+    config.clusters = [
+      {
+        name: 'cluster1',
+        server: 'server2',
+      },
+    ];
+    kubeConfig.loadFromOptions(config);
+
+    expect(informerStopMock).not.toHaveBeenCalled();
+
+    await client.update(kubeConfig);
+
+    expect(informerStopMock).toHaveBeenCalledTimes(3);
+    expect(informerStopMock).toHaveBeenNthCalledWith(1, 'context1', '/api/v1/namespaces/ns1/pods');
+    expect(informerStopMock).toHaveBeenNthCalledWith(2, 'context1', '/apis/apps/v1/namespaces/ns1/deployments');
+    expect(informerStopMock).toHaveBeenNthCalledWith(3, 'context1', '/api/v1/namespaces/ns1/services');
+    expect(makeInformerMock).toHaveBeenCalledTimes(3);
+    expect(makeInformerMock).toHaveBeenNthCalledWith(
+      1,
+      expect.any(KubeConfig),
+      '/api/v1/namespaces/ns1/pods',
+      expect.anything(),
+    );
+    expect(makeInformerMock).toHaveBeenNthCalledWith(
+      2,
+      expect.any(KubeConfig),
+      '/apis/apps/v1/namespaces/ns1/deployments',
+      expect.anything(),
+    );
+    expect(makeInformerMock).toHaveBeenNthCalledWith(
+      3,
+      expect.any(KubeConfig),
+      '/api/v1/namespaces/ns1/services',
+      expect.anything(),
+    );
+  });
+
   test('dispose', async () => {
     vi.useFakeTimers();
     vi.mocked(makeInformer).mockImplementation(
@@ -1525,7 +1658,6 @@ describe('update', async () => {
     expect(apiSenderSendMock).not.toHaveBeenCalled();
   });
 });
-
 describe('ContextsStates tests', () => {
   test('hasInformer should check if informer exists for context', () => {
     const client = new ContextsStates();
@@ -1567,5 +1699,391 @@ describe('ContextsStates tests', () => {
     expect(client.isReachable('context1')).toBeTruthy();
     expect(client.isReachable('context2')).toBeFalsy();
     expect(client.isReachable('context3')).toBeFalsy();
+  });
+});
+describe('isContextInKubeconfig', () => {
+  let client: ContextsManager;
+  beforeAll(async () => {
+    vi.mocked(makeInformer).mockImplementation(
+      (
+        kubeconfig: kubeclient.KubeConfig,
+        path: string,
+        _listPromiseFn: kubeclient.ListPromise<kubeclient.KubernetesObject>,
+      ) => {
+        const connectResult = new Error('err');
+        return new FakeInformer(kubeconfig.currentContext, path, 0, connectResult, [], []);
+      },
+    );
+    const kubeConfig = new kubeclient.KubeConfig();
+    const config = {
+      clusters: [
+        {
+          name: 'cluster',
+          server: 'server',
+        },
+        {
+          name: 'cluster1',
+          server: 'server1',
+        },
+      ],
+      users: [
+        {
+          name: 'user',
+        },
+        {
+          name: 'user1',
+        },
+      ],
+      contexts: [
+        {
+          name: 'context',
+          cluster: 'cluster',
+          user: 'user',
+          namespace: 'ns',
+        },
+      ],
+      currentContext: 'context',
+    };
+    kubeConfig.loadFromOptions(config);
+    client = new ContextsManager(apiSender);
+    await client.update(kubeConfig);
+  });
+  test('return false if cluster does not exists on kubeconfig', () => {
+    const context: KubeContext = {
+      name: 'context',
+      cluster: 'cluster2',
+      user: 'user',
+      clusterInfo: {
+        server: 'server2',
+        name: 'cluster2',
+      },
+    };
+    const exists = client.isContextInKubeconfig(context);
+    expect(exists).toBeFalsy();
+  });
+  test('return false if cluster on kubeconfig have different server', () => {
+    const context: KubeContext = {
+      name: 'context',
+      cluster: 'cluster',
+      user: 'user',
+      clusterInfo: {
+        server: 'server2',
+        name: 'cluster',
+      },
+    };
+    const exists = client.isContextInKubeconfig(context);
+    expect(exists).toBeFalsy();
+  });
+  test('return false if user does not exists on kubeconfig', () => {
+    const context: KubeContext = {
+      name: 'context',
+      cluster: 'cluster',
+      user: 'user2',
+      clusterInfo: {
+        server: 'server',
+        name: 'cluster',
+      },
+    };
+    const exists = client.isContextInKubeconfig(context);
+    expect(exists).toBeFalsy();
+  });
+  test('return false if context does not exists on kubeconfig', () => {
+    const context: KubeContext = {
+      name: 'context1',
+      cluster: 'cluster',
+      user: 'user',
+      clusterInfo: {
+        server: 'server',
+        name: 'cluster',
+      },
+    };
+    const exists = client.isContextInKubeconfig(context);
+    expect(exists).toBeFalsy();
+  });
+  test('return false if context server on kubeconfig have different server', () => {
+    const context: KubeContext = {
+      name: 'context',
+      cluster: 'cluster1',
+      user: 'user',
+      clusterInfo: {
+        server: 'server1',
+        name: 'cluster1',
+      },
+    };
+    const exists = client.isContextInKubeconfig(context);
+    expect(exists).toBeFalsy();
+  });
+  test('return false if context user on kubeconfig is different', () => {
+    const context: KubeContext = {
+      name: 'context',
+      cluster: 'cluster',
+      user: 'user1',
+      clusterInfo: {
+        server: 'server',
+        name: 'cluster',
+      },
+    };
+    const exists = client.isContextInKubeconfig(context);
+    expect(exists).toBeFalsy();
+  });
+  test('return true if the current context exists on the kubeconfig', () => {
+    const context: KubeContext = {
+      name: 'context',
+      cluster: 'cluster',
+      user: 'user',
+      clusterInfo: {
+        server: 'server',
+        name: 'cluster',
+      },
+    };
+    const exists = client.isContextInKubeconfig(context);
+    expect(exists).toBeTruthy();
+  });
+});
+describe('isContextChanged', () => {
+  let client: ContextsManager;
+  beforeAll(async () => {
+    vi.mocked(makeInformer).mockImplementation(
+      (
+        kubeconfig: kubeclient.KubeConfig,
+        path: string,
+        _listPromiseFn: kubeclient.ListPromise<kubeclient.KubernetesObject>,
+      ) => {
+        const connectResult = new Error('err');
+        return new FakeInformer(kubeconfig.currentContext, path, 0, connectResult, [], []);
+      },
+    );
+    const kubeConfig = new kubeclient.KubeConfig();
+    const config = {
+      clusters: [
+        {
+          name: 'cluster',
+          server: 'server',
+        },
+        {
+          name: 'cluster1',
+          server: 'server1',
+        },
+      ],
+      users: [
+        {
+          name: 'user',
+        },
+        {
+          name: 'user1',
+        },
+      ],
+      contexts: [
+        {
+          name: 'context',
+          cluster: 'cluster',
+          user: 'user',
+          namespace: 'ns',
+        },
+      ],
+      currentContext: 'context',
+    };
+    kubeConfig.loadFromOptions(config);
+    client = new ContextsManager(apiSender);
+    await client.update(kubeConfig);
+  });
+  test('return true if current context is different from the latest', () => {
+    const context: KubeConfig = {
+      clusters: [
+        {
+          name: 'cluster',
+          server: 'server',
+        },
+      ],
+      users: [
+        {
+          name: 'user',
+        },
+      ],
+      contexts: [
+        {
+          name: 'context2',
+          cluster: 'cluster',
+          user: 'user',
+          namespace: 'ns',
+        },
+      ],
+      currentContext: 'context2',
+    } as KubeConfig;
+    const changed = client.isContextChanged(context);
+    expect(changed).toBeTruthy();
+  });
+  test('return true if current context is undefined', () => {
+    const context: KubeConfig = {
+      clusters: [
+        {
+          name: 'cluster',
+          server: 'server',
+        },
+      ],
+      users: [
+        {
+          name: 'user',
+        },
+      ],
+      contexts: [
+        {
+          name: 'context2',
+          cluster: 'cluster',
+          user: 'user',
+          namespace: 'ns',
+        },
+      ],
+    } as KubeConfig;
+    const changed = client.isContextChanged(context);
+    expect(changed).toBeTruthy();
+  });
+  test('return true if current context has a different user compared to the latest', () => {
+    const context: KubeConfig = {
+      clusters: [
+        {
+          name: 'cluster',
+          server: 'server',
+        },
+      ],
+      users: [
+        {
+          name: 'user2',
+        },
+      ],
+      contexts: [
+        {
+          name: 'context',
+          cluster: 'cluster',
+          user: 'user',
+          namespace: 'ns',
+        },
+      ],
+      currentContext: 'context',
+      getCurrentUser: () => {
+        return {
+          name: 'user2',
+        } as kubeclient.User;
+      },
+      getCurrentCluster: () => {
+        return {
+          name: 'cluster',
+          server: 'server',
+        } as kubeclient.Cluster;
+      },
+    } as KubeConfig;
+    const changed = client.isContextChanged(context);
+    expect(changed).toBeTruthy();
+  });
+  test('return true if current context has a different cluster compared to the latest', () => {
+    const context: KubeConfig = {
+      clusters: [
+        {
+          name: 'cluster2',
+          server: 'server2',
+        },
+      ],
+      users: [
+        {
+          name: 'user',
+        },
+      ],
+      contexts: [
+        {
+          name: 'context',
+          cluster: 'cluster2',
+          user: 'user',
+          namespace: 'ns',
+        },
+      ],
+      currentContext: 'context',
+      getCurrentUser: () => {
+        return {
+          name: 'user',
+        } as kubeclient.User;
+      },
+      getCurrentCluster: () => {
+        return {
+          name: 'cluster2',
+          server: 'server2',
+        } as kubeclient.Cluster;
+      },
+    } as KubeConfig;
+    const changed = client.isContextChanged(context);
+    expect(changed).toBeTruthy();
+  });
+  test('return true if current context has a different cluster server but same cluster name compared to the latest', () => {
+    const context: KubeConfig = {
+      clusters: [
+        {
+          name: 'cluster',
+          server: 'server2',
+        },
+      ],
+      users: [
+        {
+          name: 'user',
+        },
+      ],
+      contexts: [
+        {
+          name: 'context',
+          cluster: 'cluster',
+          user: 'user',
+          namespace: 'ns',
+        },
+      ],
+      currentContext: 'context',
+      getCurrentUser: () => {
+        return {
+          name: 'user',
+        } as kubeclient.User;
+      },
+      getCurrentCluster: () => {
+        return {
+          name: 'cluster',
+          server: 'server2',
+        } as kubeclient.Cluster;
+      },
+    } as KubeConfig;
+    const changed = client.isContextChanged(context);
+    expect(changed).toBeTruthy();
+  });
+  test('return false if current context is the same to the latest', () => {
+    const context: KubeConfig = {
+      clusters: [
+        {
+          name: 'cluster',
+          server: 'server',
+        },
+      ],
+      users: [
+        {
+          name: 'user',
+        },
+      ],
+      contexts: [
+        {
+          name: 'context',
+          cluster: 'cluster',
+          user: 'user',
+          namespace: 'ns',
+        },
+      ],
+      currentContext: 'context',
+      getCurrentUser: () => {
+        return {
+          name: 'user',
+        } as kubeclient.User;
+      },
+      getCurrentCluster: () => {
+        return {
+          name: 'cluster',
+          server: 'server',
+        } as kubeclient.Cluster;
+      },
+    } as KubeConfig;
+    const changed = client.isContextChanged(context);
+    expect(changed).toBeFalsy();
   });
 });

--- a/packages/main/src/plugin/kubernetes-context-state.spec.ts
+++ b/packages/main/src/plugin/kubernetes-context-state.spec.ts
@@ -306,7 +306,6 @@ describe('update', async () => {
     });
 
     apiSenderSendMock.mockReset();
-    console.log('DA QUI');
     await client.update(kubeConfig);
 
     vi.advanceTimersToNextTimer();

--- a/packages/main/src/plugin/kubernetes-context-state.spec.ts
+++ b/packages/main/src/plugin/kubernetes-context-state.spec.ts
@@ -332,7 +332,6 @@ describe('update', async () => {
     });
 
     apiSenderSendMock.mockReset();
-    console.log('DA QUI 2');
     await client.update(kubeConfig);
     expectedMap = new Map<string, ContextGeneralState>();
     expectedMap.set('context1', {

--- a/packages/main/src/plugin/kubernetes-context-state.ts
+++ b/packages/main/src/plugin/kubernetes-context-state.ts
@@ -384,20 +384,17 @@ export class ContextsManager {
       return true;
     }
 
-    // if the current context name in the kubeconfig is undefined ->  true
-    if (!kubeconfig.currentContext) {
-      return true;
-    }
-
     // by retrieving the context from the kubeconfig, if the user is different from the latest context we saved -> true
     const user = kubeconfig.getCurrentUser();
-    if (user?.name !== this.currentContext.user) {
+    if (user?.name !== this.currentContext?.user) {
       return true;
     }
 
     // by retrieving the cluster from the kubeconfig, if the name or server url are different from the latest context we saved -> true
     const cluster = kubeconfig.getCurrentCluster();
-    return cluster?.name !== this.currentContext.cluster || cluster?.server !== this.currentContext.clusterInfo?.server;
+    return (
+      cluster?.name !== this.currentContext?.cluster || cluster?.server !== this.currentContext?.clusterInfo?.server
+    );
   }
 
   // update is the reconcile function, it gets as input the last known kube config
@@ -931,7 +928,7 @@ export class ContextsManager {
     if (isSecondaryResourceName(resourceName)) {
       this.secondaryWatchers.subscribe(resourceName);
     }
-    if (!this.currentContext) {
+    if (!this.currentContext?.name) {
       return [];
     }
     if (this.states.hasInformer(this.currentContext.name, resourceName)) {

--- a/packages/main/src/plugin/kubernetes-context-state.ts
+++ b/packages/main/src/plugin/kubernetes-context-state.ts
@@ -420,7 +420,7 @@ export class ContextsManager {
     }
 
     // Delete informers for removed contexts
-    // We also remove the state of the current context is it has changed. It may happen that the name of the context is the same but it is pointing to a different cluster
+    // We also remove the state of the current context if it has changed. It may happen that the name of the context is the same but it is pointing to a different cluster
     let removed = false;
     for (const name of this.states.getContextsNames()) {
       if (


### PR DESCRIPTION
### What does this PR do?

This PR fixes some weird behavior with the informers.
So far, we were just using the context name to detect if a context was deleted, updated, added but it may happen that a context only differs for some internal value (e.g the cluster server url). E.g create podman machine, create kind cluster, delete podman machine, the kind cluster is deleted but the kubeconfig remains dirty, so if you create a new kind cluster, the kubeconfig is almost the same expect the server url and the informer are not updated

Another thing is that we restart an informer if it fails at starting. This way, it may happen that you end up having multiple informers even though you only have one cluster. This PR adds a check to prevent a context that do not belong to the kubeconfig to be restarted again.

E.g. As before you start with a dirty kubeconfig. 
Podman desktop starts an informer which will fail as the cluster is not reachable and it will try to restart it again and again after a timeout 

https://github.com/containers/podman-desktop/blob/654b227832b93b27631507ca7cb9e09e603cf3b3/packages/main/src/plugin/kubernetes-context-state.ts#L790
 
In the meantime you create a new kind cluster.
Desktop will try to stop the old informer by calling the kubeclient library stop method (without any success as there is no active informer, we restart it on desktop side), and create a new informer pointing to the new cluster. 
You end up having a working informer and a failing one that keep trying at starting infinitely.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

it resolves #6830 

### How to test this PR?

1. create a podman machine 
2. create a kind cluster
3. delete the podman machine
4. your kubeconfig should still have the entry regarding the kind cluster
5. recreate a podmna machine + kind cluster having the same name as before
6. if you go to the deployment/service/ingress it should be connected to the newly created cluster

- [x] Tests are covering the bug fix or the new feature
