### PR TITLE
chore: adjust search and tab bar width

### DIFF
--- a/packages/ui/src/lib/layouts/NavPage.svelte
+++ b/packages/ui/src/lib/layouts/NavPage.svelte
@@ -24,7 +24,7 @@ export let searchEnabled = true;
     </div>
     {#if searchEnabled}
       <div class="flex flex-row pb-4" role="region" aria-label="search">
-        <div class="pl-5 lg:w-[35rem] w-[22rem]">
+        <div class="pl-5 w-72">
           <SearchInput bind:searchTerm="{searchTerm}" title="{title}" />
         </div>
         <div class="flex flex-1 px-5" role="group" aria-label="bottomAdditionalActions">
@@ -38,7 +38,7 @@ export let searchEnabled = true;
     {/if}
 
     {#if $$slots.tabs}
-      <div class="flex flex-row px-2 mb-2 border-b border-[var(--pd-content-divider)]">
+      <div class="flex flex-row mx-5 px-2 mb-2 border-b border-[var(--pd-content-divider)]">
         <slot name="tabs" />
       </div>
     {/if}

--- a/packages/ui/src/lib/table/Table.svelte
+++ b/packages/ui/src/lib/table/Table.svelte
@@ -180,11 +180,11 @@ function toggleChildren(name: string | undefined): void {
 }
 </script>
 
-<div class="w-full" class:hidden="{data.length === 0}" role="table">
+<div class="w-full mx-5" class:hidden="{data.length === 0}" role="table">
   <!-- Table header -->
   <div role="rowgroup">
     <div
-      class="grid grid-table gap-x-0.5 mx-5 h-7 sticky top-0 bg-[var(--pd-content-bg)] text-xs text-[var(--pd-table-header-text)] font-bold uppercase z-[2]"
+      class="grid grid-table gap-x-0.5 h-7 sticky top-0 bg-[var(--pd-content-bg)] text-xs text-[var(--pd-table-header-text)] font-bold uppercase z-[2]"
       role="row">
       <div class="whitespace-nowrap justify-self-start" role="columnheader"></div>
       {#if row.info.selectable}
@@ -227,7 +227,7 @@ function toggleChildren(name: string | undefined): void {
   <!-- Table body -->
   <div role="rowgroup">
     {#each data as object (object)}
-      <div class="mx-5 min-h-[48px] h-fit bg-[var(--pd-content-card-bg)] rounded-lg mb-2" role="row">
+      <div class="min-h-[48px] h-fit bg-[var(--pd-content-card-bg)] rounded-lg mb-2" role="row">
         <div
           class="grid grid-table gap-x-0.5 min-h-[48px] hover:bg-[var(--pd-content-card-hover-bg)]"
           class:rounded-t-lg="{object.name &&


### PR DESCRIPTION
### What does this PR do?

Reduces the width of the search bar to a fixed w-72 (18rem) width, as before it was switching between 22 and 34rem depending on the width of the window.

Adds a margin to the tab bar so that it is the same width as the table.

While I was doing this I noticed that the table is full width, but every row has mx-5. Moved this to the top level so that it is consistent, and obvious at the top level. IMHO table shouldn't have a built-in margin at all, but that's an issue for another day (#7952).

### Screenshot / video of UI

Before:

<img width="752" alt="Screenshot 2024-07-04 at 10 37 34 AM" src="https://github.com/containers/podman-desktop/assets/19958075/ae426046-f072-4e90-8a39-5a669615150c">

After:

<img width="752" alt="Screenshot 2024-07-04 at 8 45 57 AM" src="https://github.com/containers/podman-desktop/assets/19958075/06ef97ff-a5de-49d9-9255-5f79faef8bfe">


### What issues does this PR fix or reference?

Fixes #7949.
Fixes #7950.

### How to test this PR?

Go to Containers or Pods page and look at search input width/tabs.