### PR TITLE
fix: remove @kubernetes/client-node from kubectl-cli vite config

### DIFF
--- a/extensions/kubectl-cli/vite.config.js
+++ b/extensions/kubectl-cli/vite.config.js
@@ -46,7 +46,7 @@ const config = {
       formats: ['cjs'],
     },
     rollupOptions: {
-      external: ['@podman-desktop/api', '@kubernetes/client-node', ...builtinModules.flatMap(p => [p, `node:${p}`])],
+      external: ['@podman-desktop/api', ...builtinModules.flatMap(p => [p, `node:${p}`])],
       output: {
         entryFileNames: '[name].js',
       },


### PR DESCRIPTION
### What does this PR do?

removes '@kubernetes/client-node' from vite external packages configuration, because this package is not used in kubectl-cli extension.