### PR TITLE
fix: Modal component is shown too high and gets out of viewport

### DIFF
--- a/packages/ui/src/lib/modal/Modal.svelte
+++ b/packages/ui/src/lib/modal/Modal.svelte
@@ -32,7 +32,7 @@ if (previously_focused) {
 
 <svelte:window on:keydown="{handle_keydown}" />
 
-<div class:items-center="{!top}" class="fixed top-0 left-0 right-0 bottom-0 w-full h-full flex justify-center z-50">
+<div class:items-center="{!top}" class="fixed w-full h-full flex justify-center z-50">
   <button
     aria-label="close"
     class="fixed top-0 left-0 w-full h-full bg-[var(--pd-modal-fade)] bg-blend-multiply opacity-60 z-40 cursor-default"


### PR DESCRIPTION
### What does this PR do?

Removes absolute position for Modal component because it is already has w-full and h-full

### Screenshot / video of UI

That will change this behavior 

![image](https://github.com/containers/podman-desktop/assets/620330/0a320765-bd9c-4cd0-80a2-a04db1695e01)

to a normal one

![image](https://github.com/containers/podman-desktop/assets/620330/57e9ab0a-7c47-4609-bc5e-950f66d86f3e)

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
