### PR TITLE
fix: move route with params after route with fixed value

### DIFF
--- a/packages/renderer/src/App.spec.ts
+++ b/packages/renderer/src/App.spec.ts
@@ -1,0 +1,78 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { render } from '@testing-library/svelte';
+import { tick } from 'svelte';
+import { router } from 'tinro';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import App from './App.svelte';
+
+const mocks = vi.hoisted(() => ({
+  DashboardPage: vi.fn(),
+  RunImage: vi.fn(),
+  ImagesList: vi.fn(),
+}));
+
+vi.mock('./lib/dashboard/DashboardPage.svelte', () => ({
+  default: mocks.DashboardPage,
+}));
+vi.mock('./lib/image/RunImage.svelte', () => ({
+  default: mocks.RunImage,
+}));
+vi.mock('./lib/image/ImagesList.svelte', () => ({
+  default: mocks.ImagesList,
+}));
+
+vi.mock('./lib/ui/TitleBar.svelte', () => ({
+  default: vi.fn(),
+}));
+vi.mock('./lib/welcome/WelcomePage.svelte', () => ({
+  default: vi.fn(),
+}));
+
+vi.mock('./lib/context/ContextKey.svelte', () => ({
+  default: vi.fn(),
+}));
+
+vi.mock('./lib/appearance/Appearance.svelte', () => ({
+  default: vi.fn(),
+}));
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  router.goto('/');
+});
+
+test('test /images/run/* route', async () => {
+  render(App);
+  expect(mocks.RunImage).not.toHaveBeenCalled();
+  expect(mocks.DashboardPage).toHaveBeenCalled();
+  router.goto('/images/run/basic');
+  await tick();
+  expect(mocks.RunImage).toHaveBeenCalled();
+});
+
+test('test /images/:id/:engineId route', async () => {
+  render(App);
+  expect(mocks.ImagesList).not.toHaveBeenCalled();
+  expect(mocks.DashboardPage).toHaveBeenCalled();
+  router.goto('/images/an-image/an-engine');
+  await tick();
+  expect(mocks.ImagesList).toHaveBeenCalled();
+});

--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -132,6 +132,9 @@ window.events?.receive('navigate', (navigationRequest: unknown) => {
         <Route path="/images" breadcrumb="Images" navigationHint="root">
           <ImagesList />
         </Route>
+        <Route path="/images/run/*" breadcrumb="Run Image">
+          <RunImage />
+        </Route>
         <Route path="/images/:id/:engineId" breadcrumb="Images" let:meta navigationHint="root">
           <ImagesList searchTerm={meta.params.id} imageEngineId={meta.params.engineId} />
         </Route>
@@ -157,9 +160,6 @@ window.events?.receive('navigate', (navigationRequest: unknown) => {
         </Route>
         <Route path="/images/build" breadcrumb="Build an Image">
           <BuildImageFromContainerfile />
-        </Route>
-        <Route path="/images/run/*" breadcrumb="Run Image">
-          <RunImage />
         </Route>
         <Route path="/images/pull" breadcrumb="Pull an Image">
           <PullImage />


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

#8249 introduced a new route `/images/:id/:engineId`, before an existing route `/images/run/*`, which has for effect to catch `/images/run/basic` in the first route instead of the second.

This PR moves the `/images/run/*` route before all other routes with parameters.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes #8267 
Fixes #8268

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
