### PR TITLE
chore: update volumes summary page UI

### DIFF
--- a/packages/renderer/src/lib/volume/VolumeDetailsSummary.spec.ts
+++ b/packages/renderer/src/lib/volume/VolumeDetailsSummary.spec.ts
@@ -1,0 +1,72 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/svelte';
+import { expect, test } from 'vitest';
+
+import VolumeDetailsSummary from './VolumeDetailsSummary.svelte';
+import type { VolumeInfoUI } from './VolumeInfoUI';
+
+const fakeVolume: VolumeInfoUI = {
+  name: 'fakeVolume1',
+  shortName: 'fv1',
+  mountPoint: 'some-path',
+  scope: 'local1',
+  driver: 'local2',
+  created: '2024-06-18T15:17:03.000Z',
+  age: '3 days',
+  size: 5,
+  humanSize: '5 MB',
+  engineId: 'fakeEngineId',
+  engineName: 'fakeEngineName',
+  selected: false,
+  status: 'USED',
+  containersUsage: [
+    {
+      id: 'container1',
+      names: ['/name1', '/name2', 'name3'],
+    },
+    {
+      id: 'container2',
+      names: ['/name11', 'name12', '/name13'],
+    },
+  ],
+};
+
+// Test render VolumeDetailsSummary with VolumeInfoUI object
+test('VolumeDetailsSummary renders with VolumeInfoUI object', async () => {
+  // Render
+  render(VolumeDetailsSummary, { volume: fakeVolume });
+
+  // Check that the rendered text is correct
+  expect(screen.getByText('fakeVolume1')).toBeInTheDocument();
+  expect(screen.getByText('5 MB')).toBeInTheDocument();
+  expect(screen.getByText('some-path')).toBeInTheDocument();
+  expect(screen.getByText('local1')).toBeInTheDocument();
+  expect(screen.getByText('local2')).toBeInTheDocument();
+  expect(screen.getByText('used')).toBeInTheDocument();
+  expect(screen.getByText(new Date(fakeVolume.created).toString())).toBeInTheDocument();
+  expect(screen.getByText('name1 name2 name3')).toBeInTheDocument();
+  expect(screen.getByText('name11 name12 name13')).toBeInTheDocument();
+  expect(screen.getByText('container1')).toBeInTheDocument();
+  expect(screen.getByText('container2')).toBeInTheDocument();
+  expect(screen.getByText('fakeEngineId')).toBeInTheDocument();
+  expect(screen.getByText('fakeEngineName')).toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/volume/VolumeDetailsSummary.svelte
+++ b/packages/renderer/src/lib/volume/VolumeDetailsSummary.svelte
@@ -1,47 +1,76 @@
 <script lang="ts">
+import { Link } from '@podman-desktop/ui-svelte';
 import { router } from 'tinro';
 
+import DetailsCell from '../details/DetailsCell.svelte';
+import DetailsTable from '../details/DetailsTable.svelte';
+import DetailsTitle from '../details/DetailsTitle.svelte';
 import type { VolumeInfoUI } from './VolumeInfoUI';
 
 export let volume: VolumeInfoUI;
+const createdTime: Date = new Date(volume.created);
 
 function openContainer(containerID: string) {
   router.goto(`/containers/${containerID}/logs`);
 }
 </script>
 
-<div class="flex px-5 py-4 flex-col h-full overflow-auto text-[var(--pd-details-body-text)]">
-  <div class="w-full">
-    <table>
-      <tbody>
-        <tr>
-          <td class="pr-2">Name:</td>
-          <td>{volume.name}</td>
-        </tr>
-        <tr>
-          <td class="pr-2">Size:</td>
-          <td>{volume.humanSize}</td>
-        </tr>
-        <tr>
-          <td class="pr-2">Age:</td>
-          <td>{volume.age}</td>
-        </tr>
-      </tbody>
-    </table>
-  </div>
+<DetailsTable>
+  <tr>
+    <DetailsTitle>Details</DetailsTitle>
+  </tr>
+  <tr>
+    <DetailsCell>Name</DetailsCell>
+    <DetailsCell>{volume.name}</DetailsCell>
+  </tr>
+  <tr>
+    <DetailsCell>Size</DetailsCell>
+    <DetailsCell>{volume.humanSize}</DetailsCell>
+  </tr>
+  <tr>
+    <DetailsCell>Age</DetailsCell>
+    <DetailsCell>{volume.age}</DetailsCell>
+  </tr>
+  <tr>
+    <DetailsCell>Created</DetailsCell>
+    <DetailsCell>{createdTime}</DetailsCell>
+  </tr>
+  <tr>
+    <DetailsCell>Status</DetailsCell>
+    <DetailsCell>{volume.status.toLowerCase()}</DetailsCell>
+  </tr>
+  <tr>
+    <DetailsCell>Mount Point</DetailsCell>
+    <DetailsCell>{volume.mountPoint}</DetailsCell>
+  </tr>
+  <tr>
+    <DetailsCell>Scope</DetailsCell>
+    <DetailsCell>{volume.scope}</DetailsCell>
+  </tr>
+  <tr>
+    <DetailsCell>Driver</DetailsCell>
+    <DetailsCell>{volume.driver}</DetailsCell>
+  </tr>
+  <tr>
+    <DetailsCell>Engine ID</DetailsCell>
+    <DetailsCell>{volume.engineId}</DetailsCell>
+  </tr>
+  <tr>
+    <DetailsCell>Engine Name</DetailsCell>
+    <DetailsCell>{volume.engineName}</DetailsCell>
+  </tr>
   {#if volume.containersUsage.length > 0}
-    <div class="w-full mt-12">
-      <span>Containers using this volume:</span>
-      {#each volume.containersUsage as container}
-        <table>
-          <tbody>
-            <tr class="cursor-pointer" on:click="{() => openContainer(container.id)}">
-              <td class="pr-2">{container.names.join('')}</td>
-              <td>{container.id}</td>
-            </tr>
-          </tbody>
-        </table>
-      {/each}
-    </div>
+    <tr>
+      <DetailsTitle>Container Usage</DetailsTitle>
+    </tr>
+    {#each volume.containersUsage as container}
+      <tr>
+        <DetailsCell>
+          <Link on:click="{() => openContainer(container.id)}"
+            >{container.names.map(name => (name.startsWith('/') ? name.slice(1) : name)).join(' ')}</Link>
+        </DetailsCell>
+        <DetailsCell>{container.id}</DetailsCell>
+      </tr>
+    {/each}
   {/if}
-</div>
+</DetailsTable>


### PR DESCRIPTION
### What does this PR do?

Changes the UI of the summary page of volumes to match other summary pages

###  Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->
![Screenshot from 2024-06-24 21-02-20](https://github.com/containers/podman-desktop/assets/66797193/e9e0701a-a11d-4a5f-b29e-dac49db894e7)


###  What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop/issues/7562

###  How to test this PR?

<!-- Please explain steps to verify the functionality, do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature

View the summary page of a volume
