### PR TITLE
chore: consistent horizontal padding in extensions

### DIFF
--- a/packages/renderer/src/lib/extensions/CatalogExtensionList.svelte
+++ b/packages/renderer/src/lib/extensions/CatalogExtensionList.svelte
@@ -5,7 +5,7 @@ import CatalogExtension from './CatalogExtension.svelte';
 export let catalogExtensions: CatalogExtensionInfoUI[];
 </script>
 
-<div class="flex flex-col grow p-4">
+<div class="flex flex-col grow px-5 py-3">
   {#if catalogExtensions.length > 0}
     <div class="pb-4 text-[var(--pd-content-header)]">Available extensions</div>
   {/if}

--- a/packages/renderer/src/lib/extensions/ExtensionDetails.svelte
+++ b/packages/renderer/src/lib/extensions/ExtensionDetails.svelte
@@ -90,7 +90,7 @@ $: extension = derived(
     </svelte:fragment>
 
     <svelte:fragment slot="content">
-      <div class="flex w-full h-full overflow-y-auto p-4 flex-col lg:flex-row">
+      <div class="flex w-full h-full overflow-y-auto p-5 flex-col lg:flex-row">
         {#if screen === 'README'}
           <ExtensionDetailsSummaryCard extensionDetails="{$extension}" />
           <ExtensionDetailsReadme readme="{$extension.readme}" />

--- a/packages/renderer/src/lib/extensions/InstalledExtensionList.svelte
+++ b/packages/renderer/src/lib/extensions/InstalledExtensionList.svelte
@@ -6,7 +6,7 @@ import InstalledExtensionCard from './InstalledExtensionCard.svelte';
 export let extensionInfos: CombinedExtensionInfoUI[] = [];
 </script>
 
-<div class="grow p-4">
+<div class="grow px-5 py-3">
   {#each extensionInfos as extension}
     <InstalledExtensionCard extension="{extension}" />
   {/each}


### PR DESCRIPTION
### What does this PR do?

Makes the Extension page horizontal padding consistent with all the other pages (px-5). At the same time I reduced the vertical padding slightly since there was more of a vertical gap under the tabs compared to other pages and now it matches the spacing between the tiles.

### Screenshot / video of UI

Minor change, see #8074.

### What issues does this PR fix or reference?

Fixes #8074.

### How to test this PR?

Just open up Extensions page and compare padding to other pages.