### PR TITLE
Wait podman startup

### DIFF
--- a/tests/playwright/src/specs/container-smoke.spec.ts
+++ b/tests/playwright/src/specs/container-smoke.spec.ts
@@ -29,7 +29,7 @@ import { NavigationBar } from '../model/workbench/navigation';
 import { PodmanDesktopRunner } from '../runner/podman-desktop-runner';
 import type { RunnerTestContext } from '../testContext/runner-test-context';
 import { deleteContainer, deleteImage } from '../utility/operations';
-import { waitUntil, waitWhile } from '../utility/wait';
+import { waitForPodmanMachineStartup, waitUntil, waitWhile } from '../utility/wait';
 
 let pdRunner: PodmanDesktopRunner;
 let page: Page;
@@ -45,6 +45,7 @@ beforeAll(async () => {
   pdRunner.setVideoAndTraceName('containers-e2e');
   const welcomePage = new WelcomePage(page);
   await welcomePage.handleWelcomePage(true);
+  await waitForPodmanMachineStartup(page);
   // wait giving a time to podman desktop to load up
   let images: ImagesPage;
   try {

--- a/tests/playwright/src/specs/image-smoke.spec.ts
+++ b/tests/playwright/src/specs/image-smoke.spec.ts
@@ -29,6 +29,7 @@ import { NavigationBar } from '../model/workbench/navigation';
 import { PodmanDesktopRunner } from '../runner/podman-desktop-runner';
 import type { RunnerTestContext } from '../testContext/runner-test-context';
 import { handleConfirmationDialog } from '../utility/operations';
+import { waitForPodmanMachineStartup } from '../utility/wait';
 
 let pdRunner: PodmanDesktopRunner;
 let page: Page;
@@ -43,7 +44,8 @@ beforeAll(async () => {
 
   const welcomePage = new WelcomePage(page);
   await welcomePage.handleWelcomePage(true);
-  navBar = new NavigationBar(page); // always present on the left side of the page
+  await waitForPodmanMachineStartup(page);
+  navBar = new NavigationBar(page);
 });
 
 afterAll(async () => {

--- a/tests/playwright/src/specs/pod-smoke.spec.ts
+++ b/tests/playwright/src/specs/pod-smoke.spec.ts
@@ -30,7 +30,7 @@ import { NavigationBar } from '../model/workbench/navigation';
 import { PodmanDesktopRunner } from '../runner/podman-desktop-runner';
 import type { RunnerTestContext } from '../testContext/runner-test-context';
 import { deleteContainer, deleteImage, deletePod } from '../utility/operations';
-import { waitUntil, waitWhile } from '../utility/wait';
+import { waitForPodmanMachineStartup, waitUntil, waitWhile } from '../utility/wait';
 
 let pdRunner: PodmanDesktopRunner;
 let page: Page;
@@ -54,6 +54,7 @@ beforeAll(async () => {
   pdRunner.setVideoAndTraceName('pods-e2e');
   const welcomePage = new WelcomePage(page);
   await welcomePage.handleWelcomePage(true);
+  await waitForPodmanMachineStartup(page);
   // wait giving a time to podman desktop to load up
   const images = await new NavigationBar(page).openImages();
   await waitWhile(

--- a/tests/playwright/src/specs/registry-image.spec.ts
+++ b/tests/playwright/src/specs/registry-image.spec.ts
@@ -28,6 +28,7 @@ import { PodmanDesktopRunner } from '../runner/podman-desktop-runner';
 import { canTestRegistry, setupRegistry } from '../setupFiles/setup-registry';
 import type { RunnerTestContext } from '../testContext/runner-test-context';
 import { deleteImage, deleteRegistry } from '../utility/operations';
+import { waitForPodmanMachineStartup } from '../utility/wait';
 
 let pdRunner: PodmanDesktopRunner;
 let page: Page;
@@ -51,6 +52,7 @@ beforeAll(async () => {
 
   const welcomePage = new WelcomePage(page);
   await welcomePage.handleWelcomePage(true);
+  await waitForPodmanMachineStartup(page);
   navBar = new NavigationBar(page);
 });
 

--- a/tests/playwright/src/specs/volume-smoke.spec.ts
+++ b/tests/playwright/src/specs/volume-smoke.spec.ts
@@ -24,6 +24,7 @@ import { WelcomePage } from '../model/pages/welcome-page';
 import { NavigationBar } from '../model/workbench/navigation';
 import { PodmanDesktopRunner } from '../runner/podman-desktop-runner';
 import type { RunnerTestContext } from '../testContext/runner-test-context';
+import { waitForPodmanMachineStartup } from '../utility/wait';
 
 let pdRunner: PodmanDesktopRunner;
 let page: Page;
@@ -36,6 +37,7 @@ beforeAll(async () => {
 
   const welcomePage = new WelcomePage(page);
   await welcomePage.handleWelcomePage(true);
+  await waitForPodmanMachineStartup(page);
   navBar = new NavigationBar(page);
 });
 

--- a/tests/playwright/src/specs/yaml-smoke.spec.ts
+++ b/tests/playwright/src/specs/yaml-smoke.spec.ts
@@ -27,6 +27,7 @@ import { NavigationBar } from '../model/workbench/navigation';
 import { PodmanDesktopRunner } from '../runner/podman-desktop-runner';
 import type { RunnerTestContext } from '../testContext/runner-test-context';
 import { deleteImage, deletePod } from '../utility/operations';
+import { waitForPodmanMachineStartup } from '../utility/wait';
 
 let pdRunner: PodmanDesktopRunner;
 let page: Page;
@@ -41,6 +42,7 @@ beforeAll(async () => {
   pdRunner.setVideoAndTraceName('play-yaml-e2e');
 
   await new WelcomePage(page).handleWelcomePage(true);
+  await waitForPodmanMachineStartup(page);
 });
 
 beforeEach<RunnerTestContext>(async ctx => {

--- a/tests/playwright/src/utility/wait.ts
+++ b/tests/playwright/src/utility/wait.ts
@@ -16,6 +16,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { expect as playExpect, Page } from '@playwright/test';
+
+import { NavigationBar } from '../model/workbench/navigation';
+
 export async function wait(
   waitFunction: () => Promise<boolean>,
   until: boolean,
@@ -110,4 +114,11 @@ export async function executeWithTimeout(
     clearTimeout(cancelTimeout);
     return result;
   });
+}
+
+export async function waitForPodmanMachineStartup(page: Page, timeoutOut = 10000): Promise<void> {
+  const dashboardPage = await new NavigationBar(page).openDashboard();
+  await playExpect(dashboardPage.heading).toBeVisible();
+  await playExpect(dashboardPage.podmanStatusLabel).toBeVisible({ timeout: timeoutOut });
+  await playExpect(dashboardPage.podmanStatusLabel).toHaveText('RUNNING', { timeout: timeoutOut });
 }

--- a/tests/playwright/src/utility/wait.ts
+++ b/tests/playwright/src/utility/wait.ts
@@ -16,7 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { expect as playExpect, Page } from '@playwright/test';
+import type { Page } from '@playwright/test';
+import { expect as playExpect } from '@playwright/test';
 
 import { NavigationBar } from '../model/workbench/navigation';
 


### PR DESCRIPTION
### What does this PR do?
Created a method to be called at the start for some e2e test runs to wait for podman machine startup

### What issues does this PR fix or reference?
https://github.com/containers/podman-desktop-extension-bootc/issues/520
