### PR TITLE
feat: enable lightmode on multiple form pages

### DIFF
--- a/packages/main/src/plugin/color-registry.ts
+++ b/packages/main/src/plugin/color-registry.ts
@@ -248,6 +248,7 @@ export class ColorRegistry {
     this.initDropdown();
     this.initLabel();
     this.initStatusColors();
+    this.initFormPage();
   }
 
   protected initGlobalNav(): void {
@@ -1044,10 +1045,15 @@ export class ColorRegistry {
 
   protected initDropdown(): void {
     const dropdown = 'dropdown-';
+    const select = 'select-';
 
     this.registerColor(`${dropdown}bg`, {
       dark: colorPalette.charcoal[600],
       light: colorPalette.gray[100],
+    });
+    this.registerColor(`${select}bg`, {
+      dark: colorPalette.charcoal[800],
+      light: colorPalette.gray[300],
     });
     this.registerColor(`${dropdown}ring`, {
       dark: colorPalette.purple[900],
@@ -1171,6 +1177,29 @@ export class ColorRegistry {
     this.registerColor(`${status}updated`, {
       dark: colorPalette.sky[500],
       light: colorPalette.sky[500],
+    });
+    this.registerColor(`${status}ready`, {
+      dark: colorPalette.gray[900],
+      light: colorPalette.gray[100],
+    });
+  }
+
+  protected initFormPage(): void {
+    const formPage = 'formpage-';
+
+    this.registerColor(`${formPage}bg`, {
+      dark: colorPalette.charcoal[900],
+      light: colorPalette.gray[50],
+    });
+
+    this.registerColor(`${formPage}card-bg`, {
+      dark: colorPalette.charcoal[800],
+      light: colorPalette.gray[300],
+    });
+
+    this.registerColor(`${formPage}card-text`, {
+      dark: colorPalette.gray[400],
+      light: colorPalette.purple[900],
     });
   }
 }

--- a/packages/renderer/src/lib/container/ContainerExport.svelte
+++ b/packages/renderer/src/lib/container/ContainerExport.svelte
@@ -90,7 +90,8 @@ async function exportContainer() {
 
     <div slot="content" class="space-y-2">
       <div>
-        <label for="modalSelectTarget" class="block mb-2 text-sm font-medium text-gray-400">Export to:</label>
+        <label for="modalSelectTarget" class="block mb-2 text-sm font-medium text-[var(--pd-label-text)]"
+          >Export to:</label>
         <div class="flex w-full">
           <Input
             class="grow mr-2"

--- a/packages/renderer/src/lib/image/ImportContainersImages.svelte
+++ b/packages/renderer/src/lib/image/ImportContainersImages.svelte
@@ -113,10 +113,10 @@ async function importContainers() {
   </svelte:fragment>
   <div slot="content" class="space-y-2">
     {#if providerConnections.length > 1}
-      <label for="providerChoice" class="py-6 block mb-2 text-sm font-bold text-gray-400"
+      <label for="providerChoice" class="py-6 block mb-2 text-sm font-bold text-[var(--pd-label-text)]"
         >Container Engine
         <select
-          class="w-full p-2 outline-none text-sm bg-charcoal-600 rounded-sm text-gray-700 placeholder-gray-700"
+          class="w-full p-2 outline-none text-sm bg-[var(--pd-select-bg)] rounded-sm text-[var(--pd-content-text)]"
           name="providerChoice"
           id="providerChoice"
           bind:value="{selectedProvider}">
@@ -127,12 +127,12 @@ async function importContainers() {
       </label>
     {/if}
 
-    <label for="modalContainersImport" class="pt-4 block mb-2 text-sm font-medium text-gray-400"
+    <label for="modalContainersImport" class="block mb-2 text-sm font-medium text-[var(--pd-label-text)]"
       >Containers to import:</label>
     <Button on:click="{addContainersToImport}" icon="{faPlusCircle}" type="link">Add images to import</Button>
     <!-- Display the list of existing containersToImport -->
     {#if containersToImport.length > 0}
-      <div class="flex flex-row justify-center w-full py-1 text-sm font-medium text-gray-400">
+      <div class="flex flex-row justify-center w-full py-1 text-sm font-medium text-[var(--pd-content-text)]">
         <div class="flex flex-col grow pl-2">Image Path</div>
         <div class="flex flex-col w-2/4 mr-2.5">Image Name when importing (e.g quay.io/podman/hello)</div>
       </div>

--- a/packages/renderer/src/lib/image/LoadImages.svelte
+++ b/packages/renderer/src/lib/image/LoadImages.svelte
@@ -92,10 +92,10 @@ async function loadImages() {
   </svelte:fragment>
   <div slot="content" class="space-y-2">
     {#if providerConnections.length > 1}
-      <label for="providerChoice" class="pt-6 block text-sm font-bold text-gray-400"
+      <label for="providerChoice" class="pt-6 block text-sm font-bold text-[var(--pd-label-text)]"
         >Container Engine
         <select
-          class="w-full p-2 outline-none text-sm bg-charcoal-600 rounded-sm text-gray-700 placeholder-gray-700"
+          class="w-full p-2 outline-none text-sm bg-[var(--pd-select-bg)] rounded-sm text-[var(--pd-content-text)]"
           name="providerChoice"
           id="providerChoice"
           bind:value="{selectedProvider}">
@@ -109,7 +109,7 @@ async function loadImages() {
     <Button on:click="{addArchivesToLoad}" icon="{faPlusCircle}" type="link">Add archive</Button>
     <!-- Display the list of existing imagesToLoad -->
     {#if archivesToLoad.length > 0}
-      <div class="flex flex-row justify-center w-full py-1 text-sm font-medium text-gray-400">
+      <div class="flex flex-row justify-center w-full py-1 text-sm font-medium text-[var(--pd-content-text)]">
         <div class="flex flex-col grow pl-2">Image Archives</div>
       </div>
     {/if}

--- a/packages/renderer/src/lib/image/PullImage.svelte
+++ b/packages/renderer/src/lib/image/PullImage.svelte
@@ -148,10 +148,10 @@ function requestFocus(element: HTMLInputElement) {
 
   <div slot="content" class="space-y-6">
     <div class="w-full">
-      <label for="imageName" class="block mb-2 text-sm font-bold text-gray-400">Image to Pull</label>
+      <label for="imageName" class="block mb-2 text-sm font-bold text-[var(--pd-label-text)]">Image to Pull</label>
       <input
         id="imageName"
-        class="w-full p-2 outline-none text-sm bg-charcoal-600 rounded-sm text-gray-700 placeholder-gray-700"
+        class="w-full p-2 outline-none text-sm bg-[var(--pd-select-bg)] rounded-sm text-[var(--pd-content-text)] placeholder:text-[color:var(--pd-input-field-placeholder-text)]"
         type="text"
         name="imageName"
         disabled="{pullFinished || pullInProgress}"
@@ -173,18 +173,17 @@ function requestFocus(element: HTMLInputElement) {
 
       {#if providerConnections.length > 1}
         <div class="pt-4">
-          <div class="block mb-2 text-sm font-bold text-gray-400">
-            <label for="providerChoice">Container Engine:</label>
-            <select
-              id="providerChoice"
-              class="w-auto border text-sm rounded-lg focus:ring-purple-500 focus:border-purple-500 block p-2.5 bg-gray-900 border-gray-900 placeholder-gray-700 text-white"
-              name="providerChoice"
-              bind:value="{selectedProviderConnection}">
-              {#each providerConnections as providerConnection}
-                <option value="{providerConnection}">{providerConnection.name}</option>
-              {/each}
-            </select>
-          </div>
+          <label for="providerChoice" class="block mb-2 text-sm font-bold text-[var(--pd-label-text)]"
+            >Container Engine:</label>
+          <select
+            id="providerChoice"
+            class="w-auto border text-sm rounded-lg focus:ring-purple-500 focus:border-purple-500 block p-2.5 bg-[var(--pd-select-bg)] rounded-sm text-[var(--pd-content-text)]"
+            name="providerChoice"
+            bind:value="{selectedProviderConnection}">
+            {#each providerConnections as providerConnection}
+              <option value="{providerConnection}">{providerConnection.name}</option>
+            {/each}
+          </select>
         </div>
       {/if}
       {#if providerConnections.length === 1}

--- a/packages/renderer/src/lib/image/RunImage.svelte
+++ b/packages/renderer/src/lib/image/RunImage.svelte
@@ -649,7 +649,7 @@ async function assertAllPortAreValid(): Promise<void> {
         <div>
           <Route path="/basic" breadcrumb="Basic" navigationHint="tab">
             <div class="h-96 overflow-y-auto pr-4">
-              <label for="modalContainerName" class="block mb-2 text-sm font-medium text-gray-400"
+              <label for="modalContainerName" class="block mb-2 text-sm font-medium text-[var(--pd-label-text)]"
                 >Container name:</label>
               <Input
                 on:input="{event => checkContainerName(event)}"
@@ -658,11 +658,14 @@ async function assertAllPortAreValid(): Promise<void> {
                 id="modalContainerName"
                 placeholder="Leave blank to generate a name"
                 error="{containerNameError}" />
-              <label for="modalEntrypoint" class="pt-4 block mb-2 text-sm font-medium text-gray-400">Entrypoint:</label>
+              <label for="modalEntrypoint" class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-label-text)]"
+                >Entrypoint:</label>
               <Input bind:value="{entrypoint}" name="modalEntrypoint" id="modalEntrypoint" />
-              <label for="modalCommand" class="pt-4 block mb-2 text-sm font-medium text-gray-400">Command:</label>
+              <label for="modalCommand" class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-label-text)]"
+                >Command:</label>
               <Input bind:value="{command}" name="modalCommand" id="modalCommand" />
-              <label for="volumes" class="pt-4 block mb-2 text-sm font-medium text-gray-400">Volumes:</label>
+              <label for="volumes" class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-label-text)]"
+                >Volumes:</label>
               <!-- Display the list of volumes -->
               {#each volumeMounts as volumeMount, index}
                 <div class="flex flex-row justify-center items-center w-full py-1">
@@ -687,11 +690,11 @@ async function assertAllPortAreValid(): Promise<void> {
               {/each}
 
               <!-- add a label for each port-->
-              <label for="modalContainerName" class="pt-4 block mb-2 text-sm font-medium text-gray-400"
+              <label for="modalContainerName" class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-label-text)]"
                 >Port mapping:</label>
               {#each exposedPorts as port, index}
                 <div class="flex flex-row justify-center items-center w-full">
-                  <span class="text-sm flex-1 inline-block align-middle whitespace-nowrap text-gray-700"
+                  <span class="text-sm flex-1 inline-block align-middle whitespace-nowrap text-[var(--pd-content-text)]"
                     >Local port for {port}:</span>
                   <Input
                     bind:value="{containerPortMapping[index].port}"
@@ -724,8 +727,9 @@ async function assertAllPortAreValid(): Promise<void> {
                   <Button type="link" on:click="{() => deleteHostContainerPorts(index)}" icon="{faMinusCircle}" />
                 </div>
               {/each}
-              <label for="modalEnvironmentVariables" class="pt-4 block mb-2 text-sm font-medium text-gray-400"
-                >Environment variables:</label>
+              <label
+                for="modalEnvironmentVariables"
+                class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-label-text)]">Environment variables:</label>
               <!-- Display the list of existing environment variables -->
               {#each environmentVariables as environmentVariable, index}
                 <div class="flex flex-row justify-center items-center w-full py-1">
@@ -748,7 +752,7 @@ async function assertAllPortAreValid(): Promise<void> {
                 </div>
               {/each}
 
-              <label for="modalEnvironmentFiles" class="pt-4 block mb-2 text-sm font-medium text-gray-400"
+              <label for="modalEnvironmentFiles" class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-label-text)]"
                 >Environment files:</label>
               <!-- Display the list of existing environment files -->
               {#each environmentFiles as environmentFile, index}
@@ -784,8 +788,9 @@ async function assertAllPortAreValid(): Promise<void> {
           <Route path="/advanced" breadcrumb="Advanced" navigationHint="tab">
             <div class="h-96 overflow-y-auto pr-4">
               <!-- Use tty -->
-              <label for="containerTty" class="block mb-2 text-sm font-medium text-gray-400">Use TTY:</label>
-              <div class="flex flex-col text-gray-700 text-sm ml-2">
+              <label for="containerTty" class="block mb-2 text-sm font-medium text-[var(--pd-label-text)]"
+                >Use TTY:</label>
+              <div class="flex flex-col text-[var(--pd-content-text)] text-sm ml-2">
                 <Checkbox bind:checked="{useTty}" title="Attach a pseudo terminal">Attach a pseudo terminal</Checkbox>
                 <Checkbox bind:checked="{useInteractive}" title="Use interactive">
                   Interactive: Keep STDIN open even if not attached
@@ -793,7 +798,7 @@ async function assertAllPortAreValid(): Promise<void> {
               </div>
 
               <!-- Specify user-->
-              <label for="containerUser" class="pt-4 block mb-2 text-sm font-medium text-gray-400"
+              <label for="containerUser" class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-label-text)]"
                 >Specify user to run container as:</label>
               <div class="flex flex-row justify-center items-center w-full">
                 <Input
@@ -803,20 +808,22 @@ async function assertAllPortAreValid(): Promise<void> {
               </div>
 
               <!-- Autoremove-->
-              <label for="containerAutoRemove" class="pt-4 block mb-2 text-sm font-medium text-gray-400"
+              <label for="containerAutoRemove" class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-label-text)]"
                 >Auto removal of container:</label>
-              <Checkbox class="text-gray-700 text-sm ml-2" bind:checked="{autoRemove}">
+              <Checkbox class="text-[var(--pd-content-text)] text-sm ml-2" bind:checked="{autoRemove}">
                 Automatically remove the container when the process exits
               </Checkbox>
 
               <!-- RestartPolicy-->
-              <label for="containerRestartPolicy" class="pt-4 block mb-2 text-sm font-medium text-gray-400"
-                >Restart policy:</label>
-              <div class="p-0 flex flex-row justify-start items-center align-middle w-full text-gray-700">
-                <span class="text-sm w-28 inline-block align-middle whitespace-nowrap text-gray-700">Policy name:</span>
+              <label
+                for="containerRestartPolicy"
+                class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-label-text)]">Restart policy:</label>
+              <div
+                class="p-0 flex flex-row justify-start items-center align-middle w-full text-[var(--pd-content-text)]">
+                <span class="text-sm w-28 inline-block align-middle whitespace-nowrap">Policy name:</span>
 
                 <select
-                  class="w-full p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700"
+                  class="w-full p-2 outline-none text-sm bg-[var(--pd-select-bg)] rounded-sm"
                   name="restartPolicyName"
                   bind:value="{restartPolicyName}">
                   <option value="">No restart</option>
@@ -832,7 +839,7 @@ async function assertAllPortAreValid(): Promise<void> {
                   ? 'opacity-100'
                   : 'opacity-20'}">
                 <span
-                  class="text-sm w-28 inline-block align-middle whitespace-nowrap text-gray-700"
+                  class="text-sm w-28 inline-block align-middle whitespace-nowrap text-[var(--pd-content-text)]"
                   title="Number of times to retry before giving up.">Retries:</span>
                 <NumberInput
                   minimum="{0}"
@@ -846,19 +853,22 @@ async function assertAllPortAreValid(): Promise<void> {
           <Route path="/security" breadcrumb="Security" navigationHint="tab">
             <div class="h-96 overflow-y-auto pr-4">
               <!-- Privileged-->
-              <label for="containerPrivileged" class="block mb-2 text-sm font-medium text-gray-400">Privileged:</label>
-              <Checkbox bind:checked="{privileged}" class="text-gray-700 text-sm mx-2">
+              <label for="containerPrivileged" class="block mb-2 text-sm font-medium text-[var(--pd-label-text)]"
+                >Privileged:</label>
+              <Checkbox bind:checked="{privileged}" class="text-[var(--pd-content-text)] text-sm mx-2">
                 Turn off security<i class="pl-1 fas fa-exclamation-triangle"></i>
               </Checkbox>
 
               <!-- Read-Only -->
-              <label for="containerReadOnly" class="pt-4 block mb-2 text-sm font-medium text-gray-400"
+              <label for="containerReadOnly" class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-label-text)]"
                 >Read only:</label>
-              <Checkbox bind:checked="{readOnly}" class="text-gray-700 text-sm mx-2">
+              <Checkbox bind:checked="{readOnly}" class="text-[var(--pd-content-text)] text-sm mx-2">
                 Make containers root filesystem read-only
               </Checkbox>
 
-              <label for="ContainerSecurityOptions" class="pt-4 block mb-2 text-sm font-medium text-gray-400"
+              <label
+                for="ContainerSecurityOptions"
+                class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-label-text)]"
                 >Security options (security-opt):</label>
               <!-- Display the list of existing security options -->
               {#each securityOpts as securityOpt, index}
@@ -881,12 +891,14 @@ async function assertAllPortAreValid(): Promise<void> {
                 </div>
               {/each}
 
-              <label for="ContainerSecurityCapabilitiesAdd" class="pt-4 block mb-2 text-sm font-medium text-gray-400"
-                >Capabilities:</label>
+              <label
+                for="ContainerSecurityCapabilitiesAdd"
+                class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-label-text)]">Capabilities:</label>
 
               <label
                 for="ContainerSecurityCapabilitiesAdd"
-                class="pl-4 pt-2 block mb-2 text-sm font-medium text-gray-400">Add to the container (CapAdd):</label>
+                class="pl-4 pt-2 block mb-2 text-sm font-medium text-[var(--pd-label-text)]"
+                >Add to the container (CapAdd):</label>
               <!-- Display the list of existing capAdd -->
               {#each capAdds as capAdd, index}
                 <div class="flex flex-row justify-center items-center w-full py-1">
@@ -906,7 +918,7 @@ async function assertAllPortAreValid(): Promise<void> {
               {/each}
               <label
                 for="ContainerSecurityCapabilitiesDrop"
-                class="pl-4 pt-2 block mb-2 text-sm font-medium text-gray-400"
+                class="pl-4 pt-2 block mb-2 text-sm font-medium text-[var(--pd-label-text)]"
                 >Drop from the container (CapDrop):</label>
               <!-- Display the list of existing capDrop -->
               {#each capDrops as capDrop, index}
@@ -927,7 +939,9 @@ async function assertAllPortAreValid(): Promise<void> {
               {/each}
 
               <!-- Specify user namespace-->
-              <label for="containerUserNamespace" class="pt-4 block mb-2 text-sm font-medium text-gray-400"
+              <label
+                for="containerUserNamespace"
+                class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-label-text)]"
                 >Specify user namespace to use:</label>
               <div class="flex flex-row justify-center items-center w-full">
                 <Input bind:value="{userNamespace}" placeholder="Enter a user namespace" class="ml-2 w-full" />
@@ -938,14 +952,14 @@ async function assertAllPortAreValid(): Promise<void> {
           <Route path="/networking" breadcrumb="Networking" navigationHint="tab">
             <div class="h-96 overflow-y-auto pr-4">
               <!-- hostname-->
-              <label for="containerHostname" class="block mb-2 text-sm font-medium text-gray-400"
+              <label for="containerHostname" class="block mb-2 text-sm font-medium text-[var(--pd-label-text)]"
                 >Defines container hostname:</label>
               <div class="flex flex-row justify-center items-center w-full">
                 <Input bind:value="{hostname}" placeholder="Must be a valid RFC 1123 hostname" class="ml-2" />
               </div>
 
               <!-- DNS -->
-              <label for="ContainerDns" class="pt-4 block mb-2 text-sm font-medium text-gray-400"
+              <label for="ContainerDns" class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-label-text)]"
                 >Custom DNS server(s):</label>
 
               {#each dnsServers as dnsServer, index}
@@ -965,7 +979,7 @@ async function assertAllPortAreValid(): Promise<void> {
                 </div>
               {/each}
 
-              <label for="containerExtraHosts" class="pt-4 block mb-2 text-sm font-medium text-gray-400"
+              <label for="containerExtraHosts" class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-label-text)]"
                 >Add extra hosts (appends to /etc/hosts file):</label>
               <!-- Display the list of extra hosts -->
               {#each extraHosts as extraHost, index}
@@ -987,13 +1001,14 @@ async function assertAllPortAreValid(): Promise<void> {
               {/each}
 
               <!-- Select network -->
-              <label for="containerNetwork" class="pt-4 block mb-2 text-sm font-medium text-gray-400"
+              <label for="containerNetwork" class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-label-text)]"
                 >Select container networking:</label>
-              <div class="p-0 flex flex-row justify-start items-center align-middle w-full text-gray-700">
-                <span class="text-sm w-28 inline-block align-middle whitespace-nowrap text-gray-700">Mode:</span>
+              <div
+                class="p-0 flex flex-row justify-start items-center align-middle w-full text-[var(--pd-content-text)]">
+                <span class="text-sm w-28 inline-block align-middle whitespace-nowrap">Mode:</span>
 
                 <select
-                  class="w-full p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700"
+                  class="w-full p-2 outline-none text-sm bg-[var(--pd-select-bg)] rounded-sm"
                   name="providerChoice"
                   bind:value="{networkingMode}">
                   <option value="bridge">Creates a network stack on the default bridge (default)</option>
@@ -1007,9 +1022,10 @@ async function assertAllPortAreValid(): Promise<void> {
 
               {#if networkingMode === 'choice-network'}
                 <div class="flex flex-row justify-center items-center w-full py-1">
-                  <span class="text-sm w-28 inline-block align-middle whitespace-nowrap text-gray-700">Network:</span>
+                  <span class="text-sm w-28 inline-block align-middle whitespace-nowrap text-[var(--pd-content-text)]"
+                    >Network:</span>
                   <select
-                    class="w-full p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700"
+                    class="w-full p-2 outline-none text-sm bg-[var(--pd-select-bg)] rounded-sm text-[var(--pd-content-text)]"
                     disabled="{networkingMode !== 'choice-network'}"
                     name="networkingModeUserNetwork"
                     bind:value="{networkingModeUserNetwork}">
@@ -1022,9 +1038,10 @@ async function assertAllPortAreValid(): Promise<void> {
               {/if}
               {#if networkingMode === 'choice-container'}
                 <div class="flex flex-row justify-center items-center w-full py-1">
-                  <span class="text-sm w-28 inline-block align-middle whitespace-nowrap text-gray-700">Container:</span>
+                  <span class="text-sm w-28 inline-block align-middle whitespace-nowrap text-[var(--pd-content-text)]"
+                    >Container:</span>
                   <select
-                    class="w-full p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700"
+                    class="w-full p-2 outline-none text-sm bg-[var(--pd-select-bg)] rounded-sm text-[var(--pd-content-text)]"
                     disabled="{networkingMode !== 'choice-container'}"
                     name="networkingModeUserContainer"
                     bind:value="{networkingModeUserContainer}">

--- a/packages/renderer/src/lib/image/SaveImages.svelte
+++ b/packages/renderer/src/lib/image/SaveImages.svelte
@@ -134,7 +134,8 @@ async function saveImages() {
       <i class="fas fa-play fa-2x" aria-hidden="true"></i>
     </svelte:fragment>
     <div slot="content" class="space-y-2">
-      <label for="modalSelectTarget" class="block mb-2 text-sm font-medium text-gray-400">Export to:</label>
+      <label for="modalSelectTarget" class="block mb-2 text-sm font-medium text-[var(--pd-label-text)]"
+        >Export to:</label>
       <div class="flex w-full">
         <Input
           class="grow mr-2"
@@ -150,7 +151,7 @@ async function saveImages() {
 
       {#if !singleItemMode && imagesToSave.length > 0}
         <!-- Display the list of images to save -->
-        <div class="flex flex-row justify-center w-full pt-5 text-sm font-medium text-gray-400">
+        <div class="flex flex-row justify-center w-full pt-5 text-sm font-medium text-[var(--pd-label-text)]">
           <div class="flex flex-col grow">Images to save</div>
         </div>
         {#each imagesToSave as imageToSave, index}

--- a/packages/renderer/src/lib/pod/DeployPodToKube.svelte
+++ b/packages/renderer/src/lib/pod/DeployPodToKube.svelte
@@ -391,16 +391,17 @@ function updateKubeResult() {
 
     {#if bodyPod}
       <div class="pt-2 pb-4">
-        <label for="contextToUse" class="block mb-1 text-sm font-medium text-gray-400">Pod Name:</label>
+        <label for="contextToUse" class="block mb-1 text-sm font-medium text-[var(--pd-label-text)]">Pod Name:</label>
         <Input bind:value="{bodyPod.metadata.name}" name="podName" id="podName" class="w-full" required />
       </div>
     {/if}
 
     <div class="pt-2 pb-4">
-      <label for="services" class="block mb-1 text-sm font-medium text-gray-300">Kubernetes Services:</label>
+      <label for="services" class="block mb-1 text-sm font-medium text-[var(--pd-label-text)]"
+        >Kubernetes Services:</label>
       <Checkbox
         bind:checked="{deployUsingServices}"
-        class="text-gray-400 text-sm ml-1"
+        class="text-[var(--pd-content-text)] text-sm ml-1"
         name="useServices"
         id="useServices"
         required>
@@ -409,11 +410,11 @@ function updateKubeResult() {
     </div>
 
     <div class="pt-2 pb-4">
-      <label for="useRestricted" class="block mb-1 text-sm font-medium text-gray-300"
+      <label for="useRestricted" class="block mb-1 text-sm font-medium text-[var(--pd-label-text)]"
         >Restricted Security Context:</label>
       <Checkbox
         bind:checked="{deployUsingRestrictedSecurityContext}"
-        class="text-gray-400 text-sm ml-1"
+        class="text-[var(--pd-content-text)] text-sm ml-1"
         name="useRestricted"
         id="useRestricted"
         title="Use restricted security context"
@@ -428,11 +429,11 @@ function updateKubeResult() {
     <!-- Only show for non-OpenShift deployments (we use routes for OpenShift) -->
     {#if !openshiftRouteGroupSupported && deployUsingServices}
       <div class="pt-2 pb-4">
-        <label for="createIngress" class="block mb-1 text-sm font-medium text-gray-300"
+        <label for="createIngress" class="block mb-1 text-sm font-medium text-[var(--pd-label-text)]"
           >Expose Service Locally Using Kubernetes Ingress:</label>
         <Checkbox
           bind:checked="{createIngress}"
-          class="text-gray-300 text-sm ml-1"
+          class="text-[var(--pd-content-text)] text-sm ml-1"
           name="createIngress"
           id="createIngress"
           title="Create Ingress"
@@ -445,19 +446,20 @@ function updateKubeResult() {
 
     {#if createIngress && containerPortArray.length > 1}
       <div class="pt-2 pb-4">
-        <label for="ingress" class="block mb-1 text-sm font-medium text-gray-300">Ingress Host Port:</label>
+        <label for="ingress" class="block mb-1 text-sm font-medium text-[var(--pd-label-text)]"
+          >Ingress Host Port:</label>
         <select
           bind:value="{ingressPort}"
           name="serviceName"
           id="serviceName"
-          class=" cursor-default w-full p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-400 placeholder-gray-400"
+          class=" cursor-default w-full p-2 outline-none text-sm bg-[var(--pd-select-bg)] rounded-sm text-[var(--pd-content-text)]"
           required>
           <option value="" disabled selected>Select a port</option>
           {#each containerPortArray as port}
             <option value="{port}">{port}</option>
           {/each}
         </select>
-        <span class="text-gray-300 text-sm ml-1"
+        <span class="text-[var(--pd-content-text)] text-sm ml-1"
           >There are multiple exposed ports available. Select the one you want to expose to '/' with the Ingress.
         </span>
       </div>
@@ -465,11 +467,12 @@ function updateKubeResult() {
 
     <!-- Allow to create routes for OpenShift clusters -->
     {#if openshiftRouteGroupSupported}
-      <div class="pt-2 m-2">
-        <label for="routes" class="block mb-1 text-sm font-medium text-gray-400">Create OpenShift routes:</label>
+      <div class="pt-2">
+        <label for="routes" class="block mb-1 text-sm font-medium text-[var(--pd-label-text)]"
+          >Create OpenShift routes:</label>
         <Checkbox
           bind:checked="{deployUsingRoutes}"
-          class="text-gray-400 text-sm ml-1"
+          class="text-[var(--pd-content-text)] text-sm ml-1"
           name="useRoutes"
           id="useRoutes"
           required>
@@ -479,7 +482,8 @@ function updateKubeResult() {
 
     {#if defaultContextName}
       <div class="pt-2">
-        <label for="contextToUse" class="block mb-1 text-sm font-medium text-gray-400">Kubernetes Context:</label>
+        <label for="contextToUse" class="block mb-1 text-sm font-medium text-[var(--pd-label-text)]"
+          >Kubernetes Context:</label>
         <Input
           bind:value="{defaultContextName}"
           name="defaultContextName"
@@ -492,9 +496,10 @@ function updateKubeResult() {
 
     {#if allNamespaces}
       <div class="pt-2">
-        <label for="namespaceToUse" class="block mb-1 text-sm font-medium text-gray-400">Kubernetes Namespace:</label>
+        <label for="namespaceToUse" class="block mb-1 text-sm font-medium text-[var(--pd-label-text)]"
+          >Kubernetes Namespace:</label>
         <select
-          class="w-full p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700"
+          class="w-full p-2 outline-none text-sm bg-[var(--pd-select-bg)] rounded-sm text-[var(--pd-content-text)]"
           name="namespaceChoice"
           bind:value="{currentNamespace}">
           {#each allNamespaces.items as namespace}
@@ -536,7 +541,7 @@ function updateKubeResult() {
             </div>
           {/if}
         </div>
-        <div class="text-gray-700">
+        <div class="text-[var(--pd-content-text)]">
           {#if createdPod.metadata?.name}
             <p class="pt-2">Name: {createdPod.metadata.name}</p>
           {/if}
@@ -551,18 +556,18 @@ function updateKubeResult() {
                 <li class="pt-2">
                   {containerStatus.name}
                   {#if containerStatus.ready}
-                    <span class="text-gray-900">Ready</span>
+                    <span class="text-[var(--pd-status-ready)]">Ready</span>
                   {/if}
                   {#if containerStatus.state?.running}
-                    <span class="text-green-400">(Running)</span>
+                    <span class="text-[var(--pd-status-running)]">(Running)</span>
                   {/if}
                   {#if containerStatus.state?.terminated}
-                    <span class="text-red-500">(Terminated)</span>
+                    <span class="text-[var(--pd-status-terminated)]">(Terminated)</span>
                   {/if}
                   {#if containerStatus.state?.waiting}
-                    <span class="text-amber-500">(Waiting)</span>
+                    <span class="text-[var(--pd-status-waiting)]">(Waiting)</span>
                     {#if containerStatus.state.waiting.reason}
-                      <span class="text-amber-500">[{containerStatus.state.waiting.reason}]</span>
+                      <span class="text-[var(--pd-status-waiting)]">[{containerStatus.state.waiting.reason}]</span>
                     {/if}
                   {/if}
                 </li>

--- a/packages/renderer/src/lib/pod/PodCreateFromContainers.svelte
+++ b/packages/renderer/src/lib/pod/PodCreateFromContainers.svelte
@@ -229,7 +229,7 @@ function updatePortExposure(port: number, checked: boolean) {
           </div>
         {/if}
         <div class="mb-2">
-          <span class="block text-sm font-semibold rounded text-gray-400">Name of the pod:</span>
+          <span class="block text-sm font-semibold rounded text-[var(--pd-label-text)]">Name of the pod:</span>
         </div>
         <div class="mb-4">
           <Input
@@ -238,17 +238,16 @@ function updatePortExposure(port: number, checked: boolean) {
             bind:value="{podCreation.name}"
             placeholder="Select name of the pod..."
             aria-label="Pod name"
-            class="w-full mt-1"
             required />
         </div>
 
         <div class="mb-2">
-          <span class="block text-sm font-semibold rounded text-gray-400" aria-label="Containers"
+          <span class="block text-sm font-semibold rounded text-[var(--pd-label-text)]" aria-label="Containers"
             >Containers to replicate to the pod:</span>
         </div>
-        <div class="w-full bg-charcoal-800 mb-4 max-h-40 overflow-y-auto">
+        <div class="w-full bg-[var(--pd-formpage-card-bg)] mb-4 max-h-40 overflow-y-auto">
           {#each podCreation.containers as container, index}
-            <div class="p-2 flex flex-row items-center text-gray-700">
+            <div class="p-2 flex flex-row items-center text-[var(--pd-formpage-card-text)]">
               <div class="w-10"><StatusIcon icon="{ContainerIcon}" status="STOPPED" /></div>
               <div class="w-16 pl-3">{index + 1}.</div>
               <div class="grow">{container.name}</div>
@@ -259,12 +258,12 @@ function updatePortExposure(port: number, checked: boolean) {
 
         {#if mapPortExposed.size > 0}
           <div class="mb-2">
-            <span class="block text-sm font-semibold rounded text-gray-400" aria-label="Exposed ports"
+            <span class="block text-sm font-semibold rounded text-[var(--pd-label-text)]" aria-label="Exposed ports"
               >All selected ports will be exposed:</span>
           </div>
-          <div class="bg-charcoal-800 mb-4 max-h-40 overflow-y-auto">
+          <div class="bg-[var(--pd-formpage-card-bg)] mb-4 max-h-40 overflow-y-auto">
             {#each [...mapPortExposed] as [port, value]}
-              <div class="p-2 flex flex-row align-items text-gray-700">
+              <div class="p-2 flex flex-row align-items text-[var(--pd-formpage-card-text)]">
                 <input
                   type="checkbox"
                   class="mr-5"
@@ -280,28 +279,23 @@ function updatePortExposure(port: number, checked: boolean) {
         {/if}
       {/if}
 
-      <div>
-        {#if providerConnections.length > 1}
-          <label
-            for="providerConnectionName"
-            class="p-2 block mb-2 text-sm font-medium rounded bg-zinc-700 text-gray-300"
-            >Container Engine
-            <select
-              class="w-full p-2 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-400 placeholder-gray-400"
-              name="providerChoice"
-              bind:value="{selectedProvider}">
-              {#each providerConnections as providerConnection}
-                <option value="{providerConnection}">{providerConnection.name}</option>
-              {/each}
-            </select>
-          </label>
-        {/if}
-        {#if providerConnections.length === 1 && selectedProviderConnection?.name}
-          <input type="hidden" name="providerChoice" readonly bind:value="{selectedProviderConnection.name}" />
-        {/if}
-      </div>
+      {#if providerConnections.length > 1}
+        <label for="providerConnectionName" class="block mb-2 text-sm font-medium rounded text-[var(--pd-label-text)]"
+          >Container Engine</label>
+        <select
+          class="w-full p-2 outline-none text-sm bg-[var(--pd-select-bg)] rounded-sm text-[var(--pd-content-text)]"
+          name="providerChoice"
+          bind:value="{selectedProvider}">
+          {#each providerConnections as providerConnection}
+            <option value="{providerConnection}">{providerConnection.name}</option>
+          {/each}
+        </select>
+      {/if}
+      {#if providerConnections.length === 1 && selectedProviderConnection?.name}
+        <input type="hidden" name="providerChoice" readonly bind:value="{selectedProviderConnection.name}" />
+      {/if}
 
-      <div class="w-full grid justify-items-end">
+      <div class="w-full grid justify-items-end mt-5">
         <div>
           <Button type="link" on:click="{() => router.goto('/containers')}">Close</Button>
           <Button

--- a/packages/renderer/src/lib/ui/EngineFormPage.svelte
+++ b/packages/renderer/src/lib/ui/EngineFormPage.svelte
@@ -17,7 +17,7 @@ export let showEmptyScreen: boolean = false;
       {#if showEmptyScreen}
         <NoContainerEngineEmptyScreen />
       {:else}
-        <div class="bg-charcoal-900 p-6 space-y-2 lg:p-8 rounded-lg">
+        <div class="bg-[var(--pd-formpage-bg)] p-6 space-y-2 lg:p-8 rounded-lg">
           <slot name="content" />
         </div>
       {/if}

--- a/packages/renderer/src/lib/volume/CreateVolume.svelte
+++ b/packages/renderer/src/lib/volume/CreateVolume.svelte
@@ -61,22 +61,16 @@ export let volumeName = '';
   </svelte:fragment>
   <div slot="content" class="space-y-6">
     <div>
-      <label for="containerBuildContextDirectory" class="block mb-2 text-sm font-bold text-gray-400"
+      <label for="containerBuildContextDirectory" class="block mb-2 text-sm font-bold text-[var(--pd-label-text)]"
         >Volume name:</label>
-      <Input
-        clearable
-        aria-label="Volume Name"
-        disabled="{createVolumeFinished}"
-        bind:value="{volumeName}"
-        class="w-full"
-        required />
+      <Input clearable aria-label="Volume Name" disabled="{createVolumeFinished}" bind:value="{volumeName}" required />
     </div>
     <div class:hidden="{providerConnections.length < 2}">
       {#if providerConnections.length > 1}
-        <label for="providerChoice" class="py-3 block mb-2 text-sm font-bold text-gray-400"
+        <label for="providerChoice" class="py-3 block mb-2 text-sm font-bold text-[var(--pd-label-text)]"
           >Container Engine
           <select
-            class="w-full p-2 outline-none text-sm bg-charcoal-600 rounded-sm text-gray-700 placeholder-gray-700"
+            class="w-full p-2 outline-none text-sm bg-[var(--pd-select-bg)] rounded-sm text-[var(--pd-content-text)]"
             aria-label="Provider Choice"
             disabled="{createVolumeFinished}"
             bind:value="{selectedProvider}">


### PR DESCRIPTION
### What does this PR do?

This PR adds light mode to almost all form pages. There are pages that are not here bc they are a bit more complex and it would be easier to review them separately. All you find here required basic changes and most of them have similar design.

### Screenshot / video of UI

i won't include any screenshot as they are a lot, it's more convenient you check them manually by running desktop.

### What issues does this PR fix or reference?

it is part of #7214 

### How to test this PR?

The pages to verify:

1. `ExportContainer`: go to containers page -> click on the "three vertical dots" icon of a container -> export container
2. `ImportImage`: go to the images page -> click on import (top right)
3. `LoadImages`: go to the images page -> click on load(top right)
4. `PullImage`: go to the images page -> click on pull(top right)
5. `RunImage`:  go to the images page -> click on the start action of an image
6. `SaveImages`: go to images page -> click on the "three vertical dots" icon of an image-> save image
7. `DeployToKube`: go to the pods page -> click on the "three vertical dots" icon of an image-> deploy to kube
8. `PodCreateFromContainers`: go to containers page -> select 2 or more containers -> click on `create pod` on the top
9. `CreateVolume`: go to volumes page -> click on create (top right)



- [x] Tests are covering the bug fix or the new feature
