### PR TITLE
fix: preferences not shown on selected section

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItem.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItem.svelte
@@ -21,7 +21,7 @@ function startCase(str: string): string {
     return str.toUpperCase();
   });
 }
-function update() {
+function update(record: IConfigurationPropertyRecordedSchema) {
   const id = record.id;
   // take string after the last dot
   const key = id?.substring(id?.lastIndexOf('.') + 1) ?? '';
@@ -40,12 +40,16 @@ function update() {
   };
 }
 $: {
-  update();
+  update(record);
 }
 
 function updateResetButtonVisibility(recordValue: any) {
   showResetButton =
     recordUI.original.default !== undefined && recordValue !== undefined && recordValue !== recordUI.original.default;
+  // when the reset button is shown we reset the value of resetToDefault
+  if (showResetButton) {
+    resetToDefault = false;
+  }
 }
 
 function doResetToDefault() {

--- a/packages/renderer/src/lib/preferences/item-formats/NumberItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/NumberItem.svelte
@@ -22,10 +22,11 @@ $: if (recordValue) {
   // if the value is different from the original update
   if (record.id && newValue !== lastValue && !error) {
     // clear the timeout so if there was an old call to onChange pending is deleted. We will create a new one soon
+    const recordId = record.id;
     clearTimeout(valueUpdateTimeout);
 
     valueUpdateTimeout = setTimeout(() => {
-      onChange(record.id!, newValue);
+      onChange(recordId, newValue);
       lastValue = newValue;
     }, 500);
   }


### PR DESCRIPTION
### What does this PR do?

This PR fixes an issue introduces by https://github.com/containers/podman-desktop/pull/7990 and discovered by @cdrage which prevented the user from seeing the correct preferences when clicking on a specific section like kubernetes, terminal, telemetry, ....

What it does:
1. it changes the signature of the update function to use an argument so that when record is updated, it triggers it
2. it resets the status of the resetToDefault based on the showResetButton so its clicks always trigger a reset
3. updates the equality check on `PreferencesRenderingItemFormat.svelte` and adds them on the onChange + save functions so that when the user switches (quickly) between different sections, we do not mix values (e.g. saving the value of the old pref with the new one being loaded). Most probably, this is also the issue that @deboer-tim met here -> https://github.com/containers/podman-desktop/issues/7969#issuecomment-2239018741 

### Screenshot / video of UI

![phantom_reset_2](https://github.com/user-attachments/assets/15df102e-94b2-4746-9f99-8e85f7c69daf)

### What issues does this PR fix or reference?

it resolves #7142 

### How to test this PR?

go on preferences and check that you see the correct prefs when selecting a section. Try to update the prefs values and see that everything works fine. There should be no phantom resets.

- [ ] Tests are covering the bug fix or the new feature
