### PR TITLE
chore: update container summary page UI

### DIFF
--- a/packages/renderer/src/lib/container/ContainerDetailsSummary.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerDetailsSummary.spec.ts
@@ -1,0 +1,114 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/svelte';
+import { expect, test } from 'vitest';
+
+import ContainerDetailsSummary from './ContainerDetailsSummary.svelte';
+import { ContainerGroupInfoTypeUI, type ContainerInfoUI } from './ContainerInfoUI';
+
+const fakePodContainer: ContainerInfoUI = {
+  id: 'fakeId1',
+  shortId: 'FID1',
+  name: 'fakePodContainer',
+  image: 'image1',
+  shortImage: 'img1',
+  engineId: 'Podman.podman',
+  engineName: 'Podman',
+  engineType: 'podman',
+  state: 'RUNNING',
+  uptime: '3 days',
+  startedAt: '2024-06-18T15:17:03.000Z',
+  ports: [],
+  portsAsString: '',
+  displayPort: '',
+  hasPublicPort: false,
+  groupInfo: {
+    name: 'group1',
+    type: ContainerGroupInfoTypeUI.POD,
+    id: 'pod1',
+    engineId: 'Podman.podman',
+    engineName: 'Podman',
+    engineType: 'podman',
+    status: 'RUNNING',
+    created: '2024-06-18T17:39:46.000Z',
+  },
+  selected: false,
+  created: 1234,
+  labels: { label1: 'label1' },
+  imageBase64RepoTag: 'fakeRepoTag',
+};
+
+const fakeStandaloneContainer: ContainerInfoUI = {
+  id: 'fakeId2',
+  shortId: 'FID2',
+  name: 'fakeStandaloneContainer',
+  image: 'image2',
+  shortImage: 'img2',
+  engineId: 'Podman.podman',
+  engineName: 'Podman',
+  engineType: 'podman',
+  state: 'RUNNING',
+  uptime: '3 days',
+  startedAt: '2024-06-18T17:39:46.000Z',
+  ports: [],
+  portsAsString: '',
+  displayPort: '',
+  hasPublicPort: false,
+  groupInfo: {
+    name: 'group2',
+    type: ContainerGroupInfoTypeUI.STANDALONE,
+  },
+  selected: false,
+  created: 1234,
+  labels: {},
+  imageBase64RepoTag: 'fakeRepoTag',
+};
+
+// Test render ContainerDetailsSummary with ContainerInfoUI object with a pod group
+test('ContainerDetailsSummary renders with ContainerInfoUI object with a pod group', async () => {
+  // Render
+  render(ContainerDetailsSummary, { container: fakePodContainer });
+
+  // Check that the rendered text is correct
+  expect(screen.getByText('fakePodContainer')).toBeInTheDocument();
+  expect(screen.getByText('image1')).toBeInTheDocument();
+  expect(screen.getAllByText(new Date(fakePodContainer.startedAt).toString())[0]).toBeInTheDocument();
+  expect(screen.getByText('N/A')).toBeInTheDocument();
+  expect(screen.getByText('pod')).toBeInTheDocument();
+  expect(screen.getAllByText('running')[0]).toBeInTheDocument();
+  expect(screen.getByText('group1')).toBeInTheDocument();
+  expect(screen.getByText('pod1')).toBeInTheDocument();
+});
+
+// Test render ContainerDetailsSummary with standalone ContainerInfoUI object
+test('ContainerDetailsSummary renders with standalone ContainerInfoUI object', async () => {
+  // Render
+  render(ContainerDetailsSummary, { container: fakeStandaloneContainer });
+
+  // Check that the rendered text is correct
+  expect(screen.getByText('fakeStandaloneContainer')).toBeInTheDocument();
+  expect(screen.getByText('image2')).toBeInTheDocument();
+  expect(screen.getByText(new Date(fakeStandaloneContainer.startedAt).toString())).toBeInTheDocument();
+  expect(screen.getByText('N/A')).toBeInTheDocument();
+  expect(screen.getByText('standalone')).toBeInTheDocument();
+  expect(screen.getByText('running')).toBeInTheDocument();
+  expect(screen.getByText('group2')).toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/container/ContainerDetailsSummary.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetailsSummary.svelte
@@ -1,31 +1,140 @@
 <script lang="ts">
+import { faChevronDown, faChevronRight } from '@fortawesome/free-solid-svg-icons';
+import { Link } from '@podman-desktop/ui-svelte';
+import Fa from 'svelte-fa';
+import { router } from 'tinro';
+
+import DetailsCell from '../details/DetailsCell.svelte';
+import DetailsTable from '../details/DetailsTable.svelte';
+import DetailsTitle from '../details/DetailsTitle.svelte';
 import type { ContainerInfoUI } from './ContainerInfoUI';
 
 export let container: ContainerInfoUI;
+let labelsDropdownOpen: boolean = false;
+let startedTime: Date = new Date(container.startedAt);
+let createdTime: Date | undefined;
+if (container.groupInfo.created) {
+  createdTime = new Date(container.groupInfo.created);
+}
 </script>
 
-<div class="flex px-5 py-4 flex-col h-full overflow-auto text-[var(--pd-details-body-text)]">
-  <div class="w-full">
-    <table class="h-2">
-      <tbody>
-        <tr>
-          <td class="pr-2">Id</td>
-          <td>{container.shortId}</td>
-        </tr>
-        <tr class:hidden="{!container.command}">
-          <td class="pr-2">Command</td>
-          <td>{container.command}</td>
-        </tr>
-        <tr>
-          <td class="pr-2">State</td>
-          <td>{container.state}</td>
-        </tr>
-        <tr>
-          <td class="pr-2">Ports</td>
-          <td class:hidden="{container.hasPublicPort}">N/A</td>
-          <td class:hidden="{!container.hasPublicPort}">{container.portsAsString}</td>
-        </tr>
-      </tbody>
-    </table>
-  </div>
-</div>
+<DetailsTable>
+  <tr>
+    <DetailsTitle>Details</DetailsTitle>
+  </tr>
+  <tr>
+    <DetailsCell>Name</DetailsCell>
+    <DetailsCell>{container.name}</DetailsCell>
+  </tr>
+  <tr>
+    <DetailsCell>ID</DetailsCell>
+    <DetailsCell>{container.id}</DetailsCell>
+  </tr>
+  <tr>
+    <DetailsCell>Engine type</DetailsCell>
+    <DetailsCell>{container.engineType}</DetailsCell>
+  </tr>
+  <tr>
+    <DetailsCell>Engine ID</DetailsCell>
+    <DetailsCell>{container.engineId}</DetailsCell>
+  </tr>
+  <tr>
+    <DetailsCell>Image</DetailsCell>
+    <DetailsCell>
+      <Link on:click="{() => router.goto(container.imageHref ?? $router.path)}">{container.image}</Link>
+    </DetailsCell>
+  </tr>
+  {#if container.command}
+    <tr>
+      <DetailsCell>Command</DetailsCell>
+      <DetailsCell>{container.command}</DetailsCell>
+    </tr>
+  {/if}
+  <tr>
+    <DetailsCell>Ports</DetailsCell>
+    {#if container.hasPublicPort}
+      <DetailsCell>{container.portsAsString}</DetailsCell>
+    {:else}
+      <DetailsCell>N/A</DetailsCell>
+    {/if}
+  </tr>
+  <tr>
+    <DetailsCell>State</DetailsCell>
+    <DetailsCell>{container.state.toLowerCase()}</DetailsCell>
+  </tr>
+  <tr>
+    <DetailsCell>Uptime</DetailsCell>
+    <DetailsCell>{container.uptime === '' ? 'N/A' : container.uptime}</DetailsCell>
+  </tr>
+  <tr>
+    <DetailsCell>Started at</DetailsCell>
+    <DetailsCell>{startedTime}</DetailsCell>
+  </tr>
+  {#if Object.entries(container.labels).length > 0}
+    <tr>
+      <DetailsCell
+        style="cursor-pointer flex items-center"
+        onClick="{() => (labelsDropdownOpen = !labelsDropdownOpen)}">
+        Labels
+        <Fa class="ml-1" size="0.9x" icon="{labelsDropdownOpen ? faChevronDown : faChevronRight}" />
+      </DetailsCell>
+      <DetailsCell>
+        {#if labelsDropdownOpen}
+          {#each Object.entries(container.labels) as [key, value]}
+            {key}: {value}
+            <br />
+          {/each}
+        {:else}
+          ...
+        {/if}
+      </DetailsCell>
+    </tr>
+  {/if}
+  <tr>
+    <DetailsTitle>Group</DetailsTitle>
+  </tr>
+  <tr>
+    <DetailsCell>Name</DetailsCell>
+    <DetailsCell>{container.groupInfo.name}</DetailsCell>
+  </tr>
+  <tr>
+    <DetailsCell>Type</DetailsCell>
+    <DetailsCell>{container.groupInfo.type}</DetailsCell>
+  </tr>
+  {#if container.groupInfo.id}
+    <tr>
+      <DetailsCell>Id</DetailsCell>
+      <DetailsCell>{container.groupInfo.id}</DetailsCell>
+    </tr>
+  {/if}
+  {#if container.groupInfo.engineName}
+    <tr>
+      <DetailsCell>Engine name</DetailsCell>
+      <DetailsCell>{container.groupInfo.engineName}</DetailsCell>
+    </tr>
+  {/if}
+  {#if container.groupInfo.engineType}
+    <tr>
+      <DetailsCell>Engine type</DetailsCell>
+      <DetailsCell>{container.groupInfo.engineType}</DetailsCell>
+    </tr>
+  {/if}
+  {#if container.groupInfo.engineId}
+    <tr>
+      <DetailsCell>Engine Id</DetailsCell>
+      <DetailsCell>{container.groupInfo.engineId}</DetailsCell>
+    </tr>
+  {/if}
+  {#if container.groupInfo.status}
+    <tr>
+      <DetailsCell>status</DetailsCell>
+      <DetailsCell>{container.groupInfo.status.toLowerCase()}</DetailsCell>
+    </tr>
+  {/if}
+  {#if createdTime}
+    <tr>
+      <DetailsCell>Created</DetailsCell>
+      <DetailsCell>{createdTime}</DetailsCell>
+    </tr>
+  {/if}
+</DetailsTable>

--- a/tests/playwright/src/model/pages/container-details-page.ts
+++ b/tests/playwright/src/model/pages/container-details-page.ts
@@ -72,7 +72,7 @@ export class ContainerDetailsPage extends BasePage {
 
   async stopContainer(failIfStopped = false): Promise<void> {
     try {
-      await playExpect.poll(async () => await this.getState()).toBe(ContainerState.Running);
+      await playExpect.poll(async () => await this.getState()).toBe(ContainerState.Running.toLowerCase());
       await playExpect(this.stopButton).toBeEnabled();
       await this.stopButton.click();
     } catch (error) {

--- a/tests/playwright/src/model/pages/containers-page.ts
+++ b/tests/playwright/src/model/pages/containers-page.ts
@@ -53,7 +53,7 @@ export class ContainersPage extends MainPage {
     const containerDetailsPage = await this.openContainersDetails(container);
     await playExpect(containerDetailsPage.heading).toBeVisible();
     await playExpect(containerDetailsPage.heading).toContainText(container);
-    playExpect(await containerDetailsPage.getState()).toContain(ContainerState.Running);
+    playExpect(await containerDetailsPage.getState()).toContain(ContainerState.Running.toLowerCase());
     await containerDetailsPage.stopContainer();
     return containerDetailsPage;
   }

--- a/tests/playwright/src/specs/container-smoke.spec.ts
+++ b/tests/playwright/src/specs/container-smoke.spec.ts
@@ -113,7 +113,7 @@ describe('Verification of container creation workflow', async () => {
     const containerDetails = await containers.openContainersDetails(containerToRun);
     await playExpect
       .poll(async () => await containerDetails.getState(), { timeout: 10000 })
-      .toContain(ContainerState.Running);
+      .toContain(ContainerState.Running.toLowerCase());
 
     images = await navigationBar.openImages();
     playExpect(await images.getCurrentStatusOfImage(imageToPull)).toBe('USED');
@@ -128,7 +128,7 @@ describe('Verification of container creation workflow', async () => {
     // test state of container in summary tab
     await pdRunner.screenshot('containers-container-details.png');
     const containerState = await containersDetails.getState();
-    playExpect(containerState).toContain(ContainerState.Running);
+    playExpect(containerState).toContain(ContainerState.Running.toLowerCase());
     // check Logs output
     await containersDetails.activateTab('Logs');
     const helloWorldMessage = containersDetails.getPage().getByText('No Log');
@@ -147,11 +147,11 @@ describe('Verification of container creation workflow', async () => {
     await playExpect(containersDetails.heading).toBeVisible();
     await playExpect(containersDetails.heading).toContainText(containerToRun);
     // test state of container in summary tab
-    playExpect(await containersDetails.getState()).toContain(ContainerState.Running);
+    playExpect(await containersDetails.getState()).toContain(ContainerState.Running.toLowerCase());
     await containersDetails.stopContainer();
     try {
-      await waitUntil(async () => (await containersDetails.getState()) === ContainerState.Exited, 15000);
-      await playExpect(await containersDetails.getStateLocator()).toHaveText(ContainerState.Exited);
+      await waitUntil(async () => (await containersDetails.getState()) === ContainerState.Exited.toLowerCase(), 15000);
+      await playExpect(await containersDetails.getStateLocator()).toHaveText(ContainerState.Exited.toLowerCase());
     } catch (error) {
       await pdRunner.screenshot('containers--container-stop-failed.png');
       throw error;
@@ -187,7 +187,9 @@ describe('Verification of container creation workflow', async () => {
     for (const container of containerList) {
       let containersPage = new ContainersPage(page);
       const containersDetails = await containersPage.stopContainer(container);
-      await playExpect(await containersDetails.getStateLocator()).toHaveText(ContainerState.Exited, { timeout: 20000 });
+      await playExpect(await containersDetails.getStateLocator()).toHaveText(ContainerState.Exited.toLowerCase(), {
+        timeout: 20000,
+      });
       containersPage = await navigationBar.openContainers();
       await playExpect(containersPage.heading).toBeVisible();
       await containersPage.pruneContainers();

--- a/tests/playwright/src/specs/pod-smoke.spec.ts
+++ b/tests/playwright/src/specs/pod-smoke.spec.ts
@@ -124,7 +124,7 @@ describe.skipIf(process.env.GITHUB_ACTIONS && process.env.RUNNER_OS === 'Linux')
       let containerDetails = await containers.openContainersDetails(backendContainer);
       await playExpect
         .poll(async () => await containerDetails.getState(), { timeout: 15000 })
-        .toBe(ContainerState.Running);
+        .toBe(ContainerState.Running.toLowerCase());
       await waitUntil(async () => {
         backendPort = await containerDetails.getContainerPort();
         return backendPort.includes('6379');
@@ -146,7 +146,7 @@ describe.skipIf(process.env.GITHUB_ACTIONS && process.env.RUNNER_OS === 'Linux')
       playExpect(frontendPort).toContain(expectedPort);
       await playExpect
         .poll(async () => await containerDetails.getState(), { timeout: 15000 })
-        .toBe(ContainerState.Running);
+        .toBe(ContainerState.Running.toLowerCase());
     });
 
     test('Podify containers', async () => {
@@ -182,12 +182,12 @@ describe.skipIf(process.env.GITHUB_ACTIONS && process.env.RUNNER_OS === 'Linux')
       const backendContainerDetails = await containers.openContainersDetails(backendContainer);
       await playExpect
         .poll(async () => await backendContainerDetails.getState(), { timeout: 15000 })
-        .toBe(ContainerState.Exited);
+        .toBe(ContainerState.Exited.toLowerCase());
       await navigationBar.openContainers();
       const frontendContainerDetails = await containers.openContainersDetails(frontendContainer);
       await playExpect
         .poll(async () => await frontendContainerDetails.getState(), { timeout: 15000 })
-        .toBe(ContainerState.Exited);
+        .toBe(ContainerState.Exited.toLowerCase());
     });
 
     test('Checking pods page options buttons', async () => {


### PR DESCRIPTION

### What does this PR do?

Changes the UI of the summary page of containers to match other summary pages

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->
![Screenshot from 2024-06-18 17-41-39](https://github.com/containers/podman-desktop/assets/66797193/61d2e147-b11e-44b0-ab6e-762b9254f34f)

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop/issues/7560

### How to test this PR?

<!-- Please explain steps to verify the functionality, do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature

View the summary page of a container
