### PR TITLE
fix: use podman machine inspect to know if machine is rootful

### DIFF
--- a/extensions/podman/src/extension.spec.ts
+++ b/extensions/podman/src/extension.spec.ts
@@ -762,7 +762,7 @@ test('test checkDefaultMachine - if user wants to change machine, check that it 
     },
   ];
 
-  // return as inspect result a rootful machine
+  // return as inspect result a rootless machine
   const inspectCall = vi.spyOn(extensionApi.process, 'exec').mockResolvedValueOnce({
     stdout: JSON.stringify(fakeInspectJSON),
   } as extensionApi.RunResult);
@@ -799,7 +799,7 @@ test('test checkDefaultMachine - if user wants to change machine, check that it 
     },
   ];
 
-  // return as inspect result a rootful machine
+  // return as inspect result a rootless machine
   const inspectCall = vi.spyOn(extensionApi.process, 'exec').mockResolvedValueOnce({
     stdout: JSON.stringify(fakeInspectJSON),
   } as extensionApi.RunResult);

--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -388,7 +388,7 @@ export async function checkDefaultMachine(machines: MachineJSON[]): Promise<void
           runningMachine.Name,
         ]);
         const machinesInspect = JSON.parse(machineInspectJson);
-        // find the machine machine in the array
+        // find the machine name in the array
         const machineInspect = machinesInspect.find(machine => machine.Name === runningMachine.Name);
         if (machineInspect) {
           machineIsRootful = machineInspect?.Rootful ?? false;


### PR DESCRIPTION
### What does this PR do?
in the past, the flag was not exposed so we had to parse some configuration files, but now we should rely on the `podman machine inspect` command to know if it's rootful or rootless

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/7000

### How to test this PR?

use test case of the linked issue
- [x] Tests are covering the bug fix or the new feature
