### PR TITLE
chore: use fileinput in play kube

### DIFF
--- a/packages/renderer/src/lib/kube/KubePlayYAML.spec.ts
+++ b/packages/renderer/src/lib/kube/KubePlayYAML.spec.ts
@@ -128,7 +128,7 @@ test('error: When pressing the Play button, expect us to show the errors to the 
   const fileInput = screen.getByRole('textbox', { name: 'Kubernetes YAML file' });
   expect(fileInput).toBeInTheDocument();
 
-  const browseButton = screen.getByRole('button', { name: 'Browse ...' });
+  const browseButton = screen.getByLabelText('browse');
   expect(browseButton).toBeInTheDocument();
   await userEvent.click(browseButton);
 
@@ -160,7 +160,7 @@ test('expect done button is there at the end', async () => {
   const fileInput = screen.getByRole('textbox', { name: 'Kubernetes YAML file' });
   expect(fileInput).toBeInTheDocument();
 
-  const browseButton = screen.getByRole('button', { name: 'Browse ...' });
+  const browseButton = screen.getByLabelText('browse');
   expect(browseButton).toBeInTheDocument();
   await userEvent.click(browseButton);
 


### PR DESCRIPTION
### What does this PR do?

Tech debt, use the FileInput component in the Play Kubernetes Yaml form.

### Screenshot / video of UI

<img width="518" alt="Screenshot 2024-07-05 at 10 51 33 AM" src="https://github.com/containers/podman-desktop/assets/19958075/0997ed4f-1cdd-4df4-a71e-269faeefccf5">

### What issues does this PR fix or reference?

Part of #7938.

### How to test this PR?

Go to Pods and click the Play button.

- [x] Tests are covering the bug fix or the new feature