### PR TITLE
Adds feedback when Podman Desktop is checking Kube context connectivity

### DIFF
--- a/packages/main/src/plugin/kubernetes-context-state.spec.ts
+++ b/packages/main/src/plugin/kubernetes-context-state.spec.ts
@@ -23,7 +23,7 @@ import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vi
 
 import type { ApiSenderType } from './api.js';
 import type { KubeContext } from './kubernetes-context.js';
-import type { ContextGeneralState, ResourceName } from './kubernetes-context-state.js';
+import type { CheckingState, ContextGeneralState, ResourceName } from './kubernetes-context-state.js';
 import { ContextsManager, ContextsStates } from './kubernetes-context-state.js';
 
 interface InformerEvent {
@@ -202,6 +202,7 @@ describe('update', async () => {
     const dispatchGeneralStateSpy = vi.spyOn(client, 'dispatchGeneralState');
     const dispatchCurrentContextGeneralStateSpy = vi.spyOn(client, 'dispatchCurrentContextGeneralState');
     const dispatchCurrentContextResourceSpy = vi.spyOn(client, 'dispatchCurrentContextResource');
+    const dispatchCheckingStateSpy = vi.spyOn(client, 'dispatchCheckingState');
     const kubeConfig = new kubeclient.KubeConfig();
     const config = {
       clusters: [
@@ -311,6 +312,13 @@ describe('update', async () => {
     });
     expect(dispatchCurrentContextResourceSpy).toHaveBeenCalledWith('pods', Array(PODS_NS1).fill({}));
     expect(dispatchCurrentContextResourceSpy).toHaveBeenCalledWith('deployments', Array(DEPLOYMENTS_NS1).fill({}));
+
+    const expectedCheckMap = new Map<string, CheckingState>();
+    expectedCheckMap.set('context1', { state: 'waiting' });
+    expectedCheckMap.set('context2', { state: 'waiting' });
+    expectedCheckMap.set('context2-1', { state: 'waiting' });
+    expectedCheckMap.set('context2-2', { state: 'waiting' });
+    expect(dispatchCheckingStateSpy).toHaveBeenCalledWith(expectedCheckMap);
 
     // switching to unreachable context
     kubeConfig.loadFromOptions({

--- a/packages/main/src/plugin/kubernetes-context-state.spec.ts
+++ b/packages/main/src/plugin/kubernetes-context-state.spec.ts
@@ -199,6 +199,9 @@ describe('update', async () => {
   test('should send info of resources in all reachable contexts and nothing in non reachable', async () => {
     vi.mocked(makeInformer).mockImplementation(fakeMakeInformer);
     client = new ContextsManager(apiSender);
+    const dispatchGeneralStateSpy = vi.spyOn(client, 'dispatchGeneralState');
+    const dispatchCurrentContextGeneralStateSpy = vi.spyOn(client, 'dispatchCurrentContextGeneralState');
+    const dispatchCurrentContextResourceSpy = vi.spyOn(client, 'dispatchCurrentContextResource');
     const kubeConfig = new kubeclient.KubeConfig();
     const config = {
       clusters: [
@@ -249,6 +252,9 @@ describe('update', async () => {
     await client.update(kubeConfig);
     let expectedMap = new Map<string, ContextGeneralState>();
     expectedMap.set('context1', {
+      checking: {
+        state: 'waiting',
+      },
       reachable: false,
       error: 'Error: connection error',
       resources: {
@@ -257,6 +263,9 @@ describe('update', async () => {
       },
     } as ContextGeneralState);
     expectedMap.set('context2', {
+      checking: {
+        state: 'waiting',
+      },
       reachable: true,
       error: undefined,
       resources: {
@@ -265,6 +274,9 @@ describe('update', async () => {
       },
     } as ContextGeneralState);
     expectedMap.set('context2-1', {
+      checking: {
+        state: 'waiting',
+      },
       reachable: true,
       error: undefined,
       resources: {
@@ -273,6 +285,9 @@ describe('update', async () => {
       },
     } as ContextGeneralState);
     expectedMap.set('context2-2', {
+      checking: {
+        state: 'waiting',
+      },
       reachable: true,
       error: undefined,
       resources: {
@@ -282,8 +297,11 @@ describe('update', async () => {
     } as ContextGeneralState);
     vi.advanceTimersToNextTimer();
     vi.advanceTimersToNextTimer();
-    expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-contexts-general-state-update', expectedMap);
-    expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-current-context-general-state-update', {
+    expect(dispatchGeneralStateSpy).toHaveBeenCalledWith(expectedMap);
+    expect(dispatchCurrentContextGeneralStateSpy).toHaveBeenCalledWith({
+      checking: {
+        state: 'waiting',
+      },
       reachable: true,
       error: undefined,
       resources: {
@@ -291,11 +309,8 @@ describe('update', async () => {
         deployments: DEPLOYMENTS_NS1,
       },
     });
-    expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-current-context-pods-update', Array(PODS_NS1).fill({}));
-    expect(apiSenderSendMock).toHaveBeenCalledWith(
-      'kubernetes-current-context-deployments-update',
-      Array(DEPLOYMENTS_NS1).fill({}),
-    );
+    expect(dispatchCurrentContextResourceSpy).toHaveBeenCalledWith('pods', Array(PODS_NS1).fill({}));
+    expect(dispatchCurrentContextResourceSpy).toHaveBeenCalledWith('deployments', Array(DEPLOYMENTS_NS1).fill({}));
 
     // switching to unreachable context
     kubeConfig.loadFromOptions({
@@ -305,13 +320,18 @@ describe('update', async () => {
       currentContext: 'context1',
     });
 
-    apiSenderSendMock.mockReset();
+    dispatchGeneralStateSpy.mockReset();
+    dispatchCurrentContextGeneralStateSpy.mockReset();
+    dispatchCurrentContextResourceSpy.mockReset();
     await client.update(kubeConfig);
 
     vi.advanceTimersToNextTimer();
     vi.advanceTimersToNextTimer();
-    expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-contexts-general-state-update', expectedMap);
-    expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-current-context-general-state-update', {
+    expect(dispatchGeneralStateSpy).toHaveBeenCalledWith(expectedMap);
+    expect(dispatchCurrentContextGeneralStateSpy).toHaveBeenCalledWith({
+      checking: {
+        state: 'waiting',
+      },
       reachable: false,
       error: 'Error: connection error',
       resources: {
@@ -320,8 +340,8 @@ describe('update', async () => {
       },
     });
     // no pods/deployment are sent, as the context is not reachable
-    expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-current-context-pods-update', []);
-    expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-current-context-deployments-update', []);
+    expect(dispatchCurrentContextResourceSpy).toHaveBeenCalledWith('pods', []);
+    expect(dispatchCurrentContextResourceSpy).toHaveBeenCalledWith('deployments', []);
 
     // => removing context, should remove context from sent info
     kubeConfig.loadFromOptions({
@@ -331,10 +351,13 @@ describe('update', async () => {
       currentContext: 'context2-1',
     });
 
-    apiSenderSendMock.mockReset();
+    dispatchGeneralStateSpy.mockReset();
+    dispatchCurrentContextGeneralStateSpy.mockReset();
+    dispatchCurrentContextResourceSpy.mockReset();
     await client.update(kubeConfig);
     expectedMap = new Map<string, ContextGeneralState>();
     expectedMap.set('context1', {
+      checking: { state: 'waiting' },
       reachable: false,
       error: 'Error: connection error',
       resources: {
@@ -343,6 +366,7 @@ describe('update', async () => {
       },
     } as ContextGeneralState);
     expectedMap.set('context2', {
+      checking: { state: 'waiting' },
       reachable: true,
       error: undefined,
       resources: {
@@ -351,6 +375,7 @@ describe('update', async () => {
       },
     } as ContextGeneralState);
     expectedMap.set('context2-1', {
+      checking: { state: 'waiting' },
       reachable: true,
       error: undefined,
       resources: {
@@ -361,8 +386,9 @@ describe('update', async () => {
 
     vi.advanceTimersToNextTimer();
     vi.advanceTimersToNextTimer();
-    expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-contexts-general-state-update', expectedMap);
-    expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-current-context-general-state-update', {
+    expect(dispatchGeneralStateSpy).toHaveBeenCalledWith(expectedMap);
+    expect(dispatchCurrentContextGeneralStateSpy).toHaveBeenCalledWith({
+      checking: { state: 'waiting' },
       reachable: true,
       error: undefined,
       resources: {
@@ -370,11 +396,8 @@ describe('update', async () => {
         deployments: DEPLOYMENTS_NS1,
       },
     });
-    expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-current-context-pods-update', Array(PODS_NS1).fill({}));
-    expect(apiSenderSendMock).toHaveBeenCalledWith(
-      'kubernetes-current-context-deployments-update',
-      Array(DEPLOYMENTS_NS1).fill({}),
-    );
+    expect(dispatchCurrentContextResourceSpy).toHaveBeenCalledWith('pods', Array(PODS_NS1).fill({}));
+    expect(dispatchCurrentContextResourceSpy).toHaveBeenCalledWith('deployments', Array(DEPLOYMENTS_NS1).fill({}));
   });
 
   test('should write logs when connection fails', async () => {
@@ -441,6 +464,9 @@ describe('update', async () => {
       },
     );
     client = new ContextsManager(apiSender);
+    const dispatchGeneralStateSpy = vi.spyOn(client, 'dispatchGeneralState');
+    const dispatchCurrentContextGeneralStateSpy = vi.spyOn(client, 'dispatchCurrentContextGeneralState');
+    const dispatchCurrentContextResourceSpy = vi.spyOn(client, 'dispatchCurrentContextResource');
     const kubeConfig = new kubeclient.KubeConfig();
     const config = {
       clusters: [
@@ -471,6 +497,7 @@ describe('update', async () => {
     vi.advanceTimersToNextTimer(); // reachable now
     const expectedMap = new Map<string, ContextGeneralState>();
     expectedMap.set('context1', {
+      checking: { state: 'waiting' },
       reachable: true,
       error: undefined,
       resources: {
@@ -478,8 +505,9 @@ describe('update', async () => {
         deployments: 0,
       },
     });
-    expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-contexts-general-state-update', expectedMap);
-    expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-current-context-general-state-update', {
+    expect(dispatchGeneralStateSpy).toHaveBeenCalledWith(expectedMap);
+    expect(dispatchCurrentContextGeneralStateSpy).toHaveBeenCalledWith({
+      checking: { state: 'waiting' },
       reachable: true,
       error: undefined,
       resources: {
@@ -487,13 +515,13 @@ describe('update', async () => {
         deployments: 0,
       },
     });
-    expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-current-context-pods-update', []);
-    expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-current-context-deployments-update', []);
+    expect(dispatchCurrentContextResourceSpy).toHaveBeenCalledWith('pods', []);
+    expect(dispatchCurrentContextResourceSpy).toHaveBeenCalledWith('deployments', []);
 
-    apiSenderSendMock.mockReset();
     vi.advanceTimersToNextTimer(); // add event
     vi.advanceTimersToNextTimer(); // dispatches
     expectedMap.set('context1', {
+      checking: { state: 'waiting' },
       reachable: true,
       error: undefined,
       resources: {
@@ -501,9 +529,9 @@ describe('update', async () => {
         deployments: 1,
       },
     });
-    expect(apiSenderSendMock).toHaveBeenCalledTimes(3);
-    expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-contexts-general-state-update', expectedMap);
-    expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-current-context-general-state-update', {
+    expect(dispatchGeneralStateSpy).toHaveBeenCalledWith(expectedMap);
+    expect(dispatchCurrentContextGeneralStateSpy).toHaveBeenCalledWith({
+      checking: { state: 'waiting' },
       reachable: true,
       error: undefined,
       resources: {
@@ -511,9 +539,7 @@ describe('update', async () => {
         deployments: 1,
       },
     });
-    expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-current-context-deployments-update', [
-      { metadata: { name: 'deploy1' } },
-    ]);
+    expect(dispatchCurrentContextResourceSpy).toHaveBeenCalledWith('deployments', [{ metadata: { name: 'deploy1' } }]);
   });
 
   test('should delete deployment when deleted from context', async () => {
@@ -557,6 +583,9 @@ describe('update', async () => {
       },
     );
     client = new ContextsManager(apiSender);
+    const dispatchGeneralStateSpy = vi.spyOn(client, 'dispatchGeneralState');
+    const dispatchCurrentContextGeneralStateSpy = vi.spyOn(client, 'dispatchCurrentContextGeneralState');
+    const dispatchCurrentContextResourceSpy = vi.spyOn(client, 'dispatchCurrentContextResource');
     const kubeConfig = new kubeclient.KubeConfig();
     const config = {
       clusters: [
@@ -587,6 +616,7 @@ describe('update', async () => {
     vi.advanceTimersToNextTimer(); // delete
     const expectedMap = new Map<string, ContextGeneralState>();
     expectedMap.set('context1', {
+      checking: { state: 'waiting' },
       reachable: true,
       error: undefined,
       resources: {
@@ -594,8 +624,9 @@ describe('update', async () => {
         deployments: 2,
       },
     });
-    expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-contexts-general-state-update', expectedMap);
-    expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-current-context-general-state-update', {
+    expect(dispatchGeneralStateSpy).toHaveBeenCalledWith(expectedMap);
+    expect(dispatchCurrentContextGeneralStateSpy).toHaveBeenCalledWith({
+      checking: { state: 'waiting' },
       reachable: true,
       error: undefined,
       resources: {
@@ -603,17 +634,17 @@ describe('update', async () => {
         deployments: 2,
       },
     });
-    expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-current-context-pods-update', []);
-    expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-current-context-deployments-update', [
+    expect(dispatchCurrentContextResourceSpy).toHaveBeenCalledWith('pods', []);
+    expect(dispatchCurrentContextResourceSpy).toHaveBeenCalledWith('deployments', [
       { metadata: { uid: 'deploy1' } },
       { metadata: { uid: 'deploy2' } },
     ]);
 
-    apiSenderSendMock.mockReset();
     vi.advanceTimersToNextTimer(); // 'delete' event
     vi.advanceTimersToNextTimer(); // dispatches
 
     expectedMap.set('context1', {
+      checking: { state: 'waiting' },
       reachable: true,
       error: undefined,
       resources: {
@@ -621,9 +652,9 @@ describe('update', async () => {
         deployments: 1,
       },
     });
-    expect(apiSenderSendMock).toHaveBeenCalledTimes(3);
-    expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-contexts-general-state-update', expectedMap);
-    expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-current-context-general-state-update', {
+    expect(dispatchGeneralStateSpy).toHaveBeenCalledWith(expectedMap);
+    expect(dispatchCurrentContextGeneralStateSpy).toHaveBeenCalledWith({
+      checking: { state: 'waiting' },
       reachable: true,
       error: undefined,
       resources: {
@@ -631,9 +662,7 @@ describe('update', async () => {
         deployments: 1,
       },
     });
-    expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-current-context-deployments-update', [
-      { metadata: { uid: 'deploy2' } },
-    ]);
+    expect(dispatchCurrentContextResourceSpy).toHaveBeenCalledWith('deployments', [{ metadata: { uid: 'deploy2' } }]);
   });
 
   test('should update deployment when updated on context', async () => {
@@ -677,6 +706,9 @@ describe('update', async () => {
       },
     );
     client = new ContextsManager(apiSender);
+    const dispatchGeneralStateSpy = vi.spyOn(client, 'dispatchGeneralState');
+    const dispatchCurrentContextGeneralStateSpy = vi.spyOn(client, 'dispatchCurrentContextGeneralState');
+    const dispatchCurrentContextResourceSpy = vi.spyOn(client, 'dispatchCurrentContextResource');
     const kubeConfig = new kubeclient.KubeConfig();
     const config = {
       clusters: [
@@ -707,6 +739,7 @@ describe('update', async () => {
     vi.advanceTimersToNextTimer(); // update
     const expectedMap = new Map<string, ContextGeneralState>();
     expectedMap.set('context1', {
+      checking: { state: 'waiting' },
       reachable: true,
       error: undefined,
       resources: {
@@ -714,8 +747,9 @@ describe('update', async () => {
         deployments: 2,
       },
     });
-    expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-contexts-general-state-update', expectedMap);
-    expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-current-context-general-state-update', {
+    expect(dispatchGeneralStateSpy).toHaveBeenCalledWith(expectedMap);
+    expect(dispatchCurrentContextGeneralStateSpy).toHaveBeenCalledWith({
+      checking: { state: 'waiting' },
       reachable: true,
       error: undefined,
       resources: {
@@ -723,16 +757,19 @@ describe('update', async () => {
         deployments: 2,
       },
     });
-    expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-current-context-pods-update', []);
-    expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-current-context-deployments-update', [
+    expect(dispatchCurrentContextResourceSpy).toHaveBeenCalledWith('pods', []);
+    expect(dispatchCurrentContextResourceSpy).toHaveBeenCalledWith('deployments', [
       { metadata: { uid: 'deploy1', name: 'name1' } },
       { metadata: { uid: 'deploy2', name: 'name2' } },
     ]);
 
-    apiSenderSendMock.mockReset();
+    dispatchGeneralStateSpy.mockReset();
+    dispatchCurrentContextGeneralStateSpy.mockReset();
+    dispatchCurrentContextResourceSpy.mockReset();
     vi.advanceTimersToNextTimer(); // update event
     vi.advanceTimersToNextTimer(); // dispatches
     expectedMap.set('context1', {
+      checking: { state: 'waiting' },
       reachable: true,
       error: undefined,
       resources: {
@@ -740,9 +777,9 @@ describe('update', async () => {
         deployments: 2,
       },
     });
-    expect(apiSenderSendMock).toHaveBeenCalledTimes(3);
-    expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-contexts-general-state-update', expectedMap);
-    expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-current-context-general-state-update', {
+    expect(dispatchGeneralStateSpy).toHaveBeenCalledWith(expectedMap);
+    expect(dispatchCurrentContextGeneralStateSpy).toHaveBeenCalledWith({
+      checking: { state: 'waiting' },
       reachable: true,
       error: undefined,
       resources: {
@@ -750,7 +787,7 @@ describe('update', async () => {
         deployments: 2,
       },
     });
-    expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-current-context-deployments-update', [
+    expect(dispatchCurrentContextResourceSpy).toHaveBeenCalledWith('deployments', [
       { metadata: { uid: 'deploy2', name: 'name2' } },
       { metadata: { uid: 'deploy1', name: 'name1new' } },
     ]);
@@ -812,11 +849,15 @@ describe('update', async () => {
     };
     kubeConfig.loadFromOptions(config);
     await client.update(kubeConfig);
+    const dispatchGeneralStateSpy = vi.spyOn(client, 'dispatchGeneralState');
+    const dispatchCurrentContextGeneralStateSpy = vi.spyOn(client, 'dispatchCurrentContextGeneralState');
+    const dispatchCurrentContextResourceSpy = vi.spyOn(client, 'dispatchCurrentContextResource');
     vi.advanceTimersToNextTimer(); // add deployments
     vi.advanceTimersToNextTimer(); // dispatches
     vi.advanceTimersToNextTimer(); // reachable now
     const expectedMap = new Map<string, ContextGeneralState>();
     expectedMap.set('context1', {
+      checking: { state: 'waiting' },
       reachable: true,
       error: undefined,
       resources: {
@@ -824,8 +865,9 @@ describe('update', async () => {
         deployments: 2,
       },
     });
-    expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-contexts-general-state-update', expectedMap);
-    expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-current-context-general-state-update', {
+    expect(dispatchGeneralStateSpy).toHaveBeenCalledWith(expectedMap);
+    expect(dispatchCurrentContextGeneralStateSpy).toHaveBeenCalledWith({
+      checking: { state: 'waiting' },
       reachable: true,
       error: undefined,
       resources: {
@@ -833,15 +875,15 @@ describe('update', async () => {
         deployments: 2,
       },
     });
-    expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-current-context-pods-update', []);
-    expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-current-context-deployments-update', [{}, {}]);
+    expect(dispatchCurrentContextResourceSpy).toHaveBeenCalledWith('pods', []);
+    expect(dispatchCurrentContextResourceSpy).toHaveBeenCalledWith('deployments', [{}, {}]);
 
-    apiSenderSendMock.mockReset();
     vi.advanceTimersToNextTimer(); // error event
     vi.advanceTimersToNextTimer(); // dispatches
     vi.advanceTimersToNextTimer(); // reachable now
     // This time, we do not check the number of calls, as the connection will be retried, and calls will be done after each retry
     expectedMap.set('context1', {
+      checking: { state: 'waiting' },
       reachable: false,
       error: 'connection error',
       resources: {
@@ -849,8 +891,9 @@ describe('update', async () => {
         deployments: 0,
       },
     });
-    expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-contexts-general-state-update', expectedMap);
-    expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-current-context-general-state-update', {
+    expect(dispatchGeneralStateSpy).toHaveBeenCalledWith(expectedMap);
+    expect(dispatchCurrentContextGeneralStateSpy).toHaveBeenCalledWith({
+      checking: { state: 'waiting' },
       reachable: false,
       error: 'connection error',
       resources: {
@@ -858,8 +901,8 @@ describe('update', async () => {
         deployments: 0,
       },
     });
-    expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-current-context-pods-update', []);
-    expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-current-context-deployments-update', []);
+    expect(dispatchCurrentContextResourceSpy).toHaveBeenCalledWith('pods', []);
+    expect(dispatchCurrentContextResourceSpy).toHaveBeenCalledWith('deployments', []);
   });
 
   const secondaryInformers = [
@@ -914,6 +957,9 @@ describe('update', async () => {
         },
       );
       client = new ContextsManager(apiSender);
+      const dispatchGeneralStateSpy = vi.spyOn(client, 'dispatchGeneralState');
+      const dispatchCurrentContextGeneralStateSpy = vi.spyOn(client, 'dispatchCurrentContextGeneralState');
+      const dispatchCurrentContextResourceSpy = vi.spyOn(client, 'dispatchCurrentContextResource');
       const kubeConfig = new kubeclient.KubeConfig();
       const config = {
         clusters: [
@@ -947,6 +993,7 @@ describe('update', async () => {
       vi.advanceTimersToNextTimer();
       const expectedMap = new Map<string, ContextGeneralState>();
       expectedMap.set('context1', {
+        checking: { state: 'waiting' },
         reachable: true,
         error: undefined,
         resources: {
@@ -954,15 +1001,16 @@ describe('update', async () => {
           deployments: 0,
         },
       });
-      expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-contexts-general-state-update', expectedMap);
-      expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-current-context-general-state-update', {
+      expect(dispatchGeneralStateSpy).toHaveBeenCalledWith(expectedMap);
+      expect(dispatchCurrentContextGeneralStateSpy).toHaveBeenCalledWith({
+        checking: { state: 'waiting' },
         reachable: true,
         resources: {
           pods: 0,
           deployments: 0,
         },
       });
-      expect(apiSenderSendMock).toHaveBeenCalledWith(`kubernetes-current-context-${resource}-update`, [{}]);
+      expect(dispatchCurrentContextResourceSpy).toHaveBeenCalledWith(resource, [{}]);
     });
 
     test('createInformer should send data for deleted and updated resource', async () => {
@@ -1010,6 +1058,8 @@ describe('update', async () => {
         },
       );
       client = new ContextsManager(apiSender);
+      const dispatchGeneralStateSpy = vi.spyOn(client, 'dispatchGeneralState');
+      const dispatchCurrentContextResourceSpy = vi.spyOn(client, 'dispatchCurrentContextResource');
       const kubeConfig = new kubeclient.KubeConfig();
       const config = {
         clusters: [
@@ -1039,29 +1089,25 @@ describe('update', async () => {
       expect(ctx).not.toBeUndefined();
       createInformer(kubeConfig, client, ctx, resource);
       vi.advanceTimersByTime(120);
-      expect(apiSenderSendMock).toHaveBeenCalledWith(`kubernetes-current-context-${resource}-update`, [
-        { metadata: { uid: 'svc1' } },
-      ]);
+      expect(dispatchCurrentContextResourceSpy).toHaveBeenCalledWith(resource, [{ metadata: { uid: 'svc1' } }]);
 
-      apiSenderSendMock.mockReset();
+      dispatchGeneralStateSpy.mockReset();
       vi.advanceTimersByTime(100);
-      expect(apiSenderSendMock).toHaveBeenCalledTimes(1); // do not send general information
-      expect(apiSenderSendMock).toHaveBeenCalledWith(`kubernetes-current-context-${resource}-update`, [
+      expect(dispatchGeneralStateSpy).not.toHaveBeenCalled();
+      expect(dispatchCurrentContextResourceSpy).toHaveBeenCalledWith(resource, [
         { metadata: { uid: 'svc1' } },
         { metadata: { uid: 'svc2' } },
       ]);
 
-      apiSenderSendMock.mockReset();
+      dispatchGeneralStateSpy.mockReset();
       vi.advanceTimersByTime(100);
-      expect(apiSenderSendMock).toHaveBeenCalledTimes(1);
-      expect(apiSenderSendMock).toHaveBeenCalledWith(`kubernetes-current-context-${resource}-update`, [
-        { metadata: { uid: 'svc2' } },
-      ]);
+      expect(dispatchGeneralStateSpy).not.toHaveBeenCalled();
+      expect(dispatchCurrentContextResourceSpy).toHaveBeenCalledWith(resource, [{ metadata: { uid: 'svc2' } }]);
 
-      apiSenderSendMock.mockReset();
+      dispatchGeneralStateSpy.mockReset();
       vi.advanceTimersByTime(100);
-      expect(apiSenderSendMock).toHaveBeenCalledTimes(1);
-      expect(apiSenderSendMock).toHaveBeenCalledWith(`kubernetes-current-context-${resource}-update`, [
+      expect(dispatchGeneralStateSpy).not.toHaveBeenCalled();
+      expect(dispatchCurrentContextResourceSpy).toHaveBeenCalledWith(resource, [
         { metadata: { uid: 'svc2', name: 'name2' } },
       ]);
     });
@@ -1469,6 +1515,9 @@ describe('update', async () => {
       },
     );
     client = new ContextsManager(apiSender);
+    const dispatchGeneralStateSpy = vi.spyOn(client, 'dispatchGeneralState');
+    const dispatchCurrentContextGeneralStateSpy = vi.spyOn(client, 'dispatchCurrentContextGeneralState');
+    const dispatchCurrentContextResourceSpy = vi.spyOn(client, 'dispatchCurrentContextResource');
     const kubeConfig = new kubeclient.KubeConfig();
     const config = {
       clusters: [
@@ -1503,16 +1552,13 @@ describe('update', async () => {
     client.registerGetCurrentContextResources('ingresses');
     await client.update(kubeConfig);
     vi.advanceTimersByTime(20);
-    expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-contexts-general-state-update', expect.anything());
-    expect(apiSenderSendMock).toHaveBeenCalledWith(
-      'kubernetes-current-context-general-state-update',
-      expect.anything(),
-    );
-    expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-current-context-pods-update', []);
-    expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-current-context-deployments-update', []);
-    expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-current-context-services-update', [{}]);
-    expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-current-context-ingresses-update', [{}]);
-    expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-current-context-routes-update', []);
+    expect(dispatchGeneralStateSpy).toHaveBeenCalled();
+    expect(dispatchCurrentContextGeneralStateSpy).toHaveBeenCalled();
+    expect(dispatchCurrentContextResourceSpy).toHaveBeenCalledWith('pods', []);
+    expect(dispatchCurrentContextResourceSpy).toHaveBeenCalledWith('deployments', []);
+    expect(dispatchCurrentContextResourceSpy).toHaveBeenCalledWith('services', [{}]);
+    expect(dispatchCurrentContextResourceSpy).toHaveBeenCalledWith('ingresses', [{}]);
+    expect(dispatchCurrentContextResourceSpy).toHaveBeenCalledWith('routes', []);
   });
 
   test('changing context that have same name as the old one should start service informer again', async () => {
@@ -1653,7 +1699,16 @@ describe('update', async () => {
     expect(vi.getTimerCount()).not.toBe(0);
     client.dispose();
     vi.advanceTimersByTime(20000);
-    expect(apiSenderSendMock).not.toHaveBeenCalled();
+    expect(apiSenderSendMock).not.toHaveBeenCalledWith('kubernetes-contexts-general-state-update', expect.anything());
+    expect(apiSenderSendMock).not.toHaveBeenCalledWith(
+      'kubernetes-current-context-general-state-update',
+      expect.anything(),
+    );
+    expect(apiSenderSendMock).not.toHaveBeenCalledWith('kubernetes-current-context-pods-update', expect.anything());
+    expect(apiSenderSendMock).not.toHaveBeenCalledWith(
+      'kubernetes-current-context-deployments-update',
+      expect.anything(),
+    );
   });
 });
 describe('ContextsStates tests', () => {

--- a/packages/main/src/plugin/kubernetes-context-state.ts
+++ b/packages/main/src/plugin/kubernetes-context-state.ts
@@ -60,9 +60,15 @@ import {
 // ContextInternalState stores informers for a kube context
 type ContextInternalState = Map<ResourceName, Informer<KubernetesObject> & ObjectCache<KubernetesObject>>;
 
+// CheckingState indicates the state of the check for a context
+export interface CheckingState {
+  state: 'waiting' | 'checking' | 'gaveup';
+}
+
 // ContextState stores information for the user about a kube context: is the cluster reachable, the number
 // of instances of different resources
 interface ContextState {
+  checking: CheckingState;
   error?: string;
   reachable: boolean;
   resources: ContextStateResources;
@@ -89,6 +95,7 @@ export type ContextStateResources = {
 
 // information sent: status and count of selected resources
 export interface ContextGeneralState {
+  checking?: CheckingState;
   error?: string;
   reachable: boolean;
   resources: SelectedResourcesCount;
@@ -136,6 +143,8 @@ const dispatchAllResources: ResourcesDispatchOptions = {
 };
 
 interface DispatchOptions {
+  // do we send information about contexts connectivity checking?
+  checkingState: boolean;
   // do we send general context for all contexts?
   contextsGeneralState: boolean;
   // do we send general context for current context?
@@ -220,6 +229,14 @@ export class ContextsStates {
     return result;
   }
 
+  getContextsCheckingState(): Map<string, CheckingState> {
+    const result = new Map<string, CheckingState>();
+    this.state.forEach((val, key) => {
+      result.set(key, val.checking);
+    });
+    return result;
+  }
+
   getCurrentContextGeneralState(current: string): ContextGeneralState {
     if (current) {
       const state = this.state.get(current);
@@ -260,6 +277,7 @@ export class ContextsStates {
   safeSetState(name: string, update: (previous: ContextState) => void): void {
     if (!this.state.has(name)) {
       this.state.set(name, {
+        checking: { state: 'waiting' },
         error: undefined,
         reachable: false,
         resources: {
@@ -466,6 +484,7 @@ export class ContextsManager {
 
     if (added || removed || contextChanged) {
       this.dispatch({
+        checkingState: false,
         contextsGeneralState: true,
         currentContextGeneralState: true,
         resources: dispatchAllResources,
@@ -531,16 +550,22 @@ export class ContextsManager {
     let timer: NodeJS.Timeout | undefined;
     let connectionDelay: NodeJS.Timeout | undefined;
     this.setConnectionTimers('pods', timer, connectionDelay);
+
+    this.setStateAndDispatch(context.name, true, false, {}, state => {
+      state.checking = { state: 'checking' };
+    });
+
     return this.createInformer<V1Pod>(kc, context, path, listFn, {
+      checkReachable: true,
       resource: 'pods',
       timer: timer,
       backoff: new Backoff(backoffInitialValue, backoffLimit, backoffJitter),
       connectionDelay: connectionDelay,
       onAdd: obj => {
-        this.setStateAndDispatch(context.name, true, { pods: true }, state => state.resources.pods.push(obj));
+        this.setStateAndDispatch(context.name, false, true, { pods: true }, state => state.resources.pods.push(obj));
       },
       onUpdate: obj => {
-        this.setStateAndDispatch(context.name, true, { pods: true }, state => {
+        this.setStateAndDispatch(context.name, false, true, { pods: true }, state => {
           state.resources.pods = state.resources.pods.filter(o => o.metadata?.uid !== obj.metadata?.uid);
           state.resources.pods.push(obj);
         });
@@ -548,19 +573,24 @@ export class ContextsManager {
       onDelete: obj => {
         this.setStateAndDispatch(
           context.name,
+          false,
           true,
           { pods: true },
           state => (state.resources.pods = state.resources.pods.filter(d => d.metadata?.uid !== obj.metadata?.uid)),
         );
       },
       onReachable: reachable => {
-        this.setStateAndDispatch(context.name, true, dispatchAllResources, state => {
+        this.setStateAndDispatch(context.name, true, true, dispatchAllResources, state => {
+          state.checking = { state: 'waiting' };
           state.reachable = reachable;
           state.error = reachable ? undefined : state.error; // if reachable we remove error
         });
       },
       onConnectionError: error => {
-        this.setStateAndDispatch(context.name, true, dispatchAllResources, state => (state.error = error));
+        this.setStateAndDispatch(context.name, true, true, dispatchAllResources, state => {
+          state.checking = { state: 'waiting' };
+          state.error = error;
+        });
       },
     });
   }
@@ -585,12 +615,12 @@ export class ContextsManager {
       backoff: new Backoff(backoffInitialValue, backoffLimit, backoffJitter),
       connectionDelay: connectionDelay,
       onAdd: obj => {
-        this.setStateAndDispatch(context.name, true, { deployments: true }, state =>
+        this.setStateAndDispatch(context.name, false, true, { deployments: true }, state =>
           state.resources.deployments.push(obj),
         );
       },
       onUpdate: obj => {
-        this.setStateAndDispatch(context.name, true, { deployments: true }, state => {
+        this.setStateAndDispatch(context.name, false, true, { deployments: true }, state => {
           state.resources.deployments = state.resources.deployments.filter(o => o.metadata?.uid !== obj.metadata?.uid);
           state.resources.deployments.push(obj);
         });
@@ -598,6 +628,7 @@ export class ContextsManager {
       onDelete: obj => {
         this.setStateAndDispatch(
           context.name,
+          false,
           true,
           { deployments: true },
           state =>
@@ -622,10 +653,10 @@ export class ContextsManager {
       backoff: new Backoff(backoffInitialValue, backoffLimit, backoffJitter),
       connectionDelay: connectionDelay,
       onAdd: obj => {
-        this.setStateAndDispatch(context.name, false, { nodes: true }, state => state.resources.nodes.push(obj));
+        this.setStateAndDispatch(context.name, false, false, { nodes: true }, state => state.resources.nodes.push(obj));
       },
       onUpdate: obj => {
-        this.setStateAndDispatch(context.name, false, { nodes: true }, state => {
+        this.setStateAndDispatch(context.name, false, false, { nodes: true }, state => {
           state.resources.nodes = state.resources.nodes.filter(o => o.metadata?.uid !== obj.metadata?.uid);
           state.resources.nodes.push(obj);
         });
@@ -633,6 +664,7 @@ export class ContextsManager {
       onDelete: obj => {
         this.setStateAndDispatch(
           context.name,
+          false,
           false,
           { nodes: true },
           state => (state.resources.nodes = state.resources.nodes.filter(d => d.metadata?.uid !== obj.metadata?.uid)),
@@ -661,10 +693,12 @@ export class ContextsManager {
       backoff: new Backoff(backoffInitialValue, backoffLimit, backoffJitter),
       connectionDelay: connectionDelay,
       onAdd: obj => {
-        this.setStateAndDispatch(context.name, false, { services: true }, state => state.resources.services.push(obj));
+        this.setStateAndDispatch(context.name, false, false, { services: true }, state =>
+          state.resources.services.push(obj),
+        );
       },
       onUpdate: obj => {
-        this.setStateAndDispatch(context.name, false, { services: true }, state => {
+        this.setStateAndDispatch(context.name, false, false, { services: true }, state => {
           state.resources.services = state.resources.services.filter(o => o.metadata?.uid !== obj.metadata?.uid);
           state.resources.services.push(obj);
         });
@@ -672,6 +706,7 @@ export class ContextsManager {
       onDelete: obj => {
         this.setStateAndDispatch(
           context.name,
+          false,
           false,
           { services: true },
           state =>
@@ -701,12 +736,12 @@ export class ContextsManager {
       backoff: new Backoff(backoffInitialValue, backoffLimit, backoffJitter),
       connectionDelay: connectionDelay,
       onAdd: obj => {
-        this.setStateAndDispatch(context.name, false, { ingresses: true }, state =>
+        this.setStateAndDispatch(context.name, false, false, { ingresses: true }, state =>
           state.resources.ingresses.push(obj),
         );
       },
       onUpdate: obj => {
-        this.setStateAndDispatch(context.name, false, { ingresses: true }, state => {
+        this.setStateAndDispatch(context.name, false, false, { ingresses: true }, state => {
           state.resources.ingresses = state.resources.ingresses.filter(o => o.metadata?.uid !== obj.metadata?.uid);
           state.resources.ingresses.push(obj);
         });
@@ -714,6 +749,7 @@ export class ContextsManager {
       onDelete: obj => {
         this.setStateAndDispatch(
           context.name,
+          false,
           false,
           { ingresses: true },
           state =>
@@ -747,10 +783,12 @@ export class ContextsManager {
       backoff: new Backoff(backoffInitialValue, backoffLimit, backoffJitter),
       connectionDelay: connectionDelay,
       onAdd: obj => {
-        this.setStateAndDispatch(context.name, false, { routes: true }, state => state.resources.routes.push(obj));
+        this.setStateAndDispatch(context.name, false, false, { routes: true }, state =>
+          state.resources.routes.push(obj),
+        );
       },
       onUpdate: obj => {
-        this.setStateAndDispatch(context.name, false, { routes: true }, state => {
+        this.setStateAndDispatch(context.name, false, false, { routes: true }, state => {
           state.resources.routes = state.resources.routes.filter(
             o => o.metadata?.uid !== (obj.metadata as V1ObjectMeta)?.uid,
           );
@@ -760,6 +798,7 @@ export class ContextsManager {
       onDelete: obj => {
         this.setStateAndDispatch(
           context.name,
+          false,
           false,
           { routes: true },
           state =>
@@ -867,6 +906,11 @@ export class ContextsManager {
     context: KubeContext,
     options: CreateInformerOptions<T>,
   ): void {
+    if (options.checkReachable) {
+      this.setStateAndDispatch(context.name, true, false, {}, state => {
+        state.checking = { state: 'checking' };
+      });
+    }
     informer.start().catch((err: unknown) => {
       const nextTimeout = options.backoff.get();
       if (err !== undefined) {
@@ -897,12 +941,14 @@ export class ContextsManager {
 
   private setStateAndDispatch(
     name: string,
+    checkingState: boolean,
     sendGeneral: boolean,
     options: ResourcesDispatchOptions,
     update: (previous: ContextState) => void,
   ): void {
     this.states.safeSetState(name, update);
     this.dispatch({
+      checkingState,
       contextsGeneralState: sendGeneral,
       currentContextGeneralState: sendGeneral,
       resources: options,
@@ -910,41 +956,65 @@ export class ContextsManager {
   }
 
   private dispatch(options: DispatchOptions): void {
+    if (options.checkingState) {
+      this.dispatchCheckingState(this.states.getContextsCheckingState());
+    }
     if (options.contextsGeneralState) {
-      this.dispatchContextsGeneralStateTimer = this.dispatchDebounce(
-        `kubernetes-contexts-general-state-update`,
-        this.states.getContextsGeneralState(),
-        this.dispatchContextsGeneralStateTimer,
-        dispatchTimeout,
-      );
+      this.dispatchGeneralState(this.states.getContextsGeneralState());
     }
     if (options.currentContextGeneralState) {
-      this.dispatchCurrentContextGeneralStateTimer = this.dispatchDebounce(
-        `kubernetes-current-context-general-state-update`,
+      this.dispatchCurrentContextGeneralState(
         this.states.getCurrentContextGeneralState(this.kubeConfig.currentContext),
-        this.dispatchCurrentContextGeneralStateTimer,
-        dispatchTimeout,
       );
     }
     Object.keys(options.resources).forEach(res => {
       const resname = res as ResourceName;
       if (options.resources[resname]) {
-        this.dispatchCurrentContextResourceTimers.set(
+        this.dispatchCurrentContextResource(
           resname,
-          this.dispatchDebounce(
-            `kubernetes-current-context-${resname}-update`,
-            this.states.getContextResources(this.kubeConfig.currentContext, resname),
-            this.dispatchCurrentContextResourceTimers.get(resname),
-            dispatchTimeout,
-          ),
+          this.states.getContextResources(this.kubeConfig.currentContext, resname),
         );
       }
     });
   }
 
+  public dispatchCheckingState(val: Map<string, CheckingState>): void {
+    this.apiSender.send(`kubernetes-contexts-checking-state-update`, val);
+  }
+
+  public dispatchGeneralState(val: Map<string, ContextGeneralState>): void {
+    this.dispatchContextsGeneralStateTimer = this.dispatchDebounce(
+      `kubernetes-contexts-general-state-update`,
+      val,
+      this.dispatchContextsGeneralStateTimer,
+      dispatchTimeout,
+    );
+  }
+
+  public dispatchCurrentContextGeneralState(val: ContextGeneralState): void {
+    this.dispatchCurrentContextGeneralStateTimer = this.dispatchDebounce(
+      `kubernetes-current-context-general-state-update`,
+      val,
+      this.dispatchCurrentContextGeneralStateTimer,
+      dispatchTimeout,
+    );
+  }
+
+  public dispatchCurrentContextResource(resname: ResourceName, val: KubernetesObject[]): void {
+    this.dispatchCurrentContextResourceTimers.set(
+      resname,
+      this.dispatchDebounce(
+        `kubernetes-current-context-${resname}-update`,
+        val,
+        this.dispatchCurrentContextResourceTimers.get(resname),
+        dispatchTimeout,
+      ),
+    );
+  }
+
   private dispatchDebounce(
     eventName: string,
-    value: Map<string, ContextGeneralState> | ContextGeneralState | KubernetesObject[],
+    value: Map<string, ContextGeneralState> | ContextGeneralState | KubernetesObject[] | Map<string, boolean>,
     timer: NodeJS.Timeout | undefined,
     timeout: number,
   ): NodeJS.Timeout | undefined {

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.spec.ts
@@ -26,7 +26,7 @@ import { kubernetesContexts } from '/@/stores/kubernetes-contexts';
 import * as kubernetesContextsState from '/@/stores/kubernetes-contexts-state';
 
 import type { KubeContext } from '../../../../main/src/plugin/kubernetes-context';
-import type { ContextGeneralState } from '../../../../main/src/plugin/kubernetes-context-state';
+import type { CheckingState, ContextGeneralState } from '../../../../main/src/plugin/kubernetes-context-state';
 import PreferencesKubernetesContextsRendering from './PreferencesKubernetesContextsRendering.svelte';
 
 vi.mock('/@/stores/kubernetes-contexts-state', async () => {
@@ -75,6 +75,7 @@ beforeEach(() => {
 
 test('test that name, cluster and the server is displayed when rendering', async () => {
   vi.mocked(kubernetesContextsState).kubernetesContextsState = readable<Map<string, ContextGeneralState>>(new Map());
+  vi.mocked(kubernetesContextsState).kubernetesContextsCheckingState = readable<Map<string, CheckingState>>(new Map());
   (window as any).kubernetesGetCurrentContextName = vi.fn().mockResolvedValue('my-current-context');
   render(PreferencesKubernetesContextsRendering, {});
   expect(await screen.findByText('context-name')).toBeInTheDocument();
@@ -85,12 +86,14 @@ test('test that name, cluster and the server is displayed when rendering', async
 
 test('Test that namespace is displayed when available in the context', async () => {
   vi.mocked(kubernetesContextsState).kubernetesContextsState = readable<Map<string, ContextGeneralState>>(new Map());
+  vi.mocked(kubernetesContextsState).kubernetesContextsCheckingState = readable<Map<string, CheckingState>>(new Map());
   render(PreferencesKubernetesContextsRendering, {});
   expect(await screen.findByText('namespace-name3')).toBeInTheDocument();
 });
 
 test('If nothing is returned for contexts, expect that the page shows a message', async () => {
   vi.mocked(kubernetesContextsState).kubernetesContextsState = readable<Map<string, ContextGeneralState>>(new Map());
+  vi.mocked(kubernetesContextsState).kubernetesContextsCheckingState = readable<Map<string, CheckingState>>(new Map());
   kubernetesContexts.set([]);
   render(PreferencesKubernetesContextsRendering, {});
   expect(await screen.findByText('No Kubernetes contexts found')).toBeInTheDocument();
@@ -98,6 +101,7 @@ test('If nothing is returned for contexts, expect that the page shows a message'
 
 test('Test that context-name2 is the current context', async () => {
   vi.mocked(kubernetesContextsState).kubernetesContextsState = readable<Map<string, ContextGeneralState>>(new Map());
+  vi.mocked(kubernetesContextsState).kubernetesContextsCheckingState = readable<Map<string, CheckingState>>(new Map());
   (window as any).kubernetesGetCurrentContextName = vi.fn().mockResolvedValue('context-name2');
   render(PreferencesKubernetesContextsRendering, {});
 
@@ -115,6 +119,7 @@ test('Test that context-name2 is the current context', async () => {
 
 test('when deleting the current context, a popup should ask confirmation', async () => {
   vi.mocked(kubernetesContextsState).kubernetesContextsState = readable<Map<string, ContextGeneralState>>(new Map());
+  vi.mocked(kubernetesContextsState).kubernetesContextsCheckingState = readable<Map<string, CheckingState>>(new Map());
   const showMessageBoxMock = vi.fn();
   (window as any).showMessageBox = showMessageBoxMock;
   showMessageBoxMock.mockResolvedValue({ result: 1 });
@@ -134,6 +139,7 @@ test('when deleting the current context, a popup should ask confirmation', async
 
 test('when deleting the non current context, no popup should ask confirmation', async () => {
   vi.mocked(kubernetesContextsState).kubernetesContextsState = readable<Map<string, ContextGeneralState>>(new Map());
+  vi.mocked(kubernetesContextsState).kubernetesContextsCheckingState = readable<Map<string, CheckingState>>(new Map());
   const showMessageBoxMock = vi.fn();
   (window as any).showMessageBox = showMessageBoxMock;
   showMessageBoxMock.mockResolvedValue({ result: 1 });
@@ -168,6 +174,7 @@ test('state and resources counts are displayed in contexts', () => {
     },
   });
   vi.mocked(kubernetesContextsState).kubernetesContextsState = readable<Map<string, ContextGeneralState>>(state);
+  vi.mocked(kubernetesContextsState).kubernetesContextsCheckingState = readable<Map<string, CheckingState>>(new Map());
   render(PreferencesKubernetesContextsRendering, {});
   const context1 = screen.getAllByRole('row')[0];
   const context2 = screen.getAllByRole('row')[1];

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
 import { faRightToBracket, faTrash } from '@fortawesome/free-solid-svg-icons';
-import { EmptyScreen, ErrorMessage } from '@podman-desktop/ui-svelte';
+import { EmptyScreen, ErrorMessage, Spinner } from '@podman-desktop/ui-svelte';
 
-import { kubernetesContextsState } from '/@/stores/kubernetes-contexts-state';
+import { kubernetesContextsCheckingState, kubernetesContextsState } from '/@/stores/kubernetes-contexts-state';
 
 import { kubernetesContexts } from '../../stores/kubernetes-contexts';
 import { clearKubeUIContextErrors, setKubeUIContextError } from '../kube/KubeContextUI';
@@ -138,6 +138,9 @@ async function handleDeleteContext(contextName: string) {
                       aria-label="Context Unreachable">
                       UNREACHABLE
                     </div>
+                    {#if $kubernetesContextsCheckingState.get(context.name)?.state === 'checking'}
+                      <div class="ml-1"><Spinner size="12px"></Spinner></div>
+                    {/if}
                   </div>
                 {/if}
               </div>

--- a/packages/renderer/src/stores/kubernetes-contexts-state.ts
+++ b/packages/renderer/src/stores/kubernetes-contexts-state.ts
@@ -23,7 +23,6 @@ import type { CheckingState, ContextGeneralState } from '../../../main/src/plugi
 import { findMatchInLeaves } from './search-util';
 
 export const kubernetesContextsCheckingState = readable(new Map<string, CheckingState>(), set => {
-  // TODO get initial value
   window.events?.receive('kubernetes-contexts-checking-state-update', (value: unknown) => {
     set(value as Map<string, CheckingState>);
   });

--- a/packages/renderer/src/stores/kubernetes-contexts-state.ts
+++ b/packages/renderer/src/stores/kubernetes-contexts-state.ts
@@ -19,8 +19,15 @@
 import type { KubernetesObject } from '@kubernetes/client-node';
 import { derived, readable, writable } from 'svelte/store';
 
-import type { ContextGeneralState } from '../../../main/src/plugin/kubernetes-context-state';
+import type { CheckingState, ContextGeneralState } from '../../../main/src/plugin/kubernetes-context-state';
 import { findMatchInLeaves } from './search-util';
+
+export const kubernetesContextsCheckingState = readable(new Map<string, CheckingState>(), set => {
+  // TODO get initial value
+  window.events?.receive('kubernetes-contexts-checking-state-update', (value: unknown) => {
+    set(value as Map<string, CheckingState>);
+  });
+});
 
 export const kubernetesContextsState = readable(new Map<string, ContextGeneralState>(), set => {
   window.kubernetesGetContextsGeneralState().then(value => set(value));


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

- [x] Adds feedback when Podman Desktop is checking Kube context connectivity
- [x] Needs to enhance frontend to display the spinner a minimal amount of time (for example 1s)
- [x] Add tests to cover new feature

### Screenshot / video of UI


### What issues does this PR fix or reference?

Fixes #7661 

### How to test this PR?

- [x] Tests are covering the bug fix or the new feature
