### PR TITLE
feat: enable light mode for buildImageFromContainerfile page

### DIFF
--- a/packages/main/src/plugin/color-registry.ts
+++ b/packages/main/src/plugin/color-registry.ts
@@ -464,7 +464,7 @@ export class ColorRegistry {
 
     this.registerColor(`${ct}card-header-text`, {
       dark: colorPalette.gray[100],
-      light: colorPalette.charcoal[900],
+      light: colorPalette.purple[900],
     });
 
     this.registerColor(`${ct}card-bg`, {
@@ -495,6 +495,11 @@ export class ColorRegistry {
     this.registerColor(`${ct}card-inset-bg`, {
       dark: colorPalette.charcoal[900],
       light: colorPalette.dustypurple[200],
+    });
+
+    this.registerColor(`${ct}card-hover-inset-bg`, {
+      dark: colorPalette.charcoal[700],
+      light: colorPalette.dustypurple[300],
     });
 
     this.registerColor(`${ct}bg`, {
@@ -545,6 +550,16 @@ export class ColorRegistry {
     this.registerColor(`${ct}card-carousel-disabled-nav`, {
       dark: colorPalette.charcoal[700],
       light: colorPalette.gray[200],
+    });
+
+    this.registerColor(`${ct}card-border`, {
+      dark: colorPalette.charcoal[700],
+      light: colorPalette.gray[200],
+    });
+
+    this.registerColor(`${ct}card-border-selected`, {
+      dark: colorPalette.dustypurple[700],
+      light: colorPalette.purple[600],
     });
   }
 
@@ -1187,44 +1202,14 @@ export class ColorRegistry {
   protected initFormPage(): void {
     const formPage = 'formpage-';
 
-    this.registerColor(`${formPage}bg`, {
-      dark: colorPalette.charcoal[900],
-      light: colorPalette.gray[50],
-    });
-
     this.registerColor(`${formPage}card-bg`, {
       dark: colorPalette.charcoal[800],
       light: colorPalette.gray[300],
     });
 
-    this.registerColor(`${formPage}card-bg-hover`, {
-      dark: colorPalette.charcoal[500],
-      light: colorPalette.gray[500],
-    });
-
     this.registerColor(`${formPage}card-text`, {
       dark: colorPalette.gray[400],
       light: colorPalette.purple[900],
-    });
-
-    this.registerColor(`${formPage}card-border`, {
-      dark: colorPalette.charcoal[700],
-      light: colorPalette.gray[200],
-    });
-
-    this.registerColor(`${formPage}card-border-selected`, {
-      dark: colorPalette.dustypurple[700],
-      light: colorPalette.purple[600],
-    });
-
-    this.registerColor(`${formPage}badge-border`, {
-      dark: colorPalette.gray[700],
-      light: colorPalette.gray[900],
-    });
-
-    this.registerColor(`${formPage}card-input-bg`, {
-      dark: colorPalette.charcoal[400],
-      light: colorPalette.gray[50],
     });
   }
 }

--- a/packages/main/src/plugin/color-registry.ts
+++ b/packages/main/src/plugin/color-registry.ts
@@ -1197,9 +1197,34 @@ export class ColorRegistry {
       light: colorPalette.gray[300],
     });
 
+    this.registerColor(`${formPage}card-bg-hover`, {
+      dark: colorPalette.charcoal[500],
+      light: colorPalette.gray[500],
+    });
+
     this.registerColor(`${formPage}card-text`, {
       dark: colorPalette.gray[400],
       light: colorPalette.purple[900],
+    });
+
+    this.registerColor(`${formPage}card-border`, {
+      dark: colorPalette.charcoal[700],
+      light: colorPalette.gray[200],
+    });
+
+    this.registerColor(`${formPage}card-border-selected`, {
+      dark: colorPalette.dustypurple[700],
+      light: colorPalette.purple[600],
+    });
+
+    this.registerColor(`${formPage}badge-border`, {
+      dark: colorPalette.gray[700],
+      light: colorPalette.gray[900],
+    });
+
+    this.registerColor(`${formPage}card-input-bg`, {
+      dark: colorPalette.charcoal[400],
+      light: colorPalette.gray[50],
     });
   }
 }

--- a/packages/renderer/src/lib/image/BuildImageFromContainerfile.svelte
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfile.svelte
@@ -301,7 +301,7 @@ async function abortBuild() {
   </svelte:fragment>
   <div slot="content" class="space-y-6">
     <div hidden="{buildImageInfo?.buildRunning}">
-      <label for="containerFilePath" class="block mb-2 text-sm font-bold text-[var(--pd-label-text)]"
+      <label for="containerFilePath" class="block mb-2 text-sm font-bold text-[var(--pd-content-card-header-text)]"
         >Containerfile path</label>
       <div class="flex flex-row space-x-3">
         <Input
@@ -316,8 +316,9 @@ async function abortBuild() {
     </div>
 
     <div hidden="{buildImageInfo?.buildRunning}">
-      <label for="containerBuildContextDirectory" class="block mb-2 text-sm font-bold text-[var(--pd-label-text)]"
-        >Build context directory</label>
+      <label
+        for="containerBuildContextDirectory"
+        class="block mb-2 text-sm font-bold text-[var(--pd-content-card-header-text)]">Build context directory</label>
       <div class="flex flex-row space-x-3">
         <Input
           name="containerBuildContextDirectory"
@@ -331,7 +332,7 @@ async function abortBuild() {
     </div>
 
     <div hidden="{buildImageInfo?.buildRunning}">
-      <label for="containerImageName" class="block mb-2 text-sm font-bold text-[var(--pd-label-text)]"
+      <label for="containerImageName" class="block mb-2 text-sm font-bold text-[var(--pd-content-card-header-text)]"
         >Image name</label>
       <Input
         bind:value="{containerImageName}"
@@ -341,7 +342,7 @@ async function abortBuild() {
         class="w-full"
         required />
       {#if providerConnections.length > 1}
-        <label for="providerChoice" class="py-6 block mb-2 text-sm font-bold text-[var(--pd-label-text)]"
+        <label for="providerChoice" class="py-6 block mb-2 text-sm font-bold text-[var(--pd-content-card-header-text)]"
           >Container Engine
           <select
             class="w-full p-2 outline-none text-sm bg-[var(--pd-select-bg)] rounded-sm text-[var(--pd-content-text)]"
@@ -356,7 +357,8 @@ async function abortBuild() {
       {/if}
     </div>
     <div hidden="{buildImageInfo?.buildRunning}">
-      <label for="inputKey" class="block mb-2 text-sm font-bold text-[var(--pd-label-text)]">Build arguments</label>
+      <label for="inputKey" class="block mb-2 text-sm font-bold text-[var(--pd-content-card-header-text)]"
+        >Build arguments</label>
       {#each buildArgs as buildArg, index}
         <div class="flex flex-row items-center space-x-2 mb-2">
           <Input bind:value="{buildArg.key}" name="inputKey" placeholder="Key" class="flex-grow" required />
@@ -372,7 +374,7 @@ async function abortBuild() {
     </div>
 
     <div hidden="{buildImageInfo?.buildRunning}">
-      <label for="containerBuildPlatform" class="block mb-2 text-sm font-bold text-[var(--pd-label-text)]"
+      <label for="containerBuildPlatform" class="block mb-2 text-sm font-bold text-[var(--pd-content-card-header-text)]"
         >Platform</label>
       {#if platforms.length > 1}
         <p class="text-sm text-[var(--pd-content-text)] mb-2">

--- a/packages/renderer/src/lib/image/BuildImageFromContainerfile.svelte
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfile.svelte
@@ -301,7 +301,8 @@ async function abortBuild() {
   </svelte:fragment>
   <div slot="content" class="space-y-6">
     <div hidden="{buildImageInfo?.buildRunning}">
-      <label for="containerFilePath" class="block mb-2 text-sm font-bold text-gray-400">Containerfile path</label>
+      <label for="containerFilePath" class="block mb-2 text-sm font-bold text-[var(--pd-label-text)]"
+        >Containerfile path</label>
       <div class="flex flex-row space-x-3">
         <Input
           name="containerFilePath"
@@ -315,7 +316,7 @@ async function abortBuild() {
     </div>
 
     <div hidden="{buildImageInfo?.buildRunning}">
-      <label for="containerBuildContextDirectory" class="block mb-2 text-sm font-bold text-gray-400"
+      <label for="containerBuildContextDirectory" class="block mb-2 text-sm font-bold text-[var(--pd-label-text)]"
         >Build context directory</label>
       <div class="flex flex-row space-x-3">
         <Input
@@ -330,7 +331,8 @@ async function abortBuild() {
     </div>
 
     <div hidden="{buildImageInfo?.buildRunning}">
-      <label for="containerImageName" class="block mb-2 text-sm font-bold text-gray-400">Image name</label>
+      <label for="containerImageName" class="block mb-2 text-sm font-bold text-[var(--pd-label-text)]"
+        >Image name</label>
       <Input
         bind:value="{containerImageName}"
         name="containerImageName"
@@ -339,10 +341,10 @@ async function abortBuild() {
         class="w-full"
         required />
       {#if providerConnections.length > 1}
-        <label for="providerChoice" class="py-6 block mb-2 text-sm font-bold text-gray-400"
+        <label for="providerChoice" class="py-6 block mb-2 text-sm font-bold text-[var(--pd-label-text)]"
           >Container Engine
           <select
-            class="w-full p-2 outline-none text-sm bg-charcoal-600 rounded-sm text-gray-700 placeholder-gray-700"
+            class="w-full p-2 outline-none text-sm bg-[var(--pd-select-bg)] rounded-sm text-[var(--pd-content-text)]"
             name="providerChoice"
             id="providerChoice"
             bind:value="{selectedProvider}">
@@ -354,7 +356,7 @@ async function abortBuild() {
       {/if}
     </div>
     <div hidden="{buildImageInfo?.buildRunning}">
-      <label for="inputKey" class="block mb-2 text-sm font-bold text-gray-400">Build arguments</label>
+      <label for="inputKey" class="block mb-2 text-sm font-bold text-[var(--pd-label-text)]">Build arguments</label>
       {#each buildArgs as buildArg, index}
         <div class="flex flex-row items-center space-x-2 mb-2">
           <Input bind:value="{buildArg.key}" name="inputKey" placeholder="Key" class="flex-grow" required />
@@ -370,9 +372,12 @@ async function abortBuild() {
     </div>
 
     <div hidden="{buildImageInfo?.buildRunning}">
-      <label for="containerBuildPlatform" class="block mb-2 text-sm font-bold text-gray-400">Platform</label>
+      <label for="containerBuildPlatform" class="block mb-2 text-sm font-bold text-[var(--pd-label-text)]"
+        >Platform</label>
       {#if platforms.length > 1}
-        <p class="text-sm text-gray-600 mb-2">Multiple platforms selected, a manifest will be created</p>
+        <p class="text-sm text-[var(--pd-content-text)] mb-2">
+          Multiple platforms selected, a manifest will be created
+        </p>
       {/if}
       <BuildImageFromContainerfileCards bind:platforms="{containerBuildPlatform}" />
     </div>

--- a/packages/renderer/src/lib/image/BuildImageFromContainerfileCard.svelte
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfileCard.svelte
@@ -75,9 +75,9 @@ onMount(() => {
 </script>
 
 <button
-  class="rounded-md bg-charcoal-700 p-2 min-w-48 w-48 min-h-24 cursor-pointer hover:bg-charcoal-500 {checked
-    ? 'border-dustypurple-700'
-    : 'border-charcoal-700'} border-2 flex flex-col"
+  class="rounded-md bg-[var(--pd-formpage-card-bg)] p-2 min-w-48 w-48 min-h-24 cursor-pointer hover:bg-[var(--pd-formpage-card-bg-hover)] {checked
+    ? 'border-[var(--pd-formpage-card-border-selected)]'
+    : 'border-[var(--pd-formpage-card-border)]'} border-2 flex flex-col"
   aria-label="{value}"
   on:click|preventDefault="{() => handleClick()}">
   <div class="flex flex-row">
@@ -85,13 +85,13 @@ onMount(() => {
       {#if !additionalItem}
         <Checkbox bind:checked="{checked}" title="{title}" on:click="{() => handleClick()}" />
       {:else}
-        <Fa class="text-dustypurple-700 cursor-pointer" icon="{faPlusCircle}" size="1.5x" />
+        <Fa class="text-[var(--pd-formpage-card-border-selected)] cursor-pointer" icon="{faPlusCircle}" size="1.5x" />
       {/if}
     </div>
-    <div class="ml-2 text-sm text-left break-normal w-36">{title}</div>
+    <div class="ml-2 text-sm text-left break-normal w-36 text-[var(--pd-formpage-card-text)]">{title}</div>
     {#if isDefault}
       <Tooltip tip="Default platform of your computer">
-        <Fa size="0.5x" class="text-dustypurple-700 cursor-pointer" icon="{faCircle}" />
+        <Fa size="0.5x" class="text-[var(--pd-formpage-card-border-selected)] cursor-pointer" icon="{faCircle}" />
       </Tooltip>
     {/if}
   </div>
@@ -99,7 +99,8 @@ onMount(() => {
     <div class="flex">
       {#if badges.length > 0}
         {#each badges as badge}
-          <div class="text-gray-700 border-gray-700 border text-xs font-medium me-2 px-2.5 py-0.5 rounded-xl">
+          <div
+            class="text-[var(--pd-content-text)] border-[var(--pd-formpage-badge-border)] border text-xs font-medium me-2 px-2.5 py-0.5 rounded-xl">
             {badge}
           </div>
         {/each}
@@ -107,7 +108,7 @@ onMount(() => {
       {#if displayValueFieldInput}
         <input
           type="text"
-          class="w-40 outline-none text-sm bg-dustypurple-900 rounded-xs text-gray-700 placeholder-gray-700"
+          class="w-40 outline-none text-sm bg-[var(--pd-formpage-card-input-bg)] rounded-xs text-[var(--pd-content-text)]"
           bind:value="{additionalValue}"
           bind:this="{inputHtmlElement}"
           on:keydown="{handleKeydownAdditionalField}" />
@@ -115,9 +116,9 @@ onMount(() => {
     </div>
     <div class="flex grow justify-end">
       {#if iconType === 'fontAwesome'}
-        <Fa class="text-white cursor-pointer" icon="{icon}" size="1.5x" />
+        <Fa class="text-[var(--pd-content-text)] cursor-pointer" icon="{icon}" size="1.5x" />
       {:else if iconType === 'unknown'}
-        <svelte:component this="{icon}" class="text-gray-900 cursor-pointer" size="24" />
+        <svelte:component this="{icon}" class="text-[var(--pd-content-text)] cursor-pointer" size="24" />
       {/if}
     </div>
   </div>

--- a/packages/renderer/src/lib/image/BuildImageFromContainerfileCard.svelte
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfileCard.svelte
@@ -75,9 +75,9 @@ onMount(() => {
 </script>
 
 <button
-  class="rounded-md bg-[var(--pd-formpage-card-bg)] p-2 min-w-48 w-48 min-h-24 cursor-pointer hover:bg-[var(--pd-formpage-card-bg-hover)] {checked
-    ? 'border-[var(--pd-formpage-card-border-selected)]'
-    : 'border-[var(--pd-formpage-card-border)]'} border-2 flex flex-col"
+  class="rounded-md bg-[var(--pd-content-card-inset-bg)] p-2 min-w-48 w-48 min-h-24 cursor-pointer hover:bg-[var(--pd-content-card-hover-inset-bg)] {checked
+    ? 'border-[var(--pd-content-card-border-selected)]'
+    : 'border-[var(--pd-content-card-border)]'} border-2 flex flex-col"
   aria-label="{value}"
   on:click|preventDefault="{() => handleClick()}">
   <div class="flex flex-row">
@@ -85,13 +85,13 @@ onMount(() => {
       {#if !additionalItem}
         <Checkbox bind:checked="{checked}" title="{title}" on:click="{() => handleClick()}" />
       {:else}
-        <Fa class="text-[var(--pd-formpage-card-border-selected)] cursor-pointer" icon="{faPlusCircle}" size="1.5x" />
+        <Fa class="text-[var(--pd-content-card-icon)] cursor-pointer" icon="{faPlusCircle}" size="1.5x" />
       {/if}
     </div>
-    <div class="ml-2 text-sm text-left break-normal w-36 text-[var(--pd-formpage-card-text)]">{title}</div>
+    <div class="ml-2 text-sm text-left break-normal w-36 text-[var(--pd-content-card-text)]">{title}</div>
     {#if isDefault}
       <Tooltip tip="Default platform of your computer">
-        <Fa size="0.5x" class="text-[var(--pd-formpage-card-border-selected)] cursor-pointer" icon="{faCircle}" />
+        <Fa size="0.5x" class="text-[var(--pd-content-card-border-selected)] cursor-pointer" icon="{faCircle}" />
       </Tooltip>
     {/if}
   </div>
@@ -100,7 +100,7 @@ onMount(() => {
       {#if badges.length > 0}
         {#each badges as badge}
           <div
-            class="text-[var(--pd-content-text)] border-[var(--pd-formpage-badge-border)] border text-xs font-medium me-2 px-2.5 py-0.5 rounded-xl">
+            class="text-[var(--pd-content-card-text)] border-[var(--pd-content-card-border-selected)] border text-xs font-medium me-2 px-2.5 py-0.5 rounded-xl">
             {badge}
           </div>
         {/each}
@@ -108,7 +108,7 @@ onMount(() => {
       {#if displayValueFieldInput}
         <input
           type="text"
-          class="w-40 outline-none text-sm bg-[var(--pd-formpage-card-input-bg)] rounded-xs text-[var(--pd-content-text)]"
+          class="w-40 outline-none text-sm bg-[var(--pd-input-field-bg)] focus:bg-[var(--pd-input-field-focused-bg)] rounded-xs text-[var(--pd-content-text)]"
           bind:value="{additionalValue}"
           bind:this="{inputHtmlElement}"
           on:keydown="{handleKeydownAdditionalField}" />
@@ -116,9 +116,9 @@ onMount(() => {
     </div>
     <div class="flex grow justify-end">
       {#if iconType === 'fontAwesome'}
-        <Fa class="text-[var(--pd-content-text)] cursor-pointer" icon="{icon}" size="1.5x" />
+        <Fa class="text-[var(--pd-content-card-icon)] cursor-pointer" icon="{icon}" size="1.5x" />
       {:else if iconType === 'unknown'}
-        <svelte:component this="{icon}" class="text-[var(--pd-content-text)] cursor-pointer" size="24" />
+        <svelte:component this="{icon}" class="text-[var(--pd-content-card-icon)] cursor-pointer" size="24" />
       {/if}
     </div>
   </div>

--- a/packages/renderer/src/lib/image/BuildImageFromContainerfileCards.svelte
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfileCards.svelte
@@ -143,7 +143,7 @@ function addCard(item: { value: string }) {
   {#if !showMoreOptions}
     <button
       aria-label="Show more options"
-      class="pt-2 flex items-center text-sm cursor-pointer text-gray-700"
+      class="pt-2 flex items-center text-sm cursor-pointer text-[var(--pd-content-text)]"
       on:click="{() => (showMoreOptions = !showMoreOptions)}">
       <Fa icon="{faChevronRight}" class=" mr-2 " />
       More Options...
@@ -173,7 +173,7 @@ function addCard(item: { value: string }) {
     </div>
     <button
       aria-label="Show less options"
-      class="pt-2 flex items-center text-sm cursor-pointer text-gray-700"
+      class="pt-2 flex items-center text-sm cursor-pointer text-[var(--pd-content-text)]"
       on:click="{() => (showMoreOptions = !showMoreOptions)}">
       <Fa icon="{faChevronCircleDown}" class=" mr-2 transform rotate-90" />
       Less Options...

--- a/packages/renderer/src/lib/ui/EngineFormPage.svelte
+++ b/packages/renderer/src/lib/ui/EngineFormPage.svelte
@@ -17,7 +17,7 @@ export let showEmptyScreen: boolean = false;
       {#if showEmptyScreen}
         <NoContainerEngineEmptyScreen />
       {:else}
-        <div class="bg-[var(--pd-formpage-bg)] p-6 space-y-2 lg:p-8 rounded-lg">
+        <div class="bg-[var(--pd-content-card-bg)] p-6 space-y-2 lg:p-8 rounded-lg">
           <slot name="content" />
         </div>
       {/if}


### PR DESCRIPTION
### What does this PR do?

This PR enables light mode in the build image from container file page.
It is built over https://github.com/containers/podman-desktop/pull/7768

### Screenshot / video of UI

![buildimagefromcont](https://github.com/containers/podman-desktop/assets/49404737/746ae5a9-4e73-433b-b981-d6202544560b)

### What issues does this PR fix or reference?

it is part of #7214 

### How to test this PR?

go to images -> click on build button (top right)

- [ ] Tests are covering the bug fix or the new feature
