### PR TITLE
chore: light mode for tabs

### DIFF
--- a/packages/main/src/plugin/color-registry.ts
+++ b/packages/main/src/plugin/color-registry.ts
@@ -907,8 +907,8 @@ export class ColorRegistry {
       light: colorPalette.transparent,
     });
     this.registerColor(`${button}tab-border`, {
-      dark: colorPalette.charcoal[700],
-      light: colorPalette.gray[400],
+      dark: colorPalette.transparent,
+      light: colorPalette.transparent,
     });
     this.registerColor(`${button}tab-border-selected`, {
       dark: colorPalette.purple[500],
@@ -916,11 +916,15 @@ export class ColorRegistry {
     });
     this.registerColor(`${button}tab-hover-border`, {
       dark: colorPalette.charcoal[100],
-      light: colorPalette.black,
+      light: colorPalette.gray[600],
     });
     this.registerColor(`${button}tab-text`, {
       dark: colorPalette.gray[600],
       light: colorPalette.charcoal[200],
+    });
+    this.registerColor(`${button}tab-text-selected`, {
+      dark: colorPalette.white,
+      light: colorPalette.black,
     });
     this.registerColor(`${button}link-text`, {
       dark: colorPalette.purple[400],

--- a/packages/ui/src/lib/button/Button.spec.ts
+++ b/packages/ui/src/lib/button/Button.spec.ts
@@ -50,6 +50,7 @@ test('Check disabled/in-progress primary button styling', async () => {
   expect(button).toHaveClass('bg-[var(--pd-button-disabled)]');
   expect(button).toHaveClass('py-[5px]');
   expect(button).toHaveClass('text-[13px]');
+  expect(button).toHaveClass('text-[var(--pd-button-disabled-text)]');
 });
 
 test('Check primary button is the default', async () => {
@@ -107,6 +108,7 @@ test('Check disabled/in-progress secondary button styling', async () => {
   expect(button).toHaveClass('py-[4px]');
   expect(button).toHaveClass('bg-[var(--pd-button-disabled)]');
   expect(button).toHaveClass('text-[13px]');
+  expect(button).toHaveClass('text-[var(--pd-button-disabled-text)]');
 });
 
 test('Check link button styling', async () => {
@@ -154,7 +156,7 @@ test('Check selected tab button styling', async () => {
   // check for a few elements of the styling
   const button = screen.getByRole('button');
   expect(button).toBeInTheDocument();
-  expect(button).toHaveClass('text-[var(--pd-button-text)]');
+  expect(button).toHaveClass('text-[var(--pd-button-tab-text-selected)]');
   expect(button).toHaveClass('border-[var(--pd-button-tab-border-selected)]');
 });
 

--- a/packages/ui/src/lib/button/Button.svelte
+++ b/packages/ui/src/lib/button/Button.svelte
@@ -41,13 +41,14 @@ $: {
     } else if (type === 'danger') {
       classes =
         'border-2 border-[var(--pd-button-danger-disabled-border)] text-[var(--pd-button-danger-disabled-text)] bg-[var(--pd-button-danger-disabled-bg)]';
-    } else {
-      // link and tab
-      classes = 'text-[var(--pd-button-disabled-text)]';
+    }
+    if (type !== 'danger') {
+      classes += ' text-[var(--pd-button-disabled-text)]';
     }
   } else {
     if (type === 'primary') {
-      classes = 'bg-[var(--pd-button-primary-bg)] border-none hover:bg-[var(--pd-button-primary-hover-bg)]';
+      classes =
+        'bg-[var(--pd-button-primary-bg)] text-[var(--pd-button-text)] border-none hover:bg-[var(--pd-button-primary-hover-bg)]';
     } else if (type === 'secondary') {
       classes =
         'border-[1px] border-[var(--pd-button-secondary)] text-[var(--pd-button-secondary)] hover:bg-[var(--pd-button-secondary-hover)] hover:border-[var(--pd-button-secondary-hover)] hover:text-[var(--pd-button-text)]';
@@ -55,7 +56,7 @@ $: {
       classes =
         'border-2 border-[var(--pd-button-danger-border)] bg-[var(--pd-button-danger-bg)] text-[var(--pd-button-danger-text)] hover:bg-[var(--pd-button-danger-hover-bg)] hover:text-[var(--pd-button-danger-hover-text)]';
     } else if (type === 'tab') {
-      classes = 'border-b-[3px] border-[var(--pd-button-tab-border)] text-[var(--pd-button-tab-text)]';
+      classes = 'border-b-[3px] border-[var(--pd-button-tab-border)]';
     } else {
       // link
       classes = 'border-none text-[var(--pd-button-link-text)] hover:bg-[var(--pd-button-link-hover-bg)]';
@@ -73,7 +74,8 @@ $: {
   class="relative {padding} box-border whitespace-nowrap select-none transition-all {classes} {$$props.class ?? ''}"
   class:border-[var(--pd-button-tab-border-selected)]="{type === 'tab' && selected}"
   class:hover:border-[var(--pd-button-tab-hover-border)]="{type === 'tab' && !selected}"
-  class:text-[var(--pd-button-text)]="{(type === 'tab' && !!selected) || type === 'primary'}"
+  class:text-[var(--pd-button-tab-text-selected)]="{type === 'tab' && selected}"
+  class:text-[var(--pd-button-tab-text)]="{type === 'tab' && !selected}"
   title="{title}"
   aria-label="{$$props['aria-label']}"
   on:click


### PR DESCRIPTION
### What does this PR do?

Tab buttons were migrated to light mode with #7314, but there were some remaining issues when using it in practice:
- Historically primary buttons and tabs had the same text color, but in light mode the primary button doesn't change text color while tabs need to. Added a new tab-text-selected color.
- While changing this I noticed that the text color was never set for disabled & in-progress primary/secondary buttons, so fixed this.
- In dark mode the unselected tab border (tab-border) was set to the same color as the background to make it disappear, but this wasn't done in light mode. Changed both to transparent.
- Light mode hover border was too strong, reduced from black to gray[600].

### Screenshot / video of UI

No change in dark mode. In light mode:

Before:

https://github.com/containers/podman-desktop/assets/19958075/0bb994a4-cb6c-4dc0-b558-26bc4f799cdd

After:

https://github.com/containers/podman-desktop/assets/19958075/416dec7c-bef7-45d3-b7a5-d34226c28538

### What issues does this PR fix or reference?

Fixes #7212.

### How to test this PR?

Check tabs on Containers, Pods pages.

- [x] Tests are covering the bug fix or the new feature