### PR TITLE
feat: terminal light and dark mode selection

### DIFF
--- a/packages/main/src/plugin/terminal-init.ts
+++ b/packages/main/src/plugin/terminal-init.ts
@@ -47,10 +47,9 @@ export class TerminalInit {
           maximum: 4,
         },
         [TerminalSettings.SectionName + '.' + TerminalSettings.Theme]: {
-          description:
-            'Theme to be used when displaying terminal operations. Requires refreshing terminal screen after configuration change.',
+          description: 'Theme for terminal windows. Requires refreshing terminal screen after configuration change.',
           type: 'string',
-          default: 'Dark',
+          default: 'dark',
           // Uses the list of themes in terminal-theme.ts
           enum: Object.keys(themes),
         },

--- a/packages/main/src/plugin/terminal-init.ts
+++ b/packages/main/src/plugin/terminal-init.ts
@@ -18,6 +18,7 @@
 
 import type { IConfigurationNode, IConfigurationRegistry } from './configuration-registry.js';
 import { TerminalSettings } from './terminal-settings.js';
+import { themes } from './terminal-theme.js';
 
 export class TerminalInit {
   private static DEFAULT_LINE_HEIGHT = 1;
@@ -44,6 +45,14 @@ export class TerminalInit {
           default: TerminalInit.DEFAULT_LINE_HEIGHT,
           minimum: 1,
           maximum: 4,
+        },
+        [TerminalSettings.SectionName + '.' + TerminalSettings.Theme]: {
+          description:
+            'Theme to be used when displaying terminal operations. Requires refreshing terminal screen after configuration change.',
+          type: 'string',
+          default: 'Dark',
+          // Uses the list of themes in terminal-theme.ts
+          enum: Object.keys(themes),
         },
       },
     };

--- a/packages/main/src/plugin/terminal-settings.ts
+++ b/packages/main/src/plugin/terminal-settings.ts
@@ -20,4 +20,5 @@ export enum TerminalSettings {
   SectionName = 'terminal',
   FontSize = 'integrated.fontSize',
   LineHeight = 'integrated.lineHeight',
+  Theme = 'integrated.theme',
 }

--- a/packages/main/src/plugin/terminal-theme.spec.ts
+++ b/packages/main/src/plugin/terminal-theme.spec.ts
@@ -1,0 +1,72 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { expect, test } from 'vitest';
+
+import { defaultTheme, getTerminalTheme, themes } from './terminal-theme.js';
+
+test('should return the correct theme by name', () => {
+  const darkTheme = getTerminalTheme('Dark');
+  expect(darkTheme).toEqual(themes['Dark']);
+
+  const lightTheme = getTerminalTheme('Light');
+  expect(lightTheme).toEqual(themes['Light']);
+
+  const solarizedDarkTheme = getTerminalTheme('Solarized Dark');
+  expect(solarizedDarkTheme).toEqual(themes['Solarized Dark']);
+
+  const solarizedLightTheme = getTerminalTheme('Solarized Light');
+  expect(solarizedLightTheme).toEqual(themes['Solarized Light']);
+
+  const zenburnTheme = getTerminalTheme('Zenburn');
+  expect(zenburnTheme).toEqual(themes['Zenburn']);
+});
+
+test('should return the default theme if theme name is undefined', () => {
+  const theme = getTerminalTheme(undefined);
+  expect(theme).toEqual(defaultTheme);
+});
+
+test('should return the default theme if theme name does not exist', () => {
+  const theme = getTerminalTheme('NonExistentTheme');
+  expect(theme).toEqual(defaultTheme);
+});
+
+test('themes should all have correct properties', () => {
+  Object.values(themes).forEach(theme => {
+    expect(theme).toHaveProperty('foreground');
+    expect(theme).toHaveProperty('background');
+    expect(theme).toHaveProperty('cursor');
+    expect(theme).toHaveProperty('black');
+    expect(theme).toHaveProperty('brightBlack');
+    expect(theme).toHaveProperty('red');
+    expect(theme).toHaveProperty('brightRed');
+    expect(theme).toHaveProperty('green');
+    expect(theme).toHaveProperty('brightGreen');
+    expect(theme).toHaveProperty('yellow');
+    expect(theme).toHaveProperty('brightYellow');
+    expect(theme).toHaveProperty('blue');
+    expect(theme).toHaveProperty('brightBlue');
+    expect(theme).toHaveProperty('magenta');
+    expect(theme).toHaveProperty('brightMagenta');
+    expect(theme).toHaveProperty('cyan');
+    expect(theme).toHaveProperty('brightCyan');
+    expect(theme).toHaveProperty('white');
+    expect(theme).toHaveProperty('brightWhite');
+  });
+});

--- a/packages/main/src/plugin/terminal-theme.spec.ts
+++ b/packages/main/src/plugin/terminal-theme.spec.ts
@@ -21,20 +21,11 @@ import { expect, test } from 'vitest';
 import { defaultTheme, getTerminalTheme, themes } from './terminal-theme.js';
 
 test('should return the correct theme by name', () => {
-  const darkTheme = getTerminalTheme('Dark');
-  expect(darkTheme).toEqual(themes['Dark']);
+  const darkTheme = getTerminalTheme('dark');
+  expect(darkTheme).toEqual(themes['dark']);
 
-  const lightTheme = getTerminalTheme('Light');
-  expect(lightTheme).toEqual(themes['Light']);
-
-  const solarizedDarkTheme = getTerminalTheme('Solarized Dark');
-  expect(solarizedDarkTheme).toEqual(themes['Solarized Dark']);
-
-  const solarizedLightTheme = getTerminalTheme('Solarized Light');
-  expect(solarizedLightTheme).toEqual(themes['Solarized Light']);
-
-  const zenburnTheme = getTerminalTheme('Zenburn');
-  expect(zenburnTheme).toEqual(themes['Zenburn']);
+  const lightTheme = getTerminalTheme('light');
+  expect(lightTheme).toEqual(themes['light']);
 });
 
 test('should return the default theme if theme name is undefined', () => {

--- a/packages/main/src/plugin/terminal-theme.ts
+++ b/packages/main/src/plugin/terminal-theme.ts
@@ -1,0 +1,207 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import type { ITheme } from 'xterm';
+
+/**
+ * Below is a curated list of terminal themes that are available for selection / use within Podman Desktop.
+ * The 'colors' are sourced from multiple repos and cross-checked for accuracy.
+ * Each theme will have references to the original repo.
+ *
+ * Notes:
+ * - Light themes will have a darker cursor colour as well as a darker selectionForeground colour to improve visibility
+ */
+
+// Common 'visibility' elements for light theme requirements
+const LightThemeVisibilityChanges = {
+  cursor: '#000000',
+  selectionBackground: '#f0f0f0',
+  selectionForeground: '#000000',
+};
+
+// From: https://github.com/ysk2014/xterm-theme/blob/master/src/iterm/Solarized_Dark.js
+const SolarizedDark: ITheme = {
+  foreground: '#708284',
+  background: '#001e27',
+  cursor: '#708284',
+
+  black: '#002831',
+  brightBlack: '#001e27',
+
+  red: '#d11c24',
+  brightRed: '#bd3613',
+
+  green: '#738a05',
+  brightGreen: '#475b62',
+
+  yellow: '#a57706',
+  brightYellow: '#536870',
+
+  blue: '#2176c7',
+  brightBlue: '#708284',
+
+  magenta: '#c61c6f',
+  brightMagenta: '#5956ba',
+
+  cyan: '#259286',
+  brightCyan: '#819090',
+
+  white: '#eae3cb',
+  brightWhite: '#fcf4dc',
+};
+
+// Same as above, but with different background, foreground and cursor colors
+const SolarizedLight: ITheme = {
+  ...SolarizedDark,
+  ...LightThemeVisibilityChanges,
+  foreground: '#536870',
+  background: '#fcf4dc',
+};
+
+// From https://github.com/ysk2014/xterm-theme/blob/master/src/iterm/Zenburn.js
+const Zenburn: ITheme = {
+  foreground: '#dcdccc',
+  background: '#3f3f3f',
+  cursor: '#73635a',
+
+  black: '#4d4d4d',
+  brightBlack: '#709080',
+
+  red: '#705050',
+  brightRed: '#dca3a3',
+
+  green: '#60b48a',
+  brightGreen: '#c3bf9f',
+
+  yellow: '#f0dfaf',
+  brightYellow: '#e0cf9f',
+
+  blue: '#506070',
+  brightBlue: '#94bff3',
+
+  magenta: '#dc8cc3',
+  brightMagenta: '#ec93d3',
+
+  cyan: '#8cd0d3',
+  brightCyan: '#93e0e3',
+
+  white: '#dcdccc',
+  brightWhite: '#ffffff',
+};
+
+// Cross-referenced between three different theme sources:
+// https://marketplace.visualstudio.com/items?itemName=SuperPaintman.monokai-extended
+// https://github.com/phanviet/vim-monokai-pro
+// https://monokai.pro/
+// to determine the best colours. Then tested in xterm.js / Podman Desktop for visibility.
+// Monokai theme
+const MonokaiDark: ITheme = {
+  foreground: '#f8f8f2',
+  background: '#272822',
+  cursor: '#f8f8f0',
+
+  black: '#272822',
+  brightBlack: '#75715e',
+
+  red: '#f92672',
+  brightRed: '#ff669d',
+
+  green: '#a6e22e',
+  brightGreen: '#b6e354',
+
+  yellow: '#f4bf75',
+  brightYellow: '#f5d897',
+
+  blue: '#66d9ef',
+  brightBlue: '#a1efe4',
+
+  magenta: '#ae81ff',
+  brightMagenta: '#fd5ff0',
+
+  cyan: '#a1efe4',
+  brightCyan: '#a1efe4',
+
+  white: '#f8f8f2',
+  brightWhite: '#ffffff',
+};
+
+// Monokai Light theme
+const MonokaiLight: ITheme = {
+  ...MonokaiDark,
+  ...LightThemeVisibilityChanges,
+  foreground: '#49483e',
+  background: '#f9f8f5',
+};
+
+// "DefaultDark" theme with standard high-contrast colours
+// default colours are from xterm.js
+const DefaultDark: ITheme = {
+  foreground: '#ffffff',
+  background: '#000000',
+  cursor: '#ffffff',
+
+  black: '#000000',
+  brightBlack: '#666666',
+
+  red: '#990000',
+  brightRed: '#e50000',
+
+  green: '#00a600',
+  brightGreen: '#00d900',
+
+  yellow: '#999900',
+  brightYellow: '#e5e500',
+
+  blue: '#0000b2',
+  brightBlue: '#0000ff',
+
+  magenta: '#b200b2',
+  brightMagenta: '#e500e5',
+
+  cyan: '#00a6b2',
+  brightCyan: '#00e5e5',
+
+  white: '#bfbfbf',
+  brightWhite: '#e5e5e5',
+};
+
+// Same as DefaultDark, but with different background, foreground and cursor colors
+const DefaultLight: ITheme = {
+  ...DefaultDark,
+  ...LightThemeVisibilityChanges,
+  foreground: '#000000',
+  background: '#ffffff',
+};
+
+export const themes: { [key: string]: ITheme } = {
+  Dark: DefaultDark,
+  Light: DefaultLight,
+  'Monokai Dark': MonokaiDark,
+  'Monokai Light': MonokaiLight,
+  'Solarized Dark': SolarizedDark,
+  'Solarized Light': SolarizedLight,
+  Zenburn: Zenburn,
+};
+
+// Default to dark theme
+export const defaultTheme = DefaultDark;
+
+// Get the theme, but default to default theme if not found
+export function getTerminalTheme(themeName: string | undefined): ITheme {
+  // If undefined or not found somehow, instead of being unable to display it, return the default theme
+  return themes[themeName ?? 'Default Dark'] ?? defaultTheme;
+}

--- a/packages/main/src/plugin/terminal-theme.ts
+++ b/packages/main/src/plugin/terminal-theme.ts
@@ -18,12 +18,8 @@
 import type { ITheme } from 'xterm';
 
 /**
- * Below is a curated list of terminal themes that are available for selection / use within Podman Desktop.
- * The 'colors' are sourced from multiple repos and cross-checked for accuracy.
- * Each theme will have references to the original repo.
- *
- * Notes:
- * - Light themes will have a darker cursor colour as well as a darker selectionForeground colour to improve visibility
+ * Below are a list of themes that can be used in the terminal, it is either dark or light.
+ * Light themes will have a darker cursor colour as well as a darker selectionForeground colour to improve visibility
  */
 
 // Common 'visibility' elements for light theme requirements
@@ -31,120 +27,6 @@ const LightThemeVisibilityChanges = {
   cursor: '#000000',
   selectionBackground: '#f0f0f0',
   selectionForeground: '#000000',
-};
-
-// From: https://github.com/ysk2014/xterm-theme/blob/master/src/iterm/Solarized_Dark.js
-const SolarizedDark: ITheme = {
-  foreground: '#708284',
-  background: '#001e27',
-  cursor: '#708284',
-
-  black: '#002831',
-  brightBlack: '#001e27',
-
-  red: '#d11c24',
-  brightRed: '#bd3613',
-
-  green: '#738a05',
-  brightGreen: '#475b62',
-
-  yellow: '#a57706',
-  brightYellow: '#536870',
-
-  blue: '#2176c7',
-  brightBlue: '#708284',
-
-  magenta: '#c61c6f',
-  brightMagenta: '#5956ba',
-
-  cyan: '#259286',
-  brightCyan: '#819090',
-
-  white: '#eae3cb',
-  brightWhite: '#fcf4dc',
-};
-
-// Same as above, but with different background, foreground and cursor colors
-const SolarizedLight: ITheme = {
-  ...SolarizedDark,
-  ...LightThemeVisibilityChanges,
-  foreground: '#536870',
-  background: '#fcf4dc',
-};
-
-// From https://github.com/ysk2014/xterm-theme/blob/master/src/iterm/Zenburn.js
-const Zenburn: ITheme = {
-  foreground: '#dcdccc',
-  background: '#3f3f3f',
-  cursor: '#73635a',
-
-  black: '#4d4d4d',
-  brightBlack: '#709080',
-
-  red: '#705050',
-  brightRed: '#dca3a3',
-
-  green: '#60b48a',
-  brightGreen: '#c3bf9f',
-
-  yellow: '#f0dfaf',
-  brightYellow: '#e0cf9f',
-
-  blue: '#506070',
-  brightBlue: '#94bff3',
-
-  magenta: '#dc8cc3',
-  brightMagenta: '#ec93d3',
-
-  cyan: '#8cd0d3',
-  brightCyan: '#93e0e3',
-
-  white: '#dcdccc',
-  brightWhite: '#ffffff',
-};
-
-// Cross-referenced between three different theme sources:
-// https://marketplace.visualstudio.com/items?itemName=SuperPaintman.monokai-extended
-// https://github.com/phanviet/vim-monokai-pro
-// https://monokai.pro/
-// to determine the best colours. Then tested in xterm.js / Podman Desktop for visibility.
-// Monokai theme
-const MonokaiDark: ITheme = {
-  foreground: '#f8f8f2',
-  background: '#272822',
-  cursor: '#f8f8f0',
-
-  black: '#272822',
-  brightBlack: '#75715e',
-
-  red: '#f92672',
-  brightRed: '#ff669d',
-
-  green: '#a6e22e',
-  brightGreen: '#b6e354',
-
-  yellow: '#f4bf75',
-  brightYellow: '#f5d897',
-
-  blue: '#66d9ef',
-  brightBlue: '#a1efe4',
-
-  magenta: '#ae81ff',
-  brightMagenta: '#fd5ff0',
-
-  cyan: '#a1efe4',
-  brightCyan: '#a1efe4',
-
-  white: '#f8f8f2',
-  brightWhite: '#ffffff',
-};
-
-// Monokai Light theme
-const MonokaiLight: ITheme = {
-  ...MonokaiDark,
-  ...LightThemeVisibilityChanges,
-  foreground: '#49483e',
-  background: '#f9f8f5',
 };
 
 // "DefaultDark" theme with standard high-contrast colours
@@ -188,13 +70,8 @@ const DefaultLight: ITheme = {
 };
 
 export const themes: { [key: string]: ITheme } = {
-  Dark: DefaultDark,
-  Light: DefaultLight,
-  'Monokai Dark': MonokaiDark,
-  'Monokai Light': MonokaiLight,
-  'Solarized Dark': SolarizedDark,
-  'Solarized Light': SolarizedLight,
-  Zenburn: Zenburn,
+  dark: DefaultDark,
+  light: DefaultLight,
 };
 
 // Default to dark theme
@@ -203,5 +80,5 @@ export const defaultTheme = DefaultDark;
 // Get the theme, but default to default theme if not found
 export function getTerminalTheme(themeName: string | undefined): ITheme {
   // If undefined or not found somehow, instead of being unable to display it, return the default theme
-  return themes[themeName ?? 'Default Dark'] ?? defaultTheme;
+  return themes[themeName ?? 'dark'] ?? defaultTheme;
 }

--- a/packages/renderer/src/lib/compose/ComposeDetailsLogs.svelte
+++ b/packages/renderer/src/lib/compose/ComposeDetailsLogs.svelte
@@ -7,7 +7,7 @@ import { Terminal } from 'xterm';
 import { FitAddon } from 'xterm-addon-fit';
 
 import { TerminalSettings } from '../../../../main/src/plugin/terminal-settings';
-import { getPanelDetailColor } from '../color/color';
+import { getTerminalTheme } from '../../../../main/src/plugin/terminal-theme';
 import { ansi256Colours, colourizedANSIContainerName } from '../editor/editor-utils';
 import { isMultiplexedLog } from '../stream/stream-utils';
 import NoLogIcon from '../ui/NoLogIcon.svelte';
@@ -119,14 +119,15 @@ async function refreshTerminal() {
   const lineHeight = await window.getConfigurationValue<number>(
     TerminalSettings.SectionName + '.' + TerminalSettings.LineHeight,
   );
+  const terminalTheme = await window.getConfigurationValue<string>(
+    TerminalSettings.SectionName + '.' + TerminalSettings.Theme,
+  );
 
   logsTerminal = new Terminal({
     fontSize,
     lineHeight,
     disableStdin: true,
-    theme: {
-      background: getPanelDetailColor(),
-    },
+    theme: getTerminalTheme(terminalTheme),
     convertEol: true,
   });
   termFit = new FitAddon();

--- a/packages/renderer/src/lib/container/ContainerDetailsLogs.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetailsLogs.svelte
@@ -7,7 +7,7 @@ import { Terminal } from 'xterm';
 import { FitAddon } from 'xterm-addon-fit';
 
 import { TerminalSettings } from '../../../../main/src/plugin/terminal-settings';
-import { getPanelDetailColor } from '../color/color';
+import { getTerminalTheme } from '../../../../main/src/plugin/terminal-theme';
 import { isMultiplexedLog } from '../stream/stream-utils';
 import NoLogIcon from '../ui/NoLogIcon.svelte';
 import type { ContainerInfoUI } from './ContainerInfoUI';
@@ -73,14 +73,15 @@ async function refreshTerminal() {
   const lineHeight = await window.getConfigurationValue<number>(
     TerminalSettings.SectionName + '.' + TerminalSettings.LineHeight,
   );
+  const terminalTheme = await window.getConfigurationValue<string>(
+    TerminalSettings.SectionName + '.' + TerminalSettings.Theme,
+  );
 
   logsTerminal = new Terminal({
     fontSize,
     lineHeight,
     disableStdin: true,
-    theme: {
-      background: getPanelDetailColor(),
-    },
+    theme: getTerminalTheme(terminalTheme),
     convertEol: true,
   });
   termFit = new FitAddon();

--- a/packages/renderer/src/lib/container/ContainerDetailsTerminal.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetailsTerminal.svelte
@@ -10,7 +10,7 @@ import { FitAddon } from 'xterm-addon-fit';
 import { getExistingTerminal, registerTerminal } from '/@/stores/container-terminal-store';
 
 import { TerminalSettings } from '../../../../main/src/plugin/terminal-settings';
-import { getPanelDetailColor } from '../color/color';
+import { getTerminalTheme } from '../../../../main/src/plugin/terminal-theme';
 import NoLogIcon from '../ui/NoLogIcon.svelte';
 import type { ContainerInfoUI } from './ContainerInfoUI';
 
@@ -84,6 +84,9 @@ async function refreshTerminal() {
   const lineHeight = await window.getConfigurationValue<number>(
     TerminalSettings.SectionName + '.' + TerminalSettings.LineHeight,
   );
+  const terminalTheme = await window.getConfigurationValue<string>(
+    TerminalSettings.SectionName + '.' + TerminalSettings.Theme,
+  );
 
   // get terminal if any
   const existingTerminal = getExistingTerminal(container.engineId, container.id);
@@ -100,9 +103,7 @@ async function refreshTerminal() {
       fontSize,
       lineHeight,
       screenReaderMode,
-      theme: {
-        background: getPanelDetailColor(),
-      },
+      theme: getTerminalTheme(terminalTheme),
     });
   }
 

--- a/packages/renderer/src/lib/container/ContainerDetailsTtyTerminal.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetailsTtyTerminal.svelte
@@ -8,7 +8,7 @@ import { Terminal } from 'xterm';
 import { FitAddon } from 'xterm-addon-fit';
 
 import { TerminalSettings } from '../../../../main/src/plugin/terminal-settings';
-import { getPanelDetailColor } from '../color/color';
+import { getTerminalTheme } from '../../../../main/src/plugin/terminal-theme';
 import NoLogIcon from '../ui/NoLogIcon.svelte';
 import type { ContainerInfoUI } from './ContainerInfoUI';
 
@@ -68,14 +68,15 @@ async function refreshTerminal() {
   const lineHeight = await window.getConfigurationValue<number>(
     TerminalSettings.SectionName + '.' + TerminalSettings.LineHeight,
   );
+  const terminalTheme = await window.getConfigurationValue<string>(
+    TerminalSettings.SectionName + '.' + TerminalSettings.Theme,
+  );
 
   attachContainerTerminal = new Terminal({
     fontSize,
     lineHeight,
     screenReaderMode,
-    theme: {
-      background: getPanelDetailColor(),
-    },
+    theme: getTerminalTheme(terminalTheme),
   });
 
   const fitAddon = new FitAddon();

--- a/packages/renderer/src/lib/dashboard/ProviderConfiguring.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderConfiguring.svelte
@@ -9,6 +9,7 @@ import { FitAddon } from 'xterm-addon-fit';
 import type { CheckStatus, ProviderInfo } from '/@api/provider-info';
 
 import { TerminalSettings } from '../../../../main/src/plugin/terminal-settings';
+import { getTerminalTheme } from '../../../../main/src/plugin/terminal-theme';
 import { getPanelDetailColor } from '../color/color';
 import Steps from '../ui/Steps.svelte';
 import PreflightChecks from './PreflightChecks.svelte';
@@ -43,14 +44,15 @@ async function refreshTerminal() {
   const lineHeight = await window.getConfigurationValue<number>(
     TerminalSettings.SectionName + '.' + TerminalSettings.LineHeight,
   );
+  const terminalTheme = await window.getConfigurationValue<string>(
+    TerminalSettings.SectionName + '.' + TerminalSettings.Theme,
+  );
 
   logsTerminal = new Terminal({
     fontSize,
     lineHeight,
     disableStdin: true,
-    theme: {
-      background: getPanelDetailColor(),
-    },
+    theme: getTerminalTheme(terminalTheme),
     convertEol: true,
   });
   termFit = new FitAddon();

--- a/packages/renderer/src/lib/dashboard/ProviderInstalled.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderInstalled.svelte
@@ -9,6 +9,7 @@ import { FitAddon } from 'xterm-addon-fit';
 import type { CheckStatus, ProviderInfo } from '/@api/provider-info';
 
 import { TerminalSettings } from '../../../../main/src/plugin/terminal-settings';
+import { getTerminalTheme } from '../../../../main/src/plugin/terminal-theme';
 import { getPanelDetailColor } from '../color/color';
 import Steps from '../ui/Steps.svelte';
 import PreflightChecks from './PreflightChecks.svelte';
@@ -78,14 +79,15 @@ async function refreshTerminal() {
   const lineHeight = await window.getConfigurationValue<number>(
     TerminalSettings.SectionName + '.' + TerminalSettings.LineHeight,
   );
+  const terminalTheme = await window.getConfigurationValue<string>(
+    TerminalSettings.SectionName + '.' + TerminalSettings.Theme,
+  );
 
   logsTerminal = new Terminal({
     fontSize,
     lineHeight,
     disableStdin: true,
-    theme: {
-      background: getPanelDetailColor(),
-    },
+    theme: getTerminalTheme(terminalTheme),
     convertEol: true,
   });
   termFit = new FitAddon();

--- a/packages/renderer/src/lib/image/PushImageModal.svelte
+++ b/packages/renderer/src/lib/image/PushImageModal.svelte
@@ -8,6 +8,7 @@ import { Terminal } from 'xterm';
 import { FitAddon } from 'xterm-addon-fit';
 
 import { TerminalSettings } from '../../../../main/src/plugin/terminal-settings';
+import { getTerminalTheme } from '../../../../main/src/plugin/terminal-theme';
 import Dialog from '../dialogs/Dialog.svelte';
 import type { ImageInfoUI } from './ImageInfoUI';
 
@@ -48,8 +49,11 @@ async function initTerminal() {
   const lineHeight = await window.getConfigurationValue<number>(
     TerminalSettings.SectionName + '.' + TerminalSettings.LineHeight,
   );
+  const terminalTheme = await window.getConfigurationValue<string>(
+    TerminalSettings.SectionName + '.' + TerminalSettings.Theme,
+  );
 
-  logsPush = new Terminal({ fontSize, lineHeight, disableStdin: true });
+  logsPush = new Terminal({ fontSize, lineHeight, disableStdin: true, theme: getTerminalTheme(terminalTheme) });
   const fitAddon = new FitAddon();
   logsPush.loadAddon(fitAddon);
 

--- a/packages/renderer/src/lib/pod/KubernetesTerminal.svelte
+++ b/packages/renderer/src/lib/pod/KubernetesTerminal.svelte
@@ -4,10 +4,10 @@ import { router } from 'tinro';
 import { type IDisposable, Terminal } from 'xterm';
 import { FitAddon } from 'xterm-addon-fit';
 
-import { getPanelDetailColor } from '/@/lib/color/color';
 import { terminalStates } from '/@/stores/kubernetes-terminal-state-store';
 
 import { TerminalSettings } from '../../../../main/src/plugin/terminal-settings';
+import { getTerminalTheme } from '../../../../main/src/plugin/terminal-theme';
 
 export let podName: string;
 export let containerName: string;
@@ -88,14 +88,15 @@ async function initializeNewTerminal(container: HTMLElement) {
   const lineHeight = await window.getConfigurationValue<number>(
     TerminalSettings.SectionName + '.' + TerminalSettings.LineHeight,
   );
+  const terminalTheme = await window.getConfigurationValue<string>(
+    TerminalSettings.SectionName + '.' + TerminalSettings.Theme,
+  );
 
   shellTerminal = new Terminal({
     fontSize,
     lineHeight,
     screenReaderMode,
-    theme: {
-      background: getPanelDetailColor(),
-    },
+    theme: getTerminalTheme(terminalTheme),
   });
 
   id = await window.kubernetesExec(
@@ -153,4 +154,4 @@ function saveTerminalState(podName: string, containerName: string, state: State)
 }
 </script>
 
-<div class="h-full w-full" bind:this={terminalXtermDiv}></div>
+<div class="h-full w-full m-1" bind:this={terminalXtermDiv}></div>

--- a/packages/renderer/src/lib/pod/PodDetailsLogs.svelte
+++ b/packages/renderer/src/lib/pod/PodDetailsLogs.svelte
@@ -7,7 +7,7 @@ import { Terminal } from 'xterm';
 import { FitAddon } from 'xterm-addon-fit';
 
 import { TerminalSettings } from '../../../../main/src/plugin/terminal-settings';
-import { getPanelDetailColor } from '../color/color';
+import { getTerminalTheme } from '../../../../main/src/plugin/terminal-theme';
 import { ansi256Colours, colourizedANSIContainerName } from '../editor/editor-utils';
 import { isMultiplexedLog } from '../stream/stream-utils';
 import NoLogIcon from '../ui/NoLogIcon.svelte';
@@ -112,14 +112,15 @@ async function refreshTerminal() {
   const lineHeight = await window.getConfigurationValue<number>(
     TerminalSettings.SectionName + '.' + TerminalSettings.LineHeight,
   );
+  const terminalTheme = await window.getConfigurationValue<string>(
+    TerminalSettings.SectionName + '.' + TerminalSettings.Theme,
+  );
 
   logsTerminal = new Terminal({
     fontSize,
     lineHeight,
     disableStdin: true,
-    theme: {
-      background: getPanelDetailColor(),
-    },
+    theme: getTerminalTheme(terminalTheme),
     convertEol: true,
   });
   termFit = new FitAddon();

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionDetailsLogs.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionDetailsLogs.svelte
@@ -9,6 +9,7 @@ import { FitAddon } from 'xterm-addon-fit';
 import type { ProviderContainerConnectionInfo, ProviderKubernetesConnectionInfo } from '/@api/provider-info';
 
 import { TerminalSettings } from '../../../../main/src/plugin/terminal-settings';
+import { getTerminalTheme } from '../../../../main/src/plugin/terminal-theme';
 import { getPanelDetailColor } from '../color/color';
 import NoLogIcon from '../ui/NoLogIcon.svelte';
 import { writeToTerminal } from './Util';
@@ -54,13 +55,15 @@ onMount(async () => {
   const lineHeight = await window.getConfigurationValue<number>(
     TerminalSettings.SectionName + '.' + TerminalSettings.LineHeight,
   );
+  const terminalTheme = await window.getConfigurationValue<string>(
+    TerminalSettings.SectionName + '.' + TerminalSettings.Theme,
+  );
+
   logsTerminal = new Terminal({
     fontSize,
     lineHeight,
     disableStdin: true,
-    theme: {
-      background: getPanelDetailColor(),
-    },
+    theme: getTerminalTheme(terminalTheme),
     convertEol: true,
   });
   // Refresh the terminal on initial load

--- a/packages/renderer/src/lib/ui/TerminalWindow.svelte
+++ b/packages/renderer/src/lib/ui/TerminalWindow.svelte
@@ -6,6 +6,7 @@ import { Terminal } from 'xterm';
 import { FitAddon } from 'xterm-addon-fit';
 
 import { TerminalSettings } from '../../../../main/src/plugin/terminal-settings';
+import { getTerminalTheme } from '../../../../main/src/plugin/terminal-theme';
 
 export let terminal: Terminal;
 
@@ -26,8 +27,11 @@ async function refreshTerminal(): Promise<void> {
   const lineHeight = await window.getConfigurationValue<number>(
     TerminalSettings.SectionName + '.' + TerminalSettings.LineHeight,
   );
+  const terminalTheme = await window.getConfigurationValue<string>(
+    TerminalSettings.SectionName + '.' + TerminalSettings.Theme,
+  );
 
-  terminal = new Terminal({ fontSize, lineHeight, disableStdin: true });
+  terminal = new Terminal({ fontSize, lineHeight, disableStdin: true, theme: getTerminalTheme(terminalTheme) });
   const fitAddon = new FitAddon();
   terminal.loadAddon(fitAddon);
 


### PR DESCRIPTION
feat: terminal light and dark mode selection

### What does this PR do?

* Adds the ability to select your terminal theme from dark or light

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->


https://github.com/user-attachments/assets/3a90d27f-1b86-4663-b430-1cea26e79ed9



### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop/issues/7545

We will follow up with:
https://github.com/containers/podman-desktop/issues/8190 and
https://github.com/containers/podman-desktop/issues/8174 in the future

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature

1. Go to Terminal preferences and set your theme
2. Go to your Pod logs / Terminal, or anywhere else in PD that has a
   terminal
3. See the new theme.

**NOTE:** If you are going back to the "same" section and it's cached
(ex. terminal), you will have to refresh the screen.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
