### PR TITLE
chore: keep sorting despite data changes

### DIFF
--- a/packages/ui/src/lib/table/Table.svelte
+++ b/packages/ui/src/lib/table/Table.svelte
@@ -50,7 +50,7 @@ function toggleAll(e: CustomEvent<boolean>): void {
 let sortCol: Column<unknown>;
 let sortAscending: boolean;
 
-if (data) {
+$: if (data && sortCol) {
   sortImpl();
 }
 

--- a/packages/ui/src/lib/table/TestTable.svelte
+++ b/packages/ui/src/lib/table/TestTable.svelte
@@ -17,7 +17,7 @@ type Person = {
   hobby: string;
 };
 
-const people: Person[] = [
+export let people: Person[] = [
   { id: 1, name: 'John', age: 57, hobby: 'Skydiving' },
   { id: 2, name: 'Henry', age: 27, hobby: 'Cooking' },
   { id: 3, name: 'Charlie', age: 43, hobby: 'Biking' },


### PR DESCRIPTION
chore: keep sorting despite data changes

### What does this PR do?

* Adds a reactive statement that sorts if there is a sort column
  selected (sortCol) as well as a data change.
* If a data change is detected (from the reactive statement), we should
  be resorting (with sortImpl). This means that if we are sorting via
  name and any data has changes, we should check and make sure we are
  still sorting accordingly.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

https://github.com/containers/podman-desktop/assets/6422176/31662ded-566d-4f7f-8ff8-793699c70073




### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop/issues/5322
Closes https://github.com/containers/podman-desktop/issues/7516
Closes https://github.com/containers/podman-desktop/issues/7476

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature

1. Sort by name
2. Delete something
3. Should stay in same order

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
