### PR TITLE
chore: light mode for dashboard notifications

### DIFF
--- a/packages/renderer/src/lib/dashboard/NotificationCardItem.svelte
+++ b/packages/renderer/src/lib/dashboard/NotificationCardItem.svelte
@@ -13,16 +13,23 @@ async function removeNotification(id: number) {
 }
 </script>
 
-<div class="relative bg-charcoal-700 w-full py-4 px-5 rounded-sm" role="region" aria-label="id: {notification.id}">
+<div
+  class="relative bg-[var(--pd-content-card-carousel-card-bg)] w-full py-4 px-5 rounded-md"
+  role="region"
+  aria-label="id: {notification.id}">
   <div class="flex flex-row">
     <div class="mr-3">
       {#if notification.type === 'info'}
-        <Fa size="1.5x" class="text-purple-400" icon="{faCircleInfo}" />
+        <Fa size="1.5x" class="text-[var(--pd-notification-dot)]" icon="{faCircleInfo}" />
       {/if}
     </div>
     <div class="flex flex-col space-y-2">
-      <div class="font-bold" aria-label="Notification title">{notification.title}</div>
-      <div aria-label="Notification description"><Markdown markdown="{notification.body ?? ''}" /></div>
+      <div class="text-[var(--pd-content-card-carousel-card-header-text)] font-bold" aria-label="Notification title">
+        {notification.title}
+      </div>
+      <div class="text-[var(--pd-content-card-carousel-card-text)]" aria-label="Notification description">
+        <Markdown markdown="{notification.body ?? ''}" />
+      </div>
     </div>
   </div>
   {#if notification.markdownActions}
@@ -30,7 +37,7 @@ async function removeNotification(id: number) {
       <Markdown markdown="{notification.markdownActions}" />
     </div>
   {/if}
-  <div class="absolute top-2 right-2">
+  <div class="absolute top-2 right-2 text-[var(--pd-content-card-carousel-card-header-text)]">
     <button
       on:click="{() => removeNotification(notification.id)}"
       aria-label="{`Delete notification ${notification.id}`}">

--- a/packages/renderer/src/lib/dashboard/NotificationsBox.svelte
+++ b/packages/renderer/src/lib/dashboard/NotificationsBox.svelte
@@ -25,9 +25,9 @@ onDestroy(() => {
 </script>
 
 {#if notifications.length > 0}
-  <div class="bg-charcoal-800 m-5 px-5 py-4 rounded-lg">
+  <div class="bg-[var(--pd-content-card-bg)] m-5 px-5 py-4 rounded-lg">
     <div class="flex flex-col items-center justify-content space-y-3" role="region" aria-label="Notifications Box">
-      <span class="text-white mb-1">Notifications</span>
+      <span class="text-[var(--pd-content-card-header-text)] text-lg font-semibold self-start mb-1">Notifications</span>
       {#each notifications as notification}
         <NotificationCardItem notification="{notification}" />
       {/each}


### PR DESCRIPTION
### What does this PR do?

Adds standard light mode colors to the notification area. Makes the icon have the same color as the notification dot.

Notifications weren't consistent with the Learning Center (which is the newer/more recent design) so I did some minor things to make it more consistent: rounded corners on the cards, header bigger, left, and left-justified.

### Screenshot / video of UI

<img width="968" alt="Screenshot 2024-07-12 at 10 11 06 AM" src="https://github.com/user-attachments/assets/06d32d30-454b-4a92-a979-f874dbd4ed3f">
<img width="968" alt="Screenshot 2024-07-12 at 10 11 24 AM" src="https://github.com/user-attachments/assets/0e373336-9a07-4ab9-bdc1-cd3b7dba1a1c">

### What issues does this PR fix or reference?

Fixes #7998.

### How to test this PR?

Uninstall Podman or do something to make a notification appear.