### PR TITLE
chore: handle starting as mode where stop should be visible

### DIFF
--- a/packages/renderer/src/lib/extensions/InstalledExtensionCardLeftLifecycleStop.spec.ts
+++ b/packages/renderer/src/lib/extensions/InstalledExtensionCardLeftLifecycleStop.spec.ts
@@ -98,3 +98,30 @@ test('Expect unable to stop if already stopped', async () => {
   const button = screen.queryByRole('button', { name: 'Stop' });
   expect(button).not.toBeInTheDocument();
 });
+
+test('Expect to stop pd Extension if starting', async () => {
+  const extension: CombinedExtensionInfoUI = {
+    type: 'pd',
+    id: 'idExtension',
+    name: 'fooName',
+    description: 'my description',
+    displayName: '',
+    publisher: '',
+    removable: true,
+    version: 'v1.2.3',
+    state: 'starting',
+    path: '',
+    readme: '',
+  };
+  render(InstalledExtensionCardLeftLifecycleStop, { extension });
+
+  // get button with label 'Stop'
+  const button = screen.getByRole('button', { name: 'Stop' });
+  expect(button).toBeInTheDocument();
+
+  // click the button
+  await fireEvent.click(button);
+
+  // expect the delete function to be called
+  expect(vi.mocked(window.stopExtension)).toHaveBeenCalledWith('idExtension');
+});

--- a/packages/renderer/src/lib/extensions/InstalledExtensionCardLeftLifecycleStop.svelte
+++ b/packages/renderer/src/lib/extensions/InstalledExtensionCardLeftLifecycleStop.svelte
@@ -16,7 +16,7 @@ async function stopExtension(): Promise<void> {
 }
 </script>
 
-{#if extension.state === 'started'}
+{#if extension.state === 'started' || extension.state === 'starting'}
   <LoadingIconButton
     clickAction="{() => stopExtension()}"
     action="stop"


### PR DESCRIPTION
### What does this PR do?
extension is going from stopped to starting to started and we should display stop in starting state as the start button will disappear as soon as stopped condition is gone, so during the starting phase there is nothing which might cause some blinking

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
