### PR TITLE
chore: add under name load balancer IP for service

### DIFF
--- a/packages/renderer/src/lib/service/ServiceColumnName.spec.ts
+++ b/packages/renderer/src/lib/service/ServiceColumnName.spec.ts
@@ -58,3 +58,14 @@ test('Expect clicking works', async () => {
 
   expect(routerGotoSpy).toBeCalledWith('/services/my-service/default/summary');
 });
+
+test('If loadBalancerIPs is set, expect it to be displayed', async () => {
+  service.loadBalancerIPs = '10.0.0.1';
+  render(ServiceColumnName, { object: service });
+
+  const text = screen.getByText(service.name);
+  expect(text).toBeInTheDocument();
+
+  const loadBalancerIPs = screen.getByText(service.loadBalancerIPs);
+  expect(loadBalancerIPs).toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/service/ServiceColumnName.svelte
+++ b/packages/renderer/src/lib/service/ServiceColumnName.svelte
@@ -12,4 +12,7 @@ function openDetails() {
 
 <button class="hover:cursor-pointer flex flex-col" on:click="{() => openDetails()}">
   <div class="text-sm text-gray-300">{object.name}</div>
+  {#if object.loadBalancerIPs}
+    <div class="text-xs text-violet-400">{object.loadBalancerIPs}</div>
+  {/if}
 </button>

--- a/packages/renderer/src/lib/service/ServiceUI.ts
+++ b/packages/renderer/src/lib/service/ServiceUI.ts
@@ -24,5 +24,6 @@ export interface ServiceUI {
   selected: boolean;
   type: string;
   clusterIP: string;
+  loadBalancerIPs?: string;
   ports: string;
 }

--- a/packages/renderer/src/lib/service/ServicesList.svelte
+++ b/packages/renderer/src/lib/service/ServicesList.svelte
@@ -87,6 +87,7 @@ let namespaceColumn = new TableColumn<ServiceUI, string>('Namespace', {
 
 let typeColumn = new TableColumn<ServiceUI>('Type', {
   renderer: ServiceColumnType,
+  overflow: true,
   comparator: (a, b) => a.type.localeCompare(b.type),
 });
 

--- a/packages/renderer/src/lib/service/service-utils.spec.ts
+++ b/packages/renderer/src/lib/service/service-utils.spec.ts
@@ -40,3 +40,39 @@ test('expect basic UI conversion', async () => {
   expect(serviceUI.name).toEqual('my-service');
   expect(serviceUI.namespace).toEqual('test-namespace');
 });
+
+test('expect no loadBalancerIPs when it is not set in V1Service ingress', async () => {
+  const service = {
+    metadata: {
+      name: 'my-service',
+      namespace: 'test-namespace',
+    },
+    status: {
+      loadBalancer: {
+        ingress: [],
+      },
+    },
+  } as V1Service;
+  const serviceUI = serviceUtils.getServiceUI(service);
+  expect(serviceUI.loadBalancerIPs).toEqual('');
+});
+
+test('expect a loadBalancerIPs if set in service', async () => {
+  const service = {
+    metadata: {
+      name: 'my-service',
+      namespace: 'test-namespace',
+    },
+    status: {
+      loadBalancer: {
+        ingress: [
+          {
+            ip: '10.0.0.1',
+          },
+        ],
+      },
+    },
+  } as V1Service;
+  const serviceUI = serviceUtils.getServiceUI(service);
+  expect(serviceUI.loadBalancerIPs).toEqual('10.0.0.1');
+});

--- a/packages/renderer/src/lib/service/service-utils.ts
+++ b/packages/renderer/src/lib/service/service-utils.ts
@@ -30,6 +30,7 @@ export class ServiceUtils {
       selected: false,
       type: service.spec?.type ?? '',
       clusterIP: service.spec?.clusterIP ?? '',
+      loadBalancerIPs: service.status?.loadBalancer?.ingress?.map(ingress => ingress.ip).join(', '),
       ports: (service.spec?.ports ?? []).map(port => port.port + '/' + port.protocol).join(', '),
     };
   }


### PR DESCRIPTION
chore: add tooltip to show load balancer IP for service

### What does this PR do?

Adds the load balancer IP below the name for service (if it's
available).

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

![Screenshot 2024-06-05 at 9 27 10 AM](https://github.com/containers/podman-desktop/assets/6422176/97bd8c3f-a54f-4ebe-a18d-04fd3fb41aba)



### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop/issues/7426

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature

Create a load balancer and view the page.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
