### PR TITLE
chore: k8s adjust showing node OS

### DIFF
--- a/packages/renderer/src/lib/node/NodesList.svelte
+++ b/packages/renderer/src/lib/node/NodesList.svelte
@@ -69,13 +69,13 @@ let versionColumn = new TableColumn<NodeUI, string>('Version', {
 });
 
 let osImageColumn = new TableColumn<NodeUI, string>('OS', {
+  width: '1.5fr',
   renderMapping: node => node.osImage,
   renderer: TableSimpleColumn,
   comparator: (a, b) => a.osImage.localeCompare(b.osImage),
 });
 
 let kernelVersionColumn = new TableColumn<NodeUI, string>('Kernel', {
-  width: '1.3fr',
   renderMapping: node => node.kernelVersion,
   renderer: TableSimpleColumn,
   comparator: (a, b) => a.kernelVersion.localeCompare(b.kernelVersion),


### PR DESCRIPTION
chore: k8s adjust showing node OS

### What does this PR do?

* Adjusts the spacing, prioritizing the OS explanation which is usually
  a lot longer than the kernel versioning.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->
![Screenshot 2024-06-18 at 10 12 39 AM](https://github.com/containers/podman-desktop/assets/6422176/cc6a52e5-dae6-44b3-bb89-cf09b3ff0e91)



### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

N/A

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

N/A, minor change.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
