### PR TITLE
fix: don't start provider before it's stopped

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesConnectionActions.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionActions.svelte
@@ -63,17 +63,17 @@ async function restartConnectionProvider(
       '/preferences/resources',
       getLoggerHandler(provider, providerConnectionInfo),
     );
-    addConnectionToRestartingQueue({
-      container: providerConnectionInfo.name,
-      provider: provider.internalId,
-      loggerHandlerKey,
-    });
     await window.stopProviderConnectionLifecycle(
       provider.internalId,
       providerConnectionInfo,
       loggerHandlerKey,
       eventCollect,
     );
+    addConnectionToRestartingQueue({
+      container: providerConnectionInfo.name,
+      provider: provider.internalId,
+      loggerHandlerKey,
+    });
   }
 }
 


### PR DESCRIPTION
Fixes https://github.com/crc-org/crc-extension/issues/210

### What does this PR do?

Ensure provider is restarted in proper order

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

https://github.com/crc-org/crc-extension/issues/210

### How to test this PR?

1. Start OpenShift Local
2. Restart it

- [ ] Tests are covering the bug fix or the new feature
