### PR TITLE
fix(UI): formpage missing content shadow

### DIFF
--- a/packages/ui/src/lib/layouts/FormPage.svelte
+++ b/packages/ui/src/lib/layouts/FormPage.svelte
@@ -34,7 +34,7 @@ function handleKeydown(e: KeyboardEvent): void {
 
 <svelte:window on:keydown="{handleKeydown}" />
 
-<div class="flex flex-col w-full h-full shadow-pageheader">
+<div class="flex flex-col w-full h-full shadow-pageheader bg-[var(--pd-content-bg)]">
   <div class="flex flex-row w-full h-fit px-5 pt-4" class:pb-3.5="{inProgress}" class:pb-4="{!inProgress}">
     <div class="flex flex-col w-full h-fit">
       {#if showBreadcrumb}
@@ -75,11 +75,11 @@ function handleKeydown(e: KeyboardEvent): void {
     <LinearProgress />
   {/if}
   {#if $$slots.tabs}
-    <div class="flex flex-row px-2 border-b border-[var(--pd-content-divider)]">
+    <div class="flex flex-row px-2">
       <slot name="tabs" />
     </div>
   {/if}
-  <div class="flex w-full h-full bg-[var(--pd-content-bg)] overflow-auto">
+  <div class="flex w-full h-full overflow-auto">
     <slot name="content" />
   </div>
 </div>


### PR DESCRIPTION
### What does this PR do?

As suggested by @deboer-tim in https://github.com/containers/podman-desktop/issues/7549#issuecomment-2176511633 since we are using a single color for the header and the content, removing the border and moving up the bg-color to avoid hidden the shadow

### Screenshot / video of UI

| Before | After |
| --- | --- |
|  ![image](https://github.com/containers/podman-desktop/assets/42176370/47abb750-c6f9-4209-9272-82b4cbc635ce) | ![image](https://github.com/containers/podman-desktop/assets/42176370/738c6ee0-bfd8-4149-83e6-ee2e46b9a5e3) |

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop/issues/7549

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
