### PR TITLE
chore: fix name spacing in kubernetes dashboards

### DIFF
--- a/packages/renderer/src/lib/deployments/DeploymentsList.svelte
+++ b/packages/renderer/src/lib/deployments/DeploymentsList.svelte
@@ -79,7 +79,6 @@ let statusColumn = new TableColumn<DeploymentUI>('Status', {
 });
 
 let nameColumn = new TableColumn<DeploymentUI>('Name', {
-  width: '2fr',
   renderer: DeploymentColumnName,
   comparator: (a, b) => a.name.localeCompare(b.name),
 });

--- a/packages/renderer/src/lib/ingresses-routes/IngressesRoutesList.svelte
+++ b/packages/renderer/src/lib/ingresses-routes/IngressesRoutesList.svelte
@@ -107,7 +107,6 @@ let statusColumn = new TableColumn<IngressUI>('Status', {
 });
 
 let nameColumn = new TableColumn<IngressUI | RouteUI>('Name', {
-  width: '2fr',
   renderer: IngressRouteColumnName,
   comparator: (a, b) => a.name.localeCompare(b.name),
 });

--- a/packages/renderer/src/lib/service/ServicesList.svelte
+++ b/packages/renderer/src/lib/service/ServicesList.svelte
@@ -75,7 +75,6 @@ let statusColumn = new TableColumn<ServiceUI>('Status', {
 });
 
 let nameColumn = new TableColumn<ServiceUI>('Name', {
-  width: '1fr',
   renderer: ServiceColumnName,
   comparator: (a, b) => a.name.localeCompare(b.name),
 });


### PR DESCRIPTION
chore: fix name spacing in kubernetes dashboards

### What does this PR do?

The dashboard for ingress with a lot of information is "squished" and
hard to read.

This PR changes the default width of ingress/route table as well as
deployments to "1fr" which matches the current
Services list formatting.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

New changes show the name column a lot more closer to the next column:

![Screenshot 2024-05-27 at 7 53 08 PM](https://github.com/containers/podman-desktop/assets/6422176/5d9051ca-0ad3-4e97-aac1-37e0da39f5a0)




### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop/issues/7320

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

Visual change, no test really required TBH, check `yarn watch` and view
the tables for changes.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
