### PR TITLE
feat: move telemetry settings to json

### DIFF
--- a/packages/main/src/plugin/telemetry/telemetry-api.ts
+++ b/packages/main/src/plugin/telemetry/telemetry-api.ts
@@ -1,0 +1,28 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+export interface TelemetryRule {
+  // start of telemetry event id
+  event: string;
+  // ratio to send events, e.g. 0.5
+  ratio?: number;
+  // disable this event entirely
+  disabled?: boolean;
+  // limit sending to 'dailyPerInstance'
+  frequency?: string;
+}

--- a/packages/main/src/plugin/telemetry/telemetry-api.ts
+++ b/packages/main/src/plugin/telemetry/telemetry-api.ts
@@ -16,13 +16,21 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+/**
+ * Frequency of collection:
+ *  dailyPerInstance - log the first time the event happens after startup.
+ *
+ * Enum to allow for future expansion, e.g. 'daily' or 'weekly'.
+ */
+export type Frequency = 'dailyPerInstance';
+
 export interface TelemetryRule {
-  // start of telemetry event id
+  // regex matching telemetry event
   event: string;
   // ratio to send events, e.g. 0.5
   ratio?: number;
   // disable this event entirely
   disabled?: boolean;
-  // limit sending to 'dailyPerInstance'
-  frequency?: string;
+  // control the frequency of sending events
+  frequency?: Frequency;
 }

--- a/packages/main/src/plugin/telemetry/telemetry.ts
+++ b/packages/main/src/plugin/telemetry/telemetry.ts
@@ -63,6 +63,7 @@ export class Telemetry {
   private static readonly SEGMENT_KEY = 'Mhl7GXADk5M1vG6r9FXztbCqWRQY8XPy';
 
   private cachedTelemetrySettings: TelemetryRule[] | undefined;
+  private regexp: Map<string, RegExp> = new Map();
 
   private identity: Identity;
 
@@ -192,7 +193,9 @@ export class Telemetry {
     }
 
     // load the telemetry json file
-    this.cachedTelemetrySettings = telemetry.rules as TelemetryRule[];
+    this.cachedTelemetrySettings = telemetry.rules.map(obj => obj) as TelemetryRule[];
+    this.regexp = new Map();
+    this.cachedTelemetrySettings.forEach(rule => this.regexp.set(rule.event, new RegExp(rule.event)));
 
     return this.cachedTelemetrySettings;
   }
@@ -299,8 +302,8 @@ export class Telemetry {
 
     let dropIt = false;
     telem.forEach(entry => {
-      const regex = RegExp(entry.event);
-      if (regex.test(eventName)) {
+      const regex = this.regexp.get(entry.event);
+      if (regex?.test(eventName)) {
         if (entry.disabled) {
           // telemetry is entirely disabled for this event
           dropIt = true;

--- a/packages/main/src/plugin/telemetry/telemetry.ts
+++ b/packages/main/src/plugin/telemetry/telemetry.ts
@@ -299,7 +299,8 @@ export class Telemetry {
 
     let dropIt = false;
     telem.forEach(entry => {
-      if (eventName.startsWith(entry.event)) {
+      const regex = RegExp(entry.event);
+      if (regex.test(eventName)) {
         if (entry.disabled) {
           // telemetry is entirely disabled for this event
           dropIt = true;
@@ -308,7 +309,7 @@ export class Telemetry {
           // if a ratio is specified, we randomly drop
           dropIt = true;
         }
-        if (entry?.frequency === 'dailyPerInstance') {
+        if (entry.frequency === 'dailyPerInstance') {
           // only send this event once per day, per running instance (not saved to disk)
           const previousTime = this.lastTimeEvents.get(eventName);
           // it was not there, so we can send it
@@ -329,7 +330,6 @@ export class Telemetry {
       }
     });
 
-    console.log('telem: ' + eventName + ' ' + dropIt + ' ' + telem.length);
     return dropIt;
   }
 

--- a/packages/main/src/plugin/telemetry/telemetry.ts
+++ b/packages/main/src/plugin/telemetry/telemetry.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2022-2023 Red Hat, Inc.
+ * Copyright (C) 2022-2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ import type { LinuxOs } from 'getos';
 import getos from 'getos';
 import * as osLocale from 'os-locale';
 
+import { default as telemetry } from '../../../../../telemetry.json';
 import { stoppedExtensions } from '../../util.js';
 import type { ConfigurationRegistry, IConfigurationNode } from '../configuration-registry.js';
 import type { Event } from '../events/emitter.js';
@@ -38,6 +39,7 @@ import { Emitter } from '../events/emitter.js';
 import type { Proxy } from '../proxy.js';
 import { TelemetryTrustedValue as TypeTelemetryTrustedValue } from '../types/telemetry.js';
 import { Identity } from './identity.js';
+import type { TelemetryRule } from './telemetry-api.js';
 import { TelemetrySettings } from './telemetry-settings.js';
 
 export const TRACK_EVENT_TYPE = 'track';
@@ -59,6 +61,8 @@ export type EventType =
  */
 export class Telemetry {
   private static readonly SEGMENT_KEY = 'Mhl7GXADk5M1vG6r9FXztbCqWRQY8XPy';
+
+  private cachedTelemetrySettings: TelemetryRule[] | undefined;
 
   private identity: Identity;
 
@@ -180,6 +184,19 @@ export class Telemetry {
     };
   }
 
+  // internal method, not exposed
+  protected getTelemetrySettings(): TelemetryRule[] {
+    // return the cached version if we have one
+    if (this.cachedTelemetrySettings) {
+      return this.cachedTelemetrySettings;
+    }
+
+    // load the telemetry json file
+    this.cachedTelemetrySettings = telemetry.rules as TelemetryRule[];
+
+    return this.cachedTelemetrySettings;
+  }
+
   createTelemetryLogger(
     extensionInfo: { id: string; name: string; publisher: string; version: string },
     sender?: TelemetrySender,
@@ -275,25 +292,45 @@ export class Telemetry {
 
   // return true if the event needs to be dropped
   protected shouldDropEvent(eventName: string): boolean {
-    // if event is a list event (start with 'list'), do not send it more than one per day
-    if (eventName.startsWith('list')) {
-      // do we have an existing event with the same name?
-      const previousTime = this.lastTimeEvents.get(eventName);
-      // it was not there, so we can send it
-      if (!previousTime) {
-        this.lastTimeEvents.set(eventName, Date.now());
-        return false;
-      }
-      // it was there, so we check if it was more than 24h ago
-      const now = Date.now();
-      const diff = now - previousTime;
-      if (diff > 24 * 60 * 60 * 1000) {
-        this.lastTimeEvents.set(eventName, now);
-        return false;
-      }
+    const telem = this.getTelemetrySettings();
+    if (!telem || !eventName) {
       return true;
     }
-    return false;
+
+    let dropIt = false;
+    telem.forEach(entry => {
+      if (eventName.startsWith(entry.event)) {
+        if (entry.disabled) {
+          // telemetry is entirely disabled for this event
+          dropIt = true;
+        }
+        if (entry.ratio && entry.ratio < 1 && Math.random() > entry.ratio) {
+          // if a ratio is specified, we randomly drop
+          dropIt = true;
+        }
+        if (entry?.frequency === 'dailyPerInstance') {
+          // only send this event once per day, per running instance (not saved to disk)
+          const previousTime = this.lastTimeEvents.get(eventName);
+          // it was not there, so we can send it
+          if (!previousTime) {
+            this.lastTimeEvents.set(eventName, Date.now());
+            return false;
+          } else {
+            // it was there, so we check if it was more than 24h ago
+            const now = Date.now();
+            const diff = now - previousTime;
+            if (diff > 24 * 60 * 60 * 1000) {
+              this.lastTimeEvents.set(eventName, now);
+            } else {
+              dropIt = true;
+            }
+          }
+        }
+      }
+    });
+
+    console.log('telem: ' + eventName + ' ' + dropIt + ' ' + telem.length);
+    return dropIt;
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/preload/tsconfig.json
+++ b/packages/preload/tsconfig.json
@@ -8,6 +8,7 @@
     "strict": true,
     "allowSyntheticDefaultImports": true,
     "isolatedModules": true,
+    "resolveJsonModule": true,
 
     "types": ["node"],
 

--- a/telemetry.json
+++ b/telemetry.json
@@ -1,7 +1,7 @@
 {
   "rules": [
     {
-      "event": "list",
+      "event": "list.*",
       "frequency": "dailyPerInstance"
     }
   ]

--- a/telemetry.json
+++ b/telemetry.json
@@ -1,0 +1,8 @@
+{
+  "rules": [
+    {
+      "event": "list",
+      "frequency": "dailyPerInstance"
+    }
+  ]
+}


### PR DESCRIPTION
### What does this PR do?

Move filtering of telemetry events to a json file so that it is easy to configure the filtering of events without changing code.

Prior to this, 'list' events were hardcoded to be filtered to once per day per instance of Podman Desktop. Now, this setting is done via a JSON config file, and there are three options that we could use for other events:
- disabled (true/false) - totally disable an event
- ratio (0.0-1.0) - only send x% of this event
- frequency - only supports 'dailyPerInstance' to start (supports list events), but could support things like 'daily' or 'weekly' in the future.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Part of #4970.

### How to test this PR?

Automated tests updated for new options.

- [x] Tests are covering the bug fix or the new feature