### PR TITLE
chore: reduce navigation border

### DIFF
--- a/packages/main/src/plugin/color-registry.ts
+++ b/packages/main/src/plugin/color-registry.ts
@@ -281,6 +281,10 @@ export class ColorRegistry {
       dark: colorPalette.charcoal[600],
       light: colorPalette.gray[100],
     });
+    this.registerColor(`${glNav}bg-border`, {
+      dark: colorPalette.charcoal[500],
+      light: colorPalette.gray[300],
+    });
     this.registerColor(`${glNav}icon`, {
       dark: colorPalette.gray[600],
       light: colorPalette.charcoal[200],

--- a/packages/renderer/src/AppNavigation.svelte
+++ b/packages/renderer/src/AppNavigation.svelte
@@ -244,7 +244,7 @@ export let meta: TinroRouteMeta;
 
 <svelte:window />
 <nav
-  class="group w-leftnavbar min-w-leftnavbar flex flex-col hover:overflow-y-none bg-[var(--pd-global-nav-bg)]"
+  class="group w-leftnavbar min-w-leftnavbar flex flex-col hover:overflow-y-none bg-[var(--pd-global-nav-bg)] border-[var(--pd-global-nav-bg-border)] border-r-[1px]"
   aria-label="AppNavigation">
   <NavItem href="/" tooltip="Dashboard" bind:meta={meta}>
     <div class="relative w-full">

--- a/packages/renderer/src/PreferencesNavigation.svelte
+++ b/packages/renderer/src/PreferencesNavigation.svelte
@@ -41,7 +41,7 @@ onMount(async () => {
 </script>
 
 <nav
-  class="z-1 w-leftsidebar min-w-leftsidebar shadow flex-col justify-between flex transition-all duration-500 ease-in-out bg-[var(--pd-secondary-nav-bg)]"
+  class="z-1 w-leftsidebar min-w-leftsidebar flex-col justify-between flex transition-all duration-500 ease-in-out bg-[var(--pd-secondary-nav-bg)] border-[var(--pd-global-nav-bg-border)] border-r-[1px]"
   aria-label="PreferencesNavigation">
   <div class="flex items-center">
     <div class="pt-4 px-3 mb-10">

--- a/packages/renderer/src/lib/dashboard/DashboardPage.svelte
+++ b/packages/renderer/src/lib/dashboard/DashboardPage.svelte
@@ -38,7 +38,7 @@ function getInitializationContext(id: string): InitializationContext {
 </script>
 
 <NavPage searchEnabled={false} title="Dashboard">
-  <div slot="content" class="flex flex-col min-w-full h-full bg-[var(--pd-content-bg)] shadow-nav py-5">
+  <div slot="content" class="flex flex-col min-w-full h-full bg-[var(--pd-content-bg)] py-5">
     <div class="min-w-full flex-1">
       <NotificationsBox />
       <div class="px-5 space-y-5 h-full">

--- a/packages/renderer/src/lib/ui/TitleBar.svelte
+++ b/packages/renderer/src/lib/ui/TitleBar.svelte
@@ -18,7 +18,8 @@ onMount(async () => {
   class="{platform === 'win32' ? 'bg-[#202020]' : 'bg-[var(--pd-titlebar-bg)]'} body-font z-[999] relative {platform ===
   'win32'
     ? 'min-h-[32px]'
-    : 'min-h-[38px]'}"
+    : 'min-h-[38px]'}
+    border-[var(--pd-global-nav-bg-border)] border-b-[1px]"
   style="-webkit-app-region: drag;">
   <div class="flex select-none">
     <!-- On Linux, title is centered and we have control buttons in the title bar-->

--- a/packages/ui/src/lib/layouts/NavPage.svelte
+++ b/packages/ui/src/lib/layouts/NavPage.svelte
@@ -6,7 +6,7 @@ export let searchTerm = '';
 export let searchEnabled = true;
 </script>
 
-<div class="flex flex-col w-full h-full shadow-pageheader">
+<div class="flex flex-col w-full h-full">
   <div class="flex flex-col w-full h-full pt-4" role="region" aria-label={title}>
     <div class="flex pb-2" role="region" aria-label="header">
       <div class="px-5">

--- a/packages/ui/src/lib/layouts/Page.svelte
+++ b/packages/ui/src/lib/layouts/Page.svelte
@@ -36,7 +36,7 @@ function handleKeydown(e: KeyboardEvent): void {
 
 <svelte:window on:keydown={handleKeydown} />
 
-<div class="flex flex-col w-full h-full shadow-pageheader bg-[var(--pd-content-bg)]">
+<div class="flex flex-col w-full h-full bg-[var(--pd-content-bg)]">
   <div class="flex flex-row w-full h-fit px-5 pt-4 pb-2" aria-label="Header" role="region">
     <div class="flex flex-col w-full h-fit">
       {#if showBreadcrumb}

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -29,11 +29,6 @@ module.exports = {
   darkMode: 'class',
   theme: {
     extend: {
-      boxShadow: {
-        "titlebar": 'inset 0px -1px 0px 0 rgb(54 54 61 / 0.6)', // highlight for bottom of titlebar
-	"pageheader": 'inset 0 0px 10px 0 rgb(0 0 0 / 0.4)',
-	"nav": 'inset 7px -4px 6px 0 rgb(0 0 0 / 0.15)',
-      },
       transitionProperty: {
         width: 'width',
       },


### PR DESCRIPTION
### What does this PR do?

The shadows for navigation and titlebar were too prominent, especially on the Dashboard where they had some minor issues. This removes shadows from titlebar and navigation, and replaces them with a 1px border controlled by a new color variable.

### Screenshot / video of UI

Before:

<img width="464" alt="Screenshot 2024-07-26 at 3 26 39 PM" src="https://github.com/user-attachments/assets/64d13bc8-e48c-4a9e-a03f-dc4dbf42e872">

<img width="464" alt="Screenshot 2024-07-26 at 3 26 31 PM" src="https://github.com/user-attachments/assets/28247659-3c18-4599-bd9c-47a0799fcd19">

<img width="464" alt="Screenshot 2024-07-26 at 4 12 00 PM" src="https://github.com/user-attachments/assets/7b3ce520-b247-4be2-a847-becee2d2c760">

<img width="464" alt="Screenshot 2024-07-26 at 4 12 10 PM" src="https://github.com/user-attachments/assets/9444a3c6-1603-4cd1-987f-c94e6eb06731">

After:

<img width="464" alt="Screenshot 2024-07-26 at 4 08 56 PM" src="https://github.com/user-attachments/assets/b7cb872c-f339-4cdf-8383-14919519e01e">

<img width="464" alt="Screenshot 2024-07-26 at 4 09 08 PM" src="https://github.com/user-attachments/assets/91debb24-b9d7-4ab4-8f6c-edf1c6d304af">

<img width="464" alt="Screenshot 2024-07-26 at 4 09 48 PM" src="https://github.com/user-attachments/assets/b615a207-331f-4988-8e05-44cfecd440f2">

<img width="464" alt="Screenshot 2024-07-26 at 4 09 39 PM" src="https://github.com/user-attachments/assets/72f08e9e-2cf2-4f51-a4c8-54d196c409f3">

### What issues does this PR fix or reference?

Part of #8250.

### How to test this PR?

Check dashboard, nav pages, and Settings for borders with titlebar and navigation.