### PR TITLE
chore: improve aria/role labelling in tables

### DIFF
--- a/packages/ui/src/lib/table/Table.spec.ts
+++ b/packages/ui/src/lib/table/Table.spec.ts
@@ -46,6 +46,14 @@ test('Expect basic table layout', async () => {
   expect(rows[3].textContent).toContain('43');
 });
 
+test('Expect table has aria role and name', async () => {
+  render(TestTable, {});
+
+  const table = await screen.findByRole('table');
+  expect(table).toBeDefined();
+  expect(table).toHaveAccessibleName('people');
+});
+
 test('Expect basic column headers', async () => {
   render(TestTable, {});
 
@@ -136,15 +144,21 @@ test('Expect sorting by name works', async () => {
   expect(rows).toBeDefined();
   expect(rows.length).toBe(4);
   expect(rows[1].textContent).toContain('John');
+  expect(rows[1]).toHaveAccessibleName('John');
   expect(rows[2].textContent).toContain('Henry');
+  expect(rows[2]).toHaveAccessibleName('Henry');
   expect(rows[3].textContent).toContain('Charlie');
+  expect(rows[3]).toHaveAccessibleName('Charlie');
 
   await fireEvent.click(nameCol);
 
   rows = await screen.findAllByRole('row');
   expect(rows[1].textContent).toContain('Charlie');
+  expect(rows[1]).toHaveAccessibleName('Charlie');
   expect(rows[2].textContent).toContain('Henry');
+  expect(rows[2]).toHaveAccessibleName('Henry');
   expect(rows[3].textContent).toContain('John');
+  expect(rows[3]).toHaveAccessibleName('John');
 });
 
 test('Expect sorting by age sorts descending initially', async () => {

--- a/packages/ui/src/lib/table/Table.svelte
+++ b/packages/ui/src/lib/table/Table.svelte
@@ -180,7 +180,7 @@ function toggleChildren(name: string | undefined): void {
 }
 </script>
 
-<div class="w-full mx-5" class:hidden="{data.length === 0}" role="table">
+<div class="w-full mx-5" class:hidden="{data.length === 0}" role="table" aria-label="{kind}">
   <!-- Table header -->
   <div role="rowgroup">
     <div
@@ -228,7 +228,7 @@ function toggleChildren(name: string | undefined): void {
   <!-- Table body -->
   <div role="rowgroup">
     {#each data as object (object)}
-      <div class="min-h-[48px] h-fit bg-[var(--pd-content-card-bg)] rounded-lg mb-2" role="row">
+      <div class="min-h-[48px] h-fit bg-[var(--pd-content-card-bg)] rounded-lg mb-2">
         <div
           class="grid grid-table gap-x-0.5 min-h-[48px] hover:bg-[var(--pd-content-card-hover-bg)]"
           class:rounded-t-lg="{object.name &&
@@ -239,6 +239,7 @@ function toggleChildren(name: string | undefined): void {
             collapsed.includes(object.name) ||
             !row.info.children ||
             row.info.children(object).length === 0}"
+          role="row"
           aria-label="{object.name}">
           <div class="whitespace-nowrap place-self-center" role="cell">
             {#if row.info.children && row.info.children(object).length > 0}
@@ -286,6 +287,7 @@ function toggleChildren(name: string | undefined): void {
             <div
               class="grid grid-table gap-x-0.5 hover:bg-[var(--pd-content-card-hover-bg)]"
               class:rounded-b-lg="{i === row.info.children(object).length - 1}"
+              role="row"
               aria-label="{child.name}">
               <div class="whitespace-nowrap justify-self-start" role="cell"></div>
               {#if row.info.selectable}


### PR DESCRIPTION
### What does this PR do?

- Adds an aria label for the table. Will skip aria-describedby for now since we'd use the page title, which is redundant and unlikely to be used for e2e tests for the same reason.
- The 'row' role was incorrect when there are parents + children as these were marked as a single group. Moved this 'down' to the actual rows so every parent or child row has both role="row" and aria-label="{some name}".

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes #4967.

### How to test this PR?

Automated tests pass.

- [x] Tests are covering the bug fix or the new feature