### PR TITLE
chore: add icons for service k8s type

### DIFF
--- a/packages/renderer/src/lib/service/ServiceColumnType.spec.ts
+++ b/packages/renderer/src/lib/service/ServiceColumnType.spec.ts
@@ -43,7 +43,7 @@ test('Expect basic column styling', async () => {
 
   const dot = text.parentElement?.children[0].children[0];
   expect(dot).toBeInTheDocument();
-  expect(dot).toHaveClass('bg-gray-600');
+  expect(dot).toHaveClass('text-gray-600');
 });
 
 test('Expect column styling ClusterIP', async () => {
@@ -56,7 +56,7 @@ test('Expect column styling ClusterIP', async () => {
 
   const dot = text.parentElement?.children[0].children[0];
   expect(dot).toBeInTheDocument();
-  expect(dot).toHaveClass('bg-sky-500');
+  expect(dot).toHaveClass('text-sky-500');
 });
 
 test('Expect column styling LoadBalancer', async () => {
@@ -69,7 +69,7 @@ test('Expect column styling LoadBalancer', async () => {
 
   const dot = text.parentElement?.children[0].children[0];
   expect(dot).toBeInTheDocument();
-  expect(dot).toHaveClass('bg-purple-500');
+  expect(dot).toHaveClass('text-purple-500');
 });
 
 test('Expect column styling NodePort', async () => {
@@ -82,5 +82,5 @@ test('Expect column styling NodePort', async () => {
 
   const dot = text.parentElement?.children[0].children[0];
   expect(dot).toBeInTheDocument();
-  expect(dot).toHaveClass('bg-fuschia-600');
+  expect(dot).toHaveClass('text-fuschia-600');
 });

--- a/packages/renderer/src/lib/service/ServiceColumnType.svelte
+++ b/packages/renderer/src/lib/service/ServiceColumnType.svelte
@@ -1,28 +1,31 @@
 <script lang="ts">
+import { faBalanceScale, faNetworkWired, faPlug, faQuestionCircle } from '@fortawesome/free-solid-svg-icons';
+import { Fa } from 'svelte-fa';
+
 import type { ServiceUI } from './ServiceUI';
 
 export let object: ServiceUI;
 
-// Each type has a colour associated to it within tailwind, this is a map of those colours.
-// bg-sky-500 = ClusterIP
-// bg-purple-500 = LoadBalancer
-// bg-fuschia-600 = NodePort
-// bg-gray-900 = unknown
-function getTypeColour(type: string): string {
+// Determine both the icon and color based on the service type
+function getTypeAttributes(type: string) {
   switch (type) {
     case 'ClusterIP':
-      return 'bg-sky-500';
+      // faNetworkWired: Represents internal network connections, suitable for ClusterIP
+      return { color: 'text-sky-500', icon: faNetworkWired };
     case 'LoadBalancer':
-      return 'bg-purple-500';
+      // faBalanceScale: Symbolizes distribution, fitting for LoadBalancer that distributes traffic
+      return { color: 'text-purple-500', icon: faBalanceScale };
     case 'NodePort':
-      return 'bg-fuschia-600';
+      // faPlug: Indicates a connection point, appropriate for NodePort which exposes services on each Node's IP
+      return { color: 'text-fuschia-600', icon: faPlug };
     default:
-      return 'bg-gray-600';
+      // faQuestionCircle: Used for unknown or unspecified types
+      return { color: 'text-gray-600', icon: faQuestionCircle };
   }
 }
 </script>
 
 <div class="flex flex-row bg-charcoal-500 items-center p-1 rounded-md text-xs text-gray-500">
-  <div class="w-2 h-2 {getTypeColour(object.type)} rounded-full mr-1"></div>
+  <Fa size="1x" icon="{getTypeAttributes(object.type).icon}" class="{getTypeAttributes(object.type).color} mr-1" />
   {object.type}
 </div>


### PR DESCRIPTION
chore: add icons for service k8s type

### What does this PR do?

Adds small icons rather than dots to better represent the type.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

![Screenshot 2024-05-30 at 3 15 11 PM](https://github.com/containers/podman-desktop/assets/6422176/52c47ab0-f1d7-4521-838b-f86e6e8cc103)


### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Part of https://github.com/containers/podman-desktop/issues/7386

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
