### PR TITLE
chore: clean up table column

### DIFF
--- a/packages/main/src/plugin/color-registry.ts
+++ b/packages/main/src/plugin/color-registry.ts
@@ -716,12 +716,12 @@ export class ColorRegistry {
     // color for most text in tables
     this.registerColor(`${tab}body-text`, {
       dark: colorPalette.gray[700],
-      light: colorPalette.charcoal[300],
+      light: colorPalette.charcoal[100],
     });
     // color for the text in the main column of the table (generally Name)
     this.registerColor(`${tab}body-text-highlight`, {
       dark: colorPalette.gray[300],
-      light: colorPalette.charcoal[300],
+      light: colorPalette.charcoal[700],
     });
     // color for the text in second line of main column, in secondary color (generally IDs)
     this.registerColor(`${tab}body-text-sub-secondary`, {

--- a/packages/renderer/src/lib/ingresses-routes/IngressRouteColumnBackend.spec.ts
+++ b/packages/renderer/src/lib/ingresses-routes/IngressRouteColumnBackend.spec.ts
@@ -64,7 +64,7 @@ test('Expect simple column styling with single path ingress', async () => {
   const text = screen.getByText(backend);
   expect(text).toBeInTheDocument();
   expect(text).toHaveClass('text-sm');
-  expect(text).toHaveClass('text-[var(--pd-table-body-text-highlight)]');
+  expect(text).toHaveClass('text-[var(--pd-table-body-text)]');
 });
 
 test('Expect simple column styling with multiple paths ingress', async () => {

--- a/packages/renderer/src/lib/ingresses-routes/IngressRouteColumnBackend.spec.ts
+++ b/packages/renderer/src/lib/ingresses-routes/IngressRouteColumnBackend.spec.ts
@@ -110,11 +110,11 @@ test('Expect simple column styling with multiple paths ingress', async () => {
   const firstElement = screen.getByText(backends[0]);
   expect(firstElement).toBeInTheDocument();
   expect(firstElement).toHaveClass('text-sm');
-  expect(firstElement).toHaveClass('text-[var(--pd-table-body-text-highlight)]');
+  expect(firstElement).toHaveClass('text-[var(--pd-table-body-text)]');
   const secondElement = screen.getByText(backends[1]);
   expect(secondElement).toBeInTheDocument();
   expect(secondElement).toHaveClass('text-sm');
-  expect(secondElement).toHaveClass('text-[var(--pd-table-body-text-highlight)]');
+  expect(secondElement).toHaveClass('text-[var(--pd-table-body-text)]');
 });
 
 test('Expect simple column styling with route', async () => {
@@ -137,5 +137,5 @@ test('Expect simple column styling with route', async () => {
   const text = screen.getByText(backend);
   expect(text).toBeInTheDocument();
   expect(text).toHaveClass('text-sm');
-  expect(text).toHaveClass('text-[var(--pd-table-body-text-highlight)]');
+  expect(text).toHaveClass('text-[var(--pd-table-body-text)]');
 });

--- a/packages/renderer/src/lib/ingresses-routes/IngressRouteColumnBackend.svelte
+++ b/packages/renderer/src/lib/ingresses-routes/IngressRouteColumnBackend.svelte
@@ -9,5 +9,5 @@ const ingressRouteUtils = new IngressRouteUtils();
 </script>
 
 {#each ingressRouteUtils.getBackends(object) as backend}
-  <div class="text-sm text-[var(--pd-table-body-text-highlight)]">{backend}</div>
+  <div class="text-sm text-[var(--pd-table-body-text)]">{backend}</div>
 {/each}

--- a/packages/renderer/src/lib/ingresses-routes/IngressRouteColumnHostPath.spec.ts
+++ b/packages/renderer/src/lib/ingresses-routes/IngressRouteColumnHostPath.spec.ts
@@ -64,6 +64,11 @@ test('Expect simple column styling with single host/path ingress', async () => {
   const link = screen.getByLabelText(hostPath.label);
   expect(link).toBeInTheDocument();
   expect(link.textContent).toBe(hostPath.label);
+
+  const parent = link.parentElement;
+  expect(parent).toBeInTheDocument();
+  expect(parent).toHaveClass('text-sm');
+  expect(parent).toHaveClass('text-[var(--pd-table-body-text)]');
 });
 
 test('Expect simple column styling with multiple paths ingress', async () => {

--- a/packages/renderer/src/lib/ingresses-routes/IngressRouteColumnHostPath.svelte
+++ b/packages/renderer/src/lib/ingresses-routes/IngressRouteColumnHostPath.svelte
@@ -11,7 +11,7 @@ const ingressRouteUtils = new IngressRouteUtils();
 </script>
 
 {#each ingressRouteUtils.getHostPaths(object) as hostPath}
-  <div class="text-sm text-gray-500 overflow-hidden text-ellipsis">
+  <div class="text-sm text-[var(--pd-table-body-text)] overflow-hidden text-ellipsis">
     {#if hostPath.url}
       <Link
         aria-label="{hostPath.label}"

--- a/packages/renderer/src/lib/pod/PodColumnAge.spec.ts
+++ b/packages/renderer/src/lib/pod/PodColumnAge.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,5 +44,5 @@ test('Expect simple column styling', async () => {
   const text = screen.getByText(pod.age);
   expect(text).toBeInTheDocument();
   expect(text).toHaveClass('text-sm');
-  expect(text).toHaveClass('text-[var(--pd-table-body-text-highlight)]');
+  expect(text).toHaveClass('text-[var(--pd-table-body-text)]');
 });

--- a/packages/renderer/src/lib/pod/PodColumnAge.svelte
+++ b/packages/renderer/src/lib/pod/PodColumnAge.svelte
@@ -5,6 +5,6 @@ import type { PodInfoUI } from './PodInfoUI';
 export let object: PodInfoUI;
 </script>
 
-<div class="text-sm text-[var(--pd-table-body-text-highlight)]">
+<div class="text-sm text-[var(--pd-table-body-text)]">
   <StateChange state="{object.status}">{object.age}</StateChange>
 </div>


### PR DESCRIPTION
### What does this PR do?

Reviewed all tables for light mode. Overall everything was great, just found a few minor things to fix:
- Pod age & ingress/route backend - highlight is typically reserved for primary column, these should be normal text.
- Ingress host path - clean up hard-coded color.

### Screenshot / video of UI

Fairly minor/self-explanatory.

### What issues does this PR fix or reference?

Fixes #7348.

### How to test this PR?

Take a quick Look at every table in light mode for oddities.

- [x] Tests are covering the bug fix or the new feature