### PR TITLE
feat: adding highlight status bar task manager

### DIFF
--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -509,7 +509,7 @@ export class PluginSystem {
       }
     });
 
-    statusBarRegistry.setEntry('help', false, 0, undefined, 'Help', 'fa fa-question-circle', true, 'help', undefined);
+    statusBarRegistry.setEntry('help', false, -1, undefined, 'Help', 'fa fa-question-circle', true, 'help', undefined);
 
     statusBarRegistry.setEntry(
       'troubleshooting',

--- a/packages/main/src/plugin/task-manager.spec.ts
+++ b/packages/main/src/plugin/task-manager.spec.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { expect, test, vi } from 'vitest';
+import { beforeEach, expect, test, vi } from 'vitest';
 
 import type { CommandRegistry } from '/@/plugin/command-registry.js';
 import type { StatusBarRegistry } from '/@/plugin/statusbar/statusbar-registry.js';
@@ -42,6 +42,10 @@ const statusBarRegistry: StatusBarRegistry = {
 const commandRegistry: CommandRegistry = {
   registerCommand: mocks.registerCommandMock,
 } as unknown as CommandRegistry;
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
 
 test('create stateful task with title', async () => {
   const taskManager = new TaskManager(apiSender, statusBarRegistry, commandRegistry);
@@ -193,4 +197,23 @@ test('Ensure init setup command and statusbar registry', async () => {
 
   expect(mocks.registerCommandMock).toHaveBeenCalledOnce();
   expect(mocks.setEntryMock).toHaveBeenCalledOnce();
+});
+
+test('Ensure statusbar registry', async () => {
+  const taskManager = new TaskManager(apiSender, statusBarRegistry, commandRegistry);
+
+  taskManager.createTask('Dummy Task');
+
+  expect(statusBarRegistry.setEntry).toHaveBeenCalledWith(
+    'tasks',
+    false,
+    0,
+    undefined,
+    'Tasks',
+    'fa fa-bell',
+    true,
+    'show-task-manager',
+    undefined,
+    true,
+  );
 });

--- a/packages/main/src/plugin/task-manager.ts
+++ b/packages/main/src/plugin/task-manager.ts
@@ -39,6 +39,15 @@ export class TaskManager {
 
   public init(): void {
     // The TaskManager is responsible for creating the entry he will be using
+    this.setStatusBarEntry(false);
+
+    this.commandRegistry.registerCommand('show-task-manager', () => {
+      this.apiSender.send('toggle-task-manager', '');
+      this.setStatusBarEntry(false);
+    });
+  }
+
+  private setStatusBarEntry(highlight: boolean): void {
     this.statusBarRegistry.setEntry(
       'tasks',
       false,
@@ -49,11 +58,8 @@ export class TaskManager {
       true,
       'show-task-manager',
       undefined,
+      highlight,
     );
-
-    this.commandRegistry.registerCommand('show-task-manager', () => {
-      this.apiSender.send('toggle-task-manager', '');
-    });
   }
 
   public createTask(title: string | undefined): StatefulTask {
@@ -67,6 +73,7 @@ export class TaskManager {
     };
     this.tasks.set(task.id, task);
     this.apiSender.send('task-created', task);
+    this.setStatusBarEntry(true);
     return task;
   }
 
@@ -81,6 +88,7 @@ export class TaskManager {
     };
     this.tasks.set(task.id, task);
     this.apiSender.send('task-created', task);
+    this.setStatusBarEntry(true);
     return task;
   }
 


### PR DESCRIPTION
### What does this PR do?

When a task is created, we set the status bar highlight to true, adding this little bubble as shown in the screenshots.

This bubble is removed when the task manager is open. 

This PR also change the order priority of the help, to -1 to ensure it is always the one on the most right.

### Screenshot / video of UI

| Before | After |
| --- | --- |
| <img width="164" alt="image" src="https://github.com/containers/podman-desktop/assets/42176370/4e68b09e-a4b1-4339-94ec-86f6ebcaace1"> | <img width="161" alt="image" src="https://github.com/containers/podman-desktop/assets/42176370/161da9cf-f38e-4f8e-8c80-201c55ced0fc"> |
| N/A | <img width="181" alt="image" src="https://github.com/containers/podman-desktop/assets/42176370/6f58c4b2-4bda-4ee6-b4ad-818763da8ec2"> |

### What issues does this PR fix or reference?

Following https://github.com/containers/podman-desktop/pull/5773 

Fixes https://github.com/containers/podman-desktop/issues/4243

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature

Create a notification, you can do so by pushing to kubernetes cluster an image for example.
