### PR TITLE
chore: revert afterUpdate in items

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItem.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItem.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { getInitialValue } from '/@/lib/preferences/Util';
+import { afterUpdate } from 'svelte';
 
 import type { IConfigurationPropertyRecordedSchema } from '../../../../main/src/plugin/configuration-registry';
 import Markdown from '../markdown/Markdown.svelte';
@@ -14,6 +15,10 @@ let recordUI: {
   markdownDescription?: string;
   original: IConfigurationPropertyRecordedSchema;
 };
+
+afterUpdate(() => {
+  update();
+});
 
 // add space from camel case and upper case on the first letter
 function startCase(str: string): string {


### PR DESCRIPTION
chore: revert afterUpdate in items lsit

### What does this PR do?

* Reverts back to using afterUpdate due to the settings no longer
  appearing for most sections

We should look for a different solution for https://github.com/containers/podman-desktop/issues/7142

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

Before:

![image](https://github.com/user-attachments/assets/8e2e33e2-04f7-4aa8-be49-048b16d5733f)

After (shows the correct setting now):

![Screenshot 2024-07-23 at 11 11 41 AM](https://github.com/user-attachments/assets/166d2466-2e62-48ee-981b-e51a8072561b)

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop/issues/8082

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

Go to setting (example, kubernetes context) and see that the setting is
back now.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
