### PR TITLE
fix: prevent submit event propagation when clicking on number input buttons

### DIFF
--- a/packages/renderer/src/lib/ui/NumberInput.svelte
+++ b/packages/renderer/src/lib/ui/NumberInput.svelte
@@ -41,8 +41,8 @@ function onDecrement(e: MouseEvent) {
 }
 
 function onIncrement(e: MouseEvent) {
-  value = Number(value) + 1;
   e.preventDefault();
+  value = Number(value) + 1;
 }
 </script>
 

--- a/packages/renderer/src/lib/ui/NumberInput.svelte
+++ b/packages/renderer/src/lib/ui/NumberInput.svelte
@@ -35,12 +35,14 @@ function onKeyPress(event: any) {
   }
 }
 
-function onDecrement() {
+function onDecrement(e: MouseEvent) {
   value = Number(value) - 1;
+  e.preventDefault();
 }
 
-function onIncrement() {
+function onIncrement(e: MouseEvent) {
   value = Number(value) + 1;
+  e.preventDefault();
 }
 </script>
 

--- a/packages/renderer/src/lib/ui/NumberInput.svelte
+++ b/packages/renderer/src/lib/ui/NumberInput.svelte
@@ -36,8 +36,8 @@ function onKeyPress(event: any) {
 }
 
 function onDecrement(e: MouseEvent) {
-  value = Number(value) - 1;
   e.preventDefault();
+  value = Number(value) - 1;
 }
 
 function onIncrement(e: MouseEvent) {


### PR DESCRIPTION
### What does this PR do?

This fixes https://github.com/containers/podman-desktop/issues/7660 . It just adds a preventDefault to prevent the default submit behavior of a button that submit the form when changing the port

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

it resolves #7660 

### How to test this PR?

1. go to the create kind cluster page
2. click on the +/- buttons to change the ports. 
3. the ports value should change without any other behavior.

- [ ] Tests are covering the bug fix or the new feature
