### PR TITLE
chore: add icon to url for k8s ingress / routes

### DIFF
--- a/packages/renderer/src/lib/ingresses-routes/IngressRouteColumnHostPath.spec.ts
+++ b/packages/renderer/src/lib/ingresses-routes/IngressRouteColumnHostPath.spec.ts
@@ -63,7 +63,7 @@ test('Expect simple column styling with single host/path ingress', async () => {
   const hostPath = ingressRouteUtils.getHostPaths(ingressUI)[0];
   const link = screen.getByLabelText(hostPath.label);
   expect(link).toBeInTheDocument();
-  expect(link.textContent).toBe(hostPath.label);
+  expect(link.textContent).toContain(hostPath.label);
 });
 
 test('Expect simple column styling with multiple paths ingress', async () => {
@@ -105,12 +105,11 @@ test('Expect simple column styling with multiple paths ingress', async () => {
   render(IngressRouteColumnHostPath, { object: ingressUI });
 
   const hostPaths = ingressRouteUtils.getHostPaths(ingressUI);
-  const firstLink = screen.getByRole('link', { name: hostPaths[0].label });
-  expect(firstLink).toBeInTheDocument();
-  expect(firstLink.textContent).toEqual(hostPaths[0].label);
-  const secondLink = screen.getByRole('link', { name: hostPaths[1].label });
-  expect(secondLink).toBeInTheDocument();
-  expect(secondLink.textContent).toEqual(hostPaths[1].label);
+  hostPaths.forEach(hostPath => {
+    const link = screen.getByRole('link', { name: hostPath.label });
+    expect(link).toBeInTheDocument();
+    expect(link.textContent).toContain(hostPath.label);
+  });
 });
 
 test('Expect simple column styling with route', async () => {
@@ -132,5 +131,5 @@ test('Expect simple column styling with route', async () => {
   const hostPaths = ingressRouteUtils.getHostPaths(routeUI);
   const firstLink = screen.getByRole('link', { name: hostPaths[0].label });
   expect(firstLink).toBeInTheDocument();
-  expect(firstLink.textContent).toEqual(hostPaths[0].label);
+  expect(firstLink.textContent).toContain(hostPaths[0].label);
 });

--- a/packages/renderer/src/lib/ingresses-routes/IngressRouteColumnHostPath.svelte
+++ b/packages/renderer/src/lib/ingresses-routes/IngressRouteColumnHostPath.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
+import { faExternalLinkAlt } from '@fortawesome/free-solid-svg-icons';
 import { Link } from '@podman-desktop/ui-svelte';
+import { Fa } from 'svelte-fa';
 
 import { IngressRouteUtils } from './ingress-route-utils';
 import type { IngressUI } from './IngressUI';
@@ -11,7 +13,8 @@ const ingressRouteUtils = new IngressRouteUtils();
 </script>
 
 {#each ingressRouteUtils.getHostPaths(object) as hostPath}
-  <div class="text-sm text-gray-500 overflow-hidden text-ellipsis">
+  <div
+    class="flex flex-row bg-charcoal-500 items-center p-1 rounded-md text-xs text-gray-500 overflow-hidden text-ellipsis">
     {#if hostPath.url}
       <Link
         aria-label="{hostPath.label}"
@@ -20,7 +23,10 @@ const ingressRouteUtils = new IngressRouteUtils();
             window.openExternal(hostPath.url);
           }
         }}">
-        {hostPath.label}
+        <span class="flex items-center gap-1">
+          <Fa icon="{faExternalLinkAlt}" class="text-xs" />
+          {hostPath.label}
+        </span>
       </Link>
     {:else}
       {hostPath.label}


### PR DESCRIPTION
chore: add icon to url for k8s ingress / routes

### What does this PR do?

Adds little icon to the URL to make it similar to other aspects of
podman desktop, where we have the "badge" for the most important
information on the page (type, provider, etc.)

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

![Screenshot 2024-05-30 at 4 04 52 PM](https://github.com/containers/podman-desktop/assets/6422176/e3d06aa1-ae8a-4d46-840c-5e880a9c873a)



### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop/issues/7387

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature

View ingress / route page

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
