### PR TITLE
fix: increasing default timeout for extension activation

### DIFF
--- a/packages/main/src/plugin/extension-loader-settings.ts
+++ b/packages/main/src/plugin/extension-loader-settings.ts
@@ -16,6 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+export const DEFAULT_TIMEOUT = 20;
+
 export enum ExtensionLoaderSettings {
   SectionName = 'extensions',
   MaxActivationTime = 'maxActivationTime',

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -259,7 +259,7 @@ export class ExtensionLoader {
         [ExtensionLoaderSettings.SectionName + '.' + ExtensionLoaderSettings.MaxActivationTime]: {
           description: 'Maximum activation time for an extension, in seconds.',
           type: 'number',
-          default: 10,
+          default: 20,
           minimum: 1,
           maximum: 100,
         },
@@ -1372,10 +1372,9 @@ export class ExtensionLoader {
     try {
       if (typeof extensionMain?.['activate'] === 'function') {
         // maximum time to wait for the extension to activate by reading from configuration
-        const delayInSeconds: number =
-          this.configurationRegistry
-            .getConfiguration(ExtensionLoaderSettings.SectionName)
-            .get(ExtensionLoaderSettings.MaxActivationTime) || 5;
+        const delayInSeconds: number = this.configurationRegistry
+          .getConfiguration(ExtensionLoaderSettings.SectionName)
+          .get(ExtensionLoaderSettings.MaxActivationTime, 20);
         const delayInMilliseconds = delayInSeconds * 1000;
 
         // reject a promise after this delay

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -47,7 +47,7 @@ import type { CustomPickRegistry } from './custompick/custompick-registry.js';
 import type { DialogRegistry } from './dialog-registry.js';
 import type { Directories } from './directories.js';
 import { Emitter } from './events/emitter.js';
-import { ExtensionLoaderSettings } from './extension-loader-settings.js';
+import { DEFAULT_TIMEOUT, ExtensionLoaderSettings } from './extension-loader-settings.js';
 import type { FilesystemMonitoring } from './filesystem-monitoring.js';
 import type { IconRegistry } from './icon-registry.js';
 import type { ImageCheckerImpl } from './image-checker.js';
@@ -259,7 +259,7 @@ export class ExtensionLoader {
         [ExtensionLoaderSettings.SectionName + '.' + ExtensionLoaderSettings.MaxActivationTime]: {
           description: 'Maximum activation time for an extension, in seconds.',
           type: 'number',
-          default: 20,
+          default: DEFAULT_TIMEOUT,
           minimum: 1,
           maximum: 100,
         },
@@ -1374,7 +1374,7 @@ export class ExtensionLoader {
         // maximum time to wait for the extension to activate by reading from configuration
         const delayInSeconds: number = this.configurationRegistry
           .getConfiguration(ExtensionLoaderSettings.SectionName)
-          .get(ExtensionLoaderSettings.MaxActivationTime, 20);
+          .get(ExtensionLoaderSettings.MaxActivationTime, DEFAULT_TIMEOUT);
         const delayInMilliseconds = delayInSeconds * 1000;
 
         // reject a promise after this delay


### PR DESCRIPTION
### What does this PR do?

Going from `10s` to `20s`

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
