### PR TITLE
fix: text overlay on dashboard card

### DIFF
--- a/packages/renderer/src/lib/dashboard/ProviderCard.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderCard.svelte
@@ -13,15 +13,15 @@ export let provider: ProviderInfo;
   role="region"
   aria-label="{provider.name} Provider">
   <div class="flex flex-col xl:flex-row gap-x-4">
-    <div class="grid grid-cols-[3rem_1fr] w-1/4 gap-2">
+    <div class="grid grid-cols-[3rem_1fr] w-full xl:w-1/4 gap-2">
       <IconImage image="{provider?.images?.icon}" class="mx-0 max-h-12" alt="{provider.name}"></IconImage>
       <div
         class="flex flex-col gap-0 text-[var(--pd-content-card-title)] text-lg whitespace-nowrap"
         aria-label="context-name">
-        <div class="flex flex-row gap-1 items-center">
-          {provider.name}
+        <div class="gap-1 items-center">
+          <span class="float-left mr-1">{provider.name}</span>
           {#if provider.version}
-            <div class="text-[var(--pd-content-card-light-title)] text-base" aria-label="Provider Version">
+            <div class="text-[var(--pd-content-card-light-title)] text-base float-left" aria-label="Provider Version">
               v{provider.version}
             </div>
           {/if}


### PR DESCRIPTION
### What does this PR do?

This PR just remove the flex property from the div parent and use the left float on the child elements, causing them to stack horizontally until there's no more space.

This prevents the text overlay to happen

### Screenshot / video of UI

![dashboard_overflow](https://github.com/containers/podman-desktop/assets/49404737/c34ba01d-6054-4621-ac45-5dcfd65efd84)

### What issues does this PR fix or reference?

it resolves #7820 

### How to test this PR?

1. start and stop openshift local
2. check that there is no text overlay on the dashboard card

- [ ] Tests are covering the bug fix or the new feature
