### PR TITLE
chore: fix typecheck PVC and incorrect dispatch

### DIFF
--- a/packages/main/src/plugin/kubernetes-context-state.ts
+++ b/packages/main/src/plugin/kubernetes-context-state.ts
@@ -665,12 +665,12 @@ export class ContextsManager {
       backoff: new Backoff(backoffInitialValue, backoffLimit, backoffJitter),
       connectionDelay: connectionDelay,
       onAdd: obj => {
-        this.setStateAndDispatch(context.name, true, { persistentvolumeclaims: true }, state =>
+        this.setStateAndDispatch(context.name, false, false, { persistentvolumeclaims: true }, state =>
           state.resources.persistentvolumeclaims.push(obj),
         );
       },
       onUpdate: obj => {
-        this.setStateAndDispatch(context.name, true, { persistentvolumeclaims: true }, state => {
+        this.setStateAndDispatch(context.name, false, false, { persistentvolumeclaims: true }, state => {
           state.resources.persistentvolumeclaims = state.resources.persistentvolumeclaims.filter(
             o => o.metadata?.uid !== obj.metadata?.uid,
           );
@@ -680,7 +680,8 @@ export class ContextsManager {
       onDelete: obj => {
         this.setStateAndDispatch(
           context.name,
-          true,
+          false,
+          false,
           { persistentvolumeclaims: true },
           state =>
             (state.resources.persistentvolumeclaims = state.resources.persistentvolumeclaims.filter(


### PR DESCRIPTION
chore: fix typecheck PVC and incorrect dispatch

### What does this PR do?

Fixes the typecheck, as well as the incorrect dispatch that was set.
Both should be set to false to match how services / ingress / etc is
hot-reloaded / refreshed in the interface.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/A

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Fixes the below output:

```
Run yarn typecheck
yarn run v1.22.22
$ npm run typecheck:main && npm run typecheck:preload && npm run typecheck:ui && npm run typecheck:renderer && npm run typecheck:preload-dd-extension && npm run typecheck:preload-webview && npm run typecheck:extensions && npm run typecheck:extension-api

> podman-desktop@1.11.0-next typecheck:main
> tsc --noEmit -p packages/main/tsconfig.json

Error: packages/main/src/plugin/kubernetes-context-state.ts(668,14): error TS2554: Expected 5 arguments, but got 4.
Error: packages/main/src/plugin/kubernetes-context-state.ts(668,88): error TS7006: Parameter 'state' implicitly has an 'any' type.
Error: packages/main/src/plugin/kubernetes-context-state.ts(673,14): error TS2554: Expected 5 arguments, but got 4.
Error: packages/main/src/plugin/kubernetes-context-state.ts(673,88): error TS7006: Parameter 'state' implicitly has an 'any' type.
Error: packages/main/src/plugin/kubernetes-context-state.ts(675,13): error TS7006: Parameter 'o' implicitly has an 'any' type.
Error: packages/main/src/plugin/kubernetes-context-state.ts(681,14): error TS2554: Expected 5 arguments, but got 4.
Error: packages/main/src/plugin/kubernetes-context-state.ts(685,11): error TS7006: Parameter 'state' implicitly has an 'any' type.
Error: packages/main/src/plugin/kubernetes-context-state.ts(687,15): error TS7006: Parameter 'd' implicitly has an 'any' type.
error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
Error: Process completed with exit code 2.
```

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature

Should pass CI now

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
