### PR TITLE
chore: remove kube list telemetry

### DIFF
--- a/packages/main/src/plugin/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes-client.ts
@@ -543,7 +543,6 @@ export class KubernetesClient {
   }
 
   async listNamespacedPod(namespace: string, fieldSelector?: string, labelSelector?: string): Promise<V1PodList> {
-    let telemetryOptions = {};
     const k8sApi = this.kubeConfig.makeApiClient(CoreV1Api);
     try {
       const res = await k8sApi.listNamespacedPod(
@@ -562,10 +561,7 @@ export class KubernetesClient {
         };
       }
     } catch (error) {
-      telemetryOptions = { error: error };
       throw this.wrapK8sClientError(error);
-    } finally {
-      this.telemetry.track('kubernetesListNamespacePod', telemetryOptions);
     }
   }
 
@@ -849,7 +845,6 @@ export class KubernetesClient {
   }
 
   async listNamespaces(): Promise<V1NamespaceList> {
-    let telemetryOptions = {};
     try {
       const k8sApi = this.kubeConfig.makeApiClient(CoreV1Api);
       const res = await k8sApi.listNamespace();
@@ -861,10 +856,7 @@ export class KubernetesClient {
         };
       }
     } catch (error) {
-      telemetryOptions = { error: error };
       throw this.wrapK8sClientError(error);
-    } finally {
-      this.telemetry.track('kubernetesListNamespaces', telemetryOptions);
     }
   }
 


### PR DESCRIPTION
### What does this PR do?

kubernetesListNamespacePod is the single most common event sent in telemetry by far, and responsible for a significant portion of our events. It doesn't really tell us anything (we had access to pods on a namespace) compared with other events like reading individual items or modifying them, and even logging the errors isn't giving anything useful: they are infrequent in comparison and the vast majority are obvious access errors like the namespace wasn't accessible. Instead of trying to limit or change what we log, it seems prudent to just remove it.

kubernetesListNamespaces isn't called nearly as much, but since it is the only other list* tracking it seems like it should be removed to be consistent.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Part of #4970.

### How to test this PR?

List Kubernetes pods in watch mode and confirm event is not sent to Segment.