### PR TITLE
chore: light mode for settings pages

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesAuthenticationProvidersRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesAuthenticationProvidersRendering.svelte
@@ -31,9 +31,7 @@ import SettingsPage from './SettingsPage.svelte';
       {@const sessionRequests = provider.sessionRequests ?? []}
       <!-- Registered Authentication Provider row start -->
       <div class="flex flex-col w-full mb-5" role="listitem" aria-label="{provider.displayName}">
-        <div
-          class="flex rounded-md border-0 justify-between"
-          style="background-color: rgb(39 39 42 / var(--tw-bg-opacity))">
+        <div class="flex rounded-md border-0 justify-between bg-[var(--pd-invert-content-card-bg)]">
           <!-- Icon + status -->
           <div class="ml-4 flex items-center" aria-label="Provider Information">
             <!-- Icon -->
@@ -64,7 +62,9 @@ import SettingsPage from './SettingsPage.svelte';
             <!-- Authentication Provider name and status item start -->
             <div class="px-5 py-2 text-sm m-auto">
               <div class="flex flex-col">
-                <div class="flex items-center text-lg w-full h-full" aria-label="Provider Name">
+                <div
+                  class="flex items-center text-lg text-[var(--pd-invert-content-card-header-text)] w-full h-full"
+                  aria-label="Provider Name">
                   {provider.displayName}
                 </div>
                 <div class="flex flex-row items-center w-full h-full">

--- a/packages/renderer/src/lib/preferences/PreferencesCliTool.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesCliTool.svelte
@@ -50,7 +50,10 @@ function getLoggerHandler(_cliToolId: string): ConnectionCallback {
 }
 </script>
 
-<div role="row" class="bg-charcoal-600 mb-5 rounded-md p-3 flex flex-col" aria-label="{cliTool.displayName}">
+<div
+  role="row"
+  class="bg-[var(--pd-invert-content-card-bg)] mb-5 rounded-md p-3 flex flex-col"
+  aria-label="{cliTool.displayName}">
   <div class="divide-x divide-gray-900 flex flex-row">
     <div>
       <!-- left col - cli-tool icon/name + "create new" button -->
@@ -71,10 +74,13 @@ function getLoggerHandler(_cliToolId: string): ConnectionCallback {
                 class="max-w-[40px] max-h-[40px] h-full" />
             {/if}
           {/if}
-          <span id="{cliTool.id}" class="my-auto ml-3 break-words" aria-label="cli-name">{cliTool.name}</span>
+          <span
+            id="{cliTool.id}"
+            class="my-auto ml-3 break-words text-[var(--pd-invert-content-header-text)]"
+            aria-label="cli-name">{cliTool.name}</span>
         </div>
         {#if cliTool.version && cliToolStatus}
-          <div class="p-0.5 rounded-lg bg-charcoal-900 w-fit">
+          <div class="p-0.5 rounded-lg bg-[var(--pd-invert-content-bg)] w-fit">
             <LoadingIconButton
               action="update"
               clickAction="{() => {
@@ -93,17 +99,24 @@ function getLoggerHandler(_cliToolId: string): ConnectionCallback {
     </div>
     <!-- cli-tools columns -->
     <div class="grow flex-column divide-gray-900 ml-2">
-      <span class="my-auto ml-3 break-words" aria-label="cli-display-name">{cliTool.displayName}</span>
-      <div role="region" class="float-right text-gray-900 px-2 text-sm" aria-label="cli-registered-by">
+      <span class="my-auto ml-3 break-words text-[var(--pd-invert-content-header-text)]" aria-label="cli-display-name"
+        >{cliTool.displayName}</span>
+      <div
+        role="region"
+        class="float-right text-[var(--pd-invert-content-card-text)] px-2 text-sm"
+        aria-label="cli-registered-by">
         Registered by {cliTool.extensionInfo.label}
       </div>
       <div role="region" class="ml-3 mt-2 text-sm text-gray-300">
-        <div class="text-gray-700">
+        <div class="text-[var(--pd-invert-content-card-text)]">
           <Markdown markdown="{cliTool.description}" />
         </div>
         {#if cliTool.version}
-          <div class="flex flex-row justify-between align-center bg-charcoal-900 p-2 rounded-lg min-w-[320px] w-fit">
-            <div class="flex text-white-400 font-bold text-xs items-center" aria-label="cli-version">
+          <div
+            class="flex flex-row justify-between align-center bg-[var(--pd-invert-content-bg)] p-2 rounded-lg min-w-[320px] w-fit">
+            <div
+              class="flex text-[var(--pd-invert-content-card-text)] font-bold text-xs items-center"
+              aria-label="cli-version">
               {cliTool.name} v{cliTool.version}
             </div>
             {#if cliTool.newVersion}

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
@@ -60,7 +60,7 @@ async function handleDeleteContext(contextName: string) {
       <div
         role="row"
         aria-label="{context.name}"
-        class="{context.currentContext ? 'bg-charcoal-600' : 'bg-charcoal-700'} mb-5 rounded-md p-3 flex-nowrap">
+        class="bg-[var(--pd-invert-content-card-bg)] mb-5 rounded-md p-3 flex-nowrap">
         <div class="pb-2">
           <div class="flex">
             {#if context?.icon}
@@ -76,9 +76,11 @@ async function handleDeleteContext(contextName: string) {
             <div class="pl-3 flex-grow flex flex-col justify-center">
               <div class="flex flex-col items-left">
                 {#if context.currentContext}
-                  <span class="text-xs text-gray-600" aria-label="Current Context">Current Context</span>
+                  <span class="text-xs text-[var(--pd-invert-content-card-text)]" aria-label="Current Context"
+                    >Current Context</span>
                 {/if}
-                <span class="text-md" aria-label="Context Name">{context.name}</span>
+                <span class="text-md text-[var(--pd-invert-content-card-header-text)]" aria-label="Context Name"
+                  >{context.name}</span>
               </div>
             </div>
             <!-- Only show the set context button if it is not the current context -->
@@ -97,7 +99,7 @@ async function handleDeleteContext(contextName: string) {
             <ErrorMessage class="text-sm" aria-label="Context Error" error="{context.error}" />
           {/if}
         </div>
-        <div class="grow flex-column divide-gray-900 text-gray-400">
+        <div class="grow flex-column divide-gray-900 text-[var(--pd-invert-content-card-text)]">
           <div class="flex flex-row">
             {#if $kubernetesContextsState.get(context.name)}
               <div class="flex-none w-36">
@@ -110,22 +112,26 @@ async function handleDeleteContext(contextName: string) {
                   </div>
                   <div class="flex flex-row gap-4 mt-4">
                     <div class="text-center">
-                      <div class="font-bold text-[9px] text-gray-800">PODS</div>
-                      <div class="text-[16px] text-white" aria-label="Context Pods Count">
+                      <div class="font-bold text-[9px] text-[var(--pd-invert-content-card-text)]">PODS</div>
+                      <div
+                        class="text-[16px] text-[var(--pd-invert-content-card-text)]"
+                        aria-label="Context Pods Count">
                         {$kubernetesContextsState.get(context.name)?.resources.pods}
                       </div>
                     </div>
                     <div class="text-center">
-                      <div class="font-bold text-[9px] text-gray-800">DEPLOYMENTS</div>
-                      <div class="text-[16px] text-white" aria-label="Context Deployments Count">
+                      <div class="font-bold text-[9px] text-[var(--pd-invert-content-card-text)]">DEPLOYMENTS</div>
+                      <div
+                        class="text-[16px] text-[var(--pd-invert-content-card-text)]"
+                        aria-label="Context Deployments Count">
                         {$kubernetesContextsState.get(context.name)?.resources.deployments}
                       </div>
                     </div>
                   </div>
                 {:else}
                   <div class="flex flex-row pt-2">
-                    <div class="w-3 h-3 rounded-full bg-gray-900"></div>
-                    <div class="ml-1 font-bold text-[9px] text-gray-900" aria-label="Context Unreachable">
+                    <div class="w-3 h-3 rounded-full bg-status-disconnected"></div>
+                    <div class="ml-1 font-bold text-[9px] text-status-disconnected" aria-label="Context Unreachable">
                       UNREACHABLE
                     </div>
                   </div>
@@ -133,7 +139,7 @@ async function handleDeleteContext(contextName: string) {
               </div>
             {/if}
             <div class="grow">
-              <div class="text-xs bg-charcoal-800 p-2 rounded-lg mt-1 grid grid-cols-6">
+              <div class="text-xs bg-[var(--pd-invert-content-bg)] p-2 rounded-lg mt-1 grid grid-cols-6">
                 <span class="my-auto font-bold col-span-1 text-right overflow-hidden text-ellipsis">CLUSTER</span>
                 <span
                   class="my-auto col-span-5 text-left pl-0.5 ml-3 overflow-hidden text-ellipsis"
@@ -141,7 +147,7 @@ async function handleDeleteContext(contextName: string) {
               </div>
 
               {#if context.clusterInfo !== undefined}
-                <div class="text-xs bg-charcoal-800 p-2 rounded-lg mt-1 grid grid-cols-6">
+                <div class="text-xs bg-[var(--pd-invert-content-bg)] p-2 rounded-lg mt-1 grid grid-cols-6">
                   <span class="my-auto font-bold col-span-1 text-right overflow-hidden text-ellipsis">SERVER</span>
                   <span
                     class="my-auto col-span-5 text-left ml-3 overflow-hidden text-ellipsis"
@@ -151,7 +157,7 @@ async function handleDeleteContext(contextName: string) {
                 </div>
               {/if}
 
-              <div class="text-xs bg-charcoal-800 p-2 rounded-lg mt-1 grid grid-cols-6">
+              <div class="text-xs bg-[var(--pd-invert-content-bg)] p-2 rounded-lg mt-1 grid grid-cols-6">
                 <span class="my-auto font-bold col-span-1 text-right overflow-hidden text-ellipsis">USER</span>
                 <span
                   class="my-auto col-span-5 text-left pl-0.5 ml-3 overflow-hidden text-ellipsis"
@@ -159,7 +165,7 @@ async function handleDeleteContext(contextName: string) {
               </div>
 
               {#if context.namespace}
-                <div class="text-xs bg-charcoal-800 p-2 rounded-lg mt-1 grid grid-cols-6">
+                <div class="text-xs bg-[var(--pd-invert-content-bg)] p-2 rounded-lg mt-1 grid grid-cols-6">
                   <span class="my-auto font-bold col-span-1 text-right overflow-hidden text-ellipsis">NAMESPACE</span>
                   <span
                     class="my-auto col-span-5 text-left pl-0.5 ml-3 overflow-hidden text-ellipsis"


### PR DESCRIPTION
### What does this PR do?

Adds missing light mode variables in the CLI Tools, Authentication, and Kubernetes pages.

The Kube current context tile used to have a slightly different background than all other tiles and I've removed this since there is already a label that says 'Current Context', and in the past I've either not noticed the different background color or wasted time wondering why it didn't match. :)

### Screenshot / video of UI

Before:

<img width="625" alt="Screenshot 2024-06-11 at 3 26 59 PM" src="https://github.com/containers/podman-desktop/assets/19958075/1add9b0d-6297-499f-a15c-69fef4bb3d51">

<img width="625" alt="Screenshot 2024-06-11 at 3 27 16 PM" src="https://github.com/containers/podman-desktop/assets/19958075/81e2ac5c-1432-4ad9-b268-f0df6072c3d8">

<img width="625" alt="Screenshot 2024-06-11 at 3 27 50 PM" src="https://github.com/containers/podman-desktop/assets/19958075/7b49a54b-f827-43ed-8a41-09aff9345999">

After:

<img width="625" alt="Screenshot 2024-06-11 at 3 23 53 PM" src="https://github.com/containers/podman-desktop/assets/19958075/de7e5543-ae22-4c5f-8987-2d9ca3b2ef5b">

<img width="625" alt="Screenshot 2024-06-11 at 3 27 23 PM" src="https://github.com/containers/podman-desktop/assets/19958075/432bdebc-aac1-4e68-86c0-47e83240abc7">

<img width="625" alt="Screenshot 2024-06-11 at 3 27 39 PM" src="https://github.com/containers/podman-desktop/assets/19958075/95efdd3a-906a-40c8-bfdf-65c16f86edfb">

### What issues does this PR fix or reference?

Fixes #7346.

### How to test this PR?

Check Settings for visual issues, matching with other pages.