### PR TITLE
chore: tooltip simplification

### DIFF
--- a/packages/renderer/src/lib/deployments/DeploymentColumnConditions.svelte
+++ b/packages/renderer/src/lib/deployments/DeploymentColumnConditions.svelte
@@ -34,23 +34,14 @@ function getConditionAttributes(condition: DeploymentCondition) {
 
 <div class="flex flex-row gap-1">
   {#each object.conditions as condition}
-    <Tooltip bottom>
-      <svelte:fragment slot="content">
-        <div class="flex flex-row bg-charcoal-500 items-center p-1 rounded-md text-xs text-gray-500">
-          <Fa
-            size="1x"
-            icon="{getConditionAttributes(condition).icon}"
-            class="{getConditionAttributes(condition).color} mr-1" />
-          {getConditionAttributes(condition).name}
-        </div>
-      </svelte:fragment>
-      <svelte:fragment slot="tip">
-        {#if condition.message}
-          <div class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs text-white" aria-label="tooltip">
-            {condition.message}
-          </div>
-        {/if}
-      </svelte:fragment>
+    <Tooltip bottom tip="{condition.message}">
+      <div class="flex flex-row bg-charcoal-500 items-center p-1 rounded-md text-xs text-gray-500">
+        <Fa
+          size="1x"
+          icon="{getConditionAttributes(condition).icon}"
+          class="{getConditionAttributes(condition).color} mr-1" />
+        {getConditionAttributes(condition).name}
+      </div>
     </Tooltip>
   {/each}
 </div>

--- a/packages/renderer/src/lib/donut/Donut.svelte
+++ b/packages/renderer/src/lib/donut/Donut.svelte
@@ -26,32 +26,23 @@ $: stroke = percent < 0 ? '' : percent < 50 ? 'stroke-green-500' : percent < 75 
 $: tooltip = percent ? percent.toFixed(0) + '% ' + title + ' usage' : '';
 </script>
 
-<Tooltip bottom>
-  <svelte:fragment slot="content">
-    <svg viewBox="-4 -4 {size + 8} {size + 8}" height="{size}" width="{size}">
-      <circle fill="none" class="stroke-charcoal-300" stroke-width="1" r="{size / 2}" cx="{size / 2}" cy="{size / 2}"
-      ></circle>
-      <path
-        fill="none"
-        class="{stroke}"
-        stroke-width="3.5"
-        d="{describeArc(size / 2, (percent * 360) / 100)}"
-        data-testid="arc"></path>
-      <text x="{size / 2}" y="38%" text-anchor="middle" font-size="{size / 5.5}" class="fill-gray-800">{title}</text>
-      <text
-        x="{size / 2}"
-        y="52%"
-        text-anchor="middle"
-        font-size="{size / 4.5}"
-        dominant-baseline="central"
-        class="fill-gray-400">{value !== undefined ? value : ''}</text>
-    </svg>
-  </svelte:fragment>
-  <svelte:fragment slot="tip">
-    {#if tooltip}
-      <div class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs text-white" aria-label="tooltip">
-        {tooltip}
-      </div>
-    {/if}
-  </svelte:fragment>
+<Tooltip bottom tip="{tooltip}">
+  <svg viewBox="-4 -4 {size + 8} {size + 8}" height="{size}" width="{size}">
+    <circle fill="none" class="stroke-charcoal-300" stroke-width="1" r="{size / 2}" cx="{size / 2}" cy="{size / 2}"
+    ></circle>
+    <path
+      fill="none"
+      class="{stroke}"
+      stroke-width="3.5"
+      d="{describeArc(size / 2, (percent * 360) / 100)}"
+      data-testid="arc"></path>
+    <text x="{size / 2}" y="38%" text-anchor="middle" font-size="{size / 5.5}" class="fill-gray-800">{title}</text>
+    <text
+      x="{size / 2}"
+      y="52%"
+      text-anchor="middle"
+      font-size="{size / 4.5}"
+      dominant-baseline="central"
+      class="fill-gray-400">{value !== undefined ? value : ''}</text>
+  </svg>
 </Tooltip>

--- a/packages/renderer/src/lib/extensions/ExtensionBadge.svelte
+++ b/packages/renderer/src/lib/extensions/ExtensionBadge.svelte
@@ -8,26 +8,12 @@ export let extension: { type: 'dd' | 'pd'; removable: boolean };
 
 <div class="flex flex-row gap-1 items-center {$$props.class}" role="region" aria-label="Extension Badge">
   {#if extension.type === 'dd'}
-    <Tooltip right>
-      <svelte:fragment slot="content">
-        <Badge class="text-[8px] text-white" color="bg-sky-600" label="Docker Desktop extension" />
-      </svelte:fragment>
-      <svelte:fragment slot="tip">
-        <div class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs text-white" aria-label="tooltip">
-          Docker Desktop extension
-        </div>
-      </svelte:fragment>
+    <Tooltip right tip="Docker Desktop extension">
+      <Badge class="text-[8px] text-white" color="bg-sky-600" label="Docker Desktop extension" />
     </Tooltip>
   {:else if !extension.removable}
-    <Tooltip right>
-      <svelte:fragment slot="content">
-        <Badge class="text-[8px] text-charcoal-800" color="bg-sky-200" label="built-in Extension" />
-      </svelte:fragment>
-      <svelte:fragment slot="tip">
-        <div class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs text-white" aria-label="tooltip">
-          built-in Extension
-        </div>
-      </svelte:fragment>
+    <Tooltip right tip="built-in Extension">
+      <Badge class="text-[8px] text-charcoal-800" color="bg-sky-200" label="built-in Extension" />
     </Tooltip>
   {/if}
 </div>

--- a/packages/renderer/src/lib/extensions/ExtensionDetailsLink.svelte
+++ b/packages/renderer/src/lib/extensions/ExtensionDetailsLink.svelte
@@ -15,22 +15,15 @@ function openDetailsExtension() {
 }
 </script>
 
-<Tooltip top>
-  <svelte:fragment slot="content">
-    <button aria-label="{extension.name} extension details" type="button" on:click="{() => openDetailsExtension()}">
-      <div class="flex flex-row items-center">
-        {#if displayIcon}
-          <Fa icon="{faArrowUpRightFromSquare}" />
-        {/if}
-        <div class="text-left before:{$$props.class}">
-          {extension.displayName} extension
-        </div>
+<Tooltip top tip="{extension.name} extension details">
+  <button aria-label="{extension.name} extension details" type="button" on:click="{() => openDetailsExtension()}">
+    <div class="flex flex-row items-center">
+      {#if displayIcon}
+        <Fa icon="{faArrowUpRightFromSquare}" />
+      {/if}
+      <div class="text-left before:{$$props.class}">
+        {extension.displayName} extension
       </div>
-    </button>
-  </svelte:fragment>
-  <svelte:fragment slot="tip">
-    <div class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs text-white" aria-label="tooltip">
-      {extension.name} extension details
     </div>
-  </svelte:fragment>
+  </button>
 </Tooltip>

--- a/packages/renderer/src/lib/image/BuildImageFromContainerfileCard.svelte
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfileCard.svelte
@@ -90,15 +90,8 @@ onMount(() => {
     </div>
     <div class="ml-2 text-sm text-left break-normal w-36">{title}</div>
     {#if isDefault}
-      <Tooltip>
-        <svelte:fragment slot="content">
-          <Fa size="0.5x" class="text-dustypurple-700 cursor-pointer" icon="{faCircle}" />
-        </svelte:fragment>
-        <svelte:fragment slot="tip">
-          <div class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs text-white" aria-label="tooltip">
-            Default platform of your computer
-          </div>
-        </svelte:fragment>
+      <Tooltip tip="Default platform of your computer">
+        <Fa size="0.5x" class="text-dustypurple-700 cursor-pointer" icon="{faCircle}" />
       </Tooltip>
     {/if}
   </div>

--- a/packages/renderer/src/lib/kube/KubeEditYAML.svelte
+++ b/packages/renderer/src/lib/kube/KubeEditYAML.svelte
@@ -79,35 +79,21 @@ async function applyToCluster() {
   class="flex flex-row-reverse p-6 bg-transparent fixed bottom-0 right-0 mb-5 pr-10 max-h-20 bg-opacity-90 z-50"
   role="group"
   aria-label="Edit Buttons">
-  <Tooltip topLeft>
-    <svelte:fragment slot="content">
-      <Button
-        type="primary"
-        aria-label="Apply changes to cluster"
-        on:click="{applyToCluster}"
-        disabled="{!changesDetected}"
-        inProgress="{inProgress}">Apply changes to cluster</Button>
-    </svelte:fragment>
-    <svelte:fragment slot="tip">
-      <div class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs text-white" aria-label="tooltip">
-        Apply the changes to the cluster, similar to 'kubectl apply'
-      </div>
-    </svelte:fragment>
+  <Tooltip topLeft tip="Apply the changes to the cluster, similar to 'kubectl apply'">
+    <Button
+      type="primary"
+      aria-label="Apply changes to cluster"
+      on:click="{applyToCluster}"
+      disabled="{!changesDetected}"
+      inProgress="{inProgress}">Apply changes to cluster</Button>
   </Tooltip>
-  <Tooltip topLeft>
-    <svelte:fragment slot="content">
-      <Button
-        type="secondary"
-        aria-label="Revert changes"
-        class="mr-2 opacity-100"
-        on:click="{revertChanges}"
-        disabled="{!changesDetected}">Revert changes</Button>
-    </svelte:fragment>
-    <svelte:fragment slot="tip">
-      <div class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs text-white" aria-label="tooltip">
-        Revert the changes to the original content
-      </div>
-    </svelte:fragment>
+  <Tooltip topLeft tip="Revert the changes to the original content">
+    <Button
+      type="secondary"
+      aria-label="Revert changes"
+      class="mr-2 opacity-100"
+      on:click="{revertChanges}"
+      disabled="{!changesDetected}">Revert changes</Button>
   </Tooltip>
 </div>
 

--- a/packages/renderer/src/lib/preferences/PreferencesAuthenticationProvidersRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesAuthenticationProvidersRendering.svelte
@@ -96,22 +96,13 @@ import SettingsPage from './SettingsPage.svelte';
                           aria-label="Logged In Username">
                           {account.label}
                         </span>
-                        <Tooltip bottomRight>
-                          <svelte:fragment slot="content">
-                            <button
-                              aria-label="Sign out of {account.label}"
-                              class="pl-2 hover:cursor-pointer hover:text-white text-white"
-                              on:click="{() => window.requestAuthenticationProviderSignOut(provider.id, account.id)}">
-                              <Fa class="h-3 w-3 text-md mr-2" icon="{faRightFromBracket}" />
-                            </button>
-                          </svelte:fragment>
-                          <svelte:fragment slot="tip">
-                            <div
-                              class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs text-white"
-                              aria-label="tooltip">
-                              Sign out of {account.label}
-                            </div>
-                          </svelte:fragment>
+                        <Tooltip bottomRight tip="Sign out of {account.label}">
+                          <button
+                            aria-label="Sign out of {account.label}"
+                            class="pl-2 hover:cursor-pointer hover:text-white text-white"
+                            on:click="{() => window.requestAuthenticationProviderSignOut(provider.id, account.id)}">
+                            <Fa class="h-3 w-3 text-md mr-2" icon="{faRightFromBracket}" />
+                          </button>
                         </Tooltip>
                       </div>
                     </div>
@@ -125,24 +116,15 @@ import SettingsPage from './SettingsPage.svelte';
             {#if sessionRequests.length === 1}
               {@const request = sessionRequests[0]}
               <!-- Authentication Provider Auth Request Sign In button start -->
-              <Tooltip bottomLeft>
-                <svelte:fragment slot="content">
-                  <Button
-                    aria-label="Sign in"
-                    class="pl-2 mr-4 hover:cursor-pointer hover:text-white text-white"
-                    on:click="{() => window.requestAuthenticationProviderSignIn(request.id)}">
-                    <div class="flex flex-row items-center">
-                      <Fa class="h-3 w-3 text-md mr-2" icon="{faRightToBracket}" />Sign in
-                    </div>
-                  </Button>
-                </svelte:fragment>
-                <svelte:fragment slot="tip">
-                  <div
-                    class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs text-white"
-                    aria-label="tooltip">
-                    Sign in to use {request.extensionLabel}
+              <Tooltip bottomLeft tip="Sign in to use {request.extensionLabel}">
+                <Button
+                  aria-label="Sign in"
+                  class="pl-2 mr-4 hover:cursor-pointer hover:text-white text-white"
+                  on:click="{() => window.requestAuthenticationProviderSignIn(request.id)}">
+                  <div class="flex flex-row items-center">
+                    <Fa class="h-3 w-3 text-md mr-2" icon="{faRightToBracket}" />Sign in
                   </div>
-                </svelte:fragment>
+                </Button>
               </Tooltip>
               <!-- Authentication Provider Auth Request Sign In button end -->
             {:else if sessionRequests.length > 1}

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
@@ -415,22 +415,13 @@ function hasAnyConfiguration(provider: ProviderInfo) {
                           ? provider.kubernetesProviderConnectionCreationButtonTitle
                           : undefined) ?? 'Create new'}
                     <!-- create new provider button -->
-                    <Tooltip bottom>
-                      <svelte:fragment slot="content">
-                        <Button
-                          aria-label="Create new {providerDisplayName}"
-                          inProgress="{providerInstallationInProgress.get(provider.name)}"
-                          on:click="{() => doCreateNew(provider, providerDisplayName)}">
-                          {buttonTitle} ...
-                        </Button>
-                      </svelte:fragment>
-                      <svelte:fragment slot="tip">
-                        <div
-                          class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs text-white"
-                          aria-label="tooltip">
-                          Create new {providerDisplayName}
-                        </div>
-                      </svelte:fragment>
+                    <Tooltip bottom tip="Create new {providerDisplayName}">
+                      <Button
+                        aria-label="Create new {providerDisplayName}"
+                        inProgress="{providerInstallationInProgress.get(provider.name)}"
+                        on:click="{() => doCreateNew(provider, providerDisplayName)}">
+                        {buttonTitle} ...
+                      </Button>
                     </Tooltip>
                   {/if}
                   {#if isOnboardingEnabled(provider, globalContext) || hasAnyConfiguration(provider)}
@@ -464,29 +455,18 @@ function hasAnyConfiguration(provider: ProviderInfo) {
             {@const peerProperties = new PeerProperties()}
             <div class="px-5 py-2 w-[240px]" role="region" aria-label="{container.name}">
               <div class="float-right">
-                <Tooltip bottom>
-                  <svelte:fragment slot="content">
-                    <button
-                      aria-label="{provider.name} details"
-                      type="button"
-                      on:click="{() =>
-                        router.goto(
-                          `/preferences/container-connection/view/${provider.internalId}/${Buffer.from(
-                            container.name,
-                          ).toString(
-                            'base64',
-                          )}/${Buffer.from(container.endpoint.socketPath).toString('base64')}/summary`,
-                        )}">
-                      <Fa icon="{faArrowUpRightFromSquare}" />
-                    </button>
-                  </svelte:fragment>
-                  <svelte:fragment slot="tip">
-                    <div
-                      class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs text-white"
-                      aria-label="tooltip">
-                      {provider.name} details
-                    </div>
-                  </svelte:fragment>
+                <Tooltip bottom tip="{provider.name} details">
+                  <button
+                    aria-label="{provider.name} details"
+                    type="button"
+                    on:click="{() =>
+                      router.goto(
+                        `/preferences/container-connection/view/${provider.internalId}/${Buffer.from(
+                          container.name,
+                        ).toString('base64')}/${Buffer.from(container.endpoint.socketPath).toString('base64')}/summary`,
+                      )}">
+                    <Fa icon="{faArrowUpRightFromSquare}" />
+                  </button>
                 </Tooltip>
               </div>
               <div class="{container.status !== 'started' ? 'text-gray-900' : ''} text-sm">
@@ -558,27 +538,18 @@ function hasAnyConfiguration(provider: ProviderInfo) {
           {#each provider.kubernetesConnections as kubeConnection}
             <div class="px-5 py-2 w-[240px]" role="region" aria-label="{kubeConnection.name}">
               <div class="float-right">
-                <Tooltip bottom>
-                  <svelte:fragment slot="content">
-                    <button
-                      aria-label="{provider.name} details"
-                      type="button"
-                      on:click="{() =>
-                        router.goto(
-                          `/preferences/kubernetes-connection/${provider.internalId}/${Buffer.from(
-                            kubeConnection.endpoint.apiURL,
-                          ).toString('base64')}/summary`,
-                        )}">
-                      <Fa icon="{faArrowUpRightFromSquare}" />
-                    </button>
-                  </svelte:fragment>
-                  <svelte:fragment slot="tip">
-                    <div
-                      class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs text-white"
-                      aria-label="tooltip">
-                      {provider.name} details
-                    </div>
-                  </svelte:fragment>
+                <Tooltip bottom tip="{provider.name} details">
+                  <button
+                    aria-label="{provider.name} details"
+                    type="button"
+                    on:click="{() =>
+                      router.goto(
+                        `/preferences/kubernetes-connection/${provider.internalId}/${Buffer.from(
+                          kubeConnection.endpoint.apiURL,
+                        ).toString('base64')}/summary`,
+                      )}">
+                    <Fa icon="{faArrowUpRightFromSquare}" />
+                  </button>
                 </Tooltip>
               </div>
               <div class="text-sm">

--- a/packages/renderer/src/lib/preferences/item-formats/FloatNumberItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/FloatNumberItem.svelte
@@ -71,23 +71,14 @@ function assertNumericValueIsValid(value: number): boolean {
   class="flex flex-row rounded-sm bg-zinc-700 text-sm divide-x divide-charcoal-800 w-24 border-b"
   class:border-violet-500="{!numberInputInvalid}"
   class:border-red-500="{numberInputInvalid}">
-  <Tooltip topRight>
-    <svelte:fragment slot="content">
-      <input
-        type="text"
-        class="w-full px-2 outline-none focus:outline-none text-white text-sm py-0.5"
-        name="{record.id}"
-        bind:value="{recordValue}"
-        on:keypress="{event => onNumberInputKeyPress(event)}"
-        on:input="{onInput}"
-        aria-label="{record.description}" />
-    </svelte:fragment>
-    <svelte:fragment slot="tip">
-      {#if numberInputErrorMessage}
-        <div class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs text-white" aria-label="tooltip">
-          {numberInputErrorMessage}
-        </div>
-      {/if}
-    </svelte:fragment>
+  <Tooltip topRight tip="{numberInputErrorMessage}">
+    <input
+      type="text"
+      class="w-full px-2 outline-none focus:outline-none text-white text-sm py-0.5"
+      name="{record.id}"
+      bind:value="{recordValue}"
+      on:keypress="{event => onNumberInputKeyPress(event)}"
+      on:input="{onInput}"
+      aria-label="{record.description}" />
   </Tooltip>
 </div>

--- a/packages/renderer/src/lib/preferences/item-formats/NumberItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/NumberItem.svelte
@@ -36,24 +36,15 @@ $: if (error) {
 }
 </script>
 
-<Tooltip topLeft>
-  <svelte:fragment slot="content">
-    <NumberInput
-      class="w-24"
-      name="{record.id}"
-      bind:value="{recordValue}"
-      bind:error="{error}"
-      aria-label="{record.description}"
-      minimum="{record.minimum}"
-      maximum="{record.maximum && typeof record.maximum === 'number' ? record.maximum : undefined}"
-      showError="{false}">
-    </NumberInput>
-  </svelte:fragment>
-  <svelte:fragment slot="tip">
-    {#if error}
-      <div class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs text-white" aria-label="tooltip">
-        {error}
-      </div>
-    {/if}
-  </svelte:fragment>
+<Tooltip topLeft tip="{error}">
+  <NumberInput
+    class="w-24"
+    name="{record.id}"
+    bind:value="{recordValue}"
+    bind:error="{error}"
+    aria-label="{record.description}"
+    minimum="{record.minimum}"
+    maximum="{record.maximum && typeof record.maximum === 'number' ? record.maximum : undefined}"
+    showError="{false}">
+  </NumberInput>
 </Tooltip>

--- a/packages/renderer/src/lib/ui/CopyToClipboard.svelte
+++ b/packages/renderer/src/lib/ui/CopyToClipboard.svelte
@@ -12,21 +12,14 @@ function copyTextToClipboard() {
 </script>
 
 <div class="float-right">
-  <Tooltip bottom>
-    <svelte:fragment slot="content">
-      <button
-        title="Copy To Clipboard"
-        class="ml-5 {$$props.class || ''}"
-        aria-label="Copy To Clipboard"
-        on:click="{() => copyTextToClipboard()}">
-        <Fa icon="{faPaste}" />
-      </button>
-    </svelte:fragment>
-    <svelte:fragment slot="tip">
-      <div class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs text-white" aria-label="tooltip">
-        Copy to Clipboard
-      </div>
-    </svelte:fragment>
+  <Tooltip bottom tip="Copy to Clipboard">
+    <button
+      title="Copy To Clipboard"
+      class="ml-5 {$$props.class || ''}"
+      aria-label="Copy To Clipboard"
+      on:click="{() => copyTextToClipboard()}">
+      <Fa icon="{faPaste}" />
+    </button>
   </Tooltip>
 </div>
 <div class="mt-1 my-auto text-xs truncate {$$props.class || ''}" aria-label="{title} copy to clipboard" title="{title}">

--- a/packages/renderer/src/lib/ui/KubernetesCurrentContextConnectionBadge.svelte
+++ b/packages/renderer/src/lib/ui/KubernetesCurrentContextConnectionBadge.svelte
@@ -23,17 +23,8 @@ $: text = getText($kubernetesCurrentContextState);
     <div class="w-2 h-2 {getClassColor($kubernetesCurrentContextState)} rounded-full mx-1"></div>
     <span class="text-xs capitalize mr-1">
       {#if $kubernetesCurrentContextState.error !== undefined}
-        <Tooltip left>
-          <svelte:fragment slot="content">
-            {text}
-          </svelte:fragment>
-          <svelte:fragment slot="tip">
-            {#if $kubernetesCurrentContextState.error}
-              <div class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs text-white" aria-label="tooltip">
-                {$kubernetesCurrentContextState.error}
-              </div>
-            {/if}
-          </svelte:fragment>
+        <Tooltip left tip="{$kubernetesCurrentContextState.error}">
+          {text}
         </Tooltip>
       {:else}
         {text}

--- a/packages/renderer/src/lib/ui/LoadingIconButton.svelte
+++ b/packages/renderer/src/lib/ui/LoadingIconButton.svelte
@@ -51,23 +51,14 @@ $: style = disable
     : 'text-purple-600 hover:text-purple-500';
 </script>
 
-<Tooltip bottom>
-  <svelte:fragment slot="content">
-    <button aria-label="{capitalize(action)}" class="mx-2.5 my-2 {style}" on:click="{clickAction}" disabled="{disable}">
-      <LoadingIcon
-        icon="{icon}"
-        loadingWidthClass="w-6"
-        loadingHeightClass="h-6"
-        positionTopClass="top-1"
-        positionLeftClass="{leftPosition}"
-        loading="{loading}" />
-    </button>
-  </svelte:fragment>
-  <svelte:fragment slot="tip">
-    {#if tooltip}
-      <div class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs text-white" aria-label="tooltip">
-        {tooltip}
-      </div>
-    {/if}
-  </svelte:fragment>
+<Tooltip bottom tip="{tooltip}">
+  <button aria-label="{capitalize(action)}" class="mx-2.5 my-2 {style}" on:click="{clickAction}" disabled="{disable}">
+    <LoadingIcon
+      icon="{icon}"
+      loadingWidthClass="w-6"
+      loadingHeightClass="h-6"
+      positionTopClass="top-1"
+      positionLeftClass="{leftPosition}"
+      loading="{loading}" />
+  </button>
 </Tooltip>

--- a/packages/renderer/src/lib/ui/NavItem.svelte
+++ b/packages/renderer/src/lib/ui/NavItem.svelte
@@ -49,17 +49,8 @@ onDestroy(() => {
     class:hover:text-[color:var(--pd-global-nav-icon-hover)]="{!selected || inSection}"
     class:hover:bg-[var(--pd-global-nav-icon-hover-bg)]="{!selected || inSection}"
     class:hover:border-[var(--pd-global-nav-icon-hover-bg)]="{!selected && !inSection}">
-    <Tooltip right>
-      <svelte:fragment slot="content">
-        <slot />
-      </svelte:fragment>
-      <svelte:fragment slot="tip">
-        {#if tooltip}
-          <div class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs text-white" aria-label="tooltip">
-            {tooltip}
-          </div>
-        {/if}
-      </svelte:fragment>
+    <Tooltip right tip="{tooltip}">
+      <slot />
     </Tooltip>
   </div>
 </a>

--- a/packages/renderer/src/lib/ui/NavSection.svelte
+++ b/packages/renderer/src/lib/ui/NavSection.svelte
@@ -36,24 +36,15 @@ onMount(() => {
     class="inline-block flex flex-col justify-center items-center"
     on:click="{() => (expanded = !expanded)}"
     disabled="{expanded && $count < 2}">
-    <Tooltip class="flex flex-col justify-center items-center pb-1" right>
-      <svelte:fragment slot="content">
-        <div class="flex flex-col justify-center items-center" class:text-charcoal-50="{expanded && $count < 2}">
-          {#if !expanded}
-            <div class="py-2" transition:fadeSlide="{{ duration: 500 }}">
-              <slot name="icon" />
-            </div>
-          {/if}
-          <Fa size="0.8x" icon="{expanded ? faChevronUp : faChevronDown}" />
-        </div>
-      </svelte:fragment>
-      <svelte:fragment slot="tip">
-        {#if tooltip}
-          <div class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs text-white" aria-label="tooltip">
-            {tooltip}
+    <Tooltip class="flex flex-col justify-center items-center pb-1" right tip="{tooltip}">
+      <div class="flex flex-col justify-center items-center" class:text-charcoal-50="{expanded && $count < 2}">
+        {#if !expanded}
+          <div class="py-2" transition:fadeSlide="{{ duration: 500 }}">
+            <slot name="icon" />
           </div>
         {/if}
-      </svelte:fragment>
+        <Fa size="0.8x" icon="{expanded ? faChevronUp : faChevronDown}" />
+      </div>
     </Tooltip>
   </button>
 </div>

--- a/packages/renderer/src/lib/ui/ProviderInfo.svelte
+++ b/packages/renderer/src/lib/ui/ProviderInfo.svelte
@@ -34,17 +34,9 @@ function getProviderColour(providerName: string): string {
   <span class="text-xs capitalize">
     <!-- If Kubernetes, show the context via the tooltip / hover, else just provider the name.-->
     {#if provider === 'Kubernetes'}
-      <Tooltip top>
-        <svelte:fragment slot="content">
-          {provider}
-        </svelte:fragment>
-        <svelte:fragment slot="tip">
-          {#if context}
-            <div class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs text-white" aria-label="tooltip">
-              {context}
-            </div>
-          {/if}
-        </svelte:fragment></Tooltip>
+      <Tooltip top tip="{context}">
+        {provider}
+      </Tooltip>
     {:else}
       {provider}
     {/if}

--- a/packages/renderer/src/lib/ui/StatusDot.svelte
+++ b/packages/renderer/src/lib/ui/StatusDot.svelte
@@ -23,26 +23,16 @@ let dotClass = getStatusColor(status);
 // If dotClass contains "outline", then we will use 'outline-1 outline-offset-[-2px]
 </script>
 
-<Tooltip top>
-  <svelte:fragment slot="content">
-    <div
-      class="w-2.5 h-2.5 mr-0.5 rounded-full text-center {dotClass.includes('outline')
-        ? 'outline-2 outline-offset-[-2px] outline'
-        : ''} {getStatusColor(status)} {number ? 'mt-3' : ''}"
-      data-testid="status-dot"
-      title="{tooltip}">
-    </div>
-    <!-- If text -->
-    {#if number}
-      <div class="text-xs text-bold text-gray-600 mr-0.5">{number}</div>
-    {/if}
-  </svelte:fragment>
-
-  <svelte:fragment slot="tip">
-    {#if tooltip}
-      <div class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs text-white" aria-label="tooltip">
-        {tooltip}
-      </div>
-    {/if}
-  </svelte:fragment>
+<Tooltip top tip="{tooltip}">
+  <div
+    class="w-2.5 h-2.5 mr-0.5 rounded-full text-center {dotClass.includes('outline')
+      ? 'outline-2 outline-offset-[-2px] outline'
+      : ''} {getStatusColor(status)} {number ? 'mt-3' : ''}"
+    data-testid="status-dot"
+    title="{tooltip}">
+  </div>
+  <!-- If text -->
+  {#if number}
+    <div class="text-xs text-bold text-gray-600 mr-0.5">{number}</div>
+  {/if}
 </Tooltip>

--- a/packages/renderer/src/lib/ui/WarningMessage.svelte
+++ b/packages/renderer/src/lib/ui/WarningMessage.svelte
@@ -9,17 +9,8 @@ export let icon = false;
 
 {#if icon}
   {#if error !== undefined && error !== ''}
-    <Tooltip top>
-      <svelte:fragment slot="content">
-        <Fa size="1.125x" class="cursor-pointer text-amber-500" icon="{faTriangleExclamation}" />
-      </svelte:fragment>
-      <svelte:fragment slot="tip">
-        {#if error}
-          <div class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs text-white" aria-label="tooltip">
-            {error}
-          </div>
-        {/if}
-      </svelte:fragment>
+    <Tooltip top tip="{error}">
+      <Fa size="1.125x" class="cursor-pointer text-amber-500" icon="{faTriangleExclamation}" />
     </Tooltip>
   {/if}
 {:else}

--- a/packages/renderer/src/lib/welcome/WelcomePage.svelte
+++ b/packages/renderer/src/lib/welcome/WelcomePage.svelte
@@ -128,19 +128,8 @@ function startOnboardingQueue() {
                       </div>
                       <div
                         class="flex flex-1 mx-2 underline decoration-2 decoration-dotted underline-offset-2 cursor-default justify-left text-capitalize">
-                        <Tooltip top>
-                          <svelte:fragment slot="content">
-                            {onboarding.displayName}
-                          </svelte:fragment>
-                          <svelte:fragment slot="tip">
-                            {#if onboarding.description}
-                              <div
-                                class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs text-white"
-                                aria-label="tooltip">
-                                {onboarding.description}
-                              </div>
-                            {/if}
-                          </svelte:fragment>
+                        <Tooltip top tip="{onboarding.description}">
+                          {onboarding.displayName}
                         </Tooltip>
                       </div>
                     </div>

--- a/packages/ui/src/lib/alert/ErrorMessage.svelte
+++ b/packages/ui/src/lib/alert/ErrorMessage.svelte
@@ -10,17 +10,8 @@ export let icon = false;
 
 {#if icon}
   {#if error !== undefined && error !== ''}
-    <Tooltip top>
-      <svelte:fragment slot="content">
-        <Fa size="1.1x" class="cursor-pointer text-red-500 {$$props.class}" icon="{faExclamationCircle}" />
-      </svelte:fragment>
-      <svelte:fragment slot="tip">
-        {#if error}
-          <div class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs text-white" aria-label="tooltip">
-            {error}
-          </div>
-        {/if}
-      </svelte:fragment>
+    <Tooltip top tip="{error}">
+      <Fa size="1.1x" class="cursor-pointer text-red-500 {$$props.class}" icon="{faExclamationCircle}" />
     </Tooltip>
   {/if}
 {:else}

--- a/packages/ui/src/lib/tooltip/Tooltip.svelte
+++ b/packages/ui/src/lib/tooltip/Tooltip.svelte
@@ -49,7 +49,8 @@
 }
 </style>
 
-<script>
+<script lang="ts">
+export let tip: string | undefined = undefined;
 export let top = false;
 export let topLeft = false;
 export let topRight = false;
@@ -62,7 +63,7 @@ export let left = false;
 
 <div class="relative inline-block">
   <span class="group tooltip-slot {$$props.class}">
-    <slot name="content" />
+    <slot />
   </span>
   <div
     class="whitespace-nowrap absolute tooltip opacity-0 inline-block transition-opacity duration-150 ease-in-out pointer-events-none z-[10]"
@@ -74,6 +75,15 @@ export let left = false;
     class:top-right="{topRight}"
     class:bottom-left="{bottomLeft}"
     class:bottom-right="{bottomRight}">
-    <slot name="tip" />
+    {#if tip}
+      <div class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs text-white" aria-label="tooltip">
+        {tip}
+      </div>
+    {/if}
+    {#if $$slots.tip && !tip}
+      <div class="inline-block rounded-md bg-charcoal-800 text-xs text-white" aria-label="tooltip">
+        <slot name="tip" />
+      </div>
+    {/if}
   </div>
 </div>

--- a/packages/ui/src/lib/tooltip/TooltipSpec.spec.ts
+++ b/packages/ui/src/lib/tooltip/TooltipSpec.spec.ts
@@ -27,17 +27,27 @@ import TooltipSpec from './TooltipSpec.svelte';
 
 const tip = 'test';
 
-test('Expect basic styling', async () => {
-  render(TooltipSpec, { tip });
+test('Expect basic slot styling', async () => {
+  render(TooltipSpec, { tipSlot: tip });
 
   const element = screen.getByLabelText('tooltip');
   expect(element).toBeInTheDocument();
+  expect(element).toHaveClass('bg-charcoal-800');
+  expect(element).toHaveClass('text-white');
+});
+
+test('Expect basic prop styling', async () => {
+  render(TooltipSpec, { tipProp: tip });
+
+  const element = screen.getByLabelText('tooltip');
+  expect(element).toBeInTheDocument();
+  expect(element).toHaveClass('bg-charcoal-800');
   expect(element).toHaveClass('text-white');
 });
 
 function createTest(props: Record<string, boolean>, locationName: string, expectedStyle = locationName): void {
   test(`Expect property ${locationName} to add ${expectedStyle} class to parent element`, () => {
-    render(TooltipSpec, { tip, ...props });
+    render(TooltipSpec, { tipSlot: tip, ...props });
     const element = screen.getByLabelText('tooltip');
     expect(element).toBeInTheDocument();
     expect(element.parentElement).toHaveClass(expectedStyle);

--- a/packages/ui/src/lib/tooltip/TooltipSpec.svelte
+++ b/packages/ui/src/lib/tooltip/TooltipSpec.svelte
@@ -1,7 +1,8 @@
-<script>
+<script lang="ts">
 import Tooltip from './Tooltip.svelte';
 
-export let tip;
+export let tipProp: string | undefined = undefined;
+export let tipSlot: string | undefined = undefined;
 export let top = false;
 export let topLeft = false;
 export let topRight = false;
@@ -13,6 +14,7 @@ export let left = false;
 </script>
 
 <Tooltip
+  tip="{tipProp}"
   top="{top}"
   topLeft="{topLeft}"
   topRight="{topRight}"
@@ -21,12 +23,10 @@ export let left = false;
   bottomLeft="{bottomLeft}"
   bottomRight="{bottomRight}"
   left="{left}">
-  <svelte:fragment slot="content">
-    <slot />
-  </svelte:fragment>
+  <slot />
   <svelte:fragment slot="tip">
-    {#if tip}
-      <div class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs text-white" aria-label="tooltip">{tip}</div>
+    {#if tipSlot}
+      {tipSlot}
     {/if}
   </svelte:fragment>
 </Tooltip>


### PR DESCRIPTION
### What does this PR do?

Changes:
- Move 'content' back to be the default slot, since content must always be there and is naturally the visible child.
- Make the outer box consistent - i.e. you are welcome to customize the _content_ of tooltips, but the component creates the frame and bg color.
- In additional to the 'tip' slot, allow 'tip' to be a property, so in the simple cases you can still do:
```
<Tooltip right tip="some tip">
  <something/>
</Tooltip>
```
and when you want to totally customize the tip content:
```
<Tooltip right>
  <something/>
  <svelte:fragment slot="tip">tip content goes here</svelte:fragment>
</Tooltip>
```

If someone accidentally supplies both, the simple tip is used. Having two if-statements is minor duplication, but it is more obvious and avoids extra spaces in the html.

I know this undoes a bunch of change and 'tip can either be property or slot' is a bit different (could use different names?), but I think this handles the simple/normal case as easy as before and has a single 'frame', while still allowing for enough customization.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes #7435.

### How to test this PR?

Test various tooltips. PR tests updated.

- [x] Tests are covering the bug fix or the new feature