### PR TITLE
chore: ignore /kind in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,6 @@ dist
 .vale/styles/RedHat
 **/test-resources
 **/coverage
-# kind
-kind.exe
+/kind
+/kind.exe
 /storybook/.storybook/themes.css


### PR DESCRIPTION
### What does this PR do?
An empty `kind(.exe)` file is created in the repository root when running tests. These files should be ignored.

### How to test this PR?
Run `yarn test`, a new `kind` file should appear but be ignored by git

Signed-off-by: Jitse Klomp <jitse@jitseklomp.nl>