### PR TITLE
chore(test): better handle for podman machine wait

### DIFF
--- a/tests/playwright/src/model/pages/pull-image-page.ts
+++ b/tests/playwright/src/model/pages/pull-image-page.ts
@@ -16,6 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 import type { Locator, Page } from '@playwright/test';
+import { expect as playExpect } from '@playwright/test';
 
 import { BasePage } from './base-page';
 import { ImagesPage } from './images-page';
@@ -40,16 +41,14 @@ export class PullImagePage extends BasePage {
     this.imageNameInput = page.getByLabel('imageName');
   }
 
-  async pullImage(imageName: string, tag = '', timeout = 50000): Promise<ImagesPage> {
+  async pullImage(imageName: string, tag = '', timeout = 60000): Promise<ImagesPage> {
     const fullImageName = `${imageName}${tag.length === 0 ? '' : ':' + tag}`;
     await this.imageNameInput.fill(fullImageName);
-    if (await this.pullImageButton.isEnabled()) {
-      await this.pullImageButton.click();
-    } else {
-      throw Error(`Pull image button is not enabled, pulling of '${fullImageName}' failed, verify image name`);
-    }
+    await playExpect(this.pullImageButton).toBeEnabled();
+    await this.pullImageButton.click();
+
     const doneButton = this.page.getByRole('button', { name: 'Done' });
-    await doneButton.waitFor({ state: 'visible', timeout: timeout });
+    await playExpect(doneButton).toBeEnabled({ timeout: timeout });
     await doneButton.click();
     return new ImagesPage(this.page);
   }

--- a/tests/playwright/src/specs/container-smoke.spec.ts
+++ b/tests/playwright/src/specs/container-smoke.spec.ts
@@ -18,7 +18,7 @@
 
 import type { Page } from '@playwright/test';
 import { expect as playExpect } from '@playwright/test';
-import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest';
+import { afterAll, beforeAll, beforeEach, describe, test } from 'vitest';
 
 import { ContainerState } from '../model/core/states';
 import type { ContainerInteractiveParams } from '../model/core/types';
@@ -84,16 +84,14 @@ afterAll(async () => {
 }, 90000);
 
 describe('Verification of container creation workflow', async () => {
-  test(`Pulling of '${imageToPull}:${imageTag}' image`, async () => {
+  test(`Pulling of '${imageToPull}:${imageTag}' image`, { retry: 2, timeout: 90000 }, async () => {
     const navigationBar = new NavigationBar(page);
     let images = await navigationBar.openImages();
     const pullImagePage = await images.openPullImage();
-    images = await pullImagePage.pullImage(imageToPull, imageTag, 45000);
+    images = await pullImagePage.pullImage(imageToPull, imageTag);
 
-    const exists = await images.waitForImageExists(imageToPull);
-    expect(exists, `${imageToPull} image is not present in the list of images`).toBeTruthy();
-    await pdRunner.screenshot('containers-pull-image.png');
-  }, 60000);
+    await playExpect.poll(async () => await images.waitForImageExists(imageToPull)).toBeTruthy();
+  });
 
   test(`Start a container '${containerToRun}'`, async () => {
     const navigationBar = new NavigationBar(page);

--- a/tests/playwright/src/utility/wait.ts
+++ b/tests/playwright/src/utility/wait.ts
@@ -121,9 +121,12 @@ export async function executeWithTimeout(
   });
 }
 
-export async function waitForPodmanMachineStartup(page: Page, timeoutOut = 10000): Promise<void> {
+export async function waitForPodmanMachineStartup(page: Page, timeoutOut = 15000): Promise<void> {
   const dashboardPage = await new NavigationBar(page).openDashboard();
   await playExpect(dashboardPage.heading).toBeVisible();
-  await playExpect(dashboardPage.podmanStatusLabel).toBeVisible({ timeout: timeoutOut });
+  await waitUntil(async () => await dashboardPage.podmanStatusLabel.isVisible(), {
+    timeout: timeoutOut,
+    sendError: false,
+  });
   await playExpect(dashboardPage.podmanStatusLabel).toHaveText('RUNNING', { timeout: timeoutOut });
 }


### PR DESCRIPTION
### What does this PR do?
Increases robustness of test framework waiting on podman machine initial startup

### What issues does this PR fix or reference?
https://github.com/containers/podman-desktop/issues/7958
