### PR TITLE
chore: table column ellipsis

### DIFF
--- a/packages/ui/src/lib/table/DurationColumn.svelte
+++ b/packages/ui/src/lib/table/DurationColumn.svelte
@@ -3,6 +3,8 @@ import humanizeDuration from 'humanize-duration';
 import moment from 'moment';
 import { onDestroy, onMount } from 'svelte';
 
+import SimpleColumn from './SimpleColumn.svelte';
+
 export let object: Date | undefined;
 let duration: string = '';
 let refreshTimeouts: number[] = [];
@@ -61,6 +63,4 @@ onDestroy(() => {
 });
 </script>
 
-<div class="text-sm text-gray-700">
-  {duration}
-</div>
+<SimpleColumn object="{duration}" />

--- a/packages/ui/src/lib/table/SimpleColumn.spec.ts
+++ b/packages/ui/src/lib/table/SimpleColumn.spec.ts
@@ -31,4 +31,7 @@ test('Expect simple column styling', async () => {
   expect(text).toBeInTheDocument();
   expect(text).toHaveClass('text-sm');
   expect(text).toHaveClass('text-gray-700');
+  expect(text).toHaveClass('max-w-full');
+  expect(text).toHaveClass('overflow-hidden');
+  expect(text).toHaveClass('text-ellipsis');
 });

--- a/packages/ui/src/lib/table/SimpleColumn.svelte
+++ b/packages/ui/src/lib/table/SimpleColumn.svelte
@@ -2,6 +2,6 @@
 export let object: string;
 </script>
 
-<div class="text-sm text-gray-700">
+<div class="text-sm text-gray-700 max-w-full overflow-hidden text-ellipsis">
   {object}
 </div>

--- a/packages/ui/src/lib/table/Table.spec.ts
+++ b/packages/ui/src/lib/table/Table.spec.ts
@@ -53,12 +53,31 @@ test('Expect basic column headers', async () => {
   expect(headers.length).toBe(6);
   expect(headers[2].textContent).toContain('Id');
   expect(headers[2]).toHaveClass('select-none');
+  expect(headers[2]).toHaveClass('max-w-full');
+  expect(headers[2]).toHaveClass('overflow-hidden');
+  expect(headers[2].children[0]).toHaveClass('overflow-hidden');
+  expect(headers[2].children[0]).toHaveClass('text-ellipsis');
+
   expect(headers[3].textContent).toContain('Name');
   expect(headers[3]).toHaveClass('select-none');
+  expect(headers[3]).toHaveClass('max-w-full');
+  expect(headers[3]).toHaveClass('overflow-hidden');
+  expect(headers[3].children[0]).toHaveClass('overflow-hidden');
+  expect(headers[3].children[0]).toHaveClass('text-ellipsis');
+
   expect(headers[4].textContent).toContain('Age');
   expect(headers[4]).toHaveClass('select-none');
+  expect(headers[4]).toHaveClass('max-w-full');
+  expect(headers[4]).toHaveClass('overflow-hidden');
+  expect(headers[4].children[0]).toHaveClass('overflow-hidden');
+  expect(headers[4].children[0]).toHaveClass('text-ellipsis');
+
   expect(headers[5].textContent).toContain('Hobby');
   expect(headers[5]).toHaveClass('select-none');
+  expect(headers[5]).toHaveClass('max-w-full');
+  expect(headers[5]).toHaveClass('overflow-hidden');
+  expect(headers[5].children[0]).toHaveClass('overflow-hidden');
+  expect(headers[5].children[0]).toHaveClass('text-ellipsis');
 });
 
 test('Expect column sort indicators', async () => {

--- a/packages/ui/src/lib/table/Table.svelte
+++ b/packages/ui/src/lib/table/Table.svelte
@@ -147,7 +147,7 @@ function setGridColumns(): void {
         <!-- svelte-ignore a11y-click-events-have-key-events -->
         <!-- svelte-ignore a11y-interactive-supports-focus -->
         <div
-          class="whitespace-nowrap {column.info.align === 'right'
+          class="max-w-full overflow-hidden flex flex-row items-center whitespace-nowrap {column.info.align === 'right'
             ? 'justify-self-end'
             : column.info.align === 'center'
               ? 'justify-self-center'
@@ -155,7 +155,10 @@ function setGridColumns(): void {
           class:cursor-pointer="{column.info.comparator}"
           on:click="{sort.bind(undefined, column)}"
           role="columnheader">
-          {column.title}{#if column.info.comparator}<i
+          <div class="overflow-hidden text-ellipsis">
+            {column.title}
+          </div>
+          {#if column.info.comparator}<i
               class="fas pl-0.5"
               class:fa-sort="{sortCol !== column}"
               class:fa-sort-up="{sortCol === column && sortAscending}"


### PR DESCRIPTION
### What does this PR do?

Adds ellipsis to the standard table components when columns are too narrow: column headers, simple columns, and duration columns. For the header a div is added so that the sort indicators are always visible, and DurationColumn can simplify by just being a SimpleColumn.

This does not cover any custom columns, of which there are many to fix in future PRs.

### Screenshot / video of UI

Before:

<img width="238" alt="Screenshot 2024-05-13 at 3 55 20 PM" src="https://github.com/containers/podman-desktop/assets/19958075/27b8cf29-5484-47b9-8db8-69c85e1f0c27">

Used PR #7184 to make it easier to get this all in one image and screenshot is somewhat arbitrary, but note Environment header moving off to the left and Age header getting pushed to the right, months and MB cutoff.

After:

<img width="238" alt="Screenshot 2024-05-13 at 3 54 42 PM" src="https://github.com/containers/podman-desktop/assets/19958075/7277caee-cbb5-46fd-a7d3-1effcd2dc3d1">

### What issues does this PR fix or reference?

Fixes #7195.

### How to test this PR?

Images view with #7184 used for image above, but there are SimpleColumns elsewhere. If you don't have any especially long content at the moment use ctrl-+ to make the font bigger.

- [x] Tests are covering the bug fix or the new feature