### PR TITLE
feat: add build arguments to build page

### DIFF
--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1094,6 +1094,7 @@ export class PluginSystem {
         selectedProvider: ProviderContainerConnectionInfo,
         onDataCallbacksBuildImageId: number,
         cancellableTokenId?: number,
+        buildargs?: { [key: string]: string },
       ): Promise<unknown> => {
         const abortController = this.createAbortControllerOnCancellationToken(
           cancellationTokenRegistry,
@@ -1115,6 +1116,7 @@ export class PluginSystem {
             platform,
             provider: selectedProvider,
             abortController,
+            buildargs,
           },
         );
       },

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -1058,6 +1058,7 @@ export function initExposure(): void {
       key: symbol,
       eventCollect: (key: symbol, eventName: 'finish' | 'stream' | 'error', data: string) => void,
       cancellableTokenId?: number,
+      buildargs?: { [key: string]: string },
     ): Promise<unknown> => {
       onDataCallbacksBuildImageId++;
       onDataCallbacksBuildImage.set(onDataCallbacksBuildImageId, eventCollect);
@@ -1071,6 +1072,7 @@ export function initExposure(): void {
         selectedProvider,
         onDataCallbacksBuildImageId,
         cancellableTokenId,
+        buildargs,
       );
     },
   );

--- a/packages/renderer/src/lib/image/BuildImageFromContainerfile.spec.ts
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfile.spec.ts
@@ -226,6 +226,7 @@ test('Select multiple platforms and expect pressing Build will do two buildImage
     expect.anything(),
     expect.anything(),
     expect.anything(),
+    expect.anything(),
   );
 
   expect(window.buildImage).toHaveBeenCalledWith(
@@ -233,6 +234,7 @@ test('Select multiple platforms and expect pressing Build will do two buildImage
     'containerfile',
     '',
     'linux/arm64',
+    expect.anything(),
     expect.anything(),
     expect.anything(),
     expect.anything(),
@@ -271,6 +273,7 @@ test('Selecting one platform only calls buildImage once with the selected platfo
     'containerfile',
     'foobar',
     'linux/amd64',
+    expect.anything(),
     expect.anything(),
     expect.anything(),
     expect.anything(),
@@ -354,4 +357,39 @@ test('Expect recommended extension in case of build error', async () => {
   // expect to find the widget to install extension
   const proposal = screen.getByRole('button', { name: 'Install myExtension.id Extension' });
   expect(proposal).toBeInTheDocument();
+});
+
+test('Expect build to include build arguments', async () => {
+  setup();
+  render(BuildImageFromContainerfile);
+
+  const containerFilePath = screen.getByRole('textbox', { name: 'Containerfile Path' });
+  expect(containerFilePath).toBeInTheDocument();
+  await userEvent.type(containerFilePath, '/somepath/containerfile');
+
+  const buildFolder = screen.getByRole('textbox', { name: 'Build Context Directory' });
+  expect(buildFolder).toBeInTheDocument();
+  await userEvent.type(buildFolder, '/somepath');
+
+  const containerImageName = screen.getByRole('textbox', { name: 'Image Name' });
+  expect(containerImageName).toBeInTheDocument();
+  await userEvent.type(containerImageName, 'foobar');
+
+  const addArgButton = screen.getByRole('button', { name: 'Add build argument' });
+  expect(addArgButton).toBeInTheDocument();
+  await userEvent.click(addArgButton);
+
+  // Expect "Key" input to exist
+  const keyInputs = screen.getAllByPlaceholderText('Key');
+  await userEvent.type(keyInputs[1], 'ARG_KEY');
+
+  // Expect "Value" input to exist
+  const valueInputs = screen.getAllByPlaceholderText('Value');
+  await userEvent.type(valueInputs[1], 'ARG_VALUE');
+
+  // Expect to be able to build fine with the build arguments / no errors.
+  const buildButton = screen.getByRole('button', { name: 'Build' });
+  expect(buildButton).toBeInTheDocument();
+  expect(buildButton).toBeEnabled();
+  await userEvent.click(buildButton);
 });

--- a/tests/playwright/src/model/pages/build-image-page.ts
+++ b/tests/playwright/src/model/pages/build-image-page.ts
@@ -42,7 +42,7 @@ export class BuildImagePage extends BasePage {
     this.containerFilePathInput = page.getByPlaceholder('Containerfile to build');
     this.buildContextDirectoryInput = page.getByPlaceholder('Folder to build in');
     this.imageNameInput = page.getByPlaceholder('my-custom-image');
-    this.buildButton = page.getByRole('button', { name: 'Build' });
+    this.buildButton = page.getByRole('button', { name: 'Build', exact: true });
     this.doneButton = page.getByRole('button', { name: 'Done' });
     this.containerFilePathButton = page.getByRole('button', { name: 'Browse...' }).first();
     this.platformRegion = page.getByRole('region', { name: 'Build Platform Options' });


### PR DESCRIPTION
feat: add build arguments to build page

### What does this PR do?

Build arguments is already built-in to podman desktop API.

This adds to the UI the ability to pass in build arguments.

### Screenshot / video of UI


https://github.com/containers/podman-desktop/assets/6422176/b204bc38-8b35-4b49-9a49-8e614c8fe518



### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop/issues/7250

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature

1. Build a Containerfile with ARG
2. See it fail (normal)
3. In build args, add your arg (ex. foo=bar)
4. It will now build and pass.
