### PR TITLE
chore(extension-api): enhance PodCreateOptions

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -334,7 +334,7 @@ declare module '@podman-desktop/api' {
      * "stop": stop the pod when the last container exits. This is the
      * default behaviour for play kube.
      */
-    exit_policy: string;
+    exit_policy?: string;
   }
 
   export interface ManifestCreateOptions {

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -297,11 +297,44 @@ declare module '@podman-desktop/api' {
   }
 
   export interface PodCreateOptions {
-    name: string;
+    /**
+     * Name is the name of the pod. If not provided, a name will be generated when the pod is created. Optional.
+     */
+    name?: string;
+    /**
+     * PortMappings is a set of ports to map into the infra container.
+     * As, by default, containers share their network with the infra container, this will forward the ports to the entire pod.
+     * Only available if NetNS is set to Bridge, Slirp, or Pasta.
+     */
     portmappings?: PodCreatePortOptions[];
+    /**
+     * Labels are key-value pairs that are used to add metadata to pods. Optional.
+     */
     labels?: { [key: string]: string };
     // Set the provider to use, if not we will try select the first one available (sorted in favor of Podman).
     provider?: ContainerProviderConnection;
+    /**
+     * Map of networks names to ids the container should join to.
+     * You can request additional settings for each network, you can set network aliases,
+     * If the map is empty and the bridge network mode is set the container will be joined to the default network.
+     */
+    Networks?: {
+      [key: string]: {
+        aliases?: string[];
+        interface_name?: string;
+      };
+    };
+    /**
+     * ExitPolicy determines the pod's exit and stop behaviour.
+     * @example
+     * "continue": the pod continues running. This is the default policy
+     * when creating a pod.
+     *
+     * @example
+     * "stop": stop the pod when the last container exits. This is the
+     * default behaviour for play kube.
+     */
+    exit_policy: string;
   }
 
   export interface ManifestCreateOptions {

--- a/packages/main/src/plugin/api/pod-info.ts
+++ b/packages/main/src/plugin/api/pod-info.ts
@@ -42,5 +42,11 @@ export interface PodCreateOptions {
   labels?: { [key: string]: string };
   // Set the provider to use, if not we will try select the first one available (sorted in favor of Podman).
   provider?: ProviderContainerConnectionInfo | ContainerProviderConnection;
+  Networks?: {
+    [key: string]: {
+      aliases?: string[];
+      interface_name?: string;
+    };
+  };
   exit_policy?: string;
 }

--- a/packages/main/src/plugin/api/pod-info.ts
+++ b/packages/main/src/plugin/api/pod-info.ts
@@ -37,9 +37,10 @@ export interface PodInspectInfo extends LibPodPodInspectInfo {
 }
 
 export interface PodCreateOptions {
-  name: string;
+  name?: string;
   portmappings?: PodCreatePortOptions[];
   labels?: { [key: string]: string };
   // Set the provider to use, if not we will try select the first one available (sorted in favor of Podman).
   provider?: ProviderContainerConnectionInfo | ContainerProviderConnection;
+  exit_policy?: string;
 }

--- a/packages/main/src/plugin/dockerode/libpod-dockerode.ts
+++ b/packages/main/src/plugin/dockerode/libpod-dockerode.ts
@@ -85,9 +85,16 @@ export interface PodCreatePortOptions {
 }
 
 export interface PodCreateOptions {
-  name: string;
+  name?: string;
   portmappings?: PodCreatePortOptions[];
   labels?: { [key: string]: string };
+  Networks?: {
+    [key: string]: {
+      aliases?: string[];
+      interface_name?: string;
+    };
+  };
+  exit_policy?: string;
 }
 
 export interface ContainerCreateMountOption {


### PR DESCRIPTION
### What does this PR do?

See https://docs.podman.io/en/latest/_static/api.html#tag/pods/operation/PodCreateLibpod for details

Change
- `Networks` property
- `exit_policy` property
- Making `name` optional as it is written optional in the doc

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

- Pipeline should be ✅ 
