### PR TITLE
chore: button support for light mode

### DIFF
--- a/packages/main/src/plugin/color-registry.ts
+++ b/packages/main/src/plugin/color-registry.ts
@@ -857,10 +857,6 @@ export class ColorRegistry {
       dark: colorPalette.purple[500],
       light: colorPalette.purple[500],
     });
-    this.registerColor(`${button}secondary-hover-bg`, {
-      dark: colorPalette.white + '2',
-      light: colorPalette.black + '2',
-    });
     this.registerColor(`${button}text`, {
       dark: colorPalette.white,
       light: colorPalette.white,

--- a/packages/main/src/plugin/color-registry.ts
+++ b/packages/main/src/plugin/color-registry.ts
@@ -857,6 +857,10 @@ export class ColorRegistry {
       dark: colorPalette.purple[500],
       light: colorPalette.purple[500],
     });
+    this.registerColor(`${button}secondary-hover-bg`, {
+      dark: colorPalette.white + '2',
+      light: colorPalette.black + '2',
+    });
     this.registerColor(`${button}text`, {
       dark: colorPalette.white,
       light: colorPalette.white,
@@ -889,11 +893,15 @@ export class ColorRegistry {
       dark: colorPalette.red[600],
       light: colorPalette.red[600],
     });
-    this.registerColor(`${button}danger-border-disabled`, {
+    this.registerColor(`${button}danger-disabled-border`, {
       dark: colorPalette.charcoal[50],
       light: colorPalette.gray[900],
     });
-    this.registerColor(`${button}danger-bg-disabled`, {
+    this.registerColor(`${button}danger-disabled-text`, {
+      dark: colorPalette.charcoal[50],
+      light: colorPalette.gray[900],
+    });
+    this.registerColor(`${button}danger-disabled-bg`, {
       dark: colorPalette.transparent,
       light: colorPalette.transparent,
     });

--- a/packages/main/src/plugin/color-registry.ts
+++ b/packages/main/src/plugin/color-registry.ts
@@ -237,7 +237,7 @@ export class ColorRegistry {
     this.initDetails();
     this.initTab();
     this.initModal();
-    this.initLink();
+    this.initButton();
   }
 
   protected initGlobalNav(): void {
@@ -832,6 +832,92 @@ export class ColorRegistry {
       light: colorPalette.purple[700],
     });
     this.registerColor(`${link}-hover-bg`, {
+      dark: colorPalette.white + '2',
+      light: colorPalette.black + '2',
+    });
+  }
+
+  // button
+  protected initButton(): void {
+    const button = 'button-';
+
+    this.registerColor(`${button}primary-bg`, {
+      dark: colorPalette.purple[600],
+      light: colorPalette.purple[600],
+    });
+    this.registerColor(`${button}primary-hover-bg`, {
+      dark: colorPalette.purple[500],
+      light: colorPalette.purple[500],
+    });
+    this.registerColor(`${button}secondary`, {
+      dark: colorPalette.gray[200],
+      light: colorPalette.purple[600],
+    });
+    this.registerColor(`${button}secondary-hover`, {
+      dark: colorPalette.purple[500],
+      light: colorPalette.purple[500],
+    });
+    this.registerColor(`${button}text`, {
+      dark: colorPalette.white,
+      light: colorPalette.white,
+    });
+    this.registerColor(`${button}disabled`, {
+      dark: colorPalette.charcoal[50],
+      light: colorPalette.gray[900],
+    });
+    this.registerColor(`${button}disabled-text`, {
+      dark: colorPalette.charcoal[50],
+      light: colorPalette.gray[900],
+    });
+    this.registerColor(`${button}danger-border`, {
+      dark: colorPalette.red[500],
+      light: colorPalette.red[700],
+    });
+    this.registerColor(`${button}danger-bg`, {
+      dark: colorPalette.transparent,
+      light: colorPalette.transparent,
+    });
+    this.registerColor(`${button}danger-text`, {
+      dark: colorPalette.red[500],
+      light: colorPalette.red[700],
+    });
+    this.registerColor(`${button}danger-hover-text`, {
+      dark: colorPalette.white,
+      light: colorPalette.white,
+    });
+    this.registerColor(`${button}danger-hover-bg`, {
+      dark: colorPalette.red[600],
+      light: colorPalette.red[600],
+    });
+    this.registerColor(`${button}danger-border-disabled`, {
+      dark: colorPalette.charcoal[50],
+      light: colorPalette.gray[900],
+    });
+    this.registerColor(`${button}danger-bg-disabled`, {
+      dark: colorPalette.transparent,
+      light: colorPalette.transparent,
+    });
+    this.registerColor(`${button}tab-border`, {
+      dark: colorPalette.charcoal[700],
+      light: colorPalette.gray[400],
+    });
+    this.registerColor(`${button}tab-border-selected`, {
+      dark: colorPalette.purple[500],
+      light: colorPalette.purple[600],
+    });
+    this.registerColor(`${button}tab-hover-border`, {
+      dark: colorPalette.charcoal[100],
+      light: colorPalette.black,
+    });
+    this.registerColor(`${button}tab-text`, {
+      dark: colorPalette.gray[600],
+      light: colorPalette.charcoal[200],
+    });
+    this.registerColor(`${button}link-text`, {
+      dark: colorPalette.purple[400],
+      light: colorPalette.purple[700],
+    });
+    this.registerColor(`${button}link-hover-bg`, {
       dark: colorPalette.white + '2',
       light: colorPalette.black + '2',
     });

--- a/packages/ui/src/lib/button/Button.spec.ts
+++ b/packages/ui/src/lib/button/Button.spec.ts
@@ -73,6 +73,9 @@ test('Check secondary button styling', async () => {
   expect(button).toHaveClass('py-[4px]');
   expect(button).toHaveClass('text-[13px]');
   expect(button).toHaveClass('text-[var(--pd-button-secondary)]');
+  expect(button).toHaveClass('hover:bg-[var(--pd-button-secondary-hover-bg)]');
+  expect(button).toHaveClass('hover:border-[var(--pd-button-secondary-hover)]');
+  expect(button).toHaveClass('hover:text-[var(--pd-button-secondary-hover)]');
 });
 
 test('Check danger button styling', async () => {
@@ -86,9 +89,10 @@ test('Check danger button styling', async () => {
   expect(button).toHaveClass('px-4');
   expect(button).toHaveClass('py-[3px]');
   expect(button).toHaveClass('bg-[var(--pd-button-danger-bg)]');
-  expect(button).toHaveClass('hover:bg-[var(--pd-button-danger-hover-bg)]');
   expect(button).toHaveClass('text-[13px]');
   expect(button).toHaveClass('text-[var(--pd-button-danger-text)]');
+  expect(button).toHaveClass('hover:bg-[var(--pd-button-danger-hover-bg)]');
+  expect(button).toHaveClass('hover:text-[var(--pd-button-danger-hover-text)]');
 });
 
 test('Check disabled/in-progress secondary button styling', async () => {

--- a/packages/ui/src/lib/button/Button.spec.ts
+++ b/packages/ui/src/lib/button/Button.spec.ts
@@ -33,11 +33,12 @@ test('Check primary button styling', async () => {
   // check for a few elements of the styling
   const button = screen.getByRole('button');
   expect(button).toBeInTheDocument();
-  expect(button).toHaveClass('bg-purple-600');
+  expect(button).toHaveClass('bg-[var(--pd-button-primary-bg)]');
+  expect(button).toHaveClass('hover:bg-[var(--pd-button-primary-hover-bg)]');
   expect(button).toHaveClass('border-none');
   expect(button).toHaveClass('py-[5px]');
   expect(button).toHaveClass('text-[13px]');
-  expect(button).toHaveClass('text-white');
+  expect(button).toHaveClass('text-[var(--pd-button-text)]');
 });
 
 test('Check disabled/in-progress primary button styling', async () => {
@@ -46,7 +47,7 @@ test('Check disabled/in-progress primary button styling', async () => {
   // check for a few elements of the styling
   const button = screen.getByRole('button');
   expect(button).toBeInTheDocument();
-  expect(button).toHaveClass('bg-charcoal-50');
+  expect(button).toHaveClass('bg-[var(--pd-button-disabled)]');
   expect(button).toHaveClass('py-[5px]');
   expect(button).toHaveClass('text-[13px]');
 });
@@ -57,8 +58,8 @@ test('Check primary button is the default', async () => {
   // check for a few elements of the styling
   const button = screen.getByRole('button');
   expect(button).toBeInTheDocument();
-  expect(button).toHaveClass('bg-purple-600');
-  expect(button).toHaveClass('text-white');
+  expect(button).toHaveClass('bg-[var(--pd-button-primary-bg)]');
+  expect(button).toHaveClass('text-[var(--pd-button-text)]');
 });
 
 test('Check secondary button styling', async () => {
@@ -67,11 +68,11 @@ test('Check secondary button styling', async () => {
   // check for a few elements of the styling
   const button = screen.getByRole('button');
   expect(button).toBeInTheDocument();
-  expect(button).toHaveClass('border-gray-200');
+  expect(button).toHaveClass('border-[var(--pd-button-secondary)]');
   expect(button).toHaveClass('border-[1px]');
   expect(button).toHaveClass('py-[4px]');
   expect(button).toHaveClass('text-[13px]');
-  expect(button).toHaveClass('text-white');
+  expect(button).toHaveClass('text-[var(--pd-button-secondary)]');
 });
 
 test('Check danger button styling', async () => {
@@ -80,13 +81,14 @@ test('Check danger button styling', async () => {
   // check for a few elements of the styling
   const button = screen.getByRole('button');
   expect(button).toBeInTheDocument();
-  expect(button).toHaveClass('border-red-600');
+  expect(button).toHaveClass('border-[var(--pd-button-danger-border)]');
   expect(button).toHaveClass('border-2');
   expect(button).toHaveClass('px-4');
   expect(button).toHaveClass('py-[3px]');
-  expect(button).toHaveClass('bg-charcoal-700');
+  expect(button).toHaveClass('bg-[var(--pd-button-danger-bg)]');
+  expect(button).toHaveClass('hover:bg-[var(--pd-button-danger-hover-bg)]');
   expect(button).toHaveClass('text-[13px]');
-  expect(button).toHaveClass('text-white');
+  expect(button).toHaveClass('text-[var(--pd-button-danger-text)]');
 });
 
 test('Check disabled/in-progress secondary button styling', async () => {
@@ -95,11 +97,11 @@ test('Check disabled/in-progress secondary button styling', async () => {
   // check for a few elements of the styling
   const button = screen.getByRole('button');
   expect(button).toBeInTheDocument();
-  expect(button).toHaveClass('border-charcoal-50');
+  expect(button).toHaveClass('border-[var(--pd-button-disabled)]');
   expect(button).toHaveClass('border-[1px]');
   expect(button).toHaveClass('px-4');
   expect(button).toHaveClass('py-[4px]');
-  expect(button).toHaveClass('bg-charcoal-50');
+  expect(button).toHaveClass('bg-[var(--pd-button-disabled)]');
   expect(button).toHaveClass('text-[13px]');
 });
 
@@ -112,10 +114,9 @@ test('Check link button styling', async () => {
   expect(button).toHaveClass('border-none');
   expect(button).toHaveClass('px-4');
   expect(button).toHaveClass('py-[5px]');
-  expect(button).toHaveClass('hover:bg-white');
-  expect(button).toHaveClass('hover:bg-opacity-10');
+  expect(button).toHaveClass('hover:bg-[var(--pd-button-link-hover-bg)]');
   expect(button).toHaveClass('text-[13px]');
-  expect(button).toHaveClass('text-purple-400');
+  expect(button).toHaveClass('text-[var(--pd-button-link-text)]');
 });
 
 test('Check disabled/in-progress link button styling', async () => {
@@ -126,7 +127,7 @@ test('Check disabled/in-progress link button styling', async () => {
   expect(button).toBeInTheDocument();
   expect(button).toHaveClass('px-4');
   expect(button).toHaveClass('py-[5px]');
-  expect(button).toHaveClass('text-charcoal-50');
+  expect(button).toHaveClass('text-[var(--pd-button-disabled-text)]');
   expect(button).toHaveClass('text-[13px]');
 });
 
@@ -137,10 +138,9 @@ test('Check tab button styling', async () => {
   const button = screen.getByRole('button');
   expect(button).toBeInTheDocument();
   expect(button).toHaveClass('border-b-[3px]');
-  expect(button).toHaveClass('border-charcoal-700');
+  expect(button).toHaveClass('border-[var(--pd-button-tab-border)]');
   expect(button).toHaveClass('pb-1');
-  expect(button).toHaveClass('text-gray-600');
-  expect(button).toHaveClass('hover:cursor-pointer');
+  expect(button).toHaveClass('text-[var(--pd-button-tab-text)]');
   expect(button).not.toHaveClass('text-[13px]');
 });
 
@@ -150,8 +150,8 @@ test('Check selected tab button styling', async () => {
   // check for a few elements of the styling
   const button = screen.getByRole('button');
   expect(button).toBeInTheDocument();
-  expect(button).toHaveClass('text-white');
-  expect(button).toHaveClass('border-purple-500');
+  expect(button).toHaveClass('text-[var(--pd-button-text)]');
+  expect(button).toHaveClass('border-[var(--pd-button-tab-border-selected)]');
 });
 
 test('Check icon button with fas prefix is visible', async () => {

--- a/packages/ui/src/lib/button/Button.spec.ts
+++ b/packages/ui/src/lib/button/Button.spec.ts
@@ -73,9 +73,9 @@ test('Check secondary button styling', async () => {
   expect(button).toHaveClass('py-[4px]');
   expect(button).toHaveClass('text-[13px]');
   expect(button).toHaveClass('text-[var(--pd-button-secondary)]');
-  expect(button).toHaveClass('hover:bg-[var(--pd-button-secondary-hover-bg)]');
+  expect(button).toHaveClass('hover:bg-[var(--pd-button-secondary-hover)]');
   expect(button).toHaveClass('hover:border-[var(--pd-button-secondary-hover)]');
-  expect(button).toHaveClass('hover:text-[var(--pd-button-secondary-hover)]');
+  expect(button).toHaveClass('hover:text-[var(--pd-button-text)]');
 });
 
 test('Check danger button styling', async () => {

--- a/packages/ui/src/lib/button/Button.svelte
+++ b/packages/ui/src/lib/button/Button.svelte
@@ -40,7 +40,7 @@ $: {
       classes = 'border-[1px] border-[var(--pd-button-disabled)] bg-[var(--pd-button-disabled)]';
     } else if (type === 'danger') {
       classes =
-        'border-2 border-[var(--pd-button-danger-border-disabled)] text-[var(--pd-button-danger-text)] bg-[var(--pd-button-danger-bg-disabled)]';
+        'border-2 border-[var(--pd-button-danger-disabled-border)] text-[var(--pd-button-danger-disabled-text)] bg-[var(--pd-button-danger-disabled-bg)]';
     } else {
       // link and tab
       classes = 'text-[var(--pd-button-disabled-text)]';
@@ -50,7 +50,7 @@ $: {
       classes = 'bg-[var(--pd-button-primary-bg)] border-none hover:bg-[var(--pd-button-primary-hover-bg)]';
     } else if (type === 'secondary') {
       classes =
-        'border-[1px] border-[var(--pd-button-secondary)] text-[var(--pd-button-secondary)] hover:border-[var(--pd-button-secondary-hover)] hover:text-[var(--pd-button-secondary-hover)]';
+        'border-[1px] border-[var(--pd-button-secondary)] text-[var(--pd-button-secondary)] hover:bg-[var(--pd-button-secondary-hover-bg)] hover:border-[var(--pd-button-secondary-hover)] hover:text-[var(--pd-button-secondary-hover)]';
     } else if (type === 'danger') {
       classes =
         'border-2 border-[var(--pd-button-danger-border)] bg-[var(--pd-button-danger-bg)] text-[var(--pd-button-danger-text)] hover:bg-[var(--pd-button-danger-hover-bg)] hover:text-[var(--pd-button-danger-hover-text)]';

--- a/packages/ui/src/lib/button/Button.svelte
+++ b/packages/ui/src/lib/button/Button.svelte
@@ -50,7 +50,7 @@ $: {
       classes = 'bg-[var(--pd-button-primary-bg)] border-none hover:bg-[var(--pd-button-primary-hover-bg)]';
     } else if (type === 'secondary') {
       classes =
-        'border-[1px] border-[var(--pd-button-secondary)] text-[var(--pd-button-secondary)] hover:bg-[var(--pd-button-secondary-hover-bg)] hover:border-[var(--pd-button-secondary-hover)] hover:text-[var(--pd-button-secondary-hover)]';
+        'border-[1px] border-[var(--pd-button-secondary)] text-[var(--pd-button-secondary)] hover:bg-[var(--pd-button-secondary-hover)] hover:border-[var(--pd-button-secondary-hover)] hover:text-[var(--pd-button-text)]';
     } else if (type === 'danger') {
       classes =
         'border-2 border-[var(--pd-button-danger-border)] bg-[var(--pd-button-danger-bg)] text-[var(--pd-button-danger-text)] hover:bg-[var(--pd-button-danger-hover-bg)] hover:text-[var(--pd-button-danger-hover-text)]';

--- a/packages/ui/src/lib/button/Button.svelte
+++ b/packages/ui/src/lib/button/Button.svelte
@@ -35,25 +35,30 @@ let classes = '';
 $: {
   if (disabled || inProgress) {
     if (type === 'primary') {
-      classes = 'bg-charcoal-50';
+      classes = 'bg-[var(--pd-button-disabled)]';
     } else if (type === 'secondary') {
-      classes = 'border-[1px] border-charcoal-50 bg-charcoal-50';
+      classes = 'border-[1px] border-[var(--pd-button-disabled)] bg-[var(--pd-button-disabled)]';
     } else if (type === 'danger') {
-      classes = 'border-2 border-gray-700 bg-charcoal-800';
+      classes =
+        'border-2 border-[var(--pd-button-danger-border-disabled)] text-[var(--pd-button-danger-text)] bg-[var(--pd-button-danger-bg-disabled)]';
     } else {
-      classes = 'text-charcoal-50 no-underline';
+      // link and tab
+      classes = 'text-[var(--pd-button-disabled-text)]';
     }
   } else {
     if (type === 'primary') {
-      classes = 'bg-purple-600 border-none hover:bg-purple-500';
+      classes = 'bg-[var(--pd-button-primary-bg)] border-none hover:bg-[var(--pd-button-primary-hover-bg)]';
     } else if (type === 'secondary') {
-      classes = 'border-[1px] border-gray-200 hover:border-purple-500 hover:text-purple-500';
+      classes =
+        'border-[1px] border-[var(--pd-button-secondary)] text-[var(--pd-button-secondary)] hover:border-[var(--pd-button-secondary-hover)] hover:text-[var(--pd-button-secondary-hover)]';
     } else if (type === 'danger') {
-      classes = 'border-2 border-red-600 bg-charcoal-700 hover:bg-charcoal-400';
+      classes =
+        'border-2 border-[var(--pd-button-danger-border)] bg-[var(--pd-button-danger-bg)] text-[var(--pd-button-danger-text)] hover:bg-[var(--pd-button-danger-hover-bg)] hover:text-[var(--pd-button-danger-hover-text)]';
     } else if (type === 'tab') {
-      classes = 'border-b-[3px] border-charcoal-700 hover:cursor-pointer text-gray-600 no-underline';
+      classes = 'border-b-[3px] border-[var(--pd-button-tab-border)] text-[var(--pd-button-tab-text)]';
     } else {
-      classes = 'border-none text-purple-400 hover:bg-white hover:bg-opacity-10';
+      // link
+      classes = 'border-none text-[var(--pd-button-link-text)] hover:bg-[var(--pd-button-link-hover-bg)]';
     }
   }
 
@@ -66,9 +71,9 @@ $: {
 <button
   type="button"
   class="relative {padding} box-border whitespace-nowrap select-none transition-all {classes} {$$props.class || ''}"
-  class:border-purple-500="{type === 'tab' && selected}"
-  class:hover:border-charcoal-100="{type === 'tab' && !selected}"
-  class:text-white="{(type === 'tab' && selected) || type === 'primary' || type === 'secondary' || type === 'danger'}"
+  class:border-[var(--pd-button-tab-border-selected)]="{type === 'tab' && selected}"
+  class:hover:border-[var(--pd-button-tab-hover-border)]="{type === 'tab' && !selected}"
+  class:text-[var(--pd-button-text)]="{(type === 'tab' && selected) || type === 'primary'}"
   title="{title}"
   aria-label="{$$props['aria-label']}"
   on:click


### PR DESCRIPTION
### What does this PR do?

Adding Button variables for light mode and initial values. I had to make a few judgement calls on what the light mode should look like, and what variables/variable names to expose - e.g. secondary buttons I went with a single color value for both border and text.

### Screenshot / video of UI

Dark:

https://github.com/containers/podman-desktop/assets/19958075/25acc513-7b08-4fa2-96d9-4b4e4975c3bb

Light:

https://github.com/containers/podman-desktop/assets/19958075/d353c56d-c6b5-4ede-a0b0-966b1c76b2d6

### What issues does this PR fix or reference?

Fixes #7183.

### How to test this PR?

Probably easiest if you drop something like this in to see all buttons/disabled at once:

```
    <Button type="primary">Primary</Button>
    <Button type="secondary">Secondary</Button>
    <Button type="danger">Danger</Button>
    <Button type="tab">Tab</Button>
    <Button type="link">Link</Button>
    <Button type="primary" disabled>Primary</Button>
    <Button type="secondary" disabled>Secondary</Button>
    <Button type="danger" disabled>Danger</Button>
    <Button type="tab" disabled>Tab</Button>
    <Button type="link" disabled>Link</Button>
```

- [x] Tests are covering the bug fix or the new feature