### PR TITLE
chore: remove test containerfile

### DIFF
--- a/tests/playwright/resources/bootable-containerfile
+++ b/tests/playwright/resources/bootable-containerfile
@@ -1,4 +1,0 @@
-FROM quay.io/centos-bootc/fedora-bootc:eln
-
-# Change the root password
-RUN echo "root:supersecret" | chpasswd


### PR DESCRIPTION
chore: remove test containerfile

### What does this PR do?

Removes an old bootc container file that is no longer needed / should
not be referenced (uses an old FROM, as well as very insecure RUN
command)

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/A

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

N/A

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

N/A

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
