### PR TITLE
chore: number input

### DIFF
--- a/packages/renderer/src/lib/image/RunImage.svelte
+++ b/packages/renderer/src/lib/image/RunImage.svelte
@@ -17,6 +17,7 @@ import type { ContainerInfoUI } from '../container/ContainerInfoUI';
 import { splitSpacesHandlingDoubleQuotes } from '../string/string';
 import ErrorMessage from '../ui/ErrorMessage.svelte';
 import FormPage from '../ui/FormPage.svelte';
+import NumberInput from '../ui/NumberInput.svelte';
 import Tab from '../ui/Tab.svelte';
 import type { ImageInfoUI } from './ImageInfoUI';
 
@@ -847,12 +848,10 @@ async function assertAllPortAreValid(): Promise<void> {
                   <span
                     class="text-sm w-28 inline-block align-middle whitespace-nowrap text-gray-700"
                     title="Number of times to retry before giving up.">Retries:</span>
-                  <input
-                    type="number"
-                    min="0"
+                  <NumberInput
+                    minimum="{0}"
                     bind:value="{restartPolicyMaxRetryCount}"
-                    placeholder="Number of times to retry before giving up"
-                    class="w-full p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700"
+                    class="w-full p-2"
                     disabled="{restartPolicyName !== 'on-failure'}" />
                 </div>
               </div>

--- a/packages/renderer/src/lib/image/RunImage.svelte
+++ b/packages/renderer/src/lib/image/RunImage.svelte
@@ -851,7 +851,7 @@ async function assertAllPortAreValid(): Promise<void> {
                   <NumberInput
                     minimum="{0}"
                     bind:value="{restartPolicyMaxRetryCount}"
-                    class="w-full p-2"
+                    class="w-24 p-2"
                     disabled="{restartPolicyName !== 'on-failure'}" />
                 </div>
               </div>

--- a/packages/renderer/src/lib/preferences/item-formats/NumberItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/item-formats/NumberItem.spec.ts
@@ -25,28 +25,28 @@ import { expect, test } from 'vitest';
 import type { IConfigurationPropertyRecordedSchema } from '../../../../../main/src/plugin/configuration-registry';
 import NumberItem from './NumberItem.svelte';
 
-test('Expect tooltip if value input is NaN', async () => {
+test('Expect tooltip if value input is invalid', async () => {
   const record: IConfigurationPropertyRecordedSchema = {
     id: 'record',
     title: 'record',
     parentId: 'parent.record',
     description: 'record-description',
     type: 'number',
-    minimum: 1,
+    minimum: 10,
     maximum: 34,
   };
-  const value = 2;
+  const value = 12;
   render(NumberItem, { record, value });
 
   const input = screen.getByLabelText('record-description');
   expect(input).toBeInTheDocument();
   await userEvent.click(input);
   await userEvent.clear(input);
-  await userEvent.keyboard('unknown');
+  await userEvent.keyboard('5');
 
   const tooltip = screen.getByLabelText('tooltip');
   expect(tooltip).toBeInTheDocument();
-  expect(tooltip.textContent).toContain('Expecting a number');
+  expect(tooltip.textContent).toContain('The value cannot be less than 10');
 });
 
 test('Expect decrement button disabled if value is less than minimum', async () => {

--- a/packages/renderer/src/lib/preferences/item-formats/NumberItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/NumberItem.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { Tooltip } from '@podman-desktop/ui-svelte';
+
 import type { IConfigurationPropertyRecordedSchema } from '../../../../../main/src/plugin/configuration-registry';
 import NumberInput from '../../ui/NumberInput.svelte';
 

--- a/packages/renderer/src/lib/preferences/item-formats/NumberItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/NumberItem.svelte
@@ -1,10 +1,7 @@
 <script lang="ts">
 import { Tooltip } from '@podman-desktop/ui-svelte';
-import { onMount } from 'svelte';
-
 import type { IConfigurationPropertyRecordedSchema } from '../../../../../main/src/plugin/configuration-registry';
-import { uncertainStringToNumber } from '../Util';
-import { checkNumericValueValid } from './NumberItemUtils';
+import NumberInput from '../../ui/NumberInput.svelte';
 
 export let record: IConfigurationPropertyRecordedSchema;
 export let value: number | undefined;
@@ -13,132 +10,40 @@ export let invalidRecord = (_error: string) => {};
 
 let valueUpdateTimeout: NodeJS.Timeout;
 
-let recordValue: number;
+let recordValue: number = value || 0;
+let lastValue: number;
+let error: string | undefined = undefined;
+
 $: recordValue = value || 0;
 
-let numberInputErrorMessage = '';
-let numberInputInvalid = false;
-
-onMount(() => {
-  if (value && assertNumericValueIsValid(value)) {
-    recordValue = value;
-  }
-});
-
-function onInput(event: Event) {
-  // clear the timeout so if there was an old call to onChange pending is deleted. We will create a new one soon
-  clearTimeout(valueUpdateTimeout);
-  const target = event.currentTarget as HTMLInputElement;
-  // convert string to number
-  const _value: number = uncertainStringToNumber(target.value);
-  // if number is not valid (NaN), return
-  if (!assertNumericValueIsValid(_value)) {
-    invalidRecord(numberInputErrorMessage);
-    return;
-  }
-  recordValue = _value;
+$: if (recordValue) {
+  const newValue = Number(recordValue);
   // if the value is different from the original update
-  if (record.id && recordValue !== value) {
-    valueUpdateTimeout = setTimeout(() => onChange(record.id!, recordValue), 500);
+  if (record.id && newValue !== lastValue && !error) {
+    // clear the timeout so if there was an old call to onChange pending is deleted. We will create a new one soon
+    clearTimeout(valueUpdateTimeout);
+
+    valueUpdateTimeout = setTimeout(() => {
+      onChange(record.id!, newValue);
+      lastValue = newValue;
+    }, 500);
   }
 }
 
-function onNumberInputKeyPress(event: any) {
-  // if the key is not a number skip it
-  if (isNaN(Number(event.key))) {
-    event.preventDefault();
-  }
-}
-
-function onDecrement(
-  e: MouseEvent & {
-    currentTarget: EventTarget & HTMLButtonElement;
-  },
-) {
-  // clear the timeout so if there was an old call to onChange pending is deleted. We will create a new one soon
-  clearTimeout(valueUpdateTimeout);
-  // if we can decrement
-  if (record.id && canDecrement(recordValue)) {
-    // update record
-    recordValue -= 1;
-    // verify it is valid
-    // it may happen that the value is greater than min but also greater than max so we need to check if we can update it
-    if (assertNumericValueIsValid(recordValue)) {
-      valueUpdateTimeout = setTimeout(() => onChange(record.id!, recordValue), 500);
-    }
-  }
-
-  e.preventDefault();
-}
-
-function onIncrement(
-  e: MouseEvent & {
-    currentTarget: EventTarget & HTMLButtonElement;
-  },
-) {
-  // clear the timeout so if there was an old call to onChange pending is deleted. We will create a new one soon
-  clearTimeout(valueUpdateTimeout);
-  // if we can increment
-  if (record.id && canIncrement(recordValue)) {
-    // update record
-    recordValue += 1;
-    // verify it is valid
-    // it may happen that the value is less than max but also less than min so we need to check if we can update it
-    if (assertNumericValueIsValid(recordValue)) {
-      valueUpdateTimeout = setTimeout(() => onChange(record.id!, recordValue), 500);
-    }
-  }
-  e.preventDefault();
-}
-
-function canDecrement(value: number) {
-  return !record.minimum || value > record.minimum;
-}
-
-function assertNumericValueIsValid(value: number): boolean {
-  const numericValue = checkNumericValueValid(record, value);
-  numberInputInvalid = !numericValue.valid;
-  numberInputErrorMessage = numericValue.error || '';
-  return numericValue.valid;
-}
-
-function canIncrement(value: number) {
-  return !record.maximum || (typeof record.maximum === 'number' && value < record.maximum);
+$: if (error) {
+  invalidRecord(error);
 }
 </script>
 
-<div
-  class="flex flex-row rounded-sm bg-zinc-700 text-sm divide-x divide-charcoal-800 w-24 border-b"
-  class:border-violet-500="{!numberInputInvalid}"
-  class:border-red-500="{numberInputInvalid}">
-  <button
-    data-action="decrement"
-    aria-label="decrement"
-    on:click="{onDecrement}"
-    disabled="{!canDecrement(recordValue)}"
-    class="w-11 text-white {!canDecrement(recordValue)
-      ? 'bg-charcoal-600 text-charcoal-100 border-t border-l border-charcoal-800'
-      : 'hover:text-gray-900 hover:bg-gray-700'} cursor-pointer outline-none">
-    <span class="m-auto font-thin">−</span>
-  </button>
-  <Tooltip topLeft tip="{numberInputErrorMessage}">
-    <input
-      type="text"
-      class="w-[50px] outline-none focus:outline-none text-white text-center text-sm py-0.5 bg-transparent"
-      name="{record.id}"
-      bind:value="{recordValue}"
-      on:keypress="{event => onNumberInputKeyPress(event)}"
-      on:input="{onInput}"
-      aria-label="{record.description}" />
-  </Tooltip>
-  <button
-    data-action="increment"
-    aria-label="increment"
-    on:click="{onIncrement}"
-    disabled="{!canIncrement(recordValue)}"
-    class="w-11 text-white {!canIncrement(recordValue)
-      ? 'bg-charcoal-600 text-charcoal-100 border-t border-l border-charcoal-800'
-      : 'hover:text-gray-900 hover:bg-gray-700'} cursor-pointer outline-none">
-    <span class="m-auto font-thin">+</span>
-  </button>
-</div>
+<Tooltip topLeft tip="{error}">
+  <NumberInput
+    class="w-24"
+    name="{record.id}"
+    bind:value="{recordValue}"
+    bind:error="{error}"
+    aria-label="{record.description}"
+    minimum="{record.minimum}"
+    maximum="{record.maximum && typeof record.maximum === 'number' ? record.maximum : undefined}"
+    showError="{false}">
+  </NumberInput>
+</Tooltip>

--- a/packages/renderer/src/lib/ui/NumberInput.spec.ts
+++ b/packages/renderer/src/lib/ui/NumberInput.spec.ts
@@ -1,0 +1,135 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { expect, test } from 'vitest';
+
+import NumberInput from './NumberInput.svelte';
+
+function renderInput(name: string, value: number, disabled?: boolean, minimum?: number, maximum?: number): void {
+  render(NumberInput, {
+    name: name,
+    value: value,
+    disabled: disabled,
+    minimum: minimum,
+    maximum: maximum,
+  });
+}
+
+test('Expect basic styling', async () => {
+  renderInput('test', 5);
+
+  const input = screen.getByRole('textbox');
+  expect(input).toBeInTheDocument();
+
+  const decrement = screen.getByLabelText('decrement');
+  expect(decrement).toBeInTheDocument();
+  expect(decrement).toHaveClass('pr-0.5');
+  expect(decrement).toHaveClass('text-[var(--pd-input-field-stroke)]');
+  expect(decrement).toHaveClass('group-hover:text-[var(--pd-input-field-hover-stroke)]');
+
+  const increment = screen.getByLabelText('increment');
+  expect(increment).toBeInTheDocument();
+  expect(increment).toHaveClass('pl-0.5');
+  expect(increment).toHaveClass('text-[var(--pd-input-field-stroke)]');
+  expect(increment).toHaveClass('group-hover:text-[var(--pd-input-field-hover-stroke)]');
+});
+
+test('Expect disabled styling', async () => {
+  renderInput('test', 5, true);
+
+  const input = screen.getByRole('textbox');
+  expect(input).toBeInTheDocument();
+
+  const decrement = screen.getByLabelText('decrement');
+  expect(decrement).toBeInTheDocument();
+  expect(decrement).toHaveClass('pr-0.5');
+  expect(decrement).toHaveClass('text-[var(--pd-input-field-disabled-text)]');
+
+  const increment = screen.getByLabelText('increment');
+  expect(increment).toBeInTheDocument();
+  expect(increment).toHaveClass('pl-0.5');
+  expect(increment).toHaveClass('text-[var(--pd-input-field-disabled-text)]');
+});
+
+test('Expect decrement works', async () => {
+  renderInput('test', 5);
+
+  const input = screen.getByRole('textbox');
+  expect(input).toBeInTheDocument();
+  expect(input).toHaveValue('5');
+
+  const decrement = screen.getByLabelText('decrement');
+  expect(decrement).toBeInTheDocument();
+
+  await userEvent.click(decrement);
+
+  expect(input).toHaveValue('4');
+});
+
+test('Expect minimum value works', async () => {
+  renderInput('test', 11, false, 10, 100);
+
+  const input = screen.getByRole('textbox');
+  expect(input).toBeInTheDocument();
+  expect(input).toHaveValue('11');
+
+  const decrement = screen.getByLabelText('decrement');
+  expect(decrement).toBeInTheDocument();
+  expect(decrement).toBeEnabled();
+
+  await userEvent.click(decrement);
+
+  expect(decrement).toBeDisabled();
+});
+
+test('Expect increment works', async () => {
+  renderInput('test', 5);
+
+  const input = screen.getByRole('textbox');
+  expect(input).toBeInTheDocument();
+  expect(input).toHaveValue('5');
+
+  const increment = screen.getByLabelText('increment');
+  expect(increment).toBeInTheDocument();
+
+  await userEvent.click(increment);
+
+  expect(input).toHaveValue('6');
+});
+
+test('Expect maximum value works', async () => {
+  renderInput('test', 99, false, 10, 100);
+
+  const input = screen.getByRole('textbox');
+  expect(input).toBeInTheDocument();
+  expect(input).toHaveValue('99');
+
+  const increment = screen.getByLabelText('increment');
+  expect(increment).toBeInTheDocument();
+  expect(increment).toBeEnabled();
+
+  await userEvent.click(increment);
+
+  expect(increment).toBeDisabled();
+});

--- a/packages/renderer/src/lib/ui/NumberInput.svelte
+++ b/packages/renderer/src/lib/ui/NumberInput.svelte
@@ -13,20 +13,20 @@ export let showError: boolean = true;
 let minimumEnabled: boolean;
 let maximumEnabled: boolean;
 
-$: if (value) {
+$: if (value !== undefined || disabled) {
   validateNumber();
 }
 
 function validateNumber() {
-  if (maximum && value > maximum) {
+  if (maximum !== undefined && value > maximum) {
     error = `The value cannot be greater than ${maximum}`;
-  } else if (minimum && value < minimum) {
+  } else if (minimum !== undefined && value < minimum) {
     error = `The value cannot be less than ${minimum}`;
   } else {
     error = undefined;
   }
-  minimumEnabled = !disabled && (!minimum || minimum < value);
-  maximumEnabled = !disabled && (!maximum || maximum > value);
+  minimumEnabled = !disabled && (minimum === undefined || minimum < value);
+  maximumEnabled = !disabled && (maximum === undefined || maximum > value);
 }
 
 function onKeyPress(event: any) {

--- a/packages/renderer/src/lib/ui/NumberInput.svelte
+++ b/packages/renderer/src/lib/ui/NumberInput.svelte
@@ -1,0 +1,80 @@
+<script lang="ts">
+import { Input } from '@podman-desktop/ui-svelte';
+
+export let name: string | undefined = undefined;
+export let value: number;
+export let required: boolean = false;
+export let disabled: boolean = false;
+export let minimum: number | undefined = undefined;
+export let maximum: number | undefined = undefined;
+export let error: string | undefined = undefined;
+export let showError: boolean = true;
+
+let minimumEnabled: boolean;
+let maximumEnabled: boolean;
+
+$: if (value) {
+  validateNumber();
+}
+
+function validateNumber() {
+  if (maximum && value > maximum) {
+    error = `The value cannot be greater than ${maximum}`;
+  } else if (minimum && value < minimum) {
+    error = `The value cannot be less than ${minimum}`;
+  } else {
+    error = undefined;
+  }
+  minimumEnabled = !disabled && (!minimum || minimum < value);
+  maximumEnabled = !disabled && (!maximum || maximum > value);
+}
+
+function onKeyPress(event: any) {
+  if (isNaN(Number(event.key))) {
+    event.preventDefault();
+  }
+}
+
+function onDecrement() {
+  value = Number(value) - 1;
+}
+
+function onIncrement() {
+  value = Number(value) + 1;
+}
+</script>
+
+<Input
+  class="{$$props.class || ''}"
+  inputClass="text-center"
+  name="{name}"
+  bind:value="{value}"
+  on:keypress="{event => onKeyPress(event)}"
+  on:input
+  showError="{showError}"
+  error="{error}"
+  disabled="{disabled}"
+  required="{required}"
+  aria-label="{$$props['aria-label']}"
+  aria-invalid="{$$props['aria-invalid']}">
+  <button
+    class="pr-0.5"
+    class:text-[var(--pd-input-field-stroke)]="{minimumEnabled}"
+    class:text-[var(--pd-input-field-disabled-text)]="{!minimumEnabled}"
+    class:group-hover:text-[var(--pd-input-field-hover-stroke)]="{minimumEnabled}"
+    data-action="decrement"
+    aria-label="decrement"
+    on:click="{onDecrement}"
+    disabled="{!minimumEnabled}"
+    slot="left">-</button>
+  <button
+    class="pl-0.5"
+    class:text-[var(--pd-input-field-stroke)]="{maximumEnabled}"
+    class:text-[var(--pd-input-field-disabled-text)]="{!maximumEnabled}"
+    class:group-hover:text-[var(--pd-input-field-hover-stroke)]="{maximumEnabled}"
+    data-action="increment"
+    aria-label="increment"
+    on:click="{onIncrement}"
+    disabled="{!maximumEnabled}"
+    slot="right">+</button>
+</Input>

--- a/packages/ui/src/lib/input/Input.spec.ts
+++ b/packages/ui/src/lib/input/Input.spec.ts
@@ -33,6 +33,7 @@ function renderInput(
   clearable?: boolean,
   error?: string,
   onClick?: any,
+  inputClass?: string,
 ): void {
   render(Input, {
     value: value,
@@ -42,6 +43,7 @@ function renderInput(
     clearable: clearable,
     error: error,
     onClick: onClick,
+    inputClass: inputClass,
   });
 }
 
@@ -153,4 +155,14 @@ test('Expect basic error styling', async () => {
 
   const err = screen.getByText(error);
   expect(err).toBeInTheDocument();
+});
+
+test('Expect inputClass styling', async () => {
+  const value = 'test';
+  const thisClass = 'this-class';
+  renderInput(value, value, false, false, true, undefined, thisClass);
+
+  const element = screen.getByRole('textbox');
+  expect(element).toBeInTheDocument();
+  expect(element).toHaveClass(thisClass);
 });

--- a/packages/ui/src/lib/input/Input.spec.ts
+++ b/packages/ui/src/lib/input/Input.spec.ts
@@ -54,7 +54,7 @@ test('Expect basic styling', async () => {
   const element = screen.getByPlaceholderText(value);
   expect(element).toBeInTheDocument();
   expect(element).toHaveClass('grow');
-  expect(element).toHaveClass('px-1');
+  expect(element).toHaveClass('px-0.5');
   expect(element).toHaveClass('outline-0');
   expect(element).toHaveClass('bg-[var(--pd-input-field-bg)]');
   expect(element).toHaveClass('text-sm');
@@ -80,7 +80,7 @@ test('Expect basic readonly styling', async () => {
   const element = screen.getByPlaceholderText(value);
   expect(element).toBeInTheDocument();
   expect(element).toHaveClass('grow');
-  expect(element).toHaveClass('px-1');
+  expect(element).toHaveClass('px-0.5');
   expect(element).toHaveClass('outline-0');
   expect(element).toHaveClass('bg-[var(--pd-input-field-bg)]');
   expect(element).toHaveClass('text-sm');
@@ -108,7 +108,7 @@ test('Expect basic disabled styling', async () => {
   const element = screen.getByPlaceholderText(value);
   expect(element).toBeInTheDocument();
   expect(element).toHaveClass('grow');
-  expect(element).toHaveClass('px-1');
+  expect(element).toHaveClass('px-0.5');
   expect(element).toHaveClass('outline-0');
   expect(element).toHaveClass('bg-[var(--pd-input-field-bg)]');
   expect(element).toHaveClass('text-sm');
@@ -160,7 +160,7 @@ test('Expect basic error styling', async () => {
 test('Expect inputClass styling', async () => {
   const value = 'test';
   const thisClass = 'this-class';
-  renderInput(value, value, false, false, true, undefined, thisClass);
+  renderInput(value, value, false, false, true, undefined, undefined, thisClass);
 
   const element = screen.getByRole('textbox');
   expect(element).toBeInTheDocument();

--- a/packages/ui/src/lib/input/Input.svelte
+++ b/packages/ui/src/lib/input/Input.svelte
@@ -6,12 +6,14 @@ import Fa from 'svelte-fa';
 export let placeholder: string | undefined = undefined;
 export let id: string | undefined = undefined;
 export let name: string | undefined = undefined;
-export let value: string | undefined = undefined;
+export let value: string | number | undefined = undefined;
 export let readonly: boolean = false;
 export let required: boolean = false;
 export let clearable: boolean = false;
 export let disabled: boolean = false;
 export let error: string | undefined = undefined;
+export let inputClass: string | undefined = undefined;
+export let showError: boolean = true;
 
 export let element: HTMLInputElement | undefined = undefined;
 
@@ -51,7 +53,9 @@ async function onClear(): Promise<void> {
     <input
       bind:this="{element}"
       on:input
-      class="grow px-1 outline-0 text-sm bg-[var(--pd-input-field-bg)] placeholder:text-[color:var(--pd-input-field-placeholder-text)] overflow-hidden"
+      on:keypress
+      class="grow px-0.5 outline-0 text-sm bg-[var(--pd-input-field-bg)] placeholder:text-[color:var(--pd-input-field-placeholder-text)] overflow-hidden {inputClass ||
+        ''}"
       class:text-[color:var(--pd-input-field-focused-text)]="{!disabled}"
       class:text-[color:var(--pd-input-field-disabled-text)]="{disabled}"
       class:group-hover:bg-[var(--pd-input-field-hover-bg)]="{enabled}"
@@ -67,14 +71,14 @@ async function onClear(): Promise<void> {
       aria-label="{$$props['aria-label']}"
       aria-invalid="{$$props['aria-invalid']}"
       bind:value="{value}" />
-    {#if error}
-      <span class="px-1 text-[color:var(--pd-input-field-error-text)]" aria-label="error">
+    {#if error && showError}
+      <span class="px-0.5 text-[color:var(--pd-input-field-error-text)]" aria-label="error">
         <Fa icon="{faCircleExclamation}" />
       </span>
     {/if}
     {#if clearable}
       <button
-        class="px-1 cursor-pointer text-[color:var(--pd-input-field-icon)] group-hover:text-[color:var(--pd-input-field-hover-icon)] group-focus-within:text-[color:var(--pd-input-field-focused-icon)]"
+        class="px-0.5 cursor-pointer text-[color:var(--pd-input-field-icon)] group-hover:text-[color:var(--pd-input-field-hover-icon)] group-focus-within:text-[color:var(--pd-input-field-focused-icon)]"
         class:hidden="{!value || readonly || disabled}"
         aria-label="clear"
         on:click="{onClear}">
@@ -83,7 +87,7 @@ async function onClear(): Promise<void> {
     {/if}
     <slot name="right" />
   </div>
-  {#if error && error.length > 0}
+  {#if error && error.length > 0 && showError}
     <span class="text-sm text-[color:var(--pd-input-field-error-text)]">{error}</span>
   {/if}
 </div>


### PR DESCRIPTION
### What does this PR do?

The current number editor in Settings > Preferences works, but it has a few drawbacks:
 - doesn't match current design, and would need updating to light mode.
 - periodically has some odd 'resets' to a previous number. (this isn't just the input - figured out later and opened #7142)
 - has two error modes - underline for below minimum, icon to the left for invalid value.
 - after invalid entry (e.g. below minimum), incrementing does a string add vs numerical.
 - not easily reusable for editing numbers in other places.

This PR creates a NumberInput component that is just an Input with +/- buttons. Key input is restricted to numbers, and increment/decrement are used to disable +/- appropriately. If the user manually enters a number out of bounds, the Input's error is used to display a short warning.

Input required some minor changes to support this:
 - allow inputClass in order to center numbers in the textbox.
 - passthrough of key events, in order to block non-numerical entry.
 - boolean to block showing the error in a separate span. Although this is the design for inputs, it felt really out of place in preferences.
 - reduce padding slightly - it didn't matter in large Inputs, but number inputs tend to be smaller and extraneous padding was obvious.

New component is used in Settings > Preferences and max retry count for running an image.

### Screenshot / video of UI

Before:

https://github.com/containers/podman-desktop/assets/19958075/697badfb-9871-4e18-87c6-bc92edf2ebe6

After:

https://github.com/containers/podman-desktop/assets/19958075/b9755ced-6367-4a2f-a114-2e2e381914be

### What issues does this PR fix or reference?

Another part of #3234.

### How to test this PR?

Tests added. NumberItem test had to be changed since only numerical inputs work now.

Try changing some preferences. Be aware of #7142 (separate issue) if the value resets.

- [x] Tests are covering the bug fix or the new feature