### PR TITLE
fix(website): windows build and redirects

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -43,10 +43,6 @@ const config = {
       {
         redirects: [
           {
-            to: '/api',
-            from: '/docs/extensions/api',
-          },
-          {
             to: '/downloads/windows',
             from: '/downloads/Windows',
           },
@@ -69,17 +65,12 @@ const config = {
           {
             to: '/docs/installation/windows-install',
             from: [
-              '/docs/Installation/windows-install',
               '/docs/installation/windows-install/installing-podman-desktop-silently-with-the-windows-installer',
-              '/docs/Installation/windows-install/installing-podman-desktop-silently-with-the-windows-installer',
               '/docs/installation/windows-install/installing-podman-desktop-with-chocolatey',
-              '/docs/Installation/windows-install/installing-podman-desktop-with-chocolatey',
               '/docs/installation/windows-install/installing-podman-desktop-with-scoop',
-              '/docs/Installation/windows-install/installing-podman-desktop-with-scoop',
               '/docs/installation/windows-install/installing-podman-desktop-with-winget',
-              '/docs/Installation/windows-install/installing-podman-desktop-with-winget',
-              '/docs/Installation/windows-install/installing-podman-with-openshift-local',
-              '/docs/Installation/windows-install/installing-podman-with-podman-desktop',
+              '/docs/installation/windows-install/installing-podman-with-openshift-local',
+              '/docs/installation/windows-install/installing-podman-with-podman-desktop',
               '/docs/onboarding-for-containers/installing-podman-with-openshift-local-on-windows',
               '/docs/onboarding-for-containers/installing-podman',
               '/docs/onboarding/containers/installing-podman-with-openshift-local-on-windows',
@@ -90,24 +81,10 @@ const config = {
             ],
           },
           {
-            to: '/docs/installation/macos-install',
-            from: '/docs/Installation/macos-install',
-          },
-          {
-            to: '/docs/installation/linux-install',
-            from: '/docs/Installation/linux-install',
-          },
-          {
-            to: '/docs/installation/linux-install/installing-podman-desktop-from-a-flatpak-bundle',
-            from: '/docs/Installation/linux-install/installing-podman-desktop-from-a-flatpak-bundle',
-          },
-          {
             to: '/docs/proxy',
             from: [
               '/docs/installation/windows-install/installing-podman-desktop-and-podman-in-a-restricted-environment',
-              '/docs/Installation/windows-install/installing-podman-desktop-and-podman-in-a-restricted-environment',
               '/docs/installation/linux-install/installing-podman-desktop-from-a-compressed-tar-file',
-              '/docs/Installation/linux-install/installing-podman-desktop-from-a-compressed-tar-file',
               '/docs/proxy/using-a-proxy-in-your-containers',
               '/docs/proxy/using-a-proxy-on-linux',
               '/docs/proxy/using-a-proxy-requiring-a-custom-ca',


### PR DESCRIPTION
### What does this PR do?

Remove the duplicates links with difference of upper/lower-case as it is not needed nor recommended[^1].

We do not need it as we already have automatic redirection to always lower case with github pages CDN.

This PR also remove the warning, as we were trying to overwrite path, that cannot be overwritten (E.g. `/api`)

[^1]: https://github.com/facebook/docusaurus/issues/10232

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop/issues/7991

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- Pipeline should be ✅ 
