### PR TITLE
chore(tests): redo and stabilize extensions e2e tests

### DIFF
--- a/tests/playwright/src/index.ts
+++ b/tests/playwright/src/index.ts
@@ -38,6 +38,7 @@ export * from './model/pages/containers-page';
 export * from './model/pages/create-pod-page';
 export * from './model/pages/dashboard-page';
 export * from './model/pages/extension-card-page';
+export * from './model/pages/extension-catalog-card-page';
 export * from './model/pages/extension-details-page';
 export * from './model/pages/extensions-page';
 export * from './model/pages/image-details-page';

--- a/tests/playwright/src/model/pages/extension-card-page.ts
+++ b/tests/playwright/src/model/pages/extension-card-page.ts
@@ -59,12 +59,12 @@ export class ExtensionCardPage extends BasePage {
     this.removeButton = this.extensionActions.getByRole('button', { name: 'Delete' });
   }
 
-  public async openExtensionDetails(): Promise<ExtensionDetailsPage> {
+  public async openExtensionDetails(heading: string): Promise<ExtensionDetailsPage> {
     await playExpect(this.card).toBeVisible();
     await this.card.scrollIntoViewIfNeeded();
     await playExpect(this.detailsLink).toBeVisible();
     await this.detailsLink.click();
-    return new ExtensionDetailsPage(this.page, this.extensionName);
+    return new ExtensionDetailsPage(this.page, heading);
   }
 
   async disableExtension(): Promise<this> {

--- a/tests/playwright/src/model/pages/extension-catalog-card-page.ts
+++ b/tests/playwright/src/model/pages/extension-catalog-card-page.ts
@@ -48,15 +48,16 @@ export class ExtensionCatalogCardPage extends BasePage {
   public async isInstalled(): Promise<boolean> {
     await this.parent.scrollIntoViewIfNeeded();
     const downloadButton = this.parent.getByRole('button', { name: 'Install' });
-    return (await this.alreadyInstalledText.isVisible()) && !(await downloadButton.isVisible()) ? true : false;
+    return (await this.alreadyInstalledText.count()) > 0 && (await downloadButton.count()) === 0 ? true : false;
   }
 
   public async install(timeout: number): Promise<void> {
-    if (!(await this.isInstalled())) {
-      await playExpect(this.downloadButton).toBeVisible();
-      await this.downloadButton.click();
-      await playExpect(this.alreadyInstalledText).toBeVisible({ timeout: timeout });
+    if (await this.isInstalled()) {
+      console.log(`Extension ${this.extensionName} is already installed`);
+      return;
     }
-    console.log(`Extension ${this.extensionName} is already installed`);
+    await playExpect(this.downloadButton).toBeEnabled();
+    await this.downloadButton.click();
+    await playExpect(this.alreadyInstalledText).toBeVisible({ timeout: timeout });
   }
 }

--- a/tests/playwright/src/model/pages/extension-catalog-card-page.ts
+++ b/tests/playwright/src/model/pages/extension-catalog-card-page.ts
@@ -1,0 +1,62 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { Locator, Page } from '@playwright/test';
+import { expect as playExpect } from '@playwright/test';
+
+import { BasePage } from './base-page';
+import { ExtensionDetailsPage } from './extension-details-page';
+
+export class ExtensionCatalogCardPage extends BasePage {
+  readonly parent: Locator;
+  readonly extensionName: string;
+  readonly detailsButton: Locator;
+  readonly downloadButton: Locator;
+  readonly alreadyInstalledText: Locator;
+
+  constructor(page: Page, extensionName: string) {
+    super(page);
+    this.extensionName = extensionName;
+    this.parent = this.page.getByRole('group', { name: this.extensionName });
+    this.detailsButton = this.parent.getByRole('button', { name: 'More details' });
+    this.downloadButton = this.parent.getByRole('button', { name: 'Install' });
+    this.alreadyInstalledText = this.parent.getByText('Already installed', { exact: true });
+  }
+
+  public async openDetails(): Promise<ExtensionDetailsPage> {
+    await this.parent.scrollIntoViewIfNeeded();
+    await playExpect(this.detailsButton).toBeVisible();
+    await this.detailsButton.click();
+    return new ExtensionDetailsPage(this.page, this.extensionName);
+  }
+
+  public async isInstalled(): Promise<boolean> {
+    await this.parent.scrollIntoViewIfNeeded();
+    const downloadButton = this.parent.getByRole('button', { name: 'Install' });
+    return (await this.alreadyInstalledText.isVisible()) && !(await downloadButton.isVisible()) ? true : false;
+  }
+
+  public async install(timeout: number): Promise<void> {
+    if (!(await this.isInstalled())) {
+      await playExpect(this.downloadButton).toBeVisible();
+      await this.downloadButton.click();
+      await playExpect(this.alreadyInstalledText).toBeVisible({ timeout: timeout });
+    }
+    console.log(`Extension ${this.extensionName} is already installed`);
+  }
+}

--- a/tests/playwright/src/model/pages/extension-details-page.ts
+++ b/tests/playwright/src/model/pages/extension-details-page.ts
@@ -39,13 +39,6 @@ export class ExtensionDetailsPage extends BasePage {
     this.disableButton = page.getByRole('button', { name: 'Stop' });
     this.removeExtensionButton = page.getByRole('button', { name: 'Delete' });
     this.status = page.getByLabel('Extension Status Label');
-    console.log(
-      'ExtensionDetailsPage constructor',
-      this.enableButton,
-      this.disableButton,
-      this.removeExtensionButton,
-      this.status,
-    );
   }
 
   async disableExtension(): Promise<this> {

--- a/tests/playwright/src/model/pages/extensions-page.ts
+++ b/tests/playwright/src/model/pages/extensions-page.ts
@@ -79,9 +79,9 @@ export class ExtensionsPage extends MainPage {
     return this.additionalActions.getByRole('button', { name: 'Install custom...', exact: true });
   }
 
-  public async openExtensionDetails(name: string, label: string): Promise<ExtensionDetailsPage> {
+  public async openExtensionDetails(name: string, label: string, heading: string): Promise<ExtensionDetailsPage> {
     const extensionCard = await this.getInstalledExtension(name, label);
-    return await extensionCard.openExtensionDetails();
+    return await extensionCard.openExtensionDetails(heading);
   }
 
   public async getInstalledExtension(name: string, label: string): Promise<ExtensionCardPage> {

--- a/tests/playwright/src/specs/extension-installation.spec.ts
+++ b/tests/playwright/src/specs/extension-installation.spec.ts
@@ -52,7 +52,7 @@ const _startup = async function (): Promise<void> {
   pdRunner = new PodmanDesktopRunner();
   page = await pdRunner.start();
   pdRunner.setVideoAndTraceName(`${extensionName}-installation-e2e`);
-  
+
   const welcomePage = new WelcomePage(page);
   await welcomePage.handleWelcomePage(true);
 
@@ -90,13 +90,11 @@ describe.each([
     const extensionCatalog = new ExtensionCatalogCardPage(page, extensionType);
     await playExpect(extensionCatalog.parent).toBeVisible();
 
-    await playExpect.poll(async () => await extensionCatalog.isInstalled(), { timeout: 5000 }).toBeFalsy();
+    await playExpect.poll(async () => await extensionCatalog.isInstalled()).toBeFalsy();
     await extensionCatalog.install(90000);
 
     await extensionsPage.openInstalledTab();
-    await playExpect
-      .poll(async () => await extensionsPage.extensionIsInstalled(extensionLabel), { timeout: 5000 })
-      .toBeTruthy();
+    await playExpect.poll(async () => await extensionsPage.extensionIsInstalled(extensionLabel)).toBeTruthy();
   }, 120000);
 
   describe('Extension verification after installation', async () => {

--- a/tests/playwright/src/specs/extension-installation.spec.ts
+++ b/tests/playwright/src/specs/extension-installation.spec.ts
@@ -21,7 +21,7 @@ import { expect as playExpect } from '@playwright/test';
 import { afterAll, beforeAll, beforeEach, describe, test } from 'vitest';
 
 import { DashboardPage } from '../model/pages/dashboard-page';
-import { ExtensionCardPage } from '../model/pages/extension-card-page';
+import { ExtensionCatalogCardPage } from '../model/pages/extension-catalog-card-page';
 import { ExtensionsPage } from '../model/pages/extensions-page';
 import { ResourcesPage } from '../model/pages/resources-page';
 import { SettingsBar } from '../model/pages/settings-bar';
@@ -40,23 +40,19 @@ let pdRunner: PodmanDesktopRunner;
 let page: Page;
 
 let extensionDashboardStatus: Locator;
-let extensionDashboardBox: Locator;
 let extensionDashboardProvider: Locator;
-let extensionCard: ExtensionCardPage;
 let installButtonLabel: string;
 let extensionName: string;
 let extensionLabel: string;
 let resourceLabel: string;
-let imageLink: string;
-
-let extensionBoxVisible: boolean;
 
 let navBar: NavigationBar;
 
 const _startup = async function (): Promise<void> {
   pdRunner = new PodmanDesktopRunner();
   page = await pdRunner.start();
-
+  pdRunner.setVideoAndTraceName(`${extensionName}-installation-e2e`);
+  
   const welcomePage = new WelcomePage(page);
   await welcomePage.handleWelcomePage(true);
 
@@ -73,10 +69,10 @@ beforeEach<RunnerTestContext>(async ctx => {
 
 describe.each([
   {
-    extensionType: 'Developer Sandbox',
+    extensionType: 'Red Hat OpenShift Sandbox',
   },
   {
-    extensionType: 'Openshift Local',
+    extensionType: 'Red Hat Openshift Local',
   },
 ])('$extensionType installation verification', async ({ extensionType }) => {
   beforeAll(_startup);
@@ -84,49 +80,48 @@ describe.each([
 
   test('Initialize extension type', async () => {
     initializeLocators(extensionType);
-    pdRunner.setVideoAndTraceName(`${extensionName}-installation-e2e`);
-    extensionCard = new ExtensionCardPage(page, extensionLabel, extensionName);
-    extensionBoxVisible = await extensionDashboardBox.isVisible();
+    await navBar.openExtensions();
   });
 
-  describe('Check installation availability', async () => {
-    test.runIf(extensionBoxVisible)('Check Dashboard extension component for installation availability', async () => {
-      const installButton = extensionDashboardBox.getByRole('button', { name: installButtonLabel });
-      await playExpect(installButton).toBeVisible();
-    });
-
-    test('Go to extensions', async () => {
-      await navBar.openExtensions();
-    });
-
-    // requires to be rewritten, as extension are not shuffled anymore, but are part of extensions catalog
-    test.runIf(extensionBoxVisible)('Check Settings extension component for installation availability', async () => {
-      const installButton = extensionCard.card.getByRole('button', { name: installButtonLabel });
-      await playExpect(installButton).toBeVisible();
-    });
-  });
-
-  test('Install extension through Extensions page', async () => {
+  test('Install extension through Extensions Catalog', async () => {
     const extensionsPage = new ExtensionsPage(page);
 
-    await extensionsPage.installExtensionFromOCIImage(imageLink);
-    const extensionDetailsPage = await extensionsPage.openExtensionDetails(extensionName, extensionLabel);
+    await extensionsPage.openCatalogTab();
+    const extensionCatalog = new ExtensionCatalogCardPage(page, extensionType);
+    await playExpect(extensionCatalog.parent).toBeVisible();
 
-    const extensionStatusLabel = extensionDetailsPage.status;
-    await playExpect(extensionStatusLabel).toBeVisible({ timeout: 180000 });
-  }, 200000);
+    await playExpect.poll(async () => await extensionCatalog.isInstalled(), { timeout: 5000 }).toBeFalsy();
+    await extensionCatalog.install(90000);
 
-  describe('Verify UI components after installation', async () => {
-    test('Verify Settings components', async () => {
+    await extensionsPage.openInstalledTab();
+    await playExpect
+      .poll(async () => await extensionsPage.extensionIsInstalled(extensionLabel), { timeout: 5000 })
+      .toBeTruthy();
+  }, 120000);
+
+  describe('Extension verification after installation', async () => {
+    test('Extension details can be opened', async () => {
+      await navBar.openExtensions();
+      const extensionsPage = new ExtensionsPage(page);
+
+      const extensionDetailsPage = await extensionsPage.openExtensionDetails(
+        extensionName,
+        extensionLabel,
+        extensionType,
+      );
+      await playExpect(extensionDetailsPage.status).toBeVisible({ timeout: 15000 });
+    });
+
+    test('Extension is active', async () => {
       const extensionsPage = await navBar.openExtensions();
-      const extensionPage = await extensionsPage.openExtensionDetails(extensionName, extensionLabel);
+      const extensionPage = await extensionsPage.openExtensionDetails(extensionName, extensionLabel, extensionType);
       await playExpect(extensionPage.status).toHaveText(ACTIVE);
     });
 
-    describe('Toggle and verify extension status', async () => {
+    describe('Extension can be disabled and reenabled', async () => {
       test('Disable extension and verify Dashboard and Resources components', async () => {
         const extensionsPage = await navBar.openExtensions();
-        const extensionPage = await extensionsPage.openExtensionDetails(extensionName, extensionLabel);
+        const extensionPage = await extensionsPage.openExtensionDetails(extensionName, extensionLabel, extensionType);
 
         await extensionPage.disableExtension();
         await playExpect(extensionPage.status).toHaveText(DISABLED);
@@ -145,7 +140,7 @@ describe.each([
 
       test('Enable extension and verify Dashboard and Resources components', async () => {
         const extensionsPage = await navBar.openExtensions();
-        const extensionPage = await extensionsPage.openExtensionDetails(extensionName, extensionLabel);
+        const extensionPage = await extensionsPage.openExtensionDetails(extensionName, extensionLabel, extensionType);
 
         await extensionPage.enableExtension();
         await playExpect(extensionPage.status).toHaveText(ACTIVE, { timeout: 10000 });
@@ -153,7 +148,7 @@ describe.each([
         await goToDashboard();
         await playExpect(extensionDashboardProvider).toBeVisible();
         await playExpect(extensionDashboardStatus).toBeVisible();
-        if (extensionType === 'Developer Sandbox') {
+        if (extensionType === 'Red Hat OpenShift Sandbox') {
           await playExpect(extensionDashboardStatus).toHaveText(RUNNING);
         } else {
           await playExpect(extensionDashboardStatus).toHaveText(NOT_INSTALLED);
@@ -173,7 +168,7 @@ describe.each([
     test('Remove extension and verify components', async () => {
       let extensionsPage = await navBar.openExtensions();
 
-      const extensionDetails = await extensionsPage.openExtensionDetails(extensionName, extensionLabel);
+      const extensionDetails = await extensionsPage.openExtensionDetails(extensionName, extensionLabel, extensionType);
 
       await extensionDetails.disableExtension();
       await extensionDetails.removeExtension();
@@ -186,38 +181,28 @@ describe.each([
       extensionsPage = await navBar.openExtensions();
       playExpect(await extensionsPage.extensionIsInstalled(extensionLabel)).toBeFalsy();
     });
-
-    test.runIf(extensionBoxVisible)('Verify Dashboard components', async () => {
-      await goToDashboard();
-      const dashboardInstallButton = extensionDashboardBox.getByRole('button', { name: installButtonLabel });
-      await playExpect(dashboardInstallButton).toBeVisible();
-    });
   });
 });
 
 function initializeLocators(extensionType: string): void {
   const dashboardPage = new DashboardPage(page);
   switch (extensionType) {
-    case 'Developer Sandbox': {
+    case 'Red Hat OpenShift Sandbox': {
       extensionDashboardStatus = dashboardPage.devSandboxStatusLabel;
-      extensionDashboardBox = dashboardPage.devSandboxBox;
       extensionDashboardProvider = dashboardPage.devSandboxProvider;
       installButtonLabel = 'Install redhat.redhat-sandbox Extension';
       extensionName = 'redhat-sandbox';
       extensionLabel = 'redhat.redhat-sandbox';
       resourceLabel = 'redhat.sandbox';
-      imageLink = 'ghcr.io/redhat-developer/podman-desktop-sandbox-ext:0.0.2';
       break;
     }
-    case 'Openshift Local': {
+    case 'Red Hat Openshift Local': {
       extensionDashboardStatus = dashboardPage.openshiftLocalStatusLabel;
-      extensionDashboardBox = dashboardPage.openshiftLocalBox;
       extensionDashboardProvider = dashboardPage.openshiftLocalProvider;
       installButtonLabel = 'Install redhat.openshift-local Extension';
       extensionName = 'openshift-local';
       extensionLabel = 'redhat.openshift-local';
       resourceLabel = 'crc';
-      imageLink = 'quay.io/redhat-developer/openshift-local-extension:v1.3.0';
       break;
     }
   }


### PR DESCRIPTION
### What does this PR do?
Adjusts the extension-installation tests to use extensions catalog which should improve the stability of the tests

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
#7360
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?
`yarn test:e2e:extensions`
<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
