### PR TITLE
feat: container page table component

### DIFF
--- a/packages/renderer/src/lib/container/ContainerActions.svelte
+++ b/packages/renderer/src/lib/container/ContainerActions.svelte
@@ -53,7 +53,7 @@ function handleError(errorMessage: string): void {
   dispatch('update', container);
 }
 
-async function startContainer() {
+async function startContainer(): Promise<void> {
   inProgress(true, 'STARTING');
   try {
     await window.startContainer(container.engineId, container.id);
@@ -64,7 +64,7 @@ async function startContainer() {
   }
 }
 
-async function restartContainer() {
+async function restartContainer(): Promise<void> {
   inProgress(true, 'RESTARTING');
   try {
     await window.restartContainer(container.engineId, container.id);
@@ -75,7 +75,7 @@ async function restartContainer() {
   }
 }
 
-async function stopContainer() {
+async function stopContainer(): Promise<void> {
   inProgress(true, 'STOPPING');
   try {
     await window.stopContainer(container.engineId, container.id);
@@ -108,7 +108,7 @@ async function deleteContainer(): Promise<void> {
   }
 }
 
-async function exportContainer() {
+async function exportContainer(): Promise<void> {
   exportContainerInfo.set(container);
   router.goto('/containers/export');
 }

--- a/packages/renderer/src/lib/container/ContainerColumnActions.svelte
+++ b/packages/renderer/src/lib/container/ContainerColumnActions.svelte
@@ -1,52 +1,24 @@
 <script lang="ts">
-import { ErrorMessage } from '@podman-desktop/ui-svelte';
-
-import ComposeActions from '../compose/ComposeActions.svelte';
-import PodActions from '../pod/PodActions.svelte';
-import ContainerActions from './ContainerActions.svelte';
+import { ContainerUtils } from './container-utils';
+import ContainerColumnActionsCompose from './ContainerColumnActionsCompose.svelte';
+import ContainerColumnActionsContainer from './ContainerColumnActionsContainer.svelte';
+import ContainerColumnActionsPod from './ContainerColumnActionsPod.svelte';
 import type { ContainerGroupInfoUI, ContainerInfoUI } from './ContainerInfoUI';
 import { ContainerGroupInfoTypeUI } from './ContainerInfoUI';
 
 export let object: ContainerInfoUI | ContainerGroupInfoUI;
+
+const containerUtils = new ContainerUtils();
 </script>
 
-{#if object.type === ContainerGroupInfoTypeUI.POD && object.engineId && object.id && object.shortId && object.status && object.engineName && object.humanCreationDate && object.created}
-  <PodActions
-    pod="{{
-      id: object.id,
-      shortId: object.shortId,
-      status: object.status,
-      name: object.name,
-      engineId: object.engineId,
-      engineName: object.engineName,
-      age: object.humanCreationDate,
-      created: object.created,
-      selected: false,
-      containers: object.containers.map(container => ({
-        Id: container.id,
-        Names: container.name,
-        Status: container.state,
-      })),
-      kind: 'podman',
-    }}"
-    dropdownMenu="{true}"
-    on:update />
-{/if}
-{#if object.type === ContainerGroupInfoTypeUI.COMPOSE && object.status && object.engineId && object.engineType}
-  <ComposeActions
-    compose="{{
-      status: object.status,
-      name: object.name,
-      engineId: object.engineId,
-      engineType: object.engineType,
-      containers: object.containers,
-    }}"
-    dropdownMenu="{true}"
-    on:update />
-{/if}
-{#if object.state}
-  {#if object.actionError}
-    <ErrorMessage error="{object.actionError}" icon />
+{#if containerUtils.isContainerGroupInfoUI(object)}
+  {#if object.type === ContainerGroupInfoTypeUI.POD}
+    <ContainerColumnActionsPod object="{object}" />
   {/if}
-  <ContainerActions container="{object}" dropdownMenu="{true}" on:update />
+  {#if object.type === ContainerGroupInfoTypeUI.COMPOSE}
+    <ContainerColumnActionsCompose object="{object}" />
+  {/if}
+{/if}
+{#if containerUtils.isContainerInfoUI(object)}
+  <ContainerColumnActionsContainer object="{object}" />
 {/if}

--- a/packages/renderer/src/lib/container/ContainerColumnActions.svelte
+++ b/packages/renderer/src/lib/container/ContainerColumnActions.svelte
@@ -13,12 +13,10 @@ const containerUtils = new ContainerUtils();
 
 {#if containerUtils.isContainerGroupInfoUI(object)}
   {#if object.type === ContainerGroupInfoTypeUI.POD}
-    <ContainerColumnActionsPod object="{object}" />
+    <ContainerColumnActionsPod object="{object}" on:update />
+  {:else if object.type === ContainerGroupInfoTypeUI.COMPOSE}
+    <ContainerColumnActionsCompose object="{object}" on:update />
   {/if}
-  {#if object.type === ContainerGroupInfoTypeUI.COMPOSE}
-    <ContainerColumnActionsCompose object="{object}" />
-  {/if}
-{/if}
-{#if containerUtils.isContainerInfoUI(object)}
-  <ContainerColumnActionsContainer object="{object}" />
+{:else if containerUtils.isContainerInfoUI(object)}
+  <ContainerColumnActionsContainer object="{object}" on:update />
 {/if}

--- a/packages/renderer/src/lib/container/ContainerColumnActions.svelte
+++ b/packages/renderer/src/lib/container/ContainerColumnActions.svelte
@@ -1,0 +1,52 @@
+<script lang="ts">
+import { ErrorMessage } from '@podman-desktop/ui-svelte';
+
+import ComposeActions from '../compose/ComposeActions.svelte';
+import PodActions from '../pod/PodActions.svelte';
+import ContainerActions from './ContainerActions.svelte';
+import type { ContainerGroupInfoUI, ContainerInfoUI } from './ContainerInfoUI';
+import { ContainerGroupInfoTypeUI } from './ContainerInfoUI';
+
+export let object: ContainerInfoUI | ContainerGroupInfoUI;
+</script>
+
+{#if object.type === ContainerGroupInfoTypeUI.POD && object.engineId && object.id && object.shortId && object.status && object.engineName && object.humanCreationDate && object.created}
+  <PodActions
+    pod="{{
+      id: object.id,
+      shortId: object.shortId,
+      status: object.status,
+      name: object.name,
+      engineId: object.engineId,
+      engineName: object.engineName,
+      age: object.humanCreationDate,
+      created: object.created,
+      selected: false,
+      containers: object.containers.map(container => ({
+        Id: container.id,
+        Names: container.name,
+        Status: container.state,
+      })),
+      kind: 'podman',
+    }}"
+    dropdownMenu="{true}"
+    on:update />
+{/if}
+{#if object.type === ContainerGroupInfoTypeUI.COMPOSE && object.status && object.engineId && object.engineType}
+  <ComposeActions
+    compose="{{
+      status: object.status,
+      name: object.name,
+      engineId: object.engineId,
+      engineType: object.engineType,
+      containers: object.containers,
+    }}"
+    dropdownMenu="{true}"
+    on:update />
+{/if}
+{#if object.state}
+  {#if object.actionError}
+    <ErrorMessage error="{object.actionError}" icon />
+  {/if}
+  <ContainerActions container="{object}" dropdownMenu="{true}" on:update />
+{/if}

--- a/packages/renderer/src/lib/container/ContainerColumnActionsCompose.svelte
+++ b/packages/renderer/src/lib/container/ContainerColumnActionsCompose.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+import ComposeActions from '../compose/ComposeActions.svelte';
+import type { ContainerGroupInfoUI } from './ContainerInfoUI';
+
+export let object: ContainerGroupInfoUI;
+</script>
+
+{#if object.status && object.engineId && object.engineType}
+  <ComposeActions
+    compose="{{
+      status: object.status,
+      name: object.name,
+      engineId: object.engineId,
+      engineType: object.engineType,
+      containers: object.containers,
+    }}"
+    dropdownMenu="{true}"
+    on:update />
+{/if}

--- a/packages/renderer/src/lib/container/ContainerColumnActionsContainer.svelte
+++ b/packages/renderer/src/lib/container/ContainerColumnActionsContainer.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+import { ErrorMessage } from '@podman-desktop/ui-svelte';
+
+import ContainerActions from './ContainerActions.svelte';
+import type { ContainerInfoUI } from './ContainerInfoUI';
+
+export let object: ContainerInfoUI;
+</script>
+
+{#if object.actionError}
+  <ErrorMessage error="{object.actionError}" icon />
+{/if}
+<ContainerActions container="{object}" dropdownMenu="{true}" on:update />

--- a/packages/renderer/src/lib/container/ContainerColumnActionsPod.svelte
+++ b/packages/renderer/src/lib/container/ContainerColumnActionsPod.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+import PodActions from '../pod/PodActions.svelte';
+import type { ContainerGroupInfoUI } from './ContainerInfoUI';
+
+export let object: ContainerGroupInfoUI;
+</script>
+
+{#if object.engineId && object.id && object.shortId && object.status && object.engineName && object.humanCreationDate && object.created}
+  <PodActions
+    pod="{{
+      id: object.id,
+      shortId: object.shortId,
+      status: object.status,
+      name: object.name,
+      engineId: object.engineId,
+      engineName: object.engineName,
+      age: object.humanCreationDate,
+      created: object.created,
+      selected: false,
+      containers: object.containers.map(container => ({
+        Id: container.id,
+        Names: container.name,
+        Status: container.state,
+      })),
+      kind: 'podman',
+    }}"
+    dropdownMenu="{true}"
+    on:update />
+{/if}

--- a/packages/renderer/src/lib/container/ContainerColumnAge.svelte
+++ b/packages/renderer/src/lib/container/ContainerColumnAge.svelte
@@ -1,11 +1,14 @@
 <script lang="ts">
 import StateChange from '../ui/StateChange.svelte';
+import { ContainerUtils } from './container-utils';
 import type { ContainerGroupInfoUI, ContainerInfoUI } from './ContainerInfoUI';
 
 export let object: ContainerInfoUI | ContainerGroupInfoUI;
+
+const containerUtils = new ContainerUtils();
 </script>
 
-{#if 'state' in object}
+{#if containerUtils.isContainerInfoUI(object)}
   <div class="text-sm text-[var(--pd-table-body-text)]">
     <StateChange state="{object.state}">{object.uptime}</StateChange>
   </div>

--- a/packages/renderer/src/lib/container/ContainerColumnAge.svelte
+++ b/packages/renderer/src/lib/container/ContainerColumnAge.svelte
@@ -6,7 +6,7 @@ export let object: ContainerInfoUI | ContainerGroupInfoUI;
 </script>
 
 {#if 'state' in object}
-  <div class="text-sm text-gray-700">
+  <div class="text-sm text-[var(--pd-table-body-text)]">
     <StateChange state="{object.state}">{object.uptime}</StateChange>
   </div>
 {/if}

--- a/packages/renderer/src/lib/container/ContainerColumnAge.svelte
+++ b/packages/renderer/src/lib/container/ContainerColumnAge.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+import StateChange from '../ui/StateChange.svelte';
+import type { ContainerGroupInfoUI, ContainerInfoUI } from './ContainerInfoUI';
+
+export let object: ContainerInfoUI | ContainerGroupInfoUI;
+</script>
+
+{#if 'state' in object}
+  <div class="text-sm text-gray-700">
+    <StateChange state="{object.state}">{object.uptime}</StateChange>
+  </div>
+{/if}

--- a/packages/renderer/src/lib/container/ContainerColumnEnvironment.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerColumnEnvironment.spec.ts
@@ -1,0 +1,92 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/svelte';
+import { expect, test } from 'vitest';
+
+import ContainerColumnEnvironment from './ContainerColumnEnvironment.svelte';
+import type { ContainerGroupInfoUI, ContainerInfoUI } from './ContainerInfoUI';
+import { ContainerGroupInfoTypeUI } from './ContainerInfoUI';
+
+test('Expect simple column styling', async () => {
+  const container: ContainerInfoUI = {
+    id: 'sha256:1234567890123',
+    image: 'sha256:123',
+    engineId: 'podman',
+    engineName: 'podman',
+    shortId: '',
+    name: '',
+    shortImage: '',
+    engineType: 'podman',
+    state: '',
+    uptime: '',
+    startedAt: '',
+    ports: [],
+    portsAsString: '',
+    displayPort: '',
+    hasPublicPort: false,
+    groupInfo: {
+      name: '',
+      type: ContainerGroupInfoTypeUI.STANDALONE,
+    },
+    selected: false,
+    created: 0,
+    labels: {},
+    imageBase64RepoTag: '',
+  };
+  render(ContainerColumnEnvironment, { object: container });
+
+  const text = screen.getByText(container.engineName);
+  expect(text).toBeInTheDocument();
+});
+
+test('Expect simple column styling - pod', async () => {
+  const pod: ContainerGroupInfoUI = {
+    type: ContainerGroupInfoTypeUI.POD,
+    expanded: false,
+    selected: false,
+    allContainersCount: 0,
+    containers: [],
+    name: '',
+    engineType: ContainerGroupInfoTypeUI.PODMAN,
+    engineId: '',
+  };
+  render(ContainerColumnEnvironment, { object: pod });
+
+  const text = screen.getByText('podman');
+  expect(text).toBeInTheDocument();
+});
+
+test('Expect simple column styling - compose', async () => {
+  const compose: ContainerGroupInfoUI = {
+    type: ContainerGroupInfoTypeUI.COMPOSE,
+    expanded: false,
+    selected: false,
+    allContainersCount: 0,
+    containers: [],
+    name: '',
+    engineType: ContainerGroupInfoTypeUI.PODMAN,
+    engineId: '',
+  };
+  render(ContainerColumnEnvironment, { object: compose });
+
+  const text = screen.getByText('podman');
+  expect(text).toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/container/ContainerColumnEnvironment.svelte
+++ b/packages/renderer/src/lib/container/ContainerColumnEnvironment.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+import ProviderInfo from '../ui/ProviderInfo.svelte';
+import type { ContainerGroupInfoUI, ContainerInfoUI } from './ContainerInfoUI';
+
+export let object: ContainerInfoUI | ContainerGroupInfoUI;
+</script>
+
+<ProviderInfo provider="{object.engineType}" context="{object.engineId}" />

--- a/packages/renderer/src/lib/container/ContainerColumnImage.svelte
+++ b/packages/renderer/src/lib/container/ContainerColumnImage.svelte
@@ -5,7 +5,7 @@ export let object: ContainerInfoUI | ContainerGroupInfoUI;
 </script>
 
 {#if 'image' in object}
-  <div class="text-sm text-gray-700 overflow-hidden text-ellipsis" title="{object.image}">
+  <div class="text-sm text-[var(--pd-table-body-text)] overflow-hidden text-ellipsis" title="{object.image}">
     {object.shortImage}
   </div>
 {/if}

--- a/packages/renderer/src/lib/container/ContainerColumnImage.svelte
+++ b/packages/renderer/src/lib/container/ContainerColumnImage.svelte
@@ -1,10 +1,13 @@
 <script lang="ts">
+import { ContainerUtils } from './container-utils';
 import type { ContainerGroupInfoUI, ContainerInfoUI } from './ContainerInfoUI';
 
 export let object: ContainerInfoUI | ContainerGroupInfoUI;
+
+const containerUtils = new ContainerUtils();
 </script>
 
-{#if 'image' in object}
+{#if containerUtils.isContainerInfoUI(object)}
   <div class="text-sm text-[var(--pd-table-body-text)] overflow-hidden text-ellipsis" title="{object.image}">
     {object.shortImage}
   </div>

--- a/packages/renderer/src/lib/container/ContainerColumnImage.svelte
+++ b/packages/renderer/src/lib/container/ContainerColumnImage.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+import type { ContainerGroupInfoUI, ContainerInfoUI } from './ContainerInfoUI';
+
+export let object: ContainerInfoUI | ContainerGroupInfoUI;
+</script>
+
+{#if 'image' in object}
+  <div class="text-sm text-gray-700 overflow-hidden text-ellipsis" title="{object.image}">
+    {object.shortImage}
+  </div>
+{/if}

--- a/packages/renderer/src/lib/container/ContainerColumnName.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerColumnName.spec.ts
@@ -1,0 +1,135 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { fireEvent } from '@testing-library/dom';
+import { render, screen } from '@testing-library/svelte';
+import { router } from 'tinro';
+import { expect, test, vi } from 'vitest';
+
+import ContainerColumnName from './ContainerColumnName.svelte';
+import { ContainerGroupInfoTypeUI, type ContainerGroupInfoUI, type ContainerInfoUI } from './ContainerInfoUI';
+
+const container: ContainerInfoUI = {
+  id: 'sha256:1234567890123',
+  image: 'sha256:123',
+  engineId: 'podman',
+  engineName: 'podman',
+  shortId: '',
+  name: 'my-container',
+  shortImage: '',
+  engineType: 'podman',
+  state: '',
+  uptime: '',
+  startedAt: '',
+  ports: [],
+  portsAsString: '',
+  displayPort: '',
+  hasPublicPort: false,
+  groupInfo: {
+    name: '',
+    type: ContainerGroupInfoTypeUI.STANDALONE,
+  },
+  selected: false,
+  created: 0,
+  labels: {},
+  imageBase64RepoTag: '',
+};
+
+const pod: ContainerGroupInfoUI = {
+  type: ContainerGroupInfoTypeUI.POD,
+  expanded: false,
+  selected: false,
+  allContainersCount: 0,
+  containers: [],
+  name: 'my-pod',
+  engineType: ContainerGroupInfoTypeUI.PODMAN,
+  engineId: 'engineId',
+};
+
+const compose: ContainerGroupInfoUI = {
+  type: ContainerGroupInfoTypeUI.COMPOSE,
+  expanded: false,
+  selected: false,
+  allContainersCount: 0,
+  containers: [],
+  name: 'my-compose',
+  engineType: ContainerGroupInfoTypeUI.PODMAN,
+  engineId: 'engine2',
+};
+
+test('Expect simple column styling - container', async () => {
+  render(ContainerColumnName, { object: container });
+
+  const text = screen.getByText(container.name);
+  expect(text).toBeInTheDocument();
+});
+
+test('Expect simple column styling - pod', async () => {
+  render(ContainerColumnName, { object: pod });
+
+  const text = screen.getByText(`${pod.name} (pod)`);
+  expect(text).toBeInTheDocument();
+});
+
+test('Expect simple column styling - compose', async () => {
+  render(ContainerColumnName, { object: compose });
+
+  const text = screen.getByText(`${compose.name} (compose)`);
+  expect(text).toBeInTheDocument();
+});
+
+test('Expect clicking works - container', async () => {
+  render(ContainerColumnName, { object: container });
+
+  const text = screen.getByText(container.name);
+  expect(text).toBeInTheDocument();
+
+  // test click
+  const routerGotoSpy = vi.spyOn(router, 'goto');
+  fireEvent.click(text);
+
+  expect(routerGotoSpy).toBeCalledWith(`/containers/${container.id}/`);
+});
+
+test('Expect clicking works - pod', async () => {
+  render(ContainerColumnName, { object: pod });
+
+  const text = screen.getByText(`${pod.name} (pod)`);
+  expect(text).toBeInTheDocument();
+
+  // test click
+  const routerGotoSpy = vi.spyOn(router, 'goto');
+  fireEvent.click(text);
+
+  expect(routerGotoSpy).toBeCalledWith(`/pods/podman/${pod.name}/${pod.engineId}/logs`);
+});
+
+test('Expect clicking works - compose', async () => {
+  render(ContainerColumnName, { object: compose });
+
+  const text = screen.getByText(`${compose.name} (compose)`);
+  expect(text).toBeInTheDocument();
+
+  // test click
+  const routerGotoSpy = vi.spyOn(router, 'goto');
+  fireEvent.click(text);
+
+  expect(routerGotoSpy).toBeCalledWith(`/compose/details/${compose.name}/${compose.engineId}/logs`);
+});

--- a/packages/renderer/src/lib/container/ContainerColumnName.svelte
+++ b/packages/renderer/src/lib/container/ContainerColumnName.svelte
@@ -1,63 +1,16 @@
 <script lang="ts">
-import { router } from 'tinro';
-
+import { ContainerUtils } from './container-utils';
+import ContainerColumnNameContainer from './ContainerColumnNameContainer.svelte';
+import ContainerColumnNameGroup from './ContainerColumnNameGroup.svelte';
 import type { ContainerGroupInfoUI, ContainerInfoUI } from './ContainerInfoUI';
-import { ContainerGroupInfoTypeUI } from './ContainerInfoUI';
 
 export let object: ContainerInfoUI | ContainerGroupInfoUI;
 
-function displayContainersCount(containerGroup: ContainerGroupInfoUI): string {
-  let result = containerGroup.allContainersCount + ' container' + (containerGroup.allContainersCount > 1 ? 's' : '');
-  if (containerGroup.containers.length !== containerGroup.allContainersCount) {
-    result += ` (${containerGroup.allContainersCount - containerGroup.containers.length} filtered)`;
-  }
-  return result;
-}
-
-function openGroupDetails(containerGroup: ContainerGroupInfoUI): void {
-  if (!containerGroup.engineId) {
-    return;
-  }
-  if (containerGroup.type === ContainerGroupInfoTypeUI.POD) {
-    router.goto(`/pods/podman/${encodeURI(containerGroup.name)}/${encodeURIComponent(containerGroup.engineId)}/logs`);
-  } else if (containerGroup.type === ContainerGroupInfoTypeUI.COMPOSE) {
-    router.goto(`/compose/details/${encodeURI(containerGroup.name)}/${encodeURI(containerGroup.engineId)}/logs`);
-  }
-}
-
-function openContainerDetails(container: ContainerInfoUI): void {
-  router.goto(`/containers/${container.id}/`);
-}
+const containerUtils = new ContainerUtils();
 </script>
 
-{#if 'type' in object}
-  <button
-    class="flex flex-col text-sm text-[var(--pd-table-body-text-highlight)] max-w-full"
-    title="{object.type}"
-    on:click="{() => openGroupDetails(object)}">
-    <div class="max-w-full overflow-hidden text-ellipsis">
-      {object.name} ({object.type})
-    </div>
-    <div class="text-xs font-extra-light text-[var(--pd-table-body-text)]">
-      {displayContainersCount(object)}
-    </div>
-  </button>
-{:else if 'state' in object}
-  <button class="flex flex-col whitespace-nowrap max-w-full" on:click="{() => openContainerDetails(object)}">
-    <div class="flex items-center max-w-full">
-      <div class="max-w-full">
-        <div class="flex flex-nowrap max-w-full">
-          <div
-            class="text-sm text-[var(--pd-table-body-text-highlight)] overflow-hidden text-ellipsis group-hover:text-violet-400"
-            title="{object.name}">
-            {object.name}
-          </div>
-        </div>
-        <div class="flex flex-nowrap text-xs font-extra-light text-[var(--pd-table-body-text)] items-center max-w-full">
-          <div>{object.state}</div>
-          <div class="pl-2 max-w-fit overflow-hidden text-ellipsis">{object.displayPort}</div>
-        </div>
-      </div>
-    </div>
-  </button>
+{#if containerUtils.isContainerGroupInfoUI(object)}
+  <ContainerColumnNameGroup object="{object}" />
+{:else if containerUtils.isContainerInfoUI(object)}
+  <ContainerColumnNameContainer object="{object}" />
 {/if}

--- a/packages/renderer/src/lib/container/ContainerColumnName.svelte
+++ b/packages/renderer/src/lib/container/ContainerColumnName.svelte
@@ -6,7 +6,7 @@ import { ContainerGroupInfoTypeUI } from './ContainerInfoUI';
 
 export let object: ContainerInfoUI | ContainerGroupInfoUI;
 
-function displayContainersCount(containerGroup: ContainerGroupInfoUI) {
+function displayContainersCount(containerGroup: ContainerGroupInfoUI): string {
   let result = containerGroup.allContainersCount + ' container' + (containerGroup.allContainersCount > 1 ? 's' : '');
   if (containerGroup.containers.length !== containerGroup.allContainersCount) {
     result += ` (${containerGroup.allContainersCount - containerGroup.containers.length} filtered)`;
@@ -14,7 +14,7 @@ function displayContainersCount(containerGroup: ContainerGroupInfoUI) {
   return result;
 }
 
-function openGroupDetails(containerGroup: ContainerGroupInfoUI) {
+function openGroupDetails(containerGroup: ContainerGroupInfoUI): void {
   if (!containerGroup.engineId) {
     return;
   }
@@ -25,20 +25,20 @@ function openGroupDetails(containerGroup: ContainerGroupInfoUI) {
   }
 }
 
-function openContainerDetails(container: ContainerInfoUI) {
+function openContainerDetails(container: ContainerInfoUI): void {
   router.goto(`/containers/${container.id}/`);
 }
 </script>
 
-{#if 'type' in object && (object.type === ContainerGroupInfoTypeUI.POD || object.type === ContainerGroupInfoTypeUI.COMPOSE)}
+{#if 'type' in object}
   <button
-    class="flex flex-col text-sm text-gray-300 max-w-full"
+    class="flex flex-col text-sm text-[var(--pd-table-body-text-highlight)] max-w-full"
     title="{object.type}"
     on:click="{() => openGroupDetails(object)}">
     <div class="max-w-full overflow-hidden text-ellipsis">
       {object.name} ({object.type})
     </div>
-    <div class="text-xs font-extra-light text-gray-900">
+    <div class="text-xs font-extra-light text-[var(--pd-table-body-text)]">
       {displayContainersCount(object)}
     </div>
   </button>
@@ -48,12 +48,12 @@ function openContainerDetails(container: ContainerInfoUI) {
       <div class="max-w-full">
         <div class="flex flex-nowrap max-w-full">
           <div
-            class="text-sm text-gray-300 overflow-hidden text-ellipsis group-hover:text-violet-400"
+            class="text-sm text-[var(--pd-table-body-text-highlight)] overflow-hidden text-ellipsis group-hover:text-violet-400"
             title="{object.name}">
             {object.name}
           </div>
         </div>
-        <div class="flex flex-nowrap text-xs font-extra-light text-gray-900 items-center max-w-full">
+        <div class="flex flex-nowrap text-xs font-extra-light text-[var(--pd-table-body-text)] items-center max-w-full">
           <div>{object.state}</div>
           <div class="pl-2 max-w-fit overflow-hidden text-ellipsis">{object.displayPort}</div>
         </div>

--- a/packages/renderer/src/lib/container/ContainerColumnName.svelte
+++ b/packages/renderer/src/lib/container/ContainerColumnName.svelte
@@ -1,0 +1,63 @@
+<script lang="ts">
+import { router } from 'tinro';
+
+import type { ContainerGroupInfoUI, ContainerInfoUI } from './ContainerInfoUI';
+import { ContainerGroupInfoTypeUI } from './ContainerInfoUI';
+
+export let object: ContainerInfoUI | ContainerGroupInfoUI;
+
+function displayContainersCount(containerGroup: ContainerGroupInfoUI) {
+  let result = containerGroup.allContainersCount + ' container' + (containerGroup.allContainersCount > 1 ? 's' : '');
+  if (containerGroup.containers.length !== containerGroup.allContainersCount) {
+    result += ` (${containerGroup.allContainersCount - containerGroup.containers.length} filtered)`;
+  }
+  return result;
+}
+
+function openGroupDetails(containerGroup: ContainerGroupInfoUI) {
+  if (!containerGroup.engineId) {
+    return;
+  }
+  if (containerGroup.type === ContainerGroupInfoTypeUI.POD) {
+    router.goto(`/pods/podman/${encodeURI(containerGroup.name)}/${encodeURIComponent(containerGroup.engineId)}/logs`);
+  } else if (containerGroup.type === ContainerGroupInfoTypeUI.COMPOSE) {
+    router.goto(`/compose/details/${encodeURI(containerGroup.name)}/${encodeURI(containerGroup.engineId)}/logs`);
+  }
+}
+
+function openContainerDetails(container: ContainerInfoUI) {
+  router.goto(`/containers/${container.id}/`);
+}
+</script>
+
+{#if 'type' in object && (object.type === ContainerGroupInfoTypeUI.POD || object.type === ContainerGroupInfoTypeUI.COMPOSE)}
+  <button
+    class="flex flex-col text-sm text-gray-300 max-w-full"
+    title="{object.type}"
+    on:click="{() => openGroupDetails(object)}">
+    <div class="max-w-full overflow-hidden text-ellipsis">
+      {object.name} ({object.type})
+    </div>
+    <div class="text-xs font-extra-light text-gray-900">
+      {displayContainersCount(object)}
+    </div>
+  </button>
+{:else if 'state' in object}
+  <button class="flex flex-col whitespace-nowrap max-w-full" on:click="{() => openContainerDetails(object)}">
+    <div class="flex items-center max-w-full">
+      <div class="max-w-full">
+        <div class="flex flex-nowrap max-w-full">
+          <div
+            class="text-sm text-gray-300 overflow-hidden text-ellipsis group-hover:text-violet-400"
+            title="{object.name}">
+            {object.name}
+          </div>
+        </div>
+        <div class="flex flex-nowrap text-xs font-extra-light text-gray-900 items-center max-w-full">
+          <div>{object.state}</div>
+          <div class="pl-2 max-w-fit overflow-hidden text-ellipsis">{object.displayPort}</div>
+        </div>
+      </div>
+    </div>
+  </button>
+{/if}

--- a/packages/renderer/src/lib/container/ContainerColumnNameContainer.svelte
+++ b/packages/renderer/src/lib/container/ContainerColumnNameContainer.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+import { router } from 'tinro';
+
+import type { ContainerInfoUI } from './ContainerInfoUI';
+
+export let object: ContainerInfoUI;
+
+function openContainerDetails(container: ContainerInfoUI): void {
+  router.goto(`/containers/${container.id}/`);
+}
+</script>
+
+<button class="flex flex-col whitespace-nowrap max-w-full" on:click="{() => openContainerDetails(object)}">
+  <div class="flex items-center max-w-full">
+    <div class="max-w-full">
+      <div class="flex flex-nowrap max-w-full">
+        <div
+          class="text-sm text-[var(--pd-table-body-text-highlight)] overflow-hidden text-ellipsis group-hover:text-violet-400"
+          title="{object.name}">
+          {object.name}
+        </div>
+      </div>
+      <div class="flex flex-nowrap text-xs font-extra-light text-[var(--pd-table-body-text)] items-center max-w-full">
+        <div>{object.state}</div>
+        <div class="pl-2 max-w-fit overflow-hidden text-ellipsis">{object.displayPort}</div>
+      </div>
+    </div>
+  </div>
+</button>

--- a/packages/renderer/src/lib/container/ContainerColumnNameGroup.svelte
+++ b/packages/renderer/src/lib/container/ContainerColumnNameGroup.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+import { router } from 'tinro';
+
+import type { ContainerGroupInfoUI } from './ContainerInfoUI';
+import { ContainerGroupInfoTypeUI } from './ContainerInfoUI';
+
+export let object: ContainerGroupInfoUI;
+
+function displayContainersCount(containerGroup: ContainerGroupInfoUI): string {
+  let result = containerGroup.allContainersCount + ' container' + (containerGroup.allContainersCount > 1 ? 's' : '');
+  if (containerGroup.containers.length !== containerGroup.allContainersCount) {
+    result += ` (${containerGroup.allContainersCount - containerGroup.containers.length} filtered)`;
+  }
+  return result;
+}
+
+function openGroupDetails(containerGroup: ContainerGroupInfoUI): void {
+  if (!containerGroup.engineId) {
+    return;
+  }
+  if (containerGroup.type === ContainerGroupInfoTypeUI.POD) {
+    router.goto(`/pods/podman/${encodeURI(containerGroup.name)}/${encodeURIComponent(containerGroup.engineId)}/logs`);
+  } else if (containerGroup.type === ContainerGroupInfoTypeUI.COMPOSE) {
+    router.goto(`/compose/details/${encodeURI(containerGroup.name)}/${encodeURI(containerGroup.engineId)}/logs`);
+  }
+}
+</script>
+
+<button
+  class="flex flex-col text-sm text-[var(--pd-table-body-text-highlight)] max-w-full"
+  title="{object.type}"
+  on:click="{() => openGroupDetails(object)}">
+  <div class="max-w-full overflow-hidden text-ellipsis">
+    {object.name} ({object.type})
+  </div>
+  <div class="text-xs font-extra-light text-[var(--pd-table-body-text)]">
+    {displayContainersCount(object)}
+  </div>
+</button>

--- a/packages/renderer/src/lib/container/ContainerColumnStatus.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerColumnStatus.spec.ts
@@ -52,7 +52,7 @@ test('Expect simple column styling - container', async () => {
 
   const text = screen.getByRole('status');
   expect(text).toBeInTheDocument();
-  expect(text).toHaveClass('bg-status-running');
+  expect(text).toHaveClass('bg-[var(--pd-status-running)]');
 });
 
 test('Expect simple column styling - pod', async () => {
@@ -69,7 +69,7 @@ test('Expect simple column styling - pod', async () => {
 
   const text = screen.getByRole('status');
   expect(text).toBeInTheDocument();
-  expect(text).toHaveClass('bg-status-running');
+  expect(text).toHaveClass('bg-[var(--pd-status-running)]');
 });
 
 test('Expect simple column styling - compose', async () => {
@@ -86,5 +86,5 @@ test('Expect simple column styling - compose', async () => {
 
   const text = screen.getByRole('status');
   expect(text).toBeInTheDocument();
-  expect(text).toHaveClass('bg-status-running');
+  expect(text).toHaveClass('bg-[var(--pd-status-running)]');
 });

--- a/packages/renderer/src/lib/container/ContainerColumnStatus.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerColumnStatus.spec.ts
@@ -1,0 +1,90 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/svelte';
+import { expect, test } from 'vitest';
+
+import ContainerColumnStatus from './ContainerColumnStatus.svelte';
+import type { ContainerGroupInfoUI, ContainerInfoUI } from './ContainerInfoUI';
+import { ContainerGroupInfoTypeUI } from './ContainerInfoUI';
+
+test('Expect simple column styling - container', async () => {
+  const container: ContainerInfoUI = {
+    id: '',
+    shortId: '',
+    name: '',
+    image: '',
+    shortImage: '',
+    engineId: '',
+    engineName: '',
+    engineType: 'podman',
+    state: 'RUNNING',
+    uptime: '',
+    startedAt: '',
+    ports: [],
+    portsAsString: '',
+    displayPort: '',
+    hasPublicPort: false,
+    groupInfo: {} as ContainerGroupInfoUI,
+    selected: false,
+    created: 0,
+    labels: {},
+    imageBase64RepoTag: '',
+  };
+  render(ContainerColumnStatus, { object: container });
+
+  const text = screen.getByRole('status');
+  expect(text).toBeInTheDocument();
+  expect(text).toHaveClass('bg-status-running');
+});
+
+test('Expect simple column styling - pod', async () => {
+  const pod: ContainerGroupInfoUI = {
+    type: ContainerGroupInfoTypeUI.POD,
+    expanded: false,
+    status: 'RUNNING',
+    selected: false,
+    allContainersCount: 0,
+    containers: [],
+    name: '',
+  };
+  render(ContainerColumnStatus, { object: pod });
+
+  const text = screen.getByRole('status');
+  expect(text).toBeInTheDocument();
+  expect(text).toHaveClass('bg-status-running');
+});
+
+test('Expect simple column styling - compose', async () => {
+  const compose: ContainerGroupInfoUI = {
+    type: ContainerGroupInfoTypeUI.COMPOSE,
+    expanded: false,
+    status: 'RUNNING',
+    selected: false,
+    allContainersCount: 0,
+    containers: [],
+    name: '',
+  };
+  render(ContainerColumnStatus, { object: compose });
+
+  const text = screen.getByRole('status');
+  expect(text).toBeInTheDocument();
+  expect(text).toHaveClass('bg-status-running');
+});

--- a/packages/renderer/src/lib/container/ContainerColumnStatus.svelte
+++ b/packages/renderer/src/lib/container/ContainerColumnStatus.svelte
@@ -1,13 +1,16 @@
 <script lang="ts">
 import PodIcon from '../images/PodIcon.svelte';
 import StatusIcon from '../images/StatusIcon.svelte';
+import { ContainerUtils } from './container-utils';
 import type { ContainerGroupInfoUI, ContainerInfoUI } from './ContainerInfoUI';
 
 export let object: ContainerInfoUI | ContainerGroupInfoUI;
+
+const containerUtils = new ContainerUtils();
 </script>
 
-{#if 'type' in object}
+{#if containerUtils.isContainerGroupInfoUI(object)}
   <StatusIcon icon="{PodIcon}" status="{object.status}" />
-{:else if 'state' in object}
+{:else if containerUtils.isContainerInfoUI(object)}
   <StatusIcon icon="{object.icon}" status="{object.state}" />
 {/if}

--- a/packages/renderer/src/lib/container/ContainerColumnStatus.svelte
+++ b/packages/renderer/src/lib/container/ContainerColumnStatus.svelte
@@ -2,14 +2,11 @@
 import PodIcon from '../images/PodIcon.svelte';
 import StatusIcon from '../images/StatusIcon.svelte';
 import type { ContainerGroupInfoUI, ContainerInfoUI } from './ContainerInfoUI';
-import { ContainerGroupInfoTypeUI } from './ContainerInfoUI';
 
 export let object: ContainerInfoUI | ContainerGroupInfoUI;
 </script>
 
-{#if 'type' in object && object.type === ContainerGroupInfoTypeUI.POD}
-  <StatusIcon icon="{PodIcon}" status="{object.status}" />
-{:else if 'type' in object && object.type === ContainerGroupInfoTypeUI.COMPOSE}
+{#if 'type' in object}
   <StatusIcon icon="{PodIcon}" status="{object.status}" />
 {:else if 'state' in object}
   <StatusIcon icon="{object.icon}" status="{object.state}" />

--- a/packages/renderer/src/lib/container/ContainerColumnStatus.svelte
+++ b/packages/renderer/src/lib/container/ContainerColumnStatus.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+import PodIcon from '../images/PodIcon.svelte';
+import StatusIcon from '../images/StatusIcon.svelte';
+import type { ContainerGroupInfoUI, ContainerInfoUI } from './ContainerInfoUI';
+import { ContainerGroupInfoTypeUI } from './ContainerInfoUI';
+
+export let object: ContainerInfoUI | ContainerGroupInfoUI;
+</script>
+
+{#if 'type' in object && object.type === ContainerGroupInfoTypeUI.POD}
+  <StatusIcon icon="{PodIcon}" status="{object.status}" />
+{:else if 'type' in object && object.type === ContainerGroupInfoTypeUI.COMPOSE}
+  <StatusIcon icon="{PodIcon}" status="{object.status}" />
+{:else if 'state' in object}
+  <StatusIcon icon="{object.icon}" status="{object.state}" />
+{/if}

--- a/packages/renderer/src/lib/container/ContainerList.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerList.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -361,9 +361,9 @@ test('Try to delete a container without deleting pods', async () => {
   await waitRender({});
 
   // select the standalone container checkbox
-  const containerCheckbox = screen.getAllByRole('checkbox', { name: 'Toggle container' });
-  expect(containerCheckbox[0]).toBeInTheDocument();
-  await fireEvent.click(containerCheckbox[0]);
+  const checkboxes = screen.getAllByRole('checkbox', { name: 'Toggle container' });
+  expect(checkboxes[0]).toBeInTheDocument();
+  await fireEvent.click(checkboxes[0]);
 
   // click on the delete button
   const deleteButton = screen.getByRole('button', { name: 'Delete selected containers and pods' });
@@ -444,9 +444,9 @@ test('Try to delete a pod without deleting container', async () => {
   await waitRender({});
 
   // select the pod checkbox
-  const podCheckbox = screen.getByRole('checkbox', { name: 'Toggle pod' });
-  expect(podCheckbox).toBeInTheDocument();
-  await fireEvent.click(podCheckbox);
+  const checkboxes = screen.getAllByRole('checkbox', { name: 'Toggle container' });
+  expect(checkboxes[1]).toBeInTheDocument();
+  await fireEvent.click(checkboxes[1]);
 
   // click on the delete button
   const deleteButton = screen.getByRole('button', { name: 'Delete selected containers and pods' });
@@ -578,6 +578,19 @@ test('Expect clear filter in empty screen to clear serach term, except is:...', 
 });
 
 test('Expect to display running / stopped containers depending on tab', async () => {
+  removePodMock.mockClear();
+  deleteContainerMock.mockClear();
+  listContainersMock.mockResolvedValue([]);
+
+  window.dispatchEvent(new CustomEvent('extensions-already-started'));
+  window.dispatchEvent(new CustomEvent('provider-lifecycle-change'));
+  window.dispatchEvent(new CustomEvent('tray:update-provider'));
+
+  // wait for the store to be cleared
+  while (get(containersInfos).length !== 0) {
+    await new Promise(resolve => setTimeout(resolve, 250));
+  }
+
   getProviderInfosMock.mockResolvedValue([
     {
       name: 'podman',
@@ -596,16 +609,13 @@ test('Expect to display running / stopped containers depending on tab', async ()
   const pod2Id = 'pod2-id';
   const pod3Id = 'pod3-id';
 
-  const firstId = 'sha256:68347658374683476';
-
-  // one single container and two containers part of a pod
+  // 3 pods with 2 containers each
   const mockedContainers = [
     // 2 / 2 containers are running on this pod
     {
-      Id: firstId,
+      Id: 'sha256:68347658374683476',
       Image: 'sha256:234',
       Names: ['container1-pod1'],
-      RepoTags: ['veryold:image'],
       State: 'Running',
       pod: {
         name: 'pod1',
@@ -636,7 +646,6 @@ test('Expect to display running / stopped containers depending on tab', async ()
       Id: 'sha256:876532948235',
       Image: 'sha256:876',
       Names: ['container1-pod2'],
-      RepoTags: ['veryold:image'],
       State: 'Running',
       pod: {
         name: 'pod2',
@@ -667,7 +676,6 @@ test('Expect to display running / stopped containers depending on tab', async ()
       Id: 'sha256:56283769268',
       Image: 'sha256:562',
       Names: ['container1-pod3'],
-      RepoTags: ['veryold:image'],
       State: 'Stopped',
       pod: {
         name: 'pod3',
@@ -700,8 +708,8 @@ test('Expect to display running / stopped containers depending on tab', async ()
   window.dispatchEvent(new CustomEvent('provider-lifecycle-change'));
   window.dispatchEvent(new CustomEvent('tray:update-provider'));
 
-  // wait store are populated
-  while (get(containersInfos).length === 0 || get(containersInfos)[0].Id !== firstId) {
+  // wait until store is populated
+  while (get(containersInfos).length === 0) {
     await new Promise(resolve => setTimeout(resolve, 500));
   }
 
@@ -756,11 +764,11 @@ test('Expect to display running / stopped containers depending on tab', async ()
       await fireEvent.click(tab);
     }
     for (const presentCell of tt.presentCells) {
-      const cell = screen.getByRole('cell', { name: presentCell });
+      const cell = screen.getByRole('button', { name: presentCell });
       expect(cell).toBeInTheDocument();
     }
     for (const absentCell of tt.absentLabels) {
-      const cell = screen.queryByRole('cell', { name: absentCell });
+      const cell = screen.queryByText(absentCell);
       expect(cell).not.toBeInTheDocument();
     }
   }

--- a/packages/renderer/src/lib/container/ContainerList.svelte
+++ b/packages/renderer/src/lib/container/ContainerList.svelte
@@ -1,11 +1,10 @@
 <script lang="ts">
-import { faChevronDown, faChevronRight, faPlusCircle, faTrash } from '@fortawesome/free-solid-svg-icons';
-import { Button, Checkbox, ErrorMessage, FilteredEmptyScreen, Modal, NavPage } from '@podman-desktop/ui-svelte';
+import { faPlusCircle, faTrash } from '@fortawesome/free-solid-svg-icons';
+import { Button, FilteredEmptyScreen, Modal, NavPage, Table, TableColumn, TableRow } from '@podman-desktop/ui-svelte';
 import { ContainerIcon } from '@podman-desktop/ui-svelte/icons';
 import moment from 'moment';
 import { onDestroy, onMount } from 'svelte';
 import { get, type Unsubscriber } from 'svelte/store';
-import Fa from 'svelte-fa';
 import { router } from 'tinro';
 
 import type { ContainerInfo } from '/@api/container-info';
@@ -20,21 +19,20 @@ import { podsInfos } from '../../stores/pods';
 import { providerInfos } from '../../stores/providers';
 import { findMatchInLeaves } from '../../stores/search-util';
 import { viewsContributions } from '../../stores/views';
-import ComposeActions from '../compose/ComposeActions.svelte';
 import type { ContextUI } from '../context/context';
 import type { EngineInfoUI } from '../engine/EngineInfoUI';
 import Prune from '../engine/Prune.svelte';
 import NoContainerEngineEmptyScreen from '../image/NoContainerEngineEmptyScreen.svelte';
-import PodIcon from '../images/PodIcon.svelte';
 import SolidPodIcon from '../images/SolidPodIcon.svelte';
-import StatusIcon from '../images/StatusIcon.svelte';
 import { PodUtils } from '../pod/pod-utils';
-import PodActions from '../pod/PodActions.svelte';
-import ProviderInfo from '../ui/ProviderInfo.svelte';
-import StateChange from '../ui/StateChange.svelte';
 import { CONTAINER_LIST_VIEW } from '../view/views';
 import { ContainerUtils } from './container-utils';
-import ContainerActions from './ContainerActions.svelte';
+import ContainerColumnActions from './ContainerColumnActions.svelte';
+import ContainerColumnAge from './ContainerColumnAge.svelte';
+import ContainerColumnEnvironment from './ContainerColumnEnvironment.svelte';
+import ContainerColumnImage from './ContainerColumnImage.svelte';
+import ContainerColumnName from './ContainerColumnName.svelte';
+import ContainerColumnStatus from './ContainerColumnStatus.svelte';
 import ContainerEmptyScreen from './ContainerEmptyScreen.svelte';
 import { ContainerGroupInfoTypeUI, type ContainerGroupInfoUI, type ContainerInfoUI } from './ContainerInfoUI';
 
@@ -60,21 +58,6 @@ $: providerConnections = $providerInfos
   .flat()
   .filter(providerContainerConnection => providerContainerConnection.status === 'started');
 
-// number of selected items in the list
-$: selectedItemsNumber =
-  containerGroups.reduce(
-    (previous, current) => previous + current.containers.filter(container => container.selected).length,
-    0,
-  ) + containerGroups.filter(group => group.selected).length;
-
-// do we need to unselect all checkboxes if we don't have all items being selected ?
-$: selectedAllCheckboxes =
-  containerGroups.filter(group => group.type !== ContainerGroupInfoTypeUI.STANDALONE).every(group => group.selected) &&
-  containerGroups
-    .map(group => group.containers)
-    .flat()
-    .every(container => container.selected);
-
 let refreshTimeouts: NodeJS.Timeout[] = [];
 
 const SECOND = 1000;
@@ -90,7 +73,9 @@ function refreshUptime() {
   const newInterval = computeInterval();
   refreshTimeouts.forEach(timeout => clearTimeout(timeout));
   refreshTimeouts.length = 0;
-  refreshTimeouts.push(setTimeout(refreshUptime, newInterval));
+  if (newInterval > 0) {
+    refreshTimeouts.push(setTimeout(refreshUptime, newInterval));
+  }
 }
 
 function computeInterval(): number {
@@ -132,11 +117,6 @@ function computeInterval(): number {
 
   // every day
   return 60 * 60 * 24 * SECOND;
-}
-
-function toggleCheckboxContainerGroup(checked: boolean, containerGroup: ContainerGroupInfoUI) {
-  // need to apply that on all containers
-  containerGroup.containers.forEach(container => (container.selected = checked));
 }
 
 // delete the items selected in the list
@@ -333,14 +313,6 @@ function updateContainers(
   refreshTimeouts.push(setTimeout(refreshUptime, interval));
 }
 
-function displayContainersCount(containerGroup: ContainerGroupInfoUI) {
-  let result = containerGroup.allContainersCount + ' container' + (containerGroup.allContainersCount > 1 ? 's' : '');
-  if (containerGroup.containers.length !== containerGroup.allContainersCount) {
-    result += ` (${containerGroup.allContainersCount - containerGroup.containers.length} filtered)`;
-  }
-  return result;
-}
-
 onDestroy(() => {
   // store current groups for later
   containerGroupsInfo.set(containerGroups);
@@ -364,25 +336,10 @@ onDestroy(() => {
   }
 });
 
-function openDetailsContainer(container: ContainerInfoUI) {
-  router.goto(`/containers/${container.id}/`);
-}
-
 function keydownChoice(e: KeyboardEvent) {
   e.stopPropagation();
   if (e.key === 'Escape') {
     toggleCreateContainer();
-  }
-}
-
-function openGroupDetails(containerGroup: ContainerGroupInfoUI): void {
-  if (!containerGroup.engineId) {
-    return;
-  }
-  if (containerGroup.type === ContainerGroupInfoTypeUI.POD) {
-    router.goto(`/pods/podman/${encodeURI(containerGroup.name)}/${encodeURIComponent(containerGroup.engineId)}/logs`);
-  } else if (containerGroup.type === ContainerGroupInfoTypeUI.COMPOSE) {
-    router.goto(`/compose/details/${encodeURI(containerGroup.name)}/${encodeURI(containerGroup.engineId)}/logs`);
   }
 }
 
@@ -393,21 +350,6 @@ function toggleCreateContainer(): void {
 function fromDockerfile(): void {
   openChoiceModal = false;
   router.goto('/images/build');
-}
-
-function toggleContainerGroup(containerGroup: ContainerGroupInfoUI) {
-  containerGroup.expanded = !containerGroup.expanded;
-  // update the group expanded attribute if this is the matching group
-  containerGroups = containerGroups.map(group => (group.name === containerGroup.name ? containerGroup : group));
-}
-
-function toggleAllContainerGroups(checked: boolean) {
-  const toggleContainers = containerGroups;
-  toggleContainers
-    .filter(group => group.type !== ContainerGroupInfoTypeUI.STANDALONE)
-    .forEach(group => (group.selected = checked));
-  toggleContainers.forEach(group => group.containers.forEach(container => (container.selected = checked)));
-  containerGroups = toggleContainers;
 }
 
 function resetRunningFilter() {
@@ -421,6 +363,64 @@ function setRunningFilter() {
 function setStoppedFilter() {
   searchTerm = containerUtils.filterSetStopped(searchTerm);
 }
+
+let selectedItemsNumber: number;
+let table: Table;
+
+let statusColumn = new TableColumn<ContainerInfoUI | ContainerGroupInfoUI>('Status', {
+  align: 'center',
+  width: '70px',
+  renderer: ContainerColumnStatus,
+});
+
+let nameColumn = new TableColumn<ContainerInfoUI | ContainerGroupInfoUI>('Name', {
+  width: '2fr',
+  renderer: ContainerColumnName,
+  comparator: (a, b) => a.name.localeCompare(b.name),
+});
+
+let envColumn = new TableColumn<ContainerInfoUI | ContainerGroupInfoUI>('Environment', {
+  renderer: ContainerColumnEnvironment,
+});
+
+let imageColumn = new TableColumn<ContainerInfoUI | ContainerGroupInfoUI>('Image', {
+  width: '3fr',
+  renderer: ContainerColumnImage,
+});
+
+let ageColumn = new TableColumn<ContainerInfoUI | ContainerGroupInfoUI>('Age', {
+  renderer: ContainerColumnAge,
+});
+
+const columns: TableColumn<ContainerInfoUI | ContainerGroupInfoUI>[] = [
+  statusColumn,
+  nameColumn,
+  envColumn,
+  imageColumn,
+  ageColumn,
+  new TableColumn<ContainerInfoUI | ContainerGroupInfoUI>('Actions', {
+    align: 'right',
+    width: '150px',
+    renderer: ContainerColumnActions,
+    overflow: true,
+  }),
+];
+
+const row = new TableRow<ContainerGroupInfoUI | ContainerInfoUI>({
+  selectable: _container => true,
+  children: object => {
+    if ('type' in object && object.type !== ContainerGroupInfoTypeUI.STANDALONE) {
+      return object.containers;
+    } else {
+      return [];
+    }
+  },
+});
+
+let containersAndGroups: (ContainerGroupInfoUI | ContainerInfoUI)[];
+$: containersAndGroups = containerGroups.map(group =>
+  group?.type === ContainerGroupInfoTypeUI.STANDALONE ? group.containers[0] : group,
+);
 </script>
 
 <NavPage bind:searchTerm="{searchTerm}" title="containers">
@@ -463,204 +463,16 @@ function setStoppedFilter() {
   </svelte:fragment>
 
   <div class="flex min-w-full h-full" slot="content">
-    <table class="mx-5 w-full h-fit" class:hidden="{containerGroups.length === 0}">
-      <!-- title -->
-      <thead class="sticky top-0 bg-charcoal-700 z-[2]">
-        <tr class="h-7 uppercase text-xs text-gray-600">
-          <th class="whitespace-nowrap w-5"></th>
-          <th class="px-2 w-5 text-base">
-            <Checkbox
-              title="Toggle all"
-              bind:checked="{selectedAllCheckboxes}"
-              indeterminate="{selectedItemsNumber > 0 && !selectedAllCheckboxes}"
-              on:click="{event => toggleAllContainerGroups(event.detail)}" />
-          </th>
-          <th class="text-center font-extrabold w-10 px-2">Status</th>
-          <th>Name</th>
-          <th class="pl-3">Environment</th>
-          <th class="pl-3">Image</th>
-          <th class="pl-3">Age</th>
-          <th class="text-right pr-2">Actions</th>
-        </tr>
-      </thead>
-
-      <!-- Display each group -->
-      <tbody>
-        {#each containerGroups as containerGroup}
-          {#if containerGroup.type === ContainerGroupInfoTypeUI.COMPOSE || containerGroup.type === ContainerGroupInfoTypeUI.POD}
-            <tr class="group h-12 bg-charcoal-800 hover:bg-zinc-700">
-              <td
-                class="bg-charcoal-800 group-hover:bg-zinc-700 pl-2 w-3 rounded-tl-lg"
-                class:rounded-bl-lg="{!containerGroup.expanded}"
-                on:click="{() => toggleContainerGroup(containerGroup)}">
-                <Fa
-                  size="0.8x"
-                  class="text-gray-700 cursor-pointer"
-                  icon="{containerGroup.expanded ? faChevronDown : faChevronRight}" />
-              </td>
-              <td class="px-2">
-                <Checkbox
-                  title="Toggle {containerGroup.type}"
-                  bind:checked="{containerGroup.selected}"
-                  on:click="{event => toggleCheckboxContainerGroup(event.detail, containerGroup)}" />
-              </td>
-              <td class="flex flex-row justify-center h-12" title="{containerGroup.type}">
-                <div class="grid place-content-center ml-3 mr-4">
-                  <StatusIcon icon="{PodIcon}" status="{containerGroup.status}" />
-                </div>
-              </td>
-              <td class="whitespace-nowrap hover:cursor-pointer">
-                <div class="flex items-center text-sm text-gray-300 overflow-hidden text-ellipsis">
-                  <div>
-                    <button
-                      class="text-sm text-gray-300 overflow-hidden text-ellipsis"
-                      title="{containerGroup.type}"
-                      on:click="{() => openGroupDetails(containerGroup)}">
-                      {containerGroup.name} ({containerGroup.type})
-                    </button>
-                    <div class="text-xs font-extra-light text-gray-900">
-                      {displayContainersCount(containerGroup)}
-                    </div>
-                  </div>
-                </div>
-              </td>
-              <td class="pl-3 whitespace-nowrap hover:cursor-pointer group">
-                <div class="flex items-center text-xs p-1 rounded-md text-gray-500"></div>
-              </td>
-              <td class="px-6 py-2 whitespace-nowrap w-10"> </td>
-              <td class="whitespace-nowrap pl-3">
-                <div class="flex items-center">
-                  <div class="text-sm text-gray-700"></div>
-                </div>
-              </td>
-              <td
-                class="pl-6 text-right whitespace-nowrap rounded-tr-lg"
-                class:rounded-br-lg="{!containerGroup.expanded}">
-                <!-- Only show POD actions if the container group is POD, otherwise keep blank / empty (for future compose implementation) -->
-                {#if containerGroup.type === ContainerGroupInfoTypeUI.POD && containerGroup.engineId && containerGroup.id && containerGroup.shortId && containerGroup.status && containerGroup.engineName && containerGroup.humanCreationDate && containerGroup.created}
-                  <PodActions
-                    pod="{{
-                      id: containerGroup.id,
-                      shortId: containerGroup.shortId,
-                      status: containerGroup.status,
-                      name: containerGroup.name,
-                      engineId: containerGroup.engineId,
-                      engineName: containerGroup.engineName,
-                      age: containerGroup.humanCreationDate,
-                      created: containerGroup.created,
-                      selected: false,
-                      containers: containerGroup.containers.map(container => ({
-                        Id: container.id,
-                        Names: container.name,
-                        Status: container.state,
-                      })),
-                      kind: 'podman',
-                    }}"
-                    dropdownMenu="{true}"
-                    on:update="{() => (containerGroups = [...containerGroups])}" />
-                {/if}
-                {#if containerGroup.type === ContainerGroupInfoTypeUI.COMPOSE && containerGroup.status && containerGroup.engineId && containerGroup.engineType}
-                  <ComposeActions
-                    compose="{{
-                      status: containerGroup.status,
-                      name: containerGroup.name,
-                      engineId: containerGroup.engineId,
-                      engineType: containerGroup.engineType,
-                      containers: containerGroup.containers,
-                    }}"
-                    dropdownMenu="{true}"
-                    on:update="{() => {
-                      containerGroups = [...containerGroups];
-                    }}" />
-                {/if}
-              </td>
-            </tr>
-          {/if}
-          <!-- Display each container of this group -->
-          {#if containerGroup.expanded}
-            {#each containerGroup.containers as container, index}
-              <tr class="group h-12 bg-charcoal-800 hover:bg-zinc-700" aria-label="{container.name}">
-                <td
-                  class="{containerGroup.type === ContainerGroupInfoTypeUI.STANDALONE ? 'rounded-tl-lg' : ''} {index ===
-                  containerGroup.containers.length - 1
-                    ? 'rounded-bl-lg'
-                    : ''}">
-                </td>
-                <td class="px-2">
-                  <Checkbox title="Toggle container" bind:checked="{container.selected}" />
-                </td>
-                <td class="flex flex-row justify-center h-12">
-                  <div class="grid place-content-center ml-3 mr-4">
-                    <StatusIcon icon="{container.icon}" status="{container.state}" />
-                  </div>
-                </td>
-                <td
-                  class="whitespace-nowrap hover:cursor-pointer group"
-                  on:click="{() => openDetailsContainer(container)}">
-                  <div class="flex items-center">
-                    <div class="">
-                      <div class="flex flex-nowrap">
-                        <div
-                          class="text-sm text-gray-300 overflow-hidden text-ellipsis group-hover:text-violet-400"
-                          title="{container.name}">
-                          {container.name}
-                        </div>
-                      </div>
-                      <div class="flex flex-nowrap text-xs font-extra-light text-gray-900 items-center">
-                        <div>{container.state}</div>
-                        <div class="pl-2 pr-2 inline-flex">{container.displayPort}</div>
-                      </div>
-                    </div>
-                  </div>
-                </td>
-                <td class="pl-3 whitespace-nowrap hover:cursor-pointer group">
-                  <div class="flex items-center text-xs p-1 rounded-md text-gray-500">
-                    <ProviderInfo provider="{container.engineType}" context="{container.engineId}" />
-                  </div>
-                </td>
-                <!-- Open the container details, TODO: open image details instead? -->
-                <td
-                  class="pl-3 whitespace-nowrap hover:cursor-pointer group"
-                  on:click="{() => openDetailsContainer(container)}">
-                  <div class="flex items-center">
-                    <div class="text-sm text-gray-700 overflow-hidden text-ellipsis" title="{container.image}">
-                      {container.shortImage}
-                    </div>
-                  </div></td>
-                <td class="whitespace-nowrap pl-3">
-                  <div class="flex items-center">
-                    <div class="text-sm text-gray-700">
-                      <StateChange state="{container.state}">{container.uptime}</StateChange>
-                    </div>
-                  </div>
-                </td>
-                <td
-                  class="pl-6 text-right whitespace-nowrap {containerGroup.type === ContainerGroupInfoTypeUI.STANDALONE
-                    ? 'rounded-tr-lg'
-                    : ''} {index === containerGroup.containers.length - 1 ? 'rounded-br-lg' : ''}">
-                  <div class="flex w-full">
-                    <div class="flex items-center w-5">
-                      {#if container.actionError}
-                        <ErrorMessage error="{container.actionError}" icon />
-                      {:else}
-                        <div>&nbsp;</div>
-                      {/if}
-                    </div>
-                    <div class="text-right w-full mr-[5px]">
-                      <ContainerActions
-                        container="{container}"
-                        dropdownMenu="{true}"
-                        on:update="{() => (containerGroups = [...containerGroups])}" />
-                    </div>
-                  </div>
-                </td>
-              </tr>
-            {/each}
-          {/if}
-          <tr><td class="leading-[8px]">&nbsp;</td></tr>
-        {/each}
-      </tbody>
-    </table>
+    <Table
+      kind="container"
+      bind:this="{table}"
+      bind:selectedItemsNumber="{selectedItemsNumber}"
+      data="{containersAndGroups}"
+      columns="{columns}"
+      row="{row}"
+      defaultSortColumn="Name"
+      on:update="{() => (containerGroups = [...containerGroups])}">
+    </Table>
 
     {#if providerConnections.length === 0}
       <NoContainerEngineEmptyScreen />

--- a/packages/renderer/src/lib/container/ContainerList.svelte
+++ b/packages/renderer/src/lib/container/ContainerList.svelte
@@ -61,7 +61,7 @@ $: providerConnections = $providerInfos
 let refreshTimeouts: NodeJS.Timeout[] = [];
 
 const SECOND = 1000;
-function refreshUptime() {
+function refreshUptime(): void {
   containerGroups = containerGroups.map(containerGroupUiInfo => {
     containerGroupUiInfo.containers = containerGroupUiInfo.containers.map(containerUiInfo => {
       return { ...containerUiInfo, uptime: containerUtils.refreshUptime(containerUiInfo) };
@@ -121,7 +121,7 @@ function computeInterval(): number {
 
 // delete the items selected in the list
 let bulkDeleteInProgress = false;
-async function deleteSelectedContainers() {
+async function deleteSelectedContainers(): void {
   const podGroups = containerGroups
     .filter(group => group.type === ContainerGroupInfoTypeUI.POD)
     .filter(pod => pod.selected);
@@ -180,7 +180,7 @@ async function deleteSelectedContainers() {
   bulkDeleteInProgress = false;
 }
 
-function createPodFromContainers() {
+function createPodFromContainers(): void {
   const selectedContainers = containerGroups
     .map(group => group.containers)
     .flat()
@@ -245,7 +245,7 @@ function updateContainers(
   globalContext: ContextUI,
   viewContributions: ViewInfoUI[],
   searchTerm: string,
-) {
+): void {
   containersInfo = containers;
   const currentContainers = containers.map((containerInfo: ContainerInfo) => {
     return containerUtils.getContainerInfoUI(containerInfo, globalContext, viewContributions);
@@ -336,7 +336,7 @@ onDestroy(() => {
   }
 });
 
-function keydownChoice(e: KeyboardEvent) {
+function keydownChoice(e: KeyboardEvent): void {
   e.stopPropagation();
   if (e.key === 'Escape') {
     toggleCreateContainer();
@@ -352,15 +352,15 @@ function fromDockerfile(): void {
   router.goto('/images/build');
 }
 
-function resetRunningFilter() {
+function resetRunningFilter(): void {
   searchTerm = containerUtils.filterResetRunning(searchTerm);
 }
 
-function setRunningFilter() {
+function setRunningFilter(): void {
   searchTerm = containerUtils.filterSetRunning(searchTerm);
 }
 
-function setStoppedFilter() {
+function setStoppedFilter(): void {
   searchTerm = containerUtils.filterSetStopped(searchTerm);
 }
 

--- a/packages/renderer/src/lib/container/ContainerList.svelte
+++ b/packages/renderer/src/lib/container/ContainerList.svelte
@@ -121,7 +121,7 @@ function computeInterval(): number {
 
 // delete the items selected in the list
 let bulkDeleteInProgress = false;
-async function deleteSelectedContainers(): void {
+async function deleteSelectedContainers(): Promise<void> {
   const podGroups = containerGroups
     .filter(group => group.type === ContainerGroupInfoTypeUI.POD)
     .filter(pod => pod.selected);

--- a/packages/renderer/src/lib/container/container-utils.spec.ts
+++ b/packages/renderer/src/lib/container/container-utils.spec.ts
@@ -23,7 +23,7 @@ import type { ViewInfoUI } from '/@api/view-info';
 
 import { ContextUI } from '../context/context';
 import { ContainerUtils } from './container-utils';
-import { ContainerGroupInfoTypeUI } from './ContainerInfoUI';
+import { ContainerGroupInfoTypeUI, type ContainerGroupInfoUI, type ContainerInfoUI } from './ContainerInfoUI';
 
 let containerUtils: ContainerUtils;
 
@@ -315,4 +315,24 @@ test('should expect imageHref to use exact image id if no sha256: prefix', async
   } as unknown as ContainerInfo;
   const containerUI = containerUtils.getContainerInfoUI(containerInfo);
   expect(containerUI.imageHref).toBe('/images/dummy-sha256/dummy-engine-id/dummy-base-64/summary');
+});
+
+test('should be able to identify container groups', async () => {
+  const containerGroupInfo = {
+    id: 'my-pod',
+    name: 'My pod',
+    type: ContainerGroupInfoTypeUI.POD,
+  } as unknown as ContainerGroupInfoUI;
+  expect(containerUtils.isContainerGroupInfoUI(containerGroupInfo)).toBe(true);
+  expect(containerUtils.isContainerInfoUI(containerGroupInfo)).toBe(false);
+});
+
+test('should be able to identify containers', async () => {
+  const containerInfo = {
+    id: 'container1',
+    name: 'a container',
+    state: 'RUNNING',
+  } as unknown as ContainerInfoUI;
+  expect(containerUtils.isContainerInfoUI(containerInfo)).toBe(true);
+  expect(containerUtils.isContainerGroupInfoUI(containerInfo)).toBe(false);
 });

--- a/packages/renderer/src/lib/container/container-utils.ts
+++ b/packages/renderer/src/lib/container/container-utils.ts
@@ -333,4 +333,12 @@ export class ContainerUtils {
       .filter(part => !part.startsWith('is:'))
       .join(' ');
   }
+
+  isContainerGroupInfoUI(object: ContainerInfoUI | ContainerGroupInfoUI): object is ContainerGroupInfoUI {
+    return 'type' in object && typeof object.type === 'string';
+  }
+
+  isContainerInfoUI(object: ContainerInfoUI | ContainerGroupInfoUI): object is ContainerInfoUI {
+    return 'state' in object && typeof object.state === 'string';
+  }
 }


### PR DESCRIPTION
### What does this PR do?

Switch the Containers page to use the Table component. This is a final piece
of technical debt adopting the Table component, and gives a few advantages:
- Table expands/collapses to fit the display width (used to extend off the
  right edge with a scrollbar).
- Sorting of name column to start (wanted to focus on core aspects and get
  this in before sorting other columns).
- Consistent table UI with other pages.
- Basic support for light mode.

The containers table included ContainerGroupInfoUI parents of three types
(pods, compose groups, and standalone containers), all with ContainerInfoUI
children. To avoid UI issues the parent ContainerGroupInfoUI was skipped
when drawing standalone containers (i.e. it only draws the child container
object in this one case).

Since the Table component doesn't support this unique behaviour, the least
invasive/simplest option was to create a derived list where standalone
containers are mapped to actual containers.

Found an issue where Svelte was updating constantly; turns out this was
an existing bug in the timeout when no containers are running.

Ignore changes to Table - reviewed separately under [#7587](https://github.com/deboer-tim/desktop/issues/7587).

### Screenshot / video of UI

Before:

<img width="1162" alt="Screenshot 2024-06-11 at 11 29 19 AM" src="https://github.com/containers/podman-desktop/assets/19958075/391371b5-d558-4687-aa95-1d5ea4905b78">

After:

<img width="1162" alt="Screenshot 2024-06-11 at 11 49 38 AM" src="https://github.com/containers/podman-desktop/assets/19958075/3915c707-9b74-4d43-9bf8-000dde6a2a2d">

### What issues does this PR fix or reference?

Fixes #4843.

### How to test this PR?

Try Containers page for regular containers, pods, and compose.

- [x] Tests are covering the bug fix or the new feature