### PR TITLE
chore: light mode for donut component

### DIFF
--- a/packages/renderer/src/lib/donut/Donut.svelte
+++ b/packages/renderer/src/lib/donut/Donut.svelte
@@ -35,21 +35,27 @@ $: tooltip = percent ? percent.toFixed(0) + '% ' + title + ' usage' : '';
 
 <Tooltip bottom tip="{tooltip}">
   <svg viewBox="-4 -4 {size + 8} {size + 8}" height="{size}" width="{size}">
-    <circle fill="none" class="stroke-charcoal-300" stroke-width="1" r="{size / 2}" cx="{size / 2}" cy="{size / 2}"
-    ></circle>
+    <circle
+      fill="none"
+      class="stroke-[var(--pd-content-divider)]"
+      stroke-width="1"
+      r="{size / 2}"
+      cx="{size / 2}"
+      cy="{size / 2}"></circle>
     <path
       fill="none"
       class="{stroke}"
       stroke-width="3.5"
       d="{describeArc(size / 2, (percent * 360) / 100)}"
       data-testid="arc"></path>
-    <text x="{size / 2}" y="38%" text-anchor="middle" font-size="{size / 6}" class="fill-gray-800">{title}</text>
+    <text x="{size / 2}" y="38%" text-anchor="middle" font-size="{size / 6}" class="fill-[var(--pd-content-text)]"
+      >{title}</text>
     <text
       x="{size / 2}"
       y="52%"
       text-anchor="middle"
       font-size="{size / 6}"
       dominant-baseline="central"
-      class="fill-gray-400">{value !== undefined ? value : ''}</text>
+      class="fill-[var(--pd-content-card-text)]">{value !== undefined ? value : ''}</text>
   </svg>
 </Tooltip>


### PR DESCRIPTION
### What does this PR do?

State colors were already done, just had to set the text and circle colors. Tried to pick color variables that are reasonable enough and close to current colors.

### Screenshot / video of UI

Before:

<img width="286" alt="Screenshot 2024-07-17 at 11 29 20 AM" src="https://github.com/user-attachments/assets/ac8f6812-b978-49dc-9041-a9f3012dd01f">

<img width="286" alt="Screenshot 2024-07-17 at 11 29 03 AM" src="https://github.com/user-attachments/assets/4c6c71cd-f5e3-45f6-ae3e-83f86ccdc6ba">

After:

<img width="286" alt="Screenshot 2024-07-17 at 11 24 16 AM" src="https://github.com/user-attachments/assets/065700a8-0227-439d-b1e3-5a5f9ae46450">

<img width="286" alt="Screenshot 2024-07-17 at 11 24 32 AM" src="https://github.com/user-attachments/assets/846821a2-244b-4e5f-8b82-2b5455cd208e">

### What issues does this PR fix or reference?

Fixes #7546.

### How to test this PR?

Check Settings > Resources in light and dark mode.