### PR TITLE
chore: revert vale action to the usage of ubuntu 22.04

### DIFF
--- a/.github/workflows/pr-check-vale.yaml
+++ b/.github/workflows/pr-check-vale.yaml
@@ -22,11 +22,12 @@ on:
   pull_request:
     paths:
       - 'website/**'
+      - '.github/workflows/pr-check-vale.yaml'
 
 jobs:
   vale:
     name: runner / vale
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: errata-ai/vale-action@v2.1.0


### PR DESCRIPTION
### What does this PR do?
it does not work with Ubuntu 24.04

also triggers the workflow when modifying the github action file so we can check if something will break

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
