### PR TITLE
fix: flaky test port availability 

### DIFF
--- a/packages/main/src/plugin/util/port.spec.ts
+++ b/packages/main/src/plugin/util/port.spec.ts
@@ -81,9 +81,10 @@ test.each(hosts)(
 );
 
 test('return first empty port, no port is used', async () => {
-  const freePort = await port.getFreePort(20000);
+  const start = 21000 + Math.floor(Math.random() * 100);
+  const freePort = await port.getFreePort(start);
 
-  expect(freePort).toBe(20000);
+  expect(freePort).toBe(start);
   expect(await port.isFreePort(freePort)).toBe(true);
 });
 


### PR DESCRIPTION
### What does this PR do?

The test was checking for port availability, but as the port was fixed and hardcoded, sometime it was interfering with other tests using the same port.

This PR change the port and add a random value between `0-100` to ensure the port will not conflict with other tests.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop/issues/7109

### How to test this PR?

- [ ] Tests are covering the bug fix or the new feature
