### PR TITLE
fix: the Image.Id should contain sha256: prefix when listing image Id

### DIFF
--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -3770,6 +3770,7 @@ test('list images with podmanListImages correctly', async () => {
   const imagesList = [
     {
       Id: 'dummyImageId',
+      Digest: 'fooDigest',
     },
   ];
 
@@ -3795,7 +3796,7 @@ test('list images with podmanListImages correctly', async () => {
   const image = images[0];
   expect(image.engineId).toBe('podman1');
   expect(image.engineName).toBe('podman');
-  expect(image.Id).toBe('dummyImageId');
+  expect(image.Id).toBe('sha256:dummyImageId');
 });
 
 test('expect images with podmanListImages to also include History as well as engineId and engineName', async () => {

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -647,6 +647,9 @@ export class ContainerProviderRegistry {
           // and may result in false positives until issue: https://github.com/containers/podman/issues/22184 is resolved
           isManifest: guessIsManifest(image, provider.connection.type),
 
+          // Podman Id does not include the sha256 prefix, so we add it here (it's the Digest using Podman API)
+          Id: image.Digest ? `sha256:${image.Id}` : image.Id,
+
           // Compat API provider does not add the Digest field.
           // if it is missing, add it as 'sha256:image.Id'
           Digest: image.Digest || `sha256:${image.Id}`,


### PR DESCRIPTION
### What does this PR do?
backport https://github.com/containers/podman-desktop/pull/7009 to 1.10.x branch

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
