### PR TITLE
feat: extensions should stay disabled after restart

### DIFF
--- a/packages/main/src/plugin/extension-loader-settings.ts
+++ b/packages/main/src/plugin/extension-loader-settings.ts
@@ -21,4 +21,5 @@ export const DEFAULT_TIMEOUT = 20;
 export enum ExtensionLoaderSettings {
   SectionName = 'extensions',
   MaxActivationTime = 'maxActivationTime',
+  Disabled = 'disabled',
 }

--- a/packages/main/src/plugin/extension-loader.spec.ts
+++ b/packages/main/src/plugin/extension-loader.spec.ts
@@ -119,8 +119,10 @@ const kubernetesGeneratorRegistry: KubeGeneratorRegistry = {} as unknown as Kube
 const providerRegistry: ProviderRegistry = {} as unknown as ProviderRegistry;
 
 const configurationRegistryGetConfigurationMock = vi.fn();
+const configurationRegistryUpdateConfigurationMock = vi.fn();
 const configurationRegistry: ConfigurationRegistry = {
   getConfiguration: configurationRegistryGetConfigurationMock,
+  updateConfigurationValue: configurationRegistryUpdateConfigurationMock,
 } as unknown as ConfigurationRegistry;
 
 const imageRegistry: ImageRegistry = {} as unknown as ImageRegistry;
@@ -480,6 +482,50 @@ test('Verify extension load', async () => {
     'loadExtension',
     expect.objectContaining({ extensionId: id, extensionVersion: '1.1' }),
   );
+});
+
+test('Verify disable extension updates configuration', async () => {
+  const ids = ['extension.foo'];
+
+  configurationRegistryUpdateConfigurationMock.mockResolvedValue(Promise.resolve);
+  extensionLoader.setDisabledExtensionIds(ids);
+
+  expect(configurationRegistryUpdateConfigurationMock).toHaveBeenCalledWith('extensions.disabled', ids);
+});
+
+test('Verify enable extension updates configuration', async () => {
+  const id = 'extension.no.foo';
+  const before = ['a', id, 'b'];
+  const after = ['a', 'b'];
+
+  configurationRegistryGetConfigurationMock.mockReturnValue({
+    get: () => before,
+  });
+  configurationRegistryUpdateConfigurationMock.mockResolvedValue(Promise.resolve);
+  extensionLoader.ensureExtensionIsEnabled(id);
+
+  expect(configurationRegistryUpdateConfigurationMock).toHaveBeenCalledWith('extensions.disabled', after);
+});
+
+test('Verify stopping extension disables it', async () => {
+  const id = 'extension.no.foo';
+  configurationRegistryGetConfigurationMock.mockReturnValue({
+    get: () => [],
+  });
+  await extensionLoader.stopExtension(id);
+
+  expect(configurationRegistryUpdateConfigurationMock).toHaveBeenCalledWith('extensions.disabled', [id]);
+});
+
+test('Verify starting extension enables it', async () => {
+  const id = 'extension.no.foo';
+
+  configurationRegistryGetConfigurationMock.mockReturnValue({
+    get: () => ['extension.no.foo'],
+  });
+  await extensionLoader.startExtension(id);
+
+  expect(configurationRegistryUpdateConfigurationMock).toHaveBeenCalledWith('extensions.disabled', []);
 });
 
 test('Verify setExtensionsUpdates', async () => {
@@ -894,6 +940,9 @@ describe('setContextValue', async () => {
 describe('Removing extension by user', async () => {
   const ExtID = 'company.ext-id';
   test('sends telemetry w/o error when whens succeeds', async () => {
+    configurationRegistryGetConfigurationMock.mockReturnValue({
+      get: () => [],
+    });
     extensionLoader.removeExtension = vi.fn();
     await extensionLoader.removeExtensionPerUserRequest(ExtID);
     expect(extensionLoader.removeExtension).toBeCalledWith(ExtID);

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -284,9 +284,9 @@ export class ExtensionLoader {
 
   getDisabledExtensionIds(): string[] {
     return (
-      (this.configurationRegistry
+      this.configurationRegistry
         .getConfiguration(ExtensionLoaderSettings.SectionName)
-        .get(ExtensionLoaderSettings.Disabled) as string[]) || []
+        .get<string[]>(ExtensionLoaderSettings.Disabled, [])
     );
   }
 
@@ -715,7 +715,7 @@ export class ExtensionLoader {
 
         await this.activateExtension(extension, runtime);
       } else {
-        console.log('Not activating disabled extension (' + extension.id + ')');
+        console.log(`Extension (${extension.id}) not activated because it is disabled`);
       }
     } catch (err) {
       this.extensionState.set(extension.id, 'failed');

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -283,11 +283,9 @@ export class ExtensionLoader {
   }
 
   getDisabledExtensionIds(): string[] {
-    return (
-      this.configurationRegistry
-        .getConfiguration(ExtensionLoaderSettings.SectionName)
-        .get<string[]>(ExtensionLoaderSettings.Disabled, [])
-    );
+    return this.configurationRegistry
+      .getConfiguration(ExtensionLoaderSettings.SectionName)
+      .get<string[]>(ExtensionLoaderSettings.Disabled, []);
   }
 
   setDisabledExtensionIds(disabledExtensionIds: string[]): void {

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1571,9 +1571,9 @@ export class PluginSystem {
     });
 
     this.ipcHandle(
-      'extension-loader:deactivateExtension',
+      'extension-loader:stopExtension',
       async (_listener: Electron.IpcMainInvokeEvent, extensionId: string): Promise<void> => {
-        return this.extensionLoader.deactivateExtension(extensionId);
+        return this.extensionLoader.stopExtension(extensionId);
       },
     );
     this.ipcHandle(

--- a/packages/main/src/plugin/install/extension-installer.spec.ts
+++ b/packages/main/src/plugin/install/extension-installer.spec.ts
@@ -48,12 +48,14 @@ const listExtensionsMock = vi.fn();
 const loadExtensionMock = vi.fn();
 const analyzeExtensionMock = vi.fn();
 const loadExtensionsMock = vi.fn();
+const ensureExtensionsMock = vi.fn();
 const extensionLoader: ExtensionLoader = {
   getPluginsDirectory: getPluginsDirectoryMock,
   listExtensions: listExtensionsMock,
   loadExtension: loadExtensionMock,
   loadExtensions: loadExtensionsMock,
   analyzeExtension: analyzeExtensionMock,
+  ensureExtensionIsEnabled: ensureExtensionsMock,
 } as unknown as ExtensionLoader;
 
 const getImageConfigLabelsMock = vi.fn();
@@ -142,6 +144,8 @@ test('should install an image if labels are correct', async () => {
   } as AnalyzedExtension);
 
   await extensionInstaller.installFromImage(sendLog, sendError, sendEnd, imageToPull);
+
+  expect(ensureExtensionsMock).toHaveBeenCalled();
 
   expect(sendLog).toHaveBeenCalledWith(`Analyzing image ${imageToPull}...`);
   // expect no error

--- a/packages/main/src/plugin/install/extension-installer.ts
+++ b/packages/main/src/plugin/install/extension-installer.ts
@@ -325,6 +325,7 @@ export class ExtensionInstaller {
     }
 
     // load all extensions
+    analyzedExtensions.forEach(extension => this.extensionLoader.ensureExtensionIsEnabled(extension.id));
     await this.extensionLoader.loadExtensions(analyzedExtensions);
 
     sendEnd('Extension Successfully installed.');

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -1298,7 +1298,7 @@ export function initExposure(): void {
   });
 
   contextBridge.exposeInMainWorld('stopExtension', async (extensionId: string): Promise<void> => {
-    return ipcInvoke('extension-loader:deactivateExtension', extensionId);
+    return ipcInvoke('extension-loader:stopExtension', extensionId);
   });
 
   contextBridge.exposeInMainWorld('startExtension', async (extensionId: string): Promise<void> => {


### PR DESCRIPTION
### What does this PR do?

Disabled extensions should not start when you restart Podman Desktop.

Adds a new 'extensions.disabled' configuration property that stores an array with the ids of disabled extensions. If an extension is disabled it is read from disk but never activated.

To be able to only store/clear disabled extensions we need to know when the user is intentionally enabling or disabling an extension (vs the extension's normal start/stop with Podman Desktop). startExtension() already exists but stopExtension() redirected to deactivateExtension(), so I created a new stopExtension().

stopExtension() disables the extension, and both start and removeExtensionPerUserRequest (for uninstall/reinstall) make sure the extension is no longer disabled.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes #268.

### How to test this PR?

Disable a couple extensions and restart, make sure they're disabled.

Disable, uninstall, then reinstall and make sure extension is running.

- [x] Tests are covering the bug fix or the new feature