### PR TITLE
chore: light mode for extension error

### DIFF
--- a/packages/renderer/src/lib/extensions/ExtensionDetailsError.svelte
+++ b/packages/renderer/src/lib/extensions/ExtensionDetailsError.svelte
@@ -5,7 +5,7 @@ export let extension: ExtensionDetailsUI;
 </script>
 
 {#if extension.error}
-  <div class="flex flex-col">
+  <div class="flex flex-col text-[var(--pd-content-card-text)]">
     <div class="py-2">Error: {extension.error.message}</div>
     {#if extension.error.stack}
       <div class="text-xs">


### PR DESCRIPTION
### What does this PR do?

Set text to light mode color so that it is visible.

### Screenshot / video of UI

See #7701 for current behaviour. After this PR it is:

<img width="283" alt="Screenshot 2024-06-18 at 10 54 48 AM" src="https://github.com/containers/podman-desktop/assets/19958075/f77ea6d5-fee4-4660-b865-5a745cbede6e">

### What issues does this PR fix or reference?

Fixes #7708.

### How to test this PR?

Find/create an extension that fails to load, and look for this tab.