### PR TITLE
fix: remove set up podman notification if podman is set 

### DIFF
--- a/packages/main/src/plugin/notification-registry.ts
+++ b/packages/main/src/plugin/notification-registry.ts
@@ -71,7 +71,7 @@ export class NotificationRegistry {
     // return disposable object
     return Disposable.create(() => {
       disposeShowNotification.dispose();
-      this.removeNotificationById(this.notificationId);
+      this.removeNotificationById(notification.id);
       this.taskManager.deleteTask(notificationTask);
     });
   }

--- a/packages/main/src/plugin/notification-registry.ts
+++ b/packages/main/src/plugin/notification-registry.ts
@@ -57,7 +57,7 @@ export class NotificationRegistry {
     // send event
     this.apiSender.send('notifications-updated');
     // create task
-    this.taskManager.createNotificationTask({
+    const notificationTask = this.taskManager.createNotificationTask({
       title: notification.title,
       body: notification.body,
       markdownActions: notification.markdownActions,
@@ -72,6 +72,7 @@ export class NotificationRegistry {
     return Disposable.create(() => {
       disposeShowNotification.dispose();
       this.removeNotificationById(this.notificationId);
+      this.taskManager.deleteTask(notificationTask);
     });
   }
 

--- a/packages/main/src/plugin/task-manager.spec.ts
+++ b/packages/main/src/plugin/task-manager.spec.ts
@@ -217,3 +217,14 @@ test('Ensure statusbar registry', async () => {
     true,
   );
 });
+
+test('delete task should send `task-removed` message', async () => {
+  const taskManager = new TaskManager(apiSender, statusBarRegistry, commandRegistry);
+  const task = taskManager.createNotificationTask({
+    title: 'title',
+    body: 'body',
+  });
+
+  taskManager.deleteTask(task);
+  expect(apiSenderSendMock).toBeCalledWith('task-removed', task);
+});

--- a/packages/main/src/plugin/task-manager.ts
+++ b/packages/main/src/plugin/task-manager.ts
@@ -99,6 +99,11 @@ export class TaskManager {
     }
   }
 
+  public deleteTask(task: Task): void {
+    this.tasks.delete(task.id);
+    this.apiSender.send('task-removed', task);
+  }
+
   isStatefulTask(task: Task): task is StatefulTask {
     return 'state' in task;
   }


### PR DESCRIPTION
### What does this PR do?

There have been some complains about the notification that asks the user to set up podman being visible even after podman has actually been set up https://github.com/containers/podman-desktop/issues/7979 and https://github.com/containers/podman-desktop/issues/7969. 

I was not able to find an exact replicator so this PR is just a proposal by looking at the code.
What changes:
1) The Podman extension disposes its own notification if podman is correctly set up
2) The podman core is updated so that when a notification is disposed, also its related task in the taskManager is removed.

This way, we should be safe that, in any moment, when podman is correctly set up, the user will not see the "set up" notification anywhere. 

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

it resolves #7969 and 7979

### How to test this PR?

1. have podman installed without any machine
2. verify the set up notification is there
3. create a new machine
4. you should see no notifications
5. remove the machine
6. you should see the notification again

- [ ] Tests are covering the bug fix or the new feature
