### PR TITLE
chore: edge and light mode for modal dialog

### DIFF
--- a/packages/main/src/plugin/color-registry.ts
+++ b/packages/main/src/plugin/color-registry.ts
@@ -236,6 +236,7 @@ export class ColorRegistry {
     this.initTable();
     this.initDetails();
     this.initTab();
+    this.initModal();
   }
 
   protected initGlobalNav(): void {
@@ -772,6 +773,24 @@ export class ColorRegistry {
     this.registerColor(`${tab}hover`, {
       dark: colorPalette.purple[400],
       light: colorPalette.purple[500],
+    });
+  }
+
+  // modal dialog
+  protected initModal(): void {
+    const modal = 'modal-';
+
+    this.registerColor(`${modal}fade`, {
+      dark: colorPalette.black,
+      light: colorPalette.white,
+    });
+    this.registerColor(`${modal}bg`, {
+      dark: colorPalette.charcoal[800],
+      light: colorPalette.gray[300],
+    });
+    this.registerColor(`${modal}border`, {
+      dark: colorPalette.charcoal[500],
+      light: colorPalette.gray[200],
     });
   }
 }

--- a/packages/ui/src/lib/modal/Modal.svelte
+++ b/packages/ui/src/lib/modal/Modal.svelte
@@ -35,12 +35,12 @@ if (previously_focused) {
 <div class:items-center="{!top}" class="absolute w-full h-full flex justify-center">
   <button
     aria-label="close"
-    class="fixed top-0 left-0 w-full h-full bg-black bg-opacity-60 bg-blend-multiply z-40"
+    class="fixed top-0 left-0 w-full h-full bg-[var(--pd-modal-fade)] bg-blend-multiply opacity-60 z-40 cursor-default"
     on:click="{close}"></button>
 
   <div
     class:translate-y-[-20%]="{!top}"
-    class="bg-charcoal-800 z-50 rounded-xl overflow-auto w-[calc(200vw-4em)] h-fit max-w-[42em] max-h-[calc(100vh-4em)]"
+    class="bg-[var(--pd-modal-bg)] z-50 rounded-xl overflow-auto w-[calc(200vw-4em)] h-fit max-w-[42em] max-h-[calc(100vh-4em)] border-[1px] border-[var(--pd-modal-border)]"
     role="dialog"
     aria-label="{name}"
     aria-modal="true"


### PR DESCRIPTION
### What does this PR do?

Adds light mode colors for Modal dialog along with a defined 1px border so that it is not washed out.

Initial light mode color values are taken from other mappings in the registry. It is not possible to use bg-opacity-60 with colors from the registry due to Tailwind CSS post processing order. I looked at several other options (defining colors as r g b instead of hex, trying several css functions, but the simplest is just to use direct styling instead.

### Screenshot / video of UI

Dark:

<img width="193" alt="Screenshot 2024-05-17 at 11 47 34 AM" src="https://github.com/containers/podman-desktop/assets/19958075/195c3cc1-acdb-412b-b5d5-99ad30171e3b">

Light:

<img width="193" alt="Screenshot 2024-05-17 at 11 46 51 AM" src="https://github.com/containers/podman-desktop/assets/19958075/0daa7753-9d55-4bf2-8bbb-c84e8c3f9746">

### What issues does this PR fix or reference?

Fixes #7187.
First minor part of #7184.

### How to test this PR?

Confirm no regressions and new border in dark mode, check colors (of Modal, not any contents) in light mode.