### PR TITLE
chore: remove duplicate/old modal styling

### DIFF
--- a/packages/renderer/src/lib/container/ContainerList.svelte
+++ b/packages/renderer/src/lib/container/ContainerList.svelte
@@ -690,7 +690,7 @@ function setStoppedFilter() {
     }}">
     <div
       role="presentation"
-      class="inline-block w-full overflow-hidden text-left transition-all transform bg-charcoal-600 z-50 rounded-xl shadow-xl shadow-charcoal-900"
+      class="inline-block w-full overflow-hidden text-left transition-all"
       on:keydown="{keydownChoice}">
       <div class="flex items-center justify-between bg-black px-5 py-4 border-b-2 border-violet-700">
         <h1 class="text-xl font-bold">Create a new container</h1>
@@ -699,7 +699,7 @@ function setStoppedFilter() {
           <i class="fas fa-times" aria-hidden="true"></i>
         </button>
       </div>
-      <div class="bg-charcoal-600 p-5 h-full flex flex-col justify-items-center">
+      <div class="p-5 h-full flex flex-col justify-items-center">
         <span class="pb-3">Choose the following:</span>
         <ul class="list-disc ml-8 space-y-2">
           <li>Create a container from a Containerfile</li>

--- a/packages/renderer/src/lib/dialogs/QuickPickInput.svelte
+++ b/packages/renderer/src/lib/dialogs/QuickPickInput.svelte
@@ -293,9 +293,7 @@ function handleMousedown(e: MouseEvent) {
     <div class="flex justify-center items-center mt-1">
       <div
         bind:this="{outerDiv}"
-        class="bg-charcoal-800 w-[700px] {mode === 'InputBox'
-          ? 'h-fit'
-          : ''} shadow-sm p-2 rounded shadow-zinc-700 text-sm">
+        class="w-[700px] {mode === 'InputBox' ? 'h-fit' : ''} shadow-sm p-2 rounded shadow-zinc-700 text-sm">
         {#if title}
           <div
             aria-label="title"

--- a/packages/renderer/src/lib/extensions/InstallManuallyExtensionModal.svelte
+++ b/packages/renderer/src/lib/extensions/InstallManuallyExtensionModal.svelte
@@ -94,7 +94,7 @@ function handleKeydown(e: KeyboardEvent) {
   on:close="{() => {
     closeCallback();
   }}">
-  <div class="modal flex flex-col place-self-center bg-charcoal-800 shadow-xl shadow-black">
+  <div class="modal flex flex-col place-self-center">
     <div class="flex items-center justify-between px-6 py-5 space-x-2">
       <h1 class="grow text-lg font-bold capitalize">Install custom extension</h1>
 

--- a/packages/renderer/src/lib/feedback/SendFeedback.svelte
+++ b/packages/renderer/src/lib/feedback/SendFeedback.svelte
@@ -58,8 +58,7 @@ async function sendFeedback(): Promise<void> {
 
 {#if displayModal}
   <Modal on:close="{() => hideModal()}">
-    <div
-      class="inline-block w-full overflow-hidden text-left transition-all transform bg-charcoal-600 z-50 rounded-xl shadow-xl shadow-charcoal-900">
+    <div class="inline-block w-full overflow-hidden text-left transition-all">
       <div class="flex items-center justify-between bg-black px-5 py-4 border-b-2 border-violet-700">
         <h1 class="text-xl font-bold">Share your feedback</h1>
 

--- a/packages/renderer/src/lib/image/RenameImageModal.svelte
+++ b/packages/renderer/src/lib/image/RenameImageModal.svelte
@@ -67,7 +67,7 @@ async function renameImage(imageName: string, imageTag: string) {
   on:close="{() => {
     closeCallback();
   }}">
-  <div class="modal flex flex-col place-self-center bg-charcoal-800 shadow-xl shadow-black">
+  <div class="modal flex flex-col place-self-center">
     <div class="flex items-center justify-between px-6 py-5 space-x-2">
       <h1 class="grow text-lg font-bold capitalize">Edit Image</h1>
 


### PR DESCRIPTION
### What does this PR do?

When trying to test #7246 I noticed that there are several uses of Modal that override the background color of Modal or try to add their own shadow or other styling as per very old prior designs. This just removes this extraneous styling so that these dialogs use what is in Modal (including light mode) and remaining work can focus on what actually needs to change within the dialogs.

Should be more consistent or no change to existing modals, just clears out unnecessary/duplicate code. IMHO SendFeedback is the only issue here since two custom fields were being set to the (now) background color, not sure if I should temporarily set them to another color or skip this for now.

Will need #7303 to see the rename image modal.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Part of #7184.

### How to test this PR?

Open up these modal dialogs to check for visual regression.