### PR TITLE
fix: add back the error if an extension fails

### DIFF
--- a/packages/renderer/src/lib/extensions/ExtensionDetails.svelte
+++ b/packages/renderer/src/lib/extensions/ExtensionDetails.svelte
@@ -7,11 +7,13 @@ import { combinedInstalledExtensions } from '/@/stores/all-installed-extensions'
 import { catalogExtensionInfos } from '/@/stores/catalog-extensions';
 
 import FeaturedExtensionDownload from '../featured/FeaturedExtensionDownload.svelte';
+import Button from '../ui/Button.svelte';
 import DetailsPage from '../ui/DetailsPage.svelte';
 import EmptyScreen from '../ui/EmptyScreen.svelte';
 import ExtensionStatus from '../ui/ExtensionStatus.svelte';
 import type { ExtensionDetailsUI } from './extension-details-ui';
 import ExtensionBadge from './ExtensionBadge.svelte';
+import ExtensionDetailsError from './ExtensionDetailsError.svelte';
 import ExtensionDetailsReadme from './ExtensionDetailsReadme.svelte';
 import ExtensionDetailsSummaryCard from './ExtensionDetailsSummaryCard.svelte';
 import { ExtensionsUtils } from './extensions-utils';
@@ -19,6 +21,7 @@ import InstalledExtensionActions from './InstalledExtensionActions.svelte';
 
 export let extensionId: string;
 
+let screen: 'README' | 'ERROR' = 'README';
 let detailsPage: DetailsPage;
 const extensionsUtils = new ExtensionsUtils();
 
@@ -63,10 +66,32 @@ $: extension = derived(
     <div slot="detail" class="flex">
       <ExtensionBadge class="mt-2" extension="{$extension}" />
     </div>
+    <!-- Display tabs only if extension is in error state -->
+    <svelte:fragment slot="tabs">
+      {#if $extension.state === 'failed'}
+        <Button
+          type="tab"
+          on:click="{() => {
+            screen = 'README';
+          }}"
+          selected="{screen === 'README'}">Readme</Button>
+        <Button
+          type="tab"
+          on:click="{() => {
+            screen = 'ERROR';
+          }}"
+          selected="{screen === 'ERROR'}">Error</Button>
+      {/if}
+    </svelte:fragment>
+
     <svelte:fragment slot="content">
       <div class="flex w-full h-full overflow-y-auto p-4 flex-col lg:flex-row">
-        <ExtensionDetailsSummaryCard extensionDetails="{$extension}" />
-        <ExtensionDetailsReadme readme="{$extension.readme}" />
+        {#if screen === 'README'}
+          <ExtensionDetailsSummaryCard extensionDetails="{$extension}" />
+          <ExtensionDetailsReadme readme="{$extension.readme}" />
+        {:else if screen === 'ERROR'}
+          <ExtensionDetailsError extension="{$extension}" />
+        {/if}
       </div>
     </svelte:fragment>
   </DetailsPage>

--- a/packages/renderer/src/lib/extensions/ExtensionDetailsError.spec.ts
+++ b/packages/renderer/src/lib/extensions/ExtensionDetailsError.spec.ts
@@ -1,0 +1,67 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/svelte';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import type { ExtensionDetailsUI } from './extension-details-ui';
+import ExtensionDetailsError from './ExtensionDetailsError.svelte';
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+test('Expect to have error message being displayed', async () => {
+  const extension: ExtensionDetailsUI = {
+    displayName: 'my display name',
+    description: 'my description',
+    type: 'pd',
+    removable: false,
+    state: 'started',
+    name: 'foo',
+    icon: 'fooIcon',
+    readme: { content: '' },
+    releaseDate: '2024-01-01',
+    categories: ['cat1', 'cat2'],
+    publisherDisplayName: 'my publisher',
+    version: 'v1.2.3',
+    id: 'myId',
+    fetchable: true,
+    fetchLink: 'myLink',
+    fetchVersion: 'v3.4.5',
+    error: {
+      message: 'An error occurred',
+      stack: 'line1\nline2',
+    },
+  };
+
+  render(ExtensionDetailsError, { extension });
+
+  // should contain the error
+  const error = screen.getByText('Error: An error occurred');
+  expect(error).toBeInTheDocument();
+
+  // should contain the stack
+  const stack = screen.getByRole('group', { name: 'Stack Trace' });
+  expect(stack).toBeInTheDocument();
+
+  // should contain the stack lines
+  expect(stack).toContainHTML('line1\nline2');
+});

--- a/packages/renderer/src/lib/extensions/ExtensionDetailsError.svelte
+++ b/packages/renderer/src/lib/extensions/ExtensionDetailsError.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+import type { ExtensionDetailsUI } from './extension-details-ui';
+
+export let extension: ExtensionDetailsUI;
+</script>
+
+{#if extension.error}
+  <div class="flex flex-col">
+    <div class="py-2">Error: {extension.error.message}</div>
+    {#if extension.error.stack}
+      <div class="text-xs">
+        <div>Stack trace:</div>
+        <pre role="group" aria-label="Stack Trace">{extension.error.stack}</pre>
+      </div>
+    {/if}
+  </div>
+{/if}

--- a/packages/renderer/src/lib/extensions/InstalledExtensionCardLeftLifecycleStart.spec.ts
+++ b/packages/renderer/src/lib/extensions/InstalledExtensionCardLeftLifecycleStart.spec.ts
@@ -104,3 +104,30 @@ test('Expect unable to start if already started', async () => {
   const button = screen.queryByRole('button', { name: 'Start' });
   expect(button).not.toBeInTheDocument();
 });
+
+test('Expect to start Extension if failed', async () => {
+  const extension: CombinedExtensionInfoUI = {
+    type: 'pd',
+    id: 'idExtension',
+    name: 'fooName',
+    description: 'my description',
+    displayName: '',
+    publisher: '',
+    removable: true,
+    version: 'v1.2.3',
+    state: 'failed',
+    path: '',
+    readme: '',
+  };
+  render(InstalledExtensionCardLeftLifecycleStart, { extension });
+
+  // get button with label 'Start'
+  const button = screen.getByRole('button', { name: 'Start' });
+  expect(button).toBeInTheDocument();
+
+  // click the button
+  await fireEvent.click(button);
+
+  // expect the start function to be called
+  expect(vi.mocked(window.startExtension)).toHaveBeenCalledWith('idExtension');
+});

--- a/packages/renderer/src/lib/extensions/InstalledExtensionCardLeftLifecycleStart.svelte
+++ b/packages/renderer/src/lib/extensions/InstalledExtensionCardLeftLifecycleStart.svelte
@@ -16,7 +16,7 @@ async function startExtension(): Promise<void> {
 }
 </script>
 
-{#if extension.state === 'stopped'}
+{#if extension.state === 'stopped' || extension.state === 'failed'}
   <LoadingIconButton
     clickAction="{() => startExtension()}"
     action="start"

--- a/packages/renderer/src/lib/extensions/extension-details-ui.ts
+++ b/packages/renderer/src/lib/extensions/extension-details-ui.ts
@@ -18,6 +18,8 @@
 
 import type { CombinedExtensionInfoUI } from '/@/stores/all-installed-extensions';
 
+import type { ExtensionError } from '../../../../main/src/plugin/api/extension-info';
+
 export interface ExtensionDetailsUI {
   displayName: string;
   description: string;
@@ -37,4 +39,5 @@ export interface ExtensionDetailsUI {
   fetchable: boolean;
   fetchLink: string;
   fetchVersion: string;
+  error?: ExtensionError;
 }

--- a/packages/renderer/src/lib/extensions/extensions-utils.spec.ts
+++ b/packages/renderer/src/lib/extensions/extensions-utils.spec.ts
@@ -179,6 +179,10 @@ const installedExtensions: CombinedExtensionInfoUI[] = [
     id: 'idAInstalled',
     displayName: 'A installed Extension',
     removable: true,
+    error: {
+      message: 'An error occurred',
+      stack: 'line1\nline2',
+    },
   },
   {
     id: 'idYInstalled',
@@ -291,5 +295,16 @@ describe('extractExtensionDetail', () => {
     expect(extensionDetail?.displayName).toBe('Z Extension');
     expect(extensionDetail?.publisherDisplayName).toBe('Foo Publisher');
     expect(extensionDetail?.version).toBe('v1.0.0Z');
+  });
+
+  test('Check error is kept', async () => {
+    const extensionDetail = extensionsUtils.extractExtensionDetail(
+      catalogExtensions,
+      installedExtensions,
+      'idAInstalled',
+    );
+    expect(extensionDetail).toBeDefined();
+    expect(extensionDetail?.error?.message).toBe('An error occurred');
+    expect(extensionDetail?.error?.stack).toBe('line1\nline2');
   });
 });

--- a/packages/renderer/src/lib/extensions/extensions-utils.ts
+++ b/packages/renderer/src/lib/extensions/extensions-utils.ts
@@ -113,6 +113,7 @@ export class ExtensionsUtils {
     const version = matchingInstalledExtensionVersion ?? latestVersionNumber ?? 'N/A';
 
     const installedExtension = matchingInstalledExtension;
+    const error = matchingInstalledExtension?.error;
 
     const fetchLink = latestVersionOciLink ?? '';
     const fetchVersion = latestVersion?.version ?? '';
@@ -138,6 +139,7 @@ export class ExtensionsUtils {
       fetchable,
       fetchLink,
       fetchVersion,
+      error,
     };
     return matchingExtension;
   }

--- a/packages/renderer/src/lib/ui/LoadingIconButton.svelte
+++ b/packages/renderer/src/lib/ui/LoadingIconButton.svelte
@@ -17,7 +17,7 @@ export let clickAction: () => Promise<void> | void;
 $: disable =
   state?.inProgress ||
   state?.status === 'unsupported' ||
-  (action === 'start' && state?.status !== 'stopped') ||
+  (action === 'start' && state?.status !== 'stopped' && state?.status !== 'failed') ||
   (action === 'restart' && state?.status !== 'started') ||
   (action === 'stop' && state?.status !== 'started') ||
   (action === 'delete' && state?.status !== 'stopped' && state?.status !== 'unknown') ||
@@ -27,7 +27,7 @@ $: loading = state?.inProgress && action === state?.action;
 
 function getStyleByState(state: ILoadingStatus | undefined, action: string): string {
   if (
-    (action === 'start' && (state?.inProgress || state?.status !== 'stopped')) ||
+    (action === 'start' && (state?.inProgress || (state?.status !== 'stopped' && state?.status !== 'failed'))) ||
     ((action === 'stop' || action === 'restart') && (state?.inProgress || state?.status !== 'started')) ||
     (action === 'delete' && (state?.inProgress || (state?.status !== 'stopped' && state?.status !== 'unknown'))) ||
     (action === 'update' && (state?.inProgress || state?.status === 'unknown')) ||


### PR DESCRIPTION
### What does this PR do?
With the revamp of extensions, it was no longer possible to see the details in case of an extension failure

Add a new tab in case of failure within the details of the extension to see the error

### Screenshot / video of UI

![image](https://github.com/containers/podman-desktop/assets/436777/80b43ca0-26de-4337-a470-f994336f842d)


### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/6917

### How to test this PR?

- [x] Tests are covering the bug fix or the new feature
