### PR TITLE
fix(typing): improve ColumnInformation renderer property typing

### DIFF
--- a/packages/renderer/src/lib/deployments/DeploymentsList.svelte
+++ b/packages/renderer/src/lib/deployments/DeploymentsList.svelte
@@ -105,7 +105,7 @@ let ageColumn = new TableColumn<DeploymentUI, Date | undefined>('Age', {
   comparator: (a, b) => moment(b.created).diff(moment(a.created)),
 });
 
-const columns: TableColumn<DeploymentUI, DeploymentUI | string | Date | undefined>[] = [
+const columns = [
   statusColumn,
   nameColumn,
   namespaceColumn,

--- a/packages/renderer/src/lib/image/ImagesList.svelte
+++ b/packages/renderer/src/lib/image/ImagesList.svelte
@@ -280,7 +280,7 @@ let sizeColumn = new TableColumn<ImageInfoUI, string>('Size', {
   comparator: (a, b) => b.size - a.size,
 });
 
-const columns: TableColumn<ImageInfoUI, ImageInfoUI | string>[] = [
+const columns = [
   statusColumn,
   nameColumn,
   envColumn,

--- a/packages/renderer/src/lib/ingresses-routes/IngressesRoutesList.svelte
+++ b/packages/renderer/src/lib/ingresses-routes/IngressesRoutesList.svelte
@@ -119,7 +119,7 @@ let namespaceColumn = new TableColumn<IngressUI | RouteUI, string>('Namespace', 
   comparator: (a, b) => a.namespace.localeCompare(b.namespace),
 });
 
-let pathColumn = new TableColumn<IngressUI | RouteUI, string>('Host/Path', {
+let pathColumn = new TableColumn<IngressUI | RouteUI>('Host/Path', {
   width: '1.5fr',
   renderer: IngressRouteColumnHostPath,
   comparator: (a, b) => compareHostPath(a, b),
@@ -137,7 +137,7 @@ function compareHostPath(object1: IngressUI | RouteUI, object2: IngressUI | Rout
   return hostPathObject1.label.localeCompare(hostPathObject2.label);
 }
 
-let backendColumn = new TableColumn<IngressUI | RouteUI, string>('Backend', {
+let backendColumn = new TableColumn<IngressUI | RouteUI>('Backend', {
   width: '1.5fr',
   renderer: IngressRouteColumnBackend,
   comparator: (a, b) => compareBackend(a, b),
@@ -149,7 +149,7 @@ function compareBackend(object1: IngressUI | RouteUI, object2: IngressUI | Route
   return backendObject1.localeCompare(backendObject2);
 }
 
-const columns: TableColumn<IngressUI | RouteUI, IngressUI | RouteUI | string | Date | undefined>[] = [
+const columns = [
   statusColumn,
   nameColumn,
   namespaceColumn,

--- a/packages/renderer/src/lib/node/NodesList.svelte
+++ b/packages/renderer/src/lib/node/NodesList.svelte
@@ -80,15 +80,7 @@ let kernelVersionColumn = new TableColumn<NodeUI, string>('Kernel', {
   comparator: (a, b) => a.kernelVersion.localeCompare(b.kernelVersion),
 });
 
-const columns: TableColumn<NodeUI, NodeUI | string | Date | undefined>[] = [
-  statusColumn,
-  nameColumn,
-  rolesColumn,
-  versionColumn,
-  osImageColumn,
-  kernelVersionColumn,
-  ageColumn,
-];
+const columns = [statusColumn, nameColumn, rolesColumn, versionColumn, osImageColumn, kernelVersionColumn, ageColumn];
 
 const row = new TableRow<NodeUI>({});
 </script>

--- a/packages/renderer/src/lib/pod/PodsList.svelte
+++ b/packages/renderer/src/lib/pod/PodsList.svelte
@@ -196,7 +196,7 @@ let ageColumn = new TableColumn<PodInfoUI>('Age', {
   comparator: (a, b) => moment().diff(a.created) - moment().diff(b.created),
 });
 
-const columns: TableColumn<PodInfoUI>[] = [
+const columns = [
   statusColumn,
   nameColumn,
   envColumn,

--- a/packages/renderer/src/lib/service/ServicesList.svelte
+++ b/packages/renderer/src/lib/service/ServicesList.svelte
@@ -110,7 +110,7 @@ let ageColumn = new TableColumn<ServiceUI, Date | undefined>('Age', {
   comparator: (a, b) => moment(b.created).diff(moment(a.created)),
 });
 
-const columns: TableColumn<ServiceUI, ServiceUI | string | Date | undefined>[] = [
+const columns = [
   statusColumn,
   nameColumn,
   namespaceColumn,

--- a/packages/renderer/src/lib/volume/VolumesList.svelte
+++ b/packages/renderer/src/lib/volume/VolumesList.svelte
@@ -213,7 +213,7 @@ let sizeColumn = new TableColumn<VolumeInfoUI, string>('Size', {
   initialOrder: 'descending',
 });
 
-const columns: TableColumn<VolumeInfoUI, VolumeInfoUI | string>[] = [
+const columns = [
   statusColumn,
   nameColumn,
   envColumn,

--- a/packages/ui/src/lib/table/table.ts
+++ b/packages/ui/src/lib/table/table.ts
@@ -16,6 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { ComponentType, SvelteComponent } from 'svelte';
+
 /**
  * Options to be used when creating a Column.
  */
@@ -47,8 +49,7 @@ export interface ColumnInformation<Type, RenderType = Type> {
    * The component must have a property 'object' that has the
    * same type as the Column.
    */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  readonly renderer?: any;
+  readonly renderer?: ComponentType<SvelteComponent<{ object: RenderType }>>;
 
   /**
    * Set a comparator used to sort the data by the values in this column.

--- a/storybook/.storybook/main.ts
+++ b/storybook/.storybook/main.ts
@@ -57,20 +57,6 @@ const config: StorybookConfig = {
       },
     },
   },
-  async viteFinal(config, { configType }) {
-    const { mergeConfig } = await import('vite');
-
-    if (configType === 'DEVELOPMENT') {
-      // Your development configuration goes here
-    }
-    if (configType === 'PRODUCTION') {
-      // Your production configuration goes here.
-    }
-    return mergeConfig(config, {
-      // Your environment configuration here
-      base: '/storybook/',
-    });
-  },
 };
 
 export default config;

--- a/storybook/.storybook/main.ts
+++ b/storybook/.storybook/main.ts
@@ -57,6 +57,20 @@ const config: StorybookConfig = {
       },
     },
   },
+  async viteFinal(config, { configType }) {
+    const { mergeConfig } = await import('vite');
+
+    if (configType === 'DEVELOPMENT') {
+      // Your development configuration goes here
+    }
+    if (configType === 'PRODUCTION') {
+      // Your production configuration goes here.
+    }
+    return mergeConfig(config, {
+      // Your environment configuration here
+      base: '/storybook/',
+    });
+  },
 };
 
 export default config;


### PR DESCRIPTION
### What does this PR do?

Improving the renderer property from `any` to more defined. This enforce that column have the `object` property matching the expected type.

This change force use to correct the existing typing which were used for columns arrays, which were incorrect: I removed it as not needed.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- Pipeline should be ✅ 
