### PR TITLE
chore(StatusIcon): adding accepting values for status

### DIFF
--- a/packages/ui/src/lib/statusIcon/StatusIcon.svelte
+++ b/packages/ui/src/lib/statusIcon/StatusIcon.svelte
@@ -4,7 +4,7 @@ import Spinner from '../progress/Spinner.svelte';
 
 // status: one of RUNNING, STARTING, USED, CREATED, DELETING, or DEGRADED
 // any other status will result in a standard outlined box
-export let status = '';
+export let status: 'RUNNING' | 'STARTING' | 'USED' | 'DEGRADED' | 'DELETING' | 'CREATED' | string = 'UNKNOWN';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export let icon: any = undefined;
 export let size = 20;


### PR DESCRIPTION
### What does this PR do?

Add the accepted value, **and `string`** because most of our interface are using string for status.

https://github.com/containers/podman-desktop/blob/bf1acf37c99661ea8b7b8563894e37078fbe21df/packages/renderer/src/lib/compose/ComposeInfoUI.ts#L25

https://github.com/containers/podman-desktop/blob/ea3267976bfe065c155d876832b43b8371df1ea1/packages/renderer/src/lib/ingresses-routes/IngressUI.ts#L24

https://github.com/containers/podman-desktop/blob/a0ca7600815ce7b57dd1d3a4f8a5881d31d14e28/packages/renderer/src/lib/pvc/PVCUI.ts#L22

etc.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop/issues/7909

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- Pipeline should be ✅ 
