### PR TITLE
chore: add light mode to summary pages

### DIFF
--- a/packages/renderer/src/lib/deployments/DeploymentDetailsSummary.svelte
+++ b/packages/renderer/src/lib/deployments/DeploymentDetailsSummary.svelte
@@ -2,6 +2,8 @@
 import type { V1Deployment } from '@kubernetes/client-node';
 import { ErrorMessage } from '@podman-desktop/ui-svelte';
 
+import Table from '/@/lib/details/DetailsTable.svelte';
+
 import KubeDeploymentArtifact from '../kube/details/KubeDeploymentArtifact.svelte';
 import KubeDeploymentStatusArtifact from '../kube/details/KubeDeploymentStatusArtifact.svelte';
 import KubeObjectMetaArtifact from '../kube/details/KubeObjectMetaArtifact.svelte';
@@ -16,16 +18,12 @@ basic information -->
   <ErrorMessage error="{kubeError}" />
 {/if}
 
-<div class="flex px-5 py-4 flex-col items-start h-full overflow-auto">
+<Table>
   {#if deployment}
-    <table class="w-full">
-      <tbody>
-        <KubeObjectMetaArtifact artifact="{deployment.metadata}" />
-        <KubeDeploymentStatusArtifact artifact="{deployment.status}" />
-        <KubeDeploymentArtifact artifact="{deployment.spec}" />
-      </tbody>
-    </table>
+    <KubeObjectMetaArtifact artifact="{deployment.metadata}" />
+    <KubeDeploymentStatusArtifact artifact="{deployment.status}" />
+    <KubeDeploymentArtifact artifact="{deployment.spec}" />
   {:else}
     <p class="text-purple-500 font-medium">Loading ...</p>
   {/if}
-</div>
+</Table>

--- a/packages/renderer/src/lib/ingresses-routes/IngressRouteDetailsSummary.svelte
+++ b/packages/renderer/src/lib/ingresses-routes/IngressRouteDetailsSummary.svelte
@@ -2,6 +2,7 @@
 import type { V1Ingress } from '@kubernetes/client-node';
 import { ErrorMessage } from '@podman-desktop/ui-svelte';
 
+import Table from '/@/lib/details/DetailsTable.svelte';
 import type { V1Route } from '/@api/openshift-types';
 
 import KubeIngressArtifact from '../kube/details/KubeIngressArtifact.svelte';
@@ -24,21 +25,17 @@ basic information -->
   <ErrorMessage error="{kubeError}" />
 {/if}
 
-<div class="flex px-5 py-4 flex-col items-start h-full overflow-auto">
+<Table>
   {#if ingressRoute}
-    <table class="w-full">
-      <tbody>
-        <KubeObjectMetaArtifact artifact="{ingressRoute.metadata}" />
-        {#if isIngress(ingressRoute)}
-          <KubeIngressStatusArtifact artifact="{ingressRoute.status}" />
-          <KubeIngressArtifact artifact="{ingressRoute.spec}" />
-        {:else}
-          <!-- Routes are shown / structured quite differently than Kubernetes, so we will show these separate. -->
-          <OpenshiftRouteArtifact artifact="{ingressRoute}" />
-        {/if}
-      </tbody>
-    </table>
+    <KubeObjectMetaArtifact artifact="{ingressRoute.metadata}" />
+    {#if isIngress(ingressRoute)}
+      <KubeIngressStatusArtifact artifact="{ingressRoute.status}" />
+      <KubeIngressArtifact artifact="{ingressRoute.spec}" />
+    {:else}
+      <!-- Routes are shown / structured quite differently than Kubernetes, so we will show these separate. -->
+      <OpenshiftRouteArtifact artifact="{ingressRoute}" />
+    {/if}
   {:else}
     <p class="text-purple-500 font-medium">Loading ...</p>
   {/if}
-</div>
+</Table>

--- a/packages/renderer/src/lib/kube/KubePodDetailsSummary.svelte
+++ b/packages/renderer/src/lib/kube/KubePodDetailsSummary.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 import type { V1Pod } from '@kubernetes/client-node';
 
+import Table from '/@/lib/details/DetailsTable.svelte';
+
 import KubeObjectMetaArtifact from './details/KubeObjectMetaArtifact.svelte';
 import KubePodSpecArtifact from './details/KubePodSpecArtifact.svelte';
 import KubePodStatusArtifact from './details/KubePodStatusArtifact.svelte';
@@ -8,16 +10,12 @@ import KubePodStatusArtifact from './details/KubePodStatusArtifact.svelte';
 export let pod: V1Pod | undefined;
 </script>
 
-<div class="flex px-5 py-4 flex-col items-start h-full overflow-auto">
+<Table>
   {#if pod}
-    <table class="w-full">
-      <tbody>
-        <KubeObjectMetaArtifact artifact="{pod.metadata}" />
-        <KubePodStatusArtifact artifact="{pod.status}" />
-        <KubePodSpecArtifact artifact="{pod.spec}" />
-      </tbody>
-    </table>
+    <KubeObjectMetaArtifact artifact="{pod.metadata}" />
+    <KubePodStatusArtifact artifact="{pod.status}" />
+    <KubePodSpecArtifact artifact="{pod.spec}" />
   {:else}
     <p class="text-purple-500 font-medium">Loading ...</p>
   {/if}
-</div>
+</Table>

--- a/packages/renderer/src/lib/node/NodeDetailsSummary.svelte
+++ b/packages/renderer/src/lib/node/NodeDetailsSummary.svelte
@@ -2,6 +2,8 @@
 import type { V1Node } from '@kubernetes/client-node';
 import { ErrorMessage } from '@podman-desktop/ui-svelte';
 
+import Table from '/@/lib/details/DetailsTable.svelte';
+
 import KubeNodeArtifact from '../kube/details/KubeNodeArtifact.svelte';
 import KubeNodeStatusArtifact from '../kube/details/KubeNodeStatusArtifact.svelte';
 import KubeObjectMetaArtifact from '../kube/details/KubeObjectMetaArtifact.svelte';
@@ -16,16 +18,12 @@ basic information -->
   <ErrorMessage error="{kubeError}" />
 {/if}
 
-<div class="flex px-5 py-4 flex-col items-start h-full overflow-auto">
+<Table>
   {#if node}
-    <table class="w-full">
-      <tbody>
-        <KubeObjectMetaArtifact artifact="{node.metadata}" />
-        <KubeNodeStatusArtifact artifact="{node.status}" />
-        <KubeNodeArtifact artifact="{node.spec}" />
-      </tbody>
-    </table>
+    <KubeObjectMetaArtifact artifact="{node.metadata}" />
+    <KubeNodeStatusArtifact artifact="{node.status}" />
+    <KubeNodeArtifact artifact="{node.spec}" />
   {:else}
     <p class="text-purple-500 font-medium">Loading ...</p>
   {/if}
-</div>
+</Table>

--- a/packages/renderer/src/lib/service/ServiceDetailsSummary.svelte
+++ b/packages/renderer/src/lib/service/ServiceDetailsSummary.svelte
@@ -2,6 +2,8 @@
 import type { V1Service } from '@kubernetes/client-node';
 import { ErrorMessage } from '@podman-desktop/ui-svelte';
 
+import Table from '/@/lib/details/DetailsTable.svelte';
+
 import KubeObjectMetaArtifact from '../kube/details/KubeObjectMetaArtifact.svelte';
 import KubeServiceArtifact from '../kube/details/KubeServiceArtifact.svelte';
 import KubeServiceStatusArtifact from '../kube/details/KubeServiceStatusArtifact.svelte';
@@ -16,16 +18,12 @@ basic information -->
   <ErrorMessage error="{kubeError}" />
 {/if}
 
-<div class="flex px-5 py-4 flex-col items-start h-full overflow-auto">
+<Table>
   {#if service}
-    <table class="w-full">
-      <tbody>
-        <KubeObjectMetaArtifact artifact="{service.metadata}" />
-        <KubeServiceStatusArtifact artifact="{service.status}" />
-        <KubeServiceArtifact artifact="{service.spec}" />
-      </tbody>
-    </table>
+    <KubeObjectMetaArtifact artifact="{service.metadata}" />
+    <KubeServiceStatusArtifact artifact="{service.status}" />
+    <KubeServiceArtifact artifact="{service.spec}" />
   {:else}
     <p class="text-purple-500 font-medium">Loading ...</p>
   {/if}
-</div>
+</Table>


### PR DESCRIPTION
chore: add light mode to summary pages

### What does this PR do?

* Adds light mode to all summary pages

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->
![Screenshot 2024-06-12 at 4 20 31 PM](https://github.com/containers/podman-desktop/assets/6422176/da0cd161-fcd9-44fa-b326-eeffaeb6b8b1)
![Screenshot 2024-06-12 at 4 20 36 PM](https://github.com/containers/podman-desktop/assets/6422176/77d29701-c9b4-4daa-9a14-cea3bbe21aa3)



### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes #7575

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature

Current tests cover changes (regarding Loading ...)

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
