### PR TITLE
fix: update font size of the terminal if already exists

### DIFF
--- a/packages/renderer/src/lib/container/ContainerDetailsTerminal.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetailsTerminal.svelte
@@ -91,6 +91,10 @@ async function refreshTerminal() {
   if (existingTerminal) {
     sendCallbackId = existingTerminal.callbackId;
     shellTerminal = existingTerminal.terminal;
+    shellTerminal.options = {
+      fontSize,
+      lineHeight,
+    };
   } else {
     shellTerminal = new Terminal({
       fontSize,


### PR DESCRIPTION
### What does this PR do?

it fixes a problem with the font size of the terminal that it is not updated if a terminal instance already exists.

### Screenshot / video of UI

![update_font](https://github.com/containers/podman-desktop/assets/49404737/1f8e2256-63d0-4bc6-9368-aaf46c4fb5c4)

### What issues does this PR fix or reference?

it resolves #7166 

### How to test this PR?

1. have a running container, check the terminal tab
2. go to the preferences
3. update the terminal font
4. go back and check that the terminal uses the new font size 

- [ ] Tests are covering the bug fix or the new feature
