### PR TITLE
fix: light mode for podman machine details page

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesConnectionDetailsLogs.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionDetailsLogs.svelte
@@ -97,12 +97,7 @@ onDestroy(() => {
 });
 </script>
 
-<EmptyScreen
-  icon="{NoLogIcon}"
-  title="No Log"
-  message="Log output"
-  hidden="{noLogs === false}"
-  style="background-color: {getPanelDetailColor()}" />
+<EmptyScreen icon="{NoLogIcon}" title="No Log" message="Log output" hidden="{noLogs === false}" />
 
 <div
   aria-label="terminal"

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionDetailsLogs.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionDetailsLogs.svelte
@@ -97,7 +97,12 @@ onDestroy(() => {
 });
 </script>
 
-<EmptyScreen icon="{NoLogIcon}" title="No Log" message="Log output" hidden="{noLogs === false}" />
+<EmptyScreen
+  icon="{NoLogIcon}"
+  title="No Log"
+  message="Log output"
+  hidden="{noLogs === false}"
+  class="bg-[var(--pd-details-bg)]" />
 
 <div
   aria-label="terminal"

--- a/packages/renderer/src/lib/preferences/PreferencesContainerConnectionDetailsSummary.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesContainerConnectionDetailsSummary.svelte
@@ -35,7 +35,7 @@ $: providerContainerConfiguration = tmpProviderContainerConfiguration.filter(
 );
 </script>
 
-<div class="h-full text-[var(--pd-table-body-text)]">
+<div class="h-full text-[var(--pd-details-body-text)]">
   {#if containerConnectionInfo}
     {@const peerProperties = new PeerProperties()}
     <div class="flex pl-8 py-4 flex-col w-full text-sm">

--- a/packages/ui/src/lib/layouts/DetailsPage.svelte
+++ b/packages/ui/src/lib/layouts/DetailsPage.svelte
@@ -33,7 +33,7 @@ function handleKeydown(e: KeyboardEvent): void {
 
 <svelte:window on:keydown="{handleKeydown}" />
 
-<div class="flex flex-col w-full h-full shadow-pageheader">
+<div class="flex flex-col w-full h-full shadow-pageheader bg-[var(--pd-content-bg)]">
   <div class="flex flex-row w-full h-fit px-5 pt-4 pb-2">
     <div class="flex flex-col w-full h-fit">
       <div class="flex flew-row items-center text-sm text-[var(--pd-content-breadcrumb)]">

--- a/packages/ui/src/lib/screen/EmptyScreen.svelte
+++ b/packages/ui/src/lib/screen/EmptyScreen.svelte
@@ -37,7 +37,7 @@ let copyTextDivElement: HTMLDivElement;
 </script>
 
 <div
-  class="flex flex-row w-full h-full justify-center bg-[var(--pd-details-bg)] {$$props.class || ''}"
+  class="flex flex-row w-full h-full justify-center {$$props.class || ''}"
   class:hidden="{hidden}"
   style="{$$props.style}"
   aria-label="{$$props['aria-label']}">

--- a/packages/ui/src/lib/screen/EmptyScreen.svelte
+++ b/packages/ui/src/lib/screen/EmptyScreen.svelte
@@ -37,7 +37,7 @@ let copyTextDivElement: HTMLDivElement;
 </script>
 
 <div
-  class="flex flex-row w-full h-full justify-center {$$props.class || ''}"
+  class="flex flex-row w-full h-full justify-center bg-[var(--pd-details-bg)] {$$props.class || ''}"
   class:hidden="{hidden}"
   style="{$$props.style}"
   aria-label="{$$props['aria-label']}">


### PR DESCRIPTION
### What does this PR do?

This PR adds/fixes some class to enable the correct colors in light mode.

there are just 2 things to be fixed but i think they are related to follow-up PRs.
1. the terminal
2. the donuts

### Screenshot / video of UI

![details](https://github.com/containers/podman-desktop/assets/49404737/eb5d953f-23e4-40a8-9544-efcc25ee06e6)

### What issues does this PR fix or reference?

it resolves #7548 

### How to test this PR?

1. go to the podman machine details page

- [ ] Tests are covering the bug fix or the new feature
