### PR TITLE
Light mode for installed extensions buttons

### DIFF
--- a/packages/main/src/plugin/color-registry.ts
+++ b/packages/main/src/plugin/color-registry.ts
@@ -946,7 +946,7 @@ export class ColorRegistry {
 
     this.registerColor(`${ab}text`, {
       dark: colorPalette.gray[400],
-      light: colorPalette.charcoal[900],
+      light: colorPalette.charcoal[500],
     });
     this.registerColor(`${ab}bg`, {
       dark: colorPalette.charcoal[900],

--- a/packages/main/src/plugin/color-registry.ts
+++ b/packages/main/src/plugin/color-registry.ts
@@ -948,12 +948,25 @@ export class ColorRegistry {
       dark: colorPalette.gray[400],
       light: colorPalette.charcoal[900],
     });
+    this.registerColor(`${ab}bg`, {
+      dark: colorPalette.charcoal[900],
+      light: colorPalette.gray[400],
+    });
     this.registerColor(`${ab}hover-bg`, {
       dark: colorPalette.charcoal[600],
       light: colorPalette.gray[50],
     });
     this.registerColor(`${ab}hover-text`, {
       dark: colorPalette.purple[600],
+      light: colorPalette.purple[500],
+    });
+
+    this.registerColor(`${ab}primary-text`, {
+      dark: colorPalette.purple[600],
+      light: colorPalette.purple[600],
+    });
+    this.registerColor(`${ab}primary-hover-text`, {
+      dark: colorPalette.purple[500],
       light: colorPalette.purple[500],
     });
 

--- a/packages/renderer/src/lib/extensions/InstalledExtensionCardLeftLifecycle.svelte
+++ b/packages/renderer/src/lib/extensions/InstalledExtensionCardLeftLifecycle.svelte
@@ -8,7 +8,7 @@ import InstalledExtensionCardLeftLifecycleStop from './InstalledExtensionCardLef
 export let extension: CombinedExtensionInfoUI;
 </script>
 
-<div class="flex bg-charcoal-900 w-fit rounded-lg" role="group" aria-label="Extension Actions">
+<div class="flex bg-[var(--pd-action-button-bg)] w-fit rounded-lg" role="group" aria-label="Extension Actions">
   <InstalledExtensionCardLeftLifecycleStart extension="{extension}" />
   <InstalledExtensionCardLeftLifecycleStop extension="{extension}" />
   <InstalledExtensionCardLeftLifecycleDelete extension="{extension}" />

--- a/packages/renderer/src/lib/ui/LoadingIcon.svelte
+++ b/packages/renderer/src/lib/ui/LoadingIcon.svelte
@@ -17,6 +17,6 @@ export let iconSize: IconSize | undefined = undefined;
     aria-label="spinner"
     class="{loading
       ? ''
-      : 'hidden'} {loadingWidthClass} {loadingHeightClass} rounded-full animate-spin border border-solid border-violet-500 border-t-transparent absolute {positionTopClass} {positionLeftClass}">
+      : 'hidden'} {loadingWidthClass} {loadingHeightClass} rounded-full animate-spin border border-solid border-[var(--pd-action-button-spinner)] border-t-transparent absolute {positionTopClass} {positionLeftClass}">
   </div>
 </div>

--- a/packages/renderer/src/lib/ui/LoadingIconButton.spec.ts
+++ b/packages/renderer/src/lib/ui/LoadingIconButton.spec.ts
@@ -35,12 +35,12 @@ type TestScenario = {
 
 const EXPECT_ENABLE = {
   disabled: false,
-  classes: ['text-white', 'hover:text-gray-700'],
+  classes: ['text-[var(--pd-action-button-text)]', 'hover:text-[var(--pd-action-button-hover-text)]'],
 };
 
 const EXPECT_DISABLE = {
   disabled: true,
-  classes: ['text-gray-900', 'cursor-not-allowed'],
+  classes: ['text-[var(--pd-action-button-disabled-text)]', 'cursor-not-allowed'],
 };
 
 function assert(action: string, expected: { disabled: boolean; classes: string[] }): void {
@@ -101,7 +101,10 @@ test.each([
     },
     expected: {
       disabled: false,
-      classes: ['text-purple-600', 'hover:text-purple-500'],
+      classes: [
+        'text-[var(--pd-action-button-primary-text)]',
+        'hover:text-[var(--pd-action-button-primary-hover-text)]',
+      ],
     },
   },
   {

--- a/packages/renderer/src/lib/ui/LoadingIconButton.svelte
+++ b/packages/renderer/src/lib/ui/LoadingIconButton.svelte
@@ -45,10 +45,10 @@ $: {
 $: loading = state?.inProgress && action === state?.action;
 
 $: style = disable
-  ? 'text-gray-900 cursor-not-allowed'
+  ? 'text-[var(--pd-action-button-disabled-text)] cursor-not-allowed'
   : color === 'secondary'
-    ? 'text-white hover:text-gray-700'
-    : 'text-purple-600 hover:text-purple-500';
+    ? 'text-[var(--pd-action-button-text)] hover:text-[var(--pd-action-button-hover-text)]'
+    : 'text-[var(--pd-action-button-primary-text)] hover:text-[var(--pd-action-button-primary-hover-text)]';
 </script>
 
 <Tooltip bottom tip="{tooltip}">


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Light mode for actions buttons on Installed Extensions list

The icon color of the button changes from white to gray-400 and hover button from gray-700 to purple-600, to reuse the same colors as for the actions buttons in the Containers/Pods/Images lists.
 
### Screenshot / video of UI

https://github.com/containers/podman-desktop/assets/9973512/e944e7ce-6c7e-483c-bc41-69feffbb090f

### What issues does this PR fix or reference?

Fixes #7185 

### How to test this PR?

- [x] Tests are covering the bug fix or the new feature
