### PR TITLE
fix: handle hidden property for Button ui component

### DIFF
--- a/packages/ui/src/lib/button/Button.spec.ts
+++ b/packages/ui/src/lib/button/Button.spec.ts
@@ -191,3 +191,9 @@ test('Button no progress no icon do not have spinner', async () => {
   const svg = screen.queryByRole('img');
   expect(svg).toBeNull();
 });
+
+test('Button hidden should be hidden', async () => {
+  render(Button, { hidden: true });
+  const button = screen.queryByRole('button');
+  expect(button).not.toBeInTheDocument();
+});

--- a/packages/ui/src/lib/button/Button.svelte
+++ b/packages/ui/src/lib/button/Button.svelte
@@ -76,6 +76,7 @@ $: {
   class:hover:border-[var(--pd-button-tab-hover-border)]="{type === 'tab' && !selected}"
   class:text-[var(--pd-button-tab-text-selected)]="{type === 'tab' && selected}"
   class:text-[var(--pd-button-tab-text)]="{type === 'tab' && !selected}"
+  hidden="{$$props.hidden}"
   title="{title}"
   aria-label="{$$props['aria-label']}"
   on:click


### PR DESCRIPTION
### What does this PR do?
while looking at the bug https://github.com/containers/podman-desktop/issues/7252 it turns out that the minus and plus icons should not be visible at the same time as they're using the hidden property to hide/show it
but hidden property was not handled by the Button so this is why it was displayed

Fixing by adding the property hidden in the Button component

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/7252

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
