### PR TITLE
Light mode for Images and Volumes table

### DIFF
--- a/packages/main/src/plugin/color-registry.ts
+++ b/packages/main/src/plugin/color-registry.ts
@@ -233,6 +233,7 @@ export class ColorRegistry {
     this.initInputBox();
     this.initCheckbox();
     this.initToggle();
+    this.initTable();
   }
 
   protected initGlobalNav(): void {
@@ -446,6 +447,11 @@ export class ColorRegistry {
       light: colorPalette.gray[50],
     });
 
+    this.registerColor(`${ct}card-hover-bg`, {
+      dark: colorPalette.charcoal[500], // was zinc[700]
+      light: colorPalette.charcoal[500], // TODO
+    });
+
     this.registerColor(`${ct}card-text`, {
       dark: colorPalette.gray[400],
       light: colorPalette.purple[900],
@@ -627,6 +633,41 @@ export class ColorRegistry {
     this.registerColor(`${sNav}disabled-switch`, {
       dark: colorPalette.gray[900],
       light: colorPalette.charcoal[900],
+    });
+  }
+
+  protected initTable(): void {
+    const tab = 'table-';
+    // color of columns names
+    this.registerColor(`${tab}header-text`, {
+      dark: colorPalette.gray[600],
+      light: colorPalette.gray[600], // TODO
+    });
+    // color of up/down arrows when column is not the ordered one
+    this.registerColor(`${tab}header-unsorted`, {
+      dark: colorPalette.charcoal[200],
+      light: colorPalette.charcoal[200], // TODO
+    });
+
+    // color for most text in tables
+    this.registerColor(`${tab}body-text`, {
+      dark: colorPalette.gray[700],
+      light: colorPalette.gray[700], // TODO
+    });
+    // color for the text in the main column of the table (generally Name)
+    this.registerColor(`${tab}body-text-highlight`, {
+      dark: colorPalette.gray[300],
+      light: colorPalette.gray[300], // TODO
+    });
+    // color for the text in second line of main column, in secondary color (generally IDs)
+    this.registerColor(`${tab}body-text-sub-secondary`, {
+      dark: colorPalette.purple[400], // was violet[400]
+      light: colorPalette.purple[400], // TODO
+    });
+    // color for highlighted text in second line of main column
+    this.registerColor(`${tab}body-text-sub-highlight`, {
+      dark: colorPalette.gray[400],
+      light: colorPalette.gray[400], // TODO
     });
   }
 }

--- a/packages/main/src/plugin/color-registry.ts
+++ b/packages/main/src/plugin/color-registry.ts
@@ -448,8 +448,8 @@ export class ColorRegistry {
     });
 
     this.registerColor(`${ct}card-hover-bg`, {
-      dark: colorPalette.charcoal[500], // was zinc[700]
-      light: colorPalette.charcoal[500], // TODO
+      dark: colorPalette.charcoal[500],
+      light: colorPalette.purple[200],
     });
 
     this.registerColor(`${ct}card-text`, {
@@ -641,33 +641,33 @@ export class ColorRegistry {
     // color of columns names
     this.registerColor(`${tab}header-text`, {
       dark: colorPalette.gray[600],
-      light: colorPalette.gray[600], // TODO
+      light: colorPalette.charcoal[200],
     });
     // color of up/down arrows when column is not the ordered one
     this.registerColor(`${tab}header-unsorted`, {
       dark: colorPalette.charcoal[200],
-      light: colorPalette.charcoal[200], // TODO
+      light: colorPalette.charcoal[300],
     });
 
     // color for most text in tables
     this.registerColor(`${tab}body-text`, {
       dark: colorPalette.gray[700],
-      light: colorPalette.gray[700], // TODO
+      light: colorPalette.charcoal[300],
     });
     // color for the text in the main column of the table (generally Name)
     this.registerColor(`${tab}body-text-highlight`, {
       dark: colorPalette.gray[300],
-      light: colorPalette.gray[300], // TODO
+      light: colorPalette.charcoal[300],
     });
     // color for the text in second line of main column, in secondary color (generally IDs)
     this.registerColor(`${tab}body-text-sub-secondary`, {
-      dark: colorPalette.purple[400], // was violet[400]
-      light: colorPalette.purple[400], // TODO
+      dark: colorPalette.purple[400],
+      light: colorPalette.purple[700],
     });
     // color for highlighted text in second line of main column
     this.registerColor(`${tab}body-text-sub-highlight`, {
       dark: colorPalette.gray[400],
-      light: colorPalette.gray[400], // TODO
+      light: colorPalette.charcoal[200],
     });
   }
 }

--- a/packages/renderer/src/lib/image/ImageColumnName.spec.ts
+++ b/packages/renderer/src/lib/image/ImageColumnName.spec.ts
@@ -52,15 +52,15 @@ test('Expect simple column styling', async () => {
   const text = screen.getByText(image.name);
   expect(text).toBeInTheDocument();
   expect(text).toHaveClass('text-sm');
-  expect(text).toHaveClass('text-gray-300');
+  expect(text).toHaveClass('text-[var(--pd-table-body-text-highlight)]');
 
   const id = screen.getByText(image.shortId);
   expect(id).toBeInTheDocument();
-  expect(id).toHaveClass('text-violet-400');
+  expect(id).toHaveClass('text-[var(--pd-table-body-text-sub-secondary)]');
 
   const tag = screen.getByText(image.tag);
   expect(tag).toBeInTheDocument();
-  expect(tag).toHaveClass('text-gray-400');
+  expect(tag).toHaveClass('text-[var(--pd-table-body-text-sub-highlight)]');
   expect(tag).toHaveClass('font-extra-light');
 });
 

--- a/packages/renderer/src/lib/image/ImageColumnName.svelte
+++ b/packages/renderer/src/lib/image/ImageColumnName.svelte
@@ -13,7 +13,7 @@ function openDetailsImage(image: ImageInfoUI) {
 
 <button class="flex flex-col" on:click="{() => openDetailsImage(object)}">
   <div class="flex flex-row text-xs gap-1 items-center">
-    <div class="text-sm text-gray-300">{object.name}</div>
+    <div class="text-sm text-[var(--pd-table-body-text-highlight)]">{object.name}</div>
     {#if object.badges.length}
       {#each object.badges as badge}
         <Badge color="{badge.color}" label="{badge.label}" />
@@ -21,7 +21,7 @@ function openDetailsImage(image: ImageInfoUI) {
     {/if}
   </div>
   <div class="flex flex-row text-xs gap-1">
-    <div class="text-violet-400">{object.shortId}</div>
-    <div class="font-extra-light text-gray-400">{object.tag}</div>
+    <div class="text-[var(--pd-table-body-text-sub-secondary)]">{object.shortId}</div>
+    <div class="font-extra-light text-[var(--pd-table-body-text-sub-highlight)]">{object.tag}</div>
   </div>
 </button>

--- a/packages/renderer/src/lib/volume/VolumeColumnName.spec.ts
+++ b/packages/renderer/src/lib/volume/VolumeColumnName.spec.ts
@@ -49,7 +49,7 @@ test('Expect simple column styling', async () => {
   const text = screen.getByText(volume.shortName);
   expect(text).toBeInTheDocument();
   expect(text).toHaveClass('text-sm');
-  expect(text).toHaveClass('text-gray-300');
+  expect(text).toHaveClass('text-[var(--pd-table-body-text-highlight)]');
 });
 
 test('Expect clicking works', async () => {

--- a/packages/renderer/src/lib/volume/VolumeColumnName.svelte
+++ b/packages/renderer/src/lib/volume/VolumeColumnName.svelte
@@ -10,6 +10,8 @@ function openDetailsVolume(volume: VolumeInfoUI): void {
 }
 </script>
 
-<button class="hover:cursor-pointer flex text-sm text-gray-300" on:click="{() => openDetailsVolume(object)}">
+<button
+  class="hover:cursor-pointer flex text-sm text-[var(--pd-table-body-text-highlight)]"
+  on:click="{() => openDetailsVolume(object)}">
   {object.shortName}
 </button>

--- a/packages/ui/src/lib/table/DurationColumn.spec.ts
+++ b/packages/ui/src/lib/table/DurationColumn.spec.ts
@@ -32,7 +32,7 @@ test('Expect simple column styling', async () => {
   const text = screen.getByText('1 hour');
   expect(text).toBeInTheDocument();
   expect(text).toHaveClass('text-sm');
-  expect(text).toHaveClass('text-gray-700');
+  expect(text).toHaveClass('text-[var(--pd-table-body-text)]');
 });
 
 test('Expect 2s refresh on values less than a minute', async () => {

--- a/packages/ui/src/lib/table/SimpleColumn.spec.ts
+++ b/packages/ui/src/lib/table/SimpleColumn.spec.ts
@@ -30,7 +30,7 @@ test('Expect simple column styling', async () => {
   const text = screen.getByText(obj);
   expect(text).toBeInTheDocument();
   expect(text).toHaveClass('text-sm');
-  expect(text).toHaveClass('text-gray-700');
+  expect(text).toHaveClass('text-[var(--pd-table-body-text)]');
   expect(text).toHaveClass('max-w-full');
   expect(text).toHaveClass('overflow-hidden');
   expect(text).toHaveClass('text-ellipsis');

--- a/packages/ui/src/lib/table/SimpleColumn.svelte
+++ b/packages/ui/src/lib/table/SimpleColumn.svelte
@@ -2,6 +2,6 @@
 export let object: string;
 </script>
 
-<div class="text-sm text-gray-700 max-w-full overflow-hidden text-ellipsis">
+<div class="text-sm text-[var(--pd-table-body-text)] max-w-full overflow-hidden text-ellipsis">
   {object}
 </div>

--- a/packages/ui/src/lib/table/Table.svelte
+++ b/packages/ui/src/lib/table/Table.svelte
@@ -130,7 +130,7 @@ function setGridColumns(): void {
   <!-- Table header -->
   <div role="rowgroup">
     <div
-      class="grid grid-table gap-x-0.5 mx-5 h-7 sticky top-0 bg-charcoal-700 text-xs text-gray-600 font-bold uppercase z-[2]"
+      class="grid grid-table gap-x-0.5 mx-5 h-7 sticky top-0 bg-[var(--pd-content-bg)] text-xs text-[var(--pd-table-header-text)] font-bold uppercase z-[2]"
       role="row">
       <div class="whitespace-nowrap justify-self-start" role="columnheader"></div>
       {#if row.info.selectable}
@@ -163,7 +163,7 @@ function setGridColumns(): void {
               class:fa-sort="{sortCol !== column}"
               class:fa-sort-up="{sortCol === column && sortAscending}"
               class:fa-sort-down="{sortCol === column && !sortAscending}"
-              class:text-charcoal-200="{sortCol !== column}"
+              class:text-[var(--pd-table-header-unsorted)]="{sortCol !== column}"
               aria-hidden="true"></i
             >{/if}
         </div>
@@ -174,7 +174,7 @@ function setGridColumns(): void {
   <div role="rowgroup">
     {#each data as object (object)}
       <div
-        class="grid grid-table gap-x-0.5 mx-5 min-h-[48px] h-fit bg-charcoal-800 hover:bg-zinc-700 rounded-lg mb-2"
+        class="grid grid-table gap-x-0.5 mx-5 min-h-[48px] h-fit bg-[var(--pd-content-card-bg)] hover:bg-[var(--pd-content-card-hover-bg)] rounded-lg mb-2"
         animate:flip="{{ duration: 300 }}"
         role="row"
         aria-label="{object.name}">


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Light mode for Images and Volumes table

- `table-...` color registry is added
-  `zinc-700` (not in the colors palette) is replaced by `charcoal-500`
- `violet-400 (not in the colors palette) is replaced by `purple-400`
- light mode colors are defined 
- 
### Screenshot / video of UI

<img width="1118" alt="light-mode-images" src="https://github.com/containers/podman-desktop/assets/9973512/3dbe9f53-53c2-44f4-a5c4-adeaf8b880ad">

### What issues does this PR fix or reference?

Fixes #6890

### How to test this PR?
