### PR TITLE
fix: remove tinro dependency from SettingsNavItem component

### DIFF
--- a/packages/renderer/src/PreferencesNavigation.svelte
+++ b/packages/renderer/src/PreferencesNavigation.svelte
@@ -49,17 +49,9 @@ onMount(async () => {
     </div>
   </div>
   <div class="h-full overflow-hidden hover:overflow-y-auto" style="margin-bottom:auto">
-    <SettingsNavItem title="Resources" href="/preferences/resources" bind:meta="{meta}" />
-
-    <SettingsNavItem title="Proxy" href="/preferences/proxies" bind:meta="{meta}" />
-
-    <SettingsNavItem title="Registries" href="/preferences/registries" bind:meta="{meta}" />
-
-    <SettingsNavItem title="Authentication" href="/preferences/authentication-providers" bind:meta="{meta}" />
-
-    <SettingsNavItem title="CLI Tools" href="/preferences/cli-tools" bind:meta="{meta}" />
-
-    <SettingsNavItem title="Kubernetes" href="/preferences/kubernetes-contexts" bind:meta="{meta}" />
+    {#each [{ title: 'Resources', href: '/preferences/resources' }, { title: 'Proxy', href: '/preferences/proxies' }, { title: 'Registries', href: '/preferences/registries' }, { title: 'Authentication', href: '/preferences/authentication-providers' }, { title: 'CLI Tools', href: '/preferences/cli-tools' }, { title: 'Kubernetes', href: '/preferences/kubernetes-contexts' }] as navItem}
+      <SettingsNavItem title="{navItem.title}" href="{navItem.href}" selected="{meta.url === navItem.href}" />
+    {/each}
 
     <!-- Default configuration properties start -->
     {#each Object.entries(configProperties) as [configSection, configItems]}
@@ -67,7 +59,7 @@ onMount(async () => {
         title="{configSection}"
         href="/preferences/default/{configSection}"
         section="{configItems.length > 0}"
-        bind:meta="{meta}"
+        selected="{meta.url === `/preferences/default/${configSection}`}"
         bind:expanded="{sectionExpanded[configSection]}" />
       {#if sectionExpanded[configSection]}
         {#each sortItems(configItems) as configItem}
@@ -75,7 +67,7 @@ onMount(async () => {
             title="{configItem.title}"
             href="/preferences/default/{configItem.id}"
             child="{true}"
-            bind:meta="{meta}" />
+            selected="{meta.url === `/preferences/default/${configItem.id}`}" />
         {/each}
       {/if}
     {/each}

--- a/packages/renderer/src/lib/preferences/SettingsNavItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/SettingsNavItem.spec.ts
@@ -25,14 +25,14 @@ import { expect, test } from 'vitest';
 
 import SettingsNavItem from './SettingsNavItem.svelte';
 
-function renderIt(title: string, href: string, meta: any, section?: boolean, child?: boolean): void {
-  render(SettingsNavItem, { title: title, href: href, meta: meta, section: section, child: child });
+function renderIt(title: string, href: string, selected?: boolean, section?: boolean, child?: boolean): void {
+  render(SettingsNavItem, { title: title, href: href, selected: selected, section: section, child: child });
 }
 
 test('Expect correct role and href', async () => {
   const title = 'Resources';
   const href = '/test';
-  renderIt(title, href, { url: href });
+  renderIt(title, href, true);
 
   const element = screen.getByLabelText(title);
   expect(element).toBeInTheDocument();
@@ -42,7 +42,7 @@ test('Expect correct role and href', async () => {
 test('Expect selection styling', async () => {
   const title = 'Resources';
   const href = '/test';
-  renderIt(title, href, { url: href });
+  renderIt(title, href, true);
 
   const element = screen.getByLabelText(title);
   expect(element).toBeInTheDocument();
@@ -52,7 +52,7 @@ test('Expect selection styling', async () => {
 
 test('Expect not to have selection styling', async () => {
   const title = 'Resources';
-  renderIt(title, '/test', { url: '/elsewhere' });
+  renderIt(title, '/test', false);
 
   const element = screen.getByLabelText(title);
   expect(element).toBeInTheDocument();
@@ -64,7 +64,7 @@ test('Expect not to have selection styling', async () => {
 test('Expect child styling', async () => {
   const title = 'Resources';
   const href = '/test';
-  renderIt(title, href, { url: href }, false, true);
+  renderIt(title, href, true, false, true);
 
   const element = screen.getByLabelText(title);
   expect(element).toBeInTheDocument();
@@ -75,7 +75,7 @@ test('Expect child styling', async () => {
 test('Expect section styling', async () => {
   const title = 'Extensions';
   const href = '/test';
-  renderIt(title, href, { url: href }, true, false);
+  renderIt(title, href, true, true, false);
 
   const element = screen.getByLabelText(title);
   expect(element).toBeInTheDocument();
@@ -88,7 +88,7 @@ test('Expect section styling', async () => {
 test('Expect sections expand', async () => {
   const title = 'Extensions';
   const href = '/test';
-  renderIt(title, href, { url: href }, true, false);
+  renderIt(title, href, true, true, false);
 
   const element = screen.getByLabelText(title);
   expect(element).toBeInTheDocument();

--- a/packages/renderer/src/lib/preferences/SettingsNavItem.svelte
+++ b/packages/renderer/src/lib/preferences/SettingsNavItem.svelte
@@ -1,15 +1,10 @@
 <script lang="ts">
-import type { TinroRouteMeta } from 'tinro';
-
 export let title: string;
 export let href: string;
-export let meta: TinroRouteMeta;
 export let section = false;
 export let expanded = false;
 export let child = false;
-
-let selected: boolean;
-$: selected = meta.url === href;
+export let selected: boolean = false;
 
 function rotate(node: unknown, { clockwise = true }) {
   return {


### PR DESCRIPTION
### What does this PR do?

Remove the tinro dependency on the SettingsNavItem  svelte component be replacing the `meta: TinroMeta` property by `selected`.

Thus delegating to the parent, to state if an item is selected or not, which other developers full control to use the framework they want.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop/issues/7279

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Existing tests ensure no regression
