### PR TITLE
fix: show description link on preflight checks on dashboard

### DIFF
--- a/packages/main/src/plugin/api/provider-info.ts
+++ b/packages/main/src/plugin/api/provider-info.ts
@@ -112,6 +112,7 @@ export interface CheckStatus {
   name: string;
   successful?: boolean;
   description?: string;
+  docLinksDescription?: string;
   docLinks?: Link[];
 }
 

--- a/packages/main/src/plugin/provider-registry.ts
+++ b/packages/main/src/plugin/provider-registry.ts
@@ -432,6 +432,7 @@ export class ProviderRegistry {
           name: check.title,
           successful: checkResult.successful,
           description: checkResult.description,
+          docLinksDescription: checkResult.docLinksDescription,
           docLinks: checkResult.docLinks,
         });
 

--- a/packages/renderer/src/lib/dashboard/PreflightChecks.svelte
+++ b/packages/renderer/src/lib/dashboard/PreflightChecks.svelte
@@ -27,6 +27,11 @@ function openLink(e: MouseEvent, url: string): void {
         </div>
         {#if preCheck.description}
           Details: <p class="text-gray-400 w-full break-all">{preCheck.description}</p>
+          {#if preCheck.docLinksDescription}
+            <p class="text-gray-400 w-full">
+              {preCheck.docLinksDescription}
+            </p>
+          {/if}
           {#if preCheck.docLinks}
             See:
             {#each preCheck.docLinks as link}


### PR DESCRIPTION
### What does this PR do?

This PR just shows the docDescriptionLink value in the preflightCheck list in the dashboard.

### Screenshot / video of UI

![image](https://github.com/containers/podman-desktop/assets/49404737/b559339f-c1cb-47c4-b910-942071b7a64f)

### What issues does this PR fix or reference?

it resolves #7044 

### How to test this PR?

1. run the install when wsl is not installed and check that also the decription link is displayed

- [ ] Tests are covering the bug fix or the new feature

