### PR TITLE
chore: process podman system and user configuration

### DIFF
--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -40,7 +40,8 @@ import { QemuHelper } from './helpers/qemu-helper';
 import { WslHelper } from './helpers/wsl-helper';
 import type { InstalledPodman } from './podman-cli';
 import { getPodmanCli, getPodmanInstallation } from './podman-cli';
-import { PodmanConfiguration } from './podman-configuration';
+import type { PodmanConfiguration } from './podman-configuration';
+import { PodmanConfigurationProvider, ProxyConfiguration, RosettaConfiguration } from './podman-configuration';
 import { HyperVCheck, PodmanInstall, WSL2Check, WSLVersionCheck } from './podman-install';
 import { ProviderConnectionShellAccessImpl } from './podman-machine-stream';
 import { RegistrySetup } from './registry-setup';
@@ -864,7 +865,8 @@ export async function registerProviderFor(
 export async function checkRosettaMacArm(podmanConfiguration: PodmanConfiguration): Promise<void> {
   // check that rosetta is there for macOS / arm as the machine may fail to start
   if (extensionApi.env.isMac && os.arch() === 'arm64') {
-    const isEnabled = await podmanConfiguration.isRosettaEnabled();
+    const rosettaConfiguration = new RosettaConfiguration(podmanConfiguration);
+    const isEnabled = await rosettaConfiguration.isRosettaEnabled();
     if (isEnabled) {
       // call the command `arch -arch x86_64 uname -m` to check if rosetta is enabled
       // if not installed, it will fail
@@ -886,7 +888,7 @@ export async function checkRosettaMacArm(podmanConfiguration: PodmanConfiguratio
               'Please install Rosetta from the command line by running `softwareupdate --install-rosetta`',
             );
           } else if (result === 'Disable rosetta support') {
-            await podmanConfiguration.updateRosettaSetting(false);
+            await rosettaConfiguration.updateRosettaSetting(false);
           }
         }
       }
@@ -1378,8 +1380,9 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
     },
   ];
 
-  const podmanConfiguration = new PodmanConfiguration();
-  await podmanConfiguration.init();
+  const podmanConfiguration = new PodmanConfigurationProvider().getConfiguration();
+  const proxyConfiguration = new ProxyConfiguration(podmanConfiguration);
+  await proxyConfiguration.registerHandlers();
 
   const provider = extensionApi.provider.createProvider(providerOptions);
 

--- a/extensions/podman/packages/extension/src/podman-configuration.spec.ts
+++ b/extensions/podman/packages/extension/src/podman-configuration.spec.ts
@@ -16,19 +16,33 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import * as fs from 'node:fs';
+import type { Dirent, PathLike } from 'node:fs';
+import { promises as fsPromises } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 
 import type { ProxySettings } from '@podman-desktop/api';
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import * as extensionApi from '@podman-desktop/api';
+import * as toml from 'smol-toml';
+import type { Mock } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 
-import { PodmanConfiguration } from './podman-configuration';
+import {
+  merge,
+  PodmanConfiguration,
+  ProxyConfiguration,
+  RosettaConfiguration,
+  UnixPodmanConfiguration,
+  WindowsPodmanConfiguration,
+} from './podman-configuration';
+
+vi.mock('node:os');
+vi.mock('node:path');
+vi.mock('node:fs');
 
 // mock the API
 vi.mock('@podman-desktop/api', async () => {
   return {
-    process: {
-      exec: vi.fn(),
-    },
     env: {
       isWindows: false,
       isMac: false,
@@ -37,155 +51,861 @@ vi.mock('@podman-desktop/api', async () => {
   };
 });
 
-// allows to call protected methods
+interface TestablePodmanConfiguration {
+  isValid(path: PathLike): boolean;
+  userConfigPath(): PathLike;
+  addConfigs(dirPath: PathLike): Promise<PathLike[]>;
+  readConfigFromFile(path: PathLike): Promise<Record<string, unknown>>;
+  writeConfigToFile(path: PathLike, config: Record<string, unknown>): Promise<void>;
+  readUserConfig(): Promise<Record<string, unknown>>;
+  writeUserConfig(config: Record<string, unknown>): Promise<void>;
+  systemConfigs(): Promise<PathLike[]>;
+}
+
+interface TestableProxyConfiguration {
+  getProxySettings(): Promise<ProxySettings>;
+  updateProxySetting(proxySettings: ProxySettings | undefined): Promise<void>;
+}
+
+interface TestableRosettaConfiguration {
+  updateRosettaSetting(useRosetta: boolean): Promise<void>;
+}
+
 class TestPodmanConfiguration extends PodmanConfiguration {
-  readContainersConfigFile(): Promise<string> {
-    return super.readContainersConfigFile();
+  constructor() {
+    super();
+    this.configPath = 'containers/containers.conf';
+    this.userOverrideContainersConfig = `.config/${this.configPath}`;
+  }
+
+  protected defaultContainersConfig(): PathLike {
+    return '/etc/containers/containers.conf';
+  }
+
+  protected overrideContainersConfigPath(): PathLike {
+    return '/usr/local/etc/containers/containers.conf';
   }
 }
 
-let podmanConfiguration: TestPodmanConfiguration;
+describe('merge', () => {
+  test('should correctly merge two simple tables', () => {
+    const table1: Record<string, unknown> = {
+      key1: 'value1',
+      key2: 42,
+    };
+    const table2: Record<string, unknown> = {
+      key2: 100,
+      key3: true,
+    };
+    const result = merge(table1, table2);
+    const expected: Record<string, unknown> = {
+      key1: 'value1',
+      key2: 100,
+      key3: true,
+    };
 
-beforeEach(() => {
-  podmanConfiguration = new TestPodmanConfiguration();
+    expect(result).toEqual(expected);
+  });
+
+  test('should handle merging with empty table', () => {
+    const table1: Record<string, unknown> = {
+      key1: 'value1',
+      key2: 42,
+    };
+    const table2: Record<string, unknown> = {};
+    const result = merge(table1, table2);
+    const expected: Record<string, unknown> = {
+      key1: 'value1',
+      key2: 42,
+    };
+
+    expect(result).toEqual(expected);
+  });
+
+  test('should handle nested tables', () => {
+    const table1: Record<string, unknown> = {
+      nested: {
+        key1: 'value1',
+      },
+    };
+    const table2: Record<string, unknown> = {
+      nested: {
+        key2: 'value2',
+      },
+    };
+    const result = merge(table1, table2);
+    const expected: Record<string, unknown> = {
+      nested: {
+        key1: 'value1',
+        key2: 'value2',
+      },
+    };
+
+    expect(result).toEqual(expected);
+  });
+
+  test('should handle arrays in tables', () => {
+    const table1: Record<string, unknown> = {
+      array: [1, 2, 3],
+    };
+    const table2: Record<string, unknown> = {
+      array: [4, 5],
+    };
+    const result = merge(table1, table2);
+    const expected: Record<string, unknown> = {
+      array: [4, 5],
+    };
+
+    expect(result).toEqual(expected);
+  });
 });
 
-afterEach(() => {
-  vi.resetAllMocks();
-  vi.restoreAllMocks();
-});
+describe('PodmanConfiguration', () => {
+  let config: TestPodmanConfiguration & TestablePodmanConfiguration;
 
-test('should return true if regex is satisfied', async () => {
-  vi.spyOn(podmanConfiguration, 'readContainersConfigFile').mockResolvedValue(`
-[machine]
-provider = "hyperv"
-memory = 4096
-    `);
-  const found = await podmanConfiguration.matchRegexpInContainersConfig(/provider\s*=\s*"hyperv"/);
-  expect(found).toBeTruthy();
-});
+  beforeEach(() => {
+    config = new TestPodmanConfiguration() as TestPodmanConfiguration & TestablePodmanConfiguration;
+    vi.clearAllMocks();
+  });
 
-test('should return false if regex is not satisfied', async () => {
-  vi.spyOn(podmanConfiguration, 'readContainersConfigFile').mockResolvedValue(`
-[machine]
-provider = "wsl"
-memory = 4096
-    `);
-  const found = await podmanConfiguration.matchRegexpInContainersConfig(/provider\s*=\s*"hyperv"/);
-  expect(found).toBeFalsy();
-});
+  test('should return XDG_RUNTIME_DIR path if it is set and valid', () => {
+    process.env.XDG_RUNTIME_DIR = '/run/user/1000';
+    (os.homedir as unknown as Mock).mockReturnValue('/home/user');
+    (path.join as unknown as Mock).mockImplementation((...args) => {
+      const result = args.join('/');
+      console.log(`path.join called with args: ${args}, returning: ${result}`);
+      return result;
+    });
 
-test('when enable rosetta is set to true and there is already a file with rosetta = false, remove it.', async () => {
-  vi.mock('node:fs');
-  const configFileContent = `
-[machine]
-memory = 4096
-rosetta = false
+    config.isValid = vi.fn().mockReturnValue(true);
+
+    const expectedPath = '/run/user/1000/containers/containers.conf';
+    const result = config.userConfigPath();
+    expect(result).toBe(expectedPath);
+  });
+
+  test('should return home directory path if XDG_RUNTIME_DIR is not set', () => {
+    delete process.env.XDG_RUNTIME_DIR;
+    (os.homedir as unknown as Mock).mockReturnValue('/home/user');
+    (path.join as unknown as Mock).mockImplementation((...args) => args.join('/'));
+
+    const expectedPath = '/home/user/.config/containers/containers.conf';
+    const result = config.userConfigPath();
+    expect(result).toBe(expectedPath);
+  });
+
+  test('should return home directory path if XDG_RUNTIME_DIR is set but not valid', () => {
+    process.env.XDG_RUNTIME_DIR = '/run/user/1000';
+    (os.homedir as unknown as Mock).mockReturnValue('/home/user');
+    (path.join as unknown as Mock).mockImplementation((...args) => args.join('/'));
+
+    config.isValid = vi.fn().mockReturnValue(false);
+
+    const expectedPath = '/home/user/.config/containers/containers.conf';
+    const result = config.userConfigPath();
+    expect(result).toBe(expectedPath);
+  });
+
+  test('should return an array of valid config paths from directory', async () => {
+    const dirPath = '/etc/containers/containers.conf.d';
+    const entries: Dirent[] = [
+      { name: 'valid1.conf', isFile: () => true, isDirectory: () => false } as Dirent,
+      { name: 'valid2.conf', isFile: () => true, isDirectory: () => false } as Dirent,
+      { name: 'notAConf.txt', isFile: () => true, isDirectory: () => false } as Dirent,
+      { name: 'directory', isFile: () => false, isDirectory: () => true } as Dirent,
+    ];
+
+    (fsPromises.readdir as unknown as Mock).mockResolvedValue(entries);
+    (path.join as unknown as Mock).mockImplementation((...args) => args.join('/'));
+
+    console.log(`Calling addConfigs with dirPath: ${dirPath}`);
+    const result = await config.addConfigs(dirPath);
+    console.log(`Result from addConfigs: ${JSON.stringify(result)}`);
+
+    const expected = ['/etc/containers/containers.conf.d/valid1.conf', '/etc/containers/containers.conf.d/valid2.conf'];
+
+    expect(result).toEqual(expected);
+  });
+
+  test('should return an empty array if no valid config paths found', async () => {
+    const dirPath = '/etc/containers/containers.conf.d';
+    const entries: Dirent[] = [
+      { name: 'notAConf.txt', isFile: () => true, isDirectory: () => false } as Dirent,
+      { name: 'directory', isFile: () => false, isDirectory: () => true } as Dirent,
+    ];
+
+    (fsPromises.readdir as Mock).mockResolvedValue(entries);
+    (path.join as unknown as Mock).mockImplementation((...args) => args.join('/'));
+
+    console.log(`Calling addConfigs with dirPath: ${dirPath}`);
+    const result = await config.addConfigs(dirPath);
+    console.log(`Result from addConfigs: ${JSON.stringify(result)}`);
+
+    const expected: PathLike[] = [];
+
+    expect(result).toEqual(expected);
+  });
+
+  test('should sort the array of config paths', async () => {
+    const dirPath = '/etc/containers/containers.conf.d';
+    const entries: Dirent[] = [
+      { name: 'b.conf', isFile: () => true, isDirectory: () => false } as Dirent,
+      { name: 'a.conf', isFile: () => true, isDirectory: () => false } as Dirent,
+      { name: 'c.conf', isFile: () => true, isDirectory: () => false } as Dirent,
+    ];
+
+    (fsPromises.readdir as Mock).mockResolvedValue(entries);
+    (path.join as unknown as Mock).mockImplementation((...args) => args.join('/'));
+
+    console.log(`Calling addConfigs with dirPath: ${dirPath}`);
+    const result = await config.addConfigs(dirPath);
+    console.log(`Result from addConfigs: ${JSON.stringify(result)}`);
+
+    const expected = [
+      '/etc/containers/containers.conf.d/a.conf',
+      '/etc/containers/containers.conf.d/b.conf',
+      '/etc/containers/containers.conf.d/c.conf',
+    ];
+
+    expect(result).toEqual(expected);
+  });
+
+  test('should return false if path is an empty string', () => {
+    const result = config.isValid('');
+    expect(result).toBe(false);
+  });
+
+  test('should return false if path contains only spaces', () => {
+    const result = config.isValid('   ');
+    expect(result).toBe(false);
+  });
+
+  test('should return true if path is a valid string', () => {
+    const result = config.isValid('/valid/path');
+    expect(result).toBe(true);
+  });
+
+  test('should return true if path is a valid PathLike object', () => {
+    const result = config.isValid({ toString: () => '/valid/path' } as PathLike);
+    expect(result).toBe(true);
+  });
+
+  test('should read and parse valid TOML file', async () => {
+    const filePath = '/path/to/config.toml';
+    const fileContent = `
+      key1 = 'value1'
+      key2 = 42
+      key3 = true
     `;
-  vi.spyOn(fs.promises, 'writeFile').mockResolvedValue();
-  vi.spyOn(podmanConfiguration, 'readContainersConfigFile').mockResolvedValue(configFileContent);
-  vi.spyOn(fs, 'existsSync').mockImplementation(() => {
-    return true;
+    (fsPromises.readFile as Mock).mockResolvedValue(fileContent);
+
+    const result = await config.readConfigFromFile(filePath);
+    const expected = {
+      key1: 'value1',
+      key2: 42,
+      key3: true,
+    };
+
+    expect(result).toEqual(expected);
   });
 
-  await podmanConfiguration.updateRosettaSetting(true);
+  test('should throw an error if file does not exist', async () => {
+    const filePath = '/path/to/nonexistent.toml';
+    (fsPromises.readFile as Mock).mockRejectedValue(new Error('ENOENT: no such file or directory'));
 
-  expect(fs.promises.writeFile).toHaveBeenCalledWith(
-    podmanConfiguration.getContainersFileLocation(),
-    // Expect that the write file did not contain any rosetta references
-    expect.not.stringContaining('rosetta'),
-  );
-});
+    await expect(config.readConfigFromFile(filePath)).rejects.toThrow('ENOENT: no such file or directory');
+  });
 
-test('should disable Rosetta when useRosetta is false', async () => {
-  vi.mock('node:fs');
-  const configFileContent = `
-[machine]
-memory = 4096
-rosetta = true
+  test('should throw an error if file contains invalid TOML', async () => {
+    const filePath = '/path/to/invalid.toml';
+    const fileContent = `
+      key1 = 'value1'
+      key2 = 42
+      key3 = true
+      invalidToml
     `;
-  vi.spyOn(fs.promises, 'writeFile').mockResolvedValue();
-  vi.spyOn(podmanConfiguration, 'readContainersConfigFile').mockResolvedValue(configFileContent);
-  vi.spyOn(fs, 'existsSync').mockImplementation(() => {
-    return true;
+    (fsPromises.readFile as Mock).mockResolvedValue(fileContent);
+
+    await expect(config.readConfigFromFile(filePath)).rejects.toThrow();
   });
 
-  await podmanConfiguration.updateRosettaSetting(false);
+  test('should write configuration to file successfully', async () => {
+    const filePath = '/path/to/config.toml';
+    const table: Record<string, unknown> = {
+      key1: 'value1',
+      key2: 42,
+      key3: true,
+    };
+    (fsPromises.writeFile as Mock).mockResolvedValue(undefined);
 
-  expect(fs.promises.writeFile).toHaveBeenCalledWith(
-    podmanConfiguration.getContainersFileLocation(),
-    expect.stringContaining('rosetta = false'),
-  );
+    await config.writeConfigToFile(filePath, table);
+
+    const expectedContent = toml.stringify(table as never);
+    expect(fsPromises.writeFile).toHaveBeenCalledWith(filePath, expectedContent);
+  });
+
+  test('should throw an error if writing to file fails', async () => {
+    const filePath = '/path/to/config.toml';
+    const table: Record<string, unknown> = {
+      key1: 'value1',
+      key2: 42,
+      key3: true,
+    };
+    (fsPromises.writeFile as Mock).mockRejectedValue(new Error('EACCES: permission denied'));
+
+    await expect(config.writeConfigToFile(filePath, table)).rejects.toThrow('EACCES: permission denied');
+  });
+
+  test('should read and parse valid user config TOML file', async () => {
+    const filePath = '/home/user/.config/containers/containers.conf';
+    const fileContent = `
+      key1 = 'value1'
+      key2 = 42
+      key3 = true
+    `;
+    (fsPromises.readFile as Mock).mockResolvedValue(fileContent);
+    vi.spyOn(config, 'userConfigPath').mockReturnValue(filePath);
+
+    const result = await config.readUserConfig();
+    const expected = {
+      key1: 'value1',
+      key2: 42,
+      key3: true,
+    };
+
+    expect(result).toEqual(expected);
+  });
+
+  test('should throw an error if user config file does not exist', async () => {
+    const filePath = '/home/user/.config/containers/containers.conf';
+    (fsPromises.readFile as Mock).mockRejectedValue(new Error('ENOENT: no such file or directory'));
+    vi.spyOn(config, 'userConfigPath').mockReturnValue(filePath);
+
+    await expect(config.readUserConfig()).rejects.toThrow('ENOENT: no such file or directory');
+  });
+
+  test('should throw an error if user config file contains invalid TOML', async () => {
+    const filePath = '/home/user/.config/containers/containers.conf';
+    const fileContent = `
+      key1 = 'value1'
+      key2 = 42
+      key3 = true
+      invalidToml
+    `;
+    (fsPromises.readFile as Mock).mockResolvedValue(fileContent);
+    vi.spyOn(config, 'userConfigPath').mockReturnValue(filePath);
+
+    await expect(config.readUserConfig()).rejects.toThrow();
+  });
+
+  test('should write user configuration to file successfully', async () => {
+    const filePath = '/home/user/.config/containers/containers.conf';
+    const table: Record<string, unknown> = {
+      key1: 'value1',
+      key2: 42,
+      key3: true,
+    };
+    (fsPromises.writeFile as Mock).mockResolvedValue(undefined);
+    vi.spyOn(config, 'userConfigPath').mockReturnValue(filePath);
+
+    await config.writeUserConfig(table);
+
+    const expectedContent = toml.stringify(table as never);
+    expect(fsPromises.writeFile).toHaveBeenCalledWith(filePath, expectedContent);
+  });
+
+  test('should throw an error if writing user config to file fails', async () => {
+    const filePath = '/home/user/.config/containers/containers.conf';
+    const table: Record<string, unknown> = {
+      key1: 'value1',
+      key2: 42,
+      key3: true,
+    };
+    (fsPromises.writeFile as Mock).mockRejectedValue(new Error('EACCES: permission denied'));
+    vi.spyOn(config, 'userConfigPath').mockReturnValue(filePath);
+
+    await expect(config.writeUserConfig(table)).rejects.toThrow('EACCES: permission denied');
+  });
+
+  test('should return an array of valid system config paths', async () => {
+    process.env.CONTAINERS_CONF = '/etc/containers/containers.conf';
+    const configPaths = [
+      '/etc/containers/containers.conf',
+      '/usr/share/containers.conf',
+      '/usr/local/etc/containers/containers.conf',
+      '/usr/local/etc/containers/containers.conf.d/valid.conf',
+      '/home/user/.config/containers/containers.conf',
+      '/home/user/.config/containers/containers.conf.d/valid.conf',
+    ];
+
+    (fsPromises.access as Mock).mockResolvedValue(undefined);
+    vi.spyOn(config, 'defaultContainersConfig' as never).mockReturnValue('/usr/share/containers.conf' as never);
+    vi.spyOn(config, 'overrideContainersConfigPath' as never).mockReturnValue(
+      '/usr/local/etc/containers/containers.conf' as never,
+    );
+    vi.spyOn(config, 'userConfigPath').mockReturnValue('/home/user/.config/containers/containers.conf');
+    vi.spyOn(config, 'addConfigs').mockImplementation((dirPath: PathLike): Promise<PathLike[]> => {
+      let mockedReturnPath: string | undefined;
+
+      if (dirPath === '/usr/local/etc/containers/containers.conf.d') {
+        mockedReturnPath = '/usr/local/etc/containers/containers.conf.d/valid.conf';
+      } else if (dirPath === '/home/user/.config/containers/containers.conf.d') {
+        mockedReturnPath = '/home/user/.config/containers/containers.conf.d/valid.conf';
+      }
+
+      if (mockedReturnPath) {
+        return Promise.resolve([mockedReturnPath]);
+      } else {
+        return Promise.resolve([]);
+      }
+    });
+    vi.spyOn(path, 'resolve').mockImplementation((...args) => args.join('/'));
+
+    let result = await config.systemConfigs();
+
+    expect(result).toEqual(configPaths);
+
+    delete process.env.CONTAINERS_CONF;
+    const configPathsExcludedEnv = [
+      '/usr/share/containers.conf',
+      '/usr/local/etc/containers/containers.conf',
+      '/usr/local/etc/containers/containers.conf.d/valid.conf',
+      '/home/user/.config/containers/containers.conf',
+      '/home/user/.config/containers/containers.conf.d/valid.conf',
+    ];
+
+    result = await config.systemConfigs();
+
+    expect(result).toEqual(configPathsExcludedEnv);
+  });
+
+  test('should throw an error if accessing a config file fails', async () => {
+    process.env.CONTAINERS_CONF = '/not/valid/containers.conf';
+
+    (fsPromises.access as Mock).mockRejectedValue(new Error('ENOENT: no such file or directory'));
+    vi.spyOn(path, 'resolve').mockImplementation((...args) => args.join('/'));
+
+    await expect(config.systemConfigs()).rejects.toThrow('ENOENT: no such file or directory');
+  });
 });
 
-test('if rosetta is set to true and the file does NOT exist, do not try and create the file.', async () => {
-  vi.mock('node:fs');
-  vi.spyOn(fs.promises, 'writeFile').mockResolvedValue();
-  vi.spyOn(podmanConfiguration, 'readContainersConfigFile').mockResolvedValue('');
-  vi.spyOn(fs, 'existsSync').mockImplementation(() => {
-    return false;
+describe('UnixPodmanConfiguration', () => {
+  let config: UnixPodmanConfiguration & TestablePodmanConfiguration;
+
+  beforeEach(() => {
+    config = new UnixPodmanConfiguration() as UnixPodmanConfiguration & TestablePodmanConfiguration;
+    vi.clearAllMocks();
   });
 
-  await podmanConfiguration.updateRosettaSetting(true);
-
-  expect(fs.promises.writeFile).not.toHaveBeenCalled();
-});
-
-describe('isRosettaEnabled', () => {
-  test('check rosetta is enabled', async () => {
-    vi.mock('node:fs');
-    vi.spyOn(fs.promises, 'readFile').mockResolvedValue('');
-    vi.spyOn(podmanConfiguration, 'readContainersConfigFile').mockResolvedValue('[machine]\nrosetta=true');
-    vi.spyOn(fs, 'existsSync').mockReturnValue(true);
-
-    const isEnabled = await podmanConfiguration.isRosettaEnabled();
-
-    expect(isEnabled).toBeTruthy();
+  test('should return default containers config path', () => {
+    const expectedPath = '/usr/share/containers/containers.conf';
+    (path.join as unknown as Mock).mockImplementation((...args) => args.join('/'));
+    config['configPath'] = 'containers/containers.conf';
+    const result = config.defaultContainersConfig();
+    expect(result).toBe(expectedPath);
   });
 
-  test('check rosetta is enabled if file is not containing rosetta setting (default value is true)', async () => {
-    vi.mock('node:fs');
-    vi.spyOn(fs.promises, 'readFile').mockResolvedValue('');
-    vi.spyOn(podmanConfiguration, 'readContainersConfigFile').mockResolvedValue('');
-    vi.spyOn(fs, 'existsSync').mockReturnValue(true);
-
-    const isEnabled = await podmanConfiguration.isRosettaEnabled();
-
-    expect(isEnabled).toBeTruthy();
-  });
-
-  test('check rosetta is disabled', async () => {
-    vi.mock('node:fs');
-    vi.spyOn(fs.promises, 'readFile').mockResolvedValue('');
-    vi.spyOn(podmanConfiguration, 'readContainersConfigFile').mockResolvedValue('[machine]\nrosetta=false');
-
-    vi.spyOn(fs, 'existsSync').mockReturnValue(true);
-
-    const isEnabled = await podmanConfiguration.isRosettaEnabled();
-
-    expect(isEnabled).toBeFalsy();
+  test('should return override containers config path', () => {
+    const expectedPath = '/usr/local/etc/containers/containers.conf';
+    (path.join as unknown as Mock).mockImplementation((...args) => args.join('/'));
+    config['configPath'] = 'containers/containers.conf';
+    const result = config.overrideContainersConfigPath();
+    expect(result).toBe(expectedPath);
   });
 });
 
-test('doUpdateProxySettings should be called one at the time', async () => {
-  const proxySettings: ProxySettings = {
-    httpProxy: 'httpProxy',
-    httpsProxy: 'httpsProxy',
-    noProxy: 'noProxy',
-  };
+describe('WindowsPodmanConfiguration', () => {
+  let config: WindowsPodmanConfiguration & TestablePodmanConfiguration;
 
-  // Mock updateProxySettings
-  const doUpdateProxySettingsMock = vi.spyOn(podmanConfiguration, 'doUpdateProxySettings');
+  beforeEach(() => {
+    config = new WindowsPodmanConfiguration() as WindowsPodmanConfiguration & TestablePodmanConfiguration;
+    vi.clearAllMocks();
+  });
 
-  // Simultaneously call the function twice
-  const call1 = podmanConfiguration.updateProxySettings(undefined);
-  const call2 = podmanConfiguration.updateProxySettings(proxySettings);
+  test('should return default containers config path', () => {
+    const expectedPath = '';
+    const result = config.defaultContainersConfig();
+    expect(result).toBe(expectedPath);
+  });
 
-  await call1;
-  expect(doUpdateProxySettingsMock).toHaveBeenCalledTimes(1);
-  expect(doUpdateProxySettingsMock.mock.calls[0][0]).toBe(undefined);
+  test('should return override containers config path', () => {
+    process.env.PROGRAMDATA = '%PROGRAMDATA%';
+    const expectedPath = '%PROGRAMDATA%\\containers\\containers.conf';
+    (path.join as unknown as Mock).mockImplementation((...args) => args.join('\\'));
+    config['configPath'] = 'containers\\containers.conf';
+    const result = config.overrideContainersConfigPath();
+    expect(result).toBe(expectedPath);
+  });
 
-  await call2;
-  expect(doUpdateProxySettingsMock).toHaveBeenCalledTimes(2);
-  expect(doUpdateProxySettingsMock.mock.calls[1][0]).toBe(proxySettings);
+  test('should return user containers config path', () => {
+    process.env.APPDATA = '%APPDATA%';
+    const expectedPath = '%APPDATA%\\containers\\containers.conf';
+    (path.join as unknown as Mock).mockImplementation((...args) => args.join('\\'));
+    config['configPath'] = 'containers\\containers.conf';
+    const result = config.userConfigPath();
+    expect(result).toBe(expectedPath);
+  });
+});
+
+describe('ProxyConfiguration', () => {
+  let proxyConfiguration: ProxyConfiguration & TestableProxyConfiguration;
+  let podmanConfiguration: PodmanConfiguration;
+
+  beforeEach(() => {
+    podmanConfiguration = {
+      readUserConfig: vi.fn(),
+      writeUserConfig: vi.fn(),
+    } as unknown as PodmanConfiguration;
+    proxyConfiguration = new ProxyConfiguration(podmanConfiguration) as ProxyConfiguration & TestableProxyConfiguration;
+  });
+
+  describe('getProxySetting', () => {
+    test('should return proxy settings from valid TOML config file', async () => {
+      const tomlConfigFile: Record<string, unknown> = {
+        engine: {
+          env: ['https_proxy=https://localhost', 'http_proxy=http://localhost', 'no_proxy=localhost,127.0.0.1'],
+        },
+      };
+      (podmanConfiguration.readUserConfig as Mock).mockResolvedValue(tomlConfigFile);
+
+      const result = await proxyConfiguration.getProxySetting();
+
+      const expected: ProxySettings = {
+        httpProxy: 'http://localhost',
+        httpsProxy: 'https://localhost',
+        noProxy: 'localhost,127.0.0.1',
+      };
+
+      expect(result).toEqual(expected);
+    });
+
+    test('should return undefined for missing proxy settings', async () => {
+      const tomlConfigFile: Record<string, unknown> = {
+        engine: {
+          env: ['some_other_setting=value'],
+        },
+      };
+      (podmanConfiguration.readUserConfig as Mock).mockResolvedValue(tomlConfigFile);
+
+      const result = await proxyConfiguration.getProxySetting();
+
+      const expected: ProxySettings = {
+        httpProxy: undefined,
+        httpsProxy: undefined,
+        noProxy: undefined,
+      };
+
+      expect(result).toEqual(expected);
+    });
+
+    test('should handle missing engine section gracefully', async () => {
+      const tomlConfigFile: Record<string, unknown> = {};
+      (podmanConfiguration.readUserConfig as Mock).mockResolvedValue(tomlConfigFile);
+
+      const result = await proxyConfiguration.getProxySetting();
+
+      const expected: ProxySettings = {
+        httpProxy: undefined,
+        httpsProxy: undefined,
+        noProxy: undefined,
+      };
+
+      expect(result).toEqual(expected);
+    });
+
+    test('should log warning and return undefined if reading config fails', async () => {
+      const consoleWarnMock = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      (podmanConfiguration.readUserConfig as Mock).mockRejectedValue(new Error('Failed to read config'));
+
+      const result = await proxyConfiguration.getProxySetting();
+
+      const expected: ProxySettings = {
+        httpProxy: undefined,
+        httpsProxy: undefined,
+        noProxy: undefined,
+      };
+
+      expect(result).toEqual(expected);
+      expect(consoleWarnMock).toHaveBeenCalledWith(
+        'Failed to process podman user configuration: Failed to read config',
+      );
+
+      consoleWarnMock.mockRestore();
+    });
+  });
+
+  describe('updateProxySetting', () => {
+    test('should update proxy settings in user config', async () => {
+      const tomlConfigFile: Record<string, unknown> = {
+        engine: {
+          env: ['some_other_setting=value'],
+        },
+      };
+      (podmanConfiguration.readUserConfig as Mock).mockResolvedValue(tomlConfigFile);
+
+      const proxySettings: ProxySettings = {
+        httpProxy: 'http://localhost',
+        httpsProxy: 'https://localhost',
+        noProxy: 'localhost,127.0.0.1',
+      };
+
+      await proxyConfiguration.updateProxySettings(proxySettings);
+
+      const expectedConfig: Record<string, unknown> = {
+        engine: {
+          env: [
+            'some_other_setting=value',
+            'https_proxy=https://localhost',
+            'http_proxy=http://localhost',
+            'no_proxy=localhost,127.0.0.1',
+          ],
+        },
+      };
+
+      expect(podmanConfiguration.writeUserConfig).toHaveBeenCalledWith(expectedConfig);
+    });
+
+    test('should remove proxy settings from user config if undefined', async () => {
+      const tomlConfigFile: Record<string, unknown> = {
+        engine: {
+          env: [
+            'https_proxy=https://localhost',
+            'http_proxy=http://localhost',
+            'no_proxy=localhost,127.0.0.1',
+            'some_other_setting=value',
+          ],
+        },
+      };
+      (podmanConfiguration.readUserConfig as Mock).mockResolvedValue(tomlConfigFile);
+
+      await proxyConfiguration.updateProxySettings(undefined);
+
+      const expectedConfig: Record<string, unknown> = {
+        engine: {
+          env: ['some_other_setting=value'],
+        },
+      };
+
+      expect(podmanConfiguration.writeUserConfig).toHaveBeenCalledWith(expectedConfig);
+    });
+
+    test('should handle missing engine section gracefully', async () => {
+      const tomlConfigFile: Record<string, unknown> = {};
+      (podmanConfiguration.readUserConfig as Mock).mockResolvedValue(tomlConfigFile);
+
+      const proxySettings: ProxySettings = {
+        httpProxy: 'http://localhost',
+        httpsProxy: 'https://localhost',
+        noProxy: 'localhost,127.0.0.1',
+      };
+
+      await proxyConfiguration.updateProxySettings(proxySettings);
+
+      const expectedConfig: Record<string, unknown> = {
+        engine: {
+          env: ['https_proxy=https://localhost', 'http_proxy=http://localhost', 'no_proxy=localhost,127.0.0.1'],
+        },
+      };
+
+      expect(podmanConfiguration.writeUserConfig).toHaveBeenCalledWith(expectedConfig);
+    });
+
+    test('should create env array if it does not exist', async () => {
+      const tomlConfigFile: Record<string, unknown> = {
+        engine: {},
+      };
+      (podmanConfiguration.readUserConfig as Mock).mockResolvedValue(tomlConfigFile);
+
+      const proxySettings: ProxySettings = {
+        httpProxy: 'http://localhost',
+        httpsProxy: 'https://localhost',
+        noProxy: 'localhost,127.0.0.1',
+      };
+
+      await proxyConfiguration.updateProxySettings(proxySettings);
+
+      const expectedConfig: Record<string, unknown> = {
+        engine: {
+          env: ['https_proxy=https://localhost', 'http_proxy=http://localhost', 'no_proxy=localhost,127.0.0.1'],
+        },
+      };
+
+      expect(podmanConfiguration.writeUserConfig).toHaveBeenCalledWith(expectedConfig);
+    });
+
+    test('doUpdateProxySettings should be called one at the time', async () => {
+      const tomlConfigFile: Record<string, unknown> = {
+        engine: {},
+      };
+      (podmanConfiguration.readUserConfig as Mock).mockResolvedValue(tomlConfigFile);
+
+      const proxySettings: ProxySettings = {
+        httpProxy: 'httpProxy',
+        httpsProxy: 'httpsProxy',
+        noProxy: 'noProxy',
+      };
+
+      // Mock updateProxySettings
+      const doUpdateProxySettingsMock = vi.spyOn(proxyConfiguration, 'doUpdateProxySettings');
+
+      // Simultaneously call the function twice
+      const call1 = proxyConfiguration.updateProxySettings(undefined);
+      const call2 = proxyConfiguration.updateProxySettings(proxySettings);
+
+      await call1;
+      expect(doUpdateProxySettingsMock).toHaveBeenCalledTimes(1);
+      expect(doUpdateProxySettingsMock.mock.calls[0][0]).toBe(undefined);
+
+      await call2;
+      expect(doUpdateProxySettingsMock).toHaveBeenCalledTimes(2);
+      expect(doUpdateProxySettingsMock.mock.calls[1][0]).toBe(proxySettings);
+    });
+  });
+});
+
+describe('RosettaConfiguration', () => {
+  let rosettaConfiguration: RosettaConfiguration & TestableRosettaConfiguration;
+  let podmanConfiguration: PodmanConfiguration;
+
+  beforeEach(() => {
+    podmanConfiguration = {
+      readUserConfig: vi.fn(),
+      writeUserConfig: vi.fn(),
+    } as unknown as PodmanConfiguration;
+    rosettaConfiguration = new RosettaConfiguration(podmanConfiguration) as RosettaConfiguration &
+      TestableRosettaConfiguration;
+  });
+
+  describe('updateRosettaSetting', () => {
+    beforeEach(() => {
+      vi.mocked(extensionApi.env).isMac = false;
+      vi.mocked(extensionApi.env).isLinux = false;
+      vi.mocked(extensionApi.env).isWindows = false;
+    });
+
+    test('should remove rosetta setting when useRosetta is true', async () => {
+      const tomlConfigFile: Record<string, unknown> = {
+        machine: {
+          rosetta: false,
+          memory: 4096,
+        },
+      };
+      (podmanConfiguration.readUserConfig as Mock).mockResolvedValue(tomlConfigFile);
+
+      await rosettaConfiguration.updateRosettaSetting(true);
+
+      const expectedConfig: Record<string, unknown> = {
+        machine: {
+          memory: 4096,
+        },
+      };
+
+      expect(podmanConfiguration.writeUserConfig).toHaveBeenCalledWith(expectedConfig);
+    });
+
+    test('should set rosetta to false when useRosetta is false', async () => {
+      const tomlConfigFile: Record<string, unknown> = {
+        machine: {
+          memory: 4096,
+        },
+      };
+      (podmanConfiguration.readUserConfig as Mock).mockResolvedValue(tomlConfigFile);
+
+      await rosettaConfiguration.updateRosettaSetting(false);
+
+      const expectedConfig: Record<string, unknown> = {
+        machine: {
+          rosetta: false,
+          memory: 4096,
+        },
+      };
+
+      expect(podmanConfiguration.writeUserConfig).toHaveBeenCalledWith(expectedConfig);
+    });
+
+    test('should handle missing machine section gracefully', async () => {
+      const tomlConfigFile: Record<string, unknown> = {};
+      (podmanConfiguration.readUserConfig as Mock).mockResolvedValue(tomlConfigFile);
+
+      await rosettaConfiguration.updateRosettaSetting(false);
+
+      const expectedConfig: Record<string, unknown> = {
+        machine: {
+          rosetta: false,
+        },
+      };
+
+      expect(podmanConfiguration.writeUserConfig).toHaveBeenCalledWith(expectedConfig);
+    });
+
+    test('should do nothing if machine config is missing and useRosetta is true', async () => {
+      const tomlConfigFile: Record<string, unknown> = {};
+      (podmanConfiguration.readUserConfig as Mock).mockResolvedValue(tomlConfigFile);
+
+      await rosettaConfiguration.updateRosettaSetting(true);
+
+      const expectedConfig: Record<string, unknown> = {};
+
+      expect(podmanConfiguration.writeUserConfig).toHaveBeenCalledWith(expectedConfig);
+    });
+
+    test('should handle readUserConfig failure gracefully', async () => {
+      (podmanConfiguration.readUserConfig as Mock).mockRejectedValue(new Error('Failed to read config'));
+
+      await rosettaConfiguration.updateRosettaSetting(true);
+
+      const expectedConfig: Record<string, unknown> = {};
+
+      expect(podmanConfiguration.writeUserConfig).toHaveBeenCalledWith(expectedConfig);
+    });
+  });
+
+  describe('isRosettaEnabled', () => {
+    beforeEach(() => {
+      vi.mocked(extensionApi.env).isMac = false;
+      vi.mocked(extensionApi.env).isLinux = false;
+      vi.mocked(extensionApi.env).isWindows = false;
+    });
+
+    test('check rosetta is enabled', async () => {
+      const tomlConfigFile: Record<string, unknown> = {
+        machine: {
+          rosetta: true,
+          memory: 4096,
+        },
+      };
+      (podmanConfiguration.readUserConfig as Mock).mockResolvedValue(tomlConfigFile);
+
+      const isEnabled = await rosettaConfiguration.isRosettaEnabled();
+
+      expect(isEnabled).toBeTruthy();
+    });
+
+    test('check rosetta is enabled if file is not containing rosetta setting (default value is true)', async () => {
+      const tomlConfigFile: Record<string, unknown> = {
+        machine: {
+          memory: 4096,
+        },
+      };
+      (podmanConfiguration.readUserConfig as Mock).mockResolvedValue(tomlConfigFile);
+
+      const isEnabled = await rosettaConfiguration.isRosettaEnabled();
+
+      expect(isEnabled).toBeTruthy();
+    });
+
+    test('check rosetta is disabled', async () => {
+      const tomlConfigFile: Record<string, unknown> = {
+        machine: {
+          rosetta: false,
+          memory: 4096,
+        },
+      };
+      (podmanConfiguration.readUserConfig as Mock).mockResolvedValue(tomlConfigFile);
+
+      const isEnabled = await rosettaConfiguration.isRosettaEnabled();
+
+      expect(isEnabled).toBeFalsy();
+    });
+  });
 });


### PR DESCRIPTION
### What does this PR do?

The purpose of this changes request is to provide the complex mechanism to process Podman system and user based configuration. According to the latest changes in Podman [new.go](https://github.com/containers/common/blob/main/pkg/config/new.go) there is a need to implement the same logic in Podman Desktop to process these configuration files.

### Screenshot / video of UI

No screenshots. Changes are invisible from the user perspective.

### What issues does this PR fix or reference?

#7027 

### How to test this PR?

Podman Desktop should take into account Podman system-based and user-based configuration. So, no visual check on the UI. The only thing is to check, that the current PR works the same as https://github.com/containers/podman-desktop/pull/7881 and https://github.com/containers/podman-desktop/pull/7540 intended.

- [x] Tests are covering the bug fix or the new feature
