### PR TITLE
fix: table child selection

### DIFF
--- a/packages/ui/src/lib/table/Table.svelte
+++ b/packages/ui/src/lib/table/Table.svelte
@@ -45,6 +45,14 @@ function toggleAll(e: CustomEvent<boolean>): void {
     return;
   }
   data.filter(object => row.info.selectable?.(object)).forEach(object => (object.selected = checked));
+
+  // toggle children
+  data.forEach(object => {
+    const children = row.info.children?.(object);
+    if (children) {
+      children.filter(child => row.info.selectable?.(child)).forEach(child => (child.selected = checked));
+    }
+  });
 }
 
 let sortCol: Column<unknown>;
@@ -132,12 +140,13 @@ function setGridColumns(): void {
   }
 }
 
-function objectChecked(event: (Event & { detail?: boolean }) | undefined, object: unknown): void {
+function objectChecked(object: { selected?: boolean }): void {
   // check for children and set them to the same state
   if (row.info.children) {
     const children = row.info.children(object);
     if (children) {
-      children.forEach(child => (child.selected = event?.detail));
+      // event fires before parent changes so use '!'
+      children.forEach(child => (child.selected = !object.selected));
     }
   }
 }
@@ -226,7 +235,7 @@ function toggleChildren(object: unknown): void {
                 bind:checked="{object.selected}"
                 disabled="{!row.info.selectable(object)}"
                 disabledTooltip="{row.info.disabledText}"
-                on:click="{objectChecked.bind(undefined, event, object)}" />
+                on:click="{objectChecked.bind(undefined, object)}" />
             </div>
           {/if}
           {#each columns as column}


### PR DESCRIPTION
### What does this PR do?

Fixes table child selection when the parent is selected. Event is deprecated and detail was not consistently returning selection, remove it and use the state of the parent object instead.

Also fixes Toggle All, which wasn't recursive before.

### Screenshot / video of UI

See #7553.

### What issues does this PR fix or reference?

Fixes #7553.

### How to test this PR?

Use #7552 or the following code in the image list to show children:
```
  children: image => {
    if (image.shortId === '<some id>') {
      return [image];
    }
    return [];
  },
```