### PR TITLE
chore: light mode support for statusbar

### DIFF
--- a/packages/main/src/plugin/color-registry.ts
+++ b/packages/main/src/plugin/color-registry.ts
@@ -228,6 +228,7 @@ export class ColorRegistry {
   }
 
   protected initColors(): void {
+    this.initNotificationDot();
     this.initGlobalNav();
     this.initSecondaryNav();
     this.initTitlebar();
@@ -249,6 +250,14 @@ export class ColorRegistry {
     this.initLabel();
     this.initStatusColors();
     this.initFormPage();
+    this.initStatusBar();
+  }
+
+  protected initNotificationDot(): void {
+    this.registerColor('notification-dot', {
+      dark: colorPalette.purple[500],
+      light: colorPalette.purple[600],
+    });
   }
 
   protected initGlobalNav(): void {
@@ -258,10 +267,6 @@ export class ColorRegistry {
     this.registerColor(`${glNav}bg`, {
       dark: colorPalette.charcoal[600],
       light: colorPalette.gray[100],
-    });
-    this.registerColor(`${glNav}icon-notification-dot`, {
-      dark: colorPalette.purple[500],
-      light: colorPalette.purple[600],
     });
     this.registerColor(`${glNav}icon`, {
       dark: colorPalette.gray[600],
@@ -350,11 +355,6 @@ export class ColorRegistry {
     });
 
     this.registerColor(`${sNav}selected-highlight`, {
-      dark: colorPalette.purple[500],
-      light: colorPalette.purple[600],
-    });
-
-    this.registerColor(`${sNav}icon-notification-dot`, {
       dark: colorPalette.purple[500],
       light: colorPalette.purple[600],
     });
@@ -1200,6 +1200,24 @@ export class ColorRegistry {
     this.registerColor(`${formPage}card-text`, {
       dark: colorPalette.gray[400],
       light: colorPalette.purple[900],
+    });
+  }
+
+  protected initStatusBar(): void {
+    const statusbar = 'statusbar-';
+    this.registerColor(`${statusbar}bg`, {
+      dark: colorPalette.purple[900],
+      light: colorPalette.purple[900],
+    });
+
+    this.registerColor(`${statusbar}hover-bg`, {
+      dark: colorPalette.purple[800],
+      light: colorPalette.purple[800],
+    });
+
+    this.registerColor(`${statusbar}text`, {
+      dark: colorPalette.white,
+      light: colorPalette.white,
     });
   }
 }

--- a/packages/renderer/src/lib/statusbar/StatusBar.svelte
+++ b/packages/renderer/src/lib/statusbar/StatusBar.svelte
@@ -47,7 +47,8 @@ onMount(async () => {
 });
 </script>
 
-<div class="flex items-center justify-between px-1 bg-[#302251] text-sm py-0.5 space-x-2 z-40">
+<div
+  class="flex items-center justify-between px-1 bg-[var(--pd-statusbar-bg)] text-[var(--pd-statusbar-text)] text-sm py-0.5 space-x-2 z-40">
   <div>
     <ul class="flex flex-wrap gap-x-2 list-none items-center">
       {#each leftEntries as entry}

--- a/packages/renderer/src/lib/statusbar/StatusBarItem.svelte
+++ b/packages/renderer/src/lib/statusbar/StatusBarItem.svelte
@@ -13,7 +13,7 @@ function opacity(entry: StatusBarEntry): string {
 }
 
 function hoverBackground(entry: StatusBarEntry): string {
-  return entry.enabled && typeof entry.command === 'string' ? 'hover:bg-[#4d3782]' : '';
+  return entry.enabled && typeof entry.command === 'string' ? 'hover:bg-[var(--pd-statusbar-hover-bg)]' : '';
 }
 
 function hoverCursor(entry: StatusBarEntry): string {
@@ -44,6 +44,7 @@ async function executeCommand(entry: StatusBarEntry) {
     <span class="ml-1">{entry.text}</span>
   {/if}
   {#if entry.highlight}
-    <span role="status" class="absolute bg-purple-500 rounded-full p-1 top-[-2px] right-[-2px]"></span>
+    <span role="status" class="absolute bg-[var(--pd-notification-dot)] rounded-full p-1 top-[-2px] right-[-2px]"
+    ></span>
   {/if}
 </button>

--- a/packages/renderer/src/lib/ui/NewContentBadge.svelte
+++ b/packages/renderer/src/lib/ui/NewContentBadge.svelte
@@ -29,5 +29,5 @@ onDestroy(() => {
 </script>
 
 {#if hasNew}
-  <div aria-label="New content available" class="w-[6px] h-[6px] bg-purple-500 rounded-full"></div>
+  <div aria-label="New content available" class="w-[6px] h-[6px] bg-[var(--pd-notification-dot)] rounded-full"></div>
 {/if}


### PR DESCRIPTION
### What does this PR do?

The status bar had hardcoded colors that weren't in the color palette. This adds colors to the registry for them with the closest colors (bg #302251 -> purple-900, hover-bg #4d3782 to purple-800) and uses the variables.

This is the third time we're adding a notification dot color into the registry and the previous two don't appear to be used yet, so I'm separating it out into a single color, with the expectation that at some point the notification dot should be a shared component like Button or Label.

### Screenshot / video of UI

N/A, slight color change to status bar.

### What issues does this PR fix or reference?

Fixes #7727.

### How to test this PR?

Check the status bar in light and dark mode.