### PR TITLE
feat: track rosetta support before starting machine

### DIFF
--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -761,7 +761,6 @@ export async function checkRosettaMacArm(podmanConfiguration: PodmanConfiguratio
   if (isMac() && os.arch() === 'arm64') {
     const isEnabled = await podmanConfiguration.isRosettaEnabled();
     if (isEnabled) {
-      console.log('checking if rosetta is enabled');
       // call the command `arch -arch x86_64 uname -m` to check if rosetta is enabled
       // if not installed, it will fail
       try {

--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -139,7 +139,10 @@ export function isIncompatibleMachineOutput(output: string | undefined): boolean
   }
 }
 
-export async function updateMachines(provider: extensionApi.Provider): Promise<void> {
+export async function updateMachines(
+  provider: extensionApi.Provider,
+  podmanConfiguration: PodmanConfiguration,
+): Promise<void> {
   // init machines available
   let machineListOutput: MachineListOutput;
   try {
@@ -301,7 +304,7 @@ export async function updateMachines(provider: extensionApi.Provider): Promise<v
       }
       const podmanMachineInfo = podmanMachinesInfo.get(machineName);
       if (podmanMachineInfo && socketPath) {
-        await registerProviderFor(provider, podmanMachineInfo, socketPath);
+        await registerProviderFor(provider, podmanConfiguration, podmanMachineInfo, socketPath);
       }
     }),
   );
@@ -576,16 +579,19 @@ async function timeout(time: number): Promise<void> {
   });
 }
 
-async function monitorMachines(provider: extensionApi.Provider): Promise<void> {
+async function monitorMachines(
+  provider: extensionApi.Provider,
+  podmanConfiguration: PodmanConfiguration,
+): Promise<void> {
   // call us again
   if (!stopLoop) {
     try {
-      await updateMachines(provider);
+      await updateMachines(provider, podmanConfiguration);
     } catch (error) {
       // ignore the update of machines
     }
     await timeout(5000);
-    monitorMachines(provider).catch((error: unknown) => {
+    monitorMachines(provider, podmanConfiguration).catch((error: unknown) => {
       console.error('Error monitoring podman machines', error);
     });
   }
@@ -664,12 +670,13 @@ function prettyMachineName(machineName: string): string {
 
 export async function registerProviderFor(
   provider: extensionApi.Provider,
+  podmanConfiguration: PodmanConfiguration,
   machineInfo: MachineInfo,
   socketPath: string,
 ): Promise<void> {
   const lifecycle: extensionApi.ProviderConnectionLifecycle = {
     start: async (context, logger): Promise<void> => {
-      await startMachine(provider, machineInfo, context, logger, undefined, false);
+      await startMachine(provider, podmanConfiguration, machineInfo, context, logger, undefined, false);
     },
     stop: async (context, logger): Promise<void> => {
       await extensionApi.process.exec(getPodmanCli(), ['machine', 'stop', machineInfo.name], {
@@ -749,8 +756,43 @@ export async function registerProviderFor(
   storedExtensionContext?.subscriptions.push(disposable);
 }
 
+export async function checkRosettaMacArm(podmanConfiguration: PodmanConfiguration): Promise<void> {
+  // check that rosetta is there for macOS / arm as the machine may fail to start
+  if (isMac() && os.arch() === 'arm64') {
+    const isEnabled = await podmanConfiguration.isRosettaEnabled();
+    if (isEnabled) {
+      console.log('checking if rosetta is enabled');
+      // call the command `arch -arch x86_64 uname -m` to check if rosetta is enabled
+      // if not installed, it will fail
+      try {
+        await extensionApi.process.exec('arch', ['-arch', 'x86_64', 'uname', '-m']);
+      } catch (error: unknown) {
+        const runError = error as RunError;
+        if (runError.stderr?.includes('Bad CPU')) {
+          // rosetta is enabled but not installed, it will fail, stop from there and prompt the user to install rosetta or disable rosetta support
+          const result = await extensionApi.window.showInformationMessage(
+            'Podman machine is configured to use Rosetta but the support is not installed. The startup of the machine will fail.\nDo you want to install Rosetta? Rosetta is allowing to execute amd64 images on Apple silicon architecture.',
+            'Yes',
+            'No',
+            'Disable rosetta support',
+          );
+          if (result === 'Yes') {
+            // ask the person to perform the installation using cli
+            await extensionApi.window.showInformationMessage(
+              'Please install Rosetta from the command line by running `softwareupdate --install-rosetta`',
+            );
+          } else if (result === 'Disable rosetta support') {
+            await podmanConfiguration.updateRosettaSetting(false);
+          }
+        }
+      }
+    }
+  }
+}
+
 export async function startMachine(
   provider: extensionApi.Provider,
+  podmanConfiguration: PodmanConfiguration,
   machineInfo: MachineInfo,
   context?: extensionApi.LifecycleContext,
   logger?: extensionApi.Logger,
@@ -759,6 +801,9 @@ export async function startMachine(
 ): Promise<void> {
   const telemetryRecords: Record<string, unknown> = {};
   const startTime = performance.now();
+
+  await checkRosettaMacArm(podmanConfiguration);
+
   try {
     // start the machine
     await extensionApi.process.exec(getPodmanCli(), ['machine', 'start', machineInfo.name], {
@@ -1193,6 +1238,9 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
     },
   ];
 
+  const podmanConfiguration = new PodmanConfiguration();
+  await podmanConfiguration.init();
+
   const provider = extensionApi.provider.createProvider(providerOptions);
 
   // Check on initial setup
@@ -1288,7 +1336,7 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
 
   // If autostart has been enabled for the machine, try to start it.
   try {
-    await updateMachines(provider);
+    await updateMachines(provider, podmanConfiguration);
   } catch (error) {
     // ignore the update of machines
   }
@@ -1318,7 +1366,7 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
               provider.id,
               containerProviderConnection,
             );
-            await startMachine(provider, machineInfo, context, logger, undefined, true);
+            await startMachine(provider, podmanConfiguration, machineInfo, context, logger, undefined, true);
             autoMachineStarted = true;
             autoMachineName = machineName;
           }
@@ -1392,7 +1440,7 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
   // Podman Machine support is on macOS, Windows and Linux
   // Despite Linux having native container support, Podman Machine is still supported on Linux
   // so let's monitor for the machines
-  monitorMachines(provider).catch((error: unknown) => {
+  monitorMachines(provider, podmanConfiguration).catch((error: unknown) => {
     console.error('Error while monitoring machines', error);
   });
 
@@ -1511,9 +1559,6 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
   // register the registries
   const registrySetup = new RegistrySetup();
   await registrySetup.setup();
-
-  const podmanConfiguration = new PodmanConfiguration();
-  await podmanConfiguration.init();
 
   await calcPodmanMachineSetting(podmanConfiguration);
 }

--- a/extensions/podman/src/podman-configuration.spec.ts
+++ b/extensions/podman/src/podman-configuration.spec.ts
@@ -18,7 +18,7 @@
 
 import * as fs from 'node:fs';
 
-import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { PodmanConfiguration } from './podman-configuration';
 
@@ -114,4 +114,40 @@ test('if rosetta is set to true and the file does NOT exist, do not try and crea
   await podmanConfiguration.updateRosettaSetting(true);
 
   expect(fs.promises.writeFile).not.toHaveBeenCalled();
+});
+
+describe('isRosettaEnabled', () => {
+  test('check rosetta is enabled', async () => {
+    vi.mock('node:fs');
+    vi.spyOn(fs.promises, 'readFile').mockResolvedValue('');
+    vi.spyOn(podmanConfiguration, 'readContainersConfigFile').mockResolvedValue('[machine]\nrosetta=true');
+    vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+
+    const isEnabled = await podmanConfiguration.isRosettaEnabled();
+
+    expect(isEnabled).toBeTruthy();
+  });
+
+  test('check rosetta is enabled if file is not containing rosetta setting (default value is true)', async () => {
+    vi.mock('node:fs');
+    vi.spyOn(fs.promises, 'readFile').mockResolvedValue('');
+    vi.spyOn(podmanConfiguration, 'readContainersConfigFile').mockResolvedValue('');
+    vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+
+    const isEnabled = await podmanConfiguration.isRosettaEnabled();
+
+    expect(isEnabled).toBeTruthy();
+  });
+
+  test('check rosetta is disabled', async () => {
+    vi.mock('node:fs');
+    vi.spyOn(fs.promises, 'readFile').mockResolvedValue('');
+    vi.spyOn(podmanConfiguration, 'readContainersConfigFile').mockResolvedValue('[machine]\nrosetta=false');
+
+    vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+
+    const isEnabled = await podmanConfiguration.isRosettaEnabled();
+
+    expect(isEnabled).toBeFalsy();
+  });
 });

--- a/extensions/podman/src/podman-configuration.ts
+++ b/extensions/podman/src/podman-configuration.ts
@@ -113,6 +113,23 @@ export class PodmanConfiguration {
     await this.updateRosettaSetting(useRosetta);
   }
 
+  async isRosettaEnabled(): Promise<boolean> {
+    if (fs.existsSync(this.getContainersFileLocation())) {
+      // Read the file
+      const containersConfigFile = await this.readContainersConfigFile();
+      const tomlConfigFile = toml.parse(containersConfigFile);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const machine: any = tomlConfigFile.machine;
+      if (machine && 'rosetta' in machine) {
+        const val = machine['rosetta'];
+        if (typeof val === 'boolean') {
+          return val;
+        }
+      }
+    }
+    return true;
+  }
+
   async updateRosettaSetting(useRosetta: boolean): Promise<void> {
     // Initalize an empty configuration file for us to use
     const containersConfContent = {


### PR DESCRIPTION
### What does this PR do?
check if rosetta is working before starting the podman machine

### Screenshot / video of UI

![image](https://github.com/containers/podman-desktop/assets/436777/f1dc6292-d9bc-4936-9004-314f9c1dcfc8)


### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/7798

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
