### PR TITLE
chore: activate each extension sequentially

### DIFF
--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -471,7 +471,10 @@ export class ExtensionLoader {
     const sortedExtensions = this.sortExtensionsByDependencies(analyzedExtensions);
 
     // now, load all extensions
-    await Promise.all(sortedExtensions.map(extension => this.loadExtension(extension)));
+
+    for (const extension of sortedExtensions) {
+      await this.loadExtension(extension);
+    }
   }
 
   // do we have circular dependencies?


### PR DESCRIPTION
### What does this PR do?
Activate each extension one after the other

@axel7083 seems to had better result using sequential calls


### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

it targets https://github.com/containers/podman-desktop/issues/7030

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
