### PR TITLE
fix: handle ignoreFocusOut on Modal and dialog visibility

### DIFF
--- a/packages/main/src/plugin/input-quickpick/input-quickpick-registry.ts
+++ b/packages/main/src/plugin/input-quickpick/input-quickpick-registry.ts
@@ -71,6 +71,7 @@ export class InputQuickPickRegistry {
       markdownDescription: options?.markdownDescription,
       multiline: options?.multiline,
       validate,
+      ignoreFocusOut: options?.ignoreFocusOut,
     };
 
     // need to send the options to the frontend
@@ -196,6 +197,7 @@ export class InputQuickPickRegistry {
       items: items,
       // need to callback to the frontend when selecting an item
       onSelectCallback,
+      ignoreFocusOut: options?.ignoreFocusOut,
     };
 
     // need to send the options to the frontend

--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -94,10 +94,10 @@ window.events?.receive('navigate', (navigationRequest: unknown) => {
     <WelcomePage />
 
     <div class="flex flex-row w-full h-full overflow-hidden">
-      <MessageBox />
       <QuickPickInput />
       <CustomPick />
       <CommandPalette />
+      <MessageBox />
       <AppNavigation meta={meta} exitSettingsCallback={() => router.goto(nonSettingsPage)} />
       {#if meta.url.startsWith('/preferences')}
         <PreferencesNavigation meta={meta} />

--- a/packages/renderer/src/lib/dialogs/Dialog.spec.ts
+++ b/packages/renderer/src/lib/dialogs/Dialog.spec.ts
@@ -18,7 +18,7 @@
 
 import '@testing-library/jest-dom/vitest';
 
-import { fireEvent, render, screen } from '@testing-library/svelte';
+import { render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { expect, test, vi } from 'vitest';
 
@@ -28,8 +28,8 @@ test('dialog should be visible and have basic styling', async () => {
   const title = 'A dialog';
   render(Dialog, { title: title });
 
-  const close = screen.getByLabelText('close');
-  expect(close).toBeDefined();
+  const bg = screen.getByLabelText('fade-bg');
+  expect(bg).toBeDefined();
   const dialog = screen.getByRole('dialog');
   expect(dialog).toBeDefined();
 
@@ -46,8 +46,8 @@ test('bg click should trigger close event', async () => {
   const closeMock = vi.fn();
   render(Dialog, { title: 'A dialog', onclose: closeMock });
 
-  const bg = screen.getByLabelText('close');
-  await fireEvent.click(bg);
+  const bg = screen.getByLabelText('fade-bg');
+  await userEvent.click(bg);
 
   expect(closeMock).toHaveBeenCalled();
 });

--- a/packages/renderer/src/lib/dialogs/QuickPickInput.svelte
+++ b/packages/renderer/src/lib/dialogs/QuickPickInput.svelte
@@ -19,6 +19,7 @@ let multiline = false;
 
 let validationEnabled = false;
 let validationError: string | undefined = '';
+let ignoreFocusOut = false;
 
 let onSelectCallbackEnabled = false;
 
@@ -50,6 +51,7 @@ const showInputCallback = (inputCallpackParameter: unknown) => {
   multiline = options?.multiline ?? false;
 
   validationEnabled = options?.validate ?? false;
+  ignoreFocusOut = options?.ignoreFocusOut ?? false;
   display = true;
   tick()
     .then(() => {
@@ -71,6 +73,7 @@ const showQuickPickCallback = (quickpickParameter: unknown) => {
   placeHolder = options?.placeHolder;
   title = options?.title;
   currentId = options?.id ?? 0;
+  ignoreFocusOut = options?.ignoreFocusOut ?? false;
   if (options?.prompt) {
     prompt = options.prompt;
   }
@@ -178,6 +181,7 @@ function cleanup() {
   quickPickCanPickMany = false;
   quickPickSelectedFilteredIndex = 0;
   quickPickSelectedIndex = 0;
+  ignoreFocusOut = false;
 }
 
 function validateQuickPick() {
@@ -277,19 +281,12 @@ function handleKeydown(e: KeyboardEvent) {
     }
   }
 }
-
-function handleMousedown(e: MouseEvent) {
-  if (outerDiv && !e.defaultPrevented && e.target instanceof Node && !outerDiv.contains(e.target)) {
-    window.sendShowQuickPickValues(currentId, []);
-    cleanup();
-  }
-}
 </script>
 
-<svelte:window on:keydown={handleKeydown} on:mousedown={handleMousedown} />
+<svelte:window on:keydown={handleKeydown} />
 
 {#if display}
-  <Modal on:close={onClose} name={title} top>
+  <Modal on:close={onClose} name={title} top ignoreFocusOut={ignoreFocusOut}>
     <div class="flex justify-center items-center mt-1">
       <div
         bind:this={outerDiv}

--- a/packages/renderer/src/lib/dialogs/quickpick-input.ts
+++ b/packages/renderer/src/lib/dialogs/quickpick-input.ts
@@ -27,6 +27,7 @@ export interface QuickPickOptions {
   // if true, needs to send the current element when item is selected
   onSelectCallback: boolean;
   title?: string;
+  ignoreFocusOut?: boolean;
 }
 
 export interface InputBoxOptions {
@@ -40,6 +41,7 @@ export interface InputBoxOptions {
   multiline: boolean;
   id: number;
   title?: string;
+  ignoreFocusOut?: boolean;
 }
 
 export interface CustomPickOptions {

--- a/packages/ui/src/lib/modal/Modal.spec.ts
+++ b/packages/ui/src/lib/modal/Modal.spec.ts
@@ -18,7 +18,7 @@
 
 import '@testing-library/jest-dom/vitest';
 
-import { fireEvent, render, screen } from '@testing-library/svelte';
+import { render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, test, vi } from 'vitest';
 
@@ -27,7 +27,7 @@ import Modal from './Modal.svelte';
 test('modal should be visible', async () => {
   render(Modal);
 
-  const bg = screen.getByLabelText('close');
+  const bg = screen.getByLabelText('fade-bg');
   expect(bg).toBeDefined();
   const dialog = screen.getByRole('dialog');
   expect(dialog).toBeDefined();
@@ -37,10 +37,20 @@ test('bg click should trigger close event', async () => {
   const closeMock = vi.fn();
   render(Modal, { onclose: closeMock });
 
-  const bg = screen.getByLabelText('close');
-  await fireEvent.click(bg);
+  const bg = screen.getByLabelText('fade-bg');
+  await userEvent.click(bg);
 
   expect(closeMock).toHaveBeenCalled();
+});
+
+test('bg click should NOT trigger close event if ignoreFocusOut is true', async () => {
+  const closeMock = vi.fn();
+  render(Modal, { onclose: closeMock, ignoreFocusOut: true });
+
+  const bg = screen.getByLabelText('fade-bg');
+  await userEvent.click(bg);
+
+  expect(closeMock).not.toHaveBeenCalled();
 });
 
 test('Escape key should trigger close', async () => {

--- a/packages/ui/src/lib/modal/Modal.svelte
+++ b/packages/ui/src/lib/modal/Modal.svelte
@@ -8,6 +8,7 @@ const dispatch = createEventDispatcher();
 let modal: HTMLDivElement;
 export let name = '';
 export let top: boolean = false;
+export let ignoreFocusOut: boolean = false;
 export let onclose: () => void = () => {
   dispatch('close');
 };
@@ -30,16 +31,26 @@ if (previously_focused) {
     previously_focused.focus();
   });
 }
+
+function handleMousedown(e: MouseEvent): void {
+  // if click is outside modal but
+  if (modal && e.target instanceof Node && e.target !== modal && !modal.contains(e.target)) {
+    // if ignoreFocusOut is true, we do nothing and stop propagation of the click, else we dispatch the close
+    if (ignoreFocusOut) {
+      e.stopPropagation();
+    } else {
+      onclose();
+    }
+  }
+}
 </script>
 
-<svelte:window on:keydown={handle_keydown} />
+<svelte:window on:keydown={handle_keydown} on:mousedown={handleMousedown} />
 
 <div class:items-center={!top} class="fixed top-0 left-0 right-0 bottom-0 w-full h-full flex justify-center z-50">
-  <button
-    aria-label="close"
-    class="fixed top-0 left-0 w-full h-full bg-[var(--pd-modal-fade)] bg-blend-multiply opacity-60 z-40 cursor-default"
-    on:click={onclose}></button>
-
+  <div
+    class="fixed top-0 left-0 w-full h-full bg-[var(--pd-modal-fade)] bg-blend-multiply opacity-60 z-40 cursor-default">
+  </div>
   <div
     class:translate-y-[-5%]={!top}
     class:my-[32px]={top}

--- a/packages/ui/src/lib/modal/Modal.svelte
+++ b/packages/ui/src/lib/modal/Modal.svelte
@@ -49,6 +49,7 @@ function handleMousedown(e: MouseEvent): void {
 
 <div class:items-center={!top} class="fixed top-0 left-0 right-0 bottom-0 w-full h-full flex justify-center z-50">
   <div
+    aria-label="fade-bg"
     class="fixed top-0 left-0 w-full h-full bg-[var(--pd-modal-fade)] bg-blend-multiply opacity-60 z-40 cursor-default">
   </div>
   <div


### PR DESCRIPTION
### What does this PR do?

This PR fixes a couple of issues that were preventing to open a confirmation dialog from an inputbox (like done in CRC).
The main problem was that we have the `ignoreFocusOut` property but it is not handled at all in the UI, so the inputBox was closed everytime a user clicked out of it.

### Screenshot / video of UI

![ignorefocusout](https://github.com/user-attachments/assets/76df8bb2-971f-496b-a956-830e1b1818af)

### What issues does this PR fix or reference?

it resolves #7686 

### How to test this PR?

1. Install OpenShift Local and press 'Initialize and start' on dashboard
2. Wait until inputbox for pull-secret appears with link in description
3. Click on the link. You should be able to go to the browser and get back to desktop and add the pull secret value into the inputbox

- [ ] Tests are covering the bug fix or the new feature
