### PR TITLE
fix: changing namespace of the current Kube context restarts the informers

### DIFF
--- a/packages/main/src/plugin/kubernetes-context-state.ts
+++ b/packages/main/src/plugin/kubernetes-context-state.ts
@@ -396,6 +396,11 @@ export class ContextsManager {
       return true;
     }
 
+    const ns = kubeconfig.getContexts()?.find(c => c.name === kubeconfig.currentContext)?.namespace;
+    if (ns !== this.currentContext.namespace) {
+      return true;
+    }
+
     // by retrieving the cluster from the kubeconfig, if the name or server url are different from the latest context we saved -> true
     const cluster = kubeconfig.getCurrentCluster();
     return (
@@ -419,6 +424,7 @@ export class ContextsManager {
           name: currentCluster?.name ?? '',
           server: currentCluster?.server ?? '',
         },
+        namespace: kubeconfig.getContexts().find(c => c.name === kubeconfig.currentContext)?.namespace,
       };
     }
 


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

When the user changes the namespace of the current context (using `kubectl ns new-ns` for example), the Deployments/services/... pages are modified accordingly

NOTE: This is not fixing the problem when the namespace is changed on a non-current context, which would need much more changes

### Screenshot / video of UI


### What issues does this PR fix or reference?

Fixes #7688 

### How to test this PR?

See steps to reproduce in #7688 

- [x] Tests are covering the bug fix or the new feature
