### PR TITLE
fix: init kubecontext to prevent informer not starting on valid cluster

### DIFF
--- a/packages/main/src/plugin/kubernetes-context-state.spec.ts
+++ b/packages/main/src/plugin/kubernetes-context-state.spec.ts
@@ -862,6 +862,50 @@ describe('update', async () => {
     expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-current-context-deployments-update', []);
   });
 
+  test('createKubeContextInformers should receive initialized kubeContext', async () => {
+    client = new ContextsManager(apiSender);
+    const createKubeContextInformersMock = vi
+      .spyOn(client, 'createKubeContextInformers')
+      .mockImplementation((_context: KubeContext) => {
+        return undefined;
+      });
+    const kubeConfig = new kubeclient.KubeConfig();
+    const config = {
+      clusters: [
+        {
+          name: 'cluster1',
+          server: 'server1',
+        },
+      ],
+      users: [
+        {
+          name: 'user1',
+        },
+      ],
+      contexts: [
+        {
+          name: 'context1',
+          cluster: 'cluster1',
+          user: 'user1',
+          namespace: 'ns1',
+        },
+      ],
+      currentContext: 'context1',
+    };
+    kubeConfig.loadFromOptions(config);
+    await client.update(kubeConfig);
+    expect(createKubeContextInformersMock).toBeCalledWith({
+      cluster: 'cluster1',
+      clusterInfo: {
+        name: 'cluster1',
+        server: 'server1',
+      },
+      name: 'context1',
+      namespace: 'ns1',
+      user: 'user1',
+    });
+  });
+
   const secondaryInformers = [
     {
       resource: 'services',
@@ -2083,5 +2127,115 @@ describe('isContextChanged', () => {
     } as KubeConfig;
     const changed = client.isContextChanged(context);
     expect(changed).toBeFalsy();
+  });
+});
+
+describe('isContextChanged', () => {
+  let client: ContextsManager;
+  let kubeConfig: kubeclient.KubeConfig;
+  beforeAll(async () => {
+    vi.mocked(makeInformer).mockImplementation(
+      (
+        kubeconfig: kubeclient.KubeConfig,
+        path: string,
+        _listPromiseFn: kubeclient.ListPromise<kubeclient.KubernetesObject>,
+      ) => {
+        const connectResult = new Error('err');
+        return new FakeInformer(kubeconfig.currentContext, path, 0, connectResult, [], []);
+      },
+    );
+    kubeConfig = new kubeclient.KubeConfig();
+    const config = {
+      clusters: [
+        {
+          name: 'cluster',
+          server: 'server',
+        },
+        {
+          name: 'cluster1',
+          server: 'server1',
+        },
+      ],
+      users: [
+        {
+          name: 'user',
+        },
+        {
+          name: 'user1',
+        },
+      ],
+      contexts: [
+        {
+          name: 'context',
+          cluster: 'cluster',
+          user: 'user',
+          namespace: 'ns',
+        },
+      ],
+      currentContext: 'context',
+    };
+    kubeConfig.loadFromOptions(config);
+    client = new ContextsManager(apiSender);
+    await client.update(kubeConfig);
+  });
+  test('verify createInformer is called having kubeContext object initialized - services', () => {
+    vi.mocked(makeInformer).mockImplementation(fakeMakeInformer);
+    const serviceInformer = vi.spyOn(client, 'createServiceInformer');
+    client.startResourceInformer('context', 'services');
+    expect(serviceInformer).toBeCalledWith(kubeConfig, 'ns', {
+      name: 'context',
+      cluster: 'cluster',
+      user: 'user',
+      namespace: 'ns',
+      clusterInfo: {
+        name: 'cluster',
+        server: 'server',
+      },
+    });
+  });
+  test('verify createInformer is called having kubeContext object initialized - nodes', () => {
+    vi.mocked(makeInformer).mockImplementation(fakeMakeInformer);
+    const nodeInformer = vi.spyOn(client, 'createNodeInformer');
+    client.startResourceInformer('context', 'nodes');
+    expect(nodeInformer).toBeCalledWith(kubeConfig, 'ns', {
+      name: 'context',
+      cluster: 'cluster',
+      user: 'user',
+      namespace: 'ns',
+      clusterInfo: {
+        name: 'cluster',
+        server: 'server',
+      },
+    });
+  });
+  test('verify createInformer is called having kubeContext object initialized - ingress', () => {
+    vi.mocked(makeInformer).mockImplementation(fakeMakeInformer);
+    const ingressInformer = vi.spyOn(client, 'createIngressInformer');
+    client.startResourceInformer('context', 'ingresses');
+    expect(ingressInformer).toBeCalledWith(kubeConfig, 'ns', {
+      name: 'context',
+      cluster: 'cluster',
+      user: 'user',
+      namespace: 'ns',
+      clusterInfo: {
+        name: 'cluster',
+        server: 'server',
+      },
+    });
+  });
+  test('verify createInformer is called having kubeContext object initialized - routes', () => {
+    vi.mocked(makeInformer).mockImplementation(fakeMakeInformer);
+    const routeInformer = vi.spyOn(client, 'createRouteInformer');
+    client.startResourceInformer('context', 'routes');
+    expect(routeInformer).toBeCalledWith(kubeConfig, 'ns', {
+      name: 'context',
+      cluster: 'cluster',
+      user: 'user',
+      namespace: 'ns',
+      clusterInfo: {
+        name: 'cluster',
+        server: 'server',
+      },
+    });
   });
 });

--- a/packages/main/src/plugin/kubernetes-context-state.ts
+++ b/packages/main/src/plugin/kubernetes-context-state.ts
@@ -502,20 +502,28 @@ export class ContextsManager {
     if (!context) {
       throw new Error(`context ${contextName} not found`);
     }
+    const clusterObj = this.kubeConfig.getCluster(context.cluster);
+    const kubeContext: KubeContext = {
+      ...context,
+      clusterInfo: {
+        name: clusterObj?.name ?? '',
+        server: clusterObj?.server ?? '',
+      },
+    };
     const ns = context.namespace ?? 'default';
     let informer: Informer<KubernetesObject> & ObjectCache<KubernetesObject>;
     switch (resourceName) {
       case 'services':
-        informer = this.createServiceInformer(this.kubeConfig, ns, context);
+        informer = this.createServiceInformer(this.kubeConfig, ns, kubeContext);
         break;
       case 'nodes':
-        informer = this.createNodeInformer(this.kubeConfig, ns, context);
+        informer = this.createNodeInformer(this.kubeConfig, ns, kubeContext);
         break;
       case 'ingresses':
-        informer = this.createIngressInformer(this.kubeConfig, ns, context);
+        informer = this.createIngressInformer(this.kubeConfig, ns, kubeContext);
         break;
       case 'routes':
-        informer = this.createRouteInformer(this.kubeConfig, ns, context);
+        informer = this.createRouteInformer(this.kubeConfig, ns, kubeContext);
         break;
       default:
         console.debug(`unable to watch ${resourceName} in context ${contextName}, as this resource is not supported`);


### PR DESCRIPTION
### What does this PR do?

This PR fixes an issue found by @feloy on the `isContextInKubeconfig` which prevented Dekstop from keep checking a valid cluster if it was shut down at start

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

it resolves #7636 

### How to test this PR?

1. start Desktop with a kind cluster (or any k8s cluster) stopped
2. start the cluster
3. Desktop should connect to it

- [x] Tests are covering the bug fix or the new feature
