### PR TITLE
fix: podify a container with named volumes fails

### DIFF
--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -212,6 +212,101 @@ const fakeContainerInspectInfo: Dockerode.ContainerInspectInfo = {
   },
 };
 
+const fakeContainerInspectInfoWithVolume = {
+  Id: '1234',
+  Name: 'container2',
+  Image: 'image2',
+  Created: '1234567890',
+  State: {
+    Status: 'running',
+    Running: true,
+    Paused: false,
+    Restarting: false,
+    OOMKilled: false,
+    Dead: false,
+    Pid: 26852,
+    ExitCode: 0,
+    Error: '',
+    StartedAt: '2024-01-22T17:42:34.56349523+01:00',
+    FinishedAt: '0001-01-01T00:00:00Z',
+  },
+  Mounts: [
+    {
+      Destination: '/destination',
+      Mode: '',
+      Propagation: '',
+      RW: true,
+      Source: '/source',
+      Type: 'volume',
+      Name: 'vol1',
+    },
+  ],
+  HostConfig: {
+    NetworkMode: 'bridge',
+  },
+  Path: '',
+  Args: [],
+  ResolvConfPath: '',
+  HostnamePath: '',
+  HostsPath: '',
+  LogPath: '',
+  RestartCount: 0,
+  Driver: '',
+  Platform: '',
+  MountLabel: '',
+  ProcessLabel: '',
+  AppArmorProfile: '',
+  GraphDriver: {
+    Name: '',
+    Data: {
+      DeviceId: '',
+      DeviceName: '',
+      DeviceSize: '',
+    },
+  },
+  Config: {
+    Hostname: '',
+    Domainname: '',
+    User: '',
+    AttachStdin: false,
+    AttachStdout: false,
+    AttachStderr: false,
+    ExposedPorts: {},
+    Tty: false,
+    OpenStdin: false,
+    StdinOnce: false,
+    Env: [],
+    Cmd: [],
+    Image: '',
+    Volumes: {},
+    WorkingDir: '',
+    Entrypoint: undefined,
+    OnBuild: undefined,
+    Labels: {},
+  },
+  NetworkSettings: {
+    Bridge: '',
+    SandboxID: '',
+    HairpinMode: false,
+    LinkLocalIPv6Address: '',
+    LinkLocalIPv6PrefixLen: 0,
+    Ports: {},
+    SandboxKey: '',
+    SecondaryIPAddresses: undefined,
+    SecondaryIPv6Addresses: undefined,
+    EndpointID: '',
+    Gateway: '',
+    GlobalIPv6Address: '',
+    GlobalIPv6PrefixLen: 0,
+    IPAddress: '',
+    IPPrefixLen: 0,
+    IPv6Gateway: '',
+    MacAddress: '',
+    Networks: {},
+    Node: undefined,
+  },
+};
+
 class TestContainerProviderRegistry extends ContainerProviderRegistry {
   public getMatchingEngine(engineId: string): Dockerode {
     return super.getMatchingEngine(engineId);
@@ -3139,6 +3234,54 @@ test('check handleEvents with loadArchive', async () => {
   expect(apiSender.send).toBeCalledWith('image-loadfromarchive-event', '123456');
 });
 
+test('check volume mounted is replicated when executing replicatePodmanContainer with named volume', async () => {
+  const dockerAPI = new Dockerode({ protocol: 'http', host: 'localhost' });
+
+  const createPodmanContainerMock = vi.fn();
+  const fakeLibPod = {
+    createPodmanContainer: createPodmanContainerMock,
+  } as unknown as LibPod;
+
+  const inspectMock = vi.fn().mockResolvedValue(fakeContainerInspectInfoWithVolume);
+
+  const dockerodeContainer = {
+    inspect: inspectMock,
+  } as unknown as Dockerode.Container;
+
+  vi.spyOn(dockerAPI, 'getContainer').mockReturnValue(dockerodeContainer);
+
+  // set providers with docker being first
+  containerRegistry.addInternalProvider('podman1', {
+    name: 'podman',
+    id: 'podman1',
+    api: dockerAPI,
+    libpodApi: fakeLibPod,
+    connection: {
+      type: 'podman',
+    },
+  } as unknown as InternalContainerProvider);
+
+  await containerRegistry.replicatePodmanContainer(
+    {
+      engineId: 'podman1',
+      id: 'id',
+    },
+    {
+      engineId: 'podman1',
+    },
+    {},
+  );
+
+  expect(createPodmanContainerMock).toBeCalledWith({
+    command: fakeContainerInspectInfo.Config.Cmd,
+    entrypoint: fakeContainerInspectInfo.Config.Entrypoint,
+    env: {},
+    image: fakeContainerInspectInfo.Config.Image,
+    mounts: [],
+    volumes: [{ Dest: '/destination', Name: 'vol1' }],
+  });
+});
+
 test('check volume mounted is replicated when executing replicatePodmanContainer', async () => {
   const dockerAPI = new Dockerode({ protocol: 'http', host: 'localhost' });
 
@@ -3183,6 +3326,7 @@ test('check volume mounted is replicated when executing replicatePodmanContainer
     env: {},
     image: fakeContainerInspectInfo.Config.Image,
     mounts: fakeContainerInspectInfo.Mounts,
+    volumes: [],
   });
 });
 

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -1390,13 +1390,7 @@ export class ContainerProviderRegistry {
       }, {});
 
       // build create container configuration
-      const originalConfiguration = {
-        command: containerToReplicate.Config.Cmd,
-        entrypoint: containerToReplicate.Config.Entrypoint,
-        env: updatedEnv,
-        image: containerToReplicate.Config.Image,
-        mounts: containerToReplicate.Mounts,
-      };
+      const originalConfiguration = this.getCreateContainsOptionsFromOriginal(containerToReplicate, updatedEnv);
 
       // add extra information
       const configuration: ContainerCreateOptions = {
@@ -1410,6 +1404,30 @@ export class ContainerProviderRegistry {
     } finally {
       this.telemetryService.track('replicatePodmanContainer', telemetryOptions);
     }
+  }
+
+  /**
+   * @see https://github.com/containers/podman/issues/23337#issuecomment-2238704510
+   * @param containerToReplicate
+   * @param updatedEnv
+   * @private
+   */
+  private getCreateContainsOptionsFromOriginal(
+    containerToReplicate: ContainerInspectInfo,
+    updatedEnv: { [p: string]: string },
+  ): Record<string, unknown> {
+    return {
+      command: containerToReplicate.Config.Cmd,
+      entrypoint: containerToReplicate.Config.Entrypoint,
+      env: updatedEnv,
+      image: containerToReplicate.Config.Image,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      mounts: containerToReplicate.Mounts.filter(mount => (mount as any).Type !== 'volume'),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      volumes: containerToReplicate.Mounts.filter(mount => (mount as any).Type === 'volume').map(mount => {
+        return { Name: mount.Name, Dest: mount.Destination };
+      }),
+    };
   }
 
   async stopPod(engineId: string, podId: string): Promise<void> {

--- a/packages/main/src/plugin/dockerode/libpod-dockerode.ts
+++ b/packages/main/src/plugin/dockerode/libpod-dockerode.ts
@@ -132,6 +132,14 @@ export interface ContainerCreateNetNSOption {
   value?: string;
 }
 
+export interface ContainerCreateNamedVolume {
+  Name: string;
+  Dest: string;
+  Options?: Array<string>;
+  IsAnonymous?: boolean;
+  SubPath?: string;
+}
+
 export interface ContainerCreateOptions {
   command?: string[];
   entrypoint?: string | string[];
@@ -160,6 +168,7 @@ export interface ContainerCreateOptions {
   dns_server?: Array<Array<number>>;
   hostadd?: Array<string>;
   userns?: string;
+  volumes?: Array<ContainerCreateNamedVolume>;
 }
 
 export interface PodRemoveOptions {


### PR DESCRIPTION
Fixes #5668

### What does this PR do?

Fixes the way the container in a pod is created if the original container had name volumes

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

#5668 

### How to test this PR?

- Start a container with a named container (quay.io/centos7/redis-5-centos7:centos7)
- Podify him

- [x] Tests are covering the bug fix or the new feature
