### PR TITLE
Fix files watched in a non existing directory 

### DIFF
--- a/packages/main/src/plugin/filesystem-monitoring.ts
+++ b/packages/main/src/plugin/filesystem-monitoring.ts
@@ -36,6 +36,10 @@ export class FileSystemWatcherImpl implements containerDesktopAPI.FileSystemWatc
     } else if (parent !== path) {
       // we stop the recursion at /
       const parentWatcher = new FileSystemWatcherImpl(parent);
+      const dispoReady = parentWatcher.onReady(() => {
+        this._onReady.fire();
+        dispoReady.dispose();
+      });
       const disposable = parentWatcher.onDidCreate((uri: containerDesktopAPI.Uri) => {
         if (uri.path === parent) {
           this.doWatch(path);

--- a/packages/main/src/plugin/filesystem-monitoring.ts
+++ b/packages/main/src/plugin/filesystem-monitoring.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2022 Red Hat, Inc.
+ * Copyright (C) 2022, 2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import * as fs from 'node:fs';
+import * as pathfs from 'node:path';
+
 import type * as containerDesktopAPI from '@podman-desktop/api';
 import * as chokidar from 'chokidar';
 
@@ -24,9 +27,25 @@ import { Disposable } from './types/disposable.js';
 import { Uri } from './types/uri.js';
 
 export class FileSystemWatcherImpl implements containerDesktopAPI.FileSystemWatcher {
-  watcher: chokidar.FSWatcher;
+  watcher: chokidar.FSWatcher | undefined;
 
   constructor(path: string) {
+    const parent = pathfs.dirname(path);
+    if (fs.existsSync(parent)) {
+      this.doWatch(path);
+    } else {
+      const parentWatcher = new FileSystemWatcherImpl(parent);
+      const disposable = parentWatcher.onDidCreate((uri: containerDesktopAPI.Uri) => {
+        if (uri.path === parent) {
+          this.doWatch(path);
+          disposable.dispose();
+        }
+      });
+    }
+    this._disposable = Disposable.from(this._onDidCreate, this._onDidChange, this._onDidDelete);
+  }
+
+  doWatch(path: string): void {
     // needs to call chokidar
     this.watcher = chokidar.watch(path, {
       persistent: true,

--- a/packages/main/src/plugin/filesystem-monitoring.ts
+++ b/packages/main/src/plugin/filesystem-monitoring.ts
@@ -33,7 +33,8 @@ export class FileSystemWatcherImpl implements containerDesktopAPI.FileSystemWatc
     const parent = pathfs.dirname(path);
     if (fs.existsSync(parent)) {
       this.doWatch(path);
-    } else {
+    } else if (parent !== path) {
+      // we stop the recursion at /
       const parentWatcher = new FileSystemWatcherImpl(parent);
       const disposable = parentWatcher.onDidCreate((uri: containerDesktopAPI.Uri) => {
         if (uri.path === parent) {

--- a/packages/main/src/plugin/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes-client.ts
@@ -189,10 +189,10 @@ export class KubernetesClient {
     const kubernetesConfiguration = this.configurationRegistry.getConfiguration('kubernetes');
     const userKubeconfigPath = kubernetesConfiguration.get<string>('Kubeconfig');
     if (userKubeconfigPath) {
+      this.kubeconfigPath = userKubeconfigPath;
       this.setupWatcher(userKubeconfigPath);
       // check if path exists
       if (existsSync(userKubeconfigPath)) {
-        this.kubeconfigPath = userKubeconfigPath;
         this.refresh().catch(() => console.error('Refresh of kube resources on startup failed'));
       } else {
         console.error(`Kubeconfig path ${userKubeconfigPath} provided does not exist. Skipping.`);


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

When a file is watched and its parent directory does not exist, then when the directory is created later, the file creation cannot be detected (except on mac).

Example:
``` 
rm -rf /home/user/.kube
watch /home/user/.kube/config
mkdir /home/user/.kube
echo '...' > /home/user/.kube/config // the creation of the file is not detected
```

This PR changes the Watch behaviour, to watch only a file if the parent directory exists. If the parent directory does not exist, a watch in the parent directory is triggered instead, and the initial watch is triggered when the parent is created (recursively).

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes #6406 

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

- Completely terminate Podman Desktop
- `cd $HOME`
- `mv .kube .kube-save`
- Start Podman Desktop
- Kubernetes icons should not be displayed
- `mkdir .kube`
- `cp .kube-save/config .kube/`
- Kubernetes icons should appear

- [x] Tests are covering the bug fix or the new feature
