### PR TITLE
chore: add test watching renderer and main

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,8 @@
     "test:ui": "vitest run -r packages/ui --passWithNoTests --coverage",
     "test:tools": "vitest run tools --passWithNoTests --coverage",
     "test:watch": "vitest watch",
+    "test:watch:renderer": "npm run build:ui && vitest -c packages/renderer/vite.config.js watch packages/renderer --passWithNoTests",
+    "test:watch:main": "vitest watch -r packages/main --passWithNoTests",
     "watch": "node scripts/watch.mjs",
     "format:check": "prettier --cache --check \"{extensions,packages,tests,types,tools,website-argos}/**/*.{ts,svelte}\" \"extensions/*/scripts/*.{ts,js}\" \"website/**/*.{md,js}\" \"website/src/**/*.{css,tsx}\"",
     "format:fix": "prettier --cache --write \"{extensions,packages,tests,types,tools,website-argos}/**/*.{ts,svelte}\" \"extensions/*/scripts/*.{ts,js}\" \"website/**/*.{md,js}\" \"website/src/**/*.{css,tsx}\"",


### PR DESCRIPTION
chore: add test watching renderer and main

### What does this PR do?

When you run `yarn test:watch` it also runs e2e tests..

I would like to JUST run renderer or main if I am working only in that
section.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/A

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

N/A

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

Run the commands and see that it only watches the renderer directory,
etc.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
