### PR TITLE
feat: add manifest api for pushing

### DIFF
--- a/packages/api/src/manifest-info.ts
+++ b/packages/api/src/manifest-info.ts
@@ -46,3 +46,12 @@ export interface ManifestInspectInfo {
   mediaType: string;
   schemaVersion: number;
 }
+
+export interface ManifestPushOptions {
+  destination: string;
+  name: string;
+  all?: boolean;
+
+  // Provider to use for the manifest pushing, if not, we will default to the first one available
+  provider?: ContainerProviderConnection;
+}

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -440,7 +440,18 @@ declare module '@podman-desktop/api' {
 
   // Matches required API parameters of Podman options
   export interface ManifestPushOptions {
+    /**
+     * The destination of the manifest list to push.
+     * this can be the same as 'name' or a different one.
+     * @example
+     * "quay.io/myrepo/myotherdestination"
+     */
     destination: string;
+    /**
+     * The name of the manifest list to push
+     * @example
+     * "quay.io/myrepo/mymanifest"
+     */
     name: string;
     // Provider to use for the manifest pushing, if not, we will default to the first one available
     provider?: ContainerProviderConnection;

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -437,6 +437,15 @@ declare module '@podman-desktop/api' {
     // Provider to use for the manifest creation, if not, we will try to select the first one available (similar to podCreate)
     provider?: ContainerProviderConnection;
   }
+
+  // Matches required API parameters of Podman options
+  export interface ManifestPushOptions {
+    destination: string;
+    name: string;
+    // Provider to use for the manifest pushing, if not, we will default to the first one available
+    provider?: ContainerProviderConnection;
+  }
+
   export interface ManifestInspectInfo {
     engineId: string;
     engineName: string;
@@ -3670,6 +3679,7 @@ declare module '@podman-desktop/api' {
     // Manifest related methods
     export function createManifest(options: ManifestCreateOptions): Promise<{ engineId: string; Id: string }>;
     export function inspectManifest(engineId: string, id: string): Promise<ManifestInspectInfo>;
+    export function pushManifest(options: ManifestPushOptions): Promise<void>;
     export function removeManifest(engineId: string, id: string): Promise<void>;
   }
 

--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -3186,6 +3186,34 @@ test('check volume mounted is replicated when executing replicatePodmanContainer
   });
 });
 
+test('test that pushManifest does not error', async () => {
+  const pushManifestMock = vi.fn();
+
+  const fakeLibPod = {
+    podmanPushManifest: pushManifestMock,
+  } as unknown as LibPod;
+
+  containerRegistry.addInternalProvider('podman1', {
+    name: 'podman',
+    id: 'podman1',
+    libpodApi: fakeLibPod,
+    connection: {
+      type: 'podman',
+    },
+  } as unknown as InternalContainerProvider);
+
+  // Spy on the pushManifest function
+  const spyPushManifest = vi.spyOn(fakeLibPod, 'podmanPushManifest');
+
+  const result = await containerRegistry.pushManifest({ name: 'testid1', destination: 'testid1' });
+
+  // Expect PushManifest to be called
+  expect(spyPushManifest).toHaveBeenCalled();
+
+  // Expect to not error
+  expect(result).toBeUndefined();
+});
+
 test('check that createManifest returns an Id value after running podmanCreateManifest', async () => {
   const createManifestMock = vi.fn().mockResolvedValue({
     Id: 'testid1',

--- a/packages/main/src/plugin/dockerode/libpod-dockerode.spec.ts
+++ b/packages/main/src/plugin/dockerode/libpod-dockerode.spec.ts
@@ -274,6 +274,13 @@ test('Check create volume', async () => {
   expect(response.Scope).toBe('local');
 });
 
+test('Test push manifest', async () => {
+  nock('http://localhost').post('/v4.2.0/libpod/manifests/name1/registry/name2?all=true').reply(200);
+  const api = new Dockerode({ protocol: 'http', host: 'localhost' });
+  const manifest = await (api as unknown as LibPod).podmanPushManifest({ name: 'name1', destination: 'name2' });
+  expect(manifest).toBeDefined();
+});
+
 test('Test remove manifest', async () => {
   nock('http://localhost').delete('/v4.2.0/libpod/manifests/name1').reply(200);
   const api = new Dockerode({ protocol: 'http', host: 'localhost' });

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -1175,6 +1175,11 @@ export class ExtensionLoader {
       inspectManifest(engineId: string, id: string): Promise<containerDesktopAPI.ManifestInspectInfo> {
         return containerProviderRegistry.inspectManifest(engineId, id);
       },
+
+      pushManifest(manifestOptions: containerDesktopAPI.ManifestPushOptions): Promise<void> {
+        return containerProviderRegistry.pushManifest(manifestOptions);
+      },
+
       removeManifest(engineId: string, id: string): Promise<void> {
         return containerProviderRegistry.removeManifest(engineId, id);
       },

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -83,7 +83,7 @@ import type { ImageFilesInfo } from '/@api/image-files-info.js';
 import type { ImageInfo } from '/@api/image-info.js';
 import type { ImageInspectInfo } from '/@api/image-inspect-info.js';
 import type { ImageSearchOptions, ImageSearchResult } from '/@api/image-registry.js';
-import type { ManifestCreateOptions, ManifestInspectInfo } from '/@api/manifest-info.js';
+import type { ManifestCreateOptions, ManifestInspectInfo, ManifestPushOptions } from '/@api/manifest-info.js';
 import type { NetworkInspectInfo } from '/@api/network-info.js';
 import type { NotificationCard, NotificationCardOptions } from '/@api/notification.js';
 import type { OnboardingInfo, OnboardingStatus } from '/@api/onboarding.js';
@@ -796,6 +796,13 @@ export class PluginSystem {
       'container-provider-registry:createManifest',
       async (_listener, manifestOptions: ManifestCreateOptions): Promise<{ engineId: string; Id: string }> => {
         return containerProviderRegistry.createManifest(manifestOptions);
+      },
+    );
+
+    this.ipcHandle(
+      'container-provider-registry:pushManifest',
+      async (_listener, manifestOptions: ManifestPushOptions): Promise<void> => {
+        return containerProviderRegistry.pushManifest(manifestOptions);
       },
     );
 

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -64,7 +64,7 @@ import type { ImageFilesInfo } from '/@api/image-files-info';
 import type { ImageInfo } from '/@api/image-info';
 import type { ImageInspectInfo } from '/@api/image-inspect-info';
 import type { ImageSearchOptions, ImageSearchResult } from '/@api/image-registry';
-import type { ManifestCreateOptions, ManifestInspectInfo } from '/@api/manifest-info';
+import type { ManifestCreateOptions, ManifestInspectInfo, ManifestPushOptions } from '/@api/manifest-info';
 import type { NetworkInspectInfo } from '/@api/network-info';
 import type { NotificationCard, NotificationCardOptions } from '/@api/notification';
 import type { OnboardingInfo, OnboardingStatus } from '/@api/onboarding';
@@ -303,6 +303,9 @@ export function initExposure(): void {
       return ipcInvoke('container-provider-registry:inspectManifest', engine, manifestId);
     },
   );
+  contextBridge.exposeInMainWorld('pushManifest', async (pushOptions: ManifestPushOptions): Promise<void> => {
+    return ipcInvoke('container-provider-registry:pushManifest', pushOptions);
+  });
   contextBridge.exposeInMainWorld('removeManifest', async (engine: string, manifestId: string): Promise<void> => {
     return ipcInvoke('container-provider-registry:removeManifest', engine, manifestId);
   });


### PR DESCRIPTION
feat: add manifest api for pushing

### What does this PR do?

Took a while and found a bug regarding trying to push, but here is the
API for manifest pushing.

* Adds the API needed to push a manifest image
* Needs credentials, so does base64 encoding of credentials to API calls
* Requires ?all=true to work correctly.

There are other "optional" paramters (see:
https://docs.podman.io/en/latest/_static/api.html#tag/manifests/operation/ManifestPushLibpod), but we do not need to add them as
they are a not needed at the moment.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/A, API.

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop/issues/8057

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature
