### PR TITLE
docs: adds api reference to sidebar & detailed index

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -16,6 +16,25 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+/**
+ * The Podman Desktop API provides a way to interact with Podman Desktop.
+ *
+ * This file `extension-api.d.ts` is automatically generated from typedoc comments
+ * in the source code and provided [on our website](https://podman-desktop.io/api).
+ *
+ * For more information, see the main
+ * [Podman Desktop developing extensions documentation](https://podman-desktop.io/docs/extensions/developing).
+ *
+ * @example
+ * ```typescript
+ * import * as api from '@podman-desktop/api';
+ *
+ * console.log(api.version);
+ * ```
+ *
+ * @module @podman-desktop/api
+ **/
+
 declare module '@podman-desktop/api' {
   /**
    * The version of Podman Desktop.

--- a/website/docs/extensions/api/index.md
+++ b/website/docs/extensions/api/index.md
@@ -1,0 +1,9 @@
+---
+sidebar_position: 3
+title: API Reference
+description: API Reference
+tags: [podman-desktop, extension, api]
+keywords: [podman desktop, extension, api]
+---
+
+The API reference is located [here](https://podman-desktop.io/api).

--- a/website/docs/extensions/api/index.md
+++ b/website/docs/extensions/api/index.md
@@ -6,4 +6,4 @@ tags: [podman-desktop, extension, api]
 keywords: [podman desktop, extension, api]
 ---
 
-The API reference is located [here](https://podman-desktop.io/api).
+The API reference is located [here](/api).

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -42,6 +42,10 @@ const config = {
       {
         redirects: [
           {
+            to: '/api',
+            from: '/docs/extensions/api',
+          },
+          {
             to: '/downloads/windows',
             from: '/downloads/Windows',
           },


### PR DESCRIPTION
docs: adds api reference to sidebar & detailed index

### What does this PR do?

* Updates the sidebar to include the API reference
* Adds redirect, since docusaurus does not support native manually
  adding a link to the sidebar with the autogenerated functionality
* Updates the extension file so that it will generate descriptive
  information for the index page.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

![Screenshot 2024-05-27 at 7 03 28 PM](https://github.com/containers/podman-desktop/assets/6422176/e81da701-6ea8-4243-b506-79d99c14b93f)


### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop/issues/5782

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

Test by viewing netlify. It will only work on there since the redirect
plugin does not work locally.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
