### PR TITLE
feat: file input

### DIFF
--- a/packages/renderer/src/lib/onboarding/OnboardingItem.spec.ts
+++ b/packages/renderer/src/lib/onboarding/OnboardingItem.spec.ts
@@ -104,7 +104,7 @@ test('Expect boolean configuration placeholder to be replaced with a checkbox', 
   expect((input as HTMLInputElement).name).toBe('extension.boolean.prop');
 });
 
-test('Expect when configuration placeholder is type string and format file to be replaced with an input button with Browse', async () => {
+test('Expect when configuration placeholder is type string and format file to be replaced with a file input', async () => {
   const textComponent: OnboardingStepItem = {
     value: '${configuration:extension.format.prop}',
   };
@@ -133,9 +133,8 @@ test('Expect when configuration placeholder is type string and format file to be
   expect(readOnlyInput).toBeInTheDocument();
   expect(readOnlyInput instanceof HTMLInputElement).toBe(true);
   expect((readOnlyInput as HTMLInputElement).placeholder).toBe('Example: text');
-  const input = screen.getByLabelText('button-record-description');
+  const input = screen.getByLabelText('browse');
   expect(input).toBeInTheDocument();
-  expect(input.textContent).toBe('Browse ...');
 });
 
 test('Expect a type text configuration placeholder to be replaced by a text input', async () => {

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.spec.ts
@@ -147,7 +147,7 @@ test('Expect a text input when record is type number and enableSlider is false',
   expect((input as HTMLInputElement).name).toBe('record');
 });
 
-test('Expect an input button with Browse as placeholder when record is type string and format file', async () => {
+test('Expect a fileinput when record is type string and format file', async () => {
   const record: IConfigurationPropertyRecordedSchema = {
     title: 'record',
     parentId: 'parent.record',
@@ -161,12 +161,11 @@ test('Expect an input button with Browse as placeholder when record is type stri
   expect(readOnlyInput).toBeInTheDocument();
   expect(readOnlyInput instanceof HTMLInputElement).toBe(true);
   expect((readOnlyInput as HTMLInputElement).placeholder).toBe(record.placeholder);
-  const input = screen.getByLabelText('button-record-description');
+  const input = screen.getByLabelText('browse');
   expect(input).toBeInTheDocument();
-  expect(input.textContent).toBe('Browse ...');
 });
 
-test('Expect an input button with Browse as placeholder when record is type string and format folder', async () => {
+test('Expect a fileinput when record is type string and format folder', async () => {
   const record: IConfigurationPropertyRecordedSchema = {
     title: 'record',
     parentId: 'parent.record',
@@ -180,9 +179,8 @@ test('Expect an input button with Browse as placeholder when record is type stri
   expect(readOnlyInput).toBeInTheDocument();
   expect(readOnlyInput instanceof HTMLInputElement).toBe(true);
   expect((readOnlyInput as HTMLInputElement).placeholder).toBe(record.placeholder);
-  const input = screen.getByLabelText('button-record-description');
+  const input = screen.getByLabelText('browse');
   expect(input).toBeInTheDocument();
-  expect(input.textContent).toBe('Browse ...');
 });
 
 test('Expect a select when record is type string and has enum values', async () => {

--- a/packages/renderer/src/lib/preferences/item-formats/FileItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/item-formats/FileItem.spec.ts
@@ -48,7 +48,7 @@ test('Ensure HTMLInputElement', async () => {
   expect(input instanceof HTMLInputElement).toBe(true);
 });
 
-test('Ensure clicking on Browser invoke openDialog with default selector', async () => {
+test('Ensure clicking on browse invokes openDialog with default selector', async () => {
   openDialogMock.mockResolvedValue([]);
   const record: IConfigurationPropertyRecordedSchema = {
     id: 'record',
@@ -60,7 +60,7 @@ test('Ensure clicking on Browser invoke openDialog with default selector', async
   };
 
   render(FileItem, { record, value: '' });
-  const input = screen.getByRole('button', { name: `button-${record.description}` });
+  const input = screen.getByRole('button');
   expect(input).toBeInTheDocument();
   await userEvent.click(input);
 
@@ -70,7 +70,7 @@ test('Ensure clicking on Browser invoke openDialog with default selector', async
   });
 });
 
-test('Ensure clicking on Browser invoke openDialog with corresponding directory selector', async () => {
+test('Ensure clicking on browse invokes openDialog with corresponding directory selector', async () => {
   openDialogMock.mockResolvedValue([]);
   const record: IConfigurationPropertyRecordedSchema = {
     id: 'record',
@@ -82,7 +82,7 @@ test('Ensure clicking on Browser invoke openDialog with corresponding directory 
   };
 
   render(FileItem, { record, value: '' });
-  const input = screen.getByRole('button', { name: `button-${record.description}` });
+  const input = screen.getByRole('button');
   expect(input).toBeInTheDocument();
   await userEvent.click(input);
 

--- a/packages/renderer/src/lib/preferences/item-formats/FileItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/FileItem.svelte
@@ -1,45 +1,28 @@
 <script lang="ts">
-import { Button, Input } from '@podman-desktop/ui-svelte';
+import type { OpenDialogOptions } from '@podman-desktop/api';
+
+import FileInput from '/@/lib/ui/FileInput.svelte';
 
 import type { IConfigurationPropertyRecordedSchema } from '../../../../../main/src/plugin/configuration-registry';
 
 export let record: IConfigurationPropertyRecordedSchema;
 export let value: string;
-export let onChange = async (_id: string, _value: string) => {};
 
 let invalidEntry = false;
-
-async function selectFilePath() {
-  invalidEntry = false;
-  const filePaths = await window.openDialog({
-    title: `Select ${record.description}`,
-    selectors: record.format === 'folder' ? ['openDirectory'] : ['openFile'],
-  });
-  if (record.id && filePaths && filePaths.length === 1) {
-    onChange(record.id, filePaths[0]).catch((_: unknown) => (invalidEntry = true));
-  }
-}
-
-function handleCleanValue(event: CustomEvent<MouseEvent>) {
-  if (record.id) onChange(record.id, '');
-  event.preventDefault();
-}
+let dialogOptions: OpenDialogOptions = {
+  title: `Select ${record.description}`,
+  selectors: record.format === 'folder' ? ['openDirectory'] : ['openFile'],
+};
 </script>
 
 <div class="w-full flex">
-  <Input
-    class="grow mr-2"
+  <FileInput
+    id="input-standard-{record.id}"
     name="{record.id}"
     readonly
     placeholder="{record.placeholder}"
+    options="{dialogOptions}"
     value="{value || ''}"
-    id="input-standard-{record.id}"
     aria-invalid="{invalidEntry}"
-    aria-label="{record.description}"
-    on:action="{event => handleCleanValue(event)}" />
-  <Button
-    on:click="{() => selectFilePath()}"
-    id="rendering.FilePath.{record.id}"
-    aria-invalid="{invalidEntry}"
-    aria-label="button-{record.description}">Browse ...</Button>
+    aria-label="{record.description}" />
 </div>

--- a/packages/renderer/src/lib/preferences/item-formats/FileItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/FileItem.svelte
@@ -6,23 +6,33 @@ import FileInput from '/@/lib/ui/FileInput.svelte';
 import type { IConfigurationPropertyRecordedSchema } from '../../../../../main/src/plugin/configuration-registry';
 
 export let record: IConfigurationPropertyRecordedSchema;
-export let value: string;
+export let value: string = '';
+export let onChange = async (_id: string, _value: string) => {};
+
+let lastValue: string;
 
 let invalidEntry = false;
 let dialogOptions: OpenDialogOptions = {
   title: `Select ${record.description}`,
   selectors: record.format === 'folder' ? ['openDirectory'] : ['openFile'],
 };
+
+$: if (value !== lastValue) {
+  if (record.id) {
+    onChange(record.id, value).catch((_: unknown) => (invalidEntry = true));
+  }
+  lastValue = value;
+}
 </script>
 
 <div class="w-full flex">
   <FileInput
     id="input-standard-{record.id}"
     name="{record.id}"
+    bind:value="{value}"
     readonly
     placeholder="{record.placeholder}"
     options="{dialogOptions}"
-    value="{value || ''}"
     aria-invalid="{invalidEntry}"
     aria-label="{record.description}" />
 </div>

--- a/packages/renderer/src/lib/ui/FileInput.spec.ts
+++ b/packages/renderer/src/lib/ui/FileInput.spec.ts
@@ -1,0 +1,60 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { beforeAll, expect, test, vi } from 'vitest';
+
+import FileInput from './FileInput.svelte';
+
+const openDialogMock = vi.fn();
+
+beforeAll(() => {
+  (window as any).openDialog = openDialogMock;
+});
+
+test('Expect clicking the button opens file dialog', async () => {
+  openDialogMock.mockResolvedValue({ canceled: true });
+
+  render(FileInput, {});
+
+  const browseButton = screen.getByRole('button');
+  expect(browseButton).toBeInTheDocument();
+  await userEvent.click(browseButton);
+
+  expect(openDialogMock).toHaveBeenCalled();
+});
+
+test('Expect value to change when selecting via file dialog', async () => {
+  const filename = 'somefile';
+  openDialogMock.mockResolvedValue([filename]);
+
+  render(FileInput, {});
+
+  const browseButton = screen.getByRole('button');
+  expect(browseButton).toBeInTheDocument();
+  await userEvent.click(browseButton);
+
+  expect(openDialogMock).toHaveBeenCalled();
+
+  const input = screen.getByRole('textbox');
+  expect(input).toBeInTheDocument();
+  expect(input).toHaveValue(filename);
+});

--- a/packages/renderer/src/lib/ui/FileInput.svelte
+++ b/packages/renderer/src/lib/ui/FileInput.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+import { faFolderOpen } from '@fortawesome/free-solid-svg-icons';
+import type { OpenDialogOptions } from '@podman-desktop/api';
+import { Button, Input } from '@podman-desktop/ui-svelte';
+
+export let placeholder: string | undefined = undefined;
+export let id: string | undefined = undefined;
+export let name: string | undefined = undefined;
+export let value: string | undefined = undefined;
+export let options: OpenDialogOptions;
+export let readonly: boolean = false;
+export let required: boolean = false;
+
+async function openDialog() {
+  const result = await window.openDialog(options);
+  if (result?.[0]) {
+    value = result[0];
+  }
+}
+</script>
+
+<div class="flex flex-row grow space-x-1.5">
+  <Input
+    name="{name}"
+    id="{id}"
+    class="{$$props.class || ''}"
+    bind:value="{value}"
+    placeholder="{placeholder}"
+    readonly="{readonly}"
+    required="{required}"
+    aria-label="{$$props['aria-label']}"
+    aria-invalid="{$$props['aria-invalid']}">
+  </Input>
+  <Button aria-label="browse" icon="{faFolderOpen}" on:click="{openDialog}" />
+</div>

--- a/packages/renderer/src/lib/ui/FileInput.svelte
+++ b/packages/renderer/src/lib/ui/FileInput.svelte
@@ -21,10 +21,12 @@ async function openDialog() {
 
 <div class="flex flex-row grow space-x-1.5">
   <Input
-    name="{name}"
     id="{id}"
+    name="{name}"
     class="{$$props.class || ''}"
     bind:value="{value}"
+    on:input
+    on:keypress
     placeholder="{placeholder}"
     readonly="{readonly}"
     required="{required}"


### PR DESCRIPTION
### What does this PR do?

We have Inputs next to Browse buttons in many places, all with slight variations in UI or browsing. This creates a new FileInput component that uses a regular Input component with a folder icon on the right to browse for files. Exposes OpenDialogOptions to make it easy to customize what the file dialog should filter for.

Uses the new FileInput for file/folder preferences so that there's something to test. There are several other file/browse buttons elsewhere, but they would be migrated separately. Likely also a candidate for svelte-ui package, but that should be after we become comfortable with/use it.

### Screenshot / video of UI

Before:

<img width="530" alt="Screenshot 2024-05-16 at 11 57 45 AM" src="https://github.com/containers/podman-desktop/assets/19958075/b6877b30-a81e-4456-b897-4face34c196f">

After:

<img width="530" alt="Screenshot 2024-05-16 at 11 57 11 AM" src="https://github.com/containers/podman-desktop/assets/19958075/7199d0ce-6bff-4b9b-bfc2-2f6a5c8ce8be">

### What issues does this PR fix or reference?

Fixes #7197.

### How to test this PR?

Tests added, check Settings > Preferences for usability/regression.

- [x] Tests are covering the bug fix or the new feature