### PR TITLE
chore: provide default text color

### DIFF
--- a/packages/main/src/plugin/color-registry.ts
+++ b/packages/main/src/plugin/color-registry.ts
@@ -228,6 +228,7 @@ export class ColorRegistry {
   }
 
   protected initColors(): void {
+    this.initDefaults();
     this.initNotificationDot();
     this.initGlobalNav();
     this.initSecondaryNav();
@@ -252,6 +253,16 @@ export class ColorRegistry {
     this.initStatusBar();
     this.initOnboarding();
     this.initStates();
+  }
+
+  protected initDefaults(): void {
+    const def = 'default-';
+
+    // Global default colors
+    this.registerColor(`${def}text`, {
+      dark: colorPalette.white,
+      light: colorPalette.charcoal[900],
+    });
   }
 
   protected initNotificationDot(): void {


### PR DESCRIPTION
### What does this PR do?

We have bg colors defined for every type of page, and several vars for headers and other text colors in various forms. However, there is no 'default text color' defined to catch any general text that isn't quite one of these cases or isn't explicitly styled. As a result, the index.html of Podman Desktop and extensions like AI Lab and Bootc still contain a 'text-white'.

We're not quite ready to change the default for Podman Desktop itself (see PR #7729), but the missing variable stops extensions from doing it too. Breaking this off into a separate PR to define the variable now, and we'll rebase #7729 to use it in PD later.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

First part of #7724.

### How to test this PR?

N/A, just defines a color variable.