### PR TITLE
chore: move status colors to registry

### DIFF
--- a/packages/main/src/plugin/color-registry.ts
+++ b/packages/main/src/plugin/color-registry.ts
@@ -243,6 +243,7 @@ export class ColorRegistry {
     this.initTooltip();
     this.initDropdown();
     this.initLabel();
+    this.initStatusColors();
   }
 
   protected initGlobalNav(): void {
@@ -1061,6 +1062,75 @@ export class ColorRegistry {
     this.registerColor(`${label}text`, {
       dark: colorPalette.gray[500],
       light: colorPalette.charcoal[300],
+    });
+  }
+
+  protected initStatusColors(): void {
+    const status = 'status-';
+
+    // Podman & Kubernetes
+    this.registerColor(`${status}running`, {
+      dark: colorPalette.green[400],
+      light: colorPalette.green[400],
+    });
+    // Kubernetes only
+    this.registerColor(`${status}terminated`, {
+      dark: colorPalette.red[500],
+      light: colorPalette.red[500],
+    });
+    this.registerColor(`${status}waiting`, {
+      dark: colorPalette.amber[600],
+      light: colorPalette.amber[600],
+    });
+    // Podman only
+    this.registerColor(`${status}starting`, {
+      dark: colorPalette.green[600],
+      light: colorPalette.green[600],
+    });
+    // Stopped & Exited are the same color / same thing in the eyes of statuses
+    this.registerColor(`${status}stopped`, {
+      dark: colorPalette.gray[300],
+      light: colorPalette.gray[600],
+    });
+    this.registerColor(`${status}exited`, {
+      dark: colorPalette.gray[300],
+      light: colorPalette.gray[600],
+    });
+    this.registerColor(`${status}not-running`, {
+      dark: colorPalette.gray[700],
+      light: colorPalette.gray[900],
+    });
+    // "Warning"
+    this.registerColor(`${status}paused`, {
+      dark: colorPalette.amber[600],
+      light: colorPalette.amber[600],
+    });
+    this.registerColor(`${status}degraded`, {
+      dark: colorPalette.amber[700],
+      light: colorPalette.amber[700],
+    });
+    // Others
+    this.registerColor(`${status}created`, {
+      dark: colorPalette.green[300],
+      light: colorPalette.green[300],
+    });
+    this.registerColor(`${status}dead`, {
+      dark: colorPalette.red[500],
+      light: colorPalette.red[500],
+    });
+    // If we don't know the status, use gray
+    this.registerColor(`${status}unknown`, {
+      dark: colorPalette.gray[100],
+      light: colorPalette.gray[400],
+    });
+    // Connections / login
+    this.registerColor(`${status}connected`, {
+      dark: colorPalette.green[600],
+      light: colorPalette.green[600],
+    });
+    this.registerColor(`${status}disconnected`, {
+      dark: colorPalette.gray[500],
+      light: colorPalette.gray[800],
     });
   }
 }

--- a/packages/renderer/src/lib/deployments/DeploymentColumnStatus.spec.ts
+++ b/packages/renderer/src/lib/deployments/DeploymentColumnStatus.spec.ts
@@ -38,5 +38,5 @@ test('Expect simple column styling', async () => {
 
   const text = screen.getByRole('status');
   expect(text).toBeInTheDocument();
-  expect(text).toHaveClass('bg-status-running');
+  expect(text).toHaveClass('bg-[var(--pd-status-running)]');
 });

--- a/packages/renderer/src/lib/image/ImageColumnStatus.spec.ts
+++ b/packages/renderer/src/lib/image/ImageColumnStatus.spec.ts
@@ -47,5 +47,5 @@ test('Expect simple column styling', async () => {
 
   const text = screen.getByRole('status');
   expect(text).toBeInTheDocument();
-  expect(text).toHaveClass('bg-status-running');
+  expect(text).toHaveClass('bg-[var(--pd-status-running)]');
 });

--- a/packages/renderer/src/lib/images/StatusIcon.spec.ts
+++ b/packages/renderer/src/lib/images/StatusIcon.spec.ts
@@ -30,7 +30,7 @@ test('Expect starting styling', async () => {
   expect(icon).toBeInTheDocument();
   expect(icon).toHaveAttribute('title', status);
 
-  expect(icon).toHaveClass('bg-status-starting');
+  expect(icon).toHaveClass('bg-[var(--pd-status-starting)]');
 });
 
 test('Expect running styling', async () => {
@@ -40,7 +40,7 @@ test('Expect running styling', async () => {
   expect(icon).toBeInTheDocument();
   expect(icon).toHaveAttribute('title', status);
 
-  expect(icon).toHaveClass('bg-status-running');
+  expect(icon).toHaveClass('bg-[var(--pd-status-running)]');
 });
 
 test('Expect degraded styling', async () => {
@@ -50,7 +50,7 @@ test('Expect degraded styling', async () => {
   expect(icon).toBeInTheDocument();
   expect(icon).toHaveAttribute('title', status);
 
-  expect(icon).toHaveClass('bg-status-degraded');
+  expect(icon).toHaveClass('bg-[var(--pd-status-degraded)]');
 });
 
 test('Expect deleting styling', async () => {

--- a/packages/renderer/src/lib/images/StatusIcon.svelte
+++ b/packages/renderer/src/lib/images/StatusIcon.svelte
@@ -14,14 +14,14 @@ $: solid = status === 'RUNNING' || status === 'STARTING' || status === 'USED' ||
 <div class="grid place-content-center" style="position:relative">
   <div
     class="grid place-content-center rounded aspect-square text-xs"
-    class:bg-status-running="{status === 'RUNNING' || status === 'USED'}"
-    class:bg-status-starting="{status === 'STARTING'}"
-    class:bg-status-degraded="{status === 'DEGRADED'}"
+    class:bg-[var(--pd-status-running)]="{status === 'RUNNING' || status === 'USED'}"
+    class:bg-[var(--pd-status-starting)]="{status === 'STARTING'}"
+    class:bg-[var(--pd-status-degraded)]="{status === 'DEGRADED'}"
     class:border-2="{!solid && status !== 'DELETING'}"
     class:p-0.5="{!solid}"
     class:p-1="{solid}"
-    class:border-gray-700="{!solid}"
-    class:text-gray-700="{!solid}"
+    class:border-[var(--pd-status-not-running)]="{!solid}"
+    class:text-[var(--pd-status-not-running)]="{!solid}"
     role="status"
     title="{status}">
     {#if status === 'DELETING'}

--- a/packages/renderer/src/lib/ingresses-routes/IngressRouteColumnStatus.spec.ts
+++ b/packages/renderer/src/lib/ingresses-routes/IngressRouteColumnStatus.spec.ts
@@ -36,7 +36,7 @@ test('Expect simple column styling with Ingress', async () => {
 
   const text = screen.getByRole('status');
   expect(text).toBeInTheDocument();
-  expect(text).toHaveClass('bg-status-running');
+  expect(text).toHaveClass('bg-[var(--pd-status-running)]');
 });
 
 test('Expect simple column styling with Route', async () => {
@@ -57,5 +57,5 @@ test('Expect simple column styling with Route', async () => {
 
   const text = screen.getByRole('status');
   expect(text).toBeInTheDocument();
-  expect(text).toHaveClass('bg-status-running');
+  expect(text).toHaveClass('bg-[var(--pd-status-running)]');
 });

--- a/packages/renderer/src/lib/node/NodeColumnStatus.spec.ts
+++ b/packages/renderer/src/lib/node/NodeColumnStatus.spec.ts
@@ -38,5 +38,5 @@ test('Expect simple column styling', async () => {
 
   const text = screen.getByRole('status');
   expect(text).toBeInTheDocument();
-  expect(text).toHaveClass('bg-status-running');
+  expect(text).toHaveClass('bg-[var(--pd-status-running)]');
 });

--- a/packages/renderer/src/lib/pod/PodColumnContainers.spec.ts
+++ b/packages/renderer/src/lib/pod/PodColumnContainers.spec.ts
@@ -51,7 +51,7 @@ test('Expect simple column styling', async () => {
 
   const dot = screen.getByTestId('status-dot');
   expect(dot).toBeInTheDocument();
-  expect(dot).toHaveClass('bg-status-running');
+  expect(dot).toHaveClass('bg-[var(--pd-status-running)]');
 });
 
 test('Expect clicking works', async () => {

--- a/packages/renderer/src/lib/pod/PodColumnStatus.spec.ts
+++ b/packages/renderer/src/lib/pod/PodColumnStatus.spec.ts
@@ -43,5 +43,5 @@ test('Expect simple column styling', async () => {
 
   const status = screen.getByRole('status');
   expect(status).toBeInTheDocument();
-  expect(status).toHaveClass('bg-status-running');
+  expect(status).toHaveClass('bg-[var(--pd-status-running)]');
 });

--- a/packages/renderer/src/lib/pod/PodsList.spec.ts
+++ b/packages/renderer/src/lib/pod/PodsList.spec.ts
@@ -443,17 +443,17 @@ test('Expect the pod1 row to have 3 status dots with the correct colors and the 
   expect(statusDots.length).toBe(4);
 
   expect(statusDots[0].title).toBe('container1: Running');
-  expect(statusDots[0]).toHaveClass('bg-status-running');
+  expect(statusDots[0]).toHaveClass('bg-[var(--pd-status-running)]');
 
   expect(statusDots[1].title).toBe('container3: Exited');
-  expect(statusDots[1]).toHaveClass('outline-status-exited');
+  expect(statusDots[1]).toHaveClass('outline-[var(--pd-status-exited)]');
 
   expect(statusDots[2].title).toBe('container2: Terminated');
-  expect(statusDots[2]).toHaveClass('bg-status-terminated');
+  expect(statusDots[2]).toHaveClass('bg-[var(--pd-status-terminated)]');
 
   // 2nd row / 2nd pod
   expect(statusDots[3].title).toBe('container4: Running');
-  expect(statusDots[3]).toHaveClass('bg-status-running');
+  expect(statusDots[3]).toHaveClass('bg-[var(--pd-status-running)]');
 });
 
 test('Expect the manyPod row to show 9 dots representing every status', async () => {
@@ -475,31 +475,31 @@ test('Expect the manyPod row to show 9 dots representing every status', async ()
   expect(statusDots.length).toBe(9);
 
   expect(statusDots[0].title).toBe('Running: 3');
-  expect(statusDots[0]).toHaveClass('bg-status-running');
+  expect(statusDots[0]).toHaveClass('bg-[var(--pd-status-running)]');
 
   expect(statusDots[1].title).toBe('Created: 1');
-  expect(statusDots[1]).toHaveClass('outline-status-created');
+  expect(statusDots[1]).toHaveClass('outline-[var(--pd-status-created)]');
 
   expect(statusDots[2].title).toBe('Paused: 1');
-  expect(statusDots[2]).toHaveClass('bg-status-paused');
+  expect(statusDots[2]).toHaveClass('bg-[var(--pd-status-paused)]');
 
   expect(statusDots[3].title).toBe('Waiting: 1');
-  expect(statusDots[3]).toHaveClass('bg-status-waiting');
+  expect(statusDots[3]).toHaveClass('bg-[var(--pd-status-waiting)]');
 
   expect(statusDots[4].title).toBe('Degraded: 1');
-  expect(statusDots[4]).toHaveClass('bg-status-degraded');
+  expect(statusDots[4]).toHaveClass('bg-[var(--pd-status-degraded)]');
 
   expect(statusDots[5].title).toBe('Exited: 1');
-  expect(statusDots[5]).toHaveClass('outline-status-exited');
+  expect(statusDots[5]).toHaveClass('outline-[var(--pd-status-exited)]');
 
   expect(statusDots[6].title).toBe('Stopped: 1');
-  expect(statusDots[6]).toHaveClass('outline-status-stopped');
+  expect(statusDots[6]).toHaveClass('outline-[var(--pd-status-stopped)]');
 
   expect(statusDots[7].title).toBe('Terminated: 1');
-  expect(statusDots[7]).toHaveClass('bg-status-terminated');
+  expect(statusDots[7]).toHaveClass('bg-[var(--pd-status-terminated)]');
 
   expect(statusDots[8].title).toBe('Dead: 1');
-  expect(statusDots[8]).toHaveClass('bg-status-dead');
+  expect(statusDots[8]).toHaveClass('bg-[var(--pd-status-dead)]');
 });
 
 const runningPod: PodInfo = {

--- a/packages/renderer/src/lib/preferences/PreferencesAuthenticationProvidersRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesAuthenticationProvidersRendering.svelte
@@ -70,15 +70,15 @@ import SettingsPage from './SettingsPage.svelte';
                 <div class="flex flex-row items-center w-full h-full">
                   <dif>
                     <Fa
-                      class="h-3 w-3 text-md mr-2 text-{provider.accounts.length > 0
-                        ? 'status-connected'
-                        : 'status-disconnected'}"
+                      class="h-3 w-3 text-md mr-2 text-[var(--pd-status-{provider.accounts.length > 0
+                        ? 'connected'
+                        : 'disconnected'})]"
                       icon="{faCircle}" />
                   </dif>
                   <div
-                    class="uppercase text-xs text-{provider.accounts.length > 0
-                      ? 'status-connected'
-                      : 'status-disconnected'}"
+                    class="uppercase text-xs text-[var(--pd-status-{provider.accounts.length > 0
+                      ? 'connected'
+                      : 'disconnected'})]"
                     aria-label="Provider Status">
                     <span>
                       {provider.accounts.length > 0 ? 'Logged in' : 'Logged out'}

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
@@ -105,8 +105,10 @@ async function handleDeleteContext(contextName: string) {
               <div class="flex-none w-36">
                 {#if $kubernetesContextsState.get(context.name)?.reachable}
                   <div class="flex flex-row pt-2">
-                    <div class="w-3 h-3 rounded-full bg-status-connected"></div>
-                    <div class="ml-1 font-bold text-[9px] text-status-connected" aria-label="Context Reachable">
+                    <div class="w-3 h-3 rounded-full bg-[var(--pd-status-connected)]"></div>
+                    <div
+                      class="ml-1 font-bold text-[9px] text-[var(--pd-status-connected)]"
+                      aria-label="Context Reachable">
                       REACHABLE
                     </div>
                   </div>
@@ -130,8 +132,10 @@ async function handleDeleteContext(contextName: string) {
                   </div>
                 {:else}
                   <div class="flex flex-row pt-2">
-                    <div class="w-3 h-3 rounded-full bg-status-disconnected"></div>
-                    <div class="ml-1 font-bold text-[9px] text-status-disconnected" aria-label="Context Unreachable">
+                    <div class="w-3 h-3 rounded-full bg-[var(--pd-status-disconnected)]"></div>
+                    <div
+                      class="ml-1 font-bold text-[9px] text-[var(--pd-status-disconnected)]"
+                      aria-label="Context Unreachable">
                       UNREACHABLE
                     </div>
                   </div>

--- a/packages/renderer/src/lib/service/ServiceColumnStatus.spec.ts
+++ b/packages/renderer/src/lib/service/ServiceColumnStatus.spec.ts
@@ -38,5 +38,5 @@ test('Expect simple column styling', async () => {
 
   const text = screen.getByRole('status');
   expect(text).toBeInTheDocument();
-  expect(text).toHaveClass('bg-status-running');
+  expect(text).toHaveClass('bg-[var(--pd-status-running)]');
 });

--- a/packages/renderer/src/lib/ui/Dots.spec.ts
+++ b/packages/renderer/src/lib/ui/Dots.spec.ts
@@ -74,16 +74,16 @@ const mockContainers: PodInfoContainerUI[] = [
 ];
 
 test('test getStatusColor returns the correct colors', () => {
-  expect(getStatusColor('running')).toBe('bg-status-running');
-  expect(getStatusColor('terminated')).toBe('bg-status-terminated');
-  expect(getStatusColor('waiting')).toBe('bg-status-waiting');
-  expect(getStatusColor('stopped')).toBe('outline-status-stopped');
-  expect(getStatusColor('paused')).toBe('bg-status-paused');
-  expect(getStatusColor('exited')).toBe('outline-status-exited');
-  expect(getStatusColor('dead')).toBe('bg-status-dead');
-  expect(getStatusColor('created')).toBe('outline-status-created');
-  expect(getStatusColor('degraded')).toBe('bg-status-degraded');
-  expect(getStatusColor('unknown')).toBe('bg-status-unknown');
+  expect(getStatusColor('running')).toBe('bg-[var(--pd-status-running)]');
+  expect(getStatusColor('terminated')).toBe('bg-[var(--pd-status-terminated)]');
+  expect(getStatusColor('waiting')).toBe('bg-[var(--pd-status-waiting)]');
+  expect(getStatusColor('stopped')).toBe('outline-[var(--pd-status-stopped)]');
+  expect(getStatusColor('paused')).toBe('bg-[var(--pd-status-paused)]');
+  expect(getStatusColor('exited')).toBe('outline-[var(--pd-status-exited)]');
+  expect(getStatusColor('dead')).toBe('bg-[var(--pd-status-dead)]');
+  expect(getStatusColor('created')).toBe('outline-[var(--pd-status-created)]');
+  expect(getStatusColor('degraded')).toBe('bg-[var(--pd-status-degraded)]');
+  expect(getStatusColor('unknown')).toBe('bg-[var(--pd-status-unknown)]');
 });
 
 test('test organizeContainers returns a record of containers organized by status', () => {

--- a/packages/renderer/src/lib/ui/Dots.ts
+++ b/packages/renderer/src/lib/ui/Dots.ts
@@ -29,23 +29,23 @@ export function getStatusColor(status: string): string {
   // must be either "bg-" or "outline-" for either solid / outline colors
   const colors: Record<string, string> = {
     // Podman & Kubernetes
-    running: 'bg-status-running',
+    running: 'bg-[var(--pd-status-running)]',
 
     // Kubernetes-only
-    terminated: 'bg-status-terminated',
-    waiting: 'bg-status-waiting',
+    terminated: 'bg-[var(--pd-status-terminated)]',
+    waiting: 'bg-[var(--pd-status-waiting)]',
 
     // Podman-only
-    stopped: 'outline-status-stopped',
-    paused: 'bg-status-paused',
-    exited: 'outline-status-exited',
-    dead: 'bg-status-dead',
-    created: 'outline-status-created',
-    degraded: 'bg-status-degraded',
+    stopped: 'outline-[var(--pd-status-stopped)]',
+    paused: 'bg-[var(--pd-status-paused)]',
+    exited: 'outline-[var(--pd-status-exited)]',
+    dead: 'bg-[var(--pd-status-dead)]',
+    created: 'outline-[var(--pd-status-created)]',
+    degraded: 'bg-[var(--pd-status-degraded)]',
   };
 
   // Return the corresponding color class or a default if not found
-  return colors[status] || 'bg-status-unknown';
+  return colors[status] || 'bg-[var(--pd-status-unknown)]';
 }
 
 // Organize the containers by returning their status as the key + an array of containers by order of

--- a/packages/renderer/src/lib/ui/KubernetesCurrentContextConnectionBadge.spec.ts
+++ b/packages/renderer/src/lib/ui/KubernetesCurrentContextConnectionBadge.spec.ts
@@ -90,7 +90,7 @@ test('expect badges to be green when reachable', async () => {
 
   expect(mocks.getCurrentKubeContextState).toHaveBeenCalled();
   const status = screen.getByRole('status');
-  expect(status.firstChild).toHaveClass('bg-status-connected');
+  expect(status.firstChild).toHaveClass('bg-[var(--pd-status-connected)]');
 });
 
 test('expect badges to be gray when not reachable', async () => {
@@ -106,7 +106,7 @@ test('expect badges to be gray when not reachable', async () => {
 
   expect(mocks.getCurrentKubeContextState).toHaveBeenCalled();
   const status = screen.getByRole('status');
-  expect(status.firstChild).toHaveClass('bg-status-disconnected');
+  expect(status.firstChild).toHaveClass('bg-[var(--pd-status-disconnected)]');
 });
 
 test('expect no tooltip when no error', async () => {

--- a/packages/renderer/src/lib/ui/KubernetesCurrentContextConnectionBadge.svelte
+++ b/packages/renderer/src/lib/ui/KubernetesCurrentContextConnectionBadge.svelte
@@ -11,8 +11,8 @@ function getText(state?: ContextGeneralState): string {
 }
 
 function getClassColor(state?: ContextGeneralState): string {
-  if (state?.reachable) return 'bg-status-connected';
-  return 'bg-status-disconnected';
+  if (state?.reachable) return 'bg-[var(--pd-status-connected)]';
+  return 'bg-[var(--pd-status-disconnected)]';
 }
 
 $: text = getText($kubernetesCurrentContextState);

--- a/packages/renderer/src/lib/ui/StatusDot.spec.ts
+++ b/packages/renderer/src/lib/ui/StatusDot.spec.ts
@@ -30,59 +30,59 @@ const renderStatusDot = (containerStatus: string) => {
 test('Expect the dot to have the correct color for running status', () => {
   renderStatusDot('running');
   const dot = screen.getByTestId('status-dot');
-  expect(dot).toHaveClass('bg-status-running');
+  expect(dot).toHaveClass('bg-[var(--pd-status-running)]');
 });
 
 test('Expect the dot to have the correct color for terminated status', () => {
   renderStatusDot('terminated');
   const dot = screen.getByTestId('status-dot');
-  expect(dot).toHaveClass('bg-status-terminated');
+  expect(dot).toHaveClass('bg-[var(--pd-status-terminated)]');
 });
 
 test('Expect the dot to have the correct color for waiting status', () => {
   renderStatusDot('waiting');
   const dot = screen.getByTestId('status-dot');
-  expect(dot).toHaveClass('bg-status-waiting');
+  expect(dot).toHaveClass('bg-[var(--pd-status-waiting)]');
 });
 
 test('Expect the dot to have the correct color for stopped status', () => {
   renderStatusDot('stopped');
   const dot = screen.getByTestId('status-dot');
-  expect(dot).toHaveClass('outline-status-stopped');
+  expect(dot).toHaveClass('outline-[var(--pd-status-stopped)]');
 });
 
 test('Expect the dot to have the correct color for paused status', () => {
   renderStatusDot('paused');
   const dot = screen.getByTestId('status-dot');
-  expect(dot).toHaveClass('bg-status-paused');
+  expect(dot).toHaveClass('bg-[var(--pd-status-paused)]');
 });
 
 test('Expect the dot to have the correct color for exited status', () => {
   renderStatusDot('exited');
   const dot = screen.getByTestId('status-dot');
-  expect(dot).toHaveClass('outline-status-exited');
+  expect(dot).toHaveClass('outline-[var(--pd-status-exited)]');
 });
 
 test('Expect the dot to have the correct color for dead status', () => {
   renderStatusDot('dead');
   const dot = screen.getByTestId('status-dot');
-  expect(dot).toHaveClass('bg-status-dead');
+  expect(dot).toHaveClass('bg-[var(--pd-status-dead)]');
 });
 
 test('Expect the dot to have the correct color for created status', () => {
   renderStatusDot('created');
   const dot = screen.getByTestId('status-dot');
-  expect(dot).toHaveClass('outline-status-created');
+  expect(dot).toHaveClass('outline-[var(--pd-status-created)]');
 });
 
 test('Expect the dot to have the correct color for degraded status', () => {
   renderStatusDot('degraded');
   const dot = screen.getByTestId('status-dot');
-  expect(dot).toHaveClass('bg-status-degraded');
+  expect(dot).toHaveClass('bg-[var(--pd-status-degraded)]');
 });
 
 test('Expect the dot to have the correct color for unknown status', () => {
   renderStatusDot('unknown');
   const dot = screen.getByTestId('status-dot');
-  expect(dot).toHaveClass('bg-status-unknown');
+  expect(dot).toHaveClass('bg-[var(--pd-status-unknown)]');
 });

--- a/packages/renderer/src/lib/volume/VolumeColumnStatus.spec.ts
+++ b/packages/renderer/src/lib/volume/VolumeColumnStatus.spec.ts
@@ -45,5 +45,5 @@ test('Expect simple column styling', async () => {
 
   const status = screen.getByRole('status');
   expect(status).toBeInTheDocument();
-  expect(status).toHaveClass('bg-status-running');
+  expect(status).toHaveClass('bg-[var(--pd-status-running)]');
 });

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -49,37 +49,7 @@ module.exports = {
     colors: {
       // import colors from the color palette
       ...colorPalette,
-      // The "status" colours to be used for Podman and Kubernetes containers
-      // these can be referenced by in the form of "bg-status-running" or "text-status-running"
-      'status': {
-        // Podman & Kubernetes
-        'running': tailwindColors.green[400],
-
-        // Kubernetes only
-        'terminated': tailwindColors.red[500],
-        'waiting': tailwindColors.amber[600],
-
-        // Podman only
-        'starting': tailwindColors.green[600],
-
-        // Stopped & Exited are the same color / same thing in the eyes of statuses
-        'stopped': tailwindColors.gray[300],
-        'exited': tailwindColors.gray[300],
-
-        // "Warning"
-        'paused': tailwindColors.amber[600],
-        'degraded': tailwindColors.amber[700],
-
-        // Others
-        'created': tailwindColors.green[300],
-        'dead': tailwindColors.red[500],
-
-        // If we don't know the status, use gray
-        'unknown': tailwindColors.gray[100],
-
-        'connected': tailwindColors.green[600],
-        'disconnected': tailwindColors.gray[500],
-      },
+      
       // The remaining colors below are not part of our palette and are only here
       // to maintain existing code. No new use.
       'zinc': {


### PR DESCRIPTION
### What does this PR do?

Moves status colors to the color registry.

Most of this is just porting; the one addition I had to make is StatusIcon was using a hard-coded color for things that aren't running - which is *not* the same color as stopped/exited, etc. To avoid changing colors elsewhere, for now I've just defined a new 'not-running' status color, which we may want to revisit with UX later.

For light mode, the only change I made was to darken gray colors a bit since they were washed out.

### Screenshot / video of UI

No change to UI, slightly darker stopped status for light mode.

### What issues does this PR fix or reference?

Fixes #7581.

### How to test this PR?

Confirm no visual change to dark mode, and light mode looks ok.

- [x] Tests are covering the bug fix or the new feature