### PR TITLE
feat: light and dark mode for terminals

### DIFF
--- a/packages/main/src/plugin/color-registry.ts
+++ b/packages/main/src/plugin/color-registry.ts
@@ -254,6 +254,7 @@ export class ColorRegistry {
     this.initOnboarding();
     this.initStates();
     this.initFiles();
+    this.initTerminal();
   }
 
   protected initDefaults(): void {
@@ -1297,6 +1298,101 @@ export class ColorRegistry {
     this.registerColor(`${fc}executable`, {
       dark: colorPalette.green[500],
       light: colorPalette.green[500],
+    });
+  }
+
+  // terminal colours
+  protected initTerminal(): void {
+    const terminal = 'terminal-';
+
+    this.registerColor(`${terminal}foreground`, {
+      dark: colorPalette.white,
+      light: colorPalette.black,
+    });
+
+    this.registerColor(`${terminal}background`, {
+      dark: colorPalette.black,
+      light: colorPalette.white,
+    });
+
+    this.registerColor(`${terminal}cursor`, {
+      dark: colorPalette.white,
+      light: colorPalette.black,
+    });
+
+    this.registerColor(`${terminal}selectionBackground`, {
+      dark: colorPalette.white,
+      light: colorPalette.black,
+    });
+
+    this.registerColor(`${terminal}selectionForeground`, {
+      dark: colorPalette.black,
+      light: colorPalette.white,
+    });
+
+    this.registerColor(`${terminal}ansiBlack`, {
+      dark: colorPalette.black,
+      light: colorPalette.black,
+    });
+    this.registerColor(`${terminal}ansiRed`, {
+      dark: colorPalette.red[500],
+      light: colorPalette.red[500],
+    });
+    this.registerColor(`${terminal}ansiGreen`, {
+      dark: colorPalette.green[500],
+      light: colorPalette.green[500],
+    });
+    this.registerColor(`${terminal}ansiYellow`, {
+      dark: colorPalette.amber[500],
+      light: colorPalette.amber[500],
+    });
+    this.registerColor(`${terminal}ansiBlue`, {
+      dark: colorPalette.sky[500],
+      light: colorPalette.sky[500],
+    });
+    this.registerColor(`${terminal}ansiMagenta`, {
+      dark: colorPalette.purple[500],
+      light: colorPalette.purple[500],
+    });
+    this.registerColor(`${terminal}ansiCyan`, {
+      dark: colorPalette.sky[500],
+      light: colorPalette.sky[500],
+    });
+    this.registerColor(`${terminal}ansiWhite`, {
+      dark: colorPalette.white,
+      light: colorPalette.white,
+    });
+    this.registerColor(`${terminal}ansiBrightBlack`, {
+      dark: colorPalette.gray[500],
+      light: colorPalette.gray[500],
+    });
+    this.registerColor(`${terminal}ansiBrightRed`, {
+      dark: colorPalette.red[600],
+      light: colorPalette.red[600],
+    });
+    this.registerColor(`${terminal}ansiBrightGreen`, {
+      dark: colorPalette.green[600],
+      light: colorPalette.green[600],
+    });
+    this.registerColor(`${terminal}ansiBrightYellow`, {
+      dark: colorPalette.amber[600],
+      light: colorPalette.amber[600],
+    });
+    this.registerColor(`${terminal}ansiBrightBlue`, {
+      dark: colorPalette.sky[600],
+      light: colorPalette.sky[600],
+    });
+    this.registerColor(`${terminal}ansiBrightMagenta`, {
+      dark: colorPalette.purple[600],
+      light: colorPalette.purple[600],
+    });
+    this.registerColor(`${terminal}ansiBrightCyan`, {
+      dark: colorPalette.sky[600],
+      light: colorPalette.sky[600],
+    });
+    this.registerColor(`${terminal}ansiBrightWhite`, {
+      dark: colorPalette.white,
+      light: colorPalette.white,
     });
   }
 }

--- a/packages/main/src/plugin/terminal-theme.spec.ts
+++ b/packages/main/src/plugin/terminal-theme.spec.ts
@@ -1,0 +1,94 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { describe, expect, test, vi } from 'vitest';
+import type { ITheme } from 'xterm';
+
+import { getTerminalTheme } from './terminal-theme.js';
+
+describe('getTerminalTheme', () => {
+  test('should return an ITheme object with properties from CSS variables', () => {
+    // We do not want to mock *all* of the document, so we will use stubGlobal to mock only the properties we need
+    const mockDocumentElement = {} as HTMLElement;
+    vi.stubGlobal('document', {
+      documentElement: mockDocumentElement,
+    });
+    vi.stubGlobal('window', {
+      getComputedStyle: () => mockComputedStyle as unknown as CSSStyleDeclaration,
+    });
+
+    // Mock returned values with fake ones
+    const mockComputedStyle = {
+      getPropertyValue: (property: string): string => {
+        const cssVariables: { [key: string]: string } = {
+          '--pd-terminal-foreground': '#ffffff',
+          '--pd-terminal-background': '#000000',
+          '--pd-terminal-cursor': '#00ff00',
+          '--pd-terminal-selectionBackground': '#cccccc',
+          '--pd-terminal-selectionForeground': '#333333',
+          '--pd-terminal-black': '#000000',
+          '--pd-terminal-red': '#ff0000',
+          '--pd-terminal-green': '#00ff00',
+          '--pd-terminal-yellow': '#ffff00',
+          '--pd-terminal-blue': '#0000ff',
+          '--pd-terminal-magenta': '#ff00ff',
+          '--pd-terminal-cyan': '#00ffff',
+          '--pd-terminal-white': '#ffffff',
+          '--pd-terminal-brightBlack': '#555555',
+          '--pd-terminal-brightRed': '#ff5555',
+          '--pd-terminal-brightGreen': '#55ff55',
+          '--pd-terminal-brightYellow': '#ffff55',
+          '--pd-terminal-brightBlue': '#5555ff',
+          '--pd-terminal-brightMagenta': '#ff55ff',
+          '--pd-terminal-brightCyan': '#55ffff',
+          '--pd-terminal-brightWhite': '#ffffff',
+        };
+        return cssVariables[property] || '';
+      },
+    };
+
+    const theme = getTerminalTheme();
+
+    // Expect the theme to return back correctly from the mocked CSS variables.
+    const expectedTheme: ITheme = {
+      foreground: '#ffffff',
+      background: '#000000',
+      cursor: '#00ff00',
+      selectionBackground: '#cccccc',
+      selectionForeground: '#333333',
+      black: '#000000',
+      red: '#ff0000',
+      green: '#00ff00',
+      yellow: '#ffff00',
+      blue: '#0000ff',
+      magenta: '#ff00ff',
+      cyan: '#00ffff',
+      white: '#ffffff',
+      brightBlack: '#555555',
+      brightRed: '#ff5555',
+      brightGreen: '#55ff55',
+      brightYellow: '#ffff55',
+      brightBlue: '#5555ff',
+      brightMagenta: '#ff55ff',
+      brightCyan: '#55ffff',
+      brightWhite: '#ffffff',
+    };
+
+    expect(theme).toEqual(expectedTheme);
+  });
+});

--- a/packages/main/src/plugin/terminal-theme.ts
+++ b/packages/main/src/plugin/terminal-theme.ts
@@ -1,0 +1,81 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { ITheme } from 'xterm';
+
+// Array of strings to extract from the CSS variables
+// we list it here as we cannot infer the properties from the ITheme type at runtime. Another reason is to avoid
+// the conflict with the 'extendedAnsi' string[] array key. We also provide "safer" method of gathering the CSS values.
+const KNOWN_THEME_PROPERTIES = [
+  'foreground',
+  'background',
+  'cursor',
+  'selectionBackground',
+  'selectionForeground',
+  'black',
+  'red',
+  'green',
+  'yellow',
+  'blue',
+  'magenta',
+  'cyan',
+  'white',
+  'brightBlack',
+  'brightRed',
+  'brightGreen',
+  'brightYellow',
+  'brightBlue',
+  'brightMagenta',
+  'brightCyan',
+  'brightWhite',
+] as const;
+
+const TERMINAL_PREFIX = '--pd-terminal-';
+
+// Utility function to get the terminal theme from CSS variables supplied by color-registry
+// we do this by getting the computed style of the root element and extracting the values of the variables
+// that start with the prefix '--pd-terminal-'
+// we then go through all known theme properties of ITheme and assign the values to the theme object
+export function getTerminalTheme(): ITheme | undefined {
+  const root = document.documentElement;
+
+  if (!root) {
+    console.error(
+      'Could not find document.documentElement and was unable to load terminal theme, returning undefined / default theme',
+    );
+    return undefined;
+  }
+
+  // Get the computed style of the root element containing the color-registry variables
+  const computedStyle = window.getComputedStyle(root);
+  const theme: ITheme = {} as ITheme;
+
+  // Extract and assign each property to the theme object from the CSS variables
+  KNOWN_THEME_PROPERTIES.forEach(property => {
+    const cssVar = `${TERMINAL_PREFIX}${property}`;
+
+    // Find the property value, trim it and assign it to the theme object
+    // only if it is not an empty string
+    const propertyValue = computedStyle.getPropertyValue(cssVar).trim();
+    if (propertyValue) {
+      theme[property] = propertyValue;
+    }
+  });
+
+  return theme;
+}

--- a/packages/renderer/src/lib/compose/ComposeDetailsLogs.svelte
+++ b/packages/renderer/src/lib/compose/ComposeDetailsLogs.svelte
@@ -7,7 +7,7 @@ import { Terminal } from 'xterm';
 import { FitAddon } from 'xterm-addon-fit';
 
 import { TerminalSettings } from '../../../../main/src/plugin/terminal-settings';
-import { getPanelDetailColor } from '../color/color';
+import { getTerminalTheme } from '../../../../main/src/plugin/terminal-theme';
 import { ansi256Colours, colourizedANSIContainerName } from '../editor/editor-utils';
 import { isMultiplexedLog } from '../stream/stream-utils';
 import NoLogIcon from '../ui/NoLogIcon.svelte';
@@ -124,9 +124,7 @@ async function refreshTerminal() {
     fontSize,
     lineHeight,
     disableStdin: true,
-    theme: {
-      background: getPanelDetailColor(),
-    },
+    theme: getTerminalTheme(),
     convertEol: true,
   });
   termFit = new FitAddon();

--- a/packages/renderer/src/lib/container/ContainerDetailsLogs.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetailsLogs.svelte
@@ -7,7 +7,7 @@ import { Terminal } from 'xterm';
 import { FitAddon } from 'xterm-addon-fit';
 
 import { TerminalSettings } from '../../../../main/src/plugin/terminal-settings';
-import { getPanelDetailColor } from '../color/color';
+import { getTerminalTheme } from '../../../../main/src/plugin/terminal-theme';
 import { isMultiplexedLog } from '../stream/stream-utils';
 import NoLogIcon from '../ui/NoLogIcon.svelte';
 import type { ContainerInfoUI } from './ContainerInfoUI';
@@ -78,9 +78,7 @@ async function refreshTerminal() {
     fontSize,
     lineHeight,
     disableStdin: true,
-    theme: {
-      background: getPanelDetailColor(),
-    },
+    theme: getTerminalTheme(),
     convertEol: true,
   });
   termFit = new FitAddon();

--- a/packages/renderer/src/lib/container/ContainerDetailsTerminal.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetailsTerminal.svelte
@@ -10,7 +10,7 @@ import { FitAddon } from 'xterm-addon-fit';
 import { getExistingTerminal, registerTerminal } from '/@/stores/container-terminal-store';
 
 import { TerminalSettings } from '../../../../main/src/plugin/terminal-settings';
-import { getPanelDetailColor } from '../color/color';
+import { getTerminalTheme } from '../../../../main/src/plugin/terminal-theme';
 import NoLogIcon from '../ui/NoLogIcon.svelte';
 import type { ContainerInfoUI } from './ContainerInfoUI';
 
@@ -100,9 +100,7 @@ async function refreshTerminal() {
       fontSize,
       lineHeight,
       screenReaderMode,
-      theme: {
-        background: getPanelDetailColor(),
-      },
+      theme: getTerminalTheme(),
     });
   }
 

--- a/packages/renderer/src/lib/container/ContainerDetailsTtyTerminal.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetailsTtyTerminal.svelte
@@ -8,7 +8,7 @@ import { Terminal } from 'xterm';
 import { FitAddon } from 'xterm-addon-fit';
 
 import { TerminalSettings } from '../../../../main/src/plugin/terminal-settings';
-import { getPanelDetailColor } from '../color/color';
+import { getTerminalTheme } from '../../../../main/src/plugin/terminal-theme';
 import NoLogIcon from '../ui/NoLogIcon.svelte';
 import type { ContainerInfoUI } from './ContainerInfoUI';
 
@@ -73,9 +73,7 @@ async function refreshTerminal() {
     fontSize,
     lineHeight,
     screenReaderMode,
-    theme: {
-      background: getPanelDetailColor(),
-    },
+    theme: getTerminalTheme(),
   });
 
   const fitAddon = new FitAddon();

--- a/packages/renderer/src/lib/dashboard/ProviderConfiguring.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderConfiguring.svelte
@@ -9,6 +9,7 @@ import { FitAddon } from 'xterm-addon-fit';
 import type { CheckStatus, ProviderInfo } from '/@api/provider-info';
 
 import { TerminalSettings } from '../../../../main/src/plugin/terminal-settings';
+import { getTerminalTheme } from '../../../../main/src/plugin/terminal-theme';
 import { getPanelDetailColor } from '../color/color';
 import Steps from '../ui/Steps.svelte';
 import PreflightChecks from './PreflightChecks.svelte';
@@ -48,9 +49,7 @@ async function refreshTerminal() {
     fontSize,
     lineHeight,
     disableStdin: true,
-    theme: {
-      background: getPanelDetailColor(),
-    },
+    theme: getTerminalTheme(),
     convertEol: true,
   });
   termFit = new FitAddon();

--- a/packages/renderer/src/lib/dashboard/ProviderInstalled.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderInstalled.svelte
@@ -9,6 +9,7 @@ import { FitAddon } from 'xterm-addon-fit';
 import type { CheckStatus, ProviderInfo } from '/@api/provider-info';
 
 import { TerminalSettings } from '../../../../main/src/plugin/terminal-settings';
+import { getTerminalTheme } from '../../../../main/src/plugin/terminal-theme';
 import { getPanelDetailColor } from '../color/color';
 import Steps from '../ui/Steps.svelte';
 import PreflightChecks from './PreflightChecks.svelte';
@@ -83,9 +84,7 @@ async function refreshTerminal() {
     fontSize,
     lineHeight,
     disableStdin: true,
-    theme: {
-      background: getPanelDetailColor(),
-    },
+    theme: getTerminalTheme(),
     convertEol: true,
   });
   termFit = new FitAddon();

--- a/packages/renderer/src/lib/image/PushImageModal.svelte
+++ b/packages/renderer/src/lib/image/PushImageModal.svelte
@@ -8,6 +8,7 @@ import { Terminal } from 'xterm';
 import { FitAddon } from 'xterm-addon-fit';
 
 import { TerminalSettings } from '../../../../main/src/plugin/terminal-settings';
+import { getTerminalTheme } from '../../../../main/src/plugin/terminal-theme';
 import Dialog from '../dialogs/Dialog.svelte';
 import type { ImageInfoUI } from './ImageInfoUI';
 
@@ -49,7 +50,7 @@ async function initTerminal() {
     TerminalSettings.SectionName + '.' + TerminalSettings.LineHeight,
   );
 
-  logsPush = new Terminal({ fontSize, lineHeight, disableStdin: true });
+  logsPush = new Terminal({ fontSize, lineHeight, disableStdin: true, theme: getTerminalTheme() });
   const fitAddon = new FitAddon();
   logsPush.loadAddon(fitAddon);
 

--- a/packages/renderer/src/lib/image/PushManifestModal.svelte
+++ b/packages/renderer/src/lib/image/PushManifestModal.svelte
@@ -7,6 +7,7 @@ import { Terminal } from 'xterm';
 import { FitAddon } from 'xterm-addon-fit';
 
 import { TerminalSettings } from '../../../../main/src/plugin/terminal-settings';
+import { getTerminalTheme } from '../../../../main/src/plugin/terminal-theme';
 import Dialog from '../dialogs/Dialog.svelte';
 import type { ImageInfoUI } from './ImageInfoUI';
 
@@ -37,7 +38,7 @@ async function initTerminal() {
     TerminalSettings.SectionName + '.' + TerminalSettings.LineHeight,
   );
 
-  logsPush = new Terminal({ fontSize, lineHeight, disableStdin: true });
+  logsPush = new Terminal({ fontSize, lineHeight, disableStdin: true, theme: getTerminalTheme() });
   const fitAddon = new FitAddon();
   logsPush.loadAddon(fitAddon);
 

--- a/packages/renderer/src/lib/pod/KubernetesTerminal.svelte
+++ b/packages/renderer/src/lib/pod/KubernetesTerminal.svelte
@@ -4,10 +4,10 @@ import { router } from 'tinro';
 import { type IDisposable, Terminal } from 'xterm';
 import { FitAddon } from 'xterm-addon-fit';
 
-import { getPanelDetailColor } from '/@/lib/color/color';
 import { terminalStates } from '/@/stores/kubernetes-terminal-state-store';
 
 import { TerminalSettings } from '../../../../main/src/plugin/terminal-settings';
+import { getTerminalTheme } from '../../../../main/src/plugin/terminal-theme';
 
 export let podName: string;
 export let containerName: string;
@@ -35,6 +35,11 @@ onMount(async () => {
 
   if (savedState) {
     shellTerminal = savedState.terminal;
+
+    // If there is a saved state, make sure that we 'update' the theme as well to make sure that the terminal theme matches the overall apperance
+    // if the user has changed from dark to light, or vice versa
+    shellTerminal.options.theme = getTerminalTheme();
+
     id = savedState.id;
     removeAllChildren(terminalXtermDiv);
     shellTerminal.open(terminalXtermDiv);
@@ -93,9 +98,7 @@ async function initializeNewTerminal(container: HTMLElement) {
     fontSize,
     lineHeight,
     screenReaderMode,
-    theme: {
-      background: getPanelDetailColor(),
-    },
+    theme: getTerminalTheme(),
   });
 
   id = await window.kubernetesExec(
@@ -138,6 +141,7 @@ async function initializeNewTerminal(container: HTMLElement) {
 }
 
 function getSavedTerminalState(podName: string, containerName: string): State | undefined {
+  // TODO: This grabs the saved state, but what if the theme changes? We must update the terminal theme to match the overall apperance.
   let state;
   terminalStates.subscribe(states => {
     state = states.get(`${podName}-${containerName}`);

--- a/packages/renderer/src/lib/pod/PodDetailsLogs.svelte
+++ b/packages/renderer/src/lib/pod/PodDetailsLogs.svelte
@@ -7,7 +7,7 @@ import { Terminal } from 'xterm';
 import { FitAddon } from 'xterm-addon-fit';
 
 import { TerminalSettings } from '../../../../main/src/plugin/terminal-settings';
-import { getPanelDetailColor } from '../color/color';
+import { getTerminalTheme } from '../../../../main/src/plugin/terminal-theme';
 import { ansi256Colours, colourizedANSIContainerName } from '../editor/editor-utils';
 import { isMultiplexedLog } from '../stream/stream-utils';
 import NoLogIcon from '../ui/NoLogIcon.svelte';
@@ -117,9 +117,7 @@ async function refreshTerminal() {
     fontSize,
     lineHeight,
     disableStdin: true,
-    theme: {
-      background: getPanelDetailColor(),
-    },
+    theme: getTerminalTheme(),
     convertEol: true,
   });
   termFit = new FitAddon();

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionDetailsLogs.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionDetailsLogs.svelte
@@ -9,6 +9,7 @@ import { FitAddon } from 'xterm-addon-fit';
 import type { ProviderContainerConnectionInfo, ProviderKubernetesConnectionInfo } from '/@api/provider-info';
 
 import { TerminalSettings } from '../../../../main/src/plugin/terminal-settings';
+import { getTerminalTheme } from '../../../../main/src/plugin/terminal-theme';
 import { getPanelDetailColor } from '../color/color';
 import NoLogIcon from '../ui/NoLogIcon.svelte';
 import { writeToTerminal } from './Util';
@@ -58,9 +59,7 @@ onMount(async () => {
     fontSize,
     lineHeight,
     disableStdin: true,
-    theme: {
-      background: getPanelDetailColor(),
-    },
+    theme: getTerminalTheme(),
     convertEol: true,
   });
   // Refresh the terminal on initial load

--- a/packages/renderer/src/lib/ui/TerminalWindow.svelte
+++ b/packages/renderer/src/lib/ui/TerminalWindow.svelte
@@ -6,6 +6,7 @@ import { Terminal } from 'xterm';
 import { FitAddon } from 'xterm-addon-fit';
 
 import { TerminalSettings } from '../../../../main/src/plugin/terminal-settings';
+import { getTerminalTheme } from '../../../../main/src/plugin/terminal-theme';
 
 export let terminal: Terminal;
 
@@ -27,7 +28,7 @@ async function refreshTerminal(): Promise<void> {
     TerminalSettings.SectionName + '.' + TerminalSettings.LineHeight,
   );
 
-  terminal = new Terminal({ fontSize, lineHeight, disableStdin: true });
+  terminal = new Terminal({ fontSize, lineHeight, disableStdin: true, theme: getTerminalTheme() });
   const fitAddon = new FitAddon();
   terminal.loadAddon(fitAddon);
 


### PR DESCRIPTION
feat: light and dark mode for terminals

### What does this PR do?

* Switches to light / dark mode based on appearance settings for
  terminal
* Updates Kubernetes terminal theme on load even if using saved state
* Updated all terminals throughout PD

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->


https://github.com/user-attachments/assets/492eb4dd-adca-4b66-9087-2c9fcc0bdb68



### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop/issues/7545

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature

1. Go to appearance settings
2. Switch to light mode
3. Check any page with a terminal (container or pods terminal)
4. See that it is in light mode

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
