### PR TITLE
refactor: remove uneeded managedFields from k8s

### DIFF
--- a/packages/api/src/openshift-types.ts
+++ b/packages/api/src/openshift-types.ts
@@ -16,6 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { V1ManagedFieldsEntry } from '@kubernetes/client-node';
+
 export type V1Route = {
   apiVersion?: string;
   kind?: string;
@@ -24,6 +26,7 @@ export type V1Route = {
     namespace: string;
     annotations?: { [key: string]: string };
     labels?: { [key: string]: string };
+    managedFields?: Array<V1ManagedFieldsEntry>;
     creationTimestamp?: Date;
   };
   spec: {

--- a/packages/main/src/plugin/kubernetes-client.spec.ts
+++ b/packages/main/src/plugin/kubernetes-client.spec.ts
@@ -21,12 +21,15 @@ import { IncomingMessage } from 'node:http';
 import { Socket } from 'node:net';
 import type { Readable, Writable } from 'node:stream';
 
-import {
+import type {
   Exec,
   KubeConfig,
   type KubernetesObject,
+  V1ConfigMap,
   type V1Deployment,
   type V1Ingress,
+  V1Node,
+  V1Pod,
   type V1Service,
   type V1Status,
   type Watch,
@@ -1300,4 +1303,184 @@ test('Test should throw an exception during exec command if internal kube method
       () => {},
     ),
   ).rejects.toThrowError('not active connection');
+});
+
+describe('Tests that managedFields are removed from the object when using read', () => {
+  test('Pod', async () => {
+    const client = createTestClient('default');
+    const v1Pod: V1Pod = {
+      apiVersion: 'v1',
+      kind: 'Pod',
+      metadata: {
+        name: 'pod',
+        managedFields: [{ manager: 'manager' }],
+      },
+    };
+    makeApiClientMock.mockReturnValue({
+      getCode: () => Promise.resolve({ body: { gitVersion: 'v1.20.0' } }),
+      readNamespacedPod: () =>
+        Promise.resolve({
+          body: v1Pod,
+        }),
+    });
+
+    const pod = await client.readNamespacedPod('pod', 'default');
+    expect(pod).toBeDefined();
+    expect(pod?.metadata?.managedFields).toBeUndefined();
+  });
+
+  test('Deployment', async () => {
+    const client = createTestClient('default');
+    const v1Deployment: V1Deployment = {
+      apiVersion: 'networking.k8s.io/v1',
+      kind: 'Deployment',
+      metadata: {
+        name: 'deployment',
+        managedFields: [{ manager: 'manager' }],
+      },
+    };
+    makeApiClientMock.mockReturnValue({
+      getCode: () => Promise.resolve({ body: { gitVersion: 'v1.20.0' } }),
+      readNamespacedDeployment: () =>
+        Promise.resolve({
+          body: v1Deployment,
+        }),
+    });
+
+    const deployment = await client.readNamespacedDeployment('deployment', 'default');
+    expect(deployment).toBeDefined();
+    expect(deployment?.metadata?.managedFields).toBeUndefined();
+  });
+
+  test('Node', async () => {
+    const client = createTestClient('default');
+    const v1Node: V1Node = {
+      apiVersion: 'v1',
+      kind: 'Node',
+      metadata: {
+        name: 'node',
+        managedFields: [{ manager: 'manager' }],
+      },
+    };
+    makeApiClientMock.mockReturnValue({
+      getCode: () => Promise.resolve({ body: { gitVersion: 'v1.20.0' } }),
+      readNode: () =>
+        Promise.resolve({
+          body: v1Node,
+        }),
+    });
+
+    const node = await client.readNode('node');
+    expect(node).toBeDefined();
+    expect(node?.metadata?.managedFields).toBeUndefined();
+  });
+
+  test('Ingress', async () => {
+    const client = createTestClient('default');
+    const v1Ingress: V1Ingress = {
+      apiVersion: 'networking.k8s.io/v1',
+      kind: 'Ingress',
+      metadata: {
+        name: 'ingress',
+        managedFields: [{ manager: 'manager' }],
+      },
+    };
+    makeApiClientMock.mockReturnValue({
+      getCode: () => Promise.resolve({ body: { gitVersion: 'v1.20.0' } }),
+      readNamespacedIngress: () =>
+        Promise.resolve({
+          body: v1Ingress,
+        }),
+    });
+
+    const ingress = await client.readNamespacedIngress('ingress', 'default');
+    expect(ingress).toBeDefined();
+    expect(ingress?.metadata?.managedFields).toBeUndefined();
+  });
+
+  test('Route', async () => {
+    const client = createTestClient('default');
+    const v1Route: V1Route = {
+      apiVersion: 'route.openshift.io/v1',
+      kind: 'Route',
+      metadata: {
+        name: 'route',
+        namespace: 'default',
+        managedFields: [{ manager: 'manager' }],
+      },
+      spec: {
+        host: 'host',
+        port: {
+          targetPort: '80',
+        },
+        tls: {
+          insecureEdgeTerminationPolicy: '',
+          termination: '',
+        },
+        to: {
+          kind: '',
+          name: '',
+          weight: 1,
+        },
+        wildcardPolicy: '',
+      },
+    };
+    makeApiClientMock.mockReturnValue({
+      getCode: () => Promise.resolve({ body: { gitVersion: 'v1.20.0' } }),
+      getNamespacedCustomObject: () =>
+        Promise.resolve({
+          body: v1Route,
+        }),
+    });
+
+    const route = await client.readNamespacedRoute('route', 'default');
+    expect(route).toBeDefined();
+    expect(route?.metadata?.managedFields).toBeUndefined();
+  });
+
+  test('Service', async () => {
+    const client = createTestClient('default');
+    const v1Service: V1Service = {
+      apiVersion: 'k8s.io/v1',
+      kind: 'Service',
+      metadata: {
+        name: 'service',
+        managedFields: [{ manager: 'manager' }],
+      },
+    };
+    makeApiClientMock.mockReturnValue({
+      getCode: () => Promise.resolve({ body: { gitVersion: 'v1.20.0' } }),
+      readNamespacedService: () =>
+        Promise.resolve({
+          body: v1Service,
+        }),
+    });
+
+    const service = await client.readNamespacedService('service', 'default');
+    expect(service).toBeDefined();
+    expect(service?.metadata?.managedFields).toBeUndefined();
+  });
+
+  test('ConfigMap', async () => {
+    const client = createTestClient('default');
+    const v1ConfigMap: V1ConfigMap = {
+      apiVersion: 'v1',
+      kind: 'ConfigMap',
+      metadata: {
+        name: 'configmap',
+        managedFields: [{ manager: 'manager' }],
+      },
+    };
+    makeApiClientMock.mockReturnValue({
+      getCode: () => Promise.resolve({ body: { gitVersion: 'v1.20.0' } }),
+      readNamespacedConfigMap: () =>
+        Promise.resolve({
+          body: v1ConfigMap,
+        }),
+    });
+
+    const configMap = await client.readNamespacedConfigMap('configmap', 'default');
+    expect(configMap).toBeDefined();
+    expect(configMap?.metadata?.managedFields).toBeUndefined();
+  });
 });

--- a/packages/main/src/plugin/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes-client.ts
@@ -761,6 +761,9 @@ export class KubernetesClient {
     const k8sApi = this.kubeConfig.makeApiClient(CoreV1Api);
     try {
       const res = await k8sApi.readNamespacedPod(name, namespace);
+      if (res.body?.metadata?.managedFields) {
+        delete res.body.metadata.managedFields;
+      }
       return res?.body;
     } catch (error) {
       telemetryOptions = { error: error };
@@ -775,6 +778,9 @@ export class KubernetesClient {
     const k8sAppsApi = this.kubeConfig.makeApiClient(AppsV1Api);
     try {
       const res = await k8sAppsApi.readNamespacedDeployment(name, namespace);
+      if (res.body?.metadata?.managedFields) {
+        delete res.body.metadata.managedFields;
+      }
       return res?.body;
     } catch (error) {
       telemetryOptions = { error: error };
@@ -789,6 +795,9 @@ export class KubernetesClient {
     const k8sApi = this.kubeConfig.makeApiClient(CoreV1Api);
     try {
       const res = await k8sApi.readNode(name);
+      if (res.body?.metadata?.managedFields) {
+        delete res.body.metadata.managedFields;
+      }
       return res?.body;
     } catch (error) {
       telemetryOptions = { error: error };
@@ -803,6 +812,9 @@ export class KubernetesClient {
     const k8sNetworkingApi = this.kubeConfig.makeApiClient(NetworkingV1Api);
     try {
       const res = await k8sNetworkingApi.readNamespacedIngress(name, namespace);
+      if (res.body?.metadata?.managedFields) {
+        delete res.body.metadata.managedFields;
+      }
       return res?.body;
     } catch (error) {
       telemetryOptions = { error: error };
@@ -823,7 +835,11 @@ export class KubernetesClient {
         'routes',
         name,
       );
-      return res?.body as V1Route;
+      const route = res?.body as V1Route;
+      if (route?.metadata?.managedFields) {
+        delete route.metadata.managedFields;
+      }
+      return route;
     } catch (error) {
       telemetryOptions = { error: error };
       throw this.wrapK8sClientError(error);
@@ -837,6 +853,9 @@ export class KubernetesClient {
     const k8sApi = this.kubeConfig.makeApiClient(CoreV1Api);
     try {
       const res = await k8sApi.readNamespacedService(name, namespace);
+      if (res.body?.metadata?.managedFields) {
+        delete res.body.metadata.managedFields;
+      }
       return res?.body;
     } catch (error) {
       telemetryOptions = { error: error };
@@ -851,6 +870,9 @@ export class KubernetesClient {
     const k8sApi = this.kubeConfig.makeApiClient(CoreV1Api);
     try {
       const res = await k8sApi.readNamespacedConfigMap(name, namespace);
+      if (res.body?.metadata?.managedFields) {
+        delete res.body.metadata.managedFields;
+      }
       return res?.body;
     } catch (error) {
       telemetryOptions = { error: error };


### PR DESCRIPTION
refactor: remove uneeded managedFields from k8s

### What does this PR do?

Removes the uneeded managedFields from k8s

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

No longer shown in the UI for `Kube` tab.

### What issues does this PR fix or reference?

https://github.com/containers/podman-desktop/issues/7593

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature

View the JSON / YAML of a Kubernetes object.

See that managedFields is gone.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
