### PR TITLE
chore: adding engineId to ContainerCreateResult

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -2786,6 +2786,10 @@ declare module '@podman-desktop/api' {
      * a string uniquely identifying the created container, which can be used to execute other methods on the container ({@link containerEngine.deleteContainer}, {@link containerEngine.inspectContainer}, {@link containerEngine.startContainer}, {@link containerEngine.stopContainer}, {@link containerEngine.logsContainer})
      */
     id: string;
+    /**
+     * the engineId where the container is running
+     */
+    engineId: string;
   }
 
   export interface WebviewInfo {

--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -2380,6 +2380,7 @@ describe('createContainer', () => {
     const container = await containerRegistry.createContainer('podman1', { start: true });
 
     expect(container.id).toBe(createdId);
+    expect(container.engineId).toBe('podman1');
     expect(createContainerMock).toHaveBeenCalled();
     expect(startMock).toHaveBeenCalled();
   });

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -1867,7 +1867,7 @@ export class ContainerProviderRegistry {
     }
   }
 
-  async createContainer(engineId: string, options: ContainerCreateOptions): Promise<{ id: string }> {
+  async createContainer(engineId: string, options: ContainerCreateOptions): Promise<{ id: string; engineId: string }> {
     let telemetryOptions = {};
     try {
       let container: Dockerode.Container;
@@ -1884,7 +1884,7 @@ export class ContainerProviderRegistry {
           await container.start();
         }
       }
-      return { id: container.id };
+      return { id: container.id, engineId };
     } catch (error) {
       telemetryOptions = { error: error };
       throw error;


### PR DESCRIPTION
### What does this PR do?

It is often very frustating to get a `ContainerCreateResult` with the container id, but we need to keep track of which engineId has been used to use methods with the result.

This PR add the engineId to the ContainerCreateResult, as it is very handy to have it directly.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
