### PR TITLE
API provides ability to browse images on remote repositories

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -3417,6 +3417,71 @@ declare module '@podman-desktop/api' {
   }
 
   /**
+   * Options when searching images in registries
+   */
+  export interface SearchImagesOptions {
+    /**
+     * Term to search, in the form `[<registry>/]searchTerm`. For example, `quay.io/http` to search images with `http` search term in `quay.io` registry
+     */
+    term: string;
+    /**
+     * Maximum number of results to return. Defaults to 25
+     */
+    limit?: number;
+    /**
+     * If true, the `Tag` field of the result will be filled. Defaults to false
+     */
+    listTags?: boolean;
+    /**
+     * If true, require HTTPS and verify signatures when contacting registries. Defaults to true
+     */
+    tlsVerify?: boolean;
+    /**
+     * Return only images marked as Automated
+     */
+    filterIsAutomated?: boolean;
+    /**
+     * Return only images marked as Official
+     */
+    filterIsOfficial?: boolean;
+    /**
+     * Return only images with at least this number of images
+     */
+    filterMinStars?: number;
+  }
+
+  export interface SearchImagesResponseInfo {
+    /**
+     * Index of the registry providing the image
+     */
+    Index: string;
+    /**
+     * Name of the image
+     */
+    Name: string;
+    /**
+     * Description of the image, in Markdown format
+     */
+    Description: string;
+    /**
+     * Number of stars in the image
+     */
+    Stars: number;
+    /**
+     * Indicate if the image is official
+     */
+    Official: string;
+    /**
+     * Indicate if the image is automated
+     */
+    Automated: string;
+    /**
+     * If true, return one result for each tag of the image
+     */
+    Tag: string;
+  }
+
+  /**
    *  Module providing operations to execute on all container providers
    */
   export namespace containerEngine {
@@ -3608,6 +3673,16 @@ declare module '@podman-desktop/api' {
      * @return A promise resolving to a structure containing the image information
      */
     export function getImageInspect(engineId: string, id: string): Promise<ImageInspectInfo>;
+
+    /**
+     * Search images in Image Registries using a specific engine
+     * @param engineId the id of the engine to use for querying the registries, obtained from the result of {@link containerEngine.listInfos}
+     * @param searchOptions options for the search
+     */
+    export function searchImages(
+      engineId: string,
+      searchOptions: SearchImagesOptions,
+    ): Promise<SearchImagesResponseInfo[]>;
 
     export function info(engineId: string): Promise<ContainerEngineInfo>;
 

--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -4720,3 +4720,53 @@ test('inspectManifest should fail if libpod is missing from the provider', async
     'LibPod is not supported by this engine',
   );
 });
+
+describe('searchImages', () => {
+  test('search images on a specific provider with term only', async () => {
+    const searchImagesMock = vi.fn();
+    containerRegistry.addInternalProvider('podman1', {
+      name: 'podman1',
+      id: 'podman1',
+      connection: {
+        type: 'podman',
+      },
+      api: {
+        searchImages: searchImagesMock,
+      } as unknown as Dockerode,
+    } as InternalContainerProvider);
+
+    const options: podmanDesktopAPI.SearchImagesOptions = {
+      term: 'http',
+    };
+    await containerRegistry.searchImages('podman1', options);
+
+    expect(searchImagesMock).toHaveBeenCalledWith(options);
+  });
+
+  test('search images on a specific provider with all options', async () => {
+    const searchImagesMock = vi.fn();
+    containerRegistry.addInternalProvider('podman1', {
+      name: 'podman1',
+      id: 'podman1',
+      connection: {
+        type: 'podman',
+      },
+      api: {
+        searchImages: searchImagesMock,
+      } as unknown as Dockerode,
+    } as InternalContainerProvider);
+
+    const options: podmanDesktopAPI.SearchImagesOptions = {
+      term: 'http',
+      limit: 5,
+      listTags: true,
+      tlsVerify: false,
+      filterIsAutomated: true,
+      filterIsOfficial: true,
+      filterMinStars: 1000,
+    };
+    await containerRegistry.searchImages('podman1', options);
+
+    expect(searchImagesMock).toHaveBeenCalledWith(options);
+  });
+});

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -2631,4 +2631,18 @@ export class ContainerProviderRegistry {
       return Promise.reject(errors);
     }
   }
+
+  async searchImages(
+    engineId: string,
+    searchOptions: containerDesktopAPI.SearchImagesOptions,
+  ): Promise<containerDesktopAPI.SearchImagesResponseInfo[]> {
+    const provider = this.internalProviders.get(engineId);
+    if (!provider) {
+      throw new Error('no engine matching this container');
+    }
+    if (!provider.api) {
+      throw new Error('no running provider for the matching container');
+    }
+    return provider.api.searchImages(searchOptions);
+  }
 }

--- a/packages/main/src/plugin/extension-loader.spec.ts
+++ b/packages/main/src/plugin/extension-loader.spec.ts
@@ -163,6 +163,7 @@ const containerProviderRegistry: ContainerProviderRegistry = {
   listImages: vi.fn(),
   podmanListImages: vi.fn(),
   listInfos: vi.fn(),
+  searchImages: vi.fn(),
 } as unknown as ContainerProviderRegistry;
 
 const inputQuickPickRegistry: InputQuickPickRegistry = {} as unknown as InputQuickPickRegistry;
@@ -2089,6 +2090,24 @@ describe('containerEngine', async () => {
         name: 'dummyProvider',
       },
     });
+  });
+
+  test('searchImages', async () => {
+    vi.mocked(containerProviderRegistry.searchImages).mockResolvedValue([]);
+    const disposables: IDisposable[] = [];
+    const api = extensionLoader.createApi('/path', {}, disposables);
+    const options: containerDesktopAPI.SearchImagesOptions = {
+      term: 'http',
+      limit: 5,
+      listTags: true,
+      tlsVerify: false,
+      filterIsAutomated: true,
+      filterIsOfficial: true,
+      filterMinStars: 1000,
+    };
+    const images = await api.containerEngine.searchImages('engine1', options);
+    expect(images.length).toBe(0);
+    expect(containerProviderRegistry.searchImages).toHaveBeenCalledWith('engine1', options);
   });
 });
 

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -1126,6 +1126,12 @@ export class ExtensionLoader {
       getImageInspect(engineId: string, id: string): Promise<ImageInspectInfo> {
         return containerProviderRegistry.getImageInspect(engineId, id);
       },
+      searchImages(
+        engineId: string,
+        searchOptions: containerDesktopAPI.SearchImagesOptions,
+      ): Promise<containerDesktopAPI.SearchImagesResponseInfo[]> {
+        return containerProviderRegistry.searchImages(engineId, searchOptions);
+      },
       info(engineId: string): Promise<containerDesktopAPI.ContainerEngineInfo> {
         return containerProviderRegistry.info(engineId);
       },


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Adds a `searchImages` function to the API

Spec: https://docs.podman.io/en/latest/_static/api.html#tag/images/operation/ImageSearchLibpod

TODO: use Docker API instead? (https://docs.docker.com/engine/api/v1.46/#tag/Image/operation/ImageSearch)

### What issues does this PR fix or reference?

Part of #971 

### How to test this PR?

- [ ] Tests are covering the bug fix or the new feature
