### PR TITLE
fix: if installed, display the installed version

### DIFF
--- a/packages/renderer/src/lib/extensions/extensions-utils.spec.ts
+++ b/packages/renderer/src/lib/extensions/extensions-utils.spec.ts
@@ -186,6 +186,7 @@ const installedExtensions: CombinedExtensionInfoUI[] = [
   },
   {
     id: 'idYInstalled',
+    version: '2.0.0Y',
   },
 ] as unknown[] as CombinedExtensionInfoUI[];
 
@@ -216,7 +217,7 @@ describe('extractCatalogExtensions', () => {
     expect(yExtensionUI.displayName).toBe('Y Extension');
     expect(yExtensionUI.isFeatured).toBe(true);
     expect(yExtensionUI.fetchLink).toBe('linkY');
-    expect(yExtensionUI.fetchVersion).toBe('1.0.0Y');
+    expect(yExtensionUI.fetchVersion).toBe('2.0.0Y');
     expect(yExtensionUI.fetchable).toBe(true);
     expect(yExtensionUI.iconHref).toBe('iconY');
     expect(yExtensionUI.publisherDisplayName).toBe('Foo Publisher');

--- a/packages/renderer/src/lib/extensions/extensions-utils.ts
+++ b/packages/renderer/src/lib/extensions/extensions-utils.ts
@@ -157,17 +157,19 @@ export class ExtensionsUtils {
         const nonPreviewVersions = catalogExtension.versions.filter(v => !v.preview);
         const latestVersion = nonPreviewVersions[0];
         const fetchLink = latestVersion?.ociUri;
-        const fetchVersion = latestVersion?.version;
+        let fetchVersion = latestVersion?.version;
         const publisherDisplayName = catalogExtension.publisherDisplayName;
 
         // grab icon
         const icon = latestVersion?.files.find(f => f.assetType === 'icon');
-        const isInstalled = installedExtensions.some(
-          installedExtension => installedExtension.id === catalogExtension.id,
-        );
+        const installed = installedExtensions.find(installedExtension => installedExtension.id === catalogExtension.id);
+        const isInstalled = !!installed;
         const isFeatured = featuredExtensions.some(featuredExtension => featuredExtension.id === catalogExtension.id);
 
         const shortDescription = catalogExtension.shortDescription;
+        if (installed?.version) {
+          fetchVersion = installed.version;
+        }
 
         return {
           id: catalogExtension.id,


### PR DESCRIPTION
### What does this PR do?
in case of an extension being installed, display the version as being the one installed, not the one that is in the catalog

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/6989

### How to test this PR?

- [x] Tests are covering the bug fix or the new feature
