### PR TITLE
chore: adding storybook to the @storybook group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,7 @@ updates:
         patterns:
           - "@storybook/*"
           - "storybook"
+          - "storybook-dark-mode"
       docusaurus:
         applies-to: version-updates
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,7 @@ updates:
         applies-to: version-updates
         patterns:
           - "@storybook/*"
+          - "storybook"
       docusaurus:
         applies-to: version-updates
         patterns:


### PR DESCRIPTION
### What does this PR do?

Those two dependency do not get updated with the other sotrybook dependencies because they do not start with `@`

https://github.com/containers/podman-desktop/blob/59dcff63dd3eb3e6038f3065bfa04e4e65103ebe/storybook/package.json#L42-L43

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
