### PR TITLE
fix(Button): remove unused `hidden` property

### DIFF
--- a/packages/renderer/src/lib/ui/Button.spec.ts
+++ b/packages/renderer/src/lib/ui/Button.spec.ts
@@ -154,16 +154,6 @@ test('Check selected tab button styling', async () => {
   expect(button).toHaveClass('border-purple-500');
 });
 
-test('Check hidden button', async () => {
-  render(Button, { hidden: true });
-
-  // check that the button is in fact hidden
-  const button = screen.getByRole('button', { hidden: true });
-  expect(button).toBeInTheDocument();
-  expect(button).toHaveAttribute('hidden');
-  expect(button).not.toBeVisible();
-});
-
 test('Check icon button with fas prefix is visible', async () => {
   render(Button, { icon: faTrash });
 

--- a/packages/renderer/src/lib/ui/Button.svelte
+++ b/packages/renderer/src/lib/ui/Button.svelte
@@ -10,7 +10,6 @@ import Spinner from './Spinner.svelte';
 export let title: string | undefined = undefined;
 export let inProgress = false;
 export let disabled = false;
-export let hidden = false;
 export let type: ButtonType = 'primary';
 export let icon: any = undefined;
 export let selected: boolean | undefined = undefined;
@@ -72,8 +71,7 @@ $: {
   title="{title}"
   aria-label="{$$props['aria-label']}"
   on:click
-  disabled="{disabled || inProgress}"
-  hidden="{hidden}">
+  disabled="{disabled || inProgress}">
   {#if icon}
     <div
       class="flex flex-row p-0 m-0 bg-transparent justify-center items-center space-x-[4px]"


### PR DESCRIPTION
### What does this PR do?

Removing the `hidden` property of the button component.

- The `hidden` property is not used
- A component should not be responsible of hidding itself, parent should see https://github.com/containers/podman-desktop/issues/6896#issuecomment-2074781785 for details

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Related to https://github.com/containers/podman-desktop/issues/6896#issuecomment-2074781785

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
