### PR TITLE
feat: create task when updating Podman Desktop

### DIFF
--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -536,7 +536,7 @@ export class PluginSystem {
     );
 
     // Init update logic
-    new Updater(messageBox, configurationRegistry, statusBarRegistry, commandRegistry).init();
+    new Updater(messageBox, configurationRegistry, statusBarRegistry, commandRegistry, taskManager).init();
 
     commandRegistry.registerCommand('feedback', () => {
       apiSender.send('display-feedback', '');


### PR DESCRIPTION
### What does this PR do?
create task when updating Podman Desktop
the task includes percentage as progress


### Screenshot / video of UI


https://github.com/containers/podman-desktop/assets/436777/7278deec-1b18-463e-9e5a-4d5da196292e


### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/7225

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

you may manually try by first changing version in package.json and building a binary
also to lower the download speed I used on macOS network link conditionner tool (from https://developer.apple.com/download/all/)


- [x] Tests are covering the bug fix or the new feature
