### PR TITLE
chore: use color var in index.html

### DIFF
--- a/packages/main/src/plugin/color-registry.ts
+++ b/packages/main/src/plugin/color-registry.ts
@@ -228,6 +228,7 @@ export class ColorRegistry {
   }
 
   protected initColors(): void {
+    this.initDefault();
     this.initGlobalNav();
     this.initSecondaryNav();
     this.initTitlebar();
@@ -248,6 +249,16 @@ export class ColorRegistry {
     this.initDropdown();
     this.initLabel();
     this.initStatusColors();
+  }
+
+  protected initDefault(): void {
+    const def = 'default-';
+
+    // Global default colors
+    this.registerColor(`${def}text`, {
+      dark: colorPalette.white,
+      light: colorPalette.charcoal[900],
+    });
   }
 
   protected initGlobalNav(): void {

--- a/packages/renderer/index.html
+++ b/packages/renderer/index.html
@@ -6,8 +6,9 @@
     <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1.0" />
     <title>Podman Desktop</title>
   </head>
-  <body class="overflow-hidden text-white">
+  <body class="overflow-hidden text-[var(--pd-default-text)]">
     <div id="app"></div>
     <script type="module" src="/src/main.ts"></script>
   </body>
 </html>
+ 


### PR DESCRIPTION
### What does this PR do?

We should not hardcode the default text colour to white, especially in light mode. This is the (temporary) cause of many issues like #7708 where we hadn't yet set a light mode color so you get white on light.

We don't have a 'default text color' and none of the existing palette entries fit, so I talked to Emma and decided to create a new variable.

Unfortunately, even though this is a 'correct' change, setting it right now has the reverse problem: anything that is still missing light mode support will see the default text color change from white to dark and have problems on dark backgrounds. A quick test showed the following:

- some forms (#7214)
- #7727
- #7728

So we should not move this out of draft until most of these are fixed, and definitely not immediately before a release. In the meantime, it's handy to set this to something really obvious (e.g. amber) to see what still needs light mode support.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes #7724.

### How to test this PR?

TODO