### PR TITLE
feat: allow to select a folder using the fileComponent

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.spec.ts
@@ -166,6 +166,25 @@ test('Expect an input button with Browse as placeholder when record is type stri
   expect(input.textContent).toBe('Browse ...');
 });
 
+test('Expect an input button with Browse as placeholder when record is type string and format folder', async () => {
+  const record: IConfigurationPropertyRecordedSchema = {
+    title: 'record',
+    parentId: 'parent.record',
+    placeholder: 'Example: text',
+    description: 'record-description',
+    type: 'string',
+    format: 'folder',
+  };
+  await awaitRender(record, {});
+  const readOnlyInput = screen.getByLabelText('record-description');
+  expect(readOnlyInput).toBeInTheDocument();
+  expect(readOnlyInput instanceof HTMLInputElement).toBe(true);
+  expect((readOnlyInput as HTMLInputElement).placeholder).toBe(record.placeholder);
+  const input = screen.getByLabelText('button-record-description');
+  expect(input).toBeInTheDocument();
+  expect(input.textContent).toBe('Browse ...');
+});
+
 test('Expect a select when record is type string and has enum values', async () => {
   const record: IConfigurationPropertyRecordedSchema = {
     id: 'record',

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
@@ -132,7 +132,7 @@ async function onChange(recordId: string, value: boolean | string | number): Pro
         invalidRecord="{invalidRecord}" />
     {/if}
   {:else if record.type === 'string' && (typeof recordValue === 'string' || recordValue === undefined)}
-    {#if record.format === 'file'}
+    {#if record.format === 'file' || record.format === 'folder'}
       <FileItem record="{record}" value="{recordValue || ''}" onChange="{onChange}" />
     {:else if record.enum && record.enum.length > 0}
       <EnumItem record="{record}" value="{recordValue}" onChange="{onChange}" />

--- a/packages/renderer/src/lib/preferences/item-formats/FileItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/item-formats/FileItem.spec.ts
@@ -48,7 +48,7 @@ test('Ensure HTMLInputElement', async () => {
   expect(input instanceof HTMLInputElement).toBe(true);
 });
 
-test('Ensure clicking on Browser invoke openDialog', async () => {
+test('Ensure clicking on Browser invoke openDialog with default selector', async () => {
   openDialogMock.mockResolvedValue([]);
   const record: IConfigurationPropertyRecordedSchema = {
     id: 'record',
@@ -64,5 +64,30 @@ test('Ensure clicking on Browser invoke openDialog', async () => {
   expect(input).toBeInTheDocument();
   await userEvent.click(input);
 
-  expect(openDialogMock).toBeCalled();
+  expect(openDialogMock).toBeCalledWith({
+    title: 'Select record-description',
+    selectors: ['openFile'],
+  });
+});
+
+test('Ensure clicking on Browser invoke openDialog with corresponding directory selector', async () => {
+  openDialogMock.mockResolvedValue([]);
+  const record: IConfigurationPropertyRecordedSchema = {
+    id: 'record',
+    title: 'record',
+    parentId: 'parent.record',
+    description: 'record-description',
+    type: 'string',
+    format: 'folder',
+  };
+
+  render(FileItem, { record, value: '' });
+  const input = screen.getByRole('button', { name: `button-${record.description}` });
+  expect(input).toBeInTheDocument();
+  await userEvent.click(input);
+
+  expect(openDialogMock).toBeCalledWith({
+    title: 'Select record-description',
+    selectors: ['openDirectory'],
+  });
 });

--- a/packages/renderer/src/lib/preferences/item-formats/FileItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/FileItem.svelte
@@ -11,7 +11,10 @@ let invalidEntry = false;
 
 async function selectFilePath() {
   invalidEntry = false;
-  const filePaths = await window.openDialog({ title: `Select ${record.description}` });
+  const filePaths = await window.openDialog({
+    title: `Select ${record.description}`,
+    selectors: record.format === 'folder' ? ['openDirectory'] : ['openFile'],
+  });
   if (record.id && filePaths && filePaths.length === 1) {
     onChange(record.id, filePaths[0]).catch((_: unknown) => (invalidEntry = true));
   }


### PR DESCRIPTION
### What does this PR do?

It extends the fileComponent to support selecting a folder instead of a file.
It can be used by a setting, like https://github.com/containers/podman-desktop-extension-ai-lab/pull/1069

### Screenshot / video of UI

![select_folder_setting](https://github.com/containers/podman-desktop/assets/49404737/3aa38803-b033-40de-b74a-e83437105000)

### What issues does this PR fix or reference?

it is needed by https://github.com/containers/podman-desktop-extension-ai-lab/pull/1069

### How to test this PR?

1. run with https://github.com/containers/podman-desktop-extension-ai-lab/pull/1069
2 run tests

- [x] Tests are covering the bug fix or the new feature
