### PR TITLE
chore: light mode nav text

### DIFF
--- a/packages/ui/src/lib/layouts/NavPage.svelte
+++ b/packages/ui/src/lib/layouts/NavPage.svelte
@@ -15,7 +15,9 @@ export let searchEnabled = true;
       <div class="flex flex-1 justify-end">
         <div class="px-5" role="group" aria-label="additionalActions">
           {#if $$slots['additional-actions']}
-            <div class="space-x-2 flex flex-nowrap"><slot name="additional-actions" /></div>
+            <div class="space-x-2 flex flex-nowrap text-[var(--pd-content-text)]">
+              <slot name="additional-actions" />
+            </div>
           {:else}&nbsp;{/if}
         </div>
       </div>
@@ -27,7 +29,7 @@ export let searchEnabled = true;
         </div>
         <div class="flex flex-1 px-5" role="group" aria-label="bottomAdditionalActions">
           {#if $$slots['bottom-additional-actions']}
-            <div class="space-x-2 flex flex-row justify-start items-center w-full">
+            <div class="space-x-2 flex flex-row justify-start items-center w-full text-[var(--pd-content-text)]">
               <slot name="bottom-additional-actions" />
             </div>
           {:else}&nbsp;{/if}


### PR DESCRIPTION
### What does this PR do?

Just sets the default text color for nav page using the color registry value. This allows any text or other elements in the slot to pick up the default color.

### Screenshot / video of UI

Before:

![338735046-844f54a8-ec49-44e3-9294-a9532fee216f](https://github.com/containers/podman-desktop/assets/19958075/ce14e7da-49bb-46ff-b6b4-bb85c9b1644f)

After:

<img width="279" alt="Screenshot 2024-06-17 at 9 52 33 AM" src="https://github.com/containers/podman-desktop/assets/19958075/59dc56e0-22cd-4941-ac12-44e0284ae4f3">

### What issues does this PR fix or reference?

Fixes #7592.

### How to test this PR?

Select an item in one of the image/container/pod tables.