### PR TITLE
chore: fix missing link colors

### DIFF
--- a/packages/main/src/plugin/color-registry.ts
+++ b/packages/main/src/plugin/color-registry.ts
@@ -237,6 +237,7 @@ export class ColorRegistry {
     this.initDetails();
     this.initTab();
     this.initModal();
+    this.initLink();
     this.initButton();
   }
 


### PR DESCRIPTION
### What does this PR do?

Due to having to rebase multiple times yesterday due to build issues it looks like I lost a commit and accidentally removed the call to initLink(). This just brings back the Link color and hover bg color.

### Screenshot / video of UI

Before: Links are default color (same grey as text)
After: Links are purple again, with a light bg hover.

### What issues does this PR fix or reference?

https://github.com/containers/podman-desktop/issues/7387#issuecomment-2140766343

### How to test this PR?

Go to the Dashboard or a details page and check the link color.