### PR TITLE
feat: show manifests in image list

### DIFF
--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -38,6 +38,7 @@ import IngressDetails from './lib/ingresses-routes/IngressDetails.svelte';
 import IngressesRoutesList from './lib/ingresses-routes/IngressesRoutesList.svelte';
 import RouteDetails from './lib/ingresses-routes/RouteDetails.svelte';
 import KubePlayYAML from './lib/kube/KubePlayYAML.svelte';
+import ManifestDetails from './lib/manifest/ManifestDetails.svelte';
 import Onboarding from './lib/onboarding/Onboarding.svelte';
 import DeployPodToKube from './lib/pod/DeployPodToKube.svelte';
 import PodCreateFromContainers from './lib/pod/PodCreateFromContainers.svelte';
@@ -123,6 +124,16 @@ window.events?.receive('navigate', (navigationRequest: unknown) => {
 
         <Route path="/images" breadcrumb="Images" navigationHint="root">
           <ImagesList />
+        </Route>
+        <Route
+          path="/manifests/:id/:engineId/:base64RepoTag/*"
+          breadcrumb="Manifest Details"
+          let:meta
+          navigationHint="details">
+          <ManifestDetails
+            imageID="{meta.params.id}"
+            engineId="{decodeURI(meta.params.engineId)}"
+            base64RepoTag="{meta.params.base64RepoTag}" />
         </Route>
         <Route
           path="/images/:id/:engineId/:base64RepoTag/*"

--- a/packages/renderer/src/lib/image/ImageColumnActions.spec.ts
+++ b/packages/renderer/src/lib/image/ImageColumnActions.spec.ts
@@ -1,0 +1,53 @@
+/**********************************************************************
+ * Copyright (C) 2023-2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/svelte';
+import { expect, test } from 'vitest';
+
+import ImageColumnActions from './ImageColumnActions.svelte';
+import type { ImageInfoUI } from './ImageInfoUI';
+
+const image: ImageInfoUI = {
+  id: 'my-image',
+  shortId: 'short-id',
+  name: 'my-image-name',
+  engineId: 'podman',
+  engineName: '',
+  tag: 'latest-tag',
+  createdAt: 0,
+  age: '',
+  size: 0,
+  humanSize: '',
+  base64RepoTag: 'repoTag',
+  selected: false,
+  status: 'UNUSED',
+  icon: undefined,
+  badges: [],
+};
+
+test('No actions shown for manifest images', async () => {
+  const manifestImage: ImageInfoUI = { ...image, isManifest: true };
+
+  render(ImageColumnActions, { object: manifestImage });
+
+  // Check for the absence of action buttons
+  expect(screen.queryByText('Push Image')).not.toBeInTheDocument();
+  expect(screen.queryByText('Rename Image')).not.toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/image/ImageColumnActions.svelte
+++ b/packages/renderer/src/lib/image/ImageColumnActions.svelte
@@ -26,24 +26,28 @@ function closeModals() {
 }
 </script>
 
-<ImageActions
-  image="{object}"
-  onPushImage="{handlePushImageModal}"
-  onRenameImage="{handleRenameImageModal}"
-  dropdownMenu="{true}"
-  on:update />
+<!-- There is no support for interacting with manifests yet, so do not show any manifest-related-image-actions. -->
 
-{#if pushImageModal && pushImageModalImageInfo}
-  <PushImageModal
-    imageInfoToPush="{pushImageModalImageInfo}"
-    closeCallback="{() => {
-      closeModals();
-    }}" />
-{/if}
-{#if renameImageModal && renameImageModalImageInfo}
-  <RenameImageModal
-    imageInfoToRename="{renameImageModalImageInfo}"
-    closeCallback="{() => {
-      closeModals();
-    }}" />
+{#if !object.isManifest}
+  <ImageActions
+    image="{object}"
+    onPushImage="{handlePushImageModal}"
+    onRenameImage="{handleRenameImageModal}"
+    dropdownMenu="{true}"
+    on:update />
+
+  {#if pushImageModal && pushImageModalImageInfo}
+    <PushImageModal
+      imageInfoToPush="{pushImageModalImageInfo}"
+      closeCallback="{() => {
+        closeModals();
+      }}" />
+  {/if}
+  {#if renameImageModal && renameImageModalImageInfo}
+    <RenameImageModal
+      imageInfoToRename="{renameImageModalImageInfo}"
+      closeCallback="{() => {
+        closeModals();
+      }}" />
+  {/if}
 {/if}

--- a/packages/renderer/src/lib/image/ImageColumnName.spec.ts
+++ b/packages/renderer/src/lib/image/ImageColumnName.spec.ts
@@ -164,18 +164,19 @@ test('Expect badge with light color', async () => {
   expect(badge).toHaveStyle('background-color: #00ff00');
 });
 
-test('Expect if image is a manifest, the on:click is not there / no details', async () => {
+test('Expect if image is a manifest, the on:click IS there', async () => {
   const manifestImage: ImageInfoUI = {
     ...image,
     isManifest: true,
   };
   render(ImageColumnName, { object: manifestImage });
 
-  const text = screen.getByText(image.name);
+  // Make sure text shows image name then (manifest)
+  const text = screen.getByText(`${image.name} (manifest)`);
   expect(text).toBeInTheDocument();
 
-  // test click (it should NOT work)
+  // test click
   const routerGotoSpy = vi.spyOn(router, 'goto');
   fireEvent.click(text);
-  expect(routerGotoSpy).not.toBeCalled();
+  expect(routerGotoSpy).toBeCalled();
 });

--- a/packages/renderer/src/lib/image/ImageColumnName.spec.ts
+++ b/packages/renderer/src/lib/image/ImageColumnName.spec.ts
@@ -163,3 +163,19 @@ test('Expect badge with light color', async () => {
   // check background color
   expect(badge).toHaveStyle('background-color: #00ff00');
 });
+
+test('Expect if image is a manifest, the on:click is not there / no details', async () => {
+  const manifestImage: ImageInfoUI = {
+    ...image,
+    isManifest: true,
+  };
+  render(ImageColumnName, { object: manifestImage });
+
+  const text = screen.getByText(image.name);
+  expect(text).toBeInTheDocument();
+
+  // test click (it should NOT work)
+  const routerGotoSpy = vi.spyOn(router, 'goto');
+  fireEvent.click(text);
+  expect(routerGotoSpy).not.toBeCalled();
+});

--- a/packages/renderer/src/lib/image/ImageColumnName.svelte
+++ b/packages/renderer/src/lib/image/ImageColumnName.svelte
@@ -6,14 +6,16 @@ import type { ImageInfoUI } from './ImageInfoUI';
 
 export let object: ImageInfoUI;
 
-function openDetailsImage(image: ImageInfoUI) {
-  router.goto(`/images/${image.id}/${image.engineId}/${image.base64RepoTag}/summary`);
+function openDetails(image: ImageInfoUI) {
+  if (image.isManifest) {
+    router.goto(`/manifests/${image.id}/${image.engineId}/${image.base64RepoTag}/summary`);
+  } else {
+    router.goto(`/images/${image.id}/${image.engineId}/${image.base64RepoTag}/summary`);
+  }
 }
 </script>
 
-<button
-  class="flex flex-col {object.isManifest ? 'cursor-default' : ''}"
-  on:click="{object.isManifest ? undefined : () => openDetailsImage(object)}">
+<button class="flex flex-col" on:click="{() => openDetails(object)}">
   <div class="flex flex-row text-xs gap-1 items-center">
     <div class="text-sm text-[var(--pd-table-body-text-highlight)]">
       {object.name}

--- a/packages/renderer/src/lib/image/ImageColumnName.svelte
+++ b/packages/renderer/src/lib/image/ImageColumnName.svelte
@@ -11,9 +11,14 @@ function openDetailsImage(image: ImageInfoUI) {
 }
 </script>
 
-<button class="flex flex-col" on:click="{() => openDetailsImage(object)}">
+<button
+  class="flex flex-col {object.isManifest ? 'cursor-default' : ''}"
+  on:click="{object.isManifest ? undefined : () => openDetailsImage(object)}">
   <div class="flex flex-row text-xs gap-1 items-center">
-    <div class="text-sm text-[var(--pd-table-body-text-highlight)]">{object.name}</div>
+    <div class="text-sm text-[var(--pd-table-body-text-highlight)]">
+      {object.name}
+      {object.isManifest ? ' (manifest)' : ''}
+    </div>
     {#if object.badges.length}
       {#each object.badges as badge}
         <Badge color="{badge.color}" label="{badge.label}" />

--- a/packages/renderer/src/lib/image/ImageInfoUI.ts
+++ b/packages/renderer/src/lib/image/ImageInfoUI.ts
@@ -37,4 +37,5 @@ export interface ImageInfoUI {
   icon: any;
   labels?: { [label: string]: string };
   badges: ViewContributionBadgeValue[];
+  isManifest?: boolean;
 }

--- a/packages/renderer/src/lib/image/ImagesList.svelte
+++ b/packages/renderer/src/lib/image/ImagesList.svelte
@@ -295,7 +295,8 @@ const columns: TableColumn<ImageInfoUI, ImageInfoUI | string>[] = [
 ];
 
 const row = new TableRow<ImageInfoUI>({
-  selectable: image => image.status === 'UNUSED',
+  // If it is a manifest, it is not selectable (no delete functionality yet)
+  selectable: image => image.status === 'UNUSED' && !image.isManifest,
   disabledText: 'Image is used by a container',
 });
 </script>

--- a/packages/renderer/src/lib/image/image-utils.ts
+++ b/packages/renderer/src/lib/image/image-utils.ts
@@ -191,6 +191,7 @@ export class ImageUtils {
           badges,
           icon,
           labels: imageInfo.Labels,
+          isManifest: imageInfo.isManifest,
         },
       ];
     } else {
@@ -212,6 +213,7 @@ export class ImageUtils {
           badges,
           icon,
           labels: imageInfo.Labels,
+          isManifest: imageInfo.isManifest,
         };
       });
     }

--- a/packages/renderer/src/lib/image/image-utils.ts
+++ b/packages/renderer/src/lib/image/image-utils.ts
@@ -34,6 +34,7 @@ import {
 import type { ContextUI } from '../context/context';
 import { ContextKeyExpr } from '../context/contextKey';
 import ImageIcon from '../images/ImageIcon.svelte';
+import ManifestIcon from '../images/ManifestIcon.svelte';
 import type { ImageInfoUI } from './ImageInfoUI';
 
 export class ImageUtils {
@@ -169,8 +170,13 @@ export class ImageUtils {
     context?: ContextUI,
     viewContributions?: ViewInfoUI[],
   ): ImageInfoUI[] {
-    const icon = this.iconClass(imageInfo, context, viewContributions) || ImageIcon;
+    let icon = this.iconClass(imageInfo, context, viewContributions) || ImageIcon;
     const badges = this.computeBagdes(imageInfo, context, viewContributions);
+
+    // Use the manifest icon if it's a manifest
+    if (imageInfo.isManifest) {
+      icon = ManifestIcon;
+    }
 
     if (!imageInfo.RepoTags) {
       return [

--- a/packages/renderer/src/lib/manifest/ManifestDetails.spec.ts
+++ b/packages/renderer/src/lib/manifest/ManifestDetails.spec.ts
@@ -1,0 +1,60 @@
+/**********************************************************************
+ * Copyright (C) 2023-2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/svelte';
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+
+import { imagesInfos } from '/@/stores/images';
+import type { ImageInfo } from '/@api/image-info';
+
+import ManifestDetails from './ManifestDetails.svelte';
+
+const listImagesMock = vi.fn();
+beforeEach(() => {
+  imagesInfos.set([]);
+  (window as any).listImages = listImagesMock;
+  (window as any).listContainers = vi.fn();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+test('It should render correctly with given image information', async () => {
+  const imageID = '123456';
+  const engineId = 'podman';
+  const myImage = {
+    engineId,
+    Id: imageID,
+    Size: 0,
+  } as unknown as ImageInfo;
+  imagesInfos.set([myImage]);
+  listImagesMock.mockResolvedValue([myImage]);
+
+  render(ManifestDetails, {
+    imageID,
+    engineId,
+    base64RepoTag: Buffer.from('<none>', 'binary').toString('base64'),
+  });
+
+  // Expect summary to render correctly
+  const summaryTab = screen.getByRole('link', { name: 'Summary' });
+  expect(summaryTab).toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/manifest/ManifestDetails.svelte
+++ b/packages/renderer/src/lib/manifest/ManifestDetails.svelte
@@ -1,0 +1,95 @@
+<script lang="ts">
+import type { ImageInfo } from '@podman-desktop/api';
+import { Tab } from '@podman-desktop/ui-svelte';
+import { onMount } from 'svelte';
+import { router } from 'tinro';
+
+import { containersInfos } from '/@/stores/containers';
+import type { ViewInfoUI } from '/@api/view-info';
+
+import Route from '../../Route.svelte';
+import { imagesInfos } from '../../stores/images';
+import type { ContextUI } from '../context/context';
+import { ImageUtils } from '../image/image-utils';
+import ImageDetailsSummary from '../image/ImageDetailsSummary.svelte';
+import type { ImageInfoUI } from '../image/ImageInfoUI';
+import ManifestIcon from '../images/ManifestIcon.svelte';
+import StatusIcon from '../images/StatusIcon.svelte';
+import Badge from '../ui/Badge.svelte';
+import DetailsPage from '../ui/DetailsPage.svelte';
+import { getTabUrl, isTabSelected } from '../ui/Util';
+
+export let imageID: string;
+export let engineId: string;
+export let base64RepoTag: string;
+
+let globalContext: ContextUI;
+let viewContributions: ViewInfoUI[] = [];
+let allImages: ImageInfo[];
+
+let imageInfo: ImageInfo | undefined;
+let imageMetadataInfo: ImageInfoUI | undefined;
+let detailsPage: DetailsPage | undefined;
+
+const imageUtils = new ImageUtils();
+
+// We use updateImage from "Image" since it will still contain details
+// regarding the manifest (example: tags, size, etc.) even if the size is less than 5KB, it's still
+// useful to provide that information.
+function updateImage() {
+  if (!allImages) {
+    return;
+  }
+  imageInfo = allImages.find(c => c.Id === imageID && c.engineId === engineId);
+  let tempImage;
+  if (imageInfo) {
+    tempImage = imageUtils.getImageInfoUI(imageInfo, base64RepoTag, $containersInfos, globalContext, viewContributions);
+  }
+  if (tempImage) {
+    imageMetadataInfo = tempImage;
+  } else {
+    // the image has been deleted
+    detailsPage?.close();
+  }
+}
+
+onMount(() => {
+  // loading image info
+  return imagesInfos.subscribe(images => {
+    allImages = images;
+    updateImage();
+  });
+});
+</script>
+
+{#if imageMetadataInfo}
+  <DetailsPage
+    title="{imageMetadataInfo.name}"
+    titleDetail="{imageMetadataInfo.shortId}"
+    subtitle="{imageMetadataInfo.tag}"
+    bind:this="{detailsPage}">
+    <StatusIcon slot="icon" icon="{ManifestIcon}" size="{24}" status="{imageMetadataInfo.status}" />
+    <svelte:fragment slot="subtitle">
+      {#if imageMetadataInfo.badges.length}
+        <div class="flex flex-row">
+          {#each imageMetadataInfo.badges as badge}
+            <Badge color="{badge.color}" label="{badge.label}" />
+          {/each}
+        </div>
+      {/if}
+    </svelte:fragment>
+
+    <!-- Add "actions" here in the future. -->
+    <svelte:fragment slot="tabs">
+      <Tab
+        title="Summary"
+        selected="{isTabSelected($router.path, 'summary')}"
+        url="{getTabUrl($router.path, 'summary')}" />
+    </svelte:fragment>
+    <svelte:fragment slot="content">
+      <Route path="/summary" breadcrumb="Summary" navigationHint="tab">
+        <ImageDetailsSummary image="{imageMetadataInfo}" />
+      </Route>
+    </svelte:fragment>
+  </DetailsPage>
+{/if}

--- a/packages/renderer/src/stores/images.spec.ts
+++ b/packages/renderer/src/stores/images.spec.ts
@@ -130,7 +130,7 @@ describe('filtered images tests', () => {
     expect(images[0].isManifest).toBe(false);
   });
 
-  test('images with isManifest true should be excluded', async () => {
+  test('images with isManifest true should be included', async () => {
     // isManifest but set to true
     listImagesMock.mockResolvedValue([{ Id: 4, isManifest: true } as unknown as ImageInfo]);
 
@@ -143,7 +143,7 @@ describe('filtered images tests', () => {
     // Check the filtered images, make sure that we do NOT have any images
     // as we do not want filtered to show images with isManifest set to true
     const images = get(filtered);
-    expect(images.length).toBe(0);
+    expect(images.length).toBe(1);
   });
 
   test('check against 3 images with different isManifest values', async () => {
@@ -163,15 +163,15 @@ describe('filtered images tests', () => {
     // Check the filtered images
     const images = get(filtered);
 
-    // Expect to have 2 images, one with isManifest set to false and one with isManifest field missing
-    expect(images.length).toBe(2);
+    // Expect to have 3 images now
+    expect(images.length).toBe(3);
 
     // Check the first image
     expect(images[0].Id).toBe(5);
     expect(images[0].isManifest).toBe(false);
 
     // Check the second image
-    expect(images[1].Id).toBe(7);
-    expect(images[1].isManifest).toBeUndefined();
+    expect(images[1].Id).toBe(6);
+    expect(images[1].isManifest).toBeDefined();
   });
 });

--- a/packages/renderer/src/stores/images.ts
+++ b/packages/renderer/src/stores/images.ts
@@ -73,9 +73,5 @@ imagesEventStore.setupWithDebounce();
 export const searchPattern = writable('');
 
 export const filtered = derived([searchPattern, imagesInfos], ([$searchPattern, $imagesInfos]) =>
-  // We ignore any images that are manifest images as we do not support this yet in the UI.
-  // see epic issue: https://github.com/containers/podman-desktop/issues/6529
-  // If the image has isManifest and it is set to true, we ignore it.
-  // If isManifest is missing, it is most likely a compatibility API image and we still show it.
-  $imagesInfos.filter(imageInfo => !imageInfo.isManifest && findMatchInLeaves(imageInfo, $searchPattern.toLowerCase())),
+  $imagesInfos.filter(imageInfo => findMatchInLeaves(imageInfo, $searchPattern.toLowerCase())),
 );


### PR DESCRIPTION
feat: show manifests in image list

### What does this PR do?

* Shows manifest in the image list
* Does NOT show any actions / be able to click (yet)
* Allows you to click and view details.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

https://github.com/containers/podman-desktop/assets/6422176/e930329d-2a84-4c2b-b719-373f12f0b22c


### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop/issues/6529
Closes https://github.com/containers/podman-desktop/issues/7255

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature

1. Create a manifest through the GUI or `podman build --platform
   linux/arm64,linux/amd64 --manifest testmanifest123`
2. View the manifest in image list.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
