### PR TITLE
chore(tests): wait for image to be unused before delete

### DIFF
--- a/tests/playwright/src/specs/yaml-smoke.spec.ts
+++ b/tests/playwright/src/specs/yaml-smoke.spec.ts
@@ -90,6 +90,12 @@ describe.skipIf(process.env.GITHUB_ACTIONS && process.env.RUNNER_OS === 'Linux')
 
       await playExpect.poll(async () => await imagesPage.waitForImageExists(backendImage)).toBeTruthy();
       await playExpect.poll(async () => await imagesPage.waitForImageExists(frontendImage)).toBeTruthy();
+      await playExpect
+        .poll(async () => await imagesPage.getCurrentStatusOfImage(backendImage), { timeout: 15000 })
+        .toBe('UNUSED');
+      await playExpect
+        .poll(async () => await imagesPage.getCurrentStatusOfImage(frontendImage), { timeout: 15000 })
+        .toBe('UNUSED');
 
       let imageDetailsPage = await imagesPage.openImageDetails(backendImage);
       await playExpect(imageDetailsPage.heading).toContainText(backendImage);


### PR DESCRIPTION
### What does this PR do?
Fixes test flakyness by waiting for the image to be in unused state.

### What issues does this PR fix or reference?
https://github.com/containers/podman-desktop/issues/7364

