### PR TITLE
chore: use fileinput in build image form

### DIFF
--- a/packages/renderer/src/lib/image/BuildImageFromContainerfile.spec.ts
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfile.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -169,10 +169,6 @@ test('Select multiple platforms and expect pressing Build will do two buildImage
   expect(containerFilePath).toBeInTheDocument();
   await userEvent.type(containerFilePath, '/somepath/containerfile');
 
-  const buildFolder = screen.getByRole('textbox', { name: 'Build context directory' });
-  expect(buildFolder).toBeInTheDocument();
-  await userEvent.type(buildFolder, '/somepath');
-
   // Type in the image name a test value 'foobar'
   const containerImageName = screen.getByRole('textbox', { name: 'Image name' });
   expect(containerImageName).toBeInTheDocument();
@@ -251,10 +247,6 @@ test('Selecting one platform only calls buildImage once with the selected platfo
   const containerFilePath = screen.getByRole('textbox', { name: 'Containerfile path' });
   expect(containerFilePath).toBeInTheDocument();
   await userEvent.type(containerFilePath, '/somepath/containerfile');
-
-  const buildFolder = screen.getByRole('textbox', { name: 'Build context directory' });
-  expect(buildFolder).toBeInTheDocument();
-  await userEvent.type(buildFolder, '/somepath');
 
   const imageName = screen.getByRole('textbox', { name: 'Image name' });
   expect(imageName).toBeInTheDocument();

--- a/packages/renderer/src/lib/image/BuildImageFromContainerfile.svelte
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfile.svelte
@@ -43,12 +43,6 @@ let buildIDs = [];
 
 const containerFileDialogOptions: OpenDialogOptions = {
   title: 'Select Containerfile to build',
-  filters: [
-    {
-      extensions: ['containerfile', 'dockerfile'],
-      name: 'Containerfile',
-    },
-  ],
 };
 const contextDialogOptions: OpenDialogOptions = { title: 'Select Root Context', selectors: ['openDirectory'] };
 
@@ -318,7 +312,7 @@ async function abortBuild() {
         name="containerBuildContextDirectory"
         id="containerBuildContextDirectory"
         bind:value="{containerBuildContextDirectory}"
-        placeholder="Folder to build in"
+        placeholder="Directory to build in"
         options="{contextDialogOptions}"
         class="w-full" />
     </div>


### PR DESCRIPTION
### What does this PR do?

Just some tech debt, use the FileInput component in the build image form.

### Screenshot / video of UI

Before:

<img width="595" alt="Screenshot 2024-07-03 at 4 22 27 PM" src="https://github.com/containers/podman-desktop/assets/19958075/b3a3aecb-6d9d-4ace-858d-e4a90f27ec3a">

After:

<img width="595" alt="Screenshot 2024-07-03 at 4 22 40 PM" src="https://github.com/containers/podman-desktop/assets/19958075/455e3073-368e-404a-b12f-6195d4ba4cfc">

### What issues does this PR fix or reference?

Part of #7938.

### How to test this PR?

Build an image.

- [x] Tests are covering the bug fix or the new feature