### PR TITLE
fix: remove incorrect 'apply' namespace from applyResourcesFromYAML

### DIFF
--- a/packages/main/src/plugin/kubernetes-client.spec.ts
+++ b/packages/main/src/plugin/kubernetes-client.spec.ts
@@ -1141,7 +1141,7 @@ test('Expect applyResourcesFromYAML to correctly call applyResources after loadi
   const applyResourcesSpy = vi.spyOn(client, 'applyResources').mockResolvedValue(expectedObjects);
   const objects = await client.applyResourcesFromYAML('default', podAndDeploymentTestYAML);
   expect(objects).toEqual(expectedObjects);
-  expect(applyResourcesSpy).toHaveBeenCalledWith('default', expectedObjects, 'apply');
+  expect(applyResourcesSpy).toHaveBeenCalledWith('default', expectedObjects);
 });
 
 test('setupWatcher sends kubernetes-context-update when kubeconfig file changes', async () => {

--- a/packages/main/src/plugin/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes-client.ts
@@ -1116,7 +1116,7 @@ export class KubernetesClient {
    */
   async applyResourcesFromYAML(context: string, yaml: string): Promise<KubernetesObject[]> {
     const manifests = await this.loadManifestsFromYAML(yaml);
-    return this.applyResources(context, manifests, 'apply');
+    return this.applyResources(context, manifests);
   }
 
   /**


### PR DESCRIPTION
fix: remove incorrect 'apply' namespace from applyResourcesFromYAML

### What does this PR do?

Removes the 'apply' namespace from applyResourcesFromYAML which was
causing problems.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

https://github.com/containers/podman-desktop/assets/6422176/24fc3f03-4872-4756-abc6-124ac8035047




### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop/issues/7594

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature

You can now edit any k8s YAML without having to remove resourceVersion.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
