### PR TITLE
fix: throw an error when override for a module requires extension path

### DIFF
--- a/packages/main/src/plugin/module-loader.spec.ts
+++ b/packages/main/src/plugin/module-loader.spec.ts
@@ -75,10 +75,10 @@ test('module loader overrides modules registered as factory', () => {
   expect(loadedModule2).equal(fakeApi);
 });
 
-test('module loader trow exception if request came not from extension', () => {
+test('module loader trow exception if override is a function and request came not from extension', () => {
   let error;
   try {
-    fakeModule._load('module1', { filename: '/path/to/none/ext/internal/module1.js', path: '/path/to/ext' });
+    fakeModule._load('module2', { filename: '/path/to/none/ext/internal/module1.js', path: '/path/to/ext' });
   } catch (err) {
     error = err;
   }


### PR DESCRIPTION
### What does this PR do?

There are two types of module override:
* function that get extension metadata as a parameter and returns a module (usually just returns `api` property of an extension object)
* module name to overridden module object mapping

PR changes module loader logic. If override is a function then module loading should be requested from extension folder or exception to be thrown. If override is a mapping, then parent.path is used as a key for chache.

### Screenshot / video of UI

n/a

### What issues does this PR fix or reference?

Fix #7833

### How to test this PR?

- [x] Tests are covering the bug fix or the new feature
