### PR TITLE
fix: avoid electron popups when closing the window with exit on close

### DIFF
--- a/packages/main/src/mainWindow.ts
+++ b/packages/main/src/mainWindow.ts
@@ -128,8 +128,8 @@ async function createWindow(): Promise<BrowserWindow> {
       exitonclose = closeBehaviorConfiguration.get<boolean>('ExitOnClose') === true;
     }
 
+    e.preventDefault();
     if (!exitonclose) {
-      e.preventDefault();
       browserWindow.hide();
       if (isMac()) {
         app.dock.hide();

--- a/packages/main/src/plugin/index.spec.ts
+++ b/packages/main/src/plugin/index.spec.ts
@@ -34,6 +34,7 @@ let pluginSystem: PluginSystem;
 
 const emitter = new EventEmitter();
 const webContents = emitter as unknown as WebContents;
+webContents.isDestroyed = vi.fn();
 
 // add send method
 webContents.send = vi.fn();

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -339,7 +339,9 @@ export class PluginSystem {
         // send only when the UI is ready
         if (this.uiReady && this.isReady) {
           flushQueuedEvents();
-          webContents.send('api-sender', channel, data);
+          if (!webContents.isDestroyed()) {
+            webContents.send('api-sender', channel, data);
+          }
         } else {
           // add to the queue
           queuedEvents.push({ channel, data });


### PR DESCRIPTION
### What does this PR do?
avoid electron popups when closing the window with exit on close
- do not propagate the event
- only send data to the window if it's not destroyed

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/7756

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
