### PR TITLE
chore: update Podman pods summary page UI

### DIFF
--- a/packages/renderer/src/lib/pod/PodDetailsSummary.svelte
+++ b/packages/renderer/src/lib/pod/PodDetailsSummary.svelte
@@ -1,18 +1,14 @@
 <script lang="ts">
 import type { V1Pod } from '@kubernetes/client-node';
 import { onMount } from 'svelte';
-import { router } from 'tinro';
 
 import KubePodDetailsSummary from '../kube/KubePodDetailsSummary.svelte';
 import type { PodInfoUI } from './PodInfoUI';
+import PodmanPodDetailsSummary from './PodmanPodDetailsSummary.svelte';
 
 export let pod: PodInfoUI;
 let kubePod: V1Pod | undefined;
 let getKubePodError: string;
-
-function openContainer(containerID: string) {
-  router.goto(`/containers/${containerID}/logs`);
-}
 
 onMount(async () => {
   // If this is a kubernetes kind, let's retrieve the pod information and display it in the summary
@@ -42,35 +38,5 @@ ass KubePodDetailsSummary will automatically add a 'Loading ... ' section -->
   <KubePodDetailsSummary pod="{kubePod}" />
 {:else}
   <!-- Still show pod information in case the Kubernetes pod retrieval errors out -->
-  <div class="flex px-5 py-4 flex-col h-full overflow-auto text-[var(--pd-details-body-text)]">
-    <div class="w-full">
-      <table>
-        <tbody>
-          <tr>
-            <td class="pr-2">Name:</td>
-            <td>{pod.name}</td>
-          </tr>
-          <tr>
-            <td class="pr-2">Id:</td>
-            <td>{pod.id}</td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
-    {#if pod.containers.length > 0}
-      <div class="w-full mt-12">
-        <span>Containers using this pod:</span>
-        <table>
-          <tbody>
-            {#each pod.containers as container}
-              <tr class="cursor-pointer" on:click="{() => openContainer(container.Id)}">
-                <td class="pr-2">{container.Names}</td>
-                <td>{container.Id}</td>
-              </tr>
-            {/each}
-          </tbody>
-        </table>
-      </div>
-    {/if}
-  </div>
+  <PodmanPodDetailsSummary pod="{pod}" />
 {/if}

--- a/packages/renderer/src/lib/pod/PodmanPodDetailsSummary.spec.ts
+++ b/packages/renderer/src/lib/pod/PodmanPodDetailsSummary.spec.ts
@@ -1,0 +1,63 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/svelte';
+import { expect, test } from 'vitest';
+
+import type { PodInfoUI } from './PodInfoUI';
+import PodmanPodDetailsSummary from './PodmanPodDetailsSummary.svelte';
+
+const fakePod: PodInfoUI = {
+  id: 'fakePodId',
+  shortId: 'FPI',
+  name: 'pod1',
+  engineId: 'fakeEngineId',
+  engineName: 'fakeEngineName',
+  status: 'RUNNING',
+  age: '3 days',
+  created: '2021-01-01T00:00:00Z',
+  selected: false,
+  containers: [
+    {
+      Id: 'fakeCId1',
+      Names: 'fakeContainer1',
+      Status: 'running',
+    },
+    {
+      Id: 'fakeCId2',
+      Names: 'fakeContainer2',
+      Status: 'running',
+    },
+  ],
+  kind: 'podman',
+};
+
+// Test render PodmanPodDetailsSummary with the PodInfoUi object
+test('PodmanPodDetailsSummary renders with PodInfoUi object', async () => {
+  // Render
+  render(PodmanPodDetailsSummary, { pod: fakePod });
+
+  // Check that the rendered text is correct
+  expect(screen.getByText('pod1')).toBeInTheDocument();
+  expect(screen.getByText('3 days')).toBeInTheDocument();
+  expect(screen.getByText('fakeContainer1')).toBeInTheDocument();
+  expect(screen.getByText('fakeContainer2')).toBeInTheDocument();
+  expect(screen.getAllByText('running')[0]).toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/pod/PodmanPodDetailsSummary.spec.ts
+++ b/packages/renderer/src/lib/pod/PodmanPodDetailsSummary.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,8 +49,8 @@ const fakePod: PodInfoUI = {
   kind: 'podman',
 };
 
-// Test render PodmanPodDetailsSummary with the PodInfoUi object
-test('PodmanPodDetailsSummary renders with PodInfoUi object', async () => {
+// Test render PodmanPodDetailsSummary with the PodInfoUI object
+test('PodmanPodDetailsSummary renders with PodInfoUI object', async () => {
   // Render
   render(PodmanPodDetailsSummary, { pod: fakePod });
 

--- a/packages/renderer/src/lib/pod/PodmanPodDetailsSummary.svelte
+++ b/packages/renderer/src/lib/pod/PodmanPodDetailsSummary.svelte
@@ -8,67 +8,68 @@ import DetailsTable from '../details/DetailsTable.svelte';
 import DetailsTitle from '../details/DetailsTitle.svelte';
 import type { PodInfoUI } from './PodInfoUI';
 
-export let pod: PodInfoUI;
-let creationTime: Date = new Date(pod.created);
+export let pod: PodInfoUI | undefined;
+let creationTime: Date;
+if (pod) {
+  creationTime = new Date(pod.created);
+}
 </script>
 
-<div class="flex px-5 py-4 flex-col items-start h-full overflow-auto">
+<DetailsTable>
   {#if pod}
-    <DetailsTable>
-      <tr>
-        <DetailsTitle>Details</DetailsTitle>
-      </tr>
-      <tr>
-        <DetailsCell>Name</DetailsCell>
-        <DetailsCell>{pod.name}</DetailsCell>
-      </tr>
-      <tr>
-        <DetailsCell>ID</DetailsCell>
-        <DetailsCell>{pod.id}</DetailsCell>
-      </tr>
-      <tr>
-        <DetailsCell>Created</DetailsCell>
-        <DetailsCell>{creationTime}</DetailsCell>
-      </tr>
-      <tr>
-        <DetailsCell>Age</DetailsCell>
-        <DetailsCell>{pod.age}</DetailsCell>
-      </tr>
-      {#if pod}
+    <tr>
+      <DetailsTitle>Details</DetailsTitle>
+    </tr>
+    <tr>
+      <DetailsCell>Name</DetailsCell>
+      <DetailsCell>{pod.name}</DetailsCell>
+    </tr>
+    <tr>
+      <DetailsCell>ID</DetailsCell>
+      <DetailsCell>{pod.id}</DetailsCell>
+    </tr>
+    <tr>
+      <DetailsCell>Created</DetailsCell>
+      <DetailsCell>{creationTime}</DetailsCell>
+    </tr>
+    <tr>
+      <DetailsCell>Age</DetailsCell>
+      <DetailsCell>{pod.age}</DetailsCell>
+    </tr>
+    <tr>
+      <DetailsTitle>Pod Status</DetailsTitle>
+    </tr>
+    <tr>
+      <DetailsCell>Status</DetailsCell>
+      <DetailsCell>{pod.status.toLowerCase()}</DetailsCell>
+    </tr>
+    <tr>
+      <DetailsTitle>Containers</DetailsTitle>
+    </tr>
+    {#if pod.containers.length > 0}
+      {#each pod.containers as container}
         <tr>
-          <DetailsTitle>Pod Status</DetailsTitle>
+          <DetailsSubtitle>
+            <Link on:click="{() => router.goto(`/containers/${container.Id}/logs`)}">
+              {container.Names}
+            </Link>
+          </DetailsSubtitle>
+        </tr>
+        <tr>
+          <DetailsCell>ID</DetailsCell>
+          <DetailsCell>{container.Id}</DetailsCell>
         </tr>
         <tr>
           <DetailsCell>Status</DetailsCell>
-          <DetailsCell>{pod.status.toLowerCase()}</DetailsCell>
+          <DetailsCell>{container.Status}</DetailsCell>
         </tr>
-        {#if pod.containers.some(containerStatus => containerStatus.Status)}
-          <tr>
-            <DetailsTitle>Containers</DetailsTitle>
-          </tr>
-          {#each pod.containers as containerStatus}
-            {#if containerStatus.Status}
-              <tr>
-                <DetailsSubtitle>
-                  <Link on:click="{() => router.goto(`/containers/${containerStatus.Id}/logs`)}">
-                    {containerStatus.Names}
-                  </Link>
-                </DetailsSubtitle>
-              </tr>
-              <tr>
-                <DetailsCell>ID</DetailsCell>
-                <DetailsCell>{containerStatus.Id}</DetailsCell>
-              </tr>
-              <tr>
-                <DetailsCell>Status</DetailsCell>
-                <DetailsCell>{containerStatus.Status}</DetailsCell>
-              </tr>
-            {/if}
-          {/each}
-        {/if}
-      {/if}
-    </DetailsTable>
+      {/each}
+    {:else}
+      <tr>
+        <DetailsCell>No containers</DetailsCell>
+      </tr>
+    {/if}
   {:else}
     <p class="text-purple-500 font-medium">Loading ...</p>
   {/if}
-</div>
+</DetailsTable>

--- a/packages/renderer/src/lib/pod/PodmanPodDetailsSummary.svelte
+++ b/packages/renderer/src/lib/pod/PodmanPodDetailsSummary.svelte
@@ -1,0 +1,74 @@
+<script lang="ts">
+import { Link } from '@podman-desktop/ui-svelte';
+import { router } from 'tinro';
+
+import DetailsCell from '../details/DetailsCell.svelte';
+import DetailsSubtitle from '../details/DetailsSubtitle.svelte';
+import DetailsTable from '../details/DetailsTable.svelte';
+import DetailsTitle from '../details/DetailsTitle.svelte';
+import type { PodInfoUI } from './PodInfoUI';
+
+export let pod: PodInfoUI;
+let creationTime: Date = new Date(pod.created);
+</script>
+
+<div class="flex px-5 py-4 flex-col items-start h-full overflow-auto">
+  {#if pod}
+    <DetailsTable>
+      <tr>
+        <DetailsTitle>Details</DetailsTitle>
+      </tr>
+      <tr>
+        <DetailsCell>Name</DetailsCell>
+        <DetailsCell>{pod.name}</DetailsCell>
+      </tr>
+      <tr>
+        <DetailsCell>ID</DetailsCell>
+        <DetailsCell>{pod.id}</DetailsCell>
+      </tr>
+      <tr>
+        <DetailsCell>Created</DetailsCell>
+        <DetailsCell>{creationTime}</DetailsCell>
+      </tr>
+      <tr>
+        <DetailsCell>Age</DetailsCell>
+        <DetailsCell>{pod.age}</DetailsCell>
+      </tr>
+      {#if pod}
+        <tr>
+          <DetailsTitle>Pod Status</DetailsTitle>
+        </tr>
+        <tr>
+          <DetailsCell>Status</DetailsCell>
+          <DetailsCell>{pod.status.toLowerCase()}</DetailsCell>
+        </tr>
+        {#if pod.containers.some(containerStatus => containerStatus.Status)}
+          <tr>
+            <DetailsTitle>Containers</DetailsTitle>
+          </tr>
+          {#each pod.containers as containerStatus}
+            {#if containerStatus.Status}
+              <tr>
+                <DetailsSubtitle>
+                  <Link on:click="{() => router.goto(`/containers/${containerStatus.Id}/logs`)}">
+                    {containerStatus.Names}
+                  </Link>
+                </DetailsSubtitle>
+              </tr>
+              <tr>
+                <DetailsCell>ID</DetailsCell>
+                <DetailsCell>{containerStatus.Id}</DetailsCell>
+              </tr>
+              <tr>
+                <DetailsCell>Status</DetailsCell>
+                <DetailsCell>{containerStatus.Status}</DetailsCell>
+              </tr>
+            {/if}
+          {/each}
+        {/if}
+      {/if}
+    </DetailsTable>
+  {:else}
+    <p class="text-purple-500 font-medium">Loading ...</p>
+  {/if}
+</div>


### PR DESCRIPTION
### What does this PR do?

Changes the UI of the summary page of Podman pods to match other summary pages

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

![Screenshot from 2024-06-13 10-10-03](https://github.com/containers/podman-desktop/assets/66797193/96c557c5-b4ab-4196-98b3-adacf5f32700)

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop/issues/7559

### How to test this PR?

<!-- Please explain steps to verify the functionality, do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature

View the summary page of a Podman pod