### PR TITLE
feat: add option to require user confirmation for certain actions

### DIFF
--- a/packages/main/src/plugin/confirmation-init.spec.ts
+++ b/packages/main/src/plugin/confirmation-init.spec.ts
@@ -1,0 +1,50 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { expect, test, vi } from 'vitest';
+
+import type { ConfigurationRegistry } from './configuration-registry.js';
+import { ConfirmationInit } from './confirmation-init.js';
+
+let confirmationInit: ConfirmationInit;
+
+const registerConfigurationsMock = vi.fn();
+
+const configurationRegistryMock = {
+  registerConfigurations: registerConfigurationsMock,
+} as unknown as ConfigurationRegistry;
+
+test('should register a configuration', async () => {
+  confirmationInit = new ConfirmationInit(configurationRegistryMock);
+
+  confirmationInit.init();
+
+  expect(configurationRegistryMock.registerConfigurations).toBeCalled();
+
+  const configurationNode = vi.mocked(configurationRegistryMock.registerConfigurations).mock.calls[0][0][0];
+  expect(configurationNode.id).toBe('preferences.userConfirmation');
+  expect(configurationNode.title).toBe('User Confirmation');
+  expect(configurationNode.properties).toBeDefined();
+  expect(Object.keys(configurationNode.properties ?? {}).length).toBe(1);
+  expect(configurationNode.properties?.['userConfirmation.bulk']).toBeDefined();
+  expect(configurationNode.properties?.['userConfirmation.bulk'].description).toBe(
+    'Require user confirmation for bulk actions',
+  );
+  expect(configurationNode.properties?.['userConfirmation.bulk'].type).toBe('boolean');
+  expect(configurationNode.properties?.['userConfirmation.bulk'].default).toBe(true);
+});

--- a/packages/main/src/plugin/confirmation-init.ts
+++ b/packages/main/src/plugin/confirmation-init.ts
@@ -1,0 +1,40 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { IConfigurationNode, IConfigurationRegistry } from './configuration-registry.js';
+
+export class ConfirmationInit {
+  constructor(private configurationRegistry: IConfigurationRegistry) {}
+
+  init(): void {
+    const confirmationConfiguration: IConfigurationNode = {
+      id: 'preferences.userConfirmation',
+      title: 'User Confirmation',
+      type: 'object',
+      properties: {
+        ['userConfirmation.bulk']: {
+          description: 'Require user confirmation for bulk actions',
+          type: 'boolean',
+          default: true,
+        },
+      },
+    };
+
+    this.configurationRegistry.registerConfigurations([confirmationConfiguration]);
+  }
+}

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -116,6 +116,7 @@ import { ColorRegistry } from './color-registry.js';
 import { CommandRegistry } from './command-registry.js';
 import type { IConfigurationPropertyRecordedSchema } from './configuration-registry.js';
 import { ConfigurationRegistry } from './configuration-registry.js';
+import { ConfirmationInit } from './confirmation-init.js';
 import { ContainerProviderRegistry } from './container-registry.js';
 import { Context } from './context/context.js';
 import { ContributionManager } from './contribution-manager.js';
@@ -559,6 +560,9 @@ export class PluginSystem {
     // register appearance (light, dark, auto being system)
     const appearanceConfiguration = new AppearanceInit(configurationRegistry);
     appearanceConfiguration.init();
+
+    const confirmationConfiguration = new ConfirmationInit(configurationRegistry);
+    confirmationConfiguration.init();
 
     const terminalInit = new TerminalInit(configurationRegistry);
     terminalInit.init();


### PR DESCRIPTION
Adds a new setting that allows users to require user confirmation before bulk actions

###  Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->
![Screenshot from 2024-07-03 17-58-16](https://github.com/containers/podman-desktop/assets/66797193/1f70115f-ded7-4a1d-a698-b8592816955f)


###  What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop/issues/7832

### How to test this PR?

<!-- Please explain steps to verify the functionality, do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature