### PR TITLE
Check only current kubecontext when there are more than 10 contexts in config

### DIFF
--- a/packages/main/src/plugin/kubernetes-context-state.spec.ts
+++ b/packages/main/src/plugin/kubernetes-context-state.spec.ts
@@ -408,6 +408,56 @@ describe('update', async () => {
     expect(dispatchCurrentContextResourceSpy).toHaveBeenCalledWith('deployments', Array(DEPLOYMENTS_NS1).fill({}));
   });
 
+  test('should check current context if contexts are > 10', async () => {
+    vi.mocked(makeInformer).mockImplementation(fakeMakeInformer);
+    client = new ContextsManager(apiSender);
+    const kubeConfig = new kubeclient.KubeConfig();
+    const config = {
+      clusters: [
+        {
+          name: 'cluster1',
+          server: 'server1',
+        },
+      ],
+      users: [
+        {
+          name: 'user1',
+        },
+      ],
+      contexts: [
+        {
+          name: `context1`,
+          cluster: 'cluster1',
+          user: 'user1',
+        },
+      ],
+      currentContext: 'context1',
+    };
+
+    for (let i = 2; i <= 11; i++) {
+      config.contexts.push({
+        name: `context${i}`,
+        cluster: 'cluster1',
+        user: 'user1',
+      });
+    }
+
+    kubeConfig.loadFromOptions(config);
+    await client.update(kubeConfig);
+    const expectedMap = new Map<string, ContextGeneralState>();
+    expectedMap.set('context1', {
+      reachable: false,
+      error: 'Error: connection error',
+      resources: {
+        pods: 0,
+        deployments: 0,
+      },
+    } as ContextGeneralState);
+    vi.advanceTimersToNextTimer();
+    vi.advanceTimersToNextTimer();
+    expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-contexts-general-state-update', expectedMap);
+  });
+
   test('should write logs when connection fails', async () => {
     vi.mocked(makeInformer).mockImplementation(fakeMakeInformer);
     client = new ContextsManager(apiSender);

--- a/packages/main/src/plugin/kubernetes-context-state.spec.ts
+++ b/packages/main/src/plugin/kubernetes-context-state.spec.ts
@@ -446,6 +446,7 @@ describe('update', async () => {
     await client.update(kubeConfig);
     const expectedMap = new Map<string, ContextGeneralState>();
     expectedMap.set('context1', {
+      checking: { state: 'waiting' },
       reachable: false,
       error: 'Error: connection error',
       resources: {

--- a/packages/main/src/plugin/kubernetes-context-state.ts
+++ b/packages/main/src/plugin/kubernetes-context-state.ts
@@ -60,6 +60,10 @@ import {
   dispatchTimeout,
 } from './kubernetes-context-state-constants.js';
 
+// If the number of contexts in the kubeconfig file is greater than this number,
+// only the connectivity to the current context will be checked
+const MAX_NON_CURRENT_CONTEXTS_TO_CHECK = 10;
+
 // ContextInternalState stores informers for a kube context
 type ContextInternalState = Map<ResourceName, Informer<KubernetesObject> & ObjectCache<KubernetesObject>>;
 
@@ -432,7 +436,7 @@ export class ContextsManager {
   }
 
   async update(kubeconfig: KubeConfig): Promise<void> {
-    const checkOnlyCurrentContext = kubeconfig.contexts.length > 10;
+    const checkOnlyCurrentContext = kubeconfig.contexts.length > MAX_NON_CURRENT_CONTEXTS_TO_CHECK;
 
     this.kubeConfig = kubeconfig;
     let contextChanged = false;


### PR DESCRIPTION
### What does this PR do?

Check only current kubecontext when there are more than 10 contexts in config

### Screenshot / video of UI

https://github.com/containers/podman-desktop/assets/9973512/262ff89a-a4d7-45ae-9cb2-247b80d8cb67

### What issues does this PR fix or reference?

Fixes #7409 

### How to test this PR?

Add contexts in your kubeconfig and check that only the current one displays ccontext information in the Kubernetes Contexts page

- [x] Tests are covering the bug fix or the new feature
