### PR TITLE
fix: add suggestion when WSL seems to require a reboot

### DIFF
--- a/extensions/podman/src/podman-install.spec.ts
+++ b/extensions/podman/src/podman-install.spec.ts
@@ -503,6 +503,10 @@ test('expect winWSL2 preflight check return failure result if the machine has WS
   expect(result.description).equal(
     'WSL2 seems to be installed but the system needs to be restarted so the changes can take effect.',
   );
+  expect(result.docLinksDescription).equal(
+    `If already restarted, call 'wsl --install --no-distribution' in a terminal.`,
+  );
+  expect(result.docLinks[0].url).equal('https://learn.microsoft.com/en-us/windows/wsl/install');
 });
 
 test('expect winWSL2 preflight check return successful result if the machine has WSL2 installed and the reboot check fails with a code different from WSL_E_WSL_OPTIONAL_COMPONENT_REQUIRED', async () => {

--- a/extensions/podman/src/podman-install.ts
+++ b/extensions/podman/src/podman-install.ts
@@ -666,6 +666,11 @@ class WSL2Check extends BaseCheck {
         return this.createFailureResult({
           description:
             'WSL2 seems to be installed but the system needs to be restarted so the changes can take effect.',
+          docLinksDescription: `If already restarted, call 'wsl --install --no-distribution' in a terminal.`,
+          docLinks: {
+            url: 'https://learn.microsoft.com/en-us/windows/wsl/install',
+            title: 'WSL2 Manual Installation Steps',
+          },
         });
       }
     } catch (err) {


### PR DESCRIPTION
### What does this PR do?

it adds a suggestion to try installing wsl without any distribution if after having installed virtual platform and wsl and have rebooted the machine, there are still sign the machine needs to be rebooted.

### Screenshot / video of UI

![image](https://github.com/containers/podman-desktop/assets/49404737/c1de08af-f726-46c2-9039-6026a6718cf1)

### What issues does this PR fix or reference?

it fixes #6978 

### How to test this PR?

1. run tests 

- [x] Tests are covering the bug fix or the new feature
