### PR TITLE
chore(test): destructuring method params

### DIFF
--- a/tests/playwright/src/model/pages/images-page.ts
+++ b/tests/playwright/src/model/pages/images-page.ts
@@ -49,13 +49,10 @@ export class ImagesPage extends MainPage {
   }
 
   async openPullImage(): Promise<PullImagePage> {
-    await waitWhile(
-      () => this.noContainerEngine(),
-      50000,
-      1000,
-      true,
-      'No Container Engine is available, cannot pull an image',
-    );
+    await waitWhile(() => this.noContainerEngine(), {
+      timeout: 50000,
+      message: 'No Container Engine is available, cannot pull an image',
+    });
     await this.pullImageButton.click();
     return new PullImagePage(this.page);
   }
@@ -129,12 +126,12 @@ export class ImagesPage extends MainPage {
   }
 
   async waitForImageExists(name: string, timeout = 5000): Promise<boolean> {
-    await waitUntil(async () => await this.imageExists(name), timeout, 500);
+    await waitUntil(async () => await this.imageExists(name), { timeout: timeout });
     return true;
   }
 
   async waitForImageDelete(name: string, timeout = 5000): Promise<boolean> {
-    await waitWhile(async () => await this.imageExists(name), timeout, 500);
+    await waitWhile(async () => await this.imageExists(name), { timeout: timeout });
     return true;
   }
 

--- a/tests/playwright/src/model/pages/registries-page.ts
+++ b/tests/playwright/src/model/pages/registries-page.ts
@@ -105,10 +105,7 @@ export class RegistriesPage extends SettingsPage {
         async function loginIsEnabled() {
           return await loginButton.isEnabled();
         },
-        5000,
-        1000,
-        true,
-        'Login Button not enabled in time',
+        { message: 'Login Button not enabled in time' },
       );
       await loginButton.click({ timeout: 3000 });
     } catch (err) {

--- a/tests/playwright/src/model/pages/run-image-page.ts
+++ b/tests/playwright/src/model/pages/run-image-page.ts
@@ -113,9 +113,7 @@ export class RunImagePage extends BasePage {
       async () => {
         return await this.name.isVisible();
       },
-      3000,
-      900,
-      false,
+      { sendError: false },
     );
 
     const errorCount = await this.errorAlert.count();

--- a/tests/playwright/src/model/pages/volumes-page.ts
+++ b/tests/playwright/src/model/pages/volumes-page.ts
@@ -85,12 +85,12 @@ export class VolumesPage extends MainPage {
   }
 
   async waitForVolumeExists(name: string): Promise<boolean> {
-    await waitUntil(async () => await this.volumeExists(name), 3000, 900);
+    await waitUntil(async () => await this.volumeExists(name));
     return true;
   }
 
   async waitForVolumeDelete(name: string): Promise<boolean> {
-    await waitWhile(async () => await this.volumeExists(name), 3000, 900);
+    await waitWhile(async () => await this.volumeExists(name));
     return true;
   }
 }

--- a/tests/playwright/src/specs/pod-smoke.spec.ts
+++ b/tests/playwright/src/specs/pod-smoke.spec.ts
@@ -57,13 +57,10 @@ beforeAll(async () => {
   await waitForPodmanMachineStartup(page);
   // wait giving a time to podman desktop to load up
   const images = await new NavigationBar(page).openImages();
-  await waitWhile(
-    async () => await images.pageIsEmpty(),
-    5000,
-    1000,
-    false,
-    'Images page is empty, there are no images present',
-  );
+  await waitWhile(async () => await images.pageIsEmpty(), {
+    sendError: false,
+    message: 'Images page is empty, there are no images present',
+  });
   await deletePod(page, podToRun);
   await deleteContainer(page, backendContainer);
   await deleteContainer(page, frontendContainer);
@@ -128,7 +125,7 @@ describe.skipIf(process.env.GITHUB_ACTIONS && process.env.RUNNER_OS === 'Linux')
       await waitUntil(async () => {
         backendPort = await containerDetails.getContainerPort();
         return backendPort.includes('6379');
-      }, 5000);
+      });
       images = await navigationBar.openImages();
       imageDetails = await images.openImageDetails(frontendImage);
       runImage = await imageDetails.openRunImage();
@@ -163,7 +160,7 @@ describe.skipIf(process.env.GITHUB_ACTIONS && process.env.RUNNER_OS === 'Linux')
     test('Checking pod details', async () => {
       const navigationBar = new NavigationBar(page);
       const pods = await navigationBar.openPods();
-      await waitUntil(async () => await pods.podExists(podToRun), 5000, 500);
+      await playExpect.poll(async () => await pods.podExists(podToRun), { timeout: 10000 }).toBeTruthy();
       const podDetails = await pods.openPodDetails(podToRun);
       await playExpect(podDetails.heading).toBeVisible();
       await playExpect(podDetails.heading).toContainText(podToRun);

--- a/tests/playwright/src/utility/operations.ts
+++ b/tests/playwright/src/utility/operations.ts
@@ -86,9 +86,7 @@ export async function deleteImage(page: Page, name: string): Promise<void> {
           const result = await images.getImageRowByName(name);
           return !!result;
         },
-        10000,
-        1000,
-        false,
+        { timeout: 10000, sendError: false },
       );
     } catch (error) {
       if (!(error as Error).message.includes('Page is empty')) {
@@ -103,7 +101,7 @@ export async function deleteRegistry(page: Page, name: string, failIfNotExist = 
   const settingsBar = await navigationBar.openSettings();
   const registryPage = await settingsBar.openTabPage(RegistriesPage);
   const registryRecord = await registryPage.getRegistryRowByName(name);
-  await waitUntil(() => registryRecord.isVisible(), 3000, 500, failIfNotExist);
+  await waitUntil(() => registryRecord.isVisible(), { sendError: failIfNotExist });
   if (await registryRecord.isVisible()) {
     // it might be that the record exist but there are no credentials -> it is default registry and it is empty
     // or if there is a kebab memu available
@@ -130,9 +128,12 @@ export async function deletePod(page: Page, name: string): Promise<void> {
     // wait for pod to disappear
     try {
       console.log('Waiting for pod to get deleted ...');
-      await waitWhile(async () => {
-        return !!(await pods.getPodRowByName(name));
-      }, 20000);
+      await waitWhile(
+        async () => {
+          return !!(await pods.getPodRowByName(name));
+        },
+        { timeout: 20000 },
+      );
     } catch (error) {
       if (!(error as Error).message.includes('Page is empty')) {
         throw Error(`Error waiting for pod '${name}' to get removed, ${error}`);
@@ -172,9 +173,7 @@ export async function deletePodmanMachine(page: Page, machineVisibleName: string
     async () => {
       return await resourcesPodmanConnections.podmanMachineElement.isVisible();
     },
-    15_000,
-    1000,
-    false,
+    { timeout: 15000 },
   );
   if (await resourcesPodmanConnections.podmanMachineElement.isVisible()) {
     await playExpect(resourcesPodmanConnections.machineConnectionActions).toBeVisible({ timeout: 3000 });
@@ -185,7 +184,7 @@ export async function deletePodmanMachine(page: Page, machineVisibleName: string
       await playExpect(resourcesPodmanConnections.machineConnectionStatus).toHaveText('OFF', { timeout: 30_000 });
     }
     await playExpect(resourcesPodmanConnections.machineDeleteButton).toBeVisible({ timeout: 3000 });
-    await waitWhile(() => resourcesPodmanConnections.machineDeleteButton.isDisabled(), 10_000, 1000, true);
+    await waitWhile(() => resourcesPodmanConnections.machineDeleteButton.isDisabled(), { timeout: 10000 });
     await resourcesPodmanConnections.machineDeleteButton.click();
     await playExpect(resourcesPodmanConnections.podmanMachineElement).toBeHidden({ timeout: 30_000 });
   } else {

--- a/tests/playwright/src/utility/wait.ts
+++ b/tests/playwright/src/utility/wait.ts
@@ -60,10 +60,12 @@ export async function wait(
  */
 export async function waitUntil(
   waitFunction: () => Promise<boolean>,
-  timeout = 3000,
-  diff = 500,
-  sendError = true,
-  message = '',
+  {
+    timeout = 5000,
+    diff = 500,
+    sendError = true,
+    message = '',
+  }: { timeout?: number; diff?: number; sendError?: boolean; message?: string } = {},
 ): Promise<void> {
   await wait(waitFunction, true, timeout, diff, sendError, message);
 }
@@ -79,10 +81,12 @@ export async function waitUntil(
  */
 export async function waitWhile(
   waitFunction: () => Promise<boolean>,
-  timeout = 3000,
-  diff = 500,
-  sendError = true,
-  message = '',
+  {
+    timeout = 5000,
+    diff = 500,
+    sendError = true,
+    message = '',
+  }: { timeout?: number; diff?: number; sendError?: boolean; message?: string } = {},
 ): Promise<void> {
   await wait(waitFunction, false, timeout, diff, sendError, message);
 }


### PR DESCRIPTION
### What does this PR do?
Refactoring waiter methods in e2e test framework to use destructed params  

### What issues does this PR fix or reference?
https://github.com/containers/podman-desktop/issues/7946