### PR TITLE
fix: container start error is not reported

### DIFF
--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -2533,6 +2533,47 @@ describe('createContainer', () => {
     expect(createContainerMock).toHaveBeenCalled();
     expect(startMock).not.toHaveBeenCalled();
   });
+
+  test('test error reported if start fails', async () => {
+    const createdId = '1234';
+
+    const startMock = vi.fn().mockRejectedValue(new Error('start failed'));
+    const inspectMock = vi.fn();
+    const createContainerMock = vi
+      .fn()
+      .mockResolvedValue({ id: createdId, start: startMock, inspect: inspectMock } as unknown as Dockerode.Container);
+
+    inspectMock.mockResolvedValue({
+      Config: {
+        Tty: false,
+        OpenStdin: false,
+      },
+    });
+
+    const fakeDockerode = {
+      createContainer: createContainerMock,
+    } as unknown as Dockerode;
+
+    containerRegistry.addInternalProvider('podman1', {
+      name: 'podman1',
+      id: 'podman1',
+      connection: {
+        type: 'podman',
+      },
+      api: fakeDockerode,
+    } as InternalContainerProvider);
+
+    let error: unknown | undefined;
+    try {
+      await containerRegistry.createContainer('podman1', { start: true });
+    } catch (err) {
+      error = err;
+    }
+
+    expect(error).toBeDefined();
+    expect(createContainerMock).toHaveBeenCalled();
+    expect(startMock).toHaveBeenCalled();
+  });
 });
 
 describe('attach container', () => {

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -1878,11 +1878,9 @@ export class ContainerProviderRegistry {
       }
 
       const engine = this.internalProviders.get(engineId);
-      if (engine) {
+      if (engine && (options.start === true || options.start === undefined)) {
+        await container.start();
         await this.attachToContainer(engine, container, options.Tty, options.OpenStdin);
-        if (options.start === true || options.start === undefined) {
-          await container.start();
-        }
       }
       return { id: container.id };
     } catch (error) {


### PR DESCRIPTION
Fixes #6981

### What does this PR do?

Report error if container start errored

### Screenshot / video of UI

![start-container-error](https://github.com/containers/podman-desktop/assets/695993/d4dc986e-206a-45cf-8d31-b2e8a1d9c9f3)


### What issues does this PR fix or reference?

#6981 

### How to test this PR?

1. Create a dummy image (FROM scratch)
2. Start this image

- [x] Tests are covering the bug fix or the new feature
