### PR TITLE
fix: click on the dock icon should display dashboard

### DIFF
--- a/packages/main/src/index.ts
+++ b/packages/main/src/index.ts
@@ -193,12 +193,20 @@ app.whenReady().then(
     // Required for macOS to start the app correctly (this is will be shown in the dock)
     // We use 'activate' within whenReady in order to gracefully start on macOS, see this link:
     // https://www.electronjs.org/docs/latest/tutorial/quick-start#open-a-window-if-none-are-open-macos
-    app.on('activate', () => {
+    app.on('activate', (_event, hasVisibleWindows) => {
       createNewWindow()
         .then(w => mainWindowDeferred.resolve(w))
         .catch((error: unknown) => {
           console.log('Error creating window', error);
         });
+
+      // try to restore the window if it's not visible
+      // for example user click on the dock icon
+      if (isMac() && !hasVisibleWindows) {
+        restoreWindow().catch((error: unknown) => {
+          console.error('Error restoring window', error);
+        });
+      }
     });
 
     // prefer ipv4 over ipv6


### PR DESCRIPTION
### What does this PR do?
if we were clicking on the icon with dashboard being closed, it was not bringing back the dashboard

track the event and add it back.

I don't know if there is such a case on Windows being possible so I added a isMac test
### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/7403

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
