### PR TITLE
feat: handle dir creation during fs watch

### DIFF
--- a/packages/main/src/plugin/filesystem-monitoring.spec.ts
+++ b/packages/main/src/plugin/filesystem-monitoring.spec.ts
@@ -81,3 +81,34 @@ test('should send event into onDid when a file is watched into an existing direc
     expect(unlinkListener).toHaveBeenCalledWith(Uri.file(watchedFile));
   });
 });
+
+test('should send event onDidCreate when a directory is created into a watched directory', async () => {
+  watcher = new FileSystemWatcherImpl(rootdir);
+
+  const readyListener = vi.fn();
+  watcher.onReady(readyListener);
+
+  const createListener = vi.fn();
+  watcher.onDidCreate(createListener);
+  const changeListener = vi.fn();
+  watcher.onDidChange(changeListener);
+  const unlinkListener = vi.fn();
+  watcher.onDidDelete(unlinkListener);
+
+  await vi.waitFor(async () => {
+    expect(readyListener).toHaveBeenCalled();
+  });
+
+  expect(createListener).toHaveBeenCalledWith(Uri.file(rootdir));
+  expect(changeListener).not.toHaveBeenCalled();
+  expect(unlinkListener).not.toHaveBeenCalled();
+
+  const createdDir = path.join(rootdir, 'dir');
+  await promises.mkdir(createdDir);
+
+  await vi.waitFor(async () => {
+    expect(createListener).toHaveBeenCalledWith(Uri.file(createdDir));
+  });
+  expect(changeListener).not.toHaveBeenCalled();
+  expect(unlinkListener).not.toHaveBeenCalled();
+});

--- a/packages/main/src/plugin/filesystem-monitoring.ts
+++ b/packages/main/src/plugin/filesystem-monitoring.ts
@@ -41,6 +41,11 @@ export class FileSystemWatcherImpl implements containerDesktopAPI.FileSystemWatc
       this._onDidCreate.fire(uri);
     });
 
+    this.watcher.on('addDir', (addedPath: string) => {
+      const uri: containerDesktopAPI.Uri = Uri.file(addedPath);
+      this._onDidCreate.fire(uri);
+    });
+
     this.watcher.on('change', (addedPath: string) => {
       const uri: containerDesktopAPI.Uri = Uri.file(addedPath);
       this._onDidChange.fire(uri);


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Handle `addDir` events when watching filesystem.

### What issues does this PR fix or reference?

This is necessary for fixing #6406 (using #7463)

### How to test this PR?

Unit tests are added to test the feature

- [x] Tests are covering the bug fix or the new feature
