### PR TITLE
chore: light status icon default text color

### DIFF
--- a/packages/main/src/plugin/color-registry.ts
+++ b/packages/main/src/plugin/color-registry.ts
@@ -1197,6 +1197,13 @@ export class ColorRegistry {
       dark: colorPalette.gray[900],
       light: colorPalette.gray[100],
     });
+
+    // contrast color for the other status colors,
+    // e.g. to use in status icons
+    this.registerColor(`${status}contrast`, {
+      dark: colorPalette.white,
+      light: colorPalette.white,
+    });
   }
 
   protected initFormPage(): void {

--- a/packages/ui/src/lib/statusIcon/StatusIcon.spec.ts
+++ b/packages/ui/src/lib/statusIcon/StatusIcon.spec.ts
@@ -31,6 +31,7 @@ test('Expect starting styling', async () => {
   expect(icon).toHaveAttribute('title', status);
 
   expect(icon).toHaveClass('bg-[var(--pd-status-starting)]');
+  expect(icon).toHaveClass('text-[var(--pd-status-contrast)]');
 });
 
 test('Expect running styling', async () => {
@@ -41,6 +42,7 @@ test('Expect running styling', async () => {
   expect(icon).toHaveAttribute('title', status);
 
   expect(icon).toHaveClass('bg-[var(--pd-status-running)]');
+  expect(icon).toHaveClass('text-[var(--pd-status-contrast)]');
 });
 
 test('Expect degraded styling', async () => {
@@ -51,6 +53,7 @@ test('Expect degraded styling', async () => {
   expect(icon).toHaveAttribute('title', status);
 
   expect(icon).toHaveClass('bg-[var(--pd-status-degraded)]');
+  expect(icon).toHaveClass('text-[var(--pd-status-contrast)]');
 });
 
 test('Expect deleting styling', async () => {

--- a/packages/ui/src/lib/statusIcon/StatusIcon.svelte
+++ b/packages/ui/src/lib/statusIcon/StatusIcon.svelte
@@ -23,6 +23,7 @@ $: solid = status === 'RUNNING' || status === 'STARTING' || status === 'USED' ||
     class:p-1="{solid}"
     class:border-[var(--pd-status-not-running)]="{!solid}"
     class:text-[var(--pd-status-not-running)]="{!solid}"
+    class:text-[var(--pd-status-contrast)]="{solid}"
     role="status"
     title="{status}">
     {#if status === 'DELETING'}


### PR DESCRIPTION
### What does this PR do?

The status icon is currently picking up the default text (fill) color from the parent. This is fine at the moment while the default is white, but once we set the default text color in light mode to black (see PR #7729) the fill color would change to black.

This provides a new status color to use for the icons so that (as per design) they use their own color and do not pick up the default/parent text color.

I wasn't 100% sure it should be a '--pd-status' color since this isn't a status color per se like running or stopped, but it's much more obvious that it is related to the other status colors.

### Screenshot / video of UI

No visual change.

### What issues does this PR fix or reference?

Related to #7729. Fixes #7728.

### How to test this PR?

Automated tests, check status icon in a few different states.

- [x] Tests are covering the bug fix or the new feature