### PR TITLE
chore: remove GH cache on windows for PR checks

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -37,18 +37,6 @@ jobs:
         with:
           python-version: "3.x"
 
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "dir=$(yarn cache dir)" >> ${env:GITHUB_OUTPUT}
-
-      - uses: actions/cache@v4
-        id: yarn-cache
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-
       - name: yarn
         run: |
           yarn --frozen-lockfile --network-timeout 180000
@@ -200,24 +188,10 @@ jobs:
           node-version: 20
 
 
-      - name: Get yarn cache directory path (Windows)
-        if: ${{ matrix.os=='windows-2022' }}
-        id: yarn-cache-dir-path-windows
-        run: echo "dir=$(yarn cache dir)" >> ${env:GITHUB_OUTPUT}
-
       - name: Get yarn cache directory path (mac/Linux)
         if: ${{ matrix.os=='ubuntu-22.04'}}
         id: yarn-cache-dir-path-unix
         run: echo "dir=$(yarn cache dir)" >> ${GITHUB_OUTPUT}
-
-      - uses: actions/cache@v4
-        if: ${{ matrix.os=='windows-2022' }}
-        id: yarn-cache-windows
-        with:
-          path: ${{ steps.yarn-cache-dir-path-windows.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
 
       - uses: actions/cache@v4
         if: ${{ matrix.os=='ubuntu-22.04'}}


### PR DESCRIPTION
### What does this PR do?
It seems it is spending 30mn to restore the cache so give a try without the cache to see if downloading is faster

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

PR checks on Windows are slow

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
