### PR TITLE
chore: removing duplicates definition of KubernetesGeneratorSelector

### DIFF
--- a/packages/main/src/plugin/api/KubernetesGeneratorInfo.ts
+++ b/packages/main/src/plugin/api/KubernetesGeneratorInfo.ts
@@ -15,7 +15,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
-import type { KubernetesGeneratorSelector } from '../kube-generator-registry.js';
+import type { KubernetesGeneratorSelector } from '@podman-desktop/api';
 
 export interface KubernetesGeneratorInfo {
   id: string;

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -43,11 +43,7 @@ import { app, BrowserWindow, clipboard, ipcMain, shell } from 'electron';
 import type { IpcMainInvokeEvent } from 'electron/main';
 
 import type { KubernetesGeneratorInfo } from '/@/plugin/api/KubernetesGeneratorInfo.js';
-import type {
-  GenerateKubeResult,
-  KubernetesGeneratorArgument,
-  KubernetesGeneratorSelector,
-} from '/@/plugin/kube-generator-registry.js';
+import type { GenerateKubeResult, KubernetesGeneratorArgument } from '/@/plugin/kube-generator-registry.js';
 import { KubeGeneratorRegistry } from '/@/plugin/kube-generator-registry.js';
 import type { Menu } from '/@/plugin/menu-registry.js';
 import { MenuRegistry } from '/@/plugin/menu-registry.js';
@@ -1223,7 +1219,7 @@ export class PluginSystem {
 
     this.ipcHandle(
       'kube-generator-registry:getKubeGeneratorsInfos',
-      async (_, selector?: KubernetesGeneratorSelector): Promise<KubernetesGeneratorInfo[]> => {
+      async (_, selector?: containerDesktopAPI.KubernetesGeneratorSelector): Promise<KubernetesGeneratorInfo[]> => {
         return kubeGeneratorRegistry.getKubeGeneratorsInfos(selector);
       },
     );

--- a/packages/main/src/plugin/kube-generator-registry.spec.ts
+++ b/packages/main/src/plugin/kube-generator-registry.spec.ts
@@ -16,9 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { KubernetesGeneratorSelector } from '@podman-desktop/api';
 import { expect, test, vi } from 'vitest';
 
-import type { KubernetesGeneratorSelector } from '/@/plugin/kube-generator-registry.js';
 import { KubeGeneratorRegistry } from '/@/plugin/kube-generator-registry.js';
 
 test('Creating KubeGeneratorRegistry and getting KubeGeneratorsInfos', async () => {

--- a/packages/main/src/plugin/kube-generator-registry.ts
+++ b/packages/main/src/plugin/kube-generator-registry.ts
@@ -15,12 +15,10 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
+import type { KubernetesGeneratorSelector } from '@podman-desktop/api';
+
 import type { KubernetesGeneratorInfo } from './api/KubernetesGeneratorInfo.js';
 import { Disposable } from './types/disposable.js';
-
-export type KubernetesGeneratorType = 'Compose' | 'Pod' | 'Container';
-
-export type KubernetesGeneratorSelector = KubernetesGeneratorType | ReadonlyArray<KubernetesGeneratorType>;
 
 export interface GenerateKubeResult {
   yaml: string;

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -88,11 +88,7 @@ import type {
 } from '../../main/src/plugin/dockerode/libpod-dockerode';
 import type { CatalogExtension } from '../../main/src/plugin/extensions-catalog/extensions-catalog-api';
 import type { FeaturedExtension } from '../../main/src/plugin/featured/featured-api';
-import type {
-  GenerateKubeResult,
-  KubernetesGeneratorArgument,
-  KubernetesGeneratorSelector,
-} from '../../main/src/plugin/kube-generator-registry';
+import type { GenerateKubeResult, KubernetesGeneratorArgument } from '../../main/src/plugin/kube-generator-registry';
 import type { KubeContext } from '../../main/src/plugin/kubernetes-context';
 import type { ContextGeneralState, ResourceName } from '../../main/src/plugin/kubernetes-context-state.js';
 import type { Guide } from '../../main/src/plugin/learning-center/learning-center-api';
@@ -1139,7 +1135,7 @@ export function initExposure(): void {
 
   contextBridge.exposeInMainWorld(
     'getKubeGeneratorsInfos',
-    async (selector?: KubernetesGeneratorSelector): Promise<KubernetesGeneratorInfo[]> => {
+    async (selector?: containerDesktopAPI.KubernetesGeneratorSelector): Promise<KubernetesGeneratorInfo[]> => {
       return ipcInvoke('kube-generator-registry:getKubeGeneratorsInfos', selector);
     },
   );


### PR DESCRIPTION
### What does this PR do?

We are using a duplicate definition of KubernetesGeneratorSelector, when the one from the `@podman-desktop/api` is the same.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Would be great and would simplify https://github.com/containers/podman-desktop/issues/6300

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- Pipeline should be ✅ 
