### PR TITLE
chore: add more node information to summary page

### DIFF
--- a/packages/renderer/src/lib/kube/details/KubeNodeStatusArtifact.spec.ts
+++ b/packages/renderer/src/lib/kube/details/KubeNodeStatusArtifact.spec.ts
@@ -1,0 +1,89 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import type { V1NodeStatus } from '@kubernetes/client-node';
+import { render, screen } from '@testing-library/svelte';
+import { expect, test } from 'vitest';
+
+import KubeNodeStatusArtifact from './KubeNodeStatusArtifact.svelte';
+
+// A full V1NodeStatus object with all fields populated
+const fakeNodeStatus = {
+  capacity: {
+    cpu: '4',
+    memory: '16Gi',
+    pods: '110',
+  },
+  allocatable: {
+    cpu: '5',
+    memory: '17Gi',
+    pods: '111',
+  },
+  conditions: [
+    {
+      type: 'Ready',
+      status: 'True',
+      reason: 'KubeletReady',
+      message: 'kubelet is posting ready status',
+    },
+    {
+      type: 'OutOfDisk',
+      status: 'False',
+      reason: 'KubeletHasSufficientDisk',
+      message: 'kubelet has sufficient disk space available',
+    },
+  ],
+  addresses: [
+    {
+      type: 'InternalIP',
+      address: '10.0.0.1',
+    },
+    {
+      type: 'Hostname',
+      address: 'node1',
+    },
+  ],
+  nodeInfo: {
+    architecture: 'amd64',
+    operatingSystem: 'linux',
+    osImage: 'Fedora 35',
+    kernelVersion: '5.15.8',
+    kubeletVersion: 'v1.23.2',
+    containerRuntimeVersion: 'containerd://1.5.7',
+    kubeProxyVersion: 'v1.23.3',
+  },
+} as unknown as V1NodeStatus;
+
+test('Renders node status correctly', () => {
+  render(KubeNodeStatusArtifact, { artifact: fakeNodeStatus });
+  expect(screen.getByText('10.0.0.1')).toBeInTheDocument();
+  expect(screen.getByText('node1')).toBeInTheDocument();
+  expect(screen.getByText('16Gi')).toBeInTheDocument();
+  expect(screen.getByText('110')).toBeInTheDocument();
+  expect(screen.getByText('Ready')).toBeInTheDocument();
+  expect(screen.getByText('True')).toBeInTheDocument();
+  expect(screen.getByText('kubelet is posting ready status')).toBeInTheDocument();
+  expect(screen.getByText('amd64')).toBeInTheDocument();
+  expect(screen.getByText('linux')).toBeInTheDocument();
+  expect(screen.getByText('Fedora 35')).toBeInTheDocument();
+  expect(screen.getByText('5.15.8')).toBeInTheDocument();
+  expect(screen.getByText('v1.23.2')).toBeInTheDocument();
+  expect(screen.getByText('containerd://1.5.7')).toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/kube/details/KubeNodeStatusArtifact.svelte
+++ b/packages/renderer/src/lib/kube/details/KubeNodeStatusArtifact.svelte
@@ -9,6 +9,51 @@ export let artifact: V1NodeStatus | undefined;
 </script>
 
 {#if artifact}
+  {#if artifact.nodeInfo}
+    <tr>
+      <Title>Node Info</Title>
+    </tr>
+    <tr>
+      <Cell>Architecture</Cell>
+      <Cell>{artifact.nodeInfo.architecture}</Cell>
+    </tr>
+    <tr>
+      <Cell>Boot ID</Cell>
+      <Cell>{artifact.nodeInfo.bootID}</Cell>
+    </tr>
+    <tr>
+      <Cell>Container Runtime Version</Cell>
+      <Cell>{artifact.nodeInfo.containerRuntimeVersion}</Cell>
+    </tr>
+    <tr>
+      <Cell>Kernel Version</Cell>
+      <Cell>{artifact.nodeInfo.kernelVersion}</Cell>
+    </tr>
+    <tr>
+      <Cell>Kubelet Version</Cell>
+      <Cell>{artifact.nodeInfo.kubeletVersion}</Cell>
+    </tr>
+    <tr>
+      <Cell>Kube Proxy Version</Cell>
+      <Cell>{artifact.nodeInfo.kubeProxyVersion}</Cell>
+    </tr>
+    <tr>
+      <Cell>Machine ID</Cell>
+      <Cell>{artifact.nodeInfo.machineID}</Cell>
+    </tr>
+    <tr>
+      <Cell>Operating System</Cell>
+      <Cell>{artifact.nodeInfo.operatingSystem}</Cell>
+    </tr>
+    <tr>
+      <Cell>OS Image</Cell>
+      <Cell>{artifact.nodeInfo.osImage}</Cell>
+    </tr>
+    <tr>
+      <Cell>System UUID</Cell>
+      <Cell>{artifact.nodeInfo.systemUUID}</Cell>
+    </tr>
+  {/if}
   <tr>
     <Title>Status</Title>
   </tr>


### PR DESCRIPTION
chore: add more node information to summary page

### What does this PR do?

Adds the missing .nodeInfo information you would usually get from the
Kubernetes YAML to the summary page.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->
![Screenshot 2024-06-18 at 10 20 24 AM](https://github.com/containers/podman-desktop/assets/6422176/bb6d82cc-ce41-476c-84b0-f2fccc033300)



### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop/issues/7713

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature

View the Node summary page and you will now see the information.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
