### PR TITLE
chore: add container statuses to pod

### DIFF
--- a/packages/renderer/src/lib/kube/details/KubePodStatusArtifact.spec.ts
+++ b/packages/renderer/src/lib/kube/details/KubePodStatusArtifact.spec.ts
@@ -44,3 +44,27 @@ test('Renders pod status correctly with hardcoded values', () => {
   expect(screen.getByText('Host IP')).toBeInTheDocument();
   expect(screen.getByText('192.168.1.2')).toBeInTheDocument();
 });
+
+test('show container statuses when present', () => {
+  const fakePodStatusWithContainers: V1PodStatus = {
+    phase: 'Running',
+    containerStatuses: [
+      {
+        name: 'container1',
+        state: {
+          waiting: {
+            reason: 'CrashLoopBackOff',
+            message: 'Back-off restarting failed container',
+          },
+        },
+      },
+    ],
+  } as V1PodStatus;
+
+  render(KubePodStatusArtifact, { artifact: fakePodStatusWithContainers });
+
+  expect(screen.getByText('Container Status')).toBeInTheDocument();
+  expect(screen.getByText('container1')).toBeInTheDocument();
+  expect(screen.getByText('CrashLoopBackOff')).toBeInTheDocument();
+  expect(screen.getByText('Back-off restarting failed container')).toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/kube/details/KubePodStatusArtifact.svelte
+++ b/packages/renderer/src/lib/kube/details/KubePodStatusArtifact.svelte
@@ -2,6 +2,7 @@
 import type { V1PodStatus } from '@kubernetes/client-node';
 
 import Cell from './ui/Cell.svelte';
+import Subtitle from './ui/Subtitle.svelte';
 import Title from './ui/Title.svelte';
 
 export let artifact: V1PodStatus | undefined;
@@ -31,4 +32,39 @@ if (artifact?.startTime) {
     <Cell>Start Time</Cell>
     <Cell>{artifact?.startTime}</Cell>
   </tr>
+
+  <!-- If containerStatus and at least one in the array has a 'state' that's not undefined.
+    as the "state" information is where the warning is (unable to pull image, etc.) -->
+  {#if artifact.containerStatuses?.some(containerStatus => containerStatus.state)}
+    <tr>
+      <Title>Container Status</Title>
+    </tr>
+    {#each artifact.containerStatuses as containerStatus}
+      {#if containerStatus.state}
+        <tr>
+          <Subtitle>{containerStatus.name}</Subtitle>
+        </tr>
+        {#if containerStatus.state.waiting}
+          <tr>
+            <Cell>Waiting</Cell>
+            <Cell>{containerStatus.state.waiting.reason}</Cell>
+          </tr>
+          <tr>
+            <Cell>Message</Cell>
+            <Cell>{containerStatus.state.waiting.message}</Cell>
+          </tr>
+        {/if}
+        {#if containerStatus.state.terminated}
+          <tr>
+            <Cell>Terminated</Cell>
+            <Cell>{containerStatus.state.terminated.reason}</Cell>
+          </tr>
+          <tr>
+            <Cell>Exit Code</Cell>
+            <Cell>{containerStatus.state.terminated.exitCode}</Cell>
+          </tr>
+        {/if}
+      {/if}
+    {/each}
+  {/if}
 {/if}


### PR DESCRIPTION
chore: add container statuses to pod

### What does this PR do?

Adds container status to pods for warnings and terminated. We do not
adding running as there is no useful information (does not provide
message, etc.).

This PR helps determine any issues such as crashloopbackoff, etc.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->
![Screenshot 2024-06-08 at 3 19 28 PM](https://github.com/containers/podman-desktop/assets/6422176/836b29b7-e6f5-4cd2-ae9e-8e2a5733c1eb)



### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop/issues/7521

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature

Check the summary and see the new statuses.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
