### PR TITLE
test: added start/stop/delete/prune multiple containers from the container list test cases

### DIFF
--- a/tests/playwright/src/model/pages/containers-page.ts
+++ b/tests/playwright/src/model/pages/containers-page.ts
@@ -55,7 +55,7 @@ export class ContainersPage extends MainPage {
       throw Error(`Container: '${containerName}' does not exist`);
     }
     const containerRowStartButton = containerRow.getByRole('button', { name: 'Start Container' });
-    await playExpect(containerRowStartButton).toBeVisible();
+    await playExpect(containerRowStartButton).toBeEnabled();
     await containerRowStartButton.click();
     return this;
   }
@@ -66,7 +66,7 @@ export class ContainersPage extends MainPage {
       throw Error(`Container: '${containerName}' does not exist`);
     }
     const containerRowStopButton = containerRow.getByRole('button', { name: 'Stop Container' });
-    await playExpect(containerRowStopButton).toBeVisible();
+    await playExpect(containerRowStopButton).toBeEnabled();
     await containerRowStopButton.click();
 
     return this;

--- a/tests/playwright/src/model/pages/containers-page.ts
+++ b/tests/playwright/src/model/pages/containers-page.ts
@@ -49,17 +49,26 @@ export class ContainersPage extends MainPage {
     return new ContainerDetailsPage(this.page, name);
   }
 
-  async startContainerFromContainersList(containerRow: Locator): Promise<ContainersPage> {
-    const containerRowStopButton = containerRow.getByRole('button', { name: 'Start Container' });
-    await playExpect(containerRowStopButton).toBeVisible();
-    await containerRowStopButton.click();
+  async startContainer(containerName: string): Promise<ContainersPage> {
+    const containerRow = await this.getContainerRowByName(containerName);
+    if (containerRow === undefined) {
+      throw Error(`Container: '${containerName}' does not exist`);
+    }
+    const containerRowStartButton = containerRow.getByRole('button', { name: 'Start Container' });
+    await playExpect(containerRowStartButton).toBeVisible();
+    await containerRowStartButton.click();
     return this;
   }
 
-  async stopContainerFromContainersList(containerRow: Locator): Promise<ContainersPage> {
+  async stopContainer(containerName: string): Promise<ContainersPage> {
+    const containerRow = await this.getContainerRowByName(containerName);
+    if (containerRow === undefined) {
+      throw Error(`Container: '${containerName}' does not exist`);
+    }
     const containerRowStopButton = containerRow.getByRole('button', { name: 'Stop Container' });
     await playExpect(containerRowStopButton).toBeVisible();
     await containerRowStopButton.click();
+
     return this;
   }
 

--- a/tests/playwright/src/model/pages/containers-page.ts
+++ b/tests/playwright/src/model/pages/containers-page.ts
@@ -49,7 +49,21 @@ export class ContainersPage extends MainPage {
     return new ContainerDetailsPage(this.page, name);
   }
 
-  async stopContainer(container: string): Promise<ContainerDetailsPage> {
+  async startContainerFromContainersList(containerRow: Locator): Promise<ContainersPage> {
+    const containerRowStopButton = containerRow.getByRole('button', { name: 'Start Container' });
+    await playExpect(containerRowStopButton).toBeVisible();
+    await containerRowStopButton.click();
+    return this;
+  }
+
+  async stopContainerFromContainersList(containerRow: Locator): Promise<ContainersPage> {
+    const containerRowStopButton = containerRow.getByRole('button', { name: 'Stop Container' });
+    await playExpect(containerRowStopButton).toBeVisible();
+    await containerRowStopButton.click();
+    return this;
+  }
+
+  async stopContainerFromDetails(container: string): Promise<ContainerDetailsPage> {
     const containerDetailsPage = await this.openContainersDetails(container);
     await playExpect(containerDetailsPage.heading).toBeVisible();
     await playExpect(containerDetailsPage.heading).toContainText(container);

--- a/tests/playwright/src/model/pages/containers-page.ts
+++ b/tests/playwright/src/model/pages/containers-page.ts
@@ -68,8 +68,20 @@ export class ContainersPage extends MainPage {
     const containerRowStopButton = containerRow.getByRole('button', { name: 'Stop Container' });
     await playExpect(containerRowStopButton).toBeVisible();
     await containerRowStopButton.click();
-
     return this;
+  }
+
+  async deleteContainer(containerName: string): Promise<ContainersPage> {
+    const containerRow = await this.getContainerRowByName(containerName);
+    if (containerRow === undefined) {
+      throw Error(`Container: '${containerName}' does not exist`);
+    }
+    const containerRowDeleteButton = containerRow.getByRole('button', { name: 'Delete Container' });
+    await playExpect(containerRowDeleteButton).toBeVisible();
+    await playExpect(containerRowDeleteButton).toBeEnabled();
+    await containerRowDeleteButton.click();
+    await handleConfirmationDialog(this.page);
+    return new ContainersPage(this.page);
   }
 
   async stopContainerFromDetails(container: string): Promise<ContainerDetailsPage> {

--- a/tests/playwright/src/specs/container-smoke.spec.ts
+++ b/tests/playwright/src/specs/container-smoke.spec.ts
@@ -154,7 +154,7 @@ describe('Verification of container creation workflow', async () => {
     await playExpect(startButton).toBeVisible();
   });
 
-  test(`Start a container from the Containers list`, async () => {
+  test(`Start a container from the Containers page`, async () => {
     const navigationBar = new NavigationBar(page);
     const containers = await navigationBar.openContainers();
     const containersDetails = await containers.openContainersDetails(containerToRun);
@@ -164,12 +164,7 @@ describe('Verification of container creation workflow', async () => {
     await navigationBar.openContainers();
     await playExpect.poll(async () => await containers.containerExists(containerToRun)).toBeTruthy();
 
-    const containerRow = await containers.getContainerRowByName(containerToRun);
-    if (containerRow === undefined) {
-      throw Error(`Container: '${containerToRun}' does not exist`);
-    }
-
-    await containers.startContainerFromContainersList(containerRow);
+    await containers.startContainer(containerToRun);
 
     await containers.openContainersDetails(containerToRun);
     await playExpect
@@ -178,7 +173,7 @@ describe('Verification of container creation workflow', async () => {
     await playExpect(await containersDetails.getStateLocator()).toHaveText(ContainerState.Running.toLowerCase());
   });
 
-  test(`Stop a container from the Containers list`, async () => {
+  test(`Stop a container from the Containers page`, async () => {
     const navigationBar = new NavigationBar(page);
     const containers = await navigationBar.openContainers();
     const containersDetails = await containers.openContainersDetails(containerToRun);
@@ -188,12 +183,7 @@ describe('Verification of container creation workflow', async () => {
     await navigationBar.openContainers();
     await playExpect.poll(async () => await containers.containerExists(containerToRun)).toBeTruthy();
 
-    const containerRow = await containers.getContainerRowByName(containerToRun);
-    if (containerRow === undefined) {
-      throw Error(`Container: '${containerToRun}' does not exist`);
-    }
-
-    await containers.stopContainerFromContainersList(containerRow);
+    await containers.stopContainer(containerToRun);
 
     await containers.openContainersDetails(containerToRun);
     await playExpect

--- a/tests/playwright/src/specs/container-smoke.spec.ts
+++ b/tests/playwright/src/specs/container-smoke.spec.ts
@@ -161,18 +161,15 @@ describe('Verification of container creation workflow', async () => {
     await playExpect(containersDetails.heading).toBeVisible();
     await playExpect(containersDetails.heading).toContainText(containerToRun);
     // test state of container in summary tab
-    await pdRunner.screenshot('containers-container-details-start-container.png');
-    const containerState = await containersDetails.getState();
-    playExpect(containerState).toContain(ContainerState.Exited.toLowerCase());
-
     await navigationBar.openContainers();
+    await playExpect.poll(async () => await containers.containerExists(containerToRun)).toBeTruthy();
+
     const containerRow = await containers.getContainerRowByName(containerToRun);
     if (containerRow === undefined) {
       throw Error(`Container: '${containerToRun}' does not exist`);
     }
-    const containerRowStartButton = containerRow.getByRole('button', { name: 'Start Container' });
-    await playExpect(containerRowStartButton).toBeVisible();
-    await containerRowStartButton.click();
+
+    await containers.startContainerFromContainersList(containerRow);
 
     await containers.openContainersDetails(containerToRun);
     await playExpect
@@ -188,18 +185,15 @@ describe('Verification of container creation workflow', async () => {
     await playExpect(containersDetails.heading).toBeVisible();
     await playExpect(containersDetails.heading).toContainText(containerToRun);
     // test state of container in summary tab
-    await pdRunner.screenshot('containers-container-details-stop-container.png');
-    const containerState = await containersDetails.getState();
-    playExpect(containerState).toContain(ContainerState.Running.toLowerCase());
-
     await navigationBar.openContainers();
+    await playExpect.poll(async () => await containers.containerExists(containerToRun)).toBeTruthy();
+
     const containerRow = await containers.getContainerRowByName(containerToRun);
     if (containerRow === undefined) {
       throw Error(`Container: '${containerToRun}' does not exist`);
     }
-    const containerRowStopButton = containerRow.getByRole('button', { name: 'Stop Container' });
-    await playExpect(containerRowStopButton).toBeVisible();
-    await containerRowStopButton.click();
+
+    await containers.stopContainerFromContainersList(containerRow);
 
     await containers.openContainersDetails(containerToRun);
     await playExpect
@@ -234,7 +228,7 @@ describe('Verification of container creation workflow', async () => {
 
     for (const container of containerList) {
       let containersPage = new ContainersPage(page);
-      const containersDetails = await containersPage.stopContainer(container);
+      const containersDetails = await containersPage.stopContainerFromDetails(container);
       await playExpect(await containersDetails.getStateLocator()).toHaveText(ContainerState.Exited.toLowerCase(), {
         timeout: 20000,
       });


### PR DESCRIPTION
### What does this PR do?
This PR extends the container-smoke.spec.ts test suite to include the test cases of starting, stopping, deleting a container from the containers list, and pruning multiple containers on Podman Desktop.

### What issues does this PR fix or reference?
[https://github.com/containers/podman-desktop/issues/7577](https://github.com/containers/podman-desktop/issues/7577)

### How to test this PR?
Run the smoke tests with yarn test:e2e:smoke
