### PR TITLE
feat: add content theming color registry

### DIFF
--- a/packages/main/src/plugin/color-registry.spec.ts
+++ b/packages/main/src/plugin/color-registry.spec.ts
@@ -59,6 +59,10 @@ class TestColorRegistry extends ColorRegistry {
   initCardContent(): void {
     super.initCardContent();
   }
+
+  initContent(): void {
+    super.initContent();
+  }
 }
 
 const _onDidChangeConfiguration = new Emitter<IConfigurationChangeEvent>();
@@ -212,6 +216,24 @@ test('initCardContent', async () => {
   expect(spyOnRegisterColor.mock.calls[0][0]).toStrictEqual('card-bg');
   expect(spyOnRegisterColor.mock.calls[0][1].light).toBe(colorPalette.gray[300]);
   expect(spyOnRegisterColor.mock.calls[0][1].dark).toBe(colorPalette.charcoal[800]);
+});
+
+test('initContent', async () => {
+  // mock the registerColor
+  const spyOnRegisterColor = vi.spyOn(colorRegistry, 'registerColor');
+  spyOnRegisterColor.mockReturnValue(undefined);
+
+  colorRegistry.initContent();
+
+  expect(spyOnRegisterColor).toHaveBeenCalled();
+
+  // at least 10 times
+  expect(spyOnRegisterColor.mock.calls.length).toBeGreaterThanOrEqual(10);
+
+  // check the first call
+  expect(spyOnRegisterColor.mock.calls[0][0]).toStrictEqual('content-breadcrumb');
+  expect(spyOnRegisterColor.mock.calls[0][1].light).toBe(colorPalette.purple[900]);
+  expect(spyOnRegisterColor.mock.calls[0][1].dark).toBe(colorPalette.gray[600]);
 });
 
 describe('registerColor', () => {

--- a/packages/main/src/plugin/color-registry.ts
+++ b/packages/main/src/plugin/color-registry.ts
@@ -227,6 +227,7 @@ export class ColorRegistry {
     this.initGlobalNav();
     this.initSecondaryNav();
     this.initTitlebar();
+    this.initContent();
     this.initInvertContent();
     this.initCardContent();
     this.initInputBox();
@@ -408,6 +409,59 @@ export class ColorRegistry {
     this.registerColor(`${invCt}info-icon`, {
       dark: colorPalette.purple[500],
       light: colorPalette.purple[600],
+    });
+  }
+
+  protected initContent(): void {
+    const ct = 'content-';
+    this.registerColor(`${ct}breadcrumb`, {
+      dark: colorPalette.gray[600],
+      light: colorPalette.purple[900],
+    });
+
+    this.registerColor(`${ct}breadcrumb-2`, {
+      dark: colorPalette.purple[400],
+      light: colorPalette.purple[600],
+    });
+
+    this.registerColor(`${ct}header`, {
+      dark: colorPalette.white,
+      light: colorPalette.charcoal[900],
+    });
+
+    this.registerColor(`${ct}header-icon`, {
+      dark: colorPalette.gray[600],
+      light: colorPalette.gray[300],
+    });
+
+    this.registerColor(`${ct}card-header-text`, {
+      dark: colorPalette.gray[100],
+      light: colorPalette.charcoal[900],
+    });
+
+    this.registerColor(`${ct}card-bg`, {
+      dark: colorPalette.charcoal[800],
+      light: colorPalette.gray[50],
+    });
+
+    this.registerColor(`${ct}card-text`, {
+      dark: colorPalette.gray[400],
+      light: colorPalette.purple[900],
+    });
+
+    this.registerColor(`${ct}card-inset-bg`, {
+      dark: colorPalette.charcoal[900],
+      light: colorPalette.dustypurple[200],
+    });
+
+    this.registerColor(`${ct}bg`, {
+      dark: colorPalette.charcoal[700],
+      light: colorPalette.gray[300],
+    });
+
+    this.registerColor(`${ct}card-icon`, {
+      dark: colorPalette.gray[400],
+      light: colorPalette.purple[900],
     });
   }
 

--- a/packages/main/src/plugin/color-registry.ts
+++ b/packages/main/src/plugin/color-registry.ts
@@ -431,7 +431,7 @@ export class ColorRegistry {
 
     this.registerColor(`${ct}header-icon`, {
       dark: colorPalette.gray[600],
-      light: colorPalette.gray[300],
+      light: colorPalette.purple[700],
     });
 
     this.registerColor(`${ct}card-header-text`, {

--- a/packages/main/src/plugin/color-registry.ts
+++ b/packages/main/src/plugin/color-registry.ts
@@ -463,6 +463,11 @@ export class ColorRegistry {
       dark: colorPalette.gray[400],
       light: colorPalette.purple[900],
     });
+
+    this.registerColor(`${ct}divider`, {
+      dark: colorPalette.charcoal[400],
+      light: colorPalette.gray[700],
+    });
   }
 
   // input boxes


### PR DESCRIPTION
### What does this PR do?

Define content theming colors registry, with colors defined in https://github.com/containers/podman-desktop/issues/6929#issuecomment-2092726542


### What issues does this PR fix or reference?

Part of #6929 

- [x] Tests are covering the bug fix or the new feature
