### PR TITLE
fix: close watcher when FileSystemWatcher is disposed

### DIFF
--- a/packages/main/src/plugin/filesystem-monitoring.spec.ts
+++ b/packages/main/src/plugin/filesystem-monitoring.spec.ts
@@ -1,0 +1,76 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { closeSync, mkdirSync, openSync, promises, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+
+import { FileSystemWatcherImpl } from './filesystem-monitoring.js';
+import { Uri } from './types/uri.js';
+
+let rootdir: string;
+let watcher: FileSystemWatcherImpl | undefined;
+
+beforeEach(async () => {
+  rootdir = await promises.mkdtemp(path.join(os.tmpdir(), 'pd-tests-'));
+});
+
+afterEach(async () => {
+  if (watcher) {
+    watcher.dispose();
+    watcher = undefined;
+  }
+  if (rootdir) {
+    await promises.rm(rootdir, { recursive: true });
+  }
+});
+
+test('should send event into onDid when a file is watched into an existing directory', async () => {
+  const watchedFile = path.join(rootdir, '/path/to/watch/file.txt');
+  const parentDir = path.dirname(watchedFile);
+
+  mkdirSync(parentDir, { recursive: true });
+  watcher = new FileSystemWatcherImpl(watchedFile);
+  const createListener = vi.fn();
+  watcher.onDidCreate(createListener);
+  const changeListener = vi.fn();
+  watcher.onDidChange(changeListener);
+  const unlinkListener = vi.fn();
+  watcher.onDidDelete(unlinkListener);
+
+  expect(createListener).not.toHaveBeenCalled();
+  const h = openSync(watchedFile, 'a');
+  closeSync(h);
+  await vi.waitFor(async () => {
+    expect(createListener).toHaveBeenCalledWith(Uri.file(watchedFile));
+  });
+
+  expect(changeListener).not.toHaveBeenCalled();
+  writeFileSync(watchedFile, 'new content');
+  await vi.waitFor(async () => {
+    expect(changeListener).toHaveBeenCalledWith(Uri.file(watchedFile));
+  });
+
+  expect(unlinkListener).not.toHaveBeenCalled();
+  rmSync(watchedFile);
+  await vi.waitFor(async () => {
+    expect(unlinkListener).toHaveBeenCalledWith(Uri.file(watchedFile));
+  });
+});

--- a/packages/main/src/plugin/filesystem-monitoring.spec.ts
+++ b/packages/main/src/plugin/filesystem-monitoring.spec.ts
@@ -30,6 +30,8 @@ let watcher: FileSystemWatcherImpl | undefined;
 
 beforeEach(async () => {
   rootdir = await promises.mkdtemp(path.join(os.tmpdir(), 'pd-tests-'));
+  // chokidar can fail with symlinks in some circumstances, let's resolve them
+  rootdir = await promises.realpath(rootdir);
 });
 
 afterEach(async () => {

--- a/packages/main/src/plugin/filesystem-monitoring.ts
+++ b/packages/main/src/plugin/filesystem-monitoring.ts
@@ -32,6 +32,10 @@ export class FileSystemWatcherImpl implements containerDesktopAPI.FileSystemWatc
       persistent: true,
     });
 
+    this.watcher.on('ready', () => {
+      this._onReady.fire();
+    });
+
     this.watcher.on('add', (addedPath: string) => {
       const uri: containerDesktopAPI.Uri = Uri.file(addedPath);
       this._onDidCreate.fire(uri);
@@ -47,14 +51,16 @@ export class FileSystemWatcherImpl implements containerDesktopAPI.FileSystemWatc
       this._onDidDelete.fire(uri);
     });
 
-    this._disposable = Disposable.from(this._onDidCreate, this._onDidChange, this._onDidDelete);
+    this._disposable = Disposable.from(this._onReady, this._onDidCreate, this._onDidChange, this._onDidDelete);
   }
 
   private _disposable: containerDesktopAPI.Disposable;
+  private readonly _onReady = new Emitter<void>();
   private readonly _onDidChange = new Emitter<containerDesktopAPI.Uri>();
   private readonly _onDidCreate = new Emitter<containerDesktopAPI.Uri>();
   private readonly _onDidDelete = new Emitter<containerDesktopAPI.Uri>();
 
+  readonly onReady: containerDesktopAPI.Event<void> = this._onReady.event;
   readonly onDidChange: containerDesktopAPI.Event<containerDesktopAPI.Uri> = this._onDidChange.event;
   readonly onDidCreate: containerDesktopAPI.Event<containerDesktopAPI.Uri> = this._onDidCreate.event;
   readonly onDidDelete: containerDesktopAPI.Event<containerDesktopAPI.Uri> = this._onDidDelete.event;


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Fixes #7501 


### How to test this PR?

Unit tests should pass.

Specifically, the tests in packages/main/src/plugin/filesystem-monitoring.spec.ts. 

If there is only one test in packages/main/src/plugin/filesystem-monitoring.spec.ts, the issue #7501 is not reproducible, but adding a second test (by duplicating the first one for example), makes `yarn test:unit` fail with the error:

```
Assertion failed: (napi_create_external(env, instance, fse_instance_destroy, NULL, &result) == napi_ok), function FSEStart, file ../src/fsevents.c, line 217.
```

- [x] Tests are covering the bug fix or the new feature
