### PR TITLE
hotfix(Modal): adding margin top 

### DIFF
--- a/packages/ui/src/lib/modal/Modal.spec.ts
+++ b/packages/ui/src/lib/modal/Modal.spec.ts
@@ -59,6 +59,7 @@ describe('translation-y', () => {
 
     const dialog = screen.getByRole('dialog');
     expect(dialog.classList).toContain('translate-y-[-20%]');
+    expect(dialog.classList).not.toContain('my-[32px]');
   });
 
   test('modal with top should not have translate-y', async () => {
@@ -66,5 +67,7 @@ describe('translation-y', () => {
 
     const dialog = screen.getByRole('dialog');
     expect(dialog.classList).not.toContain('translate-y-[-20%]');
+    // should contain margin of size status bar height
+    expect(dialog.classList).toContain('my-[32px]');
   });
 });

--- a/packages/ui/src/lib/modal/Modal.svelte
+++ b/packages/ui/src/lib/modal/Modal.svelte
@@ -40,6 +40,7 @@ if (previously_focused) {
 
   <div
     class:translate-y-[-20%]="{!top}"
+    class:my-[32px]="{top}"
     class="bg-[var(--pd-modal-bg)] z-50 rounded-xl overflow-auto w-[calc(200vw-4em)] h-fit max-w-[42em] max-h-[calc(100vh-4em)] border-[1px] border-[var(--pd-modal-border)]"
     role="dialog"
     aria-label="{name}"


### PR DESCRIPTION
### What does this PR do?

Adding a margin top to the Modal when `top` property is defined. The `32px` correspond to the size of the status bar of the application. 

### Explanation

We are using a custom status bar for podman desktop, when we use `position: fixed` it uses full space available 

https://github.com/containers/podman-desktop/blob/60601dcc85ba56cef535f964f59e6eda6088094e/packages/ui/src/lib/modal/Modal.svelte#L35

![image](https://github.com/containers/podman-desktop/assets/42176370/7f04d463-c412-41ea-9aae-524e72c0c49d)

This hotfix, is simply adding a margin top to the modal corresponding to the size of status bar.

### Screenshot / video of UI
| Before | After |
| --- | --- |
| ![image](https://github.com/containers/podman-desktop/assets/42176370/35528874-39c9-41ce-91e7-bc760fa3009e) | ![image](https://github.com/containers/podman-desktop/assets/42176370/634254b3-c53a-4bd4-87cd-0a865fb81967) |

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop/issues/7737

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature

cc @deboer-tim 