### PR TITLE
fix: remove limit when checking default machine

### DIFF
--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -337,10 +337,7 @@ export async function updateMachines(provider: extensionApi.Provider): Promise<v
 
     // Finally, we check to see if the machine that is running is set by default or not on the CLI
     // this will create a dialog that will ask the user if they wish to set the running machine as default.
-    // this should only run if we have multiple machines
-    if (machines.length > 1) {
-      await checkDefaultMachine(machines);
-    }
+    await checkDefaultMachine(machines);
   }
 }
 

--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -333,12 +333,10 @@ export async function updateMachines(provider: extensionApi.Provider): Promise<v
         // needs to start a machine
         provider.updateStatus('configured');
       }
-    }
 
-    // Finally, we check to see if the machine that is running is set by default or not on the CLI
-    // this will create a dialog that will ask the user if they wish to set the running machine as default.
-    // this should only run if we at least one machine
-    if (machines.length > 0) {
+      // Finally, we check to see if the machine that is running is set by default or not on the CLI
+      // this will create a dialog that will ask the user if they wish to set the running machine as default.
+      // this should only run if we at least one machine
       await checkDefaultMachine(machines);
     }
   }

--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -337,7 +337,10 @@ export async function updateMachines(provider: extensionApi.Provider): Promise<v
 
     // Finally, we check to see if the machine that is running is set by default or not on the CLI
     // this will create a dialog that will ask the user if they wish to set the running machine as default.
-    await checkDefaultMachine(machines);
+    // this should only run if we at least one machine
+    if (machines.length > 0) {
+      await checkDefaultMachine(machines);
+    }
   }
 }
 


### PR DESCRIPTION
### What does this PR do?

This PR removes the check of the number of machine when checking if the machine has to be marked as default.
It may happen that you only have one machine but multiple connections (maybe old ones or, on windows, that you have connections from wsl and hyperv but only machines of wsl/hyperv are displayed), and the check to inform the user that the running machine is not the default one is skipped. At this point you would see a machine which is not the default one and many actions may fail, like creating a kind cluster.

This could be a potential fix for https://github.com/containers/podman-desktop/issues/6668 or https://github.com/containers/podman-desktop/issues/7052 

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

hard to reproduce but maybe related to #6668 and #7052

### How to test this PR?

1. Have some old connections and 0 machine. 
2. Create a new machine and see that desktop tells you to update your default machine.

- [ ] Tests are covering the bug fix or the new feature
