### PR TITLE
feat: making kind extension register cli tool

### DIFF
--- a/extensions/kind/src/extension.ts
+++ b/extensions/kind/src/extension.ts
@@ -70,7 +70,7 @@ async function registerProvider(
     {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       create: (params: { [key: string]: any }, logger?: Logger, token?: CancellationToken) => {
-        if (kindCli && kindPath) {
+        if (kindPath) {
           return createCluster(params, kindPath, telemetryLogger, logger, token);
         }
         return Promise.reject(new Error('Unable to create kind cluster. No kind cli detected'));
@@ -180,7 +180,7 @@ async function updateClusters(
             env['KIND_EXPERIMENTAL_PROVIDER'] = 'podman';
           }
           env.PATH = getKindPath() ?? '';
-          if (kindCli && kindPath) {
+          if (kindPath) {
             await extensionApi.process.exec(kindPath, ['delete', 'cluster', '--name', cluster.name], { env, logger });
           }
         },

--- a/extensions/kind/src/extension.ts
+++ b/extensions/kind/src/extension.ts
@@ -16,7 +16,15 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { AuditRequestItems, CancellationToken, Logger } from '@podman-desktop/api';
+import type {
+  AuditRequestItems,
+  CancellationToken,
+  CliTool,
+  ExtensionContext,
+  Logger,
+  StatusBarItem,
+  TelemetryLogger,
+} from '@podman-desktop/api';
 import * as extensionApi from '@podman-desktop/api';
 import { ProgressLocation, window } from '@podman-desktop/api';
 
@@ -24,7 +32,9 @@ import { connectionAuditor, createCluster } from './create-cluster';
 import type { ImageInfo } from './image-handler';
 import { ImageHandler } from './image-handler';
 import { KindInstaller } from './kind-installer';
-import { detectKind, getKindPath } from './util';
+import { getKindBinaryInfo, getKindPath } from './util';
+
+const KIND_MARKDOWN = `Podman Desktop can help you run Kind-powered local Kubernetes clusters on a container engine, such as Podman.\n\nMore information: [Podman Desktop Documentation](https://podman-desktop.io/docs/kind)`;
 
 const API_KIND_INTERNAL_API_PORT = 6443;
 
@@ -46,7 +56,8 @@ const registeredKubernetesConnections: {
   disposable: extensionApi.Disposable;
 }[] = [];
 
-let kindCli: string | undefined;
+let kindCli: CliTool | undefined;
+let kindPath: string | undefined;
 
 const imageHandler = new ImageHandler();
 
@@ -59,8 +70,8 @@ async function registerProvider(
     {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       create: (params: { [key: string]: any }, logger?: Logger, token?: CancellationToken) => {
-        if (kindCli) {
-          return createCluster(params, kindCli, telemetryLogger, logger, token);
+        if (kindCli && kindPath) {
+          return createCluster(params, kindPath, telemetryLogger, logger, token);
         }
         return Promise.reject(new Error('Unable to create kind cluster. No kind cli detected'));
       },
@@ -169,8 +180,8 @@ async function updateClusters(
             env['KIND_EXPERIMENTAL_PROVIDER'] = 'podman';
           }
           env.PATH = getKindPath() ?? '';
-          if (kindCli) {
-            await extensionApi.process.exec(kindCli, ['delete', 'cluster', '--name', cluster.name], { env, logger });
+          if (kindCli && kindPath) {
+            await extensionApi.process.exec(kindPath, ['delete', 'cluster', '--name', cluster.name], { env, logger });
           }
         },
       };
@@ -302,7 +313,7 @@ export async function moveImage(
   image: unknown,
 ): Promise<void> {
   // as the command receive an "any" value we check that it contains an id and an engineId as they are mandatory
-  if (!(kindCli && image && typeof image === 'object' && 'id' in image && 'engineId' in image)) {
+  if (!(kindCli && kindPath && image && typeof image === 'object' && 'id' in image && 'engineId' in image)) {
     throw new Error('Image selection not supported yet');
   }
 
@@ -310,7 +321,7 @@ export async function moveImage(
   imagesPushInProgressToKind.push(image.id as string);
   extensionApi.context.setValue('imagesPushInProgressToKind', imagesPushInProgressToKind);
   try {
-    await imageHandler.moveImage(image as ImageInfo, kindClusters, kindCli);
+    await imageHandler.moveImage(image as ImageInfo, kindClusters, kindPath);
   } finally {
     // Mark the task as completed and remove the image from the pushInProgressToKind list on context
     imagesPushInProgressToKind = imagesPushInProgressToKind.filter(id => id !== image.id);
@@ -322,35 +333,92 @@ export async function moveImage(
 export async function activate(extensionContext: extensionApi.ExtensionContext): Promise<void> {
   const telemetryLogger = extensionApi.env.createTelemetryLogger();
   const installer = new KindInstaller(extensionContext.storagePath, telemetryLogger);
-  kindCli = await detectKind(extensionContext.storagePath, installer);
 
-  if (!kindCli) {
-    if (await installer.isAvailable()) {
-      const statusBarItem = extensionApi.window.createStatusBarItem();
-      statusBarItem.text = 'Kind';
-      statusBarItem.tooltip = 'Kind not found on your system, click to download and install it';
-      statusBarItem.command = KIND_INSTALL_COMMAND;
-      statusBarItem.iconClass = 'fa fa-exclamation-triangle';
-      extensionContext.subscriptions.push(
-        extensionApi.commands.registerCommand(KIND_INSTALL_COMMAND, () =>
-          installer.performInstall().then(
-            async status => {
-              if (status) {
-                statusBarItem.dispose();
-                kindCli = await detectKind(extensionContext.storagePath, installer);
-                await createProvider(extensionContext, telemetryLogger);
-              }
-            },
-            (err: unknown) => window.showErrorMessage('Kind installation failed ' + err),
-          ),
-        ),
-        statusBarItem,
-      );
-      statusBarItem.show();
-    }
-  } else {
-    await createProvider(extensionContext, telemetryLogger);
+  let binary: { path: string; version: string } | undefined = undefined;
+  try {
+    binary = await getKindBinaryInfo('kind');
+  } catch (err: unknown) {
+    console.error(err);
   }
+
+  // let's try to check in the extension storage if kind is not available system-wide
+  if (!binary) {
+    try {
+      binary = await getKindBinaryInfo(installer.getInternalDestinationPath());
+    } catch (err: unknown) {
+      console.error(err);
+    }
+  }
+
+  if (binary) {
+    kindPath = binary.path;
+    kindCli = extensionApi.cli.createCliTool({
+      name: 'kind',
+      images: {
+        icon: './icon.png',
+      },
+      version: binary.version,
+      path: binary.path,
+      displayName: 'kind',
+      markdownDescription: KIND_MARKDOWN,
+    });
+  }
+
+  if (kindCli) {
+    await createProvider(extensionContext, telemetryLogger);
+    return;
+  }
+
+  if (await installer.isAvailable()) {
+    const statusBarItem = extensionApi.window.createStatusBarItem();
+    statusBarItem.text = 'Kind';
+    statusBarItem.tooltip = 'Kind not found on your system, click to download and install it';
+    statusBarItem.command = KIND_INSTALL_COMMAND;
+    statusBarItem.iconClass = 'fa fa-exclamation-triangle';
+    extensionContext.subscriptions.push(
+      extensionApi.commands.registerCommand(KIND_INSTALL_COMMAND, () =>
+        kindInstall(installer, statusBarItem, extensionContext, telemetryLogger),
+      ),
+      statusBarItem,
+    );
+    statusBarItem.show();
+  }
+}
+
+async function kindInstall(
+  installer: KindInstaller,
+  statusBarItem: StatusBarItem,
+  extensionContext: ExtensionContext,
+  telemetryLogger: TelemetryLogger,
+): Promise<void> {
+  if (kindCli || kindPath) throw new Error('kind cli is already registered');
+
+  let path: string;
+  try {
+    path = await installer.performInstall();
+  } catch (err: unknown) {
+    window.showErrorMessage('Kind installation failed ' + err).catch((error: unknown) => {
+      console.error('show error went wrong', error);
+    });
+    return;
+  }
+
+  statusBarItem.dispose();
+  const binaryInfo = await getKindBinaryInfo(path);
+
+  kindPath = path;
+  kindCli = extensionApi.cli.createCliTool({
+    name: 'kind',
+    images: {
+      icon: './icon.png',
+    },
+    version: binaryInfo.version,
+    path: binaryInfo.path,
+    displayName: 'kind',
+    markdownDescription: KIND_MARKDOWN,
+  });
+
+  await createProvider(extensionContext, telemetryLogger);
 }
 
 export function deactivate(): void {

--- a/extensions/kind/src/extension.ts
+++ b/extensions/kind/src/extension.ts
@@ -423,4 +423,5 @@ async function kindInstall(
 
 export function deactivate(): void {
   console.log('stopping kind extension');
+  kindCli?.dispose();
 }

--- a/extensions/kind/src/kind-installer.spec.ts
+++ b/extensions/kind/src/kind-installer.spec.ts
@@ -37,6 +37,11 @@ vi.mock('@podman-desktop/api', async () => {
     ProgressLocation: {
       APP_ICON: 1,
     },
+    env: {
+      isLinux: false,
+      isMac: false,
+      isWindows: false,
+    },
     process: {
       exec: vi.fn(),
     },
@@ -83,11 +88,9 @@ beforeEach(() => {
 });
 
 test.skip('expect installBinaryToSystem to succesfully pass with a binary', async () => {
-  // Mock process.platform to be linux
-  // to avoid the usage of sudo-prompt (we cannot test that in unit tests)
-  Object.defineProperty(process, 'platform', {
-    value: 'linux',
-  });
+  (extensionApi.env.isLinux as unknown as boolean) = true;
+  (extensionApi.env.isWindows as unknown as boolean) = false;
+  (extensionApi.env.isMac as unknown as boolean) = false;
 
   // Create a tmp file using tmp-promise
   const filename = await tmpName();
@@ -119,6 +122,8 @@ test('error: expect installBinaryToSystem to fail with a non existing binary', a
 });
 
 test('expect showNotification to be called', async () => {
+  (extensionApi.env.isWindows as unknown as boolean) = false;
+
   const progress = {
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     report: (): void => {},

--- a/extensions/kind/src/kind-installer.spec.ts
+++ b/extensions/kind/src/kind-installer.spec.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { RunError } from '@podman-desktop/api';
+import { Octokit } from '@octokit/rest';
 import * as extensionApi from '@podman-desktop/api';
 import { tmpName } from 'tmp-promise';
 import { beforeEach, expect, test, vi } from 'vitest';
@@ -29,7 +29,7 @@ let installer: KindInstaller;
 vi.mock('@podman-desktop/api', async () => {
   return {
     window: {
-      showInformationMessage: vi.fn().mockReturnValue(Promise.resolve('Yes')),
+      showInformationMessage: vi.fn(),
       showErrorMessage: vi.fn(),
       withProgress: vi.fn(),
       showNotification: vi.fn(),
@@ -67,11 +67,8 @@ vi.mock('sudo-prompt', () => {
 });
 
 vi.mock('@octokit/rest', () => {
-  const repos = {
-    getReleaseAsset: vi.fn().mockReturnValue({ name: 'kind', data: [] }),
-  };
   return {
-    Octokit: vi.fn().mockReturnValue({ repos: repos }),
+    Octokit: vi.fn(),
   };
 });
 
@@ -84,13 +81,16 @@ const telemetryLoggerMock = {
 
 beforeEach(() => {
   installer = new KindInstaller('.', telemetryLoggerMock);
-  vi.clearAllMocks();
+  vi.resetAllMocks();
+
+  vi.mocked(extensionApi.window.showInformationMessage).mockReturnValue(Promise.resolve('Yes'));
+  (extensionApi.env.isLinux as unknown as boolean) = false;
+  (extensionApi.env.isWindows as unknown as boolean) = false;
+  (extensionApi.env.isMac as unknown as boolean) = false;
 });
 
 test.skip('expect installBinaryToSystem to succesfully pass with a binary', async () => {
   (extensionApi.env.isLinux as unknown as boolean) = true;
-  (extensionApi.env.isWindows as unknown as boolean) = false;
-  (extensionApi.env.isMac as unknown as boolean) = false;
 
   // Create a tmp file using tmp-promise
   const filename = await tmpName();
@@ -104,25 +104,21 @@ test.skip('expect installBinaryToSystem to succesfully pass with a binary', asyn
 });
 
 test('error: expect installBinaryToSystem to fail with a non existing binary', async () => {
-  Object.defineProperty(process, 'platform', {
-    value: 'linux',
-  });
+  (extensionApi.env.isLinux as unknown as boolean) = false;
 
-  vi.spyOn(extensionApi.process, 'exec').mockRejectedValue({} as RunError);
+  vi.spyOn(extensionApi.process, 'exec').mockRejectedValue(new Error('test error'));
 
-  // Run installBinaryToSystem with a non-binary file
-  try {
-    await installBinaryToSystem('test', 'tmpBinary');
-    // Expect that showErrorMessage is called
-    expect(extensionApi.window.showErrorMessage).toHaveBeenCalled();
-  } catch (err) {
-    expect(err).to.be.a('Error');
-    expect(err).toBeDefined();
-  }
+  await expect(() => installBinaryToSystem('test', 'tmpBinary')).rejects.toThrowError('test error');
 });
 
 test('expect showNotification to be called', async () => {
-  (extensionApi.env.isWindows as unknown as boolean) = false;
+  (extensionApi.env.isLinux as unknown as boolean) = true;
+
+  vi.mocked(Octokit).mockReturnValue({
+    repos: {
+      getReleaseAsset: vi.fn().mockReturnValue({ name: 'kind', data: [] }),
+    },
+  } as unknown as Octokit);
 
   const progress = {
     // eslint-disable-next-line @typescript-eslint/no-empty-function

--- a/extensions/kind/src/kind-installer.ts
+++ b/extensions/kind/src/kind-installer.ts
@@ -118,6 +118,11 @@ export class KindInstaller {
     return path.resolve(this.storagePath, extensionApi.env.isWindows ? 'kind.exe' : 'kind');
   }
 
+  /**
+   * (1) Download the latest binary in the extension storage path.
+   * (2) Ask the user if they want to install system-wide
+   * @return the path where the binary is installed
+   */
   async performInstall(): Promise<string> {
     this.telemetryLogger.logUsage('install-kind-prompt');
     const confirm = await this.withConfirmation(

--- a/extensions/kind/src/kind-installer.ts
+++ b/extensions/kind/src/kind-installer.ts
@@ -24,7 +24,7 @@ import { Octokit } from '@octokit/rest';
 import * as extensionApi from '@podman-desktop/api';
 import { ProgressLocation } from '@podman-desktop/api';
 
-import { installBinaryToSystem, isWindows } from './util';
+import { installBinaryToSystem } from './util';
 
 const githubOrganization = 'kubernetes-sigs';
 const githubRepo = 'kind';
@@ -109,75 +109,79 @@ export class KindInstaller {
     return assetInfo !== undefined;
   }
 
-  async performInstall(): Promise<boolean> {
+  protected async withConfirmation(text: string): Promise<boolean> {
+    const result = await extensionApi.window.showInformationMessage(text, 'Yes', 'Cancel');
+    return result === 'Yes';
+  }
+
+  getInternalDestinationPath(): string {
+    return path.resolve(this.storagePath, extensionApi.env.isWindows ? 'kind.exe' : 'kind');
+  }
+
+  async performInstall(): Promise<string> {
     this.telemetryLogger.logUsage('install-kind-prompt');
-    const dialogResult = await extensionApi.window.showInformationMessage(
+    const confirm = await this.withConfirmation(
       'The kind binary is required for local Kubernetes development, would you like to download it?',
-      'Yes',
-      'Cancel',
     );
-    if (dialogResult === 'Yes') {
-      this.telemetryLogger.logUsage('install-kind-prompt-yes');
-      return extensionApi.window.withProgress(
-        { location: ProgressLocation.TASK_WIDGET, title: 'Installing kind' },
-        async progress => {
-          progress.report({ increment: 5 });
-          try {
-            const assetInfo = await this.getAssetInfo();
-            if (assetInfo) {
-              const octokit = new Octokit();
-              const asset = await octokit.repos.getReleaseAsset({
-                owner: githubOrganization,
-                repo: githubRepo,
-                asset_id: assetInfo.id,
-                headers: {
-                  accept: 'application/octet-stream',
-                },
-              });
-              progress.report({ increment: 80 });
-              if (asset) {
-                const destFile = path.resolve(this.storagePath, isWindows() ? assetInfo.name + '.exe' : assetInfo.name);
-                if (!fs.existsSync(this.storagePath)) {
-                  fs.mkdirSync(this.storagePath);
-                }
-                fs.appendFileSync(destFile, Buffer.from(asset.data as unknown as ArrayBuffer));
-                if (!isWindows()) {
-                  const stat = fs.statSync(destFile);
-                  fs.chmodSync(destFile, stat.mode | fs.constants.S_IXUSR);
-                }
-                // Explain to the user that the binary has been successfully installed to the storage path
-                // prompt and ask if they want to install it system-wide (copied to /usr/bin/, or AppData for Windows)
-                const result = await extensionApi.window.showInformationMessage(
-                  `Kind binary has been successfully downloaded to ${destFile}.\n\nWould you like to install it system-wide for accessibility on the command line? This will require administrative privileges.`,
-                  'Yes',
-                  'Cancel',
-                );
-                if (result === 'Yes') {
-                  try {
-                    // Move the binary file to the system from destFile and rename to 'kind'
-                    await installBinaryToSystem(destFile, 'kind');
-                    await extensionApi.window.showInformationMessage(
-                      'Kind binary has been successfully installed system-wide.',
-                    );
-                  } catch (error) {
-                    console.error(error);
-                    await extensionApi.window.showErrorMessage(`Unable to install kind binary: ${error}`);
-                  }
-                }
-                this.telemetryLogger.logUsage('install-kind-downloaded');
-                extensionApi.window.showNotification({ body: 'Kind is successfully installed.' });
-                return true;
-              }
-            }
-          } finally {
-            progress.report({ increment: -1 });
-          }
-          return false;
-        },
-      );
-    } else {
+    if (!confirm) {
       this.telemetryLogger.logUsage('install-kind-prompt-no');
+      throw new Error('user cancel installation');
     }
-    return false;
+
+    this.telemetryLogger.logUsage('install-kind-prompt-yes');
+
+    return extensionApi.window.withProgress<string>(
+      { location: ProgressLocation.TASK_WIDGET, title: 'Installing kind' },
+      async progress => {
+        progress.report({ increment: 5 });
+
+        const assetInfo = await this.getAssetInfo();
+        if (!assetInfo) throw new Error('cannot find assets for kind');
+
+        const octokit = new Octokit();
+        const asset = await octokit.repos.getReleaseAsset({
+          owner: githubOrganization,
+          repo: githubRepo,
+          asset_id: assetInfo.id,
+          headers: {
+            accept: 'application/octet-stream',
+          },
+        });
+        if (!asset) throw new Error(`cannot get release asset for ${assetInfo.id}`);
+
+        progress.report({ increment: 80 });
+        const destFile = this.getInternalDestinationPath();
+        if (!fs.existsSync(this.storagePath)) {
+          fs.mkdirSync(this.storagePath);
+        }
+        fs.appendFileSync(destFile, Buffer.from(asset.data as unknown as ArrayBuffer));
+        if (!extensionApi.env.isWindows) {
+          const stat = fs.statSync(destFile);
+          fs.chmodSync(destFile, stat.mode | fs.constants.S_IXUSR);
+        }
+
+        // Explain to the user that the binary has been successfully installed to the storage path
+        // prompt and ask if they want to install it system-wide (copied to /usr/bin/, or AppData for Windows)
+        const result = await this.withConfirmation(
+          `Kind binary has been successfully downloaded to ${destFile}.\n\nWould you like to install it system-wide for accessibility on the command line? This will require administrative privileges.`,
+        );
+        if (!result) {
+          return destFile;
+        }
+
+        try {
+          // Move the binary file to the system from destFile and rename to 'kind'
+          const systemPath = await installBinaryToSystem(destFile, 'kind');
+          await extensionApi.window.showInformationMessage('Kind binary has been successfully installed system-wide.');
+          this.telemetryLogger.logUsage('install-kind-downloaded');
+          extensionApi.window.showNotification({ body: 'Kind is successfully installed.' });
+          return systemPath;
+        } catch (error) {
+          console.error(error);
+          await extensionApi.window.showErrorMessage(`Unable to install kind binary: ${error}`);
+          throw error;
+        }
+      },
+    );
   }
 }

--- a/extensions/kind/src/util.ts
+++ b/extensions/kind/src/util.ts
@@ -122,10 +122,8 @@ export async function whereBinary(executable: string): Promise<string> {
 
 // Takes a binary path (e.g. /tmp/kind) and installs it to the system. Renames it based on binaryName
 export async function installBinaryToSystem(binaryPath: string, binaryName: string): Promise<string> {
-  const system = process.platform;
-
   // Before copying the file, make sure it's executable (chmod +x) for Linux and Mac
-  if (!extensionApi.env.isWindows) {
+  if (extensionApi.env.isLinux || extensionApi.env.isMac) {
     try {
       await extensionApi.process.exec('chmod', ['+x', binaryPath]);
       console.log(`Made ${binaryPath} executable`);
@@ -139,7 +137,7 @@ export async function installBinaryToSystem(binaryPath: string, binaryName: stri
   const destinationPath: string = getSystemBinaryPath(binaryName);
   let command: string;
   let args: string[];
-  if (system === 'win32') {
+  if (extensionApi.env.isWindows) {
     command = 'copy';
     args = [`"${binaryPath}"`, `"${destinationPath}"`];
   } else {

--- a/extensions/kind/src/util.ts
+++ b/extensions/kind/src/util.ts
@@ -68,7 +68,12 @@ export function parseKindVersion(raw: string): string {
   throw new Error('malformed kind output');
 }
 
+/**
+ * Return the version and the path of an executable
+ * @param executable
+ */
 export async function getKindBinaryInfo(executable: string): Promise<{ version: string; path: string }> {
+  // if absolute we do not include PATH
   if (isAbsolute(executable)) {
     const { stdout } = await extensionApi.process.exec(executable, ['--version']);
     return {
@@ -80,11 +85,15 @@ export async function getKindBinaryInfo(executable: string): Promise<{ version: 
     const { stdout } = await extensionApi.process.exec(executable, ['--version'], { env: { PATH: kindPath } });
     return {
       version: parseKindVersion(stdout),
-      path: await whereBinary(executable),
+      path: await whereBinary(executable), // we need to where/which the executable to find its real path
     };
   }
 }
 
+/**
+ * Given an executable name will find where it is installed on the system
+ * @param executable
+ */
 export async function whereBinary(executable: string): Promise<string> {
   const kindPath = getKindPath() ?? '';
   // grab full path for Linux and mac


### PR DESCRIPTION
### What does this PR do?

The kind extension is able to install the `kind` binary from the [kubernetes-sigs/kind](https://github.com/kubernetes-sigs/kind). It makes sense it register it and makes it visible in the CLI Tools page.

> ⚠️ This PR does not include the update mechanism as it is not supported currently by the extension. 

### Screenshot / video of UI

![image](https://github.com/containers/podman-desktop/assets/42176370/7b2c24f4-961c-4c88-9d92-336541f357ff)

https://github.com/containers/podman-desktop/assets/42176370/a04a5201-3208-4bfc-b2b4-40c47f93aa31

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop/issues/8031

### How to test this PR?

- [x] Tests are covering the bug fix or the new feature

**Manually**

(1) Remove kind from system and extension storage
(2) Start podman-desktop and install from status bar
(3) Go to Cli page
