### PR TITLE
chore: light mode preference headers

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesRendering.spec.ts
@@ -83,6 +83,7 @@ test('Expect to see one record when filtering with unknown keyword', async () =>
   render(PreferencesRendering, { properties: records, key: 'key', searchValue: 'unknwon' });
   const noSettingsDiv = screen.getAllByText('No Settings Found');
   expect(noSettingsDiv.length > 0).toBe(true);
+  expect(noSettingsDiv[0].parentElement).toHaveClass('text-[var(--pd-content-header)]');
 });
 
 test('Expect extension title used a section name', async () => {

--- a/packages/renderer/src/lib/preferences/PreferencesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRendering.svelte
@@ -69,7 +69,7 @@ function updateSearchValue(event: any) {
 <Route path="/" breadcrumb="{key}">
   <SettingsPage title="Preferences">
     <SearchInput slot="header" title="preferences" class="mt-4" on:input="{e => updateSearchValue(e)}" />
-    <div class="flex flex-col space-y-5">
+    <div class="flex flex-col space-y-5 text-[var(--pd-content-header)]">
       {#if matchingRecords.size === 0}
         <div>No Settings Found</div>
       {:else}


### PR DESCRIPTION
### What does this PR do?

Must have been affected by another change b/c I remember this being ok before, but 'No settings found' and preference titles don't have color set for light mode.

### Screenshot / video of UI

Before:

<img width="154" alt="Screenshot 2024-06-13 at 1 13 05 PM" src="https://github.com/containers/podman-desktop/assets/19958075/85e138ab-0414-4412-8978-893f7ddb04cd">

After:

<img width="154" alt="Screenshot 2024-06-13 at 1 07 34 PM" src="https://github.com/containers/podman-desktop/assets/19958075/e450cf1a-2b0e-4142-a8e6-78f9690f70dd">

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Open Settings > Preferences in light mode.

- [x] Tests are covering the bug fix or the new feature