### PR TITLE
Add arm64 installer to publish-to-winget.yaml

### DIFF
--- a/.github/workflows/publish-to-winget.yaml
+++ b/.github/workflows/publish-to-winget.yaml
@@ -61,9 +61,10 @@ jobs:
     steps:
       - name: Create winget PR
         run: |
-          iwr https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
-          .\wingetcreate.exe update RedHat.Podman-Desktop -u $Env:URL -v $Env:VERSION -t $Env:TOKEN --submit
+          Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
+          .\wingetcreate.exe update RedHat.Podman-Desktop -u $Env:URL_X64 $Env:URL_ARM64 -v $Env:VERSION -t $Env:TOKEN --submit
         env:
           TOKEN: ${{ secrets.PODMAN_DESKTOP_BOT_TOKEN }}
           VERSION: ${{ needs.version.outputs.desktopVersion }}
-          URL: ${{ format('https://github.com/containers/podman-desktop/releases/download/v{0}/podman-desktop-{0}-setup.exe|x64', needs.version.outputs.desktopVersion) }}
+          URL_X64: ${{ format('https://github.com/containers/podman-desktop/releases/download/v{0}/podman-desktop-{0}-setup.exe|x64', needs.version.outputs.desktopVersion) }}
+          URL_ARM64: ${{ format('https://github.com/containers/podman-desktop/releases/download/v{0}/podman-desktop-{0}-setup-arm64.exe|arm64', needs.version.outputs.desktopVersion) }}

--- a/.github/workflows/publish-to-winget.yaml
+++ b/.github/workflows/publish-to-winget.yaml
@@ -66,5 +66,5 @@ jobs:
         env:
           TOKEN: ${{ secrets.PODMAN_DESKTOP_BOT_TOKEN }}
           VERSION: ${{ needs.version.outputs.desktopVersion }}
-          URL_X64: ${{ format('https://github.com/containers/podman-desktop/releases/download/v{0}/podman-desktop-{0}-setup.exe|x64', needs.version.outputs.desktopVersion) }}
+          URL_X64: ${{ format('https://github.com/containers/podman-desktop/releases/download/v{0}/podman-desktop-{0}-setup-x64.exe|x64', needs.version.outputs.desktopVersion) }}
           URL_ARM64: ${{ format('https://github.com/containers/podman-desktop/releases/download/v{0}/podman-desktop-{0}-setup-arm64.exe|arm64', needs.version.outputs.desktopVersion) }}


### PR DESCRIPTION
### What does this PR do?
Changes the winget publication workflow to create winget manifests that include _both_ x64 and arm64 builds.  The previous version only published manifests with the x64 build.

PowerShell command alias 'iwr' replaced with the full command name 'Invoke-WebRequest' as per [PowerShell best practices](https://learn.microsoft.com/en-us/powershell/scripting/learn/shell/using-aliases?view=powershell-7.4#dont-use-aliases-in-scripts).

### What issues does this PR fix or reference?
#8160 

### How to test this PR?
Local testing is farily simple:
```powershell
# Install wingetcreate
Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
# Define testing values
$URL_X64 = 'https://github.com/containers/podman-desktop/releases/download/v1.11.1/podman-desktop-1.11.1-setup-x64.exe|x64'
$URL_ARM64 = 'https://github.com/containers/podman-desktop/releases/download/v1.11.1/podman-desktop-1.11.1-setup-arm64.exe|arm64'
$VERSION = '1.11.1'
# Execute wingetcreate and output result to file instead of publishing.
.\wingetcreate.exe update RedHat.Podman-Desktop -u $URL_X64 $URL_ARM64 -v $VERSION -o "$env:USERPROFILE\winget-manifest"
```

I'm less certain of how to test a github workflow specifically as I've never really worked on one before.
