### PR TITLE
fix: get proxy settings to initialize ImageRegistry

### DIFF
--- a/packages/main/src/plugin/image-registry.ts
+++ b/packages/main/src/plugin/image-registry.ts
@@ -80,6 +80,7 @@ export class ImageRegistry {
     });
 
     this.proxyEnabled = this.proxy.isEnabled();
+    this.proxySettings = this.proxy.proxy;
   }
 
   extractRegistryServerFromImage(imageName: string): string | undefined {

--- a/packages/main/src/plugin/image-registry.ts
+++ b/packages/main/src/plugin/image-registry.ts
@@ -80,7 +80,9 @@ export class ImageRegistry {
     });
 
     this.proxyEnabled = this.proxy.isEnabled();
-    this.proxySettings = this.proxy.proxy;
+    if (this.proxyEnabled) {
+      this.proxySettings = this.proxy.proxy;
+    }
   }
 
   extractRegistryServerFromImage(imageName: string): string | undefined {


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Get proxy settings when initializing the ImageRegistry instance.

### What issues does this PR fix or reference?

Fixes #7940 

### How to test this PR?

See steps to reproduce in #7940 

- [x] Tests are covering the bug fix or the new feature
