### PR TITLE
chore: use dialog component for remaining dialogs

### DIFF
--- a/packages/renderer/src/lib/container/ContainerList.svelte
+++ b/packages/renderer/src/lib/container/ContainerList.svelte
@@ -3,7 +3,6 @@ import { faPlusCircle, faTrash } from '@fortawesome/free-solid-svg-icons';
 import {
   Button,
   FilteredEmptyScreen,
-  Modal,
   NavPage,
   Table,
   TableColumn,
@@ -28,6 +27,7 @@ import { providerInfos } from '../../stores/providers';
 import { findMatchInLeaves } from '../../stores/search-util';
 import { viewsContributions } from '../../stores/views';
 import type { ContextUI } from '../context/context';
+import Dialog from '../dialogs/Dialog.svelte';
 import type { EngineInfoUI } from '../engine/EngineInfoUI';
 import Prune from '../engine/Prune.svelte';
 import NoContainerEngineEmptyScreen from '../image/NoContainerEngineEmptyScreen.svelte';
@@ -274,13 +274,6 @@ onDestroy(() => {
   }
 });
 
-function keydownChoice(e: KeyboardEvent): void {
-  e.stopPropagation();
-  if (e.key === 'Escape') {
-    toggleCreateContainer();
-  }
-}
-
 function toggleCreateContainer(): void {
   openChoiceModal = !openChoiceModal;
 }
@@ -440,34 +433,21 @@ $: containersAndGroups = containerGroups.map(group =>
 </NavPage>
 
 {#if openChoiceModal}
-  <Modal
+  <Dialog
+    title="Create a new container"
     on:close="{() => {
       openChoiceModal = false;
     }}">
-    <div
-      role="presentation"
-      class="inline-block w-full overflow-hidden text-left transition-all"
-      on:keydown="{keydownChoice}">
-      <div
-        class="flex items-center justify-between text-[var(--pd-modal-header-text)] bg-[var(--pd-modal-header-bg)] px-5 py-4 border-b-2 border-[var(--pd-modal-header-divider)]">
-        <h1 class="text-xl font-bold">Create a new container</h1>
-
-        <button class="hover:text-[var(--pd-modal-text-hover)] px-2 py-1" on:click="{() => toggleCreateContainer()}">
-          <i class="fas fa-times" aria-hidden="true"></i>
-        </button>
-      </div>
-      <div class="p-5 h-full flex flex-col justify-items-center text-[var(--pd-modal-text)]">
-        <span class="pb-3">Choose the following:</span>
-        <ul class="list-disc ml-8 space-y-2">
-          <li>Create a container from a Containerfile</li>
-          <li>Create a container from an existing image stored in the local registry</li>
-        </ul>
-
-        <div class="pt-5 grid grid-cols-2 gap-10 place-content-center w-full">
-          <Button type="primary" on:click="{() => fromDockerfile()}">Containerfile or Dockerfile</Button>
-          <Button type="secondary" on:click="{() => fromExistingImage()}">Existing image</Button>
-        </div>
-      </div>
+    <div slot="content" class="h-full flex flex-col justify-items-center text-[var(--pd-modal-text)]">
+      <span class="pb-3">Choose the following:</span>
+      <ul class="list-disc ml-8 space-y-2">
+        <li>Create a container from a Containerfile</li>
+        <li>Create a container from an existing image stored in the local registry</li>
+      </ul>
     </div>
-  </Modal>
+    <svelte:fragment slot="buttons">
+      <Button type="primary" on:click="{() => fromDockerfile()}">Containerfile or Dockerfile</Button>
+      <Button type="secondary" on:click="{() => fromExistingImage()}">Existing image</Button>
+    </svelte:fragment>
+  </Dialog>
 {/if}

--- a/packages/renderer/src/lib/extensions/InstallManuallyExtensionModal.svelte
+++ b/packages/renderer/src/lib/extensions/InstallManuallyExtensionModal.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
 import { faCloudDownload } from '@fortawesome/free-solid-svg-icons';
-import { Button, CloseButton, Input, Modal } from '@podman-desktop/ui-svelte';
+import { Button, Input } from '@podman-desktop/ui-svelte';
 import { onMount } from 'svelte';
+
+import Dialog from '../dialogs/Dialog.svelte';
 
 export let closeCallback: () => void;
 let imageName = '';
@@ -87,71 +89,63 @@ function handleKeydown(e: KeyboardEvent) {
 
 <svelte:window on:keydown="{handleKeydown}" />
 
-<Modal
-  name="Install Extension from OCI image"
+<Dialog
+  title="Install Custom Extension"
   on:close="{() => {
     closeCallback();
   }}">
-  <div class="modal flex flex-col place-self-center">
-    <div
-      class="flex items-center justify-between px-6 py-5 space-x-2 text-[var(--pd-modal-header-text)] bg-[var(--pd-modal-header-bg)]">
-      <h1 class="grow text-lg font-bold capitalize">Install custom extension</h1>
-
-      <CloseButton on:click="{() => closeCallback()}" />
-    </div>
-    <div class="flex flex-col px-10 py-4 text-sm leading-5 space-y-5">
-      <div>
-        <label for="imageName" class="block text-sm pb-2 text-[var(--pd-modal-text)]">OCI Image:</label>
-        <div class="min-h-14">
-          {#if installInProgress || progressPercent !== 100}
-            <Input
-              bind:value="{imageName}"
-              name="imageName"
-              id="imageName"
-              placeholder="Enter OCI image name of the extension (e.g. quay.io/namespace/my-image)"
-              on:input="{event => validateImageName(event)}"
-              disabled="{installInProgress}"
-              error="{inputfieldError}"
-              aria-invalid="{inputfieldError !== ''}"
-              aria-label="{inputAriaLabel}"
-              required />
-          {:else}
-            <div class="text-[var(--pd-modal-text)]">{imageName} successfully installed.</div>
-          {/if}
-        </div>
-        <div class="w-full min-h-9 h-9 py-2">
-          {#if installInProgress}
-            <div class="flex grow">
-              <div class="w-full h-4 mb-4 rounded-md bg-gray-600 progress-bar overflow-hidden">
-                <div
-                  class="h-4 bg-purple-500 rounded-md"
-                  role="progressbar"
-                  aria-label="Installation progress"
-                  style="width: {progressPercent}%">
-                </div>
+  <div slot="content" class="flex flex-col text-sm leading-5 space-y-5">
+    <div>
+      <label for="imageName" class="block text-sm pb-2 text-[var(--pd-modal-text)]">OCI Image:</label>
+      <div class="min-h-14">
+        {#if installInProgress || progressPercent !== 100}
+          <Input
+            bind:value="{imageName}"
+            name="imageName"
+            id="imageName"
+            placeholder="Enter OCI image name of the extension (e.g. quay.io/namespace/my-image)"
+            on:input="{event => validateImageName(event)}"
+            disabled="{installInProgress}"
+            error="{inputfieldError}"
+            aria-invalid="{inputfieldError !== ''}"
+            aria-label="{inputAriaLabel}"
+            required />
+        {:else}
+          <div class="text-[var(--pd-modal-text)]">{imageName} successfully installed.</div>
+        {/if}
+      </div>
+      <div class="w-full min-h-9 h-9 py-2">
+        {#if installInProgress}
+          <div class="flex grow">
+            <div class="w-full h-4 mb-4 rounded-md bg-gray-600 progress-bar overflow-hidden">
+              <div
+                class="h-4 bg-purple-500 rounded-md"
+                role="progressbar"
+                aria-label="Installation progress"
+                style="width: {progressPercent}%">
               </div>
-              <div class="ml-2 w-3 text-xs text-purple-500">{progressPercent}%</div>
             </div>
-          {/if}
-        </div>
-        <div class="w-full grid grid-flow-col justify-items-center">
-          <Button
-            type="link"
-            on:click="{() => {
-              closeCallback();
-            }}">Cancel</Button>
-          {#if installInProgress || progressPercent !== 100}
-            <Button
-              icon="{faCloudDownload}"
-              disabled="{inputfieldError !== undefined}"
-              on:click="{() => installExtension()}"
-              inProgress="{installInProgress}">Install</Button>
-          {/if}
-          {#if !installInProgress && progressPercent === 100}
-            <Button on:click="{() => closeCallback()}">Done</Button>
-          {/if}
-        </div>
+            <div class="ml-2 w-3 text-xs text-purple-500">{progressPercent}%</div>
+          </div>
+        {/if}
       </div>
     </div>
   </div>
-</Modal>
+  <svelte:fragment slot="buttons">
+    <Button
+      type="link"
+      on:click="{() => {
+        closeCallback();
+      }}">Cancel</Button>
+    {#if installInProgress || progressPercent !== 100}
+      <Button
+        icon="{faCloudDownload}"
+        disabled="{inputfieldError !== undefined}"
+        on:click="{() => installExtension()}"
+        inProgress="{installInProgress}">Install</Button>
+    {/if}
+    {#if !installInProgress && progressPercent === 100}
+      <Button on:click="{() => closeCallback()}">Done</Button>
+    {/if}
+  </svelte:fragment>
+</Dialog>

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingPageStoreDetails.svelte
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingPageStoreDetails.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
 import { faRefresh, faTrash } from '@fortawesome/free-solid-svg-icons';
-import { Button, CloseButton, Modal } from '@podman-desktop/ui-svelte';
+import { Button } from '@podman-desktop/ui-svelte';
 import humanizeDuration from 'humanize-duration';
 import moment from 'moment';
 
 import type { EventStoreInfo } from '/@/stores/event-store';
+
+import Dialog from '../dialogs/Dialog.svelte';
 
 export let closeCallback: () => void;
 
@@ -21,86 +23,77 @@ async function fetch(): Promise<void> {
 }
 </script>
 
-<Modal name="Details of {eventStoreInfo.name}" on:close="{() => closeCallback()}">
-  <div class="inline-block w-full overflow-hidden text-left transition-all">
-    <div
-      class="flex items-center justify-between px-5 py-4 mb-4 text-[var(--pd-modal-header-text)] bg-[var(--pd-modal-header-bg)]">
-      <h1 class="text-md font-semibold">
-        <div class="flex flex-row items-center">
-          <svelte:component this="{eventStoreInfo.iconComponent}" size="20" />
-          <div class="mx-2">Details of {eventStoreInfo.name} store</div>
-        </div>
-      </h1>
-      <CloseButton on:click="{() => closeCallback()}" />
-    </div>
-    <div class="overflow-y-auto px-4 pb-4">
-      <div class="flex flex-col rounded-lg">
-        <div class="bg-[var(--pd-card-bg)] text-[var(--pd-card-text)] w-full p-4 mb-4">
-          <div class="pb-2 text-lg">Info:</div>
+<Dialog title="Details of {eventStoreInfo.name}" on:close="{() => closeCallback()}">
+  <svelte:component this="{eventStoreInfo.iconComponent}" slot="icon" size="20" />
 
-          <div class="mx-2 flex flex-row items-center">
-            Size: <div role="status" aria-label="size">{eventStoreInfo.size}</div>
-            <div class="mx-2">
-              <Button class="my-1" bind:inProgress="{fetchInProgress}" on:click="{() => fetch()}" icon="{faRefresh}"
-                >Refresh</Button>
-            </div>
+  <div slot="content" class="inline-block w-full overflow-hidden overflow-y-auto text-left transition-all">
+    <div class="flex flex-col rounded-lg">
+      <div class="bg-[var(--pd-card-bg)] text-[var(--pd-card-text)] w-full p-4 mb-4">
+        <div class="pb-2 text-lg">Info:</div>
+
+        <div class="mx-2 flex flex-row items-center">
+          Size: <div role="status" aria-label="size">{eventStoreInfo.size}</div>
+          <div class="mx-2">
+            <Button class="my-1" bind:inProgress="{fetchInProgress}" on:click="{() => fetch()}" icon="{faRefresh}"
+              >Refresh</Button>
           </div>
-        </div>
-
-        <!-- Display buffer events-->
-        <div class="pb-4">
-          <div class="bg-[var(--pd-card-bg)] text-[var(--pd-card-text)] w-full p-4 h-45">
-            <div class="pb-2 text-lg">
-              Updating events:
-              {#if eventStoreInfo.bufferEvents.length > 0}
-                <Button
-                  class="my-1"
-                  bind:inProgress="{fetchInProgress}"
-                  title="Clear events"
-                  on:click="{() => eventStoreInfo.clearEvents()}"
-                  icon="{faTrash}">Clear</Button>
-              {/if}
-            </div>
-            {#if eventStoreInfo.bufferEvents.length > 0}
-              {@const reverseOrderedBufferEvents = [...eventStoreInfo.bufferEvents].reverse()}
-
-              <ul class="h-32 overflow-auto list-disc list-inside text-xs" aria-label="buffer-events">
-                {#each reverseOrderedBufferEvents as bufferEvent}
-                  <li aria-label="{bufferEvent.name}">
-                    {#if bufferEvent.skipped}
-                      Skipped event
-                    {:else}
-                      Grab {bufferEvent.length} items from
-                    {/if}
-
-                    '{bufferEvent.name}' event
-                    {#if bufferEvent.args?.length > 0}
-                      ({bufferEvent.args})
-                    {/if}
-
-                    {humanizeDuration(moment().diff(bufferEvent.date), { round: true, largest: 1 })} ago.
-
-                    {#if bufferEvent.humanDuration}
-                      Took {bufferEvent.humanDuration}.
-                    {/if}
-
-                    {#if bufferEvent.skipped}
-                      (ignoring)
-                    {/if}
-                  </li>
-                {/each}
-              </ul>
-            {:else}
-              <div class="h-32 flex flex-row mx-auto text-xs text-gray-800 text-center">No buffer events</div>
-            {/if}
-          </div>
-        </div>
-
-        <div class="text-xs text-gray-800 mt-2 text-center">Track events that have updated the store</div>
-        <div class="flex flex-row justify-end w-full pt-2">
-          <Button aria-label="Cancel" class="mr-3" type="link" on:click="{() => closeCallback()}">Cancel</Button>
-          <Button aria-label="OK" on:click="{() => closeCallback()}">OK</Button>
         </div>
       </div>
+
+      <!-- Display buffer events-->
+      <div class="pb-4">
+        <div class="bg-[var(--pd-card-bg)] text-[var(--pd-card-text)] w-full p-4 h-45">
+          <div class="pb-2 text-lg">
+            Updating events:
+            {#if eventStoreInfo.bufferEvents.length > 0}
+              <Button
+                class="my-1"
+                bind:inProgress="{fetchInProgress}"
+                title="Clear events"
+                on:click="{() => eventStoreInfo.clearEvents()}"
+                icon="{faTrash}">Clear</Button>
+            {/if}
+          </div>
+          {#if eventStoreInfo.bufferEvents.length > 0}
+            {@const reverseOrderedBufferEvents = [...eventStoreInfo.bufferEvents].reverse()}
+
+            <ul class="h-32 overflow-auto list-disc list-inside text-xs" aria-label="buffer-events">
+              {#each reverseOrderedBufferEvents as bufferEvent}
+                <li aria-label="{bufferEvent.name}">
+                  {#if bufferEvent.skipped}
+                    Skipped event
+                  {:else}
+                    Grab {bufferEvent.length} items from
+                  {/if}
+
+                  '{bufferEvent.name}' event
+                  {#if bufferEvent.args?.length > 0}
+                    ({bufferEvent.args})
+                  {/if}
+
+                  {humanizeDuration(moment().diff(bufferEvent.date), { round: true, largest: 1 })} ago.
+
+                  {#if bufferEvent.humanDuration}
+                    Took {bufferEvent.humanDuration}.
+                  {/if}
+
+                  {#if bufferEvent.skipped}
+                    (ignoring)
+                  {/if}
+                </li>
+              {/each}
+            </ul>
+          {:else}
+            <div class="h-32 flex flex-row mx-auto text-xs text-gray-800 text-center">No buffer events</div>
+          {/if}
+        </div>
+      </div>
+
+      <div class="text-xs text-gray-800 mt-2 text-center">Track events that have updated the store</div>
     </div>
-  </div></Modal>
+  </div>
+  <svelte:fragment slot="buttons">
+    <Button aria-label="Cancel" class="mr-3" type="link" on:click="{() => closeCallback()}">Cancel</Button>
+    <Button aria-label="OK" on:click="{() => closeCallback()}">OK</Button>
+  </svelte:fragment>
+</Dialog>


### PR DESCRIPTION
### What does this PR do?

Uses the new Dialog component for the remaining four dialogs that were using Modal. No changes to the content besides moving parts into the correct slots.

### Screenshot / video of UI

Before:

<img width="758" alt="Screenshot 2024-07-05 at 11 34 32 AM" src="https://github.com/containers/podman-desktop/assets/19958075/4cfae30f-0a5c-4e0e-9bad-3276a7339e14">

<img width="758" alt="Screenshot 2024-07-05 at 11 35 05 AM" src="https://github.com/containers/podman-desktop/assets/19958075/f684721c-5719-4c11-88c1-4c1c9555f244">

<img width="758" alt="Screenshot 2024-07-05 at 11 34 51 AM" src="https://github.com/containers/podman-desktop/assets/19958075/94b0c497-3d32-4a8c-85be-40352abc5dc2">

<img width="758" alt="Screenshot 2024-07-05 at 11 35 31 AM" src="https://github.com/containers/podman-desktop/assets/19958075/62c7a4e6-8548-42ed-9f91-f89be283ab16">

After:

<img width="758" alt="Screenshot 2024-07-05 at 11 33 19 AM" src="https://github.com/containers/podman-desktop/assets/19958075/93f3d8e6-5efc-41dc-8385-037ba39dd95e">

<img width="758" alt="Screenshot 2024-07-05 at 11 32 31 AM" src="https://github.com/containers/podman-desktop/assets/19958075/61eefd30-def7-4d33-8867-40df63bce6f2">

<img width="826" alt="Screenshot 2024-07-09 at 8 21 42 AM" src="https://github.com/containers/podman-desktop/assets/19958075/10d76e95-af93-47f3-ac04-56841dc1c2f6">

<img width="758" alt="Screenshot 2024-07-05 at 11 32 12 AM" src="https://github.com/containers/podman-desktop/assets/19958075/704e639b-109a-4b86-925d-26194f678747">

### What issues does this PR fix or reference?

Fixes #7465.

### How to test this PR?

Open each of these dialogs.