### PR TITLE
chore: increase spacing for host/path and backend

### DIFF
--- a/packages/renderer/src/lib/ingresses-routes/IngressesRoutesList.svelte
+++ b/packages/renderer/src/lib/ingresses-routes/IngressesRoutesList.svelte
@@ -118,6 +118,7 @@ let namespaceColumn = new TableColumn<IngressUI | RouteUI, string>('Namespace', 
 });
 
 let pathColumn = new TableColumn<IngressUI | RouteUI, string>('Host/Path', {
+  width: '1.5fr',
   renderer: IngressRouteColumnHostPath,
   comparator: (a, b) => compareHostPath(a, b),
 });
@@ -129,6 +130,7 @@ function compareHostPath(object1: IngressUI | RouteUI, object2: IngressUI | Rout
 }
 
 let backendColumn = new TableColumn<IngressUI | RouteUI, string>('Backend', {
+  width: '1.5fr',
   renderer: IngressRouteColumnBackend,
   comparator: (a, b) => compareBackend(a, b),
 });


### PR DESCRIPTION
chore: increase spacing for host/path and backend

### What does this PR do?

Increases the width spacing for host/path and backend so it can
accomodate the URL as well as the backend path better.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

Before:
![Screenshot 2024-05-28 at 11 00 36 AM](https://github.com/containers/podman-desktop/assets/6422176/347ae28f-eba9-4b50-9b3e-e8cb41a08677)

After:

![Screenshot 2024-05-28 at 11 01 20 AM](https://github.com/containers/podman-desktop/assets/6422176/e5351dfc-ea04-42b8-aef9-cc4193a91a39)




### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Follow up from: https://github.com/containers/podman-desktop/pull/7319#pullrequestreview-2082781055

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

N/A, small UI change.

View the ingress page.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
