### PR TITLE
fix: center loading circle where LoadingIconButton is used

### DIFF
--- a/packages/renderer/src/lib/extensions/InstalledExtensionCardLeftLifecycleDelete.svelte
+++ b/packages/renderer/src/lib/extensions/InstalledExtensionCardLeftLifecycleDelete.svelte
@@ -26,5 +26,5 @@ async function deleteExtension(): Promise<void> {
     action="delete"
     icon={faTrashCan}
     state={{ status: extension.type === 'dd' ? 'stopped' : extension.removable ? extension.state : '', inProgress }}
-    leftPosition="" />
+    leftPosition="left-[0.2rem]" />
 </div>

--- a/packages/renderer/src/lib/extensions/InstalledExtensionCardLeftLifecycleStart.svelte
+++ b/packages/renderer/src/lib/extensions/InstalledExtensionCardLeftLifecycleStart.svelte
@@ -22,5 +22,5 @@ async function startExtension(): Promise<void> {
     action="start"
     icon={faPlay}
     state={{ status: extension.state, inProgress }}
-    leftPosition="" />
+    leftPosition="left-[0.15rem]" />
 {/if}

--- a/packages/renderer/src/lib/extensions/InstalledExtensionCardLeftLifecycleStop.svelte
+++ b/packages/renderer/src/lib/extensions/InstalledExtensionCardLeftLifecycleStop.svelte
@@ -22,5 +22,5 @@ async function stopExtension(): Promise<void> {
     action="stop"
     icon={faStop}
     state={{ status: extension.type === 'dd' ? 'unsupported' : extension.state, inProgress }}
-    leftPosition="" />
+    leftPosition="left-[0.15rem]" />
 {/if}

--- a/packages/renderer/src/lib/preferences/PreferencesCliTool.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesCliTool.svelte
@@ -89,7 +89,7 @@ function getLoggerHandler(_cliToolId: string): ConnectionCallback {
                 }
               }}
               icon={faCircleArrowUp}
-              leftPosition="left-[0.4rem]"
+              leftPosition="left-[0.25rem]"
               state={cliToolStatus}
               color="primary"
               tooltip={!cliTool.newVersion ? 'No updates' : `Update to v${cliTool.newVersion}`} />

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionActions.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionActions.svelte
@@ -168,7 +168,7 @@ function getLoggerHandler(
               action="start"
               icon={faPlay}
               state={connectionStatus}
-              leftPosition="left-[0.15rem]" />
+              leftPosition="left-[0.1rem]" />
           </div>
         {/if}
         {#if connection.lifecycleMethods.includes('start') && connection.lifecycleMethods.includes('stop')}
@@ -177,7 +177,7 @@ function getLoggerHandler(
             action="restart"
             icon={faRotateRight}
             state={connectionStatus}
-            leftPosition="left-1.5" />
+            leftPosition="left-[0.25rem]" />
         {/if}
         {#if connection.lifecycleMethods.includes('stop')}
           <LoadingIconButton
@@ -185,7 +185,7 @@ function getLoggerHandler(
             action="stop"
             icon={faStop}
             state={connectionStatus}
-            leftPosition="left-[0.22rem]" />
+            leftPosition="left-[0.12rem]" />
         {/if}
         {#if connection.lifecycleMethods.includes('edit')}
           <LoadingIconButton
@@ -193,7 +193,7 @@ function getLoggerHandler(
             action="edit"
             icon={faEdit}
             state={connectionStatus}
-            leftPosition="left-[0.22rem]" />
+            leftPosition="left-[0.12rem]" />
         {/if}
         {#if connection.lifecycleMethods.includes('delete')}
           <div class="mr-2 text-sm">
@@ -202,7 +202,7 @@ function getLoggerHandler(
               action="delete"
               icon={faTrash}
               state={connectionStatus}
-              leftPosition="left-1" />
+              leftPosition="left-[0.15rem]" />
           </div>
         {/if}
       </div>

--- a/packages/renderer/src/lib/ui/LoadingIconButton.svelte
+++ b/packages/renderer/src/lib/ui/LoadingIconButton.svelte
@@ -57,7 +57,7 @@ $: style = disable
       icon={icon}
       loadingWidthClass="w-6"
       loadingHeightClass="h-6"
-      positionTopClass="top-1"
+      positionTopClass="top-0.5"
       positionLeftClass={leftPosition}
       loading={loading} />
   </button>


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
Centers the progression circle around the icon where `LoadingIconButton` is used

### Screenshot / video of UI
Before:

[Screencast from 2024-07-30 12-21-12.webm](https://github.com/user-attachments/assets/172bbae1-3639-495a-a177-7893ecfd43c3)

After:

[Screencast from 2024-07-30 12-22-47.webm](https://github.com/user-attachments/assets/f7af8757-faad-4c16-b826-dddad20dede9)

(^the circle is not always visible like in the recording, it was just used to check its placement)
<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Closes https://github.com/containers/podman-desktop/issues/8218

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
