### PR TITLE
fix: fix tooltip error message overflow

### DIFF
--- a/packages/renderer/src/lib/container/ContainerColumnActionsContainer.svelte
+++ b/packages/renderer/src/lib/container/ContainerColumnActionsContainer.svelte
@@ -8,6 +8,6 @@ export let object: ContainerInfoUI;
 </script>
 
 {#if object.actionError}
-  <ErrorMessage error={object.actionError} icon actionErrorInfo />
+  <ErrorMessage error={object.actionError} icon wrapMessage />
 {/if}
 <ContainerActions container={object} dropdownMenu={true} on:update />

--- a/packages/renderer/src/lib/container/ContainerColumnActionsContainer.svelte
+++ b/packages/renderer/src/lib/container/ContainerColumnActionsContainer.svelte
@@ -8,6 +8,6 @@ export let object: ContainerInfoUI;
 </script>
 
 {#if object.actionError}
-  <ErrorMessage error={object.actionError} icon />
+  <ErrorMessage error={object.actionError} icon actionErrorInfo />
 {/if}
 <ContainerActions container={object} dropdownMenu={true} on:update />

--- a/packages/renderer/src/lib/container/ContainerDetails.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetails.svelte
@@ -78,7 +78,7 @@ onMount(() => {
     <svelte:fragment slot="actions">
       <div class="flex items-center w-5">
         {#if container.actionError}
-          <ErrorMessage error={container.actionError} icon actionErrorInfo />
+          <ErrorMessage error={container.actionError} icon wrapMessage />
         {:else}
           <div>&nbsp;</div>
         {/if}

--- a/packages/renderer/src/lib/container/ContainerDetails.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetails.svelte
@@ -78,7 +78,7 @@ onMount(() => {
     <svelte:fragment slot="actions">
       <div class="flex items-center w-5">
         {#if container.actionError}
-          <ErrorMessage error={container.actionError} icon />
+          <ErrorMessage error={container.actionError} icon actionErrorInfo />
         {:else}
           <div>&nbsp;</div>
         {/if}

--- a/packages/renderer/src/lib/pod/PodColumnActions.svelte
+++ b/packages/renderer/src/lib/pod/PodColumnActions.svelte
@@ -10,7 +10,7 @@ export let object: PodInfoUI;
 <div class="flex w-full">
   <div class="flex items-center w-5">
     {#if object.actionError}
-      <ErrorMessage error={object.actionError} icon />
+      <ErrorMessage error={object.actionError} icon actionErrorInfo />
     {:else}
       <div>&nbsp;</div>
     {/if}

--- a/packages/renderer/src/lib/pod/PodColumnActions.svelte
+++ b/packages/renderer/src/lib/pod/PodColumnActions.svelte
@@ -10,7 +10,7 @@ export let object: PodInfoUI;
 <div class="flex w-full">
   <div class="flex items-center w-5">
     {#if object.actionError}
-      <ErrorMessage error={object.actionError} icon actionErrorInfo />
+      <ErrorMessage error={object.actionError} icon wrapMessage />
     {:else}
       <div>&nbsp;</div>
     {/if}

--- a/packages/renderer/src/lib/pod/PodDetails.svelte
+++ b/packages/renderer/src/lib/pod/PodDetails.svelte
@@ -64,7 +64,7 @@ onMount(() => {
     <svelte:fragment slot="actions">
       <div class="flex items-center w-5">
         {#if pod.actionError}
-          <ErrorMessage error={pod.actionError} icon />
+          <ErrorMessage error={pod.actionError} icon actionErrorInfo />
         {:else}
           <div>&nbsp;</div>
         {/if}

--- a/packages/renderer/src/lib/pod/PodDetails.svelte
+++ b/packages/renderer/src/lib/pod/PodDetails.svelte
@@ -64,7 +64,7 @@ onMount(() => {
     <svelte:fragment slot="actions">
       <div class="flex items-center w-5">
         {#if pod.actionError}
-          <ErrorMessage error={pod.actionError} icon actionErrorInfo />
+          <ErrorMessage error={pod.actionError} icon wrapMessage />
         {:else}
           <div>&nbsp;</div>
         {/if}

--- a/packages/ui/src/lib/alert/ErrorMessage.svelte
+++ b/packages/ui/src/lib/alert/ErrorMessage.svelte
@@ -7,13 +7,13 @@ import Tooltip from '../tooltip/Tooltip.svelte';
 
 export let error: string;
 export let icon = false;
-export let actionErrorInfo = false;
+export let wrapMessage = false;
 let customClassWidth = '';
 let left = false;
 let top = false;
 
 onMount(() => {
-  if (actionErrorInfo) {
+  if (wrapMessage) {
     customClassWidth = 'w-max max-w-[650px] overflow-hidden text-ellipsis text-wrap';
     left = true;
   } else {

--- a/packages/ui/src/lib/alert/ErrorMessage.svelte
+++ b/packages/ui/src/lib/alert/ErrorMessage.svelte
@@ -6,13 +6,26 @@ import Tooltip from '../tooltip/Tooltip.svelte';
 
 export let error: string;
 export let icon = false;
+export let actionErrorInfo = false;
 </script>
 
 {#if icon}
   {#if error !== undefined && error !== ''}
-    <Tooltip top tip={error}>
-      <Fa size="1.1x" class="cursor-pointer text-[var(--pd-state-error)] {$$props.class}" icon={faExclamationCircle} />
-    </Tooltip>
+    {#if actionErrorInfo}
+      <Tooltip left tip={error} tipWidth="w-max max-w-[650px] overflow-hidden text-wrap">
+        <Fa
+          size="1.1x"
+          class="cursor-pointer text-[var(--pd-state-error)] {$$props.class}"
+          icon={faExclamationCircle} />
+      </Tooltip>
+    {:else}
+      <Tooltip top tip={error}>
+        <Fa
+          size="1.1x"
+          class="cursor-pointer text-[var(--pd-state-error)] {$$props.class}"
+          icon={faExclamationCircle} />
+      </Tooltip>
+    {/if}
   {/if}
 {:else}
   <div

--- a/packages/ui/src/lib/alert/ErrorMessage.svelte
+++ b/packages/ui/src/lib/alert/ErrorMessage.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { faExclamationCircle } from '@fortawesome/free-solid-svg-icons';
+import { onMount } from 'svelte';
 import Fa from 'svelte-fa';
 
 import Tooltip from '../tooltip/Tooltip.svelte';
@@ -7,25 +8,25 @@ import Tooltip from '../tooltip/Tooltip.svelte';
 export let error: string;
 export let icon = false;
 export let actionErrorInfo = false;
+let customClassWidth = '';
+let left = false;
+let top = false;
+
+onMount(() => {
+  if (actionErrorInfo) {
+    customClassWidth = 'w-max max-w-[650px] overflow-hidden text-ellipsis text-wrap';
+    left = true;
+  } else {
+    top = true;
+  }
+});
 </script>
 
 {#if icon}
   {#if error !== undefined && error !== ''}
-    {#if actionErrorInfo}
-      <Tooltip left tip={error} tipWidth="w-max max-w-[650px] overflow-hidden text-wrap">
-        <Fa
-          size="1.1x"
-          class="cursor-pointer text-[var(--pd-state-error)] {$$props.class}"
-          icon={faExclamationCircle} />
-      </Tooltip>
-    {:else}
-      <Tooltip top tip={error}>
-        <Fa
-          size="1.1x"
-          class="cursor-pointer text-[var(--pd-state-error)] {$$props.class}"
-          icon={faExclamationCircle} />
-      </Tooltip>
-    {/if}
+    <Tooltip left={left} top={top} tip={error} class={customClassWidth}>
+      <Fa size="1.1x" class="cursor-pointer text-[var(--pd-state-error)] {$$props.class}" icon={faExclamationCircle} />
+    </Tooltip>
   {/if}
 {:else}
   <div

--- a/packages/ui/src/lib/tooltip/Tooltip.svelte
+++ b/packages/ui/src/lib/tooltip/Tooltip.svelte
@@ -51,7 +51,6 @@
 
 <script lang="ts">
 export let tip: string | undefined = undefined;
-export let tipWidth = '';
 export let top = false;
 export let topLeft = false;
 export let topRight = false;
@@ -78,7 +77,7 @@ export let left = false;
     class:bottom-right={bottomRight}>
     {#if tip}
       <div
-        class="inline-block py-2 px-4 rounded-md bg-[var(--pd-tooltip-bg)] text-[var(--pd-tooltip-text)] border-[1px] border-[var(--pd-tooltip-border)] {tipWidth}"
+        class="inline-block py-2 px-4 rounded-md bg-[var(--pd-tooltip-bg)] text-[var(--pd-tooltip-text)] border-[1px] border-[var(--pd-tooltip-border)] {$$props.class}"
         aria-label="tooltip">
         {tip}
       </div>

--- a/packages/ui/src/lib/tooltip/Tooltip.svelte
+++ b/packages/ui/src/lib/tooltip/Tooltip.svelte
@@ -51,6 +51,7 @@
 
 <script lang="ts">
 export let tip: string | undefined = undefined;
+export let tipWidth = '';
 export let top = false;
 export let topLeft = false;
 export let topRight = false;
@@ -77,7 +78,7 @@ export let left = false;
     class:bottom-right={bottomRight}>
     {#if tip}
       <div
-        class="inline-block py-2 px-4 rounded-md bg-[var(--pd-tooltip-bg)] text-[var(--pd-tooltip-text)] border-[1px] border-[var(--pd-tooltip-border)]"
+        class="inline-block py-2 px-4 rounded-md bg-[var(--pd-tooltip-bg)] text-[var(--pd-tooltip-text)] border-[1px] border-[var(--pd-tooltip-border)] {tipWidth}"
         aria-label="tooltip">
         {tip}
       </div>


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
Fixes the error tooltip overflow to make the entire error visible inside the page boundaries

### Screenshot / video of UI
![Screenshot from 2024-07-22 21-33-56](https://github.com/user-attachments/assets/6daf628f-b282-4d71-a05e-929e174c388a)

![Screenshot from 2024-07-22 21-33-45](https://github.com/user-attachments/assets/511de44a-5588-4d7d-8dca-2b8420d3376d)
![Screenshot from 2024-07-22 21-33-34](https://github.com/user-attachments/assets/91d0176e-bceb-4c25-bd85-eb9964145041)

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Closes https://github.com/containers/podman-desktop/issues/8153
Closes https://github.com/containers/podman-desktop/issues/7057

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->
Check that the error messages in the container list and pod list pages are visible inside the page boundaries

- [ ] Tests are covering the bug fix or the new feature
