### PR TITLE
display image files

### DIFF
--- a/packages/main/src/plugin/color-registry.ts
+++ b/packages/main/src/plugin/color-registry.ts
@@ -477,6 +477,11 @@ export class ColorRegistry {
       light: colorPalette.purple[200],
     });
 
+    this.registerColor(`${ct}card-selected-bg`, {
+      dark: colorPalette.charcoal[400],
+      light: colorPalette.purple[100],
+    });
+
     this.registerColor(`${ct}card-text`, {
       dark: colorPalette.gray[400],
       light: colorPalette.purple[900],

--- a/packages/renderer/src/lib/image/FilesystemLayerView.svelte
+++ b/packages/renderer/src/lib/image/FilesystemLayerView.svelte
@@ -1,0 +1,87 @@
+<script context="module" lang="ts">
+const expansionState = new Map<string, boolean>();
+</script>
+
+<script lang="ts">
+import type { ImageFile, ImageFileSymlink } from '@podman-desktop/api';
+
+import type { FilesystemNode } from './filesystem-tree';
+import { ImageUtils } from './image-utils';
+import { isExec, modeString } from './imageDetailsFiles';
+
+export let tree: FilesystemNode<ImageFile>;
+export let margin = 0;
+export let root = true;
+export let layerMode = false;
+
+$: label = tree.name;
+$: children = tree?.children;
+$: file = tree?.data;
+$: colorClass = getColor(tree);
+function getColor(tree: FilesystemNode<ImageFile>) {
+  if (tree.hidden) {
+    return 'text-red-500';
+  }
+  if (!tree.data) {
+    if (tree.children.size) {
+      return 'text-sky-500';
+    }
+    return '';
+  }
+  if (tree.data.type === 'symlink') {
+    return 'text-sky-300';
+  }
+  if (tree.data.type === 'directory') {
+    return 'text-sky-500';
+  }
+  if (isExec(tree.data)) {
+    return 'text-green-500';
+  }
+  return '';
+}
+$: expanded = expansionState.get(label) ?? false;
+const toggleExpansion = () => {
+  expanded = !expanded;
+  expansionState.set(label, expanded);
+};
+$: arrowDown = expanded;
+function getLink(file: ImageFile | undefined): string {
+  if (!file) {
+    return '';
+  }
+  if (file.type === 'symlink') {
+    return ' → ' + (file as ImageFileSymlink).linkPath;
+  }
+  return '';
+}
+</script>
+
+{#if layerMode || !tree.hidden}
+  {#if root}
+    {#if children}
+      {#each children as [_, child]}
+        <svelte:self root="{false}" margin="{margin + 2}" tree="{child}" layerMode="{layerMode}" />
+      {/each}
+    {/if}
+  {:else}
+    <div class="font-mono">{tree.data && !tree.hidden ? modeString(tree.data) : ''}</div>
+    <div class="text-right">{tree.data && !tree.hidden ? tree.data.uid + ':' + tree.data.gid : ''}</div>
+    <span class="text-right">{!tree.hidden ? new ImageUtils().getHumanSize(tree.size) : ''}</span>
+    {#if children?.size || (file && file.type === 'directory')}
+      <button class="{`text-left ml-${margin} ${colorClass}`}" on:click="{toggleExpansion}">
+        <span class="cursor-pointer inline-block mr-1" class:rotate-90="{arrowDown}">&gt;</span>
+        {label}<span class="text-gray-900">{getLink(tree?.data)}</span>
+      </button>
+      {#if expanded && children}
+        {#each children as [_, child]}
+          <svelte:self root="{false}" margin="{margin + 2}" tree="{child}" layerMode="{layerMode}" />
+        {/each}
+      {/if}
+    {:else}
+      <div class="{`${colorClass}`}">
+        <span class="{`pl-4 ml-${margin}`}"></span>
+        {label}<span class="text-gray-900">{getLink(tree?.data)}</span>
+      </div>
+    {/if}
+  {/if}
+{/if}

--- a/packages/renderer/src/lib/image/ImageDetails.svelte
+++ b/packages/renderer/src/lib/image/ImageDetails.svelte
@@ -8,6 +8,7 @@ import { router } from 'tinro';
 import { containersInfos } from '/@/stores/containers';
 import { context } from '/@/stores/context';
 import { imageCheckerProviders } from '/@/stores/image-checker-providers';
+import { imageFilesProviders } from '/@/stores/image-files-providers';
 import { viewsContributions } from '/@/stores/views';
 import type { ViewInfoUI } from '/@api/view-info';
 
@@ -27,6 +28,7 @@ import {
 import { ImageUtils } from './image-utils';
 import ImageActions from './ImageActions.svelte';
 import ImageDetailsCheck from './ImageDetailsCheck.svelte';
+import ImageDetailsFiles from './ImageDetailsFiles.svelte';
 import ImageDetailsHistory from './ImageDetailsHistory.svelte';
 import ImageDetailsInspect from './ImageDetailsInspect.svelte';
 import ImageDetailsSummary from './ImageDetailsSummary.svelte';
@@ -64,7 +66,9 @@ let image: ImageInfoUI | undefined;
 let detailsPage: DetailsPage | undefined;
 
 let showCheckTab: boolean = false;
-let providersUnsubscribe: Unsubscriber;
+let showFilesTab: boolean = false;
+let checkerProvidersUnsubscribe: Unsubscriber;
+let filesProvidersUnsubscribe: Unsubscriber;
 let viewsUnsubscribe: Unsubscriber;
 let contextsUnsubscribe: Unsubscriber;
 
@@ -86,8 +90,12 @@ function updateImage() {
 }
 
 onMount(() => {
-  providersUnsubscribe = imageCheckerProviders.subscribe(providers => {
+  checkerProvidersUnsubscribe = imageCheckerProviders.subscribe(providers => {
     showCheckTab = providers.length > 0;
+  });
+
+  filesProvidersUnsubscribe = imageFilesProviders.subscribe(providers => {
+    showFilesTab = providers.length > 0;
   });
 
   viewsUnsubscribe = viewsContributions.subscribe(value => {
@@ -116,7 +124,8 @@ onMount(() => {
 
 onDestroy(() => {
   // unsubscribe from the store
-  providersUnsubscribe?.();
+  checkerProvidersUnsubscribe?.();
+  filesProvidersUnsubscribe?.();
   viewsUnsubscribe?.();
   contextsUnsubscribe?.();
 });
@@ -159,6 +168,9 @@ onDestroy(() => {
       {#if showCheckTab}
         <Tab title="Check" selected="{isTabSelected($router.path, 'check')}" url="{getTabUrl($router.path, 'check')}" />
       {/if}
+      {#if showFilesTab}
+        <Tab title="Files" selected="{isTabSelected($router.path, 'files')}" url="{getTabUrl($router.path, 'files')}" />
+      {/if}
     </svelte:fragment>
     <svelte:fragment slot="content">
       <Route path="/summary" breadcrumb="Summary" navigationHint="tab">
@@ -172,6 +184,9 @@ onDestroy(() => {
       </Route>
       <Route path="/check" breadcrumb="Check" navigationHint="tab">
         <ImageDetailsCheck imageInfo="{imageInfo}" />
+      </Route>
+      <Route path="/files" breadcrumb="Files" navigationHint="tab">
+        <ImageDetailsFiles imageInfo="{imageInfo}" />
       </Route>
     </svelte:fragment>
   </DetailsPage>

--- a/packages/renderer/src/lib/image/ImageDetailsFiles.svelte
+++ b/packages/renderer/src/lib/image/ImageDetailsFiles.svelte
@@ -1,0 +1,68 @@
+<script lang="ts">
+import type { ImageFilesystemLayers, ImageInfo } from '@podman-desktop/api';
+import { Checkbox } from '@podman-desktop/ui-svelte';
+import { onDestroy, onMount } from 'svelte';
+import type { Unsubscriber } from 'svelte/store';
+
+import { imageFilesProviders } from '/@/stores/image-files-providers';
+import type { ImageFilesInfo } from '/@api/image-files-info';
+
+import FilesystemLayerView from './FilesystemLayerView.svelte';
+import { type ImageFilesystemLayerUI, toImageFilesystemLayerUIs } from './imageDetailsFiles';
+import ImageDetailsFilesLayers from './ImageDetailsFilesLayers.svelte';
+
+export let imageInfo: ImageInfo | undefined;
+
+let imageLayers: ImageFilesystemLayers | undefined;
+let filesProvidersUnsubscribe: Unsubscriber;
+let filesProvider: ImageFilesInfo;
+let selectedLayer: ImageFilesystemLayerUI;
+let showLayerOnly: boolean;
+
+function onSelectedLayer(event: CustomEvent<ImageFilesystemLayerUI>) {
+  selectedLayer = event.detail;
+}
+
+onMount(async () => {
+  filesProvidersUnsubscribe = imageFilesProviders.subscribe(providers => {
+    if (providers.length === 1 && imageInfo) {
+      filesProvider = providers[0];
+      window.imageGetFilesystemLayers(filesProvider.id, imageInfo).then(layers => {
+        imageLayers = layers;
+      });
+    }
+  });
+});
+
+onDestroy(() => {
+  filesProvidersUnsubscribe?.();
+});
+</script>
+
+{#if imageLayers}
+  <div class="flex flex-col w-full h-full p-8 pr-0 text-[var(--pd-content-text)] bg-[var(--pd-content-bg)]">
+    <div class="pr-4">
+      <slot name="header-info" />
+    </div>
+    <div class="mb-2 flex flex-row pr-12 pb-2">
+      <span class="grow">Layers</span>
+      <span><Checkbox bind:checked="{showLayerOnly}">Show layer only</Checkbox></span>
+    </div>
+    <div class="h-full flex flex-row space-x-8">
+      <div role="list" aria-label="layers" class="h-full overflow-y-auto w-3/4">
+        <ImageDetailsFilesLayers
+          on:selected="{onSelectedLayer}"
+          layers="{toImageFilesystemLayerUIs(imageLayers.layers)}" />
+      </div>
+      <div aria-label="tree" class="h-full w-full pr-4 overflow-y-auto pb-16">
+        {#if selectedLayer}
+          <div class="text-xs grid grid-cols-[90px_60px_70px_1fr]">
+            <FilesystemLayerView
+              tree="{showLayerOnly ? selectedLayer.layerTree.root : selectedLayer.stackTree.root}"
+              layerMode="{showLayerOnly}" />
+          </div>
+        {/if}
+      </div>
+    </div>
+  </div>
+{/if}

--- a/packages/renderer/src/lib/image/ImageDetailsFilesLayers.svelte
+++ b/packages/renderer/src/lib/image/ImageDetailsFilesLayers.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+import { createEventDispatcher } from 'svelte';
+
+import { ImageUtils } from './image-utils';
+import type { ImageFilesystemLayerUI } from './imageDetailsFiles';
+
+const dispatch = createEventDispatcher();
+
+export let layers: ImageFilesystemLayerUI[];
+let currentLayerId: string | undefined;
+
+function onLayerSelected(layer: ImageFilesystemLayerUI) {
+  currentLayerId = layer.id;
+  dispatch('selected', layer);
+}
+</script>
+
+{#each layers as layer}
+  <button
+    on:click="{() => onLayerSelected(layer)}"
+    role="row"
+    aria-label="{layer.id}"
+    class="rounded-lg mb-4 p-4 flex flex-col w-full text-left truncate hover:bg-[var(--pd-content-card-hover-bg)]"
+    class:bg-[var(--pd-content-card-bg)]="{layer.id !== currentLayerId}"
+    class:bg-[var(--pd-content-card-selected-bg)]="{layer.id === currentLayerId}">
+    <div>
+      <div class="text-sm">{layer.createdBy}</div>
+      <div class="text-xs text-gray-700">{layer.id}</div>
+      <div class="text-xs text-gray-700">
+        <span>{new ImageUtils().getHumanSize(layer.sizeInArchive)}</span>
+        <span> | </span>
+        <span>{new ImageUtils().getHumanSize(layer.sizeInContainer)}</span>
+        <span> | </span>
+        <span>{new ImageUtils().getHumanSize(layer.stackTree.size)}</span>
+      </div>
+    </div>
+  </button>
+{/each}

--- a/packages/renderer/src/lib/image/filesystem-tree.spec.ts
+++ b/packages/renderer/src/lib/image/filesystem-tree.spec.ts
@@ -1,0 +1,156 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { expect, test } from 'vitest';
+
+import { FilesystemTree } from './filesystem-tree.js';
+
+interface typ {
+  path: string;
+}
+
+test('add paths to filetree', () => {
+  const tree = new FilesystemTree<typ>('tree1')
+    .addPath('A', { path: 'A-path' }, 5)
+    .addPath('a/', { path: 'a/-path' }, 0)
+    .addPath('a/b/c/d.txt', { path: 'a/b/c/d.txt-path' }, 3)
+    .addPath('a/b/c/e.txt', { path: 'a/b/c/e.txt-path' }, 4);
+
+  const copy = tree.copy();
+
+  for (const t of [tree, copy]) {
+    expect(t.size).toBe(12);
+    expect(t.root.children).toHaveLength(2);
+    expect(t.root.children.get('A')!.children).toHaveLength(0);
+    expect(t.root.children.get('A')!.data!.path).toBe('A-path');
+    expect(t.root.children.get('A')!.size).toBe(5);
+
+    expect(t.root.children.get('a')!.children).toHaveLength(1);
+    expect(t.root.children.get('a')!.data!.path).toBe('a/-path');
+    expect(t.root.children.get('a')!.size).toBe(7);
+
+    expect(t.root.children.get('a')!.children.get('b')!.children).toHaveLength(1);
+    expect(t.root.children.get('a')!.children.get('b')!.data).toBeUndefined();
+    expect(t.root.children.get('a')!.children.get('b')!.size).toBe(7);
+
+    expect(t.root.children.get('a')!.children.get('b')!.children.get('c')!.children).toHaveLength(2);
+    expect(t.root.children.get('a')!.children.get('b')!.children.get('c')!.data).toBeUndefined();
+    expect(t.root.children.get('a')!.children.get('b')!.children.get('c')!.size).toBe(7);
+
+    expect(
+      t.root.children.get('a')!.children.get('b')!.children.get('c')!.children.get('d.txt')!.children,
+    ).toHaveLength(0);
+    expect(t.root.children.get('a')!.children.get('b')!.children.get('c')!.children.get('d.txt')!.data!.path).toBe(
+      'a/b/c/d.txt-path',
+    );
+    expect(t.root.children.get('a')!.children.get('b')!.children.get('c')!.children.get('d.txt')!.size).toBe(3);
+
+    expect(
+      t.root.children.get('a')!.children.get('b')!.children.get('c')!.children.get('e.txt')!.children,
+    ).toHaveLength(0);
+    expect(t.root.children.get('a')!.children.get('b')!.children.get('c')!.children.get('e.txt')!.data!.path).toBe(
+      'a/b/c/e.txt-path',
+    );
+    expect(t.root.children.get('a')!.children.get('b')!.children.get('c')!.children.get('e.txt')!.size).toBe(4);
+  }
+});
+
+test('currentSize with existing file', () => {
+  const tree = new FilesystemTree<typ>('tree1').addPath('A/B/C.txt', { path: 'A/B/C.txt' }, 5);
+  const current = tree.currentSize('A/B/C.txt');
+  expect(current).toBe(5);
+});
+
+test('currentSize with non existing file', () => {
+  const tree = new FilesystemTree<typ>('tree1').addPath('A/B/C.txt', { path: 'A/B/C.txt' }, 5);
+  const current = tree.currentSize('A/B/C.log');
+  expect(current).toBe(undefined);
+});
+
+test('add an existing file', () => {
+  const tree = new FilesystemTree<typ>('tree1')
+    .addPath('A/B/C.txt', { path: 'A/B/C.txt ' }, 5)
+    .addPath('A/B/C.txt', { path: 'A/B/C.txt ' }, 4);
+  expect(tree.size).toBe(4);
+  expect(tree.root.children).toHaveLength(1);
+  expect(tree.root.children.get('A')!.children).toHaveLength(1);
+  expect(tree.root.children.get('A')!.children.get('B')!.children).toHaveLength(1);
+  expect(tree.root.children.get('A')!.children.get('B')!.children.get('C.txt')!.children).toHaveLength(0);
+});
+
+test('remove a non existing file', () => {
+  const tree = new FilesystemTree<typ>('tree1').addPath('A/B/C.txt', { path: 'A/B/C.txt' }, 5).hidePath('A/B/D.txt');
+  expect(tree.size).toBe(5);
+  expect(tree.root.children).toHaveLength(1);
+  expect(tree.root.children.get('A')!.children).toHaveLength(1);
+  expect(tree.root.children.get('A')!.children.get('B')!.children).toHaveLength(1);
+  expect(tree.root.children.get('A')!.children.get('B')!.children.get('C.txt')!.children).toHaveLength(0);
+  expect(tree.root.children.get('A')!.children.get('B')!.children.get('C.txt')!.hidden).toBeFalsy();
+});
+
+test('remove an existing file', () => {
+  const tree = new FilesystemTree<typ>('tree1').addPath('A/B/C.txt', { path: 'A/B/C.txt' }, 5).hidePath('A/B/C.txt');
+  expect(tree.size).toBe(0);
+  expect(tree.root.children).toHaveLength(1);
+  expect(tree.root.children.get('A')!.children).toHaveLength(1);
+  expect(tree.root.children.get('A')!.children.get('B')!.children).toHaveLength(1);
+  expect(tree.root.children.get('A')!.children.get('B')!.children.get('C.txt')!.children).toHaveLength(0);
+  expect(tree.root.children.get('A')!.children.get('B')!.children.get('C.txt')!.hidden).toBeTruthy();
+});
+
+test('add a whiteout', () => {
+  const tree = new FilesystemTree<typ>('tree1').addWhiteout('A/B/C.txt');
+  expect(tree.size).toBe(0);
+  expect(tree.root.children).toHaveLength(1);
+  expect(tree.root.children.get('A')!.children).toHaveLength(1);
+  expect(tree.root.children.get('A')!.children.get('B')!.children).toHaveLength(1);
+  expect(tree.root.children.get('A')!.children.get('B')!.children.get('C.txt')!.children).toHaveLength(0);
+  expect(tree.root.children.get('A')!.children.get('B')!.children.get('C.txt')!.hidden).toBeTruthy();
+});
+
+test('hide content of non-existing directory', () => {
+  const tree = new FilesystemTree<typ>('tree1')
+    .addPath('A/B/C.txt', { path: 'A/B/C.txt' }, 1)
+    .addPath('A/B/D.txt', { path: 'A/B/D.txt' }, 2)
+    .hideDirectoryContent('A/E');
+  expect(tree.size).toBe(3);
+  expect(tree.root.children).toHaveLength(1);
+  expect(tree.root.children.get('A')!.children).toHaveLength(1);
+  expect(tree.root.children.get('A')!.children.get('B')!.children).toHaveLength(2);
+  expect(tree.root.children.get('A')!.children.get('B')!.hidden).toBeFalsy();
+  expect(tree.root.children.get('A')!.children.get('B')!.children.get('C.txt')!.children).toHaveLength(0);
+  expect(tree.root.children.get('A')!.children.get('B')!.children.get('C.txt')!.hidden).toBeFalsy();
+  expect(tree.root.children.get('A')!.children.get('B')!.children.get('D.txt')!.children).toHaveLength(0);
+  expect(tree.root.children.get('A')!.children.get('B')!.children.get('D.txt')!.hidden).toBeFalsy();
+});
+
+test('hide directory content', () => {
+  const tree = new FilesystemTree<typ>('tree1')
+    .addPath('A/B/C.txt', { path: 'A/B/C.txt' }, 1)
+    .addPath('A/B/D.txt', { path: 'A/B/D.txt' }, 2)
+    .hideDirectoryContent('A');
+  expect(tree.size).toBe(0);
+  expect(tree.root.children).toHaveLength(1);
+  expect(tree.root.children.get('A')!.children).toHaveLength(1);
+  expect(tree.root.children.get('A')!.children.get('B')!.children).toHaveLength(2);
+  expect(tree.root.children.get('A')!.children.get('B')!.hidden).toBeTruthy();
+  expect(tree.root.children.get('A')!.children.get('B')!.children.get('C.txt')!.children).toHaveLength(0);
+  expect(tree.root.children.get('A')!.children.get('B')!.children.get('C.txt')!.hidden).toBeTruthy();
+  expect(tree.root.children.get('A')!.children.get('B')!.children.get('D.txt')!.children).toHaveLength(0);
+  expect(tree.root.children.get('A')!.children.get('B')!.children.get('D.txt')!.hidden).toBeTruthy();
+});

--- a/packages/renderer/src/lib/image/filesystem-tree.ts
+++ b/packages/renderer/src/lib/image/filesystem-tree.ts
@@ -1,0 +1,192 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+export class FilesystemNode<T> {
+  name: string;
+  data?: T;
+  children: Map<string, FilesystemNode<T>>;
+  size: number;
+  hidden: boolean;
+
+  constructor(name: string) {
+    this.name = name;
+    this.children = new Map<string, FilesystemNode<T>>();
+    this.size = 0;
+    this.hidden = false;
+  }
+
+  addChild(name: string): FilesystemNode<T> {
+    const child = new FilesystemNode<T>(name);
+    this.children.set(name, child);
+    return child;
+  }
+
+  copy(): FilesystemNode<T> {
+    const result = new FilesystemNode<T>(this.name);
+    result.data = this.data;
+    result.size = this.size;
+    result.hidden = this.hidden;
+    for (const [name, child] of this.children) {
+      result.children.set(name, child.copy());
+    }
+    return result;
+  }
+}
+
+export class FilesystemTree<T> {
+  name: string;
+  root: FilesystemNode<T>;
+  size: number;
+
+  constructor(name: string) {
+    this.name = name;
+    this.root = new FilesystemNode<T>('/');
+    this.size = 0;
+  }
+
+  addPath(path: string, entry: T, size: number): FilesystemTree<T> {
+    const currentSize = this.currentSize(path);
+    this.size += size - (currentSize ?? 0);
+    const parts = path.split('/');
+    let node = this.root;
+    for (let i = 0; i < parts.length; i++) {
+      const part = parts[i];
+      if (part === '') {
+        continue;
+      }
+      const next = node.children.get(part);
+      if (next) {
+        node = next;
+      } else {
+        node = node.addChild(part);
+      }
+      node.size += size - (currentSize ?? 0);
+    }
+    node.data = entry;
+    return this;
+  }
+
+  hideDirectoryContent(path: string): FilesystemTree<T> {
+    const currentSize = this.currentSize(path);
+    if (currentSize === undefined) {
+      // the path is not found, return now
+      return this;
+    }
+    this.size -= currentSize;
+    const parts = path.split('/');
+    let node = this.root;
+    for (let i = 0; i < parts.length; i++) {
+      const part = parts[i];
+      if (part === '') {
+        continue;
+      }
+      const next = node.children.get(part);
+      if (next) {
+        node = next;
+      } else {
+        return this;
+      }
+      node.size -= currentSize;
+    }
+    for (const child of node.children.values()) {
+      this.hideRecursive(child);
+    }
+    return this;
+  }
+
+  hideRecursive(node: FilesystemNode<T>): void {
+    node.hidden = true;
+    for (const child of node.children.values()) {
+      this.hideRecursive(child);
+    }
+  }
+
+  hidePath(path: string): FilesystemTree<T> {
+    const currentSize = this.currentSize(path);
+    if (currentSize === undefined) {
+      // the path is not found, return now
+      return this;
+    }
+    this.size -= currentSize;
+    const parts = path.split('/');
+    let node = this.root;
+    for (let i = 0; i < parts.length; i++) {
+      const part = parts[i];
+      if (part === '') {
+        continue;
+      }
+      const next = node.children.get(part);
+      if (next) {
+        node = next;
+      } else {
+        return this;
+      }
+      node.size -= currentSize;
+    }
+    node.hidden = true;
+    return this;
+  }
+
+  addWhiteout(path: string): FilesystemTree<T> {
+    const currentSize = this.currentSize(path);
+    this.size -= currentSize ?? 0;
+    const parts = path.split('/');
+    let node = this.root;
+    for (let i = 0; i < parts.length; i++) {
+      const part = parts[i];
+      if (part === '') {
+        continue;
+      }
+      const next = node.children.get(part);
+      if (next) {
+        node = next;
+      } else {
+        node = node.addChild(part);
+      }
+      node.size -= currentSize ?? 0;
+    }
+    node.hidden = true;
+    return this;
+  }
+
+  // returns the size of the file is it already exists in the tree, or 0 otherwise
+  currentSize(path: string): number | undefined {
+    const parts = path.split('/');
+    let node = this.root;
+    for (let i = 0; i < parts.length; i++) {
+      const part = parts[i];
+      if (part === '') {
+        continue;
+      }
+      const next = node.children.get(part);
+      if (next) {
+        node = next;
+      } else {
+        return undefined;
+      }
+    }
+    return node.size;
+  }
+
+  copy(): FilesystemTree<T> {
+    const result = new FilesystemTree<T>(this.name);
+    result.size = this.size;
+    result.root = this.root.copy();
+    return result;
+  }
+}

--- a/packages/renderer/src/lib/image/imageDetailsFiles.spec.ts
+++ b/packages/renderer/src/lib/image/imageDetailsFiles.spec.ts
@@ -1,0 +1,175 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { ImageFilesystemLayer } from '@podman-desktop/api';
+import { expect, test } from 'vitest';
+
+import { toImageFilesystemLayerUIs } from './imageDetailsFiles';
+
+test('toImageFilesystemLayerUIs with only added files', () => {
+  const input: ImageFilesystemLayer[] = [
+    {
+      id: 'layer1',
+      files: [
+        {
+          path: 'A/B/C.txt',
+          type: 'file',
+          mode: 0o644,
+          uid: 1,
+          gid: 1,
+          ctime: new Date(),
+          atime: new Date(),
+          mtime: new Date(),
+          size: 100,
+        },
+        {
+          path: 'A/B/D.txt',
+          type: 'file',
+          mode: 0o644,
+          uid: 1,
+          gid: 1,
+          ctime: new Date(),
+          atime: new Date(),
+          mtime: new Date(),
+          size: 50,
+        },
+      ],
+    },
+    {
+      id: 'layer2',
+      files: [
+        {
+          path: 'A/B/E.txt',
+          type: 'file',
+          mode: 0o644,
+          uid: 1,
+          gid: 1,
+          ctime: new Date(),
+          atime: new Date(),
+          mtime: new Date(),
+          size: 20,
+        },
+      ],
+    },
+  ];
+  const result = toImageFilesystemLayerUIs(input);
+  expect(result[0].sizeInArchive).toBe(150);
+  expect(result[0].sizeInContainer).toBe(150);
+  expect(result[0].stackTree.size).toBe(150);
+  expect(result[1].sizeInArchive).toBe(20);
+  expect(result[1].sizeInContainer).toBe(20);
+  expect(result[1].stackTree.size).toBe(170);
+});
+
+test('toImageFilesystemLayerUIs with a modified file', () => {
+  const input: ImageFilesystemLayer[] = [
+    {
+      id: 'layer1',
+      files: [
+        {
+          path: 'A/B/C.txt',
+          type: 'file',
+          mode: 0o644,
+          uid: 1,
+          gid: 1,
+          ctime: new Date(),
+          atime: new Date(),
+          mtime: new Date(),
+          size: 100,
+        },
+        {
+          path: 'A/B/D.txt',
+          type: 'file',
+          mode: 0o644,
+          uid: 1,
+          gid: 1,
+          ctime: new Date(),
+          atime: new Date(),
+          mtime: new Date(),
+          size: 50,
+        },
+      ],
+    },
+    {
+      id: 'layer2',
+      files: [
+        {
+          path: 'A/B/D.txt',
+          type: 'file',
+          mode: 0o644,
+          uid: 1,
+          gid: 1,
+          ctime: new Date(),
+          atime: new Date(),
+          mtime: new Date(),
+          size: 42,
+        },
+      ],
+    },
+  ];
+  const result = toImageFilesystemLayerUIs(input);
+  expect(result[0].sizeInArchive).toBe(150);
+  expect(result[0].sizeInContainer).toBe(150);
+  expect(result[0].stackTree.size).toBe(150);
+  expect(result[1].sizeInArchive).toBe(42);
+  expect(result[1].sizeInContainer).toBe(-8);
+  expect(result[1].stackTree.size).toBe(142);
+});
+
+test('toImageFilesystemLayerUIs with an file', () => {
+  const input: ImageFilesystemLayer[] = [
+    {
+      id: 'layer1',
+      files: [
+        {
+          path: 'A/B/C.txt',
+          type: 'file',
+          mode: 0o644,
+          uid: 1,
+          gid: 1,
+          ctime: new Date(),
+          atime: new Date(),
+          mtime: new Date(),
+          size: 100,
+        },
+        {
+          path: 'A/B/D.txt',
+          type: 'file',
+          mode: 0o644,
+          uid: 1,
+          gid: 1,
+          ctime: new Date(),
+          atime: new Date(),
+          mtime: new Date(),
+          size: 50,
+        },
+      ],
+    },
+    {
+      id: 'layer2',
+      whiteouts: ['A/B/D.txt'],
+    },
+  ];
+  const result = toImageFilesystemLayerUIs(input);
+  expect(result[0].sizeInArchive).toBe(150);
+  expect(result[0].sizeInContainer).toBe(150);
+  expect(result[0].stackTree.size).toBe(150);
+  expect(result[1].sizeInArchive).toBe(0);
+  expect(result[1].sizeInContainer).toBe(-50);
+  expect(result[1].stackTree.size).toBe(100);
+});

--- a/packages/renderer/src/lib/image/imageDetailsFiles.ts
+++ b/packages/renderer/src/lib/image/imageDetailsFiles.ts
@@ -1,0 +1,84 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { ImageFile, ImageFilesystemLayer } from '@podman-desktop/api';
+
+import { FilesystemTree } from './filesystem-tree';
+
+export interface ImageFilesystemLayerUI extends ImageFilesystemLayer {
+  // The files of the current layer and previous ones
+  stackTree: FilesystemTree<ImageFile>;
+  // The files of the current layer only
+  layerTree: FilesystemTree<ImageFile>;
+  // The sum of the sizes of all the files in the layer
+  sizeInArchive: number;
+  // The size of the files in the final filesystem
+  sizeInContainer: number;
+}
+
+export function toImageFilesystemLayerUIs(layers: ImageFilesystemLayer[]): ImageFilesystemLayerUI[] {
+  const result: ImageFilesystemLayerUI[] = [];
+  let containerSizePreviousLayer = 0;
+  const stackTree = new FilesystemTree<ImageFile>('');
+  for (const layer of layers) {
+    const layerTree = new FilesystemTree<ImageFile>('');
+    let sizeInArchive = 0;
+    for (const whiteout of layer.whiteouts ?? []) {
+      stackTree.hidePath(whiteout);
+      layerTree.addWhiteout(whiteout);
+    }
+    for (const opaqueWhiteout of layer.opaqueWhiteouts ?? []) {
+      stackTree.hideDirectoryContent(opaqueWhiteout);
+      layerTree.addWhiteout(`${opaqueWhiteout}/*`);
+    }
+    for (const file of layer.files ?? []) {
+      stackTree.addPath(file.path, file, file.size);
+      layerTree.addPath(file.path, file, file.size);
+      sizeInArchive += file.size;
+    }
+    result.push({
+      stackTree: stackTree.copy(),
+      layerTree,
+      ...layer,
+      sizeInContainer: stackTree.size - containerSizePreviousLayer,
+      sizeInArchive,
+    });
+    containerSizePreviousLayer = stackTree.size;
+  }
+  return result;
+}
+
+export function isExec(data: ImageFile): boolean {
+  return (data.mode & 0o111) !== 0;
+}
+
+// SUID, SGID, and sticky bit: https://www.redhat.com/sysadmin/suid-sgid-sticky-bit
+export function modeString(data: ImageFile): string {
+  return (
+    (data.type === 'directory' ? 'd' : '-') +
+    (data.mode & 0o400 ? 'r' : '-') +
+    (data.mode & 0o200 ? 'w' : '-') +
+    (data.mode & 0o4000 ? (data.mode & 0o100 ? 's' : 'S') : data.mode & 0o100 ? 'x' : '-') +
+    (data.mode & 0o040 ? 'r' : '-') +
+    (data.mode & 0o020 ? 'w' : '-') +
+    (data.mode & 0o2000 ? (data.mode & 0o010 ? 's' : 'S') : data.mode & 0o010 ? 'x' : '-') +
+    (data.mode & 0o004 ? 'r' : '-') +
+    (data.mode & 0o002 ? 'w' : '-') +
+    (data.mode & 0o1000 ? 't' : data.mode & 0o001 ? 'x' : '-')
+  );
+}

--- a/packages/renderer/src/stores/image-files-providers.ts
+++ b/packages/renderer/src/stores/image-files-providers.ts
@@ -1,0 +1,53 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { type Writable, writable } from 'svelte/store';
+
+import type { ImageFilesInfo } from '/@api/image-files-info';
+
+import { EventStore } from './event-store';
+
+const windowEvents = ['image-files-provider-update', 'image-files-provider-remove'];
+const windowListeners = ['extensions-already-started'];
+
+let readyToUpdate = false;
+
+export async function checkForUpdate(eventName: string): Promise<boolean> {
+  if ('extensions-already-started' === eventName) {
+    readyToUpdate = true;
+  }
+
+  // do not fetch until extensions are all started
+  return readyToUpdate;
+}
+
+export const imageFilesProviders: Writable<readonly ImageFilesInfo[]> = writable([]);
+
+const getImageFilesProvidersInfo = (): Promise<readonly ImageFilesInfo[]> => {
+  return window.getImageFilesProviders();
+};
+
+const eventStore = new EventStore<readonly ImageFilesInfo[]>(
+  'image files providers',
+  imageFilesProviders,
+  checkForUpdate,
+  windowEvents,
+  windowListeners,
+  getImageFilesProvidersInfo,
+);
+eventStore.setup();


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Display the files in an image.

Current limitations:

- works only if a single provider is installed
- doc needs to be written to explain the sizes displayed in the layers cards and what does the checkbox `Show layer only`
- design to be discussed

### Screenshot / video of UI

https://github.com/containers/podman-desktop/assets/9973512/01fe9386-abd4-495b-9447-7c595f53fa65

### What issues does this PR fix or reference?

Fixes #7801 

### How to test this PR?

Start Podman Desktop with the fake extension https://github.com/feloy/podman-desktop-extension-image-files-fake, for example:

```
yarn watch --extension-folder ../podman-desktop-extension-image-files-fake/
```

Go to the details page of an image, and select the Files tab.

Navigate through the layers and see the files in this layer.

A checkbox `Show layer only` gives the choice to:
- (off) display the state of the filesystem at this layer (considering all the layers up to this one)
- (on) display only the files added/deleted/modified in this layer
 
- [x] Tests are covering the bug fix or the new feature
