### PR TITLE
chore(UI): migrate spinner to UI package

### DIFF
--- a/packages/renderer/src/lib/dashboard/PreflightChecks.svelte
+++ b/packages/renderer/src/lib/dashboard/PreflightChecks.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
+import { Spinner } from '@podman-desktop/ui-svelte';
+
 import type { CheckStatus } from '../../../../main/src/plugin/api/provider-info';
-import Spinner from '../ui/Spinner.svelte';
 
 export let preflightChecks: CheckStatus[] = [];
 

--- a/packages/renderer/src/lib/dashboard/ProviderConfigured.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderConfigured.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
+import { Spinner } from '@podman-desktop/ui-svelte';
 import { onMount } from 'svelte';
 
 import type { CheckStatus, ProviderInfo } from '../../../../main/src/plugin/api/provider-info';
 import Button from '../ui/Button.svelte';
 import ErrorMessage from '../ui/ErrorMessage.svelte';
-import Spinner from '../ui/Spinner.svelte';
 import Steps from '../ui/Steps.svelte';
 import PreflightChecks from './PreflightChecks.svelte';
 import ProviderCard from './ProviderCard.svelte';

--- a/packages/renderer/src/lib/dashboard/ProviderConfiguring.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderConfiguring.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import 'xterm/css/xterm.css';
 
+import { Spinner } from '@podman-desktop/ui-svelte';
 import { onDestroy, onMount } from 'svelte';
 import { Terminal } from 'xterm';
 import { FitAddon } from 'xterm-addon-fit';
@@ -8,7 +9,6 @@ import { FitAddon } from 'xterm-addon-fit';
 import type { CheckStatus, ProviderInfo } from '../../../../main/src/plugin/api/provider-info';
 import { TerminalSettings } from '../../../../main/src/plugin/terminal-settings';
 import { getPanelDetailColor } from '../color/color';
-import Spinner from '../ui/Spinner.svelte';
 import Steps from '../ui/Steps.svelte';
 import PreflightChecks from './PreflightChecks.svelte';
 import ProviderCard from './ProviderCard.svelte';

--- a/packages/renderer/src/lib/dashboard/ProviderInstalled.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderInstalled.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import 'xterm/css/xterm.css';
 
+import { Spinner } from '@podman-desktop/ui-svelte';
 import { onDestroy, onMount } from 'svelte';
 import { Terminal } from 'xterm';
 import { FitAddon } from 'xterm-addon-fit';
@@ -8,7 +9,6 @@ import { FitAddon } from 'xterm-addon-fit';
 import type { CheckStatus, ProviderInfo } from '../../../../main/src/plugin/api/provider-info';
 import { TerminalSettings } from '../../../../main/src/plugin/terminal-settings';
 import { getPanelDetailColor } from '../color/color';
-import Spinner from '../ui/Spinner.svelte';
 import Steps from '../ui/Steps.svelte';
 import PreflightChecks from './PreflightChecks.svelte';
 import ProviderCard from './ProviderCard.svelte';

--- a/packages/renderer/src/lib/images/StatusIcon.svelte
+++ b/packages/renderer/src/lib/images/StatusIcon.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-import Spinner from '../ui/Spinner.svelte';
+import { Spinner } from '@podman-desktop/ui-svelte';
+
 import StarIcon from './StarIcon.svelte';
 
 // status: one of RUNNING, STARTING, USED, CREATED, DELETING, or DEGRADED

--- a/packages/renderer/src/lib/markdown/micromark-button-directive.ts
+++ b/packages/renderer/src/lib/markdown/micromark-button-directive.ts
@@ -18,7 +18,7 @@
 
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 // @ts-nocheck
-import spinnerSourcecode from '@podman-desktop/ui-svelte/Spinner.svelte?raw';
+import spinnerSourcecode from '@podman-desktop/ui-svelte/Spinner?raw';
 
 let spinnerHtmlCode: string | undefined = undefined;
 

--- a/packages/renderer/src/lib/markdown/micromark-button-directive.ts
+++ b/packages/renderer/src/lib/markdown/micromark-button-directive.ts
@@ -18,7 +18,7 @@
 
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 // @ts-nocheck
-import spinnerSourcecode from '/@/lib/ui/Spinner.svelte?raw';
+import spinnerSourcecode from '@podman-desktop/ui-svelte/Spinner.svelte?raw';
 
 let spinnerHtmlCode: string | undefined = undefined;
 

--- a/packages/renderer/src/lib/onboarding/Onboarding.svelte
+++ b/packages/renderer/src/lib/onboarding/Onboarding.svelte
@@ -28,6 +28,7 @@
 <script lang="ts">
 import { faCircleQuestion } from '@fortawesome/free-regular-svg-icons';
 import { faForward } from '@fortawesome/free-solid-svg-icons';
+import { Spinner } from '@podman-desktop/ui-svelte';
 import { onDestroy, onMount } from 'svelte';
 import type { Unsubscriber } from 'svelte/store';
 import Fa from 'svelte-fa';
@@ -42,7 +43,6 @@ import type { ContextUI } from '../context/context';
 import { ContextKeyExpr } from '../context/contextKey';
 import Button from '../ui/Button.svelte';
 import Link from '../ui/Link.svelte';
-import Spinner from '../ui/Spinner.svelte';
 import {
   type ActiveOnboardingStep,
   cleanSetup,

--- a/packages/renderer/src/lib/pod/DeployPodToKube.spec.ts
+++ b/packages/renderer/src/lib/pod/DeployPodToKube.spec.ts
@@ -47,7 +47,7 @@ const openExternalMock = vi.fn();
 
 // replace Monaco Editor by a Spinner so we don't need to load tons of stuff
 vi.mock('../editor/MonacoEditor.svelte', actual => {
-  return vi.importActual('../ui/Spinner.svelte');
+  return vi.importActual('@podman-desktop/ui-svelte/Spinner');
 });
 
 // mock the router

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import { faCubes } from '@fortawesome/free-solid-svg-icons';
 import type { AuditRequestItems, AuditResult, ConfigurationScope } from '@podman-desktop/api';
+import { Spinner } from '@podman-desktop/ui-svelte';
 import { onDestroy, onMount } from 'svelte';
 /* eslint-disable import/no-duplicates */
 // https://github.com/import-js/eslint-plugin-import/issues/1479
@@ -25,7 +26,6 @@ import Button from '../ui/Button.svelte';
 import EmptyScreen from '../ui/EmptyScreen.svelte';
 import ErrorMessage from '../ui/ErrorMessage.svelte';
 import LinearProgress from '../ui/LinearProgress.svelte';
-import Spinner from '../ui/Spinner.svelte';
 import TerminalWindow from '../ui/TerminalWindow.svelte';
 import EditableConnectionResourceItem from './item-formats/EditableConnectionResourceItem.svelte';
 import {

--- a/packages/renderer/src/lib/ui/Button.svelte
+++ b/packages/renderer/src/lib/ui/Button.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
+import { Spinner } from '@podman-desktop/ui-svelte';
 import { onMount } from 'svelte';
 import Fa from 'svelte-fa';
 
 import { isFontAwesomeIcon } from '/@/lib/ui/icon-utils';
 
 import type { ButtonType } from './Button';
-import Spinner from './Spinner.svelte';
 
 export let title: string | undefined = undefined;
 export let inProgress = false;

--- a/packages/renderer/src/lib/ui/ProviderResultPage.svelte
+++ b/packages/renderer/src/lib/ui/ProviderResultPage.svelte
@@ -7,12 +7,12 @@ import {
   type IconDefinition,
 } from '@fortawesome/free-solid-svg-icons';
 import type { ImageCheck } from '@podman-desktop/api';
+import { Spinner } from '@podman-desktop/ui-svelte';
 import Fa from 'svelte-fa';
 
 import type { ImageCheckerInfo } from '../../../../main/src/plugin/api/image-checker-info';
 import type { ProviderUI } from './ProviderResultPage';
 import SlideToggle from './SlideToggle.svelte';
-import Spinner from './Spinner.svelte';
 import ToggleButton from './ToggleButton.svelte';
 import ToggleButtonGroup from './ToggleButtonGroup.svelte';
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -19,6 +19,14 @@
     ".": {
       "types": "./dist/index.d.ts",
       "svelte": "./dist/index.js"
+    },
+    "./Input": {
+      "types": "./dist/input/input.svelte.d.ts",
+      "svelte": "./dist/input/input.svelte"
+    },
+    "./Spinner": {
+      "types": "./dist/spinner/Spinner.svelte.d.ts",
+      "svelte": "./dist/spinner/Spinner.svelte"
     }
   },
   "peerDependencies": {

--- a/packages/ui/src/lib/index.ts
+++ b/packages/ui/src/lib/index.ts
@@ -15,5 +15,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
+import Input from './input/Input.svelte';
+import Spinner from './spinner/Spinner.svelte';
 
-export { default as Input } from './input/Input.svelte';
+export { Input, Spinner };

--- a/packages/ui/src/lib/spinner/Spinner.spec.ts
+++ b/packages/ui/src/lib/spinner/Spinner.spec.ts
@@ -1,0 +1,48 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/svelte';
+import { describe, expect, test } from 'vitest';
+
+import Spinner from './Spinner.svelte';
+
+describe('parent attributes should be propagate', () => {
+  test('style attribute should be propagated', () => {
+    render(Spinner, {
+      style: 'color: green;',
+    });
+
+    const spinner = screen.getByLabelText('spinner');
+    expect(spinner).toBeDefined();
+
+    expect(spinner.getAttribute('style')).toBe('color: green;');
+  });
+
+  test('class attribute should be propagated', () => {
+    render(Spinner, {
+      class: 'dummy-class',
+    });
+
+    const spinner = screen.getByLabelText('spinner');
+    expect(spinner).toBeDefined();
+
+    expect(spinner.classList).toContain('dummy-class');
+  });
+});

--- a/packages/ui/src/lib/spinner/Spinner.spec.ts
+++ b/packages/ui/src/lib/spinner/Spinner.spec.ts
@@ -29,7 +29,7 @@ describe('parent attributes should be propagate', () => {
       style: 'color: green;',
     });
 
-    const spinner = screen.getByLabelText('spinner');
+    const spinner = screen.getByRole('progressbar', { name: 'Loading', busy: true });
     expect(spinner).toBeDefined();
 
     expect(spinner.getAttribute('style')).toBe('color: green;');
@@ -40,7 +40,7 @@ describe('parent attributes should be propagate', () => {
       class: 'dummy-class',
     });
 
-    const spinner = screen.getByLabelText('spinner');
+    const spinner = screen.getByRole('progressbar', { name: 'Loading', busy: true });
     expect(spinner).toBeDefined();
 
     expect(spinner.classList).toContain('dummy-class');

--- a/packages/ui/src/lib/spinner/Spinner.svelte
+++ b/packages/ui/src/lib/spinner/Spinner.svelte
@@ -2,7 +2,7 @@
 export let size = '2em';
 </script>
 
-<i class="flex justify-center items-center {$$props.class}" style="{$$props.style}">
+<i aria-label="spinner" class="flex justify-center items-center {$$props.class}" style="{$$props.style}">
   <svg width="{size}" height="{size}" viewBox="0 0 100 100" role="img">
     <defs>
       <linearGradient id="grad1" x1="0%" y1="0%" x2="0%" y2="100%">

--- a/packages/ui/src/lib/spinner/Spinner.svelte
+++ b/packages/ui/src/lib/spinner/Spinner.svelte
@@ -2,7 +2,12 @@
 export let size = '2em';
 </script>
 
-<i aria-label="spinner" class="flex justify-center items-center {$$props.class}" style="{$$props.style}">
+<i
+  role="progressbar"
+  aria-label="Loading"
+  aria-busy="true"
+  class="flex justify-center items-center {$$props.class}"
+  style="{$$props.style}">
   <svg width="{size}" height="{size}" viewBox="0 0 100 100" role="img">
     <defs>
       <linearGradient id="grad1" x1="0%" y1="0%" x2="0%" y2="100%">

--- a/packages/ui/src/lib/spinner/Spinner.svelte
+++ b/packages/ui/src/lib/spinner/Spinner.svelte
@@ -2,7 +2,7 @@
 export let size = '2em';
 </script>
 
-<i class="flex justify-center items-center">
+<i class="flex justify-center items-center {$$props.class}" style="{$$props.style}">
   <svg width="{size}" height="{size}" viewBox="0 0 100 100" role="img">
     <defs>
       <linearGradient id="grad1" x1="0%" y1="0%" x2="0%" y2="100%">


### PR DESCRIPTION
### What does this PR do?

Move the Spinner.svelte component from the renderer to the ui package.

Plus adding the $$props.class and $$props.style for better usage

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop/issues/6897

### How to test this PR?

- [x] Tests are covering the bug fix or the new feature
