### PR TITLE
chore: add icons for progressing on k8s deployments

### DIFF
--- a/packages/renderer/src/lib/deployments/DeploymentColumnConditions.spec.ts
+++ b/packages/renderer/src/lib/deployments/DeploymentColumnConditions.spec.ts
@@ -47,7 +47,7 @@ test('Expect column styling available', async () => {
 
   const dot = text.parentElement?.children[0].children[0];
   expect(dot).toBeInTheDocument();
-  expect(dot).toHaveClass('bg-green-600');
+  expect(dot).toHaveClass('text-green-600');
 });
 
 test('Expect column styling failure', async () => {
@@ -59,7 +59,7 @@ test('Expect column styling failure', async () => {
 
   const dot = text.parentElement?.children[0].children[0];
   expect(dot).toBeInTheDocument();
-  expect(dot).toHaveClass('bg-amber-600');
+  expect(dot).toHaveClass('text-amber-600');
 });
 
 test('Expect column styling progressing', async () => {
@@ -71,5 +71,5 @@ test('Expect column styling progressing', async () => {
 
   const dot = text.parentElement?.children[0].children[0];
   expect(dot).toBeInTheDocument();
-  expect(dot).toHaveClass('bg-sky-400');
+  expect(dot).toHaveClass('text-sky-400');
 });

--- a/packages/renderer/src/lib/deployments/DeploymentColumnConditions.svelte
+++ b/packages/renderer/src/lib/deployments/DeploymentColumnConditions.svelte
@@ -1,25 +1,27 @@
 <script lang="ts">
+import { faCheckCircle, faExclamationTriangle, faQuestionCircle, faSync } from '@fortawesome/free-solid-svg-icons';
 import { Tooltip } from '@podman-desktop/ui-svelte';
+import Fa from 'svelte-fa';
 
 import type { DeploymentUI } from './DeploymentUI';
 
 export let object: DeploymentUI;
 
-// Each condition has a colour associated to it within tailwind, this is a map of those colours.
-// bg-green-600 = Available
-// bg-sky-400 = Progressing
-// bg-amber-600 = ReplicaFailure
-// bg-gray-900 = unknown
-function getConditionColour(type: string): string {
+// Determine both the icon and color based on the deployment condition
+function getConditionAttributes(type: string) {
   switch (type) {
     case 'Available':
-      return 'bg-green-600';
+      // faCheckCircle: Indicates a successful state, typically used to denote availability and operational readiness
+      return { color: 'text-green-600', icon: faCheckCircle };
     case 'Progressing':
-      return 'bg-sky-400';
+      // faSync: Often used to represent ongoing processes or operations, fitting for a "Progressing" state
+      return { color: 'text-sky-400', icon: faSync };
     case 'ReplicaFailure':
-      return 'bg-amber-600';
+      // faExclamationTriangle: Alerts and warnings
+      return { color: 'text-amber-600', icon: faExclamationTriangle };
     default:
-      return 'bg-gray-900';
+      // faQuestionCircle: Uncertain / unknown
+      return { color: 'text-gray-900', icon: faQuestionCircle };
   }
 }
 </script>
@@ -29,7 +31,10 @@ function getConditionColour(type: string): string {
     <Tooltip bottom>
       <svelte:fragment slot="content">
         <div class="flex flex-row bg-charcoal-500 items-center p-1 rounded-md text-xs text-gray-500">
-          <div class="w-2 h-2 {getConditionColour(condition.type)} rounded-full mr-1"></div>
+          <Fa
+            size="1x"
+            icon="{getConditionAttributes(condition.type).icon}"
+            class="{getConditionAttributes(condition.type).color} mr-1" />
           {condition.type}
         </div>
       </svelte:fragment>


### PR DESCRIPTION
chore: add icons for progressing on k8s deployments

### What does this PR do?

Adds little icons for progressing for k8s deployments to improve it the
UI instead of using dots.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

![Screenshot 2024-05-30 at 3 05 37 PM](https://github.com/containers/podman-desktop/assets/6422176/5cbebf07-fdcc-4e69-8366-42f3ec8038bd)



### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

See https://github.com/containers/podman-desktop/issues/7386

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature

Also view UI

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
