### PR TITLE
chore: adds updated details page to images and manifests

### DIFF
--- a/packages/renderer/src/lib/details/DetailsCell.svelte
+++ b/packages/renderer/src/lib/details/DetailsCell.svelte
@@ -3,6 +3,6 @@ export let style: string = '';
 export let onClick: () => void = () => {};
 </script>
 
-<td class="pt-1 pl-3 text-gray-300 {style}" on:click="{onClick}">
+<td class="pt-1 pl-3 {style}" on:click="{onClick}">
   <slot />
 </td>

--- a/packages/renderer/src/lib/details/DetailsSubtitle.svelte
+++ b/packages/renderer/src/lib/details/DetailsSubtitle.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+export let style: string = '';
+</script>
+
+<td class="pl-2 text-md font-semibold text-[var(--pd-table-body-text-sub-secondary)] {style}">
+  <slot />
+</td>

--- a/packages/renderer/src/lib/details/DetailsTable.svelte
+++ b/packages/renderer/src/lib/details/DetailsTable.svelte
@@ -1,0 +1,7 @@
+<div class="flex px-5 py-4 flex-col items-start h-full overflow-auto text-[var(--pd-table-body-text)]">
+  <table class="w-full">
+    <tbody>
+      <slot />
+    </tbody>
+  </table>
+</div>

--- a/packages/renderer/src/lib/details/DetailsTitle.svelte
+++ b/packages/renderer/src/lib/details/DetailsTitle.svelte
@@ -1,0 +1,3 @@
+<td class="pt-1 text-lg font-semibold text-[var(--pd-table-body-text-sub-secondary)]">
+  <slot />
+</td>

--- a/packages/renderer/src/lib/image/ImageDetailsSummary.spec.ts
+++ b/packages/renderer/src/lib/image/ImageDetailsSummary.spec.ts
@@ -1,0 +1,108 @@
+/**********************************************************************
+ * Copyright (C) 2023-2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import type { ManifestInspectInfo } from '@podman-desktop/api';
+import { render, screen, waitFor } from '@testing-library/svelte';
+import { beforeAll, expect, test, vi } from 'vitest';
+
+import ImageIcon from '../images/ImageIcon.svelte';
+import ImageDetailsSummary from './ImageDetailsSummary.svelte';
+import type { ImageInfoUI } from './ImageInfoUI';
+
+const image: ImageInfoUI = {
+  id: 'my-image',
+  shortId: 'short-id',
+  name: 'my-image-name',
+  engineId: 'podman',
+  engineName: '',
+  tag: 'latest-tag',
+  createdAt: 0,
+  age: '',
+  size: 0,
+  humanSize: '',
+  base64RepoTag: 'repoTag',
+  selected: false,
+  status: 'UNUSED',
+  icon: ImageIcon,
+  badges: [],
+};
+
+const inspectManifest: ManifestInspectInfo = {
+  engineId: 'podman',
+  engineName: '',
+  mediaType: 'application/vnd.docker.distribution.manifest.v2+json',
+  schemaVersion: 2,
+  manifests: [
+    {
+      digest: 'sha256:123456',
+      mediaType: 'application/vnd.docker.distribution.manifest.v2+json',
+      size: 1234,
+      platform: {
+        architecture: 'amd64',
+        os: 'linux',
+      },
+    },
+    {
+      digest: 'sha256:654321',
+      mediaType: 'application/vnd.docker.distribution.manifest.v2+json',
+      size: 4321,
+      platform: {
+        architecture: 'arm64',
+        os: 'linux',
+      },
+    },
+  ],
+};
+
+beforeAll(() => {
+  (window as any).inspectManifest = vi.fn().mockResolvedValue(inspectManifest);
+});
+
+test('Expect render ImageDetailsSummary', async () => {
+  render(ImageDetailsSummary, { image: image });
+
+  const text = screen.getByText(image.name);
+  expect(text).toBeInTheDocument();
+});
+
+test('if ImageInfoUI isManifest is true, expect window.inspectManifest to be called', async () => {
+  const imageWithManifest: ImageInfoUI = {
+    ...image,
+    isManifest: true,
+  };
+
+  render(ImageDetailsSummary, { image: imageWithManifest });
+
+  // Expect window.inspectManifest to be called
+  expect((window as any).inspectManifest).toHaveBeenCalled();
+
+  // Expect the manifest digest to be displayed
+
+  // wait for the digest to be displayed
+  await waitFor(async () => {
+    const digest = screen.getByText('123456');
+    expect(digest).toBeInTheDocument();
+  });
+
+  // Expect manifest inspect details to be shown
+  expect(screen.getByText('123456')).toBeInTheDocument();
+  expect(screen.getByText('amd64')).toBeInTheDocument();
+  expect(screen.queryAllByText('linux')).toHaveLength(2);
+});

--- a/packages/renderer/src/lib/image/ImageDetailsSummary.svelte
+++ b/packages/renderer/src/lib/image/ImageDetailsSummary.svelte
@@ -1,24 +1,94 @@
 <script lang="ts">
+import type { ManifestInspectInfo } from '@podman-desktop/api';
+import { onMount } from 'svelte';
+
+import Cell from '/@/lib/details/DetailsCell.svelte';
+import Subtitle from '/@/lib/details/DetailsSubtitle.svelte';
+import Table from '/@/lib/details/DetailsTable.svelte';
+import Title from '/@/lib/details/DetailsTitle.svelte';
+
+import { ImageUtils } from './image-utils';
 import type { ImageInfoUI } from './ImageInfoUI';
 
 export let image: ImageInfoUI;
+
+let manifestDetails: ManifestInspectInfo | undefined;
+
+const imageUtils = new ImageUtils();
+
+onMount(async () => {
+  if (image.isManifest) {
+    try {
+      manifestDetails = await window.inspectManifest(image.engineId, image.id);
+    } catch (err) {
+      console.error(err);
+    }
+  }
+});
 </script>
 
-<div class="flex px-5 py-4 flex-col h-full overflow-auto text-[var(--pd-details-body-text)]">
-  <table>
-    <tbody>
+<Table>
+  <tr>
+    <Title>Details</Title>
+  </tr>
+  <tr>
+    <Cell>Name</Cell>
+    <Cell>{image.name}</Cell>
+  </tr>
+  <tr>
+    <Cell>Tag</Cell>
+    <Cell>{image.tag}</Cell>
+  </tr>
+  <tr>
+    <Cell>ID</Cell>
+    <Cell>{image.id}</Cell>
+  </tr>
+  <tr>
+    <Cell>Size</Cell>
+    <Cell>{image.humanSize}</Cell>
+  </tr>
+  <tr>
+    <Cell>Age</Cell>
+    <Cell>{image.age}</Cell>
+  </tr>
+  {#if manifestDetails && manifestDetails.manifests.length > 0}
+    <tr>
+      <Title>Manifest Details</Title>
+    </tr>
+    {#each manifestDetails.manifests as manifest}
       <tr>
-        <td class="pr-2">Id:</td>
-        <td>{image.id}</td>
+        <Subtitle>{imageUtils.getShortId(manifest.digest)}</Subtitle>
       </tr>
       <tr>
-        <td class="pr-2">Size:</td>
-        <td>{image.humanSize}</td>
+        <Cell>Media Type</Cell>
+        <Cell>{manifest.mediaType}</Cell>
       </tr>
       <tr>
-        <td class="pr-2">Age</td>
-        <td>{image.age}</td>
+        <Cell>Architecture</Cell>
+        <Cell>{manifest.platform.architecture}</Cell>
       </tr>
-    </tbody>
-  </table>
-</div>
+      {#if manifest.platform.variant}
+        <tr>
+          <Cell>Variant</Cell>
+          <Cell>{manifest.platform.variant}</Cell>
+        </tr>
+      {/if}
+      <tr>
+        <Cell>OS</Cell>
+        <Cell>{manifest.platform.os}</Cell>
+      </tr>
+      <tr>
+        <Cell>Size</Cell>
+        <Cell>{imageUtils.getHumanSize(manifest.size)}</Cell>
+      </tr>
+      {#if manifest.urls}
+        {#each manifest.urls as url}
+          <tr>
+            <Cell>URL</Cell>
+            <Cell>{url}</Cell>
+          </tr>
+        {/each}
+      {/if}
+    {/each}
+  {/if}
+</Table>

--- a/packages/renderer/src/lib/kube/details/KubeContainerArtifact.svelte
+++ b/packages/renderer/src/lib/kube/details/KubeContainerArtifact.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 import type { V1Container } from '@kubernetes/client-node';
 
-import Cell from './ui/Cell.svelte';
+import Cell from '/@/lib/details/DetailsCell.svelte';
 
 export let artifact: V1Container | undefined;
 </script>

--- a/packages/renderer/src/lib/kube/details/KubeDeploymentArtifact.svelte
+++ b/packages/renderer/src/lib/kube/details/KubeDeploymentArtifact.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
 import type { V1DeploymentSpec } from '@kubernetes/client-node';
 
-import Cell from './ui/Cell.svelte';
-import Title from './ui/Title.svelte';
+import Cell from '/@/lib/details/DetailsCell.svelte';
+import Title from '/@/lib/details/DetailsTitle.svelte';
 
 export let artifact: V1DeploymentSpec | undefined;
 </script>

--- a/packages/renderer/src/lib/kube/details/KubeDeploymentStatusArtifact.svelte
+++ b/packages/renderer/src/lib/kube/details/KubeDeploymentStatusArtifact.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
 import type { V1DeploymentStatus } from '@kubernetes/client-node';
 
-import Cell from './ui/Cell.svelte';
-import Subtitle from './ui/Subtitle.svelte';
-import Title from './ui/Title.svelte';
+import Cell from '/@/lib/details/DetailsCell.svelte';
+import Subtitle from '/@/lib/details/DetailsSubtitle.svelte';
+import Title from '/@/lib/details/DetailsTitle.svelte';
 
 export let artifact: V1DeploymentStatus | undefined;
 </script>

--- a/packages/renderer/src/lib/kube/details/KubeIngressArtifact.svelte
+++ b/packages/renderer/src/lib/kube/details/KubeIngressArtifact.svelte
@@ -2,8 +2,8 @@
 import type { V1IngressSpec } from '@kubernetes/client-node';
 import { Link } from '@podman-desktop/ui-svelte';
 
-import Cell from './ui/Cell.svelte';
-import Title from './ui/Title.svelte';
+import Cell from '/@/lib/details/DetailsCell.svelte';
+import Title from '/@/lib/details/DetailsTitle.svelte';
 
 // Props for Ingress artifact and Status
 export let artifact: V1IngressSpec | undefined;

--- a/packages/renderer/src/lib/kube/details/KubeIngressStatusArtifact.svelte
+++ b/packages/renderer/src/lib/kube/details/KubeIngressStatusArtifact.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
 import type { V1IngressStatus } from '@kubernetes/client-node';
 
-import Cell from './ui/Cell.svelte';
-import Title from './ui/Title.svelte';
+import Cell from '/@/lib/details/DetailsCell.svelte';
+import Title from '/@/lib/details/DetailsTitle.svelte';
 
 export let artifact: V1IngressStatus | undefined;
 </script>

--- a/packages/renderer/src/lib/kube/details/KubeNodeArtifact.svelte
+++ b/packages/renderer/src/lib/kube/details/KubeNodeArtifact.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
 import type { V1NodeSpec } from '@kubernetes/client-node';
 
-import Cell from './ui/Cell.svelte';
-import Title from './ui/Title.svelte';
+import Cell from '/@/lib/details/DetailsCell.svelte';
+import Title from '/@/lib/details/DetailsTitle.svelte';
 
 export let artifact: V1NodeSpec | undefined;
 </script>

--- a/packages/renderer/src/lib/kube/details/KubeNodeStatusArtifact.svelte
+++ b/packages/renderer/src/lib/kube/details/KubeNodeStatusArtifact.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
 import type { V1NodeStatus } from '@kubernetes/client-node';
 
-import Cell from './ui/Cell.svelte';
-import Subtitle from './ui/Subtitle.svelte';
-import Title from './ui/Title.svelte';
+import Cell from '/@/lib/details/DetailsCell.svelte';
+import Subtitle from '/@/lib/details/DetailsSubtitle.svelte';
+import Title from '/@/lib/details/DetailsTitle.svelte';
 
 export let artifact: V1NodeStatus | undefined;
 </script>

--- a/packages/renderer/src/lib/kube/details/KubeObjectMetaArtifact.svelte
+++ b/packages/renderer/src/lib/kube/details/KubeObjectMetaArtifact.svelte
@@ -3,8 +3,9 @@ import { faChevronDown, faChevronRight } from '@fortawesome/free-solid-svg-icons
 import type { V1ObjectMeta } from '@kubernetes/client-node';
 import Fa from 'svelte-fa';
 
-import Cell from './ui/Cell.svelte';
-import Title from './ui/Title.svelte';
+import Cell from '/@/lib/details/DetailsCell.svelte';
+import Title from '/@/lib/details/DetailsTitle.svelte';
+
 import { internalKubernetesKeys } from './utils';
 
 export let artifact: V1ObjectMeta | undefined;

--- a/packages/renderer/src/lib/kube/details/KubePodSpecArtifact.svelte
+++ b/packages/renderer/src/lib/kube/details/KubePodSpecArtifact.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
 import type { V1PodSpec } from '@kubernetes/client-node';
 
+import Cell from '/@/lib/details/DetailsCell.svelte';
+import Subtitle from '/@/lib/details/DetailsSubtitle.svelte';
+import Title from '/@/lib/details/DetailsTitle.svelte';
+
 import Container from './KubeContainerArtifact.svelte';
 import Volume from './KubeVolumeArtifact.svelte';
-import Cell from './ui/Cell.svelte';
-import Subtitle from './ui/Subtitle.svelte';
-import Title from './ui/Title.svelte';
 
 export let artifact: V1PodSpec | undefined;
 </script>

--- a/packages/renderer/src/lib/kube/details/KubePodStatusArtifact.svelte
+++ b/packages/renderer/src/lib/kube/details/KubePodStatusArtifact.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
 import type { V1PodStatus } from '@kubernetes/client-node';
 
-import Cell from './ui/Cell.svelte';
-import Subtitle from './ui/Subtitle.svelte';
-import Title from './ui/Title.svelte';
+import Cell from '/@/lib/details/DetailsCell.svelte';
+import Subtitle from '/@/lib/details/DetailsSubtitle.svelte';
+import Title from '/@/lib/details/DetailsTitle.svelte';
 
 export let artifact: V1PodStatus | undefined;
 

--- a/packages/renderer/src/lib/kube/details/KubeServiceArtifact.svelte
+++ b/packages/renderer/src/lib/kube/details/KubeServiceArtifact.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
 import type { V1ServiceSpec } from '@kubernetes/client-node';
 
-import Cell from './ui/Cell.svelte';
-import Title from './ui/Title.svelte';
+import Cell from '/@/lib/details/DetailsCell.svelte';
+import Title from '/@/lib/details/DetailsTitle.svelte';
 
 export let artifact: V1ServiceSpec | undefined;
 </script>

--- a/packages/renderer/src/lib/kube/details/KubeServiceStatusArtifact.svelte
+++ b/packages/renderer/src/lib/kube/details/KubeServiceStatusArtifact.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
 import type { V1ServiceStatus } from '@kubernetes/client-node';
 
-import Cell from './ui/Cell.svelte';
-import Title from './ui/Title.svelte';
+import Cell from '/@/lib/details/DetailsCell.svelte';
+import Title from '/@/lib/details/DetailsTitle.svelte';
 
 export let artifact: V1ServiceStatus | undefined;
 </script>

--- a/packages/renderer/src/lib/kube/details/KubeVolumeArtifact.svelte
+++ b/packages/renderer/src/lib/kube/details/KubeVolumeArtifact.svelte
@@ -39,8 +39,8 @@ These are the ones which will be shown (see the V1 Volume spec)
 
 import type { V1Volume } from '@kubernetes/client-node';
 
-import Cell from './ui/Cell.svelte';
-import Subtitle from './ui/Title.svelte';
+import Cell from '/@/lib/details/DetailsCell.svelte';
+import Subtitle from '/@/lib/details/DetailsTitle.svelte';
 
 export let artifact: V1Volume;
 </script>

--- a/packages/renderer/src/lib/kube/details/OpenshiftRouteArtifact.svelte
+++ b/packages/renderer/src/lib/kube/details/OpenshiftRouteArtifact.svelte
@@ -1,10 +1,9 @@
 <script lang="ts">
 import { Link } from '@podman-desktop/ui-svelte';
 
+import Cell from '/@/lib/details/DetailsCell.svelte';
+import Title from '/@/lib/details/DetailsTitle.svelte';
 import type { V1Route } from '/@api/openshift-types';
-
-import Cell from './ui/Cell.svelte';
-import Title from './ui/Title.svelte';
 
 // Assuming V1Route type is imported or defined elsewhere
 export let artifact: V1Route | undefined;

--- a/packages/renderer/src/lib/kube/details/ui/Subtitle.svelte
+++ b/packages/renderer/src/lib/kube/details/ui/Subtitle.svelte
@@ -1,3 +1,0 @@
-<td class="pl-2 text-md font-semibold text-purple-300">
-  <slot />
-</td>

--- a/packages/renderer/src/lib/kube/details/ui/Title.svelte
+++ b/packages/renderer/src/lib/kube/details/ui/Title.svelte
@@ -1,3 +1,0 @@
-<td class="pt-1 text-lg font-semibold text-purple-400">
-  <slot />
-</td>


### PR DESCRIPTION
chore: adds updated details page to images and manifests

### What does this PR do?

* Changes the UI for images to the new format that is on other summary
  pages
* Adds details for manifest (using inspect)

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

https://github.com/containers/podman-desktop/assets/6422176/c4cfc162-7dac-4f60-92ad-2aa8c7eaedc3




### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop/issues/7561
Closes https://github.com/containers/podman-desktop/issues/7270

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature

View the summary pages for both an image and a manifest

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
