### PR TITLE
fix: rename volume usage button

### DIFF
--- a/packages/renderer/src/lib/volume/VolumesList.svelte
+++ b/packages/renderer/src/lib/volume/VolumesList.svelte
@@ -236,9 +236,9 @@ const row = new TableRow<VolumeInfoUI>({
       <Button
         inProgress="{fetchDataInProgress}"
         on:click="{() => fetchUsageData()}"
-        title="Collect usage data for volumes. It can take a while..."
+        title="Gather sizes for volumes. It can take a while..."
         icon="{faPieChart}"
-        aria-label="Collect usage data">Collect usage data</Button>
+        aria-label="Gather volume sizes">Gather volume sizes</Button>
     {/if}
     {#if providerConnections.length > 0}
       <Button on:click="{() => gotoCreateVolume()}" icon="{faPlusCircle}" title="Create a volume" aria-label="Create"

--- a/tests/playwright/src/model/pages/volumes-page.ts
+++ b/tests/playwright/src/model/pages/volumes-page.ts
@@ -33,7 +33,7 @@ export class VolumesPage extends MainPage {
     super(page, 'volumes');
     this.createVolumeButton = this.additionalActions.getByRole('button', { name: 'Create' });
     this.pruneVolumesButton = this.additionalActions.getByRole('button', { name: 'Prune' });
-    this.collectUsageDataButton = this.additionalActions.getByRole('button', { name: 'Collect usage data' });
+    this.collectUsageDataButton = this.additionalActions.getByRole('button', { name: 'Gather volume sizes' });
   }
 
   async openCreateVolumePage(volumeName: string): Promise<CreateVolumePage> {


### PR DESCRIPTION
### What does this PR do?

Changes the "Collect usage data" Button label ono the volume page to "Gather volume sizes".

### Screenshot / video of UI

<img width="1162" alt="Screenshot 2024-07-02 at 07 27 19" src="https://github.com/containers/podman-desktop/assets/1358554/41511ed0-72c3-4746-a9b8-5af07fd20b1a">

### What issues does this PR fix or reference?

Fixes  #7823

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
