### PR TITLE
chore: extract pod creation functionality into separate function

### DIFF
--- a/tests/playwright/src/specs/yaml-smoke.spec.ts
+++ b/tests/playwright/src/specs/yaml-smoke.spec.ts
@@ -16,8 +16,6 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import path from 'node:path';
-
 import type { Page } from '@playwright/test';
 import { expect as playExpect } from '@playwright/test';
 import { afterAll, beforeAll, beforeEach, describe, test } from 'vitest';
@@ -26,7 +24,7 @@ import { WelcomePage } from '../model/pages/welcome-page';
 import { NavigationBar } from '../model/workbench/navigation';
 import { PodmanDesktopRunner } from '../runner/podman-desktop-runner';
 import type { RunnerTestContext } from '../testContext/runner-test-context';
-import { deleteImage, deletePod } from '../utility/operations';
+import { createPod, deleteImage, deletePod } from '../utility/operations';
 import { waitForPodmanMachineStartup } from '../utility/wait';
 
 let pdRunner: PodmanDesktopRunner;
@@ -64,15 +62,8 @@ describe.skipIf(process.env.GITHUB_ACTIONS && process.env.RUNNER_OS === 'Linux')
   async () => {
     test('Playing yaml', async () => {
       const navigationBar = new NavigationBar(page);
-      let podsPage = await navigationBar.openPods();
-      await playExpect(podsPage.heading).toBeVisible();
-
-      const playYamlPage = await podsPage.openPlayKubeYaml();
-      await playExpect(playYamlPage.heading).toBeVisible();
-
-      const yamlFilePath = path.resolve(__dirname, '..', '..', 'resources', `${podAppName}.yaml`);
-      podsPage = await playYamlPage.playYaml(yamlFilePath);
-      await playExpect(podsPage.heading).toBeVisible();
+      const podsPage = await navigationBar.openPods();
+      await createPod(podsPage, podAppName);
     }, 150000);
 
     test('Checking that created pod from yaml is correct', async () => {

--- a/tests/playwright/src/utility/operations.ts
+++ b/tests/playwright/src/utility/operations.ts
@@ -16,10 +16,13 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import path from 'node:path';
+
 import type { Page } from '@playwright/test';
 import { expect as playExpect } from '@playwright/test';
 import type { TaskResult } from 'vitest';
 
+import type { PodsPage } from '../model/pages/pods-page';
 import { RegistriesPage } from '../model/pages/registries-page';
 import { ResourcesPage } from '../model/pages/resources-page';
 import { ResourcesPodmanConnections } from '../model/pages/resources-podman-connections-page';
@@ -142,6 +145,17 @@ export async function deletePod(page: Page, name: string): Promise<void> {
       }
     }
   }
+}
+
+export async function createPod(podsPage: PodsPage, podAppName: string): Promise<void> {
+  await playExpect(podsPage.heading).toBeVisible();
+
+  const playYamlPage = await podsPage.openPlayKubeYaml();
+  await playExpect(playYamlPage.heading).toBeVisible();
+
+  const yamlFilePath = path.resolve(__dirname, '..', '..', 'resources', `${podAppName}.yaml`);
+  podsPage = await playYamlPage.playYaml(yamlFilePath);
+  await playExpect(podsPage.heading).toBeVisible();
 }
 
 // Handles dialog that has accessible name `dialogTitle` and either confirms or rejects it.


### PR DESCRIPTION
Signed-off-by: Anton Misskii <amisskii@redhat.com>

### What does this PR do?

This PR extracts the pod creation functionality into a separate function. 
This refactoring aims to modularize the code, making the pod creation logic reusable across different scenarios.


### What issues does this PR fix or reference?

This PR is related to the https://github.com/containers/podman-desktop/pull/8151 that addresses the implementation of end-to-end tests for the Kind extension.


