### PR TITLE
chore: link light mode

### DIFF
--- a/packages/main/src/plugin/color-registry.ts
+++ b/packages/main/src/plugin/color-registry.ts
@@ -237,6 +237,7 @@ export class ColorRegistry {
     this.initDetails();
     this.initTab();
     this.initModal();
+    this.initLink();
   }
 
   protected initGlobalNav(): void {
@@ -791,6 +792,20 @@ export class ColorRegistry {
     this.registerColor(`${modal}border`, {
       dark: colorPalette.charcoal[500],
       light: colorPalette.gray[200],
+    });
+  }
+
+  // links
+  protected initLink(): void {
+    const link = 'link';
+
+    this.registerColor(`${link}`, {
+      dark: colorPalette.purple[400],
+      light: colorPalette.purple[700],
+    });
+    this.registerColor(`${link}-hover-bg`, {
+      dark: colorPalette.white + '2',
+      light: colorPalette.black + '2',
     });
   }
 }

--- a/packages/ui/src/lib/link/Link.spec.ts
+++ b/packages/ui/src/lib/link/Link.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023,2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,9 +32,8 @@ test('Check link styling', async () => {
   // check for one element of the styling
   const link = screen.getByRole('link');
   expect(link).toBeInTheDocument();
-  expect(link).toHaveClass('text-purple-400');
-  expect(link).toHaveClass('hover:bg-white');
-  expect(link).toHaveClass('hover:bg-opacity-10');
+  expect(link).toHaveClass('text-[var(--pd-link)]');
+  expect(link).toHaveClass('hover:bg-[var(--pd-link-hover-bg)]');
   expect(link).toHaveClass('cursor-pointer');
 });
 

--- a/packages/ui/src/lib/link/Link.svelte
+++ b/packages/ui/src/lib/link/Link.svelte
@@ -29,7 +29,7 @@ function click(): void {
 <!-- svelte-ignore a11y-no-redundant-roles -->
 <!-- svelte-ignore a11y-interactive-supports-focus -->
 <a
-  class="text-purple-400 hover:bg-white hover:bg-opacity-10 transition-all rounded-[4px] p-0.5 no-underline cursor-pointer {$$props.class ||
+  class="text-[var(--pd-link)] hover:bg-[var(--pd-link-hover-bg)] transition-all rounded-[4px] p-0.5 no-underline cursor-pointer {$$props.class ||
     ''}"
   on:click="{click}"
   role="link"


### PR DESCRIPTION
### What does this PR do?

Adds light mode support to Link component, using color defined in design for #7149.

### Screenshot / video of UI

No change on dark, looks like design on light - looks awful since I couldn't find a page with a Link that supports light mode, will look much better after #7149 has merged :) :

https://github.com/containers/podman-desktop/assets/19958075/d600456f-8d11-4424-ba1a-eac408847755

### What issues does this PR fix or reference?

Fixes #7215.

### How to test this PR?

Manually add preference: `"preferences.appearance": "light"`

- [x] Tests are covering the bug fix or the new feature