### PR TITLE
fix(UI): resource page link to extension page

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
@@ -361,7 +361,7 @@ function hasAnyConfiguration(provider: ProviderInfo) {
 <SettingsPage title="Resources">
   <span slot="subtitle" class:hidden="{providers.length === 0}">
     Additional provider information is available under <a
-      href="/preferences/extensions"
+      href="/extensions"
       class="text-gray-700 underline underline-offset-2">Extensions</a>
   </span>
   <div class="h-full" role="region" aria-label="Featured Provider Resources">


### PR DESCRIPTION
### What does this PR do?

Link was pointing to old `/preference/extensions` leading to blank page

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop/issues/6985

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
