### PR TITLE
chore: be able to compare role nodes

### DIFF
--- a/packages/renderer/src/lib/node/NodesList.svelte
+++ b/packages/renderer/src/lib/node/NodesList.svelte
@@ -52,6 +52,7 @@ let nameColumn = new TableColumn<NodeUI>('Name', {
 
 let rolesColumn = new TableColumn<NodeUI>('Roles', {
   renderer: NodeColumnRoles,
+  comparator: (a, b) => a.role.localeCompare(b.role),
 });
 
 let ageColumn = new TableColumn<NodeUI, Date | undefined>('Age', {


### PR DESCRIPTION
chore: be able to compare role nodes

### What does this PR do?

You should be able to compare role nodes / sort.

Follow up from https://github.com/containers/podman-desktop/pull/7347

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->
![Screenshot 2024-06-06 at 2 31 24 PM](https://github.com/containers/podman-desktop/assets/6422176/3c96ba04-1f30-4e34-bf0d-e10e2291fd4b)



### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

N/A

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

See that you can sort / the column sortable caret is there.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
