### PR TITLE
chore: light mode for nav section

### DIFF
--- a/packages/renderer/src/lib/ui/NavSection.spec.ts
+++ b/packages/renderer/src/lib/ui/NavSection.spec.ts
@@ -33,6 +33,13 @@ test('Expect correct button and tooltip', async () => {
 
   const button = screen.getByRole('button');
   expect(button).toBeInTheDocument();
+  expect(button).toHaveClass('inline-block');
+  expect(button).toHaveClass('flex');
+  expect(button).toHaveClass('flex-col');
+  expect(button).toHaveClass('justify-center');
+  expect(button).toHaveClass('items-center');
+  expect(button).toHaveClass('text-[var(--pd-global-nav-icon)]');
+  expect(button).toHaveClass('hover:text-[var(--pd-global-nav-icon-hover)]');
   const tip = button.children[0];
   expect(tip).toBeInTheDocument();
   expect(within(button).queryByText(tooltip)).toBeInTheDocument();

--- a/packages/renderer/src/lib/ui/NavSection.svelte
+++ b/packages/renderer/src/lib/ui/NavSection.svelte
@@ -33,7 +33,7 @@ onMount(() => {
   {/if}
 
   <button
-    class="inline-block flex flex-col justify-center items-center"
+    class="inline-block flex flex-col justify-center items-center text-[var(--pd-global-nav-icon)] hover:text-[var(--pd-global-nav-icon-hover)]"
     on:click="{() => (expanded = !expanded)}"
     disabled="{expanded && $count < 2}">
     <Tooltip class="flex flex-col justify-center items-center pb-1" right tip="{tooltip}">


### PR DESCRIPTION
### What does this PR do?

NavItem had been moved to light mode, but NavSection (the expandable sections for extensions and Kubernetes) was still picking up default colors, which happened to pick up white even in dark mode. This just sets the text color explicitly using the color from the registry, and adds the missing hover color too.

Compared to regular nav items there is still a 'missing' hover bg, but since it isn't defined how/if that should work for sections I'm not adding it here.

### Screenshot / video of UI

Before:

![338597588-30e3e8c8-5ba7-45cb-a452-760a5bfecd46](https://github.com/containers/podman-desktop/assets/19958075/5427f608-01c7-4c22-a0fd-6a29d46f8bfa)

After:

https://github.com/containers/podman-desktop/assets/19958075/89776f96-5d4d-42c2-a46c-802c18f24f40

### What issues does this PR fix or reference?

Fixes #7579.

### How to test this PR?

Just check sections in light and dark mode.

- [x] Tests are covering the bug fix or the new feature