### PR TITLE
feat(context): create when svelte component

### DIFF
--- a/packages/renderer/src/lib/actions/ContributionActions.svelte
+++ b/packages/renderer/src/lib/actions/ContributionActions.svelte
@@ -8,6 +8,7 @@ import { removeNonSerializableProperties } from '/@/lib/actions/ActionUtils';
 import type { ContextUI } from '/@/lib/context/context';
 import { ContextKeyExpr } from '/@/lib/context/contextKey';
 import { transformObjectToContext } from '/@/lib/context/ContextUtils';
+import When from '/@/lib/context/When.svelte';
 import { context as storeContext } from '/@/stores/context';
 
 import type { Menu } from '../../../../main/src/plugin/menu-registry';
@@ -98,12 +99,13 @@ async function executeContribution(menu: Menu): Promise<void> {
 </script>
 
 {#each filteredContributions as menu}
-  <ListItemButtonIcon
-    title="{menu.title}"
-    onClick="{() => executeContribution(menu)}"
-    menu="{dropdownMenu}"
-    icon="{getIcon(menu)}"
-    detailed="{detailed}"
-    disabledWhen="{menu.disabled}"
-    contextUI="{globalContext}" />
+  <When expression="{menu.disabled}" contextUI="{globalContext}" let:enabled>
+    <ListItemButtonIcon
+      title="{menu.title}"
+      onClick="{() => executeContribution(menu)}"
+      menu="{dropdownMenu}"
+      icon="{getIcon(menu)}"
+      detailed="{detailed}"
+      enabled="{!enabled}" />
+  </When>
 {/each}

--- a/packages/renderer/src/lib/actions/ContributionActions.svelte
+++ b/packages/renderer/src/lib/actions/ContributionActions.svelte
@@ -99,13 +99,13 @@ async function executeContribution(menu: Menu): Promise<void> {
 </script>
 
 {#each filteredContributions as menu}
-  <When expression="{menu.disabled}" contextUI="{globalContext}" let:enabled>
+  <When expression="{menu.disabled}" contextUI="{globalContext}" let:result>
     <ListItemButtonIcon
       title="{menu.title}"
       onClick="{() => executeContribution(menu)}"
       menu="{dropdownMenu}"
       icon="{getIcon(menu)}"
       detailed="{detailed}"
-      enabled="{!enabled}" />
+      enabled="{!result}" />
   </When>
 {/each}

--- a/packages/renderer/src/lib/context/When.spec.ts
+++ b/packages/renderer/src/lib/context/When.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/renderer/src/lib/context/When.spec.ts
+++ b/packages/renderer/src/lib/context/When.spec.ts
@@ -17,7 +17,7 @@
  ***********************************************************************/
 
 import { render, screen } from '@testing-library/svelte';
-import { beforeEach,expect, test, vi } from 'vitest';
+import { beforeEach, expect, test, vi } from 'vitest';
 
 import { ContextUI } from '/@/lib/context/context';
 

--- a/packages/renderer/src/lib/context/When.spec.ts
+++ b/packages/renderer/src/lib/context/When.spec.ts
@@ -17,7 +17,7 @@
  ***********************************************************************/
 
 import { render, screen } from '@testing-library/svelte';
-import { beforeEach, expect, test, vi } from 'vitest';
+import { beforeEach, expect, test, vi, describe } from 'vitest';
 
 import { ContextUI } from '/@/lib/context/context';
 
@@ -27,12 +27,25 @@ beforeEach(() => {
   vi.resetAllMocks();
 });
 
-test('undefined expression should result in enabled', async () => {
-  render(WhenDebug);
+describe('fallback', () => {
+  test('undefined expression should result in not enabled', async () => {
+    render(WhenDebug);
 
-  const span = screen.getByRole('status');
-  await vi.waitFor(() => {
-    expect(span.classList).toContain('enabled');
+    const span = screen.getByRole('status');
+    await vi.waitFor(() => {
+      expect(span.classList).not.toContain('enabled');
+    });
+  });
+
+  test('undefined expression with true fallback should result in enabled', async () => {
+    render(WhenDebug, {
+      fallback: true,
+    });
+
+    const span = screen.getByRole('status');
+    await vi.waitFor(() => {
+      expect(span.classList).toContain('enabled');
+    });
   });
 });
 

--- a/packages/renderer/src/lib/context/When.spec.ts
+++ b/packages/renderer/src/lib/context/When.spec.ts
@@ -1,0 +1,89 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { render, screen } from '@testing-library/svelte';
+import { beforeEach,expect, test, vi } from 'vitest';
+
+import { ContextUI } from '/@/lib/context/context';
+
+import WhenDebug from './WhenDebug.svelte';
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+test('undefined expression should result in enabled', async () => {
+  render(WhenDebug);
+
+  const span = screen.getByRole('status');
+  await vi.waitFor(() => {
+    expect(span.classList).toContain('enabled');
+  });
+});
+
+test('false context expression should result in not enabled', async () => {
+  render(WhenDebug, {
+    expression: 'false',
+  });
+
+  const span = screen.getByRole('status');
+  await vi.waitFor(() => {
+    expect(span.classList).not.toContain('enabled');
+  });
+});
+
+test('true context expression should result in enabled', async () => {
+  render(WhenDebug, {
+    expression: 'true',
+  });
+
+  const span = screen.getByRole('status');
+  await vi.waitFor(() => {
+    expect(span.classList).toContain('enabled');
+  });
+});
+
+test('custom context with valid expression should be enabled', async () => {
+  const context = new ContextUI();
+  context.setValue('fruits', ['banana', 'pineapple']);
+
+  render(WhenDebug, {
+    expression: 'banana in fruits',
+    contextUI: context,
+  });
+
+  const span = screen.getByRole('status');
+  await vi.waitFor(() => {
+    expect(span.classList).toContain('enabled');
+  });
+});
+
+test('custom context with invalid expression should not be enabled', async () => {
+  const context = new ContextUI();
+  context.setValue('fruits', ['banana', 'pineapple']);
+
+  render(WhenDebug, {
+    expression: 'potato in fruits',
+    contextUI: context,
+  });
+
+  const span = screen.getByRole('status');
+  await vi.waitFor(() => {
+    expect(span.classList).not.toContain('enabled');
+  });
+});

--- a/packages/renderer/src/lib/context/When.spec.ts
+++ b/packages/renderer/src/lib/context/When.spec.ts
@@ -17,7 +17,7 @@
  ***********************************************************************/
 
 import { render, screen } from '@testing-library/svelte';
-import { beforeEach, expect, test, vi, describe } from 'vitest';
+import { beforeEach, describe,expect, test, vi } from 'vitest';
 
 import { ContextUI } from '/@/lib/context/context';
 

--- a/packages/renderer/src/lib/context/When.spec.ts
+++ b/packages/renderer/src/lib/context/When.spec.ts
@@ -17,7 +17,7 @@
  ***********************************************************************/
 
 import { render, screen } from '@testing-library/svelte';
-import { beforeEach, describe,expect, test, vi } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { ContextUI } from '/@/lib/context/context';
 

--- a/packages/renderer/src/lib/context/When.svelte
+++ b/packages/renderer/src/lib/context/When.svelte
@@ -1,0 +1,50 @@
+<script lang="ts">
+import { onDestroy } from 'svelte';
+import type { Unsubscriber } from 'svelte/motion';
+
+import { context as storeContext } from '/@/stores/context';
+
+import type { ContextUI } from '../context/context';
+import { ContextKeyExpr } from './contextKey';
+
+export let expression: string = '';
+export let contextUI: ContextUI | undefined = undefined;
+
+let globalContext: ContextUI;
+let contextsUnsubscribe: Unsubscriber;
+
+let enabled: boolean = true;
+
+$: {
+  if (expression !== '') {
+    if (contextUI) {
+      globalContext = contextUI;
+      computeEnabled();
+    } else {
+      if (contextsUnsubscribe) {
+        contextsUnsubscribe();
+      }
+      contextsUnsubscribe = storeContext.subscribe(value => {
+        globalContext = value;
+        computeEnabled();
+      });
+    }
+  }
+}
+
+function computeEnabled() {
+  // Deserialize the `when` property
+  const whenDeserialized = ContextKeyExpr.deserialize(expression);
+  // if there is some error when evaluating the when expression, we use the default value enabled = true
+  enabled = whenDeserialized?.evaluate(globalContext) ?? true;
+}
+
+onDestroy(() => {
+  // unsubscribe from the store
+  if (contextsUnsubscribe) {
+    contextsUnsubscribe();
+  }
+});
+</script>
+
+<slot enabled="{enabled}" />

--- a/packages/renderer/src/lib/context/WhenDebug.svelte
+++ b/packages/renderer/src/lib/context/WhenDebug.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+import type { ContextUI } from '/@/lib/context/context';
+import When from '/@/lib/context/When.svelte';
+
+export let expression: string | undefined = '';
+export let contextUI: ContextUI | undefined = undefined;
+</script>
+
+<When contextUI="{contextUI}" expression="{expression}" let:enabled>
+  <span role="status" class:enabled="{enabled}">{enabled}</span>
+</When>

--- a/packages/renderer/src/lib/context/WhenDebug.svelte
+++ b/packages/renderer/src/lib/context/WhenDebug.svelte
@@ -4,8 +4,9 @@ import When from '/@/lib/context/When.svelte';
 
 export let expression: string | undefined = '';
 export let contextUI: ContextUI | undefined = undefined;
+export let fallback: boolean = false;
 </script>
 
-<When contextUI="{contextUI}" expression="{expression}" let:enabled>
-  <span role="status" class:enabled="{enabled}">{enabled}</span>
+<When fallback="{fallback}" contextUI="{contextUI}" expression="{expression}" let:result>
+  <span role="status" class:enabled="{result}">{result}</span>
 </When>

--- a/packages/renderer/src/lib/ui/ListItemButtonIcon.spec.ts
+++ b/packages/renderer/src/lib/ui/ListItemButtonIcon.spec.ts
@@ -18,107 +18,11 @@
 
 import '@testing-library/jest-dom/vitest';
 
-import { faCircleCheck, faRocket } from '@fortawesome/free-solid-svg-icons';
+import { faCircleCheck } from '@fortawesome/free-solid-svg-icons';
 import { render, screen } from '@testing-library/svelte';
 import { expect, test } from 'vitest';
 
-import { context } from '/@/stores/context';
-
-import { ContextUI } from '../context/context';
 import ListItemButtonIcon from './ListItemButtonIcon.svelte';
-
-test('Expect the dropDownMenuItem to have classes that display a disabled object if the disabled when clause is evaluated to true', async () => {
-  const title = 'title';
-
-  const contextUI = new ContextUI();
-  contextUI.setValue('values', ['test']);
-  context.set(contextUI);
-
-  render(ListItemButtonIcon, {
-    title,
-    icon: faRocket,
-    disabledWhen: 'test in values',
-    menu: true,
-    contextUI: contextUI,
-  });
-
-  const listItemSpan = screen.getByTitle(title);
-  expect(listItemSpan).toBeInTheDocument();
-  expect(
-    listItemSpan.parentElement!.outerHTML.indexOf(
-      'text-[var(--pd-dropdown-disabled-item-text)] bg-[var(--pd-dropdown-disabled-item-bg)]',
-    ) > 0,
-  ).toBeTruthy();
-});
-
-test('Expect the dropDownMenuItem to have classes that display a disabled object if the disabled when clause is true', async () => {
-  const title = 'title';
-
-  render(ListItemButtonIcon, {
-    title,
-    icon: faRocket,
-    disabledWhen: 'true',
-    menu: true,
-  });
-
-  const listItemSpan = screen.getByTitle(title);
-  expect(listItemSpan).toBeInTheDocument();
-  expect(
-    listItemSpan.parentElement!.outerHTML.indexOf(
-      'text-[var(--pd-dropdown-disabled-item-text)] bg-[var(--pd-dropdown-disabled-item-bg)]',
-    ) > 0,
-  ).toBeTruthy();
-});
-
-test('Expect the dropDownMenuItem NOT to have classes that display a disabled object if the disabled when clause is evaluated to false', async () => {
-  const title = 'title';
-
-  const contextUI = new ContextUI();
-  contextUI.setValue('values', ['test']);
-  context.set(contextUI);
-
-  render(ListItemButtonIcon, {
-    title,
-    icon: faRocket,
-    disabledWhen: 'unknown in values',
-    menu: true,
-    contextUI: contextUI,
-  });
-
-  const listItemSpan = screen.getByTitle(title);
-  expect(listItemSpan).toBeInTheDocument();
-  expect(listItemSpan.parentElement!.outerHTML.indexOf('text-gray-900 bg-charcoal-800') === -1).toBeTruthy();
-});
-
-test('Expect the dropDownMenuItem NOT to have classes that display a disabled object if the disabled when clause is false', async () => {
-  const title = 'title';
-
-  render(ListItemButtonIcon, {
-    title,
-    icon: faRocket,
-    disabledWhen: 'false',
-    menu: true,
-  });
-
-  const listItemSpan = screen.getByTitle(title);
-  expect(listItemSpan).toBeInTheDocument();
-  expect(listItemSpan.parentElement!.outerHTML.indexOf('text-gray-900 bg-charcoal-800') === -1).toBeTruthy();
-});
-
-test('Expect the dropDownMenuItem NOT to have classes that display a disabled object if the disabled when clause is empty', async () => {
-  const title = 'title';
-
-  render(ListItemButtonIcon, {
-    title,
-    icon: faRocket,
-    disabledWhen: '',
-    menu: true,
-  });
-
-  const listItemSpan = screen.getByTitle(title);
-  expect(listItemSpan).toBeInTheDocument();
-  expect(listItemSpan.parentElement!.outerHTML.indexOf('text-gray-900 bg-charcoal-800') === -1).toBeTruthy();
-});
 
 test('With custom font icon', async () => {
   const title = 'Dummy item';

--- a/packages/renderer/src/lib/ui/ListItemButtonIcon.svelte
+++ b/packages/renderer/src/lib/ui/ListItemButtonIcon.svelte
@@ -1,20 +1,13 @@
 <script lang="ts">
 import type { IconDefinition } from '@fortawesome/fontawesome-common-types';
 import { DropdownMenu, isFontAwesomeIcon } from '@podman-desktop/ui-svelte';
-import { onDestroy, onMount } from 'svelte';
-import type { Unsubscriber } from 'svelte/motion';
+import { onMount } from 'svelte';
 import Fa from 'svelte-fa';
-
-import { context as storeContext } from '/@/stores/context';
-
-import type { ContextUI } from '../context/context';
-import { ContextKeyExpr } from '../context/contextKey';
 
 export let title: string;
 export let icon: IconDefinition | string;
 export let fontAwesomeIcon: IconDefinition | undefined = undefined;
 export let hidden = false;
-export let disabledWhen = '';
 export let enabled: boolean = true;
 export let onClick: () => void = () => {};
 export let menu = false;
@@ -23,51 +16,14 @@ export let inProgress = false;
 export let iconOffset = '';
 export let tooltip: string = '';
 
-export let contextUI: ContextUI | undefined = undefined;
-
 let positionLeftClass = 'left-1';
 if (detailed) positionLeftClass = 'left-2';
 let positionTopClass = 'top-1';
 if (detailed) positionTopClass = '[0.2rem]';
 
-let globalContext: ContextUI;
-let contextsUnsubscribe: Unsubscriber;
-
-$: {
-  if (disabledWhen !== '') {
-    if (contextUI) {
-      globalContext = contextUI;
-      computeEnabled();
-    } else {
-      if (contextsUnsubscribe) {
-        contextsUnsubscribe();
-      }
-      contextsUnsubscribe = storeContext.subscribe(value => {
-        globalContext = value;
-        computeEnabled();
-      });
-    }
-  }
-}
-
-function computeEnabled() {
-  // Deserialize the `when` property
-  const whenDeserialized = ContextKeyExpr.deserialize(disabledWhen);
-  // if there is some error when evaluating the when expression, we use the default value enabled = true
-  const disabled = whenDeserialized?.evaluate(globalContext) ?? false;
-  enabled = !disabled;
-}
-
 onMount(() => {
   if (isFontAwesomeIcon(icon)) {
     fontAwesomeIcon = icon;
-  }
-});
-
-onDestroy(() => {
-  // unsubscribe from the store
-  if (contextsUnsubscribe) {
-    contextsUnsubscribe();
   }
 });
 


### PR DESCRIPTION
### What does this PR do?

Creating a `<When>` svelte component taking a `when` expression and contextUI object. It will be responsible of providing the result of the expression evaluation based on context provided and global context.

Example usage

```svelte
const context = new ContextUI();
context.setValue('fruits', ['banana', 'pineapple']);
...
<When contextUI={context} expression="banana in fruits" let:result>
     {#if result} .... {/if}
</When>
```

It not directly possible to test slot[^1], therefore I created a wrapper around the component to be able to read the result, and test it properly

[^1]: https://github.com/testing-library/svelte-testing-library/issues/48

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Related to https://github.com/containers/podman-desktop/issues/6898

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature

**Manually**

Change the kind push to kubernetes to `true` 

https://github.com/containers/podman-desktop/blob/e41ffd97589ecfa070653a58ebe4503d2f573f5f/extensions/kind/package.json#L74

And you should get the following result in the image page

![image](https://github.com/containers/podman-desktop/assets/42176370/015d6660-3ccd-440c-b99c-b29321aaf43b)

