### PR TITLE
Fix layer size

### DIFF
--- a/packages/renderer/src/lib/image/filesystem-tree.spec.ts
+++ b/packages/renderer/src/lib/image/filesystem-tree.spec.ts
@@ -93,6 +93,15 @@ test('add an existing file', () => {
   expect(tree.root.children.get('A')!.children.get('B')!.children.get('C.txt')!.children).toHaveLength(0);
 });
 
+test('add an existing directory containing files', () => {
+  const tree = new FilesystemTree<typ>('tree1')
+    .addPath('A/B/C.txt', { path: 'A/B/C.txt ' }, 5)
+    .addPath('A/B/D.txt', { path: 'A/B/D.txt ' }, 4)
+    .addPath('A/B', { path: 'A/B ' }, 0)
+    .addPath('A/B/E.txt', { path: 'A/B/E.txt ' }, 1);
+  expect(tree.size).toBe(10);
+});
+
 test('remove a non existing file', () => {
   const tree = new FilesystemTree<typ>('tree1').addPath('A/B/C.txt', { path: 'A/B/C.txt' }, 5).hidePath('A/B/D.txt');
   expect(tree.size).toBe(5);
@@ -153,4 +162,12 @@ test('hide directory content', () => {
   expect(tree.root.children.get('A')!.children.get('B')!.children.get('C.txt')!.hidden).toBeTruthy();
   expect(tree.root.children.get('A')!.children.get('B')!.children.get('D.txt')!.children).toHaveLength(0);
   expect(tree.root.children.get('A')!.children.get('B')!.children.get('D.txt')!.hidden).toBeTruthy();
+});
+
+test('isDirectory', () => {
+  const tree = new FilesystemTree<typ>('tree1').addPath('A/B/C.txt', { path: 'A/B/C.txt' }, 5);
+  expect(tree.isDirectory('/A/B')).toBeTruthy();
+  expect(tree.isDirectory('/A/C')).toBeFalsy();
+  expect(tree.isDirectory('/A/B/C.txt')).toBeFalsy();
+  expect(tree.isDirectory('/A/B/D.txt')).toBeFalsy();
 });

--- a/packages/renderer/src/lib/image/filesystem-tree.ts
+++ b/packages/renderer/src/lib/image/filesystem-tree.ts
@@ -61,6 +61,11 @@ export class FilesystemTree<T> {
 
   addPath(path: string, entry: T, size: number): FilesystemTree<T> {
     const currentSize = this.currentSize(path);
+    // If we add an already existing directory, we replace its size with its current one
+    // so we do not overwrite it (being the size of all its descendants)
+    if (currentSize && this.isDirectory(path)) {
+      size = currentSize;
+    }
     this.size += size - (currentSize ?? 0);
     const parts = path.split('/');
     let node = this.root;
@@ -181,6 +186,24 @@ export class FilesystemTree<T> {
       }
     }
     return node.size;
+  }
+
+  isDirectory(path: string): boolean {
+    const parts = path.split('/');
+    let node = this.root;
+    for (let i = 0; i < parts.length; i++) {
+      const part = parts[i];
+      if (part === '') {
+        continue;
+      }
+      const next = node.children.get(part);
+      if (next) {
+        node = next;
+      } else {
+        return false;
+      }
+    }
+    return node.children.size > 0;
   }
 
   copy(): FilesystemTree<T> {


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

When a directory was added in a layer, and the directory was already existing (with files into it), the size of the directory was reset to 0 (the size of a directory being the total size of all its descendants).

### What issues does this PR fix or reference?

Fixes #8155 

### How to test this PR?

Build an image with this Containerfile, and explore its layers in Podman Desktop, using the Image layers extension (https://github.com/containers/podman-desktop-extension-layers-explorer/pull/1):

```
FROM busybox
RUN echo -n 1 > 1.txt
RUN echo -n 12 > 2.txt
RUN echo -n 123 > 3.txt
RUN rm 2.txt
```

- [x] Tests are covering the bug fix or the new feature
