### PR TITLE
chore: expose appearance preference

### DIFF
--- a/packages/main/src/plugin/appearance-init.ts
+++ b/packages/main/src/plugin/appearance-init.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023, 2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,15 +25,14 @@ export class AppearanceInit {
   init(): void {
     const appearanceConfiguration: IConfigurationNode = {
       id: 'preferences.appearance',
-      title: 'Appearance',
+      title: 'Experimental Appearance',
       type: 'object',
       properties: {
         [AppearanceSettings.SectionName + '.' + AppearanceSettings.Appearance]: {
-          description: 'Appearance',
+          description: 'Experimental setting to test support for light mode',
           type: 'string',
           enum: ['system', 'dark', 'light'],
           default: 'system',
-          hidden: true,
         },
       },
     };


### PR DESCRIPTION
### What does this PR do?

We have four PRs in review for light mode, and hopefully only a few more until it still has issues but might be ready for experimental support/early feedback. It takes longer to test because the preference is hidden.

Creating this draft PR to make it easy to apply and test, and so that it's ready when the time comes.

### Screenshot / video of UI

<img width="529" alt="Screenshot 2024-05-10 at 4 59 37 PM" src="https://github.com/containers/podman-desktop/assets/19958075/a026f24a-8349-451e-b605-a4f93b677a7b">

### What issues does this PR fix or reference?

Fixes #7362.

### How to test this PR?

Just confirm the setting is visible, and appearance changes when you change it.