### PR TITLE
chore: add ellipsis for names

### DIFF
--- a/packages/renderer/src/lib/deployments/DeploymentColumnName.svelte
+++ b/packages/renderer/src/lib/deployments/DeploymentColumnName.svelte
@@ -10,6 +10,6 @@ function openDetails() {
 }
 </script>
 
-<button class="hover:cursor-pointer flex flex-col" on:click="{() => openDetails()}">
-  <div class="text-sm text-gray-300">{object.name}</div>
+<button class="hover:cursor-pointer flex flex-col max-w-full" on:click="{() => openDetails()}">
+  <div class="text-sm text-gray-300 max-w-full overflow-hidden text-ellipsis">{object.name}</div>
 </button>

--- a/packages/renderer/src/lib/image/ImageColumnName.svelte
+++ b/packages/renderer/src/lib/image/ImageColumnName.svelte
@@ -15,9 +15,9 @@ function openDetails(image: ImageInfoUI) {
 }
 </script>
 
-<button class="flex flex-col" on:click="{() => openDetails(object)}">
-  <div class="flex flex-row text-xs gap-1 items-center">
-    <div class="text-sm text-[var(--pd-table-body-text-highlight)]">
+<button class="flex flex-col max-w-full" on:click="{() => openDetails(object)}">
+  <div class="flex flex-row text-xs gap-1 items-center max-w-full">
+    <div class="text-sm text-[var(--pd-table-body-text-highlight)] overflow-hidden text-ellipsis">
       {object.name}
       {object.isManifest ? ' (manifest)' : ''}
     </div>

--- a/packages/renderer/src/lib/ingresses-routes/IngressRouteColumnName.svelte
+++ b/packages/renderer/src/lib/ingresses-routes/IngressRouteColumnName.svelte
@@ -17,6 +17,6 @@ function openDetails() {
 }
 </script>
 
-<button class="hover:cursor-pointer flex flex-col" on:click="{() => openDetails()}">
-  <div class="text-sm text-gray-300">{object.name}</div>
+<button class="hover:cursor-pointer flex flex-col max-w-full" on:click="{() => openDetails()}">
+  <div class="text-sm text-gray-300 max-w-full overflow-hidden text-ellipsis">{object.name}</div>
 </button>

--- a/packages/renderer/src/lib/node/NodeColumnName.svelte
+++ b/packages/renderer/src/lib/node/NodeColumnName.svelte
@@ -10,6 +10,6 @@ function openDetails() {
 }
 </script>
 
-<button class="hover:cursor-pointer flex flex-col" on:click="{() => openDetails()}">
-  <div class="text-sm text-gray-300">{object.name}</div>
+<button class="hover:cursor-pointer flex flex-col max-w-full" on:click="{() => openDetails()}">
+  <div class="text-sm text-gray-300 max-w-full overflow-hidden text-ellipsis">{object.name}</div>
 </button>

--- a/packages/renderer/src/lib/pod/PodColumnName.svelte
+++ b/packages/renderer/src/lib/pod/PodColumnName.svelte
@@ -15,7 +15,7 @@ function openDetailsPod(pod: PodInfoUI) {
 }
 </script>
 
-<button class="hover:cursor-pointer flex flex-col" on:click="{() => openDetailsPod(object)}">
-  <div class="text-sm text-gray-300">{object.name}</div>
+<button class="hover:cursor-pointer flex flex-col max-w-full" on:click="{() => openDetailsPod(object)}">
+  <div class="text-sm text-gray-300 max-w-full overflow-hidden text-ellipsis">{object.name}</div>
   <div class="text-xs text-violet-400">{object.shortId}</div>
 </button>

--- a/packages/renderer/src/lib/service/ServiceColumnName.svelte
+++ b/packages/renderer/src/lib/service/ServiceColumnName.svelte
@@ -10,8 +10,8 @@ function openDetails() {
 }
 </script>
 
-<button class="hover:cursor-pointer flex flex-col" on:click="{() => openDetails()}">
-  <div class="text-sm text-gray-300">{object.name}</div>
+<button class="hover:cursor-pointer flex flex-col max-w-full" on:click="{() => openDetails()}">
+  <div class="text-sm text-gray-300 max-w-full overflow-hidden text-ellipsis">{object.name}</div>
   {#if object.loadBalancerIPs}
     <div class="text-xs text-violet-400">{object.loadBalancerIPs}</div>
   {/if}

--- a/packages/renderer/src/lib/volume/VolumeColumnName.svelte
+++ b/packages/renderer/src/lib/volume/VolumeColumnName.svelte
@@ -11,7 +11,7 @@ function openDetailsVolume(volume: VolumeInfoUI): void {
 </script>
 
 <button
-  class="hover:cursor-pointer flex text-sm text-[var(--pd-table-body-text-highlight)]"
+  class="hover:cursor-pointer flex text-sm text-[var(--pd-table-body-text-highlight)] max-w-full overflow-hidden text-ellipsis"
   on:click="{() => openDetailsVolume(object)}">
   {object.shortName}
 </button>


### PR DESCRIPTION
chore: add ellipsis for names

### What does this PR do?

* We use custom svelte for names, since we need the onClick
  functionality, some of them are missing
* Add ellipsis for name when the name is too long.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

https://github.com/containers/podman-desktop/assets/6422176/20090886-6602-4f13-8f32-1e02b9ab86f8



### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop/issues/7498

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

There are no tests written as it's mostly just UI / no new
functionality.

View the names in each column

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
