### PR TITLE
chore: increase max-old-space lint-staged

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
   },
   "lint-staged": {
     "*.{js,ts,tsx,svelte}": [
-      "node --max-old-space-size=4096 node_modules/eslint/bin/eslint.js --cache --fix",
+      "node --max-old-space-size=6144 node_modules/eslint/bin/eslint.js --cache --fix",
       "prettier --cache --write"
     ],
     "*.{md,css,json}": "prettier --write"


### PR DESCRIPTION
### What does this PR do?

I had a javascript memory heap exception recently with a PR with a lot of changes. Increase `--max-old-space` fixed it`.

The value is already at 6444 in other places

https://github.com/containers/podman-desktop/blob/03c794b72521abc53dd98919572ca2b73215ba0e/package.json#L83
https://github.com/containers/podman-desktop/blob/03c794b72521abc53dd98919572ca2b73215ba0e/package.json#L84

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
