### PR TITLE
fix(github-action): pr check website missing storybook path

### DIFF
--- a/.github/workflows/pr-check-website.yaml
+++ b/.github/workflows/pr-check-website.yaml
@@ -23,6 +23,7 @@ on:
       - 'package.json'
       - 'yarn.lock'
       - 'website/**'
+      - 'storybook/**'
       - 'packages/extension-api/src/**'
 
 jobs:


### PR DESCRIPTION
### What does this PR do?

The `Build website on pull request` should be triggered when changes to `Storybook` are made

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
