### PR TITLE
feat: add tip slot to customize tip content

### DIFF
--- a/packages/renderer/src/lib/deployments/DeploymentColumnConditions.svelte
+++ b/packages/renderer/src/lib/deployments/DeploymentColumnConditions.svelte
@@ -27,7 +27,7 @@ function getConditionColour(type: string): string {
 <div class="flex flex-row gap-1">
   {#each object.conditions as condition}
     <Tooltip bottom>
-      <svelte:fragment slot="item">
+      <svelte:fragment slot="content">
         <div class="flex flex-row bg-charcoal-500 items-center p-1 rounded-md text-xs text-gray-500">
           <div class="w-2 h-2 {getConditionColour(condition.type)} rounded-full mr-1"></div>
           {condition.type}

--- a/packages/renderer/src/lib/deployments/DeploymentColumnConditions.svelte
+++ b/packages/renderer/src/lib/deployments/DeploymentColumnConditions.svelte
@@ -26,11 +26,18 @@ function getConditionColour(type: string): string {
 
 <div class="flex flex-row gap-1">
   {#each object.conditions as condition}
-    <Tooltip tip="{condition.message}" bottom>
-      <div class="flex flex-row bg-charcoal-500 items-center p-1 rounded-md text-xs text-gray-500">
-        <div class="w-2 h-2 {getConditionColour(condition.type)} rounded-full mr-1"></div>
-        {condition.type}
-      </div>
+    <Tooltip bottom>
+      <svelte:fragment slot="item">
+        <div class="flex flex-row bg-charcoal-500 items-center p-1 rounded-md text-xs text-gray-500">
+          <div class="w-2 h-2 {getConditionColour(condition.type)} rounded-full mr-1"></div>
+          {condition.type}
+        </div>
+      </svelte:fragment>
+      <svelte:fragment slot="tip">
+        <div class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs text-white" aria-label="tooltip">
+          {condition.message}
+        </div>
+      </svelte:fragment>
     </Tooltip>
   {/each}
 </div>

--- a/packages/renderer/src/lib/deployments/DeploymentColumnConditions.svelte
+++ b/packages/renderer/src/lib/deployments/DeploymentColumnConditions.svelte
@@ -34,9 +34,11 @@ function getConditionColour(type: string): string {
         </div>
       </svelte:fragment>
       <svelte:fragment slot="tip">
-        <div class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs text-white" aria-label="tooltip">
-          {condition.message}
-        </div>
+        {#if condition.message}
+          <div class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs text-white" aria-label="tooltip">
+            {condition.message}
+          </div>
+        {/if}
       </svelte:fragment>
     </Tooltip>
   {/each}

--- a/packages/renderer/src/lib/donut/Donut.svelte
+++ b/packages/renderer/src/lib/donut/Donut.svelte
@@ -27,7 +27,7 @@ $: tooltip = percent ? percent.toFixed(0) + '% ' + title + ' usage' : '';
 </script>
 
 <Tooltip bottom>
-  <svelte:fragment slot="item">
+  <svelte:fragment slot="content">
     <svg viewBox="-4 -4 {size + 8} {size + 8}" height="{size}" width="{size}">
       <circle fill="none" class="stroke-charcoal-300" stroke-width="1" r="{size / 2}" cx="{size / 2}" cy="{size / 2}"
       ></circle>

--- a/packages/renderer/src/lib/donut/Donut.svelte
+++ b/packages/renderer/src/lib/donut/Donut.svelte
@@ -26,23 +26,30 @@ $: stroke = percent < 0 ? '' : percent < 50 ? 'stroke-green-500' : percent < 75 
 $: tooltip = percent ? percent.toFixed(0) + '% ' + title + ' usage' : '';
 </script>
 
-<Tooltip tip="{tooltip}" bottom>
-  <svg viewBox="-4 -4 {size + 8} {size + 8}" height="{size}" width="{size}">
-    <circle fill="none" class="stroke-charcoal-300" stroke-width="1" r="{size / 2}" cx="{size / 2}" cy="{size / 2}"
-    ></circle>
-    <path
-      fill="none"
-      class="{stroke}"
-      stroke-width="3.5"
-      d="{describeArc(size / 2, (percent * 360) / 100)}"
-      data-testid="arc"></path>
-    <text x="{size / 2}" y="38%" text-anchor="middle" font-size="{size / 5.5}" class="fill-gray-800">{title}</text>
-    <text
-      x="{size / 2}"
-      y="52%"
-      text-anchor="middle"
-      font-size="{size / 4.5}"
-      dominant-baseline="central"
-      class="fill-gray-400">{value !== undefined ? value : ''}</text>
-  </svg>
+<Tooltip bottom>
+  <svelte:fragment slot="item">
+    <svg viewBox="-4 -4 {size + 8} {size + 8}" height="{size}" width="{size}">
+      <circle fill="none" class="stroke-charcoal-300" stroke-width="1" r="{size / 2}" cx="{size / 2}" cy="{size / 2}"
+      ></circle>
+      <path
+        fill="none"
+        class="{stroke}"
+        stroke-width="3.5"
+        d="{describeArc(size / 2, (percent * 360) / 100)}"
+        data-testid="arc"></path>
+      <text x="{size / 2}" y="38%" text-anchor="middle" font-size="{size / 5.5}" class="fill-gray-800">{title}</text>
+      <text
+        x="{size / 2}"
+        y="52%"
+        text-anchor="middle"
+        font-size="{size / 4.5}"
+        dominant-baseline="central"
+        class="fill-gray-400">{value !== undefined ? value : ''}</text>
+    </svg>
+  </svelte:fragment>
+  <svelte:fragment slot="tip">
+    <div class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs text-white" aria-label="tooltip">
+      {tooltip}
+    </div>
+  </svelte:fragment>
 </Tooltip>

--- a/packages/renderer/src/lib/donut/Donut.svelte
+++ b/packages/renderer/src/lib/donut/Donut.svelte
@@ -48,8 +48,10 @@ $: tooltip = percent ? percent.toFixed(0) + '% ' + title + ' usage' : '';
     </svg>
   </svelte:fragment>
   <svelte:fragment slot="tip">
-    <div class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs text-white" aria-label="tooltip">
-      {tooltip}
-    </div>
+    {#if tooltip}
+      <div class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs text-white" aria-label="tooltip">
+        {tooltip}
+      </div>
+    {/if}
   </svelte:fragment>
 </Tooltip>

--- a/packages/renderer/src/lib/extensions/ExtensionBadge.svelte
+++ b/packages/renderer/src/lib/extensions/ExtensionBadge.svelte
@@ -9,7 +9,7 @@ export let extension: { type: 'dd' | 'pd'; removable: boolean };
 <div class="flex flex-row gap-1 items-center {$$props.class}" role="region" aria-label="Extension Badge">
   {#if extension.type === 'dd'}
     <Tooltip right>
-      <svelte:fragment slot="item">
+      <svelte:fragment slot="content">
         <Badge class="text-[8px] text-white" color="bg-sky-600" label="Docker Desktop extension" />
       </svelte:fragment>
       <svelte:fragment slot="tip">
@@ -20,7 +20,7 @@ export let extension: { type: 'dd' | 'pd'; removable: boolean };
     </Tooltip>
   {:else if !extension.removable}
     <Tooltip right>
-      <svelte:fragment slot="item">
+      <svelte:fragment slot="content">
         <Badge class="text-[8px] text-charcoal-800" color="bg-sky-200" label="built-in Extension" />
       </svelte:fragment>
       <svelte:fragment slot="tip">

--- a/packages/renderer/src/lib/extensions/ExtensionBadge.svelte
+++ b/packages/renderer/src/lib/extensions/ExtensionBadge.svelte
@@ -8,12 +8,26 @@ export let extension: { type: 'dd' | 'pd'; removable: boolean };
 
 <div class="flex flex-row gap-1 items-center {$$props.class}" role="region" aria-label="Extension Badge">
   {#if extension.type === 'dd'}
-    <Tooltip tip="Docker Desktop extension" right>
-      <Badge class="text-[8px] text-white" color="bg-sky-600" label="Docker Desktop extension" />
+    <Tooltip right>
+      <svelte:fragment slot="item">
+        <Badge class="text-[8px] text-white" color="bg-sky-600" label="Docker Desktop extension" />
+      </svelte:fragment>
+      <svelte:fragment slot="tip">
+        <div class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs text-white" aria-label="tooltip">
+          Docker Desktop extension
+        </div>
+      </svelte:fragment>
     </Tooltip>
   {:else if !extension.removable}
-    <Tooltip tip="built-in Extension" right>
-      <Badge class="text-[8px] text-charcoal-800" color="bg-sky-200" label="built-in Extension" />
+    <Tooltip right>
+      <svelte:fragment slot="item">
+        <Badge class="text-[8px] text-charcoal-800" color="bg-sky-200" label="built-in Extension" />
+      </svelte:fragment>
+      <svelte:fragment slot="tip">
+        <div class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs text-white" aria-label="tooltip">
+          built-in Extension
+        </div>
+      </svelte:fragment>
     </Tooltip>
   {/if}
 </div>

--- a/packages/renderer/src/lib/extensions/ExtensionDetailsLink.svelte
+++ b/packages/renderer/src/lib/extensions/ExtensionDetailsLink.svelte
@@ -16,7 +16,7 @@ function openDetailsExtension() {
 </script>
 
 <Tooltip top>
-  <svelte:fragment slot="item">
+  <svelte:fragment slot="content">
     <button aria-label="{extension.name} extension details" type="button" on:click="{() => openDetailsExtension()}">
       <div class="flex flex-row items-center">
         {#if displayIcon}

--- a/packages/renderer/src/lib/extensions/ExtensionDetailsLink.svelte
+++ b/packages/renderer/src/lib/extensions/ExtensionDetailsLink.svelte
@@ -15,15 +15,22 @@ function openDetailsExtension() {
 }
 </script>
 
-<Tooltip tip="{extension.name} extension details" top>
-  <button aria-label="{extension.name} extension details" type="button" on:click="{() => openDetailsExtension()}">
-    <div class="flex flex-row items-center">
-      {#if displayIcon}
-        <Fa icon="{faArrowUpRightFromSquare}" />
-      {/if}
-      <div class="text-left before:{$$props.class}">
-        {extension.displayName} extension
+<Tooltip top>
+  <svelte:fragment slot="item">
+    <button aria-label="{extension.name} extension details" type="button" on:click="{() => openDetailsExtension()}">
+      <div class="flex flex-row items-center">
+        {#if displayIcon}
+          <Fa icon="{faArrowUpRightFromSquare}" />
+        {/if}
+        <div class="text-left before:{$$props.class}">
+          {extension.displayName} extension
+        </div>
       </div>
+    </button>
+  </svelte:fragment>
+  <svelte:fragment slot="tip">
+    <div class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs text-white" aria-label="tooltip">
+      {extension.name} extension details
     </div>
-  </button>
+  </svelte:fragment>
 </Tooltip>

--- a/packages/renderer/src/lib/image/BuildImageFromContainerfileCard.svelte
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfileCard.svelte
@@ -90,8 +90,15 @@ onMount(() => {
     </div>
     <div class="ml-2 text-sm text-left break-normal w-36">{title}</div>
     {#if isDefault}
-      <Tooltip tip="Default platform of your computer">
-        <Fa size="0.5x" class="text-dustypurple-700 cursor-pointer" icon="{faCircle}" />
+      <Tooltip>
+        <svelte:fragment slot="item">
+          <Fa size="0.5x" class="text-dustypurple-700 cursor-pointer" icon="{faCircle}" />
+        </svelte:fragment>
+        <svelte:fragment slot="tip">
+          <div class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs text-white" aria-label="tooltip">
+            Default platform of your computer
+          </div>
+        </svelte:fragment>
       </Tooltip>
     {/if}
   </div>

--- a/packages/renderer/src/lib/image/BuildImageFromContainerfileCard.svelte
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfileCard.svelte
@@ -91,7 +91,7 @@ onMount(() => {
     <div class="ml-2 text-sm text-left break-normal w-36">{title}</div>
     {#if isDefault}
       <Tooltip>
-        <svelte:fragment slot="item">
+        <svelte:fragment slot="content">
           <Fa size="0.5x" class="text-dustypurple-700 cursor-pointer" icon="{faCircle}" />
         </svelte:fragment>
         <svelte:fragment slot="tip">

--- a/packages/renderer/src/lib/kube/KubeEditYAML.svelte
+++ b/packages/renderer/src/lib/kube/KubeEditYAML.svelte
@@ -79,8 +79,8 @@ async function applyToCluster() {
   class="flex flex-row-reverse p-6 bg-transparent fixed bottom-0 right-0 mb-5 pr-10 max-h-20 bg-opacity-90 z-50"
   role="group"
   aria-label="Edit Buttons">
-  <Tooltip topLeft="{true}">
-    <svelte:fragment slot="item">
+  <Tooltip topLeft>
+    <svelte:fragment slot="content">
       <Button
         type="primary"
         aria-label="Apply changes to cluster"
@@ -94,8 +94,8 @@ async function applyToCluster() {
       </div>
     </svelte:fragment>
   </Tooltip>
-  <Tooltip topLeft="{true}">
-    <svelte:fragment slot="item">
+  <Tooltip topLeft>
+    <svelte:fragment slot="content">
       <Button
         type="secondary"
         aria-label="Revert changes"

--- a/packages/renderer/src/lib/kube/KubeEditYAML.svelte
+++ b/packages/renderer/src/lib/kube/KubeEditYAML.svelte
@@ -79,21 +79,35 @@ async function applyToCluster() {
   class="flex flex-row-reverse p-6 bg-transparent fixed bottom-0 right-0 mb-5 pr-10 max-h-20 bg-opacity-90 z-50"
   role="group"
   aria-label="Edit Buttons">
-  <Tooltip tip="Apply the changes to the cluster, similar to 'kubectl apply'" topLeft="{true}">
-    <Button
-      type="primary"
-      aria-label="Apply changes to cluster"
-      on:click="{applyToCluster}"
-      disabled="{!changesDetected}"
-      inProgress="{inProgress}">Apply changes to cluster</Button>
+  <Tooltip topLeft="{true}">
+    <svelte:fragment slot="item">
+      <Button
+        type="primary"
+        aria-label="Apply changes to cluster"
+        on:click="{applyToCluster}"
+        disabled="{!changesDetected}"
+        inProgress="{inProgress}">Apply changes to cluster</Button>
+    </svelte:fragment>
+    <svelte:fragment slot="tip">
+      <div class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs text-white" aria-label="tooltip">
+        Apply the changes to the cluster, similar to 'kubectl apply'
+      </div>
+    </svelte:fragment>
   </Tooltip>
-  <Tooltip tip="Revert the changes to the original content" topLeft="{true}">
-    <Button
-      type="secondary"
-      aria-label="Revert changes"
-      class="mr-2 opacity-100"
-      on:click="{revertChanges}"
-      disabled="{!changesDetected}">Revert changes</Button>
+  <Tooltip topLeft="{true}">
+    <svelte:fragment slot="item">
+      <Button
+        type="secondary"
+        aria-label="Revert changes"
+        class="mr-2 opacity-100"
+        on:click="{revertChanges}"
+        disabled="{!changesDetected}">Revert changes</Button>
+    </svelte:fragment>
+    <svelte:fragment slot="tip">
+      <div class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs text-white" aria-label="tooltip">
+        Revert the changes to the original content
+      </div>
+    </svelte:fragment>
   </Tooltip>
 </div>
 

--- a/packages/renderer/src/lib/preferences/PreferencesAuthenticationProvidersRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesAuthenticationProvidersRendering.svelte
@@ -99,13 +99,22 @@ import SettingsPage from './SettingsPage.svelte';
                           aria-label="Logged In Username">
                           {account.label}
                         </span>
-                        <Tooltip tip="Sign out of {account.label}" bottomRight>
-                          <button
-                            aria-label="Sign out of {account.label}"
-                            class="pl-2 hover:cursor-pointer hover:text-white text-white"
-                            on:click="{() => window.requestAuthenticationProviderSignOut(provider.id, account.id)}">
-                            <Fa class="h-3 w-3 text-md mr-2" icon="{faRightFromBracket}" />
-                          </button>
+                        <Tooltip bottomRight>
+                          <svelte:fragment slot="item">
+                            <button
+                              aria-label="Sign out of {account.label}"
+                              class="pl-2 hover:cursor-pointer hover:text-white text-white"
+                              on:click="{() => window.requestAuthenticationProviderSignOut(provider.id, account.id)}">
+                              <Fa class="h-3 w-3 text-md mr-2" icon="{faRightFromBracket}" />
+                            </button>
+                          </svelte:fragment>
+                          <svelte:fragment slot="tip">
+                            <div
+                              class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs text-white"
+                              aria-label="tooltip">
+                              Sign out of {account.label}
+                            </div>
+                          </svelte:fragment>
                         </Tooltip>
                       </div>
                     </div>
@@ -119,15 +128,24 @@ import SettingsPage from './SettingsPage.svelte';
             {#if sessionRequests.length === 1}
               {@const request = sessionRequests[0]}
               <!-- Authentication Provider Auth Request Sign In button start -->
-              <Tooltip tip="Sign in to use {request.extensionLabel}" bottomLeft>
-                <Button
-                  aria-label="Sign in"
-                  class="pl-2 mr-4 hover:cursor-pointer hover:text-white text-white"
-                  on:click="{() => window.requestAuthenticationProviderSignIn(request.id)}">
-                  <div class="flex flex-row items-center">
-                    <Fa class="h-3 w-3 text-md mr-2" icon="{faRightToBracket}" />Sign in
+              <Tooltip bottomLeft>
+                <svelte:fragment slot="item">
+                  <Button
+                    aria-label="Sign in"
+                    class="pl-2 mr-4 hover:cursor-pointer hover:text-white text-white"
+                    on:click="{() => window.requestAuthenticationProviderSignIn(request.id)}">
+                    <div class="flex flex-row items-center">
+                      <Fa class="h-3 w-3 text-md mr-2" icon="{faRightToBracket}" />Sign in
+                    </div>
+                  </Button>
+                </svelte:fragment>
+                <svelte:fragment slot="tip">
+                  <div
+                    class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs text-white"
+                    aria-label="tooltip">
+                    Sign in to use {request.extensionLabel}
                   </div>
-                </Button>
+                </svelte:fragment>
               </Tooltip>
               <!-- Authentication Provider Auth Request Sign In button end -->
             {:else if sessionRequests.length > 1}

--- a/packages/renderer/src/lib/preferences/PreferencesAuthenticationProvidersRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesAuthenticationProvidersRendering.svelte
@@ -100,7 +100,7 @@ import SettingsPage from './SettingsPage.svelte';
                           {account.label}
                         </span>
                         <Tooltip bottomRight>
-                          <svelte:fragment slot="item">
+                          <svelte:fragment slot="content">
                             <button
                               aria-label="Sign out of {account.label}"
                               class="pl-2 hover:cursor-pointer hover:text-white text-white"
@@ -129,7 +129,7 @@ import SettingsPage from './SettingsPage.svelte';
               {@const request = sessionRequests[0]}
               <!-- Authentication Provider Auth Request Sign In button start -->
               <Tooltip bottomLeft>
-                <svelte:fragment slot="item">
+                <svelte:fragment slot="content">
                   <Button
                     aria-label="Sign in"
                     class="pl-2 mr-4 hover:cursor-pointer hover:text-white text-white"

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
@@ -416,13 +416,22 @@ function hasAnyConfiguration(provider: ProviderInfo) {
                           ? provider.kubernetesProviderConnectionCreationButtonTitle
                           : undefined) || 'Create new'}
                     <!-- create new provider button -->
-                    <Tooltip tip="Create new {providerDisplayName}" bottom>
-                      <Button
-                        aria-label="Create new {providerDisplayName}"
-                        inProgress="{providerInstallationInProgress.get(provider.name)}"
-                        on:click="{() => doCreateNew(provider, providerDisplayName)}">
-                        {buttonTitle} ...
-                      </Button>
+                    <Tooltip bottom>
+                      <svelte:fragment slot="item">
+                        <Button
+                          aria-label="Create new {providerDisplayName}"
+                          inProgress="{providerInstallationInProgress.get(provider.name)}"
+                          on:click="{() => doCreateNew(provider, providerDisplayName)}">
+                          {buttonTitle} ...
+                        </Button>
+                      </svelte:fragment>
+                      <svelte:fragment slot="tip">
+                        <div
+                          class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs text-white"
+                          aria-label="tooltip">
+                          Create new {providerDisplayName}
+                        </div>
+                      </svelte:fragment>
                     </Tooltip>
                   {/if}
                   {#if isOnboardingEnabled(provider, globalContext) || hasAnyConfiguration(provider)}
@@ -456,18 +465,29 @@ function hasAnyConfiguration(provider: ProviderInfo) {
             {@const peerProperties = new PeerProperties()}
             <div class="px-5 py-2 w-[240px]" role="region" aria-label="{container.name}">
               <div class="float-right">
-                <Tooltip tip="{provider.name} details" bottom>
-                  <button
-                    aria-label="{provider.name} details"
-                    type="button"
-                    on:click="{() =>
-                      router.goto(
-                        `/preferences/container-connection/view/${provider.internalId}/${Buffer.from(
-                          container.name,
-                        ).toString('base64')}/${Buffer.from(container.endpoint.socketPath).toString('base64')}/summary`,
-                      )}">
-                    <Fa icon="{faArrowUpRightFromSquare}" />
-                  </button>
+                <Tooltip bottom>
+                  <svelte:fragment slot="item">
+                    <button
+                      aria-label="{provider.name} details"
+                      type="button"
+                      on:click="{() =>
+                        router.goto(
+                          `/preferences/container-connection/view/${provider.internalId}/${Buffer.from(
+                            container.name,
+                          ).toString(
+                            'base64',
+                          )}/${Buffer.from(container.endpoint.socketPath).toString('base64')}/summary`,
+                        )}">
+                      <Fa icon="{faArrowUpRightFromSquare}" />
+                    </button>
+                  </svelte:fragment>
+                  <svelte:fragment slot="tip">
+                    <div
+                      class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs text-white"
+                      aria-label="tooltip">
+                      {provider.name} details
+                    </div>
+                  </svelte:fragment>
                 </Tooltip>
               </div>
               <div class="{container.status !== 'started' ? 'text-gray-900' : ''} text-sm">
@@ -539,18 +559,27 @@ function hasAnyConfiguration(provider: ProviderInfo) {
           {#each provider.kubernetesConnections as kubeConnection}
             <div class="px-5 py-2 w-[240px]" role="region" aria-label="{kubeConnection.name}">
               <div class="float-right">
-                <Tooltip tip="{provider.name} details" bottom>
-                  <button
-                    aria-label="{provider.name} details"
-                    type="button"
-                    on:click="{() =>
-                      router.goto(
-                        `/preferences/kubernetes-connection/${provider.internalId}/${Buffer.from(
-                          kubeConnection.endpoint.apiURL,
-                        ).toString('base64')}/summary`,
-                      )}">
-                    <Fa icon="{faArrowUpRightFromSquare}" />
-                  </button>
+                <Tooltip bottom>
+                  <svelte:fragment slot="item">
+                    <button
+                      aria-label="{provider.name} details"
+                      type="button"
+                      on:click="{() =>
+                        router.goto(
+                          `/preferences/kubernetes-connection/${provider.internalId}/${Buffer.from(
+                            kubeConnection.endpoint.apiURL,
+                          ).toString('base64')}/summary`,
+                        )}">
+                      <Fa icon="{faArrowUpRightFromSquare}" />
+                    </button>
+                  </svelte:fragment>
+                  <svelte:fragment slot="tip">
+                    <div
+                      class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs text-white"
+                      aria-label="tooltip">
+                      {provider.name} details
+                    </div>
+                  </svelte:fragment>
                 </Tooltip>
               </div>
               <div class="text-sm">

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
@@ -417,7 +417,7 @@ function hasAnyConfiguration(provider: ProviderInfo) {
                           : undefined) || 'Create new'}
                     <!-- create new provider button -->
                     <Tooltip bottom>
-                      <svelte:fragment slot="item">
+                      <svelte:fragment slot="content">
                         <Button
                           aria-label="Create new {providerDisplayName}"
                           inProgress="{providerInstallationInProgress.get(provider.name)}"
@@ -466,7 +466,7 @@ function hasAnyConfiguration(provider: ProviderInfo) {
             <div class="px-5 py-2 w-[240px]" role="region" aria-label="{container.name}">
               <div class="float-right">
                 <Tooltip bottom>
-                  <svelte:fragment slot="item">
+                  <svelte:fragment slot="content">
                     <button
                       aria-label="{provider.name} details"
                       type="button"
@@ -560,7 +560,7 @@ function hasAnyConfiguration(provider: ProviderInfo) {
             <div class="px-5 py-2 w-[240px]" role="region" aria-label="{kubeConnection.name}">
               <div class="float-right">
                 <Tooltip bottom>
-                  <svelte:fragment slot="item">
+                  <svelte:fragment slot="content">
                     <button
                       aria-label="{provider.name} details"
                       type="button"

--- a/packages/renderer/src/lib/preferences/item-formats/FloatNumberItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/FloatNumberItem.svelte
@@ -83,9 +83,11 @@ function assertNumericValueIsValid(value: number): boolean {
         aria-label="{record.description}" />
     </svelte:fragment>
     <svelte:fragment slot="tip">
-      <div class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs text-white" aria-label="tooltip">
-        {numberInputErrorMessage}
-      </div>
+      {#if numberInputErrorMessage}
+        <div class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs text-white" aria-label="tooltip">
+          {numberInputErrorMessage}
+        </div>
+      {/if}
     </svelte:fragment>
   </Tooltip>
 </div>

--- a/packages/renderer/src/lib/preferences/item-formats/FloatNumberItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/FloatNumberItem.svelte
@@ -72,7 +72,7 @@ function assertNumericValueIsValid(value: number): boolean {
   class:border-violet-500="{!numberInputInvalid}"
   class:border-red-500="{numberInputInvalid}">
   <Tooltip topRight>
-    <svelte:fragment slot="item">
+    <svelte:fragment slot="content">
       <input
         type="text"
         class="w-full px-2 outline-none focus:outline-none text-white text-sm py-0.5"

--- a/packages/renderer/src/lib/preferences/item-formats/FloatNumberItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/FloatNumberItem.svelte
@@ -71,14 +71,21 @@ function assertNumericValueIsValid(value: number): boolean {
   class="flex flex-row rounded-sm bg-zinc-700 text-sm divide-x divide-charcoal-800 w-24 border-b"
   class:border-violet-500="{!numberInputInvalid}"
   class:border-red-500="{numberInputInvalid}">
-  <Tooltip topRight tip="{numberInputErrorMessage}">
-    <input
-      type="text"
-      class="w-full px-2 outline-none focus:outline-none text-white text-sm py-0.5"
-      name="{record.id}"
-      bind:value="{recordValue}"
-      on:keypress="{event => onNumberInputKeyPress(event)}"
-      on:input="{onInput}"
-      aria-label="{record.description}" />
+  <Tooltip topRight>
+    <svelte:fragment slot="item">
+      <input
+        type="text"
+        class="w-full px-2 outline-none focus:outline-none text-white text-sm py-0.5"
+        name="{record.id}"
+        bind:value="{recordValue}"
+        on:keypress="{event => onNumberInputKeyPress(event)}"
+        on:input="{onInput}"
+        aria-label="{record.description}" />
+    </svelte:fragment>
+    <svelte:fragment slot="tip">
+      <div class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs text-white" aria-label="tooltip">
+        {numberInputErrorMessage}
+      </div>
+    </svelte:fragment>
   </Tooltip>
 </div>

--- a/packages/renderer/src/lib/preferences/item-formats/NumberItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/NumberItem.svelte
@@ -37,7 +37,7 @@ $: if (error) {
 </script>
 
 <Tooltip topLeft>
-  <svelte:fragment slot="item">
+  <svelte:fragment slot="content">
     <NumberInput
       class="w-24"
       name="{record.id}"

--- a/packages/renderer/src/lib/preferences/item-formats/NumberItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/NumberItem.svelte
@@ -36,15 +36,22 @@ $: if (error) {
 }
 </script>
 
-<Tooltip topLeft tip="{error}">
-  <NumberInput
-    class="w-24"
-    name="{record.id}"
-    bind:value="{recordValue}"
-    bind:error="{error}"
-    aria-label="{record.description}"
-    minimum="{record.minimum}"
-    maximum="{record.maximum && typeof record.maximum === 'number' ? record.maximum : undefined}"
-    showError="{false}">
-  </NumberInput>
+<Tooltip topLeft>
+  <svelte:fragment slot="item">
+    <NumberInput
+      class="w-24"
+      name="{record.id}"
+      bind:value="{recordValue}"
+      bind:error="{error}"
+      aria-label="{record.description}"
+      minimum="{record.minimum}"
+      maximum="{record.maximum && typeof record.maximum === 'number' ? record.maximum : undefined}"
+      showError="{false}">
+    </NumberInput>
+  </svelte:fragment>
+  <svelte:fragment slot="tip">
+    <div class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs text-white" aria-label="tooltip">
+      {error}
+    </div>
+  </svelte:fragment>
 </Tooltip>

--- a/packages/renderer/src/lib/preferences/item-formats/NumberItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/NumberItem.svelte
@@ -50,8 +50,10 @@ $: if (error) {
     </NumberInput>
   </svelte:fragment>
   <svelte:fragment slot="tip">
-    <div class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs text-white" aria-label="tooltip">
-      {error}
-    </div>
+    {#if error}
+      <div class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs text-white" aria-label="tooltip">
+        {error}
+      </div>
+    {/if}
   </svelte:fragment>
 </Tooltip>

--- a/packages/renderer/src/lib/ui/CopyToClipboard.svelte
+++ b/packages/renderer/src/lib/ui/CopyToClipboard.svelte
@@ -12,14 +12,21 @@ function copyTextToClipboard() {
 </script>
 
 <div class="float-right">
-  <Tooltip tip="Copy to Clipboard" bottom>
-    <button
-      title="Copy To Clipboard"
-      class="ml-5 {$$props.class || ''}"
-      aria-label="Copy To Clipboard"
-      on:click="{() => copyTextToClipboard()}">
-      <Fa icon="{faPaste}" />
-    </button>
+  <Tooltip bottom>
+    <svelte:fragment slot="item">
+      <button
+        title="Copy To Clipboard"
+        class="ml-5 {$$props.class || ''}"
+        aria-label="Copy To Clipboard"
+        on:click="{() => copyTextToClipboard()}">
+        <Fa icon="{faPaste}" />
+      </button>
+    </svelte:fragment>
+    <svelte:fragment slot="tip">
+      <div class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs text-white" aria-label="tooltip">
+        Copy to Clipboard
+      </div>
+    </svelte:fragment>
   </Tooltip>
 </div>
 <div class="mt-1 my-auto text-xs truncate {$$props.class || ''}" aria-label="{title} copy to clipboard" title="{title}">

--- a/packages/renderer/src/lib/ui/CopyToClipboard.svelte
+++ b/packages/renderer/src/lib/ui/CopyToClipboard.svelte
@@ -13,7 +13,7 @@ function copyTextToClipboard() {
 
 <div class="float-right">
   <Tooltip bottom>
-    <svelte:fragment slot="item">
+    <svelte:fragment slot="content">
       <button
         title="Copy To Clipboard"
         class="ml-5 {$$props.class || ''}"

--- a/packages/renderer/src/lib/ui/KubernetesCurrentContextConnectionBadge.svelte
+++ b/packages/renderer/src/lib/ui/KubernetesCurrentContextConnectionBadge.svelte
@@ -28,9 +28,11 @@ $: text = getText($kubernetesCurrentContextState);
             {text}
           </svelte:fragment>
           <svelte:fragment slot="tip">
-            <div class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs text-white" aria-label="tooltip">
-              {$kubernetesCurrentContextState.error}
-            </div>
+            {#if $kubernetesCurrentContextState.error}
+              <div class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs text-white" aria-label="tooltip">
+                {$kubernetesCurrentContextState.error}
+              </div>
+            {/if}
           </svelte:fragment>
         </Tooltip>
       {:else}

--- a/packages/renderer/src/lib/ui/KubernetesCurrentContextConnectionBadge.svelte
+++ b/packages/renderer/src/lib/ui/KubernetesCurrentContextConnectionBadge.svelte
@@ -24,7 +24,7 @@ $: text = getText($kubernetesCurrentContextState);
     <span class="text-xs capitalize mr-1">
       {#if $kubernetesCurrentContextState.error !== undefined}
         <Tooltip left>
-          <svelte:fragment slot="item">
+          <svelte:fragment slot="content">
             {text}
           </svelte:fragment>
           <svelte:fragment slot="tip">

--- a/packages/renderer/src/lib/ui/KubernetesCurrentContextConnectionBadge.svelte
+++ b/packages/renderer/src/lib/ui/KubernetesCurrentContextConnectionBadge.svelte
@@ -23,7 +23,16 @@ $: text = getText($kubernetesCurrentContextState);
     <div class="w-2 h-2 {getClassColor($kubernetesCurrentContextState)} rounded-full mx-1"></div>
     <span class="text-xs capitalize mr-1">
       {#if $kubernetesCurrentContextState.error !== undefined}
-        <Tooltip tip="{$kubernetesCurrentContextState.error}" left>{text}</Tooltip>
+        <Tooltip left>
+          <svelte:fragment slot="item">
+            {text}
+          </svelte:fragment>
+          <svelte:fragment slot="tip">
+            <div class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs text-white" aria-label="tooltip">
+              {$kubernetesCurrentContextState.error}
+            </div>
+          </svelte:fragment>
+        </Tooltip>
       {:else}
         {text}
       {/if}

--- a/packages/renderer/src/lib/ui/LoadingIconButton.svelte
+++ b/packages/renderer/src/lib/ui/LoadingIconButton.svelte
@@ -52,7 +52,7 @@ $: style = disable
 </script>
 
 <Tooltip bottom>
-  <svelte:fragment slot="item">
+  <svelte:fragment slot="content">
     <button aria-label="{capitalize(action)}" class="mx-2.5 my-2 {style}" on:click="{clickAction}" disabled="{disable}">
       <LoadingIcon
         icon="{icon}"

--- a/packages/renderer/src/lib/ui/LoadingIconButton.svelte
+++ b/packages/renderer/src/lib/ui/LoadingIconButton.svelte
@@ -64,8 +64,10 @@ $: style = disable
     </button>
   </svelte:fragment>
   <svelte:fragment slot="tip">
-    <div class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs text-white" aria-label="tooltip">
-      {tooltip}
-    </div>
+    {#if tooltip}
+      <div class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs text-white" aria-label="tooltip">
+        {tooltip}
+      </div>
+    {/if}
   </svelte:fragment>
 </Tooltip>

--- a/packages/renderer/src/lib/ui/LoadingIconButton.svelte
+++ b/packages/renderer/src/lib/ui/LoadingIconButton.svelte
@@ -51,14 +51,21 @@ $: style = disable
     : 'text-purple-600 hover:text-purple-500';
 </script>
 
-<Tooltip tip="{tooltip}" bottom>
-  <button aria-label="{capitalize(action)}" class="mx-2.5 my-2 {style}" on:click="{clickAction}" disabled="{disable}">
-    <LoadingIcon
-      icon="{icon}"
-      loadingWidthClass="w-6"
-      loadingHeightClass="h-6"
-      positionTopClass="top-1"
-      positionLeftClass="{leftPosition}"
-      loading="{loading}" />
-  </button>
+<Tooltip bottom>
+  <svelte:fragment slot="item">
+    <button aria-label="{capitalize(action)}" class="mx-2.5 my-2 {style}" on:click="{clickAction}" disabled="{disable}">
+      <LoadingIcon
+        icon="{icon}"
+        loadingWidthClass="w-6"
+        loadingHeightClass="h-6"
+        positionTopClass="top-1"
+        positionLeftClass="{leftPosition}"
+        loading="{loading}" />
+    </button>
+  </svelte:fragment>
+  <svelte:fragment slot="tip">
+    <div class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs text-white" aria-label="tooltip">
+      {tooltip}
+    </div>
+  </svelte:fragment>
 </Tooltip>

--- a/packages/renderer/src/lib/ui/NavItem.svelte
+++ b/packages/renderer/src/lib/ui/NavItem.svelte
@@ -50,7 +50,7 @@ onDestroy(() => {
     class:hover:bg-[var(--pd-global-nav-icon-hover-bg)]="{!selected || inSection}"
     class:hover:border-[var(--pd-global-nav-icon-hover-bg)]="{!selected && !inSection}">
     <Tooltip right>
-      <svelte:fragment slot="item">
+      <svelte:fragment slot="content">
         <slot />
       </svelte:fragment>
       <svelte:fragment slot="tip">

--- a/packages/renderer/src/lib/ui/NavItem.svelte
+++ b/packages/renderer/src/lib/ui/NavItem.svelte
@@ -49,8 +49,15 @@ onDestroy(() => {
     class:hover:text-[color:var(--pd-global-nav-icon-hover)]="{!selected || inSection}"
     class:hover:bg-[var(--pd-global-nav-icon-hover-bg)]="{!selected || inSection}"
     class:hover:border-[var(--pd-global-nav-icon-hover-bg)]="{!selected && !inSection}">
-    <Tooltip tip="{tooltip}" right>
-      <slot />
+    <Tooltip right>
+      <svelte:fragment slot="item">
+        <slot />
+      </svelte:fragment>
+      <svelte:fragment slot="tip">
+        <div class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs text-white" aria-label="tooltip">
+          {tooltip}
+        </div>
+      </svelte:fragment>
     </Tooltip>
   </div>
 </a>

--- a/packages/renderer/src/lib/ui/NavItem.svelte
+++ b/packages/renderer/src/lib/ui/NavItem.svelte
@@ -54,9 +54,11 @@ onDestroy(() => {
         <slot />
       </svelte:fragment>
       <svelte:fragment slot="tip">
-        <div class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs text-white" aria-label="tooltip">
-          {tooltip}
-        </div>
+        {#if tooltip}
+          <div class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs text-white" aria-label="tooltip">
+            {tooltip}
+          </div>
+        {/if}
       </svelte:fragment>
     </Tooltip>
   </div>

--- a/packages/renderer/src/lib/ui/NavSection.svelte
+++ b/packages/renderer/src/lib/ui/NavSection.svelte
@@ -37,7 +37,7 @@ onMount(() => {
     on:click="{() => (expanded = !expanded)}"
     disabled="{expanded && $count < 2}">
     <Tooltip class="flex flex-col justify-center items-center pb-1" right>
-      <svelte:fragment slot="item">
+      <svelte:fragment slot="content">
         <div class="flex flex-col justify-center items-center" class:text-charcoal-50="{expanded && $count < 2}">
           {#if !expanded}
             <div class="py-2" transition:fadeSlide="{{ duration: 500 }}">

--- a/packages/renderer/src/lib/ui/NavSection.svelte
+++ b/packages/renderer/src/lib/ui/NavSection.svelte
@@ -48,9 +48,11 @@ onMount(() => {
         </div>
       </svelte:fragment>
       <svelte:fragment slot="tip">
-        <div class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs text-white" aria-label="tooltip">
-          {tooltip}
-        </div>
+        {#if tooltip}
+          <div class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs text-white" aria-label="tooltip">
+            {tooltip}
+          </div>
+        {/if}
       </svelte:fragment>
     </Tooltip>
   </button>

--- a/packages/renderer/src/lib/ui/NavSection.svelte
+++ b/packages/renderer/src/lib/ui/NavSection.svelte
@@ -36,15 +36,22 @@ onMount(() => {
     class="inline-block flex flex-col justify-center items-center"
     on:click="{() => (expanded = !expanded)}"
     disabled="{expanded && $count < 2}">
-    <Tooltip class="flex flex-col justify-center items-center pb-1" tip="{tooltip}" right>
-      <div class="flex flex-col justify-center items-center" class:text-charcoal-50="{expanded && $count < 2}">
-        {#if !expanded}
-          <div class="py-2" transition:fadeSlide="{{ duration: 500 }}">
-            <slot name="icon" />
-          </div>
-        {/if}
-        <Fa size="0.8x" icon="{expanded ? faChevronUp : faChevronDown}" />
-      </div>
+    <Tooltip class="flex flex-col justify-center items-center pb-1" right>
+      <svelte:fragment slot="item">
+        <div class="flex flex-col justify-center items-center" class:text-charcoal-50="{expanded && $count < 2}">
+          {#if !expanded}
+            <div class="py-2" transition:fadeSlide="{{ duration: 500 }}">
+              <slot name="icon" />
+            </div>
+          {/if}
+          <Fa size="0.8x" icon="{expanded ? faChevronUp : faChevronDown}" />
+        </div>
+      </svelte:fragment>
+      <svelte:fragment slot="tip">
+        <div class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs text-white" aria-label="tooltip">
+          {tooltip}
+        </div>
+      </svelte:fragment>
     </Tooltip>
   </button>
 </div>

--- a/packages/renderer/src/lib/ui/ProviderInfo.svelte
+++ b/packages/renderer/src/lib/ui/ProviderInfo.svelte
@@ -34,7 +34,15 @@ function getProviderColour(providerName: string): string {
   <span class="text-xs capitalize">
     <!-- If Kubernetes, show the context via the tooltip / hover, else just provider the name.-->
     {#if provider === 'Kubernetes'}
-      <Tooltip tip="{context}" top>{provider}</Tooltip>
+      <Tooltip top>
+        <svelte:fragment slot="item">
+          {provider}
+        </svelte:fragment>
+        <svelte:fragment slot="tip">
+          <div class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs text-white" aria-label="tooltip">
+            {context}
+          </div>
+        </svelte:fragment></Tooltip>
     {:else}
       {provider}
     {/if}

--- a/packages/renderer/src/lib/ui/ProviderInfo.svelte
+++ b/packages/renderer/src/lib/ui/ProviderInfo.svelte
@@ -35,7 +35,7 @@ function getProviderColour(providerName: string): string {
     <!-- If Kubernetes, show the context via the tooltip / hover, else just provider the name.-->
     {#if provider === 'Kubernetes'}
       <Tooltip top>
-        <svelte:fragment slot="item">
+        <svelte:fragment slot="content">
           {provider}
         </svelte:fragment>
         <svelte:fragment slot="tip">

--- a/packages/renderer/src/lib/ui/ProviderInfo.svelte
+++ b/packages/renderer/src/lib/ui/ProviderInfo.svelte
@@ -39,9 +39,11 @@ function getProviderColour(providerName: string): string {
           {provider}
         </svelte:fragment>
         <svelte:fragment slot="tip">
-          <div class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs text-white" aria-label="tooltip">
-            {context}
-          </div>
+          {#if context}
+            <div class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs text-white" aria-label="tooltip">
+              {context}
+            </div>
+          {/if}
         </svelte:fragment></Tooltip>
     {:else}
       {provider}

--- a/packages/renderer/src/lib/ui/StatusDot.svelte
+++ b/packages/renderer/src/lib/ui/StatusDot.svelte
@@ -23,16 +23,24 @@ let dotClass = getStatusColor(status);
 // If dotClass contains "outline", then we will use 'outline-1 outline-offset-[-2px]
 </script>
 
-<Tooltip tip="{tooltip}" top>
-  <div
-    class="w-2.5 h-2.5 mr-0.5 rounded-full text-center {dotClass.includes('outline')
-      ? 'outline-2 outline-offset-[-2px] outline'
-      : ''} {getStatusColor(status)} {number ? 'mt-3' : ''}"
-    data-testid="status-dot"
-    title="{tooltip}">
-  </div>
-  <!-- If text -->
-  {#if number}
-    <div class="text-xs text-bold text-gray-600 mr-0.5">{number}</div>
-  {/if}
+<Tooltip top>
+  <svelte:fragment slot="item">
+    <div
+      class="w-2.5 h-2.5 mr-0.5 rounded-full text-center {dotClass.includes('outline')
+        ? 'outline-2 outline-offset-[-2px] outline'
+        : ''} {getStatusColor(status)} {number ? 'mt-3' : ''}"
+      data-testid="status-dot"
+      title="{tooltip}">
+    </div>
+    <!-- If text -->
+    {#if number}
+      <div class="text-xs text-bold text-gray-600 mr-0.5">{number}</div>
+    {/if}
+  </svelte:fragment>
+
+  <svelte:fragment slot="tip">
+    <div class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs text-white" aria-label="tooltip">
+      {tooltip}
+    </div>
+  </svelte:fragment>
 </Tooltip>

--- a/packages/renderer/src/lib/ui/StatusDot.svelte
+++ b/packages/renderer/src/lib/ui/StatusDot.svelte
@@ -24,7 +24,7 @@ let dotClass = getStatusColor(status);
 </script>
 
 <Tooltip top>
-  <svelte:fragment slot="item">
+  <svelte:fragment slot="content">
     <div
       class="w-2.5 h-2.5 mr-0.5 rounded-full text-center {dotClass.includes('outline')
         ? 'outline-2 outline-offset-[-2px] outline'

--- a/packages/renderer/src/lib/ui/StatusDot.svelte
+++ b/packages/renderer/src/lib/ui/StatusDot.svelte
@@ -39,8 +39,10 @@ let dotClass = getStatusColor(status);
   </svelte:fragment>
 
   <svelte:fragment slot="tip">
-    <div class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs text-white" aria-label="tooltip">
-      {tooltip}
-    </div>
+    {#if tooltip}
+      <div class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs text-white" aria-label="tooltip">
+        {tooltip}
+      </div>
+    {/if}
   </svelte:fragment>
 </Tooltip>

--- a/packages/renderer/src/lib/ui/WarningMessage.svelte
+++ b/packages/renderer/src/lib/ui/WarningMessage.svelte
@@ -14,9 +14,11 @@ export let icon = false;
         <Fa size="1.125x" class="cursor-pointer text-amber-500" icon="{faTriangleExclamation}" />
       </svelte:fragment>
       <svelte:fragment slot="tip">
-        <div class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs text-white" aria-label="tooltip">
-          {error}
-        </div>
+        {#if error}
+          <div class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs text-white" aria-label="tooltip">
+            {error}
+          </div>
+        {/if}
       </svelte:fragment>
     </Tooltip>
   {/if}

--- a/packages/renderer/src/lib/ui/WarningMessage.svelte
+++ b/packages/renderer/src/lib/ui/WarningMessage.svelte
@@ -10,7 +10,7 @@ export let icon = false;
 {#if icon}
   {#if error !== undefined && error !== ''}
     <Tooltip top>
-      <svelte:fragment slot="item">
+      <svelte:fragment slot="content">
         <Fa size="1.125x" class="cursor-pointer text-amber-500" icon="{faTriangleExclamation}" />
       </svelte:fragment>
       <svelte:fragment slot="tip">

--- a/packages/renderer/src/lib/ui/WarningMessage.svelte
+++ b/packages/renderer/src/lib/ui/WarningMessage.svelte
@@ -9,8 +9,15 @@ export let icon = false;
 
 {#if icon}
   {#if error !== undefined && error !== ''}
-    <Tooltip tip="{error}" top>
-      <Fa size="1.125x" class="cursor-pointer text-amber-500" icon="{faTriangleExclamation}" />
+    <Tooltip top>
+      <svelte:fragment slot="item">
+        <Fa size="1.125x" class="cursor-pointer text-amber-500" icon="{faTriangleExclamation}" />
+      </svelte:fragment>
+      <svelte:fragment slot="tip">
+        <div class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs text-white" aria-label="tooltip">
+          {error}
+        </div>
+      </svelte:fragment>
     </Tooltip>
   {/if}
 {:else}

--- a/packages/renderer/src/lib/welcome/WelcomePage.svelte
+++ b/packages/renderer/src/lib/welcome/WelcomePage.svelte
@@ -129,7 +129,7 @@ function startOnboardingQueue() {
                       <div
                         class="flex flex-1 mx-2 underline decoration-2 decoration-dotted underline-offset-2 cursor-default justify-left text-capitalize">
                         <Tooltip top>
-                          <svelte:fragment slot="item">
+                          <svelte:fragment slot="content">
                             {onboarding.displayName}
                           </svelte:fragment>
                           <svelte:fragment slot="tip">

--- a/packages/renderer/src/lib/welcome/WelcomePage.svelte
+++ b/packages/renderer/src/lib/welcome/WelcomePage.svelte
@@ -128,8 +128,17 @@ function startOnboardingQueue() {
                       </div>
                       <div
                         class="flex flex-1 mx-2 underline decoration-2 decoration-dotted underline-offset-2 cursor-default justify-left text-capitalize">
-                        <Tooltip tip="{onboarding.description}" top>
-                          {onboarding.displayName}
+                        <Tooltip top>
+                          <svelte:fragment slot="item">
+                            {onboarding.displayName}
+                          </svelte:fragment>
+                          <svelte:fragment slot="tip">
+                            <div
+                              class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs text-white"
+                              aria-label="tooltip">
+                              {onboarding.description}
+                            </div>
+                          </svelte:fragment>
                         </Tooltip>
                       </div>
                     </div>

--- a/packages/renderer/src/lib/welcome/WelcomePage.svelte
+++ b/packages/renderer/src/lib/welcome/WelcomePage.svelte
@@ -133,11 +133,13 @@ function startOnboardingQueue() {
                             {onboarding.displayName}
                           </svelte:fragment>
                           <svelte:fragment slot="tip">
-                            <div
-                              class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs text-white"
-                              aria-label="tooltip">
-                              {onboarding.description}
-                            </div>
+                            {#if onboarding.description}
+                              <div
+                                class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs text-white"
+                                aria-label="tooltip">
+                                {onboarding.description}
+                              </div>
+                            {/if}
                           </svelte:fragment>
                         </Tooltip>
                       </div>

--- a/packages/ui/src/lib/alert/ErrorMessage.svelte
+++ b/packages/ui/src/lib/alert/ErrorMessage.svelte
@@ -15,9 +15,11 @@ export let icon = false;
         <Fa size="1.1x" class="cursor-pointer text-red-500 {$$props.class}" icon="{faExclamationCircle}" />
       </svelte:fragment>
       <svelte:fragment slot="tip">
-        <div class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs text-white" aria-label="tooltip">
-          {error}
-        </div>
+        {#if error}
+          <div class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs text-white" aria-label="tooltip">
+            {error}
+          </div>
+        {/if}
       </svelte:fragment>
     </Tooltip>
   {/if}

--- a/packages/ui/src/lib/alert/ErrorMessage.svelte
+++ b/packages/ui/src/lib/alert/ErrorMessage.svelte
@@ -10,8 +10,15 @@ export let icon = false;
 
 {#if icon}
   {#if error !== undefined && error !== ''}
-    <Tooltip tip="{error}" top>
-      <Fa size="1.1x" class="cursor-pointer text-red-500 {$$props.class}" icon="{faExclamationCircle}" />
+    <Tooltip top>
+      <svelte:fragment slot="item">
+        <Fa size="1.1x" class="cursor-pointer text-red-500 {$$props.class}" icon="{faExclamationCircle}" />
+      </svelte:fragment>
+      <svelte:fragment slot="tip">
+        <div class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs text-white" aria-label="tooltip">
+          {error}
+        </div>
+      </svelte:fragment>
     </Tooltip>
   {/if}
 {:else}

--- a/packages/ui/src/lib/alert/ErrorMessage.svelte
+++ b/packages/ui/src/lib/alert/ErrorMessage.svelte
@@ -11,7 +11,7 @@ export let icon = false;
 {#if icon}
   {#if error !== undefined && error !== ''}
     <Tooltip top>
-      <svelte:fragment slot="item">
+      <svelte:fragment slot="content">
         <Fa size="1.1x" class="cursor-pointer text-red-500 {$$props.class}" icon="{faExclamationCircle}" />
       </svelte:fragment>
       <svelte:fragment slot="tip">

--- a/packages/ui/src/lib/tooltip/Tooltip.spec.ts
+++ b/packages/ui/src/lib/tooltip/Tooltip.spec.ts
@@ -35,6 +35,14 @@ test('Expect basic styling', async () => {
   expect(element).toHaveClass('text-white');
 });
 
+test('Expect custom tip styling', async () => {
+  render(Tooltip, { tip, tipClass: 'text-pretty w-64' });
+
+  const element = screen.getByLabelText('tooltip');
+  expect(element).toBeInTheDocument();
+  expect(element.parentElement).toHaveClass('text-pretty w-64');
+});
+
 function createTest(props: Record<string, boolean>, locationName: string, expectedStyle = locationName): void {
   test(`Expect property ${locationName} to add ${expectedStyle} class to parent element`, () => {
     render(Tooltip, { tip, ...props });

--- a/packages/ui/src/lib/tooltip/Tooltip.svelte
+++ b/packages/ui/src/lib/tooltip/Tooltip.svelte
@@ -62,7 +62,7 @@ export let left = false;
 
 <div class="relative inline-block">
   <span class="group tooltip-slot {$$props.class}">
-    <slot name="item" />
+    <slot name="content" />
   </span>
   <div
     class="whitespace-nowrap absolute tooltip opacity-0 inline-block transition-opacity duration-150 ease-in-out pointer-events-none z-[10]"

--- a/packages/ui/src/lib/tooltip/Tooltip.svelte
+++ b/packages/ui/src/lib/tooltip/Tooltip.svelte
@@ -59,6 +59,7 @@ export let bottom = false;
 export let bottomLeft = false;
 export let bottomRight = false;
 export let left = false;
+export let tipClass = '';
 </script>
 
 <div class="relative inline-block">
@@ -66,7 +67,7 @@ export let left = false;
     <slot />
   </span>
   <div
-    class="whitespace-nowrap absolute tooltip opacity-0 inline-block transition-opacity duration-150 ease-in-out pointer-events-none z-[10]"
+    class="whitespace-nowrap absolute tooltip opacity-0 inline-block transition-opacity duration-150 ease-in-out pointer-events-none z-[10] {tipClass}"
     class:left="{left}"
     class:right="{right}"
     class:bottom="{bottom}"

--- a/packages/ui/src/lib/tooltip/Tooltip.svelte
+++ b/packages/ui/src/lib/tooltip/Tooltip.svelte
@@ -50,7 +50,6 @@
 </style>
 
 <script>
-export let tip = '';
 export let top = false;
 export let topLeft = false;
 export let topRight = false;
@@ -59,15 +58,14 @@ export let bottom = false;
 export let bottomLeft = false;
 export let bottomRight = false;
 export let left = false;
-export let tipClass = '';
 </script>
 
 <div class="relative inline-block">
   <span class="group tooltip-slot {$$props.class}">
-    <slot />
+    <slot name="item" />
   </span>
   <div
-    class="whitespace-nowrap absolute tooltip opacity-0 inline-block transition-opacity duration-150 ease-in-out pointer-events-none z-[10] {tipClass}"
+    class="whitespace-nowrap absolute tooltip opacity-0 inline-block transition-opacity duration-150 ease-in-out pointer-events-none z-[10]"
     class:left="{left}"
     class:right="{right}"
     class:bottom="{bottom}"
@@ -76,8 +74,6 @@ export let tipClass = '';
     class:top-right="{topRight}"
     class:bottom-left="{bottomLeft}"
     class:bottom-right="{bottomRight}">
-    {#if tip}
-      <div class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs text-white" aria-label="tooltip">{tip}</div>
-    {/if}
+    <slot name="tip" />
   </div>
 </div>

--- a/packages/ui/src/lib/tooltip/TooltipSpec.spec.ts
+++ b/packages/ui/src/lib/tooltip/TooltipSpec.spec.ts
@@ -23,29 +23,21 @@ import '@testing-library/jest-dom/vitest';
 import { render, screen } from '@testing-library/svelte';
 import { expect, test } from 'vitest';
 
-import Tooltip from './Tooltip.svelte';
+import TooltipSpec from './TooltipSpec.svelte';
 
 const tip = 'test';
 
 test('Expect basic styling', async () => {
-  render(Tooltip, { tip });
+  render(TooltipSpec, { tip });
 
   const element = screen.getByLabelText('tooltip');
   expect(element).toBeInTheDocument();
   expect(element).toHaveClass('text-white');
 });
 
-test('Expect custom tip styling', async () => {
-  render(Tooltip, { tip, tipClass: 'text-pretty w-64' });
-
-  const element = screen.getByLabelText('tooltip');
-  expect(element).toBeInTheDocument();
-  expect(element.parentElement).toHaveClass('text-pretty w-64');
-});
-
 function createTest(props: Record<string, boolean>, locationName: string, expectedStyle = locationName): void {
   test(`Expect property ${locationName} to add ${expectedStyle} class to parent element`, () => {
-    render(Tooltip, { tip, ...props });
+    render(TooltipSpec, { tip, ...props });
     const element = screen.getByLabelText('tooltip');
     expect(element).toBeInTheDocument();
     expect(element.parentElement).toHaveClass(expectedStyle);

--- a/packages/ui/src/lib/tooltip/TooltipSpec.svelte
+++ b/packages/ui/src/lib/tooltip/TooltipSpec.svelte
@@ -1,0 +1,32 @@
+<script>
+import Tooltip from './Tooltip.svelte';
+
+export let tip;
+export let top = false;
+export let topLeft = false;
+export let topRight = false;
+export let right = false;
+export let bottom = false;
+export let bottomLeft = false;
+export let bottomRight = false;
+export let left = false;
+</script>
+
+<Tooltip
+  top="{top}"
+  topLeft="{topLeft}"
+  topRight="{topRight}"
+  right="{right}"
+  bottom="{bottom}"
+  bottomLeft="{bottomLeft}"
+  bottomRight="{bottomRight}"
+  left="{left}">
+  <svelte:fragment slot="item">
+    <slot />
+  </svelte:fragment>
+  <svelte:fragment slot="tip">
+    {#if tip}
+      <div class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs text-white" aria-label="tooltip">{tip}</div>
+    {/if}
+  </svelte:fragment>
+</Tooltip>

--- a/packages/ui/src/lib/tooltip/TooltipSpec.svelte
+++ b/packages/ui/src/lib/tooltip/TooltipSpec.svelte
@@ -21,7 +21,7 @@ export let left = false;
   bottomLeft="{bottomLeft}"
   bottomRight="{bottomRight}"
   left="{left}">
-  <svelte:fragment slot="item">
+  <svelte:fragment slot="content">
     <slot />
   </svelte:fragment>
   <svelte:fragment slot="tip">


### PR DESCRIPTION
### What does this PR do?

This PR adds a tip slot so that one can customize the tip content.
In AI Lab we can use it to show the content multiline instead of a single line

### Screenshot / video of UI

An example is the output i want to have in AI Lab.
![tip_custom](https://github.com/containers/podman-desktop/assets/49404737/15e5481a-15c7-4dac-98ac-a8151d6523bf)


### What issues does this PR fix or reference?

N/A

### How to test this PR?

run tests

- [x] Tests are covering the bug fix or the new feature
