### PR TITLE
feat: table rows with children

### DIFF
--- a/packages/ui/src/lib/table/table.ts
+++ b/packages/ui/src/lib/table/table.ts
@@ -98,7 +98,7 @@ export class Column<Type, RenderType = Type> {
  */
 export interface RowInformation<Type> {
   /**
-   * Returns true if a row can be selested, and false otherwise.
+   * Returns true if a row can be selected, and false otherwise.
    */
   readonly selectable?: (object: Type) => boolean;
 
@@ -106,6 +106,11 @@ export interface RowInformation<Type> {
    * Tooltip text to show when row selection is disabled.
    */
   readonly disabledText?: string;
+
+  /**
+   * Returns an array of child objects of a given row.
+   */
+  readonly children?: (object: Type) => Type[];
 }
 
 /**


### PR DESCRIPTION
### What does this PR do?

Adds the ability for rows within a table to have children, very similar to how container groups exist in the Containers view today.

Optional children function added to RowInformation to provide the necessary API for consumers. Expand/collapse control matches what is in the Containers view today.

In order to allow each row to be hover-able separately, a new parent div creates the outer box for each parent/children group, and when children exist these rows are added after the parent.

Since the UI package can't use stores directly like the Containers view does, a new expanded array property has been exposed to allow consumers to store/reload the list of expanded children. Since UI objects are recreated each time, the list requires all expandable objects to have an id property, and the list of ids is what is saved. This could be a configurable property in the future, but everything we want to expand today has an id.

Svelte sort animation conflicted with this change, so it has been removed. If this PR is approved I'll open up an issue to track finding another way to add it back.

### Screenshot / video of UI

https://github.com/containers/podman-desktop/assets/19958075/d4618755-d573-4d9d-928e-f83350437a16

### What issues does this PR fix or reference?

Fixes #7209.

### How to test this PR?

Since this is component support without the corresponding use in Podman Desktop yet, the easiest way to test is to add code like the following to one of the existing tables like ImagesList.svelte:309 (adds an image as a child of itself):

```
  children: image => {
    if (image.shortId === 'some id') {
      return [image];
    }
    return [];
  },

```