### PR TITLE
fix: support multiple scopes on create/edit configurations

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.spec.ts
@@ -399,3 +399,66 @@ test(`Expect create with unchecked and checked checkboxes`, async () => {
     undefined,
   );
 });
+
+test(`Expect create with unchecked and checked checkboxes having multipl scopes`, async () => {
+  let providedKeyLogger: ((key: symbol, eventName: LoggerEventName, args: string[]) => void) | undefined;
+  const taskId = 4;
+  const callback = mockCallback(async keyLogger => {
+    providedKeyLogger = keyLogger;
+  });
+
+  const booleanProperties: IConfigurationPropertyRecordedSchema[] = [
+    {
+      title: 'unchecked checkbox',
+      parentId: '',
+      scope: ['ContainerProviderConnectionFactory', 'DEFAULT'],
+      id: 'test.unchecked',
+      type: 'boolean',
+      description: 'should be unchecked / false',
+    },
+    {
+      title: 'checked checkbox',
+      parentId: '',
+      scope: ['ContainerProviderConnectionFactory', 'DEFAULT'],
+      id: 'test.checked',
+      type: 'boolean',
+      default: true,
+      description: 'should be checked / true',
+    },
+    {
+      title: 'FactoryProperty',
+      parentId: '',
+      scope: ['ContainerProviderConnectionFactory', 'DEFAULT'],
+      id: 'test.factoryProperty',
+      type: 'number',
+      description: 'test.factoryProperty',
+    },
+  ];
+
+  // eslint-disable-next-line @typescript-eslint/await-thenable
+  render(PreferencesConnectionCreationOrEditRendering, {
+    properties: booleanProperties,
+    providerInfo,
+    connectionInfo: undefined,
+    propertyScope,
+    callback,
+    pageIsLoading: false,
+    taskId,
+  });
+  await vi.waitUntil(() => screen.queryByRole('textbox', { name: 'test.factoryProperty' }));
+  await vi.waitUntil(() => screen.getByRole('checkbox', { name: 'should be unchecked / false' }));
+  await vi.waitUntil(() => screen.getByRole('checkbox', { name: 'should be checked / true' }));
+
+  const createButton = screen.getByRole('button', { name: 'Create' });
+  expect(createButton).toBeInTheDocument();
+  // click on the button
+  await fireEvent.click(createButton);
+
+  expect(callback).toBeCalledWith(
+    'test',
+    { 'test.factoryProperty': '0', 'test.checked': true, 'test.unchecked': false },
+    expect.anything(),
+    eventCollect,
+    undefined,
+  );
+});

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.spec.ts
@@ -400,7 +400,7 @@ test(`Expect create with unchecked and checked checkboxes`, async () => {
   );
 });
 
-test(`Expect create with unchecked and checked checkboxes having multipl scopes`, async () => {
+test(`Expect create with unchecked and checked checkboxes having multiple scopes`, async () => {
   let providedKeyLogger: ((key: symbol, eventName: LoggerEventName, args: string[]) => void) | undefined;
   const taskId = 4;
   const callback = mockCallback(async keyLogger => {

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.svelte
@@ -126,7 +126,9 @@ onMount(async () => {
   }
 
   configurationKeys = properties
-    .filter(property => property.scope === propertyScope)
+    .filter(property =>
+      Array.isArray(property.scope) ? property.scope.find(s => s === propertyScope) : property.scope === propertyScope,
+    )
     .filter(property => property.id?.startsWith(providerInfo.id))
     .filter(property => isPropertyValidInContext(property.when, globalContext))
     .map(property => {
@@ -250,7 +252,9 @@ async function getConfigurationValue(configurationKey: IConfigurationPropertyRec
       internalSetConfigurationValue(configurationKey.id, false, value as string);
       return value;
     }
-    return getInitialValue(configurationKey);
+    const initialValue = await getInitialValue(configurationKey);
+    internalSetConfigurationValue(configurationKey.id, false, initialValue as string);
+    return initialValue;
   }
 }
 


### PR DESCRIPTION
### What does this PR do?

This PR fixes a couple of issues related to the configuration values I discovered while working on the crc extension.

The first is that we just checked that the property scope was equal to a value `property.scope === propertyScope` but scope can also be an array. In that case we should check if the array contains that scope.

The second is that the inner map we use to retrieve a value (used for memory/cpus/disksize) was only filled when working with a connection. (e.g. podman-machine -> cpus 2, memory 3, disk 10) . The problem is that on crc the cpus,memory and disksize are not bound to any connection bc crc does not create new machines. There is just one VM per time. So the values associated to these properties are generic.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

N/A

### How to test this PR?



- [ ] Tests are covering the bug fix or the new feature
