### PR TITLE
chore: optional label capitalization

### DIFF
--- a/packages/renderer/src/lib/ui/Label.spec.ts
+++ b/packages/renderer/src/lib/ui/Label.spec.ts
@@ -59,3 +59,22 @@ test('Expect role to be defined', async () => {
   const label = screen.getByRole(role);
   expect(label).toBeInTheDocument();
 });
+
+test('Expect no capitalization', async () => {
+  render(LabelSpec, {
+    name: 'label',
+  });
+  const label = screen.getByText('label');
+  expect(label).toBeInTheDocument();
+  expect(label).not.toHaveClass('capitalize');
+});
+
+test('Expect capitalization', async () => {
+  render(LabelSpec, {
+    name: 'label',
+    capitalize: true,
+  });
+  const label = screen.getByText('label');
+  expect(label).toBeInTheDocument();
+  expect(label).toHaveClass('capitalize');
+});

--- a/packages/renderer/src/lib/ui/Label.svelte
+++ b/packages/renderer/src/lib/ui/Label.svelte
@@ -4,6 +4,7 @@ import { Tooltip } from '@podman-desktop/ui-svelte';
 export let name = '';
 export let tip = '';
 export let role: string | undefined = undefined;
+export let capitalize: boolean = false;
 </script>
 
 <Tooltip top tip="{tip}">
@@ -11,7 +12,7 @@ export let role: string | undefined = undefined;
     role="{role}"
     class="flex items-center bg-[var(--pd-label-bg)] p-1 rounded-md text-xs text-[var(--pd-label-text)] gap-x-1">
     <slot></slot>
-    <span class="capitalize">
+    <span class:capitalize="{capitalize}">
       {name}
     </span>
   </div>

--- a/packages/renderer/src/lib/ui/LabelSpec.svelte
+++ b/packages/renderer/src/lib/ui/LabelSpec.svelte
@@ -5,6 +5,7 @@ export let name = '';
 export let tip = '';
 export let slot = '';
 export let role: string | undefined = undefined;
+export let capitalize: boolean = false;
 </script>
 
-<Label tip="{tip}" role="{role}" name="{name}">{slot}</Label>
+<Label tip="{tip}" role="{role}" name="{name}" capitalize="{capitalize}">{slot}</Label>

--- a/packages/renderer/src/lib/ui/ProviderInfo.svelte
+++ b/packages/renderer/src/lib/ui/ProviderInfo.svelte
@@ -28,6 +28,6 @@ function getProviderColour(providerName: string): string {
 }
 </script>
 
-<Label tip="{provider === 'Kubernetes' ? context : ''}" name="{provider}">
+<Label tip="{provider === 'Kubernetes' ? context : ''}" name="{provider}" capitalize>
   <div class="w-2 h-2 {getProviderColour(provider)} rounded-full"></div>
 </Label>


### PR DESCRIPTION
### What does this PR do?

When creating Label I left 'capitalize' on by default because the first Label (ProviderInfo) needed it, but none of the other instances do. PR #7681 it requires no capitalization so this just separates that out - making capitalization off by default and only used by the one use that requires it, ProviderInfo.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Prereq of #7681.

### How to test this PR?

Automated tests updated.

- [x] Tests are covering the bug fix or the new feature