### PR TITLE
feat: migrate MessageBox to modal component

### DIFF
--- a/packages/renderer/src/lib/dialogs/MessageBox.svelte
+++ b/packages/renderer/src/lib/dialogs/MessageBox.svelte
@@ -8,7 +8,6 @@ import Fa from 'svelte-fa';
 import Modal from '/@/lib/dialogs/Modal.svelte';
 import CloseButton from '/@/lib/ui/CloseButton.svelte';
 
-import { tabWithinParent } from './dialog-utils';
 import type { MessageBoxOptions } from './messagebox-input';
 
 let currentId = 0;
@@ -22,8 +21,6 @@ let defaultId: number;
 let buttonOrder: number[];
 
 let display = false;
-
-let messageBox: HTMLDivElement;
 
 const showMessageBoxCallback = (messageBoxParameter: unknown) => {
   const options: MessageBoxOptions | undefined = messageBoxParameter as MessageBoxOptions;
@@ -98,21 +95,9 @@ function clickButton(index?: number) {
   cleanup();
 }
 
-function handleKeydown(e: KeyboardEvent) {
-  if (!display) {
-    return;
-  }
-
-  if (e.key === 'Escape') {
-    // if there is a cancel button use its id, otherwise undefined
-    window.sendShowMessageBoxOnSelect(currentId, cancelId >= 0 ? cancelId : undefined);
-    cleanup();
-    e.preventDefault();
-  }
-
-  if (e.key === 'Tab') {
-    tabWithinParent(e, messageBox);
-  }
+function onClose() {
+  window.sendShowMessageBoxOnSelect(currentId, cancelId >= 0 ? cancelId : undefined);
+  cleanup();
 }
 
 function getButtonType(b: boolean): ButtonType {
@@ -124,10 +109,8 @@ function getButtonType(b: boolean): ButtonType {
 }
 </script>
 
-<svelte:window on:keydown="{handleKeydown}" />
-
 {#if display}
-  <Modal>
+  <Modal name="{title}" on:close="{onClose}">
     <div class="flex items-center justify-between pl-4 pr-3 py-3 space-x-2 text-gray-400">
       {#if type === 'error'}
         <Fa class="h-4 w-4 text-red-500" icon="{faCircleExclamation}" />

--- a/packages/renderer/src/lib/dialogs/MessageBox.svelte
+++ b/packages/renderer/src/lib/dialogs/MessageBox.svelte
@@ -5,6 +5,7 @@ import { Button, type ButtonType } from '@podman-desktop/ui-svelte';
 import { onDestroy, onMount } from 'svelte';
 import Fa from 'svelte-fa';
 
+import Modal from '/@/lib/dialogs/Modal.svelte';
 import CloseButton from '/@/lib/ui/CloseButton.svelte';
 
 import { tabWithinParent } from './dialog-utils';
@@ -126,49 +127,41 @@ function getButtonType(b: boolean): ButtonType {
 <svelte:window on:keydown="{handleKeydown}" />
 
 {#if display}
-  <!-- Create overlay-->
-  <div class="fixed top-0 left-0 right-0 bottom-0 bg-black bg-opacity-60 bg-blend-multiply h-full grid z-50">
-    <div
-      class="flex flex-col place-self-center w-[550px] rounded-xl bg-charcoal-800 shadow-xl shadow-black"
-      role="dialog"
-      aria-labelledby="{title}"
-      aria-label="{title}"
-      bind:this="{messageBox}">
-      <div class="flex items-center justify-between pl-4 pr-3 py-3 space-x-2 text-gray-400">
-        {#if type === 'error'}
-          <Fa class="h-4 w-4 text-red-500" icon="{faCircleExclamation}" />
-        {:else if type === 'warning'}
-          <Fa class="h-4 w-4 text-amber-400" icon="{faTriangleExclamation}" />
-        {:else if type === 'info'}
-          <div class="flex">
-            <Fa class="h-4 w-4 place-content-center" icon="{faCircle}" />
-            <Fa class="h-4 w-4 place-content-center -ml-4 mt-px text-xs" icon="{faInfo}" />
-          </div>
-        {:else if type === 'question'}
-          <Fa class="h-4 w-4" icon="{faCircleQuestion}" />
-        {/if}
-        <h1 class="grow text-lg font-bold capitalize">{title}</h1>
+  <Modal>
+    <div class="flex items-center justify-between pl-4 pr-3 py-3 space-x-2 text-gray-400">
+      {#if type === 'error'}
+        <Fa class="h-4 w-4 text-red-500" icon="{faCircleExclamation}" />
+      {:else if type === 'warning'}
+        <Fa class="h-4 w-4 text-amber-400" icon="{faTriangleExclamation}" />
+      {:else if type === 'info'}
+        <div class="flex">
+          <Fa class="h-4 w-4 place-content-center" icon="{faCircle}" />
+          <Fa class="h-4 w-4 place-content-center -ml-4 mt-px text-xs" icon="{faInfo}" />
+        </div>
+      {:else if type === 'question'}
+        <Fa class="h-4 w-4" icon="{faCircleQuestion}" />
+      {/if}
+      <h1 class="grow text-lg font-bold capitalize">{title}</h1>
 
-        <CloseButton on:click="{() => clickButton(cancelId >= 0 ? cancelId : undefined)}" />
-      </div>
-
-      <div class="max-h-80 overflow-auto">
-        <div class="px-10 py-4 text-sm text-gray-500 leading-5" aria-label="Dialog Message">{message}</div>
-
-        {#if detail}
-          <div class="px-10 pb-4 text-sm text-gray-500 leading-5" aria-label="Dialog Details">{detail}</div>
-        {/if}
-      </div>
-
-      <div class="px-5 py-5 mt-2 flex flex-row w-full justify-end space-x-5">
-        {#each buttonOrder as i}
-          {#if i === cancelId}
-            <Button type="link" aria-label="Cancel" on:click="{() => clickButton(i)}">Cancel</Button>
-          {:else}
-            <Button type="{getButtonType(defaultId === i)}" on:click="{() => clickButton(i)}">{buttons[i]}</Button>
-          {/if}
-        {/each}
-      </div>
+      <CloseButton on:click="{() => clickButton(cancelId >= 0 ? cancelId : undefined)}" />
     </div>
-  </div>
+
+    <div class="max-h-80 overflow-auto">
+      <div class="px-10 py-4 text-sm text-gray-500 leading-5" aria-label="Dialog Message">{message}</div>
+
+      {#if detail}
+        <div class="px-10 pb-4 text-sm text-gray-500 leading-5" aria-label="Dialog Details">{detail}</div>
+      {/if}
+    </div>
+
+    <div class="px-5 py-5 mt-2 flex flex-row w-full justify-end space-x-5">
+      {#each buttonOrder as i}
+        {#if i === cancelId}
+          <Button type="link" aria-label="Cancel" on:click="{() => clickButton(i)}">Cancel</Button>
+        {:else}
+          <Button type="{getButtonType(defaultId === i)}" on:click="{() => clickButton(i)}">{buttons[i]}</Button>
+        {/if}
+      {/each}
+    </div>
+  </Modal>
 {/if}

--- a/packages/renderer/src/lib/dialogs/Modal.svelte
+++ b/packages/renderer/src/lib/dialogs/Modal.svelte
@@ -37,7 +37,7 @@ if (previously_focused) {
   on:click="{close}"></button>
 
 <div
-  class="absolute bg-charcoal-800 top-1/2 left-1/2 z-50 rounded translate-x-[-50%] translate-y-[-50%] overflow-auto w-[calc(200vw-4em)] max-w-[42em] max-h-[calc(100vh-4em)]"
+  class="absolute bg-charcoal-800 top-1/2 left-1/2 z-50 rounded-xl translate-x-[-50%] translate-y-[-50%] overflow-auto w-[calc(200vw-4em)] max-w-[42em] max-h-[calc(100vh-4em)]"
   role="dialog"
   aria-label="{name}"
   aria-modal="true"

--- a/packages/renderer/src/lib/dialogs/Modal.svelte
+++ b/packages/renderer/src/lib/dialogs/Modal.svelte
@@ -31,16 +31,18 @@ if (previously_focused) {
 
 <svelte:window on:keydown="{handle_keydown}" />
 
-<button
-  aria-label="close"
-  class="fixed top-0 left-0 w-full h-full bg-black bg-opacity-60 bg-blend-multiply z-40"
-  on:click="{close}"></button>
+<div class="absolute w-full h-full flex justify-center items-center">
+  <button
+    aria-label="close"
+    class="fixed top-0 left-0 w-full h-full bg-black bg-opacity-60 bg-blend-multiply z-40"
+    on:click="{close}"></button>
 
-<div
-  class="absolute bg-charcoal-800 top-1/2 left-1/2 z-50 rounded-xl translate-x-[-50%] translate-y-[-50%] overflow-auto w-[calc(200vw-4em)] max-w-[42em] max-h-[calc(100vh-4em)]"
-  role="dialog"
-  aria-label="{name}"
-  aria-modal="true"
-  bind:this="{modal}">
-  <slot />
+  <div
+    class="bg-charcoal-800 z-50 rounded-xl overflow-auto w-[calc(200vw-4em)] h-fit translate-y-[-20%] max-w-[42em] max-h-[calc(100vh-4em)]"
+    role="dialog"
+    aria-label="{name}"
+    aria-modal="true"
+    bind:this="{modal}">
+    <slot />
+  </div>
 </div>

--- a/packages/renderer/src/lib/dialogs/Modal.svelte
+++ b/packages/renderer/src/lib/dialogs/Modal.svelte
@@ -37,7 +37,7 @@ if (previously_focused) {
   on:click="{close}"></button>
 
 <div
-  class="absolute top-1/2 left-1/2 z-50 rounded translate-x-[-50%] translate-y-[-50%] overflow-auto w-[calc(200vw-4em)] max-w-[42em] max-h-[calc(100vh-4em)]"
+  class="absolute bg-charcoal-800 top-1/2 left-1/2 z-50 rounded translate-x-[-50%] translate-y-[-50%] overflow-auto w-[calc(200vw-4em)] max-w-[42em] max-h-[calc(100vh-4em)]"
   role="dialog"
   aria-label="{name}"
   aria-modal="true"


### PR DESCRIPTION
### What does this PR do?

The ErrorMessage component is using its own modal logic implementation, this lead to inconsistent UI as we have several time the same code with small variation.

### Screenshot / video of UI

| Before | After |
| --- | --- |
| ![image](https://github.com/containers/podman-desktop/assets/42176370/65dbda28-0805-4906-ac3f-717fbb271330) | ![image](https://github.com/containers/podman-desktop/assets/42176370/03c04a37-8c27-4f6d-aa0e-ab36a71dcb9d) |
|  ![image](https://github.com/containers/podman-desktop/assets/42176370/d56166df-66fd-4416-90ce-d201029f7b8f) | ![image](https://github.com/containers/podman-desktop/assets/42176370/9de62584-14e7-47d7-a615-3096e4f5e4ab) |
| ![image](https://github.com/containers/podman-desktop/assets/42176370/82b33585-9307-40c9-b73b-a298fd5f0501) | ![image](https://github.com/containers/podman-desktop/assets/42176370/2eb78b6e-faba-433d-aa5d-950b7399be69) |

### What issues does this PR fix or reference?

Required to complete https://github.com/containers/podman-desktop/issues/6906#issuecomment-2106858890

See https://github.com/containers/podman-desktop/pull/7125#issuecomment-2098385540 for reference 

ℹ️ Ideally I would like to include https://github.com/containers/podman-desktop/issues/7152 in the future to avoid those big {#if}...

Fixes https://github.com/containers/podman-desktop/issues/7177

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature (`MessageBox.spec.ts` ensure no regression)
