### PR TITLE
chore: display additional field if installed version is different

### DIFF
--- a/packages/renderer/src/lib/extensions/CatalogExtension.spec.ts
+++ b/packages/renderer/src/lib/extensions/CatalogExtension.spec.ts
@@ -112,3 +112,28 @@ test('Expect to see featured and fetch button', async () => {
     expect.any(Function),
   );
 });
+
+test('Expect to have version of installed one', async () => {
+  const catalogExtensionUI: CatalogExtensionInfoUI = {
+    id: 'myId',
+    displayName: 'This is the display name',
+    isFeatured: false,
+    fetchable: false,
+    fetchLink: '',
+    fetchVersion: '1.0.0',
+    installedVersion: '2.0.0',
+    publisherDisplayName: 'Foo publisher',
+    isInstalled: true,
+    shortDescription: 'my description',
+  };
+
+  render(CatalogExtension, { catalogExtensionUI });
+
+  // check catalog version is displayed
+  const catalogVersion = screen.getByText('v1.0.0');
+  expect(catalogVersion).toBeInTheDocument();
+
+  // check if installed version is displayed
+  const installedVersion = screen.getByText('(installed: v2.0.0)');
+  expect(installedVersion).toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/extensions/CatalogExtension.svelte
+++ b/packages/renderer/src/lib/extensions/CatalogExtension.svelte
@@ -60,6 +60,9 @@ function openExtensionDetails() {
     <div class="text-gray-200 items-end flex flex-1">
       <div class="text-gray-700 text-xs">
         v{catalogExtensionUI.fetchVersion}
+        {#if catalogExtensionUI.installedVersion && catalogExtensionUI.installedVersion !== catalogExtensionUI.fetchVersion}
+          <span class="text-xs text-gray-500">(installed: v{catalogExtensionUI.installedVersion})</span>
+        {/if}
       </div>
       <div class="flex flex-1 justify-end items-center">
         <Fa icon="{faArrowUpRightFromSquare}" />

--- a/packages/renderer/src/lib/extensions/CatalogExtension.svelte
+++ b/packages/renderer/src/lib/extensions/CatalogExtension.svelte
@@ -61,7 +61,7 @@ function openExtensionDetails() {
       <div class="text-gray-700 text-xs">
         v{catalogExtensionUI.fetchVersion}
         {#if catalogExtensionUI.installedVersion && catalogExtensionUI.installedVersion !== catalogExtensionUI.fetchVersion}
-          <span class="text-xs text-gray-500">(installed: v{catalogExtensionUI.installedVersion})</span>
+          <span>(installed: v{catalogExtensionUI.installedVersion})</span>
         {/if}
       </div>
       <div class="flex flex-1 justify-end items-center">

--- a/packages/renderer/src/lib/extensions/catalog-extension-info-ui.ts
+++ b/packages/renderer/src/lib/extensions/catalog-extension-info-ui.ts
@@ -26,5 +26,6 @@ export interface CatalogExtensionInfoUI {
   iconHref?: string;
   publisherDisplayName: string;
   isInstalled: boolean;
+  installedVersion?: string;
   shortDescription: string;
 }

--- a/packages/renderer/src/lib/extensions/extensions-utils.spec.ts
+++ b/packages/renderer/src/lib/extensions/extensions-utils.spec.ts
@@ -186,6 +186,7 @@ const installedExtensions: CombinedExtensionInfoUI[] = [
   },
   {
     id: 'idYInstalled',
+    version: '2.0.0Y',
   },
 ] as unknown[] as CombinedExtensionInfoUI[];
 
@@ -221,6 +222,7 @@ describe('extractCatalogExtensions', () => {
     expect(yExtensionUI.iconHref).toBe('iconY');
     expect(yExtensionUI.publisherDisplayName).toBe('Foo Publisher');
     expect(yExtensionUI.isInstalled).toBe(true);
+    expect(yExtensionUI.installedVersion).toBe('2.0.0Y');
     expect(yExtensionUI.shortDescription).toBe('this is short Y');
 
     // check attributes of a featured extension not being installed

--- a/packages/renderer/src/lib/extensions/extensions-utils.ts
+++ b/packages/renderer/src/lib/extensions/extensions-utils.ts
@@ -162,12 +162,12 @@ export class ExtensionsUtils {
 
         // grab icon
         const icon = latestVersion?.files.find(f => f.assetType === 'icon');
-        const isInstalled = installedExtensions.some(
-          installedExtension => installedExtension.id === catalogExtension.id,
-        );
+        const installed = installedExtensions.find(installedExtension => installedExtension.id === catalogExtension.id);
+        const isInstalled = !!installed;
         const isFeatured = featuredExtensions.some(featuredExtension => featuredExtension.id === catalogExtension.id);
 
         const shortDescription = catalogExtension.shortDescription;
+        const installedVersion = installed?.version;
 
         return {
           id: catalogExtension.id,
@@ -179,6 +179,7 @@ export class ExtensionsUtils {
           iconHref: icon?.data,
           publisherDisplayName,
           isInstalled,
+          installedVersion,
           shortDescription,
         };
       });


### PR DESCRIPTION
### What does this PR do?
Display installed version if different than the catalog version
for example if I have a different version than the one in the catalog I should be able to see if while seeing the catalog because if I click on the details I will the version of the installed extension

### Screenshot / video of UI

![image](https://github.com/containers/podman-desktop/assets/436777/9f0864e9-2e41-4804-8b16-ff8b494dc7e7)

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/6989

### How to test this PR?


- [x] Tests are covering the bug fix or the new feature
