### PR TITLE
chore: light loading screen

### DIFF
--- a/packages/renderer/index.html
+++ b/packages/renderer/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1.0" />
     <title>Podman Desktop</title>
   </head>
-  <body class="overflow-hidden text-[var(--pd-default-text)] text-base">
+  <body class="overflow-hidden text-[var(--pd-default-text)] text-base bg-[var(--pd-titlebar-bg)]">
     <div id="app"></div>
     <script type="module" src="/src/main.ts"></script>
   </body>

--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -55,7 +55,6 @@ import PVCList from './lib/pvc/PVCList.svelte';
 import ServiceDetails from './lib/service/ServiceDetails.svelte';
 import ServicesList from './lib/service/ServicesList.svelte';
 import StatusBar from './lib/statusbar/StatusBar.svelte';
-import ColorsStyle from './lib/style/ColorsStyle.svelte';
 import IconsStyle from './lib/style/IconsStyle.svelte';
 import TaskManager from './lib/task-manager/TaskManager.svelte';
 import ToastHandler from './lib/toast/ToastHandler.svelte';
@@ -86,8 +85,7 @@ window.events?.receive('navigate', (navigationRequest: unknown) => {
 </script>
 
 <Route path="/*" breadcrumb="Home" let:meta>
-  <main class="flex flex-col w-screen h-screen overflow-hidden bg-charcoal-800">
-    <ColorsStyle />
+  <main class="flex flex-col w-screen h-screen overflow-hidden">
     <IconsStyle />
     <Appearance />
     <TitleBar />

--- a/packages/renderer/src/Loader.svelte
+++ b/packages/renderer/src/Loader.svelte
@@ -4,6 +4,7 @@ import { router } from 'tinro';
 
 import App from './App.svelte';
 import SealRocket from './lib/images/SealRocket.svelte';
+import ColorsStyle from './lib/style/ColorsStyle.svelte';
 import { lastPage } from './stores/breadcrumb';
 
 let systemReady = false;
@@ -84,6 +85,8 @@ window.events.receive('starting-extensions', (value: unknown) => {
   clearInterval(loadingSequence);
 });
 </script>
+
+<ColorsStyle />
 
 {#if !systemReady}
   <main class="flex flex-row w-screen h-screen justify-center" style="-webkit-app-region: drag;">


### PR DESCRIPTION
### What does this PR do?

Support for light (or dark) loading screen.

- Use the titlebar color as the default screen color (and remove hard-coded bg color from App).
- In order to get the color stylesheet, 'ColorStyle' needs to move 'up' one level to Loader. Although this implies that we're loading it earlier in the sequence and possibly before the color registry is filled, I couldn't tell any difference in initial flicker in light or dark mode.

### Screenshot / video of UI

<img width="627" alt="Screenshot 2024-07-22 at 3 42 15 PM" src="https://github.com/user-attachments/assets/c3776f5b-32a8-466d-aa10-0f8559a98490">

### What issues does this PR fix or reference?

Fixes #8001.

### How to test this PR?

Switch to light mode and restart.