### PR TITLE
chore: update the UI of the compose details summary page

### DIFF
--- a/packages/renderer/src/lib/compose/ComposeDetails.spec.ts
+++ b/packages/renderer/src/lib/compose/ComposeDetails.spec.ts
@@ -206,7 +206,7 @@ test('Simple test that compose summary is clickable and loadable', async () => {
   await fireEvent.click(summaryHref);
 
   // Check that 'Name:' is displayed meaning it has loaded correctly.
-  expect(screen.getByText('Name:')).toBeInTheDocument();
+  expect(screen.getByText('Name')).toBeInTheDocument();
 });
 
 test('Compose details inspect is clickable and loadable', async () => {

--- a/packages/renderer/src/lib/compose/ComposeDetailsSummary.spec.ts
+++ b/packages/renderer/src/lib/compose/ComposeDetailsSummary.spec.ts
@@ -1,0 +1,100 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/svelte';
+import { expect, test } from 'vitest';
+
+import { ContainerGroupInfoTypeUI, type ContainerInfoUI } from '../container/ContainerInfoUI';
+import ComposeDetailsSummary from './ComposeDetailsSummary.svelte';
+import type { ComposeInfoUI } from './ComposeInfoUI';
+
+const fakeContainer1: ContainerInfoUI = {
+  id: 'fakeContainerID1',
+  shortId: 'FC1',
+  name: 'fakeContainer1',
+  image: 'image1',
+  shortImage: 'img1',
+  engineId: 'Podman.podman',
+  engineName: 'Podman',
+  engineType: 'podman',
+  state: 'RUNNING',
+  uptime: '3 days',
+  startedAt: '2024-06-18T17:39:46.000Z',
+  ports: [],
+  portsAsString: '',
+  displayPort: '',
+  hasPublicPort: false,
+  groupInfo: {
+    name: 'group1',
+    type: ContainerGroupInfoTypeUI.STANDALONE,
+  },
+  selected: false,
+  created: 1234,
+  labels: {},
+  imageBase64RepoTag: 'fakeRepoTag',
+};
+
+const fakeContainer2: ContainerInfoUI = {
+  id: 'fakeContainerID2',
+  shortId: 'FC2',
+  name: 'fakeContainer2',
+  image: 'image1',
+  shortImage: 'img1',
+  engineId: 'Podman.podman',
+  engineName: 'Podman',
+  engineType: 'podman',
+  state: 'RUNNING',
+  uptime: '3 days',
+  startedAt: '2024-06-18T17:39:46.000Z',
+  ports: [],
+  portsAsString: '',
+  displayPort: '',
+  hasPublicPort: false,
+  groupInfo: {
+    name: 'group2',
+    type: ContainerGroupInfoTypeUI.STANDALONE,
+  },
+  selected: false,
+  created: 1234,
+  labels: {},
+  imageBase64RepoTag: 'fakeRepoTag',
+};
+
+const fakeCompose: ComposeInfoUI = {
+  engineId: 'Podman.podman',
+  engineType: 'podman',
+  name: 'fakeCompose',
+  status: 'Running',
+  containers: [fakeContainer1, fakeContainer2],
+};
+
+test('ContainerDetailsSummary renders with ContainerInfoUI object with a pod group', async () => {
+  render(ComposeDetailsSummary, { compose: fakeCompose });
+
+  // Check that the rendered text is correct
+  expect(screen.getByText('fakeCompose')).toBeInTheDocument();
+  expect(screen.getByText('podman')).toBeInTheDocument();
+  expect(screen.getByText('Podman.podman')).toBeInTheDocument();
+  expect(screen.getByText('Running')).toBeInTheDocument();
+  expect(screen.getByText('fakeContainer1')).toBeInTheDocument();
+  expect(screen.getByText('fakeContainer2')).toBeInTheDocument();
+  expect(screen.getByText('fakeContainerID1')).toBeInTheDocument();
+  expect(screen.getByText('fakeContainerID2')).toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/compose/ComposeDetailsSummary.svelte
+++ b/packages/renderer/src/lib/compose/ComposeDetailsSummary.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
+import { Link } from '@podman-desktop/ui-svelte';
 import { router } from 'tinro';
 
+import DetailsCell from '../details/DetailsCell.svelte';
+import DetailsTable from '../details/DetailsTable.svelte';
+import DetailsTitle from '../details/DetailsTitle.svelte';
 import type { ComposeInfoUI } from './ComposeInfoUI';
 
 export let compose: ComposeInfoUI;
@@ -10,30 +14,37 @@ function openContainer(containerID: string) {
 }
 </script>
 
-<div class="flex px-5 py-4 flex-col h-full overflow-auto text-[var(--pd-details-body-text)]">
-  <div class="w-full">
-    <table>
-      <tbody>
-        <tr>
-          <td class="pr-2">Name:</td>
-          <td>{compose.name}</td>
-        </tr>
-      </tbody>
-    </table>
-  </div>
+<DetailsTable>
+  <tr>
+    <DetailsTitle>Details</DetailsTitle>
+  </tr>
+  <tr>
+    <DetailsCell>Name</DetailsCell>
+    <DetailsCell>{compose.name}</DetailsCell>
+  </tr>
+  <tr>
+    <DetailsCell>Engine ID</DetailsCell>
+    <DetailsCell>{compose.engineId}</DetailsCell>
+  </tr>
+  <tr>
+    <DetailsCell>Engine type</DetailsCell>
+    <DetailsCell>{compose.engineType}</DetailsCell>
+  </tr>
+  <tr>
+    <DetailsCell>Status</DetailsCell>
+    <DetailsCell>{compose.status}</DetailsCell>
+  </tr>
   {#if compose.containers.length > 0}
-    <div class="w-full my-12">
-      <span>Containers using this Compose group:</span>
-      <table>
-        <tbody>
-          {#each compose.containers as container}
-            <tr class="cursor-pointer" on:click="{() => openContainer(container.id)}">
-              <td class="pr-2">{container.name}</td>
-              <td>{container.id}</td>
-            </tr>
-          {/each}
-        </tbody>
-      </table>
-    </div>
+    <tr>
+      <DetailsTitle>Containers in compose group</DetailsTitle>
+    </tr>
+    {#each compose.containers as container}
+      <tr>
+        <DetailsCell>
+          <Link on:click="{() => openContainer(container.id)}">{container.name}</Link>
+        </DetailsCell>
+        <DetailsCell>{container.id}</DetailsCell>
+      </tr>
+    {/each}
   {/if}
-</div>
+</DetailsTable>


### PR DESCRIPTION
### What does this PR do?

Updates the UI of the compose summary page

### Screenshot / video of UI
![Screenshot from 2024-07-15 15-01-25](https://github.com/user-attachments/assets/ce7c4f28-2c50-44bc-9ec1-206789446958)



<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop/issues/8059

### How to test this PR?

<!-- Please explain steps to verify the functionality, do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature

Go to the compose summary page