### PR TITLE
chore(ci): include junit file path to be in test artifacts

### DIFF
--- a/.github/workflows/e2e-main.yaml
+++ b/.github/workflows/e2e-main.yaml
@@ -98,4 +98,6 @@ jobs:
         if: always()
         with:
           name: e2e-tests
-          path: ./tests/output/
+          path: |
+            ./tests/output/
+            ./tests/**/output/junit*.xml

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -276,4 +276,6 @@ jobs:
         if: always()
         with:
           name: smoke-e2e-tests
-          path: ./tests/output/
+          path: |
+            ./tests/output/
+            ./tests/**/output/junit*.xml


### PR DESCRIPTION
### What does this PR do?
Grabs junit files in podman-desktop tests folder where they are expected.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
#7858 
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?
Check Smoke e2e test artifacts. Junit file should be included under `playwright/output/`
<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
