### PR TITLE
chore: add page rendering for images/imageId/engineId

### DIFF
--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -134,6 +134,9 @@ window.events?.receive('navigate', (navigationRequest: unknown) => {
         <Route path="/images" breadcrumb="Images" navigationHint="root">
           <ImagesList />
         </Route>
+        <Route path="/images/:id/:engineId" breadcrumb="Images" let:meta navigationHint="root">
+          <ImagesList searchTerm={meta.params.id} imageEngineId={meta.params.engineId} />
+        </Route>
         <Route
           path="/manifests/:id/:engineId/:base64RepoTag/*"
           breadcrumb="Manifest Details"

--- a/packages/renderer/src/lib/image/ImagesList.spec.ts
+++ b/packages/renderer/src/lib/image/ImagesList.spec.ts
@@ -196,7 +196,7 @@ test('Expect filter empty screen', async () => {
   expect(filterButton).toBeInTheDocument();
 });
 
-test('Expect two images in list given image id and engin id', async () => {
+test('Expect two images in list given image id and engine id', async () => {
   getProviderInfosMock.mockResolvedValue([
     {
       name: 'podman',

--- a/packages/renderer/src/lib/image/ImagesList.svelte
+++ b/packages/renderer/src/lib/image/ImagesList.svelte
@@ -88,7 +88,7 @@ function updateImages(globalContext: ContextUI) {
   });
 
   images = computedImages;
-  if (imageEngineId !== '') {
+  if (imageEngineId) {
     images = images.filter(image => image.engineId === imageEngineId);
   }
 

--- a/packages/renderer/src/lib/image/ImagesList.svelte
+++ b/packages/renderer/src/lib/image/ImagesList.svelte
@@ -40,6 +40,7 @@ import type { ImageInfoUI } from './ImageInfoUI';
 import NoContainerEngineEmptyScreen from './NoContainerEngineEmptyScreen.svelte';
 
 export let searchTerm = '';
+export let imageEngineId = '';
 $: searchPattern.set(searchTerm);
 
 let images: ImageInfoUI[] = [];
@@ -87,6 +88,9 @@ function updateImages(globalContext: ContextUI) {
   });
 
   images = computedImages;
+  if (imageEngineId !== '') {
+    images = images.filter(image => image.engineId === imageEngineId);
+  }
 
   // Map engineName, engineId and engineType from currentContainers to EngineInfoUI[]
   const engines = images.map(container => {


### PR DESCRIPTION
### What does this PR do?
Adds image list page rendering for the `images/imageId/engineId` path necessary for the no tag case of https://github.com/containers/podman-desktop/pull/7677 

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->
[Screencast from 2024-07-26 11-25-42.webm](https://github.com/user-attachments/assets/ef6623f7-4560-4147-b54b-e1cf1268fc6e)

^ this is just an example where images with tags were used, but the `images/imageId/engineId` path will be used only for images with id instead of a tag

### What issues does this PR fix or reference?
Closes https://github.com/containers/podman-desktop/issues/8216

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature
