### PR TITLE
chore: add different colours / outputs for deployment conditions

### DIFF
--- a/packages/main/src/plugin/color-registry.ts
+++ b/packages/main/src/plugin/color-registry.ts
@@ -1166,5 +1166,11 @@ export class ColorRegistry {
       dark: colorPalette.gray[500],
       light: colorPalette.gray[800],
     });
+    // Scaled / updated, use blue as it's a 'neutral' color
+    // to indicate that it's informative but not a problem
+    this.registerColor(`${status}updated`, {
+      dark: colorPalette.sky[500],
+      light: colorPalette.sky[500],
+    });
   }
 }

--- a/packages/renderer/src/lib/deployments/DeploymentColumnConditions.spec.ts
+++ b/packages/renderer/src/lib/deployments/DeploymentColumnConditions.spec.ts
@@ -50,55 +50,6 @@ test('Expect column styling available', async () => {
   expect(svg).toHaveClass('text-[var(--pd-status-running)]');
 });
 
-/* Add more tests for
-   // Condition map for easier lookup
-  const conditionMap: { [key: string]: { name: string; color: string; icon?: IconDefinition } } = {
-    'Available:MinimumReplicasAvailable': {
-      name: 'Available',
-      color: 'text-[var(--pd-status-running)]',
-      icon: faCheckCircle,
-    },
-    'Available:MinimumReplicasUnavailable': {
-      name: 'Unavailable',
-      color: 'text-[var(--pd-status-degraded)]',
-      icon: faTimesCircle,
-    },
-    'Progressing:ReplicaSetUpdated': {
-      name: 'Updated',
-      color: 'text-[var(--pd-status-updated)]',
-    },
-    'Progressing:NewReplicaSetCreated': {
-      name: 'New Replica Set',
-      color: 'text-[var(--pd-status-updated)]',
-    },
-    'Progressing:NewReplicaSetAvailable': {
-      name: 'Progressed',
-      color: 'text-[var(--pd-status-running)]',
-      icon: faSync,
-    },
-    'Progressing:ReplicaSetScaledUp': {
-      name: 'Scaled Up',
-      color: 'text-[var(--pd-status-updated)]',
-      icon: faArrowUp,
-    },
-    'Progressing:ReplicaSetScaledDown': {
-      name: 'Scaled Down',
-      color: 'text-[var(--pd-status-updated)]',
-      icon: faArrowDown,
-    },
-    'Progressing:ProgressDeadlineExceeded': {
-      name: 'Deadline Exceeded',
-      color: 'text-[var(--pd-status-dead)]',
-      icon: faTimesCircle,
-    },
-    ReplicaFailure: {
-      name: 'Replica Failure',
-      color: 'text-[var(--pd-status-dead)]',
-      icon: faExclamationTriangle,
-    },
-  };
-  */
-
 test('Expect column styling unavailable', async () => {
   const deployment = createDeploymentUI([
     { type: 'Available', message: 'Running fine', reason: 'MinimumReplicasUnavailable' },

--- a/packages/renderer/src/lib/deployments/DeploymentColumnConditions.spec.ts
+++ b/packages/renderer/src/lib/deployments/DeploymentColumnConditions.spec.ts
@@ -37,51 +37,176 @@ function createDeploymentUI(conditions: DeploymentCondition[]) {
 }
 
 test('Expect column styling available', async () => {
-  const deployment = createDeploymentUI([{ type: 'Available', message: 'Running fine' }]);
+  const deployment = createDeploymentUI([
+    { type: 'Available', message: 'Running fine', reason: 'MinimumReplicasAvailable' },
+  ]);
   render(DeploymentColumnConditions, { object: deployment });
 
   const text = screen.getByText('Available');
   expect(text).toBeInTheDocument();
 
-  const dot = text.parentElement?.children[0];
-  expect(dot).toBeInTheDocument();
-  expect(dot).toHaveClass('text-green-600');
+  const svg = text.parentElement?.querySelector('svg');
+  expect(svg).toBeInTheDocument();
+  expect(svg).toHaveClass('text-[var(--pd-status-running)]');
 });
 
-test('Expect column styling failure', async () => {
-  const deployment = createDeploymentUI([{ type: 'ReplicaFailure', message: 'It failed!' }]);
+/* Add more tests for
+   // Condition map for easier lookup
+  const conditionMap: { [key: string]: { name: string; color: string; icon?: IconDefinition } } = {
+    'Available:MinimumReplicasAvailable': {
+      name: 'Available',
+      color: 'text-[var(--pd-status-running)]',
+      icon: faCheckCircle,
+    },
+    'Available:MinimumReplicasUnavailable': {
+      name: 'Unavailable',
+      color: 'text-[var(--pd-status-degraded)]',
+      icon: faTimesCircle,
+    },
+    'Progressing:ReplicaSetUpdated': {
+      name: 'Updated',
+      color: 'text-[var(--pd-status-updated)]',
+    },
+    'Progressing:NewReplicaSetCreated': {
+      name: 'New Replica Set',
+      color: 'text-[var(--pd-status-updated)]',
+    },
+    'Progressing:NewReplicaSetAvailable': {
+      name: 'Progressed',
+      color: 'text-[var(--pd-status-running)]',
+      icon: faSync,
+    },
+    'Progressing:ReplicaSetScaledUp': {
+      name: 'Scaled Up',
+      color: 'text-[var(--pd-status-updated)]',
+      icon: faArrowUp,
+    },
+    'Progressing:ReplicaSetScaledDown': {
+      name: 'Scaled Down',
+      color: 'text-[var(--pd-status-updated)]',
+      icon: faArrowDown,
+    },
+    'Progressing:ProgressDeadlineExceeded': {
+      name: 'Deadline Exceeded',
+      color: 'text-[var(--pd-status-dead)]',
+      icon: faTimesCircle,
+    },
+    ReplicaFailure: {
+      name: 'Replica Failure',
+      color: 'text-[var(--pd-status-dead)]',
+      icon: faExclamationTriangle,
+    },
+  };
+  */
+
+test('Expect column styling unavailable', async () => {
+  const deployment = createDeploymentUI([
+    { type: 'Available', message: 'Running fine', reason: 'MinimumReplicasUnavailable' },
+  ]);
   render(DeploymentColumnConditions, { object: deployment });
 
-  const text = screen.getByText('ReplicaFailure');
+  const text = screen.getByText('Unavailable');
   expect(text).toBeInTheDocument();
 
-  const dot = text.parentElement?.children[0];
-  expect(dot).toBeInTheDocument();
-  expect(dot).toHaveClass('text-amber-600');
+  const svg = text.parentElement?.querySelector('svg');
+  expect(svg).toBeInTheDocument();
+  expect(svg).toHaveClass('text-[var(--pd-status-degraded)]');
 });
 
-test('Expect column styling progressing', async () => {
-  const deployment = createDeploymentUI([{ type: 'Progressing', message: 'Working on it', reason: '' }]);
+test('Expect column styling updated', async () => {
+  const deployment = createDeploymentUI([
+    { type: 'Progressing', message: 'Running fine', reason: 'ReplicaSetUpdated' },
+  ]);
   render(DeploymentColumnConditions, { object: deployment });
 
-  const text = screen.getByText('Progressing');
+  const text = screen.getByText('Updated');
   expect(text).toBeInTheDocument();
 
-  const dot = text.parentElement?.children[0];
-  expect(dot).toBeInTheDocument();
-  expect(dot).toHaveClass('text-sky-400');
+  const svg = text.parentElement?.querySelector('svg');
+  expect(svg).toBeInTheDocument();
+  expect(svg).toHaveClass('text-[var(--pd-status-updated)]');
+});
+
+test('Expect column styling new replica set', async () => {
+  const deployment = createDeploymentUI([
+    { type: 'Progressing', message: 'Running fine', reason: 'NewReplicaSetCreated' },
+  ]);
+  render(DeploymentColumnConditions, { object: deployment });
+
+  const text = screen.getByText('New Replica Set');
+  expect(text).toBeInTheDocument();
+
+  const svg = text.parentElement?.querySelector('svg');
+  expect(svg).toBeInTheDocument();
+  expect(svg).toHaveClass('text-[var(--pd-status-updated)]');
 });
 
 test('Expect column styling progressed', async () => {
   const deployment = createDeploymentUI([
-    { type: 'Progressing', message: 'Successfully progressed', reason: 'NewReplicaSetAvailable' },
+    { type: 'Progressing', message: 'Running fine', reason: 'NewReplicaSetAvailable' },
   ]);
   render(DeploymentColumnConditions, { object: deployment });
 
   const text = screen.getByText('Progressed');
   expect(text).toBeInTheDocument();
 
-  const dot = text.parentElement?.children[0];
-  expect(dot).toBeInTheDocument();
-  expect(dot).toHaveClass('text-sky-400');
+  const svg = text.parentElement?.querySelector('svg');
+  expect(svg).toBeInTheDocument();
+  expect(svg).toHaveClass('text-[var(--pd-status-running)]');
+});
+
+test('Expect column styling scaled up', async () => {
+  const deployment = createDeploymentUI([
+    { type: 'Progressing', message: 'Running fine', reason: 'ReplicaSetScaledUp' },
+  ]);
+  render(DeploymentColumnConditions, { object: deployment });
+
+  const text = screen.getByText('Scaled Up');
+  expect(text).toBeInTheDocument();
+
+  const svg = text.parentElement?.querySelector('svg');
+  expect(svg).toBeInTheDocument();
+  expect(svg).toHaveClass('text-[var(--pd-status-updated)]');
+});
+
+test('Expect column styling scaled down', async () => {
+  const deployment = createDeploymentUI([
+    { type: 'Progressing', message: 'Running fine', reason: 'ReplicaSetScaledDown' },
+  ]);
+  render(DeploymentColumnConditions, { object: deployment });
+
+  const text = screen.getByText('Scaled Down');
+  expect(text).toBeInTheDocument();
+
+  const svg = text.parentElement?.querySelector('svg');
+  expect(svg).toBeInTheDocument();
+  expect(svg).toHaveClass('text-[var(--pd-status-updated)]');
+});
+
+test('Expect column styling deadline exceeded', async () => {
+  const deployment = createDeploymentUI([
+    { type: 'Progressing', message: 'Running fine', reason: 'ProgressDeadlineExceeded' },
+  ]);
+  render(DeploymentColumnConditions, { object: deployment });
+
+  const text = screen.getByText('Deadline Exceeded');
+  expect(text).toBeInTheDocument();
+
+  const svg = text.parentElement?.querySelector('svg');
+  expect(svg).toBeInTheDocument();
+  expect(svg).toHaveClass('text-[var(--pd-status-dead)]');
+});
+
+test('Expect column styling replica failure', async () => {
+  const deployment = createDeploymentUI([
+    { type: 'ReplicaFailure', message: 'Running fine', reason: 'ReplicaFailure' },
+  ]);
+  render(DeploymentColumnConditions, { object: deployment });
+
+  const text = screen.getByText('Replica Failure');
+  expect(text).toBeInTheDocument();
+
+  const svg = text.parentElement?.querySelector('svg');
+  expect(svg).toBeInTheDocument();
+  expect(svg).toHaveClass('text-[var(--pd-status-dead)]');
 });

--- a/packages/renderer/src/lib/deployments/DeploymentColumnConditions.svelte
+++ b/packages/renderer/src/lib/deployments/DeploymentColumnConditions.svelte
@@ -15,58 +15,61 @@ import Label from '../ui/Label.svelte';
 import type { DeploymentCondition, DeploymentUI } from './DeploymentUI';
 
 export let object: DeploymentUI;
+const defaultUnknownIcon: IconDefinition = faQuestionCircle;
 
 // Determine both the icon and color based on the deployment condition
 function getConditionAttributes(condition: DeploymentCondition) {
   const defaults = {
     name: condition.type,
     color: 'text-gray-500',
-    icon: faQuestionCircle,
+    icon: defaultUnknownIcon,
   };
 
   // Condition map for easier lookup
   const conditionMap: { [key: string]: { name: string; color: string; icon?: IconDefinition } } = {
     'Available:MinimumReplicasAvailable': {
-      name: 'Available',
       color: 'text-[var(--pd-status-running)]',
+      name: 'Available',
       icon: faCheckCircle,
     },
     'Available:MinimumReplicasUnavailable': {
-      name: 'Unavailable',
       color: 'text-[var(--pd-status-degraded)]',
+      name: 'Unavailable',
       icon: faTimesCircle,
     },
     'Progressing:ReplicaSetUpdated': {
-      name: 'Updated',
       color: 'text-[var(--pd-status-updated)]',
+      name: 'Updated',
+      icon: faSync,
     },
     'Progressing:NewReplicaSetCreated': {
-      name: 'New Replica Set',
       color: 'text-[var(--pd-status-updated)]',
+      name: 'New Replica Set',
+      icon: faSync,
     },
     'Progressing:NewReplicaSetAvailable': {
-      name: 'Progressed',
       color: 'text-[var(--pd-status-running)]',
+      name: 'Progressed',
       icon: faSync,
     },
     'Progressing:ReplicaSetScaledUp': {
-      name: 'Scaled Up',
       color: 'text-[var(--pd-status-updated)]',
+      name: 'Scaled Up',
       icon: faArrowUp,
     },
     'Progressing:ReplicaSetScaledDown': {
-      name: 'Scaled Down',
       color: 'text-[var(--pd-status-updated)]',
+      name: 'Scaled Down',
       icon: faArrowDown,
     },
     'Progressing:ProgressDeadlineExceeded': {
-      name: 'Deadline Exceeded',
       color: 'text-[var(--pd-status-dead)]',
+      name: 'Deadline Exceeded',
       icon: faTimesCircle,
     },
     'ReplicaFailure:ReplicaFailure': {
-      name: 'Replica Failure',
       color: 'text-[var(--pd-status-dead)]',
+      name: 'Replica Failure',
       icon: faExclamationTriangle,
     },
   };
@@ -75,7 +78,7 @@ function getConditionAttributes(condition: DeploymentCondition) {
   const key = `${condition.type}:${condition.reason}`;
 
   // Return the corresponding attributes or default if not found
-  return conditionMap[key] || defaults;
+  return conditionMap[key] ?? defaults;
 }
 </script>
 
@@ -84,7 +87,7 @@ function getConditionAttributes(condition: DeploymentCondition) {
     <Label tip="{condition.message}" name="{getConditionAttributes(condition).name}">
       <Fa
         size="1x"
-        icon="{getConditionAttributes(condition).icon ?? faQuestionCircle}"
+        icon="{getConditionAttributes(condition).icon ?? defaultUnknownIcon}"
         class="{getConditionAttributes(condition).color}" />
     </Label>
   {/each}

--- a/packages/renderer/src/lib/deployments/DeploymentColumnConditions.svelte
+++ b/packages/renderer/src/lib/deployments/DeploymentColumnConditions.svelte
@@ -15,18 +15,17 @@ import Label from '../ui/Label.svelte';
 import type { DeploymentCondition, DeploymentUI } from './DeploymentUI';
 
 export let object: DeploymentUI;
-const defaultUnknownIcon: IconDefinition = faQuestionCircle;
 
 // Determine both the icon and color based on the deployment condition
 function getConditionAttributes(condition: DeploymentCondition) {
   const defaults = {
     name: condition.type,
     color: 'text-[var(--pd-status-unknown)]',
-    icon: defaultUnknownIcon,
+    icon: faQuestionCircle,
   };
 
   // Condition map for easier lookup
-  const conditionMap: { [key: string]: { name: string; color: string; icon?: IconDefinition } } = {
+  const conditionMap: { [key: string]: { name: string; color: string; icon: IconDefinition } } = {
     'Available:MinimumReplicasAvailable': {
       color: 'text-[var(--pd-status-running)]',
       name: 'Available',
@@ -85,10 +84,7 @@ function getConditionAttributes(condition: DeploymentCondition) {
 <div class="flex flex-row gap-1">
   {#each object.conditions as condition}
     <Label tip="{condition.message}" name="{getConditionAttributes(condition).name}">
-      <Fa
-        size="1x"
-        icon="{getConditionAttributes(condition).icon ?? defaultUnknownIcon}"
-        class="{getConditionAttributes(condition).color}" />
+      <Fa size="1x" icon="{getConditionAttributes(condition).icon}" class="{getConditionAttributes(condition).color}" />
     </Label>
   {/each}
 </div>

--- a/packages/renderer/src/lib/deployments/DeploymentColumnConditions.svelte
+++ b/packages/renderer/src/lib/deployments/DeploymentColumnConditions.svelte
@@ -21,7 +21,7 @@ const defaultUnknownIcon: IconDefinition = faQuestionCircle;
 function getConditionAttributes(condition: DeploymentCondition) {
   const defaults = {
     name: condition.type,
-    color: 'text-gray-500',
+    color: 'text-[var(--pd-status-unknown)]',
     icon: defaultUnknownIcon,
   };
 


### PR DESCRIPTION
chore: add different colours / outputs for deployment conditions

### What does this PR do?

* Adds different colours and outputs to conditions for deployments.
* Uses all available "reasons" according to kubernetes API
* Refactors to a condition map

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->
<img width="550" alt="Screenshot 2024-06-09 at 10 44 28 PM" src="https://github.com/containers/podman-desktop/assets/6422176/f1ab3f76-ac7d-4381-8d1d-906235f0d7ff">



### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop/issues/7518

### How to test this PR?

Modify a deployment / change it so that it becomes unavailable (easiest
way is to change to a non-existing image name).

See the changes on the deployment list.

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
