### PR TITLE
fix: color of disabled button

### DIFF
--- a/packages/main/src/plugin/color-registry.ts
+++ b/packages/main/src/plugin/color-registry.ts
@@ -867,8 +867,8 @@ export class ColorRegistry {
       light: colorPalette.white,
     });
     this.registerColor(`${button}disabled`, {
-      dark: colorPalette.charcoal[50],
-      light: colorPalette.gray[900],
+      dark: colorPalette.charcoal[300],
+      light: colorPalette.gray[600],
     });
     this.registerColor(`${button}disabled-text`, {
       dark: colorPalette.charcoal[50],


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

A side effect of https://github.com/containers/podman-desktop/pull/7564 was to change the text color of disabled button.

The color `button-disabled-text` is now used (when white, as inherited color, was used before). 

The problem is that `button-disabled-text` is the same color as `button-disabled`.

This PR changes the value of `button-disabled` for dark and light, to make it different and distinguisable from `button-disabled-text`.


### What issues does this PR fix or reference?

Fixes #7600 
Fixes #7590 
### How to test this PR?

Go to the Extensions list and check color of disabled button

- [x] Tests are covering the bug fix or the new feature
