### PR TITLE
test: delete from volume page and prune volume e2e tests

### DIFF
--- a/tests/playwright/src/model/pages/main-page.ts
+++ b/tests/playwright/src/model/pages/main-page.ts
@@ -18,6 +18,7 @@
 
 import type { Locator, Page } from '@playwright/test';
 
+import { waitUntil } from '../../utility/wait';
 import { BasePage } from './base-page';
 
 /**
@@ -70,6 +71,10 @@ export abstract class MainPage extends BasePage {
     return this.content.getByRole('table');
   }
 
+  async rowsAreVisible(): Promise<boolean> {
+    return await this.page.getByRole('row').first().isVisible();
+  }
+
   async getRowFromTableByName(name: string): Promise<Locator | undefined> {
     if (await this.pageIsEmpty()) {
       return undefined;
@@ -93,5 +98,33 @@ export abstract class MainPage extends BasePage {
       console.log(`Exception caught on ${this.title} page with message: ${err}`);
     }
     return undefined;
+  }
+
+  async getRowsFromTableByStatus(status: string): Promise<Array<Locator>> {
+    await waitUntil(async () => await this.rowsAreVisible(), { sendError: false });
+
+    const table = this.content.getByRole('table');
+    if (await table.isVisible()) {
+      const rows = await table.getByRole('row').all();
+      const filteredRows = [];
+      for (let rowNum = 1; rowNum < rows.length; rowNum++) {
+        //skip header
+        const statusCount = await rows[rowNum].getByRole('cell').nth(2).getByTitle(status, { exact: true }).count();
+        if (statusCount > 0) filteredRows.push(rows[rowNum]);
+      }
+      return filteredRows;
+    }
+    return [];
+  }
+
+  async countRowsFromTable(): Promise<number> {
+    await waitUntil(async () => await this.rowsAreVisible(), { sendError: false });
+
+    const table = this.content.getByRole('table');
+    if (await table.isVisible()) {
+      const rows = await table.getByRole('row').all();
+      return rows.length > 1 ? rows.length - 1 : 0;
+    }
+    return 0;
   }
 }

--- a/tests/playwright/src/model/pages/main-page.ts
+++ b/tests/playwright/src/model/pages/main-page.ts
@@ -100,7 +100,7 @@ export abstract class MainPage extends BasePage {
     return undefined;
   }
 
-  async getRowsFromTableByStatus(status: string): Promise<Array<Locator>> {
+  async getRowsFromTableByStatus(status: string): Promise<Locator[]> {
     await waitUntil(async () => await this.rowsAreVisible(), { sendError: false });
 
     const table = this.content.getByRole('table');

--- a/tests/playwright/src/model/pages/main-page.ts
+++ b/tests/playwright/src/model/pages/main-page.ts
@@ -104,27 +104,20 @@ export abstract class MainPage extends BasePage {
     await waitUntil(async () => await this.rowsAreVisible(), { sendError: false });
 
     const table = this.content.getByRole('table');
-    if (await table.isVisible()) {
-      const rows = await table.getByRole('row').all();
-      const filteredRows = [];
-      for (let rowNum = 1; rowNum < rows.length; rowNum++) {
-        //skip header
-        const statusCount = await rows[rowNum].getByRole('cell').nth(2).getByTitle(status, { exact: true }).count();
-        if (statusCount > 0) filteredRows.push(rows[rowNum]);
-      }
-      return filteredRows;
+    const rows = await table.getByRole('row').all();
+    const filteredRows = [];
+    for (let rowNum = 1; rowNum < rows.length; rowNum++) {
+      //skip header
+      const statusCount = await rows[rowNum].getByRole('cell').nth(2).getByTitle(status, { exact: true }).count();
+      if (statusCount > 0) filteredRows.push(rows[rowNum]);
     }
-    return [];
+    return filteredRows;
   }
 
   async countRowsFromTable(): Promise<number> {
     await waitUntil(async () => await this.rowsAreVisible(), { sendError: false });
-
     const table = this.content.getByRole('table');
-    if (await table.isVisible()) {
-      const rows = await table.getByRole('row').all();
-      return rows.length > 1 ? rows.length - 1 : 0;
-    }
-    return 0;
+    const rows = await table.getByRole('row').all();
+    return rows.length > 1 ? rows.length - 1 : 0;
   }
 }

--- a/tests/playwright/src/model/pages/volumes-page.ts
+++ b/tests/playwright/src/model/pages/volumes-page.ts
@@ -101,19 +101,6 @@ export class VolumesPage extends MainPage {
     return true;
   }
 
-  //returns true if the number of volumes with status "UNUSED" is 0 (prune is finished)
-  async waitForPruneVolumes(): Promise<boolean> {
-    let unusedVolumes;
-    await waitWhile(
-      async () => {
-        unusedVolumes = await this.getRowsFromTableByStatus(VolumeState.Unused);
-        return unusedVolumes.length !== 0;
-      },
-      { sendError: false },
-    );
-    return true;
-  }
-
   async pruneVolumes(): Promise<VolumesPage> {
     await playExpect(this.pruneVolumesButton).toBeEnabled();
     await this.pruneVolumesButton.click();

--- a/tests/playwright/src/model/pages/volumes-page.ts
+++ b/tests/playwright/src/model/pages/volumes-page.ts
@@ -87,8 +87,7 @@ export class VolumesPage extends MainPage {
   }
 
   async countUsedVolumesFromTable(): Promise<number> {
-    const usedVolumes = await this.getRowsFromTableByStatus(VolumeState.Used);
-    return usedVolumes.length;
+    return (await this.getRowsFromTableByStatus(VolumeState.Used)).length;
   }
 
   async waitForVolumeExists(name: string): Promise<boolean> {

--- a/tests/playwright/src/model/pages/volumes-page.ts
+++ b/tests/playwright/src/model/pages/volumes-page.ts
@@ -19,7 +19,9 @@
 import type { Locator, Page } from '@playwright/test';
 import { expect as playExpect } from '@playwright/test';
 
+import { handleConfirmationDialog } from '../../utility/operations';
 import { waitUntil, waitWhile } from '../../utility/wait';
+import { VolumeState } from '../core/states';
 import { CreateVolumePage } from './create-volume-page';
 import { MainPage } from './main-page';
 import { VolumeDetailsPage } from './volume-details-page';
@@ -58,6 +60,19 @@ export class VolumesPage extends MainPage {
     return new VolumeDetailsPage(this.page, volumeName);
   }
 
+  async deleteVolume(volumeName: string): Promise<VolumesPage> {
+    const volumeRow = await this.getVolumeRowByName(volumeName);
+    if (volumeRow === undefined) {
+      throw Error(`Volume: ${volumeName} does not exist`);
+    }
+    const containerRowDeleteButton = volumeRow.getByRole('button', { name: 'Delete Volume' });
+    await playExpect(containerRowDeleteButton).toBeEnabled();
+    await containerRowDeleteButton.click();
+    await handleConfirmationDialog(this.page);
+
+    return this;
+  }
+
   async getVolumeRowByName(name: string): Promise<Locator | undefined> {
     return this.getRowFromTableByName(name);
   }
@@ -65,6 +80,15 @@ export class VolumesPage extends MainPage {
   protected async volumeExists(name: string): Promise<boolean> {
     const result = await this.getVolumeRowByName(name);
     return result !== undefined;
+  }
+
+  async countVolumesFromTable(): Promise<number> {
+    return this.countRowsFromTable();
+  }
+
+  async countUsedVolumesFromTable(): Promise<number> {
+    const usedVolumes = await this.getRowsFromTableByStatus(VolumeState.Used);
+    return usedVolumes.length;
   }
 
   async waitForVolumeExists(name: string): Promise<boolean> {
@@ -75,5 +99,25 @@ export class VolumesPage extends MainPage {
   async waitForVolumeDelete(name: string): Promise<boolean> {
     await waitWhile(async () => await this.volumeExists(name));
     return true;
+  }
+
+  //returns true if the number of volumes with status "UNUSED" is 0 (prune is finished)
+  async waitForPruneVolumes(): Promise<boolean> {
+    let unusedVolumes;
+    await waitWhile(
+      async () => {
+        unusedVolumes = await this.getRowsFromTableByStatus(VolumeState.Unused);
+        return unusedVolumes.length !== 0;
+      },
+      { sendError: false },
+    );
+    return true;
+  }
+
+  async pruneVolumes(): Promise<VolumesPage> {
+    await playExpect(this.pruneVolumesButton).toBeEnabled();
+    await this.pruneVolumesButton.click();
+    await handleConfirmationDialog(this.page, 'Prune');
+    return this;
   }
 }

--- a/tests/playwright/src/specs/volume-smoke.spec.ts
+++ b/tests/playwright/src/specs/volume-smoke.spec.ts
@@ -87,11 +87,10 @@ describe('Volume workflow verification', async () => {
   test('Delete volume from Volumes page', async () => {
     let volumesPage = await navBar.openVolumes();
     await playExpect(volumesPage.heading).toBeVisible();
-    let volumeRow = await volumesPage.getVolumeRowByName(volumeName);
+    const volumeRow = await volumesPage.getVolumeRowByName(volumeName);
     playExpect(volumeRow).not.toBeUndefined();
     volumesPage = await volumesPage.deleteVolume(volumeName);
     await playExpect.poll(async () => await volumesPage.waitForVolumeDelete(volumeName)).toBeTruthy();
-    volumeRow = await volumesPage.getVolumeRowByName(volumeName);
   });
 
   test('Delete volume through details page', async () => {
@@ -107,14 +106,13 @@ describe('Volume workflow verification', async () => {
     //delete it from the details page
     volumesPage = await navBar.openVolumes();
     await playExpect(volumesPage.heading).toBeVisible();
-    let volumeRow = await volumesPage.getVolumeRowByName(volumeName);
+    const volumeRow = await volumesPage.getVolumeRowByName(volumeName);
     playExpect(volumeRow).not.toBeUndefined();
 
     const volumeDetails = await volumesPage.openVolumeDetails(volumeName);
     volumesPage = await volumeDetails.deleteVolume();
 
     await playExpect.poll(async () => await volumesPage.waitForVolumeDelete(volumeName)).toBeTruthy();
-    volumeRow = await volumesPage.getVolumeRowByName(volumeName);
   });
 
   test('Create volumes from bootc-image-builder', async () => {

--- a/tests/playwright/src/specs/volume-smoke.spec.ts
+++ b/tests/playwright/src/specs/volume-smoke.spec.ts
@@ -20,7 +20,7 @@ import type { Page } from '@playwright/test';
 import { expect as playExpect } from '@playwright/test';
 import { afterAll, beforeAll, beforeEach, describe, test } from 'vitest';
 
-import { ContainerState } from '../model/core/states';
+import { ContainerState, VolumeState } from '../model/core/states';
 import type { ContainerInteractiveParams } from '../model/core/types';
 import { WelcomePage } from '../model/pages/welcome-page';
 import { NavigationBar } from '../model/workbench/navigation';
@@ -129,7 +129,9 @@ describe('Volume workflow verification', async () => {
       //if there are unused volumes, prune them
       if (previousVolumes - usedVolumes > 0) {
         volumesPage = await volumesPage.pruneVolumes();
-        await playExpect.poll(async () => await volumesPage.waitForPruneVolumes(), { timeout: 10000 }).toBeTruthy();
+        await playExpect
+          .poll(async () => (await volumesPage.getRowsFromTableByStatus(VolumeState.Unused)).length, { timeout: 10000 })
+          .toBe(0);
         previousVolumes = await volumesPage.countVolumesFromTable();
       }
     }
@@ -173,7 +175,9 @@ describe('Volume workflow verification', async () => {
     //prune unused volumes
     volumesPage = await navigationBar.openVolumes();
     volumesPage = await volumesPage.pruneVolumes();
-    await playExpect.poll(async () => await volumesPage.waitForPruneVolumes(), { timeout: 10000 }).toBeTruthy();
+    await playExpect
+      .poll(async () => (await volumesPage.getRowsFromTableByStatus(VolumeState.Unused)).length, { timeout: 10000 })
+      .toBe(0);
     const finalVolumes = await volumesPage.countVolumesFromTable();
     playExpect(finalVolumes - previousVolumes).toBe(0);
   });

--- a/tests/playwright/src/specs/volume-smoke.spec.ts
+++ b/tests/playwright/src/specs/volume-smoke.spec.ts
@@ -20,6 +20,8 @@ import type { Page } from '@playwright/test';
 import { expect as playExpect } from '@playwright/test';
 import { afterAll, beforeAll, beforeEach, describe, test } from 'vitest';
 
+import { ContainerState } from '../model/core/states';
+import type { ContainerInteractiveParams } from '../model/core/types';
 import { WelcomePage } from '../model/pages/welcome-page';
 import { NavigationBar } from '../model/workbench/navigation';
 import { PodmanDesktopRunner } from '../runner/podman-desktop-runner';
@@ -29,6 +31,11 @@ import { waitForPodmanMachineStartup } from '../utility/wait';
 let pdRunner: PodmanDesktopRunner;
 let page: Page;
 let navBar: NavigationBar;
+
+const imageToPull = 'quay.io/centos-bootc/bootc-image-builder';
+const imageTag = 'latest';
+const containerToRun = 'bootc-image-builder';
+const containerStartParams: ContainerInteractiveParams = { attachTerminal: false };
 
 beforeAll(async () => {
   pdRunner = new PodmanDesktopRunner();
@@ -55,12 +62,11 @@ describe('Volume workflow verification', async () => {
   test('Create new Volume', async () => {
     let volumesPage = await navBar.openVolumes();
     await playExpect(volumesPage.heading).toBeVisible();
-
     const createVolumePage = await volumesPage.openCreateVolumePage(volumeName);
     volumesPage = await createVolumePage.createVolume(volumeName);
-
     await playExpect.poll(async () => await volumesPage.waitForVolumeExists(volumeName)).toBeTruthy();
   });
+
   test('Test navigation between pages', async () => {
     const volumesPage = await navBar.openVolumes();
     await playExpect(volumesPage.heading).toBeVisible();
@@ -77,16 +83,98 @@ describe('Volume workflow verification', async () => {
     await volumeDetails.closeButton.click();
     await playExpect(volumesPage.heading).toBeVisible();
   });
+
+  test('Delete volume from Volumes page', async () => {
+    let volumesPage = await navBar.openVolumes();
+    await playExpect(volumesPage.heading).toBeVisible();
+    let volumeRow = await volumesPage.getVolumeRowByName(volumeName);
+    playExpect(volumeRow).not.toBeUndefined();
+    volumesPage = await volumesPage.deleteVolume(volumeName);
+    await playExpect.poll(async () => await volumesPage.waitForVolumeDelete(volumeName)).toBeTruthy();
+    volumeRow = await volumesPage.getVolumeRowByName(volumeName);
+  });
+
   test('Delete volume through details page', async () => {
+    //re-create a new volume
     let volumesPage = await navBar.openVolumes();
     await playExpect(volumesPage.heading).toBeVisible();
 
-    const volumeRow = await volumesPage.getVolumeRowByName(volumeName);
+    const createVolumePage = await volumesPage.openCreateVolumePage(volumeName);
+    volumesPage = await createVolumePage.createVolume(volumeName);
+
+    await playExpect.poll(async () => await volumesPage.waitForVolumeExists(volumeName)).toBeTruthy();
+
+    //delete it from the details page
+    volumesPage = await navBar.openVolumes();
+    await playExpect(volumesPage.heading).toBeVisible();
+    let volumeRow = await volumesPage.getVolumeRowByName(volumeName);
     playExpect(volumeRow).not.toBeUndefined();
 
     const volumeDetails = await volumesPage.openVolumeDetails(volumeName);
     volumesPage = await volumeDetails.deleteVolume();
 
     await playExpect.poll(async () => await volumesPage.waitForVolumeDelete(volumeName)).toBeTruthy();
+    volumeRow = await volumesPage.getVolumeRowByName(volumeName);
+  });
+
+  test('Create volumes from bootc-image-builder', async () => {
+    //count the number of existing volumes
+    const navigationBar = new NavigationBar(page);
+    let volumesPage = await navigationBar.openVolumes();
+    let previousVolumes = await volumesPage.countVolumesFromTable();
+
+    //if there are volumes, check how many are used
+    if (previousVolumes > 0) {
+      const usedVolumes = await volumesPage.countUsedVolumesFromTable();
+      //if there are unused volumes, prune them
+      if (previousVolumes - usedVolumes > 0) {
+        volumesPage = await volumesPage.pruneVolumes();
+        await playExpect.poll(async () => await volumesPage.waitForPruneVolumes(), { timeout: 10000 }).toBeTruthy();
+        previousVolumes = await volumesPage.countVolumesFromTable();
+      }
+    }
+
+    //pull image from quay.io/centos-bootc/bootc-image-builder
+    let images = await navigationBar.openImages();
+    const pullImagePage = await images.openPullImage();
+    images = await pullImagePage.pullImage(imageToPull, imageTag);
+    await playExpect.poll(async () => await images.waitForImageExists(imageToPull)).toBeTruthy();
+
+    //start a container from the image (generates 4 new volumes)
+    const imageDetails = await images.openImageDetails(imageToPull);
+    const runImage = await imageDetails.openRunImage();
+    let containers = await runImage.startContainer(containerToRun, containerStartParams);
+    await playExpect(containers.header).toBeVisible();
+    await playExpect
+      .poll(async () => await containers.containerExists(containerToRun), { timeout: 10000 })
+      .toBeTruthy();
+    await containers.startContainer(containerToRun);
+
+    //check that four volumes are created (in addition to the existing ones)
+    volumesPage = await navigationBar.openVolumes();
+    await playExpect(volumesPage.heading).toBeVisible();
+    const newVolumes = await volumesPage.countVolumesFromTable();
+    playExpect(newVolumes - previousVolumes).toBe(4);
+
+    //check the container is stopped and delete it
+    containers = await navigationBar.openContainers();
+    const containerDetails = await containers.openContainersDetails(containerToRun);
+    await playExpect
+      .poll(async () => containerDetails.getState(), { timeout: 20000 })
+      .toContain(ContainerState.Exited.toLowerCase());
+    await playExpect(await containerDetails.getStateLocator()).toHaveText(ContainerState.Exited.toLowerCase());
+    containers = await navigationBar.openContainers();
+    const containersPage = await containers.deleteContainer(containerToRun);
+    await playExpect(containersPage.heading).toBeVisible();
+    await playExpect
+      .poll(async () => await containersPage.containerExists(containerToRun), { timeout: 15000 })
+      .toBeFalsy();
+
+    //prune unused volumes
+    volumesPage = await navigationBar.openVolumes();
+    volumesPage = await volumesPage.pruneVolumes();
+    await playExpect.poll(async () => await volumesPage.waitForPruneVolumes(), { timeout: 10000 }).toBeTruthy();
+    const finalVolumes = await volumesPage.countVolumesFromTable();
+    playExpect(finalVolumes - previousVolumes).toBe(0);
   });
 });


### PR DESCRIPTION
### What does this PR do?
This PR extends the volume-smoke.spec.ts test suite to include the test cases of deleting a volume from the Volumes page and checking that the correct number of volumes are initialized when starting a container from the **quay.io/centos-bootc/bootc-image-builder** image on Podman Desktop.

### What issues does this PR fix or reference?
https://github.com/containers/podman-desktop/issues/8040

### How to test this PR?
Run the volume tests with yarn test:e2e:smoke
