### PR TITLE
fix: boolean values should be true and not 'on' using forms

### DIFF
--- a/extensions/kind/src/create-cluster.ts
+++ b/extensions/kind/src/create-cluster.ts
@@ -138,7 +138,7 @@ export async function createCluster(
   let ingressController = false;
 
   if (params['kind.cluster.creation.ingress']) {
-    ingressController = params['kind.cluster.creation.ingress'] === 'on';
+    ingressController = params['kind.cluster.creation.ingress'];
   }
 
   // grab custom kind node image if defined

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -335,4 +335,67 @@ describe.each([
     const showLogsButton = screen.getByRole('button', { name: 'Show Logs' });
     expect(showLogsButton).toBeInTheDocument();
   });
+});
+
+test(`Expect create with unchecked and checked checkboxes`, async () => {
+  let providedKeyLogger: ((key: symbol, eventName: LoggerEventName, args: string[]) => void) | undefined;
+  const taskId = 4;
+  const callback = mockCallback(async keyLogger => {
+    providedKeyLogger = keyLogger;
+  });
+
+  const booleanProperties: IConfigurationPropertyRecordedSchema[] = [
+    {
+      title: 'unchecked checkbox',
+      parentId: '',
+      scope: 'ContainerProviderConnectionFactory',
+      id: 'test.unchecked',
+      type: 'boolean',
+      description: 'should be unchecked / false',
+    },
+    {
+      title: 'checked checkbox',
+      parentId: '',
+      scope: 'ContainerProviderConnectionFactory',
+      id: 'test.checked',
+      type: 'boolean',
+      default: true,
+      description: 'should be checked / true',
+    },
+    {
+      title: 'FactoryProperty',
+      parentId: '',
+      scope: 'ContainerProviderConnectionFactory',
+      id: 'test.factoryProperty',
+      type: 'number',
+      description: 'test.factoryProperty',
+    },
+  ];
+
+  // eslint-disable-next-line @typescript-eslint/await-thenable
+  render(PreferencesConnectionCreationOrEditRendering, {
+    properties: booleanProperties,
+    providerInfo,
+    connectionInfo: undefined,
+    propertyScope,
+    callback,
+    pageIsLoading: false,
+    taskId,
+  });
+  await vi.waitUntil(() => screen.queryByRole('textbox', { name: 'test.factoryProperty' }));
+  await vi.waitUntil(() => screen.getByRole('checkbox', { name: 'should be unchecked / false' }));
+  await vi.waitUntil(() => screen.getByRole('checkbox', { name: 'should be checked / true' }));
+
+  const createButton = screen.getByRole('button', { name: 'Create' });
+  expect(createButton).toBeInTheDocument();
+  // click on the button
+  await fireEvent.click(createButton);
+
+  expect(callback).toBeCalledWith(
+    'test',
+    { 'test.factoryProperty': '0', 'test.checked': true, 'test.unchecked': false },
+    expect.anything(),
+    eventCollect,
+    undefined,
+  );
 });

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.svelte
@@ -331,11 +331,28 @@ async function handleOnSubmit(e: any) {
   errorMessage = undefined;
   const formData = new FormData(e.target);
 
-  const data: { [key: string]: FormDataEntryValue } = {};
+  const data: { [key: string]: unknown } = {};
+
+  // handle checkboxes that are not submitted in case of unchecked
+  // get all configuration keys
+  configurationKeys.forEach(key => {
+    // do we have the value in the form
+    if (key.id && !formData.has(key.id) && key.type === 'boolean') {
+      data[key.id] = false;
+    }
+  });
+
   for (let field of formData) {
     const [key, value] = field;
+    let updatedValue: unknown = value;
+    const configurationDef = configurationKeys.find(configKey => configKey.id === key);
     if (!connectionInfo || configurationValues.get(key)?.modified) {
-      data[key] = value;
+      // definition of the key
+      // update the value to be true and not on
+      if (configurationDef?.type === 'boolean' && value === 'on') {
+        updatedValue = true;
+      }
+      data[key] = updatedValue;
     }
   }
 


### PR DESCRIPTION
### What does this PR do?
In HTML, when using submit, only checked checkboxes are submitted.
so for example it means that if we have the checkbox rootful, if the user don't check, it's like a missing parameter.

As we know which properties we're expecting, in case of missing parameter, we set to false.

And another issue, when checkbox is checked, in the form we have 'on' as value, not true. So we need to replace by a boolean value so the factories receiving the properties are able to properly handle true/false instead of 'on' 

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox#value

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/2061

### How to test this PR?
you could print what an extension receive as params when checking/unchecking some checkboxes

- [x] Tests are covering the bug fix or the new feature
