### PR TITLE
chore: light mode for troubleshooting

### DIFF
--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingContainerEngine.svelte
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingContainerEngine.svelte
@@ -7,7 +7,7 @@ import TroubleshootingContainerEnginePing from './TroubleshootingContainerEngine
 export let containerEngineRunning: ProviderContainerConnectionInfo;
 </script>
 
-<div class="flex flex-col bg-charcoal-800 border-zinc-600 m-4 p-4 text-sm">
+<div class="flex flex-col bg-[var(--pd-invert-content-card-bg)] m-4 p-4 text-sm">
   <h6 aria-label="name">Name: {containerEngineRunning.name}</h6>
   <div class="mx-4">
     <h6 aria-label="status">Status: {containerEngineRunning.status}</h6>

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingContainerEngines.svelte
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingContainerEngines.svelte
@@ -11,9 +11,9 @@ $: containerEngines = providers.map(provider => provider.containerConnections).f
 $: containerEnginesRunning = containerEngines.filter(containerEngine => containerEngine.status === 'started');
 </script>
 
-<div class="flex flex-col w-full bg-charcoal-600 p-4 rounded-lg">
+<div class="flex flex-col w-full bg-[var(--pd-content-card-bg)] p-4 rounded-lg">
   <div class="flex flex-row align-middle items-center">
-    <ContainerIcon size="40" solid={true} class="pr-3 text-gray-700" />
+    <ContainerIcon size="40" solid={true} class="pr-3" />
     <div role="status" aria-label="container connections" class="text-xl">
       Container connections: {containerEngines.length} ({containerEnginesRunning.length} running)
     </div>

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingDevToolsConsoleLogs.svelte
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingDevToolsConsoleLogs.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { faFileLines, faPaste } from '@fortawesome/free-regular-svg-icons';
+import { Button } from '@podman-desktop/ui-svelte';
 import { onDestroy, onMount } from 'svelte';
 import Fa from 'svelte-fa';
 
@@ -24,26 +25,25 @@ function copyLogsToClipboard() {
 }
 </script>
 
-<div class="flex flex-col w-full m-4 bg-charcoal-600 p-4 rounded-lg">
+<div class="flex flex-col w-full m-4 p-4 rounded-lg bg-[var(--pd-content-card-bg)]">
   <div class="flex flex-row align-middle items-center w-full mb-4">
-    <Fa size="1.875x" class="pr-3 text-gray-700" icon={faFileLines} />
+    <Fa size="1.875x" class="pr-3" icon={faFileLines} />
     <div class="text-xl">Logs</div>
     <div class="flex flex-1 justify-end">
-      <button title="Copy To Clipboard" class="ml-5" on:click={() => copyLogsToClipboard()}
-        ><Fa class="h-5 w-5 cursor-pointer text-xl text-purple-500 hover:text-purple-600" icon={faPaste} /></button>
+      <Button title="Copy To Clipboard" class="ml-5" on:click={() => copyLogsToClipboard()} type="link"
+        ><Fa class="h-5 w-5 cursor-pointer text-xl text-[var(--pd-button-primary-bg)]" icon={faPaste} /></Button>
     </div>
   </div>
   {#if logs.length > 0}
-    <div class="h-full overflow-auto p-2 bg-charcoal-800">
+    <div class="h-full overflow-auto p-2 bg-[var(--pd-invert-content-card-bg)]">
       <ul aria-label="logs">
         {#each logs as log}
           <li>
             <div class="flex flex-row align-middle items-center">
               <div
-                class="font-mono text-[10px] font-thin {log.logType === 'error' ? 'text-red-500' : ''} {log.logType ===
-                'warn'
-                  ? 'text-amber-400'
-                  : ''}">
+                class="font-mono text-[10px] font-thin {log.logType === 'error'
+                  ? 'text-[var(--pd-state-error)]'
+                  : ''} {log.logType === 'warn' ? 'text-[var(--pd-state-warning)]' : ''}">
                 {log.message}
               </div>
             </div>

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingGatherLogs.svelte
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingGatherLogs.svelte
@@ -18,9 +18,9 @@ async function saveLogsAsZip() {
 }
 </script>
 
-<div class="flex flex-col w-full m-4 bg-charcoal-600 p-4 rounded-lg">
+<div class="flex flex-col w-full m-4 bg-[var(--pd-content-card-bg)] p-4 rounded-lg">
   <div class="flex flex-row align-middle items-center w-full">
-    <Fa size="1.875x" class="pr-3 text-gray-700" icon={faFileLines} />
+    <Fa size="1.875x" class="pr-3" icon={faFileLines} />
     <div class="text-xl">Gather Log Files</div>
     <div class="flex flex-1 justify-end"></div>
   </div>
@@ -34,7 +34,7 @@ async function saveLogsAsZip() {
       icon={faScroll}>Collect and save logs as .zip</Button>
   </div>
   {#if logs.length > 0}
-    <div class="h-full overflow-auto p-2 bg-charcoal-800 mt-3">
+    <div class="h-full overflow-auto p-2 bg-[var(--pd-invert-content-card-bg)] mt-3">
       <ul aria-label="logs">
         {#each logs as log}
           <li>

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingPageStore.svelte
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingPageStore.svelte
@@ -21,7 +21,7 @@ async function fetch(): Promise<void> {
 let openDetails = false;
 </script>
 
-<div class="flex flex-col bg-charcoal-800 p-2 items-center rounded w-full">
+<div class="flex flex-col bg-[var(--pd-invert-content-card-bg)] p-2 items-center rounded w-full">
   <div><svelte:component this={eventStoreInfo.iconComponent} size="20" /></div>
   <div class="text-xl">
     <button

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingPageStores.svelte
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingPageStores.svelte
@@ -26,9 +26,9 @@ onDestroy(() => {
 });
 </script>
 
-<div class="flex w-full h-fit m-4 flex-col bg-charcoal-600 p-4 rounded-lg">
+<div class="flex w-full h-fit m-4 flex-col bg-[var(--pd-content-card-bg)] p-4 rounded-lg">
   <div class="flex flex-row align-middle items-center w-full mb-4">
-    <Fa size="1.875x" class="pr-3 text-gray-700" icon={faDatabase} />
+    <Fa size="1.875x" class="pr-3" icon={faDatabase} />
     <div role="status" aria-label="stores" class="text-xl">Stores</div>
   </div>
 

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingRepair.svelte
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingRepair.svelte
@@ -9,9 +9,9 @@ import TroubleshootingRepairCleanup from './TroubleshootingRepairCleanup.svelte'
 export let providers: ProviderInfo[] = [];
 </script>
 
-<div class="flex flex-col w-full bg-charcoal-600 p-4 rounded-lg">
+<div class="flex flex-col w-full bg-[var(--pd-content-card-bg)] p-4 rounded-lg">
   <div class="flex flex-row w-full pb-2 items-center">
-    <Fa size="1.5x" class="pr-2 text-gray-700" icon={faWrench} />
+    <Fa size="1.5x" class="pr-2" icon={faWrench} />
     <div class="text-xl" aria-label="Repair">Repair</div>
   </div>
 

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingRepairCleanup.svelte
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingRepairCleanup.svelte
@@ -47,8 +47,8 @@ async function cleanup() {
 
 <div class="flex flex-row items-center">
   <div>
-    <div class="text-gray-700 flex flex-row items-center">Clean / Purge data</div>
-    <div class="text-gray-900 text-sm flex flex-row items-center pt-1">
+    <div class="text-[var(--pd-content-header)] flex flex-row items-center">Clean / Purge data</div>
+    <div class="text-sm flex flex-row items-center pt-1">
       <Fa class="pr-1" size="0.8x" icon={faWarning} />Proceeding with this action may result in data loss, including
       existing volumes, containers, images, etc.
     </div>
@@ -65,7 +65,7 @@ async function cleanup() {
 
   <div>
     {#if cleanupFailures.length > 0}
-      <div class="text-red-500 text-xs flex flex-row items-center" role="alert" aria-label="error">
+      <div class="text-[var(--pd-state-error)] text-xs flex flex-row items-center" role="alert" aria-label="error">
         <Fa class="pr-1" size="1x" icon={faWarning} />{cleanupFailures.length} failures
       </div>
     {/if}

--- a/packages/ui/src/lib/screen/EmptyScreen.svelte
+++ b/packages/ui/src/lib/screen/EmptyScreen.svelte
@@ -69,7 +69,7 @@ let copyTextDivElement: HTMLDivElement;
           {commandline}
         </div>
         <Button title="Copy To Clipboard" class="ml-5" on:click={handleClick} type="link"
-          ><Fa class="h-5 w-5 cursor-pointer text-xl text-purple-500 hover:text-purple-600" icon={faPaste} /></Button>
+          ><Fa class="h-5 w-5 cursor-pointer text-xl text-[var(--pd-button-primary-bg)]" icon={faPaste} /></Button>
       </div>
     {/if}
     {#if $$slots}


### PR DESCRIPTION
### What does this PR do?

Replaces all hard-coded colors in the troubleshooting pages with color variables. The two 'log' screens should probably be replaced with terminals so that we get consistent styling, but terminal light mode/color vars are not there yet, so I've given them basic card backgrounds for now.

When updating the copy to clipboard button I noticed that the EmptyScreen still had hard-coded colors, so I fixed this and made the button in troubleshooting match (link Button).

### Screenshot / video of UI

Before:

<img width="831" alt="Screenshot 2024-07-23 at 9 58 05 AM" src="https://github.com/user-attachments/assets/e90de3fc-27f8-43f9-a195-e5435eb9e827">

After:

<img width="831" alt="Screenshot 2024-07-23 at 9 57 49 AM" src="https://github.com/user-attachments/assets/28037984-a778-4bed-bae5-6a6f41001b2d">

### What issues does this PR fix or reference?

Fixes #7343.

### How to test this PR?

Check troubleshooting pages in light and dark mode.