### PR TITLE
chore: light error and warning colors

### DIFF
--- a/packages/main/src/plugin/color-registry.ts
+++ b/packages/main/src/plugin/color-registry.ts
@@ -252,6 +252,7 @@ export class ColorRegistry {
     this.initFormPage();
     this.initStatusBar();
     this.initOnboarding();
+    this.initStates();
   }
 
   protected initNotificationDot(): void {
@@ -857,14 +858,6 @@ export class ColorRegistry {
       dark: colorPalette.purple[700],
       light: colorPalette.purple[300],
     });
-    this.registerColor(`${modal}error-text`, {
-      dark: colorPalette.red[500],
-      light: colorPalette.red[500],
-    });
-    this.registerColor(`${modal}warning-text`, {
-      dark: colorPalette.amber[400],
-      light: colorPalette.amber[400],
-    });
   }
 
   // links
@@ -1252,6 +1245,24 @@ export class ColorRegistry {
     this.registerColor(`${onboarding}inactive-dot-border`, {
       dark: colorPalette.gray[700],
       light: colorPalette.gray[700],
+    });
+  }
+
+  protected initStates(): void {
+    const state = 'state-';
+
+    // general error and warning states
+    this.registerColor(`${state}success`, {
+      dark: colorPalette.green[500],
+      light: colorPalette.green[600],
+    });
+    this.registerColor(`${state}warning`, {
+      dark: colorPalette.amber[500],
+      light: colorPalette.amber[600],
+    });
+    this.registerColor(`${state}error`, {
+      dark: colorPalette.red[500],
+      light: colorPalette.red[600],
     });
   }
 }

--- a/packages/renderer/src/lib/container/ContainerStatistics.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerStatistics.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -154,7 +154,7 @@ test('Expect memory donut', async () => {
   expect(memTooltip).toBeInTheDocument();
 
   const memArc = screen.getAllByTestId('arc')[1];
-  expect(memArc).toHaveClass('stroke-green-500');
+  expect(memArc).toHaveClass('stroke-[var(--pd-state-success)]');
 });
 
 test('Expect CPU donut', async () => {
@@ -173,5 +173,5 @@ test('Expect CPU donut', async () => {
   expect(cpuTooltip).toBeInTheDocument();
 
   const cpuArc = screen.getAllByTestId('arc')[0];
-  expect(cpuArc).toHaveClass('stroke-red-500');
+  expect(cpuArc).toHaveClass('stroke-[var(--pd-state-error)]');
 });

--- a/packages/renderer/src/lib/dialogs/MessageBox.svelte
+++ b/packages/renderer/src/lib/dialogs/MessageBox.svelte
@@ -111,9 +111,9 @@ function getButtonType(b: boolean): ButtonType {
   <Modal name="{title}" on:close="{onClose}">
     <div class="flex items-center justify-between pl-4 pr-3 py-3 space-x-2 text-[var(--pd-modal-header-text)]">
       {#if type === 'error'}
-        <Fa class="h-4 w-4 text-[var(--pd-modal-error-text)]" icon="{faCircleExclamation}" />
+        <Fa class="h-4 w-4 text-[var(--pd-state-error)]" icon="{faCircleExclamation}" />
       {:else if type === 'warning'}
-        <Fa class="h-4 w-4 text-[var(--pd-modal-warning-text)]" icon="{faTriangleExclamation}" />
+        <Fa class="h-4 w-4 text-[var(--pd-state-warning)]" icon="{faTriangleExclamation}" />
       {:else if type === 'info'}
         <div class="flex">
           <Fa class="h-4 w-4 place-content-center" icon="{faCircle}" />

--- a/packages/renderer/src/lib/donut/Donut.svelte
+++ b/packages/renderer/src/lib/donut/Donut.svelte
@@ -21,7 +21,14 @@ function describeArc(radius: number, endAngle: number) {
   return ['M', start.x, start.y, 'A', radius, radius, 0, largeArcFlag, 0, radius, 0].join(' ');
 }
 
-$: stroke = percent < 0 ? '' : percent < 50 ? 'stroke-green-500' : percent < 75 ? 'stroke-amber-500' : 'stroke-red-500';
+$: stroke =
+  percent < 0
+    ? ''
+    : percent < 50
+      ? 'stroke-[var(--pd-state-success)]'
+      : percent < 75
+        ? 'stroke-[var(--pd-state-warning)]'
+        : 'stroke-[var(--pd-state-error)]';
 
 $: tooltip = percent ? percent.toFixed(0) + '% ' + title + ' usage' : '';
 </script>

--- a/packages/renderer/src/lib/task-manager/TaskManagerItem.svelte
+++ b/packages/renderer/src/lib/task-manager/TaskManagerItem.svelte
@@ -30,11 +30,11 @@ onMount(() => {
   if (isStatefulTask(task)) {
     if (task.status === 'success') {
       icon = faSquareCheck;
-      iconColor = 'text-green-600';
+      iconColor = 'text-[var(--pd-state-success)]';
       return;
     } else if (task.status === 'failure') {
       icon = faTriangleExclamation;
-      iconColor = 'text-red-500';
+      iconColor = 'text-[var(--pd-state-error)]';
       return;
     }
   }

--- a/packages/renderer/src/lib/ui/WarningMessage.svelte
+++ b/packages/renderer/src/lib/ui/WarningMessage.svelte
@@ -10,14 +10,14 @@ export let icon = false;
 {#if icon}
   {#if error !== undefined && error !== ''}
     <Tooltip top tip="{error}">
-      <Fa size="1.125x" class="cursor-pointer text-amber-500" icon="{faTriangleExclamation}" />
+      <Fa size="1.125x" class="cursor-pointer text-[var(--pd-state-warning)]" icon="{faTriangleExclamation}" />
     </Tooltip>
   {/if}
 {:else}
   <div
-    class="text-amber-500 p-1 flex flex-row items-center {$$props.class}"
+    class="text-[var(--pd-state-warning)] p-1 flex flex-row items-center {$$props.class}"
     class:opacity-0="{error === undefined || error === ''}">
-    <Fa size="1.125x" class="cursor-pointer text-amber-500" icon="{faTriangleExclamation}" />
+    <Fa size="1.125x" class="cursor-pointer text-[var(--pd-state-warning)]" icon="{faTriangleExclamation}" />
     <div role="alert" aria-label="Warning Message Content" class="ml-2">{error}</div>
   </div>
 {/if}

--- a/packages/ui/src/lib/alert/ErrorMessage.svelte
+++ b/packages/ui/src/lib/alert/ErrorMessage.svelte
@@ -11,14 +11,17 @@ export let icon = false;
 {#if icon}
   {#if error !== undefined && error !== ''}
     <Tooltip top tip="{error}">
-      <Fa size="1.1x" class="cursor-pointer text-red-500 {$$props.class}" icon="{faExclamationCircle}" />
+      <Fa
+        size="1.1x"
+        class="cursor-pointer text-[var(--pd-state-error)] {$$props.class}"
+        icon="{faExclamationCircle}" />
     </Tooltip>
   {/if}
 {:else}
   <div
-    class="text-red-500 p-1 flex flex-row items-center {$$props.class}"
+    class="text-[var(--pd-state-error)] p-1 flex flex-row items-center {$$props.class}"
     class:opacity-0="{error === undefined || error === ''}">
-    <Fa size="1.1x" class="cursor-pointer text-red-500" icon="{faExclamationCircle}" />
+    <Fa size="1.1x" class="cursor-pointer text-[var(--pd-state-error)]" icon="{faExclamationCircle}" />
     <div role="alert" aria-label="Error Message Content" class="ml-2">{error}</div>
   </div>
 {/if}


### PR DESCRIPTION
### What does this PR do?

Replaces the hard-coded error and warning colors with values from the registry and uses them for ErrorMessage, WarningMessage, TaskManagerItem, MessageBox, and Donut.

I wasn't sure what to call this set as they are not quite status; went with state. The MessageBox had state colors already defined for modals, but IMHO these should be 'global' so I replaced them. These colors might need to be refined for light and there are more uses of red-* and green-*, but this felt like enough to review and get the color vars in.

### Screenshot / video of UI

<img width="128" alt="Screenshot 2024-07-03 at 3 56 14 PM" src="https://github.com/containers/podman-desktop/assets/19958075/ea1d2955-afd2-410e-9814-231cd59292d5">
<img width="128" alt="Screenshot 2024-07-03 at 3 56 33 PM" src="https://github.com/containers/podman-desktop/assets/19958075/ea68439d-9fe4-4d13-ad63-b7cca71ce8ba">

### What issues does this PR fix or reference?

Fixes #7936.

### How to test this PR?

Check these places in the UI.

- [x] Tests are covering the bug fix or the new feature
