### PR TITLE
feat: add confirmation when bulk-delete if required based on preferences

### DIFF
--- a/packages/renderer/src/lib/actions/BulkActions.ts
+++ b/packages/renderer/src/lib/actions/BulkActions.ts
@@ -1,0 +1,25 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { withConfirmation } from '../dialogs/messagebox-utils';
+
+export function withBulkConfirmation(callback: () => unknown, text: string): void {
+  window
+    .getConfigurationValue('userConfirmation.bulk')
+    .then(confirm => (confirm ? withConfirmation(callback, text) : callback()));
+}

--- a/packages/renderer/src/lib/container/ContainerList.svelte
+++ b/packages/renderer/src/lib/container/ContainerList.svelte
@@ -373,7 +373,11 @@ $: containersAndGroups = containerGroups.map(group =>
     {#if selectedItemsNumber > 0}
       <div class="inline-flex space-x-2">
         <Button
-          on:click="{() => withBulkConfirmation(deleteSelectedContainers, `delete ${selectedItemsNumber} containers`)}"
+          on:click="{() =>
+            withBulkConfirmation(
+              deleteSelectedContainers,
+              `delete ${selectedItemsNumber} container${selectedItemsNumber > 1 ? 's' : ''}`,
+            )}"
           aria-label="Delete selected containers and pods"
           title="Delete {selectedItemsNumber} selected items"
           bind:inProgress="{bulkDeleteInProgress}"

--- a/packages/renderer/src/lib/container/ContainerList.svelte
+++ b/packages/renderer/src/lib/container/ContainerList.svelte
@@ -26,6 +26,7 @@ import { podsInfos } from '../../stores/pods';
 import { providerInfos } from '../../stores/providers';
 import { findMatchInLeaves } from '../../stores/search-util';
 import { viewsContributions } from '../../stores/views';
+import { withBulkConfirmation } from '../actions/BulkActions';
 import type { ContextUI } from '../context/context';
 import Dialog from '../dialogs/Dialog.svelte';
 import type { EngineInfoUI } from '../engine/EngineInfoUI';
@@ -372,7 +373,7 @@ $: containersAndGroups = containerGroups.map(group =>
     {#if selectedItemsNumber > 0}
       <div class="inline-flex space-x-2">
         <Button
-          on:click="{() => deleteSelectedContainers()}"
+          on:click="{() => withBulkConfirmation(deleteSelectedContainers, `delete ${selectedItemsNumber} containers`)}"
           aria-label="Delete selected containers and pods"
           title="Delete {selectedItemsNumber} selected items"
           bind:inProgress="{bulkDeleteInProgress}"

--- a/packages/renderer/src/lib/deployments/DeploymentsList.svelte
+++ b/packages/renderer/src/lib/deployments/DeploymentsList.svelte
@@ -19,6 +19,7 @@ import {
   kubernetesCurrentContextDeploymentsFiltered,
 } from '/@/stores/kubernetes-contexts-state';
 
+import { withBulkConfirmation } from '../actions/BulkActions';
 import DeploymentIcon from '../images/DeploymentIcon.svelte';
 import KubeApplyYamlButton from '../kube/KubeApplyYAMLButton.svelte';
 import { DeploymentUtils } from './deployment-utils';
@@ -126,7 +127,7 @@ const row = new TableRow<DeploymentUI>({ selectable: _deployment => true });
   <svelte:fragment slot="bottom-additional-actions">
     {#if selectedItemsNumber > 0}
       <Button
-        on:click="{() => deleteSelectedDeployments()}"
+        on:click="{() => withBulkConfirmation(deleteSelectedDeployments, `delete ${selectedItemsNumber} deployments`)}"
         title="Delete {selectedItemsNumber} selected items"
         inProgress="{bulkDeleteInProgress}"
         icon="{faTrash}" />

--- a/packages/renderer/src/lib/deployments/DeploymentsList.svelte
+++ b/packages/renderer/src/lib/deployments/DeploymentsList.svelte
@@ -127,7 +127,11 @@ const row = new TableRow<DeploymentUI>({ selectable: _deployment => true });
   <svelte:fragment slot="bottom-additional-actions">
     {#if selectedItemsNumber > 0}
       <Button
-        on:click="{() => withBulkConfirmation(deleteSelectedDeployments, `delete ${selectedItemsNumber} deployments`)}"
+        on:click="{() =>
+          withBulkConfirmation(
+            deleteSelectedDeployments,
+            `delete ${selectedItemsNumber} deployment${selectedItemsNumber > 1 ? 's' : ''}`,
+          )}"
         title="Delete {selectedItemsNumber} selected items"
         inProgress="{bulkDeleteInProgress}"
         icon="{faTrash}" />

--- a/packages/renderer/src/lib/image/ImagesList.svelte
+++ b/packages/renderer/src/lib/image/ImagesList.svelte
@@ -24,6 +24,7 @@ import { containersInfos } from '../../stores/containers';
 import { context } from '../../stores/context';
 import { filtered, imagesInfos, searchPattern } from '../../stores/images';
 import { providerInfos } from '../../stores/providers';
+import { withBulkConfirmation } from '../actions/BulkActions';
 import type { ContextUI } from '../context/context';
 import type { EngineInfoUI } from '../engine/EngineInfoUI';
 import Prune from '../engine/Prune.svelte';
@@ -346,7 +347,7 @@ const row = new TableRow<ImageInfoUI>({
   <svelte:fragment slot="bottom-additional-actions">
     {#if selectedItemsNumber > 0}
       <Button
-        on:click="{() => deleteSelectedImages()}"
+        on:click="{() => withBulkConfirmation(deleteSelectedImages, `delete ${selectedItemsNumber} images`)}"
         title="Delete {selectedItemsNumber} selected items"
         bind:inProgress="{bulkDeleteInProgress}"
         icon="{faTrash}" />

--- a/packages/renderer/src/lib/image/ImagesList.svelte
+++ b/packages/renderer/src/lib/image/ImagesList.svelte
@@ -347,7 +347,11 @@ const row = new TableRow<ImageInfoUI>({
   <svelte:fragment slot="bottom-additional-actions">
     {#if selectedItemsNumber > 0}
       <Button
-        on:click="{() => withBulkConfirmation(deleteSelectedImages, `delete ${selectedItemsNumber} images`)}"
+        on:click="{() =>
+          withBulkConfirmation(
+            deleteSelectedImages,
+            `delete ${selectedItemsNumber} image${selectedItemsNumber > 1 ? 's' : ''}`,
+          )}"
         title="Delete {selectedItemsNumber} selected items"
         bind:inProgress="{bulkDeleteInProgress}"
         icon="{faTrash}" />

--- a/packages/renderer/src/lib/ingresses-routes/IngressesRoutesList.svelte
+++ b/packages/renderer/src/lib/ingresses-routes/IngressesRoutesList.svelte
@@ -23,6 +23,7 @@ import {
 } from '/@/stores/kubernetes-contexts-state';
 import type { V1Route } from '/@api/openshift-types';
 
+import { withBulkConfirmation } from '../actions/BulkActions';
 import IngressRouteIcon from '../images/IngressRouteIcon.svelte';
 import KubeApplyYamlButton from '../kube/KubeApplyYAMLButton.svelte';
 import { IngressRouteUtils } from './ingress-route-utils';
@@ -170,7 +171,8 @@ const row = new TableRow<IngressUI | RouteUI>({ selectable: _ingressRoute => tru
   <svelte:fragment slot="bottom-additional-actions">
     {#if selectedItemsNumber > 0}
       <Button
-        on:click="{() => deleteSelectedIngressesRoutes()}"
+        on:click="{() =>
+          withBulkConfirmation(deleteSelectedIngressesRoutes, `delete ${selectedItemsNumber} Ingresses Routes`)}"
         title="Delete {selectedItemsNumber} selected items"
         inProgress="{bulkDeleteInProgress}"
         icon="{faTrash}" />

--- a/packages/renderer/src/lib/ingresses-routes/IngressesRoutesList.svelte
+++ b/packages/renderer/src/lib/ingresses-routes/IngressesRoutesList.svelte
@@ -172,7 +172,10 @@ const row = new TableRow<IngressUI | RouteUI>({ selectable: _ingressRoute => tru
     {#if selectedItemsNumber > 0}
       <Button
         on:click="{() =>
-          withBulkConfirmation(deleteSelectedIngressesRoutes, `delete ${selectedItemsNumber} Ingresses Routes`)}"
+          withBulkConfirmation(
+            deleteSelectedIngressesRoutes,
+            `delete ${selectedItemsNumber} Ingress${selectedItemsNumber > 1 ? 'es' : ''} / Route${selectedItemsNumber > 1 ? 's' : ''}`,
+          )}"
         title="Delete {selectedItemsNumber} selected items"
         inProgress="{bulkDeleteInProgress}"
         icon="{faTrash}" />

--- a/packages/renderer/src/lib/pod/PodsList.spec.ts
+++ b/packages/renderer/src/lib/pod/PodsList.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,6 +42,8 @@ const listContainersMock = vi.fn();
 const kubernetesListPodsMock = vi.fn();
 const getContributedMenusMock = vi.fn();
 const kubernetesGetCurrentNamespaceMock = vi.fn();
+const getConfigurationValueMock = vi.fn();
+const removePodMock = vi.fn();
 
 const provider: ProviderInfo = {
   containerConnections: [
@@ -276,6 +278,9 @@ beforeAll(() => {
   (window as any).kubernetesListPods = kubernetesListPodsMock;
   (window as any).kubernetesGetCurrentNamespace = kubernetesGetCurrentNamespaceMock;
   (window as any).onDidUpdateProviderStatus = vi.fn().mockResolvedValue(undefined);
+  (window as any).removePod = removePodMock;
+  (window as any).getConfigurationValue = getConfigurationValueMock.mockResolvedValue(false);
+
   (window.events as unknown) = {
     receive: (_channel: string, func: any) => {
       func();
@@ -624,4 +629,35 @@ test('Expect tab filtering to not duplicate filter condition in the search bar',
 
   const searchInput = screen.getByPlaceholderText('Search pods...') as HTMLInputElement;
   expect(searchInput.value).toBe('is:running');
+});
+
+test('Expect user confirmation to pop up when preferences require', async () => {
+  getProvidersInfoMock.mockResolvedValue([provider]);
+  listPodsMock.mockResolvedValue([pod1]);
+  kubernetesListPodsMock.mockResolvedValue([]);
+  window.dispatchEvent(new CustomEvent('provider-lifecycle-change'));
+  window.dispatchEvent(new CustomEvent('extensions-already-started'));
+
+  await vi.waitUntil(() => get(providerInfos).length === 1 && get(podsInfos).length === 2, { timeout: 5000 });
+
+  render(PodsList);
+
+  const checkboxes = screen.getAllByRole('checkbox', { name: 'Toggle pod' });
+  await fireEvent.click(checkboxes[0]);
+
+  getConfigurationValueMock.mockResolvedValueOnce(true);
+  const showMessageBoxMock = vi.fn().mockResolvedValue({ response: 1 });
+
+  (window as any).showMessageBox = showMessageBoxMock;
+
+  const deleteButton = screen.getByRole('button', { name: 'Delete 1 selected items' });
+  await fireEvent.click(deleteButton);
+
+  expect(showMessageBoxMock).toHaveBeenCalledOnce();
+  expect(removePodMock).not.toHaveBeenCalled();
+
+  showMessageBoxMock.mockResolvedValue({ response: 0 });
+  await fireEvent.click(deleteButton);
+  expect(showMessageBoxMock).toHaveBeenCalledOnce();
+  expect(removePodMock).toHaveBeenCalled();
 });

--- a/packages/renderer/src/lib/pod/PodsList.svelte
+++ b/packages/renderer/src/lib/pod/PodsList.svelte
@@ -16,6 +16,7 @@ import KubernetesCurrentContextConnectionBadge from '/@/lib/ui/KubernetesCurrent
 import type { PodInfo } from '../../../../main/src/plugin/api/pod-info';
 import { filtered, podsInfos, searchPattern } from '../../stores/pods';
 import { providerInfos } from '../../stores/providers';
+import { withBulkConfirmation } from '../actions/BulkActions';
 import type { EngineInfoUI } from '../engine/EngineInfoUI';
 import Prune from '../engine/Prune.svelte';
 import NoContainerEngineEmptyScreen from '../image/NoContainerEngineEmptyScreen.svelte';
@@ -166,7 +167,7 @@ const row = new TableRow<PodInfoUI>({ selectable: _pod => true });
   <svelte:fragment slot="bottom-additional-actions">
     {#if selectedItemsNumber > 0}
       <Button
-        on:click="{() => deleteSelectedPods()}"
+        on:click="{() => withBulkConfirmation(deleteSelectedPods, `delete ${selectedItemsNumber} pods`)}"
         title="Delete {selectedItemsNumber} selected items"
         inProgress="{bulkDeleteInProgress}"
         icon="{faTrash}" />

--- a/packages/renderer/src/lib/pod/PodsList.svelte
+++ b/packages/renderer/src/lib/pod/PodsList.svelte
@@ -167,7 +167,11 @@ const row = new TableRow<PodInfoUI>({ selectable: _pod => true });
   <svelte:fragment slot="bottom-additional-actions">
     {#if selectedItemsNumber > 0}
       <Button
-        on:click="{() => withBulkConfirmation(deleteSelectedPods, `delete ${selectedItemsNumber} pods`)}"
+        on:click="{() =>
+          withBulkConfirmation(
+            deleteSelectedPods,
+            `delete ${selectedItemsNumber} pod${selectedItemsNumber > 1 ? 's' : ''}`,
+          )}"
         title="Delete {selectedItemsNumber} selected items"
         inProgress="{bulkDeleteInProgress}"
         icon="{faTrash}" />

--- a/packages/renderer/src/lib/pvc/PVCList.svelte
+++ b/packages/renderer/src/lib/pvc/PVCList.svelte
@@ -135,7 +135,11 @@ const row = new TableRow<PVCUI>({ selectable: _pvc => true });
   <svelte:fragment slot="bottom-additional-actions">
     {#if selectedItemsNumber > 0}
       <Button
-        on:click="{() => withBulkConfirmation(deleteSelectedPVCs, `delete ${selectedItemsNumber} PVCs`)}"
+        on:click="{() =>
+          withBulkConfirmation(
+            deleteSelectedPVCs,
+            `delete ${selectedItemsNumber} PVC${selectedItemsNumber > 1 ? 's' : ''}`,
+          )}"
         title="Delete {selectedItemsNumber} selected items"
         inProgress="{bulkDeleteInProgress}"
         icon="{faTrash}" />

--- a/packages/renderer/src/lib/pvc/PVCList.svelte
+++ b/packages/renderer/src/lib/pvc/PVCList.svelte
@@ -19,6 +19,7 @@ import {
   persistentVolumeClaimSearchPattern,
 } from '/@/stores/kubernetes-contexts-state';
 
+import { withBulkConfirmation } from '../actions/BulkActions';
 import PVCIcon from '../images/PVCIcon.svelte';
 import KubeApplyYamlButton from '../kube/KubeApplyYAMLButton.svelte';
 import { PVCUtils } from './pvc-utils';
@@ -134,7 +135,7 @@ const row = new TableRow<PVCUI>({ selectable: _pvc => true });
   <svelte:fragment slot="bottom-additional-actions">
     {#if selectedItemsNumber > 0}
       <Button
-        on:click="{() => deleteSelectedPVCs()}"
+        on:click="{() => withBulkConfirmation(deleteSelectedPVCs, `delete ${selectedItemsNumber} PVCs`)}"
         title="Delete {selectedItemsNumber} selected items"
         inProgress="{bulkDeleteInProgress}"
         icon="{faTrash}" />

--- a/packages/renderer/src/lib/service/ServicesList.svelte
+++ b/packages/renderer/src/lib/service/ServicesList.svelte
@@ -16,6 +16,7 @@ import { onMount } from 'svelte';
 import KubernetesCurrentContextConnectionBadge from '/@/lib/ui/KubernetesCurrentContextConnectionBadge.svelte';
 import { kubernetesCurrentContextServicesFiltered, serviceSearchPattern } from '/@/stores/kubernetes-contexts-state';
 
+import { withBulkConfirmation } from '../actions/BulkActions';
 import ServiceIcon from '../images/ServiceIcon.svelte';
 import KubeApplyYamlButton from '../kube/KubeApplyYAMLButton.svelte';
 import { ServiceUtils } from './service-utils';
@@ -132,7 +133,7 @@ const row = new TableRow<ServiceUI>({ selectable: _service => true });
   <svelte:fragment slot="bottom-additional-actions">
     {#if selectedItemsNumber > 0}
       <Button
-        on:click="{() => deleteSelectedServices()}"
+        on:click="{() => withBulkConfirmation(deleteSelectedServices, `delete ${selectedItemsNumber} services`)}"
         title="Delete {selectedItemsNumber} selected items"
         inProgress="{bulkDeleteInProgress}"
         icon="{faTrash}" />

--- a/packages/renderer/src/lib/service/ServicesList.svelte
+++ b/packages/renderer/src/lib/service/ServicesList.svelte
@@ -133,7 +133,11 @@ const row = new TableRow<ServiceUI>({ selectable: _service => true });
   <svelte:fragment slot="bottom-additional-actions">
     {#if selectedItemsNumber > 0}
       <Button
-        on:click="{() => withBulkConfirmation(deleteSelectedServices, `delete ${selectedItemsNumber} services`)}"
+        on:click="{() =>
+          withBulkConfirmation(
+            deleteSelectedServices,
+            `delete ${selectedItemsNumber} service${selectedItemsNumber > 1 ? 's' : ''}`,
+          )}"
         title="Delete {selectedItemsNumber} selected items"
         inProgress="{bulkDeleteInProgress}"
         icon="{faTrash}" />

--- a/packages/renderer/src/lib/volume/VolumesList.svelte
+++ b/packages/renderer/src/lib/volume/VolumesList.svelte
@@ -16,6 +16,7 @@ import { router } from 'tinro';
 
 import { providerInfos } from '../../stores/providers';
 import { fetchVolumesWithData, filtered, searchPattern, volumeListInfos } from '../../stores/volumes';
+import { withBulkConfirmation } from '../actions/BulkActions';
 import type { EngineInfoUI } from '../engine/EngineInfoUI';
 import Prune from '../engine/Prune.svelte';
 import NoContainerEngineEmptyScreen from '../image/NoContainerEngineEmptyScreen.svelte';
@@ -249,7 +250,7 @@ const row = new TableRow<VolumeInfoUI>({
   <svelte:fragment slot="bottom-additional-actions">
     {#if selectedItemsNumber > 0}
       <Button
-        on:click="{() => deleteSelectedVolumes()}"
+        on:click="{() => withBulkConfirmation(deleteSelectedVolumes, `delete ${selectedItemsNumber} volumes`)}"
         title="Delete {selectedItemsNumber} selected items"
         inProgress="{bulkDeleteInProgress}"
         icon="{faTrash}" />

--- a/packages/renderer/src/lib/volume/VolumesList.svelte
+++ b/packages/renderer/src/lib/volume/VolumesList.svelte
@@ -250,7 +250,11 @@ const row = new TableRow<VolumeInfoUI>({
   <svelte:fragment slot="bottom-additional-actions">
     {#if selectedItemsNumber > 0}
       <Button
-        on:click="{() => withBulkConfirmation(deleteSelectedVolumes, `delete ${selectedItemsNumber} volumes`)}"
+        on:click="{() =>
+          withBulkConfirmation(
+            deleteSelectedVolumes,
+            `delete ${selectedItemsNumber} volume${selectedItemsNumber > 1 ? 's' : ''}`,
+          )}"
         title="Delete {selectedItemsNumber} selected items"
         inProgress="{bulkDeleteInProgress}"
         icon="{faTrash}" />


### PR DESCRIPTION
### What does this PR do?

Requires user confirmation when bulk-deleting if this option is on in preferences

### Screenshot / video of UI

![Screenshot from 2024-07-10 10-27-16](https://github.com/containers/podman-desktop/assets/66797193/e433e072-caf9-4a75-b22a-3997f4886ca9)


<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop/issues/7591

### How to test this PR?

<!-- Please explain steps to verify the functionality, do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature

Try bulk-delete in any of the list pages