### PR TITLE
fix: restart informers for not current contexts after changes

### DIFF
--- a/packages/main/src/plugin/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes-client.ts
@@ -469,8 +469,9 @@ export class KubernetesClient {
     await this.fetchAPIGroups();
     this.apiSender.send('pod-event');
     this.apiSender.send('kubeconfig-update');
-
-    await this.contextsState.update(this.kubeConfig);
+    const configCopy = new KubeConfig();
+    configCopy.loadFromString(this.kubeConfig.exportConfig());
+    await this.contextsState.update(configCopy);
   }
 
   newError(message: string, cause: Error): Error {


### PR DESCRIPTION
### What does this PR do?

Iterates over contexts left after getting rid of deleted and added contexts to find changed ones and restart informers.

### Screenshot / video of UI

https://github.com/containers/podman-desktop/assets/620330/0af4d00e-14f4-49a2-bf0e-83f23086e3f3

### What issues does this PR fix or reference?

Fix #7707

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
