### PR TITLE
feat: apply multiple kube yamls

### DIFF
--- a/packages/main/src/plugin/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes-client.ts
@@ -1194,10 +1194,21 @@ export class KubernetesClient {
    * @param namespace the namespace to use for any resources that don't include one
    * @return an array of resources created
    */
-  async applyResourcesFromFile(context: string, filePath: string, namespace?: string): Promise<KubernetesObject[]> {
-    const manifests = await this.loadManifestsFromFile(filePath);
+  async applyResourcesFromFile(
+    context: string,
+    filePath: string | string[],
+    namespace?: string,
+  ): Promise<KubernetesObject[]> {
+    const manifests: KubernetesObject[] = [];
+    if (typeof filePath === 'string') {
+      manifests.push(...(await this.loadManifestsFromFile(filePath)));
+    } else {
+      for (const path of filePath) {
+        manifests.push(...(await this.loadManifestsFromFile(path)));
+      }
+    }
     if (manifests.filter(s => s?.kind).length === 0) {
-      throw new Error('No valid Kubernetes resources found in file');
+      throw new Error('No valid Kubernetes resources found');
     }
     return this.syncResources(context, manifests, 'apply', namespace);
   }

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -1901,7 +1901,7 @@ export function initExposure(): void {
 
   contextBridge.exposeInMainWorld(
     'kubernetesApplyResourcesFromFile',
-    async (context: string, file: string, namespace?: string): Promise<KubernetesObject[]> => {
+    async (context: string, file: string | string[], namespace?: string): Promise<KubernetesObject[]> => {
       return ipcInvoke('kubernetes-client:applyResourcesFromFile', context, file, namespace);
     },
   );

--- a/packages/renderer/src/lib/kube/KubeApplyYAMLButton.spec.ts
+++ b/packages/renderer/src/lib/kube/KubeApplyYAMLButton.spec.ts
@@ -63,7 +63,7 @@ test('Verify selected file will be applied', async () => {
   await userEvent.click(button);
 
   expect(openDialogMock).toHaveBeenCalled();
-  expect(kubernetesApplyResourcesFromFileMock).toHaveBeenCalledWith(currentContext, filename, currentNamespace);
+  expect(kubernetesApplyResourcesFromFileMock).toHaveBeenCalledWith(currentContext, [filename], currentNamespace);
 });
 
 test('Verify success will open an info dialog', async () => {
@@ -78,7 +78,7 @@ test('Verify success will open an info dialog', async () => {
   await userEvent.click(button);
 
   expect(openDialogMock).toHaveBeenCalled();
-  expect(kubernetesApplyResourcesFromFileMock).toHaveBeenCalledWith(currentContext, filename, currentNamespace);
+  expect(kubernetesApplyResourcesFromFileMock).toHaveBeenCalledWith(currentContext, [filename], currentNamespace);
 
   expect(showMessageBoxMock).toHaveBeenCalled();
   expect(showMessageBoxMock).toHaveBeenCalledWith(expect.objectContaining({ type: 'info' }));
@@ -97,8 +97,11 @@ test('Verify multiple file success will open an info dialog', async () => {
   await userEvent.click(button);
 
   expect(openDialogMock).toHaveBeenCalled();
-  expect(kubernetesApplyResourcesFromFileMock).toHaveBeenCalledWith(currentContext, filename1, currentNamespace);
-  expect(kubernetesApplyResourcesFromFileMock).toHaveBeenCalledWith(currentContext, filename2, currentNamespace);
+  expect(kubernetesApplyResourcesFromFileMock).toHaveBeenCalledWith(
+    currentContext,
+    [filename1, filename2],
+    currentNamespace,
+  );
 
   expect(showMessageBoxMock).toHaveBeenCalled();
   expect(showMessageBoxMock).toHaveBeenCalledWith(expect.objectContaining({ type: 'info' }));
@@ -116,7 +119,7 @@ test('Verify no results will open a warning dialog', async () => {
   await userEvent.click(button);
 
   expect(openDialogMock).toHaveBeenCalled();
-  expect(kubernetesApplyResourcesFromFileMock).toHaveBeenCalledWith(currentContext, filename, currentNamespace);
+  expect(kubernetesApplyResourcesFromFileMock).toHaveBeenCalledWith(currentContext, [filename], currentNamespace);
 
   expect(showMessageBoxMock).toHaveBeenCalled();
   expect(showMessageBoxMock).toHaveBeenCalledWith(expect.objectContaining({ type: 'warning' }));
@@ -134,7 +137,7 @@ test('Verify failure will open an error dialog', async () => {
   await userEvent.click(button);
 
   expect(openDialogMock).toHaveBeenCalled();
-  expect(kubernetesApplyResourcesFromFileMock).toHaveBeenCalledWith(currentContext, filename, currentNamespace);
+  expect(kubernetesApplyResourcesFromFileMock).toHaveBeenCalledWith(currentContext, [filename], currentNamespace);
 
   expect(showMessageBoxMock).toHaveBeenCalled();
   expect(showMessageBoxMock).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' }));

--- a/packages/renderer/src/lib/kube/KubeApplyYAMLButton.spec.ts
+++ b/packages/renderer/src/lib/kube/KubeApplyYAMLButton.spec.ts
@@ -84,6 +84,26 @@ test('Verify success will open an info dialog', async () => {
   expect(showMessageBoxMock).toHaveBeenCalledWith(expect.objectContaining({ type: 'info' }));
 });
 
+test('Verify multiple file success will open an info dialog', async () => {
+  render(KubeApplyYamlButton);
+
+  const filename1 = 'service1.yaml';
+  const filename2 = 'service2.yaml';
+  openDialogMock.mockResolvedValue([filename1, filename2]);
+  kubernetesApplyResourcesFromFileMock.mockReturnValue([{}]);
+
+  const button = screen.getByRole('button', { name: 'Apply YAML' });
+  expect(button).toBeInTheDocument();
+  await userEvent.click(button);
+
+  expect(openDialogMock).toHaveBeenCalled();
+  expect(kubernetesApplyResourcesFromFileMock).toHaveBeenCalledWith(currentContext, filename1, currentNamespace);
+  expect(kubernetesApplyResourcesFromFileMock).toHaveBeenCalledWith(currentContext, filename2, currentNamespace);
+
+  expect(showMessageBoxMock).toHaveBeenCalled();
+  expect(showMessageBoxMock).toHaveBeenCalledWith(expect.objectContaining({ type: 'info' }));
+});
+
 test('Verify no results will open a warning dialog', async () => {
   render(KubeApplyYamlButton);
 

--- a/packages/renderer/src/lib/kube/KubeApplyYAMLButton.svelte
+++ b/packages/renderer/src/lib/kube/KubeApplyYAMLButton.svelte
@@ -30,10 +30,7 @@ async function kubeApply(): Promise<void> {
   inProgress = true;
   try {
     const namespace = await window.kubernetesGetCurrentNamespace();
-    let objects: KubernetesObject[] = [];
-    for (const file of result) {
-      objects.push(...(await window.kubernetesApplyResourcesFromFile(contextName, file, namespace)));
-    }
+    let objects: KubernetesObject[] = await window.kubernetesApplyResourcesFromFile(contextName, result, namespace);
     if (objects.length === 0) {
       await window.showMessageBox({
         title: 'Kubernetes',

--- a/packages/renderer/src/lib/kube/KubeApplyYAMLButton.svelte
+++ b/packages/renderer/src/lib/kube/KubeApplyYAMLButton.svelte
@@ -14,38 +14,56 @@ async function kubeApply(): Promise<void> {
 
   const result = await window.openDialog({
     title: 'Select a .yaml file to apply',
+    selectors: ['openFile', 'multiSelections'],
     filters: [
       {
         name: 'YAML files',
-        extensions: ['yaml', 'yml'],
+        extensions: ['yaml', 'yml', 'YAML', 'YML'],
       },
     ],
   });
-  if (result?.length !== 1) {
-    return;
-  }
 
-  let file = result[0];
-  if (!file) {
+  if (!result || result.length === 0) {
     return;
   }
 
   inProgress = true;
   try {
     const namespace = await window.kubernetesGetCurrentNamespace();
-    let objects: KubernetesObject[] = await window.kubernetesApplyResourcesFromFile(contextName, file, namespace);
+    let objects: KubernetesObject[] = [];
+    for (const file of result) {
+      objects.push(...(await window.kubernetesApplyResourcesFromFile(contextName, file, namespace)));
+    }
     if (objects.length === 0) {
       await window.showMessageBox({
         title: 'Kubernetes',
         type: 'warning',
-        message: `No resource(s) were applied`,
+        message: `No resource(s) were applied.`,
         buttons: ['OK'],
       });
-    } else {
+    } else if (objects.length === 1) {
       await window.showMessageBox({
         title: 'Kubernetes',
         type: 'info',
-        message: `Successfully applied ${objects.length} resource(s)`,
+        message: `Successfully applied 1 ${objects[0].kind ?? 'unknown resource'}.`,
+        buttons: ['OK'],
+      });
+    } else {
+      const counts = objects.reduce(
+        (acc, obj) => {
+          acc[obj.kind ?? 'unknown'] = (acc[obj.kind ?? 'unknown'] || 0) + 1;
+          return acc;
+        },
+        {} as Record<string, number>,
+      );
+      const resources = Object.entries(counts)
+        .map(obj => `${obj[1]} ${obj[0]}`)
+        .join(', ');
+
+      await window.showMessageBox({
+        title: 'Kubernetes',
+        type: 'info',
+        message: `Successfully applied ${objects.length} resources (${resources}).`,
         buttons: ['OK'],
       });
     }


### PR DESCRIPTION
### What does this PR do?

Adds the ability to apply multiple Kubernetes YAML files at once.

While doing this I couldn't help but improve the dialog message. Instead of:
  "Successfully applied 2 resource(s)"
you now either get:
  "Successfully applied 1 <kind>."
or a more detailed message like:
  "Successfully applied 4 resources (2 <kind1>, 1 <kind2>)."

### Screenshot / video of UI

https://github.com/user-attachments/assets/dcf205f7-5030-4794-991c-a38cd5527e76

### What issues does this PR fix or reference?

Fixes #8198.

### How to test this PR?

Try a variety of files, resources.

- [x] Tests are covering the bug fix or the new feature