### PR TITLE
fix: remove afterUpdate in PreferencesRenderingItem

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItem.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItem.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-import { afterUpdate } from 'svelte';
-
 import { getInitialValue } from '/@/lib/preferences/Util';
 
 import type { IConfigurationPropertyRecordedSchema } from '../../../../main/src/plugin/configuration-registry';
@@ -16,10 +14,6 @@ let recordUI: {
   markdownDescription?: string;
   original: IConfigurationPropertyRecordedSchema;
 };
-
-afterUpdate(() => {
-  update();
-});
 
 // add space from camel case and upper case on the first letter
 function startCase(str: string): string {


### PR DESCRIPTION
### What does this PR do?

it removes the afterUpdate hook which seems to be superfluos at this point. There is already the reactive clause that trigger the update function when the component changes. By some testing it seems to work fine and it also fixes the problem of phantom resets https://github.com/containers/podman-desktop/issues/7142 .

During the debug i saw that the afterUpdate was triggered like 500 times when one field was updated without any actual reason. 

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

it resolves #7142 

### How to test this PR?

1. if you ever faced any phantom reset, just try to reproduce it. In my case i saw it quite frequently when switching from dark to light mode.

- [ ] Tests are covering the bug fix or the new feature
