### PR TITLE
fix: use markdown prop with Markdown component

### DIFF
--- a/packages/renderer/src/lib/dialogs/CustomPick.svelte
+++ b/packages/renderer/src/lib/dialogs/CustomPick.svelte
@@ -195,7 +195,7 @@ function dragMe(node: any) {
                     </div>
 
                     <div class="mb-2 text-xs">
-                      <Markdown>{innerItem.markDownContent}</Markdown>
+                      <Markdown markdown="{innerItem.markDownContent}" />
                     </div>
 
                     {#if usePopperForDetails || (innerItem.sections && innerItem.sections.length > 0 && itemSectionHiddenStatus.get((i / colsPerRow) * colsPerRow + j))}
@@ -267,7 +267,7 @@ function dragMe(node: any) {
                             <div
                               class="bg-charcoal-500 group-hover:bg-purple-800 group-[.is-selected]:bg-purple-800 px-4 py-2 flex flex-col text-xs border-x-2 border-transparent group-hover:border-purple-500"
                               class:rounded-b-md="{usePopperForDetails && i === innerItem.sections.length - 1}">
-                              <Markdown>{section.markDownContent}</Markdown>
+                              <Markdown markdown="{section.markDownContent}" />
                             </div>
                           {/if}
                         {/each}

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.svelte
@@ -503,7 +503,7 @@ function getConnectionResourceConfigurationValue(
                   {#if configurationKey.description}
                     {configurationKey.description}:
                   {:else if configurationKey.markdownDescription && configurationKey.type !== 'markdown'}
-                    <Markdown>{configurationKey.markdownDescription}:</Markdown>
+                    <Markdown markdown="{configurationKey.markdownDescription}" />
                   {/if}
                   {#if configurationKey.format === 'memory' || configurationKey.format === 'diskSize' || configurationKey.format === 'cpu'}
                     <div class="text-gray-600">

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItem.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItem.svelte
@@ -74,7 +74,7 @@ $: resetToDefault = false;
     </div>
     {#if recordUI.markdownDescription}
       <div class="pt-1 text-[color:var(--pd-invert-content-card-text)] text-sm pr-2">
-        <Markdown>{recordUI.markdownDescription}</Markdown>
+        <Markdown markdown="{recordUI.markdownDescription}" />
       </div>
     {:else}
       <div class="pt-1 text-[color:var(--pd-invert-content-card-text)] text-sm pr-2">{recordUI.description}</div>

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
@@ -142,7 +142,7 @@ async function onChange(recordId: string, value: boolean | string | number): Pro
     {/if}
   {:else if record.type === 'markdown'}
     <div class="text-sm">
-      <Markdown>{record.markdownDescription}</Markdown>
+      <Markdown markdown="{record.markdownDescription}" />
     </div>
   {/if}
 </div>

--- a/packages/renderer/src/lib/task-manager/TaskManagerItem.svelte
+++ b/packages/renderer/src/lib/task-manager/TaskManagerItem.svelte
@@ -80,7 +80,7 @@ function doExecuteAction(taskUI: StatefulTaskUI) {
       <div class="text-[var(--pd-modal-text)] text-xs my-2">{taskUI.description}</div>
       {#if taskUI.markdownActions}
         <div class="flex justify-end">
-          <Markdown>{taskUI.markdownActions}</Markdown>
+          <Markdown markdown="{taskUI.markdownActions}" />
         </div>
       {/if}
     {/if}


### PR DESCRIPTION
### What does this PR do?

This PR quickly fixes #8066 by using the markdown prop instead of the slot. Not sure why the slot way is not working anymore. I gave a look and the code seems correct, also tried to create a small reproducer on the svelte playground and behave correctly.  

### Screenshot / video of UI

![image](https://github.com/user-attachments/assets/f313fb7f-d4a0-47e9-816e-3c1ba07b9559)

### What issues does this PR fix or reference?

it resolves #8066 

### How to test this PR?

1. go to the create new page for podman and check all descriptions are visible or any other place where the markdown is used and verify the text is visible

- [ ] Tests are covering the bug fix or the new feature
