### PR TITLE
chore: label component

### DIFF
--- a/packages/main/src/plugin/color-registry.ts
+++ b/packages/main/src/plugin/color-registry.ts
@@ -242,6 +242,7 @@ export class ColorRegistry {
     this.initActionButton();
     this.initTooltip();
     this.initDropdown();
+    this.initLabel();
   }
 
   protected initGlobalNav(): void {
@@ -1042,6 +1043,20 @@ export class ColorRegistry {
     this.registerColor(`${dropdown}disabled-item-bg`, {
       dark: colorPalette.charcoal[800],
       light: colorPalette.gray[200],
+    });
+  }
+
+  // labels
+  protected initLabel(): void {
+    const label = 'label-';
+
+    this.registerColor(`${label}bg`, {
+      dark: colorPalette.charcoal[500],
+      light: colorPalette.purple[200],
+    });
+    this.registerColor(`${label}text`, {
+      dark: colorPalette.gray[500],
+      light: colorPalette.charcoal[300],
     });
   }
 }

--- a/packages/renderer/src/lib/deployments/DeploymentColumnConditions.spec.ts
+++ b/packages/renderer/src/lib/deployments/DeploymentColumnConditions.spec.ts
@@ -42,9 +42,8 @@ test('Expect column styling available', async () => {
 
   const text = screen.getByText('Available');
   expect(text).toBeInTheDocument();
-  expect(text).toHaveClass('text-gray-500');
 
-  const dot = text.parentElement?.children[0].children[0];
+  const dot = text.parentElement?.children[0];
   expect(dot).toBeInTheDocument();
   expect(dot).toHaveClass('text-green-600');
 });
@@ -55,9 +54,8 @@ test('Expect column styling failure', async () => {
 
   const text = screen.getByText('ReplicaFailure');
   expect(text).toBeInTheDocument();
-  expect(text).toHaveClass('text-gray-500');
 
-  const dot = text.parentElement?.children[0].children[0];
+  const dot = text.parentElement?.children[0];
   expect(dot).toBeInTheDocument();
   expect(dot).toHaveClass('text-amber-600');
 });
@@ -68,9 +66,8 @@ test('Expect column styling progressing', async () => {
 
   const text = screen.getByText('Progressing');
   expect(text).toBeInTheDocument();
-  expect(text).toHaveClass('text-gray-500');
 
-  const dot = text.parentElement?.children[0].children[0];
+  const dot = text.parentElement?.children[0];
   expect(dot).toBeInTheDocument();
   expect(dot).toHaveClass('text-sky-400');
 });
@@ -83,9 +80,8 @@ test('Expect column styling progressed', async () => {
 
   const text = screen.getByText('Progressed');
   expect(text).toBeInTheDocument();
-  expect(text).toHaveClass('text-gray-500');
 
-  const dot = text.parentElement?.children[0].children[0];
+  const dot = text.parentElement?.children[0];
   expect(dot).toBeInTheDocument();
   expect(dot).toHaveClass('text-sky-400');
 });

--- a/packages/renderer/src/lib/deployments/DeploymentColumnConditions.svelte
+++ b/packages/renderer/src/lib/deployments/DeploymentColumnConditions.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
 import { faCheckCircle, faExclamationTriangle, faQuestionCircle, faSync } from '@fortawesome/free-solid-svg-icons';
-import { Tooltip } from '@podman-desktop/ui-svelte';
 import Fa from 'svelte-fa';
 
+import Label from '../ui/Label.svelte';
 import type { DeploymentCondition, DeploymentUI } from './DeploymentUI';
 
 export let object: DeploymentUI;
@@ -34,14 +34,8 @@ function getConditionAttributes(condition: DeploymentCondition) {
 
 <div class="flex flex-row gap-1">
   {#each object.conditions as condition}
-    <Tooltip bottom tip="{condition.message}">
-      <div class="flex flex-row bg-charcoal-500 items-center p-1 rounded-md text-xs text-gray-500">
-        <Fa
-          size="1x"
-          icon="{getConditionAttributes(condition).icon}"
-          class="{getConditionAttributes(condition).color} mr-1" />
-        {getConditionAttributes(condition).name}
-      </div>
-    </Tooltip>
+    <Label tip="{condition.message}" name="{getConditionAttributes(condition).name}">
+      <Fa size="1x" icon="{getConditionAttributes(condition).icon}" class="{getConditionAttributes(condition).color}" />
+    </Label>
   {/each}
 </div>

--- a/packages/renderer/src/lib/image/ImageColumnEnvironment.spec.ts
+++ b/packages/renderer/src/lib/image/ImageColumnEnvironment.spec.ts
@@ -47,6 +47,4 @@ test('Expect simple column styling', async () => {
 
   const text = screen.getByText(image.engineName);
   expect(text).toBeInTheDocument();
-  expect(text).toHaveClass('text-xs');
-  expect(text).toHaveClass('capitalize');
 });

--- a/packages/renderer/src/lib/image/ImageColumnEnvironment.svelte
+++ b/packages/renderer/src/lib/image/ImageColumnEnvironment.svelte
@@ -5,6 +5,4 @@ import type { ImageInfoUI } from './ImageInfoUI';
 export let object: ImageInfoUI;
 </script>
 
-<div class="text-xs rounded-md text-gray-500">
-  <ProviderInfo provider="{object.engineName}" context="{object.engineId}" />
-</div>
+<ProviderInfo provider="{object.engineName}" context="{object.engineId}" />

--- a/packages/renderer/src/lib/node/NodeColumnRoles.svelte
+++ b/packages/renderer/src/lib/node/NodeColumnRoles.svelte
@@ -2,6 +2,7 @@
 import { faMicrochip, faSatelliteDish } from '@fortawesome/free-solid-svg-icons';
 import Fa from 'svelte-fa';
 
+import Label from '../ui/Label.svelte';
 import type { NodeUI } from './NodeUI';
 
 export let object: NodeUI;
@@ -25,9 +26,6 @@ function getConditionColour(role: 'control-plane' | 'node'): string {
 }
 </script>
 
-<div class="flex flex-row gap-1">
-  <div class="flex flex-row bg-charcoal-500 items-center p-1 rounded-md text-xs text-gray-500">
-    <Fa size="1x" icon="{roleIcon}" class="{getConditionColour(object.role)} mr-1" />
-    {roleName}
-  </div>
-</div>
+<Label name="{roleName}">
+  <Fa size="1x" icon="{roleIcon}" class="{getConditionColour(object.role)}" />
+</Label>

--- a/packages/renderer/src/lib/pod/PodColumnEnvironment.spec.ts
+++ b/packages/renderer/src/lib/pod/PodColumnEnvironment.spec.ts
@@ -43,6 +43,4 @@ test('Expect simple column styling', async () => {
 
   const text = screen.getByText(pod.kind);
   expect(text).toBeInTheDocument();
-  expect(text).toHaveClass('text-xs');
-  expect(text).toHaveClass('capitalize');
 });

--- a/packages/renderer/src/lib/pod/PodColumnEnvironment.svelte
+++ b/packages/renderer/src/lib/pod/PodColumnEnvironment.svelte
@@ -5,6 +5,4 @@ import type { PodInfoUI } from './PodInfoUI';
 export let object: PodInfoUI;
 </script>
 
-<div class="text-xs rounded-md text-gray-500">
-  <ProviderInfo provider="{object.kind}" context="{object.engineId}" />
-</div>
+<ProviderInfo provider="{object.kind}" context="{object.engineId}" />

--- a/packages/renderer/src/lib/service/ServiceColumnType.spec.ts
+++ b/packages/renderer/src/lib/service/ServiceColumnType.spec.ts
@@ -39,9 +39,8 @@ test('Expect basic column styling', async () => {
 
   const text = screen.getByText(service.type);
   expect(text).toBeInTheDocument();
-  expect(text).toHaveClass('text-gray-500');
 
-  const dot = text.parentElement?.children[0].children[0];
+  const dot = text.parentElement?.children[0];
   expect(dot).toBeInTheDocument();
   expect(dot).toHaveClass('text-gray-600');
 });
@@ -52,9 +51,8 @@ test('Expect column styling ClusterIP', async () => {
 
   const text = screen.getByText(service.type);
   expect(text).toBeInTheDocument();
-  expect(text).toHaveClass('text-gray-500');
 
-  const dot = text.parentElement?.children[0].children[0];
+  const dot = text.parentElement?.children[0];
   expect(dot).toBeInTheDocument();
   expect(dot).toHaveClass('text-sky-500');
 });
@@ -65,9 +63,8 @@ test('Expect column styling LoadBalancer', async () => {
 
   const text = screen.getByText(service.type);
   expect(text).toBeInTheDocument();
-  expect(text).toHaveClass('text-gray-500');
 
-  const dot = text.parentElement?.children[0].children[0];
+  const dot = text.parentElement?.children[0];
   expect(dot).toBeInTheDocument();
   expect(dot).toHaveClass('text-purple-500');
 });
@@ -78,9 +75,8 @@ test('Expect column styling NodePort', async () => {
 
   const text = screen.getByText(service.type);
   expect(text).toBeInTheDocument();
-  expect(text).toHaveClass('text-gray-500');
 
-  const dot = text.parentElement?.children[0].children[0];
+  const dot = text.parentElement?.children[0];
   expect(dot).toBeInTheDocument();
   expect(dot).toHaveClass('text-fuschia-600');
 });

--- a/packages/renderer/src/lib/service/ServiceColumnType.svelte
+++ b/packages/renderer/src/lib/service/ServiceColumnType.svelte
@@ -2,6 +2,7 @@
 import { faBalanceScale, faNetworkWired, faPlug, faQuestionCircle } from '@fortawesome/free-solid-svg-icons';
 import { Fa } from 'svelte-fa';
 
+import Label from '../ui/Label.svelte';
 import type { ServiceUI } from './ServiceUI';
 
 export let object: ServiceUI;
@@ -25,7 +26,6 @@ function getTypeAttributes(type: string) {
 }
 </script>
 
-<div class="flex flex-row bg-charcoal-500 items-center p-1 rounded-md text-xs text-gray-500">
-  <Fa size="1x" icon="{getTypeAttributes(object.type).icon}" class="{getTypeAttributes(object.type).color} mr-1" />
-  {object.type}
-</div>
+<Label name="{object.type}">
+  <Fa size="1x" icon="{getTypeAttributes(object.type).icon}" class="{getTypeAttributes(object.type).color}" />
+</Label>

--- a/packages/renderer/src/lib/ui/Label.spec.ts
+++ b/packages/renderer/src/lib/ui/Label.spec.ts
@@ -21,31 +21,31 @@ import '@testing-library/jest-dom/vitest';
 import { render, screen } from '@testing-library/svelte';
 import { expect, test } from 'vitest';
 
-import NodeColumnRoles from './NodeColumnRoles.svelte';
-import type { NodeUI } from './NodeUI';
+import LabelSpec from './LabelSpec.svelte';
 
-const nodeControlPlane: NodeUI = {
-  name: 'main-node',
-  status: 'active',
-  role: 'control-plane',
-} as NodeUI;
-
-const nodeWorker: NodeUI = {
-  name: 'second-node',
-  status: 'active',
-  role: 'node',
-} as NodeUI;
-
-test('Expect role display for control plane', async () => {
-  render(NodeColumnRoles, { object: nodeControlPlane });
-
-  const text = screen.getByText('Control Plane');
-  expect(text).toBeInTheDocument();
+test('Expect basic styling', async () => {
+  const text = 'A label';
+  render(LabelSpec, {
+    name: text,
+    slot: 'slot',
+  });
+  const label = screen.getByText(text);
+  expect(label).toBeInTheDocument();
+  expect(label.parentElement).toHaveClass('bg-[var(--pd-label-bg)]');
+  expect(label.parentElement).toHaveClass('text-[var(--pd-label-text)]');
+  expect(label.parentElement).toHaveClass('text-xs');
+  expect(label.parentElement).toHaveClass('rounded-md');
+  expect(label.parentElement).toHaveClass('p-1');
+  expect(label.parentElement).toHaveClass('gap-x-1');
 });
 
-test('Expect role display for node', async () => {
-  render(NodeColumnRoles, { object: nodeWorker });
-
-  const text = screen.getByText('Node');
-  expect(text).toBeInTheDocument();
+test('Expect tooltip', async () => {
+  const tip = 'a tooltip';
+  render(LabelSpec, {
+    name: 'label',
+    tip: tip,
+  });
+  const label = screen.getByText(tip);
+  expect(label).toBeInTheDocument();
+  expect(label.parentElement?.firstChild).toBeInTheDocument();
 });

--- a/packages/renderer/src/lib/ui/Label.svelte
+++ b/packages/renderer/src/lib/ui/Label.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+import { Tooltip } from '@podman-desktop/ui-svelte';
+
+export let name = '';
+export let tip = '';
+</script>
+
+<Tooltip top tip="{tip}">
+  <div class="flex items-center bg-[var(--pd-label-bg)] p-1 rounded-md text-xs text-[var(--pd-label-text)] gap-x-1">
+    <slot></slot>
+    <span class="capitalize">
+      {name}
+    </span>
+  </div>
+</Tooltip>

--- a/packages/renderer/src/lib/ui/LabelSpec.svelte
+++ b/packages/renderer/src/lib/ui/LabelSpec.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+import Label from './Label.svelte';
+
+export let name = '';
+export let tip = '';
+export let slot = '';
+</script>
+
+<Label tip="{tip}" name="{name}">{slot}</Label>

--- a/packages/renderer/src/lib/ui/ProviderInfo.svelte
+++ b/packages/renderer/src/lib/ui/ProviderInfo.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
-import { Tooltip } from '@podman-desktop/ui-svelte';
-
 import { ContainerGroupInfoTypeUI } from '../container/ContainerInfoUI';
 import { PodGroupInfoTypeUI } from '../pod/PodInfoUI';
+import Label from './Label.svelte';
 
 // Name of the provider (e.g. podman, docker, kubernetes)
 export let provider = '';
@@ -29,16 +28,6 @@ function getProviderColour(providerName: string): string {
 }
 </script>
 
-<div class="flex items-center bg-charcoal-500 p-1 rounded-md">
-  <div class="w-2 h-2 {getProviderColour(provider)} rounded-full mr-1"></div>
-  <span class="text-xs capitalize">
-    <!-- If Kubernetes, show the context via the tooltip / hover, else just provider the name.-->
-    {#if provider === 'Kubernetes'}
-      <Tooltip top tip="{context}">
-        {provider}
-      </Tooltip>
-    {:else}
-      {provider}
-    {/if}
-  </span>
-</div>
+<Label tip="{provider === 'Kubernetes' ? context : ''}" name="{provider}">
+  <div class="w-2 h-2 {getProviderColour(provider)} rounded-full"></div>
+</Label>

--- a/packages/renderer/src/lib/volume/VolumeColumnEnvironment.spec.ts
+++ b/packages/renderer/src/lib/volume/VolumeColumnEnvironment.spec.ts
@@ -45,6 +45,4 @@ test('Expect simple column styling', async () => {
 
   const text = screen.getByText(volume.engineName);
   expect(text).toBeInTheDocument();
-  expect(text).toHaveClass('text-xs');
-  expect(text).toHaveClass('capitalize');
 });

--- a/packages/renderer/src/lib/volume/VolumeColumnEnvironment.svelte
+++ b/packages/renderer/src/lib/volume/VolumeColumnEnvironment.svelte
@@ -5,6 +5,4 @@ import type { VolumeInfoUI } from './VolumeInfoUI';
 export let object: VolumeInfoUI;
 </script>
 
-<div class="text-xs rounded-md text-gray-500">
-  <ProviderInfo provider="{object.engineName}" context="{object.engineId}" />
-</div>
+<ProviderInfo provider="{object.engineName}" context="{object.engineId}" />


### PR DESCRIPTION
### What does this PR do?

We have labels in several table columns: a rounded bg with a dot or icon + text. (re:naming - we already have 'badges', and these are like github labels) The existing labels have copied and inconsistent styling, so this creates a new Label component and reuses it for these cases. The name property provides the text and icon or dot goes in the slot, with optional tooltip.

Image/pod had duplicate/unnecessary styling, removed rounded and text-sm. Removed styling checks from downstream tests.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Part of #7348.

### How to test this PR?

Check label columns on most pages.

- [x] Tests are covering the bug fix or the new feature