### PR TITLE
chore(tests): uses exact locators in images page

### DIFF
--- a/tests/playwright/src/model/pages/images-page.ts
+++ b/tests/playwright/src/model/pages/images-page.ts
@@ -35,10 +35,10 @@ export class ImagesPage extends MainPage {
 
   constructor(page: Page) {
     super(page, 'images');
-    this.pullImageButton = this.additionalActions.getByRole('button', { name: 'Pull' });
-    this.pruneImagesButton = this.additionalActions.getByRole('button', { name: 'Prune' });
-    this.buildImageButton = this.additionalActions.getByRole('button', { name: 'Build' });
-    this.pruneConfirmationButton = this.page.getByRole('button', { name: 'Yes' });
+    this.pullImageButton = this.additionalActions.getByRole('button', { name: 'Pull', exact: true });
+    this.pruneImagesButton = this.additionalActions.getByRole('button', { name: 'Prune', exact: true });
+    this.buildImageButton = this.additionalActions.getByRole('button', { name: 'Build', exact: true });
+    this.pruneConfirmationButton = this.page.getByRole('button', { name: 'Yes', exact: true });
   }
 
   async openPullImage(): Promise<PullImagePage> {


### PR DESCRIPTION
### What does this PR do?
Ensures that locators are searched for strictly on images page.

### What issues does this PR fix or reference?
https://github.com/containers/podman-desktop-extension-bootc/issues/502
