### PR TITLE
chore: add default sorting pod

### DIFF
--- a/packages/renderer/src/lib/pod/PodsList.svelte
+++ b/packages/renderer/src/lib/pod/PodsList.svelte
@@ -276,6 +276,7 @@ const row = new TableRow<PodInfoUI>({ selectable: _pod => true });
       data="{pods}"
       columns="{columns}"
       row="{row}"
+      defaultSortColumn="Name"
       on:update="{() => (pods = pods)}">
     </Table>
 


### PR DESCRIPTION
chore: add default sorting pod

### What does this PR do?

Adds default sorting for pods list to name

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->
![Screenshot 2024-06-08 at 2 46 09 PM](https://github.com/containers/podman-desktop/assets/6422176/94a191be-ee39-460d-bbaa-3061c3689d4f)



### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop/issues/7476

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

Minor UI change

See that loading pods list it is sorted by name now.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
