### PR TITLE
chore: bump vale action to latest

### DIFF
--- a/.github/workflows/pr-check-vale.yaml
+++ b/.github/workflows/pr-check-vale.yaml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
-      - uses: errata-ai/vale-action@38bf078c328061f59879b347ca344a718a736018 # reviewdog branch, https://github.com/errata-ai/vale-action/commit/38bf078c328061f59879b347ca344a718a736018
+      - uses: errata-ai/vale-action@v2.1.0
         env:
           # Required, set by GitHub actions automatically:
           # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#about-the-github_token-secret


### PR DESCRIPTION
### What does this PR do?

Vale seems to fail all the time see https://github.com/containers/podman-desktop/actions/workflows/pr-check-vale.yaml

> Might be related to the ubuntu upgrade ?

This aims to upgrade to their latest version to check if that fix the issue :/

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
