### PR TITLE
fix: refine colors used in form pages

### DIFF
--- a/packages/main/src/plugin/color-registry.ts
+++ b/packages/main/src/plugin/color-registry.ts
@@ -249,7 +249,6 @@ export class ColorRegistry {
     this.initDropdown();
     this.initLabel();
     this.initStatusColors();
-    this.initFormPage();
     this.initStatusBar();
     this.initOnboarding();
     this.initStates();
@@ -1194,20 +1193,6 @@ export class ColorRegistry {
     this.registerColor(`${status}ready`, {
       dark: colorPalette.gray[900],
       light: colorPalette.gray[100],
-    });
-  }
-
-  protected initFormPage(): void {
-    const formPage = 'formpage-';
-
-    this.registerColor(`${formPage}card-bg`, {
-      dark: colorPalette.charcoal[800],
-      light: colorPalette.gray[300],
-    });
-
-    this.registerColor(`${formPage}card-text`, {
-      dark: colorPalette.gray[400],
-      light: colorPalette.purple[900],
     });
   }
 

--- a/packages/renderer/src/lib/container/ContainerExport.svelte
+++ b/packages/renderer/src/lib/container/ContainerExport.svelte
@@ -104,7 +104,7 @@ async function exportContainer() {
 
     <div slot="content" class="space-y-2">
       <div>
-        <label for="modalSelectTarget" class="block mb-2 text-sm font-medium text-[var(--pd-label-text)]"
+        <label for="modalSelectTarget" class="block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]"
           >Export to:</label>
         <div class="flex w-full">
           <Input

--- a/packages/renderer/src/lib/image/ImportContainersImages.svelte
+++ b/packages/renderer/src/lib/image/ImportContainersImages.svelte
@@ -113,10 +113,10 @@ async function importContainers() {
   </svelte:fragment>
   <div slot="content" class="space-y-2">
     {#if providerConnections.length > 1}
-      <label for="providerChoice" class="py-6 block mb-2 text-sm font-bold text-[var(--pd-label-text)]"
+      <label for="providerChoice" class="py-6 block mb-2 text-sm font-bold text-[var(--pd-content-card-header-text)]"
         >Container Engine
         <select
-          class="w-full p-2 outline-none text-sm bg-[var(--pd-select-bg)] rounded-sm text-[var(--pd-content-text)]"
+          class="w-full p-2 outline-none text-sm bg-[var(--pd-select-bg)] rounded-sm text-[var(--pd-content-card-text)]"
           name="providerChoice"
           id="providerChoice"
           bind:value="{selectedProvider}">
@@ -127,12 +127,12 @@ async function importContainers() {
       </label>
     {/if}
 
-    <label for="modalContainersImport" class="block mb-2 text-sm font-medium text-[var(--pd-label-text)]"
+    <label for="modalContainersImport" class="block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]"
       >Containers to import:</label>
     <Button on:click="{addContainersToImport}" icon="{faPlusCircle}" type="link">Add images to import</Button>
     <!-- Display the list of existing containersToImport -->
     {#if containersToImport.length > 0}
-      <div class="flex flex-row justify-center w-full py-1 text-sm font-medium text-[var(--pd-content-text)]">
+      <div class="flex flex-row justify-center w-full py-1 text-sm font-medium text-[var(--pd-content-card-text)]">
         <div class="flex flex-col grow pl-2">Image Path</div>
         <div class="flex flex-col w-2/4 mr-2.5">Image Name when importing (e.g quay.io/podman/hello)</div>
       </div>

--- a/packages/renderer/src/lib/image/LoadImages.svelte
+++ b/packages/renderer/src/lib/image/LoadImages.svelte
@@ -92,10 +92,10 @@ async function loadImages() {
   </svelte:fragment>
   <div slot="content" class="space-y-2">
     {#if providerConnections.length > 1}
-      <label for="providerChoice" class="pt-6 block text-sm font-bold text-[var(--pd-label-text)]"
+      <label for="providerChoice" class="pt-6 block text-sm font-bold text-[var(--pd-content-card-header-text)]"
         >Container Engine
         <select
-          class="w-full p-2 outline-none text-sm bg-[var(--pd-select-bg)] rounded-sm text-[var(--pd-content-text)]"
+          class="w-full p-2 outline-none text-sm bg-[var(--pd-select-bg)] rounded-sm text-[var(--pd-content-card-text)]"
           name="providerChoice"
           id="providerChoice"
           bind:value="{selectedProvider}">
@@ -109,7 +109,7 @@ async function loadImages() {
     <Button on:click="{addArchivesToLoad}" icon="{faPlusCircle}" type="link">Add archive</Button>
     <!-- Display the list of existing imagesToLoad -->
     {#if archivesToLoad.length > 0}
-      <div class="flex flex-row justify-center w-full py-1 text-sm font-medium text-[var(--pd-content-text)]">
+      <div class="flex flex-row justify-center w-full py-1 text-sm font-medium text-[var(--pd-content-card-text)]">
         <div class="flex flex-col grow pl-2">Image Archives</div>
       </div>
     {/if}

--- a/packages/renderer/src/lib/image/PullImage.svelte
+++ b/packages/renderer/src/lib/image/PullImage.svelte
@@ -148,10 +148,11 @@ function requestFocus(element: HTMLInputElement) {
 
   <div slot="content" class="space-y-6">
     <div class="w-full">
-      <label for="imageName" class="block mb-2 text-sm font-bold text-[var(--pd-label-text)]">Image to Pull</label>
+      <label for="imageName" class="block mb-2 text-sm font-bold text-[var(--pd-content-card-header-text)]"
+        >Image to Pull</label>
       <input
         id="imageName"
-        class="w-full p-2 outline-none text-sm bg-[var(--pd-select-bg)] rounded-sm text-[var(--pd-content-text)] placeholder:text-[color:var(--pd-input-field-placeholder-text)]"
+        class="w-full p-2 outline-none text-sm bg-[var(--pd-select-bg)] border-[1px] border-transparent border-b-[var(--pd-input-field-stroke)] rounded-sm text-[var(--pd-content-card-text)] placeholder:text-[color:var(--pd-input-field-placeholder-text)]"
         type="text"
         name="imageName"
         disabled="{pullFinished || pullInProgress}"
@@ -173,11 +174,11 @@ function requestFocus(element: HTMLInputElement) {
 
       {#if providerConnections.length > 1}
         <div class="pt-4">
-          <label for="providerChoice" class="block mb-2 text-sm font-bold text-[var(--pd-label-text)]"
+          <label for="providerChoice" class="block mb-2 text-sm font-bold text-[var(--pd-content-card-header-text)]"
             >Container Engine:</label>
           <select
             id="providerChoice"
-            class="w-auto border text-sm rounded-lg focus:ring-purple-500 focus:border-purple-500 block p-2.5 bg-[var(--pd-select-bg)] rounded-sm text-[var(--pd-content-text)]"
+            class="w-auto border text-sm rounded-lg focus:ring-purple-500 focus:border-purple-500 block p-2.5 bg-[var(--pd-select-bg)] rounded-sm text-[var(--pd-content-card-text)]"
             name="providerChoice"
             bind:value="{selectedProviderConnection}">
             {#each providerConnections as providerConnection}

--- a/packages/renderer/src/lib/image/RunImage.svelte
+++ b/packages/renderer/src/lib/image/RunImage.svelte
@@ -649,8 +649,9 @@ async function assertAllPortAreValid(): Promise<void> {
         <div>
           <Route path="/basic" breadcrumb="Basic" navigationHint="tab">
             <div class="h-96 overflow-y-auto pr-4">
-              <label for="modalContainerName" class="block mb-2 text-sm font-medium text-[var(--pd-label-text)]"
-                >Container name:</label>
+              <label
+                for="modalContainerName"
+                class="block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]">Container name:</label>
               <Input
                 on:input="{event => checkContainerName(event)}"
                 bind:value="{containerName}"
@@ -659,13 +660,16 @@ async function assertAllPortAreValid(): Promise<void> {
                 placeholder="Leave blank to generate a name"
                 aria-label="Container Name"
                 error="{containerNameError}" />
-              <label for="modalEntrypoint" class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-label-text)]"
+              <label
+                for="modalEntrypoint"
+                class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]"
                 >Entrypoint:</label>
               <Input bind:value="{entrypoint}" name="modalEntrypoint" id="modalEntrypoint" aria-label="Entrypoint" />
-              <label for="modalCommand" class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-label-text)]"
-                >Command:</label>
+              <label
+                for="modalCommand"
+                class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]">Command:</label>
               <Input bind:value="{command}" name="modalCommand" id="modalCommand" aria-label="Command" />
-              <label for="volumes" class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-label-text)]"
+              <label for="volumes" class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]"
                 >Volumes:</label>
               <!-- Display the list of volumes -->
               {#each volumeMounts as volumeMount, index}
@@ -691,11 +695,14 @@ async function assertAllPortAreValid(): Promise<void> {
               {/each}
 
               <!-- add a label for each port-->
-              <label for="modalContainerName" class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-label-text)]"
+              <label
+                for="modalContainerName"
+                class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]"
                 >Port mapping:</label>
               {#each exposedPorts as port, index}
                 <div class="flex flex-row justify-center items-center w-full">
-                  <span class="text-sm flex-1 inline-block align-middle whitespace-nowrap text-[var(--pd-content-text)]"
+                  <span
+                    class="text-sm flex-1 inline-block align-middle whitespace-nowrap text-[var(--pd-content-card-text)]"
                     >Local port for {port}:</span>
                   <Input
                     bind:value="{containerPortMapping[index].port}"
@@ -734,7 +741,8 @@ async function assertAllPortAreValid(): Promise<void> {
               {/each}
               <label
                 for="modalEnvironmentVariables"
-                class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-label-text)]">Environment variables:</label>
+                class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]"
+                >Environment variables:</label>
               <!-- Display the list of existing environment variables -->
               {#each environmentVariables as environmentVariable, index}
                 <div class="flex flex-row justify-center items-center w-full py-1">
@@ -757,7 +765,9 @@ async function assertAllPortAreValid(): Promise<void> {
                 </div>
               {/each}
 
-              <label for="modalEnvironmentFiles" class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-label-text)]"
+              <label
+                for="modalEnvironmentFiles"
+                class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]"
                 >Environment files:</label>
               <!-- Display the list of existing environment files -->
               {#each environmentFiles as environmentFile, index}
@@ -793,9 +803,9 @@ async function assertAllPortAreValid(): Promise<void> {
           <Route path="/advanced" breadcrumb="Advanced" navigationHint="tab">
             <div class="h-96 overflow-y-auto pr-4">
               <!-- Use tty -->
-              <label for="containerTty" class="block mb-2 text-sm font-medium text-[var(--pd-label-text)]"
+              <label for="containerTty" class="block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]"
                 >Use TTY:</label>
-              <div class="flex flex-col text-[var(--pd-content-text)] text-sm ml-2">
+              <div class="flex flex-col text-[var(--pd-content-card-text)] text-sm ml-2">
                 <Checkbox bind:checked="{useTty}" title="Attach a pseudo terminal">Attach a pseudo terminal</Checkbox>
                 <Checkbox bind:checked="{useInteractive}" title="Use interactive">
                   Interactive: Keep STDIN open even if not attached
@@ -803,7 +813,9 @@ async function assertAllPortAreValid(): Promise<void> {
               </div>
 
               <!-- Specify user-->
-              <label for="containerUser" class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-label-text)]"
+              <label
+                for="containerUser"
+                class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]"
                 >Specify user to run container as:</label>
               <div class="flex flex-row justify-center items-center w-full">
                 <Input
@@ -813,18 +825,21 @@ async function assertAllPortAreValid(): Promise<void> {
               </div>
 
               <!-- Autoremove-->
-              <label for="containerAutoRemove" class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-label-text)]"
+              <label
+                for="containerAutoRemove"
+                class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]"
                 >Auto removal of container:</label>
-              <Checkbox class="text-[var(--pd-content-text)] text-sm ml-2" bind:checked="{autoRemove}">
+              <Checkbox class="text-[var(--pd-content-card-text)] text-sm ml-2" bind:checked="{autoRemove}">
                 Automatically remove the container when the process exits
               </Checkbox>
 
               <!-- RestartPolicy-->
               <label
                 for="containerRestartPolicy"
-                class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-label-text)]">Restart policy:</label>
+                class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]"
+                >Restart policy:</label>
               <div
-                class="p-0 flex flex-row justify-start items-center align-middle w-full text-[var(--pd-content-text)]">
+                class="p-0 flex flex-row justify-start items-center align-middle w-full text-[var(--pd-content-card-text)]">
                 <span class="text-sm w-28 inline-block align-middle whitespace-nowrap">Policy name:</span>
 
                 <select
@@ -844,7 +859,7 @@ async function assertAllPortAreValid(): Promise<void> {
                   ? 'opacity-100'
                   : 'opacity-20'}">
                 <span
-                  class="text-sm w-28 inline-block align-middle whitespace-nowrap text-[var(--pd-content-text)]"
+                  class="text-sm w-28 inline-block align-middle whitespace-nowrap text-[var(--pd-content-card-text)]"
                   title="Number of times to retry before giving up.">Retries:</span>
                 <NumberInput
                   minimum="{0}"
@@ -858,22 +873,24 @@ async function assertAllPortAreValid(): Promise<void> {
           <Route path="/security" breadcrumb="Security" navigationHint="tab">
             <div class="h-96 overflow-y-auto pr-4">
               <!-- Privileged-->
-              <label for="containerPrivileged" class="block mb-2 text-sm font-medium text-[var(--pd-label-text)]"
-                >Privileged:</label>
-              <Checkbox bind:checked="{privileged}" class="text-[var(--pd-content-text)] text-sm mx-2">
+              <label
+                for="containerPrivileged"
+                class="block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]">Privileged:</label>
+              <Checkbox bind:checked="{privileged}" class="text-[var(--pd-content-card-text)] text-sm mx-2">
                 Turn off security<i class="pl-1 fas fa-exclamation-triangle"></i>
               </Checkbox>
 
               <!-- Read-Only -->
-              <label for="containerReadOnly" class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-label-text)]"
-                >Read only:</label>
-              <Checkbox bind:checked="{readOnly}" class="text-[var(--pd-content-text)] text-sm mx-2">
+              <label
+                for="containerReadOnly"
+                class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]">Read only:</label>
+              <Checkbox bind:checked="{readOnly}" class="text-[var(--pd-content-card-text)] text-sm mx-2">
                 Make containers root filesystem read-only
               </Checkbox>
 
               <label
                 for="ContainerSecurityOptions"
-                class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-label-text)]"
+                class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]"
                 >Security options (security-opt):</label>
               <!-- Display the list of existing security options -->
               {#each securityOpts as securityOpt, index}
@@ -898,11 +915,12 @@ async function assertAllPortAreValid(): Promise<void> {
 
               <label
                 for="ContainerSecurityCapabilitiesAdd"
-                class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-label-text)]">Capabilities:</label>
+                class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]"
+                >Capabilities:</label>
 
               <label
                 for="ContainerSecurityCapabilitiesAdd"
-                class="pl-4 pt-2 block mb-2 text-sm font-medium text-[var(--pd-label-text)]"
+                class="pl-4 pt-2 block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]"
                 >Add to the container (CapAdd):</label>
               <!-- Display the list of existing capAdd -->
               {#each capAdds as capAdd, index}
@@ -923,7 +941,7 @@ async function assertAllPortAreValid(): Promise<void> {
               {/each}
               <label
                 for="ContainerSecurityCapabilitiesDrop"
-                class="pl-4 pt-2 block mb-2 text-sm font-medium text-[var(--pd-label-text)]"
+                class="pl-4 pt-2 block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]"
                 >Drop from the container (CapDrop):</label>
               <!-- Display the list of existing capDrop -->
               {#each capDrops as capDrop, index}
@@ -946,7 +964,7 @@ async function assertAllPortAreValid(): Promise<void> {
               <!-- Specify user namespace-->
               <label
                 for="containerUserNamespace"
-                class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-label-text)]"
+                class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]"
                 >Specify user namespace to use:</label>
               <div class="flex flex-row justify-center items-center w-full">
                 <Input bind:value="{userNamespace}" placeholder="Enter a user namespace" class="ml-2 w-full" />
@@ -957,14 +975,18 @@ async function assertAllPortAreValid(): Promise<void> {
           <Route path="/networking" breadcrumb="Networking" navigationHint="tab">
             <div class="h-96 overflow-y-auto pr-4">
               <!-- hostname-->
-              <label for="containerHostname" class="block mb-2 text-sm font-medium text-[var(--pd-label-text)]"
+              <label
+                for="containerHostname"
+                class="block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]"
                 >Defines container hostname:</label>
               <div class="flex flex-row justify-center items-center w-full">
                 <Input bind:value="{hostname}" placeholder="Must be a valid RFC 1123 hostname" class="ml-2" />
               </div>
 
               <!-- DNS -->
-              <label for="ContainerDns" class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-label-text)]"
+              <label
+                for="ContainerDns"
+                class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]"
                 >Custom DNS server(s):</label>
 
               {#each dnsServers as dnsServer, index}
@@ -984,7 +1006,9 @@ async function assertAllPortAreValid(): Promise<void> {
                 </div>
               {/each}
 
-              <label for="containerExtraHosts" class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-label-text)]"
+              <label
+                for="containerExtraHosts"
+                class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]"
                 >Add extra hosts (appends to /etc/hosts file):</label>
               <!-- Display the list of extra hosts -->
               {#each extraHosts as extraHost, index}
@@ -1006,10 +1030,12 @@ async function assertAllPortAreValid(): Promise<void> {
               {/each}
 
               <!-- Select network -->
-              <label for="containerNetwork" class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-label-text)]"
+              <label
+                for="containerNetwork"
+                class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]"
                 >Select container networking:</label>
               <div
-                class="p-0 flex flex-row justify-start items-center align-middle w-full text-[var(--pd-content-text)]">
+                class="p-0 flex flex-row justify-start items-center align-middle w-full text-[var(--pd-content-card-text)]">
                 <span class="text-sm w-28 inline-block align-middle whitespace-nowrap">Mode:</span>
 
                 <select
@@ -1027,10 +1053,11 @@ async function assertAllPortAreValid(): Promise<void> {
 
               {#if networkingMode === 'choice-network'}
                 <div class="flex flex-row justify-center items-center w-full py-1">
-                  <span class="text-sm w-28 inline-block align-middle whitespace-nowrap text-[var(--pd-content-text)]"
+                  <span
+                    class="text-sm w-28 inline-block align-middle whitespace-nowrap text-[var(--pd-content-card-text)]"
                     >Network:</span>
                   <select
-                    class="w-full p-2 outline-none text-sm bg-[var(--pd-select-bg)] rounded-sm text-[var(--pd-content-text)]"
+                    class="w-full p-2 outline-none text-sm bg-[var(--pd-select-bg)] rounded-sm text-[var(--pd-content-card-text)]"
                     disabled="{networkingMode !== 'choice-network'}"
                     name="networkingModeUserNetwork"
                     bind:value="{networkingModeUserNetwork}">
@@ -1043,10 +1070,11 @@ async function assertAllPortAreValid(): Promise<void> {
               {/if}
               {#if networkingMode === 'choice-container'}
                 <div class="flex flex-row justify-center items-center w-full py-1">
-                  <span class="text-sm w-28 inline-block align-middle whitespace-nowrap text-[var(--pd-content-text)]"
+                  <span
+                    class="text-sm w-28 inline-block align-middle whitespace-nowrap text-[var(--pd-content-card-text)]"
                     >Container:</span>
                   <select
-                    class="w-full p-2 outline-none text-sm bg-[var(--pd-select-bg)] rounded-sm text-[var(--pd-content-text)]"
+                    class="w-full p-2 outline-none text-sm bg-[var(--pd-select-bg)] rounded-sm text-[var(--pd-content-card-text)]"
                     disabled="{networkingMode !== 'choice-container'}"
                     name="networkingModeUserContainer"
                     bind:value="{networkingModeUserContainer}">

--- a/packages/renderer/src/lib/image/SaveImages.svelte
+++ b/packages/renderer/src/lib/image/SaveImages.svelte
@@ -134,7 +134,7 @@ async function saveImages() {
       <i class="fas fa-play fa-2x" aria-hidden="true"></i>
     </svelte:fragment>
     <div slot="content" class="space-y-2">
-      <label for="modalSelectTarget" class="block mb-2 text-sm font-medium text-[var(--pd-label-text)]"
+      <label for="modalSelectTarget" class="block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]"
         >Export to:</label>
       <div class="flex w-full">
         <Input
@@ -151,7 +151,8 @@ async function saveImages() {
 
       {#if !singleItemMode && imagesToSave.length > 0}
         <!-- Display the list of images to save -->
-        <div class="flex flex-row justify-center w-full pt-5 text-sm font-medium text-[var(--pd-label-text)]">
+        <div
+          class="flex flex-row justify-center w-full pt-5 text-sm font-medium text-[var(--pd-content-card-header-text)]">
           <div class="flex flex-col grow">Images to save</div>
         </div>
         {#each imagesToSave as imageToSave, index}

--- a/packages/renderer/src/lib/pod/DeployPodToKube.svelte
+++ b/packages/renderer/src/lib/pod/DeployPodToKube.svelte
@@ -391,17 +391,18 @@ function updateKubeResult() {
 
     {#if bodyPod}
       <div class="pt-2 pb-4">
-        <label for="contextToUse" class="block mb-1 text-sm font-medium text-[var(--pd-label-text)]">Pod Name:</label>
+        <label for="contextToUse" class="block mb-1 text-sm font-medium text-[var(--pd-content-card-header-text)]"
+          >Pod Name:</label>
         <Input bind:value="{bodyPod.metadata.name}" name="podName" id="podName" class="w-full" required />
       </div>
     {/if}
 
     <div class="pt-2 pb-4">
-      <label for="services" class="block mb-1 text-sm font-medium text-[var(--pd-label-text)]"
+      <label for="services" class="block mb-1 text-sm font-medium text-[var(--pd-content-card-header-text)]"
         >Kubernetes Services:</label>
       <Checkbox
         bind:checked="{deployUsingServices}"
-        class="text-[var(--pd-content-text)] text-sm ml-1"
+        class="text-[var(--pd-content-card-text)] text-sm ml-1"
         name="useServices"
         id="useServices"
         required>
@@ -410,11 +411,11 @@ function updateKubeResult() {
     </div>
 
     <div class="pt-2 pb-4">
-      <label for="useRestricted" class="block mb-1 text-sm font-medium text-[var(--pd-label-text)]"
+      <label for="useRestricted" class="block mb-1 text-sm font-medium text-[var(--pd-content-card-header-text)]"
         >Restricted Security Context:</label>
       <Checkbox
         bind:checked="{deployUsingRestrictedSecurityContext}"
-        class="text-[var(--pd-content-text)] text-sm ml-1"
+        class="text-[var(--pd-content-card-text)] text-sm ml-1"
         name="useRestricted"
         id="useRestricted"
         title="Use restricted security context"
@@ -429,11 +430,11 @@ function updateKubeResult() {
     <!-- Only show for non-OpenShift deployments (we use routes for OpenShift) -->
     {#if !openshiftRouteGroupSupported && deployUsingServices}
       <div class="pt-2 pb-4">
-        <label for="createIngress" class="block mb-1 text-sm font-medium text-[var(--pd-label-text)]"
+        <label for="createIngress" class="block mb-1 text-sm font-medium text-[var(--pd-content-card-header-text)]"
           >Expose Service Locally Using Kubernetes Ingress:</label>
         <Checkbox
           bind:checked="{createIngress}"
-          class="text-[var(--pd-content-text)] text-sm ml-1"
+          class="text-[var(--pd-content-card-text)] text-sm ml-1"
           name="createIngress"
           id="createIngress"
           title="Create Ingress"
@@ -446,20 +447,20 @@ function updateKubeResult() {
 
     {#if createIngress && containerPortArray.length > 1}
       <div class="pt-2 pb-4">
-        <label for="ingress" class="block mb-1 text-sm font-medium text-[var(--pd-label-text)]"
+        <label for="ingress" class="block mb-1 text-sm font-medium text-[var(--pd-content-card-header-text)]"
           >Ingress Host Port:</label>
         <select
           bind:value="{ingressPort}"
           name="serviceName"
           id="serviceName"
-          class=" cursor-default w-full p-2 outline-none text-sm bg-[var(--pd-select-bg)] rounded-sm text-[var(--pd-content-text)]"
+          class=" cursor-default w-full p-2 outline-none text-sm bg-[var(--pd-select-bg)] rounded-sm text-[var(--pd-content-card-text)]"
           required>
           <option value="" disabled selected>Select a port</option>
           {#each containerPortArray as port}
             <option value="{port}">{port}</option>
           {/each}
         </select>
-        <span class="text-[var(--pd-content-text)] text-sm ml-1"
+        <span class="text-[var(--pd-content-card-text)] text-sm ml-1"
           >There are multiple exposed ports available. Select the one you want to expose to '/' with the Ingress.
         </span>
       </div>
@@ -468,11 +469,11 @@ function updateKubeResult() {
     <!-- Allow to create routes for OpenShift clusters -->
     {#if openshiftRouteGroupSupported}
       <div class="pt-2">
-        <label for="routes" class="block mb-1 text-sm font-medium text-[var(--pd-label-text)]"
+        <label for="routes" class="block mb-1 text-sm font-medium text-[var(--pd-content-card-header-text)]"
           >Create OpenShift routes:</label>
         <Checkbox
           bind:checked="{deployUsingRoutes}"
-          class="text-[var(--pd-content-text)] text-sm ml-1"
+          class="text-[var(--pd-content-card-text)] text-sm ml-1"
           name="useRoutes"
           id="useRoutes"
           required>
@@ -482,7 +483,7 @@ function updateKubeResult() {
 
     {#if defaultContextName}
       <div class="pt-2">
-        <label for="contextToUse" class="block mb-1 text-sm font-medium text-[var(--pd-label-text)]"
+        <label for="contextToUse" class="block mb-1 text-sm font-medium text-[var(--pd-content-card-header-text)]"
           >Kubernetes Context:</label>
         <Input
           bind:value="{defaultContextName}"
@@ -496,10 +497,10 @@ function updateKubeResult() {
 
     {#if allNamespaces}
       <div class="pt-2">
-        <label for="namespaceToUse" class="block mb-1 text-sm font-medium text-[var(--pd-label-text)]"
+        <label for="namespaceToUse" class="block mb-1 text-sm font-medium text-[var(--pd-content-card-header-text)]"
           >Kubernetes Namespace:</label>
         <select
-          class="w-full p-2 outline-none text-sm bg-[var(--pd-select-bg)] rounded-sm text-[var(--pd-content-text)]"
+          class="w-full p-2 outline-none text-sm bg-[var(--pd-select-bg)] rounded-sm text-[var(--pd-content-card-text)]"
           name="namespaceChoice"
           bind:value="{currentNamespace}">
           {#each allNamespaces.items as namespace}
@@ -541,7 +542,7 @@ function updateKubeResult() {
             </div>
           {/if}
         </div>
-        <div class="text-[var(--pd-content-text)]">
+        <div class="text-[var(--pd-content-card-text)]">
           {#if createdPod.metadata?.name}
             <p class="pt-2">Name: {createdPod.metadata.name}</p>
           {/if}

--- a/packages/renderer/src/lib/pod/PodCreateFromContainers.spec.ts
+++ b/packages/renderer/src/lib/pod/PodCreateFromContainers.spec.ts
@@ -254,7 +254,7 @@ test('Show warning if multiple containers use the same port', async () => {
   podCreationHolder.set(podCreationSamePortContainers);
 
   render(PodCreateFromContainers, {});
-  const warningLabel = await screen.findByLabelText('warning');
+  const warningLabel = await screen.findByLabelText('Warning Message Content');
   expect(warningLabel).toBeInTheDocument();
 });
 

--- a/packages/renderer/src/lib/pod/PodCreateFromContainers.svelte
+++ b/packages/renderer/src/lib/pod/PodCreateFromContainers.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { faTriangleExclamation } from '@fortawesome/free-solid-svg-icons';
-import { Button, ErrorMessage, Input, StatusIcon } from '@podman-desktop/ui-svelte';
+import { Button, Checkbox, ErrorMessage, Input, StatusIcon } from '@podman-desktop/ui-svelte';
 import { ContainerIcon } from '@podman-desktop/ui-svelte/icons';
 import { onDestroy, onMount } from 'svelte';
 import type { Unsubscriber } from 'svelte/store';
@@ -201,15 +201,18 @@ function updatePortExposure(port: number, checked: boolean) {
     <div>
       {#if podCreation}
         {#if containersPorts.length > 0}
-          <div class="bg-charcoal-600 border-t-2 border-amber-500 p-4 mb-2" role="alert" aria-label="warning">
+          <div
+            class="bg-[var(--pd-content-card-inset-bg)] border-t-2 border-[var(--pd-modal-warning-text)] p-4 mb-2"
+            role="alert"
+            aria-label="warning">
             <div class="flex flex-row">
               <div class="mr-3">
-                <Fa size="1.125x" class="text-amber-400" icon="{faTriangleExclamation}" />
+                <Fa size="1.125x" class="text-[var(--pd-modal-warning-text)]" icon="{faTriangleExclamation}" />
               </div>
               <div class="flex flex-col">
-                <div class="text-sm text-amber-400">Possible runtime error</div>
+                <div class="text-sm text-[var(--pd-modal-warning-text)]">Possible runtime error</div>
                 {#each containersPorts as { containers, ports }}
-                  <div class="mt-1 text-sm text-white">
+                  <div class="mt-1 text-sm text-[var(--pd-content-header)]">
                     Containers
                     {#each containers as container, index}
                       <span class="font-bold">{container}</span>
@@ -228,7 +231,8 @@ function updatePortExposure(port: number, checked: boolean) {
           </div>
         {/if}
         <div class="mb-2">
-          <span class="block text-sm font-semibold rounded text-[var(--pd-label-text)]">Name of the pod:</span>
+          <span class="block text-sm font-semibold rounded text-[var(--pd-content-card-header-text)]"
+            >Name of the pod:</span>
         </div>
         <div class="mb-4">
           <Input
@@ -241,12 +245,13 @@ function updatePortExposure(port: number, checked: boolean) {
         </div>
 
         <div class="mb-2">
-          <span class="block text-sm font-semibold rounded text-[var(--pd-label-text)]" aria-label="Containers"
-            >Containers to replicate to the pod:</span>
+          <span
+            class="block text-sm font-semibold rounded text-[var(--pd-content-card-header-text)]"
+            aria-label="Containers">Containers to replicate to the pod:</span>
         </div>
-        <div class="w-full bg-[var(--pd-formpage-card-bg)] mb-4 max-h-40 overflow-y-auto">
+        <div class="w-full bg-[var(--pd-content-card-inset-bg)] mb-4 max-h-40 overflow-y-auto">
           {#each podCreation.containers as container, index}
-            <div class="p-2 flex flex-row items-center text-[var(--pd-formpage-card-text)]">
+            <div class="p-2 flex flex-row items-center text-[var(--pd-content-card-text)]">
               <div class="w-10"><StatusIcon icon="{ContainerIcon}" status="STOPPED" /></div>
               <div class="w-16 pl-3">{index + 1}.</div>
               <div class="grow">{container.name}</div>
@@ -257,21 +262,19 @@ function updatePortExposure(port: number, checked: boolean) {
 
         {#if mapPortExposed.size > 0}
           <div class="mb-2">
-            <span class="block text-sm font-semibold rounded text-[var(--pd-label-text)]" aria-label="Exposed ports"
-              >All selected ports will be exposed:</span>
+            <span
+              class="block text-sm font-semibold rounded text-[var(--pd-content-card-header-text)]"
+              aria-label="Exposed ports">All selected ports will be exposed:</span>
           </div>
-          <div class="bg-[var(--pd-formpage-card-bg)] mb-4 max-h-40 overflow-y-auto">
+          <div class="bg-[var(--pd-content-card-inset-bg)] mb-4 max-h-40 overflow-y-auto">
             {#each [...mapPortExposed] as [port, value]}
-              <div class="p-2 flex flex-row align-items text-[var(--pd-formpage-card-text)]">
-                <input
-                  type="checkbox"
-                  class="mr-5"
-                  checked="{value.exposed}"
-                  on:click="{event => updatePortExposure(port, event.currentTarget.checked)}" />
-                <div class="w-28 mr-5">
-                  <span class="text-sm">Port {port.toString()}</span>
-                </div>
-                <span class="text-sm">{value.container}</span>
+              <div class="p-2 flex flex-row align-items text-sm text-[var(--pd-content-card-text)]">
+                <Checkbox
+                  class="pt-0.5 mr-5"
+                  bind:checked="{value.exposed}"
+                  on:click="{event => updatePortExposure(port, event.detail)}" />
+                <div class="w-28 mr-5">Port {port.toString()}</div>
+                <span>{value.container}</span>
               </div>
             {/each}
           </div>
@@ -279,10 +282,12 @@ function updatePortExposure(port: number, checked: boolean) {
       {/if}
 
       {#if providerConnections.length > 1}
-        <label for="providerConnectionName" class="block mb-2 text-sm font-medium rounded text-[var(--pd-label-text)]"
+        <label
+          for="providerConnectionName"
+          class="block mb-2 text-sm font-medium rounded text-[var(--pd-content-card-header-text)]"
           >Container Engine</label>
         <select
-          class="w-full p-2 outline-none text-sm bg-[var(--pd-select-bg)] rounded-sm text-[var(--pd-content-text)]"
+          class="w-full p-2 outline-none text-sm bg-[var(--pd-select-bg)] rounded-sm text-[var(--pd-content-card-text)]"
           name="providerChoice"
           bind:value="{selectedProvider}">
           {#each providerConnections as providerConnection}

--- a/packages/renderer/src/lib/volume/CreateVolume.svelte
+++ b/packages/renderer/src/lib/volume/CreateVolume.svelte
@@ -61,16 +61,17 @@ export let volumeName = '';
   </svelte:fragment>
   <div slot="content" class="space-y-6">
     <div>
-      <label for="containerBuildContextDirectory" class="block mb-2 text-sm font-bold text-[var(--pd-label-text)]"
-        >Volume name:</label>
+      <label
+        for="containerBuildContextDirectory"
+        class="block mb-2 text-sm font-bold text-[var(--pd-content-card-header-text)]">Volume name:</label>
       <Input clearable aria-label="Volume Name" disabled="{createVolumeFinished}" bind:value="{volumeName}" required />
     </div>
     <div class:hidden="{providerConnections.length < 2}">
       {#if providerConnections.length > 1}
-        <label for="providerChoice" class="py-3 block mb-2 text-sm font-bold text-[var(--pd-label-text)]"
+        <label for="providerChoice" class="py-3 block mb-2 text-sm font-bold text-[var(--pd-content-card-header-text)]"
           >Container Engine
           <select
-            class="w-full p-2 outline-none text-sm bg-[var(--pd-select-bg)] rounded-sm text-[var(--pd-content-text)]"
+            class="w-full p-2 outline-none text-sm bg-[var(--pd-select-bg)] rounded-sm text-[var(--pd-content-card-text)]"
             aria-label="Provider Choice"
             disabled="{createVolumeFinished}"
             bind:value="{selectedProvider}">


### PR DESCRIPTION
### What does this PR do?

This PR refines the changes made by https://github.com/containers/podman-desktop/pull/7768 . I just recently discovered the mockup made by Emma https://github.com/containers/podman-desktop/wiki/Design-System-Theming#form-page so i converted the classes to what it is defined there. The output is almost the same as the main branch. 

This allowed me to remove the custom formpage classes which are not needed anymore.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

it is part of #7214 

### How to test this PR?

The pages to verify:

1. ExportContainer: go to containers page -> click on the "three vertical dots" icon of a container -> export container
2. ImportImage: go to the images page -> click on import (top right)
3. LoadImages: go to the images page -> click on load(top right)
4. PullImage: go to the images page -> click on pull(top right)
5. RunImage: go to the images page -> click on the start action of an image
6. SaveImages: go to images page -> click on the "three vertical dots" icon of an image-> save image
7. DeployToKube: go to the pods page -> click on the "three vertical dots" icon of an image-> deploy to kube
8. PodCreateFromContainers: go to containers page -> select 2 or more containers -> click on create pod on the top
9. CreateVolume: go to volumes page -> click on create (top right)

- [x] Tests are covering the bug fix or the new feature
