### PR TITLE
chore: statusbar notification dot overflow

### DIFF
--- a/packages/renderer/src/lib/statusbar/StatusBarItem.svelte
+++ b/packages/renderer/src/lib/statusbar/StatusBarItem.svelte
@@ -46,7 +46,6 @@ async function executeCommand(entry: StatusBarEntry) {
     <span class="ml-1">{entry.text}</span>
   {/if}
   {#if entry.highlight}
-    <span role="status" class="absolute bg-[var(--pd-notification-dot)] rounded-full p-1 top-[-2px] right-[-2px]"
-    ></span>
+    <span role="status" class="absolute bg-[var(--pd-notification-dot)] rounded-full p-1 top-[1px] right-[-1px]"></span>
   {/if}
 </button>


### PR DESCRIPTION
### What does this PR do?

The text size was reduced, causing the status bar to be slightly less tall and the notification dot to overflow. This PR moves the notification dot closer so that it doesn't go outside of the statusbar.

### Screenshot / video of UI

Show below with multiple dots so you can see it with different text/icons.

Before:

<img width="226" alt="Screenshot 2024-07-16 at 10 15 08 AM" src="https://github.com/user-attachments/assets/7d7a7dd1-9638-40e8-9eaf-602575762f3e">

After:

<img width="226" alt="Screenshot 2024-07-16 at 10 25 55 AM" src="https://github.com/user-attachments/assets/9ec878f6-6266-4d72-b4aa-6d8e524f68c0">

### What issues does this PR fix or reference?

Fixes #8080.

### How to test this PR?

Do something to trigger a notification.