### PR TITLE
fix: podman machine switch may lose API connection

### DIFF
--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -2327,6 +2327,7 @@ describe('createVolume', () => {
     const providerRegistry: ProviderRegistry = {
       onBeforeDidUpdateContainerConnection: vi.fn(),
       onDidUpdateContainerConnection: vi.fn(),
+      onAfterDidUpdateContainerConnection: vi.fn(),
     } as unknown as ProviderRegistry;
 
     containerRegistry.registerContainerConnection(podmanProvider, containerProviderConnection, providerRegistry);
@@ -2375,6 +2376,7 @@ describe('deleteVolume', () => {
     const providerRegistry: ProviderRegistry = {
       onBeforeDidUpdateContainerConnection: vi.fn(),
       onDidUpdateContainerConnection: vi.fn(),
+      onAfterDidUpdateContainerConnection: vi.fn(),
     } as unknown as ProviderRegistry;
 
     containerRegistry.registerContainerConnection(podmanProvider, containerProviderConnection, providerRegistry);
@@ -5077,4 +5079,146 @@ test('saveImage canceled during image saving on filesystem', async () => {
   const tmpdir = os.tmpdir();
   const savePromise = containerRegistry.saveImage('podman1', 'an-image', path.join(tmpdir, 'image-to-save'), token);
   await expect(savePromise).rejects.toThrowError('The operation was aborted');
+});
+
+describe('provider update', () => {
+  test('stopped update should reset connection API', async () => {
+    const statusMock = vi.fn();
+
+    const internalContainerProvider: InternalContainerProvider = {
+      name: 'podman',
+      id: 'podman1',
+      api: undefined,
+      libpodApi: undefined,
+      connection: {
+        type: 'podman',
+        name: 'podman',
+        endpoint: {
+          socketPath: '/endpoint1.sock',
+        },
+        status: statusMock,
+      },
+    };
+    // set provider
+    containerRegistry.addInternalProvider('podman.podman', internalContainerProvider);
+
+    const containerProviderConnection: podmanDesktopAPI.ContainerProviderConnection = {
+      name: 'podman',
+      type: 'podman',
+      endpoint: {
+        socketPath: '/endpoint1.sock',
+      },
+      status: statusMock,
+    } as unknown as podmanDesktopAPI.ContainerProviderConnection;
+
+    const podmanProvider = {
+      name: 'podman',
+      id: 'podman',
+    } as unknown as podmanDesktopAPI.Provider;
+
+    const onBeforeUpdateListeners: ((event: podmanDesktopAPI.UpdateContainerConnectionEvent) => void)[] = [];
+
+    const providerRegistry: ProviderRegistry = {
+      onBeforeDidUpdateContainerConnection: (
+        listener: (event: podmanDesktopAPI.UpdateContainerConnectionEvent) => void,
+      ) => onBeforeUpdateListeners.push(listener),
+      onAfterDidUpdateContainerConnection: vi.fn(),
+    } as unknown as ProviderRegistry;
+
+    // default to started
+    statusMock.mockReturnValue('started');
+
+    containerRegistry.registerContainerConnection(podmanProvider, containerProviderConnection, providerRegistry);
+
+    // when the provider is started, we should get the provider
+    const internal = containerRegistry.getMatchingPodmanEngine('podman.podman');
+    expect(internal.api).toBeDefined();
+    expect(internal.libpodApi).toBeDefined();
+
+    // mock the status to stopped
+    statusMock.mockReturnValue('stopped');
+    const event: podmanDesktopAPI.UpdateContainerConnectionEvent = {
+      providerId: 'podman',
+      connection: containerProviderConnection,
+      status: 'stopped',
+    };
+
+    // send the stopped event
+    onBeforeUpdateListeners.forEach(listener => listener(event));
+
+    // ensure the provider is not running
+    expect(() => containerRegistry.getMatchingPodmanEngine('podman.podman')).toThrowError(
+      'no running provider for the matching engine',
+    );
+  });
+
+  test('started update should setup connection API ', async () => {
+    const statusMock = vi.fn();
+
+    const internalContainerProvider: InternalContainerProvider = {
+      name: 'podman',
+      id: 'podman1',
+      api: undefined,
+      libpodApi: undefined,
+      connection: {
+        type: 'podman',
+        name: 'podman',
+        endpoint: {
+          socketPath: '/endpoint1.sock',
+        },
+        status: statusMock,
+      },
+    };
+    // set provider
+    containerRegistry.addInternalProvider('podman.podman', internalContainerProvider);
+
+    const containerProviderConnection: podmanDesktopAPI.ContainerProviderConnection = {
+      name: 'podman',
+      type: 'podman',
+      endpoint: {
+        socketPath: '/endpoint1.sock',
+      },
+      status: statusMock,
+    } as unknown as podmanDesktopAPI.ContainerProviderConnection;
+
+    const podmanProvider = {
+      name: 'podman',
+      id: 'podman',
+    } as unknown as podmanDesktopAPI.Provider;
+
+    const onAfterListener: ((event: podmanDesktopAPI.UpdateContainerConnectionEvent) => void)[] = [];
+
+    const providerRegistry: ProviderRegistry = {
+      onBeforeDidUpdateContainerConnection: vi.fn(),
+      onAfterDidUpdateContainerConnection: (
+        listener: (event: podmanDesktopAPI.UpdateContainerConnectionEvent) => void,
+      ) => onAfterListener.push(listener),
+    } as unknown as ProviderRegistry;
+
+    // default to stopped
+    statusMock.mockReturnValue('stopped');
+
+    containerRegistry.registerContainerConnection(podmanProvider, containerProviderConnection, providerRegistry);
+
+    // ensure the provider is not running
+    expect(() => containerRegistry.getMatchingPodmanEngine('podman.podman')).toThrowError(
+      'no running provider for the matching engine',
+    );
+
+    // mock the new status to started
+    statusMock.mockReturnValue('started');
+    const event: podmanDesktopAPI.UpdateContainerConnectionEvent = {
+      providerId: 'podman',
+      connection: containerProviderConnection,
+      status: 'started',
+    };
+
+    // send the event stating that the provider has started
+    onAfterListener.forEach(listener => listener(event));
+
+    // let's get the podman engine, it should be running, and have defined api&libpodApi
+    const internal = containerRegistry.getMatchingPodmanEngine('podman.podman');
+    expect(internal.api).toBeDefined();
+    expect(internal.libpodApi).toBeDefined();
+  });
 });

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -336,7 +336,7 @@ export class ContainerProviderRegistry {
       if (
         event.providerId === provider.id && // ensure provider id is matching
         event.connection.name === containerProviderConnection.name && // ensure connection is matching
-        event.status === 'started' && // when status is tarted
+        event.status === 'started' && // when status is started
         !internalProvider.api &&
         !internalProvider.libpodApi // api & libpodApi are undefined we need to setup
       ) {


### PR DESCRIPTION
### What does this PR do?

The problem was coming from a racing issue (most probable). 

Let's break it down. We have a `setupConnectionAPI` which is responsible for updating the `api` and `libpodApi` of the `InternalContainerProvider`.

https://github.com/containers/podman-desktop/blob/6b600670b6342613c47c9d5cda27fc9ce486aebd/packages/main/src/plugin/container-registry.ts#L258

However, this method has a special check:

https://github.com/containers/podman-desktop/blob/6b600670b6342613c47c9d5cda27fc9ce486aebd/packages/main/src/plugin/container-registry.ts#L263-L266

If the `ContainerProviderConnection` has a `stopped` status it will not create the `Dockerode` object.

This method is called from several places, the most important is the one in the `setInterval`

https://github.com/containers/podman-desktop/blob/6b600670b6342613c47c9d5cda27fc9ce486aebd/packages/main/src/plugin/container-registry.ts#L359-L363

This code is executed every 2 seconds, the problem: We might have the `containerProviderConnection` still with a `stopped` status when `setupConnectionAPI` is called. And after it is called, the `previousStatus = newStatus` and will never be executed again!

This is tricky, as we could fix this in different way. The best I found was to have some interest on the update provided by the `providerRegistry`.

We are adding a listener on their `onBeforeDidUpdateContainerConnection` event. However, on this event, since it BEFORE, the status _may be_ `stopped`, therefore the call to setupConnectionAPI is also useless.

The fix was to add a specific listener to the `onAfterDidUpdateContainerConnection` when the status would be `started` to call the `setupConnectionAPI`.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop/issues/6982 and https://github.com/containers/podman-desktop/issues/6455

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
