### PR TITLE
fix: update media queries to prevent install button to overflow card

### DIFF
--- a/packages/renderer/src/lib/dashboard/ProviderCard.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderCard.svelte
@@ -12,7 +12,7 @@ export let provider: ProviderInfo;
   class="flex bg-[var(--pd-content-card-bg)] rounded-md p-5 gap-3 flex-col flex-nowrap"
   role="region"
   aria-label="{provider.name} Provider">
-  <div class="flex flex-col lg:flex-row gap-x-4">
+  <div class="flex flex-col xl:flex-row gap-x-4">
     <div class="grid grid-cols-[3rem_1fr] w-1/4 gap-2">
       <IconImage image="{provider?.images?.icon}" class="mx-0 max-h-12" alt="{provider.name}"></IconImage>
       <div
@@ -34,7 +34,7 @@ export let provider: ProviderInfo;
         </div>
       </div>
     </div>
-    <div class="flex items-center flex-row space-x-10 mt-5 w-full lg:mt-0 lg:w-3/4 flex-nowrap">
+    <div class="flex items-center flex-row space-x-10 mt-5 w-full xl:mt-0 xl:w-3/4 flex-nowrap">
       <slot name="content" />
     </div>
   </div>


### PR DESCRIPTION
### What does this PR do?

It just updates the media query used for deciding how the components are displayed. By switching from xl to lg, we resolve the problem with the button position without adding any max-width or other constraints.

### Screenshot / video of UI

![install_overflow](https://github.com/containers/podman-desktop/assets/49404737/43ae3e9d-3ff2-4e78-8275-065920026c9d)

### What issues does this PR fix or reference?

it resolves #7809 

### How to test this PR?

1. uninstall podman and check how the install button in dashboard is positioned

- [ ] Tests are covering the bug fix or the new feature
