### PR TITLE
fix: revalidate ports when one custom port mapping entry is removed

### DIFF
--- a/packages/renderer/src/lib/image/RunImage.svelte
+++ b/packages/renderer/src/lib/image/RunImage.svelte
@@ -498,6 +498,7 @@ function addHostContainerPorts() {
 
 function deleteHostContainerPorts(index: number) {
   hostContainerPortMappings = hostContainerPortMappings.filter((_, i) => i !== index);
+  assertAllPortAreValid();
 }
 
 async function browseFolders(index: number) {


### PR DESCRIPTION
### What does this PR do?

It forces a re-check on all saved ports to see if the start container button should be enabled.

When removing a custom port mapping inside the run image page we were not checking if the ports were all valid. So if you tried inserting an invalid port, an error was displayed and the start container button was disabled. So far so good. However, if you removed the entry, the start container button remained disabled.

### Screenshot / video of UI

![enable_start_container](https://github.com/containers/podman-desktop/assets/49404737/5adf24b6-74e4-4980-96ed-47341415a070)

### What issues does this PR fix or reference?

it resolves #7812 

### How to test this PR?

1. go to the run image page
2. add a new custom port entry with an invalid port
3. you should see an error message and the start container should be disabled
4. remove the row
5. the button should be enabled again

- [ ] Tests are covering the bug fix or the new feature
