### PR TITLE
chore: light more for connection details summary/edit

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesContainerConnectionDetailsSummary.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesContainerConnectionDetailsSummary.svelte
@@ -35,7 +35,7 @@ $: providerContainerConfiguration = tmpProviderContainerConfiguration.filter(
 );
 </script>
 
-<div class="h-full bg-zinc-900">
+<div class="h-full text-[var(--pd-table-body-text)]">
   {#if containerConnectionInfo}
     {@const peerProperties = new PeerProperties()}
     <div class="flex pl-8 py-4 flex-col w-full text-sm">

--- a/packages/renderer/src/lib/preferences/PreferencesContainerConnectionEdit.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesContainerConnectionEdit.svelte
@@ -55,14 +55,14 @@ async function editConnection(
 
 {#if providerInfo && connectionInfo}
   <DetailsPage title="{connectionInfo.name}">
-    <svelte:fragment slot="content">
+    <div slot="content" class="text-[var(--pd-content-text)]">
       <PreferencesConnectionCreationRendering
         providerInfo="{providerInfo}"
         connectionInfo="{connectionInfo}"
         properties="{properties}"
         propertyScope="{scope}"
         callback="{editConnection}" />
-    </svelte:fragment>
+    </div>
     <IconImage slot="icon" image="{providerInfo?.images?.icon}" alt="{providerInfo?.name}" class="max-h-10" />
     <svelte:fragment slot="subtitle">
       {#if connectionInfo.status === 'started'}

--- a/packages/renderer/src/lib/preferences/PreferencesContainerConnectionRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesContainerConnectionRendering.svelte
@@ -136,53 +136,51 @@ function setNoLogs() {
 </script>
 
 {#if connectionInfo}
-  <div class="bg-charcoal-700 h-full">
-    <DetailsPage title="{connectionInfo.name}" bind:this="{detailsPage}">
-      <svelte:fragment slot="subtitle">
-        <div class="flex flex-row">
-          <ConnectionStatus status="{connectionInfo.status}" />
-          <ConnectionErrorInfoButton status="{connectionStatus}" />
+  <DetailsPage title="{connectionInfo.name}" bind:this="{detailsPage}">
+    <svelte:fragment slot="subtitle">
+      <div class="flex flex-row">
+        <ConnectionStatus status="{connectionInfo.status}" />
+        <ConnectionErrorInfoButton status="{connectionStatus}" />
+      </div>
+    </svelte:fragment>
+    <svelte:fragment slot="actions">
+      {#if providerInfo}
+        <div class="flex justify-end">
+          <PreferencesConnectionActions
+            provider="{providerInfo}"
+            connection="{connectionInfo}"
+            connectionStatus="{connectionStatus}"
+            updateConnectionStatus="{updateConnectionStatus}"
+            addConnectionToRestartingQueue="{addConnectionToRestartingQueue}" />
         </div>
-      </svelte:fragment>
-      <svelte:fragment slot="actions">
-        {#if providerInfo}
-          <div class="flex justify-end">
-            <PreferencesConnectionActions
-              provider="{providerInfo}"
-              connection="{connectionInfo}"
-              connectionStatus="{connectionStatus}"
-              updateConnectionStatus="{updateConnectionStatus}"
-              addConnectionToRestartingQueue="{addConnectionToRestartingQueue}" />
-          </div>
-        {/if}
-      </svelte:fragment>
-      <IconImage slot="icon" image="{providerInfo?.images?.icon}" alt="{providerInfo?.name}" class="max-h-10" />
-      <svelte:fragment slot="tabs">
-        <Tab
-          title="Summary"
-          selected="{isTabSelected($router.path, 'summary')}"
-          url="{getTabUrl($router.path, 'summary')}" />
-        {#if connectionInfo.lifecycleMethods && connectionInfo.lifecycleMethods.length > 0}
-          <Tab title="Logs" selected="{isTabSelected($router.path, 'logs')}" url="{getTabUrl($router.path, 'logs')}" />
-        {/if}
-      </svelte:fragment>
-      <svelte:fragment slot="content">
-        <div class="h-full">
-          <Route path="/summary" breadcrumb="Summary" navigationHint="tab">
-            <PreferencesContainerConnectionDetailsSummary
-              containerConnectionInfo="{connectionInfo}"
-              providerInternalId="{providerInternalId}"
-              properties="{configurationKeys}" />
-          </Route>
-          <Route path="/logs" breadcrumb="Logs" navigationHint="tab">
-            <PreferencesConnectionDetailsLogs
-              providerInternalId="{providerInternalId}"
-              connectionInfo="{connectionInfo}"
-              setNoLogs="{setNoLogs}"
-              noLog="{noLog}" />
-          </Route>
-        </div>
-      </svelte:fragment>
-    </DetailsPage>
-  </div>
+      {/if}
+    </svelte:fragment>
+    <IconImage slot="icon" image="{providerInfo?.images?.icon}" alt="{providerInfo?.name}" class="max-h-10" />
+    <svelte:fragment slot="tabs">
+      <Tab
+        title="Summary"
+        selected="{isTabSelected($router.path, 'summary')}"
+        url="{getTabUrl($router.path, 'summary')}" />
+      {#if connectionInfo.lifecycleMethods && connectionInfo.lifecycleMethods.length > 0}
+        <Tab title="Logs" selected="{isTabSelected($router.path, 'logs')}" url="{getTabUrl($router.path, 'logs')}" />
+      {/if}
+    </svelte:fragment>
+    <svelte:fragment slot="content">
+      <div class="h-full">
+        <Route path="/summary" breadcrumb="Summary" navigationHint="tab">
+          <PreferencesContainerConnectionDetailsSummary
+            containerConnectionInfo="{connectionInfo}"
+            providerInternalId="{providerInternalId}"
+            properties="{configurationKeys}" />
+        </Route>
+        <Route path="/logs" breadcrumb="Logs" navigationHint="tab">
+          <PreferencesConnectionDetailsLogs
+            providerInternalId="{providerInternalId}"
+            connectionInfo="{connectionInfo}"
+            setNoLogs="{setNoLogs}"
+            noLog="{noLog}" />
+        </Route>
+      </div>
+    </svelte:fragment>
+  </DetailsPage>
 {/if}

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesConnectionDetailsSummary.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesConnectionDetailsSummary.svelte
@@ -32,7 +32,7 @@ $: providerConnectionConfiguration = tmpProviderContainerConfiguration.filter(
 );
 </script>
 
-<div class="h-full bg-zinc-900">
+<div class="h-full text-[var(--pd-table-body-text)]">
   {#if kubernetesConnectionInfo}
     <div class="flex pl-8 py-4 flex-col w-full text-sm">
       <div class="flex flex-row mt-5">

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesConnectionRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesConnectionRendering.svelte
@@ -132,55 +132,53 @@ function setNoLogs() {
 </script>
 
 {#if connectionInfo}
-  <div class="bg-charcoal-700 h-full">
-    <DetailsPage title="{connectionInfo.name}" bind:this="{detailsPage}">
-      <svelte:fragment slot="subtitle">
-        <div class="flex flex-row">
-          <ConnectionStatus status="{connectionInfo.status}" />
-          <ConnectionErrorInfoButton status="{connectionStatus}" />
+  <DetailsPage title="{connectionInfo.name}" bind:this="{detailsPage}">
+    <svelte:fragment slot="subtitle">
+      <div class="flex flex-row">
+        <ConnectionStatus status="{connectionInfo.status}" />
+        <ConnectionErrorInfoButton status="{connectionStatus}" />
+      </div>
+    </svelte:fragment>
+    <svelte:fragment slot="actions">
+      {#if providerInfo}
+        <div class="flex justify-end">
+          <PreferencesConnectionActions
+            provider="{providerInfo}"
+            connection="{connectionInfo}"
+            connectionStatus="{connectionStatus}"
+            updateConnectionStatus="{updateConnectionStatus}"
+            addConnectionToRestartingQueue="{addConnectionToRestartingQueue}" />
         </div>
-      </svelte:fragment>
-      <svelte:fragment slot="actions">
-        {#if providerInfo}
-          <div class="flex justify-end">
-            <PreferencesConnectionActions
-              provider="{providerInfo}"
-              connection="{connectionInfo}"
-              connectionStatus="{connectionStatus}"
-              updateConnectionStatus="{updateConnectionStatus}"
-              addConnectionToRestartingQueue="{addConnectionToRestartingQueue}" />
-          </div>
-        {/if}
-      </svelte:fragment>
-      <svelte:fragment slot="icon">
-        <IconImage image="{providerInfo?.images?.icon}" alt="{providerInfo?.name}" class="max-h-10" />
-      </svelte:fragment>
-      <svelte:fragment slot="tabs">
-        <Tab
-          title="Summary"
-          selected="{isTabSelected($router.path, 'summary')}"
-          url="{getTabUrl($router.path, 'summary')}" />
-        {#if connectionInfo.lifecycleMethods && connectionInfo.lifecycleMethods.length > 0}
-          <Tab title="Logs" selected="{isTabSelected($router.path, 'logs')}" url="{getTabUrl($router.path, 'logs')}" />
-        {/if}
-      </svelte:fragment>
-      <svelte:fragment slot="content">
-        <div class="h-full">
-          <Route path="/summary" breadcrumb="Summary" navigationHint="tab">
-            <PreferencesKubernetesConnectionDetailsSummary
-              kubernetesConnectionInfo="{connectionInfo}"
-              providerInternalId="{providerInternalId}"
-              properties="{configurationKeys}" />
-          </Route>
-          <Route path="/logs" breadcrumb="Logs" navigationHint="tab">
-            <PreferencesConnectionDetailsLogs
-              providerInternalId="{providerInternalId}"
-              connectionInfo="{connectionInfo}"
-              setNoLogs="{setNoLogs}"
-              noLog="{noLog}" />
-          </Route>
-        </div>
-      </svelte:fragment>
-    </DetailsPage>
-  </div>
+      {/if}
+    </svelte:fragment>
+    <svelte:fragment slot="icon">
+      <IconImage image="{providerInfo?.images?.icon}" alt="{providerInfo?.name}" class="max-h-10" />
+    </svelte:fragment>
+    <svelte:fragment slot="tabs">
+      <Tab
+        title="Summary"
+        selected="{isTabSelected($router.path, 'summary')}"
+        url="{getTabUrl($router.path, 'summary')}" />
+      {#if connectionInfo.lifecycleMethods && connectionInfo.lifecycleMethods.length > 0}
+        <Tab title="Logs" selected="{isTabSelected($router.path, 'logs')}" url="{getTabUrl($router.path, 'logs')}" />
+      {/if}
+    </svelte:fragment>
+    <svelte:fragment slot="content">
+      <div class="h-full">
+        <Route path="/summary" breadcrumb="Summary" navigationHint="tab">
+          <PreferencesKubernetesConnectionDetailsSummary
+            kubernetesConnectionInfo="{connectionInfo}"
+            providerInternalId="{providerInternalId}"
+            properties="{configurationKeys}" />
+        </Route>
+        <Route path="/logs" breadcrumb="Logs" navigationHint="tab">
+          <PreferencesConnectionDetailsLogs
+            providerInternalId="{providerInternalId}"
+            connectionInfo="{connectionInfo}"
+            setNoLogs="{setNoLogs}"
+            noLog="{noLog}" />
+        </Route>
+      </div>
+    </svelte:fragment>
+  </DetailsPage>
 {/if}


### PR DESCRIPTION
### What does this PR do?

Initial light mode support for container and Kubernetes details screens.

Just removed two hardcoded dark mode colors: charcoal header and zinc summary page. Set the same text color as other Summary pages to make the text visible.

For editing there is no great place to set the text color until #7214 and #7547 are in, so for now the text color is set 'manually' using a div.

### Screenshot / video of UI

Before:

<img width="358" alt="Screenshot 2024-06-19 at 12 14 13 PM" src="https://github.com/containers/podman-desktop/assets/19958075/0ea93bdc-25aa-4d70-b529-0865d3d2c780">

<img width="358" alt="Screenshot 2024-06-19 at 12 26 50 PM" src="https://github.com/containers/podman-desktop/assets/19958075/1894a377-0934-4222-aa9f-a08bdc19a12a">

After:

<img width="358" alt="Screenshot 2024-06-19 at 12 09 40 PM" src="https://github.com/containers/podman-desktop/assets/19958075/9f217fb0-cf8e-49b1-9ff3-f4bb0409c123">

<img width="358" alt="Screenshot 2024-06-19 at 12 23 30 PM" src="https://github.com/containers/podman-desktop/assets/19958075/53820e0a-0f7a-4b00-a0a2-7fbdf15cc0ac">

### What issues does this PR fix or reference?

Fixes #7731.

### How to test this PR?

Check connection summary and editing, and Kubernetes summary.