### PR TITLE
chore: fix auth file registry removal

### DIFF
--- a/packages/main/src/plugin/extension-loader.spec.ts
+++ b/packages/main/src/plugin/extension-loader.spec.ts
@@ -129,7 +129,9 @@ const configurationRegistry: ConfigurationRegistry = {
   updateConfigurationValue: configurationRegistryUpdateConfigurationMock,
 } as unknown as ConfigurationRegistry;
 
-const imageRegistry: ImageRegistry = {} as unknown as ImageRegistry;
+const imageRegistry: ImageRegistry = {
+  registerRegistry: vi.fn(),
+} as unknown as ImageRegistry;
 
 const apiSender: ApiSenderType = { send: vi.fn() } as unknown as ApiSenderType;
 
@@ -2206,4 +2208,23 @@ test('load extensions sequentially', async () => {
   expect(loadExtensionMock.mock.calls[0][0]).toBe(analyzedExtension1);
   expect(loadExtensionMock.mock.calls[1][0]).toBe(analyzedExtension2);
   expect(loadExtensionMock.mock.calls[2][0]).toBe(analyzedExtension3);
+});
+
+test('when loading registry registerRegistry, do not push to disposables', async () => {
+  const disposables: IDisposable[] = [];
+
+  const api = extensionLoader.createApi('/path', {}, disposables);
+  expect(api).toBeDefined();
+
+  const fakeRegistry = {
+    source: 'fake',
+    serverUrl: 'http://fake',
+    username: 'foo',
+    password: 'bar',
+    secret: 'baz',
+  };
+
+  api.registry.registerRegistry(fakeRegistry);
+
+  expect(disposables.length).toBe(0);
 });

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -888,9 +888,7 @@ export class ExtensionLoader {
     const imageRegistry = this.imageRegistry;
     const registry: typeof containerDesktopAPI.registry = {
       registerRegistry: (registry: containerDesktopAPI.Registry): Disposable => {
-        const registration = imageRegistry.registerRegistry(registry);
-        disposables.push(registration);
-        return registration;
+        return imageRegistry.registerRegistry(registry);
       },
 
       suggestRegistry: (registry: containerDesktopAPI.RegistrySuggestedProvider): Disposable => {


### PR DESCRIPTION
chore: fix auth file registry removal

### What does this PR do?

Removes the dispose for registerRegistry which was causing an unregister
on shut down resulting in the auth file deletion.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/lA

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop/issues/7742

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
