### PR TITLE
Light mode for dropdown menus

### DIFF
--- a/packages/main/src/plugin/color-registry.ts
+++ b/packages/main/src/plugin/color-registry.ts
@@ -241,6 +241,7 @@ export class ColorRegistry {
     this.initButton();
     this.initActionButton();
     this.initTooltip();
+    this.initDropdown();
   }
 
   protected initGlobalNav(): void {
@@ -998,6 +999,49 @@ export class ColorRegistry {
     this.registerColor(`${tooltip}border`, {
       dark: colorPalette.charcoal[500],
       light: colorPalette.gray[500],
+    });
+  }
+
+  protected initDropdown(): void {
+    const dropdown = 'dropdown-';
+
+    this.registerColor(`${dropdown}bg`, {
+      dark: colorPalette.charcoal[600],
+      light: colorPalette.gray[100],
+    });
+    this.registerColor(`${dropdown}ring`, {
+      dark: colorPalette.purple[900],
+      light: colorPalette.gray[500],
+    });
+    this.registerColor(`${dropdown}hover-ring`, {
+      dark: colorPalette.purple[700],
+      light: colorPalette.purple[300],
+    });
+    this.registerColor(`${dropdown}divider`, {
+      dark: colorPalette.charcoal[600],
+      light: colorPalette.gray[100],
+    });
+
+    this.registerColor(`${dropdown}item-text`, {
+      dark: colorPalette.gray[400],
+      light: colorPalette.charcoal[600],
+    });
+    this.registerColor(`${dropdown}item-hover-bg`, {
+      dark: colorPalette.black,
+      light: colorPalette.gray[300],
+    });
+    this.registerColor(`${dropdown}item-hover-text`, {
+      dark: colorPalette.purple[500],
+      light: colorPalette.purple[500],
+    });
+
+    this.registerColor(`${dropdown}disabled-item-text`, {
+      dark: colorPalette.gray[900],
+      light: colorPalette.charcoal[100],
+    });
+    this.registerColor(`${dropdown}disabled-item-bg`, {
+      dark: colorPalette.charcoal[800],
+      light: colorPalette.gray[200],
     });
   }
 }

--- a/packages/renderer/src/lib/ui/ListItemButtonIcon.spec.ts
+++ b/packages/renderer/src/lib/ui/ListItemButtonIcon.spec.ts
@@ -44,7 +44,11 @@ test('Expect the dropDownMenuItem to have classes that display a disabled object
 
   const listItemSpan = screen.getByTitle(title);
   expect(listItemSpan).toBeInTheDocument();
-  expect(listItemSpan.parentElement!.outerHTML.indexOf('text-gray-900 bg-charcoal-800') > 0).toBeTruthy();
+  expect(
+    listItemSpan.parentElement!.outerHTML.indexOf(
+      'text-[var(--pd-dropdown-disabled-item-text)] bg-[var(--pd-dropdown-disabled-item-bg)]',
+    ) > 0,
+  ).toBeTruthy();
 });
 
 test('Expect the dropDownMenuItem to have classes that display a disabled object if the disabled when clause is true', async () => {
@@ -59,7 +63,11 @@ test('Expect the dropDownMenuItem to have classes that display a disabled object
 
   const listItemSpan = screen.getByTitle(title);
   expect(listItemSpan).toBeInTheDocument();
-  expect(listItemSpan.parentElement!.outerHTML.indexOf('text-gray-900 bg-charcoal-800') > 0).toBeTruthy();
+  expect(
+    listItemSpan.parentElement!.outerHTML.indexOf(
+      'text-[var(--pd-dropdown-disabled-item-text)] bg-[var(--pd-dropdown-disabled-item-bg)]',
+    ) > 0,
+  ).toBeTruthy();
 });
 
 test('Expect the dropDownMenuItem NOT to have classes that display a disabled object if the disabled when clause is evaluated to false', async () => {

--- a/packages/ui/src/lib/dropdownMenu/DropDownMenuItem.svelte
+++ b/packages/ui/src/lib/dropdownMenu/DropDownMenuItem.svelte
@@ -9,8 +9,9 @@ export let enabled = true;
 export let hidden = false;
 export let onClick: () => void = () => {};
 
-const enabledClasses = 'hover:bg-black hover:text-purple-500 hover:rounded-md text-gray-400 hover:cursor-pointer';
-const disabledClasses = 'text-gray-900 bg-charcoal-800';
+const enabledClasses =
+  'hover:bg-[var(--pd-dropdown-item-hover-bg)] hover:text-[var(--pd-dropdown-item-hover-text)] hover:rounded-md text-[var(--pd-dropdown-item-text)] hover:cursor-pointer';
+const disabledClasses = 'text-[var(--pd-dropdown-disabled-item-text)] bg-[var(--pd-dropdown-disabled-item-bg)]';
 </script>
 
 {#if !hidden}

--- a/packages/ui/src/lib/dropdownMenu/DropDownMenuItems.svelte
+++ b/packages/ui/src/lib/dropdownMenu/DropDownMenuItems.svelte
@@ -24,6 +24,6 @@ onMount(() => {
   title="Drop Down Menu Items"
   bind:clientHeight="{dropDownHeight}"
   bind:this="{dropDownElement}"
-  class="origin-top-right absolute right-0 z-10 m-2 rounded-md shadow-lg bg-charcoal-600 ring-2 ring-purple-900 hover:ring-purple-700 divide-y divide-charcoal-600 focus:outline-none">
+  class="origin-top-right absolute right-0 z-10 m-2 rounded-md shadow-lg bg-[var(--pd-dropdown-bg)] ring-2 ring-[var(--pd-dropdown-ring)] hover:ring-[var(--pd-dropdown-hover-ring)] divide-y divide-[var(--pd-dropdown-divider)] focus:outline-none">
   <slot />
 </div>

--- a/packages/ui/src/lib/dropdownMenu/DropdownMenu.svelte
+++ b/packages/ui/src/lib/dropdownMenu/DropdownMenu.svelte
@@ -56,9 +56,9 @@ function onButtonClick(e: MouseEvent): void {
       on:click="{onButtonClick}"
       title="{title}"
       bind:this="{outsideWindow}"
-      class="text-gray-400 {shownAsMenuActionItem
-        ? 'bg-charcoal-800 px-3'
-        : 'hover:bg-charcoal-800'} hover:text-purple-400 font-medium rounded-md inline-flex items-center px-2 py-2 text-center">
+      class="text-[var(--pd-action-button-text)] {shownAsMenuActionItem
+        ? 'bg-[var(--pd-action-button-details-bg)] px-3'
+        : 'hover:bg-[var(--pd-action-button-details-bg)]'} hover:text-[var(--pd-action-button-hover-text)] font-medium rounded-md inline-flex items-center px-2 py-2 text-center">
       <Fa class="h-4 w-4" icon="{icon}" />
     </button>
 


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Light mode for dropdown menus

Visible in containers/Images/Pods/Volumes lists

### Screenshot / video of UI
![light_dropdown](https://github.com/containers/podman-desktop/assets/9973512/c453b8d4-70e4-4ab6-b0eb-0293af089b27)

### What issues does this PR fix or reference?

Part of #7185 

### How to test this PR?

- [x] Tests are covering the bug fix or the new feature
