### PR TITLE
chore: add GPU label for nodes with GPUs & adjust icons

### DIFF
--- a/packages/renderer/src/lib/node/NodeColumnRoles.spec.ts
+++ b/packages/renderer/src/lib/node/NodeColumnRoles.spec.ts
@@ -49,3 +49,17 @@ test('Expect role display for node', async () => {
   const text = screen.getByText('Node');
   expect(text).toBeInTheDocument();
 });
+
+test('Expect GPU display if hasGpu is true', async () => {
+  render(NodeColumnRoles, { object: { ...nodeControlPlane, hasGpu: true } });
+
+  const text = screen.getByText('GPU');
+  expect(text).toBeInTheDocument();
+});
+
+test('Expect no GPU display if hasGpu is false', async () => {
+  render(NodeColumnRoles, { object: { ...nodeControlPlane, hasGpu: false } });
+
+  const text = screen.queryByText('GPU');
+  expect(text).not.toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/node/NodeColumnRoles.svelte
+++ b/packages/renderer/src/lib/node/NodeColumnRoles.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { faMicrochip, faSatelliteDish } from '@fortawesome/free-solid-svg-icons';
+import { faMicrochip, faSatelliteDish, faServer } from '@fortawesome/free-solid-svg-icons';
 import Fa from 'svelte-fa';
 
 import Label from '../ui/Label.svelte';
@@ -16,16 +16,23 @@ function getConditionColour(role: 'control-plane' | 'node'): string {
       roleName = 'Control Plane';
       // faSatelliteDish: Represents a satellite dish, suitable for the control plane role
       roleIcon = faSatelliteDish;
-      return 'text-green-600';
+      return 'text-[var(--pd-status-running)]';
     case 'node':
       roleName = 'Node';
-      // faMicrochip: Represents a microchip or hardware similar to a "subset" of a satellite dish / control plane
-      roleIcon = faMicrochip;
-      return 'text-sky-400';
+      // faServer: Better represents a "node" / server rack
+      roleIcon = faServer;
+      return 'text-[var(--pd-status-updated)]';
   }
 }
 </script>
 
-<Label name="{roleName}">
-  <Fa size="1x" icon="{roleIcon}" class="{getConditionColour(object.role)}" />
-</Label>
+<div class="flex flex-row gap-1">
+  <Label name="{roleName}">
+    <Fa size="1x" icon="{roleIcon}" class="{getConditionColour(object.role)}" />
+  </Label>
+  {#if object.hasGpu}
+    <Label name="GPU">
+      <Fa size="1x" icon="{faMicrochip}" class="text-[var(--pd-status-updated)]" />
+    </Label>
+  {/if}
+</div>

--- a/packages/renderer/src/lib/node/NodeUI.ts
+++ b/packages/renderer/src/lib/node/NodeUI.ts
@@ -24,5 +24,6 @@ export interface NodeUI {
   osImage: string;
   kernelVersion: string;
   containerRuntime: string;
+  hasGpu?: boolean;
   created?: Date;
 }

--- a/packages/renderer/src/lib/node/node-utils.spec.ts
+++ b/packages/renderer/src/lib/node/node-utils.spec.ts
@@ -81,3 +81,55 @@ describe('Node UI conversion', () => {
     expect(nodeUI.version).toEqual('v1.20.4');
   });
 });
+
+test('if gpu.intel.com, nvidia.com/gpu or amd.com/gpu is present in the node labels expect hasGpu to be true', async () => {
+  const node = {
+    metadata: {
+      name: 'kube-node',
+    },
+    status: {
+      capacity: {
+        'nvidia.com/gpu': '1',
+      },
+    },
+  } as V1Node;
+
+  expect(nodeUtils.hasGpu(node)).toEqual(true);
+
+  const node2 = {
+    metadata: {
+      name: 'kube-node',
+    },
+    status: {
+      capacity: {
+        'amd.com/gpu': '1',
+      },
+    },
+  } as V1Node;
+
+  expect(nodeUtils.hasGpu(node2)).toEqual(true);
+
+  const node3 = {
+    metadata: {
+      name: 'kube-node',
+    },
+    status: {
+      capacity: {
+        'gpu.intel.com/test123': '123',
+      },
+    },
+  } as V1Node;
+
+  expect(nodeUtils.hasGpu(node3)).toEqual(true);
+
+  const node4 = {
+    metadata: {
+      name: 'kube-node',
+    },
+    status: {
+      capacity: {},
+    },
+  } as V1Node;
+
+  expect(nodeUtils.hasGpu(node4)).toEqual(false);
+});

--- a/packages/renderer/src/lib/node/node-utils.ts
+++ b/packages/renderer/src/lib/node/node-utils.ts
@@ -68,6 +68,34 @@ export class NodeUtils {
       osImage,
       kernelVersion,
       containerRuntime,
+      hasGpu: this.hasGpu(node),
     };
+  }
+
+  // Function that returns true / false if the node has a GPU.
+  // Ex. if there is a capacity for nvidia.com/gpu, we assume the node has a GPU.
+  // For AMD GPUs, we would need to check for amd.com/gpu.
+  // For Intel GPUs, there are multiple labels, but they start with gpu.intel.com/*.
+  hasGpu(node: V1Node): boolean {
+    const capacities = node.status?.capacity ?? {};
+
+    // Check for Nvidia GPU
+    if ('nvidia.com/gpu' in capacities) {
+      return true;
+    }
+
+    // Check for AMD GPU
+    if ('amd.com/gpu' in capacities) {
+      return true;
+    }
+
+    // Check for Intel GPUs, where labels start with 'gpu.intel.com/'
+    for (const key in capacities) {
+      if (key.startsWith('gpu.intel.com/')) {
+        return true;
+      }
+    }
+
+    return false; // Return false if no GPU capacities are found
   }
 }


### PR DESCRIPTION
chore: add GPU label for nodes with GPUs & adjust icons

### What does this PR do?

Adds the "GPU" label to indicate that a node has a GPU by checking to
see if Intel, Nvidia or AMD is present. This is useful as it provides
valuable information if a node is GPU capable or not.

This commit also adjusts the icons that represent a Node. I had
previously set it as microchip, but it should be "server" looking, as a
GPU is better indicated as a microchip / something that is added to a
server.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->
<img width="431" alt="Screenshot 2024-06-22 at 11 38 38 PM" src="https://github.com/containers/podman-desktop/assets/6422176/78474d7a-4e38-4056-a787-f272afad80e5">



### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop/issues/7778

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature

Use `kubectl edit --subresource=status node/<NODE-NAME>` and add `nvidia.com/gpu: 1` under capacity.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
