### PR TITLE
chore: add counter property in the navigation item

### DIFF
--- a/packages/renderer/src/lib/ui/NavItem.spec.ts
+++ b/packages/renderer/src/lib/ui/NavItem.spec.ts
@@ -138,3 +138,31 @@ test('Expect that having an onClick handler overrides href and works', async () 
 
   expect(clicked).toBe(true);
 });
+
+test('Expect that counter is rendered', async () => {
+  const tooltip = 'Foo';
+  const href = '/href';
+  let counter = 0;
+
+  const result = render(NavItem, { counter, tooltip, href, meta: { url: '/test' } });
+
+  const element = screen.getByLabelText(tooltip);
+  expect(element).toBeInTheDocument();
+  expect(element).toHaveAttribute('href', '/href');
+
+  // unmount
+  result.unmount();
+
+  // ok now update the counter
+  counter = 4;
+
+  // check tooltip is working if counter is updated
+  render(NavItem, { counter, tooltip, href, meta: { url: '/test' } });
+
+  // get div with label tooltip
+  const element2 = screen.getByLabelText('Foo');
+  expect(element2).toBeInTheDocument();
+
+  // get text of the element
+  expect(element2.textContent).toContain('Foo (4)');
+});

--- a/packages/renderer/src/lib/ui/NavItem.svelte
+++ b/packages/renderer/src/lib/ui/NavItem.svelte
@@ -13,6 +13,7 @@ export let tooltip: string;
 export let ariaLabel: string | undefined = undefined;
 export let meta: TinroRouteMeta;
 export let onClick: MouseEventHandler<HTMLAnchorElement> | undefined = undefined;
+export let counter: number | undefined = undefined;
 
 let inSection: boolean = false;
 let uri = encodeURI(href);
@@ -20,6 +21,8 @@ let selected: boolean;
 $: selected = meta.url === uri || (uri !== '/' && meta.url.startsWith(uri));
 
 const navItems: Writable<number> = getContext('nav-items');
+
+$: tooltipText = counter ? `${tooltip} (${counter})` : tooltip;
 
 onMount(() => {
   inSection = navItems !== undefined;
@@ -49,7 +52,7 @@ onDestroy(() => {
     class:hover:text-[color:var(--pd-global-nav-icon-hover)]="{!selected || inSection}"
     class:hover:bg-[var(--pd-global-nav-icon-hover-bg)]="{!selected || inSection}"
     class:hover:border-[var(--pd-global-nav-icon-hover-bg)]="{!selected && !inSection}">
-    <Tooltip right tip="{tooltip}">
+    <Tooltip right tip="{tooltipText}">
       <slot />
     </Tooltip>
   </div>


### PR DESCRIPTION
### What does this PR do?
when working on the AppNavigation, we have a lot of if (length > 0) then tooltip = else tooltip =
I think it'll be better to handle that in the component itself rather than in the caller.

so, if set, it'll update the tooltip accordingly
it'll avoid to have children handling the update of the tooltip if there is a counter

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
