### PR TITLE
chore: fix multiple connection warnings

### DIFF
--- a/packages/main/src/plugin/provider-registry.ts
+++ b/packages/main/src/plugin/provider-registry.ts
@@ -873,9 +873,10 @@ export class ProviderRegistry {
   ): Promise<AuditResult> {
     // grab the correct provider
     const provider = this.getMatchingProvider(internalProviderId);
+    const emptyAuditResult: AuditResult = { records: [] };
 
     if (!provider.connectionAuditor) {
-      throw new Error('The provider does not support audit for connection parameters');
+      return emptyAuditResult;
     }
 
     return provider.connectionAuditor.auditItems(params);


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
Removes the console warning `The provider does not support audit for connection parameters` that pops up multiple times

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Closes https://github.com/containers/podman-desktop/issues/7582
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature

Go to one of the extensions `create new` page in the preferences page and check that the warning mentioned above doesn't pop up