### PR TITLE
feat: show node and namespace information for k8s pods

### DIFF
--- a/packages/main/src/plugin/api/pod-info.ts
+++ b/packages/main/src/plugin/api/pod-info.ts
@@ -29,6 +29,8 @@ export interface PodInfo extends LibPodPodInfo {
   engineId: string;
   engineName: string;
   kind: 'kubernetes' | 'podman';
+  // Optional information only used by Kubernetes
+  node?: string;
 }
 
 export interface PodInspectInfo extends LibPodPodInspectInfo {

--- a/packages/main/src/plugin/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes-client.ts
@@ -112,6 +112,7 @@ function toPodInfo(pod: V1Pod, contextName?: string): PodInfo {
     engineId: contextName ?? 'kubernetes',
     engineName: 'Kubernetes',
     kind: 'kubernetes',
+    node: pod.spec?.nodeName,
   };
 }
 

--- a/packages/renderer/src/lib/pod/PodColumnName.spec.ts
+++ b/packages/renderer/src/lib/pod/PodColumnName.spec.ts
@@ -38,6 +38,8 @@ const pod: PodInfoUI = {
   selected: false,
   containers: [],
   kind: 'podman',
+  node: 'node1',
+  namespace: 'default',
 };
 
 test('Expect simple column styling', async () => {
@@ -66,4 +68,30 @@ test('Expect clicking works', async () => {
   fireEvent.click(text);
 
   expect(routerGotoSpy).toBeCalledWith('/pods/podman/my-pod/podman/');
+});
+
+test('Expect kubernetes pod information', async () => {
+  const fakeKubernetesInfo: PodInfoUI = {
+    id: 'pod-id',
+    shortId: 'short-id',
+    name: 'my-pod',
+    engineId: 'kubernetes',
+    engineName: '',
+    status: '',
+    age: '',
+    created: '',
+    selected: false,
+    containers: [],
+    kind: 'kubernetes',
+    node: 'node1',
+    namespace: 'customnamespace',
+  };
+
+  render(PodColumnName, { object: fakeKubernetesInfo });
+
+  const id = screen.getByText('customnamespace');
+  expect(id).toBeInTheDocument();
+
+  const node = screen.getByText('node1');
+  expect(node).toBeInTheDocument();
 });

--- a/packages/renderer/src/lib/pod/PodColumnName.svelte
+++ b/packages/renderer/src/lib/pod/PodColumnName.svelte
@@ -2,9 +2,12 @@
 import { handleNavigation } from '/@/navigation';
 
 import { NavigationPage } from '../../../../main/src/plugin/navigation/navigation-page';
+import { PodUtils } from './pod-utils';
 import type { PodInfoUI } from './PodInfoUI';
 
 export let object: PodInfoUI;
+
+const podUtils = new PodUtils();
 
 function openDetailsPod(pod: PodInfoUI) {
   handleNavigation(NavigationPage.POD, {
@@ -19,5 +22,12 @@ function openDetailsPod(pod: PodInfoUI) {
   <div class="text-sm text-[var(--pd-table-body-text-highlight)] max-w-full overflow-hidden text-ellipsis">
     {object.name}
   </div>
-  <div class="text-xs text-[var(--pd-table-body-text-sub-secondary)]">{object.shortId}</div>
+  <div class="flex flex-row text-xs gap-1">
+    <div class="text-xs text-[var(--pd-table-body-text-sub-secondary)]">
+      {podUtils.isKubernetesPod(object) ? object.node : object.shortId}
+    </div>
+    {#if podUtils.isKubernetesPod(object)}
+      <div class="font-extra-light text-[var(--pd-table-body-text-sub-highlight)]">{object.namespace}</div>
+    {/if}
+  </div>
 </button>

--- a/packages/renderer/src/lib/pod/PodInfoUI.ts
+++ b/packages/renderer/src/lib/pod/PodInfoUI.ts
@@ -47,5 +47,7 @@ export interface PodInfoUI {
   containers: PodInfoContainerUI[];
   actionInProgress?: boolean;
   actionError?: string;
+  node?: string;
+  namespace?: string;
   kind: 'kubernetes' | 'podman';
 }

--- a/packages/renderer/src/lib/pod/pod-utils.spec.ts
+++ b/packages/renderer/src/lib/pod/pod-utils.spec.ts
@@ -110,3 +110,17 @@ test('Expect return a valid name for a new pod if there are pods with the same n
 
   expect(newPodName).toBe('my-pod-2');
 });
+
+test('Expect to get node and namespace from pod info', () => {
+  const podUtils = new PodUtils();
+  const podInfo = {
+    kind: 'kubernetes',
+    node: 'node1',
+    Namespace: 'default',
+    Id: 'pod-id',
+  } as unknown as PodInfo;
+  const pod = podUtils.getPodInfoUI(podInfo);
+
+  expect(pod.node).toBe('node1');
+  expect(pod.namespace).toBe('default');
+});

--- a/packages/renderer/src/lib/pod/pod-utils.ts
+++ b/packages/renderer/src/lib/pod/pod-utils.ts
@@ -63,7 +63,13 @@ export class PodUtils {
       containers: podinfo.Containers,
       selected: false,
       kind: podinfo.kind,
+      node: podinfo.node,
+      namespace: podinfo.Namespace,
     };
+  }
+
+  isKubernetesPod(pod: PodInfoUI): boolean {
+    return pod.kind === 'kubernetes';
   }
 
   calculateNewPodName(existedPods?: PodInfo[]) {


### PR DESCRIPTION
feat: show node and namespace information for k8s pods

### What does this PR do?

* Shows node and namespace information for Kubernetes pods on the Pods
  page

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

<img width="982" alt="Screenshot 2024-06-17 at 10 39 00 PM" src="https://github.com/containers/podman-desktop/assets/6422176/a1cfe79a-2376-420d-800d-1375b57c3e41">


<img width="369" alt="Screenshot 2024-06-17 at 10 36 56 PM" src="https://github.com/containers/podman-desktop/assets/6422176/b08ac434-41e4-42e2-bf28-9cb7477be724">


### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop/issues/7646

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature

View Kubernetes pods and see the node and namespace information.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
