### PR TITLE
chore: add hidden property to change the catalog URL

### DIFF
--- a/packages/main/src/plugin/extensions-catalog/extensions-catalog-settings.ts
+++ b/packages/main/src/plugin/extensions-catalog/extensions-catalog-settings.ts
@@ -1,0 +1,22 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+export enum ExtensionsCatalogSettings {
+  SectionName = 'extensions',
+  registryUrl = 'registryUrl',
+}

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -636,7 +636,8 @@ export class PluginSystem {
     );
     await this.extensionLoader.init();
 
-    const extensionsCatalog = new ExtensionsCatalog(certificates, proxy);
+    const extensionsCatalog = new ExtensionsCatalog(certificates, proxy, configurationRegistry);
+    extensionsCatalog.init();
     const featured = new Featured(this.extensionLoader, extensionsCatalog);
 
     const recommendationsRegistry = new RecommendationsRegistry(configurationRegistry, featured);


### PR DESCRIPTION
### What does this PR do?
Allows to override URL of the catalog

```json
"extensions.registryUrl": "https://my-link/catalog.json"
```

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fixes #6887 

### How to test this PR?

Use a property in your settings.json or unit tests

- [x] Tests are covering the bug fix or the new feature
