### PR TITLE
Display info when layers of an image are being loaded

### DIFF
--- a/packages/renderer/src/lib/image/ImageDetailsFiles.svelte
+++ b/packages/renderer/src/lib/image/ImageDetailsFiles.svelte
@@ -18,6 +18,7 @@ let filesProvidersUnsubscribe: Unsubscriber;
 let filesProvider: ImageFilesInfo;
 let selectedLayer: ImageFilesystemLayerUI;
 let showLayerOnly: boolean;
+let loading: boolean;
 
 function onSelectedLayer(event: CustomEvent<ImageFilesystemLayerUI>) {
   selectedLayer = event.detail;
@@ -27,9 +28,15 @@ onMount(async () => {
   filesProvidersUnsubscribe = imageFilesProviders.subscribe(providers => {
     if (providers.length === 1 && imageInfo) {
       filesProvider = providers[0];
-      window.imageGetFilesystemLayers(filesProvider.id, imageInfo).then(layers => {
-        imageLayers = layers;
-      });
+      loading = true;
+      window
+        .imageGetFilesystemLayers(filesProvider.id, imageInfo)
+        .then(layers => {
+          imageLayers = layers;
+        })
+        .finally(() => {
+          loading = false;
+        });
     }
   });
 });
@@ -38,6 +45,10 @@ onDestroy(() => {
   filesProvidersUnsubscribe?.();
 });
 </script>
+
+{#if loading}
+  <div class="p-4">Layers are being loaded. This can take a while for large images, please wait...</div>
+{/if}
 
 {#if imageLayers}
   <div class="flex flex-col w-full h-full p-8 pr-0 text-[var(--pd-content-text)] bg-[var(--pd-content-bg)]">


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

When the user opens the File tab of an image, the layers of the image are loaded, to be displayed. A message is displayed the time the layers are loaded and displayed.

### Screenshot / video of UI

https://github.com/user-attachments/assets/26a53632-555d-42b2-8f7a-c7acdc46d124

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

Fix #8158 

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
