### PR TITLE
feat: Add manifest push and delete butons

### DIFF
--- a/packages/renderer/src/lib/image/ImageColumnActions.spec.ts
+++ b/packages/renderer/src/lib/image/ImageColumnActions.spec.ts
@@ -42,7 +42,7 @@ const image: ImageInfoUI = {
   badges: [],
 };
 
-test('No actions shown for manifest images', async () => {
+test('No image actions shown for manifest images', async () => {
   const manifestImage: ImageInfoUI = { ...image, isManifest: true };
 
   render(ImageColumnActions, { object: manifestImage });
@@ -50,4 +50,14 @@ test('No actions shown for manifest images', async () => {
   // Check for the absence of action buttons
   expect(screen.queryByText('Push Image')).not.toBeInTheDocument();
   expect(screen.queryByText('Rename Image')).not.toBeInTheDocument();
+});
+
+test('Push push and delete manifest actions shown for manifest', async () => {
+  const manifestImage: ImageInfoUI = { ...image, isManifest: true };
+
+  render(ImageColumnActions, { object: manifestImage });
+
+  // Check for the presence of action buttons
+  expect(screen.queryByText('Push Manifest')).toBeDefined();
+  expect(screen.queryByText('Delete Manifest')).toBeDefined();
 });

--- a/packages/renderer/src/lib/image/ImageColumnActions.svelte
+++ b/packages/renderer/src/lib/image/ImageColumnActions.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
 import ImageActions from './ImageActions.svelte';
 import type { ImageInfoUI } from './ImageInfoUI';
+import ManifestActions from './ManifestActions.svelte';
 import PushImageModal from './PushImageModal.svelte';
+import PushManifestModal from './PushManifestModal.svelte';
 import RenameImageModal from './RenameImageModal.svelte';
 
 export let object: ImageInfoUI;
@@ -20,15 +22,33 @@ function handleRenameImageModal(imageInfo: ImageInfoUI) {
   renameImageModal = true;
 }
 
+let pushManifestModal = false;
+let pushManifestModalInfo: ImageInfoUI | undefined = undefined;
+function handlePushManifestModal(imageInfo: ImageInfoUI) {
+  pushManifestModalInfo = imageInfo;
+  pushManifestModal = true;
+}
+
 function closeModals() {
   pushImageModal = false;
   renameImageModal = false;
+  pushManifestModal = false;
 }
 </script>
 
 <!-- There is no support for interacting with manifests yet, so do not show any manifest-related-image-actions. -->
 
-{#if !object.isManifest}
+{#if object.isManifest}
+  <ManifestActions manifest={object} onPushManifest={handlePushManifestModal} dropdownMenu={true} on:update />
+
+  {#if pushManifestModal && pushManifestModalInfo}
+    <PushManifestModal
+      manifestInfoToPush={pushManifestModalInfo}
+      closeCallback={() => {
+        closeModals();
+      }} />
+  {/if}
+{:else}
   <ImageActions
     image={object}
     onPushImage={handlePushImageModal}

--- a/packages/renderer/src/lib/image/ManifestActions.spec.ts
+++ b/packages/renderer/src/lib/image/ManifestActions.spec.ts
@@ -1,0 +1,66 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/svelte';
+import { beforeAll, expect, test, vi } from 'vitest';
+
+import type { ImageInfoUI } from '/@/lib/image/ImageInfoUI';
+import ManifestActions from '/@/lib/image/ManifestActions.svelte';
+
+const showMessageBoxMock = vi.fn();
+const getContributedMenusMock = vi.fn();
+
+class ResizeObserver {
+  observe = vi.fn();
+  disconnect = vi.fn();
+  unobserve = vi.fn();
+}
+beforeAll(() => {
+  (window as any).showMessageBox = showMessageBoxMock;
+  (window as any).ResizeObserver = ResizeObserver;
+
+  (window as any).getContributedMenus = getContributedMenusMock;
+  (window as any).hasAuthconfigForImage = vi.fn();
+  (window as any).hasAuthconfigForImage.mockImplementation(() => Promise.resolve(false));
+});
+
+const fakedManifest: ImageInfoUI = {
+  id: 'dummy',
+  name: 'dummy',
+  isManifest: true,
+} as unknown as ImageInfoUI;
+
+test('Expect Delete Manifest to be there', async () => {
+  render(ManifestActions, { manifest: fakedManifest, onPushManifest: vi.fn() });
+
+  const button = screen.getByRole('button', { name: 'Delete Manifest' });
+  expect(button).toBeDefined();
+});
+
+test('Expect Push Manifest to be there', async () => {
+  // Mock the showMessageBox to return 0 (yes)
+  showMessageBoxMock.mockResolvedValue({ response: 0 });
+  getContributedMenusMock.mockImplementation(() => Promise.resolve([]));
+
+  render(ManifestActions, { manifest: fakedManifest, onPushManifest: vi.fn() });
+
+  const button = screen.getByRole('button', { name: 'Push Manifest' });
+  expect(button).toBeDefined();
+});

--- a/packages/renderer/src/lib/image/ManifestActions.svelte
+++ b/packages/renderer/src/lib/image/ManifestActions.svelte
@@ -1,0 +1,56 @@
+<script lang="ts">
+import { faArrowUp, faTrash } from '@fortawesome/free-solid-svg-icons';
+import { createEventDispatcher } from 'svelte';
+
+import { withConfirmation } from '/@/lib/dialogs/messagebox-utils';
+
+import ListItemButtonIcon from '../ui/ListItemButtonIcon.svelte';
+import ActionsWrapper from './ActionsMenu.svelte';
+import type { ImageInfoUI } from './ImageInfoUI';
+
+export let onPushManifest: (manifestInfo: ImageInfoUI) => void;
+export let manifest: ImageInfoUI;
+export let dropdownMenu = false;
+export let detailed = false;
+
+const dispatch = createEventDispatcher<{ update: ImageInfoUI }>();
+
+async function pushManifest(): Promise<void> {
+  onPushManifest(manifest);
+}
+
+async function deleteManifest(): Promise<void> {
+  manifest.status = 'DELETING';
+  dispatch('update', manifest);
+  try {
+    await window.removeManifest(manifest.engineId, manifest.name);
+  } catch (error) {
+    onError(`Error while deleting manifest: ${String(error)}`);
+  }
+}
+
+function onError(error: string): void {
+  window.showMessageBox({
+    title: 'Something went wrong.',
+    message: error,
+    type: 'error',
+  });
+}
+</script>
+
+<ListItemButtonIcon
+  title="Delete Manifest"
+  onClick={() => withConfirmation(deleteManifest, `delete manifest ${manifest.name}`)}
+  detailed={detailed}
+  icon={faTrash}
+  enabled={manifest.status === 'UNUSED'} />
+
+<!-- If dropdownMenu is true, use it, otherwise just show the regular buttons -->
+<ActionsWrapper dropdownMenu={dropdownMenu}>
+  <ListItemButtonIcon
+    title="Push Manifest"
+    onClick={() => pushManifest()}
+    menu={dropdownMenu}
+    detailed={detailed}
+    icon={faArrowUp} />
+</ActionsWrapper>

--- a/packages/renderer/src/lib/image/PushManifestModal.spec.ts
+++ b/packages/renderer/src/lib/image/PushManifestModal.spec.ts
@@ -1,0 +1,93 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { fireEvent } from '@testing-library/dom';
+import { render, screen } from '@testing-library/svelte';
+import { tick } from 'svelte';
+import { beforeAll, expect, test, vi } from 'vitest';
+
+import type { ImageInfoUI } from './ImageInfoUI';
+import PushManifestModal from './PushManifestModal.svelte';
+
+vi.mock('xterm', () => {
+  return {
+    Terminal: vi
+      .fn()
+      .mockReturnValue({ loadAddon: vi.fn(), open: vi.fn(), write: vi.fn(), clear: vi.fn(), reset: vi.fn() }),
+  };
+});
+
+const getConfigurationValueMock = vi.fn();
+const pushManifestMock = vi.fn();
+
+beforeAll(() => {
+  (window.events as unknown) = {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    receive: (_channel: string, func: any) => {
+      func();
+    },
+  };
+  (window as any).ResizeObserver = vi.fn().mockReturnValue({ observe: vi.fn(), unobserve: vi.fn() });
+  (window as any).getImageInspect = vi.fn().mockImplementation(() => Promise.resolve({}));
+  (window as any).logsContainer = vi.fn().mockResolvedValue(undefined);
+  (window as any).refreshTerminal = vi.fn();
+  (window as any).getConfigurationValue = getConfigurationValueMock;
+  (window as any).showMessageBox = vi.fn();
+  (window as any).pushManifest = pushManifestMock;
+});
+
+const fakedManifest: ImageInfoUI = {
+  id: 'id',
+  shortId: 'shortId',
+  name: 'name',
+  engineId: 'engineId',
+  engineName: 'engineName',
+  tag: 'tag',
+  createdAt: 0,
+  age: 'age',
+  size: 0,
+  humanSize: 'humanSize',
+  base64RepoTag: 'base64RepoTag',
+  selected: false,
+  status: 'UNUSED',
+  icon: {},
+  badges: [],
+  isManifest: true,
+  digest: 'sha256:1234567890',
+};
+
+async function waitRender(customProperties: object): Promise<void> {
+  render(PushManifestModal, { ...customProperties });
+  await tick();
+}
+
+test('Expect to render PushManifestModal correctly with Push manifest button', async () => {
+  await waitRender({
+    manifestInfoToPush: fakedManifest,
+    closeCallback: vi.fn(),
+  });
+
+  // Get the push button
+  const pushButton = screen.getByRole('button', { name: 'Push manifest' });
+  expect(pushButton).toBeInTheDocument();
+
+  // Be able to click it
+  fireEvent.click(pushButton);
+});

--- a/packages/renderer/src/lib/image/PushManifestModal.svelte
+++ b/packages/renderer/src/lib/image/PushManifestModal.svelte
@@ -1,0 +1,119 @@
+<script lang="ts">
+import { faCircleArrowUp } from '@fortawesome/free-solid-svg-icons';
+import { Button } from '@podman-desktop/ui-svelte';
+import { tick } from 'svelte';
+import { router } from 'tinro';
+import { Terminal } from 'xterm';
+import { FitAddon } from 'xterm-addon-fit';
+
+import { TerminalSettings } from '../../../../main/src/plugin/terminal-settings';
+import Dialog from '../dialogs/Dialog.svelte';
+import type { ImageInfoUI } from './ImageInfoUI';
+
+export let closeCallback: () => void;
+export let manifestInfoToPush: ImageInfoUI;
+
+let pushInProgress = false;
+let pushFinished = false;
+let logsPush: Terminal;
+
+let terminalIntialized = false;
+
+async function initTerminal() {
+  if (terminalIntialized) {
+    return;
+  }
+
+  // missing element, return
+  if (!pushLogsXtermDiv) {
+    return;
+  }
+
+  // grab font size
+  const fontSize = await window.getConfigurationValue<number>(
+    TerminalSettings.SectionName + '.' + TerminalSettings.FontSize,
+  );
+  const lineHeight = await window.getConfigurationValue<number>(
+    TerminalSettings.SectionName + '.' + TerminalSettings.LineHeight,
+  );
+
+  logsPush = new Terminal({ fontSize, lineHeight, disableStdin: true });
+  const fitAddon = new FitAddon();
+  logsPush.loadAddon(fitAddon);
+
+  logsPush.open(pushLogsXtermDiv);
+  // disable cursor
+  logsPush.write('\x1b[?25l');
+
+  // call fit addon each time we resize the window
+  window.addEventListener('resize', () => {
+    fitAddon.fit();
+  });
+  fitAddon.fit();
+  terminalIntialized = true;
+}
+
+async function pushManifest() {
+  await tick();
+  await initTerminal();
+  await tick();
+  logsPush?.reset();
+
+  pushInProgress = true;
+
+  try {
+    logsPush.write(`Pushing manifest ${manifestInfoToPush.name} ...\n\r`);
+    await window.pushManifest({ name: manifestInfoToPush.name, destination: manifestInfoToPush.name });
+    logsPush.write('Manifest pushed successfully\n\r');
+    pushFinished = true;
+  } catch (err) {
+    logsPush.write(err + '\n\r');
+    pushFinished = true;
+    console.error(err);
+  }
+}
+
+async function pushManifestFinished() {
+  closeCallback();
+  router.goto('/images');
+}
+let pushLogsXtermDiv: HTMLDivElement;
+</script>
+
+<Dialog
+  title="Push manifest"
+  on:close={() => {
+    closeCallback();
+  }}>
+  <div slot="content" class="flex flex-col leading-5 space-y-5">
+    {#if !pushInProgress}
+      <p class="text-sm">
+        Push manifest {manifestInfoToPush.name}
+
+        {#if manifestInfoToPush.children && manifestInfoToPush.children.length > 0}
+          with {manifestInfoToPush.children.length} associated images
+        {/if}
+      </p>
+    {/if}
+    <div bind:this={pushLogsXtermDiv}></div>
+  </div>
+
+  <svelte:fragment slot="buttons">
+    {#if !pushInProgress && !pushFinished}
+      <Button class="w-auto" type="secondary" on:click={() => closeCallback()}>Cancel</Button>
+    {/if}
+    {#if !pushFinished}
+      <Button
+        class="w-auto"
+        icon={faCircleArrowUp}
+        on:click={() => {
+          pushManifest();
+        }}
+        bind:inProgress={pushInProgress}>
+        Push manifest
+      </Button>
+    {:else}
+      <Button on:click={() => pushManifestFinished()} class="w-auto">Done</Button>
+    {/if}
+  </svelte:fragment>
+</Dialog>


### PR DESCRIPTION
feat: Add manifest push and delete butons

### What does this PR do?

* Adds manifest push button with the same style modal as PushImageModal
* Adds manifest delete button which deletes the manifest (but leaves the
  child images), which is the same behaviour as the podman CLI.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

https://github.com/user-attachments/assets/8f1fb5e4-1a16-4f63-9223-5e3547a66d3b


https://github.com/user-attachments/assets/728354c3-1b12-4400-a444-5fd57e0c298f




### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop/issues/7041

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature

1. Create a manifest
2. Test push
3. Test delete

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
