### PR TITLE
feat: add support for zstd images for extensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -155,6 +155,7 @@
     "eslint-plugin-simple-import-sort": "^12.1.1",
     "eslint-plugin-sonarjs": "^1.0.3",
     "eslint-plugin-unicorn": "^54.0.0",
+    "fzstd": "^0.1.1",
     "husky": "^9.0.11",
     "js-yaml": "^4.1.0",
     "lint-staged": "^15.2.7",

--- a/packages/main/src/plugin/image-registry.ts
+++ b/packages/main/src/plugin/image-registry.ts
@@ -25,6 +25,7 @@ import { pipeline } from 'node:stream/promises';
 
 import type * as containerDesktopAPI from '@podman-desktop/api';
 import type * as Dockerode from 'dockerode';
+import * as fzstd from 'fzstd';
 import type { HttpsOptions, OptionsOfTextResponseBody } from 'got';
 import got, { HTTPError, RequestError } from 'got';
 import { HttpProxyAgent, HttpsProxyAgent } from 'hpagent';
@@ -483,12 +484,28 @@ export class ImageRegistry {
     const manifest = await this.getManifest(imageData, token);
 
     // now, get all layers 'application/vnd.oci.image.layer.v1.tar+gzip' and download and expand them
-    const layers = manifest.layers.filter(
+    const gzipLayers = manifest.layers.filter(
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (layer: any) =>
         layer.mediaType === 'application/vnd.oci.image.layer.v1.tar+gzip' ||
         layer.mediaType === 'application/vnd.docker.image.rootfs.diff.tar.gzip',
     );
+
+    const zstdLayers = manifest.layers.filter(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (layer: any) => layer.mediaType === 'application/vnd.oci.image.layer.v1.tar+zstd',
+    );
+
+    let layers: { digest: string; size: number; mediaType: string }[] = [];
+    if (zstdLayers.length > 0) {
+      // using zstd layers
+      layers = zstdLayers;
+    } else if (gzipLayers.length > 0) {
+      // using gzip layers
+      layers = gzipLayers;
+    } else {
+      throw new Error(`No gzip or zstd layers found for the image ${imageName}`);
+    }
 
     // total size of all layers
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -498,7 +515,20 @@ export class ImageRegistry {
     let currentDownloaded = 0;
     for (const layer of layers) {
       const layerDigest = layer.digest;
-      await this.fetchAndExtractLayer(imageData, layerDigest, destFolder, token, currentDownloaded, totalSize, logger);
+      let compressionType: 'gzip' | 'zstd' = 'gzip';
+      if (layer.mediaType === 'application/vnd.oci.image.layer.v1.tar+zstd') {
+        compressionType = 'zstd';
+      }
+      await this.fetchAndExtractLayer(
+        imageData,
+        layerDigest,
+        compressionType,
+        destFolder,
+        token,
+        currentDownloaded,
+        totalSize,
+        logger,
+      );
       currentDownloaded += layer.size;
     }
   }
@@ -506,6 +536,7 @@ export class ImageRegistry {
   protected async fetchAndExtractLayer(
     imageData: ImageRegistryNameTag,
     digest: string,
+    compressionType: 'gzip' | 'zstd',
     destFolder: string,
     token: string,
     currentDownloaded: number,
@@ -525,7 +556,8 @@ export class ImageRegistry {
       await fs.promises.mkdir(destFolder, { recursive: true });
     }
 
-    const tmpFileName = path.resolve(os.tmpdir(), `${digestWithoutSpecialChars}.tar`);
+    const suffix = compressionType === 'gzip' ? '.tar' : '.zst';
+    const tmpFileName = path.resolve(os.tmpdir(), `${digestWithoutSpecialChars}${suffix}`);
 
     // ensure the folder exists
     const parentDir = path.dirname(tmpFileName);
@@ -539,10 +571,24 @@ export class ImageRegistry {
 
     readStream.on('downloadProgress', ({ transferred }) => {
       const globalPercentage = Math.round(((transferred + currentDownloaded) / totalSize) * 100);
-      logger(`Downloading ${digest}.tar - ${globalPercentage}% - (${transferred + currentDownloaded}/${totalSize})`);
+      logger(
+        `Downloading ${digest}${suffix} - ${globalPercentage}% - (${transferred + currentDownloaded}/${totalSize})`,
+      );
     });
     await pipeline(readStream, createWriteStream(tmpFileName));
-    await nodeTar.extract({ file: tmpFileName, cwd: destFolder });
+    // in case of zstd, we need to unpack the file first
+    if (compressionType === 'zstd') {
+      //use fstd library to extract the file
+      const content = await fs.promises.readFile(tmpFileName);
+      const decompressed = fzstd.decompress(content);
+      const unpackedFileName = tmpFileName.replace('.zst', '.tar');
+      await fs.promises.writeFile(unpackedFileName, decompressed);
+      await nodeTar.extract({ file: unpackedFileName, cwd: destFolder });
+      // remove the temporary file
+      await fs.promises.rm(tmpFileName);
+    } else {
+      await nodeTar.extract({ file: tmpFileName, cwd: destFolder });
+    }
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/main/tests/resources/data/plugin/image-registry-manifest-index.zstd.json
+++ b/packages/main/tests/resources/data/plugin/image-registry-manifest-index.zstd.json
@@ -1,0 +1,21 @@
+{
+  "mediaType": "application/vnd.oci.image.manifest.v1+json",
+  "schemaVersion": 2,
+  "config": {
+    "mediaType": "application/vnd.oci.image.config.v1+json",
+    "digest": "sha256:2f65da9a67deadfb588660ad7da746c4facba696ea5cf8ab844b281f1c14bb01",
+    "size": 2045
+  },
+  "layers": [
+    {
+      "mediaType": "application/vnd.oci.image.layer.v1.tar+zstd",
+      "digest": "sha256:ec4d84bbb887a9dba10a4551252dde152bbb42e3b02e501b44218c9c5425eac4",
+      "size": 1188
+    },
+    {
+      "mediaType": "application/vnd.oci.image.layer.v1.tar+zstd",
+      "digest": "sha256:dc0c1d0e36ea3e0b94af099c9b96012743ae22e1797eaff3308895335513d454",
+      "size": 4070
+    }
+  ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -11555,6 +11555,11 @@ functions-have-names@^1.2.3:
   resolved "https://registry.yarnpkg.com/functions-have-names/-/functions-have-names-1.2.3.tgz#0404fe4ee2ba2f607f0e0ec3c80bae994133b834"
   integrity sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==
 
+fzstd@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/fzstd/-/fzstd-0.1.1.tgz#a3da29f2fff45070ca90073f866d97e0c56a4a52"
+  integrity sha512-dkuVSOKKwh3eas5VkJy1AW1vFpet8TA/fGmVA5krThl8YcOVE/8ZIoEA1+U1vEn5ckxxhLirSdY837azmbaNHA==
+
 gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
   resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0"


### PR DESCRIPTION
### What does this PR do?
add support for zstd images for extensions
until now only gzip format was supported

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/7806

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
