### PR TITLE
fix(extension-loader): cleanup resource on extension error

### DIFF
--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -1464,6 +1464,16 @@ export class ExtensionLoader {
       this.apiSender.send('extension-started');
     } catch (err) {
       console.log(`Activating extension ${extension.id} failed error:${err}`);
+
+      // dispose resources
+      for (const subscription of extensionContext.subscriptions) {
+        try {
+          subscription.dispose();
+        } catch (err: unknown) {
+          console.error('Something went wrong while trying to dispose extension subscription', err);
+        }
+      }
+
       this.extensionState.set(extension.id, 'failed');
       this.extensionStateErrors.set(extension.id, err);
       // Storing error in the telemetry options


### PR DESCRIPTION
### What does this PR do?

Dispose extension subscriptions on failed state.

ℹ️ The failed state can occur if the extension throw an error during the activate function. 

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop/issues/7051

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
