### PR TITLE
fix(website): Use consistent arch names on download page for macOS

### DIFF
--- a/website/src/pages/downloads/macos.tsx
+++ b/website/src/pages/downloads/macos.tsx
@@ -137,7 +137,7 @@ export function MacOSDownloads(): JSX.Element {
               className="underline inline-flex dark:text-white text-purple-500 hover:text-purple-200 py-2 px-6 text-md font-semibold"
               to={downloadData.arm64}>
               <FontAwesomeIcon size="1x" icon={faDownload} className="mr-2" />
-              Arm
+              Apple silicon
             </Link>
           </div>
           <div className="pt-2 pb-4 flex flex-col">
@@ -147,13 +147,13 @@ export function MacOSDownloads(): JSX.Element {
                 className="underline inline-flex dark:text-white text-purple-500 hover:text-purple-200 py-2 px-6 font-semibold text-md"
                 to={downloadData.airgapsetupX64}>
                 <FontAwesomeIcon size="1x" icon={faDownload} className="mr-2" />
-                x64
+                Intel
               </Link>
               <Link
                 className="underline inline-flex dark:text-white text-purple-500 hover:text-purple-200 py-2 px-6 font-semibold text-md"
                 to={downloadData.airgapsetupArm64}>
                 <FontAwesomeIcon size="1x" icon={faDownload} className="mr-2" />
-                arm64
+                Apple silicon
               </Link>
             </div>
           </div>


### PR DESCRIPTION
On https://podman-desktop.io/downloads there are 2 sets of non-universal
dmgs, with inconsistent architecture names (Intel/Arm and then
x64/arm64).
This commit changes these to Intel/Apple silicon for consistency in the
macOS section, and with the way Apple names these arches.