### PR TITLE
feat: allow to use libkrun and applehv machines starting from 5.2.0

### DIFF
--- a/extensions/podman/package.json
+++ b/extensions/podman/package.json
@@ -100,17 +100,6 @@
           "description": "Disk size usage",
           "readonly": true
         },
-        "podman.factory.machine.provider": {
-          "type": "string",
-          "default": "applehv",
-          "enum": [
-            "applehv",
-            "libkrun"
-          ],
-          "scope": "ContainerProviderConnectionFactory",
-          "description": "Provider Type",
-          "when": "podman.isLibkrunSupported"
-        },
         "podman.factory.machine.name": {
           "type": "string",
           "default": "podman-machine-default",
@@ -168,6 +157,17 @@
           "scope": "ContainerProviderConnectionFactory",
           "markdownDescription": "User mode networking (traffic relayed by a user process). See [documentation](https://docs.podman.io/en/latest/markdown/podman-machine-init.1.html#user-mode-networking).",
           "when": "podman.isUserModeNetworkingSupported == true"
+        },
+        "podman.factory.machine.provider": {
+          "type": "string",
+          "default": "default (Apple HyperVisor)",
+          "enum": [
+            "default (Apple HyperVisor)",
+            "GPU enabled (LibKrun)"
+          ],
+          "scope": "ContainerProviderConnectionFactory",
+          "description": "Provider Type",
+          "when": "podman.isLibkrunSupported"
         },
         "podman.factory.machine.now": {
           "type": "boolean",

--- a/extensions/podman/package.json
+++ b/extensions/podman/package.json
@@ -100,6 +100,17 @@
           "description": "Disk size usage",
           "readonly": true
         },
+        "podman.factory.machine.provider": {
+          "type": "string",
+          "default": "applehv",
+          "enum": [
+            "applehv",
+            "libkrun"
+          ],
+          "scope": "ContainerProviderConnectionFactory",
+          "description": "Provider Type",
+          "when": "podman.isLibkrunSupported"
+        },
         "podman.factory.machine.name": {
           "type": "string",
           "default": "podman-machine-default",

--- a/extensions/podman/src/extension.spec.ts
+++ b/extensions/podman/src/extension.spec.ts
@@ -38,7 +38,7 @@ import type { InstalledPodman } from './podman-cli';
 import * as podmanCli from './podman-cli';
 import { PodmanConfiguration } from './podman-configuration';
 import { PodmanInstall } from './podman-install';
-import { getAssetsFolder, isLinux, isMac, isWindows, LoggerDelegator } from './util';
+import { getAssetsFolder, isLinux, isMac, isWindows, LIBKRUN_LABEL, LoggerDelegator, VMTYPE } from './util';
 
 const config: Configuration = {
   get: () => {
@@ -87,7 +87,7 @@ const machineInfo: extension.MachineInfo = {
   cpuUsage: 0,
   diskUsage: 0,
   memoryUsage: 0,
-  vmType: 'libkrun',
+  vmType: VMTYPE.LIBKRUN,
 };
 
 const podmanConfiguration = {} as unknown as PodmanConfiguration;
@@ -121,7 +121,7 @@ beforeEach(() => {
       Running: true,
       Starting: false,
       Default: false,
-      VMType: 'libkrun',
+      VMType: VMTYPE.LIBKRUN,
     },
     {
       Name: machine1Name,
@@ -131,7 +131,7 @@ beforeEach(() => {
       Running: false,
       Starting: false,
       Default: true,
-      VMType: 'libkrun',
+      VMType: VMTYPE.LIBKRUN,
     },
   ];
 
@@ -303,6 +303,7 @@ test('verify create command called with correct values', async () => {
       'podman.factory.machine.image-path': 'path',
       'podman.factory.machine.memory': '1048000000', // 1048MB = 999.45MiB
       'podman.factory.machine.diskSize': '250000000000', // 250GB = 232.83GiB
+      'podman.factory.machine.provider': LIBKRUN_LABEL,
     },
     undefined,
   );
@@ -312,6 +313,9 @@ test('verify create command called with correct values', async () => {
     {
       logger: undefined,
       token: undefined,
+      env: {
+        CONTAINERS_MACHINE_PROVIDER: VMTYPE.LIBKRUN,
+      },
     },
   );
 
@@ -500,7 +504,7 @@ test('checkDefaultMachine: do not prompt if the running machine is already the d
       Running: true,
       Starting: false,
       Default: true,
-      VMType: 'libkrun',
+      VMType: VMTYPE.LIBKRUN,
     },
     {
       Name: 'podman-machine-1',
@@ -510,7 +514,7 @@ test('checkDefaultMachine: do not prompt if the running machine is already the d
       Running: false,
       Starting: false,
       Default: false,
-      VMType: 'libkrun',
+      VMType: VMTYPE.LIBKRUN,
     },
   ];
 
@@ -572,7 +576,7 @@ test('if a machine is successfully started it changes its state to started', asy
 
   expect(spyExecPromise).toBeCalledWith(podmanCli.getPodmanCli(), ['machine', 'start', 'name'], {
     env: {
-      CONTAINERS_MACHINE_PROVIDER: 'libkrun',
+      CONTAINERS_MACHINE_PROVIDER: VMTYPE.LIBKRUN,
     },
     logger: new LoggerDelegator(),
   });
@@ -807,13 +811,13 @@ test('test checkDefaultMachine - if user wants to change default machine, check 
     ['system', 'connection', 'default', `${machineDefaultName}-root`],
     {
       env: {
-        CONTAINERS_MACHINE_PROVIDER: 'libkrun',
+        CONTAINERS_MACHINE_PROVIDER: VMTYPE.LIBKRUN,
       },
     },
   );
   expect(inspectCall).toHaveBeenCalledWith(podmanCli.getPodmanCli(), ['machine', 'inspect', machineDefaultName], {
     env: {
-      CONTAINERS_MACHINE_PROVIDER: 'libkrun',
+      CONTAINERS_MACHINE_PROVIDER: VMTYPE.LIBKRUN,
     },
   });
 });
@@ -857,13 +861,13 @@ test('test checkDefaultMachine - if user wants to change machine, check that it 
     ['system', 'connection', 'default', machineDefaultName],
     {
       env: {
-        CONTAINERS_MACHINE_PROVIDER: 'libkrun',
+        CONTAINERS_MACHINE_PROVIDER: VMTYPE.LIBKRUN,
       },
     },
   );
   expect(inspectCall).toHaveBeenCalledWith(podmanCli.getPodmanCli(), ['machine', 'inspect', machineDefaultName], {
     env: {
-      CONTAINERS_MACHINE_PROVIDER: 'libkrun',
+      CONTAINERS_MACHINE_PROVIDER: VMTYPE.LIBKRUN,
     },
   });
 });
@@ -900,13 +904,13 @@ test('test checkDefaultMachine - if user wants to change machine, check that it 
     ['system', 'connection', 'default', machineDefaultName],
     {
       env: {
-        CONTAINERS_MACHINE_PROVIDER: 'libkrun',
+        CONTAINERS_MACHINE_PROVIDER: VMTYPE.LIBKRUN,
       },
     },
   );
   expect(inspectCall).toHaveBeenCalledWith(podmanCli.getPodmanCli(), ['machine', 'inspect', machineDefaultName], {
     env: {
-      CONTAINERS_MACHINE_PROVIDER: 'libkrun',
+      CONTAINERS_MACHINE_PROVIDER: VMTYPE.LIBKRUN,
     },
   });
 });
@@ -938,7 +942,7 @@ test('test checkDefaultMachine, if the default connection is not in sync with th
       Running: true,
       Starting: false,
       Default: true,
-      VMType: 'libkrun',
+      VMType: VMTYPE.LIBKRUN,
     },
   ];
 

--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -43,10 +43,13 @@ import {
   appHomeDir,
   execPodman,
   getAssetsFolder,
+  getProviderByLabel,
+  getProviderLabel,
   isLinux,
   isMac,
   isWindows,
   LoggerDelegator,
+  VMTYPE,
 } from './util';
 import { getDisguisedPodmanInformation, getSocketPath, isDisguisedPodman } from './warnings';
 import { WslHelper } from './wsl-helper';
@@ -271,7 +274,7 @@ export async function updateMachines(
         machineInfo?.memory !== undefined && machineInfo?.memoryUsed !== undefined && machineInfo?.memoryUsed > 0
           ? (machineInfo?.memoryUsed * 100) / machineInfo?.memory
           : 0,
-      vmType: machine.VMType,
+      vmType: getProviderLabel(machine.VMType),
     });
 
     if (!podmanMachinesStatuses.has(machine.Name)) {
@@ -796,7 +799,7 @@ export async function registerProviderFor(
     endpoint: {
       socketPath,
     },
-    vmType: machineInfo.vmType,
+    vmType: getProviderLabel(machineInfo.vmType),
   };
 
   // Since Podman 4.5, machines are using the same path for all sockets of machines
@@ -1850,14 +1853,14 @@ export async function createMachine(
 
   let provider: string | undefined;
   if (params['podman.factory.machine.provider']) {
-    provider = params['podman.factory.machine.provider'];
+    provider = getProviderByLabel(params['podman.factory.machine.provider']);
   }
 
   // cpus
   if (params['podman.factory.machine.cpus']) {
     let cpusValue = params['podman.factory.machine.cpus'];
     // libkrun has an issue that prevent to start a machine that has been created with more than 8 cpus, so we limit it here
-    if (provider === 'libkrun' && parseInt(cpusValue) > 8) {
+    if (provider === VMTYPE.LIBKRUN && parseInt(cpusValue) > 8) {
       cpusValue = '8';
     }
     parameters.push('--cpus');

--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -99,6 +99,7 @@ export type MachineJSON = {
   Running: boolean;
   Starting: boolean;
   Default: boolean;
+  VMType: string;
   UserModeNetworking?: boolean;
 };
 
@@ -119,11 +120,17 @@ export type MachineInfo = {
   cpuUsage: number;
   diskUsage: number;
   memoryUsage: number;
+  vmType: string;
 };
 
 export type MachineListOutput = {
   stdout: string;
   stderr: string;
+};
+
+export type MachineJSONListOutput = {
+  list: MachineJSON[];
+  error: string;
 };
 
 export function isIncompatibleMachineOutput(output: string | undefined): boolean {
@@ -152,7 +159,7 @@ export async function updateMachines(
   podmanConfiguration: PodmanConfiguration,
 ): Promise<void> {
   // init machines available
-  let machineListOutput: MachineListOutput;
+  let machineListOutput: MachineJSONListOutput;
   try {
     machineListOutput = await getJSONMachineList();
   } catch (error) {
@@ -175,7 +182,7 @@ export async function updateMachines(
   }
 
   // parse output
-  const machines = JSON.parse(machineListOutput.stdout) as MachineJSON[];
+  const machines = machineListOutput.list;
   extensionApi.context.setValue('podmanMachineExists', machines.length > 0, 'onboarding');
   const installedPodman = await getPodmanInstallation();
   let shouldCleanMachine = false;
@@ -184,7 +191,7 @@ export async function updateMachines(
   }
   // check if the machine needs to be cleaned for v4 --> v5 format
   if (!shouldCleanMachine) {
-    shouldCleanMachine = isIncompatibleMachineOutput(machineListOutput.stderr);
+    shouldCleanMachine = isIncompatibleMachineOutput(machineListOutput.error);
   }
 
   // invalid machines is not making the provider working properly so always notify
@@ -255,6 +262,7 @@ export async function updateMachines(
         machineInfo?.memory !== undefined && machineInfo?.memoryUsed !== undefined && machineInfo?.memoryUsed > 0
           ? (machineInfo?.memoryUsed * 100) / machineInfo?.memory
           : 0,
+      vmType: machine.VMType,
     });
 
     if (!podmanMachinesStatuses.has(machine.Name)) {
@@ -297,13 +305,16 @@ export async function updateMachines(
           ]);
           socketPath = socket;
         } else {
-          const { stdout: socket } = await extensionApi.process.exec(getPodmanCli(), [
-            'machine',
-            'inspect',
-            '--format',
-            '{{.ConnectionInfo.PodmanSocket.Path}}',
-            machineName,
-          ]);
+          const podmanMachineInfo = podmanMachinesInfo.get(machineName);
+          const { stdout: socket } = await extensionApi.process.exec(
+            getPodmanCli(),
+            ['machine', 'inspect', '--format', '{{.ConnectionInfo.PodmanSocket.Path}}', machineName],
+            {
+              env: {
+                CONTAINERS_MACHINE_PROVIDER: podmanMachineInfo?.vmType ?? '',
+              },
+            },
+          );
           socketPath = socket;
         }
       } catch (error) {
@@ -389,7 +400,7 @@ export async function checkDefaultMachine(machines: MachineJSON[]): Promise<void
   // check if connection is in sync with machine. If the default connection is rootless but the machine is rootful ask the user to update the connection
   if (defaultConnectionNotify && !!runningMachine?.Default) {
     const defaultConnection = await getDefaultConnection();
-    const isRootful = await isRootfulMachine(runningMachine.Name);
+    const isRootful = await isRootfulMachine(runningMachine);
     if (!defaultConnection?.Name.endsWith(ROOTFUL_SUFFIX) && isRootful) {
       const result = await extensionApi.window.showInformationMessage(
         `${isRootful ? 'Rootful' : 'Rootless'} Podman Machine '${runningMachine.Name}' does not match default connection. This will cause podman CLI errors while trying to connect to '${runningMachine.Name}'. Do you want to update the default connection?`,
@@ -401,7 +412,11 @@ export async function checkDefaultMachine(machines: MachineJSON[]): Promise<void
         try {
           const connectionName = isRootful ? `${runningMachine.Name}${ROOTFUL_SUFFIX}` : runningMachine.Name;
           // make it the default to run the info command
-          await extensionApi.process.exec(getPodmanCli(), ['system', 'connection', 'default', connectionName]);
+          await extensionApi.process.exec(getPodmanCli(), ['system', 'connection', 'default', connectionName], {
+            env: {
+              CONTAINERS_MACHINE_PROVIDER: runningMachine.VMType,
+            },
+          });
         } catch (error) {
           // eslint-disable-next-line quotes
           console.error("Error running 'podman system connection default': ", error);
@@ -433,12 +448,16 @@ export async function checkDefaultMachine(machines: MachineJSON[]): Promise<void
     );
     if (result === 'Yes') {
       // check if machine is rootless or rootful
-      const machineIsRootful = await isRootfulMachine(runningMachine.Name);
+      const machineIsRootful = await isRootfulMachine(runningMachine);
 
       try {
         const connectionName = machineIsRootful ? `${runningMachine.Name}${ROOTFUL_SUFFIX}` : runningMachine.Name;
         // make it the default to run the info command
-        await extensionApi.process.exec(getPodmanCli(), ['system', 'connection', 'default', connectionName]);
+        await extensionApi.process.exec(getPodmanCli(), ['system', 'connection', 'default', connectionName], {
+          env: {
+            CONTAINERS_MACHINE_PROVIDER: runningMachine.VMType,
+          },
+        });
       } catch (error) {
         // eslint-disable-next-line quotes
         console.error("Error running 'podman system connection default': ", error);
@@ -458,17 +477,21 @@ export async function checkDefaultMachine(machines: MachineJSON[]): Promise<void
   }
 }
 
-async function isRootfulMachine(machineName: string): Promise<boolean> {
+async function isRootfulMachine(machineJSON: MachineJSON): Promise<boolean> {
   let isRootful = false;
   try {
-    const { stdout: machineInspectJson } = await extensionApi.process.exec(getPodmanCli(), [
-      'machine',
-      'inspect',
-      machineName,
-    ]);
+    const { stdout: machineInspectJson } = await extensionApi.process.exec(
+      getPodmanCli(),
+      ['machine', 'inspect', machineJSON.Name],
+      {
+        env: {
+          CONTAINERS_MACHINE_PROVIDER: machineJSON.VMType,
+        },
+      },
+    );
     const machinesInspect = JSON.parse(machineInspectJson);
     // find the machine name in the array
-    const machineInspect = machinesInspect.find((machine: { Name: string }) => machine.Name === machineName);
+    const machineInspect = machinesInspect.find((machine: { Name: string }) => machine.Name === machineJSON.Name);
     isRootful = machineInspect?.Rootful ?? false;
   } catch (error) {
     console.error('Error when checking rootful machine: ', error);
@@ -730,11 +753,19 @@ export async function registerProviderFor(
     stop: async (context, logger): Promise<void> => {
       await extensionApi.process.exec(getPodmanCli(), ['machine', 'stop', machineInfo.name], {
         logger: new LoggerDelegator(context, logger),
+        env: {
+          CONTAINERS_MACHINE_PROVIDER: machineInfo.vmType,
+        },
       });
       provider.updateStatus('stopped');
     },
     delete: async (logger): Promise<void> => {
-      await extensionApi.process.exec(getPodmanCli(), ['machine', 'rm', '-f', machineInfo.name], { logger });
+      await extensionApi.process.exec(getPodmanCli(), ['machine', 'rm', '-f', machineInfo.name], {
+        logger,
+        env: {
+          CONTAINERS_MACHINE_PROVIDER: machineInfo.vmType,
+        },
+      });
     },
   };
   //support edit only on MacOS as Podman WSL is nop and generates errors
@@ -762,6 +793,9 @@ export async function registerProviderFor(
           }
           await extensionApi.process.exec(getPodmanCli(), args, {
             logger: new LoggerDelegator(context, logger),
+            env: {
+              CONTAINERS_MACHINE_PROVIDER: machineInfo.vmType,
+            },
           });
         } finally {
           if (state === 'started') {
@@ -780,6 +814,7 @@ export async function registerProviderFor(
     endpoint: {
       socketPath,
     },
+    vmType: machineInfo.vmType,
   };
 
   // Since Podman 4.5, machines are using the same path for all sockets of machines
@@ -856,6 +891,9 @@ export async function startMachine(
     // start the machine
     await extensionApi.process.exec(getPodmanCli(), ['machine', 'start', machineInfo.name], {
       logger: new LoggerDelegator(context, logger),
+      env: {
+        CONTAINERS_MACHINE_PROVIDER: machineInfo.vmType,
+      },
     });
     provider.updateStatus('started');
   } catch (err) {
@@ -967,6 +1005,7 @@ export const CLEANUP_REQUIRED_MACHINE_KEY = 'podman.needPodmanMachineCleanup';
 export const PODMAN_MACHINE_CPU_SUPPORTED_KEY = 'podman.podmanMachineCpuSupported';
 export const PODMAN_MACHINE_MEMORY_SUPPORTED_KEY = 'podman.podmanMachineMemorySupported';
 export const PODMAN_MACHINE_DISK_SUPPORTED_KEY = 'podman.podmanMachineDiskSupported';
+export const PODMAN_PROVIDER_LIBKRUN_SUPPORTED_KEY = 'podman.isLibkrunSupported';
 
 export function initTelemetryLogger(): void {
   telemetryLogger = extensionApi.env.createTelemetryLogger();
@@ -1026,8 +1065,7 @@ export function registerOnboardingMachineExistsCommand(): extensionApi.Disposabl
     let machineLength;
     try {
       const machineListOutput = await getJSONMachineList();
-      const machines = JSON.parse(machineListOutput.stdout) as MachineJSON[];
-      machineLength = machines.length;
+      machineLength = machineListOutput.list.length;
     } catch (error) {
       machineLength = 0;
     }
@@ -1047,7 +1085,7 @@ export function registerOnboardingUnsupportedPodmanMachineCommand(): extensionAp
     if (!isUnsupported) {
       try {
         const machineListOutput = await getJSONMachineList();
-        isUnsupported = isIncompatibleMachineOutput(machineListOutput.stderr);
+        isUnsupported = isIncompatibleMachineOutput(machineListOutput.error);
       } catch (error) {
         // check if stderr in the error object
         const runError = error as RunError;
@@ -1098,7 +1136,7 @@ export function registerOnboardingRemoveUnsupportedMachinesCommand(): extensionA
     let machineListError = '';
     try {
       const machineListOutput = await getJSONMachineList();
-      machineListError = machineListOutput.stderr;
+      machineListError = machineListOutput.error;
     } catch (error) {
       machineListError = (error as RunError).stderr;
     }
@@ -1117,10 +1155,11 @@ export function registerOnboardingRemoveUnsupportedMachinesCommand(): extensionA
       const files = await fs.promises.readdir(machineFolderToCheck);
       const machineFilesToAnalyze = files.filter(file => file.endsWith('.json'));
       let machineConfigJson: { GvProxy?: string } = {};
+      const machineFolderToCheckValue = machineFolderToCheck;
       const allMachines = await Promise.all(
         machineFilesToAnalyze.map(async file => {
           // read content of the file
-          const absoluteFile = path.join(machineFolderToCheck, file);
+          const absoluteFile = path.join(machineFolderToCheckValue, file);
           try {
             const machineConfigJsonRaw = await fs.promises.readFile(absoluteFile, 'utf-8');
             machineConfigJson = JSON.parse(machineConfigJsonRaw);
@@ -1215,6 +1254,7 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
     extensionApi.context.setValue(ROOTFUL_MACHINE_INIT_SUPPORTED_KEY, isRootfulMachineInitSupported(version));
     extensionApi.context.setValue(START_NOW_MACHINE_INIT_SUPPORTED_KEY, isStartNowAtMachineInitSupported(version));
     extensionApi.context.setValue(USER_MODE_NETWORKING_SUPPORTED_KEY, isUserModeNetworkingSupported(version));
+    extensionApi.context.setValue(PODMAN_PROVIDER_LIBKRUN_SUPPORTED_KEY, isLibkrunSupported(version));
     isMovedPodmanSocket = isPodmanSocketLocationMoved(version);
   }
 
@@ -1635,7 +1675,7 @@ export async function findRunningMachine(): Promise<string | undefined> {
 
   // Find the machines
   const machineListOutput = await getJSONMachineList();
-  const machines = JSON.parse(machineListOutput.stdout) as MachineJSON[];
+  const machines = machineListOutput.list;
 
   // Find the machine that is running
   const found: MachineJSON | undefined = machines.find(machine => machine?.Running);
@@ -1654,7 +1694,7 @@ async function stopAutoStartedMachine(): Promise<void> {
   }
   const machineListOutput = await getJSONMachineList();
 
-  const machines = JSON.parse(machineListOutput.stdout) as MachineJSON[];
+  const machines = machineListOutput.list;
 
   // Find the autostarted machine and check its status
   const currentMachine: MachineJSON | undefined = machines.find(machine => machine?.Name === autoMachineName);
@@ -1665,11 +1705,50 @@ async function stopAutoStartedMachine(): Promise<void> {
     return;
   }
   console.log('stopping autostarted machine', autoMachineName);
-  await extensionApi.process.exec(getPodmanCli(), ['machine', 'stop', autoMachineName]);
+  await extensionApi.process.exec(getPodmanCli(), ['machine', 'stop', autoMachineName], {
+    env: {
+      CONTAINERS_MACHINE_PROVIDER: currentMachine.VMType,
+    },
+  });
 }
 
-export async function getJSONMachineList(): Promise<MachineListOutput> {
-  const { stdout, stderr } = await extensionApi.process.exec(getPodmanCli(), ['machine', 'list', '--format', 'json']);
+export async function getJSONMachineList(): Promise<MachineJSONListOutput> {
+  const installedPodman = await getPodmanInstallation();
+
+  const containerMachineProviders: (string | undefined)[] = [];
+  // if libkrun is supported we want to show both applehv and libkrun machines
+  if (installedPodman && isLibkrunSupported(installedPodman.version)) {
+    containerMachineProviders.push(...['applehv', 'libkrun']);
+  } else {
+    // in all other cases we set undefined so that it executes normally by using the default container provider
+    containerMachineProviders.push(undefined);
+  }
+
+  const list: MachineJSON[] = [];
+  let error = '';
+  for (const provider of containerMachineProviders) {
+    const machineListOutput = await getJSONMachineListByProvider(provider);
+    list.push(...(JSON.parse(machineListOutput.stdout) as MachineJSON[]));
+    error += machineListOutput.stderr + '\n';
+  }
+
+  return { list, error };
+}
+
+export async function getJSONMachineListByProvider(containerMachineProvider?: string): Promise<MachineListOutput> {
+  let options: extensionApi.RunOptions | undefined = undefined;
+  if (containerMachineProvider) {
+    options = {
+      env: {
+        CONTAINERS_MACHINE_PROVIDER: containerMachineProvider,
+      },
+    };
+  }
+  const { stdout, stderr } = await extensionApi.process.exec(
+    getPodmanCli(),
+    ['machine', 'list', '--format', 'json'],
+    options,
+  );
   return { stdout, stderr };
 }
 
@@ -1708,6 +1787,13 @@ const PODMAN_MINIMUM_VERSION_FOR_USER_MODE_NETWORKING = '4.6.0';
 // Checks if user mode networking is supported. Only Windows platform allows this parameter to be tuned
 export function isUserModeNetworkingSupported(podmanVersion: string): boolean {
   return isWindows() && compareVersions(podmanVersion, PODMAN_MINIMUM_VERSION_FOR_USER_MODE_NETWORKING) >= 0;
+}
+
+const PODMAN_MINIMUM_VERSION_FOR_LIBKRUN_SUPPORT = '5.2.0';
+
+// Checks if libkrun is supported. Only Mac platform allows this parameter to be tuned
+export function isLibkrunSupported(podmanVersion: string): boolean {
+  return isMac() && compareVersions(podmanVersion, PODMAN_MINIMUM_VERSION_FOR_LIBKRUN_SUPPORT) >= 0;
 }
 
 function sendTelemetryRecords(
@@ -1799,11 +1885,25 @@ export async function createMachine(
 
   const telemetryRecords: Record<string, unknown> = {};
 
+  let provider = '';
+  let env: { [key: string]: string } | undefined;
+  if (params['podman.factory.machine.provider']) {
+    provider = params['podman.factory.machine.provider'];
+    env = {
+      CONTAINERS_MACHINE_PROVIDER: provider,
+    };
+  }
+
   // cpus
   if (params['podman.factory.machine.cpus']) {
+    let cpusValue = params['podman.factory.machine.cpus'];
+    // libkrun has an issue that prevent to start a machine that has been created with more than 8 cpus, so we limit it here
+    if (provider === 'libkrun' && parseInt(cpusValue) > 8) {
+      cpusValue = '8';
+    }
     parameters.push('--cpus');
-    parameters.push(params['podman.factory.machine.cpus']);
-    telemetryRecords.cpus = params['podman.factory.machine.cpus'];
+    parameters.push(cpusValue);
+    telemetryRecords.cpus = cpusValue;
   }
 
   // memory
@@ -1896,7 +1996,11 @@ export async function createMachine(
 
   const startTime = performance.now();
   try {
-    await extensionApi.process.exec(getPodmanCli(), parameters, { logger, token });
+    await extensionApi.process.exec(getPodmanCli(), parameters, {
+      logger,
+      token,
+      env,
+    });
   } catch (error) {
     telemetryRecords.error = error;
     const runError = error as RunError;

--- a/extensions/podman/src/podman-install.spec.ts
+++ b/extensions/podman/src/podman-install.spec.ts
@@ -26,6 +26,7 @@ import type { InstalledPodman } from './podman-cli';
 import type { Installer, UpdateCheck } from './podman-install';
 import { getBundledPodmanVersion, PodmanInstall, WinInstaller } from './podman-install';
 import * as podmanInstallObj from './podman-install';
+import * as utils from './util';
 
 const originalConsoleError = console.error;
 const consoleErrorMock = vi.fn();
@@ -85,6 +86,7 @@ vi.mock('./util', async () => {
     isLinux: vi.fn(),
     isWindows: vi.fn(),
     isMac: vi.fn(),
+    execPodman: vi.fn(),
   };
 });
 
@@ -729,9 +731,13 @@ describe('update checks', () => {
   test('stopPodmanMachinesIfAnyBeforeUpdating with one machine running', async () => {
     const podmanInstall = new TestPodmanInstall(extensionContext);
 
+    vi.spyOn(extensionApi.process, 'exec').mockResolvedValueOnce({
+      stdout: 'podman version 5.0.0',
+    } as extensionApi.RunResult);
+
     // return empty machine list
-    vi.mocked(extensionApi.process.exec).mockResolvedValueOnce({
-      stdout: JSON.stringify([{ Name: 'test', Running: true }]),
+    vi.spyOn(utils, 'execPodman').mockResolvedValueOnce({
+      stdout: JSON.stringify([{ Name: 'test', Running: true, VMType: 'libkrun' }]),
     } as unknown as extensionApi.RunResult);
 
     // mock user response

--- a/extensions/podman/src/podman-install.ts
+++ b/extensions/podman/src/podman-install.ts
@@ -215,6 +215,7 @@ export class PodmanInstall {
     const machinesRunning: MachineJSON[] = [];
     try {
       const machineListOutput = await getJSONMachineList();
+      console.log(JSON.stringify(machineListOutput));
 
       machinesRunning.push(...machineListOutput.list.filter(machine => machine.Running || machine.Starting));
     } catch (error) {

--- a/extensions/podman/src/podman-install.ts
+++ b/extensions/podman/src/podman-install.ts
@@ -28,9 +28,11 @@ import { getDetectionChecks } from './detection-checks';
 import type { MachineJSON } from './extension';
 import {
   getJSONMachineList,
+  isLibkrunSupported,
   isRootfulMachineInitSupported,
   isStartNowAtMachineInitSupported,
   isUserModeNetworkingSupported,
+  PODMAN_PROVIDER_LIBKRUN_SUPPORTED_KEY,
   ROOTFUL_MACHINE_INIT_SUPPORTED_KEY,
   START_NOW_MACHINE_INIT_SUPPORTED_KEY,
   USER_MODE_NETWORKING_SUPPORTED_KEY,
@@ -174,6 +176,10 @@ export class PodmanInstall {
           START_NOW_MACHINE_INIT_SUPPORTED_KEY,
           isStartNowAtMachineInitSupported(newInstalledPodman.version),
         );
+        extensionApi.context.setValue(
+          PODMAN_PROVIDER_LIBKRUN_SUPPORTED_KEY,
+          isLibkrunSupported(newInstalledPodman.version),
+        );
       }
       // update detections checks
       provider.updateDetectionChecks(getDetectionChecks(newInstalledPodman));
@@ -209,9 +215,8 @@ export class PodmanInstall {
     const machinesRunning: MachineJSON[] = [];
     try {
       const machineListOutput = await getJSONMachineList();
-      const machines = JSON.parse(machineListOutput.stdout) as MachineJSON[];
 
-      machinesRunning.push(...machines.filter(machine => machine.Running || machine.Starting));
+      machinesRunning.push(...machineListOutput.list.filter(machine => machine.Running || machine.Starting));
     } catch (error) {
       console.debug('Unable to query machines before updating', error);
     }
@@ -355,6 +360,10 @@ export class PodmanInstall {
           extensionApi.context.setValue(
             START_NOW_MACHINE_INIT_SUPPORTED_KEY,
             isStartNowAtMachineInitSupported(updateInfo.bundledVersion),
+          );
+          extensionApi.context.setValue(
+            PODMAN_PROVIDER_LIBKRUN_SUPPORTED_KEY,
+            isLibkrunSupported(updateInfo.bundledVersion),
           );
         }
       } else if (answer === 'Ignore') {

--- a/extensions/podman/src/podman-install.ts
+++ b/extensions/podman/src/podman-install.ts
@@ -215,8 +215,6 @@ export class PodmanInstall {
     const machinesRunning: MachineJSON[] = [];
     try {
       const machineListOutput = await getJSONMachineList();
-      console.log(JSON.stringify(machineListOutput));
-
       machinesRunning.push(...machineListOutput.list.filter(machine => machine.Running || machine.Starting));
     } catch (error) {
       console.debug('Unable to query machines before updating', error);

--- a/extensions/podman/src/util.spec.ts
+++ b/extensions/podman/src/util.spec.ts
@@ -20,7 +20,15 @@ import * as extensionApi from '@podman-desktop/api';
 import { afterEach, expect, test, vi } from 'vitest';
 
 import { getPodmanCli } from './podman-cli';
-import { execPodman, normalizeWSLOutput } from './util';
+import {
+  APPLEHV_LABEL,
+  execPodman,
+  getProviderByLabel,
+  getProviderLabel,
+  LIBKRUN_LABEL,
+  normalizeWSLOutput,
+  VMTYPE,
+} from './util';
 
 const config: extensionApi.Configuration = {
   get: () => {
@@ -114,4 +122,34 @@ test('expect exec called without CONTAINERS_MACHINE_PROVIDER if a provider is NO
       label: 'one',
     },
   });
+});
+
+test('expect libkrun label with libkrun provider', async () => {
+  const label = getProviderLabel(VMTYPE.LIBKRUN);
+  expect(label).equals(LIBKRUN_LABEL);
+});
+
+test('expect applehv label with applehv provider', async () => {
+  const label = getProviderLabel(VMTYPE.APPLEHV);
+  expect(label).equals(APPLEHV_LABEL);
+});
+
+test('expect provider name with provider different from libkrun and applehv', async () => {
+  const label = getProviderLabel(VMTYPE.WSL);
+  expect(label).equals(VMTYPE.WSL);
+});
+
+test('expect libkrun provider with libkrun label', async () => {
+  const provider = getProviderByLabel(LIBKRUN_LABEL);
+  expect(provider).equals(VMTYPE.LIBKRUN);
+});
+
+test('expect applehv provider with applehv label', async () => {
+  const provider = getProviderByLabel(APPLEHV_LABEL);
+  expect(provider).equals(VMTYPE.APPLEHV);
+});
+
+test('expect provider name with provider different from libkrun and applehv', async () => {
+  const provider = getProviderByLabel(VMTYPE.WSL);
+  expect(provider).equals(VMTYPE.WSL);
 });

--- a/extensions/podman/src/util.ts
+++ b/extensions/podman/src/util.ts
@@ -145,9 +145,41 @@ export function execPodman(
   if (containersProvider) {
     finalOptions.env = {
       ...(finalOptions.env ?? {}),
-      CONTAINERS_MACHINE_PROVIDER: containersProvider,
+      CONTAINERS_MACHINE_PROVIDER: getProviderByLabel(containersProvider),
     };
   }
 
   return extensionApi.process.exec(getPodmanCli(), args, finalOptions);
+}
+
+export enum VMTYPE {
+  WSL = 'wsl',
+  HYPERV = 'hyperv',
+  APPLEHV = 'applehv',
+  LIBKRUN = 'libkrun',
+}
+
+export const APPLEHV_LABEL = 'default (Apple HyperVisor)';
+export const LIBKRUN_LABEL = 'GPU enabled (LibKrun)';
+
+export function getProviderLabel(provider: string): string {
+  switch (provider) {
+    case VMTYPE.LIBKRUN:
+      return LIBKRUN_LABEL;
+    case VMTYPE.APPLEHV:
+      return APPLEHV_LABEL;
+    default:
+      return provider;
+  }
+}
+
+export function getProviderByLabel(label: string): string {
+  switch (label) {
+    case LIBKRUN_LABEL:
+      return VMTYPE.LIBKRUN;
+    case APPLEHV_LABEL:
+      return VMTYPE.APPLEHV;
+    default:
+      return label;
+  }
 }

--- a/packages/api/src/provider-info.ts
+++ b/packages/api/src/provider-info.ts
@@ -37,6 +37,7 @@ export interface ProviderContainerConnectionInfo {
   };
   lifecycleMethods?: LifecycleMethod[];
   type: 'docker' | 'podman';
+  vmType?: string;
 }
 
 export interface ProviderKubernetesConnectionInfo {

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -362,6 +362,7 @@ declare module '@podman-desktop/api' {
     endpoint: ContainerProviderConnectionEndpoint;
     lifecycle?: ProviderConnectionLifecycle;
     status(): ProviderConnectionStatus;
+    vmType?: string;
   }
 
   export interface PodCreatePortOptions {

--- a/packages/main/src/plugin/provider-registry.spec.ts
+++ b/packages/main/src/plugin/provider-registry.spec.ts
@@ -297,6 +297,7 @@ test('should send events when starting a container connection', async () => {
       socketPath: '/endpoint1.sock',
     },
     status: 'started',
+    vmType: 'libkrun',
   };
 
   const startMock = vi.fn();
@@ -314,6 +315,7 @@ test('should send events when starting a container connection', async () => {
     status() {
       return 'started';
     },
+    vmType: 'libkrun',
   });
 
   let onBeforeDidUpdateContainerConnectionCalled = false;
@@ -360,6 +362,7 @@ test('should send events when stopping a container connection', async () => {
       socketPath: '/endpoint1.sock',
     },
     status: 'stopped',
+    vmType: 'libkrun',
   };
 
   const startMock = vi.fn();
@@ -377,6 +380,7 @@ test('should send events when stopping a container connection', async () => {
     status() {
       return 'stopped';
     },
+    vmType: 'libkrun',
   });
 
   let onBeforeDidUpdateContainerConnectionCalled = false;

--- a/packages/main/src/plugin/provider-registry.ts
+++ b/packages/main/src/plugin/provider-registry.ts
@@ -639,6 +639,7 @@ export class ProviderRegistry {
         endpoint: {
           socketPath: connection.endpoint.socketPath,
         },
+        vmType: connection.vmType,
       };
     } else {
       providerConnection = {

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.spec.ts
@@ -52,6 +52,7 @@ const providerInfo: ProviderInfo = {
       },
       lifecycleMethods: ['start', 'stop', 'delete'],
       type: 'podman',
+      vmType: 'libkrun',
     },
   ],
   installationSupport: false,
@@ -167,6 +168,8 @@ test('Expect type to be reported for Podman engines', async () => {
   expect(typeDiv.textContent).toBe('Podman endpoint');
   const endpointSpan = await vi.waitFor(() => screen.getByTitle('unix://socket'));
   expect(endpointSpan.textContent).toBe('unix://socket');
+  const connectionType = screen.getByLabelText('Connection Type');
+  expect(connectionType.textContent).equal('Libkrun');
 });
 
 test('Expect type to be reported for Docker engines', async () => {

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
@@ -531,9 +531,12 @@ function hasAnyConfiguration(provider: ProviderInfo) {
                 connectionStatus={containerConnectionStatus.get(getProviderConnectionName(provider, container))}
                 updateConnectionStatus={updateContainerStatus}
                 addConnectionToRestartingQueue={addConnectionToRestartingQueue} />
-              <div class="mt-1.5 text-gray-900 text-[9px] flex justify-between" aria-label="Connection Version">
-                <div>{provider.name} {provider.version ? `v${provider.version}` : ''}</div>
-                <div>{container.vmType ? capitalize(container.vmType) : ''}</div>
+              <div class="mt-1.5 text-gray-900 text-[9px] flex justify-between">
+                <div aria-label="Connection Version">
+                  {provider.name}
+                  {provider.version ? `v${provider.version}` : ''}
+                </div>
+                <div aria-label="Connection Type">{container.vmType ? capitalize(container.vmType) : ''}</div>
               </div>
             </div>
           {/each}

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
@@ -28,6 +28,7 @@ import { normalizeOnboardingWhenClause } from '../onboarding/onboarding-utils';
 import ConnectionErrorInfoButton from '../ui/ConnectionErrorInfoButton.svelte';
 import ConnectionStatus from '../ui/ConnectionStatus.svelte';
 import EngineIcon from '../ui/EngineIcon.svelte';
+import { capitalize } from '../ui/Util';
 import { PeerProperties } from './PeerProperties';
 import { eventCollect } from './preferences-connection-rendering-task';
 import PreferencesConnectionActions from './PreferencesConnectionActions.svelte';
@@ -530,8 +531,9 @@ function hasAnyConfiguration(provider: ProviderInfo) {
                 connectionStatus={containerConnectionStatus.get(getProviderConnectionName(provider, container))}
                 updateConnectionStatus={updateContainerStatus}
                 addConnectionToRestartingQueue={addConnectionToRestartingQueue} />
-              <div class="mt-1.5 text-gray-900 text-[9px]" aria-label="Connection Version">
+              <div class="mt-1.5 text-gray-900 text-[9px] flex justify-between" aria-label="Connection Version">
                 <div>{provider.name} {provider.version ? `v${provider.version}` : ''}</div>
+                <div>{container.vmType ? capitalize(container.vmType) : ''}</div>
               </div>
             </div>
           {/each}


### PR DESCRIPTION
### What does this PR do?

This PR allows to manage both applehv and libkrun machines at the same time starting from 5.2.0 .
Even though a provider is defined in the `containers.conf` you should be able to work with both applehv and libkrun machines (so create, start, stop, remove, edit ... actions).

The only problem is that libkrun only supports max 8 cpus. If you create a machine with 8+ cpus, you are able to create it but it will always fail to start. So, before creating a machine, I reduce the cpu value to 8 if it's larger. It would be good to edit the maximum value at the UI level but I didn't find an easy way so far. Any idea is appreciated.

If Podman is less than 5.1.0 or you are not on a Mac it should work as before.

In draft as I still have to try it on Windows and write tests but it's ready if you want to start playing with it

### Screenshot / video of UI

https://github.com/user-attachments/assets/fd13ca3c-a075-40a2-86fc-e03b325b966f

### What issues does this PR fix or reference?

it resolves #8084 

### How to test this PR?

1. edit the value here with the Podman version you are using https://github.com/containers/podman-desktop/compare/main...lstocchi:i8084?expand=1#diff-c885162dd627b7cd812c83544b19b9b166179fec79ddbc13273fede7c2566791R1792
2. you should see and being able to use both applehv and libkrun machines. When using the cli you will only have visibility on the current provider set.

- [x] Tests are covering the bug fix or the new feature
