### PR TITLE
docs: add note about mac binaries in contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,8 +57,8 @@ You can develop on either: `Windows`, `macOS` or `Linux`.
 
 Requirements:
 
-- [Node.js 18+](https://nodejs.org/en/)
-- [yarn](https://yarnpkg.com/)
+- [Node.js 20+](https://nodejs.org/en/)
+- [yarn v1.x](https://yarnpkg.com/) (`npm i -g yarn@1)
 
 Optional Linux requirements:
 
@@ -216,6 +216,8 @@ This will create a binary according to your local system and output it to the `d
 
 > **_NOTE:_** macOS and Windows create binaries while Linux will create a `.flatpak`. Make sure your flatpak dependencies are installed for successful compiling on Linux.
 
+> **_macOS NOTE:_** On macOS the `dist/` folder will contain folders for `arm64` and `universal` `.app` files. Ignore these and use the `.app` file in the `dist/mac/` folder for testing.
+
 ## Submitting Pull Requests
 
 ### Process
@@ -369,11 +371,13 @@ Colors in Podman Desktop are now managed by a [`color-registry.ts`](https://gith
 When contributing a UI component to Podman Desktop that is colorized, you must go through some steps to figure out what color to use and how to reference it.
 
 Steps:
+
 1. Open the [`color-registry.ts`](https://github.com/containers/podman-desktop/blob/main/packages/main/src/plugin/color-registry.ts) file.
 2. Figure out which color category from the `initColors()` function.
 3. Use the referenced color with the format `[var(--pd-<color>)]`
 
 Example:
+
 1. Choose what UI component you want to add: Ex. I want to add a new primary button.
 2. Look under `initColors()` and pick `this.initButton()` and scroll down to `protected initButton()`.
 3. Pick a color. I want to use the the "primary" button. So I will pick: `${button}primary-bg`.


### PR DESCRIPTION
### What does this PR do?

Adds a note about which binary to use when testing changes on macOS. Using the wrong binary results in Podman Desktop crashing.
