### PR TITLE
fix: custom extension install modal buttons

### DIFF
--- a/packages/renderer/src/lib/extensions/InstallManuallyExtensionModal.spec.ts
+++ b/packages/renderer/src/lib/extensions/InstallManuallyExtensionModal.spec.ts
@@ -76,3 +76,145 @@ test('expect able to download an extension', async () => {
   // expect close callback to be called
   expect(closeCallback).toBeCalled();
 });
+
+function mockExtensionInstallFromImage(): {
+  resolve: () => void;
+  reject: (error: unknown) => void;
+  logCallback: (data: string) => void;
+  errorCallback: (data: string) => void;
+} {
+  const resolve = vi.fn();
+  const reject = vi.fn();
+  const logCallback = vi.fn<[string], void>();
+  const errorCallback = vi.fn<[string], void>();
+  vi.mocked(window.extensionInstallFromImage).mockImplementation((_image, mLogCallback, mErrorCallback) => {
+    logCallback.mockImplementation((content: string) => mLogCallback(content));
+    errorCallback.mockImplementation((content: string) => mErrorCallback(content));
+    return new Promise((mResolve, mReject) => {
+      resolve.mockImplementation(() => mResolve());
+      reject.mockImplementation((err: unknown) => mReject(err));
+    });
+  });
+  return { resolve, reject, logCallback, errorCallback };
+}
+
+test('install button should always be disable when extensionInstallFromImage is pending', async () => {
+  const { logCallback } = mockExtensionInstallFromImage();
+
+  render(InstallManuallyExtensionModal, { closeCallback });
+
+  // enter the name quay.io/foobar
+  const input = screen.getByRole('textbox', { name: 'Image name to install custom extension' });
+  expect(input).toBeInTheDocument();
+  // now enter the text 'my-custom-image.io/foo'
+  await userEvent.type(input, 'my-custom-image.io/foo');
+
+  // click on the button
+  const installButton = screen.getByRole('button', { name: 'Install' });
+  expect(installButton).toBeInTheDocument();
+  expect(installButton).toBeEnabled();
+
+  await userEvent.click(installButton);
+
+  logCallback('Downloading sha256:random-sha256.tar - 100% - (55132/521578)');
+
+  const progressBar = screen.getByRole('progressbar');
+  await vi.waitFor(() => {
+    expect(progressBar.getAttribute('style')).toBe('width: 100%;');
+  });
+
+  // expect button done to be disabled
+  expect(installButton).toBeDisabled();
+});
+
+test('rejected installation should make the button visible', async () => {
+  const { reject } = mockExtensionInstallFromImage();
+
+  render(InstallManuallyExtensionModal, { closeCallback });
+
+  // enter the name quay.io/foobar
+  const input = screen.getByRole('textbox', { name: 'Image name to install custom extension' });
+  expect(input).toBeInTheDocument();
+  // now enter the text 'my-custom-image.io/foo'
+  await userEvent.type(input, 'my-custom-image.io/foo');
+
+  // click on the button
+  const installButton = screen.getByRole('button', { name: 'Install' });
+  await userEvent.click(installButton);
+
+  await vi.waitFor(() => {
+    expect(installButton).toBeDisabled();
+  });
+
+  reject(new Error('random error'));
+
+  await vi.waitFor(() => {
+    expect(installButton).toBeEnabled();
+  });
+});
+
+test('progressbar should match latest log', async () => {
+  const { logCallback } = mockExtensionInstallFromImage();
+
+  render(InstallManuallyExtensionModal, { closeCallback });
+
+  // enter the name quay.io/foobar
+  const input = screen.getByRole('textbox', { name: 'Image name to install custom extension' });
+  expect(input).toBeInTheDocument();
+  // now enter the text 'my-custom-image.io/foo'
+  await userEvent.type(input, 'my-custom-image.io/foo');
+
+  // click on the button
+  const installButton = screen.getByRole('button', { name: 'Install' });
+  expect(installButton).toBeInTheDocument();
+  expect(installButton).toBeEnabled();
+
+  await userEvent.click(installButton);
+
+  const progressBar = screen.getByRole('progressbar');
+  for (let i = 0; i < 64; i += 8) {
+    logCallback(`Downloading sha256:random-sha256.tar - ${i}% - (${i}/64)`);
+
+    await vi.waitFor(() => {
+      expect(progressBar.getAttribute('style')).toBe(`width: ${i}%;`);
+    });
+  }
+});
+
+test('install button should be enable while extensionInstallFromImage is resolved', async () => {
+  const { resolve, logCallback } = mockExtensionInstallFromImage();
+
+  render(InstallManuallyExtensionModal, { closeCallback });
+
+  // enter the name quay.io/foobar
+  const input = screen.getByRole('textbox', { name: 'Image name to install custom extension' });
+  expect(input).toBeInTheDocument();
+  // now enter the text 'my-custom-image.io/foo'
+  await userEvent.type(input, 'my-custom-image.io/foo');
+
+  // click on the button
+  const installButton = screen.getByRole('button', { name: 'Install' });
+  expect(installButton).toBeInTheDocument();
+  expect(installButton).toBeEnabled();
+
+  await userEvent.click(installButton);
+
+  // log 100%
+  logCallback('Downloading sha256:random-sha256.tar - 100% - (521578/521578)');
+  const progressBar = screen.getByRole('progressbar');
+  await vi.waitFor(() => {
+    expect(progressBar.getAttribute('style')).toBe('width: 100%;');
+  });
+
+  // resolve extensionInstallFromImage
+  resolve();
+
+  // done button should be visible after resolution
+  await vi.waitFor(() => {
+    const doneButton = screen.getByRole('button', { name: 'Done' });
+    expect(doneButton).toBeInTheDocument();
+  });
+
+  // install button should not be visible after resolution
+  expect(screen.queryByRole('button', { name: 'Install' })).toBeNull();
+});

--- a/packages/renderer/src/lib/extensions/InstallManuallyExtensionModal.svelte
+++ b/packages/renderer/src/lib/extensions/InstallManuallyExtensionModal.svelte
@@ -145,7 +145,7 @@ function handleKeydown(e: KeyboardEvent) {
               on:click="{() => installExtension()}"
               inProgress="{installInProgress}">Install</Button>
           {/if}
-          {#if progressPercent === 100 && !installInProgress}
+          {#if !installInProgress && progressPercent === 100}
             <Button on:click="{() => closeCallback()}">Done</Button>
           {/if}
         </div>

--- a/packages/renderer/src/lib/extensions/InstallManuallyExtensionModal.svelte
+++ b/packages/renderer/src/lib/extensions/InstallManuallyExtensionModal.svelte
@@ -106,7 +106,7 @@ function handleKeydown(e: KeyboardEvent) {
       <div>
         <label for="imageName" class="block text-sm pb-2 text-gray-400">OCI Image:</label>
         <div class="min-h-14">
-          {#if progressPercent < 100}
+          {#if installInProgress || progressPercent !== 100}
             <Input
               bind:value="{imageName}"
               name="imageName"
@@ -138,14 +138,14 @@ function handleKeydown(e: KeyboardEvent) {
             on:click="{() => {
               closeCallback();
             }}">Cancel</Button>
-          {#if progressPercent !== 100}
+          {#if installInProgress || progressPercent !== 100}
             <Button
               icon="{faCloudDownload}"
               disabled="{inputfieldError !== undefined}"
               on:click="{() => installExtension()}"
               inProgress="{installInProgress}">Install</Button>
           {/if}
-          {#if progressPercent === 100}
+          {#if progressPercent === 100 && !installInProgress}
             <Button on:click="{() => closeCallback()}">Done</Button>
           {/if}
         </div>


### PR DESCRIPTION
### What does this PR do?

The `install` button of the custom extension installation modal was having a problem were it was changing from `install -> Done -> install` for each extension install when loading an extension pack.

This PR fixes that behavior by considering it is terminated when the `window.extensionInstallFromImage` is resolved (meaning all extensions has been installed).

### Screenshot / video of UI

Before https://github.com/containers/podman-desktop/issues/6999

After

https://github.com/containers/podman-desktop/assets/42176370/82ce9213-0e44-46e0-96ed-b0451a3575b2

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop/issues/6999

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
