### PR TITLE
chore(ci): exclude playwright raw traces from archived artifacts

### DIFF
--- a/.github/workflows/e2e-main.yaml
+++ b/.github/workflows/e2e-main.yaml
@@ -101,3 +101,4 @@ jobs:
           path: |
             ./tests/output/
             ./tests/**/output/junit*.xml
+            !./tests/**/traces/raw

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -279,3 +279,4 @@ jobs:
           path: |
             ./tests/output/
             ./tests/**/output/junit*.xml
+            !./tests/**/traces/raw


### PR DESCRIPTION
### What does this PR do?
Prevents uploading of raw playwright traces, we have traces in archives already.
### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
#7860
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

The test artifacts now should be smaller (previous size around 180 MB, now should be less) and there should not be `**/tests/output/traces/raw` folder or its content.

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
