### PR TITLE
fix: edit button should be visible during started and stopped

### DIFF
--- a/packages/renderer/src/lib/ui/LoadingIconButton.spec.ts
+++ b/packages/renderer/src/lib/ui/LoadingIconButton.spec.ts
@@ -181,6 +181,43 @@ test.each([
     },
     expected: EXPECT_DISABLE,
   },
+  // edit action
+  {
+    name: 'edit action in started status should be enabled',
+    action: 'edit',
+    state: {
+      status: 'started',
+      inProgress: false,
+    },
+    expected: EXPECT_ENABLE,
+  },
+  {
+    name: 'edit action in unknown status should be disabled',
+    action: 'edit',
+    state: {
+      status: 'unknown',
+      inProgress: false,
+    },
+    expected: EXPECT_DISABLE,
+  },
+  {
+    name: 'edit action in starting status should be disabled',
+    action: 'edit',
+    state: {
+      status: 'starting',
+      inProgress: false,
+    },
+    expected: EXPECT_DISABLE,
+  },
+  {
+    name: 'edit action if in progress should be disabled',
+    action: 'edit',
+    state: {
+      status: 'started',
+      inProgress: true,
+    },
+    expected: EXPECT_DISABLE,
+  },
 ] as TestScenario[])('$name', ({ action, color, state, expected }) => {
   render(LoadingIconButton, {
     action: action,

--- a/packages/renderer/src/lib/ui/LoadingIconButton.svelte
+++ b/packages/renderer/src/lib/ui/LoadingIconButton.svelte
@@ -35,6 +35,9 @@ $: {
       case 'update':
         disable = state?.status === 'unknown';
         break;
+      case 'edit':
+        disable = state?.status !== 'started' && state?.status !== 'stopped';
+        break;
     }
   }
 }


### PR DESCRIPTION
### What does this PR do?
cherry-pick #7063 to 1.10.x branch

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
