### PR TITLE
chore: light mode for tooltip

### DIFF
--- a/packages/main/src/plugin/color-registry.ts
+++ b/packages/main/src/plugin/color-registry.ts
@@ -240,6 +240,7 @@ export class ColorRegistry {
     this.initLink();
     this.initButton();
     this.initActionButton();
+    this.initTooltip();
   }
 
   protected initGlobalNav(): void {
@@ -979,6 +980,24 @@ export class ColorRegistry {
     this.registerColor(`${ab}spinner`, {
       dark: colorPalette.purple[500],
       light: colorPalette.purple[500],
+    });
+  }
+
+  // tooltip
+  protected initTooltip(): void {
+    const tooltip = 'tooltip-';
+
+    this.registerColor(`${tooltip}bg`, {
+      dark: colorPalette.charcoal[800],
+      light: colorPalette.gray[50],
+    });
+    this.registerColor(`${tooltip}text`, {
+      dark: colorPalette.white,
+      light: colorPalette.black,
+    });
+    this.registerColor(`${tooltip}border`, {
+      dark: colorPalette.charcoal[500],
+      light: colorPalette.gray[500],
     });
   }
 }

--- a/packages/ui/src/lib/tooltip/Tooltip.svelte
+++ b/packages/ui/src/lib/tooltip/Tooltip.svelte
@@ -76,12 +76,16 @@ export let left = false;
     class:bottom-left="{bottomLeft}"
     class:bottom-right="{bottomRight}">
     {#if tip}
-      <div class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs text-white" aria-label="tooltip">
+      <div
+        class="inline-block py-2 px-4 rounded-md bg-[var(--pd-tooltip-bg)] text-xs text-[var(--pd-tooltip-text)] border-[1px] border-[var(--pd-tooltip-border)]"
+        aria-label="tooltip">
         {tip}
       </div>
     {/if}
     {#if $$slots.tip && !tip}
-      <div class="inline-block rounded-md bg-charcoal-800 text-xs text-white" aria-label="tooltip">
+      <div
+        class="inline-block rounded-md bg-[var(--pd-tooltip-bg)] text-xs text-[var(--pd-tooltip-text)] border-[1px] border-[var(--pd-tooltip-border)]"
+        aria-label="tooltip">
         <slot name="tip" />
       </div>
     {/if}

--- a/packages/ui/src/lib/tooltip/TooltipSpec.spec.ts
+++ b/packages/ui/src/lib/tooltip/TooltipSpec.spec.ts
@@ -32,8 +32,10 @@ test('Expect basic slot styling', async () => {
 
   const element = screen.getByLabelText('tooltip');
   expect(element).toBeInTheDocument();
-  expect(element).toHaveClass('bg-charcoal-800');
-  expect(element).toHaveClass('text-white');
+  expect(element).toHaveClass('bg-[var(--pd-tooltip-bg)]');
+  expect(element).toHaveClass('text-[var(--pd-tooltip-text)]');
+  expect(element).toHaveClass('border-[var(--pd-tooltip-border)]');
+  expect(element).toHaveClass('border-[1px]');
 });
 
 test('Expect basic prop styling', async () => {
@@ -41,8 +43,10 @@ test('Expect basic prop styling', async () => {
 
   const element = screen.getByLabelText('tooltip');
   expect(element).toBeInTheDocument();
-  expect(element).toHaveClass('bg-charcoal-800');
-  expect(element).toHaveClass('text-white');
+  expect(element).toHaveClass('bg-[var(--pd-tooltip-bg)]');
+  expect(element).toHaveClass('text-[var(--pd-tooltip-text)]');
+  expect(element).toHaveClass('border-[var(--pd-tooltip-border)]');
+  expect(element).toHaveClass('border-[1px]');
 });
 
 function createTest(props: Record<string, boolean>, locationName: string, expectedStyle = locationName): void {


### PR DESCRIPTION
### What does this PR do?

Adds color entries for tooltip.

Some of the tooltips were getting lost in very dark (or very light) backgrounds, so I took the opportunity to add a 1px border identical to what we did for Modal dialogs.

### Screenshot / video of UI

<img width="265" alt="Screenshot 2024-06-03 at 5 15 02 PM" src="https://github.com/containers/podman-desktop/assets/19958075/eb4f07c5-9aba-46e7-b808-6eb7d3a21228">
<img width="265" alt="Screenshot 2024-06-03 at 5 16 39 PM" src="https://github.com/containers/podman-desktop/assets/19958075/81488bac-0a63-4b68-abaf-c5088e89ae32">

### What issues does this PR fix or reference?

Fixes #6926.

### How to test this PR?

Just check a tooltip on light and dark mode.

- [x] Tests are covering the bug fix or the new feature