### PR TITLE
chore: Manage EnableNodeCliInspectArguments Fuse Enablement based on ENV: ELECTRON_ENABLE_INSPECT

### DIFF
--- a/.electron-builder.config.cjs
+++ b/.electron-builder.config.cjs
@@ -52,11 +52,16 @@ async function addElectronFuses(context) {
 
   const electronBinaryPath = path.join(context.appOutDir, `${executableName}${ext}`);
 
+  let electronEnableInspect = false;
+  if (process.env.ELECTRON_ENABLE_INSPECT === 'true') {
+    electronEnableInspect = true;
+  }
+
   await flipFuses(electronBinaryPath, {
     version: FuseVersion.V1,
     [FuseV1Options.RunAsNode]: false,
     [FuseV1Options.EnableNodeOptionsEnvironmentVariable]: false,
-    [FuseV1Options.EnableNodeCliInspectArguments]: false,
+    [FuseV1Options.EnableNodeCliInspectArguments]: electronEnableInspect,
   });
 }
 


### PR DESCRIPTION
### What does this PR do?

This PR introduces an ENV to control enable / disable (default) of `EnableNodeCliInspectArguments` electron fuse; which is required to launch the built app through Playwright 

### What issues does this PR fix or reference?

Fixes #4127 

### How to test this PR?

You can now build the app with `ELECTRON_ENABLE_INSPECT=true yarn compile` and then check the fuses with `npx @electron/fuses read --app dist/linux-unpacked/podman-desktop`

The output will show `EnableNodeCliInspectArguments is Enabled`

If we build with default target `yarn compile` we can check the fuses and ensure we can see `EnableNodeCliInspectArguments is Disabled`

Please check https://github.com/containers/podman-desktop/issues/4127#issuecomment-2077276523
