### PR TITLE
chore: fix table sorting

### DIFF
--- a/packages/ui/src/lib/table/Table.spec.ts
+++ b/packages/ui/src/lib/table/Table.spec.ts
@@ -265,3 +265,24 @@ test('Expect update callback', async () => {
 
   expect(callback).toHaveBeenCalled();
 });
+
+test('Expect table to be sorted by Id on load', async () => {
+  render(TestTable, {});
+
+  // Wait for the table to load and fetch all rows
+  const rows = await screen.findAllByRole('row');
+  expect(rows).toBeDefined();
+  expect(rows.length).toBe(4);
+
+  const headers = await screen.findAllByRole('columnheader');
+  expect(headers).toBeDefined();
+  expect(headers.length).toBe(6);
+  expect(headers[2].textContent).toContain('Id');
+
+  // Check that Id column is sorted in ascending order
+  // since Id is by 1,2,3 in TestTable, just using a for loop and converting
+  // to string is enough to check the order
+  for (let i = 1; i < 4; i++) {
+    expect(rows[i].textContent).toContain(i.toString());
+  }
+});

--- a/packages/ui/src/lib/table/Table.svelte
+++ b/packages/ui/src/lib/table/Table.svelte
@@ -101,6 +101,8 @@ onMount(async () => {
   if (column?.info.comparator) {
     sortCol = column;
     sortAscending = column.info.initialOrder ? column.info.initialOrder !== 'descending' : true;
+    await tick(); // Ensure all initializations are complete.
+    sortImpl(); // Explicitly call sortImpl to sort the data initially.
   }
 });
 


### PR DESCRIPTION
chore: fix table sorting

### What does this PR do?

When sorting, we are sorting the columns on the onMount, however, we are
not waiting for data (tick()) as well as not sorting it afterwards
(sortImpl()).

This PR fixes it by sorting the table on launch.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Fixes https://github.com/containers/podman-desktop/issues/7475

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature

View the pages and see they are ordered now.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
