### PR TITLE
fix: icon alignment on featured extension download component

### DIFF
--- a/packages/renderer/src/lib/featured/FeaturedExtensionDownload.svelte
+++ b/packages/renderer/src/lib/featured/FeaturedExtensionDownload.svelte
@@ -71,9 +71,7 @@ async function installExtension() {
   on:click="{() => installExtension()}"
   hidden="{!extension.fetchable}"
   title="Install {extension.displayName} v{extension.fetchVersion} Extension"
-  class="border-2 relative rounded border-[var(--pd-button-secondary)] text-[var(--pd-button-secondary)] hover:text-[var(--pd-button-text)] hover:bg-[var(--pd-button-secondary-hover)] hover:border-[var(--pd-button-secondary-hover)] w-10 p-2 text-center cursor-pointer flex flex-row">
-  <!--<Fa  class="ml-1.5" size="16" icon={faDownload} />-->
-  <span class="ml-0.5"></span>
+  class="border-2 relative rounded border-[var(--pd-button-secondary)] text-[var(--pd-button-secondary)] hover:text-[var(--pd-button-text)] hover:bg-[var(--pd-button-secondary-hover)] hover:border-[var(--pd-button-secondary-hover)] w-10 p-2 text-center cursor-pointer flex flex-row justify-center">
   <LoadingIcon
     icon="{faDownload}"
     iconSize="1x"


### PR DESCRIPTION
### What does this PR do?

Following https://github.com/containers/podman-desktop/pull/7995, the download icon was not centered 

### Screenshot / video of UI

| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/bd9789d4-3d02-4aea-9654-9c6d391062c8) | ![image](https://github.com/user-attachments/assets/cf97fe9d-f0e9-4aaf-b082-08b3d10b1d8b) |
| ![image](https://github.com/user-attachments/assets/dc6b626a-a766-47d5-932d-3effc452767e) | ![image](https://github.com/user-attachments/assets/34cfa629-0178-4d3e-98f7-9ca937f8730d) |

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
