### PR TITLE
feat: add k8s age column to ingress / routes

### DIFF
--- a/packages/api/src/openshift-types.ts
+++ b/packages/api/src/openshift-types.ts
@@ -24,6 +24,7 @@ export type V1Route = {
     namespace: string;
     annotations?: { [key: string]: string };
     labels?: { [key: string]: string };
+    creationTimestamp?: Date;
   };
   spec: {
     host: string;

--- a/packages/renderer/src/lib/ingresses-routes/IngressUI.ts
+++ b/packages/renderer/src/lib/ingresses-routes/IngressUI.ts
@@ -24,4 +24,5 @@ export interface IngressUI {
   status: string;
   rules?: Array<V1IngressRule>;
   selected: boolean;
+  created?: Date;
 }

--- a/packages/renderer/src/lib/ingresses-routes/IngressesRoutesList.spec.ts
+++ b/packages/renderer/src/lib/ingresses-routes/IngressesRoutesList.spec.ts
@@ -147,3 +147,10 @@ test('Expect status column name to be clickable / sortable', async () => {
   // Expect it to have the 'cursor-pointer' class which means it's clickable / sortable
   expect(statusColumn).toHaveClass('cursor-pointer');
 });
+
+test('Expect there to be an age column', async () => {
+  await waitRender({});
+
+  const ageColumn = screen.getByRole('columnheader', { name: 'Age' });
+  expect(ageColumn).toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/ingresses-routes/IngressesRoutesList.svelte
+++ b/packages/renderer/src/lib/ingresses-routes/IngressesRoutesList.svelte
@@ -6,9 +6,11 @@ import {
   NavPage,
   Table,
   TableColumn,
+  TableDurationColumn,
   TableRow,
   TableSimpleColumn,
 } from '@podman-desktop/ui-svelte';
+import moment from 'moment';
 import { onDestroy, onMount } from 'svelte';
 import type { Unsubscriber } from 'svelte/store';
 
@@ -123,6 +125,12 @@ let pathColumn = new TableColumn<IngressUI | RouteUI, string>('Host/Path', {
   comparator: (a, b) => compareHostPath(a, b),
 });
 
+let ageColumn = new TableColumn<IngressUI | RouteUI, Date | undefined>('Age', {
+  renderMapping: ingressRoute => ingressRoute.created,
+  renderer: TableDurationColumn,
+  comparator: (a, b) => moment(b.created).diff(moment(a.created)),
+});
+
 function compareHostPath(object1: IngressUI | RouteUI, object2: IngressUI | RouteUI): number {
   const hostPathObject1 = ingressRouteUtils.getHostPaths(object1)[0] ?? '';
   const hostPathObject2 = ingressRouteUtils.getHostPaths(object2)[0] ?? '';
@@ -140,12 +148,13 @@ function compareBackend(object1: IngressUI | RouteUI, object2: IngressUI | Route
   return backendObject1.localeCompare(backendObject2);
 }
 
-const columns: TableColumn<IngressUI | RouteUI, IngressUI | RouteUI | string>[] = [
+const columns: TableColumn<IngressUI | RouteUI, IngressUI | RouteUI | string | Date | undefined>[] = [
   statusColumn,
   nameColumn,
   namespaceColumn,
   pathColumn,
   backendColumn,
+  ageColumn,
   new TableColumn<IngressUI | RouteUI>('Actions', { align: 'right', renderer: IngressRouteColumnActions }),
 ];
 

--- a/packages/renderer/src/lib/ingresses-routes/RouteUI.ts
+++ b/packages/renderer/src/lib/ingresses-routes/RouteUI.ts
@@ -31,4 +31,5 @@ export interface RouteUI {
   to: RouteToReference;
   selected: boolean;
   tlsEnabled: boolean;
+  created?: Date;
 }

--- a/packages/renderer/src/lib/ingresses-routes/ingress-route-utils.spec.ts
+++ b/packages/renderer/src/lib/ingresses-routes/ingress-route-utils.spec.ts
@@ -348,3 +348,36 @@ test('expect no tls on route', async () => {
   const routeUI = ingressRouteUtils.getRouteUI(route);
   expect(routeUI.tlsEnabled).toBeFalsy();
 });
+
+test('expect created date on ingress', async () => {
+  const ingress = {
+    metadata: {
+      name: 'my-ingress',
+      namespace: 'test-namespace',
+      creationTimestamp: new Date(),
+    },
+    spec: {
+      rules: [
+        {
+          host: 'foo.bar.com',
+          http: {
+            paths: [
+              {
+                path: '/foo',
+                pathType: 'Prefix',
+                backend: {
+                  resource: {
+                    name: 'bucket',
+                    kind: 'StorageBucket',
+                  },
+                },
+              },
+            ],
+          },
+        },
+      ],
+    },
+  } as V1Ingress;
+  const ingressUI = ingressRouteUtils.getIngressUI(ingress);
+  expect(ingressUI.created).toBeDefined();
+});

--- a/packages/renderer/src/lib/ingresses-routes/ingress-route-utils.ts
+++ b/packages/renderer/src/lib/ingresses-routes/ingress-route-utils.ts
@@ -36,6 +36,7 @@ export class IngressRouteUtils {
       status: 'RUNNING',
       rules: ingress.spec?.rules,
       selected: false,
+      created: ingress.metadata?.creationTimestamp ? new Date(ingress.metadata.creationTimestamp) : undefined,
     };
   }
   getRouteUI(route: V1Route): RouteUI {
@@ -53,6 +54,7 @@ export class IngressRouteUtils {
       selected: false,
       // true if tls part is defined
       tlsEnabled: !!route.spec.tls,
+      created: route.metadata?.creationTimestamp ? new Date(route.metadata.creationTimestamp) : undefined,
     };
   }
   isIngress(object: IngressUI | RouteUI): object is IngressUI {


### PR DESCRIPTION
feat: add k8s age column to ingress / routes

### What does this PR do?

* Adds the age column for ingress / services k8s page
* Added simple test

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->
![Screenshot 2024-05-27 at 2 33 07 PM](https://github.com/containers/podman-desktop/assets/6422176/ba491ec5-0e29-489d-88e4-d89d432f852d)



### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop/issues/5978

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature

Open up ingress / routes and see age has been added.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
