### PR TITLE
feat: move column underneath name for k8s

### DIFF
--- a/packages/renderer/src/lib/deployments/DeploymentColumnName.spec.ts
+++ b/packages/renderer/src/lib/deployments/DeploymentColumnName.spec.ts
@@ -56,3 +56,10 @@ test('Expect clicking works', async () => {
 
   expect(routerGotoSpy).toBeCalledWith('/deployments/my-deployment/default/summary');
 });
+
+test('Expect to show namespace in column', async () => {
+  render(DeploymentColumnName, { object: deployment });
+
+  const text = screen.getByText(deployment.namespace);
+  expect(text).toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/deployments/DeploymentColumnName.svelte
+++ b/packages/renderer/src/lib/deployments/DeploymentColumnName.svelte
@@ -14,4 +14,9 @@ function openDetails() {
   <div class="text-[var(--pd-table-body-text-highlight)] max-w-full overflow-hidden text-ellipsis">
     {object.name}
   </div>
+  <div class="flex flex-row text-sm gap-1">
+    {#if object.namespace}
+      <div class="font-extra-light text-[var(--pd-table-body-text)]">{object.namespace}</div>
+    {/if}
+  </div>
 </button>

--- a/packages/renderer/src/lib/deployments/DeploymentsList.spec.ts
+++ b/packages/renderer/src/lib/deployments/DeploymentsList.spec.ts
@@ -85,10 +85,8 @@ test('Expect deployments list', async () => {
 
   await waitRender({});
 
-  const deploymentName = screen.getByRole('cell', { name: 'my-deployment' });
-  const deploymentNamespace = screen.getByRole('cell', { name: 'test-namespace' });
+  const deploymentName = screen.getByRole('cell', { name: 'my-deployment test-namespace' });
   expect(deploymentName).toBeInTheDocument();
-  expect(deploymentNamespace).toBeInTheDocument();
 });
 
 test('Expect correct column overflow', async () => {
@@ -120,15 +118,14 @@ test('Expect correct column overflow', async () => {
 
   const cells = await within(rows[1]).findAllByRole('cell');
   expect(cells).toBeDefined();
-  expect(cells.length).toBe(9);
+  expect(cells.length).toBe(8);
 
   expect(cells[2]).toHaveClass('overflow-hidden');
   expect(cells[3]).toHaveClass('overflow-hidden');
-  expect(cells[4]).toHaveClass('overflow-hidden');
-  expect(cells[5]).not.toHaveClass('overflow-hidden');
+  expect(cells[4]).not.toHaveClass('overflow-hidden');
+  expect(cells[5]).toHaveClass('overflow-hidden');
   expect(cells[6]).toHaveClass('overflow-hidden');
   expect(cells[7]).toHaveClass('overflow-hidden');
-  expect(cells[8]).toHaveClass('overflow-hidden');
 });
 
 test('Expect filter empty screen', async () => {

--- a/packages/renderer/src/lib/deployments/DeploymentsList.svelte
+++ b/packages/renderer/src/lib/deployments/DeploymentsList.svelte
@@ -8,7 +8,6 @@ import {
   TableColumn,
   TableDurationColumn,
   TableRow,
-  TableSimpleColumn,
 } from '@podman-desktop/ui-svelte';
 import moment from 'moment';
 import { onMount } from 'svelte';
@@ -84,12 +83,6 @@ let nameColumn = new TableColumn<DeploymentUI>('Name', {
   comparator: (a, b) => a.name.localeCompare(b.name),
 });
 
-let namespaceColumn = new TableColumn<DeploymentUI, string>('Namespace', {
-  renderMapping: deployment => deployment.namespace,
-  renderer: TableSimpleColumn,
-  comparator: (a, b) => a.namespace.localeCompare(b.namespace),
-});
-
 let conditionsColumn = new TableColumn<DeploymentUI>('Conditions', {
   width: '2fr',
   overflow: true,
@@ -109,7 +102,6 @@ let ageColumn = new TableColumn<DeploymentUI, Date | undefined>('Age', {
 const columns = [
   statusColumn,
   nameColumn,
-  namespaceColumn,
   conditionsColumn,
   podsColumn,
   ageColumn,

--- a/packages/renderer/src/lib/ingresses-routes/IngressRouteColumnName.spec.ts
+++ b/packages/renderer/src/lib/ingresses-routes/IngressRouteColumnName.spec.ts
@@ -90,3 +90,10 @@ test('Expect clicking on Route works', async () => {
 
   expect(routerGotoSpy).toBeCalledWith('/ingressesRoutes/route/my-route/test-namespace/summary');
 });
+
+test('Expect to show namespace in column', async () => {
+  render(IngressRouteColumnName, { object: routeUI });
+
+  const text = screen.getByText(routeUI.namespace);
+  expect(text).toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/ingresses-routes/IngressRouteColumnName.svelte
+++ b/packages/renderer/src/lib/ingresses-routes/IngressRouteColumnName.svelte
@@ -21,4 +21,9 @@ function openDetails() {
   <div class="text-[var(--pd-table-body-text-highlight)] max-w-full overflow-hidden text-ellipsis">
     {object.name}
   </div>
+  <div class="flex flex-row text-sm gap-1">
+    {#if object.namespace}
+      <div class="font-extra-light text-[var(--pd-table-body-text)]">{object.namespace}</div>
+    {/if}
+  </div>
 </button>

--- a/packages/renderer/src/lib/ingresses-routes/IngressesRoutesList.spec.ts
+++ b/packages/renderer/src/lib/ingresses-routes/IngressesRoutesList.spec.ts
@@ -125,9 +125,9 @@ test('Expect element in ingresses list', async () => {
 
   await waitRender({});
 
-  const ingressName = screen.getByRole('cell', { name: 'my-ingress' });
+  const ingressName = screen.getByRole('cell', { name: 'my-ingress test-namespace' });
   expect(ingressName).toBeInTheDocument();
-  const routeName = screen.getByRole('cell', { name: 'my-route' });
+  const routeName = screen.getByRole('cell', { name: 'my-route test-namespace' });
   expect(routeName).toBeInTheDocument();
 });
 

--- a/packages/renderer/src/lib/ingresses-routes/IngressesRoutesList.svelte
+++ b/packages/renderer/src/lib/ingresses-routes/IngressesRoutesList.svelte
@@ -8,7 +8,6 @@ import {
   TableColumn,
   TableDurationColumn,
   TableRow,
-  TableSimpleColumn,
 } from '@podman-desktop/ui-svelte';
 import moment from 'moment';
 import { onDestroy, onMount } from 'svelte';
@@ -114,12 +113,6 @@ let nameColumn = new TableColumn<IngressUI | RouteUI>('Name', {
   comparator: (a, b) => a.name.localeCompare(b.name),
 });
 
-let namespaceColumn = new TableColumn<IngressUI | RouteUI, string>('Namespace', {
-  renderMapping: ingressRoute => ingressRoute.namespace,
-  renderer: TableSimpleColumn,
-  comparator: (a, b) => a.namespace.localeCompare(b.namespace),
-});
-
 let pathColumn = new TableColumn<IngressUI | RouteUI>('Host/Path', {
   width: '1.5fr',
   renderer: IngressRouteColumnHostPath,
@@ -153,7 +146,6 @@ function compareBackend(object1: IngressUI | RouteUI, object2: IngressUI | Route
 const columns = [
   statusColumn,
   nameColumn,
-  namespaceColumn,
   pathColumn,
   backendColumn,
   ageColumn,

--- a/packages/renderer/src/lib/pvc/PVCColumnName.spec.ts
+++ b/packages/renderer/src/lib/pvc/PVCColumnName.spec.ts
@@ -56,3 +56,10 @@ test('Expect clicking works', async () => {
 
   expect(routerGotoSpy).toBeCalledWith('/persistentvolumeclaims/my-pvc/default/summary');
 });
+
+test('Expect to show namespace in column', async () => {
+  render(PVCColumnName, { object: fakePVC });
+
+  const text = screen.getByText(fakePVC.namespace);
+  expect(text).toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/pvc/PVCColumnName.svelte
+++ b/packages/renderer/src/lib/pvc/PVCColumnName.svelte
@@ -14,4 +14,9 @@ function openDetails() {
   <div class="max-w-full overflow-hidden text-ellipsis text-[var(--pd-table-body-text-highlight)]">
     {object.name}
   </div>
+  <div class="flex flex-row text-sm gap-1">
+    {#if object.namespace}
+      <div class="font-extra-light text-[var(--pd-table-body-text)]">{object.namespace}</div>
+    {/if}
+  </div>
 </button>

--- a/packages/renderer/src/lib/pvc/PVCList.spec.ts
+++ b/packages/renderer/src/lib/pvc/PVCList.spec.ts
@@ -87,11 +87,8 @@ test('Expect PVC list', async () => {
 
   await waitRender({});
 
-  const pvcName = screen.getByRole('cell', { name: 'pvc1' });
+  const pvcName = screen.getByRole('cell', { name: 'pvc1 default' });
   expect(pvcName).toBeInTheDocument();
-
-  const pvcNamespace = screen.getByRole('cell', { name: 'default' });
-  expect(pvcNamespace).toBeInTheDocument();
 });
 
 test('Expect user confirmation to pop up when preferences require', async () => {
@@ -110,7 +107,7 @@ test('Expect user confirmation to pop up when preferences require', async () => 
 
   await waitRender({});
 
-  const pvcName1 = screen.getByRole('cell', { name: 'pvc12' });
+  const pvcName1 = screen.getByRole('cell', { name: 'pvc12 default' });
   expect(pvcName1).toBeInTheDocument();
 
   const checkboxes = screen.getAllByRole('checkbox', { name: 'Toggle PVC' });

--- a/packages/renderer/src/lib/pvc/PVCList.svelte
+++ b/packages/renderer/src/lib/pvc/PVCList.svelte
@@ -89,12 +89,6 @@ let storageClassColumn = new TableColumn<PVCUI, string>('Storage', {
   comparator: (a, b) => a.storageClass.localeCompare(b.storageClass),
 });
 
-let namespaceColumn = new TableColumn<PVCUI, string>('Namespace', {
-  renderMapping: pvc => pvc.namespace,
-  renderer: TableSimpleColumn,
-  comparator: (a, b) => a.namespace.localeCompare(b.namespace),
-});
-
 let accessModesColumn = new TableColumn<PVCUI>('Mode', {
   renderer: PvcColumnMode,
   overflow: true,
@@ -116,7 +110,6 @@ let ageColumn = new TableColumn<PVCUI, Date | undefined>('Age', {
 const columns = [
   statusColumn,
   nameColumn,
-  namespaceColumn,
   accessModesColumn,
   storageClassColumn,
   sizeColumn,

--- a/packages/renderer/src/lib/service/ServiceColumnName.spec.ts
+++ b/packages/renderer/src/lib/service/ServiceColumnName.spec.ts
@@ -68,3 +68,10 @@ test('If loadBalancerIPs is set, expect it to be displayed', async () => {
   const loadBalancerIPs = screen.getByText(service.loadBalancerIPs);
   expect(loadBalancerIPs).toBeInTheDocument();
 });
+
+test('Expect to show namespace in column', async () => {
+  render(ServiceColumnName, { object: JSON.parse(JSON.stringify(service)) });
+
+  const text = screen.getByText(service.namespace);
+  expect(text).toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/service/ServiceColumnName.svelte
+++ b/packages/renderer/src/lib/service/ServiceColumnName.svelte
@@ -14,7 +14,12 @@ function openDetails() {
   <div class="text-[var(--pd-table-body-text-highlight)] max-w-full overflow-hidden text-ellipsis">
     {object.name}
   </div>
-  {#if object.loadBalancerIPs}
-    <div class="text-sm text-[var(--pd-table-body-text-sub-secondary)]">{object.loadBalancerIPs}</div>
-  {/if}
+  <div class="flex flex-row text-sm gap-1">
+    {#if object.loadBalancerIPs}
+      <div class="text-[var(--pd-table-body-text-sub-secondary)]">{object.loadBalancerIPs}</div>
+    {/if}
+    {#if object.namespace}
+      <div class="font-extra-light text-[var(--pd-table-body-text)]">{object.namespace}</div>
+    {/if}
+  </div>
 </button>

--- a/packages/renderer/src/lib/service/ServicesList.spec.ts
+++ b/packages/renderer/src/lib/service/ServicesList.spec.ts
@@ -68,6 +68,7 @@ test('Expect services list', async () => {
     kind: 'Service',
     metadata: {
       name: 'my-service',
+      namespace: 'test-namespace',
     },
     spec: {
       selector: {},
@@ -84,7 +85,7 @@ test('Expect services list', async () => {
 
   await waitRender({});
 
-  const serviceName = screen.getByRole('cell', { name: 'my-service' });
+  const serviceName = screen.getByRole('cell', { name: 'my-service test-namespace' });
   expect(serviceName).toBeInTheDocument();
 });
 

--- a/packages/renderer/src/lib/service/ServicesList.svelte
+++ b/packages/renderer/src/lib/service/ServicesList.svelte
@@ -76,14 +76,9 @@ let statusColumn = new TableColumn<ServiceUI>('Status', {
 });
 
 let nameColumn = new TableColumn<ServiceUI>('Name', {
+  width: '1.3fr',
   renderer: ServiceColumnName,
   comparator: (a, b) => a.name.localeCompare(b.name),
-});
-
-let namespaceColumn = new TableColumn<ServiceUI, string>('Namespace', {
-  renderMapping: service => service.namespace,
-  renderer: TableSimpleColumn,
-  comparator: (a, b) => a.namespace.localeCompare(b.namespace),
 });
 
 let typeColumn = new TableColumn<ServiceUI>('Type', {
@@ -114,7 +109,6 @@ let ageColumn = new TableColumn<ServiceUI, Date | undefined>('Age', {
 const columns = [
   statusColumn,
   nameColumn,
-  namespaceColumn,
   typeColumn,
   clusterIPColumn,
   portsColumn,


### PR DESCRIPTION
feat: move column underneath name for k8s

### What does this PR do?

* Removes the namespace column and moves it to underneath the name,
  mimicking other parts of PD.
* Improves list styling
* Checks if namespace is available before showing it (sometimes it will
  not show namespace if it hasn't 100% deployed yet).

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->
![Screenshot 2024-07-12 at 10 23 07 AM](https://github.com/user-attachments/assets/a3048d95-8a89-4133-8242-2664f5b7434d)



### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop/issues/7474

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature

Go through each k8s page.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
