### PR TITLE
chore: update pod columns, provider card

### DIFF
--- a/packages/renderer/src/lib/dashboard/ProviderCard.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderCard.svelte
@@ -15,11 +15,9 @@ export let provider: ProviderInfo;
   <div class="flex flex-col xl:flex-row gap-x-4">
     <div class="grid grid-cols-[3rem_1fr] w-full xl:w-1/4 gap-2">
       <IconImage image="{provider?.images?.icon}" class="mx-0 max-h-12" alt="{provider.name}"></IconImage>
-      <div
-        class="flex flex-col gap-0 text-[var(--pd-content-card-title)] text-lg whitespace-nowrap"
-        aria-label="context-name">
+      <div class="flex flex-col gap-0 text-[var(--pd-content-card-title)] whitespace-nowrap" aria-label="context-name">
         <div class="gap-1 items-center">
-          <span class="float-left mr-1">{provider.name}</span>
+          <span class="float-left mr-1 text-lg">{provider.name}</span>
           {#if provider.version}
             <div class="text-[var(--pd-content-card-light-title)] text-sm float-left" aria-label="Provider Version">
               v{provider.version}

--- a/packages/renderer/src/lib/deployments/DeploymentColumnPods.spec.ts
+++ b/packages/renderer/src/lib/deployments/DeploymentColumnPods.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,6 +38,5 @@ test('Expect simple column styling', async () => {
 
   const text = screen.getByText(deployment.ready + ' / ' + deployment.replicas);
   expect(text).toBeInTheDocument();
-  expect(text).toHaveClass('text-xs');
-  expect(text).toHaveClass('text-[var(--pd-table-body-text-highlight)]');
+  expect(text).toHaveClass('text-[var(--pd-table-body-text)]');
 });

--- a/packages/renderer/src/lib/deployments/DeploymentColumnPods.svelte
+++ b/packages/renderer/src/lib/deployments/DeploymentColumnPods.svelte
@@ -4,6 +4,6 @@ import type { DeploymentUI } from './DeploymentUI';
 export let object: DeploymentUI;
 </script>
 
-<div class="text-xs text-[var(--pd-table-body-text-highlight)]">
+<div class="text-[var(--pd-table-body-text)]">
   {object.ready} / {object.replicas}
 </div>


### PR DESCRIPTION
### What does this PR do?

Fixes two issues that are visible after the font/consistency change:
- Deployments pod column was missed, should be normal size and not highlighted.
- Provider card were setting a large font for the entire card instead of just the provider name, leading to abnormally large buttons. Only set it on the name.

### Screenshot / video of UI

<img width="263" alt="Screenshot 2024-07-15 at 2 47 02 PM" src="https://github.com/user-attachments/assets/e03f2784-a190-4cfd-8494-8a889929a8aa">

### What issues does this PR fix or reference?

Fixes #8088.

### How to test this PR?

Check dashboard, Deployments page.