### PR TITLE
add API for Image Files providers

### DIFF
--- a/packages/api/src/image-files-info.ts
+++ b/packages/api/src/image-files-info.ts
@@ -1,0 +1,27 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+export type ImageFilesExtensionInfo = {
+  id: string;
+  label: string;
+};
+
+export interface ImageFilesInfo {
+  id: string;
+  label: string;
+}

--- a/packages/main/src/plugin/extension-loader.spec.ts
+++ b/packages/main/src/plugin/extension-loader.spec.ts
@@ -51,6 +51,7 @@ import { ExtensionLoader } from './extension-loader.js';
 import type { FilesystemMonitoring } from './filesystem-monitoring.js';
 import type { IconRegistry } from './icon-registry.js';
 import type { ImageCheckerImpl } from './image-checker.js';
+import type { ImageFilesRegistry } from './image-files-registry.js';
 import type { ImageRegistry } from './image-registry.js';
 import type { InputQuickPickRegistry } from './input-quickpick/input-quickpick-registry.js';
 import type { KubernetesClient } from './kubernetes-client.js';
@@ -208,6 +209,10 @@ const imageCheckerImpl: ImageCheckerImpl = {
   registerImageCheckerProvider: vi.fn(),
 } as unknown as ImageCheckerImpl;
 
+const imageFilesImpl: ImageFilesRegistry = {
+  registerImageFilesProvider: vi.fn(),
+} as unknown as ImageFilesRegistry;
+
 const contributionManager: ContributionManager = {
   listContributions: vi.fn(),
 } as unknown as ContributionManager;
@@ -281,6 +286,7 @@ beforeAll(() => {
     cliToolRegistry,
     notificationRegistry,
     imageCheckerImpl,
+    imageFilesImpl,
     navigationManager,
     webviewRegistry,
     colorRegistry,

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -52,6 +52,7 @@ import { DEFAULT_TIMEOUT, ExtensionLoaderSettings } from './extension-loader-set
 import type { FilesystemMonitoring } from './filesystem-monitoring.js';
 import type { IconRegistry } from './icon-registry.js';
 import type { ImageCheckerImpl } from './image-checker.js';
+import type { ImageFilesRegistry } from './image-files-registry.js';
 import type { ImageRegistry } from './image-registry.js';
 import type { InputQuickPickRegistry } from './input-quickpick/input-quickpick-registry.js';
 import { InputBoxValidationSeverity, QuickPickItemKind } from './input-quickpick/input-quickpick-registry.js';
@@ -184,6 +185,7 @@ export class ExtensionLoader {
     private cliToolRegistry: CliToolRegistry,
     private notificationRegistry: NotificationRegistry,
     private imageCheckerProvider: ImageCheckerImpl,
+    private imageFilesRegistry: ImageFilesRegistry,
     private navigationManager: NavigationManager,
     private webviewRegistry: WebviewRegistry,
     private colorRegistry: ColorRegistry,
@@ -800,6 +802,7 @@ export class ExtensionLoader {
     //export function executeCommand<T = unknown>(command: string, ...rest: any[]): PromiseLike<T>;
 
     const providerRegistry = this.providerRegistry;
+    const imageFilesRegistry = this.imageFilesRegistry;
 
     const provider: typeof containerDesktopAPI.provider = {
       createProvider(providerOptions: containerDesktopAPI.ProviderOptions): containerDesktopAPI.Provider {
@@ -837,6 +840,14 @@ export class ExtensionLoader {
         providerConnectionInfo: containerDesktopAPI.ContainerProviderConnection,
       ): containerDesktopAPI.LifecycleContext {
         return providerRegistry.getMatchingProviderLifecycleContextByProviderId(providerId, providerConnectionInfo);
+      },
+      createImageFilesProvider: (
+        provider: containerDesktopAPI.ImageFilesCallbacks,
+        metadata?: containerDesktopAPI.ImageFilesProviderMetadata,
+      ): containerDesktopAPI.ImageFilesProvider => {
+        const imageFilesProvider = imageFilesRegistry.create(extensionInfo, provider, metadata);
+        disposables.push(imageFilesProvider);
+        return imageFilesProvider;
       },
     };
 

--- a/packages/main/src/plugin/image-files-impl.spec.ts
+++ b/packages/main/src/plugin/image-files-impl.spec.ts
@@ -1,0 +1,260 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { ImageFilesystemLayer } from '@podman-desktop/api';
+import { beforeEach, expect, suite, test, vi } from 'vitest';
+
+import { ImageFilesImpl } from './image-files-impl.js';
+import type { ImageFilesRegistry } from './image-files-registry.js';
+
+suite('add to layer', () => {
+  const currentDate = new Date(2020, 3, 1);
+  let imageFilesProvider: ImageFilesImpl;
+
+  beforeEach(() => {
+    vi.setSystemTime(currentDate);
+    imageFilesProvider = new ImageFilesImpl('an-id', {} as unknown as ImageFilesRegistry);
+  });
+
+  test('add file with default options', () => {
+    const layer: ImageFilesystemLayer = { id: 'layer1' };
+    const file1Options = {
+      path: '/etc/hosts',
+      mode: 0o644,
+      size: 100,
+    };
+    const file2Options = {
+      path: '/etc/sudoers',
+      mode: 0o440,
+      size: 200,
+    };
+    const defaultValues = {
+      uid: 1,
+      gid: 1,
+      ctime: currentDate,
+      atime: currentDate,
+      mtime: currentDate,
+    };
+    imageFilesProvider.addFile(layer, file1Options).addFile(layer, file2Options);
+    expect(layer.files?.length).toBe(2);
+    expect(layer.files![0]).toEqual({
+      ...file1Options,
+      type: 'file',
+      ...defaultValues,
+    });
+    expect(layer.files![1]).toEqual({
+      ...file2Options,
+      type: 'file',
+      ...defaultValues,
+    });
+  });
+
+  test('add file with all options set', () => {
+    const layer: ImageFilesystemLayer = { id: 'layer1' };
+    const file1Options = {
+      path: '/etc/hosts',
+      mode: 0o644,
+      size: 100,
+      uid: 1001,
+      gid: 1002,
+      mtime: new Date(2019, 3, 1),
+      ctime: new Date(2019, 3, 2),
+      atime: new Date(2019, 3, 3),
+    };
+    const file2Options = {
+      path: '/etc/sudoers',
+      mode: 0o440,
+      size: 200,
+      uid: 1003,
+      gid: 1004,
+      mtime: new Date(2021, 3, 1),
+      ctime: new Date(2021, 3, 2),
+      atime: new Date(2021, 3, 3),
+    };
+    imageFilesProvider.addFile(layer, file1Options).addFile(layer, file2Options);
+    expect(layer.files?.length).toBe(2);
+    expect(layer.files![0]).toEqual({
+      ...file1Options,
+      type: 'file',
+    });
+    expect(layer.files![1]).toEqual({
+      ...file2Options,
+      type: 'file',
+    });
+  });
+
+  test('add directory with default options', () => {
+    const layer: ImageFilesystemLayer = { id: 'layer1' };
+    const dir1Options = {
+      path: '/etc',
+      mode: 0o755,
+    };
+    const dir2Options = {
+      path: '/root',
+      mode: 0o700,
+    };
+    const defaultValues = {
+      uid: 1,
+      gid: 1,
+      ctime: currentDate,
+      atime: currentDate,
+      mtime: currentDate,
+    };
+    imageFilesProvider.addDirectory(layer, dir1Options).addDirectory(layer, dir2Options);
+    expect(layer.files?.length).toBe(2);
+    expect(layer.files![0]).toEqual({
+      ...dir1Options,
+      type: 'directory',
+      ...defaultValues,
+      size: 0,
+    });
+    expect(layer.files![1]).toEqual({
+      ...dir2Options,
+      type: 'directory',
+      ...defaultValues,
+      size: 0,
+    });
+  });
+
+  test('add directory with all options set', () => {
+    const layer: ImageFilesystemLayer = { id: 'layer1' };
+    const dir1Options = {
+      path: '/etc',
+      mode: 0o755,
+      uid: 1001,
+      gid: 1002,
+      mtime: new Date(2019, 3, 1),
+      ctime: new Date(2019, 3, 2),
+      atime: new Date(2019, 3, 3),
+    };
+    const dir2Options = {
+      path: '/root',
+      mode: 0o700,
+      size: 200,
+      uid: 1003,
+      gid: 1004,
+      mtime: new Date(2021, 3, 1),
+      ctime: new Date(2021, 3, 2),
+      atime: new Date(2021, 3, 3),
+    };
+    imageFilesProvider.addDirectory(layer, dir1Options).addDirectory(layer, dir2Options);
+    expect(layer.files?.length).toBe(2);
+    expect(layer.files![0]).toEqual({
+      ...dir1Options,
+      type: 'directory',
+      size: 0,
+    });
+    expect(layer.files![1]).toEqual({
+      ...dir2Options,
+      type: 'directory',
+      size: 0,
+    });
+  });
+
+  test('add symbolic link with default options', () => {
+    const layer: ImageFilesystemLayer = { id: 'layer1' };
+    const symlink1Options = {
+      path: '/sbin',
+      mode: 0o755,
+      linkPath: '/bin',
+    };
+    const symlink2Options = {
+      path: '/usr/sbin',
+      mode: 0o700,
+      linkPath: '/usr/bin',
+    };
+    const defaultValues = {
+      uid: 1,
+      gid: 1,
+      ctime: currentDate,
+      atime: currentDate,
+      mtime: currentDate,
+    };
+    imageFilesProvider.addSymlink(layer, symlink1Options).addSymlink(layer, symlink2Options);
+    expect(layer.files?.length).toBe(2);
+    expect(layer.files![0]).toEqual({
+      ...symlink1Options,
+      type: 'symlink',
+      ...defaultValues,
+      size: 0,
+    });
+    expect(layer.files![1]).toEqual({
+      ...symlink2Options,
+      type: 'symlink',
+      ...defaultValues,
+      size: 0,
+    });
+  });
+
+  test('add symbolic link with all options set', () => {
+    const layer: ImageFilesystemLayer = { id: 'layer1' };
+    const symlink1Options = {
+      path: '/sbin',
+      mode: 0o755,
+      linkPath: '/bin',
+      uid: 1001,
+      gid: 1002,
+      mtime: new Date(2019, 3, 1),
+      ctime: new Date(2019, 3, 2),
+      atime: new Date(2019, 3, 3),
+    };
+    const dir2Options = {
+      path: '/usr/sbin',
+      mode: 0o700,
+      linkPath: '/usr/bin',
+      size: 200,
+      uid: 1003,
+      gid: 1004,
+      mtime: new Date(2021, 3, 1),
+      ctime: new Date(2021, 3, 2),
+      atime: new Date(2021, 3, 3),
+    };
+    imageFilesProvider.addSymlink(layer, symlink1Options).addSymlink(layer, dir2Options);
+    expect(layer.files?.length).toBe(2);
+    expect(layer.files![0]).toEqual({
+      ...symlink1Options,
+      type: 'symlink',
+      size: 0,
+    });
+    expect(layer.files![1]).toEqual({
+      ...dir2Options,
+      type: 'symlink',
+      size: 0,
+    });
+  });
+
+  test('add whiteout', () => {
+    const layer: ImageFilesystemLayer = { id: 'layer1' };
+    const path1 = '/etc/oldfile1';
+    const path2 = '/etc/oldfile2';
+    imageFilesProvider.addWhiteout(layer, path1).addWhiteout(layer, path2);
+    expect(layer.whiteouts?.length).toBe(2);
+    expect(layer.whiteouts![0]).toEqual(path1);
+    expect(layer.whiteouts![1]).toEqual(path2);
+  });
+
+  test('add opaque whiteout', () => {
+    const layer: ImageFilesystemLayer = { id: 'layer1' };
+    const path1 = '/tmp';
+    const path2 = '/var/tmp';
+    imageFilesProvider.addOpaqueWhiteout(layer, path1).addOpaqueWhiteout(layer, path2);
+    expect(layer.opaqueWhiteouts?.length).toBe(2);
+    expect(layer.opaqueWhiteouts![0]).toEqual(path1);
+    expect(layer.opaqueWhiteouts![1]).toEqual(path2);
+  });
+});

--- a/packages/main/src/plugin/image-files-impl.ts
+++ b/packages/main/src/plugin/image-files-impl.ts
@@ -1,0 +1,113 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { Disposable, ImageFilesProvider, ImageFileSymlink, ImageFilesystemLayer } from '@podman-desktop/api';
+
+import type { ImageFilesRegistry } from './image-files-registry.js';
+
+export interface AddCommonOptions {
+  path: string;
+  mode: number;
+  uid?: number;
+  gid?: number;
+  ctime?: Date;
+  atime?: Date;
+  mtime?: Date;
+}
+
+export class ImageFilesImpl implements ImageFilesProvider, Disposable {
+  constructor(
+    readonly id: string,
+    readonly registry: ImageFilesRegistry,
+  ) {}
+
+  addFile(layer: ImageFilesystemLayer, opts: AddCommonOptions & { size: number }): ImageFilesProvider {
+    if (!layer.files) {
+      layer.files = [];
+    }
+    layer.files.push({
+      path: opts.path,
+      type: 'file',
+      mode: opts.mode,
+      uid: opts.uid ?? 1,
+      gid: opts.gid ?? 1,
+      ctime: opts.ctime ?? new Date(),
+      atime: opts.atime ?? new Date(),
+      mtime: opts.mtime ?? new Date(),
+      size: opts.size,
+    });
+    return this;
+  }
+
+  addDirectory(layer: ImageFilesystemLayer, opts: AddCommonOptions): ImageFilesProvider {
+    if (!layer.files) {
+      layer.files = [];
+    }
+    layer.files.push({
+      path: opts.path,
+      type: 'directory',
+      mode: opts.mode,
+      uid: opts.uid ?? 1,
+      gid: opts.gid ?? 1,
+      ctime: opts.ctime ?? new Date(),
+      atime: opts.atime ?? new Date(),
+      mtime: opts.mtime ?? new Date(),
+      size: 0,
+    });
+    return this;
+  }
+
+  addSymlink(layer: ImageFilesystemLayer, opts: AddCommonOptions & { linkPath: string }): ImageFilesProvider {
+    if (!layer.files) {
+      layer.files = [];
+    }
+    layer.files.push({
+      path: opts.path,
+      type: 'symlink',
+      mode: opts.mode,
+      uid: opts.uid ?? 1,
+      gid: opts.gid ?? 1,
+      ctime: opts.ctime ?? new Date(),
+      atime: opts.atime ?? new Date(),
+      mtime: opts.mtime ?? new Date(),
+      size: 0,
+      linkPath: opts.linkPath,
+    } as ImageFileSymlink);
+    return this;
+  }
+
+  addWhiteout(layer: ImageFilesystemLayer, path: string): ImageFilesProvider {
+    if (!layer.whiteouts) {
+      layer.whiteouts = [];
+    }
+    layer.whiteouts.push(path);
+    return this;
+  }
+
+  addOpaqueWhiteout(layer: ImageFilesystemLayer, path: string): ImageFilesProvider {
+    if (!layer.opaqueWhiteouts) {
+      layer.opaqueWhiteouts = [];
+    }
+    layer.opaqueWhiteouts.push(path);
+    return this;
+  }
+
+  dispose(): void {
+    this.registry.disposeImageFiles(this);
+  }
+}

--- a/packages/main/src/plugin/image-files-registry.spec.ts
+++ b/packages/main/src/plugin/image-files-registry.spec.ts
@@ -1,0 +1,204 @@
+/**********************************************************************
+ * Copyright (C) 2023-2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { afterEach } from 'node:test';
+
+import type {
+  CancellationToken,
+  ImageFile,
+  ImageFilesystemLayer,
+  ImageFilesystemLayers,
+  ImageInfo,
+  ProviderResult,
+} from '@podman-desktop/api';
+import { beforeEach, expect, suite, test, vi } from 'vitest';
+
+import type { ImageFilesExtensionInfo } from '/@api/image-files-info.js';
+
+import type { ApiSenderType } from './api.js';
+import { ImageFilesRegistry } from './image-files-registry.js';
+
+const apiSender: ApiSenderType = {
+  send: vi.fn(),
+  receive: vi.fn(),
+};
+
+const extensionInfo: ImageFilesExtensionInfo = {
+  id: 'ext-publisher.ext-name',
+  label: 'my-label',
+};
+
+let imageFiles: ImageFilesRegistry;
+suite('image files module', () => {
+  beforeEach(() => {
+    imageFiles = new ImageFilesRegistry(apiSender);
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+  suite('create ImageFiles', () => {
+    test('creates ImageFiles instance', () => {
+      const provider1 = {
+        getFilesystemLayers: (_image: ImageInfo, _token?: CancellationToken): ProviderResult<ImageFilesystemLayers> => {
+          return { layers: [] };
+        },
+      };
+      const provider2 = {
+        getFilesystemLayers: (_image: ImageInfo, _token?: CancellationToken): ProviderResult<ImageFilesystemLayers> => {
+          return { layers: [] };
+        },
+      };
+      const metadata1 = {
+        label: 'Provider label',
+      };
+      imageFiles.create(extensionInfo, provider1, metadata1);
+      imageFiles.create(extensionInfo, provider2);
+      const providers = imageFiles.getImageFilesProviders();
+      expect(providers.length).toBe(2);
+
+      expect(providers[0].id).equals(`${extensionInfo.id}-0`);
+      expect(providers[0].label).equals('Provider label');
+
+      expect(providers[1].id).equals(`${extensionInfo.id}-1`);
+      expect(providers[1].label).equals(extensionInfo.label);
+    });
+
+    test('Image files sends "image-files-provider-update" event when new provider is added', () => {
+      const provider = {
+        getFilesystemLayers: (_image: ImageInfo, _token?: CancellationToken): ProviderResult<ImageFilesystemLayers> => {
+          return { layers: [] };
+        },
+      };
+      imageFiles.create(extensionInfo, provider);
+      expect(apiSender.send).toBeCalledWith('image-files-provider-update', {
+        id: `${extensionInfo.id}-0`,
+      });
+    });
+
+    test('sends "image-files-provider-remove" event when provider is disposed', () => {
+      const provider = {
+        getFilesystemLayers: (_image: ImageInfo, _token?: CancellationToken): ProviderResult<ImageFilesystemLayers> => {
+          return { layers: [] };
+        },
+      };
+      const dispo = imageFiles.create(extensionInfo, provider);
+      dispo.dispose();
+      expect(apiSender.send).toBeCalledWith('image-files-provider-remove', {
+        id: `${extensionInfo.id}-0`,
+      });
+    });
+
+    test('removes image files from the registry when disposed', () => {
+      const provider1 = {
+        getFilesystemLayers: (_image: ImageInfo, _token?: CancellationToken): ProviderResult<ImageFilesystemLayers> => {
+          return { layers: [] };
+        },
+      };
+      const provider2 = {
+        getFilesystemLayers: (_image: ImageInfo, _token?: CancellationToken): ProviderResult<ImageFilesystemLayers> => {
+          return { layers: [] };
+        },
+      };
+      const metadata1 = {
+        label: 'Provider label',
+      };
+      const dispo1 = imageFiles.create(extensionInfo, provider1, metadata1);
+      imageFiles.create(extensionInfo, provider2);
+      const providers = imageFiles.getImageFilesProviders();
+      expect(providers.length).toBe(2);
+      dispo1.dispose();
+      const providersAfterDispose = imageFiles.getImageFilesProviders();
+      expect(providersAfterDispose.length).toBe(1);
+    });
+
+    test('calls getFilesystemLayers method', async () => {
+      const file: ImageFile = {
+        path: 'bin',
+        type: 'directory',
+        mode: 0o755,
+        uid: 1000,
+        gid: 1000,
+        size: 400,
+        ctime: new Date(),
+        atime: new Date(),
+        mtime: new Date(),
+      };
+      const layer: ImageFilesystemLayer = {
+        id: '123',
+        files: [file],
+        whiteouts: ['to-be-deleted'],
+        opaqueWhiteouts: ['dir-to-be-deleted'],
+      };
+      const provider = {
+        getFilesystemLayers: (_image: ImageInfo, _token?: CancellationToken): ProviderResult<ImageFilesystemLayers> => {
+          return {
+            layers: [layer],
+          };
+        },
+      };
+      imageFiles.create(extensionInfo, provider);
+      const providers = imageFiles.getImageFilesProviders();
+      expect(providers.length).toBe(1);
+      const imageInfo: ImageInfo = {
+        engineId: 'eng-id',
+        engineName: 'eng-name',
+        Id: 'id',
+        ParentId: 'parent-id',
+        RepoTags: undefined,
+        Created: 0,
+        Size: 1,
+        VirtualSize: 1,
+        SharedSize: 1,
+        Labels: {},
+        Containers: 1,
+        Digest: 'sha256:id',
+      };
+      const result = await imageFiles.getFilesystemLayers(providers[0].id, imageInfo);
+      console.log('result', result);
+      expect(result).toBeDefined();
+      expect(result!.layers.length).toBe(1);
+      expect(result!.layers[0].files!.length).toBe(1);
+      expect(result!.layers[0].files![0]).toEqual(file);
+      expect(result!.layers[0].whiteouts!.length).toBe(1);
+      expect(result!.layers[0].whiteouts![0]).toBe('to-be-deleted');
+      expect(result!.layers[0].opaqueWhiteouts!.length).toBe(1);
+      expect(result!.layers[0].opaqueWhiteouts![0]).toBe('dir-to-be-deleted');
+    });
+
+    test('check method throws an error if provider is unknown', async () => {
+      const imageInfo: ImageInfo = {
+        engineId: 'eng-id',
+        engineName: 'eng-name',
+        Id: 'id',
+        ParentId: 'parent-id',
+        RepoTags: undefined,
+        Created: 0,
+        Size: 1,
+        VirtualSize: 1,
+        SharedSize: 1,
+        Labels: {},
+        Containers: 1,
+        Digest: 'sha256:id',
+      };
+      await expect(() => imageFiles.getFilesystemLayers('unknown-id', imageInfo)).rejects.toThrow(
+        'provider not found with id unknown-id',
+      );
+    });
+  });
+});

--- a/packages/main/src/plugin/image-files-registry.ts
+++ b/packages/main/src/plugin/image-files-registry.ts
@@ -1,0 +1,100 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type {
+  CancellationToken,
+  ImageFilesCallbacks,
+  ImageFilesProvider,
+  ImageFilesProviderMetadata,
+  ImageFilesystemLayers,
+  ImageInfo,
+} from '@podman-desktop/api';
+
+import type { ImageFilesExtensionInfo, ImageFilesInfo } from '/@api/image-files-info.js';
+
+import type { ApiSenderType } from './api.js';
+import { ImageFilesImpl } from './image-files-impl.js';
+
+export interface ImageFilesProviderWithMetadata {
+  id: string;
+  label: string;
+  provider: ImageFilesCallbacks;
+}
+
+export class ImageFilesRegistry {
+  private _imageFilesProviders: Map<string, ImageFilesProviderWithMetadata> = new Map<
+    string,
+    ImageFilesProviderWithMetadata
+  >();
+
+  constructor(private apiSender: ApiSenderType) {}
+
+  create(
+    extensionInfo: ImageFilesExtensionInfo,
+    provider: ImageFilesCallbacks,
+    metadata?: ImageFilesProviderMetadata,
+  ): ImageFilesProvider {
+    const label = metadata?.label ?? extensionInfo.label;
+    const idBase = `${extensionInfo.id}-`;
+    let id: string = '';
+    for (let i = 0; ; i++) {
+      const newId = idBase + i;
+      if (!this._imageFilesProviders.get(newId)) {
+        id = newId;
+        break;
+      }
+    }
+    if (id === '') {
+      throw new Error(`Unable to register an image files for extension '${extensionInfo.id}'.`);
+    }
+    this._imageFilesProviders.set(id, {
+      id,
+      label,
+      provider,
+    });
+    this.apiSender.send('image-files-provider-update', { id });
+    return new ImageFilesImpl(id, this);
+  }
+
+  disposeImageFiles(provider: ImageFilesImpl): void {
+    this._imageFilesProviders.delete(provider.id);
+    this.apiSender.send('image-files-provider-remove', { id: provider.id });
+  }
+
+  getImageFilesProviders(): ImageFilesInfo[] {
+    return Array.from(this._imageFilesProviders.keys()).map(k => {
+      const el = this._imageFilesProviders.get(k)!;
+      return {
+        id: k,
+        label: el.label,
+      };
+    });
+  }
+
+  async getFilesystemLayers(
+    providerId: string,
+    image: ImageInfo,
+    token?: CancellationToken,
+  ): Promise<ImageFilesystemLayers | undefined> {
+    const provider = this._imageFilesProviders.get(providerId);
+    if (provider === undefined) {
+      throw new Error('provider not found with id ' + providerId);
+    }
+    return provider.provider.getFilesystemLayers(image, token);
+  }
+}

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -59,6 +59,7 @@ import type { ExtensionInfo } from '/@api/extension-info';
 import type { HistoryInfo } from '/@api/history-info';
 import type { IconInfo } from '/@api/icon-info';
 import type { ImageCheckerInfo } from '/@api/image-checker-info';
+import type { ImageFilesInfo } from '/@api/image-files-info';
 import type { ImageInfo } from '/@api/image-info';
 import type { ImageInspectInfo } from '/@api/image-inspect-info';
 import type { ManifestCreateOptions, ManifestInspectInfo } from '/@api/manifest-info';
@@ -2081,6 +2082,21 @@ export function initExposure(): void {
       cancellationToken?: number,
     ): Promise<containerDesktopAPI.ImageChecks | undefined> => {
       return ipcInvoke('image-checker:check', id, image, cancellationToken);
+    },
+  );
+
+  contextBridge.exposeInMainWorld('getImageFilesProviders', async (): Promise<ImageFilesInfo[]> => {
+    return ipcInvoke('image-files:getProviders');
+  });
+
+  contextBridge.exposeInMainWorld(
+    'imageGetFilesystemLayers',
+    async (
+      id: string,
+      image: containerDesktopAPI.ImageInfo,
+      cancellationToken?: number,
+    ): Promise<containerDesktopAPI.ImageFilesystemLayers | undefined> => {
+      return ipcInvoke('image-files:getFilesystemLayers', id, image, cancellationToken);
     },
   );
 


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Adds an API for extensions to registrer as an Image Files provider.

Inspiration from [spec](https://github.com/opencontainers/image-spec/blob/main/spec.md) and [Node implementation of Image builder](https://github.com/google/nodejs-container-image-builder).

### What issues does this PR fix or reference?

Part of #7801 
