### PR TITLE
chore(extension-api): enhancing pod create options

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -392,13 +392,28 @@ declare module '@podman-desktop/api' {
     /**
      * Map of networks names to ids the container should join to.
      * You can request additional settings for each network, you can set network aliases,
-     * If the map is empty and the bridge network mode is set the container will be joined to the default network.
+     *
+     * @remarks
+     * {@link PodCreateOptions.netns.nsmode} need to be set to `bridge` to join a network
      */
     Networks?: {
       [key: string]: {
         aliases?: string[];
         interface_name?: string;
       };
+    };
+    /**
+     * Network namespace
+     */
+    netns?: {
+      /**
+       * NamespaceMode
+       * @example
+       * `bridge` indicates that the network backend (CNI/netavark) should be used.
+       * @example
+       * `pasta` indicates that a pasta network stack should be used.
+       */
+      nsmode: string;
     };
     /**
      * ExitPolicy determines the pod's exit and stop behaviour.

--- a/packages/main/src/plugin/api/pod-info.ts
+++ b/packages/main/src/plugin/api/pod-info.ts
@@ -51,4 +51,7 @@ export interface PodCreateOptions {
     };
   };
   exit_policy?: string;
+  netns?: {
+    nsmode: string;
+  };
 }

--- a/packages/main/src/plugin/dockerode/libpod-dockerode.ts
+++ b/packages/main/src/plugin/dockerode/libpod-dockerode.ts
@@ -95,6 +95,9 @@ export interface PodCreateOptions {
     };
   };
   exit_policy?: string;
+  netns?: {
+    nsmode: string;
+  };
 }
 
 export interface ContainerCreateMountOption {


### PR DESCRIPTION
### What does this PR do?

After some long tests to make a pod join a network, I find out that you need one more additional argument, the Network Mode.

Documentation https://github.com/containers/podman/blob/32d4b1644d5ee3c3a536886ae64ecee7d9b9a5b2/pkg/specgen/namespaces.go#L50 and https://docs.podman.io/en/latest/_static/api.html?version=v5.1#tag/pods/operation/PodCreateLibpod

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
