### PR TITLE
chore: remove undefined for node in pods list

### DIFF
--- a/packages/renderer/src/lib/pod/PodColumnName.spec.ts
+++ b/packages/renderer/src/lib/pod/PodColumnName.spec.ts
@@ -95,3 +95,9 @@ test('Expect kubernetes pod information', async () => {
   const node = screen.getByText('node1');
   expect(node).toBeInTheDocument();
 });
+
+test('Do not expect undefined anywhere on the page', async () => {
+  render(PodColumnName, { object: pod });
+
+  expect(screen.queryByText('undefined')).not.toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/pod/PodColumnName.svelte
+++ b/packages/renderer/src/lib/pod/PodColumnName.svelte
@@ -23,11 +23,17 @@ function openDetailsPod(pod: PodInfoUI) {
     {object.name}
   </div>
   <div class="flex flex-row text-xs gap-1">
-    <div class="text-xs text-[var(--pd-table-body-text-sub-secondary)]">
-      {podUtils.isKubernetesPod(object) ? object.node : object.shortId}
-    </div>
     {#if podUtils.isKubernetesPod(object)}
+      {#if object.node}
+        <div class="text-xs text-[var(--pd-table-body-text-sub-secondary)]">
+          {object.node}
+        </div>
+      {/if}
       <div class="font-extra-light text-[var(--pd-table-body-text-sub-highlight)]">{object.namespace}</div>
+    {:else}
+      <div class="text-xs text-[var(--pd-table-body-text-sub-secondary)]">
+        {object.shortId}
+      </div>
     {/if}
   </div>
 </button>


### PR DESCRIPTION
chore: remove undefined for node in pods list

### What does this PR do?

If a node is not yet allocated, it will show as 'undefined' in the page.
Adds a check to make sure that we will only show the node name when
available.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

<img width="501" alt="Screenshot 2024-06-22 at 10 38 34 PM" src="https://github.com/containers/podman-desktop/assets/6422176/d3ac7dfc-0b6c-4b58-96dc-2702975fd73e">


### What issues does this PR fix or reference?

Closes https://github.com/containers/podman-desktop/issues/7780

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
