### PR TITLE
chore: add overflow for k8s node role

### DIFF
--- a/packages/renderer/src/lib/node/NodesList.svelte
+++ b/packages/renderer/src/lib/node/NodesList.svelte
@@ -52,6 +52,7 @@ let nameColumn = new TableColumn<NodeUI>('Name', {
 
 let rolesColumn = new TableColumn<NodeUI>('Roles', {
   renderer: NodeColumnRoles,
+  overflow: true,
   comparator: (a, b) => a.role.localeCompare(b.role),
 });
 


### PR DESCRIPTION
chore: add overflow for k8s node role

### What does this PR do?

Adds the "overflow" for the column so that the text does not get
squished.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->



Before:

![Screenshot 2024-06-11 at 11 07 14 AM](https://github.com/containers/podman-desktop/assets/6422176/f1f6d5e2-ddd0-4fee-9e7c-50d978f0b756)



After:
![Screenshot 2024-06-11 at 11 05 57 AM](https://github.com/containers/podman-desktop/assets/6422176/3d5d359c-2991-401f-8afb-23be7081993e)



### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

N/A, forgot to add it.

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

N/A, small change. Does not "squish" the name / hide the text. See
above screenshot.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
