### PR TITLE
feat: allow extensions to expose their own API

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -171,6 +171,82 @@ declare module '@podman-desktop/api' {
   }
 
   /**
+   * Represents an extension.
+   *
+   * To get an instance of an `Extension` use {@link extensions.getExtension getExtension}.
+   */
+  export interface Extension<T> {
+    /**
+     * The canonical extension identifier in the form of: `publisher.name`.
+     */
+    readonly id: string;
+
+    /**
+     * The uri of the directory containing the extension.
+     */
+    readonly extensionUri: Uri;
+
+    /**
+     * The absolute file path of the directory containing this extension. Shorthand
+     * notation for {@link Extension.extensionUri Extension.extensionUri.fsPath} (independent of the uri scheme).
+     */
+    readonly extensionPath: string;
+
+    /**
+     * The parsed contents of the extension's package.json.
+     */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    readonly packageJSON: any;
+
+    /**
+     * The public API exported by this extension (return value of `activate`).
+     * It is an invalid action to access this field before this extension has been activated.
+     */
+    readonly exports: T;
+  }
+
+  /**
+   * Namespace for dealing with installed extensions. Extensions are represented
+   * by an {@link Extension}-interface which enables reflection on them.
+   *
+   * Extension writers can provide APIs to other extensions by returning their API public
+   * surface from the `activate`-call.
+   *
+   * When depending on the API of another extension add an `extensionDependencies`-entry
+   * to `package.json`, and use the {@link extensions.getExtension getExtension}-function
+   * and the {@link Extension.exports exports}-property, like below:
+   *
+   * ```typescript
+   * const podmanExtension = extensions.getExtension('podman-desktop.podman');
+   * const podmanExtensionAPI = podmanExtension.exports;
+   *
+   * podmanExtensionAPI....
+   * ```
+   */
+  export namespace extensions {
+    /**
+     * Get an extension by its full identifier in the form of: `publisher.name`.
+     *
+     * @param extensionId An extension identifier.
+     * @returns An extension or `undefined`.
+     */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    export function getExtension<T = any>(extensionId: string): Extension<T> | undefined;
+
+    /**
+     * All extensions currently known to the system.
+     */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    export const all: readonly Extension<any>[];
+
+    /**
+     * An event which fires when `extensions.all` changes. This can happen when extensions are
+     * installed, uninstalled, enabled or disabled.
+     */
+    export const onDidChange: Event<void>;
+  }
+
+  /**
    * A provider result represents the values a provider, like the {@linkcode ImageCheckerProvider},
    * may return. For once this is the actual result type `T`, like `ImageChecks`, or a Promise that resolves
    * to that type `T`. In addition, `null` and `undefined` can be returned - either directly or from a

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -1522,7 +1522,6 @@ export class ExtensionLoader {
       this.apiSender.send('extension-started');
     } catch (err) {
       console.log(`Activating extension ${extension.id} failed error:${err}`);
-      this._onDidChange.fire();
 
       // dispose resources
       for (const subscription of extensionContext.subscriptions) {

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -46,6 +46,7 @@ import type { Context } from './context/context.js';
 import type { CustomPickRegistry } from './custompick/custompick-registry.js';
 import type { DialogRegistry } from './dialog-registry.js';
 import type { Directories } from './directories.js';
+import type { Event } from './events/emitter.js';
 import { Emitter } from './events/emitter.js';
 import { DEFAULT_TIMEOUT, ExtensionLoaderSettings } from './extension-loader-settings.js';
 import type { FilesystemMonitoring } from './filesystem-monitoring.js';
@@ -117,7 +118,10 @@ export interface ActivatedExtension {
   id: string;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   deactivateFunction: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  exports: any;
   extensionContext: containerDesktopAPI.ExtensionContext;
+  packageJSON: unknown;
 }
 
 const EXTENSION_OPTION = '--extension-folder';
@@ -139,6 +143,9 @@ export class ExtensionLoader {
   protected extensionStateErrors = new Map<string, unknown>();
 
   protected watchTimeout = 1000;
+
+  private readonly _onDidChange = new Emitter<void>();
+  readonly onDidChange: Event<void> = this._onDidChange.event;
 
   // Plugins directory location
   private pluginsDirectory;
@@ -218,6 +225,35 @@ export class ExtensionLoader {
     }));
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  transformActivatedExtensionToExposedExtension<T = any>(
+    activatedExtension: ActivatedExtension,
+  ): containerDesktopAPI.Extension<T> {
+    return {
+      id: activatedExtension.id,
+      exports: activatedExtension.exports,
+      extensionUri: activatedExtension.extensionContext.extensionUri,
+      extensionPath: activatedExtension.extensionContext.extensionUri.fsPath,
+      packageJSON: activatedExtension.packageJSON,
+    };
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  getExposedExtension<T = any>(extensionId: string): containerDesktopAPI.Extension<T> | undefined {
+    // do we have a matching extension?
+    const activatedExtension = this.activatedExtensions.get(extensionId);
+    if (activatedExtension) {
+      return this.transformActivatedExtensionToExposedExtension(activatedExtension);
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  getAllExposedExtensions(): containerDesktopAPI.Extension<any>[] {
+    return Array.from(this.activatedExtensions.values()).map(activatedExtension =>
+      this.transformActivatedExtensionToExposedExtension(activatedExtension),
+    );
+  }
+
   async loadPackagedFile(filePath: string): Promise<void> {
     // need to unpack the file before load it
     const filename = path.basename(filePath);
@@ -233,6 +269,7 @@ export class ExtensionLoader {
     if (!extension.error) {
       await this.loadExtension(extension);
       this.apiSender.send('extension-started', {});
+      this._onDidChange.fire();
     }
   }
 
@@ -1152,6 +1189,19 @@ export class ExtensionLoader {
       },
     };
 
+    const extensions: typeof containerDesktopAPI.extensions = {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      getExtension<T = any>(extensionId: string): containerDesktopAPI.Extension<T> | undefined {
+        return instance.getExposedExtension(extensionId);
+      },
+      get all() {
+        return instance.getAllExposedExtensions();
+      },
+      onDidChange: (listener, thisArg, disposables) => {
+        return instance.onDidChange(listener, thisArg, disposables);
+      },
+    };
+
     const telemetry = this.telemetry;
     const env: typeof containerDesktopAPI.env = {
       get isMac() {
@@ -1303,6 +1353,7 @@ export class ExtensionLoader {
       env,
       process,
       registry,
+      extensions,
       provider,
       fs,
       configuration,
@@ -1424,6 +1475,7 @@ export class ExtensionLoader {
       extensionId: extension.id,
       extensionVersion: extension.manifest?.version,
     };
+    let exports: unknown;
     try {
       if (typeof extensionMain?.['activate'] === 'function') {
         // maximum time to wait for the extension to activate by reading from configuration
@@ -1447,7 +1499,7 @@ export class ExtensionLoader {
         const activatePromise = extensionMain['activate'].apply(undefined, [extensionContext]);
 
         // if extension reach the timeout, do not wait for it to finish and flag as error
-        await Promise.race([activatePromise, timeoutPromise]);
+        exports = await Promise.race([activatePromise, timeoutPromise]);
         const afterActivateTime = performance.now();
 
         // Computing activation duration
@@ -1457,16 +1509,20 @@ export class ExtensionLoader {
         console.log(`Activating extension (${extension.id}) ended in ${Math.round(duration)} milliseconds`);
       }
       const id = extension.id;
+      const packageJSON = extension.manifest;
       const activatedExtension: ActivatedExtension = {
         id,
+        packageJSON,
         deactivateFunction,
         extensionContext,
+        exports,
       };
       this.activatedExtensions.set(extension.id, activatedExtension);
       this.extensionState.set(extension.id, 'started');
       this.apiSender.send('extension-started');
     } catch (err) {
       console.log(`Activating extension ${extension.id} failed error:${err}`);
+      this._onDidChange.fire();
 
       // dispose resources
       for (const subscription of extensionContext.subscriptions) {
@@ -1527,6 +1583,7 @@ export class ExtensionLoader {
     this.activatedExtensions.delete(extensionId);
     this.extensionState.set(extension.id, 'stopped');
     this.apiSender.send('extension-stopped');
+    this._onDidChange.fire();
     this.telemetry.track('deactivateExtension', telemetryOptions);
   }
 
@@ -1581,6 +1638,7 @@ export class ExtensionLoader {
       }
       this.analyzedExtensions.delete(extensionId);
       this.apiSender.send('extension-removed');
+      this._onDidChange.fire();
     }
   }
 


### PR DESCRIPTION
### What does this PR do?
allow extensions to expose their own API
and other 3rd party extensions can use these endpoints/API

it also offers a way to list all Podman Desktop extensions


### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->


### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/5990

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
