### PR TITLE
chore: support different parent/child types in tables

### DIFF
--- a/packages/ui/src/lib/table/table.ts
+++ b/packages/ui/src/lib/table/table.ts
@@ -96,7 +96,7 @@ export class Column<Type, RenderType = Type> {
 /**
  * Options to be used when creating a Row.
  */
-export interface RowInformation<Type> {
+export interface RowInformation<Type, ChildType> {
   /**
    * Returns true if a row can be selected, and false otherwise.
    */
@@ -110,12 +110,12 @@ export interface RowInformation<Type> {
   /**
    * Returns an array of child objects of a given row.
    */
-  readonly children?: (object: Type) => Type[];
+  readonly children?: (object: Type) => ChildType[];
 }
 
 /**
  * A table row.
  */
-export class Row<Type> {
-  constructor(readonly info: RowInformation<Type>) {}
+export class Row<Type, ChildType = Type> {
+  constructor(readonly info: RowInformation<Type, ChildType>) {}
 }


### PR DESCRIPTION
### What does this PR do?

A previous PR added support for having child items in tables, but the type of the parent and child objects is the same.

For the Containers page, the parents are always ContainerGroupInfoUI and the children are always ContainerInfoUI. This change just adds an optional second type (identically to how we did rendering types in Column) so that you can declare the different types naturally as:
  `ContainerGroupInfoUI, ContainerInfoUI`
instead of having to do:
  `ContainerGroupInfoUI | ContainerInfoUI`
and deal with typing issues in the client code.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Part of #4843.

### How to test this PR?

Just existing tests; doesn't change any functionality.