### PR TITLE
chore: add setup instructions to kind extension readme

### DIFF
--- a/extensions/kind/README.md
+++ b/extensions/kind/README.md
@@ -1,8 +1,10 @@
-# kind extension
+# Kind extension
 
-This extension adds the support of https://kind.sigs.k8s.io/
+This extension adds the support of [https://kind.sigs.k8s.io/](Kind).
 
-By using this extension, it is possible to create kubernetes clusters
-running on top of the container engine.
+By using this extension, it is possible to create Kubernetes clusters
+running on top of the container engine. Note that installing `kind` binary
+is a prerequisite to using the Kind extension.
 
-You can initialize a kind cluster using Settings/Resources.
+You can initialize a kind cluster using the Resources section in Settings
+once the `kind` binary is installed on your machine.

--- a/extensions/kind/README.md
+++ b/extensions/kind/README.md
@@ -3,8 +3,8 @@
 This extension adds the support of [https://kind.sigs.k8s.io/](Kind).
 
 By using this extension, it is possible to create Kubernetes clusters
-running on top of the container engine. Note that installing `kind` binary
-is a prerequisite to using the Kind extension.
+running on top of the container engine. Note that installing the `kind`
+binary is a prerequisite to using the Kind extension.
 
-You can initialize a kind cluster using the Resources section in Settings
+You can initialize a Kind cluster using the Resources section in Settings
 once the `kind` binary is installed on your machine.


### PR DESCRIPTION
### What does this PR do?

The current UX for Kind is unintuitive. It took me a while to find the warning icon in the bottom left of the Podman Desktop UI instructing me to install Kind. Had it been in the extension details I'd have found it immediately.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Not a fix, but a minor improvement to the UX issue #6358 

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

Using the `compile` entries in the package.json created `.app` files under dist, but they all crashed "unexpectedly" when launched. Code signing issue maybe?