### PR TITLE
chore: checkbox light mode

### DIFF
--- a/packages/main/src/plugin/color-registry.ts
+++ b/packages/main/src/plugin/color-registry.ts
@@ -231,6 +231,7 @@ export class ColorRegistry {
     this.initInvertContent();
     this.initCardContent();
     this.initInputBox();
+    this.initCheckbox();
   }
 
   protected initGlobalNav(): void {
@@ -541,6 +542,40 @@ export class ColorRegistry {
     this.registerColor(`${sNav}hover-icon`, {
       dark: colorPalette.gray[500],
       light: colorPalette.gray[500],
+    });
+  }
+
+  // chexkboxes
+  protected initCheckbox(): void {
+    const sNav = 'input-checkbox-';
+
+    this.registerColor(`${sNav}disabled`, {
+      dark: colorPalette.charcoal[300],
+      light: colorPalette.charcoal[300],
+    });
+    this.registerColor(`${sNav}indeterminate`, {
+      dark: colorPalette.dustypurple[500],
+      light: colorPalette.dustypurple[500],
+    });
+    this.registerColor(`${sNav}focused-indeterminate`, {
+      dark: colorPalette.dustypurple[400],
+      light: colorPalette.dustypurple[600],
+    });
+    this.registerColor(`${sNav}checked`, {
+      dark: colorPalette.purple[500],
+      light: colorPalette.purple[500],
+    });
+    this.registerColor(`${sNav}focused-checked`, {
+      dark: colorPalette.purple[400],
+      light: colorPalette.purple[600],
+    });
+    this.registerColor(`${sNav}unchecked`, {
+      dark: colorPalette.gray[400],
+      light: colorPalette.charcoal[700],
+    });
+    this.registerColor(`${sNav}focused-unchecked`, {
+      dark: colorPalette.purple[500],
+      light: colorPalette.purple[500],
     });
   }
 }

--- a/packages/main/src/plugin/color-registry.ts
+++ b/packages/main/src/plugin/color-registry.ts
@@ -550,32 +550,32 @@ export class ColorRegistry {
     const sNav = 'input-checkbox-';
 
     this.registerColor(`${sNav}disabled`, {
-      dark: colorPalette.charcoal[300],
-      light: colorPalette.charcoal[300],
+      dark: colorPalette.gray[700],
+      light: colorPalette.charcoal[200],
     });
     this.registerColor(`${sNav}indeterminate`, {
-      dark: colorPalette.dustypurple[500],
-      light: colorPalette.dustypurple[500],
+      dark: colorPalette.purple[500],
+      light: colorPalette.purple[900],
     });
     this.registerColor(`${sNav}focused-indeterminate`, {
-      dark: colorPalette.dustypurple[400],
-      light: colorPalette.dustypurple[600],
+      dark: colorPalette.purple[400],
+      light: colorPalette.purple[700],
     });
     this.registerColor(`${sNav}checked`, {
       dark: colorPalette.purple[500],
-      light: colorPalette.purple[500],
+      light: colorPalette.purple[900],
     });
     this.registerColor(`${sNav}focused-checked`, {
       dark: colorPalette.purple[400],
-      light: colorPalette.purple[600],
+      light: colorPalette.purple[700],
     });
     this.registerColor(`${sNav}unchecked`, {
       dark: colorPalette.gray[400],
-      light: colorPalette.charcoal[700],
+      light: colorPalette.purple[900],
     });
     this.registerColor(`${sNav}focused-unchecked`, {
-      dark: colorPalette.purple[500],
-      light: colorPalette.purple[500],
+      dark: colorPalette.purple[400],
+      light: colorPalette.purple[700],
     });
   }
 }

--- a/packages/ui/src/lib/checkbox/Checkbox.spec.ts
+++ b/packages/ui/src/lib/checkbox/Checkbox.spec.ts
@@ -36,6 +36,51 @@ test('Basic check', async () => {
   const checkbox = screen.getByRole('checkbox');
   expect(checkbox).toBeInTheDocument();
   expect(checkbox).toBeEnabled();
+
+  const peer = getPeer(checkbox);
+  expect(peer).toBeInTheDocument();
+  expect(peer).toHaveClass('cursor-pointer');
+
+  const icon = peer?.children[0];
+  expect(icon).toBeInTheDocument();
+  expect(icon).toHaveClass('text-[var(--pd-input-checkbox-unchecked)]');
+  expect(icon).toHaveClass('hover:text-[var(--pd-input-checkbox-focused-unchecked)]');
+});
+
+test('Check checked state', async () => {
+  render(Checkbox, { checked: true });
+
+  // check element exists and is enabled
+  const checkbox = screen.getByRole('checkbox');
+  expect(checkbox).toBeInTheDocument();
+  expect(checkbox).toBeEnabled();
+
+  const peer = getPeer(checkbox);
+  expect(peer).toBeInTheDocument();
+  expect(peer).toHaveClass('cursor-pointer');
+
+  const icon = peer?.children[0];
+  expect(icon).toBeInTheDocument();
+  expect(icon).toHaveClass('text-[var(--pd-input-checkbox-checked)]');
+  expect(icon).toHaveClass('hover:text-[var(--pd-input-checkbox-focused-checked)]');
+});
+
+test('Check indeterminate state', async () => {
+  render(Checkbox, { indeterminate: true });
+
+  // check element exists and is enabled
+  const checkbox = screen.getByRole('checkbox');
+  expect(checkbox).toBeInTheDocument();
+  expect(checkbox).toBeEnabled();
+
+  const peer = getPeer(checkbox);
+  expect(peer).toBeInTheDocument();
+  expect(peer).toHaveClass('cursor-pointer');
+
+  const icon = peer?.children[0];
+  expect(icon).toBeInTheDocument();
+  expect(icon).toHaveClass('text-[var(--pd-input-checkbox-indeterminate)]');
+  expect(icon).toHaveClass('hover:text-[var(--pd-input-checkbox-focused-indeterminate)]');
 });
 
 test('Check disabled state', async () => {
@@ -50,6 +95,10 @@ test('Check disabled state', async () => {
   const peer = getPeer(checkbox);
   expect(peer).toBeInTheDocument();
   expect(peer).toHaveClass('cursor-not-allowed');
+
+  const icon = peer?.children[0];
+  expect(icon).toBeInTheDocument();
+  expect(icon).toHaveClass('text-[var(--pd-input-checkbox-disabled)]');
 });
 
 test('Check tooltips', async () => {

--- a/packages/ui/src/lib/checkbox/Checkbox.svelte
+++ b/packages/ui/src/lib/checkbox/Checkbox.svelte
@@ -32,13 +32,22 @@ function onClick(
     class:cursor-pointer="{!disabled}"
     class:cursor-not-allowed="{disabled}">
     {#if disabled}
-      <Fa size="1.1x" icon="{faSquare}" class="text-charcoal-300" />
+      <Fa size="1.1x" icon="{faSquare}" class="text-[var(--pd-input-checkbox-disabled)]" />
     {:else if indeterminate}
-      <Fa size="1.1x" icon="{faMinusSquare}" class="text-dustypurple-500" />
+      <Fa
+        size="1.1x"
+        icon="{faMinusSquare}"
+        class="text-[var(--pd-input-checkbox-indeterminate)] hover:text-[var(--pd-input-checkbox-focused-indeterminate)]" />
     {:else if checked}
-      <Fa size="1.1x" icon="{faCheckSquare}" class="text-purple-500" />
+      <Fa
+        size="1.1x"
+        icon="{faCheckSquare}"
+        class="text-[var(--pd-input-checkbox-checked)] hover:text-[var(--pd-input-checkbox-focused-checked)]" />
     {:else}
-      <Fa size="1.1x" icon="{faOutlineSquare}" class="text-gray-400" />
+      <Fa
+        size="1.1x"
+        icon="{faOutlineSquare}"
+        class="text-[var(--pd-input-checkbox-unchecked)] hover:text-[var(--pd-input-checkbox-focused-unchecked)]" />
     {/if}
   </div>
   <input


### PR DESCRIPTION
### What does this PR do?

Add entries to the color registry for checkbox, with support for light mode. Light mode colors are the same for now since I couldn't find a precedent, except for unchecked.

Took this opportunity to add focus (hover) states since they were missing and didn't match other UI elements. For unchecked the outline becomes purple, for all other states it's one step lighter for dark mode and darker for light mode.

### Screenshot / video of UI

https://github.com/containers/podman-desktop/assets/19958075/e61f5f1d-b86e-4142-973c-1c698fbfce47

### What issues does this PR fix or reference?

Part of #4914.

### How to test this PR?

View checkboxes on main pages; tests added.

- [x] Tests are covering the bug fix or the new feature