### PR TITLE
chore: light mode for dashboard recommendations banner

### DIFF
--- a/packages/renderer/src/lib/featured/FeaturedExtension.svelte
+++ b/packages/renderer/src/lib/featured/FeaturedExtension.svelte
@@ -20,7 +20,7 @@ export let displayTitle: boolean = false;
   aria-label="{featuredExtension.displayName}">
   <div class="flex flex-col flex-1">
     {#if displayTitle}
-      <span class="text-sm font-bold mb-1.5">EXTENSION</span>
+      <span class="text-sm font-bold mb-1.5 text-[var(--pd-details-card-text)]">EXTENSION</span>
     {/if}
     <div class="flex flex-row place-items-center flex-1">
       <div>
@@ -29,7 +29,7 @@ export let displayTitle: boolean = false;
           alt="{featuredExtension.displayName} logo"
           src="{featuredExtension.icon}" />
       </div>
-      <div class="flex flex-1 mx-2 cursor-default font-bold justify-start">
+      <div class="flex flex-1 mx-2 cursor-default font-bold justify-start text-[var(--pd-details-body-text)]">
         {featuredExtension.displayName}
       </div>
       <div class="h-full w-18 flex flex-col items-end place-content-center">


### PR DESCRIPTION
chore: light mode for dashboard recommendations banner

### What does this PR do?

Adds light mode for the dashboard banner

### Screenshot / video of UI


![Screenshot 2024-07-12 at 11 12 18 AM](https://github.com/user-attachments/assets/9a8444a3-9483-4b93-9856-c21971633d45)
g the difference -->

![Screenshot 2024-07-12 at 11 12 30 AM](https://github.com/user-attachments/assets/7e410c19-8bc0-4ad1-b72e-8f612baa43f3)


### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop/issues/7608

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

View the dashboard with light and dark mode.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
