### PR TITLE
fix: button should have spinner when inProgress is enable

### DIFF
--- a/packages/ui/src/lib/button/Button.spec.ts
+++ b/packages/ui/src/lib/button/Button.spec.ts
@@ -169,3 +169,19 @@ test('Check icon button with fab prefix is visible', async () => {
   const img = screen.getByRole('img', { hidden: true });
   expect(img).toBeInTheDocument();
 });
+
+test('Button inProgress must have a spinner', async () => {
+  // render the component
+  render(Button, { inProgress: true });
+
+  const svg = screen.getByRole('img');
+  expect(svg).toBeDefined();
+});
+
+test('Button no progress no icon do not have spinner', async () => {
+  // render the component
+  render(Button, { inProgress: false });
+
+  const svg = screen.queryByRole('img');
+  expect(svg).toBeNull();
+});

--- a/packages/ui/src/lib/button/Button.svelte
+++ b/packages/ui/src/lib/button/Button.svelte
@@ -73,7 +73,7 @@ $: {
   aria-label="{$$props['aria-label']}"
   on:click
   disabled="{disabled || inProgress}">
-  {#if icon}
+  {#if icon || inProgress}
     <div
       class="flex flex-row p-0 m-0 bg-transparent justify-center items-center space-x-[4px]"
       class:py-[3px]="{!$$slots.default}">


### PR DESCRIPTION
### What does this PR do?

Spinner was not visible when no icon was provided. Fix already inside the fork of ai-lab, required to adopt Button component from ui package

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop/issues/7258

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
