### PR TITLE
fix: extensions cannot be installed on symlinked folders

### DIFF
--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -17,7 +17,7 @@
  ***********************************************************************/
 
 import * as fs from 'node:fs';
-import { readFile } from 'node:fs/promises';
+import { readFile, realpath } from 'node:fs/promises';
 import * as path from 'node:path';
 
 import type * as containerDesktopAPI from '@podman-desktop/api';
@@ -429,6 +429,7 @@ export class ExtensionLoader {
   }
 
   async analyzeExtension(extensionPath: string, removable: boolean): Promise<AnalyzedExtension> {
+    extensionPath = await realpath(extensionPath);
     // do nothing if there is no package.json file
     let error = undefined;
     if (!fs.existsSync(path.resolve(extensionPath, 'package.json'))) {

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -429,16 +429,16 @@ export class ExtensionLoader {
   }
 
   async analyzeExtension(extensionPath: string, removable: boolean): Promise<AnalyzedExtension> {
-    extensionPath = await realpath(extensionPath);
+    const resolvedExtensionPath = await realpath(extensionPath);
     // do nothing if there is no package.json file
     let error = undefined;
-    if (!fs.existsSync(path.resolve(extensionPath, 'package.json'))) {
-      error = `Ignoring extension ${extensionPath} without package.json file`;
+    if (!fs.existsSync(path.resolve(resolvedExtensionPath, 'package.json'))) {
+      error = `Ignoring extension ${resolvedExtensionPath} without package.json file`;
       console.warn(error);
       const analyzedExtension: AnalyzedExtension = {
         id: '<unknown>',
         name: '<unknown>',
-        path: extensionPath,
+        path: resolvedExtensionPath,
         manifest: undefined,
         readme: '',
         api: <typeof containerDesktopAPI>{},
@@ -451,28 +451,28 @@ export class ExtensionLoader {
     }
 
     // log error if the manifest is missing required entries
-    const manifest = await this.loadManifest(extensionPath);
+    const manifest = await this.loadManifest(resolvedExtensionPath);
     if (!manifest.name || !manifest.displayName || !manifest.version || !manifest.publisher || !manifest.description) {
-      error = `Extension ${extensionPath} missing required manifest entry in package.json (name, displayName, version, publisher, description)`;
+      error = `Extension ${resolvedExtensionPath} missing required manifest entry in package.json (name, displayName, version, publisher, description)`;
       console.warn(error);
     }
 
     // create api object
     const disposables: Disposable[] = [];
-    const api = this.createApi(extensionPath, manifest, disposables);
+    const api = this.createApi(resolvedExtensionPath, manifest, disposables);
 
     // is there a README.md file in the extension folder ?
     let readme = '';
-    if (fs.existsSync(path.resolve(extensionPath, 'README.md'))) {
-      readme = await readFile(path.resolve(extensionPath, 'README.md'), 'utf8');
+    if (fs.existsSync(path.resolve(resolvedExtensionPath, 'README.md'))) {
+      readme = await readFile(path.resolve(resolvedExtensionPath, 'README.md'), 'utf8');
     }
 
     const analyzedExtension: AnalyzedExtension = {
       id: `${manifest.publisher}.${manifest.name}`,
       name: manifest.name,
       manifest,
-      path: extensionPath,
-      mainPath: manifest.main ? path.resolve(extensionPath, manifest.main) : undefined,
+      path: resolvedExtensionPath,
+      mainPath: manifest.main ? path.resolve(resolvedExtensionPath, manifest.main) : undefined,
       readme,
       api,
       removable,


### PR DESCRIPTION
Fixes #7601

### What does this PR do?

Resolves extension folder as node does it and thus loading then failed if the folder is not resolved

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

#7601 

### How to test this PR?

Test on a Linux distro that have $HOME as a symlink (Fedora Silverblue or Kinoite)

- [x] Tests are covering the bug fix or the new feature
