### PR TITLE
chore: fix hidden menu in tables

### DIFF
--- a/packages/ui/src/lib/table/Table.svelte
+++ b/packages/ui/src/lib/table/Table.svelte
@@ -201,9 +201,11 @@ function toggleChildren(object: unknown): void {
   <!-- Table body -->
   <div role="rowgroup">
     {#each data as object (object)}
-      <div class="mx-5 min-h-[48px] h-fit bg-[var(--pd-content-card-bg)] rounded-lg mb-2 overflow-hidden" role="row">
+      <div class="mx-5 min-h-[48px] h-fit bg-[var(--pd-content-card-bg)] rounded-lg mb-2" role="row">
         <div
           class="grid grid-table gap-x-0.5 min-h-[48px] hover:bg-[var(--pd-content-card-hover-bg)]"
+          class:rounded-t-lg="{expanded.includes(object.id)}"
+          class:rounded-lg="{!expanded.includes(object.id)}"
           aria-label="{object.name}">
           <div class="whitespace-nowrap place-self-center" role="cell">
             {#if row.info.children && row.info.children(object).length > 0}
@@ -247,8 +249,11 @@ function toggleChildren(object: unknown): void {
 
         <!-- Child objects -->
         {#if expanded.includes(object.id) && row.info.children}
-          {#each row.info.children(object) as child (child)}
-            <div class="grid grid-table gap-x-0.5 hover:bg-[var(--pd-content-card-hover-bg)]" aria-label="{child.name}">
+          {#each row.info.children(object) as child, i (child)}
+            <div
+              class="grid grid-table gap-x-0.5 hover:bg-[var(--pd-content-card-hover-bg)]"
+              class:rounded-b-lg="{i === row.info.children.length - 1}"
+              aria-label="{child.name}">
               <div class="whitespace-nowrap justify-self-start" role="cell"></div>
               {#if row.info.selectable}
                 <div class="whitespace-nowrap place-self-center" role="cell">


### PR DESCRIPTION
### What does this PR do?

Overflow hidden was used to make sure that when hovering over a row it has the same rounded corners as the parent div. A regular row is rounded on all four corners, but in the case of an expanded pod with 2 images, the three rows would have rounded top only, not rounded, and rounded bottom corners respectively. Unfortunately, hiding the overflow also hides all other children, including drop down menus.

I explored several other layout options (different div structure, various CSS fixes, positioning changes, ...) but they all have drawbacks or other implications compared to this one: using the expanded state or being the last child to decide when to round the corners.

### Screenshot / video of UI

See issue #7382.

### What issues does this PR fix or reference?

Fixes #7382.

### How to test this PR?

Open dropdown menu on an image.