### PR TITLE
chore: add default sorting for name services

### DIFF
--- a/packages/renderer/src/lib/service/ServicesList.svelte
+++ b/packages/renderer/src/lib/service/ServicesList.svelte
@@ -150,6 +150,7 @@ const row = new TableRow<ServiceUI>({ selectable: _service => true });
       data="{services}"
       columns="{columns}"
       row="{row}"
+      defaultSortColumn="Name"
       on:update="{() => (services = services)}">
     </Table>
 


### PR DESCRIPTION
chore: add default sorting for name services

### What does this PR do?

Sort the column by default.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->
![Screenshot 2024-05-28 at 10 11 44 AM](https://github.com/containers/podman-desktop/assets/6422176/75eb1ca6-878b-4fb8-bad9-7468928e05c0)



### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop/issues/7333

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

Small change, but if you go on Services, it will be sorted now.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
