### PR TITLE
nit: fix capitalization in search bar

### DIFF
--- a/packages/renderer/src/lib/ingresses-routes/IngressesRoutesList.svelte
+++ b/packages/renderer/src/lib/ingresses-routes/IngressesRoutesList.svelte
@@ -163,7 +163,7 @@ const columns = [
 const row = new TableRow<IngressUI | RouteUI>({ selectable: _ingressRoute => true });
 </script>
 
-<NavPage bind:searchTerm="{searchTerm}" title="Ingresses & Routes">
+<NavPage bind:searchTerm="{searchTerm}" title="ingresses & routes">
   <svelte:fragment slot="additional-actions">
     <KubeApplyYamlButton />
   </svelte:fragment>

--- a/packages/renderer/src/lib/pvc/PVCList.svelte
+++ b/packages/renderer/src/lib/pvc/PVCList.svelte
@@ -127,7 +127,7 @@ const columns = [
 const row = new TableRow<PVCUI>({ selectable: _pvc => true });
 </script>
 
-<NavPage bind:searchTerm="{searchTerm}" title="Persistent Volume Claims">
+<NavPage bind:searchTerm="{searchTerm}" title="persistent volume claims">
   <svelte:fragment slot="additional-actions">
     <KubeApplyYamlButton />
   </svelte:fragment>

--- a/packages/ui/src/lib/layouts/NavPage.svelte
+++ b/packages/ui/src/lib/layouts/NavPage.svelte
@@ -10,7 +10,7 @@ export let searchEnabled = true;
   <div class="flex flex-col w-full h-full pt-4" role="region" aria-label="{title}">
     <div class="flex pb-2" role="region" aria-label="header">
       <div class="px-5">
-        <h1 class="text-xl font-bold first-letter:uppercase text-[var(--pd-content-header)]">{title}</h1>
+        <h1 class="text-xl font-bold capitalize text-[var(--pd-content-header)]">{title}</h1>
       </div>
       <div class="flex flex-1 justify-end">
         <div class="px-5" role="group" aria-label="additionalActions">


### PR DESCRIPTION
### What does this PR do?

Wrong capitalization was due to NavPage only capitalizing the first letter in the title of the page. Fixing this allows us to fix these two pages.

### Screenshot / video of UI

Before:

<img width="345" alt="Screenshot 2024-07-12 at 2 38 07 PM" src="https://github.com/user-attachments/assets/415b0fdd-9aa0-46a6-ae05-92717f1f73e7">

After:

<img width="345" alt="Screenshot 2024-07-12 at 2 37 43 PM" src="https://github.com/user-attachments/assets/133a355c-828f-4103-8564-abcd4a17dcd7">

### What issues does this PR fix or reference?

Fixes #8062.

### How to test this PR?

Just open these two pages, then check others for regression.