### PR TITLE
chore: light mode for Kubernetes status label

### DIFF
--- a/packages/renderer/src/lib/ui/KubernetesCurrentContextConnectionBadge.svelte
+++ b/packages/renderer/src/lib/ui/KubernetesCurrentContextConnectionBadge.svelte
@@ -1,9 +1,8 @@
 <script lang="ts">
-import { Tooltip } from '@podman-desktop/ui-svelte';
-
 import { kubernetesCurrentContextState } from '/@/stores/kubernetes-contexts-state';
 
 import type { ContextGeneralState } from '../../../../main/src/plugin/kubernetes-context-state';
+import Label from './Label.svelte';
 
 function getText(state?: ContextGeneralState): string {
   if (state?.reachable) return 'Connected';
@@ -19,16 +18,6 @@ $: text = getText($kubernetesCurrentContextState);
 </script>
 
 {#if $kubernetesCurrentContextState}
-  <div role="status" class="flex items-center bg-charcoal-500 p-1 rounded-md">
-    <div class="w-2 h-2 {getClassColor($kubernetesCurrentContextState)} rounded-full mx-1"></div>
-    <span class="text-xs capitalize mr-1">
-      {#if $kubernetesCurrentContextState.error !== undefined}
-        <Tooltip left tip="{$kubernetesCurrentContextState.error}">
-          {text}
-        </Tooltip>
-      {:else}
-        {text}
-      {/if}
-    </span>
-  </div>
+  <Label role="status" name="{text}" tip="{$kubernetesCurrentContextState.error}"
+    ><div class="w-2 h-2 {getClassColor($kubernetesCurrentContextState)} rounded-full mx-1"></div></Label>
 {/if}

--- a/packages/renderer/src/lib/ui/Label.spec.ts
+++ b/packages/renderer/src/lib/ui/Label.spec.ts
@@ -49,3 +49,13 @@ test('Expect tooltip', async () => {
   expect(label).toBeInTheDocument();
   expect(label.parentElement?.firstChild).toBeInTheDocument();
 });
+
+test('Expect role to be defined', async () => {
+  const role = 'test';
+  render(LabelSpec, {
+    name: 'A label',
+    role: role,
+  });
+  const label = screen.getByRole(role);
+  expect(label).toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/ui/Label.svelte
+++ b/packages/renderer/src/lib/ui/Label.svelte
@@ -3,10 +3,13 @@ import { Tooltip } from '@podman-desktop/ui-svelte';
 
 export let name = '';
 export let tip = '';
+export let role: string | undefined = undefined;
 </script>
 
 <Tooltip top tip="{tip}">
-  <div class="flex items-center bg-[var(--pd-label-bg)] p-1 rounded-md text-xs text-[var(--pd-label-text)] gap-x-1">
+  <div
+    role="{role}"
+    class="flex items-center bg-[var(--pd-label-bg)] p-1 rounded-md text-xs text-[var(--pd-label-text)] gap-x-1">
     <slot></slot>
     <span class="capitalize">
       {name}

--- a/packages/renderer/src/lib/ui/LabelSpec.svelte
+++ b/packages/renderer/src/lib/ui/LabelSpec.svelte
@@ -4,6 +4,7 @@ import Label from './Label.svelte';
 export let name = '';
 export let tip = '';
 export let slot = '';
+export let role: string | undefined = undefined;
 </script>
 
-<Label tip="{tip}" name="{name}">{slot}</Label>
+<Label tip="{tip}" role="{role}" name="{name}">{slot}</Label>


### PR DESCRIPTION
### What does this PR do?

Use a Label for consistency and light mode support. Adds support for roles to Label so that Kube can continue to set status role.

### Screenshot / video of UI

Before:

<img width="241" alt="Screenshot 2024-06-18 at 11 09 40 AM" src="https://github.com/containers/podman-desktop/assets/19958075/bdc093ad-cddb-4174-aa43-202d3d0239e1">

After:

<img width="241" alt="Screenshot 2024-06-18 at 11 07 24 AM" src="https://github.com/containers/podman-desktop/assets/19958075/09ca8199-2903-4491-a6b5-1f6154c0f4a8">

### What issues does this PR fix or reference?

Fixes #7718.

### How to test this PR?

Go to Pods or any Kubernetes page in light & dark mode.

- [x] Tests are covering the bug fix or the new feature