### PR TITLE
chore: move each entry of the left navbar to individual items

### DIFF
--- a/packages/renderer/src/AppNavigation.spec.ts
+++ b/packages/renderer/src/AppNavigation.spec.ts
@@ -29,6 +29,7 @@ import type { ContributionInfo } from '/@api/contribution-info';
 
 import AppNavigation from './AppNavigation.svelte';
 import { contributions } from './stores/contribs';
+import { fetchNavigationRegistries } from './stores/navigation/navigation-registry';
 
 const eventsMock = vi.fn();
 
@@ -41,7 +42,7 @@ beforeAll(() => {
   (window as any).events = eventsMock;
 });
 
-test('Test rendering of the navigation bar with empty items', () => {
+test('Test rendering of the navigation bar with empty items', async () => {
   const meta = {
     url: '/',
   } as unknown as TinroRouteMeta;
@@ -55,6 +56,9 @@ test('Test rendering of the navigation bar with empty items', () => {
   vi.mocked(kubeContextStore).kubernetesCurrentContextConfigMaps = readable<KubernetesObject[]>([]);
   vi.mocked(kubeContextStore).kubernetesCurrentContextSecrets = readable<KubernetesObject[]>([]);
   vi.mocked(kubeContextStore).kubernetesCurrentContextPersistentVolumeClaims = readable<KubernetesObject[]>([]);
+
+  // init navigation registry
+  await fetchNavigationRegistries();
 
   render(AppNavigation, {
     meta,

--- a/packages/renderer/src/AppNavigation.svelte
+++ b/packages/renderer/src/AppNavigation.svelte
@@ -1,235 +1,28 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
 import { faCircleUser } from '@fortawesome/free-regular-svg-icons';
-import { ContainerIcon } from '@podman-desktop/ui-svelte/icons';
-import { onDestroy, onMount } from 'svelte';
-import type { Unsubscriber } from 'svelte/store';
+import { onMount } from 'svelte';
 import Fa from 'svelte-fa';
 import type { TinroRouteMeta } from 'tinro';
 
-import Webviews from '/@/lib/webview/Webviews.svelte';
-import { webviews } from '/@/stores/webviews';
-import type { ImageInfo } from '/@api/image-info';
-
 import { CommandRegistry } from './lib/CommandRegistry';
 import NewContentOnDashboardBadge from './lib/dashboard/NewContentOnDashboardBadge.svelte';
-import { ImageUtils } from './lib/image/image-utils';
-import ConfigMapSecretIcon from './lib/images/ConfigMapSecretIcon.svelte';
 import DashboardIcon from './lib/images/DashboardIcon.svelte';
-import DeploymentIcon from './lib/images/DeploymentIcon.svelte';
-import ExtensionIcon from './lib/images/ExtensionIcon.svelte';
-import ImageIcon from './lib/images/ImageIcon.svelte';
-import IngressRouteIcon from './lib/images/IngressRouteIcon.svelte';
-import KubeIcon from './lib/images/KubeIcon.svelte';
-import NodeIcon from './lib/images/NodeIcon.svelte';
-import PodIcon from './lib/images/PodIcon.svelte';
-import PuzzleIcon from './lib/images/PuzzleIcon.svelte';
-import PVCIcon from './lib/images/PVCIcon.svelte';
-import ServiceIcon from './lib/images/ServiceIcon.svelte';
 import SettingsIcon from './lib/images/SettingsIcon.svelte';
-import VolumeIcon from './lib/images/VolumeIcon.svelte';
 import NavItem from './lib/ui/NavItem.svelte';
+import NavRegistryEntry from './lib/ui/NavRegistryEntry.svelte';
 import NavSection from './lib/ui/NavSection.svelte';
-import { combinedInstalledExtensions } from './stores/all-installed-extensions';
-import { containersInfos } from './stores/containers';
-import { contributions } from './stores/contribs';
-import { imagesInfos } from './stores/images';
-import { kubernetesContexts } from './stores/kubernetes-contexts';
-import {
-  kubernetesCurrentContextConfigMaps,
-  kubernetesCurrentContextDeployments,
-  kubernetesCurrentContextIngresses,
-  kubernetesCurrentContextNodes,
-  kubernetesCurrentContextPersistentVolumeClaims,
-  kubernetesCurrentContextRoutes,
-  kubernetesCurrentContextSecrets,
-  kubernetesCurrentContextServices,
-} from './stores/kubernetes-contexts-state';
-import { podsInfos } from './stores/pods';
-import { volumeListInfos } from './stores/volumes';
+import { navigationRegistry } from './stores/navigation/navigation-registry';
 
-let podInfoSubscribe: Unsubscriber;
-let containerInfoSubscribe: Unsubscriber;
-let imageInfoSubscribe: Unsubscriber;
-let volumeInfoSubscribe: Unsubscriber;
-let contextsSubscribe: Unsubscriber;
-let nodesSubscribe: Unsubscriber;
-let deploymentsSubscribe: Unsubscriber;
-let persistentVolumeClaimsSubscribe: Unsubscriber;
-let servicesSubscribe: Unsubscriber;
-let ingressesSubscribe: Unsubscriber;
-let routesSubscribe: Unsubscriber;
-let configmapsSubscribe: Unsubscriber;
-let secretsSubscribe: Unsubscriber;
-let combinedInstalledExtensionsSubscribe: Unsubscriber;
-
-let podCount = '';
-let containerCount = '';
-let imageCount = '';
-let volumeCount = '';
-let configmapsCount = 0;
-let secretsCount = 0;
-let configmapSecretsCount = '';
-let persistentVolumeClaimsCount = '';
-let contextCount = 0;
-let deploymentCount = '';
-let nodeCount = '';
-let serviceCount = '';
-let ingressesCount = 0;
-let routesCount = 0;
-let ingressesRoutesCount = '';
-let extensionCount = '';
-
-const imageUtils = new ImageUtils();
-export let exitSettingsCallback: () => void;
+let { exitSettingsCallback, meta = $bindable() }: { exitSettingsCallback: () => void; meta: TinroRouteMeta } = $props();
 
 const iconSize = '22';
 
 onMount(async () => {
   const commandRegistry = new CommandRegistry();
   commandRegistry.init();
-  podInfoSubscribe = podsInfos.subscribe(value => {
-    if (value.length > 0) {
-      podCount = ' (' + value.length + ')';
-    } else {
-      podCount = '';
-    }
-  });
-  containerInfoSubscribe = containersInfos.subscribe(value => {
-    if (value.length > 0) {
-      containerCount = ' (' + value.length + ')';
-    } else {
-      containerCount = '';
-    }
-  });
-  imageInfoSubscribe = imagesInfos.subscribe(value => {
-    let images = value.map((imageInfo: ImageInfo) => imageUtils.getImagesInfoUI(imageInfo, [], undefined, [])).flat();
-    if (images.length > 0) {
-      imageCount = ' (' + images.length + ')';
-    } else {
-      imageCount = '';
-    }
-  });
-  volumeInfoSubscribe = volumeListInfos.subscribe(value => {
-    let flattenedVolumes = value.map(volumeInfo => volumeInfo.Volumes).flat();
-    if (flattenedVolumes.length > 0) {
-      volumeCount = ' (' + flattenedVolumes.length + ')';
-    } else {
-      volumeCount = '';
-    }
-  });
-  deploymentsSubscribe = kubernetesCurrentContextDeployments.subscribe(value => {
-    if (value.length > 0) {
-      deploymentCount = ' (' + value.length + ')';
-    } else {
-      deploymentCount = '';
-    }
-  });
-  persistentVolumeClaimsSubscribe = kubernetesCurrentContextPersistentVolumeClaims.subscribe(value => {
-    if (value.length > 0) {
-      persistentVolumeClaimsCount = ' (' + value.length + ')';
-    } else {
-      persistentVolumeClaimsCount = '';
-    }
-  });
-  nodesSubscribe = kubernetesCurrentContextNodes.subscribe(value => {
-    if (value.length > 0) {
-      nodeCount = ' (' + value.length + ')';
-    } else {
-      nodeCount = '';
-    }
-  });
-  servicesSubscribe = kubernetesCurrentContextServices.subscribe(value => {
-    if (value.length > 0) {
-      serviceCount = ' (' + value.length + ')';
-    } else {
-      serviceCount = '';
-    }
-  });
-  ingressesSubscribe = kubernetesCurrentContextIngresses.subscribe(value => {
-    ingressesCount = value.length;
-    updateIngressesRoutesCount(ingressesCount + routesCount);
-  });
-  routesSubscribe = kubernetesCurrentContextRoutes.subscribe(value => {
-    routesCount = value.length;
-    updateIngressesRoutesCount(ingressesCount + routesCount);
-  });
-
-  configmapsSubscribe = kubernetesCurrentContextConfigMaps.subscribe(value => {
-    configmapsCount = value.length;
-    updateConfigMapSecretsCount(configmapsCount + secretsCount);
-  });
-  secretsSubscribe = kubernetesCurrentContextSecrets.subscribe(value => {
-    secretsCount = value.length;
-    updateConfigMapSecretsCount(configmapsCount + secretsCount);
-  });
-  contextsSubscribe = kubernetesContexts.subscribe(value => {
-    contextCount = value.length;
-  });
-  combinedInstalledExtensionsSubscribe = combinedInstalledExtensions.subscribe(value => {
-    if (value.length > 0) {
-      extensionCount = ` (${value.length})`;
-    } else {
-      extensionCount = '';
-    }
-  });
 });
-
-onDestroy(() => {
-  if (podInfoSubscribe) {
-    podInfoSubscribe();
-  }
-  if (containerInfoSubscribe) {
-    containerInfoSubscribe();
-  }
-  if (imageInfoSubscribe) {
-    imageInfoSubscribe();
-  }
-  if (volumeInfoSubscribe) {
-    volumeInfoSubscribe();
-  }
-  if (contextsSubscribe) {
-    contextsSubscribe();
-  }
-  if (nodesSubscribe) {
-    nodesSubscribe();
-  }
-  if (deploymentsSubscribe) {
-    deploymentsSubscribe();
-  }
-  if (persistentVolumeClaimsSubscribe) {
-    persistentVolumeClaimsSubscribe();
-  }
-  if (servicesSubscribe) {
-    servicesSubscribe();
-  }
-  if (configmapsSubscribe) {
-    configmapsSubscribe();
-  }
-  if (secretsSubscribe) {
-    secretsSubscribe();
-  }
-  ingressesSubscribe?.();
-  routesSubscribe?.();
-  configmapsSubscribe?.();
-  secretsSubscribe?.();
-  combinedInstalledExtensionsSubscribe?.();
-});
-
-function updateIngressesRoutesCount(count: number) {
-  if (count > 0) {
-    ingressesRoutesCount = ' (' + count + ')';
-  } else {
-    ingressesRoutesCount = '';
-  }
-}
-
-function updateConfigMapSecretsCount(count: number) {
-  if (count > 0) {
-    configmapSecretsCount = ' (' + count + ')';
-  } else {
-    configmapSecretsCount = '';
-  }
-}
 
 function clickSettings(b: boolean) {
   if (b) {
@@ -238,8 +31,6 @@ function clickSettings(b: boolean) {
     window.location.href = '#/preferences/resources';
   }
 }
-
-export let meta: TinroRouteMeta;
 </script>
 
 <svelte:window />
@@ -254,69 +45,27 @@ export let meta: TinroRouteMeta;
       <NewContentOnDashboardBadge />
     </div>
   </NavItem>
-  <NavItem href="/containers" tooltip="Containers{containerCount}" ariaLabel="Containers" bind:meta={meta}>
-    <ContainerIcon size={iconSize} />
-  </NavItem>
-  <NavItem href="/pods" tooltip="Pods{podCount}" ariaLabel="Pods" bind:meta={meta}>
-    <PodIcon size={iconSize} />
-  </NavItem>
-  <NavItem href="/images" tooltip="Images{imageCount}" ariaLabel="Images" bind:meta={meta}>
-    <ImageIcon size={iconSize} />
-  </NavItem>
-  <NavItem href="/volumes" tooltip="Volumes{volumeCount}" ariaLabel="Volumes" bind:meta={meta}>
-    <VolumeIcon size={iconSize} />
-  </NavItem>
-  <NavItem href="/extensions" tooltip="Extensions{extensionCount}" ariaLabel="Extensions" bind:meta={meta}>
-    <ExtensionIcon size="24" />
-  </NavItem>
-  {#if contextCount > 0}
-    <NavSection tooltip="Kubernetes">
-      <KubeIcon size={iconSize} slot="icon" />
-      <NavItem href="/nodes" tooltip="Nodes{nodeCount}" ariaLabel="Nodes" bind:meta={meta}>
-        <NodeIcon size={iconSize} />
-      </NavItem>
-      <NavItem href="/deployments" tooltip="Deployments{deploymentCount}" ariaLabel="Deployments" bind:meta={meta}>
-        <DeploymentIcon size={iconSize} />
-      </NavItem>
-      <NavItem href="/services" tooltip="Services{serviceCount}" ariaLabel="Services" bind:meta={meta}>
-        <ServiceIcon size={iconSize} />
-      </NavItem>
-      <NavItem
-        href="/ingressesRoutes"
-        tooltip="Ingresses & Routes{ingressesRoutesCount}"
-        ariaLabel="Ingresses & Routes"
-        bind:meta={meta}>
-        <IngressRouteIcon size={iconSize} />
-      </NavItem>
-      <NavItem
-        href="/persistentvolumeclaims"
-        tooltip="Persistent Volume Claims{persistentVolumeClaimsCount}"
-        ariaLabel="Persistent Volume Claims"
-        bind:meta={meta}>
-        <PVCIcon size={iconSize} />
-      </NavItem>
-      <NavItem
-        href="/configmapsSecrets"
-        tooltip="ConfigMaps & Secrets{configmapSecretsCount}"
-        ariaLabel="ConfigMaps & Secrets"
-        bind:meta={meta}>
-        <ConfigMapSecretIcon size={iconSize} />
-      </NavItem>
-    </NavSection>
-  {/if}
+  {#each $navigationRegistry as navigationRegistryItem}
+    <!-- This is a section -->
+    {#if navigationRegistryItem.type === 'section' && navigationRegistryItem.enabled}
+      <NavSection tooltip={navigationRegistryItem.name}>
+        <svelte:component this={navigationRegistryItem.icon.iconComponent} size={iconSize} slot="icon" />
 
-  {#if $contributions.length + $webviews.length > 0}
-    <NavSection tooltip="Extensions">
-      <PuzzleIcon size={iconSize} slot="icon" />
-      {#each $contributions as contribution (contribution.extensionId + contribution.id)}
-        <NavItem href="/contribs/{contribution.name}" tooltip={contribution.name} bind:meta={meta}>
-          <img src={contribution.icon} width={iconSize} height={iconSize} alt={contribution.name} />
-        </NavItem>
+        {#if navigationRegistryItem.items}
+          {#each navigationRegistryItem.items as item}
+            <NavRegistryEntry entry={item} bind:meta={meta} />
+          {/each}
+        {/if}
+      </NavSection>
+    {:else if navigationRegistryItem.items && navigationRegistryItem.type === 'group'}
+      <!-- This is a group, list all items from the entry -->
+      {#each navigationRegistryItem.items as item}
+        <NavRegistryEntry entry={item} bind:meta={meta} />
       {/each}
-
-      <Webviews bind:meta={meta} />
-    </NavSection>
-  {/if}
+    {:else if navigationRegistryItem.type === 'entry'}
+      <NavRegistryEntry entry={navigationRegistryItem} bind:meta={meta} />
+    {/if}
+  {/each}
 
   <div class="grow"></div>
 

--- a/packages/renderer/src/lib/ui/NavRegistryEntry.svelte
+++ b/packages/renderer/src/lib/ui/NavRegistryEntry.svelte
@@ -1,0 +1,24 @@
+<svelte:options runes={true} />
+
+<script lang="ts">
+import Fa from 'svelte-fa';
+import type { TinroRouteMeta } from 'tinro';
+
+import type { NavigationRegistryEntry } from '/@/stores/navigation/navigation-registry';
+
+import NavItem from './NavItem.svelte';
+
+let { entry, meta = $bindable() }: { entry: NavigationRegistryEntry; meta: TinroRouteMeta } = $props();
+</script>
+
+<NavItem href={entry.link} counter={entry.counter} tooltip={entry.tooltip} ariaLabel={entry.name} bind:meta={meta}>
+  {#if entry.icon === undefined}
+    {entry.name}
+  {:else if entry.icon.faIcon}
+    <Fa icon={entry.icon.faIcon.definition} size={entry.icon.faIcon.size} />
+  {:else if entry.icon.iconComponent}
+    <svelte:component this={entry.icon.iconComponent} size="24" />
+  {:else if entry.icon.iconImage && typeof entry.icon.iconImage === 'string'}
+    <img src={entry.icon.iconImage} width="22" height="22" alt={entry.name} />
+  {/if}
+</NavItem>

--- a/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s-configmap-secrets.svelte.spec.ts
+++ b/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s-configmap-secrets.svelte.spec.ts
@@ -1,0 +1,60 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesObject } from '@kubernetes/client-node';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { createNavigationKubernetesConfigMapSecretsEntry } from './navigation-registry-k8s-configmap-secrets.svelte';
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  (window as any).kubernetesRegisterGetCurrentContextResources = kubernetesRegisterGetCurrentContextResourcesMock;
+});
+
+const kubernetesRegisterGetCurrentContextResourcesMock = vi.fn();
+
+test('createNavigationKubernetesConfigMapSecretsEntry', async () => {
+  const nodes: KubernetesObject[] = [
+    {
+      apiVersion: 'v1',
+      kind: 'Node',
+      metadata: {
+        name: 'node1',
+      },
+    },
+    {
+      apiVersion: 'v1',
+      kind: 'Node',
+      metadata: {
+        name: 'node2',
+      },
+    },
+  ];
+  kubernetesRegisterGetCurrentContextResourcesMock.mockResolvedValue(nodes);
+
+  const entry = createNavigationKubernetesConfigMapSecretsEntry();
+
+  expect(entry).toBeDefined();
+  expect(entry.name).toBe('ConfigMaps & Secrets');
+  expect(entry.link).toBe('/configmapsSecrets');
+  expect(entry.tooltip).toBe('ConfigMaps & Secrets');
+  await vi.waitFor(() => {
+    // receive 2 and 2
+    expect(entry.counter).toBe(4);
+  });
+});

--- a/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s-configmap-secrets.svelte.ts
+++ b/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s-configmap-secrets.svelte.ts
@@ -1,0 +1,49 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import ConfigMapSecretIcon from '/@/lib/images/ConfigMapSecretIcon.svelte';
+
+import { kubernetesCurrentContextConfigMaps, kubernetesCurrentContextSecrets } from '../../kubernetes-contexts-state';
+import type { NavigationRegistryEntry } from '../navigation-registry';
+
+let configmapsCount = 0;
+let secretsCount = 0;
+let count = $state(0);
+
+export function createNavigationKubernetesConfigMapSecretsEntry(): NavigationRegistryEntry {
+  kubernetesCurrentContextConfigMaps.subscribe(value => {
+    configmapsCount = value.length;
+    count = configmapsCount + secretsCount;
+  });
+  kubernetesCurrentContextSecrets.subscribe(value => {
+    secretsCount = value.length;
+    count = configmapsCount + secretsCount;
+  });
+
+  const registry: NavigationRegistryEntry = {
+    name: 'ConfigMaps & Secrets',
+    icon: { iconComponent: ConfigMapSecretIcon },
+    link: '/configmapsSecrets',
+    tooltip: 'ConfigMaps & Secrets',
+    type: 'entry',
+    get counter() {
+      return count;
+    },
+  };
+  return registry;
+}

--- a/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s-deployments.svelte.spec.ts
+++ b/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s-deployments.svelte.spec.ts
@@ -1,0 +1,59 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesObject } from '@kubernetes/client-node';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { createNavigationKubernetesDeploymentsEntry } from './navigation-registry-k8s-deployments.svelte';
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  (window as any).kubernetesRegisterGetCurrentContextResources = kubernetesRegisterGetCurrentContextResourcesMock;
+});
+
+const kubernetesRegisterGetCurrentContextResourcesMock = vi.fn();
+
+test('createNavigationKubernetesDeploymentsEntry', async () => {
+  const nodes: KubernetesObject[] = [
+    {
+      apiVersion: 'v1',
+      kind: 'Node',
+      metadata: {
+        name: 'node1',
+      },
+    },
+    {
+      apiVersion: 'v1',
+      kind: 'Node',
+      metadata: {
+        name: 'node2',
+      },
+    },
+  ];
+  kubernetesRegisterGetCurrentContextResourcesMock.mockResolvedValue(nodes);
+
+  const entry = createNavigationKubernetesDeploymentsEntry();
+
+  expect(entry).toBeDefined();
+  expect(entry.name).toBe('Deployments');
+  expect(entry.link).toBe('/deployments');
+  expect(entry.tooltip).toBe('Deployments');
+  await vi.waitFor(() => {
+    expect(entry.counter).toBe(2);
+  });
+});

--- a/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s-deployments.svelte.ts
+++ b/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s-deployments.svelte.ts
@@ -1,0 +1,41 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import DeploymentIcon from '/@/lib/images/DeploymentIcon.svelte';
+
+import { kubernetesCurrentContextDeployments } from '../../kubernetes-contexts-state';
+import type { NavigationRegistryEntry } from '../navigation-registry';
+
+let count = $state(0);
+
+export function createNavigationKubernetesDeploymentsEntry(): NavigationRegistryEntry {
+  kubernetesCurrentContextDeployments.subscribe(nodes => {
+    count = nodes.length;
+  });
+  const registry: NavigationRegistryEntry = {
+    name: 'Deployments',
+    icon: { iconComponent: DeploymentIcon },
+    link: '/deployments',
+    tooltip: 'Deployments',
+    type: 'entry',
+    get counter() {
+      return count;
+    },
+  };
+  return registry;
+}

--- a/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s-ingresses-routes.svelte.spec.ts
+++ b/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s-ingresses-routes.svelte.spec.ts
@@ -1,0 +1,59 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesObject } from '@kubernetes/client-node';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { createNavigationKubernetesIngressesRoutesEntry } from './navigation-registry-k8s-ingresses-routes.svelte';
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  (window as any).kubernetesRegisterGetCurrentContextResources = kubernetesRegisterGetCurrentContextResourcesMock;
+});
+
+const kubernetesRegisterGetCurrentContextResourcesMock = vi.fn();
+
+test('createNavigationKubernetesIngressesRoutesEntry', async () => {
+  const nodes: KubernetesObject[] = [
+    {
+      apiVersion: 'v1',
+      kind: 'Node',
+      metadata: {
+        name: 'node1',
+      },
+    },
+    {
+      apiVersion: 'v1',
+      kind: 'Node',
+      metadata: {
+        name: 'node2',
+      },
+    },
+  ];
+  kubernetesRegisterGetCurrentContextResourcesMock.mockResolvedValue(nodes);
+
+  const entry = createNavigationKubernetesIngressesRoutesEntry();
+
+  expect(entry).toBeDefined();
+  expect(entry.name).toBe('Ingresses & Routes');
+  expect(entry.link).toBe('/ingressesRoutes');
+  expect(entry.tooltip).toBe('Ingresses & Routes');
+  await vi.waitFor(() => {
+    expect(entry.counter).toBe(2);
+  });
+});

--- a/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s-ingresses-routes.svelte.ts
+++ b/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s-ingresses-routes.svelte.ts
@@ -1,0 +1,56 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import IngressRouteIcon from '/@/lib/images/IngressRouteIcon.svelte';
+
+import {
+  kubernetesCurrentContextIngresses,
+  kubernetesCurrentContextNodes,
+  kubernetesCurrentContextRoutes,
+} from '../../kubernetes-contexts-state';
+import type { NavigationRegistryEntry } from '../navigation-registry';
+
+let ingressesCount = 0;
+let routesCount = 0;
+let count = $state(0);
+
+export function createNavigationKubernetesIngressesRoutesEntry(): NavigationRegistryEntry {
+  kubernetesCurrentContextIngresses.subscribe(value => {
+    ingressesCount = value.length;
+    count = ingressesCount + routesCount;
+  });
+  kubernetesCurrentContextRoutes.subscribe(value => {
+    routesCount = value.length;
+    count = ingressesCount + routesCount;
+  });
+
+  kubernetesCurrentContextNodes.subscribe(nodes => {
+    count = nodes.length;
+  });
+  const registry: NavigationRegistryEntry = {
+    name: 'Ingresses & Routes',
+    icon: { iconComponent: IngressRouteIcon },
+    link: '/ingressesRoutes',
+    tooltip: 'Ingresses & Routes',
+    type: 'entry',
+    get counter() {
+      return count;
+    },
+  };
+  return registry;
+}

--- a/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s-nodes.svelte.spec.ts
+++ b/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s-nodes.svelte.spec.ts
@@ -1,0 +1,59 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesObject } from '@kubernetes/client-node';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { createNavigationKubernetesNodesEntry } from './navigation-registry-k8s-nodes.svelte';
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  (window as any).kubernetesRegisterGetCurrentContextResources = kubernetesRegisterGetCurrentContextResourcesMock;
+});
+
+const kubernetesRegisterGetCurrentContextResourcesMock = vi.fn();
+
+test('createNavigationKubernetesNodesEntry', async () => {
+  const nodes: KubernetesObject[] = [
+    {
+      apiVersion: 'v1',
+      kind: 'Node',
+      metadata: {
+        name: 'node1',
+      },
+    },
+    {
+      apiVersion: 'v1',
+      kind: 'Node',
+      metadata: {
+        name: 'node2',
+      },
+    },
+  ];
+  kubernetesRegisterGetCurrentContextResourcesMock.mockResolvedValue(nodes);
+
+  const entry = createNavigationKubernetesNodesEntry();
+
+  expect(entry).toBeDefined();
+  expect(entry.name).toBe('Nodes');
+  expect(entry.link).toBe('/nodes');
+  expect(entry.tooltip).toBe('Nodes');
+  await vi.waitFor(() => {
+    expect(entry.counter).toBe(2);
+  });
+});

--- a/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s-nodes.svelte.ts
+++ b/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s-nodes.svelte.ts
@@ -1,0 +1,41 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import NodeIcon from '/@/lib/images/NodeIcon.svelte';
+
+import { kubernetesCurrentContextNodes } from '../../kubernetes-contexts-state';
+import type { NavigationRegistryEntry } from '../navigation-registry';
+
+let count = $state(0);
+
+export function createNavigationKubernetesNodesEntry(): NavigationRegistryEntry {
+  kubernetesCurrentContextNodes.subscribe(nodes => {
+    count = nodes.length;
+  });
+  const registry: NavigationRegistryEntry = {
+    name: 'Nodes',
+    icon: { iconComponent: NodeIcon },
+    link: '/nodes',
+    tooltip: 'Nodes',
+    type: 'entry',
+    get counter() {
+      return count;
+    },
+  };
+  return registry;
+}

--- a/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s-persistent-volume.svelte.spec.ts
+++ b/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s-persistent-volume.svelte.spec.ts
@@ -1,0 +1,60 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesObject } from '@kubernetes/client-node';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { createNavigationKubernetesPersistentVolumeEntry } from './navigation-registry-k8s-persistent-volume.svelte';
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  (window as any).kubernetesRegisterGetCurrentContextResources = kubernetesRegisterGetCurrentContextResourcesMock;
+});
+
+const kubernetesRegisterGetCurrentContextResourcesMock = vi.fn();
+
+test('createNavigationKubernetesPersistentVolumeEntry', async () => {
+  const nodes: KubernetesObject[] = [
+    {
+      apiVersion: 'v1',
+      kind: 'Node',
+      metadata: {
+        name: 'node1',
+      },
+    },
+    {
+      apiVersion: 'v1',
+      kind: 'Node',
+      metadata: {
+        name: 'node2',
+      },
+    },
+  ];
+
+  kubernetesRegisterGetCurrentContextResourcesMock.mockResolvedValue(nodes);
+
+  const entry = createNavigationKubernetesPersistentVolumeEntry();
+
+  expect(entry).toBeDefined();
+  expect(entry.name).toBe('Persistent Volume Claims');
+  expect(entry.link).toBe('/persistentvolumeclaims');
+  expect(entry.tooltip).toBe('Persistent Volume Claims');
+  await vi.waitFor(() => {
+    expect(entry.counter).toBe(2);
+  });
+});

--- a/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s-persistent-volume.svelte.ts
+++ b/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s-persistent-volume.svelte.ts
@@ -1,0 +1,42 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import PvcIcon from '/@/lib/images/PVCIcon.svelte';
+
+import { kubernetesCurrentContextPersistentVolumeClaims } from '../../kubernetes-contexts-state';
+import type { NavigationRegistryEntry } from '../navigation-registry';
+
+let count = $state(0);
+
+export function createNavigationKubernetesPersistentVolumeEntry(): NavigationRegistryEntry {
+  kubernetesCurrentContextPersistentVolumeClaims.subscribe(value => {
+    count = value.length;
+  });
+
+  const registry: NavigationRegistryEntry = {
+    name: 'Persistent Volume Claims',
+    icon: { iconComponent: PvcIcon },
+    link: '/persistentvolumeclaims',
+    tooltip: 'Persistent Volume Claims',
+    type: 'entry',
+    get counter() {
+      return count;
+    },
+  };
+  return registry;
+}

--- a/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s-services.svelte.spec.ts
+++ b/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s-services.svelte.spec.ts
@@ -1,0 +1,61 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesObject } from '@kubernetes/client-node';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { createNavigationKubernetesServicesEntry } from './navigation-registry-k8s-services.svelte';
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.clearAllMocks();
+  (window as any).kubernetesRegisterGetCurrentContextResources = kubernetesRegisterGetCurrentContextResourcesMock;
+});
+
+const kubernetesRegisterGetCurrentContextResourcesMock = vi.fn();
+
+test('createNavigationKubernetesServicesEntry', async () => {
+  const nodes: KubernetesObject[] = [
+    {
+      apiVersion: 'v1',
+      kind: 'Node',
+      metadata: {
+        name: 'node1',
+      },
+    },
+    {
+      apiVersion: 'v1',
+      kind: 'Node',
+      metadata: {
+        name: 'node2',
+      },
+    },
+  ];
+
+  kubernetesRegisterGetCurrentContextResourcesMock.mockResolvedValue(nodes);
+
+  const entry = createNavigationKubernetesServicesEntry();
+
+  expect(entry).toBeDefined();
+  expect(entry.name).toBe('Services');
+  expect(entry.link).toBe('/services');
+  expect(entry.tooltip).toBe('Services');
+  await vi.waitFor(() => {
+    expect(entry.counter).toBe(2);
+  });
+});

--- a/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s-services.svelte.ts
+++ b/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s-services.svelte.ts
@@ -1,0 +1,41 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import ServiceIcon from '/@/lib/images/ServiceIcon.svelte';
+
+import { kubernetesCurrentContextServices } from '../../kubernetes-contexts-state';
+import type { NavigationRegistryEntry } from '../navigation-registry';
+
+let count = $state(0);
+
+export function createNavigationKubernetesServicesEntry(): NavigationRegistryEntry {
+  kubernetesCurrentContextServices.subscribe(services => {
+    count = services.length;
+  });
+  const registry: NavigationRegistryEntry = {
+    name: 'Services',
+    icon: { iconComponent: ServiceIcon },
+    link: '/services',
+    tooltip: 'Services',
+    type: 'entry',
+    get counter() {
+      return count;
+    },
+  };
+  return registry;
+}

--- a/packages/renderer/src/stores/navigation/navigation-registry-container.svelte.spec.ts
+++ b/packages/renderer/src/stores/navigation/navigation-registry-container.svelte.spec.ts
@@ -1,0 +1,50 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import type { ContainerInfo } from '/@api/container-info';
+
+import { containersInfos } from '../containers';
+import { createNavigationContainerEntry } from './navigation-registry-container.svelte';
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+test('createNavigationContainerEntry', async () => {
+  // set 2 containers
+
+  const entry = createNavigationContainerEntry();
+  containersInfos.set([
+    {
+      Id: '1234',
+    } as unknown as ContainerInfo,
+    {
+      Id: '3456',
+    } as unknown as ContainerInfo,
+  ]);
+
+  expect(entry).toBeDefined();
+  expect(entry.name).toBe('Containers');
+  expect(entry.link).toBe('/containers');
+  expect(entry.tooltip).toBe('Containers');
+  await vi.waitFor(() => {
+    expect(entry.counter).toBe(2);
+  });
+});

--- a/packages/renderer/src/stores/navigation/navigation-registry-container.svelte.ts
+++ b/packages/renderer/src/stores/navigation/navigation-registry-container.svelte.ts
@@ -1,0 +1,41 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { ContainerIcon } from '@podman-desktop/ui-svelte/icons';
+
+import { containersInfos } from '../containers';
+import type { NavigationRegistryEntry } from './navigation-registry';
+
+let count = $state(0);
+
+export function createNavigationContainerEntry(): NavigationRegistryEntry {
+  containersInfos.subscribe(containers => {
+    count = containers.length;
+  });
+  const registry: NavigationRegistryEntry = {
+    name: 'Containers',
+    icon: { iconComponent: ContainerIcon },
+    link: '/containers',
+    tooltip: 'Containers',
+    type: 'entry',
+    get counter() {
+      return count;
+    },
+  };
+  return registry;
+}

--- a/packages/renderer/src/stores/navigation/navigation-registry-extension.svelte.ts
+++ b/packages/renderer/src/stores/navigation/navigation-registry-extension.svelte.ts
@@ -1,0 +1,112 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { faPuzzlePiece } from '@fortawesome/free-solid-svg-icons';
+
+import type { ContributionInfo } from '/@api/contribution-info';
+import type { WebviewInfo } from '/@api/webview-info';
+
+import ExtensionIcon from '../../lib/images/ExtensionIcon.svelte';
+import { contributions } from '../contribs';
+import { webviews } from '../webviews';
+import type { NavigationRegistryEntry } from './navigation-registry';
+
+export function createNavigationExtensionEntry(): NavigationRegistryEntry {
+  const registry: NavigationRegistryEntry = {
+    name: 'Extensions',
+    icon: { iconComponent: ExtensionIcon },
+    link: '/extensions',
+    tooltip: 'Extensions',
+    type: 'entry',
+    get counter() {
+      return 0;
+    },
+  };
+  return registry;
+}
+
+let extensionNavigationGroupItems: NavigationRegistryEntry[] = $state([]);
+
+export function createNavigationExtensionGroup(): NavigationRegistryEntry {
+  const mainGroupEntry: NavigationRegistryEntry = {
+    name: 'Extensions',
+    icon: { iconComponent: ExtensionIcon },
+    link: `/extensions`,
+    tooltip: 'Extensions',
+    type: 'group',
+    get counter() {
+      return 0;
+    },
+    get items() {
+      return extensionNavigationGroupItems;
+    },
+  };
+
+  let allContribs: ContributionInfo[] = [];
+
+  let allWebviews: WebviewInfo[] = [];
+
+  const refresh = () => {
+    const newItems: NavigationRegistryEntry[] = [];
+    allContribs.forEach(contrib => {
+      const registry: NavigationRegistryEntry = {
+        name: contrib.name,
+        icon: {
+          iconImage: contrib.icon,
+        },
+        link: `/contribs/${contrib.name}`,
+        type: 'entry',
+        tooltip: contrib.name,
+        get counter() {
+          return 0;
+        },
+      };
+      newItems.push(registry);
+    });
+
+    allWebviews.forEach(webview => {
+      const icon = webview.icon ? { iconImage: webview.icon } : { faIconImage: faPuzzlePiece, size: '1.5x' };
+
+      const registry: NavigationRegistryEntry = {
+        name: webview.name,
+        icon,
+        link: `/webviews/${webview.id}`,
+        tooltip: webview.name,
+        type: 'entry',
+        get counter() {
+          return 0;
+        },
+      };
+      newItems.push(registry);
+    });
+
+    extensionNavigationGroupItems = newItems;
+  };
+
+  contributions.subscribe(contribs => {
+    allContribs = [...contribs];
+    refresh();
+  });
+
+  webviews.subscribe(webviews => {
+    allWebviews = [...webviews];
+    refresh();
+  });
+
+  return mainGroupEntry;
+}

--- a/packages/renderer/src/stores/navigation/navigation-registry-extensions.svelte.spec.ts
+++ b/packages/renderer/src/stores/navigation/navigation-registry-extensions.svelte.spec.ts
@@ -1,0 +1,35 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { createNavigationExtensionEntry } from './navigation-registry-extension.svelte';
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+test('createNavigationExtensionEntry', async () => {
+  const entry = createNavigationExtensionEntry();
+
+  expect(entry).toBeDefined();
+  expect(entry.name).toBe('Extensions');
+  expect(entry.link).toBe('/extensions');
+  expect(entry.tooltip).toBe('Extensions');
+  expect(entry.counter).toBe(0);
+});

--- a/packages/renderer/src/stores/navigation/navigation-registry-image.svelte.spec.ts
+++ b/packages/renderer/src/stores/navigation/navigation-registry-image.svelte.spec.ts
@@ -1,0 +1,50 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import type { ImageInfo } from '/@api/image-info';
+
+import { imagesInfos } from '../images';
+import { createNavigationImageEntry } from './navigation-registry-image.svelte';
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+test('createNavigationImageEntry', async () => {
+  const entry = createNavigationImageEntry();
+  imagesInfos.set([
+    {
+      Id: '1234',
+      Size: 0,
+    } as unknown as ImageInfo,
+    {
+      Id: '3456',
+      Size: 0,
+    } as unknown as ImageInfo,
+  ]);
+
+  expect(entry).toBeDefined();
+  expect(entry.name).toBe('Images');
+  expect(entry.link).toBe('/images');
+  expect(entry.tooltip).toBe('Images');
+  await vi.waitFor(() => {
+    expect(entry.counter).toBe(2);
+  });
+});

--- a/packages/renderer/src/stores/navigation/navigation-registry-image.svelte.ts
+++ b/packages/renderer/src/stores/navigation/navigation-registry-image.svelte.ts
@@ -1,0 +1,49 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { ImageUtils } from '/@/lib/image/image-utils';
+import type { ImageInfo } from '/@api/image-info';
+
+import ImageIcon from '../../lib/images/ImageIcon.svelte';
+import { imagesInfos } from '../images';
+import type { NavigationRegistryEntry } from './navigation-registry';
+
+let count = $state(0);
+
+const imageUtils = new ImageUtils();
+
+export function createNavigationImageEntry(): NavigationRegistryEntry {
+  imagesInfos.subscribe(images => {
+    const allImages = images
+      .map((imageInfo: ImageInfo) => imageUtils.getImagesInfoUI(imageInfo, [], undefined, []))
+      .flat();
+    count = allImages.length;
+  });
+  const registry: NavigationRegistryEntry = {
+    name: 'Images',
+    icon: { iconComponent: ImageIcon },
+    link: '/images',
+    tooltip: 'Images',
+    type: 'entry',
+
+    get counter() {
+      return count;
+    },
+  };
+  return registry;
+}

--- a/packages/renderer/src/stores/navigation/navigation-registry-kubernetes.svelte.spec.ts
+++ b/packages/renderer/src/stores/navigation/navigation-registry-kubernetes.svelte.spec.ts
@@ -1,0 +1,62 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesObject } from '@kubernetes/client-node';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import KubeIcon from '/@/lib/images/KubeIcon.svelte';
+
+import { createNavigationKubernetesGroup } from './navigation-registry-kubernetes.svelte';
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  (window as any).kubernetesRegisterGetCurrentContextResources = kubernetesRegisterGetCurrentContextResourcesMock;
+});
+
+const kubernetesRegisterGetCurrentContextResourcesMock = vi.fn();
+
+test('createNavigationImageEntry', async () => {
+  const nodes: KubernetesObject[] = [
+    {
+      apiVersion: 'v1',
+      kind: 'Node',
+      metadata: {
+        name: 'node1',
+      },
+    },
+    {
+      apiVersion: 'v1',
+      kind: 'Node',
+      metadata: {
+        name: 'node2',
+      },
+    },
+  ];
+  kubernetesRegisterGetCurrentContextResourcesMock.mockResolvedValue(nodes);
+
+  const entry = createNavigationKubernetesGroup();
+
+  expect(entry).toBeDefined();
+  expect(entry.name).toBe('Kubernetes');
+  expect(entry.icon.iconComponent).toBe(KubeIcon);
+
+  // should have 6 items
+  await vi.waitFor(() => {
+    expect(entry.items?.length).toBe(6);
+  });
+});

--- a/packages/renderer/src/stores/navigation/navigation-registry-kubernetes.svelte.ts
+++ b/packages/renderer/src/stores/navigation/navigation-registry-kubernetes.svelte.ts
@@ -1,0 +1,67 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import KubeIcon from '/@/lib/images/KubeIcon.svelte';
+
+import { kubernetesContexts } from '../kubernetes-contexts';
+import { createNavigationKubernetesConfigMapSecretsEntry } from './kubernetes/navigation-registry-k8s-configmap-secrets.svelte';
+import { createNavigationKubernetesDeploymentsEntry } from './kubernetes/navigation-registry-k8s-deployments.svelte';
+import { createNavigationKubernetesIngressesRoutesEntry } from './kubernetes/navigation-registry-k8s-ingresses-routes.svelte';
+import { createNavigationKubernetesNodesEntry } from './kubernetes/navigation-registry-k8s-nodes.svelte';
+import { createNavigationKubernetesPersistentVolumeEntry } from './kubernetes/navigation-registry-k8s-persistent-volume.svelte';
+import { createNavigationKubernetesServicesEntry } from './kubernetes/navigation-registry-k8s-services.svelte';
+import type { NavigationRegistryEntry } from './navigation-registry';
+
+let kubernetesNavigationGroupItems: NavigationRegistryEntry[] = $state([]);
+
+// default is false until we receive the kubernetes contexts
+let enabled = $state(false);
+
+kubernetesContexts.subscribe(value => {
+  enabled = value.length > 0;
+});
+
+export function createNavigationKubernetesGroup(): NavigationRegistryEntry {
+  const newItems: NavigationRegistryEntry[] = [];
+  newItems.push(createNavigationKubernetesNodesEntry());
+  newItems.push(createNavigationKubernetesDeploymentsEntry());
+  newItems.push(createNavigationKubernetesServicesEntry());
+  newItems.push(createNavigationKubernetesIngressesRoutesEntry());
+  newItems.push(createNavigationKubernetesPersistentVolumeEntry());
+  newItems.push(createNavigationKubernetesConfigMapSecretsEntry());
+  kubernetesNavigationGroupItems = newItems;
+
+  const mainGroupEntry: NavigationRegistryEntry = {
+    name: 'Kubernetes',
+    icon: { iconComponent: KubeIcon },
+    link: ``,
+    tooltip: '',
+    type: 'section',
+    get counter() {
+      return 0;
+    },
+    get enabled() {
+      return enabled;
+    },
+    get items() {
+      return kubernetesNavigationGroupItems;
+    },
+  };
+
+  return mainGroupEntry;
+}

--- a/packages/renderer/src/stores/navigation/navigation-registry-pod.svelte.spec.ts
+++ b/packages/renderer/src/stores/navigation/navigation-registry-pod.svelte.spec.ts
@@ -1,0 +1,47 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import type { PodInfo } from '../../../../main/src/plugin/api/pod-info';
+import { podsInfos } from '../pods';
+import { createNavigationPodEntry } from './navigation-registry-pod.svelte';
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+test('createNavigationPodEntry', async () => {
+  const entry = createNavigationPodEntry();
+  podsInfos.set([
+    {
+      Id: '1234',
+    } as unknown as PodInfo,
+    {
+      Id: '3456',
+    } as unknown as PodInfo,
+  ]);
+
+  expect(entry).toBeDefined();
+  expect(entry.name).toBe('Pods');
+  expect(entry.link).toBe('/pods');
+  expect(entry.tooltip).toBe('Pods');
+  await vi.waitFor(() => {
+    expect(entry.counter).toBe(2);
+  });
+});

--- a/packages/renderer/src/stores/navigation/navigation-registry-pod.svelte.ts
+++ b/packages/renderer/src/stores/navigation/navigation-registry-pod.svelte.ts
@@ -1,0 +1,41 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import PodIcon from '../../lib/images/PodIcon.svelte';
+import { podsInfos } from '../pods';
+import type { NavigationRegistryEntry } from './navigation-registry';
+
+let count = $state(0);
+
+export function createNavigationPodEntry(): NavigationRegistryEntry {
+  podsInfos.subscribe(pods => {
+    count = pods.length;
+  });
+  const registry: NavigationRegistryEntry = {
+    name: 'Pods',
+    icon: { iconComponent: PodIcon },
+    link: '/pods',
+    tooltip: 'Pods',
+    type: 'entry',
+
+    get counter() {
+      return count;
+    },
+  };
+  return registry;
+}

--- a/packages/renderer/src/stores/navigation/navigation-registry-volume.svelte.spec.ts
+++ b/packages/renderer/src/stores/navigation/navigation-registry-volume.svelte.spec.ts
@@ -1,0 +1,50 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import type { VolumeListInfo } from '/@api/volume-info';
+
+import { volumeListInfos } from '../volumes';
+import { createNavigationVolumeEntry } from './navigation-registry-volume.svelte';
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+test('createNavigationVolumeEntry', async () => {
+  const entry = createNavigationVolumeEntry();
+  volumeListInfos.set([
+    {
+      Id: '1234',
+      Size: 0,
+    } as unknown as VolumeListInfo,
+    {
+      Id: '3456',
+      Size: 0,
+    } as unknown as VolumeListInfo,
+  ]);
+
+  expect(entry).toBeDefined();
+  expect(entry.name).toBe('Volumes');
+  expect(entry.link).toBe('/volumes');
+  expect(entry.tooltip).toBe('Volumes');
+  await vi.waitFor(() => {
+    expect(entry.counter).toBe(2);
+  });
+});

--- a/packages/renderer/src/stores/navigation/navigation-registry-volume.svelte.ts
+++ b/packages/renderer/src/stores/navigation/navigation-registry-volume.svelte.ts
@@ -1,0 +1,43 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import VolumeIcon from '../../lib/images/VolumeIcon.svelte';
+import { volumeListInfos } from '../volumes';
+import type { NavigationRegistryEntry } from './navigation-registry';
+
+let count = $state(0);
+
+export function createNavigationVolumeEntry(): NavigationRegistryEntry {
+  volumeListInfos.subscribe(volumes => {
+    const flattenedVolumes = volumes.map(volumeInfo => volumeInfo.Volumes).flat();
+
+    count = flattenedVolumes.length;
+  });
+  const registry: NavigationRegistryEntry = {
+    name: 'Volumes',
+    icon: { iconComponent: VolumeIcon },
+    link: '/volumes',
+    tooltip: 'Volumes',
+    type: 'entry',
+
+    get counter() {
+      return count;
+    },
+  };
+  return registry;
+}

--- a/packages/renderer/src/stores/navigation/navigation-registry.spec.ts
+++ b/packages/renderer/src/stores/navigation/navigation-registry.spec.ts
@@ -1,0 +1,39 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { get } from 'svelte/store';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { fetchNavigationRegistries, navigationRegistry } from './navigation-registry';
+
+const kubernetesRegisterGetCurrentContextResourcesMock = vi.fn();
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  (window as any).kubernetesRegisterGetCurrentContextResources = kubernetesRegisterGetCurrentContextResourcesMock;
+});
+
+test('check navigation registry items', async () => {
+  kubernetesRegisterGetCurrentContextResourcesMock.mockResolvedValue([]);
+  await fetchNavigationRegistries();
+  const registries = get(navigationRegistry);
+  // expect 7 items in the registry
+  expect(registries.length).equal(7);
+});

--- a/packages/renderer/src/stores/navigation/navigation-registry.ts
+++ b/packages/renderer/src/stores/navigation/navigation-registry.ts
@@ -1,0 +1,87 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { IconDefinition } from '@fortawesome/fontawesome-common-types';
+import type { Writable } from 'svelte/store';
+import { writable } from 'svelte/store';
+import type { IconSize } from 'svelte-fa';
+
+import { EventStore } from '/@/stores/event-store';
+
+import { createNavigationContainerEntry } from './navigation-registry-container.svelte';
+import { createNavigationExtensionEntry, createNavigationExtensionGroup } from './navigation-registry-extension.svelte';
+import { createNavigationImageEntry } from './navigation-registry-image.svelte';
+import { createNavigationKubernetesGroup } from './navigation-registry-kubernetes.svelte';
+import { createNavigationPodEntry } from './navigation-registry-pod.svelte';
+import { createNavigationVolumeEntry } from './navigation-registry-volume.svelte';
+
+export interface NavigationRegistryEntry {
+  name: string;
+  icon: {
+    iconImage?: string | { readonly light: string; readonly dark: string };
+    iconComponent?: any;
+    faIcon?: { definition: IconDefinition; size: IconSize };
+  };
+  tooltip: string;
+  link: string;
+  counter: number;
+  type: 'section' | 'entry' | 'group';
+  enabled?: boolean;
+  items?: NavigationRegistryEntry[];
+}
+
+const windowEvents: string[] = [];
+const windowListeners = ['extensions-already-started', 'system-ready'];
+
+export const navigationRegistry: Writable<NavigationRegistryEntry[]> = writable([]);
+
+const values: NavigationRegistryEntry[] = [];
+let initialized = false;
+const init = () => {
+  values.push(createNavigationContainerEntry());
+  values.push(createNavigationPodEntry());
+  values.push(createNavigationImageEntry());
+  values.push(createNavigationVolumeEntry());
+  values.push(createNavigationKubernetesGroup());
+  values.push(createNavigationExtensionEntry());
+  values.push(createNavigationExtensionGroup());
+};
+
+// use helper here as window methods are initialized after the store in tests
+const grabList = async (): Promise<NavigationRegistryEntry[]> => {
+  if (!initialized) {
+    init();
+    initialized = true;
+  }
+  return values;
+};
+
+export const navigationRegistryEventStore = new EventStore<NavigationRegistryEntry[]>(
+  'navigation-registry',
+  navigationRegistry,
+  // should initialize when app is initializing
+  () => Promise.resolve(true),
+  windowEvents,
+  windowListeners,
+  grabList,
+);
+const navigationRegistryEventStoreInfo = navigationRegistryEventStore.setup();
+
+export const fetchNavigationRegistries = async (): Promise<void> => {
+  await navigationRegistryEventStoreInfo.fetch();
+};


### PR DESCRIPTION
### What does this PR do?
each item is registered to the navigation-registry

AppNavigation displays items coming from the registry, either individual items or like a section for kubernetes objects

### Screenshot / video of UI

it should be as before except for extensions that are now, no longer part of a section (puzzle icon)

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/7765
fixes https://github.com/containers/podman-desktop/issues/7763

### How to test this PR?

- [x] Tests are covering the bug fix or the new feature
