### PR TITLE
nit: table header checkbox

### DIFF
--- a/packages/renderer/src/lib/container/ContainerList.svelte
+++ b/packages/renderer/src/lib/container/ContainerList.svelte
@@ -472,7 +472,7 @@ function setStoppedFilter() {
       <thead class="sticky top-0 bg-charcoal-700 z-[2]">
         <tr class="h-7 uppercase text-xs text-gray-600">
           <th class="whitespace-nowrap w-5"></th>
-          <th class="px-2 w-5">
+          <th class="px-2 w-5 text-base">
             <Checkbox
               title="Toggle all"
               bind:checked="{selectedAllCheckboxes}"

--- a/packages/renderer/src/lib/table/Table.svelte
+++ b/packages/renderer/src/lib/table/Table.svelte
@@ -28,7 +28,8 @@ $: selectedItemsNumber = row.info.selectable
 
 // do we need to unselect all checkboxes if we don't have all items being selected ?
 $: selectedAllCheckboxes = row.info.selectable
-  ? data.filter(object => row.info.selectable?.(object)).every(object => object.selected)
+  ? data.filter(object => row.info.selectable?.(object)).every(object => object.selected) &&
+    data.filter(object => row.info.selectable?.(object)).length > 0
   : false;
 
 function toggleAll(checked: boolean) {
@@ -130,10 +131,11 @@ function setGridColumns() {
       role="row">
       <div class="whitespace-nowrap justify-self-start" role="columnheader"></div>
       {#if row.info.selectable}
-        <div class="whitespace-nowrap place-self-center" role="columnheader">
+        <div class="whitespace-nowrap place-self-center text-base" role="columnheader">
           <Checkbox
             title="Toggle all"
             bind:checked="{selectedAllCheckboxes}"
+            disabled="{!row.info.selectable || data.filter(object => row.info.selectable?.(object)).length === 0}"
             indeterminate="{selectedItemsNumber > 0 && !selectedAllCheckboxes}"
             on:click="{event => toggleAll(event.detail)}" />
         </div>


### PR DESCRIPTION
### What does this PR do?

Fixes two really minor nits:
- Some time ago we reduced the text size in table headers, and this inadvertently made the checkbox in the header smaller than the checkboxes in each row. This just makes the checkbox the same size.
- When there are no selectable items in a table (e.g. all images or volumes are in use), the checkbox in the header should be disabled, not selected.

### Screenshot / video of UI

Before:

<img width="140" alt="Screenshot 2024-05-06 at 5 00 06 PM" src="https://github.com/containers/podman-desktop/assets/19958075/88bdc8aa-0254-4f0c-a294-4664859b1da1">
<img width="140" alt="Screenshot 2024-05-06 at 5 00 13 PM" src="https://github.com/containers/podman-desktop/assets/19958075/d272afaa-a062-4f72-ad00-514fc3e35138">

After:

<img width="140" alt="Screenshot 2024-05-06 at 4 59 46 PM" src="https://github.com/containers/podman-desktop/assets/19958075/312cc293-8ed3-454c-ba1d-4ef216437ed0">
<img width="140" alt="Screenshot 2024-05-06 at 4 59 37 PM" src="https://github.com/containers/podman-desktop/assets/19958075/32c8ec72-d980-41f7-956b-176fbf013271">


### What issues does this PR fix or reference?

N/A

### How to test this PR?

Just look at various tables with some/all of the items in-use.