### PR TITLE
chore(test): adding test finished hook call

### DIFF
--- a/tests/playwright/src/setupFiles/extended-hooks.ts
+++ b/tests/playwright/src/setupFiles/extended-hooks.ts
@@ -16,11 +16,16 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { afterEach, onTestFailed } from 'vitest';
+import { afterEach, beforeEach, onTestFailed, onTestFinished } from 'vitest';
 
 import type { RunnerTestContext } from '../testContext/runner-test-context';
+import { checkForFailedTest } from '../utility/operations';
 import { takeScreenshotHook } from './extended-hooks-utils';
 
 afterEach(async (context: RunnerTestContext) => {
   onTestFailed(async () => await takeScreenshotHook(context.pdRunner, context.task.name));
+});
+
+beforeEach(async (context: RunnerTestContext) => {
+  onTestFinished(results => checkForFailedTest(results, context.pdRunner));
 });

--- a/tests/playwright/src/utility/operations.ts
+++ b/tests/playwright/src/utility/operations.ts
@@ -18,11 +18,13 @@
 
 import type { Page } from '@playwright/test';
 import { expect as playExpect } from '@playwright/test';
+import type { TaskResult } from 'vitest';
 
 import { RegistriesPage } from '../model/pages/registries-page';
 import { ResourcesPage } from '../model/pages/resources-page';
 import { ResourcesPodmanConnections } from '../model/pages/resources-podman-connections-page';
 import { NavigationBar } from '../model/workbench/navigation';
+import type { PodmanDesktopRunner } from '../runner/podman-desktop-runner';
 import { waitUntil, waitWhile } from './wait';
 
 /**
@@ -194,4 +196,8 @@ export async function deletePodmanMachine(page: Page, machineVisibleName: string
   } else {
     console.log(`Podman machine [${machineVisibleName}] not present, skipping deletion.`);
   }
+}
+
+export function checkForFailedTest(result: TaskResult, runner: PodmanDesktopRunner): void {
+  if (result.errors && result.errors.length > 0) runner.setTestPassed(false);
 }


### PR DESCRIPTION
### What does this PR do?
Tries to handle errors thrown in beforeAll hook to mark tests as failed to not delete traces.

### What issues does this PR fix or reference?
https://github.com/containers/podman-desktop/issues/8129
