### PR TITLE
Light mode for DetailsPage

### DIFF
--- a/packages/main/src/plugin/color-registry.ts
+++ b/packages/main/src/plugin/color-registry.ts
@@ -234,6 +234,7 @@ export class ColorRegistry {
     this.initCheckbox();
     this.initToggle();
     this.initTable();
+    this.initDetails();
   }
 
   protected initGlobalNav(): void {
@@ -430,6 +431,11 @@ export class ColorRegistry {
     this.registerColor(`${ct}header`, {
       dark: colorPalette.white,
       light: colorPalette.charcoal[900],
+    });
+
+    this.registerColor(`${ct}sub-header`, {
+      dark: colorPalette.gray[900],
+      light: colorPalette.purple[900],
     });
 
     this.registerColor(`${ct}header-icon`, {
@@ -713,6 +719,46 @@ export class ColorRegistry {
     this.registerColor(`${tab}body-text-sub-highlight`, {
       dark: colorPalette.gray[400],
       light: colorPalette.charcoal[200],
+    });
+  }
+
+  protected initDetails(): void {
+    const details = 'details-';
+    this.registerColor(`${details}tab-text`, {
+      dark: colorPalette.gray[600],
+      light: colorPalette.charcoal[200],
+    });
+    this.registerColor(`${details}tab-text-highlight`, {
+      dark: colorPalette.white,
+      light: colorPalette.charcoal[900],
+    });
+    this.registerColor(`${details}tab-highlight`, {
+      dark: colorPalette.purple[500],
+      light: colorPalette.purple[600],
+    });
+    this.registerColor(`${details}tab-hover`, {
+      dark: colorPalette.charcoal[100],
+      light: colorPalette.charcoal[100],
+    });
+    this.registerColor(`${details}body-text`, {
+      dark: colorPalette.gray[200],
+      light: colorPalette.charcoal[500],
+    });
+    this.registerColor(`${details}empty-icon`, {
+      dark: colorPalette.gray[600],
+      light: colorPalette.charcoal[200],
+    });
+    this.registerColor(`${details}empty-header`, {
+      dark: colorPalette.gray[200],
+      light: colorPalette.charcoal[500],
+    });
+    this.registerColor(`${details}empty-sub-header`, {
+      dark: colorPalette.gray[600],
+      light: colorPalette.charcoal[500],
+    });
+    this.registerColor(`${details}bg`, {
+      dark: colorPalette.charcoal[900],
+      light: colorPalette.gray[50],
     });
   }
 }

--- a/packages/main/src/plugin/color-registry.ts
+++ b/packages/main/src/plugin/color-registry.ts
@@ -756,6 +756,14 @@ export class ColorRegistry {
       dark: colorPalette.gray[600],
       light: colorPalette.charcoal[500],
     });
+    this.registerColor(`${details}empty-cmdline-bg`, {
+      dark: colorPalette.charcoal[900],
+      light: colorPalette.gray[200],
+    });
+    this.registerColor(`${details}empty-cmdline-text`, {
+      dark: colorPalette.gray[400],
+      light: colorPalette.charcoal[700],
+    });
     this.registerColor(`${details}bg`, {
       dark: colorPalette.charcoal[900],
       light: colorPalette.gray[50],

--- a/packages/main/src/plugin/color-registry.ts
+++ b/packages/main/src/plugin/color-registry.ts
@@ -235,6 +235,7 @@ export class ColorRegistry {
     this.initToggle();
     this.initTable();
     this.initDetails();
+    this.initTab();
   }
 
   protected initGlobalNav(): void {
@@ -724,22 +725,6 @@ export class ColorRegistry {
 
   protected initDetails(): void {
     const details = 'details-';
-    this.registerColor(`${details}tab-text`, {
-      dark: colorPalette.gray[600],
-      light: colorPalette.charcoal[200],
-    });
-    this.registerColor(`${details}tab-text-highlight`, {
-      dark: colorPalette.white,
-      light: colorPalette.charcoal[900],
-    });
-    this.registerColor(`${details}tab-highlight`, {
-      dark: colorPalette.purple[500],
-      light: colorPalette.purple[600],
-    });
-    this.registerColor(`${details}tab-hover`, {
-      dark: colorPalette.charcoal[100],
-      light: colorPalette.charcoal[100],
-    });
     this.registerColor(`${details}body-text`, {
       dark: colorPalette.gray[200],
       light: colorPalette.charcoal[500],
@@ -767,6 +752,26 @@ export class ColorRegistry {
     this.registerColor(`${details}bg`, {
       dark: colorPalette.charcoal[900],
       light: colorPalette.gray[50],
+    });
+  }
+
+  protected initTab(): void {
+    const tab = 'tab-';
+    this.registerColor(`${tab}text`, {
+      dark: colorPalette.gray[600],
+      light: colorPalette.charcoal[200],
+    });
+    this.registerColor(`${tab}text-highlight`, {
+      dark: colorPalette.white,
+      light: colorPalette.charcoal[300],
+    });
+    this.registerColor(`${tab}highlight`, {
+      dark: colorPalette.purple[500],
+      light: colorPalette.purple[600],
+    });
+    this.registerColor(`${tab}hover`, {
+      dark: colorPalette.purple[400],
+      light: colorPalette.purple[500],
     });
   }
 }

--- a/packages/renderer/src/lib/compose/ComposeDetailsSummary.svelte
+++ b/packages/renderer/src/lib/compose/ComposeDetailsSummary.svelte
@@ -10,7 +10,7 @@ function openContainer(containerID: string) {
 }
 </script>
 
-<div class="flex px-5 py-4 flex-col h-full overflow-auto">
+<div class="flex px-5 py-4 flex-col h-full overflow-auto text-[var(--pd-details-body-text)]">
   <div class="w-full">
     <table>
       <tbody>

--- a/packages/renderer/src/lib/container/ContainerDetailsSummary.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetailsSummary.svelte
@@ -4,7 +4,7 @@ import type { ContainerInfoUI } from './ContainerInfoUI';
 export let container: ContainerInfoUI;
 </script>
 
-<div class="flex px-5 py-4 flex-col h-full overflow-auto">
+<div class="flex px-5 py-4 flex-col h-full overflow-auto text-[var(--pd-details-body-text)]">
   <div class="w-full">
     <table class="h-2">
       <tbody>

--- a/packages/renderer/src/lib/extensions/ExtensionDetailsReadme.svelte
+++ b/packages/renderer/src/lib/extensions/ExtensionDetailsReadme.svelte
@@ -38,7 +38,7 @@ onMount(async () => {
 </script>
 
 {#if readmeContent}
-  <div class="w-full min-h-full overflow-y-visible leading-6">
+  <div class="w-full min-h-full overflow-y-visible leading-6 text-[var(--pd-details-body-text)]">
     <Markdown markdown="{readmeContent}" />
   </div>
 {:else}

--- a/packages/renderer/src/lib/image/ImageDetailsSummary.svelte
+++ b/packages/renderer/src/lib/image/ImageDetailsSummary.svelte
@@ -4,7 +4,7 @@ import type { ImageInfoUI } from './ImageInfoUI';
 export let image: ImageInfoUI;
 </script>
 
-<div class="flex px-5 py-4 flex-col h-full overflow-auto">
+<div class="flex px-5 py-4 flex-col h-full overflow-auto text-[var(--pd-details-body-text)]">
   <table>
     <tbody>
       <tr>

--- a/packages/renderer/src/lib/pod/PodDetailsSummary.svelte
+++ b/packages/renderer/src/lib/pod/PodDetailsSummary.svelte
@@ -42,7 +42,7 @@ ass KubePodDetailsSummary will automatically add a 'Loading ... ' section -->
   <KubePodDetailsSummary pod="{kubePod}" />
 {:else}
   <!-- Still show pod information in case the Kubernetes pod retrieval errors out -->
-  <div class="flex px-5 py-4 flex-col h-full overflow-auto">
+  <div class="flex px-5 py-4 flex-col h-full overflow-auto text-[var(--pd-details-body-text)]">
     <div class="w-full">
       <table>
         <tbody>

--- a/packages/renderer/src/lib/ui/DetailsPage.svelte
+++ b/packages/renderer/src/lib/ui/DetailsPage.svelte
@@ -27,7 +27,7 @@ function handleKeydown(e: KeyboardEvent) {
 <div class="flex flex-col w-full h-full shadow-pageheader">
   <div class="flex flex-row w-full h-fit px-5 pt-4 pb-2">
     <div class="flex flex-col w-full h-fit">
-      <div class="flex flew-row items-center text-sm text-gray-700">
+      <div class="flex flew-row items-center text-sm text-[var(--pd-content-breadcrumb)]">
         <Link class="text-sm" aria-label="back" internalRef="{$lastPage.path}" title="Go back to {$lastPage.name}"
           >{$lastPage.name}</Link>
         <div class="mx-2">&gt;</div>
@@ -40,11 +40,17 @@ function handleKeydown(e: KeyboardEvent) {
         </div>
         <div class="flex flex-col grow pr-2">
           <div class="flex flex-row items-baseline">
-            <h1 aria-label="{title}" class="text-xl leading-tight">{title}</h1>
-            <div class="text-violet-400 ml-2 leading-normal" class:hidden="{!titleDetail}">{titleDetail}</div>
+            <h1 aria-label="{title}" class="text-xl leading-tight text-[var(--pd-content-header)]">{title}</h1>
+            <div
+              class="text-[var(--pd-table-body-text-sub-secondary)] ml-2 leading-normal"
+              class:hidden="{!titleDetail}">
+              {titleDetail}
+            </div>
           </div>
           <div>
-            <span class="text-sm leading-none text-gray-900 line-clamp-1" class:hidden="{!subtitle}">{subtitle}</span>
+            <span
+              class="text-sm leading-none text-[var(--pd-content-sub-header)] line-clamp-1"
+              class:hidden="{!subtitle}">{subtitle}</span>
             <slot name="subtitle" />
           </div>
         </div>
@@ -61,10 +67,10 @@ function handleKeydown(e: KeyboardEvent) {
       </div>
     </div>
   </div>
-  <div class="flex flex-row px-2 border-b border-charcoal-400">
+  <div class="flex flex-row px-2 border-b border-[var(--pd-content-divider)]">
     <slot name="tabs" />
   </div>
-  <div class="h-full bg-charcoal-900 min-h-0">
+  <div class="h-full bg-[var(--pd-details-bg)] min-h-0">
     <slot name="content" />
   </div>
 </div>

--- a/packages/renderer/src/lib/ui/EmptyScreen.svelte
+++ b/packages/renderer/src/lib/ui/EmptyScreen.svelte
@@ -37,7 +37,7 @@ let copyTextDivElement: HTMLDivElement;
   style="{$$props.style}"
   aria-label="{$$props['aria-label']}">
   <div class="flex flex-col h-full justify-center text-center space-y-3">
-    <div class="flex justify-center text-gray-700 py-2">
+    <div class="flex justify-center text-[var(--pd-details-empty-icon)] py-2">
       {#if processed}
         {#if fontAwesomeIcon}
           <Fa icon="{icon}" size="4x" />
@@ -46,14 +46,18 @@ let copyTextDivElement: HTMLDivElement;
         {/if}
       {/if}
     </div>
-    <h1 class="text-xl">{title}</h1>
-    <span class="text-gray-700 max-w-[800px] text-pretty mx-2">{message}</span>
+    <h1 class="text-xl text-[var(--pd-details-empty-header)]">{title}</h1>
+    <span class="text-[var(--pd-details-empty-sub-header)] max-w-[800px] text-pretty mx-2">{message}</span>
     {#if detail}
-      <span class="text-gray-700">{detail}</span>
+      <span class="text-[var(--pd-details-empty-sub-header)]">{detail}</span>
     {/if}
     {#if commandline}
-      <div class="flex flex-row bg-charcoal-900 items-center justify-between rounded-sm p-3 mt-4">
-        <div class="font-mono text-gray-400" bind:this="{copyTextDivElement}" data-testid="copyTextDivElement">
+      <div
+        class="flex flex-row bg-[var(--pd-details-empty-cmdline-bg)] items-center justify-between rounded-sm p-3 mt-4">
+        <div
+          class="font-mono text-[var(--pd-details-empty-cmdline-text)]"
+          bind:this="{copyTextDivElement}"
+          data-testid="copyTextDivElement">
           {commandline}
         </div>
         <button title="Copy To Clipboard" class="ml-5" on:click="{() => copyRunInstructionToClipboard()}"

--- a/packages/renderer/src/lib/volume/VolumeDetailsSummary.svelte
+++ b/packages/renderer/src/lib/volume/VolumeDetailsSummary.svelte
@@ -10,7 +10,7 @@ function openContainer(containerID: string) {
 }
 </script>
 
-<div class="flex px-5 py-4 flex-col h-full overflow-auto">
+<div class="flex px-5 py-4 flex-col h-full overflow-auto text-[var(--pd-details-body-text)]">
   <div class="w-full">
     <table>
       <tbody>

--- a/packages/ui/src/lib/tab/Tab.svelte
+++ b/packages/ui/src/lib/tab/Tab.svelte
@@ -9,13 +9,13 @@ let baseURL = $router.path.substring(0, $router.path.lastIndexOf('/'));
 
 <div
   class="pb-1 border-b-[3px] whitespace-nowrap hover:cursor-pointer"
-  class:border-[var(--pd-details-tab-highlight)]="{$router.path === baseURL + '/' + url}"
+  class:border-[var(--pd-tab-highlight)]="{$router.path === baseURL + '/' + url}"
   class:border-transparent="{$router.path !== baseURL + '/' + url}"
-  class:hover:border-[var(--pd-details-tab-hover)]="{$router.path !== baseURL + '/' + url}">
+  class:hover:border-[var(--pd-tab-hover)]="{$router.path !== baseURL + '/' + url}">
   <a
     href="{baseURL}/{url}"
-    class="px-4 py-2 text-[var(--pd-details-tab-text)] no-underline"
-    class:text-[var(--pd-details-tab-text-highlight)]="{$router.path === baseURL + '/' + url}"
+    class="px-4 py-2 text-[var(--pd-tab-text)] no-underline"
+    class:text-[var(--pd-tab-text-highlight)]="{$router.path === baseURL + '/' + url}"
     aria-controls="open-tabs-list-{url}-panel"
     id="open-tabs-list-{url}-link">
     {title}

--- a/packages/ui/src/lib/tab/Tab.svelte
+++ b/packages/ui/src/lib/tab/Tab.svelte
@@ -8,13 +8,14 @@ let baseURL = $router.path.substring(0, $router.path.lastIndexOf('/'));
 </script>
 
 <div
-  class="pb-1 border-b-[3px] border-charcoal-700 whitespace-nowrap hover:cursor-pointer"
-  class:border-purple-500="{$router.path === baseURL + '/' + url}"
-  class:hover:border-charcoal-100="{$router.path !== baseURL + '/' + url}">
+  class="pb-1 border-b-[3px] whitespace-nowrap hover:cursor-pointer"
+  class:border-[var(--pd-details-tab-highlight)]="{$router.path === baseURL + '/' + url}"
+  class:border-transparent="{$router.path !== baseURL + '/' + url}"
+  class:hover:border-[var(--pd-details-tab-hover)]="{$router.path !== baseURL + '/' + url}">
   <a
     href="{baseURL}/{url}"
-    class="px-4 py-2 text-gray-600 no-underline"
-    class:text-white="{$router.path === baseURL + '/' + url}"
+    class="px-4 py-2 text-[var(--pd-details-tab-text)] no-underline"
+    class:text-[var(--pd-details-tab-text-highlight)]="{$router.path === baseURL + '/' + url}"
     aria-controls="open-tabs-list-{url}-panel"
     id="open-tabs-list-{url}-link">
     {title}


### PR DESCRIPTION
### What does this PR do?

I have reused `--pd-table-body-text-sub-secondary` for the image id in the header of the image details page. Either we move this variable out of the `table` theming to place in a more generic one, or we create a new entry.

### Screenshot / video of UI

<img width="1118" alt="details-dark" src="https://github.com/containers/podman-desktop/assets/9973512/5ab05dd1-20b1-4534-a4c5-2b922cbb8af5">

![details-light](https://github.com/containers/podman-desktop/assets/9973512/6a62fb73-de55-47d7-9c0e-eaddaeb6ce0f)


### What issues does this PR fix or reference?

Fixes #6927 

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
