### PR TITLE
fix(compose-extension): pre-existing system-wide installation 

### DIFF
--- a/extensions/compose/src/cli-run.ts
+++ b/extensions/compose/src/cli-run.ts
@@ -29,6 +29,19 @@ export interface RunOptions {
 
 const localBinDir = '/usr/local/bin';
 
+export function getSystemBinaryPath(binaryName: string): string {
+  switch (process.platform) {
+    case 'win32':
+      return path.join(os.homedir(), 'AppData', 'Local', 'Microsoft', 'WindowsApps', `${binaryName}.exe`);
+    case 'darwin':
+      return path.join(localBinDir, binaryName);
+    case 'linux':
+      return path.join(localBinDir, binaryName);
+    default:
+      throw new Error(`unsupported platform: ${process.platform}.`);
+  }
+}
+
 // Takes a binary path (e.g. /tmp/docker-compose) and installs it to the system. Renames it based on binaryName
 export async function installBinaryToSystem(binaryPath: string, binaryName: string): Promise<void> {
   const system = process.platform;
@@ -45,19 +58,16 @@ export async function installBinaryToSystem(binaryPath: string, binaryName: stri
 
   // Create the appropriate destination path (Windows uses AppData/Local, Linux and Mac use /usr/local/bin)
   // and the appropriate command to move the binary to the destination path
-  let destinationPath: string;
+  const destinationPath: string = getSystemBinaryPath(binaryName);
   let args: string[] = [];
   let command: string | undefined;
   if (system === 'win32') {
-    destinationPath = path.join(os.homedir(), 'AppData', 'Local', 'Microsoft', 'WindowsApps', `${binaryName}.exe`);
     command = 'copy';
     args = [`"${binaryPath}"`, `"${destinationPath}"`];
   } else if (system === 'darwin') {
-    destinationPath = path.join(localBinDir, binaryName);
     command = 'exec';
     args = ['cp', binaryPath, destinationPath];
   } else if (system === 'linux') {
-    destinationPath = path.join(localBinDir, binaryName);
     command = '/bin/sh';
     args = ['-c', `cp ${binaryPath} ${destinationPath}`];
   }

--- a/extensions/compose/src/cli-run.ts
+++ b/extensions/compose/src/cli-run.ts
@@ -22,17 +22,19 @@ import * as path from 'node:path';
 
 import * as extensionApi from '@podman-desktop/api';
 
-export interface RunOptions {
-  env?: NodeJS.ProcessEnv;
-  logger?: extensionApi.Logger;
-}
-
 const localBinDir = '/usr/local/bin';
 
 export function getSystemBinaryPath(binaryName: string): string {
   switch (process.platform) {
     case 'win32':
-      return path.join(os.homedir(), 'AppData', 'Local', 'Microsoft', 'WindowsApps', `${binaryName}.exe`);
+      return path.join(
+        os.homedir(),
+        'AppData',
+        'Local',
+        'Microsoft',
+        'WindowsApps',
+        binaryName.endsWith('.exe') ? binaryName : `${binaryName}.exe`,
+      );
     case 'darwin':
       return path.join(localBinDir, binaryName);
     case 'linux':

--- a/extensions/compose/src/cli-run.ts
+++ b/extensions/compose/src/cli-run.ts
@@ -36,7 +36,6 @@ export function getSystemBinaryPath(binaryName: string): string {
         binaryName.endsWith('.exe') ? binaryName : `${binaryName}.exe`,
       );
     case 'darwin':
-      return path.join(localBinDir, binaryName);
     case 'linux':
       return path.join(localBinDir, binaryName);
     default:

--- a/extensions/compose/src/detect.spec.ts
+++ b/extensions/compose/src/detect.spec.ts
@@ -151,7 +151,7 @@ describe('Check getDockerComposePath uses proper tooling by platform', () => {
     );
   });
 
-  test('linux should uses which', async () => {
+  test('linux should use which', async () => {
     (extensionApi.env.isLinux as boolean) = true;
     (extensionApi.env.isWindows as boolean) = false;
     (extensionApi.env.isMac as boolean) = false;
@@ -160,7 +160,7 @@ describe('Check getDockerComposePath uses proper tooling by platform', () => {
     expect(extensionApi.process.exec).toHaveBeenCalledWith('which', ['docker-compose']);
   });
 
-  test('mac should uses which', async () => {
+  test('mac should use which', async () => {
     (extensionApi.env.isMac as boolean) = true;
     (extensionApi.env.isWindows as boolean) = false;
     (extensionApi.env.isLinux as boolean) = false;
@@ -169,7 +169,7 @@ describe('Check getDockerComposePath uses proper tooling by platform', () => {
     expect(extensionApi.process.exec).toHaveBeenCalledWith('which', ['docker-compose']);
   });
 
-  test('windows should uses which', async () => {
+  test('windows should use which', async () => {
     (extensionApi.env.isWindows as boolean) = true;
     (extensionApi.env.isMac as boolean) = false;
     (extensionApi.env.isLinux as boolean) = false;

--- a/extensions/compose/src/detect.spec.ts
+++ b/extensions/compose/src/detect.spec.ts
@@ -50,6 +50,11 @@ vi.mock('@podman-desktop/api', async () => {
     process: {
       exec: vi.fn(),
     },
+    env: {
+      isLinux: false,
+      isWindows: false,
+      isMac: false,
+    },
   };
 });
 
@@ -133,6 +138,72 @@ describe('Check storage path', async () => {
 
     const result = await detect.getStoragePath();
     expect(result).toBe(path.resolve('/', 'storage-path', 'bin', 'docker-compose'));
+  });
+});
+
+describe('Check getDockerComposePath uses proper tooling by platform', () => {
+  beforeEach(() => {
+    vi.mocked(extensionApi.process.exec).mockImplementation(
+      () =>
+        new Promise<extensionApi.RunResult>(resolve => {
+          resolve({ exitCode: 0, stdout: 'hello-world' } as extensionApi.RunError);
+        }),
+    );
+  });
+
+  test('linux should uses which', async () => {
+    (extensionApi.env.isLinux as boolean) = true;
+    (extensionApi.env.isWindows as boolean) = false;
+    (extensionApi.env.isMac as boolean) = false;
+
+    await detect.getDockerComposePath('docker-compose');
+    expect(extensionApi.process.exec).toHaveBeenCalledWith('which', ['docker-compose']);
+  });
+
+  test('mac should uses which', async () => {
+    (extensionApi.env.isMac as boolean) = true;
+    (extensionApi.env.isWindows as boolean) = false;
+    (extensionApi.env.isLinux as boolean) = false;
+
+    await detect.getDockerComposePath('docker-compose');
+    expect(extensionApi.process.exec).toHaveBeenCalledWith('which', ['docker-compose']);
+  });
+
+  test('windows should uses which', async () => {
+    (extensionApi.env.isWindows as boolean) = true;
+    (extensionApi.env.isMac as boolean) = false;
+    (extensionApi.env.isLinux as boolean) = false;
+
+    await detect.getDockerComposePath('docker-compose');
+    expect(extensionApi.process.exec).toHaveBeenCalledWith('where.exe', ['docker-compose']);
+  });
+});
+
+describe('parseVersion', () => {
+  test('missing content', async () => {
+    expect(() => {
+      detect['parseVersion']('{}');
+    }).toThrowError('malformed version output');
+  });
+
+  test('invalid version type', async () => {
+    expect(() => {
+      detect['parseVersion'](
+        JSON.stringify({
+          version: true,
+        }),
+      );
+    }).toThrowError('malformed version output');
+  });
+
+  test('valid version', async () => {
+    expect(
+      detect['parseVersion'](
+        JSON.stringify({
+          version: 'potatoes',
+        }),
+      ),
+    ).toBe('potatoes');
   });
 });
 

--- a/extensions/compose/src/detect.ts
+++ b/extensions/compose/src/detect.ts
@@ -89,7 +89,7 @@ export class Detect {
     };
   }
 
-  private async getDockerComposePath(executable: string): Promise<string> {
+  async getDockerComposePath(executable: string): Promise<string> {
     // grab full path for Linux and mac
     if (extensionApi.env.isLinux || extensionApi.env.isMac) {
       try {

--- a/extensions/compose/src/extension.spec.ts
+++ b/extensions/compose/src/extension.spec.ts
@@ -1,0 +1,241 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { CliTool, Logger } from '@podman-desktop/api';
+import * as extensionApi from '@podman-desktop/api';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { installBinaryToSystem } from './cli-run';
+import type { ComposeGithubReleaseArtifactMetadata } from './compose-github-releases';
+import { Detect } from './detect';
+import { ComposeDownload } from './download';
+import { activate } from './extension';
+
+vi.mock('@podman-desktop/api', async () => {
+  return {
+    process: {
+      exec: vi.fn(),
+    },
+    env: {
+      isLinux: false,
+      isWindows: false,
+      isMac: false,
+      createTelemetryLogger: vi.fn(),
+    },
+    configuration: {
+      onDidChangeConfiguration: vi.fn(),
+      getConfiguration: (): extensionApi.Configuration =>
+        ({
+          update: vi.fn(),
+          get: vi.fn(),
+          has: vi.fn(),
+        }) as unknown as extensionApi.Configuration,
+    },
+    context: {
+      setValue: vi.fn(),
+    },
+    commands: {
+      registerCommand: vi.fn(),
+    },
+    provider: {
+      createProvider: vi.fn(),
+    },
+    cli: {
+      createCliTool: vi.fn(),
+    },
+  };
+});
+
+vi.mock('node:fs', () => ({
+  existsSync: vi.fn(),
+}));
+
+const detectMock = {
+  checkSystemWideDockerCompose: vi.fn(),
+  getDockerComposeBinaryInfo: vi.fn(),
+  getStoragePath: vi.fn(),
+} as unknown as Detect;
+
+const composeDownloadMock = {
+  getLatestVersionAsset: vi.fn(),
+  download: vi.fn(),
+} as unknown as ComposeDownload;
+
+const cliToolMock = {
+  registerUpdate: vi.fn(),
+  updateVersion: vi.fn(),
+} as unknown as CliTool;
+
+vi.mock('./cli-run', () => ({
+  installBinaryToSystem: vi.fn(),
+}));
+
+vi.mock('./detect', () => ({
+  Detect: vi.fn(),
+}));
+
+vi.mock('./download', () => ({
+  ComposeDownload: vi.fn(),
+}));
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.mocked(Detect).mockReturnValue(detectMock);
+  vi.mocked(ComposeDownload).mockReturnValue(composeDownloadMock);
+  vi.mocked(extensionApi.cli.createCliTool).mockReturnValue(cliToolMock);
+});
+
+const extensionContextMock = {
+  storagePath: 'dummy-storage-path',
+  subscriptions: [],
+} as unknown as extensionApi.ExtensionContext;
+
+test('commands registered', async () => {
+  await activate(extensionContextMock);
+
+  [
+    'compose.onboarding.checkDownloadedCommand',
+    'compose.onboarding.downloadCommand',
+    'compose.onboarding.promptUserForVersion',
+    'compose.onboarding.installSystemWideCommand',
+  ].forEach(command => {
+    expect(extensionApi.commands.registerCommand).toHaveBeenCalledWith(command, expect.any(Function));
+  });
+});
+
+test('provider registered', async () => {
+  await activate(extensionContextMock);
+
+  expect(extensionApi.provider.createProvider).toHaveBeenCalledWith({
+    emptyConnectionMarkdownDescription: expect.any(String),
+    name: 'Compose',
+    id: 'Compose',
+    status: 'unknown',
+    images: {
+      icon: './icon.png',
+    },
+  });
+});
+
+/**
+ * (1) The postActivate will call createCliTool
+ * (2) if a new version is available, registerUpdate will be called
+ *
+ * This function return the object provided to the registerUpdate method
+ */
+async function getCliToolUpdate(updatable: boolean): Promise<extensionApi.CliToolUpdate> {
+  vi.mocked(detectMock.checkSystemWideDockerCompose).mockResolvedValue(true);
+  vi.mocked(detectMock.getDockerComposeBinaryInfo).mockResolvedValue({
+    version: 'v0.0.0',
+    path: 'system-wide-path',
+    updatable: updatable,
+  });
+  vi.mocked(composeDownloadMock.getLatestVersionAsset).mockResolvedValue({
+    tag: 'v1.0.0',
+  } as unknown as ComposeGithubReleaseArtifactMetadata);
+
+  let update: extensionApi.CliToolUpdate | undefined = undefined;
+  vi.mocked(cliToolMock.registerUpdate).mockImplementation(mUpdate => {
+    update = mUpdate;
+    return { dispose: vi.fn() };
+  });
+
+  await activate(extensionContextMock);
+
+  await vi.waitFor(() => {
+    expect(update).toBeDefined();
+  });
+
+  if (!update) throw new Error('undefined update');
+  return update;
+}
+
+describe('postActivate', () => {
+  test('createCliTool already installed system wide', async () => {
+    vi.mocked(detectMock.checkSystemWideDockerCompose).mockResolvedValue(true);
+    vi.mocked(detectMock.getDockerComposeBinaryInfo).mockResolvedValue({
+      version: 'v0.0.0',
+      path: 'system-wide-path',
+      updatable: false, // not updatable as unknown location
+    });
+    vi.mocked(composeDownloadMock.getLatestVersionAsset).mockResolvedValue({
+      tag: 'v0.0.0',
+    } as unknown as ComposeGithubReleaseArtifactMetadata);
+
+    await activate(extensionContextMock);
+
+    await vi.waitFor(() => {
+      expect(extensionApi.cli.createCliTool).toHaveBeenCalledWith({
+        name: 'docker-compose',
+        displayName: 'Compose',
+        markdownDescription: expect.any(String),
+        images: expect.anything(),
+        version: '0.0.0',
+        path: 'system-wide-path',
+      });
+    });
+
+    expect(cliToolMock.registerUpdate).not.toHaveBeenCalled();
+  });
+
+  test('new version docker-compose available', async () => {
+    vi.mocked(detectMock.checkSystemWideDockerCompose).mockResolvedValue(true);
+    vi.mocked(detectMock.getDockerComposeBinaryInfo).mockResolvedValue({
+      version: 'v0.0.0',
+      path: 'system-wide-path',
+      updatable: false, // not updatable as unknown location
+    });
+    vi.mocked(composeDownloadMock.getLatestVersionAsset).mockResolvedValue({
+      tag: 'v1.0.0',
+    } as unknown as ComposeGithubReleaseArtifactMetadata);
+
+    await activate(extensionContextMock);
+
+    await vi.waitFor(() => {
+      expect(extensionApi.cli.createCliTool).toHaveBeenCalled();
+      expect(cliToolMock.registerUpdate).toHaveBeenCalledWith({
+        version: '1.0.0',
+        doUpdate: expect.any(Function),
+      });
+    });
+  });
+
+  test('update not updatable version should throw an error', async () => {
+    const update: extensionApi.CliToolUpdate = await getCliToolUpdate(false);
+
+    await expect(() => update?.doUpdate({} as unknown as Logger)).rejects.toThrowError(
+      'Cannot update system-wide-path version 0.0.0 to 1.0.0 as it was not installed by podman-desktop',
+    );
+  });
+
+  test('update updatable version should update version', async () => {
+    vi.mocked(detectMock.getStoragePath).mockResolvedValue('extension-storage-path');
+    const update: extensionApi.CliToolUpdate = await getCliToolUpdate(true);
+
+    await update.doUpdate({} as unknown as Logger);
+
+    expect(composeDownloadMock.download).toHaveBeenCalledWith({
+      tag: 'v1.0.0',
+    });
+    expect(detectMock.getStoragePath).toHaveBeenCalled();
+    expect(installBinaryToSystem).toHaveBeenCalledWith('extension-storage-path', 'docker-compose');
+    expect(cliToolMock.updateVersion).toHaveBeenCalledWith({
+      version: '1.0.0',
+    });
+  });
+});

--- a/extensions/compose/src/extension.ts
+++ b/extensions/compose/src/extension.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/extensions/compose/src/extension.ts
+++ b/extensions/compose/src/extension.ts
@@ -266,7 +266,9 @@ async function postActivate(composeDownload: ComposeDownload, detect: Detect): P
       version: lastReleaseVersion,
       doUpdate: async _logger => {
         if (!binaryInfo?.updatable) {
-          throw new Error('cannot be updated as not managed by podman desktop.');
+          throw new Error(
+            `Cannot update ${binaryInfo?.path} version ${currentVersion} to ${lastReleaseVersion} as it was not installed by podman-desktop`,
+          );
         }
 
         // download, install system wide and update cli version


### PR DESCRIPTION
### What does this PR do?

Improve the `docker-compose` detection, by searching existing system wide install first.

### Screenshot / video of UI

**Trying to update a version in a path unknown to podman-desktop**

> Expected error raised 

https://github.com/containers/podman-desktop/assets/42176370/b8f55352-22bf-4c6e-a97d-1eb0790d82d8

**Trying to update a version in a path known by podman-desktop**

> Expected everything go smoothly 

https://github.com/containers/podman-desktop/assets/42176370/b69f22c2-47e4-490a-9543-637d88a47c80

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop/issues/5250

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Added `extension.spec.ts` for extension activation / post activation
