### PR TITLE
fix: initialize podmanInstall when no podman in installed

### DIFF
--- a/extensions/podman/src/extension.spec.ts
+++ b/extensions/podman/src/extension.spec.ts
@@ -1355,7 +1355,9 @@ describe('initCheckAndRegisterUpdate', () => {
 
   test('check update appear after updating the version', async () => {
     const podmanInstall = {
-      checkForUpdate: vi.fn(),
+      checkForUpdate: vi
+        .fn()
+        .mockResolvedValue({ installedVersion: undefined, hasUpdate: false, bundledVersion: undefined }),
     } as unknown as PodmanInstall;
 
     // disposable

--- a/extensions/podman/src/extension.spec.ts
+++ b/extensions/podman/src/extension.spec.ts
@@ -1856,7 +1856,7 @@ describe('calcPodmanMachineSetting', () => {
   });
 });
 
-test('checkForUpdate should be called if there is no podman installed', async () => {
+test('checkForUpdate func should be called if there is no podman installed', async () => {
   const extensionContext = { subscriptions: [], storagePath: '' } as unknown as extensionApi.ExtensionContext;
   const podmanInstall: PodmanInstall = new PodmanInstall(extensionContext);
 

--- a/extensions/podman/src/extension.spec.ts
+++ b/extensions/podman/src/extension.spec.ts
@@ -34,7 +34,7 @@ import {
 } from './extension';
 import * as extension from './extension';
 import type { InstalledPodman } from './podman-cli';
-import { getPodmanCli } from './podman-cli';
+import * as podmanCli from './podman-cli';
 import { PodmanConfiguration } from './podman-configuration';
 import { PodmanInstall } from './podman-install';
 import { getAssetsFolder, isLinux, isMac, isWindows, LoggerDelegator } from './util';
@@ -289,7 +289,7 @@ test('verify create command called with correct values', async () => {
     undefined,
   );
   expect(spyExecPromise).toBeCalledWith(
-    getPodmanCli(),
+    podmanCli.getPodmanCli(),
     ['machine', 'init', '--cpus', '2', '--memory', '999', '--disk-size', '232', '--image-path', 'path', '--rootful'],
     {
       logger: undefined,
@@ -342,7 +342,7 @@ test('verify create command called with correct values with user mode networking
     '--rootful',
     '--user-mode-networking',
   ];
-  expect(spyExecPromise).toBeCalledWith(getPodmanCli(), parameters, {
+  expect(spyExecPromise).toBeCalledWith(podmanCli.getPodmanCli(), parameters, {
     logger: undefined,
   });
   expect(console.error).not.toBeCalled();
@@ -392,7 +392,7 @@ test('verify create command called with now flag if start machine after creation
     '--rootful',
     '--now',
   ];
-  expect(spyExecPromise).toBeCalledWith(getPodmanCli(), parameters, {
+  expect(spyExecPromise).toBeCalledWith(podmanCli.getPodmanCli(), parameters, {
     logger: undefined,
   });
   expect(console.error).not.toBeCalled();
@@ -454,7 +454,7 @@ test('verify create command called with embedded image if using podman v5', asyn
 
   expect(vi.mocked(extensionApi.process.exec)).toHaveBeenNthCalledWith(
     3,
-    getPodmanCli(),
+    podmanCli.getPodmanCli(),
     expect.arrayContaining([expect.stringContaining('.zst')]),
     expect.anything(),
   );
@@ -512,7 +512,7 @@ test('if a machine is successfully started it changes its state to started', asy
   );
   await extension.startMachine(provider, machineInfo);
 
-  expect(spyExecPromise).toBeCalledWith(getPodmanCli(), ['machine', 'start', 'name'], {
+  expect(spyExecPromise).toBeCalledWith(podmanCli.getPodmanCli(), ['machine', 'start', 'name'], {
     logger: new LoggerDelegator(),
   });
 
@@ -538,7 +538,7 @@ test('if a machine is successfully reporting telemetry', async () => {
     expect.objectContaining({ hostCpus: expect.anything() }),
   );
 
-  expect(spyExecPromise).toBeCalledWith(getPodmanCli(), ['machine', 'start', 'name'], expect.anything());
+  expect(spyExecPromise).toBeCalledWith(podmanCli.getPodmanCli(), ['machine', 'start', 'name'], expect.anything());
 });
 
 test('if a machine is successfully reporting an error in telemetry', async () => {
@@ -559,7 +559,7 @@ test('if a machine is successfully reporting an error in telemetry', async () =>
     expect.objectContaining({ hostCpus: expect.anything(), error: customError }),
   );
 
-  expect(spyExecPromise).toBeCalledWith(getPodmanCli(), ['machine', 'start', 'name'], expect.anything());
+  expect(spyExecPromise).toBeCalledWith(podmanCli.getPodmanCli(), ['machine', 'start', 'name'], expect.anything());
 });
 
 test('if a machine failed to start with a generic error, this is thrown', async () => {
@@ -741,13 +741,13 @@ test('test checkDefaultMachine - if user wants to change default machine, check 
 
   await extension.checkDefaultMachine(fakeMachineJSON);
 
-  expect(spyExecPromise).toHaveBeenCalledWith(getPodmanCli(), [
+  expect(spyExecPromise).toHaveBeenCalledWith(podmanCli.getPodmanCli(), [
     'system',
     'connection',
     'default',
     `${machineDefaultName}-root`,
   ]);
-  expect(inspectCall).toHaveBeenCalledWith(getPodmanCli(), ['machine', 'inspect', machineDefaultName]);
+  expect(inspectCall).toHaveBeenCalledWith(podmanCli.getPodmanCli(), ['machine', 'inspect', machineDefaultName]);
 });
 
 test('test checkDefaultMachine - if user wants to change machine, check that it only change the connection once if it is rootless', async () => {
@@ -784,8 +784,13 @@ test('test checkDefaultMachine - if user wants to change machine, check that it 
 
   await extension.checkDefaultMachine(fakeMachineJSON);
 
-  expect(spyExecPromise).toHaveBeenCalledWith(getPodmanCli(), ['system', 'connection', 'default', machineDefaultName]);
-  expect(inspectCall).toHaveBeenCalledWith(getPodmanCli(), ['machine', 'inspect', machineDefaultName]);
+  expect(spyExecPromise).toHaveBeenCalledWith(podmanCli.getPodmanCli(), [
+    'system',
+    'connection',
+    'default',
+    machineDefaultName,
+  ]);
+  expect(inspectCall).toHaveBeenCalledWith(podmanCli.getPodmanCli(), ['machine', 'inspect', machineDefaultName]);
 });
 
 test('test checkDefaultMachine - if user wants to change machine, check that it only changes to rootless as machine inspect is not returning Rootful field (old versions of podman)', async () => {
@@ -815,8 +820,13 @@ test('test checkDefaultMachine - if user wants to change machine, check that it 
 
   await extension.checkDefaultMachine(fakeMachineJSON);
 
-  expect(spyExecPromise).toHaveBeenCalledWith(getPodmanCli(), ['system', 'connection', 'default', machineDefaultName]);
-  expect(inspectCall).toHaveBeenCalledWith(getPodmanCli(), ['machine', 'inspect', machineDefaultName]);
+  expect(spyExecPromise).toHaveBeenCalledWith(podmanCli.getPodmanCli(), [
+    'system',
+    'connection',
+    'default',
+    machineDefaultName,
+  ]);
+  expect(inspectCall).toHaveBeenCalledWith(podmanCli.getPodmanCli(), ['machine', 'inspect', machineDefaultName]);
 });
 
 test('handlecompatibilitymodesetting: enable called when configuration setting has been set to true', async () => {
@@ -1844,4 +1854,19 @@ describe('calcPodmanMachineSetting', () => {
     expect(extensionApi.context.setValue).toBeCalledWith(extension.PODMAN_MACHINE_MEMORY_SUPPORTED_KEY, false);
     expect(extensionApi.context.setValue).toBeCalledWith(extension.PODMAN_MACHINE_DISK_SUPPORTED_KEY, false);
   });
+});
+
+test('checkForUpdate should be called if there is no podman installed', async () => {
+  const extensionContext = { subscriptions: [], storagePath: '' } as unknown as extensionApi.ExtensionContext;
+  const podmanInstall: PodmanInstall = new PodmanInstall(extensionContext);
+
+  vi.spyOn(podmanCli, 'getPodmanInstallation').mockResolvedValue(undefined);
+  vi.spyOn(podmanInstall, 'checkForUpdate').mockResolvedValue({
+    installedVersion: undefined,
+    hasUpdate: false,
+    bundledVersion: undefined,
+  });
+
+  await extension.initCheckAndRegisterUpdate(provider, podmanInstall);
+  expect(podmanInstall.checkForUpdate).toBeCalledWith(undefined);
 });

--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -850,7 +850,7 @@ async function doHandleWSLDistroNotFoundError(
 
 export async function registerUpdatesIfAny(
   provider: extensionApi.Provider,
-  installedPodman: InstalledPodman,
+  installedPodman: InstalledPodman | undefined,
   podmanInstall: PodmanInstall,
 ): Promise<extensionApi.Disposable | undefined> {
   const updateInfo = await podmanInstall.checkForUpdate(installedPodman);
@@ -897,11 +897,9 @@ export async function initCheckAndRegisterUpdate(
     }
     currentUpdatesDisposables.length = 0;
     const podmanInstalledValue = await getPodmanInstallation();
-    if (podmanInstalledValue) {
-      const disposable = await registerUpdatesIfAny(provider, podmanInstalledValue, podmanInstall);
-      if (disposable) {
-        currentUpdatesDisposables.push(disposable);
-      }
+    const disposable = await registerUpdatesIfAny(provider, podmanInstalledValue, podmanInstall);
+    if (disposable) {
+      currentUpdatesDisposables.push(disposable);
     }
   };
   await checkForUpdate();

--- a/extensions/podman/src/podman-install.ts
+++ b/extensions/podman/src/podman-install.ts
@@ -113,7 +113,7 @@ export class PodmanInfoImpl implements PodmanInfo {
   }
 }
 
-interface Installer {
+export interface Installer {
   getPreflightChecks(): extensionApi.InstallCheck[] | undefined;
   getUpdatePreflightChecks(): extensionApi.InstallCheck[] | undefined;
   install(): Promise<boolean>;
@@ -194,7 +194,6 @@ export class PodmanInstall {
     }
     const installer = this.getInstaller();
     const bundledVersion = getBundledPodmanVersion();
-
     if (
       installedVersion &&
       installer?.requireUpdate(installedVersion) &&
@@ -385,7 +384,7 @@ export class PodmanInstall {
     return this.installers.has(os.platform());
   }
 
-  private getInstaller(): Installer | undefined {
+  protected getInstaller(): Installer | undefined {
     return this.installers.get(os.platform());
   }
 

--- a/extensions/podman/src/podman-install.ts
+++ b/extensions/podman/src/podman-install.ts
@@ -297,14 +297,17 @@ export class PodmanInstall {
     return true;
   }
 
-  public async performUpdate(provider: extensionApi.Provider, installedPodman: InstalledPodman): Promise<void> {
+  public async performUpdate(
+    provider: extensionApi.Provider,
+    installedPodman: InstalledPodman | undefined,
+  ): Promise<void> {
     if (!this.podmanInfo) {
       console.error('The podman extension has not been successfully initialized');
       throw new Error('The podman extension has not been successfully initialized');
     }
 
     const updateInfo = await this.checkForUpdate(installedPodman);
-    if (updateInfo.hasUpdate) {
+    if (updateInfo.hasUpdate && updateInfo.installedVersion) {
       // before updating, podman machines need to be stopped if some of them are running
       const noRunningMachine = await this.stopPodmanMachinesIfAnyBeforeUpdating();
       if (!noRunningMachine) {
@@ -313,7 +316,10 @@ export class PodmanInstall {
       }
 
       // podman v4 -> v5 migration: ask to wipe all data before doing the update
-      const wipeAllDataCompleted = await this.wipeAllDataBeforeUpdatingToV5(installedPodman, updateInfo);
+      const wipeAllDataCompleted = await this.wipeAllDataBeforeUpdatingToV5(
+        { version: updateInfo.installedVersion },
+        updateInfo,
+      );
       if (!wipeAllDataCompleted) {
         await extensionApi.window.showWarningMessage(
           'Podman update has been canceled. It is recommended to backup OCI images or containers before resuming the update procedure',


### PR DESCRIPTION
### What does this PR do?

During the refactoring to enable the strict rule i added a check that bypassed the initialization of the component responsible for podman installation if podman was not already installed.

This PR just removes that `if`

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

it fixes #7527 

### How to test this PR?

1. have a machine with podman not installed and try to install it

- [ ] Tests are covering the bug fix or the new feature
