### PR TITLE
feat: request confirmation to allow sign in requested from extension

### DIFF
--- a/packages/main/src/plugin/authentication-menu.spec.ts
+++ b/packages/main/src/plugin/authentication-menu.spec.ts
@@ -24,6 +24,7 @@ import type { ApiSenderType } from './api.js';
 import { AuthenticationImpl } from './authentication.js';
 import { AuthenticationProviderSingleAccount } from './authentication.spec.js';
 import { showAccountsMenu } from './authentication-menu.js';
+import type { MessageBox } from './message-box.js';
 import type { NavigationManager } from './navigation/navigation-manager.js';
 
 const menu = {
@@ -55,8 +56,12 @@ const apiSender: ApiSenderType = {
   receive: vi.fn(),
 };
 
+const messageBox: MessageBox = {
+  showMessageBox: () => Promise.resolve({ response: 1 }),
+} as unknown as MessageBox;
+
 beforeEach(function () {
-  authModule = new AuthenticationImpl(apiSender);
+  authModule = new AuthenticationImpl(apiSender, messageBox);
 });
 
 afterEach(() => {

--- a/packages/main/src/plugin/authentication.ts
+++ b/packages/main/src/plugin/authentication.ts
@@ -27,6 +27,7 @@ import type {
   Event,
   ProviderImages,
 } from '@podman-desktop/api';
+import { window } from '@podman-desktop/api';
 
 import type { ApiSenderType } from './api.js';
 import { Emitter } from './events/emitter.js';
@@ -249,6 +250,14 @@ export class AuthenticationImpl {
 
     if (options.createIfNone) {
       if (providerData) {
+        const allowRsp = await window.showInformationMessage(
+          `The extension '${requestingExtension.label}' wants to sign in using ${providerData.label}`,
+          'Cancel',
+          'Allow',
+        );
+        if (allowRsp !== 'Allow') {
+          return;
+        }
         const newSession = await providerData.provider.createSession(sortedScopes);
         const request = Array.from(this._signInRequestsData.values()).find(request => {
           return request.extensionId === requestingExtension.id;

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -575,7 +575,7 @@ export class PluginSystem {
     const libpodApiInit = new LibpodApiInit(configurationRegistry);
     libpodApiInit.init();
 
-    const authentication = new AuthenticationImpl(apiSender);
+    const authentication = new AuthenticationImpl(apiSender, messageBox);
 
     const cliToolRegistry = new CliToolRegistry(apiSender, exec, telemetry);
 


### PR DESCRIPTION
### What does this PR do?

Adds request user to allow singin request to be executed when it requested form extension calling `authentication.getSession()` method

### Screenshot / video of UI

![image](https://github.com/containers/podman-desktop/assets/620330/7d6c716f-0208-4b6f-8dda-4a10a61e3e58)

### What issues does this PR fix or reference?

#6632 signin request part.

### How to test this PR?

1. Pull the branch
2. Install Red Hat Authentication Extension
3. Try to login to Red Hat SSO from Authentication settings or from status bar
4. Information message `The extension 'Red Hat SSO' wants to sign in using 'Red Hat SSO'` with two buttons `Cancel` and `Allow` should appear.
5. Press `Cancel` to cancel redirect to the browser or `Allow` to continue the login workflow in default browser  

- [x] Tests are covering the bug fix or the new feature
