### PR TITLE
chore(tests): add env var to configure tests

### DIFF
--- a/tests/playwright/src/globalSetup/global-setup.ts
+++ b/tests/playwright/src/globalSetup/global-setup.ts
@@ -26,7 +26,7 @@ export async function setup(): Promise<void> {
     // remove all previous testing output files
     // Junit reporter output file is created before we can clean up output folders
     // It is not possible to remove junit output file because it is opened by the process already, at least on windows
-    if (!process.env.CI) {
+    if (!process.env.CI || !process.env.PODMAN_TEST_DEBUG) {
       await removeFolderIfExists('tests/output');
     } else {
       console.log(

--- a/tests/playwright/src/globalSetup/global-setup.ts
+++ b/tests/playwright/src/globalSetup/global-setup.ts
@@ -26,7 +26,7 @@ export async function setup(): Promise<void> {
     // remove all previous testing output files
     // Junit reporter output file is created before we can clean up output folders
     // It is not possible to remove junit output file because it is opened by the process already, at least on windows
-    if (!process.env.CI || !process.env.PODMAN_TEST_DEBUG) {
+    if (!process.env.CI || !process.env.IGNORE_REMOVE_FOLDER) {
       await removeFolderIfExists('tests/output');
     } else {
       console.log(

--- a/tests/playwright/src/globalSetup/global-setup.ts
+++ b/tests/playwright/src/globalSetup/global-setup.ts
@@ -26,7 +26,7 @@ export async function setup(): Promise<void> {
     // remove all previous testing output files
     // Junit reporter output file is created before we can clean up output folders
     // It is not possible to remove junit output file because it is opened by the process already, at least on windows
-    if (!process.env.CI || !process.env.IGNORE_REMOVE_FOLDER) {
+    if (!process.env.CI || !process.env.SKIP_REMOVE_FOLDER) {
       await removeFolderIfExists('tests/output');
     } else {
       console.log(


### PR DESCRIPTION
### What does this PR do?
Checks for an environment variable before starting a test run to check if the test session is for debug purposes to not cleanup some test folders.

### What issues does this PR fix or reference?
https://github.com/containers/podman-desktop/issues/7404
