### PR TITLE
chore: default text color using variable

### DIFF
--- a/packages/renderer/index.html
+++ b/packages/renderer/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1.0" />
     <title>Podman Desktop</title>
   </head>
-  <body class="overflow-hidden text-white text-base">
+  <body class="overflow-hidden text-[var(--pd-default-text)] text-base">
     <div id="app"></div>
     <script type="module" src="/src/main.ts"></script>
   </body>


### PR DESCRIPTION
### What does this PR do?

Replacement for #7729.

We should not hardcode the default text colour to white. Although it rarely shows up in practice, it's better for it to match the current theme so that you don't end up with white on white (e.g. see #7708).

There were a number of blockers before, because we didn't have enough light mode done. However, we're only a few issues from the end and all major screens have either been done or are imminent, so time to make this change too.

### Screenshot / video of UI

In theory, no difference. In practice, Troubleshooting page #7343 will be harder to read until we do minimal light mode. Task manager #7344 will be worse too, but PR already merged there, just not on this branch.

### What issues does this PR fix or reference?

Fixes #7724.

### How to test this PR?

Really quick pass to confirm no change.