### PR TITLE
fix: modal dialog should have fixed position

### DIFF
--- a/packages/ui/src/lib/modal/Modal.svelte
+++ b/packages/ui/src/lib/modal/Modal.svelte
@@ -32,7 +32,7 @@ if (previously_focused) {
 
 <svelte:window on:keydown="{handle_keydown}" />
 
-<div class:items-center="{!top}" class="absolute w-full h-full flex justify-center">
+<div class:items-center="{!top}" class="fixed top-0 left-0 right-0 bottom-0 w-full h-full flex justify-center z-50">
   <button
     aria-label="close"
     class="fixed top-0 left-0 w-full h-full bg-[var(--pd-modal-fade)] bg-blend-multiply opacity-60 z-40 cursor-default"


### PR DESCRIPTION
### What does this PR do?

PR #7172 moved MessageBox (which had fixed full screen positioning) to use Modal instead (which had relative positioning), which meant that any MessageBox that wasn't opened from near the root of our divs wasn't positioned correctly, and in the case of an action like Edit/rename Image at the far right, the dialog wasn't even visible on screen.

Fixes #7247 by switching Modal to fixed positioning (copied prior styling from MessageBox). Likely also fixes a couple other cases where Modals were slightly off-centre but not enough to notice.

### Screenshot / video of UI

Should be self-explanatory enough - no dialog visible prior to fix.

### What issues does this PR fix or reference?

Fixes #7247.

### How to test this PR?

Open the push or rename image dialog. Before this change the dialog isn't visible, afterward it is.