### PR TITLE
chore: light mode for docker desktop extensions (and more)

### DIFF
--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -42,7 +42,7 @@ import type * as containerDesktopAPI from '@podman-desktop/api';
 import checkDiskSpacePkg from 'check-disk-space';
 import type Dockerode from 'dockerode';
 import type { WebContents } from 'electron';
-import { app, BrowserWindow, clipboard, ipcMain, shell } from 'electron';
+import { app, BrowserWindow, clipboard, ipcMain, nativeTheme, shell } from 'electron';
 import type { IpcMainInvokeEvent } from 'electron/main';
 
 import type { KubernetesGeneratorInfo } from '/@/plugin/api/KubernetesGeneratorInfo.js';
@@ -1671,6 +1671,10 @@ export class PluginSystem {
     });
     this.ipcHandle('os:getHostCpu', async (): Promise<number> => {
       return os.cpus().length;
+    });
+
+    this.ipcHandle('native:theme', async (_listener, themeSource: 'system' | 'light' | 'dark'): Promise<void> => {
+      nativeTheme.themeSource = themeSource;
     });
 
     this.ipcHandle(

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -1968,6 +1968,10 @@ export function initExposure(): void {
     return ipcInvoke('os:getHostCpu');
   });
 
+  contextBridge.exposeInMainWorld('setNativeTheme', async (themeSource: 'system' | 'light' | 'dark'): Promise<void> => {
+    return ipcInvoke('native:theme', themeSource);
+  });
+
   contextBridge.exposeInMainWorld('sendFeedback', async (feedback: FeedbackProperties): Promise<void> => {
     return ipcInvoke('feedback:send', feedback);
   });

--- a/packages/renderer/src/lib/appearance/Appearance.spec.ts
+++ b/packages/renderer/src/lib/appearance/Appearance.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,6 +36,7 @@ beforeEach(() => {
     addEventListener: addEventListenerMock,
     removeEventListener: vi.fn(),
   });
+  (window as any).setNativeTheme = vi.fn();
 });
 
 function getRootElement(container: HTMLElement): HTMLElement {

--- a/packages/renderer/src/lib/appearance/Appearance.svelte
+++ b/packages/renderer/src/lib/appearance/Appearance.svelte
@@ -15,9 +15,11 @@ async function updateAppearance(): Promise<void> {
   if (isDark) {
     html.classList.add('dark');
     html.setAttribute('style', 'color-scheme: dark;');
+    window.setNativeTheme('dark');
   } else {
     html.classList.remove('dark');
     html.setAttribute('style', 'color-scheme: light;');
+    window.setNativeTheme('light');
   }
 }
 


### PR DESCRIPTION
### What does this PR do?

In order to set the correct prefers-color-scheme for Docker Desktop extensions in <webview>s we need to set the Electron native theme, from main. This is probably a good thing to do anyway since it sets the preferred global color scheme correctly, and has the side-effect of also setting the light/dark mode for the developer tools.

Thanks to @benoitf for hints and pointers well past working hours.

### Screenshot / video of UI

https://github.com/user-attachments/assets/c8d1864a-908e-46a9-b609-6f3443fcd960

### What issues does this PR fix or reference?

Fixes #8217.

### How to test this PR?

Install a DD extension (like Headlamp from the catalog, or redhatdeveloper/openshift-dd-ext) and toggle light/dark mode.