### PR TITLE
chore: bump @types/dockerode version to 3.3.29

### DIFF
--- a/package.json
+++ b/package.json
@@ -196,7 +196,6 @@
   "resolutions": {
     "trim": "0.0.3",
     "ssh2": "1.11.0",
-    "@types/node": "^20",
-    "@types/docker-modem": "3.0.6"
+    "@types/node": "^20"
   }
 }

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "@rollup/plugin-node-resolve": "^15.2.3",
     "@rollup/plugin-typescript": "^11.1.6",
     "@types/adm-zip": "^0.5.5",
-    "@types/dockerode": "^3.3.28",
+    "@types/dockerode": "^3.3.29",
     "@types/express": "^4.17.21",
     "@types/getos": "^3.0.4",
     "@types/js-yaml": "^4.0.9",
@@ -196,6 +196,7 @@
   "resolutions": {
     "trim": "0.0.3",
     "ssh2": "1.11.0",
-    "@types/node": "^20"
+    "@types/node": "^20",
+    "@types/docker-modem": "3.0.6"
   }
 }

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -1132,7 +1132,7 @@ export class ContainerProviderRegistry {
     try {
       const authconfig = this.imageRegistry.getAuthconfigForImage(imageName);
       const matchingEngine = this.getMatchingEngineFromConnection(providerContainerConnectionInfo);
-      const pullStream: NodeJS.ReadableStream = await matchingEngine.pull(imageName, {
+      const pullStream = await matchingEngine.pull(imageName, {
         authconfig,
         abortSignal: abortController?.signal,
       });

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -20,7 +20,7 @@ import * as crypto from 'node:crypto';
 import { EventEmitter } from 'node:events';
 import * as fs from 'node:fs';
 import path from 'node:path';
-import { type Stream, Writable } from 'node:stream';
+import { Writable } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
 
 import type * as containerDesktopAPI from '@podman-desktop/api';
@@ -1132,7 +1132,7 @@ export class ContainerProviderRegistry {
     try {
       const authconfig = this.imageRegistry.getAuthconfigForImage(imageName);
       const matchingEngine = this.getMatchingEngineFromConnection(providerContainerConnectionInfo);
-      const pullStream = await matchingEngine.pull(imageName, {
+      const pullStream: NodeJS.ReadableStream = await matchingEngine.pull(imageName, {
         authconfig,
         abortSignal: abortController?.signal,
       });
@@ -2344,7 +2344,7 @@ export class ContainerProviderRegistry {
         options.containerFile = options.containerFile.replace(/\\/g, '/');
       }
 
-      let streamingPromise: Stream;
+      let streamingPromise: NodeJS.ReadableStream;
       try {
         const buildOptions: ImageBuildOptions = {
           registryconfig,
@@ -2384,10 +2384,7 @@ export class ContainerProviderRegistry {
         if (options?.pull) {
           buildOptions.pull = options.pull;
         }
-        streamingPromise = (await matchingContainerProviderApi.buildImage(
-          tarStream,
-          buildOptions,
-        )) as unknown as Stream;
+        streamingPromise = await matchingContainerProviderApi.buildImage(tarStream, buildOptions);
       } catch (error: unknown) {
         console.log('error in buildImage', error);
         const errorMessage = error instanceof Error ? error.message : '' + error;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2114,7 +2114,7 @@
     "@docusaurus/theme-search-algolia" "3.2.1"
     "@docusaurus/types" "3.2.1"
 
-"@docusaurus/react-loadable@5.5.2", "react-loadable@npm:@docusaurus/react-loadable@5.5.2":
+"@docusaurus/react-loadable@5.5.2":
   version "5.5.2"
   resolved "https://registry.yarnpkg.com/@docusaurus/react-loadable/-/react-loadable-5.5.2.tgz#81aae0db81ecafbdaee3651f12804580868fa6ce"
   integrity sha512-A3dYjdBGuy0IGT+wyLIGIKLRE+sAk1iNk0f1HjNDysO7u8lhL4N3VEm+FAubmJbAztn94F7MxBTPmnixbiyFdQ==
@@ -13856,6 +13856,14 @@ react-loadable-ssr-addon-v5-slorber@^1.0.1:
   integrity sha512-lq3Lyw1lGku8zUEJPDxsNm1AfYHBrO9Y1+olAYwpUJ2IGFBskM0DMKok97A6LWUpHm+o7IvQBOWu9MLenp9Z+A==
   dependencies:
     "@babel/runtime" "^7.10.3"
+
+"react-loadable@npm:@docusaurus/react-loadable@5.5.2":
+  version "5.5.2"
+  resolved "https://registry.yarnpkg.com/@docusaurus/react-loadable/-/react-loadable-5.5.2.tgz#81aae0db81ecafbdaee3651f12804580868fa6ce"
+  integrity sha512-A3dYjdBGuy0IGT+wyLIGIKLRE+sAk1iNk0f1HjNDysO7u8lhL4N3VEm+FAubmJbAztn94F7MxBTPmnixbiyFdQ==
+  dependencies:
+    "@types/react" "*"
+    prop-types "^15.6.2"
 
 react-player@^2.16.0:
   version "2.16.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2114,7 +2114,7 @@
     "@docusaurus/theme-search-algolia" "3.2.1"
     "@docusaurus/types" "3.2.1"
 
-"@docusaurus/react-loadable@5.5.2":
+"@docusaurus/react-loadable@5.5.2", "react-loadable@npm:@docusaurus/react-loadable@5.5.2":
   version "5.5.2"
   resolved "https://registry.yarnpkg.com/@docusaurus/react-loadable/-/react-loadable-5.5.2.tgz#81aae0db81ecafbdaee3651f12804580868fa6ce"
   integrity sha512-A3dYjdBGuy0IGT+wyLIGIKLRE+sAk1iNk0f1HjNDysO7u8lhL4N3VEm+FAubmJbAztn94F7MxBTPmnixbiyFdQ==
@@ -3857,18 +3857,18 @@
   dependencies:
     "@types/ms" "*"
 
-"@types/docker-modem@*":
-  version "3.0.2"
-  resolved "https://registry.npmjs.org/@types/docker-modem/-/docker-modem-3.0.2.tgz"
-  integrity sha512-qC7prjoEYR2QEe6SmCVfB1x3rfcQtUr1n4x89+3e0wSTMQ/KYCyf+/RAA9n2tllkkNc6//JMUZePdFRiGIWfaQ==
+"@types/docker-modem@*", "@types/docker-modem@3.0.6":
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/@types/docker-modem/-/docker-modem-3.0.6.tgz#1f9262fcf85425b158ca725699a03eb23cddbf87"
+  integrity sha512-yKpAGEuKRSS8wwx0joknWxsmLha78wNMe9R2S3UNsVOkZded8UqOrV8KoeDXoXsjndxwyF3eIhyClGbO1SEhEg==
   dependencies:
     "@types/node" "*"
     "@types/ssh2" "*"
 
-"@types/dockerode@^3.3.28":
-  version "3.3.28"
-  resolved "https://registry.yarnpkg.com/@types/dockerode/-/dockerode-3.3.28.tgz#8accfc7543e054481ee9ee4ab08cfebc4ac2576c"
-  integrity sha512-RjY96chW88t2QvSebCsec+mQYo3/nyOr+/tVcE+0ynlOg2m/i9wPE52DhptzF75QDlhv2uDYVPqKfHKeGTn6Fg==
+"@types/dockerode@^3.3.29":
+  version "3.3.29"
+  resolved "https://registry.yarnpkg.com/@types/dockerode/-/dockerode-3.3.29.tgz#7d3c99a91c381115015587a8a2a71002029e1740"
+  integrity sha512-5PRRq/yt5OT/Jf77ltIdz4EiR9+VLnPF+HpU4xGFwUqmV24Co2HKBNW3w+slqZ1CYchbcDeqJASHDYWzZCcMiQ==
   dependencies:
     "@types/docker-modem" "*"
     "@types/node" "*"
@@ -13856,14 +13856,6 @@ react-loadable-ssr-addon-v5-slorber@^1.0.1:
   integrity sha512-lq3Lyw1lGku8zUEJPDxsNm1AfYHBrO9Y1+olAYwpUJ2IGFBskM0DMKok97A6LWUpHm+o7IvQBOWu9MLenp9Z+A==
   dependencies:
     "@babel/runtime" "^7.10.3"
-
-"react-loadable@npm:@docusaurus/react-loadable@5.5.2":
-  version "5.5.2"
-  resolved "https://registry.yarnpkg.com/@docusaurus/react-loadable/-/react-loadable-5.5.2.tgz#81aae0db81ecafbdaee3651f12804580868fa6ce"
-  integrity sha512-A3dYjdBGuy0IGT+wyLIGIKLRE+sAk1iNk0f1HjNDysO7u8lhL4N3VEm+FAubmJbAztn94F7MxBTPmnixbiyFdQ==
-  dependencies:
-    "@types/react" "*"
-    prop-types "^15.6.2"
 
 react-player@^2.16.0:
   version "2.16.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3857,7 +3857,7 @@
   dependencies:
     "@types/ms" "*"
 
-"@types/docker-modem@*", "@types/docker-modem@3.0.6":
+"@types/docker-modem@*":
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/@types/docker-modem/-/docker-modem-3.0.6.tgz#1f9262fcf85425b158ca725699a03eb23cddbf87"
   integrity sha512-yKpAGEuKRSS8wwx0joknWxsmLha78wNMe9R2S3UNsVOkZded8UqOrV8KoeDXoXsjndxwyF3eIhyClGbO1SEhEg==


### PR DESCRIPTION
### What does this PR do?

https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69385 changed the return type of the `pull` method argument `callback` from `callback: Callback<any>` to `callback: Callback<NodeJS.ReadableStream>`.

The problem are from the `docker-modem` library that was resolving an old version of its types `@types/docker-modem:3.0.2` when only the version `@types/docker-modem:3.0.6` (latest) was compatible with the new change. 

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

Pipeline should be ✅ 
