### PR TITLE
chore: update provider rendering create new background

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesProviderRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesProviderRendering.svelte
@@ -143,7 +143,7 @@ async function stopReceivingLogs(providerInternalId: string): Promise<void> {
     </svelte:fragment>
 
     <div slot="content" class="px-5 pb-5 min-w-full h-fit">
-      <div class="bg-charcoal-700 px-6 py-4">
+      <div class="bg-[var(--pd-content-card-bg)] px-6 py-4">
         <!-- Create connection panel-->
         {#if providerInfo?.containerProviderConnectionCreation === true}
           <PreferencesConnectionCreationRendering


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?

Updates the background color of the provider create new page to work with light mode.

### Screenshot / video of UI

![Screenshot from 2024-07-17 12-14-44](https://github.com/user-attachments/assets/69a22cc5-6de4-4d25-b84b-5ba535e72071)
![Screenshot from 2024-07-17 12-14-51](https://github.com/user-attachments/assets/d2676637-ca20-4b19-a7a7-8730fad7c1c6)


<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Closes https://github.com/containers/podman-desktop/issues/8077

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature

Go to the create new page of any available provider in preferences