### PR TITLE
chore: add nodeport to kubernetes services

### DIFF
--- a/packages/renderer/src/lib/kube/details/KubeServiceArtifact.spec.ts
+++ b/packages/renderer/src/lib/kube/details/KubeServiceArtifact.spec.ts
@@ -30,6 +30,7 @@ const fakeServiceSpec = {
   sessionAffinity: 'None',
   ports: [
     { name: 'http', port: 80, protocol: 'TCP' },
+    { name: 'http2', port: 80, nodePort: 12345, protocol: 'TCP' },
     { port: 443, protocol: 'TCP' },
   ],
   selector: {
@@ -55,6 +56,7 @@ test('Renders service spec correctly', () => {
   // Verify ports are displayed correctly
   expect(screen.getByText('Ports')).toBeInTheDocument();
   expect(screen.getByText('http:80/TCP')).toBeInTheDocument();
+  expect(screen.getByText('http2:80:12345/TCP')).toBeInTheDocument();
   expect(screen.getByText('443/TCP')).toBeInTheDocument();
 
   // Verify selectors are displayed correctly

--- a/packages/renderer/src/lib/kube/details/KubeServiceArtifact.svelte
+++ b/packages/renderer/src/lib/kube/details/KubeServiceArtifact.svelte
@@ -34,7 +34,9 @@ export let artifact: V1ServiceSpec | undefined;
       <Cell>Ports</Cell>
       <Cell>
         {#each artifact.ports as port}
-          <div>{port.name ? port.name + ':' : ''}{port.port}/{port.protocol}</div>
+          <div>
+            {port.name ? port.name + ':' : ''}{port.port}{port.nodePort ? ':' + port.nodePort : ''}/{port.protocol}
+          </div>
         {/each}
       </Cell>
     </tr>

--- a/packages/renderer/src/lib/service/ServicesList.svelte
+++ b/packages/renderer/src/lib/service/ServicesList.svelte
@@ -98,6 +98,7 @@ let clusterIPColumn = new TableColumn<ServiceUI, string>('Cluster IP', {
 });
 
 let portsColumn = new TableColumn<ServiceUI, string>('Ports', {
+  width: '2fr',
   renderMapping: service => service.ports,
   renderer: TableSimpleColumn,
   comparator: (a, b) => a.ports.localeCompare(b.ports),

--- a/packages/renderer/src/lib/service/service-utils.spec.ts
+++ b/packages/renderer/src/lib/service/service-utils.spec.ts
@@ -76,3 +76,32 @@ test('expect a loadBalancerIPs if set in service', async () => {
   const serviceUI = serviceUtils.getServiceUI(service);
   expect(serviceUI.loadBalancerIPs).toEqual('10.0.0.1');
 });
+
+test('if a nodeport is also set, expect it to appear as <port>:<nodePort>/protocol', async () => {
+  const service = {
+    metadata: {
+      name: 'my-service',
+      namespace: 'test-namespace',
+    },
+    spec: {
+      ports: [
+        {
+          port: 80,
+          nodePort: 30080,
+          protocol: 'TCP',
+        },
+      ],
+    },
+    status: {
+      loadBalancer: {
+        ingress: [
+          {
+            ip: '10.0.0.1',
+          },
+        ],
+      },
+    },
+  } as V1Service;
+  const serviceUI = serviceUtils.getServiceUI(service);
+  expect(serviceUI.ports).toEqual('80:30080/TCP');
+});

--- a/packages/renderer/src/lib/service/service-utils.ts
+++ b/packages/renderer/src/lib/service/service-utils.ts
@@ -31,7 +31,9 @@ export class ServiceUtils {
       type: service.spec?.type ?? '',
       clusterIP: service.spec?.clusterIP ?? '',
       loadBalancerIPs: service.status?.loadBalancer?.ingress?.map(ingress => ingress.ip).join(', '),
-      ports: (service.spec?.ports ?? []).map(port => port.port + '/' + port.protocol).join(', '),
+      ports: (service.spec?.ports ?? [])
+        .map(port => port.port + (port.nodePort ? ':' + port.nodePort : '') + '/' + port.protocol)
+        .join(', '),
     };
   }
 }


### PR DESCRIPTION
chore: add nodeport to kubernetes services

### What does this PR do?

Adds the missing nodeport for Kubernetes services which is essential for
determining what port to access.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->
![Screenshot 2024-06-07 at 9 56 36 AM](https://github.com/containers/podman-desktop/assets/6422176/e58fd9ab-81b4-491e-96ce-5d1ff295fe2a)
![Screenshot 2024-06-07 at 9 54 37 AM](https://github.com/containers/podman-desktop/assets/6422176/a55f5042-378e-43eb-ae88-ad9a5f249cc6)



### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop/issues/7513

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
